### PR TITLE
[Feature] Evaluator weight sync via WeightSyncScheme + multi-model support

### DIFF
--- a/docs/source/reference/collectors_weightsync.rst
+++ b/docs/source/reference/collectors_weightsync.rst
@@ -610,14 +610,29 @@ registered buffers), but **are** captured by both:
   ``get_extra_state()`` and stores the result under a special
   ``"__extra_state__"`` key in the TensorDict.
 
-This means no special handling is needed — just register a scheme for
-the VecNormV2 transform and include it in ``weights_dict``:
+This means no special handling is needed for the *transfer* — just
+register a scheme for the VecNormV2 transform and include it in
+``weights_dict``.
+
+**Freezing worker-side VecNormV2**: when collector workers receive
+stats from the trainer, they should **not** update those stats with
+their own data.  Freeze VecNormV2 in the worker env factory so that
+only the training process accumulates statistics:
 
 .. code-block:: python
 
+    from torchrl.collectors import MultiSyncCollector
     from torchrl.weight_update import MultiProcessWeightSyncScheme
 
-    # VecNormV2 is the first transform on the env
+    def make_worker_env():
+        """Worker env: VecNormV2 is frozen so stats come from the trainer."""
+        env = make_base_env()  # includes VecNormV2 transform
+        # Freeze so the worker doesn't update running stats locally
+        for t in env.transform:
+            if hasattr(t, "freeze"):
+                t.freeze()
+        return env
+
     weight_sync_schemes = {
         "policy": MultiProcessWeightSyncScheme(strategy="tensordict"),
         "env.transform[0]": MultiProcessWeightSyncScheme(
@@ -626,7 +641,7 @@ the VecNormV2 transform and include it in ``weights_dict``:
     }
 
     collector = MultiSyncCollector(
-        create_env_fn=[make_env, make_env],
+        create_env_fn=[make_worker_env, make_worker_env],
         policy_factory=policy_factory,
         frames_per_batch=200,
         total_frames=10000,
@@ -634,9 +649,9 @@ the VecNormV2 transform and include it in ``weights_dict``:
     )
 
     for data in collector:
-        # ... training step ...
+        # ... training step (updates train_env VecNormV2 stats) ...
 
-        # Sync policy weights + VecNormV2 running stats
+        # Push trainer's stats to frozen worker VecNormV2 instances
         collector.update_policy_weights_(
             weights_dict={
                 "policy": train_policy,
@@ -651,6 +666,12 @@ the VecNormV2 transform and include it in ``weights_dict``:
     **any** module that defines it, not just VecNormV2.  If you have
     custom modules with stateful buffers exposed via this PyTorch
     protocol, they will be synchronized automatically.
+
+.. note::
+    The :class:`~torchrl.collectors.Evaluator` **automatically freezes**
+    VecNormV2 transforms in the eval env (see :ref:`evaluator-vecnorm`
+    below).  For regular collectors, you must freeze explicitly in the
+    env factory as shown above.
 
 Evaluator Weight Sync
 ---------------------
@@ -726,6 +747,8 @@ transfer:
 
     result = evaluator.poll()
 
+.. _evaluator-vecnorm:
+
 VecNormV2 Running Stats
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -759,6 +782,30 @@ handling is needed:
         },
         step=step,
     )
+
+.. important::
+    The evaluator **automatically freezes** all
+    :class:`~torchrl.envs.transforms.VecNormV2` (and
+    :class:`~torchrl.envs.transforms.VecNorm`) transforms in the eval
+    environment — whether the env is passed directly or created from a
+    factory.  This means the eval environment uses the training
+    statistics as-is and does not update them with eval data.
+
+    You do **not** need to call ``.freeze()`` or use ``frozen_copy()``
+    in your eval env factory — the evaluator handles this.
+
+    For **regular collectors** (not the evaluator), workers that
+    receive VecNormV2 stats via ``weight_sync_schemes`` should be
+    frozen explicitly in the env factory:
+
+    .. code-block:: python
+
+        def make_worker_env():
+            env = make_base_env()
+            for t in env.transform:
+                if hasattr(t, "freeze"):
+                    t.freeze()
+            return env
 
 Transports
 ----------

--- a/docs/source/reference/collectors_weightsync.rst
+++ b/docs/source/reference/collectors_weightsync.rst
@@ -381,9 +381,10 @@ Usage Examples
 
 .. note::
     **Runnable versions** of these examples are available in the repository:
-    
+
     - `examples/collectors/weight_sync_standalone.py <https://github.com/pytorch/rl/blob/main/examples/collectors/weight_sync_standalone.py>`_: Standalone weight synchronization
     - `examples/collectors/weight_sync_collectors.py <https://github.com/pytorch/rl/blob/main/examples/collectors/weight_sync_collectors.py>`_: Collector integration
+    - `examples/collectors/multi_weight_updates.py <https://github.com/pytorch/rl/blob/main/examples/collectors/multi_weight_updates.py>`_: Multi-model weight sync (policy + env + replay buffer)
 
 Using Weight Sync Schemes with Collectors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -509,6 +510,255 @@ two-phase pattern: initialize first (no communication), then connect (blocking r
     The ``strategy`` parameter determines the weight format: ``"state_dict"`` uses PyTorch's native state
     dictionaries, while ``"tensordict"`` (default) uses TensorDict format which is more efficient for
     structured models and supports features like device mapping.
+
+Multi-Model Weight Sync in Collectors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In many RL pipelines, the policy is not the only model that needs
+synchronization.  Common cases include:
+
+- **Env transforms** such as :class:`~torchrl.envs.transforms.ModuleTransform`
+  wrapping a learned feature extractor.
+- **Replay buffer transforms** with a module (e.g., a learned priority model
+  or a preprocessing network).
+- **Running statistics** from :class:`~torchrl.envs.transforms.VecNormV2`
+  (running mean, variance, count).
+
+The ``weight_sync_schemes`` dict maps **model IDs** (dotted paths into the
+collector's object tree) to scheme instances.  The ``update_policy_weights_``
+method then accepts a ``weights_dict`` to update all models atomically.
+
+.. note::
+    **Runnable version**: `examples/collectors/multi_weight_updates.py
+    <https://github.com/pytorch/rl/blob/main/examples/collectors/multi_weight_updates.py>`_
+
+Model ID Paths
+^^^^^^^^^^^^^^
+
+Model IDs are dotted attribute paths resolved from the collector.
+Common patterns:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Model ID
+     - Resolves to
+   * - ``"policy"``
+     - The collector's policy module
+   * - ``"env.transform[0]"``
+     - First transform on the env
+   * - ``"env.transform[0].module"``
+     - The ``module`` attribute of a :class:`ModuleTransform`
+   * - ``"replay_buffer.transform[0].module"``
+     - Module inside a replay-buffer transform
+
+Subscript notation (``[0]``, ``["key"]``) is supported for indexing into
+sequences or dicts.
+
+Example: Policy + Env Transform + Replay Buffer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+    from torchrl.collectors import MultiSyncCollector
+    from torchrl.weight_update import MultiProcessWeightSyncScheme
+
+    weight_sync_schemes = {
+        "policy": MultiProcessWeightSyncScheme(strategy="state_dict"),
+        "env.transform[0].module": MultiProcessWeightSyncScheme(
+            strategy="tensordict"
+        ),
+        "replay_buffer.transform[0].module": MultiProcessWeightSyncScheme(
+            strategy="tensordict"
+        ),
+    }
+
+    collector = MultiSyncCollector(
+        create_env_fn=[make_env, make_env],
+        policy_factory=policy_factory,
+        frames_per_batch=200,
+        total_frames=10000,
+        weight_sync_schemes=weight_sync_schemes,
+        replay_buffer=rb,
+    )
+
+    for data in collector:
+        # ... training step ...
+
+        # Atomic update of all three models
+        collector.update_policy_weights_(
+            weights_dict={
+                "policy": train_policy,
+                "env.transform[0].module": train_env_module,
+                "replay_buffer.transform[0].module": train_rb_module,
+            }
+        )
+
+    collector.shutdown()
+
+VecNormV2 Running Statistics
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:class:`~torchrl.envs.transforms.VecNormV2` stores running mean, variance,
+and count as "extra state" (via PyTorch's ``get_extra_state()`` /
+``set_extra_state()``).  These are **not** captured by
+``TensorDict.from_module()`` (which only sees ``nn.Parameter`` and
+registered buffers), but **are** captured by both:
+
+- The ``"state_dict"`` strategy (via PyTorch's ``state_dict()``).
+- The ``"tensordict"`` strategy, which additionally calls
+  ``get_extra_state()`` and stores the result under a special
+  ``"__extra_state__"`` key in the TensorDict.
+
+This means no special handling is needed — just register a scheme for
+the VecNormV2 transform and include it in ``weights_dict``:
+
+.. code-block:: python
+
+    from torchrl.weight_update import MultiProcessWeightSyncScheme
+
+    # VecNormV2 is the first transform on the env
+    weight_sync_schemes = {
+        "policy": MultiProcessWeightSyncScheme(strategy="tensordict"),
+        "env.transform[0]": MultiProcessWeightSyncScheme(
+            strategy="tensordict"
+        ),
+    }
+
+    collector = MultiSyncCollector(
+        create_env_fn=[make_env, make_env],
+        policy_factory=policy_factory,
+        frames_per_batch=200,
+        total_frames=10000,
+        weight_sync_schemes=weight_sync_schemes,
+    )
+
+    for data in collector:
+        # ... training step ...
+
+        # Sync policy weights + VecNormV2 running stats
+        collector.update_policy_weights_(
+            weights_dict={
+                "policy": train_policy,
+                "env.transform[0]": train_env.transform[0],  # VecNormV2
+            }
+        )
+
+    collector.shutdown()
+
+.. important::
+    The ``"tensordict"`` strategy captures ``get_extra_state()`` from
+    **any** module that defines it, not just VecNormV2.  If you have
+    custom modules with stateful buffers exposed via this PyTorch
+    protocol, they will be synchronized automatically.
+
+Evaluator Weight Sync
+---------------------
+
+The :class:`~torchrl.collectors.Evaluator` supports multi-model weight
+synchronization through two complementary mechanisms:
+
+1. **``weights_dict``** parameter on ``evaluate()`` / ``trigger_eval()`` --
+   a dict mapping model IDs to weight sources (``nn.Module`` or
+   ``TensorDictBase``).
+2. **``weight_sync_schemes``** parameter on ``Evaluator.__init__()`` --
+   enables process-level isolation via
+   :class:`~torchrl.collectors.MultiSyncCollector` (1 worker) with
+   scheme-based weight transfer.
+
+Thread Backend (Same Process)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Without ``weight_sync_schemes``, the evaluator runs in the same process
+(thread backend) and applies weights directly via ``to_module()``.  The
+``weights_dict`` parameter lets you sync multiple models:
+
+.. code-block:: python
+
+    from torchrl.collectors import Evaluator
+
+    evaluator = Evaluator(env, policy, max_steps=1000)
+
+    # Sync policy only (backward-compatible)
+    evaluator.evaluate(weights=train_policy, step=0)
+
+    # Sync policy + env transform (e.g., VecNormV2)
+    evaluator.evaluate(
+        weights_dict={
+            "policy": train_policy,
+            "env.transform[0]": train_env.transform[0],
+        },
+        step=0,
+    )
+
+Process Backend (CUDA Isolation)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With ``backend="process"`` or ``weight_sync_schemes``, the evaluator
+creates a :class:`~torchrl.collectors.MultiSyncCollector` with a single
+worker process internally.  This provides full CUDA context isolation
+and uses the weight-sync-scheme infrastructure for cross-process weight
+transfer:
+
+.. code-block:: python
+
+    from torchrl.collectors import Evaluator
+    from torchrl.weight_update import MultiProcessWeightSyncScheme
+
+    evaluator = Evaluator(
+        env=make_eval_env,
+        policy_factory=make_eval_policy,
+        weight_sync_schemes={
+            "policy": MultiProcessWeightSyncScheme(),
+            "env.transform[0]": MultiProcessWeightSyncScheme(),
+        },
+        max_steps=1000,
+    )
+
+    # Sync both policy and env transform via schemes
+    evaluator.trigger_eval(
+        weights_dict={
+            "policy": train_policy,
+            "env.transform[0]": train_env.transform[0],
+        },
+        step=current_step,
+    )
+
+    result = evaluator.poll()
+
+VecNormV2 Running Stats
+~~~~~~~~~~~~~~~~~~~~~~~
+
+When using the ``"tensordict"`` strategy (default), the
+:class:`WeightStrategy` captures ``get_extra_state()`` alongside
+parameters from ``TensorDict.from_module()``.  This means running
+statistics from :class:`~torchrl.envs.transforms.VecNormV2` (running
+mean, variance, count) are automatically synchronized.  No special
+handling is needed:
+
+.. code-block:: python
+
+    from torchrl.weight_update import MultiProcessWeightSyncScheme
+
+    # VecNormV2 running stats are automatically captured by the
+    # tensordict strategy via get_extra_state() / set_extra_state()
+    evaluator = Evaluator(
+        env=make_eval_env,  # eval env with VecNormV2 transform
+        policy_factory=make_eval_policy,
+        weight_sync_schemes={
+            "policy": MultiProcessWeightSyncScheme(strategy="tensordict"),
+            "env.transform[0]": MultiProcessWeightSyncScheme(strategy="tensordict"),
+        },
+        max_steps=1000,
+    )
+
+    evaluator.trigger_eval(
+        weights_dict={
+            "policy": train_policy,
+            "env.transform[0]": train_env.transform[0],  # VecNormV2
+        },
+        step=step,
+    )
 
 Transports
 ----------

--- a/test/collectors/test_evaluator.py
+++ b/test/collectors/test_evaluator.py
@@ -14,8 +14,9 @@ from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 from torch import nn
 from torchrl.collectors import Evaluator
+from torchrl.collectors._evaluator import _freeze_vecnorm
 from torchrl.envs import SerialEnv, TransformedEnv
-from torchrl.envs.transforms import RewardSum, StepCounter
+from torchrl.envs.transforms import RewardSum, StepCounter, VecNormV2
 from torchrl.testing.mocking_classes import ContinuousActionVecMockEnv
 from torchrl.weight_update import WeightStrategy
 
@@ -959,6 +960,106 @@ class TestEvaluatorProcessBackendAsMultiCollector:
                 max_steps=50,
                 backend="process",
             )
+
+
+def _make_vecnorm_env():
+    """Create an env with VecNormV2 transform."""
+    base = ContinuousActionVecMockEnv()
+    return TransformedEnv(
+        base,
+        VecNormV2(
+            in_keys=["observation"],
+            out_keys=["observation"],
+        ),
+    )
+
+
+class TestEvaluatorVecNormFreeze:
+    """Tests that VecNormV2 transforms are frozen in eval environments."""
+
+    def test_freeze_vecnorm_utility(self):
+        """_freeze_vecnorm freezes VecNormV2 transforms."""
+        env = _make_vecnorm_env()
+        assert not env.transform.frozen
+        _freeze_vecnorm(env)
+        assert env.transform.frozen
+
+    def test_freeze_vecnorm_nested(self):
+        """_freeze_vecnorm handles nested Compose transforms."""
+        from torchrl.envs.transforms import Compose
+
+        base = ContinuousActionVecMockEnv()
+        vecnorm = VecNormV2(in_keys=["observation"], out_keys=["observation"])
+        env = TransformedEnv(base, Compose(StepCounter(), vecnorm))
+        assert not vecnorm.frozen
+        _freeze_vecnorm(env)
+        assert vecnorm.frozen
+
+    def test_evaluator_freezes_eager_env(self):
+        """Evaluator freezes VecNormV2 when env is passed directly."""
+        env = _make_vecnorm_env()
+        policy = _make_policy(env)
+        assert not env.transform.frozen
+
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            # VecNormV2 should be frozen after construction
+            assert env.transform.frozen
+            metrics = evaluator.evaluate(step=0)
+            assert "eval/reward" in metrics
+        finally:
+            evaluator.shutdown()
+
+    def test_evaluator_freezes_factory_env(self):
+        """Evaluator freezes VecNormV2 when env is a factory."""
+        frozen_flags = []
+
+        def tracked_env_factory():
+            env = _make_vecnorm_env()
+            # Not frozen at creation
+            frozen_flags.append(env.transform.frozen)
+            return env
+
+        evaluator = Evaluator(
+            tracked_env_factory,
+            policy_factory=_make_policy,
+            max_steps=50,
+        )
+        try:
+            metrics = evaluator.evaluate(step=0)
+            assert "eval/reward" in metrics
+            # Factory created env unfrozen, but evaluator froze it
+            assert frozen_flags[0] is False
+            # The env inside the evaluator should now be frozen
+            assert evaluator._backend._env.transform.frozen
+        finally:
+            evaluator.shutdown()
+
+    def test_frozen_vecnorm_stats_not_updated(self):
+        """Frozen VecNormV2 should not update running stats during eval."""
+        env = _make_vecnorm_env()
+        policy = _make_policy(env)
+
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            # Initialize the VecNormV2 with one step so stats exist
+            td = env.reset()
+            env.transform.frozen = False  # temporarily unfreeze to init
+            env.step(policy(td))
+            env.transform.freeze()  # re-freeze
+
+            # Record count before eval
+            count_before = env.transform._count.clone()
+
+            # Run eval — should NOT update the count
+            evaluator.evaluate(step=0)
+
+            count_after = env.transform._count.clone()
+            assert (
+                count_before == count_after
+            ).all(), "VecNormV2 count was updated during eval"
+        finally:
+            evaluator.shutdown()
 
 
 if __name__ == "__main__":

--- a/test/collectors/test_evaluator.py
+++ b/test/collectors/test_evaluator.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import threading
 import time
+from collections import OrderedDict
 
 import pytest
 import torch
@@ -16,6 +17,7 @@ from torchrl.collectors import Evaluator
 from torchrl.envs import SerialEnv, TransformedEnv
 from torchrl.envs.transforms import RewardSum, StepCounter
 from torchrl.testing.mocking_classes import ContinuousActionVecMockEnv
+from torchrl.weight_update import WeightStrategy
 
 
 def _make_env():
@@ -711,6 +713,252 @@ class TestEvaluatorErrors:
     def test_invalid_backend_raises(self):
         with pytest.raises(ValueError, match="Unknown backend"):
             Evaluator(_make_env, policy=_make_policy(), max_steps=50, backend="invalid")
+
+
+class TestEvaluatorWeightsDict:
+    """Tests for the new weights_dict multi-model weight sync API."""
+
+    def test_weights_dict_policy_only(self):
+        """weights_dict={"policy": module} should work same as weights=module."""
+        env = _make_env()
+        policy = _make_policy(env)
+        train_policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            metrics = evaluator.evaluate(weights_dict={"policy": train_policy}, step=0)
+            assert "eval/reward" in metrics
+        finally:
+            evaluator.shutdown()
+
+    def test_weights_backward_compat(self):
+        """Old weights=module API still works alongside new weights_dict."""
+        env = _make_env()
+        policy = _make_policy(env)
+        train_policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            metrics = evaluator.evaluate(weights=train_policy, step=0)
+            assert "eval/reward" in metrics
+        finally:
+            evaluator.shutdown()
+
+    def test_weights_and_weights_dict_merged(self):
+        """weights goes to 'policy' key if not already in weights_dict."""
+        env = _make_env()
+        policy = _make_policy(env)
+        train_policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            # weights_dict doesn't have "policy", so weights fills it
+            metrics = evaluator.evaluate(weights=train_policy, weights_dict={}, step=0)
+            assert "eval/reward" in metrics
+        finally:
+            evaluator.shutdown()
+
+    def test_async_weights_dict(self):
+        """trigger_eval accepts weights_dict."""
+        env = _make_env()
+        policy = _make_policy(env)
+        train_policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=50)
+        try:
+            evaluator.trigger_eval(weights_dict={"policy": train_policy}, step=0)
+            result = evaluator.wait(timeout=30)
+            assert result is not None
+            assert "eval/reward" in result
+        finally:
+            evaluator.shutdown()
+
+
+class _ModuleWithExtraState(nn.Module):
+    """Test module that defines get_extra_state/set_extra_state."""
+
+    def __init__(self, dim: int = 4):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim)
+        self.running_mean = torch.zeros(dim)
+        self.running_var = torch.ones(dim)
+        self.count = torch.tensor(0)
+
+    def forward(self, x):
+        return self.linear(x)
+
+    def get_extra_state(self) -> OrderedDict:
+        return OrderedDict(
+            running_mean=self.running_mean.clone(),
+            running_var=self.running_var.clone(),
+            count=self.count.clone(),
+        )
+
+    def set_extra_state(self, state: OrderedDict) -> None:
+        self.running_mean = state["running_mean"]
+        self.running_var = state["running_var"]
+        self.count = state["count"]
+
+
+class TestWeightStrategyExtraState:
+    """Tests for WeightStrategy tensordict mode capturing get_extra_state."""
+
+    def test_extract_captures_extra_state(self):
+        """extract_weights with tensordict mode captures get_extra_state."""
+        module = _ModuleWithExtraState(dim=4)
+        module.running_mean.fill_(42.0)
+        module.count.fill_(100)
+
+        strategy = WeightStrategy(extract_as="tensordict")
+        weights = strategy.extract_weights(module)
+        assert "__extra_state__" in weights.keys()
+        extra = weights["__extra_state__"]
+        assert torch.allclose(extra["running_mean"], torch.tensor(42.0).expand(4))
+        assert extra["count"].item() == 100
+
+    def test_extract_no_extra_state(self):
+        """Modules without get_extra_state should not have __extra_state__."""
+        module = nn.Linear(4, 4)
+        strategy = WeightStrategy(extract_as="tensordict")
+        weights = strategy.extract_weights(module)
+        assert "__extra_state__" not in weights.keys()
+
+    def test_apply_restores_extra_state(self):
+        """apply_weights with __extra_state__ calls set_extra_state."""
+        src = _ModuleWithExtraState(dim=4)
+        src.running_mean.fill_(99.0)
+        src.running_var.fill_(2.0)
+        src.count.fill_(50)
+
+        dst = _ModuleWithExtraState(dim=4)
+        assert dst.running_mean.sum().item() == 0.0
+
+        strategy = WeightStrategy(extract_as="tensordict")
+        weights = strategy.extract_weights(src)
+        strategy.apply_weights(dst, weights, inplace=True)
+
+        assert torch.allclose(dst.running_mean, torch.tensor(99.0).expand(4))
+        assert torch.allclose(dst.running_var, torch.tensor(2.0).expand(4))
+        assert dst.count.item() == 50
+
+    def test_apply_extra_state_outofplace(self):
+        """apply_weights out-of-place also restores extra_state."""
+        src = _ModuleWithExtraState(dim=4)
+        src.running_mean.fill_(7.0)
+        src.count.fill_(3)
+
+        dst = _ModuleWithExtraState(dim=4)
+
+        strategy = WeightStrategy(extract_as="tensordict")
+        weights = strategy.extract_weights(src)
+        strategy.apply_weights(dst, weights, inplace=False)
+
+        assert torch.allclose(dst.running_mean, torch.tensor(7.0).expand(4))
+        assert dst.count.item() == 3
+
+    def test_state_dict_mode_already_captures_extra(self):
+        """state_dict mode should already capture extra_state via PyTorch."""
+        module = _ModuleWithExtraState(dim=4)
+        module.running_mean.fill_(5.0)
+
+        strategy = WeightStrategy(extract_as="state_dict")
+        weights = strategy.extract_weights(module)
+        # state_dict() includes extra_state under a special key
+        assert isinstance(weights, dict)
+
+    def test_roundtrip_preserves_params_and_extra(self):
+        """Full roundtrip: extract -> apply preserves both params and extra."""
+        src = _ModuleWithExtraState(dim=4)
+        nn.init.constant_(src.linear.weight, 3.0)
+        nn.init.constant_(src.linear.bias, 1.0)
+        src.running_mean.fill_(10.0)
+        src.count.fill_(25)
+
+        dst = _ModuleWithExtraState(dim=4)
+        nn.init.constant_(dst.linear.weight, 0.0)
+        nn.init.constant_(dst.linear.bias, 0.0)
+
+        strategy = WeightStrategy(extract_as="tensordict")
+        weights = strategy.extract_weights(src)
+        strategy.apply_weights(dst, weights, inplace=True)
+
+        # Check params were updated
+        assert torch.allclose(
+            dst.linear.weight, torch.tensor(3.0).expand_as(dst.linear.weight)
+        )
+        assert torch.allclose(
+            dst.linear.bias, torch.tensor(1.0).expand_as(dst.linear.bias)
+        )
+        # Check extra_state was updated
+        assert torch.allclose(dst.running_mean, torch.tensor(10.0).expand(4))
+        assert dst.count.item() == 25
+
+
+class TestEvaluatorProcessBackendAsMultiCollector:
+    """Tests that backend='process' uses MultiSyncCollector internally."""
+
+    def test_process_backend_sync_eval(self):
+        """Process backend sync eval works via MultiSyncCollector."""
+        evaluator = Evaluator(
+            _make_env,
+            policy_factory=_make_policy,
+            max_steps=50,
+            backend="process",
+        )
+        try:
+            metrics = evaluator.evaluate(step=0)
+            assert "eval/reward" in metrics
+            assert "eval/episode_length" in metrics
+        finally:
+            evaluator.shutdown()
+
+    def test_process_backend_async_eval(self):
+        """Process backend async eval works via MultiSyncCollector."""
+        evaluator = Evaluator(
+            _make_env,
+            policy_factory=_make_policy,
+            max_steps=50,
+            backend="process",
+        )
+        try:
+            evaluator.trigger_eval(step=0)
+            result = evaluator.wait(timeout=30)
+            assert result is not None
+            assert "eval/reward" in result
+        finally:
+            evaluator.shutdown()
+
+    def test_process_backend_with_weights(self):
+        """Process backend with weight transfer works."""
+        train_policy = _make_policy()
+        evaluator = Evaluator(
+            _make_env,
+            policy_factory=_make_policy,
+            max_steps=50,
+            backend="process",
+        )
+        try:
+            metrics = evaluator.evaluate(weights=train_policy, step=0)
+            assert "eval/reward" in metrics
+        finally:
+            evaluator.shutdown()
+
+    def test_process_backend_requires_callable(self):
+        """Process backend requires env to be a callable."""
+        env = _make_env()
+        with pytest.raises(ValueError, match="callable"):
+            Evaluator(
+                env,
+                policy_factory=_make_policy,
+                max_steps=50,
+                backend="process",
+            )
+
+    def test_process_backend_requires_policy_factory(self):
+        """Process backend requires policy_factory."""
+        with pytest.raises(ValueError, match="policy_factory"):
+            Evaluator(
+                _make_env,
+                policy=_make_policy(),
+                max_steps=50,
+                backend="process",
+            )
 
 
 if __name__ == "__main__":

--- a/test/collectors/test_evaluator.py
+++ b/test/collectors/test_evaluator.py
@@ -14,8 +14,9 @@ from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 from torch import nn
 from torchrl.collectors import Evaluator
-from torchrl.collectors._evaluator import _freeze_vecnorm
+from torchrl.collectors._evaluator import _freeze_vecnorm, _wrap_env_factory_frozen
 from torchrl.envs import SerialEnv, TransformedEnv
+from torchrl.envs.env_creator import EnvCreator
 from torchrl.envs.transforms import RewardSum, StepCounter, VecNormV2
 from torchrl.testing.mocking_classes import ContinuousActionVecMockEnv
 from torchrl.weight_update import WeightStrategy
@@ -1034,6 +1035,34 @@ class TestEvaluatorVecNormFreeze:
             assert evaluator._backend._env.transform.frozen
         finally:
             evaluator.shutdown()
+
+    def test_wrap_env_creator_frozen(self):
+        """_wrap_env_factory_frozen preserves EnvCreator type + meta_data."""
+        creator = EnvCreator(_make_vecnorm_env, share_memory=False)
+        assert isinstance(creator, EnvCreator)
+
+        frozen_creator = _wrap_env_factory_frozen(creator)
+        # Should still be an EnvCreator (subclass)
+        assert isinstance(frozen_creator, EnvCreator)
+        # meta_data should be preserved from the original
+        assert frozen_creator.meta_data is not None
+
+        # Env created from the frozen creator should have VecNormV2 frozen
+        env = frozen_creator()
+        assert isinstance(env, TransformedEnv)
+        assert env.transform.frozen
+        env.close()
+
+    def test_wrap_plain_callable_frozen(self):
+        """_wrap_env_factory_frozen works with plain callables."""
+        frozen_factory = _wrap_env_factory_frozen(_make_vecnorm_env)
+        # Not an EnvCreator
+        assert not isinstance(frozen_factory, EnvCreator)
+
+        env = frozen_factory()
+        assert isinstance(env, TransformedEnv)
+        assert env.transform.frozen
+        env.close()
 
     def test_frozen_vecnorm_stats_not_updated(self):
         """Frozen VecNormV2 should not update running stats during eval."""

--- a/torchrl/collectors/_evaluator.py
+++ b/torchrl/collectors/_evaluator.py
@@ -744,9 +744,33 @@ def _freeze_vecnorm(env: EnvBase) -> EnvBase:
 
 
 def _wrap_env_factory_frozen(
-    env_factory: Callable[[], EnvBase]
+    env_factory: Callable[[], EnvBase],
 ) -> Callable[[], EnvBase]:
-    """Wrap an env factory to freeze VecNorm transforms after creation."""
+    """Wrap an env factory to freeze VecNorm transforms after creation.
+
+    If *env_factory* is an :class:`~torchrl.envs.EnvCreator`, the returned
+    object is also an ``EnvCreator`` (preserving pre-computed ``meta_data``
+    and shared-memory state dicts) whose ``__call__`` freezes VecNorm
+    transforms on the newly-created environment.
+    """
+    from torchrl.envs.env_creator import EnvCreator
+
+    if isinstance(env_factory, EnvCreator):
+
+        class _FrozenEnvCreator(EnvCreator):
+            """Thin ``EnvCreator`` wrapper that freezes VecNorm after creation."""
+
+            def __init__(self, original: EnvCreator):
+                # Skip parent __init__ (avoids recreating shadow env).
+                # Copy all state from the original instead.
+                self.__dict__.update(original.__dict__)
+                self._original = original
+
+            def __call__(self, **kwargs) -> EnvBase:
+                env = self._original(**kwargs)
+                return _freeze_vecnorm(env)
+
+        return _FrozenEnvCreator(env_factory)
 
     def wrapper():
         env = env_factory()

--- a/torchrl/collectors/_evaluator.py
+++ b/torchrl/collectors/_evaluator.py
@@ -713,6 +713,48 @@ def _resolve_collector_cls(cls_or_name: type | str | None):
     return cls_or_name
 
 
+def _freeze_vecnorm(env: EnvBase) -> EnvBase:
+    """Freeze all VecNorm / VecNormV2 transforms in the env.
+
+    Evaluation environments should not update running statistics —
+    they receive stats from the training process via weight sync and
+    use them as-is.
+    """
+    from torchrl.envs.transforms import Compose, TransformedEnv
+    from torchrl.envs.transforms.vecnorm import VecNormV2
+
+    # Also handle the legacy VecNorm
+    try:
+        from torchrl.envs.transforms.transforms import VecNorm
+    except ImportError:
+        VecNorm = None  # noqa: N806
+
+    def _freeze_transforms(transform):
+        if isinstance(transform, VecNormV2):
+            transform.freeze()
+        elif VecNorm is not None and isinstance(transform, VecNorm):
+            transform.freeze()
+        elif isinstance(transform, Compose):
+            for t in transform:
+                _freeze_transforms(t)
+
+    if isinstance(env, TransformedEnv):
+        _freeze_transforms(env.transform)
+    return env
+
+
+def _wrap_env_factory_frozen(
+    env_factory: Callable[[], EnvBase]
+) -> Callable[[], EnvBase]:
+    """Wrap an env factory to freeze VecNorm transforms after creation."""
+
+    def wrapper():
+        env = env_factory()
+        return _freeze_vecnorm(env)
+
+    return wrapper
+
+
 # ======================================================================
 # Thread backend
 # ======================================================================
@@ -767,8 +809,9 @@ class _ThreadEvalBackend(_EvalBackend):
         env_is_callable = callable(env) and not isinstance(env, EnvBase)
 
         if self._use_multi_collector:
-            # MultiSyncCollector path: always defer construction
-            self._env_factory = env
+            # MultiSyncCollector path: always defer construction.
+            # Wrap the factory to freeze VecNorm transforms in the worker.
+            self._env_factory = _wrap_env_factory_frozen(env)
             self._policy_factory = policy_factory
             self._env: EnvBase | None = None
             self._policy = None
@@ -782,6 +825,8 @@ class _ThreadEvalBackend(_EvalBackend):
             # Eager path (existing behaviour)
             if env_is_callable:
                 env = env()
+            # Freeze VecNorm transforms so eval doesn't update running stats
+            _freeze_vecnorm(env)
             self._env = env
 
             if policy_factory is not None:
@@ -897,6 +942,8 @@ class _ThreadEvalBackend(_EvalBackend):
                 "this should not happen."
             )
         self._env = self._env_factory()
