### PR TITLE
[BugFix] Avoid collision of "step_count" key from transform and collector

### DIFF
--- a/examples/td3/td3.py
+++ b/examples/td3/td3.py
@@ -273,10 +273,10 @@ def main(cfg: "DictConfig"):  # noqa: F821
         pbar.update(tensordict.numel())
 
         # extend the replay buffer with the new data
-        if "mask" in tensordict.keys():
+        if ("collector", "mask") in tensordict.keys(True):
             # if multi-step, a mask is present to help filter padded values
-            current_frames = tensordict["mask"].sum()
-            tensordict = tensordict[tensordict.get("mask").squeeze(-1)]
+            current_frames = tensordict["collector", "mask"].sum()
+            tensordict = tensordict[tensordict.get(("collector", "mask")).squeeze(-1)]
         else:
             tensordict = tensordict.view(-1)
             current_frames = tensordict.numel()

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -426,7 +426,7 @@ def test_split_trajs(num_env, env_name, frames_per_batch, seed=5):
         break
 
     assert d.ndimension() == 2
-    assert d["mask"].shape == d.shape
+    assert d["collector", "mask"].shape == d.shape
     assert d["collector", "step_count"].shape == d.shape
     assert d["collector", "traj_ids"].shape == d.shape
     for traj in d.unbind(0):
@@ -991,7 +991,7 @@ def test_collector_output_keys(collector_class, init_random_frames, explicit_spe
         "done",
         "hidden1",
         "hidden2",
-        "mask",
+        ("collector", "mask"),
         ("next", "hidden1"),
         ("next", "hidden2"),
         ("next", "observation"),

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -989,6 +989,7 @@ def test_collector_output_keys(collector_class, init_random_frames, explicit_spe
     keys = {
         "action",
         "done",
+        "collector",
         "hidden1",
         "hidden2",
         ("collector", "mask"),

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -316,7 +316,7 @@ def test_collector_env_reset():
     )
     for _data in collector:
         continue
-    steps = _data["step_count"][..., 1:]
+    steps = _data["collector", "_step_count"][..., 1:]
     done = _data["done"][..., :-1, :].squeeze(-1)
     # we don't want just one done
     assert done.sum() > 3
@@ -375,7 +375,7 @@ def test_collector_done_persist(num_env, env_name, seed=5):
         break
 
     assert (d["done"].sum(-2) >= 1).all()
-    assert torch.unique(d["traj_ids"], dim=-1).shape[-1] == 1
+    assert torch.unique(d["collector", "_traj_ids"], dim=-1).shape[-1] == 1
 
     del collector
 
@@ -427,11 +427,14 @@ def test_split_trajs(num_env, env_name, frames_per_batch, seed=5):
 
     assert d.ndimension() == 2
     assert d["mask"].shape == d.shape
-    assert d["step_count"].shape == d.shape
-    assert d["traj_ids"].shape == d.shape
+    assert d["collector", "_step_count"].shape == d.shape
+    assert d["collector", "_traj_ids"].shape == d.shape
     for traj in d.unbind(0):
-        assert traj["traj_ids"].unique().numel() == 1
-        assert (traj["step_count"][1:] - traj["step_count"][:-1] == 1).all()
+        assert traj["collector", "_traj_ids"].unique().numel() == 1
+        assert (
+            traj["collector", "_step_count"][1:] - traj["collector", "_step_count"][:-1]
+            == 1
+        ).all()
 
     del collector
 
@@ -995,8 +998,8 @@ def test_collector_output_keys(collector_class, init_random_frames, explicit_spe
         "next",
         "observation",
         "reward",
-        "step_count",
-        "traj_ids",
+        ("collector", "_step_count"),
+        ("collector", "_traj_ids"),
     }
     b = next(iter(collector))
 

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -316,7 +316,7 @@ def test_collector_env_reset():
     )
     for _data in collector:
         continue
-    steps = _data["collector", "_step_count"][..., 1:]
+    steps = _data["collector", "step_count"][..., 1:]
     done = _data["done"][..., :-1, :].squeeze(-1)
     # we don't want just one done
     assert done.sum() > 3
@@ -375,7 +375,7 @@ def test_collector_done_persist(num_env, env_name, seed=5):
         break
 
     assert (d["done"].sum(-2) >= 1).all()
-    assert torch.unique(d["collector", "_traj_ids"], dim=-1).shape[-1] == 1
+    assert torch.unique(d["collector", "traj_ids"], dim=-1).shape[-1] == 1
 
     del collector
 
@@ -427,12 +427,12 @@ def test_split_trajs(num_env, env_name, frames_per_batch, seed=5):
 
     assert d.ndimension() == 2
     assert d["mask"].shape == d.shape
-    assert d["collector", "_step_count"].shape == d.shape
-    assert d["collector", "_traj_ids"].shape == d.shape
+    assert d["collector", "step_count"].shape == d.shape
+    assert d["collector", "traj_ids"].shape == d.shape
     for traj in d.unbind(0):
-        assert traj["collector", "_traj_ids"].unique().numel() == 1
+        assert traj["collector", "traj_ids"].unique().numel() == 1
         assert (
-            traj["collector", "_step_count"][1:] - traj["collector", "_step_count"][:-1]
+            traj["collector", "step_count"][1:] - traj["collector", "step_count"][:-1]
             == 1
         ).all()
 
@@ -998,8 +998,8 @@ def test_collector_output_keys(collector_class, init_random_frames, explicit_spe
         "next",
         "observation",
         "reward",
-        ("collector", "_step_count"),
-        ("collector", "_traj_ids"),
+        ("collector", "step_count"),
+        ("collector", "traj_ids"),
     }
     b = next(iter(collector))
 

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -7,6 +7,8 @@ import argparse
 import re
 from copy import deepcopy
 
+from packaging import version as pack_version
+
 _has_functorch = True
 try:
     import functorch as ft  # noqa
@@ -2035,6 +2037,8 @@ class TestPPO:
     @pytest.mark.parametrize("advantage", ("gae", "td", "td_lambda"))
     @pytest.mark.parametrize("device", get_available_devices())
     def test_ppo_diff(self, loss_class, device, gradient_mode, advantage):
+        if pack_version.parse(torch.__version__) > pack_version.parse("1.14"):
+            raise pytest.skip("make_functional_with_buffers needs to be changed")
         torch.manual_seed(self.seed)
         td = self._create_seq_mock_data_ppo(device=device)
 
@@ -2245,6 +2249,8 @@ class TestA2C:
     @pytest.mark.parametrize("advantage", ("gae", "td", "td_lambda"))
     @pytest.mark.parametrize("device", get_available_devices())
     def test_a2c_diff(self, device, gradient_mode, advantage):
+        if pack_version.parse(torch.__version__) > pack_version.parse("1.14"):
+            raise pytest.skip("make_functional_with_buffers needs to be changed")
         torch.manual_seed(self.seed)
         td = self._create_seq_mock_data_a2c(device=device)
 

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -273,7 +273,7 @@ class TestDQN:
                     "observation": next_obs.masked_fill_(~mask.unsqueeze(-1), 0.0)
                 },
                 "done": done,
