### PR TITLE
[BugFix] assertion error message, envs/util.py

### DIFF
--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -391,7 +391,7 @@ def _per_level_env_check(data0, data1, check_dtype):
             if _data0.shape != _data1.shape:
                 raise AssertionError(
                     f"The shapes of the real and fake tensordict don't match for key {key}. "
-                    f"Got fake={_data0.shape} and real={_data0.shape}."
+                    f"Got fake={_data0.shape} and real={_data1.shape}."
                 )
             if isinstance(_data0, TensorDictBase):
                 _per_level_env_check(_data0, _data1, check_dtype=check_dtype)


### PR DESCRIPTION
The assertion checked for data0 == data1, but the error message prints out that data0 shape is not data0 shape.  Very clear error, simple fix.

## Description

Describe your changes in detail.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x ] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
