### PR TITLE
[CI] Fix missing librhash0 in doc CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,7 @@ jobs:
         # Install Mesa and OpenGL Libraries:
         yum install -y glfw mesa-libGL mesa-libGL-devel egl-utils freeglut mesa-libGLU mesa-libEGL python39-pip
         yum install epel-release -y  # for missing librhash0 when installing tensordict
+        yum install rhash -y  # Provides librhash.so.0 needed by cmake
         # Install DRI Drivers:
         yum install -y mesa-dri-drivers
         # Install Xvfb for Headless Environments:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #3203
* #3202
* __->__ #3201

