### PR TITLE
[Feature] Introduces a new memmap value for the CKPT_BACKEND environment variable.

### DIFF
--- a/docs/source/reference/trainers.rst
+++ b/docs/source/reference/trainers.rst
@@ -13,7 +13,7 @@ Key Features
 ------------
 
 - **Modular hook system**: Customize training at 10 different points in the loop
-- **Checkpointing support**: Save and restore training state with torch or torchsnapshot
+- **Checkpointing support**: Save and restore training state with ``torch``, ``torchsnapshot``, or ``memmap`` (set via the ``CKPT_BACKEND`` environment variable)
 - **Algorithm trainers**: High-level trainers for PPO, SAC, DQN, DDPG, IQL, CQL with Hydra configuration
 - **Builder helpers**: Utilities for constructing collectors, losses, and replay buffers
 

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -197,8 +197,7 @@ class TestSelectKeys:
 
             trainer2.load_from_file(file)
             assert state_dict_has_been_called[0]
-            if backend == "torch":
-                assert load_state_dict_has_been_called[0]
+            assert load_state_dict_has_been_called[0]
 
         SelectKeys.state_dict = SelectKeys_state_dict
         SelectKeys.load_state_dict = SelectKeys_load_state_dict
@@ -722,6 +721,7 @@ class TestRewardNorm:
         [
             "torchsnapshot",
             "torch",
+            "memmap",
         ],
     )
     def test_reward_norm_save(self, backend):
@@ -748,6 +748,8 @@ class TestRewardNorm:
                 file = path.join(tmpdirname, "file.pt")
             elif backend == "torchsnapshot":
                 file = tmpdirname
+            elif backend == "memmap":
+                file = path.join(tmpdirname, "ckpt")
             else:
                 raise NotImplementedError
             trainer = mocking_trainer(file)
@@ -765,6 +767,8 @@ class TestRewardNorm:
             reward_normalizer2 = RewardNormalizer()
             reward_normalizer2.register(trainer2)
             trainer2.load_from_file(file)
+            assert state_dict_has_been_called[0]
+            assert load_state_dict_has_been_called[0]
 
         RewardNormalizer.state_dict = RewardNormalizer_state_dict
         RewardNormalizer.load_state_dict = RewardNormalizer_load_state_dict
@@ -924,6 +928,7 @@ class TestRecorder:
         [
             "torchsnapshot",
             "torch",
+            "memmap",
         ],
     )
     def test_recorder_load(self, backend, N=8):
@@ -948,6 +953,8 @@ class TestRecorder:
                 file = path.join(tmpdirname, "file.pt")
             elif backend == "torchsnapshot":
                 file = tmpdirname
+            elif backend == "memmap":
+                file = path.join(tmpdirname, "ckpt")
             else:
                 raise NotImplementedError
             trainer = mocking_trainer(file)
@@ -1022,6 +1029,7 @@ class TestCountFrames:
         [
             "torchsnapshot",
             "torch",
+            "memmap",
         ],
     )
     def test_countframes_load(self, backend):
@@ -1046,6 +1054,8 @@ class TestCountFrames:
                 file = path.join(tmpdirname, "file.pt")
             elif backend == "torchsnapshot":
                 file = tmpdirname
+            elif backend == "memmap":
+                file = path.join(tmpdirname, "ckpt")
             else:
                 raise NotImplementedError
             trainer = mocking_trainer(file)

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -150,7 +150,7 @@ class TestSelectKeys:
         assert not len(sd["select_keys"])
         trainer2.load_state_dict(sd)
 
-    @pytest.mark.parametrize("backend", ["torchsnapshot", "torch"])
+    @pytest.mark.parametrize("backend", ["torchsnapshot", "torch", "memmap"])
     def test_selectkeys_save(self, backend):
         if not _has_ts and backend == "torchsnapshot":
             pytest.skip("torchsnapshot not found")
@@ -171,6 +171,8 @@ class TestSelectKeys:
                 file = path.join(tmpdirname, "file.pt")
             elif backend == "torchsnapshot":
                 file = tmpdirname
