### PR TITLE
[BugFix] Fix CI: VecNormV2 device mismatch, Windows C++20, trackio on 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ def get_extensions():
         extra_compile_args = {
             "cxx": [
                 "/O2",  # Optimization level 2 (equivalent to -O3)
-                "/std:c++17",  # C++17 standard
+                "/std:c++20",  # C++20 standard
                 "/EHsc",  # Exception handling model
             ]
         }
@@ -135,7 +135,7 @@ def get_extensions():
                 "cxx": [
                     "/Od",  # No optimization (equivalent to -O0)
                     "/Zi",  # Generate debug info
-                    "/std:c++17",  # C++17 standard
+                    "/std:c++20",  # C++20 standard
                     "/EHsc",  # Exception handling model
                 ]
             }

--- a/test/test_loggers.py
+++ b/test/test_loggers.py
@@ -677,6 +677,7 @@ class TestPixelRenderTransform:
 
 @pytest.fixture()
 def trackio_logger():
+    pytest.importorskip("trackio")
     exp_name = "ramala"
     logger = TrackioLogger(project="test", exp_name=exp_name)
     yield logger

--- a/torchrl/envs/transforms/vecnorm.py
+++ b/torchrl/envs/transforms/vecnorm.py
@@ -591,23 +591,13 @@ class VecNormV2(Transform):
         loc = self._loc
         var = self._var
         count = self._count
-        loc_device = loc.device
         data_device = data.device
-        if (
-            loc_device is not None
-            and data_device is not None
-            and loc_device != data_device
-        ):
-            stats = TensorDict(
-                {"loc": loc, "var": var, "count": count},
-                batch_size=[],
-                device=loc_device,
-            ).to(data_device, non_blocking=True)
+        if data_device is not None:
+            loc = loc.to(data_device, non_blocking=True)
+            var = var.to(data_device, non_blocking=True)
+            count = count.to(data_device, non_blocking=True)
             if data_device.type == "cuda":
                 torch.cuda.current_stream(data_device).synchronize()
-            loc = stats["loc"]
-            var = stats["var"]
-            count = stats["count"]
         return self._norm(data, loc, var, count)
 
     def _stateful_update(self, data):
@@ -646,22 +636,14 @@ class VecNormV2(Transform):
                 weight = 1 - self.decay
             else:
                 weight = 1 / count
-        data_mean_device = data_mean.device
-        loc_device = loc.device
-        if (
-            data_mean_device is not None
-            and loc_device is not None
-            and data_mean_device != loc_device
-        ):
-            data_stats = TensorDict(
-                {"mean": data_mean, "var": data2},
-                batch_size=[],
-                device=data_mean_device,
-            ).to(loc_device, non_blocking=True)
-            if data_mean_device.type == "cuda":
-                torch.cuda.current_stream(data_mean_device).synchronize()
-            data_mean = data_stats["mean"]
-            data2 = data_stats["var"]
+        data_mean = data_mean.named_apply(
+            lambda name, dm, ref: dm.to(ref.device),
+            loc,
+        )
+        data2 = data2.named_apply(
+            lambda name, d2, ref: d2.to(ref.device),
+            var,
+        )
         loc.lerp_(end=data_mean, weight=weight)
         var.lerp_(end=data2, weight=weight)
 


### PR DESCRIPTION
## Summary

Fixes three CI failures observed in #3661 nightly runs:

- **VecNormV2 device mismatch** — `_stateful_norm` and `_stateful_update` relied on `TensorDict.device` to detect CPU/CUDA mismatches, but `.device` can be `None` for shared-memory or heterogeneous TensorDicts. Now uses per-leaf `.to(data_device)` (no-op when already on the right device) and `named_apply` for in-place `lerp_` with leaf-by-leaf device matching.
- **Windows C++20** — PyTorch nightly headers (`c10/core/AutogradState.h`) now use default member initializers for bit-fields, requiring `/std:c++20`. Bumps MSVC C++ standard from C++17 to C++20 in `setup.py`.
- **trackio on Python 3.13** — `importlib.util.find_spec("trackio")` returns non-None but the actual import fails because `audioop` was removed in 3.13 and trackio depends on `pyaudioop`. Adds `pytest.importorskip("trackio")` to the test fixture so tests skip cleanly.

## Test plan

- [ ] Windows CI builds pass (C++20 fix)
- [ ] `pytest test/transforms/test_normalization.py -k "vecnorm and device_move"` passes on CUDA
- [ ] `pytest test/test_loggers.py -k trackio` skips cleanly on Python 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)