### PR TITLE
[BugFix] Avoid overlapping temporary dirs during training

### DIFF
--- a/examples/cql/utils.py
+++ b/examples/cql/utils.py
@@ -90,7 +90,7 @@ def make_replay_buffer(
     batch_size,
     prb=False,
     buffer_size=1000000,
-    buffer_scratch_dir="/tmp/",
+    buffer_scratch_dir=None,
     device="cpu",
     prefetch=3,
 ):

--- a/examples/ddpg/ddpg.py
+++ b/examples/ddpg/ddpg.py
@@ -69,7 +69,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
         batch_size=cfg.optim.batch_size,
         prb=cfg.replay_buffer.prb,
         buffer_size=cfg.replay_buffer.size,
-        buffer_scratch_dir="/tmp/" + cfg.replay_buffer.scratch_dir,
+        buffer_scratch_dir=cfg.replay_buffer.scratch_dir,
         device=device,
     )
 

--- a/examples/ddpg/utils.py
+++ b/examples/ddpg/utils.py
@@ -107,7 +107,7 @@ def make_replay_buffer(
     batch_size,
     prb=False,
     buffer_size=1000000,
-    buffer_scratch_dir="/tmp/",
+    buffer_scratch_dir=None,
     device="cpu",
     prefetch=3,
 ):

--- a/examples/decision_transformer/dt_config.yaml
+++ b/examples/decision_transformer/dt_config.yaml
@@ -33,7 +33,7 @@ replay_buffer:
   stacked_frames: 20
   buffer_prefetch: 64
   capacity: 1_000_000
-  buffer_scratch_dir: "/tmp/"
+  buffer_scratch_dir:
   device: cpu
   prefetch: 3
 

--- a/examples/decision_transformer/odt_config.yaml
+++ b/examples/decision_transformer/odt_config.yaml
@@ -33,7 +33,7 @@ replay_buffer:
   stacked_frames: 20
   buffer_prefetch: 64
   capacity: 1_000_000
-  buffer_scratch_dir: "/tmp/"
+  buffer_scratch_dir:
   device: cuda:0
   prefetch: 3
 

--- a/examples/decision_transformer/utils.py
+++ b/examples/decision_transformer/utils.py
@@ -264,7 +264,9 @@ def make_online_replay_buffer(offline_buffer, rb_cfg, reward_scaling=0.001):
         catframes,  # TODO: cat frames is not an inverse transform doesnt get triggered!
     )
     storage = LazyMemmapStorage(
-        rb_cfg.capacity, rb_cfg.buffer_scratch_dir, device=rb_cfg.device
+        max_size=rb_cfg.capacity,
+        scratch_dir=rb_cfg.buffer_scratch_dir,
+        device=rb_cfg.device,
     )
 
     replay_buffer = TensorDictReplayBuffer(

--- a/examples/discrete_sac/discrete_sac.py
+++ b/examples/discrete_sac/discrete_sac.py
@@ -43,7 +43,7 @@ def make_replay_buffer(
     prb=False,
     buffer_size=1000000,
     batch_size=256,
-    buffer_scratch_dir="/tmp/",
+    buffer_scratch_dir=None,
     device="cpu",
     prefetch=3,
 ):

--- a/examples/iql/iql_online.py
+++ b/examples/iql/iql_online.py
@@ -39,7 +39,7 @@ def make_replay_buffer(
     batch_size,
     prb=False,
     buffer_size=1000000,
-    buffer_scratch_dir="/tmp/",
+    buffer_scratch_dir=None,
     device="cpu",
     prefetch=3,
 ):

--- a/examples/sac/sac.py
+++ b/examples/sac/sac.py
@@ -69,7 +69,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
         batch_size=cfg.optim.batch_size,
         prb=cfg.replay_buffer.prb,
         buffer_size=cfg.replay_buffer.size,
-        buffer_scratch_dir="/tmp/" + cfg.replay_buffer.scratch_dir,
+        buffer_scratch_dir=cfg.replay_buffer.scratch_dir,
         device=device,
     )
 

--- a/examples/sac/utils.py
+++ b/examples/sac/utils.py
@@ -89,7 +89,7 @@ def make_replay_buffer(
     batch_size,
     prb=False,
     buffer_size=1000000,
-    buffer_scratch_dir="/tmp/",
+    buffer_scratch_dir=None,
     device="cpu",
     prefetch=3,
 ):

--- a/examples/td3/td3.py
+++ b/examples/td3/td3.py
@@ -69,7 +69,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
         batch_size=cfg.optim.batch_size,
         prb=cfg.replay_buffer.prb,
         buffer_size=cfg.replay_buffer.size,
-        buffer_scratch_dir="/tmp/" + cfg.replay_buffer.scratch_dir,
+        buffer_scratch_dir=cfg.replay_buffer.scratch_dir,
         device=device,
     )
 


### PR DESCRIPTION
## Description

Passing the same scratch directory to a replay buffer during multiple runs will write data at the exact same location, which will make the run interfere and eventually fail.