### PR TITLE
[Feature] Support trajs_per_batch with replay_buffer on multi-process and distributed collectors

### DIFF
--- a/docs/source/reference/collectors.rst
+++ b/docs/source/reference/collectors.rst
@@ -57,6 +57,8 @@ Key Features
 - **Device management**: Control where environments and policies execute
 - **Weight synchronization**: Keep inference policies up-to-date with training weights
 - **Replay buffer integration**: Seamless compatibility with TorchRL's replay buffers
+- **Trajectory assembly**: Collect complete trajectories with ``trajs_per_batch`` for
+  clean :class:`~torchrl.data.SliceSampler` sampling — see :ref:`collectors_replay_trajs`
 - **Batching strategies**: Multiple ways to organize collected data
 
 Quick Example

--- a/docs/source/reference/collectors_distributed.rst
+++ b/docs/source/reference/collectors_distributed.rst
@@ -38,6 +38,14 @@ node or across multiple nodes.
   By default, TorchRL filters out these warnings in sub-processes. If one still wishes to
   see these warnings, they can be displayed by setting ``torchrl.filter_warnings_subprocess=False``.
 
+.. tip::
+
+  All distributed collectors support ``trajs_per_batch`` combined with
+  ``replay_buffer``.  When set, each remote worker assembles **complete
+  trajectories** and writes them to the shared buffer as flat 1-D sequences,
+  which is directly compatible with :class:`~torchrl.data.SliceSampler`.
+  See :ref:`collectors_replay_trajs` for examples and best practices.
+
 .. autosummary::
     :toctree: generated/
     :template: rl_template.rst

--- a/docs/source/reference/collectors_replay.rst
+++ b/docs/source/reference/collectors_replay.rst
@@ -65,6 +65,16 @@ will work:
     >>> for data in collector:
     ...     memory.extend(data)
 
+.. important::
+
+    The ``ndim=2`` and ``ndim=3`` examples above apply to **fixed-frame
+    batches** (the default, without ``trajs_per_batch``).  When
+    ``trajs_per_batch`` is set, each trajectory is written to the buffer as a
+    **flat 1-D sequence** of variable length.  A storage with ``ndim >= 2``
+    expects a fixed second dimension that variable-length trajectories cannot
+    satisfy.  Always use the default ``ndim=1`` when combining
+    ``trajs_per_batch`` with a replay buffer.
+
 .. _collectors_replay_trajs:
 
 Complete trajectory collection with ``trajs_per_batch``

