### PR TITLE
[Doc] Document undefined symbol error with torch version < 1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,8 +489,6 @@ python -c 'from torchrl.envs.libs.gym import GymEnv'
 ```
 If this is the case, consider executing torchrl from another location.
 
-
-
 On **MacOs**, we recommend installing XCode first.
 With Apple Silicon M1 chips, make sure you are using the arm64-built python
 (e.g. [here](https://betterprogramming.pub/how-to-install-pytorch-on-apple-m1-series-512b3ad9bc6)). Running the following lines of code
@@ -509,7 +507,7 @@ OS: macOS **** (x86_64)
 ```
 
 If you successfully install and you have a ```ImportError: /usr/local/lib/python3.7/dist-packages/torchrl/_torchrl.so: undefined symbol: _ZN8pybind116detail11type_casterIN2at6TensorEvE4loadENS_6handleEb``` when you try to import the module, most probably this is caused by an incompatibility with your torch package.
-Please install torch 1.13 or build the library from source. Please refer to [versioning issues](knowledge_base/VERSIONING_ISSUES.md) for a complete explanation.
+Please install torch 1.13 or build the library from source. Please refer to this [versioning issues document](knowledge_base/VERSIONING_ISSUES.md) for a complete explanation.
 
 
 ## Running examples

--- a/README.md
+++ b/README.md
@@ -506,8 +506,7 @@ and not
 OS: macOS **** (x86_64)
 ```
 
-If you successfully install and you have a ```ImportError: /usr/local/lib/python3.7/dist-packages/torchrl/_torchrl.so: undefined symbol: _ZN8pybind116detail11type_casterIN2at6TensorEvE4loadENS_6handleEb``` when you try to import the module, most probably this is caused by an incompatibility with your torch package.
-Please install torch 1.13 or build the library from source. Please refer to this [versioning issues document](knowledge_base/VERSIONING_ISSUES.md) for a complete explanation.
+Versioning issues can cause error message of the type ```undefined symbol``` and such. For these, refer to the [versioning issues document](knowledge_base/VERSIONING_ISSUES.md) for a complete explanation and proposed workarounds.
 
 
 ## Running examples

--- a/README.md
+++ b/README.md
@@ -489,6 +489,8 @@ python -c 'from torchrl.envs.libs.gym import GymEnv'
 ```
 If this is the case, consider executing torchrl from another location.
 
