### PR TITLE
[Feature] RB MultiStep transform

### DIFF
--- a/docs/source/reference/data.rst
+++ b/docs/source/reference/data.rst
@@ -823,3 +823,11 @@ Utils
     consolidate_spec
     check_no_exclusive_keys
     contains_lazy_spec
+
+.. currentmodule:: torchrl.envs.transforms.rb_transforms
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template.rst
+
+    MultiStepTransform

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -547,7 +547,7 @@ class TestDQN(LossModuleTestBase):
         loss_fn2 = DQNLoss(actor, loss_function="l2", delay_value=delay_value)
         loss_fn2.load_state_dict(sd)
 
-    @pytest.mark.parametrize("n", range(4))
+    @pytest.mark.parametrize("n", range(1, 4))
     @pytest.mark.parametrize("delay_value", (False, True))
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("action_spec_type", ("one_hot", "categorical"))
@@ -579,7 +579,7 @@ class TestDQN(LossModuleTestBase):
 
         with torch.no_grad():
             loss = loss_fn(td)
-        if n == 0:
+        if n == 1:
             assert_allclose_td(td, ms_td.select(*td.keys(True, True)))
             _loss = sum(
                 [item for name, item in loss.items() if name.startswith("loss")]
@@ -1125,7 +1125,7 @@ class TestQMixer(LossModuleTestBase):
         loss_fn2 = QMixerLoss(actor, mixer, loss_function="l2", delay_value=delay_value)
         loss_fn2.load_state_dict(sd)
 
-    @pytest.mark.parametrize("n", range(4))
+    @pytest.mark.parametrize("n", range(1, 4))
     @pytest.mark.parametrize("delay_value", (False, True))
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("action_spec_type", ("one_hot", "categorical"))
@@ -1158,7 +1158,7 @@ class TestQMixer(LossModuleTestBase):
 
         with torch.no_grad():
             loss = loss_fn(td)
-        if n == 0:
+        if n == 1:
             assert_allclose_td(td, ms_td.select(*td.keys(True, True)))
             _loss = sum(
                 [item for name, item in loss.items() if name.startswith("loss")]
@@ -1801,7 +1801,7 @@ class TestDDPG(LossModuleTestBase):
                 raise NotImplementedError(k)
             loss_fn.zero_grad()
 
-    @pytest.mark.parametrize("n", list(range(4)))
+    @pytest.mark.parametrize("n", range(1, 4))
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("delay_actor,delay_value", [(False, False), (True, True)])
     def test_ddpg_batcher(self, n, delay_actor, delay_value, device, gamma=0.9):
@@ -1832,7 +1832,7 @@ class TestDDPG(LossModuleTestBase):
 
         with torch.no_grad():
             loss = loss_fn(td)
-        if n == 0:
+        if n == 1:
             assert_allclose_td(td, ms_td.select(*list(td.keys(True, True))))
             _loss = sum(
                 [item for name, item in loss.items() if name.startswith("loss_")]
@@ -2433,7 +2433,7 @@ class TestTD3(LossModuleTestBase):
                 loss_fn.zero_grad()
 
     @pytest.mark.skipif(not _has_functorch, reason="functorch not installed")
-    @pytest.mark.parametrize("n", list(range(4)))
+    @pytest.mark.parametrize("n", range(1, 4))
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("delay_actor,delay_qvalue", [(False, False), (True, True)])
     @pytest.mark.parametrize("policy_noise", [0.1, 1.0])
@@ -2479,7 +2479,7 @@ class TestTD3(LossModuleTestBase):
             np.random.seed(0)
             loss = loss_fn(td)
 
-        if n == 0:
+        if n == 1:
             assert_allclose_td(td, ms_td.select(*list(td.keys(True, True))))
             _loss = sum(
                 [item for name, item in loss.items() if name.startswith("loss_")]
@@ -3228,7 +3228,7 @@ class TestSAC(LossModuleTestBase):
                     raise NotImplementedError(k)
                 loss_fn.zero_grad()
 
-    @pytest.mark.parametrize("n", list(range(4)))
+    @pytest.mark.parametrize("n", range(1, 4))
     @pytest.mark.parametrize("delay_value", (True, False))
     @pytest.mark.parametrize("delay_actor", (True, False))
     @pytest.mark.parametrize("delay_qvalue", (True, False))
@@ -3292,7 +3292,7 @@ class TestSAC(LossModuleTestBase):
                 torch.manual_seed(0)  # log-prob is computed with a random action
                 np.random.seed(0)
                 loss = loss_fn(td)
-            if n == 0:
+            if n == 1:
                 assert_allclose_td(td, ms_td.select(*list(td.keys(True, True))))
                 _loss = sum(
                     [item for name, item in loss.items() if name.startswith("loss_")]
@@ -3927,7 +3927,7 @@ class TestDiscreteSAC(LossModuleTestBase):
         )
         loss_fn2.load_state_dict(sd)
 
-    @pytest.mark.parametrize("n", list(range(4)))
+    @pytest.mark.parametrize("n", range(1, 4))
     @pytest.mark.parametrize("delay_qvalue", (True, False))
     @pytest.mark.parametrize("num_qvalue", [2])
     @pytest.mark.parametrize("device", get_default_devices())
@@ -3983,7 +3983,7 @@ class TestDiscreteSAC(LossModuleTestBase):
             torch.manual_seed(0)  # log-prob is computed with a random action
             np.random.seed(0)
             loss = loss_fn(td)
-        if n == 0:
+        if n == 1:
             assert_allclose_td(td, ms_td.select(*list(td.keys(True, True))))
             _loss = sum(
                 [item for name, item in loss.items() if name.startswith("loss_")]
@@ -4871,7 +4871,7 @@ class TestREDQ(LossModuleTestBase):
         # TODO: find a way to compare the losses: problem is that we sample actions either sequentially or in batch,
         #  so setting seed has little impact
 
-    @pytest.mark.parametrize("n", list(range(4)))
+    @pytest.mark.parametrize("n", range(1, 4))
     @pytest.mark.parametrize("delay_qvalue", (True, False))
     @pytest.mark.parametrize("num_qvalue", [1, 2, 4, 8])
     @pytest.mark.parametrize("device", get_default_devices())
@@ -4914,7 +4914,7 @@ class TestREDQ(LossModuleTestBase):
                 torch.manual_seed(0)  # log-prob is computed with a random action
                 np.random.seed(0)
                 loss = loss_fn(td)
-            if n == 0:
+            if n == 1:
                 assert_allclose_td(td, ms_td.select(*list(td.keys(True, True))))
                 _loss = sum(
                     [item for name, item in loss.items() if name.startswith("loss_")]
@@ -5482,7 +5482,7 @@ class TestCQL(LossModuleTestBase):
         )
         loss_fn2.load_state_dict(sd)
 
-    @pytest.mark.parametrize("n", list(range(4)))
+    @pytest.mark.parametrize("n", range(1, 4))
     @pytest.mark.parametrize("delay_actor", (True, False))
     @pytest.mark.parametrize("delay_qvalue", (True, False))
     @pytest.mark.parametrize("max_q_backup", [True, False])
@@ -5537,7 +5537,7 @@ class TestCQL(LossModuleTestBase):
                 torch.manual_seed(0)  # log-prob is computed with a random action
                 np.random.seed(0)
                 loss = loss_fn(td)
-            if n == 0:
+            if n == 1:
                 assert_allclose_td(td, ms_td.select(*list(td.keys(True, True))))
                 _loss = sum(
                     [item for name, item in loss.items() if name.startswith("loss_")]
@@ -5843,7 +5843,7 @@ class TestDiscreteCQL(LossModuleTestBase):
         loss_fn2 = DiscreteCQLLoss(actor, loss_function="l2", delay_value=delay_value)
         loss_fn2.load_state_dict(sd)
 
-    @pytest.mark.parametrize("n", range(4))
+    @pytest.mark.parametrize("n", range(1, 4))
     @pytest.mark.parametrize("delay_value", (False, True))
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("action_spec_type", ("one_hot", "categorical"))
@@ -5874,7 +5874,7 @@ class TestDiscreteCQL(LossModuleTestBase):
 
         with torch.no_grad():
             loss = loss_fn(td)
-        if n == 0:
+        if n == 1:
             assert_allclose_td(td, ms_td.select(*td.keys(True, True)))
             _loss = sum([item for key, item in loss.items() if key.startswith("loss_")])
             _loss_ms = sum(
@@ -9356,7 +9356,7 @@ class TestIQL(LossModuleTestBase):
                     raise NotImplementedError(k)
                 loss_fn.zero_grad()
 
-    @pytest.mark.parametrize("n", list(range(4)))
+    @pytest.mark.parametrize("n", range(1, 4))
     @pytest.mark.parametrize("num_qvalue", [1, 2, 4, 8])
     @pytest.mark.parametrize("temperature", [0.0, 0.1, 1.0, 10.0])
     @pytest.mark.parametrize("expectile", [0.1, 0.5, 1.0])
@@ -9407,7 +9407,7 @@ class TestIQL(LossModuleTestBase):
             torch.manual_seed(0)  # log-prob is computed with a random action
             np.random.seed(0)
             loss = loss_fn(td)
-        if n == 0:
+        if n == 1:
             assert_allclose_td(td, ms_td.select(*list(td.keys(True, True))))
             _loss = sum(
                 [item for name, item in loss.items() if name.startswith("loss_")]
@@ -10168,7 +10168,7 @@ class TestDiscreteIQL(LossModuleTestBase):
                     raise NotImplementedError(k)
                 loss_fn.zero_grad()
 
-    @pytest.mark.parametrize("n", list(range(4)))
+    @pytest.mark.parametrize("n", range(1, 4))
     @pytest.mark.parametrize("num_qvalue", [1, 2, 4, 8])
     @pytest.mark.parametrize("temperature", [0.0, 0.1, 1.0, 10.0])
     @pytest.mark.parametrize("expectile", [0.1, 0.5])
@@ -10219,7 +10219,7 @@ class TestDiscreteIQL(LossModuleTestBase):
             torch.manual_seed(0)  # log-prob is computed with a random action
             np.random.seed(0)
             loss = loss_fn(td)
-        if n == 0:
+        if n == 1:
             assert_allclose_td(td, ms_td.select(*list(td.keys(True, True))))
             _loss = sum(
                 [item for name, item in loss.items() if name.startswith("loss_")]

--- a/test/test_postprocs.py
+++ b/test/test_postprocs.py
@@ -113,7 +113,7 @@ def test_multistep(n, key, device, T=11):
 @pytest.mark.parametrize("obs_dim", [[1], []])
 @pytest.mark.parametrize("unsq_reward", [True, False])
 @pytest.mark.parametrize("last_done", [True, False])
-@pytest.mark.parametrize("n_steps", [3, 1, 0])
+@pytest.mark.parametrize("n_steps", [4, 2, 1])
 def test_mutistep_cattrajs(
     batch_size, T, obs_dim, unsq_reward, last_done, device, n_steps
 ):
@@ -145,7 +145,7 @@ def test_mutistep_cattrajs(
     )
     ms = MultiStep(0.98, n_steps)
     tdm = ms(td)
-    if n_steps == 0:
+    if n_steps == 1:
         # n_steps = 0 has no effect
         for k in td["next"].keys():
             assert (tdm["next", k] == td["next", k]).all()
@@ -158,7 +158,7 @@ def test_mutistep_cattrajs(
         if unsq_reward:
             done = done.squeeze(-1)
         for t in range(T):
-            idx = t + n_steps
+            idx = t + n_steps - 1
             while (done[..., t:idx].any() and idx > t) or idx > done.shape[-1] - 1:
                 idx = idx - 1
             next_obs.append(obs[..., idx])

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -10246,7 +10246,7 @@ class TestMultiStepTransform:
 
         outs_3 = []
         td = env.reset()
-        for i in range(125):
+        for _ in range(125):
             rollout = env.rollout(
                 2, auto_reset=False, tensordict=td, break_when_any_done=False
             )

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -475,6 +475,8 @@ class ReplayBuffer:
         if self._transform is not None and len(self._transform):
             with _set_dispatch_td_nn_modules(is_tensor_collection(data)):
                 data = self._transform.inv(data)
+        if data is None:
+            return torch.zeros((0, self._storage.ndim), dtype=torch.long)
         return self._add(data)
 
     def _add(self, data):
@@ -517,6 +519,8 @@ class ReplayBuffer:
         if self._transform is not None and len(self._transform):
             with _set_dispatch_td_nn_modules(is_tensor_collection(data)):
                 data = self._transform.inv(data)
+        if data is None:
+            return torch.zeros((0, self._storage.ndim), dtype=torch.long)
         return self._extend(data)
 
     def update_priority(
@@ -1008,6 +1012,8 @@ class TensorDictReplayBuffer(ReplayBuffer):
         if self._transform is not None:
             with _set_dispatch_td_nn_modules(is_tensor_collection(data)):
                 data = self._transform.inv(data)
+        if data is None:
+            return torch.zeros((0, self._storage.ndim), dtype=torch.long)
 
         index = super()._add(data)
         if index is not None:
@@ -1026,6 +1032,8 @@ class TensorDictReplayBuffer(ReplayBuffer):
             )
         if self._transform is not None:
             tensordicts = self._transform.inv(tensordicts)
+        if tensordicts is None:
+            return torch.zeros((0, self._storage.ndim), dtype=torch.long)
 
         index = super()._extend(tensordicts)
         self._set_index_in_td(tensordicts, index)

--- a/torchrl/envs/__init__.py
+++ b/torchrl/envs/__init__.py
@@ -57,6 +57,7 @@ from .transforms import (
     gSDENoise,
     InitTracker,
     KLRewardTransform,
+    MultiStepTransform,
     NoopResetEnv,
     ObservationNorm,
     ObservationTransform,

--- a/torchrl/envs/transforms/__init__.py
+++ b/torchrl/envs/transforms/__init__.py
@@ -5,6 +5,7 @@
 
 from .gym_transforms import EndOfLifeTransform
 from .r3m import R3MTransform
+from .rb_transforms import MultiStepTransform
 from .rlhf import KLRewardTransform
 from .transforms import (
     ActionMask,

--- a/torchrl/envs/transforms/rb_transforms.py
+++ b/torchrl/envs/transforms/rb_transforms.py
@@ -9,8 +9,11 @@ from torchrl.data.postprocs.postprocs import _multi_step_func
 from torchrl.envs import Transform
 import torch
 
+
 class MultiStepTransform(Transform):
-    def __init__(self, n_steps, gamma, *, reward_key:NestedKey|None=None, done_key:NestedKey|None=None,truncated_key:NestedKey|None=None,terminated_key:NestedKey|None=None, mask_key:NestedKey|None=None):
+    def __init__(self, n_steps, gamma, *, reward_key: NestedKey | None = None, done_key: NestedKey | None = None,
+                 truncated_key: NestedKey | None = None, terminated_key: NestedKey | None = None,
+                 mask_key: NestedKey | None = None):
         super().__init__()
         self.n_steps = n_steps
         self.reward_key = reward_key
@@ -24,6 +27,7 @@ class MultiStepTransform(Transform):
     @property
     def done_key(self):
         return self._done_key
+
     @done_key.setter
     def done_key(self, value):
         if value is None:
@@ -33,6 +37,7 @@ class MultiStepTransform(Transform):
     @property
     def terminated_key(self):
         return self._terminated_key
+
     @terminated_key.setter
     def terminated_key(self, value):
         if value is None:
@@ -42,6 +47,7 @@ class MultiStepTransform(Transform):
     @property
     def truncated_key(self):
         return self._truncated_key
+
     @truncated_key.setter
     def truncated_key(self, value):
         if value is None:
@@ -51,6 +57,7 @@ class MultiStepTransform(Transform):
     @property
     def reward_key(self):
         return self._reward_key
+
     @reward_key.setter
     def reward_key(self, value):
         if value is None:
@@ -60,6 +67,7 @@ class MultiStepTransform(Transform):
     @property
     def mask_key(self):
         return self._mask_key
+
     @mask_key.setter
     def mask_key(self, value):
         if value is None:
@@ -67,11 +75,7 @@ class MultiStepTransform(Transform):
         self._mask_key = value
 
     def _inv_call(self, tensordict: TensorDictBase) -> TensorDictBase:
-        print('before')
-        print(tensordict.get(("next", "done")).any())
         total_cat = self._append_tensordict(tensordict)
-        print('after')
-        print(total_cat.get(("next", "done")).any())
         out = _multi_step_func(
             total_cat,
             done_key=self.done_key,
@@ -81,7 +85,7 @@ class MultiStepTransform(Transform):
             gamma=self.gamma,
             terminated_key=self.terminated_key,
             truncated_key=self.truncated_key,
-            )[..., :-self.n_steps]
+        )[..., :-self.n_steps]
         if out.numel():
             return out
         return None

--- a/torchrl/envs/transforms/rb_transforms.py
+++ b/torchrl/envs/transforms/rb_transforms.py
@@ -1,0 +1,96 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+from tensordict import TensorDictBase, NestedKey
+from torchrl.data.postprocs.postprocs import _multi_step_func
+from torchrl.envs import Transform
+import torch
+
+class MultiStepTransform(Transform):
+    def __init__(self, n_steps, gamma, *, reward_key:NestedKey|None=None, done_key:NestedKey|None=None,truncated_key:NestedKey|None=None,terminated_key:NestedKey|None=None, mask_key:NestedKey|None=None):
+        super().__init__()
+        self.n_steps = n_steps
+        self.reward_key = reward_key
+        self.done_key = done_key
+        self.terminated_key = terminated_key
+        self.truncated_key = truncated_key
+        self.mask_key = mask_key
+        self.gamma = gamma
+        self.buffer = None
+
+    @property
+    def done_key(self):
+        return self._done_key
+    @done_key.setter
+    def done_key(self, value):
+        if value is None:
+            value = "done"
+        self._done_key = value
+
+    @property
+    def terminated_key(self):
+        return self._terminated_key
+    @terminated_key.setter
+    def terminated_key(self, value):
+        if value is None:
+            value = "terminated"
+        self._terminated_key = value
+
+    @property
+    def truncated_key(self):
+        return self._truncated_key
+    @truncated_key.setter
+    def truncated_key(self, value):
+        if value is None:
+            value = "truncated"
+        self._truncated_key = value
+
+    @property
+    def reward_key(self):
+        return self._reward_key
+    @reward_key.setter
+    def reward_key(self, value):
+        if value is None:
+            value = "reward"
+        self._reward_key = value
+
+    @property
+    def mask_key(self):
+        return self._mask_key
+    @mask_key.setter
+    def mask_key(self, value):
+        if value is None:
+            value = "mask"
+        self._mask_key = value
+
+    def _inv_call(self, tensordict: TensorDictBase) -> TensorDictBase:
+        print('before')
+        print(tensordict.get(("next", "done")).any())
+        total_cat = self._append_tensordict(tensordict)
+        print('after')
+        print(total_cat.get(("next", "done")).any())
+        out = _multi_step_func(
+            total_cat,
+            done_key=self.done_key,
+            reward_key=self.reward_key,
+            mask_key=self.mask_key,
+            n_steps=self.n_steps,
+            gamma=self.gamma,
+            terminated_key=self.terminated_key,
+            truncated_key=self.truncated_key,
+            )[..., :-self.n_steps]
+        if out.numel():
+            return out
+        return None
+
+    def _append_tensordict(self, data):
+        if self.buffer is None:
+            total_cat = data
+            self.buffer = data[..., -self.n_steps:].copy()
+        else:
+            total_cat = torch.cat([self.buffer, data], -1)
+            self.buffer = total_cat[..., -self.n_steps:].copy()
+        return total_cat

--- a/torchrl/envs/transforms/rb_transforms.py
+++ b/torchrl/envs/transforms/rb_transforms.py
@@ -4,16 +4,108 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
-from tensordict import TensorDictBase, NestedKey
-from torchrl.data.postprocs.postprocs import _multi_step_func
-from torchrl.envs import Transform
 import torch
+
+from tensordict import NestedKey, TensorDictBase
+from torchrl.data.postprocs.postprocs import _multi_step_func
+from torchrl.envs.transforms.transforms import Transform
 
 
 class MultiStepTransform(Transform):
-    def __init__(self, n_steps, gamma, *, reward_key: NestedKey | None = None, done_key: NestedKey | None = None,
-                 truncated_key: NestedKey | None = None, terminated_key: NestedKey | None = None,
-                 mask_key: NestedKey | None = None):
+    """A MultiStep transformation for ReplayBuffers.
+
+    This transform keeps the previous ``n_steps`` observations in a local buffer.
+    The inverse transform (called during :meth:`~torchrl.data.ReplayBuffer.extend`)
+    outputs the transformed previous ``n_steps`` with the ``T-n_steps`` current
+    frames.
+
+    This transform is a more hyperparameter resistant version of
+    :class:`~torchrl.data.postprocs.postprocs.MultiStep`:
+    the replay buffer transform will make the multi-step transform insensitive
+    to the collectors hyperparameters, whereas the post-process
+    version will output results that are sensitive to these
+    (because collectors have no memory of previous output).
+
+    Args:
+        n_steps (int): Number of steps in multi-step.
+        gamma (float): Discount factor.
+
+    Keyword Args:
+        reward_key (NestedKey, optional): the reward key in the input tensordict.
+            Defaults to ``"reward"``.
+        done_key (NestedKey, optional): the done key in the input tensordict.
+            Defaults to ``"done"``.
+        terminated_key (NestedKey, optional): the terminated key in the input tensordict.
+            Defaults to ``"terminated"``.
+        truncated_key (NestedKey, optional): the truncated key in the input tensordict.
+            Defaults to ``"truncated"``.
+        mask_key (NestedKey, optional): the mask key in the input tensordict.
+            The mask represents the valid frames in the input tensordict and
+            should have a shape that allows the input tensordict to be masked
+            with.
+            Defaults to ``"mask"``.
+
+    Examples:
+        >>> from torchrl.envs import GymEnv, TransformedEnv, StepCounter, MultiStepTransform, SerialEnv
+        >>> from torchrl.data import ReplayBuffer, LazyTensorStorage
+        >>> rb = ReplayBuffer(
+        ...     storage=LazyTensorStorage(100, ndim=2),
+        ...     transform=MultiStepTransform(n_steps=3, gamma=0.95)
+        ... )
+        >>> base_env = SerialEnv(2, lambda: GymEnv("CartPole"))
+        >>> env = TransformedEnv(base_env, StepCounter())
+        >>> _ = env.set_seed(0)
+        >>> _ = torch.manual_seed(0)
+        >>> tdreset = env.reset()
+        >>> for _ in range(100):
+        ...     rollout = env.rollout(max_steps=50, break_when_any_done=False,
+        ...         tensordict=tdreset, auto_reset=False)
+        ...     indices = rb.extend(rollout)
+        ...     tdreset = rollout[..., -1]["next"]
+        >>> print("step_count", rb[:]["step_count"][:, :5])
+        step_count tensor([[[ 9],
+                 [10],
+                 [11],
+                 [12],
+                 [13]],
+        <BLANKLINE>
+                [[12],
+                 [13],
+                 [14],
+                 [15],
+                 [16]]])
+        >>> # The next step_count is 3 steps in the future
+        >>> print("next step_count", rb[:]["next", "step_count"][:, :5])
+        next step_count tensor([[[13],
+                 [14],
+                 [15],
+                 [16],
+                 [17]],
+        <BLANKLINE>
+                [[16],
+                 [17],
+                 [18],
+                 [19],
+                 [20]]])
+
+    """
+
+    ENV_ERR = (
+        "The MultiStepTransform is only an inverse transform and can "
+        "be applied exclusively to replay buffers."
+    )
+
+    def __init__(
+        self,
+        n_steps,
+        gamma,
+        *,
+        reward_key: NestedKey | None = None,
+        done_key: NestedKey | None = None,
+        truncated_key: NestedKey | None = None,
+        terminated_key: NestedKey | None = None,
+        mask_key: NestedKey | None = None,
+    ):
         super().__init__()
         self.n_steps = n_steps
         self.reward_key = reward_key
@@ -23,6 +115,7 @@ class MultiStepTransform(Transform):
         self.mask_key = mask_key
         self.gamma = gamma
         self.buffer = None
+        self._validated = False
 
     @property
     def done_key(self):
@@ -74,27 +167,34 @@ class MultiStepTransform(Transform):
             value = "mask"
         self._mask_key = value
 
+    def _validate(self):
+        if self.parent is not None:
+            raise ValueError(self.ENV_ERR)
+        self._validated = True
+
     def _inv_call(self, tensordict: TensorDictBase) -> TensorDictBase:
+        if not self._validated:
+            self._validate()
+
         total_cat = self._append_tensordict(tensordict)
-        out = _multi_step_func(
-            total_cat,
-            done_key=self.done_key,
-            reward_key=self.reward_key,
-            mask_key=self.mask_key,
-            n_steps=self.n_steps,
-            gamma=self.gamma,
-            terminated_key=self.terminated_key,
-            truncated_key=self.truncated_key,
-        )[..., :-self.n_steps]
-        if out.numel():
-            return out
-        return None
+        if total_cat.shape[-1] >= self.n_steps:
+            out = _multi_step_func(
+                total_cat,
+                done_key=self.done_key,
+                reward_key=self.reward_key,
+                mask_key=self.mask_key,
+                n_steps=self.n_steps,
+                gamma=self.gamma,
+                terminated_key=self.terminated_key,
+                truncated_key=self.truncated_key,
+            )
+            return out[..., : -self.n_steps]
 
     def _append_tensordict(self, data):
         if self.buffer is None:
             total_cat = data
-            self.buffer = data[..., -self.n_steps:].copy()
+            self.buffer = data[..., -self.n_steps :].copy()
         else:
             total_cat = torch.cat([self.buffer, data], -1)
-            self.buffer = total_cat[..., -self.n_steps:].copy()
+            self.buffer = total_cat[..., -self.n_steps :].copy()
         return total_cat

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -6255,7 +6255,7 @@ class Reward2GoTransform(Transform):
 
     As the :class:`~.Reward2GoTransform` is only an inverse transform the ``in_keys`` will be directly used for the ``in_keys_inv``.
     The reward-to-go can be only calculated once the episode is finished. Therefore, the transform should be applied to the replay buffer
-    and not to the collector.
+    and not to the collector or within an environment.
 
     Args:
         gamma (float or torch.Tensor): the discount factor. Defaults to 1.0.
@@ -6354,7 +6354,7 @@ class Reward2GoTransform(Transform):
 
     ENV_ERR = (
         "The Reward2GoTransform is only an inverse transform and can "
-        "only be applied to the replay buffer and not to the collector or the environment."
+        "only be applied to the replay buffer."
     )
 
     def __init__(


### PR DESCRIPTION
- [x] Allow rbs to handle extend with no data (will/may happen during the first iterations when calling extend / add)
- [x] Design class
    - [x] Handle change of horizon correctly
- [x] Test equivalence with MultiStep in collectors
- [x] Document feature + compare with collector version

Test script

```python
import torch

from torchrl.envs import GymEnv, TransformedEnv, StepCounter, SerialEnv
from torchrl.envs.transforms.rb_transforms import MultiStepTransform
from tensordict.utils import assert_allclose_td

# env = TransformedEnv(SerialEnv(2, lambda:GymEnv("CartPole-v1")), StepCounter())
env = TransformedEnv(GymEnv("CartPole-v1"), StepCounter())

env.set_seed(0)
torch.manual_seed(0)

t = MultiStepTransform(3, 0.98)

outs_2 = []
td = env.reset()
for _ in range(1):
    rollout = env.rollout(250, auto_reset=False, tensordict=td, break_when_any_done=False)
    out = t._inv_call(rollout)
    td = rollout[..., -1]
    outs_2.append(out)

outs_2 = torch.cat(outs_2, -1).split([47, 50, 50, 50, 50], -1)

t = MultiStepTransform(3, 0.98)

env.set_seed(0)
torch.manual_seed(0)

outs = []
td = env.reset()
for i in range(5):
    rollout = env.rollout(50, auto_reset=False, tensordict=td, break_when_any_done=False)
    out = t._inv_call(rollout)
    assert_allclose_td(out, outs_2[i])
    td = rollout[..., -1]["next"]
    outs.append(out)

outs = torch.cat(outs, -1)

```
cc @AechPro