### PR TITLE
[BugFix] Robust sync for non_blocking=True

### DIFF
--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -494,7 +494,7 @@ class SyncDataCollector(DataCollectorBase):
             elif torch.backends.mps.is_available():
                 self._sync_env = torch.mps.synchronize
             elif self.env_device.type == "cpu":
-                self._sync_storage = _do_nothing
+                self._sync_env = _do_nothing
             else:
                 raise RuntimeError("Non supported device")
         else:
@@ -507,7 +507,7 @@ class SyncDataCollector(DataCollectorBase):
             elif torch.backends.mps.is_available():
                 self._sync_policy = torch.mps.synchronize
             elif self.policy_device.type == "cpu":
-                self._sync_storage = _do_nothing
+                self._sync_policy = _do_nothing
             else:
                 raise RuntimeError("Non supported device")
         else:

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -49,6 +49,7 @@ from torchrl._utils import (
 from torchrl.collectors.utils import split_trajectories
 from torchrl.data.tensor_specs import TensorSpec
 from torchrl.data.utils import CloudpickleWrapper, DEVICE_TYPING
+from torchrl.envs.batched_envs import _do_nothing
 from torchrl.envs.common import EnvBase
 from torchrl.envs.transforms import StepCounter, TransformedEnv
 from torchrl.envs.utils import (
@@ -472,8 +473,39 @@ class SyncDataCollector(DataCollectorBase):
         )
 
         self.storing_device = storing_device
+        if self.storing_device is not None and self.storing_device.type != "cuda":
+            # Cuda handles sync
+            if torch.cuda.is_available():
+                self._sync_storage = torch.cuda.synchronize
+            elif torch.backends.mps.is_available():
+                self._sync_storage = torch.mps.synchronize
+            else:
+                raise RuntimeError("Non supported device")
+        else:
+            self._sync_storage = _do_nothing
+
         self.env_device = env_device
+        if self.env_device is not None and self.env_device.type != "cuda":
+            # Cuda handles sync
+            if torch.cuda.is_available():
+                self._sync_env = torch.cuda.synchronize
+            elif torch.backends.mps.is_available():
+                self._sync_env = torch.mps.synchronize
+            else:
+                raise RuntimeError("Non supported device")
+        else:
+            self._sync_env = _do_nothing
         self.policy_device = policy_device
+        if self.policy_device is not None and self.policy_device.type != "cuda":
+            # Cuda handles sync
+            if torch.cuda.is_available():
+                self._sync_policy = torch.cuda.synchronize
+            elif torch.backends.mps.is_available():
+                self._sync_policy = torch.mps.synchronize
+            else:
+                raise RuntimeError("Non supported device")
+        else:
+            self._sync_policy = _do_nothing
         self.device = device
         # Check if we need to cast things from device to device
         # If the policy has a None device and the env too, no need to cast (we don't know
@@ -503,7 +535,7 @@ class SyncDataCollector(DataCollectorBase):
         if self.env_device:
             self.env: EnvBase = self.env.to(self.env_device)
         elif self.env.device is not None:
-            # we we did not receive an env device, we use the device of the env
+            # we did not receive an env device, we use the device of the env
             self.env_device = self.env.device
 
         # If the storing device is not the same as the policy device, we have
@@ -915,6 +947,7 @@ class SyncDataCollector(DataCollectorBase):
                             policy_input = self._shuttle.to(
                                 self.policy_device, non_blocking=True
                             )
+                            self._sync_policy()
                         elif self.policy_device is None:
                             # we know the tensordict has a device otherwise we would not be here
                             # we can pass this, clear_device_ must have been called earlier
@@ -933,6 +966,7 @@ class SyncDataCollector(DataCollectorBase):
                 if self._cast_to_env_device:
                     if self.env_device is not None:
                         env_input = self._shuttle.to(self.env_device, non_blocking=True)
+                        self._sync_env()
                     elif self.env_device is None:
                         # we know the tensordict has a device otherwise we would not be here
                         # we can pass this, clear_device_ must have been called earlier
@@ -954,6 +988,7 @@ class SyncDataCollector(DataCollectorBase):
                     tensordicts.append(
                         self._shuttle.to(self.storing_device, non_blocking=True)
                     )
+                    self._sync_storage()
                 else:
                     tensordicts.append(self._shuttle)
 

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -49,8 +49,7 @@ from torchrl._utils import (
 from torchrl.collectors.utils import split_trajectories
 from torchrl.data.tensor_specs import TensorSpec
 from torchrl.data.utils import CloudpickleWrapper, DEVICE_TYPING
-from torchrl.envs.batched_envs import _do_nothing
-from torchrl.envs.common import EnvBase
+from torchrl.envs.common import _do_nothing, EnvBase
 from torchrl.envs.transforms import StepCounter, TransformedEnv
 from torchrl.envs.utils import (
     _aggregate_end_of_traj,
@@ -1040,16 +1039,6 @@ class SyncDataCollector(DataCollectorBase):
                             out=self._final_rollout,
                         )
         return self._final_rollout
-
-    @staticmethod
-    def _update_device_wise(tensor0, tensor1):
-        # given 2 tensors, returns tensor0 if their identity matches,
-        # or a copy of tensor1 on the device of tensor0 otherwise
-        if tensor1 is None or tensor1 is tensor0:
-            return tensor0
-        if tensor1.device == tensor0.device:
-            return tensor1
-        return tensor1.to(tensor0.device, non_blocking=True)
 
     @torch.no_grad()
     def reset(self, index=None, **kwargs) -> None:

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -479,6 +479,8 @@ class SyncDataCollector(DataCollectorBase):
                 self._sync_storage = torch.cuda.synchronize
             elif torch.backends.mps.is_available():
                 self._sync_storage = torch.mps.synchronize
+            elif self.storing_device.type == "cpu":
+                self._sync_storage = _do_nothing
             else:
                 raise RuntimeError("Non supported device")
         else:
@@ -491,6 +493,8 @@ class SyncDataCollector(DataCollectorBase):
                 self._sync_env = torch.cuda.synchronize
             elif torch.backends.mps.is_available():
                 self._sync_env = torch.mps.synchronize
+            elif self.env_device.type == "cpu":
+                self._sync_storage = _do_nothing
             else:
                 raise RuntimeError("Non supported device")
         else:
@@ -502,6 +506,8 @@ class SyncDataCollector(DataCollectorBase):
                 self._sync_policy = torch.cuda.synchronize
             elif torch.backends.mps.is_available():
                 self._sync_policy = torch.mps.synchronize
+            elif self.policy_device.type == "cpu":
+                self._sync_storage = _do_nothing
             else:
                 raise RuntimeError("Non supported device")
         else:

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -1141,7 +1141,7 @@ class LazyMemmapStorage(LazyTensorStorage):
         # to be deprecated in v0.4
         def map_device(tensor):
             if tensor.device != self.device:
-                return tensor.to(self.device, non_blocking=True)
+                return tensor.to(self.device, non_blocking=False)
             return tensor
 
         if is_tensor_collection(result):

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -790,17 +790,6 @@ class BatchedEnvBase(EnvBase):
         if device == self.device:
             return self
         self._device = device
-        # if not self.is_closed:
-        #     warn(
-        #         "Casting an open environment to another device requires closing and re-opening it. "
-        #         "This may have unexpected and unwanted effects (e.g. on seeding etc.)"
-        #     )
-        #     # the tensordicts must be re-created on device
-        #     super().to(device)
-        #     self.close()
-        #     self.start()
-        # else:
-
         self.__dict__["_sync_m2w_value"] = None
         self.__dict__["_sync_w2m_value"] = None
         if self.__dict__["_input_spec"] is not None:
@@ -1264,7 +1253,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                         "_selected_step_keys": self._selected_step_keys,
                         "has_lazy_inputs": self.has_lazy_inputs,
                         "num_threads": num_sub_threads,
-                        "non_blocking": False,  # self.non_blocking,
+                        "non_blocking": self.non_blocking,
                     }
                 )
                 process = proc_fun(target=func, kwargs=kwargs[idx])

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -350,6 +350,7 @@ class BatchedEnvBase(EnvBase):
 
     @property
     def _sync_func(self):
