### PR TITLE
[Feature] Contiguous stacking of matching specs

### DIFF
--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -2273,6 +2273,7 @@ class TestStackComposite:
         assert (r["a"] == 0).all()
 
     @pytest.mark.skipif(not torch.cuda.device_count(), reason="no cuda")
+    @pytest.mark.parametrize("stack_dim", [0, 1, 2, -3, -2, -1])
     def test_to(self, stack_dim):
         c1 = CompositeSpec(a=UnboundedContinuousTensorSpec(shape=(1, 3)), shape=(1, 3))
         c2 = c1.clone()

--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -18,7 +18,6 @@ from torchrl.data.tensor_specs import (
     CompositeSpec,
     DiscreteTensorSpec,
     LazyStackedCompositeSpec,
-    LazyStackedTensorSpec,
     MultiDiscreteTensorSpec,
     MultiOneHotDiscreteTensorSpec,
     OneHotDiscreteTensorSpec,
@@ -1716,7 +1715,7 @@ class TestStack:
         c1 = BinaryDiscreteTensorSpec(n=n, shape=shape)
         c2 = c1.clone()
         c = torch.stack([c1, c2], stack_dim)
-        assert isinstance(c, LazyStackedTensorSpec)
+        assert isinstance(c, BinaryDiscreteTensorSpec)
         shape = list(shape)
         if stack_dim < 0:
             stack_dim = len(shape) + stack_dim + 1
@@ -1761,7 +1760,7 @@ class TestStack:
         c1 = BoundedTensorSpec(mini, maxi, shape=shape)
         c2 = c1.clone()
         c = torch.stack([c1, c2], stack_dim)
-        assert isinstance(c, LazyStackedTensorSpec)
+        assert isinstance(c, BoundedTensorSpec)
         shape = list(shape)
         if stack_dim < 0:
             stack_dim = len(shape) + stack_dim + 1
@@ -1808,7 +1807,7 @@ class TestStack:
         c1 = DiscreteTensorSpec(n, shape=shape)
         c2 = c1.clone()
         c = torch.stack([c1, c2], stack_dim)
-        assert isinstance(c, LazyStackedTensorSpec)
+        assert isinstance(c, DiscreteTensorSpec)
         shape = list(shape)
         if stack_dim < 0:
             stack_dim = len(shape) + stack_dim + 1
@@ -1852,7 +1851,7 @@ class TestStack:
         c1 = MultiDiscreteTensorSpec(nvec, shape=shape)
         c2 = c1.clone()
         c = torch.stack([c1, c2], stack_dim)
-        assert isinstance(c, LazyStackedTensorSpec)
+        assert isinstance(c, MultiDiscreteTensorSpec)
         shape = list(shape)
         if stack_dim < 0:
             stack_dim = len(shape) + stack_dim + 1
@@ -1896,7 +1895,7 @@ class TestStack:
         c1 = MultiOneHotDiscreteTensorSpec(nvec, shape=shape)
         c2 = c1.clone()
         c = torch.stack([c1, c2], stack_dim)
-        assert isinstance(c, LazyStackedTensorSpec)
+        assert isinstance(c, MultiOneHotDiscreteTensorSpec)
         shape = list(shape)
         if stack_dim < 0:
             stack_dim = len(shape) + stack_dim + 1
@@ -1940,7 +1939,7 @@ class TestStack:
         c1 = OneHotDiscreteTensorSpec(n, shape=shape)
         c2 = c1.clone()
         c = torch.stack([c1, c2], stack_dim)
-        assert isinstance(c, LazyStackedTensorSpec)
+        assert isinstance(c, OneHotDiscreteTensorSpec)
         shape = list(shape)
         if stack_dim < 0:
             stack_dim = len(shape) + stack_dim + 1
@@ -1983,7 +1982,7 @@ class TestStack:
         c1 = UnboundedContinuousTensorSpec(shape=shape)
         c2 = c1.clone()
         c = torch.stack([c1, c2], stack_dim)
-        assert isinstance(c, LazyStackedTensorSpec)
+        assert isinstance(c, UnboundedContinuousTensorSpec)
         shape = list(shape)
         if stack_dim < 0:
             stack_dim = len(shape) + stack_dim + 1
@@ -2023,7 +2022,7 @@ class TestStack:
         c1 = UnboundedDiscreteTensorSpec(shape=shape)
         c2 = c1.clone()
         c = torch.stack([c1, c2], stack_dim)
-        assert isinstance(c, LazyStackedTensorSpec)
+        assert isinstance(c, UnboundedDiscreteTensorSpec)
         shape = list(shape)
         if stack_dim < 0:
             stack_dim = len(shape) + stack_dim + 1
@@ -2064,11 +2063,13 @@ class TestStackComposite:
         c1 = CompositeSpec(a=UnboundedContinuousTensorSpec())
         c2 = c1.clone()
         c = torch.stack([c1, c2], 0)
-        assert isinstance(c, LazyStackedCompositeSpec)
+        assert isinstance(c, CompositeSpec)
 
     def test_stack_index(self):
         c1 = CompositeSpec(a=UnboundedContinuousTensorSpec())
-        c2 = c1.clone()
+        c2 = CompositeSpec(
+            a=UnboundedContinuousTensorSpec(), b=UnboundedDiscreteTensorSpec()
+        )
         c = torch.stack([c1, c2], 0)
         assert c.shape == torch.Size([2])
         assert c[0] is c1
@@ -2082,7 +2083,11 @@ class TestStackComposite:
     @pytest.mark.parametrize("stack_dim", [0, 1, 2, -3, -2, -1])
     def test_stack_index_multdim(self, stack_dim):
         c1 = CompositeSpec(a=UnboundedContinuousTensorSpec(shape=(1, 3)), shape=(1, 3))
-        c2 = c1.clone()
+        c2 = CompositeSpec(
+            a=UnboundedContinuousTensorSpec(shape=(1, 3)),
+            b=UnboundedDiscreteTensorSpec(shape=(1, 3)),
+            shape=(1, 3),
+        )
         c = torch.stack([c1, c2], stack_dim)
         if stack_dim in (0, -3):
             assert isinstance(c[:], LazyStackedCompositeSpec)
@@ -2147,35 +2152,13 @@ class TestStackComposite:
             assert c[:, :, 1, ...] is c2
 
     @pytest.mark.parametrize("stack_dim", [0, 1, 2, -3, -2, -1])
-    def test_stack_expand_one(self, stack_dim):
-        c1 = CompositeSpec(a=UnboundedContinuousTensorSpec(shape=(1, 3)), shape=(1, 3))
-        c = torch.stack([c1], stack_dim)
-        if stack_dim in (0, -3):
-            c_expand = c.expand([4, 2, 1, 3])
-            assert c_expand.shape == torch.Size([4, 2, 1, 3])
-            assert c_expand.dim == 1
-        elif stack_dim in (1, -2):
-            c_expand = c.expand([4, 1, 2, 3])
-            assert c_expand.shape == torch.Size([4, 1, 2, 3])
-            assert c_expand.dim == 2
-        elif stack_dim in (2, -1):
-            c_expand = c.expand(
-                [
-                    4,
-                    1,
-                    3,
-                    2,
-                ]
-            )
-            assert c_expand.shape == torch.Size([4, 1, 3, 2])
-            assert c_expand.dim == 3
-        else:
-            raise NotImplementedError
-
-    @pytest.mark.parametrize("stack_dim", [0, 1, 2, -3, -2, -1])
     def test_stack_expand_multi(self, stack_dim):
         c1 = CompositeSpec(a=UnboundedContinuousTensorSpec(shape=(1, 3)), shape=(1, 3))
-        c2 = c1.clone()
+        c2 = CompositeSpec(
+            a=UnboundedContinuousTensorSpec(shape=(1, 3)),
+            b=UnboundedDiscreteTensorSpec(shape=(1, 3)),
+            shape=(1, 3),
+        )
         c = torch.stack([c1, c2], stack_dim)
         if stack_dim in (0, -3):
             c_expand = c.expand([4, 2, 1, 3])
@@ -2202,7 +2185,11 @@ class TestStackComposite:
     @pytest.mark.parametrize("stack_dim", [0, 1, 2, -3, -2, -1])
     def test_stack_rand(self, stack_dim):
         c1 = CompositeSpec(a=UnboundedContinuousTensorSpec(shape=(1, 3)), shape=(1, 3))
-        c2 = c1.clone()
+        c2 = CompositeSpec(
+            a=UnboundedContinuousTensorSpec(shape=(1, 3)),
+            b=UnboundedDiscreteTensorSpec(shape=(1, 3)),
+            shape=(1, 3),
+        )
         c = torch.stack([c1, c2], stack_dim)
         r = c.rand()
         assert isinstance(r, LazyStackedTensorDict)
@@ -2220,7 +2207,11 @@ class TestStackComposite:
     @pytest.mark.parametrize("stack_dim", [0, 1, 2, -3, -2, -1])
     def test_stack_rand_shape(self, stack_dim):
         c1 = CompositeSpec(a=UnboundedContinuousTensorSpec(shape=(1, 3)), shape=(1, 3))
-        c2 = c1.clone()
+        c2 = CompositeSpec(
+            a=UnboundedContinuousTensorSpec(shape=(1, 3)),
+            b=UnboundedDiscreteTensorSpec(shape=(1, 3)),
+            shape=(1, 3),
+        )
         c = torch.stack([c1, c2], stack_dim)
         shape = [5, 6]
         r = c.rand(shape)
@@ -2239,7 +2230,11 @@ class TestStackComposite:
     @pytest.mark.parametrize("stack_dim", [0, 1, 2, -3, -2, -1])
     def test_stack_zero(self, stack_dim):
         c1 = CompositeSpec(a=UnboundedContinuousTensorSpec(shape=(1, 3)), shape=(1, 3))
-        c2 = c1.clone()
+        c2 = CompositeSpec(
+            a=UnboundedContinuousTensorSpec(shape=(1, 3)),
+            b=UnboundedDiscreteTensorSpec(shape=(1, 3)),
+            shape=(1, 3),
+        )
         c = torch.stack([c1, c2], stack_dim)
         r = c.zero()
         assert isinstance(r, LazyStackedTensorDict)
@@ -2257,7 +2252,11 @@ class TestStackComposite:
     @pytest.mark.parametrize("stack_dim", [0, 1, 2, -3, -2, -1])
     def test_stack_zero_shape(self, stack_dim):
         c1 = CompositeSpec(a=UnboundedContinuousTensorSpec(shape=(1, 3)), shape=(1, 3))
-        c2 = c1.clone()
+        c2 = CompositeSpec(
+            a=UnboundedContinuousTensorSpec(shape=(1, 3)),
+            b=UnboundedDiscreteTensorSpec(shape=(1, 3)),
+            shape=(1, 3),
+        )
         c = torch.stack([c1, c2], stack_dim)
         shape = [5, 6]
         r = c.zero(shape)
@@ -2274,7 +2273,7 @@ class TestStackComposite:
         assert (r["a"] == 0).all()
 
     @pytest.mark.skipif(not torch.cuda.device_count(), reason="no cuda")
-    def test_to(self):
+    def test_to(self, stack_dim):
         c1 = CompositeSpec(a=UnboundedContinuousTensorSpec(shape=(1, 3)), shape=(1, 3))
         c2 = c1.clone()
         c = torch.stack([c1, c2], stack_dim)
@@ -2285,7 +2284,11 @@ class TestStackComposite:
 
     def test_clone(self):
         c1 = CompositeSpec(a=UnboundedContinuousTensorSpec(shape=(1, 3)), shape=(1, 3))
-        c2 = c1.clone()
+        c2 = CompositeSpec(
+            a=UnboundedContinuousTensorSpec(shape=(1, 3)),
+            b=UnboundedDiscreteTensorSpec(shape=(1, 3)),
+            shape=(1, 3),
+        )
         c = torch.stack([c1, c2], 0)
         cclone = c.clone()
         assert cclone[0] is not c[0]

--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -2276,12 +2276,20 @@ class TestStackComposite:
     @pytest.mark.parametrize("stack_dim", [0, 1, 2, -3, -2, -1])
     def test_to(self, stack_dim):
         c1 = CompositeSpec(a=UnboundedContinuousTensorSpec(shape=(1, 3)), shape=(1, 3))
-        c2 = c1.clone()
+        c2 = CompositeSpec(
+            a=UnboundedContinuousTensorSpec(shape=(1, 3)),
+            b=UnboundedDiscreteTensorSpec(shape=(1, 3)),
+            shape=(1, 3),
+        )
         c = torch.stack([c1, c2], stack_dim)
+        assert isinstance(c, LazyStackedCompositeSpec)
         cdevice = c.to("cuda:0")
         assert cdevice.device != c.device
         assert cdevice.device == torch.device("cuda:0")
-        assert cdevice[0].device == torch.device("cuda:0")
+        if stack_dim < 0:
+            stack_dim += 3
+        index = (slice(None),) * stack_dim + (0,)
+        assert cdevice[index].device == torch.device("cuda:0")
 
     def test_clone(self):
         c1 = CompositeSpec(a=UnboundedContinuousTensorSpec(shape=(1, 3)), shape=(1, 3))

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -2651,7 +2651,7 @@ class LazyStackedCompositeSpec(_LazyStackedMixin[CompositeSpec], CompositeSpec):
 
     @property
     def device(self) -> DEVICE_TYPING:
-        pass
+        return self._specs[0].device
 
     @property
     def ndim(self):

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -2726,6 +2726,26 @@ def _stack_composite_specs(list_of_spec, dim, out=None):
         raise NotImplementedError
 
 
+@TensorSpec.implements_for_spec(torch.squeeze)
+def _squeeze_spec(spec: TensorSpec, *args, **kwargs) -> TensorSpec:
+    return spec.squeeze(*args, **kwargs)
+
+
+@CompositeSpec.implements_for_spec(torch.squeeze)
+def _squeeze_composite_spec(spec: CompositeSpec, *args, **kwargs) -> CompositeSpec:
+    return spec.squeeze(*args, **kwargs)
+
+
+@TensorSpec.implements_for_spec(torch.unsqueeze)
+def _unsqueeze_spec(spec: TensorSpec, *args, **kwargs) -> TensorSpec:
+    return spec.unsqueeze(*args, **kwargs)
+
+
+@CompositeSpec.implements_for_spec(torch.unsqueeze)
+def _unsqueeze_composite_spec(spec: CompositeSpec, *args, **kwargs) -> CompositeSpec:
+    return spec.unsqueeze(*args, **kwargs)
+
+
 def _keys_to_empty_composite_spec(keys):
     """Given a list of keys, creates a CompositeSpec tree where each leaf is assigned a None value."""
     if not len(keys):

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -13,6 +13,7 @@ from functools import wraps
 from textwrap import indent
 from typing import (
     Any,
+    Callable,
     Dict,
     Generic,
     ItemsView,
@@ -345,6 +346,24 @@ class TensorSpec:
         """
         raise NotImplementedError
 
+    def squeeze(self, dim: int | None = None):
+        """Returns a new Spec with all the dimensions of size ``1`` removed.
+
+        When ``dim`` is given, a squeeze operation is done only in that dimension.
+
+        Args:
+            dim (int or None): the dimension to apply the squeeze operation to
+
+        """
+        shape = _squeezed_shape(self.shape, dim)
+        if shape is None:
+            return self
+        return self.__class__(shape=shape, device=self.device, dtype=self.dtype)
+
+    def unsqueeze(self, dim: int):
+        shape = _unsqueezed_shape(self.shape, dim)
+        return self.__class__(shape=shape, device=self.device, dtype=self.dtype)
+
     def _project(self, val: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError
 
@@ -644,11 +663,6 @@ class LazyStackedTensorSpec(_LazyStackedMixin[TensorSpec], TensorSpec):
     @property
     def space(self):
         return self._specs[0].space
-        if shape is not None:
-            dim = self.dim + len(shape)
-        else:
-            dim = self.dim
-        return torch.stack([spec.rand(shape) for spec in self._specs], dim)
 
     def __eq__(self, other):
         # requires unbind to be implemented
@@ -667,7 +681,9 @@ class LazyStackedTensorSpec(_LazyStackedMixin[TensorSpec], TensorSpec):
         pass
 
     def keys(
-        self, yield_nesting_keys: bool = False, nested_keys: bool = True
+        self,
+        include_nested: bool = False,
+        leaves_only: bool = False,
     ) -> KeysView:
         pass
 
@@ -835,6 +851,39 @@ class OneHotDiscreteTensorSpec(TensorSpec):
             )
         return self.__class__(
             n=shape[-1], shape=shape, device=self.device, dtype=self.dtype
+        )
+
+    def squeeze(self, dim=None):
+        if self.shape[-1] == 1 and dim in (len(self.shape), -1, None):
+            raise ValueError(
+                "Final dimension of OneHotDiscreteTensorSpec must remain unchanged"
+            )
+
+        shape = _squeezed_shape(self.shape, dim)
+        if shape is None:
+            return self
+
+        return self.__class__(
+            n=shape[-1],
+            shape=shape,
+            device=self.device,
+            dtype=self.dtype,
+            use_register=self.use_register,
+        )
+
+    def unsqueeze(self, dim: int):
+        if dim in (len(self.shape), -1):
+            raise ValueError(
+                "Final dimension of OneHotDiscreteTensorSpec must remain unchanged"
+            )
+
+        shape = _unsqueezed_shape(self.shape, dim)
+        return self.__class__(
+            n=shape[-1],
+            shape=shape,
+            device=self.device,
+            dtype=self.dtype,
+            use_register=self.use_register,
         )
 
     def rand(self, shape=None) -> torch.Tensor:
@@ -1047,6 +1096,36 @@ class BoundedTensorSpec(TensorSpec):
         return self.__class__(
             minimum=self.space.minimum.expand(shape).clone(),
             maximum=self.space.maximum.expand(shape).clone(),
+            shape=shape,
+            device=self.device,
+            dtype=self.dtype,
+        )
+
+    def squeeze(self, dim: int | None = None):
+        shape = _squeezed_shape(self.shape, dim)
+        if shape is None:
+            return self
+
+        if dim is None:
+            minimum = self.space.minimum.squeeze().clone()
+            maximum = self.space.maximum.squeeze().clone()
+        else:
+            minimum = self.space.minimum.squeeze(dim).clone()
+            maximum = self.space.maximum.squeeze(dim).clone()
+
+        return self.__class__(
+            minimum=minimum,
+            maximum=maximum,
+            shape=shape,
+            device=self.device,
+            dtype=self.dtype,
+        )
+
+    def unsqueeze(self, dim: int):
+        shape = _unsqueezed_shape(self.shape, dim)
+        return self.__class__(
+            minimum=self.space.minimum.unsqueeze(dim).clone(),
+            maximum=self.space.maximum.unsqueeze(dim).clone(),
             shape=shape,
             device=self.device,
             dtype=self.dtype,
@@ -1379,6 +1458,28 @@ class BinaryDiscreteTensorSpec(TensorSpec):
             n=shape[-1], shape=shape, device=self.device, dtype=self.dtype
         )
 
+    def squeeze(self, dim: int | None = None):
+        if self.shape[-1] == 1 and dim in (len(self.shape), -1, None):
+            raise ValueError(
+                "Final dimension of BinaryDiscreteTensorSpec must remain unchanged"
+            )
+        shape = _squeezed_shape(self.shape, dim)
+        if shape is None:
+            return self
+        return self.__class__(
+            n=shape[-1], shape=shape, device=self.device, dtype=self.dtype
+        )
+
+    def unsqueeze(self, dim: int):
+        if dim in (len(self.shape), -1):
+            raise ValueError(
+                "Final dimension of BinaryDiscreteTensorSpec must remain unchanged"
+            )
+        shape = _unsqueezed_shape(self.shape, dim)
+        return self.__class__(
+            n=shape[-1], shape=shape, device=self.device, dtype=self.dtype
+        )
+
     def to(self, dest: Union[torch.dtype, DEVICE_TYPING]) -> CompositeSpec:
         if isinstance(dest, torch.dtype):
             dest_dtype = dest
@@ -1589,6 +1690,29 @@ class MultiOneHotDiscreteTensorSpec(OneHotDiscreteTensorSpec):
             nvec=nvecs, shape=shape, device=self.device, dtype=self.dtype
         )
 
+    def squeeze(self, dim=None):
+        if self.shape[-1] == 1 and dim in (len(self.shape), -1, None):
+            raise ValueError(
+                "Final dimension of MultiOneHotDiscreteTensorSpec must remain unchanged"
+            )
+
+        shape = _squeezed_shape(self.shape, dim)
+        if shape is None:
+            return self
+        return self.__class__(
+            nvec=self.nvec, shape=shape, device=self.device, dtype=self.dtype
+        )
+
+    def unsqueeze(self, dim: int):
+        if dim in (len(self.shape), -1):
+            raise ValueError(
+                "Final dimension of MultiOneHotDiscreteTensorSpec must remain unchanged"
+            )
+        shape = _unsqueezed_shape(self.shape, dim)
+        return self.__class__(
+            nvec=self.nvec, shape=shape, device=self.device, dtype=self.dtype
+        )
+
 
 class DiscreteTensorSpec(TensorSpec):
     """A discrete tensor spec.
@@ -1701,6 +1825,20 @@ class DiscreteTensorSpec(TensorSpec):
                 f"The last {self.ndim} of the extended shape must match the"
                 f"shape of the CompositeSpec in CompositeSpec.extend."
             )
+        return self.__class__(
+            n=self.space.n, shape=shape, device=self.device, dtype=self.dtype
+        )
+
+    def squeeze(self, dim=None):
+        shape = _squeezed_shape(self.shape, dim)
+        if shape is None:
+            return self
+        return self.__class__(
+            n=self.space.n, shape=shape, device=self.device, dtype=self.dtype
+        )
+
+    def unsqueeze(self, dim: int):
+        shape = _unsqueezed_shape(self.shape, dim)
         return self.__class__(
             n=self.space.n, shape=shape, device=self.device, dtype=self.dtype
         )
@@ -1908,6 +2046,36 @@ class MultiDiscreteTensorSpec(DiscreteTensorSpec):
             )
         return self.__class__(
             nvec=self.nvec, shape=shape, device=self.device, dtype=self.dtype
+        )
+
+    def squeeze(self, dim: int | None = None):
+        if self.shape[-1] == 1 and dim in (len(self.shape), -1, None):
+            raise ValueError(
+                "Final dimension of MultiDiscreteTensorSpec must remain unchanged"
+            )
+
+        shape = _squeezed_shape(self.shape, dim)
+        if shape is None:
+            return self
+
+        if dim is None:
+            nvec = self.nvec.squeeze()
+        else:
+            nvec = self.nvec.squeeze(dim)
+
+        return self.__class__(
+            nvec=nvec, shape=shape, device=self.device, dtype=self.dtype
+        )
+
+    def unsqueeze(self, dim: int):
+        if dim in (len(self.shape), -1):
+            raise ValueError(
+                "Final dimension of MultiDiscreteTensorSpec must remain unchanged"
+            )
+        shape = _unsqueezed_shape(self.shape, dim)
+        nvec = self.nvec.unsqueeze(dim)
+        return self.__class__(
+            nvec=nvec, shape=shape, device=self.device, dtype=self.dtype
         )
 
 
