### PR TITLE
[CI] Remove linux and mac cpu unittests from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,57 +258,6 @@ jobs:
           paths:
             - "*"
 
-  unittest_linux_cpu:
-    <<: *binary_common
-
-    docker:
-      - image: "pytorch/manylinux-cuda117"
-    resource_class: 2xlarge+
-
-    environment:
-      TAR_OPTIONS: --no-same-owner
-      PYTHON_VERSION: << parameters.python_version >>
-      CU_VERSION: << parameters.cu_version >>
-
-    steps:
-      - checkout
-      - designate_upload_channel
-      - run:
-          name: Generate cache key
-          # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly
-      - restore_cache:
-          keys:
-            - env-v2-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
-      - run:
-          name: Setup
-          command: .circleci/unittest/linux/scripts/setup_env.sh
-
-      - save_cache:
-
-          key: env-v2-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
-
-          paths:
-            - conda
-            - env
-      - run:
-          name: Install torchrl
-          command: .circleci/unittest/linux/scripts/install.sh
-      - run:
-          name: Run tests
-          command: .circleci/unittest/linux/scripts/run_test.sh
-
-      - run:
-          name: Codecov upload
-          command: |
-            bash <(curl -s https://codecov.io/bash) -Z -F linux-cpu
-
-      - run:
-          name: Post process
-          command: .circleci/unittest/linux/scripts/post_process.sh
-      - store_test_results:
-          path: test-results
-
   unittest_linux_gpu:
     <<: *binary_common
     machine:
@@ -756,57 +705,6 @@ jobs:
       - store_test_results:
           path: test-results
 
-  unittest_linux_stable_cpu:
-    <<: *binary_common
-
-    docker:
-      - image: "pytorch/manylinux-cuda116"
-    resource_class: 2xlarge+
-
-    environment:
-      TAR_OPTIONS: --no-same-owner
-      PYTHON_VERSION: << parameters.python_version >>
-      CU_VERSION: << parameters.cu_version >>
-
-    steps:
-      - checkout
-      - designate_upload_channel
-      - run:
-          name: Generate cache key
-          # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly
-      - restore_cache:
-
-          keys:
-            - env-v2-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux_stable/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
-
-      - run:
-          name: Setup
-          command: .circleci/unittest/linux_stable/scripts/setup_env.sh
-
-      - save_cache:
-
-          key: env-v2-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux_stable/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
-
-          paths:
-            - conda
-            - env
-      - run:
-          name: Install torchrl
-          command: .circleci/unittest/linux_stable/scripts/install.sh
-      - run:
-          name: Run tests
-          command: .circleci/unittest/linux_stable/scripts/run_test.sh
-      - run:
-          name: Codecov upload
-          command: |
-            bash <(curl -s https://codecov.io/bash) -Z -F linux-stable-cpu
-      - run:
-          name: Post process
-          command: .circleci/unittest/linux_stable/scripts/post_process.sh
-      - store_test_results:
-          path: test-results
-
   unittest_linux_stable_gpu:
     <<: *binary_common
     machine:
@@ -907,54 +805,6 @@ jobs:
       - run:
           name: Post process
           command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e UPLOAD_CHANNEL -e CU_VERSION "${image_name}" .circleci/unittest/linux_olddeps/scripts_gym_0_13/post_process.sh
-      - store_test_results:
-          path: test-results
-
-  unittest_macos_cpu:
-    <<: *binary_common
-    macos:
-      xcode: "13.0"
-
-    resource_class: large
-    steps:
-      - checkout
-      - designate_upload_channel
-      - run:
-          name: Install wget
-          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install wget
-          # Disable brew auto update which is very slow
-      - run:
-          name: Generate cache key
-          # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly
-      - restore_cache:
-
-          keys:
-            - env-v3-macos-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
-
-      - run:
-          name: Setup
-          command: .circleci/unittest/linux/scripts/setup_env.sh
-      - save_cache:
-
-          key: env-v3-macos-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
-
-          paths:
-            - conda
-            - env
-      - run:
-          name: Install torchrl
-          command: .circleci/unittest/linux/scripts/install.sh
-      - run:
-          name: Run tests
-          command: .circleci/unittest/linux/scripts/run_test.sh
-      - run:
-          name: Codecov upload
-          command: |
-            bash <(curl -s https://codecov.io/bash) -Z -F macos-cpu
-      - run:
-          name: Post process
-          command: .circleci/unittest/linux/scripts/post_process.sh
       - store_test_results:
           path: test-results
 
@@ -1169,14 +1019,6 @@ workflows:
 
   unittest:
     jobs:
-      - unittest_macos_cpu:
-          cu_version: cpu
-          name: unittest_macos_cpu_py3.7
-          python_version: '3.7'
-      - unittest_linux_cpu:
-          cu_version: cpu
-          name: unittest_linux_cpu_py3.7
-          python_version: '3.7'
       - unittest_linux_gpu:
           cu_version: cu117
           name: unittest_linux_gpu_py3.7
@@ -1185,23 +1027,11 @@ workflows:
           cu_version: cu117
           name: unittest_linux_optdeps_gpu_py3.7
           python_version: '3.7'
-      - unittest_linux_stable_cpu:
-          cu_version: cpu
-          name: unittest_linux_stable_cpu_py3.7
-          python_version: '3.7'
       - unittest_linux_stable_gpu:
           cu_version: cu116
           name: unittest_linux_stable_gpu_py3.7
           python_version: '3.7'
 
-      - unittest_macos_cpu:
-          cu_version: cpu
-          name: unittest_macos_cpu_py3.8
-          python_version: '3.8'
-      - unittest_linux_cpu:
-          cu_version: cpu
-          name: unittest_linux_cpu_py3.8
-          python_version: '3.8'
       - unittest_linux_gpu:
           cu_version: cu117
           name: unittest_linux_gpu_py3.8
@@ -1209,10 +1039,6 @@ workflows:
       - unittest_linux_optdeps_gpu:
           cu_version: cu117
           name: unittest_linux_optdeps_gpu_py3.8
-          python_version: '3.8'
-      - unittest_linux_stable_cpu:
-          cu_version: cpu
-          name: unittest_linux_stable_cpu_py3.8
           python_version: '3.8'
       - unittest_linux_stable_gpu:
           cu_version: cu116
@@ -1245,14 +1071,6 @@ workflows:
           python_version: '3.8'
 
 
-      - unittest_macos_cpu:
-          cu_version: cpu
-          name: unittest_macos_cpu_py3.9
-          python_version: '3.9'
-      - unittest_linux_cpu:
-          cu_version: cpu
-          name: unittest_linux_cpu_py3.9
-          python_version: '3.9'
       - unittest_linux_gpu:
           cu_version: cu117
           name: unittest_linux_gpu_py3.9
@@ -1261,23 +1079,11 @@ workflows:
           cu_version: cu117
           name: unittest_linux_optdeps_gpu_py3.9
           python_version: '3.9'
-      - unittest_linux_stable_cpu:
-          cu_version: cpu
-          name: unittest_linux_stable_cpu_py3.9
-          python_version: '3.9'
       - unittest_linux_stable_gpu:
           cu_version: cu116
           name: unittest_linux_stable_gpu_py3.9
           python_version: '3.9'
 
-      - unittest_macos_cpu:
-          cu_version: cpu
-          name: unittest_macos_cpu_py3.10
-          python_version: '3.10'
-      - unittest_linux_cpu:
-          cu_version: cpu
-          name: unittest_linux_cpu_py3.10
-          python_version: '3.10'
       - unittest_linux_gpu:
           cu_version: cu117
           name: unittest_linux_gpu_py3.10
@@ -1285,10 +1091,6 @@ workflows:
       - unittest_linux_optdeps_gpu:
           cu_version: cu117
           name: unittest_linux_optdeps_gpu_py3.10
-          python_version: '3.10'
-      - unittest_linux_stable_cpu:
-          cu_version: cpu
-          name: unittest_linux_stable_cpu_py3.10
           python_version: '3.10'
       - unittest_linux_stable_gpu:
           cu_version: cu116


### PR DESCRIPTION
## Description

Remove linux and mac CPU unit tests from circle CI. These tests are now handled in GitHub Actions workflows.

## Motivation and Context

Why is this change required? What problem does it solve?

The directions is to move from circleci to GitHub Actions workflows.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

No change in functionality of PyTorch RL

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