+        # TODO: make this a no-op is needed
         sync_func = self.__dict__.get("_sync_func_value", None)
         if sync_func is None:
             if self.device is not None:

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -373,7 +373,7 @@ class BatchedEnvBase(EnvBase):
         return sync_func
 
     def _find_sync_values(self):
-        """Returns the m2w and w2m sync values, in that order"""
+        """Returns the m2w and w2m sync values, in that order."""
         # Simplest case: everything is on the same device
         worker_device = self.shared_tensordict_parent.device
         self_device = self.device

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -334,10 +334,10 @@ class BatchedEnvBase(EnvBase):
         self._properties_set = False
         self._get_metadata(create_env_fn, create_env_kwargs)
         self._non_blocking = non_blocking
-        if non_blocking and self.device is not None and self.device.type == "mps":
-            raise RuntimeError(
-                "non_blocking=True is incompatible with ParallelEnv on MPS device."
-            )
+        # if non_blocking and self.device is not None and self.device.type == "mps":
+        #     raise RuntimeError(
+        #         "non_blocking=True is incompatible with ParallelEnv on MPS device."
+        #     )
         if mp_start_method is not None and not isinstance(self, ParallelEnv):
             raise TypeError(
                 f"Cannot use mp_start_method={mp_start_method} with envs of type {type(self)}."

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -1456,7 +1456,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
             )
 
         outs = []
-        for i, channel in enumerate(self.parent_channels):
+        for i in range(self.num_workers):
             if tensordict is not None:
                 tensordict_ = tensordict[i]
                 if tensordict_.is_empty():

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -32,7 +32,7 @@ from torchrl._utils import (
 )
 from torchrl.data.tensor_specs import CompositeSpec
 from torchrl.data.utils import CloudpickleWrapper, contains_lazy_spec, DEVICE_TYPING
