### PR TITLE
[Feature] Log each entropy for composite distributions in PPO

### DIFF
--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -8637,7 +8637,7 @@ class TestPPO(LossModuleTestBase):
 
         loss = loss_fn(td).exclude("entropy")
         if composite_action_dist:
-            loss = loss.exclude("action-action1_entropy")
+            loss = loss.exclude("composite_entropy")
 
         sum(val for key, val in loss.items() if key.startswith("loss_")).backward()
         grad = TensorDict(dict(model.named_parameters()), []).apply(
@@ -8645,7 +8645,7 @@ class TestPPO(LossModuleTestBase):
         )
         loss2 = loss_fn2(td).exclude("entropy")
         if composite_action_dist:
-            loss2 = loss2.exclude("action-action1_entropy")
+            loss2 = loss2.exclude("composite_entropy")
 
         model.zero_grad()
         sum(val for key, val in loss2.items() if key.startswith("loss_")).backward()

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -8409,7 +8409,6 @@ class TestPPO(LossModuleTestBase):
         if isinstance(loss_fn, KLPENPPOLoss):
             kl = loss.pop("kl_approx")
             assert (kl != 0).any()
-
         loss_critic = loss["loss_critic"]
         loss_objective = loss["loss_objective"] + loss.get("loss_entropy", 0.0)
         loss_critic.backward(retain_graph=True)
@@ -8637,12 +8636,16 @@ class TestPPO(LossModuleTestBase):
             )
 
         loss = loss_fn(td).exclude("entropy")
+        if composite_action_dist:
+            loss = loss.exclude("action-action1_entropy")
 
         sum(val for key, val in loss.items() if key.startswith("loss_")).backward()
         grad = TensorDict(dict(model.named_parameters()), []).apply(
             lambda x: x.grad.clone()
         )
         loss2 = loss_fn2(td).exclude("entropy")
+        if composite_action_dist:
+            loss2 = loss2.exclude("action-action1_entropy")
 
         model.zero_grad()
         sum(val for key, val in loss2.items() if key.startswith("loss_")).backward()

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -684,7 +684,7 @@ class PPOLoss(LossModule):
             entropy = self._get_entropy(dist)
             if is_tensor_collection(entropy):
                 # Reports the entropy of each action head.
-                td_out.set("composite_entropy", entropy)
+                td_out.set("composite_entropy", entropy.detach())
                 entropy = _sum_td_features(entropy)
             td_out.set("entropy", entropy.detach().mean())  # for logging
             td_out.set("loss_entropy", -self.entropy_coef * entropy)
@@ -984,7 +984,7 @@ class ClipPPOLoss(PPOLoss):
             entropy = self._get_entropy(dist)
             if is_tensor_collection(entropy):
                 # Reports the entropy of each action head.
-                td_out.set("composite_entropy", entropy)
+                td_out.set("composite_entropy", entropy.detach())
                 entropy = _sum_td_features(entropy)
             td_out.set("entropy", entropy.detach().mean())  # for logging
             td_out.set("loss_entropy", -self.entropy_coef * entropy)
@@ -1297,7 +1297,7 @@ class KLPENPPOLoss(PPOLoss):
             entropy = self._get_entropy(dist)
             if is_tensor_collection(entropy):
                 # Reports the entropy of each action head.
-                td_out.set("composite_entropy", entropy)
+                td_out.set("composite_entropy", entropy.detach())
                 entropy = _sum_td_features(entropy)
             td_out.set("entropy", entropy.detach().mean())  # for logging
             td_out.set("loss_entropy", -self.entropy_coef * entropy)

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -687,8 +687,7 @@ class PPOLoss(LossModule):
                 for head_key, head_entropy in entropy.items(
                     include_nested=True, leaves_only=True
                 ):
-                    head_prefix = head_key[0] if len(head_key) == 1 else head_key[-2]
-                    td_out.set(f"{head_prefix}_entropy", head_entropy.detach().mean())
+                    td_out.set("-".join(head_key), head_entropy.detach().mean())
                 entropy = _sum_td_features(entropy)
             td_out.set("entropy", entropy.detach().mean())  # for logging
             td_out.set("loss_entropy", -self.entropy_coef * entropy)
