### PR TITLE
[CI] Add more workflows to nightly orchestrator and dashboard

### DIFF
--- a/.github/nightly-dashboard/index.html
+++ b/.github/nightly-dashboard/index.html
@@ -320,6 +320,12 @@ const WORKFLOW_ORDER = [
     'lint.yml',
     'docs.yml',
     'benchmarks.yml',
+    'validate-test-partitioning.yml',
+    'nightly_build.yml',
+    'build-wheels-linux.yml',
+    'build-wheels-m1.yml',
+    'build-wheels-windows.yml',
+    'build-wheels-aarch64-linux.yml',
 ];
 
 async function loadData() {

--- a/.github/scripts/collect_nightly_status.py
+++ b/.github/scripts/collect_nightly_status.py
@@ -32,6 +32,12 @@ NIGHTLY_WORKFLOWS = [
     "lint.yml",
     "docs.yml",
     "benchmarks.yml",
+    "validate-test-partitioning.yml",
+    "nightly_build.yml",
+    "build-wheels-linux.yml",
+    "build-wheels-m1.yml",
+    "build-wheels-windows.yml",
+    "build-wheels-aarch64-linux.yml",
 ]
 
 # Display names for workflows
@@ -46,6 +52,12 @@ WORKFLOW_DISPLAY_NAMES = {
     "lint.yml": "Lint",
     "docs.yml": "Documentation",
     "benchmarks.yml": "Benchmarks",
+    "validate-test-partitioning.yml": "Test Partitioning",
+    "nightly_build.yml": "Nightly Build",
+    "build-wheels-linux.yml": "Wheels (Linux)",
+    "build-wheels-m1.yml": "Wheels (M1)",
+    "build-wheels-windows.yml": "Wheels (Windows)",
+    "build-wheels-aarch64-linux.yml": "Wheels (Aarch64)",
 }
 
 # Job name prefixes for each workflow (used in orchestrator jobs).
@@ -62,6 +74,12 @@ WORKFLOW_JOB_PREFIXES = {
     "lint.yml": "lint",
     "docs.yml": "docs",
     "benchmarks.yml": "benchmarks",
+    "validate-test-partitioning.yml": "validate-test-partitioning",
+    "nightly_build.yml": "nightly-build",
+    "build-wheels-linux.yml": "build-wheels-linux",
+    "build-wheels-m1.yml": "build-wheels-m1",
+    "build-wheels-windows.yml": "build-wheels-windows",
+    "build-wheels-aarch64-linux.yml": "build-wheels-aarch64-linux",
 }
 
 

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -25,7 +25,7 @@ on:
 concurrency:
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.
   # On master, we want all builds to complete even if merging happens faster to make it easier to discover at which point something broke.
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
+  group: nightly-build-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/nightly_orchestrator.yml
+++ b/.github/workflows/nightly_orchestrator.yml
@@ -84,6 +84,45 @@ jobs:
       deployments: write
       pull-requests: write
 
+  validate-test-partitioning:
+    uses: ./.github/workflows/validate-test-partitioning.yml
+    secrets: inherit
+
+  nightly-build:
+    uses: ./.github/workflows/nightly_build.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+
+  build-wheels-linux:
+    uses: ./.github/workflows/build-wheels-linux.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+
+  build-wheels-m1:
+    uses: ./.github/workflows/build-wheels-m1.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+
+  build-wheels-windows:
+    uses: ./.github/workflows/build-wheels-windows.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+
+  build-wheels-aarch64-linux:
+    uses: ./.github/workflows/build-wheels-aarch64-linux.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+
   # =============================================================================
   # Status collector - updates the nightly dashboard after all workflows complete
   # =============================================================================
@@ -103,6 +142,12 @@ jobs:
       - lint
       - docs
       - benchmarks
+      - validate-test-partitioning
+      - nightly-build
+      - build-wheels-linux
+      - build-wheels-m1
+      - build-wheels-windows
+      - build-wheels-aarch64-linux
     if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     steps:
       - name: Trigger status collector

--- a/.github/workflows/validate-test-partitioning.yml
+++ b/.github/workflows/validate-test-partitioning.yml
@@ -12,9 +12,10 @@ on:
   push:
     branches: [main, nightly]
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: validate-test-partitioning-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- Adds 6 additional workflows to the nightly orchestrator for comprehensive CI coverage: test partitioning validation, nightly build, and all 4 wheel build workflows (Linux, M1, Windows, Aarch64)
- Fixes concurrency group names for `validate-test-partitioning` and `nightly_build` to use stable names (avoids collisions when called from the orchestrator)
- Updates the dashboard and status collector to track all 16 workflows

The nightly build's PyPI upload is safely gated on `event_name == schedule/workflow_dispatch`, which won't match `workflow_call` from the orchestrator.

Follow-up to #3502.

## Test plan

- [ ] Verify nightly orchestrator dispatches all 16 workflows
- [ ] Verify dashboard shows the 6 new workflow rows
- [ ] Verify nightly_build does NOT upload to PyPI when called from orchestrator


Made with [Cursor](https://cursor.com)