### PR TITLE
[Refactor] Adopt prototype ProbabilisticTensorDictModule and ProbabilisticTensorDictSequential

### DIFF
--- a/docs/source/reference/modules.rst
+++ b/docs/source/reference/modules.rst
@@ -14,6 +14,7 @@ TensorDict modules
     SafeModule
     SafeProbabilisticModule
     SafeSequential
+    SafeProbabilisticSequential
     Actor
     ProbabilisticActor
     ValueOperator

--- a/test/test_exploration.py
+++ b/test/test_exploration.py
@@ -65,7 +65,7 @@ def test_ou_wrapper(device, d_obs=4, d_act=6, batch=32, n_steps=100, seed=0):
     policy = ProbabilisticActor(
         spec=action_spec,
         module=module,
-        dist_in_keys=["loc", "scale"],
+        in_keys=["loc", "scale"],
         distribution_class=TanhNormal,
         default_interaction_mode="random",
     ).to(device)
@@ -121,7 +121,7 @@ class TestAdditiveGaussian:
         policy = ProbabilisticActor(
             spec=CompositeSpec(action=action_spec) if spec_origin is not None else None,
             module=module,
-            dist_in_keys=["loc", "scale"],
+            in_keys=["loc", "scale"],
             distribution_class=TanhNormal,
             default_interaction_mode="random",
         ).to(device)
@@ -182,7 +182,7 @@ class TestAdditiveGaussian:
         policy = ProbabilisticActor(
             spec=action_spec if spec_origin is not None else None,
             module=module,
-            dist_in_keys=["loc", "scale"],
+            in_keys=["loc", "scale"],
             distribution_class=TanhNormal,
             default_interaction_mode="random",
         ).to(device)
