### PR TITLE
[BugFix] SyncDataCollector init when device and env_device are different

### DIFF
--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -1000,6 +1000,7 @@ def test_collector_device_combinations(device, passing_device):
         env = make_make_env("conv")()
         env.set_seed(seed)
         return env
+
     policy = dummypolicy_conv()
 
     collector = SyncDataCollector(
@@ -1018,14 +1019,22 @@ def test_collector_device_combinations(device, passing_device):
     collector.shutdown()
 
     collector = MultiSyncDataCollector(
-        create_env_fn=[env_fn, ],
-        create_env_kwargs=[{"seed": 0}, ],
+        create_env_fn=[
+            env_fn,
+        ],
+        create_env_kwargs=[
+            {"seed": 0},
+        ],
         policy=policy,
         frames_per_batch=20,
         max_frames_per_traj=2000,
         total_frames=20000,
-        devices=[device, ],
-        passing_devices=[passing_device, ],
+        devices=[
+            device,
+        ],
+        passing_devices=[
+            passing_device,
+        ],
         pin_memory=False,
     )
     batch = next(collector.iterator())
@@ -1033,19 +1042,28 @@ def test_collector_device_combinations(device, passing_device):
     collector.shutdown()
 
     collector = MultiaSyncDataCollector(
-        create_env_fn=[env_fn, ],
-        create_env_kwargs=[{"seed": 0}, ],
+        create_env_fn=[
+            env_fn,
+        ],
+        create_env_kwargs=[
+            {"seed": 0},
+        ],
         policy=policy,
         frames_per_batch=20,
         max_frames_per_traj=2000,
         total_frames=20000,
-        devices=[device, ],
-        passing_devices=[passing_device, ],
+        devices=[
+            device,
+        ],
+        passing_devices=[
+            passing_device,
+        ],
         pin_memory=False,
     )
     batch = next(collector.iterator())
     assert batch.device == torch.device(passing_device) or batch["done"].device
     collector.shutdown()
+
 
 @pytest.mark.skipif(not _has_gym, reason="test designed with GymEnv")
 @pytest.mark.parametrize(

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -993,6 +993,60 @@ def test_collector_output_keys(collector_class, init_random_frames, explicit_spe
     del collector
 
 
+@pytest.mark.parametrize("device", ["cuda", "cpu"])
+@pytest.mark.parametrize("passing_device", ["cuda", "cpu"])
+def test_collector_device_combinations(device, passing_device):
+    def env_fn(seed):
+        env = make_make_env("conv")()
+        env.set_seed(seed)
+        return env
+    policy = dummypolicy_conv()
+
+    collector = SyncDataCollector(
+        create_env_fn=env_fn,
+        create_env_kwargs={"seed": 0},
+        policy=policy,
+        frames_per_batch=20,
+        max_frames_per_traj=2000,
+        total_frames=20000,
+        device=device,
+        passing_device=passing_device,
+        pin_memory=False,
+    )
+    batch = next(collector.iterator())
+    assert batch.device == torch.device(passing_device) or batch["done"].device
+    collector.shutdown()
+
+    collector = MultiSyncDataCollector(
+        create_env_fn=[env_fn, ],
+        create_env_kwargs=[{"seed": 0}, ],
+        policy=policy,
+        frames_per_batch=20,
+        max_frames_per_traj=2000,
+        total_frames=20000,
+        devices=[device, ],
+        passing_devices=[passing_device, ],
+        pin_memory=False,
+    )
+    batch = next(collector.iterator())
+    assert batch.device == torch.device(passing_device) or batch["done"].device
+    collector.shutdown()
+
+    collector = MultiaSyncDataCollector(
+        create_env_fn=[env_fn, ],
+        create_env_kwargs=[{"seed": 0}, ],
+        policy=policy,
+        frames_per_batch=20,
+        max_frames_per_traj=2000,
+        total_frames=20000,
+        devices=[device, ],
+        passing_devices=[passing_device, ],
+        pin_memory=False,
+    )
+    batch = next(collector.iterator())
+    assert batch.device == torch.device(passing_device) or batch["done"].device
+    collector.shutdown()
+
 @pytest.mark.skipif(not _has_gym, reason="test designed with GymEnv")
 @pytest.mark.parametrize(
     "collector_class",

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -1015,7 +1015,7 @@ def test_collector_device_combinations(device, passing_device):
         pin_memory=False,
     )
     batch = next(collector.iterator())
-    assert batch.device == torch.device(passing_device) or batch["done"].device
+    assert batch.device == torch.device(passing_device)
     collector.shutdown()
 
     collector = MultiSyncDataCollector(
@@ -1038,7 +1038,7 @@ def test_collector_device_combinations(device, passing_device):
         pin_memory=False,
     )
     batch = next(collector.iterator())
-    assert batch.device == torch.device(passing_device) or batch["done"].device
+    assert batch.device == torch.device(passing_device)
     collector.shutdown()
 
     collector = MultiaSyncDataCollector(
@@ -1061,7 +1061,7 @@ def test_collector_device_combinations(device, passing_device):
         pin_memory=False,
     )
     batch = next(collector.iterator())
-    assert batch.device == torch.device(passing_device) or batch["done"].device
+    assert batch.device == torch.device(passing_device)
     collector.shutdown()
 
 

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -1258,12 +1258,14 @@ class MultiSyncDataCollector(_MultiDataCollector):
                 out_buffer = torch.cat(
                     list(out_tensordicts_shared.values()), 0, out=out_buffer
                 )
+                out_buffer = out_buffer.to(prev_device)
             else:
                 out_buffer = torch.cat(
                     [item.cpu() for item in out_tensordicts_shared.values()],
                     0,
                     out=out_buffer,
                 )
+                out_buffer = out_buffer.to(torch.device("cpu"))
 
             if self.split_trajs:
                 out = split_trajectories(out_buffer)

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -457,7 +457,9 @@ class SyncDataCollector(_DataCollector):
             # See #505 for additional context.
             with torch.no_grad():
                 self._tensordict_out = env.fake_tensordict()
+                self._tensordict_out = self._tensordict_out.to(self.device)
                 self._tensordict_out = self.policy(self._tensordict_out).unsqueeze(-1)
+                self._tensordict_out = self._tensordict_out.to(self.env_device)
             self._tensordict_out = (
                 self._tensordict_out.expand(*env.batch_size, self.frames_per_batch)
                 .to_tensordict()


### PR DESCRIPTION
## Description

In the init method of the SyncDataCollector class, a small number of steps is taken with the policy to determine the relevant keys of the output TensorDict. When the policy device and the environment device are different, that can raise a RuntimeError since the input provided to the policy is located in the environment device.

This PR only makes sure that the TensorDict provided to the policy is in the policy device, and then moves the output TensorDict to the environment device again. 

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