@@ -2227,9 +2395,7 @@ class CompositeSpec(TensorSpec):
                 Default is ``False``.
         """
         return _CompositeSpecKeysView(
-            self,
-            include_nested=include_nested,
-            leaves_only=leaves_only,
+            self, include_nested=include_nested, leaves_only=leaves_only
         )
 
     def items(self) -> ItemsView:
@@ -2304,7 +2470,9 @@ class CompositeSpec(TensorSpec):
                 continue
             try:
                 if isinstance(item, TensorSpec) and item.device != self.device:
-                    item = deepcopy(item).to(self.device)
+                    item = deepcopy(item)
+                    if self.device is not None:
+                        item = item.to(self.device)
             except RuntimeError as err:
                 if DEVICE_ERR_MSG in str(err):
                     try:
@@ -2344,6 +2512,52 @@ class CompositeSpec(TensorSpec):
         )
         return out
 
+    def squeeze(self, dim: int | None = None):
+        if dim is not None:
+            if dim < 0:
+                dim += len(self.shape)
+
+            shape = _squeezed_shape(self.shape, dim)
+            if shape is None:
+                return self
+
+            try:
+                device = self.device
+            except RuntimeError:
+                device = self._device
+
+            return CompositeSpec(
+                {key: value.squeeze(dim) for key, value in self.items()},
+                shape=shape,
+                device=device,
+            )
+
+        if self.shape.count(1) == 0:
+            return self
+
+        # we can't just recursively apply squeeze with dim=None because we don't want
+        # to squeeze non-batch dims of the values. Instead we find the first dim in
+        # the batch dims with size 1, squeeze that, then recurse on the root spec
+        out = self.squeeze(self.shape.index(1))
+        return out.squeeze()
+
+    def unsqueeze(self, dim: int):
+        if dim < 0:
+            dim += len(self.shape)
+
+        shape = _unsqueezed_shape(self.shape, dim)
+
+        try:
+            device = self.device
+        except RuntimeError:
+            device = self._device
+
+        return CompositeSpec(
+            {key: value.unsqueeze(dim) for key, value in self.items()},
+            shape=shape,
+            device=device,
+        )
+
 
 class LazyStackedCompositeSpec(_LazyStackedMixin[CompositeSpec], CompositeSpec):
     """A lazy representation of a stack of composite specs.
