### PR TITLE
[BugFix] ConvNet forward method with tensors of more than 4 dimensions

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -146,7 +146,7 @@ def test_convnet(
 ):
     torch.manual_seed(seed)
     batch = 2
-    seq_length = 2
+    seq_len = 2
     convnet = ConvNet(
         in_features=in_features,
         depth=depth,
@@ -166,9 +166,10 @@ def test_convnet(
     )
     if in_features is None:
         in_features = 5
-    x = torch.randn(batch, seq_length, in_features, input_size, input_size, device=device)
+    x = torch.randn(batch, seq_len, in_features, input_size, input_size, device=device)
     y = convnet(x)
-    assert y.shape == torch.Size([batch, seq_length, expected_features])
+    assert y.shape == torch.Size([batch, seq_len, expected_features])
+
 
 @pytest.mark.parametrize(
     "layer_class",

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -146,6 +146,7 @@ def test_convnet(
 ):
     torch.manual_seed(seed)
     batch = 2
+    seq_length = 2
     convnet = ConvNet(
         in_features=in_features,
         depth=depth,
@@ -165,10 +166,9 @@ def test_convnet(
     )
     if in_features is None:
         in_features = 5
-    x = torch.randn(batch, in_features, input_size, input_size, device=device)
+    x = torch.randn(batch, seq_length, in_features, input_size, input_size, device=device)
     y = convnet(x)
-    assert y.shape == torch.Size([batch, expected_features])
-
+    assert y.shape == torch.Size([batch, seq_length, expected_features])
 
 @pytest.mark.parametrize(
     "layer_class",

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -124,7 +124,9 @@ def test_mlp(
 )
 @pytest.mark.parametrize("squeeze_output", [False])
 @pytest.mark.parametrize("device", get_available_devices())
+@pytest.mark.parametrize("batch", [(2,), (2, 2)])
 def test_convnet(
+    batch,
     in_features,
     depth,
     num_cells,
@@ -145,8 +147,6 @@ def test_convnet(
     seed=0,
 ):
     torch.manual_seed(seed)
-    batch = 2
-    seq_len = 2
     convnet = ConvNet(
         in_features=in_features,
         depth=depth,
@@ -166,9 +166,9 @@ def test_convnet(
     )
     if in_features is None:
         in_features = 5
-    x = torch.randn(batch, seq_len, in_features, input_size, input_size, device=device)
+    x = torch.randn(*batch, in_features, input_size, input_size, device=device)
     y = convnet(x)
-    assert y.shape == torch.Size([batch, seq_len, expected_features])
+    assert y.shape == torch.Size([*batch, expected_features])
 
 
 @pytest.mark.parametrize(

--- a/torchrl/modules/models/models.py
+++ b/torchrl/modules/models/models.py
@@ -463,6 +463,21 @@ class ConvNet(nn.Sequential):
             layers.append(Squeeze2dLayer())
         return layers
 
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+
+        if len(inputs.shape) == 5:
+            B, L = inputs.shape[0:2]
+            inputs = inputs.view(B * L, *inputs.shape[2:])
+        else:
+            L = None
+
+        out = super(ConvNet, self).forward(inputs)
+
+        if L:
+            out = out.view(B, L, *out.shape[1:])
+
+        return out
+
 
 class DuelingMlpDQNet(nn.Module):
     """Creates a Dueling MLP Q-network.

--- a/torchrl/modules/models/models.py
+++ b/torchrl/modules/models/models.py
@@ -464,18 +464,12 @@ class ConvNet(nn.Sequential):
         return layers
 
     def forward(self, inputs: torch.Tensor) -> torch.Tensor:
-
-        if len(inputs.shape) == 5:
-            B, L = inputs.shape[0:2]
-            inputs = inputs.view(B * L, *inputs.shape[2:])
-        else:
-            L = None
-
+        *batch, C, L, W = inputs.shape
+        if len(batch) > 1:
+            inputs = inputs.flatten(0, len(batch) - 1)
         out = super(ConvNet, self).forward(inputs)
-
-        if L:
-            out = out.view(B, L, *out.shape[1:])
-
+        if len(batch) > 1:
+            out = out.unflatten(0, batch)
         return out
 
 


### PR DESCRIPTION
## Description

Collectors and BatchSubSample produce batches with shape (Batch, Length, Channels, Height, Width), but shapes with more than 4 dimensions raise an error when passed through a CNN. 

I just added an adjustment so that for batches with 5 dimensions, then Batch and Length dimension are collapsed before the forward pass and expanded right after it.

## Motivation and Context

I was trying to train on an Atari 2600 environment and the forward pass raised the following error:

> RuntimeError: Expected 3D (unbatched) or 4D (batched) input to conv2d, but got input of size: [8, 32, 4, 84, 84]

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
