### PR TITLE
[BugFix] Fix per-group WandB step logging

### DIFF
--- a/test/test_loggers.py
+++ b/test/test_loggers.py
@@ -25,7 +25,7 @@ from torchrl.record.loggers.ray import RayLogger
 from torchrl.record.loggers.tensorboard import _has_tb, TensorboardLogger
 from torchrl.record.loggers.trackio import _has_trackio, TrackioLogger
 from torchrl.record.loggers.utils import get_logger
-from torchrl.record.loggers.wandb import _has_wandb, WandbLogger
+from torchrl.record.loggers.wandb import _has_moviepy, _has_wandb, WandbLogger
 from torchrl.record.recorder import PixelRenderTransform, VideoRecorder
 
 if _has_tv:
@@ -274,34 +274,70 @@ class TestCSVLogger:
 
 @pytest.fixture(scope="class")
 def wandb_logger(tmp_path_factory):
+    import wandb
+
+    wandb.finish()
     tmpdir1 = tmp_path_factory.mktemp("tmpdir1")
     exp_name = "ramala"
     logger = WandbLogger(log_dir=tmpdir1, exp_name=exp_name, offline=True)
     yield logger
     logger.experiment.finish()
+    wandb.finish()
+    del logger
+
+
+@pytest.fixture
+def wandb_tmp_logger(tmp_path):
+    import wandb
+
+    wandb.finish()
+    logger = WandbLogger(log_dir=tmp_path, exp_name="ramala", offline=True)
+    yield logger
+    logger.experiment.finish()
+    wandb.finish()
     del logger
 
 
 @pytest.mark.skipif(not _has_wandb, reason="Wandb not installed")
 class TestWandbLogger:
     @pytest.mark.parametrize("steps", [None, [1, 10, 11]])
-    def test_log_scalar(self, steps, wandb_logger):
+    def test_log_scalar(self, steps, wandb_tmp_logger, monkeypatch):
         torch.manual_seed(0)
+
+        logged = []
+        defined = []
+
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment,
+            "log",
+            lambda payload, **kwargs: logged.append((payload, kwargs)),
+        )
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment,
+            "define_metric",
+            lambda name, step_metric=None: defined.append((name, step_metric)),
+        )
 
         values = torch.rand(3)
         for i in range(3):
             scalar_name = "foo"
             scalar_value = values[i].item()
