### PR TITLE
[Feature] Add PrioritizedSliceSampler

### DIFF
--- a/docs/source/reference/data.rst
+++ b/docs/source/reference/data.rst
@@ -134,6 +134,7 @@ using the following components:
 
     Sampler
     PrioritizedSampler
+    PrioritizedSliceSampler
     RandomSampler
     SamplerWithoutReplacement
     SliceSampler

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -40,6 +40,7 @@ from torchrl.data import (
 from torchrl.data.replay_buffers import samplers, writers
 from torchrl.data.replay_buffers.samplers import (
     PrioritizedSampler,
+    PrioritizedSliceSampler,
     RandomSampler,
     SamplerEnsemble,
     SamplerWithoutReplacement,
@@ -1834,13 +1835,14 @@ class TestSamplers:
         assert (s.exclude("index") == 0).all()
 
     @pytest.mark.parametrize(
-        "batch_size,num_slices,slice_len",
+        "batch_size,num_slices,slice_len,prioritized",
         [
-            [100, 20, None],
-            [120, 30, None],
-            [100, None, 5],
-            [120, None, 4],
-            [101, None, 101],
+            [100, 20, None, True],
+            [100, 20, None, False],
+            [120, 30, None, False],
+            [100, None, 5, False],
+            [120, None, 4, False],
+            [101, None, 101, False],
         ],
     )
     @pytest.mark.parametrize("episode_key", ["episode", ("some", "episode")])
@@ -1853,6 +1855,7 @@ class TestSamplers:
         batch_size,
         num_slices,
         slice_len,
+        prioritized,
         episode_key,
         done_key,
         match_episode,
@@ -1897,19 +1900,34 @@ class TestSamplers:
         else:
             strict_length = True
 
-        sampler = SliceSampler(
-            num_slices=num_slices,
-            traj_key=episode_key,
-            end_key=done_key,
-            slice_len=slice_len,
-            strict_length=strict_length,
-        )
+        if prioritized:
+            num_steps = data.shape[0]
+            sampler = PrioritizedSliceSampler(
+                max_capacity=num_steps,
+                alpha=0.7,
+                beta=0.9,
+                num_slices=num_slices,
+                traj_key=episode_key,
+                end_key=done_key,
+                slice_len=slice_len,
+                strict_length=strict_length,
+            )
+            index = torch.arange(0, num_steps, 1)
+            sampler.extend(index)
+        else:
+            sampler = SliceSampler(
+                num_slices=num_slices,
+                traj_key=episode_key,
+                end_key=done_key,
+                slice_len=slice_len,
+                strict_length=strict_length,
+            )
         if slice_len is not None:
             num_slices = batch_size // slice_len
         trajs_unique_id = set()
         too_short = False
         count_unique = set()
-        for _ in range(10):
+        for _ in range(30):
             index, info = sampler.sample(storage, batch_size=batch_size)
             if _data_prefix:
                 samples = storage._storage["_data"][index]
@@ -1918,6 +1936,7 @@ class TestSamplers:
             if strict_length:
                 # check that trajs are ok
                 samples = samples.view(num_slices, -1)
+
                 assert samples["another_episode"].unique(
                     dim=1
                 ).squeeze().shape == torch.Size([num_slices])
@@ -1936,6 +1955,7 @@ class TestSamplers:
             raise AssertionError(
                 f"Not all items can be sampled: {set(range(100))-count_unique} are missing"
             )
+
         if strict_length:
             assert not too_short
         else:

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -2173,7 +2173,7 @@ def test_prioritized_slice_sampler_episodes(device):
     for _ in range(10):
         sample = rb.sample()
         episodes.append(sample["episode"])
-    assert set([1, 2, 3, 4]) == set(
+    assert {1, 2, 3, 4} == set(
         torch.cat(episodes).cpu().tolist()
     ), "all episodes are expected to be sampled at least once"
 
@@ -2187,7 +2187,7 @@ def test_prioritized_slice_sampler_episodes(device):
     for _ in range(10):
         sample = rb.sample()
         episodes.append(sample["episode"])
-    assert set([1, 3]) == set(
+    assert {1, 3} == set(
         torch.cat(episodes).cpu().tolist()
     ), "after priority update, only episode 1 and 3 are expected to be sampled"
 

--- a/torchrl/data/replay_buffers/__init__.py
+++ b/torchrl/data/replay_buffers/__init__.py
@@ -13,6 +13,7 @@ from .replay_buffers import (
 )
 from .samplers import (
     PrioritizedSampler,
+    PrioritizedSliceSampler,
     RandomSampler,
     Sampler,
     SamplerEnsemble,

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -546,7 +546,7 @@ class SliceSampler(Sampler):
             allowed to appear in the batch.
             Be mindful that this can result in effective `batch_size`  shorter
             than the one asked for! Trajectories can be split using
-            :func:`torchrl.collectors.split_trajectories`. Defaults to ``True``.
+            :func:`~torchrl.collectors.split_trajectories`. Defaults to ``True``.
 
     .. note:: To recover the trajectory splits in the storage,
         :class:`~torchrl.data.replay_buffers.samplers.SliceSampler` will first
@@ -583,7 +583,7 @@ class SliceSampler(Sampler):
         >>> print("episodes", sample.get("episode").unique())
         episodes tensor([1, 2, 3, 4], dtype=torch.int32)
 
-    :class:`torchrl.data.replay_buffers.SliceSampler` is default-compatible with
+    :class:`~torchrl.data.replay_buffers.SliceSampler` is default-compatible with
     most of TorchRL's datasets:
 
     Examples:
@@ -962,7 +962,7 @@ class SliceSamplerWithoutReplacement(SliceSampler, SamplerWithoutReplacement):
             allowed to appear in the batch.
             Be mindful that this can result in effective `batch_size`  shorter
             than the one asked for! Trajectories can be split using
-            :func:`torchrl.collectors.split_trajectories`. Defaults to ``True``.
+            :func:`~torchrl.collectors.split_trajectories`. Defaults to ``True``.
         shuffle (bool, optional): if ``False``, the order of the trajectories
             is not shuffled. Defaults to ``True``.
 
@@ -1003,7 +1003,7 @@ class SliceSamplerWithoutReplacement(SliceSampler, SamplerWithoutReplacement):
         >>> print("sample:", sample)
         >>> print("trajectories in sample", sample.get("episode").unique())
 
-    :class:`torchrl.data.replay_buffers.SliceSamplerWithoutReplacement` is default-compatible with
+    :class:`~torchrl.data.replay_buffers.SliceSamplerWithoutReplacement` is default-compatible with
     most of TorchRL's datasets, and allows users to consume datasets in a dataloader-like fashion:
 
     Examples:
@@ -1131,7 +1131,7 @@ class PrioritizedSliceSampler(SliceSampler, PrioritizedSampler):
             allowed to appear in the batch.
             Be mindful that this can result in effective `batch_size`  shorter
             than the one asked for! Trajectories can be split using
-            :func:`torchrl.collectors.split_trajectories`. Defaults to ``True``.
+            :func:`~torchrl.collectors.split_trajectories`. Defaults to ``True``.
 
     Examples:
         >>> import torch
@@ -1154,19 +1154,19 @@ class PrioritizedSliceSampler(SliceSampler, PrioritizedSampler):
         >>> rb.extend(data)
         >>> sample, info = rb.sample(return_info=True)
         >>> print("episode", sample["episode"].tolist())
+        episode [2, 2, 2, 2, 1, 1]
         >>> print("steps", sample["steps"].tolist())
+        steps [1, 2, 0, 1, 1, 2]
         >>> print("weight", info["_weight"].tolist())
+        weight [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
         >>> priority = torch.tensor([0,3,3,0,0,0,1,1,1])
         >>> rb.update_priority(torch.arange(0,9,1), priority=priority)
         >>> sample, info = rb.sample(return_info=True)
         >>> print("episode", sample["episode"].tolist())
-        >>> print("steps", sample["steps"].tolist())
-        >>> print("weight", info["_weight"].tolist())
-        episode [2, 2, 2, 2, 1, 1]
-        steps [1, 2, 0, 1, 1, 2]
-        weight [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
         episode [2, 2, 2, 2, 2, 2]
+        >>> print("steps", sample["steps"].tolist())
         steps [1, 2, 0, 1, 0, 1]
+        >>> print("weight", info["_weight"].tolist())
         weight [9.120110917137936e-06, 9.120110917137936e-06, 9.120110917137936e-06, 9.120110917137936e-06, 9.120110917137936e-06, 9.120110917137936e-06]
     """
 
@@ -1254,8 +1254,8 @@ class PrioritizedSliceSampler(SliceSampler, PrioritizedSampler):
             self, storage=storage, batch_size=batch_size // seq_length
         )
         # TODO: update PrioritizedSampler.sample to return torch tensors
-        starts = torch.from_numpy(starts).to(device=lengths.device)
-        info["_weight"] = torch.from_numpy(info["_weight"]).to(device=lengths.device)
+        starts = torch.as_tensor(starts, device=lengths.device)
+        info["_weight"] = torch.as_tensor(info["_weight"], device=lengths.device)
 
         # extends starting indices of each slice with sequence_length to get indices of all steps
         index = self._tensor_slices_from_startend(seq_length, starts)

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -867,7 +867,7 @@ class SliceSampler(Sampler):
                 truncated[seq_length.cumsum(0) - 1] = 1
             traj_terminated = stop_idx[traj_idx] == start_idx[traj_idx] + seq_length - 1
             terminated = torch.zeros_like(truncated)
-            if traj_terminated.any():
+            if terminated.any():
                 if isinstance(seq_length, int):
                     truncated.view(num_slices, -1)[traj_terminated] = 1
                 else:

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -1095,7 +1095,7 @@ class PrioritizedSliceSampler(SliceSampler, PrioritizedSampler):
         eps (float, optional): delta added to the priorities to ensure that the buffer
             does not contain null priorities. Defaults to 1e-8.
         reduction (str, optional): the reduction method for multidimensional
-            tensordicts (ie stored trajectory). Can be one of "max", "min",
+            tensordicts (i.e., stored trajectory). Can be one of "max", "min",
             "median" or "mean".
 
     Keyword Args:

--- a/torchrl/modules/tensordict_module/exploration.py
+++ b/torchrl/modules/tensordict_module/exploration.py
@@ -149,10 +149,7 @@ class EGreedyModule(TensorDictModuleBase):
 
             out = action_tensordict.get(action_key)
             eps = self.eps.item()
-            cond = (
-                torch.rand(action_tensordict.shape, device=action_tensordict.device)
-                < eps
-            ).to(out.dtype)
+            cond = torch.rand(action_tensordict.shape, device=out.device) < eps
             cond = expand_as_right(cond, out)
             spec = self.spec
             if spec is not None:
@@ -177,7 +174,7 @@ class EGreedyModule(TensorDictModuleBase):
                             f"Action mask key {self.action_mask_key} not found in {tensordict}."
                         )
                     spec.update_mask(action_mask)
-                out = cond * spec.rand().to(out.device) + (1 - cond) * out
+                out = torch.where(cond, spec.rand().to(out.device), out)
             else:
                 raise RuntimeError("spec must be provided to the exploration wrapper.")
             action_tensordict.set(action_key, out)


### PR DESCRIPTION
## Description

Add PrioritizedSliceSampler which inherits from PrioritizedSampler and SliceSampler.

Contrary to PrioritizedSampler which samples steps with a priority weight for each, PrioritizedSliceSampler samples slices with a priority weight for each. Implementation-wise, it only samples the start index of each slice, while discarding the indices at the end of each episode since they can't form long enough slices.

Contrary to SliceSampler which first samples trajectories, then randomly samples slices inside each trajectory, PrioritizedSliceSampler directly samples slices. It is easier to implement that way, but as a consequence PrioritizedSliceSampler more often samples slices from longer trajectories than shorter trajectories when priority weights are uniform. Nevertheless, since the priority weights are updated along training, slices from longer trajectories shouldn't be oversampled after a while.

## Motivation and Context

This type of sampling is used in the literature:
https://github.com/fyhMer/fowm/blob/main/src/algorithm/helper.py#L504-L510
https://github.com/fyhMer/fowm/blob/main/src/algorithm/tdmpc.py#L334-L337

Addresses this feature request: https://github.com/pytorch/rl/issues/1876

- [X] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds core functionality)
- [X] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
