### PR TITLE
[BugFix] Binary can have empty shape

### DIFF
--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -1387,6 +1387,9 @@ class TestSpec:
         assert (-3 <= sample).all() and (3 >= sample).all()
         assert sample.shape == torch.Size([100, 10, 5])
 
+    def test_binary_empty_shape_construct(self):
+        assert len(Binary(shape=()).shape) == 0
+
 
 class TestExpand:
     @pytest.mark.parametrize("shape1", [None, (4,), (5, 4)])

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -4312,7 +4312,9 @@ class Binary(Categorical):
         # Consistency checks between `shape` and `n`.
         if len(shape) == 0:
             if n is not None and n != 0:
-                raise ValueError("'n' must be zero for spec {self.__class__} when using an empty shape")
+                raise ValueError(
+                    f"'n' must be zero for spec {self.__class__} when using an empty shape"
+                )
         else:
             if shape[-1] != n:
                 raise ValueError(

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -4305,17 +4305,21 @@ class Binary(Categorical):
     ):
         if n is None and shape is None:
             raise TypeError("Must provide either n or shape.")
-        if n is None:
-            n = shape[-1]
-        if shape is None or not len(shape):
-            shape = _size((n,))
+
+        # Either `shape` or `n` is not `None`.
+        shape = _size((n,)) if shape is None else _size(shape)
+
+        # Consistency checks between `shape` and `n`.
+        if len(shape) == 0:
+            if n is not None and n != 0:
+                raise ValueError("'n' must be zero for spec {self.__class__} when using an empty shape")
         else:
-            shape = _size(shape)
             if shape[-1] != n:
                 raise ValueError(
-                    f"The last value of the shape must match n for spec {self.__class__}. "
+                    f"The last value of the shape must match 'n' for spec {self.__class__}. "
                     f"Got n={n} and shape={shape}."
                 )
+
         super().__init__(n=2, shape=shape, device=device, dtype=dtype)
         self.encode = self._encode_eager
 


### PR DESCRIPTION
## Description

Before this, `Binary(shape=())` would fail with

>     n = shape[-1]
>         ~~~~~^^^^
> IndexError: tuple index out of range


## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
