### PR TITLE
[Versioning] Use python 3.8 for GPU tests

### DIFF
--- a/.github/unittest/linux/scripts/environment.yml
+++ b/.github/unittest/linux/scripts/environment.yml
@@ -27,6 +27,6 @@ dependencies:
     - mlflow
     - av
     - coverage
-    - ray<2.7.0
+    - ray
     - transformers
     - ninja

--- a/.github/unittest/linux/scripts/environment.yml
+++ b/.github/unittest/linux/scripts/environment.yml
@@ -27,6 +27,6 @@ dependencies:
     - mlflow
     - av
     - coverage
-    - ray
+    - ray<2.7.0
     - transformers
     - ninja

--- a/.github/workflows/test-linux-gpu.yml
+++ b/.github/workflows/test-linux-gpu.yml
@@ -22,8 +22,8 @@ jobs:
   tests:
     strategy:
       matrix:
-        python_version: ["3.9"] # "3.8", "3.9", "3.10", "3.11"
-        cuda_arch_version: ["12.1"] # "11.6", "11.7"
+        python_version: ["3.10"]
+        cuda_arch_version: ["12.1"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:

--- a/.github/workflows/test-linux-gpu.yml
+++ b/.github/workflows/test-linux-gpu.yml
@@ -22,7 +22,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python_version: ["3.10"]
+        python_version: ["3.8"]
         cuda_arch_version: ["12.1"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main

--- a/.github/workflows/test-linux-stable-gpu.yml
+++ b/.github/workflows/test-linux-stable-gpu.yml
@@ -22,7 +22,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python_version: ["3.9"] # "3.8", "3.9", "3.10", "3.11"
+        python_version: ["3.8"] # "3.8", "3.9", "3.10", "3.11"
         cuda_arch_version: ["11.8"] # "11.6", "11.7"
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main


### PR DESCRIPTION
## Description

Using distributed collectors with Ray results in an exception 

```
ValueError: no signature found for builtin type <class 'types.GenericAlias'>
```

(cf #1539)

This PR updates python to 3.8 for GPU tests to avoid this error.