### PR TITLE
[BE] `_set_seed` returns `None` + type annotations

### DIFF
--- a/docs/source/reference/envs.rst
+++ b/docs/source/reference/envs.rst
@@ -814,7 +814,7 @@ Here is a working example:
     ...         reward = self.full_reward_spec.zero()
     ...         return observation.update(done).update(reward)
     ...
-    ...     def _set_seed(self, seed: Optional[int]):
+    ...     def _set_seed(self, seed: Optional[int]) -> None:
     ...         self.manual_seed = seed
     ...         return seed
     >>> env = EnvWithDynamicSpec()

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -128,29 +128,29 @@ class _MockEnv(EnvBase):
         self.is_closed = False
 
     @property
-    def maxstep(self):
+    def maxstep(self) -> int:
         return 100
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         self.seed = seed
         self.counter = seed % 17  # make counter a small number
 
-    def custom_fun(self):
+    def custom_fun(self) -> int:
         return 0
 
     custom_attr = 1
 
     @property
-    def custom_prop(self):
+    def custom_prop(self) -> int:
         return 2
 
     @property
-    def custom_td(self):
+    def custom_td(self) -> TensorDict:
         return TensorDict({"a": torch.zeros(3)}, [])
 
 
 class MockSerialEnv(EnvBase):
-    """A simple counting env that is reset after a predifined max number of steps."""
+    """A simple counting env that is reset after a predefined max number of steps."""
 
     @classmethod
     def __new__(
@@ -219,13 +219,13 @@ class MockSerialEnv(EnvBase):
         super().__init__(device=device)
         self.is_closed = False
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         assert seed >= 1
         self.seed = seed
         self.counter = seed % 17  # make counter a small number
         self.max_val = max(self.counter + 100, self.counter * 2)
 
-    def _step(self, tensordict):
+    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
         self.counter += 1
         n = torch.tensor(
             [self.counter], device=self.device, dtype=torch.get_default_dtype()
@@ -341,13 +341,13 @@ class MockBatchedLockedEnv(EnvBase):
 
     rand_step = MockSerialEnv.rand_step
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         assert seed >= 1
         self.seed = seed
         self.counter = seed % 17  # make counter a small number
         self.max_val = max(self.counter + 100, self.counter * 2)
 
-    def _step(self, tensordict):
+    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
         if len(self.batch_size):
             leading_batch_size = (
                 tensordict.shape[: -len(self.batch_size)]
@@ -506,7 +506,7 @@ class StateLessCountingEnv(EnvBase):
             device=tensordict.device,
         )
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         ...
 
 
@@ -738,7 +738,7 @@ class DiscreteActionVecPolicy(TensorDictModuleBase):
         obs = tensordict.get(*self.in_keys)
         return obs
 
-    def __call__(self, tensordict):
+    def __call__(self, tensordict: TensorDictBase) -> TensorDictBase:
         obs = self._get_in_obs(tensordict)
         max_obs = (obs == obs.max(dim=-1, keepdim=True)[0]).cumsum(-1).argmax(-1)
         k = tensordict.get(*self.in_keys).shape[-1]
@@ -1106,7 +1106,7 @@ class CountingEnv(EnvBase):
             torch.zeros((*self.batch_size, 1), device=self.device, dtype=torch.int),
         )
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         torch.manual_seed(seed)
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
@@ -1285,7 +1285,7 @@ class MultiAgentCountingEnv(EnvBase):
             torch.zeros((*self.batch_size, 1), device=self.device, dtype=torch.int),
         )
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         torch.manual_seed(seed)
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
@@ -1611,7 +1611,7 @@ class CountingBatchedEnv(EnvBase):
         elif start_val.numel() <= 1:
             self.start_val = start_val.expand_as(self.count)
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         torch.manual_seed(seed)
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
@@ -1827,7 +1827,7 @@ class HeterogeneousCountingEnv(EnvBase):
 
         return td
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         torch.manual_seed(seed)
 
 
@@ -2058,7 +2058,7 @@ class MultiKeyCountingEnv(EnvBase):
         assert td.batch_size == self.batch_size
         return td
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         torch.manual_seed(seed)
 
 
@@ -2095,8 +2095,8 @@ class EnvWithMetadata(EnvBase):
         data.update(self._saved_full_reward_spec.zero())
         return data
 
