### PR TITLE
[BugFix] VideoRecorder: support grayscale (1-channel) observations

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -14802,6 +14802,28 @@ class TestVideoRecorder:
 
         assert recorder is not None
 
+    def test_video_recorder_grayscale(self):
+        """Test that VideoRecorder handles 1-channel (grayscale) observations."""
+        recorder = VideoRecorder(None, None, fps=30)
+        # Simulate a grayscale observation: (1, H, W) — single channel
+        obs = torch.randint(0, 255, (1, 64, 64), dtype=torch.uint8)
+        recorder._apply_transform(obs)
+        # The stored frame should be expanded to 3-channel for video codecs
+        assert len(recorder.obs) == 1
+        stored = recorder.obs[0]
+        assert stored.shape == (3, 64, 64)
+
+    def test_video_recorder_grayscale_batched(self):
+        """Test that VideoRecorder handles batched grayscale observations."""
+        recorder = VideoRecorder(None, None, fps=30)
+        # Batched grayscale: (B, 1, H, W)
+        obs = torch.randint(0, 255, (4, 1, 64, 64), dtype=torch.uint8)
+        recorder._apply_transform(obs)
+        # Batched observations get flattened into individual frames
+        assert len(recorder.obs) == 4
+        for frame in recorder.obs:
+            assert frame.shape == (3, 64, 64)
+
 
 class TestConditionalPolicySwitch(TransformBase):
     def test_single_trans_env_check(self):

--- a/torchrl/record/recorder.py
+++ b/torchrl/record/recorder.py
@@ -174,13 +174,18 @@ class VideoRecorder(ObservationTransform):
         if self.count % self.skip == 0:
             if (
                 observation_trsf.ndim >= 3
-                and observation_trsf.shape[-3] == 3
+                and observation_trsf.shape[-3] in (1, 3)
                 and observation_trsf.shape[-2] > 3
                 and observation_trsf.shape[-1] > 3
             ):
                 # permute the channels to the last dim
                 observation_trsf = observation_trsf.permute(
                     *range(observation_trsf.ndim - 3), -2, -1, -3
+                )
+            # Handle grayscale (1-channel) by expanding to 3-channel for video
+            if observation_trsf.ndim >= 3 and observation_trsf.shape[-1] == 1:
+                observation_trsf = observation_trsf.expand(
+                    *observation_trsf.shape[:-1], 3
                 )
             if not (
                 observation_trsf.shape[-1] == 3 or observation_trsf.ndimension() == 2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3488
* #3487
* #3486
* #3485
* #3484
* #3483
* #3474
* #3473
* #3472
* __->__ #3471

VideoRecorder previously only accepted 3-channel (RGB) observations.
This extends it to also handle 1-channel (grayscale) observations by:
- Accepting shape[-3] in (1, 3) instead of == 3 for channel detection
- Expanding 1-channel to 3-channel for video codec compatibility

Co-authored-by: Cursor <cursoragent@cursor.com>