### PR TITLE
[Feature] ObsDecoder: add out_channels parameter for grayscale decoding

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -466,6 +466,19 @@ class TestDreamerComponents:
         obs = decoder(stoch_state, det_state)
         assert obs.shape == (*batch_size, *temporal_size, 3, 64, 64)
 
+    @pytest.mark.parametrize("depth", [32, 64])
+    @pytest.mark.parametrize("out_channels", [1, 3])
+    @pytest.mark.parametrize("stoch_size", [10])
+    @pytest.mark.parametrize("deter_size", [20])
+    def test_dreamer_decoder_out_channels(
+        self, device, batch_size, depth, out_channels, stoch_size, deter_size
+    ):
+        decoder = ObsDecoder(channels=depth, out_channels=out_channels).to(device)
+        stoch_state = torch.randn(*batch_size, stoch_size, device=device)
+        det_state = torch.randn(*batch_size, deter_size, device=device)
+        obs = decoder(stoch_state, det_state)
+        assert obs.shape == (*batch_size, out_channels, 64, 64)
+
     @pytest.mark.parametrize("stoch_size", [10, 20])
     @pytest.mark.parametrize("deter_size", [20, 30])
     @pytest.mark.parametrize("action_size", [3, 6])

--- a/torchrl/modules/models/model_based.py
+++ b/torchrl/modules/models/model_based.py
@@ -156,6 +156,9 @@ class ObsDecoder(nn.Module):
             Defaults to ``[5, 5, 6, 6]`` if num_layers if 4, else ``[5] * num_layers``.
         latent_dim (int, optional): Input dimension (state_dim + rnn_hidden_dim).
             If None, uses LazyLinear. Defaults to None for backward compatibility.
+        out_channels (int, optional): Number of output channels in the final
+            ConvTranspose2d layer.  Defaults to 3 (RGB).  Set to 1 for
+            grayscale.
         device (torch.device, optional): Device to create the module on.
             Defaults to None (uses default device).
     """
@@ -166,6 +169,7 @@ class ObsDecoder(nn.Module):
         num_layers=4,
         kernel_sizes=None,
         latent_dim=None,
+        out_channels=3,
         depth=None,
         device=None,
     ):
@@ -199,7 +203,9 @@ class ObsDecoder(nn.Module):
             kernel_sizes = [kernel_sizes] * num_layers
         layers = [
             nn.ReLU(),
-            nn.ConvTranspose2d(channels, 3, kernel_sizes[-1], stride=2, device=device),
+            nn.ConvTranspose2d(
+                channels, out_channels, kernel_sizes[-1], stride=2, device=device
+            ),
         ]
         kernel_sizes = kernel_sizes[:-1]
         k = 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3488
* #3487
* #3486
* #3485
* #3484
* #3483
* #3474
* #3473
* __->__ #3472
* #3471

Add an out_channels parameter to ObsDecoder (default 3 for RGB) that
controls the number of output channels in the final ConvTranspose2d
layer.  Setting out_channels=1 enables grayscale pixel decoding.

Co-authored-by: Cursor <cursoragent@cursor.com>