-    def _set_seed(self, seed: int | None):
-        return seed
+    def _set_seed(self, seed: int | None) -> None:
+        ...
 
 
 class AutoResettingCountingEnv(CountingEnv):
@@ -2221,9 +2221,8 @@ class EnvWithDynamicSpec(EnvBase):
         reward = self.full_reward_spec.zero()
         return observation.update(done).update(reward)
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         self.manual_seed = seed
-        return seed
 
 
 class EnvWithScalarAction(EnvBase):
@@ -2291,7 +2290,7 @@ class EnvWithScalarAction(EnvBase):
             ),
         )
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         ...
 
 
@@ -2305,7 +2304,7 @@ class EnvThatDoesNothing(EnvBase):
     ) -> TensorDictBase:
         return TensorDict(batch_size=self.batch_size, device=self.device)
 
-    def _set_seed(self, seed):
+    def _set_seed(self, seed: int | None) -> None:
         ...
 
 
@@ -2339,10 +2338,9 @@ class Str2StrEnv(EnvBase):
     def get_random_string(self):
         return get_random_string(self.min_size, self.max_size)
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         random.seed(seed)
         torch.manual_seed(0)
-        return seed
 
 
 class EnvThatErrorsAfter10Iters(EnvBase):
@@ -2367,7 +2365,7 @@ class EnvThatErrorsAfter10Iters(EnvBase):
             .update(self.full_reward_spec.zero())
         )
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         ...
 
 

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -915,7 +915,7 @@ class EnvThatWaitsFor1Sec(EnvBase):
             .update(self.full_reward_spec.zero())
         )
 
-    def _set_seed(self, seed: Optional[int]):
+    def _set_seed(self, seed: Optional[int]) -> None:
         ...
 
 if __name__ == "__main__":
@@ -1617,8 +1617,8 @@ class TestCollectorDevices:
                     device=None,
                 )
 
-        def _set_seed(self, seed: int | None = None):
-            return seed
+        def _set_seed(self, seed: int | None = None) -> None:
+            ...
 
     class EnvWithDevice(EnvBase):
         def __init__(self, default_device):
@@ -1674,8 +1674,8 @@ class TestCollectorDevices:
                     device=self.default_device,
                 )
 
-        def _set_seed(self, seed: int | None = None):
-            return seed
+        def _set_seed(self, seed: int | None = None) -> None:
+            ...
 
     class DeviceLessPolicy(TensorDictModuleBase):
         in_keys = ["observation"]
@@ -1840,8 +1840,8 @@ class TestCollectorDevices:
         def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
             return self.full_done_specs.zeros().update(self.observation_spec.zeros())
 
-        def _set_seed(self, seed: int | None):
-            return seed
+        def _set_seed(self, seed: int | None) -> None:
+            ...
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="no cuda device")
     @pytest.mark.parametrize("env_device", ["cuda:0", "cpu"])
@@ -2660,8 +2660,8 @@ class TestUpdateParams:
                 {"state": self.state.clone()}, self.batch_size, device=self.device
             )
 
-        def _set_seed(self, seed):
-            return seed
+        def _set_seed(self, seed: int | None) -> None:
+            ...
 
     class Policy(TensorDictModuleBase):
         def __init__(self):

--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -280,7 +280,7 @@ class MARLEnv(EnvBase):
     def _reset(self, tensordic):
         ...
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         ...
 
 

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -291,7 +291,7 @@ class TestEnvBase:
         ) -> TensorDictBase:
             ...
 
-        def _set_seed(self, seed: int | None):
+        def _set_seed(self, seed: int | None) -> None:
             ...
 
     def test_env_lock(self):
@@ -453,9 +453,8 @@ class TestEnvBase:
                 )
                 self.seed = 0
 
-            def _set_seed(self, seed):
+            def _set_seed(self, seed: int | None) -> None:
                 self.seed = seed
