### PR TITLE
[Feature] Added linear interpolation to FrameSkipTransform

### DIFF
--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3894,11 +3894,22 @@ class FrameSkipTransform(Transform):
         frame_skip (int, optional): a positive integer representing the number
             of frames during which the same action must be applied.
         action_interp (bool, optional): whether to perform action interpolation over frame_skip steps.
+            Defaults to ``False``.
+        Examples:
+            >>> from torchrl.envs import GymEnv
+            >>> env = TransformedEnv(GymEnv("CartPole-v1"), FrameSkipTransform(3, action_interp=False))
+            >>> print(env.rollout)
+            # add print here
+            >>> env = TransformedEnv(GymEnv("CartPole-v1"), FrameSkipTransform(3, action_interp=True))
+            >>> print(env.rollout)
+            # add print here
+            
 
     """
+    
 
     def __init__(self, frame_skip: int = 1, action_interp: bool = False):
-        super().__init()
+        super().__init__()
         if frame_skip < 1:
             raise ValueError("frame_skip should have a value greater or equal to one.")
         self.frame_skip = frame_skip

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3932,11 +3932,6 @@ class FrameSkipTransform(Transform):
 
         return next_tensordict.set(reward_key, reward)
 
-    def forward(self, tensordict):
-        raise RuntimeError(
-            "FrameSkipTransform can only be used when appended to a transformed env."
-        )
-
     def _linear_interpolation(
         self, start_action: Tensor, end_action: Tensor, num_steps: int
     ) -> List[Tensor]:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3883,6 +3883,7 @@ class DiscreteActionProjection(Transform):
             f"in_keys_inv={self.in_keys_inv})"
         )
 
+
 class FrameSkipTransform(Transform):
     """A frame-skip transform.
 
@@ -3905,7 +3906,8 @@ class FrameSkipTransform(Transform):
         self.action_interp_buffer = None
 
     def _step(
-        self, tensordict: TensorDictBase, next_tensordict: TensorDictBase) -> TensorDictBase:
+        self, tensordict: TensorDictBase, next_tensordict: TensorDictBase
+    ) -> TensorDictBase:
         parent = self.parent
         if parent is None:
             raise RuntimeError("parent not found for FrameSkipTransform")
@@ -3943,7 +3945,7 @@ class FrameSkipTransform(Transform):
             interpolated_action = start_action + alpha * (end_action - start_action)
             interpolation_steps.append(interpolated_action)
         return interpolation_steps
-    
+
     def forward(self, tensordict):
         raise RuntimeError(
             "FrameSkipTransform can only be used when appended to a transformed env."

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3935,7 +3935,7 @@ class FrameSkipTransform(Transform):
             else:
                 interpolated_actions = [current_action] * (self.frame_skip - 1)
                 self.action_interp_buffer = next_action
-            next_tensordict.set(self.action_key, interpolated_actions)
+            next_tensordict.set(self.action_key, torch.stack(interpolated_actions))
 
         reward_key = parent.reward_key
         reward = next_tensordict.get(reward_key)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3895,21 +3895,26 @@ class FrameSkipTransform(Transform):
             of frames during which the same action must be applied.
         action_interp (bool, optional): whether to perform action interpolation over frame_skip steps.
             Defaults to ``False``.
-        Examples:
-            >>> from torchrl.envs import GymEnv
-            >>> env = TransformedEnv(GymEnv("CartPole-v1"), FrameSkipTransform(3, action_interp=False))
-            >>> print(env.rollout)
-            # add print here
-            >>> env = TransformedEnv(GymEnv("CartPole-v1"), FrameSkipTransform(3, action_interp=True))
-            >>> print(env.rollout)
-            # add print here
-            
+
+    Examples:
+        >>> from torchrl.envs import GymEnv
+        >>> env = TransformedEnv(GymEnv("CartPole-v1"), FrameSkipTransform(3, action_interp=False))
+        >>> print(env.rollout)
+        # add print here
+        >>> env = TransformedEnv(GymEnv("CartPole-v1"), FrameSkipTransform(3, action_interp=True))
+        >>> print(env.rollout)
+        # add print here
+
 
     """
-    
 
-    def __init__(self, frame_skip: int = 1, action_interp: bool = False, action_key: str = "_action"):
-        super().__init()
+    def __init__(
+        self,
+        frame_skip: int = 1,
+        action_interp: bool = False,
+        action_key: str = "_action",
+    ):
+        super().__init__()
         if frame_skip < 1:
             raise ValueError("frame_skip should have a value greater or equal to one.")
         self.frame_skip = frame_skip
@@ -3956,7 +3961,6 @@ class FrameSkipTransform(Transform):
             interpolated_action = start_action + alpha * (end_action - start_action)
             interpolation_steps.append(interpolated_action)
         return interpolation_steps
-
 
     def forward(self, tensordict):
         raise RuntimeError(


### PR DESCRIPTION
## Description

- Added an `action_interp` parameter to enable or disable the action interpolation feature.
- Added an `action_interp_buffer` attribute to store the previous action for interpolation.

## Motivation and Context

Solves Issue #1659 


## Types of changes

- [x] New feature (non-breaking change which adds core functionality)
- [x] Documentation (update in the documentation)


## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## Reviewers 

cc. @vmoens 

P.S. I don't know if I have to add unit-tests for this, OR if this is a breaking change, so I haven't added them here.