### PR TITLE
[CI] Add PyTorch version check instructions to release prompt

### DIFF
--- a/.github/RELEASE_AGENT_PROMPT.md
+++ b/.github/RELEASE_AGENT_PROMPT.md
@@ -9,16 +9,51 @@ Before starting a release, ensure you have:
 - Ability to create branches, tags, and pull requests
 - Access to view GitHub Actions workflow runs
 
+## Determine Latest PyTorch Version
+
+**CRITICAL**: Before triggering any release workflow, you MUST determine the latest stable PyTorch version. Using an incorrect version will cause build failures.
+
+### Option 1: Check GitHub (Preferred)
+
+Query the latest PyTorch release from GitHub:
+
+```bash
+# Get the latest PyTorch release tag
+gh release view --repo pytorch/pytorch --json tagName --jq '.tagName'
+
+# Or list recent releases
+gh release list --repo pytorch/pytorch --limit 5
+```
+
+The release tag format is `v2.X.Y`. Extract the major.minor version for the `pytorch_release` parameter (e.g., `v2.10.0` → `release/2.10`).
+
+### Option 2: Check PyPI
+
+```bash
+pip index versions torch 2>/dev/null | head -1
+# Or: pip install torch== 2>&1 | grep -oP '\d+\.\d+\.\d+' | head -1
+```
+
+### Option 3: Ask the User
+
+If you cannot determine the latest PyTorch version programmatically, **always ask the user**:
+
+> "What is the latest stable PyTorch version? I need this to configure the release build correctly."
+
+**Never guess or use an outdated version from examples in this document.**
+
+---
+
 ## Input Parameters
 
-Collect the following information from the user:
+Collect the following information from the user (or determine automatically where possible):
 
-| Parameter | Description | Example |
-|-----------|-------------|---------|
-| `version_tag` | The version to release | `v0.11.0` |
-| `release_type` | Major (0.x.0) or minor (0.x.y) release | `major` or `minor` |
-| `pytorch_release` | PyTorch release branch to build against | `release/2.8` |
-| `previous_version` | Previous release tag (for release notes) | `v0.10.0` |
+| Parameter | Description | Example | How to Determine |
+|-----------|-------------|---------|------------------|
+| `version_tag` | The version to release | `v0.11.0` | User provides |
+| `release_type` | Major (0.x.0) or minor (0.x.y) release | `major` or `minor` | User provides |
+| `pytorch_release` | PyTorch release branch to build against | `release/2.10` | **Check latest PyTorch version (see above)** |
+| `previous_version` | Previous release tag (for release notes) | `v0.10.0` | `git describe --tags --abbrev=0` |
 
 ---
 


### PR DESCRIPTION
## Summary

Updates the release agent prompt to ensure the correct PyTorch version is used when triggering release builds.

**Changes:**
- Added a new "Determine Latest PyTorch Version" section with three options:
  1. Check GitHub releases (preferred): `gh release view --repo pytorch/pytorch`
  2. Check PyPI as fallback
  3. **Always ask the user** if version cannot be determined programmatically
- Updated the Input Parameters table to include a "How to Determine" column
- Made it explicit that agents should never guess or use outdated examples

**Motivation:**
Build failures occurred when the release workflow was triggered with an outdated PyTorch version (e.g., `release/2.7` when the latest stable is `2.10.0`). This change ensures the agent always checks the current version before proceeding.

## Test plan

- [ ] Verify the instructions are clear and actionable
- [ ] Test the `gh release view` command works correctly

Made with [Cursor](https://cursor.com)