+        # Freeze VecNorm transforms so eval doesn't update running stats
+        _freeze_vecnorm(self._env)
         self._policy = self._policy_factory(self._env)
         # Free the factories
         self._env_factory = None

--- a/torchrl/collectors/_evaluator.py
+++ b/torchrl/collectors/_evaluator.py
@@ -72,7 +72,6 @@ from __future__ import annotations
 import abc
 import importlib
 import logging
-import multiprocessing as mp
 import threading
 from collections.abc import Callable
 from typing import Any
@@ -209,7 +208,30 @@ class Evaluator:
         logger_lock: A :class:`threading.Lock` shared with the training
             loop to serialise logger access.  If ``None`` a private lock
             is created.
+        weight_sync_schemes (dict or None): A dict mapping model IDs to
+            :class:`~torchrl.weight_update.WeightSyncScheme` instances.
+            When provided, a :class:`~torchrl.collectors.MultiSyncCollector`
+            with a single worker is used for process-level CUDA isolation
+            and scheme-based weight transfer.  Model IDs follow the
+            collector convention: ``"policy"`` for the main policy,
+            ``"env.transform[0]"`` for env transforms, etc.
+            Example::
+
+                from torchrl.weight_update import MultiProcessedWeightSyncScheme
+                evaluator = Evaluator(
+                    env=make_eval_env,
+                    policy_factory=make_eval_policy,
+                    weight_sync_schemes={
+                        "policy": MultiProcessedWeightSyncScheme(),
+                        "env.transform[0]": MultiProcessedWeightSyncScheme(),
+                    },
+                    max_steps=1000,
+                )
         backend (str): ``"thread"`` (default), ``"process"``, or ``"ray"``.
