### PR TITLE
[Doc] Document EGL multi-GPU limitations in containers

### DIFF
--- a/knowledge_base/DM_CONTROL_INSTALLATION.md
+++ b/knowledge_base/DM_CONTROL_INSTALLATION.md
@@ -62,8 +62,68 @@ pip install dm-env dm-tree glfw lxml mujoco numpy pyopengl pyparsing scipy
 
 ### 2. EGL/rendering issues
 
-See [MUJOCO_INSTALLATION.md](./MUJOCO_INSTALLATION.md) for rendering-related 
+See [MUJOCO_INSTALLATION.md](./MUJOCO_INSTALLATION.md) for rendering-related
 issues, as dm_control uses MuJoCo for rendering.
+
+#### EGL multi-GPU device selection in containers (Docker / SLURM)
+
+When running `ParallelEnv` with pixel-based dm_control environments on a
+multi-GPU machine, all rendering contends on a **single GPU** — even if the
+host has 8 GPUs. This inflates per-worker render time by ~3x (e.g. 17ms serial
+→ 54ms with 8 workers sharing one GPU's EGL queue).
+
+**Root cause:** Inside Docker or SLURM containers, the NVIDIA container runtime
+only exposes the GPU(s) assigned to the job to EGL. `eglQueryDevicesEXT()`
+returns 1 device regardless of how many physical GPUs the host has.
+Setting `MUJOCO_EGL_DEVICE_ID` or `EGL_DEVICE_ID` to anything other than 0
+raises:
+
+```
+RuntimeError: MUJOCO_EGL_DEVICE_ID must be an integer between 0 and 0 (inclusive), got 1.
+```
+
+Unsetting `CUDA_VISIBLE_DEVICES` in the worker does **not** help — the
+container isolation happens at the NVIDIA driver/runtime level, below the
+environment variable.
+
+**Note on variable naming:** dm_control uses `MUJOCO_EGL_DEVICE_ID` internally
+(which maps to the same thing as MuJoCo's variable). Historically there was
+also `EGL_DEVICE_ID` used by older dm_control versions. See
+[dm_control#345](https://github.com/google-deepmind/dm_control/issues/345)
+for the unification discussion.
+
+**Upstream issues:**
+- [mujoco#572 — Cannot access all GPUs through EGL devices when using docker](https://github.com/google-deepmind/mujoco/issues/572)
+- [dm_control#345 — Unify EGL_DEVICE_ID with MUJOCO_EGL_DEVICE_ID](https://github.com/google-deepmind/dm_control/issues/345)
+
+**Workarounds:**
+
+1. **Configure container for full GPU access.** If you control the container
+   runtime, set `NVIDIA_VISIBLE_DEVICES=all` and
+   `NVIDIA_DRIVER_CAPABILITIES=all` so EGL can see all GPUs. Then assign
+   `MUJOCO_EGL_DEVICE_ID=<worker_idx % num_gpus>` per worker process
+   **before** dm_control is imported (the EGL display is created at import
+   time).
+
+2. **Run outside containers.** On bare metal, `eglQueryDevicesEXT()` correctly
+   returns all GPUs (plus the X server display, if any).
+
+3. **Reduce rendering overhead.** If multi-GPU rendering is not possible:
+   - Lower the rendering resolution (e.g. 64x64 instead of 84x84)
+   - Render at a lower frequency than the simulation step (frame-skip)
+   - Use state-only observations where possible — the IPC overhead is small
+     compared to rendering
+
+#### No batched rendering support in MuJoCo
+
+MuJoCo does not support batched GPU rendering — each environment renders its
+scene independently through its own OpenGL context. There is no API to submit
+multiple scenes to the GPU in one call.
+
+MuJoCo XLA (MJX) accelerates *simulation* on GPU via JAX but still requires
+copying data back to CPU for rendering through the standard `mujoco.Renderer`
+pipeline. See [mujoco#1604](https://github.com/google-deepmind/mujoco/issues/1604)
+for discussion on batched rendering support.
 
 ### 3. macOS ARM64 (Apple Silicon) specific issues
 


### PR DESCRIPTION
## Summary
- Documents the EGL multi-GPU device visibility limitation when running dm_control pixel environments inside Docker/SLURM containers
- Explains why `MUJOCO_EGL_DEVICE_ID` / `EGL_DEVICE_ID` only allows device 0 in containers
- Documents the lack of batched rendering support in MuJoCo
- Links upstream issues: [mujoco#572](https://github.com/google-deepmind/mujoco/issues/572), [dm_control#345](https://github.com/google-deepmind/dm_control/issues/345), [mujoco#1604](https://github.com/google-deepmind/mujoco/issues/1604)
- Lists workarounds (container config, bare metal, reducing rendering overhead)

## Test plan
- [x] Documentation-only change, no code modified


Made with [Cursor](https://cursor.com)