### PR TITLE
[CI] Fix olddeps / opt-deps / gym smoke tests broken by #3738 and #3704

### DIFF
--- a/.github/unittest/linux_olddeps/scripts_gym_0_13/install.sh
+++ b/.github/unittest/linux_olddeps/scripts_gym_0_13/install.sh
@@ -46,15 +46,14 @@ fi
 # Solving circular import: https://stackoverflow.com/questions/75501048/how-to-fix-attributeerror-partially-initialized-module-charset-normalizer-has
 #pip install -U charset-normalizer
 
-# install tensordict
-#
-# NOTE:
-# - The olddeps CI job runs on older Python/torch stacks.
-# - Installing from tensordict `main` (git+https) is brittle as `main` may drop
-#   support for older Python versions at any time, which can lead to "tensordict
-#   not installed" failures in downstream smoke tests.
-# - Use the same (pinned) range as TorchRL itself to keep this job stable.
-python -m pip install "${TORCHRL_TENSORDICT_SPEC:-tensordict>=0.12.0,<0.13.0}"
+# install tensordict (from source on PR/nightly, from PyPI only on release/*)
+if [[ "$RELEASE" == 0 ]]; then
+  # pybind11 headers are required to build tensordict's C++ extension.
+  python -m pip install "pybind11[global]"
+  python -m pip install git+https://github.com/pytorch/tensordict.git
+else
+  python -m pip install tensordict
+fi
 
 # smoke test
 python -c "import tensordict; print(f'tensordict: {tensordict.__version__}')"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -180,8 +180,6 @@ jobs:
         set -euo pipefail
         export PYTHON_VERSION="3.10"
         export CU_VERSION="cu118"