--- a/docs/source/reference/collectors_replay.rst
+++ b/docs/source/reference/collectors_replay.rst
@@ -95,7 +95,7 @@ compatible with :class:`~torchrl.data.SliceSampler`.
 
     rb = ReplayBuffer(
         storage=LazyTensorStorage(100_000),
-        sampler=SliceSampler(slice_len=20, end_key=("next", "done")),
+        sampler=SliceSampler(slice_len=32, end_key=("next", "done")),
         batch_size=256,
     )
     collector = MultiCollector(

--- a/docs/source/reference/collectors_replay.rst
+++ b/docs/source/reference/collectors_replay.rst
@@ -65,9 +65,122 @@ will work:
     >>> for data in collector:
     ...     memory.extend(data)
 
-Using replay buffers that sample trajectories with :class:`~torchrl.collectors.MultiSyncDataCollector`
-isn't currently fully supported as the data batches can come from any worker and in most cases consecutive
-batches written in the buffer won't come from the same source (thereby interrupting the trajectories).
+.. _collectors_replay_trajs:
+
+Complete trajectory collection with ``trajs_per_batch``
+-------------------------------------------------------
+
+When using a multi-process collector
+(:class:`~torchrl.collectors.MultiSyncCollector` or
+:class:`~torchrl.collectors.MultiAsyncCollector`) with fixed-frame batches
+and a :class:`~torchrl.data.SliceSampler`, adjacent frames in the buffer can
+come from **different workers and different episodes** without an intervening
+``done`` signal.  The sampler has no way to detect these invisible boundaries,
+so it may draw slices that straddle unrelated trajectories — silently
+corrupting the training data.
+
+Setting ``trajs_per_batch`` on the collector solves this.  Each worker
+assembles **complete trajectories** (episodes whose last step carries
+``("next", "done") == True``) before writing them to the buffer as flat 1-D
+sequences — no padding, no artificial boundaries.  Every trajectory in the
+buffer is guaranteed to be a genuine episode segment, making it directly
+compatible with :class:`~torchrl.data.SliceSampler`.
+
+**Synchronous iteration (for-loop)**
+
+.. code-block:: python
+
+    from torchrl.collectors import MultiCollector
+    from torchrl.data import ReplayBuffer, LazyTensorStorage, SliceSampler
+
+    rb = ReplayBuffer(
+        storage=LazyTensorStorage(100_000),
+        sampler=SliceSampler(slice_len=20, end_key=("next", "done")),
+        batch_size=256,
+    )
+    collector = MultiCollector(
+        [make_env] * 4,
+        policy,
+        replay_buffer=rb,
+        frames_per_batch=200,
+        total_frames=500_000,
+        trajs_per_batch=8,   # each worker writes complete trajectories
+        sync=True,
+    )
+    for _ in collector:          # yields None (data goes straight to rb)
+        batch = rb.sample()      # contiguous sub-sequences, no cross-episode leaks
+        loss = loss_fn(batch)
+        # ...
+
+**Asynchronous collection (``start()``)**
+
+For off-policy algorithms where data collection and training run
+concurrently, use :meth:`~torchrl.collectors.BaseCollector.start`:
+
+.. code-block:: python
+
+    collector = MultiCollector(
+        [make_env] * 4,
+        policy,
+        replay_buffer=rb,
+        frames_per_batch=200,
+        total_frames=-1,
+        trajs_per_batch=8,
+        sync=False,
+    )
+    collector.start()           # workers fill rb in background threads/processes
+    for step in range(train_steps):
+        batch = rb.sample()
+        loss = loss_fn(batch)
+        # ...
+        collector.update_policy_weights_()
+    collector.async_shutdown()
+
+This pattern fully decouples data collection from training and is the
+recommended way to maximise inference throughput on multi-core machines or
+GPU-accelerated environments.
+
+**Single-process collectors** also support ``trajs_per_batch`` with the same
+replay-buffer semantics:
+
+.. code-block:: python
+
+    collector = Collector(
+        env, policy,
+        replay_buffer=rb,
+        frames_per_batch=200,
+        total_frames=-1,
+        trajs_per_batch=8,
+    )
+    collector.start()
+    # ...
+
+.. warning::
+
+    Without ``trajs_per_batch``, a multi-process collector writes fixed-frame
+    batches from each worker.  If the buffer uses a
+    :class:`~torchrl.data.SliceSampler`, the sampler will reconstruct episode
+    boundaries from ``done`` signals, but worker batch boundaries are invisible
+    — consecutive frames in the buffer may belong to completely different
+    episodes.
+
+    A partial mitigation is ``set_truncated=True``, which marks every batch
+    boundary with a ``truncated`` (and therefore ``done``) signal.  This
+    prevents cross-episode slices but introduces artificial truncations that
+    value estimators must handle correctly.
+
+    ``trajs_per_batch`` is the recommended solution: it guarantees clean
+    episode boundaries in the buffer without artificial truncations.
+
+.. seealso::
+
+    - :class:`~torchrl.collectors.BaseCollector` for the full ``trajs_per_batch``
+      API, completeness guarantee, and batched-environment behaviour.
+    - :class:`~torchrl.data.SliceSampler` for configuring sub-sequence sampling
+      from the buffer.
+    - :ref:`The trajectory batching section <collectors_single>` in the
+      single-node collector docs for the non-replay-buffer usage
+      (padded ``(trajs, max_len)`` batches).
 
 Helper functions
 ----------------

--- a/docs/source/reference/collectors_single.rst
+++ b/docs/source/reference/collectors_single.rst
@@ -20,6 +20,8 @@ Single node data collectors
     MultiSyncCollector
     MultiAsyncCollector
 
+.. _collectors_single_traj:
+
 Trajectory batching
 -------------------
 
@@ -52,6 +54,13 @@ internally; it does **not** determine the output batch size when
         valid = batch[("collector", "mask")]  # (4, max_traj_len) bool
         loss = compute_loss(batch, valid)
         collector.update_policy_weights_()
+
+**Replay buffer integration**: when a ``replay_buffer`` is also provided,
+complete trajectories are written to the buffer as **flat 1-D sequences** (no
+padding) instead of being yielded.  This is the recommended pattern for
+off-policy training with :class:`~torchrl.data.SliceSampler`, especially
+with multi-process collectors where fixed-frame batches can silently mix
+episodes.  See :ref:`collectors_replay_trajs` for full details and examples.
 
 .. note::
     The following legacy names are also available for backward compatibility:
@@ -183,6 +192,39 @@ which truly decouples the data collection and training.
 
 Data collectors that have been started with `start()` should be shut down using
 :meth:`~torchrl.collectors.BaseCollector.async_shutdown`.
+
+.. tip::
+
+    For maximum throughput with trajectory-based training (e.g. recurrent
+    policies, decision transformers), combine ``start()`` with
+    ``trajs_per_batch`` and a :class:`~torchrl.data.SliceSampler`:
+
+    .. code-block:: python
+
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(100_000),
+            sampler=SliceSampler(slice_len=20, end_key=("next", "done")),
+            batch_size=256,
+            shared=True,
+        )
+        collector = MultiCollector(
+            [make_env] * 4,
+            policy,
+            replay_buffer=rb,
+            frames_per_batch=200,
+            total_frames=-1,
+            trajs_per_batch=8,
+            sync=False,
+        )
+        collector.start()
+        for step in range(train_steps):
+            batch = rb.sample()  # clean trajectory slices
+            # ...
+        collector.async_shutdown()
+
+    Each worker writes only **complete trajectories** to the buffer, so the
+    sampler never draws slices that cross episode boundaries.  See
+    :ref:`collectors_replay_trajs` for a full discussion.
 
 .. warning:: Running a collector asynchronously decouples the collection from training, which means that the training
     performance may be drastically different depending on the hardware, load and other factors (although it is generally

--- a/docs/source/reference/collectors_single.rst
+++ b/docs/source/reference/collectors_single.rst
@@ -203,7 +203,7 @@ Data collectors that have been started with `start()` should be shut down using
 
         rb = ReplayBuffer(
             storage=LazyTensorStorage(100_000),
-            sampler=SliceSampler(slice_len=20, end_key=("next", "done")),
+            sampler=SliceSampler(slice_len=32, end_key=("next", "done")),
             batch_size=256,
             shared=True,
         )

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -5680,22 +5680,61 @@ class TestTrajsPerBatchReplayBuffer:
         # SliceSampler returns flat slices of length slice_len
         assert sample.shape[0] == slice_len * num_trajs
 
-    def test_trajs_per_batch_multi_collector_rb_raises(self):
-        """Multi-process collectors raise NotImplementedError when both
-        trajs_per_batch and replay_buffer are provided."""
+    def test_trajs_per_batch_multi_collector_rb(self):
+        """Multi-process collectors populate the replay buffer with trajectory data
+        when both trajs_per_batch and replay_buffer are provided."""
         max_steps = 4
+        num_trajs = 2
         env_fn, policy = self._make_env_and_policy(max_steps)
         rb = ReplayBuffer(storage=LazyTensorStorage(200), shared=True)
-        with pytest.raises(NotImplementedError, match="trajs_per_batch"):
-            MultiSyncCollector(
-                [env_fn, env_fn],
-                policy,
-                replay_buffer=rb,
-                frames_per_batch=max_steps * 4,
-                total_frames=max_steps * 16,
-                trajs_per_batch=2,
-                cat_results="stack",
-            )
+        collector = MultiSyncCollector(
+            [env_fn, env_fn],
+            policy,
+            replay_buffer=rb,
+            frames_per_batch=max_steps * 4,
+            total_frames=max_steps * 16,
+            trajs_per_batch=num_trajs,
+            cat_results="stack",
+        )
+        try:
+            for _ in collector:
+                pass
+        finally:
+            collector.shutdown()
+
+        assert len(rb) > 0, "replay buffer must be non-empty"
+        sample = rb.sample(num_trajs)
+        assert ("collector", "traj_ids") in sample.keys(True)
+
+    def test_trajs_per_batch_multi_collector_rb_start(self):
+        """Multi-process collector start() mode fills the replay buffer with
+        trajectory data from all workers."""
+        max_steps = 4
+        num_trajs = 2
+        env_fn, policy = self._make_env_and_policy(max_steps)
+        rb = ReplayBuffer(storage=LazyTensorStorage(200), shared=True)
+        collector = MultiSyncCollector(
+            [env_fn, env_fn],
+            policy,
+            replay_buffer=rb,
+            frames_per_batch=max_steps * 4,
+            total_frames=-1,
+            trajs_per_batch=num_trajs,
+            cat_results="stack",
+        )
+        try:
+            collector.start()
+            deadline = time.time() + 30
+            while len(rb) < max_steps * num_trajs and time.time() < deadline:
+                time.sleep(0.05)
+        finally:
+            collector.shutdown()
+
+        assert (
+            len(rb) >= max_steps * num_trajs
+        ), f"replay buffer must have enough entries, got {len(rb)}"
+        sample = rb.sample(num_trajs)
+        assert ("collector", "traj_ids") in sample.keys(True)
 
     @pytest.mark.parametrize("with_rb", [False, True])
     def test_trajs_per_batch_batched_env_ndim2(self, with_rb):

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -5572,7 +5572,26 @@ class TestTrajsPerBatch:
 
 
 class TestTrajsPerBatchReplayBuffer:
-    """Tests for trajs_per_batch + ReplayBuffer integration."""
+    """Tests for trajs_per_batch + ReplayBuffer integration.
+
+    ``trajs_per_batch`` makes a collector yield (or write to a replay buffer)
+    only *complete* trajectories — i.e. episode segments whose last step has
+    ``("next", "done") == True``.  When combined with a replay buffer the
+    collector writes each trajectory as a **flat 1-D sequence** of valid
+    timesteps (no padding), which is directly compatible with
+    :class:`~torchrl.data.SliceSampler` using ``end_key=("next", "done")``.
+
+    The tests below cover:
+
+    * Single-process collector: sync iteration and ``start()`` async mode.
+    * Multi-process collectors (``MultiSyncCollector``, ``MultiAsyncCollector``):
+      both iteration and ``start()`` mode.
+    * Batched environments (``SerialEnv``): trajectory completeness and flat
+      1-D storage regardless of the environment batch shape.
+    * **Completeness guarantee**: every trajectory stored in the RB ends with
+      ``done=True`` — partial trajectories never leak into the buffer.
+    * **SliceSampler integration**: sampled slices respect episode boundaries.
+    """
 
     @staticmethod
     def _make_env_and_policy(max_steps=4):
@@ -5586,8 +5605,46 @@ class TestTrajsPerBatchReplayBuffer:
             probe.close(raise_if_closed=False)
         return env_fn, policy
 
+    @staticmethod
+    def _make_batched_env_fn(max_steps=4, num_envs=2):
+        """Return a factory that creates a SerialEnv with InitTracker."""
+
+        def env_fn():
+            return TransformedEnv(
+                CountingEnv(max_steps=max_steps),
+                Compose(StepCounter(max_steps), InitTracker()),
+            )
+
+        return lambda: SerialEnv(num_envs, env_fn)
+
+    @staticmethod
+    def _assert_rb_trajectories_complete(rb):
+        """Assert that every trajectory stored in *rb* ends with done=True.
+
+        Groups all stored timesteps by ``("collector", "traj_ids")`` and
+        checks that the last timestep of each trajectory has
+        ``("next", "done") == True``.  This is the core completeness
+        guarantee of ``trajs_per_batch``.
+        """
+        all_data = rb.storage[: len(rb)]
+        traj_ids = all_data[("collector", "traj_ids")]
+        done = all_data[("next", "done")]
+        unique_ids = traj_ids.unique()
+        assert len(unique_ids) > 0, "replay buffer has no trajectories"
+        for tid in unique_ids:
+            mask = traj_ids == tid
+            traj_done = done[mask]
+            assert traj_done[-1].any(), (
+                f"trajectory {tid.item()} does not end with done=True — "
+                "partial trajectory leaked into the replay buffer"
+            )
+
+    # ------------------------------------------------------------------
+    # Single-process collector tests
+    # ------------------------------------------------------------------
+
     def test_trajs_per_batch_replay_buffer_sync(self):
-        """Replay buffer receives trajectory-shaped batches, not raw frames."""
+        """Replay buffer receives complete trajectories as flat timesteps."""
         max_steps = 4
         num_trajs = 2
         env_fn, policy = self._make_env_and_policy(max_steps)
@@ -5612,11 +5669,11 @@ class TestTrajsPerBatchReplayBuffer:
         # each sampled entry is a single timestep.
         sample = rb.sample(num_trajs)
         assert sample.ndim == 1, "sampled entries should be individual timesteps (1-D)"
-        # Every stored step must carry a traj_id
         assert ("collector", "traj_ids") in sample.keys(True)
+        self._assert_rb_trajectories_complete(rb)
 
     def test_trajs_per_batch_replay_buffer_start_async(self):
-        """collector.start() fills the replay buffer with trajectory batches."""
+        """collector.start() fills the replay buffer with complete trajectories."""
         max_steps = 4
         num_trajs = 2
         env_fn, policy = self._make_env_and_policy(max_steps)
@@ -5645,28 +5702,31 @@ class TestTrajsPerBatchReplayBuffer:
         sample = rb.sample(num_trajs)
         assert sample.ndim == 1
         assert ("collector", "traj_ids") in sample.keys(True)
+        self._assert_rb_trajectories_complete(rb)
 
-    def test_trajs_per_batch_slice_sampler(self):
-        """SliceSampler samples contiguous slices from trajectory-shaped entries."""
-        max_steps = 8
-        num_trajs = 4
-        slice_len = 2
+    # ------------------------------------------------------------------
+    # Completeness guarantee: every RB trajectory ends with done=True
+    # ------------------------------------------------------------------
+
+    def test_trajs_per_batch_completeness_single(self):
+        """All trajectories in the RB are complete (single-process collector).
+
+        Fills the buffer with many trajectories and asserts every single one
+        ends with ``("next", "done") == True``.  No partial trajectory may
+        leak into the buffer — partials stay in the internal ``partial_trajs``
+        dict until the episode finishes.
+        """
+        max_steps = 5
+        num_trajs = 3
         env_fn, policy = self._make_env_and_policy(max_steps)
-        rb = ReplayBuffer(
-            storage=LazyTensorStorage(400),
-            sampler=SliceSampler(
-                slice_len=slice_len,
-                end_key=("next", "done"),
-                strict_length=False,
-            ),
-        )
+        rb = ReplayBuffer(storage=LazyTensorStorage(1000))
         env = env_fn()
         collector = Collector(
             env,
             policy,
             replay_buffer=rb,
-            frames_per_batch=max_steps * 3,
-            total_frames=max_steps * 16,
+            frames_per_batch=max_steps * 4,
+            total_frames=max_steps * 40,
             trajs_per_batch=num_trajs,
         )
         try:
@@ -5676,9 +5736,237 @@ class TestTrajsPerBatchReplayBuffer:
             env.close(raise_if_closed=False)
 
         assert len(rb) > 0
-        sample = rb.sample(slice_len * num_trajs)
-        # SliceSampler returns flat slices of length slice_len
-        assert sample.shape[0] == slice_len * num_trajs
+        self._assert_rb_trajectories_complete(rb)
+
+    def test_trajs_per_batch_completeness_batched_env(self):
+        """All trajectories in the RB are complete (batched env).
+
+        A batched env (SerialEnv with 3 sub-envs) produces interleaved steps
+        from multiple environments.  ``_traj_ingest`` flattens and groups by
+        ``traj_id``, so each trajectory is still written as a flat 1-D
+        sequence.  Verify that every one ends with done=True.
+        """
+        max_steps = 4
+        num_envs = 3
+        num_trajs = 4
+
+        def env_fn():
+            return TransformedEnv(
+                CountingEnv(max_steps=max_steps),
+                Compose(StepCounter(max_steps), InitTracker()),
+            )
+
+        batched_env = SerialEnv(num_envs, env_fn)
+        try:
+            policy = RandomPolicy(batched_env.action_spec)
+            rb = ReplayBuffer(storage=LazyTensorStorage(500))
+            collector = Collector(
+                batched_env,
+                policy,
+                replay_buffer=rb,
+                frames_per_batch=max_steps * num_envs * 3,
+                total_frames=max_steps * num_envs * 20,
+                trajs_per_batch=num_trajs,
+            )
+            try:
+                list(collector)
+            finally:
+                collector.shutdown()
+        finally:
+            batched_env.close(raise_if_closed=False)
+
+        assert len(rb) > 0, "replay buffer must be populated"
+        self._assert_rb_trajectories_complete(rb)
+
+    def test_trajs_per_batch_completeness_multi_collector(self):
+        """All trajectories in the RB are complete (multi-process collector).
+
+        Two workers each run their own ``_iter_by_trajectories`` loop and
+        write to the shared replay buffer.  Verify every trajectory stored
+        is complete.
+        """
+        max_steps = 4
+        num_trajs = 2
+        env_fn, policy = self._make_env_and_policy(max_steps)
+        rb = ReplayBuffer(storage=LazyTensorStorage(400), shared=True)
+        collector = MultiSyncCollector(
+            [env_fn, env_fn],
+            policy,
+            replay_buffer=rb,
+            frames_per_batch=max_steps * 4,
+            total_frames=max_steps * 24,
+            trajs_per_batch=num_trajs,
+            cat_results="stack",
+        )
+        try:
+            for _ in collector:
+                pass
+        finally:
+            collector.shutdown()
+
+        assert len(rb) > 0
+        self._assert_rb_trajectories_complete(rb)
+
+    # ------------------------------------------------------------------
+    # Flat 1-D storage: batched envs write flat sequences
+    # ------------------------------------------------------------------
+
+    def test_trajs_per_batch_flat_storage_batched_env(self):
+        """Batched env + trajs_per_batch writes flat 1-D sequences to the RB.
+
+        Even though the environment has batch_size > 1, trajectories are
+        disassembled by ``_traj_ingest`` (which flattens and groups by
+        ``traj_id``) and written individually.  The replay buffer storage
+        should be 1-D (ndim=1) — each entry is a single timestep.
+        """
+        max_steps = 4
+        num_envs = 2
+        num_trajs = 4
+
+        def env_fn():
+            return TransformedEnv(
+                CountingEnv(max_steps=max_steps),
+                Compose(StepCounter(max_steps), InitTracker()),
+            )
+
+        batched_env = SerialEnv(num_envs, env_fn)
+        try:
+            policy = RandomPolicy(batched_env.action_spec)
+            rb = ReplayBuffer(storage=LazyTensorStorage(400))
+            collector = Collector(
+                batched_env,
+                policy,
+                replay_buffer=rb,
+                frames_per_batch=max_steps * num_envs * 3,
+                total_frames=max_steps * num_envs * 12,
+                trajs_per_batch=num_trajs,
+            )
+            try:
+                list(collector)
+            finally:
+                collector.shutdown()
+        finally:
+            batched_env.close(raise_if_closed=False)
+
+        assert len(rb) > 0
+        # Storage is 1-D: each entry is one timestep, not an env-batch slice
+        sample = rb.sample(4)
+        assert (
+            sample.ndim == 1
+        ), f"Expected 1-D storage (flat timesteps) but got ndim={sample.ndim}"
+        assert ("collector", "traj_ids") in sample.keys(True)
+
+    # ------------------------------------------------------------------
+    # SliceSampler integration
+    # ------------------------------------------------------------------
+
+    def test_trajs_per_batch_slice_sampler(self):
+        """SliceSampler samples contiguous slices from trajectory-filled buffer."""
+        max_steps = 8
+        num_trajs = 4
+        slice_len = 3
+        env_fn, policy = self._make_env_and_policy(max_steps)
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(800),
+            sampler=SliceSampler(
+                slice_len=slice_len,
+                end_key=("next", "done"),
+                strict_length=True,
+            ),
+        )
+        env = env_fn()
+        collector = Collector(
+            env,
+            policy,
+            replay_buffer=rb,
+            frames_per_batch=max_steps * 3,
+            total_frames=max_steps * 30,
+            trajs_per_batch=num_trajs,
+        )
+        try:
+            list(collector)
+        finally:
+            collector.shutdown()
+            env.close(raise_if_closed=False)
+
+        assert len(rb) > 0
+        num_slices = 4
+        sample = rb.sample(slice_len * num_slices)
+        assert sample.shape[0] == slice_len * num_slices
+        # Verify contiguity: within each slice, traj_ids are constant and
+        # step counts are monotonically increasing
+        sample_reshaped = sample.reshape(num_slices, slice_len)
+        for i in range(num_slices):
+            slice_data = sample_reshaped[i]
+            tids = slice_data[("collector", "traj_ids")]
+            assert (
+                tids == tids[0]
+            ).all(), f"slice {i}: traj_ids should be constant within a slice"
+
+    def test_trajs_per_batch_slice_sampler_batched_env(self):
+        """SliceSampler + batched env: slices respect episode boundaries.
+
+        Fills a buffer from a batched environment using ``trajs_per_batch``,
+        then samples slices and verifies that no slice crosses an episode
+        boundary (i.e. ``done=True`` only appears at the last position of a
+        slice, or not at all).
+        """
+        max_steps = 6
+        num_envs = 2
+        num_trajs = 4
+        slice_len = 3
+
+        def env_fn():
+            return TransformedEnv(
+                CountingEnv(max_steps=max_steps),
+                Compose(StepCounter(max_steps), InitTracker()),
+            )
+
+        batched_env = SerialEnv(num_envs, env_fn)
+        try:
+            policy = RandomPolicy(batched_env.action_spec)
+            rb = ReplayBuffer(
+                storage=LazyTensorStorage(600),
+                sampler=SliceSampler(
+                    slice_len=slice_len,
+                    end_key=("next", "done"),
+                    strict_length=True,
+                ),
+            )
+            collector = Collector(
+                batched_env,
+                policy,
+                replay_buffer=rb,
+                frames_per_batch=max_steps * num_envs * 3,
+                total_frames=max_steps * num_envs * 20,
+                trajs_per_batch=num_trajs,
+            )
+            try:
+                list(collector)
+            finally:
+                collector.shutdown()
+        finally:
+            batched_env.close(raise_if_closed=False)
+
+        assert len(rb) > 0
+        num_slices = 6
+        sample = rb.sample(slice_len * num_slices)
+        sample_reshaped = sample.reshape(num_slices, slice_len)
+        for i in range(num_slices):
+            slice_data = sample_reshaped[i]
+            done = slice_data[("next", "done")].squeeze(-1)
+            # done=True should only appear at the last step or not at all
+            if done.any():
+                # Find position of the first done=True
+                done_pos = done.nonzero(as_tuple=True)[0]
+                assert done_pos[-1] == slice_len - 1, (
+                    f"slice {i}: done=True at position {done_pos.tolist()} "
+                    f"but expected only at position {slice_len - 1}"
+                )
+
+    # ------------------------------------------------------------------
+    # Multi-process collector tests
+    # ------------------------------------------------------------------
 
     def test_trajs_per_batch_multi_collector_rb(self):
         """Multi-process collectors populate the replay buffer with trajectory data
@@ -5705,6 +5993,7 @@ class TestTrajsPerBatchReplayBuffer:
         assert len(rb) > 0, "replay buffer must be non-empty"
         sample = rb.sample(num_trajs)
         assert ("collector", "traj_ids") in sample.keys(True)
+        self._assert_rb_trajectories_complete(rb)
 
     def test_trajs_per_batch_multi_collector_rb_start(self):
         """Multi-process collector start() mode fills the replay buffer with
