### PR TITLE
[BugFix] Only call replay buffer transforms when there are

### DIFF
--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -850,6 +850,7 @@ def test_smoke_replay_buffer_transform(transform):
         return
 
     rb._transform = mock.MagicMock()
+    rb._transform.__len__ = lambda *args: 3
     rb.sample()
     assert rb._transform.called
 

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -31,8 +31,8 @@ from torchrl._utils import (
     _check_for_faulty_process,
     accept_remote_rref_udf_invocation,
     prod,
-    VERBOSE,
     RL_WARNINGS,
+    VERBOSE,
 )
 from torchrl.collectors.utils import split_trajectories
 from torchrl.data.tensor_specs import TensorSpec

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -235,7 +235,7 @@ class ReplayBuffer:
         if not isinstance(index, INT_CLASSES):
             data = self._collate_fn(data)
 
-        if self._transform is not None:
+        if self._transform is not None and len(self._transform):
             is_td = True
             if not isinstance(data, TensorDictBase):
                 data = TensorDict({"data": data}, [])
@@ -286,7 +286,7 @@ class ReplayBuffer:
         """
         if self._transform is not None and isinstance(data, TensorDictBase):
             data = self._transform.inv(data)
-        elif self._transform is not None:
+        elif self._transform is not None and len(self._transform):
             # Accepts transforms that act on "data" key
             data = self._transform.inv(TensorDict({"data": data}, [])).get("data")
         with self._replay_lock:
@@ -310,7 +310,7 @@ class ReplayBuffer:
             data = self._storage[index]
         if not isinstance(index, INT_CLASSES):
             data = self._collate_fn(data)
-        if self._transform is not None:
+        if self._transform is not None and len(self._transform):
             is_td = True
             if not isinstance(data, TensorDictBase):
                 data = TensorDict({"data": data}, [])


### PR DESCRIPTION
## Description

RB transforms are called even if they're empty, resulting in tensordict casting of the data which is presumably unwanted. 