### PR TITLE
Enable `LineariseRewards` to work with negative weights

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -13778,9 +13778,8 @@ class TestLineariseRewards(TransformBase):
         ):
             LineariseRewards(in_keys=("reward",), weights=torch.ones(size=(2, 4)))
 
-    def test_weight_sign_error(self):
-        with pytest.raises(ValueError, match="Expected all weights to be >0"):
-            LineariseRewards(in_keys=("reward",), weights=-torch.ones(size=(2,)))
+    def test_weight_no_sign_error(self):
+        LineariseRewards(in_keys=("reward",), weights=-torch.ones(size=(2,)))
 
     def test_discrete_spec_error(self):
         with pytest.raises(
@@ -13980,6 +13979,7 @@ class TestLineariseRewards(TransformBase):
             (1, None),
             (3, None),
             (2, [1.0, 2.0]),
+            (2, [1.0, -1.0]),
         ],
     )
     def test_transform_env(self, num_rewards, weights):
@@ -14061,6 +14061,15 @@ class TestLineariseRewards(TransformBase):
                     shape=2,
                 ),
                 BoundedContinuous(low=-1.0, high=1.0, shape=1),
+            ),
+            (
+                [1.0, -1.0],
+                BoundedContinuous(
+                    low=[-1.0, -2.0],
+                    high=[1.0, 2.0],
+                    shape=2,
+                ),
+                BoundedContinuous(low=-3.0, high=3.0, shape=1),
             ),
         ],
     )


### PR DESCRIPTION
## Description

Enable `LineariseRewards` to work with negative weights.

## Motivation and Context

Fixes #3063.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] New feature (non-breaking change which adds core functionality)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