-from torchrl.envs.common import _EnvPostInit, EnvBase
+from torchrl.envs.common import _do_nothing, _EnvPostInit, EnvBase
 from torchrl.envs.env_creator import get_env_metadata
 
 # legacy
@@ -1880,10 +1880,6 @@ def _cuda_sync(device):
 
 def _mps_sync(device):
     return torch.mps.synchronize
-
-
-def _do_nothing():
-    return
 
 
 # Create an alias for possible imports

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -334,6 +334,10 @@ class BatchedEnvBase(EnvBase):
         self._properties_set = False
         self._get_metadata(create_env_fn, create_env_kwargs)
         self._non_blocking = non_blocking
+        if non_blocking and self.device is not None and self.device.type == "mps":
+            raise RuntimeError(
+                "non_blocking=True is incompatible with ParallelEnv on MPS device."
+            )
         if mp_start_method is not None and not isinstance(self, ParallelEnv):
             raise TypeError(
                 f"Cannot use mp_start_method={mp_start_method} with envs of type {type(self)}."
@@ -349,34 +353,91 @@ class BatchedEnvBase(EnvBase):
         return nb
 
     @property
-    def _sync_func(self):
-        # TODO: make this a no-op is needed
-        sync_func = self.__dict__.get("_sync_func_value", None)
+    def _sync_m2w(self) -> Callable:
+        sync_func = self.__dict__.get("_sync_m2w_value", None)
         if sync_func is None:
-            if self.device is not None:
-                if self.device.type == "cuda":
-                    sync_func = functools.partial(
-                        torch.cuda.synchronize, device=self.device
-                    )
-                elif self.device.type == "mps":
-                    sync_func = torch.mps.synchronize
-                elif self.device.type == "cpu":
-                    if torch.cuda.is_available():
-                        sync_func = torch.cuda.synchronize
-                    elif torch.backends.mps.is_available():
-                        sync_func = torch.cuda.synchronize
-                    else:
-                        raise RuntimeError(
-                            "Could not find a sync function. Please report this in a "
-                            "Github issue and/or set non_blocking=False."
-                        )
-                else:
-                    raise NotImplementedError(
-                        f"device type {self.device.type} not supported with non_blocking=True. "
-                        f"Please report this in a Github issue."
-                    )
-            self.__dict__["_sync_func_value"] = sync_func
+            sync_m2w, sync_w2m = self._find_sync_values()
+            self.__dict__["_sync_m2w_value"] = sync_m2w
+            self.__dict__["_sync_w2m_value"] = sync_w2m
+            return sync_m2w
         return sync_func
+
+    @property
+    def _sync_w2m(self) -> Callable:
+        sync_func = self.__dict__.get("_sync_w2m_value", None)
+        if sync_func is None:
+            sync_m2w, sync_w2m = self._find_sync_values()
+            self.__dict__["_sync_m2w_value"] = sync_m2w
+            self.__dict__["_sync_w2m_value"] = sync_w2m
+            return sync_w2m
+        return sync_func
+
+    def _find_sync_values(self):
+        """Returns the m2w and w2m sync values, in that order"""
+        # Simplest case: everything is on the same device
+        worker_device = self.shared_tensordict_parent.device
+        self_device = self.device
+        if not self.non_blocking or (
+            worker_device == self_device or self_device is None
+        ):
+            # even if they're both None, there is no device-to-device movement
+            return _do_nothing, _do_nothing
+
+        if worker_device is None:
+            worker_not_main = [False]
+
+            def find_all_worker_devices(item, worker_not_main=worker_not_main):
+                if hasattr(item, "device"):
+                    worker_not_main[0] = worker_not_main[0] or (
+                        item.device != self_device
+                    )
+
+            for td in self.shared_tensordicts:
+                td.apply(find_all_worker_devices, filter_empty=True)
+            if worker_not_main[0]:
+                if torch.cuda.is_available():
+                    worker_device = (
+                        torch.device("cuda")
+                        if self_device.type != "cuda"
+                        else torch.device("cpu")
+                    )
+                elif torch.backends.mps.is_available():
+                    worker_device = (
+                        torch.device("mps")
+                        if self_device.type != "mps"
+                        else torch.device("cpu")
+                    )
+                else:
+                    raise RuntimeError("Did not find a valid worker device")
+
+        if (
+            worker_device is not None
+            and worker_device.type == "cuda"
+            and self_device is not None
+            and self_device.type == "cpu"
+        ):
+            return _do_nothing, _cuda_sync(worker_device)
+        if (
+            worker_device is not None
+            and worker_device.type == "mps"
+            and self_device is not None
+            and self_device.type == "cpu"
+        ):
+            return _mps_sync(worker_device), _mps_sync(worker_device)
+        if (
+            worker_device is not None
+            and worker_device.type == "cpu"
+            and self_device is not None
+            and self_device.type == "cuda"
+        ):
+            return _cuda_sync(self_device), _do_nothing
+        if (
+            worker_device is not None
+            and worker_device.type == "cpu"
+            and self_device is not None
+            and self_device.type == "mps"
+        ):
+            return _mps_sync(self_device), _mps_sync(self_device)
 
     def _get_metadata(
         self, create_env_fn: List[Callable], create_env_kwargs: List[Dict]
@@ -724,20 +785,23 @@ class BatchedEnvBase(EnvBase):
         if device == self.device:
             return self
         self._device = device
-        if not self.is_closed:
-            warn(
-                "Casting an open environment to another device requires closing and re-opening it. "
-                "This may have unexpected and unwanted effects (e.g. on seeding etc.)"
-            )
-            # the tensordicts must be re-created on device
-            super().to(device)
-            self.close()
-            self.start()
-        else:
-            if self.__dict__["_input_spec"] is not None:
-                self.__dict__["_input_spec"] = self.__dict__["_input_spec"].to(device)
-            if self.__dict__["_output_spec"] is not None:
-                self.__dict__["_output_spec"] = self.__dict__["_output_spec"].to(device)
+        # if not self.is_closed:
+        #     warn(
+        #         "Casting an open environment to another device requires closing and re-opening it. "
+        #         "This may have unexpected and unwanted effects (e.g. on seeding etc.)"
+        #     )
+        #     # the tensordicts must be re-created on device
+        #     super().to(device)
+        #     self.close()
+        #     self.start()
+        # else:
+
+        self.__dict__["_sync_m2w_value"] = None
+        self.__dict__["_sync_w2m_value"] = None
+        if self.__dict__["_input_spec"] is not None:
+            self.__dict__["_input_spec"] = self.__dict__["_input_spec"].to(device)
+        if self.__dict__["_output_spec"] is not None:
+            self.__dict__["_output_spec"] = self.__dict__["_output_spec"].to(device)
         return self
 
 
@@ -825,6 +889,7 @@ class SerialEnv(BatchedEnvBase):
                 (self.num_workers,), device=self.device, dtype=torch.bool
             )
 
+        tds = []
         for i, _env in enumerate(self._envs):
             if not needs_resetting[i]:
                 continue
@@ -838,18 +903,21 @@ class SerialEnv(BatchedEnvBase):
                         tensordict_ = tensordict_.to(
                             env_device, non_blocking=self.non_blocking
                         )
-                        if self.non_blocking:
-                            self._sync_func()
                     else:
                         tensordict_ = tensordict_.clone(False)
             else:
                 tensordict_ = None
+            tds.append(tensordict_)
 
+        self._sync_m2w()
+
+        for i, (_env, tensordict_) in enumerate(zip(self._envs, tds)):
             _td = _env.reset(tensordict=tensordict_, **kwargs)
             try:
                 self.shared_tensordicts[i].update_(
                     _td,
                     keys_to_update=list(self._selected_reset_keys_filt),
+                    non_blocking=self.non_blocking,
                 )
             except RuntimeError as err:
                 if "no_grad mode" in str(err):
@@ -859,6 +927,7 @@ class SerialEnv(BatchedEnvBase):
                         "share_individual_td argument to True."
                     )
                 raise
