### PR TITLE
[BugFix] Fix NoopResetEnv behavior when trials exceeded.

### DIFF
--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -1047,6 +1047,25 @@ class CountingEnv(EnvBase):
         return tensordict.select().set("next", tensordict)
 
 
+class IncrementingEnv(CountingEnv):
+    # Same as CountingEnv but always increments the count by 1 regardless of the action.
+    def _step(
+        self,
+        tensordict: TensorDictBase,
+    ) -> TensorDictBase:
+        self.count += 1  # The only difference with CountingEnv.
+        tensordict = TensorDict(
+            source={
+                "observation": self.count.clone(),
+                "done": self.count > self.max_steps,
+                "reward": torch.zeros_like(self.count, dtype=torch.float),
+            },
+            batch_size=self.batch_size,
+            device=self.device,
+        )
+        return tensordict.select().set("next", tensordict)
+
+
 class NestedCountingEnv(CountingEnv):
     # an env with nested reward and done states
     def __init__(

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -3177,7 +3177,7 @@ class TestNoop(TransformBase):
         check_env_specs(env)
         noop_reset_env = NoopResetEnv(noops=noops, random=False)
         transformed_env = TransformedEnv(env, noop_reset_env)
-        if noops <= max_steps:  # Normal behaviour.
+        if noops <= max_steps:  # Normal behavior.
             result = transformed_env.reset()
             assert result["observation"] == noops
         elif noops > max_steps:  # Raise error as reset limit exceeded.

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -3170,8 +3170,8 @@ class TestNoop(TransformBase):
         ):
             transformed_env.reset()
 
-    @pytest.mark.parametrize("noops", [0, 2, 7, 15])
-    @pytest.mark.parametrize("max_steps", [0, 5])
+    @pytest.mark.parametrize("noops", [0, 2, 8])
+    @pytest.mark.parametrize("max_steps", [0, 5, 9])
     def test_noop_reset_limit_exceeded(self, noops, max_steps):
         env = IncrementingEnv(max_steps=max_steps)
         check_env_specs(env)
@@ -3180,15 +3180,9 @@ class TestNoop(TransformBase):
         if noops <= max_steps:  # Normal behaviour.
             result = transformed_env.reset()
             assert result["observation"] == noops
-        elif max_steps == 0:  # Error as env is done after a single step.
+        elif noops > max_steps:  # Raise error as reset limit exceeded.
             with pytest.raises(RuntimeError):
                 transformed_env.reset()
-        elif noops > max_steps:  # Warn noop reset limit exceeded.
-            with pytest.warns(UserWarning):
-                result = transformed_env.reset()
-                assert result["observation"] == 1  # A single noop is applied.
-        else:
-            raise RuntimeError("This should never happen.")
 
 
 class TestObservationNorm(TransformBase):

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3114,7 +3114,7 @@ class NoopResetEnv(Transform):
         noops (int, optional): upper-bound on the number of actions
             performed after reset. Default is `30`.
             If noops is too high such that it results in the env being
-            done or truncated before the all noops are applied,
+            done or truncated before the all the noops are applied,
             in multiple trials, the transform raises a RuntimeError.
         random (bool, optional): if False, the number of random ops will
             always be equal to the noops value. If True, the number of

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3159,10 +3159,11 @@ class NoopResetEnv(Transform):
         noops = (
             self.noops if not self.random else torch.randint(self.noops, (1,)).item()
         )
-        trial = 0
 
+        trial = 0
         while trial <= _MAX_NOOPS_TRIALS:
             i = 0
+
             while i < noops:
                 i += 1
                 tensordict = parent.rand_step(tensordict)
@@ -3176,6 +3177,7 @@ class NoopResetEnv(Transform):
                 break
 
             trial += 1
+
         else:
             raise RuntimeError(
                 f"Parent env was repeatedly done or truncated"

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3178,7 +3178,10 @@ class NoopResetEnv(Transform):
 
             trial += 1
             if trial > _MAX_NOOPS_TRIALS:
-                trials_exceeded_message = "Parent env was repeatedly done or truncated before the sampled number of noops could be applied. "
+                trials_exceeded_message = (
+                    "Parent env was repeatedly done or truncated"
+                    " before the sampled number of noops could be applied. "
+                )
                 tensordict = parent.rand_step(tensordict)
                 tensordict = step_mdp(tensordict, exclude_done=False)
                 if tensordict.get(done_key) or tensordict.get(


### PR DESCRIPTION
## Description

When the `_MAX_NOOPS_TRIALS` were exceeded the transform was calling a final `rand_step()` without a `step_mdp()`.
This PR add the `step_mdp()` call and 
- Improves the error message.
- Adds tests to test for the edge case behaviors of the transform.
- Fixes the documentation of the tranform.

Some things could be discussed. I left a TODO in front, which we will remove before merging.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
