### PR TITLE
[BugFix] Fix flaky RSSMPosteriorV3 grad test (test_rssm_posterior_v3_forward_shapes_and_grads)

### DIFF
--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -523,8 +523,18 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             state_grid.sum(-1), torch.ones(B, self.num_cats, device=device), atol=1e-5
         )
 
-        # Straight-through: gradients must flow back through logits to belief/obs
-        state.sum().backward()
+        # Straight-through: gradients must flow back through logits to belief/obs.
+        # NOTE: ``state.sum()`` is mathematically constant w.r.t. the logits — every
+        # row of the softmax inside the STE sums to 1, so any sum-reduction over
+        # the full ``state`` has zero gradient through softmax (uniform incoming
+        # gradient cancels exactly in the softmax Jacobian). Whether the resulting
+        # belief/obs grads are exactly 0.0 or a tiny float-roundoff residue depends
+        # on the runtime — leading to flakiness across Python/torch versions.
+        # Use random per-element weights so the gradient signal through softmax
+        # is non-degenerate.
+        torch.manual_seed(0)
+        weights = torch.randn_like(state)
+        (state * weights).sum().backward()
         assert belief.grad is not None and belief.grad.abs().sum() > 0
         assert obs_embed.grad is not None and obs_embed.grad.abs().sum() > 0
 


### PR DESCRIPTION
## Summary

`test/objectives/test_dreamer_v3.py::TestDreamerV3::test_rssm_posterior_v3_forward_shapes_and_grads` is intermittently failing on Python 3.10 / 3.11 in tests-cpu CI with:

```
assert (tensor([[0., 0., …]]) is not None and tensor(0.) > 0)
```

i.e. `belief.grad.abs().sum()` is exactly `0`.

### Root cause

The test probes gradient flow through the straight-through estimator with `state.sum().backward()`. But `state.sum()` is **mathematically constant** w.r.t. the logits inside the STE:

```python
state = probs + (one_hot - probs).detach()  # STE
```

Backward through this is `d state / d probs = 1`. `probs` is a softmax over the class axis, so every row sums to `1` — meaning `state.sum()` (over all elements) is the constant `B * num_categoricals` regardless of `logits`.

For softmax with **uniform** incoming gradient `g`, the outgoing gradient is

```
dL/dlogits[k] = softmax[k] * (g[k] − Σ_j softmax[j] * g[j])
              = softmax[k] * (g − g·1) = 0
```

so the gradient through to `belief` and `obs_embed` is mathematically zero. Whether the test sees `0.0` or a tiny roundoff residue (`~3e-7` on macOS / Linux Python 3.12+) depends entirely on the floating-point sum order in the runtime — which is why the test passes on Python 3.12/3.13/3.14 and fails on 3.10/3.11.

### Fix

Replace the probe with `(state * weights).sum().backward()` using random per-element weights (seeded for reproducibility). The incoming gradient is no longer uniform, so the softmax Jacobian doesn't cancel and the gradient through the STE to belief/obs is mathematically non-zero.

## Test plan
- [x] `pytest test/objectives/test_dreamer_v3.py::TestDreamerV3::test_rssm_posterior_v3_forward_shapes_and_grads -v` passes locally
- [x] pre-commit clean
- [ ] CI green on 3.10/3.11

## References
- Original failure: https://github.com/pytorch/rl/actions/runs/25431281253/job/74598204084