### PR TITLE
[Performance] Improve performance and streamline the generating of the gammalambda tensor

### DIFF
--- a/benchmarks/test_objectives_benchmarks.py
+++ b/benchmarks/test_objectives_benchmarks.py
@@ -112,43 +112,6 @@ def test_gae_speed(benchmark, gae_fn, gamma_tensor, batches, timesteps):
     )
 
 
-# the following code is not meant for merging into main,
-# but for test performances in CI
-def gl01(t, gammalmbda, device):
-    gammalmbdas = torch.ones_like(t[0], device=device)
-    gammalmbdas[1:] = gammalmbda
-    gammalmbdas[1:] = gammalmbdas[1:].cumprod(0)
-    gammalmbdas = gammalmbdas.unsqueeze(-1)
-    return gammalmbdas
-
-
-def gl02(lim, gammalmbda, device):
-    gammalmbda = torch.tensor([gammalmbda], device=device)
-    gammalmbdas = gammalmbda.pow(torch.arange(lim, device=device)).unsqueeze(-1)
-    return gammalmbdas
-
-
-def gl03(t, gammalmbda, device):
-    gammalmbdas = torch.full_like(t[0], gammalmbda, device=device)
-    gammalmbdas[0] = 1.0
-    gammalmbdas = gammalmbdas.cumprod(0)
-    gammalmbdas = gammalmbdas.unsqueeze(-1)
-    return gammalmbdas
-
-
-@pytest.mark.parametrize("lim", [5, 10, 50, 100, 500, 1000, 2000, 5000])
-@pytest.mark.parametrize("f", [gl01, gl02, gl03])
-def test_create_decay(benchmark, lim, f):
-    device = "cuda:0" if torch.cuda.device_count() else "cpu"
-
-    t = torch.ones((1, lim), device=device)
-    gammalmbda = 0.9
-    if f != gl02:
-        benchmark(f, t, gammalmbda, device)
-    else:
-        benchmark(f, lim, gammalmbda, device)
-
-
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/torchrl/objectives/value/functional.py
+++ b/torchrl/objectives/value/functional.py
@@ -160,6 +160,23 @@ def generalized_advantage_estimate(
     return advantage, value_target
 
 
+def _geom_series_like(t, r, thr):
+    """Creates a geometric series of the form [1, gammalmbda, gammalmbda**2] with the shape of `t`.
+
+    Drops all elements which are smaller than `thr`.
+    """
+    if isinstance(r, torch.Tensor):
+        r = r.item()
+
+    lim = int(math.log(thr) / math.log(r))
+
+    rs = torch.full_like(t[0][:lim], r, device=t.device)
+    rs[0] = 1.0
+    rs = rs.cumprod(0)
+    rs = rs.unsqueeze(-1)
+    return rs
+
+
 def _fast_vec_gae(
     reward: torch.Tensor,
     state_value: torch.Tensor,
@@ -202,16 +219,7 @@ def _fast_vec_gae(
     num_per_traj = _get_num_per_traj(done)
     td0_flat, mask = _split_and_pad_sequence(td0, num_per_traj, return_mask=True)
 
-    if not isinstance(gammalmbda, torch.Tensor):
-        gammalmbda_log = math.log(gammalmbda)
-    else:
-        gammalmbda_log = gammalmbda.log().item()
-    lim = int(math.log(thr) / gammalmbda_log)
-    gammalmbdas = torch.ones_like(td0_flat[0][:lim])
-
-    gammalmbdas[1:] = gammalmbda
-    gammalmbdas[1:] = gammalmbdas[1:].cumprod(0)
-    gammalmbdas = gammalmbdas.unsqueeze(-1)
+    gammalmbdas = _geom_series_like(td0_flat, gammalmbda, thr=thr)
 
     advantage = _custom_conv1d(td0_flat.unsqueeze(1), gammalmbdas)
     advantage = advantage.squeeze(1)
@@ -827,10 +835,7 @@ def _fast_td_lambda_return_estimate(
         t + v3 * gammalmbda, num_per_traj, return_mask=True
     )
 
-    # cutoff gammalmbdas as soon as is smaller than `thr`
-    lim = int(math.log(thr) / gammalmbda.log().item())
-    # create decay filter [1, g, g**2, g**3, ...]
-    gammalmbdas = gammalmbda.pow(torch.arange(lim, device=device)).unsqueeze(-1)
+    gammalmbdas = _geom_series_like(t_flat, gammalmbda, thr)
 
     ret_flat = _custom_conv1d(t_flat.unsqueeze(1), gammalmbdas)
     ret = ret_flat.squeeze(1)[mask]
@@ -1100,10 +1105,7 @@ def reward2go(
 
     num_per_traj = _get_num_per_traj(done)
     td0_flat = _split_and_pad_sequence(reward, num_per_traj)
-    gammas = torch.ones_like(td0_flat[0])
-    gammas[1:] = gamma
-    gammas[1:] = gammas[1:].cumprod(0)
-    gammas = gammas.unsqueeze(-1)
+    gammas = _geom_series_like(td0_flat, gamma, thr=1e-7)
     cumsum = _custom_conv1d(td0_flat.unsqueeze(1), gammas)
     cumsum = cumsum.squeeze(1)
     cumsum = _inv_pad_sequence(cumsum, num_per_traj)


### PR DESCRIPTION
## Description

`_fast_vec_gae`, '_fast_td_lambda_return_estimate`, and `reward2go` need to construct a geometric series of the form `[1, g, g**2, g**3, .....]. This patch introduces a helper function such that the same logic is used by all three functions.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
