### PR TITLE
[Feature] Forward generator kwarg through ProbabilisticActor

### DIFF
--- a/test/test_actors.py
+++ b/test/test_actors.py
@@ -162,6 +162,105 @@ def test_probabilistic_actor_nested_normal(log_prob_key, nested_dim=5, n_actions
         assert td_out["data", "action_log_prob"].shape == (5,)
 
 
+class TestProbabilisticActorGenerator:
+    """Tests for the ``generator`` kwarg on ``ProbabilisticActor``.
+
+    The actual sampling logic lives in ``tensordict.nn`` and is exhaustively tested there;
+    these tests just verify the kwarg threads through ``ProbabilisticActor`` →
+    ``SafeProbabilisticModule`` → ``ProbabilisticTensorDictModule``.
+    """
+
+    @staticmethod
+    def _make_actor(generator=None):
+        module = TensorDictModule(
+            lambda x: (x, torch.ones_like(x)),
+            in_keys=["obs"],
+            out_keys=["loc", "scale"],
+        )
+        return ProbabilisticActor(
+            module=module,
+            in_keys=["loc", "scale"],
+            out_keys=["action"],
+            distribution_class=dist.Normal,
+            default_interaction_type="random",
+            generator=generator,
+        )
+
+    def test_generator_object(self):
+        """Two same-seeded Generators must produce identical actions."""
+        a1 = self._make_actor(torch.Generator().manual_seed(0))
+        a2 = self._make_actor(torch.Generator().manual_seed(0))
+        # Set the global RNG to a different state to make sure it's not consulted.
+        torch.manual_seed(999)
+        s1 = a1(TensorDict(obs=torch.zeros(4)))["action"].clone()
+        s2 = a2(TensorDict(obs=torch.zeros(4)))["action"].clone()
+        assert torch.equal(s1, s2)
+
+    def test_generator_int_seed(self):
+        """Module-level int is shorthand for ``Generator().manual_seed(int)``."""
+        a_int = self._make_actor(generator=0)
+        a_gen = self._make_actor(generator=torch.Generator().manual_seed(0))
+        s_int = a_int(TensorDict(obs=torch.zeros(4)))["action"].clone()
+        s_gen = a_gen(TensorDict(obs=torch.zeros(4)))["action"].clone()
+        assert torch.equal(s_int, s_gen)
+
+    def test_generator_isolates_global_rng(self):
+        """Sampling with a generator must not advance the global RNG."""
+        a = self._make_actor(torch.Generator().manual_seed(0))
+        torch.manual_seed(1234)
+        before = torch.get_rng_state()
+        a(TensorDict(obs=torch.zeros(4)))
+        after = torch.get_rng_state()
+        assert torch.equal(before, after)
+
+    def test_generator_advances_in_place(self):
+        a = self._make_actor(torch.Generator().manual_seed(0))
+        s1 = a(TensorDict(obs=torch.zeros(4)))["action"].clone()
+        s2 = a(TensorDict(obs=torch.zeros(4)))["action"].clone()
+        assert not torch.equal(s1, s2)
+
+    def test_generator_td_key_int_writeback(self):
+        """Int seed in the input tensordict is treated as a stream-key (JAX-style)."""
+        from tensordict import NonTensorData
+
+        a = self._make_actor(generator="rng")
+
+        def run(seed, n_steps):
+            td = TensorDict(obs=torch.zeros(4))
+            td["rng"] = NonTensorData(seed)
+            samples = []
+            for _ in range(n_steps):
+                samples.append(a(td)["action"].clone())
+            return samples
+
+        traj_a = run(42, 3)
+        traj_b = run(42, 3)
+        for x, y in zip(traj_a, traj_b):
+            assert torch.equal(x, y)
+        assert not torch.equal(traj_a[0], traj_a[1])
+
+    def test_generator_td_key_generator_form(self):
+        """A Generator placed in the input tensordict is used in place."""
+        from tensordict import NonTensorData
+
+        a = self._make_actor(generator="rng")
+        td = TensorDict(obs=torch.zeros(4))
+        td["rng"] = NonTensorData(torch.Generator().manual_seed(0))
+        s_key = a(td)["action"].clone()
+        a_ref = self._make_actor(torch.Generator().manual_seed(0))
+        s_ref = a_ref(TensorDict(obs=torch.zeros(4)))["action"].clone()
+        assert torch.equal(s_key, s_ref)
+
+    def test_generator_default_unchanged(self):
+        """generator=None preserves existing global-RNG behaviour."""
+        a = self._make_actor(generator=None)
+        torch.manual_seed(0)
+        s1 = a(TensorDict(obs=torch.zeros(4)))["action"].clone()
+        torch.manual_seed(0)
+        s2 = a(TensorDict(obs=torch.zeros(4)))["action"].clone()
+        assert torch.equal(s1, s2)
+
+
 class TestQValue:
     def test_qvalue_hook_wrong_action_space(self):
         with pytest.raises(

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -220,6 +220,17 @@ class ProbabilisticActor(SafeProbabilisticTensorDictSequential):
         n_empirical_estimate (int, optional): keyword-only argument.
             Number of samples to compute the empirical
             mean when it is not available. Defaults to 1000.
+        generator (torch.Generator, int, NestedKey, or None, optional): keyword-only argument.
+            Routes sampling through an explicit RNG instead of the global PyTorch RNG.
+            Accepts a :class:`torch.Generator` (used in place, advances across calls),
+            an :class:`int` (shorthand for ``Generator().manual_seed(int)``), or a
+            :class:`NestedKey` to fetch the generator from the input tensordict on every
+            call (the value can be a ``Generator`` or a scalar int / Tensor used as a
+            JAX-style stream-key with a ``next_seed`` written back). Defaults to ``None``,
+            in which case the global RNG is used. Useful when the agent's RNG stream must
+            be isolated from the environment's — see Patterson et al.,
+            "Empirical Design in Reinforcement Learning" (`arXiv:2304.01315
+            <https://arxiv.org/abs/2304.01315>`_).
 
     Examples:
         >>> import torch

--- a/torchrl/modules/tensordict_module/probabilistic.py
+++ b/torchrl/modules/tensordict_module/probabilistic.py
@@ -145,6 +145,15 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule):
         n_empirical_estimate (int, optional): keyword-only argument.
             Number of samples to compute the empirical
             mean when it is not available. Defaults to 1000.
+        generator (torch.Generator, int, NestedKey, or None, optional): keyword-only argument.
+            Routes sampling through an explicit RNG instead of the global PyTorch RNG.
+            Accepts a :class:`torch.Generator` (used in place, advances across calls),
+            an :class:`int` (shorthand for ``Generator().manual_seed(int)``), or a
+            :class:`NestedKey` to fetch the generator from the input tensordict on every
+            call (the value can be a ``Generator`` or a scalar int / Tensor used as a
+            JAX-style stream-key with a ``next_seed`` written back). Defaults to ``None``,
+            in which case the global RNG is used. See
+            :class:`~tensordict.nn.ProbabilisticTensorDictModule` for details.
 
     .. warning:: Running checks takes time! Using `safe=True` will guarantee that the samples are within the spec bounds
         given some heuristic coded in :meth:`~torchrl.data.TensorSpec.project`, but that requires checking whether the
@@ -197,6 +206,7 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule):
         cache_dist: bool = False,
         n_empirical_estimate: int = 1000,
         num_samples: int | torch.Size | None = None,
