### PR TITLE
[Perf] ParallelEnv: replace mp.Event with shared-memory done flags

### DIFF
--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -1630,14 +1630,15 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
         # Eliminates futex syscalls from mp.Event on the critical path.
         self._shm_done_flags = mp.RawArray("b", _num_workers)
 
-        kwargs = [
-            {
-                "mp_event": self._events[i],
-                "worker_idx": i,
-                "shm_done_flags": self._shm_done_flags,
-            }
-            for i in range(_num_workers)
-        ]
+        kwargs = [{"mp_event": self._events[i]} for i in range(_num_workers)]
+        if self._use_buffers:
+            for i in range(_num_workers):
+                kwargs[i].update(
+                    {
+                        "worker_idx": i,
+                        "shm_done_flags": self._shm_done_flags,
+                    }
+                )
         with clear_mpi_env_vars():
             for idx in range(_num_workers):
                 if self._verbose:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3461
* #3460
* #3459
* #3458
* __->__ #3457

Replace multiprocessing.Event (futex-based syscalls) with
multiprocessing.RawArray shared-memory byte flags for worker-to-parent
completion signaling on the hot path (step_and_maybe_reset).

- _start_workers: creates shm_done_flags RawArray, passes to workers
- _wait_for_workers: spin-polls done_flags instead of Event.wait()
- Worker: _signal_done() closure writes shm_done_flags[idx]=1
- _shutdown_workers: uses _wait_for_workers instead of Event.wait()

Measured impact:
- 10% FPS improvement (7,737 -> 8,509 fps) on H200 with 8 workers
- 28% reduction in penv.wait_for_workers overhead (2,622us -> 1,891us)
- ParallelEnv.close() fixed from 80s timeout to ~0.9s

Co-authored-by: Cursor <cursoragent@cursor.com>