### PR TITLE
[BugFix] Fix warning call

### DIFF
--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import contextlib
-import logging
 
 import math
 import warnings
@@ -363,7 +362,7 @@ class PPOLoss(LossModule):
 
     @property
     def actor_params(self):
-        logging.warning(
+        warnings.warn(
             f"{self.__class__.__name__}.actor_params is deprecated, use {self.__class__.__name__}.actor_network_params instead. This "
             "link will be removed in v0.4.",
             category=DeprecationWarning,


### PR DESCRIPTION
Deprecation warnings are usually called with
https://github.com/pytorch/rl/blob/b0653c44fb6e3776653973861a4732c89801173e/torchrl/objectives/ppo.py#L357

This PR modifies the warning in https://github.com/pytorch/rl/blob/b0653c44fb6e3776653973861a4732c89801173e/torchrl/objectives/ppo.py#L366 to the right syntax, as the current call will not expect the `category` attribute