### PR TITLE
[BugFix] Fix docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,7 +76,8 @@ jobs:
         cd ..
     - name: Pull TensorDict docs
       run: |
-        git subtree add --prefix=docs/build/html/tensordict --squash https://github.com/pytorch-labs/tensordict.git gh-pages
+        git clone --branch gh-pages https://github.com/pytorch-labs/tensordict.git docs/build/html/tensordict
+        rm -rf docs/build/html/tensordict/.git
     - name: Get output time
       run: echo "The time was ${{ steps.build.outputs.time }}"
     - name: Deploy


### PR DESCRIPTION
## Description

Docs build was failing because `git-subtree` is not installed in the runner.

Rather than installing , we just use a clone instead and clean up the nested Git repo.