### PR TITLE
[Docs] Fix dqn_with_rnn EGreedyModule device

### DIFF
--- a/tutorials/sphinx-tutorials/dqn_with_rnn.py
+++ b/tutorials/sphinx-tutorials/dqn_with_rnn.py
@@ -332,7 +332,7 @@ policy = Seq(feature, lstm, mlp, qval)
 # (see training loop below).
 #
 exploration_module = EGreedyModule(
-    annealing_num_steps=1_000_000, spec=env.action_spec, eps_init=0.2
+    annealing_num_steps=1_000_000, spec=env.action_spec, eps_init=0.2, device=device
 )
 stoch_policy = TensorDictSequential(
     policy,


### PR DESCRIPTION
## Summary
- Fix docs build failure in `dqn_with_rnn.py` when Sphinx-gallery executes on GPU runners.
- Ensure `EGreedyModule` is constructed on the same `device` as the env/policy, avoiding a device mismatch error.

## Root cause
Sphinx-gallery executes `tutorials/sphinx-tutorials/dqn_with_rnn.py` during docs build. The tutorial selects `device=cuda` on non-fork GPU runners, but instantiates `EGreedyModule` without `device`, leaving its buffers on CPU. This triggers the explicit invariant in `torchrl.modules.tensordict_module.exploration.EGreedyModule`.

## Test plan
- Rely on CI: `Generate documentation` workflow should pass.