### PR TITLE
[CI] Pin mujoco<3.5 to fix CI after mujoco 3.5.0 release

### DIFF
--- a/.github/unittest/linux/scripts/run_all.sh
+++ b/.github/unittest/linux/scripts/run_all.sh
@@ -156,7 +156,7 @@ fi
 # Install mujoco for Python < 3.14 (mujoco doesn't have Python 3.14 wheels yet)
 if [[ "$PYTHON_VERSION" != "3.14" ]]; then
   echo "installing mujoco"
-  uv_pip_install "mujoco>=3.3.7"
+  uv_pip_install "mujoco>=3.3.7,<3.5"
 fi
 
 # Install gymnasium

--- a/.github/unittest/linux_libs/scripts_gym/run_all.sh
+++ b/.github/unittest/linux_libs/scripts_gym/run_all.sh
@@ -279,13 +279,13 @@ done
 
 # Test gymnasium >=1.1.0 (supports mujoco 3.x with v5 environments)
 printf "* Testing gymnasium >=1.1.0\n"
-uv pip install 'gymnasium[ale-py,atari]>=1.1.0' mo-gymnasium gymnasium-robotics mujoco
+uv pip install 'gymnasium[ale-py,atari]>=1.1.0' mo-gymnasium gymnasium-robotics "mujoco<3.5"
 run_tests "gymnasium>=1.1.0" || true
 uv pip uninstall gymnasium mo-gymnasium gymnasium-robotics ale-py mujoco || true
 
 # Test latest gymnasium (supports mujoco 3.x with v5 environments)
 printf "* Testing latest gymnasium\n"
-uv pip install 'gymnasium[ale-py,atari]>=1.1.0' mo-gymnasium gymnasium-robotics mujoco
+uv pip install 'gymnasium[ale-py,atari]>=1.1.0' mo-gymnasium gymnasium-robotics "mujoco<3.5"
 run_tests "gymnasium-latest" || true
 
 # =============================================================================

--- a/.github/unittest/tutorials/scripts/run_all.sh
+++ b/.github/unittest/tutorials/scripts/run_all.sh
@@ -89,7 +89,7 @@ uv pip install \
   hydra-core \
   "imageio==2.26.0" \
   dm_control \
-  "mujoco<3.3.6" \
+  "mujoco<3.5" \
   av \
   coverage \
   vmas \

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -87,7 +87,7 @@ jobs:
           ${{ matrix.device == 'CPU' && 'export CUDA_VISIBLE_DEVICES=' || '' }}
 
           python3.10 -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128 -U
-          python3.10 -m pip install ninja pytest pytest-benchmark mujoco dm_control "gym[accept-rom-license,atari]" transformers
+          python3.10 -m pip install ninja pytest pytest-benchmark "mujoco<3.5" dm_control "gym[accept-rom-license,atari]" transformers
           python -m pip install "pybind11[global]"
           python3.10 -m pip install git+https://github.com/pytorch/tensordict 
           python3.10 -m pip install safetensors tqdm pandas numpy matplotlib ray

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -79,7 +79,7 @@ jobs:
           ${{ matrix.device == 'CPU' && 'export CUDA_VISIBLE_DEVICES=' || '' }}
 
           python3.10 -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128 -U
-          python3.10 -m pip install ninja pytest pytest-benchmark mujoco dm_control "gym[accept-rom-license,atari]" transformers ray
+          python3.10 -m pip install ninja pytest pytest-benchmark "mujoco<3.5" dm_control "gym[accept-rom-license,atari]" transformers ray
           python3.10 -m pip install "pybind11[global]"
           python3.10 -m pip install git+https://github.com/pytorch/tensordict 
           python3.10 -m pip install safetensors tqdm pandas numpy matplotlib

--- a/.github/workflows/test-linux-tutorials.yml
+++ b/.github/workflows/test-linux-tutorials.yml
@@ -78,7 +78,7 @@ jobs:
         echo "::group::Install dependencies"
         python -m pip install --quiet \
           pytest pytest-timeout pytest-instafail pytest-json-report \
-          "gymnasium[atari,mujoco,classic-control]" dm_control "mujoco<3.3.6" \
+          "gymnasium[atari,mujoco,classic-control]" dm_control "mujoco<3.5" \
           matplotlib tensorboard wandb tqdm hydra-core pygame "av<14" \
           onnxruntime onnxscript vmas
         echo "::endgroup::"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,7 +15,7 @@ sphinx_design
 
 torchvision
 dm_control>=1.0.0
-mujoco>=3.0.0,<3.3.6
+mujoco>=3.0.0,<3.5
 gymnasium[classic_control,atari,mujoco]
 pygame
 tqdm


### PR DESCRIPTION
## Summary

- MuJoCo 3.5.0 was [released on Feb 13, 2026](https://github.com/google-deepmind/mujoco/releases/tag/3.5.0) but dm_control 1.0.36 hasn't been updated to support it yet (latest supports up to MuJoCo 3.4.0).
- This causes all CI jobs that install `mujoco` and `dm_control` to fail.
- Pin `mujoco<3.5` across all CI scripts, workflows, and docs requirements until dm_control releases a compatible version.

### Files changed
- `.github/unittest/linux/scripts/run_all.sh` — `mujoco>=3.3.7` → `mujoco>=3.3.7,<3.5`
- `.github/workflows/benchmarks.yml` — `mujoco` → `"mujoco<3.5"`
- `.github/workflows/benchmarks_pr.yml` — `mujoco` → `"mujoco<3.5"`
- `.github/unittest/linux_libs/scripts_gym/run_all.sh` — `mujoco` → `"mujoco<3.5"` (2 places)
- `.github/unittest/tutorials/scripts/run_all.sh` — `"mujoco<3.3.6"` → `"mujoco<3.5"`
- `.github/workflows/test-linux-tutorials.yml` — `"mujoco<3.3.6"` → `"mujoco<3.5"`
- `docs/requirements.txt` — `mujoco>=3.0.0,<3.3.6` → `mujoco>=3.0.0,<3.5`

## Test plan
- [ ] CI jobs pass with mujoco pinned to <3.5
- [ ] Remove the pin once dm_control releases a version compatible with mujoco 3.5.0


Made with [Cursor](https://cursor.com)