### PR TITLE
[Performance] Accelerate TD lambda return estimate 

### DIFF
--- a/torchrl/objectives/value/functional.py
+++ b/torchrl/objectives/value/functional.py
@@ -801,8 +801,8 @@ def _fast_td_lambda_return_estimate(
     nvalue_ndone = not_done * next_state_value
 
     t = nvalue_ndone * gamma_tensor * (1 - lmbda) + reward
-    v3 = nvalue_ndone.clone()
-    v3[..., :-1] = 0
+    v3 = torch.zeros_like(t)
+    v3[..., -1] = nvalue_ndone[..., -1].clone()
 
     t_flat, mask = _split_and_pad_sequence(
         t + v3 * gammalmbda, num_per_traj, return_mask=True

--- a/torchrl/objectives/value/functional.py
+++ b/torchrl/objectives/value/functional.py
@@ -793,17 +793,14 @@ def _fast_td_lambda_return_estimate(
     reward = reward.transpose(-2, -1)
     next_state_value = next_state_value.transpose(-2, -1)
 
-    gammalmbda = gamma * lmbda
+    gamma_tensor = torch.Tensor([gamma], device=reward.device)
+    gammalmbda = gamma_tensor * lmbda
 
     not_done = (~done).int()
     num_per_traj = _get_num_per_traj(done)
     nvalue_ndone = not_done * next_state_value
 
-    if isinstance(gamma, torch.Tensor):
-        t = nvalue_ndone * gamma.clone() * (1 - lmbda) + reward
-    else:
-        t = nvalue_ndone * gamma * (1 - lmbda) + reward
-
+    t = nvalue_ndone * gamma_tensor * (1 - lmbda) + reward
     v3 = nvalue_ndone.clone()
     v3[..., :-1] = 0
 

--- a/torchrl/objectives/value/functional.py
+++ b/torchrl/objectives/value/functional.py
@@ -812,7 +812,7 @@ def _fast_td_lambda_return_estimate(
     reward = reward.transpose(-2, -1)
     next_state_value = next_state_value.transpose(-2, -1)
 
-    gamma_tensor = torch.Tensor([gamma], device=device)
+    gamma_tensor = torch.tensor([gamma], device=device)
     gammalmbda = gamma_tensor * lmbda
 
     not_done = (~done).int()

--- a/torchrl/objectives/value/functional.py
+++ b/torchrl/objectives/value/functional.py
@@ -830,7 +830,7 @@ def _fast_td_lambda_return_estimate(
     # cutoff gammalmbdas as soon as is smaller than `thr`
     lim = int(math.log(thr) / gammalmbda.log().item())
     # create decay filter [1, g, g**2, g**3, ...]
-    gammalmbdas = gammalmbda.pow(torch.arange(lim)).unsqueeze(-1)
+    gammalmbdas = gammalmbda.pow(torch.arange(lim, device=device)).unsqueeze(-1)
 
     ret_flat = _custom_conv1d(t_flat.unsqueeze(1), gammalmbdas)
     ret = ret_flat.squeeze(1)[mask]

--- a/torchrl/objectives/value/utils.py
+++ b/torchrl/objectives/value/utils.py
@@ -340,22 +340,7 @@ def _inv_pad_sequence(
         ).unsqueeze(0)
         mask = arange < splits.unsqueeze(1)
 
-    # print(f"{tensor.shape = }")
-    # print(f"{mask.shape = }")
     return tensor[mask]
-
-
-# def _inv_pad_sequence(
-#    tensor, splits
-# ):
-#    if splits.numel() == 1:
-#        return tensor
-#
-#    arange = torch.tile(
-#        torch.arange(tensor.shape[-1], device=tensor.device), (tensor.shape[0], 1)
-#    )
-#    idx = (arange < splits.unsqueeze(1)).reshape(-1)
-#    return tensor.reshape(-1)[idx]
 
 
 def _get_num_per_traj_init(is_init):

--- a/torchrl/objectives/value/utils.py
+++ b/torchrl/objectives/value/utils.py
@@ -339,7 +339,23 @@ def _inv_pad_sequence(
             tensor.shape[-1], device=tensor.device, dtype=dtype
         ).unsqueeze(0)
         mask = arange < splits.unsqueeze(1)
+
+    # print(f"{tensor.shape = }")
+    # print(f"{mask.shape = }")
     return tensor[mask]
+
+
+# def _inv_pad_sequence(
+#    tensor, splits
+# ):
+#    if splits.numel() == 1:
+#        return tensor
+#
+#    arange = torch.tile(
+#        torch.arange(tensor.shape[-1], device=tensor.device), (tensor.shape[0], 1)
+#    )
+#    idx = (arange < splits.unsqueeze(1)).reshape(-1)
+#    return tensor.reshape(-1)[idx]
 
 
 def _get_num_per_traj_init(is_init):


### PR DESCRIPTION
## Description

Implement a version of for `vec_td_lambda_return_estimate` optimized for the case where gamma is a scalar.

## Motivation and Context

In the case gamma is a scalar one can do the same optimization as done in #1141. Instead of constructing a big gamma tensor [B, T, T], one can split and pad the consecutive traces:
```python
reward = [r00, r01, r02, r03, r10, r11]
done = [False, False, False, True, False, False]
```
into
```python
r_transformed = [
    [r00, r01, r02, r03],
    [r10, r11, 0, 0]
]
```
and then apply a gamma filter to this transformed input.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x ] Bug fix (non-breaking change which fixes an issue)

Closes #1148 

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
