### PR TITLE
[BugFix] Fix RoboHiveEnv tests

### DIFF
--- a/.github/unittest/linux_libs/scripts_robohive/environment.yml
+++ b/.github/unittest/linux_libs/scripts_robohive/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - protobuf
   - pip:
     # Initial version is required to install Atari ROMS in setup_env.sh
-    - gym==0.13
+    - gymnasium
     - hypothesis
     - future
     - cloudpickle

--- a/.github/unittest/linux_libs/scripts_robohive/setup_env.sh
+++ b/.github/unittest/linux_libs/scripts_robohive/setup_env.sh
@@ -80,5 +80,7 @@ conda install conda-forge::ffmpeg -y
 
 pip install robohive
 
+python3 -m robohive_init
+
 # make sure only gymnasium is available
 # pip uninstall gym -y

--- a/.github/unittest/linux_libs/scripts_robohive/setup_env.sh
+++ b/.github/unittest/linux_libs/scripts_robohive/setup_env.sh
@@ -78,4 +78,6 @@ conda env update --file "${this_dir}/environment.yml" --prune
 
 conda install conda-forge::ffmpeg -y
 
-pip install git+https://github.com/vikashplus/robohive@main
+pip install robohive
+# make sure only gymnasium is available
+pip uninstall gym -y

--- a/.github/unittest/linux_libs/scripts_robohive/setup_env.sh
+++ b/.github/unittest/linux_libs/scripts_robohive/setup_env.sh
@@ -79,5 +79,6 @@ conda env update --file "${this_dir}/environment.yml" --prune
 conda install conda-forge::ffmpeg -y
 
 pip install robohive
+
 # make sure only gymnasium is available
-pip uninstall gym -y
+# pip uninstall gym -y

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -7,6 +7,8 @@ import os
 from contextlib import nullcontext
 from pathlib import Path
 
+import robohive
+
 from torchrl._utils import logger as torchrl_logger
 
 from torchrl.data.datasets.gen_dgrl import GenDGRLExperienceReplay
@@ -3341,25 +3343,26 @@ class TestRoboHive:
     @pytest.mark.parametrize("from_pixels", [False, True])
     @pytest.mark.parametrize("envname", RoboHiveEnv.available_envs)
     def test_robohive(self, envname, from_pixels):
-        torchrl_logger.info(f"{envname}-{from_pixels}")
-        if any(substr in envname for substr in ("_vr3m", "_vrrl", "_vflat", "_vvc1s")):
-            torchrl_logger.info("not testing envs with prebuilt rendering")
-            return
-        if "Adroit" in envname:
-            torchrl_logger.info("tcdm are broken")
-            return
-        if from_pixels and len(RoboHiveEnv.get_available_cams(env_name=envname)) == 0:
-            torchrl_logger.info("no camera")
-            return
-        try:
-            env = RoboHiveEnv(envname, from_pixels=from_pixels)
-        except AttributeError as err:
-            if "'MjData' object has no attribute 'get_body_xipos'" in str(err):
+        with set_gym_backend("gymnasium"):
+            torchrl_logger.info(f"{envname}-{from_pixels}")
+            if any(substr in envname for substr in ("_vr3m", "_vrrl", "_vflat", "_vvc1s")):
+                torchrl_logger.info("not testing envs with prebuilt rendering")
+                return
+            if "Adroit" in envname:
                 torchrl_logger.info("tcdm are broken")
                 return
-            else:
-                raise err
-        check_env_specs(env)
+            if from_pixels and len(RoboHiveEnv.get_available_cams(env_name=envname)) == 0:
+                torchrl_logger.info("no camera")
+                return
+            try:
+                env = RoboHiveEnv(envname, from_pixels=from_pixels)
+            except AttributeError as err:
+                if "'MjData' object has no attribute 'get_body_xipos'" in str(err):
+                    torchrl_logger.info("tcdm are broken")
+                    return
+                else:
+                    raise err
+            check_env_specs(env)
 
 
 @pytest.mark.skipif(not _has_smacv2, reason="SMACv2 not found")

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -3338,10 +3338,10 @@ class TestRoboHive:
     # In the CI, robohive should not coexist with other libs so that's fine.
     # Locally these imports can be annoying, especially given the amount of
     # stuff printed by robohive.
-    @pytest.mark.parametrize("from_pixels", [True, False])
+    @pytest.mark.parametrize("from_pixels", [False, True])
     @pytest.mark.parametrize("envname", RoboHiveEnv.available_envs[:10])
-    @set_gym_backend("gym")
     def test_robohive(self, envname, from_pixels):
