### PR TITLE
[BugFix] Restore missing keys in data collector output

### DIFF
--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -787,7 +787,6 @@ def test_excluded_keys(collector_class, exclude):
 @pytest.mark.parametrize(
     "collector_class",
     [MultiaSyncDataCollector, MultiSyncDataCollector, SyncDataCollector],
-    # [SyncDataCollector],
 )
 @pytest.mark.parametrize("init_random_frames", [0, 50])
 @pytest.mark.parametrize("explicit_spec", [True, False])
@@ -812,7 +811,7 @@ def test_collector_output_keys(collector_class, init_random_frames, explicit_spe
         "out_keys": ["action", "hidden1", "hidden2", "next_hidden1", "next_hidden2"],
     }
     if explicit_spec:
-        hidden_spec = NdUnboundedContinuousTensorSpec(hidden_size)
+        hidden_spec = NdUnboundedContinuousTensorSpec((1, hidden_size))
         policy_kwargs["spec"] = CompositeSpec(
             action=UnboundedContinuousTensorSpec(),
             hidden1=hidden_spec,

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -786,7 +786,11 @@ def test_excluded_keys(collector_class, exclude):
 @pytest.mark.skipif(not _has_gym, reason="test designed with GymEnv")
 @pytest.mark.parametrize(
     "collector_class",
-    [MultiaSyncDataCollector, MultiSyncDataCollector, SyncDataCollector],
+    [
+        SyncDataCollector,
+        MultiaSyncDataCollector,
+        MultiSyncDataCollector,
+    ],
 )
 @pytest.mark.parametrize("init_random_frames", [0, 50])
 @pytest.mark.parametrize("explicit_spec", [True, False])
@@ -857,7 +861,9 @@ def test_collector_output_keys(collector_class, init_random_frames, explicit_spe
     ]
     b = next(iter(collector))
 
-    assert all(key in b for key in keys)
+    assert set(b.keys()) == set(keys)
+    collector.shutdown()
+    del collector
 
 
 def weight_reset(m):

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -30,8 +30,8 @@ from torchrl.envs import EnvCreator
 from torchrl.envs import ParallelEnv
 from torchrl.envs.libs.gym import _has_gym
 from torchrl.envs.transforms import TransformedEnv, VecNorm
-from torchrl.modules import OrnsteinUhlenbeckProcessWrapper, Actor
 from torchrl.modules import LSTMNet, TensorDictModule
+from torchrl.modules import OrnsteinUhlenbeckProcessWrapper, Actor
 
 # torch.set_default_dtype(torch.double)
 

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -326,7 +326,8 @@ class SyncDataCollector(_DataCollector):
         # TODO: perhaps check type of policy and raise TypeError if something
         # inappropriate without a `spec` attribute?
         if (
-            policy.spec is not None
+            hasattr(policy, "spec")
+            and policy.spec is not None
             and all(v is not None for v in policy.spec.values())
             and set(policy.spec.keys()) == set(policy.out_keys)
         ):

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -323,8 +323,6 @@ class SyncDataCollector(_DataCollector):
             "step_count", torch.zeros(*self.env.batch_size, 1, dtype=torch.int)
         )
 