-                "mask": mask,
+                "collector": {"mask": mask},
                 "reward": reward.masked_fill_(~mask.unsqueeze(-1), 0.0),
                 "action": action.masked_fill_(~mask.unsqueeze(-1), 0.0),
                 "action_value": action_value.masked_fill_(~mask.unsqueeze(-1), 0.0),
@@ -507,7 +507,7 @@ class TestDDPG:
                     "observation": next_obs.masked_fill_(~mask.unsqueeze(-1), 0.0)
                 },
                 "done": done,
-                "mask": mask,
+                "collector": {"mask": mask},
                 "reward": reward.masked_fill_(~mask.unsqueeze(-1), 0.0),
                 "action": action.masked_fill_(~mask.unsqueeze(-1), 0.0),
             },
@@ -735,7 +735,7 @@ class TestTD3:
                 "observation": obs * mask.to(obs.dtype),
                 "next": {"observation": next_obs * mask.to(obs.dtype)},
                 "done": done,
-                "mask": mask,
+                "collector": {"mask": mask},
                 "reward": reward * mask.to(obs.dtype),
                 "action": action * mask.to(obs.dtype),
             },
@@ -1012,7 +1012,7 @@ class TestSAC:
                     "observation": next_obs.masked_fill_(~mask.unsqueeze(-1), 0.0)
                 },
                 "done": done,
-                "mask": mask,
+                "collector": {"mask": mask},
                 "reward": reward.masked_fill_(~mask.unsqueeze(-1), 0.0),
                 "action": action.masked_fill_(~mask.unsqueeze(-1), 0.0),
             },
@@ -1441,7 +1441,7 @@ class TestREDQ:
                     "observation": next_obs.masked_fill_(~mask.unsqueeze(-1), 0.0)
                 },
                 "done": done,
-                "mask": mask,
+                "collector": {"mask": mask},
                 "reward": reward.masked_fill_(~mask.unsqueeze(-1), 0.0),
                 "action": action.masked_fill_(~mask.unsqueeze(-1), 0.0),
             },
@@ -1880,7 +1880,7 @@ class TestPPO:
                     "observation": next_obs.masked_fill_(~mask.unsqueeze(-1), 0.0)
                 },
                 "done": done,
-                "mask": mask,
+                "collector": {"mask": mask},
                 "reward": reward.masked_fill_(~mask.unsqueeze(-1), 0.0),
                 "action": action.masked_fill_(~mask.unsqueeze(-1), 0.0),
                 "sample_log_prob": (torch.randn_like(action[..., 1]) / 10).masked_fill_(
@@ -2153,7 +2153,7 @@ class TestA2C:
                     "observation": next_obs.masked_fill_(~mask.unsqueeze(-1), 0.0)
                 },
                 "done": done,
-                "mask": mask,
+                "collector": {"mask": mask},
                 "reward": reward.masked_fill_(~mask.unsqueeze(-1), 0.0),
                 "action": action.masked_fill_(~mask.unsqueeze(-1), 0.0),
                 "sample_log_prob": torch.randn_like(action[..., 1]).masked_fill_(

--- a/test/test_postprocs.py
+++ b/test/test_postprocs.py
@@ -98,28 +98,28 @@ class TestSplits:
         traj_len=200,
     ):
         traj_ids = torch.arange(num_workers)
-        steps_count = torch.zeros(num_workers)
+        step_count = torch.zeros(num_workers)
         workers = torch.arange(num_workers)
 
         out = []
         for _ in range(traj_len):
-            done = steps_count == traj_ids  # traj_id 0 has 0 steps, 1 has 1 step etc.
+            done = step_count == traj_ids  # traj_id 0 has 0 steps, 1 has 1 step etc.
 
             td = TensorDict(
                 source={
-                    "traj_ids": traj_ids,
+                    ("collector", "traj_ids"): traj_ids,
                     "a": traj_ids.clone().unsqueeze(-1),
-                    "steps_count": steps_count,
+                    ("collector", "step_count"): step_count,
                     "workers": workers,
                     "done": done.unsqueeze(-1),
                 },
                 batch_size=[num_workers],
             )
             out.append(td.clone())
-            steps_count += 1
+            step_count += 1
 
             traj_ids[done] = traj_ids.max() + torch.arange(1, done.sum() + 1)
