### PR TITLE
[BugFix] Fix run_type_checks

### DIFF
--- a/test/test_env.py
+++ b/test/test_env.py
@@ -2113,7 +2113,7 @@ def test_num_threads():
 
 @pytest.mark.skipif(not _has_gym, reason="no gym detected")
 def test_run_type_checks():
-    env = GymEnv("Pendulum-v1")
+    env = GymEnv(PENDULUM_VERSIONED)
     env._run_type_checks = False
     check_env_specs(env)
     env._run_type_checks = True

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -2122,6 +2122,9 @@ def test_run_type_checks():
     env.output_spec["full_done_spec", "done"].dtype = torch.int
     with pytest.raises(TypeError, match="expected done.dtype to"):
         check_env_specs(env)
+    env.output_spec["full_done_spec", "done"].dtype = torch.bool
+    env.output_spec["full_observation_spec", "observation"].dtype = torch.bool
+    check_env_specs(env)
 
 
 if __name__ == "__main__":

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -2111,6 +2111,14 @@ def test_num_threads():
         batched_envs._run_worker_pipe_shared_mem = _run_worker_pipe_shared_mem_save
         torch.set_num_threads(num_threads)
 
+@pytest.mark.skipif(not _has_gym, reason="no gym detected")
+def test_run_type_checks():
+    env = GymEnv("Pendulum-v1")
+    env._run_type_checks = False
+    check_env_specs(env)
+    env._run_type_checks = True
+    check_env_specs(env)
+
 
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -2124,7 +2124,8 @@ def test_run_type_checks():
         check_env_specs(env)
     env.output_spec["full_done_spec", "done"].dtype = torch.bool
     env.output_spec["full_observation_spec", "observation"].dtype = torch.bool
-    check_env_specs(env)
+    with pytest.raises(TypeError):
+        check_env_specs(env)
 
 
 if __name__ == "__main__":

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -2111,23 +2111,26 @@ def test_num_threads():
         batched_envs._run_worker_pipe_shared_mem = _run_worker_pipe_shared_mem_save
         torch.set_num_threads(num_threads)
 
-@pytest.mark.skipif(not _has_gym, reason="no gym detected")
+
 def test_run_type_checks():
-    env = GymEnv(PENDULUM_VERSIONED)
+    env = ContinuousActionVecMockEnv()
     env._run_type_checks = False
     check_env_specs(env)
     env._run_type_checks = True
     check_env_specs(env)
     env.output_spec.unlock_()
+    # check type check on done
     env.output_spec["full_done_spec", "done"].dtype = torch.int
     with pytest.raises(TypeError, match="expected done.dtype to"):
         check_env_specs(env)
     env.output_spec["full_done_spec", "done"].dtype = torch.bool
+    # check type check on reward
     env.output_spec["full_reward_spec", "reward"].dtype = torch.int
     with pytest.raises(TypeError, match="expected"):
         check_env_specs(env)
     env.output_spec["full_reward_spec", "reward"].dtype = torch.float
-    env.output_spec["full_observation_spec", "observation"].dtype = torch.bool
+    # check type check on obs
+    env.output_spec["full_observation_spec", "observation"].dtype = torch.float16
     with pytest.raises(TypeError):
         check_env_specs(env)
 

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -2123,6 +2123,10 @@ def test_run_type_checks():
     with pytest.raises(TypeError, match="expected done.dtype to"):
         check_env_specs(env)
     env.output_spec["full_done_spec", "done"].dtype = torch.bool
+    env.output_spec["full_reward_spec", "reward"].dtype = torch.int
+    with pytest.raises(TypeError, match="expected"):
+        check_env_specs(env)
+    env.output_spec["full_reward_spec", "reward"].dtype = torch.float
     env.output_spec["full_observation_spec", "observation"].dtype = torch.bool
     with pytest.raises(TypeError):
         check_env_specs(env)

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -2118,6 +2118,10 @@ def test_run_type_checks():
     check_env_specs(env)
     env._run_type_checks = True
     check_env_specs(env)
+    env.output_spec.unlock_()
+    env.output_spec["full_done_spec", "done"].dtype = torch.int
+    with pytest.raises(TypeError, match="expected done.dtype to"):
+        check_env_specs(env)
 
 
 if __name__ == "__main__":

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -1216,7 +1216,7 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
                     is not self.output_spec["full_done_spec", done_key].dtype
                 ):
                     raise TypeError(
-                        f"expected done.dtype to be torch.bool but got {next_tensordict_out.get(done_key).dtype}"
+                        f"expected done.dtype to be {self.output_spec['full_done_spec', done_key].dtype} but got {next_tensordict_out.get(done_key).dtype}"
                     )
         return next_tensordict_out
 

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -1195,7 +1195,7 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
         if self.run_type_checks:
             for key, spec in self.observation_spec.items():
                 obs = next_tensordict_out.get(key)
-                spec.type_check(obs, key)
+                spec.type_check(obs)
 
             for reward_key in self.reward_keys:
                 if (

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -1193,10 +1193,9 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
                 next_tensordict_out.set(done_key, done)
 
         if self.run_type_checks:
-            # TODO: check these errors
-            for key in self._select_observation_keys(next_tensordict_out):
+            for key, spec in self.observation_spec.items():
                 obs = next_tensordict_out.get(key)
-                self.observation_spec.type_check(obs, key)
+                spec.type_check(obs, key)
 
             for reward_key in self.reward_keys:
                 if (

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -1213,7 +1213,7 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
             for done_key in self.done_keys:
                 if (
                     next_tensordict_out.get(done_key).dtype
-                    is not self.output_spec["full_done_spec"].get(done_key).dtype
+                    is not self.output_spec["full_done_spec", done_key].dtype
                 ):
                     raise TypeError(
                         f"expected done.dtype to be torch.bool but got {next_tensordict_out.get(done_key).dtype}"


### PR DESCRIPTION
Solves a bug when `run_type_checks=True` where a composite spec is queried with a non-existent `get` method.
Also adds tests for `env._run_type_checks`.

Note that this test may fail if the env is substituted with a GymEnv as GymEnv (and others) do the casting of the obs/reward/done internally during the step computation. This trades off security (ie, we can make sure that the dtype is always appropriate) to consistency between gym and torchrl (the dtype in torchrl can differ wrt gym at the expense of loosing information).