### PR TITLE
Fix Ray actor GC: add lifetime="detached" to named actors

### DIFF
--- a/torchrl/envs/llm/transforms/dataloading.py
+++ b/torchrl/envs/llm/transforms/dataloading.py
@@ -195,7 +195,8 @@ class RayDataLoadingPrimer(RayTransform):
 
         if self._actor_name is not None:
             RemoteDataLoadingPrimer = RemoteDataLoadingPrimer.options(
-                name=self._actor_name
+                name=self._actor_name,
+                lifetime="detached",
             )
 
         # Create the shared actor, passing factory or dataloader as appropriate

--- a/torchrl/envs/llm/transforms/kl.py
+++ b/torchrl/envs/llm/transforms/kl.py
@@ -914,7 +914,9 @@ class RayRetrieveKL(RayTransform):
         )(RetrieveKL)
 
         if self._actor_name is not None:
-            RemoteRetrieveKL = RemoteRetrieveKL.options(name=self._actor_name)
+            RemoteRetrieveKL = RemoteRetrieveKL.options(
+                name=self._actor_name, lifetime="detached"
+            )
 
         # Determine how to create models on the remote actor
         gen_model_arg = self._gen_model


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3579
* #3578
* #3577
* #3576
* __->__ #3575
* #3574
* #3573
* #3572
* #3571
* #3570
* #3569
* #3568

Named Ray actors without lifetime="detached" are garbage-collected when
the owning process loses references. This caused the math_dataloader
actor to die mid-training with "all references to the actor were removed".

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>