### PR TITLE
[Docs] Use more appropriate ActorValueOperator in PPOLoss documentation

### DIFF
--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -141,7 +141,7 @@ class PPOLoss(LossModule):
         >>> actor_head = SomeActor(in_keys=["hidden"])
         >>> value_head = SomeValue(in_keys=["hidden"])
         >>> # first option, with 2 calls on the common module
-        >>> model = ActorCriticOperator(common, actor_head, value_head)
+        >>> model = ActorValueOperator(common, actor_head, value_head)
         >>> loss_module = PPOLoss(model.get_policy_operator(), model.get_value_operator())
         >>> # second option, with a single call to the common module
         >>> loss_module = PPOLoss(ProbabilisticTensorDictSequential(model, actor_head), value_head)
@@ -718,10 +718,10 @@ class ClipPPOLoss(PPOLoss):
         >>> actor_head = SomeActor(in_keys=["hidden"])
         >>> value_head = SomeValue(in_keys=["hidden"])
         >>> # first option, with 2 calls on the common module
-        >>> model = ActorCriticOperator(common, actor_head, value_head)
-        >>> loss_module = PPOLoss(model.get_policy_operator(), model.get_value_operator())
+        >>> model = ActorValueOperator(common, actor_head, value_head)
+        >>> loss_module = ClipPPOLoss(model.get_policy_operator(), model.get_value_operator())
         >>> # second option, with a single call to the common module
-        >>> loss_module = PPOLoss(ProbabilisticTensorDictSequential(model, actor_head), value_head)
+        >>> loss_module = ClipPPOLoss(ProbabilisticTensorDictSequential(model, actor_head), value_head)
 
       This will work regardless of whether separate_losses is activated or not.
 
@@ -955,10 +955,10 @@ class KLPENPPOLoss(PPOLoss):
         >>> actor_head = SomeActor(in_keys=["hidden"])
         >>> value_head = SomeValue(in_keys=["hidden"])
         >>> # first option, with 2 calls on the common module
-        >>> model = ActorCriticOperator(common, actor_head, value_head)
-        >>> loss_module = PPOLoss(model.get_policy_operator(), model.get_value_operator())
+        >>> model = ActorValueOperator(common, actor_head, value_head)
+        >>> loss_module = KLPENPPOLoss(model.get_policy_operator(), model.get_value_operator())
         >>> # second option, with a single call to the common module
-        >>> loss_module = PPOLoss(ProbabilisticTensorDictSequential(model, actor_head), value_head)
+        >>> loss_module = KLPENPPOLoss(ProbabilisticTensorDictSequential(model, actor_head), value_head)
 
       This will work regardless of whether separate_losses is activated or not.
 


### PR DESCRIPTION
## Description

The PPO algorithm implies the _critic_ operator to compute the value of each state (`V(s)`) rather than the Q value (`Q(s, a)`) of a state-action pair.
Thus, an `ActorValueOperator` is the correct module to use here.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
