### PR TITLE
[Performance] LSTM/GRU scan: canonical strides + cuDNN flat-storage clones + thread-local recurrent mode

### DIFF
--- a/test/modules/test_rnn.py
+++ b/test/modules/test_rnn.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import functools
 import sys
+import threading
 
 import pytest
 import torch
@@ -45,12 +46,14 @@ from torchrl.modules import (
     MLP,
     ProbabilisticActor,
     set_recurrent_mode,
+    ValueOperator,
 )
 from torchrl.modules.utils import (
     get_env_transforms_from_module,
     get_primers_from_module,
 )
 from torchrl.modules.utils.utils import _compute_missing_env_transforms
+from torchrl.objectives.value.advantages import GAE
 
 from torchrl.testing import get_default_devices
 from torchrl.testing.mocking_classes import CountingEnv, DiscreteActionVecMockEnv
@@ -371,6 +374,26 @@ class TestLSTMModule:
                 assert not lstm_module.recurrent_mode
             assert lstm_module.recurrent_mode
         assert lstm_module.recurrent_mode is bool(default_val)
+
+    def test_set_recurrent_mode_is_thread_local(self):
+        lstm_module = LSTMModule(
+            input_size=3,
+            hidden_size=12,
+            batch_first=True,
+            in_keys=["observation", "hidden0", "hidden1"],
+            out_keys=["intermediate", ("next", "hidden0"), ("next", "hidden1")],
+        )
+        values = []
+
+        def worker():
+            values.append(lstm_module.recurrent_mode)
+
+        with set_recurrent_mode(True):
+            thread = threading.Thread(target=worker)
+            thread.start()
+            thread.join()
+            assert lstm_module.recurrent_mode
+        assert values == [False]
 
     def test_python_cudnn(self):
         lstm_module = LSTMModule(
@@ -1212,6 +1235,365 @@ class TestLSTMModule:
             torch.testing.assert_close(
                 pad_out[key], triton_out[key], atol=5e-3, rtol=5e-3
             )
+
+    @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
+    @pytest.mark.parametrize("backend", ["scan", "triton"])
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.6.0"),
+        reason="torch._higher_order_ops.scan requires Torch >= 2.6.0",
+    )
+    def test_lstm_module_backends_non_contiguous_recurrent_inputs(self, backend):
+        torch.manual_seed(0)
+        device = torch.device("cuda")
+        B, T, F, H, L = 4, 6, 3, 8, 1
+        kwargs = {
+            "input_size": F,
+            "hidden_size": H,
+            "num_layers": L,
+            "in_keys": ["obs", "hidden0", "hidden1"],
+            "out_keys": ["feat", ("next", "hidden0"), ("next", "hidden1")],
+            "device": device,
+        }
+        pad_module = LSTMModule(**kwargs)
+        module = LSTMModule(**kwargs, recurrent_backend=backend)
+        module.load_state_dict(pad_module.state_dict())
+
+        obs_source = torch.randn(T, B, F, device=device)
+        hidden0_source = torch.randn(T, B, L, H, device=device)
+        hidden1_source = torch.randn(T, B, L, H, device=device)
+        is_init_source = torch.zeros(T, B, 1, dtype=torch.bool, device=device)
+        is_init_source[0] = True
+        is_init_source[2, 1] = True
+        is_init_source[4, 3] = True
+
+        def make_data():
+            obs_base = obs_source.detach().clone().requires_grad_()
+            hidden0_base = hidden0_source.detach().clone().requires_grad_()
+            hidden1_base = hidden1_source.detach().clone().requires_grad_()
+            obs = obs_base.transpose(0, 1)
+            hidden0 = hidden0_base.transpose(0, 1)
+            hidden1 = hidden1_base.transpose(0, 1)
+            is_init = is_init_source.transpose(0, 1)
+            assert not obs.is_contiguous()
+            assert not is_init.is_contiguous()
+            return (
+                TensorDict(
+                    {
+                        "obs": obs,
+                        "hidden0": hidden0,
+                        "hidden1": hidden1,
+                        "is_init": is_init,
+                    },
+                    [B, T],
+                ),
+                obs_base,
+                hidden0_base,
+                hidden1_base,
+            )
+
+        pad_data, pad_obs, pad_hidden0, pad_hidden1 = make_data()
+        data, obs, hidden0, hidden1 = make_data()
+        with set_recurrent_mode(True):
+            pad_out = pad_module(pad_data)
+            out = module(data)
+
+        tol = 5e-3
+        for key in ["feat", ("next", "hidden0"), ("next", "hidden1")]:
+            torch.testing.assert_close(pad_out[key], out[key], atol=tol, rtol=tol)
+
+        pad_out["feat"].square().mean().backward()
+        out["feat"].square().mean().backward()
+        torch.testing.assert_close(pad_obs.grad, obs.grad, atol=tol, rtol=tol)
+        torch.testing.assert_close(pad_hidden0.grad, hidden0.grad, atol=tol, rtol=tol)
+        torch.testing.assert_close(pad_hidden1.grad, hidden1.grad, atol=tol, rtol=tol)
+        for (_, pad_param), (_, param) in zip(
+            pad_module.named_parameters(), module.named_parameters()
+        ):
+            torch.testing.assert_close(pad_param.grad, param.grad, atol=tol, rtol=tol)
+
+    def test_canonical_contiguous_helper(self):
+        # _canonical_contiguous must be a no-op when the input strides match
+        # the C-canonical layout, and must materialize a fresh canonical
+        # tensor when they don't (the size-1-dim quirk).
+        from torchrl.modules.tensordict_module.rnn import (
+            _canonical_contiguous,
+            _canonical_stride,
+        )
+
+        canonical = torch.randn(3, 4, 5)
+        assert _canonical_stride(canonical.shape) == (20, 5, 1)
+        out = _canonical_contiguous(canonical)
+        assert out.data_ptr() == canonical.data_ptr()
+
+        # A [1, 4, 5] tensor with strides (5, 5, 1) passes is_contiguous()
+        # (size-1 leading dim makes stride[0] irrelevant for that check)
+        # but is not canonical — canonical would be (20, 5, 1).
+        weird = torch.empty_strided((1, 4, 5), (5, 5, 1))
+        weird.copy_(torch.randn(1, 4, 5))
+        assert weird.is_contiguous()
+        assert tuple(weird.stride()) != _canonical_stride(weird.shape)
+        out = _canonical_contiguous(weird)
+        assert out.data_ptr() != weird.data_ptr()
+        assert tuple(out.stride()) == _canonical_stride(out.shape)
+        torch.testing.assert_close(out, weird)
+
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.6.0"),
+        reason="torch._higher_order_ops.scan requires Torch >= 2.6.0",
+    )
+    def test_lstm_module_scan_compile_no_aliasing(self):
+        # Under torch.compile, scan's HOP tracer walks the FakeTensor graph
+        # and rejects shared storage on inputs. nn.LSTM with cuDNN flattens
+        # its parameters into a single storage, so the per-layer weight
+        # views alias each other — `_lstm_scan_with_resets` must clone
+        # them before closing the scan body over them. This test pins
+        # that contract so the clones are not silently removed again.
+        torch.manual_seed(0)
+        B, T, F_in, H, L = 4, 6, 3, 8, 1
+        scan_module = LSTMModule(
+            input_size=F_in,
+            hidden_size=H,
+            num_layers=L,
+            in_keys=["obs", "hidden0", "hidden1"],
+            out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
+            recurrent_backend="scan",
+        )
+
+        obs = torch.randn(B, T, F_in)
+        hidden0 = torch.zeros(B, T, L, H)
+        hidden1 = torch.zeros(B, T, L, H)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool)
+        is_init[:, 0] = True
+        data = TensorDict(
+            {"obs": obs, "hidden0": hidden0, "hidden1": hidden1, "is_init": is_init},
+            [B, T],
+        )
+
+        prev = torch._dynamo.config.capture_scalar_outputs
+        torch._dynamo.config.capture_scalar_outputs = True
+        try:
+
+            @torch.compile(fullgraph=False)
+            def call(td):
+                with set_recurrent_mode(True):
+                    return scan_module(td)
+
+            with torch.no_grad():
+                out = call(data.clone())
+        finally:
+            torch._dynamo.config.capture_scalar_outputs = prev
+        assert "feat" in out.keys(True, True)
+
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.6.0"),
+        reason="torch._higher_order_ops.scan requires Torch >= 2.6.0",
+    )
+    def test_gru_module_scan_compile_no_aliasing(self):
+        torch.manual_seed(0)
+        B, T, F_in, H, L = 4, 6, 3, 8, 1
+        scan_module = GRUModule(
+            input_size=F_in,
+            hidden_size=H,
+            num_layers=L,
+            in_keys=["obs", "hidden"],
+            out_keys=["feat", ("next", "hidden")],
+            recurrent_backend="scan",
+        )
+
+        obs = torch.randn(B, T, F_in)
+        hidden = torch.zeros(B, T, L, H)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool)
+        is_init[:, 0] = True
+        data = TensorDict(
+            {"obs": obs, "hidden": hidden, "is_init": is_init},
+            [B, T],
+        )
+
+        prev = torch._dynamo.config.capture_scalar_outputs
+        torch._dynamo.config.capture_scalar_outputs = True
+        try:
+
+            @torch.compile(fullgraph=False)
+            def call(td):
+                with set_recurrent_mode(True):
+                    return scan_module(td)
+
+            with torch.no_grad():
+                out = call(data.clone())
+        finally:
+            torch._dynamo.config.capture_scalar_outputs = prev
+        assert "feat" in out.keys(True, True)
+
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.6.0"),
+        reason="torch._higher_order_ops.scan requires Torch >= 2.6.0",
+    )
+    def test_lstm_module_three_backends_ppo_advantage_parity(self):
+        # End-to-end pin: feeding the LSTM output through a value head and
+        # GAE should produce identical advantages across all backends. The
+        # existing three_backends_equivalent test already pins feat and the
+        # per-step hidden tensors; this test pins the downstream PPO
+        # contract so a regression in either step is caught.
+        torch.manual_seed(0)
+        B, T, F_in, H, L = 4, 7, 3, 16, 1
+        kwargs = {
+            "input_size": F_in,
+            "hidden_size": H,
+            "num_layers": L,
+            "in_keys": ["obs", "hidden0", "hidden1"],
+            "out_keys": ["feat", ("next", "hidden0"), ("next", "hidden1")],
+        }
+        pad_module = LSTMModule(**kwargs)
+        scan_module = LSTMModule(**kwargs, recurrent_backend="scan")
+        scan_module.load_state_dict(pad_module.state_dict())
+        critic = ValueOperator(nn.Linear(H, 1), in_keys=["feat"])
+
+        obs = torch.randn(B, T, F_in)
+        hidden0 = torch.zeros(B, T, L, H)
+        hidden1 = torch.zeros(B, T, L, H)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool)
+        is_init[:, 0] = True
+        is_init[1, 3] = True
+        is_init[2, 5] = True
+        reward = torch.randn(B, T, 1)
+        done = torch.zeros(B, T, 1, dtype=torch.bool)
+        done[1, 2] = True
+        done[2, 4] = True
+        terminated = done.clone()
+        next_obs = torch.randn(B, T, F_in)
+        data = TensorDict(
+            {
+                "obs": obs,
+                "hidden0": hidden0,
+                "hidden1": hidden1,
+                "is_init": is_init,
+                "next": TensorDict(
+                    {
+                        "obs": next_obs,
+                        "reward": reward,
+                        "done": done,
+                        "terminated": terminated,
+                    },
+                    [B, T],
+                ),
+            },
+            [B, T],
+        )
+
+        def pipeline(lstm_module, td):
+            with set_recurrent_mode(True), torch.no_grad():
+                td = lstm_module(td)
+                td = critic(td)
+                # Mirror critic onto ("next", "state_value") so GAE has the
+                # bootstrap term it expects.
+                next_td = td["next"].clone()
+                next_td["feat"] = td["feat"]  # placeholder; critic just needs feat
+                # use the actual next_feat via a single re-call on next obs
+                next_lstm_in = TensorDict(
+                    {
+                        "obs": td["next", "obs"],
+                        "hidden0": td["next", "hidden0"],
+                        "hidden1": td["next", "hidden1"],
+                        "is_init": td["is_init"],
+                    },
+                    td.batch_size,
+                )
+                next_lstm_out = lstm_module(next_lstm_in)
+                next_state_value = critic(
+                    TensorDict({"feat": next_lstm_out["feat"]}, td.batch_size)
+                )["state_value"]
+                td["next", "state_value"] = next_state_value
+                gae = GAE(
+                    gamma=0.99,
+                    lmbda=0.95,
+                    value_network=None,
+                    average_gae=False,
+                    shifted=False,
+                )
+                gae(td)
+            return td["advantage"], td["value_target"], td["state_value"]
+
+        adv_pad, vt_pad, val_pad = pipeline(pad_module, data.clone())
+        adv_scan, vt_scan, val_scan = pipeline(scan_module, data.clone())
+        torch.testing.assert_close(val_pad, val_scan, atol=5e-3, rtol=5e-3)
+        torch.testing.assert_close(adv_pad, adv_scan, atol=5e-3, rtol=5e-3)
+        torch.testing.assert_close(vt_pad, vt_scan, atol=5e-3, rtol=5e-3)
+
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.6.0"),
+        reason="torch._higher_order_ops.scan requires Torch >= 2.6.0",
+    )
+    def test_lstm_module_scan_non_canonical_hidden_strides(self):
+        # Hidden buffers whose strides pass is_contiguous() but disagree with
+        # the canonical row-major layout (the size-1-dim quirk that bit the
+        # Isaac PPO run) must not break the scan backend.
+        torch.manual_seed(0)
+        B, T, F, H, L = 4, 6, 3, 8, 1
+        kwargs = {
+            "input_size": F,
+            "hidden_size": H,
+            "num_layers": L,
+            "in_keys": ["obs", "hidden0", "hidden1"],
+            "out_keys": ["feat", ("next", "hidden0"), ("next", "hidden1")],
+        }
+        pad_module = LSTMModule(**kwargs)
+        scan_module = LSTMModule(**kwargs, recurrent_backend="scan")
+        scan_module.load_state_dict(pad_module.state_dict())
+
+        obs = torch.randn(B, T, F)
+        # Build a [B, T, L, H] hidden buffer whose internal [..., 0, :, :]
+        # slice then transpose(-3, -2) yields a [L, B, H] view that
+        # is_contiguous() but has non-canonical strides. The same buffer
+        # shape PPO uses; the stride layout matters more than the values.
+        canonical_h = torch.zeros(B, T, L, H)
+        h_storage = torch.randn(B * L * H)
+        # Lay out so that hidden_buf[:, 0] -> [B, L, H] indexing then
+        # transposing yields the size-1-dim non-canonical stride pattern.
+        hidden_buf = torch.empty_strided((B, T, L, H), (L * H, L * H, H, 1))
+        hidden_buf.zero_()
+        hidden_buf[:, 0] = h_storage.view(B, L, H)
+        # sanity check that the runtime path does see a non-canonical view
+        probe = hidden_buf[:, 0].transpose(-3, -2)
+        assert probe.is_contiguous()
+        from torchrl.modules.tensordict_module.rnn import _canonical_stride
+
+        assert tuple(probe.stride()) != _canonical_stride(probe.shape)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool)
+        is_init[:, 0] = True
+        data = TensorDict(
+            {
+                "obs": obs,
+                "hidden0": hidden_buf,
+                "hidden1": hidden_buf.clone().contiguous(),
+                "is_init": is_init,
+            },
+            [B, T],
+        )
+        canonical_data = TensorDict(
+            {
+                "obs": obs,
+                "hidden0": canonical_h.clone(),
+                "hidden1": canonical_h.clone(),
+                "is_init": is_init.clone(),
+            },
+            [B, T],
+        )
+        canonical_data["hidden0"][:, 0] = h_storage.view(B, L, H)
+        canonical_data["hidden1"][:, 0] = canonical_data["hidden0"][:, 0]
+
+        with set_recurrent_mode(True), torch.no_grad():
+            pad_out = pad_module(canonical_data.clone())
+            # The weird-stride buffer must not crash scan, and must produce
+            # the same outputs as the canonical-stride buffer with matching
+            # values.
+            scan_out = scan_module(data.clone())
+        torch.testing.assert_close(pad_out["feat"], scan_out["feat"])
+        torch.testing.assert_close(
+            pad_out["next", "hidden0"], scan_out["next", "hidden0"]
+        )
+        torch.testing.assert_close(
+            pad_out["next", "hidden1"], scan_out["next", "hidden1"]
+        )
 
 
 class TestGRUModule:
