### PR TITLE
[BugFix] Fix error message of .set_keys() in advantage modules

### DIFF
--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -6028,6 +6028,10 @@ class TestAdv:
         module.set_keys(value=value)
         assert module.tensor_keys.value == value
 
+        with pytest.raises(KeyError) as excinfo:
+            module.set_keys(unknown_key="unknown_value")
+            assert "unknown_value not found" in str(excinfo.value)
+
     @pytest.mark.parametrize(
         "adv,kwargs",
         [

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -218,7 +218,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
                 and (value not in self.value_network.out_keys)
             ):
                 raise KeyError(
-                    f"value key '{self.tensor_keys.value}' not found in value network out_keys"
+                    f"value key '{value}' not found in value network out_keys"
                 )
         if self._tensor_keys is None:
             conf = asdict(self.default_keys)


### PR DESCRIPTION
## Description

When `.set_keys(action="key_name")` is called with a key_name non-existing in the value_network.out_keys the right error message is generated.

close #1216

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
