### PR TITLE
[BugFix] Fix DataLoadingPrimer batch_size detection for NonTensorStack

### DIFF
--- a/torchrl/envs/llm/transforms/dataloading.py
+++ b/torchrl/envs/llm/transforms/dataloading.py
@@ -816,6 +816,15 @@ class DataLoadingPrimer(TensorDictPrimer, metaclass=_RayServiceMetaClass):
                 batch_dims=int(bool(self.auto_batch_size or self.batch_size)),
                 device=device,
             )
+            if not out.ndim and self.auto_batch_size:
+                # auto_batch_size may fail to detect batch dimensions from
+                # NonTensorStack entries. Infer from list values in the data.
+                for v in data.values():
+                    if isinstance(v, (list, tuple)) and v:
+                        out = TensorDict.from_dict(
+                            data, batch_size=[len(v)], device=device
+                        )
+                        break
         else:
             raise TypeError(
                 "Data loader must return a mapping that can be automatically cast to a tensordict. Check that you have "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3533
* __->__ #3532
* #3531

TensorDict.from_dict with auto_batch_size=True may fail to detect
batch dimensions from NonTensorStack entries, resulting in an empty
batch_size. This causes unbind to produce items that still contain
the full batch of data, leading to corrupted History objects where
content is a nested list instead of a scalar string.

When auto_batch_size fails (ndim==0) and the raw data contains list
values, retry from_dict with an explicit batch_size inferred from
the list length.

Co-authored-by: Cursor <cursoragent@cursor.com>