### PR TITLE
[Refactor] Better init for CatFrames buffers + removing default init values

### DIFF
--- a/examples/dreamer/dreamer_utils.py
+++ b/examples/dreamer/dreamer_utils.py
@@ -90,7 +90,7 @@ def make_env_transforms(
         if cfg.grayscale:
             env.append_transform(GrayScale())
         env.append_transform(FlattenObservation(0, -3))
-        env.append_transform(CatFrames(N=cfg.catframes, in_keys=["pixels"]))
+        env.append_transform(CatFrames(N=cfg.catframes, in_keys=["pixels"], dim=-3))
         if stats is None:
             obs_stats = {
                 "loc": torch.zeros(env.observation_spec["pixels"].shape),

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -798,7 +798,7 @@ transforms = [
     pytest.param(partial(SqueezeTransform, squeeze_dim=-1), id="SqueezeTransform"),
     GrayScale,
     pytest.param(partial(ObservationNorm, loc=1, scale=2), id="ObservationNorm"),
-    CatFrames,
+    pytest.param(partial(CatFrames, dim=-3, N=4), id="CatFrames"),
     pytest.param(partial(RewardScaling, loc=1, scale=2), id="RewardScaling"),
     DoubleToFloat,
     VecNorm,

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1370,11 +1370,13 @@ class TestTransforms:
 
         tdc = td.clone()
         passed_back_td = cat_frames.reset(tdc)
+        assert "_reset" in tdc.keys()
 
         assert tdc is passed_back_td
-        assert (buffer != 0).all()
+        assert (buffer == 0).all()
 
-        _ = cat_frames._call(td.clone())
+        _ = cat_frames._call(tdc)
+        assert (buffer != 0).all()
 
     @pytest.mark.parametrize("device", get_available_devices())
     def test_finitetensordictcheck(self, device):

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -878,8 +878,6 @@ class TestTransforms:
             tensor_list.append(torch.rand(batch, nodes).to(device))
         max_vals, _ = torch.max(torch.stack(tensor_list[-T:]), dim=0)
 
-        print(f"max vals: {max_vals}")
-
         for i in range(seq_len):
             env_td = TensorDict(
                 {
@@ -1359,17 +1357,16 @@ class TestTransforms:
         td = TensorDict(dict(zip(keys, key_tensors)), [1], device=device)
         cat_frames = CatFrames(N=N, in_keys=keys)
 
-        cat_frames(td)
+        cat_frames(td.clone())
         buffer = getattr(cat_frames, f"_cat_buffers_{key1}")
 
-        passed_back_td = cat_frames.reset(td)
+        tdc = td.clone()
+        passed_back_td = cat_frames.reset(tdc)
 
-        assert td is passed_back_td
-        assert (0 == buffer).all()
+        assert tdc is passed_back_td
+        assert (buffer != 0).all()
 
-        _ = cat_frames._call(td)
-        assert (0 == buffer[..., :-1, :, :]).all()
-        assert (0 != buffer[..., -1:, :, :]).all()
+        _ = cat_frames._call(td.clone())
 
     @pytest.mark.parametrize("device", get_available_devices())
     def test_finitetensordictcheck(self, device):

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1520,10 +1520,10 @@ class CatFrames(ObservationTransform):
     calling the `reset()` method.
 
     Args:
-        N (int, optional): number of observation to concatenate.
-            Default is `4`.
-        cat_dim (int, optional): dimension along which concatenate the
-            observations. Default is `cat_dim=-3`.
+        N (int): number of observation to concatenate.
+        dim (int): dimension along which concatenate the
+            observations. Should be negative, to ensure that it is compatible
+            with environments of different batch_size.
         in_keys (list of int, optional): keys pointing to the frames that have
             to be concatenated. Defaults to ["pixels"].
         out_keys (list of int, optional): keys pointing to where the output
@@ -1539,8 +1539,8 @@ class CatFrames(ObservationTransform):
 
     def __init__(
         self,
-        N: int = 4,
-        cat_dim: int = -3,
+        N: int,
+        dim: int,
         in_keys: Optional[Sequence[str]] = None,
         out_keys: Optional[Sequence[str]] = None,
     ):
@@ -1548,9 +1548,9 @@ class CatFrames(ObservationTransform):
             in_keys = IMAGE_KEYS
         super().__init__(in_keys=in_keys, out_keys=out_keys)
         self.N = N
-        if cat_dim > 0:
+        if dim > 0:
             raise ValueError(self._CAT_DIM_ERR)
-        self.cat_dim = cat_dim
+        self.cat_dim = dim
         for in_key in self.in_keys:
             buffer_name = f"_cat_buffers_{in_key}"
             setattr(

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1568,7 +1568,9 @@ class CatFrames(ObservationTransform):
             torch.ones(
                 tensordict.batch_size,
                 dtype=torch.bool,
-                device=self.parent.device,
+                device=tensordict.device
+                if tensordict.device is not None
+                else torch.device("cpu"),
             ),
         )
         for in_key in self.in_keys:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1563,31 +1563,20 @@ class CatFrames(ObservationTransform):
 
     def reset(self, tensordict: TensorDictBase) -> TensorDictBase:
         """Resets _buffers."""
-        # Non-batched environments
-        if len(tensordict.batch_size) < 1 or tensordict.batch_size[0] == 1:
-            for in_key in self.in_keys:
-                buffer_name = f"_cat_buffers_{in_key}"
-                buffer = getattr(self, buffer_name)
-                if isinstance(buffer, torch.nn.parameter.UninitializedBuffer):
-                    continue
-                buffer.fill_(0.0)
-
-        # Batched environments
-        else:
-            _reset = tensordict.get(
-                "_reset",
-                torch.ones(
-                    tensordict.batch_size,
-                    dtype=torch.bool,
-                    device=tensordict.device,
-                ),
-            )
-            for in_key in self.in_keys:
-                buffer_name = f"_cat_buffers_{in_key}"
-                buffer = getattr(self, buffer_name)
-                if isinstance(buffer, torch.nn.parameter.UninitializedBuffer):
-                    continue
-                buffer[_reset] = 0.0
+        _reset = tensordict.set_default(
+            "_reset",
+            torch.ones(
+                tensordict.batch_size,
+                dtype=torch.bool,
+                device=self.parent.device,
+            ),
+        )
+        for in_key in self.in_keys:
+            buffer_name = f"_cat_buffers_{in_key}"
+            buffer = getattr(self, buffer_name)
+            if isinstance(buffer, torch.nn.parameter.UninitializedBuffer):
+                continue
+            buffer[_reset] = 0
 
         return tensordict
 
@@ -1603,6 +1592,8 @@ class CatFrames(ObservationTransform):
 
     def _call(self, tensordict: TensorDictBase) -> TensorDictBase:
         """Update the episode tensordict with max pooled keys."""
+        _reset = tensordict.get("_reset", None)
+
         for in_key, out_key in zip(self.in_keys, self.out_keys):
             # Lazy init of buffers
             buffer_name = f"_cat_buffers_{in_key}"
@@ -1611,9 +1602,12 @@ class CatFrames(ObservationTransform):
             buffer = getattr(self, buffer_name)
             if isinstance(buffer, torch.nn.parameter.UninitializedBuffer):
                 buffer = self._make_missing_buffer(data, buffer_name)
-            else:
-                # shift obs 1 position to the right
-                buffer.copy_(torch.roll(buffer, shifts=-d, dims=self.cat_dim))
+            # shift obs 1 position to the right
+            if _reset is not None:
+                buffer[_reset] = buffer[_reset].copy_(
+                    data[_reset].repeat_interleave(self.N, self.cat_dim)
+                )
+            buffer.copy_(torch.roll(buffer, shifts=-d, dims=self.cat_dim))
             # add new obs
             idx = self.cat_dim
             if idx < 0:

--- a/torchrl/trainers/helpers/envs.py
+++ b/torchrl/trainers/helpers/envs.py
@@ -124,7 +124,7 @@ def make_env_transforms(
         if cfg.grayscale:
             env.append_transform(GrayScale())
         env.append_transform(FlattenObservation(0, -3))
-        env.append_transform(CatFrames(N=cfg.catframes, in_keys=["pixels"]), dim=-3)
+        env.append_transform(CatFrames(N=cfg.catframes, in_keys=["pixels"], dim=-3))
         if stats is None:
             obs_stats = {
                 "loc": torch.zeros(env.observation_spec["pixels"].shape),

--- a/torchrl/trainers/helpers/envs.py
+++ b/torchrl/trainers/helpers/envs.py
@@ -124,7 +124,7 @@ def make_env_transforms(
         if cfg.grayscale:
             env.append_transform(GrayScale())
         env.append_transform(FlattenObservation(0, -3))
-        env.append_transform(CatFrames(N=cfg.catframes, in_keys=["pixels"]))
+        env.append_transform(CatFrames(N=cfg.catframes, in_keys=["pixels"]), dim=-3)
         if stats is None:
             obs_stats = {
                 "loc": torch.zeros(env.observation_spec["pixels"].shape),
@@ -197,9 +197,7 @@ def make_env_transforms(
         )
 
         if hasattr(cfg, "catframes") and cfg.catframes:
-            env.append_transform(
-                CatFrames(N=cfg.catframes, in_keys=[out_key], cat_dim=-1)
-            )
+            env.append_transform(CatFrames(N=cfg.catframes, in_keys=[out_key], dim=-1))
 
     else:
         env.append_transform(

--- a/tutorials/sphinx-tutorials/coding_dqn.py
+++ b/tutorials/sphinx-tutorials/coding_dqn.py
@@ -175,7 +175,7 @@ def make_env(parallel=False, m=0, s=1):
             GrayScale(),
             Resize(64, 64),
             ObservationNorm(in_keys=["pixels"], loc=m, scale=s, standard_normal=True),
-            CatFrames(4, in_keys=["pixels"]),
+            CatFrames(4, in_keys=["pixels"], dim=-3),
         ),
     )
     return env


### PR DESCRIPTION
## Description

Refactors the buffer init of `CatFrames`. 
After this PR, buffers won't be filled with 0s but with copies of the first frame. The advantage of doing so is that the values are not drastically different from the rest of the rollout.

We also set a default `"_reset"` key in the tensordict to keep track of the successive calls to `reset` and `_call`: in `"_reset"` has non-zero elements, then a copy of the data must be executed during the transform.

This in-turn impact the `check_envs` method that must now ignore private keys in the tensordict.

We also remove the default values for `N` and `cat_dim` which we rename `dim` for consistency with other transforms.

cc @matteobettini again because of the `"_reset"` key.
cc @albertbou92 