### PR TITLE
[BugFix] CompositeSpec.unsqueeze

### DIFF
--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -3117,7 +3117,7 @@ class CompositeSpec(TensorSpec):
 
     def unsqueeze(self, dim: int):
         if dim < 0:
-            dim += len(self.shape)
+            dim += len(self.shape) + 1
 
         shape = _unsqueezed_shape(self.shape, dim)
 


### PR DESCRIPTION
## Description

Make `CompositeSpec.unsqueeze` match the expected behavior.

```python
from torchrl.data import CompositeSpec, UnboundedContinuousTensorSpec

spec = CompositeSpec({
    "a": UnboundedContinuousTensorSpec((10, 16))
}, shape=[10])
print(spec.unsqueeze(-1))

```
should give

```
CompositeSpec(
    a: UnboundedContinuousTensorSpec(
        shape=torch.Size([10, 1, 16]),
        space=None,
        device=cpu,
        dtype=torch.float32,
        domain=continuous), device=cpu, shape=torch.Size([10, 1]))
```

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
