### PR TITLE
[Feature] SliceSampler

### DIFF
--- a/docs/source/reference/data.rst
+++ b/docs/source/reference/data.rst
@@ -34,8 +34,9 @@ We also give users the ability to compose a replay buffer using the following co
     Sampler
     PrioritizedSampler
     RandomSampler
-    SliceSampler
     SamplerWithoutReplacement
+    SliceSampler
+    SliceSamplerWithoutReplacement
     Storage
     ListStorage
     LazyTensorStorage

--- a/docs/source/reference/data.rst
+++ b/docs/source/reference/data.rst
@@ -34,6 +34,7 @@ We also give users the ability to compose a replay buffer using the following co
     Sampler
     PrioritizedSampler
     RandomSampler
+    SliceSampler
     SamplerWithoutReplacement
     Storage
     ListStorage
@@ -109,41 +110,59 @@ It is not too difficult to store trajectories in the replay buffer.
 One element to pay attention to is that the size of the replay buffer is always
 the size of the leading dimension of the storage: in other words, creating a
 replay buffer with a storage of size 1M when storing multidimensional data
-does not mean storing 1M frames but 1M trajectories.
+does not mean storing 1M frames but 1M trajectories. However, if trajectories
+(or episodes/rollouts) are flattened before being stored, the capacity will still
+be 1M steps.
 
 When sampling trajectories, it may be desirable to sample sub-trajectories
 to diversify learning or make the sampling more efficient.
-To do this, we provide a custom :class:`~torchrl.envs.Transform` class named
-:class:`~torchrl.envs.RandomCropTensorDict`. Here is an example of how this class
-can be used:
+TorchRL offers two distinctive ways of accomplishing this:
+- The :class:`~torchrl.data.replay_buffers.samplers.SliceSampler` allows to
+  sample a given number of slices of trajectories stored one after another
+  along the leading dimension of the :class:`~torchrl.data.replay_buffers.samplers.TensorStorage`.
+  This is the recommended way of sampling sub-trajectories in TorchRL __especially__
+  when using offline datasets (which are stored using that convention).
+  This strategy requires to flatten the trajectories before extending the replay
+  buffer and reshaping them after sampling. The :class:`~torchrl.data.replay_buffers.samplers.SliceSampler`
+  gives extensive details about this storage and sampling strategy.
 
-.. code-block::Python
+- Trajectories can also be stored independently, with the each element of the
+  leading dimension pointing to a different trajectory. This requires
+  for the trajectories to have a congruent shape (or to be padded).
+  We provide a custom :class:`~torchrl.envs.Transform` class named
+  :class:`~torchrl.envs.RandomCropTensorDict` that allows to sample
+  sub-trajectories in the buffer. Note that, unlike the :class:`~torchrl.data.replay_buffers.samplers.SliceSampler`-based
+  strategy, here having an ``"episode"`` or ``"done"`` key pointing at the
+  start and stop signals isn't required.
+  Here is an example of how this class can be used:
 
