### PR TITLE
[Feature] Improve CUDA prioritized replay buffer ergonomics

### DIFF
--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -105,8 +105,7 @@ jobs:
           export TORCHDYNAMO_INLINE_INBUILT_NN_MODULES=1
           export COMPOSITE_LP_AGGREGATE=0
           export TD_GET_DEFAULTS_TO_NONE=1
-          RUN_BENCHMARK="python -m pytest -vvv --rank 0 test_replaybuffer_benchmark.py::test_prioritized_sampler_sample_scale --benchmark-json "
-          $RUN_BENCHMARK ${{ env.CONTENDER_JSON }}
+          python -m pytest -vvv --rank 0 test_replaybuffer_benchmark.py::TestPrioritizedReplayBufferBenchmark --benchmark-json ${{ env.CONTENDER_JSON }}
           cp ${{ env.CONTENDER_JSON }} ${{ env.BASELINE_JSON }}
       - name: Publish results
         continue-on-error: true

--- a/benchmarks/test_replaybuffer_benchmark.py
+++ b/benchmarks/test_replaybuffer_benchmark.py
@@ -84,7 +84,7 @@ def sample_prioritized_replay_buffer(rb):
     sampler_device = rb._sampler.device
     if sampler_device.type == "cuda":
         torch.cuda.synchronize(sampler_device)
-    elif getattr(sample, "device", None) is not None and sample.device.type == "cuda":
+    elif sample.device is not None and sample.device.type == "cuda":
         torch.cuda.synchronize(sample.device)
 
 
@@ -202,8 +202,13 @@ class create_prioritized_replay_buffer:
             device=data_device,
         )
         rb.extend(data)
-        if "cuda" in {self.storage_device.type, self.sampler_device.type}:
-            torch.cuda.synchronize()
+        if self.storage_device.type == "cuda":
+            torch.cuda.synchronize(self.storage_device)
+        if (
+            self.sampler_device.type == "cuda"
+            and self.sampler_device != self.storage_device
+        ):
+            torch.cuda.synchronize(self.sampler_device)
         return ((rb,), {})
 
 

--- a/benchmarks/test_replaybuffer_benchmark.py
+++ b/benchmarks/test_replaybuffer_benchmark.py
@@ -79,6 +79,15 @@ def sample_prioritized_sampler(sampler, storage, batch_size):
         torch.cuda.synchronize(sampler.device)
 
 
+def sample_prioritized_replay_buffer(rb):
+    sample = rb.sample()
+    sampler_device = rb._sampler.device
+    if sampler_device.type == "cuda":
+        torch.cuda.synchronize(sampler_device)
+    elif getattr(sample, "device", None) is not None and sample.device.type == "cuda":
+        torch.cuda.synchronize(sample.device)
+
+
 def iterate(rb):
     next(rb)
 
@@ -136,6 +145,68 @@ class create_prioritized_sampler:
         return ((sampler, storage, self.batch_size), {})
 
 
