### PR TITLE
[Doc] fix figures display issues in documentation of actors.py

### DIFF
--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -724,25 +724,23 @@ class ActorValueOperator(SafeSequential):
         :proportional:
         :textual:
 
-            +---------------+
-            |Observation (s)|
-            +---------------+
-                     |
-                     v
-                   common
-                     |
-                     v
-           +------------------+
-           |    Hidden state  |
-           +------------------+
-            |                |
-            v                v
-         actor             critic
-           |                 |
-           v                 v
-       +-------------+  +------------+
-       |Action (a(s))|  |Value (V(s))|
-       +-------------+  +------------+
+               +---------------+
+               |Observation (s)|
+               +---------------+
+                        |
+                       "common"
+                        |
+                        v
+                 +------------+
+                 |Hidden state|
+                 +------------+
+                   |         |
+                  actor     critic
+                   |         |
+                   v         v
+        +-------------+ +------------+
+        |Action (a(s))| |Value (V(s))|
+        +-------------+ +------------+
 
     .. note::
       For a similar class that returns an action and a Quality value :math:`Q(s, a)`
@@ -867,25 +865,25 @@ class ActorCriticOperator(ActorValueOperator):
         :proportional:
         :textual:
 
-                +---------------+
-                |Observation (s)|
-                +---------------+
+                 +---------------+
+                 |Observation (s)|
+                 +---------------+
                          |
                          v
-                      common
+                        "common"
                          |
                          v
-               +------------------+
-               |    Hidden state  |
-               +------------------+
-                |                |
-                v                v
-             actor  ------>   critic
-               |                 |
-               v                 v
-       +-------------+  +----------------+
-       |Action (a(s))|  |Quality (Q(s,a))|
-       +-------------+  +----------------+
+                  +------------+
+                  |Hidden state|
+                  +------------+
+                    |        |
+                    v        v
+                   actor --> critic
+                    |        |
+                    v        v
+            +-------------+ +----------------+
+            |Action (a(s))| |Quality (Q(s,a))|
+            +-------------+ +----------------+
 
     .. note::
       For a similar class that returns an action and a state-value :math:`V(s)`
@@ -1019,17 +1017,17 @@ class ActorCriticWrapper(SafeSequential):
         :proportional:
         :textual:
 
-               +---------------+
-               |Observation (s)|
-               +---------------+
-                |     |   |
-                v     |   v
-                actor |   critic
-                |     |   |
-                v     |   v
-       +-------------+|+------------+
-       |Action (a(s))|||Value (V(s))|
-       +-------------+|+------------+
+                 +---------------+
+                 |Observation (s)|
+                 +---------------+
+                    |    |    |
+                    v    |    v
+                   actor |    critic
+                    |    |    |
+                    v    |    v
+        +-------------+  |  +------------+
+        |Action (a(s))|  |  |Value (V(s))|
+        +-------------+  |  +------------+
 
 
     To facilitate the workflow, this  class comes with a get_policy_operator() and get_value_operator() methods, which


### PR DESCRIPTION
## Description

The following figures are poorly rendered:
- [Actor Value Operator](https://pytorch.org/rl/reference/generated/torchrl.modules.tensordict_module.ActorValueOperator.html)
- [Actor Critic Operator](https://pytorch.org/rl/reference/generated/torchrl.modules.tensordict_module.ActorCriticOperator.html)
- [Actor Value Operator](https://pytorch.org/rl/reference/generated/torchrl.modules.tensordict_module.ActorCriticWrapper.html)

## Motivation and Context

Solve the figures display problems


## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
