### PR TITLE
[BugFix] Propagate args to TransformedEnv's `state_dict`

### DIFF
--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -523,8 +523,8 @@ but got an object of type {type(transform)}."""
         out_tensordict = self.transform._call(out_tensordict)
         return out_tensordict
 
-    def state_dict(self) -> OrderedDict:
-        state_dict = self.transform.state_dict()
+    def state_dict(self, *args, **kwargs) -> OrderedDict:
+        state_dict = self.transform.state_dict(*args, **kwargs)
         return state_dict
 
     def load_state_dict(self, state_dict: OrderedDict, **kwargs) -> None:


### PR DESCRIPTION
## Description

Propagate `*args` and `**kwargs` to TransformedEnv's `state_dict`.

## Motivation and Context

Since TorchRL's environments are `nn.Module`, they contain a `state_dict`. However, the TransformedEnv 's `state_dict` class does not accept any `*args` or `*kwargs`. This PR fixes that.

Example: I implemented an [example notebook](https://github.com/fedebotu/lightning-torchrl) of PyTorch Lightning + TorchRL based on the pendulum tutorial with the `LightningModule` containing both `env` and `policy`. The following error is raised:
```bash
TypeError: state_dict() got an unexpected keyword argument 'destination'
```
which happens because of the `TransformedEnv` class. With the simple change of this PR this does not happen anymore.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)