### PR TITLE
[Feature] PettingZooWrapper: use spec.encode() for .state()

### DIFF
--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -584,7 +584,7 @@ class PettingZooWrapper(_EnvWrapper):
                         )
 
         if self.return_state:
-            state = torch.as_tensor(self.state(), device=self.device)
+            state = self.observation_spec["state"].encode(self.state())
             tensordict_out.set("state", state)
 
         return tensordict_out
@@ -707,7 +707,7 @@ class PettingZooWrapper(_EnvWrapper):
         tensordict_out.set("truncated", truncated)
 
         if self.return_state:
-            state = torch.as_tensor(self.state(), device=self.device)
+            state = self.observation_spec["state"].encode(self.state())
             tensordict_out.set("state", state)
 
         return tensordict_out


### PR DESCRIPTION
## Description
Replace `torch.as_tensor(self.state(), device=self.device)` with `self.observation_spec["state"].encode(self.state())` in both `_reset` and `_step` of `PettingZooWrapper`.

## Motivation and Context
Closes #3681

PettingZoo’s `.state()` is no longer restricted to `ndarray` (see Farama-Foundation/PettingZoo#1326).  
TorchRL already correctly builds a proper `observation_spec["state"]` (using `_gym_to_torchrl_spec_transform` or fallback), but the runtime path in `_reset` and `_step` was still forcing `torch.as_tensor`.

This change makes `.state()` handling **consistent** with how observations and actions are processed and makes the wrapper fully future-proof for any type of state that matches `state_space`.

## Types of changes
- [x] New feature (non-breaking change which adds core functionality)

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation. *(documentation update is not needed)*
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.