### PR TITLE
[BugFix] Fix the bug of `RoundRobinWriter.extend(data)` 

### DIFF
--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -187,6 +187,8 @@ class TestComposableBuffers:
                     break
             else:
                 raise RuntimeError("did not find match")
+        data2 = self._get_data(rb_type, size=2 * size + 2)
+        rb.extend(data2)
 
     def test_sample(self, rb_type, sampler, writer, storage, size):
         if rb_type is RemoteTensorDictReplayBuffer and _os_is_windows:

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -94,15 +94,8 @@ class TensorDictRoundRobinWriter(RoundRobinWriter):
     def extend(self, data: Sequence) -> torch.Tensor:
         cur_size = self._cursor
         batch_size = len(data)
-        if cur_size + batch_size <= self._storage.max_size:
-            index = np.arange(cur_size, cur_size + batch_size)
-            self._cursor = (self._cursor + batch_size) % self._storage.max_size
-        else:
-            d = self._storage.max_size - cur_size
-            index = np.empty(batch_size, dtype=np.int64)
-            index[:d] = np.arange(cur_size, self._storage.max_size)
-            index[d:] = np.arange(batch_size - d)
-            self._cursor = batch_size - d
+        index = np.arange(cur_size, batch_size + cur_size) % self._storage.max_size
+        self._cursor = (batch_size + cur_size) % self._storage.max_size
         # storage must convert the data to the appropriate format if needed
         data["index"] = index
         self._storage[index] = data


### PR DESCRIPTION
## Motivation and Context

Fix the bug of `RoundRobinWriter.extend(data)` with data.batch_size > twice of storage.max_size.

bug reproduction:
```python
# bug: RoundRobinWriter
from tensordict import TensorDict
from torchrl.data.replay_buffers import TensorDictReplayBuffer,LazyTensorStorage
import torch
td=TensorDict({"a": torch.rand(10,2)}, batch_size=[10])
rb=TensorDictReplayBuffer(storage=LazyTensorStorage(4))
rb.extend(td)   # IndexError: index 4 is out of bounds for dimension 0 with size 4
```
