### PR TITLE
[BugFix] valid_size not saved as attribute

### DIFF
--- a/test/test_rlhf.py
+++ b/test/test_rlhf.py
@@ -119,18 +119,12 @@ def test_create_or_load_dataset(
 )
 @pytest.mark.parametrize("max_length", [12, 550])
 @pytest.mark.parametrize(
-    "dataset,make_process_fn,pre_tokenization_hook",
+    "dataset,make_process_fn,pre_tokenization_hook,split",
     [
-        (
-            "comp",
-            TensorDictTokenizer,
-            pre_tokenization_hook,
-        ),
-        (
-            "tldr",
-            PromptTensorDictTokenizer,
-            None,
-        ),
+        ("comp", TensorDictTokenizer, pre_tokenization_hook, "train"),
+        ("comp", TensorDictTokenizer, pre_tokenization_hook, "valid1"),
+        ("tldr", PromptTensorDictTokenizer, None, "train"),
+        ("tldr", PromptTensorDictTokenizer, None, "valid"),
     ],
 )
 def test_preproc_data(
@@ -141,7 +135,7 @@ def test_preproc_data(
     pre_tokenization_hook,
     minidata_dir_tldr,
     minidata_dir_comparison,
-    split="train",
+    split,
 ):
     import datasets
 
@@ -159,6 +153,7 @@ def test_preproc_data(
         pre_tokenization_hook=pre_tokenization_hook,
         from_disk=True,
         root_dir=tmpdir1,
+        valid_size=500,
     )
     dataset = loader._load_dataset()
     assert isinstance(dataset, datasets.Dataset)

--- a/torchrl/data/rlhf/dataset.py
+++ b/torchrl/data/rlhf/dataset.py
@@ -106,6 +106,7 @@ class TokenizedDatasetLoader:
         self.pre_tokenization_hook = pre_tokenization_hook
         self.root_dir = root_dir
         self.from_disk = from_disk
+        self.valid_size = valid_size
         if num_workers is None:
             num_workers = max(os.cpu_count() // 2, 1)
         self.num_workers = num_workers


### PR DESCRIPTION
## Description

This PR fixes a bug that arose from valid_size not being used in the constructor of TokenizedDataLoader.

The bug was not caught by the tests because it was only relevant if we used a validation split of the data. To ensure that tests catch a similar regression in the future we parametrized `split` in the test.