### PR TITLE
[Test] Make per-worker SharedMem scheme opt-in for policy_factory tests

### DIFF
--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -383,6 +383,9 @@ class TestMakePolicyFactory:
         collector = MultiSyncCollector(
             create_env_fn=[ContinuousActionVecMockEnv] * 3,
             policy_factory=policy_factories,
+            weight_sync_schemes={
+                "policy": SharedMemWeightSyncScheme(per_worker_weights=True)
+            },
             frames_per_batch=30,  # 10 per worker
             total_frames=90,  # 3 batches
             cat_results="stack",
@@ -457,6 +460,9 @@ class TestMakePolicyFactory:
         collector = MultiSyncCollector(
             create_env_fn=[ContinuousActionVecMockEnv] * 3,
             policy_factory=policy_factories,
+            weight_sync_schemes={
+                "policy": SharedMemWeightSyncScheme(per_worker_weights=True)
+            },
             frames_per_batch=30,
             total_frames=60,
             cat_results="stack",


### PR DESCRIPTION
## Summary

- #3716 deliberately simplified the auto-scheme branch in `MultiCollector.__init__` to only handle `isinstance(policy, nn.Module)`, dropping the implicit `SharedMemWeightSyncScheme(per_worker_weights=True)` setup for `policy_factory` lists. That decision is consistent with the new `TestTrajsPerBatchReplayBuffer::test_multi_async_policy_factory_is_built_only_in_workers` test added in the same PR, which asserts that nothing instantiates the factory on the orchestrator process.
- The same change silently broke the two pre-existing `TestMakePolicyFactory` tests that exercise per-worker weight sync via `update_policy_weights_({worker_idx: weights})`. They relied on the auto-detected `per_worker_weights=True` scheme. The previous CI run https://github.com/pytorch/rl/actions/runs/25511208708 was green; https://github.com/pytorch/rl/actions/runs/25560042045 fails on:
  - `test/test_collectors.py::TestMakePolicyFactory::test_per_worker_weight_sync_with_distinct_factories`
  - `test/test_collectors.py::TestMakePolicyFactory::test_per_worker_weight_sync_multiple_workers_update`
- Both an in-orchestrator probe and the alternative \"move the check into the scheme\" approach re-instantiate the factory in the orchestrator (allocating shared buffers needs the weight structure), which conflicts with the count assertion in `test_multi_async_policy_factory_is_built_only_in_workers`. So the requirements truly conflict.
- This PR keeps `_multi_base.py` exactly as on main and instead has the two failing tests opt in explicitly via `weight_sync_schemes={\"policy\": SharedMemWeightSyncScheme(per_worker_weights=True)}`. Smallest behavioural change; preserves the no-orchestrator-instantiation invariant from #3716.

Note: The `test/test_distributed.py::Test{Ray,RPC}Collector::test_distributed_collector_updatepolicy[True-...-Multi*Collector]` failures listed in the broken main run share the same root cause (no auto-scheme for uniform `policy_factory`) but live behind a distributed wrapper that doesn't currently forward `weight_sync_schemes` cleanly to the inner collector. Left out of this PR; happy to take a follow-up if you want me to thread that through.

## Test plan

- [x] `pytest test/test_collectors.py::TestMakePolicyFactory test/test_collectors.py::TestTrajsPerBatchReplayBuffer::test_multi_async_policy_factory_is_built_only_in_workers test/test_collectors.py::TestRandomPolicyLazyInit` — 11 passed locally
- [ ] Linux CI green on \`tests-cpu\`, \`tests-optdeps\`, \`tests-olddeps\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)