### PR TITLE
[Feature] step_and_maybe_reset in env

### DIFF
--- a/.github/unittest/linux/scripts/environment.yml
+++ b/.github/unittest/linux/scripts/environment.yml
@@ -16,6 +16,7 @@ dependencies:
     - pytest-mock
     - pytest-instafail
     - pytest-rerunfailures
+    - pytest-timeout
     - expecttest
     - pyyaml
     - scipy

--- a/.github/unittest/linux/scripts/run_all.sh
+++ b/.github/unittest/linux/scripts/run_all.sh
@@ -184,10 +184,12 @@ pytest test/smoke_test.py -v --durations 200
 pytest test/smoke_test_deps.py -v --durations 200 -k 'test_gym or test_dm_control_pixels or test_dm_control or test_tb'
 if [ "${CU_VERSION:-}" != cpu ] ; then
   python .github/unittest/helpers/coverage_run_parallel.py -m pytest test \
-    --instafail --durations 200 -vv --capture no --ignore test/test_rlhf.py
+    --instafail --durations 200 -vv --capture no --ignore test/test_rlhf.py \
+    --timeout=60
 else
   python .github/unittest/helpers/coverage_run_parallel.py -m pytest test \
-    --instafail --durations 200 -vv --capture no --ignore test/test_rlhf.py --ignore test/test_distributed.py
+    --instafail --durations 200 -vv --capture no --ignore test/test_rlhf.py --ignore test/test_distributed.py \
+    --timeout=60
 fi
 
 coverage combine

--- a/.github/unittest/linux/scripts/run_all.sh
+++ b/.github/unittest/linux/scripts/run_all.sh
@@ -185,11 +185,11 @@ pytest test/smoke_test_deps.py -v --durations 200 -k 'test_gym or test_dm_contro
 if [ "${CU_VERSION:-}" != cpu ] ; then
   python .github/unittest/helpers/coverage_run_parallel.py -m pytest test \
     --instafail --durations 200 -vv --capture no --ignore test/test_rlhf.py \
-    --timeout=60
+    --timeout=120
 else
   python .github/unittest/helpers/coverage_run_parallel.py -m pytest test \
     --instafail --durations 200 -vv --capture no --ignore test/test_rlhf.py --ignore test/test_distributed.py \
-    --timeout=60
+    --timeout=120
 fi
 
 coverage combine

--- a/.github/unittest/linux_examples/scripts/run_test.sh
+++ b/.github/unittest/linux_examples/scripts/run_test.sh
@@ -37,13 +37,17 @@ python .github/unittest/helpers/coverage_run_parallel.py examples/decision_trans
   optim.updates_per_episode=3 \
   optim.warmup_steps=10 \
   optim.device=cuda:0 \
-  logger.backend=
+  logger.backend= \
+  env.backend=gymnasium \
+  env.name=HalfCheetah-v4
 python .github/unittest/helpers/coverage_run_parallel.py examples/decision_transformer/online_dt.py \
   optim.pretrain_gradient_steps=55 \
   optim.updates_per_episode=3 \
   optim.warmup_steps=10 \
   optim.device=cuda:0 \
-  logger.backend=
+  logger.backend= \
+  env.backend=gymnasium \
+  env.name=HalfCheetah-v4
 
 # ==================================================================================== #
 # ================================ Gymnasium ========================================= #

