### PR TITLE
[BugFix] Fix init_random_frames in A2C example test

### DIFF
--- a/.circleci/unittest/linux_examples/scripts/run_test.sh
+++ b/.circleci/unittest/linux_examples/scripts/run_test.sh
@@ -47,7 +47,8 @@ coverage run examples/a2c/a2c.py \
   collector_devices=cuda:0 \
   optim_steps_per_batch=1 \
   record_video=True \
-  record_frames=4
+  record_frames=4 \
+  logger=csv
 coverage run examples/dqn/dqn.py \
   total_frames=48 \
   init_random_frames=10 \

--- a/.circleci/unittest/linux_examples/scripts/run_test.sh
+++ b/.circleci/unittest/linux_examples/scripts/run_test.sh
@@ -47,8 +47,7 @@ coverage run examples/a2c/a2c.py \
   collector_devices=cuda:0 \
   optim_steps_per_batch=1 \
   record_video=True \
-  record_frames=4 \
-  buffer_size=120
+  record_frames=4
 coverage run examples/dqn/dqn.py \
   total_frames=48 \
   init_random_frames=10 \

--- a/.circleci/unittest/linux_examples/scripts/run_test.sh
+++ b/.circleci/unittest/linux_examples/scripts/run_test.sh
@@ -40,7 +40,6 @@ coverage run examples/ddpg/ddpg.py \
   buffer_size=120
 coverage run examples/a2c/a2c.py \
   total_frames=48 \
-  init_random_frames=10 \
   batch_size=10 \
   frames_per_batch=16 \
   num_workers=2 \


### PR DESCRIPTION
## Description

Removes `init_random_frames` from the A2C flags in the example tests