### PR TITLE
[Doc] Fix documentation mismatch for default argument

### DIFF
--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -802,7 +802,7 @@ class DiscreteSACLoss(LossModule):
             :class:`torchrl.data.BinaryDiscreteTensorSpec` or :class:`torchrl.data.DiscreteTensorSpec`).
         num_actions (int, optional): number of actions in the action space.
             To be provided if target_entropy is set to "auto".
-        num_qvalue_nets (int, optional): Number of Q-value networks to be trained. Default is 10.
+        num_qvalue_nets (int, optional): Number of Q-value networks to be trained. Default is 2.
         loss_function (str, optional): loss function to be used for the Q-value. Can be one of `"smooth_l1"`, "l2",
             "l1", Default is "smooth_l1".
         alpha_init (float, optional): initial entropy multiplier.


### PR DESCRIPTION
## Description

This fixes a mismatch in the documentation of the default value of the `num_qvalue_nets` argument in `DiscreteSACLoss`. The documentation said that default is 10, but in reality it is 2.

## Motivation and Context

This is misleading.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:
- [x] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
