### PR TITLE
[Doc, CI] Update doc workflow to run on PR and only publishes doc on main.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - "*"
   workflow_dispatch:
 jobs:
   build_docs_job:
@@ -91,6 +94,7 @@ jobs:
     - name: Get output time
       run: echo "The time was ${{ steps.build.outputs.time }}"
     - name: Deploy
+      if: ${{ github.ref == 'refs/heads/main' }}
       uses: JamesIves/github-pages-deploy-action@releases/v4
       with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ We want to make contributing to this project as easy and transparent as
 possible.
 
 ## Installing the library
-Install the library as suggested in the README. For advanced features, 
+Install the library as suggested in the README. For advanced features,
 it is preferable to install the nightly built of pytorch.
 
 Make sure you install torchrl in develop mode by running
@@ -12,7 +12,7 @@ python setup.py develop
 ```
 in your shell.
 
-If the generation of this artifact in MacOs M1 doesn't work correctly or in the execution the message 
+If the generation of this artifact in MacOs M1 doesn't work correctly or in the execution the message
 `(mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e'))` appears, then try
 
 ```
@@ -20,17 +20,17 @@ ARCHFLAGS="-arch arm64" python setup.py develop
 ```
 
 ## Formatting your code
-**Type annotation** 
+**Type annotation**
 
-TorchRL is not strongly-typed, i.e. we do not enforce type hints, neither do we check that the ones that are present are valid. We rely on type hints purely for documentary purposes. Although this might change in the future, there is currently no need for this to be enforced at the moment. 
+TorchRL is not strongly-typed, i.e. we do not enforce type hints, neither do we check that the ones that are present are valid. We rely on type hints purely for documentary purposes. Although this might change in the future, there is currently no need for this to be enforced at the moment.
 
 **Linting**
 
-Before your PR is ready, you'll probably want your code to be checked. This can be done easily by installing 
+Before your PR is ready, you'll probably want your code to be checked. This can be done easily by installing
 ```
 pip install pre-commit
 ```
-and running 
+and running
 ```
 pre-commit run --all-files
 ```
@@ -45,7 +45,7 @@ We actively welcome your pull requests.
 1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
-4. Ensure the test suite passes.
+4. Ensure the test suite and the documentation pass.
 5. Make sure your code lints.
 6. If you haven't already, complete the Contributor License Agreement ("CLA").
 


### PR DESCRIPTION
## Description

This PR updates the workflow [docs.yml](https://github.com/pytorch/rl/blob/main/.github/workflows/docs.yml) to run it during a PR. However, it will deploy the documentation only when the commit lands on master.

**WARNING**: The use of dispatch may be affected by this change. A dispatch event may not deploy the documentation on gh-pages.

## Motivation and Context

TorchRL CI (on CircleCI) tests all the features of the library, except the build of the documentation.
This would be of little concern if that doc was static, but it actually runs a bunch of tutorial scripts that may break at times.
This PR allows to build the documentation during each PR.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
