### PR TITLE
[CI] Fix Windows build for free-threaded Python (3.13t, 3.14t)

### DIFF
--- a/.github/scripts/version_script.bat
+++ b/.github/scripts/version_script.bat
@@ -39,6 +39,19 @@ set DISTUTILS_USE_SDK=1
 :: Upgrade setuptools before installing PyTorch
 pip install --upgrade setuptools==72.1.0 || exit /b 1
 
+:: Workaround for free-threaded Python on Windows
+:: The library is python3XXt.lib but linker expects python3XX.lib
+if exist "%CONDA_PREFIX%\libs\python313t.lib" (
+    if not exist "%CONDA_PREFIX%\libs\python313.lib" (
+        copy "%CONDA_PREFIX%\libs\python313t.lib" "%CONDA_PREFIX%\libs\python313.lib"
+    )
+)
+if exist "%CONDA_PREFIX%\libs\python314t.lib" (
+    if not exist "%CONDA_PREFIX%\libs\python314.lib" (
+        copy "%CONDA_PREFIX%\libs\python314t.lib" "%CONDA_PREFIX%\libs\python314.lib"
+    )
+)
+
 set args=%1
 shift
 :start


### PR DESCRIPTION
## Problem

The Windows build for Python 3.14t (free-threaded) fails with:

```
LINK : fatal error LNK1104: cannot open file 'python314.lib'
```

## Root Cause

For free-threaded Python builds (3.13t, 3.14t), the Python library is named with a "t" suffix (`python314t.lib`), but the MSVC linker expects `python314.lib`.

## Solution

Add a workaround in `version_script.bat` to copy the `pythonXXXt.lib` file to `pythonXXX.lib` before the build runs.

## Reference

Run ID/Job ID: 21165370148/job/60868723026