### PR TITLE
[BugFix] Fix SACLoss target_entropy="auto" ignoring action space dimensionality

### DIFF
--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -499,7 +499,9 @@ class SACLoss(LossModule):
             else:
                 action_container_shape = action_spec.shape
             target_entropy = -float(
-                action_spec.shape[len(action_container_shape) :].numel()
+                action_spec[self.tensor_keys.action]
+                .shape[len(action_container_shape) :]
+                .numel()
             )
         delattr(self, "_target_entropy")
         self.register_buffer(


### PR DESCRIPTION
Closes #3291 