### PR TITLE
[NOMERG] Add @overload to forward in losses

### DIFF
--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -6,7 +6,7 @@ import contextlib
 import warnings
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Tuple, overload
+from typing import overload, Tuple
 
 import torch
 from tensordict import TensorDict, TensorDictBase, unravel_key
@@ -448,9 +448,17 @@ class A2CLoss(LossModule):
             return None
         return self.critic_network_params.detach()
 
-
     @overload
-    def forward(self, *, action, next_reward, next_terminated, next_truncated, next_observation, observation):
+    def forward(
+        self,
+        *,
+        action,
+        next_reward,
+        next_terminated,
+        next_truncated,
+        next_observation,
+        observation,
+    ):
         # The key names can be extrapolated from test_a2c_notensordict in test/test_cost.py
         ...
 


### PR DESCRIPTION
Loss functions accept non-tensordict data thanks to the tensordict.dispatch decorator.

However, we do not provide an overloaded forward, which could be useful to let users know about the typical signature using default settings.

In this PR, I propose that feature for A2C. The list input keys can be found in `A2CLoss.in_keys` property and also extrapolated from `test/test_cost.py:TestA2C:test_a2c_notensordict`.

All losses that are tested with `test_<smth>_notensordict` can benefit from this overload.