+class create_prioritized_replay_buffer:
+    def __init__(
+        self,
+        size,
+        storage_type,
+        storage_device,
+        sampler_device,
+        batch_size,
+        alpha=0.7,
+        beta=0.5,
+    ):
+        self.size = size
+        self.storage_type = storage_type
+        self.storage_device = torch.device(storage_device)
+        self.sampler_device = torch.device(sampler_device)
+        self.batch_size = batch_size
+        self.alpha = alpha
+        self.beta = beta
+
+    def __call__(self):
+        ext = pytest.importorskip("torchrl._torchrl")
+        if not hasattr(ext, "SumSegmentTreeFp32"):
+            _skip_or_fail_unavailable("TorchRL was not built with segment tree support")
+        if "cuda" in {self.storage_device.type, self.sampler_device.type}:
+            if not torch.cuda.is_available():
+                _skip_or_fail_unavailable("CUDA is not available")
+            if not hasattr(ext, "CudaSumSegmentTreeFp32"):
+                _skip_or_fail_unavailable(
+                    "TorchRL was not built with CUDA segment tree support"
+                )
+        if self.storage_type == "memmap":
+            storage = LazyMemmapStorage(self.size)
+            data_device = torch.device("cpu")
+        elif self.storage_type == "tensor":
+            storage = LazyTensorStorage(self.size, device=self.storage_device)
+            data_device = self.storage_device
+        else:
+            raise RuntimeError(f"Unknown storage_type {self.storage_type}.")
+        rb = TensorDictPrioritizedReplayBuffer(
+            alpha=self.alpha,
+            beta=self.beta,
+            storage=storage,
+            sampler_device=self.sampler_device,
+            batch_size=self.batch_size,
+            priority_key="td_error",
+        )
+        data = TensorDict(
+            {
+                "obs": torch.arange(
+                    self.size, dtype=torch.float32, device=data_device
+                ).unsqueeze(-1),
+                "td_error": torch.linspace(0.1, 1.0, self.size, device=data_device),
+            },
+            batch_size=[self.size],
+            device=data_device,
+        )
+        rb.extend(data)
+        if "cuda" in {self.storage_device.type, self.sampler_device.type}:
+            torch.cuda.synchronize()
+        return ((rb,), {})
+
+
 def _prioritized_sampler_benchmark_devices():
     device = os.getenv("TORCHRL_BENCHMARK_DEVICE")
     if device == "CPU":
@@ -143,6 +214,26 @@ def _prioritized_sampler_benchmark_devices():
     if device == "GPU":
         return ["cuda"]
     return ["cpu", "cuda"]
+
+
+def _prioritized_replay_buffer_benchmark_configs():
+    device = os.getenv("TORCHRL_BENCHMARK_DEVICE")
+    if device == "CPU":
+        return [
+            pytest.param("memmap", "cpu", "cpu", id="memmap_cpu_storage_cpu_sampler")
+        ]
+    if device == "GPU":
+        return [
+            pytest.param("tensor", "cuda", "cuda", id="cuda_storage_cuda_sampler"),
+            pytest.param("memmap", "cpu", "cuda", id="memmap_cpu_storage_cuda_sampler"),
+            pytest.param("tensor", "cuda", "cpu", id="cuda_storage_cpu_sampler"),
+        ]
+    return [
+        pytest.param("memmap", "cpu", "cpu", id="memmap_cpu_storage_cpu_sampler"),
+        pytest.param("tensor", "cuda", "cuda", id="cuda_storage_cuda_sampler"),
+        pytest.param("memmap", "cpu", "cuda", id="memmap_cpu_storage_cuda_sampler"),
+        pytest.param("tensor", "cuda", "cpu", id="cuda_storage_cpu_sampler"),
+    ]
 
 
 @pytest.mark.parametrize(
@@ -183,19 +274,38 @@ def test_rb_sample(benchmark, rb, storage, sampler, size):
     benchmark(sample, rb)
 
 
-@pytest.mark.parametrize("device", _prioritized_sampler_benchmark_devices())
-@pytest.mark.parametrize("size", [1_000_000, 10_000_000])
-def test_prioritized_sampler_sample_scale(benchmark, size, device):
-    batch_size = 65_536
-    (sampler, storage, batch_size), _ = create_prioritized_sampler(
-        size=size, device=device, batch_size=batch_size
-    )()
-    benchmark(
-        sample_prioritized_sampler,
-        sampler,
-        storage,
-        batch_size,
+class TestPrioritizedReplayBufferBenchmark:
+    @pytest.mark.parametrize("device", _prioritized_sampler_benchmark_devices())
+    @pytest.mark.parametrize("size", [1_000_000, 10_000_000])
+    def test_sampler_sample_scale(self, benchmark, size, device):
+        batch_size = 65_536
+        (sampler, storage, batch_size), _ = create_prioritized_sampler(
+            size=size, device=device, batch_size=batch_size
+        )()
+        benchmark(
+            sample_prioritized_sampler,
+            sampler,
+            storage,
+            batch_size,
+        )
+
+    @pytest.mark.parametrize(
+        "storage_type,storage_device,sampler_device",
+        _prioritized_replay_buffer_benchmark_configs(),
     )
+    @pytest.mark.parametrize("size", [1_000_000])
+    def test_sample_mixed_devices(
+        self, benchmark, size, storage_type, storage_device, sampler_device
+    ):
+        batch_size = 65_536
+        (rb,), _ = create_prioritized_replay_buffer(
+            size=size,
+            storage_type=storage_type,
+            storage_device=storage_device,
+            sampler_device=sampler_device,
+            batch_size=batch_size,
+        )()
+        benchmark(sample_prioritized_replay_buffer, rb)
 
 
 def infinite_iter(obj):

--- a/docs/source/reference/data.rst
+++ b/docs/source/reference/data.rst
@@ -109,6 +109,7 @@ CPU memmap storage with CUDA priority sampling:
     )
     rb.extend(data)
     sample = rb.sample()
+    sample["td_error"] = torch.rand(sample.shape)
     rb.update_tensordict_priority(sample)
 
 CUDA storage with CPU priority sampling:
@@ -138,6 +139,7 @@ CUDA storage with CPU priority sampling:
     )
     rb.extend(data)
     sample = rb.sample()
