### PR TITLE
[BugFix] Make `_reset` follow `done` shape

### DIFF
--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -1751,9 +1751,9 @@ class MultiKeyCountingEnv(EnvBase):
         if tensordict is not None:
             _reset = tensordict.get("_reset", None)
             if _reset is not None:
-                self.count[_reset] = self.start_val
-                self.count_nested_1[_reset] = self.start_val
-                self.count_nested_2[_reset] = self.start_val
+                self.count[_reset.squeeze(-1)] = self.start_val
+                self.count_nested_1[_reset.squeeze(-1)] = self.start_val
+                self.count_nested_2[_reset.squeeze(-1)] = self.start_val
             else:
                 reset_all = True
 

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -3518,6 +3518,32 @@ class TestPettingZoo:
         vec_env = maybe_fork_ParallelEnv(2, create_env_fn=env_fun)
         vec_env.rollout(100, break_when_any_done=False)
 
+    def test_reset_parallel_env(self, maybe_fork_ParallelEnv):
+        def base_env_fn():
+            return PettingZooEnv(
+                task="multiwalker_v9",
+                parallel=True,
+                seed=0,
+                n_walkers=3,
+                max_cycles=1000,
+            )
+
+        collector = SyncDataCollector(
+            lambda: maybe_fork_ParallelEnv(
+                num_workers=2,
+                create_env_fn=base_env_fn,
+                device="cpu",
+            ),
+            policy=None,
+            frames_per_batch=100,
+            max_frames_per_traj=50,
+            total_frames=200,
+            reset_at_each_iter=False,
+        )
+        for _ in collector:
+            pass
+        collector.shutdown()
+
     @pytest.mark.parametrize("task", ["knights_archers_zombies_v10", "pistonball_v6"])
     @pytest.mark.parametrize("parallel", [True, False])
     def test_collector(self, task, parallel):

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -1129,10 +1129,6 @@ def _terminated_or_truncated(
 
         if aggregate is not None:
             if key is not None:
-                if aggregate.ndim > data.ndim:
-                    # accounts for trailing singleton dim in done.
-                    # _reset is always expanded on the right if needed so this can only be useful
-                    aggregate = aggregate.squeeze(-1)
                 data.set(key, aggregate)
                 list_of_keys.append(curr_done_key + (key,))
             any_eot = any_eot | aggregate.any()


### PR DESCRIPTION
Fixes #2179
Replaces #2181

By enforcing resets to have the same shape as dones 