-                return seed
 
             def _reset(self, tensordict):
                 td = self.observation_spec.zero().update(self.done_spec.zero())

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -289,8 +289,8 @@ class TestGym:
                 batch_size=[],
             )
 
-        def _set_seed(self, seed):
-            return seed + 1
+        def _set_seed(self, seed: int | None) -> None:
+            ...
 
     @implement_for("gym", None, "0.18")
     def _make_spec(self, batch_size, cat, cat_shape, multicat, multicat_shape):

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -4329,8 +4329,8 @@ class TestExcludeTransform(TransformBase):
                 {"done": torch.zeros(1, dtype=torch.bool)}
             )
 
-        def _set_seed(self, seed):
-            return seed + 1
+        def _set_seed(self, seed: int | None) -> None:
+            ...
 
     def test_single_trans_env_check(self):
         t = Compose(
@@ -4567,8 +4567,8 @@ class TestSelectTransform(TransformBase):
                 {"done": torch.zeros(1, dtype=torch.bool)}
             )
 
-        def _set_seed(self, seed):
-            return seed + 1
+        def _set_seed(self, seed: int | None) -> None:
+            ...
 
     def test_single_trans_env_check(self):
         t = Compose(
@@ -9517,7 +9517,7 @@ class TestVecNormV2:
             tensordict["reward"] = self.reward_spec.rand()
             return tensordict
 
-        def _set_seed(self, seed: int | None):
+        def _set_seed(self, seed: int | None) -> None:
             ...
 
     @pytest.mark.parametrize("batched", [False, True])
@@ -11880,8 +11880,8 @@ class TestActionMask(TransformBase):
                 td.set("done", ~(mask.any().view(1)))
                 return td
 
-            def _set_seed(self, seed):
-                return seed
+            def _set_seed(self, seed: int | None) -> None:
+                ...
 
         return MaskedEnv
 
@@ -13050,8 +13050,8 @@ class TestRemoveEmptySpecs(TransformBase):
                 .update(self.full_reward_spec.rand())
             )
 
-        def _set_seed(self, seed):
-            return seed + 1
+        def _set_seed(self, seed: int | None) -> None:
+            ...
 
     def test_single_trans_env_check(self):
         env = TransformedEnv(self.DummyEnv(), RemoveEmptySpecs())
@@ -13261,8 +13261,8 @@ class TestBatchSizeTransform(TransformBase):
             result.update(self.full_reward_spec.zero(tensordict.batch_size))
             return result
 
-        def _set_seed(self, seed: int):
-            pass
+        def _set_seed(self, seed: int | None) -> None:
+            ...
 
     @classmethod
     def reset_func(tensordict, tensordict_reset, env):
@@ -13886,7 +13886,7 @@ class TestLineariseRewards(TransformBase):
                 }
             )
 
-        def _set_seed(self) -> None:
+        def _set_seed(self, seed: int | None = None) -> None:
             pass
 
     @pytest.mark.parametrize(

--- a/torchrl/envs/async_envs.py
+++ b/torchrl/envs/async_envs.py
@@ -305,7 +305,7 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
             return results, *other_results, idx
         return results, idx
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -878,8 +878,9 @@ class BatchedEnvBase(EnvBase):
     def _shutdown_workers(self) -> None:
         raise NotImplementedError
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         """This method is not used in batched envs."""
+        pass
 
     @lazy
     def start(self) -> None:

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -2899,7 +2899,7 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
         return seed
 
     @abc.abstractmethod
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         raise NotImplementedError
 
     def set_state(self):

--- a/torchrl/envs/custom/chess.py
+++ b/torchrl/envs/custom/chess.py
@@ -612,7 +612,7 @@ class ChessEnv(EnvBase, metaclass=_ChessMeta):
             dest.set("pixels", self._get_tensor_image(board=self.board))
         return dest
 
-    def _set_seed(self, *args, **kwargs):
+    def _set_seed(self, *args, **kwargs) -> None:
         ...
 
     def cardinality(self, tensordict: TensorDictBase | None = None) -> int:

--- a/torchrl/envs/custom/llm.py
+++ b/torchrl/envs/custom/llm.py
@@ -577,7 +577,7 @@ class LLMEnv(EnvBase):
             raise NotImplementedError()
         return tensordict
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         return seed
 
 
@@ -766,7 +766,7 @@ class LLMHashingEnv(EnvBase):
         )
         return out.update(kwargs)
 
