### PR TITLE
Change `__call__` to `forward` in `_LossModule`

### DIFF
--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -1,3 +1,6 @@
+import argparse
+
+import numpy as np
 import pytest
 import torch
 from torch import nn
@@ -7,13 +10,18 @@ from torchrl.data.postprocs.postprocs import MultiStep
 from torchrl.data.postprocs.utils import expand_as_right
 from torchrl.data.tensordict.tensordict import assert_allclose_td
 from torchrl.modules import DistributionalQValueActor, QValueActor
-from torchrl.modules.distributions.continuous import Delta
+from torchrl.modules.distributions.continuous import Delta, TanhNormal
 from torchrl.modules.models.models import MLP
+from torchrl.modules.probabilistic_operators.actors import ValueOperator, Actor
 from torchrl.objectives import (
     DQNLoss,
     DoubleDQNLoss,
     DistributionalDQNLoss,
     DistributionalDoubleDQNLoss,
+    DDPGLoss,
+    DoubleDDPGLoss,
+    SACLoss,
+    DoubleSACLoss, PPOLoss, ClipPPOLoss, KLPENPPOLoss, GAE
 )
 from torchrl.objectives.costs.utils import hold_out_net
 
@@ -86,7 +94,7 @@ class TestDQN:
     def _create_seq_mock_data_dqn(
         self, batch=2, T=4, obs_dim=3, action_dim=4, atoms=None
     ):
-        #  create a tensordict
+        # create a tensordict
         total_obs = torch.randn(batch, T + 1, obs_dim)
         obs = total_obs[:, :T]
         next_obs = total_obs[:, 1:]
@@ -111,7 +119,7 @@ class TestDQN:
                 "reward": reward * mask.to(obs.dtype),
                 "action": action * mask.to(obs.dtype),
                 "action_value": action_value
-                * expand_as_right(mask.to(obs.dtype).squeeze(-1), action_value),
+                                * expand_as_right(mask.to(obs.dtype).squeeze(-1), action_value),
             },
         )
         return td
@@ -121,9 +129,9 @@ class TestDQN:
         torch.manual_seed(self.seed)
         actor = self._create_mock_actor()
         td = self._create_mock_data_dqn()
-        loss_fn = loss_class(actor, gamma=0.9)
+        loss_fn = loss_class(actor, gamma=0.9, loss_function="l2")
         loss = loss_fn(td)
-        loss.backward()
+        sum([item for _, item in loss.items()]).backward()
         assert torch.nn.utils.clip_grad.clip_grad_norm_(actor.parameters(), 1.0) > 0.0
 
     @pytest.mark.parametrize("n", range(4))
@@ -133,7 +141,7 @@ class TestDQN:
         actor = self._create_mock_actor()
 
         td = self._create_seq_mock_data_dqn()
-        loss_fn = loss_class(actor, gamma=gamma)
+        loss_fn = loss_class(actor, gamma=gamma, loss_function="l2")
 
         ms = MultiStep(gamma=gamma, n_steps_max=n)
         ms_td = ms(td.clone())
@@ -142,13 +150,15 @@ class TestDQN:
             loss = loss_fn(td)
         if n == 0:
             assert_allclose_td(td, ms_td.select(*list(td.keys())))
+            _loss = sum([item for _, item in loss.items()])
+            _loss_ms = sum([item for _, item in loss_ms.items()])
             assert (
-                abs(loss - loss_ms) < 1e-3
+                abs(_loss - _loss_ms) < 1e-3
             ), f"found abs(loss-loss_ms) = {abs(loss - loss_ms):4.5f} for n=0"
         else:
             with pytest.raises(AssertionError):
-                torch.testing.assert_allclose(loss, loss_ms)
-        loss_ms.backward()
+                assert_allclose_td(loss, loss_ms)
+        sum([item for _, item in loss_ms.items()]).backward()
         assert torch.nn.utils.clip_grad.clip_grad_norm_(actor.parameters(), 1.0) > 0.0
 
     @pytest.mark.parametrize("atoms", range(4, 10))
@@ -164,8 +174,392 @@ class TestDQN:
         loss_fn = loss_class(actor, gamma=gamma)
 
         loss = loss_fn(td)