-            steps_count[done] = 0
+            step_count[done] = 0
 
         out = torch.stack(out, 1).contiguous()
         return out
@@ -132,15 +132,20 @@ class TestSplits:
         assert trajs.shape[0] == num_workers
         assert trajs.shape[1] == traj_len
         split_trajs = split_trajectories(trajs)
-        assert split_trajs.shape[0] == split_trajs.get("traj_ids").max() + 1
-        assert split_trajs.shape[1] == split_trajs.get("steps_count").max() + 1
+        assert (
+            split_trajs.shape[0] == split_trajs.get(("collector", "traj_ids")).max() + 1
+        )
+        assert (
+            split_trajs.shape[1]
+            == split_trajs.get(("collector", "step_count")).max() + 1
+        )
 
         assert split_trajs.get(("collector", "mask")).sum() == num_workers * traj_len
 
         assert split_trajs.get("done").sum(1).max() == 1
         out_mask = split_trajs[split_trajs.get(("collector", "mask"))]
         for i in range(split_trajs.shape[0]):
-            traj_id_split = split_trajs[i].get("traj_ids")[
+            traj_id_split = split_trajs[i].get(("collector", "traj_ids"))[
                 split_trajs[i].get(("collector", "mask"))
             ]
             assert 1 == len(traj_id_split.unique())
@@ -148,8 +153,8 @@ class TestSplits:
         for w in range(num_workers):
             assert (out_mask.get("workers") == w).sum() == traj_len
         # Assert that either the chain is not done XOR if it is it must have the desired length (equal to traj id by design)
-        for i in range(split_trajs.get("traj_ids").max()):
-            idx_traj_id = out_mask.get("traj_ids") == i
+        for i in range(split_trajs.get(("collector", "traj_ids")).max()):
+            idx_traj_id = out_mask.get(("collector", "traj_ids")) == i
             # (!=) == (xor)
             c1 = (idx_traj_id.sum() - 1 == i) and (
                 out_mask.get("done")[idx_traj_id].sum() == 1
@@ -164,8 +169,8 @@ class TestSplits:
             )
 
         assert (
-            split_trajs.get("traj_ids").unique().numel()
-            == split_trajs.get("traj_ids").max() + 1
+            split_trajs.get(("collector", "traj_ids")).unique().numel()
+            == split_trajs.get(("collector", "traj_ids")).max() + 1
         )
 
 

--- a/test/test_postprocs.py
+++ b/test/test_postprocs.py
@@ -41,7 +41,7 @@ def test_multistep(n, key, device, T=11):
             "done": done,
             "reward": torch.randn(1, T, 1, device=device).expand(b, T, 1)
             * mask.to(torch.float),
-            "mask": mask,
+            "collector": {"mask": mask},
         },
         batch_size=(b, T),
     ).to(device)
@@ -135,12 +135,14 @@ class TestSplits:
         assert split_trajs.shape[0] == split_trajs.get("traj_ids").max() + 1
         assert split_trajs.shape[1] == split_trajs.get("steps_count").max() + 1
 
-        assert split_trajs.get("mask").sum() == num_workers * traj_len
+        assert split_trajs.get(("collector", "mask")).sum() == num_workers * traj_len
 
         assert split_trajs.get("done").sum(1).max() == 1
-        out_mask = split_trajs[split_trajs.get("mask")]
+        out_mask = split_trajs[split_trajs.get(("collector", "mask"))]
         for i in range(split_trajs.shape[0]):
-            traj_id_split = split_trajs[i].get("traj_ids")[split_trajs[i].get("mask")]
+            traj_id_split = split_trajs[i].get("traj_ids")[
+                split_trajs[i].get(("collector", "mask"))
+            ]
             assert 1 == len(traj_id_split.unique())
 
         for w in range(num_workers):

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -762,14 +762,14 @@ def test_masking():
     batch = 10
     td = TensorDict(
         {
-            "mask": torch.zeros(batch, dtype=torch.bool).bernoulli_(),
+            ("collector", "mask"): torch.zeros(batch, dtype=torch.bool).bernoulli_(),
             "tensor": torch.randn(batch, 51),
         },
         [batch],
     )
     td_out = trainer._process_batch_hook(td)
-    assert td_out.shape[0] == td.get("mask").sum()
-    assert (td["tensor"][td["mask"]] == td_out["tensor"]).all()
+    assert td_out.shape[0] == td.get(("collector", "mask")).sum()
+    assert (td["tensor"][td[("collector", "mask")]] == td_out["tensor"]).all()
 
 
 class TestSubSampler:
@@ -989,10 +989,13 @@ class TestCountFrames:
         count_frames = CountFramesLog(frame_skip=frame_skip)
         count_frames.register(trainer)
         td = TensorDict(
-            {"mask": torch.zeros(batch, dtype=torch.bool).bernoulli_()}, [batch]
+            {("collector", "mask"): torch.zeros(batch, dtype=torch.bool).bernoulli_()},
+            [batch],
         )
         trainer._pre_steps_log_hook(td)
