### PR TITLE
[Setup] Remove `distutils` imports

### DIFF
--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -18,7 +18,6 @@ import traceback
 import warnings
 from contextlib import nullcontext
 from copy import copy
-from distutils.util import strtobool
 from functools import wraps
 from importlib import import_module
 from typing import Any, Callable, cast, TypeVar
@@ -34,6 +33,21 @@ try:
     from torch.compiler import is_compiling
 except ImportError:
     from torch._dynamo import is_compiling
+
+
+def strtobool(val: Any) -> bool:
+    """Convert a string representation of truth to a boolean.
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values are 'n', 'no', 'f', 'false', 'off', and '0'.
+    Raises ValueError if 'val' is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    if val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    raise ValueError(f"Invalid truth value {val!r}")
+
 
 LOGGING_LEVEL = os.environ.get("RL_LOGGING_LEVEL", "INFO")
 logger = logging.getLogger("torchrl")


### PR DESCRIPTION
## Description

`setuptools` is no longer available by default starting in Python 3.12. As such, `distutils` is no longer available. `setuptools` still comes as part of `torch`, making it a transitive dependency for `torchrl`. While `setuptools` and `distutils` can still be used as part of the build process, this PR removes all `distutils` imports inside the code. Effectively, it is only about re-implementing the helper function `strtobool`.
