### PR TITLE
[Feature] Add log_metrics method for efficient batch logging

### DIFF
--- a/torchrl/record/loggers/wandb.py
+++ b/torchrl/record/loggers/wandb.py
@@ -8,10 +8,11 @@ import importlib.util
 
 import os
 from collections.abc import Sequence
+from typing import Any
 
 from torch import Tensor
 
-from .common import Logger
+from .common import _make_metrics_safe, Logger
 
 _has_wandb = importlib.util.find_spec("wandb") is not None
 _has_omegaconf = importlib.util.find_spec("omegaconf") is not None
@@ -212,3 +213,24 @@ class WandbLogger(Logger):
             self.experiment.log({name: value}, step=step)
         else:
             self.experiment.log({name: table})
+
+    def log_metrics(
+        self, metrics: dict[str, Any], step: int | None = None
+    ) -> dict[str, Any]:
+        """Log multiple scalar metrics at once to wandb.
+
+        This method efficiently handles tensor values by batching CUDA->CPU
+        transfers and performing a single synchronization, then logs all
+        metrics in a single wandb API call.
+
+        Args:
+            metrics: Dictionary mapping metric names to values. Tensor values
+                are automatically converted to Python scalars/lists.
+            step: Optional step value for all metrics.
+
+        Returns:
+            The converted metrics dictionary (with tensors converted to Python types).
+        """
+        safe_metrics = _make_metrics_safe(metrics)
+        self.experiment.log(safe_metrics, step=step)
+        return safe_metrics


### PR DESCRIPTION
## Summary

- Add `log_metrics()` method to the base `Logger` class for logging multiple scalar metrics at once
- Add optimized implementations for `WandbLogger` and `MLFlowLogger` that use their native batch logging APIs (`experiment.log()` and `mlflow.log_metrics()` respectively)
- Add `_make_metrics_safe()` utility that efficiently converts CUDA tensors to Python types by batching transfers

## Motivation

When logging multiple tensor metrics from CUDA, calling `.item()` on each tensor triggers an implicit CUDA synchronization. With N metrics, that's N separate syncs.

The new implementation:
1. Queues all CUDA→CPU transfers with `non_blocking=True`
2. Synchronizes once via a CUDA event (which only waits for our transfers, not all GPU work)
3. Converts the now-CPU tensors to Python scalars/lists

This is particularly useful when logging to services running in separate processes (e.g., Ray actors for wandb/mlflow) that may not have GPU access.

## Test plan

- [ ] Verify existing logger tests pass
- [ ] Manual testing with wandb and mlflow loggers


Made with [Cursor](https://cursor.com)