@@ -2104,6 +2486,120 @@ class TestGRUModule:
             torch.testing.assert_close(
                 pad_out[key], triton_out[key], atol=5e-3, rtol=5e-3
             )
+
+    @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
+    @pytest.mark.parametrize("backend", ["scan", "triton"])
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.6.0"),
+        reason="torch._higher_order_ops.scan requires Torch >= 2.6.0",
+    )
+    def test_gru_module_backends_non_contiguous_recurrent_inputs(self, backend):
+        torch.manual_seed(0)
+        device = torch.device("cuda")
+        B, T, F, H, L = 4, 6, 3, 8, 1
+        kwargs = {
+            "input_size": F,
+            "hidden_size": H,
+            "num_layers": L,
+            "in_keys": ["obs", "hidden"],
+            "out_keys": ["feat", ("next", "hidden")],
+            "device": device,
+        }
+        pad_module = GRUModule(**kwargs)
+        module = GRUModule(**kwargs, recurrent_backend=backend)
+        module.load_state_dict(pad_module.state_dict())
+
+        obs_source = torch.randn(T, B, F, device=device)
+        hidden_source = torch.randn(T, B, L, H, device=device)
+        is_init_source = torch.zeros(T, B, 1, dtype=torch.bool, device=device)
+        is_init_source[0] = True
+        is_init_source[2, 1] = True
+        is_init_source[4, 3] = True
+
+        def make_data():
+            obs_base = obs_source.detach().clone().requires_grad_()
+            hidden_base = hidden_source.detach().clone().requires_grad_()
+            obs = obs_base.transpose(0, 1)
+            hidden = hidden_base.transpose(0, 1)
+            is_init = is_init_source.transpose(0, 1)
+            assert not obs.is_contiguous()
+            assert not is_init.is_contiguous()
+            return (
+                TensorDict(
+                    {"obs": obs, "hidden": hidden, "is_init": is_init},
+                    [B, T],
+                ),
+                obs_base,
+                hidden_base,
+            )
+
+        pad_data, pad_obs, pad_hidden = make_data()
+        data, obs, hidden = make_data()
+        with set_recurrent_mode(True):
+            pad_out = pad_module(pad_data)
+            out = module(data)
+
+        tol = 5e-3
+        for key in ["feat", ("next", "hidden")]:
+            torch.testing.assert_close(pad_out[key], out[key], atol=tol, rtol=tol)
+
+        pad_out["feat"].square().mean().backward()
+        out["feat"].square().mean().backward()
+        torch.testing.assert_close(pad_obs.grad, obs.grad, atol=tol, rtol=tol)
+        torch.testing.assert_close(pad_hidden.grad, hidden.grad, atol=tol, rtol=tol)
+        for (_, pad_param), (_, param) in zip(
+            pad_module.named_parameters(), module.named_parameters()
+        ):
+            torch.testing.assert_close(pad_param.grad, param.grad, atol=tol, rtol=tol)
+
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.6.0"),
+        reason="torch._higher_order_ops.scan requires Torch >= 2.6.0",
+    )
+    def test_gru_module_scan_non_canonical_hidden_strides(self):
+        # GRU counterpart of test_lstm_module_scan_non_canonical_hidden_strides.
+        torch.manual_seed(0)
+        B, T, F, H, L = 4, 6, 3, 8, 1
+        kwargs = {
+            "input_size": F,
+            "hidden_size": H,
+            "num_layers": L,
+            "in_keys": ["obs", "hidden"],
+            "out_keys": ["feat", ("next", "hidden")],
+        }
+        pad_module = GRUModule(**kwargs)
+        scan_module = GRUModule(**kwargs, recurrent_backend="scan")
+        scan_module.load_state_dict(pad_module.state_dict())
+
+        obs = torch.randn(B, T, F)
+        h_storage = torch.randn(B * L * H)
+        hidden_buf = torch.empty_strided((B, T, L, H), (L * H, L * H, H, 1))
+        hidden_buf.zero_()
+        hidden_buf[:, 0] = h_storage.view(B, L, H)
+        probe = hidden_buf[:, 0].transpose(-3, -2)
+        assert probe.is_contiguous()
+        from torchrl.modules.tensordict_module.rnn import _canonical_stride
+
+        assert tuple(probe.stride()) != _canonical_stride(probe.shape)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool)
+        is_init[:, 0] = True
+        canonical_h = torch.zeros(B, T, L, H)
+        canonical_h[:, 0] = h_storage.view(B, L, H)
+        canonical_data = TensorDict(
+            {"obs": obs, "hidden": canonical_h, "is_init": is_init.clone()},
+            [B, T],
+        )
+        data = TensorDict(
+            {"obs": obs, "hidden": hidden_buf, "is_init": is_init},
+            [B, T],
+        )
+        with set_recurrent_mode(True), torch.no_grad():
+            pad_out = pad_module(canonical_data.clone())
+            scan_out = scan_module(data.clone())
+        torch.testing.assert_close(pad_out["feat"], scan_out["feat"])
+        torch.testing.assert_close(
+            pad_out["next", "hidden"], scan_out["next", "hidden"]
+        )
 
 
 def test_get_primers_from_module():

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -2461,10 +2461,17 @@ class _RecurrentModeContextManager(_ContextManager):
         )
 
     def get_mode(self) -> bool | None:
+        # Dynamo can't trace ContextVar.get; fall back to the parent's plain
+        # attribute under torch.compile. set_mode keeps both in sync so this
+        # stays correct (compile traces a single thread).
+        if is_compiling():
+            return self._mode
         return self._context_mode.get()
 
     def set_mode(self, mode: bool | None) -> None:
-        self._context_mode.set(mode)
+        self._mode = mode
+        if not is_compiling():
+            self._context_mode.set(mode)
 
 
 recurrent_mode_state_manager = _RecurrentModeContextManager()

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -1119,6 +1119,13 @@ class LSTMModule(ModuleBase):
 
         layer_input = _canonical_contiguous(input)
         is_init = _canonical_contiguous(is_init)
+        # Canonicalize the full hidden buffers once. For num_layers=1
+        # (the common RL case) per-layer slicing then yields a canonical
+        # view for free; for num_layers>=2 adjacent layers are interleaved
+        # in the parent so per-layer slices still need a re-materialize
+        # below.
+        hidden0_in = _canonical_contiguous(hidden0_in)
+        hidden1_in = _canonical_contiguous(hidden1_in)
         hidden0_layers = []
         hidden1_layers = []
         for layer in range(self.lstm.num_layers):
@@ -2273,6 +2280,10 @@ class GRUModule(ModuleBase):
 
         layer_input = _canonical_contiguous(input)
         is_init = _canonical_contiguous(is_init)
