### PR TITLE
[Doc] Trim CLAUDE.md and add NestedKey / Literal rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,142 +1,106 @@
-# Contributing rules for AI agents (Claude, Codex, …)
+# Contributing rules for AI agents
 
-These are the house rules for any LLM-driven contribution to TorchRL. They sit on
-top of [`CONTRIBUTING.md`](CONTRIBUTING.md), which still applies. When the two
-disagree, this file wins for AI-generated changes.
-
-Read this end-to-end before editing anything.
+House rules for LLM contributions to TorchRL. Sits on top of `CONTRIBUTING.md`;
+this file wins on conflicts. Read end-to-end before editing.
 
 ## 1. Imports
 
-- **No local (function/method-level) imports.** Module-top imports only.
-- Two exceptions, and only two:
-  - **Optional dependencies.** Gate them with a module-level
-    `_has_<name> = importlib.util.find_spec("<name>") is not None`, then import
-    the lib lazily inside the function — or, preferred, cache it on
-    `self._<name>` the first time it is needed so subsequent calls don't re-run
-    `import`.
-  - **Genuine circular imports.** Before deferring, try
-    `from typing import TYPE_CHECKING` with a guarded import — that handles the
-    type-annotation case without paying a runtime cost.
-- **No wildcard imports** (`from x import *`). They have bitten us; remove them
-  if you see them.
-- **`from __future__ import annotations`** at the top of every new `.py` file.
+- Module-top imports only. No function/method-level imports. Two exceptions:
+  - **Optional deps**: `_has_<name> = importlib.util.find_spec("<name>") is not None`
+    at module top, then lazy import (preferably cached on `self._<name>`).
+  - **Genuine circular imports**: try `from typing import TYPE_CHECKING` first.
+- No wildcard imports (`from x import *`).
+- `from __future__ import annotations` at the top of every new `.py` file.
 
 ## 2. Cross-version compatibility
 
-- Use `implement_for` (re-exported as `torchrl.implement_for`, originally from
-  `pyvers`) to dispatch on dependency versions — torch, gym, gymnasium, etc.
-  Do not hand-roll `if torch.__version__ >= …` branches.
+Use `torchrl.implement_for` (from `pyvers`) for version dispatch on torch / gym /
+gymnasium / etc. No hand-rolled `if torch.__version__ >= …` branches.
 
 ## 3. Logging, printing, timing
 
-- **Never use `print()`** in library code. Use the logger:
-  ```python
-  from torchrl._utils import logger as torchrl_logger
-  torchrl_logger.info("…")
-  ```
-  (also re-exported as `torchrl.torchrl_logger`).
-- **For timing**, use `torchrl.timeit` — never ad-hoc `time.time()` blocks.
+- No `print()` in library code. Use `from torchrl._utils import logger as torchrl_logger`
+  (also `torchrl.torchrl_logger`).
+- Timing: `torchrl.timeit`, never `time.time()` blocks.
 
 ## 4. TensorDict-first
 
-- New modules, transforms, losses, collectors, and replay-buffer components
-  should accept and return `TensorDict` / `TensorDictBase`. Do not invent
-  parallel dict-like containers.
-- New objectives expose their tensordict keys via the `_AcceptedKeys`
-  dataclass and the `set_keys()` plumbing used by the existing losses. Follow
-  that pattern; don't bypass it.
+- New modules / transforms / losses / collectors / RB components accept and
+  return `TensorDict` / `TensorDictBase`. No parallel dict-like containers.
+- New objectives expose tensordict keys via `_AcceptedKeys` + `set_keys()`,
+  matching existing losses.
 
-## 5. `torch.compile` / cudagraphs friendliness
+## 5. Type hints & annotations
 
-Not mandatory, **strongly encouraged**. In practice:
+- Public signatures carry type hints. Hints must be accurate (not enforced by
+  mypy, but wrong hints are worse than none).
+- **Prefer `NestedKey` over `str`** for tensordict keys, unless the value
+  genuinely cannot be a `tensordict.NestedKey`.
+- **Use `Literal[...]`** for any fixed set of string values (e.g.
+  `mode: Literal["random", "greedy"]`), not bare `str`.
 
-- Prefer `torch.where(...)` and masking over Python-level `if`/`else` on tensor
-  values.
-- Avoid data-dependent shapes and `.item()` calls on hot paths.
-- Keep tensor dtypes/devices stable across calls.
+## 6. `torch.compile` / cudagraphs friendliness
 
-If a component is on a hot path (collectors, replay buffers, losses, key
-transforms), please verify it under `torch.compile` and, where reasonable,
-under cudagraphs.
+Strongly encouraged (not mandatory):
 
-## 6. Tests
+- Prefer `torch.where(...)` / masking over Python `if`/`else` on tensor values.
+- Avoid data-dependent shapes and `.item()` on hot paths.
+- Keep dtypes/devices stable across calls.
+- Hot-path components (collectors, RB, losses, key transforms): verify under
+  `torch.compile` and, where reasonable, cudagraphs.
 
