### PR TITLE
[BugFix] Initialising the classes LazyTensorStorage  with a nested TensorDict raises error

### DIFF
--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -7,11 +7,11 @@ import abc
 import os
 from collections import OrderedDict
 from copy import copy
-from typing import Any, Dict, Sequence, Union
+from typing import Any, Sequence, Union, Dict
 
 import torch
 from tensordict.memmap import MemmapTensor
-from tensordict.tensordict import TensorDict, TensorDictBase
+from tensordict.tensordict import TensorDictBase, TensorDict
 
 from torchrl._utils import _CKPT_BACKEND
 from torchrl.data.replay_buffers.utils import INT_CLASSES
@@ -236,26 +236,13 @@ class LazyTensorStorage(Storage):
                 dtype=data.dtype,
             )
         else:
-            out = TensorDict({}, [self.max_size, *data.shape])
-            print("The storage is being created: ")
-            for key, tensor in data.items():
-                if isinstance(tensor, TensorDictBase):
-                    out[key] = ( 
-                        tensor.expand(
-                            self.max_size,
-                            *tensor.shape,
-                        )
-                        .clone()
-                        .to(self.device)
-                        .zero_()
-                    )
-                else:
-                    out[key] = torch.empty(
-                        self.max_size,
-                        *tensor.shape,
-                        device=self.device,
-                        dtype=tensor.dtype,
-                    )
+            out = (
+                data.expand(self.max_size, *data.shape)
+                    .to_tensordict()
+                    .zero_()
+                    .clone()
+                    .to(self.device)
+            )
 
         self._storage = out
         self.initialized = True

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -240,7 +240,7 @@ class LazyTensorStorage(Storage):
             print("The storage is being created: ")
             for key, tensor in data.items():
                 if isinstance(tensor, TensorDictBase):
-                    out[key] = (
+                    out[key] = ( 
                         tensor.expand(
                             self.max_size,
                             *tensor.shape,

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -241,7 +241,10 @@ class LazyTensorStorage(Storage):
             for key, tensor in data.items():
                 if isinstance(tensor, TensorDictBase):
                     out[key] = (
-                        tensor.expand(self.max_size).clone().to(self.device).zero_()
+                        tensor.expand(
+                            self.max_size,
+                            *tensor.shape,
+                        ).clone().to(self.device).zero_()
                     )
                 else:
                     out[key] = torch.empty(

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -7,11 +7,11 @@ import abc
 import os
 from collections import OrderedDict
 from copy import copy
-from typing import Any, Sequence, Union, Dict
+from typing import Any, Dict, Sequence, Union
 
 import torch
 from tensordict.memmap import MemmapTensor
-from tensordict.tensordict import TensorDictBase, TensorDict
+from tensordict.tensordict import TensorDict, TensorDictBase
 
 from torchrl._utils import _CKPT_BACKEND
 from torchrl.data.replay_buffers.utils import INT_CLASSES
@@ -238,10 +238,10 @@ class LazyTensorStorage(Storage):
         else:
             out = (
                 data.expand(self.max_size, *data.shape)
-                    .to_tensordict()
-                    .zero_()
-                    .clone()
-                    .to(self.device)
+                .to_tensordict()
+                .zero_()
+                .clone()
+                .to(self.device)
             )
 
         self._storage = out

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -7,11 +7,11 @@ import abc
 import os
 from collections import OrderedDict
 from copy import copy
-from typing import Any, Sequence, Union, Dict
+from typing import Any, Dict, Sequence, Union
 
 import torch
 from tensordict.memmap import MemmapTensor
-from tensordict.tensordict import TensorDictBase, TensorDict
+from tensordict.tensordict import TensorDict, TensorDictBase
 
 from torchrl._utils import _CKPT_BACKEND
 from torchrl.data.replay_buffers.utils import INT_CLASSES
@@ -244,7 +244,10 @@ class LazyTensorStorage(Storage):
                         tensor.expand(
                             self.max_size,
                             *tensor.shape,
-                        ).clone().to(self.device).zero_()
+                        )
+                        .clone()
+                        .to(self.device)
+                        .zero_()
                     )
                 else:
                     out[key] = torch.empty(


### PR DESCRIPTION
## Description

Initialising the class LazyTensorStorage with a nested TensorDict raises the following error

> RuntimeError: the number of sizes provided (1) must be greater or equal to the number of dimensions in the TensorDict (2)

It it due to a call to _tensor.expand_ . I just added the the dimensions of tensor to the output shape, and now it does not crash anymore.

The error can be reproduced with the following code:

```

import torch
from tensordict import TensorDict
from torchrl.data.replay_buffers.storages import LazyTensorStorage

dummy_td = TensorDict({
    "key1": torch.ones(3, 4),
    "key2": torch.ones(3, 4),
    "next": TensorDict({
        "next_key1": torch.ones(3, 4),
        "next_key2": torch.ones(3, 4),
    }, [3, 4])
}, [3, 4])

mystorage = LazyTensorStorage(1000)
mystorage._init(dummy_td)
```



## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
