### PR TITLE
[BUG] Allow for composite action distributions in losses

### DIFF
--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -7560,6 +7560,7 @@ class TestPPO(LossModuleTestBase):
                 name_map={
                     "action1": (action_key, "action1"),
                 },
+                log_prob_key=sample_log_prob_key,
             )
             module_out_keys = [
                 ("params", "action1", "loc"),
@@ -7607,6 +7608,7 @@ class TestPPO(LossModuleTestBase):
         action_dim=4,
         device="cpu",
         composite_action_dist=False,
+        sample_log_prob_key="sample_log_prob",
     ):
         # Actor
         action_spec = Bounded(
@@ -7627,6 +7629,7 @@ class TestPPO(LossModuleTestBase):
                 name_map={
                     "action1": ("action", "action1"),
                 },
+                log_prob_key=sample_log_prob_key,
             )
             module_out_keys = [
                 ("params", "action1", "loc"),
@@ -7660,6 +7663,7 @@ class TestPPO(LossModuleTestBase):
         action_dim=4,
         device="cpu",
         composite_action_dist=False,
+        sample_log_prob_key="sample_log_prob",
     ):
         # Actor
         action_spec = Bounded(
@@ -7681,6 +7685,7 @@ class TestPPO(LossModuleTestBase):
                 name_map={
                     "action1": ("action", "action1"),
                 },
+                log_prob_key=sample_log_prob_key,
             )
             module_out_keys = [
                 ("params", "action1", "loc"),

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -477,6 +477,9 @@ class PPOLoss(LossModule):
             raise RuntimeError("tensordict prev_log_prob requires grad.")
 
         if isinstance(dist, CompositeDistribution):
+            if tensordict.get(self.tensor_keys.action).batch_size != tensordict.batch_size:
+                # This condition can be True in notensordict usage
+                tensordict.get(self.tensor_keys.action).batch_size = tensordict.batch_size
             tensordict = dist.log_prob(tensordict)
             log_prob = tensordict.get(self.tensor_keys.sample_log_prob)
         else:

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -451,7 +451,7 @@ class PPOLoss(LossModule):
         except NotImplementedError:
             x = dist.rsample((self.samples_mc_entropy,))
             if isinstance(dist, CompositeDistribution):
-                log_prob = dist.log_prob(x).get(self.tensor_keys.sample_log_prob)
+                log_prob = dist.log_prob(x).get("sample_log_prob")
             else:
                 log_prob = dist.log_prob(x)
             entropy = -log_prob.mean(0)
@@ -478,7 +478,7 @@ class PPOLoss(LossModule):
 
         if isinstance(dist, CompositeDistribution):
             tensordict = dist.log_prob(tensordict)
-            log_prob = tensordict.get(self.tensor_keys.sample_log_prob)
+            log_prob = tensordict.get("sample_log_prob")
         else:
             log_prob = dist.log_prob(action)
 
@@ -1118,12 +1118,8 @@ class KLPENPPOLoss(PPOLoss):
         except NotImplementedError:
             x = previous_dist.sample((self.samples_mc_kl,))
             if isinstance(current_dist, CompositeDistribution):
-                previous_log_prob = previous_dist.log_prob(x).get(
-                    self.tensor_keys.sample_log_prob
-                )
-                current_log_prob = current_dist.log_prob(x).get(
-                    self.tensor_keys.sample_log_prob
-                )
+                previous_log_prob = previous_dist.log_prob(x).get("sample_log_prob")
+                current_log_prob = current_dist.log_prob(x).get("sample_log_prob")
             else:
                 previous_log_prob = previous_dist.log_prob(x)
                 current_log_prob = current_dist.log_prob(x)

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -451,7 +451,7 @@ class PPOLoss(LossModule):
         except NotImplementedError:
             x = dist.rsample((self.samples_mc_entropy,))
             if isinstance(dist, CompositeDistribution):
-                log_prob = dist.log_prob(x).get("sample_log_prob")
+                log_prob = dist.log_prob(x).get(self.tensor_keys.sample_log_prob)
             else:
                 log_prob = dist.log_prob(x)
             entropy = -log_prob.mean(0)
@@ -478,7 +478,7 @@ class PPOLoss(LossModule):
 
         if isinstance(dist, CompositeDistribution):
             tensordict = dist.log_prob(tensordict)
-            log_prob = tensordict.get("sample_log_prob")
+            log_prob = tensordict.get(self.tensor_keys.sample_log_prob)
         else:
             log_prob = dist.log_prob(action)
 
@@ -1118,8 +1118,12 @@ class KLPENPPOLoss(PPOLoss):
         except NotImplementedError:
             x = previous_dist.sample((self.samples_mc_kl,))
             if isinstance(current_dist, CompositeDistribution):
-                previous_log_prob = previous_dist.log_prob(x).get("sample_log_prob")
-                current_log_prob = current_dist.log_prob(x).get("sample_log_prob")
+                previous_log_prob = previous_dist.log_prob(x).get(
+                    self.tensor_keys.sample_log_prob
+                )
+                current_log_prob = current_dist.log_prob(x).get(
+                    self.tensor_keys.sample_log_prob
+                )
             else:
                 previous_log_prob = previous_dist.log_prob(x)
                 current_log_prob = current_dist.log_prob(x)

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -14,6 +14,7 @@ from typing import Tuple
 import torch
 from tensordict import TensorDict, TensorDictBase, TensorDictParams
 from tensordict.nn import (
+    CompositeDistribution,
     dispatch,
     ProbabilisticTensorDictModule,
     ProbabilisticTensorDictSequential,
@@ -449,7 +450,11 @@ class PPOLoss(LossModule):
             entropy = dist.entropy()
         except NotImplementedError:
             x = dist.rsample((self.samples_mc_entropy,))
-            entropy = -dist.log_prob(x).mean(0)
+            if isinstance(dist, CompositeDistribution):
+                log_prob = dist.log_prob(x).get(self.tensor_keys.sample_log_prob)
+            else:
+                log_prob = dist.log_prob(x)
+            entropy = -log_prob.mean(0)
         return entropy.unsqueeze(-1)
 
     def _log_weight(
@@ -466,11 +471,16 @@ class PPOLoss(LossModule):
             self.actor_network
         ) if self.functional else contextlib.nullcontext():
             dist = self.actor_network.get_dist(tensordict)
-        log_prob = dist.log_prob(action)
 
         prev_log_prob = tensordict.get(self.tensor_keys.sample_log_prob)
         if prev_log_prob.requires_grad:
             raise RuntimeError("tensordict prev_log_prob requires grad.")
+
+        if isinstance(dist, CompositeDistribution):
+            tensordict = dist.log_prob(tensordict)
+            log_prob = tensordict.get(self.tensor_keys.sample_log_prob)
+        else:
+            log_prob = dist.log_prob(action)
 
         log_weight = (log_prob - prev_log_prob).unsqueeze(-1)
         kl_approx = (prev_log_prob - log_prob).unsqueeze(-1)
@@ -1107,7 +1117,17 @@ class KLPENPPOLoss(PPOLoss):
             kl = torch.distributions.kl.kl_divergence(previous_dist, current_dist)
         except NotImplementedError:
             x = previous_dist.sample((self.samples_mc_kl,))
-            kl = (previous_dist.log_prob(x) - current_dist.log_prob(x)).mean(0)
+            if isinstance(current_dist, CompositeDistribution):
+                previous_log_prob = previous_dist.log_prob(x).get(
+                    self.tensor_keys.sample_log_prob
+                )
+                current_log_prob = current_dist.log_prob(x).get(
+                    self.tensor_keys.sample_log_prob
+                )
+            else:
+                previous_log_prob = previous_dist.log_prob(x)
+                current_log_prob = current_dist.log_prob(x)
+            kl = (previous_log_prob - current_log_prob).mean(0)
         kl = kl.unsqueeze(-1)
         neg_loss = neg_loss - self.beta * kl
         if kl.mean() > self.dtarg * 1.5:


### PR DESCRIPTION
## Description

At the moment objective classes do not allow to use an actor with a composite distribution.

This PR aims to fix this. I have started by modifying the on-policy objectives and added tests for PPO.

Once these modification are correct, I will move on the the tests of the other on-policy objectives and then to all other objectives.

This PR requires the TensorDict PR https://github.com/pytorch/tensordict/pull/961 to be merged.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
