### PR TITLE
Remove windows cpu unit tests from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -958,42 +958,6 @@ jobs:
       - store_test_results:
           path: test-results
 
-  unittest_windows_optdepts_cpu:
-    <<: *binary_common
-    executor:
-      name: windows-cpu
-    steps:
-      - checkout
-      - designate_upload_channel
-      - run:
-          name: Generate cache key
-          # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly
-      - restore_cache:
-          keys:
-            - env-v2-windows-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/windows_optdepts/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
-
-      - run:
-          name: Setup
-          command: .circleci/unittest/windows_optdepts/scripts/setup_env.sh
-      - save_cache:
-          key: env-v2-windows-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/windows_optdepts/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
-
-          paths:
-            - conda
-            - env
-      - run:
-          name: Install torchrl
-          command: .circleci/unittest/windows_optdepts/scripts/install.sh
-      - run:
-          name: Run tests
-          command: .circleci/unittest/windows_optdepts/scripts/run_test.sh
-      - run:
-          name: Post process
-          command: .circleci/unittest/windows_optdepts/scripts/post_process.sh
-      - store_test_results:
-          path: test-results
-
   unittest_windows_optdepts_gpu:
     <<: *binary_common
     executor:
@@ -1305,10 +1269,6 @@ workflows:
           name: unittest_linux_examples_gpu_py3.9
           python_version: '3.9'
 
-      - unittest_windows_optdepts_cpu:
-          cu_version: cpu
-          name: unittest_windows_optdepts_cpu_py3.8
-          python_version: '3.8'
       - unittest_windows_optdepts_gpu:
           cu_version: cu116
           name: unittest_windows_optdepts_gpu_py3.8


### PR DESCRIPTION
## Description

Windows CPU unit test will run via GitHub Actions after #917 is merged. This change removes the windows CPU unit tests from CircleCI.

## Motivation and Context

Migrating unit tests from CircleCI to GitHub Actions workflows.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

No change to pytorch/rl funcionality.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