@@ -2379,10 +2593,12 @@ class LazyStackedCompositeSpec(_LazyStackedMixin[CompositeSpec], CompositeSpec):
             yield key, self[key]
 
     def keys(
-        self, yield_nesting_keys: bool = False, nested_keys: bool = True
+        self,
+        include_nested: bool = False,
+        leaves_only: bool = False,
     ) -> KeysView:
         return self._specs[0].keys(
-            yield_nesting_keys=yield_nesting_keys, nested_keys=nested_keys
+            include_nested=include_nested, leaves_only=leaves_only
         )
 
     def project(self, val: TensorDictBase) -> TensorDictBase:
@@ -2405,7 +2621,9 @@ class LazyStackedCompositeSpec(_LazyStackedMixin[CompositeSpec], CompositeSpec):
         device_str = f"device={self._specs[0].device}"
         shape_str = f"shape={self.shape}"
         sub_str = ", ".join([sub_str, device_str, shape_str])
-        return f"CompositeSpec(\n{', '.join([sub_str, device_str, shape_str])})"
+        return (
+            f"LazyStackedCompositeSpec(\n{', '.join([sub_str, device_str, shape_str])})"
+        )
 
     def encode(self, vals: Dict[str, Any]) -> Dict[str, torch.Tensor]:
         pass
