### PR TITLE
[CI] Bump olddeps tensordict default to 0.12

### DIFF
--- a/.github/unittest/linux_olddeps/scripts_gym_0_13/install.sh
+++ b/.github/unittest/linux_olddeps/scripts_gym_0_13/install.sh
@@ -54,7 +54,7 @@ fi
 #   support for older Python versions at any time, which can lead to "tensordict
 #   not installed" failures in downstream smoke tests.
 # - Use the same (pinned) range as TorchRL itself to keep this job stable.
-python -m pip install "${TORCHRL_TENSORDICT_SPEC:-tensordict>=0.11.0,<0.12.0}"
+python -m pip install "${TORCHRL_TENSORDICT_SPEC:-tensordict>=0.12.0,<0.13.0}"
 
 # smoke test
 python -c "import tensordict; print(f'tensordict: {tensordict.__version__}')"


### PR DESCRIPTION
## Summary

- The olddeps `install.sh` fallback still pinned `tensordict>=0.11.0,<0.12.0`, but `test-linux.yml` already exports the 0.12 spec via `TORCHRL_TENSORDICT_SPEC` and `pyproject.toml` requires 0.12+.
- New torchrl features (e.g. the `generator` kwarg forwarded through `ProbabilisticActor` in #3704) require tensordict 0.12. With the stale default, anyone running `install.sh` locally without the env override hit `TypeError: ProbabilisticTensorDictModule.__init__() got an unexpected keyword argument 'generator'`.
- Bumps the default to `tensordict>=0.12.0,<0.13.0` so the install script alone matches the workflow override and `pyproject.toml`.

## Test plan

- [ ] olddeps lane on this PR turns green
- [ ] `bash .github/unittest/linux_olddeps/scripts_gym_0_13/install.sh` (no env override) installs tensordict 0.12.x and `import torchrl` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)