### PR TITLE
[BugFix] Fix Compose input spec transform

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -8678,8 +8678,18 @@ class TestTransforms:
     def test_compose_action_spec(self):
         # Create a Compose transform that renames "action" to "action_1" and then to "action_2"
         c = Compose(
-            RenameTransform(in_keys=(), out_keys=(), in_keys_inv=("action",), out_keys_inv=("action_1",)),
-            RenameTransform(in_keys=(), out_keys=(), in_keys_inv=("action_1",), out_keys_inv=("action_2",)),
+            RenameTransform(
+                in_keys=(),
+                out_keys=(),
+                in_keys_inv=("action",),
+                out_keys_inv=("action_1",),
+            ),
+            RenameTransform(
+                in_keys=(),
+                out_keys=(),
+                in_keys_inv=("action_1",),
+                out_keys_inv=("action_2",),
+            ),
         )
         base_env = ContinuousActionVecMockEnv()
         env = TransformedEnv(base_env, c)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -8675,6 +8675,25 @@ class TestTransforms:
         assert last_t.scale == 4
         assert last_t2.scale == 4
 
+    def test_compose_action_spec(self):
+        # Create a Compose transform that renames "action" to "action_1" and then to "action_2"
+        c = Compose(
+            RenameTransform(in_keys=(), out_keys=(), in_keys_inv=("action",), out_keys_inv=("action_1",)),
+            RenameTransform(in_keys=(), out_keys=(), in_keys_inv=("action_1",), out_keys_inv=("action_2",)),
+        )
+        base_env = ContinuousActionVecMockEnv()
+        env = TransformedEnv(base_env, c)
+
+        # Check the `full_action_spec`s
+        assert "action_2" in env.full_action_spec
+        # Ensure intermediate keys are no longer in the action spec
+        assert "action_1" not in env.full_action_spec
+        assert "action" not in env.full_action_spec
+
+        # Final check to ensure clean sampling from the action_spec
+        action = env.rand_action()
+        assert "action_2"
+
     @pytest.mark.parametrize("device", get_default_devices())
     def test_finitetensordictcheck(self, device):
         ftd = FiniteTensorDictCheck()

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1094,7 +1094,7 @@ class Compose(Transform):
         return batch_size
 
     def transform_input_spec(self, input_spec: TensorSpec) -> TensorSpec:
-        for t in self.transforms[::-1]:
+        for t in self.transforms:
             input_spec = t.transform_input_spec(input_spec)
         return input_spec
 


### PR DESCRIPTION
## Description

This PR fixes what I think is a bug in the `transform_input_spec` method of the `Compose` transform. 


## Motivation and Context

The original code goes backward through the list of transforms:

```python
def transform_input_spec(self, input_spec: TensorSpec) -> TensorSpec:
    for t in self.transforms[::-1]:
        input_spec = t.transform_input_spec(input_spec)
    return input_spec
```

while I believe this should go forward to propagate the input spec of the underlying env.

```python
def transform_input_spec(self, input_spec: TensorSpec) -> TensorSpec:
    for t in self.transforms:
        input_spec = t.transform_input_spec(input_spec)
    return input_spec
```

I noticed this issue after trying to compose two inverse transformations: `DiscretiseAction` and `RenameTransform` -- which broke with a "key" error. I also tried to chain some `RenameTransform`s that rename the action key. I added this last examples to the tests.

_Rq_. I have seen that chaining >2 `RenameTransform` still yields some error, but this seems to be on the `RenameTransform` side, not `Compose`. I'll open an issue for this. 


- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
