### PR TITLE
[Performance, Refactor] Faster loading of uninitialized storages

### DIFF
--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -3182,6 +3182,9 @@ class TestCheckpointers:
             if frames_per_batch > 100:
                 assert rb._storage._is_full
                 assert len(rb) == 102
+                # Checks that when writing to the buffer with a batch greater than the total
+                # size, we get the last step written properly.
+                assert (rb[:]["next", "step_count"][:, -1] != 0).any()
             rb.dumps(tmpdir)
             rb.dumps(tmpdir)
             rb_test.loads(tmpdir)

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -3123,7 +3123,7 @@ class TestCheckpointers:
         )
         rb = ReplayBuffer(storage=storage_type(100))
         rb_test = ReplayBuffer(storage=storage_type(100))
-        if torch.__version__ < "2.4.0" and checkpointer in (
+        if torch.__version__ < "2.4.0.dev" and checkpointer in (
             H5StorageCheckpointer,
             NestedStorageCheckpointer,
         ):
@@ -3152,7 +3152,7 @@ class TestCheckpointers:
         )
         rb = ReplayBuffer(storage=storage_type(100, ndim=2))
         rb_test = ReplayBuffer(storage=storage_type(100, ndim=2))
-        if torch.__version__ < "2.4.0" and checkpointer in (
+        if torch.__version__ < "2.4.0.dev" and checkpointer in (
             H5StorageCheckpointer,
             NestedStorageCheckpointer,
         ):

--- a/torchrl/data/replay_buffers/utils.py
+++ b/torchrl/data/replay_buffers/utils.py
@@ -461,7 +461,7 @@ class Flat2TED:
             # iterate over data and allocate
             if out is None:
                 out = TensorDict(batch_size=_storage_shape)
-                for i in range(out.ndim):
+                for i in range(1, out.ndim):
                     if i >= 2:
                         # FLattening the lazy stack will make the data unavailable - we need to find a way to make this
                         # possible.
@@ -469,7 +469,8 @@ class Flat2TED:
                             "Checkpointing an uninitialized buffer with more than 2 dimensions is currently not supported. "
                             "Please file an issue on GitHub to ask for this feature!"
                         )
-                    out = LazyStackedTensorDict(*out.unbind(i), stack_dim=i)
+                    out_list = [out._get_sub_tensordict((slice(None),)*i + (j,)) for j in range(out.shape[i])]
+                    out = LazyStackedTensorDict(*out_list, stack_dim=i)
 
             # Create a function that reads slices of the input data
             with out.flatten(1, -1) if out.ndim > 2 else contextlib.nullcontext(

--- a/torchrl/data/replay_buffers/utils.py
+++ b/torchrl/data/replay_buffers/utils.py
@@ -460,6 +460,16 @@ class Flat2TED:
         if _storage_shape is not None and len(_storage_shape) > 1:
             # iterate over data and allocate
             if out is None:
+                # out = TensorDict(batch_size=_storage_shape)
+                # for i in range(out.ndim):
+                #     if i >= 2:
+                #         # FLattening the lazy stack will make the data unavailable - we need to find a way to make this
+                #         # possible.
+                #         raise RuntimeError(
+                #             "Checkpointing an uninitialized buffer with more than 2 dimensions is currently not supported. "
+                #             "Please file an issue on GitHub to ask for this feature!"
+                #         )
+                #     out = LazyStackedTensorDict(*out.unbind(i), stack_dim=i)
                 out = TensorDict(batch_size=_storage_shape)
                 for i in range(1, out.ndim):
                     if i >= 2:

--- a/torchrl/data/replay_buffers/utils.py
+++ b/torchrl/data/replay_buffers/utils.py
@@ -469,7 +469,10 @@ class Flat2TED:
                             "Checkpointing an uninitialized buffer with more than 2 dimensions is currently not supported. "
                             "Please file an issue on GitHub to ask for this feature!"
                         )
-                    out_list = [out._get_sub_tensordict((slice(None),)*i + (j,)) for j in range(out.shape[i])]
+                    out_list = [
+                        out._get_sub_tensordict((slice(None),) * i + (j,))
+                        for j in range(out.shape[i])
+                    ]
                     out = LazyStackedTensorDict(*out_list, stack_dim=i)
 
             # Create a function that reads slices of the input data


### PR DESCRIPTION
cc @teopir 

cc @shagunsodhani this is a good example of prealloc with tensordict. We were using a lot of lazy stacks and stacking at the last minute. Using a preallocated TD instead (create an empty td -> get a bunch of views of that td -> write on the first view, and all views get instantiated instantaneously) made the whole thing 20 - 1000x faster!