### PR TITLE
[Feature] BurnInTransform

### DIFF
--- a/docs/source/reference/envs.rst
+++ b/docs/source/reference/envs.rst
@@ -616,6 +616,7 @@ to be able to create this other composition:
     VC1Transform
     VIPRewardTransform
     VIPTransform
+    BurnInTransform
 
 Environments with masked actions
 --------------------------------

--- a/docs/source/reference/envs.rst
+++ b/docs/source/reference/envs.rst
@@ -572,6 +572,7 @@ to be able to create this other composition:
     TransformedEnv
     ActionMask
     BinarizeReward
+    BurnInTransform
     CatFrames
     CatTensors
     CenterCrop
@@ -616,7 +617,6 @@ to be able to create this other composition:
     VC1Transform
     VIPRewardTransform
     VIPTransform
-    BurnInTransform
 
 Environments with masked actions
 --------------------------------

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -9406,35 +9406,30 @@ class TestBurnInTransform(TransformBase):
         )
         return batch
 
-    @abc.abstractmethod
     def test_single_trans_env_check(self):
-        """tests that a transformed env passes the check_env_specs test.
+        raise pytest.skip(
+            "BurnInTransform can only be appended to a ReplayBuffer, not to a TransformedEnv."
+        )
 
-        If your transform can overwrite a key or create a new entry in the tensordict,
-        it is worth trying both options here.
-
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
     def test_serial_trans_env_check(self):
-        """tests that a serial transformed env (SerialEnv(N, lambda: TransformedEnv(env, transform))) passes the check_env_specs test."""
-        raise NotImplementedError
+        raise pytest.skip(
+            "BurnInTransform can only be appended to a ReplayBuffer, not to a TransformedEnv."
+        )
 
-    @abc.abstractmethod
     def test_parallel_trans_env_check(self):
-        """tests that a parallel transformed env (ParallelEnv(N, lambda: TransformedEnv(env, transform))) passes the check_env_specs test."""
-        raise NotImplementedError
+        raise pytest.skip(
+            "BurnInTransform can only be appended to a ReplayBuffer, not to a TransformedEnv."
+        )
 
-    @abc.abstractmethod
     def test_trans_serial_env_check(self):
-        """tests that a transformed serial env (TransformedEnv(SerialEnv(N, lambda: env()), transform)) passes the check_env_specs test."""
-        raise NotImplementedError
+        raise pytest.skip(
+            "BurnInTransform can only be appended to a ReplayBuffer, not to a TransformedEnv."
+        )
 
-    @abc.abstractmethod
     def test_trans_parallel_env_check(self):
-        """tests that a transformed paprallel env (TransformedEnv(ParallelEnv(N, lambda: env()), transform)) passes the check_env_specs test."""
-        raise NotImplementedError
+        raise pytest.skip(
+            "BurnInTransform can only be appended to a ReplayBuffer, not to a TransformedEnv."
+        )
 
     @pytest.mark.parametrize("module", ["gru", "lstm"])
     @pytest.mark.parametrize("batch_size", [2, 4])
@@ -9510,7 +9505,7 @@ class TestBurnInTransform(TransformBase):
         env = TransformedEnv(ContinuousActionVecMockEnv(), burn_in_transform)
         with pytest.raises(
             RuntimeError,
-            match="BurnInTransform can only be used when appended to a ReplayBuffer.",
+            match="BurnInTransform can only be appended to a ReplayBuffer.",
         ):
             rollout = env.rollout(3)
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -9437,6 +9437,7 @@ class TestBurnInTransform(TransformBase):
     @pytest.mark.parametrize("burn_in", [2])
     def test_transform_no_env(self, module, batch_size, sequence_length, burn_in):
         """tests the transform on dummy data, without an env."""
+        torch.manual_seed(0)
         data = self._make_batch(batch_size, sequence_length)
 
         if module == "gru":
@@ -9471,6 +9472,7 @@ class TestBurnInTransform(TransformBase):
     @pytest.mark.parametrize("burn_in", [2])
     def test_transform_compose(self, module, batch_size, sequence_length, burn_in):
         """tests the transform on dummy data, without an env but inside a Compose."""
+        torch.manual_seed(0)
         data = self._make_batch(batch_size, sequence_length)
 
         if module == "gru":
@@ -9514,6 +9516,7 @@ class TestBurnInTransform(TransformBase):
     @pytest.mark.parametrize("sequence_length", [4, 8])
     @pytest.mark.parametrize("burn_in", [2])
     def test_transform_model(self, module, batch_size, sequence_length, burn_in):
+        torch.manual_seed(0)
         data = self._make_batch(batch_size, sequence_length)
 
         if module == "gru":
@@ -9549,7 +9552,7 @@ class TestBurnInTransform(TransformBase):
     @pytest.mark.parametrize("burn_in", [2])
     @pytest.mark.parametrize("rbclass", [ReplayBuffer, TensorDictReplayBuffer])
     def test_transform_rb(self, module, batch_size, sequence_length, burn_in, rbclass):
-
+        torch.manual_seed(0)
         data = self._make_batch(batch_size, sequence_length)
 
         if module == "gru":

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -9407,14 +9407,15 @@ class TestBurnInTransform(TransformBase):
         return batch
 
     def test_single_trans_env_check(self):
-        # raise pytest.skip(
-        #         "BurnInTransform can only be appended to a ReplayBuffer, not to a TransformedEnv."
-        #     )
         module = self._make_gru_module()
         burn_in_transform = BurnInTransform(module, burn_in=2)
-        env = TransformedEnv(ContinuousActionVecMockEnv(), burn_in_transform)
-        check_env_specs(env)
-        env.close()
+        with pytest.raises(
+                RuntimeError,
+                match="BurnInTransform can only be appended to a ReplayBuffer.",
+        ):
+            env = TransformedEnv(ContinuousActionVecMockEnv(), burn_in_transform)
+            check_env_specs(env)
+            env.close()
 
     def test_serial_trans_env_check(self):
         raise pytest.skip(

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -9407,9 +9407,14 @@ class TestBurnInTransform(TransformBase):
         return batch
 
     def test_single_trans_env_check(self):
-        raise pytest.skip(
-            "BurnInTransform can only be appended to a ReplayBuffer, not to a TransformedEnv."
-        )
+        # raise pytest.skip(
+        #         "BurnInTransform can only be appended to a ReplayBuffer, not to a TransformedEnv."
+        #     )
+        module = self._make_gru_module()
+        burn_in_transform = BurnInTransform(module, burn_in=2)
+        env = TransformedEnv(ContinuousActionVecMockEnv(), burn_in_transform)
+        check_env_specs(env)
+        env.close()
 
     def test_serial_trans_env_check(self):
         raise pytest.skip(

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -9384,7 +9384,7 @@ class TestBurnInTransform(TransformBase):
             hidden_size=hidden_size,
             batch_first=True,
             in_keys=["observation", "rhs_h", "rhs_c", "is_init"],
-            out_keys=["output", ("next", "rs_h"), ("next", "rs_c")],
+            out_keys=["output", ("next", "rhs_h"), ("next", "rhs_c")],
             device=device,
         ).set_recurrent_mode(True)
 
@@ -9455,7 +9455,7 @@ class TestBurnInTransform(TransformBase):
             hidden = torch.zeros(
                 data.batch_size + (module.gru.num_layers, module.gru.hidden_size)
             )
-            data.set("hidden", hidden)
+            data.set("rhs", hidden)
         else:
             module = self._make_lstm_module()
             hidden_h = torch.zeros(
@@ -9464,15 +9464,15 @@ class TestBurnInTransform(TransformBase):
             hidden_c = torch.zeros(
                 data.batch_size + (module.lstm.num_layers, module.lstm.hidden_size)
             )
-            data.set("hidden_h", hidden_h)
-            data.set("hidden_c", hidden_c)
+            data.set("rhs_h", hidden_h)
+            data.set("rhs_c", hidden_c)
 
         burn_in_compose = Compose(BurnInTransform(module, burn_in=burn_in))
         data = burn_in_compose(data)
         assert data.shape[-1] == sequence_length - burn_in
 
         for key in data.keys():
-            if key.startswith("hidden"):
+            if key.startswith("rhs"):
                 assert data[:, 0].get(key).abs().sum() > 0.0
                 assert data[:, 1:].get(key).sum() == 0.0
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -9374,7 +9374,7 @@ class TestBurnInTransform(TransformBase):
             hidden_size=hidden_size,
             batch_first=True,
             in_keys=["observation", "rhs", "is_init"],
-            out_keys=["output", ("next", "hidden")],
+            out_keys=["output", ("next", "rhs")],
             device=device,
         ).set_recurrent_mode(True)
 
@@ -9407,7 +9407,7 @@ class TestBurnInTransform(TransformBase):
         return batch
 
     @abc.abstractmethod
-    def test_single_trans_env_check(self, module):
+    def test_single_trans_env_check(self):
         """tests that a transformed env passes the check_env_specs test.
 
         If your transform can overwrite a key or create a new entry in the tensordict,

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -9410,8 +9410,8 @@ class TestBurnInTransform(TransformBase):
         module = self._make_gru_module()
         burn_in_transform = BurnInTransform(module, burn_in=2)
         with pytest.raises(
-                RuntimeError,
-                match="BurnInTransform can only be appended to a ReplayBuffer.",
+            RuntimeError,
+            match="BurnInTransform can only be appended to a ReplayBuffer.",
         ):
             env = TransformedEnv(ContinuousActionVecMockEnv(), burn_in_transform)
             check_env_specs(env)

