### PR TITLE
[BugFix] Fix CI: flaky collector preemption test and MLFlow video read

### DIFF
--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -2207,8 +2207,17 @@ if __name__ == "__main__":
                 #
                 for env_idx in range(num_envs):
                     if with_preempt and env_idx % 2 == 1:
-                        # This is a slow env, should have been preempted after first step
-                        assert (batch["collector", "traj_ids"][env_idx, 1:] == -1).all()
+                        traj_ids = batch["collector", "traj_ids"][env_idx]
+                        neg_mask = traj_ids == -1
+                        assert neg_mask.any(), (
+                            f"Env {env_idx}: preemption should have produced at least one -1 slot, "
+                            f"got traj_ids={traj_ids.tolist()}"
+                        )
+                        first_neg = neg_mask.long().argmax().item()
+                        assert (traj_ids[first_neg:] == -1).all(), (
+                            f"Env {env_idx}: padding -1s should be contiguous at the end, "
+                            f"got traj_ids={traj_ids.tolist()}"
+                        )
                         continue
                     # This is a fast env, no preemption happened
                     assert (batch["collector", "traj_ids"][env_idx] != -1).all()

--- a/test/test_loggers.py
+++ b/test/test_loggers.py
@@ -616,9 +616,17 @@ class TestMLFlowLogger:
             videos_dir = client.download_artifacts(run_id, "videos", artifacts_dir)
             for i, video_name in enumerate(os.listdir(videos_dir)):
                 video_path = os.path.join(videos_dir, video_name)
-                loaded_video, _, _ = torchvision.io.read_video(
-                    video_path, pts_unit="sec", output_format="TCHW"
-                )
+                if _has_torchcodec:
+                    from torchcodec.decoders import VideoDecoder
+
+                    decoder = VideoDecoder(video_path)
+                    loaded_video = decoder.get_frames_in_range(
+                        start=0, stop=len(decoder)
+                    ).data
+                else:
+                    loaded_video, _, _ = torchvision.io.read_video(
+                        video_path, pts_unit="sec", output_format="TCHW"
+                    )
                 if steps:
                     assert torch.allclose(loaded_video.int(), videos[i].int(), rtol=0.1)
                 else:


### PR DESCRIPTION
## Summary
- **test_collectors.py**: Relax overly strict preemption assertion that caused flaky failures in `test_multi_sync_data_collector_ordering[stack-True-8-5]`. The slow env can complete 1 step before the interruptor flag is checked (race between `env.step()` and `interruptor.collection_stopped()`). New assertion checks the real invariant: preemption happened (at least one -1 slot) and padding is contiguous at the end.
- **test_loggers.py**: Add `_has_torchcodec` guard to `TestMLFlowLogger::test_log_video` — use `torchcodec.VideoDecoder` when available (standard/CI path), fall back to `torchvision.io.read_video` for old installs. Matches the existing pattern in `TestCSVLogger::test_log_video`.

## Test plan
- [ ] `pytest test/test_collectors.py::TestCollectorGeneric::test_multi_sync_data_collector_ordering -v`
- [ ] `pytest test/test_loggers.py::TestMLFlowLogger::test_log_video -v`
- [ ] `pytest test/test_loggers.py::TestCSVLogger::test_log_video -v` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)