### PR TITLE
[BugFix] Global import of optional library

### DIFF
--- a/torchrl/envs/libs/dm_control.py
+++ b/torchrl/envs/libs/dm_control.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, Optional, Tuple, Union
 
 import numpy as np
 import torch
-from dm_env import StepType
 
 from torchrl._utils import logger as torchrl_logger, VERBOSE
 
@@ -318,6 +317,8 @@ class DMControlWrapper(GymLikeEnv):
     def _output_transform(
         self, timestep_tuple: Tuple["TimeStep"]  # noqa: F821
     ) -> Tuple[np.ndarray, float, bool, bool, dict]:
+        from dm_env import StepType
+
         if type(timestep_tuple) is not tuple:
             timestep_tuple = (timestep_tuple,)
         reward = timestep_tuple[0].reward


### PR DESCRIPTION
Can we also have a test pipeline of torchrl that does not install any optional dependency?