### PR TITLE
[BugFix] Fix sampling of last item in SliceSampler

### DIFF
--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -760,7 +760,7 @@ class SliceSampler(Sampler):
         relative_starts = (
             (
                 torch.rand(num_slices, device=lengths.device)
-                * (lengths[traj_idx] - seq_length)
+                * (lengths[traj_idx] - seq_length + 1)
             )
             .floor()
             .to(start_idx.dtype)


### PR DESCRIPTION
Fixed a bug reported [here](https://github.com/pytorch/rl/pull/1762#issuecomment-1880177757) where it was pointed that the last item of a trajectory was always missed by SliceSampler.

This was due to sampling the start item of the trajectory according to `floor((traj_len - sample_len) * rand()) + start_idx` instead of `floor((traj_len - sample_len + 1) * rand()) + start_idx`. To see why the second is right and first wrong, one can thing of a trajectory of `traj_len=2`, `sample_len=1` and `start_idx=0`. It is clear that the first will only sample a start index of `0` and never `1`.

cc @nicklashansen @dasGringuen