### PR TITLE
[Feature] Loading R3M and VIP from ResNet

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1678,7 +1678,7 @@ class TestTransforms:
             {key: torch.randn(3) for key in ["a", "b", "c"]}, [], device=device
         )
         if device.type == "cuda":
-            with pytest.raises(RuntimeError, match="test_pin_mem"):
+            with pytest.raises(RuntimeError, match="cannot pin"):
                 pin_mem(td)
             return
         pin_mem(td)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1677,6 +1677,10 @@ class TestTransforms:
         td = TensorDict(
             {key: torch.randn(3) for key in ["a", "b", "c"]}, [], device=device
         )
+        if device.type == "cuda":
+            with pytest.raises(RuntimeError, match="test_pin_mem"):
+                pin_mem(td)
+            return
         pin_mem(td)
         for item in td.values():
             assert item.is_pinned

--- a/torchrl/envs/transforms/r3m.py
+++ b/torchrl/envs/transforms/r3m.py
@@ -34,6 +34,22 @@ try:
 except ImportError:
     _has_tv = False
 
+try:
+    from torchvision.models import ResNet18_Weights, ResNet34_Weights, ResNet50_Weights
+    from torchvision.models._api import WeightsEnum
+except ImportError:
+
+    class WeightsEnum:  # noqa: D101
+        # placeholder
+        pass
+
+
+R3M_MODEL_MAP = {
+    "resnet18": "r3m_18",
+    "resnet34": "r3m_34",
+    "resnet50": "r3m_50",
+}
+
 
 class _R3MNet(Transform):
 
@@ -45,18 +61,19 @@ class _R3MNet(Transform):
                 "Tried to instantiate R3M without torchvision. Make sure you have "
                 "torchvision installed in your environment."
             )
+        self.model_name = model_name
         if model_name == "resnet18":
-            self.model_name = "r3m_18"
+            # self.model_name = "r3m_18"
             self.outdim = 512
-            convnet = models.resnet18(pretrained=False)
+            convnet = models.resnet18(None)
         elif model_name == "resnet34":
-            self.model_name = "r3m_34"
+            # self.model_name = "r3m_34"
             self.outdim = 512
-            convnet = models.resnet34(pretrained=False)
+            convnet = models.resnet34(None)
         elif model_name == "resnet50":
-            self.model_name = "r3m_50"
+            # self.model_name = "r3m_50"
             self.outdim = 2048
