### PR TITLE
[FixBug] GymEnv environment overwrite frame skip argument to 1.

### DIFF
--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -383,7 +383,6 @@ class GymEnv(GymWrapper):
             del kwargs["pixels_only"]
         made_env = False
         kwargs["frameskip"] = self.frame_skip
-        self.wrapper_frame_skip = 1
         while not made_env:
             # env.__init__ may not be compatible with all the kwargs that
             # have been preset. We iterate through the various solutions


### PR DESCRIPTION
## Description

Potential error, 

I think GymEnv environment define variable wrapper_frame_skip using the input value, but then overwrites it to 1, effectively never using frame skip. 

This PR just remove the line of code that sets the value to 1.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