-- **Every new public class / function needs tests.**
-- **Do not create new test files** when an existing one already covers the
-  module/area — extend the existing file. Obvious exceptions: a brand-new
-  objective gets its own file under `test/` (e.g. `test/test_<algo>.py`),
-  matching the pattern of the others.
-- **New algorithms must be tested in the sota-implementations CI**, in
-  addition to unit tests.
+## 7. Tests
 
-## 7. Documentation
+- Every new public class / function needs tests.
+- **Do not create new test files** when an existing one covers the area —
+  extend it. Exception: a brand-new objective gets `test/test_<algo>.py`.
+- If your module accepts a `NestedKey` input, add a test exercising a nested
+  key (not just a flat string).
+- New algorithms: also tested in the sota-implementations CI.
 
-- **Every new public class / function must be referenced** in the appropriate
-  `docs/source/reference/*.rst` page. PRs that add a class but skip the `.rst`
-  entry will be sent back.
-- **Docstrings**: Sphinx-style (`Args:`, `Returns:`, `Examples:`) with a
-  runnable `>>> …` example for every new public class.
-- **Paper references**: if a new feature/algorithm is inspired by a paper,
-  include the arXiv link (and a short citation) in the class docstring.
-- **No emojis** anywhere — code, docstrings, comments, commit messages, PR
-  bodies.
+## 8. Documentation
 
-## 8. Tutorials
+- Every new public class / function referenced in `docs/source/reference/*.rst`.
+- Sphinx-style docstrings (`Args:`, `Returns:`, `Examples:`) with a runnable
+  `>>> …` example for every new public class.
+- Paper references: include the arXiv link + short citation in the class
+  docstring.
+- No emojis anywhere — code, docstrings, comments, commits, PR bodies.
 
-New "headline" features (a new algorithm family, a new collector, a new env
-wrapper class, etc.) should ship a tutorial under `tutorials/`, or extend an
-existing one. Take inspiration from the tutorials already in the repo. Tutorials
-are **Sphinx-first**, not script-first:
+## 9. Tutorials
 
-- Use `# regular prose comments` for explanation, **not** `print("…")`.
-- Structure should mirror existing tutos, including (names can be rephrased):
-  - a **"What you will learn"** section near the top,
-  - a **"Conclusion"** section,
-  - a **"Further reading"** section.
+New "headline" features (algorithm family, collector, env wrapper) ship a
+tutorial under `tutorials/` (or extend an existing one). Sphinx-first:
 
-## 9. Benchmarks
+- `# prose comments` for explanation, **not** `print(...)`.
+- Include "What you will learn", "Conclusion", "Further reading" sections
+  (names can be rephrased), mirroring existing tutos.
 
-If a change is performance-relevant — anything on a hot path
-(collectors, replay buffers, losses, transforms, env stepping) — add or extend
-a benchmark under `benchmarks/`. "Performance-relevant" is the trigger; pure
+## 10. Benchmarks
+
+Performance-relevant changes (anything on a hot path: collectors, RB, losses,
+transforms, env stepping) add/extend a benchmark under `benchmarks/`. Pure
 correctness fixes don't need one.
 
-## 10. SOTA implementations
+## 11. SOTA implementations
 
