### PR TITLE
[Feature] Enable `SliceSampler` to handle trajectories of different lengths

### DIFF
--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -971,6 +971,12 @@ class SliceSampler(Sampler):
                 "instead."
             )
         seq_length, num_slices = self._adjusted_batch_size(batch_size)
+        filt = lengths >= seq_length
+        start_idx = start_idx[filt]
+        stop_idx = stop_idx[filt]
+        lengths = lengths[filt]
+        if len(lengths) == 0:
+            raise RuntimeError("No trajectories of the require minimum length")
         storage_length = storage.shape[0]
         return self._sample_slices(
             lengths,


### PR DESCRIPTION
## Description

Currently, SliceSampler is unable to handle trajectories of varying lengths. This becomes an issue in two cases:

1. Short trajectories are added to the buffer and then SliceSampler is asked to sample with higher trajectory length
2. Once a ReplayBuffer is full with trajectories of varying lengths, then we start throwing out part of old trajectories. Thus there is non-zero chance of sampling an episode with length shorter than the requested trajectory length.

Both throw an error:
```
RuntimeError: Some stored trajectories have a length shorter than the slice that was asked for. Create the sampler with `strict_length=False` to allow shorter trajectories to appear in you batch.
````
## Example of issue

```
import torch
from tensordict.tensordict import TensorDict
from torchrl.data.replay_buffers import ReplayBuffer, LazyTensorStorage
from torchrl.data.replay_buffers.samplers import SliceSampler


class Buffer:
    def __init__(self, buffer_size, batch_size, horizon):
        self._device = torch.device("cuda")
        self._capacity = buffer_size
        self.horizon = horizon
        self._sampler = SliceSampler(
            num_slices=batch_size,
            end_key=None,
            traj_key="episode",
            truncated_key=None,
        )
        self._batch_size = batch_size * (horizon + 1)
        self._num_eps = 0

    def _reserve_buffer(self, storage):
        return ReplayBuffer(
            storage=storage,
            sampler=self._sampler,
            pin_memory=True,
            prefetch=8,
            batch_size=self._batch_size,
        )

    def _init(self, tds):
        mem_free, _ = torch.cuda.mem_get_info()
        bytes_per_step = sum(
            [
                (
                    v.numel() * v.element_size()
                    if not isinstance(v, TensorDict)
                    else sum([x.numel() * x.element_size() for x in v.values()])
                )
                for v in tds.values()
            ]
        ) / len(tds)
        total_bytes = bytes_per_step * self._capacity
        storage_device = "cuda" if 2.5 * total_bytes < mem_free else "cpu"
        return self._reserve_buffer(
            LazyTensorStorage(self._capacity, device=torch.device(storage_device))
        )

    def _to_device(self, *args, device=None):
        if device is None:
            device = self._device
        return (
            arg.to(device, non_blocking=True) if arg is not None else None
            for arg in args
        )

    def _prepare_batch(self, td):
        obs = td["obs"]
        action = td["action"][1:]
        reward = td["reward"][1:].unsqueeze(-1)
        task = td["task"][0] if "task" in td.keys() else None
        return self._to_device(obs, action, reward, task)

    def add(self, td):
        td["episode"] = (
            torch.ones_like(td["reward"].squeeze(), dtype=torch.int64) * self._num_eps
        )
        if self._num_eps == 0:
            self._buffer = self._init(td)
        self._buffer.extend(td)
        self._num_eps += 1
        return self._num_eps

    def sample(self):
        """Sample a batch of subsequences from the buffer."""
        td = self._buffer.sample()
        td = td.view(-1, self.horizon + 1).permute(1, 0)
        return self._prepare_batch(td)


# test sampling at capacity
capacity = 100
batch_size = 10
horizon = 3
obs_dim = 5
act_dim = 3

# Generate episodes of uniform
print("\nTesting fixed length episode buffer")
buffer = Buffer(capacity, batch_size, horizon)
ep_length = 10
ep_num = 20
num_samples = 100

for ep in range(ep_num):
    obs = torch.rand(ep_length, obs_dim)
    action = torch.rand(ep_length, act_dim)
    reward = torch.rand(ep_length)
    td = TensorDict(
        dict(
            obs=obs,
            action=action,
            reward=reward,
        ),
        batch_size=(ep_length),
    )
    buffer.add(td)

for n in range(num_samples):
    buffer.sample()

print("\nTesting varying length episode buffer")
buffer = Buffer(capacity, batch_size, horizon)
ep_length = 10
ep_num = 20
num_samples = 100

for ep in range(ep_num):
    ep_len = int(torch.randint(horizon, ep_length, (1,)).item())
    obs = torch.rand(ep_len, obs_dim)
    action = torch.rand(ep_len, act_dim)
    reward = torch.rand(ep_len)
    td = TensorDict(
        dict(
            obs=obs,
            action=action,
            reward=reward,
        ),
        batch_size=(ep_len),
    )
    buffer.add(td)

for n in range(num_samples):
    buffer.sample()
```

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.

Note: need to run test on GPU rig too
