### PR TITLE
[Doc, Feature] Doc improvements for video recording and CSV video formats

### DIFF
--- a/.github/unittest/linux_olddeps/scripts_gym_0_13/environment.yml
+++ b/.github/unittest/linux_olddeps/scripts_gym_0_13/environment.yml
@@ -25,3 +25,4 @@ dependencies:
     - patchelf
     - pyopengl==3.1.4
     - ray<2.8.0
+    - av

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -130,9 +130,7 @@ class A2CLoss(LossModule):
     the expected keyword arguments are:
     ``["action", "next_reward", "next_done", "next_terminated"]`` + in_keys of the actor and critic.
     The return value is a tuple of tensors in the following order:
-    ``["loss_objective"]``
-        + ``["loss_critic"]`` if critic_coef is not None
-        + ``["entropy", "loss_entropy"]`` if entropy_bonus is True and critic_coef is not None
+    ``["loss_objective"]`` + ``["loss_critic"]`` if critic_coef is not None + ``["entropy", "loss_entropy"]`` if entropy_bonus is True and critic_coef is not None
 
     Examples:
         >>> import torch

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -178,8 +178,7 @@ class PPOLoss(LossModule):
     the expected keyword arguments are:
     ``["action", "sample_log_prob", "next_reward", "next_done", "next_terminated"]`` + in_keys of the actor and value network.
     The return value is a tuple of tensors in the following order:
-    ``["loss_objective"]`` + ``["entropy", "loss_entropy"]`` if entropy_bonus is set
-                           + ``"loss_critic"`` if critic_coef is not None.
+    ``["loss_objective"]`` + ``["entropy", "loss_entropy"]`` if entropy_bonus is set + ``"loss_critic"`` if critic_coef is not ``None``.
     The output keys can also be filtered using :meth:`PPOLoss.select_out_keys` method.
 
     Examples:

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -138,8 +138,7 @@ class REDQLoss(LossModule):
     the expected keyword arguments are:
     ``["action", "next_reward", "next_done", "next_terminated"]`` + in_keys of the actor and qvalue network
     The return value is a tuple of tensors in the following order:
-    ``["loss_actor", "loss_qvalue", "loss_alpha", "alpha", "entropy",
-        "state_action_value_actor", "action_log_prob_actor", "next.state_value", "target_value",]``.
+    ``["loss_actor", "loss_qvalue", "loss_alpha", "alpha", "entropy", "state_action_value_actor", "action_log_prob_actor", "next.state_value", "target_value",]``.
 
     Examples:
         >>> import torch

--- a/torchrl/record/loggers/tensorboard.py
+++ b/torchrl/record/loggers/tensorboard.py
@@ -20,7 +20,7 @@ class TensorboardLogger(Logger):
 
     Args:
         exp_name (str): The name of the experiment.
-        log_dir (str): the tensorboard log_dir.
+        log_dir (str): the tensorboard log_dir. Defaults to ``td_logs``.
 
     """
 

--- a/torchrl/record/loggers/wandb.py
+++ b/torchrl/record/loggers/wandb.py
@@ -19,8 +19,24 @@ _has_omegaconf = importlib.util.find_spec("omegaconf") is not None
 class WandbLogger(Logger):
     """Wrapper for the wandb logger.
 
+    The keyword arguments are mainly based on the :func:`wandb.init` kwargs.
+    See the doc `here <https://docs.wandb.ai/ref/python/init>`__.
+
     Args:
         exp_name (str): The name of the experiment.
