### PR TITLE
Disable unrunnable benchmarks cpu test

### DIFF
--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -14,7 +14,7 @@ jobs:
 
   benchmark_cpu:
     name: CPU Pytest benchmark
-    runs-on: linux.g5.4xlarge.nvidia.cpu
+    runs-on: linux.4xlarge.nvidia
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -14,7 +14,8 @@ jobs:
 
   benchmark_cpu:
     name: CPU Pytest benchmark
-    runs-on: linux.4xlarge.nvidia
+    runs-on: linux.4xlarge
+    if: false 
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -15,6 +15,7 @@ jobs:
   benchmark_cpu:
     name: CPU Pytest benchmark
     runs-on: linux.4xlarge
+    # Disabling job since it hasn't worked for months
     if: false 
     defaults:
       run:


### PR DESCRIPTION
## Description

The benchmark_cpu job is currently unrunnable and has been so for  over 3 months.

Changes are:
1. Disables the job from being scheduled, since it's broken.  I'm not deleting the code in case someone is interested in fixing it later on.
2. Fixes the runner label used for benchmark cpu tests to a similar machine that actually exists and has the same amount of cpu/memory, which is the first step towards fixing the job

## Motivation and Context

This buggy runner label was referenced in this PR: https://github.com/pytorch/rl/pull/2930/files#diff-1d24b39978bd364a0913d34dc491f52f4cb244e1efaf28bd0d87ebb80a73e4cdR17

Since this the job has been unable to even start, let alone run. 

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
