### PR TITLE
[CI] Fix Chess CI by correcting test file path typo

### DIFF
--- a/.github/unittest/linux_libs/scripts_chess/run_test.sh
+++ b/.github/unittest/linux_libs/scripts_chess/run_test.sh
@@ -22,7 +22,7 @@ conda deactivate && conda activate ./env
 # this workflow only tests the libs
 python -c "import chess"
 
-python .github/unittest/helpers/coverage_run_parallel.py -m pytest test/test_env.py --instafail -v --durations 200 --capture no -k TestChessEnv --error-for-skips --runslow
+python .github/unittest/helpers/coverage_run_parallel.py -m pytest test/test_envs.py --instafail -v --durations 200 --capture no -k TestChessEnv --error-for-skips --runslow
 
 coverage combine -q
 coverage xml -i


### PR DESCRIPTION
## Summary
- Fix typo in Chess CI test script: `test/test_env.py` -> `test/test_envs.py`

The script referenced a non-existent file `test/test_env.py`, causing the CI to fail with:
```
ERROR: file or directory not found: test/test_env.py
```

The actual test file is `test/test_envs.py` (with an 's').

## Test plan
- CI should pass after this change