### PR TITLE
Fix vLLM V1 prompt log-probs and response handling

### DIFF
--- a/sota-implementations/grpo/grpo_utils.py
+++ b/sota-implementations/grpo/grpo_utils.py
@@ -910,7 +910,19 @@ def log_training_metrics(
         batch_policy_version = batch["next", "policy_version"].view(-1).min()
         batch_policy_age = collector.policy_version - batch_policy_version
 
+        # Buffer-level staleness stats
+        buffer_policy_versions = (
+            rb_content.get(("next", "policy_version")).view(-1).float()
+        )
+        current_version = collector.policy_version
+        buffer_staleness = current_version - buffer_policy_versions
+        buffer_staleness_mean = float(buffer_staleness.mean())
+        buffer_staleness_max = float(buffer_staleness.max())
+
         metrics = {
+            "steps_collected": int(replay_buffer.write_count),
+            "staleness_mean (buffer)": buffer_staleness_mean,
+            "staleness_max (buffer)": buffer_staleness_max,
             "step_count from buffer": float(step_count),
             "reward from buffer": float(
                 torch.cat(rb_content.get(("next", "reward"), as_list=True)).mean()

--- a/test/llm/test_wrapper.py
+++ b/test/llm/test_wrapper.py
@@ -30,7 +30,11 @@ from torchrl.modules.llm.policies.common import (
     Tokens,
 )
 from torchrl.modules.llm.policies.transformers_wrapper import TransformersWrapper
-from torchrl.modules.llm.policies.vllm_wrapper import vLLMWrapper
+from torchrl.modules.llm.policies.vllm_wrapper import (
+    _completion_output_to_tc,
+    _RequestOutput_tc,
+    vLLMWrapper,
+)
 
 _has_transformers = importlib.util.find_spec("transformers") is not None
 _has_vllm = importlib.util.find_spec("vllm") is not None
@@ -3370,6 +3374,179 @@ class TestPreferTokens:
         assert initial_decoded in new_decoded or new_decoded.startswith(
             initial_decoded.strip()
         )
+
+
+@pytest.mark.skipif(not _has_vllm, reason="vllm not available")
+class TestRequestOutputConversion:
+    """Tests for _RequestOutput_tc, CompletionOutput_tc, and the conversion helpers."""
+
+    @pytest.fixture
+    def CompletionOutput_tc(self):
+        return vLLMWrapper.CompletionOutput_tc
+
+    @pytest.fixture
+    def mock_completion_output(self):
+        """Create a mock vLLM CompletionOutput with typical fields."""
+        from vllm.outputs import CompletionOutput
+
+        return CompletionOutput(
+            index=0,
+            text="Hello world",
+            token_ids=[1, 2, 3, 4],
+            cumulative_logprob=-1.5,
+            logprobs=None,
+            finish_reason="stop",
+            stop_reason=None,
+        )
+
+    def test_completion_output_to_tc_basic(
+        self, CompletionOutput_tc, mock_completion_output
+    ):
+        """Test basic conversion of CompletionOutput without logprobs."""
+        tc = _completion_output_to_tc(mock_completion_output, CompletionOutput_tc)
+        assert tc.index == 0
+        assert tc.text == "Hello world"
+        assert tc.cumulative_logprob == -1.5
+        assert tc.logprobs is None
+        assert tc.finish_reason == "stop"
+        assert tc.stop_reason is None
+
+    def test_completion_output_to_tc_with_logprobs(self, CompletionOutput_tc):
+        """Test conversion of CompletionOutput with logprobs present."""
+        from vllm.outputs import CompletionOutput
+
+        logprobs = [
+            {1: {"logprob": -0.1, "rank": 1}},
+            {2: {"logprob": -0.2, "rank": 1}},
+        ]
+        output = CompletionOutput(
+            index=0,
+            text="Hi",
+            token_ids=[1, 2],
+            cumulative_logprob=-0.3,
+            logprobs=logprobs,
+            finish_reason="stop",
+            stop_reason=None,
+        )
+        tc = _completion_output_to_tc(output, CompletionOutput_tc)
+        # logprobs should be passed through (not None) since they are non-empty
+        assert tc.logprobs is not None
+
+    def test_completion_output_to_tc_empty_logprobs_list(self, CompletionOutput_tc):
+        """Test conversion when vLLM returns logprobs=[] (vLLM 0.17 V1 behavior).
+
+        This is the case that was crashing with from_dataclass due to
+        tensordict's _convert_list_to_stack failing on empty lists.
+        """
+        from vllm.outputs import CompletionOutput
+
+        output = CompletionOutput(
+            index=0,
+            text="",
+            token_ids=[],
+            cumulative_logprob=None,
+            logprobs=[],  # vLLM 0.17 V1 returns [] instead of None
+            finish_reason=None,
+            stop_reason=None,
+        )
+        tc = _completion_output_to_tc(output, CompletionOutput_tc)
+        # Empty logprobs list should be converted to None (falsy)
+        assert tc.logprobs is None
+
+    def test_request_output_post_init(self, CompletionOutput_tc):
+        """Test that _RequestOutput_tc.__post_init__ correctly processes outputs."""
+        from vllm.outputs import CompletionOutput
+
+        outputs = [
+            CompletionOutput(
+                index=0,
+                text="Hello",
+                token_ids=[10, 20, 30],
+                cumulative_logprob=-1.0,
+                logprobs=None,
+                finish_reason="stop",
+                stop_reason=None,
+            ),
+        ]
+        tc = _RequestOutput_tc(
+            request_id="req-1",
+            prompt="Say hello",
+            prompt_token_ids=torch.tensor([1, 2, 3]),
+            prompt_logprobs=torch.tensor([]),
+            outputs=outputs,
+            finished="true",
+            metrics=None,
+            lora_request=None,
+            encoder_prompt=None,
+            encoder_prompt_token_ids=None,
+            num_cached_tokens=torch.tensor(0),
+        )
+        # After __post_init__, outputs should be a CompletionOutput_tc, not a raw list
+        assert not isinstance(tc.outputs, list)
+        assert tc.outputs.text == "Hello"
+        assert tc.outputs.token_ids.dtype == torch.long
+        torch.testing.assert_close(
+            tc.outputs.token_ids, torch.tensor([10, 20, 30], dtype=torch.long)
+        )
+
+    def test_request_output_post_init_empty_logprobs(self, CompletionOutput_tc):
+        """Test __post_init__ with empty logprobs list (vLLM 0.17 V1 edge case)."""
+        from vllm.outputs import CompletionOutput
+
+        outputs = [
+            CompletionOutput(
+                index=0,
+                text="",
+                token_ids=[],
+                cumulative_logprob=None,
+                logprobs=[],  # vLLM 0.17 V1 behavior
+                finish_reason=None,
+                stop_reason=None,
+            ),
+        ]
+        # This should not crash (previously crashed with from_dataclass)
+        tc = _RequestOutput_tc(
+            request_id="req-2",
+            prompt="Test",
+            prompt_token_ids=torch.tensor([1]),
+            prompt_logprobs=torch.tensor([]),
+            outputs=outputs,
+            finished="false",
+            metrics=None,
+            lora_request=None,
+            encoder_prompt=None,
+            encoder_prompt_token_ids=None,
+            num_cached_tokens=torch.tensor(0),
+        )
+        assert not isinstance(tc.outputs, list)
+
+    def test_from_request_output(self):
+        """Test from_request_output class method with a mock RequestOutput."""
+        from vllm.outputs import CompletionOutput, RequestOutput
+
+        completion = CompletionOutput(
+            index=0,
+            text="world",
+            token_ids=[10, 20],
+            cumulative_logprob=-0.5,
+            logprobs=None,
+            finish_reason="stop",
+            stop_reason=None,
+        )
+        request = RequestOutput(
+            request_id="req-3",
+            prompt="Hello",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[completion],
+            finished=True,
+        )
+        result = _RequestOutput_tc.from_request_output([request])
+        assert result.request_id == "req-3"
+        assert result.prompt == "Hello"
+        torch.testing.assert_close(result.prompt_token_ids, torch.tensor([1, 2, 3]))
+        # prompt_logprobs=None should become empty tensor
+        assert result.prompt_logprobs.numel() == 0
 
 
 if __name__ == "__main__":

--- a/torchrl/modules/llm/policies/common.py
+++ b/torchrl/modules/llm/policies/common.py
@@ -1708,9 +1708,12 @@ def _extract_responses_from_full_histories(
         prompt_histories.unbind(0), full_histories.unbind(0)
     ):
         if h_full.shape[0] <= h_prompt.shape[0]:
-            raise RuntimeError(
-                f"Full history is shorter than prompt history: {h_full.shape} <= {h_prompt.shape}"
+            # Empty response: model generated 0 tokens. Create a minimal
+            # response history with an empty assistant message.
+            response_histories.append(
+                History(role="assistant", content="", batch_size=(1,))
             )
+            continue
         # Note: there can be more than one response, so the response has the same number of dims as prompt
         response_histories.append(h_full[h_prompt.shape[0] :])
 

--- a/torchrl/modules/llm/policies/vllm_wrapper.py
+++ b/torchrl/modules/llm/policies/vllm_wrapper.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import collections
-import dataclasses
 import importlib.util
 import threading
 import warnings
@@ -1623,10 +1622,12 @@ class vLLMWrapper(LLMWrapperBase):
 
     def _cat_tensors(
         self,
-        tokens: list[torch.Tensor] | torch.Tensor,
-        response_tokens: list[torch.Tensor] | torch.Tensor,
-    ) -> list[torch.Tensor] | torch.Tensor:
+        tokens: list[torch.Tensor] | torch.Tensor | None,
+        response_tokens: list[torch.Tensor] | torch.Tensor | None,
+    ) -> list[torch.Tensor] | torch.Tensor | None:
         """Concatenate tokens and response tokens."""
+        if tokens is None or response_tokens is None:
+            return None
         if isinstance(tokens, list) or isinstance(response_tokens, list):
             return [
                 self._cat_tensors(t, t_)
@@ -1803,27 +1804,83 @@ class vLLMWrapper(LLMWrapperBase):
             if self.pad_output:
                 self._check_padded(log_probs_padded)
                 if self.num_samples is None:
-                    self._check_padded(prompt_logprobs_padded)
-                    log_probs_obj.prompt = prompt_logprobs_padded
+                    # Only set prompt log-probs if they actually contain
+                    # data (vLLM V1 may produce all-zero padded tensors
+                    # from empty per-request prompt_logprobs).
+                    if (
+                        prompt_logprobs_padded is not None
+                        and prompt_logprobs_padded.any()
+                    ):
+                        self._check_padded(prompt_logprobs_padded)
+                        log_probs_obj.prompt = prompt_logprobs_padded
             else:
                 self._check_not_padded(log_probs_list)
-                if self.num_samples is None:
-                    self._check_not_padded(prompt_logprobs_list)
-                    log_probs_obj.prompt = prompt_logprobs_list
+                if self.num_samples is None and prompt_logprobs_list is not None:
+                    # Check that prompt_logprobs actually contain data.
+                    # vLLM V1 may return prompt_logprobs=None per request,
+                    # which from_request_output converts to empty tensors.
+                    # A list of empty tensors is not useful as prompt
+                    # log-probs and must be treated as absent so the
+                    # zero-fill path below creates proper placeholders.
+                    _has_prompt_lp = any(
+                        t.numel() > 0
+                        for t in (
+                            prompt_logprobs_list
+                            if isinstance(prompt_logprobs_list, list)
+                            else [prompt_logprobs_list]
+                        )
+                    )
+                    if _has_prompt_lp:
+                        self._check_not_padded(prompt_logprobs_list)
+                        log_probs_obj.prompt = prompt_logprobs_list
             with log_probs_obj.view(-1) as log_probs_obj_flat:
                 log_probs_obj_flat.response = (
                     log_probs_padded if self.pad_output else log_probs_list
                 )
                 if self.num_samples is None:
-                    if self.pad_output:
+                    prompt_lp = (
+                        log_probs_obj_flat.prompt
+                        if self.pad_output
+                        else log_probs_obj_flat.get("prompt", as_list=True)
+                    )
+                    response_lp = (
+                        log_probs_padded if self.pad_output else log_probs_list
+                    )
+                    if prompt_lp is None and response_lp is not None:
+                        # Prompt logprobs not available (vLLM V1 may not
+                        # return them). Create zero-filled placeholders
+                        # matching prompt token shapes so that "full" can
+                        # be constructed. The loss function masks prompt
+                        # positions anyway.
+                        tokens_prompt = out.get(
+                            (self.tokens_key, "prompt"), as_list=True
+                        )
+                        if tokens_prompt is None:
+                            tokens_prompt = (
+                                tokens_prompt_padded
+                                if self.pad_output
+                                else tokens_prompt_unpadded
+                            )
+                        if tokens_prompt is not None:
+                            if isinstance(tokens_prompt, list):
+                                prompt_lp = [
+                                    torch.zeros_like(t, dtype=response_lp[0].dtype)
+                                    for t in tokens_prompt
+                                ]
+                            else:
+                                prompt_lp = torch.zeros(
+                                    tokens_prompt.shape,
+                                    dtype=response_lp.dtype,
+                                    device=response_lp.device,
+                                )
+                    if prompt_lp is not None and response_lp is not None:
                         log_probs_obj_flat.full = self._cat_tensors(
-                            log_probs_obj_flat.prompt, log_probs_padded
+                            prompt_lp, response_lp
                         )
                     else:
-                        log_probs_obj_flat.full = self._cat_tensors(
-                            log_probs_obj_flat.get("prompt", as_list=True),
-                            log_probs_list,
-                        )
+                        # Last resort: use response as full to avoid
+                        # missing key downstream
+                        log_probs_obj_flat.full = response_lp
                 else:
                     log_probs_obj_flat.full = None
             log_probs_obj.padded = MetaData(self.pad_output)
@@ -2181,6 +2238,56 @@ class vLLMWrapper(LLMWrapperBase):
         )
 
 
+def _extract_logprob(entry):
+    """Extract logprob value from a vLLM logprob entry (dict or Logprob dataclass)."""
+    if isinstance(entry, dict):
+        lp = entry.get("logprob", 0.0)
+    else:
+        lp = getattr(entry, "logprob", 0.0)
+    return lp if lp is not None else 0.0
+
+
+def _build_prompt_logprobs(request):
+    """Build prompt logprobs tensor from a vLLM RequestOutput.
+
+    Handles prefix caching: when vLLM caches prompt tokens, it returns
+    fewer prompt_logprobs than prompt_token_ids.  We zero-pad the prefix
+    so the returned tensor always matches len(prompt_token_ids).
+    """
+    if request.prompt_logprobs is None:
+        return torch.tensor([])
+    values = [
+        _extract_logprob(v[int(tid)]) if v is not None else 0.0
+        for v, tid in zip(request.prompt_logprobs, request.prompt_token_ids)
+    ]
+    num_missing = len(request.prompt_token_ids) - len(values)
+    if num_missing > 0:
+        values = [0.0] * num_missing + values
+    return torch.tensor(values)
+
+
+def _completion_output_to_tc(output, CompletionOutput_tc):
+    """Convert a vLLM CompletionOutput dataclass to CompletionOutput_tc.
+
+    This avoids ``from_dataclass`` / ``dataclasses.asdict`` which recursively
+    converts all fields to plain Python types and chokes on edge-cases such as
+    empty lists that tensordict cannot stack.
+
+    Dynamically forwards all fields from the dataclass to handle new fields
+    added in newer vLLM versions (e.g. ``routed_experts``).
+    """
+    import dataclasses as _dc
+
+    kwargs = {}
+    for f in _dc.fields(output):
+        val = getattr(output, f.name, None)
+        # Special handling: falsy logprobs → None so tensordict can stack
+        if f.name == "logprobs":
+            val = val if val else None
+        kwargs[f.name] = val
+    return CompletionOutput_tc(**kwargs)
+
+
 class _RequestOutput_tc(TensorClass["nocast"]):
     """TensorClass wrapper for vLLM RequestOutput."""
 
@@ -2206,28 +2313,31 @@ class _RequestOutput_tc(TensorClass["nocast"]):
                 if isinstance(token_ids, torch.Tensor):
                     token_ids = token_ids.tolist()
                 for v, tid in zip(output.logprobs, token_ids):
-                    t.append(
-                        v[tid]["logprob"] if v[tid].get("logprob") is not None else 0.0
-                    )
+                    t.append(_extract_logprob(v[tid]))
                 return torch.tensor(t)
 
-            if output.logprobs:
+            logprobs = output.logprobs
+            if isinstance(logprobs, torch.Tensor):
+                has_logprobs = logprobs.numel() > 0
+            elif isinstance(logprobs, list):
+                has_logprobs = len(logprobs) > 0
+            else:
+                has_logprobs = logprobs is not None
+            if has_logprobs:
                 output.logprobs = get_logprob(output)
-            output.token_ids = torch.as_tensor(output.token_ids)
+            else:
+                output.logprobs = torch.tensor([], dtype=torch.float)
+            output.token_ids = (
+                torch.as_tensor(output.token_ids).long()
+                if output.token_ids is not None
+                else torch.tensor([], dtype=torch.long)
+            )
             return output
 
         if isinstance(self.outputs, list):
-            outputs = self.outputs
-            # Pre-process: replace empty list fields with None to avoid
-            # tensordict conversion errors (empty lists can't be stacked)
-            for output in outputs:
-                for field in dataclasses.fields(output):
-                    val = getattr(output, field.name)
-                    if isinstance(val, list) and len(val) == 0:
-                        object.__setattr__(output, field.name, None)
             outputs = [
-                postproc(from_dataclass(output, dest_cls=CompletionOutput_tc))
-                for output in outputs
+                postproc(_completion_output_to_tc(output, CompletionOutput_tc))
+                for output in self.outputs
             ]
             if len(outputs) == 1:
                 self.outputs = outputs[0]
@@ -2257,18 +2367,7 @@ class _RequestOutput_tc(TensorClass["nocast"]):
                         request_id=request.request_id,
                         prompt=request.prompt,
                         prompt_token_ids=torch.as_tensor(request.prompt_token_ids),
-                        prompt_logprobs=torch.tensor(
-                            [
-                                v[int(tid)].logprob if v is not None else 0.0
-                                # Use zip (not _zip_strict) because vLLM V1 may return
-                                # fewer prompt_logprobs than prompt_token_ids (cached tokens)
-                                for v, tid in zip(
-                                    request.prompt_logprobs, request.prompt_token_ids
-                                )
-                            ]
-                        )
-                        if request.prompt_logprobs is not None
-                        else torch.tensor([]),
+                        prompt_logprobs=_build_prompt_logprobs(request),
                         outputs=request.outputs,
                         finished=request.finished,
                         metrics=request.metrics,
@@ -2288,18 +2387,7 @@ class _RequestOutput_tc(TensorClass["nocast"]):
                     request_id=request.request_id,
                     prompt=request.prompt,
                     prompt_token_ids=torch.as_tensor(request.prompt_token_ids),
-                    prompt_logprobs=torch.tensor(
-                        [
-                            v[int(tid)].logprob if v is not None else 0.0
-                            # Use zip (not _zip_strict) because vLLM V1 may return
-                            # fewer prompt_logprobs than prompt_token_ids (cached tokens)
-                            for v, tid in zip(
-                                request.prompt_logprobs, request.prompt_token_ids
-                            )
-                        ]
-                    )
-                    if request.prompt_logprobs is not None
-                    else torch.tensor([]),
+                    prompt_logprobs=_build_prompt_logprobs(request),
                     outputs=request.outputs,
                     finished=request.finished,
                     metrics=request.metrics,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3579
* #3578
* #3577
* __->__ #3576
* #3575
* #3574
* #3573
* #3572
* #3571
* #3570
* #3569
* #3568

----

- Handle None/empty prompt_logprobs from vLLM V1 by creating zero-filled tensors
- Fix _cat_tensors to handle None tokens/response_tokens defensively
- Fix token_ids float dtype: force .long() after torch.as_tensor
- Handle empty model responses gracefully instead of crashing
- Fix Boolean value of empty tensor in logprobs check
- Replace from_dataclass with explicit construction in _RequestOutput_tc
- Fix CompletionOutput_tc construction for newer vLLM versions
- Fix vLLM Logprob object compatibility in CompletionOutput processing
- Fix prompt logprobs truncation from vLLM prefix caching

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>