### PR TITLE
Fix autocast dtype, weight sync scheduling, and inf/NaN protection

### DIFF
--- a/sota-implementations/grpo/grpo-async.py
+++ b/sota-implementations/grpo/grpo-async.py
@@ -187,6 +187,7 @@ def train(
     pbar = tqdm.tqdm(total=total_steps)
     grad_norm = 0.0  # Initialize grad_norm
     data_read_count = 0
+    optim_steps = 0  # Track optimizer steps for weight update scheduling
     start_time = time.time()
 
     for step in range(total_steps):
@@ -214,7 +215,14 @@ def train(
             data_read_count += batch.numel()
 
         with timeit("forward_pass"):
-            with autocast("cuda", enabled=cfg.train.mixed_precision):
+            # Use the model's dtype for autocast to avoid bf16→fp16 downcast
+            # (fp16 range ±65504 can overflow with bf16 activations ±3.4e38)
+            autocast_dtype = getattr(torch, cfg.train_model.torch_dtype)
+            with autocast(
+                "cuda",
+                enabled=cfg.train.mixed_precision,
+                dtype=autocast_dtype,
+            ):
                 loss = loss_fn(batch)
                 loss_val = (
                     loss.mean(reduce=True) / cfg.train.gradient_accumulation_steps
@@ -250,6 +258,26 @@ def train(
                     optimizer.step()
                 optimizer.zero_grad(set_to_none=True)
 
+            optim_steps += 1
+
+            # Weight sync is tied to optimizer steps, not gradient steps.
+            # This ensures the training model diverges from the inference model
+            # between syncs, which is essential for meaningful importance sampling
+            # in GRPO (otherwise ESS stays at 1.0 and GRPO degenerates to REINFORCE).
+            if optim_steps % cfg.train.weight_update_frequency == 0:
+                with timeit("update_policy_weights"):
+                    torchrl_logger.info(
+                        f"Updating policy weights (optim step {optim_steps})..."
+                    )
+                    sender.update_weights()
+                    gc.collect()
+
+                timeit.print(prefix="timeit")
+                wandb_logger.log_metrics(
+                    {f"timeit/{key}": val for key, val in timeit.todict().items()}
+                )
+                timeit.reset()
+
         if (step % cfg.train.logging_frequency) == 0:
             log_training_metrics(
                 wandb_logger=wandb_logger,
@@ -265,36 +293,6 @@ def train(
                 history_str=history_str,
                 use_kl_to_ref=cfg.train.use_kl_to_ref,
             )
-
-        if step % cfg.train.weight_update_frequency == 0:
-            with timeit("update_policy_weights"):
-                torchrl_logger.info("Updating policy weights...")
-                sender.update_weights()
-                # TODO: do we need this? Does it interfere with other processes?
-                # torch.cuda.empty_cache()
-                gc.collect()
-
-        # Checkpointing disabled to prevent disk space issues
-        # if (step + 1) % cfg.train.checkpoint_frequency == 0:
-        #     with timeit("save_checkpoint"):
-        #         torchrl_logger.info(
-        #             f"Saving checkpoint {(step+1) // cfg.train.checkpoint_frequency}..."
-        #         )
-        #         checkpoint = {
-        #             "step": step,
-        #             "model_state_dict": policy_training.model.state_dict(),
-        #             "optimizer_state_dict": optimizer.state_dict(),
-        #             "scaler_state_dict": scaler.state_dict(),
-        #             "config": dict(cfg),
-        #         }
-        #         torch.save(checkpoint, checkpoint_dir / f"checkpoint_{step:04d}.pt")
-
-        if step % cfg.train.weight_update_frequency == 0:
-            timeit.print(prefix="timeit")
-            wandb_logger.log_metrics(
-                {f"timeit/{key}": val for key, val in timeit.todict().items()}
-            )
-            timeit.reset()
 
         del loss_val
         # TODO: do we need this? Does it interfere with other processes?

--- a/sota-implementations/grpo/grpo-sync.py
+++ b/sota-implementations/grpo/grpo-sync.py
@@ -127,6 +127,10 @@ def train(
     metadata = get_model_metadata(policy_training.model)
     sender.init_all_workers_group(metadata, vllm_engine=inference_engine)
 
+    # Register the collector with the sender so update_weights() increments
+    # the policy version (needed for policy_version tracking in logged metrics).
+    sender.register_collector(collector)
+
     # First weight update
     with timeit("update_policy_weights"):
         sender.update_weights()
@@ -202,7 +206,13 @@ def train(
                 data_read_count += batch.numel()
 
                 with timeit("forward_pass"):
-                    with autocast("cuda", enabled=cfg.train.mixed_precision):
+                    # Use the model's dtype for autocast to avoid bf16→fp16 downcast
+                    autocast_dtype = getattr(torch, cfg.train_model.torch_dtype)
+                    with autocast(
+                        "cuda",
+                        enabled=cfg.train.mixed_precision,
+                        dtype=autocast_dtype,
+                    ):
                         loss = loss_fn(batch)
                         loss_val = (
                             loss.mean(reduce=True)
@@ -357,13 +367,6 @@ def main(cfg):
     torchrl_logger.info(f"Inference policy: {inference_policy}")
 
     torchrl_logger.info(f"Starting replay buffer with {replay_buffer_config=}")
-    if cfg.train.buffer_size is not None and (
-        cfg.train.buffer_size != cfg.train.dialog_turns_per_batch
-    ):
-        raise ValueError(
-            "buffer_size must be equal to dialog_turns_per_batch in sync settings."
-        )
-
     if cfg.train.optim_batch_size % cfg.train.gradient_accumulation_steps != 0:
         raise ValueError(
             "optim_batch_size must be divisible by gradient_accumulation_steps"

--- a/torchrl/modules/distributions/discrete.py
+++ b/torchrl/modules/distributions/discrete.py
@@ -805,7 +805,17 @@ class LLMMaskedCategorical(D.Distribution):
     def _sampling_dist(self):
         """Get masked distribution for sampling operations."""
         if self._masked_dist is None:
-            self._masked_dist = D.Categorical(logits=self._sampling_logits)
+            logits = self._sampling_logits
+            # Replace inf/NaN to prevent softmax → multinomial crashes
+            if not logits.isfinite().all():
+                finfo = torch.finfo(logits.dtype)
+                logits = torch.nan_to_num(
+                    logits,
+                    nan=0.0,
+                    posinf=finfo.max / 2,
+                    neginf=finfo.min / 2,
+                )
+            self._masked_dist = D.Categorical(logits=logits)
         return self._masked_dist
 
     def log_prob(self, value: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3579
* #3578
* #3577
* #3576
* #3575
* #3574
* #3573
* #3572
* #3571
* #3570
* #3569
* #3568

----

- Use model's dtype (bfloat16) for autocast instead of defaulting to
  float16, which can overflow bf16 activations (range ±3.4e38 vs ±65504).
- Tie weight_update_frequency to optimizer steps (not gradient steps)
  so GRPO importance sampling is meaningful (prevents ESS=1.0 degeneration).
- Add inf/NaN protection in LLMMaskedCategorical to prevent CUDA crashes
  when logits become non-finite during sampling.
- Register collector with sender in sync script for policy version tracking.
- Remove overly strict buffer_size validation in sync mode.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>