### PR TITLE
[Refactor] Put all buffers on CPU in examples

### DIFF
--- a/examples/cql/cql_online.py
+++ b/examples/cql/cql_online.py
@@ -51,7 +51,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
         batch_size=cfg.optim.batch_size,
         prb=cfg.replay_buffer.prb,
         buffer_size=cfg.replay_buffer.size,
-        device=device,
+        device="cpu",
     )
 
     # Make Model
@@ -104,7 +104,13 @@ def main(cfg: "DictConfig"):  # noqa: F821
             (actor_losses, q_losses, alpha_losses, alpha_primes) = ([], [], [], [])
             for _ in range(num_updates):
                 # sample from replay buffer
-                sampled_tensordict = replay_buffer.sample().clone()
+                sampled_tensordict = replay_buffer.sample()
+                if sampled_tensordict.device != device:
+                    sampled_tensordict = sampled_tensordict.to(
+                        device, non_blocking=True
+                    )
+                else:
+                    sampled_tensordict = sampled_tensordict.clone()
 
                 loss_td = loss_module(sampled_tensordict)
 

--- a/examples/ddpg/ddpg.py
+++ b/examples/ddpg/ddpg.py
@@ -70,7 +70,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
         prb=cfg.replay_buffer.prb,
         buffer_size=cfg.replay_buffer.size,
         buffer_scratch_dir="/tmp/" + cfg.replay_buffer.scratch_dir,
-        device=device,
+        device="cpu",
     )
 
     # Create optimizers
@@ -118,7 +118,13 @@ def main(cfg: "DictConfig"):  # noqa: F821
             ) = ([], [])
             for _ in range(num_updates):
                 # Sample from replay buffer
-                sampled_tensordict = replay_buffer.sample().clone()
+                sampled_tensordict = replay_buffer.sample()
+                if sampled_tensordict.device != device:
+                    sampled_tensordict = sampled_tensordict.to(
+                        device, non_blocking=True
+                    )
+                else:
+                    sampled_tensordict = sampled_tensordict.clone()
 
                 # Update critic
                 q_loss, *_ = loss_module.loss_value(sampled_tensordict)

--- a/examples/discrete_sac/discrete_sac.py
+++ b/examples/discrete_sac/discrete_sac.py
@@ -201,7 +201,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
         prb=cfg.prb,
         buffer_size=cfg.buffer_size,
         batch_size=cfg.batch_size,
-        device=device,
+        device="cpu",
     )
 
     # Optimizers
@@ -255,7 +255,13 @@ def main(cfg: "DictConfig"):  # noqa: F821
             ) = ([], [], [], [], [], [])
             for _ in range(cfg.frames_per_batch * int(cfg.utd_ratio)):
                 # sample from replay buffer
-                sampled_tensordict = replay_buffer.sample().clone()
+                sampled_tensordict = replay_buffer.sample()
+                if sampled_tensordict.device != device:
+                    sampled_tensordict = sampled_tensordict.to(
+                        device, non_blocking=True
+                    )
+                else:
+                    sampled_tensordict = sampled_tensordict.clone()
 
                 loss_td = loss_module(sampled_tensordict)
 

--- a/examples/dqn/dqn.py
+++ b/examples/dqn/dqn.py
@@ -115,7 +115,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
         cfg=cfg,
     )
 
-    replay_buffer = make_replay_buffer(device, cfg)
+    replay_buffer = make_replay_buffer("cpu", cfg)
 
     recorder = transformed_env_constructor(
         cfg,

--- a/examples/dreamer/dreamer.py
+++ b/examples/dreamer/dreamer.py
@@ -186,7 +186,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
     )
     print("collector:", collector)
 
-    replay_buffer = make_replay_buffer(device, cfg)
+    replay_buffer = make_replay_buffer("cpu", cfg)
 
     record = Recorder(
         record_frames=cfg.record_frames,

--- a/examples/iql/iql_online.py
+++ b/examples/iql/iql_online.py
@@ -218,7 +218,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
 
     # Make Replay Buffer
     replay_buffer = make_replay_buffer(
-        buffer_size=cfg.buffer_size, device=device, batch_size=cfg.batch_size
+        buffer_size=cfg.buffer_size, device="cpu", batch_size=cfg.batch_size
     )
 
     # Optimizers

--- a/examples/redq/redq.py
+++ b/examples/redq/redq.py
@@ -161,7 +161,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
         # ],
     )
 
-    replay_buffer = make_replay_buffer(device, cfg)
+    replay_buffer = make_replay_buffer("cpu", cfg)
 
     recorder = transformed_env_constructor(
         cfg,

--- a/examples/sac/sac.py
+++ b/examples/sac/sac.py
@@ -70,7 +70,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
         prb=cfg.replay_buffer.prb,
         buffer_size=cfg.replay_buffer.size,
         buffer_scratch_dir="/tmp/" + cfg.replay_buffer.scratch_dir,
-        device=device,
+        device="cpu",
     )
 
     # Create optimizers
@@ -122,7 +122,13 @@ def main(cfg: "DictConfig"):  # noqa: F821
             )
             for i in range(num_updates):
                 # Sample from replay buffer
-                sampled_tensordict = replay_buffer.sample().clone()
+                sampled_tensordict = replay_buffer.sample()
+                if sampled_tensordict.device != device:
+                    sampled_tensordict = sampled_tensordict.to(
+                        device, non_blocking=True
+                    )
+                else:
+                    sampled_tensordict = sampled_tensordict.clone()
 
                 # Compute loss
                 loss_td = loss_module(sampled_tensordict)

--- a/examples/td3/td3.py
+++ b/examples/td3/td3.py
@@ -70,7 +70,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
         prb=cfg.replay_buffer.prb,
         buffer_size=cfg.replay_buffer.size,
         buffer_scratch_dir=cfg.replay_buffer.scratch_dir,
-        device=device,
+        device="cpu",
     )
 
     # Create optimizers
@@ -124,7 +124,11 @@ def main(cfg: "DictConfig"):  # noqa: F821
                 update_actor = update_counter % delayed_updates == 0
 
                 # Sample from replay buffer
-                sampled_tensordict = replay_buffer.sample().clone()
+                sampled_tensordict = replay_buffer.sample()
+                if sampled_tensordict.device != device:
+                    sampled_tensordict = sampled_tensordict.to(device, non_blocking=True)
+                else:
+                    sampled_tensordict = sampled_tensordict.clone()
 
                 # Compute loss
                 q_loss, *_ = loss_module.value_loss(sampled_tensordict)

--- a/examples/td3/td3.py
+++ b/examples/td3/td3.py
@@ -126,7 +126,9 @@ def main(cfg: "DictConfig"):  # noqa: F821
                 # Sample from replay buffer
                 sampled_tensordict = replay_buffer.sample()
                 if sampled_tensordict.device != device:
-                    sampled_tensordict = sampled_tensordict.to(device, non_blocking=True)
+                    sampled_tensordict = sampled_tensordict.to(
+                        device, non_blocking=True
+                    )
                 else:
                     sampled_tensordict = sampled_tensordict.clone()
 

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -710,7 +710,7 @@ def _collate_contiguous(x):
 
 
 def _collate_as_tensor(x):
-    return x.contiguous()
+    return x.as_tensor()
 
 
 def _get_default_collate(storage, _is_tensordict=False):


### PR DESCRIPTION
## Description

We used to put the MemmapTensors on the training device, but the swap to MemoryMappedTensor will break this.
Instead of calling `tensordict.contiguous()` (which could be made more efficient) we call `as_tensor`. This will raise a warning after we introduce MemoryMappedTensor, and a follow-up PR will need to change that logic.