### PR TITLE
[Feature] Indexing specs

### DIFF
--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -2348,11 +2348,21 @@ class TestStackComposite:
             c.to_numpy(td_fail)
 
 
-@pytest.mark.parametrize("spec", [OneHotDiscreteTensorSpec(n=4, shape=[3, 4])])
+# MultiDiscreteTensorSpec: Pending resolution of https://github.com/pytorch/pytorch/issues/100080.
+@pytest.mark.parametrize(
+    "spec_class",
+    [
+        BinaryDiscreteTensorSpec,
+        OneHotDiscreteTensorSpec,
+        MultiOneHotDiscreteTensorSpec,
+        CompositeSpec,
+    ],
+)
 @pytest.mark.parametrize(
     "idx",
     [
         5,
+        (0, 1),
         range(10),
         np.array([[2, 10]]),
         (slice(None), slice(1, 2), 1),
@@ -2361,7 +2371,15 @@ class TestStackComposite:
         torch.tensor([10, 2]),
     ],  # [:,1:2,1]
 )
-def test_invalid_indices(spec, idx):
+def test_invalid_indexing(spec_class, idx):
+    if spec_class in [BinaryDiscreteTensorSpec, OneHotDiscreteTensorSpec]:
+        spec = spec_class(n=4, shape=[3, 4])
+    elif spec_class == MultiDiscreteTensorSpec:
+        spec = spec_class([2, 2, 2], shape=[3])
+    elif spec_class == MultiOneHotDiscreteTensorSpec:
+        spec = spec_class([4], shape=[3, 4])
+    elif spec_class == CompositeSpec:
+        spec = spec_class(k=UnboundedDiscreteTensorSpec(shape=(3, 4)), shape=(3,))
     with pytest.raises(IndexError):
         spec[idx]
 
@@ -2376,23 +2394,25 @@ def test_invalid_indices(spec, idx):
         OneHotDiscreteTensorSpec,
         UnboundedContinuousTensorSpec,
         UnboundedDiscreteTensorSpec,
+        CompositeSpec,
     ],
 )
-def test_valid_indices(spec_class):
+def test_valid_indexing(spec_class):
     # Default args. UnboundedContinuousTensorSpec, UnboundedDiscreteTensorSpec, MultiDiscreteTensorSpec, MultiOneHotDiscreteTensorSpec
     args = {"0d": [], "2d": [], "3d": [], "4d": [], "5d": []}
+    kwargs = {}
     if spec_class in [
         BinaryDiscreteTensorSpec,
         DiscreteTensorSpec,
         OneHotDiscreteTensorSpec,
     ]:
-        args = {"0d": [0], "2d": [4], "3d": [4], "4d": [6], "5d": [7]}
+        args = {"0d": [0], "2d": [3], "3d": [4], "4d": [6], "5d": [7]}
     elif spec_class == MultiOneHotDiscreteTensorSpec:
-        args = {"0d": [[0]], "2d": [[4]], "3d": [[4]], "4d": [[6]], "5d": [[7]]}
+        args = {"0d": [[0]], "2d": [[3]], "3d": [[4]], "4d": [[6]], "5d": [[7]]}
     elif spec_class == MultiDiscreteTensorSpec:
         args = {
             "0d": [[0]],
-            "2d": [[2] * 4],
+            "2d": [[2] * 3],
             "3d": [[2] * 4],
             "4d": [[1] * 6],
             "5d": [[2] * 7],
@@ -2406,48 +2426,57 @@ def test_valid_indices(spec_class):
             "4d": min_max,
             "5d": min_max,
         }
+    elif spec_class == CompositeSpec:
+        kwargs = {
+            "k1": UnboundedDiscreteTensorSpec(shape=(5, 3, 4, 6, 7, 8)),
+            "k2": OneHotDiscreteTensorSpec(n=7, shape=(5, 3, 4, 6, 7)),
+        }
 
-    spec_0d = spec_class(*args["0d"])
-    if spec_class in [UnboundedContinuousTensorSpec, UnboundedDiscreteTensorSpec]:
-        spec_0d = spec_class(*args["0d"], shape=[])
-    spec_2d = spec_class(*args["2d"], shape=[3, 4])
-    spec_3d = spec_class(*args["3d"], shape=[5, 3, 4])
-    spec_4d = spec_class(*args["4d"], shape=[5, 3, 4, 6])
-    spec_5d = spec_class(*args["5d"], shape=[5, 3, 4, 6, 7])
+    spec_0d = spec_class(*args["0d"], **kwargs)
+    if spec_class in [
+        UnboundedContinuousTensorSpec,
+        UnboundedDiscreteTensorSpec,
+        CompositeSpec,
+    ]:
+        spec_0d = spec_class(*args["0d"], shape=[], **kwargs)
+    spec_2d = spec_class(*args["2d"], shape=[5, 3], **kwargs)
+    spec_3d = spec_class(*args["3d"], shape=[5, 3, 4], **kwargs)
+    spec_4d = spec_class(*args["4d"], shape=[5, 3, 4, 6], **kwargs)
+    spec_5d = spec_class(*args["5d"], shape=[5, 3, 4, 6, 7], **kwargs)
 
     # Integers
