### PR TITLE
[Doc] Add RayEvalWorker to API reference docs

### DIFF
--- a/docs/source/reference/eval.rst
+++ b/docs/source/reference/eval.rst
@@ -1,0 +1,18 @@
+.. currentmodule:: torchrl.eval
+
+torchrl.eval package
+====================
+
+.. _ref_eval:
+
+The eval package provides utilities for evaluating reinforcement learning
+policies asynchronously, without blocking the training loop.
+
+RayEvalWorker
+-------------
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template.rst
+
+    RayEvalWorker

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -7,6 +7,7 @@ API Reference
     collectors
     data
     envs
+    eval
     llms
     modules
     objectives


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3482
* #3481
* __->__ #3480
* #3478
* #3477
* #3476
* #3475
* #3474
* #3473
* #3472
* #3471

Add torchrl.eval package to the Sphinx documentation with an
autosummary entry for RayEvalWorker.

Co-authored-by: Cursor <cursoragent@cursor.com>