### PR TITLE
[Feature] NextStateReconstructor RB transform

### DIFF
--- a/docs/source/reference/envs_transforms.rst
+++ b/docs/source/reference/envs_transforms.rst
@@ -277,6 +277,7 @@ Available Transforms
     MeanActionSelector
     ModuleTransform
     MultiAction
+    NextStateReconstructor
     NoopResetEnv
     ObservationNorm
     ObservationTransform

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -115,6 +115,7 @@ from torchrl.envs.transforms.transforms import (
     UnsqueezeTransform,
     VecNorm,
 )
+from torchrl.envs.transforms import NextStateReconstructor
 from torchrl.modules import GRUModule, RandomPolicy, set_recurrent_mode
 
 from torchrl.testing import (
@@ -2650,6 +2651,304 @@ def test_replay_buffer_iter(size, drop_last):
         assert i == size // 3 - 1
     else:
         assert i == (size - 1) // 3
+
+
+class TestNextStateReconstructor:
+    """Tests for :class:`~torchrl.envs.transforms.NextStateReconstructor`."""
+
+    _DEFAULT_TRAJ_KEY = ("collector", "traj_ids")
+
+    @classmethod
+    def _make_data(
+        cls,
+        n_traj=3,
+        traj_len=4,
+        obs_dim=2,
+        traj_key: tuple | str | None = None,
+    ):
+        if traj_key is None:
+            traj_key = cls._DEFAULT_TRAJ_KEY
+        n = n_traj * traj_len
+        obs = torch.arange(n * obs_dim, dtype=torch.float32).reshape(n, obs_dim)
+        done = torch.zeros(n, 1, dtype=torch.bool)
+        done[traj_len - 1 :: traj_len] = True
+        traj_ids = torch.repeat_interleave(torch.arange(n_traj), traj_len)
+        return TensorDict(
+            {
+                "observation": obs,
+                ("next", "done"): done,
+                ("next", "reward"): torch.zeros(n, 1),
+                traj_key: traj_ids,
+            },
+            batch_size=[n],
+        )
+
+    def test_slice_sampler_default(self):
+        """With ``SliceSampler`` + default ``traj_key``, slices mirror cleanly."""
+        data = self._make_data(n_traj=3, traj_len=4)
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(12),
+            sampler=SliceSampler(slice_len=4, traj_key=self._DEFAULT_TRAJ_KEY),
+            transform=NextStateReconstructor(),
+            batch_size=8,
+        )
+        rb.extend(data)
+        sample = rb.sample()
+        assert sample.batch_size == torch.Size([8])
+        next_obs = sample.get(("next", "observation"))
+        root_obs = sample.get("observation")
+        traj = sample.get(self._DEFAULT_TRAJ_KEY)
+        # Within each slice (4 entries), positions 0..2 mirror to 1..3 of the same traj.
+        for slice_start in (0, 4):
+            assert (traj[slice_start : slice_start + 4] == traj[slice_start]).all()
+            for i in range(3):
+                torch.testing.assert_close(
+                    next_obs[slice_start + i], root_obs[slice_start + i + 1]
+                )
+            # Last position of each slice belongs to a different trajectory
+            # in the (i, i+1) pair (or has no i+1 at all) → NaN.
+            assert torch.isnan(next_obs[slice_start + 3]).all()
+
+    def test_single_trajectory_full_batch(self):
+        """Whole trajectory as one batch: every transition reconstructed, last NaN."""
+        n = 6
+        td = TensorDict(
+            {
+                "observation": torch.arange(n, dtype=torch.float32).view(n, 1),
+                self._DEFAULT_TRAJ_KEY: torch.zeros(n, dtype=torch.long),
+                # No terminal in the middle; explicit final done for completeness.
+                ("next", "done"): torch.tensor([[False]] * (n - 1) + [[True]]),
+            },
+            batch_size=[n],
+        )
+        out = NextStateReconstructor()(td)
+        next_obs = out.get(("next", "observation"))
+        torch.testing.assert_close(next_obs[:-1], td.get("observation")[1:])
+        assert torch.isnan(next_obs[-1]).all()
+
+    def test_done_catches_slice_repetition(self):
+        """SliceSampler can place two slices of the same trajectory in one batch.
+
+        Trajectory ids match across the splice; ``done`` at the slice end of the
+        first copy disambiguates. Without the done check, the first slice's
+        last position would silently borrow the *second slice's first frame*
+        (same trajectory, but not its temporal successor) and the user would
+        never know.
+        """
+        n = 8  # two identical trajectories of length 4, glued together
+        obs = torch.tensor([[0.0], [1.0], [2.0], [3.0]] * 2, dtype=torch.float32)
+        td = TensorDict(
+            {
+                "observation": obs,
+                self._DEFAULT_TRAJ_KEY: torch.tensor([0] * 8),  # all same id
+                ("next", "done"): torch.tensor([[False], [False], [False], [True]] * 2),
+            },
+            batch_size=[n],
+        )
+        out = NextStateReconstructor()(td)
+        next_obs = out.get(("next", "observation"))
+        # Position 3: traj id matches position 4, but done[3]=True → NaN
+        assert torch.isnan(next_obs[3]).all()
+        # Positions 0..2 mirror to 1..3
+        torch.testing.assert_close(next_obs[:3], obs[1:4])
+        # Positions 4..6 mirror to 5..7
+        torch.testing.assert_close(next_obs[4:7], obs[5:8])
+        # Position 7: no i+1 → NaN
+        assert torch.isnan(next_obs[7]).all()
+
+    def test_random_sampler_is_mostly_nan(self):
+        """Random sampling yields mismatched traj ids between neighbors → NaN.
+
+        Documents the honest failure mode: when the user picks a sampler that
+        doesn't preserve trajectory adjacency, the transform refuses to invent
+        a next observation.
+        """
+        data = self._make_data(n_traj=8, traj_len=4)  # 32 entries
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(32),
+            sampler=RandomSampler(),
+            transform=NextStateReconstructor(),
+            batch_size=16,
+        )
+        rb.extend(data)
+        torch.manual_seed(0)
+        sample = rb.sample()
+        next_obs = sample.get(("next", "observation"))
+        # With 8 trajectories random-sampled into a 16-batch, the chance that
+        # two adjacent picks share a trajectory id (≈ 1/8) is low. Assert that
+        # the *vast majority* of positions are NaN — both that the check is
+        # firing and that we aren't accidentally fabricating next obs.
+        nan_frac = torch.isnan(next_obs).all(dim=-1).float().mean().item()
+        assert nan_frac > 0.7, f"expected mostly-NaN, got nan_frac={nan_frac:.2f}"
+
+    def test_nested_keys(self):
+        n = 8
+        td = TensorDict(
+            {
+                "agents": TensorDict(
+                    {
+                        "pos": torch.arange(n * 3, dtype=torch.float32).reshape(n, 3),
+                        "vel": torch.arange(n * 2, dtype=torch.float32).reshape(n, 2),
+                    },
+                    [n],
+                ),
+                ("next", "done"): torch.tensor([[False], [False], [False], [True]] * 2),
+                ("next", "reward"): torch.zeros(n, 1),
+                self._DEFAULT_TRAJ_KEY: torch.tensor([0] * 4 + [1] * 4),
+            },
+            batch_size=[n],
+        )
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(n),
+            sampler=SliceSampler(slice_len=4, traj_key=self._DEFAULT_TRAJ_KEY),
+            transform=NextStateReconstructor(
+                keys=[("agents", "pos"), ("agents", "vel")],
+            ),
+            batch_size=4,
+        )
+        rb.extend(td)
+        sample = rb.sample()
+        for k in (("agents", "pos"), ("agents", "vel")):
+            next_k = ("next", *k)
+            torch.testing.assert_close(sample.get(next_k)[:3], sample.get(k)[1:4])
+            assert torch.isnan(sample.get(next_k)[3]).all()
+
+    def test_explicit_fill_value(self):
+        data = self._make_data(n_traj=2, traj_len=4)
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(8),
+            sampler=SliceSampler(slice_len=4, traj_key=self._DEFAULT_TRAJ_KEY),
+            transform=NextStateReconstructor(fill_value=-1.0),
+            batch_size=8,
+        )
+        rb.extend(data)
+        sample = rb.sample()
+        next_obs = sample.get(("next", "observation"))
+        # The last position of each slice belongs to a different trajectory
+        # in (i, i+1), so it gets the fill value.
+        for slice_start in (0, 4):
+            assert (next_obs[slice_start + 3] == -1.0).all()
+
+    def test_overwrites_existing_next_obs(self):
+        """If ``("next", k)`` is already in storage, the transform overwrites it."""
+        n = 8
+        td = TensorDict(
+            {
+                "observation": torch.arange(n, dtype=torch.float32).view(n, 1),
+                ("next", "observation"): torch.full(
+                    (n, 1), -999.0, dtype=torch.float32
+                ),
+                ("next", "done"): torch.tensor([[False], [False], [False], [True]] * 2),
+                ("next", "reward"): torch.zeros(n, 1),
+                self._DEFAULT_TRAJ_KEY: torch.tensor([0] * 4 + [1] * 4),
+            },
+            batch_size=[n],
+        )
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(n),
+            sampler=SliceSampler(slice_len=4, traj_key=self._DEFAULT_TRAJ_KEY),
+            transform=NextStateReconstructor(),
+            batch_size=8,
+        )
+        rb.extend(td)
+        sample = rb.sample()
+        assert not (sample.get(("next", "observation")) == -999.0).any()
+
+    def test_step_count_cross_check(self):
+        """``step_count_key`` adds a stricter "consecutive in time" check."""
+        n = 4
+        td = TensorDict(
+            {
+                "observation": torch.arange(n, dtype=torch.float32).view(n, 1),
+                self._DEFAULT_TRAJ_KEY: torch.zeros(n, dtype=torch.long),
+                ("next", "done"): torch.zeros(n, 1, dtype=torch.bool),
+                # Same traj id and no done, but step counts disagree at i=1
+                # (jumps from 0 to 5, then 5 -> 6 -> 7).
+                ("collector", "step_count"): torch.tensor([0, 5, 6, 7]),
+            },
+            batch_size=[n],
+        )
+        t = NextStateReconstructor(step_count_key=("collector", "step_count"))
+        out = t(td)
+        next_obs = out.get(("next", "observation"))
+        # Position 0 → step_count[1] - step_count[0] = 5 ≠ 1, so NaN.
+        assert torch.isnan(next_obs[0]).all()
+        # Positions 1 and 2 are consecutive (5→6, 6→7) → reconstructed.
+        torch.testing.assert_close(next_obs[1], td.get("observation")[2])
+        torch.testing.assert_close(next_obs[2], td.get("observation")[3])
+        # Position 3 has no i+1 → NaN.
+        assert torch.isnan(next_obs[3]).all()
+
+    def test_strict_missing_traj_key_raises(self):
+        td = TensorDict(
+            {"observation": torch.arange(4, dtype=torch.float32).view(4, 1)},
+            batch_size=[4],
+        )
+        with pytest.raises(KeyError, match="trajectory key"):
+            NextStateReconstructor()(td)
+
+    def test_strict_missing_done_key_raises(self):
+        td = TensorDict(
+            {
+                "observation": torch.arange(4, dtype=torch.float32).view(4, 1),
+                self._DEFAULT_TRAJ_KEY: torch.zeros(4, dtype=torch.long),
+            },
+            batch_size=[4],
+        )
+        with pytest.raises(KeyError, match="done key"):
+            NextStateReconstructor()(td)
+
+    def test_strict_false_single_traj_fallback(self):
+        td = TensorDict(
+            {"observation": torch.arange(4, dtype=torch.float32).view(4, 1)},
+            batch_size=[4],
+        )
+        out = NextStateReconstructor(strict=False)(td)
+        next_obs = out.get(("next", "observation"))
+        torch.testing.assert_close(next_obs[:-1], td.get("observation")[1:])
+        assert torch.isnan(next_obs[-1]).all()
+
+    def test_traj_key_none_disables_check(self):
+        td = TensorDict(
+            {
+                "observation": torch.arange(4, dtype=torch.float32).view(4, 1),
+                # Different traj ids, but check is disabled → all-shift, no NaN
+                # except the last position.
+                self._DEFAULT_TRAJ_KEY: torch.tensor([0, 1, 2, 3]),
+            },
+            batch_size=[4],
+        )
+        out = NextStateReconstructor(traj_key=None, done_key=None)(td)
+        next_obs = out.get(("next", "observation"))
+        torch.testing.assert_close(next_obs[:-1], td.get("observation")[1:])
+        assert torch.isnan(next_obs[-1]).all()
+
+    def test_int_obs_requires_explicit_fill_value(self):
+        td = TensorDict(
+            {
+                "observation": torch.arange(4, dtype=torch.int64).view(4, 1),
+                self._DEFAULT_TRAJ_KEY: torch.zeros(4, dtype=torch.long),
+                ("next", "done"): torch.zeros(4, 1, dtype=torch.bool),
+            },
+            batch_size=[4],
+        )
+        with pytest.raises(TypeError, match="non-floating dtype"):
+            NextStateReconstructor()(td)
+        # Explicit integer fill works
+        out = NextStateReconstructor(fill_value=-1)(td)
+        next_obs = out.get(("next", "observation"))
+        assert next_obs[-1].item() == -1
+
+    def test_bad_batch_dims_errors(self):
+        td = TensorDict(
+            {
+                "observation": torch.arange(8, dtype=torch.float32).view(2, 4, 1),
+                self._DEFAULT_TRAJ_KEY: torch.zeros(2, 4, dtype=torch.long),
+            },
+            batch_size=[2, 4],
+        )
+        with pytest.raises(ValueError, match="flat"):
+            NextStateReconstructor()(td)
 
 
 class TestMaxValueWriter:

--- a/torchrl/envs/transforms/__init__.py
+++ b/torchrl/envs/transforms/__init__.py
@@ -8,7 +8,7 @@ from .mean_action_selector import MeanActionSelector
 from .module import ModuleTransform
 from .r3m import R3MTransform
 from .ray_service import RayTransform
-from .rb_transforms import MultiStepTransform
+from .rb_transforms import MultiStepTransform, NextStateReconstructor
 from .transforms import (
     ActionDiscretizer,
     ActionMask,
@@ -112,6 +112,7 @@ __all__ = [
     "ModuleTransform",
     "MultiAction",
     "MultiStepTransform",
+    "NextStateReconstructor",
     "NoopResetEnv",
     "ObservationNorm",
     "ObservationTransform",

--- a/torchrl/envs/transforms/rb_transforms.py
+++ b/torchrl/envs/transforms/rb_transforms.py
@@ -4,10 +4,20 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import math
+from collections.abc import Sequence
+
 import torch
 from tensordict import NestedKey, TensorDictBase
 from torchrl.data.postprocs.postprocs import _multi_step_func
 from torchrl.envs.transforms.transforms import Transform
+
+
+def _under_next(key: NestedKey) -> tuple:
+    """Return the ``("next", *key)`` variant of a nested key."""
+    if isinstance(key, tuple):
+        return ("next", *key)
+    return ("next", key)
 
 
 class MultiStepTransform(Transform):
@@ -212,3 +222,221 @@ class MultiStepTransform(Transform):
             total_cat = torch.cat([self._buffer, data], -1)
             self._buffer = total_cat[..., -self.n_steps :].copy()
         return total_cat
+
+
+class NextStateReconstructor(Transform):
+    """Re-hydrate ``("next", obs)`` keys at sampling time by shifting along the batch.
+
+    Pairs with :class:`~torchrl.collectors.SyncDataCollector` configured with
+    ``compact_obs=True`` (and the analogous flag on the multi-process collectors):
+    the collector drops the observation and state keys from the
+    ``("next", ...)`` sub-tensordict before stacking because those values are
+    bit-for-bit identical to the root keys at ``t + 1`` within the same
+    trajectory; this transform rebuilds them on the consumer side.
+
+    **Core rule.** For each registered root key ``k`` and each position ``i``
+    of the flat sampled batch:
+
+    - if position ``i + 1`` is in the batch *and* belongs to the same
+      trajectory as position ``i``, write
+      ``data[("next", k)][i] = data[k][i + 1]``;
+    - otherwise write ``data[("next", k)][i] = fill_value`` (``NaN`` by
+      default).
+
+    "Same trajectory" is decided from a trajectory id key in the sample,
+    by default ``("collector", "traj_ids")`` — the key that
+    :class:`~torchrl.collectors.SyncDataCollector` populates when
+    ``track_traj_ids=True`` (the default). The semantics fall out cleanly for
+    every common sampler:
+
+    - :class:`~torchrl.data.replay_buffers.samplers.SliceSampler` with
+      ``traj_key``: positions inside a slice mirror to the next position;
+      slice boundaries differ in trajectory id and become ``NaN``.
+    - A full rollout sampled as one contiguous batch: every transition inside
+      a trajectory is reconstructed; trajectory ends become ``NaN``.
+    - :class:`~torchrl.data.replay_buffers.samplers.RandomSampler` and similar:
+      adjacent batch positions almost never share a trajectory id, so the
+      result is mostly ``NaN``. This is correct — the next observation is
+      genuinely not available in the sampled batch — and it makes the
+      mis-use loud rather than silent.
+
+    The trajectory-id check alone is *not* enough: a sampler is allowed to
+    place two slices of the *same* trajectory back-to-back in one batch
+    (e.g. :class:`~torchrl.data.replay_buffers.samplers.SliceSampler` sampling
+    with replacement when there are fewer trajectories than slices). In that
+    case the two positions across the splice would share a trajectory id
+    without being consecutive in time. The transform therefore also consults
+    ``("next", "done")`` (if present): when ``done[i]`` is ``True`` the
+    trajectory ended at step ``i``, so position ``i + 1`` is never the next
+    step of trajectory ``traj_id[i]`` no matter what.
+
+    An additional, stricter ``step_count_key`` cross-check is available for
+    setups where neither ``traj_id`` nor ``done`` are bulletproof — see below.
+
+    Args:
+        keys (sequence of NestedKey, optional): the root keys whose
+            ``("next", k)`` counterparts should be reconstructed. Defaults to
+            ``("observation",)``. For environments with nested observation
+            specs, pass the full leaf list, e.g.
+            ``[("agents", "pos"), ("agents", "vel")]``.
+
+    Keyword Args:
+        traj_key (NestedKey, optional): key carrying the trajectory id used
+            to detect boundaries. Defaults to ``("collector", "traj_ids")``.
+            Set to ``None`` to skip the trajectory check and treat the entire
+            sampled batch as one trajectory (only the very last position is
+            then filled with ``fill_value``).
+        done_key (NestedKey, optional): key whose ``True`` entries indicate
+            that the trajectory terminated at position ``i``, so position
+            ``i + 1`` is not the next step. Defaults to ``("next", "done")``.
+            Set to ``None`` to disable the check.
+        step_count_key (NestedKey, optional): if not ``None``, also require
+            ``data[step_count_key][i + 1] == data[step_count_key][i] + 1`` to
+            consider position ``i + 1`` as the canonical next step. The
+            collector populates ``("collector", "step_count")`` only when a
+            :class:`~torchrl.envs.transforms.StepCounter` is in the env
+            transform chain. Defaults to ``None``.
+        fill_value (float, optional): value written wherever the next
+            observation is not available. Defaults to ``float("nan")``. For
+            integer-typed observation keys, NaN cannot be represented; pass
+            an explicit integer (e.g. ``0``).
+        strict (bool, optional): if ``True`` (default) and any configured
+            marker key (``traj_key``, ``done_key``, ``step_count_key``) is
+            missing from the sampled batch, raise. If ``False``, silently
+            drop that check.
+
+    Example:
+        >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from torchrl.data import ReplayBuffer, LazyTensorStorage
+        >>> from torchrl.data.replay_buffers.samplers import SliceSampler
+        >>> from torchrl.envs.transforms.rb_transforms import (
+        ...     NextStateReconstructor,
+        ... )
+        >>> rb = ReplayBuffer(
+        ...     storage=LazyTensorStorage(100),
+        ...     sampler=SliceSampler(
+        ...         slice_len=4, traj_key=("collector", "traj_ids"),
+        ...     ),
+        ...     transform=NextStateReconstructor(),
+        ...     batch_size=8,
+        ... )
+        >>> # populate `rb` with a collector configured with `compact_obs=True`
+        >>> # so that ``("next", "observation")`` is absent from storage:
+        >>> data = TensorDict({
+        ...     "observation": torch.arange(8, dtype=torch.float32).view(8, 1),
+        ...     ("next", "reward"): torch.zeros(8, 1),
+        ...     ("next", "done"): torch.tensor([[False]] * 7 + [[True]]),
+        ...     ("collector", "traj_ids"): torch.tensor([0, 0, 0, 0, 1, 1, 1, 1]),
+        ... }, batch_size=[8])
+        >>> rb.extend(data)
+        >>> sample = rb.sample()  # ('next', 'observation') is reconstructed
+    """
+
+    def __init__(
+        self,
+        keys: Sequence[NestedKey] = ("observation",),
+        *,
+        traj_key: NestedKey | None = ("collector", "traj_ids"),
+        done_key: NestedKey | None = ("next", "done"),
+        step_count_key: NestedKey | None = None,
+        fill_value: float = float("nan"),
+        strict: bool = True,
+    ):
+        super().__init__()
+        self.keys = tuple(keys)
+        self.traj_key = traj_key
+        self.done_key = done_key
+        self.step_count_key = step_count_key
+        self.fill_value = fill_value
+        self.strict = strict
+
+    @staticmethod
+    def _flatten_marker(t: torch.Tensor, B: int) -> torch.Tensor:
+        """Reduce a marker tensor of shape ``(B, ...)`` to ``(B,)`` along trailing dims."""
+        if t.shape[0] != B:
+            raise ValueError(
+                f"NextStateReconstructor: marker tensor has leading dim {t.shape[0]} "
+                f"but sample batch size is {B}."
+            )
+        if t.ndim == 1:
+            return t
+        return t.reshape(B, -1)[:, 0]
+
+    def _fetch_marker(
+        self,
+        tensordict: TensorDictBase,
+        key: NestedKey,
+        what: str,
+        B: int,
+    ) -> torch.Tensor | None:
+        if key in tensordict.keys(True, True):
+            return self._flatten_marker(tensordict.get(key), B)
+        if self.strict:
+            raise KeyError(
+                f"NextStateReconstructor: {what} {key!r} is not present in the "
+                "sampled batch. Pass the corresponding constructor kwarg "
+                "explicitly (or `None` to disable), or `strict=False` to drop "
+                "the check silently."
+            )
+        return None
+
+    def _valid_mask(self, tensordict: TensorDictBase, B: int) -> torch.Tensor:
+        """Return a ``(B,)`` bool tensor where ``True`` means ``i + 1`` is a usable next step."""
+        valid = torch.zeros(B, dtype=torch.bool, device=tensordict.device)
+        if B >= 2:
+            valid[:-1] = True
+        if self.traj_key is not None:
+            traj = self._fetch_marker(tensordict, self.traj_key, "trajectory key", B)
+            if traj is not None:
+                valid[:-1] &= traj[1:] == traj[:-1]
+        if self.done_key is not None:
+            done = self._fetch_marker(tensordict, self.done_key, "done key", B)
+            if done is not None:
+                valid[:-1] &= ~done[:-1].to(torch.bool)
+        if self.step_count_key is not None:
+            sc = self._fetch_marker(
+                tensordict, self.step_count_key, "step-count key", B
+            )
+            if sc is not None:
+                valid[:-1] &= sc[1:] == sc[:-1] + 1
+        return valid
+
+    def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
+        if tensordict.batch_dims != 1:
+            raise ValueError(
+                "NextStateReconstructor expects a flat ``(B,)`` sample. Got "
+                f"batch_size={tuple(tensordict.batch_size)}. Reshape or use a "
+                "1-d storage / sampler combination."
+            )
+        B = tensordict.batch_size[0]
+        if B < 1:
+            return tensordict
+        valid = self._valid_mask(tensordict, B)
+        invalid = ~valid
+        for k in self.keys:
+            next_k = _under_next(k)
+            root = tensordict.get(k)
+            if (
+                not root.is_floating_point()
+                and isinstance(self.fill_value, float)
+                and math.isnan(self.fill_value)
+            ):
+                raise TypeError(
+                    f"NextStateReconstructor: root key {k!r} has non-floating "
+                    f"dtype {root.dtype}; pass an explicit integer `fill_value` "
+                    "for this key (NaN cannot be represented)."
+                )
+            next_view = torch.empty_like(root)
+            if B >= 2:
+                next_view[:-1] = root[1:]
+            # Whatever sat at [-1] is overwritten below via the mask
+            # (it is always invalid: no i+1 in the batch).
+            invalid_expanded = invalid.reshape(B, *([1] * (root.ndim - 1))).expand_as(
+                root
+            )
+            next_view = torch.where(
+                invalid_expanded, root.new_full((), self.fill_value), next_view
+            )
+            tensordict.set(next_k, next_view)
+        return tensordict


### PR DESCRIPTION
## Summary

New sampling-time replay-buffer transform that re-hydrates
``("next", obs)`` keys by shifting along the batch dim, gated by
**trajectory id** and ``("next", "done")``. Pairs with
``SyncDataCollector(compact_obs=True)`` (#3742): the collector drops
the observation/state keys under ``("next", ...)`` before stacking,
halving observation VRAM; this transform rebuilds them on the
consumer side.

## Rule

For each position ``i`` of a flat sampled batch and each registered
key ``k``:

- if ``i + 1`` is in the batch **and** ``traj_id[i+1] == traj_id[i]``
  **and** ``not done[i]``, write
  ``data[("next", k)][i] = data[k][i + 1]``;
- otherwise write ``fill_value`` (``NaN`` by default).

This drops the artificial slice-length constraint of the earlier
design and falls out correctly for every common sampler:

- **SliceSampler**: slices mirror cleanly; slice boundaries differ in
  ``traj_id`` (or coincide with ``done``) → NaN.
- **SliceSampler picking the same trajectory twice in one batch**:
  ``traj_id`` matches across the splice, but ``done`` at the slice
  end of the first copy catches it. The previous slice-len based
  design silently borrowed the second slice's first frame here.
- **Full rollout sampled as one batch**: every in-trajectory
  transition rebuilt; trajectory ends → NaN.
- **RandomSampler / arbitrary indices**: ``traj_id`` almost never
  matches between adjacent picks → mostly NaN. Honest about
  non-reconstructability rather than silently fabricating data.

## API

```python
NextStateReconstructor(
    keys=("observation",),
    *,
    traj_key=("collector", "traj_ids"),
    done_key=("next", "done"),
    step_count_key=None,             # optional stricter check
    fill_value=float("nan"),
    strict=True,
)
```

Defaults match ``SyncDataCollector`` output: ``track_traj_ids=True``
writes ``("collector", "traj_ids")`` by default, and ``("next", "done")``
is preserved by ``compact_obs=True`` (it can't be reconstructed).
``strict=True`` raises if a configured marker key is missing —
explicit opt-out via ``traj_key=None``, ``done_key=None`` etc., or
``strict=False`` to silently drop missing checks.

``step_count_key`` is a stricter optional cross-check requiring
consecutive ``step_count`` between ``i`` and ``i + 1``; useful when
neither ``traj_id`` nor ``done`` alone is bulletproof.

## Test plan

- [x] ``test/test_rb.py::TestNextStateReconstructor`` (14 tests):
  SliceSampler default, full-trajectory batch, slice repetition
  guarded by ``done``, ``RandomSampler`` mostly-NaN, nested keys,
  explicit ``fill_value``, overwriting existing ``("next", obs)``,
  ``step_count`` cross-check, strict mode for missing ``traj_key`` /
  ``done_key``, ``traj_key=None`` opt-out, int-obs requires explicit
  ``fill_value``, multi-dim batch rejected.
- [x] Existing ``test/test_rb.py::TestTransforms`` continues to pass
  (22 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)