-            wandb_logger.log_scalar(
+            wandb_tmp_logger.log_scalar(
                 value=scalar_value,
                 name=scalar_name,
                 step=steps[i] if steps else None,
                 commit=True,
             )
 
-        assert wandb_logger.experiment.summary["foo"] == values[-1].item()
-        assert wandb_logger.experiment.summary["_step"] == i if not steps else steps[i]
+        assert len(logged) == 3
+        assert defined == [("step", None), ("foo", "step")]
 
+        for i, (payload, kwargs) in enumerate(logged):
+            expected_step = i if not steps else steps[i]
+            assert payload == {"foo": values[i].item(), "step": expected_step}
+            assert kwargs == {"commit": True}
+
+    @pytest.mark.skipif(not _has_moviepy, reason="moviepy not installed")
     def test_log_video(self, wandb_logger):
         torch.manual_seed(0)
 
@@ -357,6 +393,168 @@ class TestWandbLogger:
         # test with np
         data = torch.randn(10).numpy()
         wandb_logger.log_histogram("hist", data, step=1, bins=2)
+
+    def test_log_metrics_infers_nested_steps(self, wandb_tmp_logger, monkeypatch):
+        logged = []
+        defined = []
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment,
+            "log",
+            lambda payload, **kwargs: logged.append((payload, kwargs)),
+        )
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment,
+            "define_metric",
+            lambda name, step_metric=None: defined.append((name, step_metric)),
+        )
+
+        metrics = {"eval/reward": 1.0, "eval/other/something": 2.0}
+        result = wandb_tmp_logger.log_metrics(metrics, step=7)
+
+        assert result == metrics
+        assert logged == [
+            (
+                {
+                    "eval/reward": 1.0,
+                    "eval/other/something": 2.0,
+                    "eval/step": 7,
+                    "eval/other/step": 7,
+                },
+                {},
+            )
+        ]
+        assert defined == [
+            ("eval/step", None),
+            ("eval/other/step", None),
+            ("eval/reward", "eval/step"),
+            ("eval/other/something", "eval/other/step"),
+        ]
+
+    def test_log_metrics_preserves_explicit_step_keys(
+        self, wandb_tmp_logger, monkeypatch
+    ):
+        logged = []
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment,
+            "log",
+            lambda payload, **kwargs: logged.append((payload, kwargs)),
+        )
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment, "define_metric", lambda *args, **kwargs: None
+        )
+
+        wandb_tmp_logger.log_metrics({"eval/reward": 1.0, "eval/step": 4}, step=99)
+        wandb_tmp_logger.log_metrics({"eval/reward": 2.0})
+
+        assert logged[0][0]["eval/step"] == 4
+        assert logged[1][0]["eval/step"] == 5
+
+    def test_log_metrics_auto_increments_per_group(self, wandb_tmp_logger, monkeypatch):
+        logged = []
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment,
+            "log",
+            lambda payload, **kwargs: logged.append((payload, kwargs)),
+        )
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment, "define_metric", lambda *args, **kwargs: None
+        )
+
+        wandb_tmp_logger.log_metrics({"eval/reward": 1.0})
+        wandb_tmp_logger.log_metrics({"train/loss": 0.5})
+        wandb_tmp_logger.log_metrics({"eval/reward": 2.0})
+
+        assert logged[0][0]["eval/step"] == 0
+        assert logged[1][0]["train/step"] == 0
+        assert logged[2][0]["eval/step"] == 1
+
+    def test_override_global_step_uses_legacy_wandb_step(
+        self, wandb_tmp_logger, monkeypatch
+    ):
+        logged = []
+        defined = []
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment,
+            "log",
+            lambda payload, **kwargs: logged.append((payload, kwargs)),
+        )
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment,
+            "define_metric",
+            lambda name, step_metric=None: defined.append((name, step_metric)),
+        )
+
+        wandb_tmp_logger.log_metrics(
+            {"eval/reward": 1.0}, step=123, override_global_step=True
+        )
+
+        assert logged == [({"eval/reward": 1.0}, {"step": 123})]
+        assert defined == []
+
+    @pytest.mark.skipif(not _has_moviepy, reason="moviepy not installed")
+    def test_log_video_uses_inferred_step(self, wandb_tmp_logger, monkeypatch):
+        logged = []
+        defined = []
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment,
+            "log",
+            lambda payload, **kwargs: logged.append((payload, kwargs)),
+        )
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment,
+            "define_metric",
+            lambda name, step_metric=None: defined.append((name, step_metric)),
+        )
+
+        video = torch.randint(0, 255, (1, 4, 3, 8, 8), dtype=torch.uint8)
+        wandb_tmp_logger.log_video("eval/video", video, step=11)
+
+        payload, kwargs = logged[0]
+        assert payload["eval/step"] == 11
+        assert "eval/video" in payload
+        assert kwargs == {}
+        assert defined == [("eval/step", None), ("eval/video", "eval/step")]
+
+    def test_log_histogram_uses_inferred_step(self, wandb_tmp_logger, monkeypatch):
+        logged = []
+        defined = []
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment,
+            "log",
+            lambda payload, **kwargs: logged.append((payload, kwargs)),
+        )
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment,
+            "define_metric",
+            lambda name, step_metric=None: defined.append((name, step_metric)),
+        )
+
+        wandb_tmp_logger.log_histogram("eval/hist", torch.randn(10), step=3, bins=4)
+
+        payload, kwargs = logged[0]
+        assert payload["eval/step"] == 3
+        assert "eval/hist" in payload
+        assert kwargs == {}
+        assert defined == [("eval/step", None), ("eval/hist", "eval/step")]
+
+    def test_log_str_uses_inferred_step(self, wandb_tmp_logger, monkeypatch):
+        logged = []
+        defined = []
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment,
+            "log",
+            lambda payload, **kwargs: logged.append((payload, kwargs)),
+        )
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment,
+            "define_metric",
+            lambda name, step_metric=None: defined.append((name, step_metric)),
+        )
+
+        wandb_tmp_logger.log_str("eval/text", "hello", step=9)
+
+        assert logged == [({"eval/text": "hello", "eval/step": 9}, {})]
+        assert defined == [("eval/step", None), ("eval/text", "eval/step")]
 
 
 @pytest.fixture
@@ -561,6 +759,47 @@ def ray_init_shutdown():
         ray.init(num_cpus=2, log_to_driver=False)
     yield
     ray.shutdown()
