### PR TITLE
[CI] Add ruleset JSON requiring lint-done on protected branches

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,29 @@
+# Repository rulesets
+
+Source-of-truth JSON for branch rulesets applied to `pytorch/rl`.
+
+These files are **not** auto-applied by GitHub. They live here so the configuration
+is reviewable, version-controlled, and reproducible. To apply a ruleset:
+
+```bash
+gh api -X POST repos/pytorch/rl/rulesets --input .github/rulesets/<file>.json
+```
+
+To update an existing ruleset, fetch its id and `PUT`:
+
+```bash
+gh api repos/pytorch/rl/rulesets -q '.[] | select(.name=="<name>") | .id'
+gh api -X PUT repos/pytorch/rl/rulesets/<id> --input .github/rulesets/<file>.json
+```
+
+To delete:
+
+```bash
+gh api -X DELETE repos/pytorch/rl/rulesets/<id>
+```
+
+## Current rulesets
+
+- `lint-required.json` — gates merges into `main` / `nightly` / `release/*` on
+  the `lint-done` aggregator from `.github/workflows/lint.yml` and the existing
+  `Meta CLA Check`.

--- a/.github/rulesets/lint-required.json
+++ b/.github/rulesets/lint-required.json
@@ -1,0 +1,24 @@
+{
+  "name": "Require lint on protected branches",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main", "refs/heads/nightly", "refs/heads/release/*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "lint-done" },
+          { "context": "Meta CLA Check", "integration_id": 1425812 }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `.github/rulesets/lint-required.json` describing a branch ruleset that requires the `lint-done` aggregator (from `.github/workflows/lint.yml`) and the existing `Meta CLA Check` before merges into `main` / `nightly` / `release/*`.
- Adds `.github/rulesets/README.md` documenting how to apply / update / delete rulesets via `gh api`.

## Why

There is currently nothing on the GitHub side that blocks merges when lint is red. The lint workflow runs and reports a red `lint-done` check, but:

- `GET /repos/pytorch/rl/branches/main/protection` returns 404 (no classic branch protection on `main`).
- The only existing ruleset is `Meta CLA Enforcement`, which is `enforcement: "evaluate"` (audit-only) and only requires `Meta CLA Check`.

So PRs with failing lint are mergeable today. This PR commits the source-of-truth JSON for an `enforcement: active` ruleset that fixes that.

## Note: this PR does not by itself enforce anything

GitHub does not auto-apply files under `.github/rulesets/`. The JSON has to be POSTed via the API:

```bash
gh api -X POST repos/pytorch/rl/rulesets \
    --input .github/rulesets/lint-required.json
```

That `gh api` call is what flips the switch. The merge order between this PR and the API call doesn't matter — running the API call before merging is actually a nice live test that the new ruleset is wired up correctly.

## Deliberate non-goals

- Does not require any test job (`tests-cpu …`, `tests-gpu …`, etc.). Lint only, for now — easy follow-up to add more required contexts.
- Does not add a `pull_request` rule (PR-required-before-merge) or `non_fast_forward` rule. Push behavior is unchanged.
- Does not touch the existing `Meta CLA Enforcement` ruleset.

## Test plan

- [ ] Review the JSON for correctness against [GitHub Rulesets API docs](https://docs.github.com/en/rest/repos/rules).
- [ ] Optionally run `gh api -X POST repos/pytorch/rl/rulesets --input .github/rulesets/lint-required.json` and verify with `gh api repos/pytorch/rl/rulesets` that the new ruleset appears with `enforcement: "active"`.
- [ ] Confirm a PR with red `lint-done` is now blocked from merging (this very PR is a candidate, since it should pass lint).