### PR TITLE
[BugFix] check_env_specs seeding logic

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -363,8 +363,8 @@ def test_set_gym_nested():
 
 @pytest.mark.parametrize("device", get_default_devices())
 def test_rng_decorator(device):
-    torch.manual_seed(10)
     with torch.device(device):
+        torch.manual_seed(10)
         s0a = torch.randn(3)
         with _rng_decorator(0):
             torch.randn(3)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -369,7 +369,6 @@ def test_rng_decorator(device):
         s0a = torch.randn(3)
         with _rng_decorator(0):
             torch.randn(3)
-            time.sleep(4)
         s0b = torch.randn(3)
         torch.manual_seed(10)
         s1a = torch.randn(3)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -12,7 +12,10 @@ from unittest import mock
 import _utils_internal
 import pytest
 
-from torchrl._utils import get_binary_env_var, implement_for
+import torch
+
+from _utils_internal import get_default_devices
+from torchrl._utils import _rng_decorator, get_binary_env_var, implement_for
 
 from torchrl.envs.libs.gym import gym_backend, GymWrapper, set_gym_backend
 
@@ -356,6 +359,21 @@ def test_set_gym_nested():
         GymWrapper._output_transform(
             MockGym, (1, 2, True, {})
         )  # would break with gymnasium
+
+
+@pytest.mark.parametrize("device", get_default_devices())
+def test_rng_decorator(device):
+    torch.manual_seed(10)
+    with torch.device(device):
+        s0a = torch.randn(3)
+        with _rng_decorator(0):
+            torch.randn(3)
+        s0b = torch.randn(3)
+        torch.manual_seed(10)
+        s1a = torch.randn(3)
+        s1b = torch.randn(3)
+        torch.testing.assert_close(s0a, s1a)
+        torch.testing.assert_close(s0b, s1b)
 
 
 if __name__ == "__main__":

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,6 +5,7 @@
 import argparse
 import os
 import sys
+import time
 from copy import copy
 from importlib import import_module
 from unittest import mock
@@ -368,6 +369,7 @@ def test_rng_decorator(device):
         s0a = torch.randn(3)
         with _rng_decorator(0):
             torch.randn(3)
+            time.sleep(4)
         s0b = torch.randn(3)
         torch.manual_seed(10)
         s1a = torch.randn(3)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,7 +5,6 @@
 import argparse
 import os
 import sys
-import time
 from copy import copy
 from importlib import import_module
 from unittest import mock

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -721,11 +721,12 @@ class _rng_decorator(_DecoratorContextManager):
     def _get_state(self):
         if self.has_cuda:
             if self.device is None:
-                self._state = (
-                    torch.random.get_rng_state(), torch.cuda.get_rng_state())
+                self._state = (torch.random.get_rng_state(), torch.cuda.get_rng_state())
             else:
                 self._state = (
-                    torch.random.get_rng_state(), torch.cuda.get_rng_state(self.device))
+                    torch.random.get_rng_state(),
+                    torch.cuda.get_rng_state(self.device),
+                )
 
         else:
             self.state = torch.random.get_rng_state()

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -712,7 +712,7 @@ class _rng_decorator(_DecoratorContextManager):
     def __init__(self, seed, device=None):
         self.seed = seed
         self.device = device
-        self.has_cuda = torch.cuda.is_available():
+        self.has_cuda = torch.cuda.is_available()
 
     def __enter__(self):
         self._get_state()

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -704,3 +704,17 @@ def _replace_last(key: NestedKey, new_ending: str) -> NestedKey:
         return new_ending
     else:
         return key[:-1] + (new_ending,)
+
+
+class _rng_decorator(_DecoratorContextManager):
+    """Temporarily sets the seed and sets back the rng state when exiting."""
+
+    def __init__(self, seed):
+        self.seed = seed
+
+    def __enter__(self):
+        self._state = torch.random.get_rng_state()
+        torch.manual_seed(self.seed)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        torch.random.set_rng_state(self._state)

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -711,15 +711,10 @@ class _rng_decorator(_DecoratorContextManager):
 
     def __init__(self, seed):
         self.seed = seed
-        self.stream = torch.cuda.Stream()
-        self.event = self.stream.record_event()
 
     def __enter__(self):
         self._state = torch.random.get_rng_state()
         torch.manual_seed(self.seed)
-        return torch.cuda.stream(self.stream)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         torch.random.set_rng_state(self._state)
-        self.event.wait()
-        self.event.synchronize()

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -711,10 +711,15 @@ class _rng_decorator(_DecoratorContextManager):
 
     def __init__(self, seed):
         self.seed = seed
+        self.stream = torch.cuda.Stream()
+        self.event = self.stream.record_event()
 
     def __enter__(self):
         self._state = torch.random.get_rng_state()
         torch.manual_seed(self.seed)
+        return torch.cuda.stream(self.stream)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         torch.random.set_rng_state(self._state)
+        self.event.wait()
+        self.event.synchronize()

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -720,14 +720,23 @@ class _rng_decorator(_DecoratorContextManager):
 
     def _get_state(self):
         if self.has_cuda:
-            self._state = (
-                torch.random.get_rng_state(), torch.cuda.get_rng_state(self.device))
+            if self.device is None:
+                self._state = (
+                    torch.random.get_rng_state(), torch.cuda.get_rng_state())
+            else:
+                self._state = (
+                    torch.random.get_rng_state(), torch.cuda.get_rng_state(self.device))
+
         else:
             self.state = torch.random.get_rng_state()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.has_cuda:
             torch.random.set_rng_state(self._state[0])
-            torch.cuda.set_rng_state(self._state[1], device=self.device)
+            if self.device is not None:
+                torch.cuda.set_rng_state(self._state[1], device=self.device)
+            else:
+                torch.cuda.set_rng_state(self._state[1])
+
         else:
             torch.random.set_rng_state(self._state)

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -451,7 +451,10 @@ def check_env_specs(
 
     """
     if seed is not None:
-        with _rng_decorator(seed):
+        device = (
+            env.device if env.device is not None and env.device.type == "cuda" else None
+        )
+        with _rng_decorator(seed, device=device):
             env.set_seed(seed)
             return check_env_specs(
                 env, return_contiguous=return_contiguous, check_dtype=check_dtype


### PR DESCRIPTION
Sets the default seed of check_env_specs to None (no seed) and set it only temporarily for Torch. For the env, we can't reset the RNG state unfortunately.