### PR TITLE
[BugFix] Compose cloning fix

### DIFF
--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -265,7 +265,10 @@ class Transform(nn.Module):
 
     def clone(self):
         self_copy = copy(self)
-        self_copy.reset_parent()
+        state = copy(self.__dict__)
+        state["_container"] = None
+        state["_parent"] = None
+        self_copy.__dict__.update(state)
         return self_copy
 
     @property
@@ -778,7 +781,11 @@ class Compose(Transform):
         return super().to(dest)
 
     def __iter__(self):
-        return iter(self.transforms)
+        # We clone the transforms to be able to do
+        # env2 = TransformedEnv(base_env, *env1.transform.clone())
+        # which will otherwise result in an error because all the transforms
+        # from the Compose already have a container.
+        yield from (t.clone() for t in self.transforms)
 
     def __len__(self):
         return len(self.transforms)
@@ -793,6 +800,17 @@ class Compose(Transform):
         for t in self.transforms:
             t.empty_cache()
         super().empty_cache()
+
+    def reset_parent(self):
+        for t in self.transforms:
+            t.reset_parent()
+        super().reset_parent()
+
+    def clone(self):
+        transforms = []
+        for t in self.transforms:
+            transforms.append(t.clone())
+        return Compose(*transforms)
 
 
 class ToTensorImage(ObservationTransform):


### PR DESCRIPTION
## Description

Fixes a bug when re-expanding a `Compose` transform onto a new `Compose` transform:
```python
Compose(*other_compose.clone())
```
as the `other_compose` keeps the original `_container` and hence refuses to reassign the transforms to the other `Compose`.