@@ -5735,6 +6024,88 @@ class TestTrajsPerBatchReplayBuffer:
         ), f"replay buffer must have enough entries, got {len(rb)}"
         sample = rb.sample(num_trajs)
         assert ("collector", "traj_ids") in sample.keys(True)
+        self._assert_rb_trajectories_complete(rb)
+
+    def test_trajs_per_batch_multi_collector_batched_env_rb(self):
+        """Multi-process + batched env + trajs_per_batch + replay buffer.
+
+        Each worker runs a SerialEnv (2 sub-envs).  Verify that:
+        1. The replay buffer is populated with flat 1-D timesteps.
+        2. Every trajectory in the buffer is complete (ends with done=True).
+        3. traj_ids are present.
+        """
+        max_steps = 4
+        num_envs = 2
+        num_trajs = 2
+
+        batched_env_fn = EnvCreator(
+            lambda: SerialEnv(
+                num_envs,
+                EnvCreator(
+                    lambda: TransformedEnv(
+                        CountingEnv(max_steps=max_steps),
+                        Compose(StepCounter(max_steps), InitTracker()),
+                    )
+                ),
+            )
+        )
+        probe = batched_env_fn()
+        policy = RandomPolicy(probe.action_spec)
+        probe.close(raise_if_closed=False)
+
+        rb = ReplayBuffer(storage=LazyTensorStorage(400), shared=True)
+        collector = MultiSyncCollector(
+            [batched_env_fn, batched_env_fn],
+            policy,
+            replay_buffer=rb,
+            frames_per_batch=max_steps * num_envs * 4,
+            total_frames=max_steps * num_envs * 20,
+            trajs_per_batch=num_trajs,
+            cat_results="stack",
+        )
+        try:
+            for _ in collector:
+                pass
+        finally:
+            collector.shutdown()
+
+        assert len(rb) > 0, "replay buffer must be populated"
+        sample = rb.sample(4)
+        assert sample.ndim == 1, "storage should be flat 1-D timesteps"
+        assert ("collector", "traj_ids") in sample.keys(True)
+        self._assert_rb_trajectories_complete(rb)
+
+    def test_trajs_per_batch_multi_async_collector_rb(self):
+        """MultiAsyncCollector + trajs_per_batch + replay buffer.
+
+        Same guarantees as sync: buffer populated, trajectories complete.
+        """
+        max_steps = 4
+        num_trajs = 2
+        env_fn, policy = self._make_env_and_policy(max_steps)
+        rb = ReplayBuffer(storage=LazyTensorStorage(400), shared=True)
+        collector = MultiAsyncCollector(
+            [env_fn, env_fn],
+            policy,
+            replay_buffer=rb,
+            frames_per_batch=max_steps * 4,
+            total_frames=max_steps * 24,
+            trajs_per_batch=num_trajs,
+            cat_results="stack",
+        )
+        try:
+            for _ in collector:
+                pass
+        finally:
+            collector.shutdown()
+
+        assert len(rb) > 0, "replay buffer must be non-empty"
+        assert ("collector", "traj_ids") in rb.sample(2).keys(True)
+        self._assert_rb_trajectories_complete(rb)
+
+    # ------------------------------------------------------------------
+    # Batched env: trajectory completeness (yielded batches, not RB)
+    # ------------------------------------------------------------------
 
     @pytest.mark.parametrize("with_rb", [False, True])
     def test_trajs_per_batch_batched_env(self, with_rb):
