### PR TITLE
[Features] PettingZoo possibility to choose reset strategy

### DIFF
--- a/.github/unittest/linux_libs/scripts_pettingzoo/environment.yml
+++ b/.github/unittest/linux_libs/scripts_pettingzoo/environment.yml
@@ -20,4 +20,4 @@ dependencies:
     - expecttest
     - pyyaml
     - autorom[accept-rom-license]
-    - pettingzoo[all]==1.24.1
+    - pettingzoo[all]==1.24.3

--- a/.github/unittest/linux_libs/scripts_pettingzoo/environment.yml
+++ b/.github/unittest/linux_libs/scripts_pettingzoo/environment.yml
@@ -8,7 +8,7 @@ dependencies:
     - cloudpickle
     - gym
     - gym-notices
-    - importlib-metadata
+    - importlib_metadata
     - six
     - zipp
     - pytest

--- a/.github/unittest/linux_libs/scripts_pettingzoo/environment.yml
+++ b/.github/unittest/linux_libs/scripts_pettingzoo/environment.yml
@@ -8,7 +8,6 @@ dependencies:
     - cloudpickle
     - gym
     - gym-notices
-    - importlib_metadata
     - six
     - zipp
     - pytest

--- a/.github/unittest/linux_libs/scripts_smacv2/environment.yml
+++ b/.github/unittest/linux_libs/scripts_smacv2/environment.yml
@@ -7,7 +7,7 @@ dependencies:
     - cloudpickle
     - gym
     - gym-notices
-    - importlib-metadata
+    - importlib_metadata
     - zipp
     - pytest
     - pytest-cov

--- a/.github/unittest/linux_libs/scripts_smacv2/environment.yml
+++ b/.github/unittest/linux_libs/scripts_smacv2/environment.yml
@@ -7,7 +7,6 @@ dependencies:
     - cloudpickle
     - gym
     - gym-notices
-    - importlib_metadata
     - zipp
     - pytest
     - pytest-cov

--- a/.github/unittest/linux_libs/scripts_vmas/environment.yml
+++ b/.github/unittest/linux_libs/scripts_vmas/environment.yml
@@ -7,7 +7,7 @@ dependencies:
     - cloudpickle
     - gym
     - gym-notices
-    - importlib-metadata
+    - importlib_metadata
     - numpy
     - pyglet==1.5.27
     - six

--- a/.github/unittest/linux_libs/scripts_vmas/environment.yml
+++ b/.github/unittest/linux_libs/scripts_vmas/environment.yml
@@ -7,7 +7,6 @@ dependencies:
     - cloudpickle
     - gym
     - gym-notices
-    - importlib_metadata
     - numpy
     - pyglet==1.5.27
     - six

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -3178,7 +3178,7 @@ class TestPettingZoo:
                 auto_reset=False,
                 tensordict=td_reset,
             )
-            done = td.get(("next", "walker", "done")).clone()
+            done = td.get(("next", "walker", "done"))
             mask = td.get(("next", "walker", "mask"))
 
             if done_on_any:

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -278,7 +278,6 @@ class TestGym:
 
     @pytest.mark.parametrize("categorical", [True, False])
     def test_gym_spec_cast(self, categorical):
-
         batch_size = [3, 4]
         cat = DiscreteTensorSpec if categorical else OneHotDiscreteTensorSpec
         cat_shape = batch_size if categorical else (*batch_size, 5)
@@ -543,7 +542,6 @@ class TestGym:
         ],
     )
     def test_gym(self, env_name, frame_skip, from_pixels, pixels_only):
-
         if env_name == PONG_VERSIONED() and not from_pixels:
             # raise pytest.skip("already pixel")
             # we don't skip because that would raise an exception
@@ -3126,7 +3124,6 @@ class TestPettingZoo:
     def test_pistonball(
         self, parallel, continuous_actions, use_mask, return_state, group_map
     ):
