### PR TITLE
[BugFix] Fix missing raise, incorrect __torch_function__ return, and off-by-one in RayCollector

### DIFF
--- a/torchrl/collectors/_runner.py
+++ b/torchrl/collectors/_runner.py
@@ -487,7 +487,7 @@ def _main_async_collector(
                             if x.device.type in ("cpu",):
                                 x.share_memory_()
                             if x.device.type in ("mps",):
-                                RuntimeError(MPS_ERROR)
+                                raise RuntimeError(MPS_ERROR)
 
                         collected_tensordict.apply(cast_tensor, filter_empty=True)
                 data = (collected_tensordict, idx)

--- a/torchrl/collectors/distributed/ray.py
+++ b/torchrl/collectors/distributed/ray.py
@@ -1010,7 +1010,7 @@ class RayCollector(BaseCollector):
 
             if self.update_after_each_batch or self.max_weight_update_interval > -1:
                 torchrl_logger.debug(f"Updating weights on worker {collector_index}")
-                self.update_policy_weights_(worker_ids=collector_index + 1)
+                self.update_policy_weights_(worker_ids=collector_index)
 
             # Schedule a new collection task
             future = collector.next.remote()

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -1229,9 +1229,7 @@ class TensorSpec(metaclass=abc.ABCMeta):
         if func not in cls.SPEC_HANDLED_FUNCTIONS or not all(
             issubclass(t, (TensorSpec,)) for t in types
         ):
-            return NotImplementedError(
-                f"func {func} for spec {cls} with handles {cls.SPEC_HANDLED_FUNCTIONS}"
-            )
+            return NotImplemented
         return cls.SPEC_HANDLED_FUNCTIONS[func](*args, **kwargs)
 
     def unbind(self, dim: int = 0):


### PR DESCRIPTION
## Summary

Fixes three independent bugs found during code review:

- **`collectors/_runner.py`**: `RuntimeError(MPS_ERROR)` is constructed but never raised, silently allowing execution to continue when tensors are on MPS devices instead of failing with a clear error
- **`data/tensor_specs.py`**: `TensorSpec.__torch_function__` returns a `NotImplementedError(...)` instance instead of the `NotImplemented` sentinel, violating the `__torch_function__` protocol and causing downstream confusion since the caller receives an exception object as a valid return value
- **`collectors/distributed/ray.py`**: `update_policy_weights_()` is called with `collector_index + 1`, but `collector_index` is already 0-indexed (it comes from `pending_tasks.pop(future)`), so the +1 causes weight updates to target the wrong worker

## Changes

All three fixes are minimal:

1. Add `raise` before `RuntimeError(MPS_ERROR)` in `_runner.py:490`
2. Replace `return NotImplementedError(...)` with `return NotImplemented` in `tensor_specs.py:1232`
3. Remove `+ 1` from `collector_index + 1` in `ray.py:1013`

Fixes #3000