### PR TITLE
[Refactor] the usage of tensordict keys in loss modules

### DIFF
--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -3954,14 +3954,14 @@ class TestDreamer(LossModuleTestBase):
         loss_fn = DreamerModelLoss(world_model)
 
         default_keys = {
-            "reward_key": "reward",
-            "true_reward_key": "true_reward",
-            "prior_mean_key": "prior_mean",
-            "prior_std_key": "prior_std",
-            "posterior_mean_key": "posterior_mean",
-            "posterior_std_key": "posterior_std",
-            "pixels_key": "pixels",
-            "reco_pixels_key": "reco_pixels",
+            "reward": "reward",
+            "true_reward": "true_reward",
+            "prior_mean": "prior_mean",
+            "prior_std": "prior_std",
+            "posterior_mean": "posterior_mean",
+            "posterior_std": "posterior_std",
+            "pixels": "pixels",
+            "reco_pixels": "reco_pixels",
         }
         self.tensordict_keys_test(loss_fn, default_keys=default_keys)
 
@@ -3979,12 +3979,12 @@ class TestDreamer(LossModuleTestBase):
         )
 
         default_keys = {
-            "belief_key": "belief",
-            "reward_key": "reward",
-            "value_key": "state_value",
-            "done_key": "done",
+            "belief": "belief",
+            "reward": "reward",
+            "value": "state_value",
+            "done": "done",
         }
-        key_mapping = {"value_key": "value_key"}
+        key_mapping = {"value": "value_key"}
         self.tensordict_keys_test(
             loss_fn,
             default_keys=default_keys,
@@ -3997,7 +3997,7 @@ class TestDreamer(LossModuleTestBase):
         loss_fn = DreamerValueLoss(value_model)
 
         default_keys = {
-            "value_key": "state_value",
+            "value": "state_value",
         }
         self.tensordict_keys_test(loss_fn, default_keys=default_keys)
 

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -1798,32 +1798,6 @@ class TestSAC:
             p.data += torch.randn_like(p)
         assert all((p1 != p2).all() for p1, p2 in zip(parameters, actor.parameters()))
 
-    @pytest.mark.skipif(
-        not _has_functorch, reason=f"functorch not installed: {FUNCTORCH_ERR}"
-    )
-    def test_saq_tensordict_keys(self, version):
-        actor = self._create_mock_actor()
-        qvalue = self._create_mock_qvalue()
-        value = self._create_mock_value()
-        loss_fn = SACLoss(actor, qvalue, value)
-
-        # test default values
-        assert loss_fn.priority_key == "td_error"
-
-        # test setting relevant keys
-        new_key = "test1"
-        loss_fn.set_keys(priority_key=new_key)
-        assert loss_fn.priority_key == new_key
-
-        with pytest.raises(ValueError) as exc:
-            loss_fn.set_keys(value_key="test2")
-
-        # test deprecated keys
-        new_key = "test3"
-        with pytest.deprecated_call():
-            loss_fn = SACLoss(actor, qvalue, value, priority_key=new_key)
-            assert loss_fn.priority_key == new_key
-
 
 class TestDiscreteSAC:
     seed = 0
@@ -2158,33 +2132,6 @@ class TestDiscreteSAC:
         for p in loss_fn.parameters():
             p.data += torch.randn_like(p)
         assert all((p1 != p2).all() for p1, p2 in zip(parameters, actor.parameters()))
-
-    @pytest.mark.skipif(
-        not _has_functorch, reason=f"functorch not installed: {FUNCTORCH_ERR}"
-    )
-    def test_discrete_saq_tensordict_keys(self):
-        actor = self._create_mock_actor()
-        qvalue = self._create_mock_qvalue()
-        loss_fn = DiscreteSACLoss(actor, qvalue, actor.spec["action"].space.n)
-
-        # test default values
-        assert loss_fn.priority_key == "td_error"
-
-        # test setting relevant keys
-        new_key = "test1"
-        loss_fn.set_keys(priority_key=new_key)
-        assert loss_fn.priority_key == new_key
-
-        with pytest.raises(ValueError) as exc:
-            loss_fn.set_keys(value_key="test2")
-
-        # test deprecated keys
-        new_key = "test3"
-        with pytest.deprecated_call():
-            loss_fn = DiscreteSACLoss(
-                actor, qvalue, actor.spec["action"].space.n, priority_key=new_key
-            )
-            assert loss_fn.priority_key == new_key
 
 
 @pytest.mark.skipif(

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -149,100 +149,100 @@ class TestLossModuleBase:
             "sample_log_prob_key": "sample_log_prob",
             "action_key": "action",
         },
-        # ClipPPOLoss: {
-        #    "advantage_key": "advantage",
-        #    "value_target_key": "value_target",
-        #    "value_key": "state_value",
-        #    "sample_log_prob_key": "sample_log_prob",
-        #    "action_key": "action",
-        # },
-        # KLPENPPOLoss: {
-        #    "advantage_key": "advantage",
-        #    "value_target_key": "value_target",
-        #    "value_key": "state_value",
-        #    "sample_log_prob_key": "sample_log_prob",
-        #    "action_key": "action",
-        # },
-        # A2CLoss: {
-        #    "advantage_key": "advantage",
-        #    "value_target_key": "value_target",
-        #    "value_key": "state_value",
-        #    "action_key": "action",
-        # },
-        # ReinforceLoss: {
-        #    "advantage_key": "advantage",
-        #    "value_target_key": "value_target",
-        #    "value_key": "state_value",
-        #    "sample_log_prob_key": "sample_log_prob",
-        # },
-        # DDPGLoss: {
-        #    "state_action_value_key": "state_action_value",
-        #    "priority_key": "td_error",
-        # },
-        # DQNLoss: {
-        #    "priority_key": "td_error",
-        #    "action_value_key": "action_value",
-        #    "action_key": "action",
-        # },
-        # DistributionalDQNLoss: {
-        #    "priority_key": "td_error",
-        #    "action_value_key": "action_value",
-        #    "action_key": "action",
-        #    "reward_key": "reward",
-        #    "done_key": "done",
-        #    "steps_to_next_obs_key": "steps_to_next_obs",
-        # },
-        # SACLoss: {
-        #    "priority_key": "td_error",
-        #    "value_key": "state_value",
-        #    "state_action_value_key": "state_action_value",
-        #    "action_key": "action",
-        #    "sample_log_prob_key": "sample_log_prob",
-        #    "log_prob_key": "_log_prob",
-        # },
-        # DiscreteSACLoss: {
-        #    "priority_key": "td_error",
-        #    "value_key": "state_value",
-        #    "action_key": "action",
-        # },
-        # TD3Loss: {
-        #    "priority_key": "td_error",
-        #    "state_action_value_key": "state_action_value",
-        #    "action_key": "action",
-        # },
-        # IQLLoss: {
-        #    "priority_key": "td_error",
-        #    "log_prob_key": "_log_prob",
-        #    "action_key": "action",
-        #    "state_action_value_key": "state_action_value",
-        #    "value_key": "state_value",
-        # },
-        # REDQLoss: {
-        #    "priority_key": "td_error",
-        #    "action_key": "action",
-        #    "value_key": "state_value",
-        #    "sample_log_prob_key": "sample_log_prob",
-        #    "state_action_value_key": "state_action_value",
-        # },
-        # DreamerModelLoss: {
-        #    "reward_key": "reward",
-        #    "true_reward_key": "true_reward",
-        #    "prior_mean_key": "prior_mean",
-        #    "prior_std_key": "prior_std",
-        #    "posterior_mean_key": "posterior_mean",
-        #    "posterior_std_key": "posterior_std",
-        #    "pixels_key": "pixels",
-        #    "reco_pixels_key": "reco_pixels",
-        # },
-        # DreamerActorLoss: {
-        #    "belief_key": "belief",
-        #    "reward_key": "reward",
-        #    "value_key": "state_value",
-        #    "done_key": "done",
-        # },
-        # DreamerValueLoss: {
-        #    "value_key": "state_value",
-        # },
+        ClipPPOLoss: {
+            "advantage_key": "advantage",
+            "value_target_key": "value_target",
+            "value_key": "state_value",
+            "sample_log_prob_key": "sample_log_prob",
+            "action_key": "action",
+        },
+        KLPENPPOLoss: {
+            "advantage_key": "advantage",
+            "value_target_key": "value_target",
+            "value_key": "state_value",
+            "sample_log_prob_key": "sample_log_prob",
+            "action_key": "action",
+        },
+        A2CLoss: {
+            "advantage_key": "advantage",
+            "value_target_key": "value_target",
+            "value_key": "state_value",
+            "action_key": "action",
+        },
+        ReinforceLoss: {
+            "advantage_key": "advantage",
+            "value_target_key": "value_target",
+            "value_key": "state_value",
+            "sample_log_prob_key": "sample_log_prob",
+        },
+        DDPGLoss: {
+            "state_action_value_key": "state_action_value",
+            "priority_key": "td_error",
+        },
+        DQNLoss: {
+            "priority_key": "td_error",
+            "action_value_key": "action_value",
+            "action_key": "action",
+        },
+        DistributionalDQNLoss: {
+            "priority_key": "td_error",
+            "action_value_key": "action_value",
+            "action_key": "action",
+            "reward_key": "reward",
+            "done_key": "done",
+            "steps_to_next_obs_key": "steps_to_next_obs",
+        },
+        SACLoss: {
+            "priority_key": "td_error",
+            "value_key": "state_value",
+            "state_action_value_key": "state_action_value",
+            "action_key": "action",
+            "sample_log_prob_key": "sample_log_prob",
+            "log_prob_key": "_log_prob",
+        },
+        DiscreteSACLoss: {
+            "priority_key": "td_error",
+            "value_key": "state_value",
+            "action_key": "action",
+        },
+        TD3Loss: {
+            "priority_key": "td_error",
+            "state_action_value_key": "state_action_value",
+            "action_key": "action",
+        },
+        IQLLoss: {
+            "priority_key": "td_error",
+            "log_prob_key": "_log_prob",
+            "action_key": "action",
+            "state_action_value_key": "state_action_value",
+            "value_key": "state_value",
+        },
+        REDQLoss: {
+            "priority_key": "td_error",
+            "action_key": "action",
+            "value_key": "state_value",
+            "sample_log_prob_key": "sample_log_prob",
+            "state_action_value_key": "state_action_value",
+        },
+        DreamerModelLoss: {
+            "reward_key": "reward",
+            "true_reward_key": "true_reward",
+            "prior_mean_key": "prior_mean",
+            "prior_std_key": "prior_std",
+            "posterior_mean_key": "posterior_mean",
+            "posterior_std_key": "posterior_std",
+            "pixels_key": "pixels",
+            "reco_pixels_key": "reco_pixels",
+        },
+        DreamerActorLoss: {
+            "belief_key": "belief",
+            "reward_key": "reward",
+            "value_key": "state_value",
+            "done_key": "done",
+        },
+        DreamerValueLoss: {
+            "value_key": "state_value",
+        },
     }
     # loss modules which will be tested for setting tensordict keys
     LOSS_MODULES = DEFAULT_KEYS.keys()
@@ -262,7 +262,39 @@ class TestLossModuleBase:
         TD3Loss: ["priority_key"],
     }
 
-    LOSS_ADVANTAGE_KEY_MAPPING = {}
+    LOSS_ADVANTAGE_KEY_MAPPING = {
+        PPOLoss: {
+            "advantage_key": "advantage_key",
+            "value_target_key": "value_target_key",
+            "value_key": "value_key",
+        },
+        ClipPPOLoss: {
+            "advantage_key": "advantage_key",
+            "value_target_key": "value_target_key",
+            "value_key": "value_key",
+        },
+        KLPENPPOLoss: {
+            "advantage_key": "advantage_key",
+            "value_target_key": "value_target_key",
+            "value_key": "value_key",
+        },
+        A2CLoss: {
+            "advantage_key": "advantage_key",
+            "value_target_key": "value_target_key",
+            "value_key": "value_key",
+        },
+        DDPGLoss: {"state_action_value_key": "value_key"},
+        DreamerActorLoss: {"value_key": "value_key"},
+        ReinforceLoss: {
+            "advantage_key": "advantage_key",
+            "value_target_key": "value_target_key",
+            "value_key": "value_key",
+        },
+        SACLoss: {"value_key": "value_key"},
+        DiscreteSACLoss: {"value_key": "value_key"},
+        IQLLoss: {"value_key": "value_key"},
+        REDQLoss: {"value_key": "value_key"},
+    }
 
     def _create_mock_actor(
         self, action_spec_type="bounded", batch=2, obs_dim=3, action_dim=4
@@ -323,6 +355,25 @@ class TestLossModuleBase:
             out_keys=out_keys,
         )
         return value
+
+    def _create_mock_value_w_action(
+        self, batch=2, obs_dim=3, action_dim=4, device="cpu"
+    ):
+        # Actor
+        class ValueClass(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(obs_dim + action_dim, 1)
+
+            def forward(self, obs, act):
+                return self.linear(torch.cat([obs, act], -1))
+
+        module = ValueClass()
+        value = ValueOperator(
+            module=module,
+            in_keys=["observation", "action"],
+        )
+        return value.to(device)
 
     def _create_mock_qvalue(self, batch=2, obs_dim=3, action_dim=4):
         class ValueClass(nn.Module):
@@ -533,12 +584,16 @@ class TestLossModuleBase:
             ClipPPOLoss,
             KLPENPPOLoss,
             A2CLoss,
-            DDPGLoss,
             TD3Loss,
             REDQLoss,
         ]:
             actor = self._create_mock_actor()
             value = self._create_mock_value()
+            return loss_module(actor, value, **kwargs)
+        elif loss_module in [DDPGLoss]:
+            actor = self._create_mock_actor()
+            value = self._create_mock_value_w_action()
+            print(f"{value = }")
             return loss_module(actor, value, **kwargs)
         elif loss_module in [DQNLoss]:
             actor = self._create_mock_qv_actor()
@@ -643,19 +698,13 @@ class TestLossModuleBase:
 
     @pytest.mark.parametrize("loss_module", LOSS_MODULES)
     def test_set_keys_advantage(self, loss_module):
-        default_keys = self.DEFAULT_KEYS[loss_module]
-
-        loss_fn = self._construct_loss(loss_module)
-        loss_fn.make_value_estimator()
-
-        for advantage_key in ["advantage_key", "value_target_key", "value_key"]:
-            if loss_module in self.LOSS_ADVANTAGE_KEY_MAPPING:
-                loss_key = self.LOSS_ADVANTAGE_KEY_MAPPING[loss_module][advantage_key]
-            else:
-                loss_key = advantage_key
-
-            loss_fn.set_keys(**{loss_key: "test1"})
-            assert getattr(loss_fn.value_estimator, advantage_key) == "test1"
+        if loss_module in self.LOSS_ADVANTAGE_KEY_MAPPING:
+            loss_fn = self._construct_loss(loss_module)
+            loss_fn.make_value_estimator()
+            key_mapping = self.LOSS_ADVANTAGE_KEY_MAPPING[loss_module]
+            for loss_key, advantage_key in key_mapping.items():
+                loss_fn.set_keys(**{loss_key: "test1"})
+                assert getattr(loss_fn.value_estimator, advantage_key) == "test1"
 
 
 class TestDQN:
@@ -855,7 +904,7 @@ class TestDQN:
             loss_fn.make_value_estimator(td_est)
         with _check_td_steady(td):
             loss = loss_fn(td)
-        assert loss_fn.priority_key in td.keys()
+        assert loss_fn.tensor_keys.priority_key in td.keys()
 
         sum([item for _, item in loss.items()]).backward()
         assert torch.nn.utils.clip_grad.clip_grad_norm_(actor.parameters(), 1.0) > 0.0
@@ -896,7 +945,7 @@ class TestDQN:
 
         with _check_td_steady(ms_td):
             loss_ms = loss_fn(ms_td)
-        assert loss_fn.priority_key in ms_td.keys()
+        assert loss_fn.tensor_keys.priority_key in ms_td.keys()
 
         with torch.no_grad():
             loss = loss_fn(td)
@@ -958,7 +1007,7 @@ class TestDQN:
 
         with _check_td_steady(td):
             loss = loss_fn(td)
-        assert loss_fn.priority_key in td.keys()
+        assert loss_fn.tensor_keys.priority_key in td.keys()
 
         sum([item for _, item in loss.items()]).backward()
         assert torch.nn.utils.clip_grad.clip_grad_norm_(actor.parameters(), 1.0) > 0.0
@@ -1433,7 +1482,7 @@ class TestTD3:
 
         with _check_td_steady(ms_td):
             loss_ms = loss_fn(ms_td)
-        assert loss_fn.priority_key in ms_td.keys()
+        assert loss_fn.tensor_keys.priority_key in ms_td.keys()
 
         with torch.no_grad():
             torch.manual_seed(0)  # log-prob is computed with a random action
@@ -1660,7 +1709,7 @@ class TestSAC:
 
         with _check_td_steady(td):
             loss = loss_fn(td)
-        assert loss_fn.priority_key in td.keys()
+        assert loss_fn.tensor_keys.priority_key in td.keys()
 
         # check that losses are independent
         for k in loss.keys():
@@ -1817,7 +1866,7 @@ class TestSAC:
         np.random.seed(0)
         with _check_td_steady(ms_td):
             loss_ms = loss_fn(ms_td)
-        assert loss_fn.priority_key in ms_td.keys()
+        assert loss_fn.tensor_keys.priority_key in ms_td.keys()
 
         with torch.no_grad():
             torch.manual_seed(0)  # log-prob is computed with a random action
@@ -2067,7 +2116,7 @@ class TestDiscreteSAC:
 
         with _check_td_steady(td):
             loss = loss_fn(td)
-        assert loss_fn.priority_key in td.keys()
+        assert loss_fn.tensor_keys.priority_key in td.keys()
 
         # check that losses are independent
         for k in loss.keys():
@@ -2175,7 +2224,7 @@ class TestDiscreteSAC:
         np.random.seed(0)
         with _check_td_steady(ms_td):
             loss_ms = loss_fn(ms_td)
-        assert loss_fn.priority_key in ms_td.keys()
+        assert loss_fn.tensor_keys.priority_key in ms_td.keys()
 
         with torch.no_grad():
             torch.manual_seed(0)  # log-prob is computed with a random action
@@ -2410,7 +2459,7 @@ class TestREDQ:
             loss = loss_fn(td)
 
         # check td is left untouched
-        assert loss_fn.priority_key in td.keys()
+        assert loss_fn.tensor_keys.priority_key in td.keys()
 
         # check that losses are independent
         for k in loss.keys():
@@ -2535,7 +2584,7 @@ class TestREDQ:
             loss_fn.zero_grad()
 
         # check td is left untouched
-        assert loss_fn.priority_key in td.keys()
+        assert loss_fn.tensor_keys.priority_key in td.keys()
 
         sum([item for _, item in loss.items()]).backward()
         named_parameters = list(loss_fn.named_parameters())
@@ -2658,7 +2707,7 @@ class TestREDQ:
 
         with _check_td_steady(ms_td):
             loss_ms = loss_fn(ms_td)
-        assert loss_fn.priority_key in ms_td.keys()
+        assert loss_fn.tensor_keys.priority_key in ms_td.keys()
 
         with torch.no_grad():
             torch.manual_seed(0)  # log-prob is computed with a random action
@@ -3347,7 +3396,7 @@ class TestA2C:
             _ = loss_fn._log_probs(td)
         td["action"].requires_grad = False
 
-        td = td.exclude(loss_fn.value_target_key)
+        td = td.exclude(loss_fn.tensor_keys.value_target_key)
         if advantage is not None:
             advantage(td)
         elif td_est is not None:
@@ -4150,7 +4199,7 @@ class TestIQL:
 
         with _check_td_steady(td):
             loss = loss_fn(td)
-        assert loss_fn.priority_key in td.keys()
+        assert loss_fn.tensor_keys.priority_key in td.keys()
 
         # check that losses are independent
         for k in loss.keys():
@@ -4271,7 +4320,7 @@ class TestIQL:
         np.random.seed(0)
         with _check_td_steady(ms_td):
             loss_ms = loss_fn(ms_td)
-        assert loss_fn.priority_key in ms_td.keys()
+        assert loss_fn.tensor_keys.priority_key in ms_td.keys()
 
         with torch.no_grad():
             torch.manual_seed(0)  # log-prob is computed with a random action

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -190,10 +190,11 @@ class TestLossModuleBase:
             "action_key": "action",
             "reward_key": "reward",
             "done_key": "done",
+            "steps_to_next_obs_key": "steps_to_next_obs",
         },
         SACLoss: {
             "priority_key": "td_error",
-            "state_value_key": "state_value",
+            "value_key": "state_value",
             "state_action_value_key": "state_action_value",
             "action_key": "action",
             "sample_log_prob_key": "sample_log_prob",
@@ -201,7 +202,7 @@ class TestLossModuleBase:
         },
         DiscreteSACLoss: {
             "priority_key": "td_error",
-            "state_value_key": "state_value",
+            "value_key": "state_value",
             "action_key": "action",
         },
         TD3Loss: {

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -149,100 +149,100 @@ class TestLossModuleBase:
             "sample_log_prob_key": "sample_log_prob",
             "action_key": "action",
         },
-        ClipPPOLoss: {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "state_value",
-            "sample_log_prob_key": "sample_log_prob",
-            "action_key": "action",
-        },
-        KLPENPPOLoss: {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "state_value",
-            "sample_log_prob_key": "sample_log_prob",
-            "action_key": "action",
-        },
-        A2CLoss: {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "state_value",
-            "action_key": "action",
-        },
-        ReinforceLoss: {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "state_value",
-            "sample_log_prob_key": "sample_log_prob",
-        },
-        DDPGLoss: {
-            "state_action_value_key": "state_action_value",
-            "priority_key": "td_error",
-        },
-        DQNLoss: {
-            "priority_key": "td_error",
-            "action_value_key": "action_value",
-            "action_key": "action",
-        },
-        DistributionalDQNLoss: {
-            "priority_key": "td_error",
-            "action_value_key": "action_value",
-            "action_key": "action",
-            "reward_key": "reward",
-            "done_key": "done",
-            "steps_to_next_obs_key": "steps_to_next_obs",
-        },
-        SACLoss: {
-            "priority_key": "td_error",
-            "value_key": "state_value",
-            "state_action_value_key": "state_action_value",
-            "action_key": "action",
-            "sample_log_prob_key": "sample_log_prob",
-            "log_prob_key": "_log_prob",
-        },
-        DiscreteSACLoss: {
-            "priority_key": "td_error",
-            "value_key": "state_value",
-            "action_key": "action",
-        },
-        TD3Loss: {
-            "priority_key": "td_error",
-            "state_action_value_key": "state_action_value",
-            "action_key": "action",
-        },
-        IQLLoss: {
-            "priority_key": "td_error",
-            "log_prob_key": "_log_prob",
-            "action_key": "action",
-            "state_action_value_key": "state_action_value",
-            "value_key": "state_value",
-        },
-        REDQLoss: {
-            "priority_key": "td_error",
-            "action_key": "action",
-            "value_key": "state_value",
-            "sample_log_prob_key": "sample_log_prob",
-            "state_action_value_key": "state_action_value",
-        },
-        DreamerModelLoss: {
-            "reward_key": "reward",
-            "true_reward_key": "true_reward",
-            "prior_mean_key": "prior_mean",
-            "prior_std_key": "prior_std",
-            "posterior_mean_key": "posterior_mean",
-            "posterior_std_key": "posterior_std",
-            "pixels_key": "pixels",
-            "reco_pixels_key": "reco_pixels",
-        },
-        DreamerActorLoss: {
-            "belief_key": "belief",
-            "reward_key": "reward",
-            "value_key": "state_value",
-            "done_key": "done",
-        },
-        DreamerValueLoss: {
-            "value_key": "state_value",
-        },
+        # ClipPPOLoss: {
+        #    "advantage_key": "advantage",
+        #    "value_target_key": "value_target",
+        #    "value_key": "state_value",
+        #    "sample_log_prob_key": "sample_log_prob",
+        #    "action_key": "action",
+        # },
+        # KLPENPPOLoss: {
+        #    "advantage_key": "advantage",
+        #    "value_target_key": "value_target",
+        #    "value_key": "state_value",
+        #    "sample_log_prob_key": "sample_log_prob",
+        #    "action_key": "action",
+        # },
+        # A2CLoss: {
+        #    "advantage_key": "advantage",
+        #    "value_target_key": "value_target",
+        #    "value_key": "state_value",
+        #    "action_key": "action",
+        # },
+        # ReinforceLoss: {
+        #    "advantage_key": "advantage",
+        #    "value_target_key": "value_target",
+        #    "value_key": "state_value",
+        #    "sample_log_prob_key": "sample_log_prob",
+        # },
+        # DDPGLoss: {
+        #    "state_action_value_key": "state_action_value",
+        #    "priority_key": "td_error",
+        # },
+        # DQNLoss: {
+        #    "priority_key": "td_error",
+        #    "action_value_key": "action_value",
+        #    "action_key": "action",
+        # },
+        # DistributionalDQNLoss: {
+        #    "priority_key": "td_error",
+        #    "action_value_key": "action_value",
+        #    "action_key": "action",
+        #    "reward_key": "reward",
+        #    "done_key": "done",
+        #    "steps_to_next_obs_key": "steps_to_next_obs",
+        # },
+        # SACLoss: {
+        #    "priority_key": "td_error",
+        #    "value_key": "state_value",
+        #    "state_action_value_key": "state_action_value",
+        #    "action_key": "action",
+        #    "sample_log_prob_key": "sample_log_prob",
+        #    "log_prob_key": "_log_prob",
+        # },
+        # DiscreteSACLoss: {
+        #    "priority_key": "td_error",
+        #    "value_key": "state_value",
+        #    "action_key": "action",
+        # },
+        # TD3Loss: {
+        #    "priority_key": "td_error",
+        #    "state_action_value_key": "state_action_value",
+        #    "action_key": "action",
+        # },
+        # IQLLoss: {
+        #    "priority_key": "td_error",
+        #    "log_prob_key": "_log_prob",
+        #    "action_key": "action",
+        #    "state_action_value_key": "state_action_value",
+        #    "value_key": "state_value",
+        # },
+        # REDQLoss: {
+        #    "priority_key": "td_error",
+        #    "action_key": "action",
+        #    "value_key": "state_value",
+        #    "sample_log_prob_key": "sample_log_prob",
+        #    "state_action_value_key": "state_action_value",
+        # },
+        # DreamerModelLoss: {
+        #    "reward_key": "reward",
+        #    "true_reward_key": "true_reward",
+        #    "prior_mean_key": "prior_mean",
+        #    "prior_std_key": "prior_std",
+        #    "posterior_mean_key": "posterior_mean",
+        #    "posterior_std_key": "posterior_std",
+        #    "pixels_key": "pixels",
+        #    "reco_pixels_key": "reco_pixels",
+        # },
+        # DreamerActorLoss: {
+        #    "belief_key": "belief",
+        #    "reward_key": "reward",
+        #    "value_key": "state_value",
+        #    "done_key": "done",
+        # },
+        # DreamerValueLoss: {
+        #    "value_key": "state_value",
+        # },
     }
     # loss modules which will be tested for setting tensordict keys
     LOSS_MODULES = DEFAULT_KEYS.keys()
@@ -261,6 +261,8 @@ class TestLossModuleBase:
         REDQLoss: ["priority_key"],
         TD3Loss: ["priority_key"],
     }