+    sample["td_error"] = torch.rand(sample.shape, device="cuda")
     rb.update_tensordict_priority(sample)
 
 Documentation Sections

--- a/docs/source/reference/data.rst
+++ b/docs/source/reference/data.rst
@@ -24,6 +24,7 @@ Quick Example
 
 .. code-block:: python
 
+    import torch
     from torchrl.data import ReplayBuffer, LazyMemmapStorage, PrioritizedSampler
     from tensordict import TensorDict
     
@@ -44,6 +45,100 @@ Quick Example
     
     # Sample
     sample = buffer.sample()  # Returns batch_size=256
+
+CUDA prioritized replay buffers
+-------------------------------
+
+Prioritized replay buffers can keep the priority trees on CPU or CUDA
+independently from the data storage. By default, CUDA tensor storage selects a
+CUDA sampler and CPU storage selects a CPU sampler. Use ``sampler_device`` when
+the storage and priority sampler should live on different devices.
+
+All-CUDA storage and sampling:
+
+.. code-block:: python
+
+    import torch
+    from tensordict import TensorDict
+    from torchrl.data import LazyTensorStorage, TensorDictPrioritizedReplayBuffer
+
+    rb = TensorDictPrioritizedReplayBuffer(
+        alpha=0.7,
+        beta=0.5,
+        storage=LazyTensorStorage(1_000_000, device="cuda"),
+        batch_size=65_536,
+        priority_key="td_error",
+    )
+
+    data = TensorDict(
+        {
+            "obs": torch.randn(100_000, 32, device="cuda"),
+            "td_error": torch.ones(100_000, device="cuda"),
+        },
+        batch_size=[100_000],
+        device="cuda",
+    )
+    rb.extend(data)
+    sample = rb.sample()
+    sample["td_error"] = torch.rand(sample.shape, device="cuda")
+    rb.update_tensordict_priority(sample)
+
+CPU memmap storage with CUDA priority sampling:
+
+.. code-block:: python
+
+    import torch
+    from tensordict import TensorDict
+    from torchrl.data import LazyMemmapStorage, TensorDictPrioritizedReplayBuffer
+
+    rb = TensorDictPrioritizedReplayBuffer(
+        alpha=0.7,
+        beta=0.5,
+        storage=LazyMemmapStorage(10_000_000, scratch_dir="/tmp/torchrl_rb"),
+        sampler_device="cuda",
+        batch_size=65_536,
+        priority_key="td_error",
+    )
+
+    data = TensorDict(
+        {
+            "obs": torch.randn(100_000, 32),
+            "td_error": torch.ones(100_000),
+        },
+        batch_size=[100_000],
+    )
+    rb.extend(data)
+    sample = rb.sample()
+    rb.update_tensordict_priority(sample)
+
+CUDA storage with CPU priority sampling:
+
+.. code-block:: python
+
+    import torch
+    from tensordict import TensorDict
+    from torchrl.data import LazyTensorStorage, TensorDictPrioritizedReplayBuffer
+
+    rb = TensorDictPrioritizedReplayBuffer(
+        alpha=0.7,
+        beta=0.5,
+        storage=LazyTensorStorage(1_000_000, device="cuda"),
+        sampler_device="cpu",
+        batch_size=65_536,
+        priority_key="td_error",
+    )
+
+    data = TensorDict(
+        {
+            "obs": torch.randn(100_000, 32, device="cuda"),
+            "td_error": torch.ones(100_000, device="cuda"),
+        },
+        batch_size=[100_000],
+        device="cuda",
+    )
+    rb.extend(data)
+    sample = rb.sample()
+    rb.update_tensordict_priority(sample)
 
 Documentation Sections
 ----------------------

