### PR TITLE
[BugFix] Additive gaussian exploration spec fix

### DIFF
--- a/torchrl/modules/tensordict_module/exploration.py
+++ b/torchrl/modules/tensordict_module/exploration.py
@@ -209,9 +209,9 @@ class AdditiveGaussianWrapper(TensorDictModuleWrapper):
         noise = torch.randn(action.shape, device=action.device) * sigma
         action = action + noise
         spec = self.spec
+        if isinstance(spec, CompositeSpec):
+            spec = spec[self.action_key]
         if spec is not None:
-            if isinstance(spec, CompositeSpec):
-                spec = spec[self.action_key]
             action = spec.project(action)
         elif self.safe:
             raise RuntimeError(


### PR DESCRIPTION
## Description

Fixes a bug where a field in a tensorspec could be none but is not caught by AdditiveGaussian exploration wrapper