### PR TITLE
[Feature] Add reduction parameter to On-Policy losses.

### DIFF
--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -5960,6 +5960,7 @@ class TestPPO(LossModuleTestBase):
             value,
             loss_critic_type="l2",
             separate_losses=True,
+            reduction=reduction,
         )
 
         if advantage is not None:

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -6872,8 +6872,7 @@ class TestA2C(LossModuleTestBase):
     )
     @pytest.mark.parametrize("advantage", ("gae", "vtrace", None))
     @pytest.mark.parametrize("device", get_default_devices())
-    @pytest.mark.parametrize("reduction", [None, "mean", "sum"])
-    def test_a2c_tensordict_keys_run(self, device, advantage, td_est, reduction):
+    def test_a2c_tensordict_keys_run(self, device, advantage, td_est):
         """Test A2C loss module with non-default tensordict keys."""
         torch.manual_seed(self.seed)
         gradient_mode = True
@@ -6943,9 +6942,6 @@ class TestA2C(LossModuleTestBase):
                 loss_fn.make_value_estimator(td_est)
 
         loss = loss_fn(td)
-        if reduction is None:
-            assert loss.batch_size == td.batch_size
-            loss = loss.apply(lambda x: x.float().mean(), batch_size=[])
         loss_critic = loss["loss_critic"]
         loss_objective = loss["loss_objective"] + loss.get("loss_entropy", 0.0)
         loss_critic.backward(retain_graph=True)

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -5873,7 +5873,7 @@ class TestPPO(LossModuleTestBase):
         loss = loss_fn(td)
         if reduction is None:
             assert loss.batch_size == td.batch_size
-            loss.apply(lambda x: x.float().mean(), batch_size=[])
+            loss = loss.apply(lambda x: x.float().mean(), batch_size=[])
 
         loss_critic = loss["loss_critic"]
         loss_objective = loss["loss_objective"] + loss.get("loss_entropy", 0.0)
@@ -5967,7 +5967,7 @@ class TestPPO(LossModuleTestBase):
         loss = loss_fn(td)
         if reduction is None:
             assert loss.batch_size == td.batch_size
-            loss.apply(lambda x: x.float().mean(), batch_size=[])
+            loss = loss.apply(lambda x: x.float().mean(), batch_size=[])
 
         loss_critic = loss["loss_critic"]
         loss_objective = loss["loss_objective"] + loss.get("loss_entropy", 0.0)
@@ -6068,7 +6068,7 @@ class TestPPO(LossModuleTestBase):
         loss = loss_fn(td).exclude("entropy")
         if reduction is None:
             assert loss.batch_size == td.batch_size
