### PR TITLE
[Refactoring] Replace direct gym version checks with decorated functions (#)

### DIFF
--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -13,7 +13,7 @@ import pytest
 import torch.cuda
 from torchrl._utils import seed_generator, implement_for
 from torchrl.envs import EnvBase
-
+from torchrl.envs.libs.gym import _has_gym
 
 # Specified for test_utils.py
 __version__ = "0.3"
@@ -29,8 +29,8 @@ HALFCHEETAH_VERSIONED = "HalfCheetah-v4"
 def _set_gym_environments():  # noqa: F811
     global CARTPOLE_VERSIONED, PENDULUM_VERSIONED, PONG_VERSIONED, HALFCHEETAH_VERSIONED
 
-    PENDULUM_VERSIONED = "Pendulum-v0"
     CARTPOLE_VERSIONED = "CartPole-v0"
+    PENDULUM_VERSIONED = "Pendulum-v0"
     PONG_VERSIONED = "Pong-v4"
     HALFCHEETAH_VERSIONED = "HalfCheetah-v2"
 
@@ -45,7 +45,8 @@ def _set_gym_environments():  # noqa: F811
     HALFCHEETAH_VERSIONED = "HalfCheetah-v4"
 
 
-_set_gym_environments()
+if _has_gym:
+    _set_gym_environments()
 
 
 def get_relative_path(curr_file, *path_components):

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -12,12 +12,41 @@ from functools import wraps
 import pytest
 import torch.cuda
 from tensordict.tensordict import TensorDictBase
-from torchrl._utils import seed_generator
+from torchrl._utils import seed_generator, implement_for
 from torchrl.envs import EnvBase
 
 
 # Specified for test_utils.py
 __version__ = "0.3"
+
+# Default versions of the environments.
+CARTPOLE_VERSIONED = "CartPole-v1"
+PENDULUM_VERSIONED = "Pendulum-v1"
+PONG_VERSIONED = "ALE/Pong-v5"
+HALFCHEETAH_VERSIONED = "HalfCheetah-v4"
+
+
+@implement_for("gym", None, "0.20.0")
+def _set_gym_environments():  # noqa: F811
+    global CARTPOLE_VERSIONED, PENDULUM_VERSIONED, PONG_VERSIONED, HALFCHEETAH_VERSIONED
+
+    PENDULUM_VERSIONED = "Pendulum-v0"
+    CARTPOLE_VERSIONED = "CartPole-v0"
+    PONG_VERSIONED = "Pong-v4"
+    HALFCHEETAH_VERSIONED = "HalfCheetah-v2"
+
+
+@implement_for("gym", "0.20.0", None)
+def _set_gym_environments():  # noqa: F811
+    global CARTPOLE_VERSIONED, PENDULUM_VERSIONED, PONG_VERSIONED, HALFCHEETAH_VERSIONED
+
+    CARTPOLE_VERSIONED = "CartPole-v1"
+    PENDULUM_VERSIONED = "Pendulum-v1"
+    PONG_VERSIONED = "ALE/Pong-v5"
+    HALFCHEETAH_VERSIONED = "HalfCheetah-v4"
+
+
+_set_gym_environments()
 
 
 def get_relative_path(curr_file, *path_components):

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -20,29 +20,29 @@ __version__ = "0.3"
 
 # Default versions of the environments.
 CARTPOLE_VERSIONED = "CartPole-v1"
+HALFCHEETAH_VERSIONED = "HalfCheetah-v4"
 PENDULUM_VERSIONED = "Pendulum-v1"
 PONG_VERSIONED = "ALE/Pong-v5"
-HALFCHEETAH_VERSIONED = "HalfCheetah-v4"
 
 
-@implement_for("gym", None, "0.20.0")
+@implement_for("gym", None, "0.21.0")
 def _set_gym_environments():  # noqa: F811
-    global CARTPOLE_VERSIONED, PENDULUM_VERSIONED, PONG_VERSIONED, HALFCHEETAH_VERSIONED
+    global CARTPOLE_VERSIONED, HALFCHEETAH_VERSIONED, PENDULUM_VERSIONED, PONG_VERSIONED
 
     CARTPOLE_VERSIONED = "CartPole-v0"
+    HALFCHEETAH_VERSIONED = "HalfCheetah-v2"
     PENDULUM_VERSIONED = "Pendulum-v0"
     PONG_VERSIONED = "Pong-v4"
-    HALFCHEETAH_VERSIONED = "HalfCheetah-v2"
 
 
-@implement_for("gym", "0.20.0", None)
+@implement_for("gym", "0.21.0", None)
 def _set_gym_environments():  # noqa: F811
-    global CARTPOLE_VERSIONED, PENDULUM_VERSIONED, PONG_VERSIONED, HALFCHEETAH_VERSIONED
+    global CARTPOLE_VERSIONED, HALFCHEETAH_VERSIONED, PENDULUM_VERSIONED, PONG_VERSIONED
 
     CARTPOLE_VERSIONED = "CartPole-v1"
+    HALFCHEETAH_VERSIONED = "HalfCheetah-v4"
     PENDULUM_VERSIONED = "Pendulum-v1"
     PONG_VERSIONED = "ALE/Pong-v5"
-    HALFCHEETAH_VERSIONED = "HalfCheetah-v4"
 
 
 if _has_gym:

--- a/test/smoke_test_deps.py
+++ b/test/smoke_test_deps.py
@@ -2,20 +2,9 @@ import argparse
 import tempfile
 
 import pytest
+from torchrl._utils import implement_for
 from torchrl.envs.libs.dm_control import _has_dmc, DMControlEnv
 from torchrl.envs.libs.gym import _has_gym, GymEnv
-
-if _has_gym:
-    import gym
-    from packaging import version
-
-    gym_version = version.parse(gym.__version__)
-    PONG_VERSIONED = (
-        "ALE/Pong-v5" if gym_version > version.parse("0.20.0") else "Pong-v4"
-    )
-else:
-    # placeholders
-    PONG_VERSIONED = "ALE/Pong-v5"
 
 try:
     from torch.utils.tensorboard import SummaryWriter
@@ -46,7 +35,7 @@ def test_gym():
     import gym  # noqa: F401
 
     assert _has_gym
-    env = GymEnv(PONG_VERSIONED)
+    env = GymEnv(_pong_versioned())
     env.reset()
 
 
@@ -63,6 +52,16 @@ def test_tb():
             # OS error could be raised randomly
             # depending on the test machine
             test_rounds -= 1
+
+
+@implement_for("gym", None, "0.21")
+def _pong_versioned():  # noqa: F811
+    return "Pong-v4"
+
+
+@implement_for("gym", "0.21", None)
+def _pong_versioned():  # noqa: F811
+    return "ALE/Pong-v5"
 
 
 if __name__ == "__main__":

--- a/test/smoke_test_deps.py
+++ b/test/smoke_test_deps.py
@@ -2,7 +2,7 @@ import argparse
 import tempfile
 
 import pytest
-from torchrl._utils import implement_for
+from _utils_internal import PONG_VERSIONED
 from torchrl.envs.libs.dm_control import _has_dmc, DMControlEnv
 from torchrl.envs.libs.gym import _has_gym, GymEnv
 
@@ -35,7 +35,7 @@ def test_gym():
     import gym  # noqa: F401
 
     assert _has_gym
-    env = GymEnv(_pong_versioned())
+    env = GymEnv(PONG_VERSIONED)
     env.reset()
 
 
@@ -52,16 +52,6 @@ def test_tb():
             # OS error could be raised randomly
             # depending on the test machine
             test_rounds -= 1
-
-
-@implement_for("gym", None, "0.21")
-def _pong_versioned():  # noqa: F811
-    return "Pong-v4"
-
-
-@implement_for("gym", "0.21", None)
-def _pong_versioned():  # noqa: F811
-    return "ALE/Pong-v5"
 
 
 if __name__ == "__main__":

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -8,7 +8,7 @@ import argparse
 import numpy as np
 import pytest
 import torch
-from _utils_internal import generate_seeds
+from _utils_internal import generate_seeds, PENDULUM_VERSIONED, PONG_VERSIONED
 from mocking_classes import (
     ContinuousActionVecMockEnv,
     DiscreteActionConvMockEnv,
@@ -41,22 +41,6 @@ from torchrl.modules import (
     OrnsteinUhlenbeckProcessWrapper,
     TensorDictModule,
 )
-
-if _has_gym:
-    import gym
-    from packaging import version
-
-    gym_version = version.parse(gym.__version__)
-    PENDULUM_VERSIONED = (
-        "Pendulum-v1" if gym_version > version.parse("0.20.0") else "Pendulum-v0"
-    )
-    PONG_VERSIONED = (
-        "ALE/Pong-v5" if gym_version > version.parse("0.20.0") else "Pong-v4"
-    )
-else:
-    # placeholders
-    PENDULUM_VERSIONED = "Pendulum-v1"
-    PONG_VERSIONED = "ALE/Pong-v5"
 
 # torch.set_default_dtype(torch.double)
 

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -11,7 +11,13 @@ import numpy as np
 import pytest
 import torch
 import yaml
-from _utils_internal import get_available_devices
+from _utils_internal import (
+    get_available_devices,
+    CARTPOLE_VERSIONED,
+    PENDULUM_VERSIONED,
+    PONG_VERSIONED,
+    HALFCHEETAH_VERSIONED,
+)
 from mocking_classes import (
     ActionObsMergeLinear,
     DiscreteActionConvMockEnv,
@@ -53,26 +59,6 @@ if _has_gym:
     import gym
 
     gym_version = version.parse(gym.__version__)
-    PENDULUM_VERSIONED = (
-        "Pendulum-v1" if gym_version > version.parse("0.20.0") else "Pendulum-v0"
-    )
-    CARTPOLE_VERSIONED = (
-        "CartPole-v1" if gym_version > version.parse("0.20.0") else "CartPole-v0"
-    )
-    PONG_VERSIONED = (
-        "ALE/Pong-v5" if gym_version > version.parse("0.20.0") else "Pong-v4"
-    )
-    HALFCHEETAH_VERSIONED = (
-        "HalfCheetah-v4" if gym_version > version.parse("0.20.0") else "HalfCheetah-v2"
-    )
-else:
-    # placeholder
-    gym_version = version.parse("0.0.1")
-
-    # placeholders
-    PENDULUM_VERSIONED = "Pendulum-v1"
-    CARTPOLE_VERSIONED = "CartPole-v1"
-    PONG_VERSIONED = "ALE/Pong-v5"
 
 try:
     this_dir = os.path.dirname(os.path.realpath(__file__))

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -55,6 +55,7 @@ from torchrl.modules import (
 )
 from torchrl.modules.tensordict_module import WorldModelWrapper
 
+gym_version = None
 if _has_gym:
     import gym
 
@@ -1034,7 +1035,7 @@ def test_batch_unlocked_with_batch_size(device):
 
 @pytest.mark.skipif(not _has_gym, reason="no gym")
 @pytest.mark.skipif(
-    gym_version < version.parse("0.20.0"),
+    gym_version is None or gym_version < version.parse("0.20.0"),
     reason="older versions of half-cheetah do not have 'x_position' info key.",
 )
 def test_info_dict_reader(seed=0):

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import argparse
+from sys import platform
 
 import numpy as np
 import pytest
@@ -10,67 +11,83 @@ import torch
 from _utils_internal import _test_fake_tensordict
 from _utils_internal import get_available_devices
 from packaging import version
+from tensordict.tensordict import assert_allclose_td
+from torchrl._utils import implement_for
 from torchrl.collectors import MultiaSyncDataCollector
 from torchrl.collectors.collectors import RandomPolicy
+from torchrl.envs import EnvCreator, ParallelEnv
+from torchrl.envs.libs.dm_control import DMControlEnv, DMControlWrapper
 from torchrl.envs.libs.dm_control import _has_dmc
+from torchrl.envs.libs.gym import GymEnv, GymWrapper
 from torchrl.envs.libs.gym import _has_gym, _is_from_pixels
 from torchrl.envs.libs.habitat import HabitatEnv, _has_habitat
+
+
+@implement_for("gym", None, "0.20")
+def _import_pixel_observation_wrapper():  # noqa: F811
+    from torchrl.envs.libs.utils import (
+        GymPixelObservationWrapper as PixelObservationWrapper,
+    )
+
+    return PixelObservationWrapper
+
+
+@implement_for("gym", "0.20", None)
+def _import_pixel_observation_wrapper():  # noqa: F811
+    from gym.wrappers.pixel_observation import PixelObservationWrapper
+
+    return PixelObservationWrapper
+
 
 if _has_gym:
     import gym
 
     gym_version = version.parse(gym.__version__)
-    if gym_version > version.parse("0.19"):
-        from gym.wrappers.pixel_observation import PixelObservationWrapper
-    else:
-        from torchrl.envs.libs.utils import (
-            GymPixelObservationWrapper as PixelObservationWrapper,
-        )
+    PixelObservationWrapper = _import_pixel_observation_wrapper()
 
 if _has_dmc:
     from dm_control import suite
     from dm_control.suite.wrappers import pixels
 
-from sys import platform
-
-from tensordict.tensordict import assert_allclose_td
-from torchrl.envs import EnvCreator, ParallelEnv
-from torchrl.envs.libs.dm_control import DMControlEnv, DMControlWrapper
-from torchrl.envs.libs.gym import GymEnv, GymWrapper
-
 IS_OSX = platform == "darwin"
 
-if _has_gym:
-    from packaging import version
 
-    gym_version = version.parse(gym.__version__)
-    PENDULUM_VERSIONED = (
-        "Pendulum-v1" if gym_version > version.parse("0.20.0") else "Pendulum-v0"
-    )
-    HC_VERSIONED = (
-        "HalfCheetah-v4" if gym_version > version.parse("0.20.0") else "HalfCheetah-v2"
-    )
-    PONG_VERSIONED = (
-        "ALE/Pong-v5" if gym_version > version.parse("0.20.0") else "Pong-v4"
-    )
+@implement_for("gym", None, "0.21")
+def _pendulum_versioned():  # noqa: F811
+    return "Pendulum-v0"
 
-    # if gym_version < version.parse("0.24.0") and torch.cuda.device_count() > 0:
-    #     from opengl_rendering import create_opengl_context
-    #
-    #     create_opengl_context()
-else:
-    # placeholders
-    PENDULUM_VERSIONED = "Pendulum-v1"
-    HC_VERSIONED = "HalfCheetah-v4"
-    PONG_VERSIONED = "ALE/Pong-v5"
+
+@implement_for("gym", "0.21", None)
+def _pendulum_versioned():  # noqa: F811
+    return "Pendulum-v1"
+
+
+@implement_for("gym", None, "0.21")
+def _hc_versioned():  # noqa: F811
+    return "HalfCheetah-v2"
+
+
+@implement_for("gym", "0.21", None)
+def _hc_versioned():  # noqa: F811
+    return "HalfCheetah-v4"
+
+
+@implement_for("gym", None, "0.21")
+def _pong_versioned():  # noqa: F811
+    return "Pong-v4"
+
+
+@implement_for("gym", "0.21", None)
+def _pong_versioned():  # noqa: F811
+    return "ALE/Pong-v5"
 
 
 @pytest.mark.skipif(not _has_gym, reason="no gym library found")
 @pytest.mark.parametrize(
     "env_name",
     [
-        PONG_VERSIONED,
-        PENDULUM_VERSIONED,
+        _pong_versioned(),
+        _pendulum_versioned(),
     ],
 )
 @pytest.mark.parametrize("frame_skip", [1, 3])
@@ -84,10 +101,10 @@ else:
 )
 class TestGym:
     def test_gym(self, env_name, frame_skip, from_pixels, pixels_only):
-        if env_name == PONG_VERSIONED and not from_pixels:
+        if env_name == _pong_versioned() and not from_pixels:
             raise pytest.skip("already pixel")
         elif (
-            env_name != PONG_VERSIONED
+            env_name != _pong_versioned()
             and from_pixels
             and (not torch.has_cuda or not torch.cuda.device_count())
         ):
@@ -118,14 +135,11 @@ class TestGym:
         final_seed0, final_seed1 = final_seed
         assert final_seed0 == final_seed1
 
-        if env_name == PONG_VERSIONED:
+        if env_name == _pong_versioned():
             base_env = gym.make(env_name, frameskip=frame_skip)
             frame_skip = 1
         else:
-            if gym_version < version.parse("0.26.0"):
-                base_env = gym.make(env_name)
-            else:
-                base_env = gym.make(env_name, render_mode="rgb_array")
+            base_env = _make_gym_environment(env_name)
 
         if from_pixels and not _is_from_pixels(base_env):
             base_env = PixelObservationWrapper(base_env, pixels_only=pixels_only)
@@ -145,10 +159,10 @@ class TestGym:
         assert_allclose_td(tdrollout[0], rollout2, rtol=1e-4, atol=1e-4)
 
     def test_gym_fake_td(self, env_name, frame_skip, from_pixels, pixels_only):
-        if env_name == PONG_VERSIONED and not from_pixels:
+        if env_name == _pong_versioned() and not from_pixels:
             raise pytest.skip("already pixel")
         elif (
-            env_name != PONG_VERSIONED
+            env_name != _pong_versioned()
             and from_pixels
             and (not torch.has_cuda or not torch.cuda.device_count())
         ):
@@ -269,10 +283,10 @@ class TestDMControl:
     "env_lib,env_args,env_kwargs",
     [
         [DMControlEnv, ("cheetah", "run"), {"from_pixels": True}],
-        [GymEnv, (HC_VERSIONED,), {"from_pixels": True}],
+        [GymEnv, (_hc_versioned(),), {"from_pixels": True}],
         [DMControlEnv, ("cheetah", "run"), {"from_pixels": False}],
-        [GymEnv, (HC_VERSIONED,), {"from_pixels": False}],
-        [GymEnv, (PONG_VERSIONED,), {}],
+        [GymEnv, (_hc_versioned(),), {"from_pixels": False}],
+        [GymEnv, (_pong_versioned(),), {}],
     ],
 )
 def test_td_creation_from_spec(env_lib, env_args, env_kwargs):
@@ -303,10 +317,10 @@ def test_td_creation_from_spec(env_lib, env_args, env_kwargs):
     "env_lib,env_args,env_kwargs",
     [
         [DMControlEnv, ("cheetah", "run"), {"from_pixels": True}],
-        [GymEnv, (HC_VERSIONED,), {"from_pixels": True}],
+        [GymEnv, (_hc_versioned(),), {"from_pixels": True}],
         [DMControlEnv, ("cheetah", "run"), {"from_pixels": False}],
-        [GymEnv, (HC_VERSIONED,), {"from_pixels": False}],
-        [GymEnv, (PONG_VERSIONED,), {}],
+        [GymEnv, (_hc_versioned(),), {"from_pixels": False}],
+        [GymEnv, (_pong_versioned(),), {}],
     ],
 )
 @pytest.mark.parametrize("device", get_available_devices())
