### PR TITLE
[BugFix] Ensure that infos and samples have the same batch-size in SamplerEnsemble

### DIFF
--- a/torchrl/data/datasets/openx.py
+++ b/torchrl/data/datasets/openx.py
@@ -572,10 +572,12 @@ class _StreamingStorage(Storage):
             else:
                 yield data
 
-    def get(self, index: int) -> Any:
+    def get(self, index: range) -> Any:
         if not isinstance(index, range):
-            # we use a range to indicate how much data we want
-            raise RuntimeError("iterable datasets do not support indexing.")
+            if (index[1:] != index[:-1] + 1).any():
+                # we use a range to indicate how much data we want
+                raise RuntimeError("iterable datasets do not support indexing.")
+            index = range(index.shape[0])
         total = 0
         data_list = []
         episode = 0

--- a/torchrl/data/datasets/openx.py
+++ b/torchrl/data/datasets/openx.py
@@ -572,7 +572,7 @@ class _StreamingStorage(Storage):
             else:
                 yield data
 
-    def get(self, index: range) -> Any:
+    def get(self, index: range | torch.Tensor) -> Any:
         if not isinstance(index, range):
             if (index[1:] != index[:-1] + 1).any():
                 # we use a range to indicate how much data we want

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -1102,6 +1102,10 @@ class SamplerEnsemble(Sampler):
                     for i in buffer_ids.tolist()
                 ]
             )
+        samples = [
+            sample if isinstance(sample, torch.Tensor) else torch.tensor(sample)
+            for sample in samples
+        ]
         if all(samples[0].shape == sample.shape for sample in samples[1:]):
             samples_stack = torch.stack(samples)
         else:
@@ -1116,7 +1120,9 @@ class SamplerEnsemble(Sampler):
         )
         infos = torch.stack(
             [
-                TensorDict.from_dict(info) if info else TensorDict({}, [])
+                TensorDict.from_dict(info, batch_dims=samples.ndim - 1)
+                if info
+                else TensorDict({}, [])
                 for info in infos
             ]
         )


### PR DESCRIPTION
Solves a bug where `from_dict` was allocating the max batch-size to the info tensordict in the SamplerEnsemble.

cc @nicklashansen