### PR TITLE
[BugFix] Fix vLLM CompilationConfig compat and Windows CI pybind11

### DIFF
--- a/.github/unittest/windows_optdepts/scripts/unittest.sh
+++ b/.github/unittest/windows_optdepts/scripts/unittest.sh
@@ -98,13 +98,14 @@ fi
 
 #python -m pip install pip --upgrade
 
+# install build dependencies (needed for torchrl C++ extensions)
+echo "=== Installing build dependencies ==="
+conda install anaconda::cmake -y
+python -m pip install "pybind11[global]"
+
 # install tensordict
 echo "=== Installing tensordict ==="
 if [[ "$RELEASE" == 0 ]]; then
-  conda install anaconda::cmake -y
-
-  python -m pip install "pybind11[global]"
-
   python -m pip install git+https://github.com/pytorch/tensordict
 else
   pip3 install tensordict

--- a/torchrl/modules/llm/backends/vllm/vllm_async.py
+++ b/torchrl/modules/llm/backends/vllm/vllm_async.py
@@ -24,7 +24,7 @@ from typing import Any, Literal, TYPE_CHECKING
 
 import torch
 
-from torchrl._utils import logger as torchrl_logger
+from torchrl._utils import implement_for, logger as torchrl_logger
 
 # Import RLvLLMEngine and shared utilities
 from .base import RLvLLMEngine
@@ -46,6 +46,22 @@ try:
 except ImportError:
     vllm = None
     _has_vllm = False
+
+
+if _has_vllm:
+
+    @implement_for("vllm", None, "0.18.0")
+    def _compilation_config(level: int) -> dict:
+        return {"level": level}
+
+    @implement_for("vllm", "0.18.0")
+    def _compilation_config(level: int) -> dict:  # noqa: F811
+        return {"mode": level}
+
+else:
+
+    def _compilation_config(level: int) -> dict:
+        return {"mode": level}
 
 
 def _get_ray():
@@ -1980,9 +1996,9 @@ def make_async_vllm_engine(
     # Disabled by default in GRPO since it can cause issues during training
     if "compilation_config" not in kwargs:
         if compile:
-            kwargs["compilation_config"] = {"level": 3}  # PIECEWISE compilation
+            kwargs["compilation_config"] = _compilation_config(3)
         else:
-            kwargs["compilation_config"] = {"level": 0}  # NO_COMPILATION
+            kwargs["compilation_config"] = _compilation_config(0)
 
     engine_args = AsyncEngineArgs(
         model=model_name,


### PR DESCRIPTION
## Summary
- Fix vLLM >=0.18.0 compatibility: the `level` keyword was removed from `CompilationConfig` and replaced with `mode`. Uses `pyvers.implement_for` to select the right key based on installed vLLM version.
- Fix Windows CI build failure on release branches: `cmake` and `pybind11[global]` are now installed unconditionally (they were previously only installed when `RELEASE==0`, but torchrl's C++ extensions need them regardless).

## Test plan
- [ ] vLLM async tests that were previously skipped (~115 tests) due to `CompilationConfig` validation error should now load successfully
- [ ] Windows CI `unittests-cpu` job should no longer fail at `pip install -e .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)