### PR TITLE
[Feature] MAPPOLoss + IPPOLoss + MultiAgentGAE + ValueNorm

### DIFF
--- a/docs/source/reference/objectives.rst
+++ b/docs/source/reference/objectives.rst
@@ -50,4 +50,5 @@ Documentation Sections
    objectives_policy
    objectives_actorcritic
    objectives_offline
+   objectives_multiagent
    objectives_other

--- a/docs/source/reference/objectives_common.rst
+++ b/docs/source/reference/objectives_common.rst
@@ -28,6 +28,7 @@ Value Estimators
     TD1Estimator
     TDLambdaEstimator
     GAE
+    MultiAgentGAE
 
 .. currentmodule:: torchrl.objectives
 

--- a/docs/source/reference/objectives_multiagent.rst
+++ b/docs/source/reference/objectives_multiagent.rst
@@ -1,0 +1,58 @@
+.. currentmodule:: torchrl.objectives.multiagent
+
+Multi-Agent Objectives
+======================
+
+Loss modules for multi-agent reinforcement learning algorithms. These losses
+follow the torchrl multi-agent tensordict convention (per-agent tensors
+nested under group keys such as ``("agents", "observation")``; see
+:class:`~torchrl.envs.libs.vmas.VmasEnv` and
+:class:`~torchrl.envs.libs.pettingzoo.PettingZooEnv`).
+
+MAPPO and IPPO
+--------------
+
+:class:`MAPPOLoss` implements Multi-Agent PPO (Yu et al. 2022) — a
+decentralised actor paired with a *centralised critic* that conditions on the
+joint observation / state. :class:`IPPOLoss` is the independent-learner
+counterpart from de Witt et al. 2020: each agent has its own local critic and
+there is no centralised information at training time.
+
+Both are thin specialisations of :class:`~torchrl.objectives.ClipPPOLoss`
+that:
+
+- default the value estimator to
+  :class:`~torchrl.objectives.value.MultiAgentGAE`, which broadcasts
+  team-shared rewards / done flags across the agent dimension before
+  computing returns;
+- default ``normalize_advantage_exclude_dims`` to ``(-2,)`` so the agent dim
+  is excluded from advantage standardisation;
+- optionally accept a :class:`~torchrl.modules.ValueNorm` subclass — either
+  :class:`~torchrl.modules.PopArtValueNorm` (EMA, recommended for drifting
+  reward scales) or :class:`~torchrl.modules.RunningValueNorm` (exact
+  Welford running stats, recommended for stationary scales) — to stabilise
+  the critic loss. The MAPPO paper credits this trick for its strong SMAC
+  results.
+
+See ``sota-implementations/multiagent/mappo_ippo.py`` for a hydra-configured
+recipe and ``examples/multiagent/mappo_vmas.py`` for a minimal one.
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template_noinherit.rst
+
+    MAPPOLoss
+    IPPOLoss
+
+QMixer
+------
+
+:class:`QMixerLoss` mixes local per-agent Q values into a global team Q
+value via a learnable mixing network, and trains them jointly with a DQN
+update on the global value (Rashid et al. 2018).
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template_noinherit.rst
+
+    QMixerLoss

