### PR TITLE
[Feature] Auto-DoubleToFloat

### DIFF
--- a/docs/source/reference/envs.rst
+++ b/docs/source/reference/envs.rst
@@ -452,7 +452,7 @@ to be able to create this other composition:
     Compose
     DiscreteActionProjection
     DoubleToFloat
-    dTypeCastTransform
+    DTypeCastTransform
     ExcludeTransform
     FiniteTensorDictCheck
     FlattenObservation

--- a/docs/source/reference/envs.rst
+++ b/docs/source/reference/envs.rst
@@ -452,6 +452,7 @@ to be able to create this other composition:
     Compose
     DiscreteActionProjection
     DoubleToFloat
+    dTypeCastTransform
     ExcludeTransform
     FiniteTensorDictCheck
     FlattenObservation

--- a/examples/a2c/utils.py
+++ b/examples/a2c/utils.py
@@ -86,14 +86,10 @@ def make_transformed_env_pixels(base_env, env_cfg):
     if not isinstance(env_cfg.reward_scaling, float):
         env_cfg.reward_scaling = DEFAULT_REWARD_SCALING.get(env_cfg.env_name, 5.0)
 
-    env_library = LIBS[env_cfg.env_library]
     env = TransformedEnv(base_env)
 
     reward_scaling = env_cfg.reward_scaling
     env.append_transform(RewardScaling(0.0, reward_scaling))
-
-    double_to_float_list = []
-    double_to_float_inv_list = []
 
     env.append_transform(ToTensorImage())
     env.append_transform(GrayScale())
@@ -102,16 +98,7 @@ def make_transformed_env_pixels(base_env, env_cfg):
     env.append_transform(RewardSum())
     env.append_transform(StepCounter())
 
-    if env_library is DMControlEnv:
-        double_to_float_list += [
-            "reward",
-        ]
-        double_to_float_inv_list += ["action"]  # DMControl requires double-precision
-    env.append_transform(
-        DoubleToFloat(
-            in_keys=double_to_float_list, in_keys_inv=double_to_float_inv_list
-        )
-    )
+    env.append_transform(DoubleToFloat())
     return env
 
 
@@ -119,15 +106,11 @@ def make_transformed_env_states(base_env, env_cfg):
     if not isinstance(env_cfg.reward_scaling, float):
         env_cfg.reward_scaling = DEFAULT_REWARD_SCALING.get(env_cfg.env_name, 5.0)
 
-    env_library = LIBS[env_cfg.env_library]
     env = TransformedEnv(base_env)
 
     reward_scaling = env_cfg.reward_scaling
 
     env.append_transform(RewardScaling(0.0, reward_scaling))
-
-    double_to_float_list = []
-    double_to_float_inv_list = []
 
     # we concatenate all the state vectors
     # even if there is a single tensor, it'll be renamed in "observation_vector"
@@ -141,19 +124,7 @@ def make_transformed_env_states(base_env, env_cfg):
     # obs_norm = ObservationNorm(in_keys=[out_key])
     # env.append_transform(obs_norm)
 
-    if env_library is DMControlEnv:
-        double_to_float_list += [
-            "reward",
-        ]
-        double_to_float_inv_list += ["action"]  # DMControl requires double-precision
-        double_to_float_list += ["observation_vector"]
-    else:
-        double_to_float_list += ["observation_vector"]
-    env.append_transform(
-        DoubleToFloat(
-            in_keys=double_to_float_list, in_keys_inv=double_to_float_inv_list
-        )
-    )
+    env.append_transform(DoubleToFloat())
     return env
 
 

--- a/examples/cql/utils.py
+++ b/examples/cql/utils.py
@@ -41,7 +41,7 @@ def apply_env_transforms(env, reward_scaling=1.0):
         env,
         Compose(
             RewardScaling(loc=0.0, scale=reward_scaling),
-            DoubleToFloat(in_keys=["observation"], in_keys_inv=[]),
+            DoubleToFloat(),
         ),
     )
     return transformed_env