-    assert spec_2d[1].shape == torch.Size([4])
+    assert spec_2d[1].shape == torch.Size([3])
     # Lists
     assert spec_3d[[1, 2]].shape == torch.Size([2, 3, 4])
-    assert spec_2d[[0]].shape == torch.Size([1, 4])
-    assert spec_2d[[[[0]]]].shape == torch.Size([1, 1, 1, 4])
-    assert spec_2d[[0, 1]].shape == torch.Size([2, 4])
-    assert spec_2d[[[0, 1]]].shape == torch.Size([1, 2, 4])
+    assert spec_2d[[0]].shape == torch.Size([1, 3])
+    assert spec_2d[[[[0]]]].shape == torch.Size([1, 1, 1, 3])
+    assert spec_2d[[0, 1]].shape == torch.Size([2, 3])
+    assert spec_2d[[[0, 1]]].shape == torch.Size([1, 2, 3])
     assert spec_3d[[0, 1], [0, 1]].shape == torch.Size([2, 4])
-    assert spec_2d[[[0, 1], [0, 1]]].shape == torch.Size([2, 2, 4])
+    assert spec_2d[[[0, 1], [0, 1]]].shape == torch.Size([2, 2, 3])
     # Tuples
     assert spec_3d[1, 2].shape == torch.Size([4])
     assert spec_3d[(1, 2)].shape == torch.Size([4])
     assert spec_3d[((1, 2))].shape == torch.Size([4])
     # Ranges
-    assert spec_2d[range(2)].shape == torch.Size([2, 4])
+    assert spec_2d[range(2)].shape == torch.Size([2, 3])
     # Slices
-    assert spec_2d[:].shape == torch.Size([3, 4])
-    assert spec_2d[10:].shape == torch.Size([0, 4])
-    assert spec_2d[:1].shape == torch.Size([1, 4])
-    assert spec_2d[1:2].shape == torch.Size([1, 4])
-    assert spec_2d[10:1:-1].shape == torch.Size([1, 4])
-    assert spec_2d[-5:-1].shape == torch.Size([2, 4])
+    assert spec_2d[:].shape == torch.Size([5, 3])
+    assert spec_2d[10:].shape == torch.Size([0, 3])
+    assert spec_2d[:1].shape == torch.Size([1, 3])
+    assert spec_2d[1:2].shape == torch.Size([1, 3])
+    assert spec_2d[10:1:-1].shape == torch.Size([3, 3])
+    assert spec_2d[-5:-1].shape == torch.Size([4, 3])
     assert spec_3d[[1, 2], 3:].shape == torch.Size([2, 0, 4])
     # None (adds a singleton dimension where needed)
-    assert spec_2d[None].shape == torch.Size([1, 3, 4])
-    assert spec_2d[None, :2].shape == torch.Size([1, 2, 4])
+    assert spec_2d[None].shape == torch.Size([1, 5, 3])
+    assert spec_2d[None, :2].shape == torch.Size([1, 2, 3])
     # Ellipsis
-    assert spec_2d[1, ...].shape == torch.Size([4])
+    assert spec_2d[1, ...].shape == torch.Size([3])
     # Numpy arrays
-    assert spec_2d[np.array([[1, 2]])].shape == torch.Size([1, 2, 4])
+    assert spec_2d[np.array([[1, 2]])].shape == torch.Size([1, 2, 3])
     # Tensors
-    assert spec_2d[torch.randint(3, (3, 2))].shape == torch.Size([3, 2, 4])
+    assert spec_2d[torch.randint(3, (3, 2))].shape == torch.Size([3, 2, 3])
     # Tuples
     # Note: nested tuples are supported by specs but transformed into lists, similarity to numpy
     assert spec_3d[(0, 1), (0, 1)].shape == torch.Size([2, 4])
@@ -2485,28 +2514,43 @@ def test_valid_indices(spec_class):
         # Ellipsis
         assert spec_0d[None].shape == torch.Size([1, 0])
         assert spec_0d[...].shape == torch.Size([0])
-        assert spec_2d[..., :2].shape == torch.Size([2, 4])
-        assert spec_2d[..., :2, None, None].shape == torch.Size([2, 1, 1, 4])
+        assert spec_2d[..., :2].shape == torch.Size([2, 3])
+        assert spec_2d[..., :2, None, None].shape == torch.Size([2, 1, 1, 3])
         assert spec_4d[1, ..., 2].shape == torch.Size([3, 6])
