### PR TITLE
[Feature] Rework `to_one_hot` and `to_categorical` to take a tensor as parameter

### DIFF
--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -341,14 +341,26 @@ def test_discrete_conversion(n, device, shape):
         [4, 5, 1, 3],
     ],
 )
+@pytest.mark.parametrize(
+    "shape",
+    [
+        torch.Size([3]),
+        torch.Size([4, 5]),
+    ],
+)
 @pytest.mark.parametrize("device", get_available_devices())
-def test_multi_discrete_conversion(ns, device):
+def test_multi_discrete_conversion(ns, shape, device):
     categorical = MultiDiscreteTensorSpec(ns, device=device)
     one_hot = MultiOneHotDiscreteTensorSpec(ns, device=device)
 
     assert categorical != one_hot
     assert categorical.to_onehot() == one_hot
     assert one_hot.to_categorical() == categorical
+
+    assert categorical.is_in(one_hot.to_categorical(one_hot.rand(shape)))
+    assert one_hot.is_in(categorical.to_onehot(categorical.rand(shape)))
+
+    categorical.to_onehot()
 
 
 @pytest.mark.parametrize("is_complete", [True, False])

--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -240,9 +240,9 @@ def test_mult_onehot(shape, ns):
         for _r, _n in zip(rsplit, ns):
             assert (_r.sum(-1) == 1).all()
             assert _r.shape[-1] == _n
-        np_r = ts.to_numpy(r)
-        assert not ts.is_in(torch.tensor(np_r))
-        assert (ts.encode(np_r) == r).all()
+        categorical = ts.to_categorical(r)
+        assert not ts.is_in(categorical)
+        assert (ts.encode(categorical) == r).all()
 
 
 @pytest.mark.parametrize(
@@ -309,15 +309,7 @@ def test_multi_discrete(shape, ns, dtype):
         99,
     ],
 )
-@pytest.mark.parametrize(
-    "shape",
-    [
-        torch.Size([3]),
-        torch.Size([4, 5]),
-    ],
-)
 @pytest.mark.parametrize("device", get_available_devices())
