### PR TITLE
[Feature] Check number of kwargs matches num_workers

### DIFF
--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -22,13 +22,13 @@ from warnings import warn
 import torch
 
 from tensordict import (
-    _zip_strict,
     is_tensor_collection,
     LazyStackedTensorDict,
     TensorDict,
     TensorDictBase,
     unravel_key,
 )
+from tensordict.utils import _zip_strict
 from torch import multiprocessing as mp
 from torchrl._utils import (
     _check_for_faulty_process,

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -318,14 +318,20 @@ class BatchedEnvBase(EnvBase):
             create_env_fn = [create_env_fn for _ in range(num_workers)]
         elif len(create_env_fn) != num_workers:
             raise RuntimeError(
-                f"num_workers and len(create_env_fn) mismatch, "
-                f"got {len(create_env_fn)} and {num_workers}"
+                f"len(create_env_fn) and num_workers mismatch, "
+                f"got {len(create_env_fn)} and {num_workers}."
             )
+
         create_env_kwargs = {} if create_env_kwargs is None else create_env_kwargs
         if isinstance(create_env_kwargs, dict):
             create_env_kwargs = [
                 deepcopy(create_env_kwargs) for _ in range(num_workers)
             ]
+        elif len(create_env_kwargs) != num_workers:
+            raise RuntimeError(
+                f"len(create_env_kwargs) and num_workers mismatch, "
+                f"got {len(create_env_kwargs)} and {num_workers}."
+            )
 
         self.policy_proof = policy_proof
         self.num_workers = num_workers
@@ -534,7 +540,13 @@ class BatchedEnvBase(EnvBase):
             for _kwargs in self.create_env_kwargs:
                 _kwargs.update(kwargs)
         else:
-            for _kwargs, _new_kwargs in zip(self.create_env_kwargs, kwargs):
+            if len(kwargs) != self.num_workers:
+                raise RuntimeError(
+                    f"len(kwargs) and num_workers mismatch, got {len(kwargs)} and {self.num_workers}."
+                )
+            for _kwargs, _new_kwargs in zip(
+                self.create_env_kwargs, kwargs, strict=True
+            ):
                 _kwargs.update(_new_kwargs)
 
     def _get_in_keys_to_exclude(self, tensordict):

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -22,6 +22,7 @@ from warnings import warn
 import torch
 
 from tensordict import (
+    _zip_strict,
     is_tensor_collection,
     LazyStackedTensorDict,
     TensorDict,
@@ -544,9 +545,7 @@ class BatchedEnvBase(EnvBase):
                 raise RuntimeError(
                     f"len(kwargs) and num_workers mismatch, got {len(kwargs)} and {self.num_workers}."
                 )
-            for _kwargs, _new_kwargs in zip(
-                self.create_env_kwargs, kwargs, strict=True
-            ):
+            for _kwargs, _new_kwargs in _zip_strict(self.create_env_kwargs, kwargs):
                 _kwargs.update(_new_kwargs)
 
     def _get_in_keys_to_exclude(self, tensordict):


### PR DESCRIPTION
## Description

Add runtime checks to ensure the `create_env_kwargs` and `kwargs` passed to the `__init__()` and `update_kwargs()` respectively have the right number of elements, i.e. the number of workers.

## Motivation and Context

An off by one error got me pretty hard.

## Types of changes

Not sure if that is a bug fix or a new feature to add these checks.
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds core functionality)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
