### PR TITLE
[CI] Skip Windows-incompatible tests in optional deps CI

### DIFF
--- a/test/compile/test_compile_value.py
+++ b/test/compile/test_compile_value.py
@@ -5,6 +5,8 @@
 """Tests for torch.compile compatibility of value estimation functions."""
 from __future__ import annotations
 
+import sys
+
 import pytest
 import torch
 
@@ -15,7 +17,10 @@ from torchrl.objectives.value.functional import (
     vec_td_lambda_return_estimate,
 )
 
+IS_WINDOWS = sys.platform == "win32"
 
+
+@pytest.mark.skipif(IS_WINDOWS, reason="windows tests do not support compile")
 class TestValueFunctionCompile:
     """Test compilation of value estimation functions."""
 

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -4610,6 +4610,9 @@ class TestRBLazyInit:
         assert rb._init_writer is None
 
 
+@pytest.mark.skipif(
+    _os_is_windows, reason="Windows file locking prevents cleanup tests"
+)
 class TestLazyMemmapStorageCleanup:
     """Tests for LazyMemmapStorage automatic cleanup functionality."""
 


### PR DESCRIPTION
## Summary
- Skip `TestValueFunctionCompile` class on Windows (torch.compile inductor backend requires MSVC `cl` compiler not available in CI)
- Skip `TestLazyMemmapStorageCleanup` class on Windows (file locking prevents memmap file deletion/cleanup)
- Skip editable install test on Windows (file locking prevents `.pyd` file overwrite during re-install)

## Test plan
- Windows optional deps CI should pass after this change
- All skipped tests remain active on Linux/macOS

Fixes failing tests from run https://github.com/pytorch/rl/actions/runs/21143115049