### PR TITLE
[BugFix] Use GitHub for flake8 pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
           - black == 21.9b0
           - usort == 0.6.4
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8


### PR DESCRIPTION
## Description

The lint pipeline on CircleCI appears to be failing for all commits at the moment. 

This PR changes the repo to GitHub per the [flake8 docs](https://flake8.pycqa.org/en/latest/user/using-hooks.html#usage-with-the-pre-commit-git-hooks-framework).