### PR TITLE
[Example] Dreamer: add IsaacLab training script and config

### DIFF
--- a/sota-implementations/dreamer/config_isaac.yaml
+++ b/sota-implementations/dreamer/config_isaac.yaml
@@ -1,0 +1,86 @@
+env:
+  name: Isaac-Velocity-Flat-Anymal-C-v0
+  seed: 0
+  backend: isaaclab
+  from_pixels: True
+  image_size: 64
+  grayscale: False
+  # Number of parallel envs.  Rendering is expensive so we use fewer
+  # than the default 4096 used for state-based training.
+  num_envs: 256
+  horizon: 1000
+
+collector:
+  # 256 envs x 50 steps = 12 800 frames per batch.
+  frames_per_batch: 12800
+  init_random_frames: 12800
+  # More gradient steps per collection to compensate for fewer frames.
+  optim_steps_per_collect: 50
+
+optimization:
+  total_optim_steps: 100_000
+  log_every: 100
+  grad_clip: 100
+
+  world_model_lr: 6e-4
+  actor_lr: 8e-5
+  value_lr: 8e-5
+  # Linear warmup for actor/value LRs.  During the first `warmup_steps`
+  # optimisation steps the LR ramps linearly from 0 -> target.  Set to 0
+  # to disable warmup.
+  actor_value_warmup_steps: 0
+  kl_scale: 1.0
+  free_nats: 3.0
+  gamma: 0.99
+  lmbda: 0.95
+  imagination_horizon: 15
+  compile:
+    # Loss-level compile disabled: TensorDict output from compiled loss modules
+    # hits 'TensorDict has no attribute _tensordict' with the IsaacLab container's
+    # bundled tensordict. The RSSM rollout compile (networks.rssm_rollout.compile)
+    # still works because it compiles the step function internally.
+    enabled: False
+    backend: inductor
+    cudagraphs: False
+    losses: []
+  autocast: bfloat16
+
+networks:
+  exploration_noise: 0.3
+  device:
+  state_dim: 30
+  rssm_hidden_dim: 200
+  hidden_dim: 400
+  encoder_channels: 32
+  activation: "elu"
+  use_scan: False
+  rssm_rollout:
+    compile: True
+    compile_backend: inductor
+    # "default" instead of "reduce-overhead": reduce-overhead uses CUDAGraphs
+    # which re-record for every new batch size, causing massive slowdowns when
+    # the sampler returns varying batch sizes (strict_length=False).
+    compile_mode: default
+
+replay_buffer:
+  # Pixel data is large (64x64x3 float32 ~ 48 KB/frame).
+  # 8000 frames x 50 batch_length -> 160 trajectories per batch.
+  batch_size: 8000
+  buffer_size: 500000
+  batch_length: 50
+  scratch_dir: null
+  prefetch: 16
+  gpu_storage: false
+
+logger:
+  backend: wandb
+  project: dreamer-isaac
+  exp_name: ${env.name}-${env.seed}
+  mode: online
+  eval_every: 1000
+  eval_rollout_steps: 500
+  # Number of parallel envs in the eval actor (fewer = less GPU memory).
+  eval_num_envs: 4
+  # Enable async eval with viewport rendering (requires >= 3 GPUs).
+  video: True
+  video_skip: 1

