### PR TITLE
[BugFix] use correct field names in InitTrackerConfig

### DIFF
--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -1789,6 +1789,23 @@ class TestWeightUpdaterConfigs:
         assert cfg.vllm_tp_size == 2
 
 
+@pytest.mark.skipif(
+    not _python_version_compatible, reason="Python 3.10+ required for config system"
+)
+@pytest.mark.skipif(
+    not _configs_available, reason="Config system requires hydra-core and omegaconf"
+)
+class TestTransformConfigs:
+    @pytest.mark.skipif(not _has_hydra, reason="Hydra is not installed")
+    def test_init_tracker_config(self):
+        from hydra.utils import instantiate
+        from torchrl.trainers.algorithms.configs.transforms import InitTrackerConfig
+
+        cfg = InitTrackerConfig(init_key="is_test_init")
+        assert cfg.init_key == "is_test_init"
+        instantiate(cfg)
+
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/torchrl/trainers/algorithms/configs/transforms.py
+++ b/torchrl/trainers/algorithms/configs/transforms.py
@@ -585,8 +585,7 @@ class RandomCropTensorDictConfig(TransformConfig):
 class InitTrackerConfig(TransformConfig):
     """Configuration for InitTracker transform."""
 
-    in_keys: list[str] | None = None
-    out_keys: list[str] | None = None
+    init_key: str | None = None
     _target_: str = "torchrl.envs.transforms.transforms.InitTracker"
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
## Description

The `InitTrackerConfig` fields did not match the expected kwargs in the `InitTracker` transform class, which prevents use with the trainer framework. This commit renames the config fields to match and adds a test.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

Issue: #3246

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