-            convnet = models.resnet50(pretrained=False)
+            convnet = models.resnet50(None)
         else:
             raise NotImplementedError(
                 f"model {model_name} is currently not supported by R3M"
@@ -123,8 +140,34 @@ class _R3MNet(Transform):
         state_dict = td_flatten.to_dict()
         r3m_instance.convnet.load_state_dict(state_dict)
 
-    def load_weights(self, dir_prefix=None):
-        self._load_weights(self.model_name, self, dir_prefix)
+    def load_weights(self, dir_prefix=None, tv_weights=None):
+        if dir_prefix is not None and tv_weights is not None:
+            raise RuntimeError(
+                "torchvision weights API does not allow for custom download path."
+            )
+        elif tv_weights is not None:
+            model_name = self.model_name
+            if model_name == "resnet18":
+                if isinstance(tv_weights, str):
+                    tv_weights = getattr(ResNet18_Weights, tv_weights)
+                convnet = models.resnet18(weights=tv_weights)
+            elif model_name == "resnet34":
+                if isinstance(tv_weights, str):
+                    tv_weights = getattr(ResNet34_Weights, tv_weights)
+                convnet = models.resnet34(weights=tv_weights)
+            elif model_name == "resnet50":
+                if isinstance(tv_weights, str):
+                    tv_weights = getattr(ResNet50_Weights, tv_weights)
+                convnet = models.resnet50(weights=tv_weights)
+            else:
+                raise NotImplementedError(
+                    f"model {model_name} is currently not supported by R3M"
+                )
+            convnet.fc = Identity()
+            self.convnet.load_state_dict(convnet.state_dict())
+        else:
+            model_name = R3M_MODEL_MAP[self.model_name]
+            self._load_weights(model_name, self, dir_prefix)
 
 
 def _init_first(fun):
@@ -154,7 +197,7 @@ class R3MTransform(Compose):
     can ensure that the following code snippet works as expected:
 
     Examples:
-        >>> transform = R3MTransform("resenet50", in_keys=["pixels"])
+        >>> transform = R3MTransform("resnet50", in_keys=["pixels"])
         >>> env.append_transform(transform)
         >>> # the forward method will first call _init which will look at env.observation_spec
         >>> env.reset()
@@ -170,8 +213,13 @@ class R3MTransform(Compose):
         stack_images (bool, optional): if False, the images given in the :obj:`in_keys`
              argument will be treaded separetely and each will be given a single,
              separated entry in the output tensordict. Defaults to :obj:`True`.
-        download (bool, optional): if True, the weights will be downloaded using
-            the torch.hub download API (i.e. weights will be cached for future use).
+        download (bool, torchvision Weights config or corresponding string):
+            if True, the weights will be downloaded using the torch.hub download
+            API (i.e. weights will be cached for future use).
+            These weights are the original weights from the R3M publication.
+            If the torchvision weights are needed, there are two ways they can be
+            obtained: :obj:`download=ResNet50_Weights.IMAGENET1K_V1` or :obj:`download="IMAGENET1K_V1"`
+            where :obj:`ResNet50_Weights` can be imported via :obj:`from torchvision.models import resnet50, ResNet50_Weights`.
             Defaults to False.
         download_path (str, optional): path where to download the models.
             Default is None (cache path determined by torch.hub utils).
@@ -194,7 +242,7 @@ class R3MTransform(Compose):
         out_keys: List[str] = None,
         size: int = 244,
         stack_images: bool = True,
-        download: bool = False,
+        download: Union[bool, WeightsEnum, str] = False,
         download_path: Optional[str] = None,
         tensor_pixels_keys: List[str] = None,
     ):
@@ -302,8 +350,12 @@ class R3MTransform(Compose):
 
         for transform in transforms:
             self.append(transform)
-        if self.download:
-            self[-1].load_weights(dir_prefix=self.download_path)
+        if self.download is True:
+            self[-1].load_weights(dir_prefix=self.download_path, tv_weights=None)
+        elif self.download:
+            self[-1].load_weights(
+                dir_prefix=self.download_path, tv_weights=self.download
+            )
 
         if self._device is not None:
             self.to(self._device)


### PR DESCRIPTION
## Description

Allows R3M and VIP to be initialized with the torchvision's weights instead of the dedicated weights from the papers.

cc @ShahRutav 

Testing this PR:

```python
from torchrl.envs import R3MTransform, VIPTransform
from torchvision.models import ResNet18_Weights, ResNet34_Weights, \
    ResNet50_Weights

model_map = {
    "resnet18": ResNet18_Weights,
    "resnet34": ResNet34_Weights,
    "resnet50": ResNet50_Weights,
}
for model in ("resnet18", "resnet34", "resnet50"):
    for download in (True, "IMAGENET1K_V1"):
        if isinstance(download, str):
            for i in range(2):
                if i == 0:
                    download == getattr(model_map[model], download)
                R3MTransform(in_keys=["pixels"], model_name=model, download=download)
        else:
            R3MTransform(in_keys=["pixels"], model_name=model, download=download)

model_map = {
    "resnet50": ResNet50_Weights,
}
for model in ("resnet50",):
    for download in (True, "IMAGENET1K_V1"):
        if isinstance(download, str):
            for i in range(2):
                if i == 0:
                    download == getattr(model_map[model], download)
                VIPTransform(in_keys=["pixels"], model_name=model, download=download)
        else:
            VIPTransform(in_keys=["pixels"], model_name=model, download=download)
```