-        assert count_frames.frame_count == td.get("mask").sum() * frame_skip
+        assert (
+            count_frames.frame_count == td.get(("collector", "mask")).sum() * frame_skip
+        )
 
     @pytest.mark.parametrize(
         "backend",
@@ -1037,13 +1040,21 @@ class TestCountFrames:
         with tempfile.TemporaryDirectory() as tmpdirname, tempfile.TemporaryDirectory() as tmpdirname2:
             trainer, count_frames, file = _make_countframe_and_trainer(tmpdirname)
             td = TensorDict(
-                {"mask": torch.zeros(batch, dtype=torch.bool).bernoulli_()}, [batch]
+                {
+                    ("collector", "mask"): torch.zeros(
+                        batch, dtype=torch.bool
+                    ).bernoulli_()
+                },
+                [batch],
             )
             trainer._pre_steps_log_hook(td)
             trainer.save_trainer(True)
             trainer2, count_frames2, _ = _make_countframe_and_trainer(tmpdirname2)
             trainer2.load_from_file(file)
-            assert count_frames2.frame_count == td.get("mask").sum() * frame_skip
+            assert (
+                count_frames2.frame_count
+                == td.get(("collector", "mask")).sum() * frame_skip
+            )
             assert state_dict_has_been_called[0]
             assert load_state_dict_has_been_called[0]
         CountFramesLog.state_dict = CountFramesLog_state_dict

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1827,33 +1827,27 @@ class TestTransforms:
         if reset_workers:
             td.set("_reset", torch.randn(batch) < 0)
         step_counter.reset(td)
-        assert not torch.all(td.get(("collector", "step_count")))
+        assert not torch.all(td.get("step_count"))
         i = 0
         while max_steps is None or i < max_steps:
             step_counter._step(td)
             i += 1
-            assert torch.all(td.get(("collector", "step_count")) == i)
+            assert torch.all(td.get("step_count") == i), (td.get("step_count"), i)
             if max_steps is None:
                 break
         if max_steps is not None:
-            assert torch.all(td.get(("collector", "step_count")) == max_steps)
+            assert torch.all(td.get("step_count") == max_steps)
             assert torch.all(td.get("done"))
         step_counter.reset(td)
         if reset_workers:
             assert torch.all(
-                torch.masked_select(
-                    td.get(("collector", "step_count")), td.get("_reset")
-                )
-                == 0
+                torch.masked_select(td.get("step_count"), td.get("_reset")) == 0
             )
             assert torch.all(
-                torch.masked_select(
-                    td.get(("collector", "step_count")), ~td.get("_reset")
-                )
-                == i
+                torch.masked_select(td.get("step_count"), ~td.get("_reset")) == i
             )
         else:
-            assert torch.all(td.get(("collector", "step_count")) == 0)
+            assert torch.all(td.get("step_count") == 0)
 
     def test_step_counter_observation_spec(self):
         transformed_env = TransformedEnv(ContinuousActionVecMockEnv(), StepCounter(50))

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1827,27 +1827,33 @@ class TestTransforms:
         if reset_workers:
             td.set("_reset", torch.randn(batch) < 0)
         step_counter.reset(td)
-        assert not torch.all(td.get("step_count"))
+        assert not torch.all(td.get(("collector", "step_count")))
         i = 0
         while max_steps is None or i < max_steps:
             step_counter._step(td)
             i += 1
-            assert torch.all(td.get("step_count") == i)
+            assert torch.all(td.get(("collector", "step_count")) == i)
             if max_steps is None:
                 break
         if max_steps is not None:
-            assert torch.all(td.get("step_count") == max_steps)
+            assert torch.all(td.get(("collector", "step_count")) == max_steps)
             assert torch.all(td.get("done"))
         step_counter.reset(td)
         if reset_workers:
             assert torch.all(
-                torch.masked_select(td.get("step_count"), td.get("_reset")) == 0
+                torch.masked_select(
+                    td.get(("collector", "step_count")), td.get("_reset")
+                )
+                == 0
             )
             assert torch.all(
-                torch.masked_select(td.get("step_count"), ~td.get("_reset")) == i
+                torch.masked_select(
+                    td.get(("collector", "step_count")), ~td.get("_reset")
+                )
+                == i
             )
         else:
-            assert torch.all(td.get("step_count") == 0)
+            assert torch.all(td.get(("collector", "step_count")) == 0)
 
     def test_step_counter_observation_spec(self):
         transformed_env = TransformedEnv(ContinuousActionVecMockEnv(), StepCounter(50))

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -654,7 +654,7 @@ class SyncDataCollector(_DataCollector):
         n = self.env.batch_size[0] if len(self.env.batch_size) else 1
         self._tensordict.set(
             ("collector", "traj_ids"),
-            torch.arange(n).view(self.env.batch_size[:1], dtype=torch.int64),
+            torch.arange(n).view(self.env.batch_size[:1]),
         )
 
         with set_exploration_mode(self.exploration_mode):
@@ -1314,7 +1314,7 @@ class MultiSyncDataCollector(_MultiDataCollector):
 
             if self.split_trajs:
                 out = split_trajectories(out_buffer)
-                frames += out.get("mask").sum().item()
+                frames += out.get("collector", "mask").sum().item()
             else:
                 out = out_buffer.clone()
                 frames += prod(out.shape)

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -320,8 +320,8 @@ class SyncDataCollector(_DataCollector):
                 action: Tensor(shape=torch.Size([4, 50, 1]), device=cpu, dtype=torch.float32, is_shared=False),
                 collector: TensorDict(
                     fields={
-                        _step_count: Tensor(shape=torch.Size([4, 50]), device=cpu, dtype=torch.int64, is_shared=False),
-                        _traj_ids: Tensor(shape=torch.Size([4, 50]), device=cpu, dtype=torch.int64, is_shared=False)},
+                        step_count: Tensor(shape=torch.Size([4, 50]), device=cpu, dtype=torch.int64, is_shared=False),
+                        "traj_ids: Tensor(shape=torch.Size([4, 50]), device=cpu, dtype=torch.int64, is_shared=False)},
                     batch_size=torch.Size([4, 50]),
                     device=cpu,
                     is_shared=False),
@@ -433,7 +433,7 @@ class SyncDataCollector(_DataCollector):
 
         self._tensordict = env.reset()
         self._tensordict.set(
-            ("collector", "_step_count"),
+            ("collector", "step_count"),
             torch.zeros(self.env.batch_size, dtype=torch.int, device=env.device),
         )
 
@@ -468,10 +468,10 @@ class SyncDataCollector(_DataCollector):
                 .to_tensordict()
                 .zero_()
             )
