### PR TITLE
[Feature] Extend MaxValueWriter with reduce parameter for the rank_key

### DIFF
--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -1492,7 +1492,7 @@ class TestMaxValueWriter:
         )
 
         key = torch.rand(batch_size, *size)
-        obs = torch.rand(batch_size)
+        obs = torch.rand(batch_size, *size)
         td = TensorDict(
             {"key": key, "obs": obs},
             batch_size=batch_size,

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -53,6 +53,7 @@ from torchrl.data.replay_buffers.writers import (
     WriterEnsemble,
 )
 from torchrl.data.utils import DEVICE_TYPING
+from torchrl.data.replay_buffers.utils import _reduce
 
 
 class ReplayBuffer:
@@ -1091,25 +1092,6 @@ class InPlaceSampler:
         else:
             torch.stack(list_of_tds, 0, out=self.out)
         return self.out
-
-
-def _reduce(
-    tensor: torch.Tensor, reduction: str, dim: int | None = None
-) -> Union[float, torch.Tensor]:
-    """Reduces a tensor given the reduction method."""
-    if reduction == "max":
-        result = tensor.max(dim=dim)
-    elif reduction == "min":
-        result = tensor.min(dim=dim)
-    elif reduction == "mean":
-        result = tensor.mean(dim=dim)
-    elif reduction == "median":
-        result = tensor.median(dim=dim)
-    else:
-        raise NotImplementedError(f"Unknown reduction method {reduction}")
-    if isinstance(result, tuple):
-        result = result[0]
-    return result.item() if dim is None else result
 
 
 def stack_tensors(list_of_tensor_iterators: List) -> Tuple[torch.Tensor]:

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -53,7 +53,6 @@ from torchrl.data.replay_buffers.writers import (
     WriterEnsemble,
 )
 from torchrl.data.utils import DEVICE_TYPING
-from torchrl.data.replay_buffers.utils import _reduce
 
 
 class ReplayBuffer:
@@ -1092,6 +1091,25 @@ class InPlaceSampler:
         else:
             torch.stack(list_of_tds, 0, out=self.out)
         return self.out
+
+
+def _reduce(
+    tensor: torch.Tensor, reduction: str, dim: int | None = None
+) -> Union[float, torch.Tensor]:
+    """Reduces a tensor given the reduction method."""
+    if reduction == "max":
+        result = tensor.max(dim=dim)
+    elif reduction == "min":
+        result = tensor.min(dim=dim)
+    elif reduction == "mean":
+        result = tensor.mean(dim=dim)
+    elif reduction == "median":
+        result = tensor.median(dim=dim)
+    else:
+        raise NotImplementedError(f"Unknown reduction method {reduction}")
+    if isinstance(result, tuple):
+        result = result[0]
+    return result.item() if dim is None else result
 
 
 def stack_tensors(list_of_tensor_iterators: List) -> Tuple[torch.Tensor]:

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -41,6 +41,7 @@ from torchrl.data.replay_buffers.storages import (
     StorageEnsemble,
 )
 from torchrl.data.replay_buffers.utils import (
+    _reduce,
     _to_numpy,
     _to_torch,
     INT_CLASSES,
@@ -1091,25 +1092,6 @@ class InPlaceSampler:
         else:
             torch.stack(list_of_tds, 0, out=self.out)
         return self.out
-
-
-def _reduce(
-    tensor: torch.Tensor, reduction: str, dim: int | None = None
-) -> Union[float, torch.Tensor]:
-    """Reduces a tensor given the reduction method."""
-    if reduction == "max":
-        result = tensor.max(dim=dim)
-    elif reduction == "min":
-        result = tensor.min(dim=dim)
-    elif reduction == "mean":
-        result = tensor.mean(dim=dim)
-    elif reduction == "median":
-        result = tensor.median(dim=dim)
-    else:
-        raise NotImplementedError(f"Unknown reduction method {reduction}")
-    if isinstance(result, tuple):
-        result = result[0]
-    return result.item() if dim is None else result
 
 
 def stack_tensors(list_of_tensor_iterators: List) -> Tuple[torch.Tensor]:

--- a/torchrl/data/replay_buffers/utils.py
+++ b/torchrl/data/replay_buffers/utils.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 # import tree
+from __future__ import annotations
 import typing
 from typing import Any, Callable, Union
 
@@ -64,3 +65,22 @@ def _pin_memory(output: Any) -> Any:
         return output.pin_memory()
     else:
         return output
+
+
+def _reduce(
+        tensor: torch.Tensor, reduction: str, dim: int | None = None
+) -> Union[float, torch.Tensor]:
+    """Reduces a tensor given the reduction method."""
+    if reduction == "max":
+        result = tensor.max(dim=dim)
+    elif reduction == "min":
+        result = tensor.min(dim=dim)
+    elif reduction == "mean":
+        result = tensor.mean(dim=dim)
+    elif reduction == "median":
+        result = tensor.median(dim=dim)
+    else:
+        raise NotImplementedError(f"Unknown reduction method {reduction}")
+    if isinstance(result, tuple):
+        result = result[0]
+    return result.item() if dim is None else result

--- a/torchrl/data/replay_buffers/utils.py
+++ b/torchrl/data/replay_buffers/utils.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 # import tree
-from __future__ import annotations
 import typing
 from typing import Any, Callable, Union
 
@@ -65,22 +64,3 @@ def _pin_memory(output: Any) -> Any:
         return output.pin_memory()
     else:
         return output
-
-
-def _reduce(
-        tensor: torch.Tensor, reduction: str, dim: int | None = None
-) -> Union[float, torch.Tensor]:
-    """Reduces a tensor given the reduction method."""
-    if reduction == "max":
-        result = tensor.max(dim=dim)
-    elif reduction == "min":
-        result = tensor.min(dim=dim)
-    elif reduction == "mean":
-        result = tensor.mean(dim=dim)
-    elif reduction == "median":
-        result = tensor.median(dim=dim)
-    else:
-        raise NotImplementedError(f"Unknown reduction method {reduction}")
-    if isinstance(result, tuple):
-        result = result[0]
-    return result.item() if dim is None else result

--- a/torchrl/data/replay_buffers/utils.py
+++ b/torchrl/data/replay_buffers/utils.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 # import tree
+from __future__ import annotations
+
 import typing
 from typing import Any, Callable, Union
 
@@ -64,3 +66,24 @@ def _pin_memory(output: Any) -> Any:
         return output.pin_memory()
     else:
         return output
+
+
+def _reduce(
+    tensor: torch.Tensor, reduction: str, dim: int | None = None
+) -> Union[float, torch.Tensor]:
+    """Reduces a tensor given the reduction method."""
+    if reduction == "max":
+        result = tensor.max(dim=dim)
+    elif reduction == "min":
+        result = tensor.min(dim=dim)
+    elif reduction == "mean":
+        result = tensor.mean(dim=dim)
+    elif reduction == "median":
+        result = tensor.median(dim=dim)
+    elif reduction == "sum":
+        result = tensor.sum(dim=dim)
+    else:
+        raise NotImplementedError(f"Unknown reduction method {reduction}")
+    if isinstance(result, tuple):
+        result = result[0]
+    return result.item() if dim is None else result

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -268,7 +268,7 @@ class TensorDictMaxValueWriter(Writer):
         # If time dimension, sum along it.
         if rank_data.numel() > 1:
             rank_data = rank_data.reshape(rank_data.shape[0], -1)
-            rank_data = _reduce(rank_data, self._reduction)
+            rank_data = _reduce(rank_data, self._reduction, dim=1)
         else:
             rank_data = rank_data.item()
 

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -297,7 +297,7 @@ class TensorDictMaxValueWriter(Writer):
     def add(self, data: Any) -> int:
         """Inserts a single element of data at an appropriate index, and returns that index.
 
-        The ``rank_key`` in the data passed to this module should be structured as :obj:`[]`.
+        The ``rank_key`` in the data passed to this module should be structured as [].
         If it has more dimensions, it will be reduced to a single value using the ``reduction`` method.
         """
         index = self.get_insert_index(data)
@@ -309,7 +309,7 @@ class TensorDictMaxValueWriter(Writer):
     def extend(self, data: Sequence) -> None:
         """Inserts a series of data points at appropriate indices.
 
-        The ``rank_key`` in the data passed to this module should be structured as :obj:`[B]`.
+        The ``rank_key`` in the data passed to this module should be structured as [B].
         If it has more dimensions, it will be reduced to a single value using the ``reduction`` method.
         """
         data_to_replace = {}

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -267,8 +267,7 @@ class TensorDictMaxValueWriter(Writer):
 
         # If time dimension, sum along it.
         if rank_data.numel() > 1:
-            rank_data = rank_data.reshape(rank_data.shape[0], -1)
-            rank_data = _reduce(rank_data, self._reduction, dim=1)
+            rank_data = _reduce(rank_data.reshape(-1), self._reduction, dim=0)
         else:
             rank_data = rank_data.item()
 

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -205,7 +205,7 @@ class TensorDictMaxValueWriter(Writer):
     Args:
         rank_key (str or tuple of str): the key to rank the elements by. Defaults to ``("next", "reward")``.
         reduction (str): the reduction method to use if the rank key has more than one element.
-            Can be ``"max"``, ``"min"``, ``"mean"`` or ``"sum"``.
+            Can be ``"max"``, ``"min"``, ``"mean"``, ``"median"`` or ``"sum"``.
 
     Examples:
     >>> import torch


### PR DESCRIPTION
## Description

The current version of the MaxValueWriter only allows to reduce the `rank_key` by summing along the last dimension.
In a similar fashion to the PrioritizedSampler, this PR introduces a `reduce` parameter so that users have more control about how the `rank_key` will be handled when it has more that 1 dimension. Options are: max, min, mean, median and sum.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
