### PR TITLE
[CI] Enable artifact uploads for flaky test tracking

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -53,6 +53,7 @@ jobs:
       repository: pytorch/rl
       docker-image: "nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04"
       timeout: 120
+      upload-artifact: test-results-cpu-${{ matrix.python_version }}
       script: |
         if [[ "${{ github.ref }}" =~ release/* ]]; then
           export RELEASE=1
@@ -91,6 +92,7 @@ jobs:
       gpu-arch-type: cuda
       gpu-arch-version: ${{ matrix.cuda_arch_version }}
       timeout: 120
+      upload-artifact: test-results-gpu-shard-${{ matrix.shard }}
       script: |
         # Set env vars from matrix
         export PYTHON_VERSION=${{ matrix.python_version }}
@@ -134,6 +136,7 @@ jobs:
       gpu-arch-type: cuda
       gpu-arch-version: ${{ matrix.cuda_arch_version }}
       timeout: 120
+      upload-artifact: test-results-gpu-distributed
       script: |
         # Set env vars from matrix
         export PYTHON_VERSION=${{ matrix.python_version }}
@@ -208,6 +211,7 @@ jobs:
       gpu-arch-type: cuda
       gpu-arch-version: ${{ matrix.cuda_arch_version }}
       timeout: 120
+      upload-artifact: test-results-optdeps
       script: |
         # Set env vars from matrix
         export PYTHON_VERSION=${{ matrix.python_version }}
@@ -245,6 +249,7 @@ jobs:
       gpu-arch-type: cuda
       gpu-arch-version: ${{ matrix.cuda_arch_version }}
       timeout: 120
+      upload-artifact: test-results-stable-gpu-shard-${{ matrix.shard }}
       script: |
         # Set env vars from matrix
         export PYTHON_VERSION=${{ matrix.python_version }}
@@ -290,6 +295,7 @@ jobs:
       gpu-arch-type: cuda
       gpu-arch-version: ${{ matrix.cuda_arch_version }}
       timeout: 120
+      upload-artifact: test-results-stable-gpu-distributed
       script: |
         # Set env vars from matrix
         export PYTHON_VERSION=${{ matrix.python_version }}


### PR DESCRIPTION
## Summary

Adds `upload-artifact` parameter to test jobs in `test-linux.yml` to enable the `pytorch/test-infra` reusable workflow to upload test result artifacts.

**Problem**: The flaky test tracker (#3408) was merged and is working, but it found 0 test results because the test-results JSON files generated by `pytest-json-report` were not being uploaded as artifacts.

**Root cause**: The `pytorch/test-infra` reusable workflow only uploads artifacts when `upload-artifact` is explicitly specified. Without this parameter, the JSON files are generated inside the container but discarded.

**Fix**: Add `upload-artifact: test-results-<job-name>` to each test job.

## Jobs Updated

| Job | Artifact Name |
|-----|---------------|
| tests-cpu | `test-results-cpu-{python_version}` |
| tests-gpu | `test-results-gpu-shard-{shard}` |
| tests-gpu-distributed | `test-results-gpu-distributed` |
| tests-optdeps | `test-results-optdeps` |
| tests-stable-gpu | `test-results-stable-gpu-shard-{shard}` |
| tests-stable-gpu-distributed | `test-results-stable-gpu-distributed` |

## Test plan

- [ ] Verify test workflows complete successfully
- [ ] Verify artifacts are uploaded after each test job
- [ ] Re-run flaky test tracker and verify it collects test data