### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/examples/rlhf/requirements.txt
+++ b/examples/rlhf/requirements.txt
@@ -8,4 +8,4 @@ tiktoken
 tqdm
 transformers
 git+https://github.com/pytorch/rl
-git+https://github.com/meta-pytorch/tensordict
+git+https://github.com/pytorch/tensordict


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Only modified files with extensions: .py, .md, .sh, .rst, .cpp, .h, .txt, .yml
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-12T20:58:09.563241+00:00Z