-    >>> import torch
-    >>> from tensordict import TensorDict
-    >>> from torchrl.data import LazyMemmapStorage, TensorDictReplayBuffer
-    >>> from torchrl.envs import RandomCropTensorDict
-    >>>
-    >>> obs = torch.randn(100, 50, 1)
-    >>> data = TensorDict({"obs": obs[:-1], "next": {"obs": obs[1:]}}, [99])
-    >>> rb = TensorDictReplayBuffer(storage=LazyMemmapStorage(1000))
-    >>> rb.extend(data)
-    >>> # subsample trajectories of length 10
-    >>> rb.append_transform(RandomCropTensorDict(sub_seq_len=10))
-    >>> print(rb.sample(128))
-    TensorDict(
-        fields={
-            index: Tensor(shape=torch.Size([10]), device=cpu, dtype=torch.int32, is_shared=False),
-            next: TensorDict(
-                fields={
-                    obs: Tensor(shape=torch.Size([10, 50, 1]), device=cpu, dtype=torch.float32, is_shared=False)},
-                batch_size=torch.Size([10]),
-                device=None,
-                is_shared=False),
-            obs: Tensor(shape=torch.Size([10, 50, 1]), device=cpu, dtype=torch.float32, is_shared=False)},
-        batch_size=torch.Size([10]),
-        device=None,
-        is_shared=False)
+  .. code-block::Python
+
+      >>> import torch
+      >>> from tensordict import TensorDict
+      >>> from torchrl.data import LazyMemmapStorage, TensorDictReplayBuffer
+      >>> from torchrl.envs import RandomCropTensorDict
+      >>>
+      >>> obs = torch.randn(100, 50, 1)
+      >>> data = TensorDict({"obs": obs[:-1], "next": {"obs": obs[1:]}}, [99])
+      >>> rb = TensorDictReplayBuffer(storage=LazyMemmapStorage(1000))
+      >>> rb.extend(data)
+      >>> # subsample trajectories of length 10
+      >>> rb.append_transform(RandomCropTensorDict(sub_seq_len=10))
+      >>> print(rb.sample(128))
+      TensorDict(
+          fields={
+              index: Tensor(shape=torch.Size([10]), device=cpu, dtype=torch.int32, is_shared=False),
+              next: TensorDict(
+                  fields={
+                      obs: Tensor(shape=torch.Size([10, 50, 1]), device=cpu, dtype=torch.float32, is_shared=False)},
+                  batch_size=torch.Size([10]),
+                  device=None,
+                  is_shared=False),
+              obs: Tensor(shape=torch.Size([10, 50, 1]), device=cpu, dtype=torch.float32, is_shared=False)},
+          batch_size=torch.Size([10]),
+          device=None,
+          is_shared=False)
 
 Checkpointing Replay Buffers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -1646,10 +1646,7 @@ class TestSamplers:
             assert too_short
 
         assert len(trajs_unique_id) == 4
-        if _data_prefix:
-            truncated = info[("_data", ("next", "truncated"))]
-        else:
-            truncated = info[("next", "truncated")]
+        truncated = info[("next", "truncated")]
         assert truncated.view(num_slices, -1)[:, -1].all()
 
     def test_slice_sampler_errors(self):
@@ -1773,10 +1770,7 @@ class TestSamplers:
             trajs_unique_id = trajs_unique_id.union(
                 cur_episodes,
             )
