### PR TITLE
[LLM] Rewrite GSM8K reward function to follow standard GRPO conventions

### DIFF
--- a/sota-implementations/grpo/grpo_utils.py
+++ b/sota-implementations/grpo/grpo_utils.py
@@ -775,8 +775,8 @@ def make_env(cfg: DictConfig, single_env: bool = False):
     # Setup environment
     max_steps = cfg.env.max_steps if cfg.env.reasoning else 1
     if cfg.env.dataset == "gsm8k":
-        # Reward scale is 0.0 to 100
-        reward_threshold = 20
+        # Reward scale is 0.0 to 1.0
+        reward_threshold = 0.1
         env = GSM8KEnv(
             repeats=cfg.env.repeats,
             tokenizer=train_tokenizer,
@@ -785,9 +785,9 @@ def make_env(cfg: DictConfig, single_env: bool = False):
             device=torch.device("cpu"),
             ray_backend=True,
         )
-    elif cfg.env.dataset == "ifeval":  # ifeval
-        # Reward scale is 0.0 to 2.2
-        reward_threshold = 1.0
+    elif cfg.env.dataset == "ifeval":
+        # Reward scale is 0.0 to ~1.15
+        reward_threshold = 0.5
         env = IFEvalEnv(
             repeats=cfg.env.repeats,
             tokenizer=train_tokenizer,

--- a/test/llm/test_llm_envs.py
+++ b/test/llm/test_llm_envs.py
@@ -266,8 +266,90 @@ class TestGSM8K:
         r["history"].full = history_full
         s = env.step(r)
         assert s.device == device
-        assert s["next", "reward"] >= 10
+        assert s["next", "reward"] > 0
         assert s["next", "done"].all()
+
+
+class TestGSM8KRewardParser:
+    """Unit tests for the GSM8K reward parser (no model/dataset required)."""
+
+    def test_extract_tags(self):
+        from torchrl.envs.llm.reward.gsm8k import GSM8KRewardParser
+
+        think, answer = GSM8KRewardParser.extract_tags(
+            "<think>some reasoning</think> <answer>42</answer>"
+        )
+        assert think == "some reasoning"
+        assert answer == "42"
+
+    def test_extract_tags_malformed(self):
+        from torchrl.envs.llm.reward.gsm8k import GSM8KRewardParser
+
+        think, answer = GSM8KRewardParser.extract_tags(
+            "<think>reasoning with <special> chars & stuff</think> <answer>5</answer>"
+        )
+        assert answer == "5"
+
+    def test_extract_tags_missing(self):
+        from torchrl.envs.llm.reward.gsm8k import GSM8KRewardParser
+
+        think, answer = GSM8KRewardParser.extract_tags("no tags here at all")
+        assert think == ""
+        assert answer == ""
+
+    def test_normalize_answer(self):
+        from torchrl.envs.llm.reward.gsm8k import GSM8KRewardParser
+
+        assert GSM8KRewardParser.normalize_answer("1,234") == "1234"
+        assert GSM8KRewardParser.normalize_answer("$120") == "120"
+        assert GSM8KRewardParser.normalize_answer("120.0") == "120"
+        assert GSM8KRewardParser.normalize_answer("120.00") == "120"
+        assert GSM8KRewardParser.normalize_answer(" 42 ") == "42"
+        assert GSM8KRewardParser.normalize_answer("3.14") == "3.14"
+        assert GSM8KRewardParser.normalize_answer("100%") == "100"
+
+    def test_correct_answer_reward(self):
+        from torchrl.envs.llm.reward.gsm8k import GSM8KRewardParser
+
+        parser = GSM8KRewardParser()
+        td = parser._single_correctness_reward("42", "42", "some reasoning")
+        assert td["success"]
+        assert td["reward"] == 1.0
+
+    def test_wrong_answer_with_format(self):
+        from torchrl.envs.llm.reward.gsm8k import GSM8KRewardParser
+
+        parser = GSM8KRewardParser()
+        td = parser._single_correctness_reward("42", "99", "some reasoning")
+        assert not td["success"]
+        assert td["reward"] == 0.1
+        assert td["reward_answer"] == 1.0
+
+    def test_no_answer(self):
+        from torchrl.envs.llm.reward.gsm8k import GSM8KRewardParser
+
+        parser = GSM8KRewardParser()
+        td = parser._single_correctness_reward("42", "", "")
+        assert not td["success"]
+        assert td["reward"] == 0.0
+        assert td["reward_answer"] == 0.0
+
+    def test_normalized_match(self):
+        from torchrl.envs.llm.reward.gsm8k import GSM8KRewardParser
+
+        parser = GSM8KRewardParser()
+        td = parser._single_correctness_reward("1234", "1,234", "thinking")
+        assert td["success"]
+        assert td["reward"] == 1.0
+
+    def test_custom_reward_values(self):
+        from torchrl.envs.llm.reward.gsm8k import GSM8KRewardParser
+
+        parser = GSM8KRewardParser(format_reward=0.5, correct_reward=2.0)
+        td_correct = parser._single_correctness_reward("42", "42", "cot")
+        assert td_correct["reward"] == 2.0
+        td_format = parser._single_correctness_reward("42", "99", "cot")
+        assert td_format["reward"] == 0.5
 
 
 @pytest.mark.skipif(not _has_ifeval, reason="requires IFEval libs")

--- a/torchrl/envs/llm/datasets/gsm8k.py
+++ b/torchrl/envs/llm/datasets/gsm8k.py
@@ -259,7 +259,6 @@ class GSM8KEnv(DatasetChatEnv):
                             is_shared=False),
                         reward: Tensor(shape=torch.Size([1, 1, 1]), device=cpu, dtype=torch.float32, is_shared=False),
                         reward_answer: Tensor(shape=torch.Size([1, 1, 1]), device=cpu, dtype=torch.float32, is_shared=False),