+            The ``"process"`` backend is implemented as a thread backend
+            with a :class:`~torchrl.collectors.MultiSyncCollector` (1
+            worker) running in a child process.  This provides full CUDA
+            context isolation without custom queue management.
         init_fn: (*Ray only*) Callable invoked at the start of the actor
             process, before any ``torch`` import.
         num_gpus (int): (*Ray only*) GPUs requested for the actor.
@@ -229,6 +251,7 @@ class Evaluator:
         frames_per_batch: int | None = None,
         collector_cls: type | str | None = None,
         collector_kwargs: dict | None = None,
+        weight_sync_schemes: dict[str, Any] | None = None,
         logger=None,
         log_prefix: str = "eval",
         reward_keys: NestedKey = ("next", "reward"),
@@ -257,7 +280,31 @@ class Evaluator:
         self._step_counter = 0
         self._dump_video = dump_video
 
-        if backend == "thread":
+        if backend in ("thread", "process"):
+            # The process backend is implemented as a thread backend
+            # with a MultiSyncCollector (1 worker) running in a child
+            # process.  This eliminates custom process management and
+            # uses the weight_sync_schemes infrastructure for weight
+            # transfer.
+            use_multi_collector = (
+                backend == "process" or weight_sync_schemes is not None
+            )
+            if use_multi_collector:
+                env_is_callable = callable(env) and not isinstance(env, EnvBase)
+                if not env_is_callable:
+                    raise ValueError(
+                        f"The {backend!r} backend with weight_sync_schemes "
+                        "(or backend='process') requires `env` to be a callable "
+                        "(factory function) because the env is created inside "
+                        "a child process."
+                    )
+                if policy_factory is None:
+                    raise ValueError(
+                        f"The {backend!r} backend with weight_sync_schemes "
+                        "(or backend='process') requires `policy_factory` "
+                        "(a callable `(env) -> policy`) because the policy is "
+                        "created inside a child process."
+                    )
             self._backend: _EvalBackend = _ThreadEvalBackend(
                 env=env,
                 policy=policy,
@@ -272,33 +319,8 @@ class Evaluator:
                 reward_keys=reward_keys,
                 done_keys=done_keys,
                 metrics_fn=metrics_fn,
-            )
-        elif backend == "process":
-            env_is_callable = callable(env) and not isinstance(env, EnvBase)
-            if not env_is_callable:
-                raise ValueError(
-                    "The 'process' backend requires `env` to be a callable "
-                    "(factory function) because the env is created inside "
-                    "the child process."
-                )
-            if policy_factory is None:
-                raise ValueError(
-                    "The 'process' backend requires `policy_factory` (a "
-                    "callable `(env) -> policy`) because the policy is "
-                    "created inside the child process."
-                )
-            self._backend = _ProcessEvalBackend(
-                env_factory=env,
-                policy_factory=policy_factory,
-                num_trajectories=num_trajectories,
-                max_steps=max_steps,
-                frames_per_batch=frames_per_batch,
-                collector_cls=collector_cls,
-                collector_kwargs=collector_kwargs,
-                exploration_type=exploration_type,
-                reward_keys=reward_keys,
-                done_keys=done_keys,
-                metrics_fn=metrics_fn,
+                weight_sync_schemes=weight_sync_schemes,
+                use_multi_collector=use_multi_collector,
             )
         elif backend == "ray":
             self._backend = _RayEvalBackend(
@@ -323,6 +345,8 @@ class Evaluator:
         self,
         weights: TensorDictBase | nn.Module | None = None,
         step: int | None = None,
+        *,
+        weights_dict: dict[str, TensorDictBase | nn.Module] | None = None,
     ) -> dict[str, Any]:
         """Run a blocking evaluation rollout.
 
@@ -334,13 +358,21 @@ class Evaluator:
                 If ``None`` the current policy weights are used.
             step: Logging step.  If ``None`` an internal counter is used.
 
+        Keyword Args:
+            weights_dict: A dict mapping ``model_id`` strings to weight
+                sources (``nn.Module`` or ``TensorDictBase``).  Use this
+                to sync multiple models (e.g. policy + env transforms).
+                When provided, *weights* is treated as
+                ``weights_dict["policy"]`` if ``"policy"`` is not already
+                in the dict.
+
         Returns:
             dict with at least ``"<prefix>/reward"`` and
             ``"<prefix>/episode_length"`` keys.
         """