--- a/docs/source/reference/data.rst
+++ b/docs/source/reference/data.rst
@@ -54,93 +54,96 @@ independently from the data storage. By default, CUDA tensor storage selects a
 CUDA sampler and CPU storage selects a CPU sampler. Use ``sampler_device`` when
 the storage and priority sampler should live on different devices.
 
-All-CUDA storage and sampling:
+.. dropdown:: All-CUDA storage and sampling
+   :icon: code
 
-.. code-block:: python
+   .. code-block:: python
 
-    import torch
-    from tensordict import TensorDict
-    from torchrl.data import LazyTensorStorage, TensorDictPrioritizedReplayBuffer
+       import torch
+       from tensordict import TensorDict
+       from torchrl.data import LazyTensorStorage, TensorDictPrioritizedReplayBuffer
 
-    rb = TensorDictPrioritizedReplayBuffer(
-        alpha=0.7,
-        beta=0.5,
-        storage=LazyTensorStorage(1_000_000, device="cuda"),
-        batch_size=65_536,
-        priority_key="td_error",
-    )
+       rb = TensorDictPrioritizedReplayBuffer(
+           alpha=0.7,
+           beta=0.5,
+           storage=LazyTensorStorage(1_000_000, device="cuda"),
+           batch_size=65_536,
+           priority_key="td_error",
+       )
 
-    data = TensorDict(
-        {
-            "obs": torch.randn(100_000, 32, device="cuda"),
-            "td_error": torch.ones(100_000, device="cuda"),
-        },
-        batch_size=[100_000],
-        device="cuda",
-    )
-    rb.extend(data)
-    sample = rb.sample()
-    sample["td_error"] = torch.rand(sample.shape, device="cuda")
-    rb.update_tensordict_priority(sample)
+       data = TensorDict(
+           {
+               "obs": torch.randn(100_000, 32, device="cuda"),
+               "td_error": torch.ones(100_000, device="cuda"),
+           },
+           batch_size=[100_000],
+           device="cuda",
+       )
+       rb.extend(data)
+       sample = rb.sample()
+       sample["td_error"] = torch.rand(sample.shape, device="cuda")
+       rb.update_tensordict_priority(sample)
 
-CPU memmap storage with CUDA priority sampling:
+.. dropdown:: CPU memmap storage with CUDA priority sampling
+   :icon: code
 
-.. code-block:: python
+   .. code-block:: python
 
-    import torch
-    from tensordict import TensorDict
-    from torchrl.data import LazyMemmapStorage, TensorDictPrioritizedReplayBuffer
+       import torch
+       from tensordict import TensorDict
+       from torchrl.data import LazyMemmapStorage, TensorDictPrioritizedReplayBuffer
 
