### PR TITLE
[BugFix] Loss function convert_to_functional seems to generate backprop issues with shared policy-value networks

### DIFF
--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -114,7 +114,9 @@ class PPOLoss(LossModule):
         )
         # we want to make sure there are no duplicates in the params: the
         # params of critic must be refs to actor if they're shared
-        self.convert_to_functional(critic, "critic", compare_against=self.actor_params)
+        # self.convert_to_functional(critic, "critic", compare_against=self.actor_params)  # Value network update is not correct
+        # self.convert_to_functional(critic, "critic")  # Value network update is not correct either
+        self.critic = critic
         self.advantage_key = advantage_key
         self.value_target_key = value_target_key
         self.samples_mc_entropy = samples_mc_entropy
@@ -169,7 +171,7 @@ class PPOLoss(LossModule):
             tensordict_select = tensordict.select(*self.critic.in_keys)
             state_value = self.critic(
                 tensordict_select,
-                params=self.critic_params,
+                # params=self.critic_params,
             ).get("state_value")
             loss_value = distance_loss(
                 target_return,


### PR DESCRIPTION
## Description

At least in PPO (but also probably in the rest of the Objective classes), calling self.convert_to_functional in the following lines when using a policy-value shared architecture causes the value network not to update correctly. Could the current code be stopping the value loss from being propagated to the first layers?
https://github.com/pytorch/rl/blob/main/torchrl/objectives/ppo.py#L113
https://github.com/pytorch/rl/blob/main/torchrl/objectives/ppo.py#L117

This PR removes the calling of self.convert_to_functional. I ran it in a test case for Atari Pong env and as the plots show it solved the issue. Green line is the modified version of the code. However, a proper solution should probably be discussed because I am not sure if simply removing these lines causes problems somewhere else. 

<img width="1356" alt="PPO_bug1" src="https://user-images.githubusercontent.com/23138441/231083999-2d23890f-0560-4093-98e4-62d956f57e61.png">
<img width="990" alt="PPO_bug2" src="https://user-images.githubusercontent.com/23138441/231084032-f11b067d-9709-4d59-a14b-a3bb864cb3c5.png">


