### PR TITLE
[BugFix] Transformed ParallelEnv meta data are broken when passing to device

### DIFF
--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -238,6 +238,7 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
         # It can also lead to inconsistencies when calling rollout.
         cls._inplace_update = _inplace_update
         cls._batch_locked = _batch_locked
+        cls._device = None
         return super().__new__(cls)
 
     @property

--- a/torchrl/envs/env_creator.py
+++ b/torchrl/envs/env_creator.py
@@ -39,7 +39,7 @@ class EnvCreator:
         >>> # and check that the discounted count of observations match on
         >>> # both workers, even if one has not executed any step
         >>> import time
-        >>> from torchrl.envs import GymEnv
+        >>> from torchrl.envs.libs.gym import GymEnv
         >>> from torchrl.envs.transforms import VecNorm, TransformedEnv
         >>> from torchrl.envs import EnvCreator
         >>> from torch import multiprocessing as mp

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -275,35 +275,34 @@ class _BatchedEnv(EnvBase):
                 _kwargs.update(_new_kwargs)
 
     def _set_properties(self):
+        meta_data = deepcopy(self.meta_data)
         if self._single_task:
-            self._batch_size = self.meta_data.batch_size
-            self._observation_spec = self.meta_data.specs["observation_spec"]
-            self._reward_spec = self.meta_data.specs["reward_spec"]
-            self._input_spec = self.meta_data.specs["input_spec"]
-            self._dummy_env_str = self.meta_data.env_str
-            self._device = self.meta_data.device
-            self._env_tensordict = self.meta_data.tensordict
-            self._batch_locked = self.meta_data.batch_locked
+            self._batch_size = meta_data.batch_size
+            self._observation_spec = meta_data.specs["observation_spec"]
+            self._reward_spec = meta_data.specs["reward_spec"]
+            self._input_spec = meta_data.specs["input_spec"]
+            self._dummy_env_str = meta_data.env_str
+            self._device = meta_data.device
+            self._env_tensordict = meta_data.tensordict
+            self._batch_locked = meta_data.batch_locked
         else:
-            self._batch_size = torch.Size(
-                [self.num_workers, *self.meta_data[0].batch_size]
-            )
-            self._device = self.meta_data[0].device
+            self._batch_size = torch.Size([self.num_workers, *meta_data[0].batch_size])
+            self._device = meta_data[0].device
             # TODO: check that all action_spec and reward spec match (issue #351)
-            self._reward_spec = self.meta_data[0].specs["reward_spec"]
+            self._reward_spec = meta_data[0].specs["reward_spec"]
             _observation_spec = {}
-            for md in self.meta_data:
+            for md in meta_data:
                 _observation_spec.update(dict(**md.specs["observation_spec"]))
             self._observation_spec = CompositeSpec(**_observation_spec)
             _input_spec = {}
-            for md in self.meta_data:
+            for md in meta_data:
                 _input_spec.update(dict(**md.specs["input_spec"]))
             self._input_spec = CompositeSpec(**_input_spec)
-            self._dummy_env_str = str(self.meta_data[0])
+            self._dummy_env_str = str(meta_data[0])
             self._env_tensordict = torch.stack(
-                [meta_data.tensordict for meta_data in self.meta_data], 0
+                [meta_data.tensordict for meta_data in meta_data], 0
             )
-            self._batch_locked = self.meta_data[0].batch_locked
+            self._batch_locked = meta_data[0].batch_locked
 
     def state_dict(self) -> OrderedDict:
         raise NotImplementedError


### PR DESCRIPTION
## Description

In some instances, the meta data of the base_env in a transformed env are sent to cpu when the meta data is passed to a process.


