### PR TITLE
Fix MLFlow logger

### DIFF
--- a/torchrl/record/loggers/mlflow.py
+++ b/torchrl/record/loggers/mlflow.py
@@ -54,7 +54,13 @@ class MLFlowLogger(Logger):
         """
         if not _has_mlflow:
             raise ImportError("MLFlow is not installed")
-        self.id = mlflow.create_experiment(**self._mlflow_kwargs)
+
+        # Only create experiment if it doesnt exist
+        experiment = mlflow.get_experiment_by_name(self._mlflow_kwargs["name"])
+        if experiment is None:
+            self.id = mlflow.create_experiment(**self._mlflow_kwargs)
+        else:
+            self.id = experiment.experiment_id
         return mlflow.start_run(experiment_id=self.id)
 
     def log_scalar(self, name: str, value: float, step: Optional[int] = None) -> None:


### PR DESCRIPTION
Currently, the MLFlow logger always tries to create a new experiment by calling `create_experiment`. If the experiment name already exists, this throws an error - so in practice running your script for the second time will crash the run. Additionally, MLFlow considers an `experiment` as a collection of `run`s, so we don't want to create a new experiment for each run. 

This PR modifies this logic by first checking if an experiment exists, creating one if necessary, and otherwise just retrieves the experiment ID.

Additionally, the MLFlow runs should be closed using `mlflow.end_run()` when it's not called as a context manager (as is the case for us). Do we want to add a `shutdown` method to the `Logger` base class to handle that? I can do that in this PR or in another.