### PR TITLE
[CI] Fix release builds to use stable PyTorch channel

### DIFF
--- a/.github/workflows/build-wheels-aarch64-linux.yml
+++ b/.github/workflows/build-wheels-aarch64-linux.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: string
         default: 'auto'
+      channel:
+        description: 'Build channel: nightly, test, release, or empty for auto-detection'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   id-token: write
@@ -44,6 +49,8 @@ jobs:
       test-infra-repository: pytorch/test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
       with-cuda: disable
+      channel: ${{ inputs.channel || '' }}
+      use-only-dl-pytorch-org: ${{ inputs.channel == 'release' && 'true' || 'false' }}
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: string
         default: 'auto'
+      channel:
+        description: 'Build channel: nightly, test, release, or empty for auto-detection'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   id-token: write
@@ -43,6 +48,8 @@ jobs:
       os: linux
       test-infra-repository: pytorch/test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      channel: ${{ inputs.channel || '' }}
+      use-only-dl-pytorch-org: ${{ inputs.channel == 'release' && 'true' || 'false' }}
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: string
         default: 'auto'
+      channel:
+        description: 'Build channel: nightly, test, release, or empty for auto-detection'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   id-token: write
@@ -43,6 +48,8 @@ jobs:
       os: macos-arm64
       test-infra-repository: pytorch/test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      channel: ${{ inputs.channel || '' }}
+      use-only-dl-pytorch-org: ${{ inputs.channel == 'release' && 'true' || 'false' }}
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: string
         default: 'auto'
+      channel:
+        description: 'Build channel: nightly, test, release, or empty for auto-detection'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   id-token: write
@@ -43,6 +48,8 @@ jobs:
       os: windows
       test-infra-repository: pytorch/test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      channel: ${{ inputs.channel || '' }}
+      use-only-dl-pytorch-org: ${{ inputs.channel == 'release' && 'true' || 'false' }}
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,6 +258,7 @@ jobs:
     with:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
       tensordict-source: ${{ inputs.tensordict_source || 'auto' }}
+      channel: release
     secrets: inherit
 
   build-windows:
@@ -269,6 +270,7 @@ jobs:
     with:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
       tensordict-source: ${{ inputs.tensordict_source || 'auto' }}
+      channel: release
     secrets: inherit
 
   build-macos:
@@ -280,6 +282,7 @@ jobs:
     with:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
       tensordict-source: ${{ inputs.tensordict_source || 'auto' }}
+      channel: release
     secrets: inherit
 
   build-aarch64:
@@ -291,6 +294,7 @@ jobs:
     with:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
       tensordict-source: ${{ inputs.tensordict_source || 'auto' }}
+      channel: release
     secrets: inherit
 
   # =============================================================================


### PR DESCRIPTION
## Summary

The release workflow was failing because when triggered via `workflow_dispatch` from `main`, the test-infra's `set-channel` action defaults to "nightly". This caused builds to try installing PyTorch from `r2-test.pytorch.org` which is not accessible from GitHub runners (DNS resolution failure).

**Error observed:**
```
ERROR: Could not find a version that satisfies the requirement torch (from versions: none)
WARNING: Retrying after connection broken by 'NewConnectionError': Failed to establish a new connection: [Errno -2] Name or service not known': /whl/nightly/cpu/torch/
```

## Changes

- Adds a `channel` input to all build-wheels workflows (linux, windows, m1, aarch64)
- Passes `channel: release` from the release workflow
- Uses `use-only-dl-pytorch-org: true` for release builds to ensure stable PyTorch is installed from `download.pytorch.org` instead of test infrastructure URLs

## Test plan

After merging, re-trigger the release workflow with:
- `tag: v0.11.0`
- `pytorch_release: release/2.10`
- `dry_run: true`