### PR TITLE
[Refactor] Sequential probabilistic changes

### DIFF
--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -2921,6 +2921,8 @@ def test_shared_params(dest, expected_dtype, expected_device):
         loss.qvalue_network_params.items(include_nested=True, leaves_only=True)
     ):
         p1 = value
+        if isinstance(loss.actor_network, SafeProbabilisticModule):
+            key = ("module", *key) if isinstance(key, tuple) else ("module", key)
         p2 = loss.actor_network_params[key]
         assert (p1 == p2).all()
         if i == 1:
@@ -2943,6 +2945,8 @@ def test_shared_params(dest, expected_dtype, expected_device):
     for i, (key, qvalparam) in enumerate(
         loss.qvalue_network_params.items(include_nested=True, leaves_only=True)
     ):
+        if isinstance(loss.actor_network, SafeProbabilisticModule):
+            key = ("module", *key) if isinstance(key, tuple) else ("module", key)
         assert qvalparam.dtype is expected_dtype, (key, qvalparam)
         assert qvalparam.device == torch.device(expected_device), key
         assert (qvalparam == loss.actor_network_params[key]).all(), key

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -321,7 +321,9 @@ def test_ppo_maker(device, from_pixels, shared_mapping, gsde, exploration):
 
         if cfg.gSDE:
             if cfg.shared_mapping:
-                tsf_loc = actor[-1].module[-1].module.transform(td_clone.get("loc"))
+                tsf_loc = (
+                    actor.module[-1].module[-1].module.transform(td_clone.get("loc"))
+                )
             else:
                 tsf_loc = actor.module[-1].module.transform(td_clone.get("loc"))
 
@@ -448,7 +450,9 @@ def test_a2c_maker(device, from_pixels, shared_mapping, gsde, exploration):
 
         if cfg.gSDE:
             if cfg.shared_mapping:
-                tsf_loc = actor[-1].module[-1].module.transform(td_clone.get("loc"))
+                tsf_loc = (
+                    actor.module[-1].module[-1].module.transform(td_clone.get("loc"))
+                )
             else:
                 tsf_loc = actor.module[-1].module.transform(td_clone.get("loc"))
 

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -80,7 +80,7 @@ class TestTDModule:
                 self.linear_1 = nn.Linear(in_1, out_1)
                 self.linear_2 = nn.Linear(in_1, out_2)
 