@@ -129,12 +129,7 @@ def make_offline_replay_buffer(rb_cfg):
         sampler=SamplerWithoutReplacement(drop_last=False),
     )
 
-    data.append_transform(
-        DoubleToFloat(
-            in_keys=["observation", ("next", "observation")],
-            in_keys_inv=[],
-        )
-    )
+    data.append_transform(DoubleToFloat())
 
     return data
 

--- a/examples/ddpg/utils.py
+++ b/examples/ddpg/utils.py
@@ -43,7 +43,7 @@ def apply_env_transforms(env, reward_scaling=1.0):
         Compose(
             InitTracker(),
             RewardScaling(loc=0.0, scale=reward_scaling),
-            DoubleToFloat(in_keys=["observation"], in_keys_inv=[]),
+            DoubleToFloat(),
         ),
     )
     return transformed_env

--- a/examples/distributed/collectors/multi_nodes/ray_train.py
+++ b/examples/distributed/collectors/multi_nodes/ray_train.py
@@ -58,9 +58,7 @@ if __name__ == "__main__":
         Compose(
             # normalize observations
             ObservationNorm(in_keys=["observation"]),
-            DoubleToFloat(
-                in_keys=["observation"],
-            ),
+            DoubleToFloat(),
             StepCounter(),
         ),
     )

--- a/examples/dreamer/dreamer_utils.py
+++ b/examples/dreamer/dreamer_utils.py
@@ -121,9 +121,7 @@ def make_env_transforms(
             "reward",
         ]
         float_to_double_list += ["action"]  # DMControl requires double-precision
-    env.append_transform(
-        DoubleToFloat(in_keys=double_to_float_list, in_keys_inv=float_to_double_list)
-    )
+    env.append_transform(DoubleToFloat())
 
     default_dict = {
         "state": UnboundedContinuousTensorSpec(shape=(*env.batch_size, cfg.state_dim)),

--- a/examples/ppo/utils.py
+++ b/examples/ppo/utils.py
@@ -93,14 +93,10 @@ def make_transformed_env_pixels(base_env, env_cfg):
     if not isinstance(env_cfg.reward_scaling, float):
         env_cfg.reward_scaling = DEFAULT_REWARD_SCALING.get(env_cfg.env_name, 5.0)
 
-    env_library = LIBS[env_cfg.env_library]
     env = TransformedEnv(base_env)
 
     reward_scaling = env_cfg.reward_scaling
     env.append_transform(RewardScaling(0.0, reward_scaling))
-
-    double_to_float_list = []
-    double_to_float_inv_list = []
 
     env.append_transform(ToTensorImage())
     env.append_transform(GrayScale())
@@ -112,17 +108,7 @@ def make_transformed_env_pixels(base_env, env_cfg):
     obs_norm = ObservationNorm(in_keys=["pixels"], standard_normal=True)
     env.append_transform(obs_norm)
 
-    if env_library is DMControlEnv:
-        double_to_float_list += [
-            "reward",
-        ]
-        double_to_float_inv_list += ["action"]  # DMControl requires double-precision
-
-    env.append_transform(
-        DoubleToFloat(
-            in_keys=double_to_float_list, in_keys_inv=double_to_float_inv_list
-        )
-    )
+    env.append_transform(DoubleToFloat())
     return env
 
 
@@ -130,15 +116,11 @@ def make_transformed_env_states(base_env, env_cfg):
     if not isinstance(env_cfg.reward_scaling, float):
         env_cfg.reward_scaling = DEFAULT_REWARD_SCALING.get(env_cfg.env_name, 5.0)
 
-    env_library = LIBS[env_cfg.env_library]
     env = TransformedEnv(base_env)
 
     reward_scaling = env_cfg.reward_scaling
 
     env.append_transform(RewardScaling(0.0, reward_scaling))
-
-    double_to_float_list = []
-    double_to_float_inv_list = []
 
     # we concatenate all the state vectors
     # even if there is a single tensor, it'll be renamed in "observation_vector"
@@ -152,19 +134,7 @@ def make_transformed_env_states(base_env, env_cfg):
     # obs_norm = ObservationNorm(in_keys=[out_key])
     # env.append_transform(obs_norm)
 
-    if env_library is DMControlEnv:
-        double_to_float_list += [
-            "reward",
-        ]
-        double_to_float_inv_list += ["action"]  # DMControl requires double-precision
-        double_to_float_list += ["observation_vector"]
-    else:
-        double_to_float_list += ["observation_vector"]
-    env.append_transform(
-        DoubleToFloat(
-            in_keys=double_to_float_list, in_keys_inv=double_to_float_inv_list
-        )
-    )
+    env.append_transform(DoubleToFloat())
     return env
 
 

--- a/examples/sac/utils.py
+++ b/examples/sac/utils.py
@@ -29,7 +29,7 @@ def apply_env_transforms(env, reward_scaling=1.0):
         env,
         Compose(
             RewardScaling(loc=0.0, scale=reward_scaling),
-            DoubleToFloat(in_keys=["observation"], in_keys_inv=[]),
+            DoubleToFloat(),
         ),
     )
     return transformed_env

