### PR TITLE
[BugFix] Auto-create inner SharedMem scheme for Ray/RPC + policy_factory

### DIFF
--- a/torchrl/collectors/distributed/ray.py
+++ b/torchrl/collectors/distributed/ray.py
@@ -550,12 +550,35 @@ class RayCollector(BaseCollector):
         else:
             self._frames_per_batch_corrected = frames_per_batch
 
+        # When the inner collector is a Multi*Collector built from a
+        # policy_factory (no policy instance), the inner collector's
+        # auto-scheme branch in MultiCollector only handles
+        # isinstance(policy, nn.Module); a remote update_policy_weights_(weights)
+        # would otherwise propagate to the remote node's main process but
+        # never reach its worker subprocesses. Inject a default
+        # SharedMemWeightSyncScheme on the inner collector so the broadcast
+        # actually lands. Only when the user hasn't already supplied one.
+        needs_inner_shared_mem_scheme = (
+            policy is None
+            and any(policy_factory)
+            and collector_class in (MultiSyncCollector, MultiAsyncCollector)
+        )
+
         # update collector kwargs
         for i, collector_kwarg in enumerate(self.collector_kwargs):
             # Don't pass policy_factory if we have a policy - remote collectors need the policy object
             # to be able to apply weight updates
             if policy is None:
                 collector_kwarg["policy_factory"] = policy_factory[i]
+            if (
+                needs_inner_shared_mem_scheme
+                and "weight_sync_schemes" not in collector_kwarg
+            ):
+                from torchrl.weight_update import SharedMemWeightSyncScheme
+
+                collector_kwarg["weight_sync_schemes"] = {
+                    "policy": SharedMemWeightSyncScheme()
+                }
             collector_kwarg["max_frames_per_traj"] = max_frames_per_traj
             collector_kwarg["init_random_frames"] = (
                 init_random_frames // self.num_collectors

--- a/torchrl/collectors/distributed/rpc.py
+++ b/torchrl/collectors/distributed/rpc.py
@@ -425,6 +425,20 @@ class RPCCollector(BaseCollector):
             else [copy(collector_kwargs) for _ in range(self.num_workers)]
         )
 
+        # When the inner collector is a Multi*Collector built from a
+        # policy_factory (no policy instance), the inner collector's
+        # auto-scheme branch in MultiCollector only handles
+        # isinstance(policy, nn.Module); a remote update_policy_weights_(weights)
+        # would otherwise reach the remote node's main process but never
+        # propagate down to its worker subprocesses. Inject a default
+        # SharedMemWeightSyncScheme on the inner collector so the broadcast
+        # actually lands. Only when the user hasn't already supplied one.
+        needs_inner_shared_mem_scheme = (
+            policy is None
+            and any(policy_factory)
+            and collector_class in (MultiSyncCollector, MultiAsyncCollector)
+        )
+
         # update collector kwargs
         for i, collector_kwarg in enumerate(self.collector_kwargs):
             collector_kwarg["max_frames_per_traj"] = max_frames_per_traj
@@ -447,6 +461,15 @@ class RPCCollector(BaseCollector):
             collector_kwarg["policy_device"] = self.policy_device[i]
             if trajs_per_batch is not None:
                 collector_kwarg["trajs_per_batch"] = trajs_per_batch
+            if (
+                needs_inner_shared_mem_scheme
+                and "weight_sync_schemes" not in collector_kwarg
+            ):
+                from torchrl.weight_update import SharedMemWeightSyncScheme
+
+                collector_kwarg["weight_sync_schemes"] = {
+                    "policy": SharedMemWeightSyncScheme()
+                }
 
         self.postproc = postproc
         self.split_trajs = split_trajs


### PR DESCRIPTION
## Summary

Follow-up to #3728. When \`RayCollector\` or \`RPCCollector\` wraps a \`Multi*Collector\` built with a \`policy_factory\` but no \`policy\` instance, \`update_policy_weights_(weights)\` on the outer collector reaches the remote node's main process via the distributed scheme — but never propagates down to its worker subprocesses. The inner \`MultiCollector\`'s auto-scheme branch in \`_multi_base.py\` only fires for \`isinstance(policy, nn.Module)\`, so without an explicit \`weight_sync_schemes\` the inner sync is a no-op and the workers keep their original factory-built weights forever.

This is what was breaking \`tests-gpu-distributed\` / \`tests-stable-gpu-distributed\` on main:
- \`test/test_distributed.py::TestRayCollector::test_distributed_collector_updatepolicy[True-{False,True}-Multi{Sync,Async}Collector]\`
- \`test/test_distributed.py::TestRPCCollector::test_distributed_collector_updatepolicy[True-{False,True}-Multi{Sync,Async}Collector]\`

(Symptom: \`last_batch[\"action\"] == 2\` fails because actions stay at the initial value of \`1\`.)

## Fix

In both \`RayCollector.__init__\` and \`RPCCollector.__init__\`, when:
- the inner \`collector_class\` is \`MultiSyncCollector\` or \`MultiAsyncCollector\`,
- \`policy is None\`,
- \`policy_factory\` has at least one factory,
- and the user hasn't already provided a \`weight_sync_schemes\` in \`collector_kwargs\`,

inject \`{\"policy\": SharedMemWeightSyncScheme()}\` into the inner kwargs. The inner \`MultiCollector\` then sets up shared memory normally; the existing receiver flow on the remote actor cascades \`_receive_weights_scheme()\` → \`update_policy_weights_(weights)\` → inner \`SharedMemWeightSyncScheme\`, and the workers see updated weights.

This mirrors \`DistributedCollector\` (\`generic.py\`) which already pre-instantiates the factory on each dist worker to feed the inner collector's auto-scheme. Both end up with the same \`factories[0]()\` call inside \`_get_params_map\` on the remote node — the orchestrator never touches the factory.

Stacked on top of #3728 (so \`TestMakePolicyFactory\` regressions are also fixed in this branch's CI). Will rebase once that lands.

## Test plan

- [x] Existing local tests still green: \`pytest test/test_collectors.py::TestMakePolicyFactory test/test_collectors.py::TestRandomPolicyLazyInit test/test_collectors.py::TestTrajsPerBatchReplayBuffer::test_multi_async_policy_factory_is_built_only_in_workers\` — 11 passed
- [ ] CI: \`tests-gpu-distributed\` and \`tests-stable-gpu-distributed\` (Ray/RPC tests need cluster infra — couldn't run locally)
- [ ] Linux CI green for \`tests-cpu\`, \`tests-optdeps\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)