### PR TITLE
Relying on the standalone tensordict -- phase 1 updates

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,6 +54,9 @@ jobs:
       shell: bash
       run: |
         conda run -n build_binary python -m pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    - name: Install tensordict
+      run: |
+        python3 -mpip install git+https://github.com/pytorch-labs/tensordict.git
     - name: Install TorchRL
       run: |
         conda run -n build_binary python -m pip install -e .

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -217,6 +217,9 @@ jobs:
         run: |
           export PATH="/opt/python/${{ matrix.python_version[1] }}/bin:$PATH"
           python3 -mpip install --upgrade pip
+      - name: Install tensordict
+        run: |
+          python3 -mpip install git+https://github.com/pytorch-labs/tensordict.git
       - name: Install test dependencies
         run: |
           export PATH="/opt/python/${{ matrix.python_version[1] }}/bin:$PATH"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Upgrade pip
         run: |
           python3 -mpip install --upgrade pip
+      - name: Install tensordict
+        run: |
+          python3 -mpip install git+https://github.com/pytorch-labs/tensordict.git
       - name: Install test dependencies
         run: |
           python3 -mpip install numpy pytest pytest-cov codecov unittest-xml-reporting pillow>=4.1.1 scipy av networkx expecttest pyyaml

--- a/benchmarks/storage/benchmark_sample_latency_over_rpc.py
+++ b/benchmarks/storage/benchmark_sample_latency_over_rpc.py
@@ -18,6 +18,7 @@ from datetime import datetime
 
 import torch
 import torch.distributed.rpc as rpc
