### PR TITLE
[Refactor] Refactor losses (value function, doc, input batch size)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,7 +73,7 @@ Knowledge Base
 ==============
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    reference/knowledge_base
 

--- a/docs/source/reference/objectives.rst
+++ b/docs/source/reference/objectives.rst
@@ -188,13 +188,18 @@ Returns
     TD1Estimator
     TDLambdaEstimator
     GAE
+    functional.td0_return_estimate
+    functional.td0_advantage_estimate
+    functional.td1_return_estimate
+    functional.vec_td1_return_estimate
+    functional.td1_advantage_estimate
+    functional.vec_td1_advantage_estimate
+    functional.td_lambda_return_estimate
+    functional.vec_td_lambda_return_estimate
+    functional.td_lambda_advantage_estimate
+    functional.vec_td_lambda_advantage_estimate
     functional.generalized_advantage_estimate
     functional.vec_generalized_advantage_estimate
-    functional.vec_td_lambda_return_estimate
-    functional.vec_td_lambda_advantage_estimate
-    functional.td_lambda_return_estimate
-    functional.td_lambda_advantage_estimate
-    functional.td_advantage_estimate
 
 
 Utils

--- a/docs/source/reference/objectives.rst
+++ b/docs/source/reference/objectives.rst
@@ -3,6 +3,81 @@
 torchrl.objectives package
 ==========================
 
