### PR TITLE
[Feature] VMAS: choose between categorical or one-hot actions

### DIFF
--- a/examples/multiagent/sac.py
+++ b/examples/multiagent/sac.py
@@ -11,7 +11,7 @@ import torch
 from tensordict.nn import TensorDictModule
 from tensordict.nn.distributions import NormalParamExtractor
 from torch import nn
-from torch.distributions import Categorical
+from torch.distributions import Categorical, OneHotCategorical
 from torchrl.collectors import SyncDataCollector
 from torchrl.data import TensorDictReplayBuffer
 from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
@@ -52,6 +52,7 @@ def train(cfg: "DictConfig"):  # noqa: F821
         max_steps=cfg.env.max_steps,
         device=cfg.env.device,
         seed=cfg.seed,
+        categorical_actions=cfg.env.categorical_action,
         # Scenario kwargs
         **cfg.env.scenario,
     )
@@ -148,7 +149,9 @@ def train(cfg: "DictConfig"):  # noqa: F821
             spec=env.unbatched_action_spec,
             in_keys=[("agents", "logits")],
             out_keys=[env.action_key],
-            distribution_class=Categorical,
+            distribution_class=OneHotCategorical
+            if not cfg.env.categorical_action
+            else Categorical,
             return_log_prob=True,
         )
 

--- a/examples/multiagent/sac.yaml
+++ b/examples/multiagent/sac.yaml
@@ -2,6 +2,7 @@ seed: 0
 
 env:
   continuous_actions: True # False for discrete sac
+  categorical_actions: False
   max_steps: 100
   scenario_name: "balance"
   scenario:

--- a/torchrl/envs/libs/vmas.py
+++ b/torchrl/envs/libs/vmas.py
@@ -105,13 +105,17 @@ class VmasWrapper(_EnvWrapper):
     available_envs = _get_envs()
 
     def __init__(
-        self, env: "vmas.simulator.environment.environment.Environment" = None, **kwargs
+        self,
+        env: "vmas.simulator.environment.environment.Environment" = None,
+        categorical_actions: bool = True,
+        **kwargs,
     ):
         if env is not None:
             kwargs["env"] = env
             if "device" in kwargs.keys() and kwargs["device"] != str(env.device):
                 raise TypeError("Env device is different from vmas device")
             kwargs["device"] = str(env.device)
+        self.categorical_actions = categorical_actions
         super().__init__(**kwargs)
 
     @property
@@ -165,7 +169,7 @@ class VmasWrapper(_EnvWrapper):
                     {
                         "action": _gym_to_torchrl_spec_transform(
                             self.action_space[agent_index],
-                            categorical_action_encoding=True,
+                            categorical_action_encoding=self.categorical_actions,
                             device=self.device,
                             remap_state_to_observation=False,
                         )  # shape = (n_actions_per_agent,)
@@ -396,6 +400,10 @@ class VmasWrapper(_EnvWrapper):
         return rewards
 
     def read_action(self, action):
+        if not self.categorical_actions:
+            action = self.unbatched_action_spec["agents", "action"].to_categorical(
+                action
+            )
         agent_actions = []
         for i in range(self.n_agents):
             agent_actions.append(action[:, i, ...])
@@ -468,6 +476,7 @@ class VmasEnv(VmasWrapper):
         num_envs: int,
         continuous_actions: bool = True,
         max_steps: Optional[int] = None,
+        categorical_actions: bool = True,
         seed: Optional[int] = None,
         **kwargs,
     ):
@@ -481,6 +490,7 @@ class VmasEnv(VmasWrapper):
         kwargs["continuous_actions"] = continuous_actions
         kwargs["max_steps"] = max_steps
         kwargs["seed"] = seed
+        kwargs["categorical_actions"] = categorical_actions
         super().__init__(**kwargs)
 
     def _check_kwargs(self, kwargs: Dict):

--- a/torchrl/envs/libs/vmas.py
+++ b/torchrl/envs/libs/vmas.py
@@ -400,7 +400,7 @@ class VmasWrapper(_EnvWrapper):
         return rewards
 
     def read_action(self, action):
-        if not self.categorical_actions:
+        if not self.continuous_actions and not self.categorical_actions:
             action = self.unbatched_action_spec["agents", "action"].to_categorical(
                 action
             )


### PR DESCRIPTION
Ths PR introduces a flag when constructing vmas environments that allows users to choose whether they want one hot or categorical actions when the actions are discrete.

Defaults to categorical for bc-comaptibility