### PR TITLE
[Doc] actor docstrings

### DIFF
--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -153,14 +153,14 @@ class ProbabilisticActor(SafeProbabilisticTensorDictSequential):
             issues. If this value is out of bounds, it is projected back onto the
             desired space using the :obj:`TensorSpec.project`
             method. Default is ``False``.
-        default_interaction_type (str, optional): keyword-only argument.
+        default_interaction_type (tensordict.nn.InteractionType, optional): keyword-only argument.
             Default method to be used to retrieve
-            the output value. Should be one of: 'InteractionType.MODE', 'InteractionType.DETERMINISTIC',
-            'InteractionType.MEDIAN', 'InteractionType.MEAN' or
-            'InteractionType.RANDOM' (in which case the value is sampled
+            the output value. Should be one of: ``InteractionType.MODE``, ``InteractionType.DETERMINISTIC``,
+            ``InteractionType.MEDIAN``, ``InteractionType.MEAN`` or
+            ``InteractionType.RANDOM`` (in which case the value is sampled
             randomly from the distribution).
             TorchRL's ``ExplorationType`` class is a proxy to ``InteractionType``.
-            Defaults to is 'InteractionType.DETERMINISTIC'.
+            Defaults to ``InteractionType.DETERMINISTIC``.
 
             .. note:: When a sample is drawn, the :class:`ProbabilisticActor` instance will
               first look for the interaction mode dictated by the

--- a/torchrl/modules/tensordict_module/probabilistic.py
+++ b/torchrl/modules/tensordict_module/probabilistic.py
@@ -68,12 +68,12 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule):
             returned by the input module. If the sample is out of bounds, it is
             projected back onto the desired space using the `TensorSpec.project` method.
             Default is ``False``.
-        default_interaction_type (str, optional): default method to be used to retrieve
-            the output value. Should be one of: 'mode', 'median', 'mean' or 'random'
+        default_interaction_type (tensordict.nn.InteractionType, optional): default method to be used to retrieve
+            the output value. Should be one of: ``InteractionType.MODE``, ``InteractionType.MEDIAN``, ``InteractionType.MEAN`` or ``InteractionType.RANDOM``
             (in which case the value is sampled randomly from the distribution). Default
-            is 'mode'.
+            is ``InteractionType.MODE``.
             Note: When a sample is drawn, the :obj:`ProbabilisticTDModule` instance will
-            fist look for the interaction mode dictated by the `interaction_typ()`
+            fist look for the interaction mode dictated by the `interaction_type()`
             global function. If this returns `None` (its default value), then the
             `default_interaction_type` of the :class:`~.ProbabilisticTDModule`
             instance will be used. Note that DataCollector instances will use


### PR DESCRIPTION
## Description

Changed docstrings in `ProbabilisticActor` and `SafeProbabilisticModule` to clarify that the keyword argument `default_interaction_type` should take one of the enum values of `tensordict.nn.InteractionType`. Previous documentation made me think that I had to supply the literal string, e.g "InteractionType.RANDOM".

## Motivation and Context

Clearer documentation.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [X] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] I have updated the documentation accordingly.
