### PR TITLE
[Feature] RandomCropTensorDict transform

### DIFF
--- a/docs/source/reference/data.rst
+++ b/docs/source/reference/data.rst
@@ -55,6 +55,22 @@ The following mean sampling latency improvements over using ListStorage were fou
 | :class:`LazyMemmapStorage`    | 3.44x     |
 +-------------------------------+-----------+
 
+Sotring trajectories
+~~~~~~~~~~~~~~~~~~~~
+
+It is not too difficult to store trajecotries in the replay buffer.
+One element to pay attention to is that the size of the replay buffer is always
+the size of the leading dimension of the storage: in other words, creating a
+replay buffer with a storage of size 1M when storing multidimensional data
+does not mean storing 1M frames but 1M trajectories.
+
+When sampling trajectories, it may be desirable to sample sub-trajectories
+to diversify learning or make the sampling more efficient.
+To do this, we provide a custom :class:`torchrl.envs.Transform` class named
+:class:`torchrl.envs.RandomCropTensorDict`. Here is an example of how this class
+can be used:
+
+    >>>
 
 TensorSpec
 ----------

--- a/docs/source/reference/envs.rst
+++ b/docs/source/reference/envs.rst
@@ -229,6 +229,7 @@ in the environment. The keys to be included in this inverse transform are passed
     ObservationTransform
     PinMemoryTransform
     R3MTransform
+    RandomCropTensorDict
     Resize
     RewardClipping
     RewardScaling

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -662,7 +662,8 @@ def test_prb(priority_key, contiguous, device):
 
 
 @pytest.mark.parametrize("stack", [False, True])
-def test_rb_trajectories(stack):
+@pytest.mark.parametrize("reduction", ["min", "max", "mean", "median"])
+def test_rb_trajectories(stack, reduction):
     traj_td = TensorDict(
         {"obs": torch.randn(3, 4, 5), "actions": torch.randn(3, 4, 2)},
         batch_size=[3, 4],
@@ -678,11 +679,11 @@ def test_rb_trajectories(stack):
     )
     rb.extend(traj_td)
     sampled_td = rb.sample(3)
-    sampled_td.set("td_error", torch.rand(3))
+    sampled_td.set("td_error", torch.rand(3, 4))
     rb.update_tensordict_priority(sampled_td)
     sampled_td = rb.sample(3, include_info=True)
     assert (sampled_td.get("_weight") > 0).all()
