### PR TITLE
[CI] Add Github-Actions workflows for Windows wheels & nightly-build

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -252,3 +252,112 @@ jobs:
           EXIT_STATUS=0
           pytest test/smoke_test.py -v --durations 20
           exit $EXIT_STATUS
+
+  build-wheel-windows:
+    runs-on: windows-latest
+    strategy: 
+      matrix:
+        python_version: [["3.7", "3.7"], ["3.8", "3.8"], ["3.9", "3.9"], ["3.10", "3.10.3"]]
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version[1] }}
+      - name: Checkout torchrl
+        uses: actions/checkout@v2
+      - name: Install PyTorch nightly
+        shell: bash
+        run: |
+          python3 -mpip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+      - name: Build TorchRL nightly
+        shell: bash
+        run: |
+          rm -r dist || true
+          python3 -mpip install wheel
+          python3 setup.py bdist_wheel \
+            --package_name torchrl-nightly \
+            --python-tag=${{ matrix.python-tag }}
+      - name: Upload wheel for the test-wheel job
+        uses: actions/upload-artifact@v2
+        with:
+          name: torchrl-win-${{ matrix.python_version[0] }}.whl
+          path: dist/*.whl
+
+  test-wheel-windows:
+    needs: build-wheel-windows
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python_version: [["3.7", "3.7"], ["3.8", "3.8"], ["3.9", "3.9"], ["3.10", "3.10.3"]]
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version[1] }}
+      - name: Checkout torchrl
+        uses: actions/checkout@v2
+      - name: Install PyTorch Nightly
+        shell: bash
+        run: |
+          python3 -mpip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+      - name: Upgrade pip
+        shell: bash
+        run: |
+          python3 -mpip install --upgrade pip
+      - name: Install test dependencies
+        shell: bash
+        run: |
+          python3 -mpip install numpy pytest --no-cache-dir
+      - name: Download built wheels
+        uses: actions/download-artifact@v2
+        with:
+          name: torchrl-win-${{ matrix.python_version[0] }}.whl
+          path: wheels
+      - name: Install built wheels
+        shell: bash
+        run: |
+          python3 -mpip install wheels/*
+      - name: Log version string
+        shell: bash
+        run: |
+          # Avoid ambiguity of "import torchrl" by deleting the source files.
+          rm -rf torchrl/
+          python3 -c "import torchrl; print(torchrl.__version__)"
+      - name: Run tests
+        shell: bash
+        run: |
+          set -e
+          export IN_CI=1
+          mkdir test-reports
+          python -m torch.utils.collect_env
+          python -c "import torchrl; print(torchrl.__version__);from torchrl.data import ReplayBuffer"
+          EXIT_STATUS=0
+          pytest test/smoke_test.py -v --durations 20
+          exit $EXIT_STATUS
+
+  upload-wheel-windows:
+    needs: test-wheel-windows
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python_version: [["3.7", "3.7"], ["3.8", "3.8"], ["3.9", "3.9"], ["3.10", "3.10.3"]]
+    steps:
+      - name: Checkout torchrl
+        uses: actions/checkout@v2
+      - name: Download built wheels
+        uses: actions/download-artifact@v2
+        with:
+          name: torchrl-win-${{ matrix.python_version[0] }}.whl
+          path: wheels
+      - name: Push TorchRL Binary to PYPI
+        shell: bash
+        env:
+            PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          python3 -mpip install twine
+          python3 -m twine upload \
+              --username __token__ \
+              --password "$PYPI_TOKEN" \
+              --skip-existing \
+              wheels/torchrl_nightly-*.whl \
+              --verbose

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,6 +78,39 @@ jobs:
           name: torchrl-batch.whl
           path: dist/*.whl
 
+  build-wheel-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python_version: [["3.7", "3.7"], ["3.8", "3.8"], ["3.9", "3.9"], ["3.10", "3.10.3"]]
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version[1] }}
+      - name: Checkout torchrl
+        uses: actions/checkout@v2
+      - name: Install PyTorch RC
+        shell: bash
+        run: |
+          python3 -mpip install torch --extra-index-url https://download.pytorch.org/whl/cpu
+      - name: Build wheel
+        shell: bash
+        run: |
+            python3 -mpip install wheel
+            BUILD_VERSION=0.0.3 python3 setup.py bdist_wheel
+      - name: Upload wheel for the test-wheel job
+        uses: actions/upload-artifact@v2
+        with:
+          name: torchrl-win-${{ matrix.python_version[0] }}.whl
+          path: dist/torchrl-*.whl
+      - name: Upload wheel for download
+        uses: actions/upload-artifact@v2
+        with:
+          name: torchrl-batch.whl
+          path: dist/*.whl
+
+
   test-wheel:
     needs: [build-wheel-linux, build-wheel-mac]
     strategy:
@@ -119,6 +152,62 @@ jobs:
           rm -rf torchrl/
           python -c "import torchrl; print(torchrl.__version__)"
       - name: Run tests
+        run: |
+          set -e
+          export IN_CI=1
+          mkdir test-reports
+          python -m torch.utils.collect_env
+          python -c "import torchrl; print(torchrl.__version__)"
+          EXIT_STATUS=0
+          pytest test/smoke_test.py -v --durations 20
+          exit $EXIT_STATUS
+
+  test-wheel-windows:
+    needs: build-wheel-windows
+    strategy:
+      matrix:
+        python_version: [ "3.7", "3.8", "3.9", "3.10" ]
+    runs-on: windows-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
+      - name: Checkout torchrl
+        uses: actions/checkout@v2
+      - name: Install PyTorch RC
+        shell: bash
+        run: |
+          python3 -mpip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cpu
+      - name: Upgrade pip
+        shell: bash
+        run: |
+          python3 -mpip install --upgrade pip
+      - name: Install tensordict
+        shell: bash
+        run: |
+          python3 -mpip install git+https://github.com/pytorch-labs/tensordict.git
+      - name: Install test dependencies
+        shell: bash
+        run: |
+          python3 -mpip install numpy pytest pytest-cov codecov unittest-xml-reporting pillow>=4.1.1 scipy av networkx expecttest pyyaml
+      - name: Download built wheels
+        uses: actions/download-artifact@v2
+        with:
+          name: torchrl-win-${{ matrix.python_version }}.whl
+          path: wheels
+      - name: Install built wheels
+        shell: bash
+        run: |
+          python3 -mpip install wheels/*
+      - name: Log version string
+        shell: bash
+        run: |
+          # Avoid ambiguity of "import torchrl" by deleting the source files.
+          rm -rf torchrl/
+          python -c "import torchrl; print(torchrl.__version__)"
+      - name: Run tests
+        shell: bash
         run: |
           set -e
           export IN_CI=1


### PR DESCRIPTION
## Description

- For `nightly-build` Github Actions workflow, add jobs 
  - `build-wheel-windows`
  - `test-wheel-windows`
  - `upload-wheel-windows`.
- For `wheels` Github Actions workflow:  add `build-wheel-windows` job and `os:windows` case to `test-wheel`

## Motivation and Context

There is a need for a TorchRL build for Windows, hence the need for those Github actions (as for Linux and MacOS which are already supported).

## Types of changes

- [x] New feature (non-breaking change which adds core functionality)

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
