### PR TITLE
[CI] Add pyvers dependency for Minari CI

### DIFF
--- a/.github/unittest/linux_libs/scripts_minari/requirements.txt
+++ b/.github/unittest/linux_libs/scripts_minari/requirements.txt
@@ -10,6 +10,7 @@ pytest-error-for-skips
 pytest-asyncio
 expecttest
 pybind11[global]
+pyvers
 pyyaml
 scipy
 psutil


### PR DESCRIPTION
## Summary
- Adds `pyvers` to `.github/unittest/linux_libs/scripts_minari/requirements.txt`
- Required because `tensordict` now depends on `pyvers` at runtime, but is installed with `--no-deps` in the Minari CI

## Test plan
- CI should pass the `unittests-minari` job without `ModuleNotFoundError: No module named 'pyvers'`