-    assert sampled_td.batch_size == torch.Size([3])
+    assert sampled_td.batch_size == torch.Size([3, 4])
 
     # set back the trajectory length
     sampled_td_filtered = sampled_td.to_tensordict().exclude(

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -56,6 +56,7 @@ from torchrl.envs import (
     ParallelEnv,
     PinMemoryTransform,
     R3MTransform,
+    RandomCropTensorDict,
     Resize,
     RewardClipping,
     RewardScaling,
@@ -6093,6 +6094,67 @@ def test_clone_parent_compose(transform):
     assert env_clone.transform[1].parent.base_env is base_env2
     assert env.transform[1].parent.base_env is not base_env2
     assert env.transform[1].parent.base_env is base_env1
+
+
+class TestCroSeq:
+    def test_crop_dim1(self):
+        tensordict = TensorDict(
+            {
+                "a": torch.arange(20).view(1, 1, 1, 20).expand(3, 4, 2, 20),
+                "b": TensorDict(
+                    {"c": torch.arange(20).view(1, 1, 1, 20, 1).expand(3, 4, 2, 20, 1)},
+                    [3, 4, 2, 20, 1],
+                ),
+            },
+            [3, 4, 2, 20],
+        )
+        t = RandomCropTensorDict(11, -1)
+        tensordict_crop = t(tensordict)
+        assert tensordict_crop.shape == torch.Size([3, 4, 2, 11])
+        assert tensordict_crop["b"].shape == torch.Size([3, 4, 2, 11, 1])
+        assert (
+            tensordict_crop["a"][:, :, :, :-1] + 1 == tensordict_crop["a"][:, :, :, 1:]
+        ).all()
+
+    def test_crop_dim2(self):
+        tensordict = TensorDict(
+            {"a": torch.arange(20).view(1, 1, 20, 1).expand(3, 4, 20, 2)},
+            [3, 4, 20, 2],
+        )
+        t = RandomCropTensorDict(11, -2)
+        tensordict_crop = t(tensordict)
+        assert tensordict_crop.shape == torch.Size([3, 4, 11, 2])
+        assert (
+            tensordict_crop["a"][:, :, :-1] + 1 == tensordict_crop["a"][:, :, 1:]
+        ).all()
+
+    def test_crop_error(self):
+        tensordict = TensorDict(
+            {"a": torch.arange(20).view(1, 1, 20, 1).expand(3, 4, 20, 2)},
+            [3, 4, 20, 2],
+        )
+        t = RandomCropTensorDict(21, -2)
+        with pytest.raises(RuntimeError, match="Cannot sample trajectories of length"):
+            _ = t(tensordict)
+
+    @pytest.mark.parametrize("mask_key", ("mask", ("collector", "mask")))
+    def test_crop_mask(self, mask_key):
+        a = torch.arange(20).view(1, 1, 20, 1).expand(3, 4, 20, 2).clone()
+        mask = a < 21
+        mask[0] = a[0] < 15
+        mask[1] = a[1] < 16
+        mask[1] = a[2] < 14
+        tensordict = TensorDict(
+            {"a": a, mask_key: mask},
+            [3, 4, 20, 2],
+        )
+        t = RandomCropTensorDict(15, -2, mask_key=mask_key)
+        with pytest.raises(RuntimeError, match="Cannot sample trajectories of length"):
+            _ = t(tensordict)
+        t = RandomCropTensorDict(13, -2, mask_key=mask_key)
+        tensordict_crop = t(tensordict)
+        assert tensordict_crop.shape == torch.Size([3, 4, 13, 2])
+        assert tensordict_crop[mask_key].all()
 
 
 if __name__ == "__main__":

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -494,6 +494,9 @@ class TensorDictPrioritizedReplayBuffer(TensorDictReplayBuffer):
             using multithreading.
         transform (Transform, optional): Transform to be executed when sample() is called.
             To chain transforms use the :obj:`Compose` class.
+        reduction (str, optional): the reduction method for multidimensional
+            tensordicts (ie stored trajectories). Can be one of "max", "min",
+            "median" or "mean".
     """
 
     def __init__(
@@ -507,10 +510,13 @@ class TensorDictPrioritizedReplayBuffer(TensorDictReplayBuffer):
         pin_memory: bool = False,
         prefetch: Optional[int] = None,
         transform: Optional["Transform"] = None,  # noqa-F821
+        reduction: Optional[str] = "max",
     ) -> None:
         if storage is None:
             storage = ListStorage(max_size=1_000)
-        sampler = PrioritizedSampler(storage.max_size, alpha, beta, eps)
+        sampler = PrioritizedSampler(
+            storage.max_size, alpha, beta, eps, reduction=reduction
+        )
         super(TensorDictPrioritizedReplayBuffer, self).__init__(
             priority_key=priority_key,
             storage=storage,

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -385,8 +385,12 @@ class TensorDictReplayBuffer(ReplayBuffer):
                     tensordicts = tensordicts.contiguous()
                 # we keep track of the batch size to reinstantiate it when sampling
                 if "_batch_size" in tensordicts.keys():
-                    raise KeyError("conflicting key '_batch_size'. Consider removing from data.")
-                shape = torch.tensor(tensordicts.batch_size[1:]).expand(tensordicts.batch_size[0], tensordicts.batch_dims-1)
+                    raise KeyError(
+                        "conflicting key '_batch_size'. Consider removing from data."
+                    )
+                shape = torch.tensor(tensordicts.batch_size[1:]).expand(
+                    tensordicts.batch_size[0], tensordicts.batch_dims - 1
+                )
                 tensordicts.batch_size = tensordicts.batch_size[:1]
                 tensordicts.set("_batch_size", shape)
             tensordicts.set(
@@ -568,6 +572,7 @@ class InPlaceSampler:
             torch.stack(list_of_tds, 0, out=self.out)
         return self.out
 
+
 def _reduce(tensor: torch.Tensor, reduction: str):
     """Reduces a tensor given the reduction method"""
     if reduction == "max":
@@ -578,6 +583,4 @@ def _reduce(tensor: torch.Tensor, reduction: str):
         return tensor.mean().item()
     elif reduction == "median":
         return tensor.median().item()
-    raise NotImplementedError(
-        f"Unknown reduction method {reduction}"
-    )
+    raise NotImplementedError(f"Unknown reduction method {reduction}")

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -574,7 +574,7 @@ class InPlaceSampler:
 
 
 def _reduce(tensor: torch.Tensor, reduction: str):
-    """Reduces a tensor given the reduction method"""
+    """Reduces a tensor given the reduction method."""
     if reduction == "max":
         return tensor.max().item()
     elif reduction == "min":

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -147,7 +147,7 @@ class PrioritizedSampler(Sampler):
         beta: float,
         eps: float = 1e-8,
         dtype: torch.dtype = torch.float,
-        reduction: str="max",
+        reduction: str = "max",
     ) -> None:
         if alpha <= 0:
             raise ValueError(

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -132,8 +132,11 @@ class PrioritizedSampler(Sampler):
         alpha (float): exponent α determines how much prioritization is used,
             with α = 0 corresponding to the uniform case.
         beta (float): importance sampling negative exponent.
-        eps (float): delta added to the priorities to ensure that the buffer
-            does not contain null priorities.
+        eps (float, optional): delta added to the priorities to ensure that the buffer
+            does not contain null priorities. Defaults to 1e-8.
+        reduction (str, optional): the reduction method for multidimensional
+            tensordicts (ie stored trajectories). Can be one of "max", "min",
+            "median" or "mean".
 
     """
 
@@ -144,6 +147,7 @@ class PrioritizedSampler(Sampler):
         beta: float,
         eps: float = 1e-8,
         dtype: torch.dtype = torch.float,
+        reduction: str="max",
     ) -> None:
         if alpha <= 0:
             raise ValueError(
@@ -156,6 +160,7 @@ class PrioritizedSampler(Sampler):
         self._alpha = alpha
         self._beta = beta
         self._eps = eps
+        self.reduction = reduction
         if dtype in (torch.float, torch.FloatType, torch.float32):
             self._sum_tree = SumSegmentTreeFp32(self._max_capacity)
             self._min_tree = MinSegmentTreeFp32(self._max_capacity)

--- a/torchrl/envs/__init__.py
+++ b/torchrl/envs/__init__.py
@@ -26,6 +26,7 @@ from .transforms import (
     ObservationTransform,
     PinMemoryTransform,
     R3MTransform,
+    RandomCropTensorDict,
     Resize,
     RewardClipping,
     RewardScaling,

--- a/torchrl/envs/transforms/__init__.py
+++ b/torchrl/envs/transforms/__init__.py
@@ -22,6 +22,7 @@ from .transforms import (
     ObservationNorm,
     ObservationTransform,
     PinMemoryTransform,
+    RandomCropTensorDict,
     Resize,
     RewardClipping,
     RewardScaling,

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3182,3 +3182,23 @@ class TimeMaxPool(Transform):
             "(ie as LSTM would work over a whole sequence of data), file an issue on "
             "TorchRL requesting that feature."
         )
+
+class RandomCropTensorDict(Transform):
+    """A trajectory sub-sampler for ReplayBuffer and modules.
+
+    Gathers a sub-sequence of a defined length along the last dimension of the input
+    tensordict.
+    This can be used to get cropped trajectories from trajectories sampled
+    from a ReplayBuffer.
+
+    This transform is primarily designed to be used with replay buffers and modules.
+
+    """
+    def __init__(self, sub_seq_len):
+        self.sub_seq_len = sub_seq_len
+
+    def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
+        shape = tensordict.shape
+        # shape must have at least one dimension
+        if not len(shape):
+            raise RuntimeError("Cannot sub-sample from a tensordict with an empty shape.")


### PR DESCRIPTION
## Description

Introduces the `RandomCropTensorDict` transform, which samples random sub-trajectories from a tensordict.

We also introduce the following bc-breaking changes to the RB API:
- sampled tensordicts now have the shape of the tensordict that were used to populate the buffer. Setting back the shape is done via a temporary key `"_batch_size"`.
- As a result, the `"index"` and `"_weight"` keys are also expanded to the right to match the tensordict shape. During priority updates, the index is reduced to its original shape.
- When passing a tensordict with a multiple priority values per entry index, we use a `"reduction"` method specified by the sampler to reduce the priority to a single value. This can be `"max"` (max value of the error is indicative of the priority of the trajectory), `"min"`, `"median"` and `"mean"`.

closes #905 