### PR TITLE
[Docs] Host TensorDict docs inside TorchRL docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,6 +74,9 @@ jobs:
         cd ./docs
         conda run -n build_binary make html
         cd ..
+    - name: Pull TensorDict docs
+      run: |
+        git subtree add --prefix=docs/build/html/tensordict --squash https://github.com/pytorch-labs/tensordict.git gh-pages
     - name: Get output time
       run: echo "The time was ${{ steps.build.outputs.time }}"
     - name: Deploy

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,9 @@
 Welcome to the TorchRL Documentation!
 =====================================
 
+.. note::
+   The TensorDict class has been moved out of TorchRL into a dedicated library. Take a look at `the documentation <./tensordict>`_ or find the source code `on GitHub <https://github.com/pytorch-labs/tensordict>`_.
+
 TorchRL is an open-source Reinforcement Learning (RL) library for PyTorch.
 
 It provides pytorch and python-first, low and high level abstractions for RL that are intended to be efficient, modular, documented and properly tested.


### PR DESCRIPTION
## Description

This PR updates the docs CI/CD to pull in the tensordict documentation and host it at `/tensordict`. It also adds a banner to the existing docs to direct users there.

The build of the TensorDict docs happens over in the tensordict repo. The built docs are pushed to the `gh-pages` branch and pulled in here. 

cf. pytorch-labs/tensordict#61

## Motivation and Context

It is currently not trivial to host TensorDict docs through pytorch-labs organisation, so it's easier to host under the TorchRL docs for now until a permanent solution is found.