### PR TITLE
[NOMERG] Prototyping tensorclass for losses

### DIFF
--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -6567,7 +6567,13 @@ class TestA2C(LossModuleTestBase):
         else:
             raise NotImplementedError
 
-        loss_fn = A2CLoss(actor, value, loss_critic_type="l2", functional=functional)
+        loss_fn = A2CLoss(
+            actor,
+            value,
+            loss_critic_type="l2",
+            functional=functional,
+            return_tensorclass=False,
+        )
 
         # Check error is raised when actions require grads
         td["action"].requires_grad = True


### PR DESCRIPTION
We project on using @tensorclass to represent losses.

The advantage of tensorclass for losses instead of tensordict is that it will help us use all the features of tensordict while preserving type annotation or even completion.

This draft shows the various steps to integrate this feature:
- Check the `out_keys` of the loss;
- Create a tensorclass with the respective fields;
- Type the forward as returning that class (and/or a tensordict)
- Add an argument to return the class in the constructor with the False value by default;
- Update the docstrings (not done)
- Write a little test to check that things work as expected (this test should be new and not parametrized - if we add one more parameter to the existing tests the code will be much longer and harder to follow, and the tests will run for a long time).

Hopefully, all the losses in torchrl.objectives should be patchable with this.
