### PR TITLE
[BugFix] GymWrapper does not work with nested observation gym.spaces.Dict #640

### DIFF
--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -33,6 +33,7 @@ if _has_dmc:
 
 from sys import platform
 
+from torchrl.data.tensor_specs import TensorSpec
 from torchrl.data.tensordict.tensordict import assert_allclose_td, TensorDictBase
 from torchrl.envs import EnvCreator, ParallelEnv
 from torchrl.envs.libs.dm_control import DMControlEnv, DMControlWrapper
@@ -169,11 +170,12 @@ def test_gym(env_name, frame_skip, from_pixels, pixels_only):
     nested_obs_env = NestedObsGymEnv()
     env = GymWrapper(nested_obs_env)
 
-    def assert_obs_name(obs: TensorDictBase, obs_spec: TensorDictBase) -> None:
-        for key, value in obs_spec.items():
-            assert key in obs.keys()
-            if isinstance(value, dict):
-                assert_obs_name(value, obs[key])
+    def assert_obs_name(td: TensorDictBase, obs_spec: TensorSpec) -> None:
+        # Note that td can contain also other fields than those in obs_spec
+        for key in obs_spec.keys():
+            assert key in td.keys()
+            if isinstance(td[key], TensorDictBase):
+                assert_obs_name(td[key], obs_spec[key])
 
     # internal function returns with "next_"
     td = env._reset()

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -33,7 +33,7 @@ if _has_dmc:
 
 from sys import platform
 
-from torchrl.data.tensordict.tensordict import assert_allclose_td
+from torchrl.data.tensordict.tensordict import assert_allclose_td, TensorDictBase
 from torchrl.envs import EnvCreator, ParallelEnv
 from torchrl.envs.libs.dm_control import DMControlEnv, DMControlWrapper
 from torchrl.envs.libs.gym import GymEnv, GymWrapper
@@ -169,7 +169,7 @@ def test_gym(env_name, frame_skip, from_pixels, pixels_only):
     nested_obs_env = NestedObsGymEnv()
     env = GymWrapper(nested_obs_env)
 
-    def assert_obs_name(obs, obs_spec):
+    def assert_obs_name(obs: TensorDictBase, obs_spec: TensorDictBase) -> None:
         for key, value in obs_spec.items():
             assert key in obs.keys()
             if isinstance(value, dict):

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -168,13 +168,15 @@ class GymLikeEnv(_EnvWrapper):
         """
         if isinstance(observations, dict):
 
-            def rename(obs):
+            def keys_add_next(obs: dict) -> None:
+                import pdb;pdb.set_trace()
                 return {
-                    "next_" + key: rename(value) if isinstance(value, dict) else value
+                    "next_" + key: keys_add_next(value) if isinstance(value, dict) else value
                     for key, value in obs.items()
                 }
 
-            observations = rename(observations)
+            observations = keys_add_next(observations)
+
         if not isinstance(observations, (TensorDict, dict)):
             key = list(self.observation_spec.keys())[0]
             observations = {key: observations}

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -167,7 +167,14 @@ class GymLikeEnv(_EnvWrapper):
 
         """
         if isinstance(observations, dict):
-            observations = {"next_" + key: value for key, value in observations.items()}
+
+            def rename(obs):
+                return {
+                    "next_" + key: rename(value) if isinstance(value, dict) else value
+                    for key, value in obs.items()
+                }
+
+            observations = rename(observations)
         if not isinstance(observations, (TensorDict, dict)):
             key = list(self.observation_spec.keys())[0]
             observations = {key: observations}

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -169,9 +169,10 @@ class GymLikeEnv(_EnvWrapper):
         if isinstance(observations, dict):
 
             def keys_add_next(obs: dict) -> None:
-                import pdb;pdb.set_trace()
                 return {
-                    "next_" + key: keys_add_next(value) if isinstance(value, dict) else value
+                    "next_" + key: keys_add_next(value)
+                    if isinstance(value, dict)
+                    else value
                     for key, value in obs.items()
                 }
 

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -97,7 +97,7 @@ def step_mdp(
         for key in keys_all:
             new_key = key[5:]
             td.rename_key(key, new_key, safe=True)
-            if isinstance(td[new_key], (TensorDictBase, dict)):
+            if isinstance(td[new_key], TensorDictBase):
                 keys_ = [
                     key_ for key_ in td[new_key].keys() if key_.startswith("next_")
                 ]

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -93,7 +93,7 @@ def step_mdp(
         other_keys = [key for key in tensordict.keys() if key not in prohibited]
     select_tensordict = tensordict.select(*other_keys, *keys)
 
-    def rename_keys(keys_all: list, td: TensorDictBase) -> None:
+    def keys_remove_next(keys_all: list, td: TensorDictBase) -> None:
         for key in keys_all:
             new_key = key[5:]
             td.rename_key(key, new_key, safe=True)
@@ -101,9 +101,9 @@ def step_mdp(
                 keys_ = [
                     key_ for key_ in td[new_key].keys() if key_.startswith("next_")
                 ]
-                rename_keys(keys_, td[new_key])
+                keys_remove_next(keys_, td[new_key])
 
-    rename_keys(keys, select_tensordict)
+    keys_remove_next(keys, select_tensordict)
 
     if next_tensordict is not None:
         return next_tensordict.update(select_tensordict)

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -93,20 +93,17 @@ def step_mdp(
         other_keys = [key for key in tensordict.keys() if key not in prohibited]
     select_tensordict = tensordict.select(*other_keys, *keys)
 
-    from torchrl.data import TensorDict
-
-    def rename_keys(keys_all, td: TensorDict):
+    def rename_keys(keys_all: list, td: TensorDictBase) -> None:
         for key in keys_all:
             new_key = key[5:]
             td.rename_key(key, new_key, safe=True)
-            if isinstance(td[new_key], (TensorDict, dict)):
+            if isinstance(td[new_key], (TensorDictBase, dict)):
                 keys_ = [
                     key_ for key_ in td[new_key].keys() if key_.startswith("next_")
                 ]
                 rename_keys(keys_, td[new_key])
 
     rename_keys(keys, select_tensordict)
-    # import pdb; pdb.set_trace()
 
     if next_tensordict is not None:
         return next_tensordict.update(select_tensordict)


### PR DESCRIPTION
## Description
Possible bug fix for the issue mentioned in #640 that prevents to use nested `gym.spaces.Dict` due to naming errors with the "next_" word beginning of observations. This bug fix uses recursive functions to rename observations correctly for gym environments with nested `gym.spaces.Dict` spaces. Some ideas for tests have been added.

## Motivation and Context
Close #640 

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
