### PR TITLE
[BugFix] Fix invalid CUDA ID error when loading Bounded variables across devices

### DIFF
--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -397,16 +397,6 @@ class ContinuousBox(Box):
         self.device = value.device
         self._high = value.cpu()
 
-    @low.setter
-    def low(self, value):
-        self.device = value.device
-        self._low = value.cpu()
-
-    @high.setter
-    def high(self, value):
-        self.device = value.device
-        self._high = value.cpu()
-
     def __post_init__(self):
         self.low = self.low.clone()
         self.high = self.high.clone()

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -2269,9 +2269,10 @@ class Bounded(TensorSpec, metaclass=_BoundedMeta):
             dest_device = torch.device(dest)
         if dest_device == self.device and dest_dtype == self.dtype:
             return self
+        self.space.device = dest_device
         return Bounded(
-            low=self.space.low.to(dest),
-            high=self.space.high.to(dest),
+            low=self.space.low,
+            high=self.space.high,
             shape=self.shape,
             device=dest_device,
             dtype=dest_dtype,


### PR DESCRIPTION
## Description

This pull request resolves an invalid CUDA ID error that occurs when transferring a Bounded variable between servers with different numbers of GPUs.

In the current implementation, when changing the device of a `Bounded` variable, there is:

https://github.com/pytorch/rl/blob/df4fa7808e81f4b95ee2c22a4bb768370a669048/torchrl/data/tensor_specs.py#L2273-L2274

This operation first attempts to move `self.space._low` to its `self.space.device` before transferring to the target device (`dest`):

https://github.com/pytorch/rl/blob/df4fa7808e81f4b95ee2c22a4bb768370a669048/torchrl/data/tensor_specs.py#L376-L382

 This process leads to errors when a variable previously on `cuda:7` (in an 8 GPU server) is loaded on a server with only one GPU, as it incorrectly attempts to access `cuda:7`.

## Motivation and Context

The issue was identified when a model was trained and saved on a multi-GPU cluster and subsequently loaded on a local server equipped with fewer GPUs. The model’s saved state includes device information specific to the original multi-GPU environment. When attempting to assign the model to a device available on the current server, the discrepancy in device IDs between the environments leads to this bug.

This PR fixes #2420 .

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

To resolve this bug, I have adjusted the approach to device assignment. Instead of calling the saved device information from the previous cluster, we directly update the device information to match the current server’s available hardware. 

In the meantime, I think there is repeat function code here:

https://github.com/pytorch/rl/blob/df4fa7808e81f4b95ee2c22a4bb768370a669048/torchrl/data/tensor_specs.py#L390-L408

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
