### PR TITLE
[Doc] Use new canonical collector names across docs, tutorials, and SOTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ lines of code*!
   from tensordict.nn.distributions import NormalParamExtractor
   from torch import nn
   
-  from torchrl.collectors import SyncDataCollector
+  from torchrl.collectors import Collector
   from torchrl.data.replay_buffers import TensorDictReplayBuffer, \
     LazyTensorStorage, SamplerWithoutReplacement
   from torchrl.envs.libs.gym import GymEnv
@@ -308,7 +308,7 @@ lines of code*!
     sampler=SamplerWithoutReplacement(),
     batch_size=50,
     )
-  collector = SyncDataCollector(
+  collector = Collector(
     env,
     actor,
     frames_per_batch=1000,
@@ -495,7 +495,7 @@ And it is `functorch` and `torch.compile` compatible!
 
   ```python
   env_make = lambda: GymEnv("Pendulum-v1", from_pixels=True)
-  collector = MultiaSyncDataCollector(
+  collector = MultiAsyncCollector(
       [env_make, env_make],
       policy=policy,
       devices=["cuda:0", "cuda:0"],

--- a/benchmarks/ecosystem/gym_env_throughput.py
+++ b/benchmarks/ecosystem/gym_env_throughput.py
@@ -21,9 +21,9 @@ import torch
 import tqdm
 from torchrl._utils import timeit
 from torchrl.collectors import (
-    MultiaSyncDataCollector,
-    MultiSyncDataCollector,
-    SyncDataCollector,
+    MultiAsyncCollector,
+    MultiSyncCollector,
+    Collector,
 )
 from torchrl.envs import EnvCreator, GymEnv, ParallelEnv
 from torchrl.envs.libs.gym import gym_backend as gym_bc, set_gym_backend
@@ -109,7 +109,7 @@ if __name__ == "__main__":
                     env_make = EnvCreator(make)
                     # penv = SerialEnv(num_workers, env_make)
                     penv = ParallelEnv(num_workers, env_make, device=device)
-                    collector = SyncDataCollector(
+                    collector = Collector(
                         penv,
                         RandomPolicy(penv.action_spec),
                         frames_per_batch=1024,
@@ -171,7 +171,7 @@ if __name__ == "__main__":
                         EnvCreator(make_env),
                         device=device,
                     )
-                    collector = MultiaSyncDataCollector(
+                    collector = MultiAsyncCollector(
                         [penv] * num_collectors,
                         policy=RandomPolicy(penv.action_spec),
                         frames_per_batch=1024,
@@ -213,7 +213,7 @@ if __name__ == "__main__":
                             num_workers=num_workers
                         )
                     )
-                    collector = MultiaSyncDataCollector(
+                    collector = MultiAsyncCollector(
                         [penv] * num_collectors,
                         policy=RandomPolicy(penv().action_spec),
                         frames_per_batch=1024,
@@ -251,7 +251,7 @@ if __name__ == "__main__":
                         EnvCreator(make_env),
                         device=device,
                     )
-                    collector = MultiSyncDataCollector(
+                    collector = MultiSyncCollector(
                         [penv] * num_collectors,
                         policy=RandomPolicy(penv.action_spec),
                         frames_per_batch=1024,
@@ -293,7 +293,7 @@ if __name__ == "__main__":
                             num_workers=num_workers
                         )
                     )
-                    collector = MultiSyncDataCollector(
+                    collector = MultiSyncCollector(
                         [penv] * num_collectors,
                         policy=RandomPolicy(penv().action_spec),
                         frames_per_batch=1024,

--- a/benchmarks/ecosystem/gym_env_throughput.py
+++ b/benchmarks/ecosystem/gym_env_throughput.py
@@ -20,11 +20,7 @@ import time
 import torch
 import tqdm
 from torchrl._utils import timeit
-from torchrl.collectors import (
-    MultiAsyncCollector,
-    MultiSyncCollector,
-    Collector,
-)
+from torchrl.collectors import Collector, MultiAsyncCollector, MultiSyncCollector
 from torchrl.envs import EnvCreator, GymEnv, ParallelEnv
 from torchrl.envs.libs.gym import gym_backend as gym_bc, set_gym_backend
 from torchrl.modules import RandomPolicy

--- a/benchmarks/ecosystem/vmas_rllib_vs_torchrl_sampling_performance.py
+++ b/benchmarks/ecosystem/vmas_rllib_vs_torchrl_sampling_performance.py
@@ -22,7 +22,7 @@ from ray.rllib.agents.ppo import PPOTrainer
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.tune import register_env
 from torchrl._utils import logger as torchrl_logger
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.envs.libs.vmas import VmasEnv
 from vmas import Wrapper
 
@@ -56,7 +56,7 @@ def run_vmas_torchrl(
         seed=seed,
     )
 
-    collector = SyncDataCollector(
+    collector = Collector(
         env,
         policy=None,
         device=device,

--- a/benchmarks/test_collectors_benchmark.py
+++ b/benchmarks/test_collectors_benchmark.py
@@ -10,9 +10,9 @@ import torch.cuda
 import tqdm
 
 from torchrl.collectors import (
-    MultiaSyncDataCollector,
-    MultiSyncDataCollector,
-    SyncDataCollector,
+    MultiAsyncCollector,
+    MultiSyncCollector,
+    Collector,
 )
 from torchrl.data import LazyTensorStorage, ReplayBuffer
 from torchrl.data.utils import CloudpickleWrapper
@@ -24,7 +24,7 @@ from torchrl.modules import RandomPolicy
 def single_collector_setup():
     device = "cuda:0" if torch.cuda.device_count() else "cpu"
     env = TransformedEnv(DMControlEnv("cheetah", "run", device=device), StepCounter(50))
-    c = SyncDataCollector(
+    c = Collector(
         env,
         RandomPolicy(env.action_spec),
         total_frames=-1,
@@ -45,7 +45,7 @@ def sync_collector_setup():
             DMControlEnv("cheetah", "run", device=device), StepCounter(50)
         )
     )
-    c = MultiSyncDataCollector(
+    c = MultiSyncCollector(
         [env, env],
         RandomPolicy(env().action_spec),
         total_frames=-1,
@@ -66,7 +66,7 @@ def async_collector_setup():
             DMControlEnv("cheetah", "run", device=device), StepCounter(50)
         )
     )
-    c = MultiaSyncDataCollector(
+    c = MultiAsyncCollector(
         [env, env],
         RandomPolicy(env().action_spec),
         total_frames=-1,
@@ -86,7 +86,7 @@ def single_collector_setup_pixels():
     #     DMControlEnv("cheetah", "run", device=device, from_pixels=True), StepCounter(50)
     # )
     env = TransformedEnv(GymEnv("ALE/Pong-v5"), StepCounter(50))
-    c = SyncDataCollector(
+    c = Collector(
         env,
         RandomPolicy(env.action_spec),
         total_frames=-1,
@@ -109,7 +109,7 @@ def sync_collector_setup_pixels():
             StepCounter(50),
         )
     )
-    c = MultiSyncDataCollector(
+    c = MultiSyncCollector(
         [env, env],
         RandomPolicy(env().action_spec),
         total_frames=-1,
@@ -132,7 +132,7 @@ def async_collector_setup_pixels():
             StepCounter(50),
         )
     )
-    c = MultiaSyncDataCollector(
+    c = MultiAsyncCollector(
         [env, env],
         RandomPolicy(env().action_spec),
         total_frames=-1,
@@ -164,7 +164,7 @@ def single_collector_with_rb_setup():
     device = "cuda:0" if torch.cuda.device_count() else "cpu"
     env = TransformedEnv(DMControlEnv("cheetah", "run", device=device), StepCounter(50))
     rb = ReplayBuffer(storage=LazyTensorStorage(10000))
-    c = SyncDataCollector(
+    c = Collector(
         env,
         RandomPolicy(env.action_spec),
         total_frames=-1,
@@ -185,7 +185,7 @@ def single_collector_with_rb_setup_pixels():
     device = "cuda:0" if torch.cuda.device_count() else "cpu"
     env = TransformedEnv(GymEnv("ALE/Pong-v5"), StepCounter(50))
     rb = ReplayBuffer(storage=LazyTensorStorage(10000))
-    c = SyncDataCollector(
+    c = Collector(
         env,
         RandomPolicy(env.action_spec),
         total_frames=-1,
@@ -278,7 +278,7 @@ class TestRBGCollector:
 
         fpb = n_wokrers_per_col * 100
         total_frames = n_wokrers_per_col * 100_000
-        c = MultiaSyncDataCollector(
+        c = MultiAsyncCollector(
             [make_env] * n_col,
             policy,
             frames_per_batch=fpb,

--- a/benchmarks/test_collectors_benchmark.py
+++ b/benchmarks/test_collectors_benchmark.py
@@ -9,11 +9,7 @@ import pytest
 import torch.cuda
 import tqdm
 
-from torchrl.collectors import (
-    MultiAsyncCollector,
-    MultiSyncCollector,
-    Collector,
-)
+from torchrl.collectors import Collector, MultiAsyncCollector, MultiSyncCollector
 from torchrl.data import LazyTensorStorage, ReplayBuffer
 from torchrl.data.utils import CloudpickleWrapper
 from torchrl.envs import EnvCreator, GymEnv, ParallelEnv, StepCounter, TransformedEnv

--- a/benchmarks/test_storage_write_benchmark.py
+++ b/benchmarks/test_storage_write_benchmark.py
@@ -14,7 +14,7 @@ import pytest
 import torch
 
 from tensordict import LazyStackedTensorDict, TensorDict
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, ReplayBuffer
 from torchrl.modules import RandomPolicy
 from torchrl.testing import FastImageEnv
@@ -201,7 +201,7 @@ class TestCollectorIntegrationBenchmark:
         env = FastImageEnv(img_shape=img_shape)
         rb = ReplayBuffer(storage=LazyTensorStorage(frames_per_batch * 20))
 
-        collector = SyncDataCollector(
+        collector = Collector(
             env,
             RandomPolicy(env.action_spec),
             frames_per_batch=frames_per_batch,
@@ -230,7 +230,7 @@ class TestCollectorIntegrationBenchmark:
         env = FastImageEnv(img_shape=img_shape)
         rb = ReplayBuffer(storage=LazyTensorStorage(frames_per_batch * 20))
 
-        collector = SyncDataCollector(
+        collector = Collector(
             env,
             RandomPolicy(env.action_spec),
             frames_per_batch=frames_per_batch,
@@ -262,7 +262,7 @@ class TestCollectorIntegrationBenchmark:
             storage=LazyTensorStorage(frames_per_batch * 20, device=device)
         )
 
-        collector = SyncDataCollector(
+        collector = Collector(
             env,
             RandomPolicy(env.action_spec),
             frames_per_batch=frames_per_batch,
@@ -296,7 +296,7 @@ class TestCollectorIntegrationBenchmark:
             storage=LazyTensorStorage(frames_per_batch * 20, device=device)
         )
 
-        collector = SyncDataCollector(
+        collector = Collector(
             env,
             RandomPolicy(env.action_spec),
             frames_per_batch=frames_per_batch,

--- a/docs/source/reference/collectors_basics.rst
+++ b/docs/source/reference/collectors_basics.rst
@@ -82,7 +82,7 @@ In each of these cases, the last dimension (``T`` for ``time``) is adapted such
 that the batch size equals the ``frames_per_batch`` argument passed to the
 collector.
 
-.. warning:: :class:`~torchrl.collectors.MultiSyncDataCollector` (i.e., ``MultiCollector(sync=True)``) should not be
+.. warning:: :class:`~torchrl.collectors.MultiSyncCollector` (i.e., ``MultiCollector(sync=True)``) should not be
   used with ``cat_results=0``, as the data will be stacked along the batch
   dimension with batched environment, or the time dimension for single environments,
   which can introduce some confusion when swapping one with the other.
@@ -91,12 +91,12 @@ collector.
   better interchangeability between configurations, collector classes and other
   components.
 
-Whereas :class:`~torchrl.collectors.MultiSyncDataCollector` (i.e., ``MultiCollector(sync=True)``)
+Whereas :class:`~torchrl.collectors.MultiSyncCollector` (i.e., ``MultiCollector(sync=True)``)
 has a dimension corresponding to the number of sub-collectors being run (``B``),
-:class:`~torchrl.collectors.MultiaSyncDataCollector` (i.e., ``MultiCollector(sync=False)``) doesn't. This
-is easily understood when considering that :class:`~torchrl.collectors.MultiaSyncDataCollector`
+:class:`~torchrl.collectors.MultiAsyncCollector` (i.e., ``MultiCollector(sync=False)``) doesn't. This
+is easily understood when considering that :class:`~torchrl.collectors.MultiAsyncCollector`
 delivers batches of data on a first-come, first-serve basis, whereas
-:class:`~torchrl.collectors.MultiSyncDataCollector` gathers data from
+:class:`~torchrl.collectors.MultiSyncCollector` gathers data from
 each sub-collector before delivering it.
 
 Collectors and policy copies

--- a/docs/source/reference/collectors_replay.rst
+++ b/docs/source/reference/collectors_replay.rst
@@ -28,7 +28,7 @@ will work:
     ...     storage=LazyTensorStorage(N),
     ...     sampler=SliceSampler(num_slices=4, trajectory_key=("collector", "traj_ids"))
     ... )
-    >>> collector = SyncDataCollector(env, policy, frames_per_batch=N, total_frames=-1)
+    >>> collector = Collector(env, policy, frames_per_batch=N, total_frames=-1)
     >>> for data in collector:
     ...     memory.extend(data)
     >>> # Batched environments: a multi-dim buffer is required
@@ -37,27 +37,27 @@ will work:
     ...     sampler=SliceSampler(num_slices=4, trajectory_key=("collector", "traj_ids"))
     ... )
     >>> env = ParallelEnv(4, make_env)
-    >>> collector = SyncDataCollector(env, policy, frames_per_batch=N, total_frames=-1)
+    >>> collector = Collector(env, policy, frames_per_batch=N, total_frames=-1)
     >>> for data in collector:
     ...     memory.extend(data)
-    >>> # MultiSyncDataCollector + regular env: behaves like a ParallelEnv if cat_results="stack"
+    >>> # MultiSyncCollector + regular env: behaves like a ParallelEnv if cat_results="stack"
     >>> memory = ReplayBuffer(
     ...     storage=LazyTensorStorage(N, ndim=2),
     ...     sampler=SliceSampler(num_slices=4, trajectory_key=("collector", "traj_ids"))
     ... )
-    >>> collector = MultiSyncDataCollector([make_env] * 4,
+    >>> collector = MultiSyncCollector([make_env] * 4,
     ...     policy,
     ...     frames_per_batch=N,
     ...     total_frames=-1,
     ...     cat_results="stack")
     >>> for data in collector:
     ...     memory.extend(data)
-    >>> # MultiSyncDataCollector + parallel env: the ndim must be adapted accordingly
+    >>> # MultiSyncCollector + parallel env: the ndim must be adapted accordingly
     >>> memory = ReplayBuffer(
     ...     storage=LazyTensorStorage(N, ndim=3),
     ...     sampler=SliceSampler(num_slices=4, trajectory_key=("collector", "traj_ids"))
     ... )
-    >>> collector = MultiSyncDataCollector([ParallelEnv(2, make_env)] * 4,
+    >>> collector = MultiSyncCollector([ParallelEnv(2, make_env)] * 4,
     ...     policy,
     ...     frames_per_batch=N,
     ...     total_frames=-1,

--- a/docs/source/reference/envs_libraries.rst
+++ b/docs/source/reference/envs_libraries.rst
@@ -128,7 +128,7 @@ current episode.
 
 To handle these cases, torchrl provides a :class:`~torchrl.envs.AutoResetTransform` that will copy the observations
 that result from the call to `step` to the next `reset` and skip the calls to `reset` during rollouts (in both
-:meth:`~torchrl.envs.EnvBase.rollout` and :class:`~torchrl.collectors.SyncDataCollector` iterations).
+:meth:`~torchrl.envs.EnvBase.rollout` and :class:`~torchrl.collectors.Collector` iterations).
 This transform class also provides a fine-grained control over the behavior to be adopted for the invalid observations,
 which can be masked with `"nan"` or any other values, or not masked at all.
 

--- a/examples/distributed/collectors/multi_nodes/sync.py
+++ b/examples/distributed/collectors/multi_nodes/sync.py
@@ -11,7 +11,7 @@ import tqdm
 from torchrl._utils import logger as torchrl_logger
 
 from torchrl.collectors import Collector, MultiSyncCollector
-from torchrl.collectors.distributed import DistributedSyncDataCollector
+from torchrl.collectors.distributed import DistributedSyncCollector
 from torchrl.envs import EnvCreator
 from torchrl.envs.libs.gym import GymEnv, set_gym_backend
 from torchrl.modules import RandomPolicy
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     make_env = EnvCreator(gym_make)
     action_spec = make_env().action_spec
 
-    collector = DistributedSyncDataCollector(
+    collector = DistributedSyncCollector(
         [make_env] * num_nodes,
         RandomPolicy(action_spec),
         num_workers_per_collector=num_workers,

--- a/examples/distributed/collectors/single_machine/sync.py
+++ b/examples/distributed/collectors/single_machine/sync.py
@@ -28,7 +28,7 @@ import tqdm
 from torchrl._utils import logger as torchrl_logger
 
 from torchrl.collectors import Collector, MultiSyncCollector
-from torchrl.collectors.distributed import DistributedSyncDataCollector
+from torchrl.collectors.distributed import DistributedSyncCollector
 from torchrl.envs import EnvCreator, ParallelEnv
 from torchrl.envs.libs.gym import GymEnv, set_gym_backend
 from torchrl.modules import RandomPolicy
@@ -125,7 +125,7 @@ if __name__ == "__main__":
             f"device assignment not implemented for backend {args.backend}"
         )
 
-    collector = DistributedSyncDataCollector(
+    collector = DistributedSyncCollector(
         [make_env] * num_nodes,
         RandomPolicy(action_spec),
         num_workers_per_collector=num_workers_per_collector,

--- a/sota-implementations/a2c/a2c_atari.py
+++ b/sota-implementations/a2c/a2c_atari.py
@@ -23,7 +23,7 @@ def main(cfg: DictConfig):  # noqa: F821
     from tensordict.nn import CudaGraphModule
 
     from torchrl._utils import get_available_device, timeit
-    from torchrl.collectors import SyncDataCollector
+    from torchrl.collectors import Collector
     from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
     from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
     from torchrl.envs import ExplorationType, set_exploration_type
@@ -167,7 +167,7 @@ def main(cfg: DictConfig):  # noqa: F821
         adv_module = CudaGraphModule(adv_module)
 
     # Create collector
-    collector = SyncDataCollector(
+    collector = Collector(
         create_env_fn=make_parallel_env(
             cfg.env.env_name,
             num_envs=cfg.env.num_envs,

--- a/sota-implementations/a2c/a2c_mujoco.py
+++ b/sota-implementations/a2c/a2c_mujoco.py
@@ -24,7 +24,7 @@ def main(cfg: DictConfig):  # noqa: F821
     from tensordict.nn import CudaGraphModule
 
     from torchrl._utils import get_available_device, timeit
-    from torchrl.collectors import SyncDataCollector
+    from torchrl.collectors import Collector
     from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
     from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
     from torchrl.envs import ExplorationType, set_exploration_type
@@ -155,7 +155,7 @@ def main(cfg: DictConfig):  # noqa: F821
         adv_module = CudaGraphModule(adv_module, warmup=20)
 
     # Create collector
-    collector = SyncDataCollector(
+    collector = Collector(
         create_env_fn=make_env(cfg.env.env_name, device),
         policy=actor,
         frames_per_batch=cfg.collector.frames_per_batch,

--- a/sota-implementations/cql/utils.py
+++ b/sota-implementations/cql/utils.py
@@ -11,7 +11,7 @@ import torch.optim
 from tensordict.nn import TensorDictModule, TensorDictSequential
 from tensordict.nn.distributions import NormalParamExtractor
 
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import (
     Composite,
     LazyMemmapStorage,
@@ -130,7 +130,7 @@ def make_collector(
             device = torch.device("cuda:0")
         else:
             device = torch.device("cpu")
-    collector = SyncDataCollector(
+    collector = Collector(
         train_env,
         actor_model_explore,
         init_random_frames=cfg.collector.init_random_frames,

--- a/sota-implementations/crossq/utils.py
+++ b/sota-implementations/crossq/utils.py
@@ -8,7 +8,7 @@ import torch
 from tensordict.nn import InteractionType, TensorDictModule
 from tensordict.nn.distributions import NormalParamExtractor
 from torch import nn, optim
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import TensorDictPrioritizedReplayBuffer, TensorDictReplayBuffer
 from torchrl.data.replay_buffers.storages import LazyMemmapStorage
 from torchrl.envs import (
@@ -101,7 +101,7 @@ def make_collector(
     cudagraph=False,
 ):
     """Make collector."""
-    collector = SyncDataCollector(
+    collector = Collector(
         train_env,
         actor_model_explore,
         init_random_frames=cfg.collector.init_random_frames,

--- a/sota-implementations/ddpg/utils.py
+++ b/sota-implementations/ddpg/utils.py
@@ -11,7 +11,7 @@ import torch
 from tensordict.nn import TensorDictModule, TensorDictSequential
 
 from torch import nn, optim
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import TensorDictPrioritizedReplayBuffer, TensorDictReplayBuffer
 from torchrl.data.replay_buffers.storages import LazyMemmapStorage
 from torchrl.envs import (
@@ -123,7 +123,7 @@ def make_collector(
     device: torch.device | None = None,
 ):
     """Make collector."""
-    collector = SyncDataCollector(
+    collector = Collector(
         train_env,
         actor_model_explore,
         frames_per_batch=cfg.collector.frames_per_batch,

--- a/sota-implementations/decision_transformer/utils.py
+++ b/sota-implementations/decision_transformer/utils.py
@@ -13,7 +13,7 @@ import torch.optim
 from lamb import Lamb
 from tensordict.nn import TensorDictModule
 
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import (
     LazyMemmapStorage,
     RoundRobinWriter,
@@ -196,7 +196,7 @@ def make_collector(cfg, policy):
         cat,
     )
     collector_cfg = cfg.collector
-    collector_class = SyncDataCollector
+    collector_class = Collector
     collector = collector_class(
         make_env(cfg.env, train=True),
         policy,

--- a/sota-implementations/discrete_sac/utils.py
+++ b/sota-implementations/discrete_sac/utils.py
@@ -12,7 +12,7 @@ import torch
 from tensordict.nn import InteractionType, TensorDictModule
 
 from torch import nn, optim
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import (
     Composite,
     TensorDictPrioritizedReplayBuffer,
@@ -129,7 +129,7 @@ def make_collector(
         else:
             device = "cpu"
     device = torch.device(device)
-    collector = SyncDataCollector(
+    collector = Collector(
         train_env,
         actor_model_explore,
         init_random_frames=cfg.collector.init_random_frames,

--- a/sota-implementations/dqn/dqn_atari.py
+++ b/sota-implementations/dqn/dqn_atari.py
@@ -18,7 +18,7 @@ import torch.optim
 import tqdm
 from tensordict.nn import CudaGraphModule, TensorDictSequential
 from torchrl._utils import get_available_device, timeit
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyMemmapStorage, TensorDictReplayBuffer
 from torchrl.envs import ExplorationType, set_exploration_type
 from torchrl.modules import EGreedyModule
@@ -158,7 +158,7 @@ def main(cfg: DictConfig):  # noqa: F821
         update = CudaGraphModule(update, warmup=50)
 
     # Create the collector
-    collector = SyncDataCollector(
+    collector = Collector(
         create_env_fn=make_env(
             cfg.env.env_name, frame_skip, device, gym_backend=cfg.env.backend
         ),

--- a/sota-implementations/dqn/dqn_cartpole.py
+++ b/sota-implementations/dqn/dqn_cartpole.py
@@ -13,7 +13,7 @@ import torch.optim
 import tqdm
 from tensordict.nn import CudaGraphModule, TensorDictSequential
 from torchrl._utils import get_available_device, timeit
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
 from torchrl.envs import ExplorationType, set_exploration_type
 from torchrl.modules import EGreedyModule
@@ -118,7 +118,7 @@ def main(cfg: DictConfig):  # noqa: F821
         update = CudaGraphModule(update, warmup=50)
 
     # Create the collector
-    collector = SyncDataCollector(
+    collector = Collector(
         create_env_fn=make_env(cfg.env.env_name, "cpu"),
         policy=model_explore,
         frames_per_batch=cfg.collector.frames_per_batch,

--- a/sota-implementations/gail/gail.py
+++ b/sota-implementations/gail/gail.py
@@ -21,7 +21,7 @@ from gail_utils import log_metrics, make_gail_discriminator, make_offline_replay
 from ppo_utils import eval_model, make_env, make_ppo_models
 from tensordict.nn import CudaGraphModule
 from torchrl._utils import compile_with_warmup, get_available_device, timeit
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
 from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
 from torchrl.envs import set_gym_backend
@@ -126,7 +126,7 @@ def main(cfg: DictConfig):  # noqa: F821
                 compile_mode = "reduce-overhead"
 
     # Create collector
-    collector = SyncDataCollector(
+    collector = Collector(
         create_env_fn=make_env(cfg.env.env_name, device),
         policy=actor,
         frames_per_batch=cfg.ppo.collector.frames_per_batch,

--- a/sota-implementations/impala/impala_multi_node_ray.py
+++ b/sota-implementations/impala/impala_multi_node_ray.py
@@ -22,7 +22,7 @@ def main(cfg: DictConfig):  # noqa: F821
     import tqdm
 
     from tensordict import TensorDict
-    from torchrl.collectors import SyncDataCollector
+    from torchrl.collectors import Collector
     from torchrl.collectors.distributed import RayCollector
     from torchrl.data import LazyMemmapStorage, TensorDictReplayBuffer
     from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
@@ -94,7 +94,7 @@ def main(cfg: DictConfig):  # noqa: F821
         create_env_fn=[make_env(cfg.env.env_name, device, gym_backend=cfg.env.backend)]
         * num_workers,
         policy=actor,
-        collector_class=SyncDataCollector,
+        collector_class=Collector,
         frames_per_batch=frames_per_batch,
         total_frames=total_frames,
         max_frames_per_traj=-1,

--- a/sota-implementations/impala/impala_multi_node_submitit.py
+++ b/sota-implementations/impala/impala_multi_node_submitit.py
@@ -24,7 +24,7 @@ def main(cfg: DictConfig):  # noqa: F821
     import tqdm
 
     from tensordict import TensorDict
-    from torchrl.collectors import SyncDataCollector
+    from torchrl.collectors import Collector
     from torchrl.collectors.distributed import DistributedDataCollector
     from torchrl.data import LazyMemmapStorage, TensorDictReplayBuffer
     from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
@@ -87,7 +87,7 @@ def main(cfg: DictConfig):  # noqa: F821
         num_workers_per_collector=1,
         frames_per_batch=frames_per_batch,
         total_frames=total_frames,
-        collector_class=SyncDataCollector,
+        collector_class=Collector,
         collector_kwargs=collector_kwargs,
         slurm_kwargs=slurm_kwargs,
         storing_device="cuda:0" if cfg.collector.backend == "nccl" else "cpu",

--- a/sota-implementations/impala/impala_single_node.py
+++ b/sota-implementations/impala/impala_single_node.py
@@ -22,7 +22,7 @@ def main(cfg: DictConfig):  # noqa: F821
     import tqdm
 
     from tensordict import TensorDict
-    from torchrl.collectors import MultiaSyncDataCollector
+    from torchrl.collectors import MultiAsyncCollector
     from torchrl.data import LazyMemmapStorage, TensorDictReplayBuffer
     from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
     from torchrl.envs import ExplorationType, set_exploration_type
@@ -61,7 +61,7 @@ def main(cfg: DictConfig):  # noqa: F821
     actor, critic = make_ppo_models(cfg.env.env_name, cfg.env.backend)
 
     # Create collector
-    collector = MultiaSyncDataCollector(
+    collector = MultiAsyncCollector(
         create_env_fn=[make_env(cfg.env.env_name, device, gym_backend=cfg.env.backend)]
         * num_workers,
         policy=actor,

--- a/sota-implementations/iql/utils.py
+++ b/sota-implementations/iql/utils.py
@@ -12,7 +12,7 @@ from tensordict.nn import InteractionType, TensorDictModule
 from tensordict.nn.distributions import NormalParamExtractor
 from torch.distributions import Categorical
 
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import (
     Composite,
     LazyMemmapStorage,
@@ -129,7 +129,7 @@ def make_collector(cfg, train_env, actor_model_explore, compile_mode):
             device = torch.device("cuda:0")
         else:
             device = torch.device("cpu")
-    collector = SyncDataCollector(
+    collector = Collector(
         train_env,
         actor_model_explore,
         frames_per_batch=cfg.collector.frames_per_batch,

--- a/sota-implementations/multiagent/iql.py
+++ b/sota-implementations/multiagent/iql.py
@@ -11,7 +11,7 @@ import torch
 from tensordict.nn import TensorDictModule, TensorDictSequential
 from torch import nn
 from torchrl._utils import logger as torchrl_logger
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import TensorDictReplayBuffer
 from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
 from torchrl.data.replay_buffers.storages import LazyTensorStorage
@@ -108,7 +108,7 @@ def train(cfg: DictConfig):  # noqa: F821
         ),
     )
 
-    collector = SyncDataCollector(
+    collector = Collector(
         env,
         qnet_explore,
         device=cfg.env.device,

--- a/sota-implementations/multiagent/maddpg_iddpg.py
+++ b/sota-implementations/multiagent/maddpg_iddpg.py
@@ -11,7 +11,7 @@ import torch
 from tensordict.nn import TensorDictModule, TensorDictSequential
 from torch import nn
 from torchrl._utils import logger as torchrl_logger
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import TensorDictReplayBuffer
 from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
 from torchrl.data.replay_buffers.storages import LazyTensorStorage
@@ -134,7 +134,7 @@ def train(cfg: DictConfig):  # noqa: F821
         out_keys=[("agents", "state_action_value")],
     )
 
-    collector = SyncDataCollector(
+    collector = Collector(
         env,
         policy_explore,
         device=cfg.env.device,

--- a/sota-implementations/multiagent/mappo_ippo.py
+++ b/sota-implementations/multiagent/mappo_ippo.py
@@ -12,7 +12,7 @@ from tensordict.nn import TensorDictModule
 from tensordict.nn.distributions import NormalParamExtractor
 from torch import nn
 from torchrl._utils import logger as torchrl_logger
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import TensorDictReplayBuffer
 from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
 from torchrl.data.replay_buffers.storages import LazyTensorStorage
@@ -122,7 +122,7 @@ def train(cfg: DictConfig):  # noqa: F821
         in_keys=[("agents", "observation")],
     )
 
-    collector = SyncDataCollector(
+    collector = Collector(
         env,
         policy,
         device=cfg.env.device,

--- a/sota-implementations/multiagent/qmix_vdn.py
+++ b/sota-implementations/multiagent/qmix_vdn.py
@@ -11,7 +11,7 @@ import torch
 from tensordict.nn import TensorDictModule, TensorDictSequential
 from torch import nn
 from torchrl._utils import logger as torchrl_logger
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import TensorDictReplayBuffer
 from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
 from torchrl.data.replay_buffers.storages import LazyTensorStorage
@@ -133,7 +133,7 @@ def train(cfg: DictConfig):  # noqa: F821
     else:
         raise ValueError("Mixer type not in the example")
 
-    collector = SyncDataCollector(
+    collector = Collector(
         env,
         qnet_explore,
         device=cfg.env.device,

--- a/sota-implementations/multiagent/sac.py
+++ b/sota-implementations/multiagent/sac.py
@@ -13,7 +13,7 @@ from tensordict.nn.distributions import NormalParamExtractor
 from torch import nn
 from torch.distributions import Categorical, OneHotCategorical
 from torchrl._utils import logger as torchrl_logger
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import TensorDictReplayBuffer
 from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
 from torchrl.data.replay_buffers.storages import LazyTensorStorage
@@ -181,7 +181,7 @@ def train(cfg: DictConfig):  # noqa: F821
             out_keys=[("agents", "action_value")],
         )
 
-    collector = SyncDataCollector(
+    collector = Collector(
         env,
         policy,
         device=cfg.env.device,

--- a/sota-implementations/ppo-async/ppo_async_mujoco.py
+++ b/sota-implementations/ppo-async/ppo_async_mujoco.py
@@ -29,7 +29,7 @@ Supports three collection/advantage modes (configured via YAML):
     collector workers.
 
 Key components:
-  - MultiaSyncDataCollector for continuous background collection
+  - MultiAsyncCollector for continuous background collection
   - Replay buffer with StalenessAwareSampler for freshness-weighted sampling
   - Policy version tracking for staleness computation
   - IS diagnostics: ESS, max_ratio, mean_ratio, kl_approx

--- a/sota-implementations/ppo-async/train.py
+++ b/sota-implementations/ppo-async/train.py
@@ -19,7 +19,7 @@ from functools import partial
 import torch
 import tqdm
 
-from torchrl.collectors import Evaluator, MultiaSyncDataCollector
+from torchrl.collectors import Evaluator, MultiAsyncCollector
 from torchrl.weight_update import SharedMemWeightSyncScheme
 from utils_mujoco import (
     ActorWithCritic,
@@ -121,7 +121,7 @@ def train_start(
     ]
 
     # Collector init compiles the collector env in a subprocess
-    collector = MultiaSyncDataCollector(
+    collector = MultiAsyncCollector(
         create_env_fn=create_env_fn,
         policy=collector_policy,
         frames_per_batch=cfg.collector.frames_per_batch,
@@ -374,7 +374,7 @@ def train_iterate(
     ]
 
     # Collector init compiles the collector env in a subprocess
-    collector = MultiaSyncDataCollector(
+    collector = MultiAsyncCollector(
         create_env_fn=create_env_fn,
         policy=collector_policy,
         frames_per_batch=cfg.collector.frames_per_batch,

--- a/sota-implementations/ppo/ppo_atari.py
+++ b/sota-implementations/ppo/ppo_atari.py
@@ -25,7 +25,7 @@ def main(cfg: DictConfig):  # noqa: F821
     from tensordict.nn import CudaGraphModule
 
     from torchrl._utils import timeit
-    from torchrl.collectors import SyncDataCollector
+    from torchrl.collectors import Collector
     from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
     from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
     from torchrl.envs import ExplorationType, set_exploration_type
@@ -63,7 +63,7 @@ def main(cfg: DictConfig):  # noqa: F821
     )
 
     # Create collector
-    collector = SyncDataCollector(
+    collector = Collector(
         create_env_fn=make_parallel_env(
             cfg.env.env_name,
             num_envs=cfg.env.num_envs,

--- a/sota-implementations/ppo/ppo_mujoco.py
+++ b/sota-implementations/ppo/ppo_mujoco.py
@@ -25,7 +25,7 @@ def main(cfg: DictConfig):  # noqa: F821
     from tensordict.nn import CudaGraphModule
 
     from torchrl._utils import timeit
-    from torchrl.collectors import SyncDataCollector
+    from torchrl.collectors import Collector
     from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
     from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
     from torchrl.envs import ExplorationType, set_exploration_type
@@ -61,7 +61,7 @@ def main(cfg: DictConfig):  # noqa: F821
     actor, critic = make_ppo_models(cfg.env.env_name, device=device)
 
     # Create collector
-    collector = SyncDataCollector(
+    collector = Collector(
         create_env_fn=make_env(cfg.env.env_name, device),
         policy=actor,
         frames_per_batch=cfg.collector.frames_per_batch,

--- a/sota-implementations/redq/utils.py
+++ b/sota-implementations/redq/utils.py
@@ -20,7 +20,7 @@ from torch import distributions as d, nn, optim
 from torch.optim.lr_scheduler import CosineAnnealingLR
 
 from torchrl._utils import logger as torchrl_logger, VERBOSE
-from torchrl.collectors import DataCollectorBase
+from torchrl.collectors import BaseCollector
 from torchrl.data import (
     LazyMemmapStorage,
     MultiStep,
@@ -165,7 +165,7 @@ def correct_for_frame_skip(cfg: DictConfig) -> DictConfig:  # noqa: F821
 
 
 def make_trainer(
-    collector: DataCollectorBase,
+    collector: BaseCollector,
     loss_module: LossModule,
     recorder: EnvBase | None,
     target_net_updater: TargetNetUpdater | None,
@@ -177,7 +177,7 @@ def make_trainer(
     """Creates a Trainer instance given its constituents.
 
     Args:
-        collector (DataCollectorBase): A data collector to be used to collect data.
+        collector (BaseCollector): A data collector to be used to collect data.
         loss_module (LossModule): A TorchRL loss module
         recorder (EnvBase, optional): a recorder environment.
         target_net_updater (TargetNetUpdater): A target network update object.
@@ -196,7 +196,7 @@ def make_trainer(
         >>> from torchrl.trainers.loggers import TensorboardLogger
         >>> from torchrl.trainers import Trainer
         >>> from torchrl.envs import EnvCreator
-        >>> from torchrl.collectors import SyncDataCollector
+        >>> from torchrl.collectors import Collector
         >>> from torchrl.data import TensorDictReplayBuffer
         >>> from torchrl.envs.libs.gym import GymEnv
         >>> from torchrl.modules import TensorDictModuleWrapper, SafeModule, ValueOperator, EGreedyWrapper
@@ -211,7 +211,7 @@ def make_trainer(
         >>> net_value = torch.nn.Linear(env_proof.observation_spec.shape[-1], 1)  # for the purpose of testing
         >>> policy = SafeModule(action_spec, net, in_keys=["observation"], out_keys=["action"])
         >>> value = ValueOperator(net_value, in_keys=["observation"], out_keys=["state_action_value"])
-        >>> collector = SyncDataCollector(env_maker, policy, total_frames=100)
+        >>> collector = Collector(env_maker, policy, total_frames=100)
         >>> loss_module = DDPGLoss(policy, value, gamma=0.99)
         >>> recorder = env_proof
         >>> target_net_updater = None
@@ -980,7 +980,7 @@ def make_collector_offpolicy(
     actor_model_explore: TensorDictModuleWrapper | ProbabilisticTensorDictSequential,
     cfg: DictConfig,  # noqa: F821
     make_env_kwargs: dict | None = None,
-) -> DataCollectorBase:
+) -> BaseCollector:
     """Returns a data collector for off-policy sota-implementations.
 
     Args:

--- a/sota-implementations/sac/utils.py
+++ b/sota-implementations/sac/utils.py
@@ -10,7 +10,7 @@ import torch
 from tensordict.nn import InteractionType, TensorDictModule
 from tensordict.nn.distributions import NormalParamExtractor
 from torch import nn, optim
-from torchrl.collectors import aSyncDataCollector, SyncDataCollector
+from torchrl.collectors import AsyncCollector, Collector
 from torchrl.data import (
     LazyMemmapStorage,
     LazyTensorStorage,
@@ -131,7 +131,7 @@ def make_collector(cfg, train_env, actor_model_explore, compile_mode):
             device = torch.device("cuda:0")
         else:
             device = torch.device("cpu")
-    collector = SyncDataCollector(
+    collector = Collector(
         train_env,
         actor_model_explore,
         init_random_frames=cfg.collector.init_random_frames,
@@ -162,7 +162,7 @@ def make_collector_async(
         else:
             device = torch.device("cpu")
 
-    collector = aSyncDataCollector(
+    collector = AsyncCollector(
         train_env_make,
         actor_model_explore,
         init_random_frames=0,  # Currently not supported, but accounted for in script: cfg.collector.init_random_frames,

--- a/sota-implementations/td3/utils.py
+++ b/sota-implementations/td3/utils.py
@@ -12,7 +12,7 @@ import torch
 from tensordict.nn import TensorDictModule, TensorDictSequential
 
 from torch import nn, optim
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import TensorDictPrioritizedReplayBuffer, TensorDictReplayBuffer
 from torchrl.data.replay_buffers.storages import LazyMemmapStorage, LazyTensorStorage
 from torchrl.envs import (
@@ -116,7 +116,7 @@ def make_collector(cfg, train_env, actor_model_explore, compile_mode, device):
     collector_device = cfg.collector.device
     if collector_device in ("", None):
         collector_device = device
-    collector = SyncDataCollector(
+    collector = Collector(
         train_env,
         actor_model_explore,
         init_random_frames=cfg.collector.init_random_frames,

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -1977,7 +1977,7 @@ if __name__ == "__main__":
         """
         A simple mock environment that returns a fixed ID as its sole observation.
 
-        This environment is designed to test MultiSyncDataCollector ordering.
+        This environment is designed to test MultiSyncCollector ordering.
         Each environment instance is initialized with a unique env_id, which it
         returns as the observation at every step.
         """
@@ -2073,7 +2073,7 @@ if __name__ == "__main__":
         self, num_envs: int, n_steps: int, with_preempt: bool, cat_results: str | int
     ):
         """
-        Test that MultiSyncDataCollector returns data in the correct order.
+        Test that MultiSyncCollector returns data in the correct order.
 
         We create num_envs environments, each returning its env_id as the observation.
         After collection, we verify that the observations correspond to the correct env_ids in order
@@ -2196,7 +2196,7 @@ if __name__ == "__main__":
     ):
         """Regression test for issue #3137: traj_ids shape inconsistency with unbatched envs.
 
-        When using SyncDataCollector with an unbatched environment (batch_size=()),
+        When using Collector with an unbatched environment (batch_size=()),
         the traj_ids should maintain consistent shapes across all steps, even when
         done=True triggers trajectory updates.
 

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -336,10 +336,10 @@ class StalenessAwareSampler(Sampler):
         >>> # In training loop:
         >>> # sampler.consumer_version = current_training_step
 
-    Integration with :class:`~torchrl.collectors.SyncDataCollector` and
+    Integration with :class:`~torchrl.collectors.Collector` and
     :class:`~torchrl.envs.transforms.PolicyVersion`::
 
-        from torchrl.collectors import SyncDataCollector
+        from torchrl.collectors import Collector
         from torchrl.envs.transforms import PolicyVersion
         from torchrl.data import TensorDictReplayBuffer, LazyTensorStorage
 
@@ -349,7 +349,7 @@ class StalenessAwareSampler(Sampler):
             sampler=sampler,
             batch_size=256,
         )
-        collector = SyncDataCollector(
+        collector = Collector(
             env,
             policy,
             frames_per_batch=1000,

--- a/tutorials/sphinx-tutorials/coding_ddpg.py
+++ b/tutorials/sphinx-tutorials/coding_ddpg.py
@@ -808,9 +808,9 @@ if device == torch.device("cpu"):
 # GPU, number of workers, and so on).
 #
 # Here we will use
-# :class:`~torchrl.collectors.SyncDataCollector`, a simple, single-process
+# :class:`~torchrl.collectors.Collector`, a simple, single-process
 # data collector. TorchRL offers other collectors, such as
-# :class:`~torchrl.collectors.MultiaSyncDataCollector`, which executed the
+# :class:`~torchrl.collectors.MultiAsyncCollector`, which executed the
 # rollouts in an asynchronous manner (for example, data will be collected while
 # the policy is being optimized, thereby decoupling the training and
 # data collection).
@@ -855,10 +855,10 @@ frames_per_batch = env_per_collector * traj_len
 init_random_frames = 5000
 num_collectors = 2
 
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.envs import ExplorationType
 
-collector = SyncDataCollector(
+collector = Collector(
     parallel_env,
     policy=actor_model_explore,
     total_frames=total_frames,

--- a/tutorials/sphinx-tutorials/coding_dqn.py
+++ b/tutorials/sphinx-tutorials/coding_dqn.py
@@ -105,7 +105,7 @@ import uuid
 
 import torch
 from torch import nn
-from torchrl.collectors import MultiAsyncCollector, Collector
+from torchrl.collectors import Collector, MultiAsyncCollector
 from torchrl.data import LazyMemmapStorage, MultiStep, TensorDictReplayBuffer
 from torchrl.envs import (
     EnvCreator,

--- a/tutorials/sphinx-tutorials/coding_dqn.py
+++ b/tutorials/sphinx-tutorials/coding_dqn.py
@@ -105,7 +105,7 @@ import uuid
 
 import torch
 from torch import nn
-from torchrl.collectors import MultiaSyncDataCollector, SyncDataCollector
+from torchrl.collectors import MultiAsyncCollector, Collector
 from torchrl.data import LazyMemmapStorage, MultiStep, TensorDictReplayBuffer
 from torchrl.envs import (
     EnvCreator,
@@ -398,7 +398,7 @@ def get_replay_buffer(buffer_size, n_optim, batch_size, device):
 #   This feature is only available when running the code within the "spawn"
 #   start method of python multiprocessing library. If this tutorial is run
 #   directly as a script (thereby using the "fork" method) we will be using
-#   a regular :class:`~torchrl.collectors.SyncDataCollector`.
+#   a regular :class:`~torchrl.collectors.Collector`.
 #
 # The advantage of this configuration is that we can balance the amount of
 # compute that is executed in batch with what we want to be executed
@@ -430,10 +430,10 @@ def get_collector(
 ):
     # We can't use nested child processes with mp_start_method="fork"
     if is_fork:
-        cls = SyncDataCollector
+        cls = Collector
         env_arg = make_env(parallel=True, obs_norm_sd=stats, num_workers=num_workers)
     else:
-        cls = MultiaSyncDataCollector
+        cls = MultiAsyncCollector
         env_arg = [
             make_env(parallel=True, obs_norm_sd=stats, num_workers=num_workers)
         ] * num_collectors

--- a/tutorials/sphinx-tutorials/coding_ppo.py
+++ b/tutorials/sphinx-tutorials/coding_ppo.py
@@ -126,7 +126,7 @@ from tensordict.nn import TensorDictModule
 from tensordict.nn.distributions import NormalParamExtractor
 from torch import nn
 
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data.replay_buffers import ReplayBuffer
 from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
 from torchrl.data.replay_buffers.storages import LazyTensorStorage
@@ -482,12 +482,12 @@ print("Running value:", value_module(env.reset()))
 # on which ``device`` the policy should be executed, etc. They are also
 # designed to work efficiently with batched and multiprocessed environments.
 #
-# The simplest data collector is the :class:`~torchrl.collectors.SyncDataCollector`:
+# The simplest data collector is the :class:`~torchrl.collectors.Collector`:
 # it is an iterator that you can use to get batches of data of a given length, and
 # that will stop once a total number of frames (``total_frames``) have been
 # collected.
-# Other data collectors (:class:`~torchrl.collectors.MultiSyncDataCollector` and
-# :class:`~torchrl.collectors.MultiaSyncDataCollector`) will execute
+# Other data collectors (:class:`~torchrl.collectors.MultiSyncCollector` and
+# :class:`~torchrl.collectors.MultiAsyncCollector`) will execute
 # the same operations in synchronous and asynchronous manner over a
 # set of multiprocessed workers.
 #
@@ -497,7 +497,7 @@ print("Running value:", value_module(env.reset()))
 # training loop allows you to write data loading pipelines
 # that are 100% oblivious to the actual specificities of the rollout content.
 #
-collector = SyncDataCollector(
+collector = Collector(
     env,
     policy_module,
     frames_per_batch=frames_per_batch,

--- a/tutorials/sphinx-tutorials/collector_trajectory_assembly.py
+++ b/tutorials/sphinx-tutorials/collector_trajectory_assembly.py
@@ -22,7 +22,7 @@ Collectors Deep Dive: Trajectory Assembly
 
       * `TorchRL <https://github.com/pytorch/rl>`_ and
         `gymnasium <https://gymnasium.farama.org>`_ installed
-      * Familiarity with :class:`~torchrl.collectors.SyncDataCollector`
+      * Familiarity with :class:`~torchrl.collectors.Collector`
         (see :ref:`the data-collection tutorial <gs_storage_collector>`)
 """
 
@@ -33,7 +33,7 @@ warnings.filterwarnings("ignore")
 # sphinx_gallery_end_ignore
 
 import torch
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.collectors.utils import split_trajectories
 from torchrl.data import LazyTensorStorage, ReplayBuffer
 from torchrl.envs import GymEnv
@@ -58,7 +58,7 @@ env = GymEnv("CartPole-v1")
 env.set_seed(0)
 
 policy = RandomPolicy(env.action_spec)
-collector = SyncDataCollector(env, policy, frames_per_batch=200, total_frames=-1)
+collector = Collector(env, policy, frames_per_batch=200, total_frames=-1)
 
 for data in collector:
     print(data)
@@ -162,7 +162,7 @@ print(f"Nested result: {type(nested).__name__}, batch_size={nested.batch_size}")
 # and yield only once it has accumulated the requested number of
 # finished episodes.
 
-collector_trajs = SyncDataCollector(
+collector_trajs = Collector(
     env,
     policy,
     frames_per_batch=200,
@@ -239,7 +239,7 @@ print(f"Unique trajectories in sample: {traj_ids.unique().numel()}")
 #
 # .. code-block:: python
 #
-#     collector = SyncDataCollector(env, policy, frames_per_batch=200, ...)
+#     collector = Collector(env, policy, frames_per_batch=200, ...)
 #     rb = ReplayBuffer(
 #         storage=LazyTensorStorage(max_size=100_000),
 #         sampler=SliceSampler(slice_len=16, end_key=("next", "done")),

--- a/tutorials/sphinx-tutorials/dqn_with_rnn.py
+++ b/tutorials/sphinx-tutorials/dqn_with_rnn.py
@@ -91,7 +91,7 @@ from tensordict.nn import (
     TensorDictSequential as Seq,
 )
 from torch import nn
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyMemmapStorage, TensorDictReplayBuffer
 from torchrl.data.replay_buffers.samplers import SliceSampler
 from torchrl.envs import (
@@ -411,7 +411,7 @@ rb = TensorDictReplayBuffer(
     transform=lambda td: td.to(device),
 )
 
-collector = SyncDataCollector(
+collector = Collector(
     env,
     stoch_policy,
     frames_per_batch=50,

--- a/tutorials/sphinx-tutorials/export.py
+++ b/tutorials/sphinx-tutorials/export.py
@@ -63,7 +63,7 @@ from tensordict.nn import (
 from torch.optim import Adam
 
 from torchrl._utils import timeit
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, ReplayBuffer
 
 from torchrl.envs import (
@@ -102,7 +102,7 @@ policy_explore = Seq(policy, exploration_module)
 init_rand_steps = 5000
 frames_per_batch = 100
 optim_steps = 10
-collector = SyncDataCollector(
+collector = Collector(
     env,
     policy_explore,
     frames_per_batch=frames_per_batch,

--- a/tutorials/sphinx-tutorials/getting-started-3.py
+++ b/tutorials/sphinx-tutorials/getting-started-3.py
@@ -42,7 +42,7 @@ import tempfile
 #
 #
 # The primary data collector discussed here is the
-# :class:`~torchrl.collectors.SyncDataCollector`, which is the focus of this
+# :class:`~torchrl.collectors.Collector`, which is the focus of this
 # documentation. At a fundamental level, a collector is a straightforward
 # class responsible for executing your policy within the environment,
 # resetting the environment when necessary, and providing batches of a
@@ -58,7 +58,7 @@ import tempfile
 
 import torch
 
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.envs import GymEnv
 from torchrl.modules import RandomPolicy
 
@@ -68,7 +68,7 @@ env = GymEnv("CartPole-v1")
 env.set_seed(0)
 
 policy = RandomPolicy(env.action_spec)
-collector = SyncDataCollector(env, policy, frames_per_batch=200, total_frames=-1)
+collector = Collector(env, policy, frames_per_batch=200, total_frames=-1)
 
 #################################
 # We now expect that our collector will deliver batches of size ``200`` no
@@ -181,8 +181,8 @@ print(sample)
 # ----------
 #
 # - You can have look at other multiprocessed
-#   collectors such as :class:`~torchrl.collectors.MultiSyncDataCollector` or
-#   :class:`~torchrl.collectors.MultiaSyncDataCollector`.
+#   collectors such as :class:`~torchrl.collectors.MultiSyncCollector` or
+#   :class:`~torchrl.collectors.MultiAsyncCollector`.
 # - TorchRL also offers distributed collectors if you have multiple nodes to
 #   use for inference. Check them out in the
 #   :ref:`API reference <ref_collectors>`.

--- a/tutorials/sphinx-tutorials/getting-started-5.py
+++ b/tutorials/sphinx-tutorials/getting-started-5.py
@@ -81,13 +81,13 @@ policy_explore = Seq(policy, exploration_module)
 # and a :ref:`replay buffer <gs_storage_rb>` to store that data for training.
 #
 
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, ReplayBuffer
 
 init_rand_steps = 5000
 frames_per_batch = 100
 optim_steps = 10
-collector = SyncDataCollector(
+collector = Collector(
     env,
     policy_explore,
     frames_per_batch=frames_per_batch,

--- a/tutorials/sphinx-tutorials/multiagent_competitive_ddpg.py
+++ b/tutorials/sphinx-tutorials/multiagent_competitive_ddpg.py
@@ -111,7 +111,7 @@ from tensordict import TensorDictBase
 from tensordict.nn import TensorDictModule, TensorDictSequential
 from torch import multiprocessing
 
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyMemmapStorage, RandomSampler, ReplayBuffer
 
 from torchrl.envs import (
@@ -639,7 +639,7 @@ for group, _agents in env.group_map.items():
 # Put exploration policies from each group in a sequence
 agents_exploration_policy = TensorDictSequential(*exploration_policies.values())
 
-collector = SyncDataCollector(
+collector = Collector(
     env,
     agents_exploration_policy,
     device=device,

--- a/tutorials/sphinx-tutorials/multiagent_ppo.py
+++ b/tutorials/sphinx-tutorials/multiagent_ppo.py
@@ -120,7 +120,7 @@ from tensordict.nn.distributions import NormalParamExtractor
 from torch import multiprocessing
 
 # Data collection
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data.replay_buffers import ReplayBuffer
 from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
 from torchrl.data.replay_buffers.storages import LazyTensorStorage
@@ -541,7 +541,7 @@ print("Running value:", critic(env.reset()))
 # We will use the simplest possible data collector, which has the same output as an environment rollout,
 # with the only difference that it will auto reset done states until the desired frames are collected.
 #
-collector = SyncDataCollector(
+collector = Collector(
     env,
     policy,
     device=vmas_device,

--- a/tutorials/sphinx-tutorials/rb_tutorial.py
+++ b/tutorials/sphinx-tutorials/rb_tutorial.py
@@ -628,7 +628,7 @@ plt.show()
 # transformations can be recycled in the replay buffer:
 
 
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.envs.libs.gym import GymEnv
 from torchrl.envs.transforms import (
     Compose,
@@ -663,7 +663,7 @@ print(env.rollout(3))
 
 from torchrl.envs.transforms import ExcludeTransform
 
-collector = SyncDataCollector(
+collector = Collector(
     env,
     RandomPolicy(env.action_spec),
     frames_per_batch=10,
@@ -741,7 +741,7 @@ env = TransformedEnv(
         CatFrames(dim=-4, N=4, in_keys=["pixels_trsf"]),
     ),
 )
-collector = SyncDataCollector(
+collector = Collector(
     env,
     RandomPolicy(env.action_spec),
     frames_per_batch=10,

--- a/tutorials/sphinx-tutorials/torchrl_demo.py
+++ b/tutorials/sphinx-tutorials/torchrl_demo.py
@@ -310,15 +310,15 @@ print("Log prob:", td["action_log_prob"].shape)
 # this efficiently, including batching, device management, and multi-process
 # collection.
 #
-# The :class:`~torchrl.collectors.SyncDataCollector` collects data
+# The :class:`~torchrl.collectors.Collector` collects data
 # synchronously - it waits for a batch to be ready before returning:
 
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 
 # A simple deterministic policy for demonstration
 actor = TensorDictModule(nn.Linear(3, 1), in_keys=["observation"], out_keys=["action"])
 
-collector = SyncDataCollector(
+collector = Collector(
     create_env_fn=lambda: GymEnv("Pendulum-v1"),
     policy=actor,
     frames_per_batch=200,  # Collect 200 frames per iteration
@@ -334,7 +334,7 @@ collector.shutdown()
 
 ###############################################################################
 # For async collection (useful when training takes longer than collecting),
-# see :class:`~torchrl.collectors.MultiaSyncDataCollector`.
+# see :class:`~torchrl.collectors.MultiAsyncCollector`.
 #
 # Replay Buffers
 # --------------
@@ -448,7 +448,7 @@ qnet = TensorDictModule(
 policy = QValueActor(qnet, in_keys=["observation"], spec=env.action_spec)
 
 # 3. Set up the data collector
-collector = SyncDataCollector(
+collector = Collector(
     create_env_fn=lambda: GymEnv("CartPole-v1"),
     policy=policy,
     frames_per_batch=100,


### PR DESCRIPTION
## Summary

Replaces legacy collector class names with the new, shorter canonical names across user-facing code:

- `SyncDataCollector` → `Collector`
- `MultiSyncDataCollector` → `MultiSyncCollector`
- `MultiaSyncDataCollector` → `MultiAsyncCollector`
- `aSyncDataCollector` → `AsyncCollector`
- `_MultiDataCollector` → `MultiCollector`
- `DataCollectorBase` → `BaseCollector`
- `DistributedSyncDataCollector` → `DistributedSyncCollector`

Applied to README, `docs/`, `tutorials/`, `sota-implementations/`, `examples/`, `benchmarks/`, a couple of test comments, and internal docstrings in `torchrl/data/replay_buffers/samplers.py` — 50 files total, symmetric 150/150 diff.

The legacy class definitions and re-exports in `torchrl/collectors/**` are preserved (backward-compatible deprecation shims), and the deprecation tables in `docs/source/reference/collectors*.rst` are kept intact so users can still see the old→new mapping.

## Test plan

- [ ] `python -m compileall` on changed `.py` files (all 50 compile locally)
- [ ] Docs build (sphinx) — renames should resolve through the existing `:class:` cross-references since both old and new names are exported from `torchrl.collectors`
- [ ] Tutorials/SOTA scripts still run end-to-end (no behavior change — pure rename)