### PR TITLE
[CI] Fix Minari tests

### DIFF
--- a/.github/unittest/linux_libs/scripts_minari/environment.yml
+++ b/.github/unittest/linux_libs/scripts_minari/environment.yml
@@ -17,4 +17,4 @@ dependencies:
     - pyyaml
     - scipy
     - hydra-core
-    - minari
+    - minari[gcs,hdf5]

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -2823,34 +2823,12 @@ def _minari_selected_datasets():
 
     torch.manual_seed(0)
 
-    # We rely on sorting the keys as v0 < v1 but if the version is greater than 9 this won't work
-    total_keys = sorted(minari.list_remote_datasets())
-    assert not any(
-        key[-2:] == "10" for key in total_keys
-    ), "You should adapt the Minari test scripts as some dataset have a version >= 10 and sorting will fail."
-    total_keys_splits = [key.split("-") for key in total_keys]
+    total_keys = sorted(minari.list_remote_datasets(
+        latest_version=True,
+        compatible_minari_version=True
+    ))
     indices = torch.randperm(len(total_keys))[:20]
     keys = [total_keys[idx] for idx in indices]
-    keys = [
-        key
-        for key in keys
-        if "=0.4" in minari.list_remote_datasets()[key]["minari_version"]
-    ]
-
-    def _replace_with_max(key):
-        key_split = key.split("-")
-        same_entries = (
-            torch.tensor(
-                [total_key[:-1] == key_split[:-1] for total_key in total_keys_splits]
-            )
-            .nonzero()
-            .squeeze()
-            .tolist()
-        )
-        last_same_entry = same_entries[-1]
-        return total_keys[last_same_entry]
-
-    keys = [_replace_with_max(key) for key in keys]
 
     assert len(keys) > 5, keys
     _MINARI_DATASETS += keys

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -2857,12 +2857,8 @@ class TestMinari:
                 break
 
     def test_minari_preproc(self, tmpdir):
-        global _MINARI_DATASETS
-        if not _MINARI_DATASETS:
-            _minari_selected_datasets()
-        selected_dataset = _MINARI_DATASETS[0]
         dataset = MinariExperienceReplay(
-            selected_dataset,
+            "D4RL/pointmaze/large-v2",
             batch_size=32,
             split_trajs=False,
             download="force",

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -2823,10 +2823,9 @@ def _minari_selected_datasets():
 
     torch.manual_seed(0)
 
-    total_keys = sorted(minari.list_remote_datasets(
-        latest_version=True,
-        compatible_minari_version=True
-    ))
+    total_keys = sorted(
+        minari.list_remote_datasets(latest_version=True, compatible_minari_version=True)
+    )
     indices = torch.randperm(len(total_keys))[:20]
     keys = [total_keys[idx] for idx in indices]
 


### PR DESCRIPTION
## Description

With Minari 0.5.0 release, we regrouped dependencies to install only the required ones depending on user usage. 
Moreover, we restructured the datasets to be hierarchical. This caused the `torch/rl` tests to fail; this PR should fix them.

I changed the tests to rely on Minari for getting the last version of the datasets.

Also, Minari 0.5.0 adds support for Arrow datasets, I am happy to integrate it in `torch/rl`.

## Motivation and Context

Fixes failing CI due to new version of Minari.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
