### PR TITLE
Switch maybe_dense_stack calls from TensorDict to LazyStackedTensorDict

### DIFF
--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -1081,7 +1081,7 @@ class SyncDataCollector(DataCollectorBase):
                                     out=self._final_rollout[..., : t + 1],
                                 )
                     else:
-                        result = TensorDict.maybe_dense_stack(tensordicts, dim=-1)
+                        result = LazyStackedTensorDict.maybe_dense_stack(tensordicts, dim=-1)
                         assert result.names[-1] == "time"
                     break
             else:
@@ -1104,7 +1104,7 @@ class SyncDataCollector(DataCollectorBase):
                             )
                             assert result.names[-1] == "time"
                 else:
-                    result = TensorDict.maybe_dense_stack(tensordicts, dim=-1)
+                    result = LazyStackedTensorDict.maybe_dense_stack(tensordicts, dim=-1)
                     result.refine_names(..., "time")
 
         return self._maybe_set_truncated(result)
@@ -2208,7 +2208,7 @@ class MultiSyncDataCollector(_MultiDataCollector):
 
             if cat_results == "stack":
                 stack = (
-                    torch.stack if self._use_buffers else TensorDict.maybe_dense_stack
+                    torch.stack if self._use_buffers else LazyStackedTensorDict.maybe_dense_stack
                 )
                 if same_device:
                     self.out_buffer = stack(list(buffers.values()), 0)


### PR DESCRIPTION
Bug in _use_buffers = False, in the case of non-contiguous tensors. Updated all calls to TensorDict.maybe_dense_stack(...) to LazyStackedTensorDict.maybe_dense_stack(...)

## Description

When using _use_buffers = False, the code invokes TensorDict.maybe_dense_stack instead of the LazyStackedTensorDict class, which is where the API is supported. This PR aims to fix this bug.
## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