+        torchrl_logger.info(f"{envname}-{from_pixels}")
         if any(substr in envname for substr in ("_vr3m", "_vrrl", "_vflat", "_vvc1s")):
             torchrl_logger.info("not testing envs with prebuilt rendering")
             return

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -3412,6 +3412,7 @@ class TestRoboHive:
                     return
                 else:
                     raise err
+            torchrl_logger.info("rollout", env.rollout(4))
             check_env_specs(env)
 
 

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -7,8 +7,6 @@ import os
 from contextlib import nullcontext
 from pathlib import Path
 
-import robohive
-
 from torchrl._utils import logger as torchrl_logger
 
 from torchrl.data.datasets.gen_dgrl import GenDGRLExperienceReplay

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -3339,22 +3339,16 @@ class TestRoboHive:
     # Locally these imports can be annoying, especially given the amount of
     # stuff printed by robohive.
     @pytest.mark.parametrize("from_pixels", [True, False])
-    @pytest.mark.parametrize("envname", RoboHiveEnv.available_envs)
+    @pytest.mark.parametrize("envname", RoboHiveEnv.available_envs[:10])
     @set_gym_backend("gym")
     def test_robohive(self, envname, from_pixels):
-        if any(
-            substr in envname
-            for substr in ("_vr3m", "_vrrl", "_vflat", "_vvc1s")
-        ):
+        if any(substr in envname for substr in ("_vr3m", "_vrrl", "_vflat", "_vvc1s")):
             torchrl_logger.info("not testing envs with prebuilt rendering")
             return
         if "Adroit" in envname:
             torchrl_logger.info("tcdm are broken")
             return
-        if (
-            from_pixels
-            and len(RoboHiveEnv.get_available_cams(env_name=envname)) == 0
-        ):
+        if from_pixels and len(RoboHiveEnv.get_available_cams(env_name=envname)) == 0:
             torchrl_logger.info("no camera")
             return
         try:
@@ -3366,6 +3360,7 @@ class TestRoboHive:
             else:
                 raise err
         check_env_specs(env)
+
 
 @pytest.mark.skipif(not _has_smacv2, reason="SMACv2 not found")
 class TestSmacv2:

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -3329,7 +3329,7 @@ class TestPettingZoo:
             break
 
 
-@pytest.mark.skipif(not _has_robohive, reason="SMACv2 not found")
+@pytest.mark.skipif(not _has_robohive, reason="RoboHive not found")
 class TestRoboHive:
     # unfortunately we must import robohive to get the available envs
     # and this import will occur whenever pytest is run on this file.
@@ -3339,37 +3339,33 @@ class TestRoboHive:
     # Locally these imports can be annoying, especially given the amount of
     # stuff printed by robohive.
     @pytest.mark.parametrize("from_pixels", [True, False])
+    @pytest.mark.parametrize("envname", RoboHiveEnv.available_envs)
     @set_gym_backend("gym")
-    def test_robohive(self, from_pixels):
-        for envname in RoboHiveEnv.available_envs:
-            try:
-                if any(
-                    substr in envname
-                    for substr in ("_vr3m", "_vrrl", "_vflat", "_vvc1s")
-                ):
-                    torchrl_logger.info("not testing envs with prebuilt rendering")
-                    return
-                if "Adroit" in envname:
-                    torchrl_logger.info("tcdm are broken")
-                    return
-                try:
-                    env = RoboHiveEnv(envname)
-                except AttributeError as err:
-                    if "'MjData' object has no attribute 'get_body_xipos'" in str(err):
-                        torchrl_logger.info("tcdm are broken")
-                        return
-                    else:
-                        raise err
-                if (
-                    from_pixels
-                    and len(RoboHiveEnv.get_available_cams(env_name=envname)) == 0
-                ):
-                    torchrl_logger.info("no camera")
-                    return
-                check_env_specs(env)
-            except Exception as err:
-                raise RuntimeError(f"Test with robohive end {envname} failed.") from err
-
+    def test_robohive(self, envname, from_pixels):
+        if any(
+            substr in envname
+            for substr in ("_vr3m", "_vrrl", "_vflat", "_vvc1s")
+        ):
+            torchrl_logger.info("not testing envs with prebuilt rendering")
+            return
+        if "Adroit" in envname:
+            torchrl_logger.info("tcdm are broken")
+            return
+        if (
+            from_pixels
+            and len(RoboHiveEnv.get_available_cams(env_name=envname)) == 0
+        ):
+            torchrl_logger.info("no camera")
+            return
+        try:
+            env = RoboHiveEnv(envname, from_pixels=from_pixels)
+        except AttributeError as err:
+            if "'MjData' object has no attribute 'get_body_xipos'" in str(err):
+                torchrl_logger.info("tcdm are broken")
+                return
+            else:
+                raise err
+        check_env_specs(env)
 
 @pytest.mark.skipif(not _has_smacv2, reason="SMACv2 not found")
 class TestSmacv2:

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -2781,6 +2781,7 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
         they may change during the execution of the code (eg, when adding a transform).
 
         """
+        self.__dict__["_step_mdp_value"] = None
         self.__dict__["_reward_keys"] = None
         self.__dict__["_done_keys"] = None
         self.__dict__["_action_keys"] = None
@@ -2813,7 +2814,7 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
 
     @property
     def _filtered_reset_keys(self):
-        """Returns the only the effective reset keys, discarding nested resets if they're not being used."""
+        """Returns only the effective reset keys, discarding nested resets if they're not being used."""
         reset_keys = self.reset_keys
         result = []
 

