### PR TITLE
[BugFix] Sanitize NaN ('next', obs) in value-estimator forward

### DIFF
--- a/test/objectives/test_values.py
+++ b/test/objectives/test_values.py
@@ -104,6 +104,73 @@ class TestValues:
         torch.testing.assert_close(actual["advantage"], expected["advantage"])
         torch.testing.assert_close(actual["value_target"], expected["value_target"])
 
+    @pytest.mark.parametrize(
+        "estimator_cls,kwargs",
+        [
+            (TD0Estimator, {"gamma": 0.9}),
+            (TD1Estimator, {"gamma": 0.9}),
+            (TDLambdaEstimator, {"gamma": 0.9, "lmbda": 0.95}),
+            (GAE, {"gamma": 0.9, "lmbda": 0.95}),
+        ],
+    )
+    @pytest.mark.parametrize("shifted", [False, True])
+    def test_nan_next_obs_at_done_is_safe(self, estimator_cls, kwargs, shifted):
+        """``("next", obs)`` may be ``NaN`` at trajectory ends.
+
+        That happens by design when the buffer is fed by
+        :class:`~torchrl.collectors.SyncDataCollector` configured with
+        ``compact_obs=True`` and rehydrated via
+        :class:`~torchrl.envs.transforms.NextStateReconstructor`. Without the
+        sanitizer in
+        :meth:`~torchrl.objectives.value.advantages.ValueEstimatorBase._call_value_nets`,
+        ``V(NaN) = NaN`` propagates through the TD / GAE kernels because
+        ``0 * NaN = NaN`` in IEEE 754 (the canonical ``(1 - done) * V_next``
+        masking does not save us). Assert that the advantage and value target
+        are finite everywhere, and that the terminated step gets the
+        no-bootstrap target ``reward - V(s)``.
+        """
+        torch.manual_seed(0)
+        value_net = TensorDictModule(
+            nn.Linear(3, 1, bias=False),
+            in_keys=["obs"],
+            out_keys=["state_value"],
+        )
+        B, T, F = 2, 5, 3
+        obs = torch.randn(B, T, F)
+        next_obs = torch.empty(B, T, F)
+        next_obs[:, :-1] = obs[:, 1:]
+        next_obs[:, -1] = float("nan")  # mimic NextStateReconstructor at traj end
+        done = torch.zeros(B, T, 1, dtype=torch.bool)
+        done[:, -1] = True
+        reward = torch.ones(B, T, 1)
+        td = TensorDict(
+            {
+                "obs": obs,
+                "next": {
+                    "obs": next_obs,
+                    "reward": reward,
+                    "done": done.clone(),
+                    "terminated": done.clone(),
+                },
+            },
+            [B, T],
+        )
+
+        est = estimator_cls(**kwargs, value_network=value_net, shifted=shifted)
+        out = est(td.clone())
+        adv = out["advantage"]
+        vt = out["value_target"]
+        assert torch.isfinite(adv).all(), f"advantage contains non-finite: {adv}"
+        assert torch.isfinite(vt).all(), f"value_target contains non-finite: {vt}"
+
+        # At the terminated step the bootstrap is masked out: value_target
+        # equals reward (advantage = reward - V(s)). Use the (uncorrupted)
+        # raw value net to compute the expected V(s) at the last step.
+        with torch.no_grad():
+            v_s = value_net(td[..., -1].clone()).get("state_value")
+        torch.testing.assert_close(vt[..., -1, :], reward[..., -1, :])
+        torch.testing.assert_close(adv[..., -1, :], reward[..., -1, :] - v_s)
+
     @pytest.mark.skipif(not _has_gym, reason="requires gym")
     def test_gae_multi_done(self):
 

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -429,6 +429,50 @@ class ValueEstimatorBase(TensorDictModuleBase):
                     return i
         return data.ndim - 1
 