-    rb = TensorDictPrioritizedReplayBuffer(
-        alpha=0.7,
-        beta=0.5,
-        storage=LazyMemmapStorage(10_000_000, scratch_dir="/tmp/torchrl_rb"),
-        sampler_device="cuda",
-        batch_size=65_536,
-        priority_key="td_error",
-    )
+       rb = TensorDictPrioritizedReplayBuffer(
+           alpha=0.7,
+           beta=0.5,
+           storage=LazyMemmapStorage(10_000_000, scratch_dir="/tmp/torchrl_rb"),
+           sampler_device="cuda",
+           batch_size=65_536,
+           priority_key="td_error",
+       )
 
-    data = TensorDict(
-        {
-            "obs": torch.randn(100_000, 32),
-            "td_error": torch.ones(100_000),
-        },
-        batch_size=[100_000],
-    )
-    rb.extend(data)
-    sample = rb.sample()
-    sample["td_error"] = torch.rand(sample.shape)
-    rb.update_tensordict_priority(sample)
+       data = TensorDict(
+           {
+               "obs": torch.randn(100_000, 32),
+               "td_error": torch.ones(100_000),
+           },
+           batch_size=[100_000],
+       )
+       rb.extend(data)
+       sample = rb.sample()
+       sample["td_error"] = torch.rand(sample.shape)
+       rb.update_tensordict_priority(sample)
 
-CUDA storage with CPU priority sampling:
+.. dropdown:: CUDA storage with CPU priority sampling
+   :icon: code
 
-.. code-block:: python
+   .. code-block:: python
 
-    import torch
-    from tensordict import TensorDict
-    from torchrl.data import LazyTensorStorage, TensorDictPrioritizedReplayBuffer
+       import torch
+       from tensordict import TensorDict
+       from torchrl.data import LazyTensorStorage, TensorDictPrioritizedReplayBuffer
 
-    rb = TensorDictPrioritizedReplayBuffer(
-        alpha=0.7,
-        beta=0.5,
-        storage=LazyTensorStorage(1_000_000, device="cuda"),
-        sampler_device="cpu",
-        batch_size=65_536,
-        priority_key="td_error",
-    )
+       rb = TensorDictPrioritizedReplayBuffer(
+           alpha=0.7,
+           beta=0.5,
+           storage=LazyTensorStorage(1_000_000, device="cuda"),
+           sampler_device="cpu",
+           batch_size=65_536,
+           priority_key="td_error",
+       )
 
-    data = TensorDict(
-        {
-            "obs": torch.randn(100_000, 32, device="cuda"),
-            "td_error": torch.ones(100_000, device="cuda"),
-        },
-        batch_size=[100_000],
-        device="cuda",
-    )
-    rb.extend(data)
-    sample = rb.sample()
-    sample["td_error"] = torch.rand(sample.shape, device="cuda")
-    rb.update_tensordict_priority(sample)
+       data = TensorDict(
+           {
+               "obs": torch.randn(100_000, 32, device="cuda"),
+               "td_error": torch.ones(100_000, device="cuda"),
+           },
+           batch_size=[100_000],
+           device="cuda",
+       )
+       rb.extend(data)
+       sample = rb.sample()
+       sample["td_error"] = torch.rand(sample.shape, device="cuda")
+       rb.update_tensordict_priority(sample)
 
 Documentation Sections
 ----------------------

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -4946,7 +4946,7 @@ class TestSharedStorageInit:
             assert p.exitcode == 0
             assert queue.get(timeout=5) == "done"
 
