### PR TITLE
Fix MacOS Mujoco Failure

### DIFF
--- a/.github/workflows/test-macos-cpu.yml
+++ b/.github/workflows/test-macos-cpu.yml
@@ -32,6 +32,7 @@ jobs:
         # Set env vars from matrix
         export PYTHON_VERSION=${{ matrix.python_version }}
         export CU_VERSION="cpu"
+        export SYSTEM_VERSION_COMPAT=0
 
         echo "PYTHON_VERSION: $PYTHON_VERSION"
         echo "CU_VERSION: $CU_VERSION"


### PR DESCRIPTION
Despite runners running MacOS 12.6, we see wheels for mujoco being fetched for MacOS 10.6 despite MacOS 11.0 wheels being available. This is due to a strange pattern used for MacOS versioning - where essentially setting SYSTEM_VERSION_COMPAT determines what is the MacOS SDK version Python believes is being used. More info at https://github.com/deepmind/mujoco/issues/1004 and https://eclecticlight.co/2020/08/13/macos-version-numbering-isnt-so-simple/. 