### PR TITLE
[BugFix] make "_reset", "step_count", and other done_based keys follow done_spec

### DIFF
--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -315,8 +315,8 @@ def test_collector_env_reset():
     )
     for _data in collector:
         continue
-    steps = _data["next", "step_count"][..., 1:]
-    done = _data["next", "done"][..., :-1, :].squeeze(-1)
+    steps = _data["next", "step_count"][..., 1:,:]
+    done = _data["next", "done"][..., :-1, :]
     # we don't want just one done
     assert done.sum() > 3
     # check that after a done, the next step count is always 1

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -315,7 +315,7 @@ def test_collector_env_reset():
     )
     for _data in collector:
         continue
-    steps = _data["next", "step_count"][..., 1:,:]
+    steps = _data["next", "step_count"][..., 1:, :]
     done = _data["next", "done"][..., :-1, :]
     # we don't want just one done
     assert done.sum() > 3

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -424,7 +424,7 @@ def test_split_trajs(num_env, env_name, frames_per_batch, seed=5):
 
     assert d.ndimension() == 2
     assert d["collector", "mask"].shape == d.shape
-    assert d["next", "step_count"].shape == d.shape
+    assert d["next", "step_count"].shape == d["next", "done"].shape
     assert d["collector", "traj_ids"].shape == d.shape
     for traj in d.unbind(0):
         assert traj["collector", "traj_ids"].unique().numel() == 1

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -886,13 +886,9 @@ class TestParallel:
         assert (td["next", "done"] == 1).all()
         assert (td["next"]["observation"] == max_steps + 1).all()
 
-        _reset = torch.randint(
-            low=0, high=2, size=env.done_spec.shape, dtype=torch.bool
-        )
+        _reset = env.done_spec.rand()
         while not _reset.any():
