### PR TITLE
[Performance] SliceSampler use_gpu for faster trajectory computation

### DIFF
--- a/sota-implementations/dreamer/dreamer_utils.py
+++ b/sota-implementations/dreamer/dreamer_utils.py
@@ -892,7 +892,9 @@ def make_replay_buffer(
                 strict_length=False,
                 traj_key=("collector", "traj_ids"),
                 cache_values=False,  # Disabled for async collection (cache not synced across processes)
-                # Don't compile the sampler - inductor has C++ codegen bugs for int64 ops
+                use_gpu=device.type == "cuda"
+                if device is not None
+                else False,  # Speed up trajectory computation on GPU
             ),
             transform=sample_transforms,
             batch_size=batch_size,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3448
* __->__ #3447
* #3446
* #3445
* #3444

Enable GPU-accelerated trajectory index computation in SliceSampler
when running on CUDA devices. This speeds up the sampling process
by computing trajectory boundaries on GPU.

Co-authored-by: Cursor <cursoragent@cursor.com>