### PR TITLE
[Feature] Introduce grouping in VMAS

### DIFF
--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -1775,15 +1775,7 @@ class TestVmas:
         assert env.reward_key not in _td.keys(True, True)
         assert env.action_key not in _td["next"].keys(True, True)
 
-    @pytest.mark.parametrize("categorical", [True])
-    def test_multi_discrete(self, categorical):
-        env = VmasEnv(
-            scenario="simple_reference",
-            continuous_actions=False,
-            categorical_actions=categorical,
-            num_envs=2,
-        )
-        env.rollout(2)
+
 
 
 

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -1589,11 +1589,11 @@ class TestVmas:
 
         env = ParallelEnv(n_workers, make_vmas)
         tensordict = env.rollout(max_steps=n_rollout_samples)
-        env.close()
 
         assert tensordict.shape == torch.Size(
             [n_workers, list(env.num_envs)[0], n_rollout_samples]
         )
+        env.close()
 
     @pytest.mark.parametrize("num_envs", [1, 2])
     @pytest.mark.parametrize("n_workers", [1, 3])

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -1480,6 +1480,7 @@ class TestVmas:
             scenario=scenario_name,
             num_envs=num_envs,
             n_agents=n_agents,
+            group_map=MarlGroupMapType.ALL_IN_ONE_GROUP,
         )
         env.set_seed(0)
         tdreset = env.reset()
@@ -1743,6 +1744,7 @@ class TestVmas:
         env = VmasEnv(
             scenario="simple_tag",
             num_envs=n_envs,
+            group_map=MarlGroupMapType.ALL_IN_ONE_GROUP,
         )
         torch.manual_seed(1)
 
@@ -1775,8 +1777,15 @@ class TestVmas:
         assert env.reward_key not in _td.keys(True, True)
         assert env.action_key not in _td["next"].keys(True, True)
 
-
-
+    @pytest.mark.parametrize("categorical", [True])
+    def test_multi_discrete(self, categorical):
+        env = VmasEnv(
+            scenario="simple_reference",
+            continuous_actions=False,
+            categorical_actions=categorical,
+            num_envs=2,
+        )
+        env.rollout(2)
 
 
 @pytest.mark.skipif(not _has_d4rl, reason="D4RL not found")

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -1554,11 +1554,11 @@ class TestVmas:
             num_envs=num_envs,
             n_agents=n_agents,
         )
-        env.close()
         assert str(env) == (
             f"{VmasEnv.__name__}(num_envs={num_envs}, n_agents={env.n_agents},"
             f" batch_size={torch.Size((num_envs,))}, device={env.device}) (scenario={scenario_name})"
         )
+        env.close()
 
     @pytest.mark.parametrize("num_envs", [1, 10])
     @pytest.mark.parametrize("n_workers", [1, 3])
@@ -1665,7 +1665,7 @@ class TestVmas:
             )
             return env
 
-        env = ParallelEnv(2, make_vmas)
+        env = make_vmas()
 
         assert env.rollout(max_steps=3).device == devices[first]
 
@@ -1774,6 +1774,17 @@ class TestVmas:
 
         assert env.reward_key not in _td.keys(True, True)
         assert env.action_key not in _td["next"].keys(True, True)
+
+    @pytest.mark.parametrize("categorical", [True])
+    def test_multi_discrete(self, categorical):
+        env = VmasEnv(
+            scenario="simple_reference",
+            continuous_actions=False,
+            categorical_actions=categorical,
+            num_envs=2,
+        )
+        env.rollout(2)
+
 
 
 @pytest.mark.skipif(not _has_d4rl, reason="D4RL not found")

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -1524,13 +1524,13 @@ class TestVmas:
     def test_vmas_spec_rollout(
         self, scenario_name, num_envs, n_agents, continuous_actions
     ):
