### PR TITLE
[Bug] TensorDictMaxValueWriter raises error when no sample in a batch is accepted

### DIFF
--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -1270,6 +1270,19 @@ def test_max_value_writer(size, batch_size, reward_ranges):
     assert (max_reward2 <= sample.get("key")).all()
     assert len(sample.get("index").unique()) == len(sample.get("index"))
 
+    # Finally, test the case when no obs should be added
+    td = TensorDict(
+        {
+            "key": torch.zeros(size),
+            "obs": torch.tensor(torch.rand(size)),
+        },
+        batch_size=size,
+        device="cpu",
+    )
+    rb.extend(td)
+    sample = rb.sample()
+    assert (sample.get("key") != 0).all()
+
 
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -1228,7 +1228,7 @@ def test_max_value_writer(size, batch_size, reward_ranges):
     td = TensorDict(
         {
             "key": torch.clamp_max(torch.rand(size), max=max_reward1),
-            "obs": torch.tensor(torch.rand(size)),
+            "obs": torch.rand(size),
         },
         batch_size=size,
         device="cpu",
@@ -1242,7 +1242,7 @@ def test_max_value_writer(size, batch_size, reward_ranges):
     td = TensorDict(
         {
             "key": torch.clamp(torch.rand(size), min=max_reward1, max=max_reward2),
-            "obs": torch.tensor(torch.rand(size)),
+            "obs": torch.rand(size),
         },
         batch_size=size,
         device="cpu",
@@ -1256,7 +1256,7 @@ def test_max_value_writer(size, batch_size, reward_ranges):
     td = TensorDict(
         {
             "key": torch.clamp(torch.rand(size), min=max_reward2, max=max_reward3),
-            "obs": torch.tensor(torch.rand(size)),
+            "obs": torch.rand(size),
         },
         batch_size=size,
         device="cpu",
@@ -1274,7 +1274,7 @@ def test_max_value_writer(size, batch_size, reward_ranges):
     td = TensorDict(
         {
             "key": torch.zeros(size),
-            "obs": torch.tensor(torch.rand(size)),
+            "obs": torch.rand(size),
         },
         batch_size=size,
         device="cpu",

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -207,8 +207,8 @@ class TensorDictMaxValueWriter(Writer):
                 data_to_replace[index] = i
 
         # Replace the data in the storage all at once
-        keys, values = zip(*data_to_replace.items())
-        if len(keys) > 0:
+        if len(data_to_replace) > 0:
+            keys, values = zip(*data_to_replace.items())
             index = data.get("index")
             values = list(values)
             keys = index[values] = torch.tensor(keys, dtype=index.dtype)


### PR DESCRIPTION
## Description

When TensorDictMaxValueWriter receives a batch of data via `extend()` but any sample if better than what the buffer contains, raises *** ValueError: not enough values to unpack (expected 2, got 0) when trying to obtain the insertion info `keys, values = zip(*data_to_replace.items())` raises . This PR fixes this use case.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
