### PR TITLE
[BugFix] Collector: fix masked_scatter shape preservation on MPS

### DIFF
--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -1594,7 +1594,12 @@ class Collector(BaseCollector):
             new_traj = pool.get_traj_and_increment(
                 traj_sop.sum(), device=traj_sop.device
             )
-            traj_ids = traj_ids.masked_scatter(traj_sop, new_traj)
+            # masked_scatter on MPS may incorrectly change the shape from [] to [1],
+            # so we preserve the original shape and reshape after the operation.
+            original_shape = traj_ids.shape
+            traj_ids = traj_ids.masked_scatter(traj_sop, new_traj).reshape(
+                original_shape
+            )
             self._carrier.set(("collector", "traj_ids"), traj_ids)
 
     @torch.no_grad()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3488
* #3487
* #3486
* #3485
* #3484
* #3483
* #3474
* __->__ #3473
* #3472
* #3471

masked_scatter on MPS may incorrectly change a scalar tensor shape
from [] to [1].  Preserve the original shape and reshape after the
operation to work around this.

The upstream fix in PyTorch core is pytorch/pytorch#174381.
This workaround can be removed once that fix lands in a release.