### PR TITLE
Export torchrl_logger from torchrl.__init__ for GRPO scripts

### DIFF
--- a/torchrl/__init__.py
+++ b/torchrl/__init__.py
@@ -68,6 +68,7 @@ from torchrl._utils import (  # noqa: E402
 )
 
 logger = logger
+torchrl_logger = logger
 
 # TorchRL's multiprocessing default.
 _preferred_start_method = _get_default_mp_start_method()
@@ -140,5 +141,5 @@ __all__ = [
     "set_auto_unwrap_transformed_env",
     "timeit",
     "logger",
-    "logger",
+    "torchrl_logger",
 ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3579
* #3578
* #3577
* #3576
* #3575
* #3574
* __->__ #3573
* #3572
* #3571
* #3570
* #3569
* #3568

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Pull-Request: https://github.com/pytorch/rl/pull/3555