### PR TITLE
[Refactor] Add WEIGHT_SYNC_TIMEOUT constant for collector weight synchronization

### DIFF
--- a/torchrl/collectors/_constants.py
+++ b/torchrl/collectors/_constants.py
@@ -28,6 +28,7 @@ __all__ = [
     "INSTANTIATE_TIMEOUT",
     "_MIN_TIMEOUT",
     "_MAX_IDLE_COUNT",
+    "WEIGHT_SYNC_TIMEOUT",
     "DEFAULT_EXPLORATION_TYPE",
     "_is_osx",
     "_Interruptor",
@@ -38,6 +39,9 @@ __all__ = [
 _TIMEOUT = 1.0
 INSTANTIATE_TIMEOUT = 20
 _MIN_TIMEOUT = 1e-3  # should be several orders of magnitude inferior wrt time spent collecting a trajectory
+# Timeout for weight synchronization during collector init.
+# Increase this when using many collectors across different CUDA devices.
+WEIGHT_SYNC_TIMEOUT = float(os.environ.get("TORCHRL_WEIGHT_SYNC_TIMEOUT", 120.0))
 # MAX_IDLE_COUNT is the maximum number of times a Dataloader worker can timeout with his queue.
 _MAX_IDLE_COUNT = int(os.environ.get("MAX_IDLE_COUNT", torch.iinfo(torch.int64).max))
 

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -18,6 +18,7 @@ from torchrl.collectors._constants import (
     cudagraph_mark_step_begin,
     DEFAULT_EXPLORATION_TYPE,
     INSTANTIATE_TIMEOUT,
+    WEIGHT_SYNC_TIMEOUT,
 )
 
 from torchrl.collectors._multi_async import MultiAsyncCollector, MultiaSyncDataCollector
@@ -50,6 +51,7 @@ __all__ = [
     # Constants
     "_TIMEOUT",
     "INSTANTIATE_TIMEOUT",
+    "WEIGHT_SYNC_TIMEOUT",
     "_MIN_TIMEOUT",
     "_MAX_IDLE_COUNT",
     "DEFAULT_EXPLORATION_TYPE",

--- a/torchrl/weight_update/_shared.py
+++ b/torchrl/weight_update/_shared.py
@@ -11,6 +11,7 @@ from tensordict import TensorDict, TensorDictBase
 from torch import multiprocessing as mp, nn
 
 from torchrl._utils import logger as torchrl_logger
+from torchrl.collectors._constants import WEIGHT_SYNC_TIMEOUT
 
 from torchrl.weight_update.utils import _resolve_model
 from torchrl.weight_update.weight_sync_schemes import (
@@ -97,7 +98,7 @@ class SharedMemTransport:
         weights: Any = None,
         model: Any = None,
         strategy: Any = None,
-        timeout: float = 10.0,
+        timeout: float = WEIGHT_SYNC_TIMEOUT,
     ) -> TensorDictBase:
         """Receive shared memory buffer reference from sender via their per-worker queues.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #3306
* #3298
* #3308
* #3307
* #3305
* #3304
* #3303
* #3302
* #3301
* #3300
* #3299
* #3297
* #3296
* #3295
* __->__ #3294
* #3293

Add configurable timeout constant (default 120s) for weight sync operations,
configurable via TORCHRL_WEIGHT_SYNC_TIMEOUT environment variable.
This helps when using many collectors across different CUDA devices.