@@ -349,6 +363,16 @@ class TestHabitat:
         env = HabitatEnv(envname)
         rollout = env.rollout(3)
         _test_fake_tensordict(env)
+
+
+@implement_for("gym", None, "0.26")
+def _make_gym_environment(env_name):  # noqa: F811
+    return gym.make(env_name)
+
+
+@implement_for("gym", "0.26", None)
+def _make_gym_environment(env_name):  # noqa: F811
+    return gym.make(env_name, render_mode="rgb_array")
 
 
 if __name__ == "__main__":

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -8,7 +8,12 @@ from copy import copy, deepcopy
 import numpy as np
 import pytest
 import torch
-from _utils_internal import get_available_devices, retry, dtype_fixture  # noqa
+from _utils_internal import (  # noqa
+    get_available_devices,
+    retry,
+    dtype_fixture,
+    PENDULUM_VERSIONED,
+)
 from mocking_classes import (
     ContinuousActionVecMockEnv,
     DiscreteActionConvMockEnvNumpy,
@@ -58,18 +63,6 @@ from torchrl.envs.transforms.transforms import (
     UnsqueezeTransform,
 )
 from torchrl.envs.transforms.vip import _VIPNet, VIPRewardTransform
-
-if _has_gym:
-    import gym
-    from packaging import version
-
-    gym_version = version.parse(gym.__version__)
-    PENDULUM_VERSIONED = (
-        "Pendulum-v1" if gym_version > version.parse("0.20.0") else "Pendulum-v0"
-    )
-else:
-    # placeholders
-    PENDULUM_VERSIONED = "Pendulum-v1"
 
 TIMEOUT = 10.0
 

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -26,7 +26,6 @@ from ..utils import _classproperty
 
 try:
     import gym
-    from packaging import version
 
     _has_gym = True
 except ImportError:
@@ -49,9 +48,6 @@ if _has_gym:
         from torchrl.envs.libs.utils import (
             GymPixelObservationWrapper as PixelObservationWrapper,
         )
-    gym_version = version.parse(gym.__version__)
-    if gym_version >= version.parse("0.26.0"):
-        from gym.wrappers.compatibility import EnvCompatibility
 
 __all__ = ["GymWrapper", "GymEnv"]
 
@@ -202,6 +198,8 @@ class GymWrapper(GymLikeEnv):
 
     @implement_for("gym", "0.26.0", None)
     def _build_gym_env(self, env, pixels_only):  # noqa: F811
+        from gym.wrappers.compatibility import EnvCompatibility
+
         if env.render_mode:
             return PixelObservationWrapper(env, pixels_only=pixels_only)
 


### PR DESCRIPTION
## Description

Replaces direct gym version checks with `@implement_for` decorated functions (primarily `gym.py` and tests), except some places in tests where direct check still looks better (less complicated). Extracted gym environments version definition logic in tests.

## Motivation and Context

This simplifies the logic of functions that check for gym versions, improves readability and makes it easier to adapt for bc-braking changes in gym. Proposed by @vmoens.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)
- [x] Refactoring

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
