### PR TITLE
[Refactor] Import enum and interaction_type utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,9 +440,9 @@ And it is `functorch` and `torch.compile` compatible!
 
   ```python
   policy_explore = EGreedyWrapper(policy)
-  with set_exploration_mode("random"):
+  with set_exploration_type(ExplorationType.RANDOM):
       tensordict = policy_explore(tensordict)  # will use eps-greedy
-  with set_exploration_mode("mode"):
+  with set_exploration_type(ExplorationType.MODE):
       tensordict = policy_explore(tensordict)  # will not use eps-greedy
   ```
   </details>

--- a/docs/source/reference/envs.rst
+++ b/docs/source/reference/envs.rst
@@ -372,8 +372,10 @@ Helpers
 
     step_mdp
     get_available_libraries
-    set_exploration_mode
-    exploration_mode
+    set_exploration_mode #deprecated
+    set_exploration_type
+    exploration_mode #deprecated
+    exploration_type
     check_env_specs
     make_composite_from_td
 

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -7,8 +7,14 @@ from __future__ import annotations
 import pkg_resources
 import torch
 from tensordict.nn.probabilistic import (  # noqa
+    # Note: the `set_/interaction_mode` and their associated arg `default_interaction_mode` are being deprecated!
+    #       Please use the `set_/interaction_type` ones above with the InteractionType enum instead.
+    #       See more details: https://github.com/pytorch/rl/issues/1016
     interaction_mode as exploration_mode,
+    interaction_type as exploration_type,
+    InteractionType,
     set_interaction_mode as set_exploration_mode,
+    set_interaction_type as set_exploration_type,
 )
 from tensordict.tensordict import TensorDictBase
 

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -12,7 +12,7 @@ from tensordict.nn.probabilistic import (  # noqa
     #       See more details: https://github.com/pytorch/rl/issues/1016
     interaction_mode as exploration_mode,
     interaction_type as exploration_type,
-    InteractionType,
+    InteractionType as ExplorationType,
     set_interaction_mode as set_exploration_mode,
     set_interaction_type as set_exploration_type,
 )


### PR DESCRIPTION
## Description

Imported the refactored `set_/interaction_type` utils and `InteractionType` enum for future use.

## Motivation and Context

Why is this change required? What problem does it solve?
This is to address https://github.com/pytorch/rl/issues/1016

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
