### PR TITLE
[Feature] Refactor CatFrames using a proper preallocated buffer

### DIFF
--- a/test/test_shared.py
+++ b/test/test_shared.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import argparse
-import sys
 import time
 import warnings
 


### PR DESCRIPTION
## Description

Adapts the CatFrames transform to match the preallocation of #841 

@albertbou92 can you have a look at the registering of the buffers? In your case I thing that doing `transform.to(device)` will not map the buffers and may lead to a bug (although moving transforms during training may not make much sense)