### PR TITLE
[Performance] Always enable prefetch for replay buffer

### DIFF
--- a/sota-implementations/dreamer/dreamer.py
+++ b/sota-implementations/dreamer/dreamer.py
@@ -140,7 +140,7 @@ def main(cfg: DictConfig):  # noqa: F821
         buffer_size=buffer_size,
         buffer_scratch_dir=scratch_dir,
         device=device,
-        prefetch=prefetch if not profiling_enabled else None,
+        prefetch=prefetch,  # Always use prefetch for better throughput
         pixel_obs=cfg.env.from_pixels,
         grayscale=cfg.env.grayscale,
         image_size=cfg.env.image_size,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3448
* #3447
* __->__ #3446
* #3445
* #3444

Remove the conditional that disabled prefetch during profiling.
Prefetch significantly improves sampling performance by overlapping
data loading with GPU computation.

With prefetch enabled, sampling time is reduced to ~2.5ms (was a
bottleneck previously).

Co-authored-by: Cursor <cursoragent@cursor.com>