### PR TITLE
[Doc] Fix default value of `tanh_loc` in the documentation of `TruncatedNormal`.

### DIFF
--- a/torchrl/modules/distributions/continuous.py
+++ b/torchrl/modules/distributions/continuous.py
@@ -281,14 +281,12 @@ class TruncatedNormal(D.Independent):
 class TanhNormal(FasterTransformedDistribution):
     """Implements a TanhNormal distribution with location scaling.
 
-    Location scaling prevents the location to be "too far" from 0 when a TanhTransform is applied, which ultimately
+    Location scaling prevents the location to be "too far" from 0 when a TanhTransform is applied, but ultimately
     leads to numerically unstable samples and poor gradient computation (e.g. gradient explosion).
-    In practice, the location is computed according to
+    In practice, with location scaling the location is computed according to
 
         .. math::
             loc = tanh(loc / upscale) * upscale.
-
-    This behaviour can be disabled by switching off the tanh_loc parameter (see below).
 
 
     Args:
@@ -304,7 +302,7 @@ class TanhNormal(FasterTransformedDistribution):
         event_dims (int, optional): number of dimensions describing the action.
             Default is 1;
         tanh_loc (bool, optional): if ``True``, the above formula is used for the location scaling, otherwise the raw
-            value is kept. Default is :obj:`True`;
+            value is kept. Default is :obj:`False`;
     """
 
     arg_constraints = {
@@ -345,7 +343,8 @@ class TanhNormal(FasterTransformedDistribution):
         else:
             self.non_trivial_min = min != -1.0
 
-        self.tanh_loc = tanh_loc
+        self.
+        = tanh_loc
         self._event_dims = event_dims
 
         self.device = loc.device


### PR DESCRIPTION
## Description

Close #1202.
The [doc string](https://github.com/pytorch/rl/blame/f3e9a1d03909d797c06f4db33635f38dc7f7efff/torchrl/modules/distributions/continuous.py#L307) of `TruncatedNormal` says that the default value of `tanh_loc` is `True`, however in the [code](https://github.com/pytorch/rl/blame/f3e9a1d03909d797c06f4db33635f38dc7f7efff/torchrl/modules/distributions/continuous.py#L325), it is set to `False`.

This PR fixes the issue by updating the default value in the doc string to `False`, reflecting the code.

## Motivation and Context

Close #1202.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Documentation (update in the documentation)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