+        offline (bool, optional): if ``True``, the logs will be stored locally
+            only. Defaults to ``False``.
+        save_dir (path, optional): the directory where to save data. Exclusive with
+            ``log_dir``.
+        log_dir (path, optional): the directory where to save data. Exclusive with
+            ``save_dir``.
+        id (str, optional): A unique ID for this run, used for resuming.
+            It must be unique in the project, and if you delete a run you can't reuse the ID.
+        project (str, optional): The name of the project where you're sending
+            the new run. If the project is not specified, the run is put in
+            an ``"Uncategorized"`` project.
+        **kwargs: Extra keyword arguments for ``wandb.init``. See relevant page for
+            more info.
 
     """
 

--- a/torchrl/record/recorder.py
+++ b/torchrl/record/recorder.py
@@ -44,24 +44,25 @@ class VideoRecorder(ObservationTransform):
         out_keys (sequence of NestedKey, optional): destination keys. Defaults
             to ``in_keys`` if not provided.
 
-    The following example shows how to save a rollout under a video. First a few imports:
+    Examples:
+        The following example shows how to save a rollout under a video. First a few imports:
         >>> from torchrl.record import VideoRecorder
         >>> from torchrl.record.loggers.csv import CSVLogger
         >>> from torchrl.envs import TransformedEnv, DMControlEnv
 
-    The video format is chosen in the logger. Wandb and tensorboard will take care of that
-    on their own, CSV accepts various video formats.
+        The video format is chosen in the logger. Wandb and tensorboard will take care of that
+        on their own, CSV accepts various video formats.
         >>> logger = CSVLogger(exp_name="cheetah", log_dir="cheetah_videos", video_format="mp4")
 
-    Some envs (eg, Atari games) natively return images, some require the user to ask for them.
-    Check :class:`~torchrl.env.GymEnv` or :class:`~torchrl.envs.DMControlEnv` to see how to render images
-    in these contexts.
+        Some envs (eg, Atari games) natively return images, some require the user to ask for them.
+        Check :class:`~torchrl.env.GymEnv` or :class:`~torchrl.envs.DMControlEnv` to see how to render images
+        in these contexts.
         >>> base_env = DMControlEnv("cheetah", "run", from_pixels=True)
         >>> env = TransformedEnv(base_env, VideoRecorder(logger=logger, tag="run_video"))
         >>> env.rollout(100)
 
-    All transforms have a dump function, mostly a no-op except for ``VideoRecorder``, and :class:`~torchrl.envs.transforms.Composite`
-    which will dispatch the `dumps` to all its members.
+        All transforms have a dump function, mostly a no-op except for ``VideoRecorder``, and :class:`~torchrl.envs.transforms.Composite`
+        which will dispatch the `dumps` to all its members.
         >>> env.transform.dump()
 
     Our video is available under ``./cheetah_videos/cheetah/videos/run_video_0.mp4``!

--- a/torchrl/record/recorder.py
+++ b/torchrl/record/recorder.py
@@ -30,7 +30,8 @@ class VideoRecorder(ObservationTransform):
 
     Args:
         logger (Logger): a Logger instance where the video
-            should be written.
+            should be written. To save the video under a memmap tensor or an mp4 file, use
+            the :class:`~torchrl.record.loggers.CSVLogger` class.
         tag (str): the video tag in the logger.
         in_keys (Sequence of NestedKey, optional): keys to be read to produce the video.
             Default is :obj:`"pixels"`.
@@ -42,6 +43,28 @@ class VideoRecorder(ObservationTransform):
             size. Default is True.
         out_keys (sequence of NestedKey, optional): destination keys. Defaults
             to ``in_keys`` if not provided.
+
+    The following example shows how to save a rollout under a video. First a few imports:
+        >>> from torchrl.record import VideoRecorder
+        >>> from torchrl.record.loggers.csv import CSVLogger
+        >>> from torchrl.envs import TransformedEnv, DMControlEnv
+
+    The video format is chosen in the logger. Wandb and tensorboard will take care of that
+    on their own, CSV accepts various video formats.
+        >>> logger = CSVLogger(exp_name="cheetah", log_dir="cheetah_videos", video_format="mp4")
+
+    Some envs (eg, Atari games) natively return images, some require the user to ask for them.
+    Check :class:`~torchrl.env.GymEnv` or :class:`~torchrl.envs.DMControlEnv` to see how to render images
+    in these contexts.
+        >>> base_env = DMControlEnv("cheetah", "run", from_pixels=True)
+        >>> env = TransformedEnv(base_env, VideoRecorder(logger=logger, tag="run_video"))
+        >>> env.rollout(100)
+
+    All transforms have a dump function, mostly a no-op except for ``VideoRecorder``, and :class:`~torchrl.envs.transforms.Composite`
+    which will dispatch the `dumps` to all its members.
+        >>> env.transform.dump()
+
+    Our video is available under ``./cheetah_videos/cheetah/videos/run_video_0.mp4``!
 
     """
 


### PR DESCRIPTION
closes #1400

cc @lucasbasquerotto @ADebor

In a previous PR I also [refined a lot the docstrings](https://github.com/pytorch/rl/pull/1787) of all the envs we have so all in all the situation should be much better now!

I added a bunch of options in CSVLogger to save videos in a more flexible way. 

The doc will be available here https://docs-preview.pytorch.org/pytorch/rl/1829/reference/generated/torchrl.record.VideoRecorder.html#torchrl.record.VideoRecorder