### PR TITLE
[BugFix] Allow expanding TensorDictPrimer transforms shape with parent batch size

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -142,6 +142,7 @@ from torchrl.envs.transforms.vc1 import _has_vc
 from torchrl.envs.transforms.vip import _VIPNet, VIPRewardTransform
 from torchrl.envs.utils import check_env_specs, step_mdp
 from torchrl.modules import GRUModule, LSTMModule, MLP, ProbabilisticActor, TanhNormal
+from torchrl.modules.utils import get_primers_from_module
 
 IS_WIN = platform == "win32"
 if IS_WIN:
@@ -6938,6 +6939,34 @@ class TestTensorDictPrimer(TransformBase):
         assert (
             rollout_td.get(("next", "mykey2")) == torch.tensor(1, dtype=torch.int64)
         ).all
+
+    def test_spec_shape_inplace_correction(self):
+        hidden_size = input_size = 2
+        num_layers = 1
+        model = GRUModule(
+            input_size, hidden_size, num_layers, in_key="observation", out_key="action"
+        )
+        env = TransformedEnv(
+            SerialEnv(2, lambda: GymEnv("Pendulum-v1")),
+        )
+        # These primers do not have the leading batch dimension
+        # since model is agnostic to batch dimension that will be used.
+        primers = get_primers_from_module(model)
+        for primer in primers.primers:
+            assert primers.primers.get(primer).shape == torch.Size(
+                [num_layers, hidden_size]
+            )
+        env.append_transform(primers)
+
+        # Reset should add the batch dimension to the primers
+        # since the parent exists and is batch_locked.
+        td = env.reset()
+
+        for primer in primers.primers:
+            assert primers.primers.get(primer).shape == torch.Size(
+                [2, num_layers, hidden_size]
+            )
+            assert td.get(primer).shape == torch.Size([2, num_layers, hidden_size])
 
 
 class TestTimeMaxPool(TransformBase):

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -6941,8 +6941,7 @@ class TestTensorDictPrimer(TransformBase):
         ).all
 
     def test_spec_shape_inplace_correction(self):
-        hidden_size = input_size = 2
-        num_layers = 1
+        hidden_size = input_size = num_layers = 2
         model = GRUModule(
             input_size, hidden_size, num_layers, in_key="observation", out_key="action"
         )

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -4827,16 +4827,18 @@ class TensorDictPrimer(Transform):
     ) -> TensorDictBase:
         """Sets the default values in the input tensordict.
 
-        If the parent is batch-locked, we assume that the specs have the appropriate leading
+        If the parent is batch-locked, we make sure the specs have the appropriate leading
         shape. We allow for execution when the parent is missing, in which case the
         spec shape is assumed to match the tensordict's.
-
         """
         _reset = _get_reset(self.reset_key, tensordict)
-        if self.primers.shape[: len(tensordict.shape)] != self.parent.batch_size:
+        if (
+            self.parent
+            and self.primers.shape[: len(tensordict.shape)] != self.parent.batch_size
+        ):
             try:
                 # We try to set the primer shape to the parent shape
-                self.primers.shape = tensordict.shape
+                self.primers.shape = self.parent.batch_size
             except ValueError:
                 # If we fail, we expand them to parent batch size
                 self.primers = self._expand_shape(self.primers)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -4833,6 +4833,8 @@ class TensorDictPrimer(Transform):
 
         """
         _reset = _get_reset(self.reset_key, tensordict)
+        if self.primers.shape[: len(tensordict.shape)] != tensordict.shape:
+            self.primers = self.primers.expand(self._batch_size)
         if _reset.any():
             for key, spec in self.primers.items(True, True):
                 if self.random:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -4760,7 +4760,7 @@ class TensorDictPrimer(Transform):
                 # We try to set the primer shape to the observation spec shape
                 self.primers.shape = observation_spec.shape
             except ValueError:
-                # If we fail, we expnad them to that shape
+                # If we fail, we expand them to that shape
                 self.primers = self._expand_shape(self.primers)
         device = observation_spec.device
         observation_spec.update(self.primers.clone().to(device))
@@ -4833,8 +4833,13 @@ class TensorDictPrimer(Transform):
 
         """
         _reset = _get_reset(self.reset_key, tensordict)
-        if self.primers.shape[: len(tensordict.shape)] != tensordict.shape:
-            self.primers = self.primers.expand(self._batch_size)
+        if self.primers.shape[: len(tensordict.shape)] != self.parent.batch_size:
+            try:
+                # We try to set the primer shape to the parent shape
+                self.primers.shape = tensordict.shape
+            except ValueError:
+                # If we fail, we expand them to parent batch size
+                self.primers = self._expand_shape(self.primers)
         if _reset.any():
             for key, spec in self.primers.items(True, True):
                 if self.random:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -4870,14 +4870,9 @@ class TensorDictPrimer(Transform):
         if (
             self.parent
             and self.parent.batch_locked
-            and self.primers.shape[: len(tensordict.shape)] != self.parent.batch_size
+            and self.primers.shape[: len(self.parent.shape)] != self.parent.batch_size
         ):
