### PR TITLE
[Feature] Add Evaluator class for sync/async evaluation

### DIFF
--- a/docs/source/reference/collectors.rst
+++ b/docs/source/reference/collectors.rst
@@ -14,6 +14,7 @@ TorchRL provides several collector implementations optimized for different scena
 - :class:`Collector`: Single-process collection on the training worker
 - :class:`AsyncBatchedCollector`: Async environments + auto-batching inference server (see :class:`AsyncBatchedCollector`)
 - :class:`MultiCollector`: Parallel collection across multiple workers (see below)
+- :class:`Evaluator`: Sync or async evaluation during training (see :ref:`evaluation <collectors_eval>`)
 - **Distributed collectors**: For multi-node setups using Ray, RPC, or distributed backends (see :class:`DistributedCollector` / :class:`RPCCollector`)
 
 MultiCollector API
@@ -109,6 +110,7 @@ Documentation Sections
 
    collectors_basics
    collectors_single
+   collectors_eval
    collectors_distributed
    collectors_weightsync
    collectors_replay

--- a/docs/source/reference/collectors_eval.rst
+++ b/docs/source/reference/collectors_eval.rst
@@ -1,0 +1,156 @@
+.. currentmodule:: torchrl.collectors
+
+.. _collectors_eval:
+
+Evaluation
+==========
+
+The :class:`Evaluator` class provides a unified interface for running evaluation
+rollouts during RL training, either **synchronously** (blocking) or
+**asynchronously** (fire-and-forget in a background thread or Ray actor).
+
+Why use an Evaluator?
+---------------------
+
+In most RL training loops, evaluation is done inline and **blocks** the training
+loop while rollouts are collected.  For environments with expensive step
+functions (robotics simulators, LLM generation, etc.) this can waste
+significant training time.  The :class:`Evaluator` decouples evaluation from
+training by running rollouts in the background, logging results automatically,
+and letting you poll for metrics at your convenience.
+
+Quick example
+-------------
+
+.. code-block:: python
+
+    from torchrl.collectors import Evaluator
+    from torchrl.envs import GymEnv
+    from tensordict.nn import TensorDictModule
+    import torch.nn as nn
+
+    def make_eval_env():
+        return GymEnv("HalfCheetah-v4")
+
+    eval_policy = TensorDictModule(
+        nn.Linear(17, 6), in_keys=["observation"], out_keys=["action"],
+    )
+
+    evaluator = Evaluator(
+        make_eval_env,
+        eval_policy,
+        max_steps=1000,
+        logger=my_logger,       # auto-logs eval/reward, eval/episode_length
+    )
+
+    # --- Inside training loop ---
+    for data in collector:
+        train(data)
+
+        if should_eval:
+            # Non-blocking: kick off eval and move on
+            evaluator.trigger_eval(weights=train_policy, step=collected_frames)
+
+        # Optionally check for results
+        result = evaluator.poll()
+        if result is not None:
+            print(result)  # {"eval/reward": ..., "eval/episode_length": ...}
+
+    evaluator.shutdown()
+
+Synchronous usage
+-----------------
+
+If you prefer blocking evaluation (e.g. for final evaluation or simple
+scripts), use :meth:`~Evaluator.evaluate`:
+
+.. code-block:: python
+
+    metrics = evaluator.evaluate(weights=train_policy, step=step)
+    # metrics == {"eval/reward": -123.4, "eval/episode_length": 1000}
+
+Asynchronous usage
+------------------
+
+For non-blocking evaluation during training:
+
+.. code-block:: python
+
+    # Fire-and-forget: starts eval in a background thread
+    evaluator.trigger_eval(weights=train_policy, step=step)
+
+    # ... continue training ...
+
+    # Check if results are ready (non-blocking)
+    result = evaluator.poll()          # returns None if still running
+
+    # Or block until done
+    result = evaluator.wait(timeout=60)
+
+**Fire-and-forget semantics**: calling :meth:`~Evaluator.trigger_eval` while a
+previous evaluation is still running discards the in-progress result and starts
+the new one.
+
+Backends
+--------
+
+The :class:`Evaluator` supports two backends selected via the ``backend``
+parameter:
+
+**Thread backend** (default, ``backend="thread"``):
+
+- Runs ``env.rollout()`` in a daemon thread within the same process.
+- No extra dependencies required.
+- Best for most single-node training setups.
+
+**Ray backend** (``backend="ray"``):
+
+- Wraps :class:`~torchrl.collectors.distributed.RayEvalWorker` under the same
+  API.
+- Runs evaluation in a separate Ray actor process with its own GPU.
+- Required when the eval environment needs process-level initialisation
+  (e.g. Isaac Lab's ``AppLauncher``).
+
+.. code-block:: python
+
+    evaluator = Evaluator(
+        make_eval_env,
+        policy_factory=make_eval_policy,
+        max_steps=1000,
+        backend="ray",
+        init_fn=my_process_init,
+        num_gpus=1,
+    )
+
+Custom metrics and callbacks
+----------------------------
+
+Pass a ``metrics_fn`` to extract custom metrics from rollout data:
+
+.. code-block:: python
+
+    def my_metrics(rollout_td):
+        return {
+            "success_rate": (rollout_td["next", "success"].any(-1).float().mean().item()),
+        }
+
+    evaluator = Evaluator(env, policy, max_steps=1000, metrics_fn=my_metrics)
+
+Or use a ``callback`` for side effects (e.g. saving checkpoints on good evals):
+
+.. code-block:: python
+
+    def on_eval(metrics, step):
+        if metrics["eval/reward"] > best_reward:
+            save_checkpoint(step)
+
+    evaluator = Evaluator(env, policy, max_steps=1000, callback=on_eval)
+
+API Reference
+-------------
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template.rst
+
+    Evaluator

--- a/docs/source/reference/collectors_eval.rst
+++ b/docs/source/reference/collectors_eval.rst
@@ -91,6 +91,59 @@ For non-blocking evaluation during training:
 previous evaluation is still running discards the in-progress result and starts
 the new one.
 
+Device placement and compilation
+--------------------------------
+
+For best performance, place the eval policy on a **dedicated device** and
+optionally ``torch.compile`` both the env and policy independently of the
+training pipeline:
+
+.. code-block:: python
+
+    import torch
+
+    eval_device = torch.device("cuda:1")  # training on cuda:0
+
+    eval_policy = make_policy().to(eval_device)
+    eval_env = make_env(device=eval_device)
+
+    # Optional: compile for extra speed
+    eval_policy = torch.compile(eval_policy)
+
+    evaluator = Evaluator(
+        eval_env,
+        eval_policy,
+        max_steps=1000,
+        device=eval_device,
+        logger=logger,
+    )
+
+The ``device`` parameter controls where policy weights are moved before
+each rollout.  When passing weights from the training policy (which may
+live on a different device), the Evaluator automatically moves them to
+the eval device.
+
+Overlap policy (backpressure)
+-----------------------------
+
+Calling :meth:`~Evaluator.trigger_eval` while a previous evaluation is
+still running **drops** the in-progress result (fire-and-forget).  The new
+evaluation starts as soon as the background thread finishes the current
+``env.rollout()`` call.  There is no queue, no coalescing, and no error.
+Only the most recently triggered evaluation produces a result.
+
+This design means you can safely call ``trigger_eval`` on every training
+iteration without worrying about a backlog of pending evaluations.
+
+Thread safety of logging
+------------------------
+
+All logger writes (scalar metrics and video encoding) happen on the
+**caller thread** inside :meth:`~Evaluator.poll`, :meth:`~Evaluator.wait`,
+or :meth:`~Evaluator.evaluate`.  The background thread only computes plain
+metrics; it never touches the logger.  If you share a logger between
+training and evaluation, pass the same ``logger_lock`` to serialise writes.
+
 Backends
 --------
 

--- a/test/test_evaluator.py
+++ b/test/test_evaluator.py
@@ -1,0 +1,273 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+from torch import nn
+from torchrl.collectors import Evaluator
+from torchrl.testing.mocking_classes import ContinuousActionVecMockEnv
+
+
+def _make_env():
+    return ContinuousActionVecMockEnv()
+
+
+def _make_policy(env=None):
+    if env is None:
+        env = _make_env()
+    obs_dim = env.observation_spec["observation"].shape[-1]
+    act_dim = env.action_spec.shape[-1]
+    return TensorDictModule(
+        nn.Linear(obs_dim, act_dim),
+        in_keys=["observation"],
+        out_keys=["action"],
+    )
+
+
+class TestEvaluatorSync:
+    def test_evaluate_basic(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            metrics = evaluator.evaluate(step=0)
+            assert "eval/reward" in metrics
+            assert "eval/episode_length" in metrics
+            assert isinstance(metrics["eval/reward"], float)
+        finally:
+            evaluator.shutdown()
+
+    def test_evaluate_with_weights(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        train_policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            weights = Evaluator.extract_weights(train_policy)
+            metrics = evaluator.evaluate(weights=weights, step=0)
+            assert "eval/reward" in metrics
+        finally:
+            evaluator.shutdown()
+
+    def test_evaluate_with_module_weights(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        train_policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            metrics = evaluator.evaluate(weights=train_policy, step=0)
+            assert "eval/reward" in metrics
+        finally:
+            evaluator.shutdown()
+
+    def test_custom_log_prefix(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50, log_prefix="test_eval")
+        try:
+            metrics = evaluator.evaluate(step=0)
+            assert "test_eval/reward" in metrics
+            assert "test_eval/episode_length" in metrics
+        finally:
+            evaluator.shutdown()
+
+    def test_custom_metrics_fn(self):
+        env = _make_env()
+        policy = _make_policy(env)
+
+        def my_metrics(td):
+            return {"num_steps": td.shape[-1]}
+
+        evaluator = Evaluator(env, policy, max_steps=50, metrics_fn=my_metrics)
+        try:
+            metrics = evaluator.evaluate(step=0)
+            assert "eval/num_steps" in metrics
+        finally:
+            evaluator.shutdown()
+
+    def test_callback(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        results = []
+
+        def cb(metrics, step):
+            results.append((metrics, step))
+
+        evaluator = Evaluator(env, policy, max_steps=50, callback=cb)
+        try:
+            evaluator.evaluate(step=42)
+            assert len(results) == 1
+            assert results[0][1] == 42
+            assert "eval/reward" in results[0][0]
+        finally:
+            evaluator.shutdown()
+
+    def test_policy_factory(self):
+        evaluator = Evaluator(
+            _make_env,
+            policy_factory=lambda env: _make_policy(env),
+            max_steps=50,
+        )
+        try:
+            metrics = evaluator.evaluate(step=0)
+            assert "eval/reward" in metrics
+        finally:
+            evaluator.shutdown()
+
+    def test_multiple_evals(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            for i in range(3):
+                metrics = evaluator.evaluate(step=i)
+                assert "eval/reward" in metrics
+        finally:
+            evaluator.shutdown()
+
+    def test_extract_weights(self):
+        policy = _make_policy()
+        weights = Evaluator.extract_weights(policy)
+        assert isinstance(weights, TensorDict)
+        assert weights.device == torch.device("cpu")
+
+
+class TestEvaluatorAsync:
+    def test_trigger_and_wait(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            evaluator.trigger_eval(step=0)
+            result = evaluator.wait(timeout=30)
+            assert result is not None
+            assert "eval/reward" in result
+        finally:
+            evaluator.shutdown()
+
+    def test_trigger_and_poll(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            evaluator.trigger_eval(step=0)
+            # poll with generous timeout
+            result = evaluator.poll(timeout=30)
+            assert result is not None
+            assert "eval/reward" in result
+        finally:
+            evaluator.shutdown()
+
+    def test_poll_nonblocking_returns_none(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=500)
+        try:
+            evaluator.trigger_eval(step=0)
+            # Immediately poll - might be None
+            result = evaluator.poll(timeout=0)
+            # Either None or valid
+            if result is not None:
+                assert "eval/reward" in result
+        finally:
+            evaluator.shutdown()
+
+    def test_fire_and_forget(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=200)
+        try:
+            evaluator.trigger_eval(step=0)
+            evaluator.trigger_eval(step=1)
+            result = evaluator.wait(timeout=30)
+            assert result is not None
+            assert "eval/reward" in result
+        finally:
+            evaluator.shutdown()
+
+    def test_async_with_weights(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        train_policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            evaluator.trigger_eval(weights=train_policy, step=0)
+            result = evaluator.wait(timeout=30)
+            assert result is not None
+            assert "eval/reward" in result
+        finally:
+            evaluator.shutdown()
+
+    def test_async_callback(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        results = []
+
+        def cb(metrics, step):
+            results.append((metrics, step))
+
+        evaluator = Evaluator(env, policy, max_steps=50, callback=cb)
+        try:
+            evaluator.trigger_eval(step=7)
+            evaluator.wait(timeout=30)
+            assert len(results) >= 1
+            assert results[0][1] == 7
+        finally:
+            evaluator.shutdown()
+
+    def test_multiple_async_evals(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            for i in range(3):
+                evaluator.trigger_eval(step=i)
+                result = evaluator.wait(timeout=30)
+                assert result is not None
+                assert "eval/reward" in result
+        finally:
+            evaluator.shutdown()
+
+    def test_shutdown_no_thread_leak(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50)
+        evaluator.trigger_eval(step=0)
+        evaluator.wait(timeout=30)
+        evaluator.shutdown()
+        time.sleep(0.5)
+        for t in threading.enumerate():
+            assert (
+                not t.is_alive() or "eval" not in t.name.lower()
+            ), f"Thread {t.name} still alive after shutdown"
+
+
+class TestEvaluatorErrors:
+    def test_no_policy_raises(self):
+        with pytest.raises(ValueError, match="policy.*must be provided"):
+            Evaluator(_make_env, max_steps=50)
+
+    def test_both_policy_and_factory_raises(self):
+        with pytest.raises(ValueError, match="not both"):
+            Evaluator(
+                _make_env,
+                policy=_make_policy(),
+                policy_factory=lambda env: _make_policy(env),
+                max_steps=50,
+            )
+
+    def test_invalid_backend_raises(self):
+        with pytest.raises(ValueError, match="Unknown backend"):
+            Evaluator(_make_env, policy=_make_policy(), max_steps=50, backend="invalid")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-x"])

--- a/test/test_evaluator.py
+++ b/test/test_evaluator.py
@@ -139,6 +139,16 @@ class TestEvaluatorSync:
         assert isinstance(weights, TensorDict)
         assert weights.device == torch.device("cpu")
 
+    def test_step_provenance_in_result(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            metrics = evaluator.evaluate(step=123)
+            assert metrics["eval/step"] == 123
+        finally:
+            evaluator.shutdown()
+
 
 class TestEvaluatorAsync:
     def test_trigger_and_wait(self):
@@ -248,6 +258,72 @@ class TestEvaluatorAsync:
             assert (
                 not t.is_alive() or "eval" not in t.name.lower()
             ), f"Thread {t.name} still alive after shutdown"
+
+    def test_step_provenance_in_result(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            evaluator.trigger_eval(step=999)
+            result = evaluator.wait(timeout=30)
+            assert result is not None
+            assert result["eval/step"] == 999
+        finally:
+            evaluator.shutdown()
+
+    def test_shutdown_with_inflight_eval(self):
+        """Shutdown while an eval is still running should not hang."""
+        env = _make_env()
+        policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=5000)
+        evaluator.trigger_eval(step=0)
+        # Don't wait for completion -- shut down immediately
+        t0 = time.time()
+        evaluator.shutdown(timeout=5.0)
+        elapsed = time.time() - t0
+        assert elapsed < 10.0, f"Shutdown took {elapsed:.1f}s, expected < 10s"
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+    reason="Requires 2+ CUDA devices",
+)
+class TestEvaluatorMultiDevice:
+    def test_eval_on_dedicated_device(self):
+        """Training policy on cuda:0, eval on cuda:1."""
+        train_device = torch.device("cuda:0")
+        eval_device = torch.device("cuda:1")
+
+        env = ContinuousActionVecMockEnv(device=eval_device)
+        eval_policy = _make_policy(env).to(eval_device)
+        train_policy = _make_policy(env).to(train_device)
+
+        evaluator = Evaluator(env, eval_policy, max_steps=50, device=eval_device)
+        try:
+            # Pass training weights from cuda:0 -- should be moved to cuda:1
+            metrics = evaluator.evaluate(weights=train_policy, step=0)
+            assert "eval/reward" in metrics
+            assert isinstance(metrics["eval/reward"], float)
+        finally:
+            evaluator.shutdown()
+
+    def test_async_eval_on_dedicated_device(self):
+        """Async eval on a different device from training."""
+        train_device = torch.device("cuda:0")
+        eval_device = torch.device("cuda:1")
+
+        env = ContinuousActionVecMockEnv(device=eval_device)
+        eval_policy = _make_policy(env).to(eval_device)
+        train_policy = _make_policy(env).to(train_device)
+
+        evaluator = Evaluator(env, eval_policy, max_steps=50, device=eval_device)
+        try:
+            evaluator.trigger_eval(weights=train_policy, step=0)
+            result = evaluator.wait(timeout=30)
+            assert result is not None
+            assert "eval/reward" in result
+        finally:
+            evaluator.shutdown()
 
 
 class TestEvaluatorErrors:

--- a/torchrl/collectors/__init__.py
+++ b/torchrl/collectors/__init__.py
@@ -9,6 +9,7 @@ from torchrl.modules.tensordict_module.exploration import RandomPolicy
 from ._async_batched import AsyncBatchedCollector
 
 from ._base import BaseCollector, DataCollectorBase, ProfileConfig
+from ._evaluator import Evaluator
 
 from ._multi_async import MultiAsyncCollector, MultiaSyncDataCollector
 from ._multi_base import MultiCollector, MultiCollector as _MultiDataCollector
@@ -31,6 +32,7 @@ __all__ = [
     "MultiCollector",
     "MultiSyncCollector",
     "AsyncBatchedCollector",
+    "Evaluator",
     "MultiAsyncCollector",
     "ProfileConfig",
     # Legacy names (backward-compatible aliases)

--- a/torchrl/collectors/_evaluator.py
+++ b/torchrl/collectors/_evaluator.py
@@ -82,8 +82,17 @@ class Evaluator:
       (blocking) to retrieve the result.  Results are also auto-logged if a
       *logger* is provided.
 
-    Fire-and-forget semantics: calling :meth:`trigger_eval` while a previous
-    evaluation is still running discards the in-progress result.
+    **Backpressure / overlap policy**: calling :meth:`trigger_eval` while a
+    previous evaluation is still running **drops** the in-progress result
+    (fire-and-forget).  The new evaluation starts as soon as the background
+    thread finishes the current ``env.rollout()`` call — there is no queue,
+    no coalescing, and no error.  Only the most-recently-triggered evaluation
+    will produce a result.
+
+    **Logging thread-safety**: all logger writes (scalar metrics, video
+    encoding) happen on the **caller thread** inside :meth:`poll`,
+    :meth:`wait`, or :meth:`evaluate`.  The background thread only computes
+    plain metrics and returns them; it never touches the logger.
 
     Args:
         env: An :class:`~torchrl.envs.EnvBase` instance **or** a callable
@@ -167,6 +176,7 @@ class Evaluator:
         self._callback = callback
         self._logger_lock = logger_lock or threading.Lock()
         self._step_counter = 0
+        self._dump_video = dump_video
 
         if backend == "thread":
             self._backend: _EvalBackend = _ThreadEvalBackend(
@@ -179,7 +189,6 @@ class Evaluator:
                 reward_keys=reward_keys,
                 break_when_any_done=break_when_any_done,
                 auto_cast_to_device=auto_cast_to_device,
-                dump_video=dump_video,
                 metrics_fn=metrics_fn,
             )
         elif backend == "ray":
@@ -222,11 +231,7 @@ class Evaluator:
         weights = self._prepare_weights(weights)
         step = self._next_step(step)
         raw = self._backend.run_sync(weights, step)
-        metrics = self._format_metrics(raw)
-        self._auto_log(metrics, step)
-        if self._callback is not None:
-            self._callback(metrics, step)
-        return metrics
+        return self._finalize(raw)
 
     # ------------------------------------------------------------------
     # Asynchronous API
@@ -259,12 +264,7 @@ class Evaluator:
         raw = self._backend.poll(timeout)
         if raw is None:
             return None
-        metrics = self._format_metrics(raw)
-        step = raw.get("_step")
-        self._auto_log(metrics, step)
-        if self._callback is not None:
-            self._callback(metrics, step)
-        return metrics
+        return self._finalize(raw)
 
     def wait(self, timeout: float | None = None) -> dict[str, Any] | None:
         """Block until the current evaluation finishes.
@@ -275,12 +275,7 @@ class Evaluator:
         raw = self._backend.wait(timeout)
         if raw is None:
             return None
-        metrics = self._format_metrics(raw)
-        step = raw.get("_step")
-        self._auto_log(metrics, step)
-        if self._callback is not None:
-            self._callback(metrics, step)
-        return metrics
+        return self._finalize(raw)
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -325,6 +320,24 @@ class Evaluator:
         self._step_counter += 1
         return s
 
+    def _finalize(self, raw: dict[str, Any]) -> dict[str, Any]:
+        """Format metrics, dump video, log, and invoke callback.
+
+        All heavy I/O (video dump, logger writes) happens here on the
+        **caller thread**, never inside the background eval thread.
+        """
+        step = raw.get("_step")
+        metrics = self._format_metrics(raw)
+
+        # Video dump -- on the caller thread so logger writes are safe
+        if self._dump_video:
+            self._backend.dump_video(step=step)
+
+        self._auto_log(metrics, step)
+        if self._callback is not None:
+            self._callback(metrics, step)
+        return metrics
+
     def _format_metrics(self, raw: dict[str, Any]) -> dict[str, Any]:
         prefix = self._log_prefix
         out: dict[str, Any] = {}
@@ -334,6 +347,8 @@ class Evaluator:
             out[f"{prefix}/episode_length"] = raw["episode_length"]
         if "frames" in raw and raw["frames"] is not None:
             out[f"{prefix}/video"] = raw["frames"]
+        if "_step" in raw:
+            out[f"{prefix}/step"] = raw["_step"]
         # Custom metrics (already prefixed by backend or metrics_fn)
         for k, v in raw.items():
             if k.startswith("custom/"):
@@ -344,14 +359,18 @@ class Evaluator:
         if self._logger is None:
             return
         with self._logger_lock:
-            # Separate video from scalar metrics
-            video = metrics.pop(f"{self._log_prefix}/video", None)
-            if metrics:
-                self._logger.log_metrics(metrics, step=step)
+            # Separate non-scalar entries from scalar metrics for logging
+            video = metrics.get(f"{self._log_prefix}/video")
+            step_key = f"{self._log_prefix}/step"
+            scalars = {
+                k: v
+                for k, v in metrics.items()
+                if k != f"{self._log_prefix}/video" and k != step_key
+            }
+            if scalars:
+                self._logger.log_metrics(scalars, step=step)
             if video is not None:
                 self._logger.log_video(f"{self._log_prefix}/video", video, step=step)
-                # Put it back so the caller still sees it
-                metrics[f"{self._log_prefix}/video"] = video
 
 
 # ======================================================================
@@ -387,6 +406,13 @@ class _EvalBackend(abc.ABC):
         """Clean up resources."""
         ...
 
+    def dump_video(self, step: int | None = None) -> None:
+        """Dump accumulated video frames (called on caller thread).
+
+        Default is a no-op; overridden by backends that support video.
+        """
+        return None
+
 
 # ======================================================================
 # Thread backend
@@ -407,7 +433,6 @@ class _ThreadEvalBackend(_EvalBackend):
         reward_keys: NestedKey,
         break_when_any_done: bool,
         auto_cast_to_device: bool,
-        dump_video: bool,
         metrics_fn: Callable[[TensorDictBase], dict[str, float]] | None,
     ) -> None:
         # Build env
@@ -437,7 +462,6 @@ class _ThreadEvalBackend(_EvalBackend):
         self._reward_keys = reward_keys
         self._break_when_any_done = break_when_any_done
         self._auto_cast_to_device = auto_cast_to_device
-        self._dump_video = dump_video
         self._metrics_fn = metrics_fn
 
         # Threading state
@@ -567,13 +591,18 @@ class _ThreadEvalBackend(_EvalBackend):
             for k, v in custom.items():
                 metrics[f"custom/{k}"] = v
 
-        # Video dump
-        if self._dump_video and hasattr(self._env, "transform"):
-            for transform in self._env.transform:
-                if hasattr(transform, "dump"):
-                    transform.dump()
-
         return metrics
+
+    def dump_video(self, step: int | None = None) -> None:
+        """Dump accumulated video frames from VideoRecorder transforms.
+
+        Called on the caller thread so that logger writes are thread-safe.
+        """
+        if not hasattr(self._env, "transform"):
+            return
+        for transform in self._env.transform:
+            if hasattr(transform, "dump"):
+                transform.dump(step=step)
 
 
 # ======================================================================

--- a/torchrl/collectors/_evaluator.py
+++ b/torchrl/collectors/_evaluator.py
@@ -1,0 +1,661 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unified evaluator with pluggable thread / Ray backends.
+
+This module provides :class:`Evaluator`, a single entry-point for running
+evaluation rollouts either synchronously (blocking) or asynchronously
+(fire-and-forget) during RL training.
+
+Typical usage -- **thread backend** (default)::
+
+    from torchrl.collectors import Evaluator
+
+    evaluator = Evaluator(
+        make_eval_env,
+        eval_policy,
+        max_steps=1000,
+        logger=logger,
+    )
+
+    # Non-blocking: trigger and poll later
+    evaluator.trigger_eval(train_policy, step=collected_frames)
+    result = evaluator.poll()  # None while still running
+
+    # Or blocking:
+    metrics = evaluator.evaluate(train_policy, step=collected_frames)
+
+    evaluator.shutdown()
+
+Typical usage -- **Ray backend**::
+
+    evaluator = Evaluator(
+        make_eval_env,
+        policy_factory=make_eval_policy,
+        max_steps=1000,
+        logger=logger,
+        backend="ray",
+        init_fn=my_init_fn,
+        num_gpus=1,
+    )
+
+    evaluator.trigger_eval(weights, step=step)
+    result = evaluator.poll()
+    evaluator.shutdown()
+"""
+from __future__ import annotations
+
+import abc
+import importlib
+import logging
+import threading
+from collections.abc import Callable
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from tensordict import TensorDict, TensorDictBase
+from tensordict.nn import TensorDictModuleBase
+
+from torchrl.envs import EnvBase
+from torchrl.envs.utils import ExplorationType, set_exploration_type
+
+_has_ray = importlib.util.find_spec("ray") is not None
+
+logger = logging.getLogger(__name__)
+
+NestedKey = str | tuple[str, ...]
+
+
+class Evaluator:
+    """Unified sync / async evaluator with pluggable backend.
+
+    The evaluator wraps an environment and a policy and provides two modes of
+    operation:
+
+    * **Synchronous** -- call :meth:`evaluate` to run a blocking rollout and
+      get metrics back immediately.
+    * **Asynchronous** -- call :meth:`trigger_eval` to kick off a rollout in
+      the background, then :meth:`poll` (non-blocking) or :meth:`wait`
+      (blocking) to retrieve the result.  Results are also auto-logged if a
+      *logger* is provided.
+
+    Fire-and-forget semantics: calling :meth:`trigger_eval` while a previous
+    evaluation is still running discards the in-progress result.
+
+    Args:
+        env: An :class:`~torchrl.envs.EnvBase` instance **or** a callable
+            that returns one.  For the ``"ray"`` backend the callable form is
+            required (the env is created inside the Ray actor process).
+        policy: The evaluation policy.  Mutually exclusive with
+            *policy_factory*.
+
+    Keyword Args:
+        policy_factory: A callable ``(env) -> policy`` used to build the
+            policy.  Required for the ``"ray"`` backend; optional for
+            ``"thread"`` (if provided, called once at construction time).
+        max_steps (int): Maximum environment steps per rollout.
+        logger: Optional :class:`~torchrl.record.loggers.Logger` for
+            automatic metric / video logging.
+        log_prefix (str): Prefix prepended to all logged metric names.
+            Default: ``"eval"``.
+        reward_keys: Nested key(s) for reading the reward from the rollout
+            tensordict.  Default: ``("next", "reward")``.
+        done_keys: Nested key(s) for reading the done flag.
+            Default: ``("next", "done")``.
+        device: Device for the evaluation policy.  If ``None``, inferred
+            from the policy parameters.
+        exploration_type: Exploration mode during evaluation.
+            Default: :attr:`ExplorationType.DETERMINISTIC`.
+        metrics_fn: Optional ``(TensorDictBase) -> dict[str, float]``
+            called on every rollout result to extract custom metrics.
+        break_when_any_done (bool): Stop the rollout as soon as any
+            sub-environment reports done.  Default: ``True``.
+        auto_cast_to_device (bool): Auto-cast tensordicts to policy device.
+            Default: ``True``.
+        dump_video (bool): Call ``dump()`` on :class:`VideoRecorder`
+            transforms after each rollout (thread backend only).
+            Default: ``True``.
+        callback: Optional ``(dict, int) -> None`` invoked with
+            ``(metrics, step)`` after each completed evaluation.
+        logger_lock: A :class:`threading.Lock` shared with the training
+            loop to serialise logger access.  If ``None`` a private lock
+            is created.
+        backend (str): ``"thread"`` (default) or ``"ray"``.
+        init_fn: (*Ray only*) Callable invoked at the start of the actor
+            process, before any ``torch`` import.
+        num_gpus (int): (*Ray only*) GPUs requested for the actor.
+            Default: ``1``.
+        ray_kwargs (dict): (*Ray only*) Extra keyword arguments forwarded
+            to ``ray.remote()``.
+    """
+
+    def __init__(
+        self,
+        env: EnvBase | Callable[[], EnvBase],
+        policy: TensorDictModuleBase | Callable | None = None,
+        *,
+        policy_factory: Callable[..., Callable] | None = None,
+        max_steps: int,
+        logger=None,
+        log_prefix: str = "eval",
+        reward_keys: NestedKey = ("next", "reward"),
+        done_keys: NestedKey = ("next", "done"),
+        device: torch.device | str | None = None,
+        exploration_type: ExplorationType = ExplorationType.DETERMINISTIC,
+        metrics_fn: Callable[[TensorDictBase], dict[str, float]] | None = None,
+        break_when_any_done: bool = True,
+        auto_cast_to_device: bool = True,
+        dump_video: bool = True,
+        callback: Callable[[dict, int], None] | None = None,
+        logger_lock: threading.Lock | None = None,
+        # Backend selection
+        backend: str = "thread",
+        # Ray-specific
+        init_fn: Callable[[], None] | None = None,
+        num_gpus: int = 1,
+        ray_kwargs: dict | None = None,
+    ) -> None:
+        self._logger = logger
+        self._log_prefix = log_prefix
+        self._reward_keys = reward_keys
+        self._done_keys = done_keys
+        self._exploration_type = exploration_type
+        self._metrics_fn = metrics_fn
+        self._callback = callback
+        self._logger_lock = logger_lock or threading.Lock()
+        self._step_counter = 0
+
+        if backend == "thread":
+            self._backend: _EvalBackend = _ThreadEvalBackend(
+                env=env,
+                policy=policy,
+                policy_factory=policy_factory,
+                max_steps=max_steps,
+                device=device,
+                exploration_type=exploration_type,
+                reward_keys=reward_keys,
+                break_when_any_done=break_when_any_done,
+                auto_cast_to_device=auto_cast_to_device,
+                dump_video=dump_video,
+                metrics_fn=metrics_fn,
+            )
+        elif backend == "ray":
+            self._backend = _RayEvalBackend(
+                env_maker=env,
+                policy_factory=policy_factory,
+                max_steps=max_steps,
+                reward_keys=reward_keys,
+                break_when_any_done=break_when_any_done,
+                init_fn=init_fn,
+                num_gpus=num_gpus,
+                ray_kwargs=ray_kwargs or {},
+            )
+        else:
+            raise ValueError(f"Unknown backend {backend!r}. Choose 'thread' or 'ray'.")
+
+    # ------------------------------------------------------------------
+    # Synchronous API
+    # ------------------------------------------------------------------
+
+    def evaluate(
+        self,
+        weights: TensorDictBase | nn.Module | None = None,
+        step: int | None = None,
+    ) -> dict[str, Any]:
+        """Run a blocking evaluation rollout.
+
+        Args:
+            weights: Policy weights to load before the rollout.  Accepts a
+                :class:`TensorDictBase` (e.g. from
+                ``TensorDict.from_module(policy).data``) or an
+                :class:`nn.Module` (weights are extracted automatically).
+                If ``None`` the current policy weights are used.
+            step: Logging step.  If ``None`` an internal counter is used.
+
+        Returns:
+            dict with at least ``"<prefix>/reward"`` and
+            ``"<prefix>/episode_length"`` keys.
+        """
+        weights = self._prepare_weights(weights)
+        step = self._next_step(step)
+        raw = self._backend.run_sync(weights, step)
+        metrics = self._format_metrics(raw)
+        self._auto_log(metrics, step)
+        if self._callback is not None:
+            self._callback(metrics, step)
+        return metrics
+
+    # ------------------------------------------------------------------
+    # Asynchronous API
+    # ------------------------------------------------------------------
+
+    def trigger_eval(
+        self,
+        weights: TensorDictBase | nn.Module | None = None,
+        step: int | None = None,
+    ) -> None:
+        """Start an async evaluation (fire-and-forget).
+
+        If a previous evaluation is still running its result will be
+        discarded.
+
+        Args:
+            weights: See :meth:`evaluate`.
+            step: See :meth:`evaluate`.
+        """
+        weights = self._prepare_weights(weights)
+        step = self._next_step(step)
+        self._backend.submit(weights, step)
+
+    def poll(self, timeout: float = 0) -> dict[str, Any] | None:
+        """Return the latest evaluation result if ready, else ``None``.
+
+        Args:
+            timeout: Seconds to wait.  ``0`` means non-blocking.
+        """
+        raw = self._backend.poll(timeout)
+        if raw is None:
+            return None
+        metrics = self._format_metrics(raw)
+        step = raw.get("_step")
+        self._auto_log(metrics, step)
+        if self._callback is not None:
+            self._callback(metrics, step)
+        return metrics
+
+    def wait(self, timeout: float | None = None) -> dict[str, Any] | None:
+        """Block until the current evaluation finishes.
+
+        Args:
+            timeout: Max seconds to wait.  ``None`` waits forever.
+        """
+        raw = self._backend.wait(timeout)
+        if raw is None:
+            return None
+        metrics = self._format_metrics(raw)
+        step = raw.get("_step")
+        self._auto_log(metrics, step)
+        if self._callback is not None:
+            self._callback(metrics, step)
+        return metrics
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def shutdown(self, timeout: float = 5.0) -> None:
+        """Cancel any running evaluation, clean up resources."""
+        self._backend.shutdown(timeout)
+
+    def __del__(self):
+        try:
+            self.shutdown(timeout=2.0)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def extract_weights(policy: nn.Module) -> TensorDictBase:
+        """Extract detached, cloned, CPU weights from a policy.
+
+        This is a convenience helper; the returned TensorDict is safe to
+        pass across threads.
+        """
+        return TensorDict.from_module(policy).data.detach().clone().cpu()
+
+    def _prepare_weights(
+        self, weights: TensorDictBase | nn.Module | None
+    ) -> TensorDictBase | None:
+        if weights is None:
+            return None
+        if isinstance(weights, nn.Module):
+            return self.extract_weights(weights)
+        return weights.detach().clone().cpu()
+
+    def _next_step(self, step: int | None) -> int:
+        if step is not None:
+            return step
+        s = self._step_counter
+        self._step_counter += 1
+        return s
+
+    def _format_metrics(self, raw: dict[str, Any]) -> dict[str, Any]:
+        prefix = self._log_prefix
+        out: dict[str, Any] = {}
+        if "reward" in raw:
+            out[f"{prefix}/reward"] = raw["reward"]
+        if "episode_length" in raw:
+            out[f"{prefix}/episode_length"] = raw["episode_length"]
+        if "frames" in raw and raw["frames"] is not None:
+            out[f"{prefix}/video"] = raw["frames"]
+        # Custom metrics (already prefixed by backend or metrics_fn)
+        for k, v in raw.items():
+            if k.startswith("custom/"):
+                out[f"{prefix}/{k[7:]}"] = v
+        return out
+
+    def _auto_log(self, metrics: dict[str, Any], step: int | None) -> None:
+        if self._logger is None:
+            return
+        with self._logger_lock:
+            # Separate video from scalar metrics
+            video = metrics.pop(f"{self._log_prefix}/video", None)
+            if metrics:
+                self._logger.log_metrics(metrics, step=step)
+            if video is not None:
+                self._logger.log_video(f"{self._log_prefix}/video", video, step=step)
+                # Put it back so the caller still sees it
+                metrics[f"{self._log_prefix}/video"] = video
+
+
+# ======================================================================
+# Backend interface
+# ======================================================================
+
+
+class _EvalBackend(abc.ABC):
+    """Internal contract that each backend implements."""
+
+    @abc.abstractmethod
+    def run_sync(self, weights: TensorDictBase | None, step: int) -> dict[str, Any]:
+        """Run a blocking evaluation and return raw results."""
+        ...
+
+    @abc.abstractmethod
+    def submit(self, weights: TensorDictBase | None, step: int) -> None:
+        """Start an async evaluation (fire-and-forget)."""
+        ...
+
+    @abc.abstractmethod
+    def poll(self, timeout: float) -> dict[str, Any] | None:
+        """Non-blocking check for results."""
+        ...
+
+    @abc.abstractmethod
+    def wait(self, timeout: float | None) -> dict[str, Any] | None:
+        """Blocking wait for results."""
+        ...
+
+    @abc.abstractmethod
+    def shutdown(self, timeout: float) -> None:
+        """Clean up resources."""
+        ...
+
+
+# ======================================================================
+# Thread backend
+# ======================================================================
+
+
+class _ThreadEvalBackend(_EvalBackend):
+    """Runs evaluation in a daemon thread using ``env.rollout()``."""
+
+    def __init__(
+        self,
+        env: EnvBase | Callable[[], EnvBase],
+        policy: TensorDictModuleBase | Callable | None,
+        policy_factory: Callable[..., Callable] | None,
+        max_steps: int,
+        device: torch.device | str | None,
+        exploration_type: ExplorationType,
+        reward_keys: NestedKey,
+        break_when_any_done: bool,
+        auto_cast_to_device: bool,
+        dump_video: bool,
+        metrics_fn: Callable[[TensorDictBase], dict[str, float]] | None,
+    ) -> None:
+        # Build env
+        if callable(env) and not isinstance(env, EnvBase):
+            env = env()
+        self._env: EnvBase = env
+
+        # Build policy
+        if policy is not None and policy_factory is not None:
+            raise ValueError("Provide either `policy` or `policy_factory`, not both.")
+        if policy_factory is not None:
+            policy = policy_factory(self._env)
+        if policy is None:
+            raise ValueError("Either `policy` or `policy_factory` must be provided.")
+        self._policy = policy
+
+        # Device
+        if device is None:
+            try:
+                device = next(self._policy.parameters()).device
+            except StopIteration:
+                device = torch.device("cpu")
+        self._device = torch.device(device)
+
+        self._max_steps = max_steps
+        self._exploration_type = exploration_type
+        self._reward_keys = reward_keys
+        self._break_when_any_done = break_when_any_done
+        self._auto_cast_to_device = auto_cast_to_device
+        self._dump_video = dump_video
+        self._metrics_fn = metrics_fn
+
+        # Threading state
+        self._lock = threading.Lock()
+        self._cancel = threading.Event()
+        self._eval_ready = threading.Event()
+        self._result_ready = threading.Event()
+        self._pending_request: tuple[TensorDictBase | None, int] | None = None
+        self._result: dict[str, Any] | None = None
+        self._shutdown_flag = False
+        self._thread: threading.Thread | None = None
+
+    # ---- sync ----
+
+    def run_sync(self, weights: TensorDictBase | None, step: int) -> dict[str, Any]:
+        metrics = self._run_eval(weights)
+        metrics["_step"] = step
+        return metrics
+
+    # ---- async ----
+
+    def submit(self, weights: TensorDictBase | None, step: int) -> None:
+        with self._lock:
+            self._cancel.set()  # discard any in-progress result
+            self._pending_request = (weights, step)
+            self._result = None
+            self._result_ready.clear()
+        self._eval_ready.set()
+        self._ensure_thread()
+
+    def poll(self, timeout: float) -> dict[str, Any] | None:
+        if timeout > 0:
+            self._result_ready.wait(timeout=timeout)
+        with self._lock:
+            result = self._result
+            if result is not None:
+                self._result = None
+            return result
+
+    def wait(self, timeout: float | None) -> dict[str, Any] | None:
+        self._result_ready.wait(timeout=timeout)
+        with self._lock:
+            result = self._result
+            if result is not None:
+                self._result = None
+            return result
+
+    def shutdown(self, timeout: float) -> None:
+        self._shutdown_flag = True
+        self._cancel.set()
+        self._eval_ready.set()  # wake thread so it can exit
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout=timeout)
+        if not self._env.is_closed:
+            self._env.close()
+
+    # ---- internals ----
+
+    def _ensure_thread(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._shutdown_flag = False
+        self._thread = threading.Thread(target=self._eval_loop, daemon=True)
+        self._thread.start()
+
+    def _eval_loop(self) -> None:
+        while not self._shutdown_flag:
+            self._eval_ready.wait(timeout=1.0)
+            if self._shutdown_flag:
+                break
+            self._eval_ready.clear()
+
+            with self._lock:
+                request = self._pending_request
+                self._pending_request = None
+                self._cancel.clear()
+
+            if request is None:
+                continue
+
+            weights, step = request
+            metrics = self._run_eval(weights)
+
+            if not self._cancel.is_set():
+                metrics["_step"] = step
+                with self._lock:
+                    self._result = metrics
+                self._result_ready.set()
+
+    def _run_eval(self, weights: TensorDictBase | None) -> dict[str, Any]:
+        # Apply weights
+        if weights is not None:
+            weights.to(self._device).to_module(self._policy)
+
+        if isinstance(self._policy, nn.Module):
+            self._policy.eval()
+
+        with set_exploration_type(self._exploration_type), torch.no_grad():
+            rollout_td = self._env.rollout(
+                self._max_steps,
+                self._policy,
+                auto_cast_to_device=self._auto_cast_to_device,
+                break_when_any_done=self._break_when_any_done,
+            )
+
+        if isinstance(self._policy, nn.Module):
+            self._policy.train()
+
+        # Compute metrics
+        reward = rollout_td.get(self._reward_keys, None)
+        if reward is not None:
+            # sum over time, mean over batch
+            episode_reward = reward.sum(-2).mean().item()
+        else:
+            episode_reward = float("nan")
+
+        episode_length = rollout_td.shape[-1]
+
+        metrics: dict[str, Any] = {
+            "reward": episode_reward,
+            "episode_length": episode_length,
+        }
+
+        # Custom metrics
+        if self._metrics_fn is not None:
+            custom = self._metrics_fn(rollout_td)
+            for k, v in custom.items():
+                metrics[f"custom/{k}"] = v
+
+        # Video dump
+        if self._dump_video and hasattr(self._env, "transform"):
+            for transform in self._env.transform:
+                if hasattr(transform, "dump"):
+                    transform.dump()
+
+        return metrics
+
+
+# ======================================================================
+# Ray backend
+# ======================================================================
+
+
+class _RayEvalBackend(_EvalBackend):
+    """Wraps :class:`RayEvalWorker` to match the backend contract."""
+
+    def __init__(
+        self,
+        env_maker: Callable[[], Any],
+        policy_factory: Callable[..., Any] | None,
+        max_steps: int,
+        reward_keys: NestedKey,
+        break_when_any_done: bool,
+        init_fn: Callable[[], None] | None,
+        num_gpus: int,
+        ray_kwargs: dict,
+    ) -> None:
+        if not _has_ray:
+            raise RuntimeError(
+                "Ray is required for backend='ray' but could not be found. "
+                "Install it with: pip install ray"
+            )
+        if policy_factory is None:
+            raise ValueError(
+                "The 'ray' backend requires `policy_factory` (a callable "
+                "`(env) -> policy`) because the policy is created inside "
+                "the Ray actor process."
+            )
+        from torchrl.collectors.distributed import RayEvalWorker
+
+        self._worker = RayEvalWorker(
+            init_fn=init_fn,
+            env_maker=env_maker,
+            policy_maker=policy_factory,
+            num_gpus=num_gpus,
+            reward_keys=reward_keys
+            if isinstance(reward_keys, tuple)
+            else (reward_keys,),
+            **ray_kwargs,
+        )
+        self._max_steps = max_steps
+        self._break_when_any_done = break_when_any_done
+        self._last_step: int | None = None
+
+    def run_sync(self, weights: TensorDictBase | None, step: int) -> dict[str, Any]:
+        self._worker.submit(
+            weights,
+            self._max_steps,
+            break_when_any_done=self._break_when_any_done,
+        )
+        # Block until done
+        result = self._worker.poll(timeout=None)
+        result["_step"] = step
+        result.setdefault("episode_length", self._max_steps)
+        return result
+
+    def submit(self, weights: TensorDictBase | None, step: int) -> None:
+        self._last_step = step
+        self._worker.submit(
+            weights,
+            self._max_steps,
+            break_when_any_done=self._break_when_any_done,
+        )
+
+    def poll(self, timeout: float) -> dict[str, Any] | None:
+        result = self._worker.poll(timeout=timeout)
+        if result is None:
+            return None
+        result["_step"] = self._last_step
+        result.setdefault("episode_length", self._max_steps)
+        return result
+
+    def wait(self, timeout: float | None) -> dict[str, Any] | None:
+        # RayEvalWorker.poll supports timeout=None for blocking wait
+        return self.poll(timeout=timeout if timeout is not None else 1e9)
+
+    def shutdown(self, timeout: float) -> None:
+        try:
+            self._worker.shutdown()
+        except Exception:
+            logger.warning("RayEvalBackend: error during shutdown", exc_info=True)


### PR DESCRIPTION
## Summary

- Adds a new `Evaluator` class (`torchrl/collectors/_evaluator.py`) that provides a unified API for running evaluation rollouts during RL training, either synchronously (blocking) or asynchronously (fire-and-forget in a background thread)
- Supports two pluggable backends: `"thread"` (default, uses daemon thread + `env.rollout()`) and `"ray"` (wraps existing `RayEvalWorker`)
- Includes automatic metric logging, custom metrics via `metrics_fn`, video recording via `VideoRecorder` transforms, and user callbacks

## Motivation

All sota-implementations currently do blocking synchronous evaluation inside the training loop. For expensive environments (robotics simulators, LLM generation), this wastes significant training time. The `Evaluator` decouples evaluation from training.

## API

```python
from torchrl.collectors import Evaluator

evaluator = Evaluator(make_eval_env, eval_policy, max_steps=1000, logger=logger)

# Blocking:
metrics = evaluator.evaluate(weights=train_policy, step=step)

# Non-blocking:
evaluator.trigger_eval(weights=train_policy, step=step)
result = evaluator.poll()   # None if still running
result = evaluator.wait()   # block until done

evaluator.shutdown()
```

## Files changed

- **New**: `torchrl/collectors/_evaluator.py` — `Evaluator`, `_ThreadEvalBackend`, `_RayEvalBackend`
- **New**: `docs/source/reference/collectors_eval.rst` — documentation page
- **New**: `test/test_evaluator.py` — 20 unit tests
- **Modified**: `torchrl/collectors/__init__.py` — exports `Evaluator`
- **Modified**: `docs/source/reference/collectors.rst` — adds eval page to toctree

## Test plan

- [x] All 20 tests pass locally (`pytest test/test_evaluator.py -v` — 20 passed)
- [ ] CI passes
- [ ] Ray backend tests (requires Ray, skipped in basic CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)