### PR TITLE
[BugFix] Fix R3M observation spec transform

### DIFF
--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1202,7 +1202,7 @@ class CompositeSpec(TensorSpec):
                     "Got multiple arguments, when at most one is expected for CompositeSpec."
                 )
             argdict = args[0]
-            if not isinstance(argdict, dict):
+            if not isinstance(argdict, (dict, CompositeSpec)):
                 raise RuntimeError(
                     f"Expected a dictionary of specs, but got an argument of type {type(argdict)}."
                 )

--- a/torchrl/envs/transforms/r3m.py
+++ b/torchrl/envs/transforms/r3m.py
@@ -92,7 +92,7 @@ class _R3MNet(Transform):
         device = observation_spec[keys[0]].device
         dim = observation_spec[keys[0]].shape[:-3]
 
-        observation_spec = CompositeSpec(**observation_spec)
+        observation_spec = CompositeSpec(observation_spec)
         if self.del_keys:
             for in_key in keys:
                 del observation_spec[in_key]

--- a/torchrl/envs/transforms/vip.py
+++ b/torchrl/envs/transforms/vip.py
@@ -84,7 +84,7 @@ class _VIPNet(Transform):
         device = observation_spec[keys[0]].device
         dim = observation_spec[keys[0]].shape[:-3]
 
-        observation_spec = CompositeSpec(**observation_spec)
+        observation_spec = CompositeSpec(observation_spec)
         if self.del_keys:
             for in_key in keys:
                 del observation_spec[in_key]


### PR DESCRIPTION
## Description

Fixes a bug where nested composite specs lead to an error when calling the r3m obs spec transform.
