### PR TITLE
[Refactor] Update all instances of exploration `*Wrapper` to `*Module`

### DIFF
--- a/sota-implementations/ddpg/ddpg.py
+++ b/sota-implementations/ddpg/ddpg.py
@@ -108,7 +108,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
     for _, tensordict in enumerate(collector):
         sampling_time = time.time() - sampling_start
         # Update exploration policy
-        exploration_policy.step(tensordict.numel())
+        exploration_policy[1].step(tensordict.numel())
 
         # Update weights of the inference policy
         collector.update_policy_weights_()

--- a/sota-implementations/dreamer/dreamer.py
+++ b/sota-implementations/dreamer/dreamer.py
@@ -279,7 +279,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
         if logger is not None:
             log_metrics(logger, metrics_to_log, collected_frames)
 
-        policy.step(current_frames)
+        policy[1].step(current_frames)
         collector.update_policy_weights_()
         # Evaluation
         if (i % eval_iter) == 0:

--- a/sota-implementations/dreamer/dreamer_utils.py
+++ b/sota-implementations/dreamer/dreamer_utils.py
@@ -52,7 +52,7 @@ from torchrl.envs import (
 )
 from torchrl.envs.utils import check_env_specs, ExplorationType, set_exploration_type
 from torchrl.modules import (
-    AdditiveGaussianWrapper,
+    AdditiveGaussianModule,
     DreamerActor,
     IndependentNormal,
     MLP,
@@ -266,13 +266,16 @@ def make_dreamer(
         test_env=test_env,
     )
     # Exploration noise to be added to the actor_realworld
-    actor_realworld = AdditiveGaussianWrapper(
+    actor_realworld = TensorDictSequential(
         actor_realworld,
-        sigma_init=1.0,
-        sigma_end=1.0,
-        annealing_num_steps=1,
-        mean=0.0,
-        std=cfg.networks.exploration_noise,
+        AdditiveGaussianModule(
+            spec=test_env.action_spec,
+            sigma_init=1.0,
+            sigma_end=1.0,
+            annealing_num_steps=1,
+            mean=0.0,
+            std=cfg.networks.exploration_noise,
+        ),
     )
 
     # Make Critic

--- a/sota-implementations/td3/td3.py
+++ b/sota-implementations/td3/td3.py
@@ -109,7 +109,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
     sampling_start = time.time()
     for tensordict in collector:
         sampling_time = time.time() - sampling_start
-        exploration_policy.step(tensordict.numel())
+        exploration_policy[1].step(tensordict.numel())
 
         # Update weights of the inference policy
         collector.update_policy_weights_()

--- a/sota-implementations/td3/utils.py
+++ b/sota-implementations/td3/utils.py
@@ -7,6 +7,7 @@ import tempfile
 from contextlib import nullcontext
 
 import torch
+from tensordict.nn import TensorDictSequential
 
 from torch import nn, optim
 from torchrl.collectors import SyncDataCollector
@@ -27,7 +28,7 @@ from torchrl.envs import (
 from torchrl.envs.libs.gym import GymEnv, set_gym_backend
 from torchrl.envs.utils import ExplorationType, set_exploration_type
 from torchrl.modules import (
-    AdditiveGaussianWrapper,
+    AdditiveGaussianModule,
     MLP,
     SafeModule,
     SafeSequential,
@@ -233,14 +234,16 @@ def make_td3_agent(cfg, train_env, eval_env, device):
     eval_env.close()
 
     # Exploration wrappers:
-    actor_model_explore = AdditiveGaussianWrapper(
+    actor_model_explore = TensorDictSequential(
         model[0],
-        sigma_init=1,
-        sigma_end=1,
-        mean=0,
-        std=0.1,
-        spec=action_spec,
-    ).to(device)
+        AdditiveGaussianModule(
+            sigma_init=1,
+            sigma_end=1,
+            mean=0,
+            std=0.1,
+            spec=action_spec,
+        ).to(device),
+    )
     return model, actor_model_explore
 
 

--- a/sota-implementations/td3_bc/utils.py
+++ b/sota-implementations/td3_bc/utils.py
@@ -5,6 +5,7 @@
 import functools
 
 import torch
+from tensordict.nn import TensorDictSequential
 
 from torch import nn, optim
 from torchrl.data.datasets.d4rl import D4RLExperienceReplay
@@ -24,7 +25,7 @@ from torchrl.envs import (
 from torchrl.envs.libs.gym import GymEnv, set_gym_backend
 from torchrl.envs.utils import ExplorationType, set_exploration_type
 from torchrl.modules import (
-    AdditiveGaussianWrapper,
+    AdditiveGaussianModule,
     MLP,
     SafeModule,
     SafeSequential,
@@ -174,14 +175,16 @@ def make_td3_agent(cfg, train_env, device):
     del td
 
     # Exploration wrappers:
-    actor_model_explore = AdditiveGaussianWrapper(
+    actor_model_explore = TensorDictSequential(
         model[0],
-        sigma_init=1,
-        sigma_end=1,
-        mean=0,
-        std=0.1,
-        spec=action_spec,
-    ).to(device)
+        AdditiveGaussianModule(
+            sigma_init=1,
+            sigma_end=1,
+            mean=0,
+            std=0.1,
+            spec=action_spec,
+        ).to(device),
+    )
     return model, actor_model_explore
 
 

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -27,7 +27,7 @@ from torchrl.envs import (
 )
 from torchrl.envs.utils import set_exploration_type, step_mdp
 from torchrl.modules import (
-    AdditiveGaussianWrapper,
+    AdditiveGaussianModule,
     DecisionTransformerInferenceWrapper,
     DTActor,
     GRUModule,
@@ -1363,17 +1363,19 @@ def test_actor_critic_specs():
         out_keys=[action_key],
     )
     original_spec = spec.clone()
-    module = AdditiveGaussianWrapper(policy_module, spec=spec, action_key=action_key)
+    module = TensorDictSequential(
+        policy_module, AdditiveGaussianModule(spec=spec, action_key=action_key)
+    )
     value_module = ValueOperator(
         module=module,
         in_keys=[("agents", "observation"), action_key],
         out_keys=[("agents", "state_action_value")],
     )
     assert original_spec == spec
-    assert module.spec == spec
+    assert module[1].spec == spec
     DDPGLoss(actor_network=module, value_network=value_module)
     assert original_spec == spec
-    assert module.spec == spec
+    assert module[1].spec == spec
 
 
 def test_vmapmodule():

--- a/tutorials/sphinx-tutorials/getting-started-1.py
+++ b/tutorials/sphinx-tutorials/getting-started-1.py
@@ -191,8 +191,8 @@ with set_exploration_type(ExplorationType.RANDOM):
 # also palliate to this with its exploration modules.
 # We will take the example of the :class:`~torchrl.modules.EGreedyModule`
 # exploration module (check also
-# :class:`~torchrl.modules.AdditiveGaussianWrapper` and
-# :class:`~torchrl.modules.OrnsteinUhlenbeckProcessWrapper`).
+# :class:`~torchrl.modules.AdditiveGaussianModule` and
+# :class:`~torchrl.modules.OrnsteinUhlenbeckProcessModule`).
 # To see this module in action, let's revert to a deterministic policy:
 
 from tensordict.nn import TensorDictSequential

--- a/tutorials/sphinx-tutorials/multiagent_competitive_ddpg.py
+++ b/tutorials/sphinx-tutorials/multiagent_competitive_ddpg.py
@@ -125,7 +125,7 @@ from torchrl.envs import (
 )
 
 from torchrl.modules import (
-    AdditiveGaussianWrapper,
+    AdditiveGaussianModule,
     MultiAgentMLP,
     ProbabilisticActor,
     TanhDelta,
@@ -499,7 +499,7 @@ for group, _agents in env.group_map.items():
 # Since the DDPG policy is deterministic, we need a way to perform exploration during collection.
 #
 # For this purpose, we need to append an exploration layer to our policies before passing them to the collector.
-# In this case we use a :class:`~torchrl.modules.AdditiveGaussianWrapper`, which adds gaussian noise to our action
+# In this case we use a :class:`~torchrl.modules.AdditiveGaussianModule`, which adds gaussian noise to our action
 # (and clamps it if the noise makes the action out of bounds).
 #
 # This exploration wrapper uses a ``sigma`` parameter which is multiplied by the noise to determine its magnitude.
@@ -510,13 +510,16 @@ for group, _agents in env.group_map.items():
 
 exploration_policies = {}
 for group, _agents in env.group_map.items():
-    exploration_policy = AdditiveGaussianWrapper(
+    exploration_policy = TensorDictSequential(
         policies[group],
-        annealing_num_steps=total_frames
-        // 2,  # Number of frames after which sigma is sigma_end
-        action_key=(group, "action"),
-        sigma_init=0.9,  # Initial value of the sigma
-        sigma_end=0.1,  # Final value of the sigma
+        AdditiveGaussianModule(
+            spec=policies[group].spec,
+            annealing_num_steps=total_frames
+            // 2,  # Number of frames after which sigma is sigma_end
+            action_key=(group, "action"),
+            sigma_init=0.9,  # Initial value of the sigma
+            sigma_end=0.1,  # Final value of the sigma
+        ),
     )
     exploration_policies[group] = exploration_policy
 


### PR DESCRIPTION
## Description

Update instances of
* `AdditiveGaussianWrapper` --> `AdditiveGaussianModule`
* `OrnsteinUhlenbeckProcessWrapper` --> `OrnsteinUhlenbeckProcessModule`

everywhere in the code base, except in `test/test_exploration.py`, which should still test both the wrappers and modules until we finally remove the wrappers in the future.

## Motivation and Context

close #2295

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
