### PR TITLE
Remove Envpool from CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,53 +126,6 @@ jobs:
           name: Check Python types statically
           command: mypy --install-types --non-interactive --config-file mypy.ini
 
-  unittest_linux_envpool_gpu:
-    <<: *binary_common
-    machine:
-      image: ubuntu-2004-cuda-11.4:202110-01
-    resource_class: gpu.nvidia.medium
-    environment:
-      image_name: "pytorch/manylinux-cuda117"
-      TAR_OPTIONS: --no-same-owner
-      PYTHON_VERSION: << parameters.python_version >>
-      CU_VERSION: << parameters.cu_version >>
-
-    steps:
-      - checkout
-      - designate_upload_channel
-      - run:
-          name: Generate cache key
-          # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly
-      - restore_cache:
-          keys:
-            - env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux_libs/scripts_envpool/environment.yml" }}-{{ checksum ".circleci-weekly" }}
-      - run:
-          name: Setup
-          command: .circleci/unittest/linux_libs/scripts_envpool/setup_env.sh
-      - save_cache:
-          key: env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux_libs/scripts_envpool/environment.yml" }}-{{ checksum ".circleci-weekly" }}
-          paths:
-            - conda
-            - env
-      - run:
-          name: Install torchrl
-          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e UPLOAD_CHANNEL -e CU_VERSION "${image_name}" .circleci/unittest/linux_libs/scripts_envpool/install.sh
-      - run:
-          name: Run tests
-          command: bash .circleci/unittest/linux_libs/scripts_envpool/run_test.sh
-      - run:
-          name: Codecov upload
-          command: |
-            curl -Os https://uploader.codecov.io/latest/linux/codecov
-            chmod +x codecov
-            ./codecov -t ${CODECOV_TOKEN} -s ./ -Z -F linux-envpool
-      - run:
-          name: Post Process
-          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_libs/scripts_envpool/post_process.sh
-      - store_test_results:
-          path: test-results
-
   unittest_linux_stable_gpu:
     <<: *binary_common
     machine:
@@ -237,10 +190,6 @@ jobs:
 workflows:
   unittest:
     jobs:
-      - unittest_linux_envpool_gpu:
-          cu_version: cu117
-          name: unittest_linux_envpool_gpu_py3.8
-          python_version: '3.8'
       - unittest_linux_stable_gpu:
           cu_version: cu116
           name: unittest_linux_stable_gpu_py3.9


### PR DESCRIPTION
Removes the Envpool job from CCI since it has been migrated to GHA.