### PR TITLE
[Feature, Refactor] Scale in ToTensorImage based on the dtype and new from_int parameter

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -4885,7 +4885,7 @@ class TestToTensorImage(TransformBase):
         assert (td.get("dont touch") == dont_touch).all()
 
         if len(keys) == 1:
-            observation_spec = BoundedTensorSpec(0, 255, (16, 16, 3))
+            observation_spec = BoundedTensorSpec(0, 255, (16, 16, 3), dtype=torch.uint8)
             observation_spec = totensorimage.transform_observation_spec(
                 observation_spec
             )
@@ -4894,7 +4894,10 @@ class TestToTensorImage(TransformBase):
             assert (observation_spec.space.maximum == 1).all()
         else:
             observation_spec = CompositeSpec(
-                {key: BoundedTensorSpec(0, 255, (16, 16, 3)) for key in keys}
+                {
+                    key: BoundedTensorSpec(0, 255, (16, 16, 3), dtype=torch.uint8)
+                    for key in keys
+                }
             )
             observation_spec = totensorimage.transform_observation_spec(
                 observation_spec
@@ -4931,7 +4934,7 @@ class TestToTensorImage(TransformBase):
         assert (td.get("dont touch") == dont_touch).all()
 
         if len(keys) == 1:
-            observation_spec = BoundedTensorSpec(0, 255, (16, 16, 3))
+            observation_spec = BoundedTensorSpec(0, 255, (16, 16, 3), dtype=torch.uint8)
             observation_spec = totensorimage.transform_observation_spec(
                 observation_spec
             )
@@ -4940,7 +4943,10 @@ class TestToTensorImage(TransformBase):
             assert (observation_spec.space.maximum == 1).all()
         else:
             observation_spec = CompositeSpec(
-                {key: BoundedTensorSpec(0, 255, (16, 16, 3)) for key in keys}
+                {
+                    key: BoundedTensorSpec(0, 255, (16, 16, 3), dtype=torch.uint8)
+                    for key in keys
+                }
             )
             observation_spec = totensorimage.transform_observation_spec(
                 observation_spec
@@ -5024,6 +5030,27 @@ class TestToTensorImage(TransformBase):
             obs = td["pixels"]
         assert obs.shape[-3] == 3
         assert obs.dtype is torch.float32
+
+    @pytest.mark.parametrize("from_int", [None, True, False])
+    @pytest.mark.parametrize("default_dtype", [torch.float32, torch.uint8])
+    def test_transform_scale(self, from_int, default_dtype):
+        totensorimage = ToTensorImage(in_keys=["pixels"], from_int=from_int)
+        fill_value = 150 if default_dtype == torch.uint8 else 0.5
+        td = TensorDict(
+            {"pixels": torch.full((21, 22, 3), fill_value, dtype=default_dtype)}, []
+        )
+        # Save whether or not the tensor is floating point before the transform changes it
+        # to floating point type.
+        is_floating_point = torch.is_floating_point(td["pixels"])
+        totensorimage(td)
+
+        if from_int is None:
+            expected_pixel_value = (
+                fill_value / 255 if not is_floating_point else fill_value
+            )
+        else:
+            expected_pixel_value = fill_value / 255 if from_int else fill_value
+        assert (td["pixels"] == expected_pixel_value).all()
 
     @pytest.mark.parametrize("rbclass", [ReplayBuffer, TensorDictReplayBuffer])
     @pytest.mark.parametrize("out_keys", [None, ["stuff"]])


### PR DESCRIPTION
## Description

In some instances, images might already be in the 0...1 range instead of 0...255 range. This is true in Unity, for example. This PR aims to add some flexibility by only scaling the image if the dtype = torch.uint8. This behavior is consistent with [torchvision's ToTensor transform](https://pytorch.org/vision/stable/generated/torchvision.transforms.ToTensor.html).

I also updated the documentation a little bit so that way the number of channels isn't hardcoded to 3. The code seems like it doesn't rely on the dimension being 3, so I thought that making it more general shouldn't hurt. For example, grayscale images will have 1 channel rather than 3.

## Motivation and Context

See description.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
