### PR TITLE
[CI] Selective PR test matrix gated by changed-files + ciflow/* labels

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -1,0 +1,132 @@
+# Selective CI on pull requests
+
+This repo runs a large matrix of Linux/Windows/GPU/dependency variants on every
+push to `main`, `nightly`, and `release/*`. On PRs, the matrix is **pruned to the
+tests relevant to the diff**, with opt-in `ciflow/*` labels to pull individual
+tracks back in without waiting for merge.
+
+The goal is fast PR iteration, with the assurance that the full matrix still
+runs at merge time.
+
+## What runs on a PR by default
+
+| Track | Trigger on PR | Full trigger |
+|---|---|---|
+| `test-linux.yml` → `tests-cpu` | Python 3.12 only | all 5 Python versions on push / `ciflow/cpu-matrix` / `ciflow/full` |
+| `test-linux.yml` → `tests-gpu` | only the shard(s) whose paths changed; falls back to shard 3 | all 3 shards on push / `ciflow/gpu` / `ciflow/full` |
+| `test-linux.yml` → `tests-gpu-distributed` | only if distributed code (`torchrl/collectors/distributed/**`, `torchrl/services/**`, `test/test_distributed.py`, `test/test_rb_distributed.py`) changed | on push / `ciflow/distributed` / `ciflow/full` |
+| `test-linux.yml` → `tests-olddeps` | skipped | on push / `ciflow/olddeps` / `ciflow/full` |
+| `test-linux.yml` → `tests-optdeps` | skipped | on push / `ciflow/optdeps` / `ciflow/full` |
+| `test-linux.yml` → `tests-stable-gpu` and `tests-stable-gpu-distributed` | skipped | on push / `ciflow/stable` / `ciflow/full` |
+| `test-linux-sota.yml` | only if `sota-implementations/**` or `torchrl/trainers/**` changed | on push / `ciflow/sota` / `ciflow/full` |
+| `test-linux-tutorials.yml` | only if `tutorials/**` changed | on push / `ciflow/tutorials` / `ciflow/full` |
+| `test-windows-optdepts.yml` | only if `torchrl/**`, `test/**`, `setup.py`, `pyproject.toml`, or `.github/unittest/windows_optdepts/**` changed | on push / `ciflow/windows` / `ciflow/full` |
+| `test-linux-libs.yml`, `test-linux-llm.yml`, `test-linux-habitat.yml` | already label-gated on file-based labels (`Environments/*`, `llm/`, `Modules`, ...) applied by `.github/workflows/auto-labeler.yml` | on push or matching label |
+
+Docs-only / `sota-implementations/`-only / `tutorials/`-only PRs skip the relevant
+heavy workflows via `paths-ignore:` — the workflow doesn't even enqueue.
+
+## GPU shard selection
+
+The GPU test suite is split three ways:
+
+- **Shard 1** — `test/transforms/`
+- **Shard 2** — `test/envs/` and `test/test_collectors.py`
+- **Shard 3** — everything else
+
+The `prepare` job at the top of `test-linux.yml` uses
+[`tj-actions/changed-files`](https://github.com/tj-actions/changed-files) to
+compute which shards' paths intersect the PR diff and emits a JSON array
+(`shards_json`) consumed by the `tests-gpu` matrix. A PR touching only
+`torchrl/envs/transforms/vec_norm.py` runs shard 1 only; a PR touching
+`torchrl/objectives/ppo.py` runs shard 3 only.
+
+If no shard matches (shouldn't happen thanks to `paths-ignore`), the safety net
+is to run shard 3.
+
+## `ciflow/*` escape hatches
+
+Apply any of these labels to a PR to force specific tracks back in:
+
+- `ciflow/full` — run the whole matrix (everything below, plus all 5 CPU Python versions)
+- `ciflow/cpu-matrix` — run all 5 Python versions on the CPU job
+- `ciflow/gpu` — run all 3 GPU shards
+- `ciflow/stable` — run `tests-stable-gpu` + `tests-stable-gpu-distributed`
+- `ciflow/olddeps` — run `tests-olddeps`
+- `ciflow/optdeps` — run `tests-optdeps`
+- `ciflow/distributed` — run `tests-gpu-distributed`
+- `ciflow/sota` — run `test-linux-sota`
+- `ciflow/tutorials` — run `test-linux-tutorials`
+- `ciflow/windows` — run `test-windows-optdepts`
+
+Push events to `main`, `nightly`, or `release/*` implicitly behave as if
+`ciflow/full` were set.
+
+## How the decision is made
+
+[`.github/scripts/ci_decide.sh`](scripts/ci_decide.sh) centralises the
+precedence logic. It takes event name, ref, labels JSON, and the four
+`<bucket>_any_changed` flags from `tj-actions/changed-files`, and writes
+`key=value` lines suitable for `$GITHUB_OUTPUT`.
+
+Precedence (highest first):
+
+1. `push` / `workflow_call` / `workflow_dispatch` → full run.
+2. PR with `ciflow/full` → full run.
+3. PR: per-track file-change flags OR per-track `ciflow/*` labels.
+
+Unit tests for the script: [`.github/scripts/test_ci_decide.sh`](scripts/test_ci_decide.sh).
+Run locally:
+
+```bash
+bash .github/scripts/test_ci_decide.sh
+```
+
+## Running the same filtered subset locally
+
+The test driver `.github/unittest/linux/scripts/run_all.sh` respects the same
+sharding env vars used in CI:
+
+```bash
+# Run just the transforms shard (what a PR touching transforms would run on GPU CI)
+TORCHRL_TEST_SHARD=1 bash .github/unittest/linux/scripts/run_all.sh
+
+# Run just envs + collectors
+TORCHRL_TEST_SHARD=2 bash .github/unittest/linux/scripts/run_all.sh
+
+# Run everything else
+TORCHRL_TEST_SHARD=3 bash .github/unittest/linux/scripts/run_all.sh
+```
+
+For even finer selection, the `TORCHRL_TEST_PATHS` env var is passed verbatim
+to `pytest` and short-circuits the shard dispatch:
+
+```bash
+# Arbitrary pytest invocation, wrapped in the CI's coverage runner.
+TORCHRL_TEST_PATHS="test/test_rb.py -k memmap" \
+  bash .github/unittest/linux/scripts/run_all.sh
+```
+
+This is useful for `workflow_dispatch` runs and local reproduction of a
+failing CI shard.
+
+## Adding a new track
+
+When adding a new workflow (or a new track in an existing one) that you want
+to be selective on PRs:
+
+1. Add a `paths-ignore:` to the PR trigger for obviously-unrelated paths.
+2. Add (or extend the existing) `prepare`/`changes` job to emit an `in_scope`
+   output via `tj-actions/changed-files`.
+3. Gate the heavy job(s) with:
+   ```yaml
+   if: >-
+     github.event_name != 'pull_request' ||
+     needs.changes.outputs.in_scope == 'true' ||
+     contains(github.event.pull_request.labels.*.name, 'ciflow/full') ||
+     contains(github.event.pull_request.labels.*.name, 'ciflow/<track>')
+   ```
+4. Register `ciflow/<track>` in `.github/labels.yml` and document it above.
+
+If the new track needs shard-style output coordination with `test-linux.yml`,
+extend `ci_decide.sh` instead of bolting on another decision script.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -119,6 +119,49 @@
   description: "Tests full docs CI"
   color: "BFDADC"
 
+# Selective PR CI escape hatches (see .github/scripts/ci_decide.sh and .github/CI.md).
+# On PRs, the default matrix is pruned to changed-files + Python 3.12. Apply these
+# labels to force specific tracks back in without waiting for merge to main.
+- name: ciflow/full
+  description: "Run the full Linux test matrix on the PR (all tracks, all Python versions, all shards)"
+  color: "BFDADC"
+
+- name: ciflow/cpu-matrix
+  description: "Run all Python versions on the CPU test job (3.10..3.14)"
+  color: "BFDADC"
+
+- name: ciflow/gpu
+  description: "Run all three GPU test shards on the PR"
+  color: "BFDADC"
+
+- name: ciflow/stable
+  description: "Run tests-stable-gpu + tests-stable-gpu-distributed on the PR"
+  color: "BFDADC"
+
+- name: ciflow/olddeps
+  description: "Run tests-olddeps on the PR"
+  color: "BFDADC"
+
+- name: ciflow/optdeps
+  description: "Run tests-optdeps on the PR"
+  color: "BFDADC"
+
+- name: ciflow/distributed
+  description: "Run tests-gpu-distributed on the PR"
+  color: "BFDADC"
+
+- name: ciflow/sota
+  description: "Run test-linux-sota on the PR"
+  color: "BFDADC"
+
+- name: ciflow/tutorials
+  description: "Run test-linux-tutorials on the PR"
+  color: "BFDADC"
+
+- name: ciflow/windows
+  description: "Run test-windows-optdepts on the PR"
+  color: "BFDADC"
+
 # =============================================================================
 # CI Trigger Labels - Environments
 # =============================================================================

--- a/.github/scripts/ci_decide.sh
+++ b/.github/scripts/ci_decide.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Decide the selective-CI matrix from event, ref, labels, and changed-file flags.
+#
+# Writes key=value lines on stdout. The caller appends the output to
+# $GITHUB_OUTPUT so downstream jobs can read them via needs.prepare.outputs.*.
+#
+# Precedence (highest first):
+#   1. push / workflow_call / workflow_dispatch        -> full matrix
+#   2. pull_request with ciflow/full label              -> full matrix
+#   3. pull_request: per-track changed-files flags,
+#      with per-track ciflow/* labels as escape hatches
+#
+# Usage:
+#   ci_decide.sh EVENT REF LABELS_JSON SHARD1 SHARD2 SHARD3 DISTRIBUTED
+#
+#   LABELS_JSON is the raw toJSON output of github.event.pull_request.labels.*.name,
+#   e.g. ["Transforms","ciflow/full"]. On non-PR events pass [].
+#   SHARD1/SHARD2/SHARD3/DISTRIBUTED are literal "true"/"false" from
+#   tj-actions/changed-files <bucket>_any_changed outputs.
+
+set -euo pipefail
+
+event_name="${1:?event_name required}"
+ref="${2:?ref required}"
+labels_json="${3:-[]}"
+shard1_changed="${4:-false}"
+shard2_changed="${5:-false}"
+shard3_changed="${6:-false}"
+distributed_changed="${7:-false}"
+
+has_label() {
+  # labels_json example: ["Foo","ciflow/full"]. Match the quoted name exactly.
+  printf '%s' "$labels_json" | grep -Fq "\"$1\""
+}
+
+is_full=false
+case "$event_name" in
+  push|workflow_call|workflow_dispatch) is_full=true ;;
+esac
+if [ "$event_name" = pull_request ] && has_label "ciflow/full"; then
+  is_full=true
+fi
+
+if [ "$is_full" = true ]; then
+  run_cpu_matrix=true
+  run_shard1=true
+  run_shard2=true
+  run_shard3=true
+  run_olddeps=true
+  run_stable=true
+  run_optdeps=true
+  run_distributed=true
+else
+  if has_label "ciflow/cpu-matrix"; then run_cpu_matrix=true; else run_cpu_matrix=false; fi
+
+  if has_label "ciflow/gpu"; then
+    run_shard1=true; run_shard2=true; run_shard3=true
+  else
+    run_shard1="$shard1_changed"
+    run_shard2="$shard2_changed"
+    run_shard3="$shard3_changed"
+  fi
+
+  if has_label "ciflow/olddeps"; then run_olddeps=true; else run_olddeps=false; fi
+  if has_label "ciflow/stable";  then run_stable=true;  else run_stable=false;  fi
+  if has_label "ciflow/optdeps"; then run_optdeps=true; else run_optdeps=false; fi
+
+  if [ "$distributed_changed" = true ] || has_label "ciflow/distributed"; then
+    run_distributed=true
+  else
+    run_distributed=false
+  fi
+fi
+
+shards=()
+[ "$run_shard1" = true ] && shards+=('"1"')
+[ "$run_shard2" = true ] && shards+=('"2"')
+[ "$run_shard3" = true ] && shards+=('"3"')
+# Safety net: paths-ignore should keep us from reaching here on docs-only PRs,
+# but if no shard is selected we still want one to run so the job matrix is non-empty.
+if [ "${#shards[@]}" -eq 0 ]; then
+  shards+=('"3"')
+  run_shard3=true
+fi
+shards_json="[$(IFS=,; printf '%s' "${shards[*]}")]"
+
+cat <<OUT
+full=$is_full
+run_cpu_matrix=$run_cpu_matrix
+run_shard1=$run_shard1
+run_shard2=$run_shard2
+run_shard3=$run_shard3
+run_olddeps=$run_olddeps
+run_stable=$run_stable
+run_optdeps=$run_optdeps
+run_distributed=$run_distributed
+shards_json=$shards_json
+OUT

--- a/.github/scripts/create_labels.sh
+++ b/.github/scripts/create_labels.sh
@@ -55,6 +55,25 @@ gh label create "Data/openx" --repo "$REPO" --description "Triggers openx data t
 gh label create "Data/roboset" --repo "$REPO" --description "Triggers roboset data tests only" --color "$DATA_COLOR" --force
 gh label create "Data/vd4rl" --repo "$REPO" --description "Triggers vd4rl data tests only" --color "$DATA_COLOR" --force
 
+# =============================================================================
+# ciflow/* labels (grey) - opt-in escape hatches for selective PR CI
+# See .github/CI.md for the full list of tracks.
+# =============================================================================
+CIFLOW_COLOR="BFDADC"
+
+echo ""
+echo "Creating ciflow/* labels..."
+gh label create "ciflow/full"       --repo "$REPO" --description "Run the full Linux test matrix on the PR (all tracks, all Python versions, all shards)" --color "$CIFLOW_COLOR" --force
+gh label create "ciflow/cpu-matrix" --repo "$REPO" --description "Run all Python versions on the CPU test job (3.10..3.14)"                               --color "$CIFLOW_COLOR" --force
+gh label create "ciflow/gpu"        --repo "$REPO" --description "Run all three GPU test shards on the PR"                                               --color "$CIFLOW_COLOR" --force
+gh label create "ciflow/stable"     --repo "$REPO" --description "Run tests-stable-gpu + tests-stable-gpu-distributed on the PR"                          --color "$CIFLOW_COLOR" --force
+gh label create "ciflow/olddeps"    --repo "$REPO" --description "Run tests-olddeps on the PR"                                                            --color "$CIFLOW_COLOR" --force
+gh label create "ciflow/optdeps"    --repo "$REPO" --description "Run tests-optdeps on the PR"                                                            --color "$CIFLOW_COLOR" --force
+gh label create "ciflow/distributed" --repo "$REPO" --description "Run tests-gpu-distributed on the PR"                                                   --color "$CIFLOW_COLOR" --force
+gh label create "ciflow/sota"       --repo "$REPO" --description "Run test-linux-sota on the PR"                                                          --color "$CIFLOW_COLOR" --force
+gh label create "ciflow/tutorials"  --repo "$REPO" --description "Run test-linux-tutorials on the PR"                                                     --color "$CIFLOW_COLOR" --force
+gh label create "ciflow/windows"    --repo "$REPO" --description "Run test-windows-optdepts on the PR"                                                    --color "$CIFLOW_COLOR" --force
+
 echo ""
 echo "=============================================================="
 echo "Done! All CI granularity labels created/updated."
@@ -64,3 +83,6 @@ echo "  - 'Environments' → triggers ALL environment tests"
 echo "  - 'Environments/brax' → triggers only brax tests"
 echo "  - 'Data' → triggers ALL data tests"
 echo "  - 'Data/minari' → triggers only minari tests"
+echo "  - 'ciflow/full' → run the full Linux matrix on the PR"
+echo "  - 'ciflow/gpu' → run all 3 GPU shards on the PR"
+echo "  - see .github/CI.md for the complete ciflow/* list"

--- a/.github/scripts/test_ci_decide.sh
+++ b/.github/scripts/test_ci_decide.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Table-driven tests for ci_decide.sh.
+# Run: bash .github/scripts/test_ci_decide.sh
+
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+script="$here/ci_decide.sh"
+
+fail=0
+pass=0
+
+assert_line() {
+  local out="$1" expected="$2" name="$3"
+  if printf '%s\n' "$out" | grep -Fxq "$expected"; then
+    pass=$((pass+1))
+  else
+    echo "FAIL [$name] expected line: $expected"
+    echo "--- output ---"
+    printf '%s\n' "$out"
+    echo "--------------"
+    fail=$((fail+1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 1. push to main -> full run regardless of file flags
+# ---------------------------------------------------------------------------
+out=$(bash "$script" push refs/heads/main '[]' false false false false)
+assert_line "$out" 'full=true'             'push main: full'
+assert_line "$out" 'run_cpu_matrix=true'   'push main: cpu matrix'
+assert_line "$out" 'shards_json=["1","2","3"]' 'push main: all shards'
+assert_line "$out" 'run_olddeps=true'      'push main: olddeps'
+
+# ---------------------------------------------------------------------------
+# 2. push to release/* -> full
+# ---------------------------------------------------------------------------
+out=$(bash "$script" push refs/heads/release/0.12.0 '[]' false false false false)
+assert_line "$out" 'full=true'             'push release: full'
+
+# ---------------------------------------------------------------------------
+# 3. PR touching transforms only -> shard 1 only, Python 3.12 only
+# ---------------------------------------------------------------------------
+out=$(bash "$script" pull_request refs/pull/1/merge '["Transforms"]' true false false false)
+assert_line "$out" 'full=false'                'PR transforms: not full'
+assert_line "$out" 'run_cpu_matrix=false'      'PR transforms: single py'
+assert_line "$out" 'run_shard1=true'           'PR transforms: shard1'
+assert_line "$out" 'run_shard2=false'          'PR transforms: no shard2'
+assert_line "$out" 'run_shard3=false'          'PR transforms: no shard3'
+assert_line "$out" 'shards_json=["1"]'         'PR transforms: shards_json'
+assert_line "$out" 'run_olddeps=false'         'PR transforms: no olddeps'
+assert_line "$out" 'run_stable=false'          'PR transforms: no stable'
+assert_line "$out" 'run_distributed=false'     'PR transforms: no distributed'
+
+# ---------------------------------------------------------------------------
+# 4. PR touching envs + something else -> shard 2 + shard 3
+# ---------------------------------------------------------------------------
+out=$(bash "$script" pull_request refs/pull/1/merge '[]' false true true false)
+assert_line "$out" 'run_shard1=false'          'PR envs+core: no shard1'
+assert_line "$out" 'run_shard2=true'           'PR envs+core: shard2'
+assert_line "$out" 'run_shard3=true'           'PR envs+core: shard3'
+assert_line "$out" 'shards_json=["2","3"]'     'PR envs+core: shards_json'
+
+# ---------------------------------------------------------------------------
+# 5. PR with ciflow/full -> full matrix
+# ---------------------------------------------------------------------------
+out=$(bash "$script" pull_request refs/pull/1/merge '["ciflow/full"]' false false false false)
+assert_line "$out" 'full=true'                 'PR ciflow/full: full'
+assert_line "$out" 'run_cpu_matrix=true'       'PR ciflow/full: cpu matrix'
+assert_line "$out" 'shards_json=["1","2","3"]' 'PR ciflow/full: all shards'
+assert_line "$out" 'run_olddeps=true'          'PR ciflow/full: olddeps'
+assert_line "$out" 'run_stable=true'           'PR ciflow/full: stable'
+assert_line "$out" 'run_optdeps=true'          'PR ciflow/full: optdeps'
+assert_line "$out" 'run_distributed=true'      'PR ciflow/full: distributed'
+
+# ---------------------------------------------------------------------------
+# 6. PR with ciflow/gpu but no file changes -> all shards, but not olddeps/stable
+# ---------------------------------------------------------------------------
+out=$(bash "$script" pull_request refs/pull/1/merge '["ciflow/gpu"]' false false false false)
+assert_line "$out" 'run_shard1=true'           'PR ciflow/gpu: shard1'
+assert_line "$out" 'run_shard2=true'           'PR ciflow/gpu: shard2'
+assert_line "$out" 'run_shard3=true'           'PR ciflow/gpu: shard3'
+assert_line "$out" 'run_olddeps=false'         'PR ciflow/gpu: no olddeps'
+assert_line "$out" 'run_stable=false'          'PR ciflow/gpu: no stable'
+
+# ---------------------------------------------------------------------------
+# 7. PR with ciflow/cpu-matrix only -> full cpu matrix, shard fallback
+# ---------------------------------------------------------------------------
+out=$(bash "$script" pull_request refs/pull/1/merge '["ciflow/cpu-matrix"]' false false false false)
+assert_line "$out" 'run_cpu_matrix=true'       'PR ciflow/cpu-matrix: cpu matrix'
+assert_line "$out" 'full=false'                'PR ciflow/cpu-matrix: not full'
+assert_line "$out" 'shards_json=["3"]'         'PR ciflow/cpu-matrix: fallback shard3'
+
+# ---------------------------------------------------------------------------
+# 8. PR touching distributed code -> distributed flag
+# ---------------------------------------------------------------------------
+out=$(bash "$script" pull_request refs/pull/1/merge '[]' false false true true)
+assert_line "$out" 'run_distributed=true'      'PR distributed changed: distributed true'
+
+# ---------------------------------------------------------------------------
+# 9. PR with ciflow/distributed label, no file changes -> distributed true
+# ---------------------------------------------------------------------------
+out=$(bash "$script" pull_request refs/pull/1/merge '["ciflow/distributed"]' false false false false)
+assert_line "$out" 'run_distributed=true'      'PR ciflow/distributed: distributed true'
+
+# ---------------------------------------------------------------------------
+# 10. PR with no matching files and no labels -> shard 3 fallback
+# ---------------------------------------------------------------------------
+out=$(bash "$script" pull_request refs/pull/1/merge '[]' false false false false)
+assert_line "$out" 'shards_json=["3"]'         'PR empty: shard3 fallback'
+assert_line "$out" 'run_shard3=true'           'PR empty: shard3 true'
+assert_line "$out" 'full=false'                'PR empty: not full'
+
+# ---------------------------------------------------------------------------
+# 11. workflow_dispatch -> full
+# ---------------------------------------------------------------------------
+out=$(bash "$script" workflow_dispatch refs/heads/main '[]' false false false false)
+assert_line "$out" 'full=true'                 'workflow_dispatch: full'
+
+# ---------------------------------------------------------------------------
+# 12. Label name that is a substring of another label should not false-match.
+#      (e.g. "ciflow/optdeps-extra" must not match "ciflow/optdeps")
+#      This guards the exact-quoted grep.
+# ---------------------------------------------------------------------------
+out=$(bash "$script" pull_request refs/pull/1/merge '["ciflow/optdeps-extra"]' false false false false)
+assert_line "$out" 'run_optdeps=false'         'label substring safety'
+
+echo
+echo "passed: $pass, failed: $fail"
+exit $fail

--- a/.github/unittest/linux/scripts/run_all.sh
+++ b/.github/unittest/linux/scripts/run_all.sh
@@ -361,13 +361,27 @@ run_non_distributed_tests() {
   # - Shard 1: test/transforms/ (transform tests)
   # - Shard 2: test/envs/, test_collectors.py (multiprocessing-heavy)
   # - Shard 3: Everything else (can use pytest-xdist for parallelism)
+  #
+  # Fine-grained override: TORCHRL_TEST_PATHS, if set, is passed verbatim to pytest
+  # as the argument list (short-circuiting the shard case below). Useful for local
+  # debugging and workflow_dispatch runs that want `pytest path/to/file.py -k expr`.
   local shard="${TORCHRL_TEST_SHARD:-all}"
   local common_ignores="--ignore test/test_rlhf.py --ignore test/test_distributed.py --ignore test/test_rb_distributed.py --ignore test/llm --ignore test/test_setup.py"
   local common_args="--instafail --durations 200 -vv --capture no --timeout=120 --mp_fork_if_no_cuda"
-  
+
   # JSON report output for flaky test tracking
   local json_report_dir="${RUNNER_ARTIFACT_DIR:-${root_dir}}"
   local json_report_args="--json-report --json-report-file=${json_report_dir}/test-results-shard-${shard}.json --json-report-indent=2"
+
+  if [ -n "${TORCHRL_TEST_PATHS:-}" ]; then
+    # shellcheck disable=SC2086  # intentional word-splitting of TORCHRL_TEST_PATHS
+    echo "Running explicit test paths: ${TORCHRL_TEST_PATHS}"
+    python .github/unittest/helpers/coverage_run_parallel.py -m pytest ${TORCHRL_TEST_PATHS} \
+      "${GPU_MARKER_FILTER[@]}" \
+      ${json_report_args} \
+      ${common_args}
+    return
+  fi
   
   # pytest-xdist parallelism: use -n auto for shard 3 (fewer multiprocessing tests)
   # Set TORCHRL_XDIST=0 to disable parallel execution

--- a/.github/workflows/test-linux-sota.yml
+++ b/.github/workflows/test-linux-sota.yml
@@ -2,6 +2,13 @@ name: SOTA Tests on Linux
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '**.rst'
+      - 'benchmarks/**'
+      - 'tutorials/**'
+      - 'examples/**'
   push:
     branches:
       - nightly
@@ -24,7 +31,28 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      in_scope: ${{ steps.filter.outputs.any_changed || 'false' }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            sota-implementations/**
+            torchrl/trainers/**
+
   tests:
+    needs: changes
+    # Skip on PRs unless sota code is touched, or an opt-in label is present.
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.in_scope == 'true' ||
+      contains(github.event.pull_request.labels.*.name, 'ciflow/full') ||
+      contains(github.event.pull_request.labels.*.name, 'ciflow/sota')
     strategy:
       matrix:
         python_version: ["3.10"]

--- a/.github/workflows/test-linux-tutorials.yml
+++ b/.github/workflows/test-linux-tutorials.yml
@@ -3,6 +3,12 @@ name: Tutorials Tests on Linux
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '**.rst'
+      - 'benchmarks/**'
+      - 'sota-implementations/**'
   push:
     branches:
       - nightly
@@ -20,13 +26,32 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      in_scope: ${{ steps.filter.outputs.any_changed || 'false' }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            tutorials/**
+
   tests:
+    needs: changes
+    # Skip on PRs unless tutorials are touched, or an opt-in label is present.
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.in_scope == 'true' ||
+      contains(github.event.pull_request.labels.*.name, 'ciflow/full') ||
+      contains(github.event.pull_request.labels.*.name, 'ciflow/tutorials')
     strategy:
       matrix:
         python_version: ["3.12"]
         cuda_arch_version: ["12.4"]
       fail-fast: false
-    # Run on all PRs and pushes to main/nightly/release branches
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       runner: linux.g5.4xlarge.nvidia.gpu

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -2,6 +2,16 @@ name: Unit-tests on Linux
 
 on:
   pull_request:
+    # Docs-only / example-only / tutorial-only PRs don't need the Linux test matrix.
+    # The prepare job below further narrows what runs for PRs that do trigger the workflow.
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '**.rst'
+      - 'tutorials/**'
+      - 'examples/**'
+      - 'benchmarks/**'
+      - 'sota-implementations/**'
   push:
     branches:
       - nightly
@@ -24,6 +34,81 @@ permissions:
   contents: read
 
 jobs:
+  # Compute selective-CI matrix flags. Consumed by downstream jobs via needs.prepare.outputs.*.
+  # On push / workflow_call / workflow_dispatch / PR with ciflow/full label: full=true -> full matrix.
+  # On PR: tj-actions/changed-files + ciflow/* labels drive which shards and peer tracks run.
+  # See .github/scripts/ci_decide.sh for the precedence logic.
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      full: ${{ steps.decide.outputs.full }}
+      run_cpu_matrix: ${{ steps.decide.outputs.run_cpu_matrix }}
+      run_shard1: ${{ steps.decide.outputs.run_shard1 }}
+      run_shard2: ${{ steps.decide.outputs.run_shard2 }}
+      run_shard3: ${{ steps.decide.outputs.run_shard3 }}
+      run_olddeps: ${{ steps.decide.outputs.run_olddeps }}
+      run_stable: ${{ steps.decide.outputs.run_stable }}
+      run_optdeps: ${{ steps.decide.outputs.run_optdeps }}
+      run_distributed: ${{ steps.decide.outputs.run_distributed }}
+      shards_json: ${{ steps.decide.outputs.shards_json }}
+      cpu_python_versions: ${{ steps.decide.outputs.cpu_python_versions }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: changed
+        if: github.event_name == 'pull_request'
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            shard1:
+              - torchrl/envs/transforms/**
+              - test/transforms/**
+            shard2:
+              - torchrl/envs/**
+              - torchrl/collectors/**
+              - test/envs/**
+              - test/test_collectors.py
+              - '!torchrl/envs/transforms/**'
+              - '!torchrl/collectors/distributed/**'
+            shard3:
+              - torchrl/**
+              - test/**
+              - setup.py
+              - pyproject.toml
+              - .github/unittest/**
+              - '!torchrl/envs/transforms/**'
+              - '!torchrl/envs/**'
+              - '!torchrl/collectors/**'
+              - '!test/transforms/**'
+              - '!test/envs/**'
+              - '!test/test_collectors.py'
+              - '!test/test_distributed.py'
+              - '!test/test_rb_distributed.py'
+              - '!test/llm/**'
+              - '!test/test_setup.py'
+            distributed:
+              - torchrl/collectors/distributed/**
+              - torchrl/services/**
+              - test/test_distributed.py
+              - test/test_rb_distributed.py
+      - id: decide
+        run: |
+          set -euo pipefail
+          bash .github/scripts/ci_decide.sh \
+            '${{ github.event_name }}' \
+            '${{ github.ref }}' \
+            '${{ toJSON(github.event.pull_request.labels.*.name) }}' \
+            '${{ steps.changed.outputs.shard1_any_changed || 'false' }}' \
+            '${{ steps.changed.outputs.shard2_any_changed || 'false' }}' \
+            '${{ steps.changed.outputs.shard3_any_changed || 'false' }}' \
+            '${{ steps.changed.outputs.distributed_any_changed || 'false' }}' \
+            | tee -a "$GITHUB_OUTPUT"
+          # Emit the CPU python-version matrix as JSON for downstream `fromJSON`.
+          if grep -q '^run_cpu_matrix=true$' "$GITHUB_OUTPUT"; then
+            echo 'cpu_python_versions=["3.10","3.11","3.12","3.13","3.14"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'cpu_python_versions=["3.12"]' >> "$GITHUB_OUTPUT"
+          fi
+
   test-setup-minimal:
     strategy:
       matrix:
@@ -44,9 +129,10 @@ jobs:
         bash .github/unittest/linux/scripts/run_setup_test.sh
 
   tests-cpu:
+    needs: prepare
     strategy:
       matrix:
-        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python_version: ${{ fromJSON(needs.prepare.outputs.cpu_python_versions) }}
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
@@ -75,6 +161,8 @@ jobs:
         bash .github/unittest/linux/scripts/run_all.sh
 
   tests-gpu:
+    needs: prepare
+    # prepare.outputs.shards_json is always non-empty (shard 3 safety net), so no extra if: gate.
     strategy:
       matrix:
         python_version: ["3.12"]
@@ -83,7 +171,7 @@ jobs:
         # Shard 1: test/transforms/ (transform tests)
         # Shard 2: test/envs/ + test_collectors.py (multiprocessing-heavy)
         # Shard 3: all other tests
-        shard: ["1", "2", "3"]
+        shard: ${{ fromJSON(needs.prepare.outputs.shards_json) }}
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
@@ -124,6 +212,8 @@ jobs:
         bash .github/unittest/linux/scripts/run_all.sh
 
   tests-gpu-distributed:
+    needs: prepare
+    if: needs.prepare.outputs.run_distributed == 'true'
     strategy:
       matrix:
         python_version: ["3.12"]
@@ -163,6 +253,8 @@ jobs:
         bash .github/unittest/linux/scripts/run_all.sh
 
   tests-olddeps:
+    needs: prepare
+    if: needs.prepare.outputs.run_olddeps == 'true'
     strategy:
       matrix:
         python_version: ["3.10"]
@@ -199,6 +291,8 @@ jobs:
         bash .github/unittest/linux_olddeps/scripts_gym_0_13/post_process.sh
 
   tests-optdeps:
+    needs: prepare
+    if: needs.prepare.outputs.run_optdeps == 'true'
     strategy:
       matrix:
         python_version: ["3.12"]
@@ -235,12 +329,14 @@ jobs:
         bash .github/unittest/linux_optdeps/scripts/run_all.sh
 
   tests-stable-gpu:
+    needs: prepare
+    if: needs.prepare.outputs.run_stable == 'true'
     strategy:
       matrix:
         python_version: ["3.12"] # "3.9", "3.10", "3.11"
         cuda_arch_version: ["13.0"] # "11.6", "11.7"
         # Test sharding: split tests into 3 parallel jobs for faster execution
-        shard: ["1", "2", "3"]
+        shard: ${{ fromJSON(needs.prepare.outputs.shards_json) }}
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
@@ -283,6 +379,8 @@ jobs:
         bash .github/unittest/linux/scripts/run_all.sh
 
   tests-stable-gpu-distributed:
+    needs: prepare
+    if: needs.prepare.outputs.run_stable == 'true'
     strategy:
       matrix:
         python_version: ["3.12"] # "3.9", "3.10", "3.11"

--- a/.github/workflows/test-windows-optdepts.yml
+++ b/.github/workflows/test-windows-optdepts.yml
@@ -2,6 +2,14 @@ name: Unit-tests on Windows
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '**.rst'
+      - 'benchmarks/**'
+      - 'tutorials/**'
+      - 'examples/**'
+      - 'sota-implementations/**'
   push:
     branches:
       - nightly
@@ -21,7 +29,31 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      in_scope: ${{ steps.filter.outputs.any_changed || 'false' }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            torchrl/**
+            test/**
+            setup.py
+            pyproject.toml
+            .github/unittest/windows_optdepts/**
+
   unittests-cpu:
+    needs: changes
+    # Skip on PRs unless core torchrl/test code is touched, or an opt-in label is present.
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.in_scope == 'true' ||
+      contains(github.event.pull_request.labels.*.name, 'ciflow/full') ||
+      contains(github.event.pull_request.labels.*.name, 'ciflow/windows')
     strategy:
       matrix:
         python-version:


### PR DESCRIPTION
## Summary

PRs currently run a heavy matrix on every push: 5 Python versions × CPU, 3 GPU shards, `tests-olddeps`, `tests-optdeps`, `tests-stable-gpu` (3 more shards) + distributed, plus SOTA / tutorials / Windows. This PR prunes that matrix on PRs to **only what the diff demands**, with `ciflow/*` labels as opt-in escape hatches. The full matrix is unchanged on push to `main` / `nightly` / `release/*`.

The label-gating pattern already used by `test-linux-libs.yml`, `test-linux-llm.yml`, and `test-linux-habitat.yml` is the model — this PR extends it to the heavy workflows and adds a small `prepare` job that maps the diff to which GPU shards / peer workflows should run.

## Behaviour

| Track | PR default | Full trigger |
|---|---|---|
| `tests-cpu` | Python 3.12 only | push / `ciflow/cpu-matrix` / `ciflow/full` |
| `tests-gpu` | only the shard(s) whose paths changed (shard 3 fallback) | push / `ciflow/gpu` / `ciflow/full` |
| `tests-gpu-distributed` | only if distributed code changed | push / `ciflow/distributed` / `ciflow/full` |
| `tests-olddeps` | skipped | push / `ciflow/olddeps` / `ciflow/full` |
| `tests-optdeps` | skipped | push / `ciflow/optdeps` / `ciflow/full` |
| `tests-stable-gpu*` | skipped | push / `ciflow/stable` / `ciflow/full` |
| `test-linux-sota` | only if `sota-implementations/**` or `torchrl/trainers/**` changed | push / `ciflow/sota` / `ciflow/full` |
| `test-linux-tutorials` | only if `tutorials/**` changed | push / `ciflow/tutorials` / `ciflow/full` |
| `test-windows-optdepts` | only if `torchrl/**` / `test/**` / `setup.py` / `pyproject.toml` changed | push / `ciflow/windows` / `ciflow/full` |

Docs-only / `tutorials/`-only / `sota-implementations/`-only PRs skip the relevant heavy workflows entirely via `paths-ignore:`.

## Implementation

- **`.github/scripts/ci_decide.sh`** — centralised precedence logic (`push > ciflow/full > per-track labels + file flags`). Unit-tested by `test_ci_decide.sh` (40 assertions, all passing locally).
- **`.github/workflows/test-linux.yml`** — new `prepare` job using `tj-actions/changed-files@v45` to compute `shard1/shard2/shard3/distributed` change flags. All test jobs gain `needs: prepare` + `if:` gates; `tests-cpu` and `tests-gpu` matrices are now driven by `fromJSON(needs.prepare.outputs.…)`.
- **Peer workflows** (`test-linux-sota.yml`, `test-linux-tutorials.yml`, `test-windows-optdepts.yml`) — small `changes` job + label/file `if:` gate.
- **`run_all.sh`** — new optional `TORCHRL_TEST_PATHS` env var that short-circuits the shard dispatch and passes its value verbatim to pytest. Useful for `workflow_dispatch` runs and local reproduction.
- **`.github/labels.yml`** + **`create_labels.sh`** — 10 new `ciflow/*` labels registered (already created on the repo).
- **`.github/CI.md`** — end-to-end docs for contributors.

## Test plan

- [x] \`bash .github/scripts/test_ci_decide.sh\` → 40 passed, 0 failed
- [x] \`actionlint\` clean on all 4 modified workflows
- [x] \`bash -n\` clean on \`run_all.sh\`
- [x] All 10 \`ciflow/*\` labels created on \`pytorch/rl\`
- [ ] After merge, open a draft PR touching only \`torchrl/envs/transforms/vec_norm.py\`. Expect: \`tests-cpu\` matrix is \`["3.12"]\`; \`tests-gpu\` matrix is \`["1"]\`; \`tests-olddeps\` / \`tests-optdeps\` / \`tests-stable-gpu*\` / sota / tutorials / windows all skipped.
- [ ] After merge, open a draft PR editing only a \`.md\`. Expect: \`test-linux.yml\`, \`test-linux-sota.yml\`, \`test-linux-tutorials.yml\`, \`test-windows-optdepts.yml\` do not enqueue.
- [ ] After merge, open a draft PR with \`ciflow/full\`. Expect: pre-change baseline matrix runs.
- [ ] Verify the next push to \`main\` runs the full matrix (no regression vs. today's behaviour).

## Rollback

All changes are additive \`needs:\` / \`if:\` conditions plus a new \`prepare\` job; reverting this PR restores current behaviour.