### PR TITLE
Fixing the linux libs - habitat failure

### DIFF
--- a/.circleci/unittest/linux_libs/scripts_habitat/run_test.sh
+++ b/.circleci/unittest/linux_libs/scripts_habitat/run_test.sh
@@ -18,7 +18,7 @@ root_dir="$(git rev-parse --show-toplevel)"
 env_dir="${root_dir}/env"
 lib_dir="${env_dir}/lib"
 
-# smoke test
+# smoke test  
 python -c "import habitat;import habitat.gym"
 
 # solves ImportError: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found


### PR DESCRIPTION
## Description

Fixing the Circle CI linux libs - habitat unit test which is failing

## Motivation and Context

Fixing the unittest_linux_habitat_gpu_py3.9 test error.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