-        # TODO: perhaps check type of policy and raise TypeError if something
-        # inappropriate without a `spec` attribute?
         if (
             hasattr(policy, "spec")
             and policy.spec is not None
@@ -373,21 +371,9 @@ class SyncDataCollector(_DataCollector):
         # in addition to outputs of the policy, we add traj_ids and step_count to
         # _tensordict_out which will be collected during rollout
         if len(self.env.batch_size):
-            traj_ids = (
-                torch.arange(self.env.batch_size[0])
-                .unsqueeze(-1)
-                .expand(*self._tensordict_out.batch_size)
-                .unsqueeze(-1)
-                .clone()
-            )
+            traj_ids = torch.zeros(*self._tensordict_out.batch_size, 1)
         else:
-            traj_ids = (
-                torch.arange(1)
-                .expand(*self._tensordict_out.batch_size)
-                .unsqueeze(-1)
-                .unsqueeze(-1)
-                .clone()
-            )
+            traj_ids = torch.zeros(*self._tensordict_out.batch_size, 1, 1)
 
         self._tensordict_out.set("traj_ids", traj_ids)
         self._tensordict_out.set(

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -359,6 +359,7 @@ class SyncDataCollector(_DataCollector):
                 .zero_()
                 .detach()
             )
+            env.reset()
 
         # in addition to outputs of the policy, we add traj_ids and step_count to
         # _tensordict_out which will be collected during rollout

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -323,8 +323,11 @@ class SyncDataCollector(_DataCollector):
             "step_count", torch.zeros(*self.env.batch_size, 1, dtype=torch.int)
         )
 
+        # TODO: perhaps check type of policy and raise TypeError if something
+        # inappropriate without a `spec` attribute?
         if (
-            policy.spec is not None
+            hasattr(policy, "spec")
+            and policy.spec is not None
             and all(v is not None for v in policy.spec.values())
             and set(policy.spec.keys()) == set(policy.out_keys)
         ):
@@ -336,7 +339,7 @@ class SyncDataCollector(_DataCollector):
             )
             self._tensordict_out.set("reward", torch.zeros(1))
             self._tensordict_out = (
-                self._tensordict_out.expand(*env.batch_size, self.frames_per_batch, 1)
+                self._tensordict_out.expand(*env.batch_size, self.frames_per_batch)
                 .clone()
                 .zero_()
                 .detach()

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -326,24 +326,32 @@ class SyncDataCollector(_DataCollector):
         # TODO: perhaps check type of policy and raise TypeError if something
         # inappropriate without a `spec` attribute?
         if (
-            hasattr(policy, "spec")
-            and policy.spec is not None
+            policy.spec is not None
             and all(v is not None for v in policy.spec.values())
             and set(policy.spec.keys()) == set(policy.out_keys)
         ):
             # if policy spec is non-empty, all the values are not None and the keys
             # match the out_keys we assume the user has given all relevant information
-            self._tensordict_out = env.reset().update(policy.spec.rand())
-            self._tensordict_out.set(
-                "next_observation", self._tensordict_out["observation"].clone().zero_()
+            self._tensordict_out = TensorDict(
+                {
+                    **env.observation_spec.zero(env.batch_size),
+                    "reward": env.reward_spec.zero(env.batch_size),
+                    "done": torch.zeros(
+                        env.batch_size, dtype=torch.bool, device=env.device
+                    ),
+                    **policy.spec.zero(env.batch_size),
+                },
+                env.batch_size,
+                device=env.device,
             )
-            self._tensordict_out.set("reward", torch.zeros(1))
             self._tensordict_out = (
-                self._tensordict_out.expand(*env.batch_size, self.frames_per_batch)
-                .clone()
-                .zero_()
-                .detach()
+                self._tensordict_out.unsqueeze(-1)
+                .expand(*env.batch_size, self.frames_per_batch)
+                .to_tensordict()
             )
+            self._tensordict_out = self._tensordict_out.update(
+                step_mdp(self._tensordict_out)
+            )  # add "observation" when there is "next_observation"
         else:
             # otherwise, we perform a small number of steps with the policy to
             # determine the relevant keys with which to pre-populate _tensordict_out.


### PR DESCRIPTION
## Description

This PR fixes a bug with data collectors that saw some keys being omitted from the output when e.g. random actions were applied during initialisation.

Data collectors will now attempt to determine keys from the policy spec if it is supplied and complete, otherwise they will perform a short rollout with the policy to determine which keys will be returned.

## Motivation and Context

Closes #505 

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

I still need to add a test, currently seeing an error on one particular test I don't understand.

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
