### PR TITLE
[Feature] CatFrames constant padding

### DIFF
--- a/examples/decision_transformer/utils.py
+++ b/examples/decision_transformer/utils.py
@@ -116,7 +116,7 @@ def make_transformed_env(base_env, env_cfg, obs_loc, obs_std, train=False):
             in_keys=["observation_cat", "action_cat", "return_to_go_cat"],
             N=env_cfg.stacked_frames,
             dim=-2,
-            padding="zeros",
+            padding="constant",
         )
     )
 
@@ -166,7 +166,7 @@ def make_collector(cfg, policy):
         "loc",
     )
     cat = CatFrames(
-        in_keys=["action"], out_keys=["action_cat"], N=20, dim=-2, padding="zeros"
+        in_keys=["action"], out_keys=["action_cat"], N=20, dim=-2, padding="constant"
     )
     transforms = Compose(
         exclude_target_return,
@@ -278,7 +278,7 @@ def make_online_replay_buffer(offline_buffer, rb_cfg, reward_scaling=0.001):
         out_keys=["return_to_go_cat"],
         N=rb_cfg.stacked_frames,
         dim=-2,
-        padding="zeros",
+        padding="constant",
         as_inverse=True,
     )
     transforms = Compose(

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -2552,8 +2552,9 @@ class CatFrames(ObservationTransform):
             to be concatenated. Defaults to ["pixels"].
         out_keys (sequence of NestedKey, optional): keys pointing to where the output
             has to be written. Defaults to the value of `in_keys`.
-        padding (str, optional): the padding method. One of ``"same"`` or ``"zeros"``.
-            Defaults to ``"same"``, ie. the first value is uesd for padding.
+        padding (str, optional): the padding method. One of ``"same"`` or ``"constant"``.
+            Defaults to ``"same"``, ie. the first value is used for padding.
+        padding_value (float, optional): the value to use for padding if ``padding="constant"``.
         as_inverse (bool, optional): if ``True``, the transform is applied as an inverse transform. Defaults to ``False``.
         reset_key (NestedKey, optional): the reset key to be used as partial
             reset indicator. Must be unique. If not provided, defaults to the
@@ -2627,7 +2628,7 @@ class CatFrames(ObservationTransform):
         "dim must be < 0 to accomodate for tensordict of "
         "different batch-sizes (since negative dims are batch invariant)."
     )
-    ACCEPTED_PADDING = {"same", "zeros"}
+    ACCEPTED_PADDING = {"same", "constant"}
 
     def __init__(
         self,
@@ -2636,6 +2637,7 @@ class CatFrames(ObservationTransform):
         in_keys: Sequence[NestedKey] | None = None,
         out_keys: Sequence[NestedKey] | None = None,
         padding="same",
+        padding_value=0,
         as_inverse=False,
         reset_key: NestedKey | None = None,
     ):
@@ -2651,6 +2653,7 @@ class CatFrames(ObservationTransform):
         if padding not in self.ACCEPTED_PADDING:
             raise ValueError(f"padding must be one of {self.ACCEPTED_PADDING}")
         self.padding = padding
+        self.padding_value = padding_value
         for in_key in self.in_keys:
             buffer_name = f"_cat_buffers_{in_key}"
             self.register_buffer(
@@ -2701,7 +2704,12 @@ class CatFrames(ObservationTransform):
         shape[self.dim] = d * self.N
         shape = torch.Size(shape)
         getattr(self, buffer_name).materialize(shape)
-        buffer = getattr(self, buffer_name).to(data.dtype).to(data.device).zero_()
+        buffer = (
+            getattr(self, buffer_name)
+            .to(data.dtype)
+            .to(data.device)
+            .fill_(self.padding_value)
+        )
         setattr(self, buffer_name, buffer)
         return buffer
 
@@ -2745,11 +2753,11 @@ class CatFrames(ObservationTransform):
                         buffer.copy_(data_reset.repeat(shape).clone())
                     else:
                         buffer[_reset] = data_reset.repeat(shape).clone()
-                elif self.padding == "zeros":
+                elif self.padding == "constant":
                     if _all:
-                        buffer.fill_(0.0)
+                        buffer.fill_(self.padding_value)
                     else:
-                        buffer[_reset] = 0.0
+                        buffer[_reset] = self.padding_value
                 else:
                     # make linter happy. An exception has already been raised
                     raise NotImplementedError
@@ -2862,8 +2870,10 @@ class CatFrames(ObservationTransform):
                 )
                 first_val = prev_val[tuple(idx)].unsqueeze(tensordict.ndim - 1)
                 data0 = [first_val] * (self.N - 1)
-                if self.padding == "zeros":
-                    data0 = [torch.zeros_like(elt) for elt in data0[:-1]] + data0[-1:]
+                if self.padding == "constant":
+                    data0 = [
+                        torch.ones_like(elt) * self.padding_value for elt in data0[:-1]
+                    ] + data0[-1:]
                 elif self.padding == "same":
                     pass
                 else:
@@ -2872,10 +2882,11 @@ class CatFrames(ObservationTransform):
             elif self.padding == "same":
                 idx = [slice(None)] * (tensordict.ndim - 1) + [0]
                 data0 = [data[tuple(idx)].unsqueeze(tensordict.ndim - 1)] * (self.N - 1)
-            elif self.padding == "zeros":
+            elif self.padding == "constant":
                 idx = [slice(None)] * (tensordict.ndim - 1) + [0]
                 data0 = [
-                    torch.zeros_like(data[tuple(idx)]).unsqueeze(tensordict.ndim - 1)
+                    torch.ones_like(data[tuple(idx)]).unsqueeze(tensordict.ndim - 1)
+                    * self.padding_value
                 ] * (self.N - 1)
             else:
                 # make linter happy. An exception has already been raised


### PR DESCRIPTION
## Description

Allows the CatFrames Transforms to use constant padding using any specified value, instead of only zeros.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
