### PR TITLE
[BugFix] Changing the dm_control import to fail if not installed

### DIFF
--- a/torchrl/envs/libs/dm_control.py
+++ b/torchrl/envs/libs/dm_control.py
@@ -35,8 +35,9 @@ try:
 
     _has_dmc = True
 
-except ImportError:
-    _has_dmc = False
+except ImportError as error:
+    print(error)
+    raise
 
 __all__ = ["DMControlEnv", "DMControlWrapper"]
 

--- a/torchrl/envs/libs/dm_control.py
+++ b/torchrl/envs/libs/dm_control.py
@@ -35,7 +35,7 @@ try:
 
     _has_dmc = True
 
-except ImportError as error:
+except ImportError:
     _has_dmc = False
 
 __all__ = ["DMControlEnv", "DMControlWrapper"]

--- a/torchrl/envs/libs/dm_control.py
+++ b/torchrl/envs/libs/dm_control.py
@@ -36,8 +36,7 @@ try:
     _has_dmc = True
 
 except ImportError as error:
-    print(error)
-    raise
+    _has_dmc = False
 
 __all__ = ["DMControlEnv", "DMControlWrapper"]
 
@@ -273,6 +272,11 @@ class DMControlEnv(DMControlWrapper):
     """
 
     def __init__(self, env_name, task_name, **kwargs):
+        if not _has_dmc:
+            raise ImportError(
+                "dm_control python package was not found."
+                "Please install this dependency."
+            )
         kwargs["env_name"] = env_name
         kwargs["task_name"] = task_name
         super().__init__(**kwargs)


### PR DESCRIPTION
## Description

This PR handles the import of the `torchrl.envs.libs.dm_control`, when the `dm_control` library is not installed. Specifically, it raises the `ImportError`.

## Motivation and Context

close #506 

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] ? My change requires a change to the documentation.
- [ ] ? I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] ? I have updated the documentation accordingly.
