### PR TITLE
[CI] Fix nightly wheel test script path

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -139,7 +139,7 @@ jobs:
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
           export PATH="/opt/python/${{ matrix.python_version[1] }}/bin:$PATH"
-          python scripts/verify_nightly_version.py
+          python packaging/verify_nightly_version.py
       - name: Run tests
         run: |
           set -e
@@ -292,7 +292,7 @@ jobs:
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
-          python scripts/verify_nightly_version.py
+          python packaging/verify_nightly_version.py
       - name: Run tests
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- Fix `scripts/verify_nightly_version.py` → `packaging/verify_nightly_version.py` in `nightly_build.yml`
- The script was moved to `packaging/` but the workflow still referenced the old `scripts/` path, causing all nightly `test-wheel-*` jobs (Linux, macOS, Windows) to fail with `No such file or directory`

## Test plan

- [ ] Next nightly run should have all `test-wheel-*` jobs pass the version verification step


Made with [Cursor](https://cursor.com)