### PR TITLE
[Deprecation] Remove v0.12 deprecated APIs

### DIFF
--- a/examples/collectors/multi_weight_updates.py
+++ b/examples/collectors/multi_weight_updates.py
@@ -82,7 +82,6 @@ def main():
         storing_device="cpu",
         weight_sync_schemes=weight_sync_schemes,
         replay_buffer=rb,
-        local_init_rb=True,
         # extend_buffer=True is the default for MultiSyncCollector
     )
 

--- a/sota-implementations/dreamer/dreamer_utils.py
+++ b/sota-implementations/dreamer/dreamer_utils.py
@@ -939,8 +939,6 @@ def make_collector(
         replay_buffer=replay_buffer,
         postproc=storage_transform,
         track_policy_version=track_policy_version,
-        # Skip fake data initialization - storage handles coordination
-        local_init_rb=True,
         # Compile policy in workers (avoids serialization issues)
         compile_policy=compile_policy,
         cudagraph_policy=cudagraph_policy,

--- a/sota-implementations/ppo-async/train.py
+++ b/sota-implementations/ppo-async/train.py
@@ -131,7 +131,6 @@ def train_start(
         max_frames_per_traj=-1,
         replay_buffer=data_buffer,
         postproc=postproc,
-        local_init_rb=True,
         weight_sync_schemes=weight_sync_schemes,
     )
 

--- a/torchrl/collectors/_multi_base.py
+++ b/torchrl/collectors/_multi_base.py
@@ -277,11 +277,6 @@ class MultiCollector(BaseCollector, metaclass=_MultiCollectorMeta):
             but populate the buffer instead. Defaults to ``None``.
         extend_buffer (bool, optional): if `True`, the replay buffer is extended with entire rollouts and not
             with single steps. Defaults to `True` for multiprocessed data collectors.
-        local_init_rb (bool, optional): if ``False``, the collector will use fake data to initialize
-            the replay buffer in the main process (legacy behavior). If ``True``, the storage-level
-            coordination will handle initialization with real data from worker processes.
-            Defaults to ``None``, which maintains backward compatibility but shows a deprecation warning.
-            This parameter is deprecated and will be removed in v0.12.
         trust_policy (bool, optional): if ``True``, a non-TensorDictModule policy will be trusted to be
             assumed to be compatible with the collector. This defaults to ``True`` for CudaGraphModules
             and ``False`` otherwise.
@@ -386,7 +381,6 @@ class MultiCollector(BaseCollector, metaclass=_MultiCollectorMeta):
         use_buffers: bool | None = None,
         replay_buffer: ReplayBuffer | None = None,
         extend_buffer: bool = True,
-        local_init_rb: bool | None = None,
         trust_policy: bool | None = None,
         compile_policy: bool | dict[str, Any] | None = None,
         cudagraph_policy: bool | dict[str, Any] | None = None,
@@ -443,7 +437,7 @@ class MultiCollector(BaseCollector, metaclass=_MultiCollectorMeta):
         # Set up replay buffer
         self._use_buffers = use_buffers
         self.replay_buffer = replay_buffer
-        self._setup_multi_replay_buffer(local_init_rb, replay_buffer, extend_buffer)
+        self._setup_multi_replay_buffer(replay_buffer, extend_buffer)
 
         # Set up policy and weights
         if trust_policy is None:
@@ -618,21 +612,11 @@ class MultiCollector(BaseCollector, metaclass=_MultiCollectorMeta):
 
     def _setup_multi_replay_buffer(
         self,
-        local_init_rb: bool | None,
         replay_buffer: ReplayBuffer | None,
         extend_buffer: bool,
     ) -> None:
         """Set up replay buffer for multi-process collector."""
-        # Handle local_init_rb deprecation
-        if local_init_rb is None:
-            local_init_rb = False
-            if replay_buffer is not None and not local_init_rb:
-                warnings.warn(
-                    "local_init_rb=False is deprecated and will be removed in v0.12. "
-                    "The new storage-level initialization provides better performance.",
-                    FutureWarning,
-                )
-        self.local_init_rb = local_init_rb
+        self.local_init_rb = True
 
         self._check_replay_buffer_init()
 

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -438,7 +438,6 @@ class Collector(BaseCollector):
         use_buffers: bool | None = None,
         replay_buffer: ReplayBuffer | None = None,
         extend_buffer: bool = True,
-        local_init_rb: bool | None = None,
         trust_policy: bool | None = None,
         compile_policy: bool | dict[str, Any] | None = None,
         cudagraph_policy: bool | dict[str, Any] | None = None,
@@ -493,7 +492,6 @@ class Collector(BaseCollector):
         self._setup_replay_buffer(
             replay_buffer=replay_buffer,
             extend_buffer=extend_buffer,
-            local_init_rb=local_init_rb,
             postproc=postproc,
             split_trajs=split_trajs,
             return_same_td=return_same_td,
@@ -694,7 +692,6 @@ class Collector(BaseCollector):
         self,
         replay_buffer: ReplayBuffer | None,
         extend_buffer: bool,
-        local_init_rb: bool | None,
         postproc: Callable | None,
         split_trajs: bool | None,
         return_same_td: bool,
@@ -703,17 +700,7 @@ class Collector(BaseCollector):
         """Set up replay buffer configuration and validate compatibility."""
         self.replay_buffer = replay_buffer
         self.extend_buffer = extend_buffer
-
-        # Handle local_init_rb deprecation
-        if local_init_rb is None:
-            local_init_rb = False
-            if replay_buffer is not None and not local_init_rb:
-                warnings.warn(
-                    "local_init_rb=False is deprecated and will be removed in v0.12. "
-                    "The new storage-level initialization provides better performance.",
-                    FutureWarning,
-                )
-        self.local_init_rb = local_init_rb
+        self.local_init_rb = True
 
         # Validate replay buffer compatibility
         if self.replay_buffer is not None and not self._ignore_rb:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -906,12 +906,6 @@ class TransformedEnv(EnvBase, metaclass=_TEnvPostInit):
         >>> # The inner env has been unwrapped
         >>> assert isinstance(transformed_env.base_env, GymEnv)
 
-    .. note::
-        The first argument was renamed from ``env`` to ``base_env`` for clarity.
-        The old ``env`` argument is still supported for backward compatibility
-        but will be removed in v0.12. A deprecation warning will be shown when
-        using the old argument name.
-
     """
 
     @overload
@@ -938,18 +932,6 @@ class TransformedEnv(EnvBase, metaclass=_TEnvPostInit):
     ) -> None:
         ...
 
-    @overload
-    def __init__(
-        self,
-        *,
-        env: EnvBase,  # type: ignore[misc]  # deprecated
-        transform: Transform | None = None,
-        cache_specs: bool = True,
-        auto_unwrap: bool | None = None,
-        **kwargs,
-    ) -> None:
-        ...
-
     def __init__(
         self,
         *args,
@@ -963,17 +945,9 @@ class TransformedEnv(EnvBase, metaclass=_TEnvPostInit):
             cache_specs = args[2] if len(args) > 2 else kwargs.pop("cache_specs", True)
             auto_unwrap = kwargs.pop("auto_unwrap", None)
         elif "env" in kwargs:
-            # Old syntax: TransformedEnv(env=..., transform=...)
-            warnings.warn(
-                "The 'env' argument is deprecated and will be removed in v0.12. "
-                "Use 'base_env' instead.",
-                DeprecationWarning,
-                stacklevel=2,
+            raise TypeError(
+                "The 'env' argument has been removed. Use 'base_env' instead."
             )
-            base_env = kwargs.pop("env")
-            transform = kwargs.pop("transform", None)
-            cache_specs = kwargs.pop("cache_specs", True)
-            auto_unwrap = kwargs.pop("auto_unwrap", None)
         elif "base_env" in kwargs:
             # New syntax with keyword arguments: TransformedEnv(base_env=..., transform=...)
             base_env = kwargs.pop("base_env")

--- a/torchrl/trainers/algorithms/configs/collectors.py
+++ b/torchrl/trainers/algorithms/configs/collectors.py
@@ -53,7 +53,7 @@ class CollectorConfig(BaseCollectorConfig):
     weight_updater: Any = None
     weight_sync_schemes: Any = None
     track_policy_version: bool = False
-    local_init_rb: bool = False
+
     _target_: str = "torchrl.collectors.Collector"
     _partial_: bool = False
 
@@ -102,7 +102,7 @@ class AsyncCollectorConfig(BaseCollectorConfig):
     weight_updater: Any = None
     weight_sync_schemes: Any = None
     track_policy_version: bool = False
-    local_init_rb: bool = False
+
     _target_: str = "torchrl.collectors.AsyncCollector"
     _partial_: bool = False
 
@@ -150,7 +150,7 @@ class MultiSyncCollectorConfig(BaseCollectorConfig):
     weight_updater: Any = None
     weight_sync_schemes: Any = None
     track_policy_version: bool = False
-    local_init_rb: bool = False
+
     _target_: str = "torchrl.collectors.MultiSyncCollector"
     _partial_: bool = False
 
@@ -199,7 +199,7 @@ class MultiAsyncCollectorConfig(BaseCollectorConfig):
     weight_updater: Any = None
     weight_sync_schemes: Any = None
     track_policy_version: bool = False
-    local_init_rb: bool = False
+
     _target_: str = "torchrl.collectors.MultiAsyncCollector"
     _partial_: bool = False
 


### PR DESCRIPTION
## Summary

- Remove deprecated `local_init_rb` parameter from `Collector` and `MultiCollector` — storage-level initialization is now the only behavior (hardcoded to `True`)
- Remove deprecated `env` keyword argument from `TransformedEnv` — use `base_env` instead (now raises `TypeError`)
- Clean up all callers: config dataclasses, YAML configs, SOTA implementations, and examples

## Test plan

- [ ] Existing collector tests pass (no test used `local_init_rb=False`)
- [ ] Existing TransformedEnv tests pass (no test used `env=` kwarg)
- [ ] Verify no remaining `v0.12` deprecation warnings in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)