+        # Canonicalize the full hidden buffer once; per-layer slices are
+        # canonical for free for num_layers=1, still need the re-materialize
+        # below for num_layers>=2 (adjacent layers interleaved in memory).
+        hidden_in = _canonical_contiguous(hidden_in)
         hidden_layers = []
         for layer in range(self.gru.num_layers):
             weights = self.gru._all_weights[layer]

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import contextvars
 import importlib.metadata
 import typing
 from typing import Any
@@ -55,6 +56,28 @@ def _check_triton_available() -> bool:
 
 
 _has_triton = _check_triton_available()
+
+
+def _canonical_stride(shape: typing.Sequence[int]) -> tuple[int, ...]:
+    strides: list[int] = []
+    running = 1
+    for size in reversed(shape):
+        strides.append(running)
+        running *= size
+    strides.reverse()
+    return tuple(strides)
+
+
+def _canonical_contiguous(value: Tensor) -> Tensor:
+    # torch._higher_order_ops.scan and the triton RNN kernels read strides
+    # directly and reject inputs whose strides don't match the canonical
+    # row-major layout. A size-1 dim left behind by indexing+transposing a
+    # hidden-state buffer can pass is_contiguous() while having non-canonical
+    # strides — re-materialize then.
+    if tuple(value.stride()) == _canonical_stride(value.shape):
+        return value
+    result = torch.empty_like(value, memory_format=torch.contiguous_format)
+    return result.copy_(value)
 
 
 @implement_for("torch", None, "2.6.0", compilable=True)
