### PR TITLE
Fix brax examples

### DIFF
--- a/torchrl/envs/libs/brax.py
+++ b/torchrl/envs/libs/brax.py
@@ -80,8 +80,10 @@ class BraxWrapper(_EnvWrapper):
     Examples:
         >>> import brax.envs
         >>> from torchrl.envs import BraxWrapper
+        >>> import torch
+        >>> device = "cuda" if torch.cuda.is_available() else "cpu"
         >>> base_env = brax.envs.get_environment("ant")
-        >>> env = BraxWrapper(base_env)
+        >>> env = BraxWrapper(base_env, device=device)
         >>> env.set_seed(0)
         >>> td = env.reset()
         >>> td["action"] = env.action_spec.rand()
@@ -111,7 +113,9 @@ class BraxWrapper(_EnvWrapper):
     and report the execution time for a short rollout:
 
     Examples:
+        >>> import torch
         >>> from torch.utils.benchmark import Timer
+        >>> device = "cuda" if torch.cuda.is_available() else "cpu"
         >>> for batch_size in [4, 16, 128]:
         ...     timer = Timer('''
         ... env.rollout(100)
@@ -119,7 +123,7 @@ class BraxWrapper(_EnvWrapper):
         ...     setup=f'''
         ... import brax.envs
         ... from torchrl.envs import BraxWrapper
-        ... env = BraxWrapper(brax.envs.get_environment("ant"), batch_size=[{batch_size}])
+        ... env = BraxWrapper(brax.envs.get_environment("ant"), batch_size=[{batch_size}], device="{device}")
         ... env.set_seed(0)
         ... env.rollout(2)
         ... ''')
@@ -459,7 +463,9 @@ class BraxEnv(BraxWrapper):
 
     Examples:
         >>> from torchrl.envs import BraxEnv
-        >>> env = BraxEnv("ant")
+        >>> import torch
+        >>> device = "cuda" if torch.cuda.is_available() else "cpu"
+        >>> env = BraxEnv("ant", device=device)
         >>> env.set_seed(0)
         >>> td = env.reset()
         >>> td["action"] = env.action_spec.rand()
@@ -489,13 +495,16 @@ class BraxEnv(BraxWrapper):
     and report the execution time for a short rollout:
 
     Examples:
+        >>> import torch
+        >>> from torch.utils.benchmark import Timer
+        >>> device = "cuda" if torch.cuda.is_available() else "cpu"
         >>> for batch_size in [4, 16, 128]:
         ...     timer = Timer('''
         ... env.rollout(100)
         ... ''',
         ...     setup=f'''
         ... from torchrl.envs import BraxEnv
-        ... env = BraxEnv("ant", batch_size=[{batch_size}])
+        ... env = BraxEnv("ant", batch_size=[{batch_size}], device="{device}")
         ... env.set_seed(0)
         ... env.rollout(2)
         ... ''')


### PR DESCRIPTION
## Description

This fixes the brax examples. It explicitly specifies the device to run env on as recommended in the error messages.

## Motivation and Context

This fixes the issues which I was getting with the original errors:
```
/home/jorbik/Projects/rl/torchrl/envs/libs/brax.py:207: UserWarning: No device is set for env BraxEnv(env=ant, batch_size=torch.Size([4]), device=None). Setting a device in Brax wrapped environments is strongly recommended.
  warnings.warn(
Traceback (most recent call last):
  File "/home/jorbik/Projects/rl/test.py", line 19, in <module>
    print(batch_size, timer.timeit(10))
                      ^^^^^^^^^^^^^^^^
  File "/home/jorbik/miniconda3/envs/torchrl/lib/python3.11/site-packages/torch/utils/benchmark/utils/timer.py", line 274, in timeit
    self._timeit(number=max(int(number // 100), 2))
  File "/home/jorbik/miniconda3/envs/torchrl/lib/python3.11/site-packages/torch/utils/benchmark/utils/timer.py", line 264, in _timeit
    return max(self._timer.timeit(number), 1e-9)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorbik/miniconda3/envs/torchrl/lib/python3.11/timeit.py", line 180, in timeit
    timing = self.inner(it, self.timer)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<timeit-src>", line 6, in inner
  File "/home/jorbik/Projects/rl/torchrl/envs/common.py", line 2587, in rollout
    tensordicts = self._rollout_stop_early(**kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorbik/Projects/rl/torchrl/envs/common.py", line 2674, in _rollout_stop_early
    tensordict = self.step(tensordict)
                 ^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorbik/Projects/rl/torchrl/envs/common.py", line 1483, in step
    next_tensordict = self._step(tensordict)
                      ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorbik/Projects/rl/torchrl/envs/libs/brax.py", line 418, in _step
    out = self._step_without_grad(tensordict)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorbik/Projects/rl/torchrl/envs/libs/brax.py", line 348, in _step_without_grad
    next_state = self._vmap_jit_env_step(state, action)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Received incompatible devices for jitted computation. Got ARG_SHARDING with device ids [0] on platform GPU and ARG_SHARDING with device ids [0] on platform CPU
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
```

Closes #2319

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.