@@ -251,8 +251,8 @@ def test_gsde(
     actor = ProbabilisticActor(
         module=module,
         spec=spec,
-        dist_in_keys=["loc", "scale"],
-        sample_out_key=["action"],
+        in_keys=["loc", "scale"],
+        out_keys=["action"],
         distribution_class=distribution_class,
         distribution_kwargs=distribution_kwargs,
         default_interaction_mode=exploration_mode,
@@ -278,7 +278,7 @@ def test_gsde(
     if not safe:
         with set_exploration_mode(exploration_mode):
             action1 = module(td).get("action")
-        action2 = actor(td).get("action")
+        action2 = actor(td.exclude("action")).get("action")
         if gSDE or exploration_mode == "mode":
             torch.testing.assert_close(action1, action2)
         else:
@@ -286,14 +286,7 @@ def test_gsde(
                 torch.testing.assert_close(action1, action2)
 
 
-@pytest.mark.parametrize(
-    "state_dim",
-    [
-        (5,),
-        (12,),
-        (12, 3),
-    ],
-)
+@pytest.mark.parametrize("state_dim", [(5,), (12,), (12, 3)])
 @pytest.mark.parametrize("action_dim", [5, 12])
 @pytest.mark.parametrize("mean", [0, -2])
 @pytest.mark.parametrize("std", [1, 2])

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -211,7 +211,7 @@ def test_ddpg_maker(device, from_pixels, gsde, exploration):
             raise
 
         if cfg.gSDE:
-            tsf_loc = actor.module[-1].module.transform(td.get("loc"))
+            tsf_loc = actor.module[0].module[-1].module.transform(td.get("loc"))
             if exploration == "random":
                 with pytest.raises(AssertionError):
                     torch.testing.assert_close(td.get("action"), tsf_loc)
@@ -344,9 +344,11 @@ def test_ppo_maker(
 
         if cfg.gSDE:
             if cfg.shared_mapping:
-                tsf_loc = actor[-1].module[-1].module.transform(td_clone.get("loc"))
+                tsf_loc = actor[-2].module[-1].module.transform(td_clone.get("loc"))
             else:
-                tsf_loc = actor.module[-1].module.transform(td_clone.get("loc"))
+                tsf_loc = (
+                    actor.module[0].module[-1].module.transform(td_clone.get("loc"))
+                )
 
             if exploration == "random":
                 with pytest.raises(AssertionError):
@@ -494,9 +496,11 @@ def test_a2c_maker(
 
         if cfg.gSDE:
             if cfg.shared_mapping:
-                tsf_loc = actor[-1].module[-1].module.transform(td_clone.get("loc"))
+                tsf_loc = actor[-2].module[-1].module.transform(td_clone.get("loc"))
             else:
-                tsf_loc = actor.module[-1].module.transform(td_clone.get("loc"))
+                tsf_loc = (
+                    actor.module[0].module[-1].module.transform(td_clone.get("loc"))
+                )
 
             if exploration == "random":
                 with pytest.raises(AssertionError):
@@ -606,7 +610,7 @@ def test_sac_make(device, gsde, tanh_loc, from_pixels, exploration):
             expected_keys += ["_eps_gSDE"]
 
         if cfg.gSDE:
-            tsf_loc = actor.module[-1].module.transform(td_clone.get("loc"))
+            tsf_loc = actor.module[0].module[-1].module.transform(td_clone.get("loc"))
             if exploration == "random":
                 with pytest.raises(AssertionError):
                     torch.testing.assert_close(td_clone.get("action"), tsf_loc)
@@ -735,7 +739,7 @@ def test_redq_make(device, from_pixels, gsde, exploration):
             raise
 
         if cfg.gSDE:
-            tsf_loc = actor.module[-1].module.transform(td.get("loc"))
+            tsf_loc = actor.module[0].module[-1].module.transform(td.get("loc"))
             if exploration == "random":
                 with pytest.raises(AssertionError):
                     torch.testing.assert_close(td.get("action"), tsf_loc)

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -256,11 +256,11 @@ def test_value_based_policy_categorical(device):
 @pytest.mark.parametrize("device", get_available_devices())
 def test_actorcritic(device):
     common_module = SafeModule(
-        spec=None, module=nn.Linear(3, 4), in_keys=["obs"], out_keys=["hidden"]
+        module=nn.Linear(3, 4), in_keys=["obs"], out_keys=["hidden"], spec=None
     ).to(device)
     module = SafeModule(nn.Linear(4, 5), in_keys=["hidden"], out_keys=["param"])
     policy_operator = ProbabilisticActor(
-        spec=None, module=module, dist_in_keys=["param"], return_log_prob=True
+        module=module, in_keys=["param"], spec=None, return_log_prob=True
     ).to(device)
     value_operator = ValueOperator(nn.Linear(4, 1), in_keys=["hidden"]).to(device)
     op = ActorValueOperator(

--- a/torchrl/modules/__init__.py
+++ b/torchrl/modules/__init__.py
@@ -47,6 +47,7 @@ from .tensordict_module import (
     QValueActor,
     SafeModule,
     SafeProbabilisticModule,
+    SafeProbabilisticSequential,
     SafeSequential,
     ValueOperator,
     WorldModelWrapper,

--- a/torchrl/modules/tensordict_module/__init__.py
+++ b/torchrl/modules/tensordict_module/__init__.py
@@ -19,6 +19,6 @@ from .exploration import (
     EGreedyWrapper,
     OrnsteinUhlenbeckProcessWrapper,
 )
-from .probabilistic import SafeProbabilisticModule
+from .probabilistic import SafeProbabilisticModule, SafeProbabilisticSequential
 from .sequence import SafeSequential
 from .world_models import WorldModelWrapper

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -12,7 +12,10 @@ from torch import nn
 from torchrl.data import CompositeSpec, TensorSpec, UnboundedContinuousTensorSpec
 from torchrl.modules.models.models import DistributionalDQNnet
 from torchrl.modules.tensordict_module.common import SafeModule
-from torchrl.modules.tensordict_module.probabilistic import SafeProbabilisticModule
+from torchrl.modules.tensordict_module.probabilistic import (
+    SafeProbabilisticModule,
+    SafeProbabilisticSequential,
+)
 from torchrl.modules.tensordict_module.sequence import SafeSequential
 
 
@@ -68,7 +71,7 @@ class Actor(SafeModule):
         )
 
 
-class ProbabilisticActor(SafeProbabilisticModule):
+class ProbabilisticActor(SafeProbabilisticSequential):
     """General class for probabilistic actors in RL.
 
     The Actor class comes with default values for the out_keys (["action"])
@@ -110,26 +113,25 @@ class ProbabilisticActor(SafeProbabilisticModule):
     def __init__(
         self,
         module: SafeModule,
-        dist_in_keys: Union[str, Sequence[str]],
-        sample_out_key: Optional[Sequence[str]] = None,
+        in_keys: Union[str, Sequence[str]],
+        out_keys: Optional[Sequence[str]] = None,
         spec: Optional[TensorSpec] = None,
         **kwargs,
     ):
-        if sample_out_key is None:
-            sample_out_key = ["action"]
+        if out_keys is None:
+            out_keys = ["action"]
         if (
-            "action" in sample_out_key
+            "action" in out_keys
             and spec is not None
             and not isinstance(spec, CompositeSpec)
         ):
             spec = CompositeSpec(action=spec)
 
         super().__init__(
-            module=module,
-            dist_in_keys=dist_in_keys,
-            sample_out_key=sample_out_key,
-            spec=spec,
-            **kwargs,
+            module,
+            SafeProbabilisticModule(
+                in_keys=in_keys, out_keys=out_keys, spec=spec, **kwargs
+            ),
         )
 
 
@@ -652,6 +654,8 @@ class ActorValueOperator(SafeSequential):
 
     def get_policy_operator(self) -> SafeSequential:
         """Returns a stand-alone policy operator that maps an observation to an action."""
+        if isinstance(self.module[1], SafeProbabilisticSequential):
+            return SafeProbabilisticSequential(self.module[0], *self.module[1].module)
         return SafeSequential(self.module[0], self.module[1])
 
     def get_value_operator(self) -> SafeSequential:

--- a/torchrl/modules/tensordict_module/probabilistic.py
+++ b/torchrl/modules/tensordict_module/probabilistic.py
@@ -3,140 +3,29 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import warnings
 from typing import Optional, Sequence, Type, Union
 
-from tensordict.nn import ProbabilisticTensorDictModule
+from tensordict import TensorDictBase
+from tensordict.nn import TensorDictModule
+from tensordict.nn.prototype import (
+    ProbabilisticTensorDictModule,
+    ProbabilisticTensorDictSequential,
+)
 
-from torchrl.data import TensorSpec
+from torchrl.data import CompositeSpec, TensorSpec
+from torchrl.modules.tensordict_module.common import _forward_hook_safe_action
+from torchrl.modules.tensordict_module.sequence import SafeSequential
 from torchrl.modules.distributions import Delta
-from torchrl.modules.tensordict_module.common import SafeModule
 
 
-class SafeProbabilisticModule(ProbabilisticTensorDictModule, SafeModule):
-    """A :obj:``SafeProbabilisticModule`` is an :obj:``tensordict.nn.ProbabilisticTensorDictModule`` subclass that accepts a :obj:``TensorSpec`` as argument to control the output domain.
-
-    It consists in a wrapper around another TDModule that returns a tensordict
-    updated with the distribution parameters. :obj:`SafeProbabilisticModule` is
-    responsible for constructing the distribution (through the :obj:`get_dist()` method)
-    and/or sampling from this distribution (through a regular :obj:`__call__()` to the
-    module).
-
-    A :obj:`SafeProbabilisticModule` instance has two main features:
-    - It reads and writes TensorDict objects
-    - It uses a real mapping R^n -> R^m to create a distribution in R^d from
-    which values can be sampled or computed.
-    When the :obj:`__call__` / :obj:`forward` method is called, a distribution is created,
-    and a value computed (using the 'mean', 'mode', 'median' attribute or
-    the 'rsample', 'sample' method). The sampling step is skipped if the
-    inner TDModule has already created the desired key-value pair.
-
-    By default, SafeProbabilisticModule distribution class is a Delta
-    distribution, making SafeProbabilisticModule a simple wrapper around
-    a deterministic mapping function.
-
-    Args:
-        module (nn.Module): a nn.Module used to map the input to the output parameter space. Can be a functional
-            module (FunctionalModule or FunctionalModuleWithBuffers), in which case the :obj:`forward` method will expect
-            the params (and possibly) buffers keyword arguments.
-        dist_in_keys (str or iterable of str or dict): key(s) that will be produced
-            by the inner TDModule and that will be used to build the distribution.
-            Importantly, if it's an iterable of string or a string, those keys must match the keywords used by the distribution
-            class of interest, e.g. :obj:`"loc"` and :obj:`"scale"` for the Normal distribution
-            and similar. If dist_in_keys is a dictionary,, the keys are the keys of the distribution and the values are the
-            keys in the tensordict that will get match to the corresponding distribution keys.
-        sample_out_key (str or iterable of str): keys where the sampled values will be
-            written. Importantly, if this key is part of the :obj:`out_keys` of the inner model,
-            the sampling step will be skipped.
-        spec (TensorSpec): specs of the first output tensor. Used when calling td_module.random() to generate random
-            values in the target space.
-        safe (bool, optional): if True, the value of the sample is checked against the input spec. Out-of-domain sampling can
-            occur because of exploration policies or numerical under/overflow issues. As for the :obj:`spec` argument,
-            this check will only occur for the distribution sample, but not the other tensors returned by the input
-            module. If the sample is out of bounds, it is projected back onto the desired space using the
-            `TensorSpec.project`
-            method.
-            Default is :obj:`False`.
-        default_interaction_mode (str, optional): default method to be used to retrieve the output value. Should be one of:
-            'mode', 'median', 'mean' or 'random' (in which case the value is sampled randomly from the distribution).
-            Default is 'mode'.
-            Note: When a sample is drawn, the :obj:`ProbabilisticTDModule` instance will fist look for the interaction mode
-            dictated by the `exploration_mode()` global function. If this returns `None` (its default value),
-            then the `default_interaction_mode` of the `ProbabilisticTDModule` instance will be used.
-            Note that DataCollector instances will use `set_exploration_mode` to `"random"` by default.
-        distribution_class (Type, optional): a torch.distributions.Distribution class to be used for sampling.
-            Default is Delta.
-        distribution_kwargs (dict, optional): kwargs to be passed to the distribution.
-        return_log_prob (bool, optional): if True, the log-probability of the distribution sample will be written in the
-            tensordict with the key `f'{in_keys[0]}_log_prob'`. Default is `False`.
-        cache_dist (bool, optional): EXPERIMENTAL: if True, the parameters of the distribution (i.e. the output of the module)
-            will be written to the tensordict along with the sample. Those parameters can be used to
-            re-compute the original distribution later on (e.g. to compute the divergence between the distribution
-            used to sample the action and the updated distribution in PPO).
-            Default is `False`.
-        n_empirical_estimate (int, optional): number of samples to compute the empirical mean when it is not available.
-            Default is 1000
-
-    Examples:
-        >>> import torch
-        >>> from tensordict import TensorDict
-        >>> from tensordict.nn.functional_modules import make_functional
-        >>> from torchrl.data import CompositeSpec, NdUnboundedContinuousTensorSpec
-        >>> from torchrl.modules import (
-                NormalParamWrapper,
-                SafeModule,
-                SafeProbabilisticModule,
-                TanhNormal,
-            )
-        >>> td = TensorDict({"input": torch.randn(3, 4), "hidden": torch.randn(3, 8)}, [3,])
-        >>> spec = CompositeSpec(action=NdUnboundedContinuousTensorSpec(4), loc=None, scale=None)
-        >>> net = NormalParamWrapper(torch.nn.GRUCell(4, 8))
-        >>> module = SafeModule(net, in_keys=["input", "hidden"], out_keys=["loc", "scale"])
-        >>> td_module = SafeProbabilisticModule(
-        ...     module=module,
-        ...     spec=spec,
-        ...     dist_in_keys=["loc", "scale"],
-        ...     sample_out_key=["action"],
-        ...     distribution_class=TanhNormal,
-        ...     return_log_prob=True,
-        ... )
-        >>> params = make_functional(td_module)
-        >>> td_module(td, params=params)
-        >>> print(td)
-        TensorDict(
-            fields={
-                action: Tensor(torch.Size([3, 4]), dtype=torch.float32),
-                hidden: Tensor(torch.Size([3, 8]), dtype=torch.float32),
-                input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
-                loc: Tensor(torch.Size([3, 4]), dtype=torch.float32),
-                sample_log_prob: Tensor(torch.Size([3, 1]), dtype=torch.float32),
-                scale: Tensor(torch.Size([3, 4]), dtype=torch.float32)},
-            batch_size=torch.Size([3]),
-            device=None,
-            is_shared=False)
-        >>> # In the vmap case, the tensordict is again expended to match the batch:
-        >>> from functorch import vmap
-        >>> params = params.expand(4, *params.shape)
-        >>> td_vmap = vmap(td_module, (None, 0))(td, params)
-        >>> print(td_vmap)
-        TensorDict(
-            fields={
-                action: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
-                hidden: Tensor(torch.Size([4, 3, 8]), dtype=torch.float32),
-                input: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
-                loc: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
-                sample_log_prob: Tensor(torch.Size([4, 3, 1]), dtype=torch.float32),
-                scale: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32)},
-            batch_size=torch.Size([4, 3]),
-            device=None,
-            is_shared=False)
-
-    """
-
+class SafeProbabilisticModule(
+    ProbabilisticTensorDictModule,
+):
     def __init__(
         self,
-        module: SafeModule,
-        dist_in_keys: Union[str, Sequence[str], dict],
-        sample_out_key: Union[str, Sequence[str]],
+        in_keys: Union[str, Sequence[str], dict],
+        out_keys: Union[str, Sequence[str]],
         spec: Optional[TensorSpec] = None,
         safe: bool = False,
         default_interaction_mode: str = "mode",
@@ -147,9 +36,8 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule, SafeModule):
         n_empirical_estimate: int = 1000,
     ):
         super().__init__(
-            module=module,
-            dist_in_keys=dist_in_keys,
-            sample_out_key=sample_out_key,
+            in_keys=in_keys,
+            out_keys=out_keys,
             default_interaction_mode=default_interaction_mode,
             distribution_class=distribution_class,
             distribution_kwargs=distribution_kwargs,
@@ -157,10 +45,86 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule, SafeModule):
             cache_dist=cache_dist,
             n_empirical_estimate=n_empirical_estimate,
         )
-        super(ProbabilisticTensorDictModule, self).__init__(
-            module=module,
-            spec=spec,
-            in_keys=self.in_keys,
-            out_keys=self.out_keys,
-            safe=safe,
+
+        if spec is not None and not isinstance(spec, TensorSpec):
+            raise TypeError("spec must be a TensorSpec subclass")
+        elif spec is not None and not isinstance(spec, CompositeSpec):
+            if len(self.out_keys) > 1:
+                raise RuntimeError(
+                    f"got more than one out_key for the SafeModule: {self.out_keys},\nbut only one spec. "
+                    "Consider using a CompositeSpec object or no spec at all."
+                )
+            spec = CompositeSpec(**{self.out_keys[0]: spec})
+        elif spec is not None and isinstance(spec, CompositeSpec):
+            if "_" in spec.keys():
+                warnings.warn('got a spec with key "_": it will be ignored')
+        elif spec is None:
+            spec = CompositeSpec()
+
+        if set(spec.keys()) != set(self.out_keys):
+            # then assume that all the non indicated specs are None
+            for key in self.out_keys:
+                if key not in spec:
+                    spec[key] = None
+
+        if set(spec.keys()) != set(self.out_keys):
+            raise RuntimeError(
+                f"spec keys and out_keys do not match, got: {set(spec.keys())} and {set(self.out_keys)} respectively"
+            )
+
+        self._spec = spec
+        self.safe = safe
+        if safe:
+            if spec is None or (
+                isinstance(spec, CompositeSpec)
+                and all(_spec is None for _spec in spec.values())
+            ):
+                raise RuntimeError(
+                    "`SafeProbabilisticModule(spec=None, safe=True)` is not a valid configuration as the tensor "
+                    "specs are not specified"
+                )
+            self.register_forward_hook(_forward_hook_safe_action)
+
+    @property
+    def spec(self) -> CompositeSpec:
+        return self._spec
+
+    @spec.setter
+    def spec(self, spec: CompositeSpec) -> None:
+        if not isinstance(spec, CompositeSpec):
+            raise RuntimeError(
+                f"Trying to set an object of type {type(spec)} as a tensorspec but expected a CompositeSpec instance."
+            )
+        self._spec = spec
+
+    def random(self, tensordict: TensorDictBase) -> TensorDictBase:
+        """Samples a random element in the target space, irrespective of any input.
+
+        If multiple output keys are present, only the first will be written in the input :obj:`tensordict`.
+
+        Args:
+            tensordict (TensorDictBase): tensordict where the output value should be written.
+
+        Returns:
+            the original tensordict with a new/updated value for the output key.
+
+        """
+        key0 = self.out_keys[0]
+        tensordict.set(key0, self.spec.rand(tensordict.batch_size))
+        return tensordict
+
+    def random_sample(self, tensordict: TensorDictBase) -> TensorDictBase:
+        """See :obj:`SafeModule.random(...)`."""
+        return self.random(tensordict)
+
+
+class SafeProbabilisticSequential(ProbabilisticTensorDictSequential, SafeSequential):
+    def __init__(
+        self,
+        *modules: Union[TensorDictModule, ProbabilisticTensorDictModule],
+        partial_tolerant: bool = False,
+    ) -> None:
+        super().__init__(*modules, partial_tolerant=partial_tolerant)
+        super(ProbabilisticTensorDictSequential, self).__init__(
+            *modules, partial_tolerant=partial_tolerant
         )

--- a/torchrl/modules/tensordict_module/probabilistic.py
+++ b/torchrl/modules/tensordict_module/probabilistic.py
@@ -6,22 +6,93 @@
 import warnings
 from typing import Optional, Sequence, Type, Union
 
-from tensordict import TensorDictBase
 from tensordict.nn import TensorDictModule
 from tensordict.nn.prototype import (
     ProbabilisticTensorDictModule,
     ProbabilisticTensorDictSequential,
 )
+from tensordict.tensordict import TensorDictBase
 
 from torchrl.data import CompositeSpec, TensorSpec
+from torchrl.modules.distributions import Delta
 from torchrl.modules.tensordict_module.common import _forward_hook_safe_action
 from torchrl.modules.tensordict_module.sequence import SafeSequential
-from torchrl.modules.distributions import Delta
 
 
-class SafeProbabilisticModule(
-    ProbabilisticTensorDictModule,
-):
+class SafeProbabilisticModule(ProbabilisticTensorDictModule):
+    """A :obj:``SafeProbabilisticModule`` is an :obj:``tensordict.nn.prototype.ProbabilisticTensorDictModule`` subclass that accepts a :obj:``TensorSpec`` as argument to control the output domain.
+
+    `SafeProbabilisticModule` is a non-parametric module representing a
+    probability distribution. It reads the distribution parameters from an input
+    TensorDict using the specified `in_keys`. The output is sampled given some rule,
+    specified by the input :obj:`default_interaction_mode` argument and the
+    :obj:`interaction_mode()` global function.
+
+    :obj:`SafeProbabilisticModule` can be used to construct the distribution
+    (through the :obj:`get_dist()` method) and/or sampling from this distribution
+    (through a regular :obj:`__call__()` to the module).
+
+    A :obj:`SafeProbabilisticModule` instance has two main features:
+    - It reads and writes TensorDict objects
+    - It uses a real mapping R^n -> R^m to create a distribution in R^d from
+    which values can be sampled or computed.
+
+    When the :obj:`__call__` / :obj:`forward` method is called, a distribution is
+    created, and a value computed (using the 'mean', 'mode', 'median' attribute or
+    the 'rsample', 'sample' method). The sampling step is skipped if the supplied
+    TensorDict has all of the desired key-value pairs already.
+
+    By default, SafeProbabilisticModule distribution class is a Delta
+    distribution, making SafeProbabilisticModule a simple wrapper around
+    a deterministic mapping function.
+
+    Args:
+        in_keys (str or iterable of str or dict): key(s) that will be read from the
+            input TensorDict and used to build the distribution. Importantly, if it's an
+            iterable of string or a string, those keys must match the keywords used by
+            the distribution class of interest, e.g. :obj:`"loc"` and :obj:`"scale"` for
+            the Normal distribution and similar. If in_keys is a dictionary,, the keys
+            are the keys of the distribution and the values are the keys in the
+            tensordict that will get match to the corresponding distribution keys.
+        out_keys (str or iterable of str): keys where the sampled values will be
+            written. Importantly, if these keys are found in the input TensorDict, the
+            sampling step will be skipped.
+        spec (TensorSpec): specs of the first output tensor. Used when calling
+            td_module.random() to generate random values in the target space.
+        safe (bool, optional): if True, the value of the sample is checked against the
+            input spec. Out-of-domain sampling can occur because of exploration policies
+            or numerical under/overflow issues. As for the :obj:`spec` argument, this
+            check will only occur for the distribution sample, but not the other tensors
+            returned by the input module. If the sample is out of bounds, it is
+            projected back onto the desired space using the `TensorSpec.project` method.
+            Default is :obj:`False`.
+        default_interaction_mode (str, optional): default method to be used to retrieve
+            the output value. Should be one of: 'mode', 'median', 'mean' or 'random'
+            (in which case the value is sampled randomly from the distribution). Default
+            is 'mode'.
+            Note: When a sample is drawn, the :obj:`ProbabilisticTDModule` instance will
+            fist look for the interaction mode dictated by the `interaction_mode()`
+            global function. If this returns `None` (its default value), then the
+            `default_interaction_mode` of the `ProbabilisticTDModule` instance will be
+            used. Note that DataCollector instances will use `set_interaction_mode` to
+            `"random"` by default.
+        distribution_class (Type, optional): a torch.distributions.Distribution class to
+            be used for sampling. Default is Delta.
+        distribution_kwargs (dict, optional): kwargs to be passed to the distribution.
+        return_log_prob (bool, optional): if True, the log-probability of the
+            distribution sample will be written in the tensordict with the key
+            `'sample_log_prob'`. Default is `False`.
+        cache_dist (bool, optional): EXPERIMENTAL: if True, the parameters of the
+            distribution (i.e. the output of the module) will be written to the
+            tensordict along with the sample. Those parameters can be used to re-compute
+            the original distribution later on (e.g. to compute the divergence between
+            the distribution used to sample the action and the updated distribution in
+            PPO). Default is `False`.
+        n_empirical_estimate (int, optional): number of samples to compute the empirical
+            mean when it is not available. Default is 1000
+
+    """
+
     def __init__(
         self,
         in_keys: Union[str, Sequence[str], dict],
@@ -119,6 +190,26 @@ class SafeProbabilisticModule(
 
 
 class SafeProbabilisticSequential(ProbabilisticTensorDictSequential, SafeSequential):
+    """A :obj:``SafeProbabilisticSequential`` is an :obj:``tensordict.nn.prototype.ProbabilisticTensorDictSequential`` subclass that accepts a :obj:``TensorSpec`` as argument to control the output domain.
+
+    Similarly to :obj:`TensorDictSequential`, but enforces that the final module in the
+    sequence is an :obj:`ProbabilisticTensorDictModule` and also exposes ``get_dist``
+    method to recover the distribution object from the ``ProbabilisticTensorDictModule``
+
+    Args:
+         modules (iterable of TensorDictModules): ordered sequence of TensorDictModule
+            instances, terminating in ProbabilisticTensorDictModule, to be run
+            sequentially.
+         partial_tolerant (bool, optional): if True, the input tensordict can miss some
+            of the input keys. If so, the only module that will be executed are those
+            who can be executed given the keys that are present. Also, if the input
+            tensordict is a lazy stack of tensordicts AND if partial_tolerant is
+            :obj:`True` AND if the stack does not have the required keys, then
+            TensorDictSequential will scan through the sub-tensordicts looking for those
+            that have the required keys, if any.
+
+    """
+
     def __init__(
         self,
         *modules: Union[TensorDictModule, ProbabilisticTensorDictModule],

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -192,12 +192,12 @@ class REDQLoss(LossModule):
                 actor_params,
             )
             if isinstance(self.actor_network, TensorDictSequential):
-                sample_key = self.actor_network[-1].sample_out_key[0]
-                tensordict_actor_dist = self.actor_network[-1].build_dist_from_params(
+                sample_key = self.actor_network[-1].out_keys[0]
+                tensordict_actor_dist = self.actor_network.build_dist_from_params(
                     td_params
                 )
             else:
-                sample_key = self.actor_network.sample_out_key[0]
+                sample_key = self.actor_network.out_keys[0]
                 tensordict_actor_dist = self.actor_network.build_dist_from_params(
                     td_params
                 )

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -4,7 +4,7 @@ import torch
 from tensordict.tensordict import TensorDict, TensorDictBase
 
 from torchrl.envs.utils import step_mdp
-from torchrl.modules import SafeModule, SafeProbabilisticModule
+from torchrl.modules import SafeModule, SafeProbabilisticSequential
 from torchrl.objectives import distance_loss
 from torchrl.objectives.common import LossModule
 
@@ -19,7 +19,7 @@ class ReinforceLoss(LossModule):
 
     def __init__(
         self,
-        actor_network: SafeProbabilisticModule,
+        actor_network: SafeProbabilisticSequential,
         advantage_module: Callable[[TensorDictBase], TensorDictBase],
         critic: Optional[SafeModule] = None,
         delay_value: bool = False,

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -105,10 +105,7 @@ class SACLoss(LossModule):
             actor_network,
             "actor_network",
             create_target_params=self.delay_actor,
-            funs_to_decorate=[
-                "forward",
-                "get_dist",
-            ],
+            funs_to_decorate=["forward", "get_dist"],
         )
 
         # Value
@@ -215,7 +212,7 @@ class SACLoss(LossModule):
             dist = self.actor_network.get_dist(
                 tensordict,
                 params=self.actor_network_params,
-            )[0]
+            )
             a_reparm = dist.rsample()
         # if not self.actor_network.spec.is_in(a_reparm):
         #     a_reparm.data.copy_(self.actor_network.spec.project(a_reparm.data))
@@ -295,7 +292,7 @@ class SACLoss(LossModule):
         )
         pred_val = td_copy.get("state_value").squeeze(-1)
 
-        action_dist, *_ = self.actor_network.get_dist(
+        action_dist = self.actor_network.get_dist(
             td_copy,
             params=self.target_actor_network_params,
         )  # resample an action

--- a/torchrl/trainers/helpers/collectors.py
+++ b/torchrl/trainers/helpers/collectors.py
@@ -18,7 +18,7 @@ from torchrl.collectors.collectors import (
 from torchrl.data import MultiStep
 from torchrl.envs import ParallelEnv
 from torchrl.envs.common import EnvBase
-from torchrl.modules import SafeProbabilisticModule
+from torchrl.modules import SafeProbabilisticSequential
 
 
 def sync_async_collector(
@@ -249,7 +249,7 @@ def _make_collector(
 
 def make_collector_offpolicy(
     make_env: Callable[[], EnvBase],
-    actor_model_explore: Union[TensorDictModuleWrapper, SafeProbabilisticModule],
+    actor_model_explore: Union[TensorDictModuleWrapper, SafeProbabilisticSequential],
     cfg: "DictConfig",  # noqa: F821
     make_env_kwargs: Optional[Dict] = None,
 ) -> _DataCollector:
@@ -313,7 +313,7 @@ def make_collector_offpolicy(
 
 def make_collector_onpolicy(
     make_env: Callable[[], EnvBase],
-    actor_model_explore: Union[TensorDictModuleWrapper, SafeProbabilisticModule],
+    actor_model_explore: Union[TensorDictModuleWrapper, SafeProbabilisticSequential],
     cfg: "DictConfig",  # noqa: F821
     make_env_kwargs: Optional[Dict] = None,
 ) -> _DataCollector:

--- a/torchrl/trainers/helpers/models.py
+++ b/torchrl/trainers/helpers/models.py
@@ -26,6 +26,7 @@ from torchrl.modules import (
     NormalParamWrapper,
     SafeModule,
     SafeProbabilisticModule,
+    SafeProbabilisticSequential,
     SafeSequential,
 )
 from torchrl.modules.distributions import (
@@ -338,7 +339,7 @@ def make_ddpg_actor(
     # distribution.
     actor = ProbabilisticActor(
         module=actor_module,
-        dist_in_keys=["param"],
+        in_keys=["param"],
         spec=CompositeSpec(action=env_specs["action_spec"]),
         safe=True,
         distribution_class=TanhDelta,
@@ -605,7 +606,7 @@ def make_a2c_model(
         policy_operator = ProbabilisticActor(
             spec=CompositeSpec(action=action_spec),
             module=actor_module,
-            dist_in_keys=dist_in_keys,
+            in_keys=dist_in_keys,
             default_interaction_mode="random",
             distribution_class=policy_distribution_class,
             distribution_kwargs=policy_distribution_kwargs,
@@ -682,7 +683,7 @@ def make_a2c_model(
         policy_po = ProbabilisticActor(
             actor_module,
             spec=action_spec,
-            dist_in_keys=dist_in_keys,
+            in_keys=dist_in_keys,
             distribution_class=policy_distribution_class,
             distribution_kwargs=policy_distribution_kwargs,
             return_log_prob=True,
@@ -900,7 +901,7 @@ def make_ppo_model(
         policy_operator = ProbabilisticActor(
             spec=CompositeSpec(action=action_spec),
             module=actor_module,
-            dist_in_keys=dist_in_keys,
+            in_keys=dist_in_keys,
             default_interaction_mode="random",
             distribution_class=policy_distribution_class,
             distribution_kwargs=policy_distribution_kwargs,
@@ -977,7 +978,7 @@ def make_ppo_model(
         policy_po = ProbabilisticActor(
             actor_module,
             spec=action_spec,
-            dist_in_keys=dist_in_keys,
+            in_keys=dist_in_keys,
             distribution_class=policy_distribution_class,
             distribution_kwargs=policy_distribution_kwargs,
             return_log_prob=True,
@@ -1192,7 +1193,7 @@ def make_sac_model(
 
     actor = ProbabilisticActor(
         spec=action_spec,
-        dist_in_keys=["loc", "scale"],
+        in_keys=["loc", "scale"],
         module=actor_module,
         distribution_class=dist_class,
         distribution_kwargs=dist_kwargs,
@@ -1435,7 +1436,7 @@ def make_redq_model(
 
     actor = ProbabilisticActor(
         spec=action_spec,
-        dist_in_keys=["loc", "scale"],
+        in_keys=["loc", "scale"],
         module=actor_module,
         distribution_class=dist_class,
         distribution_kwargs=dist_kwargs,
@@ -1642,28 +1643,30 @@ def _dreamer_make_actors(
 
 
 def _dreamer_make_actor_sim(action_key, proof_environment, actor_module):
-    actor_simulator = SafeProbabilisticModule(
+    actor_simulator = SafeProbabilisticSequential(
         SafeModule(
             actor_module,
             in_keys=["state", "belief"],
             out_keys=["loc", "scale"],
+            spec=CompositeSpec(
+                **{
+                    "loc": NdUnboundedContinuousTensorSpec(
+                        proof_environment.action_spec.shape,
+                        device=proof_environment.action_spec.device,
+                    ),
+                    "scale": NdUnboundedContinuousTensorSpec(
+                        proof_environment.action_spec.shape,
+                        device=proof_environment.action_spec.device,
+                    ),
+                }
+            ),
         ),
-        dist_in_keys=["loc", "scale"],
-        sample_out_key=[action_key],
-        default_interaction_mode="random",
-        distribution_class=TanhNormal,
-        spec=CompositeSpec(
-            **{
-                action_key: proof_environment.action_spec,
-                "loc": NdUnboundedContinuousTensorSpec(
-                    proof_environment.action_spec.shape,
-                    device=proof_environment.action_spec.device,
-                ),
-                "scale": NdUnboundedContinuousTensorSpec(
-                    proof_environment.action_spec.shape,
-                    device=proof_environment.action_spec.device,
-                ),
-            }
+        SafeProbabilisticModule(
+            in_keys=["loc", "scale"],
+            out_keys=[action_key],
+            default_interaction_mode="random",
+            distribution_class=TanhNormal,
+            spec=CompositeSpec(**{action_key: proof_environment.action_spec}),
         ),
     )
     return actor_simulator
@@ -1690,26 +1693,30 @@ def _dreamer_make_actor_real(
                 "state",
             ],
         ),
-        SafeProbabilisticModule(
+        SafeProbabilisticSequential(
             SafeModule(
                 actor_module,
                 in_keys=["state", "belief"],
                 out_keys=["loc", "scale"],
+                spec=CompositeSpec(
+                    **{
+                        "loc": NdUnboundedContinuousTensorSpec(
+                            proof_environment.action_spec.shape,
+                        ),
+                        "scale": NdUnboundedContinuousTensorSpec(
+                            proof_environment.action_spec.shape,
+                        ),
+                    }
+                ),
             ),
-            dist_in_keys=["loc", "scale"],
-            sample_out_key=[action_key],
-            default_interaction_mode="random",
-            distribution_class=TanhNormal,
-            spec=CompositeSpec(
-                **{
-                    action_key: proof_environment.action_spec.to("cpu"),
-                    "loc": NdUnboundedContinuousTensorSpec(
-                        proof_environment.action_spec.shape,
-                    ),
-                    "scale": NdUnboundedContinuousTensorSpec(
-                        proof_environment.action_spec.shape,
-                    ),
-                }
+            SafeProbabilisticModule(
+                in_keys=["loc", "scale"],
+                out_keys=[action_key],
+                default_interaction_mode="random",
+                distribution_class=TanhNormal,
+                spec=CompositeSpec(
+                    **{action_key: proof_environment.action_spec.to("cpu")}
+                ),
             ),
         ),
         SafeModule(

--- a/tutorials/sphinx-tutorials/coding_ddpg.py
+++ b/tutorials/sphinx-tutorials/coding_ddpg.py
@@ -310,7 +310,7 @@ def make_ddpg_actor(
     # to the right space using a TanhDelta distribution.
     actor = ProbabilisticActor(
         module=actor_module,
-        dist_in_keys=["param"],
+        in_keys=["param"],
         spec=CompositeSpec(action=env_specs["action_spec"]),
         safe=True,
         distribution_class=TanhDelta,

--- a/tutorials/sphinx-tutorials/tensordict_module.py
+++ b/tutorials/sphinx-tutorials/tensordict_module.py
@@ -189,7 +189,10 @@ result_td = functorch.vmap(model, (None, 0))(tensordict, params)
 print("the output tensordict shape is: ", result_td.shape)
 
 
-from tensordict.nn import ProbabilisticTensorDictModule
+from tensordict.nn.prototype import (
+    ProbabilisticTensorDictModule,
+    ProbabilisticTensorDictSequential,
+)
 
 ###############################################################################
 # Do's and don't with TensorDictModule
@@ -207,37 +210,40 @@ from tensordict.nn import ProbabilisticTensorDictModule
 #
 # ``ProbabilisticTensorDictModule``
 # ----------------------------------
-# ``ProbabilisticTensorDictModule`` is a special case of a ``TensorDictModule``
-# where the output is sampled given some rule, specified by the input
-# ``default_interaction_mode`` argument and the ``exploration_mode()``
-# global function. If they conflict, the context manager precedes.
+# ``ProbabilisticTensorDictModule`` is a non-parametric module representing a
+# probability distribution. Distribution parameters are read from tensordict
+# input, and the output is written to an output tensordict. The output is
+# sampled given some rule, specified by the input ``default_interaction_mode``
+# argument and the ``exploration_mode()`` global function. If they conflict,
+# the context manager precedes.
 #
-# It consists in a wrapper around another ``TensorDictModule`` that returns
-# a tensordict updated with the distribution parameters.
+# It can be wired together with a ``TensorDictModule`` that returns
+# a tensordict updated with the distribution parameters using
+# ``ProbabilisticTensorDictSequential``. This is a special case of
+# ``TensorDictSequential`` that terminates in a
+# ``ProbabilisticTensorDictModule``.
 #
 # ``ProbabilisticTensorDictModule`` is responsible for constructing the
 # distribution (through the ``get_dist()`` method) and/or sampling from this
-# distribution (through a regular ``__call__()`` to the module).
+# distribution (through a regular ``__call__()`` to the module). The same
+# ``get_dist()`` method is exposed on ``ProbabilisticTensorDictSequential.
 #
 # One can find the parameters in the output tensordict as well as the log
 # probability if needed.
 
 from torchrl.modules import NormalParamWrapper, TanhNormal
 
-td = TensorDict(
-    {"input": torch.randn(3, 4), "hidden": torch.randn(3, 8)},
-    [
-        3,
-    ],
-)
+td = TensorDict({"input": torch.randn(3, 4), "hidden": torch.randn(3, 8)}, [3])
 net = NormalParamWrapper(torch.nn.GRUCell(4, 8))
 module = TensorDictModule(net, in_keys=["input", "hidden"], out_keys=["loc", "scale"])
-td_module = ProbabilisticTensorDictModule(
-    module=module,
-    dist_in_keys=["loc", "scale"],
-    sample_out_key=["action"],
-    distribution_class=TanhNormal,
-    return_log_prob=True,
+td_module = ProbabilisticTensorDictSequential(
+    module,
+    ProbabilisticTensorDictModule(
+        in_keys=["loc", "scale"],
+        out_keys=["action"],
+        distribution_class=TanhNormal,
+        return_log_prob=True,
+    ),
 )
 print(f"TensorDict before going through module: {td}")
 td_module(td)
@@ -284,8 +290,8 @@ module_action = TensorDictModule(
 )
 td_module_action = ProbabilisticActor(
     module=module_action,
-    dist_in_keys=["loc", "scale"],
-    sample_out_key=["action"],
+    in_keys=["loc", "scale"],
+    out_keys=["action"],
     distribution_class=TanhNormal,
     return_log_prob=True,
 )
@@ -296,12 +302,7 @@ td_module_value = ValueOperator(
     out_keys=["state_action_value"],
 )
 td_module = ActorCriticOperator(td_module_hidden, td_module_action, td_module_value)
-td = TensorDict(
-    {"observation": torch.randn(3, 4)},
-    [
-        3,
-    ],
-)
+td = TensorDict({"observation": torch.randn(3, 4)}, [3])
 print(td)
 td_clone = td_module(td.clone())
 print(td_clone)


### PR DESCRIPTION
## Description

This PR adopts the prototype refactored `ProbabilisticTensorDictModule` and `ProbabilisticTensorDictSequential` classes introduced in pytorch-labs/tensordict#104

Currently WIP while I work through the failing tests, but new usage should be clear. Most important changes are in:
- `torchrl/modules/tensordict_module/probabilistic.py` - refactors `SafeProbabilisticModule` and introduces the new `SafeProbabilisticSequential` class
- `torchrl/modules/tensordict_module/actors.py` - note the change to `ActorValueOperator` in particular

Most other changes are just updating usage.

This PR supercedes #719, though I will leave that open for now until it's clear we want to move ahead with the approach laid out in this PR and pytorch-labs/tensordict#104

TODO:
- [x] Update tutorials
