### PR TITLE
[BugFix] Parametric `rand_action()` in `BaseEnv`

### DIFF
--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -1048,7 +1048,7 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
                 f" match the tensordict one."
             )
         action = self.action_spec.rand(shape)
-        tensordict.set("action", action)
+        tensordict.set(self.action_key, action)
         return tensordict
 
     def rand_step(self, tensordict: Optional[TensorDictBase] = None) -> TensorDictBase:


### PR DESCRIPTION
`rand_action()` in common needs to be parametericto action key