-        # in addition to outputs of the policy, we add _traj_ids and _step_count to
+        # in addition to outputs of the policy, we add traj_ids and step_count to
         # _tensordict_out which will be collected during rollout
         self._tensordict_out.set(
-            ("collector", "_traj_ids"),
+            ("collector", "traj_ids"),
             torch.zeros(
                 *self._tensordict_out.batch_size,
                 dtype=torch.int64,
@@ -479,7 +479,7 @@ class SyncDataCollector(_DataCollector):
             ),
         )
         self._tensordict_out.set(
-            ("collector", "_step_count"),
+            ("collector", "step_count"),
             torch.zeros(
                 *self._tensordict_out.batch_size,
                 dtype=torch.int64,
@@ -600,7 +600,7 @@ class SyncDataCollector(_DataCollector):
         done = self._tensordict.get("done")
         if not self.reset_when_done:
             done = torch.zeros_like(done)
-        steps = self._tensordict.get(("collector", "_step_count"))
+        steps = self._tensordict.get(("collector", "step_count"))
         done_or_terminated = done.squeeze(-1) | (steps == self.max_frames_per_traj)
         if self._has_been_done is None:
             self._has_been_done = done_or_terminated
@@ -613,7 +613,7 @@ class SyncDataCollector(_DataCollector):
             _reset[self._has_been_done] = False
             done_or_terminated = done_or_terminated | _reset
         if done_or_terminated.any():
-            _traj_ids = self._tensordict.get(("collector", "_traj_ids")).clone()
+            traj_ids = self._tensordict.get(("collector", "traj_ids")).clone()
             steps = steps.clone()
             if len(self.env.batch_size):
                 self._tensordict.masked_fill_(done_or_terminated, 0)
@@ -630,14 +630,14 @@ class SyncDataCollector(_DataCollector):
                 raise RuntimeError(
                     f"Env {self.env} was done after reset on specified '_reset' dimensions. This is (currently) not allowed."
                 )
-            _traj_ids[done_or_terminated] = _traj_ids.max() + torch.arange(
-                1, done_or_terminated.sum() + 1, device=_traj_ids.device
+            traj_ids[done_or_terminated] = traj_ids.max() + torch.arange(
+                1, done_or_terminated.sum() + 1, device=traj_ids.device
             )
             steps[done_or_terminated] = 0
             self._tensordict.set_(
-                ("collector", "_traj_ids"), _traj_ids
+                ("collector", "traj_ids"), traj_ids
             )  # no ops if they already match
-            self._tensordict.set_(("collector", "_step_count"), steps)
+            self._tensordict.set_(("collector", "step_count"), steps)
 
     @torch.no_grad()
     def rollout(self) -> TensorDictBase:
@@ -649,11 +649,12 @@ class SyncDataCollector(_DataCollector):
         """
         if self.reset_at_each_iter:
             self._tensordict.update(self.env.reset(), inplace=True)
-            self._tensordict.fill_(("collector", "_step_count"), 0)
+            self._tensordict.fill_(("collector", "step_count"), 0)
 
         n = self.env.batch_size[0] if len(self.env.batch_size) else 1
         self._tensordict.set(
-            ("collector", "_traj_ids"), torch.arange(n).view(self.env.batch_size[:1])
+            ("collector", "traj_ids"),
+            torch.arange(n).view(self.env.batch_size[:1], dtype=torch.int64),
         )
 
         with set_exploration_mode(self.exploration_mode):
@@ -666,8 +667,8 @@ class SyncDataCollector(_DataCollector):
                     self._cast_to_env(td_cast, self._tensordict)
                     self._tensordict = self.env.step(self._tensordict)
 
-                _step_count = self._tensordict.get(("collector", "_step_count"))
-                self._tensordict.set_(("collector", "_step_count"), _step_count + 1)
+                step_count = self._tensordict.get(("collector", "step_count"))
+                self._tensordict.set_(("collector", "step_count"), step_count + 1)
                 # we must clone all the values, since the step / traj_id updates are done in-place
                 try:
                     self._tensordict_out[..., j] = self._tensordict
@@ -709,11 +710,11 @@ class SyncDataCollector(_DataCollector):
 
         self._tensordict.update(self.env.reset(**kwargs), inplace=True)
         if _reset is not None:
-            _step_count = self._tensordict[("collector", "_step_count")]
-            _step_count[_reset] = 0
-            self._tensordict.set(("collector", "_step_count"), _step_count)
+            step_count = self._tensordict[("collector", "step_count")]
+            step_count[_reset] = 0
+            self._tensordict.set(("collector", "step_count"), step_count)
         else:
-            self._tensordict.fill_(("collector", "_step_count"), 0)
+            self._tensordict.fill_(("collector", "step_count"), 0)
 
     def shutdown(self) -> None:
         """Shuts down all workers and/or closes the local environment."""
@@ -1215,8 +1216,8 @@ class MultiSyncDataCollector(_MultiDataCollector):
                 action: Tensor(shape=torch.Size([4, 50, 1]), device=cpu, dtype=torch.float32, is_shared=False),
                 collector: TensorDict(
                     fields={
-                        _step_count: Tensor(shape=torch.Size([4, 50]), device=cpu, dtype=torch.int64, is_shared=False),
-                        _traj_ids: Tensor(shape=torch.Size([4, 50]), device=cpu, dtype=torch.int64, is_shared=False)},
+                        step_count: Tensor(shape=torch.Size([4, 50]), device=cpu, dtype=torch.int64, is_shared=False),
+                        traj_ids: Tensor(shape=torch.Size([4, 50]), device=cpu, dtype=torch.int64, is_shared=False)},
                     batch_size=torch.Size([4, 50]),
                     device=cpu,
                     is_shared=False),
@@ -1284,13 +1285,13 @@ class MultiSyncDataCollector(_MultiDataCollector):
                 if workers_frames[idx] >= self.total_frames:
                     print(f"{idx} is done!")
                     dones[idx] = True
-            # we have to correct the _traj_ids to make sure that they don't overlap
+            # we have to correct the traj_ids to make sure that they don't overlap
             for idx in range(self.num_workers):
-                _traj_ids = out_tensordicts_shared[idx].get(("collector", "_traj_ids"))
+                traj_ids = out_tensordicts_shared[idx].get(("collector", "traj_ids"))
                 if max_traj_idx is not None:
-                    _traj_ids += max_traj_idx
-                    # out_tensordicts_shared[idx].set("_traj_ids", _traj_ids)
-                max_traj_idx = _traj_ids.max().item() + 1
+                    traj_ids += max_traj_idx
+                    # out_tensordicts_shared[idx].set("traj_ids", traj_ids)
+                max_traj_idx = traj_ids.max().item() + 1
                 # out = out_tensordicts_shared[idx]
             if same_device is None:
                 prev_device = None
@@ -1365,8 +1366,8 @@ class MultiaSyncDataCollector(_MultiDataCollector):
                 action: Tensor(shape=torch.Size([4, 50, 1]), device=cpu, dtype=torch.float32, is_shared=False),
                 collector: TensorDict(
                     fields={
-                        _step_count: Tensor(shape=torch.Size([4, 50]), device=cpu, dtype=torch.int64, is_shared=False),
-                        _traj_ids: Tensor(shape=torch.Size([4, 50]), device=cpu, dtype=torch.int64, is_shared=False)},
+                        step_count: Tensor(shape=torch.Size([4, 50]), device=cpu, dtype=torch.int64, is_shared=False),
+                        traj_ids: Tensor(shape=torch.Size([4, 50]), device=cpu, dtype=torch.int64, is_shared=False)},
                     batch_size=torch.Size([4, 50]),
                     device=cpu,
                     is_shared=False),

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -1314,7 +1314,7 @@ class MultiSyncDataCollector(_MultiDataCollector):
 
             if self.split_trajs:
                 out = split_trajectories(out_buffer)
-                frames += out.get("collector", "mask").sum().item()
+                frames += out.get(("collector", "mask")).sum().item()
             else:
                 out = out_buffer.clone()
                 frames += prod(out.shape)

--- a/torchrl/collectors/utils.py
+++ b/torchrl/collectors/utils.py
@@ -35,7 +35,7 @@ def split_trajectories(rollout_tensordict: TensorDictBase) -> TensorDictBase:
     # TODO: incorporate tensordict.split once it's implemented
     sep = ".-|-."
     rollout_tensordict = rollout_tensordict.flatten_keys(sep)
-    traj_ids = rollout_tensordict.get(sep.join(["collector", "_traj_ids"]))
+    traj_ids = rollout_tensordict.get(sep.join(["collector", "traj_ids"]))
     splits = traj_ids.view(-1)
     splits = [(splits == i).sum().item() for i in splits.unique_consecutive()]
     # if all splits are identical then we can skip this function

--- a/torchrl/collectors/utils.py
+++ b/torchrl/collectors/utils.py
@@ -35,7 +35,7 @@ def split_trajectories(rollout_tensordict: TensorDictBase) -> TensorDictBase:
     # TODO: incorporate tensordict.split once it's implemented
     sep = ".-|-."
     rollout_tensordict = rollout_tensordict.flatten_keys(sep)
-    traj_ids = rollout_tensordict.get("traj_ids")
+    traj_ids = rollout_tensordict.get(sep.join(["collector", "_traj_ids"]))
     splits = traj_ids.view(-1)
     splits = [(splits == i).sum().item() for i in splits.unique_consecutive()]
     # if all splits are identical then we can skip this function

--- a/torchrl/collectors/utils.py
+++ b/torchrl/collectors/utils.py
@@ -32,16 +32,16 @@ def split_trajectories(rollout_tensordict: TensorDictBase) -> TensorDictBase:
 
     From there, builds a B x T x ... zero-padded tensordict with B batches on max duration T
     """
-    # TODO: incorporate tensordict.split once it's implemented
     sep = ".-|-."
     rollout_tensordict = rollout_tensordict.flatten_keys(sep)
     traj_ids = rollout_tensordict.get(sep.join(["collector", "traj_ids"]))
     splits = traj_ids.view(-1)
     splits = [(splits == i).sum().item() for i in splits.unique_consecutive()]
     # if all splits are identical then we can skip this function
+    mask_key = sep.join(("collector", "mask"))
     if len(set(splits)) == 1 and splits[0] == traj_ids.shape[-1]:
         rollout_tensordict.set(
-            "mask",
+            mask_key,
             torch.ones(
                 rollout_tensordict.shape,
                 device=rollout_tensordict.device,
@@ -55,7 +55,7 @@ def split_trajectories(rollout_tensordict: TensorDictBase) -> TensorDictBase:
 
     for out_split in out_splits:
         out_split.set(
-            "mask",
+            mask_key,
             torch.ones(
                 out_split.shape,
                 dtype=torch.bool,

--- a/torchrl/data/postprocs/postprocs.py
+++ b/torchrl/data/postprocs/postprocs.py
@@ -169,8 +169,8 @@ class MultiStep(nn.Module):
             raise RuntimeError("Expected a tensordict with B x T x ... dimensions")
 
         done = tensordict.get("done")
-        if "mask" in tensordict.keys():
-            mask = tensordict.get("mask").view_as(done)
+        if ("collector", "mask") in tensordict.keys(True):
+            mask = tensordict.get(("collector", "mask")).view_as(done)
         else:
             mask = done.clone().flip(1).cumsum(1).flip(1).to(torch.bool)
         reward = tensordict.get("reward")

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -522,8 +522,6 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
                 f"Env {self} was done after reset on specified '_reset' dimensions. This is (currently) not allowed."
             )
         if tensordict is not None:
-            if "_reset" in tensordict.keys():
-                tensordict.del_("_reset")
             tensordict.update(tensordict_reset)
         else:
             tensordict = tensordict_reset

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -2744,32 +2744,31 @@ class StepCounter(Transform):
                 tensordict.batch_size, dtype=torch.bool, device=tensordict.device
             ),
         )
+        step_count = tensordict.get(
+            "step_count",
+            torch.zeros(
+                tensordict.batch_size,
+                dtype=torch.int64,
+                device=tensordict.device,
+            ),
+        )
+        step_count[_reset] = 0
         tensordict.set(
             "step_count",
-            (~_reset)
-            * tensordict.get(
-                "step_count",
-                torch.zeros(
-                    tensordict.batch_size,
-                    dtype=torch.int64,
-                    device=tensordict.device,
-                ),
-            ),
+            step_count,
         )
         return tensordict
 
     def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
-        next_step_count = (
-            tensordict.get(
-                "step_count",
-                torch.zeros(
-                    tensordict.batch_size,
-                    dtype=torch.int64,
-                    device=tensordict.device,
-                ),
-            )
-            + 1
+        step_count = tensordict.get(
+            "step_count",
+            torch.zeros(
+                tensordict.batch_size,
+                dtype=torch.int64,
+                device=tensordict.device,
+            ),
         )
+        next_step_count = step_count + 1
         tensordict.set("step_count", next_step_count)
         if self.max_steps is not None:
             tensordict.set(

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -474,6 +474,8 @@ but got an object of type {type(transform)}."""
     def _reset(self, tensordict: Optional[TensorDictBase] = None, **kwargs):
         if tensordict is not None:
             tensordict = tensordict.clone(recurse=False)
+            if "_reset" in tensordict.keys():
+                print("transformed env", tensordict['_reset'].sum())
         out_tensordict = self.base_env.reset(tensordict=tensordict, **kwargs)
         out_tensordict = self.transform.reset(out_tensordict)
         out_tensordict = self.transform(out_tensordict)
@@ -2747,6 +2749,7 @@ class StepCounter(Transform):
                 tensordict.batch_size, dtype=torch.bool, device=tensordict.device
             ),
         )
+        print("step count reset", _reset)
         step_count = tensordict.get(
             "step_count",
             torch.zeros(
@@ -2755,11 +2758,10 @@ class StepCounter(Transform):
                 device=tensordict.device,
             ),
         )
+        print("step count sc", step_count)
         step_count[_reset] = 0
-        tensordict.set(
-            "step_count",
-            step_count,
-        )
+        print("step count sc (after)", step_count)
+        tensordict.set("step_count", step_count,)
         return tensordict
 
     def _step(self, tensordict: TensorDictBase) -> TensorDictBase:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -2635,7 +2635,9 @@ class RewardSum(Transform):
                 if out_key in tensordict.keys():
                     value = tensordict[out_key]
                     dtype = value.dtype
-                    tensordict[out_key] = value.masked_fill(expand_as_right(_reset, value), 0.0)
+                    tensordict[out_key] = value.masked_fill(
+                        expand_as_right(_reset, value), 0.0
+                    )
                 elif in_key == "reward":
                     # Since the episode reward is not in the tensordict, we need to allocate it
                     # with zeros entirely (regardless of the _reset mask)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -2771,7 +2771,7 @@ class StepCounter(Transform):
             ),
         )
         next_step_count = step_count + 1
-        tensordict.set("step_count", next_step_count)
+        tensordict.set(("collector", "step_count"), next_step_count)
         if self.max_steps is not None:
             done = tensordict.get("done")
             done = done | (next_step_count >= self.max_steps).unsqueeze(-1)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -475,7 +475,7 @@ but got an object of type {type(transform)}."""
         if tensordict is not None:
             tensordict = tensordict.clone(recurse=False)
             if "_reset" in tensordict.keys():
-                print("transformed env", tensordict['_reset'].sum())
+                print("transformed env", tensordict["_reset"].sum())
         out_tensordict = self.base_env.reset(tensordict=tensordict, **kwargs)
         out_tensordict = self.transform.reset(out_tensordict)
         out_tensordict = self.transform(out_tensordict)
@@ -2636,7 +2636,6 @@ class RewardSum(Transform):
             for in_key, out_key in zip(self.in_keys, self.out_keys):
                 if out_key in tensordict.keys():
                     value = tensordict[out_key]
-                    dtype = value.dtype
                     tensordict[out_key] = value.masked_fill(
                         expand_as_right(_reset, value), 0.0
                     )
@@ -2761,7 +2760,10 @@ class StepCounter(Transform):
         print("step count sc", step_count)
         step_count[_reset] = 0
         print("step count sc (after)", step_count)
-        tensordict.set("step_count", step_count,)
+        tensordict.set(
+            "step_count",
+            step_count,
+        )
         return tensordict
 
     def _step(self, tensordict: TensorDictBase) -> TensorDictBase:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -2771,7 +2771,7 @@ class StepCounter(Transform):
             ),
         )
         next_step_count = step_count + 1
-        tensordict.set(("collector", "step_count"), next_step_count)
+        tensordict.set("step_count", next_step_count)
         if self.max_steps is not None:
             done = tensordict.get("done")
             done = done | (next_step_count >= self.max_steps).unsqueeze(-1)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -474,8 +474,6 @@ but got an object of type {type(transform)}."""
     def _reset(self, tensordict: Optional[TensorDictBase] = None, **kwargs):
         if tensordict is not None:
             tensordict = tensordict.clone(recurse=False)
-            if "_reset" in tensordict.keys():
-                print("transformed env", tensordict["_reset"].sum())
         out_tensordict = self.base_env.reset(tensordict=tensordict, **kwargs)
         out_tensordict = self.transform.reset(out_tensordict)
         out_tensordict = self.transform(out_tensordict)
@@ -2748,7 +2746,6 @@ class StepCounter(Transform):
                 tensordict.batch_size, dtype=torch.bool, device=tensordict.device
             ),
         )
-        print("step count reset", _reset)
         step_count = tensordict.get(
             "step_count",
             torch.zeros(
@@ -2757,9 +2754,7 @@ class StepCounter(Transform):
                 device=tensordict.device,
             ),
         )
-        print("step count sc", step_count)
         step_count[_reset] = 0
-        print("step count sc (after)", step_count)
         tensordict.set(
             "step_count",
             step_count,

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -617,9 +617,11 @@ class SerialEnv(_BatchedEnv):
             _reset = torch.ones(self.batch_size, dtype=torch.bool)
 
         keys = set()
+        print("serial env, reset=", _reset)
         for i, _env in enumerate(self._envs):
             if not _reset[i].any():
                 continue
+            print(f"resetting {i}")
             _tensordict = tensordict[i] if tensordict is not None else None
             _td = _env._reset(tensordict=_tensordict, **kwargs)
             if "_reset" in _td.keys():

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -617,11 +617,9 @@ class SerialEnv(_BatchedEnv):
             _reset = torch.ones(self.batch_size, dtype=torch.bool)
 
         keys = set()
-        print("serial env, reset=", _reset)
         for i, _env in enumerate(self._envs):
             if not _reset[i].any():
                 continue
-            print(f"resetting {i}")
             _tensordict = tensordict[i] if tensordict is not None else None
             _td = _env._reset(tensordict=_tensordict, **kwargs)
             if "_reset" in _td.keys():

--- a/torchrl/modules/models/recipes/impala.py
+++ b/torchrl/modules/models/recipes/impala.py
@@ -177,7 +177,7 @@ class ImpalaNetTensorDict(ImpalaNet):  # noqa: D101
         x = tensordict.get(self.observation_key)
         done = tensordict.get("done").squeeze(-1)
         reward = tensordict.get("reward").squeeze(-1)
-        mask = tensordict.get("mask")
+        mask = tensordict.get(("collector", "mask"))
         core_state = (
             tensordict.get("core_state") if "core_state" in tensordict.keys() else None
         )

--- a/tutorials/sphinx-tutorials/coding_ddpg.py
+++ b/tutorials/sphinx-tutorials/coding_ddpg.py
@@ -631,10 +631,10 @@ for i, tensordict in enumerate(collector):
     pbar.update(tensordict.numel())
 
     # extend the replay buffer with the new data
-    if "mask" in tensordict.keys():
+    if ("collector", "mask") in tensordict.keys(True):
         # if multi-step, a mask is present to help filter padded values
-        current_frames = tensordict["mask"].sum()
-        tensordict = tensordict[tensordict.get("mask")]
+        current_frames = tensordict["collector", "mask"].sum()
+        tensordict = tensordict[tensordict.get(("collector", "mask"))]
     else:
         tensordict = tensordict.view(-1)
         current_frames = tensordict.numel()
@@ -882,7 +882,7 @@ for i, tensordict in enumerate(collector):
         :1
     ]  # this is necessary for prioritized replay buffers: we will assign one priority value to each element, hence the batch_size must comply with the number of priority values
     current_frames = tensordict.numel()
-    collected_frames += tensordict["mask"].sum()
+    collected_frames += tensordict["collector", "mask"].sum()
     replay_buffer.extend(tensordict.cpu())
 
     # optimization steps

--- a/tutorials/sphinx-tutorials/coding_dqn.py
+++ b/tutorials/sphinx-tutorials/coding_dqn.py
@@ -364,7 +364,7 @@ prev_traj_count = 0
 pbar = tqdm.tqdm(total=total_frames)
 for j, data in enumerate(data_collector):
     # trajectories are padded to be stored in the same tensordict: since we do not care about consecutive step, we'll just mask the tensordict and get the flattened representation instead.
-    mask = data["mask"]
+    mask = data["collector", "mask"]
     current_frames = mask.sum().cpu().item()
     pbar.update(current_frames)
 
@@ -601,7 +601,7 @@ prev_traj_count = 0
 
 pbar = tqdm.tqdm(total=total_frames)
 for j, data in enumerate(data_collector):
-    mask = data["mask"]
+    mask = data["collector", "mask"]
     data = pad(data, [0, 0, 0, max_size - data.shape[1]])
     current_frames = mask.sum().cpu().item()
     pbar.update(current_frames)
@@ -644,7 +644,7 @@ for j, data in enumerate(data_collector):
                 done,
             ).pow(2)
             # reward + gamma * next_value * (1 - done)
-            mask = sampled_data["mask"]
+            mask = sampled_data["collector", "mask"]
             error = error[mask].mean()
             # assert exp_value.shape == action_value.shape
             # error = nn.functional.smooth_l1_loss(exp_value, action_value).mean()


### PR DESCRIPTION
## Description

`StepCount` and the collectors both assign a `"step_count"` key that it would be wise to use only once.
This PR solves this issue.

cc @riiswa 