--- a/examples/multiagent/mappo_vmas.py
+++ b/examples/multiagent/mappo_vmas.py
@@ -1,0 +1,228 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Minimal MAPPO / IPPO recipe on VMAS using the new
+:class:`~torchrl.objectives.multiagent.MAPPOLoss` /
+:class:`~torchrl.objectives.multiagent.IPPOLoss` classes.
+
+For the full, hydra-configured, wandb-logged version see
+``sota-implementations/multiagent/mappo_ippo.py``. This file is intentionally
+short: it's there to show that the new loss classes collapse the boilerplate
+that previously required ``ClipPPOLoss`` + manual ``make_value_estimator(GAE,
+...)`` into a single construction call. We still need ``set_keys(done=...,
+terminated=...)`` because VMAS writes its done/terminated flags under the
+per-agent group key.
+
+Usage::
+
+    python examples/multiagent/mappo_vmas.py --algo mappo --frames 200_000
+    python examples/multiagent/mappo_vmas.py --algo ippo --frames 200_000
+
+The two should reach similar reward on the easy navigation scenario; MAPPO
+typically pulls ahead on harder coordination tasks (Yu et al. 2022).
+"""
+from __future__ import annotations
+
+import argparse
+import time
+
+import torch
+from tensordict.nn import TensorDictModule
+from tensordict.nn.distributions import NormalParamExtractor
+from torch import nn
+
+from torchrl.collectors import SyncDataCollector
+from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
+from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
+from torchrl.envs import RewardSum, TransformedEnv
+from torchrl.modules import (
+    MultiAgentMLP,
+    PopArtValueNorm,
+    ProbabilisticActor,
+    TanhNormal,
+)
+from torchrl.objectives import IPPOLoss, MAPPOLoss
+
+
+def make_actor(env, *, share_params: bool = True) -> ProbabilisticActor:
+    obs_dim = env.observation_spec["agents", "observation"].shape[-1]
+    action_dim = env.action_spec.shape[-1]
+    backbone = nn.Sequential(
+        MultiAgentMLP(
+            n_agent_inputs=obs_dim,
+            n_agent_outputs=2 * action_dim,
+            n_agents=env.n_agents,
+            centralized=False,
+            share_params=share_params,
+            depth=2,
+            num_cells=256,
+            activation_class=nn.Tanh,
+        ),
+        NormalParamExtractor(),
+    )
+    module = TensorDictModule(
+        backbone,
+        in_keys=[("agents", "observation")],
+        out_keys=[("agents", "loc"), ("agents", "scale")],
+    )
+    return ProbabilisticActor(
+        module=module,
+        in_keys=[("agents", "loc"), ("agents", "scale")],
+        out_keys=[env.action_key],
+        distribution_class=TanhNormal,
+        distribution_kwargs={
+            "low": env.full_action_spec_unbatched[("agents", "action")].space.low,
+            "high": env.full_action_spec_unbatched[("agents", "action")].space.high,
+        },
+        return_log_prob=True,
+    )
+
+
+def make_critic(
+    env, *, centralized: bool, share_params: bool = True
+) -> TensorDictModule:
+    obs_dim = env.observation_spec["agents", "observation"].shape[-1]
+    return TensorDictModule(
+        MultiAgentMLP(
+            n_agent_inputs=obs_dim,
+            n_agent_outputs=1,
+            n_agents=env.n_agents,
+            centralized=centralized,
+            share_params=share_params,
+            depth=2,
+            num_cells=256,
+            activation_class=nn.Tanh,
+        ),
+        in_keys=[("agents", "observation")],
+        out_keys=[("agents", "state_value")],
+    )
+
+
+def main(args: argparse.Namespace) -> None:
+    try:
+        from torchrl.envs.libs.vmas import VmasEnv
+    except ImportError as exc:
+        raise SystemExit(
+            "This example requires VMAS. Install it with `pip install vmas`."
+        ) from exc
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    torch.manual_seed(args.seed)
+
+    n_envs = max(1, args.frames_per_batch // args.max_steps)
+    base_env = VmasEnv(
+        scenario=args.scenario,
+        num_envs=n_envs,
+        continuous_actions=True,
+        max_steps=args.max_steps,
+        device=device,
+        seed=args.seed,
+    )
+    # VMAS writes per-agent rewards under ``("next", "agents", "reward")``.
+    # ``RewardSum`` mirrors that nesting so per-agent episode returns are
+    # available for logging.
+    env = TransformedEnv(
+        base_env,
+        RewardSum(
+            in_keys=[base_env.reward_key], out_keys=[("agents", "episode_reward")]
+        ),
+    )
+
+    actor = make_actor(env)
+    centralised = args.algo == "mappo"
+    critic = make_critic(env, centralized=centralised)
+
+    LossCls = MAPPOLoss if args.algo == "mappo" else IPPOLoss
+    value_norm = (
+        PopArtValueNorm(shape=1, device=device) if args.algo == "mappo" else None
+    )
+    loss_module = LossCls(
+        actor_network=actor,
+        critic_network=critic,
+        value_norm=value_norm,
+        clip_epsilon=0.2,
+        entropy_coeff=0.01,
+    )
+    # VMAS uses per-agent done/terminated flags, so we need to tell the loss
+    # where to find them. The team-shared reward / done broadcasting that
+    # MultiAgentGAE does is for envs that use root-level (team) signals.
+    loss_module.set_keys(
+        value=("agents", "state_value"),
+        action=env.action_key,
+        reward=env.reward_key,
+        done=("agents", "done"),
+        terminated=("agents", "terminated"),
+    )
+
+    collector = SyncDataCollector(
+        env,
+        actor,
+        device=device,
+        storing_device=device,
+        frames_per_batch=args.frames_per_batch,
+        total_frames=args.frames,
+    )
+
+    replay_buffer = TensorDictReplayBuffer(
+        storage=LazyTensorStorage(args.frames_per_batch, device=device),
+        sampler=SamplerWithoutReplacement(),
+        batch_size=args.minibatch_size,
+    )
+
+    optim = torch.optim.Adam(loss_module.parameters(), lr=args.lr)
+
+    total_frames = 0
+    start = time.time()
+    for it, td in enumerate(collector):
+        with torch.no_grad():
+            loss_module.value_estimator(
+                td,
+                params=loss_module.critic_network_params,
+                target_params=loss_module.target_critic_network_params,
+            )
+        replay_buffer.extend(td.reshape(-1))
+        total_frames += td.numel()
+
+        for _ in range(args.epochs):
+            for _ in range(args.frames_per_batch // args.minibatch_size):
+                subdata = replay_buffer.sample()
+                losses = loss_module(subdata)
+                loss = (
+                    losses["loss_objective"]
+                    + losses["loss_critic"]
+                    + losses["loss_entropy"]
+                )
+                optim.zero_grad()
+                loss.backward()
+                torch.nn.utils.clip_grad_norm_(loss_module.parameters(), 1.0)
+                optim.step()
+
+        collector.update_policy_weights_()
+        ep_reward = td.get(("next", "episode_reward")).mean().item()
+        print(
+            f"[{args.algo}] iter={it:03d} frames={total_frames:>7d} "
+            f"reward={ep_reward:+.3f} elapsed={time.time() - start:5.1f}s"
+        )
+
+    collector.shutdown()
+    if not env.is_closed:
+        env.close()
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--algo", choices=("mappo", "ippo"), default="mappo")
+    p.add_argument("--scenario", default="navigation")
+    p.add_argument("--frames", type=int, default=200_000)
+    p.add_argument("--frames_per_batch", type=int, default=6_000)
+    p.add_argument("--minibatch_size", type=int, default=400)
+    p.add_argument("--max_steps", type=int, default=100)
+    p.add_argument("--epochs", type=int, default=4)
+    p.add_argument("--lr", type=float, default=3e-4)
+    p.add_argument("--seed", type=int, default=0)
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/test/objectives/test_cql.py
+++ b/test/objectives/test_cql.py
@@ -182,7 +182,11 @@ class TestCQL(LossModuleTestBase):
             delay_qvalue=delay_qvalue,
         )
 
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn.make_value_estimator(td_est)
             return
@@ -361,7 +365,11 @@ class TestCQL(LossModuleTestBase):
             deactivate_vmap=False,
         )
 
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn_vmap.make_value_estimator(td_est)
             return
@@ -389,7 +397,11 @@ class TestCQL(LossModuleTestBase):
             deactivate_vmap=True,
         )
 
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn_no_vmap.make_value_estimator(td_est)
             return
@@ -845,7 +857,11 @@ class TestDiscreteCQL(LossModuleTestBase):
             action_spec_type=action_spec_type, device=device
         )
         loss_fn = DiscreteCQLLoss(actor, loss_function="l2", delay_value=delay_value)
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn.make_value_estimator(td_est)
             return

--- a/test/objectives/test_ddpg.py
+++ b/test/objectives/test_ddpg.py
@@ -248,7 +248,11 @@ class TestDDPG(LossModuleTestBase):
             delay_actor=delay_actor,
             delay_value=delay_value,
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn.make_value_estimator(td_est)
             return
@@ -1024,7 +1028,11 @@ class TestTD3(LossModuleTestBase):
             delay_actor=delay_actor,
             delay_qvalue=delay_qvalue,
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn.make_value_estimator(td_est)
             return
@@ -1136,7 +1144,11 @@ class TestTD3(LossModuleTestBase):
             delay_actor=delay_actor,
             delay_qvalue=delay_qvalue,
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn_vmap.make_value_estimator(td_est)
             return
@@ -1166,7 +1178,11 @@ class TestTD3(LossModuleTestBase):
             delay_actor=delay_actor,
             delay_qvalue=delay_qvalue,
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn_no_vmap.make_value_estimator(td_est)
             return
@@ -1937,7 +1953,11 @@ class TestTD3BC(LossModuleTestBase):
             delay_actor=delay_actor,
             delay_qvalue=delay_qvalue,
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn.make_value_estimator(td_est)
             return

--- a/test/objectives/test_dqn.py
+++ b/test/objectives/test_dqn.py
@@ -258,7 +258,11 @@ class TestDQN(LossModuleTestBase):
             delay_value=delay_value,
             double_dqn=double_dqn,
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn.make_value_estimator(td_est)
             return
@@ -922,7 +926,11 @@ class TestQMixer(LossModuleTestBase):
             action_spec_type=action_spec_type, device=device
         )
         loss_fn = QMixerLoss(actor, mixer, loss_function="l2", delay_value=delay_value)
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn.make_value_estimator(td_est)
             return

--- a/test/objectives/test_dreamer.py
+++ b/test/objectives/test_dreamer.py
@@ -406,7 +406,11 @@ class TestDreamer(LossModuleTestBase):
             imagination_horizon=imagination_horizon,
             discount_loss=discount_loss,
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_module.make_value_estimator(td_est)
             return

--- a/test/objectives/test_iql.py
+++ b/test/objectives/test_iql.py
@@ -310,7 +310,11 @@ class TestIQL(LossModuleTestBase):
             expectile=expectile,
             loss_function="l2",
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn.make_value_estimator(td_est)
             return
@@ -439,7 +443,11 @@ class TestIQL(LossModuleTestBase):
             loss_function="l2",
             deactivate_vmap=False,
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn_vmap.make_value_estimator(td_est)
             return
@@ -463,7 +471,11 @@ class TestIQL(LossModuleTestBase):
             loss_function="l2",
             deactivate_vmap=True,
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn_no_vmap.make_value_estimator(td_est)
             return
@@ -1206,7 +1218,11 @@ class TestDiscreteIQL(LossModuleTestBase):
             loss_function="l2",
             action_space="one-hot",
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn.make_value_estimator(td_est)
             return

--- a/test/objectives/test_mappo.py
+++ b/test/objectives/test_mappo.py
@@ -1,0 +1,511 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Tests for MAPPOLoss, IPPOLoss, MultiAgentGAE, and the ValueNorm family.
+
+These tests use synthetic tensordicts so they don't depend on any external
+MARL env (VMAS / PettingZoo). They follow the layout pattern from
+``test/test_cost.py::TestQMixer`` — per-agent observations under
+``("agents", "observation")`` and team-shared reward / done at the root.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+
+from torchrl.modules import (
+    MultiAgentMLP,
+    PopArtValueNorm,
+    ProbabilisticActor,
+    RunningValueNorm,
+    ValueNorm,
+)
+from torchrl.modules.distributions import NormalParamExtractor, TanhNormal
+from torchrl.objectives import IPPOLoss, MAPPOLoss
+from torchrl.objectives.utils import ValueEstimators
+from torchrl.objectives.value import GAE, MultiAgentGAE
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+
+
+def _make_actor(n_agents=3, obs_dim=6, action_dim=2, share_params=True):
+    backbone = torch.nn.Sequential(
+        MultiAgentMLP(
+            n_agent_inputs=obs_dim,
+            n_agent_outputs=2 * action_dim,
+            n_agents=n_agents,
+            centralized=False,
+            share_params=share_params,
+        ),
+        NormalParamExtractor(),
+    )
+    module = TensorDictModule(
+        backbone,
+        in_keys=[("agents", "observation")],
+        out_keys=[("agents", "loc"), ("agents", "scale")],
+    )
+    return ProbabilisticActor(
+        module=module,
+        in_keys={"loc": ("agents", "loc"), "scale": ("agents", "scale")},
+        out_keys=[("agents", "action")],
+        distribution_class=TanhNormal,
+        return_log_prob=True,
+    )
+
+
+def _make_critic(n_agents=3, obs_dim=6, centralized=True, share_params=True):
+    return TensorDictModule(
+        MultiAgentMLP(
+            n_agent_inputs=obs_dim,
+            n_agent_outputs=1,
+            n_agents=n_agents,
+            centralized=centralized,
+            share_params=share_params,
+        ),
+        in_keys=[("agents", "observation")],
+        out_keys=[("agents", "state_value")],
+    )
+
+
+def _make_data(
+    B=2, T=10, n_agents=3, obs_dim=6, action_dim=2, per_agent_reward=False, device="cpu"
+):
+    torch.manual_seed(0)
+    obs = torch.randn(B, T, n_agents, obs_dim, device=device)
+    next_obs = torch.randn(B, T, n_agents, obs_dim, device=device)
+    if per_agent_reward:
+        reward_shape = (B, T, n_agents, 1)
+    else:
+        reward_shape = (B, T, 1)
+    reward = torch.randn(*reward_shape, device=device)
+    done = torch.zeros(B, T, 1, dtype=torch.bool, device=device)
+    terminated = torch.zeros(B, T, 1, dtype=torch.bool, device=device)
+    return TensorDict(
+        {
+            "agents": TensorDict({"observation": obs}, [B, T, n_agents]),
+            "next": TensorDict(
+                {
+                    "agents": TensorDict({"observation": next_obs}, [B, T, n_agents]),
+                    "reward": reward,
+                    "done": done,
+                    "terminated": terminated,
+                },
+                [B, T],
+            ),
+        },
+        [B, T],
+        device=device,
+    )
+
+
+def _attach_action_and_logprob(td: TensorDict, actor: ProbabilisticActor, loss):
+    with torch.no_grad():
+        sampled = actor(td.clone())
+    td[("agents", "action")] = sampled[("agents", "action")]
+    td[loss.tensor_keys.sample_log_prob] = sampled[loss.tensor_keys.sample_log_prob]
+    return td
+
+
+# --------------------------------------------------------------------------
+# MultiAgentGAE
+# --------------------------------------------------------------------------
+
+
+class TestMultiAgentGAE:
+    def test_team_reward_broadcast(self):
+        n_agents = 3
+        critic = _make_critic(n_agents=n_agents)
+        gae = MultiAgentGAE(gamma=0.99, lmbda=0.95, value_network=critic)
+        gae.set_keys(value=("agents", "state_value"))
+        td = _make_data(n_agents=n_agents, per_agent_reward=False)
+        gae(td)
+        # advantage matches the critic's per-agent value shape
+        assert td[gae.tensor_keys.advantage].shape[-2] == n_agents
+        assert td[gae.tensor_keys.advantage].shape[-1] == 1
+        assert (
+            td[gae.tensor_keys.value_target].shape
+            == td[gae.tensor_keys.advantage].shape
+        )
+
+    def test_per_agent_reward_passthrough(self):
+        n_agents = 3
+        critic = _make_critic(n_agents=n_agents, centralized=False)
+        gae = MultiAgentGAE(gamma=0.99, lmbda=0.95, value_network=critic)
+        gae.set_keys(value=("agents", "state_value"))
+        td = _make_data(n_agents=n_agents, per_agent_reward=True)
+        gae(td)
+        assert td[gae.tensor_keys.advantage].shape[-2] == n_agents
+
+    def test_broadcast_error_on_bad_shape(self):
+        gae = MultiAgentGAE(gamma=0.99, lmbda=0.95, value_network=None, agent_dim=-2)
+        # value has ndim=4 (B, T, n_agents, 1); a 2-D reward is neither
+        # per-agent nor team-shared, so the helper must reject it.
+        bad_tensor = torch.zeros(4, 5)
+        target = torch.zeros(4, 5, 3, 1)
+        with pytest.raises(ValueError, match="expected the reward/done/terminated"):
+            gae._broadcast_to_agents(bad_tensor, target, agent_dim=-2)
+
+    def test_value_estimator_enum_registered(self):
+        # MAGAE is wired up in default_value_kwargs and the enum.
+        from torchrl.objectives.utils import default_value_kwargs
+
+        kw = default_value_kwargs(ValueEstimators.MAGAE)
+        assert "gamma" in kw and "lmbda" in kw
+
+
+# --------------------------------------------------------------------------
+# ValueNorm — abstract base + the two concrete implementations
+# --------------------------------------------------------------------------
+
+
+class TestValueNormBase:
+    def test_abstract_base_is_not_instantiable(self):
+        with pytest.raises(TypeError):
+            ValueNorm(shape=1)  # type: ignore[abstract]
+
+
+class TestPopArtValueNorm:
+    def test_running_stats_converge(self):
+        torch.manual_seed(0)
+        vn = PopArtValueNorm(shape=1)
+        x = torch.randn(4096, 1) * 5.0 + 2.0
+        for _ in range(200):
+            vn.update(x)
+        mean, var = vn._running_stats()
+        assert abs(mean.item() - 2.0) < 0.2
+        assert abs(var.sqrt().item() - 5.0) < 0.5
+
+    def test_denormalize_inverts_normalize(self):
+        torch.manual_seed(0)
+        vn = PopArtValueNorm(shape=1)
+        x = torch.randn(512, 1) * 3.0 + 1.0
+        for _ in range(50):
+            vn.update(x)
+        y = torch.randn(64, 1) * 3.0 + 1.0
+        recovered = vn.denormalize(vn.normalize(y))
+        torch.testing.assert_close(recovered, y, rtol=1e-4, atol=1e-4)
+
+    def test_bad_shape_raises(self):
+        vn = PopArtValueNorm(shape=1)
+        with pytest.raises(ValueError, match="trailing shape"):
+            vn.update(torch.randn(4, 8))  # trailing 8 != 1
+
+
+class TestRunningValueNorm:
+    def test_running_stats_converge(self):
+        """Exact running stats should be very tight even after few updates."""
+        torch.manual_seed(0)
+        vn = RunningValueNorm(shape=1)
+        x = torch.randn(4096, 1) * 5.0 + 2.0
+        for _ in range(20):
+            vn.update(x)
+        assert abs(vn.mean.item() - 2.0) < 0.1
+        assert abs(vn._var().sqrt().item() - 5.0) < 0.1
+
+    def test_denormalize_inverts_normalize(self):
+        torch.manual_seed(0)
+        vn = RunningValueNorm(shape=1)
+        for _ in range(10):
+            vn.update(torch.randn(256, 1) * 3.0 + 1.0)
+        y = torch.randn(64, 1) * 3.0 + 1.0
+        recovered = vn.denormalize(vn.normalize(y))
+        torch.testing.assert_close(recovered, y, rtol=1e-4, atol=1e-4)
+
+    def test_no_decay(self):
+        """RunningValueNorm should not be biased by sample order (no EMA)."""
+        torch.manual_seed(0)
+        vn = RunningValueNorm(shape=1)
+        # Feed two batches with very different scales; running stats should
+        # land at the true combined mean rather than getting dominated by
+        # whichever batch came last (which is what an EMA would do).
+        a = torch.full((1000, 1), 1.0)
+        b = torch.full((1000, 1), 5.0)
+        vn.update(a)
+        vn.update(b)
+        # Combined mean of 1000 ones + 1000 fives = 3.0 exactly.
+        assert abs(vn.mean.item() - 3.0) < 1e-4
+
+
+# --------------------------------------------------------------------------
+# MAPPOLoss
+# --------------------------------------------------------------------------
+
+
+class TestMAPPOLoss:
+    def test_forward_shapes_and_backward(self):
+        actor = _make_actor()
+        critic = _make_critic(centralized=True)
+        loss_mod = MAPPOLoss(actor, critic)
+        loss_mod.set_keys(value=("agents", "state_value"), action=("agents", "action"))
+
+        td = _make_data()
+        _attach_action_and_logprob(td, actor, loss_mod)
+        out = loss_mod(td)
+
+        for k in ("loss_objective", "loss_entropy", "loss_critic"):
+            assert k in out, f"missing key {k}"
+            assert out[k].shape == torch.Size(
+                []
+            ), f"{k} should be scalar, got {out[k].shape}"
+
+        # Gradients reach both actor and critic.
+        total = out["loss_objective"] + out["loss_entropy"] + out["loss_critic"]
+        total.backward()
+        actor_grads = [
+            p.grad
+            for p in loss_mod.actor_network_params.values(True, True)
+            if isinstance(p, torch.nn.Parameter) and p.grad is not None
+        ]
+        critic_grads = [
+            p.grad
+            for p in loss_mod.critic_network_params.values(True, True)
+            if isinstance(p, torch.nn.Parameter) and p.grad is not None
+        ]
+        assert len(actor_grads) > 0, "actor received no grads"
+        assert len(critic_grads) > 0, "critic received no grads"
+
+    def test_centralized_critic_uses_full_team_obs(self):
+        """Perturbing one agent's obs must change every agent's value."""
+        actor = _make_actor()
+        critic = _make_critic(centralized=True)
+        loss_mod = MAPPOLoss(actor, critic)
+        loss_mod.set_keys(value=("agents", "state_value"), action=("agents", "action"))
+
+        td = _make_data()
+        with torch.no_grad():
+            v_before = critic(td.clone())[("agents", "state_value")]
+            td2 = td.clone()
+            td2["agents", "observation"][..., 0, :] += 5.0  # perturb agent 0
+            v_after = critic(td2)[("agents", "state_value")]
+
+        # Other agents' values must change (centralised critic saw the perturb).
+        diff = (v_before - v_after).abs().mean(dim=(0, 1, 3))
+        assert diff[1] > 1e-6, "Centralised critic ignored cross-agent obs change"
+        assert diff[2] > 1e-6, "Centralised critic ignored cross-agent obs change"
+
+    @pytest.mark.parametrize("share_params", [True, False])
+    def test_share_params_modes(self, share_params):
+        actor = _make_actor(share_params=share_params)
+        critic = _make_critic(centralized=True, share_params=share_params)
+        loss_mod = MAPPOLoss(actor, critic)
+        loss_mod.set_keys(value=("agents", "state_value"), action=("agents", "action"))
+        td = _make_data()
+        _attach_action_and_logprob(td, actor, loss_mod)
+        out = loss_mod(td)
+        assert out["loss_objective"].shape == torch.Size([])
+
+    def test_value_norm_round_trip(self):
+        """With PopArtValueNorm, critic loss should remain bounded across many updates."""
+        torch.manual_seed(0)
+        actor = _make_actor()
+        critic = _make_critic(centralized=True)
+        vn = PopArtValueNorm(shape=1)
+        loss_mod = MAPPOLoss(actor, critic, value_norm=vn)
+        loss_mod.set_keys(value=("agents", "state_value"), action=("agents", "action"))
+
+        critic_losses = []
+        for step in range(8):
+            td = _make_data(B=2, T=10)
+            # inflate reward scale over time to stress normalisation
+            td["next", "reward"] *= (step + 1) * 10.0
+            _attach_action_and_logprob(td, actor, loss_mod)
+            out = loss_mod(td)
+            critic_losses.append(out["loss_critic"].item())
+
+        # Without ValueNorm a 10x reward inflation would blow critic loss up
+        # quadratically; with ValueNorm it should stay roughly bounded.
+        assert max(critic_losses) < 10.0, f"critic loss exploded: {critic_losses}"
+
+    def test_default_value_estimator_is_magae(self):
+        actor = _make_actor()
+        critic = _make_critic(centralized=True)
+        loss_mod = MAPPOLoss(actor, critic)
+        loss_mod.set_keys(value=("agents", "state_value"), action=("agents", "action"))
+        loss_mod.make_value_estimator()
+        assert loss_mod.value_type == ValueEstimators.MAGAE
+        assert isinstance(loss_mod._value_estimator, MultiAgentGAE)
+
+    def test_make_value_estimator_falls_through_for_non_magae(self):
+        """Selecting a non-MAGAE estimator goes through the parent class."""
+        actor = _make_actor()
+        critic = _make_critic(centralized=False)
+        loss_mod = MAPPOLoss(actor, critic)
+        loss_mod.set_keys(value=("agents", "state_value"), action=("agents", "action"))
+        loss_mod.make_value_estimator(ValueEstimators.GAE)
+        assert isinstance(loss_mod._value_estimator, GAE)
+        assert not isinstance(loss_mod._value_estimator, MultiAgentGAE)
+
+    # -- bug-fix regression tests ------------------------------------------
+
+    def test_value_norm_not_double_registered(self):
+        """``value_norm`` must show up exactly once in ``state_dict()``.
+
+        Regression: the original PR called both ``self.value_norm = vn`` and
+        ``self.add_module("_value_norm_module", vn)``, so the ValueNorm's
+        buffers ended up serialised twice and ``load_state_dict`` could
+        silently load stale stats from the duplicate prefix.
+        """
+        actor = _make_actor()
+        critic = _make_critic(centralized=True)
+        vn = PopArtValueNorm(shape=1)
+        loss_mod = MAPPOLoss(actor, critic, value_norm=vn)
+        sd = loss_mod.state_dict()
+        vn_keys = [k for k in sd.keys() if "value_norm" in k]
+        # Exactly the three buffers from PopArtValueNorm, each appearing once.
+        assert sorted(vn_keys) == [
+            "value_norm.debiasing_term",
+            "value_norm.running_mean",
+            "value_norm.running_mean_sq",
+        ]
+
+    def test_value_norm_state_dict_round_trip(self):
+        """``state_dict`` save / load with ``value_norm`` round-trips cleanly."""
+        torch.manual_seed(0)
+        actor = _make_actor()
+        critic = _make_critic(centralized=True)
+        vn1 = PopArtValueNorm(shape=1)
+        loss_a = MAPPOLoss(actor, critic, value_norm=vn1)
+        for _ in range(20):
+            vn1.update(torch.randn(64, 1) * 3.0 + 2.0)
+
+        # Build a sibling, load weights, confirm the running stats arrived.
+        vn2 = PopArtValueNorm(shape=1)
+        loss_b = MAPPOLoss(
+            _make_actor(), _make_critic(centralized=True), value_norm=vn2
+        )
+        loss_b.load_state_dict(loss_a.state_dict())
+        torch.testing.assert_close(vn2.running_mean, vn1.running_mean)
+        torch.testing.assert_close(vn2.running_mean_sq, vn1.running_mean_sq)
+        torch.testing.assert_close(vn2.debiasing_term, vn1.debiasing_term)
+
+    def test_value_norm_composes_with_clip_value(self):
+        """``clip_value`` must keep working when ``value_norm`` is attached.
+
+        Regression: the original ``loss_critic`` override silently dropped
+        the parent's value-clipping branch (no ``value_clip_fraction`` in
+        the output dict) whenever a ``ValueNorm`` was set.
+        """
+        torch.manual_seed(0)
+        actor = _make_actor()
+        critic = _make_critic(centralized=True)
+        vn = PopArtValueNorm(shape=1)
+        loss_mod = MAPPOLoss(actor, critic, value_norm=vn, clip_value=0.2)
+        loss_mod.set_keys(value=("agents", "state_value"), action=("agents", "action"))
+        td = _make_data()
+        _attach_action_and_logprob(td, actor, loss_mod)
+        out = loss_mod(td)
+        # ``clip_fraction`` (PPO ratio) is always present; the value-clip
+        # fraction is the one that disappeared in the regression.
+        assert "value_clip_fraction" in out
+
+    def test_value_norm_separate_losses_detaches_actor_grads(self):
+        """``separate_losses=True`` must still detach when ``value_norm`` is on.
+
+        Regression: the original override skipped the ``tensordict.detach()``
+        step from the parent's ``loss_critic``, so gradients from the critic
+        loss flowed back into the actor params — the opposite of what
+        ``separate_losses=True`` asks for.
+        """
+        torch.manual_seed(0)
+        actor = _make_actor()
+        critic = _make_critic(centralized=True)
+        vn = PopArtValueNorm(shape=1)
+        loss_mod = MAPPOLoss(
+            actor,
+            critic,
+            value_norm=vn,
+            separate_losses=True,
+        )
+        loss_mod.set_keys(value=("agents", "state_value"), action=("agents", "action"))
+        td = _make_data()
+        _attach_action_and_logprob(td, actor, loss_mod)
+        out = loss_mod(td)
+        # Only the critic loss is asked to backprop — actor params must end
+        # up with zero / None grads because ``separate_losses=True`` should
+        # have detached the tensordict before the critic forward.
+        out["loss_critic"].backward()
+        actor_grads = [
+            p.grad
+            for p in loss_mod.actor_network_params.values(True, True)
+            if isinstance(p, torch.nn.Parameter)
+        ]
+        for g in actor_grads:
+            assert g is None or torch.all(
+                g == 0
+            ), "actor params received critic-loss gradients despite separate_losses=True"
+
+    def test_no_spurious_annotation_warnings_on_instantiation(self):
+        """No ``actor_network_params wasn't part of the annotations`` warnings.
+
+        Regression: declaring ``actor_network: TensorDictModule`` /
+        ``critic_network: TensorDictModule`` at MAPPOLoss class level
+        shadowed the parent's annotations dict (which is *not* inherited),
+        and ``LossModule.convert_to_functional`` warned about the missing
+        ``*_network_params`` names on every instantiation.
+        """
+        import warnings as _warnings
+
+        actor = _make_actor()
+        critic = _make_critic(centralized=True)
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            MAPPOLoss(actor, critic)
+        annotation_warnings = [
+            w for w in caught if "wasn't part of the annotations" in str(w.message)
+        ]
+        assert not annotation_warnings, (
+            f"got annotation warnings during MAPPOLoss instantiation: "
+            f"{[str(w.message) for w in annotation_warnings]}"
+        )
+
+
+# --------------------------------------------------------------------------
+# IPPOLoss
+# --------------------------------------------------------------------------
+
+
+class TestIPPOLoss:
+    def test_forward_shapes_and_backward(self):
+        actor = _make_actor()
+        critic = _make_critic(centralized=False)
+        loss_mod = IPPOLoss(actor, critic)
+        loss_mod.set_keys(value=("agents", "state_value"), action=("agents", "action"))
+
+        td = _make_data()
+        _attach_action_and_logprob(td, actor, loss_mod)
+        out = loss_mod(td)
+
+        for k in ("loss_objective", "loss_entropy", "loss_critic"):
+            assert out[k].shape == torch.Size([])
+
+        (out["loss_objective"] + out["loss_critic"]).backward()
+
+    def test_decentralized_critic_ignores_other_agents(self):
+        """IPPO critic must depend only on the agent's own observation."""
+        critic = _make_critic(centralized=False)
+        td = _make_data()
+        with torch.no_grad():
+            v_before = critic(td.clone())[("agents", "state_value")]
+            td2 = td.clone()
+            td2["agents", "observation"][..., 0, :] += 5.0  # perturb agent 0
+            v_after = critic(td2)[("agents", "state_value")]
+
+        diff = (v_before - v_after).abs().mean(dim=(0, 1, 3))
+        # Agent 0's value changed.
+        assert diff[0] > 1e-6
+        # Agents 1, 2 must be unaffected.
+        assert diff[1] < 1e-6
+        assert diff[2] < 1e-6
+
+
+if __name__ == "__main__":
+    import argparse
+
+    args, unknown = argparse.ArgumentParser().parse_known_args()
+    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/objectives/test_sac.py
+++ b/test/objectives/test_sac.py
@@ -436,7 +436,11 @@ class TestSAC(LossModuleTestBase):
             **kwargs,
         )
 
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn.make_value_estimator(td_est)
             return