-        assert len(storage) >= 8
+        assert len(storage) == 8
         learner_rb = TensorDictPrioritizedReplayBuffer(
             alpha=0.7,
             beta=0.5,

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -1544,12 +1544,12 @@ def test_cuda_prioritized_replay_buffer_samples_on_cuda():
     assert sample["priority_weight"].device == device
 
 
-def test_tensordict_prioritized_replay_buffer_device_sampler_cpu():
+def test_tensordict_prioritized_replay_buffer_sampler_device_cpu():
     rb = TensorDictPrioritizedReplayBuffer(
         alpha=0.7,
         beta=0.5,
         storage=LazyTensorStorage(32),
-        device_sampler="cpu",
+        sampler_device="cpu",
         batch_size=8,
         priority_key="td_error",
     )
@@ -1580,7 +1580,7 @@ def test_tensordict_prioritized_replay_buffer_memmap_storage_cuda_sampler(tmpdir
         alpha=0.7,
         beta=0.5,
         storage=LazyMemmapStorage(32, scratch_dir=tmpdir),
-        device_sampler="cuda:0",
+        sampler_device="cuda:0",
         batch_size=8,
         priority_key="td_error",
     )
@@ -1615,7 +1615,7 @@ def test_tensordict_prioritized_replay_buffer_cuda_storage_cpu_sampler():
         alpha=0.7,
         beta=0.5,
         storage=LazyTensorStorage(32, device=device),
-        device_sampler="cpu",
+        sampler_device="cpu",
         batch_size=8,
         priority_key="td_error",
     )
@@ -4909,6 +4909,63 @@ class TestSharedStorageInit:
         expected = {0.0, 1.0, 2.0, 3.0}
         assert expected.issubset(values)
         assert len(storage) >= 8
+
+    def prioritized_collector_worker(self, rb, worker_id, queue):
+        data = TensorDict(
+            {
+                "obs": torch.full((4, 1), worker_id, dtype=torch.float32),
+                "td_error": torch.linspace(0.1, 1.0, 4) + worker_id,
+            },
+            batch_size=(4,),
+        )
+        rb.extend(data)
+        queue.put("done")
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+    def test_prioritized_memmap_cuda_sampler_after_multiprocess_writes(self, tmpdir):
+        ext = pytest.importorskip("torchrl._torchrl")
+        if not hasattr(ext, "CudaSumSegmentTreeFp32"):
+            pytest.skip("TorchRL was not built with CUDA segment tree support")
+
+        storage = LazyMemmapStorage(max_size=32, scratch_dir=tmpdir, shared_init=True)
+        writer_rb = TensorDictReplayBuffer(storage=storage, batch_size=4).share(True)
+        queue = mp.Queue()
+
+        processes = []
+        for i in range(2):
+            p = mp.Process(
+                target=self.prioritized_collector_worker,
+                args=(writer_rb, i, queue),
+            )
+            processes.append(p)
+            p.start()
+
+        for p in processes:
+            p.join()
+            assert p.exitcode == 0
+            assert queue.get(timeout=5) == "done"
+
+        assert len(storage) >= 8
+        learner_rb = TensorDictPrioritizedReplayBuffer(
+            alpha=0.7,
+            beta=0.5,
+            storage=storage,
+            sampler_device="cuda:0",
+            batch_size=4,
+            priority_key="td_error",
+        )
+
+        sample = learner_rb.sample()
+        assert learner_rb._sampler.device == torch.device("cuda:0")
+        assert sample["obs"].device.type == "cpu"
+        assert sample["index"].device.type == "cpu"
+        assert sample["priority_weight"].device.type == "cpu"
+
+        sample["td_error"] = torch.ones_like(sample["td_error"]) * 10
+        learner_rb.update_tensordict_priority(sample)
+        sample = learner_rb.sample()
+        assert sample["index"].device.type == "cpu"
 
 
 @pytest.mark.skipif(not _has_zstandard, reason="zstandard required for this test.")

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -1342,7 +1342,7 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         sampler (Sampler, optional): the sampler to be used. If none is provided,
             a default :class:`~torchrl.data.replay_buffers.PrioritizedSampler` with
             ``alpha``, ``beta``, and ``eps`` will be created.