+            elif backend == "memmap":
+                file = path.join(tmpdirname, "ckpt")
             else:
                 raise NotImplementedError
             trainer = mocking_trainer(file=file)

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -562,7 +562,7 @@ def get_binary_env_var(key):
 class _Dynamic_CKPT_BACKEND:
     """Allows CKPT_BACKEND to be changed on-the-fly."""
 
-    backends = ["torch", "torchsnapshot"]
+    backends = ["torch", "torchsnapshot", "memmap"]
 
     def _get_backend(self):
         backend = os.environ.get("CKPT_BACKEND", "torch")

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -77,39 +77,33 @@ TYPE_DESCR = {float: "4.4f", int: ""}
 REWARD_KEY = ("next", "reward")
 
 
-def _serialize_for_json(obj):
-    """Recursively convert a state-dict to a JSON-serializable form.
+def _state_dict_to_td(sd: dict) -> TensorDict:
+    """Convert a state dict to a :class:`~tensordict.TensorDict`.
 
-    Tensors are encoded as ``{"__tensor__": true, "data": [...], "dtype":
-    "<dtype>", "shape": [...]}`` so they can be faithfully restored.
+    Tensor values are stored directly; everything else is wrapped in
+    :class:`~tensordict.NonTensorData` so that :meth:`~tensordict.TensorDict.dumps`
+    can persist the whole state without pickle dependencies.
     """
-    if isinstance(obj, torch.Tensor):
-        return {
-            "__tensor__": True,
-            "data": obj.tolist(),
-            "dtype": str(obj.dtype),
-            "shape": list(obj.shape),
-        }
-    if isinstance(obj, dict):
-        return {k: _serialize_for_json(v) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple)):
-        serialized = [_serialize_for_json(v) for v in obj]
-        return serialized if isinstance(obj, list) else serialized
-    return obj
+    from tensordict import NonTensorData
+
+    return TensorDict(
+        {
+            k: v if isinstance(v, torch.Tensor) else NonTensorData(v)
+            for k, v in sd.items()
+        },
+        [],
+    )
 
 
-def _deserialize_from_json(obj):
-    """Inverse of :func:`_serialize_for_json`."""
-    if isinstance(obj, dict):
-        if obj.get("__tensor__"):
-            t = torch.tensor(
-                obj["data"], dtype=getattr(torch, obj["dtype"].split(".")[-1])
-            )
-            return t.reshape(obj["shape"]) if obj["shape"] else t.squeeze()
-        return {k: _deserialize_from_json(v) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [_deserialize_from_json(v) for v in obj]
-    return obj
+def _td_to_state_dict(td: TensorDict) -> dict:
+    """Inverse of :func:`_state_dict_to_td`.
+
+    Unwraps :class:`~tensordict.NonTensorData` back to plain Python values and
+    leaves tensors (including :class:`~tensordict.MemoryMappedTensor`) as-is.
+    """
+    from tensordict import NonTensorData
+
+    return {k: v.data if isinstance(v, NonTensorData) else v for k, v in td.items()}
 
 
 class TrainerHookBase:
@@ -546,20 +540,14 @@ class Trainer:
             state = self.state_dict()
             path = pathlib.Path(self.save_trainer_file)
             path.mkdir(parents=True, exist_ok=True)
-            # Persist nn.Module tensor state dicts (loss_module, collector)
-            # using TensorDict memmap — pickle-free, no extra dependencies.
-            for key in ("loss_module", "collector"):
+            # Persist all module state dicts using TensorDict memmap.
+            # Non-tensor values (scalars, bools, nested dicts) are wrapped in
+            # NonTensorData automatically by _state_dict_to_td, so no pickle
+            # dependency is needed.
+            for key in ("loss_module", "collector", *self._modules):
                 sd = state[key]
                 if sd:
-                    TensorDict(sd, []).dumps(str(path / key))
-            # Persist registered hook-module state dicts as JSON.
-            # These can contain mixed types (scalars, bools, tensors), so
-            # tensors are stored as {"__tensor__": true, ...} objects.
-            hooks_state = {}
-            for mod_key in self._modules:
-                hooks_state[mod_key] = _serialize_for_json(state[mod_key])
-            with open(path / "hooks.json", "w") as f:
-                json.dump(hooks_state, f)
+                    _state_dict_to_td(sd).dumps(str(path / key))
             # Persist non-tensor training counters as JSON.
             with open(path / "state.json", "w") as f:
                 json.dump(dict(state["state"]), f)
@@ -596,24 +584,14 @@ class Trainer:
 
             path = pathlib.Path(file)
             state: dict = {}
-            for key in ("loss_module", "collector"):
+            for key in ("loss_module", "collector", *self._modules):
                 key_path = path / key
                 if key_path.exists():
-                    state[key] = dict(TensorDict.load_memmap(str(key_path)))
+                    state[key] = _td_to_state_dict(
+                        TensorDict.load_memmap(str(key_path))
+                    )
                 else:
                     state[key] = {}
-            # Restore hook-module state dicts from JSON.
-            hooks_path = path / "hooks.json"
-            if hooks_path.exists():
-                with open(hooks_path) as f:
-                    hooks_state = json.load(f)
-                for mod_key in self._modules:
-                    state[mod_key] = _deserialize_from_json(
-                        hooks_state.get(mod_key, {})
-                    )
-            else:
-                for mod_key in self._modules:
-                    state[mod_key] = {}
             with open(path / "state.json") as f:
                 state["state"] = json.load(f)
             self.load_state_dict(state)

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -77,6 +77,41 @@ TYPE_DESCR = {float: "4.4f", int: ""}
 REWARD_KEY = ("next", "reward")
 
 
+def _serialize_for_json(obj):
+    """Recursively convert a state-dict to a JSON-serializable form.
+
+    Tensors are encoded as ``{"__tensor__": true, "data": [...], "dtype":
+    "<dtype>", "shape": [...]}`` so they can be faithfully restored.
+    """
+    if isinstance(obj, torch.Tensor):
+        return {
+            "__tensor__": True,
+            "data": obj.tolist(),
+            "dtype": str(obj.dtype),
+            "shape": list(obj.shape),
+        }
+    if isinstance(obj, dict):
+        return {k: _serialize_for_json(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        serialized = [_serialize_for_json(v) for v in obj]
+        return serialized if isinstance(obj, list) else serialized
+    return obj
+
+
+def _deserialize_from_json(obj):
+    """Inverse of :func:`_serialize_for_json`."""
+    if isinstance(obj, dict):
+        if obj.get("__tensor__"):
+            t = torch.tensor(
+                obj["data"], dtype=getattr(torch, obj["dtype"].split(".")[-1])
+            )
+            return t.reshape(obj["shape"]) if obj["shape"] else t.squeeze()
+        return {k: _deserialize_from_json(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_deserialize_from_json(v) for v in obj]
+    return obj
+
+
 class TrainerHookBase:
     """An abstract hooking class for torchrl Trainer class."""
 
@@ -511,16 +546,20 @@ class Trainer:
             state = self.state_dict()
             path = pathlib.Path(self.save_trainer_file)
             path.mkdir(parents=True, exist_ok=True)
-            # Persist tensor state dicts (loss_module, collector, registered modules)
-            # using TensorDict memmap — no extra dependencies, no pickle.
+            # Persist nn.Module tensor state dicts (loss_module, collector)
+            # using TensorDict memmap — pickle-free, no extra dependencies.
             for key in ("loss_module", "collector"):
                 sd = state[key]
                 if sd:
                     TensorDict(sd, []).dumps(str(path / key))
+            # Persist registered hook-module state dicts as JSON.
+            # These can contain mixed types (scalars, bools, tensors), so
+            # tensors are stored as {"__tensor__": true, ...} objects.
+            hooks_state = {}
             for mod_key in self._modules:
-                sd = state[mod_key]
-                if sd:
-                    TensorDict(sd, []).dumps(str(path / mod_key))
+                hooks_state[mod_key] = _serialize_for_json(state[mod_key])
+            with open(path / "hooks.json", "w") as f:
+                json.dump(hooks_state, f)
             # Persist non-tensor training counters as JSON.
             with open(path / "state.json", "w") as f:
                 json.dump(dict(state["state"]), f)
@@ -563,11 +602,17 @@ class Trainer:
                     state[key] = dict(TensorDict.load_memmap(str(key_path)))
                 else:
                     state[key] = {}
-            for mod_key in self._modules:
-                mod_path = path / mod_key
-                if mod_path.exists():
-                    state[mod_key] = dict(TensorDict.load_memmap(str(mod_path)))
-                else:
+            # Restore hook-module state dicts from JSON.
+            hooks_path = path / "hooks.json"
+            if hooks_path.exists():
+                with open(hooks_path) as f:
+                    hooks_state = json.load(f)
+                for mod_key in self._modules:
+                    state[mod_key] = _deserialize_from_json(
+                        hooks_state.get(mod_key, {})
+                    )
+            else:
+                for mod_key in self._modules:
                     state[mod_key] = {}
             with open(path / "state.json") as f:
                 state["state"] = json.load(f)

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import abc
 import itertools
+import json
 import pathlib
 import time
 import warnings
@@ -18,7 +19,7 @@ from typing import Any, Literal
 
 import numpy as np
 import torch.nn
-from tensordict import NestedKey, pad, TensorDict, TensorDictBase
+from tensordict import NestedKey, NonTensorData, pad, TensorDict, TensorDictBase
 from tensordict._tensorcollection import TensorCollection
 from tensordict.nn import TensorDictModule
 from tensordict.utils import expand_right
@@ -84,8 +85,6 @@ def _state_dict_to_td(sd: dict) -> TensorDict:
     :class:`~tensordict.NonTensorData` so that :meth:`~tensordict.TensorDict.dumps`
     can persist the whole state without pickle dependencies.
     """