-        loss.backward()
+        sum([item for _, item in loss.items()]).backward()
         assert torch.nn.utils.clip_grad.clip_grad_norm_(actor.parameters(), 1.0) > 0.0
+
+
+class TestDDPG:
+    seed = 0
+
+    def _create_mock_actor(self, batch=2, obs_dim=3, action_dim=4):
+        # Actor
+        action_spec = NdBoundedTensorSpec(
+            -torch.ones(action_dim), torch.ones(action_dim), (action_dim,)
+        )
+        mapping_operator = nn.Linear(obs_dim, action_dim)
+        actor = Actor(
+            action_spec=action_spec,
+            mapping_operator=mapping_operator,
+            distribution_class=Delta,
+        )
+        return actor
+
+    def _create_mock_value(self, batch=2, obs_dim=3, action_dim=4):
+        # Actor
+        class ValueClass(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(obs_dim + action_dim, 1)
+
+            def forward(self, obs, act):
+                return self.linear(torch.cat([obs, act], -1))
+
+        mapping_operator = ValueClass()
+        value = ValueOperator(
+            mapping_operator=mapping_operator,
+            in_keys=["observation", "action"],
+        )
+        return value
+
+    def _create_mock_distributional_actor(
+        self, batch=2, obs_dim=3, action_dim=4, atoms=5, vmin=1, vmax=5
+    ):
+        raise NotImplementedError
+
+    def _create_mock_data_ddpg(self, batch=2, obs_dim=3, action_dim=4, atoms=None):
+        # create a tensordict
+        obs = torch.randn(batch, obs_dim)
+        next_obs = torch.randn(batch, obs_dim)
+        if atoms:
+            raise NotImplementedError
+        else:
+            action = torch.randn(batch, action_dim).clamp(-1, 1)
+        reward = torch.randn(batch, 1)
+        done = torch.zeros(batch, 1, dtype=torch.bool)
+        td = TensorDict(
+            batch_size=(batch,),
+            source={
+                "observation": obs,
+                "next_observation": next_obs,
+                "done": done,
+                "reward": reward,
+                "action": action,
+            },
+        )
+        return td
+
+    def _create_seq_mock_data_ddpg(
+        self, batch=2, T=4, obs_dim=3, action_dim=4, atoms=None
+    ):
+        # create a tensordict
+        total_obs = torch.randn(batch, T + 1, obs_dim)
+        obs = total_obs[:, :T]
+        next_obs = total_obs[:, 1:]
+        if atoms:
+            action = torch.randn(batch, T, atoms, action_dim).clamp(-1, 1)
+        else:
+            action = torch.randn(batch, T, action_dim).clamp(-1, 1)
+        reward = torch.randn(batch, T, 1)
+        done = torch.zeros(batch, T, 1, dtype=torch.bool)
+        mask = ~torch.zeros(batch, T, 1, dtype=torch.bool)
+        td = TensorDict(
+            batch_size=(batch, T),
+            source={
+                "observation": obs * mask.to(obs.dtype),
+                "next_observation": next_obs * mask.to(obs.dtype),
+                "done": done,
+                "mask": mask,
+                "reward": reward * mask.to(obs.dtype),
+                "action": action * mask.to(obs.dtype),
+            },
+        )
+        return td
+
+    @pytest.mark.parametrize("loss_class", (DDPGLoss, DoubleDDPGLoss))
+    def test_ddpg(self, loss_class):
+        torch.manual_seed(self.seed)
+        actor = self._create_mock_actor()
+        value = self._create_mock_value()
+        td = self._create_mock_data_ddpg()
+        loss_fn = loss_class(actor, value, gamma=0.9, loss_function="l2")
+        loss = loss_fn(td)
+        sum([item for _, item in loss.items()]).backward()
+        parameters = list(actor.parameters()) + list(value.parameters())
+        for p in parameters:
+            assert p.grad.norm() > 0.0
+
+    @pytest.mark.parametrize("n", list(range(4)))
+    @pytest.mark.parametrize("loss_class", (DDPGLoss, DoubleDDPGLoss))
+    def test_ddpg_batcher(self, n, loss_class, gamma=0.9):
+        torch.manual_seed(self.seed)
+        actor = self._create_mock_actor()
+        value = self._create_mock_value()
+
+        td = self._create_seq_mock_data_ddpg()
+        loss_fn = loss_class(actor, value, gamma=gamma, loss_function="l2")
+
+        ms = MultiStep(gamma=gamma, n_steps_max=n)
+        ms_td = ms(td.clone())
+        loss_ms = loss_fn(ms_td)
+        with torch.no_grad():
+            loss = loss_fn(td)
+        if n == 0:
+            assert_allclose_td(td, ms_td.select(*list(td.keys())))
+            _loss = sum([item for _, item in loss.items()])
+            _loss_ms = sum([item for _, item in loss_ms.items()])
+            assert (
+                abs(_loss - _loss_ms) < 1e-3
+            ), f"found abs(loss-loss_ms) = {abs(loss - loss_ms):4.5f} for n=0"
+        else:
+            with pytest.raises(AssertionError):
+                assert_allclose_td(loss, loss_ms)
+        sum([item for _, item in loss_ms.items()]).backward()
+        parameters = list(actor.parameters()) + list(value.parameters())
+        for p in parameters:
+            assert p.grad.norm() > 0.0
+
+
+class TestSAC:
+    seed = 0
+
+    def _create_mock_actor(self, batch=2, obs_dim=3, action_dim=4):
+        # Actor
+        action_spec = NdBoundedTensorSpec(
+            -torch.ones(action_dim), torch.ones(action_dim), (action_dim,)
+        )
+        mapping_operator = nn.Linear(obs_dim, 2 * action_dim)
+        actor = Actor(
+            action_spec=action_spec,
+            mapping_operator=mapping_operator,
+            distribution_class=TanhNormal,
+        )
+        return actor
+
+    def _create_mock_qvalue(self, batch=2, obs_dim=3, action_dim=4):
+        class ValueClass(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(obs_dim + action_dim, 1)
+
+            def forward(self, obs, act):
+                return self.linear(torch.cat([obs, act], -1))
+
+        mapping_operator = ValueClass()
+        qvalue = ValueOperator(
+            mapping_operator=mapping_operator,
+            in_keys=["observation", "action"],
+        )
+        return qvalue
+
+    def _create_mock_value(self, batch=2, obs_dim=3, action_dim=4):
+        mapping_operator = nn.Linear(obs_dim, 1)
+        value = ValueOperator(
+            mapping_operator=mapping_operator,
+            in_keys=["observation"],
+        )
+        return value
+
+    def _create_mock_distributional_actor(
+        self, batch=2, obs_dim=3, action_dim=4, atoms=5, vmin=1, vmax=5
+    ):
+        raise NotImplementedError
+
+    def _create_mock_data_sac(self, batch=2, obs_dim=3, action_dim=4, atoms=None):
+        # create a tensordict
+        obs = torch.randn(batch, obs_dim)
+        next_obs = torch.randn(batch, obs_dim)
+        if atoms:
+            raise NotImplementedError
+        else:
+            action = torch.randn(batch, action_dim).clamp(-1, 1)
+        reward = torch.randn(batch, 1)
+        done = torch.zeros(batch, 1, dtype=torch.bool)
+        td = TensorDict(
+            batch_size=(batch,),
+            source={
+                "observation": obs,
+                "next_observation": next_obs,
+                "done": done,
+                "reward": reward,
+                "action": action,
+            },
+        )
+        return td
+
+    def _create_seq_mock_data_sac(
+        self, batch=2, T=4, obs_dim=3, action_dim=4, atoms=None
+    ):
+        # create a tensordict
+        total_obs = torch.randn(batch, T + 1, obs_dim)
+        obs = total_obs[:, :T]
+        next_obs = total_obs[:, 1:]
+        if atoms:
+            action = torch.randn(batch, T, atoms, action_dim).clamp(-1, 1)
+        else:
+            action = torch.randn(batch, T, action_dim).clamp(-1, 1)
+        reward = torch.randn(batch, T, 1)
+        done = torch.zeros(batch, T, 1, dtype=torch.bool)
+        mask = ~torch.zeros(batch, T, 1, dtype=torch.bool)
+        td = TensorDict(
+            batch_size=(batch, T),
+            source={
+                "observation": obs * mask.to(obs.dtype),
+                "next_observation": next_obs * mask.to(obs.dtype),
+                "done": done,
+                "mask": mask,
+                "reward": reward * mask.to(obs.dtype),
+                "action": action * mask.to(obs.dtype),
+            },
+        )
+        return td
+
+    @pytest.mark.parametrize("loss_class", (SACLoss, DoubleSACLoss))
+    def test_sac(self, loss_class):
+        torch.manual_seed(self.seed)
+        td = self._create_mock_data_sac()
+
+        actor = self._create_mock_actor()
+        qvalue = self._create_mock_qvalue()
+        qvalue2 = self._create_mock_qvalue()
+        value = self._create_mock_value()
+        loss_fn = loss_class(actor, qvalue, value, qvalue2, gamma=0.9, loss_function="l2")
+
+        loss = loss_fn(td)
+        sum([item for _, item in loss.items()]).backward()
+        named_parameters = loss_fn.named_parameters()
+        for name, p in named_parameters:
+            assert p.grad.norm() > 0.0, f"parameter {name} has a null gradient"
+
+    @pytest.mark.parametrize("n", list(range(4)))
+    @pytest.mark.parametrize("loss_class", (SACLoss, DoubleSACLoss))
+    def test_sac_batcher(self, n, loss_class, gamma=0.9):
+        torch.manual_seed(self.seed)
+        td = self._create_seq_mock_data_sac()
+
+        actor = self._create_mock_actor()
+        qvalue = self._create_mock_qvalue()
+        qvalue2 = self._create_mock_qvalue()
+        value = self._create_mock_value()
+        loss_fn = loss_class(actor, qvalue, value, qvalue2, gamma=0.9, loss_function="l2")
+
+        ms = MultiStep(gamma=gamma, n_steps_max=n)
+
+        td_clone = td.clone()
+        ms_td = ms(td_clone)
+
+        torch.manual_seed(0)
+        np.random.seed(0)
+        loss_ms = loss_fn(ms_td)
+
+        with torch.no_grad():
+            torch.manual_seed(0)  # log-prob is computed with a random action
+            np.random.seed(0)
+            loss = loss_fn(td)
+        if n == 0:
+            assert_allclose_td(td, ms_td.select(*list(td.keys())))
+            _loss = sum([item for _, item in loss.items()])
+            _loss_ms = sum([item for _, item in loss_ms.items()])
+            assert (
+                abs(_loss - _loss_ms) < 1e-3
+            ), f"found abs(loss-loss_ms) = {abs(loss - loss_ms):4.5f} for n=0"
+        else:
+            with pytest.raises(AssertionError):
+                assert_allclose_td(loss, loss_ms)
+        sum([item for _, item in loss_ms.items()]).backward()
+        named_parameters = loss_fn.named_parameters()
+        for name, p in named_parameters:
+            assert p.grad.norm() > 0.0, f"parameter {name} has null gradient"
+
+
+class TestPPO:
+    seed = 0
+
+    def _create_mock_actor(self, batch=2, obs_dim=3, action_dim=4):
+        # Actor
+        action_spec = NdBoundedTensorSpec(
+            -torch.ones(action_dim), torch.ones(action_dim), (action_dim,)
+        )
+        mapping_operator = nn.Linear(obs_dim, 2 * action_dim)
+        actor = Actor(
+            action_spec=action_spec,
+            mapping_operator=mapping_operator,
+            distribution_class=TanhNormal,
+            save_dist_params=True,
+        )
+        return actor
+
+    def _create_mock_value(self, batch=2, obs_dim=3, action_dim=4):
+        mapping_operator = nn.Linear(obs_dim, 1)
+        value = ValueOperator(
+            mapping_operator=mapping_operator,
+            in_keys=["observation"],
+        )
+        return value
+
+    def _create_mock_distributional_actor(
+        self, batch=2, obs_dim=3, action_dim=4, atoms=5, vmin=1, vmax=5
+    ):
+        raise NotImplementedError
+
+    def _create_mock_data_ppo(self, batch=2, obs_dim=3, action_dim=4, atoms=None):
+        # create a tensordict
+        obs = torch.randn(batch, obs_dim)
+        next_obs = torch.randn(batch, obs_dim)
+        if atoms:
+            raise NotImplementedError
+        else:
+            action = torch.randn(batch, action_dim).clamp(-1, 1)
+        reward = torch.randn(batch, 1)
+        done = torch.zeros(batch, 1, dtype=torch.bool)
+        td = TensorDict(
+            batch_size=(batch,),
+            source={
+                "observation": obs,
+                "next_observation": next_obs,
+                "done": done,
+                "reward": reward,
+                "action": action,
+                "action_log_prob": torch.randn_like(action[..., :1]) / 10,
+            },
+        )
+        return td
+
+    def _create_seq_mock_data_ppo(
+        self, batch=2, T=4, obs_dim=3, action_dim=4, atoms=None
+    ):
+        # create a tensordict
+        total_obs = torch.randn(batch, T + 1, obs_dim)
+        obs = total_obs[:, :T]
+        next_obs = total_obs[:, 1:]
+        if atoms:
+            action = torch.randn(batch, T, atoms, action_dim).clamp(-1, 1)
+        else:
+            action = torch.randn(batch, T, action_dim).clamp(-1, 1)
+        reward = torch.randn(batch, T, 1)
+        done = torch.zeros(batch, T, 1, dtype=torch.bool)
+        mask = ~torch.zeros(batch, T, 1, dtype=torch.bool)
+        params = torch.randn_like(action.repeat(1, 1, 2)) / 10
+        td = TensorDict(
+            batch_size=(batch, T),
+            source={
+                "observation": obs * mask.to(obs.dtype),
+                "next_observation": next_obs * mask.to(obs.dtype),
+                "done": done,
+                "mask": mask,
+                "reward": reward * mask.to(obs.dtype),
+                "action": action * mask.to(obs.dtype),
+                "action_log_prob": torch.randn_like(action[..., :1]) / 10 * mask.to(obs.dtype),
+                "action_dist_param_0": params *
+                                       mask.to(obs.dtype),
+            },
+        )
+        return td
+
+    @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
+    def test_ppo(self, loss_class):
+        torch.manual_seed(self.seed)
+        td = self._create_seq_mock_data_ppo()
+
+        actor = self._create_mock_actor()
+        value = self._create_mock_value()
+        gae = GAE(gamma=0.9, lamda=0.9, critic=value)
+        loss_fn = loss_class(actor, value, advantage_module=gae, gamma=0.9, loss_critic_type="l2")
+
+        loss = loss_fn(td)
+        sum([item for _, item in loss.items()]).backward()
+        named_parameters = loss_fn.named_parameters()
+        for name, p in named_parameters:
+            assert p.grad.norm() > 0.0, f"parameter {name} has a null gradient"
 
 
 def test_hold_out():
@@ -207,4 +601,5 @@ def test_hold_out():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    args, unknown = argparse.ArgumentParser().parse_known_args()
+    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/torchrl/modules/distributions/continuous.py
+++ b/torchrl/modules/distributions/continuous.py
@@ -26,6 +26,11 @@ class SafeTanhTransform(D.TanhTransform):
         y = y.clamp(-1 + self.delta, 1 - self.delta)
         return y
 
+    def _inverse(self, y: torch.Tensor) -> torch.Tensor:
+        y = y.clamp(-1 + self.delta, 1 - self.delta)
+        x = super()._inverse(y)
+        return x
+
 
 class TruncatedNormal(D.Independent):
     """

--- a/torchrl/modules/probabilistic_operators/actors.py
+++ b/torchrl/modules/probabilistic_operators/actors.py
@@ -10,6 +10,7 @@ from ..models.models import DistributionalDQNnet
 __all__ = [
     "Actor",
     "ActorValueOperator",
+    "ValueOperator",
     "QValueActor",
     "DistributionalQValueActor",
 ]
@@ -69,7 +70,7 @@ class ValueOperator(ProbabilisticOperator):
         if in_keys is None:
             in_keys = ["observation"]
         if out_keys is None:
-            out_keys = ["state_value"]
+            out_keys = ["state_value"] if "action" not in in_keys else ["state_action_value"]
         value_spec = UnboundedContinuousTensorSpec()
         super().__init__(
             value_spec,
@@ -230,18 +231,6 @@ class QValueActor(Actor):
                 f"{self.__class__.__name__} expects a distribution_class Delta, "
                 f"but got {self.distribution_class.__name__} instead."
             )
-
-    # def random_sample(self, out_shape: Union[torch.Size, Iterable]) -> torch.Tensor:
-    #     if self.action_space == "one_hot":
-    #         values = torch.randn(out_shape, device=next(self.parameters()).device)
-    #         out = rand_one_hot(values)
-    #     else:
-    #         raise NotImplementedError(
-    #             f"{self.__class__.__name__}.random_sample is not implemented yet"
-    #             f" for action_space of type {self.action_space}"
-    #         )
-    #     return out
-
 
 class DistributionalQValueActor(QValueActor):
     """

--- a/torchrl/objectives/costs/common.py
+++ b/torchrl/objectives/costs/common.py
@@ -10,7 +10,7 @@ from torchrl.data.tensordict.tensordict import _TensorDict
 
 
 class _LossModule(nn.Module):
-    def __call__(self, tensordict: _TensorDict) -> _TensorDict:
+    def forward(self, tensordict: _TensorDict) -> _TensorDict:
         raise NotImplementedError
 
     def _networks(self) -> Iterator[nn.Module]:

--- a/torchrl/objectives/costs/ddpg.py
+++ b/torchrl/objectives/costs/ddpg.py
@@ -54,7 +54,7 @@ class DDPGLoss(_LossModule):
         target_value_network = self.value_network
         return actor_network, value_network, target_actor_network, target_value_network
 
-    def __call__(self, input_tensor_dict: _TensorDict) -> TensorDict:
+    def forward(self, input_tensor_dict: _TensorDict) -> TensorDict:
         """
         Computes the DDPG losses given a tensordict sampled from the replay buffer.
         This function will also write a "td_error" key that can be used by prioritized replay buffers to assign
@@ -92,7 +92,7 @@ class DDPGLoss(_LossModule):
         )
         input_tensor_dict.set(
             "td_error",
-            td_error.detach().unsqueeze(1).to(input_tensor_dict.device),
+            td_error.detach().unsqueeze(input_tensor_dict.ndimension()).to(input_tensor_dict.device),
             inplace=True,
         )
         loss_actor = self._loss_actor(input_tensor_dict, actor_network, value_network)

--- a/torchrl/objectives/costs/dqn.py
+++ b/torchrl/objectives/costs/dqn.py
@@ -51,7 +51,7 @@ class DQNLoss(_LossModule):
         self.gamma = gamma
         self.loss_function = loss_function
 
-    def __call__(self, input_tensor_dict: _TensorDict) -> TensorDict:
+    def forward(self, input_tensor_dict: _TensorDict) -> TensorDict:
         """
         Computes the DQN loss given a tensordict sampled from the replay buffer.
         This function will also write a "td_error" key that can be used by prioritized replay buffers to assign
@@ -189,7 +189,7 @@ class DistributionalDQNLoss(_LossModule):
             )
         self.value_network = value_network
 
-    def __call__(self, input_tensor_dict: _TensorDict) -> TensorDict:
+    def forward(self, input_tensor_dict: _TensorDict) -> TensorDict:
         # from https://github.com/Kaixhin/Rainbow/blob/9ff5567ad1234ae0ed30d8471e8f13ae07119395/agent.py
         device = self.device
         tensor_dict = TensorDict(
@@ -354,5 +354,5 @@ class DistributionalDoubleDQNLoss(DistributionalDQNLoss):
         self._target_value_network.apply(reset_noise)
         return self._target_value_network
 
-    def __call__(self, *args, **kwargs) -> torch.Tensor:
-        return super().__call__(*args, **kwargs)
+    def forward(self, *args, **kwargs) -> torch.Tensor:
+        return super().forward(*args, **kwargs)

--- a/torchrl/objectives/costs/impala.py
+++ b/torchrl/objectives/costs/impala.py
@@ -13,7 +13,7 @@ class QValEstimator:
     def device(self) -> torch.device:
         return next(self.value_model.parameters()).device
 
-    def __call__(self, tensordict: _TensorDict) -> None:
+    def forward(self, tensordict: _TensorDict) -> None:
         tensordict_device = tensordict.to(self.device)
         self.value_model_device(tensordict_device)  # udpates the value key
         gamma = tensordict_device.get("gamma")
@@ -26,7 +26,7 @@ class QValEstimator:
 
 
 class VTraceEstimator:
-    def __call__(self, tensordict: _TensorDict) -> _TensorDict:
+    def forward(self, tensordict: _TensorDict) -> _TensorDict:
         tensordict_device = tensordict.to(device)
         rewards = tensordict_device.get("reward")
         vals = tensordict_device.get("value")
@@ -42,7 +42,7 @@ class VTraceEstimator:
 
 
 class ImpalaLoss:
-    def __call__(self, tensordict):
+    def forward(self, tensordict):
         tensordict_device = tensordict.to(device)
         self.q_val_estimator(tensordict_device)
         self.v_trace_estimator(tensordict_device)

--- a/torchrl/objectives/costs/ppo.py
+++ b/torchrl/objectives/costs/ppo.py
@@ -128,13 +128,14 @@ class PPOLoss(_LossModule):
         )
         return self.critic_factor * loss_value
 
-    def __call__(self, tensor_dict: _TensorDict) -> _TensorDict:
+    def forward(self, tensor_dict: _TensorDict) -> _TensorDict:
         if self.advantage_module is not None:
             tensor_dict = self.advantage_module(tensor_dict)
         tensor_dict = tensor_dict.clone()
         advantage = tensor_dict.get(self.advantage_key)
         log_weight, dist = self._log_weight(tensor_dict)
         neg_loss = (log_weight.exp() * advantage).mean()
+        print(log_weight)
         td_out = TensorDict({"loss_objective": -neg_loss.mean()}, [])
         if self.entropy_bonus:
             entropy = self.get_entropy_bonus(dist)
@@ -206,7 +207,7 @@ class ClipPPOLoss(PPOLoss):
             math.log1p(self.clip_epsilon),
         )
 
