### PR TITLE
[Feature] Add SGLang backend base infrastructure

### DIFF
--- a/torchrl/modules/llm/backends/sglang/__init__.py
+++ b/torchrl/modules/llm/backends/sglang/__init__.py
@@ -1,0 +1,66 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""SGLang backends for TorchRL.
+
+This module provides comprehensive SGLang integration including:
+- Base classes and interfaces
+- Asynchronous SGLang server services
+- Shared utilities
+
+Examples:
+    >>> # Connect to an existing SGLang server
+    >>> from torchrl.modules.llm.backends.sglang import AsyncSGLang
+    >>> service = AsyncSGLang.connect("http://localhost:30000")
+
+    >>> # Launch a managed SGLang server
+    >>> from torchrl.modules.llm.backends.sglang import AsyncSGLang
+    >>> service = AsyncSGLang.from_pretrained("Qwen/Qwen2.5-3B")
+
+    >>> # All engines implement the same interface
+    >>> from torchrl.modules.llm.backends.sglang import RLSGLangEngine
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    # Base classes and interfaces
+    "RLSGLangEngine",
+    # Asynchronous SGLang
+    "AsyncSGLang",
+    # Utilities
+    "get_open_port",
+    "wait_for_server",
+]
+
+_LAZY_ATTRS: dict[str, tuple[str, str]] = {
+    # Base
+    "RLSGLangEngine": ("torchrl.modules.llm.backends.sglang.base", "RLSGLangEngine"),
+    # Async
+    "AsyncSGLang": (
+        "torchrl.modules.llm.backends.sglang.sglang_server",
+        "AsyncSGLang",
+    ),
+    # Utils
+    "get_open_port": (
+        "torchrl.modules.llm.backends.sglang.sglang_utils",
+        "get_open_port",
+    ),
+    "wait_for_server": (
+        "torchrl.modules.llm.backends.sglang.sglang_utils",
+        "wait_for_server",
+    ),
+}
+
+
+def __getattr__(name: str) -> Any:  # noqa: ANN401
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name, attr_name = target
+    module = __import__(module_name, fromlist=[attr_name])
+    return getattr(module, attr_name)