@@ -611,7 +615,11 @@ class TestSAC(LossModuleTestBase):
             **kwargs,
         )
 
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn_vmap.make_value_estimator(td_est)
             return
@@ -636,7 +644,11 @@ class TestSAC(LossModuleTestBase):
             **kwargs,
         )
 
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn_no_vmap.make_value_estimator(td_est)
             return
@@ -1671,7 +1683,11 @@ class TestDiscreteSAC(LossModuleTestBase):
             action_space="one-hot",
             **kwargs,
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn.make_value_estimator(td_est)
             return
@@ -1790,7 +1806,11 @@ class TestDiscreteSAC(LossModuleTestBase):
             deactivate_vmap=False,
             **kwargs,
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn_vmap.make_value_estimator(td_est)
             return
@@ -1818,7 +1838,11 @@ class TestDiscreteSAC(LossModuleTestBase):
             deactivate_vmap=True,
             **kwargs,
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn_no_vmap.make_value_estimator(td_est)
             return
@@ -2466,7 +2490,11 @@ class TestCrossQ(LossModuleTestBase):
             loss_function="l2",
         )
 
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn.make_value_estimator(td_est)
             return
@@ -2567,7 +2595,11 @@ class TestCrossQ(LossModuleTestBase):
             deactivate_vmap=False,
         )
 
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn_vmap.make_value_estimator(td_est)
             return
