### PR TITLE
[Refactor] Remove MUJOCO_EGL_DEVICE_ID auto-setting from torchrl init

### DIFF
--- a/torchrl/__init__.py
+++ b/torchrl/__init__.py
@@ -29,10 +29,6 @@ torch._C._log_api_usage_once("torchrl")
 
 set_lazy_legacy(False).set()
 
-if torch.cuda.device_count() > 1:
-    n = torch.cuda.device_count() - 1
-    os.environ["MUJOCO_EGL_DEVICE_ID"] = str(1 + (os.getpid() % n))
-
 from ._extension import _init_extension  # noqa: E402
 
 __version__ = None  # type: ignore


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #3306
* #3298
* #3308
* #3307
* #3305
* #3304
* #3303
* #3302
* #3301
* #3300
* #3299
* #3297
* #3296
* #3295
* #3294
* __->__ #3293

This environment variable should be set externally rather than auto-computed
based on process ID, which was causing issues with multi-GPU setups.