### PR TITLE
[CI] Fix Doc CI

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -26,4 +26,3 @@ memory_profiler
 pyrender
 pytest
 vmas
-pettingzoo[mpe]==1.24.3


### PR DESCRIPTION
The CI for the docs was crashing due to the added pettingzoo dependency in the requirements.

Since the merged version of the MADDPG tutorial does not depend on pettingzoo because it uses vmas, we can solve this by removing the dependency

Otherwise, we should change the tutorial by setting use_vmas=False and figure out the dependency conflict