### PR TITLE
[Doc] Add record utils to doc

### DIFF
--- a/docs/source/reference/trainers.rst
+++ b/docs/source/reference/trainers.rst
@@ -206,3 +206,16 @@ Loggers
     WandbLogger
     get_logger
     generate_exp_name
+
+
+Recording utils
+---------------
+
+.. currentmodule:: torchrl.record
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template_fun.rst
+
+    VideoRecorder
+    TensorDictRecorder


### PR DESCRIPTION
## Description

Adds the `torchrl.record` first level classes to the doc