### PR TITLE
[Tests] Omit tests and examples from codecov checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,3 +30,6 @@ ignore-decorators =
     test_*
 ;    test/*.py
 ;    .circleci/*
+
+[coverage:run]
+omit = test/*,examples/*


### PR DESCRIPTION
## Description

Currently codecov checks are being applied to test and example files. This PR configures `coverage` to only check the test coverage inside `torchrl` itself.

I originally noticed this while working on #719.