### PR TITLE
[BugFix] RSSMRollout not advancing state/belief across time steps in Dreamer

### DIFF
--- a/torchrl/modules/models/model_based.py
+++ b/torchrl/modules/models/model_based.py
@@ -19,6 +19,7 @@ from torch import nn
 # from torchrl.modules.tensordict_module.rnn import GRUCell
 from torch.nn import GRUCell
 from torchrl._utils import timeit
+from torchrl.envs.utils import step_mdp
 
 from torchrl.modules.models.models import MLP
 
@@ -261,6 +262,8 @@ class RSSMRollout(TensorDictModuleBase):
 
             tensordict_out.append(_tensordict)
             if t < time_steps - 1:
+                # Translate ("next", *) to the non-next key required for the current step input
+                _tensordict = step_mdp(_tensordict, keep_other=True)
                 _tensordict = _tensordict.select(*self.in_keys, strict=False)
                 _tensordict = update_values[t + 1].update(_tensordict)
 


### PR DESCRIPTION
## Description

This PR fixes the RSSM rollout state propagation in `RSSMRollout.forward`.  
At each timestep, after computing the prior and posterior, we now:

- shift `("next", *)` keys to current using `step_mdp(..., keep_other=True)`, and
- merge the next step inputs before continuing the rollout.

Concretely:
- add `step_mdp` import, and
- call `step_mdp` inside the time loop before selecting `in_keys` and updating with the next step’s values.

This ensures `("next", "state")` and `("next", "belief")` are correctly advanced to `state` and `belief` for the subsequent step.

## Motivation and Context

Previously, the rollout did not propagate `state` and `belief` from `("next", ...)` back to the current keys, causing the loop to reuse stale `state/belief`. This broke the intended posterior-to-prior chaining in Dreamer’s RSSM and led to incorrect latent rollouts (and potentially training instability and degraded reconstruction/reward predictions).

The fix aligns the implementation with Dreamer’s design and the world model wiring used elsewhere (e.g., in `dreamer_utils._dreamer_make_world_model`), where the prior for step t+1 must consume the posterior outputs of step t.

If there is an open issue tracking this bug, please link it here.  
Example: `close #XXXX`

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
