### PR TITLE
[CI] Fix M1 build pip command not found

### DIFF
--- a/.github/scripts/pre-build-script.sh
+++ b/.github/scripts/pre-build-script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pip install --upgrade setuptools
+${CONDA_RUN} pip install --upgrade setuptools
 
 ${CONDA_RUN} pip install "pybind11[global]"
 ${CONDA_RUN} conda install anaconda::cmake -y

--- a/.github/scripts/td_script.sh
+++ b/.github/scripts/td_script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export TORCHRL_BUILD_VERSION=0.10.0
-pip install --upgrade setuptools
+${CONDA_RUN} pip install --upgrade setuptools
 
 # Always install pybind11 - required for building C++ extensions
 ${CONDA_RUN} pip install "pybind11[global]"
@@ -9,7 +9,7 @@ ${CONDA_RUN} pip install "pybind11[global]"
 # Check if ARCH is set to aarch64
 ARCH=${ARCH:-}  # This sets ARCH to an empty string if it's not defined
 
-if pip list | grep -q torch; then
+if ${CONDA_RUN} pip list | grep -q torch; then
     echo "Torch is installed."
     ${CONDA_RUN} pip install git+https://github.com/pytorch/tensordict.git -U --no-deps
 elif [[ -n "${SMOKE_TEST_SCRIPT:-}" ]]; then


### PR DESCRIPTION
## Problem

The M1 build fails sporadically with:

```
/Users/ec2-user/runner/_work/_temp/build_env_...: line 14: pip: command not found
##[error]Process completed with exit code 127.
```

## Root Cause

In `.github/scripts/pre-build-script.sh`, the `pip install --upgrade setuptools` command was running without the `${CONDA_RUN}` prefix. When the BUILD_ENV_FILE is sourced, the conda environment isn't activated in that shell context, so `pip` may not be in PATH.

The failure was sporadic because different M1 runner instances may have different system states - some have a system-wide pip available, others don't.

## Solution

Use `${CONDA_RUN}` prefix for the pip command to ensure it runs within the conda environment.

## Reference

Example failing job: https://github.com/pytorch/rl/actions/runs/21168209973/job/60878150960