+
         selected_output_keys = self._selected_reset_keys_filt
         device = self.device
 
@@ -878,8 +947,7 @@ class SerialEnv(BatchedEnvBase):
                 out = out.clear_device_()
             else:
                 out = out.to(device, non_blocking=self.non_blocking)
-                if self.non_blocking:
-                    self._sync_func()
+                self._sync_w2m()
         return out
 
     def _reset_proc_data(self, tensordict, tensordict_reset):
@@ -895,20 +963,27 @@ class SerialEnv(BatchedEnvBase):
     ) -> TensorDict:
         tensordict_in = tensordict.clone(False)
         next_td = self.shared_tensordict_parent.get("next")
+        data_in = []
         for i in range(self.num_workers):
             # shared_tensordicts are locked, and we need to select the keys since we update in-place.
             # There may be unexpected keys, such as "_reset", that we should comfortably ignore here.
             env_device = self._envs[i].device
             if env_device != self.device and env_device is not None:
-                data_in = tensordict_in[i].to(
-                    env_device, non_blocking=self.non_blocking
+                data_in.append(
+                    tensordict_in[i].to(env_device, non_blocking=self.non_blocking)
                 )
-                if self.non_blocking:
-                    self._sync_func()
             else:
-                data_in = tensordict_in[i]
-            out_td = self._envs[i]._step(data_in)
-            next_td[i].update_(out_td, keys_to_update=list(self._env_output_keys))
+                data_in.append(tensordict_in[i])
+
+        self._sync_m2w()
+
+        for i, _data_in in enumerate(data_in):
+            out_td = self._envs[i]._step(_data_in)
+            next_td[i].update_(
+                out_td,
+                keys_to_update=list(self._env_output_keys),
+                non_blocking=self.non_blocking,
+            )
 
         # We must pass a clone of the tensordict, as the values of this tensordict
         # will be modified in-place at further steps
@@ -925,8 +1000,7 @@ class SerialEnv(BatchedEnvBase):
                 out = out.clear_device_()
             elif out.device != device:
                 out = out.to(device, non_blocking=self.non_blocking)
-                if self.non_blocking:
-                    self._sync_func()
+                self._sync_w2m()
         return out
 
     def __getattr__(self, attr: str) -> Any:
@@ -1184,6 +1258,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                         "_selected_step_keys": self._selected_step_keys,
                         "has_lazy_inputs": self.has_lazy_inputs,
                         "num_threads": num_sub_threads,
+                        "non_blocking": self.non_blocking,
                     }
                 )
                 process = proc_fun(target=func, kwargs=kwargs[idx])
