### PR TITLE
[Bugfix] Fix VecNorm eps usage

### DIFF
--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -6673,8 +6673,8 @@ class VecNorm(Transform):
             )
 
         mean = _sum / _count
-        std = (_ssq / _count - mean.pow(2)).clamp_min(self.eps).sqrt()
-        return (value - mean) / std.clamp_min(self.eps)
+        std = (_ssq / _count - mean.pow(2)).sqrt().clamp_min(self.eps)
+        return (value - mean) / std
 
     def to_observation_norm(self) -> Compose | ObservationNorm:
         """Converts VecNorm into an ObservationNorm class that can be used at inference time.


### PR DESCRIPTION
## Description

In the documentation, `eps` in `VecNorm` is described to be the lower bound of std, but it is done before the `sqrt()` operation, meaning if `eps = 0.0001` then the lower bound of `std` is `0.01`. There is also an additional clamp in the return. I kept the clamp in the `std` so that it can be the same value when using `to_observation_norm()`. 

## Motivation and Context

From reading the docstring, I set the `eps` based on my interpretation, but the actual value was different than I expected.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.