@@ -2452,15 +2670,24 @@ def _stack_specs(list_of_spec, dim, out=None):
         )
     if not len(list_of_spec):
         raise ValueError("Cannot stack an empty list of specs.")
-    if isinstance(list_of_spec[0], TensorSpec):
-        device = list_of_spec[0].device
-        for spec in list_of_spec:
+    spec0 = list_of_spec[0]
+    if isinstance(spec0, TensorSpec):
+        device = spec0.device
+        all_equal = True
+        for spec in list_of_spec[1:]:
             if not isinstance(spec, TensorSpec):
                 raise RuntimeError(
                     "Stacking specs cannot occur: Found more than one type of specs in the list."
                 )
             if device != spec.device:
                 raise RuntimeError(f"Devices differ, got {device} and {spec.device}")
+            all_equal = all_equal and spec == spec0
+        if all_equal:
+            shape = list(spec0.shape)
+            if dim < 0:
+                dim += len(shape) + 1
+            shape.insert(dim, len(list_of_spec))
+            return spec0.clone().unsqueeze(dim).expand(shape)
         return LazyStackedTensorSpec(*list_of_spec, dim=dim)
     else:
         raise NotImplementedError
@@ -2475,9 +2702,11 @@ def _stack_composite_specs(list_of_spec, dim, out=None):
         )
     if not len(list_of_spec):
         raise ValueError("Cannot stack an empty list of specs.")
