### PR TITLE
[Doc] fix LSTM example import in rnn.LSTMModule

### DIFF
--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -393,7 +393,7 @@ class LSTMModule(ModuleBase):
     Examples:
         >>> from torchrl.envs import TransformedEnv, InitTracker
         >>> from torchrl.envs import GymEnv
-        >>> from torchrl.modules import MLP
+        >>> from torchrl.modules import MLP, LSTMModule
         >>> from torch import nn
         >>> from tensordict.nn import TensorDictSequential as Seq, TensorDictModule as Mod
         >>> env = TransformedEnv(GymEnv("Pendulum-v1"), InitTracker())


### PR DESCRIPTION
This PR fixes a minor import issue in the LSTMModule docstring example.

- Add  to the import alongside  so the snippet runs as-is without raising a .

Documentation-only change.

Closes #3119