### PR TITLE
pyproject.toml: remove unknown properties

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,3 @@ first_party_detection = false
 
 [build-system]
 requires = ["setuptools", "wheel", "torch", "ninja"]
-
-first_party_detection = false
-
-target-version = ["py38"]
-
-excludes = [
-    "gallery",
-    "tutorials",
-]


### PR DESCRIPTION
## Description

Removes irrelevant (and invalid) fields in the `pyproject.toml` file (`excludes`, `target-version` and `first_party_detection`).

## Motivation and Context

When installing this package from the source, I get the following error:
```
ERROR Failed to validate `build-system` in pyproject.toml: Unknown properties: excludes, target-version, first_party_detection
```
From my understanding, the following three tags are not meant to be under the `build-system` category.
