### PR TITLE
[CI] Fix benchmark workflows

### DIFF
--- a/.github/scripts/comment_pr_benchmarks.py
+++ b/.github/scripts/comment_pr_benchmarks.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from pathlib import Path
+from urllib import request
+
+
+COMMENT_MARKER = "<!-- torchrl-pr-benchmark-comment -->"
+MAX_COMMENT_LENGTH = 60000
+
+
+def _load_json(path: Path) -> dict:
+    with path.open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+def _benchmark_name(benchmark: dict) -> str:
+    return benchmark.get("fullname") or benchmark.get("name") or "<unknown>"
+
+
+def _benchmark_ops(benchmark: dict) -> float | None:
+    stats = benchmark.get("stats", {})
+    ops = stats.get("ops")
+    if ops is not None:
+        return float(ops)
+    mean = stats.get("mean")
+    if mean:
+        return 1.0 / float(mean)
+    return None
+
+
+def _format_number(value: float) -> str:
+    if not math.isfinite(value):
+        return "n/a"
+    if value >= 1000:
+        return f"{value:,.0f}"
+    if value >= 10:
+        return f"{value:,.2f}"
+    return f"{value:,.4f}"
+
+
+def _format_percent(value: float) -> str:
+    return f"{value:+.2f}%"
+
+
+def _truncate(text: str, limit: int = 140) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."
+
+
+def _collect_results(root: Path) -> list[dict]:
+    results = []
+    for metadata_path in sorted(root.glob("*/metadata.json")):
+        result_dir = metadata_path.parent
+        baseline_path = result_dir / "baseline.json"
+        contender_path = result_dir / "contender.json"
+        if not baseline_path.exists() or not contender_path.exists():
+            continue
+        metadata = _load_json(metadata_path)
+        results.append(
+            {
+                "metadata": metadata,
+                "baseline": _load_json(baseline_path),
+                "contender": _load_json(contender_path),
+            }
+        )
+    return results
+
+
+def _comparison_rows(result: dict) -> list[dict]:
+    baseline = {
+        _benchmark_name(benchmark): benchmark
+        for benchmark in result["baseline"].get("benchmarks", [])
+    }
+    contender = {
+        _benchmark_name(benchmark): benchmark
+        for benchmark in result["contender"].get("benchmarks", [])
+    }
+    rows = []
+    for name in sorted(set(baseline) & set(contender)):
+        baseline_ops = _benchmark_ops(baseline[name])
+        contender_ops = _benchmark_ops(contender[name])
+        if not baseline_ops or contender_ops is None:
+            continue
+        change = (contender_ops / baseline_ops - 1.0) * 100.0
+        rows.append(
+            {
+                "name": name,
+                "baseline_ops": baseline_ops,
+                "contender_ops": contender_ops,
+                "change": change,
+            }
+        )
+    return rows
+
+
+def _table(rows: list[dict], max_rows: int) -> list[str]:
+    selected = sorted(rows, key=lambda row: abs(row["change"]), reverse=True)[:max_rows]
+    lines = [
+        "| Benchmark | main ops | PR ops | Change |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    for row in selected:
+        lines.append(
+            "| `{}` | {} | {} | {} |".format(
+                _truncate(row["name"]),
+                _format_number(row["baseline_ops"]),
+                _format_number(row["contender_ops"]),
+                _format_percent(row["change"]),
+            )
+        )
+    if len(rows) > max_rows:
+        lines.append(
+            f"| ... | ... | ... | Showing {max_rows} of {len(rows)} comparisons, sorted by absolute change. |"
+        )
+    return lines
+
+
+def _device_section(result: dict, max_rows: int) -> list[str]:
+    metadata = result["metadata"]
+    rows = _comparison_rows(result)
+    regressions = sum(row["change"] <= -5.0 for row in rows)
+    improvements = sum(row["change"] >= 5.0 for row in rows)
+    device = metadata["device"]
+    lines = [
+        f"#### {device}",
+        "",
+        f"Compared {len(rows)} benchmarks. Regressions over 5%: {regressions}. Improvements over 5%: {improvements}.",
+        "",
+    ]
+    lines.extend(_table(rows, max_rows))
+    lines.append("")
+    return lines
+
+
+def build_comment(results: list[dict], run_url: str) -> tuple[int, str]:
+    if not results:
+        raise RuntimeError("No benchmark artifacts were found.")
+    pr_numbers = {int(result["metadata"]["pr_number"]) for result in results}
+    if len(pr_numbers) != 1:
+        raise RuntimeError(f"Expected one PR number, found {sorted(pr_numbers)}.")
+    pr_number = pr_numbers.pop()
+    first_metadata = results[0]["metadata"]
+    base_sha = first_metadata["base_sha"][:8]
+    head_sha = first_metadata["head_sha"][:8]
+    max_rows = 120
+    while max_rows >= 20:
+        lines = [
+            COMMENT_MARKER,
+            f"### Benchmark Results: PR `{head_sha}` vs main `{base_sha}`",
+            "",
+            f"Benchmark run: {run_url}",
+            "",
+            "Higher ops/sec is better. Tables are sorted by largest absolute change.",
+            "",
+        ]
+        for result in sorted(results, key=lambda item: item["metadata"]["device"]):
+            lines.extend(_device_section(result, max_rows=max_rows))
+        body = "\n".join(lines)
+        if len(body) <= MAX_COMMENT_LENGTH:
+            return pr_number, body
+        max_rows -= 20
+    return (
+        pr_number,
+        body[: MAX_COMMENT_LENGTH - 200]
+        + "\n\nComment truncated due to GitHub size limits.\n",
+    )
+
+
+def _github_request(
+    method: str, url: str, token: str, data: dict | None = None
+) -> dict | list:
+    body = None if data is None else json.dumps(data).encode()
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    github_request = request.Request(url, data=body, headers=headers, method=method)
+    with request.urlopen(github_request) as response:
+        response_body = response.read().decode()
+    if not response_body:
+        return {}
+    return json.loads(response_body)
+
+
+def upsert_comment(repository: str, pr_number: int, body: str) -> None:
+    token = os.environ["GITHUB_TOKEN"]
+    api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+    comments_url = (
+        f"{api_url}/repos/{repository}/issues/{pr_number}/comments?per_page=100"
+    )
+    comments = _github_request("GET", comments_url, token)
+    for comment in comments:
+        if COMMENT_MARKER in comment.get("body", ""):
+            comment_url = (
+                f"{api_url}/repos/{repository}/issues/comments/{comment['id']}"
+            )
+            _github_request("PATCH", comment_url, token, {"body": body})
+            return
+    create_url = f"{api_url}/repos/{repository}/issues/{pr_number}/comments"
+    _github_request("POST", create_url, token, {"body": body})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--artifact-root", required=True, type=Path)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--comment", action="store_true")
+    args = parser.parse_args()
+
+    results = _collect_results(args.artifact_root)
+    pr_number, body = build_comment(results, args.run_url)
+    print(body)
+    if args.comment:
+        upsert_comment(args.repository, pr_number, body)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,6 +28,7 @@ jobs:
     name: ${{ matrix.device }} Pytest benchmark
     runs-on: linux.g5.4xlarge.nvidia.gpu
     strategy:
+      fail-fast: false
       matrix:
         include:
           - device: CPU
@@ -39,7 +40,7 @@ jobs:
         shell: bash -l {0}
     container:
       image: ${{ matrix.image }}
-      options: --gpus all
+      options: --gpus all --shm-size=8g
     steps:
       - name: Who triggered this?
         run: |
@@ -84,7 +85,7 @@ jobs:
           fi
 
           python3.10 -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128 -U
-          python3.10 -m pip install ninja pytest pytest-benchmark mujoco dm_control "gym[accept-rom-license,atari]" transformers
+          python3.10 -m pip install ninja pytest pytest-benchmark mujoco dm_control "gym[accept-rom-license,atari]" transformers accelerate
           python -m pip install "pybind11[global]"
           python3.10 -m pip install git+https://github.com/pytorch/tensordict 
           python3.10 -m pip install safetensors tqdm pandas numpy matplotlib ray

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - "*"
   workflow_dispatch:
   workflow_call:
     inputs:
@@ -18,7 +15,6 @@ permissions:
   id-token: write
   deployments: write
   contents: write
-  pull-requests: write
 
 concurrency:
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.
@@ -30,21 +26,24 @@ jobs:
 
   benchmark:
     name: ${{ matrix.device }} Pytest benchmark
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'benchmarks/upload') }}
     runs-on: linux.g5.4xlarge.nvidia.gpu
     strategy:
       matrix:
-        device: [CPU, GPU]
+        include:
+          - device: CPU
+            image: nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04
+          - device: GPU
+            image: nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
     defaults:
       run:
         shell: bash -l {0}
     container:
-      image: nvidia/cuda:12.3.0-base-ubuntu22.04
+      image: ${{ matrix.image }}
       options: --gpus all
     steps:
       - name: Who triggered this?
         run: |
-          echo "Action triggered by ${{ github.event.pull_request.html_url }}"
+          echo "Action triggered by ${{ github.event_name }} on ${{ github.ref }}"
       - name: Check ldd --version
         run: ldd --version
       - name: Checkout
@@ -52,7 +51,7 @@ jobs:
         with:
           fetch-depth: 50 # this is to make sure we obtain the target base commit
       - name: Python Setup
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Setup Environment
@@ -72,20 +71,17 @@ jobs:
           git config --global user.email "github@users.noreply.github.com"
       - name: setup Path
         run: |
-          echo /usr/local/bin >> $GITHUB_PATH
-      - name: Setup benchmarks
-        run: |
-          echo "BASE_SHA=$(echo ${{ github.event.pull_request.base.sha }} | cut -c1-8)" >> $GITHUB_ENV
-          echo "HEAD_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-8)" >> $GITHUB_ENV
-          echo "BASELINE_JSON=$(mktemp)" >> $GITHUB_ENV
-          echo "CONTENDER_JSON=$(mktemp)" >> $GITHUB_ENV
-          echo "PR_COMMENT=$(mktemp)" >>  $GITHUB_ENV
+          echo /usr/local/bin >> "$GITHUB_PATH"
       - name: Run
         run: |
+          set -euxo pipefail
           python3.10 -m venv --system-site-packages ./py310
           source ./py310/bin/activate
           export PYTHON_INCLUDE_DIR=/usr/include/python3.10
-          ${{ matrix.device == 'CPU' && 'export CUDA_VISIBLE_DEVICES=' || '' }}
+          export TORCHRL_BENCHMARK_DEVICE="${{ matrix.device }}"
+          if [ "${TORCHRL_BENCHMARK_DEVICE}" = "CPU" ]; then
+            export CUDA_VISIBLE_DEVICES=
+          fi
 
           python3.10 -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128 -U
           python3.10 -m pip install ninja pytest pytest-benchmark mujoco dm_control "gym[accept-rom-license,atari]" transformers
@@ -96,31 +92,33 @@ jobs:
 
           bash .github/unittest/helpers/assert_torch_version.sh nightly
 
-          # test import
-          python -c """import torch
-          assert torch.cuda.device_count()
-          """
+          if [ "${{ matrix.device }}" = "GPU" ]; then
+            # test import and fail early if the GPU runner did not expose CUDA
+            nvcc --version
+            python -c "import torch; assert torch.cuda.device_count()"
+            python -c "import torchrl._torchrl as ext; assert hasattr(ext, 'CudaSumSegmentTreeFp32')"
+          fi
 
           cd benchmarks/
           export TORCHDYNAMO_INLINE_INBUILT_NN_MODULES=1
           export COMPOSITE_LP_AGGREGATE=0
           export TD_GET_DEFAULTS_TO_NONE=1
-          python -m pytest -vvv --rank 0 --benchmark-json output.json --ignore test_collectors_benchmark.py --ignore test_llm.py
+          python -m pytest -vvv --rank 0 --benchmark-only --benchmark-json output.json .
 
