### PR TITLE
[BugFix] MaxValueWriter cuda compatibility

### DIFF
--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -1215,9 +1215,10 @@ class TestStateDict:
 @pytest.mark.parametrize("size", [20, 25, 30])
 @pytest.mark.parametrize("batch_size", [1, 10, 15])
 @pytest.mark.parametrize("reward_ranges", [(0.25, 0.5, 1.0)])
-def test_max_value_writer(size, batch_size, reward_ranges):
+@pytest.mark.parametrize("device", get_default_devices())
+def test_max_value_writer(size, batch_size, reward_ranges, device):
     rb = TensorDictReplayBuffer(
-        storage=LazyTensorStorage(size),
+        storage=LazyTensorStorage(size, device=device),
         sampler=SamplerWithoutReplacement(),
         batch_size=batch_size,
         writer=TensorDictMaxValueWriter(rank_key="key"),
@@ -1231,7 +1232,7 @@ def test_max_value_writer(size, batch_size, reward_ranges):
             "obs": torch.rand(size),
         },
         batch_size=size,
-        device="cpu",
+        device=device,
     )
     rb.extend(td)
     sample = rb.sample()
@@ -1245,7 +1246,7 @@ def test_max_value_writer(size, batch_size, reward_ranges):
             "obs": torch.rand(size),
         },
         batch_size=size,
-        device="cpu",
+        device=device,
     )
     rb.extend(td)
     sample = rb.sample()
@@ -1259,7 +1260,7 @@ def test_max_value_writer(size, batch_size, reward_ranges):
             "obs": torch.rand(size),
         },
         batch_size=size,
-        device="cpu",
+        device=device,
     )
 
     for sample in td:
@@ -1277,7 +1278,7 @@ def test_max_value_writer(size, batch_size, reward_ranges):
             "obs": torch.rand(size),
         },
         batch_size=size,
-        device="cpu",
+        device=device,
     )
     rb.extend(td)
     sample = rb.sample()

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -211,7 +211,7 @@ class TensorDictMaxValueWriter(Writer):
             keys, values = zip(*data_to_replace.items())
             index = data.get("index")
             values = list(values)
-            keys = index[values] = torch.tensor(keys, dtype=index.dtype)
+            keys = index[values] = torch.tensor(keys, dtype=index.dtype, device=index.device)
             data.set("index", index)
             self._storage[keys] = data[values]
 

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -211,7 +211,9 @@ class TensorDictMaxValueWriter(Writer):
             keys, values = zip(*data_to_replace.items())
             index = data.get("index")
             values = list(values)
-            keys = index[values] = torch.tensor(keys, dtype=index.dtype, device=index.device)
+            keys = index[values] = torch.tensor(
+                keys, dtype=index.dtype, device=index.device
+            )
             data.set("index", index)
             self._storage[keys] = data[values]
 


### PR DESCRIPTION
## Description

When calling extend, a new tensor containing the new index values is created but its device was not specified, which caused problem when the data was in GPU. Now it is created in whatever device the data is.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
