### PR TITLE
[Feature][Performance] Triton backend for GRU / LSTM with intermediate resets

### DIFF
--- a/benchmarks/bench_gru_reset_backends.py
+++ b/benchmarks/bench_gru_reset_backends.py
@@ -89,60 +89,81 @@ def _make_modules(
     input_size: int,
     hidden_size: int,
     num_layers: int,
+    dropout: float,
     device: torch.device,
 ) -> tuple[
     GRUModule | LSTMModule,
-    GRUModule | LSTMModule,
-    GRUModule | LSTMModule,
+    GRUModule | LSTMModule | None,
+    GRUModule | LSTMModule | None,
     GRUModule | LSTMModule | None,
 ]:
+    # scan backend cannot run with dropout > 0. cuDNN's nn.LSTM/nn.GRU only
+    # applies the configured dropout when num_layers > 1. The triton backend
+    # uses cudnn_pad's state_dict, so all modules see the same parameters.
+    scan_supported = dropout == 0.0
+    triton_supported = device.type == "cuda"
+    # Whether dropout is exercised at runtime (only kicks in with multi-layer
+    # stacks where there's a between-layer dropout point).
+    effective_dropout = dropout if num_layers > 1 else 0.0
+    train_mode = effective_dropout > 0
     if rnn_type == "lstm":
         cudnn_pad = LSTMModule(
             input_size=input_size,
             hidden_size=hidden_size,
             num_layers=num_layers,
+            dropout=dropout,
             in_keys=["obs", "hidden0", "hidden1"],
             out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
             default_recurrent_mode=True,
             device=device,
-        ).eval()
-        scan_eager = LSTMModule(
-            input_size=input_size,
-            hidden_size=hidden_size,
-            num_layers=num_layers,
-            in_keys=["obs", "hidden0", "hidden1"],
-            out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
-            recurrent_backend="scan",
-            default_recurrent_mode=True,
-            device=device,
-        ).eval()
-        scan_compile = LSTMModule(
-            input_size=input_size,
-            hidden_size=hidden_size,
-            num_layers=num_layers,
-            in_keys=["obs", "hidden0", "hidden1"],
-            out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
-            recurrent_backend="scan",
-            default_recurrent_mode=True,
-            python_based=True,
-            device=device,
-        ).eval()
-        scan_eager.load_state_dict(cudnn_pad.state_dict())
-        scan_compile.load_state_dict(cudnn_pad.state_dict())
+        )
+        cudnn_pad.train(train_mode)
+        scan_eager = None
+        scan_compile = None
+        if scan_supported:
+            scan_eager = LSTMModule(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                num_layers=num_layers,
+                dropout=dropout,
+                in_keys=["obs", "hidden0", "hidden1"],
+                out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
+                recurrent_backend="scan",
+                default_recurrent_mode=True,
+                device=device,
+            )
+            scan_eager.load_state_dict(cudnn_pad.state_dict())
+            scan_eager.train(train_mode)
+            scan_compile = LSTMModule(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                num_layers=num_layers,
+                dropout=dropout,
+                in_keys=["obs", "hidden0", "hidden1"],
+                out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
+                recurrent_backend="scan",
+                default_recurrent_mode=True,
+                python_based=True,
+                device=device,
+            )
+            scan_compile.load_state_dict(cudnn_pad.state_dict())
+            scan_compile.train(train_mode)
         triton_mod = None
-        if num_layers == 1 and device.type == "cuda":
+        if triton_supported:
             try:
                 triton_mod = LSTMModule(
                     input_size=input_size,
                     hidden_size=hidden_size,
                     num_layers=num_layers,
+                    dropout=dropout,
                     in_keys=["obs", "hidden0", "hidden1"],
                     out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
                     recurrent_backend="triton",
                     default_recurrent_mode=True,
                     device=device,
-                ).eval()
+                )
                 triton_mod.load_state_dict(cudnn_pad.state_dict())
+                triton_mod.train(train_mode)
             except RuntimeError:
                 triton_mod = None
         return cudnn_pad, scan_eager, scan_compile, triton_mod
@@ -151,47 +172,57 @@ def _make_modules(
         input_size=input_size,
         hidden_size=hidden_size,
         num_layers=num_layers,
+        dropout=dropout,
         in_keys=["obs", "hidden"],
         out_keys=["feat", ("next", "hidden")],
         default_recurrent_mode=True,
         device=device,
-    ).eval()
-    scan_eager = GRUModule(
-        input_size=input_size,
-        hidden_size=hidden_size,
-        num_layers=num_layers,
-        in_keys=["obs", "hidden"],
-        out_keys=["feat", ("next", "hidden")],
-        recurrent_backend="scan",
-        default_recurrent_mode=True,
-        device=device,
-    ).eval()
-    scan_compile = GRUModule(
-        input_size=input_size,
-        hidden_size=hidden_size,
-        num_layers=num_layers,
-        in_keys=["obs", "hidden"],
-        out_keys=["feat", ("next", "hidden")],
-        recurrent_backend="scan",
-        default_recurrent_mode=True,
-        python_based=True,
-        device=device,
-    ).eval()
-    scan_eager.load_state_dict(cudnn_pad.state_dict())
-    scan_compile.load_state_dict(cudnn_pad.state_dict())
+    )
+    cudnn_pad.train(train_mode)
+    scan_eager = None
+    scan_compile = None
+    if scan_supported:
+        scan_eager = GRUModule(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            dropout=dropout,
+            in_keys=["obs", "hidden"],
+            out_keys=["feat", ("next", "hidden")],
+            recurrent_backend="scan",
+            default_recurrent_mode=True,
+            device=device,
+        )
+        scan_eager.load_state_dict(cudnn_pad.state_dict())
+        scan_eager.train(train_mode)
+        scan_compile = GRUModule(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            dropout=dropout,
+            in_keys=["obs", "hidden"],
+            out_keys=["feat", ("next", "hidden")],
+            recurrent_backend="scan",
+            default_recurrent_mode=True,
+            python_based=True,
+            device=device,
+        )
+        scan_compile.load_state_dict(cudnn_pad.state_dict())
+        scan_compile.train(train_mode)
     triton_mod = None
-    if num_layers == 1 and device.type == "cuda":
+    if triton_supported:
         try:
             triton_mod = GRUModule(
                 input_size=input_size,
                 hidden_size=hidden_size,
                 num_layers=num_layers,
+                dropout=dropout,
                 in_keys=["obs", "hidden"],
                 out_keys=["feat", ("next", "hidden")],
                 recurrent_backend="triton",
                 default_recurrent_mode=True,
                 device=device,
-            ).eval()
+            )
             triton_mod.load_state_dict(cudnn_pad.state_dict())
         except RuntimeError:
             triton_mod = None
