### PR TITLE
Fix "Run in Colab" and "Download Notebook" links in tutorials

### DIFF
--- a/docs/source/_static/js/theme.js
+++ b/docs/source/_static/js/theme.js
@@ -946,7 +946,7 @@ if (downloadNote.length >= 1) {
         tutorialUrlArray[0] = tutorialUrlArray[0] + "/sphinx-tutorials"
 
     var githubLink = "https://github.com/pytorch/rl/blob/main/" + tutorialUrlArray.join("/") + ".py",
-        notebookLink = $(".reference.download")[1].href,
+        notebookLink = $(".sphx-glr-download-jupyter").find(".download.reference")[0].href,
         notebookDownloadPath = notebookLink.split('_downloads')[1],
         colabLink = "https://colab.research.google.com/github/pytorch/rl/blob/gh-pages/main/_downloads" + notebookDownloadPath;
 

--- a/docs/source/_static/js/torchrl_theme.js
+++ b/docs/source/_static/js/torchrl_theme.js
@@ -945,7 +945,7 @@ if (downloadNote.length >= 1) {
     var tutorialUrlArray = $("#tutorial-type").text().split('/');
 
     var githubLink = "https://github.com/pytorch/rl/tree/tutorial_py_dup/sphinx-tutorials/" + tutorialUrlArray[tutorialUrlArray.length - 1] + ".py",
-        notebookLink = $(".reference.download")[1].href,
+        notebookLink = $(".sphx-glr-download-jupyter").find(".download.reference")[0].href,
         notebookDownloadPath = notebookLink.split('_downloads')[1],
         colabLink = "https://colab.research.google.com/github/pytorch/rl/blob/gh-pages/_downloads" + notebookDownloadPath;
 

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -61,7 +61,7 @@
 	  if (downloadNote.length >= 1) {
 	      var tutorialUrl = $("#tutorial-type").text();
 	      var githubLink = "https://github.com/pytorch/rl/blob/main/tutorials/sphinx-tutorials/"  + tutorialUrl + ".py",
-		  notebookLink = $(".reference.download")[1].href,
+		  notebookLink = $(".sphx-glr-download-jupyter").find(".download.reference")[0].href,
 		  notebookDownloadPath = notebookLink.split('_downloads')[1],
 		  colabLink = "https://colab.research.google.com/github/pytorch/rl/blob/gh-pages/main/_downloads" + notebookDownloadPath;
 


### PR DESCRIPTION
## Description

Fixes the links to run tutorials in Colab and to download notebooks.

## Motivation and Context

close #2134

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
