### PR TITLE
[CI] Fix Mujoco version 

### DIFF
--- a/.circleci/unittest/linux/scripts/run_all.sh
+++ b/.circleci/unittest/linux/scripts/run_all.sh
@@ -90,6 +90,7 @@ conda activate "${env_dir}"
 echo "installing gymnasium"
 pip3 install "gymnasium[atari,ale-py,accept-rom-license]"
 pip3 install mo-gymnasium[mujoco]  # requires here bc needs mujoco-py
+pip3 install mujoco -U
 
 # sanity check: remove?
 python3 -c """


### PR DESCRIPTION
## Description

[mo-gymnasium](https://github.com/Farama-Foundation/MO-Gymnasium/commit/e7d1930cee84a0c22e1b0eca1087051c38de4e11) requires an [older version of mujoco](https://github.com/Farama-Foundation/MO-Gymnasium/blob/e7d1930cee84a0c22e1b0eca1087051c38de4e11/pyproject.toml#L50) than the current one which is [used by dm_control](https://github.com/deepmind/dm_control/blob/d6f9cb4e4a616d1e1d3bd8944bc89541434f1d49/setup.py#L204).

This PR fixes that by upgrading mujoco despite the strong requirement from mo-gymnasium, hoping for the best