-            loss.apply(lambda x: x.float().mean(), batch_size=[])
+            loss = loss.apply(lambda x: x.float().mean(), batch_size=[])
 
         sum(val for key, val in loss.items() if key.startswith("loss_")).backward()
         grad = TensorDict(dict(model.named_parameters()), []).apply(
@@ -6144,7 +6144,7 @@ class TestPPO(LossModuleTestBase):
             loss = loss_fn(td)
             if reduction is None:
                 assert loss.batch_size == td.batch_size
-                loss.apply(lambda x: x.float().mean(), batch_size=[])
+                loss = loss.apply(lambda x: x.float().mean(), batch_size=[])
 
         loss_critic = loss["loss_critic"]
         loss_objective = loss["loss_objective"] + loss.get("loss_entropy", 0.0)
@@ -6304,7 +6304,7 @@ class TestPPO(LossModuleTestBase):
         loss = loss_fn(td)
         if reduction is None:
             assert loss.batch_size == td.batch_size
-            loss.apply(lambda x: x.float().mean(), batch_size=[])
+            loss = loss.apply(lambda x: x.float().mean(), batch_size=[])
 
         loss_critic = loss["loss_critic"]
         loss_objective = loss["loss_objective"] + loss.get("loss_entropy", 0.0)

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -7290,7 +7290,7 @@ class TestReinforce(LossModuleTestBase):
         torch.manual_seed(self.seed)
         actor, critic, common, td = self._create_mock_common_layer_setup()
         loss_fn = ReinforceLoss(
-            actor_network=actor, critic_network=critic, separate_losses=separate_losses
+            actor_network=actor, critic_network=critic, separate_losses=separate_losses, reduction=reduction
         )
 
         loss = loss_fn(td)

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -5817,8 +5817,16 @@ class TestPPO(LossModuleTestBase):
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("td_est", list(ValueEstimators) + [None])
     @pytest.mark.parametrize("functional", [True, False])
+    @pytest.mark.parametrize("reduction", [None, "mean", "sum"])
     def test_ppo(
-        self, loss_class, device, gradient_mode, advantage, td_est, functional
+        self,
+        loss_class,
+        device,
+        gradient_mode,
+        advantage,
+        td_est,
+        functional,
+        reduction,
     ):
         torch.manual_seed(self.seed)
         td = self._create_seq_mock_data_ppo(device=device)
@@ -5849,7 +5857,13 @@ class TestPPO(LossModuleTestBase):
         else:
             raise NotImplementedError
 
-        loss_fn = loss_class(actor, value, loss_critic_type="l2", functional=functional)
+        loss_fn = loss_class(
+            actor,
+            value,
+            loss_critic_type="l2",
+            functional=functional,
+            reduction=reduction,
+        )
         if advantage is not None:
             advantage(td)
         else:
@@ -5857,6 +5871,10 @@ class TestPPO(LossModuleTestBase):
                 loss_fn.make_value_estimator(td_est)
 
         loss = loss_fn(td)
+        if reduction is None:
+            assert loss.batch_size == td.batch_size
+            loss.apply(lambda x: x.float().mean(), batch_size=[])
+
         loss_critic = loss["loss_critic"]
         loss_objective = loss["loss_objective"] + loss.get("loss_entropy", 0.0)
         loss_critic.backward(retain_graph=True)
@@ -5904,7 +5922,8 @@ class TestPPO(LossModuleTestBase):
     @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
     @pytest.mark.parametrize("advantage", ("gae", "vtrace", "td", "td_lambda", None))
     @pytest.mark.parametrize("device", get_default_devices())
-    def test_ppo_shared(self, loss_class, device, advantage):
+    @pytest.mark.parametrize("reduction", [None, "mean", "sum"])
+    def test_ppo_shared(self, loss_class, device, advantage, reduction):
         torch.manual_seed(self.seed)
         td = self._create_seq_mock_data_ppo(device=device)
 
@@ -5946,6 +5965,10 @@ class TestPPO(LossModuleTestBase):
         if advantage is not None:
             advantage(td)
         loss = loss_fn(td)
+        if reduction is None:
+            assert loss.batch_size == td.batch_size
+            loss.apply(lambda x: x.float().mean(), batch_size=[])
+
         loss_critic = loss["loss_critic"]
         loss_objective = loss["loss_objective"] + loss.get("loss_entropy", 0.0)
         loss_critic.backward(retain_graph=True)
@@ -5989,7 +6012,10 @@ class TestPPO(LossModuleTestBase):
     )
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("separate_losses", [True, False])
-    def test_ppo_shared_seq(self, loss_class, device, advantage, separate_losses):
+    @pytest.mark.parametrize("reduction", [None, "mean", "sum"])
+    def test_ppo_shared_seq(
+        self, loss_class, device, advantage, separate_losses, reduction
+    ):
         """Tests PPO with shared module with and without passing twice across the common module."""
         torch.manual_seed(self.seed)
         td = self._create_seq_mock_data_ppo(device=device)
@@ -6040,11 +6066,19 @@ class TestPPO(LossModuleTestBase):
         if advantage is not None:
             advantage(td)
         loss = loss_fn(td).exclude("entropy")
+        if reduction is None:
+            assert loss.batch_size == td.batch_size
+            loss.apply(lambda x: x.float().mean(), batch_size=[])
+
         sum(val for key, val in loss.items() if key.startswith("loss_")).backward()
         grad = TensorDict(dict(model.named_parameters()), []).apply(
             lambda x: x.grad.clone()
         )
         loss2 = loss_fn2(td).exclude("entropy")
