### PR TITLE
[BugFix] Fix PPOTrainer gamma/lmbda defaults, remove dead code, fix wildcard import

### DIFF
--- a/sota-implementations/ppo_trainer/config/config.yaml
+++ b/sota-implementations/ppo_trainer/config/config.yaml
@@ -27,7 +27,7 @@ defaults:
   - trainer@trainer: ppo
   - optimizer@optimizer: adam
   - loss@loss: ppo
-  - logger@logger: wandb
+  - logger@logger: csv
   - _self_
 
 # Network configurations

--- a/sota-implementations/ppo_trainer/train.py
+++ b/sota-implementations/ppo_trainer/train.py
@@ -4,7 +4,7 @@
 
 import hydra
 import torchrl
-from torchrl.trainers.algorithms.configs import *  # noqa: F401, F403
+from torchrl.trainers.algorithms.configs import PPOTrainerConfig  # noqa: F401
 
 
 @hydra.main(config_path="config", config_name="config", version_base="1.1")

--- a/torchrl/trainers/algorithms/ppo.py
+++ b/torchrl/trainers/algorithms/ppo.py
@@ -29,19 +29,6 @@ from torchrl.trainers.trainers import (
     UpdateWeights,
 )
 
-try:
-    pass
-
-    _has_tqdm = True
-except ImportError:
-    _has_tqdm = False
-
-try:
-    pass
-
-    _has_ts = True
-except ImportError:
-    _has_ts = False
 
 
 class PPOTrainer(Trainer):
@@ -140,8 +127,8 @@ class PPOTrainer(Trainer):
         num_epochs: int = 4,
         replay_buffer: ReplayBuffer | None = None,
         batch_size: int | None = None,
-        gamma: float = 0.9,
-        lmbda: float = 0.99,
+        gamma: float = 0.99,
+        lmbda: float = 0.95,
         enable_logging: bool = True,
         log_rewards: bool = True,
         log_actions: bool = True,


### PR DESCRIPTION
##Fix

Wrong gamma default (0.9 → 0.99): The discount factor was set to 0.9, causing the agent to heavily discount future rewards and perform significantly worse than expected on standard benchmarks. Every major PPO reference implementation (Stable Baselines3, CleanRL, the existing sota-implementations/ppo/) uses gamma=0.99.

Wrong lmbda default (0.99 → 0.95): The GAE lambda was inverted from the standard value. lmbda=0.99 produces high-variance advantage estimates close to Monte Carlo returns. The original GAE paper and all standard implementations use lmbda=0.95.

Dead try/except blocks: Two empty try: pass blocks that unconditionally set _has_tqdm=True and _has_ts=True regardless of whether those packages are installed. Removed entirely.

Wildcard import in train.py: from torchrl.trainers.algorithms.configs import * replaced with an explicit import to avoid silent name collisions.

WandB as default logger: Changed default logger from wandb to csv so the training script works out of the box without WandB credentials.