### PR TITLE
[BugFix] Fix strict-length for spanning trajectories

### DIFF
--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -2681,7 +2681,7 @@ class TestRBMultidim:
             for t in transform:
                 rb.append_transform(t())
         try:
-            for i, data in enumerate(collector):
+            for i, data in enumerate(collector):  # noqa: B007
                 rb.extend(data)
                 if isinstance(rb, TensorDictReplayBuffer) and transform is not None:
                     # this should fail bc we can't set the indices after executing the transform.
@@ -2697,8 +2697,8 @@ class TestRBMultidim:
                 if transform is not None:
                     assert s.ndim == 2
         except Exception:
-            print(f"Failing at iter {i}")
-            print(f"rb {rb}")
+            print(f"Failing at iter {i}")  # noqa: T201
+            print(f"rb {rb}")  # noqa: T201
             raise
 
 

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -2680,19 +2680,26 @@ class TestRBMultidim:
         if transform:
             for t in transform:
                 rb.append_transform(t())
-        for data in collector:
-            rb.extend(data)
-            if isinstance(rb, TensorDictReplayBuffer) and transform is not None:
-                # this should fail bc we can't set the indices after executing the transform.
-                with pytest.raises(RuntimeError, match="Failed to set the metadata"):
-                    rb.sample()
-                return
-            s = rb.sample()
-            rbtot = rb[:]
-            assert rbtot.shape[0] == 2
-            assert len(rb) == rbtot.numel()
-            if transform is not None:
-                assert s.ndim == 2
+        try:
+            for i, data in enumerate(collector):
+                rb.extend(data)
+                if isinstance(rb, TensorDictReplayBuffer) and transform is not None:
+                    # this should fail bc we can't set the indices after executing the transform.
+                    with pytest.raises(
+                        RuntimeError, match="Failed to set the metadata"
+                    ):
+                        rb.sample()
+                    return
+                s = rb.sample()
+                rbtot = rb[:]
+                assert rbtot.shape[0] == 2
+                assert len(rb) == rbtot.numel()
+                if transform is not None:
+                    assert s.ndim == 2
+        except Exception:
+            print(f"Failing at iter {i}")
+            print(f"rb {rb}")
+            raise
 
 
 if __name__ == "__main__":

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -1904,7 +1904,7 @@ class TestSamplers:
         )
 
         done = torch.zeros(100, 1, dtype=torch.bool)
-        done[torch.tensor([29, 54, 69])] = 1
+        done[torch.tensor([29, 54, 69, 99])] = 1
 
         data = TensorDict(
             {

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -736,7 +736,8 @@ class SliceSampler(Sampler):
                     "To be used, trajectories requires `cache_values` to be set to `True`."
                 )
             vals = self._find_start_stop_traj(
-                trajectory=trajectories, at_capacity=True,
+                trajectory=trajectories,
+                at_capacity=True,
             )
             self._cache["stop-and-length"] = vals
 

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -610,10 +610,16 @@ class SliceSampler(Sampler):
             To be used whenever the ``end_key`` or ``traj_key`` is expensive to get,
             or when this signal is readily available. Must be used with ``cache_values=True``
             and cannot be used in conjunction with ``end_key`` or ``traj_key``.
+            If provided, it is assumed that the storage is at capacity and that
+            if the last element of the ``ends`` tensor is ``False``,
+            the same trajectory spans across end and beginning.
         trajectories (torch.Tensor, optional): a 1d integer tensor containing the run ids.
             To be used whenever the ``end_key`` or ``traj_key`` is expensive to get,
             or when this signal is readily available. Must be used with ``cache_values=True``
             and cannot be used in conjunction with ``end_key`` or ``traj_key``.
+            If provided, it is assumed that the storage is at capacity and that
+            if the last element of the trajectory tensor is identical to the first,
+            the same trajectory spans across end and beginning.
         cache_values (bool, optional): to be used with static datasets.
             Will cache the start and end signal of the trajectory.
         truncated_key (NestedKey, optional): If not ``None``, this argument
@@ -730,7 +736,7 @@ class SliceSampler(Sampler):
                     "To be used, trajectories requires `cache_values` to be set to `True`."
                 )
             vals = self._find_start_stop_traj(
-                trajectory=trajectories, at_capacity=storage._is_full
+                trajectory=trajectories, at_capacity=True,
             )
             self._cache["stop-and-length"] = vals
 
@@ -745,7 +751,7 @@ class SliceSampler(Sampler):
                 raise RuntimeError(
                     "To be used, ends requires `cache_values` to be set to `True`."
                 )
-            vals = self._find_start_stop_traj(end=ends, at_capacity=storage._is_full)
+            vals = self._find_start_stop_traj(end=ends, at_capacity=True)
             self._cache["stop-and-length"] = vals
 
         else:


### PR DESCRIPTION
Solves #1969  as discussed in the issue

To test the feature:
```python

from torchrl.data import ReplayBuffer, SliceSampler, LazyTensorStorage
from tensordict import TensorDict
import torch


trajectory0 = torch.tensor([3, 3, 0, 1, 1, 1, 2, 2, 2, 3])
trajectory1 = torch.arange(10)
trajectory = torch.stack([trajectory0, trajectory1], -1)

td = TensorDict({"trajectory": trajectory, "steps": torch.arange(10).view(10, 1).expand(10, 2)}, [10, 2]).transpose(-2, -1).clone()
print(td)

rb = ReplayBuffer(
    sampler=SliceSampler(traj_key="trajectory", num_slices=2),
    storage=LazyTensorStorage(20, ndim=2),
    batch_size=6
)

rb.extend(td)

s = rb.sample()
print(s["steps"])
print(s["trajectory"])
```

Which can give
```
tensor([9, 0, 1, 6, 7, 8])
tensor([3, 3, 3, 2, 2, 2])
```

cc @nicklashansen @dasGringuen @aalmuzairee 