-        env = VmasEnv(
+        vmas_env = VmasEnv(
             scenario=scenario_name,
             num_envs=num_envs,
             n_agents=n_agents,
             continuous_actions=continuous_actions,
         )
-        wrapped = VmasWrapper(
+        vmas_wrapped_env = VmasWrapper(
             vmas.make_env(
                 scenario=scenario_name,
                 num_envs=num_envs,
@@ -1538,11 +1538,10 @@ class TestVmas:
                 continuous_actions=continuous_actions,
             )
         )
-        for e in [env, wrapped]:
-            e.set_seed(0)
-            check_env_specs(e, return_contiguous=False if e.het_specs else True)
+        for env in [vmas_env, vmas_wrapped_env]:
+            env.set_seed(0)
+            check_env_specs(env, return_contiguous=False if env.het_specs else True)
             env.close()
-            del e
 
     @pytest.mark.parametrize("num_envs", [1, 20])
     @pytest.mark.parametrize("n_agents", [1, 5])
@@ -1802,7 +1801,7 @@ class TestVmas:
         for group in env.group_map.keys():
             env.reset()
             action = env.full_action_spec.zero()
-            action[group, "action"] += 1.0
+            action.set((group, "action"), action.get((group, "action")) + 1.0)
             prev_pos = {agent.name: agent.state.pos.clone() for agent in env.agents}
             env.step(action)
             pos = {agent.name: agent.state.pos.clone() for agent in env.agents}

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -1777,16 +1777,6 @@ class TestVmas:
         assert env.reward_key not in _td.keys(True, True)
         assert env.action_key not in _td["next"].keys(True, True)
 
-    @pytest.mark.parametrize("categorical", [True])
-    def test_multi_discrete(self, categorical):
-        env = VmasEnv(
-            scenario="simple_reference",
-            continuous_actions=False,
-            categorical_actions=categorical,
-            num_envs=2,
-        )
-        env.rollout(2)
-
 
 @pytest.mark.skipif(not _has_d4rl, reason="D4RL not found")
 class TestD4RL:

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -1647,8 +1647,8 @@ class TestVmas:
         reset = td_reset["_reset"]
         tensordict = env.reset(td_reset)
 
-        assert not tensordict["done"][reset].any().item()
-        assert tensordict["done"][~reset].all().item()
+        assert not tensordict.get("done")[reset].any()
+        assert tensordict.get("done")[~reset].all()
         env.close()
 
     @pytest.mark.skipif(len(get_available_devices()) < 2, reason="not enough devices")
@@ -1798,13 +1798,13 @@ class TestVmas:
             },
         )
 
-        # CHeck that when setting the action for a specific group that is reflected to the right agent in the backend
+        # Check that when setting the action for a specific group, it is reflected to the right agent in the backend
         for group in env.group_map.keys():
             env.reset()
             action = env.full_action_spec.zero()
             action[group, "action"] += 1.0
             prev_pos = {agent.name: agent.state.pos.clone() for agent in env.agents}
-            _ = env.step(action)
+            env.step(action)
             pos = {agent.name: agent.state.pos.clone() for agent in env.agents}
             for agent_name in env.agent_names:
                 if agent_name == group:

--- a/torchrl/envs/libs/vmas.py
+++ b/torchrl/envs/libs/vmas.py
@@ -125,12 +125,23 @@ class VmasWrapper(_EnvWrapper):
         env (``vmas.simulator.environment.environment.Environment``): the vmas environment to wrap.
         categorical_actions (bool, optional): if the environment actions are discrete, whether to transform
             them to categorical or one-hot.
-        group_map (MarlGroupMapType or Dict[str, List[str]]], optional): how to group agents in tensordicts for
+        group_map (MarlGroupMapType or Dict[str, List[str]], optional): how to group agents in tensordicts for
             input/output. By default, if the agent names follow the ``"<name>_<int>"``
             convention, they will be grouped by ``"<name>"``. If they do not follow this convention, they will be all put
             in one group named ``"agents"``.
             Otherwise, a group map can be specified or selected from some premade options.
             See :class:`~torchrl.envs.utils.MarlGroupMapType` for more info.
