### PR TITLE
[BugFix] Fix missing ("next", "observation") key in dispatch of losses

### DIFF
--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -979,12 +979,12 @@ class TestDDPG(LossModuleTestBase):
         value = self._create_mock_value()
         td = self._create_mock_data_ddpg()
         loss = DDPGLoss(actor, value)
-        loss.make_value_estimator(ValueEstimators.TD1)
 
         kwargs = {
             "observation": td.get("observation"),
             "next_reward": td.get(("next", "reward")),
             "next_done": td.get(("next", "done")),
+            "next_observation": td.get(("next", "observation")),
             "action": td.get("action"),
         }
         td = TensorDict(kwargs, td.batch_size).unflatten_keys("_")
@@ -3623,6 +3623,7 @@ class TestA2C(LossModuleTestBase):
 
         kwargs = {
             observation_key: td.get(observation_key),
+            f"next_{observation_key}": td.get(observation_key),
             f"next_{reward_key}": td.get(("next", reward_key)),
             f"next_{done_key}": td.get(("next", done_key)),
             action_key: td.get(action_key),
@@ -4675,6 +4676,7 @@ class TestIQL(LossModuleTestBase):
             observation_key: td.get(observation_key),
             f"next_{reward_key}": td.get(("next", reward_key)),
             f"next_{done_key}": td.get(("next", done_key)),
+            f"next_{observation_key}": td.get(("next", observation_key)),
         }
         td = TensorDict(kwargs, td.batch_size).unflatten_keys("_")
 

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -149,8 +149,6 @@ class A2CLoss(LossModule):
         ...     next_done = torch.zeros(*batch, 1, dtype=torch.bool),
         ...     next_reward = torch.randn(*batch, 1),
         ...     next_observation = torch.randn(*batch, n_obs))
-        >>> loss_val
-        (tensor(4.3483, grad_fn=<MeanBackward0>), tensor(1.4114, grad_fn=<MeanBackward0>), tensor(2.5165), tensor(-0.0252, grad_fn=<MulBackward0>))
     """
 
     @dataclass

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -143,12 +143,13 @@ class A2CLoss(LossModule):
         ...     in_keys=["observation"])
         >>> loss = A2CLoss(actor, value, loss_critic_type="l2")
         >>> batch = [2, ]
-        >>> loss_val = loss(
+        >>> loss_obj, loss_critic, entropy, loss_entropy = loss(
         ...     observation = torch.randn(*batch, n_obs),
         ...     action = spec.rand(batch),
         ...     next_done = torch.zeros(*batch, 1, dtype=torch.bool),
         ...     next_reward = torch.randn(*batch, 1),
         ...     next_observation = torch.randn(*batch, n_obs))
+        >>> loss_obj.backward()
     """
 
     @dataclass

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -109,12 +109,13 @@ class DDPGLoss(LossModule):
         ...     module=module,
         ...     in_keys=["observation", "action"])
         >>> loss = DDPGLoss(actor, value)
-        >>> loss_val = loss(
+        >>> loss_actor, loss_value, pred_value, target_value, pred_value_max, target_value_max = loss(
         ...     observation=torch.randn(n_obs),
         ...     action=spec.rand(),
         ...     next_done=torch.zeros(1, dtype=torch.bool),
         ...     next_observation=torch.randn(n_obs),
         ...     next_reward=torch.randn(1))
+        >>> loss_actor.backward()
 
     """
 

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -115,8 +115,6 @@ class DDPGLoss(LossModule):
         ...     next_done=torch.zeros(1, dtype=torch.bool),
         ...     next_observation=torch.randn(n_obs),
         ...     next_reward=torch.randn(1))
-        >>> loss_val
-        (tensor(-0.8247, grad_fn=<MeanBackward0>), tensor(2.1672, grad_fn=<MeanBackward0>), tensor(0.6193), tensor(2.0914), tensor(0.6193), tensor(2.0914))
 
     """
 

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -66,6 +66,7 @@ class DDPGLoss(LossModule):
         ...        "action": spec.rand(batch),
         ...        ("next", "done"): torch.zeros(*batch, 1, dtype=torch.bool),
         ...        ("next", "reward"): torch.randn(*batch, 1),
+        ...        ("next", "observation"): torch.randn(*batch, n_obs),
         ...    }, batch)
         >>> loss(data)
         TensorDict(
@@ -112,9 +113,10 @@ class DDPGLoss(LossModule):
         ...     observation=torch.randn(n_obs),
         ...     action=spec.rand(),
         ...     next_done=torch.zeros(1, dtype=torch.bool),
+        ...     next_observation=torch.randn(n_obs),
         ...     next_reward=torch.randn(1))
         >>> loss_val
