### PR TITLE
[CI] Fix tensordict upper version to 0.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -172,7 +172,7 @@ def _main(argv):
     if is_nightly:
         tensordict_dep = "tensordict-nightly"
     else:
-        tensordict_dep = "tensordict>=0.8.0"
+        tensordict_dep = "tensordict>=0.8.1,<0.9.0"
 
     if is_nightly:
         version = get_nightly_version()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

