### PR TITLE
[BugFix] Allow zero alpha value for PrioritizedSampler

### DIFF
--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -896,7 +896,7 @@ class TestLazyStorages:
 @pytest.mark.parametrize("contiguous", [True, False])
 @pytest.mark.parametrize("device", get_default_devices())
 @pytest.mark.parametrize("alpha", [0.0, 0.7])
-def test_ptdrb(priority_key, contiguous, alpha,  device):
+def test_ptdrb(priority_key, contiguous, alpha, device):
     torch.manual_seed(0)
     np.random.seed(0)
     rb = TensorDictReplayBuffer(
@@ -934,6 +934,11 @@ def test_ptdrb(priority_key, contiguous, alpha,  device):
     assert s.batch_size == torch.Size([5])
     assert (td2[s.get("_idx").squeeze()].get("a") == s.get("a")).all()
     assert_allclose_td(td2[s.get("_idx").squeeze()].select("a"), s.select("a"))
+
+    if (
+        alpha == 0.0
+    ):  # when alpha is 0.0, sampling is uniform, so no need to check priority sampling
+        return
 
     # test strong update
     # get all indices that match first item

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -895,11 +895,12 @@ class TestLazyStorages:
 @pytest.mark.parametrize("priority_key", ["pk", "td_error"])
 @pytest.mark.parametrize("contiguous", [True, False])
 @pytest.mark.parametrize("device", get_default_devices())
-def test_ptdrb(priority_key, contiguous, device):
+@pytest.mark.parametrize("alpha", [0.0, 0.7])
+def test_ptdrb(priority_key, contiguous, alpha,  device):
     torch.manual_seed(0)
     np.random.seed(0)
     rb = TensorDictReplayBuffer(
-        sampler=samplers.PrioritizedSampler(5, alpha=0.7, beta=0.9),
+        sampler=samplers.PrioritizedSampler(5, alpha=alpha, beta=0.9),
         priority_key=priority_key,
         batch_size=5,
     )

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -333,9 +333,9 @@ class PrioritizedSampler(Sampler):
         dtype: torch.dtype = torch.float,
         reduction: str = "max",
     ) -> None:
-        if alpha <= 0:
+        if alpha < 0:
             raise ValueError(
-                f"alpha must be strictly greater than 0, got alpha={alpha}"
+                f"alpha must be greater or equal than 0, got alpha={alpha}"
             )
         if beta < 0:
             raise ValueError(f"beta must be greater or equal to 0, got beta={beta}")


### PR DESCRIPTION
## Description

The PrioritizedSampler docstring says that the input parameter alpha can be set to 0.0 to obtain uniform sampling. In practice though, a ValueError is raised when alpha = 0.0. This PR changes this to allow for alpha to be 0.0.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
