### PR TITLE
[BugFix] Fix flaky Ray replay buffer tests

### DIFF
--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -4269,6 +4269,7 @@ class TestRayRB:
     def cleanup(self):
         import ray
 
+        ray.shutdown()
         torchrl_logger.info("Initializing Ray.")
         ray.init(num_cpus=1)
         yield

--- a/torchrl/modules/models/llm.py
+++ b/torchrl/modules/models/llm.py
@@ -134,9 +134,7 @@ class GPT2RewardModel(nn.Module):
             end_ind = max(c_ind, r_ind)
 
             # Retrieve first index where trajectories diverge
-            divergence = (chosen_ids[i] != rejected_ids[i]).nonzero(
-                as_tuple=False
-            )
+            divergence = (chosen_ids[i] != rejected_ids[i]).nonzero(as_tuple=False)
             if divergence.numel() == 0:
                 # Identical sequences: no preference signal, skip sample
                 continue


### PR DESCRIPTION
## Summary

- Fix intermittent `torch.AcceleratorError: CUDA error: CUDA-capable device(s) is/are busy or unavailable` in `test_ray_replaybuffer` on GPU CI (13.64% failure rate, 12/88 runs)
- Root cause: GPU resource contention from preceding collector tests in the shared Ray cluster leaves CUDA in a busy state when the CPU-only replay buffer actors try to initialize
- Explicitly set `num_gpus=0` and `CUDA_VISIBLE_DEVICES=""` in the Ray actor remote config to prevent CUDA initialization
- Add `rb.close()` in `try/finally` to stop leaking 12 Ray actors per test run
- Add `ray.shutdown()` before `ray.init()` in `TestRayRB` fixture (`test_rb.py`) to prevent `RuntimeError: ray.init called twice` when Ray is already initialized from a prior test

## Test plan

- [ ] `tests-gpu-distributed` CI jobs pass (these are where the flaky failures occurred)
- [ ] `tests-optdeps` CI jobs pass (these run `test_rb.py::TestRayRB`)
- [ ] Monitor flaky test dashboard after merge to verify failure rate drops to 0%


Made with [Cursor](https://cursor.com)