### PR TITLE
Revert "[BugFix] buffer `__iter__` for samplers without replacement + prefetch"

### DIFF
--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -633,9 +633,7 @@ class ReplayBuffer:
             ret = self._sample(batch_size)
         else:
             with self._futures_lock:
-                while (
-                    len(self._prefetch_queue) < self._prefetch_cap
-                ) and not self._sampler.ran_out:
+                while len(self._prefetch_queue) < self._prefetch_cap:
                     fut = self._prefetch_executor.submit(self._sample, batch_size)
                     self._prefetch_queue.append(fut)
                 ret = self._prefetch_queue.popleft().result()
@@ -716,9 +714,7 @@ class ReplayBuffer:
                 "Cannot iterate over the replay buffer. "
                 "Batch_size was not specified during construction of the replay buffer."
             )
-        while not self._sampler.ran_out or (
-            self._prefetch and len(self._prefetch_queue)
-        ):
+        while not self._sampler.ran_out:
             yield self.sample()
 
     def __getstate__(self) -> Dict[str, Any]:


### PR DESCRIPTION
Reverts pytorch/rl#2178

@JulianKu I'm reverting this because it breaks the offline IQL example 

To test this:
```
python sota-implementations/iql/iql_offline.py \
  optim.gradient_steps=55 \
  logger.backend=
```
