### PR TITLE
[CI] Fix auto-label workflow for fork PRs

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -23,7 +23,9 @@
 name: PR Label
 
 on:
-  pull_request:
+  # Using pull_request_target to have write access for PRs from forks
+  # This is safe because we only read PR metadata (title), not code from the fork
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
## Summary

- Use `pull_request_target` instead of `pull_request` to have write access to labels for PRs from forks
- This fixes the `GraphQL: Resource not accessible by integration (addLabelsToLabelable)` error

This is safe because we only read PR metadata (the title), not code from the fork.

## Test plan

- After merging, the auto-label workflow will work for PRs from forks
- Existing PRs can be re-triggered by pushing a commit or manually re-running the workflow