### PR TITLE
[CI] Add checkbox options for wheel build variants (CPU/CUDA/ROCm)

### DIFF
--- a/.github/workflows/build-wheels-aarch64-linux.yml
+++ b/.github/workflows/build-wheels-aarch64-linux.yml
@@ -12,6 +12,12 @@ on:
         # Release candidate tags look like: v1.11.0-rc1
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
   workflow_dispatch:
+    inputs:
+      build-cpu:
+        description: 'Build CPU wheels'
+        required: false
+        type: boolean
+        default: true
   workflow_call:
     inputs:
       test-infra-ref:
@@ -29,6 +35,11 @@ on:
         required: false
         type: string
         default: ''
+      with-cpu:
+        description: 'Build with CPU (enable/disable)'
+        required: false
+        type: string
+        default: 'enable'
 
 permissions:
   id-token: write
@@ -48,7 +59,9 @@ jobs:
       os: linux-aarch64
       test-infra-repository: pytorch/test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      # aarch64 only supports CPU builds
       with-cuda: disable
+      with-cpu: ${{ github.event_name == 'workflow_dispatch' && (inputs.build-cpu && 'enable' || 'disable') || inputs.with-cpu || 'enable' }}
       channel: ${{ inputs.channel || '' }}
       use-only-dl-pytorch-org: ${{ inputs.channel == 'release' && 'true' || 'false' }}
   build:

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -12,6 +12,22 @@ on:
         # Release candidate tags look like: v1.11.0-rc1
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
   workflow_dispatch:
+    inputs:
+      build-cpu:
+        description: 'Build CPU wheels'
+        required: false
+        type: boolean
+        default: true
+      build-cuda:
+        description: 'Build CUDA wheels'
+        required: false
+        type: boolean
+        default: false
+      build-rocm:
+        description: 'Build ROCm wheels'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       test-infra-ref:
@@ -29,6 +45,21 @@ on:
         required: false
         type: string
         default: ''
+      with-cuda:
+        description: 'Build with CUDA (enable/disable)'
+        required: false
+        type: string
+        default: 'enable'
+      with-rocm:
+        description: 'Build with ROCm (enable/disable)'
+        required: false
+        type: string
+        default: 'enable'
+      with-cpu:
+        description: 'Build with CPU (enable/disable)'
+        required: false
+        type: string
+        default: 'enable'
 
 permissions:
   id-token: write
@@ -50,6 +81,12 @@ jobs:
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
       channel: ${{ inputs.channel || '' }}
       use-only-dl-pytorch-org: ${{ inputs.channel == 'release' && 'true' || 'false' }}
+      # For workflow_dispatch: convert boolean to enable/disable string
+      # For workflow_call: use the string input directly
+      # Default: enable all variants
+      with-cuda: ${{ github.event_name == 'workflow_dispatch' && (inputs.build-cuda && 'enable' || 'disable') || inputs.with-cuda || 'enable' }}
+      with-rocm: ${{ github.event_name == 'workflow_dispatch' && (inputs.build-rocm && 'enable' || 'disable') || inputs.with-rocm || 'enable' }}
+      with-cpu: ${{ github.event_name == 'workflow_dispatch' && (inputs.build-cpu && 'enable' || 'disable') || inputs.with-cpu || 'enable' }}
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -12,6 +12,12 @@ on:
         # Release candidate tags look like: v1.11.0-rc1
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
   workflow_dispatch:
+    inputs:
+      build-cpu:
+        description: 'Build CPU wheels'
+        required: false
+        type: boolean
+        default: true
   workflow_call:
     inputs:
       test-infra-ref:
@@ -29,6 +35,11 @@ on:
         required: false
         type: string
         default: ''
+      with-cpu:
+        description: 'Build with CPU (enable/disable)'
+        required: false
+        type: string
+        default: 'enable'
 
 permissions:
   id-token: write
@@ -50,6 +61,8 @@ jobs:
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
       channel: ${{ inputs.channel || '' }}
       use-only-dl-pytorch-org: ${{ inputs.channel == 'release' && 'true' || 'false' }}
+      # macOS only supports CPU builds
+      with-cpu: ${{ github.event_name == 'workflow_dispatch' && (inputs.build-cpu && 'enable' || 'disable') || inputs.with-cpu || 'enable' }}
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -12,6 +12,17 @@ on:
         # Release candidate tags look like: v1.11.0-rc1
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
   workflow_dispatch:
+    inputs:
+      build-cpu:
+        description: 'Build CPU wheels'
+        required: false
+        type: boolean
+        default: true
+      build-cuda:
+        description: 'Build CUDA wheels'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       test-infra-ref:
@@ -29,6 +40,16 @@ on:
         required: false
         type: string
         default: ''
+      with-cuda:
+        description: 'Build with CUDA (enable/disable)'
+        required: false
+        type: string
+        default: 'enable'
+      with-cpu:
+        description: 'Build with CPU (enable/disable)'
+        required: false
+        type: string
+        default: 'enable'
 
 permissions:
   id-token: write
@@ -50,6 +71,11 @@ jobs:
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
       channel: ${{ inputs.channel || '' }}
       use-only-dl-pytorch-org: ${{ inputs.channel == 'release' && 'true' || 'false' }}