+    @staticmethod
+    def _sanitize_next_obs_nan(
+        data: TensorDictBase, in_keys: list[NestedKey]
+    ) -> TensorDictBase:
+        """Replace ``NaN`` entries in ``("next", k)`` with the corresponding root ``k``.
+
+        Acts as a finite placeholder for "next observations" that are absent —
+        as produced by
+        :class:`~torchrl.envs.transforms.NextStateReconstructor` at trajectory
+        ends in conjunction with
+        :class:`~torchrl.collectors.SyncDataCollector` configured with
+        ``compact_obs=True``. Without this step, ``V(NaN) = NaN`` propagates
+        through the TD / GAE kernels (the multiplication by ``(1 - done)``
+        does not zero NaN out because ``0 * NaN = NaN`` in IEEE 754).
+
+        Semantics of the substitution:
+
+        - At **terminated** steps the value at the next observation is masked
+          out by ``(1 - done)`` downstream, so the substitute is discarded.
+        - At **truncated-only** steps the substitute acts as an approximate
+          bootstrap ``V(obs[t]) ≈ V(real_next_obs)`` — strictly an
+          approximation, but finite and well-defined.
+
+        Operates on a shallow copy so the caller's ``tensordict`` is not
+        mutated.
+        """
+        copied = False
+        for k in in_keys:
+            root = data.get(k, default=None)
+            if root is None or not root.is_floating_point():
+                continue
+            next_k = ("next", *k) if isinstance(k, tuple) else ("next", k)
+            nxt = data.get(next_k, default=None)
+            if nxt is None or nxt.shape != root.shape:
+                continue
+            nan_mask = torch.isnan(nxt)
+            if not nan_mask.any():
+                continue
+            if not copied:
+                data = data.copy()
+                copied = True
+            data.set(next_k, torch.where(nan_mask, root, nxt))
+        return data
+
     def _call_value_nets(
         self,
         data: TensorDictBase,
@@ -444,6 +488,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
         if value_net is None:
             value_net = self.value_network
         in_keys = value_net.in_keys
+        data = self._sanitize_next_obs_nan(data, in_keys)
 
         def _call_value_net(data_in: TensorDictBase) -> torch.Tensor:
             chunk_size = self.value_chunk_size


### PR DESCRIPTION
## Summary

The TD / GAE kernels in ``objectives/value/functional.py`` mask out the
next-state value at terminated steps via
``(~terminated).int() * V_next``. In IEEE 754 ``0 * NaN = NaN``, so when
``("next", obs)`` carries ``NaN`` at a trajectory end the
multiplication does **not** zero it out and the resulting ``advantage``
/ ``value_target`` propagate as ``NaN``. This currently makes TD(0),
TD(1), TD(λ), GAE and friends unusable with the (forthcoming)
``compact_obs=True`` + ``NextStateReconstructor`` flow (#3742 / #3743)
which by design produces ``NaN`` at trajectory ends. Both
``shifted=False`` and ``shifted=True`` are affected.

## Fix

Add ``ValueEstimatorBase._sanitize_next_obs_nan`` and call it at the
top of ``_call_value_nets``. For each value-net ``in_key`` it replaces
``NaN`` entries in ``("next", k)`` with the corresponding root ``k``
value. A shallow copy is made the first time a substitution is needed
so the caller's tensordict is never mutated.

Semantics of the substitution:

- **terminated** steps: the substitute is masked out by the existing
  ``(1 - done)`` factor downstream → bootstrap correctly evaluates to
  zero, ``advantage = reward - V(s)``.
- **truncated-only** steps: the substitute acts as an approximate
  bootstrap ``V(obs[t]) ≈ V(real_next_obs)``. Strictly an
  approximation — the canonical next-obs is genuinely unrecoverable in
  ``compact_obs`` mode without storage access — but finite and
  well-defined.

The fix sits at the value-net input layer so it covers both code paths
(``shifted=False`` two-pass vmap and ``shifted=True`` interleaved
single-pass).

## Test plan

- [x] New ``TestValues::test_nan_next_obs_at_done_is_safe``,
  parametrized over ``{TD0, TD1, TD-λ, GAE} × {shifted=False, True}``
  (8 cases). Each feeds ``("next", obs)[..., -1] = NaN`` at the
  terminated step and asserts: ``advantage`` / ``value_target`` are
  finite everywhere, the terminated step receives the no-bootstrap
  target ``reward - V(s)``.
- [x] ``test/objectives/test_values.py`` (full file, 1874 tests +
  80 deselected ``TestAdv`` cases) passes. The deselected ``TestAdv``
  ``VTrace`` cases fail on ``main`` too — pre-existing
  ``ProbabilisticTensorDictModule.__init__() got an unexpected keyword
  argument 'generator'`` from a tensordict version mismatch, unrelated.

## Notes

This is effectively a prerequisite for #3742 / #3743 to be useful with
value-based losses. Without it, every GAE / TD step in compact mode
yields ``NaN`` losses at trajectory ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)