@@ -1029,8 +1052,8 @@ class LSTMModule(ModuleBase):
         _hidden0_in = hidden0_in[..., 0, :, :]
         _hidden1_in = hidden1_in[..., 0, :, :]
         hidden = (
-            _hidden0_in.transpose(-3, -2).contiguous(),
-            _hidden1_in.transpose(-3, -2).contiguous(),
+            _canonical_contiguous(_hidden0_in.transpose(-3, -2)),
+            _canonical_contiguous(_hidden1_in.transpose(-3, -2)),
         )
 
         if is_init is not None and backend == "triton":
@@ -1094,7 +1117,8 @@ class LSTMModule(ModuleBase):
                 "Triton LSTM layer composition expects unidirectional weights."
             )
 
-        layer_input = input
+        layer_input = _canonical_contiguous(input)
+        is_init = _canonical_contiguous(is_init)
         hidden0_layers = []
         hidden1_layers = []
         for layer in range(self.lstm.num_layers):
@@ -1110,8 +1134,8 @@ class LSTMModule(ModuleBase):
                 b_ih = zeros if b_ih is None else b_ih
                 b_hh = zeros if b_hh is None else b_hh
 
-            hidden_per_step = hidden0_in[..., layer, :]
-            cell_per_step = hidden1_in[..., layer, :]
+            hidden_per_step = _canonical_contiguous(hidden0_in[..., layer, :])
+            cell_per_step = _canonical_contiguous(hidden1_in[..., layer, :])
 
             h_steps, c_steps, _, _ = lstm_triton(
                 layer_input,
@@ -1225,6 +1249,13 @@ class LSTMModule(ModuleBase):
                 "LSTMModule(recurrent_backend='scan') does not support bidirectional LSTMs yet."
             )
 
