### PR TITLE
[CI] Fix nightly status collector: setup-uv cache failure

### DIFF
--- a/.github/workflows/nightly_status_collector.yml
+++ b/.github/workflows/nightly_status_collector.yml
@@ -41,6 +41,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          ignore-nothing-to-cache: true
 
       - name: Collect nightly status
         env:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Unit-tests](https://github.com/pytorch/rl/actions/workflows/test-linux.yml/badge.svg)](https://github.com/pytorch/rl/actions/workflows/test-linux.yml)
-[![Nightly](https://img.shields.io/endpoint?url=https://pytorch.github.io/rl/nightly-status/badge.json)](https://pytorch.github.io/rl/nightly-status/)
+[![Nightly](https://github.com/pytorch/rl/actions/workflows/nightly_orchestrator.yml/badge.svg)](https://pytorch.github.io/rl/nightly-status/)
 [![Documentation](https://img.shields.io/badge/Documentation-blue.svg)](https://pytorch.org/rl/)
 [![Benchmarks](https://img.shields.io/badge/Benchmarks-blue.svg)](https://pytorch.github.io/rl/dev/bench/)
 [![codecov](https://codecov.io/gh/pytorch/rl/branch/main/graph/badge.svg?token=HcpK1ILV6r)](https://codecov.io/gh/pytorch/rl)


### PR DESCRIPTION
## Summary

- Fixes the nightly status collector which was failing on every run because `astral-sh/setup-uv@v4` with `enable-cache: true` errors out when no `uv.lock` file exists in the repository
- The fix sets `ignore-nothing-to-cache: true` so the step succeeds without a lock file
- This is why the dashboard at https://docs.pytorch.org/rl/nightly-status/ shows a 404 — the deploy step never ran

Both collector runs failed with:
```
##[error]No file matched to [**/uv.lock], make sure you have checked out the target repository
```

## Test plan

- [ ] Trigger `nightly_status_collector` via `workflow_dispatch` and verify it completes
- [ ] Verify https://pytorch.github.io/rl/nightly-status/ loads after a successful run


Made with [Cursor](https://cursor.com)