### PR TITLE
[Feature] assinging values to RB storage 

### DIFF
--- a/docs/source/reference/data.rst
+++ b/docs/source/reference/data.rst
@@ -56,6 +56,12 @@ Here are a few examples, starting with the generic :class:`~torchrl.data.replay_
     >>> rb.add("a string!") # first element will be a string
     >>> rb.extend([30, None])  # element [1] is an int, [2] is None
 
+The main entry points to write onto a buffer are :meth:`~torchrl.data.ReplayBuffer.add` and
+:meth:`~torchrl.data.ReplayBuffer.extend`.
+One can also use :meth:`~torchrl.data.ReplayBuffer.__setitem__`, in which case the data is written
+where indicated without updating the length or cursor of the buffer. This can be useful when sampling
+items from the buffer and them updating their values in-place afterwards.
+
 Using a :class:`~torchrl.data.replay_buffers.TensorStorage` we tell our RB that
 we want the storage to be contiguous, which is by far more efficient but also
 more restrictive:

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -824,6 +824,68 @@ class TestStorages:
         assert (rb[30:40] == 0).all()
         assert len(rb) == 100
 
+    @pytest.mark.parametrize(
+        "storage_type,collate_fn",
+        [
+            (LazyTensorStorage, None),
+            (LazyMemmapStorage, None),
+            (ListStorage, torch.stack),
+        ],
+    )
+    def test_storage_inplace_writing_transform(self, storage_type, collate_fn):
+        rb = ReplayBuffer(storage=storage_type(102), collate_fn=collate_fn)
+        rb.append_transform(lambda x: x + 1, invert=True)
+        rb.append_transform(lambda x: x + 1)
+        data = TensorDict(
+            {"a": torch.arange(100), ("b", "c"): torch.arange(100)}, [100]
+        )
+        rb.extend(data)
+        assert len(rb) == 100
+        rb[3:4] = TensorDict(
+            {"a": torch.tensor([0]), ("b", "c"): torch.tensor([0])}, [1]
+        )
+        assert (rb[3:4] == 2).all(), rb[3:4]["a"]
+        assert len(rb) == 100
+        assert rb._writer._cursor == 100
+        rb[10:20] = TensorDict(
+            {"a": torch.tensor([0] * 10), ("b", "c"): torch.tensor([0] * 10)}, [10]
+        )
+        assert (rb[10:20] == 2).all()
+        assert len(rb) == 100
+        assert rb._writer._cursor == 100
+        rb[torch.arange(30, 40)] = TensorDict(
+            {"a": torch.tensor([0] * 10), ("b", "c"): torch.tensor([0] * 10)}, [10]
+        )
+        assert (rb[30:40] == 2).all()
+        assert len(rb) == 100
+
+    @pytest.mark.parametrize(
+        "storage_type,collate_fn",
+        [
+            (LazyTensorStorage, None),
+            # (LazyMemmapStorage, None),
+            (ListStorage, TensorDict.maybe_dense_stack),
+        ],
+    )
+    def test_storage_inplace_writing_newkey(self, storage_type, collate_fn):
+        rb = ReplayBuffer(storage=storage_type(102), collate_fn=collate_fn)
+        data = TensorDict(
+            {"a": torch.arange(100), ("b", "c"): torch.arange(100)}, [100]
+        )
+        rb.extend(data)
+        assert len(rb) == 100
+        rb[3:4] = TensorDict(
+            {"a": torch.tensor([0]), ("b", "c"): torch.tensor([0]), "d": torch.ones(1)},
+            [1],
+        )
+        assert "d" in rb[3]
+        assert "d" in rb[3:4]
+        if storage_type is not ListStorage:
+            assert "d" in rb[3:5]
+        else:
+            # a lazy stack doesn't show exclusive fields
+            assert "d" not in rb[3:5]
+
     @pytest.mark.parametrize("storage_type", [LazyTensorStorage, LazyMemmapStorage])
     def test_storage_inplace_writing_ndim(self, storage_type):
         rb = ReplayBuffer(storage=storage_type(102, ndim=2))

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -791,6 +791,74 @@ class TestStorages:
         assert len(rb) == 1
         assert rb[:].shape == torch.Size([1, 2])
 
+    @pytest.mark.parametrize(
+        "storage_type,collate_fn",
+        [
+            (LazyTensorStorage, None),
+            (LazyMemmapStorage, None),
+            (ListStorage, torch.stack),
+        ],
+    )
+    def test_storage_inplace_writing(self, storage_type, collate_fn):
+        rb = ReplayBuffer(storage=storage_type(102), collate_fn=collate_fn)
+        data = TensorDict(
+            {"a": torch.arange(100), ("b", "c"): torch.arange(100)}, [100]
+        )
+        rb.extend(data)
+        assert len(rb) == 100
+        rb[3:4] = TensorDict(
+            {"a": torch.tensor([0]), ("b", "c"): torch.tensor([0])}, [1]
+        )
+        assert (rb[3:4] == 0).all()
+        assert len(rb) == 100
+        rb._writer._cursor == 100
+        rb[10:20] = TensorDict(
+            {"a": torch.tensor([0] * 10), ("b", "c"): torch.tensor([0] * 10)}, [10]
+        )
+        assert (rb[10:20] == 0).all()
+        assert len(rb) == 100
+        rb._writer._cursor == 100
+        rb[torch.arange(30, 40)] = TensorDict(
+            {"a": torch.tensor([0] * 10), ("b", "c"): torch.tensor([0] * 10)}, [10]
+        )
+        assert (rb[30:40] == 0).all()
+        assert len(rb) == 100
+
+    @pytest.mark.parametrize("storage_type", [LazyTensorStorage, LazyMemmapStorage])
+    def test_storage_inplace_writing_ndim(self, storage_type):
+        rb = ReplayBuffer(storage=storage_type(102, ndim=2))
+        data = TensorDict(
+            {
+                "a": torch.arange(50).expand(2, 50),
+                ("b", "c"): torch.arange(50).expand(2, 50),
+            },
+            [2, 50],
+        )
+        rb.extend(data)
+        assert len(rb) == 100
+        rb[0, 3:4] = TensorDict(
+            {"a": torch.tensor([0]), ("b", "c"): torch.tensor([0])}, [1]
+        )
+        assert (rb[0, 3:4] == 0).all()
+        assert (rb[1, 3:4] != 0).all()
+        rb._writer._cursor == 50
+        rb[1, 5:6] = TensorDict(
+            {"a": torch.tensor([0]), ("b", "c"): torch.tensor([0])}, [1]
+        )
+        assert (rb[1, 5:6] == 0).all()
+        rb._writer._cursor == 50
+        rb[:, 7:8] = TensorDict(
+            {"a": torch.tensor([0]), ("b", "c"): torch.tensor([0])}, [1]
+        ).expand(2, 1)
+        assert (rb[:, 7:8] == 0).all()
+        rb._writer._cursor == 50
+        # test broadcasting
+        rb[:, 10:20] = TensorDict(
+            {"a": torch.tensor([0] * 10), ("b", "c"): torch.tensor([0] * 10)}, [10]
+        )
+        assert (rb[:, 10:20] == 0).all()
+        assert len(rb) == 100
+
 
 @pytest.mark.parametrize("max_size", [1000])
 @pytest.mark.parametrize("shape", [[3, 4]])

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -811,13 +811,13 @@ class TestStorages:
         )
         assert (rb[3:4] == 0).all()
         assert len(rb) == 100
-        rb._writer._cursor == 100
+        assert rb._writer._cursor == 100
         rb[10:20] = TensorDict(
             {"a": torch.tensor([0] * 10), ("b", "c"): torch.tensor([0] * 10)}, [10]
         )
         assert (rb[10:20] == 0).all()
         assert len(rb) == 100
-        rb._writer._cursor == 100
+        assert rb._writer._cursor == 100
         rb[torch.arange(30, 40)] = TensorDict(
             {"a": torch.tensor([0] * 10), ("b", "c"): torch.tensor([0] * 10)}, [10]
         )
@@ -841,17 +841,17 @@ class TestStorages:
         )
         assert (rb[0, 3:4] == 0).all()
         assert (rb[1, 3:4] != 0).all()
-        rb._writer._cursor == 50
+        assert rb._writer._cursor == 50
         rb[1, 5:6] = TensorDict(
             {"a": torch.tensor([0]), ("b", "c"): torch.tensor([0])}, [1]
         )
         assert (rb[1, 5:6] == 0).all()
-        rb._writer._cursor == 50
+        assert rb._writer._cursor == 50
         rb[:, 7:8] = TensorDict(
             {"a": torch.tensor([0]), ("b", "c"): torch.tensor([0])}, [1]
         ).expand(2, 1)
         assert (rb[:, 7:8] == 0).all()
-        rb._writer._cursor == 50
+        assert rb._writer._cursor == 50
         # test broadcasting
         rb[:, 10:20] = TensorDict(
             {"a": torch.tensor([0] * 10), ("b", "c"): torch.tensor([0] * 10)}, [10]

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -956,7 +956,7 @@ class TestCatFrames(TransformBase):
         td = TensorDict(dict(zip(keys, key_tensors)), batch_size, device=device)
         if dim > 0:
             with pytest.raises(
-                ValueError, match="dim must be < 0 to accomodate for tensordict"
+                ValueError, match="dim must be < 0 to accommodate for tensordict"
             ):
                 cat_frames = CatFrames(N=N, in_keys=keys, dim=dim)
             return

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -383,6 +383,27 @@ class ReplayBuffer:
 
         return data
 
+    def __setitem__(self, index, value) -> None:
+        if isinstance(index, str) or (isinstance(index, tuple) and unravel_key(index)):
+            self[:][index] = value
+            return
+        if isinstance(index, tuple):
+            if len(index) == 1:
+                self[index[0]] = value
+            else:
+                self[:][index] = value
+            return
+        index = _to_numpy(index)
+
+        if self.dim_extend > 0:
+            index = (slice(None),) * self.dim_extend + (index,)
+            with self._replay_lock:
+                self._storage[index] = self._transpose(value)
+        else:
+            with self._replay_lock:
+                self._storage[index] = value
+        return
+
     def state_dict(self) -> Dict[str, Any]:
         return {
             "_storage": self._storage.state_dict(),

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -395,6 +395,9 @@ class ReplayBuffer:
             return
         index = _to_numpy(index)
 
+        if self._transform is not None and len(self._transform):
+            value = self._transform.inv(value)
+
         if self.dim_extend > 0:
             index = (slice(None),) * self.dim_extend + (index,)
             with self._replay_lock:

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -116,6 +116,7 @@ class Storage:
         return self.get(item)
 
     def __setitem__(self, index, value):
+        """Sets values in the storage without updating the cursor or length."""
         return self.set(index, value, set_cursor=False)
 
     def __iter__(self):
@@ -719,7 +720,7 @@ class TensorStorage(Storage):
             if len(cursor) > self._len_along_dim0:
                 warnings.warn(
                     "A cursor of length superior to the storage capacity was provided. "
-                    "To accomodate for this, the cursor will be truncated to its last "
+                    "To accommodate for this, the cursor will be truncated to its last "
                     "element such that its length matched the length of the storage. "
                     "This may **not** be the optimal behaviour for your application! "
                     "Make sure that the storage capacity is big enough to support the "

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -159,7 +159,7 @@ class RoundRobinWriter(Writer):
         )
         # Replicate index requires the shape of the storage to be known
         # Other than that, a "flat" (1d) index is ok to write the data
-        self._storage[_cursor] = data
+        self._storage.set(_cursor, data)
         index = self._replicate_index(index)
         for ent in self._storage._attached_entities:
             ent.mark_update(index)
@@ -187,7 +187,7 @@ class RoundRobinWriter(Writer):
         self._cursor = (batch_size + cur_size) % max_size_along0
         # Replicate index requires the shape of the storage to be known
         # Other than that, a "flat" (1d) index is ok to write the data
-        self._storage[index] = data
+        self._storage.set(index, data)
         index = self._replicate_index(index)
         for ent in self._storage._attached_entities:
             ent.mark_update(index)
@@ -250,7 +250,7 @@ class TensorDictRoundRobinWriter(RoundRobinWriter):
                     torch.as_tensor(index, device=data.device, dtype=torch.long), data
                 ),
             )
-        self._storage[index] = data
+        self._storage.set(index, data)
         index = self._replicate_index(index)
         for ent in self._storage._attached_entities:
             ent.mark_update(index)
@@ -279,7 +279,7 @@ class TensorDictRoundRobinWriter(RoundRobinWriter):
             )
         # Replicate index requires the shape of the storage to be known
         # Other than that, a "flat" (1d) index is ok to write the data
-        self._storage[index] = data
+        self._storage.set(index, data)
         index = self._replicate_index(index)
         for ent in self._storage._attached_entities:
             ent.mark_update(index)
@@ -465,7 +465,7 @@ class TensorDictMaxValueWriter(Writer):
             data.set("index", index)
             # Replicate index requires the shape of the storage to be known
             # Other than that, a "flat" (1d) index is ok to write the data
-            self._storage[index] = data
+            self._storage.set(index, data)
             index = self._replicate_index(index)
             for ent in self._storage._attached_entities:
                 ent.mark_update(index)

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -503,7 +503,7 @@ class BatchedEnvBase(EnvBase):
                 if share_individual_td and self.share_individual_td is False:
                     raise ValueError(
                         "share_individual_td=False was provided but share_individual_td must "
-                        "be True to accomodate non-stackable tensors."
+                        "be True to accommodate non-stackable tensors."
                     )
                 self.share_individual_td = share_individual_td
             _use_buffers = all(

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -2004,12 +2004,12 @@ class FlattenObservation(ObservationTransform):
         super().__init__(in_keys=in_keys, out_keys=out_keys)
         if not allow_positive_dim and first_dim >= 0:
             raise ValueError(
-                "first_dim should be smaller than 0 to accomodate for "
+                "first_dim should be smaller than 0 to accommodate for "
                 "envs of different batch_sizes."
             )
         if not allow_positive_dim and last_dim >= 0:
             raise ValueError(
-                "last_dim should be smaller than 0 to accomodate for "
+                "last_dim should be smaller than 0 to accommodate for "
                 "envs of different batch_sizes."
             )
         self._first_dim = first_dim
@@ -2108,8 +2108,8 @@ class UnsqueezeTransform(Transform):
         self.allow_positive_dim = allow_positive_dim
         if unsqueeze_dim >= 0 and not allow_positive_dim:
             raise RuntimeError(
-                "unsqueeze_dim should be smaller than 0 to accomodate for "
-                "envs of different batch_sizes. Turn allow_positive_dim to accomodate "
+                "unsqueeze_dim should be smaller than 0 to accommodate for "
+                "envs of different batch_sizes. Turn allow_positive_dim to accommodate "
                 "for positive unsqueeze_dim."
             )
         self._unsqueeze_dim = unsqueeze_dim

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -2802,7 +2802,7 @@ class CatFrames(ObservationTransform):
 
     inplace = False
     _CAT_DIM_ERR = (
-        "dim must be < 0 to accomodate for tensordict of "
+        "dim must be < 0 to accommodate for tensordict of "
         "different batch-sizes (since negative dims are batch invariant)."
     )
     ACCEPTED_PADDING = {"same", "constant", "zeros"}


### PR DESCRIPTION
This PR enables assigning values to a RB.

This is slightly bc-breaking: 
Previously doing `storage[index] = foo` was exactly equivalent to `storage.set(index, foo)`. Now only the second will update the cursor position. This lets us assigning values without telling the buffer that we have moved the cursor.

TODO:
- [x] Doc the feature
- [x] test transforms (forward/inverse)

cc @wertyuilife2
