### PR TITLE
[Feature] Implemented `device` argument for `modules.models`

### DIFF
--- a/test/test_exploration.py
+++ b/test/test_exploration.py
@@ -227,25 +227,23 @@ def test_gsde(
 ):
     torch.manual_seed(0)
     if gSDE:
-        model = torch.nn.LazyLinear(action_dim)
+        model = torch.nn.LazyLinear(action_dim, device=device)
         in_keys = ["observation"]
         module = TensorDictSequential(
             TensorDictModule(model, in_keys=in_keys, out_keys=["action"]),
             TensorDictModule(
-                LazygSDEModule(),
+                LazygSDEModule(device=device),
                 in_keys=["action", "observation", "_eps_gSDE"],
                 out_keys=["loc", "scale", "action", "_eps_gSDE"],
             ),
-        ).to(device)
+        )
         distribution_class = IndependentNormal
         distribution_kwargs = {}
     else:
         in_keys = ["observation"]
-        model = torch.nn.LazyLinear(action_dim * 2)
+        model = torch.nn.LazyLinear(action_dim * 2, device=device)
         wrapper = NormalParamWrapper(model)
-        module = TensorDictModule(
-            wrapper, in_keys=in_keys, out_keys=["loc", "scale"]
-        ).to(device)
+        module = TensorDictModule(wrapper, in_keys=in_keys, out_keys=["loc", "scale"])
         distribution_class = TanhNormal
         distribution_kwargs = {"min": -bound, "max": bound}
     spec = NdBoundedTensorSpec(

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -25,13 +25,17 @@ from torchrl.modules.functional_modules import (
     FunctionalModule,
     FunctionalModuleWithBuffers,
 )
-from torchrl.modules.models import MLP, NoisyLazyLinear, NoisyLinear
+from torchrl.modules.models import ConvNet, MLP, NoisyLazyLinear, NoisyLinear
+from torchrl.modules.models.utils import SquashDims
 
 
 @pytest.mark.parametrize("in_features", [3, 10, None])
 @pytest.mark.parametrize("out_features", [3, (3, 10)])
 @pytest.mark.parametrize("depth, num_cells", [(3, 32), (None, (32, 32, 32))])
-@pytest.mark.parametrize("activation_kwargs", [{"inplace": True}, {}])
+@pytest.mark.parametrize(
+    "activation_class, activation_kwargs",
+    [(nn.ReLU, {"inplace": True}), (nn.ReLU, {}), (nn.PReLU, {})],
+)
 @pytest.mark.parametrize(
     "norm_class, norm_kwargs",
     [(nn.LazyBatchNorm1d, {}), (nn.BatchNorm1d, {"num_features": 32})],
@@ -45,6 +49,7 @@ def test_mlp(
     out_features,
     depth,
     num_cells,
+    activation_class,
     activation_kwargs,
     bias_last_layer,
     norm_class,
@@ -61,20 +66,87 @@ def test_mlp(
         out_features=out_features,
         depth=depth,
         num_cells=num_cells,
-        activation_class=nn.ReLU,
+        activation_class=activation_class,
         activation_kwargs=activation_kwargs,
         norm_class=norm_class,
         norm_kwargs=norm_kwargs,
         bias_last_layer=bias_last_layer,
         single_bias_last_layer=False,
         layer_class=layer_class,
-    ).to(device)
+        device=device,
+    )
     if in_features is None:
         in_features = 5
     x = torch.randn(batch, in_features, device=device)
     y = mlp(x)
     out_features = [out_features] if isinstance(out_features, Number) else out_features
     assert y.shape == torch.Size([batch, *out_features])
+
+
+@pytest.mark.parametrize("in_features", [3, 10, None])
+@pytest.mark.parametrize(
+    "input_size, depth, num_cells, kernel_sizes, strides, paddings, expected_features",
+    [(100, None, None, 3, 1, 0, 32 * 94 * 94), (100, 3, 32, 3, 1, 1, 32 * 100 * 100)],
+)
+@pytest.mark.parametrize(
+    "activation_class, activation_kwargs",
+    [(nn.ReLU, {"inplace": True}), (nn.ReLU, {}), (nn.PReLU, {})],
+)
+@pytest.mark.parametrize(
+    "norm_class, norm_kwargs",
+    [(None, None), (nn.LazyBatchNorm2d, {}), (nn.BatchNorm2d, {"num_features": 32})],
+)
+@pytest.mark.parametrize("bias_last_layer", [True, False])
+@pytest.mark.parametrize(
+    "aggregator_class, aggregator_kwargs",
+    [(SquashDims, {})],
+)
+@pytest.mark.parametrize("squeeze_output", [False])
+@pytest.mark.parametrize("device", get_available_devices())
+def test_convnet(
+    in_features,
+    depth,
+    num_cells,
+    kernel_sizes,
+    strides,
+    paddings,
+    activation_class,
+    activation_kwargs,
+    norm_class,
+    norm_kwargs,
+    bias_last_layer,
+    aggregator_class,
+    aggregator_kwargs,
+    squeeze_output,
+    device,
+    input_size,
+    expected_features,
+    seed=0,
+):
+    torch.manual_seed(seed)
+    batch = 2
+    convnet = ConvNet(
+        in_features=in_features,
+        depth=depth,
+        num_cells=num_cells,
+        kernel_sizes=kernel_sizes,
+        strides=strides,
+        paddings=paddings,
+        activation_class=activation_class,
+        activation_kwargs=activation_kwargs,
+        norm_class=norm_class,
+        norm_kwargs=norm_kwargs,
+        bias_last_layer=bias_last_layer,
+        aggregator_class=aggregator_class,
+        aggregator_kwargs=aggregator_kwargs,
+        squeeze_output=squeeze_output,
+        device=device,
+    )
+    if in_features is None:
+        in_features = 5
+    x = torch.randn(batch, in_features, input_size, input_size, device=device)
+    y = convnet(x)
+    assert y.shape == torch.Size([batch, expected_features])
 
 
 @pytest.mark.parametrize(
@@ -87,7 +159,7 @@ def test_mlp(
 @pytest.mark.parametrize("device", get_available_devices())
 def test_noisy(layer_class, device, seed=0):
     torch.manual_seed(seed)
-    layer = layer_class(3, 4).to(device)
+    layer = layer_class(3, 4, device=device)
     x = torch.randn(10, 3, device=device)
     y1 = layer(x)
     layer.reset_noise()
@@ -106,25 +178,25 @@ def test_value_based_policy(device):
     action_spec = OneHotDiscreteTensorSpec(action_dim)
 
     def make_net():
-        net = MLP(in_features=obs_dim, out_features=action_dim, depth=2)
+        net = MLP(in_features=obs_dim, out_features=action_dim, depth=2, device=device)
         for mod in net.modules():
             if hasattr(mod, "bias") and mod.bias is not None:
                 mod.bias.data.zero_()
         return net
 
-    actor = QValueActor(spec=action_spec, module=make_net(), safe=True).to(device)
+    actor = QValueActor(spec=action_spec, module=make_net(), safe=True)
     obs = torch.zeros(2, obs_dim, device=device)
     td = TensorDict(batch_size=[2], source={"observation": obs})
     action = actor(td).get("action")
     assert (action.sum(-1) == 1).all()
 
-    actor = QValueActor(spec=action_spec, module=make_net(), safe=False).to(device)
+    actor = QValueActor(spec=action_spec, module=make_net(), safe=False)
     obs = torch.randn(2, obs_dim, device=device)
     td = TensorDict(batch_size=[2], source={"observation": obs})
     action = actor(td).get("action")
     assert (action.sum(-1) == 1).all()
 
-    actor = QValueActor(spec=action_spec, module=make_net(), safe=False).to(device)
+    actor = QValueActor(spec=action_spec, module=make_net(), safe=False)
     obs = torch.zeros(2, obs_dim, device=device)
     td = TensorDict(batch_size=[2], source={"observation": obs})
     action = actor(td).get("action")
@@ -198,7 +270,8 @@ def test_lstm_net(device, out_features, hidden_size, num_layers, has_precond_hid
             "num_layers": num_layers,
         },
         {"out_features": hidden_size},
-    ).to(device)
+        device=device,
+    )
     # test single step vs multi-step
     x = torch.randn(batch, time_steps, in_features, device=device)
     x_unbind = x.unbind(1)
@@ -264,7 +337,8 @@ def test_lstm_net_nobatch(device, out_features, hidden_size):
         out_features,
         {"input_size": hidden_size, "hidden_size": hidden_size},
         {"out_features": hidden_size},
-    ).to(device)
+        device=device,
+    )
     # test single step vs multi-step
     x = torch.randn(time_steps, in_features, device=device)
     x_unbind = x.unbind(0)

