### PR TITLE
[CI] Fix artifact pattern in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,8 +334,8 @@ jobs:
           # - cpu: Only CPU builds (recommended - avoids duplicate wheel conflicts)
           # - gpu: Only CUDA builds
           # - all: All variants (requires deduplication)
-          # pytorch/test-infra uploads artifacts named like: pytorch_torchrl__3.11_cpu_x86_64
-          pattern: ${{ inputs.wheel_variants == 'gpu' && 'pytorch_torchrl__*_cu*' || inputs.wheel_variants == 'all' && 'pytorch_torchrl*' || 'pytorch_torchrl__*_cpu_*' }}
+          # pytorch/test-infra uploads artifacts named like: pytorch_rl__3.11_cpu_x86_64
+          pattern: ${{ inputs.wheel_variants == 'gpu' && 'pytorch_rl__*_cu*' || inputs.wheel_variants == 'all' && 'pytorch_rl*' || 'pytorch_rl__*_cpu_*' }}
           merge-multiple: true
 
       - name: Deduplicate and verify wheels


### PR DESCRIPTION
## Summary

The release workflow was failing at the "Collect Wheels" step because the artifact pattern was wrong:
- Pattern used: `pytorch_torchrl__*`
- Actual artifact names: `pytorch_rl__*`

## Test plan

After merging, cherry-pick to release/0.11.0 and re-run the release workflow.