--- a/sota-implementations/dreamer/dreamer_isaac.py
+++ b/sota-implementations/dreamer/dreamer_isaac.py
@@ -1,0 +1,667 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Dreamer v1 training with IsaacLab environments (pixel-based).
+
+CRITICAL: IsaacLab requires AppLauncher to be initialized before importing torch.
+This is why this script has a non-standard import order -- the AppLauncher init
+MUST happen at the very top, before any torch/torchrl imports.
+
+IsaacLab environments are:
+- Pre-vectorized (e.g., 256 parallel envs for pixel-based training)
+- GPU-native (always on cuda:0)
+- Pixel observations via TiledCamera (efficient batched rendering)
+
+GPU strategy:
+- GPU 0 ("sim_device"): IsaacLab simulation + rendering + collection policy
+- GPU 1 ("train_device"): Model training (world model, actor, value gradients)
+- GPU 2 (optional): Async evaluation rendering via RayEvalWorker
+- Collection and training alternate synchronously
+- Falls back to single-GPU if only 1 GPU is available
+"""
+from __future__ import annotations
+
+# ============================================================================
+# STEP 1: Initialize IsaacLab AppLauncher BEFORE importing torch
+# ============================================================================
+import argparse
+import sys
+
+from isaaclab.app import AppLauncher
+
+parser = argparse.ArgumentParser(description="Dreamer + IsaacLab Training")
+AppLauncher.add_app_launcher_args(parser)
+args_cli, _ = parser.parse_known_args(["--headless", "--enable_cameras"])
+app_launcher = AppLauncher(args_cli)
+
+# ============================================================================
+# STEP 2: Now safe to import torch, torchrl, and everything else
+# ============================================================================
+import contextlib
+import copy
+import functools
+import math
+import time
+
+import hydra
+import torch
+import torch.cuda
+import tqdm
+
+from dreamer_utils import (
+    _make_env,
+    dump_video,
+    log_metrics,
+    make_dreamer,
+    make_eval_policy_factory,
+    make_isaac_eval_env_factory,
+    make_isaac_init_fn,
+    make_replay_buffer,
+    transform_env,
+)
+from omegaconf import DictConfig
+from tensordict import TensorDict
+from torch.amp import GradScaler
+from torch.autograd.profiler import record_function
+from torch.nn.utils import clip_grad_norm_
+from torchrl._utils import compile_with_warmup, logger as torchrl_logger, timeit
+from torchrl.collectors import Collector
+from torchrl.envs.utils import ExplorationType, set_exploration_type
+from torchrl.objectives.dreamer import (
+    DreamerActorLoss,
+    DreamerModelLoss,
+    DreamerValueLoss,
+)
+from torchrl.record.loggers import generate_exp_name, get_logger
+
+
+@hydra.main(version_base="1.1", config_path="", config_name="config_isaac")
+def main(cfg: DictConfig):
+    # ========================================================================
+    # Device setup: sim on cuda:0, training on cuda:1 (or cuda:0 if single GPU)
+    # ========================================================================
+    sim_device = torch.device("cuda:0")  # IsaacLab always binds to cuda:0
+    num_gpus = torch.cuda.device_count()
+    train_device = torch.device("cuda:1") if num_gpus > 1 else sim_device
+
+    torchrl_logger.info(
+        f"GPU setup: {num_gpus} GPUs available, "
+        f"sim_device={sim_device}, train_device={train_device}"
+    )
+
+    # Create logger
+    exp_name = generate_exp_name("Dreamer-Isaac", cfg.logger.exp_name)
+    logger = None
+    if cfg.logger.backend:
+        logger = get_logger(
+            logger_type=cfg.logger.backend,
+            logger_name="dreamer_isaac_logging",
+            experiment_name=exp_name,
+            wandb_kwargs={
+                "mode": cfg.logger.mode,
+                "project": cfg.logger.project,
+            },
+        )
+        if hasattr(logger, "log_hparams"):
+            logger.log_hparams(cfg)
+
+    # ========================================================================
+    # Environment setup (on sim_device = cuda:0)
+    # ========================================================================
+    torchrl_logger.info(f"Creating IsaacLab env: {cfg.env.name}")
+    train_env = _make_env(cfg, device=sim_device)
+    # Pass device=sim_device so GPU-accelerated image transforms are used
+    train_env = transform_env(cfg, train_env, device=sim_device)
+    train_env.set_seed(cfg.env.seed)
+
+    # Pixel observations are normalised to [0, 1] by ToTensorImage /
+    # GPUImageTransform inside transform_env.  No additional ObservationNorm
+    # is needed (unlike the state-based setup).
+
+    torchrl_logger.info(
+        f"IsaacLab env created: batch_size={train_env.batch_size}, "
+        f"obs_spec keys={list(train_env.observation_spec.keys())}, "
+        f"action_shape={train_env.action_spec.shape}"
+    )
+
+    # ========================================================================
+    # Dreamer components (on train_device for gradient computation)
+    # ========================================================================
+    action_key = "action"
+    value_key = "state_value"
+    (
+        world_model,
+        model_based_env,
+        model_based_env_eval,
+        actor_model,
+        value_model,
+        policy,
+    ) = make_dreamer(
+        cfg=cfg,
+        device=train_device,
+        action_key=action_key,
+        value_key=value_key,
+        use_decoder_in_env=cfg.env.from_pixels,
+        logger=logger,
+        test_env=train_env,  # env on sim_device; make_dreamer transfers init data
+    )
+
+    # ========================================================================
+    # Collector policy: deep copy on sim_device for collection
+    # ========================================================================
+    collector_policy = copy.deepcopy(policy)
+    if train_device != sim_device:
+        collector_policy = collector_policy.to(sim_device)
+        torchrl_logger.info(
+            f"Created collector policy copy on {sim_device} "
+            f"(training models on {train_device})"
+        )
+
+    # ========================================================================
+    # Async eval worker (on a dedicated GPU via Ray)
+    # ========================================================================
+    eval_worker = None
+    if cfg.logger.video and num_gpus >= 3:
+        import ray
+
+        from torchrl.eval import RayEvalWorker
+
+        ray.init(num_gpus=num_gpus - 2)
+        eval_worker = RayEvalWorker(
+            init_fn=make_isaac_init_fn(),
+            env_maker=make_isaac_eval_env_factory(cfg),
+            policy_maker=make_eval_policy_factory(cfg),
+            num_gpus=1,
+        )
+        torchrl_logger.info(
+            f"Eval worker created: eval_every={cfg.logger.eval_every}, "
+            f"eval_rollout_steps={cfg.logger.eval_rollout_steps}, "
+            f"eval_num_envs={cfg.logger.eval_num_envs}"
+        )
+    elif cfg.logger.video:
+        torchrl_logger.warning(
+            f"Video rendering requested but only {num_gpus} GPUs available. "
+            "Need >= 3 GPUs (sim + train + eval). Skipping eval worker."
+        )
+
+    # ========================================================================
+    # Losses (on train_device)
+    # ========================================================================
+    # Pixel observations are 5D [B, T, C, H, W].  The default reduction
+    # sum((-3,-2,-1)) correctly sums over C, H, W only, so global_average
+    # is not needed (unlike the 3D state-based case).
+    world_model_loss = DreamerModelLoss(world_model)
+    # Default keys "pixels" / "reco_pixels" match the CNN encoder/decoder.
+
+    actor_loss = DreamerActorLoss(
+        actor_model,
+        value_model,
+        model_based_env,
+        imagination_horizon=cfg.optimization.imagination_horizon,
+        discount_loss=True,
+    )
+    actor_loss.make_value_estimator(
+        gamma=cfg.optimization.gamma, lmbda=cfg.optimization.lmbda
+    )
+    value_loss = DreamerValueLoss(
+        value_model, discount_loss=True, gamma=cfg.optimization.gamma
+    )
+
+    # ========================================================================
+    # Replay buffer (always CPU storage for thread safety)
+    # ========================================================================
+    batch_size = cfg.replay_buffer.batch_size
+    batch_length = cfg.replay_buffer.batch_length
+    replay_buffer = make_replay_buffer(
+        batch_size=batch_size,
+        batch_seq_len=batch_length,
+        buffer_size=cfg.replay_buffer.buffer_size,
+        buffer_scratch_dir=cfg.replay_buffer.scratch_dir,
+        device=train_device,
+        prefetch=cfg.replay_buffer.prefetch,
+        pixel_obs=cfg.env.from_pixels,
+        grayscale=cfg.env.get("grayscale", False),
+        image_size=cfg.env.get("image_size", 64),
+        gpu_storage=cfg.replay_buffer.get("gpu_storage", False),
+    )
+    torchrl_logger.info(
+        f"Replay buffer: batch_size={batch_size}, batch_length={batch_length}, "
+        f"device={train_device}"
+    )
+
+    # ========================================================================
+    # Collector (on sim_device, uses collector_policy)
+    # ========================================================================
+    collector = Collector(
+        create_env_fn=train_env,
+        policy=collector_policy,
+        frames_per_batch=cfg.collector.frames_per_batch,
+        total_frames=-1,
+        init_random_frames=cfg.collector.init_random_frames,
+        storing_device="cpu",
+        no_cuda_sync=True,  # Critical for CUDA-native IsaacLab envs
+    )
+    collector.set_seed(cfg.env.seed)
+
+    # ========================================================================
+    # Optimizers (on train_device)
+    # ========================================================================
+    use_fused = train_device.type == "cuda"
+    world_model_opt = torch.optim.Adam(
+        world_model.parameters(), lr=cfg.optimization.world_model_lr, fused=use_fused
+    )
+    actor_opt = torch.optim.Adam(
+        actor_model.parameters(), lr=cfg.optimization.actor_lr, fused=use_fused
+    )
+    value_opt = torch.optim.Adam(
+        value_model.parameters(), lr=cfg.optimization.value_lr, fused=use_fused
+    )
+
+    # Optional linear warmup for actor & value LRs — keeps them near-zero
+    # while the world model learns to reconstruct, then ramps to target LR.
+    warmup_steps = cfg.optimization.get("actor_value_warmup_steps", 0)
+    actor_scheduler = None
+    value_scheduler = None
+    if warmup_steps > 0:
+        actor_scheduler = torch.optim.lr_scheduler.LinearLR(
+            actor_opt, start_factor=1e-3, end_factor=1.0, total_iters=warmup_steps
+        )
+        value_scheduler = torch.optim.lr_scheduler.LinearLR(
+            value_opt, start_factor=1e-3, end_factor=1.0, total_iters=warmup_steps
+        )
+        torchrl_logger.info(
+            f"Actor/value LR warmup: {warmup_steps} steps "
+            f"(0 → {cfg.optimization.actor_lr} / {cfg.optimization.value_lr})"
+        )
+
+    # ========================================================================
+    # Mixed precision
+    # ========================================================================
+    autocast_cfg = cfg.optimization.autocast
+    if autocast_cfg in (False, "false", "False"):
+        autocast_dtype = None
+    elif autocast_cfg in (True, "true", "True", "bfloat16"):
+        autocast_dtype = torch.bfloat16
+    elif autocast_cfg == "float16":
+        autocast_dtype = torch.float16
+    else:
+        raise ValueError(
+            f"Invalid autocast value: {autocast_cfg}. "
+            "Use false, true, float16, or bfloat16."
+        )
+
+    # GradScaler is only needed for float16 (limited dynamic range).
+    # bfloat16 has the same exponent range as float32, so no scaling needed.
+    use_scaler = autocast_dtype == torch.float16
+    if use_scaler:
+        scaler1 = GradScaler()
+        scaler2 = GradScaler()
+        scaler3 = GradScaler()
+
+    if train_device.type == "cuda":
+        torch.set_float32_matmul_precision("high")
+
+    # ========================================================================
+    # torch.compile
+    # ========================================================================
+    compile_cfg = cfg.optimization.compile
+    compile_enabled = compile_cfg.enabled
+    compile_losses = set(compile_cfg.losses)
+    if compile_enabled:
+        torch._dynamo.config.capture_scalar_outputs = True
+
+        compile_warmup = 3
+        torchrl_logger.info(f"Compiling loss modules with warmup={compile_warmup}")
+        backend = compile_cfg.backend
+        cudagraphs = compile_cfg.cudagraphs
+        compile_options = {"triton.cudagraphs": cudagraphs}
+
+        if "world_model" in compile_losses:
+            world_model_loss = compile_with_warmup(
+                world_model_loss,
+                backend=backend,
+                fullgraph=False,
+                warmup=compile_warmup,
+                options=compile_options,
+            )
+        if "actor" in compile_losses:
+            actor_loss = compile_with_warmup(
+                actor_loss,
+                backend=backend,
+                fullgraph=False,
+                warmup=compile_warmup,
+                options=compile_options,
+            )
+        if "value" in compile_losses:
+            value_loss = compile_with_warmup(
+                value_loss,
+                backend=backend,
+                fullgraph=False,
+                warmup=compile_warmup,
+                options=compile_options,
+            )
+    else:
+        compile_warmup = 0
+
+    # ========================================================================
+    # Training config
+    # ========================================================================
+    total_optim_steps = cfg.optimization.total_optim_steps
+    log_every = cfg.optimization.log_every
+    grad_clip = cfg.optimization.grad_clip
+    optim_steps_per_collect = cfg.collector.optim_steps_per_collect
+
+    eval_every = cfg.logger.eval_every
+    eval_rollout_steps = cfg.logger.eval_rollout_steps
+    next_eval_step = eval_every
+    next_sim_eval_step = eval_every
+
+    pbar = tqdm.tqdm(total=total_optim_steps, desc="Optim steps")
+    t_log_start = time.time()
+    frames_at_log_start = 0
+    collected_frames = 0
+    optim_step = 0
+    last_mean_reward = float("nan")
+
+    torchrl_logger.info(
+        f"Starting synchronous training: {total_optim_steps} optim steps, "
+        f"optim_steps_per_collect={optim_steps_per_collect}, "
+        f"frames_per_batch={cfg.collector.frames_per_batch}, "
+        f"init_random_frames={cfg.collector.init_random_frames}"
+    )
+
+    # ========================================================================
+    # Main training loop: synchronous collect -> train
+    # ========================================================================
+    for i_collect, data in enumerate(collector):
+        # ---- Extend replay buffer ----
+        with timeit("collect/extend"):
+            # Strip intermediate pixels_int to save memory (already processed
+            # into float32 "pixels" by GPUImageTransform in the env).
+            if "pixels_int" in data.keys():
+                data = data.exclude("pixels_int", ("next", "pixels_int"))
+            replay_buffer.extend(data)
+        collected_frames += data.numel()
+
+        # Track episode rewards from completed episodes
+        done_mask = data["next", "done"].squeeze(-1)
+        if done_mask.any():
+            episode_rewards = data["next", "episode_reward"][done_mask]
+            last_mean_reward = episode_rewards.mean().item()
+
+        # Skip training on first batch (random exploration data)
+        if i_collect == 0:
+            torchrl_logger.info(
+                f"Init data collected: {collected_frames} frames. "
+                f"Starting training on {train_device}."
+            )
+            continue
+
+        # ---- Train for optim_steps_per_collect steps ----
+        for _j in range(optim_steps_per_collect):
+            if optim_step >= total_optim_steps:
+                break
+            pbar.update(1)
+
+            # Sample from replay buffer
+            with timeit("train/sample"), record_function("## train/sample ##"):
+                sampled_tensordict = replay_buffer.sample()
+                # With strict_length=False, the sample numel may not be
+                # exactly divisible by batch_length. Truncate to make it so.
+                numel = sampled_tensordict.numel()
+                usable = (numel // batch_length) * batch_length
+                if usable < numel:
+                    sampled_tensordict = sampled_tensordict[:usable]
+                sampled_tensordict = sampled_tensordict.reshape(-1, batch_length)
+
+            # --- World model update ---
+            with timeit("train/world_model-forward"), record_function(
+                "## world_model/forward ##"
+            ):
+                torch.compiler.cudagraph_mark_step_begin()
+                with torch.autocast(
+                    device_type=train_device.type, dtype=autocast_dtype
+                ) if autocast_dtype else contextlib.nullcontext():
+                    model_loss_td, sampled_tensordict = world_model_loss(
+                        sampled_tensordict
+                    )
+                    loss_world_model = (
+                        model_loss_td["loss_model_kl"]
+                        + model_loss_td["loss_model_reco"]
+                        + model_loss_td["loss_model_reward"]
+                    )
+
+            total_val = loss_world_model.item()
+            if math.isnan(total_val) or math.isinf(total_val):
+                torchrl_logger.error(
+                    f"NaN/Inf in world model loss at optim_step={optim_step}, aborting."
+                )
+                sys.exit(1)
+
+            with timeit("train/world_model-backward"), record_function(
+                "## world_model/backward ##"
+            ):
+                world_model_opt.zero_grad()
+                if use_scaler:
+                    scaler1.scale(loss_world_model).backward()
+                    scaler1.unscale_(world_model_opt)
+                else:
+                    loss_world_model.backward()
+                world_model_grad = clip_grad_norm_(world_model.parameters(), grad_clip)
+
+                if use_scaler:
+                    scaler1.step(world_model_opt)
+                    scaler1.update()
+                else:
+                    world_model_opt.step()
+
+            # --- Actor update ---
+            with timeit("train/actor-forward"), record_function("## actor/forward ##"):
+                torch.compiler.cudagraph_mark_step_begin()
+                with torch.autocast(
+                    device_type=train_device.type, dtype=autocast_dtype
+                ) if autocast_dtype else contextlib.nullcontext():
+                    actor_loss_td, sampled_tensordict = actor_loss(
+                        sampled_tensordict.reshape(-1)
+                    )
+
+            actor_val = actor_loss_td["loss_actor"].item()
+            if math.isnan(actor_val) or math.isinf(actor_val):
+                torchrl_logger.error(
+                    f"NaN/Inf in actor loss at optim_step={optim_step}, aborting."
+                )
+                sys.exit(1)
+
+            with timeit("train/actor-backward"), record_function(
+                "## actor/backward ##"
+            ):
+                actor_opt.zero_grad()
+                if use_scaler:
+                    scaler2.scale(actor_loss_td["loss_actor"]).backward()
+                    scaler2.unscale_(actor_opt)
+                else:
+                    actor_loss_td["loss_actor"].backward()
+                actor_model_grad = clip_grad_norm_(actor_model.parameters(), grad_clip)
+
+                if use_scaler:
+                    scaler2.step(actor_opt)
+                    scaler2.update()
+                else:
+                    actor_opt.step()
+                if actor_scheduler is not None:
+                    actor_scheduler.step()
+
+            # --- Value update ---
+            with timeit("train/value-forward"), record_function("## value/forward ##"):
+                torch.compiler.cudagraph_mark_step_begin()
+                with torch.autocast(
+                    device_type=train_device.type, dtype=autocast_dtype
+                ) if autocast_dtype else contextlib.nullcontext():
+                    value_loss_td, sampled_tensordict = value_loss(sampled_tensordict)
+
+            value_val = value_loss_td["loss_value"].item()
+            if math.isnan(value_val) or math.isinf(value_val):
+                torchrl_logger.error(
+                    f"NaN/Inf in value loss at optim_step={optim_step}, aborting."
+                )
+                sys.exit(1)
+
+            with timeit("train/value-backward"), record_function(
+                "## value/backward ##"
+            ):
+                value_opt.zero_grad()
+                if use_scaler:
+                    scaler3.scale(value_loss_td["loss_value"]).backward()
+                    scaler3.unscale_(value_opt)
+                else:
+                    value_loss_td["loss_value"].backward()
+                critic_model_grad = clip_grad_norm_(value_model.parameters(), grad_clip)
+
+                if use_scaler:
+                    scaler3.step(value_opt)
+                    scaler3.update()
+                else:
+                    value_opt.step()
+                if value_scheduler is not None:
+                    value_scheduler.step()
+
+            optim_step += 1
+
+            # ============================================================
+            # Logging
+            # ============================================================
+            if optim_step % log_every == 0:
+                t_log_end = time.time()
+                log_interval_time = t_log_end - t_log_start
+                frames_this_interval = collected_frames - frames_at_log_start
+
+                fps = (
+                    frames_this_interval / log_interval_time
+                    if log_interval_time > 0
+                    else 0
+                )
+                ops = log_every / log_interval_time if log_interval_time > 0 else 0
+                opf = optim_step / collected_frames if collected_frames > 0 else 0
+
+                pbar.set_postfix(
+                    fps=f"{fps:.1f}",
+                    ops=f"{ops:.1f}",
+                    opf=f"{opf:.2f}",
+                    frames=collected_frames,
+                )
+
+                sampled_reward = sampled_tensordict.get(("next", "reward"))
+                reward_mean = sampled_reward.mean().item()
+                reward_std = sampled_reward.std().item()
+
+                metrics = {
+                    "loss_model_kl": model_loss_td["loss_model_kl"].item(),
+                    "loss_model_reco": model_loss_td["loss_model_reco"].item(),
+                    "loss_model_reward": model_loss_td["loss_model_reward"].item(),
+                    "loss_actor": actor_loss_td["loss_actor"].item(),
+                    "loss_value": value_loss_td["loss_value"].item(),
+                    "world_model_grad": world_model_grad,
+                    "actor_model_grad": actor_model_grad,
+                    "critic_model_grad": critic_model_grad,
+                    "train/reward_mean": reward_mean,
+                    "train/reward_std": reward_std,
+                    "train/episode_reward": last_mean_reward,
+                    "throughput/fps": fps,
+                    "throughput/ops": ops,
+                    "throughput/opf": opf,
+                    "collected_frames": collected_frames,
+                    **timeit.todict(prefix="time"),
+                }
+                if actor_scheduler is not None:
+                    metrics["lr/actor"] = actor_scheduler.get_last_lr()[0]
+                    metrics["lr/value"] = value_scheduler.get_last_lr()[0]
+
+                if logger is not None:
+                    log_metrics(logger, metrics, collected_frames)
+
+                t_log_start = time.time()
+                frames_at_log_start = collected_frames
+
+        # ---- Sync weights to collector policy ----
+        weights = TensorDict.from_module(policy)
+        collector.update_policy_weights_(weights)
+        policy[1].step(optim_steps_per_collect)  # Update exploration noise schedule
+
+        # ---- Async eval: poll results & submit new rollout ----
+        if eval_worker is not None:
+            eval_result = eval_worker.poll()
+            if eval_result is not None:
+                eval_metrics = {"eval/reward": eval_result["reward"]}
+                if logger is not None:
+                    log_metrics(logger, eval_metrics, collected_frames)
+                    if eval_result["frames"] is not None:
+                        logger.log_video(
+                            "eval/video",
+                            eval_result["frames"],
+                            step=collected_frames,
+                        )
+                torchrl_logger.info(
+                    f"Eval result: reward={eval_result['reward']:.4f}, "
+                    f"has_video={eval_result['frames'] is not None}"
+                )
+
+            if optim_step >= next_eval_step:
+                next_eval_step += eval_every
+                eval_weights = TensorDict.from_module(policy).data.detach().cpu()
+                eval_worker.submit(
+                    eval_weights,
+                    max_steps=eval_rollout_steps,
+                    # Isaac envs auto-reset, so done.any() fires as soon as a
+                    # single sub-env finishes.  Run the full rollout instead.
+                    break_when_any_done=False,
+                )
+
+        # ---- Simulated (world model) eval: imagination rollout video ----
+        if model_based_env_eval is not None and optim_step >= next_sim_eval_step:
+            next_sim_eval_step += eval_every
+            with set_exploration_type(ExplorationType.DETERMINISTIC), torch.no_grad():
+                # Seed from replay buffer: take one trajectory's first timestep
+                sim_seed = replay_buffer.sample()
+                numel = sim_seed.numel()
+                usable = (numel // batch_length) * batch_length
+                if usable < numel:
+                    sim_seed = sim_seed[:usable]
+                sim_seed = sim_seed.reshape(-1, batch_length)
+                sim_seed = sim_seed[0, 0].exclude("next", "action").to(train_device)
+                sim_rollout = model_based_env_eval.rollout(
+                    eval_rollout_steps,
+                    actor_model,
+                    auto_cast_to_device=True,
+                    break_when_any_done=True,
+                    auto_reset=False,
+                    tensordict=sim_seed,
+                )
+                model_based_env_eval.apply(
+                    functools.partial(dump_video, step=collected_frames)
+                )
+                sim_reward = sim_rollout["next", "reward"].sum(-2).mean().item()
+                if logger is not None:
+                    log_metrics(
+                        logger,
+                        {"eval/simulated_reward": sim_reward},
+                        collected_frames,
+                    )
+                torchrl_logger.info(f"Simulated eval: reward={sim_reward:.4f}")
+
+        if optim_step >= total_optim_steps:
+            break
+
+    # ========================================================================
+    # Cleanup
+    # ========================================================================
+    pbar.close()
+    if eval_worker is not None:
+        eval_worker.shutdown()
+    if not train_env.is_closed:
+        train_env.close()
+    collector.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3482
* #3481
* #3480
* #3478
* __->__ #3477
* #3476
* #3475
* #3474
* #3473
* #3472
* #3471

Add a complete Dreamer v1 training script for IsaacLab environments
with pixel-based TiledCamera observations:

- dreamer_isaac.py: standalone training script with AppLauncher init
  (must happen before torch import), multi-GPU support (sim/train/eval),
  mixed precision (bfloat16), synchronous collect-train loop, async
  eval via RayEvalWorker, NaN detection, and LR warmup
- config_isaac.yaml: Hydra config for pixel-based Isaac training
  (256 envs, 64x64 images, RSSM compile, bfloat16 autocast)

Co-authored-by: Cursor <cursoragent@cursor.com>