### PR TITLE
[Performance] Avoid cloning trajs in SliceSampler

### DIFF
--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -1243,7 +1243,7 @@ class SliceSampler(Sampler):
                             "Could not get a tensordict out of the storage, which is required for SliceSampler to compute the trajectories."
                         )
                 vals = self._find_start_stop_traj(
-                    trajectory=trajectory.clone(),
+                    trajectory=trajectory,
                     at_capacity=storage._is_full,
                     cursor=getattr(storage, "_last_cursor", None),
                 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2674
* #2672
* __->__ #2671
* #2670
* #2668