+        if reduction is None:
+            assert loss2.batch_size == td.batch_size
+            loss2.apply(lambda x: x.float().mean(), batch_size=[])
+
         model.zero_grad()
         sum(val for key, val in loss2.items() if key.startswith("loss_")).backward()
         grad2 = TensorDict(dict(model.named_parameters()), []).apply(
@@ -6061,7 +6095,8 @@ class TestPPO(LossModuleTestBase):
     @pytest.mark.parametrize("gradient_mode", (True, False))
     @pytest.mark.parametrize("advantage", ("gae", "vtrace", "td", "td_lambda", None))
     @pytest.mark.parametrize("device", get_default_devices())
-    def test_ppo_diff(self, loss_class, device, gradient_mode, advantage):
+    @pytest.mark.parametrize("reduction", [None, "mean", "sum"])
+    def test_ppo_diff(self, loss_class, device, gradient_mode, advantage, reduction):
         torch.manual_seed(self.seed)
         td = self._create_seq_mock_data_ppo(device=device)
 
@@ -6107,6 +6142,9 @@ class TestPPO(LossModuleTestBase):
             if advantage is not None:
                 advantage(td)
             loss = loss_fn(td)
+            if reduction is None:
+                assert loss.batch_size == td.batch_size
+                loss.apply(lambda x: x.float().mean(), batch_size=[])
 
         loss_critic = loss["loss_critic"]
         loss_objective = loss["loss_objective"] + loss.get("loss_entropy", 0.0)
@@ -6194,7 +6232,8 @@ class TestPPO(LossModuleTestBase):
     @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
     @pytest.mark.parametrize("advantage", ("gae", "vtrace", "td", "td_lambda", None))
     @pytest.mark.parametrize("td_est", list(ValueEstimators) + [None])
-    def test_ppo_tensordict_keys_run(self, loss_class, advantage, td_est):
+    @pytest.mark.parametrize("reduction", [None, "mean", "sum"])
+    def test_ppo_tensordict_keys_run(self, loss_class, advantage, td_est, reduction):
         """Test PPO loss module with non-default tensordict keys."""
         torch.manual_seed(self.seed)
         gradient_mode = True
@@ -6263,6 +6302,9 @@ class TestPPO(LossModuleTestBase):
                 loss_fn.make_value_estimator(td_est)
 
         loss = loss_fn(td)
+        if reduction is None:
+            assert loss.batch_size == td.batch_size
+            loss.apply(lambda x: x.float().mean(), batch_size=[])
 
         loss_critic = loss["loss_critic"]
         loss_objective = loss["loss_objective"] + loss.get("loss_entropy", 0.0)

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -6054,6 +6054,7 @@ class TestPPO(LossModuleTestBase):
             loss_critic_type="l2",
             separate_losses=separate_losses,
             entropy_coef=0.0,
+            reduction=reduction,
         )
 
         loss_fn2 = loss_class(
@@ -6062,6 +6063,7 @@ class TestPPO(LossModuleTestBase):
             loss_critic_type="l2",
             separate_losses=separate_losses,
             entropy_coef=0.0,
+            reduction=reduction,
         )
 
         if advantage is not None:
@@ -6127,7 +6129,7 @@ class TestPPO(LossModuleTestBase):
         else:
             raise NotImplementedError
 
-        loss_fn = loss_class(actor, value, loss_critic_type="l2")
+        loss_fn = loss_class(actor, value, loss_critic_type="l2", reduction=reduction)
 
         params = TensorDict.from_module(loss_fn, as_module=True)
 
@@ -6287,7 +6289,7 @@ class TestPPO(LossModuleTestBase):
         else:
             raise NotImplementedError
 
-        loss_fn = loss_class(actor, value, loss_critic_type="l2")
+        loss_fn = loss_class(actor, value, loss_critic_type="l2", reduction=reduction)
         loss_fn.set_keys(**tensor_keys)
         if advantage is not None:
             # collect tensordict key names for the advantage module

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -2,12 +2,12 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
 import argparse
 import contextlib
 import functools
 import itertools
 import operator
+import sys
 import warnings
 from copy import deepcopy
 from dataclasses import asdict, dataclass
@@ -153,6 +153,10 @@ from torchrl.objectives.value.utils import (
     _make_gammas_tensor,
     _split_and_pad_sequence,
 )
+
+
+# Increase recursion limit, some objectives have more than 1000 tests
+sys.setrecursionlimit(2000)
 
 
 class _check_td_steady:
@@ -7286,7 +7290,10 @@ class TestReinforce(LossModuleTestBase):
         torch.manual_seed(self.seed)
         actor, critic, common, td = self._create_mock_common_layer_setup()
         loss_fn = ReinforceLoss(
-            actor_network=actor, critic_network=critic, separate_losses=separate_losses, reduction=reduction
+            actor_network=actor,
+            critic_network=critic,
+            separate_losses=separate_losses,
+            reduction=reduction,
         )
 
         loss = loss_fn(td)

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -30,6 +30,8 @@ from torchrl.objectives.value import (
     VTrace,
 )
 