--- a/torchrl/modules/models/exploration.py
+++ b/torchrl/modules/models/exploration.py
@@ -35,7 +35,7 @@ class NoisyLinear(nn.Linear):
         out_features (int): out features dimension
         bias (bool): if True, a bias term will be added to the matrix multiplication: Ax + b.
             default: True
-        device (str, int or torch.device, optional): device of the layer.
+        device (DEVICE_TYPING, optional): device of the layer.
             default: "cpu"
         dtype (torch.dtype, optional): dtype of the parameters.
             default: None
@@ -157,8 +157,7 @@ class NoisyLazyLinear(LazyModuleMixin, NoisyLinear):
         out_features (int): out features dimension
         bias (bool): if True, a bias term will be added to the matrix multiplication: Ax + b.
             default: True
-        device (str, int or torch.device, optional): device of the layer.
-            default: "cpu"
+        device (DEVICE_TYPING, optional): device of the layer.
         dtype (torch.dtype, optional): dtype of the parameters.
             default: None
         std_init (scalar): initial value of the Gaussian standard deviation before optimization.
@@ -173,7 +172,7 @@ class NoisyLazyLinear(LazyModuleMixin, NoisyLinear):
         dtype: Optional[torch.dtype] = None,
         std_init: float = 0.1,
     ):