-    if isinstance(list_of_spec[0], CompositeSpec):
-        device = list_of_spec[0].device
-        for spec in list_of_spec:
+    spec0 = list_of_spec[0]
+    if isinstance(spec0, CompositeSpec):
+        device = spec0.device
+        all_equal = True
+        for spec in list_of_spec[1:]:
             if not isinstance(spec, CompositeSpec):
                 raise RuntimeError(
                     "Stacking specs cannot occur: Found more than one type of spec in "
@@ -2485,6 +2714,13 @@ def _stack_composite_specs(list_of_spec, dim, out=None):
                 )
             if device != spec.device:
                 raise RuntimeError(f"Devices differ, got {device} and {spec.device}")
+            all_equal = all_equal and spec == spec0
+        if all_equal:
+            shape = list(spec0.shape)
+            if dim < 0:
+                dim += len(shape) + 1
+            shape.insert(dim, len(list_of_spec))
+            return spec0.clone().unsqueeze(dim).expand(shape)
         return LazyStackedCompositeSpec(*list_of_spec, dim=dim)
     else:
         raise NotImplementedError
@@ -2512,6 +2748,37 @@ def _keys_to_empty_composite_spec(keys):
         else:
             c[key[0]] = _keys_to_empty_composite_spec(key[1:])
     return c