+        # nn.LSTM with cuDNN flattens its parameters: weight_ih_l*,
+        # weight_hh_l*, bias_ih_l*, bias_hh_l* are views into a single
+        # flat storage. Closing the scan body over them as-is fails with
+        # "input-to-input aliasing" under torch.compile (the HOP tracer
+        # walks the FakeTensor graph and rejects shared storage on inputs).
+        # Cloning produces independent allocations; gradients still flow
+        # back to the parameters.
         weight_ihs, weight_hhs, bias_ihs, bias_hhs = [], [], [], []
         for layer in range(self.lstm.num_layers):
             weights = self.lstm._all_weights[layer]
@@ -1237,10 +1268,14 @@ class LSTMModule(ModuleBase):
                 getattr(self.lstm, weights[3]).clone() if self.lstm.bias else None
             )
 
-        input = input.transpose(0, 1)
-        is_init = is_init.transpose(0, 1)
-        reset_hidden0 = hidden0_in.transpose(0, 1).transpose(-3, -2).contiguous()
-        reset_hidden1 = hidden1_in.transpose(0, 1).transpose(-3, -2).contiguous()
+        input = _canonical_contiguous(input.transpose(0, 1))
+        is_init = _canonical_contiguous(is_init.transpose(0, 1))
+        reset_hidden0 = _canonical_contiguous(
+            hidden0_in.transpose(0, 1).transpose(-3, -2)
+        )
+        reset_hidden1 = _canonical_contiguous(
+            hidden1_in.transpose(0, 1).transpose(-3, -2)
+        )
         num_layers = self.lstm.num_layers
 
         def step(carry, inputs):