-        super().__init__(0, 0, False)
+        super().__init__(0, 0, False, device=device)
         self.out_features = out_features
         self.std_init = std_init
 
@@ -260,6 +259,7 @@ class gSDEModule(nn.Module):
         scale_max (float, optional): max value of the scale.
         transform (torch.distribution.Transform, optional): a transform to apply
             to the sampled action.
+        device (DEVICE_TYPING, optional): device to create the model on.
 
     Examples:
         >>> from torchrl.modules import TensorDictModule, TensorDictSequential, ProbabilisticActor, TanhNormal
@@ -308,6 +308,7 @@ class gSDEModule(nn.Module):
         scale_max: float = 10.0,
         learn_sigma: bool = True,
         transform: Optional[d.Transform] = None,
+        device: Optional[DEVICE_TYPING] = None,
     ) -> None:
         super().__init__()
         self.action_dim = action_dim
@@ -321,18 +322,22 @@ class gSDEModule(nn.Module):
                 sigma_init = inv_softplus(math.sqrt((1.0 - scale_min) / state_dim))
             self.register_parameter(
                 "log_sigma",
-                nn.Parameter(torch.zeros((action_dim, state_dim), requires_grad=True)),
+                nn.Parameter(
+                    torch.zeros(
+                        (action_dim, state_dim), requires_grad=True, device=device
+                    )
+                ),
             )
         else:
             if sigma_init is None:
                 sigma_init = math.sqrt((1.0 - scale_min) / state_dim)
             self.register_buffer(
                 "_sigma",
-                torch.full((action_dim, state_dim), sigma_init),
+                torch.full((action_dim, state_dim), sigma_init, device=device),
             )
 
         if sigma_init != 0.0:
-            self.register_buffer("sigma_init", torch.tensor(sigma_init))
+            self.register_buffer("sigma_init", torch.tensor(sigma_init, device=device))
 
     @property
     def sigma(self):
@@ -417,11 +422,8 @@ class LazygSDEModule(LazyModuleMixin, gSDEModule):
         scale_max: float = 10.0,
         learn_sigma: bool = True,
         transform: Optional[d.Transform] = None,
+        device: Optional[DEVICE_TYPING] = None,
     ) -> None:
-        factory_kwargs = {
-            "device": torch.device("cpu"),
-            "dtype": torch.get_default_dtype(),
-        }
         super().__init__(
             0,
             0,
@@ -430,7 +432,12 @@ class LazygSDEModule(LazyModuleMixin, gSDEModule):
             scale_max=scale_max,
             learn_sigma=learn_sigma,
             transform=transform,
+            device=device,
         )
+        factory_kwargs = {
+            "device": device,
+            "dtype": torch.get_default_dtype(),
+        }
         self._sigma_init = sigma_init
         self.sigma_init = UninitializedBuffer(**factory_kwargs)
         if learn_sigma:
@@ -445,18 +452,17 @@ class LazygSDEModule(LazyModuleMixin, gSDEModule):
         self, mu: torch.Tensor, state: torch.Tensor, _eps_gSDE: torch.Tensor
     ) -> None:
         if self.has_uninitialized_params():
-            device = mu.device
             action_dim = mu.shape[-1]
             state_dim = state.shape[-1]
             with torch.no_grad():
                 if state.ndimension() > 2:
                     state = state.flatten(0, -2).squeeze(0)
                 if state.ndimension() == 1:
-                    state_flatten_var = torch.ones(1).to(device)
+                    state_flatten_var = torch.ones(1, device=mu.device)
                 else:
                     state_flatten_var = state.pow(2).mean(dim=0).reciprocal()
 
-                self.sigma_init.materialize(state_flatten_var.shape, device=device)
+                self.sigma_init.materialize(state_flatten_var.shape)
                 if self.learn_sigma:
                     if self._sigma_init is None:
                         state_flatten_var.clamp_min_(self.scale_min)
@@ -471,7 +477,7 @@ class LazygSDEModule(LazyModuleMixin, gSDEModule):
                             )
                         )
 
-                    self.log_sigma.materialize((action_dim, state_dim), device=device)
+                    self.log_sigma.materialize((action_dim, state_dim))
                     self.log_sigma.data.copy_(self.sigma_init.expand_as(self.log_sigma))
 
                 else:
@@ -483,5 +489,5 @@ class LazygSDEModule(LazyModuleMixin, gSDEModule):
                         self.sigma_init.data.copy_(
                             (state_flatten_var / state_dim).sqrt() * self._sigma_init
                         )
-                    self._sigma.materialize((action_dim, state_dim), device=device)
+                    self._sigma.materialize((action_dim, state_dim))
                     self._sigma.data.copy_(self.sigma_init.expand_as(self._sigma))

--- a/torchrl/modules/models/models.py
+++ b/torchrl/modules/models/models.py
@@ -14,6 +14,7 @@ from torchrl._utils import prod
 from torchrl.data import DEVICE_TYPING
 from torchrl.modules.models.utils import (
     _find_depth,
+    create_on_device,
     LazyMapping,
     SquashDims,
     Squeeze2dLayer,
@@ -56,7 +57,7 @@ class MLP(nn.Sequential):
             an integer is provided, every layer will have the same number of cells. If an iterable is provided,
             the linear layers out_features will match the content of num_cells.
             default: 32;
-        activation_class (Type): activation class to be used.
+        activation_class (Type[nn.Module]): activation class to be used.
             default: nn.Tanh
         activation_kwargs (dict, optional): kwargs to be used with the activation class;
         norm_class (Type, optional): normalization class, if any.
@@ -66,11 +67,12 @@ class MLP(nn.Sequential):
         single_bias_last_layer (bool): if True, the last dimension of the bias of the last layer will be a singleton
             dimension.
             default: True;
-        layer_class (Type): class to be used for the linear layers;
+        layer_class (Type[nn.Module]): class to be used for the linear layers;
         layer_kwargs (dict, optional): kwargs for the linear layers;
         activate_last_layer (bool): whether the MLP output should be activated. This is useful when the MLP output
             is used as the input for another module.
             default: False.
+        device (Optional[DEVICE_TYPING]): device to create the module on.
 
     Examples:
         >>> # All of the following examples provide valid, working MLPs
@@ -154,16 +156,16 @@ class MLP(nn.Sequential):
         out_features: Union[int, Sequence[int]] = None,
         depth: Optional[int] = None,
         num_cells: Optional[Union[Sequence, int]] = None,
-        activation_class: Type = nn.Tanh,
+        activation_class: Type[nn.Module] = nn.Tanh,
         activation_kwargs: Optional[dict] = None,
-        norm_class: Optional[Type] = None,
+        norm_class: Optional[Type[nn.Module]] = None,
         norm_kwargs: Optional[dict] = None,
         bias_last_layer: bool = True,
         single_bias_last_layer: bool = False,
-        layer_class: Type = nn.Linear,
+        layer_class: Type[nn.Module] = nn.Linear,
         layer_kwargs: Optional[dict] = None,
         activate_last_layer: bool = False,
-        device: DEVICE_TYPING = "cpu",
+        device: Optional[DEVICE_TYPING] = None,
     ):
         if out_features is None:
             raise ValueError("out_feature must be specified for MLP.")
@@ -188,13 +190,11 @@ class MLP(nn.Sequential):
             activation_kwargs if activation_kwargs is not None else dict()
         )
         self.norm_class = norm_class
-        self.device = torch.device(device)
         self.norm_kwargs = norm_kwargs if norm_kwargs is not None else dict()
         self.bias_last_layer = bias_last_layer
         self.single_bias_last_layer = single_bias_last_layer
         self.layer_class = layer_class
         self.layer_kwargs = layer_kwargs if layer_kwargs is not None else dict()
-        self.layer_kwargs.update({"device": self.device})
         self.activate_last_layer = activate_last_layer
         if single_bias_last_layer:
             raise NotImplementedError
@@ -213,10 +213,10 @@ class MLP(nn.Sequential):
                 "depth and num_cells length conflict, \
             consider matching or specifying a constan num_cells argument together with a a desired depth"
             )
-        layers = self._make_net()
+        layers = self._make_net(device)
         super().__init__(*layers)
 
-    def _make_net(self) -> List[nn.Module]:
+    def _make_net(self, device: Optional[DEVICE_TYPING]) -> List[nn.Module]:
         layers = []
         in_features = [self.in_features] + self.num_cells
         out_features = self.num_cells + [self._out_features_num]
@@ -224,7 +224,14 @@ class MLP(nn.Sequential):
             _bias = self.bias_last_layer if i == self.depth else True
             if _in is not None:
                 layers.append(
-                    self.layer_class(_in, _out, bias=_bias, **self.layer_kwargs)
+                    create_on_device(
+                        self.layer_class,
+                        device,
+                        _in,
+                        _out,
+                        bias=_bias,
+                        **self.layer_kwargs,
+                    )
                 )
             else:
                 try:
@@ -234,12 +241,22 @@ class MLP(nn.Sequential):
                         f"The lazy version of {self.layer_class.__name__} is not implemented yet. "
                         "Consider providing the input feature dimensions explicitely when creating an MLP module"
                     )
-                layers.append(lazy_version(_out, bias=_bias, **self.layer_kwargs))
+                layers.append(
+                    create_on_device(
+                        lazy_version, device, _out, bias=_bias, **self.layer_kwargs
+                    )
+                )
 
             if i < self.depth or self.activate_last_layer:
-                layers.append(self.activation_class(**self.activation_kwargs))
+                layers.append(
+                    create_on_device(
+                        self.activation_class, device, **self.activation_kwargs
+                    )
+                )
                 if self.norm_class is not None:
-                    layers.append(self.norm_class(**self.norm_kwargs))
+                    layers.append(
+                        create_on_device(self.norm_class, device, **self.norm_kwargs)
+                    )
         return layers
 
     def forward(self, *inputs: Tuple[torch.Tensor]) -> torch.Tensor:
@@ -271,18 +288,19 @@ class ConvNet(nn.Sequential):
             depth, defined by the num_cells or depth arguments.
         strides (int or Sequence[int]): Stride(s) of the conv network. If iterable, the length must match the
             depth, defined by the num_cells or depth arguments.
-        activation_class (Type): activation class to be used.
+        activation_class (Type[nn.Module]): activation class to be used.
             default: nn.Tanh
         activation_kwargs (dict, optional): kwargs to be used with the activation class;
         norm_class (Type, optional): normalization class, if any;
         norm_kwargs (dict, optional): kwargs to be used with the normalization layers;
         bias_last_layer (bool): if True, the last Linear layer will have a bias parameter.
             default: True;
-        aggregator_class (Type): aggregator to use at the end of the chain.
+        aggregator_class (Type[nn.Module]): aggregator to use at the end of the chain.
             default:  SquashDims;
         aggregator_kwargs (dict, optional): kwargs for the aggregator_class;
         squeeze_output (bool): whether the output should be squeezed of its singleton dimensions.
             default: True.
+        device (Optional[DEVICE_TYPING]): device to create the module on.
 
     Examples:
         >>> # All of the following examples provide valid, working MLPs
@@ -343,15 +361,15 @@ class ConvNet(nn.Sequential):
         kernel_sizes: Union[Sequence[Union[int, Sequence[int]]], int] = 3,
         strides: Union[Sequence, int] = 1,
         paddings: Union[Sequence, int] = 0,
-        activation_class: Type = nn.ELU,
+        activation_class: Type[nn.Module] = nn.ELU,
         activation_kwargs: Optional[dict] = None,
-        norm_class: Type = None,
+        norm_class: Optional[Type[nn.Module]] = None,
         norm_kwargs: Optional[dict] = None,
         bias_last_layer: bool = True,
-        aggregator_class: Type = SquashDims,
+        aggregator_class: Optional[Type[nn.Module]] = SquashDims,
         aggregator_kwargs: Optional[dict] = None,
         squeeze_output: bool = False,
-        device: DEVICE_TYPING = "cpu",
+        device: Optional[DEVICE_TYPING] = None,
     ):
         if num_cells is None:
             num_cells = [32, 32, 32]
@@ -369,7 +387,6 @@ class ConvNet(nn.Sequential):
             aggregator_kwargs if aggregator_kwargs is not None else {"ndims_in": 3}
         )
         self.squeeze_output = squeeze_output
-        self.device = torch.device(device)
         # self.single_bias_last_layer = single_bias_last_layer
 
         depth = _find_depth(depth, num_cells, kernel_sizes, strides, paddings)
@@ -401,10 +418,10 @@ class ConvNet(nn.Sequential):
         self.out_features = self.num_cells[-1]
 
         self.depth = len(self.kernel_sizes)
-        layers = self._make_net()
+        layers = self._make_net(device)
         super().__init__(*layers)
 
-    def _make_net(self) -> nn.Module:
+    def _make_net(self, device: Optional[DEVICE_TYPING]) -> nn.Module:
         layers = []
         in_features = [self.in_features] + self.num_cells[: self.depth]
         out_features = self.num_cells + [self.out_features]
@@ -424,7 +441,7 @@ class ConvNet(nn.Sequential):
                         stride=_stride,
                         bias=_bias,
                         padding=_padding,
-                        device=self.device,
+                        device=device,
                     )
                 )
             else:
@@ -435,16 +452,26 @@ class ConvNet(nn.Sequential):
                         stride=_stride,
                         bias=_bias,
                         padding=_padding,
-                        device=self.device,
+                        device=device,
                     )
                 )
 
-            layers.append(self.activation_class(**self.activation_kwargs))
+            layers.append(
+                create_on_device(
+                    self.activation_class, device, **self.activation_kwargs
+                )
+            )
             if self.norm_class is not None:
-                layers.append(self.norm_class(**self.norm_kwargs))
+                layers.append(
+                    create_on_device(self.norm_class, device, **self.norm_kwargs)
+                )
 
         if self.aggregator_class is not None:
-            layers.append(self.aggregator_class(**self.aggregator_kwargs))
+            layers.append(
+                create_on_device(
+                    self.aggregator_class, device, **self.aggregator_kwargs
+                )
+            )
 
         if self.squeeze_output:
             layers.append(Squeeze2dLayer())
@@ -480,6 +507,7 @@ class DuelingMlpDQNet(nn.Module):
             ...     "bias_last_layer": True,
             ... }
 
+        device (Optional[DEVICE_TYPING]): device to create the module on.
     """
 
     def __init__(
@@ -488,8 +516,9 @@ class DuelingMlpDQNet(nn.Module):
         out_features_value: int = 1,
         mlp_kwargs_feature: Optional[dict] = None,
         mlp_kwargs_output: Optional[dict] = None,
+        device: Optional[DEVICE_TYPING] = None,
     ):
-        super(DuelingMlpDQNet, self).__init__()
+        super().__init__()
 
         mlp_kwargs_feature = (
             mlp_kwargs_feature if mlp_kwargs_feature is not None else dict()
@@ -501,7 +530,7 @@ class DuelingMlpDQNet(nn.Module):
             "activate_last_layer": True,
         }
         _mlp_kwargs_feature.update(mlp_kwargs_feature)
-        self.features = MLP(**_mlp_kwargs_feature)
+        self.features = MLP(device=device, **_mlp_kwargs_feature)
 
         _mlp_kwargs_output = {
             "depth": 1,
@@ -515,8 +544,12 @@ class DuelingMlpDQNet(nn.Module):
         _mlp_kwargs_output.update(mlp_kwargs_output)
         self.out_features = out_features
         self.out_features_value = out_features_value
-        self.advantage = MLP(out_features=out_features, **_mlp_kwargs_output)
-        self.value = MLP(out_features=out_features_value, **_mlp_kwargs_output)
+        self.advantage = MLP(
+            out_features=out_features, device=device, **_mlp_kwargs_output
+        )
+        self.value = MLP(
+            out_features=out_features_value, device=device, **_mlp_kwargs_output
+        )
         for layer in self.modules():
             if isinstance(layer, (nn.Conv2d, nn.Linear)) and isinstance(
                 layer.bias, torch.Tensor
@@ -556,6 +589,7 @@ class DuelingCnnDQNet(nn.Module):
             ...     "bias_last_layer": True,
             ... }
 
+        device (Optional[DEVICE_TYPING]): device to create the module on.
     """
 
     def __init__(
@@ -564,8 +598,9 @@ class DuelingCnnDQNet(nn.Module):
         out_features_value: int = 1,
         cnn_kwargs: Optional[dict] = None,
         mlp_kwargs: Optional[dict] = None,
+        device: Optional[DEVICE_TYPING] = None,
     ):
-        super(DuelingCnnDQNet, self).__init__()
+        super().__init__()
 
         cnn_kwargs = cnn_kwargs if cnn_kwargs is not None else dict()
         _cnn_kwargs = {
@@ -574,7 +609,7 @@ class DuelingCnnDQNet(nn.Module):
             "kernel_sizes": [8, 4, 3],
         }
         _cnn_kwargs.update(cnn_kwargs)