+
+
+def test_ray_logger_log_metrics_forwards_override_global_step():
+    class _FakeRemoteMethod:
+        def __init__(self):
+            self.calls = []
+
+        def remote(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            return self.calls[-1]
+
+    class _FakeActor:
+        def __init__(self):
+            self.log_metrics = _FakeRemoteMethod()
+
+    class _FakeRay:
+        @staticmethod
+        def get(value):
+            return value
+
+    logger = RayLogger.__new__(RayLogger)
+    logger._actor = _FakeActor()
+    logger._ray = _FakeRay()
+
+    result = logger.log_metrics(
+        {"loss": torch.tensor(0.5)},
+        step=12,
+        override_global_step=True,
+    )
+
+    assert result == {"loss": 0.5}
+    assert logger._actor.log_metrics.calls == [
+        (
+            ({"loss": 0.5},),
+            {
+                "step": 12,
+                "keys_sep": "/",
+                "override_global_step": True,
+            },
+        )
+    ]
 
 
 @pytest.mark.skipif(not _has_ray, reason="Ray not available")

--- a/torchrl/record/loggers/ray.py
+++ b/torchrl/record/loggers/ray.py
@@ -119,14 +119,10 @@ class RayLogger:
         from torchrl.record.loggers.common import _make_metrics_safe
 
         safe_metrics = _make_metrics_safe(metrics, keys_sep=keys_sep)
-        self._ray.get(
-            self._actor.log_metrics.remote(
-                safe_metrics,
-                step=step,
-                keys_sep=keys_sep,
-                override_global_step=override_global_step,
-            )
-        )
+        remote_kwargs = {"step": step, "keys_sep": keys_sep}
+        if override_global_step:
+            remote_kwargs["override_global_step"] = True
+        self._ray.get(self._actor.log_metrics.remote(safe_metrics, **remote_kwargs))
         return safe_metrics
 
     def __repr__(self) -> str:

--- a/torchrl/record/loggers/ray.py
+++ b/torchrl/record/loggers/ray.py
@@ -108,6 +108,7 @@ class RayLogger:
         step: int | None = None,
         *,
         keys_sep: str = "/",
+        override_global_step: bool = False,
     ) -> dict[str, Any]:
         """Log multiple scalar metrics at once.
 
@@ -119,7 +120,12 @@ class RayLogger:
 
         safe_metrics = _make_metrics_safe(metrics, keys_sep=keys_sep)
         self._ray.get(
-            self._actor.log_metrics.remote(safe_metrics, step=step, keys_sep=keys_sep)
+            self._actor.log_metrics.remote(
+                safe_metrics,
+                step=step,
+                keys_sep=keys_sep,
+                override_global_step=override_global_step,
+            )
         )
         return safe_metrics
 

--- a/torchrl/record/loggers/wandb.py
+++ b/torchrl/record/loggers/wandb.py
@@ -77,6 +77,9 @@ class WandbLogger(Logger):
         self.id = id
         self.project = project
         self.video_fps = video_fps
+        self._step_registry: dict[str, int] = {}
+        self._defined_step_metrics: set[str] = set()
+        self._defined_metrics: set[str] = set()
         self._wandb_kwargs = {
             "name": exp_name,
             "dir": save_dir,
@@ -109,7 +112,13 @@ class WandbLogger(Logger):
         return wandb.init(**self._wandb_kwargs)
 
     def log_scalar(
-        self, name: str, value: float, step: int | None = None, commit: bool = False
+        self,
+        name: str,
+        value: float,
+        step: int | None = None,
+        commit: bool = False,
+        *,
+        override_global_step: bool = False,
     ) -> None:
         """Logs a scalar value to wandb.
 
@@ -120,8 +129,16 @@ class WandbLogger(Logger):
                 Defaults to None.
             commit: If true, data for current step is assumed to be final (and
                 no further data for this step should be logged).
+            override_global_step (bool, optional): If ``True``, bypasses
+                per-group step injection and forwards ``step`` to wandb's
+                global ``step`` argument. Defaults to ``False``.
         """
-        self.experiment.log({name: value}, step=step, commit=commit)
+        self._log_payload(
+            {name: value},
+            step=step,
+            commit=commit,
+            override_global_step=override_global_step,
+        )
 
     def log_video(self, name: str, video: Tensor, **kwargs) -> None:
         """Log videos inputs to wandb.
@@ -147,8 +164,10 @@ class WandbLogger(Logger):
 
         fps = kwargs.pop("fps", self.video_fps)
         format = kwargs.pop("format", "mp4")
