### PR TITLE
[Feature] Log printing in alphabetical order when creating a replay buffer

### DIFF
--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -204,7 +204,7 @@ class LazyMemmapStorage(LazyTensorStorage):
         else:
             out = TensorDict({}, [self.max_size, *data.shape])
             print("The storage is being created: ")
-            for key, tensor in data.items():
+            for key, tensor in sorted(data.items()):
                 if isinstance(tensor, TensorDictBase):
                     out[key] = (
                         tensor.expand(self.max_size)


### PR DESCRIPTION
## Description

When a replay buffer is being created, the storage is printed on the log. This print being printed in alphabetical order was a nice to have and this change brings in that.

## Motivation and Context

Close issue #508

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
