### PR TITLE
[Feature, BugFix] Better thread control in penv and collectors

### DIFF
--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -2101,8 +2101,8 @@ class TestLibThreading:
                 RandomPolicy(ContinuousActionVecMockEnv().full_action_spec),
             )
             for _ in collector:
+                assert torch.get_num_threads() == init_threads - 1
                 break
-            assert torch.get_num_threads() == init_threads - 1
             collector.shutdown()
             assert torch.get_num_threads() == init_threads
             collector = MultiSyncDataCollector(
@@ -2110,8 +2110,8 @@ class TestLibThreading:
                 RandomPolicy(ContinuousActionVecMockEnv().full_action_spec.expand(2)),
             )
             for _ in collector:
+                assert torch.get_num_threads() == init_threads - 2
                 break
-            assert torch.get_num_threads() == init_threads - 2
             collector.shutdown()
             assert torch.get_num_threads() == init_threads
         finally:

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -2095,25 +2095,27 @@ class TestLibThreading:
     )
     def test_auto_num_threads(self):
         init_threads = torch.get_num_threads()
-
-        collector = MultiSyncDataCollector(
-            [ContinuousActionVecMockEnv],
-            RandomPolicy(ContinuousActionVecMockEnv().action_spec),
-        )
-        for _ in collector:
-            break
-        assert torch.get_num_threads() == init_threads - 1
-        collector.shutdown()
-        assert torch.get_num_threads() == init_threads
-        collector = MultiSyncDataCollector(
-            [ParallelEnv(2, ContinuousActionVecMockEnv)],
-            RandomPolicy(ContinuousActionVecMockEnv().action_spec),
-        )
-        for _ in collector:
-            break
-        assert torch.get_num_threads() == init_threads - 2
-        collector.shutdown()
-        assert torch.get_num_threads() == init_threads
+        try:
+            collector = MultiSyncDataCollector(
+                [ContinuousActionVecMockEnv],
+                RandomPolicy(ContinuousActionVecMockEnv().full_action_spec),
+            )
+            for _ in collector:
+                break
+            assert torch.get_num_threads() == init_threads - 1
+            collector.shutdown()
+            assert torch.get_num_threads() == init_threads
+            collector = MultiSyncDataCollector(
+                [ParallelEnv(2, ContinuousActionVecMockEnv)],
+                RandomPolicy(ContinuousActionVecMockEnv().full_action_spec.expand(2)),
+            )
+            for _ in collector:
+                break
+            assert torch.get_num_threads() == init_threads - 2
+            collector.shutdown()
+            assert torch.get_num_threads() == init_threads
+        finally:
+            torch.set_num_threads(init_threads)
 
 
 if __name__ == "__main__":

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -2101,19 +2101,31 @@ class TestLibThreading:
                 RandomPolicy(ContinuousActionVecMockEnv().full_action_spec),
             )
             for _ in collector:
+                print("checking torch.get_num_threads()", torch.get_num_threads(), "expecting", init_threads - 1)
                 assert torch.get_num_threads() == init_threads - 1
                 break
             collector.shutdown()
             assert torch.get_num_threads() == init_threads
+            del collector
+            import gc
+            gc.collect()
+        finally:
+            torch.set_num_threads(init_threads)
+
+        try:
             collector = MultiSyncDataCollector(
                 [ParallelEnv(2, ContinuousActionVecMockEnv)],
                 RandomPolicy(ContinuousActionVecMockEnv().full_action_spec.expand(2)),
             )
             for _ in collector:
+                print("checking torch.get_num_threads()", torch.get_num_threads(), "expecting", init_threads - 2)
                 assert torch.get_num_threads() == init_threads - 2
                 break
             collector.shutdown()
             assert torch.get_num_threads() == init_threads
+            del collector
+            import gc
+            gc.collect()
         finally:
             torch.set_num_threads(init_threads)
 

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -2404,6 +2404,7 @@ class TestLibThreading:
             collector = MultiSyncDataCollector(
                 [ContinuousActionVecMockEnv],
                 RandomPolicy(ContinuousActionVecMockEnv().full_action_spec),
+                frames_per_batch=3,
             )
             for _ in collector:
                 assert torch.get_num_threads() == init_threads - 1
