### PR TITLE
[BugFix] Add scalar_output_mode to loss modules for reduction='none'

### DIFF
--- a/.github/RELEASE_AGENT_PROMPT.md
+++ b/.github/RELEASE_AGENT_PROMPT.md
@@ -42,22 +42,30 @@ Get commits from the last release:
 git log v0.11.0..HEAD --oneline --no-merges
 ```
 
-**Important: Check Release Labels**
+**Important: PR Selection for Minor Releases**
 
-PRs are labeled to indicate their release eligibility:
-- `user-facing` - API changes, new features, or public interface changes. **Only include in major releases.**
-- `non-user-facing` - Internal changes, bug fixes, refactoring. **Safe for minor releases.**
+When selecting PRs for a minor release, follow this decision flow:
 
-To filter PRs for a minor release:
+1. **If labeled `user-facing`** → **Exclude** (only for major releases)
+2. **If labeled `non-user-facing` or `Suitable for minor`** → **Include**
+3. **If neither label is present** → **Assess yourself** based on the changes
+
+Labels:
+- `user-facing` - API changes, new features, or public interface changes
+- `non-user-facing` - Internal changes, bug fixes, refactoring
+- `Suitable for minor` - Explicitly marked as safe for minor releases
+
+To filter PRs:
 ```bash
-# Find PRs safe for minor release
+# Find PRs explicitly safe for minor release
 gh pr list --label "non-user-facing" --state merged --json number,title
+gh pr list --label "Suitable for minor" --state merged --json number,title
 
-# Check if a specific PR is user-facing (exclude from minor)
-gh pr view <PR_NUMBER> --json labels --jq '.labels[].name' | grep -q "user-facing"
+# Check labels on a specific PR
+gh pr view <PR_NUMBER> --json labels --jq '.labels[].name'
 ```
 
-If cherry-picking commits for a minor release, only include commits from PRs labeled `non-user-facing`.
+For unlabeled PRs, review the changes and determine if they affect the public API or just internal implementation.
 
 ### Critical: Don't Miss ghstack Commits
 

--- a/.github/RELEASE_AGENT_PROMPT.md
+++ b/.github/RELEASE_AGENT_PROMPT.md
@@ -42,6 +42,17 @@ Get commits from the last release:
 git log v0.11.0..HEAD --oneline --no-merges
 ```
 
+**Important: Exclude User-Facing Changes**
+
+PRs with the `user-facing` label should NOT be included in minor releases. These contain API changes, new features, or other changes that affect the public interface and should only be released in major versions.
+
+To check if a PR has the user-facing label:
+```bash
+gh pr view <PR_NUMBER> --json labels --jq '.labels[].name' | grep -q "user-facing"
+```
+
+If cherry-picking commits for a minor release, skip any commits associated with user-facing PRs.
+
 ### Critical: Don't Miss ghstack Commits
 
 **The biggest pitfall in release notes is only looking at commits with PR numbers.** Many of the most significant features are merged via ghstack and have NO PR number in the commit message. Always analyze both:
@@ -477,8 +488,10 @@ After completing all steps, provide this summary to the user:
 ## Version Naming Convention
 
 - **Major releases**: `v0.11.0`, `v0.12.0` - New features, may have breaking changes
-- **Minor/Patch releases**: `v0.11.1`, `v0.11.2` - Bug fixes, no new features
+- **Minor/Patch releases**: `v0.11.1`, `v0.11.2` - Bug fixes only, no new features or user-facing changes
 - **Release candidates**: `v0.11.0-rc1` - Pre-release testing
+
+**Note:** PRs labeled `user-facing` must only be included in major releases, never in minor/patch releases.
 
 ## TensorDict Version Compatibility
 

--- a/.github/RELEASE_AGENT_PROMPT.md
+++ b/.github/RELEASE_AGENT_PROMPT.md
@@ -42,16 +42,22 @@ Get commits from the last release:
 git log v0.11.0..HEAD --oneline --no-merges
 ```
 
-**Important: Exclude User-Facing Changes**
+**Important: Check Release Labels**
 
-PRs with the `user-facing` label should NOT be included in minor releases. These contain API changes, new features, or other changes that affect the public interface and should only be released in major versions.
+PRs are labeled to indicate their release eligibility:
+- `user-facing` - API changes, new features, or public interface changes. **Only include in major releases.**
+- `non-user-facing` - Internal changes, bug fixes, refactoring. **Safe for minor releases.**
 
-To check if a PR has the user-facing label:
+To filter PRs for a minor release:
 ```bash
