### PR TITLE
[Feature] Add a new Trainer hook point `process_loss`

### DIFF
--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -1092,6 +1092,53 @@ class TestProcessLossHook:
         td_out = trainer._process_loss_hook(td_sub_batch.clone(), td_loss.clone())
         assert torch.allclose(td_out["loss_a"], torch.tensor(factor))
 
+    def test_chained_hooks(self):
+        """Test that multiple process_loss hooks are applied in order."""
+        trainer = mocking_trainer()
+        td_loss = TensorDict({"loss_a": torch.tensor(2.0)}, [])
+        td_sub_batch = TensorDict({}, [])
+
+        call_order = []
+
+        class AddOne:
+            def __call__(self, sub_batch, losses):
+                call_order.append("add")
+                losses = losses.clone()
+                losses["loss_a"] = losses["loss_a"] + 1
+                return losses
+
+        class MultiplyTwo:
+            def __call__(self, sub_batch, losses):
+                call_order.append("mul")
+                losses = losses.clone()
+                losses["loss_a"] = losses["loss_a"] * 2
+                return losses
+
+        trainer.register_op("process_loss", AddOne())
+        trainer.register_op("process_loss", MultiplyTwo())
+
+        td_out = trainer._process_loss_hook(td_sub_batch, td_loss.clone())
+        # (2 + 1) * 2 = 6
+        assert torch.allclose(td_out["loss_a"], torch.tensor(6.0))
+        assert call_order == ["add", "mul"]
+
+    def test_hook_receives_sub_batch(self):
+        """Test that the hook can use information from the sub_batch."""
+        trainer = mocking_trainer()
+        td_loss = TensorDict({"loss_a": torch.tensor(1.0)}, [])
+        td_sub_batch = TensorDict({"importance_weight": torch.tensor(0.5)}, [])
+
+        class WeightedLoss:
+            def __call__(self, sub_batch, losses):
+                weight = sub_batch.get("importance_weight")
+                losses = losses.clone()
+                losses["loss_a"] = losses["loss_a"] * weight
+                return losses
+
+        trainer.register_op("process_loss", WeightedLoss())
+        td_out = trainer._process_loss_hook(td_sub_batch, td_loss.clone())
+        assert torch.allclose(td_out["loss_a"], torch.tensor(0.5))
+
 
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()


### PR DESCRIPTION
## Description

This PR introduces a dedicated hook collection (`process_loss`) in `torchrl.trainers.trainers.Trainer`.

Maybe this could be merged with `post_loss` using:
```py
losses_td = self._post_loss_hook(sub_batch, losses_td)
```

## Motivation and Context

It makes the customisation of losses easy, e.g. to add normalisation or other tweaking.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
