### PR TITLE
[BugFix] Fix dreamer training loop

### DIFF
--- a/examples/dreamer/dreamer.py
+++ b/examples/dreamer/dreamer.py
@@ -226,11 +226,12 @@ def main(cfg: "DictConfig"):  # noqa: F821
         current_frames = tensordict.numel()
         collected_frames += current_frames
 
-        # Compared to the original paper, the replay buffer is not temporally sampled. We fill it with trajectories of length batch_length.
-        # To be closer to the paper, we would need to fill it with trajectories of lentgh 1000 and then sample subsequences of length batch_length.
+        # Compared to the original paper, the replay buffer is not temporally
+        # sampled. We fill it with trajectories of length batch_length.
+        # To be closer to the paper, we would need to fill it with trajectories
+        # of length 1000 and then sample subsequences of length batch_length.
 
-        # tensordict = tensordict.reshape(-1, cfg.batch_length)
-        print(tensordict.shape)
+        tensordict = tensordict.reshape(-1, cfg.batch_length)
         replay_buffer.extend(tensordict.cpu())
         logger.log_scalar(
             "r_training",


### PR DESCRIPTION
## Description

Fixes the Dreamer training loop which cannot be executed as is because the replay buffer grows too big to be contained on disk.