### PR TITLE
[Feature] Making action masks compatible with q value modules and e-greedy

### DIFF
--- a/docs/source/reference/modules.rst
+++ b/docs/source/reference/modules.rst
@@ -69,6 +69,7 @@ other cases, the action written in the tensordict is simply the network output.
 
     AdditiveGaussianWrapper
     EGreedyWrapper
+    EGreedyModule
     OrnsteinUhlenbeckProcessWrapper
 
 Probabilistic actors

--- a/docs/source/reference/modules.rst
+++ b/docs/source/reference/modules.rst
@@ -68,7 +68,6 @@ other cases, the action written in the tensordict is simply the network output.
     :template: rl_template_noinherit.rst
 
     AdditiveGaussianWrapper
-    EGreedyWrapper
     EGreedyModule
     OrnsteinUhlenbeckProcessWrapper
 

--- a/examples/multiagent/iql.py
+++ b/examples/multiagent/iql.py
@@ -101,7 +101,7 @@ def train(cfg: "DictConfig"):  # noqa: F821
         eps_end=0,
         annealing_num_steps=int(cfg.collector.total_frames * (1 / 2)),
         action_key=env.action_key,
-        spec=env.input_spec["full_action_spec"],
+        spec=env.unbatched_action_spec,
     )
 
     collector = SyncDataCollector(

--- a/examples/multiagent/iql.py
+++ b/examples/multiagent/iql.py
@@ -101,7 +101,7 @@ def train(cfg: "DictConfig"):  # noqa: F821
         eps_end=0,
         annealing_num_steps=int(cfg.collector.total_frames * (1 / 2)),
         action_key=env.action_key,
-        spec=env.unbatched_action_spec[env.action_key],
+        spec=env.input_spec["full_action_spec"],
     )
 
     collector = SyncDataCollector(

--- a/examples/multiagent/qmix_vdn.py
+++ b/examples/multiagent/qmix_vdn.py
@@ -102,7 +102,7 @@ def train(cfg: "DictConfig"):  # noqa: F821
         eps_end=0,
         annealing_num_steps=int(cfg.collector.total_frames * (1 / 2)),
         action_key=env.action_key,
-        spec=env.input_spec["full_action_spec"],
+        spec=env.unbatched_action_spec,
     )
 
     if cfg.loss.mixer_type == "qmix":

--- a/examples/multiagent/qmix_vdn.py
+++ b/examples/multiagent/qmix_vdn.py
@@ -102,7 +102,7 @@ def train(cfg: "DictConfig"):  # noqa: F821
         eps_end=0,
         annealing_num_steps=int(cfg.collector.total_frames * (1 / 2)),
         action_key=env.action_key,
-        spec=env.unbatched_action_spec[env.action_key],
+        spec=env.input_spec["full_action_spec"],
     )
 
     if cfg.loss.mixer_type == "qmix":

--- a/test/test_actors.py
+++ b/test/test_actors.py
@@ -619,7 +619,7 @@ class TestQValue:
         torch.manual_seed(0)
         shape = (3, 4, 3, action_n)
         action_values = torch.randn(size=shape)