@@ -2419,6 +2420,7 @@ class TestLibThreading:
             collector = MultiSyncDataCollector(
                 [ParallelEnv(2, ContinuousActionVecMockEnv)],
                 RandomPolicy(ContinuousActionVecMockEnv().full_action_spec.expand(2)),
+                frames_per_batch=3,
             )
             for _ in collector:
                 assert torch.get_num_threads() == init_threads - 2

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -2053,39 +2053,67 @@ def test_collector_reloading(collector_class):
     del collector
 
 
-@pytest.mark.skipif(
-    IS_OSX, reason="setting different threads across workeres can randomly fail on OSX."
-)
-def test_num_threads():
-    from torchrl.collectors import collectors
-
-    _main_async_collector_saved = collectors._main_async_collector
-    collectors._main_async_collector = decorate_thread_sub_func(
-        collectors._main_async_collector, num_threads=3
+class TestLibThreading:
+    @pytest.mark.skipif(
+        IS_OSX,
+        reason="setting different threads across workeres can randomly fail on OSX.",
     )
-    num_threads = torch.get_num_threads()
-    try:
-        env = ContinuousActionVecMockEnv()
-        c = MultiSyncDataCollector(
-            [env],
-            policy=RandomPolicy(env.action_spec),
-            num_threads=7,
-            num_sub_threads=3,
-            total_frames=200,
-            frames_per_batch=200,
+    def test_num_threads(self):
+        from torchrl.collectors import collectors
+
+        _main_async_collector_saved = collectors._main_async_collector
+        collectors._main_async_collector = decorate_thread_sub_func(
+            collectors._main_async_collector, num_threads=3
         )
-        assert torch.get_num_threads() == 7
-        for _ in c:
-            pass
-    finally:
+        num_threads = torch.get_num_threads()
         try:
-            c.shutdown()
-            del c
-        except Exception:
-            logging.info("Failed to shut down collector")
-        # reset vals
-        collectors._main_async_collector = _main_async_collector_saved
-        torch.set_num_threads(num_threads)
+            env = ContinuousActionVecMockEnv()
+            c = MultiSyncDataCollector(
+                [env],
+                policy=RandomPolicy(env.action_spec),
+                num_threads=7,
+                num_sub_threads=3,
+                total_frames=200,
+                frames_per_batch=200,
+            )
+            assert torch.get_num_threads() == 7
+            for _ in c:
+                pass
+        finally:
+            try:
+                c.shutdown()
+                del c
+            except Exception:
+                logging.info("Failed to shut down collector")
+            # reset vals
+            collectors._main_async_collector = _main_async_collector_saved
+            torch.set_num_threads(num_threads)
+
+    @pytest.mark.skipif(
+        IS_OSX,
+        reason="setting different threads across workeres can randomly fail on OSX.",
+    )
+    def test_auto_num_threads(self):
+        init_threads = torch.get_num_threads()
+
+        collector = MultiSyncDataCollector(
+            [ContinuousActionVecMockEnv],
+            RandomPolicy(ContinuousActionVecMockEnv().action_spec),
+        )
+        for _ in collector:
+            break
+        assert torch.get_num_threads() == init_threads - 1
+        collector.shutdown()
+        assert torch.get_num_threads() == init_threads
+        collector = MultiSyncDataCollector(
+            [ParallelEnv(2, ContinuousActionVecMockEnv)],
+            RandomPolicy(ContinuousActionVecMockEnv().action_spec),
+        )
+        for _ in collector:
+            break
+        assert torch.get_num_threads() == init_threads - 2
+        collector.shutdown()
+        assert torch.get_num_threads() == init_threads
 
 
 if __name__ == "__main__":

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
+import gc
 import logging
 
 import sys
@@ -2101,13 +2102,11 @@ class TestLibThreading:
                 RandomPolicy(ContinuousActionVecMockEnv().full_action_spec),
             )
             for _ in collector:
-                print("checking torch.get_num_threads()", torch.get_num_threads(), "expecting", init_threads - 1)
                 assert torch.get_num_threads() == init_threads - 1
                 break
             collector.shutdown()
             assert torch.get_num_threads() == init_threads
             del collector
-            import gc
             gc.collect()
         finally:
             torch.set_num_threads(init_threads)
@@ -2118,13 +2117,11 @@ class TestLibThreading:
                 RandomPolicy(ContinuousActionVecMockEnv().full_action_spec.expand(2)),
             )
             for _ in collector:
-                print("checking torch.get_num_threads()", torch.get_num_threads(), "expecting", init_threads - 2)
                 assert torch.get_num_threads() == init_threads - 2
                 break
             collector.shutdown()
             assert torch.get_num_threads() == init_threads
             del collector
-            import gc
             gc.collect()
         finally:
             torch.set_num_threads(init_threads)

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import gc
 import argparse
 import os.path
 import re
@@ -2375,10 +2376,14 @@ class TestLibThreading:
             assert torch.get_num_threads() == max(1, init_threads - 5)
 
             env2.close()
+            del env2
+            gc.collect()
 
             assert torch.get_num_threads() == max(1, init_threads - 3)
 
             env3.close()
+            del env3
+            gc.collect()
 
             assert torch.get_num_threads() == init_threads
         finally:

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -3,8 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import gc
 import argparse
+import gc
 import os.path
 import re
 from collections import defaultdict

--- a/torchrl/__init__.py
+++ b/torchrl/__init__.py
@@ -49,3 +49,5 @@ import torchrl.trainers
 # Filter warnings in subprocesses: True by default given the multiple optional
 # deps of the library. This can be turned on via `torchrl.filter_warnings_subprocess = False`.
 filter_warnings_subprocess = True
+
+_THREAD_POOL = torch.get_num_threads()

--- a/torchrl/__init__.py
+++ b/torchrl/__init__.py
@@ -50,4 +50,6 @@ import torchrl.trainers
 # deps of the library. This can be turned on via `torchrl.filter_warnings_subprocess = False`.
 filter_warnings_subprocess = True
 
+_THREAD_POOL_INIT = torch.get_num_threads()
 _THREAD_POOL = torch.get_num_threads()
+

--- a/torchrl/__init__.py
+++ b/torchrl/__init__.py
@@ -52,4 +52,3 @@ filter_warnings_subprocess = True
 
 _THREAD_POOL_INIT = torch.get_num_threads()
 _THREAD_POOL = torch.get_num_threads()
-

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -630,7 +630,6 @@ class _ProcessNoWarn(mp.Process):
 
     def run(self, *args, **kwargs):
         if self.num_threads is not None:
-            print("_utils.py: torch.set_num_threads(self.num_threads)", self.num_threads)
             torch.set_num_threads(self.num_threads)
         if self.filter_warnings_subprocess:
             import warnings

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -630,6 +630,7 @@ class _ProcessNoWarn(mp.Process):
 
     def run(self, *args, **kwargs):
         if self.num_threads is not None:
+            print("_utils.py: torch.set_num_threads(self.num_threads)", self.num_threads)
             torch.set_num_threads(self.num_threads)
         if self.filter_warnings_subprocess:
             import warnings

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -1437,7 +1437,7 @@ also that the state dict is synchronised across processes if needed."""
             )
             print(
                 "collectors.py:1439 torch.set_num_threads(torchrl._THREAD_POOL)",
-                torchrl._THREAD_POOL
+                torchrl._THREAD_POOL, self._total_workers_from_env(self.create_env_fn)
             )
             torch.set_num_threads(torchrl._THREAD_POOL)
 

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -1423,7 +1423,7 @@ also that the state dict is synchronised across processes if needed."""
             import torchrl
 
             torchrl._THREAD_POOL = min(
-                os.cpu_count(),
+                torchrl._THREAD_POOL_INIT,
                 torchrl._THREAD_POOL + self._total_workers_from_env(self.create_env_fn),
             )
             torch.set_num_threads(torchrl._THREAD_POOL)

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -1114,7 +1114,6 @@ class _MultiDataCollector(DataCollectorBase):
         self.closed = True
         self.num_workers = len(create_env_fn)
 
-
         self.num_sub_threads = num_sub_threads
         self.num_threads = num_threads
         self.create_env_fn = create_env_fn
