### PR TITLE
[Doc] Fix missing tensordict install for doc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -202,7 +202,13 @@ def _main(argv):
             "build_ext": BuildExtension.with_options(no_python_abi_suffix=True),
             "clean": clean,
         },
-        install_requires=[pytorch_package_dep, "numpy", "packaging", "cloudpickle"],
+        install_requires=[
+            pytorch_package_dep,
+            "numpy",
+            "packaging",
+            "cloudpickle",
+            "tensordict-nightly",
+        ],
         extras_require={
             "atari": [
                 "gym<=0.24",


### PR DESCRIPTION
## Description

Installing torchrl does not require tensordict. This PR fixes this.