### PR TITLE
[BugFix] Fix output of `SipHash(as_tensor=False)`

### DIFF
--- a/test/test_storage_map.py
+++ b/test/test_storage_map.py
@@ -46,6 +46,15 @@ class TestHash:
         hash_b = torch.tensor(hash_module(b))
         assert (hash_a == hash_b).all()
 
+    def test_sip_hash_nontensor(self):
+        a = torch.rand((3, 2))
+        b = a.clone()
+        hash_module = SipHash(as_tensor=False)
+        hash_a = hash_module(a)
+        hash_b = hash_module(b)
+        assert len(hash_a) == 3
+        assert hash_a == hash_b
+
     @pytest.mark.parametrize("n_components", [None, 14])
     @pytest.mark.parametrize("scale", [0.001, 0.01, 1, 100, 1000])
     def test_randomprojection_hash(self, n_components, scale):

--- a/torchrl/data/map/hash.py
+++ b/torchrl/data/map/hash.py
@@ -111,7 +111,7 @@ class SipHash(Module):
             hash_value = x_i.tobytes()
             hash_values.append(hash_value)
         if not self.as_tensor:
-            return hash_value
+            return hash_values
         result = torch.tensor([hash(x) for x in hash_values], dtype=torch.int64)
         return result
 


### PR DESCRIPTION
## Description

Fix typo so that `SipHash(as_tensor=False)` returns the correct output.

## Motivation and Context

close #2663

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
