### PR TITLE
[CI] Fix release CI failures: local_init_rb, read_video, pyvers, envpool

### DIFF
--- a/.github/unittest/linux_libs/scripts_envpool/install.sh
+++ b/.github/unittest/linux_libs/scripts_envpool/install.sh
@@ -27,17 +27,29 @@ fi
 git submodule sync && git submodule update --init --recursive
 
 printf "Installing PyTorch with cu128"
-if [ "${CU_VERSION:-}" == cpu ] ; then
-    pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu -U
+if [[ "$RELEASE" == 0 ]]; then
+    if [ "${CU_VERSION:-}" == cpu ] ; then
+        pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu -U
+    else
+        pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128 -U
+    fi
 else
-    pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128 -U
+    if [ "${CU_VERSION:-}" == cpu ] ; then
+        pip3 install torch --index-url https://download.pytorch.org/whl/cpu -U
+    else
+        pip3 install torch -U
+    fi
 fi
 
 # smoke test
 python -c "import functorch"
 
 # install tensordict
-pip install git+https://github.com/pytorch/tensordict
+if [[ "$RELEASE" == 0 ]]; then
+    pip install git+https://github.com/pytorch/tensordict
+else
+    pip install tensordict
+fi
 
 printf "* Installing torchrl\n"
 python -m pip install -e . --no-build-isolation

--- a/.github/unittest/linux_libs/scripts_gym/run_all.sh
+++ b/.github/unittest/linux_libs/scripts_gym/run_all.sh
@@ -77,6 +77,7 @@ if [[ "$RELEASE" == 0 ]]; then
     uv pip install cloudpickle packaging importlib_metadata orjson "pyvers>=0.1.0,<0.2.0"
     uv pip install --no-build-isolation --no-deps git+https://github.com/pytorch/tensordict.git
 else
+    uv pip install cloudpickle packaging importlib_metadata orjson "pyvers>=0.1.0,<0.2.0"
     uv pip install --no-deps tensordict
 fi
 

--- a/.github/unittest/linux_libs/scripts_minari/install.sh
+++ b/.github/unittest/linux_libs/scripts_minari/install.sh
@@ -42,7 +42,8 @@ else
   exit 1
 fi
 
-# install tensordict
+# install tensordict and its deps
+uv pip install cloudpickle packaging importlib_metadata orjson "pyvers>=0.1.0,<0.2.0"
 if [[ "$RELEASE" == 0 ]]; then
   uv pip install --no-deps git+https://github.com/pytorch/tensordict.git
 else

--- a/test/test_loggers.py
+++ b/test/test_loggers.py
@@ -616,9 +616,18 @@ class TestMLFlowLogger:
             videos_dir = client.download_artifacts(run_id, "videos", artifacts_dir)
             for i, video_name in enumerate(os.listdir(videos_dir)):
                 video_path = os.path.join(videos_dir, video_name)
-                loaded_video, _, _ = torchvision.io.read_video(
-                    video_path, pts_unit="sec", output_format="TCHW"
-                )
+                if _has_torchcodec:
+                    from torchcodec.decoders import VideoDecoder
+
+                    loaded_video = (
+                        VideoDecoder(video_path)
+                        .get_frames_in_range(start=0, stop=128)
+                        .data
+                    )
+                else:
+                    loaded_video, _, _ = torchvision.io.read_video(
+                        video_path, pts_unit="sec", output_format="TCHW"
+                    )
                 if steps:
                     assert torch.allclose(loaded_video.int(), videos[i].int(), rtol=0.1)
                 else:

--- a/torchrl/collectors/_multi_base.py
+++ b/torchrl/collectors/_multi_base.py
@@ -931,7 +931,8 @@ class MultiCollector(BaseCollector, metaclass=_MultiCollectorMeta):
             self.replay_buffer._storage, "initialized", True
         )
         if not is_init:
-            if self.local_init_rb:
+            storage = self.replay_buffer._storage
+            if self.local_init_rb and getattr(storage, "shared_init", False):
                 # New behavior: storage handles all coordination itself
                 # Nothing to do here - the storage will coordinate during first write
                 self.replay_buffer.share()


### PR DESCRIPTION
## Summary

Fixes multiple CI failures seen on the release/0.12.0 branch:

- **`local_init_rb` regression** (~100 collector tests): The deprecation removal PR (#3670) hardcoded `self.local_init_rb = True`, but uninitialized `LazyTensorStorage`/`LazyMemmapStorage` without `shared_init=True` refuses to share. Fix: check `storage.shared_init` before using the new init path, fall back to legacy fake-data initialization otherwise.
- **`torchvision.io.read_video` removed** (2 MLFlow tests): `test_log_video` called `torchvision.io.read_video` unconditionally at line 619 — missed during the torchcodec migration. Fix: add the same `_has_torchcodec` guard used elsewhere in the file.
- **`pyvers` missing in gym RELEASE path**: The gym CI script installs tensordict with `--no-deps` in the RELEASE=1 path but didn't install `pyvers` separately. Fix: add explicit pyvers install.
- **envpool always installs nightly torch**: The envpool install script had no RELEASE guard, always installing nightly torch. On release branches, `assert_torch_version.sh stable` then fails. Fix: add RELEASE guard to install stable torch/tensordict.
- **`pyvers` missing in minari script**: The minari install script uses `--no-deps` for both tensordict and torchrl but never installs `pyvers`. Fix: add unconditional pyvers install.

## Test plan

- [ ] Collector tests with replay buffers pass (LazyTensorStorage without shared_init)
- [ ] MLFlow `test_log_video` passes with torchcodec
- [ ] Gym CI passes on release branch (pyvers importable)
- [ ] Envpool CI passes on release branch (stable torch installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)