### PR TITLE
[Deprecation] Deprecate ambiguous device for memmap replay buffer

### DIFF
--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -586,8 +586,14 @@ class LazyMemmapStorage(LazyTensorStorage):
                 data.clone()
                 .expand(self.max_size, *data.shape)
                 .memmap_like(prefix=self.scratch_dir)
-                .to(self.device)
             )
+            if self.device.type != "cpu":
+                warnings.warn(
+                    "Support for Memmap device other than CPU will be deprecated in v0.4.0.",
+                    category=DeprecationWarning,
+                )
+                out = out.to(self.device).memmap_()
+
             for key, tensor in sorted(
                 out.items(include_nested=True, leaves_only=True), key=str
             ):
@@ -603,8 +609,14 @@ class LazyMemmapStorage(LazyTensorStorage):
                 data.clone()
                 .expand(self.max_size, *data.shape)
                 .memmap_like(prefix=self.scratch_dir)
-                .to(self.device)
             )
+            if self.device.type != "cpu":
+                warnings.warn(
+                    "Support for Memmap device other than CPU will be deprecated in v0.4.0.",
+                    category=DeprecationWarning,
+                )
+                out = out.to(self.device).memmap_()
+
             for key, tensor in sorted(
                 out.items(include_nested=True, leaves_only=True), key=str
             ):

--- a/tutorials/sphinx-tutorials/pretrained_models.py
+++ b/tutorials/sphinx-tutorials/pretrained_models.py
@@ -88,7 +88,7 @@ print("rollout, fine tuning:", rollout)
 #
 from torchrl.data import LazyMemmapStorage, ReplayBuffer
 
-storage = LazyMemmapStorage(1000, device=device)
+storage = LazyMemmapStorage(1000)
 rb = ReplayBuffer(storage=storage, transform=r3m)
 
 ##############################################################################


### PR DESCRIPTION
## Description

We allow memmap storages to sit on a "device", which basically means that when accessed, the data will be sent to that device.
This is confusing and suboptimal, and will break once we have memory mapped tensors that are actually tensors (see https://github.com/pytorch/tensordict/pull/541)