### PR TITLE
[Feature] Add new `setup` and  `shutdown` hook points

### DIFF
--- a/docs/source/reference/trainers.rst
+++ b/docs/source/reference/trainers.rst
@@ -12,7 +12,7 @@ loop the optimization steps.
 Key Features
 ------------
 
-- **Modular hook system**: Customize training at 10 different points in the loop
+- **Modular hook system**: Customize training at 18 different points in the loop
 - **Checkpointing support**: Save and restore training state with ``torch``, ``torchsnapshot``, or ``memmap`` (set via the ``CKPT_BACKEND`` environment variable)
 - **Algorithm trainers**: High-level trainers for PPO, SAC, DQN, DDPG, IQL, CQL with Hydra configuration
 - **Builder helpers**: Utilities for constructing collectors, losses, and replay buffers

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -88,6 +88,19 @@ class MockingCollector:
         pass
 
 
+class MockingIterableCollector(MockingCollector):
+    def __init__(self, batches):
+        self._batches = batches
+        self.init_random_frames = 10**9
+        self.shutdown_calls = 0
+
+    def __iter__(self):
+        return iter(self._batches)
+
+    def shutdown(self):
+        self.shutdown_calls += 1
+
+
 class MockingLossModule(nn.Module):
     pass
 
@@ -1345,6 +1358,50 @@ class TestProcessLossHook:
         trainer.register_op("process_loss", WeightedLoss())
         td_out = trainer._process_loss_hook(td_sub_batch, td_loss.clone())
         assert torch.allclose(td_out["loss_a"], torch.tensor(0.5))
+
+
+class TestSetupShutdownHooks:
+    @staticmethod
+    def _make_trainer(collector):
+        trainer = Trainer(
+            collector=collector,
+            total_frames=2,
+            frame_skip=1,
+            optim_steps_per_batch=1,
+            loss_module=MockingLossModule(),
+            optimizer=None,
+            progress_bar=False,
+        )
+        trainer._pbar_str = OrderedDict()
+        return trainer
+
+    def test_setup_and_shutdown_hooks_order(self):
+        batches = [
+            TensorDict({"x": torch.zeros(1)}, [1]),
+            TensorDict({"x": torch.ones(1)}, [1]),
+        ]
+        collector = MockingIterableCollector(batches)
+        trainer = self._make_trainer(collector)
+
+        call_order = []
+
+        def setup_hook():
+            call_order.append("setup")
+
+        def pre_steps_hook(_batch):
+            call_order.append("pre_steps")
+
+        def shutdown_hook():
+            call_order.append("shutdown")
+
+        trainer.register_op("setup", setup_hook)
+        trainer.register_op("pre_steps_log", pre_steps_hook)
+        trainer.register_op("shutdown", shutdown_hook)
+
+        trainer.train()
+
+        assert call_order == ["setup", "pre_steps", "pre_steps", "shutdown"]
+        assert collector.shutdown_calls == 1
 
 
 if __name__ == "__main__":

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -417,6 +417,8 @@ class Trainer:
             []
         )  # Process batches for optimization (e.g., subsampling)
         self._post_optim_ops = []  # After optimization (e.g., weight syncing)
+        self._setup_ops = []  # Before training starts (e.g., warmups, lazy init)
+        self._shutdown_ops = []  # At training end (e.g., final eval, publish)
 
         self._modules = {}
 
@@ -631,6 +633,8 @@ class Trainer:
             "post_optim_complete_log",
             "pre_epoch",
             "post_epoch",
+            "setup",
+            "shutdown",
         ],
         op: Callable,
         **kwargs,
@@ -752,13 +756,21 @@ class Trainer:
             _check_input_output_typehint(op, input=None, output=None)
             self._post_epoch_ops.append((timed_op, kwargs))
 
+        elif dest == "setup":
+            _check_input_output_typehint(op, input=None, output=None)
+            self._setup_ops.append((timed_op, kwargs))
+
+        elif dest == "shutdown":
+            _check_input_output_typehint(op, input=None, output=None)
+            self._shutdown_ops.append((timed_op, kwargs))
+
         else:
             raise RuntimeError(
                 f"The hook collection {dest} is not recognised. Choose from:"
                 f"(batch_process, pre_optim_steps, process_optim_batch, post_loss, "
                 f"process_loss, optimizer, post_steps, post_optim, pre_steps_log, "
                 f"post_steps_log, post_optim_log, pre_epoch_log, post_epoch_log, "
-                f"post_optim_complete_log, pre_epoch, post_epoch)"
+                f"post_optim_complete_log, setup, shutdown, pre_epoch, post_epoch)"
             )
 
     register_hook = register_op
@@ -919,6 +931,14 @@ class Trainer:
             if result is not None:
                 self._log(**result)
 
+    def _setup_hook(self) -> None:
+        for op, kwargs in self._setup_ops:
+            op(**kwargs)
+
+    def _shutdown_hook(self) -> None:
+        for op, kwargs in self._shutdown_ops:
+            op(**kwargs)
+
     def train(self):
         if self.progress_bar:
             self._pbar = tqdm(total=self.total_frames)
@@ -933,6 +953,8 @@ class Trainer:
             iterator = self._async_iterator()
         else:
             iterator = self.collector
+
+        self._setup_hook()
 
         for batch in iterator:
             if not self.async_collection:
@@ -970,6 +992,7 @@ class Trainer:
                 break
             self.save_trainer()
 
+        self._shutdown_hook()
         self.collector.shutdown()
 
     def _async_iterator(self):


### PR DESCRIPTION
## Description

Add the `setup` hook point before the collection loop and `shutdown` hook point after it.

## Motivation and Context

It is required to encapsulate pre-training evals, inits, post-training evals, publish, etc., in the trainer.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] New feature (non-breaking change which adds core functionality)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
