### PR TITLE
[CI] Auto-insert new version into gh-pages versions.html on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -446,16 +446,33 @@ jobs:
 
           # Update versions.html if it exists
           if [[ -f "versions.html" ]]; then
-            # Update the "(stable release)" marker
-            # Remove old stable marker
+            # Remove the old stable marker from whichever version currently has it
             sed -i 's/ (stable release)//g' versions.html
 
-            # Add new stable marker to the current version
+            # Insert a new <li> entry for this version if it's not already listed.
+            # Anchor the insertion right after the "main (unstable)" <li>...</li>
+            # block so the newest version sits at the top of the dropdown.
+            if ! grep -q "href=\"$VERSION_MAJOR_MINOR/\"" versions.html; then
+              awk -v ver="$VERSION_MAJOR_MINOR" '
+                { print }
+                /href="main\/">main \(unstable\)<\/a>/ { in_main = 1; next }
+                in_main && /<\/li>/ {
+                  print "        <li class=\"toctree-l1\">"
+                  print "          <a class=\"reference internal\" href=\"" ver "/\">v" ver "</a>"
+                  print "        </li>"
+                  in_main = 0
+                }
+              ' versions.html > versions.html.new && mv versions.html.new versions.html
+              echo "Inserted v$VERSION_MAJOR_MINOR entry into versions.html"
+            fi
+
+            # Add the "(stable release)" marker to this version's entry
             sed -i "s|href=\"$VERSION_MAJOR_MINOR/\">v$VERSION_MAJOR_MINOR|href=\"$VERSION_MAJOR_MINOR/\">v$VERSION_MAJOR_MINOR (stable release)|g" versions.html
 
-            # Check if this version is in versions.html
-            if ! grep -q "\"$VERSION_MAJOR_MINOR\"" versions.html; then
-              echo "::notice::Version $VERSION_MAJOR_MINOR not in versions.html, may need manual update"
+            # Sanity check: the entry must exist now
+            if ! grep -q "href=\"$VERSION_MAJOR_MINOR/\"" versions.html; then
+              echo "::error::Failed to insert v$VERSION_MAJOR_MINOR into versions.html"
+              exit 1
             fi
           fi
 


### PR DESCRIPTION
## Summary

- Fixes the release workflow so the gh-pages version picker actually
  picks up new releases. Previously the "Update stable symlink and
  versions.html" step only patched **existing** `<li>` entries — it
  ran `sed` to add `(stable release)` to `v$VERSION`, then logged
  a `::notice::` if no such entry existed and moved on. The notice
  silently passed during the 0.12 release, so [gh-pages](https://github.com/pytorch/rl/tree/gh-pages)
  ended up with `stable -> 0.12` but no v0.12 entry in
  [versions.html](https://pytorch.org/rl/versions.html) (dropdown topped out at v0.11).
- Now: if the version isn't listed, `awk` inserts a new `<li>` right
  after the `main (unstable)` block so newest versions sit at the top
  of the dropdown. The existing `sed` then adds the `(stable release)`
  marker as before.
- Promoted the post-condition check from `::notice::` to `::error::` +
  `exit 1` so a broken insertion fails the workflow instead of going
  unnoticed on the next release.

The missing v0.12 entry on gh-pages has already been fixed manually
in commit `ee580fc32` on the `gh-pages` branch. This PR ensures the
0.13 release (and onward) won't need a manual fix.

## Test plan

- [x] Verified the awk + sed pipeline locally against a sample
  `versions.html`: inserts `v0.12 (stable release)` between `main`
  and `v0.11`, and re-running it for `0.13` correctly demotes `0.12`
  and inserts `0.13` at the top.
- [ ] Will be exercised end-to-end on the next release run.