-
         kwargs = {"n_pistons": 21, "continuous": continuous_actions}
 
         env = PettingZooEnv(
@@ -3140,6 +3137,54 @@ class TestPettingZoo:
         )
 
         check_env_specs(env)
+
+    def test_dead_agents_done(self, seed=0):
+        scenario_args = {"n_walkers": 3, "terminate_on_fall": False}
+
+        env = PettingZooEnv(
+            task="multiwalker_v9",
+            parallel=True,
+            seed=0,
+            use_mask=False,
+            done_on_any=False,
+            **scenario_args,
+        )
+        with pytest.raises(
+            ValueError,
+            match="Dead agents found in the environment, "
+            "you need to set use_mask=True to allow this.",
+        ):
+            env.rollout(
+                max_steps=100,
+                break_when_any_done=True,  # This looks at root done set with done_on_any
+            )
+
+        for done_on_any in [True, False]:
+            env = PettingZooEnv(
+                task="multiwalker_v9",
+                parallel=True,
+                seed=0,
+                use_mask=True,
+                done_on_any=done_on_any,
+                **scenario_args,
+            )
+            td = env.rollout(
+                max_steps=100,
+                break_when_any_done=True,  # This looks at root done set with done_on_any
+            )
+            done = td.get(("next", "walker", "done"))
+            mask = td.get(("next", "walker", "mask"))
+
+            if done_on_any:
+                assert not done[-1].all()  # Done triggered on any
+            else:
+                assert done[-1].all()  # Done triggered on all
+            assert not done[
+                mask
+            ].any()  # When mask is true (alive agent), all agents are not done
+            assert done[
+                ~mask
+            ].all()  # When mask is false (dead agent), all agents are done
 
     @pytest.mark.parametrize(
         "wins_player_0",
@@ -3156,7 +3201,6 @@ class TestPettingZoo:
         )
 
         class Policy:
-
             action = 0
             t = 0
 

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -3149,14 +3149,17 @@ class TestPettingZoo:
             done_on_any=False,
             **scenario_args,
         )
+        td_reset = env.reset(seed=seed)
         with pytest.raises(
             ValueError,
             match="Dead agents found in the environment, "
             "you need to set use_mask=True to allow this.",
         ):
             env.rollout(
-                max_steps=100,
+                max_steps=500,
                 break_when_any_done=True,  # This looks at root done set with done_on_any
+                auto_reset=False,
+                tensordict=td_reset,
             )
 
         for done_on_any in [True, False]:
@@ -3168,11 +3171,14 @@ class TestPettingZoo:
                 done_on_any=done_on_any,
                 **scenario_args,
             )
+            td_reset = env.reset(seed=seed)
             td = env.rollout(
-                max_steps=100,
+                max_steps=500,
                 break_when_any_done=True,  # This looks at root done set with done_on_any
+                auto_reset=False,
+                tensordict=td_reset,
             )
