### PR TITLE
[BugFix] Fixes the Categorical is_in with non-long integer

### DIFF
--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -3966,7 +3966,7 @@ class Categorical(TensorSpec):
         shape = self.mask.shape
         shape = _size([*torch.broadcast_shapes(shape[:-1], val.shape), shape[-1]])
         mask_expand = self.mask.expand(shape)
-        gathered = mask_expand.gather(-1, val.unsqueeze(-1))
+        gathered = mask_expand.gather(-1, val.unsqueeze(-1).to(torch.long))
         return gathered.all()
 
     def __getitem__(self, idx: SHAPE_INDEX_TYPING):


### PR DESCRIPTION
## Description 

[!2980](https://github.com/pytorch/rl/pull/2980) can break some checks like `check_env_specs` when `is_in` receives non-long values.

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
