### PR TITLE
[Refactor] MaskedCategorical cross_entropy usage for faster loss

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -488,6 +488,46 @@ class TestMaskedCategorical:
         sample_probs = torch.bincount(samples) / num_samples
         torch.testing.assert_close(sample_probs, ref_probs, rtol=1e-5, atol=1e-2)
 
+    @pytest.mark.parametrize("neg_inf", [-1e20, float("-inf")])
+    @pytest.mark.parametrize("sparse", [False, True])
+    @pytest.mark.parametrize("ndim", [2, 1, 3])
+    def test_crossentropy(self, sparse: bool, neg_inf: float, ndim: int):
+        torch.manual_seed(0)
+        logits = torch.randn(4).log_softmax(dim=-1)
+        # probs = logits.exp()
+        mask = torch.tensor([True, False, True, True])
+        indices = torch.tensor([0, 2, 3])
+
+        if ndim >= 2:
+            mask = mask.unsqueeze(0)
+            logits = logits.unsqueeze(0)
+            indices = indices.unsqueeze(0)
+        if ndim == 3:
+            mask = mask.unsqueeze(0)
+            logits = logits.unsqueeze(0)
+            indices = indices.unsqueeze(0)
+
+        dist_ce = MaskedCategorical(
+            logits=logits,
+            neg_inf=neg_inf,
+            mask=mask if not sparse else None,
+            indices=indices if sparse else None,
+            use_cross_entropy=True,
+        )
+        dist = MaskedCategorical(
+            logits=logits,
+            neg_inf=neg_inf,
+            mask=mask if not sparse else None,
+            indices=indices if sparse else None,
+            use_cross_entropy=False,
+        )
+        data = torch.tensor(0)
+        if ndim >= 2:
+            data = data.unsqueeze(0)
+        if ndim == 3:
+            data = data.unsqueeze(0)
+        torch.testing.assert_close(dist.log_prob(data), dist_ce.log_prob(data))
+
 
 class TestOneHotCategorical:
     def test_one_hot(self):

--- a/torchrl/modules/__init__.py
+++ b/torchrl/modules/__init__.py
@@ -93,7 +93,7 @@ from .tensordict_module import (
 )
 from .utils import get_primers_from_module
 from .planners import CEMPlanner, MPCPlannerBase, MPPIPlanner  # usort:skip
-from .llm import TransformersWrapper, vLLMWrapper
+from .llm import CategoricalSequential, TransformersWrapper, vLLMWrapper
 
 __all__ = [
     "Actor",
@@ -109,6 +109,7 @@ __all__ = [
     "Conv3dNet",
     "ConvNet",
     "DTActor",
+    "CategoricalSequential",
     "DdpgCnnActor",
     "DdpgCnnQNet",
     "DdpgMlpActor",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2884
* #2883
* __->__ #2882
* #2881

