### PR TITLE
[Performance] Faster DMC

### DIFF
--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -12151,7 +12151,6 @@ class TestValues:
             time_dim=-3,
         )[0]
 
-
         v2 = vec_generalized_advantage_estimate(
             gamma=gamma,
             lmbda=lmbda,

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1555,9 +1555,9 @@ class BoundedTensorSpec(TensorSpec):
             dtype = torch.get_default_dtype()
 
         if not isinstance(low, torch.Tensor):
-            low = torch.as_tensor(low, dtype=dtype, device=device)
+            low = torch.tensor(low, dtype=dtype, device=device)
         if not isinstance(high, torch.Tensor):
-            high = torch.as_tensor(high, dtype=dtype, device=device)
+            high = torch.tensor(high, dtype=dtype, device=device)
         if high.device != device:
             high = high.to(device)
         if low.device != device:

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -3599,13 +3599,17 @@ class CompositeSpec(TensorSpec):
     def rand(self, shape=None) -> TensorDictBase:
         if shape is None:
             shape = torch.Size([])
-        _dict = {
-            key: self[key].rand(shape) for key in self.keys() if self[key] is not None
-        }
+        _dict = {}
+        for key, item in self.items():
+            if item is not None:
+                _dict[key] = item.rand(shape)
         return TensorDict(
             _dict,
             batch_size=[*shape, *self.shape],
             device=self._device,
+            # No need to run checks since we know Composite is compliant with
+            # TensorDict requirements
+            _run_checks=False,
         )
 
     def keys(

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -576,9 +576,9 @@ class TensorSpec:
             ):
                 val = val.copy()
             if not ignore_device:
-                val = torch.tensor(val, device=self.device, dtype=self.dtype)
+                val = torch.as_tensor(val, device=self.device, dtype=self.dtype)
             else:
-                val = torch.tensor(val, dtype=self.dtype)
+                val = torch.as_tensor(val, dtype=self.dtype)
             if val.shape != self.shape:
                 # if val.shape[-len(self.shape) :] != self.shape:
                 # option 1: add a singleton dim at the end

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -576,9 +576,9 @@ class TensorSpec:
             ):
                 val = val.copy()
             if not ignore_device:
-                val = torch.as_tensor(val, device=self.device, dtype=self.dtype)
+                val = torch.tensor(val, device=self.device, dtype=self.dtype)
             else:
-                val = torch.as_tensor(val, dtype=self.dtype)
+                val = torch.tensor(val, dtype=self.dtype)
             if val.shape != self.shape:
                 # if val.shape[-len(self.shape) :] != self.shape:
                 # option 1: add a singleton dim at the end

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -3605,7 +3605,7 @@ class CompositeSpec(TensorSpec):
                 _dict[key] = item.rand(shape)
         return TensorDict(
             _dict,
-            batch_size=[*shape, *self.shape],
+            batch_size=torch.Size([*shape, *self.shape]),
             device=self._device,
             # No need to run checks since we know Composite is compliant with
             # TensorDict requirements

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -2680,7 +2680,7 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
         """
         if self._simple_done:
             done = tensordict._get_str("done", default=None)
-            tensordict._set_str("done", done.clone(), validated=True, inplace=False)
+            tensordict._set_str("_reset", done.clone(), validated=True, inplace=False)
             any_done = done.any()
         else:
             any_done = _terminated_or_truncated(

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -2551,7 +2551,7 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
             if i == max_steps - 1:
                 # we don't truncated as one could potentially continue the run
                 break
-            tensordict = self._step_mdp_stop_early(tensordict)
+            tensordict = self._step_mdp(tensordict)
 
             # done and truncated are in done_keys
             # We read if any key is done.

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -2680,8 +2680,11 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
         """
         if self._simple_done:
             done = tensordict._get_str("done", default=None)
-            tensordict._set_str("_reset", done.clone(), validated=True, inplace=False)
             any_done = done.any()
+            if any_done:
+                tensordict._set_str(
+                    "_reset", done.clone(), validated=True, inplace=False
+                )
         else:
             any_done = _terminated_or_truncated(
                 tensordict,

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -21,7 +21,7 @@ from torchrl.data.tensor_specs import (
     UnboundedContinuousTensorSpec,
 )
 from torchrl.envs.common import _EnvWrapper
-from collections import Mapping
+from typing import Mapping
 
 class BaseInfoDictReader(metaclass=abc.ABCMeta):
     """Base class for info-readers."""

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -31,7 +31,8 @@ class BaseInfoDictReader(metaclass=abc.ABCMeta):
     ) -> TensorDictBase:
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def info_spec(self) -> Dict[str, TensorSpec]:
         raise NotImplementedError
 

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import abc
-import itertools
 import warnings
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
@@ -261,18 +260,14 @@ class GymLikeEnv(_EnvWrapper):
                 # when queried with and without pixels
                 observations["observation"] = observations.pop("state")
         if not isinstance(observations, Mapping):
-            observations_dict = None
             for key, spec in self.observation_spec.items(True, True):
-                if observations_dict is None:
-                    observations_dict = {}
-                    observations_dict[key] = spec.encode(
-                        observations, ignore_device=True
-                    )
-                else:
-                    raise RuntimeError(
-                        "There is more than one observation key but only one observation "
-                        "was found in the step data."
-                    )
+                observations_dict = {}
+                observations_dict[key] = spec.encode(observations, ignore_device=True)
+                # we don't check that there is only one spec because obs spec also
+                # contains the data spec of the info dict.
+                break
+            else:
+                raise RuntimeError("Could not find any element in observation_spec.")
             observations = observations_dict
         else:
             for key, val in observations.items():

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import abc
 import itertools
 import warnings
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -21,7 +21,7 @@ from torchrl.data.tensor_specs import (
     UnboundedContinuousTensorSpec,
 )
 from torchrl.envs.common import _EnvWrapper
-from typing import Mapping
+
 
 class BaseInfoDictReader(metaclass=abc.ABCMeta):
     """Base class for info-readers."""
@@ -265,10 +265,14 @@ class GymLikeEnv(_EnvWrapper):
             for key, spec in self.observation_spec.items(True, True):
                 if observations_dict is None:
                     observations_dict = {}
-                    observations_dict[key] = spec.encode(observations, ignore_device=True)
+                    observations_dict[key] = spec.encode(
+                        observations, ignore_device=True
+                    )
                 else:
-                    raise RuntimeError("There is more than one observation key but only one observation "
-                                       "was found in the step data.")
+                    raise RuntimeError(
+                        "There is more than one observation key but only one observation "
+                        "was found in the step data."
+                    )
             observations = observations_dict
         else:
             for key, val in observations.items():
@@ -327,7 +331,8 @@ class GymLikeEnv(_EnvWrapper):
             tensordict_out = TensorDict(
                 obs_dict, batch_size=tensordict.batch_size, _run_checks=False
             )
-        tensordict_out = tensordict_out.to(self.device, non_blocking=True)
+        if self.device is not None:
+            tensordict_out = tensordict_out.to(self.device, non_blocking=True)
 
         if self.info_dict_reader and (info_dict is not None):
             if not isinstance(info_dict, dict):

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -1089,9 +1089,9 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
             # since it's not a bool, we make it so
             terminated = bool(terminated)
 
-        if isinstance(observations, list) and len(obs) == 1:
+        if isinstance(observations, list) and len(observations) == 1:
             # Until gym 0.25.2 we had rendered frames returned in lists of length 1
-            obs = obs[0]
+            observations = observations[0]
 
         return (observations, reward, terminated, truncated, done, info)
 

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -1062,6 +1062,11 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
             # if it's not a ndarray, we must return bool
             # since it's not a bool, we make it so
             terminated = bool(terminated)
+
+        if isinstance(observations, list) and len(obs) == 1:
+            # Until gym 0.25.2 we had rendered frames returned in lists of length 1
+            obs = obs[0]
+
         return (observations, reward, terminated, truncated, done, info)
 
     @implement_for("gym", "0.24", "0.26")
@@ -1083,6 +1088,11 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
             # if it's not a ndarray, we must return bool
             # since it's not a bool, we make it so
             terminated = bool(terminated)
+
+        if isinstance(observations, list) and len(obs) == 1:
+            # Until gym 0.25.2 we had rendered frames returned in lists of length 1
+            obs = obs[0]
+
         return (observations, reward, terminated, truncated, done, info)
 
     @implement_for("gym", "0.26", None)

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -1063,9 +1063,9 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
             # since it's not a bool, we make it so
             terminated = bool(terminated)
 
-        if isinstance(observations, list) and len(obs) == 1:
+        if isinstance(observations, list) and len(observations) == 1:
             # Until gym 0.25.2 we had rendered frames returned in lists of length 1
-            obs = obs[0]
+            observations = observations[0]
 
         return (observations, reward, terminated, truncated, done, info)
 

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -733,7 +733,6 @@ but got an object of type {type(transform)}."""
     def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
         # No need to clone here because inv does it already
         # tensordict = tensordict.clone(False)
-
         next_preset = tensordict.get("next", None)
         tensordict_in = self.transform.inv(tensordict)
         next_tensordict = self.base_env._step(tensordict_in)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -317,9 +317,8 @@ class Transform(nn.Module):
             return state
 
     def _inv_call(self, tensordict: TensorDictBase) -> TensorDictBase:
-        # # We create a shallow copy of the tensordict to avoid that changes are
-        # # exposed to the user: we'd like that the input keys remain unchanged
-        # # in the originating script if they're being transformed.
+        if not self.in_keys_inv:
+            return tensordict
         for in_key, out_key in zip(self.in_keys_inv, self.out_keys_inv):
             data = tensordict.get(in_key, None)
             if data is not None:
@@ -3281,6 +3280,16 @@ class DTypeCastTransform(Transform):
         in_keys_inv: Sequence[NestedKey] | None = None,
         out_keys_inv: Sequence[NestedKey] | None = None,
     ):
+        if in_keys is not None and in_keys_inv is None:
+            warnings.warn(
+                "in_keys have been provided but not in_keys_inv. From v0.5, "
+                "this will result in in_keys_inv being an empty list whereas "
+                "now the input keys are retrieved automatically. "
+                "To silence this warning, pass the (possibly empty) "
+                "list of in_keys_inv.",
+                category=DeprecationWarning,
+            )
+
         self.dtype_in = dtype_in
         self.dtype_out = dtype_out
         super().__init__(


### PR DESCRIPTION
Other improvements to explore:
- usage of `to` in env._step may be unnecessary if no mapping is needed
- step_mdp takes 11% of runtime and _set called within another 8% (2.2% own time). Improving on `_set` could speed things up drastically
- tensordict.get takes another 5.1%

cc @teopir