### PR TITLE
[Bug] Fixes bug in GAE advantage estimation when `gammalmbda` is a Tensor

### DIFF
--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -132,7 +132,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
             sample_log_prob (NestedKey): The key in the input tensordict that
                 indicates the log probability of the sampled action.
                 Defaults to ``"sample_log_prob"`` when :func:`~tensordict.nn.composite_lp_aggregate` returns `True`,
-                `"action_log_prob"`  otherwise.
+                `"action_log_prob"` otherwise.
         """
 
         advantage: NestedKey = "advantage"
@@ -990,7 +990,7 @@ class TDLambdaEstimator(ValueEstimatorBase):
             Defaults to ``torch.get_default_device()``.
         time_dim (int, optional): the dimension corresponding to the time
             in the input tensordict. If not provided, defaults to the dimension
-            markes with the ``"time"`` name if any, and to the last dimension
+            marked with the ``"time"`` name if any, and to the last dimension
             otherwise. Can be overridden during a call to
             :meth:`~.value_estimate`.
             Negative dimensions are considered with respect to the input
@@ -1528,7 +1528,7 @@ class GAE(ValueEstimatorBase):
 class VTrace(ValueEstimatorBase):
     """A class wrapper around V-Trace estimate functional.
 
-    Refer to "IMPALA: Scalable Distributed Deep-RL with Importance Weighted  Actor-Learner Architectures"
+    Refer to "IMPALA: Scalable Distributed Deep-RL with Importance Weighted Actor-Learner Architectures"
     :ref:`here <https://arxiv.org/abs/1802.01561>`_ for more context.
 
     Keyword Args:
@@ -1570,7 +1570,7 @@ class VTrace(ValueEstimatorBase):
             Defaults to ``torch.get_default_device()``.
         time_dim (int, optional): the dimension corresponding to the time
             in the input tensordict. If not provided, defaults to the dimension
-            markes with the ``"time"`` name if any, and to the last dimension
+            marked with the ``"time"`` name if any, and to the last dimension
             otherwise. Can be overridden during a call to
             :meth:`~.value_estimate`.
             Negative dimensions are considered with respect to the input

--- a/torchrl/objectives/value/functional.py
+++ b/torchrl/objectives/value/functional.py
@@ -345,7 +345,6 @@ def vec_generalized_advantage_estimate(
         first_below_thr = torch.where(first_below_thr)[0][0].item()
         gammalmbdas = gammalmbdas[..., :first_below_thr, :]
 
-    not_terminated = (~terminated).to(dtype)
     td0 = reward + not_terminated * gamma * next_state_value - state_value
 
     if len(batch_size) > 1:


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context

The vectorial implementation of GAE was using `done` to compute the exponential averaging weights instead of `terminated`.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
