### PR TITLE
Re-enable CPU Pytest benchmark job

### DIFF
--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -15,8 +15,6 @@ jobs:
   benchmark_cpu:
     name: CPU Pytest benchmark
     runs-on: linux.4xlarge
-    # Disabling job since it hasn't worked for months
-    if: false 
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
Re-enabling the CPU pytest benchmark job. Even though it's failing, the signal is still helpful.

## Description

Re-enables the job

## Motivation and Context

The signals are useful for the development team and having it hidden will make tracking down issues harder during release.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
