### PR TITLE
[CI] Require lint checks to pass before merge

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,9 +73,26 @@ jobs:
         echo '::group::Lint C source'
         set +e
         python ./.github/unittest/linux/scripts/run-clang-format.py -r torchrl/csrc --clang-format-executable clang-format
-        
+
         if [ $? -ne 0 ]; then
           git --no-pager diff
           exit 1
         fi
         echo '::endgroup::'
+
+  lint-done:
+    name: lint-done
+    needs: [python-source-and-configs, c-source]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check lint results
+        run: |
+          if [[ "${{ needs.python-source-and-configs.result }}" != "success" ]] || \
+             [[ "${{ needs.c-source.result }}" != "success" ]]; then
+            echo "One or more lint checks failed or were cancelled."
+            echo "  python-source-and-configs: ${{ needs.python-source-and-configs.result }}"
+            echo "  c-source: ${{ needs.c-source.result }}"
+            exit 1
+          fi
+          echo "All lint checks passed."


### PR DESCRIPTION
## Summary
- Adds a `lint-done` summary job to the Lint workflow that depends on both `python-source-and-configs` and `c-source` jobs
- This job fails if any lint check fails or is cancelled, providing a single status check to gate merges
- A branch ruleset will be configured to require `Lint / lint-done` to pass before merging to `main`

## What this enables
- **Merge blocking**: PRs cannot be merged if lint checks are failing
- **Auto-merge**: Once enabled, contributors can click "Enable auto-merge" on a PR, and it will merge automatically as soon as all required checks pass

## Test plan
- [ ] Verify `lint-done` job appears in the Lint workflow run for this PR
- [ ] Verify it correctly reports pass/fail based on the lint sub-jobs
- [ ] Confirm branch ruleset is active and blocks merge when lint fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)