--- a/torchrl/modules/llm/backends/sglang/base.py
+++ b/torchrl/modules/llm/backends/sglang/base.py
@@ -1,0 +1,120 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Base classes for TorchRL SGLang backends."""
+
+from __future__ import annotations
+
+import abc
+from collections.abc import Iterator
+
+import torch
+
+
+class RLSGLangEngine(abc.ABC):
+    """Abstract base class for TorchRL SGLang engines that support weight updates.
+
+    All TorchRL SGLang engines should inherit from this class and implement
+    the required methods for weight synchronization.
+
+    The SGLang backend uses HTTP-based communication with the SGLang server
+    for generation, and NCCL for weight synchronization in RL training workflows.
+
+    Example:
+        >>> # All SGLang engines implement the same interface
+        >>> class MySGLangEngine(RLSGLangEngine):
+        ...     def get_tp_size(self) -> int:
+        ...         return self._tp_size
+        ...
+        ...     def get_model_metadata(self) -> dict[str, tuple[torch.dtype, torch.Size]]:
+        ...         return self._model_metadata
+        ...
+        ...     # ... implement other abstract methods
+    """
+
+    @abc.abstractmethod
+    def get_tp_size(self) -> int:
+        """Get the tensor parallel size for this engine.
+
+        Returns:
+            int: Tensor parallel size
+        """
+
+    @abc.abstractmethod
+    def get_dp_size(self) -> int:
+        """Get the data parallel size for this engine.
+
+        Returns:
+            int: Data parallel size
+        """
+
+    @abc.abstractmethod
+    def get_model_metadata(self) -> dict[str, tuple[torch.dtype, torch.Size]]:
+        """Get model parameter metadata.
+
+        Returns:
+            dict: Mapping of parameter names to (dtype, shape) tuples
+        """
+
+    @abc.abstractmethod
+    def get_master_address(self) -> str:
+        """Get the master address for weight synchronization.
+
+        Returns:
+            str: Master address (e.g., "localhost")
+        """
+
+    @abc.abstractmethod
+    def get_master_port(self) -> int:
+        """Get the master port for weight synchronization.
+
+        Returns:
+            int: Master port number
+        """
+
+    @abc.abstractmethod
+    def init_weight_update_group(
+        self,
+        master_address: str | None = None,
+        master_port: int | None = None,
+    ) -> None:
+        """Initialize the weight update communication group.
+
+        This should set up NCCL communication for weight broadcasting
+        via the SGLang server's /init_weights_update_group API.
+
+        Args:
+            master_address: Override for master address. If None, uses default.
+            master_port: Override for master port. If None, uses default.
+        """
+
+    @abc.abstractmethod
+    def update_weights_from_distributed(
+        self,
+        name: str,
+        dtype: torch.dtype,
+        shape: tuple[int, ...],
+    ) -> None:
+        """Signal the server to receive a weight update via NCCL broadcast.
+
+        This coordinates with the SGLang server's /update_weights_from_distributed API
+        to receive a single weight tensor broadcasted from the trainer.
+
+        Args:
+            name: Name of the parameter to update
+            dtype: Data type of the tensor
+            shape: Shape of the tensor
+        """
+
+    @abc.abstractmethod
+    def update_weights(self, weights: Iterator[tuple[str, torch.Tensor]]) -> None:
+        """Update model weights from an iterator.
+
+        This method should handle the actual weight broadcasting/updating
+        using NCCL communication.
+
+        Args:
+            weights: Iterator yielding (parameter_name, tensor) tuples
+        """

--- a/torchrl/modules/llm/backends/sglang/sglang_utils.py
+++ b/torchrl/modules/llm/backends/sglang/sglang_utils.py
@@ -1,0 +1,236 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Shared utilities for SGLang backends."""
+
+from __future__ import annotations
+
+import socket
+import time
+from typing import Any
+
+import requests
+
+from torchrl._utils import logger as torchrl_logger
+
+
+def get_open_port() -> int:
+    """Get an available port on localhost.
+
+    Returns:
+        int: An available port number
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_server(
+    server_url: str,
+    timeout: float = 300.0,
+    check_interval: float = 1.0,
+) -> bool:
+    """Wait for an SGLang server to become ready.
+
+    Args:
+        server_url: Base URL of the SGLang server (e.g., "http://localhost:30000")
+        timeout: Maximum time to wait in seconds
+        check_interval: Time between health checks in seconds
+
+    Returns:
+        bool: True if server is ready, False if timeout occurred
+
+    Raises:
+        TimeoutError: If the server does not become ready within the timeout
+    """
+    server_url = server_url.rstrip("/")
+    health_url = f"{server_url}/health"
+
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            response = requests.get(health_url, timeout=5.0)
+            if response.status_code == 200:
+                torchrl_logger.info(f"SGLang server at {server_url} is ready")
+                return True
+        except requests.exceptions.RequestException:
+            pass
+
+        time.sleep(check_interval)
+
+    raise TimeoutError(
+        f"SGLang server at {server_url} did not become ready within {timeout}s"
+    )
+
+
+def check_server_health(server_url: str, timeout: float = 5.0) -> bool:
+    """Check if an SGLang server is healthy.
+
+    Args:
+        server_url: Base URL of the SGLang server
+        timeout: Request timeout in seconds
+
+    Returns:
+        bool: True if server is healthy, False otherwise
+    """
+    server_url = server_url.rstrip("/")
+    try:
+        response = requests.get(f"{server_url}/health", timeout=timeout)
+        return response.status_code == 200
+    except requests.exceptions.RequestException:
+        return False
+
+
+def get_model_info(server_url: str, timeout: float = 10.0) -> dict[str, Any]:
+    """Get model information from an SGLang server.
+
+    Args:
+        server_url: Base URL of the SGLang server
+        timeout: Request timeout in seconds
+
+    Returns:
+        dict: Model information including model_path, tokenizer_path, etc.
+
+    Raises:
+        requests.exceptions.RequestException: If the request fails
+    """
+    server_url = server_url.rstrip("/")
+    response = requests.get(f"{server_url}/model_info", timeout=timeout)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_server_info(server_url: str, timeout: float = 10.0) -> dict[str, Any]:
+    """Get server information from an SGLang server.
+
+    Args:
+        server_url: Base URL of the SGLang server
+        timeout: Request timeout in seconds
+
+    Returns:
+        dict: Server information including tp_size, dp_size, etc.
+
+    Raises:
+        requests.exceptions.RequestException: If the request fails
+    """
+    server_url = server_url.rstrip("/")
+    response = requests.get(f"{server_url}/server_info", timeout=timeout)
+    response.raise_for_status()
+    return response.json()
+
+
+def flush_cache(server_url: str, timeout: float = 30.0) -> bool:
+    """Flush the radix cache on an SGLang server.
+
+    This is automatically triggered when model weights are updated,
+    but can be called manually if needed.
+
+    Args:
+        server_url: Base URL of the SGLang server
+        timeout: Request timeout in seconds
+
+    Returns:
+        bool: True if cache was flushed successfully
+    """
+    server_url = server_url.rstrip("/")
+    try:
+        response = requests.post(f"{server_url}/flush_cache", timeout=timeout)
+        return response.status_code == 200
+    except requests.exceptions.RequestException:
+        return False
+
+
+def convert_sampling_params(
+    temperature: float = 1.0,
+    top_p: float = 1.0,
+    top_k: int = -1,
+    max_tokens: int = 128,
+    stop: list[str] | None = None,
+    frequency_penalty: float = 0.0,
+    presence_penalty: float = 0.0,
+    repetition_penalty: float = 1.0,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Convert TorchRL sampling parameters to SGLang format.
+
+    Args:
+        temperature: Sampling temperature
+        top_p: Top-p (nucleus) sampling
+        top_k: Top-k sampling (-1 for disabled)
+        max_tokens: Maximum tokens to generate
+        stop: List of stop strings
+        frequency_penalty: Frequency penalty
+        presence_penalty: Presence penalty
+        repetition_penalty: Repetition penalty
+        **kwargs: Additional parameters passed through
+
+    Returns:
+        dict: SGLang-compatible sampling parameters
+    """
+    params = {
+        "temperature": temperature,
+        "top_p": top_p,
+        "max_new_tokens": max_tokens,
+        "frequency_penalty": frequency_penalty,
+        "presence_penalty": presence_penalty,
+        "repetition_penalty": repetition_penalty,
+    }
+
+    if top_k > 0:
+        params["top_k"] = top_k
+
+    if stop:
+        params["stop"] = stop
+
+    # Pass through any additional parameters
+    params.update(kwargs)
+
+    return params
+
+
+def dtype_to_str(dtype) -> str:
+    """Convert a torch dtype to a string representation.
+
+    Args:
+        dtype: A torch.dtype object
+
+    Returns:
+        str: String representation (e.g., "float16", "bfloat16")
+    """
+    import torch
+
+    dtype_map = {
+        torch.float16: "float16",
+        torch.float32: "float32",
+        torch.bfloat16: "bfloat16",
+        torch.int8: "int8",
+        torch.int16: "int16",
+        torch.int32: "int32",
+        torch.int64: "int64",
+    }
+    return dtype_map.get(dtype, str(dtype).split(".")[-1])
+
+
+def str_to_dtype(dtype_str: str):
+    """Convert a string representation to a torch dtype.
+
+    Args:
+        dtype_str: String representation (e.g., "float16", "bfloat16")
+
+    Returns:
+        torch.dtype: The corresponding dtype
+    """
+    import torch
+
+    dtype_map = {
+        "float16": torch.float16,
+        "float32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "int8": torch.int8,
+        "int16": torch.int16,
+        "int32": torch.int32,
+        "int64": torch.int64,
+    }
+    return dtype_map.get(dtype_str, torch.float32)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3437
* #3436
* #3435
* #3434
* #3433
* #3432
* #3431
* #3430
* #3429
* __->__ #3428

Add the foundational components for SGLang integration:

- RLSGLangEngine: Abstract base class mirroring RLvLLMEngine
  - get_tp_size/get_dp_size for parallelism configuration
  - get_model_metadata for weight extraction
  - init_weight_update_group/update_weights_from_distributed for NCCL
  - update_weights for direct weight updates

- sglang_utils: Shared utilities
  - HTTP client helpers for SGLang native APIs
  - Server health check and lifecycle management
  - Sampling parameter conversion (TorchRL → SGLang format)
  - Dtype conversion utilities

- Lazy loading in __init__.py for optional imports

Co-authored-by: Cursor <cursoragent@cursor.com>