### PR TITLE
[BugFix] PPO objective crashes if advantage_module is None

### DIFF
--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -80,7 +80,9 @@ class PPOLoss(LossModule):
         )
         self.register_buffer("gamma", torch.tensor(gamma, device=self.device))
         self.loss_critic_type = loss_critic_type
-        self.advantage_module = advantage_module.to(self.device)
+        self.advantage_module = advantage_module
+        if self.advantage_module is not None:
+            self.advantage_module = advantage_module.to(self.device)
 
     def reset(self) -> None:
         pass


### PR DESCRIPTION
## Description

The PPOLoss class executes

`self.advantage_module = advantage_module.to(self.device)
`

whether the optional parameter advantage_module is provided or not. I just added and if statement to solve the problem.

## Motivation and Context

I was trying to run the advantage for PPO outside the objective class, and got the following error:

> AttributeError: 'NoneType' object has no attribute 'to'


- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
