### PR TITLE
[BugFix] Sparse info in SMACv2

### DIFF
--- a/torchrl/envs/libs/smacv2.py
+++ b/torchrl/envs/libs/smacv2.py
@@ -377,10 +377,10 @@ class SMACv2Wrapper(_EnvWrapper):
         obs = self.get_obs()
         state = self.get_state()
         info = self.observation_spec["info"].encode(info)
-        info_keys = info.keys()
-        for info_key, spec in self.observation_spec["info"].items():
-            if info_key not in info_keys:
-                info[info_key] = spec.zero()
+        actual_keys = info.keys()
+        for expected_key, spec in self.observation_spec["info"].items():
+            if expected_key not in actual_keys:
+                info[expected_key] = spec.zero()
 
         reward = torch.tensor(
             reward, device=self.device, dtype=torch.float32


### PR DESCRIPTION
SMACv2 could not return certain info during execution depending on some runtime conditions.

This PR simply pads the absent info in a more general way