### PR TITLE
[BugFix] Pickable buffer

### DIFF
--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -252,7 +252,8 @@ class TestComposableBuffers:
         rb2 = pickle.loads(serialized)
         assert rb.__dict__.keys() == rb2.__dict__.keys()
         for key in sorted(rb.__dict__.keys()):
-            assert type(rb.__dict__[key]) == type(rb2.__dict__[key])
+            assert isinstance(rb.__dict__[key], type(rb2.__dict__[key]))
+
 
 @pytest.mark.parametrize("storage_type", [TensorStorage])
 class TestStorages:

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -5,6 +5,7 @@
 
 import argparse
 import importlib
+import pickle
 import sys
 from functools import partial
 from unittest import mock
@@ -241,6 +242,17 @@ class TestComposableBuffers:
         if not isinstance(b, bool):
             b = b.all()
         assert b
+
+    def test_pickable(self, rb_type, sampler, writer, storage, size):
+
+        rb = self._get_rb(
+            rb_type=rb_type, sampler=sampler, writer=writer, storage=storage, size=size
+        )
+        serialized = pickle.dumps(rb)
+        rb2 = pickle.loads(serialized)
+        assert rb.__dict__.keys() == rb2.__dict__.keys()
+        for key in sorted(rb.__dict__.keys()):
+            assert rb2.__dict__[key], rb.__dict__[key] == rb2.__dict__[key]
 
 
 @pytest.mark.parametrize("storage_type", [TensorStorage])

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -252,8 +252,7 @@ class TestComposableBuffers:
         rb2 = pickle.loads(serialized)
         assert rb.__dict__.keys() == rb2.__dict__.keys()
         for key in sorted(rb.__dict__.keys()):
-            assert rb2.__dict__[key], rb.__dict__[key] == rb2.__dict__[key]
-
+            assert type(rb.__dict__[key]) == type(rb2.__dict__[key])
 
 @pytest.mark.parametrize("storage_type", [TensorStorage])
 class TestStorages:

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -410,7 +410,7 @@ class ReplayBuffer:
             data = self.sample()
             yield data
 
-    def __getstate__(self) -> dict:
+    def __getstate__(self) -> Dict[str, Any]:
         state = self.__dict__.copy()
         _replay_lock = state.pop("_replay_lock", None)
         _futures_lock = state.pop("_futures_lock", None)
@@ -420,7 +420,7 @@ class ReplayBuffer:
             state["_futures_lock_placeholder"] = None
         return state
 
-    def __setstate__(self, state: dict):
+    def __setstate__(self, state: Dict[str, Any]):
         if "_replay_lock_placeholder" in state:
             state.pop("_replay_lock_placeholder")
             _replay_lock = threading.RLock()

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -412,23 +412,23 @@ class ReplayBuffer:
 
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
-        _replay_lock = state.pop('_replay_lock', None)
-        _futures_lock = state.pop('_futures_lock', None)
+        _replay_lock = state.pop("_replay_lock", None)
+        _futures_lock = state.pop("_futures_lock", None)
         if _replay_lock is not None:
-            state['_replay_lock_placeholder'] = None
-        if _replay_lock is not None:
-            state['_futures_lock_placeholder'] = None
+            state["_replay_lock_placeholder"] = None
+        if _futures_lock is not None:
+            state["_futures_lock_placeholder"] = None
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> dict[str, Any]:
-        if '_replay_lock_placeholder' in state:
-            state.pop('_replay_lock_placeholder')
+        if "_replay_lock_placeholder" in state:
+            state.pop("_replay_lock_placeholder")
             _replay_lock = threading.RLock()
-            state['_replay_lock'] = _replay_lock
-        if '_futures_lock_placeholder' in state:
-            state.pop('_futures_lock_placeholder')
-            _replay_lock = threading.RLock()
-            state['_futures_lock'] = _replay_lock
+            state["_replay_lock"] = _replay_lock
+        if "_futures_lock_placeholder" in state:
+            state.pop("_futures_lock_placeholder")
+            _futures_lock = threading.RLock()
+            state["_futures_lock"] = _futures_lock
         self.__dict__.update(state)
 
 

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -410,6 +410,27 @@ class ReplayBuffer:
             data = self.sample()
             yield data
 
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        _replay_lock = state.pop('_replay_lock', None)
+        _futures_lock = state.pop('_futures_lock', None)
+        if _replay_lock is not None:
+            state['_replay_lock_placeholder'] = None
+        if _replay_lock is not None:
+            state['_futures_lock_placeholder'] = None
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> dict[str, Any]:
+        if '_replay_lock_placeholder' in state:
+            state.pop('_replay_lock_placeholder')
+            _replay_lock = threading.RLock()
+            state['_replay_lock'] = _replay_lock
+        if '_futures_lock_placeholder' in state:
+            state.pop('_futures_lock_placeholder')
+            _replay_lock = threading.RLock()
+            state['_futures_lock'] = _replay_lock
+        self.__dict__.update(state)
+
 
 class PrioritizedReplayBuffer(ReplayBuffer):
     """Prioritized replay buffer.

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -410,7 +410,7 @@ class ReplayBuffer:
             data = self.sample()
             yield data
 
-    def __getstate__(self) -> dict[str, Any]:
+    def __getstate__(self) -> dict:
         state = self.__dict__.copy()
         _replay_lock = state.pop("_replay_lock", None)
         _futures_lock = state.pop("_futures_lock", None)
@@ -420,7 +420,7 @@ class ReplayBuffer:
             state["_futures_lock_placeholder"] = None
         return state
 
-    def __setstate__(self, state: dict[str, Any]) -> dict[str, Any]:
+    def __setstate__(self, state: dict):
         if "_replay_lock_placeholder" in state:
             state.pop("_replay_lock_placeholder")
             _replay_lock = threading.RLock()


### PR DESCRIPTION
## Description

This PR makes the ReplayBuffer pickable. Also a pickable test for the replay buffers.

Tries to solve the following issue: https://github.com/pytorch/rl/issues/1408

## Motivation and Context

It is convenient to have ReplayBuffer and other classes pickable for features like distributed training, were sometimes need to be serialised.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