-    def __call__(self, tensor_dict: _TensorDict) -> _TensorDict:
+    def forward(self, tensor_dict: _TensorDict) -> _TensorDict:
         if self.advantage_module is not None:
             tensor_dict = self.advantage_module(tensor_dict)
         tensor_dict = tensor_dict.clone()
@@ -335,7 +336,7 @@ class KLPENPPOLoss(PPOLoss):
         self.decrement = decrement
         self.samples_mc_kl = samples_mc_kl
 
-    def __call__(self, tensor_dict: _TensorDict) -> TensorDict:
+    def forward(self, tensor_dict: _TensorDict) -> TensorDict:
         if self.advantage_module is not None:
             tensor_dict = self.advantage_module(tensor_dict)
         tensor_dict = tensor_dict.clone()

--- a/torchrl/objectives/costs/sac.py
+++ b/torchrl/objectives/costs/sac.py
@@ -90,6 +90,14 @@ class SACLoss(_LossModule):
         if not self.fixed_alpha:
             yield self.log_alpha
 
+    def named_parameters(
+        self, prefix: str = "", recurse: bool = True
+    ) -> Iterator[Tuple[str, Parameter]]:
+        _valid = set(self.parameters())
+        for name, param in super().named_parameters():
+            if param in _valid:
+                yield name, param
+
     @property
     def target_value_network(self):
         return self.value_network
@@ -118,7 +126,7 @@ class SACLoss(_LossModule):
             "At least one of the networks of SACLoss must have trainable parameters."
         )
 
-    def __call__(self, tensordict: _TensorDict) -> _TensorDict:
+    def forward(self, tensordict: _TensorDict) -> _TensorDict:
         device = self.device
         td_device = tensordict.to(device)
 


### PR DESCRIPTION
This change make the _LossModule abide by the nn.Module syntax rules. 
This will eventually let us place forward and backward hooks on the loss modules, for instance to make them compatible with dictionaries.
Solves #21. 