### PR TITLE
[Feature] multiagent data standardization: PPO advantages

### DIFF
--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -892,14 +892,23 @@ def _standardize(
 
     """
     if eps is None:
-        eps = torch.finfo(torch.float.dtype).resolution
+        if input.dtype.is_floating_point:
+            eps = torch.finfo(torch.float).resolution
+        else:
+            eps = 1e-6
 
     len_exclude_dims = len(exclude_dims)
     if not len_exclude_dims:
         if mean is None:
             mean = input.mean()
+        else:
+            # Assume dtypes are compatible
+            mean = torch.as_tensor(mean, device=input.device)
         if std is None:
             std = input.std()
+        else:
+            # Assume dtypes are compatible
+            std = torch.as_tensor(std, device=input.device)
         return (input - mean) / std.clamp_min(eps)
 
     input_shape = input.shape

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -32,7 +32,7 @@ from packaging.version import parse
 from tensordict import unravel_key
 
 from tensordict.utils import NestedKey
-from torch import multiprocessing as mp
+from torch import multiprocessing as mp, Tensor
 
 try:
     from torch.compiler import is_compiling
@@ -873,7 +873,11 @@ class _ContextManager:
 
 
 def _standardize(
-    input, exclude_dims: Tuple[int] = (), mean=None, std=None, eps: float = None
+    input: Tensor,
+    exclude_dims: Tuple[int] = (),
+    mean: Tensor | None = None,
+    std: Tensor | None = None,
+    eps: float | None = None,
 ):
     """Standardizes the input tensor with the possibility of excluding specific dims from the statistics.
 

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -911,7 +911,7 @@ def _standardize(
         )
     if len_exclude_dims == len(input_shape):
         warnings.warn(
-            "standardize called but all dims were excluded from the statistics, returning unprocessed input"
+            "_standardize called but all dims were excluded from the statistics, returning unprocessed input"
         )
         return input
 

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -885,7 +885,7 @@ def _standardize(
 
     Args:
         input (Tensor): the input tensor to be standardized.
-        exclude_dims (Sequence[int]): dimensions to exclude from the statistics, can be negative. Default: ().
+        exclude_dims (Tuple[int]): dimensions to exclude from the statistics, can be negative. Default: ().
         mean (Tensor): a mean to be used for standardization. Must be of shape broadcastable to input. Default: None.
         std (Tensor): a standard deviation to be used for standardization. Must be of shape broadcastable to input. Default: None.
         eps (float): epsilon to be used for numerical stability. Default: float32 resolution.

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -8,7 +8,7 @@ import contextlib
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Sequence, Tuple
+from typing import Tuple
 
 import torch
 from tensordict import (
@@ -88,8 +88,9 @@ class PPOLoss(LossModule):
             Can be one of "l1", "l2" or "smooth_l1". Defaults to ``"smooth_l1"``.
         normalize_advantage (bool, optional): if ``True``, the advantage will be normalized
             before being used. Defaults to ``False``.
-        normalize_advantage_exclude_dims (Sequence[int], optional): dimensions to exclude from the advantage
-            standardization, can be negative. Useful in multiagent settings to exlude the agent dimension. Default: ().
+        normalize_advantage_exclude_dims (Tuple[int], optional): dimensions to exclude from the advantage
+            standardization. Negative dimensions are valid. This is useful in multiagent (or multiobjective) settings
+            where the agent (or objective) dimension may be excluded from the reductions. Default: ().
         separate_losses (bool, optional): if ``True``, shared parameters between
             policy and critic will only be trained on the policy loss.
             Defaults to ``False``, i.e., gradients are propagated to shared
@@ -314,7 +315,7 @@ class PPOLoss(LossModule):
         critic_coef: float = 1.0,
         loss_critic_type: str = "smooth_l1",
         normalize_advantage: bool = False,
-        normalize_advantage_exclude_dims: Sequence[int] = (),
+        normalize_advantage_exclude_dims: Tuple[int] = (),
         gamma: float = None,
         separate_losses: bool = False,
         advantage_key: str = None,
@@ -715,8 +716,9 @@ class ClipPPOLoss(PPOLoss):
             Can be one of "l1", "l2" or "smooth_l1". Defaults to ``"smooth_l1"``.
         normalize_advantage (bool, optional): if ``True``, the advantage will be normalized
             before being used. Defaults to ``False``.
-        normalize_advantage_exclude_dims (Sequence[int], optional): dimensions to exclude from the advantage
-            standardization, can be negative. Useful in multiagent settings to exlude the agent dimension. Default: ().
+        normalize_advantage_exclude_dims (Tuple[int], optional): dimensions to exclude from the advantage
+            standardization. Negative dimensions are valid. This is useful in multiagent (or multiobjective) settings
+            where the agent (or objective) dimension may be excluded from the reductions. Default: ().
         separate_losses (bool, optional): if ``True``, shared parameters between
             policy and critic will only be trained on the policy loss.
             Defaults to ``False``, i.e., gradients are propagated to shared
@@ -808,7 +810,7 @@ class ClipPPOLoss(PPOLoss):
         critic_coef: float = 1.0,
         loss_critic_type: str = "smooth_l1",
         normalize_advantage: bool = False,
-        normalize_advantage_exclude_dims: Sequence[int] = (),
+        normalize_advantage_exclude_dims: Tuple[int] = (),
         gamma: float = None,
         separate_losses: bool = False,
         reduction: str = None,
@@ -961,8 +963,9 @@ class KLPENPPOLoss(PPOLoss):
             Can be one of "l1", "l2" or "smooth_l1". Defaults to ``"smooth_l1"``.
         normalize_advantage (bool, optional): if ``True``, the advantage will be normalized
             before being used. Defaults to ``False``.
-        normalize_advantage_exclude_dims (Sequence[int], optional): dimensions to exclude from the advantage
-            standardization, can be negative. Useful in multiagent settings to exlude the agent dimension. Default: ().
+        normalize_advantage_exclude_dims (Tuple[int], optional): dimensions to exclude from the advantage
+            standardization. Negative dimensions are valid. This is useful in multiagent (or multiobjective) settings
+            where the agent (or objective) dimension may be excluded from the reductions. Default: ().
         separate_losses (bool, optional): if ``True``, shared parameters between
             policy and critic will only be trained on the policy loss.
             Defaults to ``False``, i.e., gradients are propagated to shared
@@ -1056,7 +1059,7 @@ class KLPENPPOLoss(PPOLoss):
         critic_coef: float = 1.0,
         loss_critic_type: str = "smooth_l1",
         normalize_advantage: bool = False,
-        normalize_advantage_exclude_dims: Sequence[int] = (),
+        normalize_advantage_exclude_dims: Tuple[int] = (),
         gamma: float = None,
         separate_losses: bool = False,
         reduction: str = None,

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -47,6 +47,7 @@ from torchrl.objectives.value import (
     TDLambdaEstimator,
     VTrace,
 )
+from yaml import warnings
 
 
 class PPOLoss(LossModule):
@@ -613,6 +614,15 @@ class PPOLoss(LossModule):
             )
             advantage = tensordict.get(self.tensor_keys.advantage)
         if self.normalize_advantage and advantage.numel() > 1:
+            if advantage.numel() > tensordict.batch_size.numel() and not len(
+                self.normalize_advantage_exclude_dims
+            ):
+                warnings.warn(
+                    "You requested advantage normalization and the advantage key has more dimensions"
+                    " than the tensordict batch. Make sure to pass `normalize_advantage_exclude_dims` "
+                    "if you want to keep any dimension independent while computing normalization statistics. "
+                    "If you are working in multi-agent/multi-objective settings this is highly suggested."
+                )
             advantage = _standardize(advantage, self.normalize_advantage_exclude_dims)
 
         log_weight, dist, kl_approx = self._log_weight(tensordict)
@@ -881,6 +891,15 @@ class ClipPPOLoss(PPOLoss):
             )
             advantage = tensordict.get(self.tensor_keys.advantage)
         if self.normalize_advantage and advantage.numel() > 1:
+            if advantage.numel() > tensordict.batch_size.numel() and not len(
+                self.normalize_advantage_exclude_dims
+            ):
+                warnings.warn(
+                    "You requested advantage normalization and the advantage key has more dimensions"
+                    " than the tensordict batch. Make sure to pass `normalize_advantage_exclude_dims` "
+                    "if you want to keep any dimension independent while computing normalization statistics. "
+                    "If you are working in multi-agent/multi-objective settings this is highly suggested."
+                )
             advantage = _standardize(advantage, self.normalize_advantage_exclude_dims)
 
         log_weight, dist, kl_approx = self._log_weight(tensordict)
@@ -1164,6 +1183,15 @@ class KLPENPPOLoss(PPOLoss):
             )
             advantage = tensordict_copy.get(self.tensor_keys.advantage)
         if self.normalize_advantage and advantage.numel() > 1:
+            if advantage.numel() > tensordict.batch_size.numel() and not len(
+                self.normalize_advantage_exclude_dims
+            ):
+                warnings.warn(
+                    "You requested advantage normalization and the advantage key has more dimensions"
+                    " than the tensordict batch. Make sure to pass `normalize_advantage_exclude_dims` "
+                    "if you want to keep any dimension independent while computing normalization statistics. "
+                    "If you are working in multi-agent/multi-objective settings this is highly suggested."
+                )
             advantage = _standardize(advantage, self.normalize_advantage_exclude_dims)
 
         log_weight, dist, kl_approx = self._log_weight(tensordict_copy)

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -8,7 +8,7 @@ import contextlib
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Sequence, Tuple
 
 import torch
 from tensordict import (
@@ -27,6 +27,7 @@ from tensordict.nn import (
 from tensordict.utils import NestedKey
 from torch import distributions as d
 
+from torchrl._utils import _standardize
 from torchrl.objectives.common import LossModule
 
 from torchrl.objectives.utils import (
@@ -87,6 +88,8 @@ class PPOLoss(LossModule):
             Can be one of "l1", "l2" or "smooth_l1". Defaults to ``"smooth_l1"``.
         normalize_advantage (bool, optional): if ``True``, the advantage will be normalized
             before being used. Defaults to ``False``.
+        normalize_advantage_exclude_dims (Sequence[int], optional): dimensions to exclude from the advantage
+            standardization, can be negative. Useful in multiagent settings to exlude the agent dimension. Default: ().
         separate_losses (bool, optional): if ``True``, shared parameters between
             policy and critic will only be trained on the policy loss.
             Defaults to ``False``, i.e., gradients are propagated to shared
@@ -311,6 +314,7 @@ class PPOLoss(LossModule):
         critic_coef: float = 1.0,
         loss_critic_type: str = "smooth_l1",
         normalize_advantage: bool = False,
+        normalize_advantage_exclude_dims: Sequence[int] = (),
         gamma: float = None,
         separate_losses: bool = False,
         advantage_key: str = None,
@@ -381,6 +385,8 @@ class PPOLoss(LossModule):
             self.critic_coef = None
         self.loss_critic_type = loss_critic_type
         self.normalize_advantage = normalize_advantage
+        self.normalize_advantage_exclude_dims = normalize_advantage_exclude_dims
+
         if gamma is not None:
             raise TypeError(_GAMMA_LMBDA_DEPREC_ERROR)
         self._set_deprecated_ctor_keys(
@@ -606,9 +612,7 @@ class PPOLoss(LossModule):
             )
             advantage = tensordict.get(self.tensor_keys.advantage)
         if self.normalize_advantage and advantage.numel() > 1:
-            loc = advantage.mean()
-            scale = advantage.std().clamp_min(1e-6)
-            advantage = (advantage - loc) / scale
+            advantage = _standardize(advantage, self.normalize_advantage_exclude_dims)
 
         log_weight, dist, kl_approx = self._log_weight(tensordict)
         if is_tensor_collection(log_weight):
@@ -711,6 +715,8 @@ class ClipPPOLoss(PPOLoss):
             Can be one of "l1", "l2" or "smooth_l1". Defaults to ``"smooth_l1"``.
         normalize_advantage (bool, optional): if ``True``, the advantage will be normalized
             before being used. Defaults to ``False``.
+        normalize_advantage_exclude_dims (Sequence[int], optional): dimensions to exclude from the advantage
+            standardization, can be negative. Useful in multiagent settings to exlude the agent dimension. Default: ().
         separate_losses (bool, optional): if ``True``, shared parameters between
             policy and critic will only be trained on the policy loss.
             Defaults to ``False``, i.e., gradients are propagated to shared
@@ -802,6 +808,7 @@ class ClipPPOLoss(PPOLoss):
         critic_coef: float = 1.0,
         loss_critic_type: str = "smooth_l1",
         normalize_advantage: bool = False,
+        normalize_advantage_exclude_dims: Sequence[int] = (),
         gamma: float = None,
         separate_losses: bool = False,
         reduction: str = None,
@@ -821,6 +828,7 @@ class ClipPPOLoss(PPOLoss):
             critic_coef=critic_coef,
             loss_critic_type=loss_critic_type,
             normalize_advantage=normalize_advantage,
+            normalize_advantage_exclude_dims=normalize_advantage_exclude_dims,
             gamma=gamma,
             separate_losses=separate_losses,
             reduction=reduction,
@@ -871,9 +879,7 @@ class ClipPPOLoss(PPOLoss):
             )
             advantage = tensordict.get(self.tensor_keys.advantage)
         if self.normalize_advantage and advantage.numel() > 1:
-            loc = advantage.mean()
-            scale = advantage.std().clamp_min(1e-6)
-            advantage = (advantage - loc) / scale
+            advantage = _standardize(advantage, self.normalize_advantage_exclude_dims)
 
         log_weight, dist, kl_approx = self._log_weight(tensordict)
         # ESS for logging
@@ -955,6 +961,8 @@ class KLPENPPOLoss(PPOLoss):
             Can be one of "l1", "l2" or "smooth_l1". Defaults to ``"smooth_l1"``.
         normalize_advantage (bool, optional): if ``True``, the advantage will be normalized
             before being used. Defaults to ``False``.
+        normalize_advantage_exclude_dims (Sequence[int], optional): dimensions to exclude from the advantage
+            standardization, can be negative. Useful in multiagent settings to exlude the agent dimension. Default: ().
         separate_losses (bool, optional): if ``True``, shared parameters between
             policy and critic will only be trained on the policy loss.
             Defaults to ``False``, i.e., gradients are propagated to shared
@@ -1048,6 +1056,7 @@ class KLPENPPOLoss(PPOLoss):
         critic_coef: float = 1.0,
         loss_critic_type: str = "smooth_l1",
         normalize_advantage: bool = False,
+        normalize_advantage_exclude_dims: Sequence[int] = (),
         gamma: float = None,
         separate_losses: bool = False,
         reduction: str = None,
@@ -1063,6 +1072,7 @@ class KLPENPPOLoss(PPOLoss):
             critic_coef=critic_coef,
             loss_critic_type=loss_critic_type,
             normalize_advantage=normalize_advantage,
+            normalize_advantage_exclude_dims=normalize_advantage_exclude_dims,
             gamma=gamma,
             separate_losses=separate_losses,
             reduction=reduction,
@@ -1151,9 +1161,8 @@ class KLPENPPOLoss(PPOLoss):
             )
             advantage = tensordict_copy.get(self.tensor_keys.advantage)
         if self.normalize_advantage and advantage.numel() > 1:
-            loc = advantage.mean()
-            scale = advantage.std().clamp_min(1e-6)
-            advantage = (advantage - loc) / scale
+            advantage = _standardize(advantage, self.normalize_advantage_exclude_dims)
+
         log_weight, dist, kl_approx = self._log_weight(tensordict_copy)
         neg_loss = log_weight.exp() * advantage
 


### PR DESCRIPTION
Hello!

### Context

So, in this library we frequently apply standardizations over data (also called normalization) where we subtract the mean from the data and divide it by a standard deviation.

A few places where we do this that come to mind are in the transforms (where it can be used over observations and rewards) and in the advantages in ppo. Please let me know about other places if you can think of more.

### Issue

The issue is that normally the mean and std statistics are computed over all the dimensions. But in multiagent settings, where for example a reward tensor could have an "agent" dimension, this is not the proper way to do it as different agents might have different reward distributions and applying standardization naively across them will create issues.

### Example

For example consider the case where we have 2 agents each with 2 rewards (agent_1_r = [100,200],  agent_2_r = [0,-1]), structured in a 2x2 tensor `r = torch.tensor([[100,200],[0,-1]])`

If we standardize using `mean(r)` and `std(r)`, we get `r = torch.tensor([[0.3,1.5],[-0.9,-.91]])`, which is bad

If we standardize using `mean(r, dim=1)` and `std(r,dim=1)`, hence excluding the agent dim from the statistics, we get `r = torch.tensor([[-1,1],[1,-1]])`, which is better as it does not cross pollute over agents

### Proposal 

We should adapt all places in the library where standardization is used to take a list of dimensions to exlude from the statistics. This way, multiagent users can provide the agent dimension as input and use the standardization feature

### What I did here

I did this for the advantages in PPO

To do it, I made a nice standardization util function that takes as input a list of dimensions to exlude from the standardization (a more flexible implementation of a functional layer norm)


