### PR TITLE
[BugFix] Fix envs specs and info reading

### DIFF
--- a/knowledge_base/MUJOCO_INSTALLATION.md
+++ b/knowledge_base/MUJOCO_INSTALLATION.md
@@ -202,3 +202,6 @@ RuntimeError: Failed to initialize OpenGL
 > Make sure to set `DISPLAY` environment variable correctly.
 
 5. `ImportError: Cannot initialize a headless EGL display.`
+  Make sure you have installed mujoco and all its dependencies (see instructions above).
+  Make sure you have set the `MUJOCO_GL=egl`.
+  Make sure you have a GPU accessible on your machine.

--- a/knowledge_base/MUJOCO_INSTALLATION.md
+++ b/knowledge_base/MUJOCO_INSTALLATION.md
@@ -200,3 +200,5 @@ RuntimeError: Failed to initialize OpenGL
 4. Errors like "Onscreen rendering needs 101 device"
 
 > Make sure to set `DISPLAY` environment variable correctly.
+
+5. `ImportError: Cannot initialize a headless EGL display.`

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -636,7 +636,7 @@ class TestVmas:
         )
         for e in [env, wrapped]:
             e.set_seed(0)
-            check_env_specs(e)
+            check_env_specs(e, check_dtype=False)
             del e
 
     @pytest.mark.parametrize("num_envs", [1, 20])

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1406,6 +1406,7 @@ class CompositeSpec(TensorSpec):
             if isinstance(item, TensorSpec) and item.device != self.device:
                 item = deepcopy(item).to(self.device)
             self[key] = item
+        return self
 
 
 def _keys_to_empty_composite_spec(keys):

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -710,11 +710,11 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
     def fake_tensordict(self) -> TensorDictBase:
         """Returns a fake tensordict with key-value pairs that match in shape, device and dtype what can be expected during an environment rollout."""
         input_spec = self.input_spec
-        fake_input = input_spec.rand(self.batch_size)
+        fake_input = input_spec.zero(self.batch_size)
         observation_spec = self.observation_spec
-        fake_obs = observation_spec.rand(self.batch_size)
+        fake_obs = observation_spec.zero(self.batch_size)
         reward_spec = self.reward_spec
-        fake_reward = reward_spec.rand(self.batch_size)
+        fake_reward = reward_spec.zero(self.batch_size)
         fake_td = TensorDict(
             {
                 **fake_obs,

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -65,14 +65,26 @@ def _gym_to_torchrl_spec_transform(
             if categorical_action_encoding
             else OneHotDiscreteTensorSpec
         )
-        return action_space_cls(spec.n, device=device)
-    elif isinstance(spec, gym.spaces.multi_binary.MultiBinary):
-        return BinaryDiscreteTensorSpec(spec.n, device=device)
-    elif isinstance(spec, gym.spaces.multi_discrete.MultiDiscrete):
-        return (
-            MultiDiscreteTensorSpec(spec.nvec, device=device)
+        dtype = (
+            numpy_to_torch_dtype_dict[spec.dtype]
             if categorical_action_encoding
-            else MultOneHotDiscreteTensorSpec(spec.nvec, device=device)
+            else torch.long
+        )
+        return action_space_cls(spec.n, device=device, dtype=dtype)
+    elif isinstance(spec, gym.spaces.multi_binary.MultiBinary):
+        return BinaryDiscreteTensorSpec(
+            spec.n, device=device, dtype=numpy_to_torch_dtype_dict[spec.dtype]
+        )
+    elif isinstance(spec, gym.spaces.multi_discrete.MultiDiscrete):
+        dtype = (
+            numpy_to_torch_dtype_dict[spec.dtype]
+            if categorical_action_encoding
+            else torch.long
+        )
+        return (
+            MultiDiscreteTensorSpec(spec.nvec, device=device, dtype=dtype)
+            if categorical_action_encoding
+            else MultOneHotDiscreteTensorSpec(spec.nvec, device=device, dtype=dtype)
         )
     elif isinstance(spec, gym.spaces.Box):
         shape = spec.shape


### PR DESCRIPTION
## Description

Introduces some changes in the env API to allow for:
- Reading infos at reset
- Completing reset data when info is missing
- using zero instead of rand for fake_tensordict (@matteobettini)
- better checks in check_env_spec and better error messages