### PR TITLE
[Feature] Add support for loading datasets from local Minari cache

### DIFF
--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -29,12 +29,12 @@ from pathlib import Path
 from sys import platform
 from unittest import mock
 
+import minari
+
 import numpy as np
 import pytest
 import torch
 from minari import DataCollector
-import gymnasium as gym
-import minari
 
 from packaging import version
 from tensordict import (
@@ -3455,9 +3455,10 @@ class TestMinari:
         assert len(dataset) == 100
         assert sample["data"].shape == torch.Size([32, 8])
         assert sample["next", "data"].shape == torch.Size([32, 8])
-    
-        
-    @pytest.mark.skipif(not _has_minari or not _has_gymnasium, reason="Minari or Gym not available")
+
+    @pytest.mark.skipif(
+        not _has_minari or not _has_gymnasium, reason="Minari or Gym not available"
+    )
     def test_local_minari_dataset_loading(self):
 
         if not _minari_init():
@@ -3466,7 +3467,7 @@ class TestMinari:
         dataset_id = "cartpole/test-local-v1"
 
         # Create dataset using Gym + DataCollector
-        env = gym.make("CartPole-v1")
+        env = gymnasium.make("CartPole-v1")
         env = DataCollector(env, record_infos=True)
         for _ in range(50):
             env.reset(seed=123)
@@ -3482,7 +3483,7 @@ class TestMinari:
             code_permalink="https://github.com/Farama-Foundation/Minari",
             author="Farama",
             author_email="contact@farama.org",
-            eval_env="CartPole-v1"
+            eval_env="CartPole-v1",
         )
 
         # Load from local cache
@@ -3499,14 +3500,21 @@ class TestMinari:
         t0 = time.time()
         for i, sample in enumerate(data):
             t1 = time.time()
-            torchrl_logger.info(f"[Local Minari] Sampling time {1000 * (t1 - t0):4.4f} ms")
-            assert data.metadata["action_space"].is_in(sample["action"]), "Invalid action sample"
-            assert data.metadata["observation_space"].is_in(sample["observation"]), "Invalid observation sample"
+            torchrl_logger.info(
+                f"[Local Minari] Sampling time {1000 * (t1 - t0):4.4f} ms"
+            )
+            assert data.metadata["action_space"].is_in(
+                sample["action"]
+            ), "Invalid action sample"
+            assert data.metadata["observation_space"].is_in(
+                sample["observation"]
+            ), "Invalid observation sample"
             t0 = time.time()
             if i == 10:
                 break
-        
+
         minari.delete_dataset(dataset_id="cartpole/test-local-v1")
+
 
 @pytest.mark.slow
 class TestRoboset:

--- a/torchrl/data/datasets/minari_data.py
+++ b/torchrl/data/datasets/minari_data.py
@@ -93,7 +93,7 @@ class MinariExperienceReplay(BaseDatasetExperienceReplay):
             bypassing any remote download. This is useful when working with custom
             Minari datasets previously generated and stored locally, or when network
             access should be avoided. If the dataset is not found in the expected
-            cache directory, a ``FileNotFoundError`` will be raised. 
+            cache directory, a ``FileNotFoundError`` will be raised.
             Defaults to ``False``.
 
 
@@ -186,7 +186,11 @@ class MinariExperienceReplay(BaseDatasetExperienceReplay):
         self.download = download
         self.load_from_local_minari = load_from_local_minari
 
-        if self.download == "force" or (self.download and not self._is_downloaded()) or self.load_from_local_minari:
+        if (
+            self.download == "force"
+            or (self.download and not self._is_downloaded())
+            or self.load_from_local_minari
+        ):
             if self.download == "force":
                 try:
                     if os.path.exists(self.data_path_root):
@@ -264,8 +268,10 @@ class MinariExperienceReplay(BaseDatasetExperienceReplay):
                 h5_path = parent_dir / "main_data.hdf5"
 
                 if not h5_path.exists():
-                    raise FileNotFoundError(f"{h5_path} does not exist in local Minari cache!")
-                
+                    raise FileNotFoundError(
+                        f"{h5_path} does not exist in local Minari cache!"
+                    )
+
                 torchrl_logger.info(
                     f"loading dataset from local Minari cache at {h5_path}"
                 )
@@ -273,10 +279,12 @@ class MinariExperienceReplay(BaseDatasetExperienceReplay):
 
             else:
                 minari.download_dataset(dataset_id=self.dataset_id)
-                
+
                 parent_dir = Path(tmpdir) / self.dataset_id / "data"
 
-                torchrl_logger.info("first read through data to create data structure...")
+                torchrl_logger.info(
+                    "first read through data to create data structure..."
+                )
                 h5_data = PersistentTensorDict.from_h5(parent_dir / "main_data.hdf5")
 
             # populate the tensordict
@@ -397,6 +405,7 @@ class MinariExperienceReplay(BaseDatasetExperienceReplay):
                 json.dump(self.metadata, metadata_file)
             self._load_and_proc_metadata()
             return td_data
+
     def _make_split(self):
         from torchrl.collectors.utils import split_trajectories
 


### PR DESCRIPTION
## Description

This PR adds support for loading datasets directly from the local Minari cache in the `MinariExperienceReplay` class. Specifically, it introduces the `load_from_local_minari` argument, which, when set to `True`, instructs the class to load the dataset from the user's local Minari cache (typically at `~/.minari/datasets`) and skip any fetching from the Minari server (i.e., no remote download or overwrite will occur). After loading from the local cache, all subsequent preprocessing and loading steps continue as usual, ensuring the dataset is processed and made available correctly. This is especially useful for custom Minari datasets or when you want to avoid network access.

**Documentation has been updated in the class docstring** to clearly state the new behavior of the `load_from_local_minari` argument, including details about local cache prioritization and unchanged downstream preprocessing.

This PR also includes **comprehensive test coverage** for the new feature, confirming that datasets created and stored in the local Minari cache can be loaded, sampled, and validated for correctness using the new argument. The provided test (`test_local_minari_dataset_loading`) creates a custom dataset, loads it from cache, verifies sample integrity, and cleans up afterwards.

## Motivation and Context

Previously, `MinariExperienceReplay` required datasets to be downloaded via its own interface, which was incompatible with custom or preloaded Minari datasets, attempting to load these would result in a `FileNotFoundError`. 
This change allows users to work with their own datasets, datasets created with `minari.DataCollector(...).create_dataset(...)`, or any dataset present in the local Minari cache, without requiring redundant downloads or manual metadata copying.

If the dataset is not found in the local cache, a `FileNotFoundError` is raised with a clear message.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

Solves #3067

## Types of changes

- [x] New feature (non-breaking change which adds core functionality)
- [x] Documentation (update in the documentation)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.