### PR TITLE
Cleaning in envs `common.py`

### DIFF
--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -14,12 +14,11 @@ import numpy as np
 import torch
 import torch.nn as nn
 from tensordict.tensordict import TensorDict, TensorDictBase
-
 from torchrl.data import CompositeSpec, TensorSpec
 
+from .utils import get_available_libraries, step_mdp
 from .._utils import prod, seed_generator
 from ..data.utils import DEVICE_TYPING
-from .utils import get_available_libraries, step_mdp
 
 LIBRARIES = get_available_libraries()
 
@@ -470,7 +469,9 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
     def numel(self) -> int:
         return prod(self.batch_size)
 
-    def set_seed(self, seed: int, static_seed: bool = False) -> int:
+    def set_seed(
+        self, seed: Optional[int] = None, static_seed: bool = False
+    ) -> Optional[int]:
         """Sets the seed of the environment and returns the next seed to be used (which is the input seed if a single environment is present).
 
         Args:
@@ -820,21 +821,6 @@ class _EnvWrapper(EnvBase, metaclass=abc.ABCMeta):
             self._env.close()
         except AttributeError:
             pass
-
-    def set_seed(
-        self, seed: Optional[int] = None, static_seed: bool = False
-    ) -> Optional[int]:
-        if seed is not None:
-            torch.manual_seed(seed)
-        self._set_seed(seed)
-        if seed is not None and not static_seed:
-            new_seed = seed_generator(seed)
-            seed = new_seed
-        return seed
-
-    @abc.abstractmethod
-    def _set_seed(self, seed: Optional[int]):
-        raise NotImplementedError
 
 
 def make_tensordict(

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -16,9 +16,10 @@ import torch.nn as nn
 from tensordict.tensordict import TensorDict, TensorDictBase
 
 from torchrl.data import CompositeSpec, TensorSpec
-from .utils import get_available_libraries, step_mdp
+
 from .._utils import prod, seed_generator
 from ..data.utils import DEVICE_TYPING
+from .utils import get_available_libraries, step_mdp
 
 LIBRARIES = get_available_libraries()
 

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -14,8 +14,8 @@ import numpy as np
 import torch
 import torch.nn as nn
 from tensordict.tensordict import TensorDict, TensorDictBase
-from torchrl.data import CompositeSpec, TensorSpec
 
+from torchrl.data import CompositeSpec, TensorSpec
 from .utils import get_available_libraries, step_mdp
 from .._utils import prod, seed_generator
 from ..data.utils import DEVICE_TYPING
@@ -788,6 +788,7 @@ class _EnvWrapper(EnvBase, metaclass=abc.ABCMeta):
             f"env not set in {self.__class__.__name__}, cannot access {attr}"
         )
 
+    @abc.abstractmethod
     def _init_env(self) -> Optional[int]:
         """Runs all the necessary steps such that the environment is ready to use.
 

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -824,6 +824,10 @@ class _EnvWrapper(EnvBase, metaclass=abc.ABCMeta):
         except AttributeError:
             pass
 
+    @abc.abstractmethod
+    def _set_seed(self, seed: Optional[int]):
+        raise NotImplementedError
+
 
 def make_tensordict(
     env: _EnvWrapper,


### PR DESCRIPTION
## Description

1. Removed  identical `set_seed` override in `_EnvWrapper`
2. Updated type hints in `set_seed` of `EnvBase`
3. Made `_init_env()` abstract in `_EnvWrapper`

## Motivation and Context

We now enforce inheritors of  `_EnvWrapper` to implement `_init_env()`

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.


I have checked that the tests in `test_env.py` which I am able to run (without external libraries and cuda) are all passing and linted.