### PR TITLE
[Feature] Allow non-peft models in vLLMUpdater

### DIFF
--- a/torchrl/collectors/llm/weight_update/vllm.py
+++ b/torchrl/collectors/llm/weight_update/vllm.py
@@ -256,9 +256,12 @@ class vLLMUpdater(WeightUpdaterBase):
             # Extract weights from policy module using merge_and_unload for LLMs
             if not hasattr(server_weights, "model"):
                 raise ValueError("TensorDictModuleBase must have a 'model' attribute")
-            if not hasattr(server_weights.model, "merge_and_unload"):
-                raise ValueError("Model must have a 'merge_and_unload' method")
-            return TensorDict(server_weights.model.merge_and_unload().state_dict(), [])
+            # Check if it's a LoRA model
+            if hasattr(server_weights.model, "merge_and_unload"):
+                state_dict = server_weights.model.merge_and_unload().state_dict()
+            else:
+                state_dict = server_weights.model.state_dict()
+            return TensorDict(state_dict, [])
         elif isinstance(server_weights, TensorDictBase):
             return server_weights
         elif isinstance(server_weights, dict):
@@ -281,7 +284,13 @@ class vLLMUpdater(WeightUpdaterBase):
         Returns:
             dict[str, tuple[torch.dtype, torch.Size]]: The model metadata.
         """
-        sd = model.model.merge_and_unload().state_dict()
+        # Check if the model has a LoRA adapter
+        if hasattr(model.model, 'merge_and_unload'):
+            # This is a LoRA model
+            sd = model.model.merge_and_unload().state_dict()
+        else:
+            # This is a regular model without LoRA
+            sd = model.model.state_dict()
         model_metadata = {k: (v.dtype, v.shape) for k, v in sd.items()}
         return model_metadata
 


### PR DESCRIPTION
## Description

Currently, the `vLLMUpdater` class assumes that all models use LoRA adapters and calls `merge_and_unload()` on them.

This PR adds support for standard transformer models by checking if the method exists before calling it, falling back to `state_dict()` for non-LoRA models. This makes vLLMUpdater work with any transformer model type.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