-        self.experiment.log(
+        self._log_payload(
             {name: wandb.Video(video, fps=fps, format=format)},
+            step=kwargs.pop("step", None),
+            override_global_step=kwargs.pop("override_global_step", False),
             **kwargs,
         )
 
@@ -189,14 +208,21 @@ class WandbLogger(Logger):
 
         num_bins = kwargs.pop("bins", None)
         step = kwargs.pop("step", None)
-        extra_kwargs = {}
-        if step is not None:
-            extra_kwargs["trainer/step"] = step
-        self.experiment.log(
-            {name: wandb.Histogram(data, num_bins=num_bins), **extra_kwargs}
+        self._log_payload(
+            {name: wandb.Histogram(data, num_bins=num_bins)},
+            step=step,
+            override_global_step=kwargs.pop("override_global_step", False),
+            **kwargs,
         )
 
-    def log_str(self, name: str, value: str, step: int | None = None) -> None:
+    def log_str(
+        self,
+        name: str,
+        value: str,
+        step: int | None = None,
+        *,
+        override_global_step: bool = False,
+    ) -> None:
         """Logs a string value to wandb using a table format for better visualization.
 
         Args:
@@ -204,16 +230,19 @@ class WandbLogger(Logger):
             value (str): The string value to log.
             step (int, optional): The step at which the string is logged.
                 Defaults to None.
+            override_global_step (bool, optional): If ``True``, bypasses
+                per-group step injection and forwards ``step`` to wandb's
+                global ``step`` argument. Defaults to ``False``.
         """
         import wandb
 
         # Create a table with a single row
         table = wandb.Table(columns=["text"], data=[[value]])
-
-        if step is not None:
-            self.experiment.log({name: value}, step=step)
-        else:
-            self.experiment.log({name: table})
+        self._log_payload(
+            {name: value if step is not None else table},
+            step=step,
+            override_global_step=override_global_step,
+        )
 
     def log_metrics(
         self,
@@ -221,6 +250,7 @@ class WandbLogger(Logger):
         step: int | None = None,
         *,
         keys_sep: str = "/",
+        override_global_step: bool = False,
     ) -> dict[str, Any]:
         """Log multiple scalar metrics at once to wandb.
 
@@ -240,5 +270,81 @@ class WandbLogger(Logger):
             The converted metrics dictionary (with tensors converted to Python types).
         """
         safe_metrics = _make_metrics_safe(metrics, keys_sep=keys_sep)
-        self.experiment.log(safe_metrics, step=step)
+        self._log_payload(
+            safe_metrics, step=step, override_global_step=override_global_step
+        )
         return safe_metrics
+
+    @staticmethod
+    def _is_step_key(name: str) -> bool:
+        return name == "step" or name.endswith("/step")
+
+    @staticmethod
+    def _step_key(name: str) -> str:
+        if WandbLogger._is_step_key(name):
+            return name
+        prefix, sep, _ = name.rpartition("/")
+        return f"{prefix}{sep}step" if sep else "step"
+
+    def _consume_step(self, step_key: str, step: int | None) -> int:
+        last_step = self._step_registry.get(step_key, -1)
+        if step is None:
+            step = last_step + 1
+        self._step_registry[step_key] = max(last_step, step)
+        return step
+
+    def _define_metric(self, name: str, *, step_metric: str | None = None) -> None:
+        if step_metric is None:
+            if name in self._defined_step_metrics:
+                return
+            self._defined_step_metrics.add(name)
+            self.experiment.define_metric(name)
+            return
+
+        if name in self._defined_metrics:
+            return
+        self._defined_metrics.add(name)
+        self.experiment.define_metric(name, step_metric=step_metric)
+
+    def _prepare_payload(
+        self, payload: dict[str, Any], step: int | None
+    ) -> dict[str, Any]:
+        prepared = dict(payload)
+
+        for key, value in list(prepared.items()):
+            if self._is_step_key(key):
+                self._consume_step(key, value)
+
+        for key in list(prepared):
+            if self._is_step_key(key):
+                continue
+            step_key = self._step_key(key)
+            if step_key not in prepared:
+                prepared[step_key] = self._consume_step(step_key, step)
+
+        return prepared
+
+    def _register_metrics(self, payload: dict[str, Any]) -> None:
+        for key in payload:
+            if self._is_step_key(key):
+                self._define_metric(key)
+        for key in payload:
+            if self._is_step_key(key):
+                continue
+            self._define_metric(key, step_metric=self._step_key(key))
+
+    def _log_payload(
+        self,
+        payload: dict[str, Any],
+        *,
+        step: int | None = None,
+        override_global_step: bool = False,
+        **kwargs,
+    ) -> None:
+        if override_global_step:
+            self.experiment.log(payload, step=step, **kwargs)
+            return
+
+        payload = self._prepare_payload(payload, step)
+        self._register_metrics(payload)
+        self.experiment.log(payload, **kwargs)


### PR DESCRIPTION
## Summary
- inject per-group WandB step metrics by default instead of relying on the run-global `step`
- add an `override_global_step` escape hatch across the WandB logger paths and forward it through `RayLogger.log_metrics`
- extend `test/test_loggers.py` with WandB payload assertions and a Ray forwarding unit test

## Test Plan
- python -m pytest test/test_loggers.py