-        # Olddeps tests with older torch/dependencies. Pin tensordict to stable range.
-        export TORCHRL_TENSORDICT_SPEC="tensordict>=0.12.0,<0.13.0"
         export TAR_OPTIONS="--no-same-owner"
         if [[ "${{ github.ref }}" =~ release/* ]]; then
           export RELEASE=1

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -78,7 +78,12 @@ class TestDelta:
         assert (d.log_prob(d.mode) == float("inf")).all()
 
     def test_tanhdelta_inv_ones(self, device):
-        x = torch.randn(1000000, 4, device=device)
+        # Float32 ``tanh`` saturates well before the ``SafeTanhTransform`` clamp
+        # limit (1 - finfo.resolution = 1 - 1e-6), so values where
+        # ``|x| > atanh(1 - 1e-6) ≈ 7.25`` cannot roundtrip through inv∘fwd.
+        # Seed for determinism and bound the inputs to the non-saturated region.
+        torch.manual_seed(0)
+        x = torch.randn(1000000, 4, device=device).clamp(-6.0, 6.0)
         d = TanhDelta(x, -torch.ones_like(x), torch.ones_like(x), atol=1e-4, rtol=1e-4)
         xinv = d.transforms[0].inv(d.mode)
         assert d.base_dist._is_equal(xinv).all()

--- a/torchrl/modules/tensordict_module/_rnn_triton.py
+++ b/torchrl/modules/tensordict_module/_rnn_triton.py
@@ -34,10 +34,11 @@ Limitations of this prototype:
 """
 from __future__ import annotations
 
-import importlib.util
+import importlib.metadata
 
 import torch
 import torch.nn.functional as F
+from packaging import version
 
 
 def _check_triton_available() -> bool:
@@ -45,14 +46,18 @@ def _check_triton_available() -> bool:
 
     The backend's kernels rely on ``triton.language.extra.libdevice.tanh``
     (Triton >= 2.2) and on a backward path that uses ``tl.atomic_add`` with
-    a 2-D mask, which older Triton compilers reject. Probing the lazy
-    ``libdevice`` submodule import at module-load time is a reliable proxy
-    for "Triton is new enough"; older installations fall back transparently
-    to the ``scan`` / ``pad`` backends.
+    a 2-D mask, which older Triton compilers reject. The version is read
+    from package metadata rather than probing
+    ``triton.language.extra.libdevice`` via ``find_spec`` because older
+    Triton builds lack the ``triton.language.extra`` parent and that probe
+    would raise ``ModuleNotFoundError`` at torchrl import time. Older
+    installations fall back transparently to the ``scan`` / ``pad`` backends.
     """
-    if importlib.util.find_spec("triton") is None:
+    try:
+        triton_version = importlib.metadata.version("triton")
+    except importlib.metadata.PackageNotFoundError:
         return False
-    return importlib.util.find_spec("triton.language.extra.libdevice") is not None
+    return version.parse(triton_version) >= version.parse("2.2")
 
 
 _has_triton = _check_triton_available()

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
-import importlib.util
+import importlib.metadata
 import typing
 from typing import Any
 
@@ -41,12 +41,17 @@ def _check_triton_available() -> bool:
     """True if Triton is installed and exposes the API the kernels need.
 
     Mirrors the probe in :mod:`torchrl.modules.tensordict_module._rnn_triton`.
-    Checks for the ``triton.language.extra.libdevice`` submodule (Triton
-    >= 2.2). Older Triton builds fall back to the scan / pad backends.
+    The backend requires ``triton.language.extra.libdevice`` which is only
+    available from Triton 2.2 onwards. Older Triton builds fall back to the
+    scan / pad backends. The version is read from package metadata to avoid
+    eagerly importing Triton (or its missing ``triton.language.extra`` parent)
+    at torchrl import time.
     """
-    if importlib.util.find_spec("triton") is None:
+    try:
+        triton_version = importlib.metadata.version("triton")
+    except importlib.metadata.PackageNotFoundError:
         return False
-    return importlib.util.find_spec("triton.language.extra.libdevice") is not None
+    return version.parse(triton_version) >= version.parse("2.2")
 
 
 _has_triton = _check_triton_available()

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import torch
 import torch.nn.functional as F
+from packaging import version
 from tensordict import TensorDict, TensorDictBase, unravel_key_list
 from tensordict.base import NO_DEFAULT
 from tensordict.nn import dispatch, TensorDictModuleBase as ModuleBase
@@ -25,7 +26,11 @@ from torchrl._utils import (
 )
 from torchrl.data.tensor_specs import Unbounded
 
-_has_torch_scan = importlib.util.find_spec("torch._higher_order_ops.scan") is not None
+# ``torch._higher_order_ops.scan`` was introduced in PyTorch 2.6. Gate the
+# import on the runtime torch version: probing via ``importlib.util.find_spec``
+# would eagerly import the (missing) ``torch._higher_order_ops`` parent on
+# older builds and crash this module at load time.
+_has_torch_scan = version.parse(torch.__version__) >= version.parse("2.6.0")
 if _has_torch_scan:
     from torch._higher_order_ops import scan as _torch_scan
 else:


### PR DESCRIPTION
## Summary

Three currently red CI jobs on every PR / main:

- **unittests-gym** — every gym/gymnasium smoke test errors at import with
  `ModuleNotFoundError: No module named 'torch._higher_order_ops'`. Caused by
  #3738, which added
  `_has_torch_scan = importlib.util.find_spec(\"torch._higher_order_ops.scan\")`
  to `rnn.py`. The job installs torch 2.0.1, and `find_spec` eagerly imports
  the missing parent and raises instead of returning `None`.
- **tests-olddeps** — 3660 identical
  `TypeError: ProbabilisticTensorDictModule.__init__() got an unexpected keyword argument 'generator'`.
  #3704 unconditionally forwards `generator=` from `SafeProbabilisticModule` to
  the tensordict parent class, but the olddeps job was pinned to
  `tensordict>=0.12.0,<0.13.0` (introduced in #3266 to guard against tensordict
  main dropping older Pythons), and that release line does not include the
  `generator` kwarg added in tensordict #1689.
- **tests-optdeps** — long-standing flake in
  `test/test_distributions.py::TestDelta::test_tanhdelta_inv_ones`: 4M unseeded
  float32 `randn` values occasionally exceed
  `atanh(1 - finfo.resolution) ≈ 7.25`, so `SafeTanhTransform` saturates and
  the inv∘fwd roundtrip can't recover the input.

## Changes

- `torchrl/modules/tensordict_module/rnn.py` — gate `_has_torch_scan` on
  `version.parse(torch.__version__) >= version.parse(\"2.6.0\")` (matching the
  existing `@implement_for(\"torch\", \"2.6.0\", ...)` decorator on `_scan`).
- `.github/unittest/linux_olddeps/scripts_gym_0_13/install.sh` — install
  tensordict from source on PR/nightly runs, from PyPI only on `release/*`,
  matching `linux/scripts/run_all.sh` and `linux_distributed/scripts/install.sh`.
  Restores the `pybind11[global]` install needed by the source build.
- `.github/workflows/test-linux.yml` — drop the now-unused
  `TORCHRL_TENSORDICT_SPEC` export.
- `test/test_distributions.py` — seed and clamp inputs in
  `test_tanhdelta_inv_ones` so the test stays inside the SafeTanh roundtrip
  region.

## Trade-off

Going back to source builds for olddeps re-exposes the brittleness #3266 was
guarding against: the day tensordict main drops Python 3.10 the olddeps job
breaks until we bump the Python version or temporarily re-pin. tensordict main
currently still declares `requires-python = \">=3.10\"`, so this resolves today.

## Test plan

- [ ] `unittests-gym` passes (every gym version)
- [ ] `tests-olddeps` passes (no more 3660 `TypeError`)
- [ ] `tests-optdeps` passes (no flake in `test_tanhdelta_inv_ones`)
- [ ] All other jobs green