### PR TITLE
[BugFix] ReplayBuffer's storage now signal back when changes happen

### DIFF
--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -582,13 +582,14 @@ def test_legacy_rb_does_not_attach():
     storage = LazyMemmapStorage(n)
     writer = RoundRobinWriter()
     sampler = RandomSampler()
-    ReplayBuffer(storage=storage, size=n, prefetch=0, collate_fn=lambda x: x)
-    rb_prototype.ReplayBuffer(
+    rb = ReplayBuffer(storage=storage, size=n, prefetch=0, collate_fn=lambda x: x)
+    prb = rb_prototype.ReplayBuffer(
         storage=storage, writer=writer, sampler=sampler, collate_fn=lambda x: x
     )
 
     assert len(storage._attached_entities) == 1
-    assert sampler in storage._attached_entities
+    assert prb in storage._attached_entities
+    assert rb not in storage._attached_entities
 
 
 if __name__ == "__main__":

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -582,13 +582,13 @@ def test_legacy_rb_does_not_attach():
     storage = LazyMemmapStorage(n)
     writer = RoundRobinWriter()
     sampler = RandomSampler()
-    rb = ReplayBuffer(storage=storage, size=n, prefetch=0, collate_fn=lambda x: x)
-    prb = rb_prototype.ReplayBuffer(
+    ReplayBuffer(storage=storage, size=n, prefetch=0, collate_fn=lambda x: x)
+    rb_prototype.ReplayBuffer(
         storage=storage, writer=writer, sampler=sampler, collate_fn=lambda x: x
     )
 
-    assert rb not in storage.attached_entities
-    assert prb in storage.attached_entities
+    assert len(storage._attached_entities) == 1
+    assert sampler in storage._attached_entities
 
 
 if __name__ == "__main__":

--- a/torchrl/data/replay_buffers/rb_prototype.py
+++ b/torchrl/data/replay_buffers/rb_prototype.py
@@ -42,8 +42,8 @@ class ReplayBuffer:
         prefetch: Optional[int] = None,
     ) -> None:
         self._storage = storage if storage is not None else ListStorage(max_size=1_000)
+        self._storage.attach(self)
         self._sampler = sampler if sampler is not None else RandomSampler()
-        self._storage.attach(self._sampler)
         self._writer = writer if writer is not None else RoundRobinWriter()
         self._writer.register_storage(self._storage)
 
@@ -155,6 +155,9 @@ class ReplayBuffer:
                 self._prefetch_queue.append(fut)
 
         return ret
+
+    def mark_update(self, index: Union[int, torch.Tensor]) -> None:
+        self._sampler.mark_update(index)
 
 
 class TensorDictReplayBuffer(ReplayBuffer):

--- a/torchrl/data/replay_buffers/rb_prototype.py
+++ b/torchrl/data/replay_buffers/rb_prototype.py
@@ -42,8 +42,8 @@ class ReplayBuffer:
         prefetch: Optional[int] = None,
     ) -> None:
         self._storage = storage if storage is not None else ListStorage(max_size=1_000)
-        self._storage.attach(self)
         self._sampler = sampler if sampler is not None else RandomSampler()
+        self._storage.attach(self._sampler)
         self._writer = writer if writer is not None else RoundRobinWriter()
         self._writer.register_storage(self._storage)
 
@@ -155,17 +155,6 @@ class ReplayBuffer:
                 self._prefetch_queue.append(fut)
 
         return ret
-
-    def mark_update(self, index) -> None:
-        """Marks a given storage index as having changed.
-
-        Derived classes can deal with this however appropriate,
-        forwarding this call to whichever parts are needed.
-
-        Args:
-            index: The modified index from storage.
-        """
-        return self.update_priority(index, self._sampler.default_priority)
 
 
 class TensorDictReplayBuffer(ReplayBuffer):

--- a/torchrl/data/replay_buffers/rb_prototype.py
+++ b/torchrl/data/replay_buffers/rb_prototype.py
@@ -42,6 +42,7 @@ class ReplayBuffer:
         prefetch: Optional[int] = None,
     ) -> None:
         self._storage = storage if storage is not None else ListStorage(max_size=1_000)
+        self._storage.attach(self)
         self._sampler = sampler if sampler is not None else RandomSampler()
         self._writer = writer if writer is not None else RoundRobinWriter()
         self._writer.register_storage(self._storage)
@@ -154,6 +155,17 @@ class ReplayBuffer:
                 self._prefetch_queue.append(fut)
 
         return ret
+
+    def mark_update(self, index) -> None:
+        """Marks a given storage index as having changed.
+
+        Derived classes can deal with this however appropriate,
+        forwarding this call to whichever parts are needed.
+
+        Args:
+            index: The modified index from storage.
+        """
+        return self.update_priority(index, self._sampler.default_priority)
 
 
 class TensorDictReplayBuffer(ReplayBuffer):

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -28,7 +28,7 @@ class Sampler(ABC):
         pass
 
     def update_priority(
-        self, index: Union[int, torch.Tensor], priority: Union[int, torch.Tensor]
+        self, index: Union[int, torch.Tensor], priority: Union[float, torch.Tensor]
     ) -> dict:
         pass
 

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -32,9 +32,7 @@ class Sampler(ABC):
     ) -> dict:
         pass
 
-    def mark_update(
-            self, index: Union[int, torch.Tensor]
-    ) -> None:
+    def mark_update(self, index: Union[int, torch.Tensor]) -> None:
         pass
 
     @property
@@ -188,7 +186,5 @@ class PrioritizedSampler(Sampler):
         self._sum_tree[index] = priority
         self._min_tree[index] = priority
 
-    def mark_update(
-            self, index: Union[int, torch.Tensor]
-    ) -> None:
+    def mark_update(self, index: Union[int, torch.Tensor]) -> None:
         self.update_priority(index, self.default_priority)

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -32,6 +32,11 @@ class Sampler(ABC):
     ) -> dict:
         pass
 
+    def mark_update(
+            self, index: Union[int, torch.Tensor]
+    ) -> None:
+        pass
+
     @property
     def default_priority(self) -> float:
         return 1.0
@@ -182,3 +187,8 @@ class PrioritizedSampler(Sampler):
         priority = np.power(priority + self._eps, self._alpha)
         self._sum_tree[index] = priority
         self._min_tree[index] = priority
+
+    def mark_update(
+            self, index: Union[int, torch.Tensor]
+    ) -> None:
+        self.update_priority(index, self.default_priority)

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -41,18 +41,18 @@ class Storage:
     def get(self, index: int) -> Any:
         raise NotImplementedError
 
-    def attach(self, sampler: Any) -> None:
+    def attach(self, buffer: Any) -> None:
         """This function attaches a sampler to this storage.
 
-        Samplers that read from this storage must be included as an attached
+        Buffers that read from this storage must be included as an attached
         entity by calling this method. This guarantees that when data
-        in the storage changes, samplers are made aware of changes even if the storage
+        in the storage changes, components are made aware of changes even if the storage
         is shared with other buffers (eg. Priority Samplers).
 
         Args:
-            sampler: the object that reads from this storage.
+            buffer: the object that reads from this storage.
         """
-        self._attached_entities.add(sampler)
+        self._attached_entities.add(buffer)
 
     def __getitem__(self, item):
         return self.get(item)


### PR DESCRIPTION
## Description

The prototype modular Replay Buffer has a bug (#606) when storage is shared across buffers. This happens because the different parts implicitly assume to always be aware of changes in storage, which was no true. This change introduces an API for storage to signal back to the buffers that changes were made. Buffers can then handle this signal however and whenever they see fit.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

close #606 

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [x] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