@@ -1266,8 +1301,14 @@ class LSTMModule(ModuleBase):
                 new_h.append(h_new)
                 new_c.append(c_new)
                 x_t = h_new
-            new_h = torch.stack(new_h, 0).clone()
-            new_c = torch.stack(new_c, 0).clone()
+            # torch.stack already allocates a fresh tensor, so the carry
+            # outputs need no extra clone. The per-step outputs are derived
+            # from the carry via view-style ops (transpose+flatten), which
+            # scan's HOP tracer treats as aliasing the carry even though
+            # they copy at runtime — clone these and x_t (which aliases the
+            # last layer's pre-stack hidden) to break the aliasing edge.
+            new_h = torch.stack(new_h, 0)
+            new_c = torch.stack(new_c, 0)
             hidden0_out = new_h.transpose(0, 1).flatten(1).clone()
             hidden1_out = new_c.transpose(0, 1).flatten(1).clone()
             return (new_h, new_c), (x_t.clone(), hidden0_out, hidden1_out)
@@ -2179,7 +2220,7 @@ class GRUModule(ModuleBase):
 
         # we only need the first hidden state
         _hidden_in = hidden_in[:, 0]
-        hidden = _hidden_in.transpose(-3, -2).contiguous()
+        hidden = _canonical_contiguous(_hidden_in.transpose(-3, -2))
 
         if is_init is not None and backend == "triton":
             return self._gru_triton_with_resets(input, hidden_in, is_init)
@@ -2230,7 +2271,8 @@ class GRUModule(ModuleBase):
                 "Triton GRU layer composition expects unidirectional weights."
             )
 
-        layer_input = input
+        layer_input = _canonical_contiguous(input)
+        is_init = _canonical_contiguous(is_init)
         hidden_layers = []
         for layer in range(self.gru.num_layers):
             weights = self.gru._all_weights[layer]
@@ -2245,7 +2287,7 @@ class GRUModule(ModuleBase):
                 b_ih = zeros if b_ih is None else b_ih
                 b_hh = zeros if b_hh is None else b_hh
 
-            hidden_per_step = hidden_in[..., layer, :]
+            hidden_per_step = _canonical_contiguous(hidden_in[..., layer, :])
             h_steps, _ = gru_triton(
                 layer_input,
                 hidden_per_step,
@@ -2334,6 +2376,9 @@ class GRUModule(ModuleBase):
                 "GRUModule(recurrent_backend='scan') does not support bidirectional GRUs yet."
             )
 
