### PR TITLE
[BugFix] make TensorDictReplayBuffer.extend call super().extend with stacked_td

### DIFF
--- a/torchrl/data/replay_buffers/rb_prototype.py
+++ b/torchrl/data/replay_buffers/rb_prototype.py
@@ -226,7 +226,7 @@ class TensorDictReplayBuffer(ReplayBuffer):
         else:
             stacked_td = tensordicts
 
-        index = super().extend(tensordicts)
+        index = super().extend(stacked_td)
         stacked_td.set(
             "index",
             torch.tensor(index, dtype=torch.int, device=stacked_td.device),


### PR DESCRIPTION
## Description

Calls `ReplayBuffer.extend` with stacked tensordicts rather than stacked tensordicts or a list of tensordicts depending on the input.
cc @adityagoel4512 