### PR TITLE
[Feature] PPO allow entropy logging when entropy_coeff is 0

### DIFF
--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -118,7 +118,7 @@ class PPOLoss(LossModule):
         self.advantage_key = advantage_key
         self.value_target_key = value_target_key
         self.samples_mc_entropy = samples_mc_entropy
-        self.entropy_bonus = entropy_bonus and entropy_coef
+        self.entropy_bonus = entropy_bonus
         self.register_buffer(
             "entropy_coef", torch.tensor(entropy_coef, device=self.device)
         )


### PR DESCRIPTION
Right now in order to be able to log entropy in PPO you need a non zero entropy coeff.

This allows to log entropy even if we are not incentivizing it