### PR TITLE
[BugFix] make sure the params of exploration-wrapper is float

### DIFF
--- a/test/test_exploration.py
+++ b/test/test_exploration.py
@@ -51,7 +51,7 @@ from torchrl.modules.tensordict_module.exploration import (
 
 
 class TestEGreedy:
-    @pytest.mark.parametrize("eps_init", [0.0, 0.5, 1.0])
+    @pytest.mark.parametrize("eps_init", [0.0, 0.5, 1])
     @pytest.mark.parametrize("module", [True, False])
     def test_egreedy(self, eps_init, module):
         torch.manual_seed(0)
@@ -78,7 +78,7 @@ class TestEGreedy:
             assert (action == 0).any()
             assert ((action == 1) | (action == 0)).all()
 
-    @pytest.mark.parametrize("eps_init", [0.0, 0.5, 1.0])
+    @pytest.mark.parametrize("eps_init", [0.0, 0.5, 1])
     @pytest.mark.parametrize("module", [True, False])
     @pytest.mark.parametrize("spec_class", ["discrete", "one_hot"])
     def test_egreedy_masked(self, module, eps_init, spec_class):

--- a/torchrl/modules/tensordict_module/exploration.py
+++ b/torchrl/modules/tensordict_module/exploration.py
@@ -110,7 +110,7 @@ class EGreedyModule(TensorDictModuleBase):
         self.register_buffer("eps_init", torch.tensor([eps_init]))
         self.register_buffer("eps_end", torch.tensor([eps_end]))
         self.annealing_num_steps = annealing_num_steps
-        self.register_buffer("eps", torch.tensor([eps_init]))
+        self.register_buffer("eps", torch.tensor([eps_init], dtype=torch.float32))
 
         if spec is not None:
             if not isinstance(spec, CompositeSpec) and len(self.out_keys) >= 1:
@@ -259,7 +259,7 @@ class EGreedyWrapper(TensorDictModuleWrapper):
         if self.eps_end > self.eps_init:
             raise RuntimeError("eps should decrease over time or be constant")
         self.annealing_num_steps = annealing_num_steps
-        self.register_buffer("eps", torch.tensor([eps_init]))
+        self.register_buffer("eps", torch.tensor([eps_init], dtype=torch.float32))
         self.action_key = action_key
         self.action_mask_key = action_mask_key
         if spec is not None:
@@ -405,7 +405,7 @@ class AdditiveGaussianWrapper(TensorDictModuleWrapper):
         self.annealing_num_steps = annealing_num_steps
         self.register_buffer("mean", torch.tensor([mean]))
         self.register_buffer("std", torch.tensor([std]))
-        self.register_buffer("sigma", torch.tensor([sigma_init]))
+        self.register_buffer("sigma", torch.tensor([sigma_init], dtype=torch.float32))
         self.action_key = action_key
         self.out_keys = list(self.td_module.out_keys)
         if action_key not in self.out_keys:
@@ -613,7 +613,7 @@ class OrnsteinUhlenbeckProcessWrapper(TensorDictModuleWrapper):
                 f"got eps_init={eps_init} and eps_end={eps_end}"
             )
         self.annealing_num_steps = annealing_num_steps
-        self.register_buffer("eps", torch.tensor([eps_init]))
+        self.register_buffer("eps", torch.tensor([eps_init], dtype=torch.float32))
         self.out_keys = list(self.td_module.out_keys) + self.ou.out_keys
         self.is_init_key = is_init_key
         noise_key = self.ou.noise_key


### PR DESCRIPTION
## Description

we should make sure the params of exploration-wrapper is float, or the params decay maybe abnormal.

## Motivation and Context

If the user passes an int into the wrapper (e.g. "1" instead of "1.0", like stupid me), the params will always be `0` and don't change throughout the `step` is called:
```python
 policy = TensorDictModule(
      module=torch.nn.Linear(4, 4, bias=False),
      in_keys="observation",
      out_keys="action",
  )
  p = OrnsteinUhlenbeckProcessWrapper(
      policy,
      eps_init=1,
  )
  for i in range(10):
      p.step()
      print(p.eps.item())
```

result is 
```
0
0
0
0
0
0
0
0
0
0
```

if we pass a float, the function of wrapper is normal:
 
```python
 policy = TensorDictModule(
      module=torch.nn.Linear(4, 4, bias=False),
      in_keys="observation",
      out_keys="action",
  )
  p = OrnsteinUhlenbeckProcessWrapper(
      policy,
      eps_init=1.0,
  )
  for i in range(10):
      p.step()
      print(p.eps.item())
```

result is 
```
0.9991000294685364
0.9982000589370728
0.9973000884056091
0.9964001178741455
0.9955001473426819
0.9946001768112183
0.9937002062797546
0.992800235748291
0.9919002652168274
0.9910002946853638
```

the reason of this bug is we use the type of `eps_init` as the type of `self.eps`.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