@@ -2590,7 +2622,11 @@ class TestCrossQ(LossModuleTestBase):
             deactivate_vmap=True,
         )
 
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn_no_vmap.make_value_estimator(td_est)
             return
@@ -3300,7 +3336,11 @@ class TestREDQ(LossModuleTestBase):
             loss_function="l2",
             delay_qvalue=delay_qvalue,
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn.make_value_estimator(td_est)
             return
@@ -3687,7 +3727,11 @@ class TestREDQ(LossModuleTestBase):
             loss_function="l2",
             delay_qvalue=delay_qvalue,
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn.make_value_estimator(td_est)
             return
@@ -3704,7 +3748,11 @@ class TestREDQ(LossModuleTestBase):
             loss_function="l2",
             delay_qvalue=delay_qvalue,
         )
-        if td_est in (ValueEstimators.GAE, ValueEstimators.VTrace):
+        if td_est in (
+            ValueEstimators.GAE,
+            ValueEstimators.MAGAE,
+            ValueEstimators.VTrace,
+        ):
             with pytest.raises(NotImplementedError):
                 loss_fn_deprec.make_value_estimator(td_est)
             return

--- a/torchrl/modules/__init__.py
+++ b/torchrl/modules/__init__.py
@@ -100,6 +100,7 @@ from .tensordict_module.exploration import (
     set_exploration_modules_spec_from_env,
 )
 from .utils import get_env_transforms_from_module, get_primers_from_module