+        generator: torch.Generator | int | NestedKey | None = None,
     ):
         super().__init__(
             in_keys=in_keys,
@@ -210,6 +220,7 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule):
             log_prob_keys=log_prob_keys,
             log_prob_key=log_prob_key,
             num_samples=num_samples,
+            generator=generator,
         )
         if spec is not None:
             spec = spec.clone()


### PR DESCRIPTION
## Summary

Follow-up to [pytorch/tensordict#1689](https://github.com/pytorch/tensordict/pull/1689), which added a ``generator`` kwarg to ``ProbabilisticTensorDictModule``. That PR shipped the actual sampling implementation; this PR is the thin pass-through layer needed in TorchRL so that ``ProbabilisticActor(..., generator=...)`` actually works.

Without this change, the kwarg flows from ``ProbabilisticActor`` into ``SafeProbabilisticModule`` via ``**kwargs`` and is rejected, because ``SafeProbabilisticModule.__init__`` enumerates its kwargs explicitly and forwards them by name to ``ProbabilisticTensorDictModule``.

Closes the action item from the discussion in [pytorch/rl#3701](https://github.com/pytorch/rl/discussions/3701) — separating an agent's RNG stream from its environment's, motivated by Patterson et al., *Empirical Design in Reinforcement Learning* ([arXiv:2304.01315](https://arxiv.org/abs/2304.01315)).

## Change

- ``SafeProbabilisticModule.__init__`` (`torchrl/modules/tensordict_module/probabilistic.py`): adds the ``generator`` kwarg and forwards it to ``super().__init__``. Adds a docstring entry.
- ``ProbabilisticActor`` (`torchrl/modules/tensordict_module/actors.py`): adds a docstring entry. ``**kwargs`` already forwards ``generator``, so no signature change is needed.
- New ``TestProbabilisticActorGenerator`` in ``test/test_actors.py`` with 7 tests covering Generator object, int seed, isolation from ``torch.manual_seed``, in-place advancement, tensordict-key form (Generator and int / JAX-PRNG variants), and the default (``generator=None``) path.

## Test plan

- [x] ``pytest test/test_actors.py::TestProbabilisticActorGenerator -q`` — 7 passed
- [x] ``pytest test/test_actors.py -k 'probabilistic or Probabilistic or Prob' -q`` — 15 passed (the 7 new + 8 existing)
- [ ] Lands after pytorch/tensordict#1689 is in a tagged release / pinned in CI