### PR TITLE
[BugFix] buffer __iter__ for samplers without replacement + prefetch

### DIFF
--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -718,9 +718,7 @@ class ReplayBuffer:
                 "Cannot iterate over the replay buffer. "
                 "Batch_size was not specified during construction of the replay buffer."
             )
-        while not self._sampler.ran_out or (
-            self._prefetch and len(self._prefetch_queue)
-        ):
+        while not self._sampler.ran_out:
             yield self.sample()
 
     def __getstate__(self) -> Dict[str, Any]:

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -634,7 +634,8 @@ class ReplayBuffer:
         else:
             with self._futures_lock:
                 while (
-                    len(self._prefetch_queue) < self._prefetch_cap
+                    len(self._prefetch_queue)
+                    < min(self._sampler._remaining_batches, self._prefetch_cap)
                 ) and not self._sampler.ran_out:
                     fut = self._prefetch_executor.submit(self._sample, batch_size)
                     self._prefetch_queue.append(fut)

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -718,7 +718,9 @@ class ReplayBuffer:
                 "Cannot iterate over the replay buffer. "
                 "Batch_size was not specified during construction of the replay buffer."
             )
-        while not self._sampler.ran_out:
+        while not self._sampler.ran_out or (
+            self._prefetch and len(self._prefetch_queue)
+        ):
             yield self.sample()
 
     def __getstate__(self) -> Dict[str, Any]:

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -633,7 +633,9 @@ class ReplayBuffer:
             ret = self._sample(batch_size)
         else:
             with self._futures_lock:
-                while len(self._prefetch_queue) < self._prefetch_cap:
+                while (
+                    len(self._prefetch_queue) < self._prefetch_cap
+                ) and not self._sampler.ran_out:
                     fut = self._prefetch_executor.submit(self._sample, batch_size)
                     self._prefetch_queue.append(fut)
                 ret = self._prefetch_queue.popleft().result()
@@ -714,7 +716,9 @@ class ReplayBuffer:
                 "Cannot iterate over the replay buffer. "
                 "Batch_size was not specified during construction of the replay buffer."
             )
-        while not self._sampler.ran_out:
+        while not self._sampler.ran_out or (
+            self._prefetch and len(self._prefetch_queue)
+        ):
             yield self.sample()
 
     def __getstate__(self) -> Dict[str, Any]:


### PR DESCRIPTION
Reopen #2178 (see #2182)

## Description

Adds loop termination condition in replay buffer `__iter__` method for yielding samples in prefetch queue and another condition in its `sample` method for only adding new jobs to the prefetch queue if the sampler has not yet run out.

## Motivation and Context

For replay buffers with prefetch enabled while having a sampler without replacement (that can "run out"), the buffer's `__iter__` method will not yield all samples. This is because its while loop terminates on sampler `ran_out` which is set as soon as a prefetch job is executed that triggers running out. However, there might still be prefetch jobs in the queue left that could yield samples, therefore their samples are simply skipped.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
