### PR TITLE
[CI] Fix empty wheel matrices in release workflow

### DIFF
--- a/.github/workflows/build-wheels-aarch64-linux.yml
+++ b/.github/workflows/build-wheels-aarch64-linux.yml
@@ -61,7 +61,7 @@ jobs:
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
       # aarch64 only supports CPU builds
       with-cuda: disable
-      with-cpu: ${{ github.event_name == 'workflow_dispatch' && (inputs.build-cpu && 'enable' || 'disable') || inputs.with-cpu || 'enable' }}
+      with-cpu: ${{ inputs.with-cpu || (github.event_name == 'workflow_dispatch' && (inputs.build-cpu && 'enable' || 'disable')) || 'enable' }}
       channel: ${{ inputs.channel || '' }}
       use-only-dl-pytorch-org: ${{ inputs.channel == 'release' && 'true' || 'false' }}
   build:

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -84,9 +84,9 @@ jobs:
       # For workflow_dispatch: convert boolean to enable/disable string
       # For workflow_call: use the string input directly
       # Default: disable CUDA/ROCm (torchrl is CPU-only), enable CPU
-      with-cuda: ${{ github.event_name == 'workflow_dispatch' && (inputs.build-cuda && 'enable' || 'disable') || inputs.with-cuda || 'disable' }}
-      with-rocm: ${{ github.event_name == 'workflow_dispatch' && (inputs.build-rocm && 'enable' || 'disable') || inputs.with-rocm || 'disable' }}
-      with-cpu: ${{ github.event_name == 'workflow_dispatch' && (inputs.build-cpu && 'enable' || 'disable') || inputs.with-cpu || 'enable' }}
+      with-cuda: ${{ inputs.with-cuda || (github.event_name == 'workflow_dispatch' && (inputs.build-cuda && 'enable' || 'disable')) || 'disable' }}
+      with-rocm: ${{ inputs.with-rocm || (github.event_name == 'workflow_dispatch' && (inputs.build-rocm && 'enable' || 'disable')) || 'disable' }}
+      with-cpu: ${{ inputs.with-cpu || (github.event_name == 'workflow_dispatch' && (inputs.build-cpu && 'enable' || 'disable')) || 'enable' }}
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -62,7 +62,7 @@ jobs:
       channel: ${{ inputs.channel || '' }}
       use-only-dl-pytorch-org: ${{ inputs.channel == 'release' && 'true' || 'false' }}
       # macOS only supports CPU builds
-      with-cpu: ${{ github.event_name == 'workflow_dispatch' && (inputs.build-cpu && 'enable' || 'disable') || inputs.with-cpu || 'enable' }}
+      with-cpu: ${{ inputs.with-cpu || (github.event_name == 'workflow_dispatch' && (inputs.build-cpu && 'enable' || 'disable')) || 'enable' }}
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -74,8 +74,8 @@ jobs:
       # For workflow_dispatch: convert boolean to enable/disable string
       # For workflow_call: use the string input directly
       # Default: disable CUDA (torchrl is CPU-only), enable CPU (Windows has no ROCm)
-      with-cuda: ${{ github.event_name == 'workflow_dispatch' && (inputs.build-cuda && 'enable' || 'disable') || inputs.with-cuda || 'disable' }}
-      with-cpu: ${{ github.event_name == 'workflow_dispatch' && (inputs.build-cpu && 'enable' || 'disable') || inputs.with-cpu || 'enable' }}
+      with-cuda: ${{ inputs.with-cuda || (github.event_name == 'workflow_dispatch' && (inputs.build-cuda && 'enable' || 'disable')) || 'disable' }}
+      with-cpu: ${{ inputs.with-cpu || (github.event_name == 'workflow_dispatch' && (inputs.build-cpu && 'enable' || 'disable')) || 'enable' }}
   build:
     needs: generate-matrix
     strategy:


### PR DESCRIPTION
## Summary

- Fix the `with-cpu`/`with-cuda`/`with-rocm` input resolution in all four `build-wheels-*.yml` workflows
- Root cause: when `release.yml` calls these workflows via `workflow_call`, `github.event_name` inherits `'workflow_dispatch'` from the parent trigger, causing the expression to use `inputs.build-cpu` (undefined in `workflow_call` context → falsy → `'disable'`) instead of `inputs.with-cpu` (the string `'enable'` passed from `release.yml`)
- Result: all arch flags evaluate to `'disable'`, producing empty matrices `{"include": []}`, no wheels built
- Fix: check `workflow_call` string inputs first in the `||` chain — they're always populated in `workflow_call` context (from caller or schema default) and empty in `workflow_dispatch` context, so both paths still work correctly

## Affected workflows

- `build-wheels-linux.yml` (with-cpu, with-cuda, with-rocm)
- `build-wheels-windows.yml` (with-cpu, with-cuda)
- `build-wheels-m1.yml` (with-cpu)
- `build-wheels-aarch64-linux.yml` (with-cpu)

## Test plan

- [ ] Merge and cherry-pick to release branch
- [ ] Re-trigger release workflow and verify wheel matrices are non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)