-        device_sampler (torch.device or str, optional): device where the
+        sampler_device (torch.device or str, optional): device where the
             priority sampler trees will be stored. Defaults to ``None``, in
             which case CUDA storage selects CUDA sampling and CPU storage
             selects CPU sampling. Cannot be used together with ``sampler``.
@@ -1451,7 +1451,7 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         dtype: torch.dtype = torch.float,
         storage: Storage | None = None,
         sampler: Sampler | None = None,
-        device_sampler: DEVICE_TYPING | None = None,
+        sampler_device: DEVICE_TYPING | None = None,
         collate_fn: Callable | None = None,
         pin_memory: bool = False,
         prefetch: int | None = None,
@@ -1464,10 +1464,10 @@ class PrioritizedReplayBuffer(ReplayBuffer):
             storage = ListStorage(max_size=1_000)
         if sampler is None:
             sampler = PrioritizedSampler(
-                storage.max_size, alpha, beta, eps, dtype, device=device_sampler
+                storage.max_size, alpha, beta, eps, dtype, device=sampler_device
             )
-        elif device_sampler is not None:
-            raise TypeError("device_sampler cannot be passed when sampler is provided.")
+        elif sampler_device is not None:
+            raise TypeError("sampler_device cannot be passed when sampler is provided.")
         super().__init__(
             storage=storage,
             sampler=sampler,
@@ -1917,7 +1917,7 @@ class TensorDictPrioritizedReplayBuffer(TensorDictReplayBuffer):
             This is to be used when the sampler is of type
             :class:`~torchrl.data.PrioritizedSampler`.
             Defaults to ``"td_error"``.
-        device_sampler (torch.device or str, optional): device where the
+        sampler_device (torch.device or str, optional): device where the
             priority sampler trees will be stored. Defaults to ``None``, in
             which case CUDA storage selects CUDA sampling and CPU storage
             selects CPU sampling.
@@ -2029,7 +2029,7 @@ class TensorDictPrioritizedReplayBuffer(TensorDictReplayBuffer):
         priority_key: str = "td_error",
         eps: float = 1e-8,
         storage: Storage | None = None,
-        device_sampler: DEVICE_TYPING | None = None,
+        sampler_device: DEVICE_TYPING | None = None,
         collate_fn: Callable | None = None,
         pin_memory: bool = False,
         prefetch: int | None = None,
@@ -2048,7 +2048,7 @@ class TensorDictPrioritizedReplayBuffer(TensorDictReplayBuffer):
             beta,
             eps,
             reduction=reduction,
-            device=device_sampler,
+            device=sampler_device,
         )
         super().__init__(
             priority_key=priority_key,


### PR DESCRIPTION
## Description

Follow-up to CUDA prioritized replay sampling with API, docs, benchmark, and distributed smoke coverage.

- Rename the public replay-buffer constructor argument from `device_sampler` to `sampler_device`.
- Document all-CUDA replay buffers, CPU memmap storage with CUDA sampling, and CUDA storage with CPU sampling.
- Add benchmark coverage for prioritized sampling at scale and full replay-buffer sampling across mixed storage/sampler devices.
- Add regression coverage for mixed-device replay buffers, including a distributed memmap writer flow sampled with a CUDA prioritized sampler.
- Narrow the PR benchmark workflow to the prioritized replay benchmark class.

## Testing

- `python3 -m py_compile torchrl/data/replay_buffers/replay_buffers.py test/test_rb.py benchmarks/test_replaybuffer_benchmark.py`
- `git diff --check`
- `.venv/bin/python -m pre_commit run --files .github/workflows/benchmarks_pr.yml benchmarks/test_replaybuffer_benchmark.py docs/source/reference/data.rst test/test_rb.py torchrl/data/replay_buffers/replay_buffers.py`