+
+    LOSS_ADVANTAGE_KEY_MAPPING = {}
 
     def _create_mock_actor(
         self, action_spec_type="bounded", batch=2, obs_dim=3, action_dim=4
@@ -590,7 +592,7 @@ class TestLossModuleBase:
         """Test that exception is raised if an unknown key is set via .set_keys()"""
         loss_fn = self._construct_loss(loss_module)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             loss_fn.set_keys(unknown_key="test2")
 
     @pytest.mark.parametrize("loss_module", LOSS_MODULES)
@@ -599,7 +601,7 @@ class TestLossModuleBase:
         loss_fn = self._construct_loss(loss_module)
 
         for key, value in default_keys.items():
-            assert getattr(loss_fn, key) == value
+            assert getattr(loss_fn.tensor_keys, key) == value
 
     @pytest.mark.parametrize("loss_module", LOSS_MODULES)
     def test_tensordict_set_keys(self, loss_module):
@@ -611,13 +613,13 @@ class TestLossModuleBase:
         new_key = "test1"
         for key, _ in default_keys.items():
             loss_fn.set_keys(**{key: new_key})
-            assert getattr(loss_fn, key) == new_key
+            assert getattr(loss_fn.tensor_keys, key) == new_key
 
         loss_fn = self._construct_loss(loss_module)
         loss_fn.set_keys(**{key: new_key for key, _ in default_keys.items()})
 
         for key, _ in default_keys.items():
-            assert getattr(loss_fn, key) == new_key
+            assert getattr(loss_fn.tensor_keys, key) == new_key
 
     @pytest.mark.parametrize("loss_module", LOSS_MODULES)
     def test_tensordict_deprecated_ctor(self, loss_module):
@@ -633,11 +635,27 @@ class TestLossModuleBase:
             new_key = "test3"
             with pytest.deprecated_call():
                 loss_fn = self._construct_loss(loss_module, **{key: new_key})
-                assert getattr(loss_fn, key) == new_key
+                assert getattr(loss_fn.tensor_keys, key) == new_key
 
                 for def_key, def_value in default_keys.items():
                     if def_key != key:
-                        assert getattr(loss_fn, def_key) == def_value
+                        assert getattr(loss_fn.tensor_keys, def_key) == def_value
+
+    @pytest.mark.parametrize("loss_module", LOSS_MODULES)
+    def test_set_keys_advantage(self, loss_module):
+        default_keys = self.DEFAULT_KEYS[loss_module]
+
+        loss_fn = self._construct_loss(loss_module)
+        loss_fn.make_value_estimator()
+
+        for advantage_key in ["advantage_key", "value_target_key", "value_key"]:
+            if loss_module in self.LOSS_ADVANTAGE_KEY_MAPPING:
+                loss_key = self.LOSS_ADVANTAGE_KEY_MAPPING[loss_module][advantage_key]
+            else:
+                loss_key = advantage_key
+
+            loss_fn.set_keys(**{loss_key: "test1"})
+            assert getattr(loss_fn.value_estimator, advantage_key) == "test1"
 
 
 class TestDQN:

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -185,7 +185,9 @@ class LossModuleTestBase:
         key_mapping = loss_advantage_key_mapping
         for loss_key, advantage_key in key_mapping.items():
             test_fn.set_keys(**{loss_key: "test1"})
-            assert getattr(test_fn.value_estimator.tensor_keys, advantage_key) == "test1"
+            assert (
+                getattr(test_fn.value_estimator.tensor_keys, advantage_key) == "test1"
+            )
 
     # TODO test
     # loss = Loss(...)
@@ -2597,35 +2599,68 @@ class TestPPO(LossModuleTestBase):
     @pytest.mark.parametrize("advantage", ("gae", "td", "td_lambda", None))
     @pytest.mark.parametrize("device", get_available_devices())
     @pytest.mark.parametrize("td_est", list(ValueEstimators) + [None])
-    @pytest.mark.parametrize("tensor_keys", [None, {key: value + '_test' for key, value in PPOLoss._AcceptedKeys.__dict__.items() if key.endswith('_key')}])
-    def test_ppo(self, loss_class, device, gradient_mode, advantage, td_est, tensor_keys):
+    @pytest.mark.parametrize(
+        "tensor_keys",
+        [
+            None,
+            {
+                key: value + "_test"
+                for key, value in PPOLoss._AcceptedKeys.__dict__.items()
+                if key.endswith("_key")
+            },
+        ],
+    )
+    def test_ppo(
+        self, loss_class, device, gradient_mode, advantage, td_est, tensor_keys
+    ):
         torch.manual_seed(self.seed)
         if tensor_keys is None:
             td = self._create_seq_mock_data_ppo(device=device)
         else:
-            td = self._create_seq_mock_data_ppo(device=device, sample_log_prob_key=tensor_keys['sample_log_prob_key'], action_key=tensor_keys['action_key'])
+            td = self._create_seq_mock_data_ppo(
+                device=device,
+                sample_log_prob_key=tensor_keys["sample_log_prob_key"],
+                action_key=tensor_keys["action_key"],
+            )
 
         actor = self._create_mock_actor(device=device)
         if tensor_keys is not None:
-            value = self._create_mock_value(device=device, out_keys=[tensor_keys['value_key']])
+            value = self._create_mock_value(
+                device=device, out_keys=[tensor_keys["value_key"]]
+            )
         else:
             value = self._create_mock_value(device=device)
 
         if tensor_keys is not None:
-            adv_key = {key: value for key, value in tensor_keys.items() if key in GAE._AcceptedKeys.__dict__}
+            adv_key = {
+                key: value
+                for key, value in tensor_keys.items()
+                if key in GAE._AcceptedKeys.__dict__
+            }
         else:
             adv_key = None
         if advantage == "gae":
             advantage = GAE(
-                gamma=0.9, lmbda=0.9, value_network=value, differentiable=gradient_mode, tensor_keys=adv_key
+                gamma=0.9,
+                lmbda=0.9,
+                value_network=value,
+                differentiable=gradient_mode,
+                tensor_keys=adv_key,
             )
         elif advantage == "td":
             advantage = TD1Estimator(
-                gamma=0.9, value_network=value, differentiable=gradient_mode, tensor_keys=adv_key
+                gamma=0.9,
+                value_network=value,
+                differentiable=gradient_mode,
+                tensor_keys=adv_key,
             )
         elif advantage == "td_lambda":
             advantage = TDLambdaEstimator(
-                gamma=0.9, lmbda=0.9, value_network=value, differentiable=gradient_mode, tensor_keys=adv_key
+                gamma=0.9,
+                lmbda=0.9,
+                value_network=value,
+                differentiable=gradient_mode,
+                tensor_keys=adv_key,
             )
         elif advantage is None:
             pass
@@ -2946,11 +2981,11 @@ class TestPPO(LossModuleTestBase):
             lmbda=0.9,
             value_network=value,
             differentiable=gradient_mode,
-            tensor_keys = dict(
-                advantage_key=advantage_key,
-                value_target_key=value_target_key,
-                value_key=value_key,
-            )
+            tensor_keys={
+                "advantage_key": advantage_key,
+                "value_target_key": value_target_key,
+                "value_key": value_key,
+            },
         )
 
         loss_fn = loss_class(actor, value, loss_critic_type="l2")
@@ -4324,8 +4359,7 @@ def test_updater(mode, value_network_update_interval, device, dtype):
                 else:
                     target.data += 10
 
-        @staticmethod
-        def set_keys():
+        def _forward_value_estimator_keys(self, **kwargs) -> None:
             pass
 
     module = custom_module(delay_module=False)
@@ -5568,7 +5602,7 @@ def test_shared_params(dest, expected_dtype, expected_device):
                 compare_against=list(actor_network.parameters()),
             )
 
-        def set_keys():
+        def _forward_value_estimator_keys(self, **kwargs) -> None:
             pass
 
     actor_network = td_module.get_policy_operator()
@@ -5809,7 +5843,7 @@ class TestBase:
                     expand_dim=expand_dim,
                 )
 
-            def set_keys():
+            def _forward_value_estimator_keys(self, **kwargs) -> None:
                 pass
 
         loss_module = MyLoss(compare_against=compare_against, expand_dim=expand_dim)

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -1124,7 +1124,7 @@ class TestTD3(LossModuleTestBase):
 
         with _check_td_steady(ms_td):
             loss_ms = loss_fn(ms_td)
-        assert loss_fn.tensor_keys.priority_key in ms_td.keys()
+        assert loss_fn.tensor_keys.priority in ms_td.keys()
 
         with torch.no_grad():
             torch.manual_seed(0)  # log-prob is computed with a random action
@@ -2192,7 +2192,7 @@ class TestREDQ(LossModuleTestBase):
             loss = loss_fn(td)
 
         # check td is left untouched
-        assert loss_fn.tensor_keys.priority_key in td.keys()
+        assert loss_fn.tensor_keys.priority in td.keys()
 
         # check that losses are independent
         for k in loss.keys():
@@ -2317,7 +2317,7 @@ class TestREDQ(LossModuleTestBase):
             loss_fn.zero_grad()
 
         # check td is left untouched
-        assert loss_fn.tensor_keys.priority_key in td.keys()
+        assert loss_fn.tensor_keys.priority in td.keys()
 
         sum([item for _, item in loss.items()]).backward()
         named_parameters = list(loss_fn.named_parameters())
@@ -2440,7 +2440,7 @@ class TestREDQ(LossModuleTestBase):
 
         with _check_td_steady(ms_td):
             loss_ms = loss_fn(ms_td)
-        assert loss_fn.tensor_keys.priority_key in ms_td.keys()
+        assert loss_fn.tensor_keys.priority in ms_td.keys()
 
         with torch.no_grad():
             torch.manual_seed(0)  # log-prob is computed with a random action
@@ -2514,13 +2514,13 @@ class TestREDQ(LossModuleTestBase):
         )
 
         default_keys = {
-            "priority_key": "td_error",
-            "action_key": "action",
-            "value_key": "state_value",
-            "sample_log_prob_key": "sample_log_prob",
-            "state_action_value_key": "state_action_value",
+            "priority": "td_error",
+            "action": "action",
+            "value": "state_value",
+            "sample_log_prob": "sample_log_prob",
+            "state_action_value": "state_action_value",
         }
-        key_mapping = {"value_key": "value_key"}
+        key_mapping = {"value": "value_key"}
         self.tensordict_keys_test(
             loss_fn,
             default_keys=default_keys,
@@ -4150,7 +4150,7 @@ class TestIQL(LossModuleTestBase):
 
         with _check_td_steady(td):
             loss = loss_fn(td)
-        assert loss_fn.tensor_keys.priority_key in td.keys()
+        assert loss_fn.tensor_keys.priority in td.keys()
 
         # check that losses are independent
         for k in loss.keys():
@@ -4271,7 +4271,7 @@ class TestIQL(LossModuleTestBase):
         np.random.seed(0)
         with _check_td_steady(ms_td):
             loss_ms = loss_fn(ms_td)
-        assert loss_fn.tensor_keys.priority_key in ms_td.keys()
+        assert loss_fn.tensor_keys.priority in ms_td.keys()
 
         with torch.no_grad():
             torch.manual_seed(0)  # log-prob is computed with a random action
@@ -4338,13 +4338,13 @@ class TestIQL(LossModuleTestBase):
         )
 
         default_keys = {
-            "priority_key": "td_error",
-            "log_prob_key": "_log_prob",
-            "action_key": "action",
-            "state_action_value_key": "state_action_value",
-            "value_key": "state_value",
+            "priority": "td_error",
+            "log_prob": "_log_prob",
+            "action": "action",
+            "state_action_value": "state_action_value",
+            "value": "state_value",
         }