+      # For workflow_dispatch: convert boolean to enable/disable string
+      # For workflow_call: use the string input directly
+      # Default: enable all variants (Windows has no ROCm)
+      with-cuda: ${{ github.event_name == 'workflow_dispatch' && (inputs.build-cuda && 'enable' || 'disable') || inputs.with-cuda || 'enable' }}
+      with-cpu: ${{ github.event_name == 'workflow_dispatch' && (inputs.build-cpu && 'enable' || 'disable') || inputs.with-cpu || 'enable' }}
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@
 # - main, nightly, PRs: install from git (latest dev)
 # - Can be overridden with tensordict_source input
 #
-# Wheel Variants:
-# - cpu (default): Recommended for torchrl - avoids duplicate filename conflicts
-# - gpu: Only CUDA builds
-# - all: All variants (with deduplication to prevent corruption)
+# Wheel Variants (selectable via checkboxes):
+# - build_cpu (default: true): Recommended for torchrl - pure Python library
+# - build_cuda (default: false): CUDA builds (Linux, Windows)
+# - build_rocm (default: false): ROCm builds (Linux only)
 #
 # NOTE: This workflow is NOT automatically triggered on tag push to avoid
 # race conditions with wheel builds. Use workflow_dispatch to trigger releases.
@@ -57,15 +57,21 @@ on:
           - 'stable'
           - 'git'
         default: 'auto'
-      wheel_variants:
-        description: 'Which wheel variants to collect (cpu recommended for torchrl)'
+      build_cpu:
+        description: 'Build CPU wheels (recommended for torchrl - pure Python library)'
         required: false
-        type: choice
-        options:
-          - 'cpu'
-          - 'gpu'
-          - 'all'
-        default: 'cpu'
+        type: boolean
+        default: true
+      build_cuda:
+        description: 'Build CUDA wheels'
+        required: false
+        type: boolean
+        default: false
+      build_rocm:
+        description: 'Build ROCm wheels (Linux only)'
+        required: false
+        type: boolean
+        default: false
 
 # Ensure only one release workflow runs at a time
 # cancel-in-progress: true means new runs cancel previous ones
@@ -259,6 +265,9 @@ jobs:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
       tensordict-source: ${{ inputs.tensordict_source || 'auto' }}
       channel: release
+      with-cpu: ${{ inputs.build_cpu && 'enable' || 'disable' }}
+      with-cuda: ${{ inputs.build_cuda && 'enable' || 'disable' }}
+      with-rocm: ${{ inputs.build_rocm && 'enable' || 'disable' }}
     secrets: inherit
 
   build-windows:
@@ -271,6 +280,8 @@ jobs:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
       tensordict-source: ${{ inputs.tensordict_source || 'auto' }}
       channel: release
+      with-cpu: ${{ inputs.build_cpu && 'enable' || 'disable' }}
+      with-cuda: ${{ inputs.build_cuda && 'enable' || 'disable' }}
     secrets: inherit
 
   build-macos:
@@ -283,6 +294,7 @@ jobs:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
       tensordict-source: ${{ inputs.tensordict_source || 'auto' }}
       channel: release
+      with-cpu: ${{ inputs.build_cpu && 'enable' || 'disable' }}
     secrets: inherit
 
   build-aarch64:
@@ -295,6 +307,7 @@ jobs:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
       tensordict-source: ${{ inputs.tensordict_source || 'auto' }}
       channel: release
+      with-cpu: ${{ inputs.build_cpu && 'enable' || 'disable' }}
     secrets: inherit
 
   # =============================================================================
@@ -330,12 +343,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: wheels-raw
-          # Pattern based on wheel_variants input:
-          # - cpu: Only CPU builds (recommended - avoids duplicate wheel conflicts)
-          # - gpu: Only CUDA builds
-          # - all: All variants (requires deduplication)
+          # Download all pytorch_rl artifacts - filtering by selected variants happens below
           # pytorch/test-infra uploads artifacts named like: pytorch_rl__3.11_cpu_x86_64
-          pattern: ${{ inputs.wheel_variants == 'gpu' && 'pytorch_rl__*_cu*' || inputs.wheel_variants == 'all' && 'pytorch_rl*' || 'pytorch_rl__*_cpu_*' }}
+          pattern: pytorch_rl*
           merge-multiple: true
 
       - name: Deduplicate and verify wheels


### PR DESCRIPTION
## Summary

This PR adds workflow_dispatch inputs to select which wheel variants to build, presented as tickable checkboxes in the GitHub Actions UI:

- **build_cpu**: Build CPU wheels (default: true)
- **build_cuda**: Build CUDA wheels (default: false)
- **build_rocm**: Build ROCm wheels, Linux only (default: false)

The default is CPU-only since TorchRL is a pure Python library and doesn't require CUDA-specific wheels. This significantly speeds up release dry-runs.

## Changes

### Updated workflows:
- `build-wheels-linux.yml`: CPU, CUDA, ROCm options
- `build-wheels-windows.yml`: CPU, CUDA options
- `build-wheels-m1.yml`: CPU option only (macOS ARM64)
- `build-wheels-aarch64-linux.yml`: CPU option only (no CUDA support)
- `release.yml`: Updated to use boolean checkboxes instead of choice dropdown

### How it works:
- For `workflow_dispatch` (manual trigger): Boolean checkboxes appear in the UI
- For `workflow_call` (from release.yml): String inputs (`with-cpu`, `with-cuda`, `with-rocm`) with values `enable`/`disable`
- Parameters are passed to `pytorch/test-infra`'s `generate_binary_build_matrix.yml`

## Test plan

- [ ] Trigger `Build Linux Wheels` workflow manually with CPU-only selected
- [ ] Verify only CPU matrix is generated
- [ ] Trigger with CUDA+CPU selected and verify both are generated


Made with [Cursor](https://cursor.com)