-    def _set_seed(self, *args):
+    def _set_seed(self, *args) -> None:
         """Sets the seed for the environment's randomness.
 
         .. note:: This environment has no randomness, so this method does nothing.

--- a/torchrl/envs/custom/pendulum.py
+++ b/torchrl/envs/custom/pendulum.py
@@ -365,7 +365,7 @@ class PendulumEnv(EnvBase):
         )
         return composite
 
-    def _set_seed(self, seed: int):
+    def _set_seed(self, seed: int) -> None:
         rng = torch.Generator(device=self.device)
         rng.manual_seed(seed)
         self.rng = rng

--- a/torchrl/envs/custom/tictactoeenv.py
+++ b/torchrl/envs/custom/tictactoeenv.py
@@ -251,7 +251,7 @@ class TicTacToeEnv(EnvBase):
             return torch.where(done, state, state_select)
         return state
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         ...
 
     @staticmethod

--- a/torchrl/envs/libs/brax.py
+++ b/torchrl/envs/libs/brax.py
@@ -298,7 +298,7 @@ class BraxWrapper(_EnvWrapper):
         self._vmap_jit_env_step = jax.vmap(jax.jit(self._env.step))
         self._state_example = self._make_state_example()
 
-    def _set_seed(self, seed: int):
+    def _set_seed(self, seed: int | None) -> None:
         jax = self.jax
         if seed is None:
             raise Exception("Brax requires an integer seed.")

--- a/torchrl/envs/libs/dm_control.py
+++ b/torchrl/envs/libs/dm_control.py
@@ -287,7 +287,7 @@ class DMControlWrapper(GymLikeEnv):
         seed = self.set_seed(seed)
         return seed
 
-    def _set_seed(self, _seed: int | None) -> int | None:
+    def _set_seed(self, _seed: int | None) -> None:
         from dm_control.suite.wrappers import pixels
 
         if _seed is None:
@@ -302,7 +302,6 @@ class DMControlWrapper(GymLikeEnv):
                 raise RuntimeError("self._env._env.task._random does not exist")
             self._env.task._random = random_state
         self.reset()
-        return _seed
 
     def _output_transform(
         self, timestep_tuple: tuple[TimeStep]  # noqa: F821

--- a/torchrl/envs/libs/envpool.py
+++ b/torchrl/envs/libs/envpool.py
@@ -298,7 +298,7 @@ class MultiThreadedEnvWrapper(_EnvWrapper):
 
         return {k[0]: torch.as_tensor(v) for k, v in treevalue.flatten(tv)}
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         if seed is not None:
             torchrl_logger.info(
                 "MultiThreadedEnvWrapper._set_seed ignored, as setting seed in an existing envorinment is not\
@@ -387,7 +387,7 @@ class MultiThreadedEnv(MultiThreadedEnvWrapper):
         )
         return super()._build_env(env)
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         """Library EnvPool only supports setting a seed by recreating the environment."""
         if seed is not None:
             torchrl_logger.debug("Recreating EnvPool environment to set seed.")

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -1236,7 +1236,7 @@ class GymWrapper(GymLikeEnv, metaclass=_GymAsyncMeta):
     def lib(self) -> ModuleType:
         return gym_backend()
 
-    def _set_seed(self, seed: int) -> int:  # noqa: F811
+    def _set_seed(self, seed: int | None) -> None:  # noqa: F811
         if self._seed_calls_reset is None:
             # Determine basing on gym version whether `reset` is called when setting seed.
             self._set_seed_initial(seed)
@@ -1244,8 +1244,6 @@ class GymWrapper(GymLikeEnv, metaclass=_GymAsyncMeta):
             self.reset(seed=seed)
         else:
             self._env.seed(seed=seed)
-
-        return seed
 
     @implement_for("gym", None, "0.15.0")
     def _set_seed_initial(self, seed: int) -> None:  # noqa: F811

--- a/torchrl/envs/libs/isaacgym.py
+++ b/torchrl/envs/libs/isaacgym.py
@@ -111,9 +111,9 @@ class IsaacGymWrapper(GymWrapper):
         )
         return envs
 
-    def _set_seed(self, seed: int) -> int:
+    def _set_seed(self, seed: int | None) -> None:
         # as of #665c32170d84b4be66722eea405a1e08b6e7f761 the seed points nowhere in gym.make for IsaacGymEnvs
-        return seed
+        ...
 
     def read_action(self, action):
         """Reads the action obtained from the input TensorDict and transforms it in the format expected by the contained environment.