--- a/examples/td3/utils.py
+++ b/examples/td3/utils.py
@@ -43,7 +43,7 @@ def apply_env_transforms(env, reward_scaling=1.0):
         Compose(
             InitTracker(),
             RewardScaling(loc=0.0, scale=reward_scaling),
-            DoubleToFloat(in_keys=["observation"], in_keys_inv=[]),
+            DoubleToFloat(),
         ),
     )
     return transformed_env

--- a/torchrl/envs/__init__.py
+++ b/torchrl/envs/__init__.py
@@ -15,6 +15,7 @@ from .transforms import (
     Compose,
     DiscreteActionProjection,
     DoubleToFloat,
+    dTypeCastTransform,
     ExcludeTransform,
     FiniteTensorDictCheck,
     FlattenObservation,

--- a/torchrl/envs/__init__.py
+++ b/torchrl/envs/__init__.py
@@ -15,7 +15,7 @@ from .transforms import (
     Compose,
     DiscreteActionProjection,
     DoubleToFloat,
-    dTypeCastTransform,
+    DTypeCastTransform,
     ExcludeTransform,
     FiniteTensorDictCheck,
     FlattenObservation,

--- a/torchrl/envs/libs/isaacgym.py
+++ b/torchrl/envs/libs/isaacgym.py
@@ -36,8 +36,8 @@ class IsaacGymWrapper(GymWrapper):
     """
 
     def __init__(
-        self, env: "isaacgymenvs.tasks.base.vec_task.Env", **kwargs
-    ):  # noqa: F821
+        self, env: "isaacgymenvs.tasks.base.vec_task.Env", **kwargs  # noqa: F821
+    ):
         warnings.warn(
             "IsaacGym environment support is an experimental feature that may change in the future."
         )

--- a/torchrl/envs/transforms/__init__.py
+++ b/torchrl/envs/transforms/__init__.py
@@ -13,6 +13,7 @@ from .transforms import (
     Compose,
     DiscreteActionProjection,
     DoubleToFloat,
+    dTypeCastTransform,
     ExcludeTransform,
     FiniteTensorDictCheck,
     FlattenObservation,

--- a/torchrl/envs/transforms/__init__.py
+++ b/torchrl/envs/transforms/__init__.py
@@ -13,7 +13,7 @@ from .transforms import (
     Compose,
     DiscreteActionProjection,
     DoubleToFloat,
-    dTypeCastTransform,
+    DTypeCastTransform,
     ExcludeTransform,
     FiniteTensorDictCheck,
     FlattenObservation,

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -2342,7 +2342,7 @@ class FiniteTensorDictCheck(Transform):
     forward = _call
 
 
-class dTypeCastTransform(Transform):
+class DTypeCastTransform(Transform):
     """Casts one dtype to another for selected keys.
 
     Depending on whether the ``in_keys`` or ``in_keys_inv`` are provided
@@ -2373,7 +2373,7 @@ class dTypeCastTransform(Transform):
         ...     {'obs': torch.ones(1, dtype=torch.double),
         ...     'not_transformed': torch.ones(1, dtype=torch.double),
         ... }, [])
-        >>> transform = dTypeCastTransform(torch.double, torch.float, in_keys=["obs"])
+        >>> transform = DTypeCastTransform(torch.double, torch.float, in_keys=["obs"])
         >>> _ = transform(td)
         >>> print(td.get("obs").dtype)
         torch.float32
@@ -2387,7 +2387,7 @@ class dTypeCastTransform(Transform):
         ...     {'obs': torch.ones(1, dtype=torch.double),
         ...     'not_transformed': torch.ones(1, dtype=torch.double),
         ... }, [])
