### PR TITLE
[BugFix] Added a missing .to(device) call in _from_transformers_generate_history

### DIFF
--- a/torchrl/modules/llm/policies/transformers_wrapper.py
+++ b/torchrl/modules/llm/policies/transformers_wrapper.py
@@ -787,6 +787,10 @@ class TransformersWrapper(LLMWrapperBase):
         response_struct = history.apply_chat_template(
             tokenizer=self.tokenizer, **tokenizer_kwargs
         )
+
+        if self._device is not None:
+            response_struct = response_struct.to(self._device)
+        
         tokens_prompt_padded = response_struct.get(
             "input_ids",
             as_padded_tensor=True,


### PR DESCRIPTION
## Description

I added the missing `.to(device)` call to TransformersWrapper's `_from_transformers_generate_history`.

## Motivation and Context

It seems that TransformersWrapper's `_from_transformers_generate_history` misses a `.to(device)` call after it performs `history.apply_chat_template`, i.e. the resulting token tensor is not on the correct device and an exception gets raised later in the `result = self._generate_from_tokens(` call.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ X ] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ X ] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)