### PR TITLE
[CI] Add nightly orchestrator workflow and status dashboard

### DIFF
--- a/.github/nightly-dashboard/index.html
+++ b/.github/nightly-dashboard/index.html
@@ -1,0 +1,512 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TorchRL Nightly Status</title>
+<style>
+:root {
+    --success: #22c55e;
+    --failure: #ef4444;
+    --skipped: #9ca3af;
+    --pending: #f59e0b;
+    --cancelled: #9ca3af;
+    --not_run: #6b7280;
+    --neutral: #94a3b8;
+    --bg-primary: #0f172a;
+    --bg-secondary: #1e293b;
+    --bg-tertiary: #334155;
+    --text-primary: #f1f5f9;
+    --text-secondary: #94a3b8;
+    --border: #475569;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    line-height: 1.6;
+    padding: 2rem;
+}
+
+.container {
+    max-width: 1400px;
+    margin: 0 auto;
+}
+
+header {
+    text-align: center;
+    margin-bottom: 2rem;
+}
+
+h1 {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.stat-card {
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    padding: 1.5rem;
+    text-align: center;
+}
+
+.stat-value {
+    font-size: 2.5rem;
+    font-weight: bold;
+    margin-bottom: 0.25rem;
+}
+
+.stat-value.success { color: var(--success); }
+.stat-value.failure { color: var(--failure); }
+.stat-value.neutral { color: var(--neutral); }
+
+.stat-label {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.legend {
+    display: flex;
+    gap: 1.5rem;
+    justify-content: center;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.legend-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+}
+
+.legend-dot.success { background: var(--success); }
+.legend-dot.failure { background: var(--failure); }
+.legend-dot.skipped { background: var(--skipped); }
+.legend-dot.pending { background: var(--pending); }
+
+.table-container {
+    overflow-x: auto;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    padding: 1rem;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+}
+
+th, td {
+    padding: 0.75rem 0.5rem;
+    text-align: center;
+    border-bottom: 1px solid var(--bg-tertiary);
+}
+
+th {
+    background: var(--bg-tertiary);
+    font-weight: 600;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+th:first-child, td:first-child {
+    text-align: left;
+    position: sticky;
+    left: 0;
+    background: var(--bg-secondary);
+    z-index: 5;
+    min-width: 120px;
+}
+
+th:first-child {
+    background: var(--bg-tertiary);
+    z-index: 15;
+}
+
+.date-header {
+    font-size: 0.75rem;
+    white-space: nowrap;
+}
+
+.date-header .day {
+    font-weight: 600;
+}
+
+.date-header .date {
+    color: var(--text-secondary);
+}
+
+.status-cell {
+    width: 40px;
+    min-width: 40px;
+}
+
+.status-dot {
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: transform 0.15s ease;
+}
+
+.status-dot:hover {
+    transform: scale(1.2);
+}
+
+.status-dot.success { background: var(--success); }
+.status-dot.failure { background: var(--failure); }
+.status-dot.skipped { background: var(--skipped); }
+.status-dot.pending { background: var(--pending); }
+.status-dot.cancelled { background: var(--skipped); }
+.status-dot.in_progress { background: var(--pending); }
+.status-dot.not_run { background: transparent; border: 2px dashed var(--border); }
+
+.workflow-name {
+    font-weight: 500;
+}
+
+.no-data {
+    text-align: center;
+    padding: 3rem;
+    color: var(--text-secondary);
+}
+
+.loading {
+    text-align: center;
+    padding: 3rem;
+}
+
+.loading-spinner {
+    display: inline-block;
+    width: 40px;
+    height: 40px;
+    border: 3px solid var(--bg-tertiary);
+    border-top-color: var(--text-primary);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.tooltip {
+    position: fixed;
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    pointer-events: none;
+    z-index: 100;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    max-width: 250px;
+}
+
+.tooltip-header {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}
+
+.tooltip-status {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.tooltip-status .status-indicator {
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
+}
+
+footer {
+    text-align: center;
+    margin-top: 2rem;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+}
+
+footer a {
+    color: var(--text-secondary);
+    text-decoration: underline;
+}
+</style>
+</head>
+<body>
+<div class="container">
+    <header>
+        <h1>TorchRL Nightly Status</h1>
+        <p class="subtitle">Daily health of TorchRL CI pipelines</p>
+        <p class="subtitle" id="last-updated"></p>
+    </header>
+
+    <div class="stats-grid" id="stats-grid"></div>
+
+    <div class="legend">
+        <div class="legend-item">
+            <div class="legend-dot success"></div>
+            <span>Success</span>
+        </div>
+        <div class="legend-item">
+            <div class="legend-dot failure"></div>
+            <span>Failure</span>
+        </div>
+        <div class="legend-item">
+            <div class="legend-dot skipped"></div>
+            <span>Skipped/Cancelled</span>
+        </div>
+        <div class="legend-item">
+            <div class="legend-dot pending"></div>
+            <span>In Progress</span>
+        </div>
+    </div>
+
+    <div class="table-container" id="table-container">
+        <div class="loading">
+            <div class="loading-spinner"></div>
+            <p>Loading status data...</p>
+        </div>
+    </div>
+
+    <footer>
+        <p>Data updates after each nightly run. <a href="https://github.com/pytorch/rl/actions/workflows/nightly_orchestrator.yml">View workflow runs</a></p>
+    </footer>
+</div>
+
+<div class="tooltip" id="tooltip" style="display: none;"></div>
+
+<script>
+const WORKFLOW_ORDER = [
+    'test-linux.yml',
+    'test-linux-llm.yml',
+    'test-linux-habitat.yml',
+    'test-linux-tutorials.yml',
+    'test-linux-sota.yml',
+    'test-linux-libs.yml',
+    'test-windows-optdepts.yml',
+    'lint.yml',
+    'docs.yml',
+    'benchmarks.yml',
+];
+
+async function loadData() {
+    try {
+        const response = await fetch('history.json');
+        if (!response.ok) throw new Error('Failed to load data');
+        return await response.json();
+    } catch (error) {
+        console.error('Error loading data:', error);
+        return null;
+    }
+}
+
+function formatDate(dateStr) {
+    const date = new Date(dateStr + 'T00:00:00');
+    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    return {
+        day: days[date.getDay()],
+        date: `${months[date.getMonth()]} ${date.getDate()}`
+    };
+}
+
+function getStatusClass(status) {
+    if (!status) return 'not_run';
+    switch (status.toLowerCase()) {
+        case 'success': return 'success';
+        case 'failure': return 'failure';
+        case 'skipped': return 'skipped';
+        case 'cancelled': return 'cancelled';
+        case 'in_progress':
+        case 'pending':
+        case 'queued':
+            return 'pending';
+        default: return 'skipped';
+    }
+}
+
+function renderStats(data) {
+    const container = document.getElementById('stats-grid');
+    const stats7 = data.stats?.last_7_days || {};
+    const stats30 = data.stats?.last_30_days || {};
+
+    const getSuccessRateClass = (rate) => {
+        if (rate == null) return 'neutral';
+        if (rate >= 90) return 'success';
+        if (rate >= 70) return 'neutral';
+        return 'failure';
+    };
+
+    container.innerHTML = `
+        <div class="stat-card">
+            <div class="stat-value ${getSuccessRateClass(stats7.success_rate)}">
+                ${stats7.success_rate != null ? stats7.success_rate + '%' : 'N/A'}
+            </div>
+            <div class="stat-label">7-Day Success Rate</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-value ${getSuccessRateClass(stats30.success_rate)}">
+                ${stats30.success_rate != null ? stats30.success_rate + '%' : 'N/A'}
+            </div>
+            <div class="stat-label">30-Day Success Rate</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-value success">${stats7.total_success || 0}</div>
+            <div class="stat-label">Successful (7 days)</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-value failure">${stats7.total_failure || 0}</div>
+            <div class="stat-label">Failed (7 days)</div>
+        </div>
+    `;
+}
+
+function renderTable(data) {
+    const container = document.getElementById('table-container');
+    const history = data.history || [];
+
+    if (history.length === 0) {
+        container.innerHTML = '<div class="no-data">No data available yet.</div>';
+        return;
+    }
+
+    // Get last 30 days
+    const recentHistory = history.slice(0, 30);
+
+    // Build table
+    let html = '<table><thead><tr><th>Workflow</th>';
+
+    // Date headers
+    for (const day of recentHistory) {
+        const formatted = formatDate(day.date);
+        html += `<th class="status-cell">
+            <div class="date-header">
+                <div class="day">${formatted.day}</div>
+                <div class="date">${formatted.date}</div>
+            </div>
+        </th>`;
+    }
+    html += '</tr></thead><tbody>';
+
+    // Workflow rows
+    for (const workflowFile of WORKFLOW_ORDER) {
+        const displayName = recentHistory[0]?.workflows?.[workflowFile]?.display_name || workflowFile.replace('.yml', '').replace(/-/g, ' ');
+
+        html += `<tr><td class="workflow-name">${displayName}</td>`;
+
+        for (const day of recentHistory) {
+            const workflow = day.workflows?.[workflowFile];
+            const status = workflow?.status || 'not_run';
+            const statusClass = getStatusClass(status);
+            const url = workflow?.url;
+
+            html += `<td class="status-cell">`;
+            if (url) {
+                html += `<a href="${url}" target="_blank">`;
+            }
+            html += `<span class="status-dot ${statusClass}" data-workflow="${workflowFile}" data-date="${day.date}" data-status="${status}"></span>`;
+            if (url) {
+                html += `</a>`;
+            }
+            html += `</td>`;
+        }
+
+        html += '</tr>';
+    }
+
+    html += '</tbody></table>';
+    container.innerHTML = html;
+
+    // Setup tooltips
+    setupTooltips();
+}
+
+function setupTooltips() {
+    const tooltip = document.getElementById('tooltip');
+    const dots = document.querySelectorAll('.status-dot');
+
+    dots.forEach(dot => {
+        dot.addEventListener('mouseenter', (e) => {
+            const workflow = dot.dataset.workflow;
+            const date = dot.dataset.date;
+            const status = dot.dataset.status;
+
+            tooltip.innerHTML = `
+                <div class="tooltip-header">${workflow}</div>
+                <div>${formatDate(date).day}, ${formatDate(date).date}</div>
+                <div class="tooltip-status">
+                    <span class="status-indicator ${getStatusClass(status)}" style="background: var(--${getStatusClass(status)})"></span>
+                    <span>${status}</span>
+                </div>
+            `;
+            tooltip.style.display = 'block';
+        });
+
+        dot.addEventListener('mousemove', (e) => {
+            tooltip.style.left = e.clientX + 10 + 'px';
+            tooltip.style.top = e.clientY + 10 + 'px';
+        });
+
+        dot.addEventListener('mouseleave', () => {
+            tooltip.style.display = 'none';
+        });
+    });
+}
+
+async function init() {
+    const data = await loadData();
+
+    if (!data) {
+        document.getElementById('table-container').innerHTML =
+            '<div class="no-data">Failed to load data. Please try again later.</div>';
+        return;
+    }
+
+    // Update last updated time
+    if (data.last_updated) {
+        const updated = new Date(data.last_updated);
+        document.getElementById('last-updated').textContent =
+            `Last updated: ${updated.toLocaleDateString()} ${updated.toLocaleTimeString()}`;
+    }
+
+    renderStats(data);
+    renderTable(data);
+}
+
+init();
+</script>
+</body>
+</html>

--- a/.github/scripts/collect_nightly_status.py
+++ b/.github/scripts/collect_nightly_status.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""Collect nightly workflow status and update the status dashboard.
+
+This script queries GitHub API for nightly orchestrator workflow runs and updates
+the historical status data stored on gh-pages.
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import requests
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger(__name__)
+
+
+# All nightly workflows tracked by the orchestrator.
+# These are the child workflow files called via workflow_call.
+NIGHTLY_WORKFLOWS = [
+    "test-linux.yml",
+    "test-linux-llm.yml",
+    "test-linux-habitat.yml",
+    "test-linux-tutorials.yml",
+    "test-linux-sota.yml",
+    "test-linux-libs.yml",
+    "test-windows-optdepts.yml",
+    "lint.yml",
+    "docs.yml",
+    "benchmarks.yml",
+]
+
+# Display names for workflows
+WORKFLOW_DISPLAY_NAMES = {
+    "test-linux.yml": "Linux Tests",
+    "test-linux-llm.yml": "LLM Tests",
+    "test-linux-habitat.yml": "Habitat Tests",
+    "test-linux-tutorials.yml": "Tutorials Tests",
+    "test-linux-sota.yml": "SOTA Tests",
+    "test-linux-libs.yml": "Libs Tests",
+    "test-windows-optdepts.yml": "Windows Tests",
+    "lint.yml": "Lint",
+    "docs.yml": "Documentation",
+    "benchmarks.yml": "Benchmarks",
+}
+
+# Job name prefixes for each workflow (used in orchestrator jobs).
+# When a workflow is called via workflow_call in the orchestrator,
+# its jobs appear as "{prefix} / {job-name}" in the parent run.
+WORKFLOW_JOB_PREFIXES = {
+    "test-linux.yml": "test-linux",
+    "test-linux-llm.yml": "test-linux-llm",
+    "test-linux-habitat.yml": "test-linux-habitat",
+    "test-linux-tutorials.yml": "test-linux-tutorials",
+    "test-linux-sota.yml": "test-linux-sota",
+    "test-linux-libs.yml": "test-linux-libs",
+    "test-windows-optdepts.yml": "test-windows-optdepts",
+    "lint.yml": "lint",
+    "docs.yml": "docs",
+    "benchmarks.yml": "benchmarks",
+}
+
+
+def get_run_jobs(
+    owner: str,
+    repo: str,
+    run_id: int,
+    token: str,
+) -> list[dict]:
+    """Fetch all jobs for a specific workflow run."""
+    base_url = "https://api.github.com/repos"
+    url = f"{base_url}/{owner}/{repo}/actions/runs/{run_id}/jobs"
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    params = {"per_page": 100}
+
+    all_jobs = []
+    while url:
+        response = requests.get(url, headers=headers, params=params, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        all_jobs.extend(data.get("jobs", []))
+
+        # Handle pagination
+        url = None
+        if "next" in response.links:
+            url = response.links["next"]["url"]
+            params = {}  # Clear params for subsequent requests (URL includes them)
+
+    return all_jobs
+
+
+def get_orchestrator_runs(
+    owner: str,
+    repo: str,
+    token: str,
+    created_after: str,
+    created_before: str,
+) -> list[dict]:
+    """Fetch orchestrator workflow runs within a date range."""
+    base_url = "https://api.github.com/repos"
+    workflow = "nightly_orchestrator.yml"
+    url = f"{base_url}/{owner}/{repo}/actions/workflows/{workflow}/runs"
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    params = {
+        "created": f"{created_after}..{created_before}",
+        "per_page": 100,
+        "event": "schedule",  # Only scheduled runs
+    }
+
+    response = requests.get(url, headers=headers, params=params, timeout=30)
+    response.raise_for_status()
+    return response.json().get("workflow_runs", [])
+
+
+def _get_workflow_status_from_jobs(jobs: list[dict], workflow_file: str) -> dict:
+    """Determine workflow status from its jobs in the orchestrator run.
+
+    When a workflow is called via workflow_call, its jobs appear in the parent
+    orchestrator run with names like "{prefix} / {job-name}".
+    """
+    prefix = WORKFLOW_JOB_PREFIXES.get(workflow_file, "")
+    display_name = WORKFLOW_DISPLAY_NAMES.get(workflow_file, workflow_file)
+
+    # Find all jobs belonging to this workflow
+    workflow_jobs = [j for j in jobs if j["name"].startswith(f"{prefix} /")]
+
+    if not workflow_jobs:
+        return {
+            "status": "skipped",
+            "conclusion": None,
+            "url": None,
+            "display_name": display_name,
+        }
+
+    # Determine overall status:
+    # - If any job failed, workflow failed
+    # - If all jobs succeeded, workflow succeeded
+    # - If any job is still running, workflow is in_progress
+    # - Otherwise use the most common conclusion
+    conclusions = [j.get("conclusion") for j in workflow_jobs]
+    statuses = [j.get("status") for j in workflow_jobs]
+
+    if "failure" in conclusions:
+        status = "failure"
+    elif all(c == "success" for c in conclusions if c):
+        status = "success"
+    elif "in_progress" in statuses:
+        status = "in_progress"
+    elif all(c == "skipped" for c in conclusions if c):
+        status = "skipped"
+    elif "cancelled" in conclusions:
+        status = "cancelled"
+    else:
+        # Use the first non-null conclusion
+        status = next((c for c in conclusions if c), "unknown")
+
+    # Get URL from the first job (they all link to the same run)
+    job_url = workflow_jobs[0].get("html_url") if workflow_jobs else None
+
+    return {
+        "status": status,
+        "conclusion": status if status != "in_progress" else None,
+        "url": job_url,
+        "display_name": display_name,
+    }
+
+
+def collect_status_for_date(
+    owner: str,
+    repo: str,
+    token: str,
+    date: datetime,
+) -> dict:
+    """Collect status for all nightly workflows for a specific date."""
+    # Create date range for the given date (midnight to midnight UTC)
+    date_str = date.strftime("%Y-%m-%d")
+    created_after = f"{date_str}T00:00:00Z"
+    created_before = f"{date_str}T23:59:59Z"
+
+    # First, check if orchestrator ran on this date
+    orchestrator_runs = get_orchestrator_runs(
+        owner, repo, token, created_after, created_before
+    )
+
+    if not orchestrator_runs:
+        return {
+            "date": date_str,
+            "orchestrator_ran": False,
+            "orchestrator_status": "not_run",
+            "orchestrator_url": None,
+            "workflows": {},
+        }
+
+    # Get the latest orchestrator run for this date
+    latest_orchestrator = orchestrator_runs[0]
+    orchestrator_conclusion = latest_orchestrator["conclusion"]
+    orchestrator_status = orchestrator_conclusion or latest_orchestrator["status"]
+    orchestrator_run_id = latest_orchestrator["id"]
+
+    # Fetch all jobs from the orchestrator run
+    # Child workflows called via workflow_call appear as jobs in the parent run
+    all_jobs = get_run_jobs(owner, repo, orchestrator_run_id, token)
+
+    # Collect status for each workflow by analyzing its jobs
+    workflows_status = {}
+    for workflow_file in NIGHTLY_WORKFLOWS:
+        workflows_status[workflow_file] = _get_workflow_status_from_jobs(
+            all_jobs, workflow_file
+        )
+
+    return {
+        "date": date_str,
+        "orchestrator_ran": True,
+        "orchestrator_status": orchestrator_status,
+        "orchestrator_url": latest_orchestrator["html_url"],
+        "orchestrator_run_id": orchestrator_run_id,
+        "workflows": workflows_status,
+    }
+
+
+def calculate_summary(daily_status: dict) -> dict:
+    """Calculate summary statistics for a day."""
+    workflows = daily_status.get("workflows", {})
+    if not workflows:
+        return {
+            "total": 0,
+            "success": 0,
+            "failure": 0,
+            "skipped": 0,
+            "success_rate": None,
+        }
+
+    total = len(workflows)
+    success = sum(1 for w in workflows.values() if w["status"] == "success")
+    failure = sum(1 for w in workflows.values() if w["status"] == "failure")
+    skipped = sum(1 for w in workflows.values() if w["status"] == "skipped")
+    # Count anything else as "other" (cancelled, in_progress, etc.)
+    other = total - success - failure - skipped
+
+    # Success rate is based on non-skipped workflows
+    non_skipped = success + failure + other
+    success_rate = (success / non_skipped * 100) if non_skipped > 0 else None
+
+    rate_rounded = round(success_rate, 1) if success_rate is not None else None
+    return {
+        "total": total,
+        "success": success,
+        "failure": failure,
+        "skipped": skipped,
+        "other": other,
+        "success_rate": rate_rounded,
+    }
+
+
+def load_existing_history(history_file: Path) -> list[dict]:
+    """Load existing history from file."""
+    if history_file.exists():
+        with open(history_file) as f:
+            data = json.load(f)
+        return data.get("history", [])
+    return []
+
+
+def save_history(history: list[dict], output_file: Path) -> None:
+    """Save history to file with metadata."""
+    # Sort by date descending (newest first)
+    history.sort(key=lambda x: x["date"], reverse=True)
+
+    # Keep only last 90 days
+    history = history[:90]
+
+    # Calculate overall stats
+    recent_7_days = history[:7]
+    recent_30_days = history[:30]
+
+    def calc_period_stats(days: list[dict]) -> dict:
+        total_runs = sum(
+            d["summary"]["success"]
+            + d["summary"]["failure"]
+            + d["summary"].get("other", 0)
+            for d in days
+            if d.get("orchestrator_ran")
+        )
+        total_success = sum(
+            d["summary"]["success"] for d in days if d.get("orchestrator_ran")
+        )
+        total_failure = sum(
+            d["summary"]["failure"] for d in days if d.get("orchestrator_ran")
+        )
+        runs_with_data = sum(1 for d in days if d.get("orchestrator_ran"))
+        rate = round(total_success / total_runs * 100, 1) if total_runs > 0 else None
+        return {
+            "days": len(days),
+            "runs_with_data": runs_with_data,
+            "total_workflow_runs": total_runs,
+            "total_success": total_success,
+            "total_failure": total_failure,
+            "success_rate": rate,
+        }
+
+    output = {
+        "last_updated": datetime.now(timezone.utc).isoformat(),
+        "stats": {
+            "last_7_days": calc_period_stats(recent_7_days),
+            "last_30_days": calc_period_stats(recent_30_days),
+        },
+        "history": history,
+    }
+
+    with open(output_file, "w") as f:
+        json.dump(output, f, indent=2)
+
+
+def generate_badge_json(history: list[dict], output_file: Path) -> None:
+    """Generate shields.io endpoint JSON for the badge."""
+    if not history:
+        badge_data = {
+            "schemaVersion": 1,
+            "label": "nightly",
+            "message": "no data",
+            "color": "lightgrey",
+        }
+    else:
+        # Use the most recent day with data
+        latest = next((d for d in history if d.get("orchestrator_ran")), None)
+
+        if not latest:
+            badge_data = {
+                "schemaVersion": 1,
+                "label": "nightly",
+                "message": "no runs",
+                "color": "lightgrey",
+            }
+        else:
+            summary = latest.get("summary", {})
+            success = summary.get("success", 0)
+            failure = summary.get("failure", 0)
+            total = success + failure + summary.get("other", 0)
+
+            if failure == 0 and total > 0:
+                color = "brightgreen"
+                message = f"{success}/{total} passing"
+            elif failure > 0 and success > failure:
+                color = "yellow"
+                message = f"{failure}/{total} failing"
+            elif failure > 0:
+                color = "red"
+                message = f"{failure}/{total} failing"
+            else:
+                color = "lightgrey"
+                message = "no data"
+
+            badge_data = {
+                "schemaVersion": 1,
+                "label": "nightly",
+                "message": message,
+                "color": color,
+            }
+
+    with open(output_file, "w") as f:
+        json.dump(badge_data, f, indent=2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Collect nightly workflow status")
+    parser.add_argument("--owner", default="pytorch", help="GitHub repository owner")
+    parser.add_argument("--repo", default="rl", help="GitHub repository name")
+    parser.add_argument(
+        "--token", default=os.environ.get("GITHUB_TOKEN"), help="GitHub token"
+    )
+    parser.add_argument(
+        "--days", type=int, default=7, help="Number of days to collect (for backfill)"
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("nightly-status"),
+        help="Output directory",
+    )
+    parser.add_argument(
+        "--history-file", type=Path, help="Existing history file to merge with"
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force recollection even if data already exists for a date",
+    )
+
+    args = parser.parse_args()
+
+    if not args.token:
+        log.error("GITHUB_TOKEN environment variable or --token argument required")
+        sys.exit(1)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Load existing history
+    history_file = args.history_file or args.output_dir / "history.json"
+    existing_history = load_existing_history(history_file)
+    existing_dates = {d["date"] for d in existing_history}
+
+    # Collect status for the requested days
+    today = datetime.now(timezone.utc)
+    new_entries = []
+
+    for days_ago in range(args.days):
+        date = today - timedelta(days=days_ago)
+        date_str = date.strftime("%Y-%m-%d")
+
+        # Skip if we already have data for this date (unless it's today or --force)
+        if date_str in existing_dates and days_ago > 0 and not args.force:
+            log.info("Skipping %s - already have data", date_str)
+            continue
+
+        log.info("Collecting status for %s...", date_str)
+        try:
+            daily_status = collect_status_for_date(
+                args.owner, args.repo, args.token, date
+            )
+            daily_status["summary"] = calculate_summary(daily_status)
+            new_entries.append(daily_status)
+            log.info("  Orchestrator ran: %s", daily_status["orchestrator_ran"])
+            if daily_status["orchestrator_ran"]:
+                log.info("  Summary: %s", daily_status["summary"])
+        except Exception as e:
+            log.error("  Error collecting status: %s", e)
+
+    # Merge new entries with existing history
+    # Replace entries for dates we just collected (in case of updates)
+    new_dates = {e["date"] for e in new_entries}
+    merged_history = [
+        d for d in existing_history if d["date"] not in new_dates
+    ] + new_entries
+
+    # Save outputs
+    output_history_file = args.output_dir / "history.json"
+    save_history(merged_history, output_history_file)
+    log.info("Saved history to %s", output_history_file)
+
+    # Generate badge
+    badge_file = args.output_dir / "badge.json"
+    generate_badge_json(merged_history, badge_file)
+    log.info("Saved badge data to %s", badge_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,6 +7,12 @@ on:
     branches:
       - "*"
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      skip-upload:
+        description: 'Skip benchmark upload to gh-pages'
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -17,7 +23,7 @@ permissions:
 concurrency:
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.
   # On master, we want all builds to complete even if merging happens faster to make it easier to discover at which point something broke.
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
+  group: benchmarks-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 jobs:
@@ -101,7 +107,7 @@ jobs:
       # Upload benchmark results for main branch, manual dispatch, or PRs with 'benchmarks/upload' label
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4
-        if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'benchmarks/upload')) }}
+        if: ${{ !inputs.skip-upload && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'benchmarks/upload'))) }}
         with:
           name: ${{ matrix.device }}-benchmark-results
           path: benchmarks/output.json
@@ -111,7 +117,7 @@ jobs:
     name: Upload benchmark results
     runs-on: ubuntu-latest
     needs: benchmark
-    if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'benchmarks/upload')) }}
+    if: ${{ !inputs.skip-upload && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'benchmarks/upload'))) }}
     steps:
       - name: Show upload trigger reason
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,11 +11,12 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.
   # On master, we want all builds to complete even if merging happens faster to make it easier to discover at which point something broke.
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
+  group: docs-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,11 +8,12 @@ on:
       - main
       - release/*
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.
   # On master, we want all builds to complete even if merging happens faster to make it easier to discover at which point something broke.
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
+  group: lint-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/nightly_orchestrator.yml
+++ b/.github/workflows/nightly_orchestrator.yml
@@ -1,0 +1,116 @@
+name: Nightly Orchestrator
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # 6AM UTC daily
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  test-linux:
+    uses: ./.github/workflows/test-linux.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+
+  test-linux-llm:
+    uses: ./.github/workflows/test-linux-llm.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+
+  test-linux-habitat:
+    uses: ./.github/workflows/test-linux-habitat.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+
+  test-linux-tutorials:
+    uses: ./.github/workflows/test-linux-tutorials.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+
+  test-linux-sota:
+    uses: ./.github/workflows/test-linux-sota.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+
+  test-linux-libs:
+    uses: ./.github/workflows/test-linux-libs.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+
+  test-windows-optdepts:
+    uses: ./.github/workflows/test-windows-optdepts.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+
+  lint:
+    uses: ./.github/workflows/lint.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+
+  docs:
+    uses: ./.github/workflows/docs.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: write
+
+  benchmarks:
+    uses: ./.github/workflows/benchmarks.yml
+    with:
+      skip-upload: true
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: write
+      deployments: write
+      pull-requests: write
+
+  # =============================================================================
+  # Status collector - updates the nightly dashboard after all workflows complete
+  # =============================================================================
+  update-status-dashboard:
+    name: Update Status Dashboard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs:
+      - test-linux
+      - test-linux-llm
+      - test-linux-habitat
+      - test-linux-tutorials
+      - test-linux-sota
+      - test-linux-libs
+      - test-windows-optdepts
+      - lint
+      - docs
+      - benchmarks
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+    steps:
+      - name: Trigger status collector
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          event-type: nightly-orchestrator-completed
+          client-payload: |
+            {
+              "run_id": "${{ github.run_id }}",
+              "triggered_at": "${{ github.event.repository.updated_at }}"
+            }

--- a/.github/workflows/nightly_status_collector.yml
+++ b/.github/workflows/nightly_status_collector.yml
@@ -1,0 +1,123 @@
+name: Nightly Status Collector
+
+on:
+  # Run after the orchestrator completes (triggered by repository dispatch)
+  repository_dispatch:
+    types: [nightly-orchestrator-completed]
+  # Also run on schedule to catch any missed updates
+  schedule:
+    - cron: '0 18 * * *'  # 6PM UTC (nightly starts at 6AM UTC, usually done by then)
+  # Manual trigger for backfills
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Number of days to collect (for backfill)'
+        type: number
+        default: 7
+      force:
+        description: 'Force recollection even if data already exists'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  collect-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout gh-pages branch for existing data
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-data
+        continue-on-error: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Collect nightly status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DAYS="${{ inputs.days || 7 }}"
+
+          # Copy existing history if available
+          mkdir -p nightly-status
+          if [ -f "gh-pages-data/nightly-status/history.json" ]; then
+            cp gh-pages-data/nightly-status/history.json nightly-status/history.json
+            echo "Loaded existing history"
+          fi
+
+          # Extract repo name from github.repository (format: owner/repo)
+          REPO_NAME="${{ github.repository }}"
+          REPO_NAME="${REPO_NAME#*/}"
+
+          # Build force flag if requested
+          FORCE_FLAG=""
+          if [ "${{ inputs.force }}" = "true" ]; then
+            FORCE_FLAG="--force"
+          fi
+
+          # Run the collector script with inline dependencies
+          uv run --no-project --with requests --script .github/scripts/collect_nightly_status.py \
+            --owner "${{ github.repository_owner }}" \
+            --repo "$REPO_NAME" \
+            --days "$DAYS" \
+            --output-dir nightly-status \
+            --history-file nightly-status/history.json \
+            $FORCE_FLAG
+
+      - name: Prepare dashboard files
+        run: |
+          # Copy dashboard HTML
+          cp .github/nightly-dashboard/index.html nightly-status/
+
+      - name: Deploy nightly-status to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./nightly-status
+          destination_dir: nightly-status
+          keep_files: true
+          commit_message: 'Update nightly status dashboard'
+
+  notify-if-degraded:
+    runs-on: ubuntu-latest
+    needs: collect-status
+    steps:
+      - name: Checkout for data
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-data
+        continue-on-error: true
+
+      - name: Check for degraded status
+        id: check
+        run: |
+          if [ ! -f "gh-pages-data/nightly-status/history.json" ]; then
+            echo "No history file found, skipping notification check"
+            exit 0
+          fi
+
+          # Check if success rate dropped below 70% in last 7 days
+          SUCCESS_RATE=$(jq -r '.stats.last_7_days.success_rate // 100' gh-pages-data/nightly-status/history.json)
+
+          if [ "$SUCCESS_RATE" != "null" ] && [ "$(echo "$SUCCESS_RATE < 70" | bc -l)" -eq 1 ]; then
+            echo "degraded=true" >> "$GITHUB_OUTPUT"
+            echo "success_rate=$SUCCESS_RATE" >> "$GITHUB_OUTPUT"
+          else
+            echo "degraded=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post warning (if degraded)
+        if: steps.check.outputs.degraded == 'true'
+        run: |
+          echo "::warning::Nightly workflow success rate has dropped to ${{ steps.check.outputs.success_rate }}% (below 70% threshold)"

