### PR TITLE
[BugFix] Instruct the value key to PPOLoss

### DIFF
--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -47,6 +47,8 @@ class PPOLoss(LossModule):
             Defaults to ``"advantage"``.
         value_target_key (str, optional): the input tensordict key where the target state
             value is expected to be written. Defaults to ``"value_target"``.
+        value_key (str, optional): the input tensordict key where the state
+            value is expected to be written. Defaults to ``"state_value"``.
         entropy_bonus (bool, optional): if ``True``, an entropy bonus will be added to the
             loss to favour exploratory policies.
         samples_mc_entropy (int, optional): if the distribution retrieved from the policy

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -120,6 +120,7 @@ class PPOLoss(LossModule):
         *,
         advantage_key: str = "advantage",
         value_target_key: str = "value_target",
+        value_key: str = "state_value",
         entropy_bonus: bool = True,
         samples_mc_entropy: int = 1,
         entropy_coef: float = 0.01,
@@ -142,6 +143,7 @@ class PPOLoss(LossModule):
         self.convert_to_functional(critic, "critic", compare_against=policy_params)
         self.advantage_key = advantage_key
         self.value_target_key = value_target_key
+        self.value_key = value_key
         self.samples_mc_entropy = samples_mc_entropy
         self.entropy_bonus = entropy_bonus
         self.separate_losses = separate_losses
@@ -196,7 +198,7 @@ class PPOLoss(LossModule):
             state_value = self.critic(
                 tensordict,
                 params=self.critic_params,
-            ).get("state_value")
+            ).get(self.value_key)
             loss_value = distance_loss(
                 target_return,
                 state_value,


### PR DESCRIPTION
using a `value_key` parameter instead of hardcoded name 'state_value' to get the state value tensor

## Description

using a `value_key` parameter instead of hardcoded name 'state_value' to get the state value tensor

## Motivation and Context

#1097 

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)

