### PR TITLE
[BugFix] Support for tensor collection in the `PPOLoss`

### DIFF
--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -463,8 +463,8 @@ class PPOLoss(LossModule):
     def get_entropy_bonus(self, dist: d.Distribution) -> torch.Tensor:
         try:
             entropy = dist.entropy()
-            if is_tensor_collection(entropy) and hasattr(dist, "entropy_key"):
-                entropy = entropy.get(dist.entropy_key).unsqueeze(-1)
+            if is_tensor_collection(entropy):
+                entropy = entropy.get(dist.entropy_key)
         except NotImplementedError:
             x = dist.rsample((self.samples_mc_entropy,))
             log_prob = dist.log_prob(x)

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -463,6 +463,8 @@ class PPOLoss(LossModule):
     def get_entropy_bonus(self, dist: d.Distribution) -> torch.Tensor:
         try:
             entropy = dist.entropy()
+            if isinstance(entropy, TensorDict) and hasattr(dist, "entropy_key"):
+                entropy = entropy.get(dist.entropy_key).unsqueeze(-1)
         except NotImplementedError:
             x = dist.rsample((self.samples_mc_entropy,))
             log_prob = dist.log_prob(x)

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -463,7 +463,7 @@ class PPOLoss(LossModule):
     def get_entropy_bonus(self, dist: d.Distribution) -> torch.Tensor:
         try:
             entropy = dist.entropy()
-            if isinstance(entropy, TensorDict) and hasattr(dist, "entropy_key"):
+            if is_tensor_collection(entropy) and hasattr(dist, "entropy_key"):
                 entropy = entropy.get(dist.entropy_key).unsqueeze(-1)
         except NotImplementedError:
             x = dist.rsample((self.samples_mc_entropy,))


### PR DESCRIPTION
## Description

The function `get_entropy_bonus` was not unpacking the `entropy` from the `TensorDict`.

## Motivation and Context

When using a `CompositeDistribution`, the return type of the entropy can be either a `Tensor` or a `TensorDict` depending on the `aggregate_probabilities`. This break the `get_entropy_bonus` that expects a `Tensor`. We can unpack it accessing by the entropy key.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
