### PR TITLE
[Feature] Add Dropout to MLP module

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -57,8 +57,13 @@ def double_prec_fixture():
 )
 @pytest.mark.parametrize(
     "norm_class, norm_kwargs",
-    [(nn.LazyBatchNorm1d, {}), (nn.BatchNorm1d, {"num_features": 32})],
+    [
+        (nn.LazyBatchNorm1d, {}),
+        (nn.BatchNorm1d, {"num_features": 32}),
+        (nn.LayerNorm, {"normalized_shape": 32}),
+    ],
 )
+@pytest.mark.parametrize("dropout", [0.0, 0.5])
 @pytest.mark.parametrize("bias_last_layer", [True, False])
 @pytest.mark.parametrize("single_bias_last_layer", [True, False])
 @pytest.mark.parametrize("layer_class", [nn.Linear, NoisyLinear])
@@ -70,6 +75,7 @@ def test_mlp(
     num_cells,
     activation_class,
     activation_kwargs,
+    dropout,
     bias_last_layer,
     norm_class,
     norm_kwargs,
@@ -89,6 +95,7 @@ def test_mlp(
         activation_kwargs=activation_kwargs,
         norm_class=norm_class,
         norm_kwargs=norm_kwargs,
+        dropout=dropout,
         bias_last_layer=bias_last_layer,
         single_bias_last_layer=False,
         layer_class=layer_class,

--- a/torchrl/modules/models/models.py
+++ b/torchrl/modules/models/models.py
@@ -49,6 +49,7 @@ class MLP(nn.Sequential):
         activation_kwargs (dict, optional): kwargs to be used with the activation class;
         norm_class (Type, optional): normalization class, if any.
         norm_kwargs (dict, optional): kwargs to be used with the normalization layers;
+        dropout (float, optional): dropout probability;
         bias_last_layer (bool): if True, the last Linear layer will have a bias parameter.
             default: True;
         single_bias_last_layer (bool): if True, the last dimension of the bias of the last layer will be a singleton
@@ -147,6 +148,7 @@ class MLP(nn.Sequential):
         activation_kwargs: Optional[dict] = None,
         norm_class: Optional[Type[nn.Module]] = None,
         norm_kwargs: Optional[dict] = None,
+        dropout: Optional[float] = None,
         bias_last_layer: bool = True,
         single_bias_last_layer: bool = False,
         layer_class: Type[nn.Module] = nn.Linear,
@@ -178,6 +180,7 @@ class MLP(nn.Sequential):
         )
         self.norm_class = norm_class
         self.norm_kwargs = norm_kwargs if norm_kwargs is not None else {}
+        self.dropout = dropout
         self.bias_last_layer = bias_last_layer
         self.single_bias_last_layer = single_bias_last_layer
         self.layer_class = layer_class
@@ -235,15 +238,18 @@ class MLP(nn.Sequential):
                 )
 
             if i < self.depth or self.activate_last_layer:
+                if self.dropout is not None:
+                    layers.append(create_on_device(nn.Dropout, device, p=self.dropout))
+                if self.norm_class is not None:
+                    layers.append(
+                        create_on_device(self.norm_class, device, **self.norm_kwargs)
+                    )
                 layers.append(
                     create_on_device(
                         self.activation_class, device, **self.activation_kwargs
                     )
                 )
-                if self.norm_class is not None:
-                    layers.append(
-                        create_on_device(self.norm_class, device, **self.norm_kwargs)
-                    )
+
         return layers
 
     def forward(self, *inputs: Tuple[torch.Tensor]) -> torch.Tensor:


### PR DESCRIPTION
## Description

Adds the option to use dropout in the MLP layer module and changes the order when normalization classes are applied. 

## Motivation and Context

The option to add dropout to the MLP module wasn't there yet. I also changed the order of when normalization classes are applied. It is now done directly after the layer and before the activation function as done in the batch norm paper.

These changes open up the opportunity to create [DroQ](https://openreview.net/pdf?id=xCVJMsPv3RT) algorithm which is an improvement over REDQ and applies Dropout + LayerNorm in the Critic networks which makes it possible to have a high update-to-data ratio without the need of big ensemble sizes. Thus, DroQ is sample efficient as REDQ and computationally efficient as SAC which makes it very interesting for application in the real world e.g. robots. 

![image](https://user-images.githubusercontent.com/29492081/227494444-8e09c957-2a9c-420e-b240-f2ee70114294.png)


- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
