### PR TITLE
[Nova] Remove windows Unittests from CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1044,42 +1044,6 @@ jobs:
       - store_test_results:
           path: test-results
 
-  unittest_windows_optdepts_cpu:
-    <<: *binary_common
-    executor:
-      name: windows-cpu
-    steps:
-      - checkout
-      - designate_upload_channel
-      - run:
-          name: Generate cache key
-          # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly
-#      - restore_cache:
-#          keys:
-#            - env-v2-windows-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/windows_optdepts/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
-
-      - run:
-          name: Setup
-          command: .circleci/unittest/windows_optdepts/scripts/setup_env.sh
-#      - save_cache:
-#          key: env-v2-windows-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/windows_optdepts/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
-#
-#          paths:
-#            - conda
-#            - env
-      - run:
-          name: Install torchrl
-          command: .circleci/unittest/windows_optdepts/scripts/install.sh
-      - run:
-          name: Run tests
-          command: .circleci/unittest/windows_optdepts/scripts/run_test.sh
-      - run:
-          name: Post process
-          command: .circleci/unittest/windows_optdepts/scripts/post_process.sh
-      - store_test_results:
-          path: test-results
-
   unittest_windows_optdepts_gpu:
     <<: *binary_common
     executor:
@@ -1198,10 +1162,6 @@ workflows:
           name: unittest_linux_examples_gpu_py3.9
           python_version: '3.9'
 
-      - unittest_windows_optdepts_cpu:
-          cu_version: cpu
-          name: unittest_windows_optdepts_cpu_py3.9
-          python_version: '3.9'
       - unittest_windows_optdepts_gpu:
           cu_version: cu116
           name: unittest_windows_optdepts_gpu_py3.9


### PR DESCRIPTION
We moved this unittest job to GHA in a previous PR. This removes those jobs from CCI entirely.
