### PR TITLE
Fix vLLM >= 0.17 compatibility: migrate to native WeightTransferConfig API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ llm = [
 # LLM with vLLM backend
 llm-vllm = [
     "torchrl[llm]",
-    "vllm",
+    "vllm>=0.17",
 ]
 # LLM with SGLang backend
 llm-sglang = [
@@ -120,7 +120,7 @@ llm-sglang = [
 # LLM with both backends
 llm-all = [
     "torchrl[llm]",
-    "vllm",
+    "vllm>=0.17",
     "sglang[all]",
 ]
 grpo = [

--- a/sota-implementations/expert-iteration/expert-iteration-async.py
+++ b/sota-implementations/expert-iteration/expert-iteration-async.py
@@ -132,7 +132,9 @@ def train(
     # Set up weight sender
     torchrl_logger.info("Setting up weight synchronization scheme...")
     sender = weight_sync_scheme.create_sender()
-    sender.register_model(policy_training)
+    # Register the HuggingFace model directly (not the TransformersWrapper)
+    # so state_dict() keys match vLLM's expected format (e.g., model.layers.0.*)
+    sender.register_model(policy_training.model)
 
     # Get vLLM engine reference from collector's policy
     # The collector has the policy which wraps the vLLM engine
@@ -142,7 +144,7 @@ def train(
 
     # Initialize collective group
     torchrl_logger.info("Initializing collective group...")
-    metadata = get_model_metadata(policy_training)
+    metadata = get_model_metadata(policy_training.model)
     sender.init_all_workers_group(metadata, vllm_engine=vllm_engine)
 
     # First weight update

--- a/sota-implementations/expert-iteration/expert-iteration-sync.py
+++ b/sota-implementations/expert-iteration/expert-iteration-sync.py
@@ -126,7 +126,9 @@ def train(
     # Set up weight sender
     torchrl_logger.info("Setting up weight synchronization scheme...")
     sender = weight_sync_scheme.create_sender()
-    sender.register_model(policy_training)
+    # Register the HuggingFace model directly (not the TransformersWrapper)
+    # so state_dict() keys match vLLM's expected format (e.g., model.layers.0.*)
+    sender.register_model(policy_training.model)
 
     # Get vLLM engine reference from collector's policy
     vllm_engine = collector.policy.model if hasattr(collector, "policy") else None
@@ -135,7 +137,7 @@ def train(
 
     # Initialize collective group
     torchrl_logger.info("Initializing collective group...")
-    metadata = get_model_metadata(policy_training)
+    metadata = get_model_metadata(policy_training.model)
     sender.init_all_workers_group(metadata, vllm_engine=vllm_engine)
 
     # First weight update

--- a/sota-implementations/grpo/grpo-async.py
+++ b/sota-implementations/grpo/grpo-async.py
@@ -122,11 +122,13 @@ def train(
     # We'll need to manually set up the sender since collectors were already created
     # without the scheme. In production, collectors should be created with weight_sync_schemes parameter.
     sender = weight_sync_scheme.create_sender()
-    sender.register_model(policy_training)
+    # Register the HuggingFace model directly (not the TransformersWrapper)
+    # so state_dict() keys match vLLM's expected format (e.g., model.layers.0.*)
+    sender.register_model(policy_training.model)
 
     # Initialize collective group
     torchrl_logger.info("Initializing collective group...")
-    metadata = get_model_metadata(policy_training)
+    metadata = get_model_metadata(policy_training.model)
     sender.init_all_workers_group(metadata, vllm_engine=inference_engine)
 
     # First weight update

--- a/sota-implementations/grpo/grpo-sync.py
+++ b/sota-implementations/grpo/grpo-sync.py
@@ -118,11 +118,13 @@ def train(
     # Set up weight sender
     torchrl_logger.info("Setting up weight synchronization scheme...")
     sender = weight_sync_scheme.create_sender()
-    sender.register_model(policy_training)
+    # Register the HuggingFace model directly (not the TransformersWrapper)
+    # so state_dict() keys match vLLM's expected format (e.g., model.layers.0.*)
+    sender.register_model(policy_training.model)
 
     # Initialize collective group
     torchrl_logger.info("Initializing collective group...")
-    metadata = get_model_metadata(policy_training)
+    metadata = get_model_metadata(policy_training.model)
     sender.init_all_workers_group(metadata, vllm_engine=inference_engine)
 
     # First weight update

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -1423,6 +1423,12 @@ def merge_ray_runtime_env(ray_init_config: dict[str, Any]) -> dict[str, Any]:
     elif not isinstance(runtime_env["env_vars"], dict):
         runtime_env["env_vars"] = dict(runtime_env["env_vars"])
 
+    # Auto-propagate common env vars to Ray workers
+    for key in ("WANDB_API_KEY", "HF_TOKEN", "HF_HOME"):
+        val = os.environ.get(key)
+        if val and key not in runtime_env["env_vars"]:
+            runtime_env["env_vars"][key] = val
+
     return ray_init_config
 
 

--- a/torchrl/modules/llm/backends/vllm/vllm_async.py
+++ b/torchrl/modules/llm/backends/vllm/vllm_async.py
@@ -27,7 +27,6 @@ from torchrl._utils import logger as torchrl_logger
 
 # Import RLvLLMEngine and shared utilities
 from .base import RLvLLMEngine
-from .vllm_utils import stateless_init_process_group
 
 
 _has_vllm = True
@@ -69,99 +68,6 @@ def _get_ray():
 
 class _AsyncvLLMWorker:
     """Async vLLM worker extension for Ray with weight update capabilities."""
-
-    def init_weight_update_group(
-        self,
-        master_address: str,
-        master_port: str,
-        rank_offset: int,
-        world_size: int,
-    ):
-        """Initialize weight update group for this worker (non-blocking).
-
-        This method starts NCCL initialization in a background thread and returns immediately,
-        allowing the RPC to complete. The NCCL collective will complete when the trainer joins.
-
-        Args:
-            master_address (str): The master address for distributed training.
-            master_port (str): The master port for distributed training.
-            rank_offset (int): Rank offset for this worker in the global weight update group.
-            world_size (int): Total number of processes in the weight update group.
-        """
-        import threading
-
-        from vllm.distributed.parallel_state import get_world_group
-
-        torchrl_logger.info(f"=> in {type(self).__name__}.init_weight_update_group")
-        if getattr(self, "model_update_group", None) is not None:
-            torchrl_logger.info("Model update group already initialized")
-            return
-
-        # Get the local rank within the tensor parallel group
-        tp_group = get_world_group()
-        local_rank = tp_group.rank
-        torchrl_logger.info(f"Local rank in tensor parallel group: {local_rank}")
-
-        # Calculate the global rank for weight update group
-        rank = local_rank + rank_offset
-        torchrl_logger.info(
-            f"Starting {type(self).__name__} weight update group init (non-blocking) with "
-            f"{master_address=}, {master_port=}, {rank=}, {world_size=}, device={self.device}"
-        )
-
-        # Start NCCL init in a background thread so this RPC can return immediately
-        def _init_nccl_background():
-            try:
-                from .vllm_utils import stateless_init_process_group
-
-                torchrl_logger.info(
-                    f"Worker rank {rank}: Starting NCCL init (will block until collective completes)..."
-                )
-                self.model_update_group = stateless_init_process_group(
-                    master_address, master_port, rank, world_size, self.device
-                )
-                torchrl_logger.info(f"Worker rank {rank}: NCCL init complete!")
-            except Exception as e:
-                torchrl_logger.error(f"Worker rank {rank}: NCCL init failed: {e}")
-                raise
-
-        thread = threading.Thread(target=_init_nccl_background, daemon=False)
-        thread.start()
-
-        # Store thread reference for potential cleanup
-        self._nccl_init_thread = thread
-
-        torchrl_logger.info(
-            f"{type(self).__name__}.init_weight_update_group dispatched (non-blocking)"
-        )
-
-    def update_weight(self, name: str, dtype_name: str, shape: tuple[int, ...]):
-        """Update weight via broadcast from master (rank 0) - periodic-mono pattern.
-
-        Args:
-            name (str): Parameter name.
-            dtype_name (str): Parameter dtype name (e.g., 'bfloat16').
-            shape (tuple[int, ...]): Parameter shape.
-        """
-        if self.model_update_group is None:
-            raise RuntimeError("Weight update group not initialized")
-
-        # Convert dtype name to dtype (like periodic-mono)
-        dtype = getattr(torch, dtype_name)
-
-        # Workers receive broadcast from master (rank 0)
-        weight = torch.empty(shape, dtype=dtype, device="cuda")
-        self.model_update_group.broadcast(
-            weight, src=0, stream=torch.cuda.current_stream()
-        )
-        self.model_runner.model.load_weights(weights=[(name, weight)])
-        del weight
-
-    def check_nccl_group_ready(self):
-        """Check if NCCL group is ready for communication."""
-        ready = self.model_update_group is not None
-        torchrl_logger.info(f"Worker NCCL group ready: {ready}")
-        return ready
 
     def load_weights_from_storage(self, storage_path: str, num_threads: int = 1):
         """Load weights from shared storage (double-buffer approach).
@@ -231,11 +137,19 @@ class _AsyncLLMEngine:
             )
 
         from vllm import AsyncLLMEngine
+        from vllm.config import WeightTransferConfig
 
         if bundle_indices is not None:
             os.environ["VLLM_RAY_BUNDLE_INDICES"] = ",".join(map(str, bundle_indices))
 
         engine_args.enable_prefix_caching = enable_prefix_caching
+
+        # Enable native weight transfer support (vLLM 0.17+)
+        engine_args.weight_transfer_config = WeightTransferConfig(backend="nccl")
+
+        # Store parallelism info for get_world_size()
+        self._tensor_parallel_size = engine_args.tensor_parallel_size
+        self._data_parallel_size = getattr(engine_args, "data_parallel_size", 1)
 
         # Fix for vLLM issue #19123: Set RAY_ADDRESS so vLLM subprocesses connect
         # to the same Ray cluster instead of starting a new one (causes KeyError: 'bundles')
@@ -409,7 +323,7 @@ class _AsyncLLMEngine:
         """
         from vllm import envs
 
-        if envs and envs.VLLM_USE_V1:
+        if getattr(envs, "VLLM_USE_V1", True):
             return await self.engine.collective_rpc(method, timeout, args, kwargs)
         else:
             return self.engine.engine.collective_rpc(method, timeout, args, kwargs)
@@ -491,6 +405,44 @@ class _AsyncLLMEngine:
         except Exception as e:
             torchrl_logger.warning(f"Error getting cache usage: {e}")
             return 0.0
+
+    async def init_weight_transfer_engine(self, init_request):
+        """Initialize the native weight transfer engine on this vLLM instance.
+
+        Args:
+            init_request: WeightTransferInitRequest (or dict) for the engine.
+        """
+        return await self.engine.init_weight_transfer_engine(init_request)
+
+    async def update_weights_native(self, update_request):
+        """Update weights using the native weight transfer engine.
+
+        Args:
+            update_request: WeightTransferUpdateRequest (or dict) for the engine.
+        """
+        return await self.engine.update_weights(update_request)
+
+    def get_world_size(self):
+        """Get the world size (TP * DP) for this engine instance."""
+        return self._tensor_parallel_size * self._data_parallel_size
+
+    async def sleep(self, level: int = 0):
+        """Put the vLLM engine to sleep to prepare for weight updates.
+
+        Args:
+            level: Sleep level (0 = minimal, preserves KV cache structure).
+        """
+        return await self.engine.sleep(level=level)
+
+    async def wake_up(self, tags: list[str] | None = None):
+        """Wake up the vLLM engine after weight updates.
+
+        Args:
+            tags: Tags controlling what to reinitialize (e.g., ["scheduling"]).
+        """
+        if tags is None:
+            tags = ["scheduling"]
+        return await self.engine.wake_up(tags=tags)
 
 
 def _gpus_per_replica(engine_args: AsyncEngineArgs) -> int:
@@ -1043,7 +995,7 @@ class AsyncVLLM(RLvLLMEngine):
         refs = []
         for i, actor in enumerate(self.actors):
             rank_offset = 1 + i * gpus_per_replica
-            if envs and envs.VLLM_USE_V1:
+            if getattr(envs, "VLLM_USE_V1", True):
                 actor_collective_rpc = actor.collective_rpc_v1
             else:
                 actor_collective_rpc = actor.collective_rpc_v0
@@ -1091,7 +1043,7 @@ class AsyncVLLM(RLvLLMEngine):
 
         futures = []
         for actor in self.actors:
-            if envs and envs.VLLM_USE_V1:
+            if getattr(envs, "VLLM_USE_V1", True):
                 actor_collective_rpc = actor.collective_rpc_v1
             else:
                 actor_collective_rpc = actor.collective_rpc_v0
@@ -1176,68 +1128,76 @@ class AsyncVLLM(RLvLLMEngine):
                 self._cached_master_port = 29500  # Default port
         return self._cached_master_port
 
-    def init_weight_update_group(
-        self,
-        master_address: str,
-        master_port: int | str,
-    ) -> list[Any]:
-        """Forward the request to init NCCL weight update group to all actors.
+    def init_weight_update_group(self) -> None:
+        """Initialize the weight update communication group using vLLM's native WeightTransferConfig API.
 
-        This method initializes the weight update group for all vLLM workers.
-        The external trainer should be rank 0, and vLLM workers will be ranks 1+.
-
-        Args:
-            master_address: Master address for NCCL communication.
-            master_port: Master port for NCCL communication.
-
-        Returns:
-            List of Ray futures for the initialization calls.
-
-        Note:
-            The caller must wait on the returned futures (ray.get(refs)) to ensure
-            all workers have completed initialization before sending weights.
+        This sets up NCCL weight transfer on both the trainer side and all vLLM worker actors.
+        The trainer is rank 0 and vLLM workers are ranks 1+.
         """
         if not self._launched:
             raise RuntimeError(
                 "AsyncVLLM service must be launched before initializing weight update group"
             )
 
+        from dataclasses import asdict
+
+        from vllm.distributed.weight_transfer.base import WeightTransferInitRequest
+        from vllm.distributed.weight_transfer.nccl_engine import (
+            NCCLWeightTransferInitInfo,
+        )
+
         gpus_per_replica = _gpus_per_replica(self.engine_args)
         weight_sync_world_size = self.num_replicas * gpus_per_replica + 1
+        master_address = self.get_master_address()
+        master_port = self.get_master_port()
 
         torchrl_logger.info(
             f"Initializing weight update group for {self.num_replicas} replicas "
             f"with {gpus_per_replica} GPUs each (world_size={weight_sync_world_size})"
         )
 
-        from vllm import envs
+        import threading
 
+        # Step 1: Start trainer NCCL group in a background thread — it blocks
+        # waiting for workers to connect via TCPStore, so it must run concurrently
+        # with the worker dispatch below.
+        trainer_error = [None]
+
+        def _init_trainer():
+            try:
+                self._setup_nccl_master_group()
+            except Exception as e:
+                trainer_error[0] = e
+
+        trainer_thread = threading.Thread(target=_init_trainer)
+        trainer_thread.start()
+
+        # Step 2: Dispatch init_weight_transfer_engine to all vLLM actors
         refs = []
         for i, actor in enumerate(self.actors):
             rank_offset = 1 + i * gpus_per_replica
-            if envs and envs.VLLM_USE_V1:
-                actor_collective_rpc = actor.collective_rpc_v1
-            else:
-                actor_collective_rpc = actor.collective_rpc_v0
-            refs.append(
-                actor_collective_rpc.remote(
-                    "init_weight_update_group",
-                    args=(
-                        master_address,
-                        str(master_port),
-                        rank_offset,
-                        weight_sync_world_size,
-                    ),
-                )
+            init_info = NCCLWeightTransferInitInfo(
+                master_address=master_address,
+                master_port=int(master_port),
+                rank_offset=rank_offset,
+                world_size=weight_sync_world_size,
             )
+            init_request = WeightTransferInitRequest(init_info=asdict(init_info))
+            refs.append(actor.init_weight_transfer_engine.remote(init_request))
             torchrl_logger.info(
                 f"Requested init for actor {i} with rank_offset {rank_offset}"
             )
 
-        return refs
+        # Step 3: Wait for both sides to complete
+        ray = _get_ray()
+        ray.get(refs)
+        trainer_thread.join()
+        if trainer_error[0] is not None:
+            raise trainer_error[0]
+        torchrl_logger.info("Weight update group initialized successfully")
 
     def update_weights(self, weights: Iterator[tuple[str, torch.Tensor]]) -> None:
-        """Update model weights across all replicas using NCCL broadcast.
+        """Update model weights across all replicas using vLLM's native weight transfer API.
 
         Args:
             weights: Iterator yielding (parameter_name, tensor) tuples
@@ -1247,115 +1207,128 @@ class AsyncVLLM(RLvLLMEngine):
                 "AsyncVLLM service must be launched before updating weights"
             )
 
-        # Convert iterator to dict for easier handling
-        weights_dict = dict(weights)
+        from dataclasses import asdict
 
-        if not weights_dict:
+        from vllm.distributed.weight_transfer.base import WeightTransferUpdateRequest
+        from vllm.distributed.weight_transfer.nccl_engine import (
+            NCCLTrainerSendWeightsArgs,
+            NCCLWeightTransferEngine,
+            NCCLWeightTransferUpdateInfo,
+        )
+
+        # Convert iterator to list for metadata extraction and reuse
+        weights_list = list(weights)
+
+        if not weights_list:
             torchrl_logger.warning("No weights provided for update")
             return
 
         torchrl_logger.info(
-            f"Updating {len(weights_dict)} parameters across {len(self.actors)} replicas using NCCL broadcast"
+            f"Updating {len(weights_list)} parameters across {len(self.actors)} replicas"
         )
 
-        self._update_weights_with_nccl_broadcast_simple(weights_dict)
-
-        torchrl_logger.info("AsyncVLLM NCCL weight update completed")
-
-    def _update_weights_with_nccl_broadcast_simple(
-        self, weights_dict: dict[str, torch.Tensor]
-    ) -> None:
-        """Update weights using simple NCCL broadcast like V1.
-
-        This approach follows the V1 pattern:
-        1. Training process (master) broadcasts as rank 0
-        2. All vLLM workers receive as ranks 1, 2, 3...
-        3. Simple and reliable like the working V1 implementation
-
-        Args:
-            weights_dict: Dictionary of parameter names to weight tensors
-        """
-        if not hasattr(self, "_nccl_master_group") or self._nccl_master_group is None:
+        if not hasattr(self, "_trainer_nccl_group") or self._trainer_nccl_group is None:
             raise RuntimeError(
-                "NCCL master group not initialized. This is a bug in the setup process."
+                "Trainer NCCL group not initialized. Call init_weight_update_group first."
             )
 
         t0 = time.time()
 
-        # Move all weights to cuda:0 (matching NCCL communicator device)
-        gpu_weights = {}
-        for name, weight in weights_dict.items():
-            # Ensure weight is on cuda:0 (matching NCCL communicator)
-            if weight.device != torch.device("cuda:0"):
-                gpu_weights[name] = weight.to("cuda:0", non_blocking=True)
-            else:
-                gpu_weights[name] = weight
+        # Put vLLM engines to sleep before weight update (required by vLLM's
+        # native weight transfer API to prepare model state for reloading)
+        ray = _get_ray()
+        torchrl_logger.info("Putting vLLM engines to sleep for weight update...")
+        sleep_refs = [actor.sleep.remote(level=0) for actor in self.actors]
+        ray.get(sleep_refs)
 
-        # Use periodic-mono pattern: individual weight updates with immediate RPC->NCCL
-        torchrl_logger.info(
-            f"Updating {len(gpu_weights)} weights using periodic-mono pattern..."
+        # Build weight metadata from the weights
+        weight_names = []
+        dtype_names = []
+        shapes = []
+        for name, tensor in weights_list:
+            weight_names.append(name)
+            dtype_names.append(
+                str(tensor.dtype).split(".")[-1]
+            )  # "torch.bfloat16" -> "bfloat16"
+            shapes.append(list(tensor.shape))
+
+        # Build update request with metadata
+        update_info = NCCLWeightTransferUpdateInfo(
+            names=weight_names,
+            dtype_names=dtype_names,
+            shapes=shapes,
+            packed=True,
+        )
+        update_request = WeightTransferUpdateRequest(update_info=asdict(update_info))
+
+        # Step 1: Tell all actors to start receiving weights
+        refs = []
+        for actor in self.actors:
+            refs.append(actor.update_weights_native.remote(update_request))
+
+        # Step 2: Send weights from trainer side
+        # Move weights to GPU and create iterator
+        gpu_weights_iter = (
+            (
+                name,
+                tensor.to("cuda:0", non_blocking=True)
+                if not tensor.is_cuda
+                else tensor,
+            )
+            for name, tensor in weights_list
         )
 
-        updated_weights = 0
-        ray = _get_ray()
-        with torch.cuda.device(0):  # Ensure we're on the correct CUDA device
-            for name, weight in gpu_weights.items():
-                # Convert dtype to string name (like periodic-mono)
-                dtype_name = str(weight.dtype).split(".")[
-                    -1
-                ]  # "torch.bfloat16" -> "bfloat16"
+        NCCLWeightTransferEngine.trainer_send_weights(
+            iterator=gpu_weights_iter,
+            trainer_args=NCCLTrainerSendWeightsArgs(
+                group=self._trainer_nccl_group, packed=True
+            ),
+        )
 
-                # Step 1: Send RPC to workers for this weight
-                futures = self.collective_rpc(
-                    "update_weight", args=(name, dtype_name, tuple(weight.shape))
-                )
+        # Step 3: Wait for all actors to finish receiving
+        ray.get(refs)
 
-                # Step 2: Immediately broadcast this weight (like periodic-mono)
-                self._nccl_master_group.broadcast(
-                    weight, src=0, stream=torch.cuda.current_stream()
-                )
-
-                # Step 3: Wait for workers to complete this weight
-                ray.get(futures)
-                updated_weights += 1
+        # Wake up vLLM engines after weight update
+        torchrl_logger.info("Waking up vLLM engines after weight update...")
+        wake_refs = [actor.wake_up.remote(tags=["scheduling"]) for actor in self.actors]
+        ray.get(wake_refs)
 
         torch.cuda.synchronize()
-        t2 = time.time()
+        t1 = time.time()
         torchrl_logger.info(
-            f"Successfully updated {updated_weights}/{len(gpu_weights)} weights in {t2 - t0:.3f}s"
+            f"Successfully updated {len(weights_list)} weights in {t1 - t0:.3f}s"
         )
 
     def _setup_nccl_master_group(self) -> None:
-        """Set up NCCL communication group for the master node (rank 0)."""
-        # Calculate world size (should match what workers use)
+        """Set up NCCL communication group for the trainer (rank 0) using native API."""
+        from vllm.distributed.weight_transfer.nccl_engine import (
+            NCCLWeightTransferEngine,
+        )
+
         gpus_per_replica = _gpus_per_replica(self.engine_args)
         weight_sync_world_size = self.num_replicas * gpus_per_replica + 1
-
         master_address = self.get_master_address()
         master_port = self.get_master_port()
 
         torchrl_logger.info(
-            f"Setting up NCCL master group: rank=0, world_size={weight_sync_world_size}, "
+            f"Setting up trainer NCCL group: rank=0, world_size={weight_sync_world_size}, "
             f"address={master_address}:{master_port}"
         )
 
-        # Ensure CUDA is available and initialized
         if not torch.cuda.is_available():
             raise RuntimeError("CUDA not available for NCCL communication")
 
-        # Set CUDA device before initializing NCCL
         torch.cuda.set_device(0)
 
-        # Initialize master as rank 0 in the NCCL group (use synchronous version)
-        self._nccl_master_group = stateless_init_process_group(
-            master_address=master_address,
-            master_port=str(master_port),
-            rank=0,  # Master is always rank 0
-            world_size=weight_sync_world_size,
-            device=torch.device("cuda:0"),
+        self._trainer_nccl_group = NCCLWeightTransferEngine.trainer_init(
+            {
+                "master_address": master_address,
+                "master_port": int(master_port),
+                "world_size": weight_sync_world_size,
+            }
         )
 
-        torchrl_logger.info("NCCL master group initialized successfully")
+        torchrl_logger.info("Trainer NCCL group initialized successfully")
 
     def get_num_unfinished_requests(
         self, actor_index: int | None = None

--- a/torchrl/modules/llm/backends/vllm/vllm_sync.py
+++ b/torchrl/modules/llm/backends/vllm/vllm_sync.py
@@ -19,7 +19,6 @@ from torchrl._utils import logger as torchrl_logger
 from torchrl.modules.llm.utils import _cuda_visible_devices
 
 from .base import RLvLLMEngine
-from .vllm_utils import stateless_init_process_group
 
 try:
     from vllm import LLM
@@ -69,49 +68,6 @@ class _vLLMWorker(Worker):
         torchrl_logger.info(f"device count {torch.cuda.device_count()}")
         super().__init__(*args, **kwargs)
 
-    def init_weight_update_group(
-        self, master_address, master_port, rank_offset, world_size
-    ):
-        from vllm.distributed.parallel_state import get_world_group
-
-        torchrl_logger.info(f"=> in {type(self).__name__}.init_weight_update_group")
-
-        # Get the local rank within the tensor parallel group
-        tp_group = get_world_group()
-        local_rank = tp_group.rank
-        torchrl_logger.info(f"Local rank in tensor parallel group: {local_rank}")
-
-        # Calculate the global rank for weight update group
-        # rank_offset is 1, so ranks will be [1, 2] for tp_size=2
-        rank = local_rank + rank_offset
-        torchrl_logger.info(
-            f"Initializing {type(self).__name__} weight update group with "
-            f"{master_address=}, {master_port=}, {rank=}, {world_size=}, device={self.device}"
-        )
-
-        self.model_update_group = stateless_init_process_group(
-            master_address,
-            master_port,
-            rank,
-            world_size,
-            self.device,
-        )
-
-        torchrl_logger.info(f"{type(self).__name__}.init_weight_update_group success")
-
-    def update_weight_broadcast(self, name, dtype, shape):
-        weight = torch.empty(shape, dtype=dtype, device="cuda")
-        self.model_update_group.broadcast(
-            weight, src=0, stream=torch.cuda.current_stream()
-        )
-
-        self.model_runner.model.load_weights(weights=[(name, weight)])
-        del weight
-
-    def update_weight(self, name, weight):
-        self.model_runner.model.load_weights(weights=[(name, weight)])
-        del weight
-
     def check_weights_changed(self):
         """Check if the weights are updated to 0."""
         # TODO: This is a test and should be treated as such
@@ -150,6 +106,24 @@ class _LLMOnDevice(LLM):
         # Let vLLM handle device placement
         super().__init__(*self.args, **self.kwargs)
         return True
+
+    def init_weight_transfer_engine(self, init_request):
+        """Initialize the native weight transfer engine on the underlying LLM engine."""
+        return self.llm_engine.init_weight_transfer_engine(init_request)
+
+    def update_weights_native(self, update_request):
+        """Update weights using the native weight transfer engine."""
+        return self.llm_engine.update_weights(update_request)
+
+    def sleep(self, level: int = 0):
+        """Put the vLLM engine to sleep to prepare for weight updates."""
+        return self.llm_engine.sleep(level=level)
+
+    def wake_up(self, tags: list[str] | None = None):
+        """Wake up the vLLM engine after weight updates."""
+        if tags is None:
+            tags = ["scheduling"]
+        return self.llm_engine.wake_up(tags=tags)
 
 
 class RayLLMWorker(RLvLLMEngine):
@@ -195,24 +169,61 @@ class RayLLMWorker(RLvLLMEngine):
         return self._master_port
 
     def init_weight_update_group(self) -> None:
-        """Initialize the weight update communication group."""
+        """Initialize the weight update communication group using vLLM's native API."""
+        from dataclasses import asdict
+
+        from vllm.distributed.weight_transfer.base import WeightTransferInitRequest
+        from vllm.distributed.weight_transfer.nccl_engine import (
+            NCCLWeightTransferEngine,
+            NCCLWeightTransferInitInfo,
+        )
+
         weight_sync_world_size = self._tensor_parallel_size + 1
+        master_address = self.get_master_address()
+        master_port = self.get_master_port()
 
         try:
+            import threading
+
             import ray
 
-            # Initialize weight update group on the Ray worker
-            ray.get(
-                self.ray_actor.collective_rpc.remote(
-                    "init_weight_update_group",
-                    args=(
-                        self.get_master_address(),
-                        self.get_master_port(),
-                        1,
-                        weight_sync_world_size,
-                    ),
-                )
+            # Start trainer NCCL group in background thread — it blocks waiting
+            # for workers to connect via TCPStore.
+            torch.cuda.set_device(0)
+            trainer_result = [None]
+            trainer_error = [None]
+
+            def _init_trainer():
+                try:
+                    trainer_result[0] = NCCLWeightTransferEngine.trainer_init(
+                        {
+                            "master_address": master_address,
+                            "master_port": int(master_port),
+                            "world_size": weight_sync_world_size,
+                        }
+                    )
+                except Exception as e:
+                    trainer_error[0] = e
+
+            trainer_thread = threading.Thread(target=_init_trainer)
+            trainer_thread.start()
+
+            # Initialize weight transfer engine on the Ray worker
+            init_info = NCCLWeightTransferInitInfo(
+                master_address=master_address,
+                master_port=int(master_port),
+                rank_offset=1,
+                world_size=weight_sync_world_size,
             )
+            init_request = WeightTransferInitRequest(init_info=asdict(init_info))
+            ref = self.ray_actor.init_weight_transfer_engine.remote(init_request)
+
+            ray.get(ref)
+            trainer_thread.join()
+            if trainer_error[0] is not None:
+                raise trainer_error[0]
+            self._trainer_nccl_group = trainer_result[0]
+
             torchrl_logger.info("Ray worker weight update group initialized")
         except ImportError:
             raise ImportError(
@@ -220,17 +231,24 @@ class RayLLMWorker(RLvLLMEngine):
             )
 
     def update_weights(self, weights: Iterator[tuple[str, torch.Tensor]]) -> None:
-        """Update model weights via the Ray worker.
+        """Update model weights via the Ray worker using vLLM's native API.
 
         Args:
             weights: Iterator yielding (parameter_name, tensor) tuples
         """
+        from dataclasses import asdict
+
+        from vllm.distributed.weight_transfer.base import WeightTransferUpdateRequest
+        from vllm.distributed.weight_transfer.nccl_engine import (
+            NCCLTrainerSendWeightsArgs,
+            NCCLWeightTransferEngine,
+            NCCLWeightTransferUpdateInfo,
+        )
+
         try:
             import ray
 
-            # Convert iterator to list for Ray serialization
             weights_list = list(weights)
-
             if not weights_list:
                 torchrl_logger.warning("No weights provided for update")
                 return
@@ -239,16 +257,43 @@ class RayLLMWorker(RLvLLMEngine):
                 f"Updating {len(weights_list)} parameters on Ray worker"
             )
 
-            # Send weights to the Ray worker
-            remotes = []
-            for name, weight in weights_list:
-                remotes.append(
-                    self.ray_actor.collective_rpc.remote(
-                        "update_weight", args=(name, weight.to("cuda"))
-                    )
-                )
+            # Put vLLM engine to sleep before weight transfer
+            ray.get(self.ray_actor.sleep.remote(level=0))
 
-            ray.get(remotes)
+            # Build metadata
+            weight_names = [name for name, _ in weights_list]
+            dtype_names = [str(t.dtype).split(".")[-1] for _, t in weights_list]
+            shapes = [list(t.shape) for _, t in weights_list]
+
+            update_info = NCCLWeightTransferUpdateInfo(
+                names=weight_names,
+                dtype_names=dtype_names,
+                shapes=shapes,
+                packed=True,
+            )
+            update_request = WeightTransferUpdateRequest(
+                update_info=asdict(update_info)
+            )
+
+            # Tell worker to start receiving
+            ref = self.ray_actor.update_weights_native.remote(update_request)
+
+            # Send from trainer side
+            gpu_weights_iter = (
+                (name, t.to("cuda:0", non_blocking=True) if not t.is_cuda else t)
+                for name, t in weights_list
+            )
+            NCCLWeightTransferEngine.trainer_send_weights(
+                iterator=gpu_weights_iter,
+                trainer_args=NCCLTrainerSendWeightsArgs(
+                    group=self._trainer_nccl_group, packed=True
+                ),
+            )
+
+            ray.get(ref)
+
+            # Wake up vLLM engine after weight transfer
+            ray.get(self.ray_actor.wake_up.remote(tags=["scheduling"]))
             torchrl_logger.info("Ray worker weight update completed")
 
         except ImportError:

--- a/torchrl/modules/llm/policies/vllm_wrapper.py
+++ b/torchrl/modules/llm/policies/vllm_wrapper.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import collections
-
+import dataclasses
 import importlib.util
 import threading
 import warnings
@@ -2218,6 +2218,13 @@ class _RequestOutput_tc(TensorClass["nocast"]):
 
         if isinstance(self.outputs, list):
             outputs = self.outputs
+            # Pre-process: replace empty list fields with None to avoid
+            # tensordict conversion errors (empty lists can't be stacked)
+            for output in outputs:
+                for field in dataclasses.fields(output):
+                    val = getattr(output, field.name)
+                    if isinstance(val, list) and len(val) == 0:
+                        object.__setattr__(output, field.name, None)
             outputs = [
                 postproc(from_dataclass(output, dest_cls=CompletionOutput_tc))
                 for output in outputs
@@ -2253,7 +2260,9 @@ class _RequestOutput_tc(TensorClass["nocast"]):
                         prompt_logprobs=torch.tensor(
                             [
                                 v[int(tid)].logprob if v is not None else 0.0
-                                for v, tid in _zip_strict(
+                                # Use zip (not _zip_strict) because vLLM V1 may return
+                                # fewer prompt_logprobs than prompt_token_ids (cached tokens)
+                                for v, tid in zip(
                                     request.prompt_logprobs, request.prompt_token_ids
                                 )
                             ]
@@ -2282,7 +2291,9 @@ class _RequestOutput_tc(TensorClass["nocast"]):
                     prompt_logprobs=torch.tensor(
                         [
                             v[int(tid)].logprob if v is not None else 0.0
-                            for v, tid in _zip_strict(
+                            # Use zip (not _zip_strict) because vLLM V1 may return
+                            # fewer prompt_logprobs than prompt_token_ids (cached tokens)
+                            for v, tid in zip(
                                 request.prompt_logprobs, request.prompt_token_ids
                             )
                         ]

--- a/torchrl/weight_update/llm/vllm_nccl.py
+++ b/torchrl/weight_update/llm/vllm_nccl.py
@@ -2,6 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+#
 
 """vLLM weight synchronization for the v2 API.
 
@@ -99,8 +100,6 @@ In this setup:
 
 from __future__ import annotations
 
-import time
-
 from typing import Any, Literal
 
 import torch
@@ -108,7 +107,6 @@ import torch.distributed
 from tensordict import TensorDictBase
 
 from torchrl._utils import logger as torchrl_logger
-from torchrl.modules.llm.backends import stateless_init_process_group
 from torchrl.weight_update.weight_sync_schemes import WeightStrategy, WeightSyncScheme
 
 # ============================================================================
@@ -117,17 +115,10 @@ from torchrl.weight_update.weight_sync_schemes import WeightStrategy, WeightSync
 
 
 class VLLMCollectiveTransport:
-    """Transport for vLLM using collective communication (NCCL).
+    """Transport for vLLM using vLLM's native WeightTransferConfig API (vLLM 0.17+).
 
-    **COLLECTIVE LAYER ONLY** - This class handles the data transfer layer.
-    RPC coordination is handled separately by the caller (sender/receiver).
-
-    This transport uses PyTorch distributed collectives to broadcast weights
-    from a trainer (rank 0) to vLLM workers (ranks 1+).
-
-    **Separation of Concerns:**
-    - This class: NCCL collective operations (GPU-GPU data transfer)
-    - Caller (sender/receiver): RPC coordination (when to start collective)
+    This transport uses vLLM's built-in NCCL weight transfer engine to broadcast
+    weights from a trainer (rank 0) to vLLM workers (ranks 1+).
 
     Args:
         master_address: Address of the master node for distributed init.
@@ -136,10 +127,6 @@ class VLLMCollectiveTransport:
         world_size: Total number of processes (1 + num_replicas * gpus_per_replica).
         device: Device to use for communication (typically cuda:0).
         vllm_engine: Optional vLLM engine reference (for receiver side).
-
-    Note:
-        The RPC layer (e.g., Ray remote calls) must ensure all ranks call
-        init_all_workers_group() simultaneously before any collective operations.
     """
 
     def __init__(
@@ -156,106 +143,153 @@ class VLLMCollectiveTransport:
         self.rank = rank
         self.world_size = world_size
         self.vllm_engine = vllm_engine
-        self._comm_group = None
+        self._trainer_nccl_group = None
         self._model_metadata = None
+        self._initialized = False
 
         # Ray sets CUDA_VISIBLE_DEVICES, so each actor sees only device 0
-        # PyNcclCommunicator expects an integer device index
         if device is None:
-            self.device = 0  # Default to device 0 (Ray convention)
+            self.device = 0
         elif isinstance(device, str):
-            # Extract device index from "cuda:X"
             self.device = int(device.split(":")[-1]) if ":" in device else 0
         elif isinstance(device, torch.device):
-            # Extract index from torch.device
             self.device = device.index if device.index is not None else 0
         else:
             self.device = device
 
     def init_all_workers_group(
-        self, model_metadata: dict[str, tuple[torch.dtype, torch.Size]]
+        self,
+        model_metadata: dict[str, tuple[torch.dtype, torch.Size]],
+        gpus_per_replica: int | None = None,
     ):
-        """Initialize the collective communication group.
+        """Initialize the collective communication group using vLLM's native API.
 
         Args:
             model_metadata: Dict mapping param names to (dtype, shape) tuples.
+            gpus_per_replica: GPUs per replica (for rank_offset calculation). Inferred if not provided.
         """
+        from dataclasses import asdict
+
+        from vllm.distributed.weight_transfer.base import WeightTransferInitRequest
+        from vllm.distributed.weight_transfer.nccl_engine import (
+            NCCLWeightTransferEngine,
+            NCCLWeightTransferInitInfo,
+        )
+
         self._model_metadata = model_metadata
 
-        if self.rank == 0:
-            # Trainer side - initialize process group
-            torchrl_logger.debug(
-                f"Initializing trainer collective group: rank={self.rank}, world_size={self.world_size}, device={self.device}"
-            )
-            # Ray sets CUDA_VISIBLE_DEVICES, so we always use device 0
-            # Set CUDA device before initializing NCCL to avoid segfaults
-            torch.cuda.set_device(self.device)
-            torchrl_logger.debug(f"Set CUDA device to {self.device}")
+        if gpus_per_replica is None and self.vllm_engine is not None:
+            num_replicas = getattr(self.vllm_engine, "num_replicas", 1)
+            gpus_per_replica = max(1, (self.world_size - 1) // num_replicas)
 
-            self._comm_group = stateless_init_process_group(
-                self.master_address,
-                self.master_port,
-                self.rank,
-                self.world_size,
-                device=self.device,
+        if self.rank == 0:
+            # Trainer side: start trainer NCCL group in background thread (it blocks
+            # waiting for workers to connect), then dispatch init to vLLM actors.
+            import threading
+
+            import ray
+
+            torchrl_logger.debug(
+                f"Initializing trainer NCCL group: rank=0, world_size={self.world_size}, device={self.device}"
             )
-            torchrl_logger.debug("Trainer collective group initialized successfully")
+            torch.cuda.set_device(self.device)
+
+            # Start trainer_init in a thread so it can wait for workers to connect
+            # while we dispatch the worker init calls concurrently.
+            trainer_result = [None]
+            trainer_error = [None]
+
+            def _init_trainer():
+                try:
+                    trainer_result[0] = NCCLWeightTransferEngine.trainer_init(
+                        {
+                            "master_address": self.master_address,
+                            "master_port": int(self.master_port),
+                            "world_size": self.world_size,
+                        }
+                    )
+                except Exception as e:
+                    trainer_error[0] = e
+
+            trainer_thread = threading.Thread(target=_init_trainer)
+            trainer_thread.start()
+
+            # Now dispatch init to each vLLM actor — workers will connect to
+            # the TCPStore that trainer_init is already listening on.
+            refs = []
+            if self.vllm_engine is not None:
+                torchrl_logger.debug("Dispatching vLLM worker weight transfer init...")
+                for i, actor in enumerate(self.vllm_engine.actors):
+                    rank_offset = 1 + i * gpus_per_replica
+                    init_info = NCCLWeightTransferInitInfo(
+                        master_address=self.master_address,
+                        master_port=int(self.master_port),
+                        rank_offset=rank_offset,
+                        world_size=self.world_size,
+                    )
+                    init_request = WeightTransferInitRequest(
+                        init_info=asdict(init_info)
+                    )
+                    refs.append(actor.init_weight_transfer_engine.remote(init_request))
+
+            # Wait for both sides to complete
+            if refs:
+                ray.get(refs)
+            trainer_thread.join()
+
+            if trainer_error[0] is not None:
+                raise trainer_error[0]
+            self._trainer_nccl_group = trainer_result[0]
+
+            self._initialized = True
+            torchrl_logger.debug("Trainer NCCL group initialized successfully")
         else:
-            # vLLM worker side - initialize through engine
+            # vLLM worker side - dispatch init_weight_transfer_engine to engine actors
             if self.vllm_engine is None:
                 raise ValueError("vllm_engine must be provided for worker ranks")
 
-            torchrl_logger.debug(
-                "Initializing vLLM worker collective group through engine"
-            )
-            # Call vLLM engine's init method - it returns futures for all workers
-            # Workers will start NCCL init in background threads and return immediately
-            refs = self.vllm_engine.init_weight_update_group(
-                master_address=self.master_address,
-                master_port=self.master_port,
-            )
-
-            # Wait for RPCs to complete - ensures workers have dispatched their NCCL init threads
             import ray
 
+            torchrl_logger.debug(
+                "Initializing vLLM worker weight transfer through engine"
+            )
+            refs = []
+            for i, actor in enumerate(self.vllm_engine.actors):
+                rank_offset = 1 + i * gpus_per_replica
+                init_info = NCCLWeightTransferInitInfo(
+                    master_address=self.master_address,
+                    master_port=int(self.master_port),
+                    rank_offset=rank_offset,
+                    world_size=self.world_size,
+                )
+                init_request = WeightTransferInitRequest(init_info=asdict(init_info))
+                refs.append(actor.init_weight_transfer_engine.remote(init_request))
             ray.get(refs)
-            torchrl_logger.debug(
-                f"All {len(refs)} vLLM workers have dispatched NCCL init RPCs"
-            )
-
-            # Small delay to ensure worker background threads have entered the NCCL collective
-            # This prevents a race where the trainer starts NCCL before workers are ready
-
-            time.sleep(0.2)
-
-            self._comm_group = True  # Mark as initialized
-            torchrl_logger.debug(
-                "vLLM workers should now be blocked in NCCL collective, ready for trainer"
-            )
+            self._initialized = True
+            torchrl_logger.debug("vLLM worker weight transfer initialized")
 
     def send_weights(self, model_id: str, weights: Any) -> None:
-        """Broadcast weights to all workers using NCCL.
-
-        This method follows AsyncVLLM's periodic-mono pattern:
-        For each weight: RPC → NCCL broadcast → Wait for RPC completion
-
-        This should only be called from rank 0 (trainer).
+        """Send weights to all workers using vLLM's native weight transfer API.
 
         Args:
             model_id: ID of the model (used for logging).
             weights: TensorDict or dict of weights to broadcast.
         """
-        # This code is a duplicate from AsyncVLLM
-        # We are waiting for vLLM server to accept tokens endpoints, at which point we will be
-        # able to remove all dependencies on Ray for vllm distributed features.
-        # This will allow a more natural integration with the sender/receiver API.
+        from dataclasses import asdict
 
         import ray
+
+        from vllm.distributed.weight_transfer.base import WeightTransferUpdateRequest
+        from vllm.distributed.weight_transfer.nccl_engine import (
+            NCCLTrainerSendWeightsArgs,
+            NCCLWeightTransferEngine,
+            NCCLWeightTransferUpdateInfo,
+        )
 
         if self.rank != 0:
             raise RuntimeError("send_weights should only be called from rank 0")
 
-        if self._comm_group is None:
+        if not self._initialized:
             raise RuntimeError(
                 "Communication group not initialized. Call init_all_workers_group first."
             )
@@ -268,7 +302,6 @@ class VLLMCollectiveTransport:
                 "vllm_engine must be provided to sender for RPC coordination"
             )
 
-        # Set CUDA device for this operation
         torch.cuda.set_device(self.device)
 
         # Convert to dict if needed
@@ -278,37 +311,58 @@ class VLLMCollectiveTransport:
             weights_dict = weights
 
         torchrl_logger.debug(
-            f"Broadcasting {len(weights_dict)} weights for model '{model_id}'"
+            f"Sending {len(weights_dict)} weights for model '{model_id}'"
         )
 
-        # Broadcast each weight using periodic-mono pattern (like AsyncVLLM)
-        for name, (dtype, shape) in self._model_metadata.items():
-            if name not in weights_dict:
-                raise ValueError(
-                    f"Weight '{name}' not found in weights. Weights keys: {list(weights_dict.keys())[:10]}..."
-                )
+        # Build weight metadata
+        weight_names = list(self._model_metadata.keys())
+        dtype_names = [
+            str(dtype).split(".")[-1] for dtype, _shape in self._model_metadata.values()
+        ]
+        shapes = [list(shape) for _dtype, shape in self._model_metadata.values()]
 
-            tensor = weights_dict[name].to(f"cuda:{self.device}")
-            dtype_name = str(dtype).split(".")[-1]  # "torch.float16" -> "float16"
+        update_info = NCCLWeightTransferUpdateInfo(
+            names=weight_names,
+            dtype_names=dtype_names,
+            shapes=shapes,
+            packed=True,
+        )
+        update_request = WeightTransferUpdateRequest(update_info=asdict(update_info))
 
-            # Step 1: Send RPC to workers for this weight
-            futures = self.vllm_engine.collective_rpc(
-                "update_weight", args=(name, dtype_name, tuple(shape))
-            )
+        # Put vLLM engine to sleep before weight transfer
+        sleep_refs = []
+        for actor in self.vllm_engine.actors:
+            sleep_refs.append(actor.sleep.remote(level=0))
+        ray.get(sleep_refs)
 
-            # Step 2: Immediately broadcast this weight
-            self._comm_group.broadcast(
-                tensor,
-                src=0,
-                stream=torch.cuda.current_stream(),
-            )
+        # Tell vLLM workers to start receiving
+        refs = []
+        for actor in self.vllm_engine.actors:
+            refs.append(actor.update_weights_native.remote(update_request))
 
-            # Step 3: Wait for workers to complete this weight
-            ray.get(futures)
-            del tensor
+        # Send weights from trainer side
+        def _weight_iter():
+            for name in weight_names:
+                tensor = weights_dict[name].to(f"cuda:{self.device}")
+                yield name, tensor
 
+        NCCLWeightTransferEngine.trainer_send_weights(
+            iterator=_weight_iter(),
+            trainer_args=NCCLTrainerSendWeightsArgs(
+                group=self._trainer_nccl_group, packed=True
+            ),
+        )
+
+        ray.get(refs)
         torch.cuda.synchronize()
-        torchrl_logger.debug(f"Broadcast complete for model '{model_id}'")
+
+        # Wake up vLLM engine after weight transfer
+        wake_refs = []
+        for actor in self.vllm_engine.actors:
+            wake_refs.append(actor.wake_up.remote(tags=["scheduling"]))
+        ray.get(wake_refs)
+
+        torchrl_logger.debug(f"Weight transfer complete for model '{model_id}'")
 
     def receive_weights(
         self,
@@ -320,25 +374,14 @@ class VLLMCollectiveTransport:
     ) -> Any | None:
         """Receive weights from broadcaster.
 
-        This should only be called from worker ranks (rank > 0).
-        This method is called by vLLM engine internally through collective operations.
-
-        Args:
-            timeout: Ignored (vLLM handles synchronization internally).
-            weights: Ignored.
-            model: Ignored.
-            strategy: Ignored.
-
         Returns:
-            None - vLLM handles weight application internally via collectives.
+            None - vLLM handles weight application internally via native API.
         """
-        # vLLM handles this through its own collective operations
-        # The weights are received and applied by the engine during broadcast
         return None
 
     def check_connection(self) -> bool:
         """Check if the communication group is initialized."""
-        return self._comm_group is not None
+        return self._initialized
 
 
 # ============================================================================
@@ -522,6 +565,7 @@ class VLLMWeightSender:
         self._model_ref = None
         self._transport = None
         self._model_metadata = None
+        self._trainer_nccl_group = None
 
     def register_model(self, model: Any) -> None:
         """Register the model to extract weights from."""
@@ -534,7 +578,7 @@ class VLLMWeightSender:
         model_metadata: dict[str, tuple[torch.dtype, torch.Size]],
         vllm_engine: Any | None = None,
     ):
-        """Initialize the collective communication group.
+        """Initialize the collective communication group using vLLM's native API.
 
         Args:
             model_metadata: Dict mapping param names to (dtype, shape) tuples.
@@ -556,10 +600,12 @@ class VLLMWeightSender:
         torchrl_logger.debug(
             f"Initializing transport from sender with world_size={world_size}"
         )
-        self._transport.init_all_workers_group(model_metadata)
+        self._transport.init_all_workers_group(
+            model_metadata, gpus_per_replica=self._scheme.gpus_per_replica
+        )
 
     def update_weights(self, weights: Any | None = None) -> None:
-        """Extract and broadcast weights to vLLM workers.
+        """Extract and send weights to vLLM workers using native weight transfer API.
 
         Args:
             weights: Optional weights to send. If None, extracts from registered model.
@@ -633,13 +679,12 @@ class VLLMWeightReceiver:
     def init_all_workers_group(
         self, model_metadata: dict[str, tuple[torch.dtype, torch.Size]]
     ):
-        """Initialize the collective communication group.
+        """Initialize the collective communication group using vLLM's native API.
 
         Args:
             model_metadata: Dict mapping param names to (dtype, shape) tuples.
         """
-        # For vLLM receiver, we use rank=1 as a placeholder
-        # The engine handles actual rank assignment internally for all workers
+        # For vLLM receiver, the engine handles init via init_weight_update_group()
         world_size = 1 + self._scheme.num_replicas * self._scheme.gpus_per_replica
         self._transport = VLLMCollectiveTransport(
             master_address=self._scheme.master_address,
@@ -652,7 +697,9 @@ class VLLMWeightReceiver:
         torchrl_logger.debug(
             f"Initializing transport from receiver with world_size={world_size}."
         )
-        self._transport.init_all_workers_group(model_metadata)
+        self._transport.init_all_workers_group(
+            model_metadata, gpus_per_replica=self._scheme.gpus_per_replica
+        )
 
     def apply_weights(self, weights: Any, inplace: bool = True) -> None:
         """Apply weights to vLLM engine.

--- a/torchrl/weight_update/weight_sync_schemes.py
+++ b/torchrl/weight_update/weight_sync_schemes.py
@@ -158,6 +158,10 @@ class WeightStrategy:
         elif self.extract_as == "state_dict":  # state_dict
             # Extract as state_dict
             if isinstance(source, nn.Module):
+                if hasattr(source, "merge_and_unload"):
+                    # LoRA model: merge weights to get clean parameter names
+                    # that match vLLM's expected format
+                    return source.merge_and_unload().state_dict()
                 return source.state_dict()
             elif isinstance(source, dict):
                 return source


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3579
* #3578
* #3577
* #3576
* #3575
* __->__ #3574
* #3573
* #3572
* #3571
* #3570
* #3569
* #3568

----

- Replace manual stateless_init_process_group + collective_rpc("update_weight")
  with vLLM's native WeightTransferConfig/NCCLWeightTransferEngine API
- Fix VLLM_USE_V1 env var removal (V1 always on in 0.17+)
- Fix NCCL weight sync deadlock by dispatching worker RPCs before trainer joins
- Fix LoRA weight extraction (merge_and_unload before state_dict)
- Fix weight transfer KeyError by using HF model directly (not TransformersWrapper)
- Fix prompt_logprobs length mismatch in _RequestOutput_tc for V1 engine
- Auto-propagate WANDB_API_KEY, HF_TOKEN, HF_HOME to Ray workers

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Pull-Request: https://github.com/pytorch/rl/pull/3556