@@ -5791,6 +6162,7 @@ class TestTrajsPerBatchReplayBuffer:
         if with_rb:
             assert len(rb) > 0, "replay buffer must be populated"
             assert ("collector", "traj_ids") in rb.sample(1).keys(True)
+            self._assert_rb_trajectories_complete(rb)
 
     @pytest.mark.parametrize("with_rb", [False, True])
     def test_trajs_per_batch_multi_async_ndim2(self, with_rb):

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -5737,12 +5737,13 @@ class TestTrajsPerBatchReplayBuffer:
         assert ("collector", "traj_ids") in sample.keys(True)
 
     @pytest.mark.parametrize("with_rb", [False, True])
-    def test_trajs_per_batch_batched_env_ndim2(self, with_rb):
-        """SerialEnv (batched) + trajs_per_batch, with and without ndim=2 replay buffer.
+    def test_trajs_per_batch_batched_env(self, with_rb):
+        """SerialEnv (batched) + trajs_per_batch, with and without replay buffer.
 
         Verifies trajectory completeness via InitTracker (is_init=True at start)
         and done=True at the last valid step (per ("collector", "mask")).
-        When with_rb=True, also checks the ndim=2 replay buffer is populated.
+        When with_rb=True, trajectories are written as flat sequences to a 1-D
+        replay buffer (ndim=2 is incompatible with variable-length trajectories).
         """
         max_steps = 4
         num_envs = 2
@@ -5757,11 +5758,7 @@ class TestTrajsPerBatchReplayBuffer:
         batched_env = SerialEnv(num_envs, env_fn)
         try:
             policy = RandomPolicy(batched_env.action_spec)
-            rb = (
-                ReplayBuffer(storage=LazyTensorStorage(400, ndim=2))
-                if with_rb
-                else None
-            )
+            rb = ReplayBuffer(storage=LazyTensorStorage(400)) if with_rb else None
             collector = Collector(
                 batched_env,
                 policy,
@@ -5792,7 +5789,7 @@ class TestTrajsPerBatchReplayBuffer:
             batched_env.close(raise_if_closed=False)
 
         if with_rb:
-            assert len(rb) > 0, "ndim=2 replay buffer must be populated"
+            assert len(rb) > 0, "replay buffer must be populated"
             assert ("collector", "traj_ids") in rb.sample(1).keys(True)
 
     @pytest.mark.parametrize("with_rb", [False, True])

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -38,6 +38,7 @@ from torchrl.data import (
     LazyTensorStorage,
     RandomSampler,
     RayReplayBuffer,
+    ReplayBuffer,
     RoundRobinWriter,
     SamplerWithoutReplacement,
 )
@@ -972,6 +973,71 @@ class TestRayCollector(DistributedCollectorBase):
                 collector.update_policy_weights_(weights)
         finally:
             collector.shutdown()
+
+
+@pytest.mark.skipif(
+    not _has_ray, reason="Ray not found. Ray may be badly configured or not installed."
+)
+class TestRayTrajsPerBatch:
+    """Tests for trajs_per_batch + replay_buffer on RayCollector."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def start_ray(self):
+        import ray
+
+        ray.shutdown()
+        ray_init_config = dict(DEFAULT_RAY_INIT_CONFIG)
+        ray_init_config["runtime_env"] = {
+            "working_dir": os.path.dirname(__file__),
+            "env_vars": {"PYTHONPATH": os.path.dirname(__file__)},
+        }
+        ray.init(**ray_init_config)
+        yield
+        ray.shutdown()
+
+    def test_ray_trajs_per_batch_replay_buffer(self):
+        """RayCollector with trajs_per_batch populates a local replay buffer."""
+        from torchrl.envs import StepCounter, TransformedEnv
+
+        max_steps = 4
+        num_trajs = 2
+
+        def env_fn():
+            return TransformedEnv(
+                CountingEnv(max_steps=max_steps), StepCounter(max_steps)
+            )
+
+        probe = env_fn()
+        policy = RandomPolicy(probe.action_spec)
+        probe.close(raise_if_closed=False)
+
+        rb = ReplayBuffer(storage=LazyTensorStorage(200))
+        ray_init_config = dict(DEFAULT_RAY_INIT_CONFIG)
+        ray_init_config["runtime_env"] = {
+            "working_dir": os.path.dirname(__file__),
+            "env_vars": {"PYTHONPATH": os.path.dirname(__file__)},
+        }
+        remote_configs = {"num_cpus": 1, "num_gpus": 0.0}
+        collector = RayCollector(
+            [env_fn, env_fn],
+            policy,
+            collector_class=Collector,
+            replay_buffer=rb,
+            frames_per_batch=max_steps * 4,
+            total_frames=max_steps * 16,
+            trajs_per_batch=num_trajs,
+            ray_init_config=ray_init_config,
+            remote_configs=remote_configs,
+        )
+        try:
+            for _ in collector:
+                pass
+        finally:
+            collector.shutdown()
+
+        assert len(rb) > 0, "replay buffer must be non-empty"
+        sample = rb.sample(num_trajs)
+        assert ("collector", "traj_ids") in sample.keys(True)
 
 
 if __name__ == "__main__":

