### PR TITLE
[BugFix] Prevent transform parent from being reassigned

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -327,6 +327,27 @@ def test_nested_transformed_env():
     assert children[1] == t2
 
 
+def test_transform_parent():
+    base_env = ContinuousActionVecMockEnv()
+    t1 = RewardScaling(0, 1)
+    t2 = RewardScaling(0, 2)
+    env = TransformedEnv(TransformedEnv(base_env, t1), t2)
+    t3 = RewardClipping(0.1, 0.5)
+    env.append_transform(t3)
+
+    t1_parent_gt = t1._parent
+    t2_parent_gt = t2._parent
+    t3_parent_gt = t3._parent
+
+    _ = t1.parent
+    _ = t2.parent
+    _ = t3.parent
+
+    assert t1_parent_gt == t1._parent
+    assert t2_parent_gt == t2._parent
+    assert t3_parent_gt == t3._parent
+
+
 class TestTransforms:
     @pytest.mark.skipif(not _has_tv, reason="no torchvision")
     @pytest.mark.parametrize("interpolation", ["bilinear", "bicubic"])

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -313,6 +313,20 @@ def test_added_transforms_are_in_eval_mode():
     assert t.transform[1].training
 
 
+def test_nested_transformed_env():
+    base_env = ContinuousActionVecMockEnv()
+    t1 = RewardScaling(0, 1)
+    t2 = RewardScaling(0, 2)
+    env = TransformedEnv(TransformedEnv(base_env, t1), t2)
+
+    assert env.base_env is base_env
+    assert isinstance(env.transform, Compose)
+    children = list(env.transform.transforms.children())
+    assert len(children) == 2
+    assert children[0] == t1
+    assert children[1] == t2
+
+
 class TestTransforms:
     @pytest.mark.skipif(not _has_tv, reason="no torchvision")
     @pytest.mark.parametrize("interpolation", ["bilinear", "bicubic"])
@@ -1349,7 +1363,13 @@ class TestR3M:
         transformed_env.close()
 
     @pytest.mark.parametrize("stack_images", [True, False])
-    @pytest.mark.parametrize("parallel", [True, False])
+    @pytest.mark.parametrize(
+        "parallel",
+        [
+            False,
+            True,
+        ],
+    )
     def test_r3m_mult_images(self, model, device, stack_images, parallel):
         keys_in = ["next_pixels", "next_pixels2"]
         keys_out = ["next_vec"] if stack_images else ["next_vec", "next_vec2"]

--- a/torchrl/data/replay_buffers/rb_prototype.py
+++ b/torchrl/data/replay_buffers/rb_prototype.py
@@ -226,7 +226,7 @@ class TensorDictReplayBuffer(ReplayBuffer):
         else:
             stacked_td = tensordicts
 
-        index = super().extend(tensordicts)
+        index = super().extend(stacked_td)
         stacked_td.set(
             "index",
             torch.tensor(index, dtype=torch.int, device=stacked_td.device),

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -230,7 +230,7 @@ class Transform(nn.Module):
 
     def set_parent(self, parent: Union[Transform, EnvBase]) -> None:
         if self.__dict__["_parent"] is not None:
-            raise AttributeError(f"parent of transform already set")
+            raise AttributeError("parent of transform already set")
         self.__dict__["_parent"] = parent
 
     def reset_parent(self) -> None:
@@ -257,7 +257,7 @@ class Transform(nn.Module):
                     f"Compose parent was of type {type(compose_parent)} but expected TransformedEnv."
                 )
             if compose_parent.transform is not compose:
-                comp_parent_trans = compose_parent.transform
+                comp_parent_trans = copy(compose_parent.transform)
                 comp_parent_trans.reset_parent()
             else:
                 comp_parent_trans = None
@@ -265,9 +265,10 @@ class Transform(nn.Module):
                 compose_parent.base_env,
                 transform=comp_parent_trans,
             )
-            for transform in compose.transforms:
-                if transform is self:
+            for orig_trans in compose.transforms:
+                if orig_trans is self:
                     break
+                transform = copy(orig_trans)
                 transform.reset_parent()
                 out.append_transform(transform)
         elif isinstance(parent, TransformedEnv):
@@ -321,10 +322,16 @@ class TransformedEnv(EnvBase):
                 # we don't use isinstance as some transforms may be subclassed from
                 # Compose but with other features that we don't want to loose.
                 transform = [transform]
+            else:
+                for t in transform:
+                    t.reset_parent()
             env_transform = env.transform
-            env_transform.reset_parent()
             if type(env_transform) is not Compose:
+                env_transform.reset_parent()
                 env_transform = [env_transform]
+            else:
+                for t in env_transform:
+                    t.reset_parent()
             transform = Compose(*env_transform, *transform).to(device)
         else:
             self._set_env(env, device)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -229,7 +229,12 @@ class Transform(nn.Module):
         return f"{self.__class__.__name__}(keys={self.keys_in})"
 
     def set_parent(self, parent: Union[Transform, EnvBase]) -> None:
+        if self.__dict__["_parent"] is not None:
+            raise AttributeError(f"parent of transform already set")
         self.__dict__["_parent"] = parent
+
+    def reset_parent(self) -> None:
+        self.__dict__["_parent"] = None
 
     @property
     def parent(self) -> EnvBase:
@@ -251,15 +256,19 @@ class Transform(nn.Module):
                 raise ValueError(
                     f"Compose parent was of type {type(compose_parent)} but expected TransformedEnv."
                 )
+            if compose_parent.transform is not compose:
+                comp_parent_trans = compose_parent.transform
+                comp_parent_trans.reset_parent()
+            else:
+                comp_parent_trans = None
             out = TransformedEnv(
                 compose_parent.base_env,
-                transform=compose_parent.transform
-                if compose_parent.transform is not compose
-                else None,
+                transform=comp_parent_trans,
             )
             for transform in compose.transforms:
                 if transform is self:
                     break
+                transform.reset_parent()
                 out.append_transform(transform)
         elif isinstance(parent, TransformedEnv):
             out = TransformedEnv(parent.base_env)
@@ -313,6 +322,7 @@ class TransformedEnv(EnvBase):
                 # Compose but with other features that we don't want to loose.
                 transform = [transform]
             env_transform = env.transform
+            env_transform.reset_parent()
             if type(env_transform) is not Compose:
                 env_transform = [env_transform]
             transform = Compose(*env_transform, *transform).to(device)
@@ -499,9 +509,10 @@ but got an object of type {type(transform)}."""
         transform = transform.to(self.device)
         if not isinstance(self.transform, Compose):
             prev_transform = self.transform
+            prev_transform.reset_parent()
             self.transform = Compose()
             self.transform.append(prev_transform)
-            self.transform.set_parent(self)
+
         self.transform.append(transform)
 
     def insert_transform(self, index: int, transform: Transform) -> None:
@@ -563,8 +574,6 @@ but got an object of type {type(transform)}."""
     def __setattr__(self, key, value):
         propobj = getattr(self.__class__, key, None)
 
-        if isinstance(value, Transform):
-            value.set_parent(self)
         if isinstance(propobj, property):
             ancestors = list(__class__.__mro__)[::-1]
             while isinstance(propobj, property):

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -244,10 +244,20 @@ class Transform(nn.Module):
                 raise ValueError(
                     "A transform parent must be either another Compose transform or an environment object."
                 )
+            compose = parent
+            # the parent of the compose must be a TransformedEnv
+            compose_parent = compose.parent
+            if not isinstance(compose_parent, TransformedEnv):
+                raise ValueError(
+                    f"Compose parent was of type {type(compose_parent)} but expected TransformedEnv."
+                )
             out = TransformedEnv(
-                parent.parent.base_env,
+                compose_parent.base_env,
+                transform=compose_parent.transform
+                if compose_parent.transform is not compose
+                else None,
             )
-            for transform in parent.transforms:
+            for transform in compose.transforms:
                 if transform is self:
                     break
                 out.append_transform(transform)
@@ -291,21 +301,31 @@ class TransformedEnv(EnvBase):
         cache_specs: bool = True,
         **kwargs,
     ):
+        self._transform = None
         device = kwargs.pop("device", env.device)
         env = env.to(device)
         super().__init__(device=None, **kwargs)
-        self._set_env(env, device)
-        if transform is None:
-            transform = Compose()
-            transform.set_parent(self)
+
+        if isinstance(env, TransformedEnv):
+            self._set_env(env.base_env, device)
+            if type(transform) is not Compose:
+                # we don't use isinstance as some transforms may be subclassed from
+                # Compose but with other features that we don't want to loose.
+                transform = [transform]
+            env_transform = env.transform
+            if type(env_transform) is not Compose:
+                env_transform = [env_transform]
+            transform = Compose(*env_transform, *transform).to(device)
         else:
-            transform = transform.to(device)
-        transform.eval()
+            self._set_env(env, device)
+            if transform is None:
+                transform = Compose()
+            else:
+                transform = transform.to(device)
         self.transform = transform
 
         self._last_obs = None
         self.cache_specs = cache_specs
-
         self._reward_spec = None
         self._observation_spec = None
         self.batch_size = self.base_env.batch_size
@@ -314,6 +334,21 @@ class TransformedEnv(EnvBase):
         self.base_env = env.to(device)
         # updates need not be inplace, as transforms may modify values out-place
         self.base_env._inplace_update = False
+
+    @property
+    def transform(self) -> Transform:
+        return self._transform
+
+    @transform.setter
+    def transform(self, transform: Transform):
+        if not isinstance(transform, Transform):
+            raise ValueError(
+                f"""Expected a transform of type torchrl.envs.transforms.Transform,
+but got an object of type {type(transform)}."""
+            )
+        transform.set_parent(self)
+        transform.eval()
+        self._transform = transform
 
     @property
     def device(self) -> bool:


### PR DESCRIPTION
## Description

Once a transform has been assigned a parent, it can't be assigned another parent anymore. A check in the Transform.set_parent method was added which raises an exception if the parent has already been set. A reset_parent method was also added so existing operations such as appending new transforms work with the new check.

## Motivation and Context

Following code should raise an exception because we are reassigning t1's parent:

```
env =  TransformedEnv(GymEnv("Pendulum-v1"))
t1 = RewardScaling(0, 1)
t2 = RewardClipping(0.1, 0.5)
env.append_transform(t1)
env.append_transform(t2)
env.append_transform(t1)
print(env.transform[-1])
```

`close #636`

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
