### PR TITLE
[Bug Fix] Fix unhashable type when using gym envs (e.g. cliffwalking)

### DIFF
--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -186,6 +186,13 @@ class GymLikeEnv(_EnvWrapper):
         action = tensordict.get("action")
         action_np = self.read_action(action)
 
+        try:
+            # Gym uses action to reference to a cell in dictionary in some of its environments (e.g. cliffwalking)
+            # Keeping action in numpy would raise TypeError: unhashable type: 'numpy.ndarray'
+            action_np = action_np.item()
+        except ValueError:
+            pass
+
         reward = 0
         for _ in range(self.wrapper_frame_skip):
             obs, _reward, done, *info = self._output_transform(


### PR DESCRIPTION
## Description

This PR fixes a bug when working with some of gym environments. 

Gym uses action to reference a cell in table (dict object). If the action type is numpy, it raises 
`TypeError: unhashable type: 'numpy.ndarray'`

## Motivation and Context

close #1480 

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