--- a/torchrl/collectors/_base.py
+++ b/torchrl/collectors/_base.py
@@ -1029,27 +1029,20 @@ class BaseCollector(IterableDataset, metaclass=abc.ABCMeta):
                 if batch is None:
                     continue
                 _traj_ingest(batch, partial_trajs, complete_trajs)
-                while len(complete_trajs) >= self.trajs_per_batch:
-                    traj_batch = _traj_emit(complete_trajs, self.trajs_per_batch)
-                    if has_rb:
-                        rb_ndim = getattr(getattr(rb, "_storage", None), "ndim", 1)
-                        if rb_ndim > 1:
-                            # Multi-dim storage (e.g. ndim=2 for batched envs):
-                            # store the full padded [N, max_len] batch so the
-                            # storage shape is preserved. The ("collector", "mask")
-                            # field marks valid steps within each row.
-                            rb.extend(traj_batch)
-                        else:
-                            # 1-D storage: strip padding and store each trajectory
-                            # as a flat sequence of valid timesteps so that
-                            # slice-oriented samplers (e.g. SliceSampler) work
-                            # correctly with done-signal boundaries.
-                            mask = traj_batch.get(("collector", "mask"))
-                            for i in range(traj_batch.shape[0]):
-                                valid_len = int(mask[i].sum().item())
-                                rb.extend(traj_batch[i, :valid_len])
-                        yield
-                    else:
+                if has_rb:
+                    # Write each complete trajectory to the replay buffer
+                    # immediately as a flat sequence — no padding, no
+                    # accumulation to trajs_per_batch.  This avoids the
+                    # pad-then-unpad round-trip and works with any storage
+                    # ndim (variable-length trajectories cannot fill a
+                    # fixed second dimension reliably).
+                    while complete_trajs:
+                        traj = complete_trajs.pop(0)
+                        rb.extend(traj)
+                    yield
+                else:
+                    while len(complete_trajs) >= self.trajs_per_batch:
+                        traj_batch = _traj_emit(complete_trajs, self.trajs_per_batch)
                         yield traj_batch
         finally:
             if has_rb:

--- a/torchrl/collectors/_base.py
+++ b/torchrl/collectors/_base.py
@@ -176,10 +176,10 @@ class BaseCollector(IterableDataset, metaclass=abc.ABCMeta):
                 collector.start()   # fills rb with [32, max_len] trajectory batches
 
             .. note::
-                ``trajs_per_batch`` combined with ``replay_buffer`` is only
-                supported for single-process collectors. Multi-process collectors
-                write frames directly to a shared buffer at the worker level and
-                cannot reassemble trajectories in the main process.
+                ``trajs_per_batch`` combined with ``replay_buffer`` is supported
+                for both single-process and multi-process collectors. For
+                multi-process collectors, trajectory assembly is delegated to
+                each worker's inner collector.
 
             Defaults to ``None`` (fixed-frame batches).
     """
@@ -1001,20 +1001,17 @@ class BaseCollector(IterableDataset, metaclass=abc.ABCMeta):
     def _iter_by_trajectories(self) -> Iterator[TensorDictBase]:
         """Yield padded batches of exactly ``trajs_per_batch`` complete trajectories.
 
-        When a replay buffer is configured on a single-process collector, each
-        complete trajectory is stored as a **flat sequence of valid timesteps**
-        (padding stripped via ``("collector", "mask")``), and this method yields
-        ``None`` each time — matching the behaviour of :meth:`iterator` in
-        replay-buffer mode.  Flat storage makes the buffer directly compatible
-        with :class:`~torchrl.data.SliceSampler` using
+        When a replay buffer is configured, each complete trajectory is stored
+        as a **flat sequence of valid timesteps** (padding stripped via
+        ``("collector", "mask")``), and this method yields ``None`` each time —
+        matching the behaviour of :meth:`iterator` in replay-buffer mode.
+        Flat storage makes the buffer directly compatible with
+        :class:`~torchrl.data.SliceSampler` using
         ``end_key=("next", "done")``.
 
-        .. note::
-            Replay buffer integration with ``trajs_per_batch`` is only supported
-            for single-process collectors (:class:`~torchrl.collectors.Collector`).
-            Multi-process collectors write frames directly to a shared replay
-            buffer at the worker level and cannot reassemble trajectories in the
-            main process.
+        For multi-process collectors, trajectory assembly is delegated to each
+        worker's inner collector, which calls this method independently and
+        writes complete trajectories to the shared replay buffer.
         """
         partial_trajs: dict[int, list] = {}
         complete_trajs: list = []

--- a/torchrl/collectors/_base.py
+++ b/torchrl/collectors/_base.py
@@ -151,13 +151,49 @@ class BaseCollector(IterableDataset, metaclass=abc.ABCMeta):
             how often the environment is polled internally, but the output
             batch size is determined by ``trajs_per_batch``.
 
-            When combined with a ``replay_buffer`` on a single-process
-            :class:`~torchrl.collectors.Collector`, trajectory batches are
-            written to the replay buffer instead of raw frames. This integrates
-            naturally with :class:`~torchrl.data.SliceSampler` — pass
-            ``end_key=("next", "done")`` to sample contiguous sub-sequences
-            that respect episode boundaries. Async collection via
-            :meth:`~torchrl.collectors.Collector.start` is supported:
+            **Replay buffer integration**
+
+            When combined with a ``replay_buffer``, each complete trajectory is
+            written to the buffer as a **flat 1-D sequence** of valid timesteps
+            (no padding, no accumulation to ``trajs_per_batch``).  The method
+            yields ``None`` on every write — matching the standard replay-buffer
+            collection convention.  This flat storage is directly compatible
+            with :class:`~torchrl.data.SliceSampler` using
+            ``end_key=("next", "done")``.
+
+            .. important::
+                When using a **multi-process** collector with a shared replay
+                buffer and a :class:`~torchrl.data.SliceSampler`, setting
+                ``trajs_per_batch`` is strongly recommended. Without it,
+                different workers write batches independently and adjacent
+                frames in the buffer can come from unrelated episodes without
+                an intervening ``done`` signal, causing the sampler to draw
+                slices that cross trajectory boundaries.
+
+            **Completeness guarantee**: only trajectories whose last step has
+            ``("next", "done") == True`` are written to the buffer.  Partial
+            trajectories (episodes still in flight) are held internally until
+            the episode terminates.  This means every trajectory in the buffer
+            is guaranteed to be a complete episode segment.
+
+            **Batched environments**: when the environment has a batch size > 1
+            (e.g. :class:`~torchrl.envs.SerialEnv`), steps are disassembled by
+            ``traj_id`` and each trajectory is written individually as a flat
+            sequence.  The buffer storage should use ``ndim=1`` — ``ndim=2``
+            is incompatible because variable-length trajectories cannot fill a
+            fixed second dimension.
+
+            **Multi-process and distributed collectors**: ``trajs_per_batch``
+            combined with ``replay_buffer`` is supported for
+            :class:`~torchrl.collectors.MultiSyncCollector`,
+            :class:`~torchrl.collectors.MultiAsyncCollector`,
+            :class:`~torchrl.collectors.distributed.RayCollector`, and
+            :class:`~torchrl.collectors.distributed.RPCDataCollector`.
+            Trajectory assembly is delegated to each worker's inner collector,
+            which calls :meth:`_iter_by_trajectories` independently and writes
+            complete trajectories to the shared replay buffer.  Both the
+            iteration pattern (``for data in collector``) and the async
+            ``start()`` pattern are supported.
 
             .. code-block:: python
 
@@ -166,20 +202,14 @@ class BaseCollector(IterableDataset, metaclass=abc.ABCMeta):
                     sampler=SliceSampler(slice_len=16, end_key=("next", "done")),
                     shared=True,
                 )
-                collector = Collector(
-                    env, policy,
+                collector = MultiSyncCollector(
+                    [env_fn] * 4, policy,
                     replay_buffer=rb,
                     frames_per_batch=200,
                     total_frames=-1,
                     trajs_per_batch=32,
                 )
-                collector.start()   # fills rb with [32, max_len] trajectory batches
-
-            .. note::
-                ``trajs_per_batch`` combined with ``replay_buffer`` is supported
-                for both single-process and multi-process collectors. For
-                multi-process collectors, trajectory assembly is delegated to
-                each worker's inner collector.
+                collector.start()  # workers fill rb with complete trajectories
 
             Defaults to ``None`` (fixed-frame batches).
     """