+        # See _lstm_scan_with_resets: cuDNN flattens GRU parameters into a
+        # single storage, so the views alias each other and the scan tracer
+        # rejects them as inputs. Cloning produces independent allocations.
         weight_ihs, weight_hhs, bias_ihs, bias_hhs = [], [], [], []
         for layer in range(self.gru.num_layers):
             weights = self.gru._all_weights[layer]
@@ -2346,9 +2391,9 @@ class GRUModule(ModuleBase):
                 getattr(self.gru, weights[3]).clone() if self.gru.bias else None
             )
 
-        input = input.transpose(0, 1)
-        is_init = is_init.transpose(0, 1)
-        reset_hidden = hidden_in.permute(1, 2, 0, 3).contiguous()
+        input = _canonical_contiguous(input.transpose(0, 1))
+        is_init = _canonical_contiguous(is_init.transpose(0, 1))
+        reset_hidden = _canonical_contiguous(hidden_in.permute(1, 2, 0, 3))
         num_layers = self.gru.num_layers
 
         def step(carry, inputs):
@@ -2369,9 +2414,12 @@ class GRUModule(ModuleBase):
                 )
                 new_h.append(h_new)
                 x_t = h_new
-            # scan returns both carry and per-step outputs; clone to avoid
-            # aliasing between those two pytrees under torch.compile.
-            new_h = torch.stack(new_h, 0).clone()
+            # torch.stack allocates a fresh tensor, so the carry needs no
+            # extra clone. The per-step output is derived from the carry
+            # via transpose+flatten (view-style at the HOP tracer level
+            # even though it copies at runtime) — clone it and x_t to
+            # break the carry/output aliasing scan would otherwise flag.
+            new_h = torch.stack(new_h, 0)
             hidden_out = new_h.transpose(0, 1).flatten(1).clone()
             return new_h, (x_t.clone(), hidden_out)
 
@@ -2394,7 +2442,21 @@ class GRUModule(ModuleBase):
 
 
 # Recurrent mode manager
-recurrent_mode_state_manager = _ContextManager()
+class _RecurrentModeContextManager(_ContextManager):
+    def __init__(self):
+        super().__init__()
+        self._context_mode = contextvars.ContextVar(
+            "torchrl_recurrent_mode", default=None
+        )
+
+    def get_mode(self) -> bool | None:
+        return self._context_mode.get()
+
+    def set_mode(self, mode: bool | None) -> None:
+        self._context_mode.set(mode)
+
+
+recurrent_mode_state_manager = _RecurrentModeContextManager()
 
 
 def recurrent_mode() -> bool | None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3776
* #3775
* #3769
* #3763
* #3771
* #3768
* #3767
* #3764
* #3759
* #3757
* #3762
* #3755
* __->__ #3754
* #3753

Three intertwined fixes to the scan / triton recurrent backends.

- Canonical-stride check. A `[1, 4, 5]` tensor with strides `(5, 5, 1)`
  passes `is_contiguous()` but `torch._higher_order_ops.scan` and the
  triton kernels read strides directly and reject non-canonical layouts.
  Add `_canonical_stride` + `_canonical_contiguous` and re-materialize
  inputs / hidden buffers when strides drift off the C-canonical layout.

- cuDNN flat-storage aliasing. `nn.LSTM` / `nn.GRU` with cuDNN flatten
  all per-layer parameters into a single storage; the scan HOP tracer
  walks the FakeTensor graph and rejects the aliased per-layer views as
  inputs. Clone the weight views before closing the scan body. The
  per-layer carry now also clones `x_t` and the transpose+flatten output
  (the only remaining aliasing edge) so the existing `.clone()` on the
  full `torch.stack(...)` carry can drop.

- Thread-local `recurrent_mode`. `_ContextManager` was a single mutable
  module-level flag, so spawning a collector worker thread saw the
  parent's recurrent_mode setting. Wrap in `_RecurrentModeContextManager`
  using `contextvars.ContextVar` so per-thread state is isolated.

Tests cover: `_canonical_contiguous` no-op vs re-materialize, scan/triton
output parity under non-canonical strides, scan-under-torch.compile
aliasing pin for both LSTM and GRU, LSTM scan/pad PPO-advantage parity,
non-canonical hidden-buffer regression for scan, and a thread-local
`set_recurrent_mode` test.