### PR TITLE
[Cleanup] Remove pin_memory from replay buffer

### DIFF
--- a/sota-implementations/dreamer/dreamer_utils.py
+++ b/sota-implementations/dreamer/dreamer_utils.py
@@ -878,7 +878,6 @@ def make_replay_buffer(
         )
 
         replay_buffer = TensorDictReplayBuffer(
-            pin_memory=False,
             prefetch=prefetch,
             storage=LazyMemmapStorage(
                 buffer_size,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #3448
* #3447
* #3446
* #3445
* #3444

Remove explicit pin_memory=False from TensorDictReplayBuffer.
This is not needed with prefetch enabled and the default behavior
is sufficient.

Co-authored-by: Cursor <cursoragent@cursor.com>