### PR TITLE
[Feature] Add a hook point to log average optim losses in trainers

### DIFF
--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -1174,6 +1174,64 @@ class TestOptimizationStepper:
         assert "optimization_stepper" in sd
 
 
+class TestPostOptimCompleteLog:
+    def _make_trainer(self, loss_module, optimization_stepper=None, optimizer=None):
+        trainer = Trainer(
+            collector=MockingCollector(),
+            total_frames=None,
+            frame_skip=None,
+            optim_steps_per_batch=1,
+            loss_module=loss_module,
+            optimizer=optimizer,
+            optimization_stepper=optimization_stepper,
+        )
+        trainer._pbar_str = OrderedDict()
+        return trainer
+
+    def test_hook_receives_optim_steps_and_averaged_losses(self):
+        captured = {}
+
+        def capture_hook(optim_steps, average_losses):
+            captured["optim_steps"] = optim_steps
+            captured["average_losses"] = average_losses
+            return None
+
+        stepper = _CountingStepper()
+        loss_module = _CountingLossModule()
+        trainer = self._make_trainer(
+            loss_module=loss_module,
+            optimization_stepper=stepper,
+        )
+        trainer.register_op("post_optim_complete_log", capture_hook)
+        td = TensorDict({"x": torch.randn(3)}, [])
+        trainer.optim_steps(td)
+
+        assert stepper.calls == 1
+        assert captured["optim_steps"] == trainer._optim_count
+        assert "loss" in captured["average_losses"].keys()
+        assert "optim_steps" in trainer._log_dict
+        assert "loss" in trainer._log_dict
+        assert trainer._log_dict["optim_steps"][-1] == trainer._optim_count
+
+    def test_hook_return_logs_extra_metric(self):
+        def extra_metric_hook(optim_steps, average_losses):
+            return {"custom_metric": 1.0}
+
+        stepper = _CountingStepper()
+        trainer = self._make_trainer(
+            loss_module=_CountingLossModule(),
+            optimization_stepper=stepper,
+        )
+        trainer.register_op("post_optim_complete_log", extra_metric_hook)
+        td = TensorDict({"x": torch.randn(3)}, [])
+        trainer.optim_steps(td)
+
+        assert "custom_metric" in trainer._log_dict
+        assert trainer._log_dict["custom_metric"][-1] == 1.0
+        assert "optim_steps" in trainer._log_dict
+        assert "loss" in trainer._log_dict
+
+
 class TestDefaultOptimizationStepper:
     def test_loss_components_partial(self):
         torch.manual_seed(0)

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -392,6 +392,9 @@ class Trainer:
         self._post_epoch_log_ops = (
             []
         )  # After each epoch logging (e.g., epoch completion metrics)
+        self._post_optim_complete_log_ops = (
+            []
+        )  # After all optimization steps for a batch (e.g., logging average_losses)
 
         # Regular hook collections for non-logging operations
         self._pre_epoch_ops = (
@@ -625,6 +628,7 @@ class Trainer:
             "post_optim_log",
             "pre_epoch_log",
             "post_epoch_log",
+            "post_optim_complete_log",
             "pre_epoch",
             "post_epoch",
         ],
@@ -734,6 +738,12 @@ class Trainer:
             )
             self._post_epoch_log_ops.append((timed_op, kwargs))
 
+        elif dest == "post_optim_complete_log":
+            _check_input_output_typehint(
+                op, input=[int, TensorDictBase | None], output=tuple[str, float]
+            )
+            self._post_optim_complete_log_ops.append((timed_op, kwargs))
+
         elif dest == "pre_epoch":
             _check_input_output_typehint(op, input=None, output=None)
             self._pre_epoch_ops.append((timed_op, kwargs))
@@ -748,7 +758,7 @@ class Trainer:
                 f"(batch_process, pre_optim_steps, process_optim_batch, post_loss, "
                 f"process_loss, optimizer, post_steps, post_optim, pre_steps_log, "
                 f"post_steps_log, post_optim_log, pre_epoch_log, post_epoch_log, "
-                f"pre_epoch, post_epoch)"
+                f"post_optim_complete_log, pre_epoch, post_epoch)"
             )
 
     register_hook = register_op
@@ -861,6 +871,20 @@ class Trainer:
             result = op(batch, **kwargs)
             if result is not None:
                 self._log(**result)
+
+    def _post_optim_complete_log_hook(
+        self, optim_steps: int, average_losses: TensorDictBase | None
+    ) -> None:
+        """Execute logging hooks that run AFTER all steps in the optimization loop.
+
+        These hooks log metrics that use the total step count and averaged loss TensorDict.
+        Called once per optimization loop.
+        """
+        for op, kwargs in self._post_optim_complete_log_ops:
+            result = op(optim_steps, average_losses, **kwargs)
+            if result is not None:
+                self._log(**result)
+        self._log(optim_steps=optim_steps, **average_losses)
 
     def _post_epoch_hook(self) -> None:
         """Execute regular hooks that run AFTER each epoch of optimization.
@@ -1031,12 +1055,8 @@ class Trainer:
             self._post_epoch_hook()
 
         if j >= 0:
-            # Log optimization statistics and average losses after completing all optimization steps
-            # This is the main logging point for training metrics like loss values and optimization step count
-            self._log(
-                optim_steps=self._optim_count,
-                **average_losses,
-            )
+            # LOGGING POINT 6: After all optimization for this batch (e.g., logging average_losses)
+            self._post_optim_complete_log_hook(self._optim_count, average_losses)
 
     def _log(self, log_pbar=False, **kwargs) -> None:
         """Main logging method that handles both logger output and progress bar updates.


### PR DESCRIPTION
## Description

Add the hook point `post_optim_complete_log` to trainers in order to better log average losses.

## Motivation and Context

The change is required because we otherwise get average losses logged by default, and with no option to modify it.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