-        key_mapping = {"value_key": "value_key"}
+        key_mapping = {"value": "value_key"}
         self.tensordict_keys_test(
             loss_fn,
             default_keys=default_keys,

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -139,575 +139,67 @@ def get_devices():
     return devices
 
 
-class TestLossModuleBase:
-    # tensordict keys and their default values used as input for the correspoinding loss module
-    DEFAULT_KEYS = {
-        PPOLoss: {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "state_value",
-            "sample_log_prob_key": "sample_log_prob",
-            "action_key": "action",
-        },
-        ClipPPOLoss: {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "state_value",
-            "sample_log_prob_key": "sample_log_prob",
-            "action_key": "action",
-        },
-        KLPENPPOLoss: {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "state_value",
-            "sample_log_prob_key": "sample_log_prob",
-            "action_key": "action",
-        },
-        A2CLoss: {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "state_value",
-            "action_key": "action",
-        },
-        ReinforceLoss: {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "state_value",
-            "sample_log_prob_key": "sample_log_prob",
-        },
-        DDPGLoss: {
-            "state_action_value_key": "state_action_value",
-            "priority_key": "td_error",
-        },
-        DQNLoss: {
-            "priority_key": "td_error",
-            "action_value_key": "action_value",
-            "action_key": "action",
-        },
-        DistributionalDQNLoss: {
-            "priority_key": "td_error",
-            "action_value_key": "action_value",
-            "action_key": "action",
-            "reward_key": "reward",
-            "done_key": "done",
-            "steps_to_next_obs_key": "steps_to_next_obs",
-        },
-        SACLoss: {
-            "priority_key": "td_error",
-            "value_key": "state_value",
-            "state_action_value_key": "state_action_value",
-            "action_key": "action",
-            "sample_log_prob_key": "sample_log_prob",
-            "log_prob_key": "_log_prob",
-        },
-        DiscreteSACLoss: {
-            "priority_key": "td_error",
-            "value_key": "state_value",
-            "action_key": "action",
-        },
-        TD3Loss: {
-            "priority_key": "td_error",
-            "state_action_value_key": "state_action_value",
-            "action_key": "action",
-        },
-        IQLLoss: {
-            "priority_key": "td_error",
-            "log_prob_key": "_log_prob",
-            "action_key": "action",
-            "state_action_value_key": "state_action_value",
-            "value_key": "state_value",
-        },
-        REDQLoss: {
-            "priority_key": "td_error",
-            "action_key": "action",
-            "value_key": "state_value",
-            "sample_log_prob_key": "sample_log_prob",
-            "state_action_value_key": "state_action_value",
-        },
-        DreamerModelLoss: {
-            "reward_key": "reward",
-            "true_reward_key": "true_reward",
-            "prior_mean_key": "prior_mean",
-            "prior_std_key": "prior_std",
-            "posterior_mean_key": "posterior_mean",
-            "posterior_std_key": "posterior_std",
-            "pixels_key": "pixels",
-            "reco_pixels_key": "reco_pixels",
-        },
-        DreamerActorLoss: {
-            "belief_key": "belief",
-            "reward_key": "reward",
-            "value_key": "state_value",
-            "done_key": "done",
-        },
-        DreamerValueLoss: {
-            "value_key": "state_value",
-        },
-    }
-    # loss modules which will be tested for setting tensordict keys
-    LOSS_MODULES = DEFAULT_KEYS.keys()
-
-    # deprecated ctor arguments of loss modules
-    DEPRECATED_CTOR_KEYS = {
-        PPOLoss: ["advantage_key", "value_target_key", "value_key"],
-        ClipPPOLoss: ["advantage_key", "value_target_key", "value_key"],
-        KLPENPPOLoss: ["advantage_key", "value_target_key", "value_key"],
-        A2CLoss: ["advantage_key", "value_target_key"],
-        ReinforceLoss: ["advantage_key", "value_target_key"],
-        SACLoss: ["priority_key"],
-        DiscreteSACLoss: ["priority_key"],
-        DQNLoss: ["priority_key"],
-        IQLLoss: ["priority_key"],
-        REDQLoss: ["priority_key"],
-        TD3Loss: ["priority_key"],
-    }
-
-    LOSS_ADVANTAGE_KEY_MAPPING = {
-        PPOLoss: {
-            "advantage_key": "advantage_key",
-            "value_target_key": "value_target_key",
-            "value_key": "value_key",
-        },
-        ClipPPOLoss: {
-            "advantage_key": "advantage_key",
-            "value_target_key": "value_target_key",
-            "value_key": "value_key",
-        },
-        KLPENPPOLoss: {
-            "advantage_key": "advantage_key",
-            "value_target_key": "value_target_key",
-            "value_key": "value_key",
-        },
-        A2CLoss: {
-            "advantage_key": "advantage_key",
-            "value_target_key": "value_target_key",
-            "value_key": "value_key",
-        },
-        DDPGLoss: {"state_action_value_key": "value_key"},
-        DreamerActorLoss: {"value_key": "value_key"},
-        ReinforceLoss: {
-            "advantage_key": "advantage_key",
-            "value_target_key": "value_target_key",
-            "value_key": "value_key",
-        },
-        SACLoss: {"value_key": "value_key"},
-        DiscreteSACLoss: {"value_key": "value_key"},
-        IQLLoss: {"value_key": "value_key"},
-        REDQLoss: {"value_key": "value_key"},
-    }
-
-    def _create_mock_actor(
-        self, action_spec_type="bounded", batch=2, obs_dim=3, action_dim=4
+class LossModuleTestBase:
+    def tensordict_keys_test(
+        self, loss_fn, default_keys, loss_advantage_key_mapping=None
     ):
-        if action_spec_type == "bounded":
-            action_spec = BoundedTensorSpec(
-                -torch.ones(action_dim), torch.ones(action_dim), (action_dim,)
+        self.tensordict_keys_unknown_key_test(loss_fn)
+        self.tensordict_keys_default_values_test(loss_fn, default_keys)
+        self.tensordict_set_keys_test(loss_fn, default_keys)
+        if loss_advantage_key_mapping is not None:
+            self.set_advantage_keys_through_loss_test(
+                loss_fn, loss_advantage_key_mapping
             )
-        elif action_spec_type == "one_hot":
-            action_spec = OneHotDiscreteTensorSpec(action_dim)
 
-        net = NormalParamWrapper(nn.Linear(obs_dim, 2 * action_dim))
-        module = SafeModule(net, in_keys=["observation"], out_keys=["loc", "scale"])
-        actor = ProbabilisticActor(
-            module=module,
-            distribution_class=TanhNormal,
-            in_keys=["loc", "scale"],
-            spec=action_spec,
-        )
-        return actor
-
-    def _create_mock_qv_actor(
-        self,
-        action_spec_type="one_hot",
-        batch=2,
-        obs_dim=3,
-        action_dim=4,
-        is_nn_module=False,
-    ):
-        # Actor
-        if action_spec_type == "one_hot":
-            action_spec = OneHotDiscreteTensorSpec(action_dim)
-        elif action_spec_type == "categorical":
-            action_spec = DiscreteTensorSpec(action_dim)
-        else:
-            raise ValueError(f"Wrong {action_spec_type}")
-
-        module = nn.Linear(obs_dim, action_dim)
-        if is_nn_module:
-            return module
-        actor = QValueActor(
-            spec=CompositeSpec(
-                action=action_spec,
-                action_value=None,
-                chosen_action_value=None,
-                shape=[],
-            ),
-            action_space=action_spec_type,
-            module=module,
-        )
-        return actor
-
-    def _create_mock_value(self, batch=2, obs_dim=3, action_dim=4, out_keys=None):
-        module = nn.Linear(obs_dim, 1)
-        value = ValueOperator(
-            module=module,
-            in_keys=["observation"],
-            out_keys=out_keys,
-        )
-        return value
-
-    def _create_mock_value_w_action(
-        self, batch=2, obs_dim=3, action_dim=4, device="cpu"
-    ):
-        # Actor
-        class ValueClass(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.linear = nn.Linear(obs_dim + action_dim, 1)
-
-            def forward(self, obs, act):
-                return self.linear(torch.cat([obs, act], -1))
-
-        module = ValueClass()
-        value = ValueOperator(
-            module=module,
-            in_keys=["observation", "action"],
-        )
-        return value.to(device)
-
-    def _create_mock_qvalue(self, batch=2, obs_dim=3, action_dim=4):
-        class ValueClass(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.linear = nn.Linear(obs_dim + action_dim, 1)
-
-            def forward(self, obs, act):
-                return self.linear(torch.cat([obs, act], -1))
-
-        module = ValueClass()
-        qvalue = ValueOperator(
-            module=module,
-            in_keys=["observation", "action"],
-        )
-        return qvalue
-
-    def _create_mb_env(self, rssm_hidden_dim, state_dim, mlp_num_units=200):
-        mock_env = TransformedEnv(ContinuousActionConvMockEnv(pixel_shape=[3, 64, 64]))
-        default_dict = {
-            "state": UnboundedContinuousTensorSpec(state_dim),
-            "belief": UnboundedContinuousTensorSpec(rssm_hidden_dim),
-        }
-        mock_env.append_transform(
-            TensorDictPrimer(random=False, default_value=0, **default_dict)
-        )
-
-        rssm_prior = RSSMPrior(
-            hidden_dim=rssm_hidden_dim,
-            rnn_hidden_dim=rssm_hidden_dim,
-            state_dim=state_dim,
-            action_spec=mock_env.action_spec,
-        )
-        reward_module = MLP(
-            out_features=1, depth=2, num_cells=mlp_num_units, activation_class=nn.ELU
-        )
-        transition_model = SafeSequential(
-            SafeModule(
-                rssm_prior,
-                in_keys=["state", "belief", "action"],
-                out_keys=[
-                    "_",
-                    "_",
-                    "state",
-                    "belief",
-                ],
-            ),
-        )
-        reward_model = SafeModule(
-            reward_module,
-            in_keys=["state", "belief"],
-            out_keys=["reward"],
-        )
-        model_based_env = DreamerEnv(
-            world_model=WorldModelWrapper(
-                transition_model,
-                reward_model,
-            ),
-            prior_shape=torch.Size([state_dim]),
-            belief_shape=torch.Size([rssm_hidden_dim]),
-        )
-        model_based_env.set_specs_from_env(mock_env)
-        with torch.no_grad():
-            model_based_env.rollout(3)
-        return model_based_env
-
-    def _create_actor_model(self, rssm_hidden_dim, state_dim, mlp_num_units=200):
-        mock_env = TransformedEnv(ContinuousActionConvMockEnv(pixel_shape=[3, 64, 64]))
-        default_dict = {
-            "state": UnboundedContinuousTensorSpec(state_dim),
-            "belief": UnboundedContinuousTensorSpec(rssm_hidden_dim),
-        }
-        mock_env.append_transform(
-            TensorDictPrimer(random=False, default_value=0, **default_dict)
-        )
-
-        actor_module = DreamerActor(
-            out_features=mock_env.action_spec.shape[0],
-            depth=4,
-            num_cells=mlp_num_units,
-            activation_class=nn.ELU,
-        )
-        actor_model = SafeProbabilisticTensorDictSequential(
-            SafeModule(
-                actor_module,
-                in_keys=["state", "belief"],
-                out_keys=["loc", "scale"],
-            ),
-            SafeProbabilisticModule(
-                in_keys=["loc", "scale"],
-                out_keys="action",
-                default_interaction_type=InteractionType.RANDOM,
-                distribution_class=TanhNormal,
-            ),
-        )
-        with torch.no_grad():
-            td = TensorDict(
-                {
-                    "state": torch.randn(1, 2, state_dim),
-                    "belief": torch.randn(1, 2, rssm_hidden_dim),
-                },
-                batch_size=[1],
-            )
-            actor_model(td)
-        return actor_model
-
-    def _create_value_model(self, rssm_hidden_dim, state_dim, mlp_num_units=200):
-        value_model = SafeModule(
-            MLP(
-                out_features=1,
-                depth=3,
-                num_cells=mlp_num_units,
-                activation_class=nn.ELU,
-            ),
-            in_keys=["state", "belief"],
-            out_keys=["state_value"],
-        )
-        with torch.no_grad():
-            td = TensorDict(
-                {
-                    "state": torch.randn(1, 2, state_dim),
-                    "belief": torch.randn(1, 2, rssm_hidden_dim),
-                },
-                batch_size=[1],
-            )
-            value_model(td)
-        return value_model
-
-    def _create_world_model_model(self, rssm_hidden_dim, state_dim, mlp_num_units=200):
-        mock_env = TransformedEnv(ContinuousActionConvMockEnv(pixel_shape=[3, 64, 64]))
-        default_dict = {
-            "state": UnboundedContinuousTensorSpec(state_dim),
-            "belief": UnboundedContinuousTensorSpec(rssm_hidden_dim),
-        }
-        mock_env.append_transform(
-            TensorDictPrimer(random=False, default_value=0, **default_dict)
-        )
-
-        obs_encoder = ObsEncoder()
-        obs_decoder = ObsDecoder()
-
-        rssm_prior = RSSMPrior(
-            hidden_dim=rssm_hidden_dim,
-            rnn_hidden_dim=rssm_hidden_dim,
-            state_dim=state_dim,
-            action_spec=mock_env.action_spec,
-        )
-        rssm_posterior = RSSMPosterior(hidden_dim=rssm_hidden_dim, state_dim=state_dim)
-
-        # World Model and reward model
-        rssm_rollout = RSSMRollout(
-            SafeModule(
-                rssm_prior,
-                in_keys=["state", "belief", "action"],
-                out_keys=[
-                    ("next", "prior_mean"),
-                    ("next", "prior_std"),
-                    "_",
-                    ("next", "belief"),
-                ],
-            ),
-            SafeModule(
-                rssm_posterior,
-                in_keys=[("next", "belief"), ("next", "encoded_latents")],
-                out_keys=[
-                    ("next", "posterior_mean"),
-                    ("next", "posterior_std"),
-                    ("next", "state"),
-                ],
-            ),
-        )
-        reward_module = MLP(
-            out_features=1, depth=2, num_cells=mlp_num_units, activation_class=nn.ELU
-        )
-        # World Model and reward model
-        world_modeler = SafeSequential(
-            SafeModule(
-                obs_encoder,
-                in_keys=[("next", "pixels")],
-                out_keys=[("next", "encoded_latents")],
-            ),
-            rssm_rollout,
-            SafeModule(
-                obs_decoder,
-                in_keys=[("next", "state"), ("next", "belief")],
-                out_keys=[("next", "reco_pixels")],
-            ),
-        )
-        reward_module = SafeModule(
-            reward_module,
-            in_keys=[("next", "state"), ("next", "belief")],
-            out_keys=[("next", "reward")],
-        )
-        world_model = WorldModelWrapper(world_modeler, reward_module)
-
-        with torch.no_grad():
-            td = mock_env.rollout(10)
-            td = td.unsqueeze(0).to_tensordict()
-            td["state"] = torch.zeros((1, 10, state_dim))
-            td["belief"] = torch.zeros((1, 10, rssm_hidden_dim))
-            world_model(td)
-        return world_model
-
-    def _construct_loss(self, loss_module, **kwargs):
-        print(f"{loss_module = }")
-        if loss_module in [
-            PPOLoss,
-            ClipPPOLoss,
-            KLPENPPOLoss,
-            A2CLoss,
-            TD3Loss,
-            REDQLoss,
-        ]:
-            actor = self._create_mock_actor()
-            value = self._create_mock_value()
-            return loss_module(actor, value, **kwargs)
-        elif loss_module in [DDPGLoss]:
-            actor = self._create_mock_actor()
-            value = self._create_mock_value_w_action()
-            print(f"{value = }")
-            return loss_module(actor, value, **kwargs)
-        elif loss_module in [DQNLoss]:
-            actor = self._create_mock_qv_actor()
-            return loss_module(actor, **kwargs)
-        elif loss_module in [DistributionalDQNLoss]:
-            actor = self._create_mock_qv_actor()
-            return loss_module(actor, gamma=0.9, **kwargs)
-        elif loss_module in [SACLoss, IQLLoss]:
-            actor = self._create_mock_actor()
-            qvalue = self._create_mock_qvalue()
-            value = self._create_mock_value()
-            return loss_module(actor, qvalue, value, **kwargs)
-        elif loss_module in [DiscreteSACLoss]:
-            actor = self._create_mock_actor(action_spec_type="one_hot")
-            qvalue = self._create_mock_qvalue()
-            return loss_module(actor, qvalue, actor.spec["action"].space.n, **kwargs)
-        elif loss_module in [DreamerModelLoss]:
-            world_model = self._create_world_model_model(10, 5)
-            return DreamerModelLoss(world_model)
-        elif loss_module in [DreamerActorLoss]:
-            mb_env = self._create_mb_env(10, 5)
-            actor_model = self._create_actor_model(10, 5)
-            value_model = self._create_value_model(10, 5)
-            return DreamerActorLoss(actor_model, value_model, mb_env)
-        elif loss_module in [DreamerValueLoss]:
-            value_model = self._create_value_model(10, 5)
-            return DreamerValueLoss(value_model)
-        elif loss_module in [ReinforceLoss]:
-            n_obs = 3
-            n_act = 5
-            value_net = ValueOperator(nn.Linear(n_obs, 1), in_keys=["observation"])
-            net = NormalParamWrapper(nn.Linear(n_obs, 2 * n_act))
-            module = SafeModule(net, in_keys=["observation"], out_keys=["loc", "scale"])
-            actor_net = ProbabilisticActor(
-                module,
-                distribution_class=TanhNormal,
-                return_log_prob=True,
-                in_keys=["loc", "scale"],
-                spec=UnboundedContinuousTensorSpec(n_act),
-            )
-            return ReinforceLoss(
-                actor_net,
-                critic=value_net,
-                **kwargs,
-            )
-        else:
-            raise ValueError("Unknown loss module")
-
-    @pytest.mark.parametrize("loss_module", LOSS_MODULES)
-    def test_tensordict_keys_unknown_key(self, loss_module):
+    def tensordict_keys_unknown_key_test(self, loss_fn):
         """Test that exception is raised if an unknown key is set via .set_keys()"""
-        loss_fn = self._construct_loss(loss_module)
+        test_fn = deepcopy(loss_fn)
 
         with pytest.raises(ValueError):
-            loss_fn.set_keys(unknown_key="test2")
+            test_fn.set_keys(unknown_key="test2")
 
-    @pytest.mark.parametrize("loss_module", LOSS_MODULES)
-    def test_tensordict_keys_default_values(self, loss_module):
-        default_keys = self.DEFAULT_KEYS[loss_module]
-        loss_fn = self._construct_loss(loss_module)
+    def tensordict_keys_default_values_test(self, loss_fn, default_keys):
+        test_fn = deepcopy(loss_fn)
 
         for key, value in default_keys.items():
-            assert getattr(loss_fn.tensor_keys, key) == value
+            assert getattr(test_fn.tensor_keys, key) == value
 
-    @pytest.mark.parametrize("loss_module", LOSS_MODULES)
-    def test_tensordict_set_keys(self, loss_module):
+    def tensordict_set_keys_test(self, loss_fn, default_keys):
         """Test setting of tensordict keys via .set_keys()"""
-        default_keys = self.DEFAULT_KEYS[loss_module]
-
-        loss_fn = self._construct_loss(loss_module)
+        test_fn = deepcopy(loss_fn)
 
         new_key = "test1"
         for key, _ in default_keys.items():
-            loss_fn.set_keys(**{key: new_key})
-            assert getattr(loss_fn.tensor_keys, key) == new_key
+            test_fn.set_keys(**{key: new_key})
+            assert getattr(test_fn.tensor_keys, key) == new_key
 
-        loss_fn = self._construct_loss(loss_module)
-        loss_fn.set_keys(**{key: new_key for key, _ in default_keys.items()})
+        test_fn = deepcopy(loss_fn)
+        test_fn.set_keys(**{key: new_key for key, _ in default_keys.items()})
 
         for key, _ in default_keys.items():
-            assert getattr(loss_fn.tensor_keys, key) == new_key
+            assert getattr(test_fn.tensor_keys, key) == new_key
 
-    @pytest.mark.parametrize("loss_module", LOSS_MODULES)
-    def test_tensordict_deprecated_ctor(self, loss_module):
-        """Test that a warning is raised if a deprecated tensordict key is set via the ctor."""
-        try:
-            dep_keys = self.DEPRECATED_CTOR_KEYS[loss_module]
-        except KeyError:
-            return
+    def set_advantage_keys_through_loss_test(self, loss_fn, loss_advantage_key_mapping):
+        test_fn = deepcopy(loss_fn)
 
-        default_keys = self.DEFAULT_KEYS[loss_module]
+        key_mapping = loss_advantage_key_mapping
+        for loss_key, advantage_key in key_mapping.items():
+            test_fn.set_keys(**{loss_key: "test1"})
+            assert getattr(test_fn.value_estimator, advantage_key) == "test1"
 
-        for key in dep_keys:
-            new_key = "test3"
-            with pytest.deprecated_call():
-                loss_fn = self._construct_loss(loss_module, **{key: new_key})
-                assert getattr(loss_fn.tensor_keys, key) == new_key
-
-                for def_key, def_value in default_keys.items():
-                    if def_key != key:
-                        assert getattr(loss_fn.tensor_keys, def_key) == def_value
-
-    @pytest.mark.parametrize("loss_module", LOSS_MODULES)
-    def test_set_keys_advantage(self, loss_module):
-        if loss_module in self.LOSS_ADVANTAGE_KEY_MAPPING:
-            loss_fn = self._construct_loss(loss_module)
-            loss_fn.make_value_estimator()
-            key_mapping = self.LOSS_ADVANTAGE_KEY_MAPPING[loss_module]
-            for loss_key, advantage_key in key_mapping.items():
-                loss_fn.set_keys(**{loss_key: "test1"})
-                assert getattr(loss_fn.value_estimator, advantage_key) == "test1"
+    # TODO test
+    # loss = Loss(...)
+    # loss.set_keys()
+    # loss.make_value_estimator()
+    #
+    # vs
+    #
+    # loss = Loss(...)
+    # loss.make_value_estimator()
+    # loss.set_keys()
 
 
-class TestDQN:
+class TestDQN(LossModuleTestBase):
     seed = 0
 
     def _create_mock_actor(
@@ -978,6 +470,20 @@ class TestDQN:
             p.data += torch.randn_like(p)
         assert all((p1 != p2).all() for p1, p2 in zip(parameters, actor.parameters()))
 
+    def test_dqn_tensordict_keys(self):
+        torch.manual_seed(self.seed)
+        action_spec_type = "one_hot"
+        actor = self._create_mock_actor(action_spec_type=action_spec_type)
+        loss_fn = DQNLoss(actor)
+
+        default_keys = {
+            "priority_key": "td_error",
+            "action_value_key": "action_value",
+            "action_key": "action",
+        }
+
+        self.tensordict_keys_test(loss_fn, default_keys=default_keys)
+
     @pytest.mark.parametrize("atoms", range(4, 10))
     @pytest.mark.parametrize("delay_value", (False, True))
     @pytest.mark.parametrize("device", get_devices())
@@ -1031,8 +537,30 @@ class TestDQN:
             p.data += torch.randn_like(p)
         assert all((p1 != p2).all() for p1, p2 in zip(parameters, actor.parameters()))
 
+    def test_distributional_dqn_tensordict_keys(self):
+        torch.manual_seed(self.seed)
+        action_spec_type = "one_hot"
+        atoms = 2
+        gamma = 0.9
+        actor = self._create_mock_distributional_actor(
+            action_spec_type=action_spec_type, atoms=atoms
+        )
 
-class TestDDPG:
+        loss_fn = DistributionalDQNLoss(actor, gamma=gamma)
+
+        default_keys = {
+            "priority_key": "td_error",
+            "action_value_key": "action_value",
+            "action_key": "action",
+            "reward_key": "reward",
+            "done_key": "done",
+            "steps_to_next_obs_key": "steps_to_next_obs",
+        }
+
+        self.tensordict_keys_test(loss_fn, default_keys=default_keys)
+
+
+class TestDDPG(LossModuleTestBase):
     seed = 0
 
     def _create_mock_actor(self, batch=2, obs_dim=3, action_dim=4, device="cpu"):
@@ -1269,8 +797,32 @@ class TestDDPG:
         for p in parameters:
             assert p.grad.norm() > 0.0
 
+    @pytest.mark.parametrize(
+        "td_est", [ValueEstimators.TD1, ValueEstimators.TD0, ValueEstimators.TDLambda]
+    )
+    def test_ddpg_tensordict_keys(self, td_est):
+        actor = self._create_mock_actor()
+        value = self._create_mock_value()
+        loss_fn = DDPGLoss(
+            actor,
+            value,
+            loss_function="l2",
+        )
 
-class TestTD3:
+        loss_fn.make_value_estimator(td_est)
+
+        default_keys = {
+            "state_action_value_key": "state_action_value",
+            "priority_key": "td_error",
+        }
+        key_mapping = {"state_action_value_key": "value_key"}
+
+        self.tensordict_keys_test(
+            loss_fn, default_keys=default_keys, loss_advantage_key_mapping=key_mapping
+        )
+
+
+class TestTD3(LossModuleTestBase):
     seed = 0
 
     def _create_mock_actor(self, batch=2, obs_dim=3, action_dim=4, device="cpu"):
@@ -1543,9 +1095,33 @@ class TestTD3:
             p.data += torch.randn_like(p)
         assert all((p1 != p2).all() for p1, p2 in zip(parameters, actor.parameters()))
 
+    @pytest.mark.parametrize(
+        "td_est", [ValueEstimators.TD1, ValueEstimators.TD0, ValueEstimators.TDLambda]
+    )
+    def test_td3_tensordict_keys(self, td_est):
+        actor = self._create_mock_actor()
+        value = self._create_mock_value()
+        td = self._create_mock_data_td3()
+        loss_fn = TD3Loss(
+            actor,
+            value,
+        )
+        loss_fn.make_value_estimator(td_est)
+
+        default_keys = {
+            "priority_key": "td_error",
+            "state_action_value_key": "state_action_value",
+            "action_key": "action",
+        }
+        key_mapping = {"state_action_value_key": "value_key"}
+
+        self.tensordict_keys_test(
+            loss_fn, default_keys=default_keys, loss_advantage_key_mapping=key_mapping
+        )
+
 
 @pytest.mark.parametrize("version", [1, 2])
-class TestSAC:
+class TestSAC(LossModuleTestBase):
     seed = 0
 
     def _create_mock_actor(self, batch=2, obs_dim=3, action_dim=4, device="cpu"):
@@ -1958,8 +1534,45 @@ class TestSAC:
             p.data += torch.randn_like(p)
         assert all((p1 != p2).all() for p1, p2 in zip(parameters, actor.parameters()))
 
+    @pytest.mark.parametrize(
+        "td_est", [ValueEstimators.TD1, ValueEstimators.TD0, ValueEstimators.TDLambda]
+    )
+    def test_sac_tensordict_keys(self, td_est, version):
+        td = self._create_mock_data_sac()
 
-class TestDiscreteSAC:
+        actor = self._create_mock_actor()
+        qvalue = self._create_mock_qvalue()
+        if version == 1:
+            value = self._create_mock_value()
+        else:
+            value = None
+
+        loss_fn = SACLoss(
+            actor_network=actor,
+            qvalue_network=qvalue,
+            value_network=value,
+            num_qvalue_nets=2,
+            loss_function="l2",
+        )
+
+        loss_fn.make_value_estimator(td_est)
+
+        default_keys = {
+            "priority_key": "td_error",
+            "value_key": "state_value",
+            "state_action_value_key": "state_action_value",
+            "action_key": "action",
+            "sample_log_prob_key": "sample_log_prob",
+            "log_prob_key": "_log_prob",
+        }
+        key_mapping = {"value_key": "value_key"}
+
+        self.tensordict_keys_test(
+            loss_fn, default_keys=default_keys, loss_advantage_key_mapping=key_mapping
+        )
+
+
+class TestDiscreteSAC(LossModuleTestBase):
     seed = 0
 
     def _create_mock_actor(self, batch=2, obs_dim=3, action_dim=4, device="cpu"):
@@ -2293,11 +1906,37 @@ class TestDiscreteSAC:
             p.data += torch.randn_like(p)
         assert all((p1 != p2).all() for p1, p2 in zip(parameters, actor.parameters()))
 
+    @pytest.mark.parametrize(
+        "td_est", [ValueEstimators.TD1, ValueEstimators.TD0, ValueEstimators.TDLambda]
+    )
+    def test_discrete_sac_tensordict_keys(self, td_est):
+        actor = self._create_mock_actor()
+        qvalue = self._create_mock_qvalue()
+
+        loss_fn = DiscreteSACLoss(
+            actor_network=actor,
+            qvalue_network=qvalue,
+            num_actions=actor.spec["action"].space.n,
+            loss_function="l2",
+        )
+
+        loss_fn.make_value_estimator(td_est)
+
+        default_keys = {
+            "priority_key": "td_error",
+            "value_key": "state_value",
+            "action_key": "action",
+        }
+        key_mapping = {"value_key": "value_key"}
+        self.tensordict_keys_test(
+            loss_fn, default_keys=default_keys, loss_advantage_key_mapping=key_mapping
+        )
+
 
 @pytest.mark.skipif(
     not _has_functorch, reason=f"functorch not installed: {FUNCTORCH_ERR}"
 )
-class TestREDQ:
+class TestREDQ(LossModuleTestBase):
     seed = 0
 
     def _create_mock_actor(self, batch=2, obs_dim=3, action_dim=4, device="cpu"):
@@ -2767,8 +2406,34 @@ class TestREDQ:
             p.data += torch.randn_like(p)
         assert all((p1 != p2).all() for p1, p2 in zip(parameters, actor.parameters()))
 
+    @pytest.mark.parametrize(
+        "td_est", [ValueEstimators.TD1, ValueEstimators.TD0, ValueEstimators.TDLambda]
+    )
+    def test_redq_tensordict_keys(self, td_est):
+        actor = self._create_mock_actor()
+        qvalue = self._create_mock_qvalue()
 
-class TestPPO:
+        loss_fn = REDQLoss(
+            actor_network=actor,
+            qvalue_network=qvalue,
+            loss_function="l2",
+        )
+        loss_fn.make_value_estimator(td_est)
+
+        default_keys = {
+            "priority_key": "td_error",
+            "action_key": "action",
+            "value_key": "state_value",
+            "sample_log_prob_key": "sample_log_prob",
+            "state_action_value_key": "state_action_value",
+        }
+        key_mapping = {"value_key": "value_key"}
+        self.tensordict_keys_test(
+            loss_fn, default_keys=default_keys, loss_advantage_key_mapping=key_mapping
+        )
+
+
+class TestPPO(LossModuleTestBase):
     seed = 0
 
     def _create_mock_actor(self, batch=2, obs_dim=3, action_dim=4, device="cpu"):
@@ -3209,6 +2874,39 @@ class TestPPO:
             param.grad = None
 
     @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
+    @pytest.mark.parametrize(
+        "td_est",
+        [
+            ValueEstimators.TD1,
+            ValueEstimators.TD0,
+            ValueEstimators.GAE,
+            ValueEstimators.TDLambda,
+        ],
+    )
+    def test_ppo_tensordict_keys(self, loss_class, td_est):
+        actor = self._create_mock_actor()
+        value = self._create_mock_value()
+
+        loss_fn = loss_class(actor, value, loss_critic_type="l2")
+        loss_fn.make_value_estimator(td_est)
+
+        default_keys = {
+            "advantage_key": "advantage",
+            "value_target_key": "value_target",
+            "value_key": "state_value",
+            "sample_log_prob_key": "sample_log_prob",
+            "action_key": "action",
+        }
+        key_mapping = {
+            "advantage_key": "advantage_key",
+            "value_target_key": "value_target_key",
+            "value_key": "value_key",
+        }
+        self.tensordict_keys_test(
+            loss_fn, default_keys=default_keys, loss_advantage_key_mapping=key_mapping
+        )
+
+    @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
     @pytest.mark.parametrize("device", get_available_devices())
     def test_ppo_tensordict_keys_run(self, loss_class, device):
         """Test PPO loss module with non-default rensordict keys."""
@@ -3282,7 +2980,7 @@ class TestPPO:
         actor.zero_grad()
 
 
-class TestA2C:
+class TestA2C(LossModuleTestBase):
     seed = 0
 
     def _create_mock_actor(self, batch=2, obs_dim=3, action_dim=4, device="cpu"):
@@ -3495,6 +3193,37 @@ class TestA2C:
         for param in params:
             param.grad = None
 
+    @pytest.mark.parametrize(
+        "td_est",
+        [
+            ValueEstimators.TD1,
+            ValueEstimators.TD0,
+            ValueEstimators.GAE,
+            ValueEstimators.TDLambda,
+        ],
+    )
+    def test_a2c_tensordict_keys(self, td_est):
+        actor = self._create_mock_actor()
+        value = self._create_mock_value()
+
+        loss_fn = A2CLoss(actor, value, loss_critic_type="l2")
+        loss_fn.make_value_estimator(td_est)
+
+        default_keys = {
+            "advantage_key": "advantage",
+            "value_target_key": "value_target",
+            "value_key": "state_value",
+            "action_key": "action",
+        }
+        key_mapping = {
+            "advantage_key": "advantage_key",
+            "value_target_key": "value_target_key",
+            "value_key": "value_key",
+        }
+        self.tensordict_keys_test(
+            loss_fn, default_keys=default_keys, loss_advantage_key_mapping=key_mapping
+        )
+
     @pytest.mark.parametrize("device", get_available_devices())
     def test_a2c_tensordict_keys_run(self, device):
         """Test A2C loss module with non-default tensordict keys."""
@@ -3558,7 +3287,7 @@ class TestA2C:
         loss_fn.reset()
 
 
-class TestReinforce:
+class TestReinforce(LossModuleTestBase):
     @pytest.mark.parametrize("delay_value", [True, False])
     @pytest.mark.parametrize("gradient_mode", [True, False])
     @pytest.mark.parametrize("advantage", ["gae", "td", "td_lambda", None])
@@ -3653,9 +3382,53 @@ class TestReinforce:
                 allow_unused=False,
             )
 
+    @pytest.mark.parametrize(
+        "td_est",
+        [
+            ValueEstimators.TD1,
+            ValueEstimators.TD0,
+            ValueEstimators.GAE,
+            ValueEstimators.TDLambda,
+        ],
+    )
+    def test_reinforce_tensordict_keys(self, td_est):
+        n_obs = 3
+        n_act = 5
+        value_net = ValueOperator(nn.Linear(n_obs, 1), in_keys=["observation"])
+        net = NormalParamWrapper(nn.Linear(n_obs, 2 * n_act))
+        module = SafeModule(net, in_keys=["observation"], out_keys=["loc", "scale"])
+        actor_net = ProbabilisticActor(
+            module,
+            distribution_class=TanhNormal,
+            return_log_prob=True,
+            in_keys=["loc", "scale"],
+            spec=UnboundedContinuousTensorSpec(n_act),
+        )
+
+        loss_fn = ReinforceLoss(
+            actor_net,
+            critic=value_net,
+        )
+        loss_fn.make_value_estimator(td_est)
+
+        default_keys = {
+            "advantage_key": "advantage",
+            "value_target_key": "value_target",
+            "value_key": "state_value",
+            "sample_log_prob_key": "sample_log_prob",
+        }
+        key_mapping = {
+            "advantage_key": "advantage_key",
+            "value_target_key": "value_target_key",
+            "value_key": "value_key",
+        }
+        self.tensordict_keys_test(
+            loss_fn, default_keys=default_keys, loss_advantage_key_mapping=key_mapping
+        )
+
 
 @pytest.mark.parametrize("device", get_available_devices())
-class TestDreamer:
+class TestDreamer(LossModuleTestBase):
     def _create_world_model_data(
         self, batch_size, temporal_length, rssm_hidden_dim, state_dim
     ):
@@ -4050,8 +3823,58 @@ class TestDreamer:
             raise ValueError("Gradients are zero")
         loss_module.zero_grad()
 
+    def test_dreamer_model_tensordict_keys(self, device):
+        world_model = self._create_world_model_model(10, 5)
+        loss_fn = DreamerModelLoss(world_model)
 
-class TestIQL:
+        default_keys = {
+            "reward_key": "reward",
+            "true_reward_key": "true_reward",
+            "prior_mean_key": "prior_mean",
+            "prior_std_key": "prior_std",
+            "posterior_mean_key": "posterior_mean",
+            "posterior_std_key": "posterior_std",
+            "pixels_key": "pixels",
+            "reco_pixels_key": "reco_pixels",
+        }
+        self.tensordict_keys_test(loss_fn, default_keys=default_keys)
+
+    @pytest.mark.parametrize(
+        "td_est", [ValueEstimators.TD1, ValueEstimators.TD0, ValueEstimators.TDLambda]
+    )
+    def test_dreamer_actor_tensordict_keys(self, td_est, device):
+        mb_env = self._create_mb_env(10, 5)
+        actor_model = self._create_actor_model(10, 5)
+        value_model = self._create_value_model(10, 5)
+        loss_fn = DreamerActorLoss(
+            actor_model,
+            value_model,
+            mb_env,
+        )
+        loss_fn.make_value_estimator(td_est)
+
+        default_keys = {
+            "belief_key": "belief",
+            "reward_key": "reward",
+            "value_key": "state_value",
+            "done_key": "done",
+        }
+        key_mapping = {"value_key": "value_key"}
+        self.tensordict_keys_test(
+            loss_fn, default_keys=default_keys, loss_advantage_key_mapping=key_mapping
+        )
+
+    def test_dreamer_value_tensordict_keys(self, device):
+        value_model = self._create_value_model(10, 5)
+        loss_fn = DreamerValueLoss(value_model)
+
+        default_keys = {
+            "value_key": "state_value",
+        }
+        self.tensordict_keys_test(loss_fn, default_keys=default_keys)
+
+
+class TestIQL(LossModuleTestBase):
     seed = 0
 
     def _create_mock_actor(self, batch=2, obs_dim=3, action_dim=4, device="cpu"):
@@ -4370,6 +4193,34 @@ class TestIQL:
         for p in loss_fn.parameters():
             p.data += torch.randn_like(p)
         assert all((p1 != p2).all() for p1, p2 in zip(parameters, actor.parameters()))
+
+    @pytest.mark.parametrize(
+        "td_est", [ValueEstimators.TD1, ValueEstimators.TD0, ValueEstimators.TDLambda]
+    )
+    def test_iql_tensordict_keys(self, td_est):
+        actor = self._create_mock_actor()
+        qvalue = self._create_mock_qvalue()
+        value = self._create_mock_value()
+
+        loss_fn = IQLLoss(
+            actor_network=actor,
+            qvalue_network=qvalue,
+            value_network=value,
+            loss_function="l2",
+        )
+        loss_fn.make_value_estimator(td_est)
+
+        default_keys = {
+            "priority_key": "td_error",
+            "log_prob_key": "_log_prob",
+            "action_key": "action",
+            "state_action_value_key": "state_action_value",
+            "value_key": "state_value",
+        }
+        key_mapping = {"value_key": "value_key"}
+        self.tensordict_keys_test(
+            loss_fn, default_keys=default_keys, loss_advantage_key_mapping=key_mapping
+        )
 
 
 def test_hold_out():

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -644,7 +644,7 @@ class TestLossModuleBase:
         tested_keys = set(self.DEFAULT_KEYS[loss_module].keys())
 
         loss_fn = self._construct_loss(loss_module)
-        avail_keys = set(loss_fn.tensordict_keys.keys())
+        avail_keys = set(loss_fn.default_tensordict_keys().keys())
         assert avail_keys.difference(tested_keys) == set()
 
 
@@ -4394,6 +4394,10 @@ def test_updater(mode, value_network_update_interval, device, dtype):
                 else:
                     target.data += 10
 
+        @staticmethod
+        def default_tensordict_keys():
+            return {}
+
     module = custom_module().to(device).to(dtype)
     _ = module.module1_params
     _ = module.target_module1_params
@@ -5611,6 +5615,10 @@ def test_shared_params(dest, expected_dtype, expected_device):
                 compare_against=list(actor_network.parameters()),
             )
 
+        @staticmethod
+        def default_tensordict_keys():
+            return {}
+
     actor_network = td_module.get_policy_operator()
     value_network = td_module.get_value_operator()
 
@@ -5848,6 +5856,10 @@ class TestBase:
                     compare_against=module_a.parameters() if compare_against else [],
                     expand_dim=expand_dim,
                 )
+
+            @staticmethod
+            def default_tensordict_keys():
+                return {}
 
         loss_module = MyLoss(compare_against=compare_against, expand_dim=expand_dim)
 

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -143,9 +143,9 @@ class A2CLoss(LossModule):
         self, tensordict: TensorDictBase
     ) -> Tuple[torch.Tensor, d.Distribution]:
         # current log_prob of actions
-        action = tensordict.get("action")
+        action = tensordict.get(self.action_key)
         if action.requires_grad:
-            raise RuntimeError("tensordict stored action require grad.")
+            raise RuntimeError(f"tensordict stored {self.action_key} require grad.")
         tensordict_clone = tensordict.select(*self.actor.in_keys).clone()
 
         dist = self.actor.get_dist(tensordict_clone, params=self.actor_params)

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -53,7 +53,7 @@ class A2CLoss(LossModule):
             parameters for both policy and critic losses.
         advantage_key (str): [Deprecated, use set_keys(advantage_key=advantage_key) instead]
             The input tensordict key where the advantage is expected to be written.  default: "advantage"
-            value_target_key (str): [Deprecated, use set_keys() instead] the input
+        value_target_key (str): [Deprecated, use set_keys() instead] the input
             tensordict key where the target state value is expected to be written. Defaults to ``"value_target"``.
 
     .. note:
@@ -109,7 +109,6 @@ class A2CLoss(LossModule):
         else:
             policy_params = None
         self.convert_to_functional(critic, "critic", compare_against=policy_params)
-
         self.samples_mc_entropy = samples_mc_entropy
         self.entropy_bonus = entropy_bonus and entropy_coef
         self.register_buffer(

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -96,25 +96,16 @@ class A2CLoss(LossModule):
             policy_params = None
         self.convert_to_functional(critic, "critic", compare_against=policy_params)
 
-        self.tensordict_keys = {
+        tensordict_keys = {
             "advantage_key": "advantage",
             "value_target_key": "value_target",
             "value_key": "state_value",
             "action_key": "action",
         }
-        if advantage_key is not None:
-            warnings.warn(
-                "Setting 'advantage_key' via ctor is deprecated, use .set_keys(advantage_key='some_key') instead.",
-                category=DeprecationWarning,
-            )
-            self.tensordict_keys["advantage_key"] = advantage_key
-        if value_target_key is not None:
-            warnings.warn(
-                "Setting 'value_target_key' via ctor is deprecated, use .set_keys(value_target_key='some_key') instead.",
-                category=DeprecationWarning,
-            )
-            self.tensordict_keys["value_target_key"] = value_target_key
-        self.set_keys(**self.tensordict_keys)
+        self._set_default_tensordict_keys(tensordict_keys)
+        self._set_deprecated_ctor_keys(
+            advantage_key=advantage_key, value_target_key=value_target_key
+        )
 
         self.samples_mc_entropy = samples_mc_entropy
         self.entropy_bonus = entropy_bonus and entropy_coef

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -78,16 +78,13 @@ class A2CLoss(LossModule):
 
         Attributes:
             advantage (NestedKey): The input tensordict key where the advantage is expected.
-            Will be used for the underlying value estimator. Defaults to ``"advantage"``.
-        value_target : NestedKey
-            The input tensordict key where the target state value is expected.
-            Will be used for the underlying value estimator Defaults to ``"value_target"``.
-        value : NestedKey
-            The input tensordict key where the state value is expected.
-            Will be used for the underlying value estimator. Defaults to ``"state_value"``.
-        action : NestedKey
-            The input tensordict key where the action is expected.
-            Defaults to ``"state_value"``.
+                Will be used for the underlying value estimator. Defaults to ``"advantage"``.
+            value_target (NestedKey): The input tensordict key where the target state value is expected.
+                Will be used for the underlying value estimator Defaults to ``"value_target"``.
+            value (NestedKey): The input tensordict key where the state value is expected.
+                Will be used for the underlying value estimator. Defaults to ``"state_value"``.
+            action (NestedKey): The input tensordict key where the action is expected.
+                Defaults to ``"action"``.
         """
 
         advantage: NestedKey = "advantage"

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -49,10 +49,10 @@ class A2CLoss(LossModule):
             policy and critic will only be trained on the policy loss.
             Defaults to ``False``, ie. gradients are propagated to shared
             parameters for both policy and critic losses.
-        advantage_key (str): [Deprecated, use set_keys() instead] the input tensordict key where the advantage is expected to be written.
-            default: "advantage"
-        value_target_key (str): [Deprecated, use set_keys() instead] the input tensordict key where the target state
-            value is expected to be written. Defaults to ``"value_target"``.
+        advantage_key (str): [Deprecated, use set_keys() instead] the input
+        tensordict key where the advantage is expected to be written.  default: "advantage"
+            value_target_key (str): [Deprecated, use set_keys() instead] the input
+            tensordict key where the target state value is expected to be written. Defaults to ``"value_target"``.
 
     .. note:
       The advantage (typically GAE) can be computed by the loss function or

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -71,10 +71,10 @@ class A2CLoss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and the corresponding default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values.
 
         Attributes:
         ------------

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -74,7 +74,7 @@ class A2CLoss(LossModule):
         """Stores default values for all configurable tensordict keys.
 
         This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and their default values.
+        via `.set_keys(key_name=key_value) and the corresponding default values.
 
         Attributes:
         ------------

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -86,6 +86,7 @@ class A2CLoss(LossModule):
     ):
         super().__init__()
 
+        self.set_keys()
         self._set_deprecated_ctor_keys(
             advantage_key=advantage_key, value_target_key=value_target_key
         )
@@ -114,14 +115,22 @@ class A2CLoss(LossModule):
             self.gamma = gamma
         self.loss_critic_type = loss_critic_type
 
-    @staticmethod
-    def default_loss_keys():
-        return {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "state_value",
-            "action_key": "action",
-        }
+    def set_keys(
+        self,
+        advantage_key="advantage",
+        value_target_key="value_target",
+        value_key="state_value",
+        action_key="action",
+    ):
+        self.advantage_key = advantage_key
+        self.value_target_key = value_target_key
+        self.value_key = value_key
+        self.action_key = action_key
+
+        if self._value_estimator is not None:
+            self._value_estimator.set_keys(
+                value_key=value_key,
+            )
 
     def reset(self) -> None:
         pass
@@ -138,11 +147,9 @@ class A2CLoss(LossModule):
         self, tensordict: TensorDictBase
     ) -> Tuple[torch.Tensor, d.Distribution]:
         # current log_prob of actions
-        action = tensordict.get(self.loss_key("action_key"))
+        action = tensordict.get(self.action_key)
         if action.requires_grad:
-            raise RuntimeError(
-                f"tensordict stored {self.loss_key('action_key')} require grad."
-            )
+            raise RuntimeError(f"tensordict stored {self.action_key} require grad.")
         tensordict_clone = tensordict.select(*self.actor.in_keys).clone()
 
         dist = self.actor.get_dist(tensordict_clone, params=self.actor_params)
@@ -154,12 +161,12 @@ class A2CLoss(LossModule):
         try:
             # TODO: if the advantage is gathered by forward, this introduces an
             # overhead that we could easily reduce.
-            target_return = tensordict.get(self.loss_key("value_target_key"))
+            target_return = tensordict.get(self.value_target_key)
             tensordict_select = tensordict.select(*self.critic.in_keys)
             state_value = self.critic(
                 tensordict_select,
                 params=self.critic_params,
-            ).get(self.loss_key("value_key"))
+            ).get(self.value_key)
             loss_value = distance_loss(
                 target_return,
                 state_value,
@@ -167,7 +174,7 @@ class A2CLoss(LossModule):
             )
         except KeyError:
             raise KeyError(
-                f"the key {self.loss_key('value_target_key')} was not found in the input tensordict. "
+                f"the key {self.value_target_key} was not found in the input tensordict. "
                 f"Make sure you provided the right key and the value_target (i.e. the target "
                 f"return) has been retrieved accordingly. Advantage classes such as GAE, "
                 f"TDLambdaEstimate and TDEstimate all return a 'value_target' entry that "
@@ -177,14 +184,14 @@ class A2CLoss(LossModule):
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         tensordict = tensordict.clone(False)
-        advantage = tensordict.get(self.loss_key("advantage_key"), None)
+        advantage = tensordict.get(self.advantage_key, None)
         if advantage is None:
             self.value_estimator(
                 tensordict,
                 params=self.critic_params.detach(),
                 target_params=self.target_critic_params,
             )
-            advantage = tensordict.get(self.loss_key("advantage_key"))
+            advantage = tensordict.get(self.advantage_key)
         log_probs, dist = self._log_probs(tensordict)
         loss = -(log_probs * advantage)
         td_out = TensorDict({"loss_objective": loss.mean()}, [])
@@ -205,7 +212,7 @@ class A2CLoss(LossModule):
         hp.update(hyperparams)
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
-        value_key = self.loss_key("value_key")
+        value_key = self.value_key
         if value_type == ValueEstimators.TD1:
             self._value_estimator = TD1Estimator(
                 value_network=self.critic, value_key=value_key, **hp

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -71,6 +71,27 @@ class A2CLoss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
+        """Stores default values for all configurable tensordict keys.
+
+        This class is used to define and store which tensordict keys are configurable
+        via `.set_keys(key_name=key_value) and their default values.
+
+        Attributes:
+        ------------
+        advantage : NestedKey
+            The input tensordict key where the advantage is expected.
+            Will be used for the underlying value estimator. Defaults to ``"advantage"``.
+        value_target : NestedKey
+            The input tensordict key where the target state value is expected.
+            Will be used for the underlying value estimator Defaults to ``"value_target"``.
+        value : NestedKey
+            The input tensordict key where the state value is expected.
+            Will be used for the underlying value estimator. Defaults to ``"state_value"``.
+        action : NestedKey
+            The input tensordict key where the action is expected.
+            Defaults to ``"state_value"``.
+        """
+
         advantage: NestedKey = "advantage"
         value_target: NestedKey = "value_target"
         value: NestedKey = "state_value"

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -86,13 +86,6 @@ class A2CLoss(LossModule):
     ):
         super().__init__()
 
-        tensordict_keys = {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "state_value",
-            "action_key": "action",
-        }
-        self._set_default_tensordict_keys(tensordict_keys)
         self._set_deprecated_ctor_keys(
             advantage_key=advantage_key, value_target_key=value_target_key
         )
@@ -120,6 +113,15 @@ class A2CLoss(LossModule):
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
         self.loss_critic_type = loss_critic_type
+
+    @staticmethod
+    def default_tensordict_keys():
+        return {
+            "advantage_key": "advantage",
+            "value_target_key": "value_target",
+            "value_key": "state_value",
+            "action_key": "action",
+        }
 
     def reset(self) -> None:
         pass

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -79,11 +79,6 @@ class A2CLoss(LossModule):
     default_keys = _AcceptedKeys()
     default_value_estimator: ValueEstimators = ValueEstimators.GAE
 
-    @classmethod
-    def __new__(cls, *args, **kwargs):
-        cls._tensor_keys = cls._AcceptedKeys()
-        return super().__new__(cls)
-
     def __init__(
         self,
         actor: ProbabilisticTensorDictSequential,
@@ -128,17 +123,7 @@ class A2CLoss(LossModule):
             self.gamma = gamma
         self.loss_critic_type = loss_critic_type
 
-    @property
-    def tensor_keys(self) -> _AcceptedKeys:
-        return self._tensor_keys
-
-    def set_keys(self, **kwargs) -> None:
-        """TODO"""
-        for key, _ in kwargs.items():
-            if key not in self._AcceptedKeys.__dict__:
-                raise ValueError(f"{key} it not an accepted tensordict key")
-        self._tensor_keys = self._AcceptedKeys(**kwargs)
-
+    def _forward_value_estimator_keys(self, **kwargs) -> None:
         if self._value_estimator is not None:
             self._value_estimator.set_keys(
                 advantage_key=self._tensor_keys.advantage_key,

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -77,9 +77,7 @@ class A2CLoss(LossModule):
         default values.
 
         Attributes:
-        ------------
-        advantage : NestedKey
-            The input tensordict key where the advantage is expected.
+            advantage (NestedKey): The input tensordict key where the advantage is expected.
             Will be used for the underlying value estimator. Defaults to ``"advantage"``.
         value_target : NestedKey
             The input tensordict key where the target state value is expected.

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -213,19 +213,26 @@ class A2CLoss(LossModule):
         hp.update(hyperparams)
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
-        ve_args = {
-            "value_network": self.critic,
+        tensor_keys = {
             "advantage_key": self.tensor_keys.advantage_key,
             "value_key": self.tensor_keys.value_key,
             "value_target_key": self.tensor_keys.value_target_key,
         }
         if value_type == ValueEstimators.TD1:
-            self._value_estimator = TD1Estimator(**ve_args, **hp)
+            self._value_estimator = TD1Estimator(
+                value_network=self.critic, tensor_keys=tensor_keys, **hp
+            )
         elif value_type == ValueEstimators.TD0:
-            self._value_estimator = TD0Estimator(**ve_args, **hp)
+            self._value_estimator = TD0Estimator(
+                value_network=self.critic, tensor_keys=tensor_keys, **hp
+            )
         elif value_type == ValueEstimators.GAE:
-            self._value_estimator = GAE(**ve_args, **hp)
+            self._value_estimator = GAE(
+                value_network=self.critic, tensor_keys=tensor_keys, **hp
+            )
         elif value_type == ValueEstimators.TDLambda:
-            self._value_estimator = TDLambdaEstimator(**ve_args, **hp)
+            self._value_estimator = TDLambdaEstimator(
+                value_network=self.critic, tensor_keys=tensor_keys, **hp
+            )
         else:
             raise NotImplementedError(f"Unknown value type {value_type}")

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -99,6 +99,7 @@ class A2CLoss(LossModule):
         self.tensordict_keys = {
             "advantage_key": "advantage",
             "value_target_key": "value_target",
+            "value_key": "state_value",
             "action_key": "action",
         }
         if advantage_key is not None:
@@ -162,7 +163,7 @@ class A2CLoss(LossModule):
             state_value = self.critic(
                 tensordict_select,
                 params=self.critic_params,
-            ).get("state_value")
+            ).get(self.value_key)
             loss_value = distance_loss(
                 target_return,
                 state_value,

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -49,8 +49,8 @@ class A2CLoss(LossModule):
             policy and critic will only be trained on the policy loss.
             Defaults to ``False``, ie. gradients are propagated to shared
             parameters for both policy and critic losses.
-        advantage_key (str): [Deprecated, use set_keys() instead] the input
-        tensordict key where the advantage is expected to be written.  default: "advantage"
+        advantage_key (str): [Deprecated, use set_keys(advantage_key=advantage_key) instead]
+            The input tensordict key where the advantage is expected to be written.  default: "advantage"
             value_target_key (str): [Deprecated, use set_keys() instead] the input
             tensordict key where the target state value is expected to be written. Defaults to ``"value_target"``.
 

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -63,10 +63,10 @@ class LossModule(nn.Module, ABC):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and their default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values.
         """
 
         pass
@@ -93,11 +93,11 @@ class LossModule(nn.Module, ABC):
 
     @abstractmethod
     def _forward_value_estimator_keys(self, **kwargs) -> None:
-        """Forward changed tensordict key names to the underying value estimator."""
+        """Passes updated tensordict keys to the underlying value estimator."""
         ...
 
     def _set_deprecated_ctor_keys(self, **kwargs) -> None:
-        """Helper function setting to set a tensordict key from a ctor and raising a warning at the same time."""
+        """Helper function to set a tensordict key from a ctor and raise a warning simultaneously."""
         for key, value in kwargs.items():
             if value is not None:
                 warnings.warn(

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -63,6 +63,12 @@ class LossModule(nn.Module, ABC):
 
     @dataclass
     class _AcceptedKeys:
+        """Stores default values for all configurable tensordict keys.
+
+        This class is used to define and store which tensordict keys are configurable
+        via `.set_keys(key_name=key_value) and their default values.
+        """
+
         pass
 
     default_value_estimator: ValueEstimators = None
@@ -87,11 +93,11 @@ class LossModule(nn.Module, ABC):
 
     @abstractmethod
     def _forward_value_estimator_keys(self, **kwargs) -> None:
-        """Forward changed tensordit key names to the underying value estimator."""
+        """Forward changed tensordict key names to the underying value estimator."""
         ...
 
     def _set_deprecated_ctor_keys(self, **kwargs) -> None:
-        """Helper function setting a loss key and creating a warning for using a deprecated argument."""
+        """Helper function setting to set a tensordict key from a ctor and raising a warning at the same time."""
         for key, value in kwargs.items():
             if value is not None:
                 warnings.warn(
@@ -101,7 +107,7 @@ class LossModule(nn.Module, ABC):
                 self.set_keys(**{key: value})
 
     def set_keys(self, **kwargs) -> None:
-        """Specify tensordict key for given argument.
+        """Set tensordict key names.
 
         Examples:
             >>> from torchrl.objectives import DQNLoss

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -97,11 +97,11 @@ class LossModule(nn.Module, ABC):
         ...
 
     def _set_deprecated_ctor_keys(self, **kwargs) -> None:
-        """Helper function to set a tensordict key from a ctor and raise a warning simultaneously."""
+        """Helper function to set a tensordict key from a constructor and raise a warning simultaneously."""
         for key, value in kwargs.items():
             if value is not None:
                 warnings.warn(
-                    f"Setting '{key}' via ctor is deprecated, use .set_keys({key}='some_key') instead.",
+                    f"Setting '{key}' via the constructor is deprecated, use .set_keys(<key>='some_key') instead.",
                     category=DeprecationWarning,
                 )
                 self.set_keys(**{key: value})

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -85,7 +85,7 @@ class LossModule(nn.Module):
         for key, value in kwargs.items():
             if value is not None:
                 warnings.warn(
-                    f"Setting '{key}' via ctor is deprecated, use .set_keys(advantage_key='some_key') instead.",
+                    f"Setting '{key}' via ctor is deprecated, use .set_keys({key}='some_key') instead.",
                     category=DeprecationWarning,
                 )
                 self.tensordict_keys[key] = value
@@ -104,10 +104,7 @@ class LossModule(nn.Module):
         for key, value in kwargs.items():
             if key not in self.tensordict_keys.keys():
                 raise ValueError(f"{key} not a valid tensordict key")
-            if value is None:
-                set_value = self.tensordict_keys[key]
-            else:
-                set_value = value
+            set_value = value if value is not None else self.tensordict_keys[key]
             setattr(self, key, set_value)
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -73,6 +73,17 @@ class LossModule(nn.Module):
         self._has_update_associated = False
         self.value_type = self.default_value_estimator
         # self.register_forward_pre_hook(_parameters_to_tensordict)
+        self.tensordict_keys = {}
+
+    def set_keys(self, **kwargs):
+        for key, value in kwargs.items():
+            if key not in self.tensordict_keys.keys():
+                raise ValueError(f"{key} not a valid tensordict key")
+            if value is None:
+                set_value = self.tensordict_keys[key]
+            else:
+                set_value = value
+            setattr(self, key, set_value)
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         """It is designed to read an input TensorDict and return another tensordict with loss keys named "loss*".

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -83,7 +83,7 @@ class LossModule(nn.Module, ABC):
                     f"Setting '{key}' via ctor is deprecated, use .set_keys({key}='some_key') instead.",
                     category=DeprecationWarning,
                 )
-                setattr(self, key, value)
+                self.set_keys(**{key: value})
 
     @abstractmethod
     def set_keys(self, **kwargs) -> None:

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -42,10 +42,10 @@ class DDPGLoss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and the corresponding default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values
 
         Attributes:
         ------------

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -66,7 +66,6 @@ class DDPGLoss(LossModule):
         gamma: float = None,
     ) -> None:
         super().__init__()
-        self.set_keys()
 
         self.delay_actor = delay_actor
         self.delay_value = delay_value

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -36,7 +36,7 @@ class DDPGLoss(LossModule):
         delay_actor (bool, optional): whether to separate the target actor networks from the actor networks used for
             data collection. Default is ``False``.
         delay_value (bool, optional): whether to separate the target value networks from the value networks used for
-            data collection. Default is ``False``.
+            data collection. Default is ``True``.
     """
 
     default_value_estimator: ValueEstimators = ValueEstimators.TD0
@@ -48,7 +48,7 @@ class DDPGLoss(LossModule):
         *,
         loss_function: str = "l2",
         delay_actor: bool = False,
-        delay_value: bool = False,
+        delay_value: bool = True,
         gamma: float = None,
     ) -> None:
         super().__init__()
@@ -84,7 +84,7 @@ class DDPGLoss(LossModule):
 
         self.actor_in_keys = actor_network.in_keys
 
-        self.loss_funtion = loss_function
+        self.loss_function = loss_function
 
         if gamma is not None:
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
@@ -173,7 +173,7 @@ class DDPGLoss(LossModule):
 
         # td_error = pred_val - target_value
         loss_value = distance_loss(
-            pred_val, target_value, loss_function=self.loss_funtion
+            pred_val, target_value, loss_function=self.loss_function
         )
 
         return loss_value, (pred_val - target_value).pow(2), pred_val, target_value

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -52,6 +52,12 @@ class DDPGLoss(LossModule):
         gamma: float = None,
     ) -> None:
         super().__init__()
+
+        self.tensordict_keys = {
+            "state_action_value_key": "state_action_value",
+        }
+        self.set_keys(**self.tensordict_keys)
+
         self.delay_actor = delay_actor
         self.delay_value = delay_value
 
@@ -136,7 +142,7 @@ class DDPGLoss(LossModule):
                 td_copy,
                 params=params,
             )
-        return -td_copy.get("state_action_value")
+        return -td_copy.get(self.state_action_value_key)
 
     def _loss_value(
         self,
@@ -148,7 +154,7 @@ class DDPGLoss(LossModule):
             td_copy,
             params=self.value_network_params,
         )
-        pred_val = td_copy.get("state_action_value").squeeze(-1)
+        pred_val = td_copy.get(self.state_action_value_key).squeeze(-1)
 
         target_params = TensorDict(
             {

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -45,15 +45,14 @@ class DDPGLoss(LossModule):
         """Maintains default values for all configurable tensordict keys.
 
         This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
-        default values
+        default values.
 
         Attributes:
-        ------------
-        state_action_value : NestedKey
-            The input tensordict key where the state action value is expected.
-            Will be used for the underlying value estimator as value key. Defaults to ``"state_action_value"``.
-        priority : NestedKey
-            The input tensordict key where the target priority is written to. Defaults to ``"td_error"``.
+            state_action_value (NestedKey): The input tensordict key where the
+                state action value is expected.  Will be used for the underlying
+                value estimator as value key. Defaults to ``"state_action_value"``.
+            priority (NestedKey): The input tensordict key where the target
+                priority is written to. Defaults to ``"td_error"``.
         """
 
         state_action_value: NestedKey = "state_action_value"

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -45,7 +45,7 @@ class DDPGLoss(LossModule):
         """Stores default values for all configurable tensordict keys.
 
         This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and their default values.
+        via `.set_keys(key_name=key_value) and the corresponding default values.
 
         Attributes:
         ------------

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -53,11 +53,11 @@ class DDPGLoss(LossModule):
     ) -> None:
         super().__init__()
 
-        self.tensordict_keys = {
+        tensordict_keys = {
             "state_action_value_key": "state_action_value",
             "priority_key": "td_error",
         }
-        self.set_keys(**self.tensordict_keys)
+        self._set_default_tensordict_keys(tensordict_keys)
 
         self.delay_actor = delay_actor
         self.delay_value = delay_value

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -55,6 +55,7 @@ class DDPGLoss(LossModule):
 
         self.tensordict_keys = {
             "state_action_value_key": "state_action_value",
+            "priority_key": "td_error",
         }
         self.set_keys(**self.tensordict_keys)
 
@@ -111,7 +112,7 @@ class DDPGLoss(LossModule):
         if input_tensordict.device is not None:
             td_error = td_error.to(input_tensordict.device)
         input_tensordict.set(
-            "td_error",
+            self.priority_key,
             td_error,
             inplace=True,
         )

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -53,12 +53,6 @@ class DDPGLoss(LossModule):
     ) -> None:
         super().__init__()
 
-        tensordict_keys = {
-            "state_action_value_key": "state_action_value",
-            "priority_key": "td_error",
-        }
-        self._set_default_tensordict_keys(tensordict_keys)
-
         self.delay_actor = delay_actor
         self.delay_value = delay_value
 
@@ -89,6 +83,13 @@ class DDPGLoss(LossModule):
         if gamma is not None:
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
+
+    @staticmethod
+    def default_tensordict_keys():
+        return {
+            "state_action_value_key": "state_action_value",
+            "priority_key": "td_error",
+        }
 
     def forward(self, input_tensordict: TensorDictBase) -> TensorDict:
         """Computes the DDPG losses given a tensordict sampled from the replay buffer.

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -107,7 +107,7 @@ class DDPGLoss(LossModule):
     def _forward_value_estimator_keys(self, **kwargs) -> None:
         if self._value_estimator is not None:
             self._value_estimator.set_keys(
-                value_key=self._tensor_keys.state_action_value,
+                value=self._tensor_keys.state_action_value,
             )
 
     def forward(self, input_tensordict: TensorDictBase) -> TensorDict:
@@ -206,22 +206,20 @@ class DDPGLoss(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        tensor_keys = {"value_key": self.tensor_keys.state_action_value}
         if value_type == ValueEstimators.TD1:
-            self._value_estimator = TD1Estimator(
-                value_network=self.actor_critic, tensor_keys=tensor_keys, **hp
-            )
+            self._value_estimator = TD1Estimator(value_network=self.actor_critic, **hp)
         elif value_type == ValueEstimators.TD0:
-            self._value_estimator = TD0Estimator(
-                value_network=self.actor_critic, tensor_keys=tensor_keys, **hp
-            )
+            self._value_estimator = TD0Estimator(value_network=self.actor_critic, **hp)
         elif value_type == ValueEstimators.GAE:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
         elif value_type == ValueEstimators.TDLambda:
             self._value_estimator = TDLambdaEstimator(
-                value_network=self.actor_critic, tensor_keys=tensor_keys, **hp
+                value_network=self.actor_critic, **hp
             )
         else:
             raise NotImplementedError(f"Unknown value type {value_type}")
+
+        tensor_keys = {"value": self.tensor_keys.state_action_value}
+        self._value_estimator.set_keys(**tensor_keys)

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -36,7 +36,7 @@ class DDPGLoss(LossModule):
         delay_actor (bool, optional): whether to separate the target actor networks from the actor networks used for
             data collection. Default is ``False``.
         delay_value (bool, optional): whether to separate the target value networks from the value networks used for
-            data collection. Default is ``True``.
+            data collection. Default is ``False``.
     """
 
     default_value_estimator: ValueEstimators = ValueEstimators.TD0
@@ -48,7 +48,7 @@ class DDPGLoss(LossModule):
         *,
         loss_function: str = "l2",
         delay_actor: bool = False,
-        delay_value: bool = True,
+        delay_value: bool = False,
         gamma: float = None,
     ) -> None:
         super().__init__()
@@ -84,7 +84,7 @@ class DDPGLoss(LossModule):
 
         self.actor_in_keys = actor_network.in_keys
 
-        self.loss_function = loss_function
+        self.loss_funtion = loss_function
 
         if gamma is not None:
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
@@ -173,7 +173,7 @@ class DDPGLoss(LossModule):
 
         # td_error = pred_val - target_value
         loss_value = distance_loss(
-            pred_val, target_value, loss_function=self.loss_function
+            pred_val, target_value, loss_function=self.loss_funtion
         )
 
         return loss_value, (pred_val - target_value).pow(2), pred_val, target_value
@@ -186,7 +186,7 @@ class DDPGLoss(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        value_key = "state_action_value"
+        value_key = self.state_action_value_key
         if value_type == ValueEstimators.TD1:
             self._value_estimator = TD1Estimator(
                 value_network=self.actor_critic, value_key=value_key, **hp

--- a/torchrl/objectives/deprecated.py
+++ b/torchrl/objectives/deprecated.py
@@ -102,6 +102,7 @@ class REDQLoss_deprecated(LossModule):
         if not _has_functorch:
             raise ImportError("Failed to import functorch.") from FUNCTORCH_ERR
         super().__init__()
+        self.set_keys()
         self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         self.convert_to_functional(
@@ -166,11 +167,11 @@ class REDQLoss_deprecated(LossModule):
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
 
-    @staticmethod
-    def default_loss_keys():
-        return {
-            "priority_key": "td_error",
-        }
+    def set_keys(
+        self,
+        priority_key="td_error",
+    ):
+        self.priority_key = priority_key
 
     @property
     def alpha(self):

--- a/torchrl/objectives/deprecated.py
+++ b/torchrl/objectives/deprecated.py
@@ -88,11 +88,6 @@ class REDQLoss_deprecated(LossModule):
     delay_actor: bool = False
     default_value_estimator = ValueEstimators.TD0
 
-    @classmethod
-    def __new__(cls, *args, **kwargs):
-        cls._tensor_keys = cls._AcceptedKeys()
-        return super().__new__(cls)
-
     def __init__(
         self,
         actor_network: TensorDictModule,
@@ -178,23 +173,15 @@ class REDQLoss_deprecated(LossModule):
             self.gamma = gamma
 
     @property
-    def tensor_keys(self) -> _AcceptedKeys:
-        return self._tensor_keys
-
-    def set_keys(self, **kwargs) -> None:
-        """TODO"""
-        for key, _ in kwargs.items():
-            if key not in self._AcceptedKeys.__dict__:
-                raise ValueError(f"{key} it not an accepted tensordict key")
-        self._tensor_keys = self._AcceptedKeys(**kwargs)
-
-    @property
     def alpha(self):
         # keep alpha is a reasonable range
         self.log_alpha.data.clamp_(self.min_log_alpha, self.max_log_alpha)
         with torch.no_grad():
             alpha = self.log_alpha.exp()
         return alpha
+
+    def _forward_value_estimator_keys(self, **kwargs) -> None:
+        pass
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         loss_actor, sample_log_prob = self._actor_loss(tensordict)

--- a/torchrl/objectives/deprecated.py
+++ b/torchrl/objectives/deprecated.py
@@ -302,26 +302,21 @@ class REDQLoss_deprecated(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        value_key = "state_value"
         # we do not need a value network bc the next state value is already passed
         if value_type == ValueEstimators.TD1:
-            self._value_estimator = TD1Estimator(
-                value_network=None, value_key=value_key, **hp
-            )
+            self._value_estimator = TD1Estimator(value_network=None, **hp)
         elif value_type == ValueEstimators.TD0:
-            self._value_estimator = TD0Estimator(
-                value_network=None, value_key=value_key, **hp
-            )
+            self._value_estimator = TD0Estimator(value_network=None, **hp)
         elif value_type == ValueEstimators.GAE:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
         elif value_type == ValueEstimators.TDLambda:
-            self._value_estimator = TDLambdaEstimator(
-                value_network=None, value_key=value_key, **hp
-            )
+            self._value_estimator = TDLambdaEstimator(value_network=None, **hp)
         else:
             raise NotImplementedError(f"Unknown value type {value_type}")
+        tensor_keys = {"value": "state_value"}
+        self._value_estimator.set_keys(**tensor_keys)
 
 
 class DoubleREDQLoss_deprecated(REDQLoss_deprecated):

--- a/torchrl/objectives/deprecated.py
+++ b/torchrl/objectives/deprecated.py
@@ -54,9 +54,6 @@ class REDQLoss_deprecated(LossModule):
         sub_sample_len (int, optional): number of Q-value networks to be
             subsampled to evaluate the next state value
             Default is ``2``.
-        priority_key (str, optional): Key where to write the priority value
-            for prioritized replay buffers. Default is
-            ``"td_error"``.
         loss_function (str, optional): loss function to be used for the Q-value.
             Can be one of  ``"smooth_l1"``, ``"l2"``,
             ``"l1"``, Default is ``"smooth_l1"``.
@@ -76,7 +73,9 @@ class REDQLoss_deprecated(LossModule):
         gSDE (bool, optional): Knowing if gSDE is used is necessary to create
             random noise variables.
             Default is ``False``.
-
+        priority_key (str, optional): [Deprecated] Key where to write the priority value
+            for prioritized replay buffers. Default is
+            ``"td_error"``.
     """
 
     delay_actor: bool = False
@@ -89,7 +88,6 @@ class REDQLoss_deprecated(LossModule):
         *,
         num_qvalue_nets: int = 10,
         sub_sample_len: int = 2,
-        priority_key: str = "td_error",
         loss_function: str = "smooth_l1",
         alpha_init: float = 1.0,
         min_alpha: float = 0.1,
@@ -99,10 +97,13 @@ class REDQLoss_deprecated(LossModule):
         delay_qvalue: bool = True,
         gSDE: bool = False,
         gamma: float = None,
+        priority_key: str = None,
     ):
         if not _has_functorch:
             raise ImportError("Failed to import functorch.") from FUNCTORCH_ERR
         super().__init__()
+        self._set_deprecated_ctor_keys(priority_key=priority_key)
+
         self.convert_to_functional(
             actor_network,
             "actor_network",
@@ -164,6 +165,12 @@ class REDQLoss_deprecated(LossModule):
         if gamma is not None:
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
+
+    @staticmethod
+    def default_tensordict_keys():
+        return {
+            "priority_key": "td_error",
+        }
 
     @property
     def alpha(self):

--- a/torchrl/objectives/dqn.py
+++ b/torchrl/objectives/dqn.py
@@ -69,18 +69,13 @@ class DQNLoss(LossModule):
     ) -> None:
 
         super().__init__()
-        self.tensordict_keys = {
+        tensordict_keys = {
             "priority_key": "td_error",
             "action_value_key": "action_value",
             "action_key": "action",
         }
-        if priority_key is not None:
-            warnings.warn(
-                "Setting 'priority_key' via ctor is deprecated, use .set_keys(priotity_key='some_key') instead.",
-                category=DeprecationWarning,
-            )
-            self.tensordict_keys["priority_key"] = priority_key
-        self.set_keys(**self.tensordict_keys)
+        self._set_default_tensordict_keys(tensordict_keys)
+        self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         self.delay_value = delay_value
         value_network = ensure_tensordict_compatible(
@@ -265,20 +260,15 @@ class DistributionalDQNLoss(LossModule):
         priority_key: str = None,
     ):
         super().__init__()
-        self.tensordict_keys = {
+        tensordict_keys = {
             "priority_key": "td_error",
             "action_value_key": "action_value",
             "action_key": "action",
             "reward_key": "reward",
             "done_key": "done",
         }
-        if priority_key is not None:
-            warnings.warn(
-                "Setting 'priority_key' via ctor is deprecated, use .set_keys(priotity_key='some_key') instead.",
-                category=DeprecationWarning,
-            )
-            self.tensordict_keys["priority_key"] = priority_key
-        self.set_keys(**self.tensordict_keys)
+        self._set_default_tensordict_keys(tensordict_keys)
+        self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         self.register_buffer("gamma", torch.tensor(gamma))
         self.delay_value = delay_value

--- a/torchrl/objectives/dqn.py
+++ b/torchrl/objectives/dqn.py
@@ -69,12 +69,7 @@ class DQNLoss(LossModule):
     ) -> None:
 
         super().__init__()
-        tensordict_keys = {
-            "priority_key": "td_error",
-            "action_value_key": "action_value",
-            "action_key": "action",
-        }
-        self._set_default_tensordict_keys(tensordict_keys)
+
         self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         self.delay_value = delay_value
@@ -115,6 +110,14 @@ class DQNLoss(LossModule):
         if gamma is not None:
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
+
+    @staticmethod
+    def default_tensordict_keys():
+        return {
+            "priority_key": "td_error",
+            "action_value_key": "action_value",
+            "action_key": "action",
+        }
 
     def make_value_estimator(self, value_type: ValueEstimators = None, **hyperparams):
         if value_type is None:
@@ -260,15 +263,6 @@ class DistributionalDQNLoss(LossModule):
         priority_key: str = None,
     ):
         super().__init__()
-        tensordict_keys = {
-            "priority_key": "td_error",
-            "action_value_key": "action_value",
-            "action_key": "action",
-            "reward_key": "reward",
-            "done_key": "done",
-            "steps_to_next_obs_key": "steps_to_next_obs",
-        }
-        self._set_default_tensordict_keys(tensordict_keys)
         self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         self.register_buffer("gamma", torch.tensor(gamma))
@@ -284,6 +278,17 @@ class DistributionalDQNLoss(LossModule):
             create_target_params=self.delay_value,
         )
         self.action_space = self.value_network.action_space
+
+    @staticmethod
+    def default_tensordict_keys():
+        return {
+            "priority_key": "td_error",
+            "action_value_key": "action_value",
+            "action_key": "action",
+            "reward_key": "reward",
+            "done_key": "done",
+            "steps_to_next_obs_key": "steps_to_next_obs",
+        }
 
     @staticmethod
     def _log_ps_a_default(action, action_log_softmax, batch_size, atoms):

--- a/torchrl/objectives/dqn.py
+++ b/torchrl/objectives/dqn.py
@@ -119,9 +119,12 @@ class DQNLoss(LossModule):
         default values.
 
         Attributes:
-            state_action_value (NestedKey): The input tensordict key where the state action value is expected. Defaults to ``"state_action_value"``.
-            action (NestedKey): The input tensordict key where the action is expected. Defaults to ``"action"``.
-            priority (NestedKey): The input tensordict key where the target priority is written to. Defaults to ``"td_error"``.
+            state_action_value (NestedKey): The input tensordict key where the state action value is expected.
+                Defaults to ``"state_action_value"``.
+            action (NestedKey): The input tensordict key where the action is expected.
+                Defaults to ``"action"``.
+            priority (NestedKey): The input tensordict key where the target priority is written to.
+                Defaults to ``"td_error"``.
         """
 
         action_value: NestedKey = "action_value"

--- a/torchrl/objectives/dqn.py
+++ b/torchrl/objectives/dqn.py
@@ -113,10 +113,10 @@ class DQNLoss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and the corresponding default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values.
 
         Attributes:
         ------------
@@ -315,10 +315,10 @@ class DistributionalDQNLoss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and the corresponding default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values
 
         Attributes:
         ------------

--- a/torchrl/objectives/dqn.py
+++ b/torchrl/objectives/dqn.py
@@ -273,7 +273,6 @@ class DistributionalDQNLoss(LossModule):
             )
             self.tensordict_keys["priority_key"] = priority_key
         self.set_keys(**self.tensordict_keys)
-        print(f"{self.priority_key = }")
 
         self.register_buffer("gamma", torch.tensor(gamma))
         self.delay_value = delay_value

--- a/torchrl/objectives/dqn.py
+++ b/torchrl/objectives/dqn.py
@@ -48,8 +48,8 @@ class DQNLoss(LossModule):
             :class:`torchrl.data.BinaryDiscreteTensorSpec` or :class:`torchrl.data.DiscreteTensorSpec`).
             If not provided, an attempt to retrieve it from the value network
             will be made.
-        priority_key (str, optional): [Deprecated, use .set_keys() instead] the
-            key at which priority is assumed to be stored within TensorDicts added
+        priority_key (str, optional): [Deprecated, use .set_keys(priority_key=priority_key) instead]
+            The key at which priority is assumed to be stored within TensorDicts added
             to this ReplayBuffer.  This is to be used when the sampler is of type
             :class:`~torchrl.data.PrioritizedSampler`.  Defaults to ``"td_error"``.
 
@@ -243,8 +243,8 @@ class DistributionalDQNLoss(LossModule):
               Unlike :class:`DQNLoss`, this class does not currently support
               custom value functions. The next value estimation is always
               bootstrapped.
-        priority_key (str, optional): [Deprecated, use .set_keys() instead] the
-            key at which priority is assumed to be stored within TensorDicts added
+        priority_key (str, optional): [Deprecated, use .set_keys(priority_key=priority_key) instead]
+            The key at which priority is assumed to be stored within TensorDicts added
             to this ReplayBuffer.  This is to be used when the sampler is of type
             :class:`~torchrl.data.PrioritizedSampler`.  Defaults to ``"td_error"``.
 
@@ -266,6 +266,7 @@ class DistributionalDQNLoss(LossModule):
             "action_key": "action",
             "reward_key": "reward",
             "done_key": "done",
+            "steps_to_next_obs_key": "steps_to_next_obs",
         }
         self._set_default_tensordict_keys(tensordict_keys)
         self._set_deprecated_ctor_keys(priority_key=priority_key)
@@ -325,7 +326,7 @@ class DistributionalDQNLoss(LossModule):
         reward = tensordict.get(("next", self.reward_key))
         done = tensordict.get(("next", self.done_key))
 
-        steps_to_next_obs = tensordict.get("steps_to_next_obs", 1)
+        steps_to_next_obs = tensordict.get(self.steps_to_next_obs_key, 1)
         discount = self.gamma**steps_to_next_obs
 
         # Calculate current state probabilities (online network noise already

--- a/torchrl/objectives/dqn.py
+++ b/torchrl/objectives/dqn.py
@@ -62,7 +62,7 @@ class DQNLoss(LossModule):
         """Stores default values for all configurable tensordict keys.
 
         This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and their default values.
+        via `.set_keys(key_name=key_value) and the corresponding default values.
 
         Attributes:
         ------------
@@ -268,7 +268,7 @@ class DistributionalDQNLoss(LossModule):
         """Stores default values for all configurable tensordict keys.
 
         This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and their default values.
+        via `.set_keys(key_name=key_value) and the corresponding default values.
 
         Attributes:
         ------------

--- a/torchrl/objectives/dqn.py
+++ b/torchrl/objectives/dqn.py
@@ -119,13 +119,9 @@ class DQNLoss(LossModule):
         default values.
 
         Attributes:
-        ------------
-        state_action_value : NestedKey
-            The input tensordict key where the state action value is expected. Defaults to ``"state_action_value"``.
-        action : NestedKey
-            The input tensordict key where the action is expected. Defaults to ``"action"``.
-        priority : NestedKey
-            The input tensordict key where the target priority is written to. Defaults to ``"td_error"``.
+            state_action_value (NestedKey): The input tensordict key where the state action value is expected. Defaults to ``"state_action_value"``.
+            action (NestedKey): The input tensordict key where the action is expected. Defaults to ``"action"``.
+            priority (NestedKey): The input tensordict key where the target priority is written to. Defaults to ``"td_error"``.
         """
 
         action_value: NestedKey = "action_value"
@@ -321,19 +317,18 @@ class DistributionalDQNLoss(LossModule):
         default values
 
         Attributes:
-        ------------
-        state_action_value : NestedKey
-            The input tensordict key where the state action value is expected. Defaults to ``"state_action_value"``.
-        action : NestedKey
-            The input tensordict key where the action is expected. Defaults to ``"action"``.
-        priority : NestedKey
-            The input tensordict key where the target priority is written to. Defaults to ``"td_error"``.
-        reward : NestedKey
-            The input tensordict key where the reward is expected. Defaults to ``"reward"``.
-        done : NestedKey
-            The input tensordict key where the the flag if a trajectory is done is expected. Defaults to ``"done"``.
-        steps_to_next_obs : NestedKey
-            The input tensordict key where the steps_to_next_obs is exptected. Defaults to ``"steps_to_next_obs"``.
+            state_action_value (NestedKey): The input tensordict key where the state action value is expected.
+                Defaults to ``"state_action_value"``.
+            action (NestedKey): The input tensordict key where the action is expected.
+                Defaults to ``"action"``.
+            priority (NestedKey): The input tensordict key where the target priority is written to.
+                Defaults to ``"td_error"``.
+            reward (NestedKey): The input tensordict key where the reward is expected.
+                Defaults to ``"reward"``.
+            done (NestedKey): The input tensordict key where the the flag if a trajectory is done is expected.
+                Defaults to ``"done"``.
+            steps_to_next_obs (NestedKey): The input tensordict key where the steps_to_next_obs is exptected.
+                Defaults to ``"steps_to_next_obs"``.
         """
 
         action_value: NestedKey = "action_value"

--- a/torchrl/objectives/dqn.py
+++ b/torchrl/objectives/dqn.py
@@ -144,29 +144,27 @@ class DQNLoss(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        tensor_keys = {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "chosen_action_value",
-        }
         if value_type is ValueEstimators.TD1:
-            self._value_estimator = TD1Estimator(
-                **hp, value_network=self.value_network, tensor_keys=tensor_keys
-            )
+            self._value_estimator = TD1Estimator(**hp, value_network=self.value_network)
         elif value_type is ValueEstimators.TD0:
-            self._value_estimator = TD0Estimator(
-                **hp, value_network=self.value_network, tensor_keys=tensor_keys
-            )
+            self._value_estimator = TD0Estimator(**hp, value_network=self.value_network)
         elif value_type is ValueEstimators.GAE:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
         elif value_type is ValueEstimators.TDLambda:
             self._value_estimator = TDLambdaEstimator(
-                **hp, value_network=self.value_network, tensor_keys=tensor_keys
+                **hp, value_network=self.value_network
             )
         else:
             raise NotImplementedError(f"Unknown value type {value_type}")
+
+        tensor_keys = {
+            "advantage": "advantage",
+            "value_target": "value_target",
+            "value": "chosen_action_value",
+        }
+        self._value_estimator.set_keys(**tensor_keys)
 
     def forward(self, input_tensordict: TensorDictBase) -> TensorDict:
         """Computes the DQN loss given a tensordict sampled from the replay buffer.

--- a/torchrl/objectives/dreamer.py
+++ b/torchrl/objectives/dreamer.py
@@ -211,7 +211,7 @@ class DreamerActorLoss(LossModule):
         Attributes:
         ------------
         belief : NestedKey
-            The input tensordict key where the belief is expected. Defaults to ``"done"``.
+            The input tensordict key where the belief is expected. Defaults to ``"belief"``.
         reward : NestedKey
             The reward is expected to be in the tensordict key ("next", reward). Defaults to ``"reward"``.
         value : NestedKey
@@ -319,7 +319,6 @@ class DreamerActorLoss(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-
         if value_type is ValueEstimators.TD1:
             self._value_estimator = TD1Estimator(
                 **hp,

--- a/torchrl/objectives/dreamer.py
+++ b/torchrl/objectives/dreamer.py
@@ -59,22 +59,22 @@ class DreamerModelLoss(LossModule):
         default values
 
         Attributes:
-            reward (NestedKey): The reward is expected to be in the tensordict key ("next", reward).
-                Defaults to ``"reward"``.
-            true_reward (NestedKey): The `true_reward` will be stored in the tensordict key ("next", true_reward).
-                Defaults to ``"true_reward"``.
-            prior_mean (NestedKey): The prior mean is expected to be in the tensordict key ("next", prior_mean).
-                Defaults to ``"prior_mean"``.
-            prior_std (NestedKey): The prior mean is expected to be in the tensordict key ("next", prior_mean).
-                Defaults to ``"prior_mean"``.
-            posterior_mean (NestedKey): The posterior mean is expected to be in the tensordict key ("next", prior_mean).
-                Defaults to ``"posterior_mean"``.
-            posterior_std (NestedKey): The posterior std is expected to be in the tensordict key ("next", prior_mean).
-                Defaults to ``"posterior_std"``.
+            reward (NestedKey): The reward is expected to be in the tensordict
+                key ("next", reward). Defaults to ``"reward"``.
+            true_reward (NestedKey): The `true_reward` will be stored in the
+                tensordict key ("next", true_reward). Defaults to ``"true_reward"``.
+            prior_mean (NestedKey): The prior mean is expected to be in the
+                tensordict key ("next", prior_mean). Defaults to ``"prior_mean"``.
+            prior_std (NestedKey): The prior mean is expected to be in the
+                tensordict key ("next", prior_mean). Defaults to ``"prior_mean"``.
+            posterior_mean (NestedKey): The posterior mean is expected to be in
+                the tensordict key ("next", prior_mean). Defaults to ``"posterior_mean"``.
+            posterior_std (NestedKey): The posterior std is expected to be in
+                the tensordict key ("next", prior_mean). Defaults to ``"posterior_std"``.
             pixels (NestedKey): The pixels is expected to be in the tensordict key ("next", pixels).
                 Defaults to ``"pixels"``.
             reco_pixels (NestedKey): The reconstruction pixels is expected to be
-                in the tensordict key ("next", reco_pixels).  Defaults to ``"reco_pixels"``.
+                in the tensordict key ("next", reco_pixels). Defaults to ``"reco_pixels"``.
         """
 
         reward: NestedKey = "reward"
@@ -214,8 +214,8 @@ class DreamerActorLoss(LossModule):
                 Defaults to ``"reward"``.
             value (NestedKey): The reward is expected to be in the tensordict key ("next", value).
                 Will be used for the underlying value estimator. Defaults to ``"state_value"``.
-            done (NestedKey): The input tensordict key where the flag if a trajectory is done is expected ("next", done).
-                Defaults to ``"done"``.
+            done (NestedKey): The input tensordict key where the flag if a
+                trajectory is done is expected ("next", done). Defaults to ``"done"``.
         """
 
         belief: NestedKey = "belief"

--- a/torchrl/objectives/dreamer.py
+++ b/torchrl/objectives/dreamer.py
@@ -53,10 +53,10 @@ class DreamerModelLoss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and the corresponding default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values
 
         Attributes:
         ------------
@@ -203,10 +203,10 @@ class DreamerActorLoss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and the corresponding default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values.
 
         Attributes:
         ------------
@@ -372,10 +372,10 @@ class DreamerValueLoss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and the corresponding default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values
 
         Attributes:
         ------------

--- a/torchrl/objectives/dreamer.py
+++ b/torchrl/objectives/dreamer.py
@@ -256,7 +256,7 @@ class DreamerActorLoss(LossModule):
     def _forward_value_estimator_keys(self, **kwargs) -> None:
         if self._value_estimator is not None:
             self._value_estimator.set_keys(
-                value_key=self._tensor_keys.value,
+                value=self._tensor_keys.value,
             )
 
     def forward(self, tensordict: TensorDict) -> Tuple[TensorDict, TensorDict]:
@@ -319,21 +319,16 @@ class DreamerActorLoss(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        tensor_keys = {
-            "value_key": self.tensor_keys.value,
-            "value_target_key": "value_target",
-        }
+
         if value_type is ValueEstimators.TD1:
             self._value_estimator = TD1Estimator(
                 **hp,
                 value_network=value_net,
-                tensor_keys=tensor_keys,
             )
         elif value_type is ValueEstimators.TD0:
             self._value_estimator = TD0Estimator(
                 **hp,
                 value_network=value_net,
-                tensor_keys=tensor_keys,
             )
         elif value_type is ValueEstimators.GAE:
             if hasattr(self, "lmbda"):
@@ -347,10 +342,15 @@ class DreamerActorLoss(LossModule):
             self._value_estimator = TDLambdaEstimator(
                 **hp,
                 value_network=value_net,
-                tensor_keys=tensor_keys,
             )
         else:
             raise NotImplementedError(f"Unknown value type {value_type}")
+
+        tensor_keys = {
+            "value": self.tensor_keys.value,
+            "value_target": "value_target",
+        }
+        self._value_estimator.set_keys(**tensor_keys)
 
 
 class DreamerValueLoss(LossModule):

--- a/torchrl/objectives/dreamer.py
+++ b/torchrl/objectives/dreamer.py
@@ -73,6 +73,17 @@ class DreamerModelLoss(LossModule):
         self.delayed_clamp = delayed_clamp
         self.global_average = global_average
 
+        self.tensordict_keys = {
+            "reward_key": ("next", "reward"),
+            "prior_mean_key": ("next", "prior_mean"),
+            "prior_std_key": ("next", "prior_std"),
+            "posterior_mean_key": ("next", "posterior_mean"),
+            "posterior_std_key": ("next", "posterior_std"),
+            "pixels_key": ("next", "pixels"),
+            "reco_pixels_key": ("next", "reco_pixels"),
+        }
+        self.set_keys(**self.tensordict_keys)
+
     def forward(self, tensordict: TensorDict) -> torch.Tensor:
         tensordict = tensordict.clone(recurse=False)
         tensordict.rename_key_(("next", "reward"), ("next", "true_reward"))

--- a/torchrl/objectives/dreamer.py
+++ b/torchrl/objectives/dreamer.py
@@ -259,7 +259,7 @@ class DreamerActorLoss(LossModule):
             value_type = self.default_value_estimator
         self.value_type = value_type
         value_net = None
-        value_key = "state_value"
+        value_key = self.value_key
         hp = dict(default_value_kwargs(value_type))
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma

--- a/torchrl/objectives/dreamer.py
+++ b/torchrl/objectives/dreamer.py
@@ -59,23 +59,22 @@ class DreamerModelLoss(LossModule):
         default values
 
         Attributes:
-        ------------
-        reward : NestedKey
-            The reward is expected to be in the tensordict key ("next", reward). Defaults to ``"reward"``.
-        true_reward : NestedKey
-            The `true_reward` will be stored in the tensordict key ("next", true_reward). Defaults to ``"true_reward"``.
-        prior_mean : NestedKey
-            The prior mean is expected to be in the tensordict key ("next", prior_mean). Defaults to ``"prior_mean"``.
-        prior_std : NestedKey
-            The prior mean is expected to be in the tensordict key ("next", prior_mean). Defaults to ``"prior_mean"``.
-        posterior_mean : NestedKey
-            The posterior mean is expected to be in the tensordict key ("next", prior_mean). Defaults to ``"posterior_mean"``.
-        posterior_std : NestedKey
-            The posterior std is expected to be in the tensordict key ("next", prior_mean). Defaults to ``"posterior_std"``.
-        pixels : NestedKey
-            The pixels is expected to be in the tensordict key ("next", pixels). Defaults to ``"pixels"``.
-        reco_pixels : NestedKey
-            The reconstruction pixels is expected to be in the tensordict key ("next", reco_pixels). Defaults to ``"reco_pixels"``.
+            reward (NestedKey): The reward is expected to be in the tensordict key ("next", reward).
+                Defaults to ``"reward"``.
+            true_reward (NestedKey): The `true_reward` will be stored in the tensordict key ("next", true_reward).
+                Defaults to ``"true_reward"``.
+            prior_mean (NestedKey): The prior mean is expected to be in the tensordict key ("next", prior_mean).
+                Defaults to ``"prior_mean"``.
+            prior_std (NestedKey): The prior mean is expected to be in the tensordict key ("next", prior_mean).
+                Defaults to ``"prior_mean"``.
+            posterior_mean (NestedKey): The posterior mean is expected to be in the tensordict key ("next", prior_mean).
+                Defaults to ``"posterior_mean"``.
+            posterior_std (NestedKey): The posterior std is expected to be in the tensordict key ("next", prior_mean).
+                Defaults to ``"posterior_std"``.
+            pixels (NestedKey): The pixels is expected to be in the tensordict key ("next", pixels).
+                Defaults to ``"pixels"``.
+            reco_pixels (NestedKey): The reconstruction pixels is expected to be
+                in the tensordict key ("next", reco_pixels).  Defaults to ``"reco_pixels"``.
         """
 
         reward: NestedKey = "reward"
@@ -209,16 +208,14 @@ class DreamerActorLoss(LossModule):
         default values.
 
         Attributes:
-        ------------
-        belief : NestedKey
-            The input tensordict key where the belief is expected. Defaults to ``"belief"``.
-        reward : NestedKey
-            The reward is expected to be in the tensordict key ("next", reward). Defaults to ``"reward"``.
-        value : NestedKey
-            The reward is expected to be in the tensordict key ("next", value).
-            Will be used for the underlying value estimator. Defaults to ``"state_value"``.
-        done : NestedKey
-            The input tensordict key where the flag if a trajectory is done is expected ("next", done). Defaults to ``"done"``.
+            belief (NestedKey): The input tensordict key where the belief is expected.
+                Defaults to ``"belief"``.
+            reward (NestedKey): The reward is expected to be in the tensordict key ("next", reward).
+                Defaults to ``"reward"``.
+            value (NestedKey): The reward is expected to be in the tensordict key ("next", value).
+                Will be used for the underlying value estimator. Defaults to ``"state_value"``.
+            done (NestedKey): The input tensordict key where the flag if a trajectory is done is expected ("next", done).
+                Defaults to ``"done"``.
         """
 
         belief: NestedKey = "belief"
@@ -378,9 +375,8 @@ class DreamerValueLoss(LossModule):
         default values
 
         Attributes:
-        ------------
-        value : NestedKey
-            The input tensordict key where the state value is expected. Defaults to ``"state_value"``.
+            value (NestedKey): The input tensordict key where the state value is expected.
+                Defaults to ``"state_value"``.
         """
 
         value: NestedKey = "state_value"

--- a/torchrl/objectives/dreamer.py
+++ b/torchrl/objectives/dreamer.py
@@ -73,7 +73,9 @@ class DreamerModelLoss(LossModule):
         self.delayed_clamp = delayed_clamp
         self.global_average = global_average
 
-        tensordict_keys = {
+    @staticmethod
+    def default_tensordict_keys():
+        return {
             "reward_key": "reward",
             "true_reward_key": "true_reward",
             "prior_mean_key": "prior_mean",
@@ -83,7 +85,6 @@ class DreamerModelLoss(LossModule):
             "pixels_key": "pixels",
             "reco_pixels_key": "reco_pixels",
         }
-        self._set_default_tensordict_keys(tensordict_keys)
 
     def forward(self, tensordict: TensorDict) -> torch.Tensor:
         tensordict = tensordict.clone(recurse=False)
@@ -183,13 +184,6 @@ class DreamerActorLoss(LossModule):
         lmbda: int = None,
     ):
         super().__init__()
-        tensordict_keys = {
-            "belief_key": "belief",
-            "reward_key": "reward",
-            "value_key": "state_value",
-            "done_key": "done",
-        }
-        self._set_default_tensordict_keys(tensordict_keys)
 
         self.actor_model = actor_model
         self.value_model = value_model
@@ -202,6 +196,15 @@ class DreamerActorLoss(LossModule):
         if lmbda is not None:
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.lmbda = lmbda
+
+    @staticmethod
+    def default_tensordict_keys():
+        return {
+            "belief_key": "belief",
+            "reward_key": "reward",
+            "value_key": "state_value",
+            "done_key": "done",
+        }
 
     def forward(self, tensordict: TensorDict) -> Tuple[TensorDict, TensorDict]:
         with torch.no_grad():
@@ -323,15 +326,16 @@ class DreamerValueLoss(LossModule):
         gamma: int = 0.99,
     ):
         super().__init__()
-        tensordict_keys = {
-            "value_key": "state_value",
-        }
-        self._set_default_tensordict_keys(tensordict_keys)
-
         self.value_model = value_model
         self.value_loss = value_loss if value_loss is not None else "l2"
         self.gamma = gamma
         self.discount_loss = discount_loss
+
+    @staticmethod
+    def default_tensordict_keys():
+        return {
+            "value_key": "state_value",
+        }
 
     def forward(self, fake_data) -> torch.Tensor:
         lambda_target = fake_data.get("lambda_target")

--- a/torchrl/objectives/dreamer.py
+++ b/torchrl/objectives/dreamer.py
@@ -56,7 +56,7 @@ class DreamerModelLoss(LossModule):
         """Stores default values for all configurable tensordict keys.
 
         This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and their default values.
+        via `.set_keys(key_name=key_value) and the corresponding default values.
 
         Attributes:
         ------------
@@ -206,7 +206,7 @@ class DreamerActorLoss(LossModule):
         """Stores default values for all configurable tensordict keys.
 
         This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and their default values.
+        via `.set_keys(key_name=key_value) and the corresponding default values.
 
         Attributes:
         ------------
@@ -376,7 +376,7 @@ class DreamerValueLoss(LossModule):
         """Stores default values for all configurable tensordict keys.
 
         This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and their default values.
+        via `.set_keys(key_name=key_value) and the corresponding default values.
 
         Attributes:
         ------------

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -61,10 +61,10 @@ class IQLLoss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and the corresponding default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values
 
         Attributes:
         ------------

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -164,7 +164,7 @@ class IQLLoss(LossModule):
     def _forward_value_estimator_keys(self, **kwargs) -> None:
         if self._value_estimator is not None:
             self._value_estimator.set_keys(
-                value_key=self._tensor_keys.value,
+                value=self._tensor_keys.value,
             )
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
@@ -295,21 +295,15 @@ class IQLLoss(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        tensor_keys = {
-            "value_target_key": "value_target",
-            "value_key": self.tensor_keys.value,
-        }
         if value_type is ValueEstimators.TD1:
             self._value_estimator = TD1Estimator(
                 **hp,
                 value_network=value_net,
-                tensor_keys=tensor_keys,
             )
         elif value_type is ValueEstimators.TD0:
             self._value_estimator = TD0Estimator(
                 **hp,
                 value_network=value_net,
-                tensor_keys=tensor_keys,
             )
         elif value_type is ValueEstimators.GAE:
             raise NotImplementedError(
@@ -319,7 +313,12 @@ class IQLLoss(LossModule):
             self._value_estimator = TDLambdaEstimator(
                 **hp,
                 value_network=value_net,
-                tensor_keys=tensor_keys,
             )
         else:
             raise NotImplementedError(f"Unknown value type {value_type}")
+
+        tensor_keys = {
+            "value_target": "value_target",
+            "value": self.tensor_keys.value,
+        }
+        self._value_estimator.set_keys(**tensor_keys)

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -75,20 +75,15 @@ class IQLLoss(LossModule):
         if not _has_functorch:
             raise ImportError("Failed to import functorch.") from FUNCTORCH_ERROR
         super().__init__()
-        self.tensordict_keys = {
+        tensordict_keys = {
             "priority_key": "td_error",
             "log_prob_key": "_log_prob",
             "action_key": "action",
             "state_action_value_key": "state_action_value",
             "value_key": "state_value",
         }
-        if priority_key is not None:
-            warnings.warn(
-                "Setting 'priority_key' via ctor is deprecated, use .set_keys(priotity_key='some_key') instead.",
-                category=DeprecationWarning,
-            )
-            self.tensordict_keys["priority_key"] = priority_key
-        self.set_keys(**self.tensordict_keys)
+        self._set_default_tensordict_keys(tensordict_keys)
+        self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         # IQL parameter
         self.temperature = temperature

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -67,19 +67,17 @@ class IQLLoss(LossModule):
         default values
 
         Attributes:
-        ------------
-        value : NestedKey
-            The input tensordict key where the state value is expected.
-            Will be used for the underlying value estimator. Defaults to ``"state_value"``.
-        action : NestedKey
-            The input tensordict key where the action is expected. Defaults to ``"action"``.
-        log_prob : NestedKey
-            The input tensordict key where the log probability is expected. Defaults to ``"_log_prob"``.
-        priority : NestedKey
-            The input tensordict key where the target priority is written to. Defaults to ``"td_error"``.
-        state_action_value : NestedKey
-            The input tensordict key where the state action value is expected.
-            Will be used for the underlying value estimator as value key. Defaults to ``"state_action_value"``.
+            value (NestedKey): The input tensordict key where the state value is expected.
+                Will be used for the underlying value estimator. Defaults to ``"state_value"``.
+            action (NestedKey): The input tensordict key where the action is expected.
+                Defaults to ``"action"``.
+            log_prob (NestedKey): The input tensordict key where the log probability is expected.
+                Defaults to ``"_log_prob"``.
+            priority (NestedKey): The input tensordict key where the target priority is written to.
+                Defaults to ``"td_error"``.
+            state_action_value (NestedKey): The input tensordict key where the state action value is expected.
+                Will be used for the underlying value estimator as value key.
+                Defaults to ``"state_action_value"``.
         """
 
         value: NestedKey = "state_value"

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -260,7 +260,6 @@ class IQLLoss(LossModule):
 
     def _loss_qvalue(self, tensordict: TensorDictBase) -> Tuple[Tensor, Tensor]:
         obs_keys = self.actor_network.in_keys
-        # TODO (refactor key usage): what to do with dynamically generated keys
         tensordict = tensordict.select("next", *obs_keys, self.tensor_keys.action)
 
         target_value = self.value_estimator.value_estimate(

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -64,7 +64,7 @@ class IQLLoss(LossModule):
         """Stores default values for all configurable tensordict keys.
 
         This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and their default values.
+        via `.set_keys(key_name=key_value) and the corresponding default values.
 
         Attributes:
         ------------

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -75,9 +75,9 @@ class IQLLoss(LossModule):
                 Defaults to ``"_log_prob"``.
             priority (NestedKey): The input tensordict key where the target priority is written to.
                 Defaults to ``"td_error"``.
-            state_action_value (NestedKey): The input tensordict key where the state action value is expected.
-                Will be used for the underlying value estimator as value key.
-                Defaults to ``"state_action_value"``.
+            state_action_value (NestedKey): The input tensordict key where the
+                state action value is expected. Will be used for the underlying
+                value estimator as value key. Defaults to ``"state_action_value"``.
         """
 
         value: NestedKey = "state_value"

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -75,14 +75,6 @@ class IQLLoss(LossModule):
         if not _has_functorch:
             raise ImportError("Failed to import functorch.") from FUNCTORCH_ERROR
         super().__init__()
-        tensordict_keys = {
-            "priority_key": "td_error",
-            "log_prob_key": "_log_prob",
-            "action_key": "action",
-            "state_action_value_key": "state_action_value",
-            "value_key": "state_value",
-        }
-        self._set_default_tensordict_keys(tensordict_keys)
         self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         # IQL parameter
@@ -122,6 +114,16 @@ class IQLLoss(LossModule):
         if gamma is not None:
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
+
+    @staticmethod
+    def default_tensordict_keys():
+        return {
+            "priority_key": "td_error",
+            "log_prob_key": "_log_prob",
+            "action_key": "action",
+            "state_action_value_key": "state_action_value",
+            "value_key": "state_value",
+        }
 
     @property
     def device(self) -> torch.device:

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -52,7 +52,7 @@ class IQLLoss(LossModule):
             maximum of the Q-function.
         expectile (float, optional): expectile :math:`\tau`. A larger value of :math:`\tau` is crucial
             for antmaze tasks that require dynamical programming ("stichting").
-        priority_key (str, optional): [Deprecated, use .set_keys() instead]
+        priority_key (str, optional): [Deprecated, use .set_keys(priority_key=priority_key) instead]
             tensordict key where to write the priority (for prioritized replay
             buffer usage). Default is `"td_error"`.
     """
@@ -257,7 +257,7 @@ class IQLLoss(LossModule):
         self.value_type = value_type
         value_net = self.value_network
 
-        value_key = "state_value"
+        value_key = self.value_key
         hp = dict(default_value_kwargs(value_type))
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -65,8 +65,7 @@ class PPOLoss(LossModule):
             Defaults to ``False``, ie. gradients are propagated to shared
             parameters for both policy and critic losses.
         advantage_key (str, optional): [Deprecated, use set_keys() instead] the input tensordict key where the advantage is
-            expected to be written.
-            Defaults to ``"advantage"``.
+            expected to be written. Defaults to ``"advantage"``.
         value_target_key (str, optional): [Deprecated, use set_keys() instead] the input tensordict key where the target state
             value is expected to be written. Defaults to ``"value_target"``.
         value_key (str, optional): [Deprecated, use set_keys() instead] the input tensordict key where the state

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -203,16 +203,16 @@ class PPOLoss(LossModule):
         self, tensordict: TensorDictBase
     ) -> Tuple[torch.Tensor, d.Distribution]:
         # current log_prob of actions
-        action = tensordict.get("action")
+        action = tensordict.get(self.action_key)
         if action.requires_grad:
-            raise RuntimeError("tensordict stored action requires grad.")
+            raise RuntimeError(f"tensordict stored {self.action_key} requires grad.")
 
         dist = self.actor.get_dist(tensordict, params=self.actor_params)
         log_prob = dist.log_prob(action)
 
-        prev_log_prob = tensordict.get("sample_log_prob")
+        prev_log_prob = tensordict.get(self.sample_log_prob_key)
         if prev_log_prob.requires_grad:
-            raise RuntimeError("tensordict prev_log_prob requires grad.")
+            raise RuntimeError(f"tensordict {self.sample_log_prob_key} requires grad.")
 
         log_weight = (log_prob - prev_log_prob).unsqueeze(-1)
         return log_weight, dist

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -127,22 +127,16 @@ class PPOLoss(LossModule):
         default values
 
         Attributes:
-        ------------
-        advantage : NestedKey
-            The input tensordict key where the advantage is expected.
-            Will be used for the underlying value estimator. Defaults to ``"advantage"``.
-        value_target : NestedKey
-            The input tensordict key where the target state value is expected.
-            Will be used for the underlying value estimator Defaults to ``"value_target"``.
-        value : NestedKey
-            The input tensordict key where the state value is expected.
-            Will be used for the underlying value estimator. Defaults to ``"state_value"``.
-        sample_log_prob : NestedKey
-            The input tensordict key where the sample log probability is expected.
-            Defaults to ``"sample_log_prob"``.
-        action : NestedKey
-            The input tensordict key where the action is expected.
-            Defaults to ``"action"``.
+            advantage (NestedKey): The input tensordict key where the advantage is expected.
+                Will be used for the underlying value estimator. Defaults to ``"advantage"``.
+            value_target (NestedKey): The input tensordict key where the target state value is expected.
+                Will be used for the underlying value estimator Defaults to ``"value_target"``.
+            value (NestedKey): The input tensordict key where the state value is expected.
+                Will be used for the underlying value estimator. Defaults to ``"state_value"``.
+            sample_log_prob (NestedKey): The input tensordict key where the sample log probability is expected.
+                Defaults to ``"sample_log_prob"``.
+            action (NestedKey): The input tensordict key where the action is expected.
+                Defaults to ``"action"``.
         """
 
         advantage: NestedKey = "advantage"

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -145,32 +145,19 @@ class PPOLoss(LossModule):
             policy_params = None
         self.convert_to_functional(critic, "critic", compare_against=policy_params)
 
-        self.tensordict_keys = {
+        tensordict_keys = {
             "advantage_key": "advantage",
             "value_target_key": "value_target",
             "value_key": "state_value",
             "sample_log_prob_key": "sample_log_prob",
             "action_key": "action",
         }
-        if advantage_key is not None:
-            warnings.warn(
-                "Setting 'advantage_key' via ctor is deprecated, use .set_keys(advantage_key='some_key') instead.",
-                category=DeprecationWarning,
-            )
-            self.tensordict_keys["advantage_key"] = advantage_key
-        if value_target_key is not None:
-            warnings.warn(
-                "Setting 'value_target_key' via ctor is deprecated, use .set_keys(value_target_key='some_key') instead.",
-                category=DeprecationWarning,
-            )
-            self.tensordict_keys["value_target_key"] = value_target_key
-        if value_key is not None:
-            warnings.warn(
-                "Setting 'value_key' via ctor is deprecated, use .set_keys(value_key='some_key') instead.",
-                category=DeprecationWarning,
-            )
-            self.tensordict_keys["value_key"] = value_key
-        self.set_keys(**self.tensordict_keys)
+        self._set_default_tensordict_keys(tensordict_keys)
+        self._set_deprecated_ctor_keys(
+            advantage_key=advantage_key,
+            value_target_key=value_target_key,
+            value_key=value_key,
+        )
 
         self.samples_mc_entropy = samples_mc_entropy
         self.entropy_bonus = entropy_bonus

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -207,9 +207,9 @@ class PPOLoss(LossModule):
     def _forward_value_estimator_keys(self, **kwargs) -> None:
         if self._value_estimator is not None:
             self._value_estimator.set_keys(
-                advantage_key=self._tensor_keys.advantage,
-                value_target_key=self._tensor_keys.value_target,
-                value_key=self._tensor_keys.value,
+                advantage=self._tensor_keys.advantage,
+                value_target=self._tensor_keys.value_target,
+                value=self._tensor_keys.value,
             )
 
     def reset(self) -> None:
@@ -316,29 +316,23 @@ class PPOLoss(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        tensor_keys = {
-            "advantage_key": self.tensor_keys.advantage,
-            "value_key": self.tensor_keys.value,
-            "value_target_key": self.tensor_keys.value_target,
-        }
         if value_type == ValueEstimators.TD1:
-            self._value_estimator = TD1Estimator(
-                value_network=self.critic, **hp, tensor_keys=tensor_keys
-            )
+            self._value_estimator = TD1Estimator(value_network=self.critic, **hp)
         elif value_type == ValueEstimators.TD0:
-            self._value_estimator = TD0Estimator(
-                value_network=self.critic, **hp, tensor_keys=tensor_keys
-            )
+            self._value_estimator = TD0Estimator(value_network=self.critic, **hp)
         elif value_type == ValueEstimators.GAE:
-            self._value_estimator = GAE(
-                value_network=self.critic, **hp, tensor_keys=tensor_keys
-            )
+            self._value_estimator = GAE(value_network=self.critic, **hp)
         elif value_type == ValueEstimators.TDLambda:
-            self._value_estimator = TDLambdaEstimator(
-                value_network=self.critic, **hp, tensor_keys=tensor_keys
-            )
+            self._value_estimator = TDLambdaEstimator(value_network=self.critic, **hp)
         else:
             raise NotImplementedError(f"Unknown value type {value_type}")
+
+        tensor_keys = {
+            "advantage": self.tensor_keys.advantage,
+            "value": self.tensor_keys.value,
+            "value_target": self.tensor_keys.value_target,
+        }
+        self._value_estimator.set_keys(**tensor_keys)
 
 
 class ClipPPOLoss(PPOLoss):

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -64,11 +64,14 @@ class PPOLoss(LossModule):
             policy and critic will only be trained on the policy loss.
             Defaults to ``False``, ie. gradients are propagated to shared
             parameters for both policy and critic losses.
-        advantage_key (str, optional): [Deprecated, use set_keys() instead] the input tensordict key where the advantage is
+        advantage_key (str, optional): [Deprecated, use set_keys(advantage_key=advantage_key) instead]
+            The input tensordict key where the advantage is
             expected to be written. Defaults to ``"advantage"``.
-        value_target_key (str, optional): [Deprecated, use set_keys() instead] the input tensordict key where the target state
+        value_target_key (str, optional): [Deprecated, use set_keys(value_target_key=value_target_key) instead]
+            The input tensordict key where the target state
             value is expected to be written. Defaults to ``"value_target"``.
-        value_key (str, optional): [Deprecated, use set_keys() instead] the input tensordict key where the state
+        value_key (str, optional): [Deprecated, use set_keys(value_key) instead]
+            The input tensordict key where the state
             value is expected to be written. Defaults to ``"state_value"``.
 
     .. note::

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -137,6 +137,13 @@ class PPOLoss(LossModule):
         value_key: str = None,
     ):
         super().__init__()
+
+        self._set_deprecated_ctor_keys(
+            advantage_key=advantage_key,
+            value_target_key=value_target_key,
+            value_key=value_key,
+        )
+
         self.convert_to_functional(
             actor, "actor", funs_to_decorate=["forward", "get_dist"]
         )
@@ -146,22 +153,8 @@ class PPOLoss(LossModule):
             policy_params = list(actor.parameters())
         else:
             policy_params = None
+
         self.convert_to_functional(critic, "critic", compare_against=policy_params)
-
-        tensordict_keys = {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "state_value",
-            "sample_log_prob_key": "sample_log_prob",
-            "action_key": "action",
-        }
-        self._set_default_tensordict_keys(tensordict_keys)
-        self._set_deprecated_ctor_keys(
-            advantage_key=advantage_key,
-            value_target_key=value_target_key,
-            value_key=value_key,
-        )
-
         self.samples_mc_entropy = samples_mc_entropy
         self.entropy_bonus = entropy_bonus
         self.separate_losses = separate_losses
@@ -176,6 +169,16 @@ class PPOLoss(LossModule):
         if gamma is not None:
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
+
+    @staticmethod
+    def default_tensordict_keys():
+        return {
+            "advantage_key": "advantage",
+            "value_target_key": "value_target",
+            "value_key": "state_value",
+            "sample_log_prob_key": "sample_log_prob",
+            "action_key": "action",
+        }
 
     def reset(self) -> None:
         pass

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -10,6 +10,7 @@ from typing import Tuple
 import torch
 from tensordict.nn import ProbabilisticTensorDictSequential, TensorDictModule
 from tensordict.tensordict import TensorDict, TensorDictBase
+from tensordict.utils import NestedKey
 from torch import distributions as d
 
 from torchrl.objectives.utils import (
@@ -120,14 +121,13 @@ class PPOLoss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        advantage_key: str = "advantage"
-        value_target_key: str = "value_target"
-        value_key: str = "state_value"
-        sample_log_prob_key: str = "sample_log_prob"
-        action_key: str = "action"
+        advantage_key: NestedKey = "advantage"
+        value_target_key: NestedKey = "value_target"
+        value_key: NestedKey = "state_value"
+        sample_log_prob_key: NestedKey = "sample_log_prob"
+        action_key: NestedKey = "action"
 
     default_keys = _AcceptedKeys()
-
     default_value_estimator = ValueEstimators.GAE
 
     @classmethod
@@ -187,10 +187,11 @@ class PPOLoss(LossModule):
             self.gamma = gamma
 
     @property
-    def tensor_keys(self):
+    def tensor_keys(self) -> _AcceptedKeys:
         return self._tensor_keys
 
-    def set_keys(self, **kwargs):
+    def set_keys(self, **kwargs) -> None:
+        """TODO"""
         for key, _ in kwargs.items():
             if key not in self._AcceptedKeys.__dict__:
                 raise ValueError(f"{key} it not an accepted tensordict key")
@@ -313,7 +314,6 @@ class PPOLoss(LossModule):
             "value_key": self.tensor_keys.value_key,
             "value_target_key": self.tensor_keys.value_target_key,
         }
-
         if value_type == ValueEstimators.TD1:
             self._value_estimator = TD1Estimator(**ve_args, **hp)
         elif value_type == ValueEstimators.TD0:

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -124,7 +124,7 @@ class PPOLoss(LossModule):
         """Stores default values for all configurable tensordict keys.
 
         This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and their default values.
+        via `.set_keys(key_name=key_value) and the corresponding default values.
 
         Attributes:
         ------------

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -130,11 +130,6 @@ class PPOLoss(LossModule):
     default_keys = _AcceptedKeys()
     default_value_estimator = ValueEstimators.GAE
 
-    @classmethod
-    def __new__(cls, *args, **kwargs):
-        cls._tensor_keys = cls._AcceptedKeys()
-        return super().__new__(cls)
-
     def __init__(
         self,
         actor: ProbabilisticTensorDictSequential,
@@ -185,20 +180,7 @@ class PPOLoss(LossModule):
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
 
-    @property
-    def tensor_keys(self) -> _AcceptedKeys:
-        return self._tensor_keys
-
-    def set_keys(self, **kwargs) -> None:
-        """TODO"""
-        for key, value in kwargs.items():
-            if key not in self._AcceptedKeys.__dict__:
-                raise ValueError(f"{key} it not an accepted tensordict key")
-            if value is not None:
-                setattr(self.tensor_keys, key, value)
-            else:
-                setattr(self.tensor_keys, key, self.default_keys.key)
-
+    def _forward_value_estimator_keys(self, **kwargs) -> None:
         if self._value_estimator is not None:
             self._value_estimator.set_keys(
                 advantage_key=self._tensor_keys.advantage_key,
@@ -316,13 +298,21 @@ class PPOLoss(LossModule):
             "value_target_key": self.tensor_keys.value_target_key,
         }
         if value_type == ValueEstimators.TD1:
-            self._value_estimator = TD1Estimator(value_network=self.critic, **hp, tensor_keys=tensor_keys)
+            self._value_estimator = TD1Estimator(
+                value_network=self.critic, **hp, tensor_keys=tensor_keys
+            )
         elif value_type == ValueEstimators.TD0:
-            self._value_estimator = TD0Estimator(value_network=self.critic, **hp, tensor_keys=tensor_keys)
+            self._value_estimator = TD0Estimator(
+                value_network=self.critic, **hp, tensor_keys=tensor_keys
+            )
         elif value_type == ValueEstimators.GAE:
-            self._value_estimator = GAE(value_network=self.critic, **hp, tensor_keys=tensor_keys)
+            self._value_estimator = GAE(
+                value_network=self.critic, **hp, tensor_keys=tensor_keys
+            )
         elif value_type == ValueEstimators.TDLambda:
-            self._value_estimator = TDLambdaEstimator(value_network=self.critic, **hp, tensor_keys=tensor_keys)
+            self._value_estimator = TDLambdaEstimator(
+                value_network=self.critic, **hp, tensor_keys=tensor_keys
+            )
         else:
             raise NotImplementedError(f"Unknown value type {value_type}")
 

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -138,6 +138,7 @@ class PPOLoss(LossModule):
     ):
         super().__init__()
 
+        self.set_keys()
         self._set_deprecated_ctor_keys(
             advantage_key=advantage_key,
             value_target_key=value_target_key,
@@ -170,15 +171,24 @@ class PPOLoss(LossModule):
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
 
-    @staticmethod
-    def default_loss_keys():
-        return {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "state_value",
-            "sample_log_prob_key": "sample_log_prob",
-            "action_key": "action",
-        }
+    def set_keys(
+        self,
+        advantage_key="advantage",
+        value_target_key="value_target",
+        value_key="state_value",
+        sample_log_prob_key="sample_log_prob",
+        action_key="action",
+    ):
+        self.advantage_key = advantage_key
+        self.value_target_key = value_target_key
+        self.value_key = value_key
+        self.sample_log_prob_key = sample_log_prob_key
+        self.action_key = action_key
+
+        if self._value_estimator is not None:
+            self._value_estimator.set_keys(
+                value_key=value_key,
+            )
 
     def reset(self) -> None:
         pass
@@ -195,7 +205,7 @@ class PPOLoss(LossModule):
         self, tensordict: TensorDictBase
     ) -> Tuple[torch.Tensor, d.Distribution]:
         # current log_prob of actions
-        action = tensordict.get(self.loss_key("action_key"))
+        action = tensordict.get(self.action_key)
         if action.requires_grad:
             raise RuntimeError(
                 f"tensordict stored {self.loss_key('action_key')} requires grad."
@@ -204,7 +214,7 @@ class PPOLoss(LossModule):
         dist = self.actor.get_dist(tensordict, params=self.actor_params)
         log_prob = dist.log_prob(action)
 
-        prev_log_prob = tensordict.get(self.loss_key("sample_log_prob_key"))
+        prev_log_prob = tensordict.get(self.sample_log_prob_key)
         if prev_log_prob.requires_grad:
             raise RuntimeError(
                 f"tensordict {self.loss_key('sample_log_prob_key')} requires grad."
@@ -219,7 +229,7 @@ class PPOLoss(LossModule):
         if self.separate_losses:
             tensordict = tensordict.detach()
         try:
-            target_return = tensordict.get(self.loss_key("value_target_key"))
+            target_return = tensordict.get(self.value_target_key)
         except KeyError:
             raise KeyError(
                 f"the key {self.loss_key('value_target_key')} was not found in the input tensordict. "
@@ -235,7 +245,7 @@ class PPOLoss(LossModule):
         )
 
         try:
-            state_value = state_value_td.get(self.loss_key("value_key"))
+            state_value = state_value_td.get(self.value_key)
         except KeyError:
             raise KeyError(
                 f"the key {self.loss_key('value_key')} was not found in the input tensordict. "
@@ -251,14 +261,14 @@ class PPOLoss(LossModule):
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         tensordict = tensordict.clone(False)
-        advantage = tensordict.get(self.loss_key("advantage_key"), None)
+        advantage = tensordict.get(self.advantage_key, None)
         if advantage is None:
             self.value_estimator(
                 tensordict,
                 params=self.critic_params.detach(),
                 target_params=self.target_critic_params,
             )
-            advantage = tensordict.get(self.loss_key("advantage_key"))
+            advantage = tensordict.get(self.advantage_key)
         if self.normalize_advantage and advantage.numel() > 1:
             loc = advantage.mean().item()
             scale = advantage.std().clamp_min(1e-6).item()
@@ -284,7 +294,7 @@ class PPOLoss(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        value_key = self.loss_key("value_key")
+        value_key = self.value_key
         if value_type == ValueEstimators.TD1:
             self._value_estimator = TD1Estimator(
                 value_network=self.critic, value_key=value_key, **hp
@@ -431,14 +441,14 @@ class ClipPPOLoss(PPOLoss):
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         tensordict = tensordict.clone(False)
-        advantage = tensordict.get(self.loss_key("advantage_key"), None)
+        advantage = tensordict.get(self.advantage_key, None)
         if advantage is None:
             self.value_estimator(
                 tensordict,
                 params=self.critic_params.detach(),
                 target_params=self.target_critic_params,
             )
-            advantage = tensordict.get(self.loss_key("advantage_key"))
+            advantage = tensordict.get(self.advantage_key)
         if self.normalize_advantage and advantage.numel() > 1:
             loc = advantage.mean().item()
             scale = advantage.std().clamp_min(1e-6).item()
@@ -626,14 +636,14 @@ class KLPENPPOLoss(PPOLoss):
 
     def forward(self, tensordict: TensorDictBase) -> TensorDict:
         tensordict = tensordict.clone(False)
-        advantage = tensordict.get(self.loss_key("advantage_key"), None)
+        advantage = tensordict.get(self.advantage_key, None)
         if advantage is None:
             self.value_estimator(
                 tensordict,
                 params=self.critic_params.detach(),
                 target_params=self.target_critic_params,
             )
-            advantage = tensordict.get(self.loss_key("advantage_key"))
+            advantage = tensordict.get(self.advantage_key)
         if self.normalize_advantage and advantage.numel() > 1:
             loc = advantage.mean().item()
             scale = advantage.std().clamp_min(1e-6).item()

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -121,10 +121,10 @@ class PPOLoss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and the corresponding default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values
 
         Attributes:
         ------------

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -133,8 +133,8 @@ class PPOLoss(LossModule):
                 Will be used for the underlying value estimator Defaults to ``"value_target"``.
             value (NestedKey): The input tensordict key where the state value is expected.
                 Will be used for the underlying value estimator. Defaults to ``"state_value"``.
-            sample_log_prob (NestedKey): The input tensordict key where the sample log probability is expected.
-                Defaults to ``"sample_log_prob"``.
+            sample_log_prob (NestedKey): The input tensordict key where the
+               sample log probability is expected.  Defaults to ``"sample_log_prob"``.
             action (NestedKey): The input tensordict key where the action is expected.
                 Defaults to ``"action"``.
         """

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -139,10 +139,10 @@ class PPOLoss(LossModule):
             Will be used for the underlying value estimator. Defaults to ``"state_value"``.
         sample_log_prob : NestedKey
             The input tensordict key where the sample log probability is expected.
-            Defaults to ``"state_value"``.
+            Defaults to ``"sample_log_prob"``.
         action : NestedKey
             The input tensordict key where the action is expected.
-            Defaults to ``"state_value"``.
+            Defaults to ``"action"``.
         """
 
         advantage: NestedKey = "advantage"
@@ -187,7 +187,6 @@ class PPOLoss(LossModule):
             policy_params = list(actor.parameters())
         else:
             policy_params = None
-
         self.convert_to_functional(critic, "critic", compare_against=policy_params)
         self.samples_mc_entropy = samples_mc_entropy
         self.entropy_bonus = entropy_bonus
@@ -238,9 +237,7 @@ class PPOLoss(LossModule):
 
         prev_log_prob = tensordict.get(self.tensor_keys.sample_log_prob)
         if prev_log_prob.requires_grad:
-            raise RuntimeError(
-                f"tensordict {self.tensor_keys.sample_log_prob} requires grad."
-            )
+            raise RuntimeError("tensordict prev_log_prob requires grad.")
 
         log_weight = (log_prob - prev_log_prob).unsqueeze(-1)
         return log_weight, dist

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -82,10 +82,10 @@ class REDQLoss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and the corresponding default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values
 
         Attributes:
         ------------

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -88,18 +88,12 @@ class REDQLoss(LossModule):
         default values
 
         Attributes:
-        ------------
-        value : NestedKey
-            The input tensordict key where the state value is expected.
-            Will be used for the underlying value estimator. Defaults to ``"state_value"``.
-        action : NestedKey
-            The input tensordict key where the action is expected. Defaults to ``"action"``.
-        sample_log_prob : NestedKey
-            The input tensordict key where the sample log probability is expected. Defaults to ``"sample_log_prob"``.
-        priority : NestedKey
-            The input tensordict key where the target priority is written to. Defaults to ``"td_error"``.
-        state_action_value : NestedKey
-            The input tensordict key where the state action value is expected. Defaults to ``"state_action_value"``.
+            value (NestedKey): The input tensordict key where the state value is expected.
+                Will be used for the underlying value estimator. Defaults to ``"state_value"``.
+            action (NestedKey): The input tensordict key where the action is expected. Defaults to ``"action"``.
+            sample_log_prob (NestedKey): The input tensordict key where the sample log probability is expected. Defaults to ``"sample_log_prob"``.
+            priority (NestedKey): The input tensordict key where the target priority is written to. Defaults to ``"td_error"``.
+            state_action_value (NestedKey): The input tensordict key where the state action value is expected. Defaults to ``"state_action_value"``.
         """
 
         action: NestedKey = "action"

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -350,7 +350,7 @@ class REDQLoss(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        value_key = "state_value"
+        value_key = self.value_key
         # we do not need a value network bc the next state value is already passed
         if value_type == ValueEstimators.TD1:
             self._value_estimator = TD1Estimator(

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -85,7 +85,7 @@ class REDQLoss(LossModule):
         """Stores default values for all configurable tensordict keys.
 
         This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and their default values.
+        via `.set_keys(key_name=key_value) and the corresponding default values.
 
         Attributes:
         ------------

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -202,7 +202,7 @@ class REDQLoss(LossModule):
     def _forward_value_estimator_keys(self, **kwargs) -> None:
         if self._value_estimator is not None:
             self._value_estimator.set_keys(
-                value_key=self._tensor_keys.value,
+                value=self._tensor_keys.value,
             )
 
     @property
@@ -384,23 +384,19 @@ class REDQLoss(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        tensor_keys = {"value_key": self.tensor_keys.value}
         # we do not need a value network bc the next state value is already passed
         if value_type == ValueEstimators.TD1:
-            self._value_estimator = TD1Estimator(
-                value_network=None, tensor_keys=tensor_keys, **hp
-            )
+            self._value_estimator = TD1Estimator(value_network=None, **hp)
         elif value_type == ValueEstimators.TD0:
-            self._value_estimator = TD0Estimator(
-                value_network=None, tensor_keys=tensor_keys, **hp
-            )
+            self._value_estimator = TD0Estimator(value_network=None, **hp)
         elif value_type == ValueEstimators.GAE:
             raise NotImplementedError(
                 f"Value type {value_type} it not implemented for loss {type(self)}."
             )
         elif value_type == ValueEstimators.TDLambda:
-            self._value_estimator = TDLambdaEstimator(
-                value_network=None, tensor_keys=tensor_keys, **hp
-            )
+            self._value_estimator = TDLambdaEstimator(value_network=None, **hp)
         else:
             raise NotImplementedError(f"Unknown value type {value_type}")
+
+        tensor_keys = {"value": self.tensor_keys.value}
+        self._value_estimator.set_keys(**tensor_keys)

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -104,20 +104,15 @@ class REDQLoss(LossModule):
 
         super().__init__()
 
-        self.tensordict_keys = {
+        tensordict_keys = {
             "priority_key": "td_error",
             "action_key": "action",
             "value_key": "state_value",
             "sample_log_prob_key": "sample_log_prob",
             "state_action_value_key": "state_action_value",
         }
-        if priority_key is not None:
-            warnings.warn(
-                "Setting 'priority_key' via ctor is deprecated, use .set_keys(priotity_key='some_key') instead.",
-                category=DeprecationWarning,
-            )
-            self.tensordict_keys["priority_key"] = priority_key
-        self.set_keys(**self.tensordict_keys)
+        self._set_default_tensordict_keys(tensordict_keys)
+        self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         self.convert_to_functional(
             actor_network,

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -91,9 +91,12 @@ class REDQLoss(LossModule):
             value (NestedKey): The input tensordict key where the state value is expected.
                 Will be used for the underlying value estimator. Defaults to ``"state_value"``.
             action (NestedKey): The input tensordict key where the action is expected. Defaults to ``"action"``.
-            sample_log_prob (NestedKey): The input tensordict key where the sample log probability is expected. Defaults to ``"sample_log_prob"``.
-            priority (NestedKey): The input tensordict key where the target priority is written to. Defaults to ``"td_error"``.
-            state_action_value (NestedKey): The input tensordict key where the state action value is expected. Defaults to ``"state_action_value"``.
+            sample_log_prob (NestedKey): The input tensordict key where the
+                sample log probability is expected. Defaults to ``"sample_log_prob"``.
+            priority (NestedKey): The input tensordict key where the target
+                priority is written to. Defaults to ``"td_error"``.
+            state_action_value (NestedKey): The input tensordict key where the
+                state action value is expected. Defaults to ``"state_action_value"``.
         """
 
         action: NestedKey = "action"

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -103,15 +103,6 @@ class REDQLoss(LossModule):
             raise ImportError("Failed to import functorch.") from FUNCTORCH_ERR
 
         super().__init__()
-
-        tensordict_keys = {
-            "priority_key": "td_error",
-            "action_key": "action",
-            "value_key": "state_value",
-            "sample_log_prob_key": "sample_log_prob",
-            "state_action_value_key": "state_action_value",
-        }
-        self._set_default_tensordict_keys(tensordict_keys)
         self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         self.convert_to_functional(
@@ -174,6 +165,16 @@ class REDQLoss(LossModule):
         if gamma is not None:
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
+
+    @staticmethod
+    def default_tensordict_keys():
+        return {
+            "priority_key": "td_error",
+            "action_key": "action",
+            "value_key": "state_value",
+            "sample_log_prob_key": "sample_log_prob",
+            "state_action_value_key": "state_action_value",
+        }
 
     @property
     def alpha(self):

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -33,10 +33,11 @@ class ReinforceLoss(LossModule):
             for the critic. Defaults to ``False``.
         loss_critic_type (str): loss function for the value discrepancy.
             Can be one of "l1", "l2" or "smooth_l1". Defaults to ``"smooth_l1"``.
-        advantage_key (str): [Deprecated, use .set_keys() instead] the input tensordict key where the advantage is
-            expected to be written.
+        advantage_key (str): [Deprecated, use .set_keys(advantage_key=advantage_key) instead]
+            The input tensordict key where the advantage is expected to be written.
             Defaults to ``"advantage"``.
-        value_target_key (str): [Deprecated, use .set_keys() instead] the input tensordict key where the target state
+        value_target_key (str): [Deprecated, use .set_keys(value_target_key=value_target_key) instead]
+            The input tensordict key where the target state
             value is expected to be written. Defaults to ``"value_target"``.
 
     .. note:
@@ -170,7 +171,7 @@ class ReinforceLoss(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        value_key = "state_value"
+        value_key = self.value_key
         if value_type == ValueEstimators.TD1:
             self._value_estimator = TD1Estimator(
                 value_network=self.critic, value_key=value_key, **hp

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -81,25 +81,16 @@ class ReinforceLoss(LossModule):
     ) -> None:
         super().__init__()
 
-        self.tensordict_keys = {
+        tensordict_keys = {
             "advantage_key": "advantage",
             "value_target_key": "value_target",
             "value_key": "state_value",
             "sample_log_prob_key": "sample_log_prob",
         }
-        if advantage_key is not None:
-            warnings.warn(
-                "Setting 'advantage_key' via ctor is deprecated, use .set_keys(advantage_key='some_key') instead.",
-                category=DeprecationWarning,
-            )
-            self.tensordict_keys["advantage_key"] = advantage_key
-        if value_target_key is not None:
-            warnings.warn(
-                "Setting 'value_target_key' via ctor is deprecated, use .set_keys(value_target_key='some_key') instead.",
-                category=DeprecationWarning,
-            )
-            self.tensordict_keys["value_target_key"] = value_target_key
-        self.set_keys(**self.tensordict_keys)
+        self._set_default_tensordict_keys(tensordict_keys)
+        self._set_deprecated_ctor_keys(
+            advantage_key=advantage_key, value_target_key=value_target_key
+        )
 
         self.delay_value = delay_value
         self.loss_critic_type = loss_critic_type

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -77,19 +77,14 @@ class ReinforceLoss(LossModule):
         default values.
 
         Attributes:
-        ------------
-        advantage : NestedKey
-            The input tensordict key where the advantage is expected.
-            Will be used for the underlying value estimator. Defaults to ``"advantage"``.
-        value_target : NestedKey
-            The input tensordict key where the target state value is expected.
-            Will be used for the underlying value estimator Defaults to ``"value_target"``.
-        value : NestedKey
-            The input tensordict key where the state value is expected.
-            Will be used for the underlying value estimator. Defaults to ``"state_value"``.
-        sample_log_prob : NestedKey
-            The input tensordict key where the sample log probability is expected.
-            Defaults to ``"sample_log_prob"``.
+            advantage (NestedKey): he input tensordict key where the advantage is expected.
+                Will be used for the underlying value estimator. Defaults to ``"advantage"``.
+            value_target (NestedKey): The input tensordict key where the target state value is expected.
+                Will be used for the underlying value estimator Defaults to ``"value_target"``.
+            value (NestedKey): The input tensordict key where the state value is expected.
+                Will be used for the underlying value estimator. Defaults to ``"state_value"``.
+            sample_log_prob (NestedKey): The input tensordict key where the sample log probability is expected.
+                Defaults to ``"sample_log_prob"``.
         """
 
         advantage: NestedKey = "advantage"

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -122,17 +122,7 @@ class ReinforceLoss(LossModule):
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
 
-    @property
-    def tensor_keys(self) -> _AcceptedKeys:
-        return self._tensor_keys
-
-    def set_keys(self, **kwargs) -> None:
-        """TODO"""
-        for key, _ in kwargs.items():
-            if key not in self._AcceptedKeys.__dict__:
-                raise ValueError(f"{key} it not an accepted tensordict key")
-        self._tensor_keys = self._AcceptedKeys(**kwargs)
-
+    def _forward_value_estimator_keys(self, **kwargs) -> None:
         if self._value_estimator is not None:
             self._value_estimator.set_keys(
                 advantage_key=self._tensor_keys.advantage_key,
@@ -196,19 +186,26 @@ class ReinforceLoss(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        ve_args = {
-            "value_network": self.critic,
+        tensor_keys = {
             "advantage_key": self.tensor_keys.advantage_key,
             "value_key": self.tensor_keys.value_key,
             "value_target_key": self.tensor_keys.value_target_key,
         }
         if value_type == ValueEstimators.TD1:
-            self._value_estimator = TD1Estimator(**ve_args, **hp)
+            self._value_estimator = TD1Estimator(
+                value_network=self.critic, tensor_keys=tensor_keys, **hp
+            )
         elif value_type == ValueEstimators.TD0:
-            self._value_estimator = TD0Estimator(**ve_args, **hp)
+            self._value_estimator = TD0Estimator(
+                value_network=self.critic, tensor_keys=tensor_keys, **hp
+            )
         elif value_type == ValueEstimators.GAE:
-            self._value_estimator = GAE(**ve_args, **hp)
+            self._value_estimator = GAE(
+                value_network=self.critic, tensor_keys=tensor_keys, **hp
+            )
         elif value_type == ValueEstimators.TDLambda:
-            self._value_estimator = TDLambdaEstimator(**ve_args, **hp)
+            self._value_estimator = TDLambdaEstimator(
+                value_network=self.critic, tensor_keys=tensor_keys, **hp
+            )
         else:
             raise NotImplementedError(f"Unknown value type {value_type}")

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -81,14 +81,6 @@ class ReinforceLoss(LossModule):
         value_target_key: str = None,
     ) -> None:
         super().__init__()
-
-        tensordict_keys = {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "state_value",
-            "sample_log_prob_key": "sample_log_prob",
-        }
-        self._set_default_tensordict_keys(tensordict_keys)
         self._set_deprecated_ctor_keys(
             advantage_key=advantage_key, value_target_key=value_target_key
         )
@@ -114,6 +106,15 @@ class ReinforceLoss(LossModule):
         if gamma is not None:
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
+
+    @staticmethod
+    def default_tensordict_keys():
+        return {
+            "advantage_key": "advantage",
+            "value_target_key": "value_target",
+            "value_key": "state_value",
+            "sample_log_prob_key": "sample_log_prob",
+        }
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         advantage = tensordict.get(self.advantage_key, None)

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -74,7 +74,7 @@ class ReinforceLoss(LossModule):
         """Stores default values for all configurable tensordict keys.
 
         This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and their default values.
+        via `.set_keys(key_name=key_value) and the corresponding default values.
 
         Attributes:
         ------------

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -71,10 +71,10 @@ class ReinforceLoss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and the corresponding default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values.
 
         Attributes:
         ------------

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -81,6 +81,7 @@ class ReinforceLoss(LossModule):
         value_target_key: str = None,
     ) -> None:
         super().__init__()
+        self.set_keys()
         self._set_deprecated_ctor_keys(
             advantage_key=advantage_key, value_target_key=value_target_key
         )
@@ -107,24 +108,32 @@ class ReinforceLoss(LossModule):
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
 
-    @staticmethod
-    def default_loss_keys():
-        return {
-            "advantage_key": "advantage",
-            "value_target_key": "value_target",
-            "value_key": "state_value",
-            "sample_log_prob_key": "sample_log_prob",
-        }
+    def set_keys(
+        self,
+        advantage_key="advantage",
+        value_target_key="value_target",
+        value_key="state_value",
+        sample_log_prob_key="sample_log_prob",
+    ):
+        self.advantage_key = advantage_key
+        self.value_target_key = value_target_key
+        self.value_key = value_key
+        self.sample_log_prob_key = sample_log_prob_key
+
+        if self._value_estimator is not None:
+            self._value_estimator.set_keys(
+                value_key=value_key,
+            )
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
-        advantage = tensordict.get(self.loss_key("advantage_key"), None)
+        advantage = tensordict.get(self.advantage_key, None)
         if advantage is None:
             self.value_estimator(
                 tensordict,
                 params=self.critic_params.detach(),
                 target_params=self.target_critic_params,
             )
-            advantage = tensordict.get(self.loss_key("advantage_key"))
+            advantage = tensordict.get(self.advantage_key)
 
         # compute log-prob
         tensordict = self.actor_network(
@@ -132,7 +141,7 @@ class ReinforceLoss(LossModule):
             params=self.actor_network_params,
         )
 
-        log_prob = tensordict.get(self.loss_key("sample_log_prob_key"))
+        log_prob = tensordict.get(self.sample_log_prob_key)
         loss_actor = -log_prob * advantage.detach()
         loss_actor = loss_actor.mean()
         td_out = TensorDict({"loss_actor": loss_actor}, [])
@@ -143,12 +152,12 @@ class ReinforceLoss(LossModule):
 
     def loss_critic(self, tensordict: TensorDictBase) -> torch.Tensor:
         try:
-            target_return = tensordict.get(self.loss_key("value_target_key"))
+            target_return = tensordict.get(self.value_target_key)
             tensordict_select = tensordict.select(*self.critic.in_keys)
             state_value = self.critic(
                 tensordict_select,
                 params=self.critic_params,
-            ).get(self.loss_key("value_key"))
+            ).get(self.value_key)
             loss_value = distance_loss(
                 target_return,
                 state_value,
@@ -172,7 +181,7 @@ class ReinforceLoss(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        value_key = self.loss_key("value_key")
+        value_key = self.value_key
         if value_type == ValueEstimators.TD1:
             self._value_estimator = TD1Estimator(
                 value_network=self.critic, value_key=value_key, **hp

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -83,9 +83,9 @@ class SACLoss(LossModule):
         delay_value (bool, optional): Whether to separate the target value
             networks from the value networks used for data collection.
             Default is ``False``.
-        priority_key (str, optional): [Deprecated, use .set_keys() instead] tensordict key where to write the
-            priority (for prioritized replay buffer usage). Defaults to
-            ``"td_error"``.
+        priority_key (str, optional): [Deprecated, use .set_keys(priority_key=priority_key) instead]
+            Tensordict key where to write the
+            priority (for prioritized replay buffer usage). Defaults to ``"td_error"``.
     """
 
     default_value_estimator = ValueEstimators.TD0
@@ -507,8 +507,8 @@ class DiscreteSACLoss(LossModule):
         target_entropy (Union[str, Number], optional): Target entropy for the stochastic policy. Default is "auto".
         delay_qvalue (bool, optional): Whether to separate the target Q value networks from the Q value networks used
             for data collection. Default is ``False``.
-        priority_key (str, optional): [Deprecated, use .set_keys() instead] Key
-            where to write the priority value for prioritized replay buffers.
+        priority_key (str, optional): [Deprecated, use .set_keys(priority_key=priority_key) instead]
+            Key where to write the priority value for prioritized replay buffers.
             Default is `"td_error"`.
 
     """

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -114,7 +114,7 @@ class SACLoss(LossModule):
         super().__init__()
         tensordict_keys = {
             "priority_key": "td_error",
-            "state_value_key": "state_value",
+            "value_key": "state_value",
             "state_action_value_key": "state_action_value",
             "action_key": "action",
             "sample_log_prob_key": "sample_log_prob",
@@ -438,7 +438,7 @@ class SACLoss(LossModule):
             td_copy,
             params=self.value_network_params,
         )
-        pred_val = td_copy.get(self.state_value_key).squeeze(-1)
+        pred_val = td_copy.get(self.value_key).squeeze(-1)
 
         action_dist = self.actor_network.get_dist(
             td_copy,
@@ -538,7 +538,7 @@ class DiscreteSACLoss(LossModule):
         super().__init__()
         tensordict_keys = {
             "priority_key": "td_error",
-            "state_value_key": "state_value",
+            "value_key": "state_value",
             "action_key": "action",
         }
         self._set_default_tensordict_keys(tensordict_keys)
@@ -675,7 +675,7 @@ class DiscreteSACLoss(LossModule):
             qvalue_params,
         )
 
-        state_action_value = tensordict_qval.get(self.state_value_key).squeeze(-1)
+        state_action_value = tensordict_qval.get(self.value_key).squeeze(-1)
         (
             state_action_value_actor,
             next_state_action_value_qvalue,

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -112,7 +112,7 @@ class SACLoss(LossModule):
         if not _has_functorch:
             raise ImportError("Failed to import functorch.") from FUNCTORCH_ERROR
         super().__init__()
-        self.tensordict_keys = {
+        tensordict_keys = {
             "priority_key": "td_error",
             "state_value_key": "state_value",
             "state_action_value_key": "state_action_value",
@@ -120,13 +120,8 @@ class SACLoss(LossModule):
             "sample_log_prob_key": "sample_log_prob",
             "log_prob_key": "_log_prob",
         }
-        if priority_key is not None:
-            warnings.warn(
-                "Setting 'priority_key' via ctor is deprecated, use .set_keys(priotity_key='some_key') instead.",
-                category=DeprecationWarning,
-            )
-            self.tensordict_keys["priority_key"] = priority_key
-        self.set_keys(**self.tensordict_keys)
+        self._set_default_tensordict_keys(tensordict_keys)
+        self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         # Actor
         self.delay_actor = delay_actor
@@ -312,7 +307,7 @@ class SACLoss(LossModule):
         log_prob = dist.log_prob(a_reparm)
 
         td_q = tensordict.select(*self.qvalue_network.in_keys)
-        td_q.set("action", a_reparm)
+        td_q.set(self.action_key, a_reparm)
         td_q = vmap(self.qvalue_network, (None, 0))(
             td_q, self.target_qvalue_network_params
         )
@@ -541,18 +536,13 @@ class DiscreteSACLoss(LossModule):
         if not _has_functorch:
             raise ImportError("Failed to import functorch.") from FUNCTORCH_ERROR
         super().__init__()
-        self.tensordict_keys = {
+        tensordict_keys = {
             "priority_key": "td_error",
             "state_value_key": "state_value",
             "action_key": "action",
         }
-        if priority_key is not None:
-            warnings.warn(
-                "Setting 'priority_key' via ctor is deprecated, use .set_keys(priotity_key='some_key') instead.",
-                category=DeprecationWarning,
-            )
-            self.tensordict_keys["priority_key"] = priority_key
-        self.set_keys(**self.tensordict_keys)
+        self._set_default_tensordict_keys(tensordict_keys)
+        self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         self.convert_to_functional(
             actor_network,

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -95,7 +95,7 @@ class SACLoss(LossModule):
         """Stores default values for all configurable tensordict keys.
 
         This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and their default values.
+        via `.set_keys(key_name=key_value) and the corresponding default values.
 
         Attributes:
         ------------
@@ -555,7 +555,7 @@ class DiscreteSACLoss(LossModule):
         """Stores default values for all configurable tensordict keys.
 
         This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and their default values.
+        via `.set_keys(key_name=key_value) and the corresponding default values.
 
         Attributes:
         ------------

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -92,10 +92,10 @@ class SACLoss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and the corresponding default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values.
 
         Attributes:
         ------------
@@ -552,10 +552,10 @@ class DiscreteSACLoss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and the corresponding default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values
 
         Attributes:
         ------------

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 import math
 import warnings
+from dataclasses import dataclass
 from numbers import Number
 from typing import Optional, Tuple, Union
 
@@ -11,6 +12,7 @@ import numpy as np
 import torch
 from tensordict.nn import make_functional, TensorDictModule
 from tensordict.tensordict import TensorDict, TensorDictBase
+from tensordict.utils import NestedKey
 from torch import Tensor
 
 from torchrl.envs.utils import ExplorationType, set_exploration_type, step_mdp
@@ -88,7 +90,22 @@ class SACLoss(LossModule):
             priority (for prioritized replay buffer usage). Defaults to ``"td_error"``.
     """
 
+    @dataclass
+    class _AcceptedKeys:
+        priority_key: NestedKey = "td_error"
+        action_key: NestedKey = "action"
+        value_key: NestedKey = "state_value"
+        state_action_value_key: NestedKey = "state_action_value"
+        sample_log_prob_key: NestedKey = "sample_log_prob"
+        log_prob_key: NestedKey = "_log_prob"
+
+    default_keys = _AcceptedKeys()
     default_value_estimator = ValueEstimators.TD0
+
+    @classmethod
+    def __new__(cls, *args, **kwargs):
+        cls._tensor_keys = cls._AcceptedKeys()
+        return super().__new__(cls)
 
     def __init__(
         self,
@@ -112,7 +129,6 @@ class SACLoss(LossModule):
         if not _has_functorch:
             raise ImportError("Failed to import functorch.") from FUNCTORCH_ERROR
         super().__init__()
-        self.set_keys()
         self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         # Actor
@@ -195,21 +211,21 @@ class SACLoss(LossModule):
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
 
-    def set_keys(
-        self,
-        priority_key="td_error",
-        action_key="action",
-        value_key="state_value",
-        sample_log_prob_key="sample_log_prob",
-        state_action_value_key="state_action_value",
-        log_prob_key="_log_prob",
-    ):
-        self.priority_key = priority_key
-        self.action_key = action_key
-        self.state_action_value_key = state_action_value_key
-        self.value_key = value_key
-        self.sample_log_prob_key = sample_log_prob_key
-        self.log_prob_key = log_prob_key
+    @property
+    def tensor_keys(self) -> _AcceptedKeys:
+        return self._tensor_keys
+
+    def set_keys(self, **kwargs) -> None:
+        """TODO"""
+        for key, _ in kwargs.items():
+            if key not in self._AcceptedKeys.__dict__:
+                raise ValueError(f"{key} it not an accepted tensordict key")
+        self._tensor_keys = self._AcceptedKeys(**kwargs)
+
+        if self._value_estimator is not None:
+            self._value_estimator.set_keys(
+                value_key=self._tensor_keys.value_key,
+            )
 
     def make_value_estimator(self, value_type: ValueEstimators = None, **hyperparams):
         if value_type is None:
@@ -224,7 +240,7 @@ class SACLoss(LossModule):
             # unreachable
             raise NotImplementedError
 
-        value_key = "state_value"
+        value_key = self.tensor_keys.value_key
         hp = dict(default_value_kwargs(value_type))
         hp.update(hyperparams)
         if value_type is ValueEstimators.TD1:
@@ -282,7 +298,7 @@ class SACLoss(LossModule):
             loss_qvalue, priority = self._loss_qvalue_v2(td_device)
             loss_value = None
         loss_alpha = self._loss_alpha(td_device)
-        tensordict_reshape.set(self.priority_key, priority)
+        tensordict_reshape.set(self.tensor_keys.priority_key, priority)
         if (loss_actor.shape != loss_qvalue.shape) or (
             loss_value is not None and loss_actor.shape != loss_value.shape
         ):
@@ -296,7 +312,7 @@ class SACLoss(LossModule):
             "loss_qvalue": loss_qvalue.mean(),
             "loss_alpha": loss_alpha.mean(),
             "alpha": self._alpha,
-            "entropy": -td_device.get(self.log_prob_key).mean().detach(),
+            "entropy": -td_device.get(self.tensor_keys.log_prob_key).mean().detach(),
         }
         if self._version == 1:
             out["loss_value"] = loss_value.mean()
@@ -315,11 +331,13 @@ class SACLoss(LossModule):
         log_prob = dist.log_prob(a_reparm)
 
         td_q = tensordict.select(*self.qvalue_network.in_keys)
-        td_q.set(self.action_key, a_reparm)
+        td_q.set(self.tensor_keys.action_key, a_reparm)
         td_q = vmap(self.qvalue_network, (None, 0))(
             td_q, self.target_qvalue_network_params
         )
-        min_q_logprob = td_q.get(self.state_action_value_key).min(0)[0].squeeze(-1)
+        min_q_logprob = (
+            td_q.get(self.tensor_keys.state_action_value_key).min(0)[0].squeeze(-1)
+        )
 
         if log_prob.shape != min_q_logprob.shape:
             raise RuntimeError(
@@ -327,7 +345,7 @@ class SACLoss(LossModule):
             )
 
         # write log_prob in tensordict for alpha loss
-        tensordict.set(self.log_prob_key, log_prob.detach())
+        tensordict.set(self.tensor_keys.log_prob_key, log_prob.detach())
         return self._alpha * log_prob - min_q_logprob
 
     def _loss_qvalue_v1(self, tensordict: TensorDictBase) -> Tuple[Tensor, Tensor]:
@@ -366,7 +384,9 @@ class SACLoss(LossModule):
         tensordict_chunks = vmap(qvalue_network)(
             tensordict_chunks, self.qvalue_network_params
         )
-        pred_val = tensordict_chunks.get(self.state_action_value_key).squeeze(-1)
+        pred_val = tensordict_chunks.get(
+            self.tensor_keys.state_action_value_key
+        ).squeeze(-1)
         loss_value = distance_loss(
             pred_val, target_chunks, loss_function=self.loss_function
         ).view(*shape)
@@ -392,16 +412,18 @@ class SACLoss(LossModule):
             with set_exploration_type(ExplorationType.RANDOM):
                 next_tensordict = step_mdp(tensordict)
                 dist = self.actor_network.get_dist(next_tensordict, params=actor_params)
-                next_tensordict.set(self.action_key, dist.rsample())
-                log_prob = dist.log_prob(tensordict.get(self.action_key))
-                next_tensordict.set(self.sample_log_prob_key, log_prob)
-            sample_log_prob = next_tensordict.get(self.sample_log_prob_key)
+                next_tensordict.set(self.tensor_keys.action_key, dist.rsample())
+                log_prob = dist.log_prob(tensordict.get(self.tensor_keys.action_key))
+                next_tensordict.set(self.tensor_keys.sample_log_prob_key, log_prob)
+            sample_log_prob = next_tensordict.get(self.tensor_keys.sample_log_prob_key)
 
             # get q-values
             next_tensordict_expand = vmap(self.qvalue_network, (None, 0))(
                 next_tensordict, qval_params
             )
-            state_action_value = next_tensordict_expand.get(self.state_action_value_key)
+            state_action_value = next_tensordict_expand.get(
+                self.tensor_keys.state_action_value_key
+            )
             if (
                 state_action_value.shape[-len(sample_log_prob.shape) :]
                 != sample_log_prob.shape
@@ -426,7 +448,9 @@ class SACLoss(LossModule):
             tensordict.select(*self.qvalue_network.in_keys),
             self.qvalue_network_params,
         )
-        pred_val = tensordict_expand.get(self.state_action_value_key).squeeze(-1)
+        pred_val = tensordict_expand.get(
+            self.tensor_keys.state_action_value_key
+        ).squeeze(-1)
         td_error = abs(pred_val - target_value)
         loss_qval = distance_loss(
             pred_val,
@@ -442,7 +466,7 @@ class SACLoss(LossModule):
             td_copy,
             params=self.value_network_params,
         )
-        pred_val = td_copy.get(self.value_key).squeeze(-1)
+        pred_val = td_copy.get(self.tensor_keys.value_key).squeeze(-1)
 
         action_dist = self.actor_network.get_dist(
             td_copy,
@@ -450,7 +474,7 @@ class SACLoss(LossModule):
         )  # resample an action
         action = action_dist.rsample()
 
-        td_copy.set(self.action_key, action, inplace=False)
+        td_copy.set(self.tensor_keys.action_key, action, inplace=False)
 
         qval_net = self.qvalue_network
         td_copy = vmap(qval_net, (None, 0))(
@@ -458,7 +482,9 @@ class SACLoss(LossModule):
             self.target_qvalue_network_params,
         )
 
-        min_qval = td_copy.get(self.state_action_value_key).squeeze(-1).min(0)[0]
+        min_qval = (
+            td_copy.get(self.tensor_keys.state_action_value_key).squeeze(-1).min(0)[0]
+        )
 
         log_p = action_dist.log_prob(action)
         if log_p.shape != min_qval.shape:
@@ -473,7 +499,7 @@ class SACLoss(LossModule):
         return loss_value
 
     def _loss_alpha(self, tensordict: TensorDictBase) -> Tensor:
-        log_pi = tensordict.get(self.log_prob_key)
+        log_pi = tensordict.get(self.tensor_keys.log_prob_key)
         if self.target_entropy is not None:
             # we can compute this loss even if log_alpha is not a parameter
             alpha_loss = -self.log_alpha.exp() * (log_pi.detach() + self.target_entropy)
@@ -517,8 +543,20 @@ class DiscreteSACLoss(LossModule):
 
     """
 
+    @dataclass
+    class _AcceptedKeys:
+        priority_key: NestedKey = "td_error"
+        action_key: NestedKey = "action"
+        value_key: NestedKey = "state_value"
+
+    default_keys = _AcceptedKeys()
     default_value_estimator = ValueEstimators.TD0
     delay_actor: bool = False
+
+    @classmethod
+    def __new__(cls, *args, **kwargs):
+        cls._tensor_keys = cls._AcceptedKeys()
+        return super().__new__(cls)
 
     def __init__(
         self,
@@ -540,7 +578,6 @@ class DiscreteSACLoss(LossModule):
         if not _has_functorch:
             raise ImportError("Failed to import functorch.") from FUNCTORCH_ERROR
         super().__init__()
-        self.set_keys()
         self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         self.convert_to_functional(
@@ -590,19 +627,20 @@ class DiscreteSACLoss(LossModule):
             "target_entropy", torch.tensor(target_entropy, device=device)
         )
 
-    def set_keys(
-        self,
-        priority_key="td_error",
-        action_key="action",
-        value_key="state_value",
-    ):
-        self.priority_key = priority_key
-        self.action_key = action_key
-        self.value_key = value_key
+    @property
+    def tensor_keys(self) -> _AcceptedKeys:
+        return self._tensor_keys
+
+    def set_keys(self, **kwargs) -> None:
+        """TODO"""
+        for key, _ in kwargs.items():
+            if key not in self._AcceptedKeys.__dict__:
+                raise ValueError(f"{key} it not an accepted tensordict key")
+        self._tensor_keys = self._AcceptedKeys(**kwargs)
 
         if self._value_estimator is not None:
             self._value_estimator.set_keys(
-                value_key=value_key,
+                value_key=self._tensor_keys.value_key,
             )
 
     @property
@@ -615,7 +653,7 @@ class DiscreteSACLoss(LossModule):
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         obs_keys = self.actor_network.in_keys
         tensordict_select = tensordict.clone(False).select(
-            "next", *obs_keys, self.action_key
+            "next", *obs_keys, self.tensor_keys.action_key
         )
 
         actor_params = torch.stack(
@@ -689,7 +727,7 @@ class DiscreteSACLoss(LossModule):
             qvalue_params,
         )
 
-        state_action_value = tensordict_qval.get(self.value_key).squeeze(-1)
+        state_action_value = tensordict_qval.get(self.tensor_keys.value_key).squeeze(-1)
         (
             state_action_value_actor,
             next_state_action_value_qvalue,
@@ -714,7 +752,9 @@ class DiscreteSACLoss(LossModule):
             -1
         )
 
-        actions = torch.argmax(tensordict_select.get(self.action_key), dim=-1)
+        actions = torch.argmax(
+            tensordict_select.get(self.tensor_keys.action_key), dim=-1
+        )
 
         pred_val_1 = (
             state_action_value_qvalue[0].gather(-1, actions.unsqueeze(-1)).unsqueeze(0)
@@ -735,7 +775,7 @@ class DiscreteSACLoss(LossModule):
             * 0.5
         )
 
-        tensordict.set(self.priority_key, td_error.detach().max(0)[0])
+        tensordict.set(self.tensor_keys.priority_key, td_error.detach().max(0)[0])
 
         loss_alpha = self._loss_alpha(logp_pi_pol)
         if not loss_qval.shape == loss_actor.shape:
@@ -777,11 +817,11 @@ class DiscreteSACLoss(LossModule):
             value_type = self.default_value_estimator
         self.value_type = value_type
         value_net = None
-        value_key = self.value_key
         hp = dict(default_value_kwargs(value_type))
         hp.update(hyperparams)
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
+        value_key = self.tensor_keys.value_key
         if value_type is ValueEstimators.TD1:
             self._value_estimator = TD1Estimator(
                 **hp,

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -112,15 +112,6 @@ class SACLoss(LossModule):
         if not _has_functorch:
             raise ImportError("Failed to import functorch.") from FUNCTORCH_ERROR
         super().__init__()
-        tensordict_keys = {
-            "priority_key": "td_error",
-            "value_key": "state_value",
-            "state_action_value_key": "state_action_value",
-            "action_key": "action",
-            "sample_log_prob_key": "sample_log_prob",
-            "log_prob_key": "_log_prob",
-        }
-        self._set_default_tensordict_keys(tensordict_keys)
         self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         # Actor
@@ -202,6 +193,17 @@ class SACLoss(LossModule):
         if gamma is not None:
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
+
+    @staticmethod
+    def default_tensordict_keys():
+        return {
+            "priority_key": "td_error",
+            "value_key": "state_value",
+            "state_action_value_key": "state_action_value",
+            "action_key": "action",
+            "sample_log_prob_key": "sample_log_prob",
+            "log_prob_key": "_log_prob",
+        }
 
     def make_value_estimator(self, value_type: ValueEstimators = None, **hyperparams):
         if value_type is None:
@@ -536,12 +538,6 @@ class DiscreteSACLoss(LossModule):
         if not _has_functorch:
             raise ImportError("Failed to import functorch.") from FUNCTORCH_ERROR
         super().__init__()
-        tensordict_keys = {
-            "priority_key": "td_error",
-            "value_key": "state_value",
-            "action_key": "action",
-        }
-        self._set_default_tensordict_keys(tensordict_keys)
         self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         self.convert_to_functional(
@@ -590,6 +586,14 @@ class DiscreteSACLoss(LossModule):
         self.register_buffer(
             "target_entropy", torch.tensor(target_entropy, device=device)
         )
+
+    @staticmethod
+    def default_tensordict_keys():
+        return {
+            "priority_key": "td_error",
+            "value_key": "state_value",
+            "action_key": "action",
+        }
 
     @property
     def alpha(self):

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -560,7 +560,7 @@ class DiscreteSACLoss(LossModule):
         Attributes:
         ------------
         action : NestedKey
-            The input tensordict key where the action is expected. Defaults to ``"advantage"``.
+            The input tensordict key where the action is expected. Defaults to ``"action"``.
         value : NestedKey
             The input tensordict key where the state value is expected.
             Will be used for the underlying value estimator. Defaults to ``"state_value"``.

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -98,19 +98,16 @@ class SACLoss(LossModule):
         default values.
 
         Attributes:
-        ------------
-        action : NestedKey
-            The input tensordict key where the action is expected. Defaults to ``"advantage"``.
-        value : NestedKey
-            The input tensordict key where the state value is expected.
-            Will be used for the underlying value estimator. Defaults to ``"state_value"``.
-        state_action_value : NestedKey
-            The input tensordict key where the state action value is expected. Defaults to ``"state_action_value"``.
-        log_prob : NestedKey
-            The input tensordict key where the log probability is expected.
-            Defaults to ``"_log_prob"``.
-        priority : NestedKey
-            The input tensordict key where the target priority is written to. Defaults to ``"td_error"``.
+            action (NestedKey): The input tensordict key where the action is expected.
+                Defaults to ``"advantage"``.
+            value (NestedKey): The input tensordict key where the state value is expected.
+                Will be used for the underlying value estimator. Defaults to ``"state_value"``.
+            state_action_value (NestedKey): The input tensordict key where the
+                state action value is expected.  Defaults to ``"state_action_value"``.
+            log_prob (NestedKey): The input tensordict key where the log probability is expected.
+                Defaults to ``"_log_prob"``.
+            priority (NestedKey): The input tensordict key where the target priority is written to.
+                Defaults to ``"td_error"``.
         """
 
         action: NestedKey = "action"
@@ -567,14 +564,12 @@ class DiscreteSACLoss(LossModule):
         default values
 
         Attributes:
-        ------------
-        action : NestedKey
-            The input tensordict key where the action is expected. Defaults to ``"action"``.
-        value : NestedKey
-            The input tensordict key where the state value is expected.
-            Will be used for the underlying value estimator. Defaults to ``"state_value"``.
-        priority : NestedKey
-            The input tensordict key where the target priority is written to. Defaults to ``"td_error"``.
+            action (NestedKey): The input tensordict key where the action is expected.
+                Defaults to ``"action"``.
+            value (NestedKey): The input tensordict key where the state value is expected.
+                Will be used for the underlying value estimator. Defaults to ``"state_value"``.
+            priority (NestedKey): The input tensordict key where the target priority is written to.
+                Defaults to ``"td_error"``.
         """
 
         action: NestedKey = "action"

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -82,12 +82,12 @@ class TD3Loss(LossModule):
 
         super().__init__()
 
-        self.tensordict_keys = {
+        tensordict_keys = {
             "priority_key": "td_error",
             "state_action_value_key": "state_action_value",
             "action_key": "action",
         }
-        self.set_keys(**self.tensordict_keys)
+        self._set_default_tensordict_keys(tensordict_keys)
 
         self.delay_actor = delay_actor
         self.delay_qvalue = delay_qvalue

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -71,7 +71,7 @@ class TD3Loss(LossModule):
         Attributes:
         ------------
         action : NestedKey
-            The input tensordict key where the action is expected. Defaults to ``"advantage"``.
+            The input tensordict key where the action is expected. Defaults to ``"action"``.
         state_action_value : NestedKey
             The input tensordict key where the state action value is expected.
             Will be used for the underlying value estimator. Defaults to ``"state_action_value"``.

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -69,14 +69,12 @@ class TD3Loss(LossModule):
         default values.
 
         Attributes:
-        ------------
-        action : NestedKey
-            The input tensordict key where the action is expected. Defaults to ``"action"``.
-        state_action_value : NestedKey
-            The input tensordict key where the state action value is expected.
-            Will be used for the underlying value estimator. Defaults to ``"state_action_value"``.
-        priority : NestedKey
-            The input tensordict key where the target priority is written to. Defaults to ``"td_error"``.
+            action (NestedKey): The input tensordict key where the action is expected.
+                Defaults to ``"action"``.
+            state_action_value (NestedKey): The input tensordict key where the state action value is expected.
+                Will be used for the underlying value estimator. Defaults to ``"state_action_value"``.
+            priority (NestedKey): The input tensordict key where the target priority is written to.
+                Defaults to ``"td_error"``.
         """
 
         action: NestedKey = "action"

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -63,10 +63,10 @@ class TD3Loss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and the corresponding default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values.
 
         Attributes:
         ------------

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -138,7 +138,7 @@ class TD3Loss(LossModule):
 
         if self._value_estimator is not None:
             self._value_estimator.set_keys(
-                value_key=self._tensor_keys.value_key,
+                value_key=self._tensor_keys.state_action_value_key,
             )
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -150,7 +150,7 @@ class TD3Loss(LossModule):
             -self.max_action, self.max_action
         )
         actor_output_td[1].set(self.action_key, next_action, inplace=True)
-        tensordict_actor[self.action_key] = actor_output_td[self.action_key]
+        tensordict_actor.set(self.action_key, actor_output_td.get(self.action_key))
 
         # repeat tensordict_actor to match the qvalue size
         _actor_loss_td = (

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -82,13 +82,6 @@ class TD3Loss(LossModule):
 
         super().__init__()
 
-        tensordict_keys = {
-            "priority_key": "td_error",
-            "state_action_value_key": "state_action_value",
-            "action_key": "action",
-        }
-        self._set_default_tensordict_keys(tensordict_keys)
-
         self.delay_actor = delay_actor
         self.delay_qvalue = delay_qvalue
 
@@ -115,6 +108,14 @@ class TD3Loss(LossModule):
         if gamma is not None:
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
+
+    @staticmethod
+    def default_tensordict_keys():
+        return {
+            "priority_key": "td_error",
+            "state_action_value_key": "state_action_value",
+            "action_key": "action",
+        }
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         obs_keys = self.actor_network.in_keys

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -81,6 +81,7 @@ class TD3Loss(LossModule):
             )
 
         super().__init__()
+        self.set_keys()
         self._set_deprecated_ctor_keys(priority_key=priority_key)
 
         self.delay_actor = delay_actor
@@ -104,20 +105,20 @@ class TD3Loss(LossModule):
         self.loss_function = loss_function
         self.policy_noise = policy_noise
         self.noise_clip = noise_clip
-        self.max_action = (
-            actor_network.spec[self.loss_key("action_key")].space.maximum.max().item()
-        )
+        self.max_action = actor_network.spec[self.action_key].space.maximum.max().item()
         if gamma is not None:
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
 
-    @staticmethod
-    def default_loss_keys():
-        return {
-            "priority_key": "td_error",
-            "state_action_value_key": "state_action_value",
-            "action_key": "action",
-        }
+    def set_keys(
+        self,
+        priority_key="td_error",
+        action_key="action",
+        state_action_value_key="state_action_value",
+    ):
+        self.priority_key = priority_key
+        self.action_key = action_key
+        self.state_action_value_key = state_action_value_key
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         obs_keys = self.actor_network.in_keys
@@ -142,20 +143,20 @@ class TD3Loss(LossModule):
             actor_params,
         )
         # add noise to target policy
-        action = actor_output_td[1].get(self.loss_key("action_key"))
+        action = actor_output_td[1].get(self.action_key)
         noise = torch.normal(
             mean=torch.zeros(action.shape),
             std=torch.full(action.shape, self.policy_noise),
         ).to(action.device)
         noise = noise.clamp(-self.noise_clip, self.noise_clip)
 
-        next_action = (actor_output_td[1][self.loss_key("action_key")] + noise).clamp(
+        next_action = (actor_output_td[1][self.action_key] + noise).clamp(
             -self.max_action, self.max_action
         )
-        actor_output_td[1].set(self.loss_key("action_key"), next_action, inplace=True)
+        actor_output_td[1].set(self.action_key, next_action, inplace=True)
         tensordict_actor.set(
-            self.loss_key("action_key"),
-            actor_output_td.get(self.loss_key("action_key")),
+            self.action_key,
+            actor_output_td.get(self.action_key),
         )
 
         # repeat tensordict_actor to match the qvalue size
@@ -197,9 +198,9 @@ class TD3Loss(LossModule):
             qvalue_params,
         )
 
-        state_action_value = tensordict_qval.get(
-            self.loss_key("state_action_value_key")
-        ).squeeze(-1)
+        state_action_value = tensordict_qval.get(self.state_action_value_key).squeeze(
+            -1
+        )
         (
             state_action_value_actor,
             next_state_action_value_qvalue,
@@ -213,7 +214,7 @@ class TD3Loss(LossModule):
 
         next_state_value = next_state_action_value_qvalue.min(0)[0]
         tensordict.set(
-            ("next", self.loss_key("state_action_value_key")),
+            ("next", self.state_action_value_key),
             next_state_value.unsqueeze(-1),
         )
         target_value = self.value_estimator.value_estimate(tensordict).squeeze(-1)
@@ -230,7 +231,7 @@ class TD3Loss(LossModule):
             * 0.5
         )
 
-        tensordict_save.set(self.loss_key("priority_key"), td_error.detach().max(0)[0])
+        tensordict_save.set(self.priority_key, td_error.detach().max(0)[0])
 
         if not loss_qval.shape == loss_actor.shape:
             raise RuntimeError(

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -70,11 +70,6 @@ class TD3Loss(LossModule):
     default_keys = _AcceptedKeys()
     default_value_estimator = ValueEstimators.TD0
 
-    @classmethod
-    def __new__(cls, *args, **kwargs):
-        cls._tensor_keys = cls._AcceptedKeys()
-        return super().__new__(cls)
-
     def __init__(
         self,
         actor_network: TensorDictModule,
@@ -125,17 +120,7 @@ class TD3Loss(LossModule):
             warnings.warn(_GAMMA_LMBDA_DEPREC_WARNING, category=DeprecationWarning)
             self.gamma = gamma
 
-    @property
-    def tensor_keys(self) -> _AcceptedKeys:
-        return self._tensor_keys
-
-    def set_keys(self, **kwargs) -> None:
-        """TODO"""
-        for key, _ in kwargs.items():
-            if key not in self._AcceptedKeys.__dict__:
-                raise ValueError(f"{key} it not an accepted tensordict key")
-        self._tensor_keys = self._AcceptedKeys(**kwargs)
-
+    def _forward_value_estimator_keys(self, **kwargs) -> None:
         if self._value_estimator is not None:
             self._value_estimator.set_keys(
                 value_key=self._tensor_keys.state_action_value_key,
@@ -280,15 +265,15 @@ class TD3Loss(LossModule):
         if hasattr(self, "gamma"):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
-        value_key = self.tensor_keys.state_action_value_key
         # we do not need a value network bc the next state value is already passed
+        tensor_keys = {"value_key": self.tensor_keys.state_action_value_key}
         if value_type == ValueEstimators.TD1:
             self._value_estimator = TD1Estimator(
-                value_network=None, value_key=value_key, **hp
+                value_network=None, tensor_keys=tensor_keys, **hp
             )
         elif value_type == ValueEstimators.TD0:
             self._value_estimator = TD0Estimator(
-                value_network=None, value_key=value_key, **hp
+                value_network=None, tensor_keys=tensor_keys, **hp
             )
         elif value_type == ValueEstimators.GAE:
             raise NotImplementedError(
@@ -296,7 +281,7 @@ class TD3Loss(LossModule):
             )
         elif value_type == ValueEstimators.TDLambda:
             self._value_estimator = TDLambdaEstimator(
-                value_network=None, value_key=value_key, **hp
+                value_network=None, tensor_keys=tensor_keys, **hp
             )
         else:
             raise NotImplementedError(f"Unknown value type {value_type}")

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -63,9 +63,25 @@ class TD3Loss(LossModule):
 
     @dataclass
     class _AcceptedKeys:
-        priority: NestedKey = "td_error"
+        """Stores default values for all configurable tensordict keys.
+
+        This class is used to define and store which tensordict keys are configurable
+        via `.set_keys(key_name=key_value) and the corresponding default values.
+
+        Attributes:
+        ------------
+        action : NestedKey
+            The input tensordict key where the action is expected. Defaults to ``"advantage"``.
+        state_action_value : NestedKey
+            The input tensordict key where the state action value is expected.
+            Will be used for the underlying value estimator. Defaults to ``"state_action_value"``.
+        priority : NestedKey
+            The input tensordict key where the target priority is written to. Defaults to ``"td_error"``.
+        """
+
         action: NestedKey = "action"
         state_action_value: NestedKey = "state_action_value"
+        priority: NestedKey = "td_error"
 
     default_keys = _AcceptedKeys()
     default_value_estimator = ValueEstimators.TD0

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -106,7 +106,6 @@ class ValueEstimatorBase(TensorDictModuleBase):
         skip_existing: Optional[bool] = None,
     ):
         super().__init__()
-        print(f"{advantage_key = }")
         self.differentiable = differentiable
         self.skip_existing = skip_existing
         self.value_network = value_network

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -106,6 +106,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
         skip_existing: Optional[bool] = None,
     ):
         super().__init__()
+        print(f"{advantage_key = }")
         self.differentiable = differentiable
         self.skip_existing = skip_existing
         self.value_network = value_network

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -5,9 +5,9 @@
 import abc
 import functools
 import warnings
-from functools import wraps
 from dataclasses import dataclass
-from typing import Callable, List, Optional, Tuple, Union, Dict
+from functools import wraps
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 from tensordict.nn import (
@@ -65,6 +65,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
     should be used instead.
 
     """
+
     @dataclass
     class _AcceptedKeys:
         advantage_key: NestedKey = "advantage"
@@ -129,22 +130,23 @@ class ValueEstimatorBase(TensorDictModuleBase):
 
         if advantage_key is not None:
             warnings.warn(
-                f"Setting 'advantage_key' via ctor is deprecated, use .set_keys(advantage_key='some_key') instead.",
+                "Setting 'advantage_key' via ctor is deprecated, use .set_keys(advantage_key='some_key') instead.",
                 category=DeprecationWarning,
             )
-            self.tensor_keys.advantage_key=advantage_key
+            self.tensor_keys.advantage_key = advantage_key
         if value_target_key is not None:
             warnings.warn(
-                f"Setting 'value_target_key' via ctor is deprecated, use .set_keys(value_target_key='some_key') instead.",
+                "Setting 'value_target_key' via ctor is deprecated, use .set_keys(value_target_key='some_key') instead.",
                 category=DeprecationWarning,
             )
-            self.tensor_keys.value_target_key=value_target_key
+            self.tensor_keys.value_target_key = value_target_key
         if value_key is not None:
             warnings.warn(
-                f"Setting 'value_key' via ctor is deprecated, use .set_keys(value_target_key='some_key') instead.",
+                "Setting 'value_key' via ctor is deprecated, use .set_keys(value_target_key='some_key') instead.",
                 category=DeprecationWarning,
             )
-            self.tensor_keys.value_key=value_key
+            self.tensor_keys.value_key = value_key
+
         if tensor_keys is not None:
             self.set_keys(**tensor_keys)
 
@@ -167,7 +169,10 @@ class ValueEstimatorBase(TensorDictModuleBase):
         try:
             self.in_keys = (
                 self.value_network.in_keys
-                + [("next", self.tensor_keys.reward_key), ("next", self.tensor_keys.done_key)]
+                + [
+                    ("next", self.tensor_keys.reward_key),
+                    ("next", self.tensor_keys.done_key),
+                ]
                 + [("next", in_key) for in_key in self.value_network.in_keys]
             )
         except AttributeError:
@@ -176,7 +181,10 @@ class ValueEstimatorBase(TensorDictModuleBase):
             pass
 
     def _set_out_keys(self) -> None:
-        self.out_keys = [self.tensor_keys.advantage_key, self.tensor_keys.value_target_key]
+        self.out_keys = [
+            self.tensor_keys.advantage_key,
+            self.tensor_keys.value_target_key,
+        ]
 
     def set_keys(self, **kwargs) -> None:
         """Change the tensordict keys where data is expected to be written.
@@ -290,7 +298,7 @@ class TD0Estimator(ValueEstimatorBase):
             value_target_key=value_target_key,
             value_key=value_key,
             skip_existing=skip_existing,
-            tensor_keys=tensor_keys
+            tensor_keys=tensor_keys,
         )
         try:
             device = next(value_network.parameters()).device
@@ -453,7 +461,7 @@ class TD1Estimator(ValueEstimatorBase):
         value_network: TensorDictModule,
         average_rewards: bool = False,
         differentiable: bool = False,
-        tensor_keys = None,
+        tensor_keys=None,
         skip_existing: Optional[bool] = None,
         advantage_key: Union[str, Tuple] = None,
         value_target_key: Union[str, Tuple] = None,

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -134,6 +134,16 @@ class ValueEstimatorBase(TensorDictModuleBase):
 
         self.out_keys = [self.advantage_key, self.value_target_key]
 
+    def set_keys(
+        self,
+        advantage_key="advantage",
+        value_target_key="value_target",
+        value_key="state_value",
+    ):
+        self.advantage_key = advantage_key
+        self.value_target_key = value_target_key
+        self.value_key = value_key
+
     def value_estimate(
         self,
         tensordict,

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -290,14 +290,12 @@ class TD0Estimator(ValueEstimatorBase):
             modules which outputs are already present in the tensordict.
             Defaults to ``None``, ie. the value of :func:`tensordict.nn.skip_existing()`
             is not affected.
-        tensor_keys: (Dict[str, str or tuple of str], optional) Specify tensordict key names for
-            all keys specified in :class:`~._AcceptedKeys`.
-        advantage_key (str or tuple of str, optional): [Deprecated] the key of the advantage entry.
-            Defaults to ``"advantage"``.
-        value_target_key (str or tuple of str, optional): [Deprecated] the key of the advantage entry.
-            Defaults to ``"value_target"``.
-        value_key (str or tuple of str, optional): [Deprecated] the value key to read from the input tensordict.
-            Defaults to ``"state_value"``.
+        advantage_key (str or tuple of str, optional): [Deprecated] the key of
+            the advantage entry.  Defaults to ``"advantage"``.
+        value_target_key (str or tuple of str, optional): [Deprecated] the key
+            of the advantage entry.  Defaults to ``"value_target"``.
+        value_key (str or tuple of str, optional): [Deprecated] the value key to
+            read from the input tensordict.  Defaults to ``"state_value"``.
 
     """
 
@@ -466,14 +464,12 @@ class TD1Estimator(ValueEstimatorBase):
             modules which outputs are already present in the tensordict.
             Defaults to ``None``, ie. the value of :func:`tensordict.nn.skip_existing()`
             is not affected.
-        tensor_keys: (Dict[str, str or tuple of str], optional) Specify tensordict key names for
-            all keys specified in :class:`~._AcceptedKeys`.
-        advantage_key (str or tuple of str, optional): [Deprecated] the key of the advantage entry.
-            Defaults to "advantage".
-        value_target_key (str or tuple of str, optional): [Deprecated] the key of the advantage entry.
-            Defaults to "value_target".
-        value_key (str or tuple of str, optional): [Deprecated] the value key to read from the input tensordict.
-            Defaults to "state_value".
+        advantage_key (str or tuple of str, optional): [Deprecated] the key of
+            the advantage entry.  Defaults to ``"advantage"``.
+        value_target_key (str or tuple of str, optional): [Deprecated] the key
+            of the advantage entry.  Defaults to ``"value_target"``.
+        value_key (str or tuple of str, optional): [Deprecated] the value key to
+            read from the input tensordict.  Defaults to ``"state_value"``.
 
     """
 
@@ -646,14 +642,12 @@ class TDLambdaEstimator(ValueEstimatorBase):
             modules which outputs are already present in the tensordict.
             Defaults to ``None``, ie. the value of :func:`tensordict.nn.skip_existing()`
             is not affected.
-        tensor_keys: (Dict[str, str or tuple of str], optional) Specify tensordict key names for
-            all keys specified in :class:`~._AcceptedKeys`.
-        advantage_key (str or tuple of str, optional): [Deprecated] the key of the advantage entry.
-            Defaults to "advantage".
-        value_target_key (str or tuple of str, optional): [Deprecated] the key of the advantage entry.
-            Defaults to "value_target".
-        value_key (str or tuple of str, optional): [Deprecated] the value key to read from the input tensordict.
-            Defaults to "state_value".
+        advantage_key (str or tuple of str, optional): [Deprecated] the key of
+            the advantage entry.  Defaults to ``"advantage"``.
+        value_target_key (str or tuple of str, optional): [Deprecated] the key
+            of the advantage entry.  Defaults to ``"value_target"``.
+        value_key (str or tuple of str, optional): [Deprecated] the value key to
+            read from the input tensordict.  Defaults to ``"state_value"``.
 
     """
 
@@ -837,16 +831,17 @@ class GAE(ValueEstimatorBase):
 
         vectorized (bool, optional): whether to use the vectorized version of the
             lambda return. Default is `True`.
-        advantage_key (str or tuple of str, optional): the key of the advantage entry.
-            Defaults to "advantage".
-        value_target_key (str or tuple of str, optional): the key of the advantage entry.
-            Defaults to "value_target".
-        value_key (str or tuple of str, optional): the value key to read from the input tensordict.
-            Defaults to "state_value".
         skip_existing (bool, optional): if ``True``, the value network will skip
             modules which outputs are already present in the tensordict.
             Defaults to ``None``, ie. the value of :func:`tensordict.nn.skip_existing()`
             is not affected.
+            Defaults to "state_value".
+        advantage_key (str or tuple of str, optional): [Deprecated] the key of
+            the advantage entry.  Defaults to ``"advantage"``.
+        value_target_key (str or tuple of str, optional): [Deprecated] the key
+            of the advantage entry.  Defaults to ``"value_target"``.
+        value_key (str or tuple of str, optional): [Deprecated] the value key to
+            read from the input tensordict.  Defaults to ``"state_value"``.
 
     GAE will return an :obj:`"advantage"` entry containing the advange value. It will also
     return a :obj:`"value_target"` entry with the return value that is to be used

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -208,11 +208,12 @@ class ValueEstimatorBase(TensorDictModuleBase):
     def set_keys(self, **kwargs) -> None:
         """Set tensordict key names."""
         for key, value in kwargs.items():
-            # instance does not work with Generics
-            # if not isinstance(value, NestedKey):
-            #   raise ValueError("key name must be of type NestedKey (Union[str, Tuple[str]])")
+            if not isinstance(value, (str, tuple)):
+                raise ValueError(
+                    "key name must be of type NestedKey (Union[str, Tuple[str]])"
+                )
             if value is None:
-                raise ValueError("key names cannot be None")
+                raise ValueError("tensordict keys cannot be None")
             if key not in self._AcceptedKeys.__dict__:
                 raise KeyError(
                     f"{key} it not an accepted tensordict key for advantages"
@@ -848,8 +849,6 @@ class GAE(ValueEstimatorBase):
             Defaults to "value_target".
         value_key (str or tuple of str, optional): the value key to read from the input tensordict.
             Defaults to "state_value".
-        tensor_keys: (Dict[str, str or tuple of str], optional) Specify tensordict key names for
-            all keys specified in _AcceptedKeys.
         skip_existing (bool, optional): if ``True``, the value network will skip
             modules which outputs are already present in the tensordict.
             Defaults to ``None``, ie. the value of :func:`tensordict.nn.skip_existing()`
@@ -970,7 +969,6 @@ class GAE(ValueEstimatorBase):
                 "Expected input tensordict to have at least one dimensions, got "
                 f"tensordict.batch_size = {tensordict.batch_size}"
             )
-
         reward = tensordict.get(("next", self.tensor_keys.reward))
         device = reward.device
         gamma, lmbda = self.gamma.to(device), self.lmbda.to(device)

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -100,6 +100,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
         *,
         value_network: TensorDictModule,
         differentiable: bool = False,
+        # TODO make deprecated
         advantage_key: Union[str, Tuple] = "advantage",
         value_target_key: Union[str, Tuple] = "value_target",
         value_key: Union[str, Tuple] = "state_value",
@@ -140,6 +141,15 @@ class ValueEstimatorBase(TensorDictModuleBase):
         value_target_key="value_target",
         value_key="state_value",
     ):
+        """Change the tensordict keys where data is expected to be written.
+
+        advantage_key (str, optional): The input tensordict key where the advantage is
+            expected to be written. Defaults to ``"advantage"``.
+        value_target_key (str, optional): The input tensordict key where the target state
+            value is expected to be written. Defaults to ``"value_target"``.
+        value_key (str, optional): The input tensordict key where the state
+            value is expected to be written. Defaults to ``"state_value"``.
+        """
         self.advantage_key = advantage_key
         self.value_target_key = value_target_key
         self.value_key = value_key

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -86,13 +86,13 @@ class ValueEstimatorBase(TensorDictModuleBase):
             Will be used for the underlying value estimator. Defaults to ``"state_value"``.
         reward_key : NestedKey
             The input tensordict key where the reward is written to.
-            Defaults to ``"state_value"``.
+            Defaults to ``"reward"``.
         done_key : NestedKey
             The input tensordict key where the flag if a trajectory is done is expected.
-            Defaults to ``"state_value"``.
+            Defaults to ``"done"``.
         steps_to_next_obs_key : NestedKey
-            The input tensordict key where the stpes_to_next_obs is expected.
-            Defaults to ``"state_value"``.
+            The input tensordict key where the steps_to_next_obs is expected.
+            Defaults to ``"steps_to_next_obs"``.
         """
 
         advantage_key: NestedKey = "advantage"

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -71,7 +71,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
         """Stores default values for all configurable tensordict keys.
 
         This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and their default values.
+        via `.set_keys(key_name=key_value) and the corresponding default values.
 
         Attributes:
         ------------

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -74,25 +74,19 @@ class ValueEstimatorBase(TensorDictModuleBase):
         default values.
 
         Attributes:
-        ------------
-        advantage : NestedKey
-            The input tensordict key where the advantage is written to.
-            Will be used for the underlying value estimator. Defaults to ``"advantage"``.
-        value_target : NestedKey
-            The input tensordict key where the target state value is written to.
-            Will be used for the underlying value estimator Defaults to ``"value_target"``.
-        value_key : NestedKey
-            The input tensordict key where the state value is expected.
-            Will be used for the underlying value estimator. Defaults to ``"state_value"``.
-        reward_key : NestedKey
-            The input tensordict key where the reward is written to.
-            Defaults to ``"reward"``.
-        done_key : NestedKey
-            The key in the input TensorDict that indicates whether a trajectory is done.
-            Defaults to ``"done"``.
-        steps_to_next_obs_key : NestedKey
-            The key in the input tensordict that indicates the number of steps to the next observation.
-            Defaults to ``"steps_to_next_obs"``.
+            advantage (NestedKey): The input tensordict key where the advantage is written to.
+                Will be used for the underlying value estimator. Defaults to ``"advantage"``.
+            value_target (NestedKey): The input tensordict key where the target state value is written to.
+                Will be used for the underlying value estimator Defaults to ``"value_target"``.
+            value_key (NestedKey): The input tensordict key where the state value is expected.
+                Will be used for the underlying value estimator. Defaults to ``"state_value"``.
+            reward_key (NestedKey): The input tensordict key where the reward is written to.
+                Defaults to ``"reward"``.
+            done_key (NestedKey): The key in the input TensorDict that indicates
+                whether a trajectory is done.  Defaults to ``"done"``.
+            steps_to_next_obs_key (NestedKey): The key in the input tensordict
+                that indicates the number of steps to the next observation.
+                Defaults to ``"steps_to_next_obs"``.
         """
 
         advantage: NestedKey = "advantage"
@@ -297,13 +291,13 @@ class TD0Estimator(ValueEstimatorBase):
             Defaults to ``None``, ie. the value of :func:`tensordict.nn.skip_existing()`
             is not affected.
         tensor_keys: (Dict[str, str or tuple of str], optional) Specify tensordict key names for
-            all keys specified in _AcceptedKeys.
+            all keys specified in :class:`~._AcceptedKeys`.
         advantage_key (str or tuple of str, optional): [Deprecated] the key of the advantage entry.
-            Defaults to "advantage".
+            Defaults to ``"advantage"``.
         value_target_key (str or tuple of str, optional): [Deprecated] the key of the advantage entry.
-            Defaults to "value_target".
+            Defaults to ``"value_target"``.
         value_key (str or tuple of str, optional): [Deprecated] the value key to read from the input tensordict.
-            Defaults to "state_value".
+            Defaults to ``"state_value"``.
 
     """
 
@@ -473,7 +467,7 @@ class TD1Estimator(ValueEstimatorBase):
             Defaults to ``None``, ie. the value of :func:`tensordict.nn.skip_existing()`
             is not affected.
         tensor_keys: (Dict[str, str or tuple of str], optional) Specify tensordict key names for
-            all keys specified in _AcceptedKeys.
+            all keys specified in :class:`~._AcceptedKeys`.
         advantage_key (str or tuple of str, optional): [Deprecated] the key of the advantage entry.
             Defaults to "advantage".
         value_target_key (str or tuple of str, optional): [Deprecated] the key of the advantage entry.
@@ -653,7 +647,7 @@ class TDLambdaEstimator(ValueEstimatorBase):
             Defaults to ``None``, ie. the value of :func:`tensordict.nn.skip_existing()`
             is not affected.
         tensor_keys: (Dict[str, str or tuple of str], optional) Specify tensordict key names for
-            all keys specified in _AcceptedKeys.
+            all keys specified in :class:`~._AcceptedKeys`.
         advantage_key (str or tuple of str, optional): [Deprecated] the key of the advantage entry.
             Defaults to "advantage".
         value_target_key (str or tuple of str, optional): [Deprecated] the key of the advantage entry.

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -68,10 +68,10 @@ class ValueEstimatorBase(TensorDictModuleBase):
 
     @dataclass
     class _AcceptedKeys:
-        """Stores default values for all configurable tensordict keys.
+        """Maintains default values for all configurable tensordict keys.
 
-        This class is used to define and store which tensordict keys are configurable
-        via `.set_keys(key_name=key_value) and the corresponding default values.
+        This class defines which tensordict keys can be set using '.set_keys(key_name=key_value)' and their
+        default values.
 
         Attributes:
         ------------
@@ -88,10 +88,10 @@ class ValueEstimatorBase(TensorDictModuleBase):
             The input tensordict key where the reward is written to.
             Defaults to ``"reward"``.
         done_key : NestedKey
-            The input tensordict key where the flag if a trajectory is done is expected.
+            The key in the input TensorDict that indicates whether a trajectory is done.
             Defaults to ``"done"``.
         steps_to_next_obs_key : NestedKey
-            The input tensordict key where the steps_to_next_obs is expected.
+            The key in the input tensordict that indicates the number of steps to the next observation.
             Defaults to ``"steps_to_next_obs"``.
         """
 
@@ -178,7 +178,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
     @tensor_keys.setter
     def tensor_keys(self, value):
         if not isinstance(value, type(self._AcceptedKeys)):
-            raise ValueError
+            raise ValueError("value must be an instance of _AcceptedKeys")
         self._keys = value
 
     @property
@@ -210,7 +210,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
         for key, value in kwargs.items():
             if not isinstance(value, (str, tuple)):
                 raise ValueError(
-                    "key name must be of type NestedKey (Union[str, Tuple[str]])"
+                    f"key name must be of type NestedKey (Union[str, Tuple[str]]) but got {type(value)}"
                 )
             if value is None:
                 raise ValueError("tensordict keys cannot be None")

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -117,7 +117,6 @@ class ValueEstimatorBase(TensorDictModuleBase):
         value_network: TensorDictModule,
         differentiable: bool = False,
         tensor_keys: Dict[str, Union[str, Tuple]] = None,
-        # TODO make deprecated
         skip_existing: Optional[bool] = None,
         advantage_key: Union[str, Tuple] = None,
         value_target_key: Union[str, Tuple] = None,
@@ -168,7 +167,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
         try:
             self.in_keys = (
                 self.value_network.in_keys
-                + [("next", self.tensor_keys.reward_key), ("next", self.tensor_keys_done_key)]
+                + [("next", self.tensor_keys.reward_key), ("next", self.tensor_keys.done_key)]
                 + [("next", in_key) for in_key in self.value_network.in_keys]
             )
         except AttributeError:


### PR DESCRIPTION
## Description

We have various loss modules in RL. 
They work as

```
loss_module = LossModule(network, …)
loss_module(data)
```

These loss modules access the actual data by keys. Some keys are configurable via ctor,

https://github.com/pytorch/rl/blob/3c8197b41e351de2ebefbe2df5d5900d82e43882/torchrl/objectives/ppo.py#L125

others are hardcoded,

https://github.com/pytorch/rl/blob/714d6459e7b58f3b5601c26d612211527582327a/torchrl/objectives/ddpg.py#L139

This is refactored such that all relevant keys can be set via

```
loss_module.set_keys(sample_log_prob=“some_other_key”)
```

The same is done for the advantage modules.
```
advantage_module.set_keys(advantage="other_advantage")
```

Closes #1174 

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)


## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] New feature (non-breaking change which adds core functionality)
- [x] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
