### PR TITLE
[Fix] EndOfLifeTransform fix in end of life detection

### DIFF
--- a/torchrl/envs/transforms/gym_transforms.py
+++ b/torchrl/envs/transforms/gym_transforms.py
@@ -148,7 +148,7 @@ class EndOfLifeTransform(Transform):
 
         lives = self._get_lives()
         end_of_life = torch.tensor(
-            tensordict.get(self.lives_key) < lives, device=self.parent.device
+            tensordict.get(self.lives_key) > lives, device=self.parent.device
         )
         try:
             done = next_tensordict.get(self.done_key)


### PR DESCRIPTION
## Description

EndOfLifeTransform should check if the current number of lives in the tensordict is higher that the number of lives after the step (meaning on has been lost). However, the sign is the opposite. This PR changes that.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
