### PR TITLE
[Lint] Add TorchFix linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         additional_dependencies:
           - flake8-bugbear==22.10.27
           - flake8-comprehensions==3.10.1
-
+          - torchfix==0.0.2
 
   - repo: https://github.com/PyCQA/pydocstyle
     rev: 6.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,15 @@ per-file-ignores =
     test/smoke_test_deps.py: F401
     test_*.py: F841, E731, E266
     test/opengl_rendering.py: F401
+    test/test_modules.py: F841, E731, E266, TOR101
+    test/test_tensordictmodules.py: F841, E731, E266, TOR101
+    torchrl/objectives/cql.py: TOR101
+    torchrl/objectives/deprecated.py: TOR101
+    torchrl/objectives/iql.py: TOR101
+    torchrl/objectives/redq.py: TOR101
+    torchrl/objectives/sac.py: TOR101
+    torchrl/objectives/td3.py: TOR101
+    torchrl/objectives/value/advantages.py: TOR101
 
 exclude = venv
 extend-select = B901, C401, C408, C409, TOR0, TOR1, TOR2

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ per-file-ignores =
     test/opengl_rendering.py: F401
 
 exclude = venv
-extend-select = B901, C401, C408, C409
+extend-select = B901, C401, C408, C409, TOR0, TOR1, TOR2
 
 [pydocstyle]
 ;select = D417 # Missing argument descriptions in the docstring

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -6599,8 +6599,8 @@ class TestVIP(TransformBase):
         with pytest.raises(AssertionError):
             torch.testing.assert_close(cur_embedding[:, 1:], last_embedding[:, :-1])
 
-        explicit_reward = -torch.norm(cur_embedding - goal_embedding, dim=-1) - (
-            -torch.norm(last_embedding - goal_embedding, dim=-1)
+        explicit_reward = -torch.linalg.norm(cur_embedding - goal_embedding, dim=-1) - (
+            -torch.linalg.norm(last_embedding - goal_embedding, dim=-1)
         )
         torch.testing.assert_close(explicit_reward, td["next", "reward"].squeeze())
 

--- a/torchrl/envs/transforms/vip.py
+++ b/torchrl/envs/transforms/vip.py
@@ -380,8 +380,8 @@ class VIPRewardTransform(VIPTransform):
         cur_embedding = next_tensordict.get(self.out_keys[0])
         if last_embedding is not None:
             goal_embedding = tensordict["goal_embedding"]
-            reward = -torch.norm(cur_embedding - goal_embedding, dim=-1) - (
-                -torch.norm(last_embedding - goal_embedding, dim=-1)
+            reward = -torch.linalg.norm(cur_embedding - goal_embedding, dim=-1) - (
+                -torch.linalg.norm(last_embedding - goal_embedding, dim=-1)
             )
             next_tensordict.set("reward", reward)
         return next_tensordict


### PR DESCRIPTION
Add TorchFix (https://github.com/pytorch/test-infra/tree/main/tools/torchfix) flake8 plugin.

To make it pass:

1. Update `from functorch import` to `from torch.func import vmap`.
2. Update deprecated `torch.norm` to `torch.linalg.norm`.