### PR TITLE
[BugFix] Check agent presence before updating action mask in PettingZoo

### DIFF
--- a/torchrl/envs/libs/pettingzoo.py
+++ b/torchrl/envs/libs/pettingzoo.py
@@ -804,6 +804,8 @@ class PettingZooWrapper(_EnvWrapper):
                 group_mask = td.get((group, "action_mask"))
                 group_mask += True
                 for index, agent in enumerate(agents):
+                    if agent not in observation_dict or agent not in info_dict:
+                        continue
                     agent_obs = observation_dict[agent]
                     agent_info = info_dict[agent]
                     if isinstance(agent_obs, dict) and "action_mask" in agent_obs:


### PR DESCRIPTION


## Description

This PR fixes a case an error in the PettingZoo adapter where, in cases of a `ParallelEnv`, with action masking and `done_on_any=False`, a `KeyError` can occur. This happens because there is no check on active agents before values are pulled from the observation dictionary. PettingZoo expects that the observation dictionary only contains entries for active agents.

## Motivation and Context

PettingZoo expects that agents are removed from observations if inactive, so the `torchrl` should handle that situation. It's worth noting that I implemented a simple check before trying to index the dictionary, but another viable fix would be repositioning the existing  check `if agent in agents_acting:` to an earlier location in the execution path as well.

This is a PR to address #3702.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*). - I don't think a new test is required for this minimal change.
- [ ] I have updated the documentation accordingly.
