### PR TITLE
Fixed VideoRecorder crash when passing fps

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -131,6 +131,7 @@ from torchrl.envs.transforms.vip import _VIPNet, VIPRewardTransform
 from torchrl.envs.utils import check_env_specs, MarlGroupMapType, step_mdp
 from torchrl.modules import GRUModule, LSTMModule, MLP, ProbabilisticActor, TanhNormal
 from torchrl.modules.utils import get_primers_from_module
+from torchrl.record.recorder import VideoRecorder
 
 if os.getenv("PYTORCH_TEST_FBCODE"):
     from pytorch.rl.test._utils_internal import (  # noqa
@@ -13976,6 +13977,14 @@ class TestTimer(TransformBase):
 
     def test_transform_inverse(self):
         raise pytest.skip("Tested elsewhere")
+
+
+class TestVideoRecorder:
+    # TODO: add more tests
+    def test_can_init_with_fps(self):
+        recorder = VideoRecorder(None, None, fps=30)
+
+        assert recorder is not None
 
 
 if __name__ == "__main__":

--- a/torchrl/record/recorder.py
+++ b/torchrl/record/recorder.py
@@ -121,7 +121,7 @@ class VideoRecorder(ObservationTransform):
         video_kwargs = {}
         video_kwargs.update(kwargs)
         if fps is not None:
-            self.video_kwargs["fps"] = fps
+            video_kwargs["fps"] = fps
         self.video_kwargs = video_kwargs
         self.iter = 0
         self.skip = skip


### PR DESCRIPTION
## Description
Small fix to prevent a crash in VideoRecorder

## Motivation and Context  
Fixes https://github.com/pytorch/rl/issues/2826
When creating a VideoRecorder with the latest torchrl version, we get a crash if we pass `fps` argument since `self.video_kwargs` is not set yet we try to set `self.video_kwargs['fps'] = fps`
- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [] My change requires a change to the documentation.
- [ x ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [] I have updated the documentation accordingly.
