### PR TITLE
[Minor] Fix runnability of RLHF example in examples/rlhf

### DIFF
--- a/examples/rlhf/train.py
+++ b/examples/rlhf/train.py
@@ -62,7 +62,7 @@ def main(cfg):
     dtype = cfg.sys.dtype
     compile_ = cfg.sys.compile
 
-    ctx = setup(device=device, dtype=dtype)
+    ctx = setup(cfg.sys)
 
     train_loader = get_dataloader(
         data_cfg.batch_size,

--- a/examples/rlhf/train_reward.py
+++ b/examples/rlhf/train_reward.py
@@ -65,7 +65,7 @@ def main(cfg):
     dtype = cfg.sys.dtype
     compile_ = cfg.sys.compile
 
-    ctx = setup(device=device, dtype=dtype)
+    ctx = setup(cfg.sys)
 
     train_loader = get_dataloader(
         data_cfg.batch_size,

--- a/examples/rlhf/utils.py
+++ b/examples/rlhf/utils.py
@@ -130,7 +130,7 @@ class Evaluator:
     ):
         self.reward_estimator = reward_estimator
         self.model = model
-        self.promp_logger = prompt_logger
+        self.prompt_logger = prompt_logger
         self.io_cfg = io_cfg
         self.eval_interval = io_cfg.eval_interval
         self.log_interval = io_cfg.log_interval
@@ -154,7 +154,7 @@ class Evaluator:
                 val_reward = self.reward_estimator(self.model, self.val_loader)
                 self.prompt_logger.log(self.model)
             self.val_reward_logger.info(f"VALID: {self.it=}: {val_reward=:.4f}")
-            self.logger.log_scalar({"val_reward": val_reward}, step=self.it)
+            self.logger.log_scalar("val_reward", val_reward, step=self.it)
             # pbar.set_description(f"VALID: {it=}: {val_reward=:.4f}")
             if val_reward > self.best_val_reward:
                 self.best_val_reward = val_reward


### PR DESCRIPTION
## Description

Small amount of bit rot on the RLHF example.

- Correct passing of configuration in train transformer and reward steps
- Fix typo on prompt logger
- Update log_scalar to match class spec.

## Motivation and Context

There was one larger issue which I didn't address, which was that tensordictmodule wasn't playing well with dynamo, due to the optimizedmodule not forwarding getattr calls to the underlying module: I didn't get round to verifying that was fixed in nightlies (though I think it might be), but I did think about about updating the train/train_reward configs to default compile to be off as it will fail in the stable release version with `TypeError: _forward_unimplemented() got an unexpected keyword argument 'input_ids'` or similar. Its easy enough to disable compile in config or on command line, but it might be worth disabling in the base config as well.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
