### PR TITLE
[Refactor] Box device

### DIFF
--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import contextlib
 import os
 import time
 from functools import wraps
@@ -104,3 +105,13 @@ def dtype_fixture():
     torch.set_default_dtype(torch.double)
     yield dtype
     torch.set_default_dtype(dtype)
+
+
+@contextlib.contextmanager
+def set_global_var(module, var_name, value):
+    old_value = getattr(module, var_name)
+    setattr(module, var_name, value)
+    try:
+        yield
+    finally:
+        setattr(module, var_name, old_value)

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -814,12 +814,7 @@ def test_smoke_replay_buffer_transform(transform):
 
     td = TensorDict({"observation": torch.randn(3, 3, 3, 16, 1)}, [])
     rb.add(td)
-    if not isinstance(rb._transform[0], (CatFrames, StepCounter)):
-        rb.sample(1)
-    else:
-        with pytest.raises(NotImplementedError):
-            rb.sample(1)
-        return
+    rb.sample(1)
 
     rb._transform = mock.MagicMock()
     rb.sample(1)

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -51,6 +51,7 @@ from torchrl.envs.transforms.transforms import (
     Resize,
     RewardClipping,
     RewardScaling,
+    StepCounter,
     SqueezeTransform,
     ToTensorImage,
     UnsqueezeTransform,
@@ -813,12 +814,16 @@ def test_smoke_replay_buffer_transform(transform):
 
     td = TensorDict({"observation": torch.randn(3, 3, 3, 16, 1)}, [])
     rb.add(td)
-    rb.sample(1)
+    if not isinstance(rb._transform[0], (CatFrames, StepCounter)):
+        rb.sample(1)
+    else:
+        with pytest.raises(NotImplementedError):
+            rb.sample(1)
+        return
 
     rb._transform = mock.MagicMock()
     rb.sample(1)
     assert rb._transform.called
-
 
 transforms = [
     partial(DiscreteActionProjection, max_n=1, m=1),

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -51,8 +51,8 @@ from torchrl.envs.transforms.transforms import (
     Resize,
     RewardClipping,
     RewardScaling,
-    StepCounter,
     SqueezeTransform,
+    StepCounter,
     ToTensorImage,
     UnsqueezeTransform,
     VecNorm,
@@ -824,6 +824,7 @@ def test_smoke_replay_buffer_transform(transform):
     rb._transform = mock.MagicMock()
     rb.sample(1)
     assert rb._transform.called
+
 
 transforms = [
     partial(DiscreteActionProjection, max_n=1, m=1),

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -52,7 +52,6 @@ from torchrl.envs.transforms.transforms import (
     RewardClipping,
     RewardScaling,
     SqueezeTransform,
-    StepCounter,
     ToTensorImage,
     UnsqueezeTransform,
     VecNorm,

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -286,7 +286,7 @@ class TensorSpec:
                         f"Shape mismatch: the value has shape {val.shape} which "
                         f"is incompatible with the spec shape {self.shape}."
                     )
-        if not _CHECK_SPEC_ENCODE:
+        if _CHECK_SPEC_ENCODE:
             self.assert_is_in(val)
         return val
 

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -38,6 +38,7 @@ INDEX_TYPING = Union[int, torch.Tensor, np.ndarray, slice, List]
 # By default, we do not check that an obs is in the domain. THis should be done when validating the env beforehand
 _CHECK_SPEC_ENCODE = get_binary_env_var("CHECK_SPEC_ENCODE")
 
+
 _DEFAULT_SHAPE = torch.Size((1,))
 
 DEVICE_ERR_MSG = "device of empty CompositeSpec is not defined."

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -108,8 +108,27 @@ class Box:
 class ContinuousBox(Box):
     """A continuous box of values, in between a minimum and a maximum."""
 
-    minimum: torch.Tensor
-    maximum: torch.Tensor
+    _minimum: torch.Tensor
+    _maximum: torch.Tensor
+    device: torch.device = None
+
+    @property
+    def minimum(self):
+        return self._minimum.to(self.device)
+
+    @property
+    def maximum(self):
+        return self._maximum.to(self.device)
+
+    @minimum.setter
+    def minimum(self, value):
+        self.device = value.device
+        self._minimum = value.cpu()
+
+    @maximum.setter
+    def maximum(self, value):
+        self.device = value.device
+        self._maximum = value.cpu()
 
     def __post_init__(self):
         self.minimum = self.minimum.clone()

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -116,18 +116,10 @@ class ContinuousBox(Box):
     # We store the tensors on CPU to avoid overloading CUDA with tensors that are rarely used.
     @property
     def minimum(self):
-        print("calling min")
-        import traceback
-
-        traceback.print_stack()
         return self._minimum.to(self.device)
 
     @property
     def maximum(self):
-        print("calling max")
-        import traceback
-
-        traceback.print_stack()
         return self._maximum.to(self.device)
 
     @minimum.setter

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -35,7 +35,8 @@ DEVICE_TYPING = Union[torch.device, str, int]
 
 INDEX_TYPING = Union[int, torch.Tensor, np.ndarray, slice, List]
 
-_NO_CHECK_SPEC_ENCODE = get_binary_env_var("NO_CHECK_SPEC_ENCODE")
+# By default, we do not check that an obs is in the domain. THis should be done when validating the env beforehand
+_CHECK_SPEC_ENCODE = get_binary_env_var("CHECK_SPEC_ENCODE")
 
 _DEFAULT_SHAPE = torch.Size((1,))
 
@@ -117,6 +118,7 @@ class ContinuousBox(Box):
     def minimum(self):
         print("calling min")
         import traceback
+
         traceback.print_stack()
         return self._minimum.to(self.device)
 
@@ -124,6 +126,7 @@ class ContinuousBox(Box):
     def maximum(self):
         print("calling max")
         import traceback
+
         traceback.print_stack()
         return self._maximum.to(self.device)
 
@@ -283,7 +286,7 @@ class TensorSpec:
                         f"Shape mismatch: the value has shape {val.shape} which "
                         f"is incompatible with the spec shape {self.shape}."
                     )
-        if not _NO_CHECK_SPEC_ENCODE:
+        if not _CHECK_SPEC_ENCODE:
             self.assert_is_in(val)
         return val
 

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -115,10 +115,17 @@ class ContinuousBox(Box):
     # We store the tensors on CPU to avoid overloading CUDA with tensors that are rarely used.
     @property
     def minimum(self):
+        import traceback
+        import sys
+
+        print("calling min")
+        traceback.print_stack()
         return self._minimum.to(self.device)
 
     @property
     def maximum(self):
+        print("calling max")
+        traceback.print_stack()
         return self._maximum.to(self.device)
 
     @minimum.setter

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -115,16 +115,15 @@ class ContinuousBox(Box):
     # We store the tensors on CPU to avoid overloading CUDA with tensors that are rarely used.
     @property
     def minimum(self):
-        import traceback
-        import sys
-
         print("calling min")
+        import traceback
         traceback.print_stack()
         return self._minimum.to(self.device)
 
     @property
     def maximum(self):
         print("calling max")
+        import traceback
         traceback.print_stack()
         return self._maximum.to(self.device)
 

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -112,6 +112,7 @@ class ContinuousBox(Box):
     _maximum: torch.Tensor
     device: torch.device = None
 
+    # We store the tensors on CPU to avoid overloading CUDA with tensors that are rarely used.
     @property
     def minimum(self):
         return self._minimum.to(self.device)

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -210,6 +210,7 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
         - run_type_checks (bool): if True, the observation and reward dtypes
             will be compared against their respective spec and an exception
             will be raised if they don't match.
+            Defaults to False.
 
     Methods:
         step (TensorDictBase -> TensorDictBase): step in the environment
@@ -226,7 +227,7 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
         device: DEVICE_TYPING = "cpu",
         dtype: Optional[Union[torch.dtype, np.dtype]] = None,
         batch_size: Optional[torch.Size] = None,
-        run_type_checks: bool = True,
+        run_type_checks: bool = False,
     ):
         super().__init__()
         if device is not None:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -400,16 +400,16 @@ but got an object of type {type(transform)}."""
 
     @property
     def observation_spec(self) -> TensorSpec:
-        import traceback
-        import sys
-
-        traceback.print_stack()
-
         """Observation spec of the transformed environment."""
         if self._observation_spec is None or not self.cache_specs:
             observation_spec = self.transform.transform_observation_spec(
                 self.base_env.observation_spec.clone()
             )
+            import traceback
+            import sys
+
+            traceback.print_stack()
+
             if self.cache_specs:
                 self.__dict__["_observation_spec"] = observation_spec
         else:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -406,7 +406,6 @@ but got an object of type {type(transform)}."""
                 self.base_env.observation_spec.clone()
             )
             import traceback
-            import sys
 
             traceback.print_stack()
 

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -407,7 +407,8 @@ but got an object of type {type(transform)}."""
             raise Exception
         except Exception:
             print("Calling TransformedEnv.observation_spec")
-            print(exc_info = sys.exc_info())
+            exc_info = sys.exc_info()
+            print(exc_info)
 
         """Observation spec of the transformed environment."""
         if self._observation_spec is None or not self.cache_specs:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -405,10 +405,6 @@ but got an object of type {type(transform)}."""
             observation_spec = self.transform.transform_observation_spec(
                 self.base_env.observation_spec.clone()
             )
-            import traceback
-
-            traceback.print_stack()
-
             if self.cache_specs:
                 self.__dict__["_observation_spec"] = observation_spec
         else:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -400,6 +400,15 @@ but got an object of type {type(transform)}."""
 
     @property
     def observation_spec(self) -> TensorSpec:
+        import traceback
+        import sys
+
+        try:
+            raise Exception
+        except Exception:
+            print("Calling TransformedEnv.observation_spec")
+            print(traceback.format_exc())
+
         """Observation spec of the transformed environment."""
         if self._observation_spec is None or not self.cache_specs:
             observation_spec = self.transform.transform_observation_spec(

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -407,7 +407,7 @@ but got an object of type {type(transform)}."""
             raise Exception
         except Exception:
             print("Calling TransformedEnv.observation_spec")
-            print(traceback.format_exc())
+            print(exc_info = sys.exc_info())
 
         """Observation spec of the transformed environment."""
         if self._observation_spec is None or not self.cache_specs:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -403,12 +403,7 @@ but got an object of type {type(transform)}."""
         import traceback
         import sys
 
-        try:
-            raise Exception
-        except Exception:
-            print("Calling TransformedEnv.observation_spec")
-            exc_info = sys.exc_info()
-            traceback.print_exception(*exc_info)
+        traceback.print_stack()
 
         """Observation spec of the transformed environment."""
         if self._observation_spec is None or not self.cache_specs:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -408,7 +408,7 @@ but got an object of type {type(transform)}."""
         except Exception:
             print("Calling TransformedEnv.observation_spec")
             exc_info = sys.exc_info()
-            print(exc_info)
+            traceback.print_exception(*exc_info)
 
         """Observation spec of the transformed environment."""
         if self._observation_spec is None or not self.cache_specs:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -2738,7 +2738,9 @@ class StepCounter(Transform):
             dtype=torch.int64,
             device=observation_spec.device,
         )
-        observation_spec["step_count"].space.minimum = 0
+        observation_spec["step_count"].space.minimum = (
+            observation_spec["step_count"].space.minimum * 0
+        )
         return observation_spec
 
 


### PR DESCRIPTION
## Description

Changes the memory location of the tensors for the bounded tensorspecs. The goal is to free space on devices by storing these on RAM instead.

To make the rollout collection faster, we also disable the observation spec checking by default. This can be reinstantiated via `CHECK_SPEC_ENCODE=True python myscript.py`.