### PR TITLE
Updating Recorder to accomodate "solved" key

### DIFF
--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -1157,8 +1157,6 @@ class Recorder(TrainerHookBase):
                         out[self.out_keys[key]] = mean_value
                         out["total_" + self.out_keys[key]] = total_value
                         continue
-                    if key == "solved":
-                        value = value.any().float()
                     out[self.out_keys[key]] = value
                 out["log_pbar"] = self.log_pbar
         self._count += 1


### PR DESCRIPTION
## Description

Removed the `value.any()` for `solved` key in Recorder

## Motivation and Context

In `mj_envs`,  `solved` key is returned at every step that indicates whether the task has reached the goal. Adding `value.any()` returns a single indicator for all the trajectories. An example use case of `solved` key is [here](https://github.com/vikashplus/mj_envs/blob/77274c05f085d052b7efb65fab9cb15269281f9b/mj_envs/envs/env_base.py#L356)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
