### PR TITLE
[Feature] RayEvalWorker: add named actors, from_name, and error on missing Ray

### DIFF
--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -5879,6 +5879,51 @@ class TestRayEvalWorker:
         finally:
             worker.shutdown()
 
+    def test_ray_eval_worker_from_name(self):
+        """Test that from_name can reconnect to a named actor."""
+        import torch.nn as nn
+
+        from tensordict import TensorDict
+        from tensordict.nn import TensorDictModule
+
+        from torchrl.envs import GymEnv, StepCounter, TransformedEnv
+        from torchrl.eval import RayEvalWorker
+
+        def make_env():
+            return TransformedEnv(GymEnv("Pendulum-v1"), StepCounter(10))
+
+        def make_policy(env):
+            action_dim = env.action_spec.shape[-1]
+            obs_dim = env.observation_spec["observation"].shape[-1]
+            return TensorDictModule(
+                nn.Linear(obs_dim, action_dim),
+                in_keys=["observation"],
+                out_keys=["action"],
+            )
+
+        worker = RayEvalWorker(
+            init_fn=None,
+            env_maker=make_env,
+            policy_maker=make_policy,
+            num_gpus=0,
+            name="test_eval_worker",
+        )
+        try:
+            # Reconnect via from_name
+            worker2 = RayEvalWorker.from_name("test_eval_worker")
+
+            weights = (
+                TensorDict.from_module(make_policy(make_env())).data.detach().cpu()
+            )
+            # Submit through the reconnected handle
+            worker2.submit(weights, max_steps=5)
+
+            result = worker2.poll(timeout=30)
+            assert result is not None
+            assert "reward" in result
+        finally:
+            worker.shutdown()
+
 
 @pytest.mark.skipif(not _has_procgen, reason="Procgen not found")
 class TestProcgen:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3482
* __->__ #3481
* #3480
* #3478
* #3477
* #3476
* #3475
* #3474
* #3473
* #3472
* #3471

----

- Raise informative RuntimeError when Ray is not installed
- Add name parameter: registers the actor with Ray so other processes
  can reconnect via RayEvalWorker.from_name(name)
- Move numpy import to module level in _EvalActor (safe without init_fn)
- Add explicit comments in _EvalActor explaining that local torch/torchrl
  imports are required for Isaac Lab AppLauncher compatibility

Co-authored-by: Cursor <cursoragent@cursor.com>