### PR TITLE
[BugFix] Fix sliced PRB when only traj is provided

### DIFF
--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -1806,6 +1806,7 @@ class PrioritizedSliceSampler(SliceSampler, PrioritizedSampler):
         )
 
     def _preceding_stop_idx(self, storage, lengths, seq_length):
+        print('lengths', lengths)
         preceding_stop_idx = self._cache.get("preceding_stop_idx")
         if preceding_stop_idx is not None:
             return preceding_stop_idx
@@ -1841,6 +1842,7 @@ class PrioritizedSliceSampler(SliceSampler, PrioritizedSampler):
         seq_length, num_slices = self._adjusted_batch_size(batch_size)
 
         preceding_stop_idx = self._preceding_stop_idx(storage, lengths, seq_length)
+        preceding_stop_idx = (preceding_stop_idx + start_idx[0, 0]) % storage._len_along_dim0
         if storage.ndim > 1:
             # we need to convert indices of the permuted, flatten storage to indices in a flatten storage (not permuted)
             # This is because the lengths come as they would for a permuted storage

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -1862,12 +1862,14 @@ class PrioritizedSliceSampler(SliceSampler, PrioritizedSampler):
             )
 
         # force to not sample index at the end of a trajectory
+        vals = torch.tensor(self._sum_tree[preceding_stop_idx.cpu().numpy()])
         self._sum_tree[preceding_stop_idx.cpu().numpy()] = 0.0
         # and no need to update self._min_tree
 
         starts, info = PrioritizedSampler.sample(
             self, storage=storage, batch_size=batch_size // seq_length
         )
+        self._sum_tree[preceding_stop_idx.cpu().numpy()] = vals
         # We must truncate the seq_length if (1) not strict length or (2) span[1]
         if self.span[1] or not self.strict_length:
             if not isinstance(starts, torch.Tensor):

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -1068,7 +1068,9 @@ class SliceSampler(Sampler):
                             "Could not get a tensordict out of the storage, which is required for SliceSampler to compute the trajectories."
                         )
                 vals = self._find_start_stop_traj(
-                    trajectory=trajectory, at_capacity=storage._is_full
+                    trajectory=trajectory,
+                    at_capacity=storage._is_full,
+                    cursor=getattr(storage, "_last_cursor", None),
                 )
                 if self.cache_values:
                     self._cache["stop-and-length"] = vals


### PR DESCRIPTION
As noted in #2208, we register the cursor when computing the start/stop signals based on the "done" signals, but we don't do so when trajectories are provided. This PR solves this/
