### PR TITLE
[Feature] Linearise reward transform

### DIFF
--- a/docs/source/reference/envs.rst
+++ b/docs/source/reference/envs.rst
@@ -826,6 +826,7 @@ to be able to create this other composition:
     GrayScale
     InitTracker
     KLRewardTransform
+    LineariseReward
     NoopResetEnv
     ObservationNorm
     ObservationTransform

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -12630,9 +12630,7 @@ class TestLineariseRewards(TransformBase):
 
         expected = sum(
             w * r
-            for w, r in zip(
-                weights, rollout.get(("next", "reward")).split(1, dim=-1), strict=True
-            )
+            for w, r in zip(weights, rollout.get(("next", "reward")).split(1, dim=-1))
         )
         torch.testing.assert_close(scalar_reward, expected)
 
@@ -12654,7 +12652,7 @@ class TestLineariseRewards(TransformBase):
         td = TensorDict({"reward": torch.randn(num_rewards)}, [])
         model(td)
 
-        expected = sum(w * r for w, r in zip(weights, td["reward"], strict=True))
+        expected = sum(w * r for w, r in zip(weights, td["reward"]))
         torch.testing.assert_close(td["scalar_reward"], expected)
 
     @pytest.mark.parametrize("rbclass", [ReplayBuffer, TensorDictReplayBuffer])

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -12703,7 +12703,7 @@ class TestLineariseRewards(TransformBase):
     )
     def test_reward_spec(
         self,
-        weights: list[float] | None,
+        weights,
         reward_spec: TensorSpec,
         expected_spec: TensorSpec,
     ) -> None:

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -84,6 +84,7 @@ from torch import multiprocessing as mp, nn, Tensor
 from torchrl._utils import _replace_last, prod
 from torchrl.data import (
     Bounded,
+    BoundedContinuous,
     Categorical,
     Composite,
     LazyTensorStorage,
@@ -94,7 +95,6 @@ from torchrl.data import (
     Unbounded,
     UnboundedContinuous,
 )
-from torchrl.data.tensor_specs import BoundedContinuous
 from torchrl.envs import (
     ActionMask,
     BinarizeReward,

--- a/torchrl/data/__init__.py
+++ b/torchrl/data/__init__.py
@@ -72,6 +72,7 @@ from .tensor_specs import (
     Binary,
     BinaryDiscreteTensorSpec,
     Bounded,
+    BoundedContinuous,
     BoundedTensorSpec,
     Categorical,
     Composite,

--- a/torchrl/envs/__init__.py
+++ b/torchrl/envs/__init__.py
@@ -69,6 +69,7 @@ from .transforms import (
     gSDENoise,
     InitTracker,
     KLRewardTransform,
+    LineariseRewards,
     MultiStepTransform,
     NoopResetEnv,
     ObservationNorm,

--- a/torchrl/envs/transforms/__init__.py
+++ b/torchrl/envs/transforms/__init__.py
@@ -32,6 +32,7 @@ from .transforms import (
     GrayScale,
     gSDENoise,
     InitTracker,
+    LineariseRewards,
     NoopResetEnv,
     ObservationNorm,
     ObservationTransform,

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -9295,11 +9295,11 @@ class LineariseRewards(Transform):
     """Transforms a multi-objective reward signal to a single-objective one via a weighted sum.
 
     Args:
-        in_keys: The keys under which the multi-objective rewards are found
-        out_keys: The keys under which single-objective rewards should be written. Defaults to `in_keys`.
+        in_keys (List[NestedKey]): The keys under which the multi-objective rewards are found.
+        out_keys (List[NestedKey], optional): The keys under which single-objective rewards should be written. Defaults to :attr:`in_keys`.
         weights: Dictates how to weight each reward when summing them. Defaults to `[1.0, 1.0, ...]`.
 
-    Warning:
+    .. warning::
         If a sequence of `in_keys` of length strictly greater than one is passed (e.g. one group for each agent in a
         multi-agent set-up), the same weights will be applied for each entry. If you need to aggregate rewards
         differently for each group, use several `AggregateRewardsTransform` in a row.
@@ -9372,7 +9372,7 @@ class LineariseRewards(Transform):
         num_weights = torch.numel(weights)
         if num_weights != num_rewards:
             raise ValueError(
-                "The number of rewards and weights should match."
+                "The number of rewards and weights should match. "
                 f"Got: {num_rewards} and {num_weights}"
             )
 
@@ -9399,7 +9399,7 @@ class LineariseRewards(Transform):
         num_weights = torch.numel(self.weights)
         if num_weights != num_rewards:
             raise ValueError(
-                "The number of rewards and weights should match."
+                "The number of rewards and weights should match. "
                 f"Got: {num_rewards} and {num_weights}."
             )
 

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -9302,7 +9302,7 @@ class LineariseRewards(Transform):
     .. warning::
         If a sequence of `in_keys` of length strictly greater than one is passed (e.g. one group for each agent in a
         multi-agent set-up), the same weights will be applied for each entry. If you need to aggregate rewards
-        differently for each group, use several `AggregateRewardsTransform` in a row.
+        differently for each group, use several :class:`~torchrl.envs.LineariseRewards` in a row.
 
     Example:
         >>> import mo_gymnasium as mo_gym

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -63,6 +63,7 @@ from torchrl._utils import (
 from torchrl.data.tensor_specs import (
     Binary,
     Bounded,
+    BoundedContinuous,
     Categorical,
     Composite,
     ContinuousBox,
@@ -9357,14 +9358,12 @@ class LineariseRewards(Transform):
             return reward_spec
 
         # The lines below are correct only if all weights are positive.
-        low = (weights * reward_spec.space.low).sum(dim=-1)
-        high = (weights * reward_spec.space.high).sum(dim=-1)
+        low = (weights * reward_spec.space.low).sum(dim=-1, keepdim=True)
+        high = (weights * reward_spec.space.high).sum(dim=-1, keepdim=True)
 
-        return Bounded(
-            shape=torch.Size([*batch_size, 1]),
+        return BoundedContinuous(
             low=low,
             high=high,
-            domain="continuous",
             device=reward_spec.device,
             dtype=reward_spec.dtype,
         )

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -4234,7 +4234,7 @@ class CatTensors(Transform):
         del_keys (bool, optional): if ``True``, the input values will be deleted after
             concatenation. Default is ``True``.
         unsqueeze_if_oor (bool, optional): if ``True``, CatTensor will check that
-            the dimension indicated exist for the tensors to concatenate. If not,
+            the indicated dimension exists for the tensors to concatenate. If not,
             the tensors will be unsqueezed along that dimension.
             Default is ``False``.
         sort (bool, optional): if ``True``, the keys will be sorted in the
@@ -7709,7 +7709,7 @@ class BurnInTransform(Transform):
 
     .. note::
         This transform expects as inputs TensorDicts with its last dimension being the
-        time dimension. It also  assumes that all provided modules can process
+        time dimension. It also assumes that all provided modules can process
         sequential data.
 
     Examples:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -9364,7 +9364,7 @@ class LineariseRewards(Transform):
 
         *batch_size, num_rewards = reward_spec.shape
         weights = (
-            torch.ones(num_rewards, device=reward_spec.device)
+            torch.ones(num_rewards, device=reward_spec.device, dtype=reward_spec.dtype)
             if self.weights is None
             else self.weights
         )

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -9325,7 +9325,7 @@ class LineariseRewards(Transform):
             ...)
         >>> td = so_env.rollout(5)
         >>> td["next", "reward"].shape
-        [5, 1]
+        torch.Size([5, 1])
     """
 
     def __init__(

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -9368,24 +9368,16 @@ class LineariseRewards(Transform):
             dtype=reward_spec.dtype,
         )
 
-    def _call(self, tensordict: TensorDictBase) -> TensorDictBase:
-        def _agg_reward(reward: Tensor) -> Tensor:
-            """Aggregates a reward Tensor according to a weighted sum."""
-            if self.weights is None:
-                return reward.sum(dim=-1)
+    def _apply_transform(self, reward: Tensor) -> TensorDictBase:
+        if self.weights is None:
+            return reward.sum(dim=-1)
 
-            *batch_size, num_rewards = reward.shape
-            num_weights = torch.numel(self.weights)
-            if num_weights != num_rewards:
-                raise ValueError(
-                    "The number of rewards and weights should match."
-                    f"Got: {num_rewards} and {num_weights}."
-                )
+        *batch_size, num_rewards = reward.shape
+        num_weights = torch.numel(self.weights)
+        if num_weights != num_rewards:
+            raise ValueError(
+                "The number of rewards and weights should match."
+                f"Got: {num_rewards} and {num_weights}."
+            )
 
-            return (self.weights * reward).sum(dim=-1)
-
-        for in_key, out_key in zip(self.in_keys, self.out_keys, strict=True):
-            agg_reward = _agg_reward(tensordict.get(in_key))
-            tensordict.set(out_key, agg_reward)
-
-        return tensordict
+        return (self.weights * reward).sum(dim=-1)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -9303,6 +9303,29 @@ class LineariseRewards(Transform):
         If a sequence of `in_keys` of length strictly greater than one is passed (e.g. one group for each agent in a
         multi-agent set-up), the same weights will be applied for each entry. If you need to aggregate rewards
         differently for each group, use several `AggregateRewardsTransform` in a row.
+
+    Example:
+        >>> import mo_gymnasium as mo_gym
+        >>> from torchrl.envs import MOGymWrapper
+        >>> mo_env = MOGymWrapper(mo_gym.make("deep-sea-treasure-v0"))
+        >>> mo_env.reward_spec
+        BoundedContinuous(
+            shape=torch.Size([2]),
+            space=ContinuousBox(
+            low=Tensor(shape=torch.Size([2]), device=cpu, dtype=torch.float32, contiguous=True),
+            high=Tensor(shape=torch.Size([2]), device=cpu, dtype=torch.float32, contiguous=True)),
+            ...)
+        >>> so_env = TransformedEnv(mo_env, LineariseRewards(in_keys=("reward",)))
+        >>> so_env.reward_spec
+        BoundedContinuous(
+            shape=torch.Size([1]),
+            space=ContinuousBox(
+                low=Tensor(shape=torch.Size([1]), device=cpu, dtype=torch.float32, contiguous=True),
+                high=Tensor(shape=torch.Size([1]), device=cpu, dtype=torch.float32, contiguous=True)),
+            ...)
+        >>> td = so_env.rollout(5)
+        >>> td["next", "reward"].shape
+        [5, 1]
     """
 
     def __init__(

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -9297,7 +9297,7 @@ class LineariseRewards(Transform):
     Args:
         in_keys (List[NestedKey]): The keys under which the multi-objective rewards are found.
         out_keys (List[NestedKey], optional): The keys under which single-objective rewards should be written. Defaults to :attr:`in_keys`.
-        weights: Dictates how to weight each reward when summing them. Defaults to `[1.0, 1.0, ...]`.
+        weights (List[float], Tensor, optional): Dictates how to weight each reward when summing them. Defaults to `[1.0, 1.0, ...]`.
 
     .. warning::
         If a sequence of `in_keys` of length strictly greater than one is passed (e.g. one group for each agent in a


### PR DESCRIPTION
## Description
Adds a transform to linearise multi-objective rewards into a single one, via a weighted sum. Essentially, this is a reproduction of mo-gym's `LinearReward ` wrapper.

## Motivation and Context
This feature provides a naive way to address multi-objective environments.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