--- a/torchrl/envs/libs/jumanji.py
+++ b/torchrl/envs/libs/jumanji.py
@@ -517,7 +517,7 @@ class JumanjiWrapper(GymLikeEnv, metaclass=_JumanjiMakeRender):
     def key(self, value):
         self._key = value
 
-    def _set_seed(self, seed):
+    def _set_seed(self, seed: int | None) -> None:
         import jax
 
         if seed is None:

--- a/torchrl/envs/libs/meltingpot.py
+++ b/torchrl/envs/libs/meltingpot.py
@@ -340,7 +340,7 @@ class MeltingpotWrapper(_EnvWrapper):
         # Caching
         self.cached_full_done_spec_zero = self.full_done_spec.zero()
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         raise NotImplementedError(
             "It is currently unclear how to set a seed in Meltingpot. "
             "see https://github.com/google-deepmind/meltingpot/issues/129 to track the issue."

--- a/torchrl/envs/libs/openml.py
+++ b/torchrl/envs/libs/openml.py
@@ -149,5 +149,5 @@ class OpenMLEnv(EnvBase):
         )
         return td
 
-    def _set_seed(self, seed):
+    def _set_seed(self, seed: int | None) -> None:
         self.rng = torch.random.manual_seed(seed)

--- a/torchrl/envs/libs/openspiel.py
+++ b/torchrl/envs/libs/openspiel.py
@@ -334,7 +334,7 @@ class OpenSpielWrapper(_EnvWrapper):
         self.action_spec = Composite(action_spec)
         self.reward_spec = Composite(reward_spec)
 
-    def _set_seed(self, seed):
+    def _set_seed(self, seed: int | None) -> None:
         if seed is not None:
             raise NotImplementedError("This environment has no seed.")
 

--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -537,7 +537,7 @@ class PettingZooWrapper(_EnvWrapper):
         self.cached_step_output_zero.update(self.output_spec["full_reward_spec"].zero())
         self.cached_step_output_zero.update(self.output_spec["full_done_spec"].zero())
 
-    def _set_seed(self, seed: int):
+    def _set_seed(self, seed: int | None) -> None:
         self.seed = seed
         self.reset(seed=self.seed)
 

--- a/torchrl/envs/libs/smacv2.py
+++ b/torchrl/envs/libs/smacv2.py
@@ -311,7 +311,7 @@ class SMACv2Wrapper(_EnvWrapper):
         )
         return spec
 
