### PR TITLE
[Refactor] Move WEIGHT_SYNC_TIMEOUT to collectors._constants

### DIFF
--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -42,8 +42,8 @@ from torchrl.envs.utils import (
     set_exploration_type,
 )
 from torchrl.modules import RandomPolicy, set_exploration_modules_spec_from_env
-from torchrl.weight_update import WeightSyncScheme
 from torchrl.weight_update.utils import _resolve_model
+from torchrl.weight_update.weight_sync_schemes import WeightSyncScheme
 
 
 class _CollectorProfiler:

--- a/torchrl/weight_update/_shared.py
+++ b/torchrl/weight_update/_shared.py
@@ -10,8 +10,7 @@ from tensordict import TensorDict, TensorDictBase
 
 from torch import multiprocessing as mp, nn
 
-from torchrl._utils import logger as torchrl_logger
-from torchrl.collectors._constants import WEIGHT_SYNC_TIMEOUT
+from torchrl._utils import logger as torchrl_logger, WEIGHT_SYNC_TIMEOUT
 
 from torchrl.weight_update.utils import _resolve_model
 from torchrl.weight_update.weight_sync_schemes import (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #3330
* __->__ #3329
* #3328

Move `WEIGHT_SYNC_TIMEOUT` from `torchrl._utils.py` to
`torchrl/collectors/_constants.py` to match the target branch.