### PR TITLE
[Feature] add TensorDictSequentialConfig

### DIFF
--- a/torchrl/trainers/algorithms/configs/__init__.py
+++ b/torchrl/trainers/algorithms/configs/__init__.py
@@ -82,6 +82,7 @@ from torchrl.trainers.algorithms.configs.modules import (
     ModelConfig,
     TanhNormalModelConfig,
     TensorDictModuleConfig,
+    TensorDictSequentialConfig,
     ValueModelConfig,
 )
 from torchrl.trainers.algorithms.configs.objectives import (
@@ -256,6 +257,7 @@ __all__ = [
     "ModelConfig",
     "TanhNormalModelConfig",
     "TensorDictModuleConfig",
+    "TensorDictSequentialConfig",
     "ValueModelConfig",
     # Transforms - Core
     "ActionDiscretizerConfig",
@@ -427,6 +429,9 @@ def _register_configs():
 
     # Model configs
     cs.store(group="network", name="tensordict_module", node=TensorDictModuleConfig)
+    cs.store(
+        group="network", name="tensordict_sequential", node=TensorDictSequentialConfig
+    )
     cs.store(group="model", name="tanh_normal", node=TanhNormalModelConfig)
     cs.store(group="model", name="value", node=ValueModelConfig)
 


### PR DESCRIPTION
## Description

This PR adds the `TensorDictSequentialConfig` dataclass, which corresponds with the already-existing `TensorDictSequential`. This PR also adds a test for the new config dataclass.

## Motivation and Context

Adding this config dataclass will allow for directly instantiating a `TensorDictSequential`, simply by defining the relevant fields in the config yaml.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes) Here: #3249

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] New feature (non-breaking change which adds core functionality)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