+from tensordict import TensorDict
 from torchrl.data.replay_buffers.rb_prototype import RemoteTensorDictReplayBuffer
 from torchrl.data.replay_buffers.samplers import RandomSampler
 from torchrl.data.replay_buffers.storages import (
@@ -26,7 +27,6 @@ from torchrl.data.replay_buffers.storages import (
     ListStorage,
 )
 from torchrl.data.replay_buffers.writers import RoundRobinWriter
-from torchrl.data.tensordict import TensorDict
 
 RETRY_LIMIT = 2
 RETRY_DELAY_SECS = 3

--- a/docs/source/reference/data.rst
+++ b/docs/source/reference/data.rst
@@ -89,6 +89,4 @@ Utils
     :toctree: generated/
     :template: rl_template.rst
 
-    utils.expand_as_right
-    utils.expand_right
     MultiStep

--- a/examples/distributed/distributed_replay_buffer.py
+++ b/examples/distributed/distributed_replay_buffer.py
@@ -15,12 +15,12 @@ import time
 
 import torch
 import torch.distributed.rpc as rpc
+from tensordict import TensorDict
 from torchrl.data.replay_buffers.rb_prototype import RemoteTensorDictReplayBuffer
 from torchrl.data.replay_buffers.samplers import RandomSampler
 from torchrl.data.replay_buffers.storages import LazyMemmapStorage
 from torchrl.data.replay_buffers.utils import accept_remote_rref_invocation
 from torchrl.data.replay_buffers.writers import RoundRobinWriter
-from torchrl.data.tensordict import TensorDict
 
 RETRY_LIMIT = 2
 RETRY_DELAY_SECS = 3

--- a/examples/torchrl_features/memmap_speed_distributed.py
+++ b/examples/torchrl_features/memmap_speed_distributed.py
@@ -9,7 +9,7 @@ import time
 import configargparse
 import torch
 import torch.distributed.rpc as rpc
-from torchrl.data.tensordict import MemmapTensor
+from tensordict import MemmapTensor
 
 parser = configargparse.ArgumentParser()
 parser.add_argument("--rank", default=-1, type=int)

--- a/test/smoke_test.py
+++ b/test/smoke_test.py
@@ -2,7 +2,6 @@ def test_imports():
     from torchrl.data import (  # noqa: F401
         PrioritizedReplayBuffer,
         ReplayBuffer,
-        TensorDict,
         TensorSpec,
     )
     from torchrl.envs import Transform, TransformedEnv  # noqa: F401

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -17,7 +17,7 @@ from mocking_classes import (
     DiscreteActionVecPolicy,
     MockSerialEnv,
 )
-from tensordict.tensordict import assert_allclose_td
+from tensordict.tensordict import TensorDict, assert_allclose_td
 from torch import nn
 from torchrl._utils import seed_generator
 from torchrl.collectors import aSyncDataCollector, SyncDataCollector
@@ -30,7 +30,6 @@ from torchrl.collectors.utils import split_trajectories
 from torchrl.data import (
     CompositeSpec,
     NdUnboundedContinuousTensorSpec,
-    TensorDict,
     UnboundedContinuousTensorSpec,
 )
 from torchrl.envs import EnvCreator, ParallelEnv, SerialEnv

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -25,19 +25,18 @@ from _utils_internal import get_available_devices
 from mocking_classes import ContinuousActionConvMockEnv
 
 # from torchrl.data.postprocs.utils import expand_as_right
-from tensordict.tensordict import assert_allclose_td, TensorDictBase
+from tensordict.tensordict import assert_allclose_td, TensorDictBase, TensorDict
+from tensordict.utils import expand_as_right
 from torch import autograd, nn
 from torchrl.data import (
     CompositeSpec,
     MultOneHotDiscreteTensorSpec,
     NdBoundedTensorSpec,
     NdUnboundedContinuousTensorSpec,
-    TensorDict,
     OneHotDiscreteTensorSpec,
     DiscreteTensorSpec,
 )
 from torchrl.data.postprocs.postprocs import MultiStep
-from torchrl.data.utils import expand_as_right
 from torchrl.envs.model_based.dreamer import DreamerEnv
 from torchrl.envs.transforms import TransformedEnv, TensorDictPrimer
 from torchrl.modules import (

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -653,7 +653,7 @@ class TestParallel:
         td_serial = env_serial.rollout(
             max_steps=10, auto_reset=False, tensordict=td0_serial
         ).contiguous()
-        key = "pixels" if "pixels" in td_serial else "observation"
+        key = "pixels" if "pixels" in td_serial.keys() else "observation"
         torch.testing.assert_close(
             td_serial[:, 0].get("next_" + key), td_serial[:, 1].get(key)
         )

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -9,11 +9,10 @@ import numpy as np
 import pytest
 import torch
 from _utils_internal import get_available_devices
-from tensordict.tensordict import assert_allclose_td, TensorDictBase
+from tensordict.tensordict import assert_allclose_td, TensorDictBase, TensorDict
 from torchrl.data import (
     PrioritizedReplayBuffer,
     ReplayBuffer,
-    TensorDict,
     TensorDictReplayBuffer,
 )
 from torchrl.data.replay_buffers import (

--- a/test/test_shared.py
+++ b/test/test_shared.py
@@ -8,8 +8,8 @@ import warnings
 
 import pytest
 import torch
+from tensordict import SavedTensorDict, TensorDict
 from torch import multiprocessing as mp
-from torchrl.data import SavedTensorDict, TensorDict
 
 
 class TestShared:

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -22,8 +22,8 @@ try:
 except ImportError:
     _has_tb = False
 
+from tensordict import TensorDict
 from torchrl.data import (
-    TensorDict,
     TensorDictPrioritizedReplayBuffer,
     TensorDictReplayBuffer,
     ListStorage,

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -14,13 +14,13 @@ from mocking_classes import (
     MockBatchedLockedEnv,
     MockBatchedUnLockedEnv,
 )
+from tensordict import TensorDict
 from torch import multiprocessing as mp, Tensor
 from torchrl._utils import prod
 from torchrl.data import (
     CompositeSpec,
     NdBoundedTensorSpec,
     NdUnboundedContinuousTensorSpec,
-    TensorDict,
     UnboundedContinuousTensorSpec,
 )
 from torchrl.envs import (

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -60,8 +60,8 @@ class RandomPolicy:
             action_spec: TensorSpec object describing the action specs
 
         Examples:
-            >>> from torchrl.data.tensor_specs import NdBoundedTensorSpec
             >>> from tensordict import TensorDict
+            >>> from torchrl.data.tensor_specs import NdBoundedTensorSpec
             >>> action_spec = NdBoundedTensorSpec(-torch.ones(3), torch.ones(3))
             >>> actor = RandomPolicy(spec=action_spec)
             >>> td = actor(TensorDict(batch_size=[])) # selects a random action in the cube [-1; 1]

--- a/torchrl/data/__init__.py
+++ b/torchrl/data/__init__.py
@@ -6,4 +6,3 @@
 from .postprocs import *
 from .replay_buffers import *
 from .tensor_specs import *
-from .tensordict import *

--- a/torchrl/data/postprocs/postprocs.py
+++ b/torchrl/data/postprocs/postprocs.py
@@ -9,10 +9,10 @@ from typing import Tuple
 
 import torch
 from tensordict.tensordict import TensorDictBase
+from tensordict.utils import expand_as_right
 from torch import nn
 from torch.nn import functional as F
 
-from torchrl.data.utils import expand_as_right
 
 __all__ = ["MultiStep"]
 

--- a/torchrl/data/tensordict/__init__.py
+++ b/torchrl/data/tensordict/__init__.py
@@ -1,6 +1,0 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-
-from tensordict import *  # noqa

--- a/torchrl/data/utils.py
+++ b/torchrl/data/utils.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import typing
-from typing import Any, Callable, List, Sequence, Tuple, Union
+from typing import Any, Callable, List, Tuple, Union
 
 import numpy as np
 import torch
@@ -61,66 +61,3 @@ class CloudpickleWrapper(object):
         kwargs = {k: item for k, item in kwargs.items()}
         kwargs.update(self.kwargs)
         return self.fn(**kwargs)
-
-
-def expand_as_right(
-    tensor: Union[torch.Tensor, "MemmapTensor", "TensorDictBase"],  # noqa: F821
-    dest: Union[torch.Tensor, "MemmapTensor", "TensorDictBase"],  # noqa: F821
-):
-    """Expand a tensor on the right to match another tensor shape.
-
-    Args:
-        tensor: tensor to be expanded
-        dest: tensor providing the target shape
-
-    Returns:
-         a tensor with shape matching the dest input tensor shape.
-
-    Examples:
-        >>> tensor = torch.zeros(3,4)
-        >>> dest = torch.zeros(3,4,5)
-        >>> print(expand_as_right(tensor, dest).shape)
-        torch.Size([3,4,5])
-
-    """
-    if dest.ndimension() < tensor.ndimension():
-        raise RuntimeError(
-            "expand_as_right requires the destination tensor to have less "
-            f"dimensions than the input tensor, got"
-            f" tensor.ndimension()={tensor.ndimension()} and "
-            f"dest.ndimension()={dest.ndimension()}"
-        )
-    if not (tensor.shape == dest.shape[: tensor.ndimension()]):
-        raise RuntimeError(
-            f"tensor shape is incompatible with dest shape, "
-            f"got: tensor.shape={tensor.shape}, dest={dest.shape}"
-        )
-    for _ in range(dest.ndimension() - tensor.ndimension()):
-        tensor = tensor.unsqueeze(-1)
-    return tensor.expand(dest.shape)
-
-
-def expand_right(
-    tensor: Union[torch.Tensor, "MemmapTensor"], shape: Sequence[int]  # noqa: F821
-) -> torch.Tensor:
-    """Expand a tensor on the right to match a desired shape.
-
-    Args:
-        tensor: tensor to be expanded
-        shape: target shape
-
-    Returns:
-         a tensor with shape matching the target shape.
-
-    Examples:
-        >>> tensor = torch.zeros(3,4)
-        >>> shape = (3,4,5)
-        >>> print(expand_right(tensor, shape).shape)
-        torch.Size([3,4,5])
-
-    """
-    tensor_expand = tensor
-    while tensor_expand.ndimension() < len(shape):
-        tensor_expand = tensor_expand.unsqueeze(-1)
-    tensor_expand = tensor_expand.expand(*shape)
-    return tensor_expand

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -13,9 +13,9 @@ from typing import Any, Callable, Iterator, Optional, Union, Dict, Sequence
 import numpy as np
 import torch
 import torch.nn as nn
-from tensordict.tensordict import TensorDictBase
+from tensordict.tensordict import TensorDictBase, TensorDict
 
-from torchrl.data import CompositeSpec, TensorDict, TensorSpec
+from torchrl.data import CompositeSpec, TensorSpec
 from .._utils import seed_generator, prod
 from ..data.utils import DEVICE_TYPING
 from .utils import get_available_libraries, step_mdp

--- a/torchrl/envs/model_based/common.py
+++ b/torchrl/envs/model_based/common.py
@@ -29,7 +29,8 @@ class ModelBasedEnvBase(EnvBase, metaclass=abc.ABCMeta):
 
     Example:
         >>> import torch
-        >>> from torchrl.data import TensorDict, CompositeSpec, NdUnboundedContinuousTensorSpec
+        >>> from tensordict import TensorDict
+        >>> from torchrl.data import CompositeSpec, NdUnboundedContinuousTensorSpec
         >>> class MyMBEnv(ModelBasedEnvBase):
         ...     def __init__(self, world_model, device="cpu", dtype=None, batch_size=None):
         ...         super().__init__(world_model, device=device, dtype=dtype, batch_size=batch_size)
@@ -51,8 +52,8 @@ class ModelBasedEnvBase(EnvBase, metaclass=abc.ABCMeta):
         ...         tensordict = tensordict.update(self.observation_spec.rand(self.batch_size))
         ...         return tensordict
         >>> # This environment is used as follows:
-        >>> from torchrl.modules import MLP, WorldModelWrapper
         >>> import torch.nn as nn
+        >>> from torchrl.modules import MLP, WorldModelWrapper
         >>> world_model = WorldModelWrapper(
         ...     TensorDictModule(
         ...         MLP(out_features=4, activation_class=nn.ReLU, activate_last_layer=True, depth=0),

--- a/torchrl/modules/models/exploration.py
+++ b/torchrl/modules/models/exploration.py
@@ -265,8 +265,8 @@ class gSDEModule(nn.Module):
         device (DEVICE_TYPING, optional): device to create the model on.
 
     Examples:
+        >>> from tensordict import TensorDict
         >>> from torchrl.modules import TensorDictModule, TensorDictSequential, ProbabilisticActor, TanhNormal
-        >>> from torchrl.data import TensorDict
         >>> batch, state_dim, action_dim = 3, 7, 5
         >>> model = nn.Linear(state_dim, action_dim)
         >>> deterministic_policy = TensorDictModule(model, in_keys=["obs"], out_keys=["action"])

--- a/torchrl/modules/planners/cem.py
+++ b/torchrl/modules/planners/cem.py
@@ -46,7 +46,8 @@ class CEMPlanner(MPCPlannerBase):
             the action. Defaults to "action"
 
     Examples:
-        >>> from torchrl.data import CompositeSpec, NdUnboundedContinuousTensorSpec, TensorDict
+        >>> from tensordict import TensorDict
+        >>> from torchrl.data import CompositeSpec, NdUnboundedContinuousTensorSpec
         >>> from torchrl.envs.model_based import ModelBasedEnvBase
         >>> from torchrl.modules import TensorDictModule
         >>> class MyMBEnv(ModelBasedEnvBase):

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -40,10 +40,10 @@ class Actor(TensorDictModule):
     automatically translated into :obj:`spec = CompositeSpec(action=spec)`
 
     Examples:
-        >>> from torchrl.data import TensorDict,
-        ...    NdUnboundedContinuousTensorSpec
-        >>> from torchrl.modules import Actor
         >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from torchrl.data import NdUnboundedContinuousTensorSpec
+        >>> from torchrl.modules import Actor
         >>> td = TensorDict({"observation": torch.randn(3, 4)}, [3,])
         >>> action_spec = NdUnboundedContinuousTensorSpec(4)
         >>> module = torch.nn.Linear(4, 4)
@@ -92,9 +92,11 @@ class ProbabilisticActor(ProbabilisticTensorDictModule):
     automatically translated into :obj:`spec = CompositeSpec(action=spec)`
 
     Examples:
-        >>> from torchrl.data import TensorDict, NdBoundedTensorSpec
+        >>> import functorch
+        >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from torchrl.data import NdBoundedTensorSpec
         >>> from torchrl.modules import Actor, TanhNormal, NormalParamWrapper
-        >>> import torch, functorch
         >>> td = TensorDict({"observation": torch.randn(3, 4)}, [3,])
         >>> action_spec = NdBoundedTensorSpec(shape=torch.Size([4]),
         ...    minimum=-1, maximum=1)
@@ -157,10 +159,12 @@ class ValueOperator(TensorDictModule):
     key is part of the in_keys list).
 
     Examples:
-        >>> from torchrl.data import TensorDict, NdUnboundedContinuousTensorSpec
-        >>> from torchrl.modules import ValueOperator
-        >>> import torch, functorch
+        >>> import functorch
+        >>> import torch
+        >>> from tensordict import TensorDict
         >>> from torch import nn
+        >>> from torchrl.data import NdUnboundedContinuousTensorSpec
+        >>> from torchrl.modules import ValueOperator
         >>> td = TensorDict({"observation": torch.randn(3, 4), "action": torch.randn(3, 2)}, [3,])
         >>> class CustomModule(nn.Module):
         ...     def __init__(self):
@@ -223,11 +227,11 @@ class QValueHook:
 
     Examples:
         >>> import functorch
-        >>> from torchrl.data import TensorDict, OneHotDiscreteTensorSpec
-        >>> from torchrl.modules.tensordict_module.actors import QValueHook, Actor
+        >>> import torch
+        >>> from tensordict import TensorDict
         >>> from torch import nn
-        >>> from torchrl.data import OneHotDiscreteTensorSpec, TensorDict
-        >>> import torch, functorch
+        >>> from torchrl.data import OneHotDiscreteTensorSpec
+        >>> from torchrl.modules.tensordict_module.actors import QValueHook, Actor
         >>> td = TensorDict({'observation': torch.randn(5, 4)}, [5])
         >>> module = nn.Linear(4, 4)
         >>> fmodule, params, buffers = functorch.make_functional_with_buffers(module)
@@ -338,10 +342,12 @@ class DistributionalQValueHook(QValueHook):
             action component.
 
     Examples:
-        >>> from torchrl.data import TensorDict, OneHotDiscreteTensorSpec
-        >>> from torchrl.modules.tensordict_module.actors import DistributionalQValueHook, Actor
+        >>> import functorch
+        >>> import torch
+        >>> from tensordict import TensorDict
         >>> from torch import nn
-        >>> import torch, functorch
+        >>> from torchrl.data import OneHotDiscreteTensorSpec
+        >>> from torchrl.modules.tensordict_module.actors import DistributionalQValueHook, Actor
         >>> td = TensorDict({'observation': torch.randn(5, 4)}, [5])
         >>> nbins = 3
         >>> class CustomDistributionalQval(nn.Module):
@@ -448,10 +454,12 @@ class QValueActor(Actor):
     This class hooks the module such that it returns a one-hot encoding of the argmax value.
 
     Examples:
-        >>> from torchrl.data import TensorDict, OneHotDiscreteTensorSpec
-        >>> from torchrl.modules.tensordict_module.actors import QValueActor
+        >>> import functorch
+        >>> import torch
+        >>> from tensordict import TensorDict
         >>> from torch import nn
-        >>> import torch, functorch
+        >>> from torchrl.data import OneHotDiscreteTensorSpec
+        >>> from torchrl.modules.tensordict_module.actors import QValueActor
         >>> td = TensorDict({'observation': torch.randn(5, 4)}, [5])
         >>> module = nn.Linear(4, 4)
         >>> fmodule, params, buffers = functorch.make_functional_with_buffers(module)
@@ -488,10 +496,12 @@ class DistributionalQValueActor(QValueActor):
     This class hooks the module such that it returns a one-hot encoding of the argmax value on its support.
 
     Examples:
-        >>> from torchrl.data import TensorDict, OneHotDiscreteTensorSpec
-        >>> from torchrl.modules import DistributionalQValueActor, MLP
+        >>> import functorch
+        >>> import torch
+        >>> from tensordict import TensorDict
         >>> from torch import nn
-        >>> import torch, functorch
+        >>> from torchrl.data import OneHotDiscreteTensorSpec
+        >>> from torchrl.modules import DistributionalQValueActor, MLP
         >>> td = TensorDict({'observation': torch.randn(5, 4)}, [5])
         >>> nbins = 3
         >>> module = MLP(out_features=(nbins, 4), depth=2)
@@ -570,10 +580,11 @@ class ActorValueOperator(TensorDictSequential):
         value_operator (TensorDictModule): a value operator, that reads the hidden variable and returns a value
 
     Examples:
-        >>> from torchrl.modules.tensordict_module import ProbabilisticActor
-        >>> from torchrl.data import TensorDict, NdUnboundedContinuousTensorSpec, NdBoundedTensorSpec
-        >>> from torchrl.modules import  ValueOperator, TanhNormal, ActorValueOperator, NormalParamWrapper
         >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from torchrl.modules.tensordict_module import ProbabilisticActor
+        >>> from torchrl.data import NdUnboundedContinuousTensorSpec, NdBoundedTensorSpec
+        >>> from torchrl.modules import ValueOperator, TanhNormal, ActorValueOperator, NormalParamWrapper
         >>> spec_hidden = NdUnboundedContinuousTensorSpec(4)
         >>> module_hidden = torch.nn.Linear(4, 4)
         >>> td_module_hidden = TensorDictModule(
@@ -695,10 +706,11 @@ class ActorCriticOperator(ActorValueOperator):
         value_operator (TensorDictModule): a value operator, that reads the hidden variable and returns a value
 
     Examples:
-        >>> from torchrl.modules.tensordict_module import ProbabilisticActor
-        >>> from torchrl.data import TensorDict, NdUnboundedContinuousTensorSpec, NdBoundedTensorSpec
-        >>> from torchrl.modules import  ValueOperator, TanhNormal, ActorCriticOperator, NormalParamWrapper, MLP
         >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from torchrl.modules.tensordict_module import ProbabilisticActor
+        >>> from torchrl.data import NdUnboundedContinuousTensorSpec, NdBoundedTensorSpec
+        >>> from torchrl.modules import  ValueOperator, TanhNormal, ActorCriticOperator, NormalParamWrapper, MLP
         >>> spec_hidden = NdUnboundedContinuousTensorSpec(4)
         >>> module_hidden = torch.nn.Linear(4, 4)
         >>> td_module_hidden = TensorDictModule(
@@ -824,9 +836,11 @@ class ActorCriticWrapper(TensorDictSequential):
         value_operator (TensorDictModule): a value operator, that reads the hidden variable and returns a value
 
     Examples:
-        >>> from torchrl.modules.tensordict_module.deprec import ProbabilisticActor_deprecated        >>> from torchrl.data import TensorDict, NdUnboundedContinuousTensorSpec, NdBoundedTensorSpec
-        >>> from torchrl.modules import  ValueOperator, TanhNormal, ActorCriticWrapper
         >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from torchrl.data import NdUnboundedContinuousTensorSpec, NdBoundedTensorSpec
+        >>> from torchrl.modules.tensordict_module.deprec import ProbabilisticActor_deprecated
+        >>> from torchrl.modules import ValueOperator, TanhNormal, ActorCriticWrapper
         >>> spec_action = NdBoundedTensorSpec(-1, 1, torch.Size([8]))
         >>> module_action = torch.nn.Linear(4, 8)
         >>> td_module_action = ProbabilisticActor_deprecated(

--- a/torchrl/modules/tensordict_module/common.py
+++ b/torchrl/modules/tensordict_module/common.py
@@ -122,9 +122,11 @@ class TensorDictModule(nn.Module):
         case, the 'params' (and 'buffers') keyword argument must be specified:
 
     Examples:
-        >>> from torchrl.data import TensorDict, NdUnboundedContinuousTensorSpec
+        >>> import functorch
+        >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from torchrl.data import NdUnboundedContinuousTensorSpec
         >>> from torchrl.modules import TensorDictModule
-        >>> import torch, functorch
         >>> td = TensorDict({"input": torch.randn(3, 4), "hidden": torch.randn(3, 8)}, [3,])
         >>> spec = NdUnboundedContinuousTensorSpec(8)
         >>> module = torch.nn.GRUCell(4, 8)
@@ -472,7 +474,8 @@ class TensorDictModule(nn.Module):
             A tuple of parameter and buffer tuples
 
         Examples:
-            >>> from torchrl.data import NdUnboundedContinuousTensorSpec, TensorDict
+            >>> from tensordict import TensorDict
+            >>> from torchrl.data import NdUnboundedContinuousTensorSpec
             >>> lazy_module = nn.LazyLinear(4)
             >>> spec = NdUnboundedContinuousTensorSpec(18)
             >>> td_module = TensorDictModule(lazy_module, spec, ["some_input"],
@@ -577,10 +580,11 @@ class TensorDictModuleWrapper(nn.Module):
     Examples:
         >>> #     This class can be used for exploration wrappers
         >>> import functorch
-        >>> from torchrl.modules import TensorDictModuleWrapper, TensorDictModule
-        >>> from torchrl.data import TensorDict, NdUnboundedContinuousTensorSpec
-        >>> from torchrl.data.utils import expand_as_right
         >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from tensordict.utils import expand_as_right
+        >>> from torchrl.data import NdUnboundedContinuousTensorSpec
+        >>> from torchrl.modules import TensorDictModuleWrapper, TensorDictModule
         >>>
         >>> class EpsilonGreedyExploration(TensorDictModuleWrapper):
         ...     eps = 0.5

--- a/torchrl/modules/tensordict_module/exploration.py
+++ b/torchrl/modules/tensordict_module/exploration.py
@@ -7,9 +7,9 @@ from typing import Optional, Union
 
 import numpy as np
 import torch
+from tensordict.utils import expand_as_right
 
 from torchrl.data import CompositeSpec, TensorSpec
-from torchrl.data.utils import expand_as_right
 from torchrl.envs.utils import exploration_mode
 from torchrl.modules.tensordict_module.common import (
     _forward_hook_safe_action,
@@ -45,9 +45,10 @@ class EGreedyWrapper(TensorDictModuleWrapper):
             the exploration wrapper will attempt to recover it from the policy.
 
     Examples:
-        >>> from torchrl.modules import EGreedyWrapper, Actor
-        >>> from torchrl.data import NdBoundedTensorSpec, TensorDict
         >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from torchrl.modules import EGreedyWrapper, Actor
+        >>> from torchrl.data import NdBoundedTensorSpec
         >>> torch.manual_seed(0)
         >>> spec = NdBoundedTensorSpec(-1, 1, torch.Size([4]))
         >>> module = torch.nn.Linear(4, 4, bias=False)
@@ -277,9 +278,10 @@ class OrnsteinUhlenbeckProcessWrapper(TensorDictModuleWrapper):
             default: True
 
     Examples:
-        >>> from torchrl.modules import OrnsteinUhlenbeckProcessWrapper, Actor
-        >>> from torchrl.data import NdBoundedTensorSpec, TensorDict
         >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from torchrl.data import NdBoundedTensorSpec
+        >>> from torchrl.modules import OrnsteinUhlenbeckProcessWrapper, Actor
         >>> torch.manual_seed(0)
         >>> spec = NdBoundedTensorSpec(-1, 1, torch.Size([4]))
         >>> module = torch.nn.Linear(4, 4, bias=False)

--- a/torchrl/modules/tensordict_module/probabilistic.py
+++ b/torchrl/modules/tensordict_module/probabilistic.py
@@ -89,10 +89,11 @@ class ProbabilisticTensorDictModule(TensorDictModule):
             Default is 1000
 
     Examples:
-        >>> from torchrl.modules import ProbabilisticTensorDictModule
-        >>> from torchrl.data import TensorDict, NdUnboundedContinuousTensorSpec
-        >>> from torchrl.modules import  TanhNormal, NormalParamWrapper
-        >>> import functorch, torch
+        >>> import functorch
+        >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from torchrl.data import NdUnboundedContinuousTensorSpec
+        >>> from torchrl.modules import ProbabilisticTensorDictModule, TanhNormal, NormalParamWrapper
         >>> td = TensorDict({"input": torch.randn(3, 4), "hidden": torch.randn(3, 8)}, [3,])
         >>> spec = NdUnboundedContinuousTensorSpec(4)
         >>> net = NormalParamWrapper(torch.nn.GRUCell(4, 8))

--- a/torchrl/modules/tensordict_module/sequence.py
+++ b/torchrl/modules/tensordict_module/sequence.py
@@ -57,10 +57,12 @@ class TensorDictSequential(TensorDictModule):
 
     TensorDictSequence supports functional, modular and vmap coding:
     Examples:
+        >>> import functorch
+        >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from torchrl.data import NdUnboundedContinuousTensorSpec
+        >>> from torchrl.modules import TanhNormal, TensorDictSequential, NormalParamWrapper
         >>> from torchrl.modules.tensordict_module import ProbabilisticTensorDictModule
-        >>> from torchrl.data import TensorDict, NdUnboundedContinuousTensorSpec
-        >>> from torchrl.modules import  TanhNormal, TensorDictSequential, NormalParamWrapper
-        >>> import torch, functorch
         >>> td = TensorDict({"input": torch.randn(3, 4)}, [3,])
         >>> spec1 = NdUnboundedContinuousTensorSpec(4)
         >>> net1 = NormalParamWrapper(torch.nn.Linear(4, 8))
@@ -391,7 +393,8 @@ class TensorDictSequential(TensorDictModule):
             A tuple of parameter and buffer tuples
 
         Examples:
-            >>> from torchrl.data import NdUnboundedContinuousTensorSpec, TensorDict
+            >>> from tensordict import TensorDict
+            >>> from torchrl.data import NdUnboundedContinuousTensorSpec
             >>> lazy_module1 = nn.LazyLinear(4)
             >>> lazy_module2 = nn.LazyLinear(3)
             >>> spec1 = NdUnboundedContinuousTensorSpec(18)

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -15,6 +15,7 @@ from typing import Callable, Dict, Optional, Union, Sequence, Tuple, Type, List,
 import numpy as np
 import torch.nn
 from tensordict.tensordict import TensorDictBase, pad
+from tensordict.utils import expand_right
 from torch import nn, optim
 
 from torchrl._utils import KeyDependentDefaultDict
@@ -25,7 +26,7 @@ from torchrl.data import (
     TensorDictPrioritizedReplayBuffer,
     TensorDictReplayBuffer,
 )
-from torchrl.data.utils import expand_right, DEVICE_TYPING
+from torchrl.data.utils import DEVICE_TYPING
 from torchrl.envs.common import EnvBase
 from torchrl.envs.utils import set_exploration_mode
 from torchrl.modules import TensorDictModule


### PR DESCRIPTION
## Description

Updates to #650 TensorDict deprecation in favour of standalone [TensorDict](https://github.com/pytorch-labs/tensordict/). CI should be passing and I've killed remaining references to the TorchRL `TensorDict` class.

- [x] README
- [x] Examples
- [x] Docs

I haven't touched the tutorials as instructed.