-            done = td.get(("next", "walker", "done"))
+            done = td.get(("next", "walker", "done")).clone()
             mask = td.get(("next", "walker", "mask"))
 
             if done_on_any:

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -3144,7 +3144,7 @@ class TestPettingZoo:
         env = PettingZooEnv(
             task="multiwalker_v9",
             parallel=True,
-            seed=0,
+            seed=seed,
             use_mask=False,
             done_on_any=False,
             **scenario_args,
@@ -3163,7 +3163,7 @@ class TestPettingZoo:
             env = PettingZooEnv(
                 task="multiwalker_v9",
                 parallel=True,
-                seed=0,
+                seed=seed,
                 use_mask=True,
                 done_on_any=done_on_any,
                 **scenario_args,

--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -90,12 +90,12 @@ class PettingZooWrapper(_EnvWrapper):
     If the number of agents during the task varies, please set ``use_mask=True``.
     ``"mask"`` will be provided
     as an output in each group and should be used to mask out dead agents.
-    The environment will be reset as soon as one agent is done.
+    The environment will be reset as soon as one agent is done (unless ``done_on_any`` is ``False``).
 
     In wrapped ``pettingzoo.AECEnv``, at each step only one agent will act.
     For this reason, it is compulsory to set ``use_mask=True`` for this type of environment.
     ``"mask"`` will be provided as an output for each group and can be used to mask out non-acting agents.
-    The environment will be reset only when all agents are done.
+    The environment will be reset only when all agents are done (unless ``done_on_any`` is ``True``).
 
     If there are any unavailable actions for an agent,
     the environment will also automatically update the mask of its ``action_spec`` and output an ``"action_mask"``
@@ -156,6 +156,9 @@ class PettingZooWrapper(_EnvWrapper):
         categorical_actions (bool, optional): if the enviornments actions are discrete, whether to transform
             them to categorical or one-hot.
         seed (int, optional): the seed. Defaults to ``None``.
+        done_on_any (bool, optional): whether the environment's done keys are set by aggregating the agent keys
+            using ``any()`` (when True) or ``all()`` (when False). Default (``None``) is to use ``any()`` for
+            parallel environments and ``all()`` for AEC ones.
 
     Examples:
         >>> # Parallel env
@@ -204,6 +207,7 @@ class PettingZooWrapper(_EnvWrapper):
         use_mask: bool = False,
         categorical_actions: bool = True,
         seed: int | None = None,
+        done_on_any: bool = None,
         **kwargs,
     ):
         if env is not None:
@@ -214,6 +218,7 @@ class PettingZooWrapper(_EnvWrapper):
         self.seed = seed
         self.use_mask = use_mask
         self.categorical_actions = categorical_actions
+        self.done_on_any = done_on_any
 
         super().__init__(**kwargs, allow_done_after_reset=True)
 
@@ -283,6 +288,9 @@ class PettingZooWrapper(_EnvWrapper):
             "pettingzoo.utils.env.AECEnv",  # noqa: F821
         ],
     ) -> None:
+        # Set default for done on any or all
+        if self.done_on_any is None:
+            self.done_on_any = self.parallel
 
         # Create and check group map
         if self.group_map is None:
@@ -582,7 +590,6 @@ class PettingZooWrapper(_EnvWrapper):
         self,
         tensordict: TensorDictBase,
     ) -> TensorDictBase:
-
         if self.parallel:
             (
                 observation_dict,
@@ -651,16 +658,33 @@ class PettingZooWrapper(_EnvWrapper):
                                 value, device=self.device
                             )
 
-                elif not self.use_action_mask:
+                elif self.use_mask:
+                    if agent in self.agents:
+                        raise ValueError(
+                            f"Dead agent {agent} not found in step observation but still available in {self.agents}"
+                        )
+                    # Dead agent
+                    terminated = (
+                        terminations_dict[agent] if agent in terminations_dict else True
+                    )
+                    truncated = (
+                        truncations_dict[agent] if agent in truncations_dict else True
+                    )
+                    done = terminated or truncated
+                    group_done[index] = done
+                    group_terminated[index] = terminated
+                    group_truncated[index] = truncated
+
+                else:
                     # Dead agent, if we are not masking it out, this is not allowed
                     raise ValueError(
                         "Dead agents found in the environment,"
-                        " you need to set use_action_mask=True to allow this."
+                        " you need to set use_mask=True to allow this."
                     )
 
         # set done values
         done, terminated, truncated = self._aggregate_done(
-            tensordict_out, use_any=self.parallel
+            tensordict_out, use_any=self.done_on_any
         )
 
         tensordict_out.set("done", done)
@@ -673,7 +697,7 @@ class PettingZooWrapper(_EnvWrapper):
         truncated = False if use_any else True
         terminated = False if use_any else True
         for key in self.done_keys:
-            if isinstance(key, tuple):
+            if isinstance(key, tuple):  # Only look at group keys
                 if use_any:
                     if key[-1] == "done":
                         done = done | tensordict_out.get(key).any()
@@ -719,7 +743,6 @@ class PettingZooWrapper(_EnvWrapper):
         self,
         tensordict: TensorDictBase,
     ) -> Tuple[Dict, Dict, Dict, Dict, Dict]:
-
         for group, agents in self.group_map.items():
             if self.agent_selection in agents:
                 agent_index = agents.index(self._env.agent_selection)
@@ -747,7 +770,6 @@ class PettingZooWrapper(_EnvWrapper):
         )
 
     def _update_action_mask(self, td, observation_dict, info_dict):
-
         # Since we remove the action_mask keys we need to copy the data
         observation_dict = copy.deepcopy(observation_dict)
         info_dict = copy.deepcopy(info_dict)
@@ -821,7 +843,7 @@ class PettingZooEnv(PettingZooWrapper):
     If the number of agents during the task varies, please set ``use_mask=True``.
     ``"mask"`` will be provided
     as an output in each group and should be used to mask out dead agents.
-    The environment will be reset as soon as one agent is done.
+    The environment will be reset as soon as one agent is done (unless ``done_on_any`` is ``False``).
 
     For wrapping ``pettingzoo.AECEnv`` provide the name of your petting zoo task (in the ``task`` argument)
     and specify ``parallel=False``. This will construct the ``pettingzoo.AECEnv`` version of that task
@@ -829,7 +851,7 @@ class PettingZooEnv(PettingZooWrapper):
     In wrapped ``pettingzoo.AECEnv``, at each step only one agent will act.
     For this reason, it is compulsory to set ``use_mask=True`` for this type of environment.
     ``"mask"`` will be provided as an output for each group and can be used to mask out non-acting agents.
-    The environment will be reset only when all agents are done.
+    The environment will be reset only when all agents are done (unless ``done_on_any`` is ``True``).
 
     If there are any unavailable actions for an agent,
     the environment will also automatically update the mask of its ``action_spec`` and output an ``"action_mask"``
@@ -892,6 +914,9 @@ class PettingZooEnv(PettingZooWrapper):
         categorical_actions (bool, optional): if the enviornments actions are discrete, whether to transform
             them to categorical or one-hot.
         seed (int, optional): the seed.  Defaults to ``None``.
+        done_on_any (bool, optional): whether the environment's done keys are set by aggregating the agent keys
+            using ``any()`` (when True) or ``all()`` (when False). Default (``None``) is to use ``any()`` for
+            parallel environments and ``all()`` for AEC ones.
 
     Examples:
         >>> # Parallel env
@@ -930,6 +955,7 @@ class PettingZooEnv(PettingZooWrapper):
         use_mask: bool = False,
         categorical_actions: bool = True,
         seed: int | None = None,
+        done_on_any: bool = None,
         **kwargs,
     ):
         if not _has_pettingzoo:
@@ -944,6 +970,7 @@ class PettingZooEnv(PettingZooWrapper):
         kwargs["use_mask"] = use_mask
         kwargs["categorical_actions"] = categorical_actions
         kwargs["seed"] = seed
+        kwargs["done_on_any"] = done_on_any
 
         super().__init__(**kwargs)
 

--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -955,7 +955,7 @@ class PettingZooEnv(PettingZooWrapper):
         use_mask: bool = False,
         categorical_actions: bool = True,
         seed: int | None = None,
-        done_on_any: bool = None,
+        done_on_any: bool | None = None,
         **kwargs,
     ):
         if not _has_pettingzoo:

--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -207,7 +207,7 @@ class PettingZooWrapper(_EnvWrapper):
         use_mask: bool = False,
         categorical_actions: bool = True,
         seed: int | None = None,
-        done_on_any: bool = None,
+        done_on_any: bool | None = None,
         **kwargs,
     ):
         if env is not None:

--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -9,6 +9,7 @@ import importlib
 import warnings
 from typing import Dict, List, Tuple, Union
 
+import packaging
 import torch
 from tensordict import TensorDictBase
 
@@ -270,7 +271,7 @@ class PettingZooWrapper(_EnvWrapper):
     ):
         import pettingzoo
 
-        if importlib.metadata.version("pettingzoo") != "1.24.3":
+        if packaging.version.parse(pettingzoo.__version__).base_version != "1.24.3":
             warnings.warn(
                 "PettingZoo in TorchRL is tested using version == 1.24.3 , "
                 "If you are using a different version and are experiencing compatibility issues,"

--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -915,7 +915,7 @@ class PettingZooEnv(PettingZooWrapper):
             them to categorical or one-hot.
         seed (int, optional): the seed.  Defaults to ``None``.
         done_on_any (bool, optional): whether the environment's done keys are set by aggregating the agent keys
-            using ``any()`` (when True) or ``all()`` (when False). Default (``None``) is to use ``any()`` for
+            using ``any()`` (when ``True``) or ``all()`` (when ``False``). Default (``None``) is to use ``any()`` for
             parallel environments and ``all()`` for AEC ones.
 
     Examples:

--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -157,7 +157,7 @@ class PettingZooWrapper(_EnvWrapper):
             them to categorical or one-hot.
         seed (int, optional): the seed. Defaults to ``None``.
         done_on_any (bool, optional): whether the environment's done keys are set by aggregating the agent keys
-            using ``any()`` (when True) or ``all()`` (when False). Default (``None``) is to use ``any()`` for
+            using ``any()`` (when ``True``) or ``all()`` (when ``False``). Default (``None``) is to use ``any()`` for
             parallel environments and ``all()`` for AEC ones.
 
     Examples:

--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -270,6 +270,13 @@ class PettingZooWrapper(_EnvWrapper):
     ):
         import pettingzoo
 
+        if importlib.metadata.version("pettingzoo") > "1.24.3":
+            warnings.warn(
+                "PettingZoo in TorchRL is tested using version == 1.24.3."
+                "If you are using a later version and are experiencing backwards compatibility issues,"
+                "please raise an issue in the TorchRL github"
+            )
+
         self.parallel = isinstance(env, pettingzoo.utils.env.ParallelEnv)
         if not self.parallel and not self.use_mask:
             raise ValueError("For AEC environments you need to set use_mask=True")

--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -272,9 +272,9 @@ class PettingZooWrapper(_EnvWrapper):
 
         if importlib.metadata.version("pettingzoo") > "1.24.3":
             warnings.warn(
-                "PettingZoo in TorchRL is tested using version == 1.24.3."
+                "PettingZoo in TorchRL is tested using version == 1.24.3 , "
                 "If you are using a later version and are experiencing backwards compatibility issues,"
-                "please raise an issue in the TorchRL github"
+                "please raise an issue in the TorchRL github."
             )
 
         self.parallel = isinstance(env, pettingzoo.utils.env.ParallelEnv)

--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -270,10 +270,10 @@ class PettingZooWrapper(_EnvWrapper):
     ):
         import pettingzoo
 
-        if importlib.metadata.version("pettingzoo") > "1.24.3":
+        if importlib.metadata.version("pettingzoo") != "1.24.3":
             warnings.warn(
                 "PettingZoo in TorchRL is tested using version == 1.24.3 , "
-                "If you are using a later version and are experiencing backwards compatibility issues,"
+                "If you are using a different version and are experiencing compatibility issues,"
                 "please raise an issue in the TorchRL github."
             )
 


### PR DESCRIPTION
Here I have a small set of modifications to PettingZoo wrapper that have been requested by users.

The modifications are:
- possibility to override if an environment is done whaen any or all agents are done
- setting the done flags for dead agents properly

cc @renos