-        if _data_prefix:
-            truncated = info[("_data", ("next", "truncated"))]
-        else:
-            truncated = info[("next", "truncated")]
+        truncated = info[("next", "truncated")]
         assert truncated.view(num_slices, -1)[:, -1].all()
 
 

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -31,6 +31,7 @@ from torchrl.data.replay_buffers.samplers import (
     PrioritizedSampler,
     RandomSampler,
     SamplerWithoutReplacement,
+    SliceSampler,
 )
 
 from torchrl.data.replay_buffers.storages import (
@@ -1542,6 +1543,130 @@ class TestMultiProc:
         # list storage cannot be shared
         with pytest.raises(RuntimeError, match="it has not been initialized yet"):
             self.exec_multiproc_rb(init=False)
+
+
+class TestSamplers:
+    @pytest.mark.parametrize("batch_size,num_slices", [[100, 20], [120, 30]])
+    @pytest.mark.parametrize("episode_key", ["episode", ("some", "episode")])
+    @pytest.mark.parametrize("done_key", ["done", ("some", "done")])
+    @pytest.mark.parametrize("match_episode", [True, False])
+    @pytest.mark.parametrize("_data_prefix", [True, False])
+    @pytest.mark.parametrize("device", get_default_devices())
+    def test_slice_sampler(
+        self,
+        batch_size,
+        num_slices,
+        episode_key,
+        done_key,
+        match_episode,
+        _data_prefix,
+        device,
+    ):
+        torch.manual_seed(0)
+        storage = LazyMemmapStorage(100)
+        episode = torch.zeros(100, dtype=torch.int, device=device)
+        episode[:30] = 1
+        episode[30:55] = 2
+        episode[55:70] = 3
+        episode[70:] = 4
+        steps = torch.cat(
+            [torch.arange(30), torch.arange(25), torch.arange(15), torch.arange(30)], 0
+        )
+
+        done = torch.zeros(100, 1, dtype=torch.bool)
+        done[torch.tensor([29, 54, 69])] = 1
+
+        data = TensorDict(
+            {
+                # we only use episode_key if we want the sampler to access it
+                episode_key if match_episode else "whatever_episode": episode,
+                "another_episode": episode,
+                "obs": torch.randn((3, 4, 5)).expand(100, 3, 4, 5),
+                "act": torch.randn((20,)).expand(100, 20),
+                "steps": steps,
+                "other": torch.randn((20, 50)).expand(100, 20, 50),
+                done_key: done,
+            },
+            [100],
+            device=device,
+        )
+        if _data_prefix:
+            data = TensorDict({"_data": data}, [100])
+        storage.set(range(100), data)
+        sampler = SliceSampler(
+            num_slices=num_slices, traj_key=episode_key, end_key=done_key
+        )
+        index, _ = sampler.sample(storage, batch_size=batch_size)
+        if _data_prefix:
+            samples = storage._storage["_data"][index]
+        else:
+            samples = storage._storage[index]
+        trajs_unique_id = set()
+        for _ in range(5):
+            # check that trajs are ok
+            samples = samples.view(num_slices, -1)
+            assert samples["another_episode"].unique(
+                dim=1
+            ).squeeze().shape == torch.Size([num_slices])
+            assert (samples["steps"][..., 1:] - 1 == samples["steps"][..., :-1]).all()
+            trajs_unique_id = trajs_unique_id.union(
+                samples["another_episode"].view(-1).tolist()
+            )
+        assert len(trajs_unique_id) == 4
+
+    def test_slice_sampler_errors(self):
+        device = "cpu"
+        _data_prefix = False
+        batch_size, num_slices = 100, 20
+
+        episode = torch.zeros(100, dtype=torch.int, device=device)
+        episode[:30] = 1
+        episode[30:55] = 2
+        episode[55:70] = 3
+        episode[70:] = 4
+        steps = torch.cat(
+            [torch.arange(30), torch.arange(25), torch.arange(15), torch.arange(30)], 0
+        )
+
+        done = torch.zeros(100, 1, dtype=torch.bool)
+        done[torch.tensor([29, 54, 69])] = 1
+
+        data = TensorDict(
+            {
+                # we only use episode_key if we want the sampler to access it
+                "episode": episode,
+                "another_episode": episode,
+                "obs": torch.randn((3, 4, 5)).expand(100, 3, 4, 5),
+                "act": torch.randn((20,)).expand(100, 20),
+                "steps": steps,
+                "other": torch.randn((20, 50)).expand(100, 20, 50),
+                ("next", "done"): done,
+            },
+            [100],
+            device=device,
+        )
+        if _data_prefix:
+            data = TensorDict({"_data": data}, [100])
+
+        data_wrong_done = data.clone(False)
+        data_wrong_done.rename_key_("episode", "_")
+        data_wrong_done["next", "done"] = done.unsqueeze(1).expand(100, 5, 1)
+        storage = LazyMemmapStorage(100)
+        storage.set(range(100), data_wrong_done)
+        sampler = SliceSampler(num_slices=num_slices)
+        with pytest.raises(
+            RuntimeError,
+            match="Expected the end-of-trajectory signal to be 1-dimensional",
+        ):
+            index, _ = sampler.sample(storage, batch_size=batch_size)
+
+        storage = ListStorage(100)
+        storage.set(range(100), data)
+        sampler = SliceSampler(num_slices=num_slices)
+        with pytest.raises(
+            RuntimeError, match="can only sample from TensorStorage subclasses"
+        ):
+            index, _ = sampler.sample(storage, batch_size=batch_size)
 
 
 if __name__ == "__main__":

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -1892,9 +1892,7 @@ class TestLSTMModule:
             with params.to_module(training_model):
                 return training_model(data)
 
-        assert vmap(call, (None, 0))(data, params).shape == torch.Size(
-            (2, 50, 11)
-        )
+        assert vmap(call, (None, 0))(data, params).shape == torch.Size((2, 50, 11))
 
 
 class TestGRUModule:
@@ -2221,9 +2219,7 @@ class TestGRUModule:
             with params.to_module(training_model):
                 return training_model(data)
 
-        assert vmap(call, (None, 0))(data, params).shape == torch.Size(
-            (2, 50, 11)
-        )
+        assert vmap(call, (None, 0))(data, params).shape == torch.Size((2, 50, 11))
 
 
 def test_safe_specs():

--- a/torchrl/data/__init__.py
+++ b/torchrl/data/__init__.py
@@ -13,6 +13,7 @@ from .replay_buffers import (
     RemoteTensorDictReplayBuffer,
     ReplayBuffer,
     RoundRobinWriter,
+    SliceSampler,
     Storage,
     TensorDictMaxValueWriter,
     TensorDictPrioritizedReplayBuffer,

--- a/torchrl/data/__init__.py
+++ b/torchrl/data/__init__.py
@@ -14,6 +14,7 @@ from .replay_buffers import (
     ReplayBuffer,
     RoundRobinWriter,
     SliceSampler,
+    SliceSamplerWithoutReplacement,
     Storage,
     TensorDictMaxValueWriter,
     TensorDictPrioritizedReplayBuffer,

--- a/torchrl/data/replay_buffers/__init__.py
+++ b/torchrl/data/replay_buffers/__init__.py
@@ -15,6 +15,7 @@ from .samplers import (
     RandomSampler,
     Sampler,
     SamplerWithoutReplacement,
+    SliceSampler,
 )
 from .storages import (
     LazyMemmapStorage,

--- a/torchrl/data/replay_buffers/__init__.py
+++ b/torchrl/data/replay_buffers/__init__.py
@@ -16,6 +16,7 @@ from .samplers import (
     Sampler,
     SamplerWithoutReplacement,
     SliceSampler,
+    SliceSamplerWithoutReplacement,
 )
 from .storages import (
     LazyMemmapStorage,

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -439,16 +439,11 @@ class ReplayBuffer:
         if not self._prefetch:
             ret = self._sample(batch_size)
         else:
-            if len(self._prefetch_queue) == 0:
-                ret = self._sample(batch_size)
-            else:
-                with self._futures_lock:
-                    ret = self._prefetch_queue.popleft().result()
-
             with self._futures_lock:
                 while len(self._prefetch_queue) < self._prefetch_cap:
                     fut = self._prefetch_executor.submit(self._sample, batch_size)
                     self._prefetch_queue.append(fut)
+                ret = self._prefetch_queue.popleft().result()
 
         if return_info:
             return ret

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -258,7 +258,7 @@ class TD3Loss(LossModule):
         if not ((action_spec is not None) ^ (bounds is not None)):
             raise ValueError(
                 "One of 'bounds' and 'action_spec' must be provided, "
-                f"but not both. Got bounds={bounds} and action_spec={action_spec}."
+                f"but not both or none. Got bounds={bounds} and action_spec={action_spec}."
             )
         elif action_spec is not None:
             if isinstance(action_spec, CompositeSpec):


### PR DESCRIPTION
In this PR I propose a new sampler that samples slices of data in a storage.

## Setting

Let RB be a replay buffer of capacity `M` (for simplicity the replay buffer is full). 
We have `N` trajectories stored in this buffer, with length `T_{min} < T_i < T_{max}` for all `T_i for i in 1:N`.
We want to sample batches of data of some arbitrary length such that the batch size `B = S * U` (potentially with a tensordict of shape `[S, U]` or `[S * U]`, TBD) where `S` is the number of slices and `U` a fixed sub-trajectory length.
Assume `U > T_{min}`.
The slices sampled from the RB can start anywhere from `t_start=0` to `t_start = T_i - U` and end at `t_start + U`.

## Usage

In many cases, users want to sample sub-trajectories out of complete trajectories. Those sub-trajectories should generally not start at the beginning of the trajectory or end at the end (hence, we say that users want _slices_ of trajectories). Typical usages are:
- RNN/Transformer-based policies
- Offline RL datasets

## Proposed class

The `SliceSampler` we propose here does exactly what was suggested above.

To keep the batch-size unchanged, the user has to specify how many slices she wants out of the batch-size (`S`). Alternatively, we could ask for a trajectory length (`U`) (or one of these but not both).
Eg,
```
class SliceSampler(Sampler):
    def __init__(self, ..., num_slices=None, traj_len=None): # either traj_len or num_slices must be non-none, but not both
       ...
```

We can sample trajectories when we know the start and stop signals. To gather these, users can pass either the key pointing to the trajectory indicators `traj_key` or a done state `done_key`. 

**Note**: passing `"done"` can be dangerous since if one gets an incomplete trajectory, it will not be marked as `"done"` at the last step! Using the `"truncated"` signal from the collector could be an alternative, but in general it should be safer to use the trajectory indicator. The user is responsible of making sure that two consecutive trajectories do not share the same indicator.

Computing the start and stop signals can be expensive, and for static datasets one could cache the start and stop signals. This speeds up sampling by an important factor (0.3 ms with caching vs 1ms on my computer)

Example code:
```python
import timeit
import torch
import tqdm

from tensordict import TensorDict
from torchrl.data.replay_buffers import LazyMemmapStorage, \
    TensorDictReplayBuffer
from torchrl.data.replay_buffers.samplers import SliceSampler

prefetch = 0
for cache in [True, False]:
    rb = TensorDictReplayBuffer(
        storage=LazyMemmapStorage(1_000_000),
        sampler=SliceSampler(cache_values=cache, num_slices=10),
        batch_size=320,
        prefetch=prefetch
        )
    episode = torch.zeros(1000, dtype=torch.int)
    episode[:300] = 1
    episode[300:550] = 2
    episode[550:700] = 3
    episode[700:] = 4
    data = TensorDict(
        {
            "episode": episode,
            "obs": torch.randn((3, 4, 5)).expand(1000, 3, 4, 5),
            "act": torch.randn((20,)).expand(1000, 20),
            "other": torch.randn((20, 50)).expand(1000, 20, 50),
        }, [1000]
    )
    for _ in tqdm.tqdm(range(1000)):
        rb.extend(data)

    print(prefetch, min(*timeit.repeat("rb.sample()", globals={"rb": rb}, number=1000)))

```

Results in `0.3468737329999989` ms with caching, `1.150314997999999` without

## Why is this PR important

This PR paves the way for a new API to store trajectories, where one can flatten the data coming from the collector and extend the RB with it. Storing trajectories of different lengths will be easy, and sampling trajectories should be cheaper. This will also participate in making the dataset and dynamic RB APIs uniform.
Pseudocode:
```python
for data in collector: # data is of shape [C, D]
    replay_buffer.extend(data.view(-1)) # adds the C consecutive trajectories of length D
    samples = replay_buffer.sample(B) # B elements divided in S slices of length U
    samples = samples.view(S, U)
```
Ultimately, we will be able to deprecate the hacky `"_data"` key in `TensorDictReplayBuffers` that is bothering us so much!

cc: @matteobettini @albertbou92 @BY571 @skandermoalla @nicklashansen @truncs @btx0424 @smorad @vikashplus

## Question

- Should `batch_size` indicate the number of slices (ie, trajectories) sampled? In other words: Should users ask for `B` or `S`. Pros for `B`: clearer API, I ask for `B` transitions I get `B` transitions, whatever the sampler. Pros for `S`: users may ask for a certain "number of items" referring items to the trajectories. I'm still in favour of `B` because otherwise we assume that the sampler impacts the shape of the samples, which isn't great for composability (swapping samples will change the amount of data consumed, or UTD of the algo).
- Related: Should we return batches of size `[S, U]` or `[S * U]`? I like the second best for the same reason as before (composability).
- Last one: what do we do if some trajectories have an insufficient length (T_min > U)? My take: there should be an arg `pad` in the constructor, `None` by default. If `pad=True`, we pad with 0s. If `pad=smth` and `smth` is not `None`, we pas with `smth`. If `pad=None` (default) an exception is raised if `T_min < U` (or cheaper option: if `T_i < U` is encountered at some point during training.
- Should we give a device to the sampler to speed up the trajectory recovering (with cuda)?

Related issues
https://github.com/pytorch/rl/issues/1671
https://github.com/pytorch/rl/issues/1079


TODO:
- [x] Doc
- [x] Tests
- [x] Allow padding => @matteobettini Samplers cannot do padding (they just return indices) so we just return fewer indices if trajectories don't comply with minimum length whenever `strict_length=False`.
- [x] allow sampling without replacement (what does that look like?)
- [ ] sampling each transition with equal probability? => NOT PLANNED
- [ ] prepare ordered dataset iterations => follow-up PR
