### PR TITLE
[Environment] Complete `PettingZooWrapper` state support

### DIFF
--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -3948,6 +3948,20 @@ class TestPettingZoo:
                 td[-1]["next", "player", "reward"] == torch.tensor([[-1], [1]])
             ).all()
 
+    @pytest.mark.parametrize("task", ["simple_v3"])
+    def test_return_state(self, task):
+        env = PettingZooEnv(
+            task=task,
+            parallel=True,
+            seed=0,
+            use_mask=False,
+            return_state=True,
+        )
+        check_env_specs(env)
+        r = env.rollout(10)
+        assert (r["state"] != 0).any()
+        assert (r["next", "state"] != 0).any()
+
     @pytest.mark.parametrize(
         "task",
         [

--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -584,6 +584,10 @@ class PettingZooWrapper(_EnvWrapper):
                             value, device=self.device
                         )
 
+        if self.return_state:
+            state = torch.as_tensor(self.state(), device=self.device)
+            tensordict_out.set("state", state)
+
         return tensordict_out
 
     def _reset_aec(self, **kwargs) -> tuple[dict, dict]:
@@ -702,6 +706,11 @@ class PettingZooWrapper(_EnvWrapper):
         tensordict_out.set("done", done)
         tensordict_out.set("terminated", terminated)
         tensordict_out.set("truncated", truncated)
+
+        if self.return_state:
+            state = torch.as_tensor(self.state(), device=self.device)
+            tensordict_out.set("state", state)
+
         return tensordict_out
 
     def _aggregate_done(self, tensordict_out, use_any):


### PR DESCRIPTION
## Description

Set the "state" field in `step` and `reset`.

## Motivation and Context

The `PettingZooWrapper` support of (environment) state was limited to configuring the spec. This commit completes it by setting the state in `reset` and `step`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).

`PettingZooWrapper` is currently not tested.

- [ ] I have updated the documentation accordingly.