-                        reward_contained: Tensor(shape=torch.Size([1, 1, 1]), device=cpu, dtype=torch.float32, is_shared=False),
                         reward_right: Tensor(shape=torch.Size([1, 1, 1]), device=cpu, dtype=torch.float32, is_shared=False),
                         reward_think: Tensor(shape=torch.Size([1, 1, 1]), device=cpu, dtype=torch.float32, is_shared=False),
                         step_count: Tensor(shape=torch.Size([1, 1]), device=cpu, dtype=torch.int64, is_shared=False),
@@ -293,7 +292,7 @@ class GSM8KEnv(DatasetChatEnv):
             device=None,
             is_shared=False,
             stack_dim=0)
-        >>> assert s["next", "reward"] >= 10
+        >>> assert s["next", "reward"] > 0
         >>> assert s["next", "done"].all()
 
     """

--- a/torchrl/envs/llm/reward/gsm8k.py
+++ b/torchrl/envs/llm/reward/gsm8k.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import re
 from typing import Literal
 
 import torch
@@ -23,24 +24,36 @@ class GSM8KRewardParser(Transform):
     - "text" mode: response is in ("text", "response") and is text
     - "tokens" mode: response is in ("tokens", "response") and is tokens
 
+    The reward follows the standard GRPO convention:
+
+    - ``1.0`` if the extracted answer matches the ground truth (after normalization).
+    - ``format_reward`` (default ``0.1``) if the response has a valid ``<answer>`` tag but
+      the answer is wrong.
+    - ``0.0`` otherwise (no parseable answer).
+
     Args:
         tokenizer (AutoTokenizer from transformers): the tokenizer associated with the model.
         in_keys (list of NestedKey): the input keys. If None, will be automatically determined based on parent's input_mode.
-        out_keys (list of NestedKey): the output keys. Defaults to `[ "reward_answer", "reward_think", "reward_right", "reward_contained", "reward", "success"]`.
-        eos_token (str): the end of sentence token. Defaults to `tokenizer.eos_token` if not provided.
-        set_done_if_answer (bool): whether to set the done flag to `True` when an answer is present. Defaults to `True`.
+        out_keys (list of NestedKey): the output keys. Defaults to
+            ``["reward_answer", "reward_think", "reward_right", "reward", "success"]``.
+        eos_token (str): the end of sentence token. Defaults to ``tokenizer.eos_token`` if not provided.
+        set_done_if_answer (bool): whether to set the done flag to ``True`` when an answer is present. Defaults to ``True``.
         input_mode (Literal["history", "text", "tokens"]): the input mode of the parent environment.
-            Defaults to `None` (will be automatically determined based on parent's input_mode).
+            Defaults to ``None`` (will be automatically determined based on parent's input_mode).
+        format_reward (float): reward for correct format but wrong answer. Defaults to ``0.1``.
+        correct_reward (float): reward for correct answer. Defaults to ``1.0``.
     """
 
     def __init__(
         self,
-        tokenizer,
+        tokenizer=None,
         in_keys: list[NestedKey] | None = None,
         out_keys: list[NestedKey] | None = None,
         eos_token: str | None = None,
         set_done_if_answer: bool = True,
         input_mode: Literal["history", "text", "tokens"] | None = None,
+        format_reward: float = 0.1,
+        correct_reward: float = 1.0,
     ):
         super().__init__()
         self.tokenizer = tokenizer
