### PR TITLE
[BugFix] Avoid `reshape(-1)` for inputs to `objectives` modules

### DIFF
--- a/torchrl/objectives/cql.py
+++ b/torchrl/objectives/cql.py
@@ -514,32 +514,21 @@ class CQLLoss(LossModule):
 
     @dispatch
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
-        shape = None
-        if tensordict.ndimension() > 1:
-            shape = tensordict.shape
-            tensordict_reshape = tensordict.reshape(-1)
-        else:
-            tensordict_reshape = tensordict
-
-        q_loss, metadata = self.q_loss(tensordict_reshape)
-        cql_loss, cql_metadata = self.cql_loss(tensordict_reshape)
+        q_loss, metadata = self.q_loss(tensordict)
+        cql_loss, cql_metadata = self.cql_loss(tensordict)
         if self.with_lagrange:
-            alpha_prime_loss, alpha_prime_metadata = self.alpha_prime_loss(
-                tensordict_reshape
-            )
+            alpha_prime_loss, alpha_prime_metadata = self.alpha_prime_loss(tensordict)
             metadata.update(alpha_prime_metadata)
-        loss_actor_bc, bc_metadata = self.actor_bc_loss(tensordict_reshape)
-        loss_actor, actor_metadata = self.actor_loss(tensordict_reshape)
+        loss_actor_bc, bc_metadata = self.actor_bc_loss(tensordict)
+        loss_actor, actor_metadata = self.actor_loss(tensordict)
         loss_alpha, alpha_metadata = self.alpha_loss(actor_metadata)
         metadata.update(bc_metadata)
         metadata.update(cql_metadata)
         metadata.update(actor_metadata)
         metadata.update(alpha_metadata)
-        tensordict_reshape.set(
+        tensordict.set(
             self.tensor_keys.priority, metadata.pop("td_error").detach().max(0).values
         )
-        if shape:
-            tensordict.update(tensordict_reshape.view(shape))
         out = {
             "loss_actor": loss_actor,
             "loss_actor_bc": loss_actor_bc,
@@ -682,7 +671,9 @@ class CQLLoss(LossModule):
                 )
                 # take max over actions
                 state_action_value = state_action_value.reshape(
-                    self.num_qvalue_nets, tensordict.shape[0], self.num_random, -1
+                    torch.Size([self.num_qvalue_nets])
+                    + tensordict.shape
+                    + torch.Size([self.num_random, -1])
                 ).max(-2)[0]
                 # take min over qvalue nets
                 next_state_value = state_action_value.min(0)[0]
@@ -741,8 +732,13 @@ class CQLLoss(LossModule):
 
         random_actions_tensor = (
             torch.FloatTensor(
-                tensordict.shape[0] * self.num_random,
-                tensordict[self.tensor_keys.action].shape[-1],
+                tensordict.shape[:-1]
+                + torch.Size(
+                    [
+                        tensordict.shape[-1] * self.num_random,
+                        tensordict[self.tensor_keys.action].shape[-1],
+                    ]
+                )
             )
             .uniform_(-1, 1)
             .to(tensordict.device)
@@ -833,7 +829,7 @@ class CQLLoss(LossModule):
                 q_new[0] - new_log_pis.detach().unsqueeze(-1),
                 q_curr[0] - curr_log_pis.detach().unsqueeze(-1),
             ],
-            1,
+            -1,
         )
         cat_q2 = torch.cat(
             [
@@ -841,23 +837,23 @@ class CQLLoss(LossModule):
                 q_new[1] - new_log_pis.detach().unsqueeze(-1),
                 q_curr[1] - curr_log_pis.detach().unsqueeze(-1),
             ],
-            1,
+            -1,
         )
 
         min_qf1_loss = (
-            torch.logsumexp(cat_q1 / self.temperature, dim=1)
+            torch.logsumexp(cat_q1 / self.temperature, dim=-1)
             * self.min_q_weight
             * self.temperature
         )
         min_qf2_loss = (
-            torch.logsumexp(cat_q2 / self.temperature, dim=1)
+            torch.logsumexp(cat_q2 / self.temperature, dim=-1)
             * self.min_q_weight
             * self.temperature
         )
 
         # Subtract the log likelihood of data
-        cql_q1_loss = min_qf1_loss - pred_q1 * self.min_q_weight
-        cql_q2_loss = min_qf2_loss - pred_q2 * self.min_q_weight
+        cql_q1_loss = min_qf1_loss.flatten() - pred_q1 * self.min_q_weight
+        cql_q2_loss = min_qf2_loss.flatten() - pred_q2 * self.min_q_weight
 
         # write cql losses in tensordict for alpha prime loss
         tensordict.set(self.tensor_keys.cql_q1_loss, cql_q1_loss)

--- a/torchrl/objectives/crossq.py
+++ b/torchrl/objectives/crossq.py
@@ -495,23 +495,14 @@ class CrossQLoss(LossModule):
         To see what keys are expected in the input tensordict and what keys are expected as output, check the
         class's `"in_keys"` and `"out_keys"` attributes.
         """
-        shape = None
-        if tensordict.ndimension() > 1:
-            shape = tensordict.shape
-            tensordict_reshape = tensordict.reshape(-1)
-        else:
-            tensordict_reshape = tensordict
-
-        loss_qvalue, value_metadata = self.qvalue_loss(tensordict_reshape)
-        loss_actor, metadata_actor = self.actor_loss(tensordict_reshape)
+        loss_qvalue, value_metadata = self.qvalue_loss(tensordict)
+        loss_actor, metadata_actor = self.actor_loss(tensordict)
         loss_alpha = self.alpha_loss(log_prob=metadata_actor["log_prob"])
-        tensordict_reshape.set(self.tensor_keys.priority, value_metadata["td_error"])
+        tensordict.set(self.tensor_keys.priority, value_metadata["td_error"])
         if loss_actor.shape != loss_qvalue.shape:
             raise RuntimeError(
                 f"Losses shape mismatch: {loss_actor.shape} and {loss_qvalue.shape}"
             )
-        if shape:
-            tensordict.update(tensordict_reshape.view(shape))
         entropy = -metadata_actor["log_prob"]
         out = {
             "loss_actor": loss_actor,


### PR DESCRIPTION
## Description

Avoids flattening the inputs of `objectives` modules.

NOTE: There is one remaining module that still flattens the input, `DreamerActorLoss`. This one seems to be more complicated and should be fixed in a follow-up PR.


## Motivation and Context

Close #2338

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
