### PR TITLE
[Feature] Move `transform.forward` to `transform.step`

### DIFF
--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -124,6 +124,8 @@ def test_dqn_maker(
             categorical_action_encoding=cfg.categorical_action_encoding
         )
 
+        print(proof_environment)
+        raise Exception
         actor = make_dqn_actor(proof_environment, cfg, device)
         td = proof_environment.reset().to(device)
         if UNSQUEEZE_SINGLETON and not td.ndimension():

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -124,8 +124,6 @@ def test_dqn_maker(
             categorical_action_encoding=cfg.categorical_action_encoding
         )
 
-        print(proof_environment)
-        raise Exception
         actor = make_dqn_actor(proof_environment, cfg, device)
         td = proof_environment.reset().to(device)
         if UNSQUEEZE_SINGLETON and not td.ndimension():

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -991,7 +991,7 @@ class TestTransforms:
         )
         ftd(td)
         td.set("inf", torch.zeros(1, 3).fill_(float("inf")))
-        with pytest.raises(ValueError, match="Found non-finite elements"):
+        with pytest.raises(ValueError, match="Encountered a non-finite tensor"):
             ftd(td)
 
     @pytest.mark.parametrize("device", get_available_devices())

--- a/torchrl/envs/transforms/utils.py
+++ b/torchrl/envs/transforms/utils.py
@@ -3,41 +3,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable, Optional, Tuple
 
 import torch
-from torch.utils._pytree import tree_map
 
 
-class FiniteTensor(torch.Tensor):
-    """A finite tensor.
-
-    If the data contained in this tensor contain non-finite values (nan or inf)
-    a :obj:`RuntimeError` will be thrown.
-
-    """
-
-    @staticmethod
-    def __new__(cls, elem: torch.Tensor, *args, **kwargs):
-        if not torch.isfinite(elem).all():
-            raise RuntimeError("FiniteTensor encountered a non-finite tensor.")
-        return torch.Tensor._make_subclass(cls, elem, elem.requires_grad)
-
-    def __repr__(self) -> str:
-        return f"FiniteTensor({super().__repr__()})"
-
-    @classmethod
-    def __torch_dispatch__(
-        cls,
-        func: Callable,
-        types,
-        args: Tuple = (),
-        kwargs: Optional[dict] = None,
-    ):
-        # TODO: also explicitly recheck invariants on inplace/out mutation
-        if kwargs:
-            raise Exception("Expected empty kwargs")
-        rs = func(*args)
-        return tree_map(
-            lambda e: FiniteTensor(e) if isinstance(e, torch.Tensor) else e, rs
-        )
+def check_finite(tensor: torch.Tensor):
+    if not tensor.isfinite().all():
+        raise ValueError("Encountered a non-finite tensor.")

--- a/torchrl/envs/transforms/utils.py
+++ b/torchrl/envs/transforms/utils.py
@@ -8,5 +8,6 @@ import torch
 
 
 def check_finite(tensor: torch.Tensor):
+    """Raise an error if a tensor has non-finite elements."""
     if not tensor.isfinite().all():
         raise ValueError("Encountered a non-finite tensor.")


### PR DESCRIPTION
## Description

Relies on `transform.step` instead of `forward` which we will reserve for Replay buffers.
`transform.step` will ultimately work on the `tensordict["next"]` nested tensordict only.