### PR TITLE
[Feature] Support wrapping IsaacLab environments with GymEnv

### DIFF
--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -3039,6 +3039,7 @@ class _EnvWrapper(EnvBase):
 
         self._constructor_kwargs = kwargs
         self._check_kwargs(kwargs)
+        self._convert_actions_to_numpy = kwargs.pop("convert_actions_to_numpy", True)
         self._env = self._build_env(**kwargs)  # writes the self._env attribute
         self._make_specs(self._env)  # writes the self._env attribute
         self.is_closed = False

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -172,7 +172,6 @@ class GymLikeEnv(_EnvWrapper):
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls, *args, _batch_locked=True, **kwargs)
         self._info_dict_reader = []
-        self._convert_actions_to_numpy = kwargs.pop("convert_actions_to_numpy", True)
 
         return self
 

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -172,6 +172,8 @@ class GymLikeEnv(_EnvWrapper):
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls, *args, _batch_locked=True, **kwargs)
         self._info_dict_reader = []
+        self._convert_actions_to_numpy = kwargs.pop('convert_actions_to_numpy', True)
+
         return self
 
     def read_action(self, action):
@@ -289,7 +291,8 @@ class GymLikeEnv(_EnvWrapper):
 
     def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
         action = tensordict.get(self.action_key)
-        action_np = self.read_action(action)
+        if self._convert_actions_to_numpy:
+            action = self.read_action(action)
 
         reward = 0
         for _ in range(self.wrapper_frame_skip):

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -172,7 +172,7 @@ class GymLikeEnv(_EnvWrapper):
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls, *args, _batch_locked=True, **kwargs)
         self._info_dict_reader = []
-        self._convert_actions_to_numpy = kwargs.pop('convert_actions_to_numpy', True)
+        self._convert_actions_to_numpy = kwargs.pop("convert_actions_to_numpy", True)
 
         return self
 
@@ -303,7 +303,7 @@ class GymLikeEnv(_EnvWrapper):
                 truncated,
                 done,
                 info_dict,
-            ) = self._output_transform(self._env.step(action_np))
+            ) = self._output_transform(self._env.step(action))
 
             if _reward is not None:
                 reward = reward + _reward

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -645,7 +645,12 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
         allow_done_after_reset (bool, optional): if ``True``, it is tolerated
             for envs to be ``done`` just after :meth:`~.reset` is called.
             Defaults to ``False``.
-
+        convert_actions_to_numpy (bool, optional): if ``True``, actions will be 
+            converted from tensors to numpy arrays and moved to CPU before being passed to the 
+            env step function. Set this to ``False`` if the environment is evaluated 
+            on GPU, such as IsaacLab.
+            Defaults to ``True``.
+            
     Attributes:
         available_envs (List[str]): a list of environments to build.
 

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -839,6 +839,7 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
         env,
         from_pixels: bool = False,
         pixels_only: bool = False,
+        convert_actions_to_numpy: bool = True,
     ) -> "gym.core.Env":  # noqa: F821
         self.batch_size = self._get_batch_size(env)
 

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -839,7 +839,6 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
         env,
         from_pixels: bool = False,
         pixels_only: bool = False,
-        convert_actions_to_numpy: bool = True,
     ) -> "gym.core.Env":  # noqa: F821
         self.batch_size = self._get_batch_size(env)
 

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -645,12 +645,12 @@ class GymWrapper(GymLikeEnv, metaclass=_AsyncMeta):
         allow_done_after_reset (bool, optional): if ``True``, it is tolerated
             for envs to be ``done`` just after :meth:`~.reset` is called.
             Defaults to ``False``.
-        convert_actions_to_numpy (bool, optional): if ``True``, actions will be 
-            converted from tensors to numpy arrays and moved to CPU before being passed to the 
-            env step function. Set this to ``False`` if the environment is evaluated 
+        convert_actions_to_numpy (bool, optional): if ``True``, actions will be
+            converted from tensors to numpy arrays and moved to CPU before being passed to the
+            env step function. Set this to ``False`` if the environment is evaluated
             on GPU, such as IsaacLab.
             Defaults to ``True``.
-            
+
     Attributes:
         available_envs (List[str]): a list of environments to build.
 


### PR DESCRIPTION
## Description

Adds a configuration parameter to `GymLikeEnv` to specify whether or not actions should be converted to numpy arrays before being passed to the step function of the underlying environment to retrieve the next state. Users can now pass `convert_actions_to_numpy=False` when wrapping environments that work with torch tensors. 

Let me know if a new test is required for this. 

## Motivation and Context

Previously, it was assumed that the step function argument expected numpy array types on CPU, which makes torchrl incompatible with environments like IsaacLab that operate on torch tensors and on the GPU. 

If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213
Closes #2369 

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [] Example (update in the folder of examples)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