-        weights = self._prepare_weights(weights)
+        prepared = self._prepare_weights_dict(weights, weights_dict)
         step = self._next_step(step)
-        raw = self._backend.run_sync(weights, step)
+        raw = self._backend.run_sync(prepared, step)
         return self._finalize(raw)
 
     # ------------------------------------------------------------------
@@ -351,6 +383,8 @@ class Evaluator:
         self,
         weights: TensorDictBase | nn.Module | None = None,
         step: int | None = None,
+        *,
+        weights_dict: dict[str, TensorDictBase | nn.Module] | None = None,
     ) -> None:
         """Start an async evaluation (fire-and-forget).
 
@@ -358,12 +392,13 @@ class Evaluator:
         discarded.
 
         Args:
-            weights: See :meth:`evaluate`.
-            step: See :meth:`evaluate`.
+            weights: Policy weights to load.  See :meth:`evaluate`.
+            step: Logging step.  See :meth:`evaluate`.
+            weights_dict: Multi-model weights dict.  See :meth:`evaluate`.
         """
-        weights = self._prepare_weights(weights)
+        prepared = self._prepare_weights_dict(weights, weights_dict)
         step = self._next_step(step)
-        self._backend.submit(weights, step)
+        self._backend.submit(prepared, step)
 
     def poll(self, timeout: float = 0) -> dict[str, Any] | None:
         """Return the latest evaluation result if ready, else ``None``.
@@ -429,14 +464,31 @@ class Evaluator:
         """
         return TensorDict.from_module(policy).data.detach().clone().cpu()
 
