### PR TITLE
[CI] Add dry-run and smoke-test modes to nightly orchestrator

### DIFF
--- a/.github/workflows/nightly_orchestrator.yml
+++ b/.github/workflows/nightly_orchestrator.yml
@@ -4,13 +4,58 @@ on:
   schedule:
     - cron: '0 6 * * *'  # 6AM UTC daily
   workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Run mode: full (run tests + deploy dashboard), dry-run (run tests, skip dashboard deploy), smoke-test (skip tests, validate CI plumbing only)'
+        type: choice
+        options:
+          - full
+          - dry-run
+          - smoke-test
+        default: full
 
 concurrency:
   group: nightly-${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
+  # =============================================================================
+  # Resolve the effective mode (schedule always uses "full")
+  # =============================================================================
+  config:
+    name: Configure
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.resolve.outputs.mode }}
+      run_tests: ${{ steps.resolve.outputs.run_tests }}
+      deploy_dashboard: ${{ steps.resolve.outputs.deploy_dashboard }}
+    steps:
+      - name: Resolve mode
+        id: resolve
+        run: |
+          MODE="${{ inputs.mode || 'full' }}"
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+
+          if [ "$MODE" = "smoke-test" ]; then
+            echo "run_tests=false" >> "$GITHUB_OUTPUT"
+            echo "deploy_dashboard=true" >> "$GITHUB_OUTPUT"
+          elif [ "$MODE" = "dry-run" ]; then
+            echo "run_tests=true" >> "$GITHUB_OUTPUT"
+            echo "deploy_dashboard=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_tests=true" >> "$GITHUB_OUTPUT"
+            echo "deploy_dashboard=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "### Nightly Orchestrator Configuration" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Mode**: $MODE" >> "$GITHUB_STEP_SUMMARY"
+
+  # =============================================================================
+  # Test workflows (skipped in smoke-test mode)
+  # =============================================================================
   test-linux:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/test-linux.yml
     secrets: inherit
     permissions:
@@ -18,6 +63,8 @@ jobs:
       contents: read
 
   test-linux-llm:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/test-linux-llm.yml
     secrets: inherit
     permissions:
@@ -25,6 +72,8 @@ jobs:
       contents: read
 
   test-linux-habitat:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/test-linux-habitat.yml
     secrets: inherit
     permissions:
@@ -32,6 +81,8 @@ jobs:
       contents: read
 
   test-linux-tutorials:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/test-linux-tutorials.yml
     secrets: inherit
     permissions:
@@ -39,6 +90,8 @@ jobs:
       contents: read
 
   test-linux-sota:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/test-linux-sota.yml
     secrets: inherit
     permissions:
@@ -46,6 +99,8 @@ jobs:
       contents: read
 
   test-linux-libs:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/test-linux-libs.yml
     secrets: inherit
     permissions:
@@ -53,6 +108,8 @@ jobs:
       contents: read
 
   test-windows-optdepts:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/test-windows-optdepts.yml
     secrets: inherit
     permissions:
@@ -60,6 +117,8 @@ jobs:
       contents: read
 
   lint:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/lint.yml
     secrets: inherit
     permissions:
@@ -67,6 +126,8 @@ jobs:
       contents: read
 
   docs:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/docs.yml
     secrets: inherit
     permissions:
@@ -74,6 +135,8 @@ jobs:
       contents: write
 
   benchmarks:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/benchmarks.yml
     with:
       skip-upload: true
@@ -85,10 +148,14 @@ jobs:
       pull-requests: write
 
   validate-test-partitioning:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/validate-test-partitioning.yml
     secrets: inherit
 
   nightly-build:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/nightly_build.yml
     secrets: inherit
     permissions:
@@ -96,6 +163,8 @@ jobs:
       contents: read
 
   build-wheels-linux:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/build-wheels-linux.yml
     secrets: inherit
     permissions:
@@ -103,6 +172,8 @@ jobs:
       contents: read
 
   build-wheels-m1:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/build-wheels-m1.yml
     secrets: inherit
     permissions:
@@ -110,6 +181,8 @@ jobs:
       contents: read
 
   build-wheels-windows:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/build-wheels-windows.yml
     secrets: inherit
     permissions:
@@ -117,6 +190,8 @@ jobs:
       contents: read
 
   build-wheels-aarch64-linux:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/build-wheels-aarch64-linux.yml
     secrets: inherit
     permissions:
@@ -132,6 +207,7 @@ jobs:
     permissions:
       contents: write
     needs:
+      - config
       - test-linux
       - test-linux-llm
       - test-linux-habitat
@@ -148,7 +224,7 @@ jobs:
       - build-wheels-m1
       - build-wheels-windows
       - build-wheels-aarch64-linux
-    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+    if: always()
     steps:
       - name: Trigger status collector
         uses: peter-evans/repository-dispatch@v4
@@ -157,5 +233,6 @@ jobs:
           client-payload: |
             {
               "run_id": "${{ github.run_id }}",
-              "triggered_at": "${{ github.event.repository.updated_at }}"
+              "triggered_at": "${{ github.event.repository.updated_at }}",
+              "deploy": ${{ needs.config.outputs.deploy_dashboard }}
             }

--- a/.github/workflows/nightly_status_collector.yml
+++ b/.github/workflows/nightly_status_collector.yml
@@ -18,6 +18,10 @@ on:
         description: 'Force recollection even if data already exists'
         type: boolean
         default: false
+      skip-deploy:
+        description: 'Collect status but skip deploying to gh-pages (dry-run)'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -26,7 +30,29 @@ permissions:
 jobs:
   collect-status:
     runs-on: ubuntu-latest
+    outputs:
+      should-deploy: ${{ steps.resolve-deploy.outputs.deploy }}
     steps:
+      - name: Resolve deploy flag
+        id: resolve-deploy
+        run: |
+          # repository_dispatch: read from client payload
+          # workflow_dispatch: read from inputs
+          # schedule: always deploy
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            DEPLOY="${{ github.event.client_payload.deploy }}"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "${{ inputs.skip-deploy }}" = "true" ]; then
+              DEPLOY="false"
+            else
+              DEPLOY="true"
+            fi
+          else
+            DEPLOY="true"
+          fi
+          echo "deploy=${DEPLOY:-true}" >> "$GITHUB_OUTPUT"
+          echo "Deploy dashboard: ${DEPLOY:-true}"
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -40,8 +66,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
-          ignore-nothing-to-cache: true
+          enable-cache: false
 
       - name: Collect nightly status
         env:
@@ -81,6 +106,7 @@ jobs:
           cp .github/nightly-dashboard/index.html nightly-status/
 
       - name: Deploy nightly-status to GitHub Pages
+        if: steps.resolve-deploy.outputs.deploy == 'true'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -88,6 +114,20 @@ jobs:
           destination_dir: nightly-status
           keep_files: true
           commit_message: 'Update nightly status dashboard'
+
+      - name: Dry-run summary
+        if: steps.resolve-deploy.outputs.deploy != 'true'
+        run: |
+          echo "### Dry-run: skipped dashboard deployment" >> "$GITHUB_STEP_SUMMARY"
+          echo "Collected status data is available in the workflow artifacts below." >> "$GITHUB_STEP_SUMMARY"
+          head -50 nightly-status/history.json >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload collected data (artifact)
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-status-data
+          path: nightly-status/
+          retention-days: 7
 
   notify-if-degraded:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a **mode selector** to the nightly orchestrator: `full`, `dry-run`, `smoke-test`
  - **full** (default, schedule): runs all tests and deploys the dashboard
  - **dry-run**: runs all tests but skips dashboard deployment
  - **smoke-test**: skips all tests, validates CI plumbing only (fast way to test the dashboard)
- Disables uv cache in collector (`enable-cache: false`) to avoid symlink loop issues
- Collector respects the `deploy` flag from the orchestrator payload and a manual `skip-deploy` input
- Uploads collected status data as a workflow artifact for inspection
- Changes `update-status-dashboard` condition to `always()` so it fires in smoke-test mode

Mirrors tensordict fixes from pytorch/tensordict#1560 and pytorch/tensordict#1561.

## Test plan

- [ ] Trigger orchestrator with `smoke-test` mode -- should skip all tests and deploy dashboard
- [ ] Verify dashboard appears at https://pytorch.github.io/rl/nightly-status/


Made with [Cursor](https://cursor.com)