+
+
 On **MacOs**, we recommend installing XCode first.
 With Apple Silicon M1 chips, make sure you are using the arm64-built python
 (e.g. [here](https://betterprogramming.pub/how-to-install-pytorch-on-apple-m1-series-512b3ad9bc6)). Running the following lines of code
@@ -505,6 +507,10 @@ and not
 ```
 OS: macOS **** (x86_64)
 ```
+
+If you successfully install and you have a ```ImportError: /usr/local/lib/python3.7/dist-packages/torchrl/_torchrl.so: undefined symbol: _ZN8pybind116detail11type_casterIN2at6TensorEvE4loadENS_6handleEb``` when you try to import the module, most probably this is caused by an incompatibility with your torch package.
+Please install torch 1.13 or build the library from source. Please refer to [versioning issues](knowledge_base/VERSIONING_ISSUES.md) for a complete explanation.
+
 
 ## Running examples
 Examples are coded in a very similar way but the configuration may change from one algorithm to another (e.g. async/sync data collection, hyperparameters, ratio of model updates / frame etc.)

--- a/knowledge_base/VERSIONING_ISSUES.md
+++ b/knowledge_base/VERSIONING_ISSUES.md
@@ -1,7 +1,7 @@
 # Versioning Issues
 
 ## Pytorch version
-This issue is related to https://github.com/pytorch/rl/issues/689. Using PyTorch versions lower < 1.13 and installing stable package leads to the following error:
+This issue is related to https://github.com/pytorch/rl/issues/689. Using PyTorch versions <1.13 and installing stable package leads to undefined symbol errors. For example:
 ```
 ImportError: /usr/local/lib/python3.7/dist-packages/torchrl/_torchrl.so: undefined symbol: _ZN8pybind116detail11type_casterIN2at6TensorEvE4loadENS_6handleEb
 ```
@@ -13,11 +13,14 @@ This is probably due to some incompatibility (tensor casting?) of torch C++ bind
 2. ``` !pip install torchrl ```
 3. ``` import torchrl ```
 
+On Colab you can solve the issue by running:
+``` 
+!pip3 install torch --extra-index-url https://download.pytorch.org/whl/cpu -U 
+```
+before the ```!pip install torchrl``` command. This will install the latest pytorch. Instructions can be found [here](https://pytorch.org/get-started/locally/).
+
 ### Workarounds
-1. Install torch 1.13 or above.
-2. Install latest version of functorch. This version depends on torch 1.13 and will install it for you. 
-
-      ``` pip install functorch ```
-3. If you need to keep you current torch version, install from source. 
-
-      ``` pip install git+https://github.com/pytorch/rl@<put_version_here> ```
+There are two workarounds to this issue
+1. Install/upgrade to the latest pytorch release before installing torchrl.
+2. If you need to use a previous pytorch relase: Install functorch version related to your torch distribution: e.g. ``` pip install functorch==0.2.0 ```   
+      and install library from source ``` pip install git+https://github.com/pytorch/rl@<lib_version_here> ```.

--- a/knowledge_base/VERSIONING_ISSUES.md
+++ b/knowledge_base/VERSIONING_ISSUES.md
@@ -5,8 +5,6 @@ This issue is related to https://github.com/pytorch/rl/issues/689. Using PyTorch
 ```
 ImportError: /usr/local/lib/python3.7/dist-packages/torchrl/_torchrl.so: undefined symbol: _ZN8pybind116detail11type_casterIN2at6TensorEvE4loadENS_6handleEb
 ```
-This is probably due to some incompatibility (tensor casting?) of torch C++ bindings between version 1.12 and 1.13. 
-
 
 ### How to reproduce
 1. Create an Colab Notebook (at 24/11/2022 Colab enviroment has Python 3.7 and Pytorch 1.12 installed by default).

--- a/knowledge_base/VERSIONING_ISSUES.md
+++ b/knowledge_base/VERSIONING_ISSUES.md
@@ -11,7 +11,7 @@ ImportError: /usr/local/lib/python3.7/dist-packages/torchrl/_torchrl.so: undefin
 2. ``` !pip install torchrl ```
 3. ``` import torchrl ```
 
-On Colab you can solve the issue by running:
+In Colab you can solve the issue by running:
 ``` 
 !pip3 install torch --extra-index-url https://download.pytorch.org/whl/cpu -U 
 ```

--- a/knowledge_base/VERSIONING_ISSUES.md
+++ b/knowledge_base/VERSIONING_ISSUES.md
@@ -21,5 +21,3 @@ This is probably due to some incompatibility (tensor casting?) of torch C++ bind
 3. If you need to keep you current torch version, install from source. 
 
       ``` pip install git+https://github.com/pytorch/rl@<put_version_here> ```
-
-

--- a/knowledge_base/VERSIONING_ISSUES.md
+++ b/knowledge_base/VERSIONING_ISSUES.md
@@ -1,0 +1,25 @@
+# Versioning Issues
+
+## Pytorch version
+This issue is related to https://github.com/pytorch/rl/issues/689. Using PyTorch versions lower < 1.13 and installing stable package leads to the following error:
+```
+ImportError: /usr/local/lib/python3.7/dist-packages/torchrl/_torchrl.so: undefined symbol: _ZN8pybind116detail11type_casterIN2at6TensorEvE4loadENS_6handleEb
+```
+This is probably due to some incompatibility (tensor casting?) of torch C++ bindings between version 1.12 and 1.13. 
+
+
+### How to reproduce
+1. Create an Colab Notebook (at 24/11/2022 Colab enviroment has Python 3.7 and Pytorch 1.12 installed by default).
+2. ``` !pip install torchrl ```
+3. ``` import torchrl ```
+
+### Workarounds
+1. Install torch 1.13 or above.
+2. Install latest version of functorch. This version depends on torch 1.13 and will install it for you. 
+
+      ``` pip install functorch ```
+3. If you need to keep you current torch version, install from source. 
+
+      ``` pip install git+https://github.com/pytorch/rl@<put_version_here> ```
+
+

--- a/knowledge_base/VERSIONING_ISSUES.md
+++ b/knowledge_base/VERSIONING_ISSUES.md
@@ -20,5 +20,4 @@ before the ```!pip install torchrl``` command. This will install the latest pyto
 ### Workarounds
 There are two workarounds to this issue
 1. Install/upgrade to the latest pytorch release before installing torchrl.
-2. If you need to use a previous pytorch relase: Install functorch version related to your torch distribution: e.g. ``` pip install functorch==0.2.0 ```   
-      and install library from source ``` pip install git+https://github.com/pytorch/rl@<lib_version_here> ```.
+2. If you need to use a previous pytorch relase: Install functorch version related to your torch distribution: e.g. ``` pip install functorch==0.2.0 ``` and install library from source ``` pip install git+https://github.com/pytorch/rl@<lib_version_here> ```.


### PR DESCRIPTION
## Description
This PR:
- Documents an issue with PyTorch versioning
- Proposes some workarounds to make the library work with older PyTorch versions installed.
- Links such documentation in the troubleshooting section of the README

## Motivation and Context

When using torch at lower version than 1.13 and installing the package stable version via pip, an undefined symbol error appears when trying to import the module. 

Related to https://github.com/pytorch/rl/issues/689.

## Types of changes
- [x] Documentation (update in the documentation)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