@@ -999,19 +1029,38 @@ class BaseCollector(IterableDataset, metaclass=abc.ABCMeta):
             raise
 
     def _iter_by_trajectories(self) -> Iterator[TensorDictBase]:
-        """Yield padded batches of exactly ``trajs_per_batch`` complete trajectories.
+        """Yield complete trajectories, either as padded batches or into a replay buffer.
 
-        When a replay buffer is configured, each complete trajectory is stored
-        as a **flat sequence of valid timesteps** (padding stripped via
-        ``("collector", "mask")``), and this method yields ``None`` each time —
-        matching the behaviour of :meth:`iterator` in replay-buffer mode.
-        Flat storage makes the buffer directly compatible with
+        **Without a replay buffer** (the default when iterating directly):
+        accumulates complete trajectories and yields zero-padded batches of
+        shape ``(trajs_per_batch, max_traj_len)`` with a
+        ``("collector", "mask")`` boolean field marking valid timesteps.
+
+        **With a replay buffer**: each complete trajectory is written to the
+        buffer immediately as a **flat 1-D sequence** of valid timesteps — no
+        padding, no accumulation to ``trajs_per_batch``.  The method yields
+        ``None`` on every write, matching the standard replay-buffer collection
+        convention.  This flat storage is directly compatible with
         :class:`~torchrl.data.SliceSampler` using
         ``end_key=("next", "done")``.
 