-        self.features = ConvNet(**_cnn_kwargs)
+        self.features = ConvNet(device=device, **_cnn_kwargs)
 
         _mlp_kwargs = {
             "depth": 1,
@@ -586,8 +621,8 @@ class DuelingCnnDQNet(nn.Module):
         _mlp_kwargs.update(mlp_kwargs)
         self.out_features = out_features
         self.out_features_value = out_features_value
-        self.advantage = MLP(out_features=out_features, **_mlp_kwargs)
-        self.value = MLP(out_features=out_features_value, **_mlp_kwargs)
+        self.advantage = MLP(out_features=out_features, device=device, **_mlp_kwargs)
+        self.value = MLP(out_features=out_features_value, device=device, **_mlp_kwargs)
         for layer in self.modules():
             if isinstance(layer, (nn.Conv2d, nn.Linear)) and isinstance(
                 layer.bias, torch.Tensor
@@ -634,13 +669,17 @@ class DistributionalDQNnet(nn.Module):
         return F.log_softmax(q_values, dim=-2)
 
 
-def ddpg_init_last_layer(last_layer: nn.Module, scale: float = 6e-4) -> None:
+def ddpg_init_last_layer(
+    last_layer: nn.Module,
+    scale: float = 6e-4,
+    device: Optional[DEVICE_TYPING] = None,
+) -> None:
     last_layer.weight.data.copy_(
-        torch.rand_like(last_layer.weight.data) * scale - scale / 2
+        torch.rand_like(last_layer.weight.data, device=device) * scale - scale / 2
     )
     if last_layer.bias is not None:
         last_layer.bias.data.copy_(
-            torch.rand_like(last_layer.bias.data) * scale - scale / 2
+            torch.rand_like(last_layer.bias.data, device=device) * scale - scale / 2
         )
 
 
@@ -679,6 +718,7 @@ class DdpgCnnActor(nn.Module):
         }
         use_avg_pooling (bool, optional): if True, a nn.AvgPooling layer is
             used to aggregate the output. Default is `False`.
+        device (Optional[DEVICE_TYPING]): device to create the module on.
     """
 
     def __init__(
@@ -687,6 +727,7 @@ class DdpgCnnActor(nn.Module):
         conv_net_kwargs: Optional[dict] = None,
         mlp_net_kwargs: Optional[dict] = None,
         use_avg_pooling: bool = False,
+        device: Optional[DEVICE_TYPING] = None,
     ):
         super().__init__()
         conv_net_default_kwargs = {
@@ -717,9 +758,9 @@ class DdpgCnnActor(nn.Module):
         }
         mlp_net_kwargs = mlp_net_kwargs if mlp_net_kwargs is not None else dict()
         mlp_net_default_kwargs.update(mlp_net_kwargs)
-        self.convnet = ConvNet(**conv_net_default_kwargs)
-        self.mlp = MLP(**mlp_net_default_kwargs)
-        ddpg_init_last_layer(self.mlp[-1], 6e-4)
+        self.convnet = ConvNet(device=device, **conv_net_default_kwargs)
+        self.mlp = MLP(device=device, **mlp_net_default_kwargs)
+        ddpg_init_last_layer(self.mlp[-1], 6e-4, device=device)
 
     def forward(self, observation: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         hidden = self.convnet(observation)
@@ -746,9 +787,15 @@ class DdpgMlpActor(nn.Module):
             'activation_class': nn.ELU,
             'bias_last_layer': True,
         }
+        device (Optional[DEVICE_TYPING]): device to create the module on.
     """
 
-    def __init__(self, action_dim: int, mlp_net_kwargs: Optional[dict] = None):
+    def __init__(
+        self,
+        action_dim: int,
+        mlp_net_kwargs: Optional[dict] = None,
+        device: Optional[DEVICE_TYPING] = None,
+    ):
         super().__init__()
         mlp_net_default_kwargs = {
             "in_features": None,
@@ -760,8 +807,8 @@ class DdpgMlpActor(nn.Module):
         }
         mlp_net_kwargs = mlp_net_kwargs if mlp_net_kwargs is not None else dict()
         mlp_net_default_kwargs.update(mlp_net_kwargs)
-        self.mlp = MLP(**mlp_net_default_kwargs)
-        ddpg_init_last_layer(self.mlp[-1], 6e-3)
+        self.mlp = MLP(device=device, **mlp_net_default_kwargs)
+        ddpg_init_last_layer(self.mlp[-1], 6e-3, device=device)
 
     def forward(self, observation: torch.Tensor) -> torch.Tensor:
         action = self.mlp(observation)
@@ -800,6 +847,7 @@ class DdpgCnnQNet(nn.Module):
         }
         use_avg_pooling (bool, optional): if True, a nn.AvgPooling layer is
             used to aggregate the output. Default is `True`.
+        device (Optional[DEVICE_TYPING]): device to create the module on.
     """
 
     def __init__(
@@ -807,6 +855,7 @@ class DdpgCnnQNet(nn.Module):
         conv_net_kwargs: Optional[dict] = None,
         mlp_net_kwargs: Optional[dict] = None,
         use_avg_pooling: bool = True,
+        device: Optional[DEVICE_TYPING] = None,
     ):
         super().__init__()
         conv_net_default_kwargs = {
@@ -837,9 +886,9 @@ class DdpgCnnQNet(nn.Module):
         }
         mlp_net_kwargs = mlp_net_kwargs if mlp_net_kwargs is not None else dict()
         mlp_net_default_kwargs.update(mlp_net_kwargs)
-        self.convnet = ConvNet(**conv_net_default_kwargs)
-        self.mlp = MLP(**mlp_net_default_kwargs)
-        ddpg_init_last_layer(self.mlp[-1], 6e-4)
+        self.convnet = ConvNet(device=device, **conv_net_default_kwargs)
+        self.mlp = MLP(device=device, **mlp_net_default_kwargs)
+        ddpg_init_last_layer(self.mlp[-1], 6e-4, device=device)
 
     def forward(self, observation: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
         hidden = torch.cat([self.convnet(observation), action], -1)
@@ -875,12 +924,14 @@ class DdpgMlpQNet(nn.Module):
             'activation_class': nn.ELU,
             'bias_last_layer': True,
         }
+        device (Optional[DEVICE_TYPING]): device to create the module on.
     """
 
     def __init__(
         self,
         mlp_net_kwargs_net1: Optional[dict] = None,
         mlp_net_kwargs_net2: Optional[dict] = None,
+        device: Optional[DEVICE_TYPING] = None,
     ):
         super().__init__()
         mlp1_net_default_kwargs = {
@@ -896,7 +947,7 @@ class DdpgMlpQNet(nn.Module):
             mlp_net_kwargs_net1 if mlp_net_kwargs_net1 is not None else dict()
         )
         mlp1_net_default_kwargs.update(mlp_net_kwargs_net1)