@@ -53,13 +66,14 @@ class GSM8KRewardParser(Transform):
         )
         self.set_done_if_answer = set_done_if_answer
         self._input_mode = input_mode
+        self.format_reward = format_reward
+        self.correct_reward = correct_reward
 
         if out_keys is None:
             out_keys = [
                 "reward_answer",
                 "reward_think",
                 "reward_right",
-                "reward_contained",
                 "reward",
                 "success",
             ]
@@ -105,44 +119,34 @@ class GSM8KRewardParser(Transform):
     def _step(
         self, tensordict: TensorDictBase, next_tensordict: TensorDictBase
     ) -> TensorDictBase:
-        from xml.etree import ElementTree as ET
-
         if next_tensordict.batch_dims > 1:
             with tensordict.view(-1) as td_view, next_tensordict.view(
                 -1
             ) as next_td_view:
                 self._step(td_view, next_td_view)
-            # did update in place
             return next_tensordict
 
-        # Get the completion based on input_mode
         self._maybe_get_in_keys()
-        responses = tensordict[self.in_keys[0]]  # batch_size, grpo_size, L
+        responses = tensordict[self.in_keys[0]]
 
-        # Handle different response types based on input_mode
         input_mode = self.input_mode
         if input_mode == "history":
-            # responses is a History object, extract the text content
             responses = lazy_stack([r[..., -1] for r in responses.unbind(0)])
             if hasattr(responses, "content"):
-                # If it's a History object with content attribute
                 text_completion = responses.content
                 if is_non_tensor(text_completion):
                     text_completion = text_completion.tolist()
                 if not isinstance(text_completion, list):
                     text_completion = [text_completion]
             elif hasattr(responses, "apply_chat_template"):
-                # If it's a History object, apply chat template to get text
                 text_completion = responses.apply_chat_template(
                     tokenizer=self.tokenizer, add_generation_prompt=False
                 )
                 if not isinstance(text_completion, list):
                     text_completion = [text_completion]
             else:
-                # Fallback: try to convert to string
                 text_completion = [str(responses)]
         elif input_mode == "text":
-            # responses is already text
             if isinstance(responses, str):
                 text_completion = [
                     responses for _ in range(next_tensordict.batch_size[0])
@@ -152,11 +156,9 @@ class GSM8KRewardParser(Transform):
             else:
                 text_completion = responses
         elif input_mode == "tokens":
-            # responses is tokens, need to decode
             if isinstance(responses, torch.Tensor):
                 if responses.ndim == 3:
                     batch_size, grpo_size, _ = responses.shape
-                # decode
                 text_completion = self.tokenizer.decode(
                     responses.flatten(0, 1).tolist()
                 )
@@ -165,7 +167,6 @@ class GSM8KRewardParser(Transform):
                         text_completion for _ in range(next_tensordict.batch_size[0])
                     ]
             else:
-                # Assume it's already a list of token sequences
                 text_completion = []
                 for token_seq in responses:
                     if isinstance(token_seq, torch.Tensor):
@@ -179,41 +180,20 @@ class GSM8KRewardParser(Transform):
 
         if self.eos_token is not None:
             text_completion = [r.removesuffix(self.eos_token) for r in text_completion]
-        answers = next_tensordict[self.in_keys[1]]  # batch_size, grpo_size
+        answers = next_tensordict[self.in_keys[1]]
 
-        # Decomposed reward
         tds = []
-        # torchrl_logger.info(f"{answers=}")
-        # torchrl_logger.info(f"{text_completion=}")
         for answer, compl in _zip_strict(answers, text_completion):
-            try:
-                if not compl.startswith("<think>"):
-                    compl = "<think>" + compl
-                if compl.endswith("<|im_end|>"):
-                    compl = compl.removesuffix("<|im_end|>")
-                cot, potential_answer = self.extract_tags(compl)
-            except ET.ParseError:
-                cot, potential_answer = ("", "")
-            if potential_answer is None:
-                potential_answer = ""
-            if cot is None:
-                cot = ""
-            # TODO: in tune, the answer is parsed during dataloading
-            #  we could create a similar dataclass for both proposed and real answer
-            #  With tensorclass comparison should be easy
-            cot_orig, answer = answer.split("#### ")
-            tds.append(
-                self._single_shaped_correctness_reward(
-                    answer, [potential_answer], [cot]
-                )
-            )
+            if compl.endswith("<|im_end|>"):
+                compl = compl.removesuffix("<|im_end|>")
+            cot, potential_answer = self.extract_tags(compl)
+            _unused, answer = answer.split("#### ")
+            tds.append(self._single_correctness_reward(answer, potential_answer, cot))
         tds = torch.stack(tds)
         if isinstance(responses, torch.Tensor) and responses.ndim == 3:
             batch_size, grpo_size, _ = responses.shape
             tds = tds.reshape(batch_size, grpo_size)
-        # Rewards need to have shape broadcastable to [batch x tokens x 1]
         tds = tds.apply(lambda t: t.unsqueeze(-1).unsqueeze(-1))
-        # Add the rewards, in case some have already been written
         next_td_exist = next_tensordict.select(*tds.keys(True, True), strict=False)
         if not next_td_exist.is_empty():
             tds = tds.add(
@@ -241,84 +221,69 @@ class GSM8KRewardParser(Transform):
                 reward_answer=Unbounded(shape),
                 reward_think=Unbounded(shape),
                 reward_right=Unbounded(shape),
-                reward_contained=Unbounded(shape),
                 reward=Unbounded(shape),
                 success=Unbounded(shape, dtype=torch.bool),
             )
         )
         return reward_spec
 
