### PR TITLE
[BugFix] DDPG select also critic input for actor loss

### DIFF
--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -236,7 +236,7 @@ class DDPGLoss(LossModule):
         self._set_in_keys()
 
     def _set_in_keys(self):
-        keys = {
+        in_keys = {
             unravel_key(("next", self.tensor_keys.reward)),
             unravel_key(("next", self.tensor_keys.done)),
             *self.actor_in_keys,
@@ -244,7 +244,7 @@ class DDPGLoss(LossModule):
             *self.value_network.in_keys,
             *[unravel_key(("next", key)) for key in self.value_network.in_keys],
         }
-        self._in_keys = sorted(keys, keys=str)
+        self._in_keys = sorted(in_keys, keys=str)
 
     @property
     def in_keys(self):

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -11,10 +11,10 @@ from dataclasses import dataclass
 from typing import Tuple
 
 import torch
-
 from tensordict.nn import dispatch, make_functional, repopulate_module, TensorDictModule
 from tensordict.tensordict import TensorDict, TensorDictBase
-from tensordict.utils import NestedKey
+
+from tensordict.utils import NestedKey, unravel_key
 from torchrl.modules.tensordict_module.actors import ActorCriticWrapper
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
@@ -236,15 +236,15 @@ class DDPGLoss(LossModule):
         self._set_in_keys()
 
     def _set_in_keys(self):
-        keys = [
-            ("next", self.tensor_keys.reward),
-            ("next", self.tensor_keys.done),
+        keys = {
+            unravel_key(("next", self.tensor_keys.reward)),
+            unravel_key(("next", self.tensor_keys.done)),
             *self.actor_in_keys,
-            *[("next", key) for key in self.actor_in_keys],
+            *[unravel_key(("next", key)) for key in self.actor_in_keys],
             *self.value_network.in_keys,
-            *[("next", key) for key in self.value_network.in_keys],
-        ]
-        self._in_keys = list(set(keys))
+            *[unravel_key(("next", key)) for key in self.value_network.in_keys],
+        }
+        self._in_keys = sorted(keys, keys=str)
 
     @property
     def in_keys(self):

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -293,7 +293,9 @@ class DDPGLoss(LossModule):
         self,
         tensordict: TensorDictBase,
     ) -> torch.Tensor:
-        td_copy = tensordict.select(*self.actor_in_keys).detach()
+        td_copy = tensordict.select(
+            *self.actor_in_keys, *self.value_network.in_keys
+        ).detach()
         td_copy = self.actor_network(
             td_copy,
             params=self.actor_network_params,

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -244,7 +244,7 @@ class DDPGLoss(LossModule):
             *self.value_network.in_keys,
             *[unravel_key(("next", key)) for key in self.value_network.in_keys],
         }
-        self._in_keys = sorted(in_keys, keys=str)
+        self._in_keys = sorted(in_keys, key=str)
 
     @property
     def in_keys(self):


### PR DESCRIPTION
Before we were only selecting the actor input and output keys when computing the actor loss (which involves a forward critic pass).

This is limiting as the critic can have extra inputs (for example a fully observable state or a centralized state in MARL)

This PR fixes that by extending the selected keys.