### PR TITLE
[BugFix] fix formatting for VideoRecorder docstring

### DIFF
--- a/torchrl/record/recorder.py
+++ b/torchrl/record/recorder.py
@@ -43,23 +43,27 @@ class VideoRecorder(ObservationTransform):
 
     Examples:
         The following example shows how to save a rollout under a video. First a few imports:
+
         >>> from torchrl.record import VideoRecorder
         >>> from torchrl.record.loggers.csv import CSVLogger
         >>> from torchrl.envs import TransformedEnv, DMControlEnv
 
         The video format is chosen in the logger. Wandb and tensorboard will take care of that
         on their own, CSV accepts various video formats.
+
         >>> logger = CSVLogger(exp_name="cheetah", log_dir="cheetah_videos", video_format="mp4")
 
         Some envs (eg, Atari games) natively return images, some require the user to ask for them.
-        Check :class:`~torchrl.env.GymEnv` or :class:`~torchrl.envs.DMControlEnv` to see how to render images
+        Check :class:`~torchrl.envs.GymEnv` or :class:`~torchrl.envs.DMControlEnv` to see how to render images
         in these contexts.
+
         >>> base_env = DMControlEnv("cheetah", "run", from_pixels=True)
         >>> env = TransformedEnv(base_env, VideoRecorder(logger=logger, tag="run_video"))
         >>> env.rollout(100)
 
         All transforms have a dump function, mostly a no-op except for ``VideoRecorder``, and :class:`~torchrl.envs.transforms.Composite`
         which will dispatch the `dumps` to all its members.
+
         >>> env.transform.dump()
 
     Our video is available under ``./cheetah_videos/cheetah/videos/run_video_0.mp4``!

--- a/torchrl/record/recorder.py
+++ b/torchrl/record/recorder.py
@@ -61,7 +61,7 @@ class VideoRecorder(ObservationTransform):
         >>> env = TransformedEnv(base_env, VideoRecorder(logger=logger, tag="run_video"))
         >>> env.rollout(100)
 
-        All transforms have a dump function, mostly a no-op except for ``VideoRecorder``, and :class:`~torchrl.envs.transforms.Composite`
+        All transforms have a dump function, mostly a no-op except for ``VideoRecorder``, and :class:`~torchrl.envs.transforms.Compose`
         which will dispatch the `dumps` to all its members.
 
         >>> env.transform.dump()


### PR DESCRIPTION
## Description

Fixes the formatting for the VideoRecorder docstring example, which is [currently broken](https://pytorch.org/rl/reference/generated/torchrl.record.VideoRecorder.html).

## Types of changes

- [X] Documentation (update in the documentation)

## Checklist

- [X] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [X] I have updated the documentation accordingly.
