### PR TITLE
[BugFix] Multiagent "auto" entropy fix in SAC

### DIFF
--- a/examples/multiagent/sac.py
+++ b/examples/multiagent/sac.py
@@ -189,7 +189,10 @@ def train(cfg: "DictConfig"):  # noqa: F821
 
     if cfg.env.continuous_actions:
         loss_module = SACLoss(
-            actor_network=policy, qvalue_network=value_module, delay_qvalue=True
+            actor_network=policy,
+            qvalue_network=value_module,
+            delay_qvalue=True,
+            action_spec=env.unbatched_action_spec,
         )
         loss_module.set_keys(
             state_action_value=("agents", "state_action_value"),

--- a/torchrl/objectives/cql.py
+++ b/torchrl/objectives/cql.py
@@ -366,8 +366,19 @@ class CQLLoss(LossModule):
                     )
                 if not isinstance(action_spec, CompositeSpec):
                     action_spec = CompositeSpec({self.tensor_keys.action: action_spec})
+                if (
+                    isinstance(self.tensor_keys.action, tuple)
+                    and len(self.tensor_keys.action) > 1
+                ):
+                    action_container_shape = action_spec[
+                        self.tensor_keys.action[:-1]
+                    ].shape
+                else:
+                    action_container_shape = action_spec.shape
                 target_entropy = -float(
-                    np.prod(action_spec[self.tensor_keys.action].shape)
+                    action_spec[self.tensor_keys.action]
+                    .shape[len(action_container_shape) :]
+                    .numel()
                 )
             self.register_buffer(
                 "target_entropy_buffer", torch.tensor(target_entropy, device=device)

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from numbers import Number
 from typing import Union
 
-import numpy as np
 import torch
 
 from tensordict.nn import dispatch, TensorDictModule, TensorDictSequential
@@ -352,8 +351,19 @@ class REDQLoss(LossModule):
                     )
                 if not isinstance(action_spec, CompositeSpec):
                     action_spec = CompositeSpec({self.tensor_keys.action: action_spec})
+                if (
+                    isinstance(self.tensor_keys.action, tuple)
+                    and len(self.tensor_keys.action) > 1
+                ):
+                    action_container_shape = action_spec[
+                        self.tensor_keys.action[:-1]
+                    ].shape
+                else:
+                    action_container_shape = action_spec.shape
                 target_entropy = -float(
-                    np.prod(action_spec[self.tensor_keys.action].shape)
+                    action_spec[self.tensor_keys.action]
+                    .shape[len(action_container_shape) :]
+                    .numel()
                 )
             self.register_buffer(
                 "target_entropy_buffer", torch.tensor(target_entropy, device=device)

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -410,11 +410,9 @@ class SACLoss(LossModule):
                 else:
                     action_container_shape = action_spec.shape
                 target_entropy = -float(
-                    np.prod(
-                        action_spec[self.tensor_keys.action].shape[
+                    action_spec[self.tensor_keys.action].shape[
                             len(action_container_shape) :
-                        ]
-                    )
+                    ].numel()
                 )
             self.register_buffer(
                 "target_entropy_buffer", torch.tensor(target_entropy, device=device)

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -270,7 +270,18 @@ class TD3Loss(LossModule):
             )
         elif action_spec is not None:
             if isinstance(action_spec, CompositeSpec):
-                action_spec = action_spec[self.tensor_keys.action]
+                if (
+                    isinstance(self.tensor_keys.action, tuple)
+                    and len(self.tensor_keys.action) > 1
+                ):
+                    action_container_shape = action_spec[
+                        self.tensor_keys.action[:-1]
+                    ].shape
+                else:
+                    action_container_shape = action_spec.shape
+                action_spec = action_spec[self.tensor_keys.action][
+                    (0,) * len(action_container_shape)
+                ]
             if not isinstance(action_spec, BoundedTensorSpec):
                 raise ValueError(
                     f"action_spec is not of type BoundedTensorSpec but {type(action_spec)}."


### PR DESCRIPTION
In SAC, when the entropy target is set to "auto", it is computed using the shape of the action.
In multi-agent settings this shape included the number of agents, which should not be the case.

This PR fixes that