### PR TITLE
[BugFix] Tree make node fix

### DIFF
--- a/test/test_storage_map.py
+++ b/test/test_storage_map.py
@@ -350,6 +350,21 @@ class TestTree:
         edges_check = {(0, 1), (0, 2), (1, 3), (1, 4), (2, 5), (2, 6)}
         assert edges == edges_check
 
+    def test_tree_constructor(self):
+        td = TensorDict({"obs": torch.tensor([0])})
+        tree = Tree(node_data=td)
+        assert tree.node_data is not None
+
+    def test_make_node_with_kwarg(self):
+        td = TensorDict({"obs": torch.tensor([0])})
+        tree = Tree.make_node(data=td)
+        assert tree.node_data is not None
+
+    def test_make_node_with_no_kwarg(self):
+        td = TensorDict({"obs": torch.tensor([0])})
+        tree = Tree.make_node(td)
+        assert tree.node_data is not None
+
 
 class TestMCTSForest:
     def dummy_rollouts(self) -> Tuple[TensorDict, ...]:

--- a/test/test_storage_map.py
+++ b/test/test_storage_map.py
@@ -350,18 +350,14 @@ class TestTree:
         edges_check = {(0, 1), (0, 2), (1, 3), (1, 4), (2, 5), (2, 6)}
         assert edges == edges_check
 
-    def test_tree_constructor(self):
+    def test_make_node(self):
         td = TensorDict({"obs": torch.tensor([0])})
         tree = Tree(node_data=td)
         assert tree.node_data is not None
 
-    def test_make_node_with_kwarg(self):
-        td = TensorDict({"obs": torch.tensor([0])})
         tree = Tree.make_node(data=td)
         assert tree.node_data is not None
 
-    def test_make_node_with_no_kwarg(self):
-        td = TensorDict({"obs": torch.tensor([0])})
         tree = Tree.make_node(td)
         assert tree.node_data is not None
 

--- a/torchrl/data/llm/__init__.py
+++ b/torchrl/data/llm/__init__.py
@@ -11,7 +11,14 @@ from .dataset import (
 )
 from .prompt import PromptData, PromptTensorDictTokenizer
 from .reward import PairwiseDataset, RewardData
-from .utils import AdaptiveKLController, ConstantKLController, RolloutFromModel, LLMData, LLMOutput, LLMInput
+from .utils import (
+    AdaptiveKLController,
+    ConstantKLController,
+    LLMData,
+    LLMInput,
+    LLMOutput,
+    RolloutFromModel,
+)
 
 __all__ = [
     "AdaptiveKLController",

--- a/torchrl/data/llm/utils.py
+++ b/torchrl/data/llm/utils.py
@@ -543,7 +543,9 @@ class RolloutFromModel:
             while len(self._kl_queue):
                 self._kl_queue.remove(self._kl_queue[0])
 
+
 LLMInpOut = TypeVar("LLMInpOut")
+
 
 class LLMInput(TensorClass["nocast"]):
     """Represents the input to a Large Language Model (LLM).
@@ -557,10 +559,12 @@ class LLMInput(TensorClass["nocast"]):
     .. seealso:: :class:`~torchrl.data.LLMOutput` and :class:`~torchrl.data.LLMData`.
 
     """
+
     tokens: torch.Tensor
     attention_mask: torch.Tensor | None = None
     token_list: list[int] | list[list[int]] | None = None
     text: str | list[str] | None = None
+
 
 class LLMOutput(TensorClass["nocast"]):
     """Represents the output from a Large Language Model (LLM).
@@ -581,6 +585,7 @@ class LLMOutput(TensorClass["nocast"]):
     .. seealso:: :class:`~torchrl.data.LLMInput` and :class:`~torchrl.data.LLMData`.
 
     """
+
     tokens: torch.Tensor
     tokens_response: torch.Tensor | None = None
     token_list: list[int] | list[list[int]] | None = None
@@ -593,6 +598,7 @@ class LLMOutput(TensorClass["nocast"]):
     def from_vllm_output(cls: type[LLMInpOut], vllm_output) -> LLMInpOut:
         # placeholder
         raise NotImplementedError
+
 
 class LLMData(TensorClass["nocast"]):
     """Represents the input or output of a Large Language Model (LLM).
@@ -619,6 +625,7 @@ class LLMData(TensorClass["nocast"]):
     .. seealso:: :class:`~torchrl.data.LLMInput` and :class:`~torchrl.data.LLMOutput`.
 
     """
+
     tokens: torch.Tensor
     tokens_response: torch.Tensor | None = None
     attention_mask: torch.Tensor | None = None

--- a/torchrl/data/map/tree.py
+++ b/torchrl/data/map/tree.py
@@ -122,7 +122,7 @@ class Tree(TensorClass["nocast"]):
         return cls(
             count=torch.zeros(()),
             wins=torch.zeros(()),
-            node=data.exclude("action", "next"),
+            node_data=data.exclude("action", "next"),
             rollout=rollout,
             subtree=subtree,
             device=device,


### PR DESCRIPTION
## Description

Calling Tree.make_node was resulting in `TypeError: Tree.__init__() got an unexpected keyword argument 'node'.`

It looks as though it's because of a kwarg being passed as "node" instead of "node_data" at the end of the function so I renamed it. I added some tests to show this but it seemed a bit over the top to keep 3 separate tests for such a small thing so I combined them afterwards.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.

Thanks :)