-    from tensordict import NonTensorData
-
     return TensorDict(
         {
             k: v if isinstance(v, torch.Tensor) else NonTensorData(v)
@@ -101,8 +100,6 @@ def _td_to_state_dict(td: TensorDict) -> dict:
     Unwraps :class:`~tensordict.NonTensorData` back to plain Python values and
     leaves tensors (including :class:`~tensordict.MemoryMappedTensor`) as-is.
     """
-    from tensordict import NonTensorData
-
     return {k: v.data if isinstance(v, NonTensorData) else v for k, v in td.items()}
 
 
@@ -535,8 +532,6 @@ class Trainer:
         elif _CKPT_BACKEND == "torch":
             torch.save(self.state_dict(), self.save_trainer_file)
         elif _CKPT_BACKEND == "memmap":
-            import json
-
             state = self.state_dict()
             path = pathlib.Path(self.save_trainer_file)
             path.mkdir(parents=True, exist_ok=True)
@@ -571,6 +566,12 @@ class Trainer:
         Keyword arguments are passed to the :func:`~torch.load` function.
         They are ignored when ``CKPT_BACKEND=memmap``.
 
+        .. note::
+            When ``CKPT_BACKEND=torch``, ``weights_only=True`` is set by
+            default for safer deserialization. Pass ``weights_only=False``
+            explicitly only if you have custom (non-stdlib) objects in your
+            state dict.
+
         """
         if _CKPT_BACKEND == "torchsnapshot":
             snapshot = Snapshot(path=file)
@@ -580,8 +581,6 @@ class Trainer:
             loaded_dict: OrderedDict = torch.load(file, **kwargs)
             self.load_state_dict(loaded_dict)
         elif _CKPT_BACKEND == "memmap":
-            import json
-
             path = pathlib.Path(file)
             state: dict = {}
             for key in ("loss_module", "collector", *self._modules):

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -60,6 +60,7 @@ try:
 except ImportError:
     _has_ts = False
 
+
 REPLAY_BUFFER_CLASS = {
     "prioritized": TensorDictPrioritizedReplayBuffer,
     "circular": TensorDictReplayBuffer,
@@ -504,6 +505,25 @@ class Trainer:
             Snapshot.take(app_state=self.app_state, path=self.save_trainer_file)
         elif _CKPT_BACKEND == "torch":
             torch.save(self.state_dict(), self.save_trainer_file)
+        elif _CKPT_BACKEND == "memmap":
+            import json
+
+            state = self.state_dict()
+            path = pathlib.Path(self.save_trainer_file)
+            path.mkdir(parents=True, exist_ok=True)
+            # Persist tensor state dicts (loss_module, collector, registered modules)
+            # using TensorDict memmap — no extra dependencies, no pickle.
+            for key in ("loss_module", "collector"):
+                sd = state[key]
+                if sd:
+                    TensorDict(sd, []).dumps(str(path / key))
+            for mod_key in self._modules:
+                sd = state[mod_key]
+                if sd:
+                    TensorDict(sd, []).dumps(str(path / mod_key))
+            # Persist non-tensor training counters as JSON.
+            with open(path / "state.json", "w") as f:
+                json.dump(dict(state["state"]), f)
         else:
             raise NotImplementedError(
                 f"CKPT_BACKEND should be one of {_CKPT_BACKEND.backends}, got {_CKPT_BACKEND}."
@@ -522,14 +542,36 @@ class Trainer:
         """Loads a file and its state-dict in the trainer.
 
         Keyword arguments are passed to the :func:`~torch.load` function.
+        They are ignored when ``CKPT_BACKEND=memmap``.
 
         """
         if _CKPT_BACKEND == "torchsnapshot":
             snapshot = Snapshot(path=file)
             snapshot.restore(app_state=self.app_state)
         elif _CKPT_BACKEND == "torch":
+            kwargs.setdefault("weights_only", True)
             loaded_dict: OrderedDict = torch.load(file, **kwargs)
             self.load_state_dict(loaded_dict)
+        elif _CKPT_BACKEND == "memmap":
+            import json
+
+            path = pathlib.Path(file)
+            state: dict = {}
+            for key in ("loss_module", "collector"):
+                key_path = path / key
+                if key_path.exists():
+                    state[key] = dict(TensorDict.load_memmap(str(key_path)))
+                else:
+                    state[key] = {}
+            for mod_key in self._modules:
+                mod_path = path / mod_key
+                if mod_path.exists():
+                    state[mod_key] = dict(TensorDict.load_memmap(str(mod_path)))
+                else:
+                    state[mod_key] = {}
+            with open(path / "state.json") as f:
+                state["state"] = json.load(f)
+            self.load_state_dict(state)
         return self
 
     def set_seed(self):


### PR DESCRIPTION
Tensor state dicts are persisted via TensorDict(sd, []).dumps() (pickle-free, no extra dependencies). Plain Python metadata is stored as JSON alongside. Also adds weights_only=True default to the torch backend for safer loading.

## Description

Fixes #3617 
Describe your changes in detail.

## Motivations

Adds a `memmap` option for the `CKPT_BACKEND` environment variable used by `Trainer`.

**Motivation**: The `torch` backend uses `pickle` under the hood, which has security concerns. The `safetensors` approach requires an extra dependency. `TensorDict.dumps()` is pickle-free, requires no new dependencies, and is already part of the TorchRL stack.

### How to use
```bash
CKPT_BACKEND=memmap python train.py
```

## Changes

- **`torchrl/_utils.py`**: registers `"memmap"` as a valid backend in `_Dynamic_CKPT_BACKEND.backends`
- **`torchrl/trainers/trainers.py`**:
  - `_save_trainer()`: saves tensor state dicts via `TensorDict(sd, []).dumps(path/key)`, plain Python metadata (frame counts etc.) via JSON
  - `load_from_file()`: restores tensor state via `TensorDict.load_memmap()` and metadata from JSON
  - torch backend: adds `weights_only=True` default for safer deserialization
- **`test/test_trainer.py`**: extends the existing checkpoint round-trip parametrize to include `"memmap"`
- **`docs/source/reference/trainers.rst`**: documents the memmap backend option

## Checklist

- [x] Tests added for memmap save/load round-trip
- [x] `weights_only=True` added for torch backend (security improvement)  
- [x] No new dependencies introduced
- [x] Docs updated
