### PR TITLE
[Feature] Categorical encoding for action space

### DIFF
--- a/docs/source/reference/data.rst
+++ b/docs/source/reference/data.rst
@@ -57,6 +57,7 @@ as shape, device, dtype and domain.
     NdUnboundedContinuousTensorSpec
     BinaryDiscreteTensorSpec
     MultOneHotDiscreteTensorSpec
+    DiscreteTensorSpec
     CompositeSpec
 
 

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -295,7 +295,11 @@ class DiscreteActionVecMockEnv(_MockEnv):
                 ),
             )
         if action_spec is None:
-            action_spec_cls = DiscreteTensorSpec if categorical_action_encoding else OneHotDiscreteTensorSpec
+            action_spec_cls = (
+                DiscreteTensorSpec
+                if categorical_action_encoding
+                else OneHotDiscreteTensorSpec
+            )
             action_spec = action_spec_cls(7)
         if reward_spec is None:
             reward_spec = UnboundedContinuousTensorSpec()
@@ -541,7 +545,11 @@ class DiscreteActionConvMockEnvNumpy(DiscreteActionConvMockEnv):
                 ),
             )
         if action_spec is None:
-            action_spec_cls = DiscreteTensorSpec if categorical_action_encoding else OneHotDiscreteTensorSpec
+            action_spec_cls = (
+                DiscreteTensorSpec
+                if categorical_action_encoding
+                else OneHotDiscreteTensorSpec
+            )
             action_spec = action_spec_cls(7)
         if input_spec is None:
             cls._out_key = "pixels_orig"

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -11,6 +11,7 @@ from torchrl.data.tensor_specs import (
     BinaryDiscreteTensorSpec,
     BoundedTensorSpec,
     CompositeSpec,
+    DiscreteTensorSpec,
     MultOneHotDiscreteTensorSpec,
     NdBoundedTensorSpec,
     NdUnboundedContinuousTensorSpec,
@@ -24,6 +25,7 @@ from torchrl.envs.model_based.common import ModelBasedEnvBase
 spec_dict = {
     "bounded": BoundedTensorSpec,
     "one_hot": OneHotDiscreteTensorSpec,
+    "categorical": DiscreteTensorSpec,
     "unbounded": UnboundedContinuousTensorSpec,
     "ndbounded": NdBoundedTensorSpec,
     "ndunbounded": NdUnboundedContinuousTensorSpec,
@@ -35,6 +37,7 @@ spec_dict = {
 default_spec_kwargs = {
     BoundedTensorSpec: {"minimum": -1.0, "maximum": 1.0},
     OneHotDiscreteTensorSpec: {"n": 7},
+    DiscreteTensorSpec: {"n": 7},
     UnboundedContinuousTensorSpec: {},
     NdBoundedTensorSpec: {"minimum": -torch.ones(4), "maxmimum": torch.ones(4)},
     NdUnboundedContinuousTensorSpec: {

--- a/test/test_actors.py
+++ b/test/test_actors.py
@@ -12,12 +12,10 @@ class TestQValue:
             QValueHook(action_space="wrong_value")
         assert "action_space must be one of" in str(exc.value)
 
-
     def test_distributional_qvalue_hook_wrong_action_space(self):
         with pytest.raises(ValueError) as exc:
             DistributionalQValueHook(action_space="wrong_value", support=None)
         assert "action_space must be one of" in str(exc.value)
-
 
     @pytest.mark.parametrize(
         "action_space, expected_action",
@@ -37,7 +35,6 @@ class TestQValue:
         assert (torch.tensor(expected_action, dtype=torch.long) == action).all()
         assert (values == in_values).all()
         assert (torch.tensor([100.0]) == chosen_action_value).all()
-
 
     @pytest.mark.parametrize(
         "action_space, expected_action",
@@ -63,7 +60,6 @@ class TestQValue:
         assert (values == in_values).all()
         assert (torch.tensor([[100.0], [5.0]]) == chosen_action_value).all()
 
-
     @pytest.mark.parametrize(
         "action_space, expected_action",
         (
@@ -71,7 +67,9 @@ class TestQValue:
             ("categorical", 2),
         ),
     )
-    def test_distributional_qvalue_hook_0_dim_batch(self, action_space, expected_action):
+    def test_distributional_qvalue_hook_0_dim_batch(
+        self, action_space, expected_action
+    ):
         support = torch.tensor([-2.0, 0.0, 2.0])
         hook = DistributionalQValueHook(action_space=action_space, support=support)
 
@@ -91,7 +89,6 @@ class TestQValue:
         assert (action == expected_action).all()
         assert values.shape == in_values.shape
         assert (values == in_values).all()
-
 
     @pytest.mark.parametrize(
         "action_space, expected_action",

--- a/test/test_actors.py
+++ b/test/test_actors.py
@@ -1,7 +1,10 @@
 import pytest
 import torch
+from torchrl.modules.tensordict_module.actors import (
+    QValueHook,
+    DistributionalQValueHook,
+)
 
-from torchrl.modules.tensordict_module.actors import QValueHook, DistributionalQValueHook
 
 def test_qvalue_hook_wrong_action_space():
     with pytest.raises(ValueError):
@@ -12,19 +15,22 @@ def test_distributional_qvalue_hook_wrong_action_space():
     with pytest.raises(ValueError):
         DistributionalQValueHook(action_space="wrong_value", support=None)
 
+
 @pytest.mark.parametrize(
     "action_space, expected_action",
     (
         ("one_hot", [0, 0, 1, 0, 0]),
         ("categorical", 2),
-    )
+    ),
 )
 def test_qvalue_hook_0_dim_batch(action_space, expected_action):
     hook = QValueHook(action_space=action_space)
-    
+
     in_values = torch.tensor([1.0, -1.0, 100.0, -2.0, -3.0])
-    action, values, chosen_action_value = hook(net=None, observation=None, values=in_values)
-    
+    action, values, chosen_action_value = hook(
+        net=None, observation=None, values=in_values
+    )
+
     assert (torch.tensor(expected_action, dtype=torch.long) == action).all()
     assert (values == in_values).all()
     assert (torch.tensor([100.0]) == chosen_action_value).all()
@@ -35,17 +41,21 @@ def test_qvalue_hook_0_dim_batch(action_space, expected_action):
     (
         ("one_hot", [[0, 0, 1, 0, 0], [1, 0, 0, 0, 0]]),
         ("categorical", [2, 0]),
-    )
+    ),
 )
 def test_qvalue_hook_1_dim_batch(action_space, expected_action):
     hook = QValueHook(action_space=action_space)
-    
-    in_values = torch.tensor([
-        [1.0, -1.0, 100.0, -2.0, -3.0],
-        [5.0, 4.0, 3.0, 2.0, -5.0],
-    ])
-    action, values, chosen_action_value = hook(net=None, observation=None, values=in_values)
-    
+
+    in_values = torch.tensor(
+        [
+            [1.0, -1.0, 100.0, -2.0, -3.0],
+            [5.0, 4.0, 3.0, 2.0, -5.0],
+        ]
+    )
+    action, values, chosen_action_value = hook(
+        net=None, observation=None, values=in_values
+    )
+
     assert (torch.tensor(expected_action, dtype=torch.long) == action).all()
     assert (values == in_values).all()
     assert (torch.tensor([[100.0], [5.0]]) == chosen_action_value).all()
@@ -56,20 +66,24 @@ def test_qvalue_hook_1_dim_batch(action_space, expected_action):
     (
         ("one_hot", [0, 0, 1, 0, 0]),
         ("categorical", 2),
-    )
+    ),
 )
-def test_distributional_qvalue_hook_0_dim_batch(action_space, expected_action):    
+def test_distributional_qvalue_hook_0_dim_batch(action_space, expected_action):
     support = torch.tensor([-2.0, 0.0, 2.0])
     hook = DistributionalQValueHook(action_space=action_space, support=support)
-    
-    in_values = torch.nn.LogSoftmax(dim=-1)(torch.tensor([
-            [1.0, -1.0, 11.0, -2.0, 30.0],
-            [1.0, -1.0, 1.0, -2.0, -3.0],
-            [1.0, -1.0, 10.0, -2.0, -3.0],
-    ]))
+
+    in_values = torch.nn.LogSoftmax(dim=-1)(
+        torch.tensor(
+            [
+                [1.0, -1.0, 11.0, -2.0, 30.0],
+                [1.0, -1.0, 1.0, -2.0, -3.0],
+                [1.0, -1.0, 10.0, -2.0, -3.0],
+            ]
+        )
+    )
     action, values = hook(net=None, observation=None, values=in_values)
     expected_action = torch.tensor(expected_action, dtype=torch.long)
-    
+
     assert action.shape == expected_action.shape
     assert (action == expected_action).all()
     assert values.shape == in_values.shape
@@ -81,27 +95,31 @@ def test_distributional_qvalue_hook_0_dim_batch(action_space, expected_action):
     (
         ("one_hot", [[0, 0, 1, 0, 0], [1, 0, 0, 0, 0]]),
         ("categorical", [2, 0]),
-    )
+    ),
 )
 def test_qvalue_hook_categorical_1_dim_batch(action_space, expected_action):
     support = torch.tensor([-2.0, 0.0, 2.0])
     hook = DistributionalQValueHook(action_space=action_space, support=support)
-    
-    in_values = torch.nn.LogSoftmax(dim=-1)(torch.tensor([
-        [
-            [1.0, -1.0, 11.0, -2.0, 30.0],
-            [1.0, -1.0, 1.0, -2.0, -3.0],
-            [1.0, -1.0, 10.0, -2.0, -3.0],
-        ],
-        [
-            [11.0, -1.0, 7.0, -1.0, 20.0],
-            [10.0, 19.0, 1.0, -2.0, -3.0],
-            [1.0, -1.0, 0.0, -2.0, -3.0],
-        ],
-    ]))
+
+    in_values = torch.nn.LogSoftmax(dim=-1)(
+        torch.tensor(
+            [
+                [
+                    [1.0, -1.0, 11.0, -2.0, 30.0],
+                    [1.0, -1.0, 1.0, -2.0, -3.0],
+                    [1.0, -1.0, 10.0, -2.0, -3.0],
+                ],
+                [
+                    [11.0, -1.0, 7.0, -1.0, 20.0],
+                    [10.0, 19.0, 1.0, -2.0, -3.0],
+                    [1.0, -1.0, 0.0, -2.0, -3.0],
+                ],
+            ]
+        )
+    )
     action, values = hook(net=None, observation=None, values=in_values)
     expected_action = torch.tensor(expected_action, dtype=torch.long)
-            
+
     assert action.shape == expected_action.shape
     assert (action == expected_action).all()
     assert values.shape == in_values.shape

--- a/test/test_actors.py
+++ b/test/test_actors.py
@@ -1,0 +1,108 @@
+import pytest
+import torch
+
+from torchrl.modules.tensordict_module.actors import QValueHook, DistributionalQValueHook
+
+def test_qvalue_hook_wrong_action_space():
+    with pytest.raises(ValueError):
+        QValueHook(action_space="wrong_value")
+
+
+def test_distributional_qvalue_hook_wrong_action_space():
+    with pytest.raises(ValueError):
+        DistributionalQValueHook(action_space="wrong_value", support=None)
+
+@pytest.mark.parametrize(
+    "action_space, expected_action",
+    (
+        ("one_hot", [0, 0, 1, 0, 0]),
+        ("categorical", 2),
+    )
+)
+def test_qvalue_hook_0_dim_batch(action_space, expected_action):
+    hook = QValueHook(action_space=action_space)
+    
+    in_values = torch.tensor([1.0, -1.0, 100.0, -2.0, -3.0])
+    action, values, chosen_action_value = hook(net=None, observation=None, values=in_values)
+    
+    assert (torch.tensor(expected_action, dtype=torch.long) == action).all()
+    assert (values == in_values).all()
+    assert (torch.tensor([100.0]) == chosen_action_value).all()
+
+
+@pytest.mark.parametrize(
+    "action_space, expected_action",
+    (
+        ("one_hot", [[0, 0, 1, 0, 0], [1, 0, 0, 0, 0]]),
+        ("categorical", [2, 0]),
+    )
+)
+def test_qvalue_hook_1_dim_batch(action_space, expected_action):
+    hook = QValueHook(action_space=action_space)
+    
+    in_values = torch.tensor([
+        [1.0, -1.0, 100.0, -2.0, -3.0],
+        [5.0, 4.0, 3.0, 2.0, -5.0],
+    ])
+    action, values, chosen_action_value = hook(net=None, observation=None, values=in_values)
+    
+    assert (torch.tensor(expected_action, dtype=torch.long) == action).all()
+    assert (values == in_values).all()
+    assert (torch.tensor([[100.0], [5.0]]) == chosen_action_value).all()
+
+
+@pytest.mark.parametrize(
+    "action_space, expected_action",
+    (
+        ("one_hot", [0, 0, 1, 0, 0]),
+        ("categorical", 2),
+    )
+)
+def test_distributional_qvalue_hook_0_dim_batch(action_space, expected_action):    
+    support = torch.tensor([-2.0, 0.0, 2.0])
+    hook = DistributionalQValueHook(action_space=action_space, support=support)
+    
+    in_values = torch.nn.LogSoftmax(dim=-1)(torch.tensor([
+            [1.0, -1.0, 11.0, -2.0, 30.0],
+            [1.0, -1.0, 1.0, -2.0, -3.0],
+            [1.0, -1.0, 10.0, -2.0, -3.0],
+    ]))
+    action, values = hook(net=None, observation=None, values=in_values)
+    expected_action = torch.tensor(expected_action, dtype=torch.long)
+    
+    assert action.shape == expected_action.shape
+    assert (action == expected_action).all()
+    assert values.shape == in_values.shape
+    assert (values == in_values).all()
+
+
+@pytest.mark.parametrize(
+    "action_space, expected_action",
+    (
+        ("one_hot", [[0, 0, 1, 0, 0], [1, 0, 0, 0, 0]]),
+        ("categorical", [2, 0]),
+    )
+)
+def test_qvalue_hook_categorical_1_dim_batch(action_space, expected_action):
+    support = torch.tensor([-2.0, 0.0, 2.0])
+    hook = DistributionalQValueHook(action_space=action_space, support=support)
+    
+    in_values = torch.nn.LogSoftmax(dim=-1)(torch.tensor([
+        [
+            [1.0, -1.0, 11.0, -2.0, 30.0],
+            [1.0, -1.0, 1.0, -2.0, -3.0],
+            [1.0, -1.0, 10.0, -2.0, -3.0],
+        ],
+        [
+            [11.0, -1.0, 7.0, -1.0, 20.0],
+            [10.0, 19.0, 1.0, -2.0, -3.0],
+            [1.0, -1.0, 0.0, -2.0, -3.0],
+        ],
+    ]))
+    action, values = hook(net=None, observation=None, values=in_values)
+    expected_action = torch.tensor(expected_action, dtype=torch.long)
+            
+    assert action.shape == expected_action.shape
+    assert (action == expected_action).all()
+    assert values.shape == in_values.shape
+    assert (values == in_values).all()

--- a/test/test_actors.py
+++ b/test/test_actors.py
@@ -6,121 +6,124 @@ from torchrl.modules.tensordict_module.actors import (
 )
 
 
-def test_qvalue_hook_wrong_action_space():
-    with pytest.raises(ValueError):
-        QValueHook(action_space="wrong_value")
+class TestQValue:
+    def test_qvalue_hook_wrong_action_space(self):
+        with pytest.raises(ValueError) as exc:
+            QValueHook(action_space="wrong_value")
+        assert "action_space must be one of" in str(exc.value)
 
 
-def test_distributional_qvalue_hook_wrong_action_space():
-    with pytest.raises(ValueError):
-        DistributionalQValueHook(action_space="wrong_value", support=None)
+    def test_distributional_qvalue_hook_wrong_action_space(self):
+        with pytest.raises(ValueError) as exc:
+            DistributionalQValueHook(action_space="wrong_value", support=None)
+        assert "action_space must be one of" in str(exc.value)
 
 
-@pytest.mark.parametrize(
-    "action_space, expected_action",
-    (
-        ("one_hot", [0, 0, 1, 0, 0]),
-        ("categorical", 2),
-    ),
-)
-def test_qvalue_hook_0_dim_batch(action_space, expected_action):
-    hook = QValueHook(action_space=action_space)
-
-    in_values = torch.tensor([1.0, -1.0, 100.0, -2.0, -3.0])
-    action, values, chosen_action_value = hook(
-        net=None, observation=None, values=in_values
+    @pytest.mark.parametrize(
+        "action_space, expected_action",
+        (
+            ("one_hot", [0, 0, 1, 0, 0]),
+            ("categorical", 2),
+        ),
     )
+    def test_qvalue_hook_0_dim_batch(self, action_space, expected_action):
+        hook = QValueHook(action_space=action_space)
 
-    assert (torch.tensor(expected_action, dtype=torch.long) == action).all()
-    assert (values == in_values).all()
-    assert (torch.tensor([100.0]) == chosen_action_value).all()
+        in_values = torch.tensor([1.0, -1.0, 100.0, -2.0, -3.0])
+        action, values, chosen_action_value = hook(
+            net=None, observation=None, values=in_values
+        )
+
+        assert (torch.tensor(expected_action, dtype=torch.long) == action).all()
+        assert (values == in_values).all()
+        assert (torch.tensor([100.0]) == chosen_action_value).all()
 
 
-@pytest.mark.parametrize(
-    "action_space, expected_action",
-    (
-        ("one_hot", [[0, 0, 1, 0, 0], [1, 0, 0, 0, 0]]),
-        ("categorical", [2, 0]),
-    ),
-)
-def test_qvalue_hook_1_dim_batch(action_space, expected_action):
-    hook = QValueHook(action_space=action_space)
-
-    in_values = torch.tensor(
-        [
-            [1.0, -1.0, 100.0, -2.0, -3.0],
-            [5.0, 4.0, 3.0, 2.0, -5.0],
-        ]
+    @pytest.mark.parametrize(
+        "action_space, expected_action",
+        (
+            ("one_hot", [[0, 0, 1, 0, 0], [1, 0, 0, 0, 0]]),
+            ("categorical", [2, 0]),
+        ),
     )
-    action, values, chosen_action_value = hook(
-        net=None, observation=None, values=in_values
-    )
+    def test_qvalue_hook_1_dim_batch(self, action_space, expected_action):
+        hook = QValueHook(action_space=action_space)
 
-    assert (torch.tensor(expected_action, dtype=torch.long) == action).all()
-    assert (values == in_values).all()
-    assert (torch.tensor([[100.0], [5.0]]) == chosen_action_value).all()
-
-
-@pytest.mark.parametrize(
-    "action_space, expected_action",
-    (
-        ("one_hot", [0, 0, 1, 0, 0]),
-        ("categorical", 2),
-    ),
-)
-def test_distributional_qvalue_hook_0_dim_batch(action_space, expected_action):
-    support = torch.tensor([-2.0, 0.0, 2.0])
-    hook = DistributionalQValueHook(action_space=action_space, support=support)
-
-    in_values = torch.nn.LogSoftmax(dim=-1)(
-        torch.tensor(
+        in_values = torch.tensor(
             [
-                [1.0, -1.0, 11.0, -2.0, 30.0],
-                [1.0, -1.0, 1.0, -2.0, -3.0],
-                [1.0, -1.0, 10.0, -2.0, -3.0],
+                [1.0, -1.0, 100.0, -2.0, -3.0],
+                [5.0, 4.0, 3.0, 2.0, -5.0],
             ]
         )
+        action, values, chosen_action_value = hook(
+            net=None, observation=None, values=in_values
+        )
+
+        assert (torch.tensor(expected_action, dtype=torch.long) == action).all()
+        assert (values == in_values).all()
+        assert (torch.tensor([[100.0], [5.0]]) == chosen_action_value).all()
+
+
+    @pytest.mark.parametrize(
+        "action_space, expected_action",
+        (
+            ("one_hot", [0, 0, 1, 0, 0]),
+            ("categorical", 2),
+        ),
     )
-    action, values = hook(net=None, observation=None, values=in_values)
-    expected_action = torch.tensor(expected_action, dtype=torch.long)
+    def test_distributional_qvalue_hook_0_dim_batch(self, action_space, expected_action):
+        support = torch.tensor([-2.0, 0.0, 2.0])
+        hook = DistributionalQValueHook(action_space=action_space, support=support)
 
-    assert action.shape == expected_action.shape
-    assert (action == expected_action).all()
-    assert values.shape == in_values.shape
-    assert (values == in_values).all()
-
-
-@pytest.mark.parametrize(
-    "action_space, expected_action",
-    (
-        ("one_hot", [[0, 0, 1, 0, 0], [1, 0, 0, 0, 0]]),
-        ("categorical", [2, 0]),
-    ),
-)
-def test_qvalue_hook_categorical_1_dim_batch(action_space, expected_action):
-    support = torch.tensor([-2.0, 0.0, 2.0])
-    hook = DistributionalQValueHook(action_space=action_space, support=support)
-
-    in_values = torch.nn.LogSoftmax(dim=-1)(
-        torch.tensor(
-            [
+        in_values = torch.nn.LogSoftmax(dim=-1)(
+            torch.tensor(
                 [
                     [1.0, -1.0, 11.0, -2.0, 30.0],
                     [1.0, -1.0, 1.0, -2.0, -3.0],
                     [1.0, -1.0, 10.0, -2.0, -3.0],
-                ],
-                [
-                    [11.0, -1.0, 7.0, -1.0, 20.0],
-                    [10.0, 19.0, 1.0, -2.0, -3.0],
-                    [1.0, -1.0, 0.0, -2.0, -3.0],
-                ],
-            ]
+                ]
+            )
         )
-    )
-    action, values = hook(net=None, observation=None, values=in_values)
-    expected_action = torch.tensor(expected_action, dtype=torch.long)
+        action, values = hook(net=None, observation=None, values=in_values)
+        expected_action = torch.tensor(expected_action, dtype=torch.long)
 
-    assert action.shape == expected_action.shape
-    assert (action == expected_action).all()
-    assert values.shape == in_values.shape
-    assert (values == in_values).all()
+        assert action.shape == expected_action.shape
+        assert (action == expected_action).all()
+        assert values.shape == in_values.shape
+        assert (values == in_values).all()
+
+
+    @pytest.mark.parametrize(
+        "action_space, expected_action",
+        (
+            ("one_hot", [[0, 0, 1, 0, 0], [1, 0, 0, 0, 0]]),
+            ("categorical", [2, 0]),
+        ),
+    )
+    def test_qvalue_hook_categorical_1_dim_batch(self, action_space, expected_action):
+        support = torch.tensor([-2.0, 0.0, 2.0])
+        hook = DistributionalQValueHook(action_space=action_space, support=support)
+
+        in_values = torch.nn.LogSoftmax(dim=-1)(
+            torch.tensor(
+                [
+                    [
+                        [1.0, -1.0, 11.0, -2.0, 30.0],
+                        [1.0, -1.0, 1.0, -2.0, -3.0],
+                        [1.0, -1.0, 10.0, -2.0, -3.0],
+                    ],
+                    [
+                        [11.0, -1.0, 7.0, -1.0, 20.0],
+                        [10.0, 19.0, 1.0, -2.0, -3.0],
+                        [1.0, -1.0, 0.0, -2.0, -3.0],
+                    ],
+                ]
+            )
+        )
+        action, values = hook(net=None, observation=None, values=in_values)
+        expected_action = torch.tensor(expected_action, dtype=torch.long)
+
+        assert action.shape == expected_action.shape
+        assert (action == expected_action).all()
+        assert values.shape == in_values.shape
+        assert (values == in_values).all()

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -19,6 +19,8 @@ from torchrl.data import (
     NdBoundedTensorSpec,
     NdUnboundedContinuousTensorSpec,
     TensorDict,
+    OneHotDiscreteTensorSpec,
+    DiscreteTensorSpec,
 )
 from torchrl.data.postprocs.postprocs import MultiStep
 
@@ -112,11 +114,21 @@ def get_devices():
 class TestDQN:
     seed = 0
 
-    def _create_mock_actor(self, batch=2, obs_dim=3, action_dim=4, device="cpu"):
+    def _create_mock_actor(
+        self, action_spec_type, batch=2, obs_dim=3, action_dim=4, device="cpu"
+    ):
         # Actor
-        action_spec = NdBoundedTensorSpec(
-            -torch.ones(action_dim), torch.ones(action_dim), (action_dim,)
-        )
+        if action_spec_type == "one_hot":
+            action_spec = OneHotDiscreteTensorSpec(action_dim)
+        elif action_spec_type == "categorical":
+            action_spec = DiscreteTensorSpec(action_dim)
+        elif action_spec_type == "nd_bounded":
+            action_spec = NdBoundedTensorSpec(
+                -torch.ones(action_dim), torch.ones(action_dim), (action_dim,)
+            )
+        else:
+            raise ValueError(f"Wrong {action_spec_type}")
+
         module = nn.Linear(obs_dim, action_dim)
         actor = QValueActor(
             spec=CompositeSpec(
@@ -127,21 +139,44 @@ class TestDQN:
         return actor
 
     def _create_mock_distributional_actor(
-        self, batch=2, obs_dim=3, action_dim=4, atoms=5, vmin=1, vmax=5
+        self,
+        action_spec_type,
+        batch=2,
+        obs_dim=3,
+        action_dim=4,
+        atoms=5,
+        vmin=1,
+        vmax=5,
     ):
         # Actor
-        action_spec = MultOneHotDiscreteTensorSpec([atoms] * action_dim)
+        if action_spec_type == "mult_one_hot":
+            action_spec = MultOneHotDiscreteTensorSpec([atoms] * action_dim)
+        elif action_spec_type == "one_hot":
+            action_spec = OneHotDiscreteTensorSpec(action_dim)
+        elif action_spec_type == "categorical":
+            action_spec = DiscreteTensorSpec(action_dim)
+        else:
+            raise ValueError(f"Wrong {action_spec_type}")
         support = torch.linspace(vmin, vmax, atoms, dtype=torch.float)
         module = MLP(obs_dim, (atoms, action_dim))
         actor = DistributionalQValueActor(
             spec=CompositeSpec(action=action_spec, action_value=None),
             module=module,
             support=support,
+            action_space="categorical"
+            if isinstance(action_spec, DiscreteTensorSpec)
+            else "one_hot",
         )
         return actor
 
     def _create_mock_data_dqn(
-        self, batch=2, obs_dim=3, action_dim=4, atoms=None, device="cpu"
+        self,
+        action_spec_type,
+        batch=2,
+        obs_dim=3,
+        action_dim=4,
+        atoms=None,
+        device="cpu",
     ):
         # create a tensordict
         obs = torch.randn(batch, obs_dim)
@@ -154,6 +189,10 @@ class TestDQN:
         else:
             action_value = torch.randn(batch, action_dim)
             action = (action_value == action_value.max(-1, True)[0]).to(torch.long)
+
+        if action_spec_type == "categorical":
+            action_value = torch.max(action_value, -1, keepdim=True)[0]
+            action = torch.argmax(action, -1, keepdim=True)
         reward = torch.randn(batch, 1)
         done = torch.zeros(batch, 1, dtype=torch.bool)
         td = TensorDict(
@@ -171,7 +210,14 @@ class TestDQN:
         return td
 
     def _create_seq_mock_data_dqn(
-        self, batch=2, T=4, obs_dim=3, action_dim=4, atoms=None, device="cpu"
+        self,
+        action_spec_type,
+        batch=2,
+        T=4,
+        obs_dim=3,
+        action_dim=4,
+        atoms=None,
+        device="cpu",
     ):
         # create a tensordict
         total_obs = torch.randn(batch, T + 1, obs_dim, device=device)
@@ -187,6 +233,10 @@ class TestDQN:
         else:
             action_value = torch.randn(batch, T, action_dim, device=device)
             action = (action_value == action_value.max(-1, True)[0]).to(torch.long)
+
+        if action_spec_type == "categorical":
+            action_value = torch.max(action_value, -1, keepdim=True)[0]
+            action = torch.argmax(action, -1, keepdim=True)
         reward = torch.randn(batch, T, 1, device=device)
         done = torch.zeros(batch, T, 1, dtype=torch.bool, device=device)
         mask = ~torch.zeros(batch, T, 1, dtype=torch.bool, device=device)
@@ -207,10 +257,17 @@ class TestDQN:
 
     @pytest.mark.parametrize("delay_value", (False, True))
     @pytest.mark.parametrize("device", get_available_devices())
-    def test_dqn(self, delay_value, device):
+    @pytest.mark.parametrize(
+        "action_spec_type", ("nd_bounded", "one_hot", "categorical")
+    )
+    def test_dqn(self, delay_value, device, action_spec_type):
         torch.manual_seed(self.seed)
-        actor = self._create_mock_actor(device=device)
-        td = self._create_mock_data_dqn(device=device)
+        actor = self._create_mock_actor(
+            action_spec_type=action_spec_type, device=device
+        )
+        td = self._create_mock_data_dqn(
+            action_spec_type=action_spec_type, device=device
+        )
         loss_fn = DQNLoss(actor, gamma=0.9, loss_function="l2", delay_value=delay_value)
         with _check_td_steady(td):
             loss = loss_fn(td)
@@ -240,11 +297,18 @@ class TestDQN:
     @pytest.mark.parametrize("n", range(4))
     @pytest.mark.parametrize("delay_value", (False, True))
     @pytest.mark.parametrize("device", get_available_devices())
-    def test_dqn_batcher(self, n, delay_value, device, gamma=0.9):
+    @pytest.mark.parametrize(
+        "action_spec_type", ("nd_bounded", "one_hot", "categorical")
+    )
+    def test_dqn_batcher(self, n, delay_value, device, action_spec_type, gamma=0.9):
         torch.manual_seed(self.seed)
-        actor = self._create_mock_actor(device=device)
+        actor = self._create_mock_actor(
+            action_spec_type=action_spec_type, device=device
+        )
 
-        td = self._create_seq_mock_data_dqn(device=device)
+        td = self._create_seq_mock_data_dqn(
+            action_spec_type=action_spec_type, device=device
+        )
         loss_fn = DQNLoss(
             actor, gamma=gamma, loss_function="l2", delay_value=delay_value
         )
@@ -292,11 +356,20 @@ class TestDQN:
     @pytest.mark.parametrize("atoms", range(4, 10))
     @pytest.mark.parametrize("delay_value", (False, True))
     @pytest.mark.parametrize("device", get_devices())
-    def test_distributional_dqn(self, atoms, delay_value, device, gamma=0.9):
+    @pytest.mark.parametrize(
+        "action_spec_type", ("mult_one_hot", "one_hot", "categorical")
+    )
+    def test_distributional_dqn(
+        self, atoms, delay_value, device, action_spec_type, gamma=0.9
+    ):
         torch.manual_seed(self.seed)
-        actor = self._create_mock_distributional_actor(atoms=atoms).to(device)
+        actor = self._create_mock_distributional_actor(
+            action_spec_type=action_spec_type, atoms=atoms
+        ).to(device)
 
-        td = self._create_mock_data_dqn(atoms=atoms).to(device)
+        td = self._create_mock_data_dqn(
+            action_spec_type=action_spec_type, atoms=atoms
+        ).to(device)
         loss_fn = DistributionalDQNLoss(actor, gamma=gamma, delay_value=delay_value)
 
         with _check_td_steady(td):

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -892,7 +892,9 @@ class TestParallel:
 
 
 class TestSpec:
-    @pytest.mark.parametrize("action_spec_cls", [OneHotDiscreteTensorSpec, DiscreteTensorSpec])
+    @pytest.mark.parametrize(
+        "action_spec_cls", [OneHotDiscreteTensorSpec, DiscreteTensorSpec]
+    )
     def test_discrete_action_spec_reconstruct(self, action_spec_cls):
         torch.manual_seed(0)
         action_spec = action_spec_cls(10)
@@ -943,7 +945,7 @@ class TestSpec:
         sample = action_spec.to_numpy(sample)
         sample = [sum(sample == i) for i in range(10)]
         assert chisquare(sample).pvalue > 0.1
-        
+
     def test_categorical_action_spec_rand(self):
         torch.manual_seed(0)
         action_spec = DiscreteTensorSpec(10)

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -988,6 +988,23 @@ class TestSpec:
         sample_list = list([sum(sample1 == i) for i in range(ns[1])])
         assert chisquare(sample_list).pvalue > 0.1
 
+    def test_categorical_action_spec_encode(self):
+        action_spec = DiscreteTensorSpec(10)
+
+        projected = action_spec.project(
+            torch.tensor([-100, -1, 0, 1, 9, 10, 100], dtype=torch.long)
+        )
+        assert (
+            projected == torch.tensor([0, 0, 0, 1, 9, 9, 9], dtype=torch.long)
+        ).all()
+
+        projected = action_spec.project(
+            torch.tensor([-100.0, -1.0, 0.0, 1.0, 9.0, 10.0, 100.0], dtype=torch.float)
+        )
+        assert (
+            projected == torch.tensor([0, 0, 0, 1, 9, 9, 9], dtype=torch.long)
+        ).all()
+
     def test_bounded_rand(self):
         spec = BoundedTensorSpec(-3, 3)
         sample = torch.stack([spec.rand() for _ in range(100)])

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -96,7 +96,9 @@ def test_dqn_maker(
         env_maker = transformed_env_constructor(
             cfg, use_env_creator=False, custom_env_maker=env_maker
         )
-        proof_environment = env_maker(categorical_action_encoding=cfg.categorical_action_encoding)
+        proof_environment = env_maker(
+            categorical_action_encoding=cfg.categorical_action_encoding
+        )
 
         actor = make_dqn_actor(proof_environment, cfg, device)
         td = proof_environment.reset().to(device)

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -64,9 +64,16 @@ def _assert_keys_match(td, expeceted_keys):
 @pytest.mark.parametrize("noisy", [tuple(), ("noisy=True",)])
 @pytest.mark.parametrize("distributional", [tuple(), ("distributional=True",)])
 @pytest.mark.parametrize("from_pixels", [tuple(), ("from_pixels=True", "catframes=4")])
-@pytest.mark.parametrize("categorical_action_encoding", [("categorical_action_encoding=true",), ("categorical_action_encoding=false",)])
-def test_dqn_maker(device, noisy, distributional, from_pixels, categorical_action_encoding):
-    flags = list(noisy + distributional + from_pixels + categorical_action_encoding) + ["env_name=CartPole-v1"]
+@pytest.mark.parametrize(
+    "categorical_action_encoding",
+    [("categorical_action_encoding=true",), ("categorical_action_encoding=false",)],
+)
+def test_dqn_maker(
+    device, noisy, distributional, from_pixels, categorical_action_encoding
+):
+    flags = list(noisy + distributional + from_pixels + categorical_action_encoding) + [
+        "env_name=CartPole-v1"
+    ]
 
     config_fields = [
         (config_field.name, config_field.type, config_field)

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -64,8 +64,9 @@ def _assert_keys_match(td, expeceted_keys):
 @pytest.mark.parametrize("noisy", [tuple(), ("noisy=True",)])
 @pytest.mark.parametrize("distributional", [tuple(), ("distributional=True",)])
 @pytest.mark.parametrize("from_pixels", [tuple(), ("from_pixels=True", "catframes=4")])
-def test_dqn_maker(device, noisy, distributional, from_pixels):
-    flags = list(noisy + distributional + from_pixels) + ["env_name=CartPole-v1"]
+@pytest.mark.parametrize("categorical_action_encoding", [("categorical_action_encoding=true",), ("categorical_action_encoding=false",)])
+def test_dqn_maker(device, noisy, distributional, from_pixels, categorical_action_encoding):
+    flags = list(noisy + distributional + from_pixels + categorical_action_encoding) + ["env_name=CartPole-v1"]
 
     config_fields = [
         (config_field.name, config_field.type, config_field)

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -66,7 +66,7 @@ def _assert_keys_match(td, expeceted_keys):
 @pytest.mark.parametrize("from_pixels", [tuple(), ("from_pixels=True", "catframes=4")])
 @pytest.mark.parametrize(
     "categorical_action_encoding",
-    [("categorical_action_encoding=true",), ("categorical_action_encoding=false",)],
+    [("categorical_action_encoding=True",), ("categorical_action_encoding=False",)],
 )
 def test_dqn_maker(
     device, noisy, distributional, from_pixels, categorical_action_encoding
@@ -96,7 +96,7 @@ def test_dqn_maker(
         env_maker = transformed_env_constructor(
             cfg, use_env_creator=False, custom_env_maker=env_maker
         )
-        proof_environment = env_maker()
+        proof_environment = env_maker(categorical_action_encoding=cfg.categorical_action_encoding)
 
         actor = make_dqn_actor(proof_environment, cfg, device)
         td = proof_environment.reset().to(device)

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -14,7 +14,7 @@ from torchrl.data import TensorDict
 from torchrl.data.tensor_specs import (
     DiscreteTensorSpec,
     OneHotDiscreteTensorSpec,
-    NdBoundedTensorSpec
+    NdBoundedTensorSpec,
 )
 from torchrl.modules import (
     ActorValueOperator,
@@ -188,7 +188,7 @@ def test_value_based_policy(device):
     obs_dim = 4
     action_dim = 5
     action_spec = OneHotDiscreteTensorSpec(action_dim)
-    
+
     def make_net():
         net = MLP(in_features=obs_dim, out_features=action_dim, depth=2, device=device)
         for mod in net.modules():
@@ -230,13 +230,17 @@ def test_value_based_policy_categorical(device):
                 mod.bias.data.zero_()
         return net
 
-    actor = QValueActor(spec=action_spec, module=make_net(), safe=True, action_space="categorical")
+    actor = QValueActor(
+        spec=action_spec, module=make_net(), safe=True, action_space="categorical"
+    )
     obs = torch.zeros(2, obs_dim, device=device)
     td = TensorDict(batch_size=[2], source={"observation": obs})
     action = actor(td).get("action")
     assert (0 <= action).all() and (action < action_dim).all()
 
-    actor = QValueActor(spec=action_spec, module=make_net(), safe=False, action_space="categorical")
+    actor = QValueActor(
+        spec=action_spec, module=make_net(), safe=False, action_space="categorical"
+    )
     obs = torch.randn(2, obs_dim, device=device)
     td = TensorDict(batch_size=[2], source={"observation": obs})
     action = actor(td).get("action")

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -11,7 +11,11 @@ from _utils_internal import get_available_devices
 from mocking_classes import MockBatchedUnLockedEnv
 from torch import nn
 from torchrl.data import TensorDict
-from torchrl.data.tensor_specs import OneHotDiscreteTensorSpec, NdBoundedTensorSpec
+from torchrl.data.tensor_specs import (
+    DiscreteTensorSpec,
+    OneHotDiscreteTensorSpec,
+    NdBoundedTensorSpec
+)
 from torchrl.modules import (
     ActorValueOperator,
     CEMPlanner,
@@ -184,7 +188,7 @@ def test_value_based_policy(device):
     obs_dim = 4
     action_dim = 5
     action_spec = OneHotDiscreteTensorSpec(action_dim)
-
+    
     def make_net():
         net = MLP(in_features=obs_dim, out_features=action_dim, depth=2, device=device)
         for mod in net.modules():
@@ -210,6 +214,33 @@ def test_value_based_policy(device):
     action = actor(td).get("action")
     with pytest.raises(AssertionError):
         assert (action.sum(-1) == 1).all()
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_value_based_policy_categorical(device):
+    torch.manual_seed(0)
+    obs_dim = 4
+    action_dim = 5
+    action_spec = DiscreteTensorSpec(action_dim)
+
+    def make_net():
+        net = MLP(in_features=obs_dim, out_features=action_dim, depth=2, device=device)
+        for mod in net.modules():
+            if hasattr(mod, "bias") and mod.bias is not None:
+                mod.bias.data.zero_()
+        return net
+
+    actor = QValueActor(spec=action_spec, module=make_net(), safe=True, action_space="categorical")
+    obs = torch.zeros(2, obs_dim, device=device)
+    td = TensorDict(batch_size=[2], source={"observation": obs})
+    action = actor(td).get("action")
+    assert (0 <= action).all() and (action < action_dim).all()
+
+    actor = QValueActor(spec=action_spec, module=make_net(), safe=False, action_space="categorical")
+    obs = torch.randn(2, obs_dim, device=device)
+    td = TensorDict(batch_size=[2], source={"observation": obs})
+    action = actor(td).get("action")
+    assert (0 <= action).all() and (action < action_dim).all()
 
 
 @pytest.mark.parametrize("device", get_available_devices())

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -244,6 +244,7 @@ def test_recorder():
         args.catframes = 4
         args.image_size = 84
         args.collector_devices = ["cpu"]
+        args.categorical_action_encoding = False
 
         N = 8
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 from torchrl._utils import get_binary_env_var
 
@@ -7,12 +8,12 @@ from torchrl._utils import get_binary_env_var
 def test_get_binary_env_var_positive(value):
     try:
         key = "SOME_ENVIRONMENT_VARIABLE_UNLIKELY_TO_BE_IN_ENVIRONMENT"
-        
+
         assert key not in os.environ
-        
+
         os.environ[key] = value
         assert get_binary_env_var(key)
-        
+
     finally:
         if key in os.environ:
             del os.environ[key]
@@ -22,14 +23,14 @@ def test_get_binary_env_var_positive(value):
 def test_get_binary_env_var_negative(value):
     try:
         key = "SOME_ENVIRONMENT_VARIABLE_UNLIKELY_TO_BE_IN_ENVIRONMENT"
-        
+
         assert key not in os.environ
-        
+
         os.environ[key] = "True"
         assert get_binary_env_var(key)
         os.environ[key] = value
         assert not get_binary_env_var(key)
-        
+
     finally:
         if key in os.environ:
             del os.environ[key]
@@ -38,10 +39,10 @@ def test_get_binary_env_var_negative(value):
 def test_get_binary_env_var_missing():
     try:
         key = "SOME_ENVIRONMENT_VARIABLE_UNLIKELY_TO_BE_IN_ENVIRONMENT"
-        
+
         assert key not in os.environ
         assert not get_binary_env_var(key)
-        
+
     finally:
         if key in os.environ:
             del os.environ[key]
@@ -50,12 +51,12 @@ def test_get_binary_env_var_missing():
 def test_get_binary_env_var_wrong_value():
     try:
         key = "SOME_ENVIRONMENT_VARIABLE_UNLIKELY_TO_BE_IN_ENVIRONMENT"
-        
+
         assert key not in os.environ
         os.environ[key] = "smthwrong"
         with pytest.raises(ValueError):
             get_binary_env_var(key)
-        
+
     finally:
         if key in os.environ:
             del os.environ[key]

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,61 @@
+import os
+import pytest
+from torchrl._utils import get_binary_env_var
+
+
+@pytest.mark.parametrize("value", ["True", "1", "true"])
+def test_get_binary_env_var_positive(value):
+    try:
+        key = "SOME_ENVIRONMENT_VARIABLE_UNLIKELY_TO_BE_IN_ENVIRONMENT"
+        
+        assert key not in os.environ
+        
+        os.environ[key] = value
+        assert get_binary_env_var(key)
+        
+    finally:
+        if key in os.environ:
+            del os.environ[key]
+
+
+@pytest.mark.parametrize("value", ["False", "0", "false"])
+def test_get_binary_env_var_negative(value):
+    try:
+        key = "SOME_ENVIRONMENT_VARIABLE_UNLIKELY_TO_BE_IN_ENVIRONMENT"
+        
+        assert key not in os.environ
+        
+        os.environ[key] = "True"
+        assert get_binary_env_var(key)
+        os.environ[key] = value
+        assert not get_binary_env_var(key)
+        
+    finally:
+        if key in os.environ:
+            del os.environ[key]
+
+
+def test_get_binary_env_var_missing():
+    try:
+        key = "SOME_ENVIRONMENT_VARIABLE_UNLIKELY_TO_BE_IN_ENVIRONMENT"
+        
+        assert key not in os.environ
+        assert not get_binary_env_var(key)
+        
+    finally:
+        if key in os.environ:
+            del os.environ[key]
+
+
+def test_get_binary_env_var_wrong_value():
+    try:
+        key = "SOME_ENVIRONMENT_VARIABLE_UNLIKELY_TO_BE_IN_ENVIRONMENT"
+        
+        assert key not in os.environ
+        os.environ[key] = "smthwrong"
+        with pytest.raises(ValueError):
+            get_binary_env_var(key)
+        
+    finally:
+        if key in os.environ:
+            del os.environ[key]

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -128,10 +128,10 @@ def get_binary_env_var(key):
     Args:
         key (str): name of the environment variable.
     """
-    val = os.environ.get(key, False)
-    if val in ("0", "False", False):
+    val = os.environ.get(key, "False")
+    if val in ("0", "False", "false"):
         val = False
-    elif val in ("1", "True", True):
+    elif val in ("1", "True", "true"):
         val = True
     else:
         raise ValueError(

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -121,11 +121,12 @@ def prod(sequence):
 
 
 def get_binary_env_var(key):
-    """Parses and returns the binary enironment variable. If not present in environment,
-    it is considered False.
+    """Parses and returns the binary enironment variable value.
+
+    If not present in environment, it is considered `False`.
 
     Args:
-        key (str): _description_
+        key (str): name of the environment variable.
     """
     val = os.environ.get(key, False)
     if val in ("0", "False", False):

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -1,5 +1,6 @@
 import collections
 import math
+import os
 import time
 
 import numpy as np
@@ -117,3 +118,23 @@ def prod(sequence):
         return math.prod(sequence)
     else:
         return int(np.prod(sequence))
+
+
+def get_binary_env_var(key):
+    """Parses and returns the binary enironment variable. If not present in environment,
+    it is considered False.
+
+    Args:
+        key (str): _description_
+    """
+    val = os.environ.get(key, False)
+    if val in ("0", "False", False):
+        val = False
+    elif val in ("1", "True", True):
+        val = True
+    else:
+        raise ValueError(
+            f"Environment variable {key} should be in 'True', 'False', '0' or '1'. "
+            f"Got {val} instead."
+        )
+    return val

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1034,7 +1034,9 @@ class DiscreteTensorSpec(TensorSpec):
     def rand(self, shape=None) -> torch.Tensor:
         if shape is None:
             shape = torch.Size([])
-        return (torch.rand(*shape, *self.shape, device=self.device) * self.space.n).to(torch.long)
+        return (torch.rand(*shape, *self.shape, device=self.device) * self.space.n).to(
+            torch.long
+        )
 
     def _project(self, val: torch.Tensor) -> torch.Tensor:
         return torch.round(val).clamp_(min=0, max=self.space.n - 1)

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -13,12 +13,14 @@ from packaging import version
 from torchrl.data import (
     BinaryDiscreteTensorSpec,
     CompositeSpec,
+    DiscreteTensorSpec,
     MultOneHotDiscreteTensorSpec,
     NdBoundedTensorSpec,
     OneHotDiscreteTensorSpec,
     TensorSpec,
     UnboundedContinuousTensorSpec,
 )
+from torchrl._utils import get_binary_env_var
 from ...data.utils import numpy_to_torch_dtype_dict
 from ..gym_like import GymLikeEnv, default_info_dict_reader
 from ..utils import _classproperty
@@ -54,12 +56,15 @@ if _has_gym:
 
 __all__ = ["GymWrapper", "GymEnv"]
 
+_CATEGORICAL_ACTION_ENCODING = get_binary_env_var("CATEGORICAL_ACTION_ENCODING")
+
 
 def _gym_to_torchrl_spec_transform(spec, dtype=None, device="cpu") -> TensorSpec:
     if isinstance(spec, gym.spaces.tuple.Tuple):
         raise NotImplementedError("gym.spaces.tuple.Tuple mapping not yet implemented")
     if isinstance(spec, gym.spaces.discrete.Discrete):
-        return OneHotDiscreteTensorSpec(spec.n, device=device)
+        action_space_cls = DiscreteTensorSpec if _CATEGORICAL_ACTION_ENCODING else OneHotDiscreteTensorSpec
+        return action_space_cls(spec.n, device=device)
     elif isinstance(spec, gym.spaces.multi_binary.MultiBinary):
         return BinaryDiscreteTensorSpec(spec.n, device=device)
     elif isinstance(spec, gym.spaces.multi_discrete.MultiDiscrete):

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -10,6 +10,7 @@ from warnings import warn
 import torch
 from packaging import version
 
+from torchrl._utils import get_binary_env_var
 from torchrl.data import (
     BinaryDiscreteTensorSpec,
     CompositeSpec,
@@ -20,7 +21,6 @@ from torchrl.data import (
     TensorSpec,
     UnboundedContinuousTensorSpec,
 )
-from torchrl._utils import get_binary_env_var
 from ...data.utils import numpy_to_torch_dtype_dict
 from ..gym_like import GymLikeEnv, default_info_dict_reader
 from ..utils import _classproperty
@@ -63,7 +63,11 @@ def _gym_to_torchrl_spec_transform(spec, dtype=None, device="cpu") -> TensorSpec
     if isinstance(spec, gym.spaces.tuple.Tuple):
         raise NotImplementedError("gym.spaces.tuple.Tuple mapping not yet implemented")
     if isinstance(spec, gym.spaces.discrete.Discrete):
-        action_space_cls = DiscreteTensorSpec if _CATEGORICAL_ACTION_ENCODING else OneHotDiscreteTensorSpec
+        action_space_cls = (
+            DiscreteTensorSpec
+            if _CATEGORICAL_ACTION_ENCODING
+            else OneHotDiscreteTensorSpec
+        )
         return action_space_cls(spec.n, device=device)
     elif isinstance(spec, gym.spaces.multi_binary.MultiBinary):
         return BinaryDiscreteTensorSpec(spec.n, device=device)

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -262,7 +262,7 @@ class QValueHook:
         }
         self.action_value_func_mapping = {
             "categorical": self._categorical_action_value,
-        }        
+        }
         if action_space not in self.action_func_mapping:
             raise ValueError(
                 f"action_space must be one of {list(self.action_func_mapping.keys())}"
@@ -275,7 +275,9 @@ class QValueHook:
             values = values[0]
         action = self.action_func_mapping[self.action_space](values)
 
-        action_value_func = self.action_value_func_mapping.get(self.action_space, self._default_action_value)
+        action_value_func = self.action_value_func_mapping.get(
+            self.action_space, self._default_action_value
+        )
         chosen_action_value = action_value_func(values, action)
         return action, values, chosen_action_value
 
@@ -303,13 +305,17 @@ class QValueHook:
     @staticmethod
     def _binary(value: torch.Tensor, support: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError
-    
+
     @staticmethod
-    def _default_action_value(values: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
+    def _default_action_value(
+        values: torch.Tensor, action: torch.Tensor
+    ) -> torch.Tensor:
         return (action * values).sum(-1, True)
 
     @staticmethod
-    def _categorical_action_value(values: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
+    def _categorical_action_value(
+        values: torch.Tensor, action: torch.Tensor
+    ) -> torch.Tensor:
         if len(values.shape) == 1:
             return values[action].unsqueeze(-1)
         batch_size = values.size(0)
@@ -377,7 +383,7 @@ class DistributionalQValueHook(QValueHook):
             "one_hot": self._one_hot,
             "mult_one_hot": self._mult_one_hot,
             "binary": self._binary,
-            "categorical": self._categorical
+            "categorical": self._categorical,
         }
         if action_space not in self.action_func_mapping:
             raise ValueError(

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -217,7 +217,7 @@ class QValueHook:
     Currently, this is returned as a one-hot encoding.
 
     Args:
-        action_space (str): Action space. Must be one of "one-hot", "mult_one_hot" or "binary".
+        action_space (str): Action space. Must be one of "one-hot", "mult_one_hot", "binary" or "categorical".
         var_nums (int, optional): if action_space == "mult_one_hot", this value represents the cardinality of each
             action component.
 
@@ -254,14 +254,18 @@ class QValueHook:
     ):
         self.action_space = action_space
         self.var_nums = var_nums
-        self.fun_dict = {
+        self.action_func_mapping = {
             "one_hot": self._one_hot,
             "mult_one_hot": self._mult_one_hot,
             "binary": self._binary,
+            "categorical": self._categorical,
         }
-        if action_space not in self.fun_dict:
+        self.action_value_func_mapping = {
+            "categorical": self._categorical_action_value,
+        }        
+        if action_space not in self.action_func_mapping:
             raise ValueError(
-                f"action_space must be one of {list(self.fun_dict.keys())}"
+                f"action_space must be one of {list(self.action_func_mapping.keys())}"
             )
 
     def __call__(
@@ -269,14 +273,20 @@ class QValueHook:
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if isinstance(values, tuple):
             values = values[0]
-        action = self.fun_dict[self.action_space](values)
-        chosen_action_value = (action * values).sum(-1, True)
+        action = self.action_func_mapping[self.action_space](values)
+
+        action_value_func = self.action_value_func_mapping.get(self.action_space, self._default_action_value)
+        chosen_action_value = action_value_func(values, action)
         return action, values, chosen_action_value
 
     @staticmethod
     def _one_hot(value: torch.Tensor) -> torch.Tensor:
         out = (value == value.max(dim=-1, keepdim=True)[0]).to(torch.long)
         return out
+
+    @staticmethod
+    def _categorical(value: torch.Tensor) -> torch.Tensor:
+        return torch.argmax(value, dim=-1).to(torch.long)
 
     def _mult_one_hot(self, value: torch.Tensor, support: torch.Tensor) -> torch.Tensor:
         values = value.split(self.var_nums, dim=-1)
@@ -293,6 +303,17 @@ class QValueHook:
     @staticmethod
     def _binary(value: torch.Tensor, support: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError
+    
+    @staticmethod
+    def _default_action_value(values: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
+        return (action * values).sum(-1, True)
+
+    @staticmethod
+    def _categorical_action_value(values: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
+        if len(values.shape) == 1:
+            return values[action].unsqueeze(-1)
+        batch_size = values.size(0)
+        return values[range(batch_size), action].unsqueeze(-1)
 
 
 class DistributionalQValueHook(QValueHook):
@@ -305,7 +326,7 @@ class DistributionalQValueHook(QValueHook):
     https://arxiv.org/pdf/1707.06887.pdf
 
     Args:
-        action_space (str): Action space. Must be one of "one_hot", "mult_one_hot" or "binary".
+        action_space (str): Action space. Must be one of "one_hot", "mult_one_hot", "binary" or "categorical".
         support (torch.Tensor): support of the action values.
         var_nums (int, optional): if action_space == "mult_one_hot", this value represents the cardinality of each
             action component.
@@ -352,18 +373,23 @@ class DistributionalQValueHook(QValueHook):
         self.action_space = action_space
         self.support = support
         self.var_nums = var_nums
-        self.fun_dict = {
+        self.action_func_mapping = {
             "one_hot": self._one_hot,
             "mult_one_hot": self._mult_one_hot,
             "binary": self._binary,
+            "categorical": self._categorical
         }
+        if action_space not in self.action_func_mapping:
+            raise ValueError(
+                f"action_space must be one of {list(self.action_func_mapping.keys())}"
+            )
 
     def __call__(
         self, net: nn.Module, observation: torch.Tensor, values: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if isinstance(values, tuple):
             values = values[0]
-        action = self.fun_dict[self.action_space](values, self.support)
+        action = self.action_func_mapping[self.action_space](values, self.support)
         return action, values
 
     def _support_expected(
@@ -400,6 +426,10 @@ class DistributionalQValueHook(QValueHook):
             ],
             -1,
         )
+
+    def _categorical(self, value: torch.Tensor, support: torch.Tensor) -> torch.Tensor:
+        value = value = self._support_expected(value, support)
+        return torch.argmax(value, dim=-1).to(torch.long)
 
     @staticmethod
     def _binary(value: torch.Tensor, support: torch.Tensor) -> torch.Tensor:

--- a/torchrl/objectives/dqn.py
+++ b/torchrl/objectives/dqn.py
@@ -5,13 +5,13 @@
 
 import torch
 
+from torchrl._utils import get_binary_env_var
 from torchrl.data import TensorDict
 from torchrl.envs.utils import step_mdp
 from torchrl.modules import (
     DistributionalQValueActor,
     QValueActor,
 )
-from torchrl._utils import get_binary_env_var
 from ..data.tensordict.tensordict import TensorDictBase
 from .common import LossModule
 from .utils import distance_loss, next_state_value
@@ -209,7 +209,7 @@ class DistributionalDQNLoss(LossModule):
 
         if _CATEGORICAL_ACTION_ENCODING:
             log_ps_a = action_log_softmax[range(batch_size), :, action.squeeze(-1)]
-        else:    
+        else:
             action_expand = action.unsqueeze(-2).expand_as(action_log_softmax)
             log_ps_a = action_log_softmax.masked_select(action_expand.to(torch.bool))
             log_ps_a = log_ps_a.view(batch_size, atoms)  # log p(s_t, a_t; θonline)
@@ -222,7 +222,7 @@ class DistributionalDQNLoss(LossModule):
                 params=self.value_network_params,
                 buffers=self.value_network_buffers,
             )  # Probabilities p(s_t+n, ·; θonline)
-            
+
             next_td_action = next_td.get("action")
             if _CATEGORICAL_ACTION_ENCODING:
                 argmax_indices_ns = next_td_action.squeeze(-1)

--- a/torchrl/trainers/helpers/envs.py
+++ b/torchrl/trainers/helpers/envs.py
@@ -261,6 +261,7 @@ def transformed_env_constructor(
         env_library = LIBS[cfg.env_library]
         frame_skip = cfg.frame_skip
         from_pixels = cfg.from_pixels
+        categorical_action_encoding = cfg.categorical_action_encoding
 
         if custom_env is None and custom_env_maker is None:
             if isinstance(cfg.collector_devices, str):
@@ -277,6 +278,7 @@ def transformed_env_constructor(
                 "frame_skip": frame_skip,
                 "from_pixels": from_pixels or len(video_tag),
                 "pixels_only": from_pixels,
+                "categorical_action_encoding": categorical_action_encoding,
             }
             if env_library is DMControlEnv:
                 env_kwargs.update({"task_name": env_task})
@@ -466,3 +468,5 @@ class EnvConfig:
     batch_transform: bool = False
     # if True, the transforms will be applied to the parallel env, and not to each individual env.\
     image_size: int = 84
+    # if True and environment has discrete action space, then it is encoded as categorical values rather than one-hot.
+    categorical_action_encoding: bool = False

--- a/torchrl/trainers/helpers/models.py
+++ b/torchrl/trainers/helpers/models.py
@@ -9,6 +9,7 @@ from typing import Optional, Sequence
 import torch
 from torch import nn, distributions as d
 
+from torchrl._utils import get_binary_env_var
 from torchrl.data import DEVICE_TYPING, CompositeSpec, NdUnboundedContinuousTensorSpec
 from torchrl.envs import TransformedEnv, TensorDictPrimer
 from torchrl.envs.common import EnvBase
@@ -66,7 +67,6 @@ from torchrl.modules.tensordict_module.world_models import (
     WorldModelWrapper,
 )
 from torchrl.trainers.helpers import transformed_env_constructor
-from torchrl._utils import get_binary_env_var
 
 DISTRIBUTIONS = {
     "delta": Delta,

--- a/torchrl/trainers/helpers/models.py
+++ b/torchrl/trainers/helpers/models.py
@@ -185,6 +185,8 @@ def make_dqn_actor(
     actor_kwargs = {}
 
     if isinstance(action_spec, DiscreteTensorSpec):
+        # if action spec is modeled as categorical variable, we still need to have features equal
+        # to the number of possible choices and also set categorical behavioural for actors.
         actor_kwargs.update({"action_space": "categorical"})
         out_features = env_specs["action_spec"].space.n
 

--- a/torchrl/trainers/helpers/models.py
+++ b/torchrl/trainers/helpers/models.py
@@ -66,6 +66,7 @@ from torchrl.modules.tensordict_module.world_models import (
     WorldModelWrapper,
 )
 from torchrl.trainers.helpers import transformed_env_constructor
+from torchrl._utils import get_binary_env_var
 
 DISTRIBUTIONS = {
     "delta": Delta,
@@ -88,6 +89,8 @@ __all__ = [
     "make_redq_model",
     "make_dreamer",
 ]
+
+_CATEGORICAL_ACTION_ENCODING = get_binary_env_var("CATEGORICAL_ACTION_ENCODING")
 
 
 def make_dqn_actor(
@@ -178,6 +181,11 @@ def make_dqn_actor(
     out_features = env_specs["action_spec"].shape[0]
     actor_class = QValueActor
     actor_kwargs = {}
+
+    if _CATEGORICAL_ACTION_ENCODING:
+        actor_kwargs.update({"action_space": "categorical"})
+        out_features = env_specs["action_spec"].space.n
+
     if cfg.distributional:
         if not atoms:
             raise RuntimeError(

--- a/torchrl/trainers/helpers/models.py
+++ b/torchrl/trainers/helpers/models.py
@@ -9,8 +9,12 @@ from typing import Optional, Sequence
 import torch
 from torch import nn, distributions as d
 
-from torchrl._utils import get_binary_env_var
-from torchrl.data import DEVICE_TYPING, CompositeSpec, NdUnboundedContinuousTensorSpec
+from torchrl.data import (
+    DEVICE_TYPING,
+    CompositeSpec,
+    NdUnboundedContinuousTensorSpec,
+    DiscreteTensorSpec,
+)
 from torchrl.envs import TransformedEnv, TensorDictPrimer
 from torchrl.envs.common import EnvBase
 from torchrl.envs.model_based.dreamer import DreamerEnv
@@ -89,8 +93,6 @@ __all__ = [
     "make_redq_model",
     "make_dreamer",
 ]
-
-_CATEGORICAL_ACTION_ENCODING = get_binary_env_var("CATEGORICAL_ACTION_ENCODING")
 
 
 def make_dqn_actor(
@@ -178,11 +180,11 @@ def make_dqn_actor(
         # automatically infer in key
         in_key = list(env_specs["observation_spec"])[0].split("next_")[-1]
 
-    out_features = env_specs["action_spec"].shape[0]
+    out_features = action_spec.shape[0]
     actor_class = QValueActor
     actor_kwargs = {}
 
-    if _CATEGORICAL_ACTION_ENCODING:
+    if isinstance(action_spec, DiscreteTensorSpec):
         actor_kwargs.update({"action_space": "categorical"})
         out_features = env_specs["action_spec"].space.n
 


### PR DESCRIPTION
## Description

Added alternative to one-hot encoding for action spaces with categorical features.

## Motivation and Context

Implementing feature #538.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] New feature (non-breaking change which adds core functionality)

## Checklist
* [x]  I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
* [ ]  My change requires a change to the documentation.
* [x]  I have updated the tests accordingly (_required for a bug fix or a new feature_).
* [ ]  I have updated the documentation accordingly.

Checklist from #538:
* [x]  Create a `DiscreteTensorSpec` [similar to `MultOneHotDiscreteTensorSpec`](https://github.com/pytorch/rl/blob/417817abc12240cb8c93d767445fdec5f6c7050c/torchrl/data/tensor_specs.py#L909) + tests
* [x]  Change QValueHook to make it possible to use [a "categorical" space (or similar) instead of "one_hot"](https://github.com/pytorch/rl/blob/497ad8f6304403f358f093f289d4c94ad2ce5878/torchrl/modules/tensordict_module/actors.py#L259)
* [x]  Do the same with [`DistributionalQValueHook`](https://github.com/pytorch/rl/blob/497ad8f6304403f358f093f289d4c94ad2ce5878/torchrl/modules/tensordict_module/actors.py#L357)
* [x]  [Adapt the DQNLoss](https://github.com/pytorch/rl/blob/497ad8f6304403f358f093f289d4c94ad2ce5878/torchrl/objectives/costs/dqn.py#L91-L104) to these changes
* [x]  [Adapt the DistributionalDQNLoss](https://github.com/pytorch/rl/blob/497ad8f6304403f358f093f289d4c94ad2ce5878/torchrl/objectives/costs/dqn.py#L129) to these changes
* [x]  Change the gym specs reader [here](https://github.com/pytorch/rl/blob/497ad8f6304403f358f093f289d4c94ad2ce5878/torchrl/envs/libs/gym.py#L58) to make it possible to choose one spec type or the other. One way to go about this would be to have a global variable that controls which categorical encoding must be used.

Current implementation seems to couple different parts of TorchRL quite tightly as there is quite a few places where it is assumed that the action space is one-hot. Perhaps, a more generic action-space object that encapsulates manipulation with values and that is shared across losses, actors, hooks, etc. (as a `nn.Module` maybe) might be a worth investment in future.

The mode is turned on by `export CATEGORICAL_ACTION_ENCODING=True` command, and it is turned off by default. Another alternative could be to provide it through the config-file, however this, again, would require a bit more generic solution to configure module that will be passed to all the necessary modules.