### PR TITLE
[Feature] Masked specs and masked distiribution uniformity

### DIFF
--- a/docs/source/reference/envs.rst
+++ b/docs/source/reference/envs.rst
@@ -543,6 +543,9 @@ to always know what the latest available actions are. You can do this like so:
         >>>     ActionMask(action_key="action", mask_key="action_mask"),
         >>> )
 
+If an action mask with all ``False`` entries is passed to either of these components, it will be considered as
+all actions available.
+
 .. note::
   In case you are using a parallel environment it is important to add the transform to the parallel enviornment itself
   and not to its sub-environments.

--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -3253,6 +3253,31 @@ class TestSpecMasking:
         else:
             assert (sp != s).all()
 
+    def test_false_mask(self, shape, device, spectype, rand_shape, n=5):
+        shape = torch.Size(shape)
+        rand_shape = torch.Size(rand_shape)
+        spec = (
+            self._one_hot_spec(shape, device, n=n)
+            if spectype == "one_hot"
+            else self._discrete_spec(shape, device, n=n)
+            if spectype == "categorical"
+            else self._mult_one_hot_spec(shape, device, n=n)
+            if spectype == "mult_one_hot"
+            else self._mult_discrete_spec(shape, device, n=n)
+            if spectype == "mult_discrete"
+            else None
+        )
+        mask = spec.mask
+        zero_mask = torch.zeros_like(spec.mask)
+
+        spec.update_mask(None)
+        s = spec.rand(rand_shape)
+        assert spec.is_in(s)
+        spec.update_mask(zero_mask)
+        assert spec.is_in(s)
+        s = spec.rand(rand_shape)
+        assert spec.is_in(s)
+
 
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1168,6 +1168,11 @@ class OneHotDiscreteTensorSpec(TensorSpec):
 
     def update_mask(self, mask):
         if mask is not None:
+            # If the mask is all Falses, we do not apply it
+            # This is coherent with the behavior of torchrl.modules.MaskedCategorical
+            if not mask.any():
+                self.mask = None
+                return
             try:
                 mask = mask.expand(self.shape)
             except RuntimeError as err:
@@ -1941,6 +1946,11 @@ class MultiOneHotDiscreteTensorSpec(OneHotDiscreteTensorSpec):
 
     def update_mask(self, mask):
         if mask is not None:
+            # If the mask is all Falses, we do not apply it
+            # This is coherent with the behavior of torchrl.modules.MaskedCategorical
+            if not mask.any():
+                self.mask = None
+                return
             try:
                 mask = mask.expand(*self.shape)
             except RuntimeError as err:
@@ -2259,6 +2269,11 @@ class DiscreteTensorSpec(TensorSpec):
 
     def update_mask(self, mask):
         if mask is not None:
+            # If the mask is all Falses, we do not apply it
+            # This is coherent with the behavior of torchrl.modules.MaskedCategorical
+            if not mask.any():
+                self.mask = None
+                return
             try:
                 mask = mask.expand(*self.shape, self.space.n)
             except RuntimeError as err:
@@ -2598,6 +2613,11 @@ class MultiDiscreteTensorSpec(DiscreteTensorSpec):
 
     def update_mask(self, mask):
         if mask is not None:
+            # If the mask is all Falses, we do not apply it
+            # This is coherent with the behavior of torchrl.modules.MaskedCategorical
+            if not mask.any():
+                self.mask = None
+                return
             try:
                 mask = mask.expand(*self.shape[:-1], mask.shape[-1])
             except RuntimeError as err:


### PR DESCRIPTION
Currently our masked distributions, when receiving a mask with all `False` entries, will sample with equal probability for all events.

https://github.com/pytorch/rl/blob/fe91c4fc0e7ec6bde969a4f25ea58b247ec4dc65/torchrl/modules/distributions/discrete.py#L145

This PR brings the same behaviour to specs.

When an `action_mask`  with all `False` entries is passed to `spec.update_mask(mask)`, this will be discarded and all actions will be considered available.

Another option would be to throw an error in both masked specs and distributions for this corner case, but this would come at the price of more runtime checks.