-      # Upload benchmark results for main branch, manual dispatch, or PRs with 'benchmarks/upload' label
+      # Upload benchmark results for main branch and manual dispatch runs.
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4
-        if: ${{ !inputs.skip-upload && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'benchmarks/upload'))) }}
+        if: ${{ !inputs.skip-upload && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') }}
         with:
           name: ${{ matrix.device }}-benchmark-results
           path: benchmarks/output.json
 
-  # Upload benchmark results to gh-pages branch (only for main, manual dispatch, or PRs with 'benchmarks/upload' label)
+  # Upload benchmark results to gh-pages branch.
   benchmark-upload:
     name: Upload benchmark results
     runs-on: ubuntu-latest
     needs: benchmark
-    if: ${{ !inputs.skip-upload && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'benchmarks/upload'))) }}
+    if: ${{ !inputs.skip-upload && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') }}
     steps:
       - name: Show upload trigger reason
         run: |
@@ -128,8 +126,6 @@ jobs:
             echo "Uploading benchmarks because this is the main branch"
           elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "Uploading benchmarks because of manual workflow dispatch"
-          elif [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "Uploading benchmarks because PR has 'benchmarks/upload' label"
           fi
       - name: Checkout
         uses: actions/checkout@v4
@@ -167,7 +163,6 @@ jobs:
           fail-on-alert: true
           alert-threshold: '200%'
           alert-comment-cc-users: '@vmoens'
-          # Disable PR comments to avoid permission issues with PR reviews
           comment-on-alert: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gh-pages-branch: gh-pages
@@ -181,7 +176,6 @@ jobs:
           fail-on-alert: true
           alert-threshold: '200%'
           alert-comment-cc-users: '@vmoens'
-          # Disable PR comments to avoid permission issues with PR reviews
           comment-on-alert: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gh-pages-branch: gh-pages

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -104,7 +104,7 @@ jobs:
           export TORCHDYNAMO_INLINE_INBUILT_NN_MODULES=1
           export COMPOSITE_LP_AGGREGATE=0
           export TD_GET_DEFAULTS_TO_NONE=1
-          python -m pytest -vvv --rank 0 --benchmark-only --benchmark-json output.json .
+          python -m pytest -vvv --rank 0 --benchmark-only --benchmark-json output.json --ignore test_llm.py .
 
       # Upload benchmark results for main branch and manual dispatch runs.
       - name: Upload benchmark results

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -4,7 +4,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  actions: read
 
 concurrency:
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.
@@ -145,17 +145,25 @@ jobs:
           export COMPOSITE_LP_AGGREGATE=0
           export TD_GET_DEFAULTS_TO_NONE=1
           python -m pytest -vvv --rank 0 --benchmark-only --benchmark-json "${CONTENDER_JSON}" --ignore test_llm.py .
-      - name: Publish results
-        continue-on-error: true
-        uses: apbard/pytest-benchmark-commenter@v3
-        env:
-          GIT_WORK_TREE: /__w/rl/rl
+      - name: Upload PR benchmark results
+        if: ${{ always() }}
+        run: |
+          set -euxo pipefail
+          mkdir -p benchmark-results
+          cp "${BASELINE_JSON}" benchmark-results/baseline.json
+          cp "${CONTENDER_JSON}" benchmark-results/contender.json
+          cat > benchmark-results/metadata.json <<EOF
+          {
+            "device": "${{ matrix.device }}",
+            "pr_number": ${{ github.event.pull_request.number }},
+            "base_sha": "${PR_BASE_SHA}",
+            "head_sha": "${PR_HEAD_SHA}",
+            "run_id": "${{ github.run_id }}"
+          }
+          EOF
+      - name: Upload PR benchmark artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          benchmark-file: ${{ env.CONTENDER_JSON }}
-          comparison-benchmark-file: ${{ env.BASELINE_JSON }}
-          benchmark-metrics: 'name,max,mean,ops'
-          comparison-benchmark-metric: 'ops'
-          comparison-higher-is-better: true
-          comparison-threshold: 5
-          benchmark-title: '${{ matrix.device }} Benchmark Tests: PR ${{ env.HEAD_SHA }} vs main ${{ env.BASE_SHA }}'
+          name: ${{ matrix.device }}-benchmark-pr-results
+          path: benchmark-results

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -2,7 +2,9 @@ name: Continuous Benchmark (PR)
 on:
   pull_request:
 
-permissions: write-all
+permissions:
+  contents: read
+  pull-requests: write
 
 concurrency:
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.
@@ -15,6 +17,9 @@ jobs:
   benchmark:
     name: ${{ matrix.device }} Pytest benchmark
     runs-on: linux.g5.4xlarge.nvidia.gpu
+    env:
+      PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     strategy:
       matrix:
         include:
@@ -29,17 +34,6 @@ jobs:
       image: ${{ matrix.image }}
       options: --gpus all
     steps:
-      - name: Set GITHUB_BRANCH environment variable
-        run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            export GITHUB_BRANCH=${{ github.event.branch }}
-          elif [ "${{ github.event_name }}" == "pull_request" ]; then
-            export GITHUB_BRANCH=${{ github.event.pull_request.head.ref }}
-          else
-            echo "Unsupported event type"
-            exit 1
-          fi
-          echo "GITHUB_BRANCH=$GITHUB_BRANCH" >> $GITHUB_ENV
       - name: Who triggered this?
         run: |
           echo "Action triggered by ${{ github.event.pull_request.html_url }}"
@@ -48,9 +42,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 50 # this is to make sure we obtain the target base commit
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Python Setup
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Setup Environment
@@ -67,31 +62,42 @@ jobs:
         run: git config --global --add safe.directory /__w/rl/rl
       - name: setup Path
         run: |
-          echo /usr/local/bin >> $GITHUB_PATH
+          echo /usr/local/bin >> "$GITHUB_PATH"
       - name: Setup benchmarks
         run: |
-          echo "BASE_SHA=$(echo ${{ github.event.pull_request.base.sha }} | cut -c1-8)" >> $GITHUB_ENV
-          echo "HEAD_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-8)" >> $GITHUB_ENV
-          echo "BASELINE_JSON=$(mktemp)" >> $GITHUB_ENV
-          echo "CONTENDER_JSON=$(mktemp)" >> $GITHUB_ENV
-          echo "PR_COMMENT=$(mktemp)" >>  $GITHUB_ENV
-      - name: Run
+          {
+            echo "BASE_SHA=${PR_BASE_SHA:0:8}"
+            echo "HEAD_SHA=${PR_HEAD_SHA:0:8}"
+            echo "BASELINE_JSON=$(mktemp)"
+            echo "CONTENDER_JSON=$(mktemp)"
+          } >> "$GITHUB_ENV"
+      - name: Install benchmark dependencies
         run: |
           set -euxo pipefail
           python3.10 -m venv --system-site-packages ./py310
           source ./py310/bin/activate
           export PYTHON_INCLUDE_DIR=/usr/include/python3.10
-          export TORCHRL_BENCHMARK_DEVICE=${{ matrix.device }}
-          ${{ matrix.device == 'CPU' && 'export CUDA_VISIBLE_DEVICES=' || '' }}
 
           python3.10 -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128 -U
           python3.10 -m pip install ninja pytest pytest-benchmark mujoco dm_control "gym[accept-rom-license,atari]" transformers ray
           python3.10 -m pip install "pybind11[global]"
           python3.10 -m pip install git+https://github.com/pytorch/tensordict 
           python3.10 -m pip install safetensors tqdm pandas numpy matplotlib
-          python3.10 setup.py develop
 
           bash .github/unittest/helpers/assert_torch_version.sh nightly
+      - name: Run baseline benchmarks
+        run: |
+          set -euxo pipefail
+          source ./py310/bin/activate
+          export PYTHON_INCLUDE_DIR=/usr/include/python3.10
+          export TORCHRL_BENCHMARK_DEVICE="${{ matrix.device }}"
+          if [ "${TORCHRL_BENCHMARK_DEVICE}" = "CPU" ]; then
+            export CUDA_VISIBLE_DEVICES=
+          fi
+          git fetch --no-tags --depth=1 origin "${PR_BASE_SHA}"
+          git checkout --detach "${PR_BASE_SHA}"
+          rm -rf build
+          python3.10 setup.py develop
 
           if [ "${{ matrix.device }}" = "GPU" ]; then
             # test import and fail early if the GPU runner did not expose CUDA
@@ -105,8 +111,33 @@ jobs:
           export TORCHDYNAMO_INLINE_INBUILT_NN_MODULES=1
           export COMPOSITE_LP_AGGREGATE=0
           export TD_GET_DEFAULTS_TO_NONE=1
-          python -m pytest -vvv --rank 0 test_replaybuffer_benchmark.py::TestPrioritizedReplayBufferBenchmark --benchmark-json ${{ env.CONTENDER_JSON }}
-          cp ${{ env.CONTENDER_JSON }} ${{ env.BASELINE_JSON }}
+          python -m pytest -vvv --rank 0 --benchmark-only --benchmark-json "${BASELINE_JSON}" .
+      - name: Run PR benchmarks
+        run: |
+          set -euxo pipefail
+          source ./py310/bin/activate
+          export PYTHON_INCLUDE_DIR=/usr/include/python3.10
+          export TORCHRL_BENCHMARK_DEVICE="${{ matrix.device }}"
+          if [ "${TORCHRL_BENCHMARK_DEVICE}" = "CPU" ]; then
+            export CUDA_VISIBLE_DEVICES=
+          fi
+          git checkout --detach "${PR_HEAD_SHA}"
+          rm -rf build
+          python3.10 setup.py develop
+
+          if [ "${{ matrix.device }}" = "GPU" ]; then
+            # test import and fail early if the GPU runner did not expose CUDA
+            nvcc --version
+            python -c "import torch; assert torch.cuda.device_count()"
+            python -c "import torchrl._torchrl as ext; assert hasattr(ext, 'CudaSumSegmentTreeFp32')"
+          fi
+
+          REPO_ROOT="$(pwd)"
+          cd "${REPO_ROOT}/benchmarks"
+          export TORCHDYNAMO_INLINE_INBUILT_NN_MODULES=1
+          export COMPOSITE_LP_AGGREGATE=0
+          export TD_GET_DEFAULTS_TO_NONE=1
+          python -m pytest -vvv --rank 0 --benchmark-only --benchmark-json "${CONTENDER_JSON}" .
       - name: Publish results
         continue-on-error: true
         uses: apbard/pytest-benchmark-commenter@v3
@@ -120,4 +151,4 @@ jobs:
           comparison-benchmark-metric: 'ops'
           comparison-higher-is-better: true
           comparison-threshold: 5
-          benchmark-title: 'Result of ${{ matrix.device }} Benchmark Tests'
+          benchmark-title: '${{ matrix.device }} Benchmark Tests: PR ${{ env.HEAD_SHA }} vs main ${{ env.BASE_SHA }}'

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -18,6 +18,7 @@ jobs:
     name: ${{ matrix.device }} Pytest benchmark
     runs-on: linux.g5.4xlarge.nvidia.gpu
     env:
+      PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
       PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     strategy:
@@ -39,10 +40,15 @@ jobs:
           echo "Action triggered by ${{ github.event.pull_request.html_url }}"
       - name: Check ldd --version
         run: ldd --version
+      - name: Install git for checkout
+        run: |
+          apt-get update -y
+          apt-get install -y git ca-certificates
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Python Setup
         uses: actions/setup-python@v5
@@ -94,7 +100,7 @@ jobs:
           if [ "${TORCHRL_BENCHMARK_DEVICE}" = "CPU" ]; then
             export CUDA_VISIBLE_DEVICES=
           fi
-          git fetch --no-tags --depth=1 origin "${PR_BASE_SHA}"
+          git fetch --no-tags --depth=1 "https://github.com/${PR_BASE_REPO}.git" "${PR_BASE_SHA}"
           git checkout --detach "${PR_BASE_SHA}"
           rm -rf build
           python3.10 setup.py develop

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -118,7 +118,7 @@ jobs:
           export TORCHDYNAMO_INLINE_INBUILT_NN_MODULES=1
           export COMPOSITE_LP_AGGREGATE=0
           export TD_GET_DEFAULTS_TO_NONE=1
-          python -m pytest -vvv --rank 0 --benchmark-only --benchmark-json "${BASELINE_JSON}" .
+          python -m pytest -vvv --rank 0 --benchmark-only --benchmark-json "${BASELINE_JSON}" --ignore test_llm.py .
       - name: Run PR benchmarks
         run: |
           set -euxo pipefail
@@ -144,7 +144,7 @@ jobs:
           export TORCHDYNAMO_INLINE_INBUILT_NN_MODULES=1
           export COMPOSITE_LP_AGGREGATE=0
           export TD_GET_DEFAULTS_TO_NONE=1
-          python -m pytest -vvv --rank 0 --benchmark-only --benchmark-json "${CONTENDER_JSON}" .
+          python -m pytest -vvv --rank 0 --benchmark-only --benchmark-json "${CONTENDER_JSON}" --ignore test_llm.py .
       - name: Publish results
         continue-on-error: true
         uses: apbard/pytest-benchmark-commenter@v3

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -22,6 +22,7 @@ jobs:
       PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - device: CPU
@@ -33,7 +34,7 @@ jobs:
         shell: bash -l {0}
     container:
       image: ${{ matrix.image }}
-      options: --gpus all
+      options: --gpus all --shm-size=8g
     steps:
       - name: Who triggered this?
         run: |
@@ -85,7 +86,7 @@ jobs:
           export PYTHON_INCLUDE_DIR=/usr/include/python3.10
 
           python3.10 -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128 -U
-          python3.10 -m pip install ninja pytest pytest-benchmark mujoco dm_control "gym[accept-rom-license,atari]" transformers ray
+          python3.10 -m pip install ninja pytest pytest-benchmark mujoco dm_control "gym[accept-rom-license,atari]" transformers accelerate ray
           python3.10 -m pip install "pybind11[global]"
           python3.10 -m pip install git+https://github.com/pytorch/tensordict 
           python3.10 -m pip install safetensors tqdm pandas numpy matplotlib

--- a/.github/workflows/benchmarks_pr_comment.yml
+++ b/.github/workflows/benchmarks_pr_comment.yml
@@ -1,0 +1,40 @@
+name: Continuous Benchmark (PR Comment)
+on:
+  workflow_run:
+    workflows:
+      - Continuous Benchmark (PR)
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  benchmark-comment:
+    name: Publish benchmark PR comment
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download PR benchmark artifacts
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+          pattern: '*-benchmark-pr-results'
+          path: benchmark-artifacts
+      - name: Publish benchmark comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BENCHMARK_RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          python .github/scripts/comment_pr_benchmarks.py \
+            --artifact-root benchmark-artifacts \
+            --repository "${{ github.repository }}" \
+            --run-url "${BENCHMARK_RUN_URL}" \
+            --comment

--- a/.github/workflows/test-linux-tutorials.yml
+++ b/.github/workflows/test-linux-tutorials.yml
@@ -62,7 +62,7 @@ jobs:
         # ============================================
         echo "::group::Install TensorDict"
         # Docker image has PyTorch 2.5.1+cu124 pre-installed
-        python -m pip install tensordict --quiet
+        python -m pip install git+https://github.com/pytorch/tensordict.git --quiet
         echo "::endgroup::"
 
         # ============================================


### PR DESCRIPTION
## Summary
- run the full pytest benchmark suite in both continuous and PR benchmark workflows
- compare PR benchmark JSON against a real baseline from the PR base SHA instead of comparing the PR against itself
- make CPU/GPU benchmark jobs use matching CUDA containers and device setup

## Test plan
- actionlint -ignore 'label \"linux\\.g5\\.4xlarge\\.nvidia\\.gpu\" is unknown' .github/workflows/benchmarks.yml .github/workflows/benchmarks_pr.yml
- ruby -e 'require \"yaml\"; ARGV.each { |f| YAML.load_file(f); puts \"ok #{f}\" }' .github/workflows/benchmarks.yml .github/workflows/benchmarks_pr.yml
- git diff --check -- .github/workflows/benchmarks.yml .github/workflows/benchmarks_pr.yml