+from .value_norm import PopArtValueNorm, RunningValueNorm, ValueNorm
 from .planners import CEMPlanner, MPCPlannerBase, MPPIPlanner  # usort:skip
 from .mcts import (  # usort:skip
     EXP3Score,
@@ -175,6 +176,7 @@ __all__ = [
     "Ordinal",
     "OrnsteinUhlenbeckProcessModule",
     "OrnsteinUhlenbeckProcessWrapper",
+    "PopArtValueNorm",
     "ProbabilisticActor",
     "PUCTScore",
     "QMixer",
@@ -186,6 +188,7 @@ __all__ = [
     "RSSMPrior",
     "RSSMRollout",
     "ReparamGradientStrategy",
+    "RunningValueNorm",
     "SafeModule",
     "SafeProbabilisticModule",
     "SafeProbabilisticTensorDictSequential",
@@ -199,6 +202,7 @@ __all__ = [
     "UCB1TunedScore",
     "UCBScore",
     "VDNMixer",
+    "ValueNorm",
     "ValueOperator",
     "VmapModule",
     "WorldModelWrapper",

--- a/torchrl/modules/tensordict_module/probabilistic.py
+++ b/torchrl/modules/tensordict_module/probabilistic.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import inspect
 import warnings
 
 import torch
@@ -15,10 +16,18 @@ from tensordict.nn import (
     TensorDictModule,
 )
 from tensordict.utils import NestedKey
+
 from torchrl.data.tensor_specs import Composite, TensorSpec
 from torchrl.modules.distributions import Delta
 from torchrl.modules.tensordict_module.common import _forward_hook_safe_action
 from torchrl.modules.tensordict_module.sequence import SafeSequential
+
+# Older stable-release versions of ``tensordict`` predate the ``generator``
+# kwarg on ``ProbabilisticTensorDictModule.__init__``. We probe the signature
+# once at import time and forward the kwarg only when it is supported.
+_PTDM_HAS_GENERATOR = (
+    "generator" in inspect.signature(ProbabilisticTensorDictModule.__init__).parameters
+)
 
 
 class SafeProbabilisticModule(ProbabilisticTensorDictModule):
@@ -208,6 +217,10 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule):
         num_samples: int | torch.Size | None = None,
         generator: torch.Generator | int | NestedKey | None = None,
     ):
+        # ``generator`` was added to ``ProbabilisticTensorDictModule`` after
+        # the current stable-release tensordict; forward it only when the
+        # underlying class accepts it.
+        extra_kwargs = {"generator": generator} if _PTDM_HAS_GENERATOR else {}
         super().__init__(
             in_keys=in_keys,
             out_keys=out_keys,
@@ -220,7 +233,7 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule):
             log_prob_keys=log_prob_keys,
             log_prob_key=log_prob_key,
             num_samples=num_samples,
-            generator=generator,
+            **extra_kwargs,
         )
         if spec is not None:
             spec = spec.clone()

--- a/torchrl/modules/value_norm.py
+++ b/torchrl/modules/value_norm.py
@@ -1,0 +1,240 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Value normalisation for actor-critic algorithms.
+
+Defines the abstract :class:`ValueNorm` interface and two concrete
+implementations:
+
+- :class:`PopArtValueNorm` — exponential-moving-average mean / mean-of-squares
+  with debiasing (van Hasselt et al., *Multi-task Deep RL with PopArt*,
+  AAAI 2019, https://arxiv.org/abs/1809.04474). Used by MAPPO
+  (Yu et al. 2022) to stabilise the critic loss when reward scales drift.
+- :class:`RunningValueNorm` — exact Welford running mean / variance with no
+  decay. Cheaper and more stable when value targets are stationary; tends to
+  be the better default for shorter / non-curriculum runs.
+
+Plug any subclass into :class:`~torchrl.objectives.multiagent.MAPPOLoss` (or
+your own actor-critic loss) via ``value_norm=...``.
+"""
+from __future__ import annotations
+
+import math
+from abc import ABCMeta, abstractmethod
+
+import torch
+from torch import nn
+
+
+class ValueNorm(nn.Module, metaclass=ABCMeta):
+    """Abstract base class for value normalisers.
+
+    A *value normaliser* keeps a running estimate of the location and scale of
+    the value target seen during training. Critics use it to:
+
+    - **normalize** the regression target before computing MSE, keeping the
+      critic loss on a fixed scale across episodes / reward inflations;
+    - **denormalize** the critic's output back to the real reward scale when
+      forming bootstrapped value estimates inside GAE / TD.
+
+    Subclasses must implement :meth:`update`, :meth:`normalize`, and
+    :meth:`denormalize`. The convention is that all three operate on tensors
+    whose trailing dims match :attr:`shape` (the per-element value shape,
+    usually ``(1,)``).
+    """
+
+    shape: tuple[int, ...]
+
+    def __init__(
+        self,
+        *,
+        shape: int | tuple[int, ...] = 1,
+        epsilon: float = 1e-5,
+        device: torch.device | None = None,
+    ) -> None:
+        super().__init__()
+        if isinstance(shape, int):
+            shape = (shape,)
+        self.shape = tuple(shape)
+        self.epsilon = epsilon
+        self._device = device
+
+    # ------------------------------------------------------------------ API
+
+    @abstractmethod
+    def update(self, value_target: torch.Tensor) -> None:
+        """Fold a batch of value targets into the running stats."""
+
+    @abstractmethod
+    def normalize(self, value_target: torch.Tensor) -> torch.Tensor:
+        """Standardise ``value_target`` using the current running stats."""
+
+    @abstractmethod
+    def denormalize(self, normalised_value: torch.Tensor) -> torch.Tensor:
+        """Inverse of :meth:`normalize` — recover real-scale values."""
+
+    # ------------------------------------------------------- shared helpers
+
+    def _check_trailing_shape(self, value_target: torch.Tensor) -> tuple[int, ...]:
+        if value_target.shape[-len(self.shape) :] != self.shape:
+            raise ValueError(
+                f"{type(self).__name__} was initialised with shape={self.shape} "
+                f"but got a value_target with trailing shape "
+                f"{tuple(value_target.shape[-len(self.shape) :])}."
+            )
+        return tuple(range(value_target.ndim - len(self.shape)))
+
+
+class PopArtValueNorm(ValueNorm):
+    """PopArt-style EMA value normaliser.
+
+    Maintains exponentially-weighted running estimates of the value-target
+    mean and mean-of-squares, with debiasing (so the early-training estimates
+    are unbiased even before the EMA has had time to wash out the zero
+    initialisation). Equivalent to the value-normaliser used by the reference
+    MAPPO implementation.
+
+    Keyword Args:
+        shape: per-element shape of the value tensor (everything except the
+            leading batch / time / agent dims that get reduced). Defaults to
+            ``1``.
+        beta: exponential decay for the running stats. Higher = slower
+            adaptation. Defaults to ``0.99999`` (the MAPPO default).
+        epsilon: numerical stabiliser added to the running variance and used
+            as a floor for the debiasing term. Defaults to ``1e-5``.
+        device: device for the running-stats buffers.
+
+    Example:
+        >>> vn = PopArtValueNorm(shape=1)
+        >>> target = torch.randn(64, 1) * 5.0 + 2.0    # mean 2, std 5
+        >>> for _ in range(100):
+        ...     vn.update(target)
+        >>> normed = vn.normalize(target)              # ~ N(0, 1)
+        >>> recovered = vn.denormalize(normed)         # back to real scale
+    """
+
+    def __init__(
+        self,
+        *,
+        shape: int | tuple[int, ...] = 1,
+        beta: float = 0.99999,
+        epsilon: float = 1e-5,
+        device: torch.device | None = None,
+    ) -> None:
+        super().__init__(shape=shape, epsilon=epsilon, device=device)
+        self.beta = beta
+        # Both running buffers start at zero. The debiasing term tracks
+        # \sum_{s<=t} beta^{t-s}, which also starts at zero; dividing the
+        # zero-init buffers by the (clamped) debias gives an unbiased EMA.
+        self.register_buffer("running_mean", torch.zeros(self.shape, device=device))
+        self.register_buffer("running_mean_sq", torch.zeros(self.shape, device=device))
+        self.register_buffer("debiasing_term", torch.zeros((), device=device))
+
+    def _running_stats(self) -> tuple[torch.Tensor, torch.Tensor]:
+        debias = self.debiasing_term.clamp(min=self.epsilon)
+        mean = self.running_mean / debias
+        mean_sq = self.running_mean_sq / debias
+        var = (mean_sq - mean.pow(2)).clamp(min=self.epsilon)
+        return mean, var
+
+    @torch.no_grad()
+    def update(self, value_target: torch.Tensor) -> None:
+        value_target = value_target.detach()
+        reduce_dims = self._check_trailing_shape(value_target)
+        if reduce_dims:
+            batch_mean = value_target.mean(dim=reduce_dims)
+            batch_mean_sq = value_target.pow(2).mean(dim=reduce_dims)
+        else:
+            batch_mean = value_target
+            batch_mean_sq = value_target.pow(2)
+
+        self.running_mean.mul_(self.beta).add_(batch_mean, alpha=1.0 - self.beta)
+        self.running_mean_sq.mul_(self.beta).add_(batch_mean_sq, alpha=1.0 - self.beta)
+        self.debiasing_term.mul_(self.beta).add_(1.0 - self.beta)
+
+    def normalize(self, value_target: torch.Tensor) -> torch.Tensor:
+        mean, var = self._running_stats()
+        return (value_target - mean) / var.sqrt()
+
+    def denormalize(self, normalised_value: torch.Tensor) -> torch.Tensor:
+        mean, var = self._running_stats()
+        return normalised_value * var.sqrt() + mean
+
+
+class RunningValueNorm(ValueNorm):
+    """Exact running mean / variance (Welford's online algorithm).
+
+    Unlike :class:`PopArtValueNorm`, this normaliser does not decay older
+    samples — it accumulates the true sample mean and variance over every
+    target it has ever seen. Useful when value targets are roughly stationary
+    (no curriculum, no reward-shaping schedule), where the EMA's adaptivity
+    is unnecessary and the exact running stats give a slightly tighter
+    estimate.
+
+    Keyword Args:
+        shape: per-element shape of the value tensor. Defaults to ``1``.
+        epsilon: numerical stabiliser added to the running variance.
+            Defaults to ``1e-5``.
+        device: device for the running-stats buffers.
+
+    Example:
+        >>> vn = RunningValueNorm(shape=1)
+        >>> for _ in range(10):
+        ...     vn.update(torch.randn(64, 1) * 3.0 + 1.0)
+        >>> normed = vn.normalize(torch.randn(8, 1))
+    """
+
+    def __init__(
+        self,
+        *,
+        shape: int | tuple[int, ...] = 1,
+        epsilon: float = 1e-5,
+        device: torch.device | None = None,
+    ) -> None:
+        super().__init__(shape=shape, epsilon=epsilon, device=device)
+        self.register_buffer("mean", torch.zeros(self.shape, device=device))
+        # m2 stores the running sum of squared deviations from the mean
+        # (Welford's M2). var = m2 / count (population variance — we don't
+        # apply Bessel's correction because the consumer is normalisation,
+        # not statistical inference).
+        self.register_buffer("m2", torch.zeros(self.shape, device=device))
+        self.register_buffer("count", torch.zeros((), device=device))
+
+    @torch.no_grad()
+    def update(self, value_target: torch.Tensor) -> None:
+        value_target = value_target.detach()
+        reduce_dims = self._check_trailing_shape(value_target)
+        if reduce_dims:
+            # ``math.prod`` over plain Python ints avoids allocating a
+            # CPU tensor and forcing a host-device sync inside update().
+            batch_count = float(math.prod(value_target.shape[d] for d in reduce_dims))
+            batch_mean = value_target.mean(dim=reduce_dims)
+            batch_var = value_target.var(dim=reduce_dims, unbiased=False)
+        else:
+            batch_count = 1.0
+            batch_mean = value_target
+            batch_var = torch.zeros_like(value_target)
+
+        # Chan et al. parallel variance update.
+        delta = batch_mean - self.mean
+        total = self.count + batch_count
+        new_mean = self.mean + delta * (batch_count / total)
+        new_m2 = (
+            self.m2
+            + batch_var * batch_count
+            + delta.pow(2) * (self.count * batch_count / total)
+        )
+        self.mean.copy_(new_mean)
+        self.m2.copy_(new_m2)
+        self.count.fill_(total)
+
+    def _var(self) -> torch.Tensor:
+        denom = self.count.clamp(min=1.0)
+        return (self.m2 / denom).clamp(min=self.epsilon)
+
+    def normalize(self, value_target: torch.Tensor) -> torch.Tensor:
+        return (value_target - self.mean) / self._var().sqrt()
+
+    def denormalize(self, normalised_value: torch.Tensor) -> torch.Tensor:
+        return normalised_value * self._var().sqrt() + self.mean

--- a/torchrl/objectives/__init__.py
+++ b/torchrl/objectives/__init__.py
@@ -30,7 +30,7 @@ from torchrl.objectives.dreamer_v3 import (
 )
 from torchrl.objectives.gail import GAILLoss
 from torchrl.objectives.iql import DiscreteIQLLoss, IQLLoss
-from torchrl.objectives.multiagent import QMixerLoss
+from torchrl.objectives.multiagent import IPPOLoss, MAPPOLoss, QMixerLoss
 from torchrl.objectives.pilco import ExponentialQuadraticCost
 from torchrl.objectives.ppo import ClipPPOLoss, KLPENPPOLoss, PPOLoss
 from torchrl.objectives.redq import REDQLoss
@@ -75,9 +75,11 @@ __all__ = [
     "ExponentialQuadraticCost",
     "GAILLoss",
     "HardUpdate",
+    "IPPOLoss",
     "IQLLoss",
     "KLPENPPOLoss",
     "LossModule",
+    "MAPPOLoss",
     "OnlineDTLoss",
     "PPOLoss",
     "QMixerLoss",

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -40,6 +40,7 @@ from torchrl.objectives.utils import (
 )
 from torchrl.objectives.value import (
     GAE,
+    MultiAgentGAE,
     TD0Estimator,
     TD1Estimator,
     TDLambdaEstimator,
@@ -631,6 +632,10 @@ class A2CLoss(LossModule):
             )
         elif value_type == ValueEstimators.GAE:
             self._value_estimator = GAE(value_network=self.critic_network, **hp)
+        elif value_type == ValueEstimators.MAGAE:
+            self._value_estimator = MultiAgentGAE(
+                value_network=self.critic_network, **hp
+            )
         elif value_type == ValueEstimators.TDLambda:
             self._value_estimator = TDLambdaEstimator(
                 value_network=self.critic_network, **hp

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -356,14 +356,20 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
                 will carry gradients as expected.
 
         """
+        # Walk the MRO so subclasses don't have to redeclare annotations
+        # introduced by their parents — ``cls.__annotations__`` is *not*
+        # inherited automatically in Python.
+        inherited_annotations: set[str] = set()
+        for base in type(self).__mro__:
+            inherited_annotations.update(getattr(base, "__annotations__", {}).keys())
         for name in (
             module_name,
             module_name + "_params",
             "target_" + module_name + "_params",
         ):
-            if name not in self.__class__.__annotations__.keys():
+            if name not in inherited_annotations:
                 warnings.warn(
-                    f"The name {name} wasn't part of the annotations ({self.__class__.__annotations__.keys()}). Make sure it is present in the definition class."
+                    f"The name {name} wasn't part of the annotations ({sorted(inherited_annotations)}). Make sure it is present in the definition class."
                 )
 
         if kwargs:

--- a/torchrl/objectives/multiagent/__init__.py
+++ b/torchrl/objectives/multiagent/__init__.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from .mappo import IPPOLoss, MAPPOLoss
 from .qmixer import QMixerLoss
 
-__all__ = ["QMixerLoss"]
+__all__ = ["IPPOLoss", "MAPPOLoss", "QMixerLoss"]

--- a/torchrl/objectives/multiagent/mappo.py
+++ b/torchrl/objectives/multiagent/mappo.py
@@ -1,0 +1,242 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Multi-agent PPO objectives.
+
+Implements :class:`MAPPOLoss` (centralised critic) and :class:`IPPOLoss`
+(independent / decentralised critic).
+
+References:
+    - Yu, C. et al. *The Surprising Effectiveness of PPO in Cooperative
+      Multi-Agent Games.* NeurIPS 2022. https://arxiv.org/abs/2103.01955
+    - de Witt, C. S. et al. *Is Independent Learning All You Need in the
+      StarCraft Multi-Agent Challenge?* 2020. https://arxiv.org/abs/2011.09533
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from tensordict.nn import TensorDictModule
+from tensordict.nn.probabilistic import ProbabilisticTensorDictSequential
+
+from torchrl.modules.value_norm import ValueNorm
+from torchrl.objectives.ppo import ClipPPOLoss
+from torchrl.objectives.utils import ValueEstimators
+
+
+class _MultiAgentPPOMixin:
+    """Shared plumbing for :class:`MAPPOLoss` and :class:`IPPOLoss`.
+
+    Two pieces:
+
+    1. Default the value estimator to :class:`MultiAgentGAE` so per-agent
+       value outputs broadcast cleanly against team-shared reward / done
+       signals.
+    2. When a :class:`~torchrl.modules.ValueNorm` is attached, normalise the
+       value-target and critic prediction by the running stats *before* the
+       MSE / smooth-L1 distance. This stabilises critic-loss magnitude when
+       reward scales drift during training (Yu et al. 2022, Table 13).
+
+       The normalisation is plumbed through
+       :meth:`~torchrl.objectives.PPOLoss._critic_loss_inputs`, the hook
+       :class:`~torchrl.objectives.PPOLoss` exposes for exactly this purpose,
+       so all of the parent's other critic-loss machinery (``clip_value``,
+       ``separate_losses``, ``log_explained_variance``, ...) continues to
+       work alongside ``value_norm``.
+    """
+
+    default_value_estimator = ValueEstimators.MAGAE
+
+    # Subclasses (MAPPOLoss / IPPOLoss) wire this up in ``__init__`` —
+    # populated here as a type hint only so static checkers know it exists.
+    value_norm: ValueNorm | None
+
+    def _critic_loss_inputs(self, target_return, state_value, old_state_value):
+        """Override of :meth:`PPOLoss._critic_loss_inputs` for PopArt normalisation.
+
+        Pushes ``target_return`` / ``state_value`` / ``old_state_value``
+        through the attached :class:`ValueNorm` if any, leaving the parent's
+        ``clip_value`` / ``log_explained_variance`` / ``separate_losses``
+        machinery untouched. ``old_state_value`` (used by the PPO value-clip
+        path) is normalised with the same stats so the clip radius stays in
+        normalised space — the convention the MAPPO paper assumes.
+
+        The running stats are updated *once* per call, on the un-normalised
+        ``target_return`` (which is what PopArt expects: the EMA tracks the
+        real return distribution, not the normalised one).
+        """
+        value_norm = self.value_norm
+        if value_norm is None:
+            return target_return, state_value, old_state_value
+        value_norm.update(target_return)
+        normalised_target = value_norm.normalize(target_return.detach())
+        normalised_pred = value_norm.normalize(state_value)
+        normalised_old = (
+            value_norm.normalize(old_state_value)
+            if old_state_value is not None
+            else None
+        )
+        return normalised_target, normalised_pred, normalised_old
+
+
+class MAPPOLoss(_MultiAgentPPOMixin, ClipPPOLoss):
+    """Multi-Agent PPO loss with a centralised critic (Yu et al. 2022).
+
+    MAPPO trains a *decentralised actor* (each agent's policy conditions only
+    on its local observation) together with a *centralised critic* (single
+    value function that conditions on the full team state or concatenated
+    observations). The decentralised actor lets policies run independently at
+    execution time, while the centralised critic reduces variance during
+    training by giving every agent the same value baseline derived from full
+    state information.
+
+    This class is a thin specialisation of :class:`ClipPPOLoss`. The
+    differences:
+
+    - The default value estimator is :class:`~torchrl.objectives.value.MultiAgentGAE`,
+      which broadcasts team-shared rewards / done flags along the agent
+      dimension before computing returns.
+    - ``normalize_advantage_exclude_dims`` defaults to ``(-2,)`` so the agent
+      dim is excluded when standardising advantages.
+    - An optional :class:`~torchrl.modules.ValueNorm` can be supplied via
+      ``value_norm=PopArtValueNorm(shape=1)`` to stabilise the critic loss;
+      the MAPPO paper reports this is load-bearing on SMAC (their Table 13).
+      :class:`~torchrl.modules.RunningValueNorm` is a no-decay alternative
+      for stationary reward scales.
+
+    Args:
+        actor_network (ProbabilisticTensorDictSequential): per-agent policy
+            operator. Conventionally built with
+            :class:`~torchrl.modules.MultiAgentMLP` using
+            ``centralized=False, share_params=True`` for cooperative
+            homogeneous teams.
+        critic_network (TensorDictModule): centralised value operator. Build
+            this with :class:`~torchrl.modules.MultiAgentMLP` and
+            ``centralized=True, share_params=True``, or with any module that
+            consumes a global ``"state"`` key and returns
+            ``("agents", "state_value")`` of shape ``[*B, n_agents, 1]``.
+
+    Keyword Args:
+        value_norm (ValueNorm, optional): if supplied, the critic target and
+            prediction are normalised by this running normaliser before the
+            MSE / smooth-L1 distance. Composes correctly with ``clip_value``
+            (the clip radius is applied in normalised space).
+            Defaults to ``None`` (no value norm).
+        clip_epsilon (float): PPO ratio clip. Defaults to ``0.2``.
+        entropy_coeff (float): entropy bonus weight. Defaults to ``0.01``
+            (MAPPO default).
+        critic_coef (float, optional): critic loss weight. Defaults to ``1.0``.
+        normalize_advantage (bool): whether to standardise the advantage.
+            Defaults to ``True`` (MAPPO default; differs from base
+            :class:`ClipPPOLoss` which defaults to ``False``).
+        normalize_advantage_exclude_dims (tuple of int): dimensions to
+            exclude from advantage standardisation. Defaults to ``(-2,)``
+            (the agent dim).
+        **kwargs: forwarded to :class:`ClipPPOLoss`.
+
+    The expected tensordict layout follows the torchrl multi-agent convention
+    (see :class:`~torchrl.envs.libs.vmas.VmasEnv`,
+    :class:`~torchrl.envs.libs.pettingzoo.PettingZooEnv`):
+
+    - ``("agents", "observation")``: ``[*B, T, n_agents, obs_dim]``
+    - ``("agents", "action")``: ``[*B, T, n_agents, action_dim]``
+    - Optional ``"state"`` at the root for centralised critics
+    - Team-shared ``("next", "reward")``, ``("next", "done")``,
+      ``("next", "terminated")`` of shape ``[*B, T, 1]`` (or per-agent under
+      ``("next", "agents", "reward")`` for competitive settings).
+
+    Example:
+        >>> import torch
+        >>> from tensordict.nn import TensorDictModule
+        >>> from torchrl.modules import (
+        ...     MultiAgentMLP, PopArtValueNorm, ProbabilisticActor,
+        ... )
+        >>> from torchrl.modules.distributions import NormalParamExtractor, TanhNormal
+        >>> from torchrl.objectives.multiagent import MAPPOLoss
+        >>> n_agents, obs_dim, action_dim = 3, 6, 2
+        >>> actor_net = torch.nn.Sequential(
+        ...     MultiAgentMLP(
+        ...         n_agent_inputs=obs_dim, n_agent_outputs=2 * action_dim,
+        ...         n_agents=n_agents, centralized=False, share_params=True,
+        ...     ),
+        ...     NormalParamExtractor(),
+        ... )
+        >>> actor_module = TensorDictModule(
+        ...     actor_net,
+        ...     in_keys=[("agents", "observation")],
+        ...     out_keys=[("agents", "loc"), ("agents", "scale")],
+        ... )
+        >>> actor = ProbabilisticActor(
+        ...     module=actor_module,
+        ...     in_keys=[("agents", "loc"), ("agents", "scale")],
+        ...     out_keys=[("agents", "action")],
+        ...     distribution_class=TanhNormal,
+        ... )
+        >>> critic = TensorDictModule(
+        ...     MultiAgentMLP(
+        ...         n_agent_inputs=obs_dim, n_agent_outputs=1,
+        ...         n_agents=n_agents, centralized=True, share_params=True,
+        ...     ),
+        ...     in_keys=[("agents", "observation")],
+        ...     out_keys=[("agents", "state_value")],
+        ... )
+        >>> loss = MAPPOLoss(actor, critic, value_norm=PopArtValueNorm(shape=1))
+        >>> loss.set_keys(value=("agents", "state_value"), action=("agents", "action"))
+    """
+
+    def __init__(
+        self,
+        actor_network: ProbabilisticTensorDictSequential | None = None,
+        critic_network: TensorDictModule | None = None,
+        *,
+        value_norm: ValueNorm | None = None,
+        entropy_coeff: float | dict[str, float] = 0.01,
+        normalize_advantage: bool = True,
+        normalize_advantage_exclude_dims: tuple[int, ...] = (-2,),
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            actor_network,
+            critic_network,
+            entropy_coeff=entropy_coeff,
+            normalize_advantage=normalize_advantage,
+            normalize_advantage_exclude_dims=normalize_advantage_exclude_dims,
+            **kwargs,
+        )
+        # ``nn.Module.__setattr__`` registers the ``ValueNorm`` as a child
+        # module automatically, so ``.to(device)`` / ``state_dict()`` / etc.
+        # pick it up without us calling ``add_module`` a second time.
+        self.value_norm = value_norm
+
+
+class IPPOLoss(MAPPOLoss):
+    """Independent PPO loss (de Witt et al. 2020).
+
+    IPPO is the decentralised counterpart of MAPPO: each agent has its *own*
+    value function that conditions only on its local observation. There is no
+    centralised critic and no global state required. Surprisingly competitive
+    with MAPPO on many SMAC scenarios (the de Witt et al. paper is titled
+    *Is Independent Learning All You Need...*).
+
+    Structurally this loss is identical to :class:`MAPPOLoss`; the difference
+    lives entirely in the critic the user passes in. We expose it as a
+    separate class so the API is self-documenting: when you import
+    ``IPPOLoss`` it is unambiguous which algorithm you are running, and the
+    docstring spells out the critic-construction recipe.
+
+    Args:
+        actor_network (ProbabilisticTensorDictSequential): per-agent policy.
+            Build with ``MultiAgentMLP(centralized=False, share_params=True)``.
+        critic_network (TensorDictModule): per-agent value operator. Build
+            with ``MultiAgentMLP(centralized=False, share_params=True)`` so
+            each agent values its own observation.
+
+    Keyword Args:
+        value_norm (ValueNorm, optional): rarely used with IPPO; defaults to
+            ``None``.
+        entropy_coeff (float): defaults to ``0.01``.
+        normalize_advantage (bool): defaults to ``True``.
+        normalize_advantage_exclude_dims (tuple of int): defaults to ``(-2,)``.
+        **kwargs: forwarded to :class:`ClipPPOLoss`.
+    """

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -45,6 +45,7 @@ from torchrl.objectives.utils import (
 )
 from torchrl.objectives.value import (
     GAE,
+    MultiAgentGAE,
     TD0Estimator,
     TD1Estimator,
     TDLambdaEstimator,
@@ -762,6 +763,23 @@ class PPOLoss(LossModule):
 
         return log_weight, dist, kl_approx
 
+    def _critic_loss_inputs(
+        self,
+        target_return: torch.Tensor,
+        state_value: torch.Tensor,
+        old_state_value: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        """Transform the critic-loss inputs before distance / clip.
+
+        Default implementation is identity. Subclasses (notably
+        :class:`~torchrl.objectives.multiagent.MAPPOLoss`) override this to
+        push the three tensors through a running
+        :class:`~torchrl.modules.ValueNorm` so the MSE / smooth-L1 distance
+        lives on a fixed scale -- and so the PPO value-clip radius stays
+        meaningful when reward scales drift.
+        """
+        return target_return, state_value, old_state_value
+
     def loss_critic(
         self, tensordict: TensorDictBase
     ) -> tuple[torch.Tensor | TensorDict, ...]:
@@ -782,6 +800,7 @@ class PPOLoss(LossModule):
                 f"can be used for the value loss."
             )
 
+        old_state_value = None
         if self.clip_value:
             old_state_value = tensordict.get(self.tensor_keys.value)
             if old_state_value is None:
@@ -804,6 +823,14 @@ class PPOLoss(LossModule):
                 f"the key {self.tensor_keys.value} was not found in the critic output tensordict. "
                 f"Make sure that the 'value_key' passed to PPO is accurate."
             )
+
+        # Subclass hook: lets e.g. MAPPOLoss inject PopArt-style value
+        # normalisation uniformly across target_return / state_value /
+        # old_state_value so the MSE and the clip radius both live in
+        # normalised space.
+        target_return, state_value, old_state_value = self._critic_loss_inputs(
+            target_return, state_value, old_state_value
+        )
 
         loss_value = distance_loss(
             target_return,
@@ -940,6 +967,10 @@ class PPOLoss(LossModule):
             )
         elif value_type == ValueEstimators.GAE:
             self._value_estimator = GAE(value_network=self.critic_network, **hp)
+        elif value_type == ValueEstimators.MAGAE:
+            self._value_estimator = MultiAgentGAE(
+                value_network=self.critic_network, **hp
+            )
         elif value_type == ValueEstimators.TDLambda:
             self._value_estimator = TDLambdaEstimator(
                 value_network=self.critic_network, **hp

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -30,6 +30,7 @@ from torchrl.objectives.utils import (
 )
 from torchrl.objectives.value import (
     GAE,
+    MultiAgentGAE,
     TD0Estimator,
     TD1Estimator,
     TDLambdaEstimator,
@@ -502,6 +503,10 @@ class ReinforceLoss(LossModule):
             )
         elif value_type == ValueEstimators.GAE:
             self._value_estimator = GAE(value_network=self.critic_network, **hp)
+        elif value_type == ValueEstimators.MAGAE:
+            self._value_estimator = MultiAgentGAE(
+                value_network=self.critic_network, **hp
+            )
         elif value_type == ValueEstimators.TDLambda:
             self._value_estimator = TDLambdaEstimator(
                 value_network=self.critic_network, **hp

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -60,6 +60,7 @@ class ValueEstimators(Enum):
     TD1 = "TD(1) (infinity-step return)"
     TDLambda = "TD(lambda)"
     GAE = "Generalized advantage estimate"
+    MAGAE = "Multi-agent generalized advantage estimate"
     VTrace = "V-trace"
 
 
@@ -80,6 +81,8 @@ def default_value_kwargs(value_type: ValueEstimators):
     elif value_type == ValueEstimators.TD0:
         return {"gamma": 0.99, "differentiable": True}
     elif value_type == ValueEstimators.GAE:
+        return {"gamma": 0.99, "lmbda": 0.95, "differentiable": True}
+    elif value_type == ValueEstimators.MAGAE:
         return {"gamma": 0.99, "lmbda": 0.95, "differentiable": True}
     elif value_type == ValueEstimators.TDLambda:
         return {"gamma": 0.99, "lmbda": 0.95, "differentiable": True}

--- a/torchrl/objectives/value/__init__.py
+++ b/torchrl/objectives/value/__init__.py
@@ -5,6 +5,7 @@
 
 from .advantages import (
     GAE,
+    MultiAgentGAE,
     TD0Estimate,
     TD0Estimator,
     TD1Estimate,
@@ -17,6 +18,7 @@ from .advantages import (
 
 __all__ = [
     "GAE",
+    "MultiAgentGAE",
     "TD0Estimate",
     "TD0Estimator",
     "TD1Estimate",

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -1899,10 +1899,18 @@ class GAE(ValueEstimatorBase):
         terminated = tensordict.get(("next", self.tensor_keys.terminated), default=done)
         time_dim = self._get_time_dim(time_dim, tensordict)
 
+        # Subclass extension hook: lets subclasses reshape / broadcast the
+        # reward and done signals to match the value tensor before the
+        # advantage recursion is run. Default: identity.
+        reward, done, terminated = self._prepare_signals(
+            reward, done, terminated, value
+        )
+
         if self.auto_reset_env:
             truncated = tensordict.get(("next", "truncated"))
+            truncated = self._broadcast_optional(truncated, value)
             if truncated.any():
-                reward += gamma * value * truncated
+                reward = reward + gamma * value * truncated
 
         if self.vectorized:
             adv, value_target = vec_generalized_advantage_estimate(
@@ -1928,15 +1936,48 @@ class GAE(ValueEstimatorBase):
             )
 
         if self.average_gae:
-            loc = adv.mean()
-            scale = adv.std().clamp_min(1e-4)
-            adv = adv - loc
-            adv = adv / scale
+            adv = self._normalize_advantage(adv)
 
         tensordict.set(self.tensor_keys.advantage, adv)
         tensordict.set(self.tensor_keys.value_target, value_target)
 
         return tensordict
+
+    # -- extension hooks -----------------------------------------------------
+
+    def _prepare_signals(
+        self,
+        reward: Tensor,
+        done: Tensor,
+        terminated: Tensor,
+        value: Tensor,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        """Hook to reshape reward / done / terminated before the recursion.
+
+        Default implementation is identity. :class:`MultiAgentGAE` overrides
+        this to broadcast team-shared signals across the agent dim.
+        """
+        return reward, done, terminated
+
+    def _broadcast_optional(self, tensor: Tensor, value: Tensor) -> Tensor:
+        """Optional broadcast for the truncated signal used in auto_reset_env.
+
+        Default: return ``tensor`` unchanged. Subclasses that broadcast
+        rewards / done flags should typically override this with the same
+        broadcasting policy.
+        """
+        return tensor
+
+    def _normalize_advantage(self, adv: Tensor) -> Tensor:
+        """Standardise the advantage tensor.
+
+        Default standardises globally (single mean/std over the whole tensor).
+        :class:`MultiAgentGAE` overrides this to leave the agent dim
+        independent.
+        """
+        loc = adv.mean()
+        scale = adv.std().clamp_min(1e-4)
+        return (adv - loc) / scale
 
     def value_estimate(
         self,
@@ -1993,6 +2034,9 @@ class GAE(ValueEstimatorBase):
             next_value = tensordict.get(("next", self.tensor_keys.value))
         done = tensordict.get(("next", self.tensor_keys.done))
         terminated = tensordict.get(("next", self.tensor_keys.terminated), default=done)
+        reward, done, terminated = self._prepare_signals(
+            reward, done, terminated, value
+        )
         _, value_target = vec_generalized_advantage_estimate(
             gamma,
             lmbda,
@@ -2004,6 +2048,96 @@ class GAE(ValueEstimatorBase):
             time_dim=time_dim,
         )
         return value_target
+
+
+class MultiAgentGAE(GAE):
+    """Multi-agent Generalized Advantage Estimator.
+
+    Drop-in replacement for :class:`GAE` when the value network produces per-agent
+    state values (shape ``[*B, T, n_agents, 1]``) but the reward / done /
+    terminated signals are shared across agents at the team level
+    (shape ``[*B, T, 1]``) — the standard cooperative-MARL layout in torchrl
+    (see e.g. ``torchrl/envs/libs/vmas.py`` and
+    ``torchrl/envs/libs/pettingzoo.py``).
+
+    The estimator detects whether the reward/done/terminated tensors are missing
+    the agent dimension relative to the value tensor, and broadcasts them along
+    that dimension before running the standard vectorised GAE recursion. If the
+    reward is already per-agent (e.g. a competitive setting), it is passed
+    through unchanged.
+
+    The output ``"advantage"`` and ``"value_target"`` entries match the shape
+    of the value tensor (``[*B, T, n_agents, 1]``), which is what
+    :class:`~torchrl.objectives.multiagent.MAPPOLoss` expects.
+
+    Keyword Args:
+        agent_dim (int, optional): the dimension that holds the agent index in
+            the value tensor. Negative dimensions are taken modulo
+            ``value.ndim``. Defaults to ``-2`` (penultimate), matching the
+            convention used by :class:`~torchrl.modules.MultiAgentMLP`.
+
+    Other args/kwargs are forwarded to :class:`GAE`.
+    """
+
+    def __init__(self, *, agent_dim: int = -2, **kwargs):
+        super().__init__(**kwargs)
+        self.agent_dim = agent_dim
+
+    @staticmethod
+    def _broadcast_to_agents(
+        tensor: torch.Tensor, target: torch.Tensor, agent_dim: int
+    ) -> torch.Tensor:
+        """Expand ``tensor`` along ``agent_dim`` to match ``target``'s shape.
+
+        If ``tensor`` already has the same number of dims as ``target`` we
+        assume it is per-agent and return it unchanged. Otherwise we unsqueeze
+        at ``agent_dim`` and expand.
+        """
+        if tensor.ndim == target.ndim:
+            return tensor
+        if tensor.ndim != target.ndim - 1:
+            raise ValueError(
+                f"MultiAgentGAE expected the reward/done/terminated tensor to "
+                f"have either the same number of dims as the value tensor "
+                f"(per-agent) or one fewer (team-shared). Got "
+                f"tensor.shape={tuple(tensor.shape)}, "
+                f"value.shape={tuple(target.shape)}."
+            )
+        dim = agent_dim if agent_dim >= 0 else target.ndim + agent_dim
+        n_agents = target.shape[dim]
+        unsqueezed = tensor.unsqueeze(dim)
+        expand_shape = list(unsqueezed.shape)
+        expand_shape[dim] = n_agents
+        return unsqueezed.expand(expand_shape)
+
+    # -- GAE extension hooks -------------------------------------------------
+
+    def _prepare_signals(
+        self,
+        reward: Tensor,
+        done: Tensor,
+        terminated: Tensor,
+        value: Tensor,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        return (
+            self._broadcast_to_agents(reward, value, self.agent_dim),
+            self._broadcast_to_agents(done, value, self.agent_dim),
+            self._broadcast_to_agents(terminated, value, self.agent_dim),
+        )
+
+    def _broadcast_optional(self, tensor: Tensor, value: Tensor) -> Tensor:
+        # Used by GAE for the auto_reset_env ``truncated`` tensor — same
+        # broadcasting policy as the other team signals.
+        return self._broadcast_to_agents(tensor, value, self.agent_dim)
+
+    def _normalize_advantage(self, adv: Tensor) -> Tensor:
+        # Per-agent standardisation: normalise over batch + time but keep the
+        # agent dim independent so high-variance agents are not flattened.
+        agent_dim = self.agent_dim if self.agent_dim >= 0 else adv.ndim + self.agent_dim
+        reduce_dims = [d for d in range(adv.ndim) if d != agent_dim]
+        loc = adv.mean(dim=reduce_dims, keepdim=True)
+        scale = adv.std(dim=reduce_dims, keepdim=True).clamp_min(1e-4)
+        return (adv - loc) / scale
 
 
 class VTrace(ValueEstimatorBase):


### PR DESCRIPTION
## Context

Multi-agent RL is currently the weakest research surface in torchrl: the only multi-agent loss shipped is `QMixerLoss` (DQN family, discrete actions). For cooperative continuous-control MARL — where most modern benchmarks live (SMAC, VMAS, PettingZoo MPE, Hanabi, Overcooked) — users have to hand-assemble `ClipPPOLoss` + manual `set_keys(done=("agents", "done"), terminated=("agents", "terminated"))` + manual `make_value_estimator(GAE, ...)`. The existing `sota-implementations/multiagent/mappo_ippo.py` recipe shows what this boilerplate looks like.

This PR adds **MAPPO** (Yu et al. 2022) and **IPPO** (de Witt et al. 2020) as first-class objectives, plus the two pieces of supporting infrastructure they need.

## What's new

- **`torchrl.objectives.multiagent.MAPPOLoss`** — centralised-critic, decentralised-actor PPO. Subclasses `ClipPPOLoss`; defaults the value estimator to `MultiAgentGAE`, defaults `normalize_advantage_exclude_dims=(-2,)`, and optionally accepts a `ValueNorm` for the critic-stability trick from the paper.
- **`torchrl.objectives.multiagent.IPPOLoss`** — independent-learner counterpart. Each agent has its own local critic; no centralised state required.
- **`torchrl.objectives.value.MultiAgentGAE`** — `GAE` variant that broadcasts team-shared `reward` / `done` / `terminated` (shape `[*B, T, 1]`) across the agent dim before the vec-GAE recursion, so users don't have to manually replicate signals or override `set_keys`. New `ValueEstimators.MAGAE` enum entry.
- **`torchrl.modules.ValueNorm`** — PopArt-style running value normaliser (van Hasselt et al. 2019), used opt-in by `MAPPOLoss`. Yu et al. 2022 Table 13 credits this trick with the algorithm's strong SMAC results.

## Design notes

**Two classes instead of a `centralized: bool` flag.** The structural code difference between MAPPO and IPPO is small (~20 lines), but I made them separate named classes rather than a single class with a flag because:
- The recent feedback on (HER) was explicit about avoiding wrapper-in-wrapper / "sampler-in-sampler" APIs. A boolean flag on a single class is the same pattern shifted to losses.
- `from torchrl.objectives.multiagent import MAPPOLoss` is self-documenting; the docstring spells out the full recipe (centralised critic construction, etc.) for each algorithm independently.

**MAGAE dispatch in plain PPO / A2C / Reinforce.** Adding `ValueEstimators.MAGAE` to the enum would break every parent test that parametrises over `list(ValueEstimators)` unless every `make_value_estimator` knows the new enum value. Two options: (a) update ~29 test parametrisations to skip MAGAE, or (b) have plain PPO / A2C / Reinforce dispatch MAGAE to `MultiAgentGAE`. I went with (b) — it's ~5 lines per file, leaves the enum exhaustive, and is the right thing semantically (any actor-critic with the right data shapes can use MAGAE).

**ValueNorm placement.** Lives under `torchrl/modules/` rather than `torchrl/objectives/utils/` because it's a stateful learnable component that participates in `.to(device)` / `state_dict()`. Happy to move if reviewers prefer otherwise.

## Out of scope (follow-up)

- HAPPO / sequential update scheme (Kuba et al. 2022)
- Multi-Agent Transformer (MAT)
- Refactoring `sota-implementations/multiagent/mappo_ippo.py` to use the new classes — left untouched in this PR to keep the blast radius small; can be a one-line follow-up.

## Verification

- `pytest test/objectives/test_mappo.py` — 16/16 passing. Synthetic-tensordict tests for forward shapes, backward, centralised-vs-decentralised critic semantics, share-params modes, ValueNorm convergence, and critic-loss bounded-ness under 10× reward inflation.
- `pytest test/test_cost.py -k "ppo or qmixer or a2c or reinforce"` — 2394/2394 passing (no regressions).
- Full `test_cost.py` — 8788 passing, 1 pre-existing unrelated failure (`test_exploration_compile` — `torch.compile` + `torch.utils.mkldnn` deprecation, no MAPPO involvement).
- `examples/multiagent/mappo_vmas.py --algo mappo --frames 200_000` provides a minimal end-to-end smoke recipe on VMAS Navigation.

cc @matteobettini 