### PR TITLE
[BugFix] Fix slice sampler end computation at the cursor place

### DIFF
--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -2609,9 +2609,10 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
             for key in self.done_keys:
                 if _ends_with(key, "truncated"):
                     val = out_td.get(("next", key))
+                    done = out_td.get(("next", _replace_last(key, "done")))
                     val[(slice(None),) * (out_td.ndim - 1) + (-1,)] = True
                     out_td.set(("next", key), val)
-                    out_td.set(("next", _replace_last(key, "done")), val)
+                    out_td.set(("next", _replace_last(key, "done")), val | done)
                     found_truncated = True
             if not found_truncated:
                 raise RuntimeError(

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -3048,7 +3048,7 @@ class CatFrames(ObservationTransform):
             reset_unfold_list = [torch.zeros_like(reset_unfold_slice)]
             for r in reversed(reset_unfold.unbind(-1)):
                 reset_unfold_list.append(r | reset_unfold_list[-1])
-                reset_unfold_slice = reset_unfold_list[-1]
+                # reset_unfold_slice = reset_unfold_list[-1]
             reset_unfold = torch.stack(list(reversed(reset_unfold_list))[1:], -1)
             reset = reset[prefix + (slice(self.N - 1, None),)]
             reset[prefix + (0,)] = 1


### PR DESCRIPTION
Enables this code to run without error in all cases:
```
rb = ReplayBuffer(
storage=LazyTensorStorage(100, ndim=2), 
sampler=SliceSampler(strict_length=True, num_slices=1), batch_size=8, 
transform=Compose(
    UnsqueezeTransform(-2, in_keys=["step_count"], out_keys=["obs_cat0"]),
    CatFrames(N=4, dim=-2, in_keys=["obs_cat0"], done_key="done"),
    UnsqueezeTransform(-2, in_keys=["step_count"], out_keys=["obs_cat1"]),
    CatFrames(N=5, dim=-2, in_keys=["obs_cat1"], done_key="done")
)
)
env = SerialEnv(2, lambda: GymEnv("CartPole-v1", device=None).append_transform(StepCounter()))
r = env.rollout(120, break_when_any_done=False)
rb.extend(r)
print(rb._storage._last_cursor)
s, info = rb.sample(return_info=True)
assert (s["obs_cat0"].squeeze()[4:]!=0).all(), info
```