--- a/benchmarks/ecosystem/gym_env_throughput.py
+++ b/benchmarks/ecosystem/gym_env_throughput.py
@@ -16,7 +16,7 @@ The tests are executed with various number of cpus, and on different devices.
 """
 import time
 
-import myosuite  # noqa: F401
+# import myosuite  # noqa: F401
 import torch
 import tqdm
 from torchrl._utils import timeit
@@ -30,6 +30,10 @@ from torchrl.envs import EnvCreator, GymEnv, ParallelEnv
 from torchrl.envs.libs.gym import gym_backend as gym_bc, set_gym_backend
 
 if __name__ == "__main__":
+    avail_devices = ("cpu",)
+    if torch.cuda.device_count():
+        avail_devices = avail_devices + ("cuda:0",)
+
     for envname in [
         "CartPole-v1",
         "HalfCheetah-v4",
@@ -70,7 +74,7 @@ if __name__ == "__main__":
                 log.flush()
 
                 # regular parallel env
-                for device in ("cuda:0", "cpu"):
+                for device in avail_devices:
 
                     def make(envname=envname, gym_backend=gym_backend, device=device):
                         with set_gym_backend(gym_backend):
@@ -97,7 +101,7 @@ if __name__ == "__main__":
                     timeit.print()
                     del penv
 
-                for device in ("cpu", "cuda:0"):
+                for device in avail_devices:
 
                     def make(envname=envname, gym_backend=gym_backend, device=device):
                         with set_gym_backend(gym_backend):
@@ -130,7 +134,7 @@ if __name__ == "__main__":
                     collector.shutdown()
                     del collector
 
-                for device in ("cpu", "cuda:0"):
+                for device in avail_devices:
                     # gym parallel env
                     def make_env(
                         envname=envname,
@@ -157,7 +161,7 @@ if __name__ == "__main__":
                     penv.close()
                     del penv
 
-                for device in ("cpu", "cuda:0"):
+                for device in avail_devices:
                     # async collector
                     # + torchrl parallel env
                     def make_env(
@@ -195,7 +199,7 @@ if __name__ == "__main__":
                     collector.shutdown()
                     del collector
 
-                for device in ("cpu", "cuda:0"):
+                for device in avail_devices:
                     # async collector
                     # + gym async env
                     def make_env(
@@ -240,7 +244,7 @@ if __name__ == "__main__":
                     collector.shutdown()
                     del collector
 
-                for device in ("cpu", "cuda:0"):
+                for device in avail_devices:
                     # sync collector
                     # + torchrl parallel env
                     def make_env(
@@ -278,7 +282,7 @@ if __name__ == "__main__":
                     collector.shutdown()
                     del collector
 
-                for device in ("cpu", "cuda:0"):
+                for device in avail_devices:
                     # sync collector
                     # + gym async env
                     def make_env(

--- a/benchmarks/ecosystem/gym_env_throughput.py
+++ b/benchmarks/ecosystem/gym_env_throughput.py
@@ -116,8 +116,8 @@ if __name__ == "__main__":
                     )
                     pbar = tqdm.tqdm(total=num_workers * 10_000)
                     total_frames = 0
+                    t0 = time.time()
                     for i, data in enumerate(collector):
-                        t0 = time.time()
                         total_frames += data.numel()
                         pbar.update(data.numel())
                         pbar.set_description(

--- a/benchmarks/ecosystem/gym_env_throughput.py
+++ b/benchmarks/ecosystem/gym_env_throughput.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
                     pbar = tqdm.tqdm(total=num_workers * 10_000)
                     total_frames = 0
                     t0 = time.time()
-                    for i, data in enumerate(collector):
+                    for data in collector:
                         total_frames += data.numel()
                         pbar.update(data.numel())
                         pbar.set_description(

--- a/docs/source/reference/envs.rst
+++ b/docs/source/reference/envs.rst
@@ -187,36 +187,94 @@ one can simply call:
         9.81
 
 TorchRL uses a private ``"_reset"`` key to indicate to the environment which
-sub-environments should be reset.
-This allows to reset some but not all of the environments.
-Keep in mind that this is a private key, and it should only be used when coding
-specific environment features that are internal facing.
-The way an environment deals with the ``"_reset"`` keys is proper to it and
-designing an environment that behaves according to ``"_reset"`` inputs is the
-developer's responsibility. The following assumptions are made:
+component (sub-environments or agents) should be reset.
+This allows to reset some but not all of the components.
 
-- Each ``"_reset"`` is paired with a ``"done"`` (and/or ``"terminated"``,
-  ``"truncated"`` etc.). This means that the following structure is not
-  allowed: ``TensorDict({"done": done, "nested": {"_reset": reset}}, [])``.
-- A reset at one level precludes the presence of a ``"_reset"`` at lower
-  levels below it. For instance, this is not allowed:
-  ``TensorDict({"_reset": reset_main, "nested": {"_reset": reset_leaf}}, [])``
+The ``"_reset"`` key has two distinct functionalities:
+1. During a call to :meth:`~.EnvBase._reset`, the ``"_reset"`` key may or may
+   not be present in the input tensordict. TorchRL's convention is that the
+   absence of the ``"_reset"`` key at a given ``"done"`` level indicates
+   a total reset of that level (unless a ``"_reset"`` key was found at a level
+   above, see details below).
+   If it is present, it is expected that those entries and only those components
+   where the ``"_reset"`` entry is ``True`` (along key and shape dimension) will be reset.
+
+   The way an environment deals with the ``"_reset"`` keys in its :meth:`~.EnvBase._reset`
+   method is proper to its class.
+   Designing an environment that behaves according to ``"_reset"`` inputs is the
+   developer's responsibility, as TorchRL has no control over the inner logic
+   of :meth:`~.EnvBase._reset`. Nevertheless, the following point should be
+   kept in mind when desiging that method.
+
+2. After a call to :meth:`~.EnvBase._reset`, the output will be masked with the
+   ``"_reset"`` entries and the output of the previous :meth:`~.EnvBase.step`
+   will be written wherever the ``"_reset"`` was ``False``. In practice, this
+   means that if a ``"_reset"`` modifies data that isn't exposed by it, this
+   modification will be lost. After this masking operation, the ``"_reset"``
+   entries will be erased from the :meth:`~.EnvBase.reset` outputs.
+
+It must be pointed that ``"_reset"`` is a private key, and it should only be
+used when coding specific environment features that are internal facing.
+In other words, this should NOT be used outside of the library, and developers
+will keep the right to modify the logic of partial resets through ``"_reset"``
+setting without preliminary warranty, as long as they don't affect TorchRL
+internal tests.
+
+Finally, the following assumptions are made and should be kept in mind when
+designing reset functionalities:
+
+- Each ``"_reset"`` is paired with a ``"done"`` entry (+ ``"terminated"`` and,
+  possibly, ``"truncated"``). This means that the following structure is not
+  allowed: ``TensorDict({"done": done, "nested": {"_reset": reset}}, [])``, as
+  the ``"_reset"`` lives at a different nesting level than the ``"done"``.
+- A reset at one level does not preclude the presence of a ``"_reset"`` at lower
+  levels, but it annihilates its effects. The reason is simply that
+  whether the ``"_reset"`` at the root level corresponds to an ``all()``, ``any()``
+  or custom call to the nested ``"done"`` entries cannot be known in advance,
+  and it is explicitly assumed that the ``"_reset"`` at the root was placed
+  there to superseed the nested values (for an example, have a look at
+  :class:`~.PettingZooWrapper` implementation where each group has one or more
+  ``"done"`` entries associated which is aggregated at the root level with a
+  ``any`` or ``all`` logic depending on the task).
 - When calling :meth:`env.reset(tensordict)` with a partial ``"_reset"`` entry
   that will reset some but not all the done sub-environments, the input data
   should contain the data of the sub-environemtns that are __not__ being reset.
-  The reason for this constrain is that the output of the ``env._reset(data)``
-  can only be predicted for the entries that are reset. For the others, we
-  cannot know in advance if they will be meaningful or not. For instance,
-  one could perfectly just pad the values of the non-reset environments, in
-  which case the data will be meaningless and should be discarded.
-  :meth:`~torchrl.envs.EnvBase.reset` will merge the input tensordict with
-  the one resulting from reset and pad missing values with 0 (except for
-  ``done`` signals).
-  The other reason why this constrain is enforced is that usually,
-  setting ``"_reset"`` is achieved by internal methods that have access to
-  the data at the previous step, and use that data to call ``reset`` (after
-  passing it through :func:`~torchrl.envs.utils.step_mdp`). We can safely
-  assume that the data presented to ``reset`` is therefore complete.
+  The reason for this constrain lies in the fact that the output of the
+  ``env._reset(data)`` can only be predicted for the entries that are reset.
+  For the others, TorchRL cannot know in advance if they will be meaningful or
+  not. For instance, one could perfectly just pad the values of the non-reset
+  components, in which case the non-reset data will be meaningless and should
+  be discarded.
+
+Below, we give some examples of the expected effect that ``"_reset"`` keys will
+have on an environment returning zeros after reset:
+
+    >>> # single reset at the root
+    >>> data = TensorDict({"val": [1, 1], "_reset": [False, True]}, [])
+    >>> env.reset(data)
+    >>> print(data.get("val"))  # only the second value is 0
+    tensor([1, 0])
+    >>> # nested resets
+    >>> data = TensorDict({
+    ...     ("agent0", "val"): [1, 1], ("agent0", "_reset"): [False, True],
+    ...     ("agent1", "val"): [2, 2], ("agent1", "_reset"): [True, False],
+    ... }, [])
+    >>> env.reset(data)
+    >>> print(data.get(("agent0", "val")))  # only the second value is 0
+    tensor([1, 0])
+    >>> print(data.get(("agent1", "val")))  # only the second value is 0
+    tensor([0, 2])
+    >>> # nested resets are overridden by a "_reset" at the root
+    >>> data = TensorDict({
+    ...     "_reset": [True, True],
+    ...     ("agent0", "val"): [1, 1], ("agent0", "_reset"): [False, True],
+    ...     ("agent1", "val"): [2, 2], ("agent1", "_reset"): [True, False],
+    ... }, [])
+    >>> env.reset(data)
+    >>> print(data.get(("agent0", "val")))  # reset at the root overrides nested
+    tensor([0, 0])
+    >>> print(data.get(("agent1", "val")))  # reset at the root overrides nested
+    tensor([0, 0])
 
 .. code-block::
    :caption: Parallel environment reset

--- a/examples/decision_transformer/dt.py
+++ b/examples/decision_transformer/dt.py
@@ -28,9 +28,10 @@ from utils import (
 )
 
 
-@set_gym_backend("gym")  # D4RL uses gym so we make sure gymnasium is hidden
-@hydra.main(config_path=".", config_name="dt_config")
+@hydra.main(config_path=".", config_name="dt_config", version_base="1.1")
 def main(cfg: "DictConfig"):  # noqa: F821
+    set_gym_backend(cfg.env.backend).set()
+
     model_device = cfg.optim.device
 
     # Set seeds
@@ -63,6 +64,11 @@ def main(cfg: "DictConfig"):  # noqa: F821
         policy=policy,
         inference_context=cfg.env.inference_context,
     ).to(model_device)
+    inference_policy.set_tensor_keys(
+        observation="observation_cat",
+        action="action_cat",
+        return_to_go="return_to_go_cat",
+    )
 
     pbar = tqdm.tqdm(total=cfg.optim.pretrain_gradient_steps)
 

--- a/examples/decision_transformer/dt.py
+++ b/examples/decision_transformer/dt.py
@@ -82,7 +82,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
     # Pretraining
     start_time = time.time()
     for i in range(pretrain_gradient_steps):
-        pbar.update(i)
+        pbar.update(1)
 
         # Sample data
         data = offline_buffer.sample()

--- a/examples/decision_transformer/dt_config.yaml
+++ b/examples/decision_transformer/dt_config.yaml
@@ -15,6 +15,7 @@ env:
   target_return_mode: reduce
   eval_target_return: 6000 
   collect_target_return: 12000
+  backend: gym  # D4RL uses gym so we make sure gymnasium is hidden
 
 # logger
 logger:

--- a/examples/decision_transformer/dt_config.yaml
+++ b/examples/decision_transformer/dt_config.yaml
@@ -63,3 +63,4 @@ transformer:
   n_positions: 1024
   resid_pdrop: 0.1
   attn_pdrop: 0.1
+  compile: False

--- a/examples/decision_transformer/dt_config.yaml
+++ b/examples/decision_transformer/dt_config.yaml
@@ -63,4 +63,3 @@ transformer:
   n_positions: 1024
   resid_pdrop: 0.1
   attn_pdrop: 0.1
-  compile: False

--- a/examples/decision_transformer/odt_config.yaml
+++ b/examples/decision_transformer/odt_config.yaml
@@ -14,6 +14,7 @@ env:
   target_return_mode: reduce
   eval_target_return: 6000
   collect_target_return: 12000
+  backend: gym  # D4RL uses gym so we make sure gymnasium is hidden
 
 
 # logger

--- a/examples/decision_transformer/odt_config.yaml
+++ b/examples/decision_transformer/odt_config.yaml
@@ -64,3 +64,4 @@ transformer:
   n_positions: 1024
   resid_pdrop: 0.1
   attn_pdrop: 0.1
+  compile: False

--- a/examples/decision_transformer/odt_config.yaml
+++ b/examples/decision_transformer/odt_config.yaml
@@ -64,4 +64,3 @@ transformer:
   n_positions: 1024
   resid_pdrop: 0.1
   attn_pdrop: 0.1
-  compile: False

--- a/examples/decision_transformer/online_dt.py
+++ b/examples/decision_transformer/online_dt.py
@@ -29,9 +29,10 @@ from utils import (
 )
 
 
-@set_gym_backend("gym")  # D4RL uses gym so we make sure gymnasium is hidden
-@hydra.main(config_path=".", config_name="odt_config")
+@hydra.main(config_path=".", config_name="odt_config", version_base="1.1")
 def main(cfg: "DictConfig"):  # noqa: F821
+    set_gym_backend(cfg.env.backend).set()
+
     model_device = cfg.optim.device
 
     # Set seeds
@@ -66,6 +67,11 @@ def main(cfg: "DictConfig"):  # noqa: F821
         policy=policy,
         inference_context=cfg.env.inference_context,
     ).to(model_device)
+    inference_policy.set_tensor_keys(
+        observation="observation_cat",
+        action="action_cat",
+        return_to_go="return_to_go_cat",
+    )
 
     pbar = tqdm.tqdm(total=cfg.optim.pretrain_gradient_steps)
 

--- a/examples/decision_transformer/online_dt.py
+++ b/examples/decision_transformer/online_dt.py
@@ -85,7 +85,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
     # Pretraining
     start_time = time.time()
     for i in range(pretrain_gradient_steps):
-        pbar.update(i)
+        pbar.update(1)
         # Sample data
         data = offline_buffer.sample()
         # Compute loss

--- a/examples/decision_transformer/utils.py
+++ b/examples/decision_transformer/utils.py
@@ -332,6 +332,8 @@ def make_odt_model(cfg):
         action_dim=action_spec.shape[-1],
         transformer_config=cfg.transformer,
     )
+    if cfg.transformer.compile:
+        actor_net = torch.compile(actor_net)
 
     actor_module = TensorDictModule(
         actor_net,
@@ -386,6 +388,8 @@ def make_dt_model(cfg):
         action_dim=action_spec.shape[-1],
         transformer_config=cfg.transformer,
     )
+    if cfg.transformer.compile:
+        actor_net = torch.compile(actor_net)
 
     actor_module = TensorDictModule(
         actor_net,

--- a/examples/decision_transformer/utils.py
+++ b/examples/decision_transformer/utils.py
@@ -95,6 +95,7 @@ def make_transformed_env(base_env, env_cfg, obs_loc, obs_std, train=False):
             )
         )
 
+    # copy action from the input tensordict to the output
     transformed_env.append_transform(TensorDictPrimer(action=base_env.action_spec))
 
     transformed_env.append_transform(DoubleToFloat())
@@ -392,8 +393,8 @@ def make_dt_model(cfg):
     )
     dist_class = TanhDelta
     dist_kwargs = {
-        "min": action_spec.space.minimum,
-        "max": action_spec.space.maximum,
+        "min": action_spec.space.low,
+        "max": action_spec.space.high,
     }
 
     actor = ProbabilisticActor(
@@ -428,7 +429,6 @@ def make_odt_loss(loss_cfg, actor_network):
         alpha_init=loss_cfg.alpha_init,
         target_entropy=loss_cfg.target_entropy,
     )
-    loss.set_keys(action="action_cat")
     return loss
 
 
@@ -437,7 +437,7 @@ def make_dt_loss(loss_cfg, actor_network):
         actor_network,
         loss_function=loss_cfg.loss_function,
     )
-    loss.set_keys(action="action_cat")
+    loss.set_keys(action_target="action_cat")
     return loss
 
 

--- a/examples/decision_transformer/utils.py
+++ b/examples/decision_transformer/utils.py
@@ -20,15 +20,15 @@ from torchrl.envs import (
     EnvCreator,
     ExcludeTransform,
     ObservationNorm,
+    ParallelEnv,
     RandomCropTensorDict,
     Reward2GoTransform,
     RewardScaling,
     RewardSum,
-    SerialEnv,
     TargetReturn,
     TensorDictPrimer,
     TransformedEnv,
-    UnsqueezeTransform, ParallelEnv,
+    UnsqueezeTransform,
 )
 from torchrl.envs.libs.dm_control import DMControlEnv
 from torchrl.envs.libs.gym import set_gym_backend

--- a/examples/decision_transformer/utils.py
+++ b/examples/decision_transformer/utils.py
@@ -332,8 +332,6 @@ def make_odt_model(cfg):
         action_dim=action_spec.shape[-1],
         transformer_config=cfg.transformer,
     )
-    if cfg.transformer.compile:
-        actor_net = torch.compile(actor_net)
 
     actor_module = TensorDictModule(
         actor_net,
@@ -388,8 +386,6 @@ def make_dt_model(cfg):
         action_dim=action_spec.shape[-1],
         transformer_config=cfg.transformer,
     )
-    if cfg.transformer.compile:
-        actor_net = torch.compile(actor_net)
 
     actor_module = TensorDictModule(
         actor_net,

--- a/examples/decision_transformer/utils.py
+++ b/examples/decision_transformer/utils.py
@@ -28,7 +28,7 @@ from torchrl.envs import (
     TargetReturn,
     TensorDictPrimer,
     TransformedEnv,
-    UnsqueezeTransform,
+    UnsqueezeTransform, ParallelEnv,
 )
 from torchrl.envs.libs.dm_control import DMControlEnv
 from torchrl.envs.libs.gym import set_gym_backend
@@ -96,12 +96,7 @@ def make_transformed_env(base_env, env_cfg, obs_loc, obs_std, train=False):
 
     transformed_env.append_transform(TensorDictPrimer(action=base_env.action_spec))
 
-    transformed_env.append_transform(
-        DoubleToFloat(
-            in_keys=["observation"],
-            in_keys_inv=[],
-        )
-    )
+    transformed_env.append_transform(DoubleToFloat())
     obsnorm = ObservationNorm(
         loc=obs_loc, scale=obs_std, in_keys="observation", standard_normal=True
     )
@@ -139,7 +134,7 @@ def make_parallel_env(env_cfg, obs_loc, obs_std, train=False):
             return make_base_env(env_cfg)
 
     env = make_transformed_env(
-        SerialEnv(num_envs, EnvCreator(make_env)),
+        ParallelEnv(num_envs, EnvCreator(make_env)),
         env_cfg,
         obs_loc,
         obs_std,
@@ -201,10 +196,7 @@ def make_offline_replay_buffer(rb_cfg, reward_scaling):
     )
     crop_seq = RandomCropTensorDict(sub_seq_len=rb_cfg.stacked_frames, sample_dim=-1)
 
-    d2f = DoubleToFloat(
-        in_keys=["observation", ("next", "observation")],
-        in_keys_inv=[],
-    )
+    d2f = DoubleToFloat()
     exclude = ExcludeTransform(
         "next_observations",
         # "timeout",

--- a/examples/decision_transformer/utils.py
+++ b/examples/decision_transformer/utils.py
@@ -224,8 +224,18 @@ def make_offline_replay_buffer(rb_cfg, reward_scaling):
         use_truncated_as_done=True,
         direct_download=True,
     )
-    loc = data._storage._storage["_data", "observation"].mean(axis=0).float()
-    std = data._storage._storage["_data", "observation"].std(axis=0).float()
+    loc = (
+        data._storage._storage.get(("_data", "observation"))
+        .flatten(0, -2)
+        .mean(axis=0)
+        .float()
+    )
+    std = (
+        data._storage._storage.get(("_data", "observation"))
+        .flatten(0, -2)
+        .std(axis=0)
+        .float()
+    )
     obsnorm = ObservationNorm(
         loc=loc, scale=std, in_keys="observation", standard_normal=True
     )

--- a/examples/decision_transformer/utils.py
+++ b/examples/decision_transformer/utils.py
@@ -133,7 +133,7 @@ def make_parallel_env(env_cfg, obs_loc, obs_std, train=False):
         num_envs = env_cfg.num_eval_envs
 
     def make_env():
-        with set_gym_backend(cfg.env.backend):
+        with set_gym_backend(env_cfg.backend):
             return make_base_env(env_cfg)
 
     env = make_transformed_env(

--- a/examples/decision_transformer/utils.py
+++ b/examples/decision_transformer/utils.py
@@ -430,6 +430,7 @@ def make_odt_loss(loss_cfg, actor_network):
         alpha_init=loss_cfg.alpha_init,
         target_entropy=loss_cfg.target_entropy,
     )
+    loss.set_keys(action_target="action_cat")
     return loss
 
 

--- a/examples/decision_transformer/utils.py
+++ b/examples/decision_transformer/utils.py
@@ -157,8 +157,6 @@ def make_collector(cfg, policy):
     exclude_target_return = ExcludeTransform(
         "return_to_go",
         ("next", "return_to_go"),
-        "return_to_go_single",
-        ("next", "return_to_go_single"),
         ("next", "action"),
         ("next", "observation"),
         "scale",

--- a/examples/decision_transformer/utils.py
+++ b/examples/decision_transformer/utils.py
@@ -421,6 +421,7 @@ def make_odt_loss(loss_cfg, actor_network):
         alpha_init=loss_cfg.alpha_init,
         target_entropy=loss_cfg.target_entropy,
     )
+    loss.set_keys(action="action_cat")
     return loss
 
 
@@ -429,6 +430,7 @@ def make_dt_loss(loss_cfg, actor_network):
         actor_network,
         loss_function=loss_cfg.loss_function,
     )
+    loss.set_keys(action="action_cat")
     return loss
 
 

--- a/examples/decision_transformer/utils.py
+++ b/examples/decision_transformer/utils.py
@@ -186,12 +186,14 @@ def make_collector(cfg, policy):
 
 def make_offline_replay_buffer(rb_cfg, reward_scaling):
     r2g = Reward2GoTransform(
-        gamma=1.0, in_keys=[("next", "reward")], out_keys=[("next", "return_to_go")]
+        gamma=1.0,
+        in_keys=[("next", "reward"), "reward"],
+        out_keys=[("next", "return_to_go"), "return_to_go"],
     )
     reward_scale = RewardScaling(
         loc=0,
         scale=reward_scaling,
-        in_keys=[("next", "return_to_go")],
+        in_keys=[("next", "return_to_go"), "return_to_go"],
         standard_normal=False,
     )
     crop_seq = RandomCropTensorDict(sub_seq_len=rb_cfg.stacked_frames, sample_dim=-1)
@@ -200,12 +202,14 @@ def make_offline_replay_buffer(rb_cfg, reward_scaling):
         in_keys=[
             "action",
             "observation",
+            "return_to_go",
             ("next", "return_to_go"),
             ("next", "observation"),
         ],
         out_keys=[
             "action_cat",
             "observation_cat",
+            "return_to_go_cat",
             ("next", "return_to_go_cat"),
             ("next", "observation_cat"),
         ],
@@ -249,7 +253,10 @@ def make_offline_replay_buffer(rb_cfg, reward_scaling):
         .float()
     )
     obsnorm = ObservationNorm(
-        loc=loc, scale=std, in_keys=["observation_cat", ("next", "observation_cat")], standard_normal=True
+        loc=loc,
+        scale=std,
+        in_keys=["observation_cat", ("next", "observation_cat")],
+        standard_normal=True,
     )
     data.append_transform(obsnorm)
     return data, loc, std

--- a/examples/decision_transformer/utils.py
+++ b/examples/decision_transformer/utils.py
@@ -51,8 +51,9 @@ from torchrl.trainers.helpers.envs import LIBS
 # -----------------
 
 
-@set_gym_backend("gym")  # D4RL uses gym so we make sure gymnasium is hidden
 def make_base_env(env_cfg):
+    set_gym_backend(env_cfg.backend).set()
+
     env_library = LIBS[env_cfg.library]
     env_name = env_cfg.name
     frame_skip = env_cfg.frame_skip
@@ -132,7 +133,7 @@ def make_parallel_env(env_cfg, obs_loc, obs_std, train=False):
         num_envs = env_cfg.num_eval_envs
 
     def make_env():
-        with set_gym_backend("gym"):
+        with set_gym_backend(cfg.env.backend):
             return make_base_env(env_cfg)
 
     env = make_transformed_env(
@@ -481,6 +482,8 @@ def make_dt_optimizer(optim_cfg, loss_module):
 
 
 def make_logger(cfg):
+    from omegaconf import OmegaConf
+
     if not cfg.logger.backend:
         return None
     exp_name = generate_exp_name(cfg.logger.model_name, cfg.logger.exp_name)
@@ -489,7 +492,7 @@ def make_logger(cfg):
         cfg.logger.backend,
         logger_name=cfg.logger.model_name,
         experiment_name=exp_name,
-        wandb_kwargs={"config": cfg},
+        wandb_kwargs={"config": OmegaConf.to_container(cfg)},
     )
     return logger
 

--- a/examples/decision_transformer/utils.py
+++ b/examples/decision_transformer/utils.py
@@ -22,13 +22,14 @@ from torchrl.envs import (
     ObservationNorm,
     ParallelEnv,
     RandomCropTensorDict,
+    RenameTransform,
     Reward2GoTransform,
     RewardScaling,
     RewardSum,
     TargetReturn,
     TensorDictPrimer,
     TransformedEnv,
-    UnsqueezeTransform, RenameTransform,
+    UnsqueezeTransform,
 )
 from torchrl.envs.libs.dm_control import DMControlEnv
 from torchrl.envs.libs.gym import set_gym_backend
@@ -205,12 +206,22 @@ def make_offline_replay_buffer(rb_cfg, reward_scaling):
         ("next", "info"),
     )
     rename = RenameTransform(
-        in_keys=["return_to_go", "action", "observation",
-                 ("next", "return_to_go"), ("next", "action"),
-                 ("next", "observation")],
-        out_keys=["return_to_go_cat", "action_cat", "observation_cat",
-                 ("next", "return_to_go_cat"), ("next", "action_cat"),
-                 ("next", "observation_cat")],
+        in_keys=[
+            "return_to_go",
+            "action",
+            "observation",
+            ("next", "return_to_go"),
+            ("next", "action"),
+            ("next", "observation"),
+        ],
+        out_keys=[
+            "return_to_go_cat",
+            "action_cat",
+            "observation_cat",
+            ("next", "return_to_go_cat"),
+            ("next", "action_cat"),
+            ("next", "observation_cat"),
+        ],
     )
 
     transforms = Compose(

--- a/examples/dqn/config.yaml
+++ b/examples/dqn/config.yaml
@@ -26,7 +26,7 @@ max_frames_per_traj: -1
 weight_decay: 0.0
 annealing_frames: 1000000
 init_env_steps: 10000
-record_frames: 50000
+record_frames: 5000
 loss_function: smooth_l1
 batch_transform: 1
 buffer_prefetch: 64

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -401,7 +401,8 @@ def check_rollout_consistency_multikey_env(td: TensorDict, max_steps: int):
 
     # Check done and reset for nested_1
     observation_is_max = td["next", "nested_1", "observation"][..., 0] == max_steps + 1
-    next_is_done = td["next", "nested_1", "done"][index_batch_size][:-1].squeeze(-1)
+    # done at the root always prevail
+    next_is_done = td["next", "done"][index_batch_size][:-1].squeeze(-1)
     assert (td["next", "nested_1", "done"][observation_is_max]).all()
     assert (~td["next", "nested_1", "done"][~observation_is_max]).all()
     # Obs after done is 0
@@ -429,7 +430,8 @@ def check_rollout_consistency_multikey_env(td: TensorDict, max_steps: int):
 
     # Check done and reset for nested_2
     observation_is_max = td["next", "nested_2", "observation"][..., 0] == max_steps + 1
-    next_is_done = td["next", "nested_2", "done"][index_batch_size][:-1].squeeze(-1)
+    # done at the root always prevail
+    next_is_done = td["next", "done"][index_batch_size][:-1].squeeze(-1)
     assert (td["next", "nested_2", "done"][observation_is_max]).all()
     assert (~td["next", "nested_2", "done"][~observation_is_max]).all()
     # Obs after done is 0

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -93,6 +93,13 @@ class _MockEnv(EnvBase):
                 action=cls._input_spec["full_action_spec"],
                 shape=cls._input_spec["full_action_spec"].shape[:-1],
             )
+        dtype = kwargs.pop("dtype", torch.get_default_dtype())
+        for spec in (cls._output_spec, cls._input_spec):
+            if dtype != torch.get_default_dtype():
+                for key, val in list(spec.items(True, True)):
+                    if val.dtype == torch.get_default_dtype():
+                        val = val.to(dtype)
+                        spec[key] = val
         return super().__new__(cls, *args, **kwargs)
 
     def __init__(

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -1499,7 +1499,8 @@ class HeteroCountingEnv(EnvBase):
         reset_td.update(self.output_spec["full_done_spec"].zero())
 
         assert reset_td.batch_size == self.batch_size
-
+        for key in reset_td.keys(True):
+            assert "_reset" not in key
         return reset_td
 
     def _step(

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -1106,11 +1106,13 @@ class NestedCountingEnv(CountingEnv):
         nest_done: bool = True,
         nest_reward: bool = True,
         nested_dim: int = 3,
+        has_root_done: bool = False,
         **kwargs,
     ):
         super().__init__(max_steps=max_steps, start_val=start_val, **kwargs)
 
         self.nested_dim = nested_dim
+        self.has_root_done = has_root_done
 
         self.nested_obs_action = nest_obs_action
         self.nested_done = nest_done
@@ -1172,81 +1174,105 @@ class NestedCountingEnv(CountingEnv):
             done_spec = self.full_done_spec.unsqueeze(-1).expand(
                 *self.batch_size, self.nested_dim
             )
-            self.done_spec = CompositeSpec(
+            done_spec = CompositeSpec(
                 {"data": done_spec},
                 shape=self.batch_size,
             )
+            if self.has_root_done:
+                done_spec["done"] = DiscreteTensorSpec(
+                    2,
+                    shape=(
+                        *self.batch_size,
+                        1,
+                    ),
+                    dtype=torch.bool,
+                )
+            self.done_spec = done_spec
 
     def _reset(self, tensordict):
-        if (
-            self.nested_done
-            and tensordict is not None
-            and "_reset" in tensordict.keys()
-        ):
-            tensordict = tensordict.clone()
-            tensordict["_reset"] = tensordict["_reset"].sum(-2, dtype=torch.bool)
-        td = super()._reset(tensordict)
-        if self.nested_done:
-            for done_key in self.done_keys:
-                if isinstance(done_key, str):
-                    done_key = (done_key,)
-                td[done_key] = (
-                    td[done_key[-1]]
-                    .unsqueeze(-1)
-                    .expand(*self.batch_size, self.nested_dim, 1)
-                )
-                del td[done_key[-1]]
-        if self.nested_obs_action:
-            td["data", "states"] = (
-                td["observation"]
-                .unsqueeze(-1)
-                .expand(*self.batch_size, self.nested_dim, 1)
-            )
-            del td["observation"]
-        if "data" in td.keys():
-            td["data"].batch_size = (*self.batch_size, self.nested_dim)
-        return td
 
-    def _step(self, td):
-        if self.nested_obs_action:
-            td = td.clone()
-            td["data"].batch_size = self.batch_size
-            td[self.action_key] = td[self.action_key].max(-2)[0]
-        next_td = super()._step(td)
-        if self.nested_obs_action:
-            td[self.action_key] = (
-                td[self.action_key]
-                .unsqueeze(-1)
-                .expand(*self.batch_size, self.nested_dim, 1)
-            )
-        if "data" in td.keys():
-            td["data"].batch_size = (*self.batch_size, self.nested_dim)
-        td = next_td
+        # check that reset works as expected
+        if tensordict is not None:
+            if self.nested_done:
+                if not self.has_root_done:
+                    assert "_reset" not in tensordict.keys()
+            else:
+                assert ("data", "_reset") not in tensordict.keys(True)
+
+        tensordict_reset = super()._reset(tensordict)
+
         if self.nested_done:
             for done_key in self.done_keys:
                 if isinstance(done_key, str):
-                    done_key = (done_key,)
-                td[done_key] = (
-                    td[done_key[-1]]
-                    .unsqueeze(-1)
-                    .expand(*self.batch_size, self.nested_dim, 1)
+                    continue
+                if self.has_root_done:
+                    done = tensordict_reset.get(done_key[-1])
+                else:
+                    done = tensordict_reset.pop(done_key[-1])
+                tensordict_reset.set(
+                    done_key,
+                    (done.unsqueeze(-2).expand(*self.batch_size, self.nested_dim, 1)),
                 )
-                del td[done_key[-1]]
         if self.nested_obs_action:
-            td["data", "states"] = (
-                td["observation"]
+            obs = tensordict_reset.pop("observation")
+            tensordict_reset.set(
+                ("data", "states"),
+                (obs.unsqueeze(-1).expand(*self.batch_size, self.nested_dim, 1)),
+            )
+        if "data" in tensordict_reset.keys():
+            tensordict_reset.get("data").batch_size = (
+                *self.batch_size,
+                self.nested_dim,
+            )
+        return tensordict_reset
+
+    def _step(self, tensordict):
+        if self.nested_obs_action:
+            tensordict = tensordict.clone()
+            tensordict["data"].batch_size = self.batch_size
+            tensordict[self.action_key] = tensordict[self.action_key].max(-2)[0]
+        next_tensordict = super()._step(tensordict)
+        if self.nested_obs_action:
+            tensordict[self.action_key] = (
+                tensordict[self.action_key]
                 .unsqueeze(-1)
                 .expand(*self.batch_size, self.nested_dim, 1)
             )
-            del td["observation"]
-        if self.nested_reward:
-            td[self.reward_key] = (
-                td["reward"].unsqueeze(-1).expand(*self.batch_size, self.nested_dim, 1)
+        if "data" in tensordict.keys():
+            tensordict["data"].batch_size = (*self.batch_size, self.nested_dim)
+        if self.nested_done:
+            for done_key in self.done_keys:
+                if isinstance(done_key, str):
+                    continue
+                if self.has_root_done:
+                    done = next_tensordict.get(done_key[-1])
+                else:
+                    done = next_tensordict.pop(done_key[-1])
+                next_tensordict.set(
+                    done_key,
+                    (done.unsqueeze(-1).expand(*self.batch_size, self.nested_dim, 1)),
+                )
+        if self.nested_obs_action:
+            next_tensordict.set(
+                ("data", "states"),
+                (
+                    next_tensordict.pop("observation")
+                    .unsqueeze(-1)
+                    .expand(*self.batch_size, self.nested_dim, 1)
+                ),
             )
-            del td["reward"]
-        if "data" in td.keys():
-            td["data"].batch_size = (*self.batch_size, self.nested_dim)
-        return td
+        if self.nested_reward:
+            next_tensordict.set(
+                self.reward_key,
+                (
+                    next_tensordict.pop("reward")
+                    .unsqueeze(-1)
+                    .expand(*self.batch_size, self.nested_dim, 1)
+                ),
+            )
+        if "data" in next_tensordict.keys():
+            next_tensordict.get("data").batch_size = (*self.batch_size, self.nested_dim)
+        return next_tensordict
 
 
 class CountingBatchedEnv(EnvBase):

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -1715,6 +1715,7 @@ class MultiKeyCountingEnv(EnvBase):
                 ),
                 shape=(self.nested_dim_2,),
             ),
+            # done at the root always prevail
             done=DiscreteTensorSpec(
                 n=2,
                 shape=(1,),
@@ -1736,17 +1737,10 @@ class MultiKeyCountingEnv(EnvBase):
         if tensordict is not None:
             _reset = tensordict.get("_reset", None)
             if _reset is not None:
-                self.count[_reset.squeeze(-1)] = self.start_val
-
-            _reset_nested_1 = tensordict.get(("nested_1", "_reset"), None)
-            if _reset_nested_1 is not None:
-                self.count_nested_1[_reset_nested_1.squeeze(-1)] = self.start_val
-
-            _reset_nested_2 = tensordict.get(("nested_2", "_reset"), None)
-            if _reset_nested_2 is not None:
-                self.count_nested_2[_reset_nested_2.squeeze(-1)] = self.start_val
-
-            if _reset is None and _reset_nested_1 is None and _reset_nested_2 is None:
+                self.count[_reset] = self.start_val
+                self.count_nested_1[_reset] = self.start_val
+                self.count_nested_2[_reset] = self.start_val
+            else:
                 reset_all = True
 
         if tensordict is None or reset_all:

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -59,7 +59,7 @@ from torchrl.envs import (
 from torchrl.envs.libs.gym import _has_gym, gym_backend, GymEnv, set_gym_backend
 from torchrl.envs.transforms import TransformedEnv, VecNorm
 from torchrl.envs.utils import (
-    _aggregate_resets,
+    _aggregate_end_of_traj,
     _replace_last,
     check_env_specs,
     PARTIAL_MISSING_ERR,
@@ -1816,12 +1816,12 @@ class TestAggregateReset:
     def test_aggregate_reset_to_root(self):
         # simple
         td = TensorDict({"_reset": torch.zeros((1,), dtype=torch.bool)}, [])
-        assert _aggregate_resets(td).shape == ()
+        assert _aggregate_end_of_traj(td).shape == ()
         # td with batch size
         td = TensorDict({"_reset": torch.zeros((1,), dtype=torch.bool)}, [1])
-        assert _aggregate_resets(td).shape == (1,)
+        assert _aggregate_end_of_traj(td).shape == (1,)
         td = TensorDict({"_reset": torch.zeros((1, 2), dtype=torch.bool)}, [1])
-        assert _aggregate_resets(td).shape == (1,)
+        assert _aggregate_end_of_traj(td).shape == (1,)
         # nested td
         td = TensorDict(
             {
@@ -1830,7 +1830,7 @@ class TestAggregateReset:
             },
             [1],
         )
-        assert _aggregate_resets(td).shape == (1,)
+        assert _aggregate_end_of_traj(td).shape == (1,)
         # nested td with greater number of dims
         td = TensorDict(
             {
@@ -1843,7 +1843,7 @@ class TestAggregateReset:
             [1, 2],
         )
         # test reduction
-        assert _aggregate_resets(td).shape == (1, 2)
+        assert _aggregate_end_of_traj(td).shape == (1, 2)
         td = TensorDict(
             {
                 "_reset": torch.zeros(
@@ -1855,7 +1855,7 @@ class TestAggregateReset:
             [1, 2],
         )
         # test reduction, partial
-        assert _aggregate_resets(td).shape == (1, 2)
+        assert _aggregate_end_of_traj(td).shape == (1, 2)
         td = TensorDict(
             {
                 "_reset": torch.tensor([True, False]).view(1, 2),
@@ -1863,7 +1863,9 @@ class TestAggregateReset:
             },
             [1, 2],
         )
-        assert (_aggregate_resets(td) == torch.tensor([True, False]).view(1, 2)).all()
+        assert (
+            _aggregate_end_of_traj(td) == torch.tensor([True, False]).view(1, 2)
+        ).all()
         # with a stack
         td0 = TensorDict(
             {
@@ -1888,17 +1890,17 @@ class TestAggregateReset:
             [1, 2],
         )
         td = torch.stack([td0, td1], 0)
-        assert _aggregate_resets(td).all()
+        assert _aggregate_end_of_traj(td).all()
 
     def test_aggregate_reset_to_root_keys(self):
         # simple
         td = TensorDict({"_reset": torch.zeros((1,), dtype=torch.bool)}, [])
-        assert _aggregate_resets(td, reset_keys=["_reset"]).shape == ()
+        assert _aggregate_end_of_traj(td, reset_keys=["_reset"]).shape == ()
         # td with batch size
         td = TensorDict({"_reset": torch.zeros((1,), dtype=torch.bool)}, [1])
-        assert _aggregate_resets(td, reset_keys=["_reset"]).shape == (1,)
+        assert _aggregate_end_of_traj(td, reset_keys=["_reset"]).shape == (1,)
         td = TensorDict({"_reset": torch.zeros((1, 2), dtype=torch.bool)}, [1])
-        assert _aggregate_resets(td, reset_keys=["_reset"]).shape == (1,)
+        assert _aggregate_end_of_traj(td, reset_keys=["_reset"]).shape == (1,)
         # nested td
         td = TensorDict(
             {
@@ -1907,9 +1909,9 @@ class TestAggregateReset:
             },
             [1],
         )
-        assert _aggregate_resets(td, reset_keys=["_reset", ("a", "_reset")]).shape == (
-            1,
-        )
+        assert _aggregate_end_of_traj(
+            td, reset_keys=["_reset", ("a", "_reset")]
+        ).shape == (1,)
         # nested td with greater number of dims
         td = TensorDict(
             {
@@ -1922,7 +1924,9 @@ class TestAggregateReset:
             [1, 2],
         )
         # test reduction
-        assert _aggregate_resets(td, reset_keys=["_reset", ("a", "_reset")]).shape == (
+        assert _aggregate_end_of_traj(
+            td, reset_keys=["_reset", ("a", "_reset")]
+        ).shape == (
             1,
             2,
         )
@@ -1936,9 +1940,11 @@ class TestAggregateReset:
             },
             [1, 2],
         )
-        assert _aggregate_resets(td, reset_keys=["_reset", ("a", "_reset")]).all()
+        assert _aggregate_end_of_traj(td, reset_keys=["_reset", ("a", "_reset")]).all()
         # test reduction, partial
-        assert _aggregate_resets(td, reset_keys=["_reset", ("a", "_reset")]).shape == (
+        assert _aggregate_end_of_traj(
+            td, reset_keys=["_reset", ("a", "_reset")]
+        ).shape == (
             1,
             2,
         )
@@ -1952,7 +1958,7 @@ class TestAggregateReset:
             [1, 2],
         )
         assert (
-            _aggregate_resets(td, reset_keys=["_reset", ("a", "_reset")])
+            _aggregate_end_of_traj(td, reset_keys=["_reset", ("a", "_reset")])
             == torch.tensor([True, False]).view(1, 2)
         ).all()
         # with a stack
@@ -1979,17 +1985,17 @@ class TestAggregateReset:
             [1, 2],
         )
         td = torch.stack([td0, td1], 0)
-        assert _aggregate_resets(td, reset_keys=["_reset", ("a", "_reset")]).all()
+        assert _aggregate_end_of_traj(td, reset_keys=["_reset", ("a", "_reset")]).all()
 
     def test_aggregate_reset_to_root_errors(self):
         # the order matters: if the first or another key is missing, the ValueError is raised at a different line
         with pytest.raises(ValueError, match=PARTIAL_MISSING_ERR):
-            _aggregate_resets(
+            _aggregate_end_of_traj(
                 TensorDict({"_reset": False}, []),
                 reset_keys=["_reset", ("another", "_reset")],
             )
         with pytest.raises(ValueError, match=PARTIAL_MISSING_ERR):
-            _aggregate_resets(
+            _aggregate_end_of_traj(
                 TensorDict({"_reset": False}, []),
                 reset_keys=[("another", "_reset"), "_reset"],
             )

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -7511,7 +7511,8 @@ class TestDT(LossModuleTestBase):
         loss_fn = DTLoss(actor)
 
         default_keys = {
-            "action": "action",
+            "action_target": "action",
+            "action_pred": "action",
         }
 
         self.tensordict_keys_test(

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -7412,7 +7412,8 @@ class TestOnlineDT(LossModuleTestBase):
         loss_fn = OnlineDTLoss(actor)
 
         default_keys = {
-            "action": "action",
+            "action_pred": "action",
+            "action_target": "action",
         }
 
         self.tensordict_keys_test(

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -2273,16 +2273,16 @@ def test_auto_cast_to_device(break_when_any_done):
     with pytest.raises(RuntimeError):
         env.rollout(10, policy)
     torch.manual_seed(0)
-    env.seed(0)
+    env.set_seed(0)
     rollout0 = env.rollout(
         100, policy, auto_cast_to_device=True, break_when_any_done=break_when_any_done
     )
     torch.manual_seed(0)
-    env.seed(0)
+    env.set_seed(0)
     rollout1 = env.rollout(
         100,
         policy.cpu(),
-        auto_cast_to_device=True,
+        auto_cast_to_device=False,
         break_when_any_done=break_when_any_done,
     )
     assert_allclose_td(rollout0, rollout1)

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -1018,6 +1018,7 @@ def test_env_base_reset_flag(batch_size, max_steps=3):
     assert (td["next", "observation"] == max_steps + 1).all()
 
     td_reset = TensorDict(rand_reset(env), batch_size=env.batch_size, device=env.device)
+    td_reset.update(td.get("next").exclude("reward"))
     reset = td_reset["_reset"]
     td_reset = env.reset(td_reset)
 

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -2082,7 +2082,7 @@ class TestTerminatedOrTruncated:
     def test_terminated_or_truncated_nospec(self):
         data = TensorDict({"done": torch.zeros(2, 1, dtype=torch.bool)}, [2])
         assert not _terminated_or_truncated(data, write_full_false=True)
-        assert data["_reset"].shape == (2, 1)
+        assert data["_reset"].shape == (2,)
         assert not _terminated_or_truncated(data, write_full_false=False)
         assert data.get("_reset", None) is None
 
@@ -2094,8 +2094,8 @@ class TestTerminatedOrTruncated:
             [2],
         )
         assert _terminated_or_truncated(data)
-        assert data["_reset"].shape == (2, 1)
-        assert data["nested", "_reset"].shape == (2, 1)
+        assert data["_reset"].shape == (2,)
+        assert data["nested", "_reset"].shape == (2,)
 
         data = TensorDict(
             {
@@ -2108,8 +2108,8 @@ class TestTerminatedOrTruncated:
         assert data.get("_reset", None) is None
         assert data.get(("nested", "_reset"), None) is None
         assert not _terminated_or_truncated(data, write_full_false=True)
-        assert data["_reset"].shape == (2, 1)
-        assert data["nested", "_reset"].shape == (2, 1)
+        assert data["_reset"].shape == (2,)
+        assert data["nested", "_reset"].shape == (2,)
 
         data = TensorDict(
             {
@@ -2120,8 +2120,8 @@ class TestTerminatedOrTruncated:
             [2],
         )
         assert _terminated_or_truncated(data, write_full_false=False)
-        assert data["_reset"].shape == (2, 1)
-        assert data["nested", "_reset"].shape == (2, 1)
+        assert data["_reset"].shape == (2,)
+        assert data["nested", "_reset"].shape == (2,)
         assert data["_reset"].all()
         assert not data["nested", "_reset"].any()
 
@@ -2136,7 +2136,7 @@ class TestTerminatedOrTruncated:
         assert not _terminated_or_truncated(
             data, write_full_false=True, full_done_spec=spec
         )
-        assert data["_reset"].shape == (2, 1)
+        assert data["_reset"].shape == (2,)
         assert not _terminated_or_truncated(
             data, write_full_false=False, full_done_spec=spec
         )
@@ -2161,8 +2161,8 @@ class TestTerminatedOrTruncated:
             [2],
         )
         assert _terminated_or_truncated(data, full_done_spec=spec)
-        assert data["_reset"].shape == (2, 1)
-        assert data["nested", "_reset"].shape == (2, 1)
+        assert data["_reset"].shape == (2,)
+        assert data["nested", "_reset"].shape == (2,)
 
         data = TensorDict(
             {
@@ -2179,8 +2179,8 @@ class TestTerminatedOrTruncated:
         assert not _terminated_or_truncated(
             data, write_full_false=True, full_done_spec=spec
         )
-        assert data["_reset"].shape == (2, 1)
-        assert data["nested", "_reset"].shape == (2, 1)
+        assert data["_reset"].shape == (2,)
+        assert data["nested", "_reset"].shape == (2,)
 
         spec = CompositeSpec(
             {
@@ -2203,8 +2203,8 @@ class TestTerminatedOrTruncated:
         assert _terminated_or_truncated(
             data, write_full_false=False, full_done_spec=spec
         )
-        assert data["_reset"].shape == (2, 1)
-        assert data["nested", "_reset"].shape == (2, 1)
+        assert data["_reset"].shape == (2,)
+        assert data["nested", "_reset"].shape == (2,)
         assert data["_reset"].all()
         assert not data["nested", "_reset"].any()
 

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -72,7 +72,7 @@ from torchrl.envs.utils import (
     make_composite_from_td,
     MarlGroupMapType,
     step_mdp,
-    terminated_or_truncated,
+    _terminated_or_truncated,
 )
 from torchrl.modules import Actor, ActorCriticOperator, MLP, SafeModule, ValueOperator
 from torchrl.modules.tensordict_module import WorldModelWrapper
@@ -2060,9 +2060,9 @@ def test_mocking_envs(envclass):
 class TestTerminatedOrTruncated:
     def test_terminated_or_truncated_nospec(self):
         data = TensorDict({"done": torch.zeros(2, 1, dtype=torch.bool)}, [2])
-        assert not terminated_or_truncated(data, write_full_false=True)
+        assert not _terminated_or_truncated(data, write_full_false=True)
         assert data["_reset"].shape == (2, 1)
-        assert not terminated_or_truncated(data, write_full_false=False)
+        assert not _terminated_or_truncated(data, write_full_false=False)
         assert data.get("_reset", None) is None
 
         data = TensorDict(
@@ -2072,7 +2072,7 @@ class TestTerminatedOrTruncated:
             },
             [2],
         )
-        assert terminated_or_truncated(data)
+        assert _terminated_or_truncated(data)
         assert data["_reset"].shape == (2, 1)
         assert data["nested", "_reset"].shape == (2, 1)
 
@@ -2083,10 +2083,10 @@ class TestTerminatedOrTruncated:
             },
             [2],
         )
-        assert not terminated_or_truncated(data, write_full_false=False)
+        assert not _terminated_or_truncated(data, write_full_false=False)
         assert data.get("_reset", None) is None
         assert data.get(("nested", "_reset"), None) is None
-        assert not terminated_or_truncated(data, write_full_false=True)
+        assert not _terminated_or_truncated(data, write_full_false=True)
         assert data["_reset"].shape == (2, 1)
         assert data["nested", "_reset"].shape == (2, 1)
 
@@ -2098,7 +2098,7 @@ class TestTerminatedOrTruncated:
             },
             [2],
         )
-        assert terminated_or_truncated(data, write_full_false=False)
+        assert _terminated_or_truncated(data, write_full_false=False)
         assert data["_reset"].shape == (2, 1)
         assert data["nested", "_reset"].shape == (2, 1)
         assert data["_reset"].all()
@@ -2112,11 +2112,11 @@ class TestTerminatedOrTruncated:
             ],
         )
         data = TensorDict({"done": torch.zeros(2, 1, dtype=torch.bool)}, [2])
-        assert not terminated_or_truncated(
+        assert not _terminated_or_truncated(
             data, write_full_false=True, full_done_spec=spec
         )
         assert data["_reset"].shape == (2, 1)
-        assert not terminated_or_truncated(
+        assert not _terminated_or_truncated(
             data, write_full_false=False, full_done_spec=spec
         )
         assert data.get("_reset", None) is None
@@ -2139,7 +2139,7 @@ class TestTerminatedOrTruncated:
             },
             [2],
         )
-        assert terminated_or_truncated(data, full_done_spec=spec)
+        assert _terminated_or_truncated(data, full_done_spec=spec)
         assert data["_reset"].shape == (2, 1)
         assert data["nested", "_reset"].shape == (2, 1)
 
@@ -2150,12 +2150,12 @@ class TestTerminatedOrTruncated:
             },
             [2],
         )
-        assert not terminated_or_truncated(
+        assert not _terminated_or_truncated(
             data, write_full_false=False, full_done_spec=spec
         )
         assert data.get("_reset", None) is None
         assert data.get(("nested", "_reset"), None) is None
-        assert not terminated_or_truncated(
+        assert not _terminated_or_truncated(
             data, write_full_false=True, full_done_spec=spec
         )
         assert data["_reset"].shape == (2, 1)
@@ -2179,7 +2179,7 @@ class TestTerminatedOrTruncated:
             },
             [2],
         )
-        assert terminated_or_truncated(
+        assert _terminated_or_truncated(
             data, write_full_false=False, full_done_spec=spec
         )
         assert data["_reset"].shape == (2, 1)

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -1905,6 +1905,24 @@ class TestNestedSpecs:
             nested_dim,
         )
 
+    @pytest.mark.parametrize("batch_size", [(), (32,), (32, 1)])
+    @pytest.mark.parametrize(
+        "nest_done,has_root_done", [[False, False], [True, False], [True, True]]
+    )
+    def test_nested_reset(self, nest_done, has_root_done, batch_size):
+        env = NestedCountingEnv(
+            nest_done=nest_done, has_root_done=has_root_done, batch_size=batch_size
+        )
+        for reset_key, done_keys in zip(env.reset_keys, env.done_keys_groups):
+            if isinstance(reset_key, str):
+                for done_key in done_keys:
+                    assert isinstance(done_key, str)
+            else:
+                for done_key in done_keys:
+                    assert done_key[:-1] == reset_key[:-1]
+        env.rollout(100)
+        env.rollout(100, break_when_any_done=False)
+
 
 class TestHeteroEnvs:
     @pytest.mark.parametrize("batch_size", [(), (32,), (1, 2)])

--- a/test/test_exploration.py
+++ b/test/test_exploration.py
@@ -609,7 +609,9 @@ def test_gsde(
         device=device,
     )
     if gSDE:
-        gSDENoise(shape=[batch]).reset(td)
+        td_reset = td.empty()
+        gSDENoise(shape=[batch], reset_key="_reset")._reset(td, td_reset)
+        td.update(td_reset)
         assert "_eps_gSDE" in td.keys()
         assert td.get("_eps_gSDE").device == device
     actor(td)

--- a/test/test_exploration.py
+++ b/test/test_exploration.py
@@ -610,7 +610,8 @@ def test_gsde(
     )
     if gSDE:
         td_reset = td.empty()
-        gSDENoise(shape=[batch], reset_key="_reset")._reset(td, td_reset)
+        gsde = gSDENoise(shape=[batch], reset_key="_reset").to(device)
+        gsde._reset(td, td_reset)
         td.update(td_reset)
         assert "_eps_gSDE" in td.keys()
         assert td.get("_eps_gSDE").device == device

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -1590,7 +1590,7 @@ class TestVmas:
             [n_workers, list(env.num_envs)[0], n_rollout_samples]
         )
 
-    @pytest.mark.parametrize("num_envs", [1, 10])
+    @pytest.mark.parametrize("num_envs", [1, 2])
     @pytest.mark.parametrize("n_workers", [1, 3])
     @pytest.mark.parametrize(
         "scenario_name", ["simple_reference", "waterfall", "flocking", "discovery"]
@@ -1631,6 +1631,9 @@ class TestVmas:
         td_reset = TensorDict(
             rand_reset(env), batch_size=env.batch_size, device=env.device
         )
+        # it is good practice to have a "complete" input tensordict for reset
+        for done_key in env.done_keys:
+            td_reset.set(done_key, tensordict[..., -1].get(("next", done_key)))
         reset = td_reset["_reset"]
         tensordict = env.reset(td_reset)
         assert not tensordict["done"][reset].all().item()

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -1889,12 +1889,9 @@ class TestD4RL:
         env = GymWrapper(gym.make(task))
         rollout = env.rollout(2)
         for key in rollout.keys(True, True):
-            if "truncated" in key:
-                # truncated is missing from static datasets
-                continue
-            sim = rollout[key]
-            offline = sample[key]
-            assert sim.dtype == offline.dtype, key
+            sim = rollout.get(key)
+            offline = sample.get(key)
+            # assert sim.dtype == offline.dtype, key
             assert sim.shape[-1] == offline.shape[-1], key
         print(f"terminated test after {time.time()-t0}s")
 

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -2191,10 +2191,10 @@ class TestDecisionTransformerInferenceWrapper:
         )
         with pytest.raises(
             ValueError,
-            match="The action key action was not found in the policy out_keys",
+            match="The value of out_action_key",
         ):
             result = inference_actor(td)
-        inference_actor.set_tensor_keys(action=action_key)
+        inference_actor.set_tensor_keys(action=action_key, out_action=action_key)
         result = inference_actor(td)
         # checks that the seq length has disappeared
         assert result.get(action_key).shape == torch.Size([1, 2])

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -1789,7 +1789,9 @@ class TestLSTMModule:
 
         def create_transformed_env():
             primer = lstm_module.make_tensordict_primer()
-            env = DiscreteActionVecMockEnv(categorical_action_encoding=True, device=device)
+            env = DiscreteActionVecMockEnv(
+                categorical_action_encoding=True, device=device
+            )
             env = TransformedEnv(env)
             env.append_transform(InitTracker())
             env.append_transform(primer)
@@ -1822,8 +1824,8 @@ class TestLSTMModule:
         )
         for break_when_any_done in [False, True]:
             data = env.rollout(10, actor, break_when_any_done=break_when_any_done)
-            assert (data.get("recurrent_state_c") != 0.0).any()
             assert (data.get(("next", "recurrent_state_c")) != 0.0).all()
+            assert (data.get("recurrent_state_c") != 0.0).any()
 
 
 class TestGRUModule:
@@ -2036,6 +2038,7 @@ class TestGRUModule:
     def test_gru_parallel_env(self):
         from torchrl.envs import InitTracker, ParallelEnv, TransformedEnv
 
+        device = "cuda" if torch.cuda.device_count() else "cpu"
         # tests that hidden states are carried over with parallel envs
         gru_module = GRUModule(
             input_size=7,
@@ -2043,11 +2046,14 @@ class TestGRUModule:
             num_layers=2,
             in_key="observation",
             out_key="features",
+            device=device,
         )
 
         def create_transformed_env():
             primer = gru_module.make_tensordict_primer()
-            env = DiscreteActionVecMockEnv(categorical_action_encoding=True)
+            env = DiscreteActionVecMockEnv(
+                categorical_action_encoding=True, device=device
+            )
             env = TransformedEnv(env)
             env.append_transform(InitTracker())
             env.append_transform(primer)
@@ -2063,6 +2069,7 @@ class TestGRUModule:
                 in_features=12,
                 out_features=7,
                 num_cells=[],
+                device=device,
             ),
             in_keys=["features"],
             out_keys=["logits"],

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -1776,6 +1776,7 @@ class TestLSTMModule:
     def test_lstm_parallel_env(self):
         from torchrl.envs import InitTracker, ParallelEnv, TransformedEnv
 
+        device = "cuda" if torch.cuda.device_count() else "cpu"
         # tests that hidden states are carried over with parallel envs
         lstm_module = LSTMModule(
             input_size=7,
@@ -1783,11 +1784,12 @@ class TestLSTMModule:
             num_layers=2,
             in_key="observation",
             out_key="features",
+            device=device,
         )
 
         def create_transformed_env():
             primer = lstm_module.make_tensordict_primer()
-            env = DiscreteActionVecMockEnv(categorical_action_encoding=True)
+            env = DiscreteActionVecMockEnv(categorical_action_encoding=True, device=device)
             env = TransformedEnv(env)
             env.append_transform(InitTracker())
             env.append_transform(primer)
@@ -1803,6 +1805,7 @@ class TestLSTMModule:
                 in_features=12,
                 out_features=7,
                 num_cells=[],
+                device=device,
             ),
             in_keys=["features"],
             out_keys=["logits"],

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -6275,7 +6275,7 @@ class TestTimeMaxPool(TransformBase):
         tdc = td.clone()
         passed_back_td = t._reset(tdc, tdc.empty())
 
-        assert tdc is passed_back_td
+        # assert tdc is passed_back_td
         assert (buffer == 0).all()
 
         _ = t._call(tdc)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1732,6 +1732,20 @@ class TestStepCounter(TransformBase):
         check_env_specs(transformed_env)
         transformed_env.close()
 
+    def test_stepcounter_ignore(self):
+        # checks that step_count_keys respect the convention that nested dones should
+        # be ignored if there is a done in a root td
+        env = TransformedEnv(
+            NestedCountingEnv(has_root_done=True, nest_done=True), StepCounter()
+        )
+        assert len(env.transform.step_count_keys) == 1
+        assert env.transform.step_count_keys[0] == "step_count"
+        env = TransformedEnv(
+            NestedCountingEnv(has_root_done=False, nest_done=True), StepCounter()
+        )
+        assert len(env.transform.step_count_keys) == 1
+        assert env.transform.step_count_keys[0] == ("data", "step_count")
+
 
 class TestCatTensors(TransformBase):
     @pytest.mark.parametrize("append", [True, False])
@@ -8582,6 +8596,20 @@ class TestInitTracker(TransformBase):
 
         td_reset = transformed_env.reset(td_reset)
         assert (td_reset[init_key] == reset).all()
+
+    def test_inittracker_ignore(self):
+        # checks that init keys respect the convention that nested dones should
+        # be ignored if there is a done in a root td
+        env = TransformedEnv(
+            NestedCountingEnv(has_root_done=True, nest_done=True), InitTracker()
+        )
+        assert len(env.transform.init_keys) == 1
+        assert env.transform.init_keys[0] == "is_init"
+        env = TransformedEnv(
+            NestedCountingEnv(has_root_done=False, nest_done=True), InitTracker()
+        )
+        assert len(env.transform.init_keys) == 1
+        assert env.transform.init_keys[0] == ("data", "is_init")
 
 
 class TestKLRewardTransform(TransformBase):

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1554,7 +1554,7 @@ class TestStepCounter(TransformBase):
         td_reset = step_counter._reset(td, td_reset)
         assert not torch.all(td_reset.get("step_count"))
         i = 0
-        td_next = td.get('next')
+        td_next = td.get("next")
         td = td_reset
         while max_steps is None or i < max_steps:
             td_next = step_counter._step(td, td_next)
@@ -1578,8 +1578,12 @@ class TestStepCounter(TransformBase):
         if reset_workers:
             td.set("_reset", _reset)
             td_reset = step_counter._reset(td, td_reset)
-            assert torch.all(torch.masked_select(td_reset.get("step_count"), _reset) == 0)
-            assert torch.all(torch.masked_select(td_reset.get("step_count"), ~_reset) == i)
+            assert torch.all(
+                torch.masked_select(td_reset.get("step_count"), _reset) == 0
+            )
+            assert torch.all(
+                torch.masked_select(td_reset.get("step_count"), ~_reset) == i
+            )
         else:
             td_reset = step_counter._reset(td, td_reset)
             assert torch.all(td_reset.get("step_count") == 0)
@@ -1625,7 +1629,7 @@ class TestStepCounter(TransformBase):
         td_reset = step_counter._reset(td, td_reset)
         assert not torch.all(td_reset.get("step_count"))
         i = 0
-        td_next = td.get('next')
+        td_next = td.get("next")
         td = td_reset
         while max_steps is None or i < max_steps:
             td_next = step_counter._step(td, td_next)
@@ -1649,8 +1653,12 @@ class TestStepCounter(TransformBase):
         if reset_workers:
             td.set("_reset", _reset)
             td_reset = step_counter._reset(td, td_reset)
-            assert torch.all(torch.masked_select(td_reset.get("step_count"), _reset) == 0)
-            assert torch.all(torch.masked_select(td_reset.get("step_count"), ~_reset) == i)
+            assert torch.all(
+                torch.masked_select(td_reset.get("step_count"), _reset) == 0
+            )
+            assert torch.all(
+                torch.masked_select(td_reset.get("step_count"), ~_reset) == i
+            )
         else:
             td_reset = step_counter._reset(td, td_reset)
             assert torch.all(td_reset.get("step_count") == 0)
@@ -1748,11 +1756,7 @@ class TestCatTensors(TransformBase):
         td = TensorDict(
             {
                 key: torch.full(
-                    (
-                        1,
-                        4,
-                        32,
-                    ),
+                    (1, 4, 32),
                     value,
                     dtype=torch.float,
                     device=device,
@@ -3478,7 +3482,7 @@ class TestNoop(TransformBase):
             match="NoopResetEnv.parent not found. Make sure that the parent is set.",
         ):
             td = TensorDict({"next": {}}, [])
-            t._reset(td, td)
+            t._reset(td, td.empty())
         td = TensorDict({"next": {}}, [])
         t._step(td, td.get("next"))
 
@@ -3489,7 +3493,7 @@ class TestNoop(TransformBase):
             match="NoopResetEnv.parent not found. Make sure that the parent is set.",
         ):
             td = TensorDict({"next": {}}, [])
-            t.reset(td, td)
+            td = t._reset(td, td.empty())
         td = TensorDict({"next": {}}, [])
         t._step(td, td.get("next"))
 
@@ -4707,7 +4711,8 @@ class TestRewardSum(TransformBase):
         with pytest.raises(TypeError, match="reset_keys not provided but parent"):
             rs._reset(td, td)
         rs._reset_keys = ["_reset"]
-        rs._reset(td, td.empty())
+        td_reset = rs._reset(td, td.empty())
+        td = td_reset.set("next", td.get("next"))
 
         # apply a third time, episode_reward should be equal to reward again
         td_next = rs._step(td, td.get("next"))

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -44,7 +44,7 @@ from torchrl.data.utils import CloudpickleWrapper, DEVICE_TYPING
 from torchrl.envs.common import EnvBase
 from torchrl.envs.transforms import StepCounter, TransformedEnv
 from torchrl.envs.utils import (
-    _aggregate_resets,
+    _aggregate_end_of_traj,
     _convert_exploration_type,
     ExplorationType,
     set_exploration_type,
@@ -786,7 +786,7 @@ class SyncDataCollector(DataCollectorBase):
 
     def _update_traj_ids(self, tensordict) -> None:
         # we can't use the reset keys because they're gone
-        traj_sop = _aggregate_resets(
+        traj_sop = _aggregate_end_of_traj(
             tensordict.get("next"), done_keys=self.env.done_keys
         )
         if traj_sop.any():

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -873,14 +873,14 @@ class SyncDataCollector(DataCollectorBase):
             # check that the env supports partial reset
             if prod(self.env.batch_size) == 0:
                 raise RuntimeError("resetting unique env with index is not permitted.")
-            _reset = torch.zeros(
-                self.env.done_spec.shape,
-                dtype=torch.bool,
-                device=self.env.device,
-            )
-            _reset[index] = 1
-            self._tensordict[index].zero_()
-            self._tensordict.set("_reset", _reset)
+            for reset_key, done_keys in zip(self.env.reset_keys, self.env.done_keys_groups):
+                _reset = torch.zeros(
+                    self.env.full_done_spec[done_keys[0]].shape,
+                    dtype=torch.bool,
+                    device=self.env.device,
+                )
+                _reset[index] = 1
+                self._tensordict.set(reset_key, _reset)
         else:
             _reset = None
             self._tensordict.zero_()

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -873,7 +873,9 @@ class SyncDataCollector(DataCollectorBase):
             # check that the env supports partial reset
             if prod(self.env.batch_size) == 0:
                 raise RuntimeError("resetting unique env with index is not permitted.")
-            for reset_key, done_keys in zip(self.env.reset_keys, self.env.done_keys_groups):
+            for reset_key, done_keys in zip(
+                self.env.reset_keys, self.env.done_keys_groups
+            ):
                 _reset = torch.zeros(
                     self.env.full_done_spec[done_keys[0]].shape,
                     dtype=torch.bool,

--- a/torchrl/data/datasets/d4rl.py
+++ b/torchrl/data/datasets/d4rl.py
@@ -69,7 +69,7 @@ class D4RLExperienceReplay(TensorDictReplayBuffer):
 
             .. note::
 
-              Using ``from_env=False`` will provide less data than ``from_env=True``.
+              Using ``from_env=False`` will provide fewer data than ``from_env=True``.
               For instance, the info keys will be left out.
               Usually, ``from_env=False`` with ``terminate_on_end=True`` will
               lead to the same result as ``from_env=True``, with the latter
@@ -136,17 +136,6 @@ class D4RLExperienceReplay(TensorDictReplayBuffer):
         terminate_on_end: bool = None,
         **env_kwargs,
     ):
-        if from_env is None:
-            warnings.warn(
-                "from_env will soon default to ``False``, ie the data will be "
-                "downloaded without relying on d4rl by default. "
-                "For now, ``True`` will still be the default. "
-                "To disable this warning, explicitly pass the ``from_env`` argument "
-                "during construction of the dataset.",
-                category=DeprecationWarning,
-            )
-            from_env = True
-        self.from_env = from_env
         self.use_truncated_as_done = use_truncated_as_done
 
         if not from_env and direct_download is None:
@@ -154,6 +143,17 @@ class D4RLExperienceReplay(TensorDictReplayBuffer):
             direct_download = not self._has_d4rl
 
         if not direct_download:
+            if from_env is None:
+                warnings.warn(
+                    "from_env will soon default to ``False``, ie the data will be "
+                    "downloaded without relying on d4rl by default. "
+                    "For now, ``True`` will still be the default. "
+                    "To disable this warning, explicitly pass the ``from_env`` argument "
+                    "during construction of the dataset.",
+                    category=DeprecationWarning,
+                )
+                from_env = True
+            self.from_env = from_env
             if terminate_on_end is None:
                 # we use the default of d4rl
                 terminate_on_end = False
@@ -175,6 +175,9 @@ class D4RLExperienceReplay(TensorDictReplayBuffer):
                 env_kwargs.update({"terminate_on_end": terminate_on_end})
                 dataset = self._get_dataset_direct(name, env_kwargs)
         else:
+            if from_env is None:
+                from_env = False
+            self.from_env = from_env
             if terminate_on_end is False:
                 raise ValueError(
                     "Using terminate_on_end=False is not compatible with direct_download=True."

--- a/torchrl/data/datasets/d4rl.py
+++ b/torchrl/data/datasets/d4rl.py
@@ -276,7 +276,6 @@ class D4RLExperienceReplay(TensorDictReplayBuffer):
         dataset["terminated"] = dataset["terminated"].bool().unsqueeze(-1)
         if "truncated" in dataset.keys():
             dataset["truncated"] = dataset["truncated"].bool().unsqueeze(-1)
-        # dataset.rename_key_("next_observations", "next/observation")
         dataset["reward"] = dataset["reward"].unsqueeze(-1)
         dataset["next"].update(
             dataset.select("reward", "done", "terminated", "truncated", strict=False)
@@ -357,10 +356,17 @@ class D4RLExperienceReplay(TensorDictReplayBuffer):
             dataset["truncated"] = dataset["truncated"].bool().unsqueeze(-1)
 
         dataset["reward"] = dataset["reward"].unsqueeze(-1)
-        dataset = dataset[:-1].set(
-            "next",
-            dataset.select("observation", "info", strict=False)[1:],
-        )
+        if "next_observations" in dataset.keys():
+            dataset = dataset[:-1].set(
+                "next",
+                dataset.select("info", strict=False)[1:],
+            )
+            dataset.rename_key_("next_observations", ("next", "observation"))
+        else:
+            dataset = dataset[:-1].set(
+                "next",
+                dataset.select("observation", "info", strict=False)[1:],
+            )
         dataset["next"].update(
             dataset.select("reward", "done", "terminated", "truncated", strict=False)
         )

--- a/torchrl/data/datasets/d4rl.py
+++ b/torchrl/data/datasets/d4rl.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import importlib
 import os
 import urllib
 import warnings
@@ -111,13 +112,14 @@ class D4RLExperienceReplay(TensorDictReplayBuffer):
 
     @classmethod
     def _import_d4rl(cls):
+        cls._has_d4rl = importlib.util.find_spec("d4rl") is not None
         try:
             import d4rl  # noqa
 
-            cls._has_d4rl = True
         except ModuleNotFoundError as err:
-            cls._has_d4rl = False
             cls.D4RL_ERR = err
+        except Exception:
+            pass
 
     def __init__(
         self,

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -740,7 +740,7 @@ def _collate_contiguous(x):
 
 
 def _collate_as_tensor(x):
-    return x.contiguous()
+    return x.as_tensor()
 
 
 def _get_default_collate(storage, _is_tensordict=False):

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -615,8 +615,8 @@ class LazyMemmapStorage(LazyTensorStorage):
             for key, tensor in sorted(
                 out.items(include_nested=True, leaves_only=True), key=str
             ):
-                filesize = os.path.getsize(tensor.filename) / 1024 / 1024
                 if VERBOSE:
+                    filesize = os.path.getsize(tensor.filename) / 1024 / 1024
                     print(
                         f"\t{key}: {tensor.filename}, {filesize} Mb of storage (size: {tensor.shape})."
                     )
@@ -626,8 +626,8 @@ class LazyMemmapStorage(LazyTensorStorage):
             out = MemmapTensor(
                 self.max_size, *data.shape, device=self.device, dtype=data.dtype
             )
-            filesize = os.path.getsize(out.filename) / 1024 / 1024
             if VERBOSE:
+                filesize = os.path.getsize(out.filename) / 1024 / 1024
                 print(
                     f"The storage was created in {out.filename} and occupies {filesize} Mb of storage."
                 )

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -740,7 +740,7 @@ def _collate_contiguous(x):
 
 
 def _collate_as_tensor(x):
-    return x.as_tensor()
+    return x.contiguous()
 
 
 def _get_default_collate(storage, _is_tensordict=False):

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -3424,9 +3424,7 @@ class CompositeSpec(TensorSpec):
         if shape is None:
             shape = torch.Size([])
         _dict = {
-            key: self[key].rand(shape)
-            for key in self.keys(True)
-            if isinstance(key, str) and self[key] is not None
+            key: self[key].rand(shape) for key in self.keys() if self[key] is not None
         }
         return TensorDict(
             _dict,

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1565,7 +1565,9 @@ class BoundedTensorSpec(TensorSpec):
                 raise RuntimeError(shape_err_msg)
         self.shape = shape
 
-        super().__init__(shape, ContinuousBox(low, high), device, dtype, "continuous")
+        super().__init__(
+            shape, ContinuousBox(low, high, device=device), device, dtype, "continuous"
+        )
 
     def expand(self, *shape):
         if len(shape) == 1 and isinstance(shape[0], (tuple, list, torch.Size)):
@@ -1783,7 +1785,8 @@ class UnboundedContinuousTensorSpec(TensorSpec):
         dtype, device = _default_dtype_and_device(dtype, device)
         box = (
             ContinuousBox(
-                torch.tensor(-np.inf).expand(shape), torch.tensor(np.inf).expand(shape)
+                torch.tensor(-np.inf, device=device).expand(shape),
+                torch.tensor(np.inf, device=device).expand(shape),
             )
             if shape == _DEFAULT_SHAPE
             else None

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -3254,7 +3254,10 @@ class CompositeSpec(TensorSpec):
 
     def __getitem__(self, idx):
         """Indexes the current CompositeSpec based on the provided index."""
-        idx_unravel = unravel_key(idx)
+        if isinstance(idx, (str, tuple)):
+            idx_unravel = unravel_key(idx)
+        else:
+            idx_unravel = ()
         if idx_unravel:
             if isinstance(idx_unravel, tuple):
                 return self[idx[0]][idx[1:]]

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -3254,19 +3254,13 @@ class CompositeSpec(TensorSpec):
 
     def __getitem__(self, idx):
         """Indexes the current CompositeSpec based on the provided index."""
-        if (
-            isinstance(idx, str)
-            or isinstance(idx, tuple)
-            and all(isinstance(item, str) for item in idx)
-        ):
-            if isinstance(idx, tuple) and len(idx) > 1:
+        idx_unravel = unravel_key(idx)
+        if idx_unravel:
+            if isinstance(idx_unravel, tuple):
                 return self[idx[0]][idx[1:]]
-            elif isinstance(idx, tuple):
-                return self[idx[0]]
-
-            if idx in {"shape", "device", "dtype", "space"}:
-                raise AttributeError(f"CompositeSpec has no key {idx}")
-            return self._specs[idx]
+            if idx_unravel in {"shape", "device", "dtype", "space"}:
+                raise AttributeError(f"CompositeSpec has no key {idx_unravel}")
+            return self._specs[idx_unravel]
 
         indexed_shape = _shape_indexing(self.shape, idx)
         indexed_specs = {}

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1782,7 +1782,9 @@ class UnboundedContinuousTensorSpec(TensorSpec):
 
         dtype, device = _default_dtype_and_device(dtype, device)
         box = (
-            ContinuousBox(torch.tensor(-np.inf).expand(shape), torch.tensor(np.inf).expand(shape))
+            ContinuousBox(
+                torch.tensor(-np.inf).expand(shape), torch.tensor(np.inf).expand(shape)
+            )
             if shape == _DEFAULT_SHAPE
             else None
         )

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1782,7 +1782,7 @@ class UnboundedContinuousTensorSpec(TensorSpec):
 
         dtype, device = _default_dtype_and_device(dtype, device)
         box = (
-            ContinuousBox(torch.tensor(-np.inf), torch.tensor(np.inf))
+            ContinuousBox(torch.tensor(-np.inf).expand(shape), torch.tensor(np.inf).expand(shape))
             if shape == _DEFAULT_SHAPE
             else None
         )

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -1223,7 +1223,6 @@ def _run_worker_pipe_cuda(
     verbose: bool = False,
 ) -> None:
     stream = torch.cuda.Stream(device)
-    env = env.to("cpu")
     with torch.cuda.StreamContext(stream):
         parent_pipe.close()
         pid = os.getpid()
@@ -1235,7 +1234,7 @@ def _run_worker_pipe_cuda(
                     "env_fun_kwargs must be empty if an environment is passed to a process."
                 )
             env = env_fun
-        env = env.to(device)
+        env = env.to("cpu")
         del env_fun
 
         i = -1

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -1223,6 +1223,7 @@ def _run_worker_pipe_cuda(
     verbose: bool = False,
 ) -> None:
     stream = torch.cuda.Stream(device)
+    env = env.to("cpu")
     with torch.cuda.StreamContext(stream):
         parent_pipe.close()
         pid = os.getpid()
@@ -1297,12 +1298,12 @@ def _run_worker_pipe_cuda(
                 td, root_next_td = env.step_and_maybe_reset(
                     shared_tensordict.clone(False)
                 )
-                # for key, val in td.get("next").items(True, True):
-                #     next_shared_tensordict.get(key).copy_(val, non_blocking=True)
-                next_shared_tensordict.update_(td.get("next"))
-                # for key, val in root_next_td.items(True, True):
-                #     shared_tensordict.get(key).copy_(val, non_blocking=True)
-                shared_tensordict.update_(root_next_td)
+                for key, val in td.get("next").items(True, True):
+                    next_shared_tensordict.get(key).copy_(val, non_blocking=True)
+                # next_shared_tensordict.update_(td.get("next"))
+                for key, val in root_next_td.items(True, True):
+                    shared_tensordict.get(key).copy_(val, non_blocking=True)
+                # shared_tensordict.update_(root_next_td)
                 stream.record_event(cuda_event)
                 stream.synchronize()
 

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -1295,7 +1295,7 @@ def _run_worker_pipe_cuda(
                     raise RuntimeError("called 'init' before step")
                 i += 1
                 td, root_next_td = env.step_and_maybe_reset(
-                    shared_tensordict.clone(False)
+                    shared_tensordict.select(*_selected_input_keys).cpu()
                 )
                 for key, val in td.get("next").items(True, True):
                     next_shared_tensordict.get(key).copy_(val, non_blocking=True)

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -29,7 +29,8 @@ from torchrl.envs.utils import (
     _aggregate_resets,
     _set_single_key,
     _sort_keys,
-    clear_mpi_env_vars, _update_during_reset,
+    _update_during_reset,
+    clear_mpi_env_vars,
 )
 
 # legacy

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -26,7 +26,7 @@ from torchrl.envs.common import EnvBase
 from torchrl.envs.env_creator import get_env_metadata
 
 from torchrl.envs.utils import (
-    _aggregate_resets,
+    _aggregate_end_of_traj,
     _set_single_key,
     _sort_keys,
     _update_during_reset,
@@ -581,7 +581,9 @@ class SerialEnv(_BatchedEnv):
     @_check_start
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         if tensordict is not None:
-            needs_resetting = _aggregate_resets(tensordict, reset_keys=self.reset_keys)
+            needs_resetting = _aggregate_end_of_traj(
+                tensordict, reset_keys=self.reset_keys
+            )
             if needs_resetting.ndim > 2:
                 needs_resetting = needs_resetting.flatten(1, needs_resetting.ndim - 1)
             if needs_resetting.ndim > 1:
@@ -888,7 +890,9 @@ class ParallelEnv(_BatchedEnv):
     @_check_start
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         if tensordict is not None:
-            needs_resetting = _aggregate_resets(tensordict, reset_keys=self.reset_keys)
+            needs_resetting = _aggregate_end_of_traj(
+                tensordict, reset_keys=self.reset_keys
+            )
             if needs_resetting.ndim > 2:
                 needs_resetting = needs_resetting.flatten(1, needs_resetting.ndim - 1)
             if needs_resetting.ndim > 1:

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -602,7 +602,7 @@ class SerialEnv(_BatchedEnv):
             else:
                 tensordict_ = None
             _td = _env.reset(tensordict=tensordict_, **kwargs)
-            self.shared_tensordicts[i].update_(_td)
+            self.shared_tensordicts[i].update_(_td.select(*self._selected_reset_keys_filt, strict=False))
         selected_output_keys = self._selected_reset_keys_filt
         if self._single_task:
             # select + clone creates 2 tds, but we can create one only
@@ -1098,7 +1098,7 @@ def _run_worker_pipe_shared_mem(
             if not initialized:
                 raise RuntimeError("call 'init' before resetting")
             cur_td = env.reset(tensordict=data)
-            shared_tensordict.update_(cur_td)
+            shared_tensordict.update_(cur_td.select(*_selected_reset_keys, strict=False))
             if event is not None:
                 event.record()
                 event.synchronize()

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -30,7 +30,7 @@ from torchrl.envs.utils import (
     _update_during_reset,
     get_available_libraries,
     step_mdp,
-    terminated_or_truncated,
+    _terminated_or_truncated,
 )
 
 LIBRARIES = get_available_libraries()
@@ -1857,7 +1857,7 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
             )
             # done and truncated are in done_keys
             # We read if any key is done.
-            any_done = terminated_or_truncated(
+            any_done = _terminated_or_truncated(
                 tensordict,
                 full_done_spec=self.output_spec["full_done_spec"],
                 key=None,
@@ -1952,7 +1952,7 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
             action_keys=self.action_keys,
             done_keys=self.done_keys,
         )
-        any_done = terminated_or_truncated(
+        any_done = _terminated_or_truncated(
             tensordict_,
             full_done_spec=self.output_spec["full_done_spec"],
             key="_reset",

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -1962,6 +1962,28 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
         )
 
     @property
+    def _filtered_reset_keys(self):
+        """Returns the only the effective reset keys, discarding nested resets if they're not being used."""
+        reset_keys = self.reset_keys
+        result = []
+
+        def _root(key):
+            if isinstance(key, str):
+                return ()
+            return key[:-1]
+
+        roots = []
+        for reset_key in reset_keys:
+            cur_root = _root(reset_key)
+            for root in roots:
+                if cur_root[: len(root)] == root:
+                    break
+            else:
+                roots.append(cur_root)
+                result.append(reset_key)
+        return result
+
+    @property
     def done_keys_groups(self):
         """A list of done keys, grouped as the reset keys.
 

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -1528,11 +1528,11 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
                         # we set the done val to tensordict, to make sure that
                         # _update_during_reset does not pad the value
                         tensordict.set(done_key, done_val)
-            elif self._allow_done_after_reset:
+            elif not self._allow_done_after_reset:
                 for done_key in done_key_group:
                     if tensordict_reset.get(done_key).any():
                         raise RuntimeError(
-                            f"Env done entry '{done_key}' was (partially) True after a call to reset(). This is not allowed."
+                            f"The done entry '{done_key}' was (partially) True after a call to reset() in env {self}."
                         )
 
     def numel(self) -> int:
@@ -1868,7 +1868,7 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
                 tensordict_ = tensordict_.to(policy_device, non_blocking=True)
             tensordict_ = policy(tensordict_)
             if auto_cast_to_device:
-                tensordict_ = tensordict.to(env_device, non_blocking=True)
+                tensordict_ = tensordict_.to(env_device, non_blocking=True)
             tensordict, tensordict_ = self.step_and_maybe_reset(tensordict_)
             tensordicts.append(tensordict)
             if i == max_steps - 1:

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -1333,7 +1333,11 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
         next_tensordict = self._step_proc_data(next_tensordict)
         if next_preset is not None:
             # tensordict could already have a "next" key
-            next_tensordict.update(next_preset)
+            # this could be done more efficiently by not excluding but just passing
+            # the necessary keys
+            next_tensordict.update(
+                next_preset.exclude(*next_tensordict.keys(True, True))
+            )
         tensordict.set("next", next_tensordict)
         return tensordict
 

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -27,10 +27,10 @@ from torchrl.data.tensor_specs import (
 from torchrl.data.utils import DEVICE_TYPING
 from torchrl.envs.utils import (
     _replace_last,
+    _terminated_or_truncated,
     _update_during_reset,
     get_available_libraries,
     step_mdp,
-    _terminated_or_truncated,
 )
 
 LIBRARIES = get_available_libraries()

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -926,7 +926,7 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
             if reset is None:
                 return super()._reset(tensordict)
             elif reset is not None:
-                return tensordict.clone(False)
+                return tensordict.exclude("_reset")
         return super()._reset(tensordict, **kwargs)
 
 

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -128,6 +128,10 @@ class set_gym_backend(_DecoratorContextManager):
                 f"Check that the gym versions match!"
             )
 
+    def set(self):
+        """Irreversibly sets the gym backend in the script."""
+        self._call()
+
     def __enter__(self):
         # we save a complete list of setters as well as whether they should be set.
         # we want the full list becasue we want to be able to nest the calls to set_gym_backend.

--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -626,9 +626,7 @@ class PettingZooWrapper(_EnvWrapper):
                     if key[-1] == "done":
                         done = done | tensordict_out.get(key).any()
                     if key[-1] == "terminated":
-                        terminated = (
-                            terminated | tensordict_out.get(key).any()
-                        )
+                        terminated = terminated | tensordict_out.get(key).any()
                     if key[-1] == "truncated":
                         truncated = truncated | tensordict_out.get(key).any()
                     if done:
@@ -637,9 +635,7 @@ class PettingZooWrapper(_EnvWrapper):
                     if key[-1] == "done":
                         done = done & tensordict_out.get(key).all()
                     if key[-1] == "terminated":
-                        terminated = (
-                            terminated & tensordict_out.get(key).all()
-                        )
+                        terminated = terminated & tensordict_out.get(key).all()
                     if key[-1] == "truncated":
                         truncated = truncated & tensordict_out.get(key).all()
                     if not done:

--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -2,10 +2,11 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+from __future__ import annotations
 
 import copy
 import importlib
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
 import torch
 from tensordict.tensordict import TensorDictBase
@@ -154,11 +155,11 @@ class PettingZooWrapper(_EnvWrapper):
             "pettingzoo.utils.env.ParallelEnv",  # noqa: F821
             "pettingzoo.utils.env.AECEnv",  # noqa: F821
         ] = None,
-        return_state: Optional[bool] = False,
-        group_map: Optional[Union[MarlGroupMapType, Dict[str, List[str]]]] = None,
+        return_state: bool = False,
+        group_map: MarlGroupMapType | Dict[str, List[str]] | None = None,
         use_mask: bool = False,
         categorical_actions: bool = True,
-        seed: Optional[int] = None,
+        seed: int | None = None,
         **kwargs,
     ):
         if env is not None:
@@ -401,7 +402,7 @@ class PettingZooWrapper(_EnvWrapper):
         ):
             raise TypeError("env is not of type expected.")
 
-    def _init_env(self) -> Optional[int]:
+    def _init_env(self):
         # Add info
         if self.parallel:
             _, info_dict = self._reset_parallel(seed=self.seed)
@@ -477,15 +478,16 @@ class PettingZooWrapper(_EnvWrapper):
         self.reset(seed=self.seed)
 
     def _reset(
-        self, tensordict: Optional[TensorDictBase] = None, **kwargs
+        self, tensordict: TensorDictBase | None = None, **kwargs
     ) -> TensorDictBase:
-
-        _reset = tensordict.get("_reset", None)
-        if _reset is not None and not _reset.all():
-            raise RuntimeError(
-                f"An attempt to call {type(self)}._reset was made when no reset signal could be found. "
-                f"Expected '_reset' entry to be `tensor(True)` or `None` but got `{_reset}`."
-            )
+        if tensordict is not None:
+            _reset = tensordict.get("_reset", None)
+            if _reset is not None and not _reset.all():
+                raise RuntimeError(
+                    f"An attempt to call {type(self)}._reset was made when no "
+                    f"reset signal could be found. Expected '_reset' entry to "
+                    f"be `tensor(True)` or `None` but got `{_reset}`."
+                )
         if self.parallel:
             # This resets when any is done
             observation_dict, info_dict = self._reset_parallel(**kwargs)
@@ -878,11 +880,11 @@ class PettingZooEnv(PettingZooWrapper):
         self,
         task: str,
         parallel: bool,
-        return_state: Optional[bool] = False,
-        group_map: Optional[Union[MarlGroupMapType, Dict[str, List[str]]]] = None,
+        return_state: bool = False,
+        group_map: MarlGroupMapType | Dict[str, List[str]] | None = None,
         use_mask: bool = False,
         categorical_actions: bool = True,
-        seed: Optional[int] = None,
+        seed: int | None = None,
         **kwargs,
     ):
         if not _has_pettingzoo:

--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -18,12 +18,7 @@ from torchrl.data import (
 )
 from torchrl.envs.common import _EnvWrapper
 from torchrl.envs.libs.gym import _gym_to_torchrl_spec_transform, set_gym_backend
-from torchrl.envs.utils import (
-    _classproperty,
-    _replace_last,
-    check_marl_grouping,
-    MarlGroupMapType,
-)
+from torchrl.envs.utils import _classproperty, check_marl_grouping, MarlGroupMapType
 
 _has_pettingzoo = importlib.util.find_spec("pettingzoo") is not None
 
@@ -255,7 +250,28 @@ class PettingZooWrapper(_EnvWrapper):
         action_spec = CompositeSpec()
         observation_spec = CompositeSpec()
         reward_spec = CompositeSpec()
-        done_spec = CompositeSpec()
+        done_spec = CompositeSpec(
+            {
+                "done": DiscreteTensorSpec(
+                    n=2,
+                    shape=torch.Size((1,)),
+                    dtype=torch.bool,
+                    device=self.device,
+                ),
+                "terminated": DiscreteTensorSpec(
+                    n=2,
+                    shape=torch.Size((1,)),
+                    dtype=torch.bool,
+                    device=self.device,
+                ),
+                "truncated": DiscreteTensorSpec(
+                    n=2,
+                    shape=torch.Size((1,)),
+                    dtype=torch.bool,
+                    device=self.device,
+                ),
+            },
+        )
         for group, agents in self.group_map.items():
             (
                 group_observation_spec,
@@ -469,7 +485,7 @@ class PettingZooWrapper(_EnvWrapper):
             observation_dict, info_dict = self._reset_parallel(**kwargs)
         else:
             # This resets when all are done
-            observation_dict, info_dict = self._reset_aec(tensordict, **kwargs)
+            observation_dict, info_dict = self._reset_aec(**kwargs)
 
         # We start with zeroed data and fill in the data for alive agents
         tensordict_out = self.cached_reset_output_zero.clone()
@@ -498,26 +514,8 @@ class PettingZooWrapper(_EnvWrapper):
 
         return tensordict_out
 
-    def _reset_aec(self, tensordict=None, **kwargs) -> Tuple[Dict, Dict]:
-        all_done = True
-        if tensordict is not None:
-            _resets = []
-            for done_key in self.done_keys:
-                _reset_key = _replace_last(done_key, "_reset")
-                _reset = tensordict.get(_reset_key, default=None)
-                if _reset is None:
-                    continue
-                _resets.append(_reset)
-            if len(_resets) < len(self.done_keys):
-                all_done = False
-            else:
-                for _reset in _resets:
-                    if not _reset.all():
-                        all_done = False
-                        break
-
-        if all_done:
-            self._env.reset(**kwargs)
+    def _reset_aec(self, **kwargs) -> Tuple[Dict, Dict]:
+        self._env.reset(**kwargs)
 
         observation_dict = {
             agent: self._env.observe(agent) for agent in self.possible_agents
@@ -608,7 +606,31 @@ class PettingZooWrapper(_EnvWrapper):
                         " you need to set use_action_mask=True to allow this."
                     )
 
+        # set done values
+        done = self._aggregate_done(tensordict_out, use_any=self.parallel)
+
+        tensordict_out.set("done", done)
+        tensordict_out.set("terminated", done)
+        tensordict_out.set("truncated", torch.zeros_like(done))
         return tensordict_out
+
+    def _aggregate_done(self, tensordict_out, use_any):
+        done = False
+        for done_key in self.full_done_spec.keys(True, True):
+            if isinstance(done_key, tuple):
+                if use_any:
+                    done = done | tensordict_out.get(done_key).any()
+                    if done:
+                        break
+                else:
+                    done = done & tensordict_out.get(done_key).all()
+                    if not done:
+                        break
+        else:
+            raise RuntimeError(
+                f"Could not find done values in tensordict {tensordict_out}."
+            )
+        return torch.tensor([done], device=self.device)
 
     def _step_parallel(
         self,

--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -482,8 +482,10 @@ class PettingZooWrapper(_EnvWrapper):
 
         _reset = tensordict.get("_reset", None)
         if _reset is not None and not _reset.all():
-            raise RuntimeError(f"An attempt to call {type(self)}._reset was made when no reset signal could be found. "
-                               f"Expected '_reset' entry to be `tensor(True)` or `None` but got `{_reset}`.")
+            raise RuntimeError(
+                f"An attempt to call {type(self)}._reset was made when no reset signal could be found. "
+                f"Expected '_reset' entry to be `tensor(True)` or `None` but got `{_reset}`."
+            )
         if self.parallel:
             # This resets when any is done
             observation_dict, info_dict = self._reset_parallel(**kwargs)

--- a/torchrl/envs/transforms/gym_transforms.py
+++ b/torchrl/envs/transforms/gym_transforms.py
@@ -162,20 +162,20 @@ class EndOfLifeTransform(Transform):
         next_tensordict.set(self.lives_key, lives)
         return next_tensordict
 
-    def reset(self, tensordict):
+    def _reset(self, tensordict, tensordict_reset):
         parent = self.parent
         if parent is None:
             raise RuntimeError(self.NO_PARENT_ERR.format(type(self)))
         lives = self._get_lives()
         end_of_life = False
-        tensordict.set(
+        tensordict_reset.set(
             self.eol_key,
             torch.tensor(end_of_life).expand(
                 parent.full_done_spec[self.done_key].shape
             ),
         )
-        tensordict.set(self.lives_key, lives)
-        return tensordict
+        tensordict_reset.set(self.lives_key, lives)
+        return tensordict_reset
 
     def transform_observation_spec(self, observation_spec):
         full_done_spec = self.parent.output_spec["full_done_spec"]

--- a/torchrl/envs/transforms/r3m.py
+++ b/torchrl/envs/transforms/r3m.py
@@ -6,7 +6,7 @@
 from typing import List, Optional, Union
 
 import torch
-from tensordict import TensorDict
+from tensordict import TensorDict, TensorDictBase
 from torch.hub import load_state_dict_from_url
 from torch.nn import Identity
 
@@ -26,6 +26,7 @@ from torchrl.envs.transforms.transforms import (
     Transform,
     UnsqueezeTransform,
 )
+from torchrl.envs.transforms.utils import _set_missing_tolerance
 
 try:
     from torchvision import models
@@ -91,6 +92,14 @@ class _R3MNet(Transform):
         return tensordict
 
     forward = _call
+
+    def _reset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        # TODO: Check this makes sense
+        with _set_missing_tolerance(self, True):
+            tensordict_reset = self._call(tensordict_reset)
+        return tensordict_reset
 
     @torch.no_grad()
     def _apply_transform(self, obs: torch.Tensor) -> None:

--- a/torchrl/envs/transforms/rlhf.py
+++ b/torchrl/envs/transforms/rlhf.py
@@ -16,6 +16,7 @@ from tensordict.utils import is_seq_of_nested_key
 from torch import nn
 from torchrl.data.tensor_specs import CompositeSpec, UnboundedContinuousTensorSpec
 from torchrl.envs.transforms.transforms import Transform
+from torchrl.envs.transforms.utils import _set_missing_tolerance
 
 
 class KLRewardTransform(Transform):
@@ -153,6 +154,13 @@ class KLRewardTransform(Transform):
         if not isinstance(coef, torch.Tensor):
             coef = torch.tensor(coef)
         self.register_buffer("coef", coef)
+
+    def _reset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        with _set_missing_tolerance(self, True):
+            tensordict_reset = self._call(tensordict_reset)
+        return tensordict_reset
 
     def _call(self, tensordict: TensorDictBase) -> TensorDictBase:
         # run the actor on the tensordict

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -565,7 +565,7 @@ class TransformedEnv(EnvBase, metaclass=_TEnvPostInit):
         cache_specs: bool = True,
         **kwargs,
     ):
-        self._transform=None
+        self._transform = None
         device = kwargs.pop("device", None)
         if device is not None:
             env = env.to(device)
@@ -626,7 +626,7 @@ class TransformedEnv(EnvBase, metaclass=_TEnvPostInit):
 
     @property
     def transform(self) -> Transform:
-        return getattr(self, '_transform', None)
+        return getattr(self, "_transform", None)
 
     @transform.setter
     def transform(self, transform: Transform):
@@ -635,12 +635,14 @@ class TransformedEnv(EnvBase, metaclass=_TEnvPostInit):
                 f"""Expected a transform of type torchrl.envs.transforms.Transform,
 but got an object of type {type(transform)}."""
             )
-        prev_transform = getattr(self, '_transform', None)
+        prev_transform = getattr(self, "_transform", None)
         if prev_transform is not None:
             prev_transform.empty_cache()
             prev_transform.reset_parent()
         if not isinstance(transform, Transform):
-            raise ValueError(f"Transforms passed to {type(self)} must be instances of a `torch.envs.Transform` subclass. Got {type(transform)}.")
+            raise ValueError(
+                f"Transforms passed to {type(self)} must be instances of a `torch.envs.Transform` subclass. Got {type(transform)}."
+            )
         transform = transform.to(self.device)
         transform.set_container(self)
         transform.eval()

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -77,14 +77,14 @@ def _apply_to_composite(function):
     @wraps(function)
     def new_fun(self, observation_spec):
         if isinstance(observation_spec, CompositeSpec):
-            d = observation_spec._specs
+            _specs = observation_spec._specs
             in_keys = self.in_keys
             out_keys = self.out_keys
             for in_key, out_key in zip(in_keys, out_keys):
                 if in_key in observation_spec.keys(True, True):
-                    d[out_key] = function(self, observation_spec[in_key].clone())
+                    _specs[out_key] = function(self, observation_spec[in_key].clone())
             return CompositeSpec(
-                d, shape=observation_spec.shape, device=observation_spec.device
+                _specs, shape=observation_spec.shape, device=observation_spec.device
             )
         else:
             return function(self, observation_spec)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -4733,19 +4733,29 @@ class RewardSum(Transform):
             # We take the filtered reset keys, which are the only keys that really
             # matter when calling reset, and check that they match the in_keys root.
             reset_keys = parent._filtered_reset_keys
+
             def _check_match(reset_keys, in_keys):
                 # if this is called, the length of reset_keys and in_keys must match
                 for reset_key, in_key in zip(reset_keys, in_keys):
                     if isinstance(reset_key, str) ^ isinstance(in_key, str):
                         return False
-                    if isinstance(reset_key, tuple) and isinstance(in_key, tuple) and reset_key[:-1] != in_key[:-1]:
+                    if (
+                        isinstance(reset_key, tuple)
+                        and isinstance(in_key, tuple)
+                        and reset_key[:-1] != in_key[:-1]
+                    ):
                         return False
                 return True
-            if len(reset_keys) != len(self.in_keys) or not _check_match(reset_keys, self.in_keys):
-                raise ValueError(f"Could not match the env reset_keys with the {type(self)} in_keys. "
-                                 f"Please provide the reset_keys manually. Reset entries can be "
-                                 f"non-unique and must be right-expandable to the shape of "
-                                 f"the input entries.")
+
+            if len(reset_keys) != len(self.in_keys) or not _check_match(
+                reset_keys, self.in_keys
+            ):
+                raise ValueError(
+                    f"Could not match the env reset_keys with the {type(self)} in_keys. "
+                    f"Please provide the reset_keys manually. Reset entries can be "
+                    f"non-unique and must be right-expandable to the shape of "
+                    f"the input entries."
+                )
             reset_keys = copy(reset_keys)
             self._reset_keys = reset_keys
         return reset_keys

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -4737,12 +4737,14 @@ class RewardSum(Transform):
             def _check_match(reset_keys, in_keys):
                 # if this is called, the length of reset_keys and in_keys must match
                 for reset_key, in_key in zip(reset_keys, in_keys):
-                    if isinstance(reset_key, str) ^ isinstance(in_key, str):
+                    # having _reset at the root and the reward_key ("agent", "reward") is allowed
+                    # but having ("agent", "_reset") and "reward" isn't
+                    if isinstance(reset_key, tuple) and isinstance(in_key, str):
                         return False
                     if (
                         isinstance(reset_key, tuple)
                         and isinstance(in_key, tuple)
-                        and reset_key[:-1] != in_key[:-1]
+                        and in_key[:(len(reset_key)-1)] != reset_key[:-1]
                     ):
                         return False
                 return True

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -29,7 +29,6 @@ from torchrl.data.tensor_specs import (
     BoundedTensorSpec,
     CompositeSpec,
     ContinuousBox,
-    DEVICE_TYPING,
     DiscreteTensorSpec,
     MultiDiscreteTensorSpec,
     MultiOneHotDiscreteTensorSpec,
@@ -642,7 +641,7 @@ but got an object of type {type(transform)}."""
             prev_transform.__dict__["_container"] = None
         transform.set_container(self)
         transform.eval()
