### PR TITLE
[Feature] Checking for dtype to all tensorspec is_in funcs

### DIFF
--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1456,7 +1456,7 @@ class OneHotDiscreteTensorSpec(TensorSpec):
         shape = torch.broadcast_shapes(shape, val.shape)
         mask_expand = self.mask.expand(shape)
         gathered = mask_expand & val
-        return gathered.any(-1).all() and val.dtype == self.dtype and val.shape[-len(self.shape):] == self.shape
+        return (gathered.sum(-1) == 1).all() and val.dtype == self.dtype and val.shape[-len(self.shape):] == self.shape
 
     def __eq__(self, other):
         if not hasattr(other, "mask"):

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1456,7 +1456,11 @@ class OneHotDiscreteTensorSpec(TensorSpec):
         shape = torch.broadcast_shapes(shape, val.shape)
         mask_expand = self.mask.expand(shape)
         gathered = mask_expand & val
-        return (gathered.sum(-1) == 1).all() and val.dtype == self.dtype and val.shape[-len(self.shape):] == self.shape
+        return (
+            (gathered.sum(-1) == 1).all()
+            and val.dtype == self.dtype
+            and val.shape[-len(self.shape) :] == self.shape
+        )
 
     def __eq__(self, other):
         if not hasattr(other, "mask"):
@@ -1763,9 +1767,12 @@ class BoundedTensorSpec(TensorSpec):
 
     def is_in(self, val: torch.Tensor) -> bool:
         try:
-            return (val >= self.space.low.to(val.device)).all() and (
-                val <= self.space.high.to(val.device)
-            ).all() and (val.dtype == self.dtype) and (val.shape[-len(self.shape):] == self.shape)
+            return (
+                (val >= self.space.low.to(val.device)).all()
+                and (val <= self.space.high.to(val.device)).all()
+                and (val.dtype == self.dtype)
+                and (val.shape[-len(self.shape) :] == self.shape)
+            )
         except RuntimeError as err:
             if "The size of tensor a" in str(err):
                 warnings.warn(f"Got a shape mismatch: {str(err)}")
@@ -1894,7 +1901,7 @@ class UnboundedContinuousTensorSpec(TensorSpec):
         return torch.empty(shape, device=self.device, dtype=self.dtype).random_()
 
     def is_in(self, val: torch.Tensor) -> bool:
-        return val.dtype == self.dtype and val.shape[-len(self.shape):] == self.shape
+        return val.dtype == self.dtype and val.shape[-len(self.shape) :] == self.shape
 
     def expand(self, *shape):
         if len(shape) == 1 and isinstance(shape[0], (tuple, list, torch.Size)):
@@ -2034,7 +2041,7 @@ class UnboundedDiscreteTensorSpec(TensorSpec):
         return r.to(self.device)
 
     def is_in(self, val: torch.Tensor) -> bool:
-        return val.dtype == self.dtype and val.shape[-len(self.shape):] == self.shape
+        return val.dtype == self.dtype and val.shape[-len(self.shape) :] == self.shape
 
     def expand(self, *shape):
         if len(shape) == 1 and isinstance(shape[0], (tuple, list, torch.Size)):
@@ -2589,7 +2596,11 @@ class DiscreteTensorSpec(TensorSpec):
         shape = torch.Size([*torch.broadcast_shapes(shape[:-1], val.shape), shape[-1]])
         mask_expand = self.mask.expand(shape)
         gathered = mask_expand.gather(-1, val.unsqueeze(-1))
-        return gathered.all() and (val.dtype == self.dtype) and (val.shape[-len(self.shape):] == self.shape)
+        return (
+            gathered.all()
+            and (val.dtype == self.dtype)
+            and (val.shape[-len(self.shape) :] == self.shape)
+        )
 
     def __getitem__(self, idx: SHAPE_INDEX_TYPING):
         """Indexes the current TensorSpec based on the provided index."""

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1456,7 +1456,7 @@ class OneHotDiscreteTensorSpec(TensorSpec):
         shape = torch.broadcast_shapes(shape, val.shape)
         mask_expand = self.mask.expand(shape)
         gathered = mask_expand & val