-    def _set_seed(self, seed: Optional[int]):
+    def _set_seed(self, seed: Optional[int]) -> None:
         if seed is not None:
             raise NotImplementedError(
                 "Seed cannot be changed once environment was created."

--- a/torchrl/envs/libs/unity_mlagents.py
+++ b/torchrl/envs/libs/unity_mlagents.py
@@ -277,7 +277,7 @@ class UnityMLAgentsWrapper(_EnvWrapper):
         self.reward_spec = Composite(reward_spec)
         self.done_spec = Composite(done_spec)
 
-    def _set_seed(self, seed):
+    def _set_seed(self, seed: int | None) -> None:
         if seed is not None:
             raise NotImplementedError("This environment has no seed.")
 

--- a/torchrl/envs/libs/vmas.py
+++ b/torchrl/envs/libs/vmas.py
@@ -490,7 +490,7 @@ class VmasWrapper(_EnvWrapper):
     def _init_env(self) -> int | None:
         pass
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         self._env.seed(seed)
 
     def _reset(

--- a/torchrl/envs/model_based/common.py
+++ b/torchrl/envs/model_based/common.py
@@ -173,6 +173,5 @@ class ModelBasedEnvBase(EnvBase):
     def _reset(self, tensordict: TensorDict, **kwargs) -> TensorDict:
         raise NotImplementedError
 
-    def _set_seed(self, seed: int | None) -> int:
+    def _set_seed(self, seed: int | None) -> None:
         warnings.warn("Set seed isn't needed for model based environments")
-        return seed

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1167,7 +1167,7 @@ but got an object of type {type(transform)}."""
         """Set the seeds of the environment."""
         return self.base_env.set_seed(seed, static_seed=static_seed)
 
-    def _set_seed(self, seed: int | None):
+    def _set_seed(self, seed: int | None) -> None:
         """This method is not used in transformed envs."""
 
     def _reset(self, tensordict: TensorDictBase | None = None, **kwargs):
@@ -3991,7 +3991,7 @@ class DTypeCastTransform(Transform):
         ...         assert reward.dtype == torch.float64
         ...         assert obs["obs"].dtype == torch.float64
         ...         return obs.empty().set("next", obs.update({"reward": reward, "done": done}))
-        ...     def _set_seed(self, seed):
+        ...     def _set_seed(self, seed) -> None:
         ...         pass
         >>> env = TransformedEnv(MyEnv(), DTypeCastTransform(torch.double, torch.float))
         >>> assert env.action_spec.dtype == torch.float32
@@ -4361,7 +4361,7 @@ class DoubleToFloat(DTypeCastTransform):
         ...         assert reward.dtype == torch.float64
         ...         assert obs["obs"].dtype == torch.float64
         ...         return obs.empty().set("next", obs.update({"reward": reward, "done": done}))
-        ...     def _set_seed(self, seed):
+        ...     def _set_seed(self, seed) -> None:
         ...         pass
         >>> env = TransformedEnv(MyEnv(), DoubleToFloat())
         >>> assert env.action_spec.dtype == torch.float32
@@ -8764,8 +8764,8 @@ class ActionMask(Transform):
         ...         td.set("done", ~mask.any().view(1))
         ...         return td
         ...
-        ...     def _set_seed(self, seed):
-        ...         return seed
+        ...     def _set_seed(self, seed) -> None:
+        ...         pass
         ...
         >>> torch.manual_seed(0)
         >>> base_env = MaskedEnv()
@@ -9286,8 +9286,8 @@ class RemoveEmptySpecs(Transform):
         ...             self.full_done_spec.zero()
         ...             ).update(self.full_reward_spec.rand())
         ...
-        ...     def _set_seed(self, seed):
-        ...         return seed + 1
+        ...     def _set_seed(self, seed) -> None:
+        ...         pass
         >>>
         >>>
         >>> base_env = DummyEnv()
@@ -9620,7 +9620,7 @@ class BatchSizeTransform(Transform):
         ...         result.update(self.full_reward_spec.zero(tensordict.batch_size))
         ...         return result
         ...
-        ...     def _set_seed(self, seed: Optional[int]):
+        ...     def _set_seed(self, seed: Optional[int]) -> None:
         ...         pass
         ...
         >>> env = TransformedEnv(MyEnv(), BatchSizeTransform([5]))

--- a/tutorials/sphinx-tutorials/pendulum.py
+++ b/tutorials/sphinx-tutorials/pendulum.py
@@ -470,7 +470,7 @@ def make_composite_from_td(td):
 #
 
 
-def _set_seed(self, seed: Optional[int]):
+def _set_seed(self, seed: Optional[int]) -> None:
     rng = torch.manual_seed(seed)
     self.rng = rng
 


### PR DESCRIPTION
## Description

`_set_seed` is not expected to return anything as the sequence of seeds is handled by the parent function `set_seed`. The type annotation should make it more explicit that no return value is expected. 

## Motivation and Context

I went into a rabbit hole to figure out how to handle the seeds when dealing with a pool of environments. Certain implementation of `_set_seed` were returning `seed+1` for example which was confusing. I believe the type annotation `-> None` makes it clear.
