### PR TITLE
[Feature] RNG for RBs

### DIFF
--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -109,6 +109,11 @@ torch_2_3 = version.parse(
     ".".join([str(s) for s in version.parse(str(torch.__version__)).release])
 ) >= version.parse("2.3.0")
 
+ReplayBufferRNG = functools.partial(ReplayBuffer, generator=torch.Generator())
+TensorDictReplayBufferRNG = functools.partial(
+    TensorDictReplayBuffer, generator=torch.Generator()
+)
+
 
 @pytest.mark.parametrize(
     "sampler",
@@ -125,17 +130,27 @@ torch_2_3 = version.parse(
     "rb_type,storage,datatype",
     [
         [ReplayBuffer, ListStorage, None],
+        [ReplayBufferRNG, ListStorage, None],
         [TensorDictReplayBuffer, ListStorage, "tensordict"],
+        [TensorDictReplayBufferRNG, ListStorage, "tensordict"],
         [RemoteTensorDictReplayBuffer, ListStorage, "tensordict"],
         [ReplayBuffer, LazyTensorStorage, "tensor"],
         [ReplayBuffer, LazyTensorStorage, "tensordict"],
         [ReplayBuffer, LazyTensorStorage, "pytree"],
+        [ReplayBufferRNG, LazyTensorStorage, "tensor"],
+        [ReplayBufferRNG, LazyTensorStorage, "tensordict"],
+        [ReplayBufferRNG, LazyTensorStorage, "pytree"],
         [TensorDictReplayBuffer, LazyTensorStorage, "tensordict"],
+        [TensorDictReplayBufferRNG, LazyTensorStorage, "tensordict"],
         [RemoteTensorDictReplayBuffer, LazyTensorStorage, "tensordict"],
         [ReplayBuffer, LazyMemmapStorage, "tensor"],
         [ReplayBuffer, LazyMemmapStorage, "tensordict"],
         [ReplayBuffer, LazyMemmapStorage, "pytree"],
+        [ReplayBufferRNG, LazyMemmapStorage, "tensor"],
+        [ReplayBufferRNG, LazyMemmapStorage, "tensordict"],
+        [ReplayBufferRNG, LazyMemmapStorage, "pytree"],
         [TensorDictReplayBuffer, LazyMemmapStorage, "tensordict"],
+        [TensorDictReplayBufferRNG, LazyMemmapStorage, "tensordict"],
         [RemoteTensorDictReplayBuffer, LazyMemmapStorage, "tensordict"],
     ],
 )
@@ -1155,17 +1170,86 @@ def test_replay_buffer_trajectories(stack, reduction, datatype):
     # sampled_td_filtered.batch_size = [3, 4]
 
 
+class TestRNG:
+    def test_rb_rng(self):
+        state = torch.random.get_rng_state()
+        rb = ReplayBufferRNG(sampler=RandomSampler(), storage=LazyTensorStorage(100))
+        rb.extend(torch.arange(100))
+        rb._rng.set_state(state)
+        a = rb.sample(32)
+        rb._rng.set_state(state)
+        b = rb.sample(32)
+        assert (a == b).all()
+        c = rb.sample(32)
+        assert (a != c).any()
+
+    def test_prb_rng(self):
+        state = torch.random.get_rng_state()
+        rb = ReplayBuffer(
+            sampler=PrioritizedSampler(100, 1.0, 1.0),
+            storage=LazyTensorStorage(100),
+            generator=torch.Generator(),
+        )
+        rb.extend(torch.arange(100))
+        rb.update_priority(index=torch.arange(100), priority=torch.arange(1, 101))
+
+        rb._rng.set_state(state)
+        a = rb.sample(32)
+
+        rb._rng.set_state(state)
+        b = rb.sample(32)
+        assert (a == b).all()
+
+        c = rb.sample(32)
+        assert (a != c).any()
+
+    def test_slice_rng(self):
+        state = torch.random.get_rng_state()
+        rb = ReplayBuffer(
+            sampler=SliceSampler(num_slices=4),
+            storage=LazyTensorStorage(100),
+            generator=torch.Generator(),
+        )
+        done = torch.zeros(100, 1, dtype=torch.bool)
+        done[49] = 1
+        done[-1] = 1
+        data = TensorDict(
+            {
+                "data": torch.arange(100),
+                ("next", "done"): done,
+            },
+            batch_size=[100],
+        )
+        rb.extend(data)
+
+        rb._rng.set_state(state)
+        a = rb.sample(32)
+
+        rb._rng.set_state(state)
+        b = rb.sample(32)
+        assert (a == b).all()
+
+        c = rb.sample(32)
+        assert (a != c).any()
+
+
 @pytest.mark.parametrize(
     "rbtype,storage",
     [
         (ReplayBuffer, None),
         (ReplayBuffer, ListStorage),
+        (ReplayBufferRNG, None),
+        (ReplayBufferRNG, ListStorage),
         (PrioritizedReplayBuffer, None),
         (PrioritizedReplayBuffer, ListStorage),
         (TensorDictReplayBuffer, None),
         (TensorDictReplayBuffer, ListStorage),
         (TensorDictReplayBuffer, LazyTensorStorage),
         (TensorDictReplayBuffer, LazyMemmapStorage),
+        (TensorDictReplayBufferRNG, None),
+        (TensorDictReplayBufferRNG, ListStorage),
+        (TensorDictReplayBufferRNG, LazyTensorStorage),
+        (TensorDictReplayBufferRNG, LazyMemmapStorage),
         (TensorDictPrioritizedReplayBuffer, None),
         (TensorDictPrioritizedReplayBuffer, ListStorage),
         (TensorDictPrioritizedReplayBuffer, LazyTensorStorage),

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -804,12 +804,13 @@ class ReplayBuffer:
         return state
 
     def __setstate__(self, state: Dict[str, Any]):
+        rngstate = None
         if "_rng" in state:
-            rng = state["_rng"]
-            if rng is not None:
-                rng = torch.Generator(device=rng.device)
-                rng.set_state(rng["rng_state"])
-                state["_rng"] = rng
+            rngstate = state["_rng"]
+            if rngstate is not None:
+                rng = torch.Generator(device=rngstate.device)
+                rng.set_state(rngstate["rng_state"])
+
         if "_replay_lock_placeholder" in state:
             state.pop("_replay_lock_placeholder")
             _replay_lock = threading.RLock()
@@ -819,6 +820,8 @@ class ReplayBuffer:
             _futures_lock = threading.RLock()
             state["_futures_lock"] = _futures_lock
         self.__dict__.update(state)
+        if rngstate is not None:
+            self.set_rng(rng)
 
     @property
     def sampler(self):

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -186,6 +186,11 @@ class Storage:
         """Alias for :meth:`~.loads`."""
         return self.loads(*args, **kwargs)
 
+    def __getstate__(self):
+        state = copy(self.__dict__)
+        state["_rng"] = None
+        return state
+
 
 class ListStorage(Storage):
     """A storage stored in a list.
@@ -300,7 +305,7 @@ class ListStorage(Storage):
             raise RuntimeError(
                 f"Cannot share a storage of type {type(self)} between processes."
             )
-        state = copy(self.__dict__)
+        state = super().__getstate__()
         return state
 
     def __repr__(self):
@@ -525,7 +530,7 @@ class TensorStorage(Storage):
         )
 
     def __getstate__(self):
-        state = copy(self.__dict__)
+        state = super().__getstate__()
         if get_spawning_popen() is None:
             length = self._len
             del state["_len_value"]

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -38,6 +38,7 @@ class Writer(ABC):
     """A ReplayBuffer base Writer class."""
 
     _storage: Storage
+    _rng: torch.Generator | None = None
 
     def __init__(self) -> None:
         self._storage = None
@@ -582,7 +583,18 @@ class WriterEnsemble(Writer):
     """
 
     def __init__(self, *writers):
+        self._rng_private = None
         self._writers = writers
+
+    @property
+    def _rng(self):
+        return self._rng_private
+
+    @_rng.setter
+    def _rng(self, value):
+        self._rng_private = value
+        for writer in self._writers:
+            writer._rng = value
 
     def _empty(self):
         raise NotImplementedError

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -104,6 +104,11 @@ class Writer(ABC):
     def __repr__(self):
         return f"{self.__class__.__name__}()"
 
+    def __getstate__(self):
+        state = copy(self.__dict__)
+        state["_rng"] = None
+        return state
+
 
 class ImmutableDatasetWriter(Writer):
     """A blocking writer for immutable datasets."""
@@ -218,7 +223,7 @@ class RoundRobinWriter(Writer):
         _cursor_value.value = value
 
     def __getstate__(self):
-        state = copy(self.__dict__)
+        state = super().__getstate__()
         if get_spawning_popen() is None:
             cursor = self._cursor
             del state["_cursor_value"]
@@ -514,7 +519,7 @@ class TensorDictMaxValueWriter(Writer):
             raise RuntimeError(
                 f"Writers of type {type(self)} cannot be shared between processes."
             )
-        state = copy(self.__dict__)
+        state = super().__getstate__()
         return state
 
     def dumps(self, path):


### PR DESCRIPTION
Implements a `generator` argument in replay buffers that allows to control the local (RB-specific) seed.