-        >>> transform = dTypeCastTransform(torch.double, torch.float)
+        >>> transform = DTypeCastTransform(torch.double, torch.float)
         >>> _ = transform(td)
         >>> print(td.get("obs").dtype)
         torch.float32
@@ -2417,7 +2417,7 @@ class dTypeCastTransform(Transform):
         ...         return obs.select().set("next", obs.update({"reward": reward, "done": done}))
         ...     def _set_seed(self, seed):
         ...         pass
-        >>> env = TransformedEnv(MyEnv(), dTypeCastTransform(torch.double, torch.float))
+        >>> env = TransformedEnv(MyEnv(), DTypeCastTransform(torch.double, torch.float))
         >>> assert env.action_spec.dtype == torch.float32
         >>> assert env.observation_spec["obs"].dtype == torch.float32
         >>> assert env.reward_spec.dtype == torch.float32, env.reward_spec.dtype
@@ -2589,7 +2589,7 @@ class dTypeCastTransform(Transform):
         return s
 
 
-class DoubleToFloat(dTypeCastTransform):
+class DoubleToFloat(DTypeCastTransform):
     """Casts one dtype to another for selected keys.
 
     Depending on whether the ``in_keys`` or ``in_keys_inv`` are provided
@@ -2696,36 +2696,6 @@ class DoubleToFloat(dTypeCastTransform):
         in_keys_inv: Optional[Sequence[NestedKey]] = None,
     ):
         super().__init__(torch.double, torch.float, in_keys, in_keys_inv)
-
-    def _set_in_keys(self):
-        env_base = self.parent
-        if env_base is not None:
-            # retrieve the specs that are float32
-            if self._keys_unset:
-                in_keys = []
-                observation_spec = env_base.observation_spec
-                for key, spec in observation_spec.items(True, True):
-                    if spec.dtype == torch.float64:
-                        in_keys.append(unravel_key(key))
-                reward_spec = env_base.reward_spec
-                if reward_spec.dtype == torch.float64:
-                    in_keys.append(unravel_key(env_base.reward_key))
-
-                self.in_keys = self.out_keys = in_keys
-                self._keys_unset = False
-            if self._keys_inv_unset:
-                in_keys_inv = []
-                state_spec = env_base.state_spec
-                if state_spec is not None:
-                    for key, spec in state_spec.items(True, True):
-                        if spec.dtype == torch.float64:
-                            in_keys_inv.append(unravel_key(key))
-                action_spec = env_base.action_spec
-                if action_spec.dtype == torch.float64:
-                    in_keys_inv.append(unravel_key(env_base.action_key))
-                self.in_keys_inv = self.out_keys_inv = in_keys_inv
-                self._keys_inv_unset = False
-            self._container.empty_cache()
 
 
 class CatTensors(Transform):

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -9,6 +9,7 @@ import collections
 import multiprocessing as mp
 import warnings
 from copy import copy, deepcopy
+from functools import wraps
 from textwrap import indent
 from typing import Any, List, Optional, OrderedDict, Sequence, Tuple, Union
 
@@ -65,6 +66,7 @@ FORWARD_NOT_IMPLEMENTED = "class {} cannot be executed without a parent" "enviro
 
 
 def _apply_to_composite(function):
+    @wraps(function)
     def new_fun(self, observation_spec):
         if isinstance(observation_spec, CompositeSpec):
             d = observation_spec._specs
@@ -215,12 +217,10 @@ class Transform(nn.Module):
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         """Reads the input tensordict, and for the selected keys, applies the transform."""
         for in_key, out_key in zip(self.in_keys, self.out_keys):
-            if in_key in tensordict.keys(include_nested=True):
-                observation = self._apply_transform(tensordict.get(in_key))
-                tensordict.set(
-                    out_key,
-                    observation,
-                )
+            data = tensordict.get(in_key, None)
+            if data is not None:
+                data = self._apply_transform(data)
+                tensordict.set(out_key, data)
             elif not self.missing_tolerance:
                 raise KeyError(f"'{in_key}' not found in tensordict {tensordict}")
         return tensordict
@@ -254,12 +254,10 @@ class Transform(nn.Module):
         # # exposed to the user: we'd like that the input keys remain unchanged
         # # in the originating script if they're being transformed.
         for in_key, out_key in zip(self.in_keys_inv, self.out_keys_inv):
-            if in_key in tensordict.keys(include_nested=True):
-                item = self._inv_apply_transform(tensordict.get(in_key))
-                tensordict.set(
-                    out_key,
-                    item,
-                )
+            data = tensordict.get(in_key, None)
+            if data is not None:
+                item = self._inv_apply_transform(data)
+                tensordict.set(out_key, item)
             elif not self.missing_tolerance:
                 raise KeyError(f"'{in_key}' not found in tensordict {tensordict}")
 
@@ -391,10 +389,7 @@ class Transform(nn.Module):
                     compose_parent = TransformedEnv(
                         compose.__dict__["_container"].base_env
                     )
-                    if compose_parent.transform is not compose:
-                        comp_parent_trans = compose_parent.transform.clone()
-                    else:
-                        comp_parent_trans = None
+                    comp_parent_trans = compose_parent.transform.clone()
                     out = TransformedEnv(
                         compose_parent.base_env,
                         transform=comp_parent_trans,
@@ -2350,6 +2345,21 @@ class FiniteTensorDictCheck(Transform):
 class DoubleToFloat(Transform):
     """Maps actions float to double before they are called on the environment.
 