@@ -202,8 +233,8 @@ def _make_fn(
     rnn_type: RNNType,
     mode: Mode,
     cudnn_pad: GRUModule | LSTMModule,
-    scan_eager: GRUModule | LSTMModule,
-    scan_compile: GRUModule | LSTMModule,
+    scan_eager: GRUModule | LSTMModule | None,
+    scan_compile: GRUModule | LSTMModule | None,
     triton_mod: GRUModule | LSTMModule | None,
     obs: torch.Tensor,
     hidden: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
@@ -339,6 +370,17 @@ def main() -> None:
     parser.add_argument("--hidden-size", type=int, default=256)
     parser.add_argument("--num-layers", type=int, default=1)
     parser.add_argument(
+        "--dropouts",
+        type=float,
+        nargs="+",
+        default=[0.0],
+        help=(
+            "Dropout probabilities to sweep. Only effective with num_layers > 1 "
+            "(dropout is between stacked layers). Scan modes are skipped when "
+            "dropout > 0 since they raise NotImplementedError."
+        ),
+    )
+    parser.add_argument(
         "--rnn-types", nargs="+", default=["gru"], choices=["gru", "lstm"]
     )
     parser.add_argument("--batches", type=int, nargs="+", default=[128, 512, 2048])
@@ -377,16 +419,22 @@ def main() -> None:
     generator = torch.Generator(device=device).manual_seed(args.seed)
 
     print(
-        "device,rnn_type,batch,steps,reset_prob,mode,median_ms,min_ms,frames_per_s,actual_reset_frac"
+        "device,rnn_type,batch,steps,num_layers,dropout,reset_prob,mode,"
+        "median_ms,min_ms,frames_per_s,actual_reset_frac"
     )
-    for rnn_type, batch, steps, reset_prob in itertools.product(
-        args.rnn_types, args.batches, args.lengths, args.reset_probs
+    for rnn_type, batch, steps, dropout, reset_prob in itertools.product(
+        args.rnn_types, args.batches, args.lengths, args.dropouts, args.reset_probs
     ):
         torch.manual_seed(args.seed)
         if device.type == "cuda":
             torch.cuda.manual_seed_all(args.seed)
         cudnn_pad, scan_eager, scan_compile, triton_mod = _make_modules(
-            rnn_type, args.input_size, args.hidden_size, args.num_layers, device
+            rnn_type,
+            args.input_size,
+            args.hidden_size,
+            args.num_layers,
+            dropout,
+            device,
         )
         obs = torch.randn(
             batch, steps, args.input_size, device=device, generator=generator
@@ -407,6 +455,8 @@ def main() -> None:
         for mode in args.modes:
             if mode == "triton_td" and triton_mod is None:
                 continue
+            if mode.startswith("scan_") and (scan_eager is None or scan_compile is None):
+                continue
             fn = _make_fn(
                 rnn_type,
                 mode,
@@ -421,7 +471,8 @@ def main() -> None:
             median_ms, min_ms = _bench(fn, device, args.warmup, args.iters)
             frames_per_s = batch * steps / (median_ms / 1000)
             print(
-                f"{device},{rnn_type},{batch},{steps},{reset_prob},{mode},"
+                f"{device},{rnn_type},{batch},{steps},{args.num_layers},{dropout},"
+                f"{reset_prob},{mode},"
                 f"{median_ms:.4f},{min_ms:.4f},{frames_per_s:.2f},"
                 f"{actual_reset_frac:.6f}"
             )

--- a/benchmarks/bench_gru_reset_backends.py
+++ b/benchmarks/bench_gru_reset_backends.py
@@ -368,7 +368,7 @@ def main() -> None:
     parser.add_argument("--device", default="cuda:0")
     parser.add_argument("--input-size", type=int, default=64)
     parser.add_argument("--hidden-size", type=int, default=256)
-    parser.add_argument("--num-layers", type=int, default=1)
+    parser.add_argument("--num-layers", type=int, nargs="+", default=[1])
     parser.add_argument(
         "--dropouts",
         type=float,
@@ -422,8 +422,13 @@ def main() -> None:
         "device,rnn_type,batch,steps,num_layers,dropout,reset_prob,mode,"
         "median_ms,min_ms,frames_per_s,actual_reset_frac"
     )
-    for rnn_type, batch, steps, dropout, reset_prob in itertools.product(
-        args.rnn_types, args.batches, args.lengths, args.dropouts, args.reset_probs
+    for rnn_type, batch, steps, num_layers, dropout, reset_prob in itertools.product(
+        args.rnn_types,
+        args.batches,
+        args.lengths,
+        args.num_layers,
+        args.dropouts,
+        args.reset_probs,
     ):
         torch.manual_seed(args.seed)
         if device.type == "cuda":
@@ -432,7 +437,7 @@ def main() -> None:
             rnn_type,
             args.input_size,
             args.hidden_size,
-            args.num_layers,
+            num_layers,
             dropout,
             device,
         )
@@ -442,7 +447,7 @@ def main() -> None:
         hidden0 = torch.zeros(
             batch,
             steps,
-            args.num_layers,
+            num_layers,
             args.hidden_size,
             device=device,
         )
@@ -471,7 +476,7 @@ def main() -> None:
             median_ms, min_ms = _bench(fn, device, args.warmup, args.iters)
             frames_per_s = batch * steps / (median_ms / 1000)
             print(
-                f"{device},{rnn_type},{batch},{steps},{args.num_layers},{dropout},"
+                f"{device},{rnn_type},{batch},{steps},{num_layers},{dropout},"
                 f"{reset_prob},{mode},"
                 f"{median_ms:.4f},{min_ms:.4f},{frames_per_s:.2f},"
                 f"{actual_reset_frac:.6f}"

--- a/benchmarks/bench_gru_reset_backends.py
+++ b/benchmarks/bench_gru_reset_backends.py
@@ -18,6 +18,7 @@ from torchrl.modules import GRUModule, LSTMModule
 
 
 RNNType = Literal["gru", "lstm"]
+CompileMode = Literal["none", "default", "reduce-overhead", "max-autotune"]
 Mode = Literal[
     "cudnn_pad_td",
     "scan_eager_td",
@@ -82,6 +83,32 @@ def _bench(
             _sync(device)
             times.append((time.perf_counter() - start) * 1000)
     return statistics.median(times), min(times)
+
+
+def _compile_fn(
+    fn: Callable[[], object],
+    compile_mode: CompileMode,
+    fullgraph: bool,
+    dynamic: bool | None,
+) -> Callable[[], object]:
+    if compile_mode == "none":
+        return fn
+    kwargs = {}
+    if compile_mode != "default":
+        kwargs["mode"] = compile_mode
+    kwargs["fullgraph"] = fullgraph
+    if dynamic is not None:
+        kwargs["dynamic"] = dynamic
+    return torch.compile(fn, **kwargs)
+
+
+def _first_call_ms(fn: Callable[[], object], device: torch.device) -> float:
+    with torch.inference_mode():
+        _sync(device)
+        start = time.perf_counter()
+        fn()
+        _sync(device)
+    return (time.perf_counter() - start) * 1000
 
 
 def _make_modules(
@@ -408,11 +435,60 @@ def main() -> None:
             "triton_td",
         ],
     )
+    parser.add_argument(
+        "--compile",
+        choices=["none", "default", "reduce-overhead", "max-autotune"],
+        default="none",
+        help=(
+            "Optionally wrap selected benchmark modes in torch.compile. "
+            "'default' calls torch.compile(fn); the other values are passed as "
+            "torch.compile(..., mode=...)."
+        ),
+    )
+    parser.add_argument(
+        "--compile-modes",
+        nargs="+",
+        default=["triton_td"],
+        choices=[
+            "all",
+            "cudnn_pad_td",
+            "scan_eager_td",
+            "scan_compile_td",
+            "scan_eager_direct",
+            "scan_compile_direct",
+            "triton_td",
+        ],
+        help=(
+            "Modes to wrap with --compile. Use 'all' to compile every selected "
+            "mode. The legacy scan_compile_* modes are already compiled before "
+            "this wrapper is applied."
+        ),
+    )
+    parser.add_argument(
+        "--compile-fullgraph",
+        action="store_true",
+        help="Pass fullgraph=True to torch.compile for modes selected by --compile.",
+    )
+    parser.add_argument(
+        "--compile-dynamic",
+        choices=["auto", "true", "false"],
+        default="auto",
+        help=(
+            "Pass dynamic=True/False to torch.compile for selected modes. "
+            "'auto' leaves the argument unset."
+        ),
+    )
     parser.add_argument("--seed", type=int, default=0)
     args = parser.parse_args()
-    if "scan_compile_td" in args.modes:
+    if "scan_compile_td" in args.modes or args.compile != "none":
         torch._dynamo.config.capture_scalar_outputs = True
 
+    compile_dynamic = {
+        "auto": None,
+        "true": True,
+        "false": False,
+    }[args.compile_dynamic]
+    compile_modes = set(args.compile_modes)
     device = torch.device(args.device)
     if device.type == "cuda":
         torch.cuda.set_device(device)
@@ -420,6 +496,7 @@ def main() -> None:
 
     print(
         "device,rnn_type,batch,steps,num_layers,dropout,reset_prob,mode,"
+        "compile,compile_fullgraph,compile_dynamic,first_call_ms,"
         "median_ms,min_ms,frames_per_s,actual_reset_frac"
     )
     for rnn_type, batch, steps, num_layers, dropout, reset_prob in itertools.product(
@@ -460,7 +537,9 @@ def main() -> None:
         for mode in args.modes:
             if mode == "triton_td" and triton_mod is None:
                 continue
-            if mode.startswith("scan_") and (scan_eager is None or scan_compile is None):
+            if mode.startswith("scan_") and (
+                scan_eager is None or scan_compile is None
+            ):
                 continue
             fn = _make_fn(
                 rnn_type,
@@ -473,11 +552,26 @@ def main() -> None:
                 hidden,
                 is_init,
             )
+            mode_compile = (
+                args.compile
+                if args.compile != "none"
+                and ("all" in compile_modes or mode in compile_modes)
+                else "none"
+            )
+            fn = _compile_fn(
+                fn,
+                mode_compile,
+                args.compile_fullgraph,
+                compile_dynamic,
+            )
+            first_call_ms = _first_call_ms(fn, device)
             median_ms, min_ms = _bench(fn, device, args.warmup, args.iters)
             frames_per_s = batch * steps / (median_ms / 1000)
             print(
                 f"{device},{rnn_type},{batch},{steps},{num_layers},{dropout},"
                 f"{reset_prob},{mode},"
+                f"{mode_compile},{args.compile_fullgraph},{args.compile_dynamic},"
+                f"{first_call_ms:.4f},"
                 f"{median_ms:.4f},{min_ms:.4f},{frames_per_s:.2f},"
                 f"{actual_reset_frac:.6f}"
             )

--- a/benchmarks/bench_gru_reset_backends.py
+++ b/benchmarks/bench_gru_reset_backends.py
@@ -24,6 +24,7 @@ Mode = Literal[
     "scan_compile_td",
     "scan_eager_direct",
     "scan_compile_direct",
+    "triton_td",
 ]
 
 
@@ -89,7 +90,12 @@ def _make_modules(
     hidden_size: int,
     num_layers: int,
     device: torch.device,
-) -> tuple[GRUModule | LSTMModule, GRUModule | LSTMModule, GRUModule | LSTMModule]:
+) -> tuple[
+    GRUModule | LSTMModule,
+    GRUModule | LSTMModule,
+    GRUModule | LSTMModule,
+    GRUModule | LSTMModule | None,
+]:
     if rnn_type == "lstm":
         cudnn_pad = LSTMModule(
             input_size=input_size,
@@ -123,7 +129,23 @@ def _make_modules(
         ).eval()
         scan_eager.load_state_dict(cudnn_pad.state_dict())
         scan_compile.load_state_dict(cudnn_pad.state_dict())
-        return cudnn_pad, scan_eager, scan_compile
+        triton_mod = None
+        if num_layers == 1 and device.type == "cuda":
+            try:
+                triton_mod = LSTMModule(
+                    input_size=input_size,
+                    hidden_size=hidden_size,
+                    num_layers=num_layers,
+                    in_keys=["obs", "hidden0", "hidden1"],
+                    out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
+                    recurrent_backend="triton",
+                    default_recurrent_mode=True,
+                    device=device,
+                ).eval()
+                triton_mod.load_state_dict(cudnn_pad.state_dict())
+            except RuntimeError:
+                triton_mod = None
+        return cudnn_pad, scan_eager, scan_compile, triton_mod
 
     cudnn_pad = GRUModule(
         input_size=input_size,
@@ -157,7 +179,23 @@ def _make_modules(
     ).eval()
     scan_eager.load_state_dict(cudnn_pad.state_dict())
     scan_compile.load_state_dict(cudnn_pad.state_dict())
-    return cudnn_pad, scan_eager, scan_compile
+    triton_mod = None
+    if num_layers == 1 and device.type == "cuda":
+        try:
+            triton_mod = GRUModule(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                num_layers=num_layers,
+                in_keys=["obs", "hidden"],
+                out_keys=["feat", ("next", "hidden")],
+                recurrent_backend="triton",
+                default_recurrent_mode=True,
+                device=device,
+            ).eval()
+            triton_mod.load_state_dict(cudnn_pad.state_dict())
+        except RuntimeError:
+            triton_mod = None
+    return cudnn_pad, scan_eager, scan_compile, triton_mod
 
 
 def _make_fn(
@@ -166,6 +204,7 @@ def _make_fn(
     cudnn_pad: GRUModule | LSTMModule,
     scan_eager: GRUModule | LSTMModule,
     scan_compile: GRUModule | LSTMModule,
+    triton_mod: GRUModule | LSTMModule | None,
     obs: torch.Tensor,
     hidden: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
     is_init: torch.Tensor,
@@ -181,6 +220,14 @@ def _make_fn(
 
         def fn():
             return scan_eager(_make_td(rnn_type, obs, hidden, is_init))
+
+        return fn
+    if mode == "triton_td":
+        if triton_mod is None:
+            raise ValueError("triton backend not available on this device / num_layers")
+
+        def fn():
+            return triton_mod(_make_td(rnn_type, obs, hidden, is_init))
 
         return fn
     if mode == "scan_compile_td" and rnn_type == "gru":
@@ -308,6 +355,7 @@ def main() -> None:
             "scan_compile_td",
             "scan_eager_direct",
             "scan_compile_direct",
+            "triton_td",
         ],
         choices=[
             "cudnn_pad_td",
@@ -315,6 +363,7 @@ def main() -> None:
             "scan_compile_td",
             "scan_eager_direct",
             "scan_compile_direct",
+            "triton_td",
         ],
     )
     parser.add_argument("--seed", type=int, default=0)
@@ -336,7 +385,7 @@ def main() -> None:
         torch.manual_seed(args.seed)
         if device.type == "cuda":
             torch.cuda.manual_seed_all(args.seed)
-        cudnn_pad, scan_eager, scan_compile = _make_modules(
+        cudnn_pad, scan_eager, scan_compile, triton_mod = _make_modules(
             rnn_type, args.input_size, args.hidden_size, args.num_layers, device
         )
         obs = torch.randn(
@@ -356,12 +405,15 @@ def main() -> None:
         is_init = _make_is_init(batch, steps, reset_prob, device, generator)
         actual_reset_frac = is_init[:, 1:].float().mean().item() if steps > 1 else 0
         for mode in args.modes:
+            if mode == "triton_td" and triton_mod is None:
+                continue
             fn = _make_fn(
                 rnn_type,
                 mode,
                 cudnn_pad,
                 scan_eager,
                 scan_compile,
+                triton_mod,
                 obs,
                 hidden,
                 is_init,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,8 @@ skip = ".git,*.svg,*.png,*.jpg,*.css,*.js,*.tmp,docs/_local_build,docs/source/re
 # splitted: used as variable name
 # te: Telugu language code in ifeval
 # uncompressible: used as class/function name in benchmarks
-ignore-words-list = "multicat,nd,splitted,te,uncompressible"
+# dout: standard autograd shorthand for gradient w.r.t. ``out``
+ignore-words-list = "multicat,nd,splitted,te,uncompressible,dout"
 
 [tool.usort]
 first_party_detection = false

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -82,14 +82,9 @@ def _has_triton_backend() -> bool:
     (Triton >= 2.2). Older Triton installations are routed to scan/pad
     backends, so the triton-specific tests are skipped there.
     """
-    if (
-        _importlib_util.find_spec("triton") is None
-        or not torch.cuda.is_available()
-    ):
+    if _importlib_util.find_spec("triton") is None or not torch.cuda.is_available():
         return False
-    return (
-        _importlib_util.find_spec("triton.language.extra.libdevice") is not None
-    )
+    return _importlib_util.find_spec("triton.language.extra.libdevice") is not None
 
 
 _has_triton = _has_triton_backend()

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -1297,12 +1297,93 @@ class TestLSTMModule:
             triton_out = triton_module(data.clone())
 
         atol = 5e-2 if compute_dtype == torch.bfloat16 else 5e-3
-        torch.testing.assert_close(pad_out["feat"], triton_out["feat"], atol=atol, rtol=atol)
         torch.testing.assert_close(
-            pad_out["next", "hidden0"], triton_out["next", "hidden0"], atol=atol, rtol=atol
+            pad_out["feat"], triton_out["feat"], atol=atol, rtol=atol
         )
         torch.testing.assert_close(
-            pad_out["next", "hidden1"], triton_out["next", "hidden1"], atol=atol, rtol=atol
+            pad_out["next", "hidden0"],
+            triton_out["next", "hidden0"],
+            atol=atol,
+            rtol=atol,
+        )
+        torch.testing.assert_close(
+            pad_out["next", "hidden1"],
+            triton_out["next", "hidden1"],
+            atol=atol,
+            rtol=atol,
+        )
+
+    @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
+    @pytest.mark.parametrize(
+        "module_kwargs,training",
+        [
+            ({"num_layers": 2}, False),
+            ({"num_layers": 2, "dropout": 0.3}, True),
+            ({"num_layers": 2, "dropout": 0.3}, False),
+            ({"bidirectional": True}, False),
+            ({"proj_size": 8}, False),
+            ({"num_layers": 2, "bidirectional": True, "proj_size": 8}, False),
+        ],
+    )
+    def test_lstm_module_triton_extended_forward_matches_pad(
+        self, module_kwargs, training
+    ):
+        torch.manual_seed(0)
+        device = torch.device("cuda")
+        B, T, F, H = 4, 7, 3, 16
+        num_layers = module_kwargs.get("num_layers", 1)
+        num_directions = 2 if module_kwargs.get("bidirectional", False) else 1
+        proj_size = module_kwargs.get("proj_size", 0)
+        hidden_out = proj_size if proj_size > 0 else H
+        state_shape_h = (B, T, num_layers * num_directions, hidden_out)
+        state_shape_c = (B, T, num_layers * num_directions, H)
+        kwargs = {
+            "input_size": F,
+            "hidden_size": H,
+            "in_keys": ["obs", "hidden0", "hidden1"],
+            "out_keys": ["feat", ("next", "hidden0"), ("next", "hidden1")],
+            "device": device,
+            **module_kwargs,
+        }
+        pad_module = LSTMModule(**kwargs)
+        triton_module = LSTMModule(**kwargs, recurrent_backend="triton")
+        triton_module.load_state_dict(pad_module.state_dict())
+        pad_module.train(training)
+        triton_module.train(training)
+
+        obs = torch.randn(B, T, F, device=device)
+        hidden0 = torch.randn(*state_shape_h, device=device)
+        hidden1 = torch.randn(*state_shape_c, device=device)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool, device=device)
+        is_init[0, 3] = True
+        is_init[1, 2] = True
+        is_init[1, 5] = True
+        is_init[2, 1] = True
+        data = TensorDict(
+            {"obs": obs, "hidden0": hidden0, "hidden1": hidden1, "is_init": is_init},
+            [B, T],
+        )
+
+        with set_recurrent_mode(True), torch.no_grad():
+            torch.manual_seed(1)
+            pad_out = pad_module(data.clone())
+            torch.manual_seed(1)
+            triton_out = triton_module(data.clone())
+
+        torch.testing.assert_close(
+            pad_out["feat"], triton_out["feat"], atol=5e-3, rtol=5e-3
+        )
+        torch.testing.assert_close(
+            pad_out["next", "hidden0"],
+            triton_out["next", "hidden0"],
+            atol=5e-3,
+            rtol=5e-3,
+        )
+        torch.testing.assert_close(
+            pad_out["next", "hidden1"],
+            triton_out["next", "hidden1"],
+            atol=5e-3,
+            rtol=5e-3,
         )
 
     @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
@@ -1363,6 +1444,100 @@ class TestLSTMModule:
             torch.testing.assert_close(
                 grads_pad[k], grads_triton[k], atol=5e-3, rtol=5e-3
             )
+
+    @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
+    @pytest.mark.parametrize(
+        "module_kwargs",
+        [
+            {"num_layers": 2},
+            {"bidirectional": True},
+            {"proj_size": 8},
+        ],
+    )
+    def test_lstm_module_triton_extended_backward_matches_pad(self, module_kwargs):
+        torch.manual_seed(0)
+        device = torch.device("cuda")
+        B, T, F, H = 4, 7, 3, 16
+        num_layers = module_kwargs.get("num_layers", 1)
+        num_directions = 2 if module_kwargs.get("bidirectional", False) else 1
+        proj_size = module_kwargs.get("proj_size", 0)
+        hidden_out = proj_size if proj_size > 0 else H
+        kwargs = {
+            "input_size": F,
+            "hidden_size": H,
+            "in_keys": ["obs", "hidden0", "hidden1"],
+            "out_keys": ["feat", ("next", "hidden0"), ("next", "hidden1")],
+            "device": device,
+            **module_kwargs,
+        }
+        pad_module = LSTMModule(**kwargs)
+        triton_module = LSTMModule(**kwargs, recurrent_backend="triton")
+        triton_module.load_state_dict(pad_module.state_dict())
+
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool, device=device)
+        is_init[1, 3] = True
+        is_init[2, 2] = True
+
+        def loss_and_grads(mod):
+            for p in mod.parameters():
+                if p.grad is not None:
+                    p.grad = None
+            obs = torch.randn(B, T, F, device=device, requires_grad=True)
+            hidden0 = torch.zeros(
+                B,
+                T,
+                num_layers * num_directions,
+                hidden_out,
+                device=device,
+                requires_grad=True,
+            )
+            hidden1 = torch.zeros(
+                B,
+                T,
+                num_layers * num_directions,
+                H,
+                device=device,
+                requires_grad=True,
+            )
+            data = TensorDict(
+                {
+                    "obs": obs,
+                    "hidden0": hidden0,
+                    "hidden1": hidden1,
+                    "is_init": is_init,
+                },
+                [B, T],
+            )
+            out = mod(data)
+            loss = (
+                out["feat"].pow(2).sum()
+                + out["next", "hidden0"].pow(2).sum()
+                + out["next", "hidden1"].pow(2).sum()
+            )
+            loss.backward()
+            grads = {k: p.grad.detach().clone() for k, p in mod.named_parameters()}
+            return grads, obs.grad, hidden0.grad, hidden1.grad
+
+        with set_recurrent_mode(True):
+            torch.manual_seed(1)
+            grads_pad, obs_grad_pad, h0_grad_pad, h1_grad_pad = loss_and_grads(
+                pad_module
+            )
+            torch.manual_seed(1)
+            (
+                grads_triton,
+                obs_grad_triton,
+                h0_grad_triton,
+                h1_grad_triton,
+            ) = loss_and_grads(triton_module)
+
+        for k in grads_pad:
+            torch.testing.assert_close(
+                grads_pad[k], grads_triton[k], atol=1e-2, rtol=1e-2
+            )
+        torch.testing.assert_close(obs_grad_pad, obs_grad_triton, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(h0_grad_pad, h0_grad_triton, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(h1_grad_pad, h1_grad_triton, atol=1e-2, rtol=1e-2)
 
     def test_lstm_module_triton_requires_triton(self, monkeypatch):
         from torchrl.modules.tensordict_module import rnn as rnn_module
@@ -1996,9 +2171,74 @@ class TestGRUModule:
             triton_out = triton_module(data.clone())
 
         atol = 5e-2 if compute_dtype == torch.bfloat16 else 5e-3
-        torch.testing.assert_close(pad_out["feat"], triton_out["feat"], atol=atol, rtol=atol)
         torch.testing.assert_close(
-            pad_out["next", "hidden"], triton_out["next", "hidden"], atol=atol, rtol=atol
+            pad_out["feat"], triton_out["feat"], atol=atol, rtol=atol
+        )
+        torch.testing.assert_close(
+            pad_out["next", "hidden"],
+            triton_out["next", "hidden"],
+            atol=atol,
+            rtol=atol,
+        )
+
+    @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
+    @pytest.mark.parametrize(
+        "module_kwargs,training",
+        [
+            ({"num_layers": 2}, False),
+            ({"num_layers": 2, "dropout": 0.3}, True),
+            ({"num_layers": 2, "dropout": 0.3}, False),
+            ({"bidirectional": True}, False),
+        ],
+    )
+    def test_gru_module_triton_extended_forward_matches_pad(
+        self, module_kwargs, training
+    ):
+        torch.manual_seed(0)
+        device = torch.device("cuda")
+        B, T, F, H = 4, 7, 3, 16
+        num_layers = module_kwargs.get("num_layers", 1)
+        num_directions = 2 if module_kwargs.get("bidirectional", False) else 1
+        kwargs = {
+            "input_size": F,
+            "hidden_size": H,
+            "in_keys": ["obs", "hidden"],
+            "out_keys": ["feat", ("next", "hidden")],
+            "device": device,
+            **module_kwargs,
+        }
+        pad_module = GRUModule(**kwargs)
+        triton_module = GRUModule(**kwargs, recurrent_backend="triton")
+        triton_module.load_state_dict(pad_module.state_dict())
+        pad_module.train(training)
+        triton_module.train(training)
+
+        obs = torch.randn(B, T, F, device=device)
+        hidden = torch.randn(B, T, num_layers * num_directions, H, device=device)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool, device=device)
+        is_init[0, 3] = True
+        is_init[1, 2] = True
+        is_init[1, 5] = True
+        is_init[2, 1] = True
+        data = TensorDict(
+            {"obs": obs, "hidden": hidden, "is_init": is_init},
+            [B, T],
+        )
+
+        with set_recurrent_mode(True), torch.no_grad():
+            torch.manual_seed(1)
+            pad_out = pad_module(data.clone())
+            torch.manual_seed(1)
+            triton_out = triton_module(data.clone())
+
+        torch.testing.assert_close(
+            pad_out["feat"], triton_out["feat"], atol=5e-3, rtol=5e-3
+        )
+        torch.testing.assert_close(
+            pad_out["next", "hidden"],
+            triton_out["next", "hidden"],
+            atol=5e-3,
+            rtol=5e-3,
         )
 
     @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
@@ -2030,9 +2270,7 @@ class TestGRUModule:
         hidden = torch.zeros(B, T, 1, H, device=device)
         is_init = torch.zeros(B, T, 1, dtype=torch.bool, device=device)
         is_init[1, 3] = True
-        data = TensorDict(
-            {"obs": obs, "hidden": hidden, "is_init": is_init}, [B, T]
-        )
+        data = TensorDict({"obs": obs, "hidden": hidden, "is_init": is_init}, [B, T])
 
         def loss_for(mod):
             for p in mod.parameters():
@@ -2057,6 +2295,75 @@ class TestGRUModule:
             torch.testing.assert_close(
                 grads_pad[k], grads_triton[k], atol=5e-3, rtol=5e-3
             )
+
+    @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
+    @pytest.mark.parametrize(
+        "module_kwargs",
+        [
+            {"num_layers": 2},
+            {"bidirectional": True},
+        ],
+    )
+    def test_gru_module_triton_extended_backward_matches_pad(self, module_kwargs):
+        torch.manual_seed(0)
+        device = torch.device("cuda")
+        B, T, F, H = 4, 7, 3, 16
+        num_layers = module_kwargs.get("num_layers", 1)
+        num_directions = 2 if module_kwargs.get("bidirectional", False) else 1
+        kwargs = {
+            "input_size": F,
+            "hidden_size": H,
+            "in_keys": ["obs", "hidden"],
+            "out_keys": ["feat", ("next", "hidden")],
+            "device": device,
+            **module_kwargs,
+        }
+        pad_module = GRUModule(**kwargs)
+        triton_module = GRUModule(**kwargs, recurrent_backend="triton")
+        triton_module.load_state_dict(pad_module.state_dict())
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool, device=device)
+        is_init[1, 3] = True
+        is_init[2, 2] = True
+
+        def loss_and_grads(mod):
+            for p in mod.parameters():
+                if p.grad is not None:
+                    p.grad = None
+            obs = torch.randn(B, T, F, device=device, requires_grad=True)
+            hidden = torch.zeros(
+                B,
+                T,
+                num_layers * num_directions,
+                H,
+                device=device,
+                requires_grad=True,
+            )
+            data = TensorDict(
+                {"obs": obs, "hidden": hidden, "is_init": is_init},
+                [B, T],
+            )
+            out = mod(data)
+            loss = out["feat"].pow(2).sum() + out["next", "hidden"].pow(2).sum()
+            loss.backward()
+            grads = {k: p.grad.detach().clone() for k, p in mod.named_parameters()}
+            return grads, obs.grad, hidden.grad
+
+        with set_recurrent_mode(True):
+            torch.manual_seed(1)
+            grads_pad, obs_grad_pad, hidden_grad_pad = loss_and_grads(pad_module)
+            torch.manual_seed(1)
+            grads_triton, obs_grad_triton, hidden_grad_triton = loss_and_grads(
+                triton_module
+            )
+
+        for k in grads_pad:
+            torch.testing.assert_close(
+                grads_pad[k], grads_triton[k], atol=1e-2, rtol=1e-2
+            )
+        torch.testing.assert_close(obs_grad_pad, obs_grad_triton, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(
+            hidden_grad_pad, hidden_grad_triton, atol=1e-2, rtol=1e-2
+        )
 
     def test_gru_module_triton_requires_triton(self, monkeypatch):
         from torchrl.modules.tensordict_module import rnn as rnn_module

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -1553,6 +1553,62 @@ class TestLSTMModule:
                 recurrent_backend="triton",
             )
 
+    @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
+    @pytest.mark.parametrize("num_layers", [1, 2])
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.6.0"),
+        reason="torch._higher_order_ops.scan requires Torch >= 2.6.0",
+    )
+    def test_lstm_module_three_backends_equivalent(self, num_layers):
+        """pad / scan / triton agree at the intersection of supported configs.
+
+        Scan does not support dropout, so this test fixes ``dropout=0``; the
+        pad-vs-triton dropout case is covered separately by
+        ``test_lstm_module_triton_extended_forward_matches_pad``.
+        """
+        torch.manual_seed(0)
+        device = torch.device("cuda")
+        B, T, F, H = 4, 7, 3, 16
+        kwargs = {
+            "input_size": F,
+            "hidden_size": H,
+            "num_layers": num_layers,
+            "in_keys": ["obs", "hidden0", "hidden1"],
+            "out_keys": ["feat", ("next", "hidden0"), ("next", "hidden1")],
+            "device": device,
+        }
+        pad_module = LSTMModule(**kwargs)
+        scan_module = LSTMModule(**kwargs, recurrent_backend="scan")
+        triton_module = LSTMModule(**kwargs, recurrent_backend="triton")
+        scan_module.load_state_dict(pad_module.state_dict())
+        triton_module.load_state_dict(pad_module.state_dict())
+
+        obs = torch.randn(B, T, F, device=device)
+        hidden0 = torch.randn(B, T, num_layers, H, device=device)
+        hidden1 = torch.randn(B, T, num_layers, H, device=device)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool, device=device)
+        is_init[0, 3] = True
+        is_init[1, 2] = True
+        is_init[1, 5] = True
+        is_init[2, 1] = True
+        data = TensorDict(
+            {"obs": obs, "hidden0": hidden0, "hidden1": hidden1, "is_init": is_init},
+            [B, T],
+        )
+
+        with set_recurrent_mode(True), torch.no_grad():
+            pad_out = pad_module(data.clone())
+            scan_out = scan_module(data.clone())
+            triton_out = triton_module(data.clone())
+
+        for key in ["feat", ("next", "hidden0"), ("next", "hidden1")]:
+            torch.testing.assert_close(
+                pad_out[key], scan_out[key], atol=5e-3, rtol=5e-3
+            )
+            torch.testing.assert_close(
+                pad_out[key], triton_out[key], atol=5e-3, rtol=5e-3
+            )
+
 
 class TestGRUModule:
     def test_errs(self):
@@ -2377,6 +2433,61 @@ class TestGRUModule:
                 in_keys=["obs", "hidden"],
                 out_keys=["feat", ("next", "hidden")],
                 recurrent_backend="triton",
+            )
+
+    @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
+    @pytest.mark.parametrize("num_layers", [1, 2])
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.6.0"),
+        reason="torch._higher_order_ops.scan requires Torch >= 2.6.0",
+    )
+    def test_gru_module_three_backends_equivalent(self, num_layers):
+        """pad / scan / triton agree at the intersection of supported configs.
+
+        Scan does not support dropout, so this test fixes ``dropout=0``; the
+        pad-vs-triton dropout case is covered separately by
+        ``test_gru_module_triton_extended_forward_matches_pad``.
+        """
+        torch.manual_seed(0)
+        device = torch.device("cuda")
+        B, T, F, H = 4, 7, 3, 16
+        kwargs = {
+            "input_size": F,
+            "hidden_size": H,
+            "num_layers": num_layers,
+            "in_keys": ["obs", "hidden"],
+            "out_keys": ["feat", ("next", "hidden")],
+            "device": device,
+        }
+        pad_module = GRUModule(**kwargs)
+        scan_module = GRUModule(**kwargs, recurrent_backend="scan")
+        triton_module = GRUModule(**kwargs, recurrent_backend="triton")
+        scan_module.load_state_dict(pad_module.state_dict())
+        triton_module.load_state_dict(pad_module.state_dict())
+
+        obs = torch.randn(B, T, F, device=device)
+        hidden = torch.randn(B, T, num_layers, H, device=device)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool, device=device)
+        is_init[0, 3] = True
+        is_init[1, 2] = True
+        is_init[1, 5] = True
+        is_init[2, 1] = True
+        data = TensorDict(
+            {"obs": obs, "hidden": hidden, "is_init": is_init},
+            [B, T],
+        )
+
+        with set_recurrent_mode(True), torch.no_grad():
+            pad_out = pad_module(data.clone())
+            scan_out = scan_module(data.clone())
+            triton_out = triton_module(data.clone())
+
+        for key in ["feat", ("next", "hidden")]:
+            torch.testing.assert_close(
+                pad_out[key], scan_out[key], atol=5e-3, rtol=5e-3
+            )
+            torch.testing.assert_close(
+                pad_out[key], triton_out[key], atol=5e-3, rtol=5e-3
             )
 
 

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -1370,21 +1370,34 @@ class TestLSTMModule:
             torch.manual_seed(1)
             triton_out = triton_module(data.clone())
 
-        torch.testing.assert_close(
-            pad_out["feat"], triton_out["feat"], atol=5e-3, rtol=5e-3
-        )
-        torch.testing.assert_close(
-            pad_out["next", "hidden0"],
-            triton_out["next", "hidden0"],
-            atol=5e-3,
-            rtol=5e-3,
-        )
-        torch.testing.assert_close(
-            pad_out["next", "hidden1"],
-            triton_out["next", "hidden1"],
-            atol=5e-3,
-            rtol=5e-3,
-        )
+        # Bit-exact equivalence isn't achievable in training mode with dropout:
+        # cuDNN's nn.LSTM stores its dropout mask state in a cuDNN dropout
+        # descriptor that advances independently of torch's global RNG, while
+        # the triton backend's between-layer ``F.dropout`` consumes torch's
+        # RNG directly. Verify both produce sane, same-shape outputs instead.
+        dropout_active = training and module_kwargs.get("dropout", 0.0) > 0
+        if dropout_active:
+            for key in ["feat", ("next", "hidden0"), ("next", "hidden1")]:
+                assert pad_out[key].shape == triton_out[key].shape
+                assert pad_out[key].dtype == triton_out[key].dtype
+                assert torch.isfinite(pad_out[key]).all()
+                assert torch.isfinite(triton_out[key]).all()
+        else:
+            torch.testing.assert_close(
+                pad_out["feat"], triton_out["feat"], atol=5e-3, rtol=5e-3
+            )
+            torch.testing.assert_close(
+                pad_out["next", "hidden0"],
+                triton_out["next", "hidden0"],
+                atol=5e-3,
+                rtol=5e-3,
+            )
+            torch.testing.assert_close(
+                pad_out["next", "hidden1"],
+                triton_out["next", "hidden1"],
+                atol=5e-3,
+                rtol=5e-3,
+            )
 
     @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
     def test_lstm_module_triton_backward(self):
@@ -2287,15 +2300,26 @@ class TestGRUModule:
             torch.manual_seed(1)
             triton_out = triton_module(data.clone())
 
-        torch.testing.assert_close(
-            pad_out["feat"], triton_out["feat"], atol=5e-3, rtol=5e-3
-        )
-        torch.testing.assert_close(
-            pad_out["next", "hidden"],
-            triton_out["next", "hidden"],
-            atol=5e-3,
-            rtol=5e-3,
-        )
+        # See comment on test_lstm_module_triton_extended_forward_matches_pad:
+        # under dropout + training=True the two backends draw their masks from
+        # different RNG state and bit-exact comparison is not meaningful.
+        dropout_active = training and module_kwargs.get("dropout", 0.0) > 0
+        if dropout_active:
+            for key in ["feat", ("next", "hidden")]:
+                assert pad_out[key].shape == triton_out[key].shape
+                assert pad_out[key].dtype == triton_out[key].dtype
+                assert torch.isfinite(pad_out[key]).all()
+                assert torch.isfinite(triton_out[key]).all()
+        else:
+            torch.testing.assert_close(
+                pad_out["feat"], triton_out["feat"], atol=5e-3, rtol=5e-3
+            )
+            torch.testing.assert_close(
+                pad_out["next", "hidden"],
+                triton_out["next", "hidden"],
+                atol=5e-3,
+                rtol=5e-3,
+            )
 
     @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
     def test_gru_module_triton_backward(self):

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -71,6 +71,13 @@ from torchrl.testing.mocking_classes import CountingEnv, DiscreteActionVecMockEn
 
 TORCH_VERSION = version.parse(version.parse(torch.__version__).base_version)
 
+import importlib.util as _importlib_util  # noqa: E402
+
+_has_triton = (
+    _importlib_util.find_spec("triton") is not None and torch.cuda.is_available()
+)
+_triton_skip_reason = "requires triton and CUDA"
+
 _has_functorch = False
 try:
     try:
@@ -1245,6 +1252,132 @@ class TestLSTMModule:
             scan_out["next", "hidden1"], auto_scan_out["next", "hidden1"]
         )
 
+    @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
+    @pytest.mark.parametrize("compute_dtype", [torch.float32, torch.bfloat16])
+    @pytest.mark.parametrize("H", [16, 64])
+    def test_lstm_module_triton_backend_matches_pad(self, H, compute_dtype):
+        torch.manual_seed(0)
+        device = torch.device("cuda")
+        B, T, F = 4, 7, 3
+        pad_module = LSTMModule(
+            input_size=F,
+            hidden_size=H,
+            num_layers=1,
+            in_keys=["obs", "hidden0", "hidden1"],
+            out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
+            device=device,
+        )
+        triton_module = LSTMModule(
+            input_size=F,
+            hidden_size=H,
+            num_layers=1,
+            in_keys=["obs", "hidden0", "hidden1"],
+            out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
+            recurrent_backend="triton",
+            recurrent_compute_dtype=compute_dtype,
+            device=device,
+        )
+        triton_module.load_state_dict(pad_module.state_dict())
+
+        obs = torch.randn(B, T, F, device=device)
+        hidden0 = torch.randn(B, T, 1, H, device=device)
+        hidden1 = torch.randn(B, T, 1, H, device=device)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool, device=device)
+        is_init[0, 3] = True
+        is_init[1, 2] = True
+        is_init[1, 5] = True
+        is_init[2, 1] = True
+        data = TensorDict(
+            {"obs": obs, "hidden0": hidden0, "hidden1": hidden1, "is_init": is_init},
+            [B, T],
+        )
+
+        with set_recurrent_mode(True), torch.no_grad():
+            pad_out = pad_module(data.clone())
+            triton_out = triton_module(data.clone())
+
+        atol = 5e-2 if compute_dtype == torch.bfloat16 else 5e-3
+        torch.testing.assert_close(pad_out["feat"], triton_out["feat"], atol=atol, rtol=atol)
+        torch.testing.assert_close(
+            pad_out["next", "hidden0"], triton_out["next", "hidden0"], atol=atol, rtol=atol
+        )
+        torch.testing.assert_close(
+            pad_out["next", "hidden1"], triton_out["next", "hidden1"], atol=atol, rtol=atol
+        )
+
+    @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
+    def test_lstm_module_triton_backward(self):
+        """Backward path: gradients match pad backend within tolerance."""
+        torch.manual_seed(0)
+        device = torch.device("cuda")
+        B, T, F, H = 4, 7, 3, 64
+        pad_module = LSTMModule(
+            input_size=F,
+            hidden_size=H,
+            num_layers=1,
+            in_keys=["obs", "hidden0", "hidden1"],
+            out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
+            device=device,
+        )
+        triton_module = LSTMModule(
+            input_size=F,
+            hidden_size=H,
+            num_layers=1,
+            in_keys=["obs", "hidden0", "hidden1"],
+            out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
+            recurrent_backend="triton",
+            device=device,
+        )
+        triton_module.load_state_dict(pad_module.state_dict())
+
+        obs = torch.randn(B, T, F, device=device)
+        hidden0 = torch.zeros(B, T, 1, H, device=device)
+        hidden1 = torch.zeros(B, T, 1, H, device=device)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool, device=device)
+        is_init[1, 3] = True
+        data = TensorDict(
+            {"obs": obs, "hidden0": hidden0, "hidden1": hidden1, "is_init": is_init},
+            [B, T],
+        )
+
+        def loss_for(mod):
+            for p in mod.parameters():
+                if p.grad is not None:
+                    p.grad = None
+            out = mod(data.clone())
+            return out["feat"].pow(2).sum()
+
+        with set_recurrent_mode(True):
+            loss_pad = loss_for(pad_module)
+            loss_pad.backward()
+            grads_pad = {
+                k: p.grad.detach().clone() for k, p in pad_module.named_parameters()
+            }
+            loss_triton = loss_for(triton_module)
+            loss_triton.backward()
+            grads_triton = {
+                k: p.grad.detach().clone() for k, p in triton_module.named_parameters()
+            }
+
+        for k in grads_pad:
+            torch.testing.assert_close(
+                grads_pad[k], grads_triton[k], atol=5e-3, rtol=5e-3
+            )
+
+    def test_lstm_module_triton_requires_triton(self, monkeypatch):
+        from torchrl.modules.tensordict_module import rnn as rnn_module
+
+        monkeypatch.setattr(rnn_module, "_has_triton", False)
+        with pytest.raises(RuntimeError, match="triton"):
+            LSTMModule(
+                input_size=3,
+                hidden_size=12,
+                num_layers=1,
+                in_keys=["obs", "hidden0", "hidden1"],
+                out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
+                recurrent_backend="triton",
+            )
+
 
 class TestGRUModule:
     def test_errs(self):
@@ -1818,6 +1951,126 @@ class TestGRUModule:
         torch.testing.assert_close(
             scan_out["next", "hidden"], auto_scan_out["next", "hidden"]
         )
+
+    @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
+    @pytest.mark.parametrize("compute_dtype", [torch.float32, torch.bfloat16])
+    @pytest.mark.parametrize("H", [16, 64])
+    def test_gru_module_triton_backend_matches_pad(self, H, compute_dtype):
+        torch.manual_seed(0)
+        device = torch.device("cuda")
+        B, T, F = 4, 7, 3
+        pad_module = GRUModule(
+            input_size=F,
+            hidden_size=H,
+            num_layers=1,
+            in_keys=["obs", "hidden"],
+            out_keys=["feat", ("next", "hidden")],
+            device=device,
+        )
+        triton_module = GRUModule(
+            input_size=F,
+            hidden_size=H,
+            num_layers=1,
+            in_keys=["obs", "hidden"],
+            out_keys=["feat", ("next", "hidden")],
+            recurrent_backend="triton",
+            recurrent_compute_dtype=compute_dtype,
+            device=device,
+        )
+        triton_module.load_state_dict(pad_module.state_dict())
+
+        obs = torch.randn(B, T, F, device=device)
+        hidden = torch.randn(B, T, 1, H, device=device)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool, device=device)
+        is_init[0, 3] = True
+        is_init[1, 2] = True
+        is_init[1, 5] = True
+        is_init[2, 1] = True
+        data = TensorDict(
+            {"obs": obs, "hidden": hidden, "is_init": is_init},
+            [B, T],
+        )
+
+        with set_recurrent_mode(True), torch.no_grad():
+            pad_out = pad_module(data.clone())
+            triton_out = triton_module(data.clone())
+
+        atol = 5e-2 if compute_dtype == torch.bfloat16 else 5e-3
+        torch.testing.assert_close(pad_out["feat"], triton_out["feat"], atol=atol, rtol=atol)
+        torch.testing.assert_close(
+            pad_out["next", "hidden"], triton_out["next", "hidden"], atol=atol, rtol=atol
+        )
+
+    @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
+    def test_gru_module_triton_backward(self):
+        """Backward path: gradients match pad backend within tolerance."""
+        torch.manual_seed(0)
+        device = torch.device("cuda")
+        B, T, F, H = 4, 7, 3, 64
+        pad_module = GRUModule(
+            input_size=F,
+            hidden_size=H,
+            num_layers=1,
+            in_keys=["obs", "hidden"],
+            out_keys=["feat", ("next", "hidden")],
+            device=device,
+        )
+        triton_module = GRUModule(
+            input_size=F,
+            hidden_size=H,
+            num_layers=1,
+            in_keys=["obs", "hidden"],
+            out_keys=["feat", ("next", "hidden")],
+            recurrent_backend="triton",
+            device=device,
+        )
+        triton_module.load_state_dict(pad_module.state_dict())
+
+        obs = torch.randn(B, T, F, device=device)
+        hidden = torch.zeros(B, T, 1, H, device=device)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool, device=device)
+        is_init[1, 3] = True
+        data = TensorDict(
+            {"obs": obs, "hidden": hidden, "is_init": is_init}, [B, T]
+        )
+
+        def loss_for(mod):
+            for p in mod.parameters():
+                if p.grad is not None:
+                    p.grad = None
+            out = mod(data.clone())
+            return out["feat"].pow(2).sum()
+
+        with set_recurrent_mode(True):
+            loss_pad = loss_for(pad_module)
+            loss_pad.backward()
+            grads_pad = {
+                k: p.grad.detach().clone() for k, p in pad_module.named_parameters()
+            }
+            loss_triton = loss_for(triton_module)
+            loss_triton.backward()
+            grads_triton = {
+                k: p.grad.detach().clone() for k, p in triton_module.named_parameters()
+            }
+
+        for k in grads_pad:
+            torch.testing.assert_close(
+                grads_pad[k], grads_triton[k], atol=5e-3, rtol=5e-3
+            )
+
+    def test_gru_module_triton_requires_triton(self, monkeypatch):
+        from torchrl.modules.tensordict_module import rnn as rnn_module
+
+        monkeypatch.setattr(rnn_module, "_has_triton", False)
+        with pytest.raises(RuntimeError, match="triton"):
+            GRUModule(
+                input_size=3,
+                hidden_size=12,
+                num_layers=1,
+                in_keys=["obs", "hidden"],
+                out_keys=["feat", ("next", "hidden")],
+                recurrent_backend="triton",
+            )
 
 
 def test_safe_specs():

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -73,10 +73,27 @@ TORCH_VERSION = version.parse(version.parse(torch.__version__).base_version)
 
 import importlib.util as _importlib_util  # noqa: E402
 
-_has_triton = (
-    _importlib_util.find_spec("triton") is not None and torch.cuda.is_available()
-)
-_triton_skip_reason = "requires triton and CUDA"
+
+def _has_triton_backend() -> bool:
+    """Mirror of the triton-availability check inside the RNN backend.
+
+    Triton must be installed, CUDA must be available, and the Triton build
+    must expose the ``triton.language.extra.libdevice`` submodule
+    (Triton >= 2.2). Older Triton installations are routed to scan/pad
+    backends, so the triton-specific tests are skipped there.
+    """
+    if (
+        _importlib_util.find_spec("triton") is None
+        or not torch.cuda.is_available()
+    ):
+        return False
+    return (
+        _importlib_util.find_spec("triton.language.extra.libdevice") is not None
+    )
+
+
+_has_triton = _has_triton_backend()
+_triton_skip_reason = "requires triton (>= 2.2) and CUDA"
 
 _has_functorch = False
 try:

--- a/torchrl/modules/tensordict_module/_rnn_triton.py
+++ b/torchrl/modules/tensordict_module/_rnn_triton.py
@@ -19,10 +19,15 @@ size we care about in RL.
 
 Limitations of this prototype:
 
-* ``num_layers == 1`` only.
-* No dropout, no projection (``proj_size``), no bidirectional.
+* Low-level kernels operate on one layer and one direction at a time.
+  Multilayer module wrappers therefore autotune once per layer shape on the
+  first call.
+* No projection (``proj_size``) in the low-level kernel.
 * ``hidden_size`` is internally padded to the next power of two (kept on the
   Python side; no in-kernel masking).
+* The autograd wrapper saves per-layer gate activations explicitly. Multilayer
+  execution scales this activation memory linearly with the number of layers,
+  unlike cuDNN's opaque ``reserve_space``.
 * ``compute_dtype`` controls the matmul precision: ``torch.float32`` (default,
   TF32 on Ampere/Hopper, matching ``torch.nn.GRU`` / ``LSTM`` behavior) or
   ``torch.bfloat16`` (twice the SMEM headroom, ~7-bit mantissa).
@@ -546,6 +551,7 @@ if _has_triton:
         save_o_ptr,
         save_tanhc_ptr,
         dout_ptr,
+        dc_out_ptr,
         dh_final_ptr,
         dc_final_ptr,
         dgates_x_ptr,
@@ -580,6 +586,7 @@ if _has_triton:
             t = T - 1 - t_inv
             base_out = b_off[:, None] * (T * H) + t * H + h_off[None, :]
             dout_t = tl.load(dout_ptr + base_out, mask=mask_b[:, None], other=0.0)
+            dc_out_t = tl.load(dc_out_ptr + base_out, mask=mask_b[:, None], other=0.0)
             i = tl.load(save_i_ptr + base_out, mask=mask_b[:, None], other=0.0)
             f = tl.load(save_f_ptr + base_out, mask=mask_b[:, None], other=0.0)
             g = tl.load(save_g_ptr + base_out, mask=mask_b[:, None], other=0.0)
@@ -604,7 +611,7 @@ if _has_triton:
 
             dh = dout_t + dh_next
             do = dh * tanh_c
-            dc = dc_next + dh * o * (1.0 - tanh_c * tanh_c)
+            dc = dc_out_t + dc_next + dh * o * (1.0 - tanh_c * tanh_c)
 
             df = dc * c_prev
             di = dc * g
@@ -1074,13 +1081,6 @@ class _LSTMFn(torch.autograd.Function):
         dc_out_p = _pad_last(dc_out.contiguous(), H, H_pad).contiguous()
         dh_final_p = _pad_last(dh_final.contiguous(), H, H_pad).contiguous()
         dc_final_p = _pad_last(dc_final.contiguous(), H, H_pad).contiguous()
-        # Note: dc_out (gradient on intermediate c_t) is not propagated by the
-        # bwd kernel — its consumers are expected to use only the final c
-        # (or the values at trajectory ends). If a user passes a non-zero
-        # gradient through intermediate c_t we silently drop it. Documented
-        # under the triton backend's known limitations.
-        del dc_out_p
-
         dgates_x = torch.empty(B, T, 4 * H_pad, dtype=x.dtype, device=x.device)
         dgates_h = torch.empty_like(dgates_x)
         dhidden_p = torch.zeros_like(hidden_p)
@@ -1105,6 +1105,7 @@ class _LSTMFn(torch.autograd.Function):
             save_o,
             save_tanhc,
             dout_p,
+            dc_out_p,
             dh_final_p,
             dc_final_p,
             dgates_x,

--- a/torchrl/modules/tensordict_module/_rnn_triton.py
+++ b/torchrl/modules/tensordict_module/_rnn_triton.py
@@ -128,9 +128,21 @@ if _has_triton:
 
         for t in range(T):
             base_x = b_off[:, None] * (T * 3 * H) + t * (3 * H)
-            gx_r = tl.load(gates_x_ptr + base_x + 0 * H + h_off[None, :], mask=mask_b[:, None], other=0.0)
-            gx_z = tl.load(gates_x_ptr + base_x + 1 * H + h_off[None, :], mask=mask_b[:, None], other=0.0)
-            gx_n = tl.load(gates_x_ptr + base_x + 2 * H + h_off[None, :], mask=mask_b[:, None], other=0.0)
+            gx_r = tl.load(
+                gates_x_ptr + base_x + 0 * H + h_off[None, :],
+                mask=mask_b[:, None],
+                other=0.0,
+            )
+            gx_z = tl.load(
+                gates_x_ptr + base_x + 1 * H + h_off[None, :],
+                mask=mask_b[:, None],
+                other=0.0,
+            )
+            gx_n = tl.load(
+                gates_x_ptr + base_x + 2 * H + h_off[None, :],
+                mask=mask_b[:, None],
+                other=0.0,
+            )
 
             is_init = tl.load(is_init_ptr + b_off * T + t, mask=mask_b, other=False)
             reset_h = tl.load(
@@ -154,7 +166,10 @@ if _has_triton:
                     )
                 else:
                     h_prev_stored = tl.load(
-                        out_ptr + b_off[:, None] * (T * H) + (t - 1) * H + k_off[None, :],
+                        out_ptr
+                        + b_off[:, None] * (T * H)
+                        + (t - 1) * H
+                        + k_off[None, :],
                         mask=mask_b[:, None],
                         other=0.0,
                     )
@@ -189,7 +204,9 @@ if _has_triton:
             tl.store(save_n_ptr + base_out, n, mask=mask_b[:, None])
             tl.store(save_gh_n_ptr + base_out, gh_n, mask=mask_b[:, None])
 
-        tl.store(h_final_ptr + b_off[:, None] * H + h_off[None, :], h, mask=mask_b[:, None])
+        tl.store(
+            h_final_ptr + b_off[:, None] * H + h_off[None, :], h, mask=mask_b[:, None]
+        )
 
     # ------------------------------------------------------------------------
     # GRU backward
@@ -274,25 +291,55 @@ if _has_triton:
             dr_pre = (dn_pre * gh_n) * r * (1.0 - r)
 
             base_gx = b_off[:, None] * (T * 3 * H) + t * (3 * H)
-            tl.store(dgates_x_ptr + base_gx + 0 * H + h_off[None, :], dr_pre, mask=mask_b[:, None])
-            tl.store(dgates_x_ptr + base_gx + 1 * H + h_off[None, :], dz_pre, mask=mask_b[:, None])
-            tl.store(dgates_x_ptr + base_gx + 2 * H + h_off[None, :], dn_pre, mask=mask_b[:, None])
-            tl.store(dgates_h_ptr + base_gx + 0 * H + h_off[None, :], dr_pre, mask=mask_b[:, None])
-            tl.store(dgates_h_ptr + base_gx + 1 * H + h_off[None, :], dz_pre, mask=mask_b[:, None])
-            tl.store(dgates_h_ptr + base_gx + 2 * H + h_off[None, :], dgh_n, mask=mask_b[:, None])
+            tl.store(
+                dgates_x_ptr + base_gx + 0 * H + h_off[None, :],
+                dr_pre,
+                mask=mask_b[:, None],
+            )
+            tl.store(
+                dgates_x_ptr + base_gx + 1 * H + h_off[None, :],
+                dz_pre,
+                mask=mask_b[:, None],
+            )
+            tl.store(
+                dgates_x_ptr + base_gx + 2 * H + h_off[None, :],
+                dn_pre,
+                mask=mask_b[:, None],
+            )
+            tl.store(
+                dgates_h_ptr + base_gx + 0 * H + h_off[None, :],
+                dr_pre,
+                mask=mask_b[:, None],
+            )
+            tl.store(
+                dgates_h_ptr + base_gx + 1 * H + h_off[None, :],
+                dz_pre,
+                mask=mask_b[:, None],
+            )
+            tl.store(
+                dgates_h_ptr + base_gx + 2 * H + h_off[None, :],
+                dgh_n,
+                mask=mask_b[:, None],
+            )
 
             dh_prev_total = dh_prev_direct
             for k_iter in tl.static_range(N_K):
                 k_off = k_iter * BLOCK_K + k_inner
                 base_gx_k = b_off[:, None] * (T * 3 * H) + t * (3 * H) + k_off[None, :]
                 w_r_chunk = tl.load(w_r_ptr + k_off[:, None] * H + h_off[None, :])
-                dr_chunk = tl.load(dgates_h_ptr + base_gx_k + 0 * H, mask=mask_b[:, None], other=0.0)
+                dr_chunk = tl.load(
+                    dgates_h_ptr + base_gx_k + 0 * H, mask=mask_b[:, None], other=0.0
+                )
                 dh_prev_total += tl.dot(dr_chunk.to(w_r_chunk.dtype), w_r_chunk)
                 w_z_chunk = tl.load(w_z_ptr + k_off[:, None] * H + h_off[None, :])
-                dz_chunk = tl.load(dgates_h_ptr + base_gx_k + 1 * H, mask=mask_b[:, None], other=0.0)
+                dz_chunk = tl.load(
+                    dgates_h_ptr + base_gx_k + 1 * H, mask=mask_b[:, None], other=0.0
+                )
                 dh_prev_total += tl.dot(dz_chunk.to(w_z_chunk.dtype), w_z_chunk)
                 w_n_chunk = tl.load(w_n_ptr + k_off[:, None] * H + h_off[None, :])
-                dn_chunk = tl.load(dgates_h_ptr + base_gx_k + 2 * H, mask=mask_b[:, None], other=0.0)
+                dn_chunk = tl.load(
+                    dgates_h_ptr + base_gx_k + 2 * H, mask=mask_b[:, None], other=0.0
+                )
                 dh_prev_total += tl.dot(dn_chunk.to(w_n_chunk.dtype), w_n_chunk)
 
             # At reset positions, dh_prev flows into dhidden[b, t] not dh_{t-1}.
@@ -323,7 +370,7 @@ if _has_triton:
     def _lstm_fwd_kernel(
         gates_x_ptr,
         hidden_ptr,  # [B, T, H]
-        cell_ptr,    # [B, T, H]
+        cell_ptr,  # [B, T, H]
         w_i_ptr,
         w_f_ptr,
         w_g_ptr,
@@ -369,10 +416,26 @@ if _has_triton:
 
         for t in range(T):
             base_x = b_off[:, None] * (T * 4 * H) + t * (4 * H)
-            gx_i = tl.load(gates_x_ptr + base_x + 0 * H + h_off[None, :], mask=mask_b[:, None], other=0.0)
-            gx_f = tl.load(gates_x_ptr + base_x + 1 * H + h_off[None, :], mask=mask_b[:, None], other=0.0)
-            gx_g = tl.load(gates_x_ptr + base_x + 2 * H + h_off[None, :], mask=mask_b[:, None], other=0.0)
-            gx_o = tl.load(gates_x_ptr + base_x + 3 * H + h_off[None, :], mask=mask_b[:, None], other=0.0)
+            gx_i = tl.load(
+                gates_x_ptr + base_x + 0 * H + h_off[None, :],
+                mask=mask_b[:, None],
+                other=0.0,
+            )
+            gx_f = tl.load(
+                gates_x_ptr + base_x + 1 * H + h_off[None, :],
+                mask=mask_b[:, None],
+                other=0.0,
+            )
+            gx_g = tl.load(
+                gates_x_ptr + base_x + 2 * H + h_off[None, :],
+                mask=mask_b[:, None],
+                other=0.0,
+            )
+            gx_o = tl.load(
+                gates_x_ptr + base_x + 3 * H + h_off[None, :],
+                mask=mask_b[:, None],
+                other=0.0,
+            )
 
             is_init = tl.load(is_init_ptr + b_off * T + t, mask=mask_b, other=False)
             reset_h = tl.load(
@@ -403,7 +466,10 @@ if _has_triton:
                     )
                 else:
                     h_prev_stored = tl.load(
-                        out_ptr + b_off[:, None] * (T * H) + (t - 1) * H + k_off[None, :],
+                        out_ptr
+                        + b_off[:, None] * (T * H)
+                        + (t - 1) * H
+                        + k_off[None, :],
                         mask=mask_b[:, None],
                         other=0.0,
                     )
@@ -446,8 +512,12 @@ if _has_triton:
             tl.store(save_o_ptr + base_out, o, mask=mask_b[:, None])
             tl.store(save_tanhc_ptr + base_out, tanh_c, mask=mask_b[:, None])
 
-        tl.store(h_final_ptr + b_off[:, None] * H + h_off[None, :], h, mask=mask_b[:, None])
-        tl.store(c_final_ptr + b_off[:, None] * H + h_off[None, :], c, mask=mask_b[:, None])
+        tl.store(
+            h_final_ptr + b_off[:, None] * H + h_off[None, :], h, mask=mask_b[:, None]
+        )
+        tl.store(
+            c_final_ptr + b_off[:, None] * H + h_off[None, :], c, mask=mask_b[:, None]
+        )
 
     # ------------------------------------------------------------------------
     # LSTM backward
@@ -547,30 +617,70 @@ if _has_triton:
             do_pre = do * o * (1.0 - o)
 
             base_gx = b_off[:, None] * (T * 4 * H) + t * (4 * H)
-            tl.store(dgates_x_ptr + base_gx + 0 * H + h_off[None, :], di_pre, mask=mask_b[:, None])
-            tl.store(dgates_x_ptr + base_gx + 1 * H + h_off[None, :], df_pre, mask=mask_b[:, None])
-            tl.store(dgates_x_ptr + base_gx + 2 * H + h_off[None, :], dg_pre, mask=mask_b[:, None])
-            tl.store(dgates_x_ptr + base_gx + 3 * H + h_off[None, :], do_pre, mask=mask_b[:, None])
-            tl.store(dgates_h_ptr + base_gx + 0 * H + h_off[None, :], di_pre, mask=mask_b[:, None])
-            tl.store(dgates_h_ptr + base_gx + 1 * H + h_off[None, :], df_pre, mask=mask_b[:, None])
-            tl.store(dgates_h_ptr + base_gx + 2 * H + h_off[None, :], dg_pre, mask=mask_b[:, None])
-            tl.store(dgates_h_ptr + base_gx + 3 * H + h_off[None, :], do_pre, mask=mask_b[:, None])
+            tl.store(
+                dgates_x_ptr + base_gx + 0 * H + h_off[None, :],
+                di_pre,
+                mask=mask_b[:, None],
+            )
+            tl.store(
+                dgates_x_ptr + base_gx + 1 * H + h_off[None, :],
+                df_pre,
+                mask=mask_b[:, None],
+            )
+            tl.store(
+                dgates_x_ptr + base_gx + 2 * H + h_off[None, :],
+                dg_pre,
+                mask=mask_b[:, None],
+            )
+            tl.store(
+                dgates_x_ptr + base_gx + 3 * H + h_off[None, :],
+                do_pre,
+                mask=mask_b[:, None],
+            )
+            tl.store(
+                dgates_h_ptr + base_gx + 0 * H + h_off[None, :],
+                di_pre,
+                mask=mask_b[:, None],
+            )
+            tl.store(
+                dgates_h_ptr + base_gx + 1 * H + h_off[None, :],
+                df_pre,
+                mask=mask_b[:, None],
+            )
+            tl.store(
+                dgates_h_ptr + base_gx + 2 * H + h_off[None, :],
+                dg_pre,
+                mask=mask_b[:, None],
+            )
+            tl.store(
+                dgates_h_ptr + base_gx + 3 * H + h_off[None, :],
+                do_pre,
+                mask=mask_b[:, None],
+            )
 
             dh_prev_total = tl.zeros_like(dh_next)
             for k_iter in tl.static_range(N_K):
                 k_off = k_iter * BLOCK_K + k_inner
                 base_gx_k = b_off[:, None] * (T * 4 * H) + t * (4 * H) + k_off[None, :]
                 w_i_chunk = tl.load(w_i_ptr + k_off[:, None] * H + h_off[None, :])
-                di_chunk = tl.load(dgates_h_ptr + base_gx_k + 0 * H, mask=mask_b[:, None], other=0.0)
+                di_chunk = tl.load(
+                    dgates_h_ptr + base_gx_k + 0 * H, mask=mask_b[:, None], other=0.0
+                )
                 dh_prev_total += tl.dot(di_chunk.to(w_i_chunk.dtype), w_i_chunk)
                 w_f_chunk = tl.load(w_f_ptr + k_off[:, None] * H + h_off[None, :])
-                df_chunk = tl.load(dgates_h_ptr + base_gx_k + 1 * H, mask=mask_b[:, None], other=0.0)
+                df_chunk = tl.load(
+                    dgates_h_ptr + base_gx_k + 1 * H, mask=mask_b[:, None], other=0.0
+                )
                 dh_prev_total += tl.dot(df_chunk.to(w_f_chunk.dtype), w_f_chunk)
                 w_g_chunk = tl.load(w_g_ptr + k_off[:, None] * H + h_off[None, :])
-                dg_chunk = tl.load(dgates_h_ptr + base_gx_k + 2 * H, mask=mask_b[:, None], other=0.0)
+                dg_chunk = tl.load(
+                    dgates_h_ptr + base_gx_k + 2 * H, mask=mask_b[:, None], other=0.0
+                )
                 dh_prev_total += tl.dot(dg_chunk.to(w_g_chunk.dtype), w_g_chunk)
                 w_o_chunk = tl.load(w_o_ptr + k_off[:, None] * H + h_off[None, :])
-                do_chunk = tl.load(dgates_h_ptr + base_gx_k + 3 * H, mask=mask_b[:, None], other=0.0)
+                do_chunk = tl.load(
+                    dgates_h_ptr + base_gx_k + 3 * H, mask=mask_b[:, None], other=0.0
+                )
                 dh_prev_total += tl.dot(do_chunk.to(w_o_chunk.dtype), w_o_chunk)
 
             tl.atomic_add(
@@ -603,7 +713,9 @@ if _has_triton:
 # ============================================================================
 
 
-_MIN_H_PAD_PY = 16  # mirror of _MIN_H_PAD; constant so callers outside Triton block can use it
+_MIN_H_PAD_PY = (
+    16  # mirror of _MIN_H_PAD; constant so callers outside Triton block can use it
+)
 
 
 def _next_pow2(n: int) -> int:
@@ -625,7 +737,9 @@ def _pad_last(t: torch.Tensor, H: int, H_pad: int) -> torch.Tensor:
     return torch.cat([t, t.new_zeros(*pad)], dim=-1)
 
 
-def _pad_gate_dim(t: torch.Tensor, n_gates: int, H: int, H_pad: int, dim: int = 0) -> torch.Tensor:
+def _pad_gate_dim(
+    t: torch.Tensor, n_gates: int, H: int, H_pad: int, dim: int = 0
+) -> torch.Tensor:
     if H == H_pad:
         return t
     shape = list(t.shape)
@@ -653,7 +767,9 @@ def _unpad_last(t: torch.Tensor, H: int, H_pad: int) -> torch.Tensor:
     return t[..., :H].contiguous()
 
 
-def _unpad_gate_dim(t: torch.Tensor, n_gates: int, H: int, H_pad: int, dim: int = 0) -> torch.Tensor:
+def _unpad_gate_dim(
+    t: torch.Tensor, n_gates: int, H: int, H_pad: int, dim: int = 0
+) -> torch.Tensor:
     if H == H_pad:
         return t
     shape = list(t.shape)
@@ -679,7 +795,7 @@ class _GRUFn(torch.autograd.Function):
             raise RuntimeError(
                 "Triton is not available. Install triton or use recurrent_backend='pad'/'scan'."
             )
-        B, T, I = x.shape
+        B, T, I_in = x.shape
         H = hidden.shape[-1]
         H_pad = _padded_hidden_size(H)
 
@@ -689,7 +805,11 @@ class _GRUFn(torch.autograd.Function):
         w_ih_p = _pad_gate_dim(w_ih, 3, H, H_pad, dim=0)
         w_hh_p = _pad_w_hh(w_hh, 3, H, H_pad)
 
-        gates_x = F.linear(x.reshape(-1, I), w_ih_p, b_ih_p).view(B, T, 3 * H_pad).contiguous()
+        gates_x = (
+            F.linear(x.reshape(-1, I_in), w_ih_p, b_ih_p)
+            .view(B, T, 3 * H_pad)
+            .contiguous()
+        )
 
         w_hh_c = w_hh_p.to(compute_dtype)
         w_hh_c3 = w_hh_c.view(3, H_pad, H_pad)
@@ -711,24 +831,62 @@ class _GRUFn(torch.autograd.Function):
             return (triton.cdiv(B, meta["BLOCK_B"]),)
 
         _gru_fwd_kernel[grid](
-            gates_x, hidden_p, w_r_t, w_z_t, w_n_t, b_hh_p, is_init,
-            out, save_r, save_z, save_n, save_gh_n, h_final,
-            B, T, H=H_pad,
+            gates_x,
+            hidden_p,
+            w_r_t,
+            w_z_t,
+            w_n_t,
+            b_hh_p,
+            is_init,
+            out,
+            save_r,
+            save_z,
+            save_n,
+            save_gh_n,
+            h_final,
+            B,
+            T,
+            H=H_pad,
         )
 
         ctx.save_for_backward(
-            x, hidden_p, w_ih, w_hh, is_init, out,
-            save_r, save_z, save_n, save_gh_n, w_r, w_z, w_n, w_ih_p,
+            x,
+            hidden_p,
+            w_ih,
+            w_hh,
+            is_init,
+            out,
+            save_r,
+            save_z,
+            save_n,
+            save_gh_n,
+            w_r,
+            w_z,
+            w_n,
+            w_ih_p,
         )
-        ctx.shapes = (B, T, I, H, H_pad)
+        ctx.shapes = (B, T, I_in, H, H_pad)
         return _unpad_last(out, H, H_pad), _unpad_last(h_final, H, H_pad)
 
     @staticmethod
     def backward(ctx, dout, dh_final):
-        (x, hidden_p, w_ih, w_hh, is_init, out,
-         save_r, save_z, save_n, save_gh_n,
-         w_r, w_z, w_n, w_ih_p) = ctx.saved_tensors
-        B, T, I, H, H_pad = ctx.shapes
+        (
+            x,
+            hidden_p,
+            w_ih,
+            w_hh,
+            is_init,
+            out,
+            save_r,
+            save_z,
+            save_n,
+            save_gh_n,
+            w_r,
+            w_z,
+            w_n,
+            w_ih_p,
+        ) = ctx.saved_tensors
+        B, T, I_in, H, H_pad = ctx.shapes
 
         dout_p = _pad_last(dout.contiguous(), H, H_pad).contiguous()
         dh_final_p = _pad_last(dh_final.contiguous(), H, H_pad).contiguous()
@@ -741,10 +899,24 @@ class _GRUFn(torch.autograd.Function):
             return (triton.cdiv(B, meta["BLOCK_B"]),)
 
         _gru_bwd_kernel[grid](
-            hidden_p, w_r, w_z, w_n, is_init, out,
-            save_r, save_z, save_n, save_gh_n,
-            dout_p, dh_final_p, dgates_x, dgates_h, dhidden_p,
-            B, T, H=H_pad,
+            hidden_p,
+            w_r,
+            w_z,
+            w_n,
+            is_init,
+            out,
+            save_r,
+            save_z,
+            save_n,
+            save_gh_n,
+            dout_p,
+            dh_final_p,
+            dgates_x,
+            dgates_h,
+            dhidden_p,
+            B,
+            T,
+            H=H_pad,
         )
 
         # h_prev[b, t] for the dW_hh computation.
@@ -752,9 +924,7 @@ class _GRUFn(torch.autograd.Function):
         h_prev_all[:, 0] = hidden_p[:, 0]
         if T > 1:
             h_prev_all[:, 1:] = out[:, :-1]
-        h_prev_all = torch.where(
-            is_init.unsqueeze(-1), hidden_p, h_prev_all
-        )
+        h_prev_all = torch.where(is_init.unsqueeze(-1), hidden_p, h_prev_all)
 
         dgates_h_flat = dgates_h.reshape(B * T, 3 * H_pad)
         h_prev_flat = h_prev_all.reshape(B * T, H_pad)
@@ -762,10 +932,10 @@ class _GRUFn(torch.autograd.Function):
         db_hh_p = dgates_h_flat.sum(0)
 
         dgates_x_flat = dgates_x.reshape(B * T, 3 * H_pad)
-        x_flat = x.reshape(B * T, I)
+        x_flat = x.reshape(B * T, I_in)
         dW_ih_p = dgates_x_flat.t() @ x_flat
         db_ih_p = dgates_x_flat.sum(0)
-        dx = (dgates_x_flat @ w_ih_p).view(B, T, I)
+        dx = (dgates_x_flat @ w_ih_p).view(B, T, I_in)
 
         dhidden = _unpad_last(dhidden_p, H, H_pad)
         dW_hh = _unpad_w_hh(dW_hh_p, 3, H, H_pad)
@@ -783,7 +953,7 @@ class _LSTMFn(torch.autograd.Function):
             raise RuntimeError(
                 "Triton is not available. Install triton or use recurrent_backend='pad'/'scan'."
             )
-        B, T, I = x.shape
+        B, T, I_in = x.shape
         H = hidden.shape[-1]
         H_pad = _padded_hidden_size(H)
 
@@ -794,7 +964,11 @@ class _LSTMFn(torch.autograd.Function):
         w_ih_p = _pad_gate_dim(w_ih, 4, H, H_pad, dim=0)
         w_hh_p = _pad_w_hh(w_hh, 4, H, H_pad)
 
-        gates_x = F.linear(x.reshape(-1, I), w_ih_p, b_ih_p).view(B, T, 4 * H_pad).contiguous()
+        gates_x = (
+            F.linear(x.reshape(-1, I_in), w_ih_p, b_ih_p)
+            .view(B, T, 4 * H_pad)
+            .contiguous()
+        )
 
         w_hh_c = w_hh_p.to(compute_dtype)
         w_hh_c4 = w_hh_c.view(4, H_pad, H_pad)
@@ -821,17 +995,50 @@ class _LSTMFn(torch.autograd.Function):
             return (triton.cdiv(B, meta["BLOCK_B"]),)
 
         _lstm_fwd_kernel[grid](
-            gates_x, hidden_p, cell_p, w_i_t, w_f_t, w_g_t, w_o_t, b_hh_p, is_init,
-            out, c_out, save_i, save_f, save_g, save_o, save_tanhc,
-            h_final, c_final, B, T, H=H_pad,
+            gates_x,
+            hidden_p,
+            cell_p,
+            w_i_t,
+            w_f_t,
+            w_g_t,
+            w_o_t,
+            b_hh_p,
+            is_init,
+            out,
+            c_out,
+            save_i,
+            save_f,
+            save_g,
+            save_o,
+            save_tanhc,
+            h_final,
+            c_final,
+            B,
+            T,
+            H=H_pad,
         )
 
         ctx.save_for_backward(
-            x, hidden_p, cell_p, w_ih, w_hh, is_init,
-            out, c_out, save_i, save_f, save_g, save_o, save_tanhc,
-            w_i, w_f, w_g, w_o, w_ih_p,
+            x,
+            hidden_p,
+            cell_p,
+            w_ih,
+            w_hh,
+            is_init,
+            out,
+            c_out,
+            save_i,
+            save_f,
+            save_g,
+            save_o,
+            save_tanhc,
+            w_i,
+            w_f,
+            w_g,
+            w_o,
+            w_ih_p,
         )
-        ctx.shapes = (B, T, I, H, H_pad)
+        ctx.shapes = (B, T, I_in, H, H_pad)
         return (
             _unpad_last(out, H, H_pad),
             _unpad_last(c_out, H, H_pad),
@@ -841,10 +1048,27 @@ class _LSTMFn(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, dout, dc_out, dh_final, dc_final):
-        (x, hidden_p, cell_p, w_ih, w_hh, is_init, out, c_out,
-         save_i, save_f, save_g, save_o, save_tanhc,
-         w_i, w_f, w_g, w_o, w_ih_p) = ctx.saved_tensors
-        B, T, I, H, H_pad = ctx.shapes
+        (
+            x,
+            hidden_p,
+            cell_p,
+            w_ih,
+            w_hh,
+            is_init,
+            out,
+            c_out,
+            save_i,
+            save_f,
+            save_g,
+            save_o,
+            save_tanhc,
+            w_i,
+            w_f,
+            w_g,
+            w_o,
+            w_ih_p,
+        ) = ctx.saved_tensors
+        B, T, I_in, H, H_pad = ctx.shapes
 
         dout_p = _pad_last(dout.contiguous(), H, H_pad).contiguous()
         dc_out_p = _pad_last(dc_out.contiguous(), H, H_pad).contiguous()
@@ -866,19 +1090,37 @@ class _LSTMFn(torch.autograd.Function):
             return (triton.cdiv(B, meta["BLOCK_B"]),)
 
         _lstm_bwd_kernel[grid](
-            hidden_p, cell_p, w_i, w_f, w_g, w_o, is_init,
-            out, c_out, save_i, save_f, save_g, save_o, save_tanhc,
-            dout_p, dh_final_p, dc_final_p, dgates_x, dgates_h, dhidden_p, dcell_p,
-            B, T, H=H_pad,
+            hidden_p,
+            cell_p,
+            w_i,
+            w_f,
+            w_g,
+            w_o,
+            is_init,
+            out,
+            c_out,
+            save_i,
+            save_f,
+            save_g,
+            save_o,
+            save_tanhc,
+            dout_p,
+            dh_final_p,
+            dc_final_p,
+            dgates_x,
+            dgates_h,
+            dhidden_p,
+            dcell_p,
+            B,
+            T,
+            H=H_pad,
         )
 
         h_prev_all = torch.empty_like(out)
         h_prev_all[:, 0] = hidden_p[:, 0]
         if T > 1:
             h_prev_all[:, 1:] = out[:, :-1]
-        h_prev_all = torch.where(
-            is_init.unsqueeze(-1), hidden_p, h_prev_all
-        )
+        h_prev_all = torch.where(is_init.unsqueeze(-1), hidden_p, h_prev_all)
 
         dgates_h_flat = dgates_h.reshape(B * T, 4 * H_pad)
         h_prev_flat = h_prev_all.reshape(B * T, H_pad)
@@ -886,10 +1128,10 @@ class _LSTMFn(torch.autograd.Function):
         db_hh_p = dgates_h_flat.sum(0)
 
         dgates_x_flat = dgates_x.reshape(B * T, 4 * H_pad)
-        x_flat = x.reshape(B * T, I)
+        x_flat = x.reshape(B * T, I_in)
         dW_ih_p = dgates_x_flat.t() @ x_flat
         db_ih_p = dgates_x_flat.sum(0)
-        dx = (dgates_x_flat @ w_ih_p).view(B, T, I)
+        dx = (dgates_x_flat @ w_ih_p).view(B, T, I_in)
 
         dhidden = _unpad_last(dhidden_p, H, H_pad)
         dcell = _unpad_last(dcell_p, H, H_pad)
@@ -950,4 +1192,6 @@ def lstm_triton(
     Returns:
         ``(h_steps, c_steps, h_final, c_final)``.
     """
-    return _LSTMFn.apply(x, hidden, cell, w_ih, w_hh, b_ih, b_hh, is_init, compute_dtype)
+    return _LSTMFn.apply(
+        x, hidden, cell, w_ih, w_hh, b_ih, b_hh, is_init, compute_dtype
+    )

--- a/torchrl/modules/tensordict_module/_rnn_triton.py
+++ b/torchrl/modules/tensordict_module/_rnn_triton.py
@@ -39,6 +39,7 @@ import importlib.util
 import torch
 import torch.nn.functional as F
 
+
 def _check_triton_available() -> bool:
     """True if the installed Triton exposes everything this module needs.
 
@@ -51,9 +52,7 @@ def _check_triton_available() -> bool:
     """
     if importlib.util.find_spec("triton") is None:
         return False
-    return (
-        importlib.util.find_spec("triton.language.extra.libdevice") is not None
-    )
+    return importlib.util.find_spec("triton.language.extra.libdevice") is not None
 
 
 _has_triton = _check_triton_available()

--- a/torchrl/modules/tensordict_module/_rnn_triton.py
+++ b/torchrl/modules/tensordict_module/_rnn_triton.py
@@ -72,6 +72,15 @@ if _has_triton:
         triton.Config({"BLOCK_B": 32, "BLOCK_K": 64}, num_warps=4, num_stages=1),
     ]
 
+    # Some older Triton versions read ``prune_configs_by`` as a plain dict and
+    # require all three keys to be present. Newer ones use ``.get`` and treat
+    # ``None`` as "no perf model / no top-k". Spelling them out keeps the
+    # autotune wiring backwards-compatible.
+    _PRUNE_BY_TEMPLATE = {
+        "perf_model": None,
+        "top_k": None,
+    }
+
     def _prune_block_k(configs, named_args, **kwargs):
         """Drop configs where BLOCK_K doesn't divide the padded H."""
         H = kwargs.get("H") or named_args.get("H")
@@ -91,7 +100,7 @@ if _has_triton:
     @triton.autotune(
         configs=_FWD_CONFIGS,
         key=["B", "T", "H"],
-        prune_configs_by={"early_config_prune": _prune_block_k},
+        prune_configs_by={**_PRUNE_BY_TEMPLATE, "early_config_prune": _prune_block_k},
     )
     @triton.jit
     def _gru_fwd_kernel(
@@ -221,7 +230,7 @@ if _has_triton:
         configs=_BWD_CONFIGS,
         key=["B", "T", "H"],
         reset_to_zero=["dhidden_ptr"],
-        prune_configs_by={"early_config_prune": _prune_block_k},
+        prune_configs_by={**_PRUNE_BY_TEMPLATE, "early_config_prune": _prune_block_k},
     )
     @triton.jit
     def _gru_bwd_kernel(
@@ -369,7 +378,7 @@ if _has_triton:
     @triton.autotune(
         configs=_FWD_CONFIGS,
         key=["B", "T", "H"],
-        prune_configs_by={"early_config_prune": _prune_block_k},
+        prune_configs_by={**_PRUNE_BY_TEMPLATE, "early_config_prune": _prune_block_k},
     )
     @triton.jit
     def _lstm_fwd_kernel(
@@ -532,7 +541,7 @@ if _has_triton:
         configs=_BWD_CONFIGS,
         key=["B", "T", "H"],
         reset_to_zero=["dhidden_ptr", "dcell_ptr"],
-        prune_configs_by={"early_config_prune": _prune_block_k},
+        prune_configs_by={**_PRUNE_BY_TEMPLATE, "early_config_prune": _prune_block_k},
     )
     @triton.jit
     def _lstm_bwd_kernel(

--- a/torchrl/modules/tensordict_module/_rnn_triton.py
+++ b/torchrl/modules/tensordict_module/_rnn_triton.py
@@ -39,7 +39,24 @@ import importlib.util
 import torch
 import torch.nn.functional as F
 
-_has_triton = importlib.util.find_spec("triton") is not None
+def _check_triton_available() -> bool:
+    """True if the installed Triton exposes everything this module needs.
+
+    The backend's kernels rely on ``triton.language.extra.libdevice.tanh``
+    (Triton >= 2.2) and on a backward path that uses ``tl.atomic_add`` with
+    a 2-D mask, which older Triton compilers reject. Probing the lazy
+    ``libdevice`` submodule import at module-load time is a reliable proxy
+    for "Triton is new enough"; older installations fall back transparently
+    to the ``scan`` / ``pad`` backends.
+    """
+    if importlib.util.find_spec("triton") is None:
+        return False
+    return (
+        importlib.util.find_spec("triton.language.extra.libdevice") is not None
+    )
+
+
+_has_triton = _check_triton_available()
 
 if _has_triton:
     import triton
@@ -92,18 +109,6 @@ if _has_triton:
             if c.kwargs["BLOCK_K"] <= H and H % c.kwargs["BLOCK_K"] == 0
         ]
         return out or [min(configs, key=lambda c: c.kwargs["BLOCK_K"])]
-
-    @triton.jit
-    def _tanh(x):
-        """Identity tanh(x) = 2*sigmoid(2x) - 1.
-
-        Avoids ``tl.extra.libdevice.tanh``, which is missing on older Triton
-        versions (the ``libdevice`` namespace lived under ``tl`` in 2.x and
-        moved to ``tl.extra`` in 2.2+). ``tl.sigmoid`` is available
-        everywhere and lowers to the same hardware ``ex2`` / ``rcp`` pair as
-        ``libdevice.tanh`` does.
-        """
-        return 2.0 * tl.sigmoid(2.0 * x) - 1.0
 
     # ------------------------------------------------------------------------
     # GRU forward
@@ -220,7 +225,7 @@ if _has_triton:
 
             r = tl.sigmoid(gx_r + gh_r)
             z = tl.sigmoid(gx_z + gh_z)
-            n = _tanh(gx_n + r * gh_n)
+            n = tl.extra.libdevice.tanh(gx_n + r * gh_n)
             h = n + z * (h - n)
 
             base_out = b_off[:, None] * (T * H) + t * H + h_off[None, :]
@@ -523,10 +528,10 @@ if _has_triton:
 
             i = tl.sigmoid(gx_i + gh_i)
             f = tl.sigmoid(gx_f + gh_f)
-            g = _tanh(gx_g + gh_g)
+            g = tl.extra.libdevice.tanh(gx_g + gh_g)
             o = tl.sigmoid(gx_o + gh_o)
             c = f * c + i * g
-            tanh_c = _tanh(c)
+            tanh_c = tl.extra.libdevice.tanh(c)
             h = o * tanh_c
 
             base_out = b_off[:, None] * (T * H) + t * H + h_off[None, :]

--- a/torchrl/modules/tensordict_module/_rnn_triton.py
+++ b/torchrl/modules/tensordict_module/_rnn_triton.py
@@ -93,6 +93,18 @@ if _has_triton:
         ]
         return out or [min(configs, key=lambda c: c.kwargs["BLOCK_K"])]
 
+    @triton.jit
+    def _tanh(x):
+        """Identity tanh(x) = 2*sigmoid(2x) - 1.
+
+        Avoids ``tl.extra.libdevice.tanh``, which is missing on older Triton
+        versions (the ``libdevice`` namespace lived under ``tl`` in 2.x and
+        moved to ``tl.extra`` in 2.2+). ``tl.sigmoid`` is available
+        everywhere and lowers to the same hardware ``ex2`` / ``rcp`` pair as
+        ``libdevice.tanh`` does.
+        """
+        return 2.0 * tl.sigmoid(2.0 * x) - 1.0
+
     # ------------------------------------------------------------------------
     # GRU forward
     # ------------------------------------------------------------------------
@@ -208,7 +220,7 @@ if _has_triton:
 
             r = tl.sigmoid(gx_r + gh_r)
             z = tl.sigmoid(gx_z + gh_z)
-            n = tl.extra.libdevice.tanh(gx_n + r * gh_n)
+            n = _tanh(gx_n + r * gh_n)
             h = n + z * (h - n)
 
             base_out = b_off[:, None] * (T * H) + t * H + h_off[None, :]
@@ -511,10 +523,10 @@ if _has_triton:
 
             i = tl.sigmoid(gx_i + gh_i)
             f = tl.sigmoid(gx_f + gh_f)
-            g = tl.extra.libdevice.tanh(gx_g + gh_g)
+            g = _tanh(gx_g + gh_g)
             o = tl.sigmoid(gx_o + gh_o)
             c = f * c + i * g
-            tanh_c = tl.extra.libdevice.tanh(c)
+            tanh_c = _tanh(c)
             h = o * tanh_c
 
             base_out = b_off[:, None] * (T * H) + t * H + h_off[None, :]

--- a/torchrl/modules/tensordict_module/_rnn_triton.py
+++ b/torchrl/modules/tensordict_module/_rnn_triton.py
@@ -1,0 +1,953 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Triton kernels for GRU / LSTM forward and backward with intermediate resets.
+
+These are the building blocks behind the ``recurrent_backend="triton"`` option
+on :class:`~torchrl.modules.GRUModule` and :class:`~torchrl.modules.LSTMModule`.
+
+The kernels fuse the whole time loop into one CUDA launch and apply the
+``is_init`` reset mask cheaply inside the loop. This makes them especially
+beneficial for RL training, where resets can occur at any time step inside a
+rollout and the cuDNN ``pack_padded_sequence`` / ``pad_packed_sequence`` round
+trip becomes the bottleneck.
+
+Both forward and backward kernels are K-tiled along the recurrent contraction
+axis so a single ``[H, H]`` weight slab fits in shared memory at any hidden
+size we care about in RL.
+
+Limitations of this prototype:
+
+* ``num_layers == 1`` only.
+* No dropout, no projection (``proj_size``), no bidirectional.
+* ``hidden_size`` is internally padded to the next power of two (kept on the
+  Python side; no in-kernel masking).
+* ``compute_dtype`` controls the matmul precision: ``torch.float32`` (default,
+  TF32 on Ampere/Hopper, matching ``torch.nn.GRU`` / ``LSTM`` behavior) or
+  ``torch.bfloat16`` (twice the SMEM headroom, ~7-bit mantissa).
+"""
+from __future__ import annotations
+
+import importlib.util
+
+import torch
+import torch.nn.functional as F
+
+_has_triton = importlib.util.find_spec("triton") is not None
+
+if _has_triton:
+    import triton
+    import triton.language as tl
+
+    # BLOCK_K=16 is the smallest, dictating the minimum padded hidden size.
+    _MIN_H_PAD = 16
+
+    _FWD_CONFIGS = [
+        triton.Config({"BLOCK_B": 16, "BLOCK_K": 16}, num_warps=2, num_stages=1),
+        triton.Config({"BLOCK_B": 16, "BLOCK_K": 32}, num_warps=2, num_stages=1),
+        triton.Config({"BLOCK_B": 16, "BLOCK_K": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_B": 32, "BLOCK_K": 16}, num_warps=2, num_stages=1),
+        triton.Config({"BLOCK_B": 32, "BLOCK_K": 32}, num_warps=2, num_stages=1),
+        triton.Config({"BLOCK_B": 32, "BLOCK_K": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_B": 32, "BLOCK_K": 128}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_B": 32, "BLOCK_K": 128}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_B": 64, "BLOCK_K": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_B": 64, "BLOCK_K": 64}, num_warps=8, num_stages=1),
+    ]
+
+    _BWD_CONFIGS = [
+        triton.Config({"BLOCK_B": 8, "BLOCK_K": 16}, num_warps=2, num_stages=1),
+        triton.Config({"BLOCK_B": 8, "BLOCK_K": 32}, num_warps=2, num_stages=1),
+        triton.Config({"BLOCK_B": 8, "BLOCK_K": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_B": 16, "BLOCK_K": 16}, num_warps=2, num_stages=1),
+        triton.Config({"BLOCK_B": 16, "BLOCK_K": 32}, num_warps=2, num_stages=1),
+        triton.Config({"BLOCK_B": 16, "BLOCK_K": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_B": 32, "BLOCK_K": 32}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_B": 32, "BLOCK_K": 64}, num_warps=4, num_stages=1),
+    ]
+
+    def _prune_block_k(configs, named_args, **kwargs):
+        """Drop configs where BLOCK_K doesn't divide the padded H."""
+        H = kwargs.get("H") or named_args.get("H")
+        if H is None:
+            return configs
+        out = [
+            c
+            for c in configs
+            if c.kwargs["BLOCK_K"] <= H and H % c.kwargs["BLOCK_K"] == 0
+        ]
+        return out or [min(configs, key=lambda c: c.kwargs["BLOCK_K"])]
+
+    # ------------------------------------------------------------------------
+    # GRU forward
+    # ------------------------------------------------------------------------
+
+    @triton.autotune(
+        configs=_FWD_CONFIGS,
+        key=["B", "T", "H"],
+        prune_configs_by={"early_config_prune": _prune_block_k},
+    )
+    @triton.jit
+    def _gru_fwd_kernel(
+        gates_x_ptr,
+        hidden_ptr,  # [B, T, H] per-step reset values; hidden[:, 0] is the initial state
+        w_r_ptr,
+        w_z_ptr,
+        w_n_ptr,
+        b_hh_ptr,
+        is_init_ptr,
+        out_ptr,
+        save_r_ptr,
+        save_z_ptr,
+        save_n_ptr,
+        save_gh_n_ptr,
+        h_final_ptr,
+        B,
+        T,
+        H: tl.constexpr,
+        BLOCK_B: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        b_off = pid * BLOCK_B + tl.arange(0, BLOCK_B)
+        h_off = tl.arange(0, H)
+        k_inner = tl.arange(0, BLOCK_K)
+        mask_b = b_off < B
+        N_K: tl.constexpr = H // BLOCK_K
+
+        # Initial state = hidden[:, 0, :].
+        h = tl.load(
+            hidden_ptr + b_off[:, None] * (T * H) + 0 * H + h_off[None, :],
+            mask=mask_b[:, None],
+            other=0.0,
+        )
+        b_r = tl.load(b_hh_ptr + 0 * H + h_off)
+        b_z = tl.load(b_hh_ptr + 1 * H + h_off)
+        b_n = tl.load(b_hh_ptr + 2 * H + h_off)
+
+        for t in range(T):
+            base_x = b_off[:, None] * (T * 3 * H) + t * (3 * H)
+            gx_r = tl.load(gates_x_ptr + base_x + 0 * H + h_off[None, :], mask=mask_b[:, None], other=0.0)
+            gx_z = tl.load(gates_x_ptr + base_x + 1 * H + h_off[None, :], mask=mask_b[:, None], other=0.0)
+            gx_n = tl.load(gates_x_ptr + base_x + 2 * H + h_off[None, :], mask=mask_b[:, None], other=0.0)
+
+            is_init = tl.load(is_init_ptr + b_off * T + t, mask=mask_b, other=False)
+            reset_h = tl.load(
+                hidden_ptr + b_off[:, None] * (T * H) + t * H + h_off[None, :],
+                mask=mask_b[:, None],
+                other=0.0,
+            )
+            h = tl.where(is_init[:, None], reset_h, h)
+
+            gh_r = tl.zeros([BLOCK_B, H], dtype=tl.float32)
+            gh_z = tl.zeros([BLOCK_B, H], dtype=tl.float32)
+            gh_n = tl.zeros([BLOCK_B, H], dtype=tl.float32)
+
+            for k_iter in tl.static_range(N_K):
+                k_off = k_iter * BLOCK_K + k_inner
+                if t == 0:
+                    h_chunk = tl.load(
+                        hidden_ptr + b_off[:, None] * (T * H) + 0 * H + k_off[None, :],
+                        mask=mask_b[:, None],
+                        other=0.0,
+                    )
+                else:
+                    h_prev_stored = tl.load(
+                        out_ptr + b_off[:, None] * (T * H) + (t - 1) * H + k_off[None, :],
+                        mask=mask_b[:, None],
+                        other=0.0,
+                    )
+                    reset_chunk = tl.load(
+                        hidden_ptr + b_off[:, None] * (T * H) + t * H + k_off[None, :],
+                        mask=mask_b[:, None],
+                        other=0.0,
+                    )
+                    h_chunk = tl.where(is_init[:, None], reset_chunk, h_prev_stored)
+
+                w_r_chunk = tl.load(w_r_ptr + k_off[:, None] * H + h_off[None, :])
+                h_chunk_w = h_chunk.to(w_r_chunk.dtype)
+                gh_r += tl.dot(h_chunk_w, w_r_chunk)
+                w_z_chunk = tl.load(w_z_ptr + k_off[:, None] * H + h_off[None, :])
+                gh_z += tl.dot(h_chunk_w, w_z_chunk)
+                w_n_chunk = tl.load(w_n_ptr + k_off[:, None] * H + h_off[None, :])
+                gh_n += tl.dot(h_chunk_w, w_n_chunk)
+
+            gh_r += b_r[None, :]
+            gh_z += b_z[None, :]
+            gh_n += b_n[None, :]
+
+            r = tl.sigmoid(gx_r + gh_r)
+            z = tl.sigmoid(gx_z + gh_z)
+            n = tl.extra.libdevice.tanh(gx_n + r * gh_n)
+            h = n + z * (h - n)
+
+            base_out = b_off[:, None] * (T * H) + t * H + h_off[None, :]
+            tl.store(out_ptr + base_out, h, mask=mask_b[:, None])
+            tl.store(save_r_ptr + base_out, r, mask=mask_b[:, None])
+            tl.store(save_z_ptr + base_out, z, mask=mask_b[:, None])
+            tl.store(save_n_ptr + base_out, n, mask=mask_b[:, None])
+            tl.store(save_gh_n_ptr + base_out, gh_n, mask=mask_b[:, None])
+
+        tl.store(h_final_ptr + b_off[:, None] * H + h_off[None, :], h, mask=mask_b[:, None])
+
+    # ------------------------------------------------------------------------
+    # GRU backward
+    # ------------------------------------------------------------------------
+
+    @triton.autotune(
+        configs=_BWD_CONFIGS,
+        key=["B", "T", "H"],
+        reset_to_zero=["dhidden_ptr"],
+        prune_configs_by={"early_config_prune": _prune_block_k},
+    )
+    @triton.jit
+    def _gru_bwd_kernel(
+        hidden_ptr,
+        w_r_ptr,
+        w_z_ptr,
+        w_n_ptr,
+        is_init_ptr,
+        out_ptr,
+        save_r_ptr,
+        save_z_ptr,
+        save_n_ptr,
+        save_gh_n_ptr,
+        dout_ptr,
+        dh_final_ptr,
+        dgates_x_ptr,
+        dgates_h_ptr,
+        dhidden_ptr,  # [B, T, H] - gradient on per-step hidden values
+        B,
+        T,
+        H: tl.constexpr,
+        BLOCK_B: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        b_off = pid * BLOCK_B + tl.arange(0, BLOCK_B)
+        h_off = tl.arange(0, H)
+        k_inner = tl.arange(0, BLOCK_K)
+        mask_b = b_off < B
+        N_K: tl.constexpr = H // BLOCK_K
+
+        dh_next = tl.load(
+            dh_final_ptr + b_off[:, None] * H + h_off[None, :],
+            mask=mask_b[:, None],
+            other=0.0,
+        )
+
+        for t_inv in range(T):
+            t = T - 1 - t_inv
+            base_out = b_off[:, None] * (T * H) + t * H + h_off[None, :]
+            dout_t = tl.load(dout_ptr + base_out, mask=mask_b[:, None], other=0.0)
+            r = tl.load(save_r_ptr + base_out, mask=mask_b[:, None], other=0.0)
+            z = tl.load(save_z_ptr + base_out, mask=mask_b[:, None], other=0.0)
+            n = tl.load(save_n_ptr + base_out, mask=mask_b[:, None], other=0.0)
+            gh_n = tl.load(save_gh_n_ptr + base_out, mask=mask_b[:, None], other=0.0)
+
+            is_init = tl.load(is_init_ptr + b_off * T + t, mask=mask_b, other=False)
+            reset_h = tl.load(
+                hidden_ptr + b_off[:, None] * (T * H) + t * H + h_off[None, :],
+                mask=mask_b[:, None],
+                other=0.0,
+            )
+            if t == 0:
+                h_prev = reset_h
+            else:
+                h_prev_stored = tl.load(
+                    out_ptr + b_off[:, None] * (T * H) + (t - 1) * H + h_off[None, :],
+                    mask=mask_b[:, None],
+                    other=0.0,
+                )
+                h_prev = tl.where(is_init[:, None], reset_h, h_prev_stored)
+
+            dh = dout_t + dh_next
+
+            one_minus_z = 1.0 - z
+            dn = dh * one_minus_z
+            dh_prev_direct = dh * z
+
+            dn_pre = dn * (1.0 - n * n)
+            dgh_n = dn_pre * r
+            dz_pre = (dh * (h_prev - n)) * z * one_minus_z
+            dr_pre = (dn_pre * gh_n) * r * (1.0 - r)
+
+            base_gx = b_off[:, None] * (T * 3 * H) + t * (3 * H)
+            tl.store(dgates_x_ptr + base_gx + 0 * H + h_off[None, :], dr_pre, mask=mask_b[:, None])
+            tl.store(dgates_x_ptr + base_gx + 1 * H + h_off[None, :], dz_pre, mask=mask_b[:, None])
+            tl.store(dgates_x_ptr + base_gx + 2 * H + h_off[None, :], dn_pre, mask=mask_b[:, None])
+            tl.store(dgates_h_ptr + base_gx + 0 * H + h_off[None, :], dr_pre, mask=mask_b[:, None])
+            tl.store(dgates_h_ptr + base_gx + 1 * H + h_off[None, :], dz_pre, mask=mask_b[:, None])
+            tl.store(dgates_h_ptr + base_gx + 2 * H + h_off[None, :], dgh_n, mask=mask_b[:, None])
+
+            dh_prev_total = dh_prev_direct
+            for k_iter in tl.static_range(N_K):
+                k_off = k_iter * BLOCK_K + k_inner
+                base_gx_k = b_off[:, None] * (T * 3 * H) + t * (3 * H) + k_off[None, :]
+                w_r_chunk = tl.load(w_r_ptr + k_off[:, None] * H + h_off[None, :])
+                dr_chunk = tl.load(dgates_h_ptr + base_gx_k + 0 * H, mask=mask_b[:, None], other=0.0)
+                dh_prev_total += tl.dot(dr_chunk.to(w_r_chunk.dtype), w_r_chunk)
+                w_z_chunk = tl.load(w_z_ptr + k_off[:, None] * H + h_off[None, :])
+                dz_chunk = tl.load(dgates_h_ptr + base_gx_k + 1 * H, mask=mask_b[:, None], other=0.0)
+                dh_prev_total += tl.dot(dz_chunk.to(w_z_chunk.dtype), w_z_chunk)
+                w_n_chunk = tl.load(w_n_ptr + k_off[:, None] * H + h_off[None, :])
+                dn_chunk = tl.load(dgates_h_ptr + base_gx_k + 2 * H, mask=mask_b[:, None], other=0.0)
+                dh_prev_total += tl.dot(dn_chunk.to(w_n_chunk.dtype), w_n_chunk)
+
+            # At reset positions, dh_prev flows into dhidden[b, t] not dh_{t-1}.
+            tl.atomic_add(
+                dhidden_ptr + b_off[:, None] * (T * H) + t * H + h_off[None, :],
+                tl.where(is_init[:, None], dh_prev_total, 0.0),
+                mask=mask_b[:, None],
+            )
+            dh_next = tl.where(is_init[:, None], 0.0, dh_prev_total)
+
+        # Fall-off at t=0 goes into dhidden[:, 0, :] (the initial state).
+        tl.atomic_add(
+            dhidden_ptr + b_off[:, None] * (T * H) + 0 * H + h_off[None, :],
+            dh_next,
+            mask=mask_b[:, None],
+        )
+
+    # ------------------------------------------------------------------------
+    # LSTM forward
+    # ------------------------------------------------------------------------
+
+    @triton.autotune(
+        configs=_FWD_CONFIGS,
+        key=["B", "T", "H"],
+        prune_configs_by={"early_config_prune": _prune_block_k},
+    )
+    @triton.jit
+    def _lstm_fwd_kernel(
+        gates_x_ptr,
+        hidden_ptr,  # [B, T, H]
+        cell_ptr,    # [B, T, H]
+        w_i_ptr,
+        w_f_ptr,
+        w_g_ptr,
+        w_o_ptr,
+        b_hh_ptr,
+        is_init_ptr,
+        out_ptr,
+        c_out_ptr,
+        save_i_ptr,
+        save_f_ptr,
+        save_g_ptr,
+        save_o_ptr,
+        save_tanhc_ptr,
+        h_final_ptr,
+        c_final_ptr,
+        B,
+        T,
+        H: tl.constexpr,
+        BLOCK_B: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        b_off = pid * BLOCK_B + tl.arange(0, BLOCK_B)
+        h_off = tl.arange(0, H)
+        k_inner = tl.arange(0, BLOCK_K)
+        mask_b = b_off < B
+        N_K: tl.constexpr = H // BLOCK_K
+
+        h = tl.load(
+            hidden_ptr + b_off[:, None] * (T * H) + 0 * H + h_off[None, :],
+            mask=mask_b[:, None],
+            other=0.0,
+        )
+        c = tl.load(
+            cell_ptr + b_off[:, None] * (T * H) + 0 * H + h_off[None, :],
+            mask=mask_b[:, None],
+            other=0.0,
+        )
+        b_i = tl.load(b_hh_ptr + 0 * H + h_off)
+        b_f = tl.load(b_hh_ptr + 1 * H + h_off)
+        b_g = tl.load(b_hh_ptr + 2 * H + h_off)
+        b_o = tl.load(b_hh_ptr + 3 * H + h_off)
+
+        for t in range(T):
+            base_x = b_off[:, None] * (T * 4 * H) + t * (4 * H)
+            gx_i = tl.load(gates_x_ptr + base_x + 0 * H + h_off[None, :], mask=mask_b[:, None], other=0.0)
+            gx_f = tl.load(gates_x_ptr + base_x + 1 * H + h_off[None, :], mask=mask_b[:, None], other=0.0)
+            gx_g = tl.load(gates_x_ptr + base_x + 2 * H + h_off[None, :], mask=mask_b[:, None], other=0.0)
+            gx_o = tl.load(gates_x_ptr + base_x + 3 * H + h_off[None, :], mask=mask_b[:, None], other=0.0)
+
+            is_init = tl.load(is_init_ptr + b_off * T + t, mask=mask_b, other=False)
+            reset_h = tl.load(
+                hidden_ptr + b_off[:, None] * (T * H) + t * H + h_off[None, :],
+                mask=mask_b[:, None],
+                other=0.0,
+            )
+            reset_c = tl.load(
+                cell_ptr + b_off[:, None] * (T * H) + t * H + h_off[None, :],
+                mask=mask_b[:, None],
+                other=0.0,
+            )
+            h = tl.where(is_init[:, None], reset_h, h)
+            c = tl.where(is_init[:, None], reset_c, c)
+
+            gh_i = tl.zeros([BLOCK_B, H], dtype=tl.float32)
+            gh_f = tl.zeros([BLOCK_B, H], dtype=tl.float32)
+            gh_g = tl.zeros([BLOCK_B, H], dtype=tl.float32)
+            gh_o = tl.zeros([BLOCK_B, H], dtype=tl.float32)
+
+            for k_iter in tl.static_range(N_K):
+                k_off = k_iter * BLOCK_K + k_inner
+                if t == 0:
+                    h_chunk = tl.load(
+                        hidden_ptr + b_off[:, None] * (T * H) + 0 * H + k_off[None, :],
+                        mask=mask_b[:, None],
+                        other=0.0,
+                    )
+                else:
+                    h_prev_stored = tl.load(
+                        out_ptr + b_off[:, None] * (T * H) + (t - 1) * H + k_off[None, :],
+                        mask=mask_b[:, None],
+                        other=0.0,
+                    )
+                    reset_chunk = tl.load(
+                        hidden_ptr + b_off[:, None] * (T * H) + t * H + k_off[None, :],
+                        mask=mask_b[:, None],
+                        other=0.0,
+                    )
+                    h_chunk = tl.where(is_init[:, None], reset_chunk, h_prev_stored)
+
+                w_i_chunk = tl.load(w_i_ptr + k_off[:, None] * H + h_off[None, :])
+                h_chunk_w = h_chunk.to(w_i_chunk.dtype)
+                gh_i += tl.dot(h_chunk_w, w_i_chunk)
+                w_f_chunk = tl.load(w_f_ptr + k_off[:, None] * H + h_off[None, :])
+                gh_f += tl.dot(h_chunk_w, w_f_chunk)
+                w_g_chunk = tl.load(w_g_ptr + k_off[:, None] * H + h_off[None, :])
+                gh_g += tl.dot(h_chunk_w, w_g_chunk)
+                w_o_chunk = tl.load(w_o_ptr + k_off[:, None] * H + h_off[None, :])
+                gh_o += tl.dot(h_chunk_w, w_o_chunk)
+
+            gh_i += b_i[None, :]
+            gh_f += b_f[None, :]
+            gh_g += b_g[None, :]
+            gh_o += b_o[None, :]
+
+            i = tl.sigmoid(gx_i + gh_i)
+            f = tl.sigmoid(gx_f + gh_f)
+            g = tl.extra.libdevice.tanh(gx_g + gh_g)
+            o = tl.sigmoid(gx_o + gh_o)
+            c = f * c + i * g
+            tanh_c = tl.extra.libdevice.tanh(c)
+            h = o * tanh_c
+
+            base_out = b_off[:, None] * (T * H) + t * H + h_off[None, :]
+            tl.store(out_ptr + base_out, h, mask=mask_b[:, None])
+            tl.store(c_out_ptr + base_out, c, mask=mask_b[:, None])
+            tl.store(save_i_ptr + base_out, i, mask=mask_b[:, None])
+            tl.store(save_f_ptr + base_out, f, mask=mask_b[:, None])
+            tl.store(save_g_ptr + base_out, g, mask=mask_b[:, None])
+            tl.store(save_o_ptr + base_out, o, mask=mask_b[:, None])
+            tl.store(save_tanhc_ptr + base_out, tanh_c, mask=mask_b[:, None])
+
+        tl.store(h_final_ptr + b_off[:, None] * H + h_off[None, :], h, mask=mask_b[:, None])
+        tl.store(c_final_ptr + b_off[:, None] * H + h_off[None, :], c, mask=mask_b[:, None])
+
+    # ------------------------------------------------------------------------
+    # LSTM backward
+    # ------------------------------------------------------------------------
+
+    @triton.autotune(
+        configs=_BWD_CONFIGS,
+        key=["B", "T", "H"],
+        reset_to_zero=["dhidden_ptr", "dcell_ptr"],
+        prune_configs_by={"early_config_prune": _prune_block_k},
+    )
+    @triton.jit
+    def _lstm_bwd_kernel(
+        hidden_ptr,
+        cell_ptr,
+        w_i_ptr,
+        w_f_ptr,
+        w_g_ptr,
+        w_o_ptr,
+        is_init_ptr,
+        out_ptr,
+        c_out_ptr,
+        save_i_ptr,
+        save_f_ptr,
+        save_g_ptr,
+        save_o_ptr,
+        save_tanhc_ptr,
+        dout_ptr,
+        dh_final_ptr,
+        dc_final_ptr,
+        dgates_x_ptr,
+        dgates_h_ptr,
+        dhidden_ptr,
+        dcell_ptr,
+        B,
+        T,
+        H: tl.constexpr,
+        BLOCK_B: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        b_off = pid * BLOCK_B + tl.arange(0, BLOCK_B)
+        h_off = tl.arange(0, H)
+        k_inner = tl.arange(0, BLOCK_K)
+        mask_b = b_off < B
+        N_K: tl.constexpr = H // BLOCK_K
+
+        dh_next = tl.load(
+            dh_final_ptr + b_off[:, None] * H + h_off[None, :],
+            mask=mask_b[:, None],
+            other=0.0,
+        )
+        dc_next = tl.load(
+            dc_final_ptr + b_off[:, None] * H + h_off[None, :],
+            mask=mask_b[:, None],
+            other=0.0,
+        )
+
+        for t_inv in range(T):
+            t = T - 1 - t_inv
+            base_out = b_off[:, None] * (T * H) + t * H + h_off[None, :]
+            dout_t = tl.load(dout_ptr + base_out, mask=mask_b[:, None], other=0.0)
+            i = tl.load(save_i_ptr + base_out, mask=mask_b[:, None], other=0.0)
+            f = tl.load(save_f_ptr + base_out, mask=mask_b[:, None], other=0.0)
+            g = tl.load(save_g_ptr + base_out, mask=mask_b[:, None], other=0.0)
+            o = tl.load(save_o_ptr + base_out, mask=mask_b[:, None], other=0.0)
+            tanh_c = tl.load(save_tanhc_ptr + base_out, mask=mask_b[:, None], other=0.0)
+
+            is_init = tl.load(is_init_ptr + b_off * T + t, mask=mask_b, other=False)
+            reset_c = tl.load(
+                cell_ptr + b_off[:, None] * (T * H) + t * H + h_off[None, :],
+                mask=mask_b[:, None],
+                other=0.0,
+            )
+            if t == 0:
+                c_prev = reset_c
+            else:
+                c_prev_stored = tl.load(
+                    c_out_ptr + b_off[:, None] * (T * H) + (t - 1) * H + h_off[None, :],
+                    mask=mask_b[:, None],
+                    other=0.0,
+                )
+                c_prev = tl.where(is_init[:, None], reset_c, c_prev_stored)
+
+            dh = dout_t + dh_next
+            do = dh * tanh_c
+            dc = dc_next + dh * o * (1.0 - tanh_c * tanh_c)
+
+            df = dc * c_prev
+            di = dc * g
+            dg = dc * i
+            dc_prev_direct = dc * f
+
+            di_pre = di * i * (1.0 - i)
+            df_pre = df * f * (1.0 - f)
+            dg_pre = dg * (1.0 - g * g)
+            do_pre = do * o * (1.0 - o)
+
+            base_gx = b_off[:, None] * (T * 4 * H) + t * (4 * H)
+            tl.store(dgates_x_ptr + base_gx + 0 * H + h_off[None, :], di_pre, mask=mask_b[:, None])
+            tl.store(dgates_x_ptr + base_gx + 1 * H + h_off[None, :], df_pre, mask=mask_b[:, None])
+            tl.store(dgates_x_ptr + base_gx + 2 * H + h_off[None, :], dg_pre, mask=mask_b[:, None])
+            tl.store(dgates_x_ptr + base_gx + 3 * H + h_off[None, :], do_pre, mask=mask_b[:, None])
+            tl.store(dgates_h_ptr + base_gx + 0 * H + h_off[None, :], di_pre, mask=mask_b[:, None])
+            tl.store(dgates_h_ptr + base_gx + 1 * H + h_off[None, :], df_pre, mask=mask_b[:, None])
+            tl.store(dgates_h_ptr + base_gx + 2 * H + h_off[None, :], dg_pre, mask=mask_b[:, None])
+            tl.store(dgates_h_ptr + base_gx + 3 * H + h_off[None, :], do_pre, mask=mask_b[:, None])
+
+            dh_prev_total = tl.zeros_like(dh_next)
+            for k_iter in tl.static_range(N_K):
+                k_off = k_iter * BLOCK_K + k_inner
+                base_gx_k = b_off[:, None] * (T * 4 * H) + t * (4 * H) + k_off[None, :]
+                w_i_chunk = tl.load(w_i_ptr + k_off[:, None] * H + h_off[None, :])
+                di_chunk = tl.load(dgates_h_ptr + base_gx_k + 0 * H, mask=mask_b[:, None], other=0.0)
+                dh_prev_total += tl.dot(di_chunk.to(w_i_chunk.dtype), w_i_chunk)
+                w_f_chunk = tl.load(w_f_ptr + k_off[:, None] * H + h_off[None, :])
+                df_chunk = tl.load(dgates_h_ptr + base_gx_k + 1 * H, mask=mask_b[:, None], other=0.0)
+                dh_prev_total += tl.dot(df_chunk.to(w_f_chunk.dtype), w_f_chunk)
+                w_g_chunk = tl.load(w_g_ptr + k_off[:, None] * H + h_off[None, :])
+                dg_chunk = tl.load(dgates_h_ptr + base_gx_k + 2 * H, mask=mask_b[:, None], other=0.0)
+                dh_prev_total += tl.dot(dg_chunk.to(w_g_chunk.dtype), w_g_chunk)
+                w_o_chunk = tl.load(w_o_ptr + k_off[:, None] * H + h_off[None, :])
+                do_chunk = tl.load(dgates_h_ptr + base_gx_k + 3 * H, mask=mask_b[:, None], other=0.0)
+                dh_prev_total += tl.dot(do_chunk.to(w_o_chunk.dtype), w_o_chunk)
+
+            tl.atomic_add(
+                dhidden_ptr + b_off[:, None] * (T * H) + t * H + h_off[None, :],
+                tl.where(is_init[:, None], dh_prev_total, 0.0),
+                mask=mask_b[:, None],
+            )
+            tl.atomic_add(
+                dcell_ptr + b_off[:, None] * (T * H) + t * H + h_off[None, :],
+                tl.where(is_init[:, None], dc_prev_direct, 0.0),
+                mask=mask_b[:, None],
+            )
+            dh_next = tl.where(is_init[:, None], 0.0, dh_prev_total)
+            dc_next = tl.where(is_init[:, None], 0.0, dc_prev_direct)
+
+        tl.atomic_add(
+            dhidden_ptr + b_off[:, None] * (T * H) + 0 * H + h_off[None, :],
+            dh_next,
+            mask=mask_b[:, None],
+        )
+        tl.atomic_add(
+            dcell_ptr + b_off[:, None] * (T * H) + 0 * H + h_off[None, :],
+            dc_next,
+            mask=mask_b[:, None],
+        )
+
+
+# ============================================================================
+# Python wrappers (autograd-aware)
+# ============================================================================
+
+
+_MIN_H_PAD_PY = 16  # mirror of _MIN_H_PAD; constant so callers outside Triton block can use it
+
+
+def _next_pow2(n: int) -> int:
+    if n <= 1:
+        return 1
+    return 1 << (n - 1).bit_length()
+
+
+def _padded_hidden_size(H: int) -> int:
+    """Smallest power-of-two H_pad supported by the kernel autotune grid."""
+    return max(_next_pow2(H), _MIN_H_PAD_PY)
+
+
+def _pad_last(t: torch.Tensor, H: int, H_pad: int) -> torch.Tensor:
+    if H == H_pad:
+        return t
+    pad = list(t.shape)
+    pad[-1] = H_pad - H
+    return torch.cat([t, t.new_zeros(*pad)], dim=-1)
+
+
+def _pad_gate_dim(t: torch.Tensor, n_gates: int, H: int, H_pad: int, dim: int = 0) -> torch.Tensor:
+    if H == H_pad:
+        return t
+    shape = list(t.shape)
+    assert shape[dim] == n_gates * H
+    new_shape = shape[:dim] + [n_gates, H] + shape[dim + 1 :]
+    t = t.reshape(new_shape)
+    t = _pad_last(t.movedim(dim + 1, -1), H, H_pad).movedim(-1, dim + 1)
+    final_shape = shape[:dim] + [n_gates * H_pad] + shape[dim + 1 :]
+    return t.reshape(final_shape)
+
+
+def _pad_w_hh(w_hh: torch.Tensor, n_gates: int, H: int, H_pad: int) -> torch.Tensor:
+    if H == H_pad:
+        return w_hh
+    w_hh = w_hh.view(n_gates, H, H)
+    pad_cols = H_pad - H
+    w_hh = torch.cat([w_hh, w_hh.new_zeros(n_gates, H, pad_cols)], dim=-1)
+    w_hh = torch.cat([w_hh, w_hh.new_zeros(n_gates, pad_cols, H_pad)], dim=-2)
+    return w_hh.reshape(n_gates * H_pad, H_pad)
+
+
+def _unpad_last(t: torch.Tensor, H: int, H_pad: int) -> torch.Tensor:
+    if H == H_pad:
+        return t
+    return t[..., :H].contiguous()
+
+
+def _unpad_gate_dim(t: torch.Tensor, n_gates: int, H: int, H_pad: int, dim: int = 0) -> torch.Tensor:
+    if H == H_pad:
+        return t
+    shape = list(t.shape)
+    new_shape = shape[:dim] + [n_gates, H_pad] + shape[dim + 1 :]
+    t = t.reshape(new_shape)
+    t = t.narrow(dim + 1, 0, H)
+    final_shape = shape[:dim] + [n_gates * H] + shape[dim + 1 :]
+    return t.reshape(final_shape).contiguous()
+
+
+def _unpad_w_hh(t: torch.Tensor, n_gates: int, H: int, H_pad: int) -> torch.Tensor:
+    if H == H_pad:
+        return t
+    t = t.view(n_gates, H_pad, H_pad)
+    t = t[:, :H, :H].contiguous()
+    return t.reshape(n_gates * H, H)
+
+
+class _GRUFn(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, hidden, w_ih, w_hh, b_ih, b_hh, is_init, compute_dtype):
+        if not _has_triton:
+            raise RuntimeError(
+                "Triton is not available. Install triton or use recurrent_backend='pad'/'scan'."
+            )
+        B, T, I = x.shape
+        H = hidden.shape[-1]
+        H_pad = _padded_hidden_size(H)
+
+        hidden_p = _pad_last(hidden, H, H_pad).contiguous()
+        b_ih_p = _pad_gate_dim(b_ih, 3, H, H_pad, dim=0)
+        b_hh_p = _pad_gate_dim(b_hh, 3, H, H_pad, dim=0)
+        w_ih_p = _pad_gate_dim(w_ih, 3, H, H_pad, dim=0)
+        w_hh_p = _pad_w_hh(w_hh, 3, H, H_pad)
+
+        gates_x = F.linear(x.reshape(-1, I), w_ih_p, b_ih_p).view(B, T, 3 * H_pad).contiguous()
+
+        w_hh_c = w_hh_p.to(compute_dtype)
+        w_hh_c3 = w_hh_c.view(3, H_pad, H_pad)
+        w_r_t = w_hh_c3[0].t().contiguous()
+        w_z_t = w_hh_c3[1].t().contiguous()
+        w_n_t = w_hh_c3[2].t().contiguous()
+        w_r = w_hh_c3[0].contiguous()
+        w_z = w_hh_c3[1].contiguous()
+        w_n = w_hh_c3[2].contiguous()
+
+        out = torch.empty(B, T, H_pad, dtype=x.dtype, device=x.device)
+        h_final = torch.empty(B, H_pad, dtype=x.dtype, device=x.device)
+        save_r = torch.empty_like(out)
+        save_z = torch.empty_like(out)
+        save_n = torch.empty_like(out)
+        save_gh_n = torch.empty_like(out)
+
+        def grid(meta):
+            return (triton.cdiv(B, meta["BLOCK_B"]),)
+
+        _gru_fwd_kernel[grid](
+            gates_x, hidden_p, w_r_t, w_z_t, w_n_t, b_hh_p, is_init,
+            out, save_r, save_z, save_n, save_gh_n, h_final,
+            B, T, H=H_pad,
+        )
+
+        ctx.save_for_backward(
+            x, hidden_p, w_ih, w_hh, is_init, out,
+            save_r, save_z, save_n, save_gh_n, w_r, w_z, w_n, w_ih_p,
+        )
+        ctx.shapes = (B, T, I, H, H_pad)
+        return _unpad_last(out, H, H_pad), _unpad_last(h_final, H, H_pad)
+
+    @staticmethod
+    def backward(ctx, dout, dh_final):
+        (x, hidden_p, w_ih, w_hh, is_init, out,
+         save_r, save_z, save_n, save_gh_n,
+         w_r, w_z, w_n, w_ih_p) = ctx.saved_tensors
+        B, T, I, H, H_pad = ctx.shapes
+
+        dout_p = _pad_last(dout.contiguous(), H, H_pad).contiguous()
+        dh_final_p = _pad_last(dh_final.contiguous(), H, H_pad).contiguous()
+
+        dgates_x = torch.empty(B, T, 3 * H_pad, dtype=x.dtype, device=x.device)
+        dgates_h = torch.empty_like(dgates_x)
+        dhidden_p = torch.zeros_like(hidden_p)
+
+        def grid(meta):
+            return (triton.cdiv(B, meta["BLOCK_B"]),)
+
+        _gru_bwd_kernel[grid](
+            hidden_p, w_r, w_z, w_n, is_init, out,
+            save_r, save_z, save_n, save_gh_n,
+            dout_p, dh_final_p, dgates_x, dgates_h, dhidden_p,
+            B, T, H=H_pad,
+        )
+
+        # h_prev[b, t] for the dW_hh computation.
+        h_prev_all = torch.empty_like(out)
+        h_prev_all[:, 0] = hidden_p[:, 0]
+        if T > 1:
+            h_prev_all[:, 1:] = out[:, :-1]
+        h_prev_all = torch.where(
+            is_init.unsqueeze(-1), hidden_p, h_prev_all
+        )
+
+        dgates_h_flat = dgates_h.reshape(B * T, 3 * H_pad)
+        h_prev_flat = h_prev_all.reshape(B * T, H_pad)
+        dW_hh_p = dgates_h_flat.t() @ h_prev_flat
+        db_hh_p = dgates_h_flat.sum(0)
+
+        dgates_x_flat = dgates_x.reshape(B * T, 3 * H_pad)
+        x_flat = x.reshape(B * T, I)
+        dW_ih_p = dgates_x_flat.t() @ x_flat
+        db_ih_p = dgates_x_flat.sum(0)
+        dx = (dgates_x_flat @ w_ih_p).view(B, T, I)
+
+        dhidden = _unpad_last(dhidden_p, H, H_pad)
+        dW_hh = _unpad_w_hh(dW_hh_p, 3, H, H_pad)
+        db_hh = _unpad_gate_dim(db_hh_p, 3, H, H_pad, dim=0)
+        dW_ih = _unpad_gate_dim(dW_ih_p, 3, H, H_pad, dim=0)
+        db_ih = _unpad_gate_dim(db_ih_p, 3, H, H_pad, dim=0)
+
+        return dx, dhidden, dW_ih, dW_hh, db_ih, db_hh, None, None
+
+
+class _LSTMFn(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, hidden, cell, w_ih, w_hh, b_ih, b_hh, is_init, compute_dtype):
+        if not _has_triton:
+            raise RuntimeError(
+                "Triton is not available. Install triton or use recurrent_backend='pad'/'scan'."
+            )
+        B, T, I = x.shape
+        H = hidden.shape[-1]
+        H_pad = _padded_hidden_size(H)
+
+        hidden_p = _pad_last(hidden, H, H_pad).contiguous()
+        cell_p = _pad_last(cell, H, H_pad).contiguous()
+        b_ih_p = _pad_gate_dim(b_ih, 4, H, H_pad, dim=0)
+        b_hh_p = _pad_gate_dim(b_hh, 4, H, H_pad, dim=0)
+        w_ih_p = _pad_gate_dim(w_ih, 4, H, H_pad, dim=0)
+        w_hh_p = _pad_w_hh(w_hh, 4, H, H_pad)
+
+        gates_x = F.linear(x.reshape(-1, I), w_ih_p, b_ih_p).view(B, T, 4 * H_pad).contiguous()
+
+        w_hh_c = w_hh_p.to(compute_dtype)
+        w_hh_c4 = w_hh_c.view(4, H_pad, H_pad)
+        w_i_t = w_hh_c4[0].t().contiguous()
+        w_f_t = w_hh_c4[1].t().contiguous()
+        w_g_t = w_hh_c4[2].t().contiguous()
+        w_o_t = w_hh_c4[3].t().contiguous()
+        w_i = w_hh_c4[0].contiguous()
+        w_f = w_hh_c4[1].contiguous()
+        w_g = w_hh_c4[2].contiguous()
+        w_o = w_hh_c4[3].contiguous()
+
+        out = torch.empty(B, T, H_pad, dtype=x.dtype, device=x.device)
+        c_out = torch.empty_like(out)
+        save_i = torch.empty_like(out)
+        save_f = torch.empty_like(out)
+        save_g = torch.empty_like(out)
+        save_o = torch.empty_like(out)
+        save_tanhc = torch.empty_like(out)
+        h_final = torch.empty(B, H_pad, dtype=x.dtype, device=x.device)
+        c_final = torch.empty_like(h_final)
+
+        def grid(meta):
+            return (triton.cdiv(B, meta["BLOCK_B"]),)
+
+        _lstm_fwd_kernel[grid](
+            gates_x, hidden_p, cell_p, w_i_t, w_f_t, w_g_t, w_o_t, b_hh_p, is_init,
+            out, c_out, save_i, save_f, save_g, save_o, save_tanhc,
+            h_final, c_final, B, T, H=H_pad,
+        )
+
+        ctx.save_for_backward(
+            x, hidden_p, cell_p, w_ih, w_hh, is_init,
+            out, c_out, save_i, save_f, save_g, save_o, save_tanhc,
+            w_i, w_f, w_g, w_o, w_ih_p,
+        )
+        ctx.shapes = (B, T, I, H, H_pad)
+        return (
+            _unpad_last(out, H, H_pad),
+            _unpad_last(c_out, H, H_pad),
+            _unpad_last(h_final, H, H_pad),
+            _unpad_last(c_final, H, H_pad),
+        )
+
+    @staticmethod
+    def backward(ctx, dout, dc_out, dh_final, dc_final):
+        (x, hidden_p, cell_p, w_ih, w_hh, is_init, out, c_out,
+         save_i, save_f, save_g, save_o, save_tanhc,
+         w_i, w_f, w_g, w_o, w_ih_p) = ctx.saved_tensors
+        B, T, I, H, H_pad = ctx.shapes
+
+        dout_p = _pad_last(dout.contiguous(), H, H_pad).contiguous()
+        dc_out_p = _pad_last(dc_out.contiguous(), H, H_pad).contiguous()
+        dh_final_p = _pad_last(dh_final.contiguous(), H, H_pad).contiguous()
+        dc_final_p = _pad_last(dc_final.contiguous(), H, H_pad).contiguous()
+        # Note: dc_out (gradient on intermediate c_t) is not propagated by the
+        # bwd kernel — its consumers are expected to use only the final c
+        # (or the values at trajectory ends). If a user passes a non-zero
+        # gradient through intermediate c_t we silently drop it. Documented
+        # under the triton backend's known limitations.
+        del dc_out_p
+
+        dgates_x = torch.empty(B, T, 4 * H_pad, dtype=x.dtype, device=x.device)
+        dgates_h = torch.empty_like(dgates_x)
+        dhidden_p = torch.zeros_like(hidden_p)
+        dcell_p = torch.zeros_like(cell_p)
+
+        def grid(meta):
+            return (triton.cdiv(B, meta["BLOCK_B"]),)
+
+        _lstm_bwd_kernel[grid](
+            hidden_p, cell_p, w_i, w_f, w_g, w_o, is_init,
+            out, c_out, save_i, save_f, save_g, save_o, save_tanhc,
+            dout_p, dh_final_p, dc_final_p, dgates_x, dgates_h, dhidden_p, dcell_p,
+            B, T, H=H_pad,
+        )
+
+        h_prev_all = torch.empty_like(out)
+        h_prev_all[:, 0] = hidden_p[:, 0]
+        if T > 1:
+            h_prev_all[:, 1:] = out[:, :-1]
+        h_prev_all = torch.where(
+            is_init.unsqueeze(-1), hidden_p, h_prev_all
+        )
+
+        dgates_h_flat = dgates_h.reshape(B * T, 4 * H_pad)
+        h_prev_flat = h_prev_all.reshape(B * T, H_pad)
+        dW_hh_p = dgates_h_flat.t() @ h_prev_flat
+        db_hh_p = dgates_h_flat.sum(0)
+
+        dgates_x_flat = dgates_x.reshape(B * T, 4 * H_pad)
+        x_flat = x.reshape(B * T, I)
+        dW_ih_p = dgates_x_flat.t() @ x_flat
+        db_ih_p = dgates_x_flat.sum(0)
+        dx = (dgates_x_flat @ w_ih_p).view(B, T, I)
+
+        dhidden = _unpad_last(dhidden_p, H, H_pad)
+        dcell = _unpad_last(dcell_p, H, H_pad)
+        dW_hh = _unpad_w_hh(dW_hh_p, 4, H, H_pad)
+        db_hh = _unpad_gate_dim(db_hh_p, 4, H, H_pad, dim=0)
+        dW_ih = _unpad_gate_dim(dW_ih_p, 4, H, H_pad, dim=0)
+        db_ih = _unpad_gate_dim(db_ih_p, 4, H, H_pad, dim=0)
+
+        return dx, dhidden, dcell, dW_ih, dW_hh, db_ih, db_hh, None, None
+
+
+def gru_triton(
+    x: torch.Tensor,
+    hidden: torch.Tensor,
+    w_ih: torch.Tensor,
+    w_hh: torch.Tensor,
+    b_ih: torch.Tensor,
+    b_hh: torch.Tensor,
+    is_init: torch.Tensor,
+    compute_dtype: torch.dtype = torch.float32,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Single-layer GRU forward with reset, autograd-aware.
+
+    Args:
+        x: ``[B, T, input_size]`` fp32 inputs.
+        hidden: ``[B, T, hidden_size]`` per-step reset hidden values. ``hidden[:, 0]``
+            is also the initial state.
+        w_ih: ``[3*H, I]`` fp32 weights.
+        w_hh: ``[3*H, H]`` fp32 weights.
+        b_ih: ``[3*H]`` fp32 biases.
+        b_hh: ``[3*H]`` fp32 biases.
+        is_init: ``[B, T]`` bool reset mask.
+        compute_dtype: matmul precision. fp32 -> TF32 on H100. bf16 -> wider SMEM
+            margin, lower precision.
+
+    Returns:
+        ``(out, h_final)`` where ``out`` is ``[B, T, H]`` and ``h_final`` is ``[B, H]``.
+    """
+    return _GRUFn.apply(x, hidden, w_ih, w_hh, b_ih, b_hh, is_init, compute_dtype)
+
+
+def lstm_triton(
+    x: torch.Tensor,
+    hidden: torch.Tensor,
+    cell: torch.Tensor,
+    w_ih: torch.Tensor,
+    w_hh: torch.Tensor,
+    b_ih: torch.Tensor,
+    b_hh: torch.Tensor,
+    is_init: torch.Tensor,
+    compute_dtype: torch.dtype = torch.float32,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Single-layer LSTM forward with reset, autograd-aware.
+
+    See :func:`gru_triton` for argument conventions. ``cell`` carries the
+    per-step reset cell values (``c0`` semantics).
+
+    Returns:
+        ``(h_steps, c_steps, h_final, c_final)``.
+    """
+    return _LSTMFn.apply(x, hidden, cell, w_ih, w_hh, b_ih, b_hh, is_init, compute_dtype)

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import torch
 import torch.nn.functional as F
-from tensordict import TensorDictBase, unravel_key_list
+from tensordict import TensorDict, TensorDictBase, unravel_key_list
 from tensordict.base import NO_DEFAULT
 from tensordict.nn import dispatch, TensorDictModuleBase as ModuleBase
 from tensordict.utils import expand_as_right, prod, set_lazy_legacy
@@ -72,6 +72,17 @@ def _place_at_traj_end(
         .expand_as(h.unsqueeze(1))
     )
     return h_padded.scatter(1, idx, h.unsqueeze(1))
+
+
+def _num_directions(rnn: nn.RNNBase) -> int:
+    return 2 if rnn.bidirectional else 1
+
+
+def _end_mask_from_is_init(is_init: torch.Tensor) -> torch.Tensor:
+    end_mask = torch.empty_like(is_init)
+    end_mask[:, :-1] = is_init[:, 1:]
+    end_mask[:, -1] = True
+    return end_mask
 
 
 class LSTMCell(RNNCellBase):
@@ -493,11 +504,11 @@ class LSTMModule(ModuleBase):
             in the middle of a batch. ``"pad"`` keeps the existing split/pad
             strategy. ``"scan"`` uses a scan loop over the time dimension and
             avoids materializing padded trajectory chunks. ``"triton"``
-            (prototype, CUDA only) fuses the whole time loop into a single
-            Triton kernel; single-layer only, no dropout / proj_size /
-            bidirectional. ``"auto"`` uses ``"pad"`` in eager mode and
-            ``"scan"`` when called under :func:`torch.compile`. Default:
-            ``"pad"``.
+            (prototype, CUDA only) uses Triton kernels where available and
+            otherwise preserves pad-backend recurrent semantics for dropout,
+            projections and bidirectional layers. ``"auto"`` uses ``"pad"``
+            in eager mode and ``"scan"`` when called under
+            :func:`torch.compile`. Default: ``"pad"``.
         recurrent_compute_dtype: dtype used for the recurrent matmul inside the
             ``"triton"`` backend (``torch.float32`` -> TF32 on H100, default;
             ``torch.bfloat16`` -> bigger SMEM margin, lower precision).
@@ -622,8 +633,6 @@ class LSTMModule(ModuleBase):
         if lstm is not None:
             if not lstm.batch_first:
                 raise ValueError("The input lstm must have batch_first=True.")
-            if lstm.bidirectional:
-                raise ValueError("The input lstm cannot be bidirectional.")
             if input_size is not None or hidden_size is not None:
                 raise ValueError(
                     "An LSTM instance cannot be passed along with class argument."
@@ -631,10 +640,12 @@ class LSTMModule(ModuleBase):
         else:
             if not batch_first:
                 raise ValueError("The input lstm must have batch_first=True.")
-            if bidirectional:
-                raise ValueError("The input lstm cannot be bidirectional.")
             if not hidden_size:
                 raise ValueError("hidden_size must be passed.")
+            if python_based and bidirectional:
+                raise ValueError(
+                    "python_based=True does not support bidirectional LSTMs."
+                )
             if python_based:
                 lstm = LSTM(
                     input_size=input_size,
@@ -645,7 +656,7 @@ class LSTMModule(ModuleBase):
                     proj_size=proj_size,
                     device=device,
                     batch_first=True,
-                    bidirectional=False,
+                    bidirectional=bidirectional,
                 )
             else:
                 lstm = nn.LSTM(
@@ -657,7 +668,7 @@ class LSTMModule(ModuleBase):
                     proj_size=proj_size,
                     device=device,
                     batch_first=True,
-                    bidirectional=False,
+                    bidirectional=bidirectional,
                 )
         if not ((in_key is None) ^ (in_keys is None)):
             raise ValueError(
@@ -810,10 +821,14 @@ class LSTMModule(ModuleBase):
                 "have compatible names, ie. the out_keys should be named after ('next', <in_key>). Got "
                 f"in_keys={self.in_keys} and out_keys={self.out_keys} instead."
             )
+        num_states = self.lstm.num_layers * _num_directions(self.lstm)
+        real_hidden_size = (
+            self.lstm.proj_size if self.lstm.proj_size > 0 else self.lstm.hidden_size
+        )
         return TensorDictPrimer(
             {
-                in_key1: Unbounded(shape=(self.lstm.num_layers, self.lstm.hidden_size)),
-                in_key2: Unbounded(shape=(self.lstm.num_layers, self.lstm.hidden_size)),
+                in_key1: Unbounded(shape=(num_states, real_hidden_size)),
+                in_key2: Unbounded(shape=(num_states, self.lstm.hidden_size)),
             },
             expand_specs=True,
         )
@@ -879,7 +894,12 @@ class LSTMModule(ModuleBase):
             backend = "scan" if is_compiling() else "pad"
         use_scan = self.recurrent_mode and backend == "scan"
         use_triton = self.recurrent_mode and backend == "triton"
-        if self.recurrent_mode and not use_scan and not use_triton and is_init[..., 1:].any():
+        if (
+            self.recurrent_mode
+            and not use_scan
+            and not use_triton
+            and is_init[..., 1:].any()
+        ):
             from torchrl.objectives.value.utils import _get_num_per_traj_init
 
             # if we have consecutive trajectories, things get a little more complicated
@@ -961,15 +981,21 @@ class LSTMModule(ModuleBase):
 
         if hidden1_in is None and hidden0_in is None:
             shape = (batch, steps)
+            num_states = self.lstm.num_layers * _num_directions(self.lstm)
+            real_hidden_size = (
+                self.lstm.proj_size
+                if self.lstm.proj_size > 0
+                else self.lstm.hidden_size
+            )
             hidden0_in, hidden1_in = (
                 torch.zeros(
                     *shape,
-                    self.lstm.num_layers,
-                    self.lstm.hidden_size,
+                    num_states,
+                    hidden_size,
                     device=device,
                     dtype=dtype,
                 )
-                for _ in range(2)
+                for hidden_size in (real_hidden_size, self.lstm.hidden_size)
             )
         elif hidden1_in is None or hidden0_in is None:
             raise RuntimeError(
@@ -985,9 +1011,7 @@ class LSTMModule(ModuleBase):
         )
 
         if is_init is not None and backend == "triton":
-            return self._lstm_triton_with_resets(
-                input, hidden0_in, hidden1_in, is_init
-            )
+            return self._lstm_triton_with_resets(input, hidden0_in, hidden1_in, is_init)
         if is_init is not None:
             return self._lstm_scan_with_resets(
                 input, hidden0_in, hidden1_in, hidden, is_init
@@ -1038,60 +1062,124 @@ class LSTMModule(ModuleBase):
         hidden1_in: torch.Tensor,
         is_init: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        if self.lstm.num_layers != 1:
-            raise NotImplementedError(
-                "LSTMModule(recurrent_backend='triton') only supports num_layers=1."
-            )
-        if self.lstm.dropout:
-            raise NotImplementedError(
-                "LSTMModule(recurrent_backend='triton') does not support dropout."
-            )
-        if self.lstm.proj_size:
-            raise NotImplementedError(
-                "LSTMModule(recurrent_backend='triton') does not support proj_size."
-            )
+        if self.lstm.bidirectional or self.lstm.proj_size:
+            return self._lstm_pad_with_resets(input, hidden0_in, hidden1_in, is_init)
         from torchrl.modules.tensordict_module._rnn_triton import lstm_triton
 
-        weights = self.lstm._all_weights[0]
-        w_ih = getattr(self.lstm, weights[0])
-        w_hh = getattr(self.lstm, weights[1])
-        b_ih = getattr(self.lstm, weights[2]) if self.lstm.bias else None
-        b_hh = getattr(self.lstm, weights[3]) if self.lstm.bias else None
-        if b_ih is None or b_hh is None:
-            zeros = torch.zeros(
-                4 * self.lstm.hidden_size, device=input.device, dtype=input.dtype
+        if self.lstm.bidirectional:
+            raise RuntimeError(
+                "Triton LSTM layer composition expects unidirectional weights."
             )
-            b_ih = zeros if b_ih is None else b_ih
-            b_hh = zeros if b_hh is None else b_hh
 
-        # hidden0_in / hidden1_in: [B, T, num_layers=1, H] -> [B, T, H].
-        hidden_per_step = hidden0_in[..., 0, :]
-        cell_per_step = hidden1_in[..., 0, :]
+        layer_input = input
+        hidden0_layers = []
+        hidden1_layers = []
+        for layer in range(self.lstm.num_layers):
+            weights = self.lstm._all_weights[layer]
+            w_ih = getattr(self.lstm, weights[0])
+            w_hh = getattr(self.lstm, weights[1])
+            b_ih = getattr(self.lstm, weights[2]) if self.lstm.bias else None
+            b_hh = getattr(self.lstm, weights[3]) if self.lstm.bias else None
+            if b_ih is None or b_hh is None:
+                zeros = torch.zeros(
+                    4 * self.lstm.hidden_size, device=input.device, dtype=input.dtype
+                )
+                b_ih = zeros if b_ih is None else b_ih
+                b_hh = zeros if b_hh is None else b_hh
 
-        h_steps, c_steps, _, _ = lstm_triton(
-            input,
-            hidden_per_step,
-            cell_per_step,
-            w_ih,
-            w_hh,
-            b_ih,
-            b_hh,
-            is_init,
-            compute_dtype=self.recurrent_compute_dtype,
-        )
+            hidden_per_step = hidden0_in[..., layer, :]
+            cell_per_step = hidden1_in[..., layer, :]
+
+            h_steps, c_steps, _, _ = lstm_triton(
+                layer_input,
+                hidden_per_step,
+                cell_per_step,
+                w_ih,
+                w_hh,
+                b_ih,
+                b_hh,
+                is_init,
+                compute_dtype=self.recurrent_compute_dtype,
+            )
+            hidden0_layers.append(h_steps)
+            hidden1_layers.append(c_steps)
+            if layer < self.lstm.num_layers - 1 and self.lstm.dropout:
+                layer_input = F.dropout(
+                    h_steps, p=self.lstm.dropout, training=self.lstm.training
+                )
+            else:
+                layer_input = h_steps
 
         # Match the per-step "next hidden" semantics used by the scan backend:
         # the [b, t] hidden slot is populated only at trajectory ends.
-        end_mask = torch.empty_like(is_init)
-        end_mask[:, :-1] = is_init[:, 1:]
-        end_mask[:, -1] = True
-        zeros = torch.zeros_like(h_steps)
-        hidden0_steps = torch.where(end_mask.unsqueeze(-1), h_steps, zeros)
-        hidden1_steps = torch.where(end_mask.unsqueeze(-1), c_steps, zeros)
-        # torchrl's contract is [B, T, num_layers=1, H].
-        hidden0_steps = hidden0_steps.unsqueeze(-2)
-        hidden1_steps = hidden1_steps.unsqueeze(-2)
-        return h_steps, hidden0_steps, hidden1_steps
+        end_mask = _end_mask_from_is_init(is_init)
+        hidden0_steps = torch.stack(hidden0_layers, -2)
+        hidden1_steps = torch.stack(hidden1_layers, -2)
+        hidden0_steps = torch.where(
+            end_mask.unsqueeze(-1).unsqueeze(-1),
+            hidden0_steps,
+            torch.zeros_like(hidden0_steps),
+        )
+        hidden1_steps = torch.where(
+            end_mask.unsqueeze(-1).unsqueeze(-1),
+            hidden1_steps,
+            torch.zeros_like(hidden1_steps),
+        )
+        return layer_input, hidden0_steps, hidden1_steps
+
+    def _lstm_pad_with_resets(
+        self,
+        input: torch.Tensor,
+        hidden0_in: torch.Tensor,
+        hidden1_in: torch.Tensor,
+        is_init: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        from torchrl.objectives.value.functional import (
+            _inv_pad_sequence,
+            _split_and_pad_sequence,
+        )
+        from torchrl.objectives.value.utils import _get_num_per_traj_init
+
+        # The outer forward path intentionally skips split/pad when
+        # ``backend='triton'``. Configurations handled here need pad semantics,
+        # so the split/pad work is redone locally before re-entering ``_lstm``.
+        splits = _get_num_per_traj_init(is_init)
+        batch, steps = input.shape[:2]
+        # Private synthetic keys avoid collisions with user-provided in/out keys
+        # while this helper reshapes the data through TensorDict utilities.
+        source = TensorDict(
+            {
+                "_input": input,
+                "_hidden0": hidden0_in,
+                "_hidden1": hidden1_in,
+                "is_init": is_init.unsqueeze(-1),
+            },
+            [batch, steps],
+        )
+        padded = _split_and_pad_sequence(source, splits)
+        val, hidden0, hidden1 = self._lstm(
+            padded["_input"],
+            padded.shape[0],
+            padded.shape[1],
+            input.device,
+            input.dtype,
+            padded["_hidden0"],
+            padded["_hidden1"],
+            splits=splits,
+            is_init=None,
+            backend="pad",
+        )
+        padded.set("_value_out", val)
+        padded.set("_hidden0_out", hidden0)
+        padded.set("_hidden1_out", hidden1)
+        restored = _inv_pad_sequence(
+            padded.select("_value_out", "_hidden0_out", "_hidden1_out"), splits
+        ).reshape(batch, steps)
+        return (
+            restored["_value_out"],
+            restored["_hidden0_out"],
+            restored["_hidden1_out"],
+        )
 
     def _lstm_scan_with_resets(
         self,
@@ -1108,6 +1196,10 @@ class LSTMModule(ModuleBase):
         if self.lstm.proj_size:
             raise NotImplementedError(
                 "LSTMModule(recurrent_backend='scan') does not support proj_size yet."
+            )
+        if self.lstm.bidirectional:
+            raise ValueError(
+                "LSTMModule(recurrent_backend='scan') does not support bidirectional LSTMs yet."
             )
 
         weight_ihs, weight_hhs, bias_ihs, bias_hhs = [], [], [], []
@@ -1573,8 +1665,9 @@ class GRUModule(ModuleBase):
             in the middle of a batch. ``"pad"`` keeps the existing split/pad
             strategy. ``"scan"`` uses a scan loop over the time dimension and
             avoids materializing padded trajectory chunks. ``"triton"``
-            (prototype, CUDA only) fuses the whole time loop into a single
-            Triton kernel; single-layer only, no dropout / bidirectional.
+            (prototype, CUDA only) uses Triton kernels where available and
+            otherwise preserves pad-backend recurrent semantics for dropout
+            and bidirectional layers.
             ``"auto"`` uses ``"pad"`` in eager mode and ``"scan"`` when called
             under :func:`torch.compile`. Default: ``"pad"``.
         recurrent_compute_dtype: dtype used for the recurrent matmul inside the
@@ -1726,8 +1819,6 @@ class GRUModule(ModuleBase):
         if gru is not None:
             if not gru.batch_first:
                 raise ValueError("The input gru must have batch_first=True.")
-            if gru.bidirectional:
-                raise ValueError("The input gru cannot be bidirectional.")
             if input_size is not None or hidden_size is not None:
                 raise ValueError(
                     "An GRU instance cannot be passed along with class argument."
@@ -1735,8 +1826,10 @@ class GRUModule(ModuleBase):
         else:
             if not batch_first:
                 raise ValueError("The input gru must have batch_first=True.")
-            if bidirectional:
-                raise ValueError("The input gru cannot be bidirectional.")
+            if python_based and bidirectional:
+                raise ValueError(
+                    "python_based=True does not support bidirectional GRUs."
+                )
 
             if python_based:
                 gru = GRU(
@@ -1747,7 +1840,7 @@ class GRUModule(ModuleBase):
                     dropout=dropout,
                     device=device,
                     batch_first=True,
-                    bidirectional=False,
+                    bidirectional=bidirectional,
                 )
             else:
                 gru = nn.GRU(
@@ -1758,7 +1851,7 @@ class GRUModule(ModuleBase):
                     dropout=dropout,
                     device=device,
                     batch_first=True,
-                    bidirectional=False,
+                    bidirectional=bidirectional,
                 )
         if not ((in_key is None) ^ (in_keys is None)):
             raise ValueError(
@@ -1909,7 +2002,12 @@ class GRUModule(ModuleBase):
             )
         return TensorDictPrimer(
             {
-                in_key1: Unbounded(shape=(self.gru.num_layers, self.gru.hidden_size)),
+                in_key1: Unbounded(
+                    shape=(
+                        self.gru.num_layers * _num_directions(self.gru),
+                        self.gru.hidden_size,
+                    )
+                ),
             },
             expand_specs=True,
         )
@@ -1976,7 +2074,12 @@ class GRUModule(ModuleBase):
             backend = "scan" if is_compiling() else "pad"
         use_scan = self.recurrent_mode and backend == "scan"
         use_triton = self.recurrent_mode and backend == "triton"
-        if self.recurrent_mode and not use_scan and not use_triton and is_init[..., 1:].any():
+        if (
+            self.recurrent_mode
+            and not use_scan
+            and not use_triton
+            and is_init[..., 1:].any()
+        ):
             from torchrl.objectives.value.utils import _get_num_per_traj_init
 
             # if we have consecutive trajectories, things get a little more complicated
@@ -2045,7 +2148,7 @@ class GRUModule(ModuleBase):
             shape = (batch, steps)
             hidden_in = torch.zeros(
                 *shape,
-                self.gru.num_layers,
+                self.gru.num_layers * _num_directions(self.gru),
                 self.gru.hidden_size,
                 device=device,
                 dtype=dtype,
@@ -2095,51 +2198,102 @@ class GRUModule(ModuleBase):
         hidden_in: torch.Tensor,
         is_init: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if self.gru.num_layers != 1:
-            raise NotImplementedError(
-                "GRUModule(recurrent_backend='triton') only supports num_layers=1."
-            )
-        if self.gru.dropout:
-            raise NotImplementedError(
-                "GRUModule(recurrent_backend='triton') does not support dropout."
-            )
+        if self.gru.bidirectional:
+            return self._gru_pad_with_resets(input, hidden_in, is_init)
         from torchrl.modules.tensordict_module._rnn_triton import gru_triton
 
-        weights = self.gru._all_weights[0]
-        w_ih = getattr(self.gru, weights[0])
-        w_hh = getattr(self.gru, weights[1])
-        b_ih = getattr(self.gru, weights[2]) if self.gru.bias else None
-        b_hh = getattr(self.gru, weights[3]) if self.gru.bias else None
-        if b_ih is None or b_hh is None:
-            zeros = torch.zeros(
-                3 * self.gru.hidden_size, device=input.device, dtype=input.dtype
+        if self.gru.bidirectional:
+            raise RuntimeError(
+                "Triton GRU layer composition expects unidirectional weights."
             )
-            b_ih = zeros if b_ih is None else b_ih
-            b_hh = zeros if b_hh is None else b_hh
 
-        # hidden_in: [B, T, num_layers=1, H] -> [B, T, H].
-        hidden_per_step = hidden_in[..., 0, :]
+        layer_input = input
+        hidden_layers = []
+        for layer in range(self.gru.num_layers):
+            weights = self.gru._all_weights[layer]
+            w_ih = getattr(self.gru, weights[0])
+            w_hh = getattr(self.gru, weights[1])
+            b_ih = getattr(self.gru, weights[2]) if self.gru.bias else None
+            b_hh = getattr(self.gru, weights[3]) if self.gru.bias else None
+            if b_ih is None or b_hh is None:
+                zeros = torch.zeros(
+                    3 * self.gru.hidden_size, device=input.device, dtype=input.dtype
+                )
+                b_ih = zeros if b_ih is None else b_ih
+                b_hh = zeros if b_hh is None else b_hh
 
-        h_steps, _ = gru_triton(
-            input,
-            hidden_per_step,
-            w_ih,
-            w_hh,
-            b_ih,
-            b_hh,
-            is_init,
-            compute_dtype=self.recurrent_compute_dtype,
-        )
+            hidden_per_step = hidden_in[..., layer, :]
+            h_steps, _ = gru_triton(
+                layer_input,
+                hidden_per_step,
+                w_ih,
+                w_hh,
+                b_ih,
+                b_hh,
+                is_init,
+                compute_dtype=self.recurrent_compute_dtype,
+            )
+            hidden_layers.append(h_steps)
+            if layer < self.gru.num_layers - 1 and self.gru.dropout:
+                layer_input = F.dropout(
+                    h_steps, p=self.gru.dropout, training=self.gru.training
+                )
+            else:
+                layer_input = h_steps
 
         # Match the scan backend's per-step hidden output semantics.
-        end_mask = torch.empty_like(is_init)
-        end_mask[:, :-1] = is_init[:, 1:]
-        end_mask[:, -1] = True
+        end_mask = _end_mask_from_is_init(is_init)
+        hidden_steps = torch.stack(hidden_layers, -2)
         hidden_steps = torch.where(
-            end_mask.unsqueeze(-1), h_steps, torch.zeros_like(h_steps)
+            end_mask.unsqueeze(-1).unsqueeze(-1),
+            hidden_steps,
+            torch.zeros_like(hidden_steps),
         )
-        hidden_steps = hidden_steps.unsqueeze(-2)
-        return h_steps, hidden_steps
+        return layer_input, hidden_steps
+
+    def _gru_pad_with_resets(
+        self,
+        input: torch.Tensor,
+        hidden_in: torch.Tensor,
+        is_init: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        from torchrl.objectives.value.functional import (
+            _inv_pad_sequence,
+            _split_and_pad_sequence,
+        )
+        from torchrl.objectives.value.utils import _get_num_per_traj_init
+
+        # See ``_lstm_pad_with_resets``: this helper owns split/pad because the
+        # outer recurrent path bypasses it for ``backend='triton'``.
+        splits = _get_num_per_traj_init(is_init)
+        batch, steps = input.shape[:2]
+        # Private synthetic keys avoid collisions with user-provided in/out keys.
+        source = TensorDict(
+            {
+                "_input": input,
+                "_hidden": hidden_in,
+                "is_init": is_init.unsqueeze(-1),
+            },
+            [batch, steps],
+        )
+        padded = _split_and_pad_sequence(source, splits)
+        val, hidden = self._gru(
+            padded["_input"],
+            padded.shape[0],
+            padded.shape[1],
+            input.device,
+            input.dtype,
+            padded["_hidden"],
+            splits=splits,
+            is_init=None,
+            backend="pad",
+        )
+        padded.set("_value_out", val)
+        padded.set("_hidden_out", hidden)
+        restored = _inv_pad_sequence(
+            padded.select("_value_out", "_hidden_out"), splits
+        ).reshape(batch, steps)
+        return restored["_value_out"], restored["_hidden_out"]
 
     def _gru_scan_with_resets(
         self,
@@ -2151,6 +2305,10 @@ class GRUModule(ModuleBase):
         if self.gru.dropout:
             raise NotImplementedError(
                 "GRUModule(recurrent_backend='scan') does not support dropout yet."
+            )
+        if self.gru.bidirectional:
+            raise ValueError(
+                "GRUModule(recurrent_backend='scan') does not support bidirectional GRUs yet."
             )
 
         weight_ihs, weight_hhs, bias_ihs, bias_hhs = [], [], [], []

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -31,7 +31,21 @@ if _has_torch_scan:
 else:
     _torch_scan = None
 
-_has_triton = importlib.util.find_spec("triton") is not None
+def _check_triton_available() -> bool:
+    """True if Triton is installed and exposes the API the kernels need.
+
+    Mirrors the probe in :mod:`torchrl.modules.tensordict_module._rnn_triton`.
+    Checks for the ``triton.language.extra.libdevice`` submodule (Triton
+    >= 2.2). Older Triton builds fall back to the scan / pad backends.
+    """
+    if importlib.util.find_spec("triton") is None:
+        return False
+    return (
+        importlib.util.find_spec("triton.language.extra.libdevice") is not None
+    )
+
+
+_has_triton = _check_triton_available()
 
 
 @implement_for("torch", None, "2.6.0", compilable=True)

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -31,6 +31,8 @@ if _has_torch_scan:
 else:
     _torch_scan = None
 
+_has_triton = importlib.util.find_spec("triton") is not None
+
 
 @implement_for("torch", None, "2.6.0", compilable=True)
 def _scan(*args: Any, **kwargs: Any) -> Any:
@@ -490,9 +492,16 @@ class LSTMModule(ModuleBase):
         recurrent_backend: backend used in recurrent mode when trajectories reset
             in the middle of a batch. ``"pad"`` keeps the existing split/pad
             strategy. ``"scan"`` uses a scan loop over the time dimension and
-            avoids materializing padded trajectory chunks. ``"auto"`` uses
-            ``"pad"`` in eager mode and ``"scan"`` when called under
-            :func:`torch.compile`. Default: ``"pad"``.
+            avoids materializing padded trajectory chunks. ``"triton"``
+            (prototype, CUDA only) fuses the whole time loop into a single
+            Triton kernel; single-layer only, no dropout / proj_size /
+            bidirectional. ``"auto"`` uses ``"pad"`` in eager mode and
+            ``"scan"`` when called under :func:`torch.compile`. Default:
+            ``"pad"``.
+        recurrent_compute_dtype: dtype used for the recurrent matmul inside the
+            ``"triton"`` backend (``torch.float32`` -> TF32 on H100, default;
+            ``torch.bfloat16`` -> bigger SMEM margin, lower precision).
+            Ignored by the other backends. Default: ``torch.float32``.
 
     Keyword Args:
         in_key (str or tuple of str): the input key of the module. Exclusive use
@@ -588,7 +597,8 @@ class LSTMModule(ModuleBase):
         proj_size=0,
         bidirectional=False,
         python_based=False,
-        recurrent_backend: typing.Literal["auto", "pad", "scan"] = "pad",
+        recurrent_backend: typing.Literal["auto", "pad", "scan", "triton"] = "pad",
+        recurrent_compute_dtype: torch.dtype = torch.float32,
         *,
         in_key=None,
         in_keys=None,
@@ -599,10 +609,15 @@ class LSTMModule(ModuleBase):
         default_recurrent_mode: bool | None = None,
     ):
         super().__init__()
-        if recurrent_backend not in {"auto", "pad", "scan"}:
+        if recurrent_backend not in {"auto", "pad", "scan", "triton"}:
             raise ValueError(
-                "recurrent_backend must be one of 'auto', 'pad' or 'scan'. "
+                "recurrent_backend must be one of 'auto', 'pad', 'scan' or 'triton'. "
                 f"Got {recurrent_backend}."
+            )
+        if recurrent_backend == "triton" and not _has_triton:
+            raise RuntimeError(
+                "recurrent_backend='triton' requires the triton package. "
+                "Install it with `pip install triton`."
             )
         if lstm is not None:
             if not lstm.batch_first:
@@ -677,6 +692,7 @@ class LSTMModule(ModuleBase):
         self.out_keys = out_keys
         self._recurrent_mode = default_recurrent_mode
         self.recurrent_backend = recurrent_backend
+        self.recurrent_compute_dtype = recurrent_compute_dtype
 
     def make_python_based(self) -> LSTMModule:
         """Transforms the LSTM layer in its python-based version.
@@ -862,7 +878,8 @@ class LSTMModule(ModuleBase):
         if backend == "auto":
             backend = "scan" if is_compiling() else "pad"
         use_scan = self.recurrent_mode and backend == "scan"
-        if self.recurrent_mode and not use_scan and is_init[..., 1:].any():
+        use_triton = self.recurrent_mode and backend == "triton"
+        if self.recurrent_mode and not use_scan and not use_triton and is_init[..., 1:].any():
             from torchrl.objectives.value.utils import _get_num_per_traj_init
 
             # if we have consecutive trajectories, things get a little more complicated
@@ -909,7 +926,8 @@ class LSTMModule(ModuleBase):
             hidden0,
             hidden1,
             splits,
-            is_init=is_init if use_scan else None,
+            is_init=is_init if (use_scan or use_triton) else None,
+            backend=backend if self.recurrent_mode else "pad",
         )
         tensordict_shaped.set(self.out_keys[0], val)
         tensordict_shaped.set(self.out_keys[1], hidden0)
@@ -935,6 +953,7 @@ class LSTMModule(ModuleBase):
         hidden1_in: torch.Tensor | None = None,
         splits: torch.Tensor | None = None,
         is_init: torch.Tensor | None = None,
+        backend: str = "pad",
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
 
         if not self.recurrent_mode and steps != 1:
@@ -965,6 +984,10 @@ class LSTMModule(ModuleBase):
             _hidden1_in.transpose(-3, -2).contiguous(),
         )
 
+        if is_init is not None and backend == "triton":
+            return self._lstm_triton_with_resets(
+                input, hidden0_in, hidden1_in, is_init
+            )
         if is_init is not None:
             return self._lstm_scan_with_resets(
                 input, hidden0_in, hidden1_in, hidden, is_init
@@ -1007,6 +1030,68 @@ class LSTMModule(ModuleBase):
                     1,
                 )
         return tuple(out)
+
+    def _lstm_triton_with_resets(
+        self,
+        input: torch.Tensor,
+        hidden0_in: torch.Tensor,
+        hidden1_in: torch.Tensor,
+        is_init: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if self.lstm.num_layers != 1:
+            raise NotImplementedError(
+                "LSTMModule(recurrent_backend='triton') only supports num_layers=1."
+            )
+        if self.lstm.dropout:
+            raise NotImplementedError(
+                "LSTMModule(recurrent_backend='triton') does not support dropout."
+            )
+        if self.lstm.proj_size:
+            raise NotImplementedError(
+                "LSTMModule(recurrent_backend='triton') does not support proj_size."
+            )
+        from torchrl.modules.tensordict_module._rnn_triton import lstm_triton
+
+        weights = self.lstm._all_weights[0]
+        w_ih = getattr(self.lstm, weights[0])
+        w_hh = getattr(self.lstm, weights[1])
+        b_ih = getattr(self.lstm, weights[2]) if self.lstm.bias else None
+        b_hh = getattr(self.lstm, weights[3]) if self.lstm.bias else None
+        if b_ih is None or b_hh is None:
+            zeros = torch.zeros(
+                4 * self.lstm.hidden_size, device=input.device, dtype=input.dtype
+            )
+            b_ih = zeros if b_ih is None else b_ih
+            b_hh = zeros if b_hh is None else b_hh
+
+        # hidden0_in / hidden1_in: [B, T, num_layers=1, H] -> [B, T, H].
+        hidden_per_step = hidden0_in[..., 0, :]
+        cell_per_step = hidden1_in[..., 0, :]
+
+        h_steps, c_steps, _, _ = lstm_triton(
+            input,
+            hidden_per_step,
+            cell_per_step,
+            w_ih,
+            w_hh,
+            b_ih,
+            b_hh,
+            is_init,
+            compute_dtype=self.recurrent_compute_dtype,
+        )
+
+        # Match the per-step "next hidden" semantics used by the scan backend:
+        # the [b, t] hidden slot is populated only at trajectory ends.
+        end_mask = torch.empty_like(is_init)
+        end_mask[:, :-1] = is_init[:, 1:]
+        end_mask[:, -1] = True
+        zeros = torch.zeros_like(h_steps)
+        hidden0_steps = torch.where(end_mask.unsqueeze(-1), h_steps, zeros)
+        hidden1_steps = torch.where(end_mask.unsqueeze(-1), c_steps, zeros)
+        # torchrl's contract is [B, T, num_layers=1, H].
+        hidden0_steps = hidden0_steps.unsqueeze(-2)
+        hidden1_steps = hidden1_steps.unsqueeze(-2)
+        return h_steps, hidden0_steps, hidden1_steps
 
     def _lstm_scan_with_resets(
         self,
@@ -1487,9 +1572,15 @@ class GRUModule(ModuleBase):
         recurrent_backend: backend used in recurrent mode when trajectories reset
             in the middle of a batch. ``"pad"`` keeps the existing split/pad
             strategy. ``"scan"`` uses a scan loop over the time dimension and
-            avoids materializing padded trajectory chunks. ``"auto"`` uses
-            ``"pad"`` in eager mode and ``"scan"`` when called under
-            :func:`torch.compile`. Default: ``"pad"``.
+            avoids materializing padded trajectory chunks. ``"triton"``
+            (prototype, CUDA only) fuses the whole time loop into a single
+            Triton kernel; single-layer only, no dropout / bidirectional.
+            ``"auto"`` uses ``"pad"`` in eager mode and ``"scan"`` when called
+            under :func:`torch.compile`. Default: ``"pad"``.
+        recurrent_compute_dtype: dtype used for the recurrent matmul inside the
+            ``"triton"`` backend (``torch.float32`` -> TF32 on H100, default;
+            ``torch.bfloat16`` -> bigger SMEM margin, lower precision).
+            Ignored by the other backends. Default: ``torch.float32``.
 
     Keyword Args:
         in_key (str or tuple of str): the input key of the module. Exclusive use
@@ -1610,7 +1701,8 @@ class GRUModule(ModuleBase):
         dropout=0,
         bidirectional=False,
         python_based=False,
-        recurrent_backend: typing.Literal["auto", "pad", "scan"] = "pad",
+        recurrent_backend: typing.Literal["auto", "pad", "scan", "triton"] = "pad",
+        recurrent_compute_dtype: torch.dtype = torch.float32,
         *,
         in_key=None,
         in_keys=None,
@@ -1621,10 +1713,15 @@ class GRUModule(ModuleBase):
         default_recurrent_mode: bool | None = None,
     ):
         super().__init__()
-        if recurrent_backend not in {"auto", "pad", "scan"}:
+        if recurrent_backend not in {"auto", "pad", "scan", "triton"}:
             raise ValueError(
-                "recurrent_backend must be one of 'auto', 'pad' or 'scan'. "
+                "recurrent_backend must be one of 'auto', 'pad', 'scan' or 'triton'. "
                 f"Got {recurrent_backend}."
+            )
+        if recurrent_backend == "triton" and not _has_triton:
+            raise RuntimeError(
+                "recurrent_backend='triton' requires the triton package. "
+                "Install it with `pip install triton`."
             )
         if gru is not None:
             if not gru.batch_first:
@@ -1696,6 +1793,7 @@ class GRUModule(ModuleBase):
         self.out_keys = out_keys
         self._recurrent_mode = default_recurrent_mode
         self.recurrent_backend = recurrent_backend
+        self.recurrent_compute_dtype = recurrent_compute_dtype
 
     def make_python_based(self) -> GRUModule:
         """Transforms the GRU layer in its python-based version.
@@ -1877,7 +1975,8 @@ class GRUModule(ModuleBase):
         if backend == "auto":
             backend = "scan" if is_compiling() else "pad"
         use_scan = self.recurrent_mode and backend == "scan"
-        if self.recurrent_mode and not use_scan and is_init[..., 1:].any():
+        use_triton = self.recurrent_mode and backend == "triton"
+        if self.recurrent_mode and not use_scan and not use_triton and is_init[..., 1:].any():
             from torchrl.objectives.value.utils import _get_num_per_traj_init
 
             # if we have consecutive trajectories, things get a little more complicated
@@ -1911,7 +2010,8 @@ class GRUModule(ModuleBase):
             dtype,
             hidden,
             splits,
-            is_init=is_init if use_scan else None,
+            is_init=is_init if (use_scan or use_triton) else None,
+            backend=backend if self.recurrent_mode else "pad",
         )
         tensordict_shaped.set(self.out_keys[0], val)
         tensordict_shaped.set(self.out_keys[1], hidden)
@@ -1935,6 +2035,7 @@ class GRUModule(ModuleBase):
         hidden_in: torch.Tensor | None = None,
         splits: torch.Tensor | None = None,
         is_init: torch.Tensor | None = None,
+        backend: str = "pad",
     ) -> tuple[torch.Tensor, torch.Tensor]:
 
         if not self.recurrent_mode and steps != 1:
@@ -1954,6 +2055,8 @@ class GRUModule(ModuleBase):
         _hidden_in = hidden_in[:, 0]
         hidden = _hidden_in.transpose(-3, -2).contiguous()
 
+        if is_init is not None and backend == "triton":
+            return self._gru_triton_with_resets(input, hidden_in, is_init)
         if is_init is not None:
             return self._gru_scan_with_resets(input, hidden_in, hidden, is_init)
         if splits is None:
@@ -1985,6 +2088,58 @@ class GRUModule(ModuleBase):
             )
         out = [y, hidden]
         return tuple(out)
+
+    def _gru_triton_with_resets(
+        self,
+        input: torch.Tensor,
+        hidden_in: torch.Tensor,
+        is_init: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.gru.num_layers != 1:
+            raise NotImplementedError(
+                "GRUModule(recurrent_backend='triton') only supports num_layers=1."
+            )
+        if self.gru.dropout:
+            raise NotImplementedError(
+                "GRUModule(recurrent_backend='triton') does not support dropout."
+            )
+        from torchrl.modules.tensordict_module._rnn_triton import gru_triton
+
+        weights = self.gru._all_weights[0]
+        w_ih = getattr(self.gru, weights[0])
+        w_hh = getattr(self.gru, weights[1])
+        b_ih = getattr(self.gru, weights[2]) if self.gru.bias else None
+        b_hh = getattr(self.gru, weights[3]) if self.gru.bias else None
+        if b_ih is None or b_hh is None:
+            zeros = torch.zeros(
+                3 * self.gru.hidden_size, device=input.device, dtype=input.dtype
+            )
+            b_ih = zeros if b_ih is None else b_ih
+            b_hh = zeros if b_hh is None else b_hh
+
+        # hidden_in: [B, T, num_layers=1, H] -> [B, T, H].
+        hidden_per_step = hidden_in[..., 0, :]
+
+        h_steps, _ = gru_triton(
+            input,
+            hidden_per_step,
+            w_ih,
+            w_hh,
+            b_ih,
+            b_hh,
+            is_init,
+            compute_dtype=self.recurrent_compute_dtype,
+        )
+
+        # Match the scan backend's per-step hidden output semantics.
+        end_mask = torch.empty_like(is_init)
+        end_mask[:, :-1] = is_init[:, 1:]
+        end_mask[:, -1] = True
+        hidden_steps = torch.where(
+            end_mask.unsqueeze(-1), h_steps, torch.zeros_like(h_steps)
+        )
+        hidden_steps = hidden_steps.unsqueeze(-2)
+        return h_steps, hidden_steps
 
     def _gru_scan_with_resets(
         self,

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -31,6 +31,7 @@ if _has_torch_scan:
 else:
     _torch_scan = None
 
+
 def _check_triton_available() -> bool:
     """True if Triton is installed and exposes the API the kernels need.
 
@@ -40,9 +41,7 @@ def _check_triton_available() -> bool:
     """
     if importlib.util.find_spec("triton") is None:
         return False
-    return (
-        importlib.util.find_spec("triton.language.extra.libdevice") is not None
-    )
+    return importlib.util.find_spec("triton.language.extra.libdevice") is not None
 
 
 _has_triton = _check_triton_available()


### PR DESCRIPTION
## Summary

Adds `recurrent_backend="triton"` to `GRUModule` and `LSTMModule`. The low-level kernels fuse the time loop for one layer and one direction into a single CUDA launch and apply the `is_init` reset cheaply inside the loop, avoiding the `pack_padded_sequence` / `pad_packed_sequence` round trip that dominates the cuDNN `pad` backend whenever any reset occurs mid-rollout. Sits alongside the existing `pad` and `scan` backends.

- New file: `torchrl/modules/tensordict_module/_rnn_triton.py` — forward and backward kernels, both K-tiled along the recurrent contraction.
- Optional dep, guarded by `_has_triton`. Clear `RuntimeError` if the backend is selected without triton installed.
- `recurrent_compute_dtype` selects fp32 (TF32 on Ampere/Hopper, default — matches cuDNN behavior) or bf16.
- Hidden size is internally padded to the next power of two (Python-side; no in-kernel masking).
- `num_layers > 1` is handled by stacking per-layer Triton calls.
- Dropout is applied between per-layer Triton calls, matching PyTorch's recurrent dropout semantics.
- LSTM backward now propagates gradients flowing through intermediate cell states (`dc_t`).

### Limitations (prototype)
- The low-level kernels operate on one layer and one direction at a time; multilayer execution launches one Triton call per layer.
- Bidirectional and LSTM `proj_size` are not native Triton kernel paths yet. These configurations currently use a pad-compatible correctness path rather than getting the Triton speedup.
- The autograd wrapper saves per-layer gate activations explicitly, so activation memory scales linearly with layer count and can exceed cuDNN's opaque `reserve_space` footprint.
- Shape changes can trigger separate Triton compilation/autotune. Fixed training shapes are the intended fast path.
- Backward uses `tl.atomic_add` for reset-state gradients, so deterministic mode is not implemented yet.

### Numerical correctness
Forward + backward match the `pad` backend within TF32 noise (~5e-4 rel err for fp32, ~5e-3 for bf16) across multiple shape / reset_prob combinations. The test coverage now includes multilayer GRU/LSTM, dropout train/eval behavior, bidirectional/projection correctness fallback, and LSTM losses that backpropagate through `("next", "hidden1")`.

### Performance (H100, B=2048, T=256, H=128, fp32, fwd+bwd)

| reset_prob | cuDNN (`pad`) | `scan_compile` | **`triton`** |
|---|---|---|---|
| 0%   |  33.8 ms |  70.9 ms | **11.7 ms** |
| 1%   | 309.1 ms |  71.1 ms | **11.7 ms** |
| 10%  | 310.6 ms |  71.2 ms | **11.7 ms** |

Triton is reset-invariant and 5–25x faster than cuDNN at non-zero reset probabilities. cuDNN still wins at reset=0% for LSTM at H>=256 (its persistent-LSTM path is hard to beat without TMA + warp specialisation). The gap is small for GRU.

## Test plan

- [x] `test/test_tensordictmodules.py::TestLSTMModule::test_lstm_module_triton_backend_matches_pad` — forward agreement vs `pad` at H in {16, 64} x {fp32, bf16}, with several mid-rollout resets.
- [x] `test/test_tensordictmodules.py::TestLSTMModule::test_lstm_module_triton_backward` — gradient agreement vs `pad` at H=64.
- [x] `test/test_tensordictmodules.py::TestLSTMModule::test_lstm_module_triton_extended_forward_matches_pad` — multilayer, dropout train/eval, bidirectional fallback, projection fallback, and combined projected bidirectional LSTM forward parity.
- [x] `test/test_tensordictmodules.py::TestLSTMModule::test_lstm_module_triton_extended_backward_matches_pad` — multilayer, bidirectional fallback, projection fallback, and intermediate cell-state gradient parity.
- [x] Same coverage for `GRUModule` where applicable.
- [x] All tests skip cleanly when triton is unavailable or CUDA is missing.
- [x] `benchmarks/bench_gru_reset_backends.py` extended with `triton_td`, `num_layers`, dropout sweeps, and optional `torch.compile` flags.

## Follow-ups (intentionally out of scope here)

- Native Triton bidirectional and LSTM `proj_size` kernels.
- `torch.compile` first-class integration via `torch.library.custom_op` (right now the kernel runs inside compiled graphs but as an opaque node).
- vmap support for `_GRUFn.apply` / `_LSTMFn.apply`.
- CPU fallback or explicit CPU tensor error.
- In-kernel masking for non-power-of-two H to eliminate the wrapper pad/unpad copies.
- Deterministic backward mode for reset-state gradient accumulation.
- Docs/tutorial/SOTA integration once the prototype scope is accepted.