### PR TITLE
fix: ClipPPOLoss args in coding_ppo.py

### DIFF
--- a/tutorials/sphinx-tutorials/coding_ppo.py
+++ b/tutorials/sphinx-tutorials/coding_ppo.py
@@ -571,8 +571,8 @@ advantage_module = GAE(
 )
 
 loss_module = ClipPPOLoss(
-    actor_network=policy_module,
-    critic_network=value_module,
+    actor=policy_module,
+    critic=value_module,
     clip_epsilon=clip_epsilon,
     entropy_bonus=bool(entropy_eps),
     entropy_coef=entropy_eps,


### PR DESCRIPTION
## Description
the main two params foreseen in ClipPPOLoss are named "actor" and "critic", respectively. Without them, the following error will be raised during the script run: "TypeError: ClipPPOLoss.__init__() missing 2 required positional arguments: 'actor' and 'critic'".

## Motivation and Context

Without that change, the coding_ppo.py script won't run. The modification corrects the actor and critic variable names when using ClipPPOLoss class. 

- [ x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