--- a/.github/workflows/test-linux-habitat.yml
+++ b/.github/workflows/test-linux-habitat.yml
@@ -8,11 +8,12 @@ on:
       - main
       - release/*
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.
   # On master, we want all builds to complete even if merging happens faster to make it easier to discover at which point something broke.
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
+  group: test-linux-habitat-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/test-linux-libs.yml
+++ b/.github/workflows/test-linux-libs.yml
@@ -9,11 +9,12 @@ on:
       - main
       - release/*
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.
   # On master, we want all builds to complete even if merging happens faster to make it easier to discover at which point something broke.
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
+  group: test-linux-libs-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/test-linux-llm.yml
+++ b/.github/workflows/test-linux-llm.yml
@@ -8,11 +8,12 @@ on:
       - main
       - release/*
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.
   # On master, we want all builds to complete even if merging happens faster to make it easier to discover at which point something broke.
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
+  group: test-linux-llm-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/test-linux-sota.yml
+++ b/.github/workflows/test-linux-sota.yml
@@ -8,6 +8,7 @@ on:
       - main
       - release/*
   workflow_dispatch:
+  workflow_call:
 
 env:
   CHANNEL: "nightly"
@@ -15,7 +16,7 @@ env:
 concurrency:
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.
   # On master, we want all builds to complete even if merging happens faster to make it easier to discover at which point something broke.
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
+  group: test-linux-sota-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/test-linux-tutorials.yml
+++ b/.github/workflows/test-linux-tutorials.yml
@@ -9,9 +9,10 @@ on:
       - main
       - release/*
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
+  group: test-linux-tutorials-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -8,6 +8,7 @@ on:
       - main
       - release/*
   workflow_dispatch:
+  workflow_call:
 
 env:
   CHANNEL: "nightly"
@@ -15,7 +16,7 @@ env:
 concurrency:
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.
   # On master, we want all builds to complete even if merging happens faster to make it easier to discover at which point something broke.
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
+  group: test-linux-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/test-windows-optdepts.yml
+++ b/.github/workflows/test-windows-optdepts.yml
@@ -8,11 +8,12 @@ on:
       - main
       - release/*
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.
   # On master, we want all builds to complete even if merging happens faster to make it easier to discover at which point something broke.
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
+  group: test-windows-optdepts-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Unit-tests](https://github.com/pytorch/rl/actions/workflows/test-linux.yml/badge.svg)](https://github.com/pytorch/rl/actions/workflows/test-linux.yml)
+[![Nightly](https://img.shields.io/endpoint?url=https://pytorch.github.io/rl/nightly-status/badge.json)](https://pytorch.github.io/rl/nightly-status/)
 [![Documentation](https://img.shields.io/badge/Documentation-blue.svg)](https://pytorch.org/rl/)
 [![Benchmarks](https://img.shields.io/badge/Benchmarks-blue.svg)](https://pytorch.github.io/rl/dev/bench/)
 [![codecov](https://codecov.io/gh/pytorch/rl/branch/main/graph/badge.svg?token=HcpK1ILV6r)](https://codecov.io/gh/pytorch/rl)


### PR DESCRIPTION
## Summary

- Adds a **nightly orchestrator** workflow that runs all CI workflows daily at 6AM UTC via `workflow_call`, with a status collector that deploys results to a GitHub Pages dashboard
- Modifies all existing test, lint, docs, and benchmark workflows to support `workflow_call` trigger and uses **stable concurrency group names** (instead of `${{ github.workflow }}`) to avoid collisions when called from the orchestrator
- Adds a `skip-upload` input to `benchmarks.yml` to prevent benchmark gh-pages writes during nightly orchestrator runs
- Includes a dark-themed **nightly status dashboard** (HTML + JS) showing 30 days of workflow health with success rate stats, deployed to `gh-pages/nightly-status/`
- Adds a Nightly badge to `README.md` linking to the dashboard

Mirrors the equivalent setup from [pytorch/tensordict#1555](https://github.com/pytorch/tensordict/pull/1555).

## Test plan

- [ ] Verify nightly orchestrator can be triggered via `workflow_dispatch`
- [ ] Verify each child workflow still works standalone (push/PR triggers)
- [ ] Verify status collector populates `gh-pages/nightly-status/` correctly
- [ ] Verify dashboard renders at `https://pytorch.github.io/rl/nightly-status/`
- [ ] Verify Nightly badge in README renders correctly


Made with [Cursor](https://cursor.com)