### PR TITLE
[LLM] Remove placement-group xfails and fix vLLM tokenizer compat

### DIFF
--- a/test/llm/test_llm_envs.py
+++ b/test/llm/test_llm_envs.py
@@ -1357,11 +1357,6 @@ class TestChatEnvIntegration:
         except Exception as e:
             pytest.skip(f"Failed to load vLLM model: {e}")
 
-    @pytest.mark.xfail(
-        reason="vLLM 0.14+ Ray async backend has KeyError: 'bundles' issue during "
-        "engine initialization. See PR #3360 for context.",
-        strict=False,
-    )
     @pytest.mark.skipif(not _has_vllm, reason="vllm not available")
     @pytest.mark.skipif(not _has_datasets, reason="datasets not available")
     @pytest.mark.parametrize("pad_output", [True, False], ids=["padded", "unpadded"])
@@ -1474,11 +1469,6 @@ class TestChatEnvIntegration:
         r = policy(r_)
         r, r_ = env.step_and_maybe_reset(r)
 
-    @pytest.mark.xfail(
-        reason="IFEvalEnv tests with vLLM fail due to Ray placement group timeout. "
-        "See LLM_TEST_ISSUES.md for details.",
-        strict=False,
-    )
     @pytest.mark.parametrize("pad_output", [True, False], ids=["padded", "unpadded"])
     @pytest.mark.parametrize("ref_input_mode", ["tokens"], ids=["tokens"])
     @pytest.mark.parametrize(
@@ -1541,11 +1531,6 @@ class TestChatEnvIntegration:
                 assert r.shape[1] > 1
                 assert r.shape[2] == 1
 
-    @pytest.mark.xfail(
-        reason="IFEvalEnv tests with vLLM fail due to Ray placement group timeout. "
-        "See LLM_TEST_ISSUES.md for details.",
-        strict=False,
-    )
     @pytest.mark.parametrize(
         "env_class", ["GSM8KEnv", "IFEvalEnv"], ids=["gsm8k", "ifeval"]
     )

--- a/test/llm/test_llm_updaters.py
+++ b/test/llm/test_llm_updaters.py
@@ -228,11 +228,6 @@ class BaseVLLMUpdaterTest(ABC):
         logger.info("✓ Error handling tests passed")
 
 
-@pytest.mark.xfail(
-    reason="AsyncVLLM tests fail due to Ray placement group timeout. "
-    "ray.get(pg.ready(), timeout=180) times out. See LLM_TEST_ISSUES.md for details.",
-    strict=False,
-)
 @pytest.mark.skipif(not _has_ray, reason="missing ray dependencies")
 class TestVLLMUpdaterV2WithAsyncVLLM(BaseVLLMUpdaterTest):
     """Test vLLMUpdaterV2 with AsyncVLLM engines.
@@ -609,11 +604,6 @@ class TestWeightSyncVLLMNCCL:
 
 
 @pytest.mark.gpu
-@pytest.mark.xfail(
-    reason="AsyncVLLM tests fail due to Ray placement group timeout. "
-    "See LLM_TEST_ISSUES.md for details.",
-    strict=False,
-)
 @pytest.mark.skipif(not _has_ray, reason="missing ray dependencies")
 @pytest.mark.skipif(not _has_vllm, reason="missing vllm dependencies")
 @pytest.mark.skipif(not _has_transformers, reason="missing transformers dependencies")

--- a/test/llm/test_vllm.py
+++ b/test/llm/test_vllm.py
@@ -31,11 +31,6 @@ def sampling_params():
     )  # Use greedy decoding for reproducibility
 
 
-@pytest.mark.xfail(
-    reason="AsyncVLLM tests fail due to Ray placement group timeout. "
-    "ray.get(pg.ready(), timeout=180) times out. See LLM_TEST_ISSUES.md for details.",
-    strict=False,
-)
 class TestAsyncVLLMIntegration:
     """Integration tests for AsyncVLLM with real models."""
 
@@ -166,8 +161,8 @@ class TestAsyncVLLMIntegration:
                     self.policy = policy_ref
                     # The vLLMUpdater expects the collector to have a _collector attribute
                     # for Ray-based collectors, or a policy.model for local collectors
-                    # We'll use the local collector pattern and patch policy.model to be the Ray actor
-                    self.policy.model = vllm_service.actors[0]
+                    # Use object.__setattr__ to bypass nn.Module type checks
+                    object.__setattr__(self.policy, "model", vllm_service.actors[0])
 
                 def increment_version(self):
                     pass

--- a/test/llm/test_wrapper.py
+++ b/test/llm/test_wrapper.py
@@ -2102,11 +2102,6 @@ class TestLogProbsComparison:
             vllm_lp_result, tf_lp_result, atol=1e-1, rtol=1e-1, intersection=True
         )
 
-    @pytest.mark.xfail(
-        reason="AsyncVLLM tests fail due to Ray placement group timeout. "
-        "See LLM_TEST_ISSUES.md for details.",
-        strict=False,
-    )
     @pytest.mark.gpu
     @pytest.mark.skipif(not _has_vllm, reason="vllm not available")
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/torchrl/modules/llm/backends/vllm/vllm_async.py
+++ b/torchrl/modules/llm/backends/vllm/vllm_async.py
@@ -13,6 +13,7 @@ approach used in the legacy vLLM backend.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import os
 import random
 import time
@@ -304,7 +305,10 @@ class _AsyncLLMEngine:
 
     async def get_tokenizer(self):
         """Get the tokenizer from the engine."""
-        return await self.engine.get_tokenizer()
+        result = self.engine.get_tokenizer()
+        if inspect.isawaitable(result):
+            return await result
+        return result
 
     async def collective_rpc_v1(
         self,


### PR DESCRIPTION
## Summary
- Remove 7 `@pytest.mark.xfail` markers from vLLM/AsyncVLLM tests that were failing due to Ray placement group timeouts — placement groups were removed in #3585
- Fix `_AsyncLLMEngine.get_tokenizer()` to handle both sync (vLLM 0.17+) and async returns via `inspect.isawaitable`
- Fix `test_vllm.py` `MockCollector` to use `object.__setattr__` to bypass `nn.Module` type checks when assigning a Ray `ActorHandle`

**Xfails removed:**
| File | Reason |
|------|--------|
| `test_llm_updaters.py` (x2) | Ray placement group timeout |
| `test_vllm.py` (x1) | Ray placement group timeout |
| `test_wrapper.py` (x1) | Ray placement group timeout |
| `test_llm_envs.py` (x3) | Ray placement group timeout / KeyError: 'bundles' |

## Test plan
- [ ] `unittests-vllm` CI job passes with all 7 previously-xfailed tests now running
- [ ] `unittests-sglang` CI job unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)