### PR TITLE
[Refactor] More unravel fixes

### DIFF
--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -1537,7 +1537,7 @@ def test_ensure_tensordict_compatible():
         in_keys=["x"],
         out_keys=["out_1", "out_2", "out_3"],
     )
-    assert set(unravel_key_list(ensured_module.in_keys)) == {("x",)}
+    assert set(unravel_key_list(ensured_module.in_keys)) == {"x"}
     assert isinstance(ensured_module, TensorDictModule)
 
 

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -7,9 +7,10 @@ import argparse
 
 import pytest
 import torch
-from tensordict import TensorDict, unravel_key_list
+from tensordict import TensorDict
 from tensordict.nn import InteractionType, make_functional, TensorDictModule
 from torch import nn
+from torchrl._utils import unravel_key_list
 from torchrl.data.tensor_specs import (
     BoundedTensorSpec,
     CompositeSpec,

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -2830,7 +2830,7 @@ class TestNoop(TransformBase):
         env = TransformedEnv(SerialEnv(2, ContinuousActionVecMockEnv), NoopResetEnv())
         with pytest.raises(
             ValueError,
-            match="there is more than one done state in the parent environment",
+            match="The parent environment batch-size is non-null",
         ):
             check_env_specs(env)
 
@@ -2904,7 +2904,7 @@ class TestNoop(TransformBase):
         transformed_env.append_transform(noop_reset_env)
         with pytest.raises(
             ValueError,
-            match="there is more than one done state in the parent environment",
+            match="The parent environment batch-size is non-null",
         ):
             transformed_env.reset()
 

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -17,6 +17,8 @@ import warnings
 from copy import copy
 from distutils.util import strtobool
 from functools import wraps
+
+# from tensordict._tensordict import unravel_keys
 from importlib import import_module
 from typing import Any, Callable, cast, TypeVar, Union
 
@@ -529,3 +531,39 @@ class _DecoratorContextManager:
 def get_trace():
     """A simple debugging util to spot where a function is being called."""
     traceback.print_stack()
+
+
+def unravel_key_list(key_list):
+    """Temporary fix for change in behaviour in unravel_key_list."""
+    if isinstance(key_list, str):
+        raise TypeError("incompatible function arguments")
+    key_list_out = []
+    for key in key_list:
+        key = unravel_keys(key)
+        if isinstance(key, tuple) and len(key) == 1:
+            key_list_out.append(key[0])
+        else:
+            key_list_out.append(key)
+    return key_list_out
+
+
+def unravel_keys(key):
+    """Temporary fix for change in behaviour in unravel_key(s).
+
+    The current behaviour is the behavious after update in tensordict.
+
+    This ensures that tests will be passing before and after merge on both parts.
+    """
+    if not isinstance(key, (tuple, str)):
+        raise RuntimeError("key should be a Sequence<NestedKey>")
+    if isinstance(key, str):
+        return key
+    out = []
+    for subkey in key:
+        subkey = unravel_keys(subkey)
+        if isinstance(subkey, str):
+            subkey = (subkey,)
+        out += subkey
+    if len(out) == 1:
+        return out[0]
+    return tuple(out)

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -539,7 +539,7 @@ def unravel_key_list(key_list):
         raise TypeError("incompatible function arguments")
     key_list_out = []
     for key in key_list:
-        key = unravel_keys(key)
+        key = unravel_key(key)
         if isinstance(key, tuple) and len(key) == 1:
             key_list_out.append(key[0])
         else:
@@ -547,7 +547,7 @@ def unravel_key_list(key_list):
     return key_list_out
 
 
-def unravel_keys(key):
+def unravel_key(key):
     """Temporary fix for change in behaviour in unravel_key(s).
 
     The current behaviour is the behavious after update in tensordict.
@@ -560,7 +560,7 @@ def unravel_keys(key):
         return key
     out = []
     for subkey in key:
-        subkey = unravel_keys(subkey)
+        subkey = unravel_key(subkey)
         if isinstance(subkey, str):
             subkey = (subkey,)
         out += subkey

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -548,7 +548,7 @@ def unravel_key_list(key_list):
 
 
 def unravel_key(key):
-    """Temporary fix for change in behaviour in unravel_key(s).
+    """Temporary fix for change in behaviour in the tensordict version.
 
     The current behaviour is the behavious after update in tensordict.
 

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -32,9 +32,9 @@ from typing import (
 import numpy as np
 import torch
 from tensordict.tensordict import TensorDict, TensorDictBase
-from tensordict.utils import _getitem_batch_size, unravel_key
+from tensordict.utils import _getitem_batch_size
 
-from torchrl._utils import get_binary_env_var
+from torchrl._utils import get_binary_env_var, unravel_keys
 
 DEVICE_TYPING = Union[torch.device, str, int]
 
@@ -3392,7 +3392,7 @@ class _CompositeSpecKeysView:
         return f"_CompositeSpecKeysView(keys={list(self)})"
 
     def __contains__(self, item):
-        item = unravel_key(item)
+        item = unravel_keys(item)
         if len(item) == 1:
             item = item[0]
         for key in self.__iter__():

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -34,7 +34,7 @@ import torch
 from tensordict.tensordict import TensorDict, TensorDictBase
 from tensordict.utils import _getitem_batch_size
 
-from torchrl._utils import get_binary_env_var, unravel_keys
+from torchrl._utils import get_binary_env_var, unravel_key
 
 DEVICE_TYPING = Union[torch.device, str, int]
 
@@ -3392,7 +3392,7 @@ class _CompositeSpecKeysView:
         return f"_CompositeSpecKeysView(keys={list(self)})"
 
     def __contains__(self, item):
-        item = unravel_keys(item)
+        item = unravel_key(item)
         if len(item) == 1:
             item = item[0]
         for key in self.__iter__():

--- a/torchrl/envs/transforms/rlhf.py
+++ b/torchrl/envs/transforms/rlhf.py
@@ -13,7 +13,7 @@ from tensordict.nn import (
     repopulate_module,
 )
 from tensordict.utils import is_seq_of_nested_key
-from torchrl._utils import unravel_keys
+from torchrl._utils import unravel_key
 from torchrl.data.tensor_specs import CompositeSpec, UnboundedContinuousTensorSpec
 from torchrl.envs.transforms.transforms import Transform
 
@@ -160,8 +160,8 @@ class KLRewardTransform(Transform):
         output_spec = super().transform_output_spec(output_spec)
         # todo: here we'll need to use the reward_key once it's implemented
         # parent = self.parent
-        in_key = unravel_keys(self.in_keys[0])
-        out_key = unravel_keys(self.out_keys[0])
+        in_key = unravel_key(self.in_keys[0])
+        out_key = unravel_key(self.out_keys[0])
 
         if in_key == "reward" and out_key == "reward":
             parent = self.parent

--- a/torchrl/envs/transforms/rlhf.py
+++ b/torchrl/envs/transforms/rlhf.py
@@ -162,7 +162,7 @@ class KLRewardTransform(Transform):
         in_key = unravel_key(self.in_keys[0])
         out_key = unravel_key(self.out_keys[0])
 
-        if in_key == ("reward",) and out_key == ("reward",):
+        if in_key == "reward" and out_key == "reward":
             parent = self.parent
             reward_spec = UnboundedContinuousTensorSpec(
                 device=output_spec.device,
@@ -172,7 +172,7 @@ class KLRewardTransform(Transform):
                 {parent.reward_key: reward_spec},
                 shape=output_spec["_reward_spec"].shape,
             )
-        elif in_key == ("reward",):
+        elif in_key == "reward":
             parent = self.parent
             reward_spec = UnboundedContinuousTensorSpec(
                 device=output_spec.device,

--- a/torchrl/envs/transforms/rlhf.py
+++ b/torchrl/envs/transforms/rlhf.py
@@ -12,7 +12,8 @@ from tensordict.nn import (
     ProbabilisticTensorDictModule,
     repopulate_module,
 )
-from tensordict.utils import is_seq_of_nested_key, unravel_key
+from tensordict.utils import is_seq_of_nested_key
+from torchrl._utils import unravel_keys
 from torchrl.data.tensor_specs import CompositeSpec, UnboundedContinuousTensorSpec
 from torchrl.envs.transforms.transforms import Transform
 
@@ -159,8 +160,8 @@ class KLRewardTransform(Transform):
         output_spec = super().transform_output_spec(output_spec)
         # todo: here we'll need to use the reward_key once it's implemented
         # parent = self.parent
-        in_key = unravel_key(self.in_keys[0])
-        out_key = unravel_key(self.out_keys[0])
+        in_key = unravel_keys(self.in_keys[0])
+        out_key = unravel_keys(self.out_keys[0])
 
         if in_key == "reward" and out_key == "reward":
             parent = self.parent

--- a/torchrl/envs/transforms/rlhf.py
+++ b/torchrl/envs/transforms/rlhf.py
@@ -12,7 +12,7 @@ from tensordict.nn import (
     ProbabilisticTensorDictModule,
     repopulate_module,
 )
-from tensordict.utils import _normalize_key, is_seq_of_nested_key
+from tensordict.utils import is_seq_of_nested_key, unravel_key
 from torchrl.data.tensor_specs import CompositeSpec, UnboundedContinuousTensorSpec
 from torchrl.envs.transforms.transforms import Transform
 
@@ -159,10 +159,10 @@ class KLRewardTransform(Transform):
         output_spec = super().transform_output_spec(output_spec)
         # todo: here we'll need to use the reward_key once it's implemented
         # parent = self.parent
-        in_key = _normalize_key(self.in_keys[0])
-        out_key = _normalize_key(self.out_keys[0])
+        in_key = unravel_key(self.in_keys[0])
+        out_key = unravel_key(self.out_keys[0])
 
-        if in_key == "reward" and out_key == "reward":
+        if in_key == ("reward",) and out_key == ("reward",):
             parent = self.parent
             reward_spec = UnboundedContinuousTensorSpec(
                 device=output_spec.device,
@@ -172,7 +172,7 @@ class KLRewardTransform(Transform):
                 {parent.reward_key: reward_spec},
                 shape=output_spec["_reward_spec"].shape,
             )
-        elif in_key == "reward":
+        elif in_key == ("reward",):
             parent = self.parent
             reward_spec = UnboundedContinuousTensorSpec(
                 device=output_spec.device,

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -18,7 +18,7 @@ from tensordict.tensordict import TensorDict, TensorDictBase
 from tensordict.utils import expand_as_right
 from torch import nn, Tensor
 
-from torchrl._utils import unravel_key_list, unravel_key
+from torchrl._utils import unravel_key, unravel_key_list
 
 from torchrl.data.tensor_specs import (
     BinaryDiscreteTensorSpec,

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -2781,16 +2781,15 @@ class NoopResetEnv(Transform):
         tensordict = tensordict.clone(False)
         # check that there is a single done state -- behaviour is undefined for multiple dones
         parent = self.parent
-        done_key = parent.done_key
-        reward_key = parent.reward_key
-
         if parent is None:
             raise RuntimeError(
                 "NoopResetEnv.parent not found. Make sure that the parent is set."
             )
-        if tensordict.get(done_key).numel() > 1:
+        done_key = parent.done_key
+        reward_key = parent.reward_key
+        if parent.batch_size.numel() > 1:
             raise ValueError(
-                "there is more than one done state in the parent environment. "
+                "The parent environment batch-size is non-null. "
                 "NoopResetEnv is designed to work on single env instances, as partial reset "
                 "is currently not supported. If you feel like this is a missing feature, submit "
                 "an issue on TorchRL github repo. "
@@ -2798,6 +2797,7 @@ class NoopResetEnv(Transform):
                 "that you can have a transformed batch of transformed envs, such as: "
                 "`TransformedEnv(ParallelEnv(3, lambda: TransformedEnv(MyEnv(), NoopResetEnv(3))), OtherTransform())`."
             )
+
         noops = (
             self.noops if not self.random else torch.randint(self.noops, (1,)).item()
         )

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -15,8 +15,10 @@ from typing import Any, List, Optional, OrderedDict, Sequence, Tuple, Union
 import torch
 from tensordict.nn import dispatch
 from tensordict.tensordict import TensorDict, TensorDictBase
-from tensordict.utils import expand_as_right, unravel_key, unravel_key_list
+from tensordict.utils import expand_as_right
 from torch import nn, Tensor
+
+from torchrl._utils import unravel_key_list, unravel_keys
 
 from torchrl.data.tensor_specs import (
     BinaryDiscreteTensorSpec,
@@ -3670,7 +3672,7 @@ class ExcludeTransform(Transform):
                 {
                     key: value
                     for key, value in observation_spec.items()
-                    if unravel_key(key) not in self.excluded_keys
+                    if unravel_keys(key) not in self.excluded_keys
                 },
                 shape=observation_spec.shape,
             )
@@ -3725,7 +3727,7 @@ class SelectTransform(Transform):
             {
                 key: value
                 for key, value in observation_spec.items()
-                if unravel_key(key) in self.selected_keys
+                if unravel_keys(key) in self.selected_keys
             },
             shape=observation_spec.shape,
         )

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -18,7 +18,7 @@ from tensordict.tensordict import TensorDict, TensorDictBase
 from tensordict.utils import expand_as_right
 from torch import nn, Tensor
 
-from torchrl._utils import unravel_key_list, unravel_keys
+from torchrl._utils import unravel_key_list, unravel_key
 
 from torchrl.data.tensor_specs import (
     BinaryDiscreteTensorSpec,
@@ -3672,7 +3672,7 @@ class ExcludeTransform(Transform):
                 {
                     key: value
                     for key, value in observation_spec.items()
-                    if unravel_keys(key) not in self.excluded_keys
+                    if unravel_key(key) not in self.excluded_keys
                 },
                 shape=observation_spec.shape,
             )
@@ -3727,7 +3727,7 @@ class SelectTransform(Transform):
             {
                 key: value
                 for key, value in observation_spec.items()
-                if unravel_keys(key) in self.selected_keys
+                if unravel_key(key) in self.selected_keys
             },
             shape=observation_spec.shape,
         )

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -4129,9 +4129,9 @@ class RenameTransform(Transform):
             output_spec["_observation_spec"][out_key] = output_spec[
                 "_done_spec"
             ].clone()
-        if "reward" in self.in_keys:
+        if ("reward",) in self.in_keys:
             for i, out_key in enumerate(self.out_keys):  # noqa: B007
-                if self.in_keys[i] == "reward":
+                if self.in_keys[i] == ("reward",):
                     break
             else:
                 raise RuntimeError("Expected one key to be 'reward'")

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -216,7 +216,6 @@ def step_mdp(
         _set_single_key(tensordict, out, action_key)
     for key in next_td.keys():
         _set(next_td, out, key, total_key, excluded)
-
     if next_tensordict is not None:
         return next_tensordict.update(out)
     else:
@@ -245,7 +244,7 @@ def _set_single_key(source, dest, key, clone=False):
 def _set(source, dest, key, total_key, excluded):
     total_key = total_key + (key,)
     non_empty = False
-    if total_key not in excluded:
+    if unravel_key(total_key) not in excluded:
         val = source.get(key)
         if is_tensor_collection(val):
             new_val = dest.get(key, None)

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -28,7 +28,7 @@ from tensordict.tensordict import (
 )
 
 # from tensordict.utils import unravel_keys
-from torchrl._utils import unravel_keys
+from torchrl._utils import unravel_key
 
 __all__ = [
     "exploration_mode",
@@ -195,9 +195,9 @@ def step_mdp(
             return next_tensordict
         return out
 
-    action_key = unravel_keys(action_key)
-    done_key = unravel_keys(done_key)
-    reward_key = unravel_keys(reward_key)
+    action_key = unravel_key(action_key)
+    done_key = unravel_key(done_key)
+    reward_key = unravel_key(reward_key)
 
     excluded = set()
     if exclude_reward:
@@ -246,7 +246,7 @@ def _set_single_key(source, dest, key, clone=False):
 def _set(source, dest, key, total_key, excluded):
     total_key = total_key + (key,)
     non_empty = False
-    if unravel_keys(total_key) not in excluded:
+    if unravel_key(total_key) not in excluded:
         val = source.get(key)
         if is_tensor_collection(val):
             new_val = dest.get(key, None)
@@ -487,7 +487,7 @@ class classproperty:
 
 def _sort_keys(element):
     if isinstance(element, tuple):
-        element = unravel_keys(element)
+        element = unravel_key(element)
         return "_-|-_".join(element)
     return element
 

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -26,7 +26,9 @@ from tensordict.tensordict import (
     TensorDict,
     TensorDictBase,
 )
-from tensordict.utils import unravel_key
+
+# from tensordict.utils import unravel_keys
+from torchrl._utils import unravel_keys
 
 __all__ = [
     "exploration_mode",
@@ -193,9 +195,9 @@ def step_mdp(
             return next_tensordict
         return out
 
-    action_key = unravel_key((action_key,))
-    done_key = unravel_key((done_key,))
-    reward_key = unravel_key((reward_key,))
+    action_key = unravel_keys(action_key)
+    done_key = unravel_keys(done_key)
+    reward_key = unravel_keys(reward_key)
 
     excluded = set()
     if exclude_reward:
@@ -244,7 +246,7 @@ def _set_single_key(source, dest, key, clone=False):
 def _set(source, dest, key, total_key, excluded):
     total_key = total_key + (key,)
     non_empty = False
-    if unravel_key(total_key) not in excluded:
+    if unravel_keys(total_key) not in excluded:
         val = source.get(key)
         if is_tensor_collection(val):
             new_val = dest.get(key, None)
@@ -485,7 +487,7 @@ class classproperty:
 
 def _sort_keys(element):
     if isinstance(element, tuple):
-        element = unravel_key(element)
+        element = unravel_keys(element)
         return "_-|-_".join(element)
     return element
 

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -20,10 +20,10 @@ import numpy as np
 import torch
 from tensordict import TensorDict
 from tensordict.tensordict import LazyStackedTensorDict, TensorDictBase
-from tensordict.utils import unravel_key
 from torch import multiprocessing as mp
 
-from torchrl._utils import _check_for_faulty_process, VERBOSE
+# from tensordict.utils import unravel_keys
+from torchrl._utils import _check_for_faulty_process, unravel_keys, VERBOSE
 from torchrl.data.tensor_specs import (
     CompositeSpec,
     DiscreteTensorSpec,
@@ -331,10 +331,10 @@ class _BatchedEnv(EnvBase):
             self.env_output_keys = []
             self.env_obs_keys = []
             for key in self.output_spec["_observation_spec"].keys(True, True):
-                self.env_output_keys.append(unravel_key(("next", key)))
+                self.env_output_keys.append(unravel_keys(("next", key)))
                 self.env_obs_keys.append(key)
-            self.env_output_keys.append(unravel_key(("next", self.reward_key)))
-            self.env_output_keys.append(unravel_key(("next", self.done_key)))
+            self.env_output_keys.append(unravel_keys(("next", self.reward_key)))
+            self.env_output_keys.append(unravel_keys(("next", self.done_key)))
         else:
             env_input_keys = set()
             for meta_data in self.meta_data:
@@ -355,15 +355,15 @@ class _BatchedEnv(EnvBase):
                     )
                 )
                 env_output_keys = env_output_keys.union(
-                    unravel_key(("next", key))
+                    unravel_keys(("next", key))
                     for key in meta_data.specs["output_spec"]["_observation_spec"].keys(
                         True, True
                     )
                 )
             env_output_keys = env_output_keys.union(
                 {
-                    unravel_key(("next", self.reward_key)),
-                    unravel_key(("next", self.done_key)),
+                    unravel_keys(("next", self.reward_key)),
+                    unravel_keys(("next", self.done_key)),
                 }
             )
             self.env_obs_keys = sorted(env_obs_keys, key=_sort_keys)

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -23,7 +23,7 @@ from tensordict.tensordict import LazyStackedTensorDict, TensorDictBase
 from torch import multiprocessing as mp
 
 # from tensordict.utils import unravel_keys
-from torchrl._utils import _check_for_faulty_process, unravel_keys, VERBOSE
+from torchrl._utils import _check_for_faulty_process, unravel_key, VERBOSE
 from torchrl.data.tensor_specs import (
     CompositeSpec,
     DiscreteTensorSpec,
@@ -331,10 +331,10 @@ class _BatchedEnv(EnvBase):
             self.env_output_keys = []
             self.env_obs_keys = []
             for key in self.output_spec["_observation_spec"].keys(True, True):
-                self.env_output_keys.append(unravel_keys(("next", key)))
+                self.env_output_keys.append(unravel_key(("next", key)))
                 self.env_obs_keys.append(key)
-            self.env_output_keys.append(unravel_keys(("next", self.reward_key)))
-            self.env_output_keys.append(unravel_keys(("next", self.done_key)))
+            self.env_output_keys.append(unravel_key(("next", self.reward_key)))
+            self.env_output_keys.append(unravel_key(("next", self.done_key)))
         else:
             env_input_keys = set()
             for meta_data in self.meta_data:
@@ -355,15 +355,15 @@ class _BatchedEnv(EnvBase):
                     )
                 )
                 env_output_keys = env_output_keys.union(
-                    unravel_keys(("next", key))
+                    unravel_key(("next", key))
                     for key in meta_data.specs["output_spec"]["_observation_spec"].keys(
                         True, True
                     )
                 )
             env_output_keys = env_output_keys.union(
                 {
-                    unravel_keys(("next", self.reward_key)),
-                    unravel_keys(("next", self.done_key)),
+                    unravel_key(("next", self.reward_key)),
+                    unravel_key(("next", self.done_key)),
                 }
             )
             self.env_obs_keys = sorted(env_obs_keys, key=_sort_keys)

--- a/torchrl/modules/tensordict_module/common.py
+++ b/torchrl/modules/tensordict_module/common.py
@@ -12,12 +12,14 @@ import warnings
 from typing import Iterable, Optional, Type, Union
 
 import torch
-from tensordict import unravel_key_list
 
 from tensordict.nn import TensorDictModule, TensorDictModuleBase
 from tensordict.tensordict import TensorDictBase
 
 from torch import nn
+
+# from tensordict import unravel_key_list
+from torchrl._utils import unravel_key_list
 
 from torchrl.data.tensor_specs import CompositeSpec, TensorSpec
 

--- a/torchrl/modules/tensordict_module/probabilistic.py
+++ b/torchrl/modules/tensordict_module/probabilistic.py
@@ -6,7 +6,7 @@
 import warnings
 from typing import Optional, Sequence, Type, Union
 
-from tensordict import TensorDictBase, unravel_key_list
+from tensordict import TensorDictBase
 
 from tensordict.nn import (
     InteractionType,
@@ -14,6 +14,7 @@ from tensordict.nn import (
     ProbabilisticTensorDictSequential,
     TensorDictModule,
 )
+from torchrl._utils import unravel_key_list
 from torchrl.data.tensor_specs import CompositeSpec, TensorSpec
 from torchrl.modules.distributions import Delta
 from torchrl.modules.tensordict_module.common import _forward_hook_safe_action

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -190,8 +190,7 @@ class LSTMModule(ModuleBase):
         in_keys = unravel_key_list(in_keys)
         out_keys = unravel_key_list(out_keys)
         if not isinstance(in_keys, (tuple, list)) or (
-            len(in_keys) != 3
-            and not (len(in_keys) == 4 and in_keys[-1] == ("is_init",))
+            len(in_keys) != 3 and not (len(in_keys) == 4 and in_keys[-1] == "is_init")
         ):
             raise ValueError(
                 f"LSTMModule expects 3 inputs: a value, and two hidden states (and potentially an 'is_init' marker). Got in_keys {in_keys} instead."

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -9,9 +9,10 @@ import torch
 from tensordict.nn import TensorDictModuleBase as ModuleBase
 
 from tensordict.tensordict import NO_DEFAULT, TensorDictBase
-from tensordict.utils import prod, unravel_key_list
+from tensordict.utils import prod
 
 from torch import nn
+from torchrl._utils import unravel_key_list
 
 from torchrl.data import UnboundedContinuousTensorSpec
 from torchrl.objectives.value.functional import (


### PR DESCRIPTION
The problem this PR solves is that we made changes in the way unravel_key(s) work but we'll revert that in tenrordict.
In the meantime, torchrl has been adapted.
Rather than reverting the PR in torchrl which will break the CI, we will do the following:
  - Merge this PR in torchrl to emulate the behaviour of unravel_key in tensordict after https://github.com/pytorch-labs/tensordict/pull/473 is merged
  - Merge https://github.com/pytorch-labs/tensordict/pull/473 in tensordict
  - Revert imports in torchrl to tensordict instead of emulated functions

I expect this will temporarily impact negatively the benchmarks but they should recover afterwards.

cc @matteobettini 