### PR TITLE
Clone TensorDict docs into _local_build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -86,8 +86,8 @@ jobs:
         cd ..
     - name: Pull TensorDict docs
       run: |
-        git clone --branch gh-pages https://github.com/pytorch-labs/tensordict.git docs/build/html/tensordict
-        rm -rf docs/build/html/tensordict/.git
+        git clone --branch gh-pages https://github.com/pytorch-labs/tensordict.git docs/_local_build/tensordict
+        rm -rf docs/_local_build/tensordict/.git
     - name: Get output time
       run: echo "The time was ${{ steps.build.outputs.time }}"
     - name: Deploy


### PR DESCRIPTION
## Description

Recent changes to docs CI/CD change the outputdir of sphinx from build/html to _local_build.

This PR ensures we pull the TensorDict docs into the same directory.

Tested in my fork and seems to be working: https://github.com/tcbegley/rl/tree/gh-pages