+
+
+def _squeezed_shape(shape: torch.Size, dim: int | None) -> torch.Size | None:
+    if dim is None:
+        if len(shape) == 1 or shape.count(1) == 0:
+            return None
+        new_shape = torch.Size([s for s in shape if s != 1])
+    else:
+        if dim < 0:
+            dim += len(shape)
+
+        if shape[dim] != 1:
+            return None
+
+        new_shape = torch.Size([s for i, s in enumerate(shape) if i != dim])
+    return new_shape
+
+
+def _unsqueezed_shape(shape: torch.Size, dim: int) -> torch.Size:
+    n = len(shape)
+    if dim < -(n + 1) or dim > n:
+        raise ValueError(
+            f"Dimension out of range, expected value in the range [{-(n+1)}, {n}], but "
+            f"got {dim}"
+        )
+    if dim < 0:
+        dim += n + 1
+
+    new_shape = list(shape)
+    new_shape.insert(dim, 1)
+    return torch.Size(new_shape)
 
 
 class _CompositeSpecKeysView:


### PR DESCRIPTION
## Description

This PR changes the behaviour of `torch.stack` when the arguments are `TensorSpec` or `CompositeSpec` variants. It checks for equality among the specs being stacked, and if they all match, it actually performs the stack (rather than returning a lazy stacked spec).

To facilitate this, I have added `squeeze` and `unsqueeze` methods to all specs. Stacking is done by computing the new shape and then calling something like `spec.clone().unsqueeze(stack_dim).expand(new_shape)`. I added `squeeze` since you can't have `unsqueeze` without `squeeze` 😄 

Some of the tests probably need rethinking. I've made small changes to get them to pass, but there is new behaviour here which ideally would be tested for explicitly.