-<<<<<<< HEAD:test/test_specs.py
 @pytest.mark.parametrize(
     "shape",
     [
@@ -1040,21 +1032,22 @@ class TestSpec:
         action_spec = MultiOneHotDiscreteTensorSpec((10, 5))
 
         actions_tensors = [action_spec.rand() for _ in range(10)]
-        actions_numpy = [action_spec.to_numpy(a) for a in actions_tensors]
-        actions_tensors_2 = [action_spec.encode(a) for a in actions_numpy]
+        actions_categorical = [action_spec.to_categorical(a) for a in actions_tensors]
+        actions_tensors_2 = [action_spec.encode(a) for a in actions_categorical]
         assert all(
             [(a1 == a2).all() for a1, a2 in zip(actions_tensors, actions_tensors_2)]
         )
 
-        actions_numpy = [
-            np.concatenate(
-                [np.random.randint(0, 10, (1,)), np.random.randint(0, 5, (1,))], 0
-            )
+        actions_categorical = [
+            torch.cat((torch.randint(0, 10, (1,)), torch.randint(0, 5, (1,))), 0)
             for a in actions_tensors
         ]
-        actions_tensors = [action_spec.encode(a) for a in actions_numpy]
-        actions_numpy_2 = [action_spec.to_numpy(a) for a in actions_tensors]
-        assert all((a1 == a2).all() for a1, a2 in zip(actions_numpy, actions_numpy_2))
+        actions_tensors = [action_spec.encode(a) for a in actions_categorical]
+        actions_categorical_2 = [action_spec.to_categorical(a) for a in actions_tensors]
+        assert all(
+            (a1 == a2).all()
+            for a1, a2 in zip(actions_categorical, actions_categorical_2)
+        )
 
     def test_one_hot_discrete_action_spec_rand(self):
         torch.manual_seed(0)
@@ -1091,14 +1084,14 @@ class TestSpec:
         action_spec = MultiOneHotDiscreteTensorSpec((10, 5))
 
         actions_tensors = [action_spec.rand() for _ in range(10)]
-        actions_numpy = [action_spec.to_numpy(a) for a in actions_tensors]
-        actions_tensors_2 = [action_spec.encode(a) for a in actions_numpy]
+        actions_categorical = [action_spec.to_categorical(a) for a in actions_tensors]
+        actions_tensors_2 = [action_spec.encode(a) for a in actions_categorical]
         assert all(
             [(a1 == a2).all() for a1, a2 in zip(actions_tensors, actions_tensors_2)]
         )
 
-        sample = np.stack(
-            [action_spec.to_numpy(action_spec.rand()) for _ in range(N)], 0
+        sample = torch.stack(
+            [action_spec.to_categorical(action_spec.rand()) for _ in range(N)], 0
         )
         assert sample.shape[0] == N
         assert sample.shape[1] == 2

--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -327,11 +327,11 @@ def test_discrete_conversion(n, device, shape):
     one_hot = OneHotDiscreteTensorSpec(n, device=device, shape=shape_one_hot)
 
     assert categorical != one_hot
-    assert categorical.to_onehot() == one_hot
-    assert one_hot.to_categorical() == categorical
+    assert categorical.to_one_hot_spec() == one_hot
+    assert one_hot.to_categorical_spec() == categorical
 
     assert categorical.is_in(one_hot.to_categorical(one_hot.rand(shape)))
-    assert one_hot.is_in(categorical.to_onehot(categorical.rand(shape)))
+    assert one_hot.is_in(categorical.to_one_hot(categorical.rand(shape)))
 
 
 @pytest.mark.parametrize(
@@ -357,11 +357,11 @@ def test_multi_discrete_conversion(ns, shape, device):
     one_hot = MultiOneHotDiscreteTensorSpec(ns, device=device)
 
     assert categorical != one_hot
-    assert categorical.to_onehot() == one_hot
-    assert one_hot.to_categorical() == categorical
+    assert categorical.to_one_hot_spec() == one_hot
+    assert one_hot.to_categorical_spec() == categorical
 
     assert categorical.is_in(one_hot.to_categorical(one_hot.rand(shape)))
-    assert one_hot.is_in(categorical.to_onehot(categorical.rand(shape)))
+    assert one_hot.is_in(categorical.to_one_hot(categorical.rand(shape)))
 
 
 @pytest.mark.parametrize("is_complete", [True, False])

--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -309,7 +309,15 @@ def test_multi_discrete(shape, ns, dtype):
         99,
     ],
 )
+@pytest.mark.parametrize(
+    "shape",
+    [
+        torch.Size([3]),
+        torch.Size([4, 5]),
+    ],
+)
 @pytest.mark.parametrize("device", get_available_devices())
+<<<<<<< HEAD:test/test_specs.py
 @pytest.mark.parametrize(
     "shape",
     [
@@ -329,6 +337,9 @@ def test_discrete_conversion(n, device, shape):
     assert categorical != one_hot
     assert categorical.to_onehot() == one_hot
     assert one_hot.to_categorical() == categorical
+
+    assert categorical.is_in(one_hot.to_categorical(one_hot.rand(shape)))
+    assert one_hot.is_in(categorical.to_onehot(categorical.rand(shape)))
 
 
 @pytest.mark.parametrize(
@@ -359,8 +370,6 @@ def test_multi_discrete_conversion(ns, shape, device):
 
     assert categorical.is_in(one_hot.to_categorical(one_hot.rand(shape)))
     assert one_hot.is_in(categorical.to_onehot(categorical.rand(shape)))
-
-    categorical.to_onehot()
 
 
 @pytest.mark.parametrize("is_complete", [True, False])

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -621,6 +621,17 @@ class OneHotDiscreteTensorSpec(TensorSpec):
     def to_categorical(
         self, val: Optional[torch.Tensor] = None, safe: bool = True
     ) -> Union[DiscreteTensorSpec, torch.Tensor]:
+        """Convert a given one-hot tensor in categorical format or convert the spec to the equivalent categorical spec.
+
+        Args:
+            val (torch.Tensor, optional): One-hot tensor to convert in categorical format. If not provided, the function
+                will convert the spec to the equivalent DiscreteTensorSpec (default).
+            safe (bool): boolean value indicating whether a check should be
+                performed on the value against the domain of the spec.
+
+        Returns:
+            If val is provided, returns the categorical tensor, otherwise returns a DiscreteTensorSpec
+        """
         if val is None:
             return DiscreteTensorSpec(
                 self.space.n, device=self.device, dtype=self.dtype, shape=self.shape[:-1]
@@ -1229,6 +1240,17 @@ class MultiOneHotDiscreteTensorSpec(OneHotDiscreteTensorSpec):
     def to_categorical(
         self, val: Optional[torch.Tensor] = None, safe: bool = True
     ) -> Union[MultiDiscreteTensorSpec, torch.Tensor]:
+        """Convert a given one-hot tensor in categorical format or convert the spec to the equivalent categorical spec.
+
+        Args:
+            val (torch.Tensor, optional): One-hot tensor to convert in categorical format. If not provided, the function
+                will convert the spec to the equivalent MultiDiscreteTensorSpec (default).
+            safe (bool): boolean value indicating whether a check should be
+                performed on the value against the domain of the spec.
+
+        Returns:
+            If val is provided, returns the categorical tensor, otherwise returns a MultiDiscreteTensorSpec
+        """
         if val is None:
             return MultiDiscreteTensorSpec(
                 [_space.n for _space in self.space],
@@ -1338,6 +1360,17 @@ class DiscreteTensorSpec(TensorSpec):
     def to_onehot(
         self, val: Optional[torch.Tensor] = None, safe: bool = True
     ) -> Union[OneHotDiscreteTensorSpec, torch.Tensor]:
+        """One-hot encode a given tensor or convert the spec to the equivalent one-hot spec.
+
+        Args:
+            val (torch.Tensor, optional): Tensor to one-hot encode. If not provided, the function will convert the
+                spec to the equivalent OneHotDiscreteTensorSpec (default).
+            safe (bool): boolean value indicating whether a check should be
+                performed on the value against the domain of the spec.
+
+        Returns:
+            If val is provided, returns the one-hot encoded tensor, otherwise returns a OneHotDiscreteTensorSpec
+        """
         if val is None:
             shape = [*self.shape, self.space.n]
             return OneHotDiscreteTensorSpec(
@@ -1507,8 +1540,20 @@ class MultiDiscreteTensorSpec(DiscreteTensorSpec):
 
         return ((val >= torch.zeros(self.nvec.size())) & (val < self.nvec)).all().item()
 
-    def to_onehot(self, val: Optional[torch.Tensor] = None, safe: bool = True) -> Union[
-        MultiOneHotDiscreteTensorSpec, torch.Tensor]:
+    def to_onehot(
+        self, val: Optional[torch.Tensor] = None, safe: bool = True
+    ) -> Union[MultiOneHotDiscreteTensorSpec, torch.Tensor]:
+        """One-hot encode a given tensor or convert the spec to the equivalent one-hot spec.
+
+        Args:
+            val (torch.Tensor, optional): Tensor to one-hot encode. If not provided, the function will convert the
+                spec to the equivalent MultOneHotDiscreteTensorSpec (default).
+            safe (bool): boolean value indicating whether a check should be
+                performed on the value against the domain of the spec.
+
+        Returns:
+            If val is provided, returns the one-hot encoded tensor, otherwise returns a MultOneHotDiscreteTensorSpec
+        """
         if val is None:
             nvec = [_space.n for _space in self.space]
             return MultiOneHotDiscreteTensorSpec(

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1533,8 +1533,15 @@ class MultiDiscreteTensorSpec(DiscreteTensorSpec):
         )
         if self.dtype != val.dtype or len(self.shape) > val.ndim or val_have_wrong_dim:
             return False
-
-        return ((val >= torch.zeros(self.nvec.size())) & (val < self.nvec)).all().item()
+        val_device = val.device
+        return (
+            (
+                (val >= torch.zeros(self.nvec.size(), device=val_device))
+                & (val < self.nvec.to(val_device))
+            )
+            .all()
+            .item()
+        )
 
     def to_onehot(
         self, val: Optional[torch.Tensor] = None, safe: bool = True

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -43,8 +43,8 @@ DEVICE_ERR_MSG = "device of empty CompositeSpec is not defined."
 
 
 def _default_dtype_and_device(
-        dtype: Union[None, torch.dtype],
-        device: Union[None, str, int, torch.device],
+    dtype: Union[None, torch.dtype],
+    device: Union[None, str, int, torch.device],
 ) -> Tuple[torch.dtype, torch.device]:
     if dtype is None:
         dtype = torch.get_default_dtype()
@@ -152,11 +152,11 @@ class ContinuousBox(Box):
 
     def __eq__(self, other):
         return (
-                type(self) == type(other)
-                and self.minimum.dtype == other.minimum.dtype
-                and self.maximum.dtype == other.maximum.dtype
-                and torch.equal(self.minimum, other.minimum)
-                and torch.equal(self.maximum, other.maximum)
+            type(self) == type(other)
+            and self.minimum.dtype == other.minimum.dtype
+            and self.maximum.dtype == other.maximum.dtype
+            and torch.equal(self.minimum, other.minimum)
+            and torch.equal(self.maximum, other.maximum)
         )
 
 
@@ -254,15 +254,15 @@ class TensorSpec:
                 else:
                     val = np.array(val)
             if isinstance(val, np.ndarray) and not all(
-                    stride > 0 for stride in val.strides
+                stride > 0 for stride in val.strides
             ):
                 val = val.copy()
             val = torch.tensor(val, device=self.device, dtype=self.dtype)
             if val.shape[-len(self.shape) :] != self.shape:
                 # option 1: add a singleton dim at the end
                 if (
-                        val.shape[-len(self.shape):] == self.shape[:-1]
-                        and self.shape[-1] == 1
+                    val.shape[-len(self.shape) :] == self.shape[:-1]
+                    and self.shape[-1] == 1
                 ):
                     val = val.unsqueeze(-1)
                 else:
@@ -477,12 +477,12 @@ class OneHotDiscreteTensorSpec(TensorSpec):
     domain: str = ""
 
     def __init__(
-            self,
-            n: int,
-            shape: Optional[torch.Size] = None,
-            device: Optional[DEVICE_TYPING] = None,
-            dtype: Optional[Union[str, torch.dtype]] = torch.long,
-            use_register: bool = False,
+        self,
+        n: int,
+        shape: Optional[torch.Size] = None,
+        device: Optional[DEVICE_TYPING] = None,
+        dtype: Optional[Union[str, torch.dtype]] = torch.long,
+        use_register: bool = False,
     ):
 
         dtype, device = _default_dtype_and_device(dtype, device)
@@ -532,7 +532,7 @@ class OneHotDiscreteTensorSpec(TensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -553,9 +553,9 @@ class OneHotDiscreteTensorSpec(TensorSpec):
         ).to(torch.long)
 
     def encode(
-            self,
-            val: Union[np.ndarray, torch.Tensor],
-            space: Optional[DiscreteBox] = None,
+        self,
+        val: Union[np.ndarray, torch.Tensor],
+        space: Optional[DiscreteBox] = None,
     ) -> torch.Tensor:
         if not isinstance(val, torch.Tensor):
             val = torch.tensor(val, dtype=self.dtype, device=self.device)
@@ -609,13 +609,13 @@ class OneHotDiscreteTensorSpec(TensorSpec):
 
     def __eq__(self, other):
         return (
-                type(self) == type(other)
-                and self.shape == other.shape
-                and self.space == other.space
-                and self.device == other.device
-                and self.dtype == other.dtype
-                and self.domain == other.domain
-                and self.use_register == other.use_register
+            type(self) == type(other)
+            and self.shape == other.shape
+            and self.space == other.space
+            and self.device == other.device
+            and self.dtype == other.dtype
+            and self.domain == other.domain
+            and self.use_register == other.use_register
         )
 
     def to_categorical(
@@ -634,7 +634,10 @@ class OneHotDiscreteTensorSpec(TensorSpec):
         """
         if val is None:
             return DiscreteTensorSpec(
-                self.space.n, device=self.device, dtype=self.dtype, shape=self.shape[:-1]
+                self.space.n,
+                device=self.device,
+                dtype=self.dtype,
+                shape=self.shape[:-1],
             )
         else:
             if safe:
@@ -655,12 +658,12 @@ class BoundedTensorSpec(TensorSpec):
     """
 
     def __init__(
-            self,
-            minimum: Union[float, torch.Tensor, np.ndarray],
-            maximum: Union[float, torch.Tensor, np.ndarray],
-            shape: Optional[Union[torch.Size, int]] = None,
-            device: Optional[DEVICE_TYPING] = None,
-            dtype: Optional[Union[torch.dtype, str]] = None,
+        self,
+        minimum: Union[float, torch.Tensor, np.ndarray],
+        maximum: Union[float, torch.Tensor, np.ndarray],
+        shape: Optional[Union[torch.Size, int]] = None,
+        device: Optional[DEVICE_TYPING] = None,
+        dtype: Optional[Union[torch.dtype, str]] = None,
     ):
         dtype, device = _default_dtype_and_device(dtype, device)
         if dtype is None:
@@ -740,7 +743,7 @@ class BoundedTensorSpec(TensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -760,9 +763,9 @@ class BoundedTensorSpec(TensorSpec):
         if self.dtype in (torch.float, torch.double, torch.half):
             shape = [*shape, *self.shape]
             out = (
-                    torch.zeros(shape, dtype=self.dtype, device=self.device).uniform_()
-                    * (b - a)
-                    + a
+                torch.zeros(shape, dtype=self.dtype, device=self.device).uniform_()
+                * (b - a)
+                + a
             )
             if (out > b).any():
                 out[out > b] = b.expand_as(out)[out > b]
@@ -805,7 +808,7 @@ class BoundedTensorSpec(TensorSpec):
     def is_in(self, val: torch.Tensor) -> bool:
         try:
             return (val >= self.space.minimum.to(val.device)).all() and (
-                    val <= self.space.maximum.to(val.device)
+                val <= self.space.maximum.to(val.device)
             ).all()
         except RuntimeError as err:
             if "The size of tensor a" in str(err):
@@ -849,10 +852,10 @@ class UnboundedContinuousTensorSpec(TensorSpec):
     """
 
     def __init__(
-            self,
-            shape: Union[torch.Size, int] = _DEFAULT_SHAPE,
-            device: Optional[DEVICE_TYPING] = None,
-            dtype: Optional[Union[str, torch.dtype]] = None,
+        self,
+        shape: Union[torch.Size, int] = _DEFAULT_SHAPE,
+        device: Optional[DEVICE_TYPING] = None,
+        dtype: Optional[Union[str, torch.dtype]] = None,
     ):
         if isinstance(shape, int):
             shape = torch.Size([shape])
@@ -899,7 +902,7 @@ class UnboundedContinuousTensorSpec(TensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -918,10 +921,10 @@ class UnboundedDiscreteTensorSpec(TensorSpec):
     """
 
     def __init__(
-            self,
-            shape: Union[torch.Size, int] = _DEFAULT_SHAPE,
-            device: Optional[DEVICE_TYPING] = None,
-            dtype: Optional[Union[str, torch.dtype]] = None,
+        self,
+        shape: Union[torch.Size, int] = _DEFAULT_SHAPE,
+        device: Optional[DEVICE_TYPING] = None,
+        dtype: Optional[Union[str, torch.dtype]] = None,
     ):
         if isinstance(shape, int):
             shape = torch.Size([shape])
@@ -982,7 +985,7 @@ class UnboundedDiscreteTensorSpec(TensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -1013,11 +1016,11 @@ class BinaryDiscreteTensorSpec(TensorSpec):
     domain: str = ""
 
     def __init__(
-            self,
-            n: int,
-            shape: Optional[torch.Size] = None,
-            device: Optional[DEVICE_TYPING] = None,
-            dtype: Union[str, torch.dtype] = torch.long,
+        self,
+        n: int,
+        shape: Optional[torch.Size] = None,
+        device: Optional[DEVICE_TYPING] = None,
+        dtype: Union[str, torch.dtype] = torch.long,
     ):
         dtype, device = _default_dtype_and_device(dtype, device)
         box = BinaryBox(n)
@@ -1059,7 +1062,7 @@ class BinaryDiscreteTensorSpec(TensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -1112,12 +1115,12 @@ class MultiOneHotDiscreteTensorSpec(OneHotDiscreteTensorSpec):
     """
 
     def __init__(
-            self,
-            nvec: Sequence[int],
-            shape: Optional[torch.Size] = None,
-            device=None,
-            dtype=torch.long,
-            use_register=False,
+        self,
+        nvec: Sequence[int],
+        shape: Optional[torch.Size] = None,
+        device=None,
+        dtype=torch.long,
+        use_register=False,
     ):
         self.nvec = nvec
         dtype, device = _default_dtype_and_device(dtype, device)
@@ -1202,13 +1205,6 @@ class MultiOneHotDiscreteTensorSpec(OneHotDiscreteTensorSpec):
             return None
         return val.split(split_sizes, dim=-1)
 
-    def to_numpy(self, val: torch.Tensor, safe: bool = True) -> np.ndarray:
-        if safe:
-            self.assert_is_in(val)
-        vals = self._split(val)
-        out = torch.stack([val.argmax(-1) for val in vals], -1).numpy()
-        return out
-
     def index(self, index: INDEX_TYPING, tensor_to_index: torch.Tensor) -> torch.Tensor:
         if not isinstance(index, torch.Tensor):
             raise ValueError(
@@ -1272,7 +1268,7 @@ class MultiOneHotDiscreteTensorSpec(OneHotDiscreteTensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -1313,11 +1309,11 @@ class DiscreteTensorSpec(TensorSpec):
     domain: str = ""
 
     def __init__(
-            self,
-            n: int,
-            shape: Optional[torch.Size] = None,
-            device: Optional[DEVICE_TYPING] = None,
-            dtype: Optional[Union[str, torch.dtype]] = torch.long,
+        self,
+        n: int,
+        shape: Optional[torch.Size] = None,
+        device: Optional[DEVICE_TYPING] = None,
+        dtype: Optional[Union[str, torch.dtype]] = torch.long,
     ):
         if shape is None:
             shape = torch.Size([])
@@ -1346,12 +1342,12 @@ class DiscreteTensorSpec(TensorSpec):
 
     def __eq__(self, other):
         return (
-                type(self) == type(other)
-                and self.shape == other.shape
-                and self.space == other.space
-                and self.device == other.device
-                and self.dtype == other.dtype
-                and self.domain == other.domain
+            type(self) == type(other)
+            and self.shape == other.shape
+            and self.space == other.space
+            and self.device == other.device
+            and self.dtype == other.dtype
+            and self.domain == other.domain
         )
 
     def to_numpy(self, val: TensorDict, safe: bool = True) -> dict:
@@ -1388,7 +1384,7 @@ class DiscreteTensorSpec(TensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -1439,11 +1435,11 @@ class MultiDiscreteTensorSpec(DiscreteTensorSpec):
     """
 
     def __init__(
-            self,
-            nvec: Union[Sequence[int], torch.Tensor, int],
-            shape: Optional[torch.Size] = None,
-            device: Optional[DEVICE_TYPING] = None,
-            dtype: Optional[Union[str, torch.dtype]] = torch.long,
+        self,
+        nvec: Union[Sequence[int], torch.Tensor, int],
+        shape: Optional[torch.Size] = None,
+        device: Optional[DEVICE_TYPING] = None,
+        dtype: Optional[Union[str, torch.dtype]] = torch.long,
     ):
         if not isinstance(nvec, torch.Tensor):
             nvec = torch.tensor(nvec)
@@ -1532,8 +1528,8 @@ class MultiDiscreteTensorSpec(DiscreteTensorSpec):
         if val.ndim < 1:
             val = val.unsqueeze(0)
         val_have_wrong_dim = (
-                self.shape != torch.Size([1])
-                and val.shape[-len(self.shape):] != self.shape
+            self.shape != torch.Size([1])
+            and val.shape[-len(self.shape) :] != self.shape
         )
         if self.dtype != val.dtype or len(self.shape) > val.ndim or val_have_wrong_dim:
             return False
@@ -1547,12 +1543,12 @@ class MultiDiscreteTensorSpec(DiscreteTensorSpec):
 
         Args:
             val (torch.Tensor, optional): Tensor to one-hot encode. If not provided, the function will convert the
-                spec to the equivalent MultOneHotDiscreteTensorSpec (default).
+                spec to the equivalent MultiOneHotDiscreteTensorSpec (default).
             safe (bool): boolean value indicating whether a check should be
                 performed on the value against the domain of the spec.
 
         Returns:
-            If val is provided, returns the one-hot encoded tensor, otherwise returns a MultOneHotDiscreteTensorSpec
+            If val is provided, returns the one-hot encoded tensor, otherwise returns a MultiOneHotDiscreteTensorSpec
         """
         if val is None:
             nvec = [_space.n for _space in self.space]
@@ -1571,7 +1567,7 @@ class MultiDiscreteTensorSpec(DiscreteTensorSpec):
                     for i, n in enumerate(self.nvec)
                 ],
                 -1,
-            )
+            ).to(self.device)
 
     def expand(self, *shape):
         if len(shape) == 1 and isinstance(shape[0], (tuple, list, torch.Size)):
@@ -1580,7 +1576,7 @@ class MultiDiscreteTensorSpec(DiscreteTensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -1850,9 +1846,9 @@ class CompositeSpec(TensorSpec):
         return f"CompositeSpec(\n{sub_str}, device={self._device}, shape={self.shape})"
 
     def type_check(
-            self,
-            value: Union[torch.Tensor, TensorDictBase],
-            selected_keys: Union[str, Optional[Sequence[str]]] = None,
+        self,
+        value: Union[torch.Tensor, TensorDictBase],
+        selected_keys: Union[str, Optional[Sequence[str]]] = None,
     ):
         if isinstance(value, torch.Tensor) and isinstance(selected_keys, str):
             value = {selected_keys: value}
@@ -1860,7 +1856,7 @@ class CompositeSpec(TensorSpec):
 
         for _key in self:
             if self[_key] is not None and (
-                    selected_keys is None or _key in selected_keys
+                selected_keys is None or _key in selected_keys
             ):
                 self._specs[_key].type_check(value[_key], _key)
 
@@ -1967,9 +1963,9 @@ class CompositeSpec(TensorSpec):
 
     def __eq__(self, other):
         return (
-                type(self) is type(other)
-                and self._device == other._device
-                and self._specs == other._specs
+            type(self) is type(other)
+            and self._device == other._device
+            and self._specs == other._specs
         )
 
     def update(self, dict_or_spec: Union[CompositeSpec, Dict[str, TensorSpec]]) -> None:
@@ -2000,14 +1996,14 @@ class CompositeSpec(TensorSpec):
             shape = shape[0]
         if any(val < 0 for val in shape):
             raise ValueError("CompositeSpec.extend does not support negative shapes.")
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
             )
         out = CompositeSpec(
             {
-                key: value.expand(*shape, *value.shape[self.ndim:])
+                key: value.expand(*shape, *value.shape[self.ndim :])
                 for key, value in tuple(self.items())
             },
             shape=shape,
@@ -2043,17 +2039,17 @@ class _CompositeSpecKeysView:
     """Wrapper class that enables richer behaviour of `key in tensordict.keys()`."""
 
     def __init__(
-            self,
-            composite: CompositeSpec,
-            nested_keys: bool = True,
-            _yield_nesting_keys: bool = False,
+        self,
+        composite: CompositeSpec,
+        nested_keys: bool = True,
+        _yield_nesting_keys: bool = False,
     ):
         self.composite = composite
         self._yield_nesting_keys = _yield_nesting_keys
         self.nested_keys = nested_keys
 
     def __iter__(
-            self,
+        self,
     ):
         for key, item in self.composite.items():
             if self.nested_keys and isinstance(item, CompositeSpec):

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1219,8 +1219,9 @@ class MultiOneHotDiscreteTensorSpec(OneHotDiscreteTensorSpec):
         vals = self._split(val)
         return torch.cat([super()._project(_val) for _val in vals], -1)
 
-    def to_categorical(self, val: Optional[torch.Tensor] = None, safe: bool = True) -> Union[
-        MultiDiscreteTensorSpec, torch.Tensor]:
+    def to_categorical(
+        self, val: Optional[torch.Tensor] = None, safe: bool = True
+    ) -> Union[MultiDiscreteTensorSpec, torch.Tensor]:
         if val is None:
             return MultiDiscreteTensorSpec(
                 [_space.n for _space in self.space],
@@ -1510,7 +1511,13 @@ class MultiDiscreteTensorSpec(DiscreteTensorSpec):
         else:
             if safe:
                 self.assert_is_in(val)
-            return val
+            return torch.cat(
+                [
+                    torch.nn.functional.one_hot(val[..., i], n)
+                    for i, n in enumerate(self.nvec)
+                ],
+                -1,
+            )
 
     def expand(self, *shape):
         if len(shape) == 1 and isinstance(shape[0], (tuple, list, torch.Size)):

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -43,8 +43,8 @@ DEVICE_ERR_MSG = "device of empty CompositeSpec is not defined."
 
 
 def _default_dtype_and_device(
-    dtype: Union[None, torch.dtype],
-    device: Union[None, str, int, torch.device],
+        dtype: Union[None, torch.dtype],
+        device: Union[None, str, int, torch.device],
 ) -> Tuple[torch.dtype, torch.device]:
     if dtype is None:
         dtype = torch.get_default_dtype()
@@ -152,11 +152,11 @@ class ContinuousBox(Box):
 
     def __eq__(self, other):
         return (
-            type(self) == type(other)
-            and self.minimum.dtype == other.minimum.dtype
-            and self.maximum.dtype == other.maximum.dtype
-            and torch.equal(self.minimum, other.minimum)
-            and torch.equal(self.maximum, other.maximum)
+                type(self) == type(other)
+                and self.minimum.dtype == other.minimum.dtype
+                and self.maximum.dtype == other.maximum.dtype
+                and torch.equal(self.minimum, other.minimum)
+                and torch.equal(self.maximum, other.maximum)
         )
 
 
@@ -254,15 +254,15 @@ class TensorSpec:
                 else:
                     val = np.array(val)
             if isinstance(val, np.ndarray) and not all(
-                stride > 0 for stride in val.strides
+                    stride > 0 for stride in val.strides
             ):
                 val = val.copy()
             val = torch.tensor(val, device=self.device, dtype=self.dtype)
             if val.shape[-len(self.shape) :] != self.shape:
                 # option 1: add a singleton dim at the end
                 if (
-                    val.shape[-len(self.shape) :] == self.shape[:-1]
-                    and self.shape[-1] == 1
+                        val.shape[-len(self.shape):] == self.shape[:-1]
+                        and self.shape[-1] == 1
                 ):
                     val = val.unsqueeze(-1)
                 else:
@@ -477,12 +477,12 @@ class OneHotDiscreteTensorSpec(TensorSpec):
     domain: str = ""
 
     def __init__(
-        self,
-        n: int,
-        shape: Optional[torch.Size] = None,
-        device: Optional[DEVICE_TYPING] = None,
-        dtype: Optional[Union[str, torch.dtype]] = torch.long,
-        use_register: bool = False,
+            self,
+            n: int,
+            shape: Optional[torch.Size] = None,
+            device: Optional[DEVICE_TYPING] = None,
+            dtype: Optional[Union[str, torch.dtype]] = torch.long,
+            use_register: bool = False,
     ):
 
         dtype, device = _default_dtype_and_device(dtype, device)
@@ -532,7 +532,7 @@ class OneHotDiscreteTensorSpec(TensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -553,9 +553,9 @@ class OneHotDiscreteTensorSpec(TensorSpec):
         ).to(torch.long)
 
     def encode(
-        self,
-        val: Union[np.ndarray, torch.Tensor],
-        space: Optional[DiscreteBox] = None,
+            self,
+            val: Union[np.ndarray, torch.Tensor],
+            space: Optional[DiscreteBox] = None,
     ) -> torch.Tensor:
         if not isinstance(val, torch.Tensor):
             val = torch.tensor(val, dtype=self.dtype, device=self.device)
@@ -609,13 +609,13 @@ class OneHotDiscreteTensorSpec(TensorSpec):
 
     def __eq__(self, other):
         return (
-            type(self) == type(other)
-            and self.shape == other.shape
-            and self.space == other.space
-            and self.device == other.device
-            and self.dtype == other.dtype
-            and self.domain == other.domain
-            and self.use_register == other.use_register
+                type(self) == type(other)
+                and self.shape == other.shape
+                and self.space == other.space
+                and self.device == other.device
+                and self.dtype == other.dtype
+                and self.domain == other.domain
+                and self.use_register == other.use_register
         )
 
     def to_categorical(self) -> DiscreteTensorSpec:
@@ -637,12 +637,12 @@ class BoundedTensorSpec(TensorSpec):
     """
 
     def __init__(
-        self,
-        minimum: Union[float, torch.Tensor, np.ndarray],
-        maximum: Union[float, torch.Tensor, np.ndarray],
-        shape: Optional[Union[torch.Size, int]] = None,
-        device: Optional[DEVICE_TYPING] = None,
-        dtype: Optional[Union[torch.dtype, str]] = None,
+            self,
+            minimum: Union[float, torch.Tensor, np.ndarray],
+            maximum: Union[float, torch.Tensor, np.ndarray],
+            shape: Optional[Union[torch.Size, int]] = None,
+            device: Optional[DEVICE_TYPING] = None,
+            dtype: Optional[Union[torch.dtype, str]] = None,
     ):
         dtype, device = _default_dtype_and_device(dtype, device)
         if dtype is None:
@@ -722,7 +722,7 @@ class BoundedTensorSpec(TensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -742,9 +742,9 @@ class BoundedTensorSpec(TensorSpec):
         if self.dtype in (torch.float, torch.double, torch.half):
             shape = [*shape, *self.shape]
             out = (
-                torch.zeros(shape, dtype=self.dtype, device=self.device).uniform_()
-                * (b - a)
-                + a
+                    torch.zeros(shape, dtype=self.dtype, device=self.device).uniform_()
+                    * (b - a)
+                    + a
             )
             if (out > b).any():
                 out[out > b] = b.expand_as(out)[out > b]
@@ -787,7 +787,7 @@ class BoundedTensorSpec(TensorSpec):
     def is_in(self, val: torch.Tensor) -> bool:
         try:
             return (val >= self.space.minimum.to(val.device)).all() and (
-                val <= self.space.maximum.to(val.device)
+                    val <= self.space.maximum.to(val.device)
             ).all()
         except RuntimeError as err:
             if "The size of tensor a" in str(err):
@@ -831,10 +831,10 @@ class UnboundedContinuousTensorSpec(TensorSpec):
     """
 
     def __init__(
-        self,
-        shape: Union[torch.Size, int] = _DEFAULT_SHAPE,
-        device: Optional[DEVICE_TYPING] = None,
-        dtype: Optional[Union[str, torch.dtype]] = None,
+            self,
+            shape: Union[torch.Size, int] = _DEFAULT_SHAPE,
+            device: Optional[DEVICE_TYPING] = None,
+            dtype: Optional[Union[str, torch.dtype]] = None,
     ):
         if isinstance(shape, int):
             shape = torch.Size([shape])
@@ -881,7 +881,7 @@ class UnboundedContinuousTensorSpec(TensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -900,10 +900,10 @@ class UnboundedDiscreteTensorSpec(TensorSpec):
     """
 
     def __init__(
-        self,
-        shape: Union[torch.Size, int] = _DEFAULT_SHAPE,
-        device: Optional[DEVICE_TYPING] = None,
-        dtype: Optional[Union[str, torch.dtype]] = None,
+            self,
+            shape: Union[torch.Size, int] = _DEFAULT_SHAPE,
+            device: Optional[DEVICE_TYPING] = None,
+            dtype: Optional[Union[str, torch.dtype]] = None,
     ):
         if isinstance(shape, int):
             shape = torch.Size([shape])
@@ -964,7 +964,7 @@ class UnboundedDiscreteTensorSpec(TensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -995,11 +995,11 @@ class BinaryDiscreteTensorSpec(TensorSpec):
     domain: str = ""
 
     def __init__(
-        self,
-        n: int,
-        shape: Optional[torch.Size] = None,
-        device: Optional[DEVICE_TYPING] = None,
-        dtype: Union[str, torch.dtype] = torch.long,
+            self,
+            n: int,
+            shape: Optional[torch.Size] = None,
+            device: Optional[DEVICE_TYPING] = None,
+            dtype: Union[str, torch.dtype] = torch.long,
     ):
         dtype, device = _default_dtype_and_device(dtype, device)
         box = BinaryBox(n)
@@ -1041,7 +1041,7 @@ class BinaryDiscreteTensorSpec(TensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -1094,12 +1094,12 @@ class MultiOneHotDiscreteTensorSpec(OneHotDiscreteTensorSpec):
     """
 
     def __init__(
-        self,
-        nvec: Sequence[int],
-        shape: Optional[torch.Size] = None,
-        device=None,
-        dtype=torch.long,
-        use_register=False,
+            self,
+            nvec: Sequence[int],
+            shape: Optional[torch.Size] = None,
+            device=None,
+            dtype=torch.long,
+            use_register=False,
     ):
         self.nvec = nvec
         dtype, device = _default_dtype_and_device(dtype, device)
@@ -1219,14 +1219,20 @@ class MultiOneHotDiscreteTensorSpec(OneHotDiscreteTensorSpec):
         vals = self._split(val)
         return torch.cat([super()._project(_val) for _val in vals], -1)
 
-    def to_categorical(self) -> MultiDiscreteTensorSpec:
-
-        return MultiDiscreteTensorSpec(
-            [_space.n for _space in self.space],
-            device=self.device,
-            dtype=self.dtype,
-            shape=[*self.shape[:-1], len(self.space)],
-        )
+    def to_categorical(self, val: Optional[torch.Tensor] = None, safe: bool = True) -> Union[
+        MultiDiscreteTensorSpec, torch.Tensor]:
+        if val is None:
+            return MultiDiscreteTensorSpec(
+                [_space.n for _space in self.space],
+                device=self.device,
+                dtype=self.dtype,
+                shape=[*self.shape[:-1], len(self.space)],
+            )
+        else:
+            if safe:
+                self.assert_is_in(val)
+            vals = self._split(val)
+            return torch.stack([val.argmax(-1) for val in vals], -1)
 
     def expand(self, *shape):
         nvecs = [space.n for space in self.space]
@@ -1236,7 +1242,7 @@ class MultiOneHotDiscreteTensorSpec(OneHotDiscreteTensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -1277,11 +1283,11 @@ class DiscreteTensorSpec(TensorSpec):
     domain: str = ""
 
     def __init__(
-        self,
-        n: int,
-        shape: Optional[torch.Size] = None,
-        device: Optional[DEVICE_TYPING] = None,
-        dtype: Optional[Union[str, torch.dtype]] = torch.long,
+            self,
+            n: int,
+            shape: Optional[torch.Size] = None,
+            device: Optional[DEVICE_TYPING] = None,
+            dtype: Optional[Union[str, torch.dtype]] = torch.long,
     ):
         if shape is None:
             shape = torch.Size([])
@@ -1310,12 +1316,12 @@ class DiscreteTensorSpec(TensorSpec):
 
     def __eq__(self, other):
         return (
-            type(self) == type(other)
-            and self.shape == other.shape
-            and self.space == other.space
-            and self.device == other.device
-            and self.dtype == other.dtype
-            and self.domain == other.domain
+                type(self) == type(other)
+                and self.shape == other.shape
+                and self.space == other.space
+                and self.device == other.device
+                and self.dtype == other.dtype
+                and self.domain == other.domain
         )
 
     def to_numpy(self, val: TensorDict, safe: bool = True) -> dict:
@@ -1339,7 +1345,7 @@ class DiscreteTensorSpec(TensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -1390,11 +1396,11 @@ class MultiDiscreteTensorSpec(DiscreteTensorSpec):
     """
 
     def __init__(
-        self,
-        nvec: Union[Sequence[int], torch.Tensor, int],
-        shape: Optional[torch.Size] = None,
-        device: Optional[DEVICE_TYPING] = None,
-        dtype: Optional[Union[str, torch.dtype]] = torch.long,
+            self,
+            nvec: Union[Sequence[int], torch.Tensor, int],
+            shape: Optional[torch.Size] = None,
+            device: Optional[DEVICE_TYPING] = None,
+            dtype: Optional[Union[str, torch.dtype]] = torch.long,
     ):
         if not isinstance(nvec, torch.Tensor):
             nvec = torch.tensor(nvec)
@@ -1483,29 +1489,28 @@ class MultiDiscreteTensorSpec(DiscreteTensorSpec):
         if val.ndim < 1:
             val = val.unsqueeze(0)
         val_have_wrong_dim = (
-            self.shape != torch.Size([1])
-            and val.shape[-len(self.shape) :] != self.shape
+                self.shape != torch.Size([1])
+                and val.shape[-len(self.shape):] != self.shape
         )
         if self.dtype != val.dtype or len(self.shape) > val.ndim or val_have_wrong_dim:
             return False
 
         return ((val >= torch.zeros(self.nvec.size())) & (val < self.nvec)).all().item()
 
-    def to_onehot(self) -> MultiOneHotDiscreteTensorSpec:
-        if len(self.shape) > 1:
-            raise RuntimeError(
-                f"DiscreteTensorSpec with shape that has several dimensions can't be converted to"
-                f"OneHotDiscreteTensorSpec. Got shape={self.shape}. This could be accomplished via padding or "
-                f"nestedtensors but it is not implemented yet. If you would like to see that feature, please submit "
-                f"an issue of torchrl's github repo. "
+    def to_onehot(self, val: Optional[torch.Tensor] = None, safe: bool = True) -> Union[
+        MultiOneHotDiscreteTensorSpec, torch.Tensor]:
+        if val is None:
+            nvec = [_space.n for _space in self.space]
+            return MultiOneHotDiscreteTensorSpec(
+                nvec,
+                device=self.device,
+                dtype=self.dtype,
+                shape=[*self.shape[:-1], sum(nvec)],
             )
-        nvec = [_space.n for _space in self.space]
-        return MultiOneHotDiscreteTensorSpec(
-            nvec,
-            device=self.device,
-            dtype=self.dtype,
-            shape=[*self.shape[:-1], sum(nvec)],
-        )
+        else:
+            if safe:
+                self.assert_is_in(val)
+            return val
 
     def expand(self, *shape):
         if len(shape) == 1 and isinstance(shape[0], (tuple, list, torch.Size)):
@@ -1514,7 +1519,7 @@ class MultiDiscreteTensorSpec(DiscreteTensorSpec):
             raise ValueError(
                 f"{self.__class__.__name__}.extend does not support negative shapes."
             )
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
@@ -1784,9 +1789,9 @@ class CompositeSpec(TensorSpec):
         return f"CompositeSpec(\n{sub_str}, device={self._device}, shape={self.shape})"
 
     def type_check(
-        self,
-        value: Union[torch.Tensor, TensorDictBase],
-        selected_keys: Union[str, Optional[Sequence[str]]] = None,
+            self,
+            value: Union[torch.Tensor, TensorDictBase],
+            selected_keys: Union[str, Optional[Sequence[str]]] = None,
     ):
         if isinstance(value, torch.Tensor) and isinstance(selected_keys, str):
             value = {selected_keys: value}
@@ -1794,7 +1799,7 @@ class CompositeSpec(TensorSpec):
 
         for _key in self:
             if self[_key] is not None and (
-                selected_keys is None or _key in selected_keys
+                    selected_keys is None or _key in selected_keys
             ):
                 self._specs[_key].type_check(value[_key], _key)
 
@@ -1901,9 +1906,9 @@ class CompositeSpec(TensorSpec):
 
     def __eq__(self, other):
         return (
-            type(self) is type(other)
-            and self._device == other._device
-            and self._specs == other._specs
+                type(self) is type(other)
+                and self._device == other._device
+                and self._specs == other._specs
         )
 
     def update(self, dict_or_spec: Union[CompositeSpec, Dict[str, TensorSpec]]) -> None:
@@ -1934,14 +1939,14 @@ class CompositeSpec(TensorSpec):
             shape = shape[0]
         if any(val < 0 for val in shape):
             raise ValueError("CompositeSpec.extend does not support negative shapes.")
-        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim :], self.shape)):
+        if any(s1 != s2 and s2 != 1 for s1, s2 in zip(shape[-self.ndim:], self.shape)):
             raise ValueError(
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
             )
         out = CompositeSpec(
             {
-                key: value.expand(*shape, *value.shape[self.ndim :])
+                key: value.expand(*shape, *value.shape[self.ndim:])
                 for key, value in tuple(self.items())
             },
             shape=shape,
@@ -1977,17 +1982,17 @@ class _CompositeSpecKeysView:
     """Wrapper class that enables richer behaviour of `key in tensordict.keys()`."""
 
     def __init__(
-        self,
-        composite: CompositeSpec,
-        nested_keys: bool = True,
-        _yield_nesting_keys: bool = False,
+            self,
+            composite: CompositeSpec,
+            nested_keys: bool = True,
+            _yield_nesting_keys: bool = False,
     ):
         self.composite = composite
         self._yield_nesting_keys = _yield_nesting_keys
         self.nested_keys = nested_keys
 
     def __iter__(
-        self,
+            self,
     ):
         for key, item in self.composite.items():
             if self.nested_keys and isinstance(item, CompositeSpec):


### PR DESCRIPTION
## Description

As mentioned in the closed PR #783 we want to update the methods `to_onehot` and `to_categorical` to support value conversion in addition to spec conversion.

This is what currently happens

```pytho
spec = torchrl.data.MultOneHotDiscreteTensorSpec([5,10])
sample = spec.rand((2,3))
sample.shape
torch.Size([2, 3, 15])
sample_np =spec.to_numpy(sample)
sample_np.shape
(2, 3, 2)
```

```python
spec = torchrl.data.MultOneHotDiscreteTensorSpec([5,10])
sample = spec.rand((2,3))
sample.shape
torch.Size([2, 3, 15])
sample_np =spec.to_numpy(sample)
sample_np.shape
(2, 3, 15)

sample_cat = spec.to_categorical(sample)
sample_cat.shape
torch.Size([2, 3, 2])
```

To keep the current behaviour (conversion of the spec), I decided that `val` will be an optional parameter. The documentation will be well written to explain the different behaviours of theses methods.

## Motivation and Context

Also related to the issue #781 

- [X] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] New feature (non-breaking change which adds core functionality)
- [x] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
