### PR TITLE
[BugFix] Device of info specs

### DIFF
--- a/test/test_env.py
+++ b/test/test_env.py
@@ -1120,10 +1120,11 @@ def test_batch_unlocked_with_batch_size(device):
     gym_version is None or gym_version < version.parse("0.20.0"),
     reason="older versions of half-cheetah do not have 'x_position' info key.",
 )
-def test_info_dict_reader(seed=0):
+@pytest.mark.parametrize("device", get_available_devices())
+def test_info_dict_reader(device, seed=0):
     import gym
 
-    env = GymWrapper(gym.make(HALFCHEETAH_VERSIONED))
+    env = GymWrapper(gym.make(HALFCHEETAH_VERSIONED), device=device)
     env.set_info_dict_reader(default_info_dict_reader(["x_position"]))
 
     assert "x_position" in env.observation_spec.keys()

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -280,7 +280,7 @@ class GymLikeEnv(_EnvWrapper):
         """
         self.info_dict_reader = info_dict_reader
         for info_key, spec in info_dict_reader.info_spec.items():
-            self.observation_spec[info_key] = spec
+            self.observation_spec[info_key] = spec.to(self.device)
         return self
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## Description

`info_key_reader` crashes when the device is not the default "cpu".
This PR solves this issue.