### PR TITLE
[Feature] Lazy-init RandomPolicy action_spec from env in collectors

### DIFF
--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -502,6 +502,82 @@ class TestMakePolicyFactory:
             collector.shutdown()
 
 
+class TestRandomPolicyLazyInit:
+    """Tests for lazy initialization of ``RandomPolicy`` from the env's action_spec."""
+
+    def test_standalone_random_policy_requires_spec(self):
+        """Calling a spec-less ``RandomPolicy`` outside a collector raises a clear error."""
+        pol = RandomPolicy()
+        assert pol.action_spec is None
+        with pytest.raises(RuntimeError, match="action_spec is not set"):
+            pol(TensorDict())
+
+    def test_set_action_spec_from_env_is_idempotent(self):
+        """``set_action_spec_from_env`` only fills the spec when unset."""
+        env = ContinuousActionVecMockEnv()
+        pol = RandomPolicy()
+        pol.set_action_spec_from_env(env)
+        assert pol.action_spec is not None
+        first_spec = pol.action_spec
+        # Second call is a no-op — should not overwrite
+        pol.set_action_spec_from_env(env)
+        assert pol.action_spec is first_spec
+
+    def test_sync_collector_lazy_policy_instance(self):
+        """``Collector(env, RandomPolicy())`` fills the spec from the env."""
+        pol = RandomPolicy()
+        env = ContinuousActionVecMockEnv()
+        collector = Collector(
+            env,
+            policy=pol,
+            total_frames=20,
+            frames_per_batch=10,
+        )
+        try:
+            # Spec is filled by the collector, the user's policy instance is mutated.
+            assert pol.action_spec is not None
+            data = next(iter(collector))
+            assert "action" in data.keys()
+            assert data["action"].shape[-1] == env.full_action_spec["action"].shape[-1]
+        finally:
+            collector.shutdown()
+
+    def test_sync_collector_lazy_policy_factory(self):
+        """``policy_factory=RandomPolicy`` (returning a spec-less instance) also works."""
+        collector = Collector(
+            ContinuousActionVecMockEnv,
+            policy_factory=RandomPolicy,
+            total_frames=20,
+            frames_per_batch=10,
+        )
+        try:
+            data = next(iter(collector))
+            assert "action" in data.keys()
+        finally:
+            collector.shutdown()
+
+    def test_multi_sync_collector_lazy_policy_instance(self):
+        """Multi-worker collectors inherit the lazy-init path via the inner ``Collector``."""
+        collector = MultiSyncCollector(
+            [ContinuousActionVecMockEnv, ContinuousActionVecMockEnv],
+            policy=RandomPolicy(),
+            total_frames=40,
+            frames_per_batch=20,
+        )
+        try:
+            data = next(iter(collector))
+            assert "action" in data.keys()
+        finally:
+            collector.shutdown()
+
+    def test_explicit_spec_still_works(self):
+        """Passing an explicit ``action_spec`` keeps the original behavior unchanged."""
+        env = ContinuousActionVecMockEnv()
+        pol = RandomPolicy(env.full_action_spec)
+        td = pol(TensorDict())
+        assert "action" in td.keys()
+
+
 class TestCollectorGeneric:
     @pytest.mark.parametrize("num_env", [1, 2])
     # 1226: for efficiency, we just test vec, not "conv"

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -606,6 +606,12 @@ class Collector(BaseCollector):
         elif policy_factory is not None:
             raise TypeError("policy_factory cannot be used with policy argument.")
 
+        # Lazily initialize a RandomPolicy that was constructed without an
+        # action_spec (supports both `policy=RandomPolicy()` and a
+        # `policy_factory` that returns one).
+        if isinstance(policy, RandomPolicy):
+            policy.set_action_spec_from_env(env)
+
         if trust_policy is None:
             trust_policy = isinstance(policy, (RandomPolicy, CudaGraphModule))
         self.trust_policy = trust_policy

--- a/torchrl/modules/tensordict_module/exploration.py
+++ b/torchrl/modules/tensordict_module/exploration.py
@@ -774,7 +774,11 @@ class RandomPolicy:
     This is a wrapper around the action_spec.rand method.
 
     Args:
-        action_spec: TensorSpec object describing the action specs
+        action_spec: TensorSpec object describing the action specs. If ``None``,
+            the spec is initialized lazily (e.g. by a collector from
+            ``env.full_action_spec``). A ``RandomPolicy`` with no spec will
+            raise if called before the spec is set.
+        action_key: key at which the action is written. Defaults to ``"action"``.
 
     Examples:
         >>> from tensordict import TensorDict
@@ -782,14 +786,39 @@ class RandomPolicy:
         >>> action_spec = Bounded(-torch.ones(3), torch.ones(3))
         >>> actor = RandomPolicy(action_spec=action_spec)
         >>> td = actor(TensorDict()) # selects a random action in the cube [-1; 1]
+
+        Lazy initialization — let the collector fill in the spec from the env:
+
+        >>> from torchrl.collectors import SyncDataCollector
+        >>> collector = SyncDataCollector(env, RandomPolicy(), ...)  # doctest: +SKIP
     """
 
-    def __init__(self, action_spec: TensorSpec, action_key: NestedKey = "action"):
+    def __init__(
+        self,
+        action_spec: TensorSpec | None = None,
+        action_key: NestedKey = "action",
+    ):
         super().__init__()
-        self.action_spec = action_spec.clone()
+        self.action_spec = action_spec.clone() if action_spec is not None else None
         self.action_key = action_key
 
+    def set_action_spec_from_env(self, env: EnvBase) -> None:
+        """Initialize ``action_spec`` from ``env.full_action_spec``.
+
+        No-op if the spec is already set. Intended for lazy initialization by
+        data collectors.
+        """
+        if self.action_spec is None:
+            self.action_spec = env.full_action_spec.clone()
+
     def __call__(self, td: TensorDictBase) -> TensorDictBase:
+        if self.action_spec is None:
+            raise RuntimeError(
+                "RandomPolicy.action_spec is not set. Either pass `action_spec` "
+                "to the constructor, or let a collector initialize it by passing "
+                "the policy alongside an environment (e.g. `Collector(env, "
+                "RandomPolicy())`)."
+            )
         if isinstance(self.action_spec, Composite):
             return td.update(self.action_spec.rand())
         else:


### PR DESCRIPTION
## Summary

- Allow `Collector(env, RandomPolicy())` without pre-supplying an `action_spec`. The collector fills it in from `env.full_action_spec` in `_init_policy`.
- Same path covers `policy_factory=RandomPolicy` (factory returns a spec-less instance). Multi-worker / distributed collectors inherit the fix via the inner `SyncDataCollector`.
- Spec-less `RandomPolicy` called outside a collector raises a clear `RuntimeError` explaining the two ways to fix it.

## Test plan

- [x] New `TestRandomPolicyLazyInit` class in `test/test_collectors.py` covers:
  - standalone spec-less call raises `RuntimeError`
  - `set_action_spec_from_env` is idempotent
  - `Collector(env, RandomPolicy())` fills the spec and rolls out
  - `Collector(env, policy_factory=RandomPolicy)` works
  - `MultiSyncCollector` with `policy=RandomPolicy()` works
  - explicit `RandomPolicy(spec)` behavior unchanged
- [x] All 6 new tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)