### PR TITLE
[BugFix] Fix offline CatFrames

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1001,8 +1001,7 @@ class TestCatFrames(TransformBase):
 
         r2 = c(r)
 
-        print(r2["observation_cat2"][0, :2])
-        print(r2["observation_cat"][0, :2])
+        torch.testing.assert_close(r2["observation_cat2"], r2["observation_cat"])
         assert (r2["observation_cat2"] == r2["observation_cat"]).all()
 
         assert (r2["next", "observation_cat2"] == r2["next", "observation_cat"]).all()

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -2981,8 +2981,15 @@ class CatFrames(ObservationTransform):
             if self.padding != "same":
                 data = torch.where(done_mask, self.padding_value, data)
             else:
+                # TODO: we actually need for data_orig[:, 1] to contain info from data_orig[:, 0]
+                data_orig = torch.cat([
+                    data_orig[:, :1].repeat_interleave(self.N-1),
+                    data], tensordict.ndim - 1)
+
+                data_orig = data_orig.unfold(tensordict.ndim - 1, self.N, 1)
+
                 data = torch.where(
-                    done_mask, data_orig.unsqueeze(-1).expand_as(data), data
+                    done_mask, data_orig, data
                 )
             data = data.permute(
                 *range(0, data.ndim + self.dim - 1),

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -2994,10 +2994,11 @@ class CatFrames(ObservationTransform):
             else:
                 # TODO: This is a pretty bad implementation, could be
                 # made more efficient but it works!
-                reset_vals = list(data_orig[reset.squeeze()].unbind(0))
+                reset_vals = list(data_orig[reset.squeeze(-1)].unbind(0))
                 j_ = float("inf")
                 reps = []
-                for j in done_mask_expand.sum(-1).sum(self.dim).view(-1) // n_feat:
+                d = data.ndim + self.dim - 1
+                for j in done_mask_expand.sum(d).sum(d).view(-1) // n_feat:
                     if j > j_:
                         reset_vals = reset_vals[1:]
                     reps.extend([reset_vals[0]] * int(j))


### PR DESCRIPTION
Currently offline catframes is broken
- it does not return cat but stacks
- it ignores reset signals

I'm trying to fix this

Example code:

```python

from torchrl.envs import GymEnv, TransformedEnv, CatFrames, SerialEnv

env = SerialEnv(3, lambda: TransformedEnv(GymEnv("CartPole-v1"), CatFrames(dim=-1, N=4, in_keys=["observation"], out_keys=["observation_cat"], padding="constant")))

r = env.rollout(100, break_when_any_done=False)


c = CatFrames(dim=-1, N=4, in_keys=["observation", ("next", "observation")], out_keys=["observation_cat2", ("next", "observation_cat2")], padding="constant")

r2 = c(r)

assert (r2["observation_cat2"] == r2["observation_cat"]).all()

assert (r2["next", "observation_cat2"] == r2["next", "observation_cat"]).all()
```

cc @btx0424 @BY571 