-        (tensor(-0.8247, grad_fn=<MeanBackward0>), tensor(1.3344, grad_fn=<MeanBackward0>), tensor(0.6193), tensor(1.7744), tensor(0.6193), tensor(1.7744))
+        (tensor(-0.8247, grad_fn=<MeanBackward0>), tensor(2.1672, grad_fn=<MeanBackward0>), tensor(0.6193), tensor(2.0914), tensor(0.6193), tensor(2.0914))
 
     """
 
@@ -202,9 +204,10 @@ class DDPGLoss(LossModule):
         keys = [
             ("next", self.tensor_keys.reward),
             ("next", self.tensor_keys.done),
+            *self.actor_in_keys,
+            *[("next", key) for key in self.actor_in_keys],
+            *self.value_network.in_keys,
         ]
-        keys += self.value_network.in_keys
-        keys += self.actor_in_keys
         keys = list(set(keys))
         return keys
 

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -159,8 +159,6 @@ class IQLLoss(LossModule):
         ...     next_done=torch.zeros(*batch, 1, dtype=torch.bool),
         ...     next_observation=torch.zeros(*batch, n_obs),
         ...     next_reward=torch.randn(*batch, 1))
-        >>> loss_val
-        (tensor(1.4535, grad_fn=<MeanBackward0>), tensor(0.7506, grad_fn=<MeanBackward0>), tensor(0.3406, grad_fn=<MeanBackward0>), tensor(3.3441))
 
     """
 

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -98,6 +98,7 @@ class IQLLoss(LossModule):
         ...         "action": action,
         ...         ("next", "done"): torch.zeros(*batch, 1, dtype=torch.bool),
         ...         ("next", "reward"): torch.randn(*batch, 1),
+        ...         ("next", "observation"): torch.randn(*batch, n_obs),
         ...     }, batch)
         >>> loss(data)
         TensorDict(
@@ -156,9 +157,10 @@ class IQLLoss(LossModule):
         ...     observation=torch.randn(*batch, n_obs),
         ...     action=action,
         ...     next_done=torch.zeros(*batch, 1, dtype=torch.bool),
+        ...     next_observation=torch.zeros(*batch, n_obs),
         ...     next_reward=torch.randn(*batch, 1))
         >>> loss_val
-        (tensor(1.4535, grad_fn=<MeanBackward0>), tensor(0.8389, grad_fn=<MeanBackward0>), tensor(0.3406, grad_fn=<MeanBackward0>), tensor(3.3441))
+        (tensor(1.4535, grad_fn=<MeanBackward0>), tensor(0.7506, grad_fn=<MeanBackward0>), tensor(0.3406, grad_fn=<MeanBackward0>), tensor(3.3441))
 
     """
 
@@ -269,10 +271,11 @@ class IQLLoss(LossModule):
             self.tensor_keys.action,
             ("next", self.tensor_keys.reward),
             ("next", self.tensor_keys.done),
+            *self.actor_network.in_keys,
+            *[("next", key) for key in self.actor_network.in_keys],
+            *self.qvalue_network.in_keys,
+            *self.value_network.in_keys,
         ]
-        keys.extend(self.actor_network.in_keys)
-        keys.extend(self.qvalue_network.in_keys)
-        keys.extend(self.value_network.in_keys)
 
         return list(set(keys))
 

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -153,12 +153,13 @@ class IQLLoss(LossModule):
         >>> loss = IQLLoss(actor, qvalue, value)
         >>> batch = [2, ]
         >>> action = spec.rand(batch)
-        >>> loss_val = loss(
+        >>> loss_actor, loss_qvlaue, loss_value, entropy = loss(
         ...     observation=torch.randn(*batch, n_obs),
         ...     action=action,
         ...     next_done=torch.zeros(*batch, 1, dtype=torch.bool),
         ...     next_observation=torch.zeros(*batch, n_obs),
         ...     next_reward=torch.randn(*batch, 1))
+        >>> loss_actor.backward()
 
     """
 


### PR DESCRIPTION
## Description

Fix missing ("next", "dispatch") key of in_keys from IQL, DDPG, and A2C loss module.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
