### PR TITLE
[Feature] add `standard_normal` for RewardScaling

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1312,7 +1312,7 @@ class TestTransforms:
         reward_scaling(td)
         for key in keys_total:
             if standard_normal:
-                assert (td.get(key) == -loc / scale).all()
+                assert (td.get(key) == ((td_copy.get(key) - loc) / scale)).all()
             else:
                 assert (td.get(key) == td_copy.get(key).mul_(scale).add_(loc)).all()
         assert (td.get("dont touch") == td_copy.get("dont touch")).all()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1317,11 +1317,7 @@ class TestTransforms:
                 assert (td.get(key) == td_copy.get(key).mul_(scale).add_(loc)).all()
         assert (td.get("dont touch") == td_copy.get("dont touch")).all()
 
-        if len(keys_total) == 0:
-            assert (
-                td.get("reward") == td_copy.get("reward").mul_(scale).add_(loc)
-            ).all()
-        elif len(keys_total) == 1:
+        if len(keys_total) == 1:
             reward_spec = UnboundedContinuousTensorSpec(device=device)
             reward_spec = reward_scaling.transform_reward_spec(reward_spec)
             assert reward_spec.shape == torch.Size([1])

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1312,9 +1312,13 @@ class TestTransforms:
         reward_scaling(td)
         for key in keys_total:
             if standard_normal:
-                assert (td.get(key) == ((td_copy.get(key) - loc) / scale)).all()
+                original_key = td.get(key)
+                scaled_key = (td_copy.get(key) - loc) / scale
+                torch.testing.assert_close(original_key, scaled_key)
             else:
-                assert (td.get(key) == td_copy.get(key).mul_(scale).add_(loc)).all()
+                original_key = td.get(key)
+                scaled_key = td_copy.get(key) * scale + loc
+                torch.testing.assert_close(original_key, scaled_key)
         assert (td.get("dont touch") == td_copy.get("dont touch")).all()
 
         if len(keys_total) == 1:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1520,6 +1520,8 @@ class RewardScaling(Transform):
         if in_keys is None:
             in_keys = ["reward"]
         super().__init__(in_keys=in_keys)
+        self.standard_normal = standard_normal
+
         if not isinstance(loc, torch.Tensor):
             loc = torch.tensor(loc)
         if not isinstance(scale, torch.Tensor):

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1532,7 +1532,9 @@ class RewardScaling(Transform):
 
     def _apply_transform(self, reward: torch.Tensor) -> torch.Tensor:
         if self.standard_normal:
-            return (reward - self.loc) / self.scale
+            loc = self.loc
+            scale = self.scale
+            return (reward - loc) / scale
         else:
             reward.mul_(self.scale).add_(self.loc)
             return reward

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1534,9 +1534,12 @@ class RewardScaling(Transform):
         if self.standard_normal:
             loc = self.loc
             scale = self.scale
-            return (reward - loc) / scale
+            reward = (reward - loc) / scale
+            return reward
         else:
-            reward.mul_(self.scale).add_(self.loc)
+            scale = self.scale
+            loc = self.loc
+            reward = reward * scale + loc
             return reward
 
     def transform_reward_spec(self, reward_spec: TensorSpec) -> TensorSpec:


### PR DESCRIPTION
## Description

Implement `standard_normal` kwarg for RewardScaling 

## Motivation and Context

Why is this change required? What problem does it solve?
Fixes #646 
Brings consistency to RewardScaling wrt ObservationNorm by implementing the `standard_normal` kwarg with the existing regular transform

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