-        td = TensorDict({"action_value": action_values.clone()}, [3])
+        td = TensorDict({"action_value": action_values}, [3])
         module = QValueModule(
             action_space=action_space,
             action_value_key="action_value",

--- a/test/test_actors.py
+++ b/test/test_actors.py
@@ -614,9 +614,10 @@ class TestQValue:
         assert (values == in_values).all()
 
     @pytest.mark.parametrize("action_space", ["categorical", "one-hot"])
-    def test_qvalue_mask(self, action_space):
+    @pytest.mark.parametrize("action_n", [2, 3, 4, 5])
+    def test_qvalue_mask(self, action_space, action_n):
         torch.manual_seed(0)
-        shape = (3, 4, 6)
+        shape = (3, 4, 3, action_n)
         action_values = torch.randn(size=shape)
         td = TensorDict({"action_value": action_values.clone()}, [3])
         module = QValueModule(
@@ -637,6 +638,7 @@ class TestQValue:
 
         assert (new_action_values[~action_mask] != action_values[~action_mask]).all()
         assert (new_action_values[action_mask] == action_values[action_mask]).all()
+        assert (td.get("chosen_action_value") > torch.finfo(torch.float).min).all()
 
         if action_space == "one-hot":
             assert (td.get("action")[action_mask]).any()

--- a/test/test_exploration.py
+++ b/test/test_exploration.py
@@ -14,12 +14,18 @@ from mocking_classes import (
     NestedCountingEnv,
 )
 from scipy.stats import ttest_1samp
-from tensordict.nn import InteractionType, TensorDictModule
+
+from tensordict.nn import InteractionType, TensorDictModule, TensorDictSequential
 from tensordict.tensordict import TensorDict
 from torch import nn
 
 from torchrl.collectors import SyncDataCollector
-from torchrl.data import BoundedTensorSpec, CompositeSpec
+from torchrl.data import (
+    BoundedTensorSpec,
+    CompositeSpec,
+    DiscreteTensorSpec,
+    OneHotDiscreteTensorSpec,
+)
 from torchrl.envs import SerialEnv
 from torchrl.envs.transforms.transforms import gSDENoise, InitTracker, TransformedEnv
 from torchrl.envs.utils import set_exploration_type
@@ -30,10 +36,15 @@ from torchrl.modules.distributions.continuous import (
     NormalParamWrapper,
 )
 from torchrl.modules.models.exploration import LazygSDEModule
-from torchrl.modules.tensordict_module.actors import Actor, ProbabilisticActor
+from torchrl.modules.tensordict_module.actors import (
+    Actor,
+    ProbabilisticActor,
+    QValueActor,
+)
 from torchrl.modules.tensordict_module.exploration import (
     _OrnsteinUhlenbeckProcess,
     AdditiveGaussianWrapper,
+    EGreedyModule,
     EGreedyWrapper,
     OrnsteinUhlenbeckProcessWrapper,
 )
@@ -41,12 +52,21 @@ from torchrl.modules.tensordict_module.exploration import (
 
 @pytest.mark.parametrize("eps_init", [0.0, 0.5, 1.0])
 class TestEGreedy:
-    def test_egreedy(self, eps_init):
+    @pytest.mark.parametrize("module", [True, False])
+    def test_egreedy(self, eps_init, module):
         torch.manual_seed(0)
         spec = BoundedTensorSpec(1, 1, torch.Size([4]))
         module = torch.nn.Linear(4, 4, bias=False)
+
         policy = Actor(spec=spec, module=module)
-        explorative_policy = EGreedyWrapper(policy, eps_init=eps_init, eps_end=eps_init)
+        if module:
+            explorative_policy = TensorDictSequential(
+                policy, EGreedyModule(eps_init=eps_init, eps_end=eps_init, spec=spec)
+            )
+        else:
+            explorative_policy = EGreedyWrapper(
+                policy, eps_init=eps_init, eps_end=eps_init
+            )
         td = TensorDict({"observation": torch.zeros(10, 4)}, batch_size=[10])
         action = explorative_policy(td).get("action")
         if eps_init == 0:
@@ -57,6 +77,73 @@ class TestEGreedy:
             assert (action == 1).any()
             assert (action == 0).any()
             assert ((action == 1) | (action == 0)).all()
+
+    @pytest.mark.parametrize("module", [True])
+    @pytest.mark.parametrize("spec_class", ["discrete", "one_hot"])
+    def test_egreedy_masked(self, module, eps_init, spec_class):
+        torch.manual_seed(0)
+        action_size = 4
+        batch_size = (3, 4, 2)
+        module = torch.nn.Linear(action_size, action_size, bias=False)
+        if spec_class == "discrete":
+            spec = DiscreteTensorSpec(action_size, shape=batch_size)
+        else:
+            spec = OneHotDiscreteTensorSpec(
+                action_size, shape=batch_size + (action_size,)
+            )
+        policy = QValueActor(spec=spec, module=module, action_mask_key="action_mask")
+        if module:
+            explorative_policy = TensorDictSequential(
+                policy,
+                EGreedyModule(
+                    eps_init=eps_init,
+                    eps_end=eps_init,
+                    spec=spec,
+                    action_mask_key="action_mask",
+                ),
+            )
+        else:
+            explorative_policy = EGreedyWrapper(
+                policy,
+                eps_init=eps_init,
+                eps_end=eps_init,
+                action_mask_key="action_mask",
+            )
+        torch.manual_seed(0)
+        action_mask = torch.ones(*batch_size, action_size).to(torch.bool)
+        td = TensorDict(
+            {
+                "observation": torch.zeros(*batch_size, action_size),
+                "action_mask": action_mask,
+            },
+            batch_size=batch_size,
+        )
+        action = explorative_policy(td).get("action")
+
+        torch.manual_seed(0)
+        action_mask = torch.randint(high=2, size=(*batch_size, action_size)).to(
+            torch.bool
+        )
+        while not action_mask.any(dim=-1).all() or action_mask.all():
+            action_mask = torch.randint(high=2, size=(*batch_size, action_size)).to(
+                torch.bool
+            )
+
+        td = TensorDict(
+            {
+                "observation": torch.zeros(*batch_size, action_size),
+                "action_mask": action_mask,
+            },
+            batch_size=batch_size,
+        )
+        masked_action = explorative_policy(td).get("action")
+
+        if spec_class == "discrete":
+            action = spec.to_one_hot(action)
+            masked_action = spec.to_one_hot(masked_action)
+
+        assert not (action[~action_mask] == 0).all()
+        assert (masked_action[~action_mask] == 0).all()
 
 
 @pytest.mark.parametrize("device", get_default_devices())

--- a/test/test_exploration.py
+++ b/test/test_exploration.py
@@ -78,7 +78,7 @@ class TestEGreedy:
             assert (action == 0).any()
             assert ((action == 1) | (action == 0)).all()
 
-    @pytest.mark.parametrize("module", [True])
+    @pytest.mark.parametrize("module", [True, False])
     @pytest.mark.parametrize("spec_class", ["discrete", "one_hot"])
     def test_egreedy_masked(self, module, eps_init, spec_class):
         torch.manual_seed(0)

--- a/test/test_exploration.py
+++ b/test/test_exploration.py
@@ -174,7 +174,7 @@ class TestEGreedy:
         policy = QValueActor(spec=spec, module=module)
         explorative_policy = TensorDictSequential(
             policy,
-            EGreedyModule(),
+            EGreedyModule(spec=None),
         )
         td = TensorDict(
             {

--- a/torchrl/modules/__init__.py
+++ b/torchrl/modules/__init__.py
@@ -53,6 +53,7 @@ from .tensordict_module import (
     DistributionalQValueActor,
     DistributionalQValueHook,
     DistributionalQValueModule,
+    EGreedyModule,
     EGreedyWrapper,
     LMHeadActorValueOperator,
     LSTMModule,

--- a/torchrl/modules/tensordict_module/__init__.py
+++ b/torchrl/modules/tensordict_module/__init__.py
@@ -23,6 +23,7 @@ from .actors import (
 from .common import SafeModule, VmapModule
 from .exploration import (
     AdditiveGaussianWrapper,
+    EGreedyModule,
     EGreedyWrapper,
     OrnsteinUhlenbeckProcessWrapper,
 )

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -410,10 +410,11 @@ class QValueModule(TensorDictModuleBase):
             )
         if action_value_key is None:
             action_value_key = "action_value"
-        self.in_keys = [action_value_key]
         self.action_mask_key = action_mask_key
+        in_keys = [action_value_key]
         if self.action_mask_key is not None:
-            self.in_keys.append(self.action_mask_key)
+            in_keys.append(self.action_mask_key)
+        self.in_keys = in_keys
         if out_keys is None:
             out_keys = ["action", action_value_key, "chosen_action_value"]
         elif action_value_key not in out_keys:

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -459,7 +459,9 @@ class QValueModule(TensorDictModuleBase):
                 raise KeyError(
                     f"Action mask key {self.action_mask_key} not found in {tensordict}."
                 )
-            action_values[~action_mask] = torch.finfo(action_values.dtype).min
+            action_values = torch.where(
+                action_mask, action_values, torch.finfo(action_values.dtype).min
+            )
 
         action = self.action_func_mapping[self.action_space](action_values)
 
@@ -633,7 +635,9 @@ class DistributionalQValueModule(QValueModule):
                 raise KeyError(
                     f"Action mask key {self.action_mask_key} not found in {tensordict}."
                 )
-            action_values[action_mask] = torch.finfo(action_values.dtype).min
+            action_values = torch.where(
+                action_mask, action_values, torch.finfo(action_values.dtype).min
+            )
 
         action = self.action_func_mapping[self.action_space](action_values)
 

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -458,7 +458,7 @@ class QValueModule(TensorDictModuleBase):
                 raise KeyError(
                     f"Action mask key {self.action_mask_key} not found in {tensordict}."
                 )
-            action_values[action_mask] = torch.finfo(action_values.dtype).min
+            action_values[~action_mask] = torch.finfo(action_values.dtype).min
 
         action = self.action_func_mapping[self.action_space](action_values)
 

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -327,6 +327,8 @@ class QValueModule(TensorDictModuleBase):
             conditions the action_space.
         action_value_key (str or tuple of str, optional): The input key
             representing the action value. Defaults to ``"action_value"``.
+        action_mask_key (str or tuple of str, optional): The input key
+            representing the action mask. Defaults to ``"None"`` (equivalent to no masking).
         out_keys (list of str or tuple of str, optional): The output keys
             representing the actions, action values and chosen action value.
             Defaults to ``["action", "action_value", "chosen_action_value"]``.
@@ -378,6 +380,7 @@ class QValueModule(TensorDictModuleBase):
         self,
         action_space: Optional[str],
         action_value_key: Optional[NestedKey] = None,
+        action_mask_key: Optional[NestedKey] = None,
         out_keys: Optional[Sequence[NestedKey]] = None,
         var_nums: Optional[int] = None,
         spec: Optional[TensorSpec] = None,
@@ -408,6 +411,9 @@ class QValueModule(TensorDictModuleBase):
         if action_value_key is None:
             action_value_key = "action_value"
         self.in_keys = [action_value_key]
+        self.action_mask_key = action_mask_key
+        if self.action_mask_key is not None:
+            self.in_keys.append(self.action_mask_key)
         if out_keys is None:
             out_keys = ["action", action_value_key, "chosen_action_value"]
         elif action_value_key not in out_keys:
@@ -446,6 +452,13 @@ class QValueModule(TensorDictModuleBase):
             raise KeyError(
                 f"Action value key {self.action_value_key} not found in {tensordict}."
             )
+        if self.action_mask_key is not None:
+            action_mask = tensordict.get(self.action_mask_key, None)
+            if action_mask is None:
+                raise KeyError(
+                    f"Action mask key {self.action_mask_key} not found in {tensordict}."
+                )
+            action_values[action_mask] = torch.finfo(action_values.dtype).min
 
         action = self.action_func_mapping[self.action_space](action_values)
 
@@ -528,6 +541,8 @@ class DistributionalQValueModule(QValueModule):
         support (torch.Tensor): support of the action values.
         action_value_key (str or tuple of str, optional): The input key
             representing the action value. Defaults to ``"action_value"``.
+        action_mask_key (str or tuple of str, optional): The input key
+            representing the action mask. Defaults to ``"None"`` (equivalent to no masking).
         out_keys (list of str or tuple of str, optional): The output keys
             representing the actions and action values.
             Defaults to ``["action", "action_value"]``.
@@ -583,6 +598,7 @@ class DistributionalQValueModule(QValueModule):
         action_space: Optional[str],
         support: torch.Tensor,
         action_value_key: Optional[NestedKey] = None,
+        action_mask_key: Optional[NestedKey] = None,
         out_keys: Optional[Sequence[NestedKey]] = None,
         var_nums: Optional[int] = None,
         spec: TensorSpec = None,
@@ -595,6 +611,7 @@ class DistributionalQValueModule(QValueModule):
         super().__init__(
             action_space=action_space,
             action_value_key=action_value_key,
+            action_mask_key=action_mask_key,
             out_keys=out_keys,
             var_nums=var_nums,
             spec=spec,
@@ -609,6 +626,13 @@ class DistributionalQValueModule(QValueModule):
             raise KeyError(
                 f"Action value key {self.action_value_key} not found in {tensordict}."
             )
+        if self.action_mask_key is not None:
+            action_mask = tensordict.get(self.action_mask_key, None)
+            if action_mask is None:
+                raise KeyError(
+                    f"Action mask key {self.action_mask_key} not found in {tensordict}."
+                )
+            action_values[action_mask] = torch.finfo(action_values.dtype).min
 
         action = self.action_func_mapping[self.action_space](action_values)
 
@@ -698,6 +722,8 @@ class QValueHook:
         action_value_key (str or tuple of str, optional): to be used when hooked on
             a TensorDictModule. The input key representing the action value. Defaults
             to ``"action_value"``.
+        action_mask_key (str or tuple of str, optional): The input key
+            representing the action mask. Defaults to ``"None"`` (equivalent to no masking).
         out_keys (list of str or tuple of str, optional): to be used when hooked on
             a TensorDictModule. The output keys representing the actions, action values
             and chosen action value. Defaults to ``["action", "action_value", "chosen_action_value"]``.
@@ -733,6 +759,7 @@ class QValueHook:
         action_space: str,
         var_nums: Optional[int] = None,
         action_value_key: Optional[NestedKey] = None,
+        action_mask_key: Optional[NestedKey] = None,
         out_keys: Optional[Sequence[NestedKey]] = None,
     ):
         if isinstance(action_space, TensorSpec):
@@ -747,6 +774,7 @@ class QValueHook:
             action_space=action_space,
             var_nums=var_nums,
             action_value_key=action_value_key,
+            action_mask_key=action_mask_key,
             out_keys=out_keys,
         )
         action_value_key = self.qvalue_model.in_keys[0]
@@ -776,6 +804,11 @@ class DistributionalQValueHook(QValueHook):
     Args:
         action_space (str): Action space. Must be one of
             ``"one-hot"``, ``"mult-one-hot"``, ``"binary"`` or ``"categorical"``.
+        action_value_key (str or tuple of str, optional): to be used when hooked on
+            a TensorDictModule. The input key representing the action value. Defaults
+            to ``"action_value"``.
+        action_mask_key (str or tuple of str, optional): The input key
+            representing the action mask. Defaults to ``"None"`` (equivalent to no masking).
         support (torch.Tensor): support of the action values.
         var_nums (int, optional): if ``action_space = "mult-one-hot"``, this
             value represents the cardinality of each
@@ -823,6 +856,7 @@ class DistributionalQValueHook(QValueHook):
         support: torch.Tensor,
         var_nums: Optional[int] = None,
         action_value_key: Optional[NestedKey] = None,
+        action_mask_key: Optional[NestedKey] = None,
         out_keys: Optional[Sequence[NestedKey]] = None,
     ):
         if isinstance(action_space, TensorSpec):
@@ -837,6 +871,7 @@ class DistributionalQValueHook(QValueHook):
             var_nums=var_nums,
             support=support,
             action_value_key=action_value_key,
+            action_mask_key=action_mask_key,
             out_keys=out_keys,
         )
         action_value_key = self.qvalue_model.in_keys[0]
@@ -884,6 +919,8 @@ class QValueActor(SafeSequential):
             is a :class:`tensordict.nn.TensorDictModuleBase` instance, it must
             match one of its output keys. Otherwise, this string represents
             the name of the action-value entry in the output tensordict.
+        action_mask_key (str or tuple of str, optional): The input key
+            representing the action mask. Defaults to ``"None"`` (equivalent to no masking).
 
     .. note::
         ``out_keys`` cannot be passed. If the module is a :class:`tensordict.nn.TensorDictModule`
@@ -942,6 +979,7 @@ class QValueActor(SafeSequential):
         safe=False,
         action_space: Optional[str] = None,
         action_value_key=None,
+        action_mask_key: Optional[NestedKey] = None,
     ):
         if isinstance(action_space, TensorSpec):
             warnings.warn(
@@ -987,6 +1025,7 @@ class QValueActor(SafeSequential):
             spec=spec,
             safe=safe,
             action_space=action_space,
+            action_mask_key=action_mask_key,
         )
 
         super().__init__(module, qvalue)
@@ -1035,6 +1074,12 @@ class DistributionalQValueActor(QValueActor):
         make_log_softmax (bool, optional): if ``True`` and if the module is not
             of type :class:`torchrl.modules.DistributionalDQNnet`, a log-softmax
             operation will be applied along dimension -2 of the action value tensor.
+        action_value_key (str or tuple of str, optional): if the input module
+            is a :class:`tensordict.nn.TensorDictModuleBase` instance, it must
+            match one of its output keys. Otherwise, this string represents
+            the name of the action-value entry in the output tensordict.
+        action_mask_key (str or tuple of str, optional): The input key
+            representing the action mask. Defaults to ``"None"`` (equivalent to no masking).
 
     Examples:
         >>> import torch
@@ -1079,6 +1124,7 @@ class DistributionalQValueActor(QValueActor):
         var_nums: Optional[int] = None,
         action_space: Optional[str] = None,
         action_value_key: str = "action_value",
+        action_mask_key: Optional[NestedKey] = None,
         make_log_softmax: bool = True,
     ):
         if isinstance(action_space, TensorSpec):
@@ -1121,6 +1167,7 @@ class DistributionalQValueActor(QValueActor):
             spec=spec,
             safe=safe,
             action_space=action_space,
+            action_mask_key=action_mask_key,
             support=support,
             var_nums=var_nums,
         )

