### PR TITLE
[BugFix] Fix MultOneHotDiscreteTensorSpec.is_in

### DIFF
--- a/test/test_tensor_spec.py
+++ b/test/test_tensor_spec.py
@@ -231,6 +231,7 @@ def test_mult_onehot(shape, ns):
             assert (_r.sum(-1) == 1).all()
             assert _r.shape[-1] == _n
         np_r = ts.to_numpy(r)
+        assert not ts.is_in(torch.tensor(np_r))
         assert (ts.encode(np_r) == r).all()
 
 


### PR DESCRIPTION
## Description

Should fix #815. Just checking the shape of an input `val` tensor, before splitting it. Add add one line in tests to check the false case.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
