### PR TITLE
[CI] Fix permission of flaky tests notification

### DIFF
--- a/.github/workflows/flaky-test-tracker.yml
+++ b/.github/workflows/flaky-test-tracker.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 env:
   FLAKY_RUNS_TO_ANALYZE: ${{ inputs.num_runs || '30' }}


### PR DESCRIPTION
The notify job needs issues:write permission to create/update the
flaky test tracking issue. Without this, the workflow fails with
"Resource not accessible by integration" (403) error.
