### PR TITLE
[BugFix] Fix flaky test by waiting for procs instead of sleep

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -217,7 +217,8 @@ def test_vecnorm_parallel_auto(nprc):
     for idx in range(nprc):
         queues[idx][1].put(msg)
 
-    # sleep(0.01)
+    for p in prcs:
+        p.join()
     obs_sum = td.get("next_observation_sum").clone()
     obs_ssq = td.get("next_observation_ssq").clone()
     obs_count = td.get("next_observation_count").clone()


### PR DESCRIPTION
## Description

I noticed a unit test fails locally, and I see an attempt to make it work using `sleep`. Using `join` on the procs fixes it more reliably, waiting for the actual procs to finish.


## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x ] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