-        self._transform = transform
+        self._transform = transform.to(self.device)
 
     @property
     def device(self) -> bool:
@@ -951,8 +950,9 @@ class Compose(Transform):
     def to(self, *args, **kwargs):
         # because Module.to(...) does not call to(...) on sub-modules, we have
         # manually call it:
-        for t in self.transforms:
-            t.to(*args, **kwargs)
+        self.transforms = nn.ModuleList(
+            [t.to(*args, **kwargs) for t in self.transforms]
+        )
         return super().to(*args, **kwargs)
 
     def _call(self, tensordict: TensorDictBase) -> TensorDictBase:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -4751,7 +4751,7 @@ class RewardSum(Transform):
                 reset_keys, self.in_keys
             ):
                 raise ValueError(
-                    f"Could not match the env reset_keys with the {type(self)} in_keys. "
+                    f"Could not match the env reset_keys {reset_keys} with the {type(self)} in_keys {self.in_keys}. "
                     f"Please provide the reset_keys manually. Reset entries can be "
                     f"non-unique and must be right-expandable to the shape of "
                     f"the input entries."

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -688,8 +688,8 @@ but got an object of type {type(transform)}."""
         if not self.cache_specs or self.__dict__.get("_output_spec", None) is None:
             output_spec = self.base_env.output_spec.clone()
 
-            # remove cached key values
-            self.empty_cache()
+            # remove cached key values, but not _input_spec
+            super().empty_cache()
 
             output_spec = output_spec.unlock_()
             output_spec = self.transform.transform_output_spec(output_spec)
@@ -706,8 +706,8 @@ but got an object of type {type(transform)}."""
         if self.__dict__.get("_input_spec", None) is None or not self.cache_specs:
             input_spec = self.base_env.input_spec.clone()
 
-            # remove cached key values
-            self.empty_cache()
+            # remove cached key values but not _output_spec
+            super().empty_cache()
 
             input_spec.unlock_()
             input_spec = self.transform.transform_input_spec(input_spec)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -5757,7 +5757,7 @@ class InitTracker(Transform):
             if isinstance(done_key, str):
                 init_key = self.init_key
             else:
-                init_key = unravel_key((*done_key[:-1], self.init_key))
+                init_key = unravel_key((done_key[:-1], self.init_key))
             init_keys.append(init_key)
         self._init_keys = init_keys
         return self._init_keys
@@ -5802,7 +5802,12 @@ class InitTracker(Transform):
                     ),
                 )
             else:
-                tensordict_reset.set(init_key, _reset.clone())
+                init_val = _reset.clone()
+                parent_td = tensordict_reset if isinstance(init_key, str) else tensordict_reset.get(init_key[:-1])
+                if init_val.ndim == parent_td.ndim:
+                    # unsqueeze, to match the done shape
+                    init_val = init_val.unsqueeze(-1)
+                tensordict_reset.set(init_key, init_val)
         return tensordict_reset
 
     def transform_observation_spec(self, observation_spec: TensorSpec) -> TensorSpec:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -4744,7 +4744,7 @@ class RewardSum(Transform):
                     if (
                         isinstance(reset_key, tuple)
                         and isinstance(in_key, tuple)
-                        and in_key[:(len(reset_key)-1)] != reset_key[:-1]
+                        and in_key[: (len(reset_key) - 1)] != reset_key[:-1]
                     ):
                         return False
                 return True

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -4133,6 +4133,7 @@ class TensorDictPrimer(Transform):
     def to(self, dtype_or_device):
         if not isinstance(dtype_or_device, torch.dtype):
             self.device = dtype_or_device
+            self.empty_cache()
         return super().to(dtype_or_device)
 
     def transform_observation_spec(
@@ -4264,6 +4265,7 @@ class gSDENoise(TensorDictPrimer):
         state_dim=None,
         action_dim=None,
         shape=None,
+        **kwargs,
     ) -> None:
         self.state_dim = state_dim
         self.action_dim = action_dim