+TorchRL provides a series of losses to use in your training scripts.
+The aim is to have losses that are easily reusable/swappable and that have
+a simple signature.
+
+The main characteristics of TorchRL losses are:
+
+- they are stateful objects: they contain a copy of the trainable parameters
+  such that ``loss_module.parameters()`` gives whatever is needed to train the
+  algorithm.
+- They follow the ``tensordict`` convention: the :meth:`torch.nn.Module.forward`
+  method will receive a tensordict as input that contains all the necessary
+  information to return a loss value.
+- They output a :class:`tensordict.TensorDict` instance with the loss values
+  written under a ``"loss_<smth>`` where ``smth`` is a string describing the
+  loss. Additional keys in the tensordict may be useful metrics to log during
+  training time.
+  .. note::
+    The reason we return independent losses is to let the user use a different
+    optimizer for different sets of parameters for instance. Summing the losses
+    can be simply done via ``sum(loss for key, loss in loss_vals.items() if key.startswith("loss_")``.
+
+Training value functions
+------------------------
+
+TorchRL provides a range of **value estimators** such as TD(0), TD(1), TD(:math:`\lambda`)
+and GAE.
+In a nutshell, a value estimator is a function of data (mostly
+rewards and done states) and a state value (ie. the value
+returned by a function that is fit to estimate state-values).
+To learn more about value estimators, check the introduction to RL from `Sutton
+and Barto <https://web.stanford.edu/class/psych209/Readings/SuttonBartoIPRLBook2ndEd.pdf>`_,
+in particular the chapters about value iteration and TD learning.
+It gives a somewhat biased estimation of the discounted return following a state
+or a state-action pair based on data and proxy maps. These estimators are
+used in two contexts:
+
+- To train the value network to learn the "true" state value (or state-action
+  value) map, one needs a target value to fit it to. The better (less bias,
+  less variance) the estimator, the better the value network will be, which in
+  turn can speed up the policy training significantly. Typically, the value
+  network loss will look like:
+
+    >>> value = value_network(states)
+    >>> target_value = value_estimator(rewards, done, value_network(next_state))
+    >>> value_net_loss = (value - target_value).pow(2).mean()
+
+- Computing an "advantage" signal for policy-optimization. The advantage is
+  the delta between the value estimate (from the estimator, ie from "real" data)
+  and the output of the value network (ie the proxy to this value). A positive
+  advantage can be seen as a signal that the policy actually performed better
+  than expected, thereby signaling that there is room for improvement if that
+  trajectory is to be taken as example. Conversely, a negative advantage signifies
+  that the policy underperformed compared to what was to be expected.
+
+Thins are not always as easy as in the example above and the formula to compute
+the value estimator or the advantage may be slightly more intricate than this.
+To help users flexibly use one or another value estimator, we provide a simple
+API to change it on-the-fly. Here is an example with DQN, but all modules will
+follow a similar structure:
+
+  >>> from torchrl.objectives import DQNLoss, ValueEstimators
+  >>> loss_module = DQNLoss(actor)
+  >>> kwargs = {"gamma": 0.9, "lmbda": 0.9}
+  >>> loss_module.make_value_estimator(ValueEstimators.TDLambda, **kwargs)
+
+The :class:`torchrl.objectives.ValueEstimators` class enumerates the value
+estimators to choose from. This makes it easy for the users to rely on
+auto-completion to make their choice.
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template_noinherit.rst
+
+    LossModule
+
 DQN
 ---
 
@@ -108,10 +183,10 @@ Returns
     :toctree: generated/
     :template: rl_template_noinherit.rst
 
-    ValueFunctionBase
-    TD0Estimate
-    TD1Estimate
-    TDLambdaEstimate
+    ValueEstimatorBase
+    TD0Estimator
+    TD1Estimator
+    TDLambdaEstimator
     GAE
     functional.generalized_advantage_estimate
     functional.vec_generalized_advantage_estimate

--- a/docs/source/reference/objectives.rst
+++ b/docs/source/reference/objectives.rst
@@ -109,9 +109,10 @@ Returns
     :template: rl_template_noinherit.rst
 
     ValueFunctionBase
-    GAE
+    TD0Estimate
+    TD1Estimate
     TDLambdaEstimate
-    TDEstimate
+    GAE
     functional.generalized_advantage_estimate
     functional.vec_generalized_advantage_estimate
     functional.vec_td_lambda_return_estimate
@@ -135,3 +136,5 @@ Utils
     next_state_value
     SoftUpdate
     HardUpdate
+    ValueFunctions
+    default_value_kwargs

--- a/docs/source/reference/objectives.rst
+++ b/docs/source/reference/objectives.rst
@@ -108,6 +108,7 @@ Returns
     :toctree: generated/
     :template: rl_template_noinherit.rst
 
+    ValueFunctionBase
     GAE
     TDLambdaEstimate
     TDEstimate

--- a/examples/a2c/a2c.py
+++ b/examples/a2c/a2c.py
@@ -10,7 +10,7 @@ import torch.cuda
 from hydra.core.config_store import ConfigStore
 from torchrl.envs.transforms import RewardScaling
 from torchrl.envs.utils import set_exploration_mode
-from torchrl.objectives.value import TDEstimate
+from torchrl.objectives.value import TD0Estimate
 from torchrl.record.loggers import generate_exp_name, get_logger
 from torchrl.trainers.helpers.collectors import (
     make_collector_onpolicy,
@@ -144,7 +144,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
     )
 
     critic_model = model.get_value_operator()
-    advantage = TDEstimate(
+    advantage = TD0Estimate(
         cfg.gamma,
         value_network=critic_model,
         average_rewards=True,

--- a/examples/a2c/a2c.py
+++ b/examples/a2c/a2c.py
@@ -10,7 +10,7 @@ import torch.cuda
 from hydra.core.config_store import ConfigStore
 from torchrl.envs.transforms import RewardScaling
 from torchrl.envs.utils import set_exploration_mode
-from torchrl.objectives.value import TD0Estimate
+from torchrl.objectives.value import TD0Estimator
 from torchrl.record.loggers import generate_exp_name, get_logger
 from torchrl.trainers.helpers.collectors import (
     make_collector_onpolicy,
@@ -144,14 +144,15 @@ def main(cfg: "DictConfig"):  # noqa: F821
     )
 
     critic_model = model.get_value_operator()
-    advantage = TD0Estimate(
+    advantage = TD0Estimator(
         cfg.gamma,
         value_network=critic_model,
         average_rewards=True,
+        differentiable=True,
     )
     trainer.register_op(
         "process_optim_batch",
-        advantage,
+        torch.no_grad()(advantage),
     )
 
     final_seed = collector.set_seed(cfg.seed)

--- a/examples/a2c/a2c.py
+++ b/examples/a2c/a2c.py
@@ -145,7 +145,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
 
     critic_model = model.get_value_operator()
     advantage = TD0Estimator(
-        cfg.gamma,
+        gamma=cfg.gamma,
         value_network=critic_model,
         average_rewards=True,
         differentiable=True,

--- a/examples/ppo/ppo.py
+++ b/examples/ppo/ppo.py
@@ -168,10 +168,11 @@ def main(cfg: "DictConfig"):  # noqa: F821
         cfg.lmbda,
         value_network=critic_model,
         average_gae=True,
+        differentiable=True,
     )
     trainer.register_op(
         "process_optim_batch",
-        lambda tensordict: advantage(tensordict.to(device)),
+        lambda tensordict: torch.no_grad()(advantage(tensordict.to(device))),
     )
     trainer._process_optim_batch_ops = [
         trainer._process_optim_batch_ops[-1],

--- a/examples/ppo/ppo.py
+++ b/examples/ppo/ppo.py
@@ -164,8 +164,8 @@ def main(cfg: "DictConfig"):  # noqa: F821
 
     critic_model = model.get_value_operator()
     advantage = GAE(
-        cfg.gamma,
-        cfg.lmbda,
+        gamma=cfg.gamma,
+        lmbda=cfg.lmbda,
         value_network=critic_model,
         average_gae=True,
         differentiable=True,

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -109,7 +109,7 @@ class _check_td_steady:
         pass
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        assert (self.td.select(*self.td_clone.keys()) == self.td_clone).all()
+        assert (self.td.select(*self.td_clone.keys()) == self.td_clone).all(), "Some keys have been modified in the tensordict!"
 
 
 def get_devices():
@@ -301,7 +301,7 @@ class TestDQN:
         td = self._create_mock_data_dqn(
             action_spec_type=action_spec_type, device=device
         )
-        loss_fn = DQNLoss(actor, gamma=0.9, loss_function="l2", delay_value=delay_value)
+        loss_fn = DQNLoss(actor, loss_function="l2", delay_value=delay_value)
         with _check_td_steady(td):
             loss = loss_fn(td)
         assert loss_fn.priority_key in td.keys()
@@ -341,7 +341,7 @@ class TestDQN:
             action_spec_type=action_spec_type, device=device
         )
         loss_fn = DQNLoss(
-            actor, gamma=gamma, loss_function="l2", delay_value=delay_value
+            actor, loss_function="l2", delay_value=delay_value
         )
 
         ms = MultiStep(gamma=gamma, n_steps=n).to(device)

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -2623,7 +2623,7 @@ class TestA2C:
         td = td.exclude(loss_fn.value_target_key)
         if advantage is not None:
             advantage(td)
-        else:
+        elif td_est is not None:
             loss_fn.make_value_function(td_est)
         loss = loss_fn(td)
         loss_critic = loss["loss_critic"]
@@ -2787,7 +2787,7 @@ class TestReinforce:
         params = TensorDict(value_net.state_dict(), []).unflatten_keys(".")
         if advantage is not None:
             advantage(td, params=params)
-        else:
+        elif td_est is not None:
             loss_fn.make_value_function(td_est)
         loss_td = loss_fn(td)
         autograd.grad(

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -37,7 +37,7 @@ from torchrl.modules.models.model_based import (
 )
 from torchrl.modules.models.utils import SquashDims
 from torchrl.modules.planners.mppi import MPPIPlanner
-from torchrl.objectives.value import TDLambdaEstimate
+from torchrl.objectives.value import TDLambdaEstimator
 
 
 @pytest.fixture
@@ -477,7 +477,7 @@ class TestPlanner:
         env = MockBatchedUnLockedEnv(device=device)
         value_net = nn.LazyLinear(1, device=device)
         value_net = ValueOperator(value_net, in_keys=["observation"])
-        advantage_module = TDLambdaEstimate(
+        advantage_module = TDLambdaEstimator(
             0.99,
             0.95,
             value_net,

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -478,9 +478,9 @@ class TestPlanner:
         value_net = nn.LazyLinear(1, device=device)
         value_net = ValueOperator(value_net, in_keys=["observation"])
         advantage_module = TDLambdaEstimator(
-            0.99,
-            0.95,
-            value_net,
+            gamma=0.99,
+            lmbda=0.95,
+            value_network=value_net,
         )
         value_net(env.reset())
         planner = MPPIPlanner(

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -635,7 +635,7 @@ class SyncDataCollector(DataCollectorBase):
 
         Args:
             seed (int): integer representing the seed to be used for the environment.
-            static_seed(bool, optional): if True, the seed is not incremented.
+            static_seed(bool, optional): if ``True``, the seed is not incremented.
                 Defaults to False
 
         Returns:
@@ -1263,7 +1263,7 @@ also that the state dict is synchronised across processes if needed."""
 
         Args:
             seed: integer representing the seed to be used for the environment.
-            static_seed (bool, optional): if True, the seed is not incremented.
+            static_seed (bool, optional): if ``True``, the seed is not incremented.
                 Defaults to False
 
         Returns:
@@ -1840,7 +1840,7 @@ class aSyncDataCollector(MultiaSyncDataCollector):
             the output TensorDict will be stored. For long trajectories,
             it may be necessary to store the data on a different.
             device than the one where the policy is stored. Default is None.
-        update_at_each_batch (bool): if True, the policy weights will be updated every time a batch of trajectories
+        update_at_each_batch (bool): if ``True``, the policy weights will be updated every time a batch of trajectories
             is collected.
             default=False
 

--- a/torchrl/data/datasets/d4rl.py
+++ b/torchrl/data/datasets/d4rl.py
@@ -47,7 +47,7 @@ class D4RLExperienceReplay(TensorDictReplayBuffer):
             using multithreading.
         transform (Transform, optional): Transform to be executed when sample() is called.
             To chain transforms use the :obj:`Compose` class.
-        split_trajs (bool, optional): if True, the trajectories will be split
+        split_trajs (bool, optional): if ``True``, the trajectories will be split
             along the first dimension and padded to have a matching shape.
             To split the trajectories, the ``"done"`` signal will be used, which
             is recovered via ``done = timeout | terminal``. In other words,

--- a/torchrl/data/postprocs/postprocs.py
+++ b/torchrl/data/postprocs/postprocs.py
@@ -201,7 +201,7 @@ class MultiStep(nn.Module):
 
         tensordict.set("steps_to_next_obs", time_to_obs + 1)
         tensordict.rename_key_(("next", "reward"), ("next", "original_reward"))
-        tensordict["next"].update(tensordict_gather)
+        tensordict.get("next").update(tensordict_gather)
         tensordict.set(("next", "reward"), summed_rewards)
         tensordict.set("gamma", self.gamma ** (time_to_obs + 1))
         nonterminal = time_to_obs != 0

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -561,7 +561,7 @@ class TensorDictPrioritizedReplayBuffer(TensorDictReplayBuffer):
             mini-batch of Tensor(s)/outputs.  Used when using batched loading
             from a map-style dataset.
         pin_memory (bool, optional): whether pin_memory() should be called on
-            the rb samples. Default is :obj:`False`.
+            the rb samples. Default is ``False``.
         prefetch (int, optional): number of next batches to be prefetched
             using multithreading.
         transform (Transform, optional): Transform to be executed when sample() is called.

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -76,7 +76,7 @@ class SamplerWithoutReplacement(Sampler):
     """A data-consuming sampler that ensures that the same sample is not present in consecutive batches.
 
     Args:
-        drop_last (bool, optional): if True, the last incomplete sample (if any) will be dropped.
+        drop_last (bool, optional): if ``True``, the last incomplete sample (if any) will be dropped.
             If False, this last sample will be kept and (unlike with torch dataloaders)
             completed with other samples from a fresh indices permutation.
 

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -2345,7 +2345,7 @@ class CompositeSpec(TensorSpec):
                 :obj:`CompositeSpec(next=CompositeSpec(obs=None))` will lead to the keys
                 :obj:`["next"]. Default is ``False``, i.e. nested keys will not
                 be returned.
-            leaves_only (bool, optional): if :obj:`False`, the values returned
+            leaves_only (bool, optional): if ``False``, the values returned
                 will contain every level of nesting, i.e. a :obj:`CompositeSpec(next=CompositeSpec(obs=None))`
                 will lead to the keys :obj:`["next", ("next", "obs")]`.
                 Default is ``False``.
@@ -2367,7 +2367,7 @@ class CompositeSpec(TensorSpec):
                 :obj:`CompositeSpec(next=CompositeSpec(obs=None))` will lead to the keys
                 :obj:`["next"]. Default is ``False``, i.e. nested keys will not
                 be returned.
-            leaves_only (bool, optional): if :obj:`False`, the values returned
+            leaves_only (bool, optional): if ``False``, the values returned
                 will contain every level of nesting, i.e. a :obj:`CompositeSpec(next=CompositeSpec(obs=None))`
                 will lead to the keys :obj:`["next", ("next", "obs")]`.
                 Default is ``False``.
@@ -2395,7 +2395,7 @@ class CompositeSpec(TensorSpec):
                 :obj:`CompositeSpec(next=CompositeSpec(obs=None))` will lead to the keys
                 :obj:`["next"]. Default is ``False``, i.e. nested keys will not
                 be returned.
-            leaves_only (bool, optional): if :obj:`False`, the values returned
+            leaves_only (bool, optional): if ``False``, the values returned
                 will contain every level of nesting, i.e. a :obj:`CompositeSpec(next=CompositeSpec(obs=None))`
                 will lead to the keys :obj:`["next", ("next", "obs")]`.
                 Default is ``False``.

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -127,7 +127,7 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
         - reward_spec (TensorSpec): sampling spec of the rewards;
         - batch_size (torch.Size): number of environments contained in the instance;
         - device (torch.device): device where the env input and output are expected to live
-        - run_type_checks (bool): if True, the observation and reward dtypes
+        - run_type_checks (bool): if ``True``, the observation and reward dtypes
             will be compared against their respective spec and an exception
             will be raised if they don't match.
             Defaults to False.
@@ -538,7 +538,7 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
 
         Args:
             seed (int): seed to be set
-            static_seed (bool, optional): if True, the seed is not incremented.
+            static_seed (bool, optional): if ``True``, the seed is not incremented.
                 Defaults to False
 
         Returns:
@@ -651,11 +651,11 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
                 actions will be called using :obj:`env.rand_step()`
                 default = None
             callback (callable, optional): function to be called at each iteration with the given TensorDict.
-            auto_reset (bool, optional): if True, resets automatically the environment
+            auto_reset (bool, optional): if ``True``, resets automatically the environment
                 if it is in a done state when the rollout is initiated.
                 Default is :obj:`True`.
-            auto_cast_to_device (bool, optional): if True, the device of the tensordict is automatically cast to the
-                policy device before the policy is used. Default is :obj:`False`.
+            auto_cast_to_device (bool, optional): if ``True``, the device of the tensordict is automatically cast to the
+                policy device before the policy is used. Default is ``False``.
             break_when_any_done (bool): breaks if any of the done state is True. If False, a reset() is
                 called on the sub-envs that are done. Default is True.
             return_contiguous (bool): if False, a LazyStackedTensorDict will be returned. Default is True.

--- a/torchrl/envs/libs/dm_control.py
+++ b/torchrl/envs/libs/dm_control.py
@@ -116,7 +116,7 @@ class DMControlWrapper(GymLikeEnv):
 
     Args:
         env (dm_control.suite env): environment instance
-        from_pixels (bool): if True, the observation
+        from_pixels (bool): if ``True``, the observation
 
     Examples:
         >>> env = dm_control.suite.load("cheetah", "run")
@@ -272,7 +272,7 @@ class DMControlEnv(DMControlWrapper):
         env_name (str): name of the environment
         task_name (str): name of the task
         seed (int, optional): seed to use for the environment
-        from_pixels (bool, optional): if True, the observation will be returned
+        from_pixels (bool, optional): if ``True``, the observation will be returned
             as an image.
             Default is False.
 

--- a/torchrl/envs/libs/utils.py
+++ b/torchrl/envs/libs/utils.py
@@ -37,7 +37,7 @@ class GymPixelObservationWrapper(ObservationWrapper):
         env: The environment to wrap.
         pixels_only: If :obj:`True` (default), the original observation returned
             by the wrapped environment will be discarded, and a dictionary
-            observation will only include pixels. If :obj:`False`, the
+            observation will only include pixels. If ``False``, the
             observation dictionary will contain both the original
             observations and the pixel observations.
         render_kwargs: Optional :obj:`dict` containing keyword arguments passed

--- a/torchrl/envs/transforms/r3m.py
+++ b/torchrl/envs/transforms/r3m.py
@@ -215,7 +215,7 @@ class R3MTransform(Compose):
              argument will be treaded separetely and each will be given a single,
              separated entry in the output tensordict. Defaults to :obj:`True`.
         download (bool, torchvision Weights config or corresponding string):
-            if True, the weights will be downloaded using the torch.hub download
+            if ``True``, the weights will be downloaded using the torch.hub download
             API (i.e. weights will be cached for future use).
             These weights are the original weights from the R3M publication.
             If the torchvision weights are needed, there are two ways they can be

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -396,7 +396,7 @@ class TransformedEnv(EnvBase):
         transform (Transform, optional): transform to apply to the tensordict resulting
             from :obj:`env.step(td)`. If none is provided, an empty Compose
             placeholder in an eval mode is used.
-        cache_specs (bool, optional): if True, the specs will be cached once
+        cache_specs (bool, optional): if ``True``, the specs will be cached once
             and for all after the first call (i.e. the specs will be
             transformed_in only once). If the transform changes during
             training, the original spec transform may not be valid anymore,
@@ -880,7 +880,7 @@ class ToTensorImage(ObservationTransform):
     with values between 0 and 1.
 
     Args:
-        unsqueeze (bool): if True, the observation tensor is unsqueezed
+        unsqueeze (bool): if ``True``, the observation tensor is unsqueezed
             along the first dimension. default=False.
         dtype (torch.dtype, optional): dtype to use for the resulting
             observations.
@@ -1154,7 +1154,7 @@ class FlattenObservation(ObservationTransform):
             :obj:`["pixels"]` is assumed.
         out_keys (sequence of str, optional): the flatten observation keys. If none is
             provided, :obj:`in_keys` is assumed.
-        allow_positive_dim (bool, optional): if True, positive dimensions are accepted.
+        allow_positive_dim (bool, optional): if ``True``, positive dimensions are accepted.
             :obj:`FlattenObservation` will map these to the n^th feature dimension
             (ie n^th dimension after batch size of parent env) of the input tensor.
             Defaults to False, ie. non-negative dimensions are not permitted.
@@ -1229,7 +1229,7 @@ class UnsqueezeTransform(Transform):
     Args:
         unsqueeze_dim (int): dimension to unsqueeze. Must be negative (or allow_positive_dim
             must be turned on).
-        allow_positive_dim (bool, optional): if True, positive dimensions are accepted.
+        allow_positive_dim (bool, optional): if ``True``, positive dimensions are accepted.
             :obj:`UnsqueezeTransform` will map these to the n^th feature dimension
             (ie n^th dimension after batch size of parent env) of the input tensor,
             independently from the tensordict batch size (ie positive dims may be
@@ -1414,7 +1414,7 @@ class ObservationNorm(ObservationTransform):
             only the forward transform will be called.
         out_keys_inv (list of int, optional): output entries for the inverse transform.
             Defaults to the value of `in_keys_inv`.
-        standard_normal (bool, optional): if True, the transform will be
+        standard_normal (bool, optional): if ``True``, the transform will be
 
             .. math::
                 obs = (obs-loc)/scale
@@ -1831,7 +1831,7 @@ class RewardScaling(Transform):
     Args:
         loc (number or torch.Tensor): location of the affine transform
         scale (number or torch.Tensor): scale of the affine transform
-        standard_normal (bool, optional): if True, the transform will be
+        standard_normal (bool, optional): if ``True``, the transform will be
 
             .. math::
                 reward = (reward-loc)/scale
@@ -1993,9 +1993,9 @@ class CatTensors(Transform):
         out_key: key of the resulting tensor.
         dim (int, optional): dimension along which the concatenation will occur.
             Default is -1.
-        del_keys (bool, optional): if True, the input values will be deleted after
+        del_keys (bool, optional): if ``True``, the input values will be deleted after
             concatenation. Default is True.
-        unsqueeze_if_oor (bool, optional): if True, CatTensor will check that
+        unsqueeze_if_oor (bool, optional): if ``True``, CatTensor will check that
             the dimension indicated exist for the tensors to concatenate. If not,
             the tensors will be unsqueezed along that dimension.
             Default is False.
@@ -2168,7 +2168,7 @@ class DiscreteActionProjection(Transform):
         num_actions_effective (int): max number of action considered.
         max_actions (int): maximum number of actions that this module can read.
         action_key (str, optional): key name of the action. Defaults to "action".
-        include_forward (bool, optional): if True, a call to forward will also
+        include_forward (bool, optional): if ``True``, a call to forward will also
             map the action from one domain to the other when the module is called
             by a replay buffer or an nn.Module chain. Defaults to True.
 
@@ -2383,7 +2383,7 @@ class TensorDictPrimer(Transform):
     Args:
         primers (dict, optional): a dictionary containing key-spec pairs which will
             be used to populate the input tensordict.
-        random (bool, optional): if True, the values will be drawn randomly from
+        random (bool, optional): if ``True``, the values will be drawn randomly from
             the TensorSpec domain (or a unit Gaussian if unbounded). Otherwise a fixed value will be assumed.
             Defaults to `False`.
         default_value (float, optional): if non-random filling is chosen, this
@@ -2771,7 +2771,7 @@ class VecNorm(Transform):
                 tensordict
             keys (iterable of str, optional): keys that
                 have to be normalized. Default is `["next", "reward"]`
-            memmap (bool): if True, the resulting tensordict will be cast into
+            memmap (bool): if ``True``, the resulting tensordict will be cast into
                 memmory map (using `memmap_()`). Otherwise, the tensordict
                 will be placed in shared memory.
 

--- a/torchrl/envs/transforms/vip.py
+++ b/torchrl/envs/transforms/vip.py
@@ -181,7 +181,7 @@ class VIPTransform(Compose):
              argument will be treaded separetely and each will be given a single,
              separated entry in the output tensordict. Defaults to :obj:`True`.
         download (bool, torchvision Weights config or corresponding string):
-            if True, the weights will be downloaded using the torch.hub download
+            if ``True``, the weights will be downloaded using the torch.hub download
             API (i.e. weights will be cached for future use).
             These weights are the original weights from the VIP publication.
             If the torchvision weights are needed, there are two ways they can be

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -39,17 +39,17 @@ def step_mdp(
     Args:
         tensordict (TensorDictBase): tensordict with keys to be renamed
         next_tensordict (TensorDictBase, optional): destination tensordict
-        keep_other (bool, optional): if True, all keys that do not start with :obj:`'next_'` will be kept.
+        keep_other (bool, optional): if ``True``, all keys that do not start with :obj:`'next_'` will be kept.
             Default is ``True``.
-        exclude_reward (bool, optional): if True, the :obj:`"reward"` key will be discarded
+        exclude_reward (bool, optional): if ``True``, the :obj:`"reward"` key will be discarded
             from the resulting tensordict. If ``False``, it will be copied (and replaced)
             from the ``"next"`` entry (if present).
             Default is ``False``.
-        exclude_done (bool, optional): if True, the :obj:`"done"` key will be discarded
+        exclude_done (bool, optional): if ``True``, the :obj:`"done"` key will be discarded
             from the resulting tensordict. If ``False``, it will be copied (and replaced)
             from the ``"next"`` entry (if present).
             Default is ``False``.
-        exclude_action (bool, optional): if True, the :obj:`"action"` key will
+        exclude_action (bool, optional): if ``True``, the :obj:`"action"` key will
             be discarded from the resulting tensordict. If ``False``, it will
             be kept in the root tensordict (since it should not be present in
             the ``"next"`` entry).
@@ -232,7 +232,7 @@ def check_env_specs(env, return_contiguous=True, check_dtype=True, seed=0):
 
     Args:
         env (EnvBase): the env for which the specs have to be checked against data.
-        return_contiguous (bool, optional): if True, the random rollout will be called with
+        return_contiguous (bool, optional): if ``True``, the random rollout will be called with
             return_contiguous=True. This will fail in some cases (e.g. heterogeneous shapes
             of inputs/outputs). Defaults to True.
         check_dtype (bool, optional): if False, dtype checks will be skipped.

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -107,7 +107,7 @@ class _BatchedEnv(EnvBase):
             needed, which comes with a slight compute overhead;
         create_env_kwargs (dict or list of dicts, optional): kwargs to be used with the environments being created;
         pin_memory (bool): if True and device is "cpu", calls :obj:`pin_memory` on the tensordicts when created.
-        share_individual_td (bool, optional): if True, a different tensordict is created for every process/worker and a lazy
+        share_individual_td (bool, optional): if ``True``, a different tensordict is created for every process/worker and a lazy
             stack is returned.
             default = None (False if single task);
         shared_memory (bool): whether or not the returned tensordict will be placed in shared memory;
@@ -119,9 +119,9 @@ class _BatchedEnv(EnvBase):
             It is assumed that all environments will run on the same device as a common shared
             tensordict will be used to pass data from process to process. The device can be
             changed after instantiation using :obj:`env.to(device)`.
-        allow_step_when_done (bool, optional): if True, batched environments can
+        allow_step_when_done (bool, optional): if ``True``, batched environments can
             execute steps after a done state is encountered.
-            Defaults to :obj:`False`.
+            Defaults to ``False``.
 
     """
 

--- a/torchrl/modules/models/models.py
+++ b/torchrl/modules/models/models.py
@@ -172,7 +172,6 @@ class MLP(nn.Sequential):
 
         _out_features_num = out_features
         if not isinstance(out_features, Number):
-            print(out_features, type(out_features))
             _out_features_num = prod(out_features)
         self.out_features = out_features
         self._out_features_num = _out_features_num
@@ -725,7 +724,7 @@ class DdpgCnnActor(nn.Module):
             'bias_last_layer': True,
         }
         use_avg_pooling (bool, optional): if ``True``, a nn.AvgPooling layer is
-            used to aggregate the output. Default is :obj:`False`.
+            used to aggregate the output. Default is ``False``.
         device (Optional[DEVICE_TYPING]): device to create the module on.
     """
 

--- a/torchrl/modules/planners/mppi.py
+++ b/torchrl/modules/planners/mppi.py
@@ -46,7 +46,7 @@ class MPPIPlanner(MPCPlannerBase):
         >>> from torchrl.data import CompositeSpec, NdUnboundedContinuousTensorSpec
         >>> from torchrl.envs.model_based import ModelBasedEnvBase
         >>> from torchrl.modules import TensorDictModule, ValueOperator
-        >>> from torchrl.objectives.value import TDLambdaEstimate
+        >>> from torchrl.objectives.value import TDLambdaEstimator
         >>> class MyMBEnv(ModelBasedEnvBase):
         ...     def __init__(self, world_model, device="cpu", dtype=None, batch_size=None):
         ...         super().__init__(world_model, device=device, dtype=dtype, batch_size=batch_size)
@@ -87,7 +87,7 @@ class MPPIPlanner(MPCPlannerBase):
         >>> env = MyMBEnv(world_model)
         >>> value_net = nn.Linear(4, 1)
         >>> value_net = ValueOperator(value_net, in_keys=["hidden_observation"])
-        >>> adv = TDLambdaEstimate(
+        >>> adv = TDLambdaEstimator(
         ...     0.99,
         ...     0.95,
         ...     value_net,

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -52,7 +52,7 @@ class Actor(SafeModule):
             occur because of exploration policies or numerical under/overflow
             issues. If this value is out of bounds, it is projected back onto the
             desired space using the :obj:`TensorSpec.project`
-            method. Default is :obj:`False`.
+            method. Default is ``False``.
 
     Examples:
         >>> import torch
@@ -142,7 +142,7 @@ class ProbabilisticActor(SafeProbabilisticTensorDictSequential):
             occur because of exploration policies or numerical under/overflow
             issues. If this value is out of bounds, it is projected back onto the
             desired space using the :obj:`TensorSpec.project`
-            method. Default is :obj:`False`.
+            method. Default is ``False``.
         default_interaction_mode (str, optional): keyword-only argument.
             Default method to be used to retrieve
             the output value. Should be one of: 'mode', 'median', 'mean' or 'random'
@@ -586,7 +586,7 @@ class QValueActor(Actor):
             occur because of exploration policies or numerical under/overflow
             issues. If this value is out of bounds, it is projected back onto the
             desired space using the :obj:`TensorSpec.project`
-            method. Default is :obj:`False`.
+            method. Default is ``False``.
         action_space (str, optional): The action space to be considered.
             Must be one of
             ``"one-hot"``, ``"mult_one_hot"``, ``"binary"`` or ``"categorical"``.
@@ -659,7 +659,7 @@ class DistributionalQValueActor(QValueActor):
             occur because of exploration policies or numerical under/overflow
             issues. If this value is out of bounds, it is projected back onto the
             desired space using the :obj:`TensorSpec.project`
-            method. Default is :obj:`False`.
+            method. Default is ``False``.
         support (torch.Tensor): support of the action values.
         action_space (str, optional): The action space to be considered.
             Must be one of

--- a/torchrl/modules/tensordict_module/common.py
+++ b/torchrl/modules/tensordict_module/common.py
@@ -119,7 +119,7 @@ class SafeModule(TensorDictModule):
             occur because of exploration policies or numerical under/overflow issues.
             If this value is out of bounds, it is projected back onto the
             desired space using the :obj:`TensorSpec.project`
-            method. Default is :obj:`False`.
+            method. Default is ``False``.
 
     Embedding a neural network in a TensorDictModule only requires to specify the input and output keys. The domain spec can
         be passed along if needed. TensorDictModule support functional and regular :obj:`nn.Module` objects. In the functional

--- a/torchrl/modules/tensordict_module/probabilistic.py
+++ b/torchrl/modules/tensordict_module/probabilistic.py
@@ -65,7 +65,7 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule):
             check will only occur for the distribution sample, but not the other tensors
             returned by the input module. If the sample is out of bounds, it is
             projected back onto the desired space using the `TensorSpec.project` method.
-            Default is :obj:`False`.
+            Default is ``False``.
         default_interaction_mode (str, optional): default method to be used to retrieve
             the output value. Should be one of: 'mode', 'median', 'mean' or 'random'
             (in which case the value is sampled randomly from the distribution). Default

--- a/torchrl/modules/tensordict_module/sequence.py
+++ b/torchrl/modules/tensordict_module/sequence.py
@@ -13,7 +13,7 @@ from torchrl.modules.tensordict_module.common import SafeModule
 
 
 class SafeSequential(TensorDictSequential, SafeModule):
-    """A sequence of TensorDictModules.
+    """A safe sequence of TensorDictModules.
 
     Similarly to :obj:`nn.Sequence` which passes a tensor through a chain of mappings that read and write a single tensor
     each, this module will read and write over a tensordict by querying each of the input modules.

--- a/torchrl/objectives/__init__.py
+++ b/torchrl/objectives/__init__.py
@@ -22,7 +22,7 @@ from .utils import (
     hold_out_params,
     next_state_value,
     SoftUpdate,
-    ValueFunctions,
+    ValueEstimators,
 )
 
 # from .value import bellman_max, c_val, dv_val, vtrace, GAE, TDLambdaEstimate, TDEstimate

--- a/torchrl/objectives/__init__.py
+++ b/torchrl/objectives/__init__.py
@@ -15,12 +15,14 @@ from .reinforce import ReinforceLoss
 from .sac import DiscreteSACLoss, SACLoss
 from .td3 import TD3Loss
 from .utils import (
+    default_value_kwargs,
     distance_loss,
     HardUpdate,
     hold_out_net,
     hold_out_params,
     next_state_value,
     SoftUpdate,
+    ValueFunctions,
 )
 
 # from .value import bellman_max, c_val, dv_val, vtrace, GAE, TDLambdaEstimate, TDEstimate

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -155,7 +155,7 @@ class A2CLoss(LossModule):
         if advantage is None:
             self.value_estimator(
                 tensordict,
-                params=self.critic_params,
+                params=self.critic_params.detach(),
                 target_params=self.target_critic_params,
             )
             advantage = tensordict.get(self.advantage_key)

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -153,7 +153,7 @@ class A2CLoss(LossModule):
         tensordict = tensordict.clone(False)
         advantage = tensordict.get(self.advantage_key, None)
         if advantage is None:
-            self.value_function(
+            self.value_estimator(
                 tensordict,
                 params=self.critic_params,
                 target_params=self.target_critic_params,
@@ -178,19 +178,19 @@ class A2CLoss(LossModule):
             hp["gamma"] = self.gamma
         value_key = "state_value"
         if value_type == ValueEstimators.TD1:
-            self._value_function = TD1Estimator(
+            self._value_estimator = TD1Estimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.TD0:
-            self._value_function = TD0Estimator(
+            self._value_estimator = TD0Estimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.GAE:
-            self._value_function = GAE(
+            self._value_estimator = GAE(
                 value_network=self.critic, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.TDLambda:
-            self._value_function = TDLambdaEstimator(
+            self._value_estimator = TDLambdaEstimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
         else:

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -15,9 +15,9 @@ from torchrl.objectives.utils import (
     _GAMMA_LMBDA_DEPREC_WARNING,
     default_value_kwargs,
     distance_loss,
-    ValueFunctions,
+    ValueEstimators,
 )
-from torchrl.objectives.value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
+from torchrl.objectives.value import GAE, TD0Estimator, TD1Estimator, TDLambdaEstimator
 
 
 class A2CLoss(LossModule):
@@ -57,13 +57,13 @@ class A2CLoss(LossModule):
       If the advantage key (``"advantage`` by default) is not present in the
       input tensordict, the advantage will be computed by the :meth:`~.forward`
       method.
-      A custom advantage module can be built using :meth:`~.make_value_function`.
+      A custom advantage module can be built using :meth:`~.make_value_estimator`.
       The default is :class:`torchrl.objectives.value.GAE` with hyperparameters
       dictated by :func:`torchrl.objectives.utils.default_value_kwargs`.
 
     """
 
-    default_value_type: ValueFunctions = ValueFunctions.GAE
+    default_value_estimator: ValueEstimators = ValueEstimators.GAE
 
     def __init__(
         self,
@@ -171,26 +171,26 @@ class A2CLoss(LossModule):
             td_out.set("loss_critic", loss_critic.mean())
         return td_out
 
-    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+    def make_value_estimator(self, value_type: ValueEstimators, **hyperparams):
         hp = dict(default_value_kwargs(value_type))
         hp.update(hyperparams)
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         value_key = "state_value"
-        if value_type == ValueFunctions.TD1:
-            self._value_function = TD1Estimate(
+        if value_type == ValueEstimators.TD1:
+            self._value_function = TD1Estimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.TD0:
-            self._value_function = TD0Estimate(
+        elif value_type == ValueEstimators.TD0:
+            self._value_function = TD0Estimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.GAE:
+        elif value_type == ValueEstimators.GAE:
             self._value_function = GAE(
                 value_network=self.critic, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.TDLambda:
-            self._value_function = TDLambdaEstimate(
+        elif value_type == ValueEstimators.TDLambda:
+            self._value_function = TDLambdaEstimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
         else:

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -54,7 +54,7 @@ class LossModule(nn.Module):
         The value estimator can be changed using the :meth:`~.make_value_function` method.
     """
 
-    default_value_type: ValueFunctions = None
+    default_value_function: ValueFunctions = None
 
     def __init__(self):
         super().__init__()
@@ -383,7 +383,7 @@ class LossModule(nn.Module):
         from :obj:`torchrl.objectives.utils.DEFAULT_VALUE_FUN_PARAMS`.
 
         """
-        self.make_value_function(self.default_value_type)
+        self.make_value_function(self.default_value_function)
 
     def make_value_function(self, value_type: ValueFunctions, **hyperparams):
         """Value-function constructor.

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -47,7 +47,14 @@ class LossModule(nn.Module):
     the various loss values throughout
     training. Other scalars present in the output tensordict will be logged too.
 
+    :cvar defaylt_value_type: The default value type of the class.
+        Losses that require a value estimation are equipped with a default value
+        pointer. This class attribute indicates which value estimator will be
+        used if none other is specified.
+        The value estimator can be changed using the :meth:`~.make_value_function` method.
     """
+
+    default_value_type: ValueFunctions = None
 
     def __init__(self):
         super().__init__()
@@ -358,6 +365,7 @@ class LossModule(nn.Module):
 
     @property
     def value_function(self) -> ValueFunctionBase:
+        """The value function blends in the reward and value estimate(s) from upcoming state(s)/state-action pair(s) into a target value estimate for the value network."""
         out = self._value_function
         if out is None:
             self._default_value_function()
@@ -375,7 +383,7 @@ class LossModule(nn.Module):
         from :obj:`torchrl.objectives.utils.DEFAULT_VALUE_FUN_PARAMS`.
 
         """
-        raise NotImplementedError
+        self.make_value_function(self.default_value_type)
 
     def make_value_function(self, value_type: ValueFunctions, **hyperparams):
         """Value-function constructor.

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -79,8 +79,7 @@ class LossModule(nn.Module):
         compare_against: Optional[List[Parameter]] = None,
         funs_to_decorate=None,
     ) -> None:
-        """Converts a module to functional to be used in the loss.
-        """
+        """Converts a module to functional to be used in the loss."""
         if funs_to_decorate is None:
             funs_to_decorate = ["forward"]
         # To make it robust to device casting, we must register list of

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -18,8 +18,8 @@ from torch import nn, Tensor
 from torch.nn import Parameter
 
 from torchrl.modules.utils import Buffer
-from torchrl.objectives.utils import ValueFunctions
-from torchrl.objectives.value import ValueFunctionBase
+from torchrl.objectives.utils import ValueEstimators
+from torchrl.objectives.value import ValueEstimatorBase
 
 _has_functorch = False
 try:
@@ -51,10 +51,10 @@ class LossModule(nn.Module):
         Losses that require a value estimation are equipped with a default value
         pointer. This class attribute indicates which value estimator will be
         used if none other is specified.
-        The value estimator can be changed using the :meth:`~.make_value_function` method.
+        The value estimator can be changed using the :meth:`~.make_value_estimator` method.
     """
 
-    default_value_function: ValueFunctions = None
+    default_value_estimator: ValueEstimators = None
 
     def __init__(self):
         super().__init__()
@@ -364,11 +364,11 @@ class LossModule(nn.Module):
         return self.to(torch.device("cpu"))
 
     @property
-    def value_function(self) -> ValueFunctionBase:
+    def value_function(self) -> ValueEstimatorBase:
         """The value function blends in the reward and value estimate(s) from upcoming state(s)/state-action pair(s) into a target value estimate for the value network."""
         out = self._value_function
         if out is None:
-            self._default_value_function()
+            self._default_value_estimator()
             return self._value_function
         return out
 
@@ -376,23 +376,23 @@ class LossModule(nn.Module):
     def value_function(self, value):
         self._value_function = value
 
-    def _default_value_function(self):
+    def _default_value_estimator(self):
         """A value-function constructor when none is provided.
 
         No kwarg should be present as default parameters should be retrieved
         from :obj:`torchrl.objectives.utils.DEFAULT_VALUE_FUN_PARAMS`.
 
         """
-        self.make_value_function(self.default_value_function)
+        self.make_value_estimator(self.default_value_estimator)
 
-    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+    def make_value_estimator(self, value_type: ValueEstimators, **hyperparams):
         """Value-function constructor.
 
         If the non-default value function is wanted, it must be built using
         this method.
 
         Args:
-            value_type (ValueFunctions): A :class:`torchrl.objectives.utils.ValueFunctions`
+            value_type (ValueEstimators): A :class:`torchrl.objectives.utils.ValueFunctions`
                 enum type indicating the value function to use.
             **hyperparams: hyperparameters to use for the value function.
                 If not provided, the value indicated by
@@ -402,24 +402,24 @@ class LossModule(nn.Module):
         Examples:
             >>> # initialize the DQN loss
             >>> dqn_loss = DQNLoss(actor)
-            >>> dqn_loss.make_value_function(
-            ...     ValueFunctions.TD1,
+            >>> dqn_loss.make_value_estimator(
+            ...     ValueEstimators.TD1,
             ...     gamma=0.9)
 
         """
-        if value_type == ValueFunctions.TD1:
+        if value_type == ValueEstimators.TD1:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
-        elif value_type == ValueFunctions.TD0:
+        elif value_type == ValueEstimators.TD0:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
-        elif value_type == ValueFunctions.GAE:
+        elif value_type == ValueEstimators.GAE:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
-        elif value_type == ValueFunctions.TDLambda:
+        elif value_type == ValueEstimators.TDLambda:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -18,6 +18,7 @@ from torch import nn, Tensor
 from torch.nn import Parameter
 
 from torchrl.modules.utils import Buffer
+from torchrl.objectives.utils import ValueFunctions
 from torchrl.objectives.value import ValueFunctionBase
 
 _has_functorch = False
@@ -362,3 +363,42 @@ class LossModule(nn.Module):
 
         """
         raise NotImplementedError
+
+    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+        """Value-function constructor.
+
+        If the non-default value function is wanted, it must be built using
+        this method.
+
+        Args:
+            value_type (ValueFunctions): A :class:`torchrl.objectives.utils.ValueFunctions`
+                enum type indicating the value function to use.
+            **hyperparams: hyperparameters to use for the value function.
+                If not provided, the value indicated by
+                :func:`torchrl.objectives.utils.default_value_kwargs` will be
+                used.
+
+        Examples:
+            >>> # initialize the DQN loss
+            >>> dqn_loss = DQNLoss(actor)
+            >>> dqn_loss.make_value_function(
+            ...     ValueFunctions.TD1,
+            ...     gamma=0.9)
+
+        """
+        if value_type == ValueFunctions.TD1:
+            raise NotImplementedError(f"Value type {value_type} it not implemented for loss {type(self)}.")
+        elif value_type == ValueFunctions.TD0:
+            raise NotImplementedError(
+                f"Value type {value_type} it not implemented for loss {type(self)}."
+                )
+        elif value_type == ValueFunctions.GAE:
+            raise NotImplementedError(
+                f"Value type {value_type} it not implemented for loss {type(self)}."
+                )
+        elif value_type == ValueFunctions.TDLambda:
+            raise NotImplementedError(
+                f"Value type {value_type} it not implemented for loss {type(self)}."
+                )
+        else:
+            raise NotImplementedError(f"Unknown value type {value_type}")

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -18,6 +18,7 @@ from torch import nn, Tensor
 from torch.nn import Parameter
 
 from torchrl.modules.utils import Buffer
+from torchrl.objectives.value import ValueFunctionBase
 
 _has_functorch = False
 try:
@@ -353,3 +354,12 @@ class LossModule(nn.Module):
 
     def cpu(self) -> LossModule:
         return self.to(torch.device("cpu"))
+
+    def _default_value_function(self) -> ValueFunctionBase:
+        """A value-function constructor when none is provided.
+
+        No kwarg should be present as default parameters should be retrieved
+        from :obj:`torchrl.objectives.utils.DEFAULT_VALUE_FUN_PARAMS`.
+
+        """
+        raise NotImplementedError

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -59,7 +59,7 @@ class LossModule(nn.Module):
     def __init__(self):
         super().__init__()
         self._param_maps = {}
-        self._value_function = None
+        self._value_estimator = None
         # self.register_forward_pre_hook(_parameters_to_tensordict)
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
@@ -364,17 +364,17 @@ class LossModule(nn.Module):
         return self.to(torch.device("cpu"))
 
     @property
-    def value_function(self) -> ValueEstimatorBase:
+    def value_estimator(self) -> ValueEstimatorBase:
         """The value function blends in the reward and value estimate(s) from upcoming state(s)/state-action pair(s) into a target value estimate for the value network."""
-        out = self._value_function
+        out = self._value_estimator
         if out is None:
             self._default_value_estimator()
-            return self._value_function
+            return self._value_estimator
         return out
 
-    @value_function.setter
-    def value_function(self, value):
-        self._value_function = value
+    @value_estimator.setter
+    def value_estimator(self, value):
+        self._value_estimator = value
 
     def _default_value_estimator(self):
         """A value-function constructor when none is provided.

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -37,9 +37,12 @@ except ImportError:
 class LossModule(nn.Module):
     """A parent class for RL losses.
 
-    LossModule inherits from nn.Module. It is designed to read an input TensorDict and return another tensordict
-    with loss keys named "loss_*".
-    Splitting the loss in its component can then be used by the trainer to log the various loss values throughout
+    LossModule inherits from nn.Module. It is designed to read an input
+    TensorDict and return another tensordict
+    with loss keys named ``"loss_*"``.
+
+    Splitting the loss in its component can then be used by the trainer to log
+    the various loss values throughout
     training. Other scalars present in the output tensordict will be logged too.
 
     """
@@ -75,6 +78,8 @@ class LossModule(nn.Module):
         compare_against: Optional[List[Parameter]] = None,
         funs_to_decorate=None,
     ) -> None:
+        """Converts a module to functional to be used in the loss.
+        """
         if funs_to_decorate is None:
             funs_to_decorate = ["forward"]
         # To make it robust to device casting, we must register list of

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -52,6 +52,7 @@ class LossModule(nn.Module):
     def __init__(self):
         super().__init__()
         self._param_maps = {}
+        self._value_function = None
         # self.register_forward_pre_hook(_parameters_to_tensordict)
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
@@ -355,7 +356,19 @@ class LossModule(nn.Module):
     def cpu(self) -> LossModule:
         return self.to(torch.device("cpu"))
 
-    def _default_value_function(self) -> ValueFunctionBase:
+    @property
+    def value_function(self) -> ValueFunctionBase:
+        out = self._value_function
+        if out is None:
+            self._default_value_function()
+            return self._value_function
+        return out
+
+    @value_function.setter
+    def value_function(self, value):
+        self._value_function = value
+
+    def _default_value_function(self):
         """A value-function constructor when none is provided.
 
         No kwarg should be present as default parameters should be retrieved
@@ -387,18 +400,20 @@ class LossModule(nn.Module):
 
         """
         if value_type == ValueFunctions.TD1:
-            raise NotImplementedError(f"Value type {value_type} it not implemented for loss {type(self)}.")
+            raise NotImplementedError(
+                f"Value type {value_type} it not implemented for loss {type(self)}."
+            )
         elif value_type == ValueFunctions.TD0:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
-                )
+            )
         elif value_type == ValueFunctions.GAE:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
-                )
+            )
         elif value_type == ValueFunctions.TDLambda:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
-                )
+            )
         else:
             raise NotImplementedError(f"Unknown value type {value_type}")

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -20,12 +20,12 @@ from torchrl.objectives.utils import (
     default_value_kwargs,
     distance_loss,
     hold_out_params,
-    ValueFunctions,
+    ValueEstimators,
 )
 
 from ..envs.utils import set_exploration_mode
 from .common import LossModule
-from .value import TD0Estimate, TD1Estimate, TDLambdaEstimate
+from .value import TD0Estimator, TD1Estimator, TDLambdaEstimator
 
 
 class DDPGLoss(LossModule):
@@ -41,7 +41,7 @@ class DDPGLoss(LossModule):
             data collection. Default is ``False``.
     """
 
-    default_value_type: ValueFunctions = ValueFunctions.TD0
+    default_value_estimator: ValueEstimators = ValueEstimators.TD0
 
     def __init__(
         self,
@@ -180,26 +180,26 @@ class DDPGLoss(LossModule):
 
         return loss_value, (pred_val - target_value).pow(2), pred_val, target_value
 
-    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+    def make_value_estimator(self, value_type: ValueEstimators, **hyperparams):
         hp = dict(default_value_kwargs(value_type))
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
         value_key = "state_action_value"
-        if value_type == ValueFunctions.TD1:
-            self._value_function = TD1Estimate(
+        if value_type == ValueEstimators.TD1:
+            self._value_function = TD1Estimator(
                 value_network=self.actor_critic, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.TD0:
-            self._value_function = TD0Estimate(
+        elif value_type == ValueEstimators.TD0:
+            self._value_function = TD0Estimator(
                 value_network=self.actor_critic, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.GAE:
+        elif value_type == ValueEstimators.GAE:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
-        elif value_type == ValueFunctions.TDLambda:
-            self._value_function = TDLambdaEstimate(
+        elif value_type == ValueEstimators.TDLambda:
+            self._value_function = TDLambdaEstimator(
                 value_network=self.actor_critic, value_key=value_key, **hp
             )
         else:

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -14,10 +14,16 @@ from tensordict.nn import make_functional, repopulate_module, TensorDictModule
 from tensordict.tensordict import TensorDict, TensorDictBase
 
 from torchrl.modules.tensordict_module.actors import ActorCriticWrapper
-from torchrl.objectives.utils import distance_loss, hold_out_params, next_state_value
+from torchrl.objectives.utils import (
+    default_value_kwargs,
+    distance_loss,
+    hold_out_params,
+    ValueFunctions,
+)
 
 from ..envs.utils import set_exploration_mode
 from .common import LossModule
+from .value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
 
 
 class DDPGLoss(LossModule):
@@ -26,21 +32,20 @@ class DDPGLoss(LossModule):
     Args:
         actor_network (TensorDictModule): a policy operator.
         value_network (TensorDictModule): a Q value operator.
-        gamma (scalar): a discount factor for return computation.
-        device (str, int or torch.device, optional): a device where the losses will be computed, if it can't be found
-            via the value operator.
         loss_function (str): loss function for the value discrepancy. Can be one of "l1", "l2" or "smooth_l1".
         delay_actor (bool, optional): whether to separate the target actor networks from the actor networks used for
-            data collection. Default is :obj:`False`.
+            data collection. Default is ``False``.
         delay_value (bool, optional): whether to separate the target value networks from the value networks used for
-            data collection. Default is :obj:`False`.
+            data collection. Default is ``False``.
     """
+
+    default_value_type: ValueFunctions = ValueFunctions.TD0
 
     def __init__(
         self,
         actor_network: TensorDictModule,
         value_network: TensorDictModule,
-        gamma: float,
+        *,
         loss_function: str = "l2",
         delay_actor: bool = False,
         delay_value: bool = False,
@@ -71,7 +76,6 @@ class DDPGLoss(LossModule):
 
         self.actor_in_keys = actor_network.in_keys
 
-        self.register_buffer("gamma", torch.tensor(gamma))
         self.loss_funtion = loss_function
 
     def forward(self, input_tensordict: TensorDictBase) -> TensorDict:
@@ -147,7 +151,6 @@ class DDPGLoss(LossModule):
         )
         pred_val = td_copy.get("state_action_value").squeeze(-1)
 
-        actor_critic = self.actor_critic
         target_params = TensorDict(
             {
                 "module": {
@@ -159,12 +162,9 @@ class DDPGLoss(LossModule):
             device=self.target_actor_network_params.device,
         )
         with set_exploration_mode("mode"):
-            target_value = next_state_value(
-                tensordict,
-                actor_critic,
-                gamma=self.gamma,
-                params=target_params,
-            )
+            target_value = self.value_function.value_estimate(
+                tensordict, target_params=target_params
+            ).squeeze(-1)
 
         # td_error = pred_val - target_value
         loss_value = distance_loss(
@@ -172,3 +172,26 @@ class DDPGLoss(LossModule):
         )
 
         return loss_value, (pred_val - target_value).pow(2), pred_val, target_value
+
+    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+        hp = dict(default_value_kwargs(value_type))
+        hp.update(hyperparams)
+        value_key = "state_action_value"
+        if value_type == ValueFunctions.TD1:
+            self._value_function = TD1Estimate(
+                value_network=self.actor_critic, value_key=value_key, **hp
+            )
+        elif value_type == ValueFunctions.TD0:
+            self._value_function = TD0Estimate(
+                value_network=self.actor_critic, value_key=value_key, **hp
+            )
+        elif value_type == ValueFunctions.GAE:
+            raise NotImplementedError(
+                f"Value type {value_type} it not implemented for loss {type(self)}."
+            )
+        elif value_type == ValueFunctions.TDLambda:
+            self._value_function = TDLambdaEstimate(
+                value_network=self.actor_critic, value_key=value_key, **hp
+            )
+        else:
+            raise NotImplementedError(f"Unknown value type {value_type}")

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -169,7 +169,7 @@ class DDPGLoss(LossModule):
             device=self.target_actor_network_params.device,
         )
         with set_exploration_mode("mode"):
-            target_value = self.value_function.value_estimate(
+            target_value = self.value_estimator.value_estimate(
                 tensordict, target_params=target_params
             ).squeeze(-1)
 
@@ -187,11 +187,11 @@ class DDPGLoss(LossModule):
         hp.update(hyperparams)
         value_key = "state_action_value"
         if value_type == ValueEstimators.TD1:
-            self._value_function = TD1Estimator(
+            self._value_estimator = TD1Estimator(
                 value_network=self.actor_critic, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.TD0:
-            self._value_function = TD0Estimator(
+            self._value_estimator = TD0Estimator(
                 value_network=self.actor_critic, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.GAE:
@@ -199,7 +199,7 @@ class DDPGLoss(LossModule):
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
         elif value_type == ValueEstimators.TDLambda:
-            self._value_function = TDLambdaEstimator(
+            self._value_estimator = TDLambdaEstimator(
                 value_network=self.actor_critic, value_key=value_key, **hp
             )
         else:

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -23,7 +23,7 @@ from torchrl.objectives.utils import (
 
 from ..envs.utils import set_exploration_mode
 from .common import LossModule
-from .value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
+from .value import TD0Estimate, TD1Estimate, TDLambdaEstimate
 
 
 class DDPGLoss(LossModule):

--- a/torchrl/objectives/deprecated.py
+++ b/torchrl/objectives/deprecated.py
@@ -22,7 +22,7 @@ from torchrl.objectives import (
     ValueFunctions,
 )
 from torchrl.objectives.common import LossModule
-from torchrl.objectives.value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
+from torchrl.objectives.value import TD0Estimate, TD1Estimate, TDLambdaEstimate
 
 try:
     from functorch import vmap
@@ -289,7 +289,9 @@ class REDQLoss_deprecated(LossModule):
                 value_network=None, value_key=value_key, **hp
             )
         elif value_type == ValueFunctions.GAE:
-            self._value_function = GAE(value_network=None, value_key=value_key, **hp)
+            raise NotImplementedError(
+                f"Value type {value_type} it not implemented for loss {type(self)}."
+            )
         elif value_type == ValueFunctions.TDLambda:
             self._value_function = TDLambdaEstimate(
                 value_network=None, value_key=value_key, **hp

--- a/torchrl/objectives/deprecated.py
+++ b/torchrl/objectives/deprecated.py
@@ -253,7 +253,7 @@ class REDQLoss_deprecated(LossModule):
             next_state_value = next_state_value.min(0)[0]
 
         tensordict.set(("next", "state_value"), next_state_value)
-        target_value = self.value_function.value_estimate(tensordict).squeeze(-1)
+        target_value = self.value_estimator.value_estimate(tensordict).squeeze(-1)
         tensordict_expand = vmap(self.qvalue_network, (None, 0))(
             tensordict.select(*self.qvalue_network.in_keys),
             self.qvalue_network_params,
@@ -289,11 +289,11 @@ class REDQLoss_deprecated(LossModule):
         value_key = "state_value"
         # we do not need a value network bc the next state value is already passed
         if value_type == ValueEstimators.TD1:
-            self._value_function = TD1Estimator(
+            self._value_estimator = TD1Estimator(
                 value_network=None, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.TD0:
-            self._value_function = TD0Estimator(
+            self._value_estimator = TD0Estimator(
                 value_network=None, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.GAE:
@@ -301,7 +301,7 @@ class REDQLoss_deprecated(LossModule):
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
         elif value_type == ValueEstimators.TDLambda:
-            self._value_function = TDLambdaEstimator(
+            self._value_estimator = TDLambdaEstimator(
                 value_network=None, value_key=value_key, **hp
             )
         else:

--- a/torchrl/objectives/deprecated.py
+++ b/torchrl/objectives/deprecated.py
@@ -16,11 +16,13 @@ from tensordict.tensordict import TensorDictBase
 from torch import Tensor
 from torchrl.envs.utils import set_exploration_mode, step_mdp
 from torchrl.objectives import (
+    default_value_kwargs,
     distance_loss,
     hold_out_params,
-    next_state_value as get_next_state_value,
+    ValueFunctions,
 )
 from torchrl.objectives.common import LossModule
+from torchrl.objectives.value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
 
 try:
     from functorch import vmap
@@ -41,36 +43,49 @@ class REDQLoss_deprecated(LossModule):
 
     Args:
         actor_network (TensorDictModule): the actor to be trained
-        qvalue_network (TensorDictModule): a single Q-value network that will be multiplicated as many times as needed.
-        num_qvalue_nets (int, optional): Number of Q-value networks to be trained. Default is 10.
-        sub_sample_len (int, optional): number of Q-value networks to be subsampled to evaluate the next state value
-            Default is 2.
-        gamma (Number, optional): gamma decay factor. Default is 0.99.
-        priotity_key (str, optional): Key where to write the priority value for prioritized replay buffers. Default is
-            `"td_error"`.
-        loss_function (str, optional): loss function to be used for the Q-value. Can be one of  `"smooth_l1"`, "l2",
-            "l1", Default is "smooth_l1".
+        qvalue_network (TensorDictModule): a single Q-value network that will
+            be multiplicated as many times as needed.
+        num_qvalue_nets (int, optional): Number of Q-value networks to be trained.
+            Default is ``10``.
+        sub_sample_len (int, optional): number of Q-value networks to be
+            subsampled to evaluate the next state value
+            Default is ``2``.
+        priority_key (str, optional): Key where to write the priority value
+            for prioritized replay buffers. Default is
+            ``"td_error"``.
+        loss_function (str, optional): loss function to be used for the Q-value.
+            Can be one of  ``"smooth_l1"``, ``"l2"``,
+            ``"l1"``, Default is ``"smooth_l1"``.
         alpha_init (float, optional): initial entropy multiplier.
-            Default is 1.0.
+            Default is ``1.0``.
         min_alpha (float, optional): min value of alpha.
-            Default is 0.1.
+            Default is ``0.1``.
         max_alpha (float, optional): max value of alpha.
-            Default is 10.0.
-        fixed_alpha (bool, optional): whether alpha should be trained to match a target entropy. Default is :obj:`False`.
-        target_entropy (Union[str, Number], optional): Target entropy for the stochastic policy. Default is "auto".
+            Default is ``10.0``.
+        fixed_alpha (bool, optional): whether alpha should be trained to match
+            a target entropy. Default is ``False``.
+        target_entropy (Union[str, Number], optional): Target entropy for the
+            stochastic policy. Default is "auto".
+        delay_qvalue (bool, optional): Whether to separate the target Q value
+            networks from the Q value networks used
+            for data collection. Default is ``False``.
+        gSDE (bool, optional): Knowing if gSDE is used is necessary to create
+            random noise variables.
+            Default is ``False``.
 
     """
 
     delay_actor: bool = False
+    default_value_type = ValueFunctions.TD0
 
     def __init__(
         self,
         actor_network: TensorDictModule,
         qvalue_network: TensorDictModule,
+        *,
         num_qvalue_nets: int = 10,
         sub_sample_len: int = 2,
-        gamma: Number = 0.99,
-        priotity_key: str = "td_error",
+        priority_key: str = "td_error",
         loss_function: str = "smooth_l1",
         alpha_init: float = 1.0,
         min_alpha: float = 0.1,
@@ -102,8 +117,7 @@ class REDQLoss_deprecated(LossModule):
         )
         self.num_qvalue_nets = num_qvalue_nets
         self.sub_sample_len = max(1, min(sub_sample_len, num_qvalue_nets - 1))
-        self.register_buffer("gamma", torch.tensor(gamma))
-        self.priority_key = priotity_key
+        self.priority_key = priority_key
         self.loss_function = loss_function
 
         try:
@@ -197,7 +211,7 @@ class REDQLoss_deprecated(LossModule):
         tensordict_save = tensordict
 
         obs_keys = self.actor_network.in_keys
-        tensordict = tensordict.select("next", *obs_keys, "action")
+        tensordict = tensordict.clone(False).select("next", *obs_keys, "action")
 
         selected_models_idx = torch.randperm(self.num_qvalue_nets)[
             : self.sub_sample_len
@@ -227,17 +241,13 @@ class REDQLoss_deprecated(LossModule):
                 != sample_log_prob.shape
             ):
                 sample_log_prob = sample_log_prob.unsqueeze(-1)
-            state_value = (
+            next_state_value = (
                 next_td.get("state_action_value") - self.alpha * sample_log_prob
             )
-            state_value = state_value.min(0)[0]
+            next_state_value = next_state_value.min(0)[0]
 
-        tensordict.set("next.state_value", state_value)
-        target_value = get_next_state_value(
-            tensordict,
-            gamma=self.gamma,
-            pred_next_val=state_value,
-        )
+        tensordict.set(("next", "state_value"), next_state_value)
+        target_value = self.value_function.value_estimate(tensordict).squeeze(-1)
         tensordict_expand = vmap(self.qvalue_network, (None, 0))(
             tensordict.select(*self.qvalue_network.in_keys),
             self.qvalue_network_params,
@@ -264,6 +274,28 @@ class REDQLoss_deprecated(LossModule):
             # placeholder
             alpha_loss = torch.zeros_like(log_pi)
         return alpha_loss
+
+    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+        hp = dict(default_value_kwargs(value_type))
+        hp.update(hyperparams)
+        value_key = "state_value"
+        # we do not need a value network bc the next state value is already passed
+        if value_type == ValueFunctions.TD1:
+            self._value_function = TD1Estimate(
+                value_network=None, value_key=value_key, **hp
+            )
+        elif value_type == ValueFunctions.TD0:
+            self._value_function = TD0Estimate(
+                value_network=None, value_key=value_key, **hp
+            )
+        elif value_type == ValueFunctions.GAE:
+            self._value_function = GAE(value_network=None, value_key=value_key, **hp)
+        elif value_type == ValueFunctions.TDLambda:
+            self._value_function = TDLambdaEstimate(
+                value_network=None, value_key=value_key, **hp
+            )
+        else:
+            raise NotImplementedError(f"Unknown value type {value_type}")
 
 
 class DoubleREDQLoss_deprecated(REDQLoss_deprecated):

--- a/torchrl/objectives/deprecated.py
+++ b/torchrl/objectives/deprecated.py
@@ -19,11 +19,11 @@ from torchrl.objectives import (
     default_value_kwargs,
     distance_loss,
     hold_out_params,
-    ValueFunctions,
+    ValueEstimators,
 )
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import _GAMMA_LMBDA_DEPREC_WARNING
-from torchrl.objectives.value import TD0Estimate, TD1Estimate, TDLambdaEstimate
+from torchrl.objectives.value import TD0Estimator, TD1Estimator, TDLambdaEstimator
 
 try:
     from functorch import vmap
@@ -77,7 +77,7 @@ class REDQLoss_deprecated(LossModule):
     """
 
     delay_actor: bool = False
-    default_value_type = ValueFunctions.TD0
+    default_value_estimator = ValueEstimators.TD0
 
     def __init__(
         self,
@@ -281,27 +281,27 @@ class REDQLoss_deprecated(LossModule):
             alpha_loss = torch.zeros_like(log_pi)
         return alpha_loss
 
-    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+    def make_value_estimator(self, value_type: ValueEstimators, **hyperparams):
         hp = dict(default_value_kwargs(value_type))
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
         value_key = "state_value"
         # we do not need a value network bc the next state value is already passed
-        if value_type == ValueFunctions.TD1:
-            self._value_function = TD1Estimate(
+        if value_type == ValueEstimators.TD1:
+            self._value_function = TD1Estimator(
                 value_network=None, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.TD0:
-            self._value_function = TD0Estimate(
+        elif value_type == ValueEstimators.TD0:
+            self._value_function = TD0Estimator(
                 value_network=None, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.GAE:
+        elif value_type == ValueEstimators.GAE:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
-        elif value_type == ValueFunctions.TDLambda:
-            self._value_function = TDLambdaEstimate(
+        elif value_type == ValueEstimators.TDLambda:
+            self._value_function = TDLambdaEstimator(
                 value_network=None, value_key=value_key, **hp
             )
         else:

--- a/torchrl/objectives/dqn.py
+++ b/torchrl/objectives/dqn.py
@@ -15,7 +15,7 @@ from torchrl.modules.tensordict_module.common import ensure_tensordict_compatibl
 
 from .common import LossModule
 from .utils import default_value_kwargs, distance_loss, ValueFunctions
-from .value import GAE, TDLambdaEstimate
+from .value import TDLambdaEstimate
 from .value.advantages import TD0Estimate, TD1Estimate
 
 

--- a/torchrl/objectives/dqn.py
+++ b/torchrl/objectives/dqn.py
@@ -75,7 +75,7 @@ class DQNLoss(LossModule):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
         if value_type is ValueEstimators.TD1:
-            self._value_function = TD1Estimator(
+            self._value_estimator = TD1Estimator(
                 **hp,
                 value_network=self.value_network,
                 advantage_key="advantage",
@@ -83,7 +83,7 @@ class DQNLoss(LossModule):
                 value_key="chosen_action_value",
             )
         elif value_type is ValueEstimators.TD0:
-            self._value_function = TD0Estimator(
+            self._value_estimator = TD0Estimator(
                 **hp,
                 value_network=self.value_network,
                 advantage_key="advantage",
@@ -95,7 +95,7 @@ class DQNLoss(LossModule):
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
         elif value_type is ValueEstimators.TDLambda:
-            self._value_function = TDLambdaEstimator(
+            self._value_estimator = TDLambdaEstimator(
                 **hp,
                 value_network=self.value_network,
                 advantage_key="advantage",
@@ -155,7 +155,7 @@ class DQNLoss(LossModule):
             action = action.to(torch.float)
             pred_val_index = (pred_val * action).sum(-1)
 
-        target_value = self.value_function.value_estimate(
+        target_value = self.value_estimator.value_estimate(
             tensordict.clone(False), target_params=self.target_value_network_params
         ).squeeze(-1)
 
@@ -191,7 +191,7 @@ class DistributionalDQNLoss(LossModule):
         gamma (scalar): a discount factor for return computation.
             .. note::
               Unlike :class:`DQNLoss`, this class does not currently support
-              custom value functions. The next value estimation is not
+              custom value functions. The next value estimation is always
               bootstrapped.
         delay_value (bool): whether to duplicate the value network into a new
             target value network to create double DQN

--- a/torchrl/objectives/dqn.py
+++ b/torchrl/objectives/dqn.py
@@ -18,10 +18,10 @@ from .utils import (
     _GAMMA_LMBDA_DEPREC_WARNING,
     default_value_kwargs,
     distance_loss,
-    ValueFunctions,
+    ValueEstimators,
 )
-from .value import TDLambdaEstimate
-from .value.advantages import TD0Estimate, TD1Estimate
+from .value import TDLambdaEstimator
+from .value.advantages import TD0Estimator, TD1Estimator
 
 
 class DQNLoss(LossModule):
@@ -35,7 +35,7 @@ class DQNLoss(LossModule):
 
     """
 
-    default_value_type = ValueFunctions.TDLambda
+    default_value_estimator = ValueEstimators.TDLambda
 
     def __init__(
         self,
@@ -69,33 +69,33 @@ class DQNLoss(LossModule):
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING)
             self.gamma = gamma
 
-    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+    def make_value_estimator(self, value_type: ValueEstimators, **hyperparams):
         hp = dict(default_value_kwargs(value_type))
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        if value_type is ValueFunctions.TD1:
-            self._value_function = TD1Estimate(
+        if value_type is ValueEstimators.TD1:
+            self._value_function = TD1Estimator(
                 **hp,
                 value_network=self.value_network,
                 advantage_key="advantage",
                 value_target_key="value_target",
                 value_key="chosen_action_value",
             )
-        elif value_type is ValueFunctions.TD0:
-            self._value_function = TD0Estimate(
+        elif value_type is ValueEstimators.TD0:
+            self._value_function = TD0Estimator(
                 **hp,
                 value_network=self.value_network,
                 advantage_key="advantage",
                 value_target_key="value_target",
                 value_key="chosen_action_value",
             )
-        elif value_type is ValueFunctions.GAE:
+        elif value_type is ValueEstimators.GAE:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
-        elif value_type is ValueFunctions.TDLambda:
-            self._value_function = TDLambdaEstimate(
+        elif value_type is ValueEstimators.TDLambda:
+            self._value_function = TDLambdaEstimator(
                 **hp,
                 value_network=self.value_network,
                 advantage_key="advantage",
@@ -359,24 +359,24 @@ class DistributionalDQNLoss(LossModule):
         loss_td = TensorDict({"loss": loss.mean()}, [])
         return loss_td
 
-    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
-        if value_type is ValueFunctions.TD1:
+    def make_value_estimator(self, value_type: ValueEstimators, **hyperparams):
+        if value_type is ValueEstimators.TD1:
             raise NotImplementedError(
                 f"value type {value_type} is not implemented for {self.__class__.__name__}."
             )
-        elif value_type is ValueFunctions.TD0:
+        elif value_type is ValueEstimators.TD0:
             # see forward call
             pass
-        elif value_type is ValueFunctions.GAE:
+        elif value_type is ValueEstimators.GAE:
             raise NotImplementedError(
                 f"value type {value_type} is not implemented for {self.__class__.__name__}."
             )
-        elif value_type is ValueFunctions.TDLambda:
+        elif value_type is ValueEstimators.TDLambda:
             raise NotImplementedError(
                 f"value type {value_type} is not implemented for {self.__class__.__name__}."
             )
         else:
             raise NotImplementedError(f"Unknown value type {value_type}")
 
-    def _default_value_function(self):
-        self.make_value_function(ValueFunctions.TD0)
+    def _default_value_estimator(self):
+        self.make_value_estimator(ValueEstimators.TD0)

--- a/torchrl/objectives/dreamer.py
+++ b/torchrl/objectives/dreamer.py
@@ -17,9 +17,9 @@ from torchrl.objectives.utils import (
     default_value_kwargs,
     distance_loss,
     hold_out_net,
-    ValueFunctions,
+    ValueEstimators,
 )
-from torchrl.objectives.value import TD0Estimate, TD1Estimate, TDLambdaEstimate
+from torchrl.objectives.value import TD0Estimator, TD1Estimator, TDLambdaEstimator
 
 
 class DreamerModelLoss(LossModule):
@@ -155,7 +155,7 @@ class DreamerActorLoss(LossModule):
 
     """
 
-    default_value_type = ValueFunctions.TDLambda
+    default_value_estimator = ValueEstimators.TDLambda
 
     def __init__(
         self,
@@ -230,37 +230,37 @@ class DreamerActorLoss(LossModule):
         )
         return self.value_function.value_estimate(input_tensordict)
 
-    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+    def make_value_estimator(self, value_type: ValueEstimators, **hyperparams):
         value_net = None
         value_key = "state_value"
         hp = dict(default_value_kwargs(value_type))
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        if value_type is ValueFunctions.TD1:
-            self._value_function = TD1Estimate(
+        if value_type is ValueEstimators.TD1:
+            self._value_function = TD1Estimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",
                 value_key=value_key,
             )
-        elif value_type is ValueFunctions.TD0:
-            self._value_function = TD0Estimate(
+        elif value_type is ValueEstimators.TD0:
+            self._value_function = TD0Estimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",
                 value_key=value_key,
             )
-        elif value_type is ValueFunctions.GAE:
+        elif value_type is ValueEstimators.GAE:
             if hasattr(self, "lmbda"):
                 hp["lmbda"] = self.lmbda
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
-        elif value_type is ValueFunctions.TDLambda:
+        elif value_type is ValueEstimators.TDLambda:
             if hasattr(self, "lmbda"):
                 hp["lmbda"] = self.lmbda
-            self._value_function = TDLambdaEstimate(
+            self._value_function = TDLambdaEstimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",

--- a/torchrl/objectives/dreamer.py
+++ b/torchrl/objectives/dreamer.py
@@ -17,7 +17,7 @@ from torchrl.objectives.utils import (
     hold_out_net,
     ValueFunctions,
 )
-from torchrl.objectives.value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
+from torchrl.objectives.value import TD0Estimate, TD1Estimate, TDLambdaEstimate
 
 
 class DreamerModelLoss(LossModule):
@@ -240,11 +240,8 @@ class DreamerActorLoss(LossModule):
                 value_key=value_key,
             )
         elif value_type is ValueFunctions.GAE:
-            self._value_function = GAE(
-                **hp,
-                value_network=value_net,
-                value_target_key="value_target",
-                value_key=value_key,
+            raise NotImplementedError(
+                f"Value type {value_type} it not implemented for loss {type(self)}."
             )
         elif value_type is ValueFunctions.TDLambda:
             self._value_function = TDLambdaEstimate(

--- a/torchrl/objectives/dreamer.py
+++ b/torchrl/objectives/dreamer.py
@@ -208,7 +208,7 @@ class DreamerActorLoss(LossModule):
         fake_data.set("lambda_target", lambda_target)
 
         if self.discount_loss:
-            gamma = self.value_function.gamma.to(tensordict.device)
+            gamma = self.value_estimator.gamma.to(tensordict.device)
             discount = gamma.expand(lambda_target.shape)
             discount[..., 0, :] = 1
             discount = discount.cumprod(dim=-2)
@@ -228,7 +228,7 @@ class DreamerActorLoss(LossModule):
             },
             [],
         )
-        return self.value_function.value_estimate(input_tensordict)
+        return self.value_estimator.value_estimate(input_tensordict)
 
     def make_value_estimator(self, value_type: ValueEstimators, **hyperparams):
         value_net = None
@@ -238,14 +238,14 @@ class DreamerActorLoss(LossModule):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
         if value_type is ValueEstimators.TD1:
-            self._value_function = TD1Estimator(
+            self._value_estimator = TD1Estimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",
                 value_key=value_key,
             )
         elif value_type is ValueEstimators.TD0:
-            self._value_function = TD0Estimator(
+            self._value_estimator = TD0Estimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",
@@ -260,7 +260,7 @@ class DreamerActorLoss(LossModule):
         elif value_type is ValueEstimators.TDLambda:
             if hasattr(self, "lmbda"):
                 hp["lmbda"] = self.lmbda
-            self._value_function = TDLambdaEstimator(
+            self._value_estimator = TDLambdaEstimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",

--- a/torchrl/objectives/dreamer.py
+++ b/torchrl/objectives/dreamer.py
@@ -11,15 +11,22 @@ from tensordict.nn import TensorDictModule
 from torchrl.envs.model_based.dreamer import DreamerEnv
 from torchrl.envs.utils import set_exploration_mode, step_mdp
 from torchrl.objectives.common import LossModule
-from torchrl.objectives.utils import distance_loss, hold_out_net
-from torchrl.objectives.value.functional import vec_td_lambda_return_estimate
+from torchrl.objectives.utils import (
+    default_value_kwargs,
+    distance_loss,
+    hold_out_net,
+    ValueFunctions,
+)
+from torchrl.objectives.value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
 
 
 class DreamerModelLoss(LossModule):
     """Dreamer Model Loss.
 
-    Computes the loss of the dreamer world model. The loss is composed of the kl divergence between the prior and posterior of the RSSM,
-    the reconstruction loss over the reconstructed observation and the reward loss over the predicted reward.
+    Computes the loss of the dreamer world model. The loss is composed of the
+    kl divergence between the prior and posterior of the RSSM,
+    the reconstruction loss over the reconstructed observation and the reward
+    loss over the predicted reward.
 
     Reference: https://arxiv.org/abs/1912.01603.
 
@@ -31,10 +38,10 @@ class DreamerModelLoss(LossModule):
         reco_loss (str, optional): the reconstruction loss. Default: "l2".
         reward_loss (str, optional): the reward loss. Default: "l2".
         free_nats (int, optional): the free nats. Default: 3.
-        delayed_clamp (bool, optional): if True, the KL clamping occurs after
+        delayed_clamp (bool, optional): if ``True``, the KL clamping occurs after
             averaging. If False (default), the kl divergence is clamped to the
             free nats value first and then averaged.
-        global_average (bool, optional): if True, the losses will be averaged
+        global_average (bool, optional): if ``True``, the losses will be averaged
             over all dimensions. Otherwise, a sum will be performed over all
             non-batch/time dimensions and an average over batch and time.
             Default: False.
@@ -43,6 +50,7 @@ class DreamerModelLoss(LossModule):
     def __init__(
         self,
         world_model: TensorDictModule,
+        *,
         lambda_kl: float = 1.0,
         lambda_reco: float = 1.0,
         lambda_reward: float = 1.0,
@@ -129,7 +137,8 @@ class DreamerModelLoss(LossModule):
 class DreamerActorLoss(LossModule):
     """Dreamer Actor Loss.
 
-    Computes the loss of the dreamer actor. The actor loss is computed as the negative average lambda return.
+    Computes the loss of the dreamer actor. The actor loss is computed as the
+    negative average lambda return.
 
     Reference: https://arxiv.org/abs/1912.01603.
 
@@ -138,22 +147,21 @@ class DreamerActorLoss(LossModule):
         value_model (TensorDictModule): the value model.
         model_based_env (DreamerEnv): the model based environment.
         imagination_horizon (int, optional): The number of steps to unroll the
-            model. Default: 15.
-        gamma (float, optional): the gamma discount factor. Default: 0.99.
-        lmbda (float, optional): the lambda discount factor factor. Default: 0.95.
-        discount_loss (bool, optional): if True, the loss is discounted with a
-            gamma discount factor. Default: False.
+            model. Defaults to ``15``.
+        discount_loss (bool, optional): if ``True``, the loss is discounted with a
+            gamma discount factor. Default to ``False``.
 
     """
+
+    default_value_type = ValueFunctions.TDLambda
 
     def __init__(
         self,
         actor_model: TensorDictModule,
         value_model: TensorDictModule,
         model_based_env: DreamerEnv,
+        *,
         imagination_horizon: int = 15,
-        gamma: int = 0.99,
-        lmbda: int = 0.95,
         discount_loss: bool = False,  # for consistency with paper
     ):
         super().__init__()
@@ -161,8 +169,6 @@ class DreamerActorLoss(LossModule):
         self.value_model = value_model
         self.model_based_env = model_based_env
         self.imagination_horizon = imagination_horizon
-        self.gamma = gamma
-        self.lmbda = lmbda
         self.discount_loss = discount_loss
 
     def forward(self, tensordict: TensorDict) -> Tuple[TensorDict, TensorDict]:
@@ -192,9 +198,8 @@ class DreamerActorLoss(LossModule):
         fake_data.set("lambda_target", lambda_target)
 
         if self.discount_loss:
-            discount = self.gamma * torch.ones_like(
-                lambda_target, device=tensordict.device
-            )
+            gamma = self.value_function.gamma.to(tensordict.device)
+            discount = gamma.expand(lambda_target.shape)
             discount[..., 0, :] = 1
             discount = discount.cumprod(dim=-2)
             actor_loss = -(lambda_target * discount).sum((-2, -1)).mean()
@@ -205,15 +210,58 @@ class DreamerActorLoss(LossModule):
 
     def lambda_target(self, reward: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
         done = torch.zeros(reward.shape, dtype=torch.bool, device=reward.device)
-        return vec_td_lambda_return_estimate(
-            self.gamma, self.lmbda, value, reward, done
+        input_tensordict = TensorDict(
+            {
+                ("next", "reward"): reward,
+                ("next", "state_value"): value,
+                ("next", "done"): done,
+            },
+            [],
         )
+        return self.value_function.value_estimate(input_tensordict)
+
+    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+        value_net = None
+        value_key = "state_value"
+        hp = dict(default_value_kwargs(value_type))
+        hp.update(hyperparams)
+        if value_type is ValueFunctions.TD1:
+            self._value_function = TD1Estimate(
+                **hp,
+                value_network=value_net,
+                value_target_key="value_target",
+                value_key=value_key,
+            )
+        elif value_type is ValueFunctions.TD0:
+            self._value_function = TD0Estimate(
+                **hp,
+                value_network=value_net,
+                value_target_key="value_target",
+                value_key=value_key,
+            )
+        elif value_type is ValueFunctions.GAE:
+            self._value_function = GAE(
+                **hp,
+                value_network=value_net,
+                value_target_key="value_target",
+                value_key=value_key,
+            )
+        elif value_type is ValueFunctions.TDLambda:
+            self._value_function = TDLambdaEstimate(
+                **hp,
+                value_network=value_net,
+                value_target_key="value_target",
+                value_key=value_key,
+            )
+        else:
+            raise NotImplementedError(f"Unknown value type {value_type}")
 
 
 class DreamerValueLoss(LossModule):
     """Dreamer Value Loss.
 
-    Computes the loss of the dreamer value model. The value loss is computed between the predicted value and the lambda target.
+    Computes the loss of the dreamer value model. The value loss is computed
+    between the predicted value and the lambda target.
 
     Reference: https://arxiv.org/abs/1912.01603.
 
@@ -221,7 +269,7 @@ class DreamerValueLoss(LossModule):
         value_model (TensorDictModule): the value model.
         value_loss (str, optional): the loss to use for the value loss. Default: "l2".
         gamma (float, optional): the gamma discount factor. Default: 0.99.
-        discount_loss (bool, optional): if True, the loss is discounted with a
+        discount_loss (bool, optional): if ``True``, the loss is discounted with a
             gamma discount factor. Default: False.
 
     """

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -223,7 +223,7 @@ class IQLLoss(LossModule):
         obs_keys = self.actor_network.in_keys
         tensordict = tensordict.select("next", *obs_keys, "action")
 
-        target_value = self.value_function.value_estimate(
+        target_value = self.value_estimator.value_estimate(
             tensordict, target_params=self.target_value_network_params
         ).squeeze(-1)
         tensordict_expand = vmap(self.qvalue_network, (None, 0))(
@@ -252,14 +252,14 @@ class IQLLoss(LossModule):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
         if value_type is ValueEstimators.TD1:
-            self._value_function = TD1Estimator(
+            self._value_estimator = TD1Estimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",
                 value_key=value_key,
             )
         elif value_type is ValueEstimators.TD0:
-            self._value_function = TD0Estimator(
+            self._value_estimator = TD0Estimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",
@@ -270,7 +270,7 @@ class IQLLoss(LossModule):
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
         elif value_type is ValueEstimators.TDLambda:
-            self._value_function = TDLambdaEstimator(
+            self._value_estimator = TDLambdaEstimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from numbers import Number
 from typing import Optional, Tuple
 
 import torch
@@ -12,10 +11,11 @@ from tensordict.tensordict import TensorDict, TensorDictBase
 from torch import Tensor
 
 from torchrl.modules import ProbabilisticActor
-from torchrl.objectives.utils import distance_loss, next_state_value
+from torchrl.objectives.utils import default_value_kwargs, distance_loss, ValueFunctions
 
-from ..envs.utils import set_exploration_mode, step_mdp
+from ..envs.utils import set_exploration_mode
 from .common import LossModule
+from .value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
 
 try:
     from functorch import vmap
@@ -35,14 +35,9 @@ class IQLLoss(LossModule):
     Args:
         actor_network (ProbabilisticActor): stochastic actor
         qvalue_network (TensorDictModule): Q(s, a) parametric model
-        value_network (TensorDictModule, optional): V(s) parametric model. If not
-            provided, the second version of SAC is assumed.
-        qvalue_network_bis (ProbabilisticTDModule, optional): if required, the
-            Q-value can be computed twice independently using two separate
-            networks. The minimum predicted value will then be used for
-            inference.
-        gamma (number, optional): discount for return computation
-            Default is 0.99
+        value_network (TensorDictModule, optional): V(s) parametric model.
+        num_qvalue_nets (integer, optional): number of Q-Value networks used.
+            Defaults to ``2``.
         priority_key (str, optional): tensordict key where to write the
             priority (for prioritized replay buffer usage). Default is
             `"td_error"`.
@@ -57,14 +52,16 @@ class IQLLoss(LossModule):
 
     """
 
+    default_value_type = ValueFunctions.TD0
+
     def __init__(
         self,
         actor_network: ProbabilisticActor,
         qvalue_network: TensorDictModule,
-        value_network: Optional[TensorDictModule] = None,
+        value_network: Optional[TensorDictModule],
+        *,
         num_qvalue_nets: int = 2,
-        gamma: Number = 0.99,
-        priotity_key: str = "td_error",
+        priority_key: str = "td_error",
         loss_function: str = "smooth_l1",
         temperature: float = 1.0,
         expectile: float = 0.5,
@@ -106,8 +103,7 @@ class IQLLoss(LossModule):
             + list(value_network.parameters()),
         )
 
-        self.register_buffer("gamma", torch.tensor(gamma))
-        self.priority_key = priotity_key
+        self.priority_key = priority_key
         self.loss_function = loss_function
 
     @property
@@ -218,26 +214,9 @@ class IQLLoss(LossModule):
         obs_keys = self.actor_network.in_keys
         tensordict = tensordict.select("next", *obs_keys, "action")
 
-        with torch.no_grad():
-            next_td = step_mdp(tensordict).select(
-                *self.actor_network.in_keys
-            )  # next_observation ->
-            # observation
-            # select pseudo-action
-            # get state values
-            next_td = self.value_network(
-                next_td,
-                params=self.value_network_params,
-            )
-
-            state_value = next_td.get("state_value")
-
-        tensordict.set("next.state_value", state_value)
-        target_value = next_state_value(
-            tensordict,
-            gamma=self.gamma,
-            pred_next_val=state_value,
-        )
+        target_value = self.value_function.value_estimate(
+            tensordict, target_params=self.target_value_network_params
+        ).squeeze(-1)
         tensordict_expand = vmap(self.qvalue_network, (None, 0))(
             tensordict.select(*self.qvalue_network.in_keys),
             self.qvalue_network_params,
@@ -254,3 +233,40 @@ class IQLLoss(LossModule):
             .mean()
         )
         return loss_qval, td_error.detach().max(0)[0]
+
+    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+        value_net = self.value_network
+
+        value_key = "state_value"
+        hp = dict(default_value_kwargs(value_type))
+        hp.update(hyperparams)
+        if value_type is ValueFunctions.TD1:
+            self._value_function = TD1Estimate(
+                **hp,
+                value_network=value_net,
+                value_target_key="value_target",
+                value_key=value_key,
+            )
+        elif value_type is ValueFunctions.TD0:
+            self._value_function = TD0Estimate(
+                **hp,
+                value_network=value_net,
+                value_target_key="value_target",
+                value_key=value_key,
+            )
+        elif value_type is ValueFunctions.GAE:
+            self._value_function = GAE(
+                **hp,
+                value_network=value_net,
+                value_target_key="value_target",
+                value_key=value_key,
+            )
+        elif value_type is ValueFunctions.TDLambda:
+            self._value_function = TDLambdaEstimate(
+                **hp,
+                value_network=value_net,
+                value_target_key="value_target",
+                value_key=value_key,
+            )
+        else:
+            raise NotImplementedError(f"Unknown value type {value_type}")

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -15,12 +15,12 @@ from torchrl.objectives.utils import (
     _GAMMA_LMBDA_DEPREC_WARNING,
     default_value_kwargs,
     distance_loss,
-    ValueFunctions,
+    ValueEstimators,
 )
 
 from ..envs.utils import set_exploration_mode
 from .common import LossModule
-from .value import TD0Estimate, TD1Estimate, TDLambdaEstimate
+from .value import TD0Estimator, TD1Estimator, TDLambdaEstimator
 
 try:
     from functorch import vmap
@@ -57,7 +57,7 @@ class IQLLoss(LossModule):
 
     """
 
-    default_value_type = ValueFunctions.TD0
+    default_value_estimator = ValueEstimators.TD0
 
     def __init__(
         self,
@@ -243,7 +243,7 @@ class IQLLoss(LossModule):
         )
         return loss_qval, td_error.detach().max(0)[0]
 
-    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+    def make_value_estimator(self, value_type: ValueEstimators, **hyperparams):
         value_net = self.value_network
 
         value_key = "state_value"
@@ -251,26 +251,26 @@ class IQLLoss(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        if value_type is ValueFunctions.TD1:
-            self._value_function = TD1Estimate(
+        if value_type is ValueEstimators.TD1:
+            self._value_function = TD1Estimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",
                 value_key=value_key,
             )
-        elif value_type is ValueFunctions.TD0:
-            self._value_function = TD0Estimate(
+        elif value_type is ValueEstimators.TD0:
+            self._value_function = TD0Estimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",
                 value_key=value_key,
             )
-        elif value_type is ValueFunctions.GAE:
+        elif value_type is ValueEstimators.GAE:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
-        elif value_type is ValueFunctions.TDLambda:
-            self._value_function = TDLambdaEstimate(
+        elif value_type is ValueEstimators.TDLambda:
+            self._value_function = TDLambdaEstimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -15,7 +15,7 @@ from torchrl.objectives.utils import default_value_kwargs, distance_loss, ValueF
 
 from ..envs.utils import set_exploration_mode
 from .common import LossModule
-from .value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
+from .value import TD0Estimate, TD1Estimate, TDLambdaEstimate
 
 try:
     from functorch import vmap
@@ -255,11 +255,8 @@ class IQLLoss(LossModule):
                 value_key=value_key,
             )
         elif value_type is ValueFunctions.GAE:
-            self._value_function = GAE(
-                **hp,
-                value_network=value_net,
-                value_target_key="value_target",
-                value_key=value_key,
+            raise NotImplementedError(
+                f"Value type {value_type} it not implemented for loss {type(self)}."
             )
         elif value_type is ValueFunctions.TDLambda:
             self._value_function = TDLambdaEstimate(

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -11,21 +11,25 @@ from tensordict.nn import ProbabilisticTensorDictSequential, TensorDictModule
 from tensordict.tensordict import TensorDict, TensorDictBase
 from torch import distributions as d
 
-from torchrl.objectives.utils import distance_loss
+from torchrl.objectives.utils import default_value_kwargs, distance_loss, ValueFunctions
 
 from .common import LossModule
+from .value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
 
 
 class PPOLoss(LossModule):
     """A parent PPO loss class.
 
-    PPO (Proximal Policy Optimisation) is a model-free, online RL algorithm that makes use of a recorded (batch of)
-    trajectories to perform several optimization steps, while actively preventing the updated policy to deviate too
+    PPO (Proximal Policy Optimisation) is a model-free, online RL algorithm
+    that makes use of a recorded (batch of)
+    trajectories to perform several optimization steps, while actively
+    preventing the updated policy to deviate too
     much from its original parameter configuration.
 
-    PPO loss can be found in different flavours, depending on the way the constrained optimisation is implemented:
-        ClipPPOLoss and KLPENPPOLoss.
-    Unlike its subclasses, this class does not implement any regularisation and should therefore be used cautiously.
+    PPO loss can be found in different flavours, depending on the way the
+    constrained optimisation is implemented: ClipPPOLoss and KLPENPPOLoss.
+    Unlike its subclasses, this class does not implement any regularisation
+    and should therefore be used cautiously.
 
     For more details regarding PPO, refer to: "Proximal Policy Optimization Algorithms",
     https://arxiv.org/abs/1707.06347
@@ -33,35 +37,68 @@ class PPOLoss(LossModule):
     Args:
         actor (ProbabilisticTensorDictSequential): policy operator.
         critic (ValueOperator): value operator.
-        advantage_key (str): the input tensordict key where the advantage is expected to be written.
-            default: "advantage"
-        entropy_bonus (bool): if True, an entropy bonus will be added to the loss to favour exploratory policies.
-        samples_mc_entropy (int): if the distribution retrieved from the policy operator does not have a closed form
-            formula for the entropy, a Monte-Carlo estimate will be used. samples_mc_entropy will control how many
+        advantage_key (str): the input tensordict key where the advantage is
+            expected to be written.
+            Defaults to ``"advantage"``.
+        value_target_key (str): the input tensordict key where the target state
+            value is expected to be written. Defaults to ``"value_target"``.
+        entropy_bonus (bool): if ``True``, an entropy bonus will be added to the
+            loss to favour exploratory policies.
+        samples_mc_entropy (int): if the distribution retrieved from the policy
+            operator does not have a closed form
+            formula for the entropy, a Monte-Carlo estimate will be used.
+            ``samples_mc_entropy`` will control how many
             samples will be used to compute this estimate.
-            default: 1
+            Defaults to ``1``.
         entropy_coef (scalar): entropy multiplier when computing the total loss.
-            default: 0.01
-        critic_coef (scalar): critic loss multiplier when computing the total loss.
-            default: 1.0
-        gamma (scalar): a discount factor for return computation.
-        loss_function (str): loss function for the value discrepancy. Can be one of "l1", "l2" or "smooth_l1".
-        normalize_advantage (bool): if True, the advantage will be normalized before being used.
-            Defaults to False.
+            Defaults to ``0.01``.
+        critic_coef (scalar): critic loss multiplier when computing the total
+            loss. Defaults to ``1.0``.
+        loss_critic_type (str): loss function for the value discrepancy.
+            Can be one of "l1", "l2" or "smooth_l1". Defaults to ``"smooth_l1"``.
+        normalize_advantage (bool): if ``True``, the advantage will be normalized
+            before being used. Defaults to ``False``.
+
+    .. note:
+      The advantage (typically GAE) can be computed by the loss function or
+      in the training loop. The latter option is usually preferred, but this is
+      up to the user to choose which option is to be preferred.
+      If the advantage key (``"advantage`` by default) is not present in the
+      input tensordict, the advantage will be computed by the :meth:`~.forward`
+      method.
+
+        >>> ppo_loss = PPOLoss(actor, critic)
+        >>> advantage = GAE(critic)
+        >>> data = next(datacollector)
+        >>> losses = ppo_loss(data)
+        >>> # equivalent
+        >>> advantage(data)
+        >>> losses = ppo_loss(data)
+
+      A custom advantage module can be built using :meth:`~.make_value_function`.
+      The default is :class:`torchrl.objectives.value.GAE` with hyperparameters
+      dictated by :func:`torchrl.objectives.utils.default_value_kwargs`.
+
+        >>> ppo_loss = PPOLoss(actor, critic)
+        >>> ppo_loss.make_value_function(ValueFunctions.TDLambda)
+        >>> data = next(datacollector)
+        >>> losses = ppo_loss(data)
 
     """
+
+    default_value_type = ValueFunctions.GAE
 
     def __init__(
         self,
         actor: ProbabilisticTensorDictSequential,
         critic: TensorDictModule,
+        *,
         advantage_key: str = "advantage",
         value_target_key: str = "value_target",
         entropy_bonus: bool = True,
         samples_mc_entropy: int = 1,
         entropy_coef: float = 0.01,
         critic_coef: float = 1.0,
-        gamma: float = 0.99,
         loss_critic_type: str = "smooth_l1",
         normalize_advantage: bool = False,
     ):
@@ -82,7 +119,6 @@ class PPOLoss(LossModule):
         self.register_buffer(
             "critic_coef", torch.tensor(critic_coef, device=self.device)
         )
-        self.register_buffer("gamma", torch.tensor(gamma, device=self.device))
         self.loss_critic_type = loss_critic_type
         self.normalize_advantage = normalize_advantage
 
@@ -117,6 +153,8 @@ class PPOLoss(LossModule):
         return log_weight, dist
 
     def loss_critic(self, tensordict: TensorDictBase) -> torch.Tensor:
+        # TODO: if the advantage is gathered by forward, this introduces an
+        # overhead that we could easily reduce.
         try:
             target_return = tensordict.get(self.value_target_key)
             tensordict_select = tensordict.select(*self.critic.in_keys)
@@ -141,7 +179,14 @@ class PPOLoss(LossModule):
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         tensordict = tensordict.clone(False)
-        advantage = tensordict.get(self.advantage_key)
+        advantage = tensordict.get(self.advantage_key, None)
+        if advantage is None:
+            self.value_function(
+                tensordict,
+                params=self.critic_params,
+                target_params=self.target_critic_params,
+            )
+            advantage = tensordict.get(self.advantage_key)
         if self.normalize_advantage and advantage.numel() > 1:
             loc = advantage.mean().item()
             scale = advantage.std().clamp_min(1e-6).item()
@@ -159,6 +204,29 @@ class PPOLoss(LossModule):
             td_out.set("loss_critic", loss_critic.mean())
         return td_out
 
+    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+        hp = dict(default_value_kwargs(value_type))
+        hp.update(hyperparams)
+        value_key = "state_value"
+        if value_type == ValueFunctions.TD1:
+            self._value_function = TD1Estimate(
+                value_network=self.critic, value_key=value_key, **hp
+            )
+        elif value_type == ValueFunctions.TD0:
+            self._value_function = TD0Estimate(
+                value_network=self.critic, value_key=value_key, **hp
+            )
+        elif value_type == ValueFunctions.GAE:
+            self._value_function = GAE(
+                value_network=self.critic, value_key=value_key, **hp
+            )
+        elif value_type == ValueFunctions.TDLambda:
+            self._value_function = TDLambdaEstimate(
+                value_network=self.critic, value_key=value_key, **hp
+            )
+        else:
+            raise NotImplementedError(f"Unknown value type {value_type}")
+
 
 class ClipPPOLoss(PPOLoss):
     """Clipped PPO loss.
@@ -170,22 +238,52 @@ class ClipPPOLoss(PPOLoss):
         actor (ProbabilisticTensorDictSequential): policy operator.
         critic (ValueOperator): value operator.
         advantage_key (str): the input tensordict key where the advantage is expected to be written.
-            default: "advantage"
+            Defaults to ``"advantage"``.
+        value_target_key (str): the input tensordict key where the target state
+            value is expected to be written. Defaults to ``"value_target"``.
         clip_epsilon (scalar): weight clipping threshold in the clipped PPO loss equation.
             default: 0.2
-        entropy_bonus (bool): if True, an entropy bonus will be added to the loss to favour exploratory policies.
-        samples_mc_entropy (int): if the distribution retrieved from the policy operator does not have a closed form
-            formula for the entropy, a Monte-Carlo estimate will be used. samples_mc_entropy will control how many
+        entropy_bonus (bool): if ``True``, an entropy bonus will be added to the
+            loss to favour exploratory policies.
+        samples_mc_entropy (int): if the distribution retrieved from the policy
+            operator does not have a closed form
+            formula for the entropy, a Monte-Carlo estimate will be used.
+            ``samples_mc_entropy`` will control how many
             samples will be used to compute this estimate.
-            default: 1
+            Defaults to ``1``.
         entropy_coef (scalar): entropy multiplier when computing the total loss.
-            default: 0.01
-        critic_coef (scalar): critic loss multiplier when computing the total loss.
-            default: 1.0
-        gamma (scalar): a discount factor for return computation.
-        loss_function (str): loss function for the value discrepancy. Can be one of "l1", "l2" or "smooth_l1".
-        normalize_advantage (bool): if True, the advantage will be normalized before being used.
-            Defaults to True.
+            Defaults to ``0.01``.
+        critic_coef (scalar): critic loss multiplier when computing the total
+            loss. Defaults to ``1.0``.
+        loss_critic_type (str): loss function for the value discrepancy.
+            Can be one of "l1", "l2" or "smooth_l1". Defaults to ``"smooth_l1"``.
+        normalize_advantage (bool): if ``True``, the advantage will be normalized
+            before being used. Defaults to ``False``.
+
+    .. note:
+      The advantage (typically GAE) can be computed by the loss function or
+      in the training loop. The latter option is usually preferred, but this is
+      up to the user to choose which option is to be preferred.
+      If the advantage key (``"advantage`` by default) is not present in the
+      input tensordict, the advantage will be computed by the :meth:`~.forward`
+      method.
+
+        >>> ppo_loss = ClipPPOLoss(actor, critic)
+        >>> advantage = GAE(critic)
+        >>> data = next(datacollector)
+        >>> losses = ppo_loss(data)
+        >>> # equivalent
+        >>> advantage(data)
+        >>> losses = ppo_loss(data)
+
+      A custom advantage module can be built using :meth:`~.make_value_function`.
+      The default is :class:`torchrl.objectives.value.GAE` with hyperparameters
+      dictated by :func:`torchrl.objectives.utils.default_value_kwargs`.
+
+        >>> ppo_loss = ClipPPOLoss(actor, critic)
+        >>> ppo_loss.make_value_function(ValueFunctions.TDLambda)
+        >>> data = next(datacollector)
+        >>> losses = ppo_loss(data)
 
     """
 
@@ -193,13 +291,13 @@ class ClipPPOLoss(PPOLoss):
         self,
         actor: ProbabilisticTensorDictSequential,
         critic: TensorDictModule,
+        *,
         advantage_key: str = "advantage",
         clip_epsilon: float = 0.2,
         entropy_bonus: bool = True,
         samples_mc_entropy: int = 1,
         entropy_coef: float = 0.01,
         critic_coef: float = 1.0,
-        gamma: float = 0.99,
         loss_critic_type: str = "smooth_l1",
         normalize_advantage: bool = True,
         **kwargs,
@@ -207,12 +305,11 @@ class ClipPPOLoss(PPOLoss):
         super(ClipPPOLoss, self).__init__(
             actor,
             critic,
-            advantage_key,
+            advantage_key=advantage_key,
             entropy_bonus=entropy_bonus,
             samples_mc_entropy=samples_mc_entropy,
             entropy_coef=entropy_coef,
             critic_coef=critic_coef,
-            gamma=gamma,
             loss_critic_type=loss_critic_type,
             normalize_advantage=normalize_advantage,
             **kwargs,
@@ -228,7 +325,14 @@ class ClipPPOLoss(PPOLoss):
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         tensordict = tensordict.clone(False)
-        advantage = tensordict.get(self.advantage_key)
+        advantage = tensordict.get(self.advantage_key, None)
+        if advantage is None:
+            self.value_function(
+                tensordict,
+                params=self.critic_params,
+                target_params=self.target_critic_params,
+            )
+            advantage = tensordict.get(self.advantage_key)
         log_weight, dist = self._log_weight(tensordict)
         # ESS for logging
         with torch.no_grad():
@@ -278,28 +382,61 @@ class KLPENPPOLoss(PPOLoss):
     Args:
         actor (ProbabilisticTensorDictSequential): policy operator.
         critic (ValueOperator): value operator.
-        advantage_key (str): the input tensordict key where the advantage is expected to be written.
-            default: "advantage"
-        dtarg (scalar): target KL divergence.
-        beta (scalar): initial KL divergence multiplier.
-            default: 1.0
-        increment (scalar): how much beta should be incremented if KL > dtarg. Valid range: increment >= 1.0
-            default: 2.0
-        decrement (scalar): how much beta should be decremented if KL < dtarg. Valid range: decrement <= 1.0
-            default: 0.5
-        entropy_bonus (bool): if True, an entropy bonus will be added to the loss to favour exploratory policies.
-        samples_mc_entropy (int): if the distribution retrieved from the policy operator does not have a closed form
-            formula for the entropy, a Monte-Carlo estimate will be used. samples_mc_entropy will control how many
+        advantage_key (str, optional): the input tensordict key where the advantage is expected to be written.
+            Defaults to ``"advantage"``.
+        value_target_key (str, optional): the input tensordict key where the target state
+            value is expected to be written. Defaults to ``"value_target"``.
+        dtarg (scalar, optional): target KL divergence. Defaults to ``0.01``.
+        samples_mc_kl (int, optional): number of samples used to compute the KL divergence
+            if no analytical formula can be found. Defaults to ``1``.
+        beta (scalar, optional): initial KL divergence multiplier.
+            Defaults to ``1.0``.
+        decrement (scalar, optional): how much beta should be decremented if KL < dtarg. Valid range: decrement <= 1.0
+            default: ``0.5``.
+        increment (scalar, optional): how much beta should be incremented if KL > dtarg. Valid range: increment >= 1.0
+            default: ``2.0``.
+        entropy_bonus (bool, optional): if ``True``, an entropy bonus will be added to the
+            loss to favour exploratory policies. Defaults to ``True``.
+        samples_mc_entropy (int, optional): if the distribution retrieved from the policy
+            operator does not have a closed form
+            formula for the entropy, a Monte-Carlo estimate will be used.
+            ``samples_mc_entropy`` will control how many
             samples will be used to compute this estimate.
-            default: 1
-        entropy_coef (scalar): entropy multiplier when computing the total loss.
-            default: 0.01
-        critic_coef (scalar): critic loss multiplier when computing the total loss.
-            default: 1.0
-        gamma (scalar): a discount factor for return computation.
-        loss_critic_type (str): loss function for the value discrepancy. Can be one of "l1", "l2" or "smooth_l1".
-        normalize_advantage (bool): if True, the advantage will be normalized before being used.
-            Defaults to True.
+            Defaults to ``1``.
+        entropy_coef (scalar, optional): entropy multiplier when computing the total loss.
+            Defaults to ``0.01``.
+        critic_coef (scalar, optional): critic loss multiplier when computing the total
+            loss. Defaults to ``1.0``.
+        loss_critic_type (str, optional): loss function for the value discrepancy.
+            Can be one of "l1", "l2" or "smooth_l1". Defaults to ``"smooth_l1"``.
+        normalize_advantage (bool, optional): if ``True``, the advantage will be normalized
+            before being used. Defaults to ``False``.
+
+
+    .. note:
+      The advantage (typically GAE) can be computed by the loss function or
+      in the training loop. The latter option is usually preferred, but this is
+      up to the user to choose which option is to be preferred.
+      If the advantage key (``"advantage`` by default) is not present in the
+      input tensordict, the advantage will be computed by the :meth:`~.forward`
+      method.
+
+        >>> ppo_loss = KLPENPPOLoss(actor, critic)
+        >>> advantage = GAE(critic)
+        >>> data = next(datacollector)
+        >>> losses = ppo_loss(data)
+        >>> # equivalent
+        >>> advantage(data)
+        >>> losses = ppo_loss(data)
+
+      A custom advantage module can be built using :meth:`~.make_value_function`.
+      The default is :class:`torchrl.objectives.value.GAE` with hyperparameters
+      dictated by :func:`torchrl.objectives.utils.default_value_kwargs`.
+
+        >>> ppo_loss = KLPENPPOLoss(actor, critic)
+        >>> ppo_loss.make_value_function(ValueFunctions.TDLambda)
+        >>> data = next(datacollector)
+        >>> losses = ppo_loss(data)
 
     """
 
@@ -307,6 +444,7 @@ class KLPENPPOLoss(PPOLoss):
         self,
         actor: ProbabilisticTensorDictSequential,
         critic: TensorDictModule,
+        *,
         advantage_key="advantage",
         dtarg: float = 0.01,
         beta: float = 1.0,
@@ -317,7 +455,6 @@ class KLPENPPOLoss(PPOLoss):
         samples_mc_entropy: int = 1,
         entropy_coef: float = 0.01,
         critic_coef: float = 1.0,
-        gamma: float = 0.99,
         loss_critic_type: str = "smooth_l1",
         normalize_advantage: bool = True,
         **kwargs,
@@ -325,12 +462,11 @@ class KLPENPPOLoss(PPOLoss):
         super(KLPENPPOLoss, self).__init__(
             actor,
             critic,
-            advantage_key,
+            advantage_key=advantage_key,
             entropy_bonus=entropy_bonus,
             samples_mc_entropy=samples_mc_entropy,
             entropy_coef=entropy_coef,
             critic_coef=critic_coef,
-            gamma=gamma,
             loss_critic_type=loss_critic_type,
             normalize_advantage=normalize_advantage,
             **kwargs,
@@ -354,7 +490,14 @@ class KLPENPPOLoss(PPOLoss):
 
     def forward(self, tensordict: TensorDictBase) -> TensorDict:
         tensordict = tensordict.clone(False)
-        advantage = tensordict.get(self.advantage_key)
+        advantage = tensordict.get(self.advantage_key, None)
+        if advantage is None:
+            self.value_function(
+                tensordict,
+                params=self.critic_params,
+                target_params=self.target_critic_params,
+            )
+            advantage = tensordict.get(self.advantage_key)
         if self.normalize_advantage and advantage.numel() > 1:
             loc = advantage.mean().item()
             scale = advantage.std().clamp_min(1e-6).item()

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -192,7 +192,7 @@ class PPOLoss(LossModule):
         if advantage is None:
             self.value_estimator(
                 tensordict,
-                params=self.critic_params,
+                params=self.critic_params.detach(),
                 target_params=self.target_critic_params,
             )
             advantage = tensordict.get(self.advantage_key)
@@ -342,7 +342,7 @@ class ClipPPOLoss(PPOLoss):
         if advantage is None:
             self.value_estimator(
                 tensordict,
-                params=self.critic_params,
+                params=self.critic_params.detach(),
                 target_params=self.target_critic_params,
             )
             advantage = tensordict.get(self.advantage_key)
@@ -509,7 +509,7 @@ class KLPENPPOLoss(PPOLoss):
         if advantage is None:
             self.value_estimator(
                 tensordict,
-                params=self.critic_params,
+                params=self.critic_params.detach(),
                 target_params=self.target_critic_params,
             )
             advantage = tensordict.get(self.advantage_key)

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -15,11 +15,11 @@ from torchrl.objectives.utils import (
     _GAMMA_LMBDA_DEPREC_WARNING,
     default_value_kwargs,
     distance_loss,
-    ValueFunctions,
+    ValueEstimators,
 )
 
 from .common import LossModule
-from .value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
+from .value import GAE, TD0Estimator, TD1Estimator, TDLambdaEstimator
 
 
 class PPOLoss(LossModule):
@@ -80,18 +80,18 @@ class PPOLoss(LossModule):
         >>> advantage(data)
         >>> losses = ppo_loss(data)
 
-      A custom advantage module can be built using :meth:`~.make_value_function`.
+      A custom advantage module can be built using :meth:`~.make_value_estimator`.
       The default is :class:`torchrl.objectives.value.GAE` with hyperparameters
       dictated by :func:`torchrl.objectives.utils.default_value_kwargs`.
 
         >>> ppo_loss = PPOLoss(actor, critic)
-        >>> ppo_loss.make_value_function(ValueFunctions.TDLambda)
+        >>> ppo_loss.make_value_estimator(ValueEstimators.TDLambda)
         >>> data = next(datacollector)
         >>> losses = ppo_loss(data)
 
     """
 
-    default_value_type = ValueFunctions.GAE
+    default_value_estimator = ValueEstimators.GAE
 
     def __init__(
         self,
@@ -213,26 +213,26 @@ class PPOLoss(LossModule):
             td_out.set("loss_critic", loss_critic.mean())
         return td_out
 
-    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+    def make_value_estimator(self, value_type: ValueEstimators, **hyperparams):
         hp = dict(default_value_kwargs(value_type))
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
         value_key = "state_value"
-        if value_type == ValueFunctions.TD1:
-            self._value_function = TD1Estimate(
+        if value_type == ValueEstimators.TD1:
+            self._value_function = TD1Estimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.TD0:
-            self._value_function = TD0Estimate(
+        elif value_type == ValueEstimators.TD0:
+            self._value_function = TD0Estimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.GAE:
+        elif value_type == ValueEstimators.GAE:
             self._value_function = GAE(
                 value_network=self.critic, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.TDLambda:
-            self._value_function = TDLambdaEstimate(
+        elif value_type == ValueEstimators.TDLambda:
+            self._value_function = TDLambdaEstimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
         else:
@@ -287,12 +287,12 @@ class ClipPPOLoss(PPOLoss):
         >>> advantage(data)
         >>> losses = ppo_loss(data)
 
-      A custom advantage module can be built using :meth:`~.make_value_function`.
+      A custom advantage module can be built using :meth:`~.make_value_estimator`.
       The default is :class:`torchrl.objectives.value.GAE` with hyperparameters
       dictated by :func:`torchrl.objectives.utils.default_value_kwargs`.
 
         >>> ppo_loss = ClipPPOLoss(actor, critic)
-        >>> ppo_loss.make_value_function(ValueFunctions.TDLambda)
+        >>> ppo_loss.make_value_estimator(ValueEstimators.TDLambda)
         >>> data = next(datacollector)
         >>> losses = ppo_loss(data)
 
@@ -442,12 +442,12 @@ class KLPENPPOLoss(PPOLoss):
         >>> advantage(data)
         >>> losses = ppo_loss(data)
 
-      A custom advantage module can be built using :meth:`~.make_value_function`.
+      A custom advantage module can be built using :meth:`~.make_value_estimator`.
       The default is :class:`torchrl.objectives.value.GAE` with hyperparameters
       dictated by :func:`torchrl.objectives.utils.default_value_kwargs`.
 
         >>> ppo_loss = KLPENPPOLoss(actor, critic)
-        >>> ppo_loss.make_value_function(ValueFunctions.TDLambda)
+        >>> ppo_loss.make_value_estimator(ValueEstimators.TDLambda)
         >>> data = next(datacollector)
         >>> losses = ppo_loss(data)
 

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -190,7 +190,7 @@ class PPOLoss(LossModule):
         tensordict = tensordict.clone(False)
         advantage = tensordict.get(self.advantage_key, None)
         if advantage is None:
-            self.value_function(
+            self.value_estimator(
                 tensordict,
                 params=self.critic_params,
                 target_params=self.target_critic_params,
@@ -220,19 +220,19 @@ class PPOLoss(LossModule):
         hp.update(hyperparams)
         value_key = "state_value"
         if value_type == ValueEstimators.TD1:
-            self._value_function = TD1Estimator(
+            self._value_estimator = TD1Estimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.TD0:
-            self._value_function = TD0Estimator(
+            self._value_estimator = TD0Estimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.GAE:
-            self._value_function = GAE(
+            self._value_estimator = GAE(
                 value_network=self.critic, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.TDLambda:
-            self._value_function = TDLambdaEstimator(
+            self._value_estimator = TDLambdaEstimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
         else:
@@ -340,7 +340,7 @@ class ClipPPOLoss(PPOLoss):
         tensordict = tensordict.clone(False)
         advantage = tensordict.get(self.advantage_key, None)
         if advantage is None:
-            self.value_function(
+            self.value_estimator(
                 tensordict,
                 params=self.critic_params,
                 target_params=self.target_critic_params,
@@ -507,7 +507,7 @@ class KLPENPPOLoss(PPOLoss):
         tensordict = tensordict.clone(False)
         advantage = tensordict.get(self.advantage_key, None)
         if advantage is None:
-            self.value_function(
+            self.value_estimator(
                 tensordict,
                 params=self.critic_params,
                 target_params=self.target_critic_params,

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -2,8 +2,8 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
 import math
+import warnings
 from numbers import Number
 from typing import Union
 
@@ -16,7 +16,12 @@ from torch import Tensor
 
 from torchrl.envs.utils import set_exploration_mode, step_mdp
 from torchrl.objectives.common import LossModule
-from torchrl.objectives.utils import default_value_kwargs, distance_loss, ValueFunctions
+from torchrl.objectives.utils import (
+    _GAMMA_LMBDA_DEPREC_WARNING,
+    default_value_kwargs,
+    distance_loss,
+    ValueFunctions,
+)
 from torchrl.objectives.value import TD0Estimate, TD1Estimate, TDLambdaEstimate
 
 try:
@@ -89,6 +94,7 @@ class REDQLoss(LossModule):
         target_entropy: Union[str, Number] = "auto",
         delay_qvalue: bool = True,
         gSDE: bool = False,
+        gamma: float = None,
     ):
         if not _has_functorch:
             raise ImportError("Failed to import functorch.") from FUNCTORCH_ERR
@@ -152,6 +158,9 @@ class REDQLoss(LossModule):
             "target_entropy", torch.tensor(target_entropy, device=device)
         )
         self.gSDE = gSDE
+        if gamma is not None:
+            warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING)
+            self.gamma = gamma
 
     @property
     def alpha(self):
@@ -315,6 +324,8 @@ class REDQLoss(LossModule):
 
     def make_value_function(self, value_type: ValueFunctions, **hyperparams):
         hp = dict(default_value_kwargs(value_type))
+        if hasattr(self, "gamma"):
+            hp["gamma"] = self.gamma
         hp.update(hyperparams)
         value_key = "state_value"
         # we do not need a value network bc the next state value is already passed

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -17,7 +17,7 @@ from torch import Tensor
 from torchrl.envs.utils import set_exploration_mode, step_mdp
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import default_value_kwargs, distance_loss, ValueFunctions
-from torchrl.objectives.value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
+from torchrl.objectives.value import TD0Estimate, TD1Estimate, TDLambdaEstimate
 
 try:
     from functorch import vmap
@@ -327,7 +327,9 @@ class REDQLoss(LossModule):
                 value_network=None, value_key=value_key, **hp
             )
         elif value_type == ValueFunctions.GAE:
-            self._value_function = GAE(value_network=None, value_key=value_key, **hp)
+            raise NotImplementedError(
+                f"Value type {value_type} it not implemented for loss {type(self)}."
+            )
         elif value_type == ValueFunctions.TDLambda:
             self._value_function = TDLambdaEstimate(
                 value_network=None, value_key=value_key, **hp

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -20,9 +20,9 @@ from torchrl.objectives.utils import (
     _GAMMA_LMBDA_DEPREC_WARNING,
     default_value_kwargs,
     distance_loss,
-    ValueFunctions,
+    ValueEstimators,
 )
-from torchrl.objectives.value import TD0Estimate, TD1Estimate, TDLambdaEstimate
+from torchrl.objectives.value import TD0Estimator, TD1Estimator, TDLambdaEstimator
 
 try:
     from functorch import vmap
@@ -76,7 +76,7 @@ class REDQLoss(LossModule):
     """
 
     delay_actor: bool = False
-    default_value_type = ValueFunctions.TD0
+    default_value_estimator = ValueEstimators.TD0
 
     def __init__(
         self,
@@ -322,27 +322,27 @@ class REDQLoss(LossModule):
             alpha_loss = torch.zeros_like(log_pi)
         return alpha_loss
 
-    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+    def make_value_estimator(self, value_type: ValueEstimators, **hyperparams):
         hp = dict(default_value_kwargs(value_type))
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
         value_key = "state_value"
         # we do not need a value network bc the next state value is already passed
-        if value_type == ValueFunctions.TD1:
-            self._value_function = TD1Estimate(
+        if value_type == ValueEstimators.TD1:
+            self._value_function = TD1Estimator(
                 value_network=None, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.TD0:
-            self._value_function = TD0Estimate(
+        elif value_type == ValueEstimators.TD0:
+            self._value_function = TD0Estimator(
                 value_network=None, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.GAE:
+        elif value_type == ValueEstimators.GAE:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
-        elif value_type == ValueFunctions.TDLambda:
-            self._value_function = TDLambdaEstimate(
+        elif value_type == ValueEstimators.TDLambda:
+            self._value_function = TDLambdaEstimator(
                 value_network=None, value_key=value_key, **hp
             )
         else:

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -275,7 +275,9 @@ class REDQLoss(LossModule):
         next_state_value = next_state_value.min(0)[0]
 
         tensordict_select.set(("next", "state_value"), next_state_value.unsqueeze(-1))
-        target_value = self.value_function.value_estimate(tensordict_select).squeeze(-1)
+        target_value = self.value_estimator.value_estimate(tensordict_select).squeeze(
+            -1
+        )
 
         pred_val = state_action_value_qvalue
         td_error = (pred_val - target_value).pow(2)
@@ -330,11 +332,11 @@ class REDQLoss(LossModule):
         value_key = "state_value"
         # we do not need a value network bc the next state value is already passed
         if value_type == ValueEstimators.TD1:
-            self._value_function = TD1Estimator(
+            self._value_estimator = TD1Estimator(
                 value_network=None, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.TD0:
-            self._value_function = TD0Estimator(
+            self._value_estimator = TD0Estimator(
                 value_network=None, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.GAE:
@@ -342,7 +344,7 @@ class REDQLoss(LossModule):
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
         elif value_type == ValueEstimators.TDLambda:
-            self._value_function = TDLambdaEstimator(
+            self._value_estimator = TDLambdaEstimator(
                 value_network=None, value_key=value_key, **hp
             )
         else:

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -16,10 +16,8 @@ from torch import Tensor
 
 from torchrl.envs.utils import set_exploration_mode, step_mdp
 from torchrl.objectives.common import LossModule
-from torchrl.objectives.utils import (
-    distance_loss,
-    next_state_value as get_next_state_value,
-)
+from torchrl.objectives.utils import default_value_kwargs, distance_loss, ValueFunctions
+from torchrl.objectives.value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
 
 try:
     from functorch import vmap
@@ -40,40 +38,49 @@ class REDQLoss(LossModule):
 
     Args:
         actor_network (TensorDictModule): the actor to be trained
-        qvalue_network (TensorDictModule): a single Q-value network that will be multiplicated as many times as needed.
-        num_qvalue_nets (int, optional): Number of Q-value networks to be trained. Default is 10.
-        sub_sample_len (int, optional): number of Q-value networks to be subsampled to evaluate the next state value
-            Default is 2.
-        gamma (Number, optional): gamma decay factor. Default is 0.99.
-        priotity_key (str, optional): Key where to write the priority value for prioritized replay buffers. Default is
-            `"td_error"`.
-        loss_function (str, optional): loss function to be used for the Q-value. Can be one of  `"smooth_l1"`, "l2",
-            "l1", Default is "smooth_l1".
+        qvalue_network (TensorDictModule): a single Q-value network that will
+            be multiplicated as many times as needed.
+        num_qvalue_nets (int, optional): Number of Q-value networks to be trained.
+            Default is ``10``.
+        sub_sample_len (int, optional): number of Q-value networks to be
+            subsampled to evaluate the next state value
+            Default is ``2``.
+        priority_key (str, optional): Key where to write the priority value
+            for prioritized replay buffers. Default is
+            ``"td_error"``.
+        loss_function (str, optional): loss function to be used for the Q-value.
+            Can be one of  ``"smooth_l1"``, ``"l2"``,
+            ``"l1"``, Default is ``"smooth_l1"``.
         alpha_init (float, optional): initial entropy multiplier.
-            Default is 1.0.
+            Default is ``1.0``.
         min_alpha (float, optional): min value of alpha.
-            Default is 0.1.
+            Default is ``0.1``.
         max_alpha (float, optional): max value of alpha.
-            Default is 10.0.
-        fixed_alpha (bool, optional): whether alpha should be trained to match a target entropy. Default is :obj:`False`.
-        target_entropy (Union[str, Number], optional): Target entropy for the stochastic policy. Default is "auto".
-        delay_qvalue (bool, optional): Whether to separate the target Q value networks from the Q value networks used
-            for data collection. Default is :obj:`False`.
-        gSDE (bool, optional): Knowing if gSDE is used is necessary to create random noise variables.
-            Default is False
+            Default is ``10.0``.
+        fixed_alpha (bool, optional): whether alpha should be trained to match
+            a target entropy. Default is ``False``.
+        target_entropy (Union[str, Number], optional): Target entropy for the
+            stochastic policy. Default is "auto".
+        delay_qvalue (bool, optional): Whether to separate the target Q value
+            networks from the Q value networks used
+            for data collection. Default is ``False``.
+        gSDE (bool, optional): Knowing if gSDE is used is necessary to create
+            random noise variables.
+            Default is ``False``.
 
     """
 
     delay_actor: bool = False
+    default_value_type = ValueFunctions.TD0
 
     def __init__(
         self,
         actor_network: TensorDictModule,
         qvalue_network: TensorDictModule,
+        *,
         num_qvalue_nets: int = 10,
         sub_sample_len: int = 2,
-        gamma: Number = 0.99,
-        priotity_key: str = "td_error",
+        priority_key: str = "td_error",
         loss_function: str = "smooth_l1",
         alpha_init: float = 1.0,
         min_alpha: float = 0.1,
@@ -107,8 +114,7 @@ class REDQLoss(LossModule):
         )
         self.num_qvalue_nets = num_qvalue_nets
         self.sub_sample_len = max(1, min(sub_sample_len, num_qvalue_nets - 1))
-        self.register_buffer("gamma", torch.tensor(gamma))
-        self.priority_key = priotity_key
+        self.priority_key = priority_key
         self.loss_function = loss_function
 
         try:
@@ -156,7 +162,7 @@ class REDQLoss(LossModule):
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         obs_keys = self.actor_network.in_keys
-        tensordict_select = tensordict.select("next", *obs_keys, "action")
+        tensordict_select = tensordict.clone(False).select("next", *obs_keys, "action")
         selected_models_idx = torch.randperm(self.num_qvalue_nets)[
             : self.sub_sample_len
         ].sort()[0]
@@ -259,11 +265,9 @@ class REDQLoss(LossModule):
         )
         next_state_value = next_state_value.min(0)[0]
 
-        target_value = get_next_state_value(
-            tensordict,
-            gamma=self.gamma,
-            pred_next_val=next_state_value,
-        )
+        tensordict_select.set(("next", "state_value"), next_state_value.unsqueeze(-1))
+        target_value = self.value_function.value_estimate(tensordict_select).squeeze(-1)
+
         pred_val = state_action_value_qvalue
         td_error = (pred_val - target_value).pow(2)
         loss_qval = distance_loss(
@@ -308,3 +312,25 @@ class REDQLoss(LossModule):
             # placeholder
             alpha_loss = torch.zeros_like(log_pi)
         return alpha_loss
+
+    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+        hp = dict(default_value_kwargs(value_type))
+        hp.update(hyperparams)
+        value_key = "state_value"
+        # we do not need a value network bc the next state value is already passed
+        if value_type == ValueFunctions.TD1:
+            self._value_function = TD1Estimate(
+                value_network=None, value_key=value_key, **hp
+            )
+        elif value_type == ValueFunctions.TD0:
+            self._value_function = TD0Estimate(
+                value_network=None, value_key=value_key, **hp
+            )
+        elif value_type == ValueFunctions.GAE:
+            self._value_function = GAE(value_network=None, value_key=value_key, **hp)
+        elif value_type == ValueFunctions.TDLambda:
+            self._value_function = TDLambdaEstimate(
+                value_network=None, value_key=value_key, **hp
+            )
+        else:
+            raise NotImplementedError(f"Unknown value type {value_type}")

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -108,7 +108,7 @@ class ReinforceLoss(LossModule):
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         advantage = tensordict.get(self.advantage_key, None)
         if advantage is None:
-            self.value_function(
+            self.value_estimator(
                 tensordict,
                 params=self.critic_params,
                 target_params=self.target_critic_params,
@@ -160,19 +160,19 @@ class ReinforceLoss(LossModule):
         hp.update(hyperparams)
         value_key = "state_value"
         if value_type == ValueEstimators.TD1:
-            self._value_function = TD1Estimator(
+            self._value_estimator = TD1Estimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.TD0:
-            self._value_function = TD0Estimator(
+            self._value_estimator = TD0Estimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.GAE:
-            self._value_function = GAE(
+            self._value_estimator = GAE(
                 value_network=self.critic, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.TDLambda:
-            self._value_function = TDLambdaEstimator(
+            self._value_estimator = TDLambdaEstimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
         else:

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -14,9 +14,9 @@ from torchrl.objectives.utils import (
     _GAMMA_LMBDA_DEPREC_WARNING,
     default_value_kwargs,
     distance_loss,
-    ValueFunctions,
+    ValueEstimators,
 )
-from torchrl.objectives.value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
+from torchrl.objectives.value import GAE, TD0Estimator, TD1Estimator, TDLambdaEstimator
 
 
 class ReinforceLoss(LossModule):
@@ -55,18 +55,18 @@ class ReinforceLoss(LossModule):
         >>> advantage(data)
         >>> losses = reinforce_loss(data)
 
-      A custom advantage module can be built using :meth:`~.make_value_function`.
+      A custom advantage module can be built using :meth:`~.make_value_estimator`.
       The default is :class:`torchrl.objectives.value.GAE` with hyperparameters
       dictated by :func:`torchrl.objectives.utils.default_value_kwargs`.
 
         >>> reinforce_loss = ReinforceLoss(actor, critic)
-        >>> reinforce_loss.make_value_function(ValueFunctions.TDLambda)
+        >>> reinforce_loss.make_value_estimator(ValueEstimators.TDLambda)
         >>> data = next(datacollector)
         >>> losses = reinforce_loss(data)
 
     """
 
-    default_value_type = ValueFunctions.GAE
+    default_value_estimator = ValueEstimators.GAE
 
     def __init__(
         self,
@@ -153,26 +153,26 @@ class ReinforceLoss(LossModule):
             )
         return loss_value
 
-    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+    def make_value_estimator(self, value_type: ValueEstimators, **hyperparams):
         hp = dict(default_value_kwargs(value_type))
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
         value_key = "state_value"
-        if value_type == ValueFunctions.TD1:
-            self._value_function = TD1Estimate(
+        if value_type == ValueEstimators.TD1:
+            self._value_function = TD1Estimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.TD0:
-            self._value_function = TD0Estimate(
+        elif value_type == ValueEstimators.TD0:
+            self._value_function = TD0Estimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.GAE:
+        elif value_type == ValueEstimators.GAE:
             self._value_function = GAE(
                 value_network=self.critic, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.TDLambda:
-            self._value_function = TDLambdaEstimate(
+        elif value_type == ValueEstimators.TDLambda:
+            self._value_function = TDLambdaEstimator(
                 value_network=self.critic, value_key=value_key, **hp
             )
         else:

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -110,7 +110,7 @@ class ReinforceLoss(LossModule):
         if advantage is None:
             self.value_estimator(
                 tensordict,
-                params=self.critic_params,
+                params=self.critic_params.detach(),
                 target_params=self.target_critic_params,
             )
             advantage = tensordict.get(self.advantage_key)

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -19,7 +19,7 @@ from torchrl.objectives.utils import default_value_kwargs, distance_loss, ValueF
 
 from ..envs.utils import set_exploration_mode, step_mdp
 from .common import LossModule
-from .value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
+from .value import TD0Estimate, TD1Estimate, TDLambdaEstimate
 
 try:
     from functorch import vmap

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -15,7 +15,9 @@ from torch import Tensor
 
 from torchrl.modules import ProbabilisticActor
 from torchrl.modules.tensordict_module.actors import ActorCriticWrapper
-from torchrl.objectives.utils import distance_loss, next_state_value
+from torchrl.objectives.utils import distance_loss, next_state_value, \
+    DEFAULT_VALUE_FUN_PARAMS
+from .value import ValueFunctionBase, TDLambdaEstimate
 
 from ..envs.utils import set_exploration_mode, step_mdp
 from .common import LossModule
@@ -39,14 +41,18 @@ class SACLoss(LossModule):
 
     Args:
         actor_network (ProbabilisticActor): stochastic actor
-        qvalue_network (TensorDictModule): Q(s, a) parametric model
-        value_network (TensorDictModule, optional): V(s) parametric model. If not
-            provided, the second version of SAC is assumed.
-        gamma (number, optional): discount for return computation
-            Default is 0.99
+        qvalue_network (TensorDictModule): Q(s, a) parametric model.
+            This module typically outputs a ``"state_action_value"`` entry.
+        value_network (TensorDictModule, optional): V(s) parametric model.
+            This module typically outputs a ``"state_value"`` entry.
+            .. note::
+              If not provided, the second version of SAC is assumed, where
+              only the Q-Value network is needed.
+        value_function (ValueFunctionBase, optional): the value function module
+            to be used. Defaults to :class:`torchrl.objectives.values.TDLambdaEstimate`.
         priority_key (str, optional): tensordict key where to write the
-            priority (for prioritized replay buffer usage). Default is
-            `"td_error"`.
+            priority (for prioritized replay buffer usage). Defaults to
+            ``"td_error"``.
         loss_function (str, optional): loss function to be used with
             the value function loss. Default is `"smooth_l1"`.
         alpha_init (float, optional): initial entropy multiplier.
@@ -78,8 +84,8 @@ class SACLoss(LossModule):
         actor_network: ProbabilisticActor,
         qvalue_network: TensorDictModule,
         value_network: Optional[TensorDictModule] = None,
+        value_function: Optional[ValueFunctionBase] = None,
         num_qvalue_nets: int = 2,
-        gamma: Number = 0.99,
         priority_key: str = "td_error",
         loss_function: str = "smooth_l1",
         alpha_init: float = 1.0,
@@ -132,7 +138,6 @@ class SACLoss(LossModule):
             compare_against=list(actor_network.parameters()) + value_params,
         )
 
-        self.register_buffer("gamma", torch.tensor(gamma))
         self.priority_key = priority_key
         self.loss_function = loss_function
         try:
@@ -173,6 +178,26 @@ class SACLoss(LossModule):
                 self.actor_network, self.value_network
             )
             make_functional(self.actor_critic)
+
+        if value_function is None:
+            value_function = self._default_value_function()
+        else:
+            value_function.value_key = "chosen_action_value"
+        self.value_function = value_function
+
+
+    def _default_value_function(self):
+        return TDLambdaEstimate(
+            gamma=DEFAULT_VALUE_FUN_PARAMS.gamma,
+            lmbda=DEFAULT_VALUE_FUN_PARAMS.lmbda,
+            value_network=self.value_network if self._version == 1 else self.qvalue_network,
+            average_rewards=True,
+            differentiable=False,
+            vectorized=True,
+            advantage_key="advantage",
+            value_target_key="value_target",
+            value_key="state_action_value" if self._version == 2 else "state_value",
+        )
 
     @property
     def device(self) -> torch.device:
@@ -409,266 +434,3 @@ class SACLoss(LossModule):
         with torch.no_grad():
             alpha = self.log_alpha.exp()
         return alpha
-
-
-class DiscreteSACLoss(LossModule):
-    """Discrete SAC Loss module.
-
-    Args:
-        actor_network (ProbabilisticActor): the actor to be trained
-        qvalue_network (TensorDictModule): a single Q-value network that will be multiplicated as many times as needed.
-        num_qvalue_nets (int, optional): Number of Q-value networks to be trained. Default is 10.
-        gamma (Number, optional): gamma decay factor. Default is 0.99.
-        priotity_key (str, optional): Key where to write the priority value for prioritized replay buffers. Default is
-            `"td_error"`.
-        loss_function (str, optional): loss function to be used for the Q-value. Can be one of  `"smooth_l1"`, "l2",
-            "l1", Default is "smooth_l1".
-        alpha_init (float, optional): initial entropy multiplier.
-            Default is 1.0.
-        min_alpha (float, optional): min value of alpha.
-            Default is 0.1.
-        max_alpha (float, optional): max value of alpha.
-            Default is 10.0.
-        fixed_alpha (bool, optional): whether alpha should be trained to match a target entropy. Default is :obj:`False`.
-        target_entropy_weight (float, optional): weight for the target entropy term.
-        target_entropy (Union[str, Number], optional): Target entropy for the stochastic policy. Default is "auto".
-        delay_qvalue (bool, optional): Whether to separate the target Q value networks from the Q value networks used
-            for data collection. Default is :obj:`False`.
-    """
-
-    delay_actor: bool = False
-
-    def __init__(
-        self,
-        actor_network: ProbabilisticActor,
-        qvalue_network: TensorDictModule,
-        num_actions: int,
-        num_qvalue_nets: int = 2,
-        gamma: Number = 0.99,
-        priotity_key: str = "td_error",
-        loss_function: str = "smooth_l1",
-        alpha_init: float = 1.0,
-        min_alpha: float = 0.1,
-        max_alpha: float = 10.0,
-        fixed_alpha: bool = False,
-        target_entropy_weight: float = 0.98,
-        target_entropy: Union[str, Number] = "auto",
-        delay_qvalue: bool = True,
-    ):
-        if not _has_functorch:
-            raise ImportError("Failed to import functorch.") from FUNCTORCH_ERROR
-        super().__init__()
-        self.convert_to_functional(
-            actor_network,
-            "actor_network",
-            create_target_params=self.delay_actor,
-            funs_to_decorate=["forward", "get_dist_params"],
-        )
-
-        self.delay_qvalue = delay_qvalue
-        self.convert_to_functional(
-            qvalue_network,
-            "qvalue_network",
-            num_qvalue_nets,
-            create_target_params=self.delay_qvalue,
-            compare_against=list(actor_network.parameters()),
-        )
-        self.num_qvalue_nets = num_qvalue_nets
-        self.register_buffer("gamma", torch.tensor(gamma))
-        self.priority_key = priotity_key
-        self.loss_function = loss_function
-
-        try:
-            device = next(self.parameters()).device
-        except AttributeError:
-            device = torch.device("cpu")
-
-        self.register_buffer("alpha_init", torch.tensor(alpha_init, device=device))
-        self.register_buffer(
-            "min_log_alpha", torch.tensor(min_alpha, device=device).log()
-        )
-        self.register_buffer(
-            "max_log_alpha", torch.tensor(max_alpha, device=device).log()
-        )
-        self.fixed_alpha = fixed_alpha
-        if fixed_alpha:
-            self.register_buffer(
-                "log_alpha", torch.tensor(math.log(alpha_init), device=device)
-            )
-        else:
-            self.register_parameter(
-                "log_alpha",
-                torch.nn.Parameter(torch.tensor(math.log(alpha_init), device=device)),
-            )
-
-        if target_entropy == "auto":
-            target_entropy = -float(np.log(1.0 / num_actions) * target_entropy_weight)
-        self.register_buffer(
-            "target_entropy", torch.tensor(target_entropy, device=device)
-        )
-
-    @property
-    def alpha(self):
-        self.log_alpha.data.clamp_(self.min_log_alpha, self.max_log_alpha)
-        with torch.no_grad():
-            alpha = self.log_alpha.exp()
-        return alpha
-
-    def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
-        obs_keys = self.actor_network.in_keys
-        tensordict_select = tensordict.select("next", *obs_keys, "action")
-
-        actor_params = torch.stack(
-            [self.actor_network_params, self.target_actor_network_params], 0
-        )
-
-        tensordict_actor_grad = tensordict_select.select(
-            *obs_keys
-        )  # to avoid overwriting keys
-        next_td_actor = step_mdp(tensordict_select).select(
-            *self.actor_network.in_keys
-        )  # next_observation ->
-        tensordict_actor = torch.stack([tensordict_actor_grad, next_td_actor], 0)
-        tensordict_actor = tensordict_actor.contiguous()
-
-        with set_exploration_mode("random"):
-            # vmap doesn't support sampling, so we take it out from the vmap
-            td_params = vmap(self.actor_network.get_dist_params)(
-                tensordict_actor,
-                actor_params,
-            )
-            if isinstance(self.actor_network, ProbabilisticActor):
-                tensordict_actor_dist = self.actor_network.build_dist_from_params(
-                    td_params
-                )
-            else:
-                tensordict_actor_dist = self.actor_network.build_dist_from_params(
-                    td_params
-                )
-            probs = tensordict_actor_dist.probs
-            z = (probs == 0.0).float() * 1e-8
-            logp_pi = torch.log(probs + z)
-            logp_pi_pol = torch.sum(probs * logp_pi, dim=-1, keepdim=True)
-
-        # repeat tensordict_actor to match the qvalue size
-        _actor_loss_td = (
-            tensordict_actor[0]
-            .select(*self.qvalue_network.in_keys)
-            .expand(self.num_qvalue_nets, *tensordict_actor[0].batch_size)
-        )  # for actor loss
-        _qval_td = tensordict_select.select(*self.qvalue_network.in_keys).expand(
-            self.num_qvalue_nets,
-            *tensordict_select.select(*self.qvalue_network.in_keys).batch_size,
-        )  # for qvalue loss
-        _next_val_td = (
-            tensordict_actor[1]
-            .select(*self.qvalue_network.in_keys)
-            .expand(self.num_qvalue_nets, *tensordict_actor[1].batch_size)
-        )  # for next value estimation
-        tensordict_qval = torch.cat(
-            [
-                _actor_loss_td,
-                _next_val_td,
-                _qval_td,
-            ],
-            0,
-        )
-
-        # cat params
-        q_params_detach = self.qvalue_network_params.detach()
-        qvalue_params = torch.cat(
-            [
-                q_params_detach,
-                self.target_qvalue_network_params,
-                self.qvalue_network_params,
-            ],
-            0,
-        )
-        tensordict_qval = vmap(self.qvalue_network)(
-            tensordict_qval,
-            qvalue_params,
-        )
-
-        state_action_value = tensordict_qval.get("state_value").squeeze(-1)
-        (
-            state_action_value_actor,
-            next_state_action_value_qvalue,
-            state_action_value_qvalue,
-        ) = state_action_value.split(
-            [self.num_qvalue_nets, self.num_qvalue_nets, self.num_qvalue_nets],
-            dim=0,
-        )
-
-        loss_actor = -(
-            (state_action_value_actor.min(0)[0] * probs[0]).sum(-1, keepdim=True)
-            - self.alpha * logp_pi_pol[0]
-        ).mean()
-
-        pred_next_val = (
-            probs[1]
-            * (next_state_action_value_qvalue.min(0)[0] - self.alpha * logp_pi[1])
-        ).sum(dim=-1, keepdim=True)
-
-        target_value = next_state_value(
-            tensordict,
-            gamma=self.gamma,
-            pred_next_val=pred_next_val,
-        )
-
-        actions = torch.argmax(tensordict_select["action"], dim=-1)
-
-        pred_val_1 = (
-            state_action_value_qvalue[0].gather(-1, actions.unsqueeze(-1)).unsqueeze(0)
-        )
-        pred_val_2 = (
-            state_action_value_qvalue[1].gather(-1, actions.unsqueeze(-1)).unsqueeze(0)
-        )
-        pred_val = torch.cat([pred_val_1, pred_val_2], dim=0).squeeze()
-        td_error = (pred_val - target_value.expand_as(pred_val)).pow(2)
-        loss_qval = (
-            distance_loss(
-                pred_val,
-                target_value.expand_as(pred_val),
-                loss_function=self.loss_function,
-            )
-            .mean(-1)
-            .sum()
-            * 0.5
-        )
-
-        tensordict.set("td_error", td_error.detach().max(0)[0])
-
-        loss_alpha = self._loss_alpha(logp_pi_pol)
-        if not loss_qval.shape == loss_actor.shape:
-            raise RuntimeError(
-                f"QVal and actor loss have different shape: {loss_qval.shape} and {loss_actor.shape}"
-            )
-        td_out = TensorDict(
-            {
-                "loss_actor": loss_actor.mean(),
-                "loss_qvalue": loss_qval.mean(),
-                "loss_alpha": loss_alpha.mean(),
-                "alpha": self.alpha.detach(),
-                "entropy": -logp_pi.mean().detach(),
-                "state_action_value_actor": state_action_value_actor.mean().detach(),
-                "action_log_prob_actor": logp_pi.mean().detach(),
-                "next.state_value": pred_next_val.mean().detach(),
-                "target_value": target_value.mean().detach(),
-            },
-            [],
-        )
-
-        return td_out
-
-    def _loss_alpha(self, log_pi: Tensor) -> Tensor:
-        if torch.is_grad_enabled() and not log_pi.requires_grad:
-            raise RuntimeError(
-                "expected log_pi to require gradient for the alpha loss)"
-            )
-        if self.target_entropy is not None:
-            # we can compute this loss even if log_alpha is not a parameter
-            alpha_loss = -self.log_alpha.exp() * (log_pi.detach() + self.target_entropy)
-        else:
-            # placeholder
-            alpha_loss = torch.zeros_like(log_pi)
-        return alpha_loss

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -15,8 +15,7 @@ from torch import Tensor
 
 from torchrl.modules import ProbabilisticActor
 from torchrl.modules.tensordict_module.actors import ActorCriticWrapper
-from torchrl.objectives.utils import distance_loss, next_state_value, \
-    DEFAULT_VALUE_FUN_PARAMS
+from torchrl.objectives.utils import distance_loss, next_state_value
 from .value import ValueFunctionBase, TDLambdaEstimate
 
 from ..envs.utils import set_exploration_mode, step_mdp
@@ -181,8 +180,13 @@ class SACLoss(LossModule):
 
         if value_function is None:
             value_function = self._default_value_function()
+        elif self._version == 1:
+            # in v1, the next value requires an action to be sampled
+            value_function.value_network = self.actor_critic
         else:
-            value_function.value_key = "chosen_action_value"
+            # TODO
+            pass
+
         self.value_function = value_function
 
 
@@ -190,7 +194,7 @@ class SACLoss(LossModule):
         return TDLambdaEstimate(
             gamma=DEFAULT_VALUE_FUN_PARAMS.gamma,
             lmbda=DEFAULT_VALUE_FUN_PARAMS.lmbda,
-            value_network=self.value_network if self._version == 1 else self.qvalue_network,
+            value_network=self.actor_critic if self._version == 1 else self.qvalue_network,
             average_rewards=True,
             differentiable=False,
             vectorized=True,
@@ -244,10 +248,7 @@ class SACLoss(LossModule):
         }
         if self._version == 1:
             out["loss_value"] = loss_value.mean()
-        return TensorDict(
-            out,
-            [],
-        )
+        return TensorDict(out,[])
 
     def _loss_actor(self, tensordict: TensorDictBase) -> Tensor:
         # KL lossa
@@ -278,8 +279,7 @@ class SACLoss(LossModule):
         return self._alpha * log_prob - min_q_logprob
 
     def _loss_qvalue_v1(self, tensordict: TensorDictBase) -> Tuple[Tensor, Tensor]:
-        actor_critic = self.actor_critic
-        params = TensorDict(
+        target_params = TensorDict(
             {
                 "module": {
                     "0": self.target_actor_network_params,
@@ -290,19 +290,16 @@ class SACLoss(LossModule):
             _run_checks=False,
         )
         with set_exploration_mode("mode"):
-            target_value = next_state_value(
+            target_value = self.value_function.value_estimate(
                 tensordict,
-                actor_critic,
-                gamma=self.gamma,
-                next_val_key="state_value",
-                params=params,
+                target_params=target_params
             )
 
         # value loss
         qvalue_network = self.qvalue_network
 
-        # Q-nets must be trained independently: as such, we split the data in 2 if required and train each q-net on
-        # one half of the data.
+        # Q-nets must be trained independently: as such, we split the data in 2
+        # if required and train each q-net on one half of the data.
         shape = tensordict.shape
         if shape[0] % self.num_qvalue_nets != 0:
             raise RuntimeError(
@@ -341,8 +338,8 @@ class SACLoss(LossModule):
                     next_td,
                     params=self.target_actor_network_params,
                 )
-                next_td["action"] = dist.rsample()
-                next_td["sample_log_prob"] = dist.log_prob(next_td["action"])
+                next_td.set("action", dist.rsample())
+                next_td.set("sample_log_prob", dist.log_prob(next_td["action"]))
             sample_log_prob = next_td.get("sample_log_prob")
             # get q-values
             next_td = vmap(self.qvalue_network, (None, 0))(
@@ -356,7 +353,7 @@ class SACLoss(LossModule):
             ):
                 sample_log_prob = sample_log_prob.unsqueeze(-1)
             state_value = (
-                next_td.get("state_action_value") - self._alpha * sample_log_prob
+                state_action_value - self._alpha * sample_log_prob
             )
             state_value = state_value.min(0)[0]
 
@@ -434,3 +431,266 @@ class SACLoss(LossModule):
         with torch.no_grad():
             alpha = self.log_alpha.exp()
         return alpha
+
+
+class DiscreteSACLoss(LossModule):
+    """Discrete SAC Loss module.
+
+    Args:
+        actor_network (ProbabilisticActor): the actor to be trained
+        qvalue_network (TensorDictModule): a single Q-value network that will be multiplicated as many times as needed.
+        num_qvalue_nets (int, optional): Number of Q-value networks to be trained. Default is 10.
+        gamma (Number, optional): gamma decay factor. Default is 0.99.
+        priotity_key (str, optional): Key where to write the priority value for prioritized replay buffers. Default is
+            `"td_error"`.
+        loss_function (str, optional): loss function to be used for the Q-value. Can be one of  `"smooth_l1"`, "l2",
+            "l1", Default is "smooth_l1".
+        alpha_init (float, optional): initial entropy multiplier.
+            Default is 1.0.
+        min_alpha (float, optional): min value of alpha.
+            Default is 0.1.
+        max_alpha (float, optional): max value of alpha.
+            Default is 10.0.
+        fixed_alpha (bool, optional): whether alpha should be trained to match a target entropy. Default is :obj:`False`.
+        target_entropy_weight (float, optional): weight for the target entropy term.
+        target_entropy (Union[str, Number], optional): Target entropy for the stochastic policy. Default is "auto".
+        delay_qvalue (bool, optional): Whether to separate the target Q value networks from the Q value networks used
+            for data collection. Default is :obj:`False`.
+    """
+
+    delay_actor: bool = False
+
+    def __init__(
+        self,
+        actor_network: ProbabilisticActor,
+        qvalue_network: TensorDictModule,
+        num_actions: int,
+        num_qvalue_nets: int = 2,
+        gamma: Number = 0.99,
+        priotity_key: str = "td_error",
+        loss_function: str = "smooth_l1",
+        alpha_init: float = 1.0,
+        min_alpha: float = 0.1,
+        max_alpha: float = 10.0,
+        fixed_alpha: bool = False,
+        target_entropy_weight: float = 0.98,
+        target_entropy: Union[str, Number] = "auto",
+        delay_qvalue: bool = True,
+    ):
+        if not _has_functorch:
+            raise ImportError("Failed to import functorch.") from FUNCTORCH_ERROR
+        super().__init__()
+        self.convert_to_functional(
+            actor_network,
+            "actor_network",
+            create_target_params=self.delay_actor,
+            funs_to_decorate=["forward", "get_dist_params"],
+        )
+
+        self.delay_qvalue = delay_qvalue
+        self.convert_to_functional(
+            qvalue_network,
+            "qvalue_network",
+            num_qvalue_nets,
+            create_target_params=self.delay_qvalue,
+            compare_against=list(actor_network.parameters()),
+        )
+        self.num_qvalue_nets = num_qvalue_nets
+        self.register_buffer("gamma", torch.tensor(gamma))
+        self.priority_key = priotity_key
+        self.loss_function = loss_function
+
+        try:
+            device = next(self.parameters()).device
+        except AttributeError:
+            device = torch.device("cpu")
+
+        self.register_buffer("alpha_init", torch.tensor(alpha_init, device=device))
+        self.register_buffer(
+            "min_log_alpha", torch.tensor(min_alpha, device=device).log()
+        )
+        self.register_buffer(
+            "max_log_alpha", torch.tensor(max_alpha, device=device).log()
+        )
+        self.fixed_alpha = fixed_alpha
+        if fixed_alpha:
+            self.register_buffer(
+                "log_alpha", torch.tensor(math.log(alpha_init), device=device)
+            )
+        else:
+            self.register_parameter(
+                "log_alpha",
+                torch.nn.Parameter(torch.tensor(math.log(alpha_init), device=device)),
+            )
+
+        if target_entropy == "auto":
+            target_entropy = -float(np.log(1.0 / num_actions) * target_entropy_weight)
+        self.register_buffer(
+            "target_entropy", torch.tensor(target_entropy, device=device)
+        )
+
+    @property
+    def alpha(self):
+        self.log_alpha.data.clamp_(self.min_log_alpha, self.max_log_alpha)
+        with torch.no_grad():
+            alpha = self.log_alpha.exp()
+        return alpha
+
+    def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
+        obs_keys = self.actor_network.in_keys
+        tensordict_select = tensordict.select("next", *obs_keys, "action")
+
+        actor_params = torch.stack(
+            [self.actor_network_params, self.target_actor_network_params], 0
+        )
+
+        tensordict_actor_grad = tensordict_select.select(
+            *obs_keys
+        )  # to avoid overwriting keys
+        next_td_actor = step_mdp(tensordict_select).select(
+            *self.actor_network.in_keys
+        )  # next_observation ->
+        tensordict_actor = torch.stack([tensordict_actor_grad, next_td_actor], 0)
+        tensordict_actor = tensordict_actor.contiguous()
+
+        with set_exploration_mode("random"):
+            # vmap doesn't support sampling, so we take it out from the vmap
+            td_params = vmap(self.actor_network.get_dist_params)(
+                tensordict_actor,
+                actor_params,
+            )
+            if isinstance(self.actor_network, ProbabilisticActor):
+                tensordict_actor_dist = self.actor_network.build_dist_from_params(
+                    td_params
+                )
+            else:
+                tensordict_actor_dist = self.actor_network.build_dist_from_params(
+                    td_params
+                )
+            probs = tensordict_actor_dist.probs
+            z = (probs == 0.0).float() * 1e-8
+            logp_pi = torch.log(probs + z)
+            logp_pi_pol = torch.sum(probs * logp_pi, dim=-1, keepdim=True)
+
+        # repeat tensordict_actor to match the qvalue size
+        _actor_loss_td = (
+            tensordict_actor[0]
+            .select(*self.qvalue_network.in_keys)
+            .expand(self.num_qvalue_nets, *tensordict_actor[0].batch_size)
+        )  # for actor loss
+        _qval_td = tensordict_select.select(*self.qvalue_network.in_keys).expand(
+            self.num_qvalue_nets,
+            *tensordict_select.select(*self.qvalue_network.in_keys).batch_size,
+        )  # for qvalue loss
+        _next_val_td = (
+            tensordict_actor[1]
+            .select(*self.qvalue_network.in_keys)
+            .expand(self.num_qvalue_nets, *tensordict_actor[1].batch_size)
+        )  # for next value estimation
+        tensordict_qval = torch.cat(
+            [
+                _actor_loss_td,
+                _next_val_td,
+                _qval_td,
+            ],
+            0,
+        )
+
+        # cat params
+        q_params_detach = self.qvalue_network_params.detach()
+        qvalue_params = torch.cat(
+            [
+                q_params_detach,
+                self.target_qvalue_network_params,
+                self.qvalue_network_params,
+            ],
+            0,
+        )
+        tensordict_qval = vmap(self.qvalue_network)(
+            tensordict_qval,
+            qvalue_params,
+        )
+
+        state_action_value = tensordict_qval.get("state_value").squeeze(-1)
+        (
+            state_action_value_actor,
+            next_state_action_value_qvalue,
+            state_action_value_qvalue,
+        ) = state_action_value.split(
+            [self.num_qvalue_nets, self.num_qvalue_nets, self.num_qvalue_nets],
+            dim=0,
+        )
+
+        loss_actor = -(
+            (state_action_value_actor.min(0)[0] * probs[0]).sum(-1, keepdim=True)
+            - self.alpha * logp_pi_pol[0]
+        ).mean()
+
+        pred_next_val = (
+            probs[1]
+            * (next_state_action_value_qvalue.min(0)[0] - self.alpha * logp_pi[1])
+        ).sum(dim=-1, keepdim=True)
+
+        target_value = next_state_value(
+            tensordict,
+            gamma=self.gamma,
+            pred_next_val=pred_next_val,
+        )
+
+        actions = torch.argmax(tensordict_select["action"], dim=-1)
+
+        pred_val_1 = (
+            state_action_value_qvalue[0].gather(-1, actions.unsqueeze(-1)).unsqueeze(0)
+        )
+        pred_val_2 = (
+            state_action_value_qvalue[1].gather(-1, actions.unsqueeze(-1)).unsqueeze(0)
+        )
+        pred_val = torch.cat([pred_val_1, pred_val_2], dim=0).squeeze()
+        td_error = (pred_val - target_value.expand_as(pred_val)).pow(2)
+        loss_qval = (
+            distance_loss(
+                pred_val,
+                target_value.expand_as(pred_val),
+                loss_function=self.loss_function,
+            )
+            .mean(-1)
+            .sum()
+            * 0.5
+        )
+
+        tensordict.set("td_error", td_error.detach().max(0)[0])
+
+        loss_alpha = self._loss_alpha(logp_pi_pol)
+        if not loss_qval.shape == loss_actor.shape:
+            raise RuntimeError(
+                f"QVal and actor loss have different shape: {loss_qval.shape} and {loss_actor.shape}"
+            )
+        td_out = TensorDict(
+            {
+                "loss_actor": loss_actor.mean(),
+                "loss_qvalue": loss_qval.mean(),
+                "loss_alpha": loss_alpha.mean(),
+                "alpha": self.alpha.detach(),
+                "entropy": -logp_pi.mean().detach(),
+                "state_action_value_actor": state_action_value_actor.mean().detach(),
+                "action_log_prob_actor": logp_pi.mean().detach(),
+                "next.state_value": pred_next_val.mean().detach(),
+                "target_value": target_value.mean().detach(),
+            },
+            [],
+        )
+
+        return td_out
+
+    def _loss_alpha(self, log_pi: Tensor) -> Tensor:
+        if torch.is_grad_enabled() and not log_pi.requires_grad:
+            raise RuntimeError(
+                "expected log_pi to require gradient for the alpha loss)"
+            )
+        if self.target_entropy is not None:
+            # we can compute this loss even if log_alpha is not a parameter
+            alpha_loss = -self.log_alpha.exp() * (log_pi.detach() + self.target_entropy)
+        else:
+            # placeholder
+            alpha_loss = torch.zeros_like(log_pi)
+        return alpha_loss

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -19,12 +19,12 @@ from torchrl.objectives.utils import (
     _GAMMA_LMBDA_DEPREC_WARNING,
     default_value_kwargs,
     distance_loss,
-    ValueFunctions,
+    ValueEstimators,
 )
 
 from ..envs.utils import set_exploration_mode, step_mdp
 from .common import LossModule
-from .value import TD0Estimate, TD1Estimate, TDLambdaEstimate
+from .value import TD0Estimator, TD1Estimator, TDLambdaEstimator
 
 try:
     from functorch import vmap
@@ -83,7 +83,7 @@ class SACLoss(LossModule):
             Default is ``False``.
     """
 
-    default_value_type = ValueFunctions.TD0
+    default_value_estimator = ValueEstimators.TD0
 
     def __init__(
         self,
@@ -189,7 +189,7 @@ class SACLoss(LossModule):
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING)
             self.gamma = gamma
 
-    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+    def make_value_estimator(self, value_type: ValueEstimators, **hyperparams):
         if self._version == 1:
             value_net = self.actor_critic
         elif self._version == 2:
@@ -202,26 +202,26 @@ class SACLoss(LossModule):
         value_key = "state_value"
         hp = dict(default_value_kwargs(value_type))
         hp.update(hyperparams)
-        if value_type is ValueFunctions.TD1:
-            self._value_function = TD1Estimate(
+        if value_type is ValueEstimators.TD1:
+            self._value_function = TD1Estimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",
                 value_key=value_key,
             )
-        elif value_type is ValueFunctions.TD0:
-            self._value_function = TD0Estimate(
+        elif value_type is ValueEstimators.TD0:
+            self._value_function = TD0Estimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",
                 value_key=value_key,
             )
-        elif value_type is ValueFunctions.GAE:
+        elif value_type is ValueEstimators.GAE:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
-        elif value_type is ValueFunctions.TDLambda:
-            self._value_function = TDLambdaEstimate(
+        elif value_type is ValueEstimators.TDLambda:
+            self._value_function = TDLambdaEstimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",
@@ -495,7 +495,7 @@ class DiscreteSACLoss(LossModule):
 
     """
 
-    default_value_type = ValueFunctions.TD0
+    default_value_estimator = ValueEstimators.TD0
     delay_actor: bool = False
 
     def __init__(
@@ -729,33 +729,33 @@ class DiscreteSACLoss(LossModule):
             alpha_loss = torch.zeros_like(log_pi)
         return alpha_loss
 
-    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+    def make_value_estimator(self, value_type: ValueEstimators, **hyperparams):
         value_net = None
         value_key = "state_value"
         hp = dict(default_value_kwargs(value_type))
         hp.update(hyperparams)
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
-        if value_type is ValueFunctions.TD1:
-            self._value_function = TD1Estimate(
+        if value_type is ValueEstimators.TD1:
+            self._value_function = TD1Estimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",
                 value_key=value_key,
             )
-        elif value_type is ValueFunctions.TD0:
-            self._value_function = TD0Estimate(
+        elif value_type is ValueEstimators.TD0:
+            self._value_function = TD0Estimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",
                 value_key=value_key,
             )
-        elif value_type is ValueFunctions.GAE:
+        elif value_type is ValueEstimators.GAE:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
-        elif value_type is ValueFunctions.TDLambda:
-            self._value_function = TDLambdaEstimate(
+        elif value_type is ValueEstimators.TDLambda:
+            self._value_function = TDLambdaEstimator(
                 **hp,
                 value_network=value_net,
                 value_target_key="value_target",

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -195,7 +195,7 @@ class TD3Loss(LossModule):
 
         next_state_value = next_state_action_value_qvalue.min(0)[0]
         tensordict.set(("next", "state_action_value"), next_state_value.unsqueeze(-1))
-        target_value = self.value_function.value_estimate(tensordict).squeeze(-1)
+        target_value = self.value_estimator.value_estimate(tensordict).squeeze(-1)
         pred_val = state_action_value_qvalue
         td_error = (pred_val - target_value).pow(2)
         loss_qval = (
@@ -237,11 +237,11 @@ class TD3Loss(LossModule):
         value_key = "state_action_value"
         # we do not need a value network bc the next state value is already passed
         if value_type == ValueEstimators.TD1:
-            self._value_function = TD1Estimator(
+            self._value_estimator = TD1Estimator(
                 value_network=None, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.TD0:
-            self._value_function = TD0Estimator(
+            self._value_estimator = TD0Estimator(
                 value_network=None, value_key=value_key, **hp
             )
         elif value_type == ValueEstimators.GAE:
@@ -249,7 +249,7 @@ class TD3Loss(LossModule):
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
         elif value_type == ValueEstimators.TDLambda:
-            self._value_function = TDLambdaEstimator(
+            self._value_estimator = TDLambdaEstimator(
                 value_network=None, value_key=value_key, **hp
             )
         else:

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -34,21 +34,29 @@ class TD3Loss(LossModule):
 
     Args:
         actor_network (TensorDictModule): the actor to be trained
-        qvalue_network (TensorDictModule): a single Q-value network that will be multiplicated as many times as needed.
-        num_qvalue_nets (int, optional): Number of Q-value networks to be trained. Default is 10.
-        policy_noise (float, optional): Standard deviation for the target policy action noise. Default is 0.2.
-        noise_clip (float, optional): Clipping range value for the sampled target policy action noise. Default is 0.5.
-        priority_key (str, optional): Key where to write the priority value for prioritized replay buffers. Default is
+        qvalue_network (TensorDictModule): a single Q-value network that will
+            be multiplicated as many times as needed.
+        num_qvalue_nets (int, optional): Number of Q-value networks to be
+            trained. Default is ``10``.
+        policy_noise (float, optional): Standard deviation for the target
+            policy action noise. Default is ``0.2``.
+        noise_clip (float, optional): Clipping range value for the sampled
+            target policy action noise. Default is ``0.5``.
+        priority_key (str, optional): Key where to write the priority value
+            for prioritized replay buffers. Default is
             `"td_error"`.
-        loss_function (str, optional): loss function to be used for the Q-value. Can be one of  `"smooth_l1"`, "l2",
-            "l1", Default is "smooth_l1".
-        delay_actor (bool, optional): whether to separate the target actor networks from the actor networks used for
+        loss_function (str, optional): loss function to be used for the Q-value.
+            Can be one of  ``"smooth_l1"``, ``"l2"``,
+            ``"l1"``, Default is ``"smooth_l1"``.
+        delay_actor (bool, optional): whether to separate the target actor
+            networks from the actor networks used for
             data collection. Default is ``False``.
-        delay_qvalue (bool, optional): Whether to separate the target Q value networks from the Q value networks used
+        delay_qvalue (bool, optional): Whether to separate the target Q value
+            networks from the Q value networks used
             for data collection. Default is ``False``.
     """
 
-    default_value_type = ValueFunctions.TD0
+    default_value_function = ValueFunctions.TD0
 
     def __init__(
         self,

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -15,9 +15,9 @@ from torchrl.objectives.utils import (
     _GAMMA_LMBDA_DEPREC_WARNING,
     default_value_kwargs,
     distance_loss,
-    ValueFunctions,
+    ValueEstimators,
 )
-from torchrl.objectives.value import TD0Estimate, TD1Estimate, TDLambdaEstimate
+from torchrl.objectives.value import TD0Estimator, TD1Estimator, TDLambdaEstimator
 
 try:
     from functorch import vmap
@@ -56,7 +56,7 @@ class TD3Loss(LossModule):
             for data collection. Default is ``False``.
     """
 
-    default_value_function = ValueFunctions.TD0
+    default_value_estimator = ValueEstimators.TD0
 
     def __init__(
         self,
@@ -229,27 +229,27 @@ class TD3Loss(LossModule):
 
         return td_out
 
-    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+    def make_value_estimator(self, value_type: ValueEstimators, **hyperparams):
         hp = dict(default_value_kwargs(value_type))
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
         value_key = "state_action_value"
         # we do not need a value network bc the next state value is already passed
-        if value_type == ValueFunctions.TD1:
-            self._value_function = TD1Estimate(
+        if value_type == ValueEstimators.TD1:
+            self._value_function = TD1Estimator(
                 value_network=None, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.TD0:
-            self._value_function = TD0Estimate(
+        elif value_type == ValueEstimators.TD0:
+            self._value_function = TD0Estimator(
                 value_network=None, value_key=value_key, **hp
             )
-        elif value_type == ValueFunctions.GAE:
+        elif value_type == ValueEstimators.GAE:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
-        elif value_type == ValueFunctions.TDLambda:
-            self._value_function = TDLambdaEstimate(
+        elif value_type == ValueEstimators.TDLambda:
+            self._value_function = TDLambdaEstimator(
                 value_network=None, value_key=value_key, **hp
             )
         else:

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -12,7 +12,7 @@ from tensordict.tensordict import TensorDict, TensorDictBase
 from torchrl.envs.utils import set_exploration_mode, step_mdp
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import default_value_kwargs, distance_loss, ValueFunctions
-from torchrl.objectives.value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
+from torchrl.objectives.value import TD0Estimate, TD1Estimate, TDLambdaEstimate
 
 try:
     from functorch import vmap

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from numbers import Number
 
 import torch
 from tensordict.nn import TensorDictModule
@@ -12,10 +11,8 @@ from tensordict.tensordict import TensorDict, TensorDictBase
 
 from torchrl.envs.utils import set_exploration_mode, step_mdp
 from torchrl.objectives.common import LossModule
-from torchrl.objectives.utils import (
-    distance_loss,
-    next_state_value as get_next_state_value,
-)
+from torchrl.objectives.utils import default_value_kwargs, distance_loss, ValueFunctions
+from torchrl.objectives.value import GAE, TD0Estimate, TD1Estimate, TDLambdaEstimate
 
 try:
     from functorch import vmap
@@ -34,29 +31,29 @@ class TD3Loss(LossModule):
         actor_network (TensorDictModule): the actor to be trained
         qvalue_network (TensorDictModule): a single Q-value network that will be multiplicated as many times as needed.
         num_qvalue_nets (int, optional): Number of Q-value networks to be trained. Default is 10.
-        gamma (Number, optional): gamma decay factor. Default is 0.99.
-        max_action (float, optional): Maximum action, in MuJoCo environments typically 1.0.
         policy_noise (float, optional): Standard deviation for the target policy action noise. Default is 0.2.
         noise_clip (float, optional): Clipping range value for the sampled target policy action noise. Default is 0.5.
-        priotity_key (str, optional): Key where to write the priority value for prioritized replay buffers. Default is
+        priority_key (str, optional): Key where to write the priority value for prioritized replay buffers. Default is
             `"td_error"`.
         loss_function (str, optional): loss function to be used for the Q-value. Can be one of  `"smooth_l1"`, "l2",
             "l1", Default is "smooth_l1".
         delay_actor (bool, optional): whether to separate the target actor networks from the actor networks used for
-            data collection. Default is :obj:`False`.
+            data collection. Default is ``False``.
         delay_qvalue (bool, optional): Whether to separate the target Q value networks from the Q value networks used
-            for data collection. Default is :obj:`False`.
+            for data collection. Default is ``False``.
     """
+
+    default_value_type = ValueFunctions.TD0
 
     def __init__(
         self,
         actor_network: TensorDictModule,
         qvalue_network: TensorDictModule,
+        *,
         num_qvalue_nets: int = 2,
-        gamma: Number = 0.99,
         policy_noise: float = 0.2,
         noise_clip: float = 0.5,
-        priotity_key: str = "td_error",
+        priority_key: str = "td_error",
         loss_function: str = "smooth_l1",
         delay_actor: bool = False,
         delay_qvalue: bool = False,
@@ -86,8 +83,7 @@ class TD3Loss(LossModule):
         )
 
         self.num_qvalue_nets = num_qvalue_nets
-        self.register_buffer("gamma", torch.tensor(gamma))
-        self.priority_key = priotity_key
+        self.priority_key = priority_key
         self.loss_function = loss_function
         self.policy_noise = policy_noise
         self.noise_clip = noise_clip
@@ -95,16 +91,17 @@ class TD3Loss(LossModule):
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         obs_keys = self.actor_network.in_keys
-        tensordict_select = tensordict.select("next", *obs_keys, "action")
+        tensordict_save = tensordict
+        tensordict = tensordict.clone(False)
 
         actor_params = torch.stack(
             [self.actor_network_params, self.target_actor_network_params], 0
         )
 
-        tensordict_actor_grad = tensordict_select.select(
+        tensordict_actor_grad = tensordict.select(
             *obs_keys
         )  # to avoid overwriting keys
-        next_td_actor = step_mdp(tensordict_select).select(
+        next_td_actor = step_mdp(tensordict).select(
             *self.actor_network.in_keys
         )  # next_observation ->
         tensordict_actor = torch.stack([tensordict_actor_grad, next_td_actor], 0)
@@ -134,9 +131,9 @@ class TD3Loss(LossModule):
             .select(*self.qvalue_network.in_keys)
             .expand(self.num_qvalue_nets, *tensordict_actor[0].batch_size)
         )  # for actor loss
-        _qval_td = tensordict_select.select(*self.qvalue_network.in_keys).expand(
+        _qval_td = tensordict.select(*self.qvalue_network.in_keys).expand(
             self.num_qvalue_nets,
-            *tensordict_select.select(*self.qvalue_network.in_keys).batch_size,
+            *tensordict.select(*self.qvalue_network.in_keys).batch_size,
         )  # for qvalue loss
         _next_val_td = (
             tensordict_actor[1]
@@ -180,12 +177,8 @@ class TD3Loss(LossModule):
         loss_actor = -(state_action_value_actor.min(0)[0]).mean()
 
         next_state_value = next_state_action_value_qvalue.min(0)[0]
-
-        target_value = get_next_state_value(
-            tensordict,
-            gamma=self.gamma,
-            pred_next_val=next_state_value,
-        )
+        tensordict.set(("next", "state_action_value"), next_state_value.unsqueeze(-1))
+        target_value = self.value_function.value_estimate(tensordict).squeeze(-1)
         pred_val = state_action_value_qvalue
         td_error = (pred_val - target_value).pow(2)
         loss_qval = (
@@ -199,7 +192,7 @@ class TD3Loss(LossModule):
             * 0.5
         )
 
-        tensordict.set("td_error", td_error.detach().max(0)[0])
+        tensordict_save.set("td_error", td_error.detach().max(0)[0])
 
         if not loss_qval.shape == loss_actor.shape:
             raise RuntimeError(
@@ -218,3 +211,27 @@ class TD3Loss(LossModule):
         )
 
         return td_out
+
+    def make_value_function(self, value_type: ValueFunctions, **hyperparams):
+        hp = dict(default_value_kwargs(value_type))
+        hp.update(hyperparams)
+        value_key = "state_action_value"
+        # we do not need a value network bc the next state value is already passed
+        if value_type == ValueFunctions.TD1:
+            self._value_function = TD1Estimate(
+                value_network=None, value_key=value_key, **hp
+            )
+        elif value_type == ValueFunctions.TD0:
+            self._value_function = TD0Estimate(
+                value_network=None, value_key=value_key, **hp
+            )
+        elif value_type == ValueFunctions.GAE:
+            raise NotImplementedError(
+                f"Value type {value_type} it not implemented for loss {type(self)}."
+            )
+        elif value_type == ValueFunctions.TDLambda:
+            self._value_function = TDLambdaEstimate(
+                value_network=None, value_key=value_key, **hp
+            )
+        else:
+            raise NotImplementedError(f"Unknown value type {value_type}")

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -18,11 +18,11 @@ from torchrl.envs.utils import step_mdp
 _GAMMA_LMBDA_DEPREC_WARNING = (
     "Passing gamma / lambda parameters through the loss constructor "
     "is deprecated and will be removed soon. To customize your value function, "
-    "run `loss_module.make_value_function(ValueFunctions.<value_fun>, gamma=val)`."
+    "run `loss_module.make_value_estimator(ValueFunctions.<value_fun>, gamma=val)`."
 )
 
 
-class ValueFunctions(Enum):
+class ValueEstimators(Enum):
     """Value function enumerator for custom-built estimators.
 
     Allows for a flexible usage of various value functions when the loss module
@@ -30,7 +30,7 @@ class ValueFunctions(Enum):
 
     Examples:
         >>> dqn_loss = DQNLoss(actor)
-        >>> dqn_loss.make_value_function(ValueFunctions.TD0, gamma=0.9)
+        >>> dqn_loss.make_value_estimator(ValueEstimators.TD0, gamma=0.9)
 
     """
 
@@ -40,7 +40,7 @@ class ValueFunctions(Enum):
     GAE = 4
 
 
-def default_value_kwargs(value_type: ValueFunctions):
+def default_value_kwargs(value_type: ValueEstimators):
     """Default value function keyword argument generator.
 
     Args:
@@ -48,17 +48,17 @@ def default_value_kwargs(value_type: ValueFunctions):
         :class:`torchrl.objectives.utils.ValueFunctions` class.
 
     Examples:
-        >>> kwargs = default_value_kwargs(ValueFunctions.TDLambda)
+        >>> kwargs = default_value_kwargs(ValueEstimators.TDLambda)
         {"gamma": 0.99, "lmbda": 0.95}
 
     """
-    if value_type == ValueFunctions.TD1:
+    if value_type == ValueEstimators.TD1:
         return {"gamma": 0.99}
-    elif value_type == ValueFunctions.TD0:
+    elif value_type == ValueEstimators.TD0:
         return {"gamma": 0.99}
-    elif value_type == ValueFunctions.GAE:
+    elif value_type == ValueEstimators.GAE:
         return {"gamma": 0.99, "lmbda": 0.95}
-    elif value_type == ValueFunctions.TDLambda:
+    elif value_type == ValueEstimators.TDLambda:
         return {"gamma": 0.99, "lmbda": 0.95}
     else:
         raise NotImplementedError(f"Unknown value type {value_type}.")

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -14,9 +14,11 @@ from torch.nn import functional as F
 
 from torchrl.envs.utils import step_mdp
 
+
 class DEFAULT_VALUE_FUN_PARAMS:
-    gamma: 0.99
-    lmbda: 0.95
+    gamma = 0.99
+    lmbda = 0.95
+
 
 class _context_manager:
     def __init__(self, value=True):

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -15,6 +15,12 @@ from torch.nn import functional as F
 
 from torchrl.envs.utils import step_mdp
 
+_GAMMA_LMBDA_DEPREC_WARNING = (
+    "Passing gamma / lambda parameters through the loss constructor "
+    "is deprecated and will be removed soon. To customize your value function, "
+    "run `loss_module.make_value_function(ValueFunctions.<value_fun>, gamma=val)`."
+)
+
 
 class ValueFunctions(Enum):
     """Value function enumerator for custom-built estimators.

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -34,10 +34,10 @@ class ValueEstimators(Enum):
 
     """
 
-    TD0 = 1
-    TD1 = 2
-    TDLambda = 3
-    GAE = 4
+    TD0 = "Bootstrapped TD (1-step return)"
+    TD1 = "TD(1) (infinity-step return)"
+    TDLambda = "TD(lambda)"
+    GAE = "Generalized advantage estimate"
 
 
 def default_value_kwargs(value_type: ValueEstimators):

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -14,6 +14,9 @@ from torch.nn import functional as F
 
 from torchrl.envs.utils import step_mdp
 
+class DEFAULT_VALUE_FUN_PARAMS:
+    gamma: 0.99
+    lmbda: 0.95
 
 class _context_manager:
     def __init__(self, value=True):

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import functools
+from enum import Enum
 from typing import Iterable, Optional, Union
 
 import torch
@@ -15,9 +16,36 @@ from torch.nn import functional as F
 from torchrl.envs.utils import step_mdp
 
 
-class DEFAULT_VALUE_FUN_PARAMS:
-    gamma = 0.99
-    lmbda = 0.95
+class ValueFunctions(Enum):
+    TD0 = 1
+    TD1 = 2
+    TDLambda = 3
+    GAE = 4
+
+def default_value_kwargs(value_type: ValueFunctions):
+    """Default value function keyword argument generator.
+
+    Args:
+        value_type (Enum.value): the value function type, from the
+        :class:`torchrl.objectives.utils.ValueFunctions` class.
+
+    Examples:
+        >>> kwargs = default_value_kwargs(ValueFunctions.TDLambda)
+        {"gamma": 0.99, "lmbda": 0.95}
+
+    """
+    if value_type == ValueFunctions.TD1:
+        return {"gamma": 0.99}
+    elif value_type == ValueFunctions.TD0:
+        return {"gamma": 0.99}
+    elif value_type == ValueFunctions.GAE:
+        return {"gamma": 0.99, "lmbda": 0.95}
+    elif value_type == ValueFunctions.TDLambda:
+        return {"gamma": 0.99, "lmbda": 0.95}
+    else:
+        raise NotImplementedError(f"Unknown value type {value_type}.")
+
+
 
 
 class _context_manager:

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -53,13 +53,13 @@ def default_value_kwargs(value_type: ValueEstimators):
 
     """
     if value_type == ValueEstimators.TD1:
-        return {"gamma": 0.99}
+        return {"gamma": 0.99, "differentiable": True}
     elif value_type == ValueEstimators.TD0:
-        return {"gamma": 0.99}
+        return {"gamma": 0.99, "differentiable": True}
     elif value_type == ValueEstimators.GAE:
-        return {"gamma": 0.99, "lmbda": 0.95}
+        return {"gamma": 0.99, "lmbda": 0.95, "differentiable": True}
     elif value_type == ValueEstimators.TDLambda:
-        return {"gamma": 0.99, "lmbda": 0.95}
+        return {"gamma": 0.99, "lmbda": 0.95, "differentiable": True}
     else:
         raise NotImplementedError(f"Unknown value type {value_type}.")
 

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -17,10 +17,22 @@ from torchrl.envs.utils import step_mdp
 
 
 class ValueFunctions(Enum):
+    """Value function enumerator for custom-built estimators.
+
+    Allows for a flexible usage of various value functions when the loss module
+    allows it.
+
+    Examples:
+        >>> dqn_loss = DQNLoss(actor)
+        >>> dqn_loss.make_value_function(ValueFunctions.TD0, gamma=0.9)
+
+    """
+
     TD0 = 1
     TD1 = 2
     TDLambda = 3
     GAE = 4
+
 
 def default_value_kwargs(value_type: ValueFunctions):
     """Default value function keyword argument generator.
@@ -44,8 +56,6 @@ def default_value_kwargs(value_type: ValueFunctions):
         return {"gamma": 0.99, "lmbda": 0.95}
     else:
         raise NotImplementedError(f"Unknown value type {value_type}.")
-
-
 
 
 class _context_manager:

--- a/torchrl/objectives/value/__init__.py
+++ b/torchrl/objectives/value/__init__.py
@@ -3,4 +3,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .advantages import GAE, TDEstimate, TDLambdaEstimate, ValueFunctionBase
+from .advantages import (
+    GAE,
+    TD0Estimate,
+    TD1Estimate,
+    TDLambdaEstimate,
+    ValueFunctionBase,
+)

--- a/torchrl/objectives/value/__init__.py
+++ b/torchrl/objectives/value/__init__.py
@@ -6,7 +6,10 @@
 from .advantages import (
     GAE,
     TD0Estimate,
+    TD0Estimator,
     TD1Estimate,
+    TD1Estimator,
     TDLambdaEstimate,
-    ValueFunctionBase,
+    TDLambdaEstimator,
+    ValueEstimatorBase,
 )

--- a/torchrl/objectives/value/__init__.py
+++ b/torchrl/objectives/value/__init__.py
@@ -3,4 +3,4 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .advantages import GAE, TDEstimate, TDLambdaEstimate
+from .advantages import GAE, TDEstimate, TDLambdaEstimate, ValueFunctionBase

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -46,10 +46,12 @@ class ValueEstimatorBase(nn.Module):
 
     value_network: Union[TensorDictModule, Callable]
     value_key: Union[Tuple[str], str]
-    DIFF_DEPREC_MSG = "differentiable=False will soon be deprecated and all value computations will be made" \
-                      "differentiable. " \
-                      "Consider using differentiable=True and " \
-                      "decorate your function with `torch.no_grad()` or pass detached functional parameters."
+    DIFF_DEPREC_MSG = (
+        "differentiable=False will soon be deprecated and all value computations will be made"
+        "differentiable. "
+        "Consider using differentiable=True and "
+        "decorate your function with `torch.no_grad()` or pass detached functional parameters."
+    )
 
     @abc.abstractmethod
     def forward(

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -16,6 +16,7 @@ from torchrl.envs.utils import step_mdp
 
 from torchrl.objectives.utils import hold_out_net
 from torchrl.objectives.value.functional import (
+    td0_return_estimate,
     td_lambda_return_estimate,
     vec_generalized_advantage_estimate,
     vec_td1_return_estimate,
@@ -302,7 +303,9 @@ class TD0Estimator(ValueEstimatorBase):
         next_value = step_td.get(self.value_key)
 
         done = tensordict.get(("next", "done"))
-        value_target = reward + gamma * (1 - done.to(reward.dtype)) * next_value
+        value_target = td0_return_estimate(
+            gamma=gamma, next_state_value=next_value, reward=reward, done=done
+        )
         return value_target
 
 

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -46,6 +46,10 @@ class ValueEstimatorBase(nn.Module):
 
     value_network: Union[TensorDictModule, Callable]
     value_key: Union[Tuple[str], str]
+    DIFF_DEPREC_MSG = "differentiable=False will soon be deprecated and all value computations will be made" \
+                      "differentiable. " \
+                      "Consider using differentiable=True and " \
+                      "decorate your function with `torch.no_grad()` or pass detached functional parameters."
 
     @abc.abstractmethod
     def forward(
@@ -54,7 +58,7 @@ class ValueEstimatorBase(nn.Module):
         params: Optional[TensorDictBase] = None,
         target_params: Optional[TensorDictBase] = None,
     ) -> TensorDictBase:
-        """Computes the a value estimate given the data in tensordict.
+        """Computes the advantage estimate given the data in tensordict.
 
         If a functional module is provided, a nested TensorDict containing the parameters
         (and if relevant the target parameters) can be passed to the module.
@@ -123,8 +127,12 @@ class TD0Estimator(ValueEstimatorBase):
             the value estimates.
         average_rewards (bool, optional): if ``True``, rewards will be standardized
             before the TD is computed.
-        differentiable (bool, optional): if ``True``, gradients are propagated throught
+        differentiable (bool, optional): if ``True``, gradients are propagated through
             the computation of the value function. Default is ``False``.
+            .. note::
+              The proper way to make the function call non-differentiable is to
+              decorate it in a `torch.no_grad()` context manager/decorator or
+              pass detached parameters for functional modules.
         advantage_key (str or tuple of str, optional): the key of the advantage entry.
             Defaults to "advantage".
         value_target_key (str or tuple of str, optional): the key of the advantage entry.
@@ -155,6 +163,8 @@ class TD0Estimator(ValueEstimatorBase):
 
         self.average_rewards = average_rewards
         self.differentiable = differentiable
+        if not differentiable:
+            warnings.warn(self.DIFF_DEPREC_MSG)
         self.value_key = value_key
         if (
             hasattr(value_network, "out_keys")
@@ -187,7 +197,7 @@ class TD0Estimator(ValueEstimatorBase):
         params: Optional[TensorDictBase] = None,
         target_params: Optional[TensorDictBase] = None,
     ) -> TensorDictBase:
-        """Computes the TDEstimate given the data in tensordict.
+        """Computes the TD(0) advantage given the data in tensordict.
 
         If a functional module is provided, a nested TensorDict containing the parameters
         (and if relevant the target parameters) can be passed to the module.
@@ -214,7 +224,6 @@ class TD0Estimator(ValueEstimatorBase):
             >>> module = TDEstimate(
             ...     gamma=0.98,
             ...     value_network=value_net,
-            ...     differentiable=False,
             ... )
             >>> obs, next_obs = torch.randn(2, 1, 10, 3)
             >>> reward = torch.randn(1, 10, 1)
@@ -232,7 +241,6 @@ class TD0Estimator(ValueEstimatorBase):
             >>> module = TDEstimate(
             ...     gamma=0.98,
             ...     value_network=value_net,
-            ...     differentiable=False,
             ... )
             >>> obs, next_obs = torch.randn(2, 1, 10, 3)
             >>> reward = torch.randn(1, 10, 1)
@@ -304,8 +312,12 @@ class TD1Estimator(ValueEstimatorBase):
         value_network (TensorDictModule): value operator used to retrieve the value estimates.
         average_rewards (bool, optional): if ``True``, rewards will be standardized
             before the TD is computed.
-        differentiable (bool, optional): if ``True``, gradients are propagated throught
+        differentiable (bool, optional): if ``True``, gradients are propagated through
             the computation of the value function. Default is ``False``.
+            .. note::
+              The proper way to make the function call non-differentiable is to
+              decorate it in a `torch.no_grad()` context manager/decorator or
+              pass detached parameters for functional modules.
         advantage_key (str or tuple of str, optional): the key of the advantage entry.
             Defaults to "advantage".
         value_target_key (str or tuple of str, optional): the key of the advantage entry.
@@ -336,6 +348,8 @@ class TD1Estimator(ValueEstimatorBase):
 
         self.average_rewards = average_rewards
         self.differentiable = differentiable
+        if not differentiable:
+            warnings.warn(self.DIFF_DEPREC_MSG)
         self.value_key = value_key
         if (
             hasattr(value_network, "out_keys")
@@ -367,7 +381,7 @@ class TD1Estimator(ValueEstimatorBase):
         params: Optional[TensorDictBase] = None,
         target_params: Optional[TensorDictBase] = None,
     ) -> TensorDictBase:
-        """Computes the TDEstimate given the data in tensordict.
+        """Computes the TD(1) advantage given the data in tensordict.
 
         If a functional module is provided, a nested TensorDict containing the parameters
         (and if relevant the target parameters) can be passed to the module.
@@ -394,7 +408,6 @@ class TD1Estimator(ValueEstimatorBase):
             >>> module = TDEstimate(
             ...     gamma=0.98,
             ...     value_network=value_net,
-            ...     differentiable=False,
             ... )
             >>> obs, next_obs = torch.randn(2, 1, 10, 3)
             >>> reward = torch.randn(1, 10, 1)
@@ -412,7 +425,6 @@ class TD1Estimator(ValueEstimatorBase):
             >>> module = TDEstimate(
             ...     gamma=0.98,
             ...     value_network=value_net,
-            ...     differentiable=False,
             ... )
             >>> obs, next_obs = torch.randn(2, 1, 10, 3)
             >>> reward = torch.randn(1, 10, 1)
@@ -485,8 +497,12 @@ class TDLambdaEstimator(ValueEstimatorBase):
         value_network (TensorDictModule): value operator used to retrieve the value estimates.
         average_rewards (bool, optional): if ``True``, rewards will be standardized
             before the TD is computed.
-        differentiable (bool, optional): if ``True``, gradients are propagated throught
+        differentiable (bool, optional): if ``True``, gradients are propagated through
             the computation of the value function. Default is ``False``.
+            .. note::
+              The proper way to make the function call non-differentiable is to
+              decorate it in a `torch.no_grad()` context manager/decorator or
+              pass detached parameters for functional modules.
         vectorized (bool, optional): whether to use the vectorized version of the
             lambda return. Default is `True`.
         advantage_key (str or tuple of str, optional): the key of the advantage entry.
@@ -523,6 +539,8 @@ class TDLambdaEstimator(ValueEstimatorBase):
 
         self.average_rewards = average_rewards
         self.differentiable = differentiable
+        if not differentiable:
+            warnings.warn(self.DIFF_DEPREC_MSG)
         self.value_key = value_key
         if (
             hasattr(value_network, "out_keys")
@@ -554,7 +572,7 @@ class TDLambdaEstimator(ValueEstimatorBase):
         params: Optional[List[Tensor]] = None,
         target_params: Optional[List[Tensor]] = None,
     ) -> TensorDictBase:
-        """Computes the TDLambdaEstimate given the data in tensordict.
+        r"""Computes the TD(:math:`\lambda`) advantage given the data in tensordict.
 
         If a functional module is provided, a nested TensorDict containing the parameters
         (and if relevant the target parameters) can be passed to the module.
@@ -582,7 +600,6 @@ class TDLambdaEstimator(ValueEstimatorBase):
             ...     gamma=0.98,
             ...     lmbda=0.94,
             ...     value_network=value_net,
-            ...     differentiable=False,
             ... )
             >>> obs, next_obs = torch.randn(2, 1, 10, 3)
             >>> reward = torch.randn(1, 10, 1)
@@ -601,7 +618,6 @@ class TDLambdaEstimator(ValueEstimatorBase):
             ...     gamma=0.98,
             ...     lmbda=0.94,
             ...     value_network=value_net,
-            ...     differentiable=False,
             ... )
             >>> obs, next_obs = torch.randn(2, 1, 10, 3)
             >>> reward = torch.randn(1, 10, 1)
@@ -681,8 +697,12 @@ class GAE(ValueEstimatorBase):
         value_network (TensorDictModule): value operator used to retrieve the value estimates.
         average_gae (bool): if ``True``, the resulting GAE values will be standardized.
             Default is ``False``.
-        differentiable (bool, optional): if ``True``, gradients are propagated throught
+        differentiable (bool, optional): if ``True``, gradients are propagated through
             the computation of the value function. Default is ``False``.
+            .. note::
+              The proper way to make the function call non-differentiable is to
+              decorate it in a `torch.no_grad()` context manager/decorator or
+              pass detached parameters for functional modules.
         advantage_key (str or tuple of str, optional): the key of the advantage entry.
             Defaults to "advantage".
         value_target_key (str or tuple of str, optional): the key of the advantage entry.
@@ -730,7 +750,8 @@ class GAE(ValueEstimatorBase):
 
         self.average_gae = average_gae
         self.differentiable = differentiable
-
+        if not differentiable:
+            warnings.warn(self.DIFF_DEPREC_MSG)
         self.advantage_key = advantage_key
         self.value_target_key = value_target_key
 

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -16,10 +16,10 @@ from torchrl.envs.utils import step_mdp
 
 from torchrl.objectives.utils import hold_out_net
 from torchrl.objectives.value.functional import (
-    td_lambda_advantage_estimate,
+    td_lambda_return_estimate,
     vec_generalized_advantage_estimate,
-    vec_td1_advantage_estimate,
-    vec_td_lambda_advantage_estimate,
+    vec_td1_return_estimate,
+    vec_td_lambda_return_estimate,
 )
 
 
@@ -472,9 +472,7 @@ class TD1Estimator(ValueEstimatorBase):
         next_value = step_td.get(self.value_key)
 
         done = tensordict.get(("next", "done"))
-        value_target = vec_td1_advantage_estimate(
-            gamma, torch.zeros_like(next_value), next_value, reward, done
-        )
+        value_target = vec_td1_return_estimate(gamma, next_value, reward, done)
         return value_target
 
 
@@ -665,13 +663,9 @@ class TDLambdaEstimator(ValueEstimatorBase):
 
         done = tensordict.get(("next", "done"))
         if self.vectorized:
-            val = vec_td_lambda_advantage_estimate(
-                gamma, lmbda, torch.zeros_like(next_value), next_value, reward, done
-            )
+            val = vec_td_lambda_return_estimate(gamma, lmbda, next_value, reward, done)
         else:
-            val = td_lambda_advantage_estimate(
-                gamma, lmbda, torch.zeros_like(next_value), next_value, reward, done
-            )
+            val = td_lambda_return_estimate(gamma, lmbda, next_value, reward, done)
         return val
 
 

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -30,6 +30,7 @@ def _self_set_grad_enabled(fun):
 
     return new_fun
 
+
 class ValueFunctionBase(nn.Module):
     """An abstract parent class for value function modules."""
 
@@ -63,6 +64,7 @@ class ValueFunctionBase(nn.Module):
             An updated TensorDict with an advantage and a value_error keys as defined in the constructor.
         """
         raise NotImplementedError
+
 
 class TDEstimate(ValueFunctionBase):
     """Temporal Difference estimate of advantage function.

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -7,7 +7,7 @@ from functools import wraps
 from typing import List, Optional, Tuple, Union
 
 import torch
-from tensordict.nn import dispatch, TensorDictModule
+from tensordict.nn import dispatch, TensorDictModule, is_functional
 from tensordict.tensordict import TensorDictBase
 from torch import nn, Tensor
 
@@ -65,7 +65,7 @@ class ValueFunctionBase(nn.Module):
         """
         raise NotImplementedError
 
-    def value_estimate(self, tensordict, requires_grad=False, target_params: Optional[TensorDictBase] = None):
+    def value_estimate(self, tensordict, requires_grad=True, target_params: Optional[TensorDictBase] = None):
         """Gets a value estimate, usually used as a target value for the value network.
 
         Args:
@@ -73,15 +73,29 @@ class ValueFunctionBase(nn.Module):
                 read.
             requires_grad (bool, optional): whether the estimate should be part
                 of a computational graph.
-                Defaults to ``False``.
+                .. note::
+                  To avoid carrying gradient with respect to the parameters,
+                  one can also use ``val_fun.value_estimate(tensordict, target_params=params.detach())``
+                  which allows gradients to pass through the value function
+                  without including the parameters in the computational graph.
+
+                Defaults to ``True``.
             target_params (TensorDictBase, optional): A nested TensorDict containing the
                 target params to be passed to the functional value network module.
 
         """
         raise NotImplementedError
 
-class TDEstimate(ValueFunctionBase):
-    """Temporal Difference estimate of advantage function.
+    @property
+    def is_functional(self):
+        if isinstance(self.value_network, nn.Module):
+            return is_functional(self.value_network)
+        else:
+            raise RuntimeError("Cannot determine if value network is functional.")
+
+
+class TD0Estimate(ValueFunctionBase):
+    """Myopic Temporal Difference (TD(0)) estimate of advantage function.
 
     Args:
         gamma (scalar): exponential mean discount.
@@ -135,12 +149,169 @@ class TDEstimate(ValueFunctionBase):
         )
         self.out_keys = [self.advantage_key, self.value_target_key]
 
-    @property
-    def is_functional(self):
-        return (
-            "_is_stateless" in self.value_network.__dict__
-            and self.value_network.__dict__["_is_stateless"]
+    @_self_set_grad_enabled
+    @dispatch
+    def forward(
+        self,
+        tensordict: TensorDictBase,
+        params: Optional[TensorDictBase] = None,
+        target_params: Optional[TensorDictBase] = None,
+    ) -> TensorDictBase:
+        """Computes the TDEstimate given the data in tensordict.
+
+        If a functional module is provided, a nested TensorDict containing the parameters
+        (and if relevant the target parameters) can be passed to the module.
+
+        Args:
+            tensordict (TensorDictBase): A TensorDict containing the data
+                (an observation key, "action", ("next", "reward"), ("next", "done") and "next" tensordict state
+                as returned by the environment) necessary to compute the value estimates and the TDEstimate.
+                The data passed to this module should be structured as :obj:`[*B, T, F]` where :obj:`B` are
+                the batch size, :obj:`T` the time dimension and :obj:`F` the feature dimension(s).
+            params (TensorDictBase, optional): A nested TensorDict containing the params
+                to be passed to the functional value network module.
+            target_params (TensorDictBase, optional): A nested TensorDict containing the
+                target params to be passed to the functional value network module.
+
+        Returns:
+            An updated TensorDict with an advantage and a value_error keys as defined in the constructor.
+
+        Examples:
+            >>> from tensordict import TensorDict
+            >>> value_net = TensorDictModule(
+            ...     nn.Linear(3, 1), in_keys=["obs"], out_keys=["state_value"]
+            ... )
+            >>> module = TDEstimate(
+            ...     gamma=0.98,
+            ...     value_network=value_net,
+            ...     differentiable=False,
+            ... )
+            >>> obs, next_obs = torch.randn(2, 1, 10, 3)
+            >>> reward = torch.randn(1, 10, 1)
+            >>> done = torch.zeros(1, 10, 1, dtype=torch.bool)
+            >>> tensordict = TensorDict({"obs": obs, "next": {"obs": next_obs, "done": done, "reward": reward}}, [1, 10])
+            >>> _ = module(tensordict)
+            >>> assert "advantage" in tensordict.keys()
+
+        The module supports non-tensordict (i.e. unpacked tensordict) inputs too:
+
+        Examples:
+            >>> value_net = TensorDictModule(
+            ...     nn.Linear(3, 1), in_keys=["obs"], out_keys=["state_value"]
+            ... )
+            >>> module = TDEstimate(
+            ...     gamma=0.98,
+            ...     value_network=value_net,
+            ...     differentiable=False,
+            ... )
+            >>> obs, next_obs = torch.randn(2, 1, 10, 3)
+            >>> reward = torch.randn(1, 10, 1)
+            >>> done = torch.zeros(1, 10, 1, dtype=torch.bool)
+            >>> advantage, value_target = module(obs=obs, reward=reward, done=done, next_obs=next_obs)
+
+        """
+        if tensordict.batch_dims < 1:
+            raise RuntimeError(
+                "Expected input tensordict to have at least one dimensions, got"
+                f"tensordict.batch_size = {tensordict.batch_size}"
+            )
+
+        kwargs = {}
+        if self.is_functional and params is None:
+            raise RuntimeError(
+                "Expected params to be passed to advantage module but got none."
+            )
+        if params is not None:
+            kwargs["params"] = params.detach()
+        with hold_out_net(self.value_network):
+            self.value_network(tensordict, **kwargs)
+            value = tensordict.get(self.value_key)
+
+        if params is not None and target_params is None:
+            target_params = params.detach()
+        value_target = self.value_estimate(tensordict, target_params=target_params)
+        tensordict.set("advantage", value_target - value)
+        tensordict.set("value_target", value_target)
+        return tensordict
+
+    def value_estimate(self, tensordict, requires_grad=False, target_params: Optional[TensorDictBase] = None):
+        kwargs = {}
+        gamma = self.gamma
+        # we may still need to pass gradient, but we don't want to assign grads to
+        # value net params
+        reward = tensordict.get(("next", "reward"))
+        if self.average_rewards:
+            reward = reward - reward.mean()
+            reward = reward / reward.std().clamp_min(1e-4)
+            tensordict.set(
+                ("next", "reward"), reward
+            )  # we must update the rewards if they are used later in the code
+        step_td = step_mdp(tensordict)
+        if target_params is not None:
+            # we assume that target parameters are not differentiable
+            kwargs["params"] = target_params
+        with hold_out_net(self.value_network):
+            self.value_network(step_td, **kwargs)
+            next_value = step_td.get(self.value_key)
+
+        done = tensordict.get(("next", "done"))
+        value_target = reward + gamma * (1 - done.to(reward.dtype)) * next_value
+        return value_target
+
+class TD1Estimate(ValueFunctionBase):
+    """Bootstrapped Temporal Difference (TD(1)) estimate of advantage function.
+
+    Args:
+        gamma (scalar): exponential mean discount.
+        value_network (TensorDictModule): value operator used to retrieve the value estimates.
+        average_rewards (bool, optional): if True, rewards will be standardized
+            before the TD is computed.
+        differentiable (bool, optional): if True, gradients are propagated throught
+            the computation of the value function. Default is :obj:`False`.
+        advantage_key (str or tuple of str, optional): the key of the advantage entry.
+            Defaults to "advantage".
+        value_target_key (str or tuple of str, optional): the key of the advantage entry.
+            Defaults to "value_target".
+        value_key (str or tuple of str, optional): the value key to read from the input tensordict.
+            Defaults to "state_value".
+
+    """
+
+    def __init__(
+        self,
+        gamma: Union[float, torch.Tensor],
+        value_network: TensorDictModule,
+        average_rewards: bool = False,
+        differentiable: bool = False,
+        advantage_key: Union[str, Tuple] = "advantage",
+        value_target_key: Union[str, Tuple] = "value_target",
+        value_key: Union[str, Tuple] = "state_value",
+    ):
+        super().__init__()
+        try:
+            device = next(value_network.parameters()).device
+        except StopIteration:
+            device = torch.device("cpu")
+        self.register_buffer("gamma", torch.tensor(gamma, device=device))
+        self.value_network = value_network
+
+        self.average_rewards = average_rewards
+        self.differentiable = differentiable
+        self.value_key = value_key
+        if value_key not in value_network.out_keys:
+            raise KeyError(
+                f"value key '{value_key}' not found in value network out_keys."
+            )
+
+        self.advantage_key = advantage_key
+        self.value_target_key = value_target_key
+
+        self.in_keys = (
+            value_network.in_keys
+            + [("next", "reward"), ("next", "done")]
+            + [("next", in_key) for in_key in value_network.in_keys]
         )
+        self.out_keys = [self.advantage_key, self.value_target_key]
 
     @_self_set_grad_enabled
     @dispatch
@@ -252,7 +423,7 @@ class TDEstimate(ValueFunctionBase):
         return value_target
 
 class TDLambdaEstimate(ValueFunctionBase):
-    """TD-Lambda estimate of advantage function.
+    """TD(:math:`\lambda`) estimate of advantage function.
 
     Args:
         gamma (scalar): exponential mean discount.
@@ -312,13 +483,6 @@ class TDLambdaEstimate(ValueFunctionBase):
             + [("next", in_key) for in_key in value_network.in_keys]
         )
         self.out_keys = [self.advantage_key, self.value_target_key]
-
-    @property
-    def is_functional(self):
-        return (
-            "_is_stateless" in self.value_network.__dict__
-            and self.value_network.__dict__["_is_stateless"]
-        )
 
     @_self_set_grad_enabled
     @dispatch
@@ -433,14 +597,14 @@ class TDLambdaEstimate(ValueFunctionBase):
 
         done = tensordict.get(("next", "done"))
         if self.vectorized:
-            adv = vec_td_lambda_advantage_estimate(
-                gamma, lmbda, value, next_value, reward, done
+            val = vec_td_lambda_advantage_estimate(
+                gamma, lmbda, torch.zeros_like(next_value), next_value, reward, done
             )
         else:
-            adv = td_lambda_advantage_estimate(
-                gamma, lmbda, value, next_value, reward, done
+            val = td_lambda_advantage_estimate(
+                gamma, lmbda, torch.zeros_like(next_value), next_value, reward, done
             )
-
+        return val
 
 class GAE(ValueFunctionBase):
     """A class wrapper around the generalized advantage estimate functional.
@@ -509,13 +673,6 @@ class GAE(ValueFunctionBase):
             + [("next", in_key) for in_key in value_network.in_keys]
         )
         self.out_keys = [self.advantage_key, self.value_target_key]
-
-    @property
-    def is_functional(self):
-        return (
-            "_is_stateless" in self.value_network.__dict__
-            and self.value_network.__dict__["_is_stateless"]
-        )
 
     @_self_set_grad_enabled
     @dispatch

--- a/torchrl/objectives/value/functional.py
+++ b/torchrl/objectives/value/functional.py
@@ -45,6 +45,10 @@ def generalized_advantage_estimate(
         done (Tensor): boolean flag for end of episode.
 
     """
+    if not (next_state_value.shape == state_value.shape == reward.shape == done.shape):
+        raise RuntimeError(
+            "All input tensors (value, reward and done states) must share a unique shape."
+        )
     for tensor in (next_state_value, state_value, reward, done):
         if tensor.shape[-1] != 1:
             raise RuntimeError(
@@ -97,6 +101,10 @@ def vec_generalized_advantage_estimate(
         done (Tensor): boolean flag for end of episode.
 
     """
+    if not (next_state_value.shape == state_value.shape == reward.shape == done.shape):
+        raise RuntimeError(
+            "All input tensors (value, reward and done states) must share a unique shape."
+        )
     for tensor in (next_state_value, state_value, reward, done):
         if tensor.shape[-1] != 1:
             raise RuntimeError(
@@ -163,6 +171,10 @@ def td_advantage_estimate(
         done (Tensor): boolean flag for end of episode.
 
     """
+    if not (next_state_value.shape == state_value.shape == reward.shape == done.shape):
+        raise RuntimeError(
+            "All input tensors (value, reward and done states) must share a unique shape."
+        )
     for tensor in (next_state_value, state_value, reward, done):
         if tensor.shape[-1] != 1:
             raise RuntimeError(
@@ -191,7 +203,7 @@ def td_lambda_return_estimate(
         reward (Tensor): reward of taking actions in the environment.
             must be a [Batch x TimeSteps x 1] or [Batch x TimeSteps] tensor
         done (Tensor): boolean flag for end of episode.
-        rolling_gamma (bool, optional): if True, it is assumed that each gamma
+        rolling_gamma (bool, optional): if ``True``, it is assumed that each gamma
             if a gamma tensor is tied to a single event:
               gamma = [g1, g2, g3, g4]
               value = [v1, v2, v3, v4]
@@ -214,6 +226,10 @@ def td_lambda_return_estimate(
             Default is True.
 
     """
+    if not (next_state_value.shape == reward.shape == done.shape):
+        raise RuntimeError(
+            "All input tensors (value, reward and done states) must share a unique shape."
+        )
     for tensor in (next_state_value, reward, done):
         if tensor.shape[-1] != 1:
             raise RuntimeError(
@@ -288,7 +304,7 @@ def td_lambda_advantage_estimate(
         reward (Tensor): reward of taking actions in the environment.
             must be a [Batch x TimeSteps x 1] or [Batch x TimeSteps] tensor
         done (Tensor): boolean flag for end of episode.
-        rolling_gamma (bool, optional): if True, it is assumed that each gamma
+        rolling_gamma (bool, optional): if ``True``, it is assumed that each gamma
             if a gamma tensor is tied to a single event:
               gamma = [g1, g2, g3, g4]
               value = [v1, v2, v3, v4]
@@ -311,6 +327,10 @@ def td_lambda_advantage_estimate(
             Default is True.
 
     """
+    if not (next_state_value.shape == state_value.shape == reward.shape == done.shape):
+        raise RuntimeError(
+            "All input tensors (value, reward and done states) must share a unique shape."
+        )
     if not state_value.shape == next_state_value.shape:
         raise RuntimeError("shape of state_value and next_state_value must match")
     returns = td_lambda_return_estimate(
@@ -342,7 +362,7 @@ def vec_td_lambda_advantage_estimate(
         reward (Tensor): reward of taking actions in the environment.
             must be a [Batch x TimeSteps x 1] or [Batch x TimeSteps] tensor
         done (Tensor): boolean flag for end of episode.
-        rolling_gamma (bool, optional): if True, it is assumed that each gamma
+        rolling_gamma (bool, optional): if ``True``, it is assumed that each gamma
             if a gamma tensor is tied to a single event:
               gamma = [g1, g2, g3, g4]
               value = [v1, v2, v3, v4]
@@ -365,6 +385,10 @@ def vec_td_lambda_advantage_estimate(
             Default is True.
 
     """
+    if not (next_state_value.shape == state_value.shape == reward.shape == done.shape):
+        raise RuntimeError(
+            "All input tensors (value, reward and done states) must share a unique shape."
+        )
     return (
         vec_td_lambda_return_estimate(
             gamma, lmbda, next_state_value, reward, done, rolling_gamma
@@ -387,7 +411,7 @@ def vec_td_lambda_return_estimate(
         reward (Tensor): reward of taking actions in the environment.
             must be a [Batch x TimeSteps x 1] or [Batch x TimeSteps] tensor
         done (Tensor): boolean flag for end of episode.
-        rolling_gamma (bool, optional): if True, it is assumed that each gamma
+        rolling_gamma (bool, optional): if ``True``, it is assumed that each gamma
             if a gamma tensor is tied to a single event:
               gamma = [g1, g2, g3, g4]
               value = [v1, v2, v3, v4]
@@ -410,6 +434,10 @@ def vec_td_lambda_return_estimate(
             Default is True.
 
     """
+    if not (next_state_value.shape == reward.shape == done.shape):
+        raise RuntimeError(
+            "All input tensors (value, reward and done states) must share a unique shape."
+        )
     shape = next_state_value.shape
     if not shape[-1] == 1:
         raise RuntimeError("last dimension of inputs shape must be singleton")

--- a/torchrl/objectives/value/utils.py
+++ b/torchrl/objectives/value/utils.py
@@ -145,7 +145,7 @@ def _make_gammas_tensor(gamma: torch.Tensor, T: int, rolling_gamma: bool):
     Args:
         gamma (torch.tensor): the gamma tensor to be prepared.
         T (int): the time length
-        rolling_gamma (bool): if True, the gamma value is set for each step
+        rolling_gamma (bool): if ``True``, the gamma value is set for each step
             independently. If False, the gamma value at (i, t) will be used for the
             trajectory following (i, t).
 

--- a/torchrl/record/recorder.py
+++ b/torchrl/record/recorder.py
@@ -34,7 +34,7 @@ class VideoRecorder(ObservationTransform):
         skip (int): frame interval in the output video.
             Default is 2.
         center_crop (int, optional): value of square center crop.
-        make_grid (bool, optional): if True, a grid is created assuming that a
+        make_grid (bool, optional): if ``True``, a grid is created assuming that a
             tensor of shape [B x W x H x 3] is provided, with B being the batch
             size. Default is True.
 
@@ -138,7 +138,7 @@ class TensorDictRecorder(Transform):
 
     Args:
         out_file_base (str): a string defining the prefix of the file where the tensordict will be written.
-        skip_reset (bool): if True, the first TensorDict of the list will be discarded (usually the tensordict
+        skip_reset (bool): if ``True``, the first TensorDict of the list will be discarded (usually the tensordict
             resulting from the call to :obj:`env.reset()`)
             default: True
         skip (int): frame interval for the saved tensordict.

--- a/torchrl/trainers/helpers/collectors.py
+++ b/torchrl/trainers/helpers/collectors.py
@@ -373,7 +373,7 @@ class OnPolicyCollectorConfig:
     # If the collector device differs from the policy device (cuda:0 if available), then the
     # weights of the collector policy are synchronized with collector.update_policy_weights_().
     pin_memory: bool = False
-    # if True, the data collector will call pin_memory before dispatching tensordicts onto the passing device
+    # if ``True``, the data collector will call pin_memory before dispatching tensordicts onto the passing device
     frames_per_batch: int = 1000
     # number of steps executed in the environment per collection.
     # This value represents how many steps will the data collector execute and return in *each*

--- a/torchrl/trainers/helpers/envs.py
+++ b/torchrl/trainers/helpers/envs.py
@@ -244,7 +244,7 @@ def transformed_env_constructor(
         custom_env (EnvBase, optional): if an existing environment needs to be
             transformed_in, it can be passed directly to this helper. `custom_env_maker`
             and `custom_env` are exclusive features.
-        return_transformed_envs (bool, optional): if True, a transformed_in environment
+        return_transformed_envs (bool, optional): if ``True``, a transformed_in environment
             is returned.
         action_dim_gsde (int, Optional): if gSDE is used, this can present the action dim to initialize the noise.
             Make sure this is indicated in environment executed in parallel.
@@ -556,7 +556,7 @@ class EnvConfig:
     max_frames_per_traj: int = 1000
     # Number of steps before a reset of the environment is called (if it has not been flagged as done before).
     batch_transform: bool = False
-    # if True, the transforms will be applied to the parallel env, and not to each individual env.\
+    # if ``True``, the transforms will be applied to the parallel env, and not to each individual env.\
     image_size: int = 84
     # if True and environment has discrete action space, then it is encoded as categorical values rather than one-hot.
     categorical_action_encoding: bool = False

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -603,11 +603,11 @@ class ReplayBufferTrainer(TrainerHookBase):
         replay_buffer (TensorDictReplayBuffer): replay buffer to be used.
         batch_size (int): batch size when sampling data from the
             latest collection or from the replay buffer.
-        memmap (bool, optional): if True, a memmap tensordict is created.
+        memmap (bool, optional): if ``True``, a memmap tensordict is created.
             Default is False.
         device (device, optional): device where the samples must be placed.
             Default is cpu.
-        flatten_tensordicts (bool, optional): if True, the tensordicts will be
+        flatten_tensordicts (bool, optional): if ``True``, the tensordicts will be
             flattened (or equivalently masked with the valid mask obtained from
             the collector) before being passed to the replay buffer. Otherwise,
             no transform will be achieved other than padding (see :obj:`max_dims` arg below).
@@ -792,8 +792,8 @@ class LogReward(TrainerHookBase):
 
     Args:
         logname (str, optional): name of the rewards to be logged. Default is :obj:`"r_training"`.
-        log_pbar (bool, optional): if True, the reward value will be logged on
-            the progression bar. Default is :obj:`False`.
+        log_pbar (bool, optional): if ``True``, the reward value will be logged on
+            the progression bar. Default is ``False``.
         reward_key (str or tuple, optional): the key where to find the reward
             in the input batch. Defaults to ``("next", "reward")``
 
@@ -1125,7 +1125,7 @@ class Recorder(TrainerHookBase):
         out_key (str, optional): reward key to set to the logger. Default is
             `"reward_evaluation"`.
         suffix (str, optional): suffix of the video to be recorded.
-        log_pbar (bool, optional): if True, the reward value will be logged on
+        log_pbar (bool, optional): if ``True``, the reward value will be logged on
             the progression bar. Default is `False`.
 
     """
@@ -1265,7 +1265,7 @@ class CountFramesLog(TrainerHookBase):
         frame_skip (int): frame skip of the environment. This argument is
             important to keep track of the total number of frames, not the
             apparent one.
-        log_pbar (bool, optional): if True, the reward value will be logged on
+        log_pbar (bool, optional): if ``True``, the reward value will be logged on
             the progression bar. Default is `False`.
 
     Examples:


### PR DESCRIPTION
## Description

This is a major refactoring of the loss modules.
From now on, loss and value estimation are decoupled as much as can be. This leaves the possibility to the user to pick the value function that she feels appropriate.

In a nutshell, the previous API left little choice of value estimator:
```python
dqn_loss = DQNLoss(actor, gamma=0.9) # always uses TD0
```
From now on, one can pick up the value function after creating the loss:
```python
dqn_loss = DQNLoss(actor)
dqn_loss.make_value_function(ValueFunctions.TDLambda, gamma=0.99, lmbda=0.95) # hyperparameters can also be ommitted.
```

Each loss is equipped with a default value function that can be accessed via
```
dqn_loss.default_value_function
```
If `make_value_function` is not called, then this default value estimator will be used.

The reason why we don't simply pass a ValueFunction module is that some losses (eg SAC) have an intricated value:
`Q(s,a) - log_prob(a|s)` for instance. Hence we can't just have the users make `vf = ValueFunction(network, ...)` and pass `vf` to the loss. With this `Enum` trick, we get the best of both worlds: total flexibility in user-facing constructors and full compatibility in the backend.

## BC-breaking changes

- We've renamed the value function modules: `TD0Estimate`, `TD1Estimate`, `TDLambdaEstimate`
- Passing `gamma` or `lmbda` to the module raises a warning. However for bc-compatibility the value passed will still be used *unless another is passed via `make_value_function`.
- Various typos
- All value functions now inherit from a common parent class.
- ValueEstimators and loss modules have a lot more keyword only arguments

## Unaddressed

We did not take care of making all losses compatible with GAE. The only reason is that GAE requires the value (not only the next value), which we currently don't support. This can be addressed separately.