### PR TITLE
[BugFix] Writers extend() method should always return indices in data.device 

### DIFF
--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -373,6 +373,7 @@ class PrioritizedSampler(Sampler):
         super().extend(index)
         if index is not None:
             # some writers don't systematically write data and can return None
+            index = index.cpu()
             self._add_or_extend(index)
 
     def update_priority(

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -312,7 +312,7 @@ class TensorDictMaxValueWriter(Writer):
                 index[values] = keys
                 data.set("index", index)
             self._storage.set(keys, data[values])
-            return keys.long()
+            return keys.long().cpu()
         return None
 
     def _empty(self) -> None:

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -118,7 +118,12 @@ class RoundRobinWriter(Writer):
     def extend(self, data: Sequence) -> torch.Tensor:
         cur_size = self._cursor
         batch_size = len(data)
-        index = np.arange(cur_size, batch_size + cur_size) % self._storage.max_size
+        index = (
+            torch.arange(
+                cur_size, batch_size + cur_size, dtype=torch.long, device=data.device
+            )
+            % self._storage.max_size
+        )
         # we need to update the cursor first to avoid race conditions between workers
         self._cursor = (batch_size + cur_size) % self._storage.max_size
         self._storage[index] = data
@@ -177,7 +182,12 @@ class TensorDictRoundRobinWriter(RoundRobinWriter):
     def extend(self, data: Sequence) -> torch.Tensor:
         cur_size = self._cursor
         batch_size = len(data)
-        index = np.arange(cur_size, batch_size + cur_size) % self._storage.max_size
+        index = (
+            torch.arange(
+                cur_size, batch_size + cur_size, dtype=torch.long, device=data.device
+            )
+            % self._storage.max_size
+        )
         # we need to update the cursor first to avoid race conditions between workers
         self._cursor = (batch_size + cur_size) % self._storage.max_size
         # storage must convert the data to the appropriate format if needed
@@ -312,7 +322,7 @@ class TensorDictMaxValueWriter(Writer):
                 index[values] = keys
                 data.set("index", index)
             self._storage.set(keys, data[values])
-            return keys.long().cpu()
+            return keys.long()
         return None
 
     def _empty(self) -> None:

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -118,9 +118,10 @@ class RoundRobinWriter(Writer):
     def extend(self, data: Sequence) -> torch.Tensor:
         cur_size = self._cursor
         batch_size = len(data)
+        device = data.device if hasattr(data, "device") else None
         index = (
             torch.arange(
-                cur_size, batch_size + cur_size, dtype=torch.long, device=data.device
+                cur_size, batch_size + cur_size, dtype=torch.long, device=device
             )
             % self._storage.max_size
         )
@@ -182,9 +183,10 @@ class TensorDictRoundRobinWriter(RoundRobinWriter):
     def extend(self, data: Sequence) -> torch.Tensor:
         cur_size = self._cursor
         batch_size = len(data)
+        device = data.device if hasattr(data, "device") else None
         index = (
             torch.arange(
-                cur_size, batch_size + cur_size, dtype=torch.long, device=data.device
+                cur_size, batch_size + cur_size, dtype=torch.long, device=device
             )
             % self._storage.max_size
         )


### PR DESCRIPTION
## Description

This PR replaces the numpy indices returned by data writers with tensor indices in the correspondent device.
It also makes sure that PrioritizedSampler moves received indices to cpu to avoid segmentation fault.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
