### PR TITLE
[BugFix] Make `TransformedEnv` mirror `allow_done_after_reset` property of base env

### DIFF
--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -111,7 +111,7 @@ class _MockEnv(EnvBase):
         super().__init__(
             device=kwargs.pop("device", "cpu"),
             dtype=torch.get_default_dtype(),
-            **kwargs,
+            allow_done_after_reset=kwargs.pop("allow_done_after_reset", False),
         )
         self.set_seed(seed)
         self.is_closed = False

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -111,6 +111,7 @@ class _MockEnv(EnvBase):
         super().__init__(
             device=kwargs.pop("device", "cpu"),
             dtype=torch.get_default_dtype(),
+            **kwargs,
         )
         self.set_seed(seed)
         self.is_closed = False

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -7691,6 +7691,21 @@ class TestTransformedEnv:
         assert base_env.reward_spec.space.minimum == -np.inf
         assert base_env.reward_spec.space.maximum == np.inf
 
+    def test_allow_done_after_reset(self):
+        base_env = ContinuousActionVecMockEnv(allow_done_after_reset=True)
+        assert base_env.allow_done_after_reset
+        t1 = TransformedEnv(
+            base_env, transform=RewardClipping(clamp_min=0, clamp_max=4)
+        )
+        assert t1.allow_done_after_reset
+        with pytest.raises(
+            RuntimeError,
+            match="allow_done_after_reset is a read-only property for TransformedEnvs",
+        ):
+            t1.allow_done_after_reset = False
+        base_env.allow_done_after_reset = False
+        assert not t1.allow_done_after_reset
+
 
 def test_nested_transformed_env():
     base_env = ContinuousActionVecMockEnv()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -7693,18 +7693,18 @@ class TestTransformedEnv:
 
     def test_allow_done_after_reset(self):
         base_env = ContinuousActionVecMockEnv(allow_done_after_reset=True)
-        assert base_env.allow_done_after_reset
+        assert base_env._allow_done_after_reset
         t1 = TransformedEnv(
             base_env, transform=RewardClipping(clamp_min=0, clamp_max=4)
         )
-        assert t1.allow_done_after_reset
+        assert t1._allow_done_after_reset
         with pytest.raises(
             RuntimeError,
-            match="allow_done_after_reset is a read-only property for TransformedEnvs",
+            match="_allow_done_after_reset is a read-only property for TransformedEnvs",
         ):
-            t1.allow_done_after_reset = False
-        base_env.allow_done_after_reset = False
-        assert not t1.allow_done_after_reset
+            t1._allow_done_after_reset = False
+        base_env._allow_done_after_reset = False
+        assert not t1._allow_done_after_reset
 
 
 def test_nested_transformed_env():

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -335,6 +335,14 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
         self._run_type_checks = run_type_checks
 
     @property
+    def allow_done_after_reset(self) -> bool:
+        return self._allow_done_after_reset
+
+    @allow_done_after_reset.setter
+    def allow_done_after_reset(self, allow_done_after_reset: bool):
+        self._allow_done_after_reset = allow_done_after_reset
+
+    @property
     def batch_size(self) -> torch.Size:
         _batch_size = self.__dict__["_batch_size"]
         if _batch_size is None:
@@ -1522,7 +1530,7 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
             if reset_value is not None:
                 for done_key in done_key_group:
                     done_val = tensordict_reset.get(done_key)
-                    if done_val[reset_value].any() and not self._allow_done_after_reset:
+                    if done_val[reset_value].any() and not self.allow_done_after_reset:
                         raise RuntimeError(
                             f"Env done entry '{done_key}' was (partially) True after reset on specified '_reset' dimensions. This is not allowed."
                         )
@@ -1540,7 +1548,7 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
                         # we set the done val to tensordict, to make sure that
                         # _update_during_reset does not pad the value
                         tensordict.set(done_key, done_val)