+# Find PRs safe for minor release
+gh pr list --label "non-user-facing" --state merged --json number,title
+
+# Check if a specific PR is user-facing (exclude from minor)
 gh pr view <PR_NUMBER> --json labels --jq '.labels[].name' | grep -q "user-facing"
 ```
 
-If cherry-picking commits for a minor release, skip any commits associated with user-facing PRs.
+If cherry-picking commits for a minor release, only include commits from PRs labeled `non-user-facing`.
 
 ### Critical: Don't Miss ghstack Commits
 

--- a/test/test_objectives.py
+++ b/test/test_objectives.py
@@ -5376,6 +5376,7 @@ class TestSAC(LossModuleTestBase):
             delay_value=False,
             reduction=reduction,
             action_spec=action_spec,
+            scalar_output_mode="exclude" if reduction == "none" else None,
         )
         loss_fn.make_value_estimator()
         loss = loss_fn(td)
@@ -6259,6 +6260,7 @@ class TestDiscreteSAC(LossModuleTestBase):
             action_space="one-hot",
             delay_qvalue=False,
             reduction=reduction,
+            scalar_output_mode="exclude" if reduction == "none" else None,
         )
         loss_fn.make_value_estimator()
         loss = loss_fn(td)
@@ -7052,6 +7054,7 @@ class TestCrossQ(LossModuleTestBase):
             qvalue_network=qvalue,
             loss_function="l2",
             reduction=reduction,
+            scalar_output_mode="exclude" if reduction == "none" else None,
         )
         loss_fn.make_value_estimator()
         loss = loss_fn(td)
@@ -8043,6 +8046,7 @@ class TestREDQ(LossModuleTestBase):
                 loss_function="l2",
                 delay_qvalue=False,
                 reduction=reduction,
+                scalar_output_mode="exclude" if reduction == "none" else None,
             )
         loss_fn.make_value_estimator()
         loss = loss_fn(td)
@@ -8706,6 +8710,7 @@ class TestCQL(LossModuleTestBase):
             delay_actor=False,
             delay_qvalue=False,
             reduction=reduction,
+            scalar_output_mode="exclude" if reduction == "none" else None,
         )
         loss_fn.make_value_estimator()
         loss = loss_fn(td)
@@ -12677,7 +12682,11 @@ class TestOnlineDT(LossModuleTestBase):
         )
         td = self._create_mock_data_odt(device=device)
         actor = self._create_mock_actor(device=device)
-        loss_fn = OnlineDTLoss(actor, reduction=reduction)
+        loss_fn = OnlineDTLoss(
+            actor,
+            reduction=reduction,
+            scalar_output_mode="exclude" if reduction == "none" else None,
+        )
         loss = loss_fn(td)
         if reduction == "none":
             for key in loss.keys():
@@ -13983,6 +13992,7 @@ class TestIQL(LossModuleTestBase):
             value_network=value,
             loss_function="l2",
             reduction=reduction,
+            scalar_output_mode="exclude" if reduction == "none" else None,
         )
         loss_fn.make_value_estimator()
         with _check_td_steady(td), pytest.warns(

--- a/test/test_objectives.py
+++ b/test/test_objectives.py
@@ -14825,6 +14825,7 @@ class TestDiscreteIQL(LossModuleTestBase):
             loss_function="l2",
             action_space="one-hot",
             reduction=reduction,
+            scalar_output_mode="exclude" if reduction == "none" else None,
         )
         loss_fn.make_value_estimator()
         with _check_td_steady(td), pytest.warns(


### PR DESCRIPTION
## Summary

Fixes #2338

When using `SACLoss` (or other loss modules) with `reduction='none'`, the output `TensorDict` should preserve the input batch dimensions. Previously, the output had an empty batch size (`torch.Size([])`), which caused issues when users expected the loss values to maintain per-sample granularity.

### The Problem

Scalar values like `alpha` (the temperature parameter) and `entropy` cannot be included in a `TensorDict` with non-empty batch dimensions without changing their shape. This created a conflict: either output an empty-batch TensorDict (breaking expectations) or expand the scalars (changing their semantics).

### The Solution

Added a new `scalar_output_mode` parameter to the following loss module constructors:
- `SACLoss` / `DiscreteSACLoss`
- `CrossQLoss`
- `CQLLoss`
- `REDQLoss`
- `IQLLoss` / `DiscreteIQLLoss`
- `OnlineDTLoss`

Options:
- **`None` (default)**: Issues a warning and excludes scalars from output
- **`"exclude"`**: Silently excludes scalars (suppresses warning)
- **`"non_tensor"`**: Includes scalars as non-tensor data via `set_non_tensor()`

The warning is raised at instantiation time (not during forward), making it clear upfront that the behavior differs.

### Example

```python
# Default: warning + exclude scalars
loss = SACLoss(..., reduction="none")

# Explicit exclude, no warning
loss = SACLoss(..., reduction="none", scalar_output_mode="exclude")

# Include as non-tensor data
loss = SACLoss(..., reduction="none", scalar_output_mode="non_tensor")
td_out = loss(data)
for key, val in td_out.non_tensor_items():
    print(key, val)  # alpha, entropy
```

## Test plan

- [x] Local verification with test script
- [x] Existing unit tests pass (`pytest test/test_objectives.py -k "test_sac"`)
- [ ] CI tests pass