-        For multi-process collectors, trajectory assembly is delegated to each
-        worker's inner collector, which calls this method independently and
-        writes complete trajectories to the shared replay buffer.
+        **Completeness guarantee**: a trajectory is considered complete when
+        its last step carries ``("next", "done") == True`` (which equals
+        ``terminated | truncated``).  Partial trajectories (episodes still in
+        flight) are held in the internal ``partial_trajs`` dict and never
+        written to the buffer or yielded.
+
+        **Batched environments**: when the environment has ``batch_size > 1``,
+        :func:`_traj_ingest` flattens the batch and groups steps by
+        ``("collector", "traj_ids")``, so each trajectory is assembled and
+        written individually regardless of the environment batch shape.
+
+        **Multi-process / distributed collectors**: trajectory assembly is
+        delegated to each worker's inner collector.  The multi-collector
+        redirects ``trajs_per_batch`` to workers (nulling it on itself to
+        avoid an infinite loop in ``__iter__``), and each worker calls this
+        method independently to write complete trajectories to the shared
+        replay buffer.
         """
         partial_trajs: dict[int, list] = {}
         complete_trajs: list = []

--- a/torchrl/collectors/_multi_base.py
+++ b/torchrl/collectors/_multi_base.py
@@ -382,6 +382,7 @@ class MultiCollector(BaseCollector, metaclass=_MultiCollectorMeta):
         self.closed = True
         self.worker_idx = worker_idx
         self.trajs_per_batch = trajs_per_batch
+        self._worker_trajs_per_batch = None
 
         # Set up workers and environment functions
         create_env_fn, total_frames_per_batch = self._setup_workers_and_env_fns(
@@ -859,13 +860,14 @@ class MultiCollector(BaseCollector, metaclass=_MultiCollectorMeta):
         if self.replay_buffer is None:
             return
         if getattr(self, "trajs_per_batch", None) is not None:
-            raise NotImplementedError(
-                "trajs_per_batch is not supported together with replay_buffer on "
-                "multi-process collectors. Multi-process collectors write frames "
-                "directly to a shared replay buffer at the worker level, so "
-                "trajectory reassembly cannot be performed in the main process. "
-                "Use a single-process Collector instead."
-            )
+            # Trajectory assembly will happen at the worker level: each worker's
+            # inner Collector uses _iter_by_trajectories() to assemble complete
+            # trajectories and write them to the shared replay buffer.
+            # Null out trajs_per_batch on the multi-collector so that __iter__
+            # routes to self.iterator() directly (not _iter_by_trajectories,
+            # which would spin forever on the None yields from the RB path).
+            self._worker_trajs_per_batch = self.trajs_per_batch
+            self.trajs_per_batch = None
         is_init = hasattr(self.replay_buffer, "_storage") and getattr(
             self.replay_buffer._storage, "initialized", True
         )
@@ -1170,6 +1172,7 @@ class MultiCollector(BaseCollector, metaclass=_MultiCollectorMeta):
                     "worker_idx": i,  # Worker index for queue-based weight distribution
                     "init_random_frames": self.init_random_frames,
                     "profile_config": self._profile_config,
+                    "trajs_per_batch": self._worker_trajs_per_batch,
                 }
                 proc = _ProcessNoWarnCtx(
                     target=_main_async_collector,

--- a/torchrl/collectors/_multi_base.py
+++ b/torchrl/collectors/_multi_base.py
@@ -249,6 +249,27 @@ class MultiCollector(BaseCollector, metaclass=_MultiCollectorMeta):
             a rollout is reached. If no ``"truncated"`` key is found, an exception is raised.
             Truncated keys can be set through ``env.add_truncated_keys``.
             Defaults to ``False``.
+        trajs_per_batch (int, optional): When set together with ``replay_buffer``,
+            trajectory assembly is delegated to each worker's inner
+            :class:`~torchrl.collectors.Collector`.  Each worker calls
+            :meth:`~torchrl.collectors.BaseCollector._iter_by_trajectories`
+            independently and writes **complete trajectories** (episodes whose
+            last step has ``("next", "done") == True``) to the shared replay
+            buffer as flat 1-D sequences — no padding, no accumulation.
+
+            When set *without* ``replay_buffer``, each worker assembles
+            trajectories and the multi-collector yields zero-padded batches
+            of shape ``(trajs_per_batch, max_traj_len)`` with a
+            ``("collector", "mask")`` boolean field.
+
+            Both the iteration pattern (``for data in collector``) and the
+            async ``start()`` pattern are supported.
+
+            Defaults to ``None`` (fixed-frame batches).
+
+            See :class:`~torchrl.collectors.BaseCollector` for the full
+            description of the completeness guarantee and replay-buffer
+            storage contract.
         use_buffers (bool, optional): if ``True``, a buffer will be used to stack the data.
             This isn't compatible with environments with dynamic specs. Defaults to ``True``
             for envs without dynamic specs, ``False`` for others.
@@ -859,6 +880,30 @@ class MultiCollector(BaseCollector, metaclass=_MultiCollectorMeta):
     def _check_replay_buffer_init(self):
         if self.replay_buffer is None:
             return
+
+        # Warn when a SliceSampler is used without trajs_per_batch: workers
+        # write batches independently so adjacent frames in the buffer can
+        # come from different episodes without an intervening done signal.
+        from torchrl.data.replay_buffers.samplers import SliceSampler
+
+        if (
+            getattr(self, "trajs_per_batch", None) is None
+            and isinstance(getattr(self.replay_buffer, "_sampler", None), SliceSampler)
+            and not self.set_truncated
+        ):
+            warnings.warn(
+                "A SliceSampler is used with a multi-process collector but "
+                "trajs_per_batch is not set and set_truncated is False. "
+                "Adjacent frames in the replay buffer may come from different "
+                "workers and different episodes, causing SliceSampler to "
+                "sample slices that cross trajectory boundaries. "
+                "Consider setting trajs_per_batch to write only complete "
+                "trajectories, or set_truncated=True to mark batch "
+                "boundaries (note: this introduces artificial truncations).",
+                category=UserWarning,
+                stacklevel=2,
+            )
+
         if getattr(self, "trajs_per_batch", None) is not None:
             # Trajectory assembly will happen at the worker level: each worker's
             # inner Collector uses _iter_by_trajectories() to assemble complete

--- a/torchrl/collectors/_runner.py
+++ b/torchrl/collectors/_runner.py
@@ -188,6 +188,7 @@ def _main_async_collector(
     worker_idx: int | None = None,
     init_random_frames: int | None = None,
     profile_config: ProfileConfig | None = None,
+    trajs_per_batch: int | None = None,
 ) -> None:
     if collector_class is None:
         collector_class = Collector
@@ -211,7 +212,10 @@ def _main_async_collector(
         init_random_frames if init_random_frames is not None else 0
     )
     try:
-        collector_class._ignore_rb = extend_buffer
+        # When trajs_per_batch is set, _iter_by_trajectories() handles RB writes
+        # (with proper padding stripping for 1-D storage). Set _ignore_rb=False so
+        # it detects the RB. When trajs_per_batch is None, keep existing behavior.
+        collector_class._ignore_rb = extend_buffer if trajs_per_batch is None else False
         inner_collector = collector_class(
             create_env_fn,
             create_env_kwargs=create_env_kwargs,
@@ -245,6 +249,7 @@ def _main_async_collector(
             # init_random_frames is passed; inner collector will use _should_use_random_frames()
             # which checks replay_buffer.write_count when replay_buffer is provided
             init_random_frames=init_random_frames,
+            trajs_per_batch=trajs_per_batch,
         )
         # Set up weight receivers for worker process using the standard register_scheme_receiver API.
         # This properly initializes the schemes on the receiver side and stores them in _receiver_schemes.
@@ -441,7 +446,7 @@ def _main_async_collector(
                 continue
 
             if replay_buffer is not None:
-                if extend_buffer:
+                if extend_buffer and next_data is not None:
                     next_data.names = None
                     replay_buffer.extend(next_data)
 

--- a/torchrl/collectors/distributed/ray.py
+++ b/torchrl/collectors/distributed/ray.py
@@ -288,6 +288,16 @@ class RayCollector(BaseCollector):
             in :class:`~torchrl.envs.EnvCreator`. This is useful for multiprocessed settings where shared memory
             needs to be managed, but Ray has its own object storage mechanism, so this is typically not needed.
             Defaults to ``False``.
+        trajs_per_batch (int, optional): When set, each remote collector
+            assembles complete trajectories (episodes ending with
+            ``("next", "done") == True``) before writing them to the replay
+            buffer as flat 1-D sequences.  Passed through to
+            ``collector_kwargs`` so that each worker's inner collector calls
+            :meth:`~torchrl.collectors.BaseCollector._iter_by_trajectories`.
+
+            See :class:`~torchrl.collectors.BaseCollector` for the full
+            description of the completeness guarantee and storage contract.
+            Defaults to ``None``.
 
     Examples:
         >>> from torch import nn

--- a/torchrl/collectors/distributed/ray.py
+++ b/torchrl/collectors/distributed/ray.py
@@ -356,6 +356,7 @@ class RayCollector(BaseCollector):
         weight_recv_schemes: dict[str, WeightSyncScheme] | None = None,
         use_env_creator: bool = False,
         no_cuda_sync: bool | None = None,
+        trajs_per_batch: int | None = None,
     ):
         self.frames_per_batch = frames_per_batch
         if remote_configs is None:
@@ -374,6 +375,12 @@ class RayCollector(BaseCollector):
                     ck.setdefault("replay_buffer", replay_buffer)
                     for ck in collector_kwargs
                 ]
+        if trajs_per_batch is not None:
+            if isinstance(collector_kwargs, dict):
+                collector_kwargs.setdefault("trajs_per_batch", trajs_per_batch)
+            else:
+                for ck in collector_kwargs:
+                    ck.setdefault("trajs_per_batch", trajs_per_batch)
 
         # Make sure input parameters are consistent
         def check_consistency_with_num_collectors(param, param_name, num_collectors):
@@ -938,11 +945,14 @@ class RayCollector(BaseCollector):
     def _run_collection_loop(self):
         """Runs the collection loop in a background thread."""
         try:
-            for _ in self.iterator():
+            for data in self.iterator():
                 if self._stop_event.is_set():
                     break
                 # When RayReplayBuffer is configured, sub-collectors write directly
-                # to the buffer and data will be None. Otherwise, data contains rollouts.
+                # to the buffer and data will be None. Otherwise, write returned
+                # data (e.g. trajectory batches) to the local replay buffer.
+                if self.replay_buffer is not None and data is not None:
+                    self.replay_buffer.extend(data)
         except Exception as e:
             torchrl_logger.error(f"Error in collection thread: {e}")
             raise

--- a/torchrl/collectors/distributed/rpc.py
+++ b/torchrl/collectors/distributed/rpc.py
@@ -294,6 +294,16 @@ class RPCCollector(BaseCollector):
             and values are WeightSyncScheme instances configured to receive weights.
             This is typically used when RPCDataCollector is itself a worker in a larger distributed setup.
             Defaults to ``None``.
+        trajs_per_batch (int, optional): When set, each remote collector
+            assembles complete trajectories (episodes ending with
+            ``("next", "done") == True``) before writing them to the replay
+            buffer as flat 1-D sequences.  Passed through to each worker's
+            ``collector_kwargs`` so that the inner collector calls
+            :meth:`~torchrl.collectors.BaseCollector._iter_by_trajectories`.
+
+            See :class:`~torchrl.collectors.BaseCollector` for the full
+            description of the completeness guarantee and storage contract.
+            Defaults to ``None``.
 
     """
 

--- a/torchrl/collectors/distributed/rpc.py
+++ b/torchrl/collectors/distributed/rpc.py
@@ -336,6 +336,7 @@ class RPCCollector(BaseCollector):
         | None = None,
         weight_sync_schemes: dict[str, WeightSyncScheme] | None = None,
         weight_recv_schemes: dict[str, WeightSyncScheme] | None = None,
+        trajs_per_batch: int | None = None,
     ):
 
         if self._VERBOSE:
@@ -434,6 +435,8 @@ class RPCCollector(BaseCollector):
             collector_kwarg["storing_device"] = self.storing_device[i]
             collector_kwarg["env_device"] = self.env_device[i]
             collector_kwarg["policy_device"] = self.policy_device[i]
+            if trajs_per_batch is not None:
+                collector_kwarg["trajs_per_batch"] = trajs_per_batch
 
         self.postproc = postproc
         self.split_trajs = split_trajs

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -145,6 +145,11 @@ class ReplayBuffer:
             multi-dimensional and keep consistent notions of storage-capacity
             and batch-size during sampling.
 
+            .. important:: When using a collector with ``trajs_per_batch``,
+                trajectories are written as flat 1-D sequences of variable
+                length.  Do not set ``dim_extend > 0`` or ``ndim >= 2`` in
+                this case — the storage must be 1-dimensional.
+
             .. note:: This argument has no effect on :meth:`add` and
                 therefore should be used with caution when both :meth:`add`
                 and :meth:`extend` are used in a codebase. For example:
@@ -1347,6 +1352,11 @@ class PrioritizedReplayBuffer(ReplayBuffer):
             available, to let storages know that the data is
             multi-dimensional and keep consistent notions of storage-capacity
             and batch-size during sampling.
+
+            .. important:: When using a collector with ``trajs_per_batch``,
+                trajectories are written as flat 1-D sequences of variable
+                length.  Do not set ``dim_extend > 0`` or ``ndim >= 2`` in
+                this case — the storage must be 1-dimensional.
 
             .. note:: This argument has no effect on :meth:`add` and
                 therefore should be used with caution when both :meth:`add`

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -900,7 +900,9 @@ class SliceSampler(Sampler):
 
         - set ``trajs_per_batch`` on the collector so that only **complete**
           trajectories (each ending with ``done=True``) are written to the
-          buffer, or
+          buffer (use ``ndim=1`` on the storage — ``ndim >= 2`` is
+          incompatible with the variable-length flat sequences that
+          ``trajs_per_batch`` produces), or
         - set ``set_truncated=True`` on the collector so that every batch
           boundary carries a ``done`` signal (note: this introduces artificial
           truncations that value estimators must account for).

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -889,6 +889,22 @@ class SliceSampler(Sampler):
         attempt to find the ``traj_key`` entry in the storage. If it cannot be
         found, the ``end_key`` will be used to reconstruct the episodes.
 
