### PR TITLE
[BugFix] Update test_reinforce_value_net regex for new torch autograd error wording

### DIFF
--- a/test/objectives/test_ppo.py
+++ b/test/objectives/test_ppo.py
@@ -2560,14 +2560,24 @@ class TestReinforce(LossModuleTestBase):
                 value_net.parameters(),
                 retain_graph=True,
             )
-            with pytest.raises(RuntimeError, match="One of the "):
+            with pytest.raises(
+                RuntimeError,
+                # torch < nightly 2026-05-05: "One of the differentiated Tensors appears to not have been used in the graph"
+                # torch >= nightly 2026-05-05 (pytorch/pytorch#181917): "The differentiated Tensor at index N appears to not have been used in the graph"
+                match=r"One of the differentiated Tensors|differentiated Tensor at index",
+            ):
                 autograd.grad(
                     loss_td.get("loss_actor"),
                     value_net.parameters(),
                     retain_graph=True,
                     allow_unused=False,
                 )
-            with pytest.raises(RuntimeError, match="One of the "):
+            with pytest.raises(
+                RuntimeError,
+                # torch < nightly 2026-05-05: "One of the differentiated Tensors appears to not have been used in the graph"
+                # torch >= nightly 2026-05-05 (pytorch/pytorch#181917): "The differentiated Tensor at index N appears to not have been used in the graph"
+                match=r"One of the differentiated Tensors|differentiated Tensor at index",
+            ):
                 autograd.grad(
                     loss_td.get("loss_value"),
                     actor_net.parameters(),


### PR DESCRIPTION
## Summary

`test/objectives/test_ppo.py::TestReinforce::test_reinforce_value_net` is failing on recent torch nightlies, e.g.

```
AssertionError: Regex pattern did not match.
  Expected regex: 'One of the '
  Actual message: 'The differentiated Tensor at index 0 appears to not have been used in the graph. Set allow_unused=True if this is the desired behavior.'
```

(seen on `unittests-cpu (3.10, windows.4xlarge, cpu)` with torch `2.13.0.dev20260506+cpu`).

### Root cause

[pytorch/pytorch#181917](https://github.com/pytorch/pytorch/pull/181917) (merged 2026-05-05) renamed the `autograd.grad` unused-input error message:

| Case | Pre-#181917 | Post-#181917 |
|---|---|---|
| Input has `requires_grad=False` | `One of the differentiated Tensors does not require grad` | unchanged |
| Input is in the graph but disconnected from outputs | **`One of the differentiated Tensors appears to not have been used in the graph. ...`** | **`The differentiated Tensor at index N appears to not have been used in the graph. ...`** |

`test_reinforce_value_net` exercises the second case (passing `value_net.parameters()` against `loss_actor` and vice versa) and matched only on the old wording (`"One of the "`).

### Fix

Broaden the regex to match either wording. No source-code change needed — purely a test update.

## Test plan
- [x] Verified the regex matches both messages locally.
- [x] pre-commit clean.
- [ ] CI green on Windows job that exercised this.