### PR TITLE
[Test] Skip tests in python 3.11

### DIFF
--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -773,6 +773,11 @@ def test_traj_len_consistency(num_env, env_name, collector_class, seed=100):
     assert_allclose_td(data10, data20)
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 11),
+    reason="Nested spawned multiprocessed is currently failing in python 3.11. "
+    "See https://github.com/python/cpython/pull/108568 for info and fix.",
+)
 @pytest.mark.skipif(not _has_gym, reason="test designed with GymEnv")
 @pytest.mark.parametrize("static_seed", [True, False])
 def test_collector_vecnorm_envcreator(static_seed):

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -6,6 +6,7 @@ import abc
 import argparse
 
 import itertools
+import sys
 from copy import copy
 from functools import partial
 
@@ -7058,6 +7059,11 @@ class TestVecNorm:
         queue_in.close()
         del parallel_env, queue_out, queue_in
 
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 11),
+        reason="Nested spawned multiprocessed is currently failing in python 3.11. "
+        "See https://github.com/python/cpython/pull/108568 for info and fix.",
+    )
     def test_parallelenv_vecnorm(self):
         if _has_gym:
             make_env = EnvCreator(


### PR DESCRIPTION
## Description

Skipping tests that involve nested multiprocessing in python 3.11

cc @albanD since you implemented the fix :) 