### PR TITLE
[Feature] Allow collectors to accept regular modules as policies

### DIFF
--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -28,6 +28,7 @@ from torchrl.collectors.collectors import (
 from torchrl.data import (
     CompositeSpec,
     NdUnboundedContinuousTensorSpec,
+    TensorDict,
     UnboundedContinuousTensorSpec,
 )
 from torchrl.data.tensordict.tensordict import assert_allclose_td
@@ -44,7 +45,7 @@ from torchrl.modules import (
 # torch.set_default_dtype(torch.double)
 
 
-class UnwrappedPolicy(nn.Module):
+class WrappablePolicy(nn.Module):
     def __init__(self, out_features: int, multiple_outputs: bool = False):
         super().__init__()
         self.multiple_outputs = multiple_outputs
@@ -55,6 +56,29 @@ class UnwrappedPolicy(nn.Module):
         if self.multiple_outputs:
             return output, output.sum(), output.min(), output.max()
         return self.linear(observation)
+
+
+class TensorDictCompatiblePolicy(nn.Module):
+    def __init__(self, out_features: int):
+        super().__init__()
+        self.in_keys = ["observation"]
+        self.out_keys = ["action"]
+        self.linear = nn.LazyLinear(out_features)
+
+    def forward(self, tensordict):
+        return TensorDict(
+            {self.out_keys[0]: self.linear(tensordict.get(self.in_keys[0]))},
+            [],
+        )
+
+
+class UnwrappablePolicy(nn.Module):
+    def __init__(self, out_features: int):
+        super().__init__()
+        self.linear = nn.LazyLinear(out_features)
+
+    def forward(self, observation, other_stuff):
+        return self.linear(observation), other_stuff.sum()
 
 
 class ParametricPolicyNet(nn.Module):
@@ -891,40 +915,83 @@ def test_collector_output_keys(collector_class, init_random_frames, explicit_spe
         MultiSyncDataCollector,
     ],
 )
-@pytest.mark.parametrize("multiple_outputs", [False, True])
-def test_auto_wrap_modules(collector_class, multiple_outputs):
-    from torchrl.envs.libs.gym import GymEnv
-
+class TestAutoWrap:
     num_envs = 3
 
-    env_maker = lambda: GymEnv("Pendulum-v1")
-    out_features = env_maker().action_spec.shape[-1]
-    policy = UnwrappedPolicy(
-        out_features=out_features, multiple_outputs=multiple_outputs
-    )
+    @pytest.fixture
+    def env_maker(self):
+        from torchrl.envs.libs.gym import GymEnv
 
-    collector_kwargs = {"create_env_fn": env_maker, "policy": policy}
+        return lambda: GymEnv("Pendulum-v1")
 
-    if collector_class is not SyncDataCollector:
-        collector_kwargs["create_env_fn"] = [
-            collector_kwargs["create_env_fn"] for _ in range(num_envs)
-        ]
+    def _create_collector_kwargs(self, env_maker, collector_class, policy):
+        collector_kwargs = {"create_env_fn": env_maker, "policy": policy}
 
-    collector = collector_class(**collector_kwargs)
-    out_keys = ["action"]
-    if multiple_outputs:
-        out_keys.extend(f"output{i}" for i in range(1, 4))
+        if collector_class is not SyncDataCollector:
+            collector_kwargs["create_env_fn"] = [
+                collector_kwargs["create_env_fn"] for _ in range(self.num_envs)
+            ]
 
-    if collector_class is not SyncDataCollector:
-        assert all(
-            isinstance(p, TensorDictModule) for p in collector._policy_dict.values()
+        return collector_kwargs
+
+    @pytest.mark.parametrize("multiple_outputs", [False, True])
+    def test_auto_wrap_modules(self, collector_class, multiple_outputs, env_maker):
+        policy = WrappablePolicy(
+            out_features=env_maker().action_spec.shape[-1],
+            multiple_outputs=multiple_outputs,
         )
-        assert all(p.out_keys == out_keys for p in collector._policy_dict.values())
-        assert all(p.module is policy for p in collector._policy_dict.values())
-    else:
-        assert isinstance(collector.policy, TensorDictModule)
-        assert collector.policy.out_keys == out_keys
-        assert collector.policy.module is policy
+        collector = collector_class(
+            **self._create_collector_kwargs(env_maker, collector_class, policy)
+        )
+
+        out_keys = ["action"]
+        if multiple_outputs:
+            out_keys.extend(f"output{i}" for i in range(1, 4))
+
+        if collector_class is not SyncDataCollector:
+            assert all(
+                isinstance(p, TensorDictModule) for p in collector._policy_dict.values()
+            )
+            assert all(p.out_keys == out_keys for p in collector._policy_dict.values())
+            assert all(p.module is policy for p in collector._policy_dict.values())
+        else:
+            assert isinstance(collector.policy, TensorDictModule)
+            assert collector.policy.out_keys == out_keys
+            assert collector.policy.module is policy
+
+    def test_no_wrap_compatible_module(self, collector_class, env_maker):
+        policy = TensorDictCompatiblePolicy(
+            out_features=env_maker().action_spec.shape[-1]
+        )
+
+        collector = collector_class(
+            **self._create_collector_kwargs(env_maker, collector_class, policy)
+        )
+
+        if collector_class is not SyncDataCollector:
+            assert all(
+                isinstance(p, TensorDictCompatiblePolicy)
+                for p in collector._policy_dict.values()
+            )
+            assert all(
+                p.out_keys == ["action"] for p in collector._policy_dict.values()
+            )
+            assert all(p is policy for p in collector._policy_dict.values())
+        else:
+            assert isinstance(collector.policy, TensorDictCompatiblePolicy)
+            assert collector.policy.out_keys == ["action"]
+            assert collector.policy is policy
+
+    def test_auto_wrap_error(self, collector_class, env_maker):
+        policy = UnwrappablePolicy(out_features=env_maker().action_spec.shape[-1])
+
+        with pytest.raises(
+            TypeError,
+            match="If the supplied policy is a nn.Module, it must either accept",
+        ):
+            collector_class(
+                **self._create_collector_kwargs(env_maker, collector_class, policy)
+            )
 
 
 def weight_reset(m):

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -987,7 +987,10 @@ class TestAutoWrap:
 
         with pytest.raises(
             TypeError,
-            match="If the supplied policy is a nn.Module, it must either accept",
+            match=(
+                "Arguments to policy.forward are incompatible with entries in "
+                "env.observation_spec."
+            ),
         ):
             collector_class(
                 **self._create_collector_kwargs(env_maker, collector_class, policy)

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import abc
+import inspect
 import os
 import queue
 import time
@@ -15,12 +16,13 @@ from typing import Callable, Iterator, Optional, Sequence, Tuple, Union, Any, Di
 
 import numpy as np
 import torch
+import torch.nn as nn
 from torch import multiprocessing as mp
 from torch.utils.data import IterableDataset
 
 from torchrl.envs.utils import set_exploration_mode, step_mdp
 from .._utils import _check_for_faulty_process, prod
-from ..modules.tensordict_module import ProbabilisticTensorDictModule
+from ..modules.tensordict_module import ProbabilisticTensorDictModule, TensorDictModule
 from .utils import split_trajectories
 
 __all__ = [
@@ -91,6 +93,7 @@ class _DataCollector(IterableDataset, metaclass=abc.ABCMeta):
             ]
         ] = None,
         device: Optional[DEVICE_TYPING] = None,
+        observation_spec: TensorSpec = None,
     ) -> Tuple[
         ProbabilisticTensorDictModule, torch.device, Union[None, Callable[[], dict]]
     ]:
@@ -105,6 +108,7 @@ class _DataCollector(IterableDataset, metaclass=abc.ABCMeta):
             policy (ProbabilisticTensorDictModule, optional): a policy to be used
             device (int, str or torch.device, optional): device where to place
                 the policy
+            observation_spec (TensorSpec, optional): spec of the observations
 
         """
         # if create_env_fn is not None:
@@ -124,6 +128,28 @@ class _DataCollector(IterableDataset, metaclass=abc.ABCMeta):
                     "env must be provided to _get_policy_and_device if policy is None"
                 )
             policy = RandomPolicy(self.env.action_spec)
+        elif (
+            observation_spec is not None
+            and isinstance(policy, nn.Module)
+            and not isinstance(policy, TensorDictModule)
+        ):
+            # auto-wrap policy with TensorDictModule
+            sig = inspect.signature(policy.forward)
+            next_observation = {
+                key[5:]: value
+                for key, value in observation_spec.rand().items()
+                if key.startswith("next_")
+            }
+            if set(sig.parameters) == set(next_observation):
+                out_keys = ["action"]
+                output = policy(**next_observation)
+
+                if isinstance(output, tuple):
+                    out_keys.extend(f"output{i+1}" for i in range(len(output) - 1))
+
+                policy = TensorDictModule(
+                    policy, in_keys=list(sig.parameters), out_keys=out_keys
+                )
 
         try:
             policy_device = next(policy.parameters()).device
@@ -298,6 +324,7 @@ class SyncDataCollector(_DataCollector):
         (self.policy, self.device, self.get_weights_fn,) = self._get_policy_and_device(
             policy=policy,
             device=device,
+            observation_spec=self.env.observation_spec,
         )
 
         self.env_device = env.device
@@ -324,10 +351,10 @@ class SyncDataCollector(_DataCollector):
         )
 
         if (
-            hasattr(policy, "spec")
-            and policy.spec is not None
-            and all(v is not None for v in policy.spec.values())
-            and set(policy.spec.keys()) == set(policy.out_keys)
+            hasattr(self.policy, "spec")
+            and self.policy.spec is not None
+            and all(v is not None for v in self.policy.spec.values())
+            and set(self.policy.spec.keys()) == set(self.policy.out_keys)
         ):
             # if policy spec is non-empty, all the values are not None and the keys
             # match the out_keys we assume the user has given all relevant information
@@ -338,7 +365,7 @@ class SyncDataCollector(_DataCollector):
                     "done": torch.zeros(
                         env.batch_size, dtype=torch.bool, device=env.device
                     ),
-                    **policy.spec.zero(env.batch_size),
+                    **self.policy.spec.zero(env.batch_size),
                 },
                 env.batch_size,
                 device=env.device,
@@ -355,7 +382,7 @@ class SyncDataCollector(_DataCollector):
             # otherwise, we perform a small number of steps with the policy to
             # determine the relevant keys with which to pre-populate _tensordict_out.
             # See #505 for additional context.
-            self._tensordict_out = env.rollout(3, policy)
+            self._tensordict_out = env.rollout(3, self.policy)
             if env.batch_size:
                 self._tensordict_out = self._tensordict_out[..., :1]
             else:
@@ -791,12 +818,24 @@ class _MultiDataCollector(_DataCollector):
             )
         self._policy_dict = {}
         self._get_weights_fn_dict = {}
-        for i, _device in enumerate(devices):
+
+        for i, (_device, create_env, kwargs) in enumerate(
+            zip(devices, self.create_env_fn, self.create_env_kwargs)
+        ):
             if _device in self._policy_dict:
                 devices[i] = _device
                 continue
+
+            if hasattr(create_env, "observation_spec"):
+                observation_spec = create_env.observation_spec
+            else:
+                try:
+                    observation_spec = create_env(**kwargs).observation_spec
+                except:  # noqa
+                    observation_spec = None
+
             _policy, _device, _get_weight_fn = self._get_policy_and_device(
-                policy=policy, device=_device
+                policy=policy, device=_device, observation_spec=observation_spec
             )
             self._policy_dict[_device] = _policy
             self._get_weights_fn_dict[_device] = _get_weight_fn

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -105,11 +105,11 @@ def _policy_is_tensordict_compatible(policy: nn.Module):
     # that will have undetermined behaviour, we raise an error
     raise TypeError(
         "Received a policy that defines in_keys or out_keys and also expects multiple "
-        "arguments to self.forward. If the policy is compatible with TensorDict, it "
-        "should take a single argument of type TensorDict to self.forward and define "
-        "both in_keys and out_keys. Alternatively, self.forward can accept arbitrarily "
-        "many tensor inputs and leave in_keys and out_keys undefined and TorchRL will "
-        "attempt to automatically wrap the policy with a TensorDictModule."
+        "arguments to policy.forward. If the policy is compatible with TensorDict, it "
+        "should take a single argument of type TensorDict to policy.forward and define "
+        "both in_keys and out_keys. Alternatively, policy.forward can accept "
+        "arbitrarily many tensor inputs and leave in_keys and out_keys undefined and "
+        "TorchRL will attempt to automatically wrap the policy with a TensorDictModule."
     )
 
 

--- a/torchrl/modules/models/models.py
+++ b/torchrl/modules/models/models.py
@@ -166,7 +166,7 @@ class MLP(nn.Sequential):
         device: DEVICE_TYPING = "cpu",
     ):
         if out_features is None:
-            raise ValueError("out_feature must be specified for MLP.")
+            raise ValueError("out_features must be specified for MLP.")
 
         default_num_cells = 32
         if num_cells is None:


### PR DESCRIPTION
## Description

This PR makes changes to the collector classes in order that users can pass simple `nn.Module`s as policies.

It checks that the signature of the `forward` method matches the `next_` entries in the environment's `observation_spec`. The first returned value is assumed to be the action while remaining return values are simply enumerated and labelled `output1`, `output2`, etc.

## Motivation and Context

Closes #544

## Types of changes

- [x] New feature (non-breaking change which adds core functionality)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