-A new algorithm needs:
-
-- a runnable script in `sota-implementations/<algo>/` with a Hydra config,
-- an entry in `sota-check/` so it's exercised by the SOTA CI.
-
-## 11. Type hints
-
-- New public signatures should carry type hints. Internal helpers can skip
-  them, but prefer to add them when convenient.
-- Hints are documentary (we don't enforce them with mypy in CI), but they
-  must be **accurate** — wrong hints are worse than no hints.
+New algorithm needs: a runnable script under `sota-implementations/<algo>/`
+with a Hydra config, plus an entry in `sota-check/`.
 
 ## 12. Backwards compatibility & deprecations
 
-We give users **two minor releases** of warning before any breaking change.
-Concretely, if the next release is `0.X`:
+Two minor releases of warning before any breaking change. If next release is
+`0.X`: deprecate in `0.X`, default-value changes in `0.(X+1)`, final removal
+in `0.(X+2)`.
 
-- Deprecate in `0.X`,
-- Default-value changes (if any) can land in `0.(X+1)`,
-- Final removal / behavior switch in `0.(X+2)`.
+- `DeprecationWarning` for API removals; `FutureWarning` for upcoming default
+  changes.
+- **Always name the target version explicitly** in the warning, e.g.
+  `"MyClass.foo is deprecated and will be removed in v0.X+2. Use MyClass.bar."`
 
-Rules:
+## 13. PR labels & commits
 
-- Use `DeprecationWarning` for API removals; `FutureWarning` for upcoming
-  default-value changes that users can already see.
-- **Always state the schedule explicitly** in the warning message, naming the
-  version where the change will happen, e.g.:
-  > `MyClass.foo` is deprecated and will be removed in v0.X+2. Use
-  > `MyClass.bar` instead.
-
-## 13. PR labels
-
-Use a `[Tag]` prefix on the PR title. Canonical set seen in the repo:
+`[Tag]` prefix on PR title. Canonical set:
 
 ```
 [Algorithm] [BE] [BugFix] [CI] [Deprecation] [Doc]
@@ -144,40 +108,26 @@ Use a `[Tag]` prefix on the PR title. Canonical set seen in the repo:
 [Test] [Versioning]
 ```
 
-Pick the most specific one. `[Feature]` for new user-facing capability,
-`[BugFix]` for fixes, `[Doc]` for docs-only, `[CI]` for workflows,
-`[BE]` for backend / internal plumbing, `[Performance]` for perf work,
-`[Quality]` for lint/typing/cleanup, `[Refactor]` for behavior-preserving
-restructure, `[Algorithm]` when adding/modifying a learning algorithm,
-`[Deprecation]` for deprecation warnings, `[Versioning]` for version bumps.
+Pick the most specific. No squash requirement on commits — just make each
+commit read sensibly on its own.
 
-## 14. Commits
+## 14. Config / class parity
 
-No squash requirement. Make commits that read sensibly on their own; that's
-all.
+Some classes (Trainers, losses, RB components, transforms, …) have a Hydra
+`*Config` dataclass companion under `torchrl/trainers/algorithms/configs/`.
+
+- **Parity.** Every kwarg of the wrapped class's `__init__` must appear as a
+  Config field (same default), be popped in the matching `_make_*` factory,
+  and forwarded to the constructor. Adding a kwarg without surfacing it in the
+  Config silently breaks Hydra users.
+- **Cross-references.** Config docstring references its class
+  (`Hydra configuration for :class:`~torchrl.trainers.algorithms.SACTrainer``);
+  class docstring references the Config
+  (`See also :class:`~torchrl.trainers.algorithms.configs.SACTrainerConfig``).
+- **When in doubt**:
+  `git grep -n "class .*Config(" torchrl/trainers/algorithms/configs/` and
+  match the existing pattern.
 
 ## 15. When in doubt
 
-Read a recently-merged PR in the same area and match the conventions there
-before inventing your own.
-
-## 16. Config / class parity
-
-Some classes (Trainers under `torchrl/trainers/algorithms/`, losses, replay-buffer
-components, transforms, …) have a Hydra `*Config` dataclass companion under
-`torchrl/trainers/algorithms/configs/`. The Config exists so users can construct
-the class via Hydra YAML — it is a faithful façade.
-
-- **Parity.** Every kwarg accepted by the wrapped class's `__init__` must
-  appear as a field on the Config (with the same default), be popped from
-  `kwargs` inside the matching `_make_*` factory, and be forwarded into the
-  constructor. Adding a kwarg to the class without surfacing it in the Config
-  silently breaks Hydra users.
-- **Cross-references.** Each Config docstring must reference its wrapped class
-  via Sphinx (e.g. ``Hydra configuration for :class:`~torchrl.trainers.algorithms.SACTrainer```)
-  and the class docstring must reference the Config (e.g.
-  ``See also :class:`~torchrl.trainers.algorithms.configs.SACTrainerConfig```).
-  This makes the round-trip discoverable for both human and AI contributors.
-- **When in doubt**, run
-  `git grep -n "class .*Config(" torchrl/trainers/algorithms/configs/`
-  and inspect the matching `_make_*` factory to see the existing pattern.
+Read a recently-merged PR in the same area and match its conventions.


### PR DESCRIPTION
## Summary

- Condenses `CLAUDE.md` (the AI-agent contributing guide) from ~180 to ~120 lines without dropping coverage — the file is loaded into context on every LLM-driven contribution, so verbosity has a real cost.
- Adds three new rules:
  - **Annotations:** prefer `NestedKey` over `str` for tensordict keys, unless the value genuinely cannot be a `tensordict.NestedKey`.
  - **Annotations:** use `Literal[...]` for any fixed set of string values (e.g. `mode: Literal["random", "greedy"]`) rather than bare `str`.
  - **Tests:** if a module accepts a `NestedKey` input, add a test exercising a nested key, not just a flat string.
- Merges the old type-hints section into a unified "Type hints & annotations" section and collapses the PR-labels and commits sections into one.

No behavioral / code changes — docs only.

## Test plan

- [ ] Render preview of `CLAUDE.md` reads cleanly
- [ ] All existing rules (imports, logging, TensorDict-first, compile-friendliness, tests, docs, tutorials, benchmarks, SOTA, deprecations, config parity) still present