### PR TITLE
[Naming] Rename keys_in to in_keys in transforms.py and related modules

### DIFF
--- a/examples/dreamer/dreamer_utils.py
+++ b/examples/dreamer/dreamer_utils.py
@@ -93,13 +93,13 @@ def make_env_transforms(
         if cfg.grayscale:
             env.append_transform(GrayScale())
         env.append_transform(FlattenObservation())
-        env.append_transform(CatFrames(N=cfg.catframes, keys_in=["next_pixels"]))
+        env.append_transform(CatFrames(N=cfg.catframes, in_keys=["next_pixels"]))
         if stats is None:
             obs_stats = {"loc": 0.0, "scale": 1.0}
         else:
             obs_stats = stats
         obs_stats["standard_normal"] = True
-        env.append_transform(ObservationNorm(**obs_stats, keys_in=["next_pixels"]))
+        env.append_transform(ObservationNorm(**obs_stats, in_keys=["next_pixels"]))
     if norm_rewards:
         reward_scaling = 1.0
         reward_loc = 0.0
@@ -118,7 +118,7 @@ def make_env_transforms(
         ]
         float_to_double_list += ["action"]  # DMControl requires double-precision
     env.append_transform(
-        DoubleToFloat(keys_in=double_to_float_list, keys_inv_in=float_to_double_list)
+        DoubleToFloat(in_keys=double_to_float_list, in_keys_inv=float_to_double_list)
     )
 
     default_dict = {

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -254,7 +254,7 @@ def _make_envs(
                     GymEnv(env_name, frame_skip=frame_skip, device=device),
                     Compose(
                         ObservationNorm(
-                            keys_in=["next_observation"], loc=0.5, scale=1.1
+                            in_keys=["next_observation"], loc=0.5, scale=1.1
                         ),
                         RewardClipping(0, 0.1),
                     ),
@@ -275,7 +275,7 @@ def _make_envs(
                     Compose(*[ToTensorImage(), RewardClipping(0, 0.1)])
                     if not transformed_in
                     else Compose(
-                        *[ObservationNorm(keys_in=["next_pixels"], loc=0, scale=1)]
+                        *[ObservationNorm(in_keys=["next_pixels"], loc=0, scale=1)]
                     )
                 )
 
@@ -297,14 +297,14 @@ def _make_envs(
                 return (
                     Compose(
                         ObservationNorm(
-                            keys_in=["next_observation"], loc=0.5, scale=1.1
+                            in_keys=["next_observation"], loc=0.5, scale=1.1
                         ),
                         RewardClipping(0, 0.1),
                     )
                     if not transformed_in
                     else Compose(
                         ObservationNorm(
-                            keys_in=["next_observation"], loc=1.0, scale=1.0
+                            in_keys=["next_observation"], loc=1.0, scale=1.0
                         )
                     )
                 )
@@ -458,8 +458,8 @@ class TestParallel:
                     CatTensors(env1_obs_keys, "next_observation_stand", del_keys=False),
                     CatTensors(env1_obs_keys, "next_observation"),
                     DoubleToFloat(
-                        keys_in=["next_observation_stand", "next_observation"],
-                        keys_inv_in=["action"],
+                        in_keys=["next_observation_stand", "next_observation"],
+                        in_keys_inv=["action"],
                     ),
                 ),
             )
@@ -471,8 +471,8 @@ class TestParallel:
                     CatTensors(env2_obs_keys, "next_observation_walk", del_keys=False),
                     CatTensors(env2_obs_keys, "next_observation"),
                     DoubleToFloat(
-                        keys_in=["next_observation_walk", "next_observation"],
-                        keys_inv_in=["action"],
+                        in_keys=["next_observation_walk", "next_observation"],
+                        in_keys_inv=["action"],
                     ),
                 ),
             )

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -406,7 +406,7 @@ class TestTransforms:
     def test_resize(self, interpolation, keys, nchannels, batch, device):
         torch.manual_seed(0)
         dont_touch = torch.randn(*batch, nchannels, 16, 16, device=device)
