### PR TITLE
[BugFIx] Changed "set_count" set in collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,4 +550,3 @@ The features are available before an official release so that users and collabor
 
 # License
 TorchRL is licensed under the MIT License. See [LICENSE](LICENSE) for details.
-

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -22,6 +22,7 @@ from tensordict.nn import TensorDictModule
 from tensordict.tensordict import TensorDict, TensorDictBase
 from torch import multiprocessing as mp
 from torch.utils.data import IterableDataset
+
 from torchrl._utils import _check_for_faulty_process, prod
 from torchrl.collectors.utils import split_trajectories
 from torchrl.data import TensorSpec
@@ -655,7 +656,7 @@ class SyncDataCollector(_DataCollector):
                     self._tensordict = self.env.step(self._tensordict)
 
                 step_count = self._tensordict.get("step_count")
-                step_count += 1
+                self._tensordict.set("step_count", step_count + 1)
                 # we must clone all the values, since the step / traj_id updates are done in-place
                 try:
                     self._tensordict_out[..., j] = self._tensordict

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -656,7 +656,7 @@ class SyncDataCollector(_DataCollector):
                     self._tensordict = self.env.step(self._tensordict)
 
                 step_count = self._tensordict.get("step_count")
-                self._tensordict.set("step_count", step_count + 1)
+                self._tensordict.set_("step_count", step_count + 1)
                 # we must clone all the values, since the step / traj_id updates are done in-place
                 try:
                     self._tensordict_out[..., j] = self._tensordict


### PR DESCRIPTION
## Description

 This one line PR modifies the way the step_count is set in collectors.

With the current
```
step_count += 1
```
The step_count is not set in the case the get method returns a cloned object, which happens if 

```
self._tensordict = env.reset() 
```
Is created from a _reset method that returns LazyStacks