--- a/torchrl/envs/__init__.py
+++ b/torchrl/envs/__init__.py
@@ -38,6 +38,7 @@ from .model_based import ModelBasedEnvBase
 from .transforms import (
     ActionMask,
     BinarizeReward,
+    BurnInTransform,
     CatFrames,
     CatTensors,
     CenterCrop,
@@ -84,7 +85,6 @@ from .transforms import (
     VecNorm,
     VIPRewardTransform,
     VIPTransform,
-    BurnInTransform,
 )
 from .utils import (
     check_env_specs,

--- a/torchrl/envs/__init__.py
+++ b/torchrl/envs/__init__.py
@@ -84,6 +84,7 @@ from .transforms import (
     VecNorm,
     VIPRewardTransform,
     VIPTransform,
+    BurnInTransform,
 )
 from .utils import (
     check_env_specs,

--- a/torchrl/envs/transforms/__init__.py
+++ b/torchrl/envs/transforms/__init__.py
@@ -49,6 +49,7 @@ from .transforms import (
     UnsqueezeTransform,
     VecGymEnvTransform,
     VecNorm,
+    BurnInTransform,
 )
 from .vc1 import VC1Transform
 from .vip import VIPRewardTransform, VIPTransform

--- a/torchrl/envs/transforms/__init__.py
+++ b/torchrl/envs/transforms/__init__.py
@@ -9,6 +9,7 @@ from .rlhf import KLRewardTransform
 from .transforms import (
     ActionMask,
     BinarizeReward,
+    BurnInTransform,
     CatFrames,
     CatTensors,
     CenterCrop,
@@ -49,7 +50,6 @@ from .transforms import (
     UnsqueezeTransform,
     VecGymEnvTransform,
     VecNorm,
-    BurnInTransform,
 )
 from .vc1 import VC1Transform
 from .vip import VIPRewardTransform, VIPTransform

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -19,7 +19,7 @@ import torch
 
 from tensordict import unravel_key, unravel_key_list
 from tensordict._tensordict import _unravel_key_to_tuple
-from tensordict.nn import dispatch
+from tensordict.nn import dispatch, TensorDictModuleBase
 from tensordict.tensordict import TensorDict, TensorDictBase
 from tensordict.utils import expand_as_right, NestedKey
 from torch import nn, Tensor
@@ -6623,10 +6623,10 @@ class BurnInTransform(Transform):
     invertible = False
 
     def __init__(
-            self,
-            modules: Sequence[TensorDictModuleBase],
-            burn_in: int,
-            out_keys: Sequence[NestedKey] | None = None,
+        self,
+        modules: Sequence[TensorDictModuleBase],
+        burn_in: int,
+        out_keys: Sequence[NestedKey] | None = None,
     ):
         self.modules = modules
         self.burn_in = burn_in
@@ -6658,7 +6658,7 @@ class BurnInTransform(Transform):
         )
 
     def _step(
-            self, tensordict: TensorDictBase, next_tensordict: TensorDictBase
+        self, tensordict: TensorDictBase, next_tensordict: TensorDictBase
     ) -> TensorDictBase:
         raise RuntimeError(
             "BurnInTransform can only be used when appended to a ReplayBuffer."

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -6681,7 +6681,7 @@ class BurnInTransform(Transform):
 
         # Update out TensorDict with the burnt-in data.
         for out_key in self.out_keys:
-            if out_key not in td_out.keys():
+            if out_key not in td_out.keys(include_nested=True):
                 td_out.set(
                     out_key,
                     torch.zeros(

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -6634,7 +6634,7 @@ class BurnInTransform(Transform):
         for module in modules:
             if not isinstance(module, TensorDictModuleBase):
                 raise ValueError(
-                    f"All modules must be TensorDictModules, not {type(module)}."
+                    f"All modules must be TensorDictModules, but a {type(module)} was provided."
                 )
 
         in_keys = set()

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -6631,27 +6631,26 @@ class BurnInTransform(Transform):
         if not isinstance(modules, Sequence):
             modules = [modules]
 
-        self.modules = modules
-        self.burn_in = burn_in
-
-        for module in self.modules:
+        for module in modules:
             if not isinstance(module, TensorDictModuleBase):
                 raise ValueError(
                     f"All modules must be TensorDictModules, not {type(module)}."
                 )
 
         in_keys = set()
-        for module in self.modules:
+        for module in modules:
             in_keys.update(module.in_keys)
 
         if out_keys is None:
             out_keys = set()
-            for module in self.modules:
+            for module in modules:
                 for key in module.out_keys:
                     if key[0] == "next":
                         out_keys.add(key[1])
 
         super().__init__(in_keys=in_keys, out_keys=out_keys)
+        self.modules = modules
+        self.burn_in = burn_in
 
     def _call(self, tensordict: TensorDictBase) -> TensorDictBase:
         raise RuntimeError(

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -6552,3 +6552,150 @@ class VecGymEnvTransform(Transform):
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         raise RuntimeError(FORWARD_NOT_IMPLEMENTED.format(type(self)))
+
+
+class BurnInTransform(Transform):
+    """Transform to partially burn-in data sequences.
+
+    This transform is useful to obtain up-to-date recurrent states when
+    they are not available. It burns-in a number of steps along the time dimension
+    from sampled sequential data slices and returs the remaining data sequence with
+    the burnt in data in its initial time step. It is intended to be used as a
+    replay buffer transform, not as an environment transform.
+
+    Args:
+        modules (sequence of TensorDictModule): A list of modules to burn in.
+        burn_in (int): The number of time steps to burn in.
+        out_keys (sequence of NestedKey, optional): destination keys. defaults to
+        all the modules out keys that point to the next time step (e.g. ("next", "hidden")).
+
+    .. note::
+        This transform expects TensorDicts with its last dimension being the
+        time dimension. It also  assumes that all provided modules can process
+        sequential data.
+
+    Examples:
+        >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from torchrl.envs.transforms import BurnInTransform
+        >>> from torchrl.modules import GRUModule
+
+        >>> gru_module = GRUModule(
+        ...     input_size=10,
+        ...     hidden_size=10,
+        ...     in_keys=["observation", "hidden"],
+        ...     out_keys=["intermediate", ("next", "hidden")],
+        ... ).set_recurrent_mode(True)
+        >>> burn_in_transform = BurnInTransform(
+        ...     modules=[gru_module],
+        ...     burn_in=5,
+        ... )
+        >>> td = TensorDict({
+        ...     "observation": torch.randn(2, 10, 10),
+        ...      "hidden": torch.randn(2, 10, gru_module.gru.num_layers, 10),
+        ...      "is_init": torch.zeros(2, 10, 1),
+        ... }, batch_size=[2, 10])
+        >>> td = burn_in_transform(td)
+        >>> td.shape
+        torch.Size([2, 5])
+        >>> td.get("hidden").abs().sum()
+        tensor(86.3008)
+
+        >>> from torchrl.data import LazyMemmapStorage, TensorDictReplayBuffer
+        >>> buffer = TensorDictReplayBuffer(
+        ...     storage=LazyMemmapStorage(2),
+        ...     batch_size=1,
+        ... )
+        >>> buffer.append_transform(burn_in_transform)
+        >>> td = TensorDict({
+        ...     "observation": torch.randn(2, 10, 10),
+        ...      "hidden": torch.randn(2, 10, gru_module.gru.num_layers, 10),
+        ...      "is_init": torch.zeros(2, 10, 1),
+        ... }, batch_size=[2, 10])
+        >>> buffer.extend(td)
+        >>> td = buffer.sample(1)
+        >>> td.shape
+        torch.Size([1, 5])
+        >>> td.get("hidden").abs().sum()
+        tensor(37.0344)
+    """
+
+    invertible = False
+
+    def __init__(
+            self,
+            modules: Sequence[TensorDictModuleBase],
+            burn_in: int,
+            out_keys: Sequence[NestedKey] | None = None,
+    ):
+        self.modules = modules
+        self.burn_in = burn_in
+
+        if not isinstance(modules, Sequence):
+            self.modules = [modules]
+        for module in self.modules:
+            if not isinstance(module, TensorDictModuleBase):
+                raise ValueError(
+                    f"All modules must be TensorDictModules, not {type(module)}."
+                )
+
+        in_keys = set()
+        for module in self.modules:
+            in_keys.update(module.in_keys)
+
+        if out_keys is None:
+            out_keys = set()
+            for module in self.modules:
+                for key in module.out_keys:
+                    if key[0] == "next":
+                        out_keys.add(key[1])
+
+        super().__init__(in_keys=in_keys, out_keys=out_keys)
+
+    def _call(self, tensordict: TensorDictBase) -> TensorDictBase:
+        raise RuntimeError(
+            "BurnInTransform can only be used when appended to a ReplayBuffer."
+        )
+
+    def _step(
+            self, tensordict: TensorDictBase, next_tensordict: TensorDictBase
+    ) -> TensorDictBase:
+        raise RuntimeError(
+            "BurnInTransform can only be used when appended to a ReplayBuffer."
+        )
+
+    def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
+
+        if self.burn_in == 0:
+            return tensordict
+
+        td_device = tensordict.device or "cpu"
+        B, T, *extra_dims = tensordict.batch_size
+
+        # Split the tensor dict into the burn in and the rest.
+        td_burn_in = tensordict[..., : self.burn_in]
+        td_out = tensordict[..., self.burn_in :]
+
+        # Burn in the recurrent state.
+        with torch.no_grad():
+            for module in self.modules:
+                module_device = next(module.parameters()).device or "cpu"
+                td_burn_in = td_burn_in.to(module_device)
+                td_burn_in = module(td_burn_in)
+        td_burn_in = td_burn_in.to(td_device)
+
+        # Update out TensorDict with the burnt in data.
+        for out_key in self.out_keys:
+            if out_key not in td_out.keys():
+                td_out.set(
+                    out_key,
+                    torch.zeros(
+                        B, T - self.burn_in, *tensordict.get(out_key).shape[2:]
+                    ),
+                )
+            td_out[..., 0][out_key].copy_(td_burn_in["next"][..., -1][out_key])
+
+        return td_out
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(burn_in={self.burn_in}, in_keys={self.in_keys}, out_keys={self.out_keys})"

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -6566,8 +6566,8 @@ class BurnInTransform(Transform):
     Args:
         modules (sequence of TensorDictModule): A list of modules used to burn-in data sequences.
         burn_in (int): The number of time steps to burn in.
-        out_keys (sequence of NestedKey, optional): destination keys. defaults to
-        all the modules out keys that point to the next time step (e.g. ("next", "hidden")).
+        out_keys (sequence of NestedKey, optional): destination keys. Defaults to
+            all the modules `out_keys` that point to the next time step (e.g. `("next", "hidden")`).
 
     .. note::
         This transform expects as inputs TensorDicts with its last dimension being the

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -6579,7 +6579,6 @@ class BurnInTransform(Transform):
         >>> from tensordict import TensorDict
         >>> from torchrl.envs.transforms import BurnInTransform
         >>> from torchrl.modules import GRUModule
-
         >>> gru_module = GRUModule(
         ...     input_size=10,
         ...     hidden_size=10,

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -6674,7 +6674,7 @@ class BurnInTransform(Transform):
         # Burn in the recurrent state.
         with torch.no_grad():
             for module in self.modules:
-                module_device = next(module.parameters()).device or "cpu"
+                module_device = next(module.parameters()).device or None
                 td_burn_in = td_burn_in.to(module_device)
                 td_burn_in = module(td_burn_in)
         td_burn_in = td_burn_in.to(td_device)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -6653,16 +6653,12 @@ class BurnInTransform(Transform):
         self.burn_in = burn_in
 
     def _call(self, tensordict: TensorDictBase) -> TensorDictBase:
-        raise RuntimeError(
-            "BurnInTransform can only be used when appended to a ReplayBuffer."
-        )
+        raise RuntimeError("BurnInTransform can only be appended to a ReplayBuffer")
 
     def _step(
         self, tensordict: TensorDictBase, next_tensordict: TensorDictBase
     ) -> TensorDictBase:
-        raise RuntimeError(
-            "BurnInTransform can only be used when appended to a ReplayBuffer."
-        )
+        raise RuntimeError("BurnInTransform can only be appended to a ReplayBuffer.")
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
 

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -6664,7 +6664,7 @@ class BurnInTransform(Transform):
         if self.burn_in == 0:
             return tensordict
 
-        td_device = tensordict.device or "cpu"
+        td_device = tensordict.device
         B, T, *extra_dims = tensordict.batch_size
 
         # Split the tensor dict into burn-in data and the rest.

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -6628,11 +6628,12 @@ class BurnInTransform(Transform):
         burn_in: int,
         out_keys: Sequence[NestedKey] | None = None,
     ):
+        if not isinstance(modules, Sequence):
+            modules = [modules]
+
         self.modules = modules
         self.burn_in = burn_in
 
-        if not isinstance(modules, Sequence):
-            self.modules = [modules]
         for module in self.modules:
             if not isinstance(module, TensorDictModuleBase):
                 raise ValueError(

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -6564,13 +6564,13 @@ class BurnInTransform(Transform):
     replay buffer transform, not as an environment transform.
 
     Args:
-        modules (sequence of TensorDictModule): A list of modules to burn in.
+        modules (sequence of TensorDictModule): A list of modules used to burn-in data sequences.
         burn_in (int): The number of time steps to burn in.
         out_keys (sequence of NestedKey, optional): destination keys. defaults to
         all the modules out keys that point to the next time step (e.g. ("next", "hidden")).
 
     .. note::
-        This transform expects TensorDicts with its last dimension being the
+        This transform expects as inputs TensorDicts with its last dimension being the
         time dimension. It also  assumes that all provided modules can process
         sequential data.
 
@@ -6668,7 +6668,7 @@ class BurnInTransform(Transform):
         td_device = tensordict.device or "cpu"
         B, T, *extra_dims = tensordict.batch_size
 
-        # Split the tensor dict into the burn in and the rest.
+        # Split the tensor dict into burn-in data and the rest.
         td_burn_in = tensordict[..., : self.burn_in]
         td_out = tensordict[..., self.burn_in :]
 
@@ -6680,7 +6680,7 @@ class BurnInTransform(Transform):
                 td_burn_in = module(td_burn_in)
         td_burn_in = td_burn_in.to(td_device)
 
-        # Update out TensorDict with the burnt in data.
+        # Update out TensorDict with the burnt-in data.
         for out_key in self.out_keys:
             if out_key not in td_out.keys():
                 td_out.set(


### PR DESCRIPTION
## Description

Transform to partially burn-in data sequences. 

This transform is useful to obtain up-to-date recurrent states when they are not available. It burns-in a number of steps along the time dimension from sampled sequential data slices and returns the remaining data sequence with the burnt in data in its initial time step.

As an example, this transform can be used with off-policy RL algorithms when the models are RNN's.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
