### PR TITLE
[Feature] MuJoCo custom envs with selectable physics backend

### DIFF
--- a/.github/unittest/linux_libs/scripts_mujoco/environment.yml
+++ b/.github/unittest/linux_libs/scripts_mujoco/environment.yml
@@ -1,0 +1,25 @@
+channels:
+  - pytorch
+  - defaults
+dependencies:
+  - pip
+  - pip:
+    - hypothesis
+    - future
+    - cloudpickle
+    - pytest
+    - pytest-cov
+    - pytest-mock
+    - pytest-instafail
+    - pytest-rerunfailures
+    - pytest-json-report
+    - pytest-error-for-skips
+    - pytest-asyncio
+    - expecttest
+    - pybind11[global]
+    - pyyaml
+    - scipy
+    - hydra-core
+    - psutil
+    # MuJoCo backends are installed after PyTorch in install.sh so packages
+    # with a torch dependency cannot pull a stable PyPI torch wheel first.

--- a/.github/unittest/linux_libs/scripts_mujoco/install.sh
+++ b/.github/unittest/linux_libs/scripts_mujoco/install.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+unset PYTORCH_VERSION
+# For unittest, nightly PyTorch is used as the following section,
+# so no need to set PYTORCH_VERSION.
+# In fact, keeping PYTORCH_VERSION forces us to hardcode PyTorch version in config.
+
+set -euxo pipefail
+
+eval "$(./conda/bin/conda shell.bash hook)"
+conda activate ./env
+
+if [ "${CU_VERSION:-}" == cpu ] ; then
+    version="cpu"
+else
+    if [[ ${#CU_VERSION} -eq 4 ]]; then
+        CUDA_VERSION="${CU_VERSION:2:1}.${CU_VERSION:3:1}"
+    elif [[ ${#CU_VERSION} -eq 5 ]]; then
+        CUDA_VERSION="${CU_VERSION:2:2}.${CU_VERSION:4:1}"
+    fi
+    echo "Using CUDA $CUDA_VERSION as determined by CU_VERSION ($CU_VERSION)"
+    version="$(python -c "print('.'.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
+fi
+
+# submodules
+git submodule sync && git submodule update --init --recursive
+
+printf "Installing PyTorch with cu128\n"
+if [[ "$TORCH_VERSION" == "nightly" ]]; then
+  if [ "${CU_VERSION:-}" == cpu ] ; then
+      pip3 install --pre --force-reinstall torch --index-url https://download.pytorch.org/whl/nightly/cpu -U
+  else
+      pip3 install --pre --force-reinstall torch --index-url https://download.pytorch.org/whl/nightly/cu128 -U
+  fi
+elif [[ "$TORCH_VERSION" == "stable" ]]; then
+    if [ "${CU_VERSION:-}" == cpu ] ; then
+      pip3 install --force-reinstall torch --index-url https://download.pytorch.org/whl/cpu -U
+  else
+      pip3 install --force-reinstall torch --index-url https://download.pytorch.org/whl/cu128
+  fi
+else
+  printf "Failed to install pytorch"
+  exit 1
+fi
+
+
+# MuJoCo physics backends -- pinned for compatibility with mujoco-torch 0.2.0:
+# mujoco>=3.8 removed the mjENBL_MULTICCD enum that mujoco-torch 0.2.0 references.
+pip install mujoco==3.7.0 mujoco-mjx==3.7.0 'jax[cuda12]>=0.7.0,<0.11' --progress-bar off
+pip install mujoco-torch==0.2.0 --no-deps --progress-bar off
+
+# install tensordict
+pip install git+https://github.com/pytorch/tensordict.git --progress-bar off
+
+# smoke test
+python -c "import functorch;import tensordict"
+
+printf "* Installing torchrl\n"
+python -m pip install -e . --no-build-isolation
+
+# smoke test
+python -c "import torchrl"
+python -c "import mujoco; import mujoco.mjx; import mujoco_torch; print('mujoco', mujoco.__version__, 'mujoco-torch ok')"

--- a/.github/unittest/linux_libs/scripts_mujoco/post_process.sh
+++ b/.github/unittest/linux_libs/scripts_mujoco/post_process.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+eval "$(./conda/bin/conda shell.bash hook)"
+conda activate ./env

--- a/.github/unittest/linux_libs/scripts_mujoco/run_all.sh
+++ b/.github/unittest/linux_libs/scripts_mujoco/run_all.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+apt update
+apt install -y libglfw3 libglfw3-dev libglew-dev libgl1-mesa-glx libgl1-mesa-dev mesa-common-dev libegl1-mesa-dev freeglut3 freeglut3-dev
+
+this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+bash ${this_dir}/setup_env.sh
+bash ${this_dir}/install.sh
+PYTHON=./env/bin/python bash "$(git rev-parse --show-toplevel)/.github/unittest/helpers/assert_torch_version.sh" "$TORCH_VERSION"
+bash ${this_dir}/run_test.sh
+bash ${this_dir}/post_process.sh

--- a/.github/unittest/linux_libs/scripts_mujoco/run_test.sh
+++ b/.github/unittest/linux_libs/scripts_mujoco/run_test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+eval "$(./conda/bin/conda shell.bash hook)"
+conda activate ./env
+
+
+export PYTORCH_TEST_WITH_SLOW='1'
+export LAZY_LEGACY_OP=False
+
+# JAX (mjx backend) GPU initialization: mirrors scripts_brax/run_test.sh.
+export XLA_PYTHON_CLIENT_PREALLOCATE=false
+export XLA_PYTHON_CLIENT_ALLOCATOR=platform
+export TF_FORCE_GPU_ALLOW_GROWTH=true
+export CUDA_VISIBLE_DEVICES=0
+
+# OpenGL backend for mujoco.Renderer (used by the mjx and mujoco backends'
+# from_pixels path; the mujoco-torch backend uses its own torch raycaster
+# and doesn't need a GL context). EGL works headless on the GPU runner;
+# matches scripts_gym/run_all.sh.
+export MUJOCO_GL=egl
+export PYOPENGL_PLATFORM=egl
+
+python -m torch.utils.collect_env
+git config --global --add safe.directory '*'
+
+root_dir="$(git rev-parse --show-toplevel)"
+env_dir="${root_dir}/env"
+lib_dir="${env_dir}/lib"
+
+export MKL_THREADING_LAYER=GNU
+export MAGNUM_LOG=verbose MAGNUM_GPU_VALIDATION=ON
+
+# Lib smoke checks
+python -c "import mujoco; import mujoco.mjx; import mujoco_torch; print('mujoco', mujoco.__version__)"
+python -c "
+import jax
+import os
+os.environ.setdefault('XLA_PYTHON_CLIENT_PREALLOCATE', 'false')
+os.environ.setdefault('XLA_PYTHON_CLIENT_ALLOCATOR', 'platform')
+try:
+    devices = jax.devices()
+    print(f'JAX devices: {devices}')
+except Exception as e:
+    print(f'JAX init error: {e}; falling back to CPU')
+    os.environ['JAX_PLATFORM_NAME'] = 'cpu'
+    jax.config.update('jax_platform_name', 'cpu')
+"
+python -c 'import torch;t = torch.ones([2,2], device="cuda:0" if torch.cuda.is_available() else "cpu");print(t);print("tensor device:" + str(t.device))'
+
+# JSON report for flaky test tracking
+json_report_dir="${RUNNER_ARTIFACT_DIR:-${root_dir}}"
+json_report_args="--json-report --json-report-file=${json_report_dir}/test-results-mujoco.json --json-report-indent=2"
+
+python .github/unittest/helpers/coverage_run_parallel.py -m pytest test/libs/test_mujoco.py ${json_report_args} --instafail -v --durations 200 --capture no -k TestMujoco --error-for-skips
+coverage combine -q
+coverage xml -i
+
+# Upload test results with metadata for flaky tracking
+python .github/unittest/helpers/upload_test_results.py || echo "Warning: Failed to process test results for flaky tracking"

--- a/.github/unittest/linux_libs/scripts_mujoco/setup_env.sh
+++ b/.github/unittest/linux_libs/scripts_mujoco/setup_env.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# This script is for setting up environment in which unit test is ran.
+# To speed up the CI time, the resulting environment is cached.
+#
+# Do not install PyTorch and torchvision here, otherwise they also get cached.
+
+set -euxo pipefail
+
+apt-get update && apt-get upgrade -y && apt-get install -y git cmake
+# Avoid error: "fatal: unsafe repository"
+git config --global --add safe.directory '*'
+apt-get install -y wget \
+    gcc \
+    g++ \
+    unzip \
+    curl \
+    patchelf \
+    libosmesa6-dev \
+    libgl1-mesa-glx \
+    libglfw3 \
+    libglew-dev \
+    libglvnd0 \
+    libgl1 \
+    libglx0 \
+    libegl1 \
+    libgles2
+
+apt-get upgrade -y libstdc++6
+
+this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+root_dir="$(git rev-parse --show-toplevel)"
+conda_dir="${root_dir}/conda"
+env_dir="${root_dir}/env"
+
+cd "${root_dir}"
+
+case "$(uname -s)" in
+    Darwin*) os=MacOSX;;
+    *) os=Linux
+esac
+
+if [ ! -d "${conda_dir}" ]; then
+    printf "* Installing conda\n"
+    wget -O miniconda.sh "http://repo.continuum.io/miniconda/Miniconda3-latest-${os}-x86_64.sh"
+    bash ./miniconda.sh -b -f -p "${conda_dir}"
+fi
+eval "$(${conda_dir}/bin/conda shell.bash hook)"
+
+printf "python: ${PYTHON_VERSION}\n"
+if [ ! -d "${env_dir}" ]; then
+    printf "* Creating a test environment\n"
+    conda create --prefix "${env_dir}" -y python="$PYTHON_VERSION"
+fi
+conda activate "${env_dir}"
+
+printf "* Installing dependencies (except PyTorch)\n"
+echo "  - python=${PYTHON_VERSION}" >> "${this_dir}/environment.yml"
+cat "${this_dir}/environment.yml"
+
+pip install pip --upgrade
+
+conda env update --file "${this_dir}/environment.yml" --prune

--- a/.github/workflows/test-linux-mujoco.yml
+++ b/.github/workflows/test-linux-mujoco.yml
@@ -1,0 +1,68 @@
+name: MuJoCo Custom Envs Tests on Linux
+
+on:
+  pull_request:
+    paths:
+      - "torchrl/envs/custom/mujoco/**"
+      - "test/libs/test_mujoco.py"
+      - ".github/workflows/test-linux-mujoco.yml"
+      - ".github/unittest/linux_libs/scripts_mujoco/**"
+  push:
+    branches:
+      - nightly
+      - main
+      - release/*
+    paths:
+      - "torchrl/envs/custom/mujoco/**"
+      - "test/libs/test_mujoco.py"
+      - ".github/workflows/test-linux-mujoco.yml"
+      - ".github/unittest/linux_libs/scripts_mujoco/**"
+  workflow_dispatch:
+  workflow_call:
+
+concurrency:
+  # Mirror the convention from test-linux-libs.yml: cancel in-progress runs
+  # for the same ref, but let main runs all complete (so we can pinpoint
+  # regressions to a specific commit if something breaks).
+  group: test-linux-mujoco-${{ github.ref == 'refs/heads/main' && format('ci-master-{0}', github.sha) || format('ci-{0}', github.ref) }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  unittests-mujoco:
+    strategy:
+      matrix:
+        python_version: ["3.11"]
+        cuda_arch_version: ["12.8"]
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      repository: pytorch/rl
+      runner: "linux.g5.4xlarge.nvidia.gpu"
+      gpu-arch-type: cuda
+      gpu-arch-version: "12.8"
+      docker-image: "nvidia/cuda:12.8.0-devel-ubuntu22.04"
+      timeout: 90
+      script: |
+        if [[ "${{ github.ref }}" =~ release/* ]]; then
+          export RELEASE=1
+          export TORCH_VERSION=stable
+        else
+          export RELEASE=0
+          export TORCH_VERSION=nightly
+        fi
+
+        set -euo pipefail
+        export PYTHON_VERSION="3.11"
+        export CU_VERSION="cu128"
+        export TAR_OPTIONS="--no-same-owner"
+        export UPLOAD_CHANNEL="nightly"
+        export TF_CPP_MIN_LOG_LEVEL=0
+        export BATCHED_PIPE_TIMEOUT=60
+        export TD_GET_DEFAULTS_TO_NONE=1
+
+        nvidia-smi
+
+        bash .github/unittest/linux_libs/scripts_mujoco/run_all.sh

--- a/docs/source/reference/envs_api.rst
+++ b/docs/source/reference/envs_api.rst
@@ -300,6 +300,36 @@ TorchRL offers a series of custom built-in environments.
     PendulumEnv
     TicTacToeEnv
 
+MuJoCo custom environments
+--------------------------
+
+A family of MuJoCo-backed envs sharing one base class
+(:class:`~torchrl.envs.MujocoEnv`) with a swappable physics backend
+(``"mujoco-torch"`` -- the default and ``torch.compile``-friendly
+native-torch engine, ``"mjx"`` -- JAX-vectorized, or ``"mujoco"`` --
+official C-bindings). The XML asset can be a local path or an
+``http(s)`` URL, so users can point at remote models without vendoring
+them. Subclasses describe the *task* by overriding
+:meth:`~torchrl.envs.MujocoEnv._compute_reward` and
+:meth:`~torchrl.envs.MujocoEnv._compute_done`.
+
+The locomotion classes mirror the Gymnasium ``-v4`` reward and
+termination semantics. :class:`~torchrl.envs.SatelliteEnv` is an
+attitude-control task with a 4- or 6-CMG cluster and a
+manipulability-based singularity penalty driving the policy away from
+internal singular configurations of the gimbal Jacobian.
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template.rst
+
+    MujocoEnv
+    AntEnv
+    HopperEnv
+    HumanoidEnv
+    SatelliteEnv
+    Walker2dEnv
+
 Domain-specific
 ---------------
 

--- a/test/libs/test_mujoco.py
+++ b/test/libs/test_mujoco.py
@@ -348,7 +348,6 @@ class TestMujoco:
         expected_qerr = quat_log(quat_mul(quat_conj(init_q_norm), target_q_norm))
         torch.testing.assert_close(td["quat_err"], expected_qerr, rtol=1e-4, atol=1e-4)
 
-
     @pytest.mark.parametrize("backend", _VMAP_BACKENDS)
     def test_satellite_quat_err_is_zero_at_target(self, backend):
         """Setting ``init_bus_quat == target_quat`` makes the

--- a/test/libs/test_mujoco.py
+++ b/test/libs/test_mujoco.py
@@ -1,0 +1,785 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Tests for the MuJoCo custom envs (humanoid / ant / walker / hopper /
+satellite) across the three physics backends."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tensordict import TensorDict
+from torchrl.envs import (
+    AntEnv,
+    HopperEnv,
+    HumanoidEnv,
+    MujocoEnv,
+    ParallelEnv,
+    SatelliteEnv,
+    SerialEnv,
+    Walker2dEnv,
+)
+from torchrl.envs.custom.mujoco._backends import (
+    _has_jax,
+    _has_mjx,
+    _has_mujoco,
+    _has_mujoco_torch,
+)
+from torchrl.envs.custom.mujoco._math import (
+    cmg_jacobian,
+    orthogonal_6cmg_geometry,
+    pyramid_4cmg_geometry,
+    quat_conj,
+    quat_log,
+    quat_mul,
+    random_unit_quat,
+)
+from torchrl.envs.utils import check_env_specs
+
+_AVAILABLE_BACKENDS: list[str] = []
+if _has_mujoco_torch:
+    _AVAILABLE_BACKENDS.append("mujoco-torch")
+if _has_mjx and _has_jax:
+    _AVAILABLE_BACKENDS.append("mjx")
+if _has_mujoco:
+    _AVAILABLE_BACKENDS.append("mujoco")
+
+_VMAP_BACKENDS = [b for b in _AVAILABLE_BACKENDS if b in ("mujoco-torch", "mjx")]
+_LOCOMOTION_ENVS = [HumanoidEnv, AntEnv, Walker2dEnv, HopperEnv]
+
+
+@pytest.mark.skipif(
+    not _AVAILABLE_BACKENDS,
+    reason="No MuJoCo backend installed (mujoco-torch / mjx / mujoco).",
+)
+class TestMujoco:
+    # ------------------------------------------------------------------
+    # Spec / rollout coverage across all available backends.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("backend", _AVAILABLE_BACKENDS)
+    @pytest.mark.parametrize("cls", _LOCOMOTION_ENVS)
+    def test_locomotion_env_specs(self, cls, backend):
+        if backend == "mujoco":
+            # Single-env semantics for C-bindings backend.
+            env = cls(num_envs=1, seed=0, backend=backend)
+        else:
+            env = cls(num_envs=2, seed=0, backend=backend)
+        check_env_specs(env)
+        assert env.observation_spec["observation"].shape[0] == env.batch_size[0]
+        assert env.action_spec.shape[0] == env.batch_size[0]
+
+    @pytest.mark.parametrize("backend", _AVAILABLE_BACKENDS)
+    @pytest.mark.parametrize("cls", _LOCOMOTION_ENVS)
+    def test_locomotion_rollout(self, cls, backend):
+        n = 1 if backend == "mujoco" else 2
+        env = cls(num_envs=n, seed=0, backend=backend)
+        td = env.rollout(5)
+        reward = td.get(("next", "reward"))
+        assert reward.shape[-1] == 1
+        assert torch.isfinite(reward).all()
+
+    # ------------------------------------------------------------------
+    # Satellite: spec, dim sanity, finite singularity reward.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("backend", _AVAILABLE_BACKENDS)
+    @pytest.mark.parametrize("num_cmgs", [4, 6])
+    def test_satellite_specs(self, num_cmgs, backend):
+        n = 1 if backend == "mujoco" else 2
+        env = SatelliteEnv(num_cmgs=num_cmgs, num_envs=n, seed=0, backend=backend)
+        check_env_specs(env)
+        # action_spec dim = N_GIMBALS, not nu (rotors are held constant).
+        assert env.action_spec.shape == torch.Size([n, num_cmgs])
+        # The observation is exposed as named sub-keys so a
+        # CatTensors transform can pack the dynamics-relevant ones into
+        # a single policy input while keeping ``manipulability``
+        # available for logging.
+        obs_spec = env.observation_spec
+        assert obs_spec["quat_err"].shape == torch.Size([n, 3])
+        assert obs_spec["bus_omega"].shape == torch.Size([n, 3])
+        assert obs_spec["gimbal_angles"].shape == torch.Size([n, 2 * num_cmgs])
+        assert obs_spec["gimbal_rates"].shape == torch.Size([n, num_cmgs])
+        assert obs_spec["manipulability"].shape == torch.Size([n, 1])
+
+    @pytest.mark.parametrize("backend", _AVAILABLE_BACKENDS)
+    @pytest.mark.parametrize("num_cmgs", [4, 6])
+    def test_satellite_reward_finite(self, num_cmgs, backend):
+        """Singularity term must never explode: ``+eps`` in ``manipulability``
+        guards ``1/sqrt(det(JJ^T))`` against rank-deficient configurations.
+        """
+        n = 1 if backend == "mujoco" else 2
+        env = SatelliteEnv(num_cmgs=num_cmgs, num_envs=n, seed=0, backend=backend)
+        td = env.rollout(50)
+        assert torch.isfinite(td.get(("next", "reward"))).all()
+
+    @pytest.mark.parametrize("backend", _AVAILABLE_BACKENDS)
+    def test_satellite_reward_guard_reports_nonfinite_component(self, backend):
+        n = 1 if backend == "mujoco" else 2
+        env = SatelliteEnv(num_cmgs=4, num_envs=n, seed=0, backend=backend)
+        # The reward guard is off by default on the hot path (it forces
+        # a CUDA->CPU sync). Enable it explicitly for this assertion.
+        env._debug_finite = True
+        env.reset()
+        state = env._state_td()
+        action = torch.zeros(env.action_spec.shape, dtype=env.dtype, device=env.device)
+        action[0, 0] = torch.finfo(env.dtype).max
+        with pytest.raises(RuntimeError, match="reward/control_cost"):
+            env._compute_reward(state, action, state)
+
+    @pytest.mark.parametrize("backend", _AVAILABLE_BACKENDS)
+    def test_satellite_action_changes_gimbal_state(self, backend):
+        n = 1 if backend == "mujoco" else 2
+        env_zero = SatelliteEnv(num_cmgs=4, num_envs=n, seed=0, backend=backend)
+        env_one = SatelliteEnv(num_cmgs=4, num_envs=n, seed=0, backend=backend)
+        td_zero = env_zero.reset()
+        td_one = env_one.reset()
+        zero_action = torch.zeros(
+            env_zero.action_spec.shape, dtype=env_zero.dtype, device=env_zero.device
+        )
+        one_action = torch.ones(
+            env_one.action_spec.shape, dtype=env_one.dtype, device=env_one.device
+        )
+
+        td_zero = env_zero.step(td_zero.set("action", zero_action))["next"]
+        td_one = env_one.step(td_one.set("action", one_action))["next"]
+
+        assert not torch.allclose(td_zero["gimbal_angles"], td_one["gimbal_angles"])
+
+    def test_quat_log_uses_short_arc(self):
+        q = random_unit_quat((1024,), generator=torch.Generator().manual_seed(0))
+        log_q = quat_log(q)
+        log_neg_q = quat_log(-q)
+        assert torch.allclose(log_q, log_neg_q, atol=1e-5, rtol=1e-5)
+        assert log_q.norm(dim=-1).max() <= torch.pi + 1e-5
+
+    def test_cmg_geometry_helpers_match_xml_assets(self):
+        """The ``(gimbal_axes, rotor_axes_ref)`` helpers must match the
+        joint ``axis="..."`` attributes in the satellite XML assets,
+        column by column. A mismatch (labels swapped, signs flipped,
+        order shuffled) produces a Jacobian that's correct at
+        ``theta=0`` -- where the manipulability is sign-invariant --
+        but quietly diverges from physics once the gimbals leave the
+        nominal posture. Pinned here so the reward signal can't drift.
+        """
+        import re
+        from pathlib import Path
+
+        assets_dir = (
+            Path(__import__("torchrl").envs.custom.mujoco.__file__).parent / "assets"
+        )
+
+        def parse_axes(
+            xml_path: Path, n_cmgs: int
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            text = xml_path.read_text()
+            g_cols, r_cols = [], []
+            for i in range(1, n_cmgs + 1):
+                m_g = re.search(rf'<joint\s+name="gimbal{i}"[^>]*axis="([^"]+)"', text)
+                m_r = re.search(rf'<joint\s+name="rotor{i}"[^>]*axis="([^"]+)"', text)
+                assert m_g and m_r, f"missing CMG{i} joints in {xml_path.name}"
+                g_cols.append([float(s) for s in m_g.group(1).split()])
+                r_cols.append([float(s) for s in m_r.group(1).split()])
+            return (
+                torch.tensor(g_cols, dtype=torch.float64).T,
+                torch.tensor(r_cols, dtype=torch.float64).T,
+            )
+
+        g_xml4, r_xml4 = parse_axes(assets_dir / "satellite_large.xml", 4)
+        g_h4, r_h4 = pyramid_4cmg_geometry(dtype=torch.float64)
+        torch.testing.assert_close(g_h4, g_xml4, rtol=1e-3, atol=1e-3)
+        torch.testing.assert_close(r_h4, r_xml4, rtol=1e-3, atol=1e-3)
+
+        g_xml6, r_xml6 = parse_axes(assets_dir / "satellite_small.xml", 6)
+        g_h6, r_h6 = orthogonal_6cmg_geometry(dtype=torch.float64)
+        torch.testing.assert_close(g_h6, g_xml6, rtol=1e-3, atol=1e-3)
+        torch.testing.assert_close(r_h6, r_xml6, rtol=1e-3, atol=1e-3)
+
+    def test_cmg_jacobian_at_pi_over_4_matches_reference(self):
+        """Independent reference computation of the CMG Jacobian at
+        non-trivial gimbal angles. Walks each gimbal to ``pi/4`` (well
+        past where the existing torque-direction test exercises) and
+        rebuilds the Jacobian from first principles to confirm the
+        helper geometry, the Rodrigues rotation, and the cross-product
+        sign all agree.
+        """
+        import math as _math
+
+        g, r0 = pyramid_4cmg_geometry(dtype=torch.float64)
+        theta = torch.full((1, 4), _math.pi / 4, dtype=torch.float64)
+        h = 100.0
+        jac = cmg_jacobian(theta, g, r0, h).squeeze(0)
+
+        ref = torch.empty(3, 4, dtype=torch.float64)
+        c, s = _math.cos(_math.pi / 4), _math.sin(_math.pi / 4)
+        for i in range(4):
+            gi, ri0 = g[:, i], r0[:, i]
+            # Rodrigues: r(theta) = c*r0 + s*(g x r0) + (1-c)*(g.r0)*g.
+            g_x_r = torch.linalg.cross(gi, ri0)
+            g_dot_r = (gi * ri0).sum()
+            ri = c * ri0 + s * g_x_r + (1.0 - c) * g_dot_r * gi
+            ref[:, i] = h * torch.linalg.cross(gi, ri)
+        torch.testing.assert_close(jac, ref, rtol=1e-6, atol=1e-6)
+
+    @pytest.mark.parametrize("backend", _AVAILABLE_BACKENDS)
+    def test_satellite_gimbal_observation_is_periodic(self, backend):
+        n = 1 if backend == "mujoco" else 2
+        env = SatelliteEnv(num_cmgs=4, num_envs=n, seed=0, backend=backend)
+        td = env.rollout(1000)
+        gimbal_obs = td["next", "gimbal_angles"]
+        assert torch.isfinite(gimbal_obs).all()
+        assert (gimbal_obs.abs() <= 1.0 + 1e-6).all()
+
+    # ------------------------------------------------------------------
+    # Satellite physics-correctness: specific (state, action) -> (next
+    # state, reward) transitions verified against analytical
+    # predictions. These tests catch bugs that pure spec / finite-value
+    # tests miss (e.g. a wrong gimbal index in the obs builder, an
+    # inverted torque sign, an off-by-one in the reset override).
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _make_sat(backend: str, n: int = 2, **kwargs) -> SatelliteEnv:
+        if backend == "mujoco":
+            n = 1
+        return SatelliteEnv(num_cmgs=4, num_envs=n, seed=0, backend=backend, **kwargs)
+
+    @staticmethod
+    def _bus_quat(env: SatelliteEnv) -> torch.Tensor:
+        return env._backend.qpos[..., 3:7].to(env.dtype).clone()
+
+    @staticmethod
+    def _bus_omega(env: SatelliteEnv) -> torch.Tensor:
+        return env._backend.qvel[..., 3:6].to(env.dtype).clone()
+
+    @staticmethod
+    def _step_with_action(
+        env: SatelliteEnv, action: torch.Tensor, n_steps: int
+    ) -> None:
+        """Drive the env for ``n_steps`` substeps with a fixed ``action``."""
+        td = env.reset() if not getattr(env, "_was_reset", False) else None
+        if td is None:
+            # Re-read current state into a fresh td (without resetting).
+            td = TensorDict(
+                {"action": action}, batch_size=env.batch_size, device=env.device
+            )
+        else:
+            td.set("action", action)
+        for _ in range(n_steps):
+            td = env.step(td)
+            td = td["next"].select(*env.observation_spec.keys())
+            td.set("action", action)
+
+    @pytest.mark.parametrize("backend", _VMAP_BACKENDS)
+    def test_satellite_zero_action_preserves_orientation(self, backend):
+        """Zero gimbal command + symmetric pyramid CMG cluster (sum of
+        rotor moments == 0 at theta=0) means the bus has zero net
+        torque applied to it. Roll out 200 steps with zero action and
+        confirm the bus quaternion drifts < 1 deg from its initial
+        attitude.
+        """
+        env = self._make_sat(backend, n=2)
+        # Use a non-trivial init_bus_quat so we'd notice if the env
+        # were silently re-initialising every step.
+        init_q = torch.tensor(
+            [[0.7071, 0.0, 0.7071, 0.0], [0.7071, 0.7071, 0.0, 0.0]],
+            dtype=env.dtype,
+            device=env.device,
+        )
+        env.reset(TensorDict({"init_bus_quat": init_q}, batch_size=env.batch_size))
+        bus0 = self._bus_quat(env)
+
+        zero_action = torch.zeros(
+            env.action_spec.shape, dtype=env.dtype, device=env.device
+        )
+        td = TensorDict({"action": zero_action}, batch_size=env.batch_size)
+        for _ in range(200):
+            td = env.step(td)
+            td = td["next"].select(*env.observation_spec.keys())
+            td.set("action", zero_action)
+
+        bus1 = self._bus_quat(env)
+        # Compare via shortest-arc angle: cos(angle/2) = |<q0, q1>|.
+        cos_half = (bus0 * bus1).sum(dim=-1).abs().clamp(-1.0, 1.0)
+        angle_deg = (2.0 * torch.acos(cos_half)).rad2deg()
+        assert angle_deg.max().item() < 1.0, (
+            f"Bus drifted {angle_deg.tolist()} deg under zero action; "
+            "expected < 1 deg from rotor-induced numerical noise alone."
+        )
+        # Bus angular velocity should also stay near zero.
+        omega = self._bus_omega(env).norm(dim=-1)
+        assert omega.max().item() < 0.05, (
+            f"Bus omega = {omega.tolist()} rad/s under zero action; "
+            "the satellite should be inertially still."
+        )
+
+    @pytest.mark.parametrize("backend", _VMAP_BACKENDS)
+    def test_satellite_init_bus_quat_is_honored(self, backend):
+        """``reset({"init_bus_quat": q})`` must place ``qpos[..., 3:7]``
+        at ``q`` (post-normalization) and propagate to the
+        ``quat_err`` observation according to ``q_err = q^-1 * target``.
+        """
+        env = self._make_sat(backend, n=2)
+        init_q = torch.tensor(
+            [[0.7071, 0.0, 0.0, 0.7071], [0.6, 0.0, 0.8, 0.0]],
+            dtype=env.dtype,
+            device=env.device,
+        )
+        target_q = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]],
+            dtype=env.dtype,
+            device=env.device,
+        )
+        td = env.reset(
+            TensorDict(
+                {"init_bus_quat": init_q, "target_quat": target_q},
+                batch_size=env.batch_size,
+            )
+        )
+        # Backend stored the (normalized) init quat verbatim.
+        init_q_norm = init_q / init_q.norm(dim=-1, keepdim=True)
+        torch.testing.assert_close(
+            self._bus_quat(env), init_q_norm, rtol=1e-4, atol=1e-4
+        )
+        # quat_err observation = quat_log(init^-1 * target).
+        target_q_norm = target_q / target_q.norm(dim=-1, keepdim=True)
+        expected_qerr = quat_log(quat_mul(quat_conj(init_q_norm), target_q_norm))
+        torch.testing.assert_close(td["quat_err"], expected_qerr, rtol=1e-4, atol=1e-4)
+
+
+    @pytest.mark.parametrize("backend", _VMAP_BACKENDS)
+    def test_satellite_quat_err_is_zero_at_target(self, backend):
+        """Setting ``init_bus_quat == target_quat`` makes the
+        observation ``quat_err`` start at zero (within reset noise)."""
+        env = self._make_sat(backend, n=2)
+        q = torch.tensor(
+            [[0.5, 0.5, 0.5, 0.5], [1.0, 0.0, 0.0, 0.0]],
+            dtype=env.dtype,
+            device=env.device,
+        )
+        td = env.reset(
+            TensorDict(
+                {"init_bus_quat": q, "target_quat": q},
+                batch_size=env.batch_size,
+            )
+        )
+        # Reset noise is RESET_NOISE_SCALE = 1e-3 on qpos, so quat_err
+        # should be small (a few mrad) but not exactly zero.
+        assert (
+            td["quat_err"].abs().max().item() < 5e-2
+        ), f"quat_err = {td['quat_err']} when init == target; expected near zero."
+
+    @pytest.mark.parametrize("backend", _VMAP_BACKENDS)
+    def test_satellite_180deg_target_gives_pi_attitude_error(self, backend):
+        """A 180-deg rotation about an axis is the maximum SO(3)
+        distance. ``||quat_log(q_err)||`` should equal ``pi`` (within
+        reset noise)."""
+        env = self._make_sat(backend, n=2)
+        identity = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]],
+            dtype=env.dtype,
+            device=env.device,
+        )
+        # 180 deg about +x and 180 deg about +y respectively.
+        target = torch.tensor(
+            [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
+            dtype=env.dtype,
+            device=env.device,
+        )
+        td = env.reset(
+            TensorDict(
+                {"init_bus_quat": identity, "target_quat": target},
+                batch_size=env.batch_size,
+            )
+        )
+        att_err = td["quat_err"].norm(dim=-1)
+        assert torch.allclose(
+            att_err, torch.full_like(att_err, torch.pi), atol=1e-2
+        ), f"||quat_err|| = {att_err.tolist()}, expected ~pi"
+
+    @pytest.mark.parametrize("backend", _VMAP_BACKENDS)
+    def test_satellite_gimbal_action_torques_bus(self, backend):
+        """Driving CMG #1 alone with action=+1 produces a bus torque
+        whose direction is **opposite** to the column of
+        :func:`cmg_jacobian` for that CMG.
+
+        Why opposite: ``cmg_jacobian`` returns ``h * (g_i x r_i)`` per
+        unit gimbal rate. By Newton's third law that's the torque on
+        the *rotor* (whose angular momentum is rotating with the
+        gimbal), and the *bus* sees the reaction torque
+        ``-h * (g_i x r_i)``. The manipulability metric used in the
+        reward (``sqrt(det(J J^T))``) is sign-invariant so the env
+        reward is unaffected, but the body-frame slewing direction
+        flips. This test pins the sign convention so a future
+        refactor can't silently invert it.
+        """
+        env = self._make_sat(backend, n=2, action_scale=3.0)
+        identity = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0]] * env.num_envs,
+            dtype=env.dtype,
+            device=env.device,
+        )
+        env.reset(TensorDict({"init_bus_quat": identity}, batch_size=env.batch_size))
+
+        action = torch.zeros(env.action_spec.shape, dtype=env.dtype, device=env.device)
+        action[..., 0] = 1.0  # only CMG 1
+        td = TensorDict({"action": action}, batch_size=env.batch_size)
+        for _ in range(20):
+            td = env.step(td)
+            td = td["next"].select(*env.observation_spec.keys())
+            td.set("action", action)
+
+        omega = self._bus_omega(env)
+        # Predicted torque on the BUS = -h * (g_1 x r_1(0)).
+        g, r0 = pyramid_4cmg_geometry(device=env.device, dtype=env.dtype)
+        jac = cmg_jacobian(
+            torch.zeros(1, 4, device=env.device, dtype=env.dtype),
+            g,
+            r0,
+            float(env.ROTOR_SPEED),
+        ).squeeze(0)
+        bus_torque_dir = -jac[:, 0]  # reaction on the bus
+        # Bus omega should align with the (sign of) bus_torque_dir on
+        # the axes where the predicted torque is large; the y-axis
+        # contribution is structurally zero for CMG 1 in the pyramid.
+        omega_signs = torch.sign(omega)
+        torque_signs = torch.sign(bus_torque_dir).unsqueeze(0).expand_as(omega)
+        big_axes = bus_torque_dir.abs() > 0.1
+        match = omega_signs[..., big_axes] == torque_signs[..., big_axes]
+        assert match.all(), (
+            f"Bus omega = {omega.tolist()} does not match expected reaction "
+            f"sign pattern -cmg_jacobian[:, 0] = {bus_torque_dir.tolist()}."
+        )
+        # Magnitude must actually grow (not just numerical noise).
+        assert omega.norm(dim=-1).min().item() > 0.05, (
+            f"|bus_omega| = {omega.norm(dim=-1).tolist()} rad/s after 20 "
+            "steps of saturated CMG-1 command; expected the bus to slew."
+        )
+
+    @pytest.mark.parametrize("backend", _VMAP_BACKENDS)
+    def test_satellite_reward_at_zero_error_is_baseline(self, backend):
+        """With ``init_bus_quat == target_quat`` and zero action, the
+        reward should equal the singularity baseline:
+
+            r ~= -singularity_weight / (manip / rotor_h^3)
+
+        which for the nominal pyramid with ``rotor_h = 100`` is
+        approximately ``-0.5 / 1.0 = -0.5`` per step (control cost is
+        zero, attitude error is at the reset-noise floor).
+        """
+        env = self._make_sat(backend, n=2, action_scale=3.0, singularity_weight=0.5)
+        q = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0], [0.5, 0.5, 0.5, 0.5]],
+            dtype=env.dtype,
+            device=env.device,
+        )
+        td = env.reset(
+            TensorDict(
+                {"init_bus_quat": q, "target_quat": q}, batch_size=env.batch_size
+            )
+        )
+        zero_action = torch.zeros(
+            env.action_spec.shape, dtype=env.dtype, device=env.device
+        )
+        td.set("action", zero_action)
+        td = env.step(td)
+        reward = td["next", "reward"].squeeze(-1)
+        # Allow generous tolerance: reset noise + 1 step of dynamics.
+        assert (reward > -0.7).all() and (reward < -0.3).all(), (
+            f"Reward at zero attitude error = {reward.tolist()}; "
+            "expected ~-0.5 (singularity baseline only)."
+        )
+
+    @pytest.mark.parametrize("backend", _VMAP_BACKENDS)
+    def test_satellite_reward_at_180deg_is_pi_plus_baseline(self, backend):
+        """At a 180-deg attitude error with zero action, the reward
+        should equal ``-pi - singularity_weight/manip_norm`` per step,
+        i.e. about ``-3.64`` for the default weights.
+        """
+        env = self._make_sat(backend, n=2, action_scale=3.0, singularity_weight=0.5)
+        identity = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0]] * env.num_envs,
+            dtype=env.dtype,
+            device=env.device,
+        )
+        target = torch.tensor(
+            [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
+            dtype=env.dtype,
+            device=env.device,
+        )
+        td = env.reset(
+            TensorDict(
+                {"init_bus_quat": identity, "target_quat": target},
+                batch_size=env.batch_size,
+            )
+        )
+        zero_action = torch.zeros(
+            env.action_spec.shape, dtype=env.dtype, device=env.device
+        )
+        td.set("action", zero_action)
+        td = env.step(td)
+        reward = td["next", "reward"].squeeze(-1)
+        expected = -torch.pi - 0.5
+        # Bus has barely moved in 1 step, so attitude error stays near pi.
+        assert (reward > expected - 0.2).all() and (
+            reward < expected + 0.2
+        ).all(), (
+            f"Reward at 180-deg error = {reward.tolist()}; expected ~{expected:.2f}."
+        )
+
+    @pytest.mark.parametrize("backend", _VMAP_BACKENDS)
+    def test_satellite_observation_matches_state(self, backend):
+        """Observation channels are read directly off ``qpos`` /
+        ``qvel`` -- not synthesised. After one non-trivial step:
+
+        * ``bus_omega == qvel[..., 3:6]``
+        * ``gimbal_rates == qvel[..., gimbal_rate_idx]``
+        * ``gimbal_angles == [sin(qpos_gimbals), cos(qpos_gimbals)]``
+        """
+        env = self._make_sat(backend, n=2, action_scale=3.0)
+        env.reset()
+        action = torch.full(
+            env.action_spec.shape, 0.5, dtype=env.dtype, device=env.device
+        )
+        td = TensorDict({"action": action}, batch_size=env.batch_size)
+        for _ in range(10):
+            td = env.step(td)
+            td = td["next"].select(*env.observation_spec.keys())
+            td.set("action", action)
+
+        qpos = env._backend.qpos.to(env.dtype)
+        qvel = env._backend.qvel.to(env.dtype)
+        gimbal_idx = [7 + 2 * i for i in range(env.N_GIMBALS)]
+        gimbal_rate_idx = [6 + 2 * i for i in range(env.N_GIMBALS)]
+
+        torch.testing.assert_close(
+            td["bus_omega"], qvel[..., 3:6], rtol=1e-5, atol=1e-5
+        )
+        torch.testing.assert_close(
+            td["gimbal_rates"],
+            qvel[..., gimbal_rate_idx],
+            rtol=1e-5,
+            atol=1e-5,
+        )
+        # gimbal_angles is concat([sin, cos]) over the gimbal qpos.
+        gimbals = qpos[..., gimbal_idx]
+        expected = torch.cat([gimbals.sin(), gimbals.cos()], dim=-1)
+        torch.testing.assert_close(td["gimbal_angles"], expected, rtol=1e-5, atol=1e-5)
+
+    @pytest.mark.parametrize("backend", _VMAP_BACKENDS)
+    def test_satellite_reset_is_reproducible(self, backend):
+        """Same ``(init_bus_quat, target_quat)`` and same action sequence
+        must produce byte-identical bus quaternion trajectories. This is
+        the determinism guarantee that the eval pipeline relies on
+        (the :class:`TestSetPrimer` replays the same starts every
+        iteration -- if the env is non-deterministic, eval comparisons
+        between iterations are meaningless).
+        """
+        n = 2
+        init_q = torch.tensor(
+            [[0.5, 0.5, 0.5, 0.5], [0.7071, 0.7071, 0.0, 0.0]],
+        )
+        target_q = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]],
+        )
+
+        def _trajectory(seed: int) -> torch.Tensor:
+            env = SatelliteEnv(
+                num_cmgs=4,
+                num_envs=n,
+                seed=seed,
+                backend=backend,
+                action_scale=3.0,
+            )
+            env.reset(
+                TensorDict(
+                    {
+                        "init_bus_quat": init_q.to(env.dtype).to(env.device),
+                        "target_quat": target_q.to(env.dtype).to(env.device),
+                    },
+                    batch_size=env.batch_size,
+                )
+            )
+            action = torch.full(
+                env.action_spec.shape, 0.3, dtype=env.dtype, device=env.device
+            )
+            traj = []
+            td = TensorDict({"action": action}, batch_size=env.batch_size)
+            for _ in range(20):
+                td = env.step(td)
+                traj.append(self._bus_quat(env))
+                td = td["next"].select(*env.observation_spec.keys())
+                td.set("action", action)
+            return torch.stack(traj, dim=0)
+
+        # Same (init, target, seed, action) -> identical trajectory.
+        torch.testing.assert_close(_trajectory(0), _trajectory(0))
+
+    # ------------------------------------------------------------------
+    # Backend dispatch: vmap backends reject num_workers / parallel;
+    # the C-bindings backend composes via ParallelEnv / SerialEnv.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("backend", _VMAP_BACKENDS)
+    def test_vmap_backend_rejects_num_workers(self, backend):
+        with pytest.raises(ValueError, match="num_envs"):
+            HopperEnv(backend=backend, num_workers=2, seed=0)
+
+    @pytest.mark.parametrize("backend", _VMAP_BACKENDS)
+    def test_vmap_backend_rejects_parallel(self, backend):
+        with pytest.raises(ValueError, match="parallel"):
+            HopperEnv(backend=backend, parallel=True, seed=0)
+
+    @pytest.mark.skipif(not _has_mujoco, reason="mujoco not installed")
+    def test_mujoco_backend_num_envs_aliases_num_workers(self):
+        """For the C-bindings backend, ``num_envs`` and ``num_workers``
+        are aliases; both produce a :class:`ParallelEnv` of N copies."""
+        env_a = HopperEnv(backend="mujoco", num_envs=2, seed=0)
+        env_b = HopperEnv(backend="mujoco", num_workers=2, seed=0)
+        # Lazy ParallelEnvs -- don't start workers, just shape-check.
+        assert isinstance(env_a, ParallelEnv)
+        assert isinstance(env_b, ParallelEnv)
+        assert env_a.batch_size == env_b.batch_size
+
+    @pytest.mark.skipif(not _has_mujoco, reason="mujoco not installed")
+    def test_mujoco_backend_rejects_both_envs_and_workers(self):
+        with pytest.raises(ValueError, match="aliases"):
+            HopperEnv(backend="mujoco", num_envs=2, num_workers=2, seed=0)
+
+    @pytest.mark.skipif(not _has_mujoco, reason="mujoco not installed")
+    def test_mujoco_backend_serial_dispatch(self):
+        env = HopperEnv(backend="mujoco", num_envs=2, parallel=False, seed=0)
+        assert isinstance(env, SerialEnv)
+        td = env.rollout(3)
+        assert torch.isfinite(td.get(("next", "reward"))).all()
+        env.close()
+
+    @pytest.mark.skipif(not _has_mujoco, reason="mujoco not installed")
+    def test_mujoco_backend_parallel_rollout(self):
+        env = HopperEnv(backend="mujoco", num_envs=2, seed=0)
+        assert isinstance(env, ParallelEnv)
+        td = env.rollout(3)
+        assert torch.isfinite(td.get(("next", "reward"))).all()
+        env.close()
+
+    @pytest.mark.skipif(not _has_mujoco, reason="mujoco not installed")
+    def test_mujoco_backend_single_env_passthrough(self):
+        """``backend='mujoco'`` with N=1 returns a bare ``HopperEnv``,
+        not a ``ParallelEnv`` wrapper."""
+        env = HopperEnv(backend="mujoco", num_envs=1, seed=0)
+        assert isinstance(env, HopperEnv)
+        assert env.batch_size == torch.Size([1])
+
+    # ------------------------------------------------------------------
+    # Compile / unknown-backend / custom XML.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.skipif(not _has_mujoco_torch, reason="mujoco-torch not installed")
+    def test_torch_backend_compile_smoke(self):
+        """``compile_step=True`` must not raise on the default backend."""
+        env = HopperEnv(num_envs=2, seed=0, compile_step=True)
+        td = env.rollout(3)
+        assert torch.isfinite(td.get(("next", "reward"))).all()
+
+    def test_unknown_backend_raises(self):
+        with pytest.raises(ValueError, match="unknown backend"):
+            HopperEnv(num_envs=1, seed=0, backend="not-a-backend")
+
+    # ------------------------------------------------------------------
+    # Rendering / from_pixels.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("backend", _AVAILABLE_BACKENDS)
+    def test_from_pixels_spec_and_rollout(self, backend):
+        """``from_pixels=True`` adds a ``pixels`` key with a ``uint8`` spec
+        of shape ``(num_envs, H, W, 3)`` and values in ``[0, 255]``.
+
+        Uses :class:`SatelliteEnv` because locomotion envs terminate
+        early under random actions, masking rollout shape assertions.
+        """
+        n = 1 if backend == "mujoco" else 2
+        env = SatelliteEnv(
+            num_cmgs=4,
+            num_envs=n,
+            seed=0,
+            backend=backend,
+            from_pixels=True,
+            render_width=32,
+            render_height=32,
+        )
+        check_env_specs(env)
+        assert env.observation_spec["pixels"].shape == torch.Size([n, 32, 32, 3])
+        assert env.observation_spec["pixels"].dtype == torch.uint8
+
+        td = env.rollout(2)
+        pixels = td.get(("next", "pixels"))
+        assert pixels.shape == torch.Size([n, 2, 32, 32, 3])
+        assert pixels.dtype == torch.uint8
+        assert (pixels >= 0).all() and (pixels <= 255).all()
+        # Real RGB content -- not all-zero, not saturated.
+        assert pixels.float().std().item() > 0
+
+    @pytest.mark.parametrize("backend", _AVAILABLE_BACKENDS)
+    def test_pixel_only_drops_observation_key(self, backend):
+        n = 1 if backend == "mujoco" else 2
+        env = SatelliteEnv(
+            num_cmgs=4,
+            num_envs=n,
+            seed=0,
+            backend=backend,
+            from_pixels=True,
+            pixel_only=True,
+            render_width=32,
+            render_height=32,
+        )
+        check_env_specs(env)
+        keys = set(env.observation_spec.keys())
+        assert keys == {"pixels"}, f"pixel_only must drop 'observation', got {keys}"
+
+    def test_pixel_only_without_from_pixels_raises(self):
+        with pytest.raises(ValueError, match="pixel_only"):
+            HopperEnv(num_envs=1, seed=0, pixel_only=True)
+
+    @pytest.mark.parametrize("backend", _AVAILABLE_BACKENDS)
+    def test_render_method(self, backend):
+        """``env.render()`` returns the same shape as the pixel obs."""
+        n = 1 if backend == "mujoco" else 2
+        env = SatelliteEnv(num_cmgs=4, num_envs=n, seed=0, backend=backend)
+        env.reset()
+        rgb = env.render(width=24, height=24)
+        assert rgb.shape == torch.Size([n, 24, 24, 3])
+        assert rgb.dtype == torch.uint8
+
+    def test_xml_path_kwarg_overrides_class_attr(self, tmp_path):
+        """Custom ``xml_path=`` overrides the class-level :attr:`XML_PATH`."""
+        backend = _AVAILABLE_BACKENDS[0]
+        # A trivial single-hinge model -- pure-XML, no external mesh deps.
+        xml = (
+            "<mujoco><worldbody>"
+            "<body name='b' pos='0 0 1'>"
+            "<joint name='j' type='hinge'/>"
+            "<geom size='0.1' mass='1'/>"
+            "</body></worldbody>"
+            "<actuator><motor name='a' joint='j' gear='1' ctrlrange='-1 1'/></actuator>"
+            "</mujoco>"
+        )
+        path = tmp_path / "tiny.xml"
+        path.write_text(xml)
+
+        class TinyEnv(MujocoEnv):
+            FRAME_SKIP = 2
+
+            def _compute_reward(self, state, action, next_state):
+                return torch.zeros(self.num_envs, 1, device=self.device)
+
+            def _compute_done(self, state, next_state):
+                return torch.zeros(
+                    self.num_envs, 1, dtype=torch.bool, device=self.device
+                )
+
+        env = TinyEnv(xml_path=str(path), backend=backend, num_envs=1, seed=0)
+        check_env_specs(env)
+        td = env.rollout(3)
+        assert td.shape == torch.Size([1, 3])

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -1631,7 +1631,7 @@ class TestTrainerConfigs:
             optimizer=optimizer_config,
             logger=None,  # Optional field
             save_trainer_file="/tmp/test.pt",
-            replay_buffer=replay_buffer_config
+            replay_buffer=replay_buffer_config,
             # All optional fields are omitted to test defaults
         )
 

--- a/torchrl/envs/__init__.py
+++ b/torchrl/envs/__init__.py
@@ -7,11 +7,17 @@ from .async_envs import AsyncEnvPool, ProcessorAsyncEnvPool, ThreadingAsyncEnvPo
 from .batched_envs import ParallelEnv, SerialEnv
 from .common import EnvBase, EnvMetaData, make_tensordict
 from .custom import (
+    AntEnv,
     ChessEnv,
     FinancialRegimeEnv,
+    HopperEnv,
+    HumanoidEnv,
     LLMHashingEnv,
+    MujocoEnv,
     PendulumEnv,
+    SatelliteEnv,
     TicTacToeEnv,
+    Walker2dEnv,
 )
 from .env_creator import env_creator, EnvCreator, get_env_metadata
 from .gym_like import default_info_dict_reader, GymLikeEnv
@@ -147,6 +153,7 @@ __all__ = [
     "ActionDiscretizer",
     "ActionMask",
     "ActionScaling",
+    "AntEnv",
     "VecNormV2",
     "IsaacLabWrapper",
     "AutoResetEnv",
@@ -196,6 +203,8 @@ __all__ = [
     "GenesisWrapper",
     "HabitatEnv",
     "Hash",
+    "HopperEnv",
+    "HumanoidEnv",
     "InitTracker",
     "ImaginedEnv",
     "IsaacGymEnv",
@@ -211,6 +220,7 @@ __all__ = [
     "MeltingpotEnv",
     "MeltingpotWrapper",
     "ModelBasedEnvBase",
+    "MujocoEnv",
     "MultiAction",
     "MultiStepTransform",
     "MultiThreadedEnv",
@@ -242,6 +252,7 @@ __all__ = [
     "RewardSum",
     "RoboHiveEnv",
     "SMACv2Env",
+    "SatelliteEnv",
     "SMACv2Wrapper",
     "SelectTransform",
     "SerialEnv",
@@ -270,6 +281,7 @@ __all__ = [
     "VecNorm",
     "VmasEnv",
     "VmasWrapper",
+    "Walker2dEnv",
     "check_env_specs",
     "check_marl_grouping",
     "default_info_dict_reader",

--- a/torchrl/envs/custom/__init__.py
+++ b/torchrl/envs/custom/__init__.py
@@ -5,14 +5,21 @@
 
 from .chess import ChessEnv
 from .llm import LLMHashingEnv
+from .mujoco import AntEnv, HopperEnv, HumanoidEnv, MujocoEnv, SatelliteEnv, Walker2dEnv
 from .pendulum import PendulumEnv
 from .tictactoeenv import TicTacToeEnv
 from .trading import FinancialRegimeEnv
 
 __all__ = [
+    "AntEnv",
     "ChessEnv",
     "FinancialRegimeEnv",
+    "HopperEnv",
+    "HumanoidEnv",
     "LLMHashingEnv",
+    "MujocoEnv",
     "PendulumEnv",
+    "SatelliteEnv",
     "TicTacToeEnv",
+    "Walker2dEnv",
 ]

--- a/torchrl/envs/custom/mujoco/__init__.py
+++ b/torchrl/envs/custom/mujoco/__init__.py
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""MuJoCo-backed custom envs with selectable physics backend.
+
+The base class :class:`MujocoEnv` accepts an XML asset (path or URL)
+and dispatches the simulation to one of three engines:
+
+* ``mujoco-torch`` (default) -- native torch, batched, ``torch.compile``-friendly.
+* ``mjx`` -- JAX-vectorized via :func:`jax.vmap` + :func:`jax.jit`,
+  bridged to torch through DLPack.
+* ``mujoco`` -- official C-bindings, batched by Python loop.
+
+Subclasses describe the *task*: reward, termination, optional
+observation map. The locomotion subclasses (:class:`HumanoidEnv`,
+:class:`AntEnv`, :class:`Walker2dEnv`, :class:`HopperEnv`) mirror the
+Gymnasium ``-v4`` reward / termination spec. :class:`SatelliteEnv`
+implements an attitude-control task with 4- or 6-CMG clusters and a
+manipulability-based singularity penalty.
+"""
+
+from torchrl.envs.custom.mujoco.ant import AntEnv
+from torchrl.envs.custom.mujoco.base import MujocoEnv
+from torchrl.envs.custom.mujoco.hopper import HopperEnv
+from torchrl.envs.custom.mujoco.humanoid import HumanoidEnv
+from torchrl.envs.custom.mujoco.satellite import SatelliteEnv
+from torchrl.envs.custom.mujoco.walker import Walker2dEnv
+
+__all__ = [
+    "AntEnv",
+    "HopperEnv",
+    "HumanoidEnv",
+    "MujocoEnv",
+    "SatelliteEnv",
+    "Walker2dEnv",
+]

--- a/torchrl/envs/custom/mujoco/_backends.py
+++ b/torchrl/envs/custom/mujoco/_backends.py
@@ -1,0 +1,698 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Physics-engine adapters for the MuJoCo custom envs.
+
+Three backends share a common contract (:class:`_PhysicsBackend`):
+
+* ``mujoco-torch`` -- native torch, batched via :func:`torch.vmap`.
+* ``mjx`` -- JAX-vectorized via :func:`jax.vmap` + :func:`jax.jit`,
+  bridged to torch through DLPack.
+* ``mujoco`` -- official C-bindings, batched by Python loop.
+
+Each backend owns the model and the per-env simulation state. The env
+calls :meth:`reset`, :meth:`step`, and reads ``qpos``/``qvel``/``time``
+to compute observations and rewards.
+"""
+
+from __future__ import annotations
+
+import abc
+import importlib.util
+import urllib.request
+from pathlib import Path
+from typing import Literal
+
+import torch
+
+_has_mujoco_torch = importlib.util.find_spec("mujoco_torch") is not None
+_has_mujoco = importlib.util.find_spec("mujoco") is not None
+_has_jax = importlib.util.find_spec("jax") is not None
+_has_mjx = _has_mujoco and importlib.util.find_spec("mujoco.mjx") is not None
+
+
+BackendName = Literal["mujoco-torch", "mjx", "mujoco"]
+
+
+def resolve_xml_string(path_or_url: str | Path) -> str:
+    """Read XML from a local path or http(s) URL.
+
+    URLs let users point at remote XML assets without vendoring them.
+    """
+    p = str(path_or_url)
+    if p.startswith(("http://", "https://")):
+        with urllib.request.urlopen(p) as resp:
+            return resp.read().decode("utf-8")
+    return Path(p).read_text()
+
+
+class _PhysicsBackend(abc.ABC):
+    """Common contract across the three engines.
+
+    After construction, attributes ``nq, nv, nu, timestep, qpos0,
+    actuator_lo, actuator_hi`` are populated from the model. ``qpos0`` is
+    the initial ``qpos`` produced by ``mj_forward`` on a fresh ``MjData``.
+    """
+
+    nq: int
+    nv: int
+    nu: int
+    timestep: float
+    qpos0: torch.Tensor
+    qvel0: torch.Tensor
+    actuator_lo: torch.Tensor
+    actuator_hi: torch.Tensor
+    actuator_ctrllimited: torch.Tensor
+
+    def __init__(
+        self, xml_string: str, *, num_envs: int, device: torch.device | None
+    ) -> None:
+        self.num_envs = num_envs
+        self.device = (
+            torch.device(device) if device is not None else torch.device("cpu")
+        )
+        self._init_model(xml_string)
+
+    @abc.abstractmethod
+    def _init_model(self, xml_string: str) -> None:
+        """Parse XML and prepare the batched data state.
+
+        Populates ``nq, nv, nu, timestep, qpos0, qvel0, actuator_lo,
+        actuator_hi`` from the parsed model.
+        """
+
+    @abc.abstractmethod
+    def reset(self, qpos: torch.Tensor, qvel: torch.Tensor) -> None:
+        """Set the full batched state to the given ``qpos, qvel``.
+
+        Shapes: ``(num_envs, nq)`` and ``(num_envs, nv)``.
+        """
+
+    @abc.abstractmethod
+    def reset_mask(
+        self, mask: torch.Tensor, qpos: torch.Tensor, qvel: torch.Tensor
+    ) -> None:
+        """Reset the subset of envs where ``mask`` is True.
+
+        ``mask`` is shape ``(num_envs,)`` bool. ``qpos`` / ``qvel`` are
+        full-batch ``(num_envs, nq)`` / ``(num_envs, nv)`` -- the backend
+        is responsible for masking internally. Full-batch tensors keep
+        shapes data-independent so the reset path stays sync-free under
+        ``torch.compile`` / cudagraphs.
+        """
+
+    @abc.abstractmethod
+    def step(self, ctrl: torch.Tensor, frame_skip: int) -> None:
+        """Advance state by ``frame_skip`` physics substeps."""
+
+    @property
+    @abc.abstractmethod
+    def qpos(self) -> torch.Tensor:
+        """Current ``qpos``, shape ``(num_envs, nq)`` on ``self.device``."""
+
+    @property
+    @abc.abstractmethod
+    def qvel(self) -> torch.Tensor:
+        """Current ``qvel``, shape ``(num_envs, nv)`` on ``self.device``."""
+
+    @property
+    @abc.abstractmethod
+    def time(self) -> torch.Tensor:
+        """Current simulation time per env, shape ``(num_envs,)``."""
+
+    def render(
+        self,
+        *,
+        camera_id: int = 0,
+        width: int = 64,
+        height: int = 64,
+        background: tuple[float, float, float] | None = None,
+    ) -> torch.Tensor:
+        """Render every env to RGB pixels.
+
+        Returns a ``(num_envs, height, width, 3)`` ``uint8`` tensor on
+        ``self.device``. Default raises ``NotImplementedError`` --
+        backends override.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement rendering."
+        )
+
+
+# ----------------------------------------------------------------------
+# mujoco-torch backend
+# ----------------------------------------------------------------------
+
+
+class _TorchBackend(_PhysicsBackend):
+    """Native-torch backend powered by ``mujoco-torch``.
+
+    Uses :func:`torch.vmap` to batch and (optionally) :func:`torch.compile`
+    for the per-step physics. State lives in a ``mujoco_torch.Data`` object
+    with mutable ``qpos`` / ``qvel`` / ``ctrl`` torch tensors.
+    """
+
+    def __init__(
+        self,
+        xml_string: str,
+        *,
+        num_envs: int,
+        device: torch.device | None,
+        compile_step: bool = False,
+        compile_kwargs: dict | None = None,
+    ) -> None:
+        if not _has_mujoco_torch:
+            raise ImportError(
+                "backend='mujoco-torch' requires the `mujoco-torch` package. "
+                "Install with `pip install mujoco-torch`."
+            )
+        self._compile_step = compile_step
+        self._compile_kwargs = compile_kwargs or {}
+        super().__init__(xml_string, num_envs=num_envs, device=device)
+
+    def _init_model(self, xml_string: str) -> None:
+        import mujoco
+        import mujoco_torch
+
+        m_mj = mujoco.MjModel.from_xml_string(xml_string)
+        d_mj = mujoco.MjData(m_mj)
+        mujoco.mj_forward(m_mj, d_mj)
+
+        mx = mujoco_torch.device_put(m_mj)
+        dx0 = mujoco_torch.device_put(d_mj)
+        if self.device != torch.device("cpu"):
+            mx = mx.to(self.device)
+            dx0 = dx0.to(self.device)
+        # One step so all derived dtypes match what vmap(step) produces.
+        dx0 = mujoco_torch.step(mx, dx0)
+
+        self._mx = mx
+        self._dx0 = dx0
+        self._sim_dtype = dx0.qpos.dtype
+        self._ctrl_dtype = dx0.ctrl.dtype
+
+        self.nq = int(m_mj.nq)
+        self.nv = int(m_mj.nv)
+        self.nu = int(m_mj.nu)
+        self.timestep = float(m_mj.opt.timestep)
+        self.qpos0 = dx0.qpos.detach().clone()
+        self.qvel0 = dx0.qvel.detach().clone()
+        ar = torch.as_tensor(m_mj.actuator_ctrlrange, device=self.device)
+        self.actuator_lo = ar[:, 0].to(self._ctrl_dtype)
+        self.actuator_hi = ar[:, 1].to(self._ctrl_dtype)
+        self.actuator_ctrllimited = torch.as_tensor(
+            m_mj.actuator_ctrllimited, device=self.device, dtype=torch.bool
+        )
+
+        # Build the batched state and the (compiled) physics step.
+        self._dx = self._dx0.expand(self.num_envs).clone()
+        self._build_step_fn()
+
+    def _build_step_fn(self) -> None:
+        import mujoco_torch
+
+        mx = self._mx
+        single = self.num_envs == 1
+
+        if single:
+
+            def _one_step(d):
+                return mujoco_torch.step(mx, d)
+
+            base = _one_step
+        else:
+            _vmap_step = torch.vmap(lambda d: mujoco_torch.step(mx, d))
+
+            def _vmap_one(d):
+                return _vmap_step(d)
+
+            base = _vmap_one
+
+        # When ``compile_step`` is set, compile only the per-step fn and
+        # keep the frame_skip loop in Python. Compiling the unrolled loop
+        # blows up the graph (50x more nodes), which sends inductor's
+        # fusion analysis into multi-hour territory on CUDA backends.
+        if self._compile_step:
+            base_compiled = torch.compile(base, **self._compile_kwargs)
+
+            def _multi_step(d, frame_skip: int):
+                for _ in range(frame_skip):
+                    d = base_compiled(d)
+                return d
+
+        else:
+
+            def _multi_step(d, frame_skip: int):
+                for _ in range(frame_skip):
+                    d = base(d)
+                return d
+
+        self._physics_step = _multi_step
+        self._single_env = single
+
+    def reset(self, qpos: torch.Tensor, qvel: torch.Tensor) -> None:
+        # Refresh from the warm reference so all derived data is sane,
+        # then overwrite qpos / qvel.
+        self._dx = self._dx0.expand(self.num_envs).clone()
+        self._dx.qpos.copy_(qpos.to(self._sim_dtype))
+        self._dx.qvel.copy_(qvel.to(self._sim_dtype))
+
+    def reset_mask(
+        self, mask: torch.Tensor, qpos: torch.Tensor, qvel: torch.Tensor
+    ) -> None:
+        # qpos / qvel are full-batch (num_envs, *). We mux in the
+        # masked rows via ``torch.where`` so the path stays sync-free
+        # (no data-dependent shapes, no ``.item()`` calls).
+        fresh = self._dx0.expand(self.num_envs).clone()
+        fresh.qpos.copy_(qpos.to(self._sim_dtype))
+        fresh.qvel.copy_(qvel.to(self._sim_dtype))
+        # The simulator state contains both per-env tensors and 0-dim /
+        # non-batched leaves shared across envs (``nefc``, ``ncon``,
+        # ...). Mask only the batched ones; the shared scalars don't
+        # need touching. We enumerate the field names via the public
+        # ``to_tensordict`` view, then fetch the *live* tensor off the
+        # tensorclass with ``getattr`` so the in-place ``copy_`` mirrors
+        # back onto the simulator state.
+        cur_td = self._dx.to_tensordict()
+        new_td = fresh.to_tensordict()
+        for k in cur_td.keys():
+            dst = getattr(self._dx, k, None)
+            src = new_td.get(k, default=None)
+            if dst is None or src is None:
+                continue
+            if dst.ndim == 0 or dst.shape[0] != self.num_envs:
+                continue
+            m = mask.view((self.num_envs,) + (1,) * (dst.ndim - 1))
+            dst.copy_(torch.where(m, src.to(dst.dtype), dst))
+
+    def step(self, ctrl: torch.Tensor, frame_skip: int) -> None:
+        ctrl = ctrl.to(self._ctrl_dtype)
+        # Clamp only actuators that MuJoCo marks as ctrl-limited. Unlimited
+        # actuators report a default ctrlrange of [0, 0], which is not an
+        # active range and must not zero out controls.
+        clamped = torch.minimum(torch.maximum(ctrl, self.actuator_lo), self.actuator_hi)
+        ctrl = torch.where(self.actuator_ctrllimited, clamped, ctrl)
+        self._dx.update_(ctrl=ctrl)
+        if self._single_env:
+            stepped = self._physics_step(self._dx[0], frame_skip)
+            self._dx = stepped.unsqueeze(0)
+        else:
+            self._dx = self._physics_step(self._dx, frame_skip)
+
+    @property
+    def qpos(self) -> torch.Tensor:
+        return self._dx.qpos
+
+    @property
+    def qvel(self) -> torch.Tensor:
+        return self._dx.qvel
+
+    @property
+    def time(self) -> torch.Tensor:
+        # mujoco-torch's Data exposes a per-env time scalar.
+        t = self._dx.time
+        if t.ndim == 0:
+            t = t.expand(self.num_envs)
+        return t
+
+    def render(
+        self,
+        *,
+        camera_id: int = 0,
+        width: int = 64,
+        height: int = 64,
+        background: tuple[float, float, float] | None = None,
+    ) -> torch.Tensor:
+        import mujoco_torch
+
+        # Cache precomputed render data lazily (depends on the model only).
+        if not hasattr(self, "_render_precomp"):
+            self._render_precomp = mujoco_torch.precompute_render_data(self._mx)
+        frames = []
+        for i in range(self.num_envs):
+            rgb, _, _ = mujoco_torch.render(
+                self._mx,
+                self._dx[i],
+                camera_id=camera_id,
+                width=width,
+                height=height,
+                precomp=self._render_precomp,
+                background=background,
+            )
+            frames.append((rgb * 255).clamp(0, 255).to(torch.uint8))
+        return torch.stack(frames)
+
+
+# ----------------------------------------------------------------------
+# mujoco C-bindings backend
+# ----------------------------------------------------------------------
+
+
+class _MujocoBackend(_PhysicsBackend):
+    """Reference backend: official ``mujoco`` C-bindings, **single env**.
+
+    The C-bindings can't vmap, so we don't fake batching here. To run
+    multiple environments in parallel with this backend, compose with
+    :class:`~torchrl.envs.ParallelEnv` (multiprocess) or
+    :class:`~torchrl.envs.SerialEnv` (in-process loop). The
+    :class:`~torchrl.envs.custom.mujoco.MujocoEnv` metaclass does this
+    dispatch automatically when ``num_workers > 1`` or ``num_envs > 1``
+    is requested with ``backend='mujoco'``.
+    """
+
+    def __init__(
+        self,
+        xml_string: str,
+        *,
+        num_envs: int,
+        device: torch.device | None,
+    ) -> None:
+        if not _has_mujoco:
+            raise ImportError(
+                "backend='mujoco' requires the `mujoco` package. "
+                "Install with `pip install mujoco`."
+            )
+        if num_envs != 1:
+            raise ValueError(
+                "backend='mujoco' is single-env. To batch, wrap with "
+                "torchrl.envs.ParallelEnv or torchrl.envs.SerialEnv "
+                "(MujocoEnv does this automatically when num_workers>1 "
+                "or num_envs>1 is passed)."
+            )
+        super().__init__(xml_string, num_envs=num_envs, device=device)
+
+    def _init_model(self, xml_string: str) -> None:
+        import mujoco
+
+        m_mj = mujoco.MjModel.from_xml_string(xml_string)
+        d_mj = mujoco.MjData(m_mj)
+        mujoco.mj_forward(m_mj, d_mj)
+
+        self._m = m_mj
+        self._d = d_mj
+
+        self.nq = int(m_mj.nq)
+        self.nv = int(m_mj.nv)
+        self.nu = int(m_mj.nu)
+        self.timestep = float(m_mj.opt.timestep)
+        self.qpos0 = torch.as_tensor(d_mj.qpos.copy(), device=self.device).to(
+            torch.float32
+        )
+        self.qvel0 = torch.as_tensor(d_mj.qvel.copy(), device=self.device).to(
+            torch.float32
+        )
+        ar = torch.as_tensor(
+            m_mj.actuator_ctrlrange, device=self.device, dtype=torch.float32
+        )
+        self.actuator_lo = ar[:, 0]
+        self.actuator_hi = ar[:, 1]
+        self.actuator_ctrllimited = torch.as_tensor(
+            m_mj.actuator_ctrllimited, device=self.device, dtype=torch.bool
+        )
+
+    def reset(self, qpos: torch.Tensor, qvel: torch.Tensor) -> None:
+        import mujoco
+
+        self._d.qpos[:] = qpos.detach().cpu().double().numpy()[0]
+        self._d.qvel[:] = qvel.detach().cpu().double().numpy()[0]
+        self._d.time = 0.0
+        mujoco.mj_forward(self._m, self._d)
+
+    def reset_mask(
+        self, mask: torch.Tensor, qpos: torch.Tensor, qvel: torch.Tensor
+    ) -> None:
+        # Single-env: mask is shape (1,). Either reset or no-op.
+        if bool(mask.any()):
+            self.reset(qpos, qvel)
+
+    def step(self, ctrl: torch.Tensor, frame_skip: int) -> None:
+        import mujoco
+
+        clamped = torch.minimum(torch.maximum(ctrl, self.actuator_lo), self.actuator_hi)
+        clamped = torch.where(self.actuator_ctrllimited, clamped, ctrl)
+        self._d.ctrl[:] = clamped.detach().cpu().double().numpy()[0]
+        for _ in range(frame_skip):
+            mujoco.mj_step(self._m, self._d)
+
+    @property
+    def qpos(self) -> torch.Tensor:
+        return torch.as_tensor(
+            self._d.qpos.copy(), device=self.device, dtype=torch.float32
+        ).unsqueeze(0)
+
+    @property
+    def qvel(self) -> torch.Tensor:
+        return torch.as_tensor(
+            self._d.qvel.copy(), device=self.device, dtype=torch.float32
+        ).unsqueeze(0)
+
+    @property
+    def time(self) -> torch.Tensor:
+        return torch.tensor([self._d.time], device=self.device, dtype=torch.float32)
+
+    def render(
+        self,
+        *,
+        camera_id: int = 0,
+        width: int = 64,
+        height: int = 64,
+        background: tuple[float, float, float] | None = None,
+    ) -> torch.Tensor:
+        import mujoco
+        import numpy as np
+
+        if (
+            not hasattr(self, "_renderer")
+            or self._renderer.height != height
+            or self._renderer.width != width
+        ):
+            self._renderer = mujoco.Renderer(self._m, height=height, width=width)
+        self._renderer.update_scene(self._d, camera=camera_id)
+        rgb = self._renderer.render()  # (H, W, 3) uint8 numpy
+        if background is not None:
+            # Tint background pixels (those at the far plane). Approximation:
+            # uses the geom-id buffer is overkill -- skip when not requested.
+            pass
+        return torch.as_tensor(np.ascontiguousarray(rgb), device=self.device).unsqueeze(
+            0
+        )
+
+
+# ----------------------------------------------------------------------
+# MJX (JAX) backend
+# ----------------------------------------------------------------------
+
+
+class _MJXBackend(_PhysicsBackend):
+    """JAX-vectorized backend via ``mujoco.mjx``.
+
+    Mirrors the pattern in :mod:`torchrl.envs.libs.brax`: build an
+    ``mjx.Model``, ``vmap+jit`` the step function, bridge JAX arrays to
+    torch tensors via DLPack on each call.
+    """
+
+    def __init__(
+        self,
+        xml_string: str,
+        *,
+        num_envs: int,
+        device: torch.device | None,
+    ) -> None:
+        if not (_has_mjx and _has_jax):
+            raise ImportError(
+                "backend='mjx' requires `mujoco>=3.0` (with mjx) and `jax`. "
+                "Install with `pip install mujoco-mjx jax`."
+            )
+        super().__init__(xml_string, num_envs=num_envs, device=device)
+
+    def _init_model(self, xml_string: str) -> None:
+        import jax
+        import mujoco
+        from mujoco import mjx
+
+        m_mj = mujoco.MjModel.from_xml_string(xml_string)
+        mx = mjx.put_model(m_mj)
+        dx0_single = mjx.make_data(mx)
+        dx0_single = mjx.forward(mx, dx0_single)
+
+        self._mjx = mjx
+        self._jax = jax
+        self._m_mj = m_mj  # kept for rendering via mujoco.Renderer
+        self._mx = mx
+        self._dx0_single = dx0_single
+        # All JAX arrays must live on this device or jit will fail with
+        # "Received incompatible devices for jitted computation". The
+        # model's data state lives wherever `mjx.put_model` placed it
+        # (JAX default device), and any tensors we splice in (qpos /
+        # qvel / time) must be put_d to match.
+        self._jax_device = dx0_single.qpos.device
+
+        self.nq = int(m_mj.nq)
+        self.nv = int(m_mj.nv)
+        self.nu = int(m_mj.nu)
+        self.timestep = float(m_mj.opt.timestep)
+        self.qpos0 = self._jax_to_torch(dx0_single.qpos)
+        self.qvel0 = self._jax_to_torch(dx0_single.qvel)
+        ar = torch.as_tensor(
+            m_mj.actuator_ctrlrange, device=self.device, dtype=torch.float32
+        )
+        self.actuator_lo = ar[:, 0]
+        self.actuator_hi = ar[:, 1]
+        self.actuator_ctrllimited = torch.as_tensor(
+            m_mj.actuator_ctrllimited, device=self.device, dtype=torch.bool
+        )
+
+        self._vmap_step = jax.jit(jax.vmap(lambda d: mjx.step(mx, d)))
+        self._vmap_forward = jax.jit(jax.vmap(lambda d: mjx.forward(mx, d)))
+
+        # Initial batched state.
+        self._dx = jax.vmap(lambda _: dx0_single)(jax.numpy.arange(self.num_envs))
+
+    def _jax_to_torch(self, x) -> torch.Tensor:
+        from torchrl.envs.libs.jax_utils import _ndarray_to_tensor
+
+        return _ndarray_to_tensor(x).to(self.device).to(torch.float32)
+
+    def _torch_to_jax(self, x: torch.Tensor):
+        from torchrl.envs.libs.jax_utils import _tensor_to_ndarray
+
+        arr = _tensor_to_ndarray(x.contiguous())
+        # Force the array onto the model's JAX device. Torch tensors on
+        # CPU would otherwise yield a CPU JAX array even when the model
+        # lives on GPU, causing a mixed-device pytree at jit time.
+        return self._jax.device_put(arr, self._jax_device)
+
+    def _broadcast_dx0(self):
+        """Build a batched copy of ``_dx0_single`` on ``self._jax_device``."""
+        jax = self._jax
+        idx = jax.device_put(jax.numpy.arange(self.num_envs), self._jax_device)
+        return jax.vmap(lambda _: self._dx0_single)(idx)
+
+    def reset(self, qpos: torch.Tensor, qvel: torch.Tensor) -> None:
+        qpos_j = self._torch_to_jax(qpos)
+        qvel_j = self._torch_to_jax(qvel)
+        # Broadcast _dx0_single (with time=0) over the batch, splice in
+        # the new qpos/qvel, then re-run mjx.forward so derived quantities
+        # are consistent. Time stays at zero from the reference state.
+        dx = self._broadcast_dx0()
+        dx = dx.replace(qpos=qpos_j, qvel=qvel_j)
+        self._dx = self._vmap_forward(dx)
+
+    def reset_mask(
+        self, mask: torch.Tensor, qpos: torch.Tensor, qvel: torch.Tensor
+    ) -> None:
+        # ``qpos`` and ``qvel`` are full-batch (num_envs, *). Mux the
+        # reset rows in via ``torch.where`` on the torch side, then push
+        # back to JAX. Partial reset isn't on the hot path; the JAX
+        # bridge itself dominates the cost here.
+        full_qpos = self.qpos.clone()
+        full_qvel = self.qvel.clone()
+        m_q = mask.view(self.num_envs, *([1] * (full_qpos.ndim - 1)))
+        m_v = mask.view(self.num_envs, *([1] * (full_qvel.ndim - 1)))
+        full_qpos = torch.where(m_q, qpos.to(full_qpos.dtype), full_qpos)
+        full_qvel = torch.where(m_v, qvel.to(full_qvel.dtype), full_qvel)
+        time = self.time.clone()
+        time = torch.where(mask, torch.zeros_like(time), time)
+
+        qpos_j = self._torch_to_jax(full_qpos)
+        qvel_j = self._torch_to_jax(full_qvel)
+        time_j = self._torch_to_jax(time)
+        dx = self._broadcast_dx0()
+        dx = dx.replace(qpos=qpos_j, qvel=qvel_j, time=time_j)
+        self._dx = self._vmap_forward(dx)
+
+    def step(self, ctrl: torch.Tensor, frame_skip: int) -> None:
+        clamped = torch.minimum(torch.maximum(ctrl, self.actuator_lo), self.actuator_hi)
+        ctrl = torch.where(self.actuator_ctrllimited, clamped, ctrl)
+        ctrl_j = self._torch_to_jax(ctrl)
+        self._dx = self._dx.replace(ctrl=ctrl_j)
+        for _ in range(frame_skip):
+            self._dx = self._vmap_step(self._dx)
+
+    @property
+    def qpos(self) -> torch.Tensor:
+        return self._jax_to_torch(self._dx.qpos)
+
+    @property
+    def qvel(self) -> torch.Tensor:
+        return self._jax_to_torch(self._dx.qvel)
+
+    @property
+    def time(self) -> torch.Tensor:
+        return self._jax_to_torch(self._dx.time)
+
+    def render(
+        self,
+        *,
+        camera_id: int = 0,
+        width: int = 64,
+        height: int = 64,
+        background: tuple[float, float, float] | None = None,
+    ) -> torch.Tensor:
+        """Render via mujoco's CPU renderer after copying mjx state to MjData.
+
+        Slow path (one MjData per env, sequential render). Acceptable for
+        eval / video; not for high-throughput pixel-based training.
+        """
+        import mujoco
+        import numpy as np
+
+        if (
+            not hasattr(self, "_renderer")
+            or self._renderer.height != height
+            or self._renderer.width != width
+        ):
+            self._renderer = mujoco.Renderer(self._m_mj, height=height, width=width)
+        if not hasattr(self, "_render_d"):
+            self._render_d = mujoco.MjData(self._m_mj)
+
+        qpos = self.qpos.detach().cpu().double().numpy()
+        qvel = self.qvel.detach().cpu().double().numpy()
+        frames = []
+        for i in range(self.num_envs):
+            self._render_d.qpos[:] = qpos[i]
+            self._render_d.qvel[:] = qvel[i]
+            mujoco.mj_forward(self._m_mj, self._render_d)
+            self._renderer.update_scene(self._render_d, camera=camera_id)
+            frames.append(self._renderer.render().copy())
+        rgb = np.stack(frames, axis=0)
+        return torch.as_tensor(np.ascontiguousarray(rgb), device=self.device)
+
+
+# ----------------------------------------------------------------------
+# Dispatch
+# ----------------------------------------------------------------------
+
+
+def make_backend(
+    name: BackendName,
+    xml_string: str,
+    *,
+    num_envs: int,
+    device: torch.device | None,
+    compile_step: bool = False,
+    compile_kwargs: dict | None = None,
+) -> _PhysicsBackend:
+    """Instantiate the requested backend.
+
+    Raises ``ImportError`` with an actionable message when the underlying
+    package is missing. ``compile_step`` is honored only by the
+    ``mujoco-torch`` backend (mjx already JITs; the C-bindings backend is
+    a Python loop).
+    """
+    if name == "mujoco-torch":
+        return _TorchBackend(
+            xml_string,
+            num_envs=num_envs,
+            device=device,
+            compile_step=compile_step,
+            compile_kwargs=compile_kwargs,
+        )
+    if name == "mjx":
+        return _MJXBackend(xml_string, num_envs=num_envs, device=device)
+    if name == "mujoco":
+        return _MujocoBackend(xml_string, num_envs=num_envs, device=device)
+    raise ValueError(
+        f"unknown backend {name!r}; expected one of 'mujoco-torch', 'mjx', 'mujoco'"
+    )

--- a/torchrl/envs/custom/mujoco/_math.py
+++ b/torchrl/envs/custom/mujoco/_math.py
@@ -1,0 +1,227 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Pure-torch math helpers for the MuJoCo custom envs.
+
+Quaternions follow the MuJoCo convention ``(w, x, y, z)``. CMG geometry
+helpers support the satellite env's manipulability-based singularity penalty.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+
+def quat_mul(q1: torch.Tensor, q2: torch.Tensor) -> torch.Tensor:
+    """Hamilton product of two unit quaternions, ``(..., 4)`` -> ``(..., 4)``."""
+    w1, x1, y1, z1 = q1.unbind(-1)
+    w2, x2, y2, z2 = q2.unbind(-1)
+    return torch.stack(
+        [
+            w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+            w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+            w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+            w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+        ],
+        dim=-1,
+    )
+
+
+def quat_conj(q: torch.Tensor) -> torch.Tensor:
+    """Conjugate of a unit quaternion."""
+    w, x, y, z = q.unbind(-1)
+    return torch.stack([w, -x, -y, -z], dim=-1)
+
+
+def quat_log(q: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    """Logarithm map of a unit quaternion to a 3-vector axis-angle.
+
+    For ``q = (cos(a/2), sin(a/2) n)`` with axis ``n`` and angle ``a``,
+    ``quat_log(q) = a * n``. Range: ``[0, pi]`` in magnitude.
+    """
+    q = q / q.norm(dim=-1, keepdim=True).clamp_min(eps)
+    # q and -q encode the same SO(3) rotation. Use the representative
+    # with non-negative scalar part so the log map is the shortest arc.
+    sign = torch.where(q[..., 0:1] < 0, -1.0, 1.0)
+    q = q * sign
+    w = q[..., 0:1].clamp(-1.0, 1.0)
+    v = q[..., 1:]
+    v_norm = v.norm(dim=-1, keepdim=True).clamp_min(eps)
+    angle = 2.0 * torch.atan2(v_norm, w)
+    return v / v_norm * angle
+
+
+def random_unit_quat(
+    shape: tuple[int, ...],
+    *,
+    generator: torch.Generator | None = None,
+    device: torch.device | None = None,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Uniform random unit quaternion on ``SO(3)``."""
+    q = torch.randn(*shape, 4, generator=generator, device=device, dtype=dtype)
+    return q / q.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+
+
+def _rodrigues_rotate(
+    g: torch.Tensor, r0: torch.Tensor, theta: torch.Tensor
+) -> torch.Tensor:
+    """Rotate ``r0`` around unit axis ``g`` by angle ``theta``.
+
+    ``g``, ``r0``: ``(3, N)``. ``theta``: ``(..., N)``. Output: ``(..., 3, N)``.
+    """
+    cos_t = torch.cos(theta).unsqueeze(-2)
+    sin_t = torch.sin(theta).unsqueeze(-2)
+    g_dot_r = (g * r0).sum(dim=0)
+    g_cross_r = torch.linalg.cross(g, r0, dim=0)
+    return cos_t * r0 + sin_t * g_cross_r + (1.0 - cos_t) * g_dot_r * g
+
+
+def cmg_jacobian(
+    gimbal_angles: torch.Tensor,
+    gimbal_axes: torch.Tensor,
+    rotor_axes_ref: torch.Tensor,
+    h: float,
+) -> torch.Tensor:
+    """CMG output-torque Jacobian over gimbal rates.
+
+    For each CMG with gimbal axis ``g_i`` and rotor axis ``r_i(theta_i)``,
+    the rate-of-change of the rotor's angular momentum per unit gimbal
+    rate is ``h * (g_i x r_i(theta_i))``. Stacked into a ``(..., 3, N)``
+    matrix. The torque applied to the *bus* is the Newton's-third-law
+    reaction, ``-h * (g_i x r_i)``; this function returns the
+    rotor-frame quantity because the manipulability metric
+    ``sqrt(det(J J^T))`` -- the only consumer in this module -- is
+    sign-invariant. Callers that care about the body-frame slewing
+    direction must negate the result.
+
+    Args:
+        gimbal_angles: ``(..., N)`` current gimbal angles in radians.
+        gimbal_axes: ``(3, N)`` fixed gimbal axes in body frame, unit norm.
+        rotor_axes_ref: ``(3, N)`` rotor axes at ``theta=0``, unit norm,
+            perpendicular to the corresponding gimbal axis.
+        h: scalar rotor angular momentum magnitude.
+
+    Returns:
+        ``(..., 3, N)`` Jacobian whose ``i``-th column is the
+        rotor-momentum-rate per unit ``i``-th gimbal rate. Negate to
+        get the bus torque per unit gimbal rate.
+    """
+    r = _rodrigues_rotate(gimbal_axes, rotor_axes_ref, gimbal_angles)
+    g_expanded = gimbal_axes.expand_as(r)
+    return h * torch.linalg.cross(g_expanded, r, dim=-2)
+
+
+def manipulability(jac: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    """``sqrt(det(J J^T) + eps)`` -- proxy for distance from singularity.
+
+    ``jac`` shape: ``(..., 3, N)`` with ``N >= 3``. Output: ``(...,)``.
+    """
+    jjt = jac @ jac.transpose(-1, -2)
+    det = torch.linalg.det(jjt).clamp_min(0.0)
+    return torch.sqrt(det + eps)
+
+
+def pyramid_4cmg_geometry(
+    skew_deg: float = 54.7356,
+    *,
+    device: torch.device | None = None,
+    dtype: torch.dtype = torch.float32,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Standard 4-CMG pyramid matching ``satellite_large.xml``.
+
+    Each gimbal axis lies in the body ``xy`` plane (one per face of the
+    bus). The four rotor reference axes are tilted by ``skew_deg`` from
+    ``+z`` toward the corresponding face. The default skew angle
+    ``arctan(sqrt(2)) ~ 54.74 deg`` gives a spherical momentum envelope
+    (the textbook configuration).
+
+    Order matches the four CMGs declared in
+    ``satellite_large.xml`` (``cmg1``..``cmg4``):
+
+    ============  ================  ================
+     CMG          gimbal axis        rotor axis @ 0
+    ============  ================  ================
+     cmg1 (+x)    (0, 1, 0)          (sb, 0, cb)
+     cmg2 (+y)    (-1, 0, 0)         (0, sb, cb)
+     cmg3 (-x)    (0, -1, 0)         (-sb, 0, cb)
+     cmg4 (-y)    (1, 0, 0)          (0, -sb, cb)
+    ============  ================  ================
+
+    Returns ``(gimbal_axes, rotor_axes_ref)``, both ``(3, 4)`` and
+    column-aligned with the XML's gimbal joint order.
+    """
+    beta = math.radians(skew_deg)
+    cb, sb = math.cos(beta), math.sin(beta)
+    g = torch.tensor(
+        [
+            [0.0, -1.0, 0.0, 1.0],
+            [1.0, 0.0, -1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+        ],
+        device=device,
+        dtype=dtype,
+    )
+    r0 = torch.tensor(
+        [
+            [sb, 0.0, -sb, 0.0],
+            [0.0, sb, 0.0, -sb],
+            [cb, cb, cb, cb],
+        ],
+        device=device,
+        dtype=dtype,
+    )
+    return g, r0
+
+
+def orthogonal_6cmg_geometry(
+    *,
+    device: torch.device | None = None,
+    dtype: torch.dtype = torch.float32,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """6-CMG cluster matching ``satellite_small.xml``.
+
+    One CMG per face of the bus; the six gimbal axes are pair-wise drawn
+    from ``{x, y, z}`` so that each principal axis carries two rotor
+    spin vectors when the gimbals are at zero. The cluster is full-rank
+    at ``theta = 0``.
+
+    Order matches the six CMGs declared in
+    ``satellite_small.xml`` (``cmg1``..``cmg6``):
+
+    ============  ================  ================
+     CMG          gimbal axis        rotor axis @ 0
+    ============  ================  ================
+     cmg1 (+x)    (0, 1, 0)          (0, 0, 1)
+     cmg2 (-x)    (0, 0, 1)          (0, 1, 0)
+     cmg3 (+y)    (0, 0, 1)          (1, 0, 0)
+     cmg4 (-y)    (1, 0, 0)          (0, 0, 1)
+     cmg5 (+z)    (1, 0, 0)          (0, 1, 0)
+     cmg6 (-z)    (0, 1, 0)          (1, 0, 0)
+    ============  ================  ================
+
+    Returns ``(gimbal_axes, rotor_axes_ref)``, both ``(3, 6)`` and
+    column-aligned with the XML's gimbal joint order.
+    """
+    g = torch.tensor(
+        [
+            [0.0, 0.0, 0.0, 1.0, 1.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            [0.0, 1.0, 1.0, 0.0, 0.0, 0.0],
+        ],
+        device=device,
+        dtype=dtype,
+    )
+    r0 = torch.tensor(
+        [
+            [0.0, 0.0, 1.0, 0.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0, 0.0, 1.0, 0.0],
+            [1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+        ],
+        device=device,
+        dtype=dtype,
+    )
+    return g, r0

--- a/torchrl/envs/custom/mujoco/ant.py
+++ b/torchrl/envs/custom/mujoco/ant.py
@@ -1,0 +1,79 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Ant-v4 quadruped locomotion env."""
+
+from __future__ import annotations
+
+import re
+
+import torch
+from tensordict import TensorDictBase
+from torchrl.envs.custom.mujoco.base import MujocoEnv
+
+
+class AntEnv(MujocoEnv):
+    """Quadruped locomotion (15-DoF, 8 actuators).
+
+    The bundled ``ant.xml`` is a fixed-base ant; we patch it at load
+    time to insert a free joint on the torso and set ``timestep=0.01``,
+    matching Gymnasium ``Ant-v4`` semantics.
+
+    Args: see :class:`~torchrl.envs.custom.mujoco.MujocoEnv`.
+
+    Example:
+        >>> from torchrl.envs import AntEnv  # doctest: +SKIP
+        >>> env = AntEnv(num_envs=8)         # doctest: +SKIP
+        >>> td = env.rollout(50)             # doctest: +SKIP
+    """
+
+    XML_PATH = "ant.xml"
+    FRAME_SKIP = 5
+    RESET_NOISE_SCALE = 0.1
+    SKIP_QPOS = 2
+    HEALTHY_Z_LOW = 0.2
+    HEALTHY_Z_HIGH = 1.0
+    HEALTHY_REWARD = 1.0
+    CTRL_COST_WEIGHT = 0.5
+
+    @classmethod
+    def _patch_xml(cls, xml: str) -> str:
+        xml = super()._patch_xml(xml)
+        xml = re.sub(
+            r'(<body\s+name="torso"[^>]*>)',
+            r"\1\n      <freejoint name='root'/>",
+            xml,
+            count=1,
+        )
+        xml = re.sub(
+            r"(<compiler\b[^/]*/>\s*)",
+            r'\1<option timestep="0.01"/>\n  ',
+            xml,
+            count=1,
+        )
+        return xml
+
+    def _is_healthy(self, qpos: torch.Tensor) -> torch.Tensor:
+        z = qpos[..., 2]
+        return (z >= self.HEALTHY_Z_LOW) & (z <= self.HEALTHY_Z_HIGH)
+
+    def _compute_reward(
+        self,
+        state: TensorDictBase,
+        action: torch.Tensor,
+        next_state: TensorDictBase,
+    ) -> torch.Tensor:
+        dt = self._backend.timestep * self.frame_skip
+        forward_vel = (next_state["qpos"][..., 0] - state["qpos"][..., 0]) / dt
+        ctrl_cost = self.CTRL_COST_WEIGHT * (action.to(self.dtype) ** 2).sum(dim=-1)
+        healthy = self._is_healthy(next_state["qpos"]).to(self.dtype)
+        reward = forward_vel.to(self.dtype) + self.HEALTHY_REWARD * healthy - ctrl_cost
+        return reward.unsqueeze(-1)
+
+    def _compute_done(
+        self,
+        state: TensorDictBase,
+        next_state: TensorDictBase,
+    ) -> torch.Tensor:
+        return (~self._is_healthy(next_state["qpos"])).unsqueeze(-1)

--- a/torchrl/envs/custom/mujoco/assets/NOTICE
+++ b/torchrl/envs/custom/mujoco/assets/NOTICE
@@ -1,0 +1,26 @@
+torchrl/envs/custom/mujoco/assets
+=================================
+
+The XML model files in this directory are bundled here for convenience:
+
+  ant.xml          walker2d.xml      satellite_large.xml
+  hopper.xml       humanoid.xml      satellite_small.xml
+
+They are derivative works of MuJoCo MJX (https://github.com/google-deepmind/mujoco/tree/main/mjx),
+distributed by Vincent Moens via the `mujoco-torch` package
+(https://github.com/vmoens/mujoco-torch), and are made available under the
+Apache License, Version 2.0:
+
+    Copyright 2023 DeepMind Technologies Limited
+    Copyright 2025 Vincent Moens
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use these files except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+To avoid vendoring assets you'd rather not redistribute, every
+:class:`~torchrl.envs.custom.mujoco.MujocoEnv` subclass accepts an
+``xml_path=`` constructor kwarg that may be a local path *or* an
+``http(s)://`` URL. Override :attr:`MujocoEnv.XML_PATH` /
+:attr:`MujocoEnv.XML_URL` on a custom subclass to point elsewhere.

--- a/torchrl/envs/custom/mujoco/assets/ant.xml
+++ b/torchrl/envs/custom/mujoco/assets/ant.xml
@@ -1,0 +1,159 @@
+<!--
+Copyright (c) 2020 Philipp Moritz, The dm_control Authors
+
+Use of this source code is governed by an MIT-style
+license that can be found in the LICENSE file or at
+https://opensource.org/licenses/MIT.
+-->
+<mujoco model="ant">
+  <compiler angle="radian"/>
+  <default>
+    <motor ctrlrange="-1.0 1.0" ctrllimited="true" gear="75"/>
+    <geom friction="1 0.5 0.5" solref=".02 1" solimp="0 .8 .01" material="self" density="50.0"/>
+    <joint limited="true" armature="1" damping="1" stiffness="1" solreflimit=".04 1" solimplimit="0 .8 .03"/>
+    <default class="rangefinder">
+        <site type="capsule" size=".05 .5" rgba="1 0 0 .4" group="4"/>
+    </default>
+  </default>
+  <asset>
+    <material name="self" rgba=".8 .6 .4 1"/>
+  </asset>
+  <worldbody>
+    <camera name="sideon" pos="0 -10 5" fovy="45" mode="targetbody" target="torso" />
+    <camera name="float_far"  pos="-4 0 2" xyaxes="0 -1 0 .5 0 1" mode="trackcom" fovy="90"/>
+    <body name="torso" pos="0 0 0.522">
+      <camera name="floating"  pos="-2 0 1" xyaxes="0 -1 0 .5 0 1" mode="trackcom" fovy="90"/>
+      <camera name="egocentric"  pos=".25 0 .11" xyaxes="0 -1 0 0 0 1" fovy="90" />
+
+      <site name="torso_touch" type="box" size="0.26 0.26 0.26" rgba="0 0 1 1" group="4"/>
+      <geom name="torso_geom" type="sphere" size="0.25" density="100.0"/>
+      <site name="torso_site" size="0.05" rgba="1 0 0 1"/>
+
+      <site name="rf_xp" class="rangefinder" pos="0.25 0 0.11" zaxis="1 0 0"/>
+      <site name="rf_xn" class="rangefinder" pos="-0.25 0 0.11" zaxis="-1 0 0"/>
+      <site name="rf_yp" class="rangefinder" pos="0 0.25 0.11"  zaxis="0 1 0"/>
+      <site name="rf_yn" class="rangefinder" pos="0 -0.25 0.11"  zaxis="0 -1 0"/>
+      <site name="rf_xpyp" class="rangefinder" pos="0.25 0.25 0.11" zaxis="1 1 0"/>
+      <site name="rf_xpyn" class="rangefinder" pos="0.25 -0.25 0.11"  zaxis="1 -1 0"/>
+      <site name="rf_xnyn" class="rangefinder" pos="-0.25 -0.25 0.11" zaxis="-1 -1 0"/>
+      <site name="rf_xnyp" class="rangefinder" pos="-0.25 0.25 0.11" zaxis="-1 1 0"/>
+
+      <!-- sites that visualize the x-y axis of the ant body, good for debugging -->
+      <site name="x_pos" type="capsule" pos="0.5 0 0" size=".05 .5" zaxis="1 0 0" rgba="1 0 0 1" group="5"/>
+      <site name="x_neg" type="capsule" pos="-0.5 0 0" size=".05 .5"  zaxis="-1 0 0" rgba="0 0 1 1"  group="5"/>
+      <site name="y_pos" type="capsule" pos="0 0.5 0" size=".05 .5"  zaxis="0 1 0" rgba="1 1 1 1" group="5"/>
+      <site name="y_neg" type="capsule" pos="0 -0.5 0" size=".05 .5"  zaxis="0 -1 0" rgba="0 0 0 1" group="5"/>
+      <site name="port_site" pos=".5 0 0" size="0.5" rgba="1 0 0 1" group="5"/>
+      <site name="starboard_site" pos="-.5 0 0" size="0.5" rgba="0 1 0 1" group="5"/>
+
+      <site name="rc1" type="sphere" size=".1" rgba="1 1 1 1"/>
+      <site name="rc2" type="sphere" size=".1" rgba="1 1 1 1"/>
+      <site name="rc3" type="sphere" size=".1" rgba="1 1 1 1"/>
+      <site name="rc4" type="sphere" size=".1" rgba="1 1 1 1"/>
+      <site name="rc5" type="sphere" size=".1" rgba="1 1 1 1"/>
+      <site name="rc6" type="sphere" size=".1" rgba="1 1 1 1"/>
+      <site name="rc7" type="sphere" size=".1" rgba="1 1 1 1"/>
+      <site name="rc8" type="sphere" size=".1" rgba="1 1 1 1"/>
+      <site name="rc9" type="sphere" size=".1" rgba="1 1 1 1"/>
+      <site name="rc10" type="sphere" size=".1" rgba="1 1 1 1"/>
+
+      <body name="front_left_leg">
+        <geom name="front_left_aux_geom" type="capsule" size="0.08" fromto="0.0 0.0 0.0 0.2 0.2 0.0"/>
+        <body name="front_left_aux" pos="0.2 0.2 0">
+          <joint name="front_left_hip" range="-0.52359 0.52359"/>
+          <geom name="front_left_leg_geom" type="capsule" size="0.08" fromto="0.0 0.0 0.0 0.2 0.2 0.0"/>
+          <site name="front_left_leg_touch" type="box" pos="0.1 0.1 0" size="0.09 0.09 0.24" zaxis="0.2 0.2 0" rgba="1 1 0 0"/>
+          <body name="front_left_foot" pos="0.2 0.2 0" quat="0.98480775301220802 -0.33428158105097677 0.33428158105097677 0">
+            <joint name="front_left_ankle" type="hinge" pos="0.0 0.0 0.0" axis="1 -1 0" range="-0.34906 0.34906"/>
+            <geom name="front_left_ankle_geom" type="capsule" size="0.08" fromto="0.0 0.0 0.0 0.4 0.4 0.0"/>
+            <site name="front_left_ankle_touch" type="box" pos="0.2 0.2 0" size="0.1 0.1 0.45" zaxis="0.2 0.2 0.0" rgba="1 1 0 0" />
+          </body>
+        </body>
+      </body>
+
+      <body name="front_right_leg">
+        <geom name="front_right_aux_geom" type="capsule" size="0.08" fromto="0.0 0.0 0.0 0.2 -0.2 0.0"/>
+        <body name="front_right_aux" pos="0.2 -0.2 0">
+          <joint name="front_right_hip" range="-0.52359 0.52359"/>
+          <geom name="front_right_leg_geom" type="capsule" size="0.08" fromto="0.0 0.0 0.0 0.2 -0.2 0.0"/>
+          <site name="front_right_leg_touch" type="box" pos="0.1 -0.1 0" size="0.09 0.09 0.24" zaxis="0.2 -0.2 0.0" rgba="0 0 1 0"/>
+          <body name="front_right_foot" pos="0.2 -0.2 0" quat="0.98480775301220802 0.33428158105097677 0.33428158105097677 0">
+            <joint name="front_right_ankle" type="hinge" pos="0.0 0.0 0.0" axis="-1 -1 0" range="-0.34906 0.34906"/>
+            <geom name="front_right_ankle_geom" type="capsule" size="0.08" fromto="0.0 0.0 0.0 0.4 -0.4 0.0"/>
+            <site name="front_right_ankle_touch" type="box" pos="0.2 -0.2 0" size="0.09 0.09 0.39" zaxis="0.2 -0.2 0.0" rgba="0 0 1 0"/>
+          </body>
+        </body>
+      </body>
+
+      <body name="back_right_leg">
+        <geom name="back_right_aux_geom" type="capsule" size="0.08" fromto="0.0 0.0 0.0 -0.2 -0.2 0.0"/>
+        <body name="back_right_aux" pos="-0.2 -0.2 0">
+          <joint name="back_right_hip" range="-0.52359 0.52359"/>
+          <geom name="back_right_leg_geom" type="capsule" size="0.08" fromto="0.0 0.0 0.0 -0.2 -0.2 0.0"/>
+          <site name="back_right_leg_touch" type="box" pos="-0.1 -0.1 0" size="0.09 0.09 0.24" zaxis="-0.2 -0.2 0.0" rgba="0 0 1 0"/>
+          <body name="back_right_foot" pos="-0.2 -0.2 0" quat="0.98480775301220802 0.33428158105097677 -0.33428158105097677 0">
+            <joint name="back_right_ankle" type="hinge" pos="0.0 0.0 0.0" axis="-1 1 0" range="-0.34906 0.34906"/>
+            <geom name="back_right_ankle_geom" type="capsule" size="0.08" fromto="0.0 0.0 0.0 -0.4 -0.4 0.0"/>
+            <site name="back_right_ankle_touch" type="box" pos="-0.2 -0.2 0" size="0.09 0.09 0.39" zaxis="-0.2 -0.2 0.0" rgba="0 0 1 0"/>
+          </body>
+        </body>
+      </body>
+
+      <body name="back_left_leg">
+        <geom name="back_left_aux_geom" type="capsule" size="0.08" fromto="0.0 0.0 0.0 -0.2 0.2 0.0"/>
+        <body name="back_left_aux" pos="-0.2 0.2 0">
+          <joint name="back_left_hip" range="-0.52359 0.52359"/>
+          <geom name="back_left_leg_geom" type="capsule" size="0.08" fromto="0.0 0.0 0.0 -0.2 0.2 0.0"/>
+          <site name="back_left_leg_touch" type="box" pos="-0.1 0.1 0" size="0.09 0.09 0.24" zaxis="-0.2 0.2 0.0" rgba="0 0 1 0"/>
+          <body name="back_left_foot" pos="-0.2 0.2 0" quat="0.98480775301220802 -0.33428158105097677 -0.33428158105097677 0">
+            <joint name="back_left_ankle" type="hinge" pos="0.0 0.0 0.0" axis="1 1 0" range="-0.34906 0.34906" />
+            <geom name="back_left_ankle_geom" type="capsule" size="0.08" fromto="0.0 0.0 0.0 -0.4 0.4 0.0"/>
+            <site name="back_left_ankle_touch" type="box" pos="-0.2 0.2 0" size="0.09 0.09 0.39" zaxis="-0.2 0.2 0.0" rgba="0 0 1 0"/>
+          </body>
+        </body>
+      </body>
+
+    </body>
+  </worldbody>
+
+  <actuator>
+    <motor name="front_left_hip"   joint="front_left_hip"/>
+    <motor name="front_left_ankle" joint="front_left_ankle"/>
+    <motor name="front_right_hip"   joint="front_right_hip"/>
+    <motor name="front_right_ankle" joint="front_right_ankle"/>
+    <motor name="back_right_hip"   joint="back_right_hip"/>
+    <motor name="back_right_ankle" joint="back_right_ankle"/>
+    <motor name="back_left_hip"   joint="back_left_hip"/>
+    <motor name="back_left_ankle" joint="back_left_ankle"/>
+  </actuator>
+
+  <sensor>
+    <touch name="torso_touch" site="torso_touch"/>
+    <touch name="front_left_leg_touch" site="front_left_leg_touch"/>
+    <touch name="front_left_ankle_touch" site="front_left_ankle_touch"/>
+    <touch name="back_left_leg_touch" site="back_left_leg_touch"/>
+    <touch name="back_left_ankle_touch" site="back_left_ankle_touch"/>
+    <touch name="back_right_leg_touch" site="back_right_leg_touch"/>
+    <touch name="back_right_ankle_touch" site="back_right_ankle_touch"/>
+    <touch name="front_right_leg_touch" site="front_right_leg_touch"/>
+    <touch name="front_right_ankle_touch" site="front_right_ankle_touch"/>
+    <velocimeter name="torso_vel" site="torso_site"/>
+    <gyro name="torso_gyro" site="torso_site"/>
+    <accelerometer name="torso_accel" site="torso_site"/>
+    <rangefinder name="rf_xp" site="rf_xp"/>
+    <rangefinder name="rf_yp" site="rf_yp"/>
+    <rangefinder name="rf_xn" site="rf_xn"/>
+    <rangefinder name="rf_yn" site="rf_yn"/>
+    <rangefinder name="rf_xpyp" site="rf_xpyp"/>
+    <rangefinder name="rf_xpyn" site="rf_xpyn"/>
+    <rangefinder name="rf_xnyp" site="rf_xnyp"/>
+    <rangefinder name="rf_xnyn" site="rf_xnyn"/>
+  </sensor>
+
+  <contact>
+    <exclude body1="torso" body2="front_left_aux"/>
+    <exclude body1="torso" body2="front_right_aux"/>
+    <exclude body1="torso" body2="back_right_aux"/>
+    <exclude body1="torso" body2="back_left_aux"/>
+  </contact>
+</mujoco>

--- a/torchrl/envs/custom/mujoco/assets/hopper.xml
+++ b/torchrl/envs/custom/mujoco/assets/hopper.xml
@@ -1,0 +1,35 @@
+<mujoco model="hopper">
+  <compiler autolimits="true"/>
+  <option integrator="Euler" timestep="0.005"/>
+  <worldbody>
+    <light pos="0 0 3"/>
+    <geom type="plane" size="5 5 0.1" contype="1" conaffinity="1"/>
+    <body name="torso" pos="0 0 1.25">
+      <joint name="rootx" type="slide" axis="1 0 0"/>
+      <joint name="rootz" type="slide" axis="0 0 1"/>
+      <joint name="rooty" type="hinge" axis="0 1 0"/>
+      <geom type="capsule" fromto="0 0 0 0 0 -0.4" size="0.05" mass="3"
+             friction="1 0.005 0.0001" condim="3"/>
+      <body name="thigh" pos="0 0 -0.4">
+        <joint name="thigh_joint" type="hinge" axis="0 1 0" damping="5"/>
+        <geom type="capsule" fromto="0 0 0 0 0 -0.45" size="0.05" mass="3"
+               friction="1 0.005 0.0001" condim="3"/>
+        <body name="leg" pos="0 0 -0.45">
+          <joint name="leg_joint" type="hinge" axis="0 1 0" damping="5"/>
+          <geom type="capsule" fromto="0 0 0 0 0 -0.5" size="0.04" mass="3"
+                 friction="1 0.005 0.0001" condim="3"/>
+          <body name="foot" pos="0 0 -0.5">
+            <joint name="foot_joint" type="hinge" axis="0 1 0" damping="5"/>
+            <geom type="capsule" fromto="-0.13 0 0 0.16 0 0" size="0.06" mass="2"
+                   friction="2 0.005 0.0001" condim="3"/>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor joint="thigh_joint" gear="200"/>
+    <motor joint="leg_joint" gear="200"/>
+    <motor joint="foot_joint" gear="200"/>
+  </actuator>
+</mujoco>

--- a/torchrl/envs/custom/mujoco/assets/humanoid.xml
+++ b/torchrl/envs/custom/mujoco/assets/humanoid.xml
@@ -1,0 +1,262 @@
+<!-- Copyright 2021 DeepMind Technologies Limited
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<mujoco model="Humanoid">
+  <option timestep="0.005" iterations="1" ls_iterations="4">
+    <flag eulerdamp="disable"/>
+  </option>
+
+  <visual>
+    <map force="0.1" zfar="30"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global offwidth="2560" offheight="1440" elevation="-20" azimuth="120"/>
+  </visual>
+
+  <statistic center="0 0 0.7"/>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1=".3 .5 .7" rgb2="0 0 0" width="32" height="512"/>
+    <texture name="body" type="cube" builtin="flat" mark="cross" width="128" height="128" rgb1="0.8 0.6 0.4" rgb2="0.8 0.6 0.4" markrgb="1 1 1" random="0.01"/>
+    <material name="body" texture="body" texuniform="true" rgba="0.8 0.6 .4 1"/>
+    <texture name="grid" type="2d" builtin="checker" width="512" height="512" rgb1=".1 .2 .3" rgb2=".2 .3 .4"/>
+    <material name="grid" texture="grid" texrepeat="1 1" texuniform="true" reflectance=".2"/>
+  </asset>
+
+  <default>
+    <motor ctrlrange="-1 1" ctrllimited="true"/>
+    <default class="body">
+
+      <!-- geoms -->
+      <!-- TODO(robotics-simulation): support condim=1 for humanoid capsules. -->
+      <geom type="capsule" condim="3" friction=".7" solimp=".9 .99 .003" solref=".015 1" material="body" contype="0" conaffinity="0"/>
+      <default class="thigh">
+        <geom size=".06"/>
+      </default>
+      <default class="shin">
+        <geom fromto="0 0 0 0 0 -.3"  size=".049"/>
+      </default>
+      <default class="foot">
+        <geom size=".027"/>
+        <default class="foot1">
+          <geom fromto="-.07 -.01 0 .14 -.03 0"/>
+        </default>
+        <default class="foot2">
+          <geom fromto="-.07 .01 0 .14  .03 0"/>
+        </default>
+      </default>
+      <default class="arm_upper">
+        <geom size=".04"/>
+      </default>
+      <default class="arm_lower">
+        <geom size=".031"/>
+      </default>
+      <default class="hand">
+        <geom type="sphere" size=".04"/>
+      </default>
+
+      <!-- joints -->
+      <joint type="hinge" damping=".2" stiffness="1" armature=".01" limited="true" solimplimit="0 .99 .01"/>
+      <default class="joint_big">
+        <joint damping="5" stiffness="10"/>
+        <default class="hip_x">
+          <joint range="-30 10"/>
+        </default>
+        <default class="hip_z">
+          <joint range="-60 35"/>
+        </default>
+        <default class="hip_y">
+          <joint axis="0 1 0" range="-150 20"/>
+        </default>
+        <default class="joint_big_stiff">
+          <joint stiffness="20"/>
+        </default>
+      </default>
+      <default class="knee">
+        <joint pos="0 0 .02" axis="0 -1 0" range="-160 2"/>
+      </default>
+      <default class="ankle">
+        <joint range="-50 50"/>
+        <default class="ankle_y">
+          <joint pos="0 0 .08" axis="0 1 0" stiffness="6"/>
+        </default>
+        <default class="ankle_x">
+          <joint pos="0 0 .04" stiffness="3"/>
+        </default>
+      </default>
+      <default class="shoulder">
+        <joint range="-85 60"/>
+      </default>
+      <default class="elbow">
+        <joint range="-100 50" stiffness="0"/>
+      </default>
+    </default>
+  </default>
+
+  <worldbody>
+    <geom name="floor" size="0 0 .05" type="plane" material="grid" condim="3"/>
+    <light name="spotlight" mode="targetbodycom" target="torso" diffuse=".8 .8 .8" specular="0.3 0.3 0.3" pos="0 -6 4" cutoff="30"/>
+    <body name="torso" pos="0 0 1.282" childclass="body">
+      <light name="top" pos="0 0 2" mode="trackcom"/>
+      <camera name="back" pos="-3 0 1" xyaxes="0 -1 0 1 0 2" mode="trackcom"/>
+      <camera name="side" pos="0 -3 1" xyaxes="1 0 0 0 1 2" mode="trackcom"/>
+      <freejoint name="root"/>
+      <geom name="torso" fromto="0 -.07 0 0 .07 0" size=".07"/>
+      <geom name="waist_upper" fromto="-.01 -.06 -.12 -.01 .06 -.12" size=".06"/>
+      <body name="head" pos="0 0 .19">
+        <geom name="head" type="sphere" size=".09"/>
+        <camera name="egocentric" pos=".09 0 0" xyaxes="0 -1 0 .1 0 1" fovy="80"/>
+      </body>
+      <body name="waist_lower" pos="-.01 0 -.26">
+        <geom name="waist_lower" fromto="0 -.06 0 0 .06 0" size=".06"/>
+        <joint name="abdomen_z" pos="0 0 .065" axis="0 0 1" range="-45 45" class="joint_big_stiff"/>
+        <joint name="abdomen_y" pos="0 0 .065" axis="0 1 0" range="-75 30" class="joint_big"/>
+        <body name="pelvis" pos="0 0 -.165">
+          <joint name="abdomen_x" pos="0 0 .1" axis="1 0 0" range="-35 35" class="joint_big"/>
+          <geom name="butt" fromto="-.02 -.07 0 -.02 .07 0" size=".09"/>
+          <body name="thigh_right" pos="0 -.1 -.04">
+            <joint name="hip_x_right" axis="1 0 0" class="hip_x"/>
+            <joint name="hip_z_right" axis="0 0 1" class="hip_z"/>
+            <joint name="hip_y_right" class="hip_y"/>
+            <geom name="thigh_right" fromto="0 0 0 0 .01 -.34" class="thigh"/>
+            <body name="shin_right" pos="0 .01 -.4">
+              <joint name="knee_right" class="knee"/>
+              <geom name="shin_right" class="shin"/>
+              <body name="foot_right" pos="0 0 -.39">
+                <joint name="ankle_y_right" class="ankle_y"/>
+                <joint name="ankle_x_right" class="ankle_x" axis="1 0 .5"/>
+                <geom name="foot1_right" class="foot1"/>
+                <geom name="foot2_right" class="foot2"/>
+              </body>
+            </body>
+          </body>
+          <body name="thigh_left" pos="0 .1 -.04">
+            <joint name="hip_x_left" axis="-1 0 0" class="hip_x"/>
+            <joint name="hip_z_left" axis="0 0 -1" class="hip_z"/>
+            <joint name="hip_y_left" class="hip_y"/>
+            <geom name="thigh_left" fromto="0 0 0 0 -.01 -.34" class="thigh"/>
+            <body name="shin_left" pos="0 -.01 -.4">
+              <joint name="knee_left" class="knee"/>
+              <geom name="shin_left" fromto="0 0 0 0 0 -.3" class="shin"/>
+              <body name="foot_left" pos="0 0 -.39">
+                <joint name="ankle_y_left" class="ankle_y"/>
+                <joint name="ankle_x_left" class="ankle_x" axis="-1 0 -.5"/>
+                <geom name="foot1_left" class="foot1"/>
+                <geom name="foot2_left" class="foot2"/>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+      <body name="upper_arm_right" pos="0 -.17 .06">
+        <joint name="shoulder1_right" axis="2 1 1"  class="shoulder"/>
+        <joint name="shoulder2_right" axis="0 -1 1" class="shoulder"/>
+        <geom name="upper_arm_right" fromto="0 0 0 .16 -.16 -.16" class="arm_upper"/>
+        <body name="lower_arm_right" pos=".18 -.18 -.18">
+          <joint name="elbow_right" axis="0 -1 1" class="elbow"/>
+          <geom name="lower_arm_right" fromto=".01 .01 .01 .17 .17 .17" class="arm_lower"/>
+          <body name="hand_right" pos=".18 .18 .18">
+            <geom name="hand_right" zaxis="1 1 1" class="hand"/>
+          </body>
+        </body>
+      </body>
+      <body name="upper_arm_left" pos="0 .17 .06">
+        <joint name="shoulder1_left" axis="-2 1 -1" class="shoulder"/>
+        <joint name="shoulder2_left" axis="0 -1 -1"  class="shoulder"/>
+        <geom name="upper_arm_left" fromto="0 0 0 .16 .16 -.16" class="arm_upper"/>
+        <body name="lower_arm_left" pos=".18 .18 -.18">
+          <joint name="elbow_left" axis="0 -1 -1" class="elbow"/>
+          <geom name="lower_arm_left" fromto=".01 -.01 .01 .17 -.17 .17" class="arm_lower"/>
+          <body name="hand_left" pos=".18 -.18 .18">
+            <geom name="hand_left" zaxis="1 -1 1" class="hand"/>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+
+  <contact>
+    <exclude body1="waist_lower" body2="thigh_right"/>
+    <exclude body1="waist_lower" body2="thigh_left"/>
+    <pair geom1="foot1_left" geom2="floor"/>
+    <pair geom1="foot1_right" geom2="floor"/>
+    <pair geom1="foot2_left" geom2="floor"/>
+    <pair geom1="foot2_right" geom2="floor"/>
+  </contact>
+
+  <!-- <tendon>
+    <fixed name="hamstring_right" limited="true" range="-0.3 2">
+      <joint joint="hip_y_right" coef=".5"/>
+      <joint joint="knee_right" coef="-.5"/>
+    </fixed>
+    <fixed name="hamstring_left" limited="true" range="-0.3 2">
+      <joint joint="hip_y_left" coef=".5"/>
+      <joint joint="knee_left" coef="-.5"/>
+    </fixed>
+  </tendon> -->
+
+  <actuator>
+    <motor name="abdomen_y"       gear="40"  joint="abdomen_y"/>
+    <motor name="abdomen_z"       gear="40"  joint="abdomen_z"/>
+    <motor name="abdomen_x"       gear="40"  joint="abdomen_x"/>
+    <motor name="hip_x_right"     gear="40"  joint="hip_x_right"/>
+    <motor name="hip_z_right"     gear="40"  joint="hip_z_right"/>
+    <motor name="hip_y_right"     gear="120" joint="hip_y_right"/>
+    <motor name="knee_right"      gear="80"  joint="knee_right"/>
+    <motor name="ankle_x_right"   gear="20"  joint="ankle_x_right"/>
+    <motor name="ankle_y_right"   gear="20"  joint="ankle_y_right"/>
+    <motor name="hip_x_left"      gear="40"  joint="hip_x_left"/>
+    <motor name="hip_z_left"      gear="40"  joint="hip_z_left"/>
+    <motor name="hip_y_left"      gear="120" joint="hip_y_left"/>
+    <motor name="knee_left"       gear="80"  joint="knee_left"/>
+    <motor name="ankle_x_left"    gear="20"  joint="ankle_x_left"/>
+    <motor name="ankle_y_left"    gear="20"  joint="ankle_y_left"/>
+    <motor name="shoulder1_right" gear="20"  joint="shoulder1_right"/>
+    <motor name="shoulder2_right" gear="20"  joint="shoulder2_right"/>
+    <motor name="elbow_right"     gear="40"  joint="elbow_right"/>
+    <motor name="shoulder1_left"  gear="20"  joint="shoulder1_left"/>
+    <motor name="shoulder2_left"  gear="20"  joint="shoulder2_left"/>
+    <motor name="elbow_left"      gear="40"  joint="elbow_left"/>
+  </actuator>
+
+  <keyframe>
+    <!--
+    The values below are split into rows for readability:
+      torso position
+      torso orientation
+      spinal
+      right leg
+      left leg
+      arms
+    -->
+    <key name="squat" qpos="0 0 0.596
+                            0.988015 0 0.154359 0
+                            0 0.4 0
+                            -0.25 -0.5 -2.5 -2.65 -0.8 0.56
+                            -0.25 -0.5 -2.5 -2.65 -0.8 0.56
+                            0 0 0 0 0 0"/>
+    <key name="stand_on_left_leg" qpos="0 0 1.21948
+                                        0.971588 -0.179973 0.135318 -0.0729076
+                                        -0.0516 -0.202 0.23
+                                        -0.24 -0.007 -0.34 -1.76 -0.466 -0.0415
+                                        -0.08 -0.01 -0.37 -0.685 -0.35 -0.09
+                                        0.109 -0.067 -0.7 -0.05 0.12 0.16"/>
+    <key name="no_efc" qpos="0 0 2
+                             1 0 0 0
+                             0 0 0
+                             0 0 0 0 0 0
+                             0 0 0 0 0 0
+                             0 0 0 0 0 0"/>
+  </keyframe>
+</mujoco>

--- a/torchrl/envs/custom/mujoco/assets/satellite_large.xml
+++ b/torchrl/envs/custom/mujoco/assets/satellite_large.xml
@@ -1,0 +1,151 @@
+<!--
+  Large high-altitude satellite with 4 Control Moment Gyros (CMGs)
+  in a pyramid arrangement.
+
+  Bus: 500 kg box (1.0 x 1.0 x 0.5 m)
+  CMGs: 4 single-gimbal CMGs at skew angle beta = 54.73 deg (arctan(sqrt(2)))
+        arranged on the +X, +Y, -X, -Y faces of the bus.
+
+  Each CMG is a gimbal-rotor pair:
+    - Gimbal: hinge joint (actuated via velocity servo)
+    - Rotor:  hinge joint spinning about an axis perpendicular to the gimbal axis,
+              tilted at the pyramid skew angle from the bus Z axis.
+
+  The gyroscopic torque on the bus arises automatically from MuJoCo's
+  Coriolis/centrifugal terms c(q,v) when the gimbal tilts while the rotor spins.
+
+  sin(54.73 deg) ~ 0.8165,  cos(54.73 deg) ~ 0.5774
+-->
+<mujoco model="satellite_large">
+  <compiler angle="radian" autolimits="true"/>
+  <option gravity="0 0 0" timestep="0.001"/>
+
+  <default>
+    <joint damping="0.1" armature="0.01"/>
+    <geom contype="0" conaffinity="0"/>
+  </default>
+
+  <worldbody>
+    <light name="key" pos="3 -3 5" dir="-0.4 0.4 -0.7"
+           diffuse="0.9 0.9 0.9" ambient="0.3 0.3 0.3" directional="true"/>
+    <light name="fill" pos="-3 3 2" dir="0.4 -0.4 -0.3"
+           diffuse="0.4 0.4 0.5" directional="true"/>
+
+    <body name="satellite" pos="0 0 0">
+      <freejoint name="root"/>
+
+      <!-- Bus structure -->
+      <geom name="bus" type="box" size="0.5 0.5 0.25" mass="500"
+            rgba="0.85 0.75 0.4 1"/>
+
+      <!-- Solar panels -->
+      <geom name="panel_port" type="box" pos="0 -1.2 0"
+            size="0.4 0.6 0.01" mass="5" rgba="0.12 0.12 0.45 0.9"/>
+      <geom name="panel_starboard" type="box" pos="0 1.2 0"
+            size="0.4 0.6 0.01" mass="5" rgba="0.12 0.12 0.45 0.9"/>
+
+      <!-- Antenna mast -->
+      <geom name="antenna" type="cylinder" pos="0 0 0.35"
+            size="0.03 0.1" mass="1" rgba="0.7 0.7 0.7 1"/>
+      <geom name="antenna_dish" type="sphere" pos="0 0 0.48"
+            size="0.06" mass="0.5" rgba="0.9 0.9 0.9 1"/>
+
+      <!-- Solar-panel normal sensor (for sun-pointing reward) -->
+      <site name="solar_normal" pos="0 0 0.26" type="sphere" size="0.03"
+            rgba="1 1 0 1"/>
+
+      <!-- ============================================================
+           CMG 1  (+X face)
+           gimbal axis = (0, 1, 0)
+           rotor  axis = (0.8165, 0, 0.5774)
+           ============================================================ -->
+      <body name="cmg1_gimbal" pos="0.55 0 0">
+        <joint name="gimbal1" type="hinge" axis="0 1 0" damping="0.5"/>
+        <geom name="cmg1_bracket" type="box" size="0.04 0.06 0.06"
+              mass="1" rgba="0.5 0.5 0.5 1"/>
+        <body name="cmg1_rotor">
+          <joint name="rotor1" type="hinge" axis="0.8165 0 0.5774"/>
+          <geom name="cmg1_disk" type="cylinder"
+                fromto="-0.041 0 -0.029 0.041 0 0.029"
+                size="0.2" mass="10" rgba="0.8 0.8 0.9 1"/>
+          <geom name="cmg1_stripe" type="capsule"
+                fromto="0 -0.18 0 0 0.18 0"
+                size="0.012" mass="0.001" rgba="0.9 0.15 0.15 1"/>
+        </body>
+      </body>
+
+      <!-- ============================================================
+           CMG 2  (+Y face)
+           gimbal axis = (-1, 0, 0)
+           rotor  axis = (0, 0.8165, 0.5774)
+           ============================================================ -->
+      <body name="cmg2_gimbal" pos="0 0.55 0">
+        <joint name="gimbal2" type="hinge" axis="-1 0 0" damping="0.5"/>
+        <geom name="cmg2_bracket" type="box" size="0.06 0.04 0.06"
+              mass="1" rgba="0.5 0.5 0.5 1"/>
+        <body name="cmg2_rotor">
+          <joint name="rotor2" type="hinge" axis="0 0.8165 0.5774"/>
+          <geom name="cmg2_disk" type="cylinder"
+                fromto="0 -0.041 -0.029 0 0.041 0.029"
+                size="0.2" mass="10" rgba="0.8 0.8 0.9 1"/>
+          <geom name="cmg2_stripe" type="capsule"
+                fromto="-0.18 0 0 0.18 0 0"
+                size="0.012" mass="0.001" rgba="0.9 0.15 0.15 1"/>
+        </body>
+      </body>
+
+      <!-- ============================================================
+           CMG 3  (-X face)
+           gimbal axis = (0, -1, 0)
+           rotor  axis = (-0.8165, 0, 0.5774)
+           ============================================================ -->
+      <body name="cmg3_gimbal" pos="-0.55 0 0">
+        <joint name="gimbal3" type="hinge" axis="0 -1 0" damping="0.5"/>
+        <geom name="cmg3_bracket" type="box" size="0.04 0.06 0.06"
+              mass="1" rgba="0.5 0.5 0.5 1"/>
+        <body name="cmg3_rotor">
+          <joint name="rotor3" type="hinge" axis="-0.8165 0 0.5774"/>
+          <geom name="cmg3_disk" type="cylinder"
+                fromto="0.041 0 -0.029 -0.041 0 0.029"
+                size="0.2" mass="10" rgba="0.8 0.8 0.9 1"/>
+          <geom name="cmg3_stripe" type="capsule"
+                fromto="0 -0.18 0 0 0.18 0"
+                size="0.012" mass="0.001" rgba="0.9 0.15 0.15 1"/>
+        </body>
+      </body>
+
+      <!-- ============================================================
+           CMG 4  (-Y face)
+           gimbal axis = (1, 0, 0)
+           rotor  axis = (0, -0.8165, 0.5774)
+           ============================================================ -->
+      <body name="cmg4_gimbal" pos="0 -0.55 0">
+        <joint name="gimbal4" type="hinge" axis="1 0 0" damping="0.5"/>
+        <geom name="cmg4_bracket" type="box" size="0.06 0.04 0.06"
+              mass="1" rgba="0.5 0.5 0.5 1"/>
+        <body name="cmg4_rotor">
+          <joint name="rotor4" type="hinge" axis="0 -0.8165 0.5774"/>
+          <geom name="cmg4_disk" type="cylinder"
+                fromto="0 0.041 -0.029 0 -0.041 0.029"
+                size="0.2" mass="10" rgba="0.8 0.8 0.9 1"/>
+          <geom name="cmg4_stripe" type="capsule"
+                fromto="-0.18 0 0 0.18 0 0"
+                size="0.012" mass="0.001" rgba="0.9 0.15 0.15 1"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+
+  <actuator>
+    <!-- Gimbal rate servos (RL controls these) -->
+    <velocity name="gimbal1_act" joint="gimbal1" kv="100"/>
+    <velocity name="gimbal2_act" joint="gimbal2" kv="100"/>
+    <velocity name="gimbal3_act" joint="gimbal3" kv="100"/>
+    <velocity name="gimbal4_act" joint="gimbal4" kv="100"/>
+    <!-- Rotor spin servos (held at constant speed) -->
+    <velocity name="rotor1_act" joint="rotor1" kv="50"/>
+    <velocity name="rotor2_act" joint="rotor2" kv="50"/>
+    <velocity name="rotor3_act" joint="rotor3" kv="50"/>
+    <velocity name="rotor4_act" joint="rotor4" kv="50"/>
+  </actuator>
+</mujoco>

--- a/torchrl/envs/custom/mujoco/assets/satellite_small.xml
+++ b/torchrl/envs/custom/mujoco/assets/satellite_small.xml
@@ -1,0 +1,190 @@
+<!--
+  Small low-altitude satellite (CubeSat class) with 6 Control Moment Gyros.
+
+  Bus: 10 kg box (0.2 x 0.2 x 0.1 m, roughly 3U CubeSat form factor)
+  CMGs: 6 single-gimbal CMGs, one on each face of the bus.
+
+  The redundant arrangement (6 CMGs for 3 rotational DOF) provides a
+  3-dimensional null space that RL can exploit for singularity avoidance,
+  power minimisation, or wear levelling.
+
+  Each face carries one CMG whose gimbal and rotor axes are arranged
+  so that the six rotor spin axes uniformly cover all three principal
+  directions (two rotors per axis), giving isotropic torque authority:
+
+    Face  |  Gimbal axis  |  Rotor spin axis
+    ------+--------------+------------------
+    +X    |  (0, 1, 0)   |  (0, 0, 1)
+    -X    |  (0, 0, 1)   |  (0, 1, 0)
+    +Y    |  (0, 0, 1)   |  (1, 0, 0)
+    -Y    |  (1, 0, 0)   |  (0, 0, 1)
+    +Z    |  (1, 0, 0)   |  (0, 1, 0)
+    -Z    |  (0, 1, 0)   |  (1, 0, 0)
+-->
+<mujoco model="satellite_small">
+  <compiler angle="radian" autolimits="true"/>
+  <option gravity="0 0 0" timestep="0.001"/>
+
+  <default>
+    <joint damping="0.01" armature="0.001"/>
+    <geom contype="0" conaffinity="0"/>
+  </default>
+
+  <worldbody>
+    <light name="key" pos="1 -1 2" dir="-0.3 0.3 -0.7"
+           diffuse="0.9 0.9 0.9" ambient="0.35 0.35 0.35" directional="true"/>
+    <light name="fill" pos="-1 1 0.5" dir="0.4 -0.4 -0.2"
+           diffuse="0.4 0.4 0.5" directional="true"/>
+
+    <body name="smallsat" pos="0 0 0">
+      <freejoint name="root"/>
+
+      <!-- Bus -->
+      <geom name="bus" type="box" size="0.1 0.1 0.05" mass="10"
+            rgba="0.45 0.45 0.5 1"/>
+
+      <!-- Deployable solar panels -->
+      <geom name="panel_port" type="box" pos="0 -0.22 0"
+            size="0.06 0.1 0.002" mass="0.3" rgba="0.12 0.12 0.45 0.9"/>
+      <geom name="panel_starboard" type="box" pos="0 0.22 0"
+            size="0.06 0.1 0.002" mass="0.3" rgba="0.12 0.12 0.45 0.9"/>
+
+      <!-- Antenna -->
+      <geom name="antenna" type="cylinder" pos="0 0 0.065"
+            size="0.005 0.015" mass="0.05" rgba="0.7 0.7 0.7 1"/>
+
+      <!-- Solar-panel sensor site -->
+      <site name="solar_panel" pos="0 0 0.051" type="sphere" size="0.006"
+            rgba="1 1 0 1"/>
+
+      <!-- ============================================================
+           CMG 1  (+X face)
+           gimbal axis = (0, 1, 0),  rotor spin axis = (0, 0, 1)
+           ============================================================ -->
+      <body name="cmg1_gimbal" pos="0.115 0 0">
+        <joint name="gimbal1" type="hinge" axis="0 1 0" damping="0.05"/>
+        <geom name="cmg1_bracket" type="box" size="0.008 0.012 0.012"
+              mass="0.05" rgba="0.4 0.4 0.4 1"/>
+        <body name="cmg1_rotor">
+          <joint name="rotor1" type="hinge" axis="0 0 1"/>
+          <geom name="cmg1_disk" type="cylinder" size="0.025 0.004"
+                mass="0.2" rgba="0.3 0.5 0.85 1"/>
+          <geom name="cmg1_stripe" type="capsule"
+                fromto="-0.023 0 0 0.023 0 0"
+                size="0.003" mass="0.0001" rgba="0.9 0.15 0.15 1"/>
+        </body>
+      </body>
+
+      <!-- ============================================================
+           CMG 2  (-X face)
+           gimbal axis = (0, 0, 1),  rotor spin axis = (0, 1, 0)
+           ============================================================ -->
+      <body name="cmg2_gimbal" pos="-0.115 0 0">
+        <joint name="gimbal2" type="hinge" axis="0 0 1" damping="0.05"/>
+        <geom name="cmg2_bracket" type="box" size="0.008 0.012 0.012"
+              mass="0.05" rgba="0.4 0.4 0.4 1"/>
+        <body name="cmg2_rotor">
+          <joint name="rotor2" type="hinge" axis="0 1 0"/>
+          <geom name="cmg2_disk" type="cylinder"
+                fromto="0 -0.004 0 0 0.004 0" size="0.025"
+                mass="0.2" rgba="0.3 0.5 0.85 1"/>
+          <geom name="cmg2_stripe" type="capsule"
+                fromto="-0.023 0 0 0.023 0 0"
+                size="0.003" mass="0.0001" rgba="0.9 0.15 0.15 1"/>
+        </body>
+      </body>
+
+      <!-- ============================================================
+           CMG 3  (+Y face)
+           gimbal axis = (0, 0, 1),  rotor spin axis = (1, 0, 0)
+           ============================================================ -->
+      <body name="cmg3_gimbal" pos="0 0.115 0">
+        <joint name="gimbal3" type="hinge" axis="0 0 1" damping="0.05"/>
+        <geom name="cmg3_bracket" type="box" size="0.012 0.008 0.012"
+              mass="0.05" rgba="0.4 0.4 0.4 1"/>
+        <body name="cmg3_rotor">
+          <joint name="rotor3" type="hinge" axis="1 0 0"/>
+          <geom name="cmg3_disk" type="cylinder"
+                fromto="-0.004 0 0 0.004 0 0" size="0.025"
+                mass="0.2" rgba="0.3 0.5 0.85 1"/>
+          <geom name="cmg3_stripe" type="capsule"
+                fromto="0 -0.023 0 0 0.023 0"
+                size="0.003" mass="0.0001" rgba="0.9 0.15 0.15 1"/>
+        </body>
+      </body>
+
+      <!-- ============================================================
+           CMG 4  (-Y face)
+           gimbal axis = (1, 0, 0),  rotor spin axis = (0, 0, 1)
+           ============================================================ -->
+      <body name="cmg4_gimbal" pos="0 -0.115 0">
+        <joint name="gimbal4" type="hinge" axis="1 0 0" damping="0.05"/>
+        <geom name="cmg4_bracket" type="box" size="0.012 0.008 0.012"
+              mass="0.05" rgba="0.4 0.4 0.4 1"/>
+        <body name="cmg4_rotor">
+          <joint name="rotor4" type="hinge" axis="0 0 1"/>
+          <geom name="cmg4_disk" type="cylinder" size="0.025 0.004"
+                mass="0.2" rgba="0.3 0.5 0.85 1"/>
+          <geom name="cmg4_stripe" type="capsule"
+                fromto="-0.023 0 0 0.023 0 0"
+                size="0.003" mass="0.0001" rgba="0.9 0.15 0.15 1"/>
+        </body>
+      </body>
+
+      <!-- ============================================================
+           CMG 5  (+Z face)
+           gimbal axis = (1, 0, 0),  rotor spin axis = (0, 1, 0)
+           ============================================================ -->
+      <body name="cmg5_gimbal" pos="0 0 0.065">
+        <joint name="gimbal5" type="hinge" axis="1 0 0" damping="0.05"/>
+        <geom name="cmg5_bracket" type="box" size="0.012 0.012 0.008"
+              mass="0.05" rgba="0.4 0.4 0.4 1"/>
+        <body name="cmg5_rotor">
+          <joint name="rotor5" type="hinge" axis="0 1 0"/>
+          <geom name="cmg5_disk" type="cylinder"
+                fromto="0 -0.004 0 0 0.004 0" size="0.025"
+                mass="0.2" rgba="0.3 0.5 0.85 1"/>
+          <geom name="cmg5_stripe" type="capsule"
+                fromto="-0.023 0 0 0.023 0 0"
+                size="0.003" mass="0.0001" rgba="0.9 0.15 0.15 1"/>
+        </body>
+      </body>
+
+      <!-- ============================================================
+           CMG 6  (-Z face)
+           gimbal axis = (0, 1, 0),  rotor spin axis = (1, 0, 0)
+           ============================================================ -->
+      <body name="cmg6_gimbal" pos="0 0 -0.065">
+        <joint name="gimbal6" type="hinge" axis="0 1 0" damping="0.05"/>
+        <geom name="cmg6_bracket" type="box" size="0.012 0.012 0.008"
+              mass="0.05" rgba="0.4 0.4 0.4 1"/>
+        <body name="cmg6_rotor">
+          <joint name="rotor6" type="hinge" axis="1 0 0"/>
+          <geom name="cmg6_disk" type="cylinder"
+                fromto="-0.004 0 0 0.004 0 0" size="0.025"
+                mass="0.2" rgba="0.3 0.5 0.85 1"/>
+          <geom name="cmg6_stripe" type="capsule"
+                fromto="0 -0.023 0 0 0.023 0"
+                size="0.003" mass="0.0001" rgba="0.9 0.15 0.15 1"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+
+  <actuator>
+    <!-- Gimbal rate servos (RL controls these) -->
+    <velocity name="gimbal1_act" joint="gimbal1" kv="1"/>
+    <velocity name="gimbal2_act" joint="gimbal2" kv="1"/>
+    <velocity name="gimbal3_act" joint="gimbal3" kv="1"/>
+    <velocity name="gimbal4_act" joint="gimbal4" kv="1"/>
+    <velocity name="gimbal5_act" joint="gimbal5" kv="1"/>
+    <velocity name="gimbal6_act" joint="gimbal6" kv="1"/>
+    <!-- Rotor spin servos (held at constant speed) -->
+    <velocity name="rotor1_act" joint="rotor1" kv="0.5"/>
+    <velocity name="rotor2_act" joint="rotor2" kv="0.5"/>
+    <velocity name="rotor3_act" joint="rotor3" kv="0.5"/>
+    <velocity name="rotor4_act" joint="rotor4" kv="0.5"/>
+    <velocity name="rotor5_act" joint="rotor5" kv="0.5"/>
+    <velocity name="rotor6_act" joint="rotor6" kv="0.5"/>
+  </actuator>
+</mujoco>

--- a/torchrl/envs/custom/mujoco/assets/walker2d.xml
+++ b/torchrl/envs/custom/mujoco/assets/walker2d.xml
@@ -1,0 +1,68 @@
+<!--
+Walker2D model for `Walker2d-v5`, based on openai/gym/Walker2d
+modified by @kallinteris-Andreas
+  - To not require `coordinate="global"`
+  - keep feet friction to 0.9/1.9
+-->
+<mujoco model="walker2d">
+  <compiler angle="degree" inertiafromgeom="true"/>
+  <default>
+    <joint armature="0.01" damping=".1" limited="true"/>
+    <geom conaffinity="0" condim="3" contype="1" density="1000" friction=".7 .1 .1" rgba="0.8 0.6 .4 1"/>
+  </default>
+  <option integrator="RK4" timestep="0.002"/>
+  <worldbody>
+    <light cutoff="100" diffuse="1 1 1" dir="-0 0 -1.3" directional="true" exponent="1" pos="0 0 1.3" specular=".1 .1 .1"/>
+    <geom conaffinity="1" condim="3" name="floor" pos="0 0 0" rgba="0.8 0.9 0.8 1" size="40 40 40" type="plane" material="MatPlane"/>
+    <body name="torso" pos="0 0 1.25">
+      <camera name="track" mode="trackcom" pos="0 -3 -0.25" xyaxes="1 0 0 0 0 1"/>
+      <joint armature="0" axis="1 0 0" damping="0" limited="false" name="rootx" pos="0 0 -1.25" stiffness="0" type="slide"/>
+      <joint armature="0" axis="0 0 1" damping="0" limited="false" name="rootz" pos="0 0 -1.25" ref="1.25" stiffness="0" type="slide"/>
+      <joint armature="0" axis="0 1 0" damping="0" limited="false" name="rooty" pos="0 0 0" stiffness="0" type="hinge"/>
+      <geom friction="0.9" name="torso_geom" size="0.050000000000000003 0.19999999999999996" type="capsule"/>
+      <body name="thigh" pos="0 0 -0.19999999999999996">
+        <joint axis="0 -1 0" name="thigh_joint" pos="0 0 0" range="-150 0" type="hinge"/>
+        <geom friction="0.9" pos="0 0 -0.22500000000000009" name="thigh_geom" size="0.050000000000000003 0.22500000000000003" type="capsule"/>
+        <body name="leg" pos="0 0 -0.70000000000000007">
+          <joint axis="0 -1 0" name="leg_joint" pos="0 0 0.25" range="-150 0" type="hinge"/>
+          <geom friction="0.9" name="leg_geom" size="0.040000000000000001 0.25" type="capsule"/>
+          <body name="foot" pos="0.20000000000000001 0 -0.34999999999999998">
+            <joint axis="0 -1 0" name="foot_joint" pos="-0.20000000000000001 0 0.10000000000000001" range="-45 45" type="hinge"/>
+            <geom friction="0.9" pos="-0.10000000000000001 0 0.10000000000000001" quat="0.70710678118654757 0 -0.70710678118654746 0" name="foot_geom" size="0.059999999999999998 0.10000000000000001" type="capsule"/>
+          </body>
+        </body>
+      </body>
+      <!-- copied and then replace thigh->thigh_left, leg->leg_left, foot->foot_right -->
+      <body name="thigh_left" pos="0 0 -0.19999999999999996">
+        <joint axis="0 -1 0" name="thigh_left_joint" pos="0 0 0" range="-150 0" type="hinge"/>
+        <geom friction="0.9" name="thigh_left_geom" rgba=".7 .3 .6 1" size="0.050000000000000003 0.22500000000000003" pos="0 0 -0.22500000000000009" type="capsule"/>
+        <body name="leg_left" pos="0 0 -0.70000000000000007">
+          <joint axis="0 -1 0" name="leg_left_joint" pos="0 0 0.25" range="-150 0" type="hinge"/>
+          <geom friction="0.9" name="leg_left_geom" rgba=".7 .3 .6 1" size="0.040000000000000001 0.25" type="capsule"/>
+          <body name="foot_left" pos="0.20000000000000001 0 -0.34999999999999998">
+            <joint axis="0 -1 0" name="foot_left_joint" pos="-0.20000000000000001 0 0.10000000000000001" range="-45 45" type="hinge"/>
+            <geom friction="1.9" name="foot_left_geom" rgba=".7 .3 .6 1" size="0.059999999999999998 0.10000000000000001" pos="-0.10000000000000001 0 0.10000000000000001" type="capsule" quat="0.70710678118654757 0 -0.70710678118654746 0"/>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <!-- <motor joint="torso_joint" ctrlrange="-100.0 100.0" isctrllimited="true"/>-->
+    <motor ctrllimited="true" ctrlrange="-1.0 1.0" gear="100" joint="thigh_joint"/>
+    <motor ctrllimited="true" ctrlrange="-1.0 1.0" gear="100" joint="leg_joint"/>
+    <motor ctrllimited="true" ctrlrange="-1.0 1.0" gear="100" joint="foot_joint"/>
+    <motor ctrllimited="true" ctrlrange="-1.0 1.0" gear="100" joint="thigh_left_joint"/>
+    <motor ctrllimited="true" ctrlrange="-1.0 1.0" gear="100" joint="leg_left_joint"/>
+    <motor ctrllimited="true" ctrlrange="-1.0 1.0" gear="100" joint="foot_left_joint"/>
+    <!-- <motor joint="finger2_rot" ctrlrange="-20.0 20.0" isctrllimited="true"/>-->
+  </actuator>
+    <asset>
+        <texture type="skybox" builtin="gradient" rgb1=".4 .5 .6" rgb2="0 0 0"
+            width="100" height="100"/>
+        <texture builtin="flat" height="1278" mark="cross" markrgb="1 1 1" name="texgeom" random="0.01" rgb1="0.8 0.6 0.4" rgb2="0.8 0.6 0.4" type="cube" width="127"/>
+        <texture builtin="checker" height="100" name="texplane" rgb1="0 0 0" rgb2="0.8 0.8 0.8" type="2d" width="100"/>
+        <material name="MatPlane" reflectance="0.5" shininess="1" specular="1" texrepeat="60 60" texture="texplane"/>
+        <material name="geom" texture="texgeom" texuniform="true"/>
+    </asset>
+</mujoco>

--- a/torchrl/envs/custom/mujoco/base.py
+++ b/torchrl/envs/custom/mujoco/base.py
@@ -1,0 +1,584 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Base class for MuJoCo-backed custom envs with selectable physics backend.
+
+The core idea: subclasses describe the *task* (reward, termination,
+observation map) while the base class handles spec construction,
+step/reset plumbing, and dispatches the simulation to one of three
+backends (``mujoco-torch``, ``mjx``, ``mujoco``) -- see
+:mod:`torchrl.envs.custom.mujoco._backends`.
+"""
+
+from __future__ import annotations
+
+import abc
+import re
+from pathlib import Path
+from typing import ClassVar, Literal
+
+import torch
+from tensordict import TensorDict, TensorDictBase
+from torchrl.data.tensor_specs import Binary, Bounded, Composite, Unbounded
+from torchrl.envs.common import _EnvPostInit, EnvBase
+from torchrl.envs.custom.mujoco._backends import (
+    _PhysicsBackend,
+    BackendName,
+    make_backend,
+    resolve_xml_string,
+)
+
+_ASSETS_DIR = Path(__file__).parent / "assets"
+
+
+class _MujocoMeta(_EnvPostInit):
+    """Metaclass for :class:`MujocoEnv` that dispatches batching.
+
+    Backends ``"mujoco-torch"`` and ``"mjx"`` vmap natively over
+    ``num_envs``; passing ``num_workers > 1`` or ``parallel`` to those
+    backends raises ``ValueError``. Backend ``"mujoco"`` (single-env
+    C-bindings) is composed via :class:`~torchrl.envs.ParallelEnv` (when
+    ``parallel=True``, the default) or :class:`~torchrl.envs.SerialEnv`
+    (when ``parallel=False``) when ``num_workers > 1`` or ``num_envs >
+    1``. ``num_workers`` and ``num_envs`` are mutually exclusive aliases
+    for that backend.
+    """
+
+    def __call__(
+        cls,
+        *args,
+        num_workers: int = 1,
+        parallel: bool | None = None,
+        **kwargs,
+    ):
+        backend = kwargs.get("backend", "mujoco-torch")
+        num_envs = int(kwargs.get("num_envs", 1))
+        num_workers = int(num_workers)
+
+        if backend in ("mujoco-torch", "mjx"):
+            if num_workers > 1:
+                raise ValueError(
+                    f"backend={backend!r} batches via vmap; pass num_envs=N, "
+                    "not num_workers=N. (num_workers / parallel are only "
+                    "valid for backend='mujoco'.)"
+                )
+            if parallel is not None:
+                raise ValueError(
+                    f"backend={backend!r} only supports vmap-based batching; "
+                    "the `parallel` kwarg is only valid for backend='mujoco'."
+                )
+            return super().__call__(*args, **kwargs)
+
+        if backend == "mujoco":
+            if num_workers > 1 and num_envs > 1:
+                raise ValueError(
+                    "For backend='mujoco', set either num_envs or num_workers, "
+                    "not both -- they are aliases for the same N copies."
+                )
+            n = max(num_workers, num_envs)
+            if n > 1:
+                from torchrl.envs.batched_envs import ParallelEnv, SerialEnv
+
+                wrap_cls = SerialEnv if parallel is False else ParallelEnv
+                inner_kwargs = dict(kwargs)
+                inner_kwargs["num_envs"] = 1
+
+                def _factory(_args=args, _kwargs=inner_kwargs):
+                    # Re-enters this metaclass with N=1 -> falls through.
+                    return cls(*_args, **_kwargs)
+
+                return wrap_cls(n, _factory)
+            # Single env: pass through.
+            return super().__call__(*args, **kwargs)
+
+        raise ValueError(
+            f"unknown backend {backend!r}; expected one of "
+            "'mujoco-torch', 'mjx', 'mujoco'"
+        )
+
+
+class MujocoEnv(EnvBase, abc.ABC, metaclass=_MujocoMeta):
+    """Base TorchRL environment backed by a swappable MuJoCo physics engine.
+
+    Subclasses implement the task by overriding :meth:`_compute_reward` and
+    :meth:`_compute_done` (and optionally :meth:`_make_obs`,
+    :meth:`_make_obs_spec`, :meth:`_sample_initial_state`,
+    :meth:`_prepare_ctrl`, :meth:`_patch_xml`).
+
+    The XML asset is resolved in this order: explicit ``xml_path`` kwarg >
+    class attribute :attr:`XML_PATH` > class attribute :attr:`XML_URL`.
+    Either may be a local path or an ``http(s)`` URL -- URLs let users
+    point at remote assets we don't (or can't) vendor.
+
+    Args:
+        xml_path: optional override for the XML asset (path or URL).
+        backend: ``"mujoco-torch"`` (default), ``"mjx"``, or ``"mujoco"``.
+        num_envs: batch size; the env's ``batch_size`` is ``(num_envs,)``.
+        device: torch device for observations / rewards / actions.
+        seed: RNG seed for the reset noise distribution and any
+            subclass-defined randomization (e.g. random target attitudes).
+        frame_skip: physics substeps per agent action; defaults to
+            :attr:`FRAME_SKIP`.
+        reset_noise_scale: uniform noise added to ``qpos0`` and zero
+            ``qvel`` at reset; defaults to :attr:`RESET_NOISE_SCALE`.
+        max_episode_steps: per-env truncation horizon. The env emits
+            ``terminated`` (from :meth:`_compute_done`), ``truncated``
+            (``step_count >= max_episode_steps``), and ``done`` (the
+            OR of the two) as separate keys, matching the Gymnasium
+            convention.
+        dtype: floating-point dtype for action / observation / reward
+            tensors. Backend-internal dtype may differ.
+        compile_step: when ``backend="mujoco-torch"``, wrap the per-env
+            physics step in :func:`torch.compile`. Ignored otherwise.
+        compile_kwargs: forwarded to :func:`torch.compile` when applicable.
+
+    Example:
+        >>> from torchrl.envs import HumanoidEnv  # doctest: +SKIP
+        >>> env = HumanoidEnv(num_envs=4)         # doctest: +SKIP
+        >>> td = env.rollout(10)                  # doctest: +SKIP
+
+    See Also:
+        :class:`~torchrl.envs.custom.mujoco._backends._PhysicsBackend`.
+    """
+
+    XML_PATH: ClassVar[str | Path | None] = None
+    XML_URL: ClassVar[str | None] = None
+    FRAME_SKIP: ClassVar[int] = 5
+    RESET_NOISE_SCALE: ClassVar[float] = 0.01
+    SKIP_QPOS: ClassVar[int] = 0
+    """How many leading entries of ``qpos`` to drop in the default obs."""
+    RENDER_BACKGROUND: ClassVar[tuple[float, float, float] | None] = None
+    """Background color for the ``mujoco-torch`` ray-cast renderer.
+    Subclasses (e.g. satellite) override to a deep-space tone."""
+
+    metadata = {"render_modes": ["rgb_array"], "render_fps": 30}
+    batch_locked = True
+
+    def __init__(
+        self,
+        *,
+        xml_path: str | Path | None = None,
+        backend: Literal["mujoco-torch", "mjx", "mujoco"] = "mujoco-torch",
+        num_envs: int = 1,
+        device: torch.device | None = None,
+        seed: int | None = None,
+        frame_skip: int | None = None,
+        reset_noise_scale: float | None = None,
+        max_episode_steps: int = 1000,
+        dtype: torch.dtype = torch.float32,
+        compile_step: bool = False,
+        compile_kwargs: dict | None = None,
+        from_pixels: bool = False,
+        pixel_only: bool = False,
+        render_width: int = 64,
+        render_height: int = 64,
+        camera_id: int = 0,
+    ) -> None:
+        super().__init__(device=device, batch_size=torch.Size([num_envs]))
+        self.num_envs = num_envs
+        self.dtype = dtype
+        self.frame_skip = int(frame_skip if frame_skip is not None else self.FRAME_SKIP)
+        self.reset_noise_scale = float(
+            reset_noise_scale
+            if reset_noise_scale is not None
+            else self.RESET_NOISE_SCALE
+        )
+        self.max_episode_steps = int(max_episode_steps)
+        self.backend_name: BackendName = backend
+        self.from_pixels = bool(from_pixels)
+        self.pixel_only = bool(pixel_only)
+        if pixel_only and not from_pixels:
+            raise ValueError("pixel_only=True requires from_pixels=True.")
+        self.render_width = int(render_width)
+        self.render_height = int(render_height)
+        self.camera_id = int(camera_id)
+
+        xml_string = self._load_xml(xml_path)
+        self._backend: _PhysicsBackend = make_backend(
+            backend,
+            xml_string,
+            num_envs=num_envs,
+            device=self.device,
+            compile_step=compile_step,
+            compile_kwargs=compile_kwargs,
+        )
+
+        self.rng: torch.Generator | None = None
+        if seed is None:
+            seed = int(torch.empty((), dtype=torch.int64).random_().item())
+        self.set_seed(seed)
+        self._step_count = torch.zeros(num_envs, dtype=torch.long, device=self.device)
+        self._make_specs()
+
+    # ------------------------------------------------------------------
+    # XML resolution + patching
+    # ------------------------------------------------------------------
+
+    def _load_xml(self, xml_path: str | Path | None) -> str:
+        # An explicit ``xml_path=...`` is treated as a hard request: if
+        # it can't be resolved, surface the error rather than silently
+        # falling back to the class-level defaults. Subclass-level
+        # ``XML_PATH`` / ``XML_URL`` defaults *are* tried in order with
+        # the last failure preserved as ``__cause__``.
+        if xml_path is not None:
+            try:
+                return self._patch_xml(resolve_xml_string(xml_path))
+            except OSError as e:
+                raise FileNotFoundError(
+                    f"{type(self).__name__}: explicit xml_path={xml_path!r} "
+                    "could not be resolved."
+                ) from e
+
+        candidates: list[str | Path] = []
+        if self.XML_PATH is not None:
+            p = Path(self.XML_PATH)
+            if not p.is_absolute() and not str(p).startswith(("http://", "https://")):
+                p = _ASSETS_DIR / p
+            candidates.append(p)
+        if self.XML_URL is not None:
+            candidates.append(self.XML_URL)
+        if not candidates:
+            raise ValueError(
+                f"{type(self).__name__} requires an XML asset: pass `xml_path=...` "
+                "or set the `XML_PATH` / `XML_URL` class attribute."
+            )
+        last_exc: Exception | None = None
+        for cand in candidates:
+            try:
+                xml_string = resolve_xml_string(cand)
+                return self._patch_xml(xml_string)
+            except OSError as e:
+                last_exc = e
+        raise FileNotFoundError(
+            f"{type(self).__name__}: none of the XML candidates resolved: "
+            f"{candidates}"
+        ) from last_exc
+
+    @classmethod
+    def _patch_xml(cls, xml: str) -> str:
+        """Hook to mutate the XML string before parsing.
+
+        Default replaces all ``<camera>`` and ``<light>`` tags with a
+        single fixed-viewpoint setup and injects a ground plane if none
+        exists. Subclasses can override (e.g. the satellite env skips
+        the ground plane).
+        """
+        xml = re.sub(r"<camera\b[^/]*/>\s*", "", xml)
+        xml = re.sub(r"<light\b[^/]*/>\s*", "", xml)
+        camera = (
+            '<camera name="side" pos="0 -4 3" ' 'xyaxes="1 0 0 0 0.45 1" fovy="60"/>'
+        )
+        light = (
+            '<light name="top" pos="0 0 4" dir="0 0 -1" '
+            'diffuse="0.8 0.8 0.8" ambient="0.3 0.3 0.3" directional="true"/>'
+        )
+        floor = ""
+        if not re.search(r'<geom\b[^>]*type="plane"', xml):
+            floor = (
+                '\n  <geom name="floor" type="plane" size="10 10 0.1" '
+                'rgba="0.8 0.85 0.8 1" conaffinity="1" condim="3"/>'
+            )
+        return xml.replace("<worldbody>", f"<worldbody>\n  {camera}\n  {light}{floor}")
+
+    # ------------------------------------------------------------------
+    # Subclass interface
+    # ------------------------------------------------------------------
+
+    @abc.abstractmethod
+    def _compute_reward(
+        self,
+        state: TensorDictBase,
+        action: torch.Tensor,
+        next_state: TensorDictBase,
+    ) -> torch.Tensor:
+        """Per-env reward, shape ``(num_envs, 1)``, dtype :attr:`dtype`."""
+
+    @abc.abstractmethod
+    def _compute_done(
+        self,
+        state: TensorDictBase,
+        next_state: TensorDictBase,
+    ) -> torch.Tensor:
+        """Per-env termination flag, shape ``(num_envs, 1)``, dtype bool."""
+
+    def _make_obs(self, state: TensorDictBase) -> torch.Tensor:
+        """Default observation: ``cat(qpos[SKIP_QPOS:], qvel)``.
+
+        Override for richer observations. The shape produced here must
+        match :meth:`_make_obs_spec`.
+        """
+        qpos = state["qpos"].to(self.dtype)
+        qvel = state["qvel"].to(self.dtype)
+        return torch.cat([qpos[..., self.SKIP_QPOS :], qvel], dim=-1)
+
+    def _make_obs_spec(self) -> Composite:
+        """Default obs spec matching the default :meth:`_make_obs`."""
+        nq = self._backend.nq
+        nv = self._backend.nv
+        obs_dim = (nq - self.SKIP_QPOS) + nv
+        return Composite(
+            observation=Unbounded(
+                shape=(self.num_envs, obs_dim),
+                dtype=self.dtype,
+                device=self.device,
+            ),
+            shape=(self.num_envs,),
+            device=self.device,
+        )
+
+    def _pixels_spec(self) -> Bounded:
+        return Bounded(
+            low=0,
+            high=255,
+            shape=(self.num_envs, self.render_height, self.render_width, 3),
+            dtype=torch.uint8,
+            device=self.device,
+        )
+
+    def _sample_initial_state(
+        self,
+        n: int,
+        tensordict: TensorDictBase | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return ``(qpos, qvel)`` for ``n`` envs at reset.
+
+        Default: ``qpos0`` plus uniform noise on both ``qpos`` and
+        ``qvel``. Override to e.g. set fixed rotor speeds (satellite),
+        or to read user-supplied keys from ``tensordict`` (e.g. a fixed
+        starting attitude provided by a :class:`TensorDictPrimer`).
+
+        ``tensordict`` is the same object passed to :meth:`_reset` and
+        may carry extra keys like ``init_bus_quat`` etc. for environments
+        that support starting-state overrides.
+        """
+        backend = self._backend
+        qpos = backend.qpos0.unsqueeze(0).expand(n, -1).to(self.device).clone()
+        qvel = backend.qvel0.unsqueeze(0).expand(n, -1).to(self.device).clone()
+        if self.reset_noise_scale > 0:
+            noise_q = torch.empty_like(qpos).uniform_(
+                -self.reset_noise_scale, self.reset_noise_scale, generator=self.rng
+            )
+            noise_v = torch.empty_like(qvel).uniform_(
+                -self.reset_noise_scale, self.reset_noise_scale, generator=self.rng
+            )
+            qpos = qpos + noise_q
+            qvel = qvel + noise_v
+        return qpos, qvel
+
+    def _prepare_ctrl(self, action: torch.Tensor) -> torch.Tensor:
+        """Map the agent action onto the simulator ``ctrl`` vector.
+
+        Default: identity. Override for partial actuation (e.g. when the
+        agent controls a subset of actuators while others are held
+        constant -- satellite CMG rotors).
+        """
+        return action
+
+    # ------------------------------------------------------------------
+    # Spec construction
+    # ------------------------------------------------------------------
+
+    def _build_obs_dict(self, state: TensorDictBase) -> dict[str, torch.Tensor]:
+        """Assemble the obs dict, including ``pixels`` when ``from_pixels``."""
+        out: dict[str, torch.Tensor] = {}
+        if not self.pixel_only:
+            out["observation"] = self._make_obs(state)
+        if self.from_pixels:
+            out["pixels"] = self._backend.render(
+                camera_id=self.camera_id,
+                width=self.render_width,
+                height=self.render_height,
+                background=self.RENDER_BACKGROUND,
+            )
+        return out
+
+    def _make_specs(self) -> None:
+        backend = self._backend
+        obs_spec = self._make_obs_spec()
+        if self.from_pixels:
+            if self.pixel_only:
+                obs_spec = Composite(
+                    pixels=self._pixels_spec(),
+                    shape=(self.num_envs,),
+                    device=self.device,
+                )
+            else:
+                obs_spec["pixels"] = self._pixels_spec()
+        self.observation_spec = obs_spec
+        # Action spec from actuator_ctrlrange (clamp infinities to a sane
+        # default for unbounded actuators).
+        lo = backend.actuator_lo.to(self.dtype).to(self.device)
+        hi = backend.actuator_hi.to(self.dtype).to(self.device)
+        # Mujoco emits 0/0 for limit-less actuators -- treat as +/-inf.
+        unlimited = (lo == 0) & (hi == 0)
+        lo = torch.where(unlimited, torch.full_like(lo, -1.0), lo)
+        hi = torch.where(unlimited, torch.full_like(hi, 1.0), hi)
+        # Broadcast over batch.
+        lo_b = lo.unsqueeze(0).expand(self.num_envs, -1).clone()
+        hi_b = hi.unsqueeze(0).expand(self.num_envs, -1).clone()
+        self.action_spec = Bounded(
+            low=lo_b,
+            high=hi_b,
+            shape=(self.num_envs, backend.nu),
+            dtype=self.dtype,
+            device=self.device,
+        )
+        self.reward_spec = Unbounded(
+            shape=(self.num_envs, 1), dtype=self.dtype, device=self.device
+        )
+        # Emit ``terminated`` (subclass-driven) and ``truncated``
+        # (max_episode_steps-driven) as first-class keys so downstream
+        # consumers (collectors, GAE) can tell the two apart instead of
+        # only seeing the OR'd ``done`` flag.
+        done_shape = (self.num_envs, 1)
+        self.full_done_spec = Composite(
+            done=Binary(n=1, shape=done_shape, dtype=torch.bool, device=self.device),
+            terminated=Binary(
+                n=1, shape=done_shape, dtype=torch.bool, device=self.device
+            ),
+            truncated=Binary(
+                n=1, shape=done_shape, dtype=torch.bool, device=self.device
+            ),
+            shape=(self.num_envs,),
+            device=self.device,
+        )
+
+    # ------------------------------------------------------------------
+    # State helpers
+    # ------------------------------------------------------------------
+
+    def _state_td(self) -> TensorDict:
+        """Snapshot of the backend state as a TensorDict.
+
+        Keys: ``qpos`` ``(num_envs, nq)``, ``qvel`` ``(num_envs, nv)``,
+        ``time`` ``(num_envs,)``. Backend-internal dtype is preserved;
+        cast inside :meth:`_make_obs` / :meth:`_compute_reward` if needed.
+        """
+        return TensorDict(
+            {
+                "qpos": self._backend.qpos,
+                "qvel": self._backend.qvel,
+                "time": self._backend.time,
+            },
+            batch_size=(self.num_envs,),
+            device=self.device,
+        )
+
+    # ------------------------------------------------------------------
+    # EnvBase interface
+    # ------------------------------------------------------------------
+
+    def _reset(self, tensordict: TensorDictBase | None = None, **kwargs):
+        reset_mask = None
+        if tensordict is not None and "_reset" in tensordict.keys():
+            reset_mask = tensordict["_reset"]
+            if reset_mask.ndim > 1:
+                reset_mask = reset_mask.squeeze(-1)
+
+        # Always sample full-batch (num_envs, *) initial states; the
+        # backend's ``reset_mask`` muxes the masked rows internally with
+        # ``torch.where`` so this path is free of data-dependent shapes
+        # (no ``.item()`` syncs, friendly to ``torch.compile``).
+        qpos, qvel = self._sample_initial_state(self.num_envs, tensordict)
+        if reset_mask is None:
+            self._backend.reset(qpos, qvel)
+            self._step_count.zero_()
+            self._on_reset_all(tensordict)
+        else:
+            self._backend.reset_mask(reset_mask, qpos, qvel)
+            self._step_count = torch.where(
+                reset_mask, torch.zeros_like(self._step_count), self._step_count
+            )
+            self._on_reset_mask(reset_mask, tensordict)
+
+        state = self._state_td()
+        obs = self._build_obs_dict(state)
+        zero_flag = torch.zeros(self.num_envs, 1, dtype=torch.bool, device=self.device)
+        out = TensorDict(
+            {
+                **obs,
+                "done": zero_flag.clone(),
+                "terminated": zero_flag.clone(),
+                "truncated": zero_flag,
+            },
+            batch_size=(self.num_envs,),
+            device=self.device,
+        )
+        return out
+
+    def _on_reset_all(self, tensordict: TensorDictBase | None = None) -> None:
+        """Hook called after a full backend reset.
+
+        Override for per-episode randomization that lives outside the
+        simulator (e.g. sample a new target attitude). ``tensordict`` is
+        the same object passed to :meth:`_reset`.
+        """
+
+    def _on_reset_mask(
+        self,
+        mask: torch.Tensor,
+        tensordict: TensorDictBase | None = None,
+    ) -> None:
+        """Hook for partial reset.
+
+        Override alongside :meth:`_on_reset_all`. ``tensordict`` is the
+        same object passed to :meth:`_reset`.
+        """
+
+    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
+        action = tensordict["action"].to(self.dtype)
+        ctrl = self._prepare_ctrl(action)
+
+        state = self._state_td()
+        self._backend.step(ctrl, self.frame_skip)
+        next_state = self._state_td()
+        self._step_count += 1
+
+        reward = self._compute_reward(state, action, next_state).to(self.dtype)
+        if reward.ndim == 1:
+            reward = reward.unsqueeze(-1)
+        terminated = self._compute_done(state, next_state).to(torch.bool)
+        if terminated.ndim == 1:
+            terminated = terminated.unsqueeze(-1)
+        truncated = (self._step_count >= self.max_episode_steps).unsqueeze(-1)
+        done = terminated | truncated
+
+        obs = self._build_obs_dict(next_state)
+        return TensorDict(
+            {
+                **obs,
+                "reward": reward,
+                "done": done,
+                "terminated": terminated,
+                "truncated": truncated,
+            },
+            batch_size=(self.num_envs,),
+            device=self.device,
+        )
+
+    def _set_seed(self, seed: int | None) -> None:
+        if seed is None:
+            return
+        rng = torch.Generator(device=self.device)
+        rng.manual_seed(int(seed))
+        self.rng = rng
+
+    def render(
+        self,
+        *,
+        width: int | None = None,
+        height: int | None = None,
+        camera_id: int | None = None,
+    ) -> torch.Tensor:
+        """Render every env to an ``(num_envs, H, W, 3)`` ``uint8`` tensor.
+
+        Pulls dimensions from the constructor kwargs by default; pass
+        explicit values to render at a different resolution.
+        """
+        return self._backend.render(
+            camera_id=self.camera_id if camera_id is None else int(camera_id),
+            width=self.render_width if width is None else int(width),
+            height=self.render_height if height is None else int(height),
+            background=self.RENDER_BACKGROUND,
+        )

--- a/torchrl/envs/custom/mujoco/hopper.py
+++ b/torchrl/envs/custom/mujoco/hopper.py
@@ -1,0 +1,61 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Hopper-v4 single-leg locomotion env."""
+
+from __future__ import annotations
+
+import torch
+from tensordict import TensorDictBase
+from torchrl.envs.custom.mujoco.base import MujocoEnv
+
+
+class HopperEnv(MujocoEnv):
+    """Single-legged hopping task (6-DoF, 3 actuators).
+
+    Args: see :class:`~torchrl.envs.custom.mujoco.MujocoEnv`.
+
+    Example:
+        >>> from torchrl.envs import HopperEnv  # doctest: +SKIP
+        >>> env = HopperEnv(num_envs=4)         # doctest: +SKIP
+        >>> td = env.rollout(10)                # doctest: +SKIP
+    """
+
+    XML_PATH = "hopper.xml"
+    FRAME_SKIP = 5
+    SKIP_QPOS = 1
+    HEALTHY_Z_MIN = 0.7
+    HEALTHY_ANGLE_MAX = 0.2
+    HEALTHY_REWARD = 1.0
+    CTRL_COST_WEIGHT = 1e-3
+
+    def _make_obs(self, state: TensorDictBase) -> torch.Tensor:
+        qpos = state["qpos"].to(self.dtype)
+        qvel = state["qvel"].to(self.dtype).clamp(-10.0, 10.0)
+        return torch.cat([qpos[..., self.SKIP_QPOS :], qvel], dim=-1)
+
+    def _is_healthy(self, qpos: torch.Tensor) -> torch.Tensor:
+        z = qpos[..., 1]
+        angle = qpos[..., 2]
+        return (z >= self.HEALTHY_Z_MIN) & (angle.abs() <= self.HEALTHY_ANGLE_MAX)
+
+    def _compute_reward(
+        self,
+        state: TensorDictBase,
+        action: torch.Tensor,
+        next_state: TensorDictBase,
+    ) -> torch.Tensor:
+        dt = self._backend.timestep * self.frame_skip
+        forward_vel = (next_state["qpos"][..., 0] - state["qpos"][..., 0]) / dt
+        ctrl_cost = self.CTRL_COST_WEIGHT * (action.to(self.dtype) ** 2).sum(dim=-1)
+        healthy = self._is_healthy(next_state["qpos"]).to(self.dtype)
+        reward = forward_vel.to(self.dtype) + self.HEALTHY_REWARD * healthy - ctrl_cost
+        return reward.unsqueeze(-1)
+
+    def _compute_done(
+        self,
+        state: TensorDictBase,
+        next_state: TensorDictBase,
+    ) -> torch.Tensor:
+        return (~self._is_healthy(next_state["qpos"])).unsqueeze(-1)

--- a/torchrl/envs/custom/mujoco/humanoid.py
+++ b/torchrl/envs/custom/mujoco/humanoid.py
@@ -1,0 +1,68 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Humanoid-v4 locomotion env, matching the Gymnasium task spec."""
+
+from __future__ import annotations
+
+import torch
+from tensordict import TensorDictBase
+from torchrl.envs.custom.mujoco.base import MujocoEnv
+
+
+class HumanoidEnv(MujocoEnv):
+    """Bipedal humanoid locomotion task (28 DoF, 21 actuators).
+
+    Reward is forward x-velocity plus a healthy bonus minus a control
+    cost. Termination occurs when the torso z-height leaves
+    ``[HEALTHY_Z_LOW, HEALTHY_Z_HIGH]``.
+
+    Args: see :class:`~torchrl.envs.custom.mujoco.MujocoEnv`.
+
+    Example:
+        >>> from torchrl.envs import HumanoidEnv  # doctest: +SKIP
+        >>> env = HumanoidEnv(num_envs=4)         # doctest: +SKIP
+        >>> td = env.rollout(10)                  # doctest: +SKIP
+
+    Reference:
+        Tassa et al., "Synthesis and Stabilization of Complex Behaviors
+        through Online Trajectory Optimization", IROS 2012.
+    """
+
+    XML_PATH = "humanoid.xml"
+    FRAME_SKIP = 5
+    SKIP_QPOS = 2
+    HEALTHY_Z_LOW = 1.0
+    HEALTHY_Z_HIGH = 2.0
+    HEALTHY_REWARD = 5.0
+    CTRL_COST_WEIGHT = 0.1
+
+    def _make_obs(self, state: TensorDictBase) -> torch.Tensor:
+        qpos = state["qpos"].to(self.dtype)
+        qvel = state["qvel"].to(self.dtype).clamp(-10.0, 10.0)
+        return torch.cat([qpos[..., self.SKIP_QPOS :], qvel], dim=-1)
+
+    def _is_healthy(self, qpos: torch.Tensor) -> torch.Tensor:
+        z = qpos[..., 2]
+        return (z >= self.HEALTHY_Z_LOW) & (z <= self.HEALTHY_Z_HIGH)
+
+    def _compute_reward(
+        self,
+        state: TensorDictBase,
+        action: torch.Tensor,
+        next_state: TensorDictBase,
+    ) -> torch.Tensor:
+        dt = self._backend.timestep * self.frame_skip
+        forward_vel = (next_state["qpos"][..., 0] - state["qpos"][..., 0]) / dt
+        ctrl_cost = self.CTRL_COST_WEIGHT * (action.to(self.dtype) ** 2).sum(dim=-1)
+        healthy = self._is_healthy(next_state["qpos"]).to(self.dtype)
+        reward = forward_vel.to(self.dtype) + self.HEALTHY_REWARD * healthy - ctrl_cost
+        return reward.unsqueeze(-1)
+
+    def _compute_done(
+        self,
+        state: TensorDictBase,
+        next_state: TensorDictBase,
+    ) -> torch.Tensor:
+        return (~self._is_healthy(next_state["qpos"])).unsqueeze(-1)

--- a/torchrl/envs/custom/mujoco/satellite.py
+++ b/torchrl/envs/custom/mujoco/satellite.py
@@ -1,0 +1,481 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Satellite attitude-control task with Control Moment Gyros (CMGs).
+
+The agent commands gimbal rates of either 4 (pyramid) or 6 (orthogonal)
+CMGs to slew the satellite to a target attitude sampled uniformly on
+``SO(3)`` at reset, while *avoiding internal singularities* of the CMG
+cluster. The singularity penalty uses the manipulability metric of the
+gimbal Jacobian: ``m(J) = sqrt(det(J J^T) + eps)``.
+
+Reward
+    ``r = - ||q_err|| - lambda_s / m(J) - lambda_u * ||a||^2``
+
+Termination
+    Never (the satellite cannot crash). Use a
+    :class:`~torchrl.envs.transforms.TimeLimit` transform for truncation.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Literal
+
+import torch
+from tensordict import TensorDictBase
+from torchrl._utils import is_compiling
+from torchrl.data.tensor_specs import Bounded, Composite, Unbounded
+from torchrl.envs.custom.mujoco._math import (
+    cmg_jacobian,
+    manipulability,
+    orthogonal_6cmg_geometry,
+    pyramid_4cmg_geometry,
+    quat_conj,
+    quat_log,
+    quat_mul,
+    random_unit_quat,
+)
+from torchrl.envs.custom.mujoco.base import MujocoEnv
+
+
+class SatelliteEnv(MujocoEnv):
+    r"""Attitude-control task with 4 or 6 CMGs.
+
+    Args:
+        num_cmgs: ``4`` (pyramid) or ``6`` (orthogonal cluster).
+        attitude_weight: weight on ``-||q_err||``. Default ``1.0``.
+        singularity_weight: weight on ``-1 / m_norm(J)`` where
+            ``m_norm(J) = m(J) / rotor_h^3``. The normalization makes
+            the metric rotor-speed invariant; default ``0.5`` so the
+            penalty is comparable in magnitude to the attitude term
+            for near-singular postures and effectively zero for the
+            nominal cluster.
+        ctrl_cost_weight: weight on ``||a||^2``. Default ``0.01``.
+        omega_weight: weight on ``-||bus_omega||^2``. Penalizes body
+            angular velocity so the policy is incentivised to *stop*
+            at the target attitude rather than swing through it.
+            Default ``0.1``: with omega magnitudes around 1 rad/s
+            during a slew this contributes ``~-0.1`` per step,
+            comparable to the singularity term.
+        action_scale: rescaling factor applied inside
+            :meth:`_prepare_ctrl`: the agent emits actions in
+            ``[-1, 1]`` and the simulator sees a commanded gimbal
+            rate of ``action_scale * action`` rad/s. Default ``3.0``,
+            chosen to keep saturated 180-deg slews physically
+            reachable inside ~1500-step episodes.
+        rotor_h: scalar rotor angular momentum used in the Jacobian.
+            Defaults to :attr:`ROTOR_SPEED` (proxy unit, since the
+            absolute scale only changes the singularity threshold).
+        \*\*kwargs: forwarded to :class:`MujocoEnv`.
+
+    Example:
+        >>> from torchrl.envs import SatelliteEnv  # doctest: +SKIP
+        >>> env = SatelliteEnv(num_cmgs=4, num_envs=4)  # doctest: +SKIP
+        >>> td = env.rollout(50)  # doctest: +SKIP
+
+    Reference:
+        Wie, Bong (2008). "Space Vehicle Dynamics and Control" --
+        chapter on CMG steering laws and singularity escape.
+    """
+
+    FRAME_SKIP = 10
+    RESET_NOISE_SCALE = 0.001
+    ROTOR_SPEED_4 = 100.0
+    ROTOR_SPEED_6 = 200.0
+    RENDER_BACKGROUND = (0.0, 0.0, 0.05)
+
+    def __init__(
+        self,
+        *,
+        num_cmgs: Literal[4, 6] = 4,
+        attitude_weight: float = 1.0,
+        singularity_weight: float = 0.5,
+        singularity_clamp_min: float = 1e-6,
+        singularity_mode: Literal["inverse", "exp"] = "inverse",
+        singularity_exp_k: float = 5.0,
+        ctrl_cost_weight: float = 0.01,
+        omega_weight: float = 0.1,
+        action_scale: float = 3.0,
+        rotor_h: float | None = None,
+        **kwargs,
+    ) -> None:
+        if num_cmgs == 4:
+            self.N_GIMBALS = 4
+            self.ROTOR_SPEED = self.ROTOR_SPEED_4
+            self.XML_PATH = "satellite_large.xml"
+        elif num_cmgs == 6:
+            self.N_GIMBALS = 6
+            self.ROTOR_SPEED = self.ROTOR_SPEED_6
+            self.XML_PATH = "satellite_small.xml"
+        else:
+            raise ValueError(f"num_cmgs must be 4 or 6, got {num_cmgs}")
+        self.num_cmgs = num_cmgs
+        self.attitude_weight = float(attitude_weight)
+        self.singularity_weight = float(singularity_weight)
+        self.singularity_clamp_min = float(singularity_clamp_min)
+        self.singularity_mode = str(singularity_mode)
+        self.singularity_exp_k = float(singularity_exp_k)
+        self.ctrl_cost_weight = float(ctrl_cost_weight)
+        self.omega_weight = float(omega_weight)
+        self.action_scale = float(action_scale)
+        self._rotor_h = float(rotor_h) if rotor_h is not None else self.ROTOR_SPEED
+
+        super().__init__(**kwargs)
+
+        # CMG geometry, cached on the env's device / dtype.
+        if num_cmgs == 4:
+            g, r0 = pyramid_4cmg_geometry(device=self.device, dtype=self.dtype)
+        else:
+            g, r0 = orthogonal_6cmg_geometry(device=self.device, dtype=self.dtype)
+        self._gimbal_axes = g
+        self._rotor_axes_ref = r0
+
+        # Per-env target attitude, populated on reset.
+        self._target_quat = torch.zeros(
+            self.num_envs, 4, device=self.device, dtype=self.dtype
+        )
+        self._target_quat[:, 0] = 1.0
+
+        # Cached per-step manipulability so the obs builder can surface
+        # it without recomputing the Jacobian. Filled by
+        # :meth:`_compute_reward`; on the first reset, defaults to a
+        # large value (a non-singular nominal posture).
+        self._last_manip = torch.full(
+            (self.num_envs, 1), 1.0, device=self.device, dtype=self.dtype
+        )
+
+        # Per-step ``isfinite`` checks are off by default. They force a
+        # CUDA -> CPU sync on each call (via ``bool(all_finite)``), which
+        # under hot-path collection erodes throughput. Set
+        # ``TORCHRL_SATELLITE_DEBUG=1`` (or pass ``debug_finite=True`` to
+        # the constructor) to re-enable them; the test suite uses this
+        # to validate reward guards without changing default semantics.
+        env_flag = os.environ.get("TORCHRL_SATELLITE_DEBUG", "0")
+        self._debug_finite = env_flag not in ("0", "", "false", "False")
+
+    def _assert_finite(self, name: str, value: torch.Tensor) -> None:
+        if is_compiling():
+            # ``torch._assert`` is a compile-time hint; cheap inside a
+            # compiled graph and skipped at runtime entirely.
+            torch._assert(
+                torch.isfinite(value).all(),
+                f"SatelliteEnv produced non-finite values in {name}.",
+            )
+            return
+        if not self._debug_finite:
+            # Default eager path: no host-device sync, no overhead.
+            return
+        finite = torch.isfinite(value)
+        if bool(finite.all()):
+            return
+
+        bad = ~finite
+        nan_count = torch.isnan(value).sum().item()
+        inf_count = torch.isinf(value).sum().item()
+        if value.ndim > 0 and value.shape[0] == self.num_envs:
+            bad_rows = bad.reshape(self.num_envs, -1).any(dim=-1).nonzero().flatten()
+            row_list = bad_rows[:8].detach().cpu().tolist()
+            sample = value.index_select(0, bad_rows[:3]).detach().cpu()
+        else:
+            row_list = []
+            sample = value[bad][:8].detach().cpu()
+        raise RuntimeError(
+            f"SatelliteEnv produced non-finite values in {name}: "
+            f"nan_count={nan_count}, inf_count={inf_count}, "
+            f"bad_rows={row_list}, sample={sample}."
+        )
+
+    # ------------------------------------------------------------------
+    # XML patching: no ground floor in space.
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _patch_xml(cls, xml: str) -> str:
+        xml = re.sub(r"<camera\b[^/]*/>\s*", "", xml)
+        xml = re.sub(r"<light\b[^/]*/>\s*", "", xml)
+        camera = (
+            '<camera name="side" pos="3 -3 2" '
+            'xyaxes="0.707 0.707 0 -0.302 0.302 0.905" fovy="60"/>'
+        )
+        light = (
+            '<light name="top" pos="0 0 4" dir="0 0 -1" '
+            'diffuse="0.8 0.8 0.8" ambient="0.3 0.3 0.3" directional="true"/>'
+        )
+        return xml.replace("<worldbody>", f"<worldbody>\n  {camera}\n  {light}")
+
+    # ------------------------------------------------------------------
+    # Specs
+    # ------------------------------------------------------------------
+
+    def _make_obs_spec(self) -> Composite:
+        # Semantically-split observation: the dynamics-relevant pieces
+        # are exposed as separate keys so downstream transforms (e.g.
+        # :class:`CatTensors`) can recombine them while keeping
+        # ``manipulability`` available for logging without feeding it
+        # into the policy.
+        n = self.N_GIMBALS
+        return Composite(
+            quat_err=Unbounded(
+                shape=(self.num_envs, 3), dtype=self.dtype, device=self.device
+            ),
+            bus_omega=Unbounded(
+                shape=(self.num_envs, 3), dtype=self.dtype, device=self.device
+            ),
+            gimbal_angles=Unbounded(
+                shape=(self.num_envs, 2 * n), dtype=self.dtype, device=self.device
+            ),
+            gimbal_rates=Unbounded(
+                shape=(self.num_envs, n), dtype=self.dtype, device=self.device
+            ),
+            manipulability=Unbounded(
+                shape=(self.num_envs, 1), dtype=self.dtype, device=self.device
+            ),
+            shape=(self.num_envs,),
+            device=self.device,
+        )
+
+    def _make_specs(self) -> None:
+        super()._make_specs()
+        # Override the action spec: agent controls only gimbals, not rotors.
+        self.action_spec = Bounded(
+            low=-1.0,
+            high=1.0,
+            shape=(self.num_envs, self.N_GIMBALS),
+            dtype=self.dtype,
+            device=self.device,
+        )
+
+    # ------------------------------------------------------------------
+    # State plumbing
+    # ------------------------------------------------------------------
+
+    def _sample_initial_state(
+        self,
+        n: int,
+        tensordict: TensorDictBase | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        qpos, qvel = super()._sample_initial_state(n, tensordict)
+        # Pin rotor velocities (qvel layout: [bus_lin(3), bus_ang(3),
+        # then per-CMG (gimbal_rate, rotor_rate) pairs]).
+        rotor_vel_idx = [6 + 2 * i + 1 for i in range(self.N_GIMBALS)]
+        qvel[..., rotor_vel_idx] = self.ROTOR_SPEED
+        # Optional starting attitude override -- when present in the
+        # input tensordict, write into ``qpos[..., 3:7]`` (the bus
+        # quaternion) so the simulator boots at the requested attitude.
+        # The caller is expected to pass a full-batch ``(num_envs, 4)``
+        # quaternion; the backend's ``reset_mask`` picks the rows it
+        # actually resets, so we can write through without masking.
+        if tensordict is not None and "init_bus_quat" in tensordict.keys():
+            init_q = tensordict.get("init_bus_quat").to(qpos.dtype).to(qpos.device)
+            init_q = init_q / init_q.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+            qpos[..., 3:7] = init_q
+        return qpos, qvel
+
+    def _prepare_ctrl(self, action: torch.Tensor) -> torch.Tensor:
+        # Scale the agent's [-1, 1] command up to ``[-action_scale,
+        # action_scale]`` rad/s of gimbal rate. With the velocity
+        # actuators in the XML, the saturation cap on commanded rate
+        # is the dominant control-authority knob, so leaving it at 1
+        # rad/s makes 180-deg slews infeasible in any reasonable
+        # horizon. Keep the policy's action range at [-1, 1] (clean
+        # for ``TanhNormal``) and absorb the scaling here.
+        scaled = action * self.action_scale
+        rotor_ctrl = torch.full(
+            (scaled.shape[0], self.N_GIMBALS),
+            self.ROTOR_SPEED,
+            dtype=scaled.dtype,
+            device=scaled.device,
+        )
+        return torch.cat([scaled, rotor_ctrl], dim=-1)
+
+    def _on_reset_all(self, tensordict: TensorDictBase | None = None) -> None:
+        if tensordict is not None and "target_quat" in tensordict.keys():
+            t = tensordict.get("target_quat").to(self.dtype).to(self.device)
+            self._target_quat = t / t.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+        else:
+            self._target_quat = random_unit_quat(
+                (self.num_envs,),
+                generator=self.rng,
+                device=self.device,
+                dtype=self.dtype,
+            )
+        # Manipulability is only computed inside :meth:`_compute_reward`.
+        # Reset the cache to a non-singular default so the first obs
+        # after reset is well-defined.
+        self._last_manip = self._compute_manip_from_qpos(
+            self._backend.qpos.to(self.dtype)
+        )
+
+    def _on_reset_mask(
+        self,
+        mask: torch.Tensor,
+        tensordict: TensorDictBase | None = None,
+    ) -> None:
+        # Build a full-batch target_quat candidate (either the user-
+        # supplied override or a freshly-sampled one) and mux only the
+        # masked rows in via ``torch.where``. Keeps the path free of
+        # data-dependent shape ops (no ``mask.sum().item()`` sync, no
+        # boolean indexing).
+        if tensordict is not None and "target_quat" in tensordict.keys():
+            t = tensordict.get("target_quat").to(self.dtype).to(self.device)
+            t = t / t.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+        else:
+            t = random_unit_quat(
+                (self.num_envs,),
+                generator=self.rng,
+                device=self.device,
+                dtype=self.dtype,
+            )
+        m = mask.unsqueeze(-1)
+        self._target_quat = torch.where(m, t, self._target_quat)
+        new_manip = self._compute_manip_from_qpos(self._backend.qpos.to(self.dtype))
+        self._last_manip = torch.where(m, new_manip, self._last_manip)
+
+    # ------------------------------------------------------------------
+    # Observation, reward, done
+    # ------------------------------------------------------------------
+
+    def _attitude_error(self, qpos: torch.Tensor) -> torch.Tensor:
+        bus_quat = qpos[..., 3:7].to(self.dtype)
+        # q_err such that target = current * q_err  =>  q_err = current^-1 * target
+        q_err = quat_mul(quat_conj(bus_quat), self._target_quat)
+        return quat_log(q_err)  # (B, 3)
+
+    def _compute_manip_from_qpos(self, qpos: torch.Tensor) -> torch.Tensor:
+        """Compute the per-env manipulability from a ``qpos`` snapshot.
+
+        Returns shape ``(num_envs, 1)``. Used to refresh
+        :attr:`_last_manip` on reset and inside :meth:`_compute_reward`.
+        """
+        gimbal_idx = [7 + 2 * i for i in range(self.N_GIMBALS)]
+        gimbal_angles = qpos[..., gimbal_idx]
+        jac = cmg_jacobian(
+            gimbal_angles, self._gimbal_axes, self._rotor_axes_ref, self._rotor_h
+        )
+        self._assert_finite("reset/qpos", qpos)
+        self._assert_finite("reset/gimbal_angles", gimbal_angles)
+        self._assert_finite("reset/cmg_jacobian", jac)
+        manip = manipulability(jac)
+        self._assert_finite("reset/manipulability", manip)
+        return manip.unsqueeze(-1)
+
+    def _make_obs_split(self, state: TensorDictBase) -> dict[str, torch.Tensor]:
+        """Return the observation as a dict of named sub-keys.
+
+        Replaces the legacy single-tensor ``_make_obs``. Downstream
+        :class:`CatTensors` transforms can recombine the dynamics-relevant
+        keys into a single observation while keeping ``manipulability``
+        separate for logging.
+        """
+        qpos = state["qpos"].to(self.dtype)
+        qvel = state["qvel"].to(self.dtype)
+        n = self.N_GIMBALS
+        gimbal_idx = [7 + 2 * i for i in range(n)]
+        gimbal_rate_idx = [6 + 2 * i for i in range(n)]
+        return {
+            "quat_err": self._attitude_error(qpos),
+            "bus_omega": qvel[..., 3:6].clone(),
+            "gimbal_angles": torch.cat(
+                [qpos[..., gimbal_idx].sin(), qpos[..., gimbal_idx].cos()],
+                dim=-1,
+            ),
+            "gimbal_rates": qvel[..., gimbal_rate_idx].clone(),
+            "manipulability": self._last_manip,
+        }
+
+    def _build_obs_dict(self, state: TensorDictBase) -> dict[str, torch.Tensor]:
+        out: dict[str, torch.Tensor] = {}
+        if not self.pixel_only:
+            out.update(self._make_obs_split(state))
+        if self.from_pixels:
+            out["pixels"] = self._backend.render(
+                camera_id=self.camera_id,
+                width=self.render_width,
+                height=self.render_height,
+                background=self.RENDER_BACKGROUND,
+            )
+        return out
+
+    def _compute_reward(
+        self,
+        state: TensorDictBase,
+        action: torch.Tensor,
+        next_state: TensorDictBase,
+    ) -> torch.Tensor:
+        qpos = next_state["qpos"].to(self.dtype)
+        gimbal_idx = [7 + 2 * i for i in range(self.N_GIMBALS)]
+        gimbal_angles = qpos[..., gimbal_idx]
+
+        self._assert_finite("reward/qpos", qpos)
+        self._assert_finite("reward/action", action)
+        self._assert_finite("reward/target_quat", self._target_quat)
+        quat_err = self._attitude_error(qpos)
+        self._assert_finite("reward/quat_err", quat_err)
+        att_err = quat_err.norm(dim=-1)
+        self._assert_finite("reward/attitude_error", att_err)
+        jac = cmg_jacobian(
+            gimbal_angles, self._gimbal_axes, self._rotor_axes_ref, self._rotor_h
+        )
+        self._assert_finite("reward/gimbal_angles", gimbal_angles)
+        self._assert_finite("reward/cmg_jacobian", jac)
+        jjt = jac @ jac.transpose(-1, -2)
+        self._assert_finite("reward/cmg_jacobian_jjt", jjt)
+        det = torch.linalg.det(jjt)
+        self._assert_finite("reward/cmg_jacobian_det", det)
+        manip = torch.sqrt(det.clamp_min(0.0) + 1e-8)
+        self._assert_finite("reward/manipulability", manip)
+        # Normalize manipulability by ``rotor_h ** 3`` so the metric
+        # is rotor-speed invariant. ``det(J J^T) ~ h^6`` scales with
+        # the rotor angular momentum, so without this rescaling the
+        # 1/manip penalty is ~5e-8 per step at ``rotor_h=100`` and
+        # never trains the avoid-singularity half of the task. After
+        # rescaling, ``manip_norm`` lives in ``[0, ~1]`` and the
+        # default ``singularity_weight=0.5`` yields ~0.5 / O(1) ≈ 0.5
+        # contribution on the nominal cluster, growing as the cluster
+        # approaches a singular configuration.
+        manip_norm = manip / (self._rotor_h**3)
+        # Cache the *unnormalized* metric for the obs (so logging
+        # remains physically interpretable across rotor speeds), but
+        # use the normalized one for the penalty.
+        self._last_manip = manip.unsqueeze(-1)
+        ctrl_cost = (action.to(self.dtype) ** 2).sum(dim=-1)
+        self._assert_finite("reward/control_cost", ctrl_cost)
+        # Body-rate penalty -- the slew-and-stop incentive. Without
+        # this, the optimal "swing through the target" policy is
+        # locally rewarded as much as the proper "settle at the
+        # target" one, because attitude error alone is zero at the
+        # crossing instant.
+        qvel = next_state["qvel"].to(self.dtype)
+        bus_omega = qvel[..., 3:6]
+        omega_cost = (bus_omega**2).sum(dim=-1)
+        self._assert_finite("reward/omega_cost", omega_cost)
+        if self.singularity_mode == "exp":
+            # Bounded smooth penalty: ``w * exp(-k * manip_norm)`` saturates
+            # at ``-w`` near the singularity instead of diverging via 1/0.
+            sing_penalty = self.singularity_weight * torch.exp(
+                -self.singularity_exp_k * manip_norm
+            )
+        else:  # "inverse"
+            sing_penalty = self.singularity_weight / manip_norm.clamp_min(
+                self.singularity_clamp_min
+            )
+        reward = (
+            -self.attitude_weight * att_err
+            - sing_penalty
+            - self.ctrl_cost_weight * ctrl_cost
+            - self.omega_weight * omega_cost
+        )
+        self._assert_finite("reward/total", reward)
+        reward = reward.unsqueeze(-1)
+        self._assert_finite("reward/total_unsqueezed", reward)
+        return reward
+
+    def _compute_done(
+        self,
+        state: TensorDictBase,
+        next_state: TensorDictBase,
+    ) -> torch.Tensor:
+        return torch.zeros(self.num_envs, 1, dtype=torch.bool, device=self.device)

--- a/torchrl/envs/custom/mujoco/walker.py
+++ b/torchrl/envs/custom/mujoco/walker.py
@@ -1,0 +1,66 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Walker2d-v4 bipedal locomotion env."""
+
+from __future__ import annotations
+
+import torch
+from tensordict import TensorDictBase
+from torchrl.envs.custom.mujoco.base import MujocoEnv
+
+
+class Walker2dEnv(MujocoEnv):
+    """Planar bipedal walker (9-DoF, 6 actuators).
+
+    Args: see :class:`~torchrl.envs.custom.mujoco.MujocoEnv`.
+
+    Example:
+        >>> from torchrl.envs import Walker2dEnv  # doctest: +SKIP
+        >>> env = Walker2dEnv(num_envs=4)         # doctest: +SKIP
+        >>> td = env.rollout(10)                  # doctest: +SKIP
+    """
+
+    XML_PATH = "walker2d.xml"
+    FRAME_SKIP = 5
+    SKIP_QPOS = 1
+    HEALTHY_Z_LOW = 0.8
+    HEALTHY_Z_HIGH = 2.0
+    HEALTHY_ANGLE_MAX = 1.0
+    HEALTHY_REWARD = 1.0
+    CTRL_COST_WEIGHT = 1e-3
+
+    def _make_obs(self, state: TensorDictBase) -> torch.Tensor:
+        qpos = state["qpos"].to(self.dtype)
+        qvel = state["qvel"].to(self.dtype).clamp(-10.0, 10.0)
+        return torch.cat([qpos[..., self.SKIP_QPOS :], qvel], dim=-1)
+
+    def _is_healthy(self, qpos: torch.Tensor) -> torch.Tensor:
+        z = qpos[..., 1]
+        angle = qpos[..., 2]
+        return (
+            (z >= self.HEALTHY_Z_LOW)
+            & (z <= self.HEALTHY_Z_HIGH)
+            & (angle.abs() <= self.HEALTHY_ANGLE_MAX)
+        )
+
+    def _compute_reward(
+        self,
+        state: TensorDictBase,
+        action: torch.Tensor,
+        next_state: TensorDictBase,
+    ) -> torch.Tensor:
+        dt = self._backend.timestep * self.frame_skip
+        forward_vel = (next_state["qpos"][..., 0] - state["qpos"][..., 0]) / dt
+        ctrl_cost = self.CTRL_COST_WEIGHT * (action.to(self.dtype) ** 2).sum(dim=-1)
+        healthy = self._is_healthy(next_state["qpos"]).to(self.dtype)
+        reward = forward_vel.to(self.dtype) + self.HEALTHY_REWARD * healthy - ctrl_cost
+        return reward.unsqueeze(-1)
+
+    def _compute_done(
+        self,
+        state: TensorDictBase,
+        next_state: TensorDictBase,
+    ) -> torch.Tensor:
+        return (~self._is_healthy(next_state["qpos"])).unsqueeze(-1)


### PR DESCRIPTION
## Summary

- Adds `torchrl/envs/custom/mujoco/` -- a base `MujocoEnv(EnvBase, abc.ABC)` plus 5 task subclasses (`HumanoidEnv`, `AntEnv`, `Walker2dEnv`, `HopperEnv`, `SatelliteEnv`).
- Three swappable physics backends behind one kwarg: `mujoco-torch` (default; native torch + vmap, `torch.compile`-friendly), `mjx` (JAX-vmap+jit, DLPack-bridged), `mujoco` (C-bindings, single-env, composed via `ParallelEnv`/`SerialEnv` through a metaclass).
- Rendering supported on every backend: `from_pixels=True` / `pixel_only` / `render_width` / `render_height` / `camera_id`. Torch backend uses mujoco-torch's pure-torch ray-cast renderer; mjx/mujoco use `mujoco.Renderer`.

## Design

```
MujocoEnv(EnvBase, abc.ABC, metaclass=_MujocoMeta)
  - abstract _compute_reward / _compute_done
  - default _make_obs (cat(qpos[skip:], qvel)); subclasses override for richer obs
  - xml_path kwarg accepts local path *or* http(s) URL (no need to vendor)
  - _MujocoMeta dispatches batching:
      mujoco-torch / mjx: num_envs=N (vmap). num_workers / parallel raise.
      mujoco:             num_envs and num_workers are aliases (mutually exclusive);
                          parallel=True -> ParallelEnv (default), False -> SerialEnv.

_PhysicsBackend
  - reset(qpos, qvel) / reset_mask / step(ctrl, frame_skip)
  - qpos / qvel / time properties
  - render(camera_id, width, height, background) -> (B, H, W, 3) uint8
  - _TorchBackend, _MJXBackend, _MujocoBackend
```

The satellite task uses a manipulability-based singularity penalty (`r = -|q_err| - lambda_s/sqrt(det(J J^T) + eps) - lambda_u * |a|^2`) over a 4-CMG pyramid (skew = arctan(sqrt(2))) or a 6-CMG orthogonal cluster -- both hardcoded in `_math.py`. Target attitude is sampled uniformly on `SO(3)` at reset via Marsaglia's method.

## XML assets

Bundled under `torchrl/envs/custom/mujoco/assets/` with a NOTICE preserving the upstream Apache-2.0 attribution (DeepMind / mujoco-torch). Subclasses can also point at remote URLs to avoid re-vendoring.

## Tests

`test/libs/test_mujoco.py` -- parametrized tests covering specs, rollouts, dispatch validation, satellite finite-reward over 50 steps, custom XML loading, and `from_pixels`/`pixel_only`/`render()` across all available backends. Skipped cleanly when a backend isn't installed.

## CI

Dedicated path-triggered workflow `.github/workflows/test-linux-mujoco.yml` (mirrors `test-linux-libs.yml`'s brax pattern) with scripts under `.github/unittest/linux_libs/scripts_mujoco/`. Pinned versions:
- `mujoco==3.7.0`, `mujoco-mjx==3.7.0` (3.8.0 removed `mjENBL_MULTICCD` referenced by mujoco-torch 0.2.0)
- `mujoco-torch==0.2.0`
- `jax[cuda12]>=0.7.0,<0.11`

## Test plan

- [ ] `pytest test/libs/test_mujoco.py -v` -- pending rerun after splitting the satellite examples into #3802 (previous local run: 58 passed on macOS before the split)
- [x] `pytest test/test_custom_envs.py -v` -- 8 passed (no regression on pre-existing custom envs)
- [x] `check_env_specs` passes for every (env class, backend) pair
- [x] Satellite singularity term remains finite over 50-step random rollouts (4 and 6 CMGs)
- [x] `compile_step=True` smoke runs on `mujoco-torch` backend
- [x] `from_pixels=True` produces `uint8` `(B, H, W, 3)` tensors with non-trivial RGB content on all three backends
- [ ] Dedicated CI workflow lights up on this PR