@@ -1240,10 +1315,12 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
         #   and this transform overrides an observation key (eg, CatFrames)
         #   the shape, dtype or device may not necessarily match and writing
         #   the value in-place will fail.
+
         self.shared_tensordict_parent.update_(
-            tensordict, keys_to_update=self._env_input_keys
+            tensordict,
+            keys_to_update=self._env_input_keys,
+            non_blocking=self.non_blocking,
         )
-        self._sync_func()
         next_td_passthrough = tensordict.get("next", None)
         if next_td_passthrough is not None:
             # if we have input "next" data (eg, RNNs which pass the next state)
@@ -1251,10 +1328,12 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
             # We keep track of which keys are present to let the worker know what
             # should be passd to the env (we don't want to pass done states for instance)
             next_td_keys = list(next_td_passthrough.keys(True, True))
-            self.shared_tensordict_parent.get("next").update_(next_td_passthrough)
-            self._sync_func()
+            self.shared_tensordict_parent.get("next").update_(
+                next_td_passthrough, non_blocking=self.non_blocking
+            )
         else:
             next_td_keys = None
+        self._sync_m2w()
         for i in range(self.num_workers):
             self.parent_channels[i].send(("step_and_maybe_reset", next_td_keys))
 
@@ -1286,8 +1365,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                 device=device,
                 filter_empty=True,
             )
-            if self.non_blocking:
-                self._sync_func()
+            self._sync_w2m()
         else:
             next_td = next_td.clone().clear_device_()
             tensordict_ = tensordict_.clone().clear_device_()
@@ -1305,10 +1383,12 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
         #   and this transform overrides an observation key (eg, CatFrames)
         #   the shape, dtype or device may not necessarily match and writing
         #   the value in-place will fail.
+
         self.shared_tensordict_parent.update_(
-            tensordict, keys_to_update=list(self._env_input_keys)
+            tensordict,
+            keys_to_update=list(self._env_input_keys),
+            non_blocking=self.non_blocking,
         )
-        self._sync_func()
         next_td_passthrough = tensordict.get("next", None)
         if next_td_passthrough is not None:
             # if we have input "next" data (eg, RNNs which pass the next state)
@@ -1316,10 +1396,13 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
             # We keep track of which keys are present to let the worker know what
             # should be passd to the env (we don't want to pass done states for instance)
             next_td_keys = list(next_td_passthrough.keys(True, True))
-            self.shared_tensordict_parent.get("next").update_(next_td_passthrough)
-            self._sync_func()
+            self.shared_tensordict_parent.get("next").update_(
+                next_td_passthrough, non_blocking=self.non_blocking
+            )
         else:
             next_td_keys = None
+
+        self._sync_m2w()
 
         if self.event is not None:
             self.event.record()
@@ -1351,8 +1434,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                 out.clear_device_()
             else:
                 out = out.to(device, non_blocking=self.non_blocking)
-                if self.non_blocking:
-                    self._sync_func()
+                self._sync_w2m()
         return out
 
     @torch.no_grad()
@@ -1373,8 +1455,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                 (self.num_workers,), device=self.device, dtype=torch.bool
             )
 
-        workers = []
-
+        outs = []
         for i, channel in enumerate(self.parent_channels):
             if tensordict is not None:
                 tensordict_ = tensordict[i]
@@ -1392,13 +1473,14 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                 self.shared_tensordicts[i].update_(
                     self.shared_tensordicts[i].get("next"),
                     keys_to_update=list(self._selected_reset_keys),
+                    non_blocking=self.non_blocking,
                 )
-                self._sync_func()
                 if tensordict_ is not None:
                     self.shared_tensordicts[i].update_(
-                        tensordict_, keys_to_update=list(self._selected_reset_keys)
+                        tensordict_,
+                        keys_to_update=list(self._selected_reset_keys),
+                        non_blocking=self.non_blocking,
                     )
-                    self._sync_func()
                 continue
             if tensordict_ is not None:
                 tdkeys = list(tensordict_.keys(True, True))
@@ -1406,7 +1488,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                 # This way we can avoid calling select over all the keys in the shared tensordict
                 def tentative_update(val, other):
                     if other is not None:
