### PR TITLE
[BugFix] Fix Qwen parsing for tools

### DIFF
--- a/torchrl/data/llm/history.py
+++ b/torchrl/data/llm/history.py
@@ -82,10 +82,14 @@ _CHAT_TEMPLATES = {
         {{- '<|im_end|>\\n' }}{% endgeneration %}
     {%- elif message.role == "tool" %}
         {%- if (loop.index0 == 0) or (messages[loop.index0 - 1].role != "tool") %}
-            {{- '<|im_start|>user' }}
+            {{- '<|im_start|>tool' }}
         {%- endif %}
         {{- '\\n<tool_response>\\n' }}
-        {{- message.content }}
+        {%- if message.tool_responses %}
+            {{- message.tool_responses }}
+        {%- else %}
+            {{- message.content }}
+        {%- endif %}
         {{- '\\n</tool_response>' }}
         {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
             {{- '<|im_end|>\\n' }}


### PR DESCRIPTION
Fixes Qwen parsing for tools:
```python
from torchrl.data.llm.history import History
from tensordict import set_list_to_stack
from transformers import AutoTokenizer

set_list_to_stack(True).set()

tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-7B-Instruct")

h = History(
    role=["system", "user", "assistant", "tool"],
    content=["You are a helpful assistant. Answer in <answer>...</answer> blocks, think in <think>...</think> blocks.", 
             "Write a python script that gives the capital of France or Germany.", 
             """<think>The capital of France is Paris, the capital of Germany is Berlin.</think> <answer><python>
capitals = {
    "France": "Paris",
    "Germany": "Berlin"
}
def get_capital(country):
    return capitals.get(country, "Unknown")
</python></answer>""", ""],
    tool_calls=[None, None, None, [
    {
        "id": "call_123",  # Unique identifier for this call
        "type": "function",  # Usually "function"
        "function": {
            "name": "get_capital",
            "arguments": '{"country": "Germany"}'  # JSON string
        }
    }
]],
    batch_size=4, tool_responses=[None, None, None, "Berlin"]
)

parsed = h.apply_chat_template(tokenizer=tokenizer, add_generation_prompt=False)
print(parsed)
```
produces
```
<|im_start|>system
You are a helpful assistant. Answer in <answer>...</answer> blocks, think in <think>...</think> blocks.<|im_end|>
<|im_start|>user
Write a python script that gives the capital of France or Germany.<|im_end|>
<|im_start|>assistant
<think>The capital of France is Paris, the capital of Germany is Berlin.</think> <answer><python>
capitals = {
    "France": "Paris",
    "Germany": "Berlin"
}
def get_capital(country):
    return capitals.get(country, "Unknown")
</python></answer><|im_end|>
    <|im_start|>tool
<tool_response>
Berlin
</tool_response><|im_end|>
```

Notice
- the role is now `tool`
- the tool response is printed