### PR TITLE
[BugFix] Change default of skip_existing to None

### DIFF
--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -397,7 +397,7 @@ class TD1Estimator(ValueEstimatorBase):
         advantage_key: Union[str, Tuple] = "advantage",
         value_target_key: Union[str, Tuple] = "value_target",
         value_key: Union[str, Tuple] = "state_value",
-        skip_existing: bool = False,
+        skip_existing: Optional[bool] = None,
     ):
         super().__init__(
             value_network=value_network,
@@ -577,7 +577,7 @@ class TDLambdaEstimator(ValueEstimatorBase):
         advantage_key: Union[str, Tuple] = "advantage",
         value_target_key: Union[str, Tuple] = "value_target",
         value_key: Union[str, Tuple] = "state_value",
-        skip_existing: bool = False,
+        skip_existing: Optional[bool] = None,
     ):
         super().__init__(
             value_network=value_network,
@@ -782,7 +782,7 @@ class GAE(ValueEstimatorBase):
         advantage_key: Union[str, Tuple] = "advantage",
         value_target_key: Union[str, Tuple] = "value_target",
         value_key: Union[str, Tuple] = "state_value",
-        skip_existing: bool = False,
+        skip_existing: Optional[bool] = None,
     ):
         super().__init__(
             value_network=value_network,


### PR DESCRIPTION
This is the behaviour stated in the docstring, and the current default value of `False` makes it impossible to override `skip_existing` with the `set_skip_existing` context manager.