--- a/torchrl/envs/libs/robohive.py
+++ b/torchrl/envs/libs/robohive.py
@@ -12,7 +12,6 @@ from pathlib import Path
 import numpy as np
 import torch
 from tensordict import make_tensordict, TensorDict
-from torchrl._utils import implement_for
 from torchrl.data.tensor_specs import UnboundedContinuousTensorSpec
 from torchrl.envs.libs.gym import (
     _AsyncMeta,

--- a/torchrl/envs/libs/robohive.py
+++ b/torchrl/envs/libs/robohive.py
@@ -273,14 +273,16 @@ class RoboHiveEnv(GymEnv, metaclass=_RoboHiveBuild):
             _dict = {}
             _dict.update(get_obs())
             _dict["action"] = action = env.action_space.sample()
-            _, r, d, _ = env.step(action)
+            _, r, trunc, term, done, _ = self._output_transform(env.step(action))
             _dict[("next", "reward")] = r.reshape(1)
             _dict[("next", "done")] = [1]
+            _dict[("next", "terminated")] = [1]
+            _dict[("next", "truncated")] = [1]
             _dict["next"] = get_obs()
             rollout[i] = TensorDict(_dict, [])
 
         observation_spec = make_composite_from_td(
-            rollout.get("next").exclude("done", "reward")[0]
+            rollout.get("next").exclude("done", "reward", "terminated", "truncated")[0]
         )
         self.observation_spec = observation_spec
 

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -6676,7 +6676,7 @@ class ActionMask(Transform):
         ...         self.observation_spec = CompositeSpec(obs=UnboundedContinuousTensorSpec(3))
         ...         self.reward_spec = UnboundedContinuousTensorSpec(1)
         ...
-        ...     def _reset(self, data):
+        ...     def _reset(self, tensordict=None):
         ...         td = self.observation_spec.rand()
         ...         td.update(torch.ones_like(self.state_spec.rand()))
         ...         return td


### PR DESCRIPTION
## Description

- Make `RoboHiveEnv` tests actually run correctly when executed
- Fixed a bug in testing of envs without cameras  
- Refactor and simplify test case 

## Motivation and Context

Currently, the tests for `RoboHiveEnv` aren't actually executing correctly.  When the env is [instantiated](https://github.com/pytorch/rl/blob/main/test/test_libs.py#L3356), the `from_pixels` key isn't actually used, and none of the envs are tested with `from_pixels=True`.

After the test code is fixed, I get 9 failures for the RoboHive tests, all of which seem to be caused by an issue with `DKitty` environments. 

Short Test log:

```
================================================= short test summary info =================================================
FAILED test/test_libs.py::TestRoboHive::test_robohive[DKittyOrientFixed-v0-True] - gym.error.Error: A module (A) was specified for the environment but was not found, make sure the package is installed ...
FAILED test/test_libs.py::TestRoboHive::test_robohive[DKittyOrientRandom-v0-True] - gym.error.Error: A module (A) was specified for the environment but was not found, make sure the package is installed ...
FAILED test/test_libs.py::TestRoboHive::test_robohive[DKittyOrientRandom_v2d-v0-True] - gym.error.Error: A module (A) was specified for the environment but was not found, make sure the package is installed ...
FAILED test/test_libs.py::TestRoboHive::test_robohive[DKittyStandFixed-v0-True] - gym.error.Error: A module (A) was specified for the environment but was not found, make sure the package is installed ...
FAILED test/test_libs.py::TestRoboHive::test_robohive[DKittyStandRandom-v0-True] - gym.error.Error: A module (A) was specified for the environment but was not found, make sure the package is installed ...
FAILED test/test_libs.py::TestRoboHive::test_robohive[DKittyStandRandom_v2d-v0-True] - gym.error.Error: A module (A) was specified for the environment but was not found, make sure the package is installed ...
FAILED test/test_libs.py::TestRoboHive::test_robohive[DKittyWalkFixed-v0-True] - gym.error.Error: A module (A) was specified for the environment but was not found, make sure the package is installed ...
FAILED test/test_libs.py::TestRoboHive::test_robohive[DKittyWalkRandom-v0-True] - gym.error.Error: A module (A) was specified for the environment but was not found, make sure the package is installed ...
FAILED test/test_libs.py::TestRoboHive::test_robohive[DKittyWalkRandom_v2d-v0-True] - gym.error.Error: A module (A) was specified for the environment but was not found, make sure the package is installed ...
```

Full traceback:

```
-------------------------------------------------- Captured stdout call ---------------------------------------------------
Registered a new env-variant: A:head-A:left-A:right-A:tail-A:tracki-A:tracki-DKittyWalkRandom-v0
________________________________ TestRoboHive.test_robohive[DKittyWalkRandom_v2d-v0-True] _________________________________
Traceback (most recent call last):
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/gym/envs/registration.py", line 120, in spec
    importlib.import_module(mod_name)
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'A'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/_pytest/runner.py", line 342, in from_call
    result: Optional[TResult] = func()
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/_pytest/runner.py", line 263, in <lambda>
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/pluggy/_hooks.py", line 501, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/pluggy/_manager.py", line 119, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/pluggy/_callers.py", line 138, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/pluggy/_callers.py", line 121, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/_pytest/threadexception.py", line 87, in pytest_runtest_call
    yield from thread_exception_runtest_hook()
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/_pytest/threadexception.py", line 63, in thread_exception_runtest_hook
    yield
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/pluggy/_callers.py", line 121, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/_pytest/unraisableexception.py", line 90, in pytest_runtest_call
    yield from unraisable_exception_runtest_hook()
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/_pytest/unraisableexception.py", line 65, in unraisable_exception_runtest_hook
    yield
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/pluggy/_callers.py", line 121, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/_pytest/logging.py", line 839, in pytest_runtest_call
    yield from self._runtest_for(item, "call")
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/_pytest/logging.py", line 822, in _runtest_for
    yield
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/pluggy/_callers.py", line 121, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/_pytest/capture.py", line 882, in pytest_runtest_call
    return (yield)
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/pluggy/_callers.py", line 121, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/_pytest/skipping.py", line 256, in pytest_runtest_call
    return (yield)
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/pluggy/_callers.py", line 102, in _multicall
    res = hook_impl.function(*args)
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/_pytest/runner.py", line 178, in pytest_runtest_call
    raise e
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/_pytest/runner.py", line 170, in pytest_runtest_call
    item.runtest()
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/_pytest/python.py", line 1831, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/pluggy/_hooks.py", line 501, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/pluggy/_manager.py", line 119, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/pluggy/_callers.py", line 138, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/pluggy/_callers.py", line 102, in _multicall
    res = hook_impl.function(*args)
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/sriramsk/desktop/torchrl/test/test_libs.py", line 3355, in test_robohive
    env = RoboHiveEnv(envname, from_pixels=from_pixels)
  File "/home/sriramsk/desktop/torchrl/torchrl/envs/libs/robohive.py", line 54, in __call__
    instance: RoboHiveEnv = super().__call__(*args, **kwargs)
  File "/home/sriramsk/desktop/torchrl/torchrl/envs/libs/gym.py", line 543, in __call__
    instance: GymWrapper = super().__call__(*args, **kwargs)
  File "/home/sriramsk/desktop/torchrl/torchrl/envs/common.py", line 166, in __call__
    instance: EnvBase = super().__call__(*args, **kwargs)
  File "/home/sriramsk/desktop/torchrl/torchrl/envs/libs/gym.py", line 1277, in __init__
    super().__init__(**kwargs)
  File "/home/sriramsk/desktop/torchrl/torchrl/envs/libs/gym.py", line 731, in __init__
    super().__init__(**kwargs)
  File "/home/sriramsk/desktop/torchrl/torchrl/envs/common.py", line 2993, in __init__
    self._env = self._build_env(**kwargs)  # writes the self._env attribute
  File "/home/sriramsk/desktop/torchrl/torchrl/envs/libs/robohive.py", line 201, in _build_env
    env = self.lib.make(
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/gym/envs/registration.py", line 156, in make
    return registry.make(id, **kwargs)
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/gym/envs/registration.py", line 100, in make
    spec = self.spec(path)
  File "/home/sriramsk/miniconda3/envs/torch_rl/lib/python3.9/site-packages/gym/envs/registration.py", line 123, in spec
    raise error.Error('A module ({}) was specified for the environment but was not found, make sure the package is installed with `pip install` before calling `gym.make()`'.format(mod_name))
gym.error.Error: A module (A) was specified for the environment but was not found, make sure the package is installed with `pip install` before calling `gym.make()`
```



