### PR TITLE
[BugFix] make_trainer possible bug for on-policy cases

### DIFF
--- a/torchrl/trainers/helpers/trainers.py
+++ b/torchrl/trainers/helpers/trainers.py
@@ -222,6 +222,7 @@ def make_trainer(
             "process_optim_batch",
             BatchSubSampler(batch_size=cfg.batch_size, sub_traj_len=cfg.sub_traj_len),
         )
+        trainer.register_op("process_optim_batch", lambda batch: batch.to(device))
 
     if optim_scheduler is not None:
         trainer.register_op("post_optim", optim_scheduler.step)


### PR DESCRIPTION
## Description

Possible bug: using the make_trainer helper function in a script can raise an error if you want to use GPU, because mini batches seem to be placed by default in CPU if you don't use a replay buffer. I added a line to register a "process_optim_batch" operation so it places the mini batches to whatever device the networks are in, avoiding this error.

## Motivation and Context

I was trying to run the PPO example on GPU and kept complaining about the data and the weights being in different devices (CPU and GPU).

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
