### PR TITLE
[BugFix] Advantage normalisation in ClipPPOLoss is done after computing gain1

### DIFF
--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -350,7 +350,7 @@ class ClipPPOLoss(PPOLoss):
             loc = advantage.mean().item()
             scale = advantage.std().clamp_min(1e-6).item()
             advantage = (advantage - loc) / scale
-            
+
         log_weight, dist = self._log_weight(tensordict)
         # ESS for logging
         with torch.no_grad():


### PR DESCRIPTION
## Description

In the ClipPPOLoss, the advantage normalisation is done after computing gain1 and before computing gain2. 

Shouldn't it be computed at the beginning, before both gain1 and gain2? This PR simply proposes to normalise the advantage at the beginning of the loss. 