-                        val.copy_(other)
+                        val.copy_(other, non_blocking=self.non_blocking)
                     return val
 
                 self.shared_tensordicts[i].apply_(
@@ -1415,11 +1497,14 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                 out = ("reset", tdkeys)
             else:
                 out = ("reset", False)
+            outs.append((i, out))
 
-            channel.send(out)
-            workers.append(i)
+        self._sync_m2w()
 
-        for i in workers:
+        for i, out in outs:
+            self.parent_channels[i].send(out)
+
+        for i, _ in outs:
             event = self._events[i]
             event.wait(self._timeout)
             event.clear()
@@ -1442,8 +1527,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                 out.clear_device_()
             else:
                 out = out.to(device, non_blocking=self.non_blocking)
-                if self.non_blocking:
-                    self._sync_func()
+                self._sync_w2m()
         return out
 
     @_check_start
@@ -1562,6 +1646,7 @@ def _run_worker_pipe_shared_mem(
     _selected_input_keys=None,
     _selected_reset_keys=None,
     _selected_step_keys=None,
+    non_blocking: bool = False,
     has_lazy_inputs: bool = False,
     verbose: bool = False,
     num_threads: int | None = None,  # for fork start method
@@ -1655,6 +1740,7 @@ def _run_worker_pipe_shared_mem(
             shared_tensordict.update_(
                 cur_td,
                 keys_to_update=list(_selected_reset_keys),
+                non_blocking=non_blocking,
             )
             if event is not None:
                 event.record()
@@ -1675,7 +1761,7 @@ def _run_worker_pipe_shared_mem(
             else:
                 input = root_shared_tensordict
             next_td = env._step(input)
-            next_shared_tensordict.update_(next_td)
+            next_shared_tensordict.update_(next_td, non_blocking=non_blocking)
             if event is not None:
                 event.record()
                 event.synchronize()
@@ -1702,8 +1788,8 @@ def _run_worker_pipe_shared_mem(
             else:
                 input = root_shared_tensordict
             td, root_next_td = env.step_and_maybe_reset(input)
-            next_shared_tensordict.update_(td.pop("next"))
-            root_shared_tensordict.update_(root_next_td)
+            next_shared_tensordict.update_(td.pop("next"), non_blocking=non_blocking)
+            root_shared_tensordict.update_(root_next_td, non_blocking=non_blocking)
 
             if event is not None:
                 event.record()
@@ -1776,6 +1862,18 @@ def _stackable(*tensordicts):
         return not ls._has_exclusive_keys
     except RuntimeError:
         return False
+
+
+def _cuda_sync(device):
+    return functools.partial(torch.cuda.synchronize, device=device)
+
+
+def _mps_sync(device):
+    return torch.mps.synchronize
+
+
+def _do_nothing():
+    return
 
 
 # Create an alias for possible imports

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -3044,5 +3044,6 @@ def _get_sync_func(policy_device, env_device):
         return torch.mps.synchronize
     return _do_nothing
 
+
 def _do_nothing():
     return

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -3029,35 +3029,19 @@ def make_tensordict(
 
 
 def _get_sync_func(policy_device, env_device):
-    if policy_device.type == "cuda":
-        if env_device.type not in ("cpu", "cuda"):
-            raise NotImplementedError(
-                f"auto-casting from {policy_device.type} to {env_device.type} "
-                "isn't supported yet. Please file an issue on github."
-            )
-        sync_func = functools.partial(torch.cuda.synchronize, device=policy_device)
-    elif env_device.type == "cuda":
-        if policy_device.type not in ("cpu", "cuda"):
-            raise NotImplementedError(
-                f"auto-casting from {policy_device.type} to {env_device.type} "
-                "isn't supported yet. Please file an issue on github."
-            )
-        sync_func = functools.partial(torch.cuda.synchronize, device=env_device)
-    elif policy_device.type == "mps":
-        if env_device.type not in ("cpu", "mps"):
-            raise NotImplementedError(
-                f"auto-casting from {policy_device.type} to {env_device.type} "
-                "isn't supported yet. Please file an issue on github."
-            )
-        sync_func = torch.mps.synchronize
-    elif env_device.type == "mps":
-        if policy_device.type not in ("cpu", "mps"):
-            raise NotImplementedError(
-                f"auto-casting from {policy_device.type} to {env_device.type} "
-                "isn't supported yet. Please file an issue on github."
-            )
-        sync_func = torch.mps.synchronize
-    return sync_func
+    if torch.cuda.is_available():
+        # Look for a specific device
+        if policy_device is not None and policy_device.type == "cuda":
+            if env_device is None or env_device.type == "cuda":
+                return torch.cuda.synchronize
+            return functools.partial(torch.cuda.synchronize, device=policy_device)
+        if env_device is not None and env_device.type == "cuda":
+            if policy_device is None:
+                return torch.cuda.synchronize
+            return functools.partial(torch.cuda.synchronize, device=env_device)
+        return torch.cuda.synchronize
+    if torch.backends.mps.is_available():
+        return torch.mps.synchronize
 
 
 def _do_nothing():

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -3042,7 +3042,7 @@ def _get_sync_func(policy_device, env_device):
         return torch.cuda.synchronize
     if torch.backends.mps.is_available():
         return torch.mps.synchronize
-
+    return _do_nothing
 
 def _do_nothing():
     return

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -2942,7 +2942,7 @@ class _EnvWrapper(EnvBase):
                     self._sync_device_val = _do_nothing
             else:
                 self._sync_device_val = _do_nothing
-            return self._sync_orig_device
+            return self._sync_device
         return sync_func
 
     @abc.abstractmethod

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -2691,7 +2691,11 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
             any_done = done.any()
             if any_done:
                 tensordict._set_str(
-                    "_reset", done.clone(), validated=True, inplace=False
+                    "_reset",
+                    done.clone(),
+                    validated=True,
+                    inplace=False,
+                    non_blocking=False,
                 )
         else:
             any_done = _terminated_or_truncated(

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -2132,7 +2132,6 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
             elif not self._allow_done_after_reset:
                 for done_key in done_key_group:
                     if tensordict_reset.get(done_key).any():
-                        print(tensordict_reset.get(done_key))
                         raise RuntimeError(
                             f"The done entry '{done_key}' was (partially) True after a call to reset() in env {self}."
                         )

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -2132,6 +2132,7 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
             elif not self._allow_done_after_reset:
                 for done_key in done_key_group:
                     if tensordict_reset.get(done_key).any():
+                        print(tensordict_reset.get(done_key))
                         raise RuntimeError(
                             f"The done entry '{done_key}' was (partially) True after a call to reset() in env {self}."
                         )

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -329,6 +329,7 @@ class GymLikeEnv(_EnvWrapper):
             )
         if self.device is not None:
             tensordict_out = tensordict_out.to(self.device, non_blocking=True)
+            self._sync_device()
 
         if self.info_dict_reader and (info_dict is not None):
             if not isinstance(info_dict, dict):
@@ -372,7 +373,9 @@ class GymLikeEnv(_EnvWrapper):
             for key, item in self.observation_spec.items(True, True):
                 if key not in tensordict_out.keys(True, True):
                     tensordict_out[key] = item.zero()
-        tensordict_out = tensordict_out.to(self.device, non_blocking=True)
+        if self.device is not None:
+            tensordict_out = tensordict_out.to(self.device, non_blocking=True)
+            self._sync_device()
         return tensordict_out
 
     @abc.abstractmethod

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -936,7 +936,7 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
             return env.reward_space
 
     @implement_for("gymnasium")
-    def _reward_space(self, env):
+    def _reward_space(self, env):  # noqa: F811
         env = env.unwrapped
         if hasattr(env, "reward_space") and env.reward_space is not None:
             rs = env.reward_space

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -934,9 +934,9 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
     def _reward_space(self, env):
         if hasattr(env, "reward_space") and env.reward_space is not None:
             return env.reward_space
+
     @implement_for("gymnasium")
     def _reward_space(self, env):
-        print('getting reward space')
         env = env.unwrapped
         if hasattr(env, "reward_space") and env.reward_space is not None:
             rs = env.reward_space

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -963,7 +963,7 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
         elif observation_spec.shape[: len(self.batch_size)] != self.batch_size:
             observation_spec.shape = self.batch_size
 
-        reward_space = self._reward_spec(env)
+        reward_space = self._reward_space(env)
         if reward_space is not None:
             reward_spec = _gym_to_torchrl_spec_transform(
                 reward_space,

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -936,9 +936,11 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
             return env.reward_space
     @implement_for("gymnasium")
     def _reward_space(self, env):
+        print('getting reward space')
         env = env.unwrapped
         if hasattr(env, "reward_space") and env.reward_space is not None:
-            return env.reward_space
+            rs = env.reward_space
+            return rs
 
     def _make_specs(self, env: "gym.Env", batch_size=None) -> None:  # noqa: F821
         action_spec = _gym_to_torchrl_spec_transform(

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -769,8 +769,9 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
 
     @implement_for("gymnasium")  # gymnasium wants the unwrapped env
     def _get_batch_size(self, env):  # noqa: F811
-        if hasattr(env, "num_envs"):
-            batch_size = torch.Size([env.unwrapped.num_envs, *self.batch_size])
+        env_unwrapped = env.unwrapped
+        if hasattr(env_unwrapped, "num_envs"):
+            batch_size = torch.Size([env_unwrapped.num_envs, *self.batch_size])
         else:
             batch_size = self.batch_size
         return batch_size
@@ -929,6 +930,16 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
             self._seed_calls_reset = False
             self._env.seed(seed=seed)
 
+    @implement_for("gym")
+    def _reward_space(self, env):
+        if hasattr(env, "reward_space") and env.reward_space is not None:
+            return env.reward_space
+    @implement_for("gymnasium")
+    def _reward_space(self, env):
+        env = env.unwrapped
+        if hasattr(env, "reward_space") and env.reward_space is not None:
+            return env.reward_space
+
     def _make_specs(self, env: "gym.Env", batch_size=None) -> None:  # noqa: F821
         action_spec = _gym_to_torchrl_spec_transform(
             env.action_space,
@@ -952,9 +963,10 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
         elif observation_spec.shape[: len(self.batch_size)] != self.batch_size:
             observation_spec.shape = self.batch_size
 
-        if hasattr(env, "reward_space") and env.reward_space is not None:
+        reward_space = self._reward_spec(env)
+        if reward_space is not None:
             reward_spec = _gym_to_torchrl_spec_transform(
-                env.reward_space,
+                reward_space,
                 device=self.device,
                 categorical_action_encoding=self._categorical_action_encoding,
             )

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -173,7 +173,7 @@ class _StepMDP:
 
             actual = {key for key in tensordict.keys(True, True) if not _is_reset(key)}
             expected = set(expected)
-            self.validated = expected.union(actual) == expected
+            self.validated = expected.intersection(actual) == expected
             if not self.validated:
                 warnings.warn(
                     "The expected key set and actual key set differ. "

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -198,7 +198,9 @@ class _StepMDP:
                     )
                 else:
                     val = cls._grab_and_place(subdict, val, val_out)
-            data_out._set_str(key, val, validated=True, inplace=False)
+            data_out._set_str(
+                key, val, validated=True, inplace=False, non_blocking=False
+            )
         return data_out
 
     def __call__(self, tensordict):
@@ -416,7 +418,9 @@ def _set_single_key(
                 new_val = dest._get_str(k, None)
                 if new_val is None:
                     new_val = val.empty()
-                    dest._set_str(k, new_val, inplace=False, validated=True)
+                    dest._set_str(
+                        k, new_val, inplace=False, validated=True, non_blocking=False
+                    )
                 source = val
                 dest = new_val
             else:
@@ -424,7 +428,7 @@ def _set_single_key(
                     val = val.to(device, non_blocking=True)
                 elif clone:
                     val = val.clone()
-                dest._set_str(k, val, inplace=False, validated=True)
+                dest._set_str(k, val, inplace=False, validated=True, non_blocking=False)
         # This is a temporary solution to understand if a key is heterogeneous
         # while not having performance impact when the exception is not raised
         except RuntimeError as err:
@@ -456,12 +460,16 @@ def _set(source, dest, key, total_key, excluded):
                     )
                 if non_empty_local:
                     # dest.set(key, new_val)
-                    dest._set_str(key, new_val, inplace=False, validated=True)
+                    dest._set_str(
+                        key, new_val, inplace=False, validated=True, non_blocking=False
+                    )
                 non_empty = non_empty_local
             else:
                 non_empty = True
                 # dest.set(key, val)
-                dest._set_str(key, val, inplace=False, validated=True)
+                dest._set_str(
+                    key, val, inplace=False, validated=True, non_blocking=False
+                )
         # This is a temporary solution to understand if a key is heterogeneous
         # while not having performance impact when the exception is not raised
         except RuntimeError as err:

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -154,7 +154,13 @@ class _StepMDP:
                 + [unravel_key(("next", key)) for key in self.done_keys]
                 + [unravel_key(("next", key)) for key in self.reward_keys]
             )
-            actual = set(tensordict.keys(True, True))
+
+            def _is_reset(key: NestedKey):
+                if isinstance(key, str):
+                    return key == "_reset"
+                return key[-1] == "_reset"
+
+            actual = {key for key in tensordict.keys(True, True) if not _is_reset(key)}
             self.validated = set(expected) == actual
             if not self.validated:
                 warnings.warn(


### PR DESCRIPTION
@skandermoalla @dennismalmgren @albanD  @alexander-soare

To test this (replace mps with cuda if available):

```python
import torch
from tensordict.nn import TensorDictModule

from torchrl.envs import GymEnv
from torchrl.modules import MLP
import torch.utils.benchmark

if __name__ == "__main__":
    env = GymEnv("Pendulum-v1", device="cpu")
    policy = TensorDictModule(
        MLP(
            env.observation_spec["observation"].shape[-1],
            env.action_spec.shape[-1],
            num_cells=(64, 64),
            device="mps",
        ),
        in_keys=["observation"], out_keys=["action"])

    print(torch.utils.benchmark.Timer("env.rollout(1000, policy=policy, auto_cast_to_device=True, break_when_any_done=False)", globals=globals()).adaptive_autorange())

    torch.manual_seed(0)
    env.set_seed(0)
    rollout = env.rollout(1000, policy=policy, auto_cast_to_device=True, break_when_any_done=False)
    act0 = rollout["action"].squeeze()
    torch.manual_seed(0)
    env.set_seed(0)
    rollout = env.rollout(1000, policy=policy, auto_cast_to_device=True, break_when_any_done=False)
    act1 = rollout["action"].squeeze()
    torch.testing.assert_close(act0, act1)

```

The final assertion fails on main but succeeds here.
The runtime is 2x higher with the sync on my machine (but the results are accurate)