+    .. note:: When using a multi-process collector
+        (:class:`~torchrl.collectors.MultiSyncCollector` or
+        :class:`~torchrl.collectors.MultiAsyncCollector`) with a shared replay
+        buffer, adjacent transitions in the buffer may come from different
+        workers and different episodes. A ``SliceSampler`` that relies on
+        ``end_key`` can then sample slices that straddle unrelated trajectories.
+
+        To avoid this, either:
+
+        - set ``trajs_per_batch`` on the collector so that only **complete**
+          trajectories (each ending with ``done=True``) are written to the
+          buffer, or
+        - set ``set_truncated=True`` on the collector so that every batch
+          boundary carries a ``done`` signal (note: this introduces artificial
+          truncations that value estimators must account for).
+
     .. note:: When using `strict_length=False`, it is recommended to use
         :func:`~torchrl.collectors.utils.split_trajectories` to split the sampled trajectories.
         However, if two samples from the same episode are placed next to each other,
@@ -1358,6 +1374,12 @@ class SliceSampler(Sampler):
                 return vals
             except KeyError:
                 if fallback:
+                    logger.info(
+                        "SliceSampler could not find traj_key %r in storage. "
+                        "Falling back to end_key %r to reconstruct trajectory boundaries.",
+                        self.traj_key,
+                        self.end_key,
+                    )
                     self._fetch_traj = False
                     return self._get_stop_and_length(storage, fallback=False)
                 raise
@@ -1370,8 +1392,15 @@ class SliceSampler(Sampler):
                     raise RuntimeError(
                         "Could not get a tensordict out of the storage, which is required for SliceSampler to compute the trajectories."
                     )
+                done = done.squeeze()
+                if done.ndim > 1:
+                    # Multi-dimensional done signals arise when pre-assembled
+                    # trajectory data (trajs, max_len, ...) is stored in the
+                    # buffer.  Flatten to 1-D so that _find_start_stop_traj
+                    # can locate episode boundaries correctly.
+                    done = done.reshape(-1)
                 vals = self._find_start_stop_traj(
-                    end=done.squeeze()[: len(storage)],
+                    end=done[: len(storage)],
                     at_capacity=storage._is_full,
                     cursor=getattr(storage, "_last_cursor", None),
                 )

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -647,6 +647,13 @@ class TensorStorage(Storage):
             measuring the storage size. For instance, a storage of shape ``[3, 4]``
             has capacity ``3`` if ``ndim=1`` and ``12`` if ``ndim=2``.
             Defaults to ``1``.
+
+            .. important:: When using a collector with ``trajs_per_batch``,
+                keep the default ``ndim=1``.  ``trajs_per_batch`` writes
+                variable-length trajectories as flat 1-D sequences, which is
+                incompatible with a storage that expects a fixed second
+                dimension (``ndim >= 2``).
+
         compilable (bool, optional): whether the storage is compilable.
             If ``True``, the writer cannot be shared between multiple processes.
             Defaults to ``False``.
@@ -1332,6 +1339,12 @@ class LazyTensorStorage(TensorStorage):
             measuring the storage size. For instance, a storage of shape ``[3, 4]``
             has capacity ``3`` if ``ndim=1`` and ``12`` if ``ndim=2``.
             Defaults to ``1``.
+
+            .. important:: When using a collector with ``trajs_per_batch``,
+                keep the default ``ndim=1``.  ``trajs_per_batch`` writes
+                variable-length trajectories as flat 1-D sequences, which is
+                incompatible with a storage that expects a fixed second
+                dimension (``ndim >= 2``).
         compilable (bool, optional): whether the storage is compilable.
             If ``True``, the writer cannot be shared between multiple processes.
             Defaults to ``False``.
@@ -1566,6 +1579,13 @@ class LazyMemmapStorage(LazyTensorStorage):
             measuring the storage size. For instance, a storage of shape ``[3, 4]``
             has capacity ``3`` if ``ndim=1`` and ``12`` if ``ndim=2``.
             Defaults to ``1``.
+
+            .. important:: When using a collector with ``trajs_per_batch``,
+                keep the default ``ndim=1``.  ``trajs_per_batch`` writes
+                variable-length trajectories as flat 1-D sequences, which is
+                incompatible with a storage that expects a fixed second
+                dimension (``ndim >= 2``).
+
         existsok (bool, optional): whether an error should be raised if any of the
             tensors already exists on disk. Defaults to ``True``. If ``False``, the
             tensor will be opened as is, not overewritten.

--- a/tutorials/sphinx-tutorials/getting-started-3.py
+++ b/tutorials/sphinx-tutorials/getting-started-3.py
@@ -195,6 +195,11 @@ print(sample)
 #   simplicity. Try it out for yourself: build a buffer and indicate its
 #   batch-size in the constructor, then try to iterate over it. This is
 #   equivalent to calling ``rb.sample()`` within a loop!
+# - For trajectory-based training (recurrent policies, decision transformers),
+#   see :ref:`collectors_replay_trajs` — it shows how to use
+#   ``trajs_per_batch`` with a :class:`~torchrl.data.SliceSampler` to store
+#   and sample clean trajectory slices from the replay buffer, especially
+#   with multi-process collectors.
 #
 
 # sphinx_gallery_start_ignore

--- a/tutorials/sphinx-tutorials/rb_tutorial.py
+++ b/tutorials/sphinx-tutorials/rb_tutorial.py
@@ -883,6 +883,15 @@ gc.collect()
 # :ref:`the dedicated collector + replay buffer section <collectors_replay_trajs>`
 # for full examples and discussion.
 #
+# .. important::
+#
+#     When using ``trajs_per_batch``, always use a **flat 1-D storage**
+#     (the default ``ndim=1``).  Although batched environments normally call
+#     for ``ndim=2``, ``trajs_per_batch`` disassembles batches and writes
+#     each trajectory as a variable-length 1-D sequence.  A storage with
+#     ``ndim >= 2`` expects a fixed second dimension that variable-length
+#     trajectories cannot fill.
+#
 
 ######################################################################
 # Conclusion

--- a/tutorials/sphinx-tutorials/rb_tutorial.py
+++ b/tutorials/sphinx-tutorials/rb_tutorial.py
@@ -840,6 +840,51 @@ print("steps are successive", sample["steps"])
 gc.collect()
 
 ######################################################################
+# Storing trajectories from a collector
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# The example above uses hand-crafted data.  In practice you will be
+# collecting data with a :class:`~torchrl.collectors.Collector` (or its
+# multi-process variants).  The collector already tags every transition with
+# a ``("collector", "traj_ids")`` key, so the
+# :class:`~torchrl.data.SliceSampler` can reconstruct episode boundaries
+# automatically.
+#
+# For **single-process** collectors the setup is straightforward — just
+# ``extend`` the buffer with the collected batch and use ``traj_ids`` as
+# the trajectory key:
+#
+# .. code-block:: python
+#
+#     from torchrl.collectors import Collector
+#     from torchrl.data import ReplayBuffer, LazyTensorStorage, SliceSampler
+#
+#     rb = ReplayBuffer(
+#         storage=LazyTensorStorage(100_000),
+#         sampler=SliceSampler(
+#             slice_len=20,
+#             traj_key=("collector", "traj_ids"),
+#         ),
+#         batch_size=256,
+#     )
+#     collector = Collector(env, policy, frames_per_batch=200, total_frames=-1)
+#     for data in collector:
+#         rb.extend(data)
+#         batch = rb.sample()  # contiguous sub-sequences
+#
+# For **multi-process** collectors, a subtlety arises: different workers
+# write their batches independently, so adjacent frames in the buffer can
+# come from unrelated episodes *without* an intervening ``done`` signal.
+# The sampler cannot detect these invisible boundaries and may draw slices
+# that cross episodes.
+#
+# The recommended solution is ``trajs_per_batch``, which makes each worker
+# write only **complete trajectories** to the buffer — see
+# :ref:`the dedicated collector + replay buffer section <collectors_replay_trajs>`
+# for full examples and discussion.
+#
+
+######################################################################
 # Conclusion
 # ----------
 #


### PR DESCRIPTION
Removes the NotImplementedError that blocked trajs_per_batch + replay_buffer
on MultiCollector. Trajectory assembly is now delegated to each worker's inner
Collector via _iter_by_trajectories(), which handles padding stripping for 1-D
storage and writes complete trajectories to the shared replay buffer.

Also adds trajs_per_batch as a first-class parameter to RayCollector and
RPCCollector, and fixes RayCollector._run_collection_loop to write non-None
data to the local replay buffer (enabling start() with local buffers).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