--- a/torchrl/modules/tensordict_module/exploration.py
+++ b/torchrl/modules/tensordict_module/exploration.py
@@ -32,10 +32,12 @@ class EGreedyModule(TensorDictModuleBase):
     """Epsilon-Greedy exploration module.
 
     This module randomly updates the action(s) in a tensordict given an epsilon greedy exploration strategy.
-    At each call, random draws (one per action) are executed given a certain probability threshold. If successful, the corresponding actions are being replaced by random samples drawn from the action spec provided. Others are left unchanged.
+    At each call, random draws (one per action) are executed given a certain probability threshold. If successful,
+    the corresponding actions are being replaced by random samples drawn from the action spec provided.
+    Others are left unchanged.
 
     Args:
-        spec (TensorSpec): the spec used for samppling actions.
+        spec (TensorSpec): the spec used for sampling actions.
         eps_init (scalar, optional): initial epsilon value.
             default: 1.0
         eps_end (scalar, optional): final epsilon value.

--- a/torchrl/modules/tensordict_module/exploration.py
+++ b/torchrl/modules/tensordict_module/exploration.py
@@ -111,8 +111,6 @@ class EGreedyModule(TensorDictModuleBase):
             if not isinstance(spec, CompositeSpec) and len(self.out_keys) >= 1:
                 spec = CompositeSpec({action_key: spec}, shape=spec.shape[:-1])
             self._spec = spec
-        else:
-            self._spec = CompositeSpec({action_key: None})
 
     @property
     def spec(self):
@@ -266,8 +264,6 @@ class EGreedyWrapper(TensorDictModuleWrapper):
             self._spec = self.td_module.spec.clone()
             if action_key not in self._spec.keys():
                 self._spec[action_key] = None
-        else:
-            self._spec = CompositeSpec({key: None for key in policy.out_keys})
 
     @property
     def spec(self):

--- a/torchrl/modules/tensordict_module/exploration.py
+++ b/torchrl/modules/tensordict_module/exploration.py
@@ -35,6 +35,7 @@ class EGreedyModule(TensorDictModuleBase):
     At each call, random draws (one per action) are executed given a certain probability threshold. If successful, the corresponding actions are being replaced by random samples drawn from the action spec provided. Others are left unchanged.
 
     Args:
+        spec (TensorSpec): the spec used for samppling actions.
         eps_init (scalar, optional): initial epsilon value.
             default: 1.0
         eps_end (scalar, optional): final epsilon value.
@@ -43,15 +44,10 @@ class EGreedyModule(TensorDictModuleBase):
             the ``eps_end`` value. Defaults to `1000`.
 
     Keyword Args:
-        action_key (NestedKey, optional): if the policy module has more than one output key,
-            its output spec will be of type :class:`torchrl.data.CompositeSpec`. One needs to know where to
-            find the action spec.
+        action_key (NestedKey, optional): the key where the action can be found in the input tensordict.
             Default is ``"action"``.
         action_mask_key (NestedKey, optional): the key where the action mask can be found in the input tensordict.
             Default is ``None`` (corresponding to no mask).
-        spec (TensorSpec, optional): if provided, the sampled action will be
-            projected onto the valid action space once explored. If not provided,
-            the exploration wrapper will attempt to recover it from the policy.
 
     .. note::
         It is crucial to incorporate a call to :meth:`~.step` in the training loop
@@ -87,13 +83,13 @@ class EGreedyModule(TensorDictModuleBase):
 
     def __init__(
         self,
+        spec: TensorSpec,
         eps_init: float = 1.0,
         eps_end: float = 0.1,
         annealing_num_steps: int = 1000,
         *,
         action_key: Optional[NestedKey] = "action",
         action_mask_key: Optional[NestedKey] = None,
-        spec: Optional[TensorSpec] = None,
     ):
         self.action_key = action_key
         self.action_mask_key = action_mask_key
@@ -196,14 +192,12 @@ class EGreedyWrapper(TensorDictModuleWrapper):
         eps_end (scalar, optional): final epsilon value.
             default: 0.1
         annealing_num_steps (int, optional): number of steps it will take for epsilon to reach the eps_end value
-        action_key (NestedKey, optional): if the policy module has more than one output key,
-            its output spec will be of type CompositeSpec. One needs to know where to
-            find the action spec.
-            Default is "action".
+        action_key (NestedKey, optional): the key where the action can be found in the input tensordict.
+            Default is ``"action"``.
         action_mask_key (NestedKey, optional): the key where the action mask can be found in the input tensordict.
             Default is ``None`` (corresponding to no mask).
         spec (TensorSpec, optional): if provided, the sampled action will be
-            projected onto the valid action space once explored. If not provided,
+            taken from this action space. If not provided,
             the exploration wrapper will attempt to recover it from the policy.
 
     .. note::

--- a/torchrl/modules/tensordict_module/exploration.py
+++ b/torchrl/modules/tensordict_module/exploration.py
@@ -90,19 +90,23 @@ class EGreedyModule(TensorDictModuleBase):
         action_mask_key: Optional[NestedKey] = None,
         spec: Optional[TensorSpec] = None,
     ):
+        self.action_key = action_key
+        self.action_mask_key = action_mask_key
+        in_keys = [self.action_key]
+        if self.action_mask_key is not None:
+            in_keys.append(self.action_mask_key)
+        self.in_keys = in_keys
+        self.out_keys = [self.action_key]
+
+        super().__init__()
+
         self.register_buffer("eps_init", torch.tensor([eps_init]))
         self.register_buffer("eps_end", torch.tensor([eps_end]))
         if self.eps_end > self.eps_init:
             raise RuntimeError("eps should decrease over time or be constant")
         self.annealing_num_steps = annealing_num_steps
         self.register_buffer("eps", torch.tensor([eps_init]))
-        self.action_key = action_key
-        self.action_mask_key = action_mask_key
-        in_keys = [action_key]
-        if self.action_mask_key is not None:
-            in_keys.append(self.action_mask_key)
-        self.in_keys = in_keys
-        self.out_keys = [self.action_key]
+
         if spec is not None:
             if not isinstance(spec, CompositeSpec) and len(self.out_keys) >= 1:
                 spec = CompositeSpec({action_key: spec}, shape=spec.shape[:-1])

--- a/torchrl/modules/tensordict_module/exploration.py
+++ b/torchrl/modules/tensordict_module/exploration.py
@@ -29,9 +29,10 @@ __all__ = [
 
 
 class EGreedyModule(TensorDictModuleBase):
-    """Epsilon-Greedy module.
+    """Epsilon-Greedy exploration module.
 
-    This module updates the action in a tensordict to an epsilon greedy one.
+    This module randomly updates the action(s) in a tensordict given an epsilon greedy exploration strategy.
+    At each call, random draws (one per action) are executed given a certain probability threshold. If successful, the corresponding actions are being replaced by random samples drawn from the action spec provided. Others are left unchanged.
 
     Keyword Args:
         eps_init (scalar, optional): initial epsilon value.

--- a/torchrl/modules/tensordict_module/exploration.py
+++ b/torchrl/modules/tensordict_module/exploration.py
@@ -245,7 +245,8 @@ class EGreedyWrapper(TensorDictModuleWrapper):
         spec: Optional[TensorSpec] = None,
     ):
         warnings.warn(
-            "EGreedyWrapper is deprecated and it will be removed in v0.3. Please use torchrl/modules.EGreedyModule instead.",
+            "EGreedyWrapper is deprecated and it will be removed in v0.3. "
+            "Please use torchrl.modules.EGreedyModule instead.",
             category=DeprecationWarning,
         )
 

--- a/torchrl/modules/tensordict_module/exploration.py
+++ b/torchrl/modules/tensordict_module/exploration.py
@@ -156,9 +156,14 @@ class EGreedyModule(TensorDictModuleBase):
                 if isinstance(spec, CompositeSpec):
                     spec = spec[self.action_key]
                 if spec.shape != out.shape:
-                    raise ValueError(
-                        "Action spec shape does not match the action shape"
-                    )
+                    # In batched envs if the spec is passed unbatched, the rand() will not
+                    # cover all batched dims
+                    if out.shape[-len(spec.shape) :] == spec.shape:
+                        spec = spec.expand(out.shape)
+                    else:
+                        raise ValueError(
+                            "Action spec shape does not match the action shape"
+                        )
                 if self.action_mask_key is not None:
                     action_mask = tensordict.get(self.action_mask_key, None)
                     if action_mask is None:
@@ -307,9 +312,14 @@ class EGreedyWrapper(TensorDictModuleWrapper):
                 if isinstance(spec, CompositeSpec):
                     spec = spec[self.action_key]
                 if spec.shape != out.shape:
-                    raise ValueError(
-                        "Action spec shape does not match the action shape"
-                    )
+                    # In batched envs if the spec is passed unbatched, the rand() will not
+                    # cover all batched dims
+                    if out.shape[-len(spec.shape) :] == spec.shape:
+                        spec = spec.expand(out.shape)
+                    else:
+                        raise ValueError(
+                            "Action spec shape does not match the action shape"
+                        )
                 if self.action_mask_key is not None:
                     action_mask = tensordict.get(self.action_mask_key, None)
                     if action_mask is None:

--- a/torchrl/modules/tensordict_module/exploration.py
+++ b/torchrl/modules/tensordict_module/exploration.py
@@ -34,18 +34,21 @@ class EGreedyModule(TensorDictModuleBase):
     This module randomly updates the action(s) in a tensordict given an epsilon greedy exploration strategy.
     At each call, random draws (one per action) are executed given a certain probability threshold. If successful, the corresponding actions are being replaced by random samples drawn from the action spec provided. Others are left unchanged.
 
-    Keyword Args:
+    Args:
         eps_init (scalar, optional): initial epsilon value.
             default: 1.0
         eps_end (scalar, optional): final epsilon value.
             default: 0.1
-        annealing_num_steps (int, optional): number of steps it will take for epsilon to reach the eps_end value
+        annealing_num_steps (int, optional): number of steps it will take for epsilon to reach
+            the ``eps_end`` value. Defaults to `1000`.
+
+    Keyword Args:
         action_key (NestedKey, optional): if the policy module has more than one output key,
-            its output spec will be of type CompositeSpec. One needs to know where to
+            its output spec will be of type :class:`torchrl.data.CompositeSpec`. One needs to know where to
             find the action spec.
             Default is ``"action"``.
-        action_mask_key (NestedKey, optional): the key where the action maskcan be found in the tensordict.
-            Default is ``"None"`` (corresponding to no mask).
+        action_mask_key (NestedKey, optional): the key where the action mask can be found in the input tensordict.
+            Default is ``None`` (corresponding to no mask).
         spec (TensorSpec, optional): if provided, the sampled action will be
             projected onto the valid action space once explored. If not provided,
             the exploration wrapper will attempt to recover it from the policy.
@@ -87,6 +90,7 @@ class EGreedyModule(TensorDictModuleBase):
         eps_init: float = 1.0,
         eps_end: float = 0.1,
         annealing_num_steps: int = 1000,
+        *,
         action_key: Optional[NestedKey] = "action",
         action_mask_key: Optional[NestedKey] = None,
         spec: Optional[TensorSpec] = None,
@@ -120,10 +124,10 @@ class EGreedyModule(TensorDictModuleBase):
     def step(self, frames: int = 1) -> None:
         """A step of epsilon decay.
 