+    Depending on whether the ``in_keys`` or ``in_keys_inv`` are provided
+    during construction, the class behaviour will change:
+
+      * If the keys are provided, those entries and those entries only will be
+        transformed from ``float64`` to ``float32`` entries;
+      * If the keys are not provided and the object is within an environment
+        register of transforms, the input and output specs that have a dtype
+        set to ``float64`` will be used as in_keys_inv / in_keys respectively.
+      * If the keys are not provided and the object is used without an
+        environment, the ``forward`` / ``inverse`` pass will scan through the
+        input tensordict for all float64 values and map them to a float32
+        tensor. For large data structures, this can impact performance as this
+        scanning doesn't come for free. The keys to be
+        transformed will not be cached.
+
     Args:
         in_keys (sequence of NestedKey, optional): list of double keys to be converted to
             float before being exposed to external objects and functions.
@@ -2358,11 +2368,76 @@ class DoubleToFloat(Transform):
 
     Examples:
         >>> td = TensorDict(
-        ...     {'obs': torch.ones(1, dtype=torch.double)}, [])
+        ...     {'obs': torch.ones(1, dtype=torch.double),
+        ...     'not_transformed': torch.ones(1, dtype=torch.double),
+        ... }, [])
         >>> transform = DoubleToFloat(in_keys=["obs"])
         >>> _ = transform(td)
         >>> print(td.get("obs").dtype)
         torch.float32
