### PR TITLE
[Minor] Remove dead code in RolloutFromModel

### DIFF
--- a/torchrl/data/rlhf/utils.py
+++ b/torchrl/data/rlhf/utils.py
@@ -335,15 +335,6 @@ class RolloutFromModel:
         )  # we assume that if it's not truncated, it was terminated
         return truncated | terminated, terminated
 
-        print("batch.prompt_rindex", batch.prompt_rindex)
-        print("generated", generated.shape)
-        terminated = (generated == self.EOS_TOKEN_ID)[..., -batch.prompt_rindex :]
-        terminated = terminated.int().cumsum(-1).bool()
-        done = terminated.clone()
-        done[..., self.max_new_tokens - 1] = 1
-        print("self.max_new_tokens", self.max_new_tokens)
-        return done.unsqueeze(-1), terminated.unsqueeze(-1)
-
     def _get_action(self, generated, batch):
         # the sequence of actions for each trajectory is just the generated token ids
         action_idx = torch.arange(self.max_new_tokens, device=generated.device)


### PR DESCRIPTION
## Description

Removing what looks like some leftover debug code, happens after a non-conditional return statement so cannot be executed.

## Motivation and Context

Purely a cleanup, observed when reading through the code. 

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
