### PR TITLE
[Feature] Faster RNNs (no split)

### DIFF
--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -2,6 +2,8 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import torch
@@ -232,7 +234,7 @@ class LSTM(LSTMBase):
 
         return hy, cy
 
-    def _lstm(self, x, hx):
+    def _lstm(self, x, hx, done: torch.Tensor | None = None):
 
         h_t, c_t = hx
         h_t, c_t = h_t.unbind(0), c_t.unbind(0)
@@ -254,7 +256,7 @@ class LSTM(LSTMBase):
                 bias_ihs.append(None)
                 bias_hhs.append(None)
 
-        for x_t in x.unbind(int(self.batch_first)):
+        for t, x_t in enumerate(x.unbind(int(self.batch_first))):
             h_t_out = []
             c_t_out = []
 
@@ -280,13 +282,20 @@ class LSTM(LSTMBase):
                     x_t = _h_t
             h_t = h_t_out
             c_t = c_t_out
+            if done is not None:
+                done_t = done[..., t, :]
+                h_t = [torch.where(~done_t.expand_as(_h_t), _h_t, 0) for _h_t in h_t]
+                c_t = [torch.where(~done_t.expand_as(_c_t), _c_t, 0) for _c_t in c_t]
+
             outputs.append(x_t)
 
         outputs = torch.stack(outputs, dim=int(self.batch_first))
 
         return outputs, (torch.stack(h_t_out, 0), torch.stack(c_t_out, 0))
 
-    def forward(self, input, hx=None):  # noqa: F811
+    def forward(
+        self, input, hx: Tuple[Tensor, Tensor] | None = None, done: Tensor | None = None
+    ):  # noqa: F811
         real_hidden_size = self.proj_size if self.proj_size > 0 else self.hidden_size
         if input.dim() != 3:
             raise ValueError(
@@ -309,7 +318,7 @@ class LSTM(LSTMBase):
                 device=input.device,
             )
             hx = (h_zeros, c_zeros)
-        return self._lstm(input, hx)
+        return self._lstm(input, hx, done)
 
 
 class LSTMModule(ModuleBase):

--- a/torchrl/objectives/value/functional.py
+++ b/torchrl/objectives/value/functional.py
@@ -81,8 +81,10 @@ def _transpose_time(fun):
             return tensor, single_dim
 
         if time_dim != -2:
-            args, single_dim = zip(*(transpose_tensor(arg) for arg in args))
-            single_dim = any(single_dim)
+            single_dim = False
+            if args:
+                args, single_dim = zip(*(transpose_tensor(arg) for arg in args))
+                single_dim = any(single_dim)
             for k, item in list(kwargs.items()):
                 item, sd = transpose_tensor(item)
                 single_dim = single_dim or sd

--- a/torchrl/objectives/value/utils.py
+++ b/torchrl/objectives/value/utils.py
@@ -182,14 +182,15 @@ def _make_gammas_tensor(gamma: torch.Tensor, T: int, rolling_gamma: bool):
     return gammas
 
 
-def _flatten_batch(tensor):
+def _flatten_batch(tensor, time_dim=-1):
     """Because we mark the end of each batch with a truncated signal, we can concatenate them.
 
     Args:
-        tensor (torch.Tensor): a tensor of shape [*B, T]
+        tensor (torch.Tensor): a tensor of shape [*B, T, *F]
+        time_dim (int, optional): the time dimension T. Defaults to -1.
 
     """
-    return tensor.flatten(0, -2)
+    return tensor.flatten(0, time_dim)
 
 
 def _get_num_per_traj(done):
@@ -211,7 +212,10 @@ def _get_num_per_traj(done):
 
 
 def _split_and_pad_sequence(
-    tensor: Union[torch.Tensor, TensorDictBase], splits: torch.Tensor, return_mask=False
+    tensor: Union[torch.Tensor, TensorDictBase],
+    splits: torch.Tensor,
+    return_mask=False,
+    time_dim=-1,
 ):
     """Given a tensor of size [*B, T, F] and the corresponding traj lengths (flattened), returns the padded trajectories [NPad, Tmax, *other].
 
@@ -277,16 +281,17 @@ def _split_and_pad_sequence(
                  [19, 19, 19]]])
 
     """
-    tensor = _flatten_batch(tensor)
     max_seq_len = torch.max(splits)
     shape = (len(splits), max_seq_len)
 
     # int16 supports length up to 32767
     dtype = (
-        torch.int16 if tensor.shape[-1] < torch.iinfo(torch.int16).max else torch.int32
+        torch.int16 if tensor.shape[-2] < torch.iinfo(torch.int16).max else torch.int32
     )
     arange = torch.arange(max_seq_len, device=tensor.device, dtype=dtype).unsqueeze(0)
     mask = arange < splits.unsqueeze(1)
+
+    tensor = _flatten_batch(tensor, time_dim=time_dim)
 
     def _fill_tensor(tensor):
         empty_tensor = torch.zeros(

--- a/torchrl/objectives/value/utils.py
+++ b/torchrl/objectives/value/utils.py
@@ -189,7 +189,7 @@ def _flatten_batch(tensor):
         tensor (torch.Tensor): a tensor of shape [*B, T]
 
     """
-    return tensor.flatten(0, -1)
+    return tensor.flatten(0, -2)
 
 
 def _get_num_per_traj(done):


### PR DESCRIPTION
```python
from torchrl.modules import LSTM
import torch
from torch.utils.benchmark import Timer
from torchrl.modules.tensordict_module.rnn import _get_num_per_traj_init, _split_and_pad_sequence

b = 10
t = 100
c = 32
device = "cuda"

with torch.device(device):
    lstm = LSTM(c, c, batch_first=True)

    x = torch.randn(b, t, c)
    while True:
        done = torch.zeros(b, t, 1, dtype=torch.bool).bernoulli_(0.05)
        if done.any():
            break

    print(Timer("lstm(x, None, done)", globals={"lstm": lstm, "done": done, "x": x}).adaptive_autorange())


    def split_and_run(x, done):
        is_init = torch.cat([torch.ones_like(done[:, :1]), done[:, :-1]], 1)

        splits = _get_num_per_traj_init(is_init.squeeze())
        x_split = _split_and_pad_sequence(
            x, splits
        )

        return lstm(x_split)

    print(Timer("split_and_run(x, done)", globals={"split_and_run": split_and_run, "done": done, "x": x}).adaptive_autorange())

    for mode in ["default", "reduce-overhead"]:
        c_lstm = torch.compile(lstm, mode=mode)
        c_lstm(x, None, done);

        print(mode, Timer("lstm(x, None, done)", globals={"lstm": c_lstm, "done": done, "x": x}).adaptive_autorange())
```