+from .utils import _reduce
+
 
 class A2CLoss(LossModule):
     """TorchRL implementation of the A2C loss.
@@ -68,6 +70,10 @@ class A2CLoss(LossModule):
             Functionalizing permits features like meta-RL, but makes it
             impossible to use distributed models (DDP, FSDP, ...) and comes
             with a little cost. Defaults to ``True``.
+        reduction (str, optional): Specifies the reduction to apply to the output:
+            ``"none"`` | ``"mean"`` | ``"sum"``. ``"none"``: no reduction will be applied,
+            ``"mean"``: the sum of the output will be divided by the number of
+            elements in the output, ``"sum"``: the output will be summed. Default: ``"mean"``.
 
     .. note:
       The advantage (typically GAE) can be computed by the loss function or
@@ -234,6 +240,7 @@ class A2CLoss(LossModule):
         functional: bool = True,
         actor: ProbabilisticTensorDictSequential = None,
         critic: ProbabilisticTensorDictSequential = None,
+        reduction: str = "mean",
     ):
         if actor is not None:
             actor_network = actor
@@ -276,6 +283,7 @@ class A2CLoss(LossModule):
 
         self.samples_mc_entropy = samples_mc_entropy
         self.entropy_bonus = entropy_bonus and entropy_coef
+        self.reduction = reduction
 
         try:
             device = next(self.parameters()).device
@@ -388,7 +396,7 @@ class A2CLoss(LossModule):
             entropy = dist.entropy()
         except NotImplementedError:
             x = dist.rsample((self.samples_mc_entropy,))
-            entropy = -dist.log_prob(x)
+            entropy = -dist.log_prob(x).mean(0)
         return entropy.unsqueeze(-1)
 
     def _log_probs(
@@ -457,14 +465,16 @@ class A2CLoss(LossModule):
         assert not advantage.requires_grad
         log_probs, dist = self._log_probs(tensordict)
         loss = -(log_probs * advantage)
-        td_out = TensorDict({"loss_objective": loss.mean()}, [])
+        td_out = TensorDict({"loss_objective": loss}, batch_size=tensordict.batch_size)
         if self.entropy_bonus:
             entropy = self.get_entropy_bonus(dist)
-            td_out.set("entropy", entropy.mean().detach())  # for logging
-            td_out.set("loss_entropy", -self.entropy_coef * entropy.mean())
+            td_out.set("entropy", entropy.detach())  # for logging
+            td_out.set("loss_entropy", -self.entropy_coef * entropy)
         if self.critic_coef:
-            loss_critic = self.loss_critic(tensordict).mean()
-            td_out.set("loss_critic", loss_critic.mean())
+            loss_critic = self.loss_critic(tensordict)
+            td_out.set("loss_critic", loss_critic)
+        if self.reduction is not None:
+            td_out = td_out.apply(lambda x: _reduce(x, self.reduction), batch_size=[])
         return td_out
 
     def make_value_estimator(self, value_type: ValueEstimators = None, **hyperparams):

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -793,8 +793,8 @@ class ClipPPOLoss(PPOLoss):
             td_out.set("loss_critic", loss_critic)
 
         if self.reduction is not None:
-            td_out.set("ESS", ess / batch)
             td_out = td_out.apply(lambda x: _reduce(x, self.reduction), batch_size=[])
+            td_out.set("ESS", _reduce(ess, self.reduction) / batch)
         return td_out
 
 

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -396,7 +396,6 @@ class ReinforceLoss(LossModule):
         if log_prob.shape == advantage.shape[:-1]:
             log_prob = log_prob.unsqueeze(-1)
         loss_actor = -log_prob * advantage.detach()
-        loss_actor = loss_actor.mean()
         td_out = TensorDict(
             {"loss_actor": loss_actor}, batch_size=tensordict.batch_size
         )

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -506,9 +506,7 @@ def _vmap_func(module, *args, func=None, **kwargs):
 
 def _reduce(tensor: torch.Tensor, reduction: str) -> Union[float, torch.Tensor]:
     """Reduces a tensor given the reduction method."""
-    if reduction is None:
-        return tensor
-    elif reduction == "mean":
+    if reduction == "mean":
         result = tensor.mean()
     elif reduction == "sum":
         result = tensor.sum()

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -506,10 +506,12 @@ def _vmap_func(module, *args, func=None, **kwargs):
 
 def _reduce(tensor: torch.Tensor, reduction: str) -> Union[float, torch.Tensor]:
     """Reduces a tensor given the reduction method."""
-    if reduction == "mean":
+    if reduction is None:
+        return tensor
+    elif reduction == "mean":
         result = tensor.mean()
     elif reduction == "sum":
         result = tensor.sum()
     else:
         raise NotImplementedError(f"Unknown reduction method {reduction}")
-    return result.item()
+    return result

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -2,6 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+from __future__ import annotations
 
 import functools
 import re
@@ -501,3 +502,16 @@ def _vmap_func(module, *args, func=None, **kwargs):
             raise RuntimeError(
                 "Please use <loss_module>.set_vmap_randomness('different') to handle random operations during vmap."
             ) from err
+
+
+def _reduce(tensor: torch.Tensor, reduction: str) -> Union[float, torch.Tensor]:
+    """Reduces a tensor given the reduction method."""
+    if reduction is None:
+        return tensor
+    elif reduction == "mean":
+        result = tensor.mean()
+    elif reduction == "sum":
+        result = tensor.sum()
+    else:
+        raise NotImplementedError(f"Unknown reduction method {reduction}")
+    return result.item()


### PR DESCRIPTION
## Description

This PR introduces a reduction option to the on-policy losses, similar to how Torch does it (e.g. https://pytorch.org/docs/stable/generated/torch.nn.MSELoss.html).

The ideas is to validate the approach for on-policy losses, the then move on to replicate it in the other losses.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