-        self.mlp1 = MLP(**mlp1_net_default_kwargs)
+        self.mlp1 = MLP(device=device, **mlp1_net_default_kwargs)
 
         mlp2_net_default_kwargs = {
             "in_features": None,
@@ -911,8 +962,8 @@ class DdpgMlpQNet(nn.Module):
             mlp_net_kwargs_net2 if mlp_net_kwargs_net2 is not None else dict()
         )
         mlp2_net_default_kwargs.update(mlp_net_kwargs_net2)
-        self.mlp2 = MLP(**mlp2_net_default_kwargs)
-        ddpg_init_last_layer(self.mlp2[-1], 6e-3)
+        self.mlp2 = MLP(device=device, **mlp2_net_default_kwargs)
+        ddpg_init_last_layer(self.mlp2[-1], 6e-3, device=device)
 
     def forward(self, observation: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
         value = self.mlp2(torch.cat([self.mlp1(observation), action], -1))
@@ -948,12 +999,18 @@ class LSTMNet(nn.Module):
 
     """
 
-    def __init__(self, out_features, lstm_kwargs: Dict, mlp_kwargs: Dict) -> None:
+    def __init__(
+        self,
+        out_features: int,
+        lstm_kwargs: Dict,
+        mlp_kwargs: Dict,
+        device: Optional[DEVICE_TYPING] = None,
+    ) -> None:
         super().__init__()
         lstm_kwargs.update({"batch_first": True})
-        self.mlp = MLP(**mlp_kwargs)
-        self.lstm = nn.LSTM(**lstm_kwargs)
-        self.linear = nn.LazyLinear(out_features)
+        self.mlp = MLP(device=device, **mlp_kwargs)
+        self.lstm = nn.LSTM(device=device, **lstm_kwargs)
+        self.linear = nn.LazyLinear(out_features, device=device)
 
     def _lstm(
         self,

--- a/torchrl/modules/models/utils.py
+++ b/torchrl/modules/models/utils.py
@@ -3,11 +3,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional, Sequence
+import inspect
+from typing import Optional, Sequence, Type
 
 import torch
 from torch import nn
 
+from torchrl.data import DEVICE_TYPING
 from .exploration import NoisyLazyLinear, NoisyLinear
 
 LazyMapping = {
@@ -103,3 +105,25 @@ def _find_depth(depth: Optional[int], *list_or_ints: Sequence):
             f"num_cells) to be a a list or tuple. Got {tuple(type(item) for item in list_or_ints)}"
         )
     return depth
+
+
+def create_on_device(
+    module_class: Type[nn.Module], device: Optional[DEVICE_TYPING], *args, **kwargs
+) -> nn.Module:
+    """
+    Create a new instance of `module_class` on `device`.
+
+    The new instance is created directly on the device if its constructor supports this.
+
+    Args:
+        module_class (Type[nn.Module]): the class of module to be created.
+        device (DEVICE_TYPING): device to create the module on.
+        *args: positional arguments to be passed to the module constructor.
+        **kwargs: keyword arguments to be passed to the module constructor.
+    """
+    fullargspec = inspect.getfullargspec(module_class.__init__)
+    if "device" in fullargspec.args or "device" in fullargspec.kwonlyargs:
+        return module_class(*args, device=device, **kwargs)
+    else:
+        return module_class(*args, **kwargs).to(device)
+        # .to() is always available for nn.Module, and does nothing if the Module contains no parameters or buffers


### PR DESCRIPTION
## Description

Implemented a `device` argument for modules in `torchrl.modules.models` to allow them to be directly constructed on a particular device, rather than first constructing it then moving it with `.to()`. This follows the behaviour of most modules in `torch.nn`. Updated `test_modules.py` to make use of this.

However, an arbitrary `nn.Module` subclass does not necessarily support the `device` argument, in particular for modules that do not contain parameters or buffers. The utility function added in `torchrl/modules/models/utils.py` addresses this. This functionality is tested in `test_mlp` in `test_modules.py`, parameterised with both `nn.ReLU` (which does not support `device`) and `nn.PReLU` (which does).

## Motivation and Context

Addresses #507

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