+
+    Attributes:
+        group_map (Dict[str, List[str]]): how to group agents in tensordicts for
+            input/output. See :class:`~torchrl.envs.utils.MarlGroupMapType` for more info.
+        agent_names (list of str): names of the agent in the environment
+        agent_names_to_indices_map (Dict[str, int]): dictionary mapping agent names to their index in the enviornment
+        unbatched_action_spec (TensorSpec): version of the spec without the vectorized dimension
+        unbatched_observation_spec (TensorSpec): version of the spec without the vectorized dimension
+        unbatched_reward_spec (TensorSpec): version of the spec without the vectorized dimension
+        het_specs (bool): whether the enviornment has any lazy spec
+        het_specs_map (Dict[str, bool]): dictionary mapping each group to a flag representing of the group has lazy specs
 
     Examples:
         >>>  env = VmasWrapper(

--- a/torchrl/envs/libs/vmas.py
+++ b/torchrl/envs/libs/vmas.py
@@ -598,7 +598,7 @@ class VmasWrapper(_EnvWrapper):
         rewards = _selective_unsqueeze(rewards, batch_size=self.batch_size)
         return rewards
 
-    def _read_action(self, action, group: str):
+    def _read_action(self, action, group: str = "agents"):
         if not self.continuous_actions and not self.categorical_actions:
             action = self.unbatched_action_spec[group, "action"].to_categorical(action)
         agent_actions = action.unbind(dim=1)

--- a/torchrl/envs/libs/vmas.py
+++ b/torchrl/envs/libs/vmas.py
@@ -123,14 +123,14 @@ class VmasWrapper(_EnvWrapper):
 
     Args:
         env (``vmas.simulator.environment.environment.Environment``): the vmas environment to wrap.
-        categorical_actions (bool, optional): if the enviornments actions are discrete, whether to transform
-            them to categorical or one-hot.`
+        categorical_actions (bool, optional): if the environment actions are discrete, whether to transform
+            them to categorical or one-hot.
         group_map (MarlGroupMapType or Dict[str, List[str]]], optional): how to group agents in tensordicts for
-            input/output. By default, if agent names follow the "{name}_{int}"
-            convention, they will be grouped by "{name}", if they do not follow this convention, they will be all put
-            in one group named "agents".
+            input/output. By default, if the agent names follow the ``"<name>_<int>"``
+            convention, they will be grouped by ``"<name>"``. If they do not follow this convention, they will be all put
+            in one group named ``"agents"``.
             Otherwise, a group map can be specified or selected from some premade options.
-            See :class:`torchrl.envs.utils.MarlGroupMapType` for more info.
+            See :class:`~torchrl.envs.utils.MarlGroupMapType` for more info.
 
     Examples:
         >>>  env = VmasWrapper(
@@ -252,14 +252,14 @@ class VmasWrapper(_EnvWrapper):
         return env
 
     def _get_default_group_map(self, agent_names: List[str]):
-        # This function performs the default grouping in vmas
-        # Agents with names "str_int" will be grouped in group name "str"
-        # If any of the agents to not follow the naming convention, we fall back
-        # to all agents in one group named "agents"
+        # This function performs the default grouping in vmas.
+        # Agents with names "<name>_<int>" will be grouped in group name "<name>".
+        # If any of the agents does not follow the naming convention, we fall back
+        # back on having all agents in one group named "agents".
         group_map = {}
         follows_convention = True
         for agent_name in agent_names:
-            # See if the agent follows the convention "name_int"
+            # See if the agent follows the convention "<name>_<int>"
             agent_name_split = agent_name.split("_")
             if len(agent_name_split) == 1:
                 follows_convention = False

--- a/torchrl/envs/libs/vmas.py
+++ b/torchrl/envs/libs/vmas.py
@@ -263,10 +263,7 @@ class VmasWrapper(_EnvWrapper):
             agent_name_split = agent_name.split("_")
             if len(agent_name_split) == 1:
                 follows_convention = False
-            try:
-                int(agent_name_split[-1])
-            except ValueError:
-                follows_convention = False
+            follows_convention = follows_convention and agent_name_split[-1].isdigit()
 
             if not follows_convention:
                 break
@@ -324,7 +321,7 @@ class VmasWrapper(_EnvWrapper):
                 group_observation_spec, LazyStackedCompositeSpec
             ) or isinstance(group_action_spec, LazyStackedCompositeSpec)
             self.het_specs_map[group] = group_het_specs
-            self.het_specs += group_het_specs
+            self.het_specs = self.het_specs or group_het_specs
 
         self.unbatched_done_spec = CompositeSpec(
             {

--- a/torchrl/envs/libs/vmas.py
+++ b/torchrl/envs/libs/vmas.py
@@ -293,6 +293,9 @@ class VmasWrapper(_EnvWrapper):
     ) -> None:
         # Create and check group map
         self.agent_names = [agent.name for agent in self.agents]
+        self.agent_names_to_indices_map = {
+            agent.name: i for i, agent in enumerate(self.agents)
+        }
         if self.group_map is None:
             self.group_map = self._get_default_group_map(self.agent_names)
         elif isinstance(self.group_map, MarlGroupMapType):
@@ -354,7 +357,7 @@ class VmasWrapper(_EnvWrapper):
         reward_specs = []
         info_specs = []
         for agent_name in self.group_map[group]:
-            agent_index = self.agent_names.index(agent_name)
+            agent_index = self.agent_names_to_indices_map[agent_name]
             agent = self.agents[agent_index]
             action_specs.append(
                 CompositeSpec(
@@ -468,7 +471,7 @@ class VmasWrapper(_EnvWrapper):
         for group, agent_names in self.group_map.items():
             agent_tds = []
             for agent_name in agent_names:
-                i = self.agent_names.index(agent_name)
+                i = self.agent_names_to_indices_map[agent_name]
 
                 agent_obs = self.read_obs(obs[i])
                 agent_info = self.read_info(infos[i])
@@ -507,7 +510,7 @@ class VmasWrapper(_EnvWrapper):
             group_action_list = list(self.read_action(group_action, group=group))
             agent_indices.update(
                 {
-                    self.agent_names.index(agent_name): i + n_agents
+                    self.agent_names_to_indices_map[agent_name]: i + n_agents
                     for i, agent_name in enumerate(agent_names)
                 }
             )
@@ -523,7 +526,7 @@ class VmasWrapper(_EnvWrapper):
         for group, agent_names in self.group_map.items():
             agent_tds = []
             for agent_name in agent_names:
-                i = self.agent_names.index(agent_name)
+                i = self.agent_names_to_indices_map[agent_name]
 
                 agent_obs = self.read_obs(obs[i])
                 agent_rew = self.read_reward(rews[i])


### PR DESCRIPTION
This PR allows VMAS to use the MARL api with grouping.

Users will be able to provide a group_map to VMAS.
By default this will try to group agents named `name_n` into a group named "name".

In case at least one agent does not follow this convention and not group map is specified, VMAS will try to group all agents under the "agent" group