### PR TITLE
[BugFix] missing deprecated kwargs

### DIFF
--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1597,12 +1597,12 @@ class BoundedTensorSpec(TensorSpec):
             if high is not None:
                 raise TypeError(self.CONFLICTING_KWARGS.format("high", "maximum"))
             high = kwargs.pop("maximum")
-            warnings.warn(self.DEPRECATED_KWARGS, category=DeprecationWarning)
+            warnings.warn("Maximum is deprecated since v0.4.0, using high instead.", category=DeprecationWarning)
         if "minimum" in kwargs:
             if low is not None:
                 raise TypeError(self.CONFLICTING_KWARGS.format("low", "minimum"))
             low = kwargs.pop("minimum")
-            warnings.warn(self.DEPRECATED_KWARGS, category=DeprecationWarning)
+            warnings.warn("Minimum is deprecated since v0.4.0, using low instead.", category=DeprecationWarning)
         domain = kwargs.pop("domain", "continuous")
         if len(kwargs):
             raise TypeError(f"Got unrecognised kwargs {tuple(kwargs.keys())}.")


### PR DESCRIPTION
## Description

The following code, passing the deprecated `minimum` and `maximum`:

```python
from torchrl.data import BoundedTensorSpec

spec = BoundedTensorSpec(minimum=0, maximum=1, shape=(2,))
```

Raises the following error: `AttributeError: 'BoundedTensorSpec' object has no attribute 'DEPRECATED_KWARGS'`. This attribute was removed in a previous commit. 

I simply modified the warning message to keep the current functionality!

## Motivation and Context

(did not raise an issue since it is super simple and will only affect depracted usage of one tensor spec)

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist


- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