-    @classmethod
-    def _single_shaped_correctness_reward(
-        cls, true_answer: str, potential_answer: list[str], cot: list[str]
+    def _single_correctness_reward(
+        self, true_answer: str, potential_answer: str, cot: str
     ) -> TensorDict:
-        # TODO: In tune, these end up being lists
-        # torchrl_logger.info(f"{potential_answer=}")
-        # torchrl_logger.info(f"{true_answer=}")
-        if isinstance(potential_answer, str):
-            potential_answer = [potential_answer]
-        if isinstance(cot, str):
-            cot = [cot]
+        has_answer = bool(potential_answer)
+        has_think = bool(cot)
 
-        # Format quality rewards (always applied)
-        reward_answer = 5.0 * (len(potential_answer) == 1)
-        reward_think = 5.0 * (len(cot) == 1)
+        norm_true = self.normalize_answer(true_answer)
+        correct = has_answer and self.normalize_answer(potential_answer) == norm_true
 
-        # Answer correctness rewards
-        reward_right = 20.0 * (
-            any(attempt == true_answer for attempt in potential_answer)
-        )
-        reward_contained = 10.0 * (
-            any((true_answer in attempt) for attempt in potential_answer)
-        )
+        reward_answer = float(has_answer)
+        reward_think = float(has_think)
 
-        success = len(potential_answer) > 0 and potential_answer[-1] == true_answer
+        if correct:
+            reward_right = self.correct_reward
+        elif has_answer:
+            reward_right = self.format_reward
+        else:
+            reward_right = 0.0
 
-        # Base success reward (lower than before to make format quality more important)
-        base_success_reward = 60.0 if success else 0.0
+        reward = reward_right
 
-        # Compose the rewards - always include format quality, even when successful
-        reward = (
-            base_success_reward
-            + reward_answer
-            + reward_think
-            + reward_contained
-            + reward_right
-        )
-
-        rewards = TensorDict(
+        return TensorDict(
             reward_answer=reward_answer,
             reward_think=reward_think,
             reward_right=reward_right,
-            reward_contained=reward_contained,
             reward=reward,
-            success=success,
+            success=correct,
         )
-        return rewards
+
+    @staticmethod
+    def normalize_answer(answer: str) -> str:
+        """Normalize a numerical answer string for comparison.
+
+        Strips whitespace, removes commas/dollar signs/percent signs, and
+        normalizes trailing decimal zeros (e.g. ``"120.0"`` becomes ``"120"``).
+        """
+        answer = answer.strip()
+        answer = answer.replace(",", "").replace("$", "").replace("%", "")
+        answer = answer.rstrip(".")
+        if "." in answer:
+            answer = answer.rstrip("0").rstrip(".")
+        return answer
 
     @staticmethod
     def extract_tags(text: str) -> tuple[str, str]:
-        """Parse XML-like tags from text.
+        """Extract think and answer content from a response using regex.
 
-        Returns: a dictionary with keys 'think' and 'answer'.
-            The values are lists of strings, with each string being the content of a tag.
+        More robust than XML parsing since LLM outputs frequently contain
+        malformed markup.
 
+        Returns:
+            A ``(think_content, answer_content)`` tuple.  Empty strings are
+            returned when the corresponding tag is absent.
         """
-        from xml.etree import ElementTree as ET
-
-        xml_string = f"<root>{text}</root>"
-        try:
-            root = ET.fromstring(xml_string)
-        except ET.ParseError:
-            return ("", "")
-
-        think_elem = root.find("think")
-        answer_elem = root.find("answer")
+        think_match = re.search(r"<think>(.*?)</think>", text, re.DOTALL)
+        answer_match = re.search(r"<answer>(.*?)</answer>", text, re.DOTALL)
         return (
-            think_elem.text
-            if think_elem is not None and think_elem.text is not None
-            else "",
-            answer_elem.text
-            if answer_elem is not None and answer_elem.text is not None
-            else "",
+            think_match.group(1).strip() if think_match else "",
+            answer_match.group(1).strip() if answer_match else "",
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3579
* #3578
* #3577
* #3576
* #3575
* #3574
* #3573
* #3572
* #3571
* #3570
* #3569
* __->__ #3568

Replace the complex 5-component additive reward (0-100 scale) with the
standard 0/0.1/1.0 convention used by veRL and DeepSeek-R1.

Key changes:
- Use regex instead of xml.etree for tag extraction (robust to malformed output)
- Add answer normalization (commas, dollar signs, trailing zeros, whitespace)
- Remove reward_contained (substring match anti-pattern)
- Simplify to: 1.0 correct, 0.1 format ok but wrong, 0.0 no answer
- Add configurable format_reward and correct_reward parameters
- Add comprehensive unit tests for the reward parser

Made-with: Cursor
Pull-Request: https://github.com/pytorch/rl/pull/3542