-            elif not self._allow_done_after_reset:
+            elif not self.allow_done_after_reset:
                 for done_key in done_key_group:
                     if tensordict_reset.get(done_key).any():
                         raise RuntimeError(

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -335,14 +335,6 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
         self._run_type_checks = run_type_checks
 
     @property
-    def allow_done_after_reset(self) -> bool:
-        return self._allow_done_after_reset
-
-    @allow_done_after_reset.setter
-    def allow_done_after_reset(self, allow_done_after_reset: bool):
-        self._allow_done_after_reset = allow_done_after_reset
-
-    @property
     def batch_size(self) -> torch.Size:
         _batch_size = self.__dict__["_batch_size"]
         if _batch_size is None:
@@ -1530,7 +1522,7 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
             if reset_value is not None:
                 for done_key in done_key_group:
                     done_val = tensordict_reset.get(done_key)
-                    if done_val[reset_value].any() and not self.allow_done_after_reset:
+                    if done_val[reset_value].any() and not self._allow_done_after_reset:
                         raise RuntimeError(
                             f"Env done entry '{done_key}' was (partially) True after reset on specified '_reset' dimensions. This is not allowed."
                         )
@@ -1548,7 +1540,7 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
                         # we set the done val to tensordict, to make sure that
                         # _update_during_reset does not pad the value
                         tensordict.set(done_key, done_val)
-            elif not self.allow_done_after_reset:
+            elif not self._allow_done_after_reset:
                 for done_key in done_key_group:
                     if tensordict_reset.get(done_key).any():
                         raise RuntimeError(

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -572,7 +572,9 @@ class TransformedEnv(EnvBase, metaclass=_TEnvPostInit):
             env = env.to(device)
         else:
             device = env.device
-        super().__init__(device=None, **kwargs)
+        super().__init__(
+            device=None, allow_done_after_reset=env._allow_done_after_reset, **kwargs
+        )
 
         if isinstance(env, TransformedEnv):
             self._set_env(env.base_env, device)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -572,9 +572,7 @@ class TransformedEnv(EnvBase, metaclass=_TEnvPostInit):
             env = env.to(device)
         else:
             device = env.device
-        super().__init__(
-            device=None, allow_done_after_reset=env._allow_done_after_reset, **kwargs
-        )
+        super().__init__(device=None, **kwargs)
 
         if isinstance(env, TransformedEnv):
             self._set_env(env.base_env, device)
@@ -679,6 +677,16 @@ but got an object of type {type(transform)}."""
     def run_type_checks(self, value):
         raise RuntimeError(
             "run_type_checks is a read-only property for TransformedEnvs"
+        )
+
+    @property
+    def allow_done_after_reset(self) -> bool:
+        return self.base_env.allow_done_after_reset
+
+    @allow_done_after_reset.setter
+    def allow_done_after_reset(self, value):
+        raise RuntimeError(
+            "allow_done_after_reset is a read-only property for TransformedEnvs"
         )
 
     @property

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -572,7 +572,7 @@ class TransformedEnv(EnvBase, metaclass=_TEnvPostInit):
             env = env.to(device)
         else:
             device = env.device
-        super().__init__(device=None, **kwargs)
+        super().__init__(device=None, allow_done_after_reset=None, **kwargs)
 
         if isinstance(env, TransformedEnv):
             self._set_env(env.base_env, device)
@@ -680,13 +680,15 @@ but got an object of type {type(transform)}."""
         )
 
     @property
-    def allow_done_after_reset(self) -> bool:
-        return self.base_env.allow_done_after_reset
+    def _allow_done_after_reset(self) -> bool:
+        return self.base_env._allow_done_after_reset
 
-    @allow_done_after_reset.setter
-    def allow_done_after_reset(self, value):
+    @_allow_done_after_reset.setter
+    def _allow_done_after_reset(self, value):
+        if value is None:
+            return
         raise RuntimeError(
-            "allow_done_after_reset is a read-only property for TransformedEnvs"
+            "_allow_done_after_reset is a read-only property for TransformedEnvs"
         )
 
     @property


### PR DESCRIPTION
Fixes #1806

The context is:

Some enviornments can be done immediately after a reset (e.g., some agents can be still dead after a reset in multiagent settings).
TorchRL by default does not allow this and will throw an error.
If you, however, would like to allow your environment to be done after reset, you can set `allow_done_after_reset` during construction of your environment.
`PettingZoo` and `VMAS` need this.

However, in #1806, it is shown that when a transform is added to the environment, this attribute changes.

In this PR, we fix this, by making the attribute of transformend enviornments mirror the one of the base environment.