### PR TITLE
[Doc] Add `Stack` transform link in docs

### DIFF
--- a/docs/source/reference/envs.rst
+++ b/docs/source/reference/envs.rst
@@ -846,6 +846,7 @@ to be able to create this other composition:
     SelectTransform
     SignTransform
     SqueezeTransform
+    Stack
     StepCounter
     TargetReturn
     TensorDictPrimer


### PR DESCRIPTION
`Stack` wasn't getting included in the docs build because there was no link to it