### PR TITLE
[Doc] Indicate necessary context to run multiprocessed collectors in doc

### DIFF
--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -535,7 +535,10 @@ class SyncDataCollector(DataCollectorBase):
         self.reset_when_done = reset_when_done
         self.n_env = self.env.batch_size.numel()
 
-        (self.policy, self.get_weights_fn,) = self._get_policy_and_device(
+        (
+            self.policy,
+            self.get_weights_fn,
+        ) = self._get_policy_and_device(
             policy=policy,
             observation_spec=self.env.observation_spec,
         )
@@ -2238,27 +2241,34 @@ class MultiaSyncDataCollector(_MultiDataCollector):
     the batch of rollouts is collected and the next call to the iterator.
     This class can be safely used with offline RL sota-implementations.
 
+    note:: Python requires multiprocessed code to be instantiated within a
+        ```if __name__ == "__main__":``` block. See https://docs.python.org/3/library/multiprocessing.html
+        for more info.
+
     Examples:
-        >>> from torchrl.envs.libs.gym import GymEnv
+           >>> from torchrl.envs.libs.gym import GymEnv
         >>> from tensordict.nn import TensorDictModule
         >>> from torch import nn
-        >>> env_maker = lambda: GymEnv("Pendulum-v1", device="cpu")
-        >>> policy = TensorDictModule(nn.Linear(3, 1), in_keys=["observation"], out_keys=["action"])
-        >>> collector = MultiaSyncDataCollector(
-        ...     create_env_fn=[env_maker, env_maker],
-        ...     policy=policy,
-        ...     total_frames=2000,
-        ...     max_frames_per_traj=50,
-        ...     frames_per_batch=200,
-        ...     init_random_frames=-1,
-        ...     reset_at_each_iter=False,
-        ...     devices="cpu",
-        ...     storing_devices="cpu",
-        ... )
-        >>> for i, data in enumerate(collector):
-        ...     if i == 2:
-        ...         print(data)
-        ...         break
+        >>> from torchrl.collectors import MultiaSyncDataCollector
+        >>> if __name__ == "__main__":
+        >>>     env_maker = lambda: GymEnv("Pendulum-v1", device="cpu")
+        >>>     policy = TensorDictModule(nn.Linear(3, 1), in_keys=["observation"], out_keys=["action"])
+        >>>     collector = MultiaSyncDataCollector(
+            ...     create_env_fn=[env_maker, env_maker],
+            ...     policy=policy,
+            ...     total_frames=2000,
+            ...     max_frames_per_traj=50,
+            ...     frames_per_batch=200,
+            ...     init_random_frames=-1,
+            ...     reset_at_each_iter=False,
+            ...     device="cpu",
+            ...     storing_device="cpu",
+            ...     cat_results="stack",
+            ... )
+        >>>     for i, data in enumerate(collector):
+        ...         if i == 2:
+        ...             print(data)
+        ...             break
         TensorDict(
             fields={
                 action: Tensor(shape=torch.Size([200, 1]), device=cpu, dtype=torch.float32, is_shared=False),

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -1902,21 +1902,21 @@ class MultiSyncDataCollector(_MultiDataCollector):
         >>> from torch import nn
         >>> from torchrl.collectors import MultiSyncDataCollector
         >>> if __name__ == "__main__":
-        >>>     env_maker = lambda: GymEnv("Pendulum-v1", device="cpu")
-        >>>     policy = TensorDictModule(nn.Linear(3, 1), in_keys=["observation"], out_keys=["action"])
-        >>>     collector = MultiSyncDataCollector(
-            ...     create_env_fn=[env_maker, env_maker],
-            ...     policy=policy,
-            ...     total_frames=2000,
-            ...     max_frames_per_traj=50,
-            ...     frames_per_batch=200,
-            ...     init_random_frames=-1,
-            ...     reset_at_each_iter=False,
-            ...     device="cpu",
-            ...     storing_device="cpu",
-            ...     cat_results="stack",
-            ... )
-        >>>     for i, data in enumerate(collector):
+        ...     env_maker = lambda: GymEnv("Pendulum-v1", device="cpu")
+        ...     policy = TensorDictModule(nn.Linear(3, 1), in_keys=["observation"], out_keys=["action"])
+        ...     collector = MultiSyncDataCollector(
+        ...         create_env_fn=[env_maker, env_maker],
+        ...         policy=policy,
+        ...         total_frames=2000,
+        ...         max_frames_per_traj=50,
+        ...         frames_per_batch=200,
+        ...         init_random_frames=-1,
+        ...         reset_at_each_iter=False,
+        ...         device="cpu",
+        ...         storing_device="cpu",
+        ...         cat_results="stack",
+        ...     )
+        ...     for i, data in enumerate(collector):
         ...         if i == 2:
         ...             print(data)
         ...             break

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -535,10 +535,7 @@ class SyncDataCollector(DataCollectorBase):
         self.reset_when_done = reset_when_done
         self.n_env = self.env.batch_size.numel()
 
-        (
-            self.policy,
-            self.get_weights_fn,
-        ) = self._get_policy_and_device(
+        (self.policy, self.get_weights_fn,) = self._get_policy_and_device(
             policy=policy,
             observation_spec=self.env.observation_spec,
         )
@@ -1889,12 +1886,11 @@ class MultiSyncDataCollector(_MultiDataCollector):
 
     .. note:: Python requires multiprocessed code to be instantiated within a main guard:
 
+            >>> from torchrl.collectors import MultiSyncDataCollector
             >>> if __name__ == "__main__":
             ...     # Create your collector here
 
         See https://docs.python.org/3/library/multiprocessing.html for more info.
-
-
 
     Examples:
         >>> from torchrl.envs.libs.gym import GymEnv
@@ -1920,6 +1916,8 @@ class MultiSyncDataCollector(_MultiDataCollector):
         ...         if i == 2:
         ...             print(data)
         ...             break
+        ... collector.shutdown()
+        ... del collector
         TensorDict(
             fields={
                 action: Tensor(shape=torch.Size([200, 1]), device=cpu, dtype=torch.float32, is_shared=False),
@@ -1946,8 +1944,6 @@ class MultiSyncDataCollector(_MultiDataCollector):
             batch_size=torch.Size([200]),
             device=cpu,
             is_shared=False)
-        ... collector.shutdown()
-        ... del collector
 
     """
 
@@ -2245,11 +2241,15 @@ class MultiaSyncDataCollector(_MultiDataCollector):
     the batch of rollouts is collected and the next call to the iterator.
     This class can be safely used with offline RL sota-implementations.
 
-    note:: Python requires multiprocessed code to be instantiated within a
-        `if __name__ == "__main__":` block. See https://docs.python.org/3/library/multiprocessing.html
-        for more info.
+    .. note:: Python requires multiprocessed code to be instantiated within a main guard:
 
-     Examples:
+            >>> from torchrl.collectors import MultiaSyncDataCollector
+            >>> if __name__ == "__main__":
+            ...     # Create your collector here
+
+        See https://docs.python.org/3/library/multiprocessing.html for more info.
+
+        Examples:
         >>> from torchrl.envs.libs.gym import GymEnv
         >>> from tensordict.nn import TensorDictModule
         >>> from torch import nn
@@ -2273,6 +2273,8 @@ class MultiaSyncDataCollector(_MultiDataCollector):
         ...         if i == 2:
         ...             print(data)
         ...             break
+        ... collector.shutdown()
+        ... del collector
         TensorDict(
             fields={
                 action: Tensor(shape=torch.Size([200, 1]), device=cpu, dtype=torch.float32, is_shared=False),
@@ -2299,8 +2301,6 @@ class MultiaSyncDataCollector(_MultiDataCollector):
             batch_size=torch.Size([200]),
             device=cpu,
             is_shared=False)
-        ... collector.shutdown()
-        ... del collector
 
     """
 

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -1946,8 +1946,8 @@ class MultiSyncDataCollector(_MultiDataCollector):
             batch_size=torch.Size([200]),
             device=cpu,
             is_shared=False)
-        >>> collector.shutdown()
-        >>> del collector
+        ... collector.shutdown()
+        ... del collector
 
     """
 
@@ -2249,27 +2249,27 @@ class MultiaSyncDataCollector(_MultiDataCollector):
         `if __name__ == "__main__":` block. See https://docs.python.org/3/library/multiprocessing.html
         for more info.
 
-    Examples:
-           >>> from torchrl.envs.libs.gym import GymEnv
+     Examples:
+        >>> from torchrl.envs.libs.gym import GymEnv
         >>> from tensordict.nn import TensorDictModule
         >>> from torch import nn
         >>> from torchrl.collectors import MultiaSyncDataCollector
         >>> if __name__ == "__main__":
-        >>>     env_maker = lambda: GymEnv("Pendulum-v1", device="cpu")
-        >>>     policy = TensorDictModule(nn.Linear(3, 1), in_keys=["observation"], out_keys=["action"])
-        >>>     collector = MultiaSyncDataCollector(
-            ...     create_env_fn=[env_maker, env_maker],
-            ...     policy=policy,
-            ...     total_frames=2000,
-            ...     max_frames_per_traj=50,
-            ...     frames_per_batch=200,
-            ...     init_random_frames=-1,
-            ...     reset_at_each_iter=False,
-            ...     device="cpu",
-            ...     storing_device="cpu",
-            ...     cat_results="stack",
-            ... )
-        >>>     for i, data in enumerate(collector):
+        ...     env_maker = lambda: GymEnv("Pendulum-v1", device="cpu")
+        ...     policy = TensorDictModule(nn.Linear(3, 1), in_keys=["observation"], out_keys=["action"])
+        ...     collector = MultiaSyncDataCollector(
+        ...         create_env_fn=[env_maker, env_maker],
+        ...         policy=policy,
+        ...         total_frames=2000,
+        ...         max_frames_per_traj=50,
+        ...         frames_per_batch=200,
+        ...         init_random_frames=-1,
+        ...         reset_at_each_iter=False,
+        ...         device="cpu",
+        ...         storing_device="cpu",
+        ...         cat_results="stack",
+        ...     )
+        ...     for i, data in enumerate(collector):
         ...         if i == 2:
         ...             print(data)
         ...             break
@@ -2299,8 +2299,8 @@ class MultiaSyncDataCollector(_MultiDataCollector):
             batch_size=torch.Size([200]),
             device=cpu,
             is_shared=False)
-        >>> collector.shutdown()
-        >>> del collector
+        ... collector.shutdown()
+        ... del collector
 
     """
 

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -1888,7 +1888,7 @@ class MultiSyncDataCollector(_MultiDataCollector):
     This class can be safely used with online RL sota-implementations.
 
     note:: Python requires multiprocessed code to be instantiated within a
-    ```if __name__ == "__main__":``` block. See https://docs.python.org/3/library/multiprocessing.html
+    `if __name__ == "__main__":` block. See https://docs.python.org/3/library/multiprocessing.html
     for more info.
 
 
@@ -2242,7 +2242,7 @@ class MultiaSyncDataCollector(_MultiDataCollector):
     This class can be safely used with offline RL sota-implementations.
 
     note:: Python requires multiprocessed code to be instantiated within a
-        ```if __name__ == "__main__":``` block. See https://docs.python.org/3/library/multiprocessing.html
+        `if __name__ == "__main__":` block. See https://docs.python.org/3/library/multiprocessing.html
         for more info.
 
     Examples:

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -1887,9 +1887,13 @@ class MultiSyncDataCollector(_MultiDataCollector):
     trajectory and the start of the next collection.
     This class can be safely used with online RL sota-implementations.
 
-    note:: Python requires multiprocessed code to be instantiated within a
-    `if __name__ == "__main__":` block. See https://docs.python.org/3/library/multiprocessing.html
-    for more info.
+    .. note:: Python requires multiprocessed code to be instantiated within a main guard:
+
+            >>> if __name__ == "__main__":
+            ...     # Create your collector here
+
+        See https://docs.python.org/3/library/multiprocessing.html for more info.
+
 
 
     Examples:

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1597,12 +1597,18 @@ class BoundedTensorSpec(TensorSpec):
             if high is not None:
                 raise TypeError(self.CONFLICTING_KWARGS.format("high", "maximum"))
             high = kwargs.pop("maximum")
-            warnings.warn("Maximum is deprecated since v0.4.0, using high instead.", category=DeprecationWarning)
+            warnings.warn(
+                "Maximum is deprecated since v0.4.0, using high instead.",
+                category=DeprecationWarning,
+            )
         if "minimum" in kwargs:
             if low is not None:
                 raise TypeError(self.CONFLICTING_KWARGS.format("low", "minimum"))
             low = kwargs.pop("minimum")
-            warnings.warn("Minimum is deprecated since v0.4.0, using low instead.", category=DeprecationWarning)
+            warnings.warn(
+                "Minimum is deprecated since v0.4.0, using low instead.",
+                category=DeprecationWarning,
+            )
         domain = kwargs.pop("domain", "continuous")
         if len(kwargs):
             raise TypeError(f"Got unrecognised kwargs {tuple(kwargs.keys())}.")


### PR DESCRIPTION
This PR updates the docstrings for the `MultiSyncCollector` and `MultiaSyncCollector. It does several things:
- Add a note that code should be run inside a `if __name__ == "__main__":` block.
- Updated the examples and fixes some errors, including:
  - The gymenv already has a stepcounter, so removed it.
  - `devices` and `storing_devices` kwargs don't exist - it needs to be `device` and `storing_device`.
  - Added `cat_results="stack"` to follow future behaviour.
- The collector wasn't actually imported in the example, so I added that too - it's now self-contained.
- The current `main` branch also does not pass pre-commit, which is why `tensor_specs.py` is changed too.

I'm currently building the docs to see if everything looks good, but it's taking *very* long. Any advice there?