### PR TITLE
[Feature] Add ActionScaling transform (part 1 of #1209)

### DIFF
--- a/docs/source/reference/envs_transforms.rst
+++ b/docs/source/reference/envs_transforms.rst
@@ -247,6 +247,7 @@ Available Transforms
     TransformedEnv
     ActionDiscretizer
     ActionMask
+    ActionScaling
     AutoResetEnv
     AutoResetTransform
     BatchSizeTransform

--- a/test/transforms/test_action_transforms.py
+++ b/test/transforms/test_action_transforms.py
@@ -824,6 +824,58 @@ class TestActionScaling(TransformBase):
         assert (r["action"] >= -1.0).all()
         assert (r["action"] <= 1.0).all()
 
+    def test_nested_action_key(self):
+        # Verify that ActionScaling rewrites the spec and applies the inv
+        # transform for dict-structured action spaces (issue #1209).
+        class _NestedActionEnv(EnvBase):
+            def __init__(self):
+                super().__init__()
+                self.action_spec = Composite(
+                    {("agent", "action"): Bounded(low=-2.0, high=4.0, shape=(7,))}
+                )
+                self.observation_spec = Composite(observation=Unbounded(shape=(4,)))
+                self.reward_spec = Unbounded(shape=(1,))
+                self.full_done_spec = Composite(
+                    done=Categorical(2, shape=(1,), dtype=torch.bool),
+                    terminated=Categorical(2, shape=(1,), dtype=torch.bool),
+                )
+                self.last_action = None
+
+            def _reset(self, tensordict=None):
+                out = TensorDict({}, batch_size=[])
+                out.update(self.observation_spec.zero())
+                out.update(self.full_done_spec.zero())
+                return out
+
+            def _step(self, tensordict):
+                self.last_action = tensordict["agent", "action"].clone()
+                out = TensorDict({}, batch_size=[])
+                out.update(self.observation_spec.zero())
+                out.update(self.full_done_spec.zero())
+                out["reward"] = self.reward_spec.zero()
+                return out
+
+            def _set_seed(self, seed):
+                pass
+
+        base_env = _NestedActionEnv()
+        env = TransformedEnv(base_env, ActionScaling(in_keys_inv=[("agent", "action")]))
+        leaf = env.full_action_spec[("agent", "action")]
+        assert torch.allclose(leaf.space.low, -torch.ones(7))
+        assert torch.allclose(leaf.space.high, torch.ones(7))
+
+        td = env.reset()
+        td["agent", "action"] = torch.ones(7)
+        env.step(td)
+        # normalized +1 -> env-scale +4 (high)
+        assert torch.allclose(base_env.last_action, torch.full((7,), 4.0))
+
+        td = env.reset()
+        td["agent", "action"] = -torch.ones(7)
+        env.step(td)
+        # normalized -1 -> env-scale -2 (low)
+        assert torch.allclose(base_env.last_action, torch.full((7,), -2.0))
+
 
 class TestMultiAction(TransformBase):
     @pytest.mark.parametrize("bwad", [False, True])

--- a/test/transforms/test_action_transforms.py
+++ b/test/transforms/test_action_transforms.py
@@ -29,6 +29,7 @@ from torch import nn
 
 from torchrl.data import (
     Binary,
+    Bounded,
     Categorical,
     Composite,
     LazyTensorStorage,
@@ -40,6 +41,7 @@ from torchrl.data import (
 )
 from torchrl.envs import (
     ActionMask,
+    ActionScaling,
     Compose,
     ConditionalPolicySwitch,
     ConditionalSkip,
@@ -569,6 +571,256 @@ class TestDiscreteActionProjection(TransformBase):
         td_out = env.rand_step(td)
         assert td_out["action"].shape == torch.Size([10])
         assert td is td_out
+
+
+class TestActionScaling(TransformBase):
+    @staticmethod
+    def _bounded_env(low=-2.0, high=4.0, shape=(7,)):
+        return ContinuousActionVecMockEnv(action_spec=Bounded(low=low, high=high, shape=shape))
+
+    def test_single_trans_env_check(self):
+        env = TransformedEnv(self._bounded_env(), ActionScaling())
+        check_env_specs(env)
+
+    def test_serial_trans_env_check(self):
+        def make_env():
+            return TransformedEnv(self._bounded_env(), ActionScaling())
+
+        env = SerialEnv(2, make_env)
+        check_env_specs(env)
+
+    def test_parallel_trans_env_check(self, maybe_fork_ParallelEnv):
+        def make_env():
+            return TransformedEnv(self._bounded_env(), ActionScaling())
+
+        env = maybe_fork_ParallelEnv(2, make_env)
+        try:
+            check_env_specs(env)
+        finally:
+            try:
+                env.close()
+            except RuntimeError:
+                pass
+
+    def test_trans_serial_env_check(self):
+        env = TransformedEnv(
+            SerialEnv(2, self._bounded_env),
+            ActionScaling(),
+        )
+        check_env_specs(env)
+
+    def test_trans_parallel_env_check(self, maybe_fork_ParallelEnv):
+        env = TransformedEnv(
+            maybe_fork_ParallelEnv(2, self._bounded_env),
+            ActionScaling(),
+        )
+        try:
+            check_env_specs(env)
+        finally:
+            try:
+                env.close()
+            except RuntimeError:
+                pass
+
+    def test_transform_no_env(self):
+        # Without an env, ``loc`` and ``scale`` can be passed explicitly.
+        t = ActionScaling(loc=2.0, scale=3.0)
+        # inv: normalized -> env action; 1 -> 2 + 3 = 5, -1 -> 2 - 3 = -1
+        out = t._inv_apply_transform(torch.tensor([1.0, -1.0, 0.0]))
+        assert torch.allclose(out, torch.tensor([5.0, -1.0, 2.0]))
+        # forward: env -> normalized; 5 -> 1, -1 -> -1, 2 -> 0
+        back = t._apply_transform(out)
+        assert torch.allclose(back, torch.tensor([1.0, -1.0, 0.0]))
+
+    def test_transform_compose(self):
+        t = ActionScaling()
+        env = TransformedEnv(self._bounded_env(), Compose(t))
+        spec = env.action_spec
+        assert torch.allclose(spec.space.low, -torch.ones(7))
+        assert torch.allclose(spec.space.high, torch.ones(7))
+        # ``inv`` returns a new tensordict with the rescaled action.
+        td = TensorDict({"action": torch.ones(7)}, [])
+        out = env.transform.inv(td)
+        assert torch.allclose(out["action"], torch.full((7,), 4.0))
+
+    def test_transform_env(self):
+        captured = {}
+
+        class CaptureEnv(ContinuousActionVecMockEnv):
+            def _step(self, td):
+                captured["action"] = td["action"].clone()
+                return super()._step(td)
+
+        env = TransformedEnv(
+            CaptureEnv(action_spec=Bounded(low=-2.0, high=4.0, shape=(7,))),
+            ActionScaling(),
+        )
+        spec = env.action_spec
+        assert torch.allclose(spec.space.low, -torch.ones(7))
+        assert torch.allclose(spec.space.high, torch.ones(7))
+
+        # Drive the env with a normalized action of +1: env should receive +4.
+        td = env.reset()
+        td["action"] = torch.ones(7)
+        env.step(td)
+        assert torch.allclose(captured["action"], torch.full((7,), 4.0))
+
+        # Normalized action of -1 -> env should receive -2.
+        td = env.reset()
+        td["action"] = -torch.ones(7)
+        env.step(td)
+        assert torch.allclose(captured["action"], torch.full((7,), -2.0))
+
+        # Normalized action of 0 -> env should receive midpoint (1.0).
+        td = env.reset()
+        td["action"] = torch.zeros(7)
+        env.step(td)
+        assert torch.allclose(captured["action"], torch.full((7,), 1.0))
+
+    def test_transform_model(self):
+        # When used in a model / replay buffer context, ``forward`` maps
+        # env-scale actions back to the normalized range.
+        t = ActionScaling(loc=1.0, scale=3.0)
+        td = TensorDict({"action": torch.tensor([4.0, -2.0, 1.0])}, [])
+        model = nn.Sequential(t, nn.Identity())
+        td = model(td)
+        assert torch.allclose(td["action"], torch.tensor([1.0, -1.0, 0.0]))
+
+    @pytest.mark.parametrize("rbclass", [ReplayBuffer, TensorDictReplayBuffer])
+    def test_transform_rb(self, rbclass):
+        # Storage path: extend applies ``inv`` (normalized -> env-scale),
+        # sample applies ``forward`` (env-scale -> normalized), so each
+        # sampled action recovers one of the original normalized values.
+        t = ActionScaling(loc=1.0, scale=3.0)
+        normalized = torch.tensor([-1.0, -0.5, 0.0, 0.5])
+        td = TensorDict({"action": normalized}, [4])
+        rb = rbclass(storage=LazyTensorStorage(4))
+        rb.append_transform(t)
+        rb.extend(td)
+        # Stored data should be in env-scale (-2, -0.5, 1, 2.5).
+        stored = rb._storage._storage[:]
+        torch.testing.assert_close(
+            stored["action"].sort().values,
+            torch.tensor([-2.0, -0.5, 1.0, 2.5]),
+        )
+        sampled = rb.sample(16)
+        # Sampling is stochastic — every sampled action must be one of the
+        # original normalized values.
+        for value in sampled["action"].tolist():
+            assert any(abs(value - x) < 1e-6 for x in normalized.tolist()), (
+                f"sampled value {value} is not among the stored normalized values"
+            )
+
+    def test_transform_inverse(self):
+        # Round-trip a batch of normalized actions through inv then forward and
+        # confirm we recover the input.
+        t = ActionScaling(loc=1.0, scale=3.0)
+        norm = torch.tensor([-1.0, -0.5, 0.0, 0.5, 1.0])
+        env_action = t._inv_apply_transform(norm)
+        recovered = t._apply_transform(env_action)
+        assert torch.allclose(recovered, norm)
+
+    # ActionScaling-specific tests
+    def test_scaling_math_default(self):
+        env = TransformedEnv(self._bounded_env(low=-2.0, high=4.0), ActionScaling())
+        _ = env.action_spec  # trigger initialization
+        t = env.transform
+        # loc = (high + low) / 2 = 1, scale = (high - low) / 2 = 3
+        assert torch.allclose(t.loc, torch.full((7,), 1.0))
+        assert torch.allclose(t.scale, torch.full((7,), 3.0))
+
+    def test_scaling_per_dim_bounds(self):
+        # Different bounds per dimension.
+        low = torch.tensor([-1.0, 0.0, -5.0])
+        high = torch.tensor([1.0, 2.0, 5.0])
+        env = TransformedEnv(
+            ContinuousActionVecMockEnv(
+                action_spec=Bounded(low=low, high=high, shape=(3,))
+            ),
+            ActionScaling(),
+        )
+        _ = env.action_spec
+        t = env.transform
+        assert torch.allclose(t.loc, torch.tensor([0.0, 1.0, 0.0]))
+        assert torch.allclose(t.scale, torch.tensor([1.0, 1.0, 5.0]))
+
+    def test_standard_normal_false(self):
+        captured = {}
+
+        class CaptureEnv(ContinuousActionVecMockEnv):
+            def _step(self, td):
+                captured["action"] = td["action"].clone()
+                return super()._step(td)
+
+        env = TransformedEnv(
+            CaptureEnv(action_spec=Bounded(low=-2.0, high=4.0, shape=(7,))),
+            ActionScaling(standard_normal=False),
+        )
+        spec = env.action_spec
+        # standard_normal=False -> exposed spec is [0, 1]
+        assert torch.allclose(spec.space.low, torch.zeros(7))
+        assert torch.allclose(spec.space.high, torch.ones(7))
+
+        td = env.reset()
+        td["action"] = torch.zeros(7)
+        env.step(td)
+        # 0 in [0,1] -> low (-2) in env range
+        assert torch.allclose(captured["action"], torch.full((7,), -2.0))
+
+        td = env.reset()
+        td["action"] = torch.ones(7)
+        env.step(td)
+        # 1 in [0,1] -> high (4) in env range
+        assert torch.allclose(captured["action"], torch.full((7,), 4.0))
+
+    def test_unbounded_action_spec_raises(self):
+        env = TransformedEnv(
+            ContinuousActionVecMockEnv(action_spec=Unbounded(shape=(7,))),
+            ActionScaling(),
+        )
+        with pytest.raises(RuntimeError, match="ActionScaling"):
+            _ = env.action_spec
+
+    def test_partially_unbounded_action_spec_raises(self):
+        spec = Bounded(low=float("-inf"), high=1.0, shape=(7,))
+        env = TransformedEnv(
+            ContinuousActionVecMockEnv(action_spec=spec), ActionScaling()
+        )
+        with pytest.raises(RuntimeError, match="ActionScaling"):
+            _ = env.action_spec
+
+    def test_finfo_extreme_bound_raises(self):
+        # Bound equal to ``finfo.max`` is treated as unbounded.
+        hi = torch.tensor([torch.finfo(torch.float32).max] * 7)
+        lo = torch.tensor([-2.0] * 7)
+        spec = Bounded(low=lo, high=hi, shape=(7,))
+        env = TransformedEnv(
+            ContinuousActionVecMockEnv(action_spec=spec), ActionScaling()
+        )
+        with pytest.raises(RuntimeError, match="ActionScaling"):
+            _ = env.action_spec
+
+    def test_explicit_loc_scale_inconsistent_raises(self):
+        with pytest.raises(ValueError, match="loc and scale"):
+            ActionScaling(loc=1.0)
+        with pytest.raises(ValueError, match="loc and scale"):
+            ActionScaling(scale=1.0)
+
+    def test_explicit_zero_scale_raises(self):
+        with pytest.raises(ValueError, match="scale"):
+            ActionScaling(loc=0.0, scale=0.0)
+
+    def test_multiple_in_keys_raises(self):
+        with pytest.raises(ValueError, match="single action key"):
+            ActionScaling(in_keys_inv=["action_a", "action_b"])
+
+    def test_rollout_action_in_bounds(self):
+        env = TransformedEnv(self._bounded_env(low=-2.0, high=4.0), ActionScaling())
+        torch.manual_seed(0)
+        r = env.rollout(20, auto_cast_to_device=False)
+        # The recorded ``action`` lives in the normalized [-1, 1] space.
+        assert (r["action"] >= -1.0).all()
+        assert (r["action"] <= 1.0).all()
 
 
 class TestMultiAction(TransformBase):

--- a/test/transforms/test_action_transforms.py
+++ b/test/transforms/test_action_transforms.py
@@ -576,7 +576,9 @@ class TestDiscreteActionProjection(TransformBase):
 class TestActionScaling(TransformBase):
     @staticmethod
     def _bounded_env(low=-2.0, high=4.0, shape=(7,)):
-        return ContinuousActionVecMockEnv(action_spec=Bounded(low=low, high=high, shape=shape))
+        return ContinuousActionVecMockEnv(
+            action_spec=Bounded(low=low, high=high, shape=shape)
+        )
 
     def test_single_trans_env_check(self):
         env = TransformedEnv(self._bounded_env(), ActionScaling())
@@ -707,9 +709,9 @@ class TestActionScaling(TransformBase):
         # Sampling is stochastic — every sampled action must be one of the
         # original normalized values.
         for value in sampled["action"].tolist():
-            assert any(abs(value - x) < 1e-6 for x in normalized.tolist()), (
-                f"sampled value {value} is not among the stored normalized values"
-            )
+            assert any(
+                abs(value - x) < 1e-6 for x in normalized.tolist()
+            ), f"sampled value {value} is not among the stored normalized values"
 
     def test_transform_inverse(self):
         # Round-trip a batch of normalized actions through inv then forward and

--- a/torchrl/envs/__init__.py
+++ b/torchrl/envs/__init__.py
@@ -58,6 +58,7 @@ from .model_based import DreamerDecoder, DreamerEnv, ImaginedEnv, ModelBasedEnvB
 from .transforms import (
     ActionDiscretizer,
     ActionMask,
+    ActionScaling,
     AutoResetEnv,
     AutoResetTransform,
     BatchSizeTransform,
@@ -143,6 +144,7 @@ from .utils import (
 __all__ = [
     "ActionDiscretizer",
     "ActionMask",
+    "ActionScaling",
     "VecNormV2",
     "IsaacLabWrapper",
     "AutoResetEnv",

--- a/torchrl/envs/transforms/__init__.py
+++ b/torchrl/envs/transforms/__init__.py
@@ -12,6 +12,7 @@ from .rb_transforms import MultiStepTransform, NextStateReconstructor
 from .transforms import (
     ActionDiscretizer,
     ActionMask,
+    ActionScaling,
     AutoResetEnv,
     AutoResetTransform,
     BatchSizeTransform,
@@ -81,6 +82,7 @@ from .vip import VIPRewardTransform, VIPTransform
 __all__ = [
     "ActionDiscretizer",
     "ActionMask",
+    "ActionScaling",
     "AutoResetEnv",
     "AutoResetTransform",
     "BatchSizeTransform",

--- a/torchrl/envs/transforms/_action.py
+++ b/torchrl/envs/transforms/_action.py
@@ -43,7 +43,6 @@ from torchrl.envs.transforms._base import (
     FORWARD_NOT_IMPLEMENTED,
     Transform,
 )
-from torchrl.envs.transforms.utils import _set_missing_tolerance
 
 __all__ = [
     "ActionDiscretizer",
@@ -869,7 +868,7 @@ class MultiAction(Transform):
 
 
 class ActionScaling(Transform):
-    """Affine-scale a continuous action using the bounds of the action spec.
+    r"""Affine-scale a continuous action using the bounds of the action spec.
 
     Given a bounded action spec with bounds ``[low, high]``, this transform exposes
     a normalized action space to the policy and rescales actions back to the
@@ -879,14 +878,14 @@ class ActionScaling(Transform):
 
     .. math::
 
-        loc = \\frac{high + low}{2}, \\quad scale = \\frac{high - low}{2}.
+        loc = \frac{high + low}{2}, \quad scale = \frac{high - low}{2}.
 
     When ``standard_normal=True`` (default) the normalized action space is
     ``[-1, 1]`` and the inverse mapping (policy action -> env action) is
 
     .. math::
 
-        a_{env} = a_{norm} \\cdot scale + loc.
+        a_{env} = a_{norm} \cdot scale + loc.
 
     The forward mapping (env action -> normalized action, used by replay buffer
     transforms) is the inverse:
@@ -1038,7 +1037,6 @@ class ActionScaling(Transform):
         # that the spec we read here reflects the env-scale bounds at the point
         # in the chain where this transform sits.
         full_action_spec = full_action_spec.clone()
-        container = self.container
         # ``parent`` is an EnvBase; walk through preceding transforms in the
         # Compose (if any) up to ``self``.
         transform = parent.transform
@@ -1061,12 +1059,9 @@ class ActionScaling(Transform):
         if key not in full_action_spec.keys(True, True):
             return
         leaf = full_action_spec[key]
-        try:
-            low, high = self._validate_bounded(leaf)
-        except RuntimeError:
-            # surface the validation error to the caller — this is the same
-            # error that would have been raised when the spec was first queried.
-            raise
+        # surface the validation error to the caller - it is the same error
+        # that would have been raised when the spec was first queried.
+        low, high = self._validate_bounded(leaf)
         dtype = low.dtype if low.dtype.is_floating_point else torch.get_default_dtype()
         loc = ((high + low) / 2).to(dtype)
         scale = ((high - low) / 2).to(dtype)

--- a/torchrl/envs/transforms/_action.py
+++ b/torchrl/envs/transforms/_action.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import functools
+from collections.abc import Sequence
 from copy import copy
 from enum import IntEnum
 from textwrap import indent
@@ -21,10 +22,12 @@ from torchrl.data.tensor_specs import (
     Bounded,
     Categorical,
     Composite,
+    ContinuousBox,
     MultiCategorical,
     MultiOneHot,
     OneHot,
     TensorSpec,
+    Unbounded,
 )
 
 if TYPE_CHECKING:
@@ -35,11 +38,17 @@ if TYPE_CHECKING:
 else:
     Self = Any
 
-from torchrl.envs.transforms._base import FORWARD_NOT_IMPLEMENTED, Transform
+from torchrl.envs.transforms._base import (
+    _apply_to_composite_inv,
+    FORWARD_NOT_IMPLEMENTED,
+    Transform,
+)
+from torchrl.envs.transforms.utils import _set_missing_tolerance
 
 __all__ = [
     "ActionDiscretizer",
     "ActionMask",
+    "ActionScaling",
     "DiscreteActionProjection",
     "MultiAction",
 ]
@@ -857,3 +866,325 @@ class MultiAction(Transform):
             )
         )
         return observation_spec
+
+
+class ActionScaling(Transform):
+    """Affine-scale a continuous action using the bounds of the action spec.
+
+    Given a bounded action spec with bounds ``[low, high]``, this transform exposes
+    a normalized action space to the policy and rescales actions back to the
+    original env range before they are passed to the environment.
+
+    The ``loc`` and ``scale`` are derived from the spec:
+
+    .. math::
+
+        loc = \\frac{high + low}{2}, \\quad scale = \\frac{high - low}{2}.
+
+    When ``standard_normal=True`` (default) the normalized action space is
+    ``[-1, 1]`` and the inverse mapping (policy action -> env action) is
+
+    .. math::
+
+        a_{env} = a_{norm} \\cdot scale + loc.
+
+    The forward mapping (env action -> normalized action, used by replay buffer
+    transforms) is the inverse:
+
+    .. math::
+
+        a_{norm} = (a_{env} - loc) / scale.
+
+    When ``standard_normal=False`` the normalized space is ``[0, 1]`` and the
+    mapping is rescaled accordingly so that ``0`` maps to ``low`` and ``1`` to
+    ``high``.
+
+    Args:
+        in_keys_inv (sequence of NestedKey, optional): keys read during the
+            ``inv`` direction (policy -> env). Defaults to ``["action"]``. A
+            single key per :class:`ActionScaling` instance is supported; compose
+            several instances to scale several actions.
+        out_keys_inv (sequence of NestedKey, optional): keys written during the
+            ``inv`` direction. Defaults to ``in_keys_inv``.
+        in_keys (sequence of NestedKey, optional): keys read during the forward
+            direction (env action -> normalized action, used by replay buffers
+            and inside :class:`~torch.nn.Module` chains). Defaults to
+            ``in_keys_inv``.
+        out_keys (sequence of NestedKey, optional): keys written during the
+            forward direction. Defaults to ``in_keys``.
+
+    Keyword Args:
+        loc (torch.Tensor or float, optional): explicit location of the affine
+            transform. If both ``loc`` and ``scale`` are provided the values are
+            used as-is and no derivation from the spec is performed (useful when
+            no parent environment is available, e.g. inside a replay buffer).
+            Defaults to ``None``.
+        scale (torch.Tensor or float, optional): explicit scale of the affine
+            transform. Must be provided together with ``loc``.
+            Defaults to ``None``.
+        standard_normal (bool, optional): if ``True`` (default), the normalized
+            action space is ``[-1, 1]``. If ``False``, the normalized action
+            space is ``[0, 1]``.
+
+    Raises:
+        RuntimeError: if the action spec is unbounded or partially unbounded
+            (any bound is non-finite).
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.data.tensor_specs import Bounded
+        >>> from torchrl.envs.transforms import ActionScaling, TransformedEnv
+        >>> from torchrl.testing.mocking_classes import ContinuousActionVecMockEnv
+        >>> base_env = ContinuousActionVecMockEnv(
+        ...     action_spec=Bounded(low=-2.0, high=4.0, shape=(7,))
+        ... )
+        >>> env = TransformedEnv(base_env, ActionScaling())
+        >>> env.action_spec.space.low
+        tensor([-1., -1., -1., -1., -1., -1., -1.])
+        >>> env.action_spec.space.high
+        tensor([1., 1., 1., 1., 1., 1., 1.])
+    """
+
+    invertible = True
+
+    def __init__(
+        self,
+        in_keys_inv: Sequence[NestedKey] | None = None,
+        out_keys_inv: Sequence[NestedKey] | None = None,
+        in_keys: Sequence[NestedKey] | None = None,
+        out_keys: Sequence[NestedKey] | None = None,
+        *,
+        loc: torch.Tensor | float | None = None,
+        scale: torch.Tensor | float | None = None,
+        standard_normal: bool = True,
+    ):
+        if in_keys_inv is None:
+            in_keys_inv = ["action"]
+        if not isinstance(in_keys_inv, (list, tuple)):
+            in_keys_inv = [in_keys_inv]
+        if len(in_keys_inv) != 1:
+            raise ValueError(
+                "ActionScaling only supports a single action key per instance. "
+                "Compose several ActionScaling transforms to scale multiple actions."
+            )
+        if out_keys_inv is None:
+            out_keys_inv = copy(in_keys_inv)
+        if in_keys is None:
+            in_keys = copy(in_keys_inv)
+        if out_keys is None:
+            out_keys = copy(in_keys)
+        super().__init__(
+            in_keys=in_keys,
+            out_keys=out_keys,
+            in_keys_inv=in_keys_inv,
+            out_keys_inv=out_keys_inv,
+        )
+        self.standard_normal = bool(standard_normal)
+
+        if (loc is None) != (scale is None):
+            raise ValueError(
+                "loc and scale must either both be provided or both be None."
+            )
+        self._explicit = loc is not None
+        if loc is not None:
+            loc = torch.as_tensor(loc)
+            scale = torch.as_tensor(scale)
+            if not loc.dtype.is_floating_point:
+                loc = loc.to(torch.get_default_dtype())
+            if not scale.dtype.is_floating_point:
+                scale = scale.to(torch.get_default_dtype())
+            if (scale == 0).any():
+                raise ValueError(
+                    "scale must not contain zero entries (would cause division by zero)."
+                )
+            self.register_buffer("loc", loc)
+            self.register_buffer("scale", scale)
+        else:
+            self.register_buffer("loc", nn.UninitializedBuffer())
+            self.register_buffer("scale", nn.UninitializedBuffer())
+
+    @property
+    def initialized(self) -> bool:
+        return not isinstance(self.loc, nn.UninitializedBuffer)
+
+    def _check_initialized(self) -> None:
+        if not self.initialized:
+            self._maybe_init_from_parent()
+        if not self.initialized:
+            raise RuntimeError(
+                "ActionScaling has not been initialized yet. Either pass explicit "
+                "`loc` and `scale` to the constructor, or attach this transform to "
+                "a TransformedEnv whose action spec is bounded so that the values "
+                "can be derived automatically."
+            )
+
+    def _maybe_init_from_parent(self) -> None:
+        """Derive ``loc`` and ``scale`` from the parent env's action spec.
+
+        Walks up the transform chain to compute the action spec as it would be
+        seen on the inv direction (env-scale) for our action key, and uses its
+        bounds to materialize ``loc`` and ``scale``.
+        """
+        if self.initialized or self._explicit:
+            return
+        parent = self.parent
+        if parent is None:
+            return
+        try:
+            full_action_spec = parent.base_env.full_action_spec
+        except Exception:  # noqa: BLE001
+            return
+        # Apply every preceding transform's transform_action_spec on a clone so
+        # that the spec we read here reflects the env-scale bounds at the point
+        # in the chain where this transform sits.
+        full_action_spec = full_action_spec.clone()
+        container = self.container
+        # ``parent`` is an EnvBase; walk through preceding transforms in the
+        # Compose (if any) up to ``self``.
+        transform = parent.transform
+        from torchrl.envs.transforms._base import Compose
+
+        if isinstance(transform, Compose):
+            for t in transform.transforms:
+                if t is self:
+                    break
+                # Each transform may modify the action spec on the way through.
+                input_spec = Composite(
+                    full_action_spec=full_action_spec,
+                    full_state_spec=Composite(),
+                    shape=full_action_spec.shape,
+                    device=full_action_spec.device,
+                )
+                input_spec = t.transform_input_spec(input_spec)
+                full_action_spec = input_spec["full_action_spec"]
+        key = self.in_keys_inv[0]
+        if key not in full_action_spec.keys(True, True):
+            return
+        leaf = full_action_spec[key]
+        try:
+            low, high = self._validate_bounded(leaf)
+        except RuntimeError:
+            # surface the validation error to the caller — this is the same
+            # error that would have been raised when the spec was first queried.
+            raise
+        dtype = low.dtype if low.dtype.is_floating_point else torch.get_default_dtype()
+        loc = ((high + low) / 2).to(dtype)
+        scale = ((high - low) / 2).to(dtype)
+        self._set_loc_scale(loc, scale)
+
+    def _set_loc_scale(self, loc: torch.Tensor, scale: torch.Tensor) -> None:
+        if isinstance(self.loc, nn.UninitializedBuffer):
+            self.loc.materialize(shape=loc.shape, dtype=loc.dtype)
+            self.scale.materialize(shape=scale.shape, dtype=scale.dtype)
+        self.loc.data.copy_(loc)
+        self.scale.data.copy_(scale)
+
+    @staticmethod
+    def _validate_bounded(action_spec: TensorSpec) -> tuple[torch.Tensor, torch.Tensor]:
+        space = getattr(action_spec, "space", None)
+        if not isinstance(space, ContinuousBox):
+            raise RuntimeError(
+                f"ActionScaling requires a bounded continuous action spec, got "
+                f"{type(action_spec).__name__} with space "
+                f"{type(space).__name__ if space is not None else None}. "
+                "Unbounded or discrete action specs are not supported."
+            )
+        # ``Unbounded`` specs use a ``ContinuousBox`` whose low/high are set to
+        # ``finfo.min`` and ``finfo.max`` respectively, so checking the spec type
+        # is more reliable than ``torch.isfinite``.
+        if isinstance(action_spec, Unbounded):
+            raise RuntimeError(
+                "ActionScaling cannot be used with an Unbounded action spec. "
+                "The action spec must be fully bounded for spec-based normalization."
+            )
+        low = space.low
+        high = space.high
+        # Partially unbounded: one side is finite but the other matches the
+        # ``finfo`` extreme used internally by ``Unbounded``.
+        dtype = low.dtype
+        if dtype.is_floating_point:
+            extreme_low = torch.finfo(dtype).min
+            extreme_high = torch.finfo(dtype).max
+            if (low == extreme_low).any() or (high == extreme_high).any():
+                raise RuntimeError(
+                    "ActionScaling requires fully bounded actions: at least one "
+                    "entry of the action spec is unbounded (low equals finfo.min or "
+                    "high equals finfo.max)."
+                )
+        if not torch.isfinite(low).all() or not torch.isfinite(high).all():
+            raise RuntimeError(
+                "ActionScaling requires fully bounded actions: every entry of the "
+                "action spec must have a finite lower and upper bound. Got "
+                "non-finite values in low or high."
+            )
+        if (high <= low).any():
+            raise RuntimeError(
+                "ActionScaling requires high > low for every entry of the action "
+                "spec. Got entries with high <= low."
+            )
+        return low, high
+
+    @_apply_to_composite_inv
+    def transform_action_spec(self, action_spec: TensorSpec) -> TensorSpec:
+        low, high = self._validate_bounded(action_spec)
+        dtype = low.dtype if low.dtype.is_floating_point else torch.get_default_dtype()
+        low = low.to(dtype)
+        high = high.to(dtype)
+        if not self._explicit:
+            loc = (high + low) / 2
+            scale = (high - low) / 2
+            self._set_loc_scale(loc, scale)
+        if self.standard_normal:
+            new_low = torch.full_like(low, -1.0)
+            new_high = torch.full_like(high, 1.0)
+        else:
+            new_low = torch.zeros_like(low)
+            new_high = torch.ones_like(high)
+        return Bounded(
+            low=new_low,
+            high=new_high,
+            shape=action_spec.shape,
+            device=action_spec.device,
+            dtype=action_spec.dtype,
+        )
+
+    def _apply_transform(self, action: torch.Tensor) -> torch.Tensor:
+        # env action -> normalized
+        self._check_initialized()
+        loc = self.loc.to(action.device)
+        scale = self.scale.to(action.device)
+        normalized = (action - loc) / scale
+        if not self.standard_normal:
+            normalized = (normalized + 1) / 2
+        return normalized
+
+    def _inv_apply_transform(self, action: torch.Tensor) -> torch.Tensor:
+        # normalized -> env action
+        self._check_initialized()
+        loc = self.loc.to(action.device)
+        scale = self.scale.to(action.device)
+        if not self.standard_normal:
+            action = action * 2 - 1
+        return action * scale + loc
+
+    def _call(self, next_tensordict: TensorDictBase) -> TensorDictBase:
+        # The action only flows through the inv direction during env stepping.
+        # The next_tensordict returned by the base env does not contain the
+        # action, so we leave it untouched here. The forward direction
+        # (env action -> normalized) is still available via ``forward`` for use
+        # inside replay buffers and ``nn.Module`` chains.
+        return next_tensordict
+
+    def _reset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        return tensordict_reset
+
+    def __repr__(self) -> str:
+        loc = self.loc if self.initialized else "uninitialized"
+        scale = self.scale if self.initialized else "uninitialized"
+        return (
+            f"{self.__class__.__name__}("
+            f"loc={loc}, scale={scale}, standard_normal={self.standard_normal}, "
+            f"in_keys_inv={self.in_keys_inv})"
+        )

--- a/torchrl/envs/transforms/_action.py
+++ b/torchrl/envs/transforms/_action.py
@@ -1143,11 +1143,22 @@ class ActionScaling(Transform):
             dtype=action_spec.dtype,
         )
 
+    def _loc_scale(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+        # Only move the buffers when the device actually differs: an
+        # unconditional ``.to()`` inserts a copy node in the compile graph,
+        # whereas the device comparison is resolved at trace time (device is
+        # static metadata, not data), so the common same-device path stays
+        # copy-free and compile-friendly.
+        loc, scale = self.loc, self.scale
+        if loc.device != device:
+            loc = loc.to(device)
+            scale = scale.to(device)
+        return loc, scale
+
     def _apply_transform(self, action: torch.Tensor) -> torch.Tensor:
         # env action -> normalized
         self._check_initialized()
-        loc = self.loc.to(action.device)
-        scale = self.scale.to(action.device)
+        loc, scale = self._loc_scale(action.device)
         normalized = (action - loc) / scale
         if not self.standard_normal:
             normalized = (normalized + 1) / 2
@@ -1156,8 +1167,7 @@ class ActionScaling(Transform):
     def _inv_apply_transform(self, action: torch.Tensor) -> torch.Tensor:
         # normalized -> env action
         self._check_initialized()
-        loc = self.loc.to(action.device)
-        scale = self.scale.to(action.device)
+        loc, scale = self._loc_scale(action.device)
         if not self.standard_normal:
             action = action * 2 - 1
         return action * scale + loc

--- a/torchrl/envs/transforms/_action.py
+++ b/torchrl/envs/transforms/_action.py
@@ -15,7 +15,7 @@ from typing import Any, TYPE_CHECKING
 import torch
 
 from tensordict import TensorDictBase
-from tensordict.utils import NestedKey
+from tensordict.utils import NestedKey, unravel_key
 from torch import nn
 
 from torchrl.data.tensor_specs import (
@@ -38,11 +38,7 @@ if TYPE_CHECKING:
 else:
     Self = Any
 
-from torchrl.envs.transforms._base import (
-    _apply_to_composite_inv,
-    FORWARD_NOT_IMPLEMENTED,
-    Transform,
-)
+from torchrl.envs.transforms._base import FORWARD_NOT_IMPLEMENTED, Transform
 
 __all__ = [
     "ActionDiscretizer",
@@ -1006,68 +1002,39 @@ class ActionScaling(Transform):
     def initialized(self) -> bool:
         return not isinstance(self.loc, nn.UninitializedBuffer)
 
-    def _check_initialized(self) -> None:
-        if not self.initialized:
-            self._maybe_init_from_parent()
-        if not self.initialized:
-            raise RuntimeError(
-                "ActionScaling has not been initialized yet. Either pass explicit "
-                "`loc` and `scale` to the constructor, or attach this transform to "
-                "a TransformedEnv whose action spec is bounded so that the values "
-                "can be derived automatically."
-            )
-
-    def _maybe_init_from_parent(self) -> None:
-        """Derive ``loc`` and ``scale`` from the parent env's action spec.
-
-        Walks up the transform chain to compute the action spec as it would be
-        seen on the inv direction (env-scale) for our action key, and uses its
-        bounds to materialize ``loc`` and ``scale``.
-        """
-        if self.initialized or self._explicit:
+    def _ensure_initialized(self) -> None:
+        # Lazily populate ``loc`` and ``scale`` from the parent env's action
+        # spec at the insertion point of this transform. ``self.parent`` is
+        # rebuilt with all transforms up to (but not including) ``self``, so
+        # its action spec is exactly the env-scale spec we need to read.
+        if self.initialized:
             return
         parent = self.parent
         if parent is None:
-            return
-        try:
-            full_action_spec = parent.base_env.full_action_spec
-        except Exception:  # noqa: BLE001
-            return
-        # Apply every preceding transform's transform_action_spec on a clone so
-        # that the spec we read here reflects the env-scale bounds at the point
-        # in the chain where this transform sits.
-        full_action_spec = full_action_spec.clone()
-        # ``parent`` is an EnvBase; walk through preceding transforms in the
-        # Compose (if any) up to ``self``.
-        transform = parent.transform
-        from torchrl.envs.transforms._base import Compose
+            raise RuntimeError(
+                "ActionScaling has not been initialized: pass explicit ``loc`` "
+                "and ``scale`` to the constructor, or attach this transform to "
+                "a TransformedEnv whose action spec is bounded so that the "
+                "values can be derived automatically."
+            )
+        in_key = unravel_key(self.in_keys_inv[0])
+        full_action_spec = parent.full_action_spec
+        if in_key not in full_action_spec.keys(True, True):
+            raise RuntimeError(
+                f"ActionScaling could not find key {in_key!r} in the parent "
+                f"environment's action spec. Available keys: "
+                f"{list(full_action_spec.keys(True, True))}."
+            )
+        self._init_from_spec(full_action_spec[in_key])
 
-        if isinstance(transform, Compose):
-            for t in transform.transforms:
-                if t is self:
-                    break
-                # Each transform may modify the action spec on the way through.
-                input_spec = Composite(
-                    full_action_spec=full_action_spec,
-                    full_state_spec=Composite(),
-                    shape=full_action_spec.shape,
-                    device=full_action_spec.device,
-                )
-                input_spec = t.transform_input_spec(input_spec)
-                full_action_spec = input_spec["full_action_spec"]
-        key = self.in_keys_inv[0]
-        if key not in full_action_spec.keys(True, True):
-            return
-        leaf = full_action_spec[key]
-        # surface the validation error to the caller - it is the same error
-        # that would have been raised when the spec was first queried.
-        low, high = self._validate_bounded(leaf)
+    def _init_from_spec(self, leaf_spec: TensorSpec) -> None:
+        low, high = self._validate_bounded(leaf_spec)
         dtype = low.dtype if low.dtype.is_floating_point else torch.get_default_dtype()
         loc = ((high + low) / 2).to(dtype)
         scale = ((high - low) / 2).to(dtype)
-        self._set_loc_scale(loc, scale)
+        self._materialize_loc_scale(loc, scale)
 
-    def _set_loc_scale(self, loc: torch.Tensor, scale: torch.Tensor) -> None:
+    def _materialize_loc_scale(self, loc: torch.Tensor, scale: torch.Tensor) -> None:
         if isinstance(self.loc, nn.UninitializedBuffer):
             self.loc.materialize(shape=loc.shape, dtype=loc.dtype)
             self.scale.materialize(shape=scale.shape, dtype=scale.dtype)
@@ -1119,16 +1086,22 @@ class ActionScaling(Transform):
             )
         return low, high
 
-    @_apply_to_composite_inv
-    def transform_action_spec(self, action_spec: TensorSpec) -> TensorSpec:
-        low, high = self._validate_bounded(action_spec)
-        dtype = low.dtype if low.dtype.is_floating_point else torch.get_default_dtype()
-        low = low.to(dtype)
-        high = high.to(dtype)
-        if not self._explicit:
-            loc = (high + low) / 2
-            scale = (high - low) / 2
-            self._set_loc_scale(loc, scale)
+    def _transform_leaf(self, leaf_spec: TensorSpec) -> TensorSpec:
+        # Validate the leaf action spec, lazily populate ``loc``/``scale`` from
+        # the bounds and return a new bounded spec in normalized space.
+        if not self._explicit and not self.initialized:
+            self._init_from_spec(leaf_spec)
+        else:
+            # Still validate so that downstream users get a consistent error
+            # message for unbounded / partially-unbounded specs.
+            self._validate_bounded(leaf_spec)
+        dtype = (
+            leaf_spec.dtype
+            if leaf_spec.dtype.is_floating_point
+            else torch.get_default_dtype()
+        )
+        low = leaf_spec.space.low.to(dtype)
+        high = leaf_spec.space.high.to(dtype)
         if self.standard_normal:
             new_low = torch.full_like(low, -1.0)
             new_high = torch.full_like(high, 1.0)
@@ -1138,10 +1111,29 @@ class ActionScaling(Transform):
         return Bounded(
             low=new_low,
             high=new_high,
-            shape=action_spec.shape,
-            device=action_spec.device,
-            dtype=action_spec.dtype,
+            shape=leaf_spec.shape,
+            device=leaf_spec.device,
+            dtype=leaf_spec.dtype,
         )
+
+    def transform_action_spec(self, action_spec: TensorSpec) -> TensorSpec:
+        # We iterate the action spec manually rather than relying on
+        # ``@_apply_to_composite_inv``: when ``transform_input_spec`` calls this
+        # method with the action sub-composite, the decorator only inspects
+        # top-level keys (``input_spec.keys(False, True)``) and silently skips
+        # nested action keys. Iterating ourselves makes dict-structured action
+        # spaces (e.g. ``("agent", "action")``) work like flat ones.
+        if not isinstance(action_spec, Composite):
+            return self._transform_leaf(action_spec)
+        action_spec = action_spec.clone()
+        in_key = unravel_key(self.in_keys_inv[0])
+        out_key = unravel_key(self.out_keys_inv[0])
+        if in_key in action_spec.keys(True, True):
+            leaf = action_spec[in_key].clone()
+            action_spec[out_key] = self._transform_leaf(leaf)
+            if in_key != out_key:
+                del action_spec[in_key]
+        return action_spec
 
     def _loc_scale(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
         # Only move the buffers when the device actually differs: an
@@ -1156,8 +1148,7 @@ class ActionScaling(Transform):
         return loc, scale
 
     def _apply_transform(self, action: torch.Tensor) -> torch.Tensor:
-        # env action -> normalized
-        self._check_initialized()
+        self._ensure_initialized()
         loc, scale = self._loc_scale(action.device)
         normalized = (action - loc) / scale
         if not self.standard_normal:
@@ -1165,29 +1156,24 @@ class ActionScaling(Transform):
         return normalized
 
     def _inv_apply_transform(self, action: torch.Tensor) -> torch.Tensor:
-        # normalized -> env action
-        self._check_initialized()
+        self._ensure_initialized()
         loc, scale = self._loc_scale(action.device)
         if not self.standard_normal:
             action = action * 2 - 1
         return action * scale + loc
 
     def _call(self, next_tensordict: TensorDictBase) -> TensorDictBase:
-        # The action only flows through the inv direction during env stepping.
-        # The next_tensordict returned by the base env does not contain the
-        # action, so we leave it untouched here. The forward direction
-        # (env action -> normalized) is still available via ``forward`` for use
-        # inside replay buffers and ``nn.Module`` chains.
+        # The action only flows through the inv direction during env stepping;
+        # the ``next_tensordict`` returned by the base env does not contain it.
+        # Overriding ``_call`` as a no-op avoids the default loop raising a
+        # ``KeyError`` for the missing action key. The forward direction
+        # (env action -> normalized) is still wired through ``forward`` /
+        # ``_apply_transform`` for replay buffers and ``nn.Module`` chains.
         return next_tensordict
 
-    def _reset(
-        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
-    ) -> TensorDictBase:
-        return tensordict_reset
-
     def __repr__(self) -> str:
-        loc = self.loc if self.initialized else "uninitialized"
-        scale = self.scale if self.initialized else "uninitialized"
+        loc = self.loc if self.initialized else "<uninitialized>"
+        scale = self.scale if self.initialized else "<uninitialized>"
         return (
             f"{self.__class__.__name__}("
             f"loc={loc}, scale={scale}, standard_normal={self.standard_normal}, "

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from torchrl.envs.transforms._action import (
     ActionDiscretizer,
     ActionMask,
+    ActionScaling,
     DiscreteActionProjection,
     MultiAction,
 )
@@ -105,6 +106,7 @@ from torchrl.envs.transforms._timer import Timer
 __all__ = [
     "ActionDiscretizer",
     "ActionMask",
+    "ActionScaling",
     "AutoResetEnv",
     "AutoResetTransform",
     "BatchSizeTransform",


### PR DESCRIPTION
## Summary

Adds `ActionScaling`, a new transform that addresses the first half of #1209.

`ActionScaling` is a spec-driven action normalization layer:

- Reads the bounds of the action spec and derives `loc = (high + low) / 2` and `scale = (high - low) / 2`.
- Exposes a normalized action space to the policy: `[-1, 1]` by default, or `[0, 1]` when `standard_normal=False`.
- On the inv direction (policy -> env), rescales the normalized action back to the env's bounds: `env_action = norm * scale + loc`.
- On the forward direction (env action -> normalized, used inside replay buffers / `nn.Module` chains), applies the inverse mapping.

Unlike `ObservationNorm`, the values are derived from the spec (not from rollouts) and there is no moving-average / `init_stats` path - the issue explicitly asks for a static, spec-based transform for actions.

### Unbounded handling

A `RuntimeError` is raised when the action spec is:

- A non-`ContinuousBox` spec (discrete or categorical).
- An `Unbounded` spec.
- A `Bounded` spec where any entry of `low` is `-inf` / `torch.finfo(dtype).min`, or any entry of `high` is `+inf` / `torch.finfo(dtype).max`.
- Has any entry with `high <= low`.

This covers both fully and partially unbounded specs, including the case where `Unbounded` internally uses the `finfo` extremes (which `torch.isfinite` reports as finite).

### What changed

- `torchrl/envs/transforms/_action.py`: implements `ActionScaling`, with a `_maybe_init_from_parent` hook that walks the transform chain so that `loc` / `scale` are populated lazily on the first inv call when the transform is attached to a `TransformedEnv`. Explicit `loc` / `scale` can also be passed to the constructor (useful for replay-buffer-only usage).
- `torchrl/envs/transforms/transforms.py`, `torchrl/envs/transforms/__init__.py`, `torchrl/envs/__init__.py`: re-export the new class.
- `docs/source/reference/envs_transforms.rst`: add `ActionScaling` to the autosummary list.
- `test/transforms/test_action_transforms.py`: full `TransformBase` coverage plus class-specific tests for the scaling math, per-dimension bounds, `[0, 1]` mode, unbounded / partially-unbounded / `finfo` extremes, explicit `loc`/`scale`, multi-key rejection, and a rollout-bounds invariant.

### How to test

```
pytest test/transforms/test_action_transforms.py::TestActionScaling -x
```

22 tests, all passing locally on Windows / Python 3.12 / Torch 2.8.

Closes the first half of #1209.