@@ -991,8 +990,7 @@ class ClipPPOLoss(PPOLoss):
                 for head_key, head_entropy in entropy.items(
                     include_nested=True, leaves_only=True
                 ):
-                    head_prefix = head_key[0] if len(head_key) == 1 else head_key[-2]
-                    td_out.set(f"{head_prefix}_entropy", head_entropy.detach().mean())
+                    td_out.set("-".join(head_key), head_entropy.detach().mean())
                 entropy = _sum_td_features(entropy)
             td_out.set("entropy", entropy.detach().mean())  # for logging
             td_out.set("loss_entropy", -self.entropy_coef * entropy)
@@ -1308,8 +1306,7 @@ class KLPENPPOLoss(PPOLoss):
                 for head_key, head_entropy in entropy.items(
                     include_nested=True, leaves_only=True
                 ):
-                    head_prefix = head_key[0] if len(head_key) == 1 else head_key[-2]
-                    td_out.set(f"{head_prefix}_entropy", head_entropy.detach().mean())
+                    td_out.set("-".join(head_key), head_entropy.detach().mean())
                 entropy = _sum_td_features(entropy)
             td_out.set("entropy", entropy.detach().mean())  # for logging
             td_out.set("loss_entropy", -self.entropy_coef * entropy)

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -683,11 +683,8 @@ class PPOLoss(LossModule):
         if self.entropy_bonus:
             entropy = self._get_entropy(dist)
             if is_tensor_collection(entropy):
-                # Logs the entropy of each action head.
-                for head_key, head_entropy in entropy.items(
-                    include_nested=True, leaves_only=True
-                ):
-                    td_out.set("-".join(head_key), head_entropy.detach().mean())
+                # Reports the entropy of each action head.
+                td_out.set("composite_entropy", entropy)
                 entropy = _sum_td_features(entropy)
             td_out.set("entropy", entropy.detach().mean())  # for logging
             td_out.set("loss_entropy", -self.entropy_coef * entropy)
@@ -986,11 +983,8 @@ class ClipPPOLoss(PPOLoss):
         if self.entropy_bonus:
             entropy = self._get_entropy(dist)
             if is_tensor_collection(entropy):
-                # Logs the entropy of each action head.
-                for head_key, head_entropy in entropy.items(
-                    include_nested=True, leaves_only=True
-                ):
-                    td_out.set("-".join(head_key), head_entropy.detach().mean())
+                # Reports the entropy of each action head.
+                td_out.set("composite_entropy", entropy)
                 entropy = _sum_td_features(entropy)
             td_out.set("entropy", entropy.detach().mean())  # for logging
             td_out.set("loss_entropy", -self.entropy_coef * entropy)
@@ -1302,11 +1296,8 @@ class KLPENPPOLoss(PPOLoss):
         if self.entropy_bonus:
             entropy = self._get_entropy(dist)
             if is_tensor_collection(entropy):
-                # Logs the entropy of each action head.
-                for head_key, head_entropy in entropy.items(
-                    include_nested=True, leaves_only=True
-                ):
-                    td_out.set("-".join(head_key), head_entropy.detach().mean())
+                # Reports the entropy of each action head.
+                td_out.set("composite_entropy", entropy)
                 entropy = _sum_td_features(entropy)
             td_out.set("entropy", entropy.detach().mean())  # for logging
             td_out.set("loss_entropy", -self.entropy_coef * entropy)


### PR DESCRIPTION
## Description

This PR enables PPO to log the entropy of each individual head of a composite policy separately.  

Concretely, for a composite distribution with, say, a nested discrete and continuous head, the `td_out` is augmented with some detached values.
```python
>>> loss = PPO(td)
>>> loss.keys()
[..., entropy, discrete-head-entropy, continuous-head-entropy, ...]
```
## Motivation and Context

This is an extremely useful debugging tool when training composite policies.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