-    def _prepare_weights(
-        self, weights: TensorDictBase | nn.Module | None
-    ) -> TensorDictBase | None:
-        if weights is None:
-            return None
+    @staticmethod
+    def _prepare_single(weights: TensorDictBase | nn.Module) -> TensorDictBase:
+        """Prepare a single weight source for cross-thread transfer."""
         if isinstance(weights, nn.Module):
-            return self.extract_weights(weights)
+            return Evaluator.extract_weights(weights)
         return weights.detach().clone().cpu()
+
+    def _prepare_weights_dict(
+        self,
+        weights: TensorDictBase | nn.Module | None,
+        weights_dict: dict[str, TensorDictBase | nn.Module] | None,
+    ) -> dict[str, TensorDictBase] | None:
+        """Build a ``{model_id: TensorDictBase}`` dict from user inputs.
+
+        When *weights_dict* is ``None`` and *weights* is provided, the
+        result is ``{"policy": prepared_weights}`` for backward
+        compatibility.  When both are ``None``, returns ``None``.
+        """
+        result: dict[str, TensorDictBase] = {}
+        if weights_dict:
+            for k, v in weights_dict.items():
+                result[k] = self._prepare_single(v)
+        if weights is not None and "policy" not in result:
+            result["policy"] = self._prepare_single(weights)
+        return result or None
 
     def _next_step(self, step: int | None) -> int:
         if step is not None:
@@ -503,15 +555,22 @@ class Evaluator:
 
 
 class _EvalBackend(abc.ABC):
-    """Internal contract that each backend implements."""
+    """Internal contract that each backend implements.
+
+    All weight arguments are now ``dict[str, TensorDictBase] | None``
+    mapping model IDs to prepared weight tensordicts.  For backward
+    compatibility, the ``"policy"`` key holds the main policy weights.
+    """
 
     @abc.abstractmethod
-    def run_sync(self, weights: TensorDictBase | None, step: int) -> dict[str, Any]:
+    def run_sync(
+        self, weights_dict: dict[str, TensorDictBase] | None, step: int
+    ) -> dict[str, Any]:
         """Run a blocking evaluation and return raw results."""
         ...
 
     @abc.abstractmethod
-    def submit(self, weights: TensorDictBase | None, step: int) -> None:
+    def submit(self, weights_dict: dict[str, TensorDictBase] | None, step: int) -> None:
         """Start an async evaluation (fire-and-forget)."""
         ...
 
@@ -667,6 +726,14 @@ class _ThreadEvalBackend(_EvalBackend):
     call.  For async evaluation this means construction happens inside the
     worker thread, which is critical for multi-device setups where the
     eval environment lives on a dedicated GPU.
+
+    When *weight_sync_schemes* is provided (or *use_multi_collector* is
+    ``True``), a :class:`~torchrl.collectors.MultiSyncCollector` with a
+    single worker is used instead of a plain
+    :class:`~torchrl.collectors.Collector`.  This provides process-level
+    CUDA isolation and uses the weight-sync-scheme infrastructure for
+    cross-process weight transfer — replacing the old
+    ``_ProcessEvalBackend``.
     """
 
     def __init__(
@@ -684,20 +751,32 @@ class _ThreadEvalBackend(_EvalBackend):
         reward_keys: NestedKey,
         done_keys: NestedKey,
         metrics_fn: Callable[[TensorDictBase], dict[str, float]] | None,
+        weight_sync_schemes: dict[str, Any] | None = None,
+        use_multi_collector: bool = False,
     ) -> None:
         if policy is not None and policy_factory is not None:
             raise ValueError("Provide either `policy` or `policy_factory`, not both.")
 
         self._env_factory: Callable[[], EnvBase] | None = None
         self._policy_factory: Callable[..., Callable] | None = None
+        self._use_multi_collector = use_multi_collector or (
+            weight_sync_schemes is not None
+        )
+        self._weight_sync_schemes = weight_sync_schemes
 
         env_is_callable = callable(env) and not isinstance(env, EnvBase)
 
-        # Lazy path: defer both env and policy creation to the worker thread
-        if policy_factory is not None and env_is_callable:
+        if self._use_multi_collector:
+            # MultiSyncCollector path: always defer construction
             self._env_factory = env
             self._policy_factory = policy_factory
             self._env: EnvBase | None = None
+            self._policy = None
+        elif policy_factory is not None and env_is_callable:
+            # Lazy path: defer both env and policy creation to the worker thread
+            self._env_factory = env
+            self._policy_factory = policy_factory
+            self._env = None
             self._policy = None
         else:
             # Eager path (existing behaviour)
@@ -736,6 +815,7 @@ class _ThreadEvalBackend(_EvalBackend):
 
         # Collector (created lazily)
         self._collector = None
+        self._collector_iter = None  # persistent iterator for multi-collector
 
         # Threading state
         self._lock = threading.Lock()
@@ -743,25 +823,29 @@ class _ThreadEvalBackend(_EvalBackend):
         self._eval_ready = threading.Event()
         self._result_ready = threading.Event()
         self._pending = threading.Event()  # set while an eval is in-flight
-        self._pending_request: tuple[TensorDictBase | None, int] | None = None
+        self._pending_request: tuple[
+            dict[str, TensorDictBase] | None, int
+        ] | None = None
         self._result: dict[str, Any] | None = None
         self._shutdown_flag = False
         self._thread: threading.Thread | None = None
 
     # ---- sync ----
 
-    def run_sync(self, weights: TensorDictBase | None, step: int) -> dict[str, Any]:
+    def run_sync(
+        self, weights_dict: dict[str, TensorDictBase] | None, step: int
+    ) -> dict[str, Any]:
         self._ensure_collector()
-        metrics = self._run_eval(weights)
+        metrics = self._run_eval(weights_dict)
         metrics["_step"] = step
         return metrics
 
     # ---- async ----
 
-    def submit(self, weights: TensorDictBase | None, step: int) -> None:
+    def submit(self, weights_dict: dict[str, TensorDictBase] | None, step: int) -> None:
         with self._lock:
             self._cancel.set()  # discard any in-progress result
-            self._pending_request = (weights, step)
+            self._pending_request = (weights_dict, step)
             self._result = None
             self._result_ready.clear()
             self._pending.set()
@@ -847,8 +931,8 @@ class _ThreadEvalBackend(_EvalBackend):
             if request is None:
                 continue
 
-            weights, step = request
-            metrics = self._run_eval(weights)
+            weights_dict, step = request
+            metrics = self._run_eval(weights_dict)
 
             if not self._cancel.is_set():
                 metrics["_step"] = step
@@ -864,45 +948,85 @@ class _ThreadEvalBackend(_EvalBackend):
         """Create the collector lazily (inside the worker thread)."""
         if self._collector is not None:
             return
-        self._ensure_env_and_policy()
-        cls = _resolve_collector_cls(self._collector_cls)
-        fpb = self._frames_per_batch or self._max_steps or 1000
-        # If the env already has a StepCounter (step_count in output),
-        # set max_frames_per_traj=0 to avoid conflict with the collector
-        # trying to add a second StepCounter.
-        max_frames = self._max_steps
-        if _env_has_step_count(self._env):
-            max_frames = 0
-        self._collector = cls(
-            create_env_fn=self._env,
-            policy=self._policy,
-            frames_per_batch=fpb,
-            total_frames=-1,
-            max_frames_per_traj=max_frames,
-            trajs_per_batch=self._num_trajectories,
-            exploration_type=self._exploration_type,
-            **(self._collector_kwargs or {}),
-        )
 
-    def _run_eval(self, weights: TensorDictBase | None) -> dict[str, Any]:
+        fpb = self._frames_per_batch or self._max_steps or 1000
+        kwargs = dict(self._collector_kwargs or {})
+
+        if self._use_multi_collector:
+            # Process isolation via MultiSyncCollector (1 worker).
+            # The env and policy are created inside the child process
+            # by the collector, so we pass factories — not instances.
+            from torchrl.collectors import MultiSyncCollector
+
+            self._collector = MultiSyncCollector(
+                create_env_fn=[self._env_factory],
+                policy_factory=self._policy_factory,
+                frames_per_batch=fpb,
+                total_frames=-1,
+                max_frames_per_traj=self._max_steps,
+                trajs_per_batch=self._num_trajectories,
+                exploration_type=self._exploration_type,
+                weight_sync_schemes=self._weight_sync_schemes,
+                **kwargs,
+            )
+        else:
+            self._ensure_env_and_policy()
+            cls = _resolve_collector_cls(self._collector_cls)
+            # If the env already has a StepCounter (step_count in output),
+            # set max_frames_per_traj=0 to avoid conflict with the collector
+            # trying to add a second StepCounter.
+            max_frames = self._max_steps
+            if _env_has_step_count(self._env):
+                max_frames = 0
+            self._collector = cls(
+                create_env_fn=self._env,
+                policy=self._policy,
+                frames_per_batch=fpb,
+                total_frames=-1,
+                max_frames_per_traj=max_frames,
+                trajs_per_batch=self._num_trajectories,
+                exploration_type=self._exploration_type,
+                **kwargs,
+            )
+
+    def _run_eval(
+        self, weights_dict: dict[str, TensorDictBase] | None
+    ) -> dict[str, Any]:
         """Run evaluation using the internal collector."""
         self._ensure_collector()
 
-        if weights is not None:
-            weights.to(self._device).to_module(self._policy)
+        if weights_dict:
+            if self._use_multi_collector:
+                # Multi-process: use scheme-based sync via the collector
+                self._collector.update_policy_weights_(weights_dict=weights_dict)
+            else:
+                # Same process: apply weights directly
+                for model_id, w in weights_dict.items():
+                    if model_id == "policy":
+                        w.to(self._device).to_module(self._policy)
+                    else:
+                        from torchrl.weight_update.utils import _resolve_model
 
-        if isinstance(self._policy, nn.Module):
+                        target = _resolve_model(self._collector, model_id)
+                        w.to(self._device).to_module(target)
+
+        if not self._use_multi_collector and isinstance(self._policy, nn.Module):
             self._policy.eval()
 
-        # Reset collector for clean episode boundaries
-        self._collector.reset()
-
         with set_exploration_type(self._exploration_type), torch.no_grad():
-            # Each yield gives exactly num_trajectories complete,
-            # zero-padded episodes with ("collector", "mask").
-            traj_batch = next(iter(self._collector))
+            if self._use_multi_collector:
+                # MultiSyncCollector: use a persistent iterator because
+                # re-creating the iterator (next(iter(...))) after the first
+                # batch causes data loss from the queue/pipe based workers.
+                if self._collector_iter is None:
+                    self._collector_iter = iter(self._collector)
+                traj_batch = next(self._collector_iter)
+            else:
+                # Single-process Collector: reset and use fresh iterator
+                self._collector.reset()
+                traj_batch = next(iter(self._collector))
 
-        if isinstance(self._policy, nn.Module):
+        if not self._use_multi_collector and isinstance(self._policy, nn.Module):
             self._policy.train()
 
         return _extract_metrics_from_trajectories(
@@ -975,7 +1099,10 @@ class _RayEvalBackend(_EvalBackend):
         self._last_step: int | None = None
         self._pending_flag = False
 
-    def run_sync(self, weights: TensorDictBase | None, step: int) -> dict[str, Any]:
+    def run_sync(
+        self, weights_dict: dict[str, TensorDictBase] | None, step: int
+    ) -> dict[str, Any]:
+        weights = weights_dict.get("policy") if weights_dict else None
         self._worker.submit(
             weights,
             self._max_steps,
@@ -986,7 +1113,8 @@ class _RayEvalBackend(_EvalBackend):
         result.setdefault("episode_length", self._max_steps)
         return result
 
-    def submit(self, weights: TensorDictBase | None, step: int) -> None:
+    def submit(self, weights_dict: dict[str, TensorDictBase] | None, step: int) -> None:
+        weights = weights_dict.get("policy") if weights_dict else None
         self._last_step = step
         self._pending_flag = True
         self._worker.submit(
@@ -1017,199 +1145,3 @@ class _RayEvalBackend(_EvalBackend):
             self._worker.shutdown()
         except Exception:
             logger.warning("RayEvalBackend: error during shutdown", exc_info=True)
-
-
-# ======================================================================
-# Process backend
-# ======================================================================
-
-
-def _process_eval_worker(
-    env_factory: Callable[[], EnvBase],
-    policy_factory: Callable,
-    request_queue: mp.Queue,
-    result_queue: mp.Queue,
-    num_trajectories: int,
-    max_steps: int,
-    frames_per_batch: int | None,
-    collector_cls_name: str | None,
-    collector_kwargs: dict | None,
-    exploration_type: ExplorationType,
-    reward_keys: NestedKey,
-    done_keys: NestedKey,
-    metrics_fn: Callable[[TensorDictBase], dict[str, float]] | None,
-) -> None:
-    """Entry point for the evaluator child process.
-
-    Creates env, policy, and collector inside the process, then loops
-    waiting for ``(weights, step)`` requests on *request_queue* and puts
-    result dicts on *result_queue*.  A ``None`` sentinel terminates the loop.
-    """
-    env = env_factory()
-    policy = policy_factory(env)
-
-    try:
-        device = next(policy.parameters()).device
-    except (StopIteration, AttributeError):
-        device = torch.device("cpu")
-
-    cls = _resolve_collector_cls(collector_cls_name)
-    fpb = frames_per_batch or max_steps or 1000
-    max_frames = 0 if _env_has_step_count(env) else max_steps
-    collector = cls(
-        create_env_fn=env,
-        policy=policy,
-        frames_per_batch=fpb,
-        total_frames=-1,
-        max_frames_per_traj=max_frames,
-        trajs_per_batch=num_trajectories,
-        exploration_type=exploration_type,
-        **(collector_kwargs or {}),
-    )
-
-    while True:
-        request = request_queue.get()
-        if request is None:
-            break
-
-        weights, step = request
-
-        if weights is not None:
-            weights.to(device).to_module(policy)
-
-        if isinstance(policy, nn.Module):
-            policy.eval()
-
-        collector.reset()
-        with set_exploration_type(exploration_type), torch.no_grad():
-            traj_batch = next(iter(collector))
-        metrics = _extract_metrics_from_trajectories(
-            traj_batch, reward_keys, done_keys, metrics_fn
-        )
-
-        if isinstance(policy, nn.Module):
-            policy.train()
-
-        metrics["_step"] = step
-        result_queue.put(metrics)
-
-    collector.shutdown()
-
-
-class _ProcessEvalBackend(_EvalBackend):
-    """Runs evaluation in a child process.
-
-    The environment and policy are created **inside** the child process
-    from the provided factories, which means they live in an entirely
-    separate address space.  This avoids GIL contention for CPU-bound
-    work and gives clean CUDA context isolation for multi-GPU setups.
-
-    Like the thread backend, only the most-recently-triggered evaluation
-    produces a result (fire-and-forget).
-    """
-
-    def __init__(
-        self,
-        env_factory: Callable[[], EnvBase],
-        policy_factory: Callable[..., Callable],
-        num_trajectories: int,
-        max_steps: int,
-        frames_per_batch: int | None,
-        collector_cls: type | str | None,
-        collector_kwargs: dict | None,
-        exploration_type: ExplorationType,
-        reward_keys: NestedKey,
-        done_keys: NestedKey,
-        metrics_fn: Callable[[TensorDictBase], dict[str, float]] | None,
-    ) -> None:
-        # Serialise collector_cls as string for pickling
-        if collector_cls is not None and not isinstance(collector_cls, str):
-            collector_cls_name = (
-                collector_cls.__name__
-                if hasattr(collector_cls, "__name__")
-                else str(collector_cls)
-            )
-        else:
-            collector_cls_name = collector_cls
-
-        ctx = mp.get_context("spawn")
-        self._request_queue: mp.Queue = ctx.Queue(maxsize=1)
-        self._result_queue: mp.Queue = ctx.Queue(maxsize=1)
-        self._pending_flag = False
-        self._last_step: int | None = None
-
-        self._process = ctx.Process(
-            target=_process_eval_worker,
-            kwargs={
-                "env_factory": env_factory,
-                "policy_factory": policy_factory,
-                "request_queue": self._request_queue,
-                "result_queue": self._result_queue,
-                "num_trajectories": num_trajectories,
-                "max_steps": max_steps,
-                "frames_per_batch": frames_per_batch,
-                "collector_cls_name": collector_cls_name,
-                "collector_kwargs": collector_kwargs,
-                "exploration_type": exploration_type,
-                "reward_keys": reward_keys,
-                "done_keys": done_keys,
-                "metrics_fn": metrics_fn,
-            },
-            daemon=True,
-        )
-        self._process.start()
-
-    # ---- sync ----
-
-    def run_sync(self, weights: TensorDictBase | None, step: int) -> dict[str, Any]:
-        self._request_queue.put((weights, step))
-        return self._result_queue.get()
-
-    # ---- async ----
-
-    def submit(self, weights: TensorDictBase | None, step: int) -> None:
-        # Drain any stale result from a previous (possibly cancelled) eval
-        self._drain_result_queue()
-        self._last_step = step
-        self._pending_flag = True
-        self._request_queue.put((weights, step))
-
-    def poll(self, timeout: float) -> dict[str, Any] | None:
-        try:
-            result = self._result_queue.get(timeout=timeout if timeout > 0 else 0.001)
-            self._pending_flag = False
-            return result
-        except Exception:
-            # queue.Empty
-            return None
-
-    def wait(self, timeout: float | None) -> dict[str, Any] | None:
-        try:
-            result = self._result_queue.get(timeout=timeout)
-            self._pending_flag = False
-            return result
-        except Exception:
-            return None
-
-    @property
-    def pending(self) -> bool:
-        return self._pending_flag
-
-    def shutdown(self, timeout: float) -> None:
-        self._pending_flag = False
-        try:
-            self._request_queue.put_nowait(None)  # sentinel
-        except Exception:
-            pass
-        if self._process.is_alive():
-            self._process.join(timeout=timeout)
-            if self._process.is_alive():
-                self._process.terminate()
-
-    def _drain_result_queue(self) -> None:
-        """Remove any stale result left in the queue."""
-        while not self._result_queue.empty():
-            try:
-                self._result_queue.get_nowait()
-            except Exception:
-                break

--- a/torchrl/weight_update/weight_sync_schemes.py
+++ b/torchrl/weight_update/weight_sync_schemes.py
@@ -144,7 +144,16 @@ class WeightStrategy:
         if self.extract_as == "tensordict":
             # Extract as TensorDict
             if isinstance(source, nn.Module):
-                return TensorDict.from_module(source)
+                td = TensorDict.from_module(source)
+                # Also capture extra_state (e.g., VecNormV2 running stats)
+                # which is not included in TensorDict.from_module()
+                try:
+                    extra = source.get_extra_state()
+                except RuntimeError:
+                    extra = None
+                if extra:
+                    td["__extra_state__"] = TensorDict(extra)
+                return td
             elif isinstance(source, TensorDictBase):
                 return source
             elif isinstance(source, dict):
@@ -203,10 +212,20 @@ class WeightStrategy:
             weights = TensorDict(weights)
             if any("." in key for key in weights.keys()):
                 weights = weights.unflatten_keys(".")
+
+        # Pop extra_state before applying parameter weights
+        extra_state = None
+        if isinstance(weights, TensorDictBase) and "__extra_state__" in weights.keys():
+            extra_state = weights.pop("__extra_state__").flatten_keys(".").to_dict()
+
+        destination_module = None
         if isinstance(destination, nn.Module):
+            destination_module = destination
             # Do not update in-place
             if not inplace:
                 weights.to_module(destination)
+                if extra_state is not None:
+                    destination_module.set_extra_state(extra_state)
                 return
             else:
                 destination = TensorDict.from_module(destination)
@@ -226,6 +245,8 @@ class WeightStrategy:
                 raise ValueError(
                     "Non-empty weights are associated with a non-dict, non-td, non-Module destination."
                 )
+            if extra_state is not None and destination_module is not None:
+                destination_module.set_extra_state(extra_state)
             return
 
         try:
@@ -237,6 +258,9 @@ class WeightStrategy:
             raise KeyError(
                 f"Error updating destination. Destination keys: {destination.keys(True, True)}, weights keys: {weights.keys(True, True)}"
             ) from e
+
+        if extra_state is not None and destination_module is not None:
+            destination_module.set_extra_state(extra_state)
         return
 
 


### PR DESCRIPTION
## Summary

- **Remove `_ProcessEvalBackend` / `_process_eval_worker`** — the process backend is now a `_ThreadEvalBackend` with a `MultiSyncCollector` (1 worker), eliminating custom mp.Queue weight serialization
- **Add `weight_sync_schemes` param to `Evaluator`** for scheme-based cross-process weight sync (reuses the collector weight-sync infrastructure)
- **Add `weights_dict` param to `evaluate()` / `trigger_eval()`** for multi-model sync (policy + env transforms + VecNormV2 running stats)
- **Extend `WeightStrategy` tensordict mode** to capture `get_extra_state()` / `set_extra_state()` (needed for VecNormV2 running mean/var/count which aren't in `TensorDict.from_module()`)
- **Document multi-model weight sync** for both regular collectors and evaluators in `collectors_weightsync.rst`

## Test plan

- [x] 6 new `TestWeightStrategyExtraState` tests — extract/apply/roundtrip for `get_extra_state`
- [x] 4 new `TestEvaluatorWeightsDict` tests — weights_dict API (policy-only, backward compat, merged, async)
- [x] 5 new `TestEvaluatorProcessBackendAsMultiCollector` tests — process backend via MultiSyncCollector
- [x] All 61 existing evaluator tests pass (2 skipped: multi-CUDA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)