-        resize = Resize(w=20, h=21, interpolation=interpolation, keys_in=keys)
+        resize = Resize(w=20, h=21, interpolation=interpolation, in_keys=keys)
         td = TensorDict(
             {
                 key: torch.randn(*batch, nchannels, 16, 16, device=device)
@@ -444,7 +444,7 @@ class TestTransforms:
     def test_centercrop(self, keys, h, nchannels, batch, device):
         torch.manual_seed(0)
         dont_touch = torch.randn(*batch, nchannels, 16, 16, device=device)
-        cc = CenterCrop(w=20, h=h, keys_in=keys)
+        cc = CenterCrop(w=20, h=h, in_keys=keys)
         if h is None:
             h = 20
         td = TensorDict(
@@ -485,7 +485,7 @@ class TestTransforms:
         torch.manual_seed(0)
         dont_touch = torch.randn(*batch, *size, nchannels, 16, 16, device=device)
         start_dim = -3 - len(size)
-        flatten = FlattenObservation(start_dim, -3, keys_in=keys)
+        flatten = FlattenObservation(start_dim, -3, in_keys=keys)
         td = TensorDict(
             {
                 key: torch.randn(*batch, *size, nchannels, 16, 16, device=device)
@@ -527,7 +527,7 @@ class TestTransforms:
     def test_unsqueeze(self, keys, size, nchannels, batch, device, unsqueeze_dim):
         torch.manual_seed(0)
         dont_touch = torch.randn(*batch, *size, nchannels, 16, 16, device=device)
-        unsqueeze = UnsqueezeTransform(unsqueeze_dim, keys_in=keys)
+        unsqueeze = UnsqueezeTransform(unsqueeze_dim, in_keys=keys)
         td = TensorDict(
             {
                 key: torch.randn(*batch, *size, nchannels, 16, 16, device=device)
@@ -586,7 +586,7 @@ class TestTransforms:
         torch.manual_seed(0)
         keys_total = set(keys + keys_inv)
         unsqueeze = UnsqueezeTransform(
-            unsqueeze_dim, keys_in=keys, keys_inv_in=keys_inv
+            unsqueeze_dim, in_keys=keys, in_keys_inv=keys_inv
         )
         td = TensorDict(
             {
@@ -621,7 +621,7 @@ class TestTransforms:
     def test_squeeze(self, keys, keys_inv, size, nchannels, batch, device, squeeze_dim):
         torch.manual_seed(0)
         keys_total = set(keys + keys_inv)
-        squeeze = SqueezeTransform(squeeze_dim, keys_in=keys, keys_inv_in=keys_inv)
+        squeeze = SqueezeTransform(squeeze_dim, in_keys=keys, in_keys_inv=keys_inv)
         td = TensorDict(
             {
                 key: torch.randn(*batch, *size, nchannels, 16, 16, device=device)
@@ -656,7 +656,7 @@ class TestTransforms:
     ):
         torch.manual_seed(0)
         keys_total = set(keys + keys_inv)
-        squeeze = SqueezeTransform(squeeze_dim, keys_in=keys, keys_inv_in=keys_inv)
+        squeeze = SqueezeTransform(squeeze_dim, in_keys=keys, in_keys_inv=keys_inv)
         td = TensorDict(
             {
                 key: torch.randn(*batch, *size, nchannels, 16, 16, device=device)
@@ -687,7 +687,7 @@ class TestTransforms:
     def test_grayscale(self, keys, device):
         torch.manual_seed(0)
         nchannels = 3
-        gs = GrayScale(keys_in=keys)
+        gs = GrayScale(in_keys=keys)
         dont_touch = torch.randn(1, nchannels, 16, 16, device=device)
         td = TensorDict(
             {key: torch.randn(1, nchannels, 16, 16, device=device) for key in keys},
@@ -720,7 +720,7 @@ class TestTransforms:
     def test_totensorimage(self, keys, batch, device):
         torch.manual_seed(0)
         nchannels = 3
-        totensorimage = ToTensorImage(keys_in=keys)
+        totensorimage = ToTensorImage(in_keys=keys)
         dont_touch = torch.randn(*batch, nchannels, 16, 16, device=device)
         td = TensorDict(
             {
@@ -764,7 +764,7 @@ class TestTransforms:
     @pytest.mark.parametrize("device", get_available_devices())
     def test_compose(self, keys, batch, device, nchannels=1, N=4):
         torch.manual_seed(0)
-        t1 = CatFrames(keys_in=keys, N=4)
+        t1 = CatFrames(in_keys=keys, N=4)
         t2 = FiniteTensorDictCheck()
         compose = Compose(t1, t2)
         dont_touch = torch.randn(*batch, nchannels, 16, 16, device=device)
@@ -818,8 +818,8 @@ class TestTransforms:
         torch.manual_seed(0)
         keys_to_transform = set(keys_inv_1 + keys_inv_2)
         keys_total = set(["action_1", "action_2", "dont_touch"])
-        double2float_1 = DoubleToFloat(keys_inv_in=keys_inv_1)
-        double2float_2 = DoubleToFloat(keys_inv_in=keys_inv_2)
+        double2float_1 = DoubleToFloat(in_keys_inv=keys_inv_1)
+        double2float_2 = DoubleToFloat(in_keys_inv=keys_inv_2)
         compose = Compose(double2float_1, double2float_2)
         td = TensorDict(
             {
@@ -861,7 +861,7 @@ class TestTransforms:
             loc = loc.to(device)
         if isinstance(scale, Tensor):
             scale = scale.to(device)
-        on = ObservationNorm(loc, scale, keys_in=keys, standard_normal=standard_normal)
+        on = ObservationNorm(loc, scale, in_keys=keys, standard_normal=standard_normal)
         dont_touch = torch.randn(1, nchannels, 16, 16, device=device)
         td = TensorDict(
             {key: torch.zeros(1, nchannels, 16, 16, device=device) for key in keys}, [1]
@@ -910,7 +910,7 @@ class TestTransforms:
         key1 = "first key"
         key2 = "second key"
         keys = [key1, key2]
-        cat_frames = CatFrames(N=N, keys_in=keys)
+        cat_frames = CatFrames(N=N, in_keys=keys)
         mins = [0, 0.5]
         maxes = [0.5, 1]
         observation_spec = CompositeSpec(
@@ -953,7 +953,7 @@ class TestTransforms:
         key2_tensor = torch.ones(1, 1, 3, 3, device=device)
         key_tensors = [key1_tensor, key2_tensor]
         td = TensorDict(dict(zip(keys, key_tensors)), [1], device=device)
-        cat_frames = CatFrames(N=N, keys_in=keys)
+        cat_frames = CatFrames(N=N, in_keys=keys)
 
         cat_frames(td)
         latest_frame = td.get(key2)
@@ -973,7 +973,7 @@ class TestTransforms:
         key2_tensor = torch.ones(1, 1, 3, 3, device=device)
         key_tensors = [key1_tensor, key2_tensor]
         td = TensorDict(dict(zip(keys, key_tensors)), [1], device=device)
-        cat_frames = CatFrames(N=N, keys_in=keys)
+        cat_frames = CatFrames(N=N, in_keys=keys)
 
         cat_frames(td)
         buffer_length1 = len(cat_frames.buffer)
@@ -1014,7 +1014,7 @@ class TestTransforms:
     def test_double2float(self, keys, keys_inv, device):
         torch.manual_seed(0)
         keys_total = set(keys + keys_inv)
-        double2float = DoubleToFloat(keys_in=keys, keys_inv_in=keys_inv)
+        double2float = DoubleToFloat(in_keys=keys, in_keys_inv=keys_inv)
         dont_touch = torch.randn(1, 3, 3, dtype=torch.double, device=device)
         td = TensorDict(
             {
@@ -1066,7 +1066,7 @@ class TestTransforms:
         ],
     )
     def test_cattensors(self, keys, device):
-        cattensors = CatTensors(keys_in=keys, out_key="observation_out", dim=-2)
+        cattensors = CatTensors(in_keys=keys, out_key="observation_out", dim=-2)
 
         dont_touch = torch.randn(1, 3, 3, dtype=torch.double, device=device)
         td = TensorDict(
@@ -1235,7 +1235,7 @@ class TestTransforms:
             keys_total = set([])
         else:
             keys_total = set(keys)
-        reward_scaling = RewardScaling(keys_in=keys, scale=scale, loc=loc)
+        reward_scaling = RewardScaling(in_keys=keys, scale=scale, loc=loc)
         td = TensorDict(
             {
                 **{key: torch.randn(*batch, 1, device=device) for key in keys_total},
@@ -1276,7 +1276,7 @@ class TestTransforms:
         key = list(obs_spec.keys())[0]
 
         env = TransformedEnv(env)
-        env.append_transform(CatFrames(N=4, cat_dim=-1, keys_in=[key]))
+        env.append_transform(CatFrames(N=4, cat_dim=-1, in_keys=[key]))
         assert isinstance(env.transform, Compose)
         assert len(env.transform) == 1
         obs_spec = env.observation_spec
@@ -1301,7 +1301,7 @@ class TestTransforms:
         assert env._observation_spec is not None
         assert env._reward_spec is not None
 
-        env.insert_transform(0, CatFrames(N=4, cat_dim=-1, keys_in=[key]))
+        env.insert_transform(0, CatFrames(N=4, cat_dim=-1, in_keys=[key]))
 
         # transformed envs do not have spec after insert -- they need to be computed
         assert env._input_spec is None
@@ -1348,7 +1348,7 @@ class TestTransforms:
         assert env._observation_spec is None
         assert env._reward_spec is None
 
-        env.insert_transform(-5, CatFrames(N=4, cat_dim=-1, keys_in=[key]))
+        env.insert_transform(-5, CatFrames(N=4, cat_dim=-1, in_keys=[key]))
         assert isinstance(env.transform, Compose)
         assert len(env.transform) == 6
 
@@ -1411,7 +1411,7 @@ class TestR3M:
         keys_out = ["next_vec"]
         r3m = R3MTransform(
             model,
-            keys_in=keys_in,
+            in_keys=keys_in,
             keys_out=keys_out,
             tensor_pixels_keys=tensor_pixels_key,
         )
@@ -1442,7 +1442,7 @@ class TestR3M:
         keys_out = ["next_vec"] if stack_images else ["next_vec", "next_vec2"]
         r3m = R3MTransform(
             model,
-            keys_in=keys_in,
+            in_keys=keys_in,
             keys_out=keys_out,
             stack_images=stack_images,
         )
@@ -1492,7 +1492,7 @@ class TestR3M:
         tensor_pixels_key = None
         r3m = R3MTransform(
             model,
-            keys_in=keys_in,
+            in_keys=keys_in,
             keys_out=keys_out,
             tensor_pixels_keys=tensor_pixels_key,
         )
@@ -1566,7 +1566,7 @@ class TestR3M:
         keys_out = ["next_vec"]
         r3m = R3MTransform(
             model,
-            keys_in=keys_in,
+            in_keys=keys_in,
             keys_out=keys_out,
             tensor_pixels_keys=tensor_pixels_key,
         )
@@ -1592,7 +1592,7 @@ class TestVIP:
         keys_out = ["next_vec"]
         vip = VIPTransform(
             model,
-            keys_in=keys_in,
+            in_keys=keys_in,
             keys_out=keys_out,
             tensor_pixels_keys=tensor_pixels_key,
         )
@@ -1617,7 +1617,7 @@ class TestVIP:
         keys_out = ["next_vec"] if stack_images else ["next_vec", "next_vec2"]
         vip = VIPTransform(
             model,
-            keys_in=keys_in,
+            in_keys=keys_in,
             keys_out=keys_out,
             stack_images=stack_images,
         )
@@ -1667,7 +1667,7 @@ class TestVIP:
         tensor_pixels_key = None
         vip = VIPTransform(
             model,
-            keys_in=keys_in,
+            in_keys=keys_in,
             keys_out=keys_out,
             tensor_pixels_keys=tensor_pixels_key,
         )
@@ -1741,7 +1741,7 @@ class TestVIP:
         keys_out = ["next_vec"]
         vip = VIPTransform(
             model,
-            keys_in=keys_in,
+            in_keys=keys_in,
             keys_out=keys_out,
             tensor_pixels_keys=tensor_pixels_key,
         )
@@ -1762,7 +1762,7 @@ def test_batch_locked_transformed(device):
     env = TransformedEnv(
         MockBatchedLockedEnv(device),
         Compose(
-            ObservationNorm(keys_in=["next_observation"], loc=0.5, scale=1.1),
+            ObservationNorm(in_keys=["next_observation"], loc=0.5, scale=1.1),
             RewardClipping(0, 0.1),
         ),
     )
@@ -1786,7 +1786,7 @@ def test_batch_unlocked_transformed(device):
     env = TransformedEnv(
         MockBatchedUnLockedEnv(device),
         Compose(
-            ObservationNorm(keys_in=["next_observation"], loc=0.5, scale=1.1),
+            ObservationNorm(in_keys=["next_observation"], loc=0.5, scale=1.1),
             RewardClipping(0, 0.1),
         ),
     )
@@ -1806,7 +1806,7 @@ def test_batch_unlocked_with_batch_size_transformed(device):
     env = TransformedEnv(
         MockBatchedUnLockedEnv(device, batch_size=torch.Size([2])),
         Compose(
-            ObservationNorm(keys_in=["next_observation"], loc=0.5, scale=1.1),
+            ObservationNorm(in_keys=["next_observation"], loc=0.5, scale=1.1),
             RewardClipping(0, 0.1),
         ),
     )

--- a/torchrl/envs/transforms/r3m.py
+++ b/torchrl/envs/transforms/r3m.py
@@ -61,7 +61,7 @@ class _R3MNet(Transform):
                 f"model {model_name} is currently not supported by R3M"
             )
         convnet.fc = Identity()
-        super().__init__(keys_in=in_keys, keys_out=out_keys)
+        super().__init__(in_keys=in_keys, keys_out=out_keys)
         self.convnet = convnet
         self.del_keys = del_keys
 
@@ -69,7 +69,7 @@ class _R3MNet(Transform):
         tensordict_view = tensordict.view(-1)
         super()._call(tensordict_view)
         if self.del_keys:
-            tensordict.exclude(*self.keys_in, inplace=True)
+            tensordict.exclude(*self.in_keys, inplace=True)
         return tensordict
 
     @torch.no_grad()
@@ -87,7 +87,7 @@ class _R3MNet(Transform):
         if not isinstance(observation_spec, CompositeSpec):
             raise ValueError("_R3MNet can only infer CompositeSpec")
 
-        keys = [key for key in observation_spec._specs.keys() if key in self.keys_in]
+        keys = [key for key in observation_spec._specs.keys() if key in self.in_keys]
         device = observation_spec[keys[0]].device
 
         observation_spec = CompositeSpec(**observation_spec)
@@ -152,14 +152,14 @@ class R3MTransform(Compose):
     can ensure that the following code snippet works as expected:
 
     Examples:
-        >>> transform = R3MTransform("resenet50", keys_in=["next_pixels"])
+        >>> transform = R3MTransform("resenet50", in_keys=["next_pixels"])
         >>> env.append_transform(transform)
         >>> # the forward method will first call _init which will look at env.observation_spec
         >>> env.reset()
 
     Args:
         model_name (str): one of resnet50, resnet34 or resnet18
-        keys_in (list of str, optional): list of input keys. If left empty, the
+        in_keys (list of str, optional): list of input keys. If left empty, the
             "next_pixels" key is assumed.
         keys_out (list of str, optional): list of output keys. If left empty,
              "next_r3m_vec" is assumed.
@@ -186,7 +186,7 @@ class R3MTransform(Compose):
     def __init__(
         self,
         model_name: str,
-        keys_in: List[str] = None,
+        in_keys: List[str] = None,
         keys_out: List[str] = None,
         size: int = 244,
         stack_images: bool = True,
@@ -195,7 +195,7 @@ class R3MTransform(Compose):
         tensor_pixels_keys: List[str] = None,
     ):
         super().__init__()
-        self.keys_in = keys_in
+        self.keys_in = in_keys
         self.download = download
         self.download_path = download_path
         self.model_name = model_name
@@ -218,7 +218,7 @@ class R3MTransform(Compose):
             for i in range(len(keys_in)):
                 transforms.append(
                     CatTensors(
-                        keys_in=[keys_in[i]],
+                        in_keys=[keys_in[i]],
                         out_key=tensor_pixels_keys[i],
                         del_keys=False,
                     )
@@ -226,7 +226,7 @@ class R3MTransform(Compose):
 
         totensor = ToTensorImage(
             unsqueeze=False,
-            keys_in=keys_in,
+            in_keys=keys_in,
         )
         transforms.append(totensor)
 
@@ -234,7 +234,7 @@ class R3MTransform(Compose):
         mean = [0.485, 0.456, 0.406]
         std = [0.229, 0.224, 0.225]
         normalize = ObservationNorm(
-            keys_in=keys_in,
+            in_keys=keys_in,
             loc=torch.tensor(mean).view(3, 1, 1),
             scale=torch.tensor(std).view(3, 1, 1),
             standard_normal=True,
@@ -242,7 +242,7 @@ class R3MTransform(Compose):
         transforms.append(normalize)
 
         # Resize: note that resize is a no-op if the tensor has the desired size already
-        resize = Resize(size, size, keys_in=keys_in)
+        resize = Resize(size, size, in_keys=keys_in)
         transforms.append(resize)
 
         # R3M
@@ -257,13 +257,13 @@ class R3MTransform(Compose):
             )
         elif not stack_images and len(keys_out) != len(keys_in):
             raise ValueError(
-                "key_out must be of length equal to keys_in if stack_images is False."
+                "key_out must be of length equal to in_keys if stack_images is False."
             )
 
         if stack_images and len(keys_in) > 1:
             if self.is_3d:
                 unsqueeze = UnsqueezeTransform(
-                    keys_in=keys_in,
+                    in_keys=keys_in,
                     keys_out=keys_in,
                     unsqueeze_dim=-4,
                 )

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1598,7 +1598,7 @@ class CatTensors(Transform):
 
     def _check_in_keys(self, in_keys, out_key):
         if not out_key.startswith("next_") and all(
-                key.startswith("next_") for key in in_keys
+            key.startswith("next_") for key in in_keys
         ):
             warn(
                 f"It seems that 'next_'-like keys are being concatenated to a non 'next_' key {out_key}. This may result in unwanted behaviours, and the 'next_' flag is missing from the output key."

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -50,9 +50,9 @@ def _apply_to_composite(function):
     def new_fun(self, observation_spec):
         if isinstance(observation_spec, CompositeSpec):
             d = observation_spec._specs
-            for key_in, key_out in zip(self.keys_in, self.keys_out):
-                if key_in in observation_spec.keys():
-                    d[key_out] = function(self, observation_spec[key_in])
+            for in_key, key_out in zip(self.in_keys, self.keys_out):
+                if in_key in observation_spec.keys():
+                    d[key_out] = function(self, observation_spec[in_key])
             return CompositeSpec(**d)
         else:
             return function(self, observation_spec)
@@ -89,21 +89,21 @@ class Transform(nn.Module):
 
     def __init__(
         self,
-        keys_in: Sequence[str],
+        in_keys: Sequence[str],
         keys_out: Optional[Sequence[str]] = None,
-        keys_inv_in: Optional[Sequence[str]] = None,
+        in_keys_inv: Optional[Sequence[str]] = None,
         keys_inv_out: Optional[Sequence[str]] = None,
     ):
         super().__init__()
-        self.keys_in = keys_in
+        self.in_keys = in_keys
         if keys_out is None:
-            keys_out = copy(self.keys_in)
+            keys_out = copy(self.in_keys)
         self.keys_out = keys_out
-        if keys_inv_in is None:
-            keys_inv_in = []
-        self.keys_inv_in = keys_inv_in
+        if in_keys_inv is None:
+            in_keys_inv = []
+        self.in_keys_inv = in_keys_inv
         if keys_inv_out is None:
-            keys_inv_out = copy(self.keys_inv_in)
+            keys_inv_out = copy(self.in_keys_inv)
         self.keys_inv_out = keys_inv_out
         self.__dict__["_parent"] = None
 
@@ -133,7 +133,7 @@ class Transform(nn.Module):
     def _call(self, tensordict: TensorDictBase) -> TensorDictBase:
         """Reads the input tensordict, and for the selected keys, applies the transform."""
         self._check_inplace()
-        for key_in, key_out in zip(self.keys_in, self.keys_out):
+        for key_in, key_out in zip(self.in_keys, self.keys_out):
             if key_in in tensordict.keys():
                 observation = self._apply_transform(tensordict.get(key_in))
                 tensordict.set(key_out, observation, inplace=self.inplace)
@@ -151,7 +151,7 @@ class Transform(nn.Module):
 
     def _inv_call(self, tensordict: TensorDictBase) -> TensorDictBase:
         self._check_inplace()
-        for key_in, key_out in zip(self.keys_inv_in, self.keys_inv_out):
+        for key_in, key_out in zip(self.in_keys_inv, self.keys_inv_out):
             if key_in in tensordict.keys():
                 observation = self._inv_apply_transform(tensordict.get(key_in))
                 tensordict.set(key_out, observation, inplace=self.inplace)
@@ -201,7 +201,7 @@ class Transform(nn.Module):
         pass
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(keys={self.keys_in})"
+        return f"{self.__class__.__name__}(keys={self.in_keys})"
 
     def set_parent(self, parent: Union[Transform, EnvBase]) -> None:
         if self.__dict__["_parent"] is not None:
@@ -580,16 +580,16 @@ class ObservationTransform(Transform):
 
     def __init__(
         self,
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
         keys_out: Optional[Sequence[str]] = None,
     ):
-        if keys_in is None:
-            keys_in = [
+        if in_keys is None:
+            in_keys = [
                 "next_observation",
                 "next_pixels",
                 "next_observation_state",
             ]
-        super(ObservationTransform, self).__init__(keys_in=keys_in, keys_out=keys_out)
+        super(ObservationTransform, self).__init__(in_keys=in_keys, keys_out=keys_out)
 
 
 class Compose(Transform):
@@ -606,7 +606,7 @@ class Compose(Transform):
     inplace = False
 
     def __init__(self, *transforms: Transform):
-        super().__init__(keys_in=[])
+        super().__init__(in_keys=[])
         self.transforms = nn.ModuleList(transforms)
         for t in self.transforms:
             t.set_parent(self)
@@ -720,7 +720,7 @@ class ToTensorImage(ObservationTransform):
             observations.
 
     Examples:
-        >>> transform = ToTensorImage(keys_in=["next_pixels"])
+        >>> transform = ToTensorImage(in_keys=["next_pixels"])
         >>> ri = torch.randint(0, 255, (1,1,10,11,3), dtype=torch.uint8)
         >>> td = TensorDict(
         ...     {"next_pixels": ri},
@@ -737,12 +737,12 @@ class ToTensorImage(ObservationTransform):
         self,
         unsqueeze: bool = False,
         dtype: Optional[torch.device] = None,
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
         keys_out: Optional[Sequence[str]] = None,
     ):
-        if keys_in is None:
-            keys_in = IMAGE_KEYS  # default
-        super().__init__(keys_in=keys_in, keys_out=keys_out)
+        if in_keys is None:
+            in_keys = IMAGE_KEYS  # default
+        super().__init__(in_keys=in_keys, keys_out=keys_out)
         self.unsqueeze = unsqueeze
         self.dtype = dtype if dtype is not None else torch.get_default_dtype()
 
@@ -791,12 +791,12 @@ class RewardClipping(Transform):
         self,
         clamp_min: float = None,
         clamp_max: float = None,
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
         keys_out: Optional[Sequence[str]] = None,
     ):
-        if keys_in is None:
-            keys_in = ["reward"]
-        super().__init__(keys_in=keys_in, keys_out=keys_out)
+        if in_keys is None:
+            in_keys = ["reward"]
+        super().__init__(in_keys=in_keys, keys_out=keys_out)
         clamp_min_tensor = (
             clamp_min if isinstance(clamp_min, Tensor) else torch.tensor(clamp_min)
         )
@@ -834,7 +834,7 @@ class RewardClipping(Transform):
         return (
             f"{self.__class__.__name__}("
             f"clamp_min={float(self.clamp_min):4.4f}, clamp_max"
-            f"={float(self.clamp_max):4.4f}, keys={self.keys_in})"
+            f"={float(self.clamp_max):4.4f}, keys={self.in_keys})"
         )
 
 
@@ -845,12 +845,12 @@ class BinarizeReward(Transform):
 
     def __init__(
         self,
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
         keys_out: Optional[Sequence[str]] = None,
     ):
-        if keys_in is None:
-            keys_in = ["reward"]
-        super().__init__(keys_in=keys_in, keys_out=keys_out)
+        if in_keys is None:
+            in_keys = ["reward"]
+        super().__init__(in_keys=in_keys, keys_out=keys_out)
 
     def _apply_transform(self, reward: torch.Tensor) -> torch.Tensor:
         if not reward.shape or reward.shape[-1] != 1:
@@ -879,7 +879,7 @@ class Resize(ObservationTransform):
         w: int,
         h: int,
         interpolation: str = "bilinear",
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
         keys_out: Optional[Sequence[str]] = None,
     ):
         if not _has_tv:
@@ -888,9 +888,9 @@ class Resize(ObservationTransform):
                 "torchvision implementation. "
                 "Consider installing this dependency."
             )
-        if keys_in is None:
-            keys_in = IMAGE_KEYS  # default
-        super().__init__(keys_in=keys_in, keys_out=keys_out)
+        if in_keys is None:
+            in_keys = IMAGE_KEYS  # default
+        super().__init__(in_keys=in_keys, keys_out=keys_out)
         self.w = int(w)
         self.h = int(h)
         self.interpolation = interpolation
@@ -929,7 +929,7 @@ class Resize(ObservationTransform):
         return (
             f"{self.__class__.__name__}("
             f"w={int(self.w)}, h={int(self.h)}, "
-            f"interpolation={self.interpolation}, keys={self.keys_in})"
+            f"interpolation={self.interpolation}, keys={self.in_keys})"
         )
 
 
@@ -947,11 +947,11 @@ class CenterCrop(ObservationTransform):
         self,
         w: int,
         h: int = None,
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
     ):
-        if keys_in is None:
-            keys_in = IMAGE_KEYS  # default
-        super().__init__(keys_in=keys_in)
+        if in_keys is None:
+            in_keys = IMAGE_KEYS  # default
+        super().__init__(in_keys=in_keys)
         self.w = w
         self.h = h if h else w
 
@@ -964,7 +964,7 @@ class CenterCrop(ObservationTransform):
             return CompositeSpec(
                 **{
                     key: self.transform_observation_spec(_obs_spec)
-                    if key in self.keys_in
+                    if key in self.in_keys
                     else _obs_spec
                     for key, _obs_spec in observation_spec._specs.items()
                 }
@@ -1005,11 +1005,11 @@ class FlattenObservation(ObservationTransform):
         self,
         first_dim: int = 0,
         last_dim: int = -3,
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
     ):
-        if keys_in is None:
-            keys_in = IMAGE_KEYS  # default
-        super().__init__(keys_in=keys_in)
+        if in_keys is None:
+            in_keys = IMAGE_KEYS  # default
+        super().__init__(in_keys=in_keys)
         self.first_dim = first_dim
         self.last_dim = last_dim
 
@@ -1020,7 +1020,7 @@ class FlattenObservation(ObservationTransform):
     def set_parent(self, parent: Union[Transform, EnvBase]) -> None:
         out = super().set_parent(parent)
         observation_spec = self.parent.observation_spec
-        for key in self.keys_in:
+        for key in self.in_keys:
             if key in observation_spec:
                 observation_spec = observation_spec[key]
                 if self.first_dim >= 0:
@@ -1069,17 +1069,17 @@ class UnsqueezeTransform(Transform):
     def __init__(
         self,
         unsqueeze_dim: int,
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
         keys_out: Optional[Sequence[str]] = None,
-        keys_inv_in: Optional[Sequence[str]] = None,
+        in_keys_inv: Optional[Sequence[str]] = None,
         keys_inv_out: Optional[Sequence[str]] = None,
     ):
-        if keys_in is None:
-            keys_in = IMAGE_KEYS  # default
+        if in_keys is None:
+            in_keys = IMAGE_KEYS  # default
         super().__init__(
-            keys_in=keys_in,
+            in_keys=in_keys,
             keys_out=keys_out,
-            keys_inv_in=keys_inv_in,
+            in_keys_inv=in_keys_inv,
             keys_inv_out=keys_inv_out,
         )
         self._unsqueeze_dim_orig = unsqueeze_dim
@@ -1133,12 +1133,12 @@ class UnsqueezeTransform(Transform):
         return spec
 
     def transform_input_spec(self, input_spec: TensorSpec) -> TensorSpec:
-        for key in self.keys_inv_in:
+        for key in self.in_keys_inv:
             input_spec = self._transform_spec(input_spec[key])
         return input_spec
 
     def transform_reward_spec(self, reward_spec: TensorSpec) -> TensorSpec:
-        if "reward" in self.keys_in:
+        if "reward" in self.in_keys:
             reward_spec = self._transform_spec(reward_spec)
         return reward_spec
 
@@ -1149,8 +1149,8 @@ class UnsqueezeTransform(Transform):
 
     def __repr__(self) -> str:
         s = (
-            f"{self.__class__.__name__}(keys_in={self.keys_in}, keys_out={self.keys_out},"
-            f" keys_inv_in={self.keys_inv_in}, keys_inv_out={self.keys_inv_out})"
+            f"{self.__class__.__name__}(in_keys={self.in_keys}, keys_out={self.keys_out},"
+            f" keys_inv_in={self.in_keys_inv}, keys_inv_out={self.keys_inv_out})"
         )
         return s
 
@@ -1168,16 +1168,16 @@ class SqueezeTransform(UnsqueezeTransform):
     def __init__(
         self,
         squeeze_dim: int,
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
         keys_out: Optional[Sequence[str]] = None,
-        keys_inv_in: Optional[Sequence[str]] = None,
+        in_keys_inv: Optional[Sequence[str]] = None,
         keys_inv_out: Optional[Sequence[str]] = None,
     ):
         super().__init__(
             unsqueeze_dim=squeeze_dim,
-            keys_in=keys_inv_in,
+            in_keys=in_keys_inv,
             keys_out=keys_out,
-            keys_inv_in=keys_in,
+            in_keys_inv=in_keys,
             keys_inv_out=keys_inv_out,
         )
 
@@ -1197,10 +1197,10 @@ class GrayScale(ObservationTransform):
 
     inplace = False
 
-    def __init__(self, keys_in: Optional[Sequence[str]] = None):
-        if keys_in is None:
-            keys_in = IMAGE_KEYS
-        super(GrayScale, self).__init__(keys_in=keys_in)
+    def __init__(self, in_keys: Optional[Sequence[str]] = None):
+        if in_keys is None:
+            in_keys = IMAGE_KEYS
+        super(GrayScale, self).__init__(in_keys=in_keys)
 
     def _apply_transform(self, observation: torch.Tensor) -> torch.Tensor:
         observation = F.rgb_to_grayscale(observation)
@@ -1245,7 +1245,7 @@ class ObservationNorm(ObservationTransform):
         >>> transform = ObservationNorm(
         ...     loc = td.get('next_obs').mean(0),
         ...     scale = td.get('next_obs').std(0),
-        ...     keys_in=["next_obs"],
+        ...     in_keys=["next_obs"],
         ...     standard_normal=True)
         >>> _ = transform(td)
         >>> print(torch.isclose(td.get('next_obs').mean(0),
@@ -1263,17 +1263,17 @@ class ObservationNorm(ObservationTransform):
         self,
         loc: Union[float, torch.Tensor],
         scale: Union[float, torch.Tensor],
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
         # observation_spec_key: =None,
         standard_normal: bool = False,
     ):
-        if keys_in is None:
-            keys_in = [
+        if in_keys is None:
+            in_keys = [
                 "next_observation",
                 "next_pixels",
                 "next_observation_state",
             ]
-        super().__init__(keys_in=keys_in)
+        super().__init__(in_keys=in_keys)
         if not isinstance(loc, torch.Tensor):
             loc = torch.tensor(loc, dtype=torch.float)
         if not isinstance(scale, torch.Tensor):
@@ -1308,7 +1308,7 @@ class ObservationNorm(ObservationTransform):
             return (
                 f"{self.__class__.__name__}("
                 f"loc={float(self.loc):4.4f}, scale"
-                f"={float(self.scale):4.4f}, keys={self.keys_in})"
+                f"={float(self.scale):4.4f}, keys={self.in_keys})"
             )
         else:
             return super().__repr__()
@@ -1329,7 +1329,7 @@ class CatFrames(ObservationTransform):
             Default is `4`.
         cat_dim (int, optional): dimension along which concatenate the
             observations. Default is `cat_dim=-3`.
-        keys_in (list of int, optional): keys pointing to the frames that have
+        in_keys (list of int, optional): keys pointing to the frames that have
             to be concatenated.
 
     """
@@ -1340,11 +1340,11 @@ class CatFrames(ObservationTransform):
         self,
         N: int = 4,
         cat_dim: int = -3,
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
     ):
-        if keys_in is None:
-            keys_in = IMAGE_KEYS
-        super().__init__(keys_in=keys_in)
+        if in_keys is None:
+            in_keys = IMAGE_KEYS
+        super().__init__(in_keys=in_keys)
         self.N = N
         self.cat_dim = cat_dim
         self.buffer = []
@@ -1380,7 +1380,7 @@ class CatFrames(ObservationTransform):
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(N={self.N}, cat_dim"
-            f"={self.cat_dim}, keys={self.keys_in})"
+            f"={self.cat_dim}, keys={self.in_keys})"
         )
 
 
@@ -1403,11 +1403,11 @@ class RewardScaling(Transform):
         self,
         loc: Union[float, torch.Tensor],
         scale: Union[float, torch.Tensor],
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
     ):
-        if keys_in is None:
-            keys_in = ["reward"]
-        super().__init__(keys_in=keys_in)
+        if in_keys is None:
+            in_keys = ["reward"]
+        super().__init__(in_keys=in_keys)
         if not isinstance(loc, torch.Tensor):
             loc = torch.tensor(loc)
         if not isinstance(scale, torch.Tensor):
@@ -1434,7 +1434,7 @@ class RewardScaling(Transform):
         return (
             f"{self.__class__.__name__}("
             f"loc={self.loc.item():4.4f}, scale={self.scale.item():4.4f}, "
-            f"keys={self.keys_in})"
+            f"keys={self.in_keys})"
         )
 
 
@@ -1444,7 +1444,7 @@ class FiniteTensorDictCheck(Transform):
     inplace = False
 
     def __init__(self):
-        super().__init__(keys_in=[])
+        super().__init__(in_keys=[])
 
     def _call(self, tensordict: TensorDictBase) -> TensorDictBase:
         source = {}
@@ -1467,7 +1467,7 @@ class DoubleToFloat(Transform):
     Examples:
         >>> td = TensorDict(
         ...     {'next_obs': torch.ones(1, dtype=torch.double)}, [])
-        >>> transform = DoubleToFloat(keys_in=["next_obs"])
+        >>> transform = DoubleToFloat(in_keys=["next_obs"])
         >>> _ = transform(td)
         >>> print(td.get("next_obs").dtype)
         torch.float32
@@ -1479,10 +1479,10 @@ class DoubleToFloat(Transform):
 
     def __init__(
         self,
-        keys_in: Optional[Sequence[str]] = None,
-        keys_inv_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
+        in_keys_inv: Optional[Sequence[str]] = None,
     ):
-        super().__init__(keys_in=keys_in, keys_inv_in=keys_inv_in)
+        super().__init__(in_keys=in_keys, in_keys_inv=in_keys_inv)
 
     def _apply_transform(self, obs: torch.Tensor) -> torch.Tensor:
         return obs.to(torch.float)
@@ -1502,7 +1502,7 @@ class DoubleToFloat(Transform):
                 space.maximum = space.maximum.to(torch.float)
 
     def transform_input_spec(self, input_spec: TensorSpec) -> TensorSpec:
-        for key in self.keys_inv_in:
+        for key in self.in_keys_inv:
             if input_spec[key].dtype is not torch.double:
                 raise TypeError(
                     f"input_spec[{key}].dtype is not double: {input_spec[key].dtype}"
@@ -1511,7 +1511,7 @@ class DoubleToFloat(Transform):
         return input_spec
 
     def transform_reward_spec(self, reward_spec: TensorSpec) -> TensorSpec:
-        if "reward" in self.keys_in:
+        if "reward" in self.in_keys:
             if reward_spec.dtype is not torch.double:
                 raise TypeError("reward_spec.dtype is not double")
 
@@ -1525,8 +1525,8 @@ class DoubleToFloat(Transform):
 
     def __repr__(self) -> str:
         s = (
-            f"{self.__class__.__name__}(keys_in={self.keys_in}, keys_out={self.keys_out},"
-            f"keys_inv_in={self.keys_inv_in}, keys_inv_out={self.keys_inv_out})"
+            f"{self.__class__.__name__}(in_keys={self.in_keys}, keys_out={self.keys_out},"
+            f"keys_inv_in={self.in_keys_inv}, keys_inv_out={self.keys_inv_out})"
         )
         return s
 
@@ -1539,7 +1539,7 @@ class CatTensors(Transform):
     "observation_velocity")
 
     Args:
-        keys_in (Sequence of str): keys to be concatenated. If `None` (or not provided)
+        in_keys (Sequence of str): keys to be concatenated. If `None` (or not provided)
             the keys will be retrieved from the parent environment the first time
             the transform is used. This behaviour will only work if a parent is set.
         out_key: key of the resulting tensor.
@@ -1553,13 +1553,13 @@ class CatTensors(Transform):
             Default is False.
 
     Examples:
-        >>> transform = CatTensors(keys_in=["key1", "key2"])
+        >>> transform = CatTensors(in_keys=["key1", "key2"])
         >>> td = TensorDict({"key1": torch.zeros(1, 1),
         ...     "key2": torch.ones(1, 1)}, [1])
         >>> _ = transform(td)
         >>> print(td.get("observation_vector"))
         tensor([[0., 1.]])
-        >>> transform = CatTensors(keys_in=["key1", "key2"], dim=-2, unsqueeze_if_oor=True)
+        >>> transform = CatTensors(in_keys=["key1", "key2"], dim=-2, unsqueeze_if_oor=True)
         >>> td = TensorDict({"key1": torch.zeros(1),
         ...     "key2": torch.ones(1)}, [])
         >>> _ = transform(td)
@@ -1573,55 +1573,55 @@ class CatTensors(Transform):
 
     def __init__(
         self,
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
         out_key: str = "next_observation_vector",
         dim: int = -1,
         del_keys: bool = True,
         unsqueeze_if_oor: bool = False,
     ):
-        self._initialized = keys_in is not None
+        self._initialized = in_keys is not None
         if not self._initialized:
             if dim != -1:
                 raise ValueError(
                     "Lazy call to CatTensors is only supported when `dim=-1`."
                 )
         else:
-            keys_in = sorted(list(keys_in))
-            self._check_keys_in(keys_in, out_key)
+            in_keys = sorted(list(in_keys))
+            self._check_in_keys(in_keys, out_key)
         if type(out_key) != str:
             raise Exception("CatTensors requires out_key to be of type string")
-        # super().__init__(keys_in=keys_in)
-        super(CatTensors, self).__init__(keys_in=keys_in, keys_out=[out_key])
+        # super().__init__(in_keys=in_keys)
+        super(CatTensors, self).__init__(in_keys=in_keys, keys_out=[out_key])
         self.dim = dim
         self.del_keys = del_keys
         self.unsqueeze_if_oor = unsqueeze_if_oor
 
-    def _check_keys_in(self, keys_in, out_key):
+    def _check_in_keys(self, in_keys, out_key):
         if not out_key.startswith("next_") and all(
-            key.startswith("next_") for key in keys_in
+                key.startswith("next_") for key in in_keys
         ):
             warn(
                 f"It seems that 'next_'-like keys are being concatenated to a non 'next_' key {out_key}. This may result in unwanted behaviours, and the 'next_' flag is missing from the output key."
                 f"Consider renaming the out_key to 'next_{out_key}'"
             )
 
-    def _find_keys_in(self):
+    def _find_in_keys(self):
         parent = self.parent
         obs_spec = parent.observation_spec
-        keys_in = []
+        in_keys = []
         for key, value in obs_spec.items():
             if len(value.shape) == 1:
-                keys_in.append(key)
-        self._check_keys_in(keys_in, self.keys_out[0])
-        return sorted(keys_in)
+                in_keys.append(key)
+        self._check_in_keys(in_keys, self.keys_out[0])
+        return sorted(in_keys)
 
     def _call(self, tensordict: TensorDictBase) -> TensorDictBase:
         if not self._initialized:
-            self.keys_in = self._find_keys_in()
+            self.in_keys = self._find_in_keys()
             self._initialized = True
 
-        if all([key in tensordict.keys() for key in self.keys_in]):
-            values = [tensordict.get(key) for key in self.keys_in]
+        if all([key in tensordict.keys() for key in self.in_keys]):
+            values = [tensordict.get(key) for key in self.in_keys]
             if self.unsqueeze_if_oor:
                 pos_idx = self.dim > 0
                 abs_idx = self.dim if pos_idx else -self.dim - 1
@@ -1637,25 +1637,25 @@ class CatTensors(Transform):
             out_tensor = torch.cat(values, dim=self.dim)
             tensordict.set(self.keys_out[0], out_tensor)
             if self.del_keys:
-                tensordict.exclude(*self.keys_in, inplace=True)
+                tensordict.exclude(*self.in_keys, inplace=True)
         else:
             raise Exception(
                 f"CatTensor failed, as it expected input keys ="
-                f" {sorted(list(self.keys_in))} but got a TensorDict with keys"
+                f" {sorted(list(self.in_keys))} but got a TensorDict with keys"
                 f" {sorted(list(tensordict.keys()))}"
             )
         return tensordict
 
     def transform_observation_spec(self, observation_spec: TensorSpec) -> TensorSpec:
         # check that all keys are in observation_spec
-        if len(self.keys_in) > 1 and not isinstance(observation_spec, CompositeSpec):
+        if len(self.in_keys) > 1 and not isinstance(observation_spec, CompositeSpec):
             raise ValueError(
                 "CatTensor cannot infer the output observation spec as there are multiple input keys but "
                 "only one observation_spec."
             )
 
         if isinstance(observation_spec, CompositeSpec) and len(
-            [key for key in self.keys_in if key not in observation_spec]
+            [key for key in self.in_keys if key not in observation_spec]
         ):
             raise ValueError(
                 "CatTensor got a list of keys that does not match the keys in observation_spec. "
@@ -1666,7 +1666,7 @@ class CatTensors(Transform):
             # by def, there must be only one key
             return observation_spec
 
-        keys = [key for key in observation_spec._specs.keys() if key in self.keys_in]
+        keys = [key for key in observation_spec._specs.keys() if key in self.in_keys]
 
         sum_shape = sum(
             [
@@ -1688,13 +1688,13 @@ class CatTensors(Transform):
             device=device,
         )
         if self.del_keys:
-            for key in self.keys_in:
+            for key in self.in_keys:
                 del observation_spec[key]
         return observation_spec
 
     def __repr__(self) -> str:
         return (
-            f"{self.__class__.__name__}(in_keys={self.keys_in}, out_key"
+            f"{self.__class__.__name__}(in_keys={self.in_keys}, out_key"
             f"={self.keys_out[0]})"
         )
 
@@ -1755,7 +1755,7 @@ class DiscreteActionProjection(Transform):
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(max_N={self.max_n}, M={self.m}, "
-            f"keys={self.keys_in})"
+            f"keys={self.in_keys})"
         )
 
 
@@ -1975,7 +1975,7 @@ class gSDENoise(Transform):
         state_dim=None,
         action_dim=None,
     ) -> None:
-        super().__init__(keys_in=[])
+        super().__init__(in_keys=[])
         self.state_dim = state_dim
         self.action_dim = action_dim
 
@@ -2020,7 +2020,7 @@ class VecNorm(Transform):
     observations, one should substitute this layer by `vecnorm.to_observation_norm()`.
 
     Args:
-        keys_in (iterable of str, optional): keys to be updated.
+        in_keys (iterable of str, optional): keys to be updated.
             default: ["next_observation", "reward"]
         shared_td (TensorDictBase, optional): A shared tensordict containing the
             keys of the transform.
@@ -2052,7 +2052,7 @@ class VecNorm(Transform):
 
     def __init__(
         self,
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
         shared_td: Optional[TensorDictBase] = None,
         lock: mp.Lock = None,
         decay: float = 0.9999,
@@ -2060,9 +2060,9 @@ class VecNorm(Transform):
     ) -> None:
         if lock is None:
             lock = mp.Lock()
-        if keys_in is None:
-            keys_in = ["next_observation", "reward"]
-        super().__init__(keys_in)
+        if in_keys is None:
+            in_keys = ["next_observation", "reward"]
+        super().__init__(in_keys)
         self._td = shared_td
         if shared_td is not None and not (
             shared_td.is_shared() or shared_td.is_memmap()
@@ -2071,7 +2071,7 @@ class VecNorm(Transform):
                 "shared_td must be either in shared memory or a memmap " "tensordict."
             )
         if shared_td is not None:
-            for key in keys_in:
+            for key in in_keys:
                 if (
                     (key + "_sum" not in shared_td.keys())
                     or (key + "_ssq" not in shared_td.keys())
@@ -2090,7 +2090,7 @@ class VecNorm(Transform):
         if self.lock is not None:
             self.lock.acquire()
 
-        for key in self.keys_in:
+        for key in self.in_keys:
             if key not in tensordict.keys():
                 continue
             self._init(tensordict, key)
@@ -2156,7 +2156,7 @@ class VecNorm(Transform):
     def to_observation_norm(self) -> Union[Compose, ObservationNorm]:
         """Converts VecNorm into an ObservationNorm class that can be used at inference time."""
         out = []
-        for key in self.keys_in:
+        for key in self.in_keys:
             _sum = self._td.get(key + "_sum")
             _ssq = self._td.get(key + "_ssq")
             _count = self._td.get(key + "_count")
@@ -2167,9 +2167,9 @@ class VecNorm(Transform):
                 loc=mean,
                 scale=std,
                 standard_normal=True,
-                keys_in=self.keys_in,
+                in_keys=self.in_keys,
             )
-            if len(self.keys_in) == 1:
+            if len(self.in_keys) == 1:
                 return _out
             else:
                 out += ObservationNorm
@@ -2261,5 +2261,5 @@ class VecNorm(Transform):
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(decay={self.decay:4.4f},"
-            f"eps={self.eps:4.4f}, keys={self.keys_in})"
+            f"eps={self.eps:4.4f}, keys={self.in_keys})"
         )

--- a/torchrl/envs/transforms/vip.py
+++ b/torchrl/envs/transforms/vip.py
@@ -52,7 +52,7 @@ class _VIPNet(Transform):
             raise NotImplementedError(
                 f"model {model_name} is currently not supported by VIP"
             )
-        super().__init__(keys_in=in_keys, keys_out=out_keys)
+        super().__init__(in_keys=in_keys, keys_out=out_keys)
         self.convnet = convnet
         self.del_keys = del_keys
 
@@ -60,7 +60,7 @@ class _VIPNet(Transform):
         tensordict_view = tensordict.view(-1)
         super()._call(tensordict_view)
         if self.del_keys:
-            tensordict.exclude(*self.keys_in, inplace=True)
+            tensordict.exclude(*self.in_keys, inplace=True)
         return tensordict
 
     @torch.no_grad()
@@ -78,7 +78,7 @@ class _VIPNet(Transform):
         if not isinstance(observation_spec, CompositeSpec):
             raise ValueError("_VIPNet can only infer CompositeSpec")
 
-        keys = [key for key in observation_spec._specs.keys() if key in self.keys_in]
+        keys = [key for key in observation_spec._specs.keys() if key in self.in_keys]
         device = observation_spec[keys[0]].device
 
         observation_spec = CompositeSpec(**observation_spec)
@@ -133,7 +133,7 @@ class VIPTransform(Compose):
 
     Args:
         model_name (str): one of resnet50
-        keys_in (list of str, optional): list of input keys. If left empty, the
+        in_keys (list of str, optional): list of input keys. If left empty, the
             "next_pixels" key is assumed.
         keys_out (list of str, optional): list of output keys. If left empty,
              "next_vip_vec" is assumed.
@@ -160,7 +160,7 @@ class VIPTransform(Compose):
     def __init__(
         self,
         model_name: str,
-        keys_in: List[str] = None,
+        in_keys: List[str] = None,
         keys_out: List[str] = None,
         size: int = 244,
         stack_images: bool = True,
@@ -169,7 +169,7 @@ class VIPTransform(Compose):
         tensor_pixels_keys: List[str] = None,
     ):
         super().__init__()
-        self.keys_in = keys_in
+        self.keys_in = in_keys
         self.download = download
         self.download_path = download_path
         self.model_name = model_name
@@ -192,7 +192,7 @@ class VIPTransform(Compose):
             for i in range(len(keys_in)):
                 transforms.append(
                     CatTensors(
-                        keys_in=[keys_in[i]],
+                        in_keys=[keys_in[i]],
                         out_key=tensor_pixels_keys[i],
                         del_keys=False,
                     )
@@ -200,7 +200,7 @@ class VIPTransform(Compose):
 
         totensor = ToTensorImage(
             unsqueeze=False,
-            keys_in=keys_in,
+            in_keys=keys_in,
         )
         transforms.append(totensor)
 
@@ -208,7 +208,7 @@ class VIPTransform(Compose):
         mean = [0.485, 0.456, 0.406]
         std = [0.229, 0.224, 0.225]
         normalize = ObservationNorm(
-            keys_in=keys_in,
+            in_keys=keys_in,
             loc=torch.tensor(mean).view(3, 1, 1),
             scale=torch.tensor(std).view(3, 1, 1),
             standard_normal=True,
@@ -216,7 +216,7 @@ class VIPTransform(Compose):
         transforms.append(normalize)
 
         # Resize: note that resize is a no-op if the tensor has the desired size already
-        resize = Resize(size, size, keys_in=keys_in)
+        resize = Resize(size, size, in_keys=keys_in)
         transforms.append(resize)
 
         # VIP
@@ -231,13 +231,13 @@ class VIPTransform(Compose):
             )
         elif not stack_images and len(keys_out) != len(keys_in):
             raise ValueError(
-                "key_out must be of length equal to keys_in if stack_images is False."
+                "key_out must be of length equal to in_keys if stack_images is False."
             )
 
         if stack_images and len(keys_in) > 1:
             if self.is_3d:
                 unsqueeze = UnsqueezeTransform(
-                    keys_in=keys_in,
+                    in_keys=keys_in,
                     keys_out=keys_in,
                     unsqueeze_dim=-4,
                 )

--- a/torchrl/record/recorder.py
+++ b/torchrl/record/recorder.py
@@ -28,7 +28,7 @@ class VideoRecorder(ObservationTransform):
         logger (Logger): a Logger instance where the video
             should be written.
         tag (str): the video tag in the logger.
-        keys_in (Sequence[str], optional): keys to be read to produce the video.
+        in_keys (Sequence[str], optional): keys to be read to produce the video.
             Default is :obj:`"next_pixels"`.
         skip (int): frame interval in the output video.
             Default is 2.
@@ -43,16 +43,16 @@ class VideoRecorder(ObservationTransform):
         self,
         logger: Logger,
         tag: str,
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
         skip: int = 2,
         center_crop: Optional[int] = None,
         make_grid: bool = True,
         **kwargs,
     ) -> None:
-        if keys_in is None:
-            keys_in = ["next_pixels"]
+        if in_keys is None:
+            in_keys = ["next_pixels"]
 
-        super().__init__(keys_in=keys_in)
+        super().__init__(in_keys=in_keys)
         video_kwargs = {"fps": 6}
         video_kwargs.update(kwargs)
         self.video_kwargs = video_kwargs
@@ -150,12 +150,12 @@ class TensorDictRecorder(Transform):
         out_file_base: str,
         skip_reset: bool = True,
         skip: int = 4,
-        keys_in: Optional[Sequence[str]] = None,
+        in_keys: Optional[Sequence[str]] = None,
     ) -> None:
-        if keys_in is None:
-            keys_in = []
+        if in_keys is None:
+            in_keys = []
 
-        super().__init__(keys_in=keys_in)
+        super().__init__(in_keys=in_keys)
         self.iter = 0
         self.out_file_base = out_file_base
         self.td = []
@@ -167,8 +167,8 @@ class TensorDictRecorder(Transform):
         self.count += 1
         if self.count % self.skip == 0:
             _td = td
-            if self.keys_in:
-                _td = td.select(*self.keys_in).to_tensordict()
+            if self.in_keys:
+                _td = td.select(*self.in_keys).to_tensordict()
             self.td.append(_td)
         return td
 

--- a/torchrl/trainers/helpers/envs.py
+++ b/torchrl/trainers/helpers/envs.py
@@ -124,13 +124,13 @@ def make_env_transforms(
         if cfg.grayscale:
             env.append_transform(GrayScale())
         env.append_transform(FlattenObservation())
-        env.append_transform(CatFrames(N=cfg.catframes, keys_in=["next_pixels"]))
+        env.append_transform(CatFrames(N=cfg.catframes, in_keys=["next_pixels"]))
         if stats is None:
             obs_stats = {"loc": 0.0, "scale": 1.0}
         else:
             obs_stats = stats
         obs_stats["standard_normal"] = True
-        env.append_transform(ObservationNorm(**obs_stats, keys_in=["next_pixels"]))
+        env.append_transform(ObservationNorm(**obs_stats, in_keys=["next_pixels"]))
     if norm_rewards:
         reward_scaling = 1.0
         reward_loc = 0.0
@@ -160,7 +160,7 @@ def make_env_transforms(
 
         # even if there is a single tensor, it'll be renamed in "next_observation_vector"
         out_key = "next_observation_vector"
-        env.append_transform(CatTensors(keys_in=selected_keys, out_key=out_key))
+        env.append_transform(CatTensors(in_keys=selected_keys, out_key=out_key))
 
         if not vecnorm:
             if stats is None:
@@ -168,12 +168,12 @@ def make_env_transforms(
             else:
                 _stats = stats
             env.append_transform(
-                ObservationNorm(**_stats, keys_in=[out_key], standard_normal=True)
+                ObservationNorm(**_stats, in_keys=[out_key], standard_normal=True)
             )
         else:
             env.append_transform(
                 VecNorm(
-                    keys_in=[out_key, "reward"] if not _norm_obs_only else [out_key],
+                    in_keys=[out_key, "reward"] if not _norm_obs_only else [out_key],
                     decay=0.9999,
                 )
             )
@@ -181,19 +181,19 @@ def make_env_transforms(
         double_to_float_list.append(out_key)
         env.append_transform(
             DoubleToFloat(
-                keys_in=double_to_float_list, keys_inv_in=double_to_float_inv_list
+                in_keys=double_to_float_list, in_keys_inv=double_to_float_inv_list
             )
         )
 
         if hasattr(cfg, "catframes") and cfg.catframes:
             env.append_transform(
-                CatFrames(N=cfg.catframes, keys_in=[out_key], cat_dim=-1)
+                CatFrames(N=cfg.catframes, in_keys=[out_key], cat_dim=-1)
             )
 
     else:
         env.append_transform(
             DoubleToFloat(
-                keys_in=double_to_float_list, keys_inv_in=double_to_float_inv_list
+                in_keys=double_to_float_list, in_keys_inv=double_to_float_inv_list
             )
         )
 


### PR DESCRIPTION
## Description

Describe your changes in detail.
Refactoring change to fix the naming inconsistency of variables in different modules. In the transforms module and related module in RL renamed all useage of key_in to in_keys e.g. keys_inv_in becomes in_keys_inv 

## Motivation and Context

Working on this change to close https://github.com/pytorch/rl/issues/611. close #611 

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:
- [x] New feature (non-breaking change which adds core functionality)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
