### PR TITLE
[Doc] BatchSubSampler class docstrings example

### DIFF
--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -889,7 +889,7 @@ class BatchSubSampler(TrainerHookBase):
         ...         key1: torch.stack([torch.arange(0, 10), torch.arange(10, 20)], 0),
         ...         key2: torch.stack([torch.arange(0, 10), torch.arange(10, 20)], 0),
         ...     },
-        ...     [13, 10],
+        ...     [2, 10],
         ... )
         >>> trainer.register_op(
         ...     "process_optim_batch",


### PR DESCRIPTION
## Description

The example provided in the docstring of the BatchSubSampler class can not be executed. Just changed the TensorDict shape so it runs correctly. 

## Motivation and Context

I tried to run the example to better understand the BatchSubSampler class and I got this error:

> RuntimeError: batch_size are incongruent, got [torch.Size([2, 10]), torch.Size([13, 10])], -- expected torch.Size([13, 10])


- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
