### PR TITLE
[BugFix] Remove `split_trajectories`'s reference to `("next", "done")`.

### DIFF
--- a/torchrl/collectors/utils.py
+++ b/torchrl/collectors/utils.py
@@ -179,7 +179,7 @@ def split_trajectories(
             torch.ones(
                 out_split.shape,
                 dtype=torch.bool,
-                device=out_split.get(("next", "done")).device,
+                device=out_split.device,
             ),
         )
     if len(out_splits) > 1:


### PR DESCRIPTION
## Description

Changes the way `.device` is obtained inside `split_trajectories`.

## Motivation and Context

When `trajectory_key` is used there is not need for having `("next", "done")`, however, it was still used to get the `.device`.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
