### PR TITLE
[Refactoring] Import at root to enable vmap monkey-patching

### DIFF
--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -8,7 +8,7 @@ import os
 # Get relative file path
 # this returns relative path from current file.
 import torch.cuda
-from torchrl import seed_generator
+from torchrl._utils import seed_generator
 
 
 def get_relative_path(curr_file, *path_components):

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import torch
 import torch.nn as nn
-from torchrl import seed_generator
+from torchrl._utils import seed_generator
 from torchrl.data.tensor_specs import (
     NdUnboundedContinuousTensorSpec,
     NdBoundedTensorSpec,

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -18,7 +18,7 @@ from mocking_classes import (
     MockSerialEnv,
 )
 from torch import nn
-from torchrl import seed_generator
+from torchrl._utils import seed_generator
 from torchrl.collectors import SyncDataCollector, aSyncDataCollector
 from torchrl.collectors.collectors import (
     RandomPolicy,

--- a/test/test_functorch.py
+++ b/test/test_functorch.py
@@ -83,7 +83,7 @@ def test_vmap_tdmodule(moduletype, batch_params):
         if batch_params:
             params = params.expand(10, *params.batch_size).contiguous()
             buffers = buffers.expand(10, *buffers.batch_size).contiguous()
-            y = tdmodule(td, params=params, buffers=buffers, vmap=(0, 0, 0))
+            tdmodule(td, params=params, buffers=buffers, vmap=(0, 0, 0))
         else:
             raise NotImplementedError
         y = td["y"]
@@ -126,7 +126,7 @@ def test_vmap_tdmodule_nativebuilt(moduletype, batch_params):
         if batch_params:
             params = params.expand(10, *params.batch_size).contiguous()
             buffers = buffers.expand(10, *buffers.batch_size).contiguous()
-            y = tdmodule(td, params=params, buffers=buffers, vmap=(0, 0, 0))
+            tdmodule(td, params=params, buffers=buffers, vmap=(0, 0, 0))
         else:
             raise NotImplementedError
         y = td["y"]
@@ -239,6 +239,16 @@ def test_vmap_tdsequence_nativebuilt(moduletype, batch_params):
             raise NotImplementedError
         z = td["z"]
         assert z.shape == torch.Size([10, 2, 3])
+
+
+def test_vamp_basic():
+    class MyModule(torch.nn.Module):
+        def forward(self, tensordict):
+            a = tensordict["a"]
+            return TensorDict({"a": a}, tensordict.batch_size, device=tensordict.device)
+
+    tensordict = TensorDict({"a": torch.randn(3)}, [])
+    vmap(MyModule(), (0,))(tensordict.expand(3))
 
 
 if __name__ == "__main__":

--- a/test/test_functorch.py
+++ b/test/test_functorch.py
@@ -248,7 +248,7 @@ def test_vamp_basic():
             return TensorDict({"a": a}, tensordict.batch_size, device=tensordict.device)
 
     tensordict = TensorDict({"a": torch.randn(3)}, [])
-    vmap(MyModule(), (0,))(tensordict.expand(3))
+    vmap(MyModule(), (0,))(tensordict.expand(4))
 
 
 if __name__ == "__main__":

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -12,7 +12,7 @@ import pytest
 import torch
 from _utils_internal import get_available_devices
 from torch import multiprocessing as mp
-from torchrl import prod
+from torchrl._utils import prod
 from torchrl.data import SavedTensorDict, TensorDict, MemmapTensor
 from torchrl.data.tensordict.tensordict import (
     assert_allclose_td,

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -16,7 +16,7 @@ from mocking_classes import (
 )
 from torch import Tensor
 from torch import multiprocessing as mp
-from torchrl import prod
+from torchrl._utils import prod
 from torchrl.data import (
     NdBoundedTensorSpec,
     CompositeSpec,

--- a/torchrl/__init__.py
+++ b/torchrl/__init__.py
@@ -3,18 +3,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import abc
-import collections
-import math
-import time
-import typing
-from typing import Optional, Type, Tuple
 from warnings import warn
 
-import numpy as np
 from torch import multiprocessing as mp
 
 from ._extension import _init_extension
+
 
 try:
     from .version import __version__
@@ -38,93 +32,9 @@ except RuntimeError as err:
             )
 
 
-class timeit:
-    """
-    A dirty but easy to use decorator for profiling code
-    """
-
-    _REG = {}
-
-    def __init__(self, name):
-        self.name = name
-
-    def __call__(self, fn):
-        def decorated_fn(*args, **kwargs):
-            with self:
-                out = fn(*args, **kwargs)
-                return out
-
-        return decorated_fn
-
-    def __enter__(self):
-        self.t0 = time.time()
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        t = time.time() - self.t0
-        self._REG.setdefault(self.name, [0.0, 0.0, 0])
-
-        count = self._REG[self.name][1]
-        self._REG[self.name][0] = (self._REG[self.name][0] * count + t) / (count + 1)
-        self._REG[self.name][1] = self._REG[self.name][1] + t
-        self._REG[self.name][2] = count + 1
-
-    @staticmethod
-    def print(prefix=None):
-        keys = list(timeit._REG)
-        keys.sort()
-        for name in keys:
-            strings = []
-            if prefix:
-                strings.append(prefix)
-            strings.append(
-                f"{name} took {timeit._REG[name][0] * 1000:4.4} msec (total = {timeit._REG[name][1]} sec)"
-            )
-            print(" -- ".join(strings))
-
-    @staticmethod
-    def erase():
-        for k in timeit._REG:
-            timeit._REG[k] = [0.0, 0.0, 0]
-
-
-def _check_for_faulty_process(processes):
-    terminate = False
-    for p in processes:
-        if not p.is_alive():
-            terminate = True
-            for _p in processes:
-                if _p.is_alive():
-                    _p.terminate()
-        if terminate:
-            break
-    if terminate:
-        raise RuntimeError(
-            "At least one process failed. Check for more infos in the log."
-        )
-
-
-def seed_generator(seed):
-    max_seed_val = (
-        2 ** 32 - 1
-    )  # https://discuss.pytorch.org/t/what-is-the-max-seed-you-can-set-up/145688
-    rng = np.random.default_rng(seed)
-    seed = int.from_bytes(rng.bytes(8), "big")
-    return seed % max_seed_val
-
-
-class KeyDependentDefaultDict(collections.defaultdict):
-    def __init__(self, fun):
-        self.fun = fun
-        super().__init__()
-
-    def __missing__(self, key):
-        value = self.fun(key)
-        self[key] = value
-        return value
-
-
-def prod(sequence):
-    if hasattr(math, "prod"):
-        return math.prod(sequence)
-    else:
-        return int(np.prod(sequence))
+import torchrl.collectors
+import torchrl.data
+import torchrl.envs
+import torchrl.modules
+import torchrl.objectives
+import torchrl.trainers

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -1,0 +1,97 @@
+import collections
+import math
+import time
+
+import numpy as np
+
+
+class timeit:
+    """
+    A dirty but easy to use decorator for profiling code
+    """
+
+    _REG = {}
+
+    def __init__(self, name):
+        self.name = name
+
+    def __call__(self, fn):
+        def decorated_fn(*args, **kwargs):
+            with self:
+                out = fn(*args, **kwargs)
+                return out
+
+        return decorated_fn
+
+    def __enter__(self):
+        self.t0 = time.time()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        t = time.time() - self.t0
+        self._REG.setdefault(self.name, [0.0, 0.0, 0])
+
+        count = self._REG[self.name][1]
+        self._REG[self.name][0] = (self._REG[self.name][0] * count + t) / (count + 1)
+        self._REG[self.name][1] = self._REG[self.name][1] + t
+        self._REG[self.name][2] = count + 1
+
+    @staticmethod
+    def print(prefix=None):
+        keys = list(timeit._REG)
+        keys.sort()
+        for name in keys:
+            strings = []
+            if prefix:
+                strings.append(prefix)
+            strings.append(
+                f"{name} took {timeit._REG[name][0] * 1000:4.4} msec (total = {timeit._REG[name][1]} sec)"
+            )
+            print(" -- ".join(strings))
+
+    @staticmethod
+    def erase():
+        for k in timeit._REG:
+            timeit._REG[k] = [0.0, 0.0, 0]
+
+
+def _check_for_faulty_process(processes):
+    terminate = False
+    for p in processes:
+        if not p.is_alive():
+            terminate = True
+            for _p in processes:
+                if _p.is_alive():
+                    _p.terminate()
+        if terminate:
+            break
+    if terminate:
+        raise RuntimeError(
+            "At least one process failed. Check for more infos in the log."
+        )
+
+
+def seed_generator(seed):
+    max_seed_val = (
+        2 ** 32 - 1
+    )  # https://discuss.pytorch.org/t/what-is-the-max-seed-you-can-set-up/145688
+    rng = np.random.default_rng(seed)
+    seed = int.from_bytes(rng.bytes(8), "big")
+    return seed % max_seed_val
+
+
+class KeyDependentDefaultDict(collections.defaultdict):
+    def __init__(self, fun):
+        self.fun = fun
+        super().__init__()
+
+    def __missing__(self, key):
+        value = self.fun(key)
+        self[key] = value
+        return value
+
+
+def prod(sequence):
+    if hasattr(math, "prod"):
+        return math.prod(sequence)
+    else:
+        return int(np.prod(sequence))

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -19,7 +19,7 @@ from torch import multiprocessing as mp
 from torch.utils.data import IterableDataset
 
 from torchrl.envs.utils import set_exploration_mode, step_tensordict
-from .. import _check_for_faulty_process, prod
+from .._utils import _check_for_faulty_process, prod
 from ..modules.tensordict_module import ProbabilisticTensorDictModule
 from .utils import split_trajectories
 

--- a/torchrl/data/tensordict/memmap.py
+++ b/torchrl/data/tensordict/memmap.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, List, Optional, Tuple, Union, Dict
 import numpy as np
 import torch
 
-from torchrl import prod
+from torchrl._utils import prod
 from torchrl.data.tensordict.utils import _getitem_batch_size
 from torchrl.data.utils import (
     DEVICE_TYPING,

--- a/torchrl/data/tensordict/metatensor.py
+++ b/torchrl/data/tensordict/metatensor.py
@@ -14,7 +14,7 @@ import torch
 
 from torchrl.data.utils import DEVICE_TYPING, INDEX_TYPING
 from .memmap import MemmapTensor
-from .utils import _getitem_batch_size
+from .utils import _getitem_batch_size, _get_shape
 
 META_HANDLED_FUNCTIONS = dict()
 
@@ -74,7 +74,7 @@ class MetaTensor:
     ):
         if len(shape) == 1 and not isinstance(shape[0], (Number,)):
             tensor = shape[0]
-            shape = tensor.shape
+            shape = _get_shape(tensor)
             if _is_shared is None:
                 _is_shared = tensor.is_shared()
             if _is_memmap is None:

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -1897,7 +1897,7 @@ class TensorDict(TensorDictBase):
             self._is_shared
             if self._is_shared is not None
             else proc_value.is_shared()
-            if isinstance(proc_value, TensorDictBase)
+            if isinstance(proc_value, (TensorDictBase, MemmapTensor))
             or not is_batchedtensor(proc_value)
             else False
         )

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -1891,7 +1891,11 @@ class TensorDict(TensorDictBase):
             else isinstance(proc_value, MemmapTensor)
         )
         is_shared = (
-            self._is_shared if self._is_shared is not None else proc_value.is_shared()
+            self._is_shared
+            if self._is_shared is not None
+            else proc_value.is_shared()
+            if not is_batchedtensor(proc_value)
+            else False
         )
         return MetaTensor(
             proc_value,

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -37,7 +37,7 @@ import torch
 from torch import Tensor
 from torch.jit._shape_functions import infer_size_impl
 
-from torchrl import KeyDependentDefaultDict, prod
+from torchrl._utils import KeyDependentDefaultDict, prod
 from torchrl.data.tensordict.memmap import MemmapTensor
 from torchrl.data.tensordict.metatensor import MetaTensor
 from torchrl.data.tensordict.utils import (

--- a/torchrl/data/tensordict/utils.py
+++ b/torchrl/data/tensordict/utils.py
@@ -11,6 +11,16 @@ from typing import Tuple, List, Union
 import numpy as np
 import torch
 
+try:
+    try:
+        from functorch._C import is_batchedtensor, get_unwrapped
+    except ImportError:
+        from torch._C._functorch import is_batchedtensor, get_unwrapped
+
+    _has_functorch = True
+except ImportError:
+    _has_functorch = False
+
 from torchrl.data.utils import INDEX_TYPING
 
 
@@ -151,3 +161,22 @@ def convert_ellipsis_to_idx(idx: Union[Tuple, Ellipsis], batch_size: List[int]):
         )
 
     return new_index
+
+
+def _get_shape(value):
+    # we call it "legacy code"
+    return value.shape
+
+
+def _unwrap_value(value):
+    # batch_dims = value.ndimension()
+    if not isinstance(value, torch.Tensor):
+        out = value
+    elif is_batchedtensor(value):
+        out = get_unwrapped(value)
+    else:
+        out = value
+    return out
+    # batch_dims = out.ndimension() - batch_dims
+    # batch_size = out.shape[:batch_dims]
+    # return out, batch_size

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -14,8 +14,8 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from torchrl import seed_generator, prod
 from torchrl.data import CompositeSpec, TensorDict, TensorSpec
+from .._utils import seed_generator, prod
 from ..data.tensordict.tensordict import TensorDictBase
 from ..data.utils import DEVICE_TYPING
 from .utils import get_available_libraries, step_tensordict

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -17,7 +17,7 @@ from warnings import warn
 import torch
 from torch import multiprocessing as mp
 
-from torchrl import _check_for_faulty_process
+from torchrl._utils import _check_for_faulty_process
 from torchrl.data import TensorDict, TensorSpec, CompositeSpec
 from torchrl.data.tensordict.tensordict import TensorDictBase, LazyStackedTensorDict
 from torchrl.data.utils import CloudpickleWrapper, DEVICE_TYPING

--- a/torchrl/modules/__init__.py
+++ b/torchrl/modules/__init__.py
@@ -7,3 +7,4 @@ from .distributions import *
 from .models import *
 from .tensordict_module import *
 from .planners import *
+from .functional_modules import *

--- a/torchrl/modules/functional_modules.py
+++ b/torchrl/modules/functional_modules.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     _has_functorch = False
 
-"""Monky-patch functorch, mainly for cases where a "isinstance(obj, Tensor) is invoked"""
+# Monky-patch functorch, mainly for cases where a "isinstance(obj, Tensor) is invoked
 if _has_functorch:
     from functorch._src.vmap import (
         _get_name,
@@ -164,7 +164,7 @@ if _has_functorch:
 
     functorch._src.vmap._unwrap_batched = _unwrap_batched
 
-"""Tensordict-compatible Functional modules"""
+# Tensordict-compatible Functional modules
 
 
 class FunctionalModule(nn.Module):
@@ -239,7 +239,7 @@ class FunctionalModuleWithBuffers(nn.Module):
                 _swap_state(self.stateless_model, old_state_buffers)
 
 
-"""Some utils for these"""
+# Some utils for these
 
 
 def extract_weights(model):

--- a/torchrl/modules/models/exploration.py
+++ b/torchrl/modules/models/exploration.py
@@ -13,7 +13,7 @@ from torch.nn.parameter import UninitializedBuffer, UninitializedParameter
 
 __all__ = ["NoisyLinear", "NoisyLazyLinear", "reset_noise"]
 
-from torchrl import prod
+from torchrl._utils import prod
 from torchrl.data.utils import DEVICE_TYPING, DEVICE_TYPING_ARGS
 from torchrl.envs.utils import exploration_mode
 from torchrl.modules.distributions.utils import _cast_transform_device

--- a/torchrl/modules/models/models.py
+++ b/torchrl/modules/models/models.py
@@ -10,7 +10,7 @@ import torch
 from torch import nn
 from torch.nn import functional as F
 
-from torchrl import prod
+from torchrl._utils import prod
 from torchrl.data import DEVICE_TYPING
 from torchrl.modules.models.utils import (
     _find_depth,

--- a/torchrl/trainers/__init__.py
+++ b/torchrl/trainers/__init__.py
@@ -4,4 +4,5 @@
 # LICENSE file in the root directory of this source tree.
 
 from .trainers import *
-from .loggers import *
+
+# from .loggers import *

--- a/torchrl/trainers/loggers/tensorboard.py
+++ b/torchrl/trainers/loggers/tensorboard.py
@@ -3,19 +3,18 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import os
-from warnings import warn
 
 from torch import Tensor
 
 from .common import Logger
 
-_has_tb = False
+
 try:
     from torch.utils.tensorboard import SummaryWriter
 
     _has_tb = True
 except ImportError:
-    warn("torch.utils.tensorboard could not be imported")
+    _has_tb = False
 
 
 class TensorboardLogger(Logger):
@@ -45,6 +44,8 @@ class TensorboardLogger(Logger):
             SummaryWriter: The tensorboard experiment.
 
         """
+        if not _has_tb:
+            raise ImportError("torch.utils.tensorboard could not be imported")
 
         log_dir = str(os.path.join(self.log_dir, self.exp_name))
         return SummaryWriter(log_dir=log_dir)

--- a/torchrl/trainers/loggers/wandb.py
+++ b/torchrl/trainers/loggers/wandb.py
@@ -11,22 +11,21 @@ from torch import Tensor
 
 from .common import Logger
 
-_has_wandb = False
+
 try:
     import wandb
 
     _has_wandb = True
 except ImportError:
-    warnings.warn("wandb could not be imported")
-_has_omgaconf = False
+    _has_wandb = False
+
+
 try:
     from omegaconf import OmegaConf
 
     _has_omgaconf = True
 except ImportError:
-    warnings.warn(
-        "OmegaConf could not be imported. Cannot log hydra configs without OmegaConf"
-    )
+    _has_omgaconf = False
 
 
 class WandbLogger(Logger):
@@ -52,6 +51,9 @@ class WandbLogger(Logger):
         project: str = None,
         **kwargs,
     ) -> None:
+        if not _has_wandb:
+            raise ImportError("wandb could not be imported")
+
         log_dir = kwargs.pop("log_dir", None)
         self.offline = offline
         if save_dir and log_dir:
@@ -168,6 +170,11 @@ class WandbLogger(Logger):
         """
 
         if type(cfg) is not dict and _has_omgaconf:
+            if not _has_omgaconf:
+                raise ImportError(
+                    "OmegaConf could not be imported. "
+                    "Cannot log hydra configs without OmegaConf."
+                )
             cfg = OmegaConf.to_container(cfg, resolve=True)
         self.experiment.config.update(cfg, allow_val_change=True)
 

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -15,7 +15,7 @@ import numpy as np
 import torch.nn
 from torch import nn, optim
 
-from torchrl import KeyDependentDefaultDict
+from torchrl._utils import KeyDependentDefaultDict
 
 try:
     from tqdm import tqdm


### PR DESCRIPTION
## Description

- monkey-patches a few more functorch functions
- implements tests for `nn.Module` vmap with tensordicts

Following suggestions from @zou3519 we remove and add a batch dimension when vmapping over a tensordict.
Some commended code shows attempts to register TensorDIct in pytree but that failed + it requires to decompose and recompose the tensordict multiple times, while doing complex operations to keep track of the modified batch size. Besides the fact that it did not work, it also seemed suboptimal from a compute time perspective.
