### PR TITLE
[BigFix] Fix Ray collector on Python > 3.8

### DIFF
--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -235,6 +235,9 @@ class DataCollectorBase(IterableDataset, metaclass=abc.ABCMeta):
         string = f"{self.__class__.__name__}()"
         return string
 
+    def __class_getitem__(self, index):
+        raise NotImplementedError
+
 
 @accept_remote_rref_udf_invocation
 class SyncDataCollector(DataCollectorBase):

--- a/torchrl/collectors/distributed/ray.py
+++ b/torchrl/collectors/distributed/ray.py
@@ -345,6 +345,9 @@ class RayCollector(DataCollectorBase):
                 remote_configs, "remote_config", num_collectors
             )
 
+        def __class_getitem__(key):
+            return
+
         def check_list_length_consistency(*lists):
             """Checks that all input lists have the same length.
 

--- a/torchrl/collectors/distributed/ray.py
+++ b/torchrl/collectors/distributed/ray.py
@@ -345,9 +345,6 @@ class RayCollector(DataCollectorBase):
                 remote_configs, "remote_config", num_collectors
             )
 
-        def __class_getitem__(key):
-            return
-
         def check_list_length_consistency(*lists):
             """Checks that all input lists have the same length.
 


### PR DESCRIPTION
## Description

This PR should fix the issues with Ray and Python > 3.8

Ray uses the `inspect` module it its process to convert a class into a remote object to inspect the methods. If the class has methods ( in particular _getitems__) that return a GenericAlias object, the inspect.signature(...) will throw an error. It is explained very well here: https://github.com/ray-project/ray/pull/43117.

Therefore, I assume the long term fix should come from the `inspect` module. 

However, since at least for our collectors the only problematic methods was indeed `_getitems__`, we can just declared it and not return a GenericAlias object. 

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