-        return gathered.any(-1).all() and val.dtype == self.dtype
+        return gathered.any(-1).all() and val.dtype == self.dtype and val.shape[-len(self.shape):] == self.shape
 
     def __eq__(self, other):
         if not hasattr(other, "mask"):
@@ -1765,7 +1765,7 @@ class BoundedTensorSpec(TensorSpec):
         try:
             return (val >= self.space.low.to(val.device)).all() and (
                 val <= self.space.high.to(val.device)
-            ).all() and (val.dtype == self.dtype)
+            ).all() and (val.dtype == self.dtype) and (val.shape[-len(self.shape):] == self.shape)
         except RuntimeError as err:
             if "The size of tensor a" in str(err):
                 warnings.warn(f"Got a shape mismatch: {str(err)}")
@@ -1894,7 +1894,7 @@ class UnboundedContinuousTensorSpec(TensorSpec):
         return torch.empty(shape, device=self.device, dtype=self.dtype).random_()
 
     def is_in(self, val: torch.Tensor) -> bool:
-        return val.dtype == self.dtype
+        return val.dtype == self.dtype and val.shape[-len(self.shape):] == self.shape
 
     def expand(self, *shape):
         if len(shape) == 1 and isinstance(shape[0], (tuple, list, torch.Size)):
@@ -2034,7 +2034,7 @@ class UnboundedDiscreteTensorSpec(TensorSpec):
         return r.to(self.device)
 
     def is_in(self, val: torch.Tensor) -> bool:
-        return val.dtype == self.dtype
+        return val.dtype == self.dtype and val.shape[-len(self.shape):] == self.shape
 
     def expand(self, *shape):
         if len(shape) == 1 and isinstance(shape[0], (tuple, list, torch.Size)):
@@ -2333,7 +2333,7 @@ class MultiOneHotDiscreteTensorSpec(OneHotDiscreteTensorSpec):
         vals = self._split(val)
         if vals is None:
             return False
-        return all(spec.is_in(val) for val, spec in zip(vals, self._split_self())) and (val.dtype == self.dtype)
+        return all(spec.is_in(val) for val, spec in zip(vals, self._split_self()))
 
     def _project(self, val: torch.Tensor) -> torch.Tensor:
         vals = self._split(val)
@@ -2589,7 +2589,7 @@ class DiscreteTensorSpec(TensorSpec):
         shape = torch.Size([*torch.broadcast_shapes(shape[:-1], val.shape), shape[-1]])
         mask_expand = self.mask.expand(shape)
         gathered = mask_expand.gather(-1, val.unsqueeze(-1))
-        return gathered.all() and (val.dtype == self.dtype)
+        return gathered.all() and (val.dtype == self.dtype) and (val.shape[-len(self.shape):] == self.shape)
 
     def __getitem__(self, idx: SHAPE_INDEX_TYPING):
         """Indexes the current TensorSpec based on the provided index."""
@@ -3585,7 +3585,7 @@ class CompositeSpec(TensorSpec):
             val_item = val.get(key)
             if not item.is_in(val_item):
                 return False
-        return val.dtype == self.dtype
+        return True
 
     def project(self, val: TensorDictBase) -> TensorDictBase:
         for key, item in self.items():
@@ -4107,7 +4107,7 @@ class LazyStackedCompositeSpec(_LazyStackedMixin[CompositeSpec], CompositeSpec):
         for spec, subval in zip(self._specs, val.unbind(self.dim)):
             if not spec.is_in(subval):
                 return False
-        return val.dtype == self.dtype
+        return True
 
     def __delitem__(self, key: NestedKey):
         """Deletes a key from the stacked composite spec.


### PR DESCRIPTION
## Description

I've added a check to all `is_in` functions in TensorSpec for the datatype, as specified in #793.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

Close #793 initially proposed in #783

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
