### PR TITLE
[Feature] Add Step Counter transform

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -63,6 +63,7 @@ from torchrl.envs.transforms.transforms import (
     UnsqueezeTransform,
 )
 from torchrl.envs.transforms.vip import _VIPNet, VIPRewardTransform
+from torchrl.envs.utils import check_env_specs
 
 TIMEOUT = 10.0
 
@@ -1687,6 +1688,11 @@ class TestTransforms:
             )
         else:
             assert torch.all(td.get("step_count") == 0)
+
+    def test_step_counter_observation_spec(self):
+        env = TransformedEnv(GymEnv("Pendulum-v1"), StepCounter(50))
+        check_env_specs(GymEnv("Pendulum-v1"))
+        check_env_specs(env)
 
 
 @pytest.mark.skipif(not _has_tv, reason="torchvision not installed")

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1690,9 +1690,9 @@ class TestTransforms:
             assert torch.all(td.get("step_count") == 0)
 
     def test_step_counter_observation_spec(self):
-        env = TransformedEnv(GymEnv("Pendulum-v1"), StepCounter(50))
-        check_env_specs(GymEnv("Pendulum-v1"))
-        check_env_specs(env)
+        transformed_env = TransformedEnv(ContinuousActionVecMockEnv(), StepCounter(50))
+        check_env_specs(transformed_env)
+        transformed_env.close()
 
 
 @pytest.mark.skipif(not _has_tv, reason="torchvision not installed")

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1656,7 +1656,7 @@ class TestTransforms:
 
     @pytest.mark.parametrize("device", get_available_devices())
     @pytest.mark.parametrize("batch", [[], [4], [6, 4]])
-    @pytest.mark.parametrize("max_steps", [None, 0, 5])
+    @pytest.mark.parametrize("max_steps", [None, 1, 5, 50])
     @pytest.mark.parametrize("reset_workers", [True, False])
     def test_step_counter(self, max_steps, device, batch, reset_workers):
         torch.manual_seed(0)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1656,23 +1656,37 @@ class TestTransforms:
     @pytest.mark.parametrize("device", get_available_devices())
     @pytest.mark.parametrize("batch", [[], [4], [6, 4]])
     @pytest.mark.parametrize("max_steps", [None, 0, 5])
-    def test_step_counter(self, max_steps, device, batch):
+    @pytest.mark.parametrize("reset_workers", [True, False])
+    def test_step_counter(self, max_steps, device, batch, reset_workers):
         torch.manual_seed(0)
         step_counter = StepCounter(max_steps)
         td = TensorDict(
             {"done": torch.zeros(*batch, 1, dtype=torch.bool)}, batch, device=device
         )
+        if reset_workers:
+            td.set("reset_workers", torch.randn(*batch, 1) < 0)
         step_counter.reset(td)
         assert not torch.all(td.get("step_count"))
         i = 0
-        while not td.get("done").all():
+        while max_steps is None or i < max_steps:
             step_counter._step(td)
             i += 1
             assert torch.all(td.get("step_count") == i)
-            if max_steps is None or i == max_steps:
+            if max_steps is None:
                 break
         if max_steps is not None:
             assert torch.all(td.get("step_count") == max_steps)
+            assert torch.all(td.get("done"))
+        step_counter.reset(td)
+        if reset_workers:
+            assert torch.all(
+                torch.masked_select(td.get("step_count"), td.get("reset_workers")) == 0
+            )
+            assert torch.all(
+                torch.masked_select(td.get("step_count"), ~td.get("reset_workers")) == i
+            )
+        else:
+            assert torch.all(td.get("step_count") == 0)
 
 
 @pytest.mark.skipif(not _has_tv, reason="torchvision not installed")

--- a/torchrl/envs/__init__.py
+++ b/torchrl/envs/__init__.py
@@ -26,6 +26,7 @@ from .transforms import (
     Resize,
     RewardClipping,
     RewardScaling,
+    StepCounter,
     TensorDictPrimer,
     ToTensorImage,
     Transform,

--- a/torchrl/envs/transforms/__init__.py
+++ b/torchrl/envs/transforms/__init__.py
@@ -24,6 +24,7 @@ from .transforms import (
     RewardClipping,
     RewardScaling,
     SqueezeTransform,
+    StepCounter,
     TensorDictPrimer,
     ToTensorImage,
     Transform,

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -2486,7 +2486,7 @@ class StepCounter(Transform):
         max_steps (:obj:`int`, optional): a positive integer that indicates the maximum number of steps to take before
         setting the done state to True. If set to None (the default value), the environment will run indefinitely until
         the done state is manually set by the user or by the environment itself. However, the step count will still be
-        incremented on each call to step().
+        incremented on each call to step() into the `step_count` attribute.
     """
 
     invertible = False
@@ -2549,7 +2549,7 @@ class StepCounter(Transform):
                 f"observation_spec was expected to be of type CompositeSpec. Got {type(observation_spec)} instead."
             )
         observation_spec["step_count"] = UnboundedDiscreteTensorSpec(
-            dtype=torch.int64, device=observation_spec.device
+            shape=torch.Size([1]), dtype=torch.int64, device=observation_spec.device
         )
         observation_spec["step_count"].space.minimum = 0
         return observation_spec

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -2483,16 +2483,18 @@ class StepCounter(Transform):
     """Counts the steps from a reset and sets the done state to True after a certain number of steps.
 
     Args:
-        max_steps (:obj:`int`, optional): the maximum number of steps to take before setting the done state to
-        True. If set to None (the default value), the environment will run indefinitely until the done state is manually
-        set by the user or by the environment itself. However, the step count will still be incremented on each call to
-        step().
+        max_steps (:obj:`int`, optional): a positive integer that indicates the maximum number of steps to take before
+        setting the done state to True. If set to None (the default value), the environment will run indefinitely until
+        the done state is manually set by the user or by the environment itself. However, the step count will still be
+        incremented on each call to step().
     """
 
     invertible = False
     inplace = True
 
     def __init__(self, max_steps: Optional[int] = None):
+        if max_steps is not None and max_steps < 1:
+            raise ValueError("max_steps should have a value greater or equal to one.")
         self.max_steps = max_steps
         super().__init__([])
 
@@ -2516,8 +2518,6 @@ class StepCounter(Transform):
                 ),
             ),
         )
-        if self.max_steps is not None and self.max_steps <= 0:
-            tensordict.fill_("done", True)
         return tensordict
 
     def _step(self, tensordict: TensorDictBase) -> TensorDictBase:


### PR DESCRIPTION
## Description

Add a transform that counts the steps from a reset and sets the done state to True after a certain number of steps.

This transform can be used in parallel / multi env settings, as the counter has the size of the env.batch_size. The "step_counter" key will be added to the output of tensordict when reset or step in the environment.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] New feature (non-breaking change which adds core functionality)
- [x] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