-        assert spec_2d[1, ..., None].shape == torch.Size([1, 4])
+        assert spec_2d[1, ..., None].shape == torch.Size([1, 3])
         assert spec_3d[..., [0, 1], [0]].shape == torch.Size([2, 4])
         assert spec_3d[None, 1, ..., None].shape == torch.Size([1, 3, 1, 4])
+        assert spec_4d[:, None, ..., None, :].shape == torch.Size([5, 1, 3, 1, 4, 6])
 
-    # BoundedTensorSpec, DiscreteTensorSpec, UnboundedContinuousTensorSpec, UnboundedDiscreteTensorSpec
+    # BoundedTensorSpec, DiscreteTensorSpec, UnboundedContinuousTensorSpec, UnboundedDiscreteTensorSpec, CompositeSpec
     else:
         # Integers
         assert spec_2d[0, 1].shape == torch.Size([])
 
         # Ellipsis
-        print(spec_0d)
         assert spec_0d[None].shape == torch.Size([1])
         assert spec_0d[...].shape == torch.Size([])
-        assert spec_2d[..., :2].shape == torch.Size([3, 2])
-        assert spec_2d[..., :2, None, None].shape == torch.Size([3, 2, 1, 1])
+        assert spec_2d[..., :2].shape == torch.Size([5, 2])
+        assert spec_2d[..., :2, None, None].shape == torch.Size([5, 2, 1, 1])
         assert spec_4d[1, ..., 2].shape == torch.Size([3, 4])
-        assert spec_2d[1, ..., None].shape == torch.Size([4, 1])
+        assert spec_2d[1, ..., None].shape == torch.Size([3, 1])
         assert spec_3d[..., [0, 1], [0]].shape == torch.Size([5, 2])
         assert spec_3d[None, 1, ..., None].shape == torch.Size([1, 3, 4, 1])
+        assert spec_4d[:, None, ..., None, :].shape == torch.Size([5, 1, 3, 4, 1, 6])
+
+    # Additional tests for composite spec
+    if spec_class == CompositeSpec:
+        assert spec_2d[1]["k1"].shape == torch.Size([3, 4, 6, 7, 8])
+        assert spec_3d[[1, 2]]["k1"].shape == torch.Size([2, 3, 4, 6, 7, 8])
+        assert spec_2d[torch.randint(3, (3, 2))]["k1"].shape == torch.Size(
+            [3, 2, 3, 4, 6, 7, 8]
+        )
+        assert spec_0d["k1"].shape == torch.Size([5, 3, 4, 6, 7, 8])
+        assert spec_0d[None]["k1"].shape == torch.Size([1, 5, 3, 4, 6, 7, 8])
+
+        assert spec_2d[..., 0]["k1"].shape == torch.Size([5, 4, 6, 7, 8])
+        assert spec_4d[1, ..., 2]["k2"].shape == torch.Size([3, 4, 7])
+        assert spec_2d[1, ..., None]["k2"].shape == torch.Size([3, 1, 4, 6, 7])
 
 
 if __name__ == "__main__":

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -2509,18 +2509,16 @@ class CompositeSpec(TensorSpec):
         for k, v in self._specs.items():
             _idx = idx
             if isinstance(idx, tuple):
-                protected_dims = (
-                    1
-                    if any(
-                        isinstance(v, spec_class)
-                        for spec_class in [
-                            BinaryDiscreteTensorSpec,
-                            MultiDiscreteTensorSpec,
-                            OneHotDiscreteTensorSpec,
-                        ]
-                    )
-                    else 0
-                )
+                protected_dims = 0
+                if any(
+                    isinstance(v, spec_class)
+                    for spec_class in [
+                        BinaryDiscreteTensorSpec,
+                        MultiDiscreteTensorSpec,
+                        OneHotDiscreteTensorSpec,
+                    ]
+                ):
+                    protected_dims = 1
                 # TensorSpecs dims which are not part of the composite shape cannot be indexed
                 _idx = idx + (slice(None),) * (
                     len(v.shape) - len(self.shape) - protected_dims


### PR DESCRIPTION
## Description

Add indexing support to remaining specs:
- [x] BinaryDiscreteTensorSpec
- [x] BoundedTensorSpec
- [x] CompositeSpec
- [x] MultiDiscreteTensorSpec
- [x] MultiOneHotDiscreteTensorSpec
- [x] UnboundedContinuousTensorSpec
- [x] UnboundedDiscreteTensorSpec

Already supported by previous PR #1081 :
- [x] DiscreteTensorSpec
- [x] OneHotDiscreteTensorSpec

Note: although indexing & tests have been implemented for BoundedTensorSpec & MultiDiscreteTensorSpec, a NotImplementedError is currently set to prevent a different behavior with the other specs until https://github.com/pytorch/pytorch/issues/100080 is addressed.

## Motivation and Context

Address feature request of adding indexing to specs: https://github.com/pytorch/rl/issues/1051.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] New feature (non-breaking change which adds core functionality)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.

cc @matteobettini 