-            _reset = torch.randint(
-                low=0, high=2, size=env.done_spec.shape, dtype=torch.bool
-            )
+            _reset = env.done_spec.rand()
 
         td_reset = env.reset(
             TensorDict({"_reset": _reset}, batch_size=env.batch_size, device=env.device)
@@ -926,7 +922,7 @@ def test_env_base_reset_flag(batch_size, max_steps=3):
     assert (td["next", "done"] == 1).all()
     assert (td["next", "observation"] == max_steps + 1).all()
 
-    _reset = torch.randint(low=0, high=2, size=env.done_spec.shape, dtype=torch.bool)
+    _reset = env.done_spec.rand()
     td_reset = env.reset(
         TensorDict({"_reset": _reset}, batch_size=env.batch_size, device=env.device)
     )

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -455,7 +455,7 @@ class TestParallel:
             _ = env_parallel.step(td)
 
         td_reset = TensorDict(
-            source={"_reset": env_parallel.done_spec.zero().bernoulli_()},
+            source={"_reset": env_parallel.done_spec.rand()},
             batch_size=[
                 N,
             ],
@@ -530,7 +530,7 @@ class TestParallel:
             _ = env_parallel.step(td)
 
         td_reset = TensorDict(
-            source={"_reset": env_parallel.done_spec.zero().bernoulli_()},
+            source={"_reset": env_parallel.done_spec.rand()},
             batch_size=[
                 N,
             ],

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -926,7 +926,7 @@ def test_env_base_reset_flag(batch_size, max_steps=3):
     assert (td["next", "done"] == 1).all()
     assert (td["next", "observation"] == max_steps + 1).all()
 
-    _reset = torch.randint(low=0, high=2, size=env.batch_size, dtype=torch.bool)
+    _reset = torch.randint(low=0, high=2, size=env.done_spec.shape, dtype=torch.bool)
     td_reset = env.reset(
         TensorDict({"_reset": _reset}, batch_size=env.batch_size, device=env.device)
     )

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -455,7 +455,7 @@ class TestParallel:
             _ = env_parallel.step(td)
 
         td_reset = TensorDict(
-            source={"_reset": torch.zeros(N, dtype=torch.bool).bernoulli_()},
+            source={"_reset": env_parallel.done_spec.zero().bernoulli_()},
             batch_size=[
                 N,
             ],
@@ -530,7 +530,7 @@ class TestParallel:
             _ = env_parallel.step(td)
 
         td_reset = TensorDict(
-            source={"_reset": torch.zeros(N, dtype=torch.bool).bernoulli_()},
+            source={"_reset": env_parallel.done_spec.zero().bernoulli_()},
             batch_size=[
                 N,
             ],
@@ -886,9 +886,13 @@ class TestParallel:
         assert (td["next", "done"] == 1).all()
         assert (td["next"]["observation"] == max_steps + 1).all()
 
-        _reset = torch.randint(low=0, high=2, size=env.batch_size, dtype=torch.bool)
+        _reset = torch.randint(
+            low=0, high=2, size=env.done_spec.shape, dtype=torch.bool
+        )
         while not _reset.any():
-            _reset = torch.randint(low=0, high=2, size=env.batch_size, dtype=torch.bool)
+            _reset = torch.randint(
+                low=0, high=2, size=env.done_spec.shape, dtype=torch.bool
+            )
 
         td_reset = env.reset(
             TensorDict({"_reset": _reset}, batch_size=env.batch_size, device=env.device)

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -1069,9 +1069,9 @@ class TestVmas:
 
         assert tensordict["next", "done"].squeeze(-1)[..., -1].all()
 
-        _reset = torch.randint(low=0, high=2, size=env.batch_size, dtype=torch.bool)
+        _reset = env.done_spec.rand()
         while not _reset.any():
-            _reset = torch.randint(low=0, high=2, size=env.batch_size, dtype=torch.bool)
+            _reset = env.done_spec.rand()
 
         tensordict = env.reset(
             TensorDict({"_reset": _reset}, batch_size=env.batch_size, device=env.device)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -6676,7 +6676,7 @@ class TestInitTracker(TransformBase):
         env = CountingBatchedEnv(max_steps=torch.tensor([3, 4]), batch_size=[2])
         env = TransformedEnv(env, InitTracker())
         r = env.rollout(100, policy, break_when_any_done=False)
-        assert (r["is_init"].sum(1) == torch.tensor([25, 20])).all()
+        assert (r["is_init"].view(r.batch_size).sum(-1) == torch.tensor([25, 20])).all()
 
     def test_transform_model(self):
         with pytest.raises(

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1073,18 +1073,8 @@ class TestStepCounter(TransformBase):
         td = step_counter.reset(td)
         if reset_workers:
 
-            assert torch.all(
-                torch.masked_select(
-                    td.get("step_count"), _reset.view(*td.batch_size, -1).any(-1)
-                )
-                == 0
-            )
-            assert torch.all(
-                torch.masked_select(
-                    td.get("step_count"), ~_reset.view(*td.batch_size, -1).any(-1)
-                )
-                == i
-            )
+            assert torch.all(torch.masked_select(td.get("step_count"), _reset) == 0)
+            assert torch.all(torch.masked_select(td.get("step_count"), ~_reset) == i)
         else:
             assert torch.all(td.get("step_count") == 0)
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -11,8 +11,6 @@ from functools import partial
 import numpy as np
 import pytest
 import torch
-from tensordict.tensordict import TensorDict, TensorDictBase
-from torch import multiprocessing as mp, nn, Tensor
 
 from _utils_internal import (  # noqa
     dtype_fixture,
@@ -29,6 +27,8 @@ from mocking_classes import (
     MockBatchedLockedEnv,
     MockBatchedUnLockedEnv,
 )
+from tensordict.tensordict import TensorDict, TensorDictBase
+from torch import multiprocessing as mp, nn, Tensor
 from torchrl._utils import prod
 from torchrl.data import (
     BoundedTensorSpec,
@@ -1073,8 +1073,18 @@ class TestStepCounter(TransformBase):
         td = step_counter.reset(td)
         if reset_workers:
 
-            assert torch.all(torch.masked_select(td.get("step_count"), _reset.view(*td.batch_size,-1).any(-1)) == 0)
-            assert torch.all(torch.masked_select(td.get("step_count"), ~_reset.view(*td.batch_size,-1).any(-1)) == i)
+            assert torch.all(
+                torch.masked_select(
+                    td.get("step_count"), _reset.view(*td.batch_size, -1).any(-1)
+                )
+                == 0
+            )
+            assert torch.all(
+                torch.masked_select(
+                    td.get("step_count"), ~_reset.view(*td.batch_size, -1).any(-1)
+                )
+                == i
+            )
         else:
             assert torch.all(td.get("step_count") == 0)
 

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -506,11 +506,7 @@ class SyncDataCollector(DataCollectorBase):
         self.reset_when_done = reset_when_done
         self.n_env = self.env.batch_size.numel()
 
-        (
-            self.policy,
-            self.device,
-            self.get_weights_fn,
-        ) = self._get_policy_and_device(
+        (self.policy, self.device, self.get_weights_fn,) = self._get_policy_and_device(
             policy=policy,
             device=device,
             observation_spec=self.env.observation_spec,

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -693,7 +693,7 @@ class SyncDataCollector(_DataCollector):
             # to `reset()`.
             if len(self.env.batch_size):
                 self._tensordict.masked_fill_(done_or_terminated, 0)
-                _reset = done_or_terminated
+                _reset = done_or_terminated.unsqueeze(-1)
                 td_reset = self._tensordict.select().set("_reset", _reset)
             else:
                 _reset = None
@@ -750,7 +750,10 @@ class SyncDataCollector(_DataCollector):
                         self._tensordict_out.lock()
 
                 self._step_and_maybe_reset()
-                if self.interruptor is not None and self.interruptor.collection_stopped():
+                if (
+                    self.interruptor is not None
+                    and self.interruptor.collection_stopped()
+                ):
                     break
 
         return self._tensordict_out

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -725,9 +725,9 @@ class SyncDataCollector(DataCollectorBase):
                 raise RuntimeError(
                     f"Env {self.env} was done after reset on specified '_reset' dimensions. This is (currently) not allowed."
                 )
-            traj_done_or_terminated = done_or_terminated.view(
-                *self._tensordict.batch_size, -1
-            ).any(-1)
+            traj_done_or_terminated = done_or_terminated.sum(
+                tuple(range(self._tensordict.batch_dims, done_or_terminated.ndim))
+            )
             traj_ids[traj_done_or_terminated] = traj_ids.max() + torch.arange(
                 1, traj_done_or_terminated.sum() + 1, device=traj_ids.device
             )

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -726,7 +726,8 @@ class SyncDataCollector(DataCollectorBase):
                     f"Env {self.env} was done after reset on specified '_reset' dimensions. This is (currently) not allowed."
                 )
             traj_done_or_terminated = done_or_terminated.sum(
-                tuple(range(self._tensordict.batch_dims, done_or_terminated.ndim))
+                tuple(range(self._tensordict.batch_dims, done_or_terminated.ndim)),
+                dtype=torch.bool,
             )
             traj_ids[traj_done_or_terminated] = traj_ids.max() + torch.arange(
                 1, traj_done_or_terminated.sum() + 1, device=traj_ids.device

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -717,7 +717,7 @@ class SyncDataCollector(DataCollectorBase):
                 self._tensordict.batch_size, -1
             ).any(-1)
             traj_ids[traj_done_or_terminated] = traj_ids.max() + torch.arange(
-                1, traj_done_or_terminated + 1, device=traj_ids.device
+                1, traj_done_or_terminated.sum() + 1, device=traj_ids.device
             )
             self._tensordict.set_(
                 ("collector", "traj_ids"), traj_ids

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -767,7 +767,7 @@ class SyncDataCollector(_DataCollector):
             if prod(self.env.batch_size) == 0:
                 raise RuntimeError("resetting unique env with index is not permitted.")
             _reset = torch.zeros(
-                self.env.batch_size,
+                self.env.done_spec.shape,
                 dtype=torch.bool,
                 device=self.env.device,
             )

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -506,7 +506,11 @@ class SyncDataCollector(DataCollectorBase):
         self.reset_when_done = reset_when_done
         self.n_env = self.env.batch_size.numel()
 
-        (self.policy, self.device, self.get_weights_fn,) = self._get_policy_and_device(
+        (
+            self.policy,
+            self.device,
+            self.get_weights_fn,
+        ) = self._get_policy_and_device(
             policy=policy,
             device=device,
             observation_spec=self.env.observation_spec,
@@ -699,9 +703,6 @@ class SyncDataCollector(DataCollectorBase):
             # collectors do not support passing other tensors than `"_reset"`
             # to `reset()`.
             if len(self.env.batch_size):
-                self._tensordict.masked_fill_(
-                    done_or_terminated.view(self._tensordict.batch_size, -1).any(-1), 0
-                )
                 _reset = done_or_terminated
                 td_reset = self._tensordict.select().set("_reset", _reset)
             else:

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -711,7 +711,7 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
                 exclude_action=False,
             )
             if not break_when_any_done and done.any():
-                _reset = done.view(tensordict.shape)
+                _reset = done
                 tensordict.set("_reset", _reset)
                 self.reset(tensordict)
 

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -712,7 +712,7 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
                 exclude_action=False,
             )
             if not break_when_any_done and done.any():
-                _reset = done
+                _reset = done.clone()
                 tensordict.set("_reset", _reset)
                 self.reset(tensordict)
 

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -21,6 +21,7 @@ from torchrl.data.tensor_specs import (
     TensorSpec,
     UnboundedContinuousTensorSpec,
 )
+
 from .._utils import prod, seed_generator
 from ..data.utils import DEVICE_TYPING
 from .utils import get_available_libraries, step_mdp

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -479,16 +479,7 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
         if tensordict is not None and "_reset" in tensordict.keys():
             self._assert_tensordict_shape(tensordict)
             _reset = tensordict.get("_reset")
-            batch_size = self.batch_size
-            dims = len(batch_size)
-            leading_batch_size = (
-                tensordict.batch_size[:-dims] if dims else tensordict.shape
-            )
-            expected_reset_spec = torch.Size(
-                [*leading_batch_size, *self.done_spec.shape]
-            )
-            actual_reset_shape = _reset.shape
-            if actual_reset_shape != expected_reset_spec:
+            if _reset.shape[-len(self.done_spec.shape) :] != self.done_spec.shape:
                 raise RuntimeError(
                     "_reset flag in tensordict should follow env.done_spec"
                 )

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3415,7 +3415,9 @@ class InitTracker(Transform):
                 device = torch.device("cpu")
             tensordict.set(
                 self.out_keys[0],
-                torch.zeros(self.parent.done_spec.shape, device=device, dtype=torch.bool),
+                torch.zeros(
+                    self.parent.done_spec.shape, device=device, dtype=torch.bool
+                ),
             )
         return tensordict
 
@@ -3423,7 +3425,10 @@ class InitTracker(Transform):
         device = tensordict.device
         if device is None:
             device = torch.device("cpu")
-        _reset = tensordict.get("_reset",  torch.ones(self.parent.done_spec.shape, device=device, dtype=torch.bool))
+        _reset = tensordict.get(
+            "_reset",
+            torch.ones(self.parent.done_spec.shape, device=device, dtype=torch.bool),
+        )
         tensordict.set(self.out_keys[0], _reset.clone())
         return tensordict
 

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3415,7 +3415,7 @@ class InitTracker(Transform):
                 device = torch.device("cpu")
             tensordict.set(
                 self.out_keys[0],
-                torch.zeros(tensordict.shape, device=device, dtype=torch.bool),
+                torch.zeros(self.parent.done_spec.shape, device=device, dtype=torch.bool),
             )
         return tensordict
 
@@ -3423,9 +3423,7 @@ class InitTracker(Transform):
         device = tensordict.device
         if device is None:
             device = torch.device("cpu")
-        _reset = tensordict.get("_reset", None)
-        if _reset is None:
-            _reset = torch.ones(tensordict.shape, device=device, dtype=torch.bool)
+        _reset = tensordict.get("_reset",  torch.ones(self.parent.done_spec.shape, device=device, dtype=torch.bool))
         tensordict.set(self.out_keys[0], _reset.clone())
         return tensordict
 
@@ -3434,7 +3432,7 @@ class InitTracker(Transform):
             2,
             dtype=torch.bool,
             device=self.parent.device,
-            shape=self.parent.batch_size,
+            shape=self.parent.done_spec.shape,
         )
         return observation_spec
 

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1723,15 +1723,13 @@ class CatFrames(ObservationTransform):
             tensordict.get(
                 "_reset",
                 torch.ones(
-                    self.parent.done_spec.shape,
+                    tensordict.batch_size,
                     dtype=torch.bool,
                     device=tensordict.device
                     if tensordict.device is not None
                     else torch.device("cpu"),
                 ),
             )
-            .view(*tensordict.batch_size, -1)
-            .any(-1)
         )
 
         for in_key in self.in_keys:
@@ -2886,13 +2884,11 @@ class RewardSum(Transform):
             tensordict.get(
                 "_reset",
                 torch.ones(
-                    self.parent.done_spec.shape,
+                    tensordict.batch_size,
                     dtype=torch.bool,
                     device=tensordict.device,
                 ),
             )
-            .view(*tensordict.batch_size, -1)
-            .any(-1)
         )
         if _reset.any():
             for in_key, out_key in zip(self.in_keys, self.out_keys):

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3007,12 +3007,16 @@ class StepCounter(Transform):
         _reset = tensordict.get(
             "_reset",
             # TODO: decide if using done here, or using a default `True` tensor
-            default=torch.ones_like(done),
+            default=None,
         )
+        if _reset is None:
+            _reset = torch.ones_like(done)
         step_count = tensordict.get(
             "step_count",
-            default=torch.zeros_like(done),
+            default=None,
         )
+        if step_count is None:
+            step_count = torch.zeros_like(done)
 
         step_count[_reset] = 0
         tensordict.set(

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3062,9 +3062,7 @@ class StepCounter(Transform):
             observation_spec["step_count"].space.minimum * 0
         )
         if self.max_steps is not None and self.truncated_key != "done":
-            observation_spec[self.truncated_key] = (
-                self.parent.done_spec.clone() if self.parent else observation_spec.shape
-            )
+            observation_spec[self.truncated_key] = self.parent.done_spec.clone()
         return observation_spec
 
     def transform_input_spec(self, input_spec: CompositeSpec) -> CompositeSpec:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1719,15 +1719,19 @@ class CatFrames(ObservationTransform):
 
     def reset(self, tensordict: TensorDictBase) -> TensorDictBase:
         """Resets _buffers."""
-        _reset = tensordict.get(
-            "_reset",
-            torch.ones(
-                tensordict.batch_size,
-                dtype=torch.bool,
-                device=tensordict.device
-                if tensordict.device is not None
-                else torch.device("cpu"),
-            ),
+        _reset = (
+            tensordict.get(
+                "_reset",
+                torch.ones(
+                    self.parent.done_spec.shape,
+                    dtype=torch.bool,
+                    device=tensordict.device
+                    if tensordict.device is not None
+                    else torch.device("cpu"),
+                ),
+            )
+            .view(*tensordict.batch_size, -1)
+            .any(-1)
         )
 
         for in_key in self.in_keys:
@@ -2881,7 +2885,7 @@ class RewardSum(Transform):
         _reset = tensordict.get(
             "_reset",
             torch.ones(
-                tensordict.batch_size,
+                self.parent.done_spec.shape,
                 dtype=torch.bool,
                 device=tensordict.device,
             ),

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1728,7 +1728,9 @@ class CatFrames(ObservationTransform):
                 if tensordict.device is not None
                 else torch.device("cpu"),
             )
-        _reset = _reset.sum(tuple(range(tensordict.batch_dims, _reset.ndim)))
+        _reset = _reset.sum(
+            tuple(range(tensordict.batch_dims, _reset.ndim)), dtype=torch.bool
+        )
 
         for in_key in self.in_keys:
             buffer_name = f"_cat_buffers_{in_key}"
@@ -1754,7 +1756,9 @@ class CatFrames(ObservationTransform):
         """Update the episode tensordict with max pooled keys."""
         _reset = tensordict.get("_reset", None)
         if _reset is not None:
-            _reset = _reset.sum(tuple(range(tensordict.batch_dims, _reset.ndim)))
+            _reset = _reset.sum(
+                tuple(range(tensordict.batch_dims, _reset.ndim)), dtype=torch.bool
+            )
 
         for in_key, out_key in zip(self.in_keys, self.out_keys):
             # Lazy init of buffers
@@ -3246,7 +3250,9 @@ class TimeMaxPool(Transform):
                 buffer = getattr(self, buffer_name)
                 if isinstance(buffer, torch.nn.parameter.UninitializedBuffer):
                     continue
-                _reset = _reset.sum(tuple(range(tensordict.batch_dims, _reset.ndim)))
+                _reset = _reset.sum(
+                    tuple(range(tensordict.batch_dims, _reset.ndim)), dtype=torch.bool
+                )
                 buffer[:, _reset] = 0.0
 
         return tensordict
@@ -3431,12 +3437,10 @@ class InitTracker(Transform):
             device = torch.device("cpu")
         _reset = tensordict.get("_reset", None)
         if _reset is None:
-            _reset = (
-                torch.ones(
-                    self.parent.done_spec.shape,
-                    device=device,
-                    dtype=torch.bool,
-                ),
+            _reset = torch.ones(
+                self.parent.done_spec.shape,
+                device=device,
+                dtype=torch.bool,
             )
         tensordict.set(self.out_keys[0], _reset.clone())
         return tensordict

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1721,7 +1721,7 @@ class CatFrames(ObservationTransform):
         """Resets _buffers."""
         _reset = tensordict.get("_reset", None)
         if _reset is None:
-            torch.ones(
+            _reset = torch.ones(
                 self.parent.done_spec.shape if self.parent else tensordict.batch_size,
                 dtype=torch.bool,
                 device=tensordict.device

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3006,7 +3006,7 @@ class StepCounter(Transform):
         done = tensordict.get("done", None)
         if done is None:
             done = torch.ones(
-                self.parent.done_spec.shape if self.parent else tensordict.batch_size,
+                self.parent.done_spec.shape,
                 dtype=self.parent.done_spec.dtype,
                 device=self.parent.done_spec.device,
             )
@@ -3434,7 +3434,7 @@ class InitTracker(Transform):
         _reset = tensordict.get(
             "_reset",
             torch.ones(
-                self.parent.done_spec.shape if self.parent else tensordict.batch_size,
+                self.parent.done_spec.shape,
                 device=device,
                 dtype=torch.bool,
             ),
@@ -3447,9 +3447,7 @@ class InitTracker(Transform):
             2,
             dtype=torch.bool,
             device=self.parent.device,
-            shape=self.parent.done_spec.shape
-            if self.parent
-            else observation_spec.shape,
+            shape=self.parent.done_spec.shape,
         )
         return observation_spec
 

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3020,7 +3020,7 @@ class StepCounter(Transform):
             default=None,
         )
         if step_count is None:
-            step_count = torch.zeros_like(done)
+            step_count = torch.zeros_like(done, dtype=torch.int64)
 
         step_count[_reset] = 0
         tensordict.set(

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1719,17 +1719,15 @@ class CatFrames(ObservationTransform):
 
     def reset(self, tensordict: TensorDictBase) -> TensorDictBase:
         """Resets _buffers."""
-        _reset = (
-            tensordict.get(
-                "_reset",
-                torch.ones(
-                    tensordict.batch_size,
-                    dtype=torch.bool,
-                    device=tensordict.device
-                    if tensordict.device is not None
-                    else torch.device("cpu"),
-                ),
-            )
+        _reset = tensordict.get(
+            "_reset",
+            torch.ones(
+                tensordict.batch_size,
+                dtype=torch.bool,
+                device=tensordict.device
+                if tensordict.device is not None
+                else torch.device("cpu"),
+            ),
         )
 
         for in_key in self.in_keys:
@@ -2880,15 +2878,13 @@ class RewardSum(Transform):
     def reset(self, tensordict: TensorDictBase) -> TensorDictBase:
         """Resets episode rewards."""
         # Non-batched environments
-        _reset = (
-            tensordict.get(
-                "_reset",
-                torch.ones(
-                    tensordict.batch_size,
-                    dtype=torch.bool,
-                    device=tensordict.device,
-                ),
-            )
+        _reset = tensordict.get(
+            "_reset",
+            torch.ones(
+                tensordict.batch_size,
+                dtype=torch.bool,
+                device=tensordict.device,
+            ),
         )
         if _reset.any():
             for in_key, out_key in zip(self.in_keys, self.out_keys):

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import logging
-
 import os
 from collections import OrderedDict
 from copy import deepcopy
@@ -17,10 +16,10 @@ from warnings import warn
 
 import numpy as np
 import torch
-
 from tensordict import TensorDict
 from tensordict.tensordict import LazyStackedTensorDict, TensorDictBase
 from torch import multiprocessing as mp
+
 from torchrl._utils import _check_for_faulty_process, VERBOSE
 from torchrl.data.tensor_specs import (
     CompositeSpec,
@@ -568,12 +567,11 @@ class SerialEnv(_BatchedEnv):
 
     @_check_start
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
-
         if tensordict is not None and "_reset" in tensordict.keys():
             self._assert_tensordict_shape(tensordict)
             _reset = tensordict.get("_reset")
         else:
-            _reset = torch.ones(self.batch_size, dtype=torch.bool)
+            _reset = torch.ones(self.done_spec.shape, dtype=torch.bool)
 
         for i, _env in enumerate(self._envs):
             if tensordict is not None:
@@ -656,7 +654,6 @@ class ParallelEnv(_BatchedEnv):
     __doc__ += _BatchedEnv.__doc__
 
     def _start_workers(self) -> None:
-
         _num_workers = self.num_workers
         ctx = mp.get_context("spawn")
 
@@ -795,7 +792,9 @@ class ParallelEnv(_BatchedEnv):
             self._assert_tensordict_shape(tensordict)
             _reset = tensordict.get("_reset")
         else:
-            _reset = torch.ones(self.batch_size, dtype=torch.bool, device=self.device)
+            _reset = torch.ones(
+                self.done_spec.shape, dtype=torch.bool, device=self.device
+            )
 
         for i, channel in enumerate(self.parent_channels):
             if tensordict is not None:
@@ -1253,7 +1252,6 @@ class MultiThreadedEnv(MultiThreadedEnvWrapper):
         create_env_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs,
     ):
-
         self.env_name = env_name.replace("ALE/", "")  # Naming convention of EnvPool
         self.num_workers = num_workers
         self.batch_size = torch.Size([num_workers])

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -570,6 +570,10 @@ class SerialEnv(_BatchedEnv):
         if tensordict is not None and "_reset" in tensordict.keys():
             self._assert_tensordict_shape(tensordict)
             _reset = tensordict.get("_reset")
+            if _reset.shape[-len(self.done_spec.shape) :] != self.done_spec.shape:
+                raise RuntimeError(
+                    "_reset flag in tensordict should follow env.done_spec"
+                )
         else:
             _reset = torch.ones(self.done_spec.shape, dtype=torch.bool)
 
@@ -791,6 +795,10 @@ class ParallelEnv(_BatchedEnv):
         if tensordict is not None and "_reset" in tensordict.keys():
             self._assert_tensordict_shape(tensordict)
             _reset = tensordict.get("_reset")
+            if _reset.shape[-len(self.done_spec.shape) :] != self.done_spec.shape:
+                raise RuntimeError(
+                    "_reset flag in tensordict should follow env.done_spec"
+                )
         else:
             _reset = torch.ones(
                 self.done_spec.shape, dtype=torch.bool, device=self.device


### PR DESCRIPTION
There are many places where _reset is just intantieated using the batch_size, while in reality it needs to follow the done_spec.

In particular, in transforms, how do we enforce this?