@@ -1312,17 +1311,10 @@ class _MultiDataCollector(DataCollectorBase):
             import torchrl
 
             total_workers = self._total_workers_from_env(self.create_env_fn)
-            print("torchrl._THREAD_POOL", torchrl._THREAD_POOL)
-            print("total_workers", total_workers)
             self.num_threads = max(
                 1, torchrl._THREAD_POOL - total_workers
             )  # 1 more thread for this proc
-            print("self.num_threads", self.num_threads)
 
-        print(
-            "collectors.py:1323 torch.set_num_threads(self.num_threads)",
-            self.num_threads
-            )
         torch.set_num_threads(self.num_threads)
         assert torch.get_num_threads() == self.num_threads
         import torchrl
@@ -1434,10 +1426,6 @@ also that the state dict is synchronised across processes if needed."""
             torchrl._THREAD_POOL = min(
                 torchrl._THREAD_POOL_INIT,
                 torchrl._THREAD_POOL + self._total_workers_from_env(self.create_env_fn),
-            )
-            print(
-                "collectors.py:1439 torch.set_num_threads(torchrl._THREAD_POOL)",
-                torchrl._THREAD_POOL, self._total_workers_from_env(self.create_env_fn)
             )
             torch.set_num_threads(torchrl._THREAD_POOL)
 

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -1114,13 +1114,6 @@ class _MultiDataCollector(DataCollectorBase):
         self.closed = True
         self.num_workers = len(create_env_fn)
 
-        if num_threads is None:
-            import torchrl
-
-            total_workers = self._total_workers_from_env(create_env_fn)
-            num_threads = max(
-                1, torchrl._THREAD_POOL - total_workers
-            )  # 1 more thread for this proc
 
         self.num_sub_threads = num_sub_threads
         self.num_threads = num_threads
@@ -1315,6 +1308,17 @@ class _MultiDataCollector(DataCollectorBase):
         raise NotImplementedError
 
     def _run_processes(self) -> None:
+        if self.num_threads is None:
+            import torchrl
+
+            total_workers = self._total_workers_from_env(self.create_env_fn)
+            print("torchrl._THREAD_POOL", torchrl._THREAD_POOL)
+            print("total_workers", total_workers)
+            self.num_threads = max(
+                1, torchrl._THREAD_POOL - total_workers
+            )  # 1 more thread for this proc
+            print("self.num_threads", self.num_threads)
+
         torch.set_num_threads(self.num_threads)
         import torchrl
 

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -1320,6 +1320,7 @@ class _MultiDataCollector(DataCollectorBase):
             print("self.num_threads", self.num_threads)
 
         torch.set_num_threads(self.num_threads)
+        assert torch.get_num_threads() == self.num_threads
         import torchrl
 
         torchrl._THREAD_POOL = self.num_threads

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -1319,6 +1319,10 @@ class _MultiDataCollector(DataCollectorBase):
             )  # 1 more thread for this proc
             print("self.num_threads", self.num_threads)
 
+        print(
+            "collectors.py:1323 torch.set_num_threads(self.num_threads)",
+            self.num_threads
+            )
         torch.set_num_threads(self.num_threads)
         assert torch.get_num_threads() == self.num_threads
         import torchrl
@@ -1430,6 +1434,10 @@ also that the state dict is synchronised across processes if needed."""
             torchrl._THREAD_POOL = min(
                 torchrl._THREAD_POOL_INIT,
                 torchrl._THREAD_POOL + self._total_workers_from_env(self.create_env_fn),
+            )
+            print(
+                "collectors.py:1439 torch.set_num_threads(torchrl._THREAD_POOL)",
+                torchrl._THREAD_POOL
             )
             torch.set_num_threads(torchrl._THREAD_POOL)
 

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -1409,7 +1409,7 @@ also that the state dict is synchronised across processes if needed."""
         finally:
             import torchrl
 
-            torchrl._THREAD_POOL = min(os.cpu_count(), self.num_workers)
+            torchrl._THREAD_POOL = min(os.cpu_count(), torchrl._THREAD_POOL+self.num_workers)
             torch.set_num_threads(torchrl._THREAD_POOL)
 
             for proc in self.procs:

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -625,7 +625,9 @@ class _BatchedEnv(EnvBase):
         self.is_closed = True
         import torchrl
 
-        torchrl._THREAD_POOL = min(os.cpu_count(), torchrl._THREAD_POOL+self.num_workers)
+        torchrl._THREAD_POOL = min(
+            os.cpu_count(), torchrl._THREAD_POOL + self.num_workers
+        )
         torch.set_num_threads(torchrl._THREAD_POOL)
 
     def _shutdown_workers(self) -> None:
@@ -1001,6 +1003,7 @@ class ParallelEnv(_BatchedEnv, metaclass=_PEnvMeta):
 
         if self.num_threads is None:
             import torchrl
+
             self.num_threads = max(
                 1, torchrl._THREAD_POOL - self.num_workers
             )  # 1 more thread for this proc

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -628,10 +628,6 @@ class _BatchedEnv(EnvBase):
         torchrl._THREAD_POOL = min(
             torchrl._THREAD_POOL_INIT, torchrl._THREAD_POOL + self.num_workers
         )
-        print(
-            "batched_envs.py:631 torch.set_num_threads(torchrl._THREAD_POOL)",
-            torchrl._THREAD_POOL
-        )
         torch.set_num_threads(torchrl._THREAD_POOL)
 
     def _shutdown_workers(self) -> None:
@@ -1012,10 +1008,6 @@ class ParallelEnv(_BatchedEnv, metaclass=_PEnvMeta):
                 1, torchrl._THREAD_POOL - self.num_workers
             )  # 1 more thread for this proc
 
-        print(
-            "batched_envs.py:1016 torch.set_num_threads(self.num_threads)",
-            self.num_threads
-        )
         torch.set_num_threads(self.num_threads)
         import torchrl
 

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -626,7 +626,7 @@ class _BatchedEnv(EnvBase):
         import torchrl
 
         torchrl._THREAD_POOL = min(
-            os.cpu_count(), torchrl._THREAD_POOL + self.num_workers
+            torchrl._THREAD_POOL_INIT, torchrl._THREAD_POOL + self.num_workers
         )
         torch.set_num_threads(torchrl._THREAD_POOL)
 

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -628,6 +628,10 @@ class _BatchedEnv(EnvBase):
         torchrl._THREAD_POOL = min(
             torchrl._THREAD_POOL_INIT, torchrl._THREAD_POOL + self.num_workers
         )
+        print(
+            "batched_envs.py:631 torch.set_num_threads(torchrl._THREAD_POOL)",
+            torchrl._THREAD_POOL
+        )
         torch.set_num_threads(torchrl._THREAD_POOL)
 
     def _shutdown_workers(self) -> None:
@@ -1008,6 +1012,10 @@ class ParallelEnv(_BatchedEnv, metaclass=_PEnvMeta):
                 1, torchrl._THREAD_POOL - self.num_workers
             )  # 1 more thread for this proc
 
+        print(
+            "batched_envs.py:1016 torch.set_num_threads(self.num_threads)",
+            self.num_threads
+        )
         torch.set_num_threads(self.num_threads)
         import torchrl
 

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -625,7 +625,7 @@ class _BatchedEnv(EnvBase):
         self.is_closed = True
         import torchrl
 
-        torchrl._THREAD_POOL = min(os.cpu_count(), self.num_workers)
+        torchrl._THREAD_POOL = min(os.cpu_count(), torchrl._THREAD_POOL+self.num_workers)
         torch.set_num_threads(torchrl._THREAD_POOL)
 
     def _shutdown_workers(self) -> None:

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -270,8 +270,6 @@ class _BatchedEnv(EnvBase):
         super().__init__(device=device)
         self.serial_for_single = serial_for_single
         self.is_closed = True
-        if num_threads is None:
-            num_threads = num_workers + 1  # 1 more thread for this proc
         self.num_sub_threads = num_sub_threads
         self.num_threads = num_threads
         self._cache_in_keys = None
@@ -625,6 +623,10 @@ class _BatchedEnv(EnvBase):
 
         self._shutdown_workers()
         self.is_closed = True
+        import torchrl
+
+        torchrl._THREAD_POOL = min(os.cpu_count(), self.num_workers)
+        torch.set_num_threads(torchrl._THREAD_POOL)
 
     def _shutdown_workers(self) -> None:
         raise NotImplementedError
@@ -997,7 +999,16 @@ class ParallelEnv(_BatchedEnv, metaclass=_PEnvMeta):
     def _start_workers(self) -> None:
         from torchrl.envs.env_creator import EnvCreator
 
+        if self.num_threads is None:
+            import torchrl
+            self.num_threads = max(
+                1, torchrl._THREAD_POOL - self.num_workers
+            )  # 1 more thread for this proc
+
         torch.set_num_threads(self.num_threads)
+        import torchrl
+
+        torchrl._THREAD_POOL = self.num_threads
 
         ctx = mp.get_context("spawn")
 

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -306,16 +306,16 @@ def _gym_to_torchrl_spec_transform(
             shape = torch.Size([1])
         if dtype is None:
             dtype = numpy_to_torch_dtype_dict[spec.dtype]
-        low = torch.tensor(spec.low, device=device, dtype=dtype)
-        high = torch.tensor(spec.high, device=device, dtype=dtype)
+        low = torch.as_tensor(spec.low, device=device, dtype=dtype)
+        high = torch.as_tensor(spec.high, device=device, dtype=dtype)
         is_unbounded = low.isinf().all() and high.isinf().all()
 
         minval, maxval = _minmax_dtype(dtype)
         minval = torch.as_tensor(minval).to(low.device, dtype)
         maxval = torch.as_tensor(maxval).to(low.device, dtype)
         is_unbounded = is_unbounded or (
-            torch.isclose(low, torch.tensor(minval, dtype=dtype)).all()
-            and torch.isclose(high, torch.tensor(maxval, dtype=dtype)).all()
+            torch.isclose(low, torch.as_tensor(minval, dtype=dtype)).all()
+            and torch.isclose(high, torch.as_tensor(maxval, dtype=dtype)).all()
         )
         return (
             UnboundedContinuousTensorSpec(shape, device=device, dtype=dtype)
@@ -1480,7 +1480,7 @@ class terminal_obs_reader(BaseInfoDictReader):
             # Simplest case: there is one observation,
             # presented as a np.ndarray. The key should be pixels or observation.
             # We just write that value at its location in the tensor
-            tensor[index] = torch.tensor(obs, device=tensor.device)
+            tensor[index] = torch.as_tensor(obs, device=tensor.device)
         elif isinstance(obs, dict):
             if key not in obs:
                 raise KeyError(
@@ -1491,13 +1491,13 @@ class terminal_obs_reader(BaseInfoDictReader):
                 # if the obs is a dict, we expect that the key points also to
                 # a value in the obs. We retrieve this value and write it in the
                 # tensor
-                tensor[index] = torch.tensor(subobs, device=tensor.device)
+                tensor[index] = torch.as_tensor(subobs, device=tensor.device)
 
         elif isinstance(obs, (list, tuple)):
             # tuples are stacked along the first dimension when passing gym spaces
             # to torchrl specs. As such, we can simply stack the tuple and set it
             # at the relevant index (assuming stacking can be achieved)
-            tensor[index] = torch.tensor(obs, device=tensor.device)
+            tensor[index] = torch.as_tensor(obs, device=tensor.device)
         else:
             raise NotImplementedError(
                 f"Observations of type {type(obs)} are not supported yet."


### PR DESCRIPTION
Closes #1847 

To test:
```python
import torch
from torchrl.envs import ParallelEnv, GymEnv

if __name__ == "__main__":
    print(torch.get_num_threads()) # 8
    
    env3 = ParallelEnv(3, lambda: GymEnv("Pendulum-v1"))
    env3.rollout(2) 
    
    print(torch.get_num_threads()) # 5
    
    env2 = ParallelEnv(2, lambda: GymEnv("Pendulum-v1"))
    env2.rollout(2)
    
    print(torch.get_num_threads()) # 3
    
    env2.close()
    
    print(torch.get_num_threads()) # 5
    
    env3.close()

    print(torch.get_num_threads()) # 8
```

cc @skandermoalla 