### PR TITLE
[Minor] correct typo 'occured' to 'occurred' in error message

### DIFF
--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1295,7 +1295,7 @@ class _LazyStackedMixin(Generic[T]):
                             return self
                         if dim_idx != self.dim:
                             raise RuntimeError(
-                                f"Indexing occured along dimension {dim_idx} but stacking was done along dim {self.dim}."
+                                f"Indexing occurred along dimension {dim_idx} but stacking was done along dim {self.dim}."
                             )
                         out = self._specs[item]
                         if isinstance(out, TensorSpec):


### PR DESCRIPTION
Fixed a typo in an error message in tensor_specs.py.

- `occured` → `occurred`

This is a non-functional fix.