### PR TITLE
Envpool Tests to Nova

### DIFF
--- a/.circleci/unittest/linux_libs/scripts_envpool/setup_env.sh
+++ b/.circleci/unittest/linux_libs/scripts_envpool/setup_env.sh
@@ -81,8 +81,8 @@ if [[ $OSTYPE != 'darwin'* ]]; then
 else
   pip install "gym[atari,accept-rom-license]"
 fi
-pip install treevalue
+pip install envpool treevalue
 
-wget https://files.pythonhosted.org/packages/a1/ee/b35ab21e71d34cdcedf05c0d32abca3a3e87d669bdc772660165ee2f55b8/envpool-0.8.2-cp39-cp39-manylinux_2_24_x86_64.whl
-pip install envpool-0.8.2-cp39-cp39-manylinux_2_24_x86_64.whl
-rm envpool-0.8.2-cp39-cp39-manylinux_2_24_x86_64.whl
+# wget https://files.pythonhosted.org/packages/a1/ee/b35ab21e71d34cdcedf05c0d32abca3a3e87d669bdc772660165ee2f55b8/envpool-0.8.2-cp39-cp39-manylinux_2_24_x86_64.whl
+# pip install envpool-0.8.2-cp39-cp39-manylinux_2_24_x86_64.whl
+# rm envpool-0.8.2-cp39-cp39-manylinux_2_24_x86_64.whl

--- a/.circleci/unittest/linux_libs/scripts_envpool/setup_env.sh
+++ b/.circleci/unittest/linux_libs/scripts_envpool/setup_env.sh
@@ -47,7 +47,7 @@ pip install pip --upgrade
 
 conda env update --file "${this_dir}/environment.yml" --prune
 
-yum install mesa-libGL
+yum install -y mesa-libGL
 
 conda deactivate
 conda activate "${env_dir}"

--- a/.circleci/unittest/linux_libs/scripts_envpool/setup_env.sh
+++ b/.circleci/unittest/linux_libs/scripts_envpool/setup_env.sh
@@ -47,6 +47,8 @@ pip install pip --upgrade
 
 conda env update --file "${this_dir}/environment.yml" --prune
 
+yum install mesa-libGL
+
 conda deactivate
 conda activate "${env_dir}"
 

--- a/.circleci/unittest/linux_libs/scripts_envpool/setup_env.sh
+++ b/.circleci/unittest/linux_libs/scripts_envpool/setup_env.sh
@@ -81,4 +81,8 @@ if [[ $OSTYPE != 'darwin'* ]]; then
 else
   pip install "gym[atari,accept-rom-license]"
 fi
-pip install envpool treevalue
+pip install treevalue
+
+wget https://files.pythonhosted.org/packages/a1/ee/b35ab21e71d34cdcedf05c0d32abca3a3e87d669bdc772660165ee2f55b8/envpool-0.8.2-cp39-cp39-manylinux_2_24_x86_64.whl
+pip install envpool-0.8.2-cp39-cp39-manylinux_2_24_x86_64.whl
+rm envpool-0.8.2-cp39-cp39-manylinux_2_24_x86_64.whl

--- a/.github/workflows/test-linux-envpool.yml
+++ b/.github/workflows/test-linux-envpool.yml
@@ -17,7 +17,8 @@ jobs:
       runner: "linux.g5.4xlarge.nvidia.gpu"
       # gpu-arch-type: cuda
       # gpu-arch-version: "11.7"
-      docker-image: "nvidia/cudagl:11.4.0-base"
+      # docker-image: "nvidia/cudagl:11.4.0-base"
+      docker-image: "pytorch/manylinux-cuda117"
       timeout: 120
       script: |
         set -euo pipefail

--- a/.github/workflows/test-linux-envpool.yml
+++ b/.github/workflows/test-linux-envpool.yml
@@ -1,0 +1,34 @@
+name: Envpool Tests on Linux
+
+on:
+  pull_request:
+  push:
+    branches:
+      - nightly
+      - main
+      - release/*
+  workflow_dispatch:
+
+jobs:
+  unittests:
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    with:
+      repository: pytorch/rl
+      runner: "linux.g5.4xlarge.nvidia.gpu"
+      gpu-arch-type: cuda
+      gpu-arch-version: "11.7"
+      timeout: 120
+      script: |
+        set -euo pipefail
+        export PYTHON_VERSION="3.9"
+        export CU_VERSION="11.7"
+        export TAR_OPTIONS="--no-same-owner"
+        export UPLOAD_CHANNEL="nightly"
+        export TF_CPP_MIN_LOG_LEVEL=0
+
+        nvidia-smi
+
+        bash .circleci/unittest/linux_libs/scripts_envpool/setup_env.sh
+        bash .circleci/unittest/linux_libs/scripts_envpool/install.sh
+        bash .circleci/unittest/linux_libs/scripts_envpool/run_test.sh
+        bash .circleci/unittest/linux_libs/scripts_envpool/post_process.sh

--- a/.github/workflows/test-linux-envpool.yml
+++ b/.github/workflows/test-linux-envpool.yml
@@ -22,7 +22,7 @@ jobs:
       timeout: 120
       script: |
         set -euo pipefail
-        export PYTHON_VERSION="3.9"
+        export PYTHON_VERSION="3.8"
         export CU_VERSION="11.7"
         export TAR_OPTIONS="--no-same-owner"
         export UPLOAD_CHANNEL="nightly"

--- a/.github/workflows/test-linux-envpool.yml
+++ b/.github/workflows/test-linux-envpool.yml
@@ -15,8 +15,9 @@ jobs:
     with:
       repository: pytorch/rl
       runner: "linux.g5.4xlarge.nvidia.gpu"
-      gpu-arch-type: cuda
-      gpu-arch-version: "11.7"
+      # gpu-arch-type: cuda
+      # gpu-arch-version: "11.7"
+      docker-image: "nvidia/cudagl:11.4.0-base"
       timeout: 120
       script: |
         set -euo pipefail


### PR DESCRIPTION
Migrating the Envpool CCI test to GHA. Will deprecate the CCI job in a follow-up.

Passing job link: https://github.com/pytorch/rl/actions/runs/5558582448/jobs/10153849785?pr=1283