-        After self.annealing_num_steps, this function is a no-op.
+        After `self.annealing_num_steps` calls to this method, calls result in no-op.
 
         Args:
-            frames (int): number of frames since last step.
+            frames (int, optional): number of frames since last step. Defaults to ``1``.
 
         """
         for _ in range(frames):
@@ -181,7 +185,7 @@ class EGreedyModule(TensorDictModuleBase):
 
 
 class EGreedyWrapper(TensorDictModuleWrapper):
-    """[Deprecated] ]Epsilon-Greedy PO wrapper.
+    """[Deprecated] Epsilon-Greedy PO wrapper.
 
     Args:
         policy (TensorDictModule): a deterministic policy.
@@ -196,8 +200,8 @@ class EGreedyWrapper(TensorDictModuleWrapper):
             its output spec will be of type CompositeSpec. One needs to know where to
             find the action spec.
             Default is "action".
-        action_mask_key (NestedKey, optional): the key where the action maskcan be found in the tensordict.
-            Default is ``"None"`` (corresponding to no mask).
+        action_mask_key (NestedKey, optional): the key where the action mask can be found in the input tensordict.
+            Default is ``None`` (corresponding to no mask).
         spec (TensorSpec, optional): if provided, the sampled action will be
             projected onto the valid action space once explored. If not provided,
             the exploration wrapper will attempt to recover it from the policy.


### PR DESCRIPTION
Action masks where introduced in #1421.

This PR has the job of making the components in the training pipeline use this mask.

The components that need updating are:
- q modules and actors
- e-greedy

This addresses some of the issues brought up in  #1404

cc @Kang-SungKu @1030852813 @fedebotu 