@@ -4275,7 +4277,7 @@ class gSDENoise(TensorDictPrimer):
         random = state_dim is not None and action_dim is not None
         shape = tuple(shape) + tail_dim
         primers = {"_eps_gSDE": UnboundedContinuousTensorSpec(shape=shape)}
-        super().__init__(primers=primers, random=random)
+        super().__init__(primers=primers, random=random, **kwargs)
 
 
 class VecNorm(Transform):

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -5032,7 +5032,6 @@ class StepCounter(Transform):
             self.done_keys,
             self.done_keys_groups,
         ):
-            step_count = tensordict.get(step_count_key, default=None)
             reset = tensordict.get(reset_key, default=None)
             if reset is None:
                 # get done status, just to inform the reset shape, dtype and device
@@ -5045,6 +5044,8 @@ class StepCounter(Transform):
                     # we fall back on the spec
                     done = self.parent.output_spec["full_done_spec", entry_name].zero()
                 reset = torch.ones_like(done)
+
+            step_count = tensordict.get(step_count_key, default=None)
             if step_count is None:
                 step_count = self.container.observation_spec[step_count_key].zero()
 

--- a/torchrl/envs/transforms/utils.py
+++ b/torchrl/envs/transforms/utils.py
@@ -20,3 +20,42 @@ def _init_first(fun):
         return fun(self, *args, **kwargs)
 
     return new_fun
+
+
+class _set_missing_tolerance:
+    """Context manager to change the transform tolerance to missing values."""
+
+    def __init__(self, transform, mode):
+        self.transform = transform
+        self.mode = mode
+
+    def __enter__(self):
+        self.exit_mode = self.transform.missing_tolerance
+        if self.mode != self.exit_mode:
+            self.transform.set_missing_tolerance(self.mode)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.mode != self.exit_mode:
+            self.transform.set_missing_tolerance(self.exit_mode)
+
+
+def _get_reset(reset_key, tensordict):
+    _reset = tensordict.get(reset_key, None)
+    # reset key must be unraveled already
+    parent_td = (
+        tensordict.get(reset_key[:-1], None)
+        if isinstance(reset_key, tuple)
+        else tensordict
+    )
+    if parent_td is None:
+        # we do this just in case the nested td wasn't found
+        parent_td = tensordict
+    if _reset is None:
+        _reset = torch.ones(
+            (),
+            dtype=torch.bool,
+            device=parent_td.device,
+        ).expand(parent_td.batch_size)
+    if _reset.ndim > parent_td.ndim:
+        _reset = _reset.flatten(parent_td.ndim, -1).any(-1)
+    return _reset

--- a/torchrl/envs/transforms/vc1.py
+++ b/torchrl/envs/transforms/vc1.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import importlib
 import os
 import subprocess
@@ -5,6 +10,7 @@ from functools import partial
 from typing import Union
 
 import torch
+from tensordict import TensorDictBase
 from torch import nn
 
 from torchrl.data.tensor_specs import (
@@ -21,6 +27,7 @@ from torchrl.envs.transforms.transforms import (
     ToTensorImage,
     Transform,
 )
+from torchrl.envs.transforms.utils import _set_missing_tolerance
 
 _has_vc = importlib.util.find_spec("vc_models") is not None
 
@@ -169,6 +176,14 @@ class VC1Transform(Transform):
         return tensordict
 
     forward = _call
+
+    def _reset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        # TODO: Check this makes sense
+        with _set_missing_tolerance(self, True):
+            tensordict_reset = self._call(tensordict_reset)
+        return tensordict_reset
 
     @torch.no_grad()
     def _apply_transform(self, obs: torch.Tensor) -> None:

--- a/torchrl/envs/transforms/vip.py
+++ b/torchrl/envs/transforms/vip.py
@@ -26,6 +26,7 @@ from torchrl.envs.transforms.transforms import (
     Transform,
     UnsqueezeTransform,
 )
+from torchrl.envs.transforms.utils import _set_missing_tolerance
 
 try:
     from torchvision import models
@@ -80,6 +81,14 @@ class _VIPNet(Transform):
         return tensordict
 
     forward = _call
+
+    def _reset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        # TODO: Check this makes sense
+        with _set_missing_tolerance(self, True):
+            tensordict_reset = self._call(tensordict_reset)
+        return tensordict_reset
 
     @torch.no_grad()
     def _apply_transform(self, obs: torch.Tensor) -> None:

--- a/torchrl/envs/transforms/vip.py
+++ b/torchrl/envs/transforms/vip.py
@@ -349,7 +349,9 @@ class VIPRewardTransform(VIPTransform):
     This class will update the reward computation
     """
 
-    def _reset(self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase) -> TensorDictBase:
+    def _reset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
         if "goal_embedding" not in tensordict.keys():
             tensordict = self._embed_goal(tensordict)
         return super()._reset(tensordict, tensordict_reset)

--- a/torchrl/envs/transforms/vip.py
+++ b/torchrl/envs/transforms/vip.py
@@ -363,6 +363,7 @@ class VIPRewardTransform(VIPTransform):
     ) -> TensorDictBase:
         if "goal_embedding" not in tensordict.keys():
             tensordict = self._embed_goal(tensordict)
+        tensordict_reset.set("goal_embedding", tensordict.pop("goal_embedding"))
         return super()._reset(tensordict, tensordict_reset)
 
     def _embed_goal(self, tensordict):

--- a/torchrl/envs/transforms/vip.py
+++ b/torchrl/envs/transforms/vip.py
@@ -349,10 +349,10 @@ class VIPRewardTransform(VIPTransform):
     This class will update the reward computation
     """
 
-    def reset(self, tensordict: TensorDictBase) -> TensorDictBase:
+    def _reset(self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase) -> TensorDictBase:
         if "goal_embedding" not in tensordict.keys():
             tensordict = self._embed_goal(tensordict)
-        return super().reset(tensordict)
+        return super()._reset(tensordict, tensordict_reset)
 
     def _embed_goal(self, tensordict):
         if "goal_image" not in tensordict.keys():

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -847,6 +847,7 @@ def _terminated_or_truncated(
         data.exclude(*list_of_keys, inplace=True)
     return any_eot
 
+
 def terminated_or_truncated(
     data: TensorDictBase,
     full_done_spec: TensorSpec | None = None,
@@ -1057,7 +1058,7 @@ def _update_during_reset(
 
             # empty tensordicts won't be returned
             if reset.ndim > node.ndim:
-                reset = reset.flatten(node.ndim, reset.ndim-1)
+                reset = reset.flatten(node.ndim, reset.ndim - 1)
                 reset = reset.any(-1)
             reset = reset.reshape(node.shape)
             # node.update(node.where(~reset, other=node_reset, pad=0))

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -1041,6 +1041,8 @@ def _update_during_reset(
             node = tensordict
         # get the reset signal
         reset = tensordict.pop(reset_key, None)
+        if reset_key in tensordict_reset.keys(True):
+            raise ValueError((reset_key, tensordict_reset))
         if reset is None or reset.all():
             # perform simple update, at a single level.
             # by contract, a reset signal at one level cannot
@@ -1054,6 +1056,9 @@ def _update_during_reset(
             # case we just return the data
 
             # empty tensordicts won't be returned
+            if reset.ndim > node.ndim:
+                reset = reset.flatten(node.ndim, reset.ndim-1)
+                reset = reset.any(-1)
             reset = reset.reshape(node.shape)
             # node.update(node.where(~reset, other=node_reset, pad=0))
             node.where(~reset, other=node_reset, out=node, pad=0)

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -836,6 +836,10 @@ def _terminated_or_truncated(
                     aggregate = aggregate | sop
         if aggregate is not None:
             if key is not None:
+                if aggregate.ndim > data.ndim:
+                    # accounts for trailing singleton dim in done.
+                    # _reset is always expanded on the right if needed so this can only be useful
+                    aggregate = aggregate.squeeze(-1)
                 data.set(key, aggregate)
                 list_of_keys.append(curr_done_key + (key,))
             any_eot = any_eot | aggregate.any()

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -910,7 +910,6 @@ def _update_during_reset(
     reset_keys: List[NestedKey],
 ):
     """Updates the input tensordict with the reset data, based on the reset keys."""
-
     for reset_key in reset_keys:
         # get the node of the reset key
         if isinstance(reset_key, tuple):

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -732,7 +732,7 @@ def check_marl_grouping(group_map: Dict[str, List[str]], agent_names: List[str])
 def _terminated_or_truncated(
     data: TensorDictBase,
     full_done_spec: TensorSpec | None = None,
-    key: str = "_reset",
+    key: str | None = "_reset",
     write_full_false: bool = False,
 ) -> bool:
     """Reads the done / terminated / truncated keys within a tensordict, and writes a new tensor where the values of both signals are aggregated.
@@ -826,14 +826,14 @@ def _terminated_or_truncated(
                         curr_done_key=curr_done_key + (eot_key,),
                     )
                 else:
-                    sop = data.get(eot_key, None)
-                    if sop is None:
-                        sop = torch.zeros(
+                    stop = data.get(eot_key, None)
+                    if stop is None:
+                        stop = torch.zeros(
                             (*data.shape, 1), dtype=torch.bool, device=data.device
                         )
                     if aggregate is None:
-                        aggregate = torch.tensor(False, device=sop.device)
-                    aggregate = aggregate | sop
+                        aggregate = False
+                    aggregate = aggregate | stop
         if aggregate is not None:
             if key is not None:
                 if aggregate.ndim > data.ndim:

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -909,6 +909,8 @@ def _update_during_reset(
     tensordict: TensorDictBase,
     reset_keys: List[NestedKey],
 ):
+    """Updates the input tensordict with the reset data, based on the reset keys."""
+
     for reset_key in reset_keys:
         # get the node of the reset key
         if isinstance(reset_key, tuple):

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -1758,8 +1758,10 @@ class DecisionTransformerInferenceWrapper(TensorDictModuleWrapper):
         self.action_key = action_key
         self.return_to_go_key = return_to_go_key
         if out_action_key not in self.td_module.out_keys:
-            raise ValueError(f"The value of out_action_key ({out_action_key}) must be "
-                             f"within the actor output keys ({self.td_module.out_keys}).")
+            raise ValueError(
+                f"The value of out_action_key ({out_action_key}) must be "
+                f"within the actor output keys ({self.td_module.out_keys})."
+            )
         self.out_action_key = out_action_key
 
     def step(self, frames: int = 1) -> None:

--- a/torchrl/objectives/decision_transformer.py
+++ b/torchrl/objectives/decision_transformer.py
@@ -204,7 +204,9 @@ class OnlineDTLoss(LossModule):
         """Compute the loss for the Online Decision Transformer."""
         # extract action targets
         tensordict = tensordict.clone(False)
-        target_actions = tensordict.get(self.tensor_keys.action_target).detach()
+        target_actions = tensordict.get(self.tensor_keys.action_target)
+        if target_actions.requires_grad:
+            raise RuntimeError("target action cannot be part of a graph.")
 
         action_dist = self.actor_network.get_dist(
             tensordict, params=self.actor_network_params

--- a/torchrl/objectives/decision_transformer.py
+++ b/torchrl/objectives/decision_transformer.py
@@ -53,12 +53,18 @@ class OnlineDTLoss(LossModule):
         default values.
 
         Attributes:
-            action (NestedKey): The input tensordict key where the action is expected.
+            action_target (NestedKey): The input tensordict key where the action is expected.
+                Defaults to ``"action"``.
+            action_pred (NestedKey): The tensordict key where the output action (from the model) is expected.
+                Used to compute the target entropy.
                 Defaults to ``"action"``.
 
         """
 
-        action: NestedKey = "action"
+        # the "action" contained in the dataset
+        action_target: NestedKey = "action"
+        # the "action" output from the model
+        action_pred: NestedKey = "action"
 
     default_keys = _AcceptedKeys()
 
@@ -125,17 +131,14 @@ class OnlineDTLoss(LossModule):
                     "the target entropy explicitely or provide the spec of the "
                     "action tensor in the actor network."
                 )
-            if (
-                isinstance(self.tensor_keys.action, tuple)
-                and len(self.tensor_keys.action) > 1
-            ):
+            if isinstance(self.tensor_keys.action_pred, tuple):
                 action_container_shape = actor_network.spec[
-                    self.tensor_keys.action[:-1]
+                    self.tensor_keys.action_pred[:-1]
                 ].shape
             else:
                 action_container_shape = actor_network.spec.shape
             target_entropy = -float(
-                actor_network.spec[self.tensor_keys.action]
+                actor_network.spec[self.tensor_keys.action_pred]
                 .shape[len(action_container_shape) :]
                 .numel()
             )
@@ -149,7 +152,7 @@ class OnlineDTLoss(LossModule):
     def _set_in_keys(self):
         keys = self.actor_network.in_keys
         keys = set(keys)
-        keys.add(self.tensor_keys.action)
+        keys.add(self.tensor_keys.action_target)
         self._in_keys = sorted(keys, key=str)
 
     def _forward_value_estimator_keys(self, **kwargs):
@@ -200,7 +203,8 @@ class OnlineDTLoss(LossModule):
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         """Compute the loss for the Online Decision Transformer."""
         # extract action targets
-        target_actions = tensordict.get(self.tensor_keys.action).detach()
+        tensordict = tensordict.clone(False)
+        target_actions = tensordict.get(self.tensor_keys.action_target).detach()
 
         action_dist = self.actor_network.get_dist(
             tensordict, params=self.actor_network_params
@@ -243,11 +247,16 @@ class DTLoss(LossModule):
         default values.
 
         Attributes:
-            action (NestedKey): The input tensordict key where the action is expected.
+            action_target (NestedKey): The input tensordict key where the action is expected.
+                Defaults to ``"action"``.
+            action_pred (NestedKey): The tensordict key where the output action (from the model) is expected.
                 Defaults to ``"action"``.
         """
 
-        action: NestedKey = "action"
+        # the "action" contained in the dataset
+        action_target: NestedKey = "action"
+        # the "action" output from the model
+        action_pred: NestedKey = "action"
 
     default_keys = _AcceptedKeys()
 
@@ -273,7 +282,8 @@ class DTLoss(LossModule):
     def _set_in_keys(self):
         keys = self.actor_network.in_keys
         keys = set(keys)
-        keys.add(self.tensor_keys.action)
+        keys.add(self.tensor_keys.action_pred)
+        keys.add(self.tensor_keys.action_target)
         self._in_keys = sorted(keys, key=str)
 
     def _forward_value_estimator_keys(self, **kwargs) -> None:
@@ -304,11 +314,12 @@ class DTLoss(LossModule):
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         """Compute the loss for the Online Decision Transformer."""
         # extract action targets
-        target_actions = tensordict.get(self.tensor_keys.action).detach()
+        tensordict = tensordict.clone(False)
+        target_actions = tensordict.get(self.tensor_keys.action_target).detach()
 
         pred_actions = self.actor_network(
             tensordict, params=self.actor_network_params
-        ).get(self.tensor_keys.action)
+        ).get(self.tensor_keys.action_pred)
         loss = distance_loss(
             pred_actions,
             target_actions,

--- a/torchrl/record/recorder.py
+++ b/torchrl/record/recorder.py
@@ -136,6 +136,12 @@ class VideoRecorder(ObservationTransform):
         self.count = 0
         self.obs = []
 
+    def _reset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        self._call(tensordict_reset)
+        return tensordict_reset
+
 
 class TensorDictRecorder(Transform):
     """TensorDict recorder.
@@ -171,14 +177,14 @@ class TensorDictRecorder(Transform):
         self.skip = skip
         self.count = 0
 
-    def _call(self, td: TensorDictBase) -> TensorDictBase:
+    def _call(self, tensordict: TensorDictBase) -> TensorDictBase:
         self.count += 1
         if self.count % self.skip == 0:
-            _td = td
+            _td = tensordict
             if self.in_keys:
-                _td = td.select(*self.in_keys).to_tensordict()
+                _td = tensordict.select(*self.in_keys).to_tensordict()
             self.td.append(_td)
-        return td
+        return tensordict
 
     def dump(self, suffix: Optional[str] = None) -> None:
         if suffix is None:
@@ -197,3 +203,9 @@ class TensorDictRecorder(Transform):
         self.count = 0
         del self.td
         self.td = []
+
+    def _reset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        self._call(tensordict_reset)
+        return tensordict_reset

--- a/torchrl/trainers/helpers/trainers.py
+++ b/torchrl/trainers/helpers/trainers.py
@@ -258,6 +258,7 @@ def make_trainer(
     )
 
     if recorder is not None:
+        # create recorder object
         recorder_obj = Recorder(
             record_frames=cfg.record_frames,
             frame_skip=cfg.frame_skip,
@@ -266,11 +267,14 @@ def make_trainer(
             record_interval=cfg.record_interval,
             log_keys=cfg.recorder_log_keys,
         )
+        # register recorder
         trainer.register_op(
             "post_steps_log",
             recorder_obj,
         )
+        # call recorder - could be removed
         recorder_obj(None)
+        # create explorative recorder - could be optional
         recorder_obj_explore = Recorder(
             record_frames=cfg.record_frames,
             frame_skip=cfg.frame_skip,
@@ -281,10 +285,12 @@ def make_trainer(
             suffix="exploration",
             out_keys={("next", "reward"): "r_evaluation_exploration"},
         )
+        # register recorder
         trainer.register_op(
             "post_steps_log",
             recorder_obj_explore,
         )
+        # call recorder - could be removed
         recorder_obj_explore(None)
 
     trainer.register_op(


### PR DESCRIPTION
## Contribution

This PR proposes the `step_and_maybe_reset` in EnvBase. 
This method executes a step followed by a reset, if necessary.

We also make `reset` more robust by ensuring that partial resets are handled uniformly. This is necessary since `step_and_maybe_reset` must take care of this functionality, and from our perspective handling partial resets is the responsibility of `reset` (the user should not have to worry about data not updated properly).

This has repercussions on the logic behind `TransformedEnv._reset` and `BatchedEnv._reset`.

I'm now considering having batched envs calling `reset` and not `_reset` to make sure that the data is well presented, since now the update of the input tensordict with the `tensordict_reset` occurs after `_reset` (hence, the output of `_reset` in SerialEnv is incomplete).
This could introduce some overhead but that's of limited impact since now `step_and_maybe_reset` is there to handle things faster.