-            def forward(self, x):
+            def forward(self, x):  # pragma: no cover
                 return self.linear_1(x), self.linear_2(x)
 
         spec_dict = {
@@ -176,7 +176,7 @@ class TestTDModule:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 4)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(4)
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError
         spec = (
             CompositeSpec(out=spec, **{out_key: None for out_key in out_keys})
@@ -189,7 +189,7 @@ class TestTDModule:
             dist_in_keys = ["loc", "scale"]
         elif out_keys == ["loc_1", "scale_1"]:
             dist_in_keys = {"loc": "loc_1", "scale": "scale_1"}
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError
 
         if safe and spec is None:
@@ -299,7 +299,7 @@ class TestTDModule:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 4)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(4)
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError
         spec = (
             CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
@@ -411,7 +411,7 @@ class TestTDModule:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 32)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(32)
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError
         spec = (
             CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
@@ -515,8 +515,6 @@ class TestTDModule:
         # test bounds
         if not safe and spec_type == "bounded":
             assert ((td_out.get("out") > 0.1) | (td_out.get("out") < -0.1)).any()
-        elif safe and spec_type == "bounded":
-            assert ((td_out.get("out") < 0.1) | (td_out.get("out") > -0.1)).all()
 
         # vmap = (0, 0)
         td = TensorDict({"in": torch.randn(3, 3)}, [3])
@@ -528,8 +526,6 @@ class TestTDModule:
         # test bounds
         if not safe and spec_type == "bounded":
             assert ((td_out.get("out") > 0.1) | (td_out.get("out") < -0.1)).any()
-        elif safe and spec_type == "bounded":
-            assert ((td_out.get("out") < 0.1) | (td_out.get("out") > -0.1)).all()
 
     @pytest.mark.skipif(
         not _has_functorch, reason="vmap can only be used with functorch"
@@ -551,7 +547,7 @@ class TestTDModule:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 4)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(4)
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError
         spec = (
             CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
@@ -603,8 +599,6 @@ class TestTDModule:
         # test bounds
         if not safe and spec_type == "bounded":
             assert ((td_out.get("out") > 0.1) | (td_out.get("out") < -0.1)).any()
-        elif safe and spec_type == "bounded":
-            assert ((td_out.get("out") < 0.1) | (td_out.get("out") > -0.1)).all()
 
         # vmap = (0, 0)
         td = TensorDict({"in": torch.randn(3, 3)}, [3])
@@ -616,8 +610,6 @@ class TestTDModule:
         # test bounds
         if not safe and spec_type == "bounded":
             assert ((td_out.get("out") > 0.1) | (td_out.get("out") < -0.1)).any()
-        elif safe and spec_type == "bounded":
-            assert ((td_out.get("out") < 0.1) | (td_out.get("out") > -0.1)).all()
 
 
 class TestTDSequence:
@@ -729,7 +721,7 @@ class TestTDSequence:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 4)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(4)
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError
         spec = (
             CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
@@ -876,7 +868,7 @@ class TestTDSequence:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 4)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(4)
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError
         spec = (
             CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
@@ -1040,7 +1032,7 @@ class TestTDSequence:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 7)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(7)
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError
         spec = (
             CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
@@ -1187,8 +1179,6 @@ class TestTDSequence:
         # test bounds
         if not safe and spec_type == "bounded":
             assert ((td_out.get("out") > 0.1) | (td_out.get("out") < -0.1)).any()
-        elif safe and spec_type == "bounded":
-            assert ((td_out.get("out") < 0.1) | (td_out.get("out") > -0.1)).all()
 
         # vmap = (0, 0)
         td = TensorDict({"in": torch.randn(3, 3)}, [3])
@@ -1200,8 +1190,6 @@ class TestTDSequence:
         # test bounds
         if not safe and spec_type == "bounded":
             assert ((td_out.get("out") > 0.1) | (td_out.get("out") < -0.1)).any()
-        elif safe and spec_type == "bounded":
-            assert ((td_out.get("out") < 0.1) | (td_out.get("out") > -0.1)).all()
 
     @pytest.mark.skipif(
         not _has_functorch, reason="vmap can only be used with functorch"
@@ -1223,7 +1211,7 @@ class TestTDSequence:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 4)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(4)
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError
         spec = (
             CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
@@ -1271,8 +1259,6 @@ class TestTDSequence:
         # test bounds
         if not safe and spec_type == "bounded":
             assert ((td_out.get("out") > 0.1) | (td_out.get("out") < -0.1)).any()
-        elif safe and spec_type == "bounded":
-            assert ((td_out.get("out") < 0.1) | (td_out.get("out") > -0.1)).all()
 
         # vmap = (0, 0)
         td = TensorDict({"in": torch.randn(3, 3)}, [3])
@@ -1284,8 +1270,6 @@ class TestTDSequence:
         # test bounds
         if not safe and spec_type == "bounded":
             assert ((td_out.get("out") > 0.1) | (td_out.get("out") < -0.1)).any()
-        elif safe and spec_type == "bounded":
-            assert ((td_out.get("out") < 0.1) | (td_out.get("out") > -0.1)).all()
 
     @pytest.mark.parametrize("functional", [True, False])
     def test_submodule_sequence(self, functional):
@@ -1419,7 +1403,7 @@ def test_is_tensordict_compatible():
             self.linear_2 = nn.Linear(in_1, out_2)
             self.linear_3 = nn.Linear(in_1, out_3)
 
-        def forward(self, x):
+        def forward(self, x):  # pragma: no cover
             return self.linear_1(x), self.linear_2(x), self.linear_3(x)
 
     td_module = SafeModule(
@@ -1434,7 +1418,7 @@ def test_is_tensordict_compatible():
             self.in_keys = in_keys
             self.out_keys = out_keys
 
-        def forward(self, tensordict):
+        def forward(self, tensordict):  # pragma: no cover
             pass
 
     compatible_nn_module = MockCompatibleModule(
@@ -1444,7 +1428,7 @@ def test_is_tensordict_compatible():
     assert is_tensordict_compatible(compatible_nn_module)
 
     class MockIncompatibleModuleNoKeys(nn.Module):
-        def forward(self, input):
+        def forward(self, input):  # pragma: no cover
             pass
 
     incompatible_nn_module_no_keys = MockIncompatibleModuleNoKeys()
@@ -1455,7 +1439,7 @@ def test_is_tensordict_compatible():
             self.in_keys = in_keys
             self.out_keys = out_keys
 
-        def forward(self, input_1, input_2):
+        def forward(self, input_1, input_2):  # pragma: no cover
             pass
 
     incompatible_nn_module_multi_args = MockIncompatibleModuleMultipleArgs(
@@ -1474,7 +1458,7 @@ def test_ensure_tensordict_compatible():
             self.linear_2 = nn.Linear(in_1, out_2)
             self.linear_3 = nn.Linear(in_1, out_3)
 
-        def forward(self, x):
+        def forward(self, x):  # pragma: no cover
             return self.linear_1(x), self.linear_2(x), self.linear_3(x)
 
     td_module = SafeModule(
@@ -1490,10 +1474,7 @@ def test_ensure_tensordict_compatible():
         ensure_tensordict_compatible(td_module, out_keys=["output"])
 
     class NonNNModule:
-        def __init__(self):
-            pass
-
-        def forward(self, x):
+        def forward(self, x):  # pragma: no cover
             pass
 
     non_nn_module = NonNNModule()
@@ -1501,7 +1482,7 @@ def test_ensure_tensordict_compatible():
         ensure_tensordict_compatible(non_nn_module)
 
     class ErrorNNModule(nn.Module):
-        def forward(self, in_1, in_2):
+        def forward(self, in_1, in_2):  # pragma: no cover
             pass
 
     error_nn_module = ErrorNNModule()
@@ -1518,6 +1499,6 @@ def test_ensure_tensordict_compatible():
     assert isinstance(ensured_module, SafeModule)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -650,8 +650,22 @@ class ActorValueOperator(SafeSequential):
             value_operator,
         )
 
-    def get_policy_operator(self) -> SafeSequential:
+    def get_policy_operator(self) -> SafeModule:
         """Returns a stand-alone policy operator that maps an observation to an action."""
+        if isinstance(self.module[1], SafeProbabilisticModule):
+            return SafeProbabilisticModule(
+                SafeSequential(self.module[0], self.module[1].module),
+                dist_in_keys=self.module[1].dist_in_keys,
+                sample_out_key=self.module[1].sample_out_key,
+                spec=self.module[1].spec,
+                safe=self.module[1].safe,
+                default_interaction_mode=self.module[1].default_interaction_mode,
+                distribution_class=self.module[1].distribution_class,
+                distribution_kwargs=self.module[1].distribution_kwargs,
+                return_log_prob=self.module[1].return_log_prob,
+                cache_dist=self.module[1].cache_dist,
+                n_empirical_estimate=self.module[1].n_empirical_estimate,
+            )
         return SafeSequential(self.module[0], self.module[1])
 
     def get_value_operator(self) -> SafeSequential:

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -10,7 +10,6 @@ from typing import Union
 import numpy as np
 import torch
 
-from tensordict.nn import TensorDictSequential
 from tensordict.tensordict import TensorDict, TensorDictBase
 from torch import Tensor
 
@@ -191,16 +190,9 @@ class REDQLoss(LossModule):
                 tensordict_actor,
                 actor_params,
             )
-            if isinstance(self.actor_network, TensorDictSequential):
-                sample_key = self.actor_network[-1].sample_out_key[0]
-                tensordict_actor_dist = self.actor_network[-1].build_dist_from_params(
-                    td_params
-                )
-            else:
-                sample_key = self.actor_network.sample_out_key[0]
-                tensordict_actor_dist = self.actor_network.build_dist_from_params(
-                    td_params
-                )
+
+            sample_key = self.actor_network.sample_out_key[0]
+            tensordict_actor_dist = self.actor_network.build_dist_from_params(td_params)
             tensordict_actor[sample_key] = tensordict_actor_dist.rsample()
             tensordict_actor["sample_log_prob"] = tensordict_actor_dist.log_prob(
                 tensordict_actor[sample_key]


### PR DESCRIPTION
## Description

pytorch-labs/tensordict#88 deprecates the `get_dist` and `get_dist_params` methods of `TensorDictSequential` and hence `torchrl.modules.SafeSequential` which subclasses it. This PR adapts code and tests in TorchRL for that change.

This supercedes an earlier PR https://github.com/tcbegley/rl/pull/5 (rebased onto new commits + targeting TorchRL main rather than a branch on my fork).