### PR TITLE
Fix QValueModule multi_one_hot

### DIFF
--- a/test/test_actors.py
+++ b/test/test_actors.py
@@ -267,6 +267,20 @@ class TestQValue:
         )
 
     @pytest.mark.parametrize(
+        "action_space, var_nums, expected_action",
+        (
+            ("multi_one_hot", [2, 2, 2], [1, 0, 1, 0, 1, 0]),
+            ("multi_one_hot", [2, 4], [1, 0, 1, 0, 0, 0]),
+        ),
+    )
+    def test_qvalue_module_multi_one_hot(self, action_space, var_nums, expected_action):
+        module = QValueModule(action_space=action_space, var_nums=var_nums)
+        in_values = torch.tensor([1.0, 0, 2, 0, 1, 0])
+        action, values, chosen_action_value = module(in_values)
+        assert (torch.tensor(expected_action, dtype=torch.long) == action).all()
+        assert (values == in_values).all()
+
+    @pytest.mark.parametrize(
         "action_space, expected_action",
         (
             ("one_hot", [0, 0, 1, 0, 0]),

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -468,11 +468,17 @@ class QValueModule(TensorDictModuleBase):
     def _categorical(value: torch.Tensor) -> torch.Tensor:
         return torch.argmax(value, dim=-1).to(torch.long)
 
-    def _mult_one_hot(self, value: torch.Tensor, support: torch.Tensor) -> torch.Tensor:
+    def _mult_one_hot(
+        self, value: torch.Tensor, support: torch.Tensor = None
+    ) -> torch.Tensor:
+        if self.var_nums is None:
+            raise ValueError(
+                "var_nums must be provided to the constructor for multi one-hot action spaces."
+            )
         values = value.split(self.var_nums, dim=-1)
         return torch.cat(
             [
-                QValueHook._one_hot(
+                self._one_hot(
                     _value,
                 )
                 for _value in values


### PR DESCRIPTION
## Description

The current implementation of `QValueModule` for `MultiOneHotDiscrete` action spaces seems incorrect and untested. This fixes the issue and adds tests.

## Motivation and Context

I ran into various errors using `MultiOneHotDiscrete` using the following test script:
```python
import gymnasium as gym
from torchrl.envs.libs.gym import GymWrapper
from tensordict.nn import TensorDictModule as Mod, TensorDictSequential as Seq
from torch import nn
import tensordict
from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
from torchrl.modules import QValueModule


class TestEnv(gym.Env):
    def __init__(self):
        self.observation_space = gym.spaces.Box(low=-1, high=1, shape=(2,))
        self.action_space = gym.spaces.MultiDiscrete([2, 3])

    def step(self):
        return self.observation_space.sample(), 0, False, False, {}

    def reset(self):
        return self.observation_space.sample(), {}

env = GymWrapper(TestEnv())
feature = Mod(nn.Linear(env.observation_spec['observation'].shape[0], 2 * 3), in_keys=["observation"], out_keys=["action_value"])
qnet = Seq(
    feature,
    QValueModule(action_space=env.action_spec, var_nums=[3, 3])
)
qnet(env.reset())
```

I basically went through and changed one line at a time until the output was as expected.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