-            try:
-                # We try to set the primer shape to the parent shape
-                self.primers.shape = self.parent.batch_size
-            except ValueError:
-                # If we fail, we expand them to parent batch size
-                self.primers = self._expand_shape(self.primers)
+            self.primers = self._expand_shape(self.primers)
         if _reset.any():
             for key, spec in self.primers.items(True, True):
                 if self.random:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -4594,9 +4594,9 @@ class TensorDictPrimer(Transform):
 
     When used in a `TransformedEnv`, the spec shapes must match the environment's shape if
     the parent environment is batch-locked (`env.batch_locked=True`). If the spec shapes and
-    parent shapes do not match, the spec shapes are modified in place to match the leading
-    dimensions of the parent's batch size.  This adjustment is made for cases where the primer
-    shape is known during instantiation, but the batch size is not known until reset.
+    parent shapes do not match, the spec shapes are modified in-place to match the leading
+    dimensions of the parent's batch size. This adjustment is made for cases where the parent
+    batch size dimension is not known during instantiation.
 
     Examples:
         >>> from torchrl.envs.libs.gym import GymEnv

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -4592,10 +4592,11 @@ class TensorDictPrimer(Transform):
             The corresponding value has to be a TensorSpec instance indicating
             what the value must be.
 
-    When used in a TransfomedEnv, the spec shapes must match the envs shape if
-    the parent env is batch-locked (:obj:`env.batch_locked=True`).
-    If the env is not batch-locked (e.g. model-based envs), it is assumed that the batch is
-    given by the input tensordict instead.
+    When used in a `TransformedEnv`, the spec shapes must match the environment's shape if
+    the parent environment is batch-locked (`env.batch_locked=True`). If the spec shapes and
+    parent shapes do not match, the spec shapes are modified in place to match the leading
+    dimensions of the parent's batch size.  This adjustment is made for cases where the primer
+    shape is known during instantiation, but the batch size is not known until reset.
 
     Examples:
         >>> from torchrl.envs.libs.gym import GymEnv
@@ -4634,6 +4635,40 @@ class TensorDictPrimer(Transform):
         >>> print(td.get(("next", "mykey")))
         tensor([[1., 1., 1.],
                 [1., 1., 1.]])
+
+    Examples:
+        >>> from torchrl.envs.libs.gym import GymEnv
+        >>> from torchrl.envs import SerialEnv, TransformedEnv
+        >>> from torchrl.modules.utils import get_primers_from_module
+        >>> from torchrl.modules import GRUModule
+        >>> base_env = SerialEnv(2, lambda: GymEnv("Pendulum-v1"))
+        >>> env = TransformedEnv(base_env)
+        >>> model = GRUModule(input_size=2, hidden_size=2, in_key="observation", out_key="action")
+        >>> primers = get_primers_from_module(model)
+        >>> print(primers) # Primers shape is independent of the env batch size
+        TensorDictPrimer(primers=Composite(
+            recurrent_state: UnboundedContinuous(
+                shape=torch.Size([1, 2]),
+                space=ContinuousBox(
+                    low=Tensor(shape=torch.Size([1, 2]), device=cpu, dtype=torch.float32, contiguous=True),
+                    high=Tensor(shape=torch.Size([1, 2]), device=cpu, dtype=torch.float32, contiguous=True)),
+                device=cpu,
+                dtype=torch.float32,
+                domain=continuous),
+            device=None,
+            shape=torch.Size([])), default_value={'recurrent_state': 0.0}, random=None)
+        >>> env.append_transform(primers)
+        >>> print(env.reset()) # The primers are automatically expanded to match the env batch size
+        TensorDict(
+            fields={
+                done: Tensor(shape=torch.Size([2, 1]), device=cpu, dtype=torch.bool, is_shared=False),
+                observation: Tensor(shape=torch.Size([2, 3]), device=cpu, dtype=torch.float32, is_shared=False),
+                recurrent_state: Tensor(shape=torch.Size([2, 1, 2]), device=cpu, dtype=torch.float32, is_shared=False),
+                terminated: Tensor(shape=torch.Size([2, 1]), device=cpu, dtype=torch.bool, is_shared=False),
+                truncated: Tensor(shape=torch.Size([2, 1]), device=cpu, dtype=torch.bool, is_shared=False)},
+            batch_size=torch.Size([2]),
+            device=None,
+            is_shared=False)
 
     .. note:: Some TorchRL modules rely on specific keys being present in the environment TensorDicts,
         like :class:`~torchrl.modules.models.LSTM` or :class:`~torchrl.modules.models.GRU`.
@@ -4834,6 +4869,7 @@ class TensorDictPrimer(Transform):
         _reset = _get_reset(self.reset_key, tensordict)
         if (
             self.parent
+            and self.parent.batch_locked
             and self.primers.shape[: len(tensordict.shape)] != self.parent.batch_size
         ):
             try:


### PR DESCRIPTION
## Description

Often, when defining `TensorDictPrimer` transforms during environment creation, the batch size is unknown. For example when we create the transform with the` torchrl.modules.utils.get_primers_from_module` method.


In `TensorDictPrimer`, we assume that if the parent environment is batch-locked, the specs will already have the appropriate leading shape. However, this can lead to issues if the batch size is unknown at instantiation.

Maybe I am missing something here, but this PR makes sure the primer matches the parent batch size during reset, expanding it if necessary.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