+        >>> print(td.get("not_transformed").dtype)
+        torch.float64
+
+    In "automatic" mode, all float64 entries are transformed:
+
+    Examples:
+        >>> td = TensorDict(
+        ...     {'obs': torch.ones(1, dtype=torch.double),
+        ...     'not_transformed': torch.ones(1, dtype=torch.double),
+        ... }, [])
+        >>> transform = DoubleToFloat()
+        >>> _ = transform(td)
+        >>> print(td.get("obs").dtype)
+        torch.float32
+        >>> print(td.get("not_transformed").dtype)
+        torch.float32
+
+    The same behaviour is the rule when environments are constructedw without
+    specifying the transform keys:
+
+    Examples:
+        >>> class MyEnv(EnvBase):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.observation_spec = CompositeSpec(obs=UnboundedContinuousTensorSpec((), dtype=torch.float64))
+        ...         self.action_spec = UnboundedContinuousTensorSpec((), dtype=torch.float64)
+        ...         self.reward_spec = UnboundedContinuousTensorSpec((1,), dtype=torch.float64)
+        ...         self.done_spec = UnboundedContinuousTensorSpec((1,), dtype=torch.bool)
+        ...     def _reset(self, data=None):
+        ...         return TensorDict({"done": torch.zeros((1,), dtype=torch.bool), **self.observation_spec.rand()}, [])
+        ...     def _step(self, data):
+        ...         assert data["action"].dtype == torch.float64
+        ...         reward = self.reward_spec.rand()
+        ...         done = torch.zeros((1,), dtype=torch.bool)
+        ...         obs = self.observation_spec.rand()
+        ...         assert reward.dtype == torch.float64
+        ...         assert obs["obs"].dtype == torch.float64
+        ...         return obs.select().set("next", obs.update({"reward": reward, "done": done}))
+        ...     def _set_seed(self, seed):
+        ...         pass
+        >>> env = TransformedEnv(MyEnv(), DoubleToFloat())
+        >>> assert env.action_spec.dtype == torch.float32
+        >>> assert env.observation_spec["obs"].dtype == torch.float32
+        >>> assert env.reward_spec.dtype == torch.float32, env.reward_spec.dtype
+        >>> print(env.rollout(2))
+        TensorDict(
+            fields={
+                action: Tensor(shape=torch.Size([2]), device=cpu, dtype=torch.float32, is_shared=False),
+                done: Tensor(shape=torch.Size([2, 1]), device=cpu, dtype=torch.bool, is_shared=False),
+                next: TensorDict(
+                    fields={
+                        done: Tensor(shape=torch.Size([2, 1]), device=cpu, dtype=torch.bool, is_shared=False),
+                        obs: Tensor(shape=torch.Size([2]), device=cpu, dtype=torch.float32, is_shared=False),
+                        reward: Tensor(shape=torch.Size([2, 1]), device=cpu, dtype=torch.float32, is_shared=False)},
+                    batch_size=torch.Size([2]),
+                    device=cpu,
+                    is_shared=False),
+                obs: Tensor(shape=torch.Size([2]), device=cpu, dtype=torch.float32, is_shared=False)},
+            batch_size=torch.Size([2]),
+            device=cpu,
+            is_shared=False)
+        >>> assert env.transform.in_keys == ["obs", "reward"]
+        >>> assert env.transform.in_keys_inv == ["action"]
 
     """
 
@@ -2373,7 +2448,74 @@ class DoubleToFloat(Transform):
         in_keys: Optional[Sequence[NestedKey]] = None,
         in_keys_inv: Optional[Sequence[NestedKey]] = None,
     ):
+        if in_keys is None:
+            self._keys_unset = True
+            in_keys = []
+        else:
+            self._keys_unset = False
+        if in_keys_inv is None:
+            self._keys_inv_unset = True
+            in_keys_inv = []
+        else:
+            self._keys_inv_unset = False
+
         super().__init__(in_keys=in_keys, in_keys_inv=in_keys_inv)
+
+    def _set_in_keys(self):
+        env_base = self.parent
+        if env_base is not None:
+            # retrieve the specs that are float32
+            if self._keys_unset:
+                in_keys = []
+                observation_spec = env_base.observation_spec
+                for key, spec in observation_spec.items(True, True):
+                    if spec.dtype == torch.float64:
+                        in_keys.append(unravel_key(key))
+                reward_spec = env_base.reward_spec
+                if reward_spec.dtype == torch.float64:
+                    in_keys.append(unravel_key(env_base.reward_key))
+
+                self.in_keys = self.out_keys = in_keys
+                self._keys_unset = False
+            if self._keys_inv_unset:
+                in_keys_inv = []
+                state_spec = env_base.state_spec
+                if state_spec is not None:
+                    for key, spec in state_spec.items(True, True):
+                        if spec.dtype == torch.float64:
+                            in_keys_inv.append(unravel_key(key))
+                action_spec = env_base.action_spec
+                if action_spec.dtype == torch.float64:
+                    in_keys_inv.append(unravel_key(env_base.action_key))
+                self.in_keys_inv = self.out_keys_inv = in_keys_inv
+                self._keys_inv_unset = False
+            self._container.empty_cache()
+
+    @dispatch(source="in_keys", dest="out_keys")
+    def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
+        """Reads the input tensordict, and for the selected keys, applies the transform."""
+        if self._keys_unset:
+            self._set_in_keys()
+            for in_key, data in tensordict.items(True, True):
+                if data.dtype == torch.float64:
+                    out_key = in_key
+                    data = self._apply_transform(data)
+                    tensordict.set(out_key, data)
+            return tensordict
+        return super().forward(tensordict)
+
+    def _inv_call(self, tensordict: TensorDictBase) -> TensorDictBase:
+        if self._keys_inv_unset:
+            self._set_in_keys()
+            # we can't differentiate between content of forward and inverse
+            tensordict = tensordict.clone(False)
+            for in_key, data in tensordict.items(True, True):
+                if data.dtype == torch.float32:
+                    out_key = in_key
+                    data = self._inv_apply_transform(data)
+                    tensordict.set(out_key, data)
+            return tensordict
+        return super()._inv_call(tensordict)
 
     def _apply_transform(self, obs: torch.Tensor) -> torch.Tensor:
         return obs.to(torch.float)
@@ -2393,6 +2535,8 @@ class DoubleToFloat(Transform):
                 space.maximum = space.maximum.to(torch.float)
 
     def transform_input_spec(self, input_spec: TensorSpec) -> TensorSpec:
+        if self._keys_inv_unset:
+            self._set_in_keys()
         action_spec = input_spec["_action_spec"]
         state_spec = input_spec["_state_spec"]
         for key in self.in_keys_inv:
@@ -2411,6 +2555,8 @@ class DoubleToFloat(Transform):
 
     @_apply_to_composite
     def transform_reward_spec(self, reward_spec: TensorSpec) -> TensorSpec:
+        if self._keys_unset:
+            self._set_in_keys()
         reward_key = self.parent.reward_key if self.parent is not None else "reward"
         if unravel_key(reward_key) in self.in_keys:
             if reward_spec.dtype is not torch.double:
@@ -2419,8 +2565,13 @@ class DoubleToFloat(Transform):
             self._transform_spec(reward_spec)
         return reward_spec
 
-    @_apply_to_composite
     def transform_observation_spec(self, observation_spec: TensorSpec) -> TensorSpec:
+        if self._keys_unset:
+            self._set_in_keys()
+        return self._transform_observation_spec(observation_spec)
+
+    @_apply_to_composite
+    def _transform_observation_spec(self, observation_spec: TensorSpec) -> TensorSpec:
         self._transform_spec(observation_spec)
         return observation_spec
 


### PR DESCRIPTION
## Description

Closes #1437 

As per the discussion below, we also introduce a ``dTypeCastTransform``.
This class is tested through Double2Float: we do this as transform tests take a long time to run and double2float tests cover all functionalities of the parent class. This is not optimal but it saves about a minute of CI runtime.