### PR TITLE
[CI] Pin transformers version to < 4.42.0 to make vmap happy

### DIFF
--- a/.github/unittest/linux_libs/scripts_rlhf/environment.yml
+++ b/.github/unittest/linux_libs/scripts_rlhf/environment.yml
@@ -17,5 +17,5 @@ dependencies:
     - pyyaml
     - scipy
     - hydra-core
-    - transformers
+    - transformers<4.42.0
     - datasets


### PR DESCRIPTION
With `transformers>=4.42.0` we get this error from calling vmap around the model:
```
  File "/home/vmoens/tensordict/tensordict/nn/common.py", line 1185, in forward
    tensors = self._call_module(tensors, **kwargs)
  File "/home/vmoens/tensordict/tensordict/nn/common.py", line 1141, in _call_module
    out = self.module(*tensors, **kwargs)
  File "/home/vmoens/.conda/envs/torchrl/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1566, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/vmoens/.conda/envs/torchrl/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1575, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/vmoens/.conda/envs/torchrl/lib/python3.10/site-packages/transformers/models/gpt2/modeling_gpt2.py", line 1144, in forward
    attention_mask = _prepare_4d_causal_attention_mask_for_sdpa(
  File "/home/vmoens/.conda/envs/torchrl/lib/python3.10/site-packages/transformers/modeling_attn_mask_utils.py", line 372, in _prepare_4d_causal_attention_mask_for_sdpa
    ignore_causal_mask = AttentionMaskConverter._ignore_causal_mask_sdpa(
  File "/home/vmoens/.conda/envs/torchrl/lib/python3.10/site-packages/transformers/modeling_attn_mask_utils.py", line 279, in _ignore_causal_mask_sdpa
    elif (is_training or not is_tracing) and torch.all(attention_mask == 1):
RuntimeError: vmap: It looks like you're attempting to use a Tensor in some data-dependent control flow. We don't support that yet, please shout over at https://github.com/pytorch/functorch/issues/257 .
```