### PR TITLE
[Feature] Add compact-drop shifted value backend

### DIFF
--- a/examples/collectors/isaaclab_rnn_ppo_memory.py
+++ b/examples/collectors/isaaclab_rnn_ppo_memory.py
@@ -246,11 +246,12 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--gae-shifted",
-        choices=["false", "legacy", "compact"],
+        choices=["false", "legacy", "compact", "compact-drop"],
         default="compact",
         help=(
             "GAE shifted mode. Use 'false' for the full baseline path and "
-            "'compact' for the compile-friendly compact shifted path."
+            "'compact' or 'compact-drop' for compile-friendly compact shifted "
+            "paths."
         ),
     )
     parser.add_argument(

--- a/test/objectives/test_values.py
+++ b/test/objectives/test_values.py
@@ -490,7 +490,7 @@ class TestValues:
     @pytest.mark.parametrize("reset_steps", [[2], [1, 3]])
     def test_gae_shifted_compact_drop_retained_matches_unshifted(self, reset_steps):
         torch.manual_seed(0)
-        B, T, obs_dim = 2, 6, 4
+        B, T, obs_dim = 2, 6, 6
         all_obs = torch.randn(B, T + 1, obs_dim)
         obs = all_obs[:, :T].clone()
         next_obs = all_obs[:, 1:].clone()
@@ -548,7 +548,7 @@ class TestValues:
 
     def test_gae_shifted_compact_drop_without_next_observation(self):
         torch.manual_seed(0)
-        B, T, obs_dim = 2, 6, 4
+        B, T, obs_dim = 2, 6, 6
         obs = torch.randn(B, T, obs_dim)
         done = torch.zeros(B, T, 1, dtype=torch.bool)
         done[:, 2, 0] = True
@@ -583,6 +583,85 @@ class TestValues:
         assert torch.isfinite(out["advantage"]).all()
         assert out["compact_drop_valid"].shape == td.shape
         assert (~out["compact_drop_valid"]).sum() == done[..., :-1, :].sum()
+
+    def test_gae_shifted_compact_drop_does_not_keep_stale_valid_mask(self):
+        torch.manual_seed(0)
+        B, T, obs_dim = 2, 6, 6
+        value_net = TensorDictModule(
+            nn.Linear(obs_dim, 1),
+            in_keys=["observation"],
+            out_keys=["state_value"],
+        )
+        gae = GAE(
+            gamma=0.9,
+            lmbda=0.95,
+            value_network=value_net,
+            shifted="compact-drop",
+        )
+        td_with_reset, _ = self._build_shifted_test_td(with_internal_done=True)
+        out_with_reset = gae(td_with_reset.clone())
+        assert out_with_reset.get("compact_drop_valid", default=None) is not None
+
+        all_obs = torch.randn(B, T + 1, obs_dim)
+        td_without_reset = TensorDict(
+            {
+                "observation": all_obs[:, :T].clone(),
+                "next": TensorDict(
+                    {
+                        "observation": all_obs[:, 1:].clone(),
+                        "reward": torch.randn(B, T, 1),
+                        "done": torch.zeros(B, T, 1, dtype=torch.bool),
+                        "terminated": torch.zeros(B, T, 1, dtype=torch.bool),
+                    },
+                    [B, T],
+                ),
+            },
+            [B, T],
+        )
+        td_without_reset["next", "done"][:, -1, 0] = True
+        out_without_reset = gae(td_without_reset)
+        assert out_without_reset.get("compact_drop_valid", default=None) is None
+
+    def test_gae_shifted_compact_drop_average_gae_uses_valid_only(self):
+        torch.manual_seed(0)
+        B, T, obs_dim = 2, 6, 4
+        all_obs = torch.randn(B, T + 1, obs_dim)
+        done = torch.zeros(B, T, 1, dtype=torch.bool)
+        done[:, 2, 0] = True
+        done[:, -1, 0] = True
+        td = TensorDict(
+            {
+                "observation": all_obs[:, :T].clone(),
+                "next": TensorDict(
+                    {
+                        "observation": all_obs[:, 1:].clone(),
+                        "reward": torch.randn(B, T, 1),
+                        "done": done,
+                        "terminated": torch.zeros_like(done),
+                    },
+                    [B, T],
+                ),
+            },
+            [B, T],
+        )
+        td["next", "observation"][:, 2] = torch.randn(B, obs_dim)
+        value_net = TensorDictModule(
+            nn.Linear(obs_dim, 1),
+            in_keys=["observation"],
+            out_keys=["state_value"],
+        )
+        out = GAE(
+            gamma=0.9,
+            lmbda=0.95,
+            value_network=value_net,
+            shifted="compact-drop",
+            average_gae=True,
+        )(td)
+        valid = out["compact_drop_valid"].unsqueeze(-1)
+        torch.testing.assert_close(
+            out["advantage"][valid].mean(),
+            torch.zeros((), dtype=out["advantage"].dtype),
+        )
 
     def test_compact_drop_valid_masks_loss_reduction(self):
         loss = LossModule()

--- a/test/objectives/test_values.py
+++ b/test/objectives/test_values.py
@@ -27,6 +27,7 @@ from torchrl.envs.transforms import TransformedEnv
 from torchrl.modules import GRUModule, LSTMModule, OneHotCategorical, set_recurrent_mode
 from torchrl.modules.models.models import MLP
 from torchrl.modules.tensordict_module.actors import ProbabilisticActor
+from torchrl.objectives.common import LossModule
 from torchrl.objectives.value.advantages import (
     GAE,
     TD0Estimator,
@@ -463,6 +464,136 @@ class TestValues:
         adv_legacy = gae_legacy(td.copy())["advantage"]
         torch.testing.assert_close(adv_true, adv_legacy)
 
+    def _compact_drop_reference(self, td):
+        done = td["next", "done"]
+        reset = done.squeeze(-1).clone()
+        reset[..., -1] = False
+        reset_cs = reset.to(torch.long).cumsum(-1)
+        reset_before = torch.cat(
+            [reset_cs.new_zeros((*reset.shape[:-1], 1)), reset_cs[..., :-1]], -1
+        )
+        root_slot = torch.arange(reset.shape[-1], device=reset.device) + reset_before
+        valid = root_slot + 1 < reset.shape[-1] + 1
+        next_valid = torch.cat(
+            [valid[..., 1:], valid.new_zeros((*valid.shape[:-1], 1))], -1
+        )
+        last_valid = valid & ~next_valid
+        td = td.clone()
+        done = done.clone()
+        terminated = td["next", "terminated"].clone()
+        done[last_valid] = True
+        terminated[last_valid] = False
+        td["next", "done"] = done
+        td["next", "terminated"] = terminated
+        return td, valid
+
+    @pytest.mark.parametrize("reset_steps", [[2], [1, 3]])
+    def test_gae_shifted_compact_drop_retained_matches_unshifted(self, reset_steps):
+        torch.manual_seed(0)
+        B, T, obs_dim = 2, 6, 4
+        all_obs = torch.randn(B, T + 1, obs_dim)
+        obs = all_obs[:, :T].clone()
+        next_obs = all_obs[:, 1:].clone()
+        done = torch.zeros(B, T, 1, dtype=torch.bool)
+        for reset_step in reset_steps:
+            done[:, reset_step, 0] = True
+            next_obs[:, reset_step] = torch.randn(B, obs_dim)
+        done[:, -1, 0] = True
+        terminated = torch.zeros_like(done)
+        reward = torch.randn(B, T, 1)
+        td = TensorDict(
+            {
+                "observation": obs,
+                "next": TensorDict(
+                    {
+                        "observation": next_obs,
+                        "reward": reward,
+                        "done": done,
+                        "terminated": terminated,
+                    },
+                    [B, T],
+                ),
+            },
+            [B, T],
+        )
+        value_net = TensorDictModule(
+            nn.Linear(obs_dim, 1),
+            in_keys=["observation"],
+            out_keys=["state_value"],
+        )
+        ref_td, valid = self._compact_drop_reference(td)
+        gae_unshifted = GAE(
+            gamma=0.9,
+            lmbda=0.95,
+            value_network=value_net,
+            shifted=False,
+        )
+        gae_drop = GAE(
+            gamma=0.9,
+            lmbda=0.95,
+            value_network=value_net,
+            shifted="compact-drop",
+        )
+        ref_td = gae_unshifted(ref_td)
+        ref = ref_td["advantage"]
+        out = gae_drop(td.clone())
+        mask = valid.unsqueeze(-1)
+        torch.testing.assert_close(out["advantage"][mask], ref[mask])
+        torch.testing.assert_close(
+            out["value_target"][mask], ref_td["value_target"][mask]
+        )
+        assert out["compact_drop_valid"].equal(valid)
+        assert (~valid).sum() == done[..., :-1, :].sum()
+        assert (out["advantage"][~mask] == 0).all()
+
+    def test_gae_shifted_compact_drop_without_next_observation(self):
+        torch.manual_seed(0)
+        B, T, obs_dim = 2, 6, 4
+        obs = torch.randn(B, T, obs_dim)
+        done = torch.zeros(B, T, 1, dtype=torch.bool)
+        done[:, 2, 0] = True
+        done[:, -1, 0] = True
+        terminated = torch.zeros_like(done)
+        reward = torch.randn(B, T, 1)
+        td = TensorDict(
+            {
+                "observation": obs,
+                "next": TensorDict(
+                    {
+                        "reward": reward,
+                        "done": done,
+                        "terminated": terminated,
+                    },
+                    [B, T],
+                ),
+            },
+            [B, T],
+        )
+        value_net = TensorDictModule(
+            nn.Linear(obs_dim, 1),
+            in_keys=["observation"],
+            out_keys=["state_value"],
+        )
+        out = GAE(
+            gamma=0.9,
+            lmbda=0.95,
+            value_network=value_net,
+            shifted="compact-drop",
+        )(td.clone())
+        assert torch.isfinite(out["advantage"]).all()
+        assert out["compact_drop_valid"].shape == td.shape
+        assert (~out["compact_drop_valid"]).sum() == done[..., :-1, :].sum()
+
+    def test_compact_drop_valid_masks_loss_reduction(self):
+        loss = LossModule()
+        loss.reduction = "mean"
+        td = TensorDict(
+            {"compact_drop_valid": torch.tensor([True, False, True])},
+            [3],
+        )
+        value = torch.tensor([1.0, 100.0, 3.0])
+        torch.testing.assert_close(loss._reduce_loss(value, td), torch.tensor(2.0))
+
     @pytest.mark.skipif(
         _TORCH_VERSION < version.parse("2.7"),
         reason="GAE compact recurrent path uses torch.vmap chunked semantics that fall "
@@ -608,6 +739,39 @@ class TestValues:
             "episode boundary is a truncation), so the bias propagates "
             "into the value target."
         )
+
+        ref_td, valid = self._compact_drop_reference(td)
+        gae_legacy_drop_ref = GAE(
+            gamma=0.99,
+            lmbda=0.95,
+            value_network=value_net,
+            shifted="legacy",
+            deactivate_vmap=False,
+            average_gae=False,
+            vectorized=False,
+        )
+        gae_compact_drop = GAE(
+            gamma=0.99,
+            lmbda=0.95,
+            value_network=value_net,
+            shifted="compact-drop",
+            deactivate_vmap=False,
+            average_gae=False,
+            vectorized=False,
+        )
+        with set_recurrent_mode(True), torch.no_grad():
+            adv_legacy_drop = gae_legacy_drop_ref(ref_td.clone())["advantage"]
+            out_drop = gae_compact_drop(td.clone())
+        mask = valid.unsqueeze(-1)
+        torch.testing.assert_close(
+            out_drop["advantage"][mask],
+            adv_legacy_drop[mask],
+            atol=2.5e-1,
+            rtol=2.5e-1,
+        )
+        assert out_drop["compact_drop_valid"].equal(valid)
+        assert (~valid).sum() == done[..., :-1, :].sum()
+        assert (out_drop["advantage"][~mask] == 0).all()
 
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("gamma", [0.1, 0.5, 0.99])

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -33,7 +33,6 @@ from torchrl.objectives.utils import (
     _clip_value_loss,
     _GAMMA_LMBDA_DEPREC_ERROR,
     _get_default_device,
-    _reduce,
     default_value_kwargs,
     distance_loss,
     ValueEstimators,
@@ -589,7 +588,7 @@ class A2CLoss(LossModule):
             if value_clip_fraction is not None:
                 td_out.set("value_clip_fraction", value_clip_fraction)
         td_out = td_out.named_apply(
-            lambda name, value: _reduce(value, reduction=self.reduction).squeeze(-1)
+            lambda name, value: self._reduce_loss(value, tensordict).squeeze(-1)
             if name.startswith("loss_")
             else value,
         )

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -587,8 +587,9 @@ class A2CLoss(LossModule):
             td_out.set("loss_critic", loss_critic)
             if value_clip_fraction is not None:
                 td_out.set("value_clip_fraction", value_clip_fraction)
+        loss_mask = tensordict.get("compact_drop_valid", default=None)
         td_out = td_out.named_apply(
-            lambda name, value: self._reduce_loss(value, tensordict).squeeze(-1)
+            lambda name, value: self._reduce_loss(value, mask=loss_mask).squeeze(-1)
             if name.startswith("loss_")
             else value,
         )

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -263,25 +263,31 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
 
     @staticmethod
     def _expand_loss_mask(mask: torch.Tensor, loss: torch.Tensor) -> torch.Tensor:
-        while mask.ndim < loss.ndim:
-            mask = mask.unsqueeze(-1)
+        if mask.ndim < loss.ndim:
+            mask = mask.reshape(mask.shape + (1,) * (loss.ndim - mask.ndim))
         return mask.expand_as(loss)
 
     def _reduce_loss(
         self,
         loss: torch.Tensor,
-        tensordict: TensorDictBase,
+        tensordict: TensorDictBase | None = None,
         *,
+        mask: torch.Tensor | None = None,
         reduction: str | None = None,
         weights: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if reduction is None:
             reduction = self.reduction
-        mask = tensordict.get("compact_drop_valid", default=None)
+        if mask is None and tensordict is not None:
+            mask = tensordict.get("compact_drop_valid", default=None)
         if mask is not None:
             mask = self._expand_loss_mask(mask, loss)
             if weights is not None and weights.shape != loss.shape:
                 weights = self._expand_loss_mask(weights, loss)
+            if weights is None and reduction == "mean":
+                return (loss * mask.to(loss.dtype)).sum() / mask.sum().clamp_min(1)
+            if weights is None and reduction == "sum":
+                return (loss * mask.to(loss.dtype)).sum()
         return _reduce(loss, reduction=reduction, mask=mask, weights=weights)
 
     def set_keys(self, **kwargs) -> None:

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -22,7 +22,7 @@ from torch.nn import Parameter
 from torchrl._utils import rl_warnings
 from torchrl.envs.utils import ExplorationType, set_exploration_type
 from torchrl.modules.tensordict_module.rnn import set_recurrent_mode
-from torchrl.objectives.utils import ValueEstimators
+from torchrl.objectives.utils import _reduce, ValueEstimators
 from torchrl.objectives.value import ValueEstimatorBase
 
 try:
@@ -260,6 +260,29 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
                 raise RuntimeError(
                     f"Setting '{key}' via the constructor is deprecated, use .set_keys(<key>='some_key') instead.",
                 )
+
+    @staticmethod
+    def _expand_loss_mask(mask: torch.Tensor, loss: torch.Tensor) -> torch.Tensor:
+        while mask.ndim < loss.ndim:
+            mask = mask.unsqueeze(-1)
+        return mask.expand_as(loss)
+
+    def _reduce_loss(
+        self,
+        loss: torch.Tensor,
+        tensordict: TensorDictBase,
+        *,
+        reduction: str | None = None,
+        weights: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if reduction is None:
+            reduction = self.reduction
+        mask = tensordict.get("compact_drop_valid", default=None)
+        if mask is not None:
+            mask = self._expand_loss_mask(mask, loss)
+            if weights is not None and weights.shape != loss.shape:
+                weights = self._expand_loss_mask(weights, loss)
+        return _reduce(loss, reduction=reduction, mask=mask, weights=weights)
 
     def set_keys(self, **kwargs) -> None:
         """Set tensordict key names.

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -928,7 +928,7 @@ class PPOLoss(LossModule):
             if explained_variance is not None:
                 td_out.set("explained_variance", explained_variance)
         td_out = td_out.named_apply(
-            lambda name, value: _reduce(value, reduction=self.reduction).squeeze(-1)
+            lambda name, value: self._reduce_loss(value, tensordict).squeeze(-1)
             if name.startswith("loss_")
             else value,
         )
@@ -1335,7 +1335,7 @@ class ClipPPOLoss(PPOLoss):
             td_out.set("max_ratio", ratio.max())
             td_out.set("mean_ratio", ratio.mean())
         td_out = td_out.named_apply(
-            lambda name, value: _reduce(value, reduction=self.reduction).squeeze(-1)
+            lambda name, value: self._reduce_loss(value, tensordict).squeeze(-1)
             if name.startswith("loss_")
             else value,
         )
@@ -1691,7 +1691,7 @@ class KLPENPPOLoss(PPOLoss):
             if explained_variance is not None:
                 td_out.set("explained_variance", explained_variance)
         td_out = td_out.named_apply(
-            lambda name, value: _reduce(value, reduction=self.reduction).squeeze(-1)
+            lambda name, value: self._reduce_loss(value, tensordict_copy).squeeze(-1)
             if name.startswith("loss_")
             else value,
         )

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -878,6 +878,32 @@ class PPOLoss(LossModule):
             return None
         return self.critic_network_params.detach()
 
+    def _standardize_advantage(
+        self, advantage: torch.Tensor, tensordict: TensorDictBase
+    ) -> torch.Tensor:
+        mask = tensordict.get("compact_drop_valid", default=None)
+        if mask is None:
+            return _standardize(advantage, self.normalize_advantage_exclude_dims)
+        while mask.ndim < advantage.ndim:
+            mask = mask.unsqueeze(-1)
+        mask = mask.expand_as(advantage).to(advantage.dtype)
+        exclude_dims = {
+            dim if dim >= 0 else advantage.ndim + dim
+            for dim in self.normalize_advantage_exclude_dims
+        }
+        reduce_dims = [dim for dim in range(advantage.ndim) if dim not in exclude_dims]
+        count = mask.sum(dim=reduce_dims, keepdim=True).clamp_min(1)
+        loc = (advantage * mask).sum(dim=reduce_dims, keepdim=True) / count
+        scale = (
+            (
+                ((advantage - loc).pow(2) * mask).sum(dim=reduce_dims, keepdim=True)
+                / count
+            )
+            .sqrt()
+            .clamp_min(1e-4)
+        )
+        return (advantage - loc) / scale
+
     @dispatch
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         tensordict = tensordict.clone(False)
@@ -899,7 +925,7 @@ class PPOLoss(LossModule):
                     "if you want to keep any dimension independent while computing normalization statistics. "
                     "If you are working in multi-agent/multi-objective settings this is highly suggested."
                 )
-            advantage = _standardize(advantage, self.normalize_advantage_exclude_dims)
+            advantage = self._standardize_advantage(advantage, tensordict)
 
         log_weight, dist, kl_approx = self._log_weight(
             tensordict, adv_shape=advantage.shape[:-1]
@@ -927,8 +953,9 @@ class PPOLoss(LossModule):
                 td_out.set("value_clip_fraction", value_clip_fraction)
             if explained_variance is not None:
                 td_out.set("explained_variance", explained_variance)
+        loss_mask = tensordict.get("compact_drop_valid", default=None)
         td_out = td_out.named_apply(
-            lambda name, value: self._reduce_loss(value, tensordict).squeeze(-1)
+            lambda name, value: self._reduce_loss(value, mask=loss_mask).squeeze(-1)
             if name.startswith("loss_")
             else value,
         )
@@ -1282,7 +1309,7 @@ class ClipPPOLoss(PPOLoss):
                     "if you want to keep any dimension independent while computing normalization statistics. "
                     "If you are working in multi-agent/multi-objective settings this is highly suggested."
                 )
-            advantage = _standardize(advantage, self.normalize_advantage_exclude_dims)
+            advantage = self._standardize_advantage(advantage, tensordict)
 
         log_weight, dist, kl_approx = self._log_weight(
             tensordict, adv_shape=advantage.shape[:-1]
@@ -1334,8 +1361,9 @@ class ClipPPOLoss(PPOLoss):
             ratio = log_weight.exp()
             td_out.set("max_ratio", ratio.max())
             td_out.set("mean_ratio", ratio.mean())
+        loss_mask = tensordict.get("compact_drop_valid", default=None)
         td_out = td_out.named_apply(
-            lambda name, value: self._reduce_loss(value, tensordict).squeeze(-1)
+            lambda name, value: self._reduce_loss(value, mask=loss_mask).squeeze(-1)
             if name.startswith("loss_")
             else value,
         )
@@ -1619,7 +1647,7 @@ class KLPENPPOLoss(PPOLoss):
                     "if you want to keep any dimension independent while computing normalization statistics. "
                     "If you are working in multi-agent/multi-objective settings this is highly suggested."
                 )
-            advantage = _standardize(advantage, self.normalize_advantage_exclude_dims)
+            advantage = self._standardize_advantage(advantage, tensordict)
 
         log_weight, dist, kl_approx = self._log_weight(
             tensordict_copy, adv_shape=advantage.shape[:-1]
@@ -1690,8 +1718,9 @@ class KLPENPPOLoss(PPOLoss):
                 td_out.set("value_clip_fraction", value_clip_fraction)
             if explained_variance is not None:
                 td_out.set("explained_variance", explained_variance)
+        loss_mask = tensordict_copy.get("compact_drop_valid", default=None)
         td_out = td_out.named_apply(
-            lambda name, value: self._reduce_loss(value, tensordict_copy).squeeze(-1)
+            lambda name, value: self._reduce_loss(value, mask=loss_mask).squeeze(-1)
             if name.startswith("loss_")
             else value,
         )

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -402,8 +402,9 @@ class ReinforceLoss(LossModule):
         td_out.set("loss_value", loss_value)
         if value_clip_fraction is not None:
             td_out.set("value_clip_fraction", value_clip_fraction)
+        loss_mask = tensordict.get("compact_drop_valid", default=None)
         td_out = td_out.named_apply(
-            lambda name, value: self._reduce_loss(value, tensordict).squeeze(-1)
+            lambda name, value: self._reduce_loss(value, mask=loss_mask).squeeze(-1)
             if name.startswith("loss_")
             else value,
         )

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -23,7 +23,6 @@ from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _clip_value_loss,
     _GAMMA_LMBDA_DEPREC_ERROR,
-    _reduce,
     default_value_kwargs,
     distance_loss,
     ValueEstimators,
@@ -404,7 +403,7 @@ class ReinforceLoss(LossModule):
         if value_clip_fraction is not None:
             td_out.set("value_clip_fraction", value_clip_fraction)
         td_out = td_out.named_apply(
-            lambda name, value: _reduce(value, reduction=self.reduction).squeeze(-1)
+            lambda name, value: self._reduce_loss(value, tensordict).squeeze(-1)
             if name.startswith("loss_")
             else value,
         )

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -654,9 +654,13 @@ def _reduce(
         if weights is not None:
             # Weighted average: (tensor * weights).sum() / weights.sum()
             if mask is not None:
-                masked_weight = weights[mask]
-                masked_tensor = tensor[mask]
-                result = (masked_tensor * masked_weight).sum() / masked_weight.sum()
+                if tensor.shape != weights.shape:
+                    raise ValueError(
+                        f"Tensor and weights shapes must match, but got {tensor.shape} and {weights.shape}"
+                    )
+                mask = mask.to(dtype=weights.dtype)
+                masked_weight = weights * mask
+                result = (tensor * masked_weight).sum() / masked_weight.sum()
             else:
                 if tensor.shape != weights.shape:
                     raise ValueError(
@@ -664,16 +668,20 @@ def _reduce(
                     )
                 result = (tensor * weights).sum() / weights.sum()
         elif mask is not None:
-            result = tensor[mask].mean()
+            mask = mask.to(dtype=tensor.dtype)
+            result = (tensor * mask).sum() / mask.sum()
         else:
             result = tensor.mean()
     elif reduction == "sum":
         if weights is not None:
             # Weighted sum: (tensor * weights).sum()
             if mask is not None:
-                masked_weight = weights[mask]
-                masked_tensor = tensor[mask]
-                result = (masked_tensor * masked_weight).sum()
+                if tensor.shape != weights.shape:
+                    raise ValueError(
+                        f"Tensor and weights shapes must match, but got {tensor.shape} and {weights.shape}"
+                    )
+                mask = mask.to(dtype=weights.dtype)
+                result = (tensor * weights * mask).sum()
             else:
                 if tensor.shape != weights.shape:
                     raise ValueError(
@@ -681,7 +689,8 @@ def _reduce(
                     )
                 result = (tensor * weights).sum()
         elif mask is not None:
-            result = tensor[mask].sum()
+            mask = mask.to(dtype=tensor.dtype)
+            result = (tensor * mask).sum()
         else:
             result = tensor.sum()
     else:

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -257,7 +257,6 @@ class ValueEstimatorBase(TensorDictModuleBase):
         self.deactivate_vmap = deactivate_vmap
         self.value_chunk_size = value_chunk_size
         self.compact_cat_dim = compact_cat_dim
-        self._compact_drop_valid = None
         self.skip_existing = skip_existing
         self.__dict__["value_network"] = value_network
         self.dep_keys = {}
@@ -653,11 +652,21 @@ class ValueEstimatorBase(TensorDictModuleBase):
         next_part = self._fill_missing_next_inputs(next_part, root_part, in_keys)
         done = data.get(("next", self.tensor_keys.done))
         if done.shape[-1] == 1:
-            reset = done.squeeze(-1)
+            reset = done.squeeze(-1).clone()
         else:
             reset = done.any(-1)
-        reset = reset.clone()
         reset[(slice(None),) * time_idx + (-1,)] = False
+        if not is_dynamo_compiling() and not bool(reset.any()):
+            value, value_ = self._call_value_net_compact(
+                data=data,
+                params=params,
+                next_params=next_params,
+                value_key=value_key,
+                ndim=ndim,
+                value_net=value_net,
+                _call_value_net=_call_value_net,
+            )
+            return value, value_, None
         reset_long = reset.to(torch.long)
         reset_cs = reset_long.cumsum(time_idx)
         zero_shape = list(reset.shape)
@@ -790,7 +799,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
                 values.append(value_net(chunk).get(value_key))
             return torch.cat(values, dim=0)
 
-        self._compact_drop_valid = None
+        valid = None
         if single_call == "compact":
             value, value_ = self._call_value_net_compact(
                 data=data,
@@ -811,7 +820,6 @@ class ValueEstimatorBase(TensorDictModuleBase):
                 value_net=value_net,
                 _call_value_net=_call_value_net,
             )
-            self._compact_drop_valid = valid
         elif single_call:
             # We are going to flatten the data, then interleave the last observation of each trajectory in between its
             #  previous obs (from the root TD) and the first of the next trajectory. Eventually, each trajectory will
@@ -921,7 +929,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
         data.set(("next", value_key), value_)
         if detach_next:
             value_ = value_.detach()
-        return value, value_
+        return value, value_, valid
 
     def _compact_drop_last_valid(self, valid: torch.Tensor, time_dim: int):
         next_valid = torch.cat(
@@ -957,11 +965,11 @@ class ValueEstimatorBase(TensorDictModuleBase):
         tensordict = tensordict.copy()
         tensordict.set(
             ("next", self.tensor_keys.done),
-            torch.where(done_mask, torch.ones_like(done), done),
+            done.masked_fill(done_mask, True),
         )
         tensordict.set(
             ("next", self.tensor_keys.terminated),
-            torch.where(done_mask, torch.zeros_like(terminated), terminated),
+            terminated.masked_fill(done_mask, False),
         )
         return tensordict
 
@@ -974,7 +982,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
         for key in (self.tensor_keys.advantage, self.tensor_keys.value_target):
             value = tensordict.get(key)
             mask = self._expand_to_match(valid, value)
-            tensordict.set(key, torch.where(mask, value, torch.zeros_like(value)))
+            tensordict.set(key, value.masked_fill(~mask, 0))
 
 
 class TD0Estimator(ValueEstimatorBase):
@@ -1176,7 +1184,7 @@ class TD0Estimator(ValueEstimatorBase):
             ) else nullcontext():
                 # we may still need to pass gradient, but we don't want to assign grads to
                 # value net params
-                value, next_value = self._call_value_nets(
+                value, next_value, valid = self._call_value_nets(
                     data=tensordict,
                     params=params,
                     next_params=target_params,
@@ -1185,11 +1193,13 @@ class TD0Estimator(ValueEstimatorBase):
                     detach_next=True,
                     vmap_randomness=self.vmap_randomness,
                 )
+                if valid is not None:
+                    tensordict.set("compact_drop_valid", valid)
         else:
             value = tensordict.get(self.tensor_keys.value)
             next_value = tensordict.get(("next", self.tensor_keys.value))
 
-        valid = self._compact_drop_valid
+        valid = tensordict.get("compact_drop_valid", default=None)
         data_for_value = self._prepare_compact_drop_tensordict(
             tensordict, valid, self._get_time_dim(None, tensordict)
         )
@@ -1441,7 +1451,7 @@ class TD1Estimator(ValueEstimatorBase):
             ) else nullcontext():
                 # we may still need to pass gradient, but we don't want to assign grads to
                 # value net params
-                value, next_value = self._call_value_nets(
+                value, next_value, valid = self._call_value_nets(
                     data=tensordict,
                     params=params,
                     next_params=target_params,
@@ -1450,11 +1460,13 @@ class TD1Estimator(ValueEstimatorBase):
                     detach_next=True,
                     vmap_randomness=self.vmap_randomness,
                 )
+                if valid is not None:
+                    tensordict.set("compact_drop_valid", valid)
         else:
             value = tensordict.get(self.tensor_keys.value)
             next_value = tensordict.get(("next", self.tensor_keys.value))
 
-        valid = self._compact_drop_valid
+        valid = tensordict.get("compact_drop_valid", default=None)
         data_for_value = self._prepare_compact_drop_tensordict(
             tensordict, valid, self._get_time_dim(None, tensordict)
         )
@@ -1492,7 +1504,7 @@ class TD1Estimator(ValueEstimatorBase):
             next_value = self._next_value(tensordict, target_params, kwargs=kwargs)
 
         time_dim = self._get_time_dim(time_dim, tensordict)
-        valid = self._compact_drop_valid
+        valid = tensordict.get("compact_drop_valid", default=None)
         data_for_value = self._prepare_compact_drop_tensordict(
             tensordict, valid, time_dim
         )
@@ -1734,7 +1746,7 @@ class TDLambdaEstimator(ValueEstimatorBase):
             ) else nullcontext():
                 # we may still need to pass gradient, but we don't want to assign grads to
                 # value net params
-                value, next_value = self._call_value_nets(
+                value, next_value, valid = self._call_value_nets(
                     data=tensordict,
                     params=params,
                     next_params=target_params,
@@ -1743,10 +1755,12 @@ class TDLambdaEstimator(ValueEstimatorBase):
                     detach_next=True,
                     vmap_randomness=self.vmap_randomness,
                 )
+                if valid is not None:
+                    tensordict.set("compact_drop_valid", valid)
         else:
             value = tensordict.get(self.tensor_keys.value)
             next_value = tensordict.get(("next", self.tensor_keys.value))
-        valid = self._compact_drop_valid
+        valid = tensordict.get("compact_drop_valid", default=None)
         data_for_value = self._prepare_compact_drop_tensordict(
             tensordict, valid, self._get_time_dim(None, tensordict)
         )
@@ -1789,7 +1803,7 @@ class TDLambdaEstimator(ValueEstimatorBase):
             next_value = self._next_value(tensordict, target_params, kwargs=kwargs)
 
         time_dim = self._get_time_dim(time_dim, tensordict)
-        valid = self._compact_drop_valid
+        valid = tensordict.get("compact_drop_valid", default=None)
         data_for_value = self._prepare_compact_drop_tensordict(
             tensordict, valid, time_dim
         )
@@ -2109,7 +2123,7 @@ class GAE(ValueEstimatorBase):
                 # with torch.no_grad():
                 # we may still need to pass gradient, but we don't want to assign grads to
                 # value net params
-                value, next_value = self._call_value_nets(
+                value, next_value, valid = self._call_value_nets(
                     data=tensordict,
                     params=params,
                     next_params=target_params,
@@ -2118,6 +2132,8 @@ class GAE(ValueEstimatorBase):
                     detach_next=True,
                     vmap_randomness=self.vmap_randomness,
                 )
+                if valid is not None:
+                    tensordict.set("compact_drop_valid", valid)
         else:
             value = tensordict.get(self.tensor_keys.value)
             next_value = tensordict.get(("next", self.tensor_keys.value))
@@ -2132,7 +2148,7 @@ class GAE(ValueEstimatorBase):
                 )
 
         time_dim = self._get_time_dim(time_dim, tensordict)
-        valid = self._compact_drop_valid
+        valid = tensordict.get("compact_drop_valid", default=None)
         data_for_value = self._prepare_compact_drop_tensordict(
             tensordict, valid, time_dim
         )
@@ -2179,7 +2195,7 @@ class GAE(ValueEstimatorBase):
             )
 
         if self.average_gae:
-            adv = self._normalize_advantage(adv)
+            adv = self._normalize_advantage(adv, valid)
 
         tensordict.set(self.tensor_keys.advantage, adv)
         tensordict.set(self.tensor_keys.value_target, value_target)
@@ -2212,15 +2228,23 @@ class GAE(ValueEstimatorBase):
         """
         return tensor
 
-    def _normalize_advantage(self, adv: Tensor) -> Tensor:
+    def _normalize_advantage(
+        self, adv: Tensor, valid: torch.Tensor | None = None
+    ) -> Tensor:
         """Standardise the advantage tensor.
 
         Default standardises globally (single mean/std over the whole tensor).
         :class:`MultiAgentGAE` overrides this to leave the agent dim
         independent.
         """
-        loc = adv.mean()
-        scale = adv.std().clamp_min(1e-4)
+        if valid is None:
+            loc = adv.mean()
+            scale = adv.std().clamp_min(1e-4)
+            return (adv - loc) / scale
+        mask = self._expand_to_match(valid, adv).to(adv.dtype)
+        count = mask.sum().clamp_min(1)
+        loc = (adv * mask).sum() / count
+        scale = (((adv - loc).pow(2) * mask).sum() / count).sqrt().clamp_min(1e-4)
         return (adv - loc) / scale
 
     def value_estimate(
@@ -2264,7 +2288,7 @@ class GAE(ValueEstimatorBase):
             ) else nullcontext():
                 # we may still need to pass gradient, but we don't want to assign grads to
                 # value net params
-                value, next_value = self._call_value_nets(
+                value, next_value, valid = self._call_value_nets(
                     data=tensordict,
                     params=params,
                     next_params=target_params,
@@ -2273,11 +2297,20 @@ class GAE(ValueEstimatorBase):
                     detach_next=True,
                     vmap_randomness=self.vmap_randomness,
                 )
+                if valid is not None:
+                    tensordict.set("compact_drop_valid", valid)
         else:
             value = tensordict.get(self.tensor_keys.value)
             next_value = tensordict.get(("next", self.tensor_keys.value))
-        done = tensordict.get(("next", self.tensor_keys.done))
-        terminated = tensordict.get(("next", self.tensor_keys.terminated), default=done)
+        valid = tensordict.get("compact_drop_valid", default=None)
+        data_for_value = self._prepare_compact_drop_tensordict(
+            tensordict, valid, time_dim
+        )
+        reward = data_for_value.get(("next", self.tensor_keys.reward))
+        done = data_for_value.get(("next", self.tensor_keys.done))
+        terminated = data_for_value.get(
+            ("next", self.tensor_keys.terminated), default=done
+        )
         reward, done, terminated = self._prepare_signals(
             reward, done, terminated, value
         )
@@ -2374,13 +2407,25 @@ class MultiAgentGAE(GAE):
         # broadcasting policy as the other team signals.
         return self._broadcast_to_agents(tensor, value, self.agent_dim)
 
-    def _normalize_advantage(self, adv: Tensor) -> Tensor:
+    def _normalize_advantage(
+        self, adv: Tensor, valid: torch.Tensor | None = None
+    ) -> Tensor:
         # Per-agent standardisation: normalise over batch + time but keep the
         # agent dim independent so high-variance agents are not flattened.
         agent_dim = self.agent_dim if self.agent_dim >= 0 else adv.ndim + self.agent_dim
         reduce_dims = [d for d in range(adv.ndim) if d != agent_dim]
-        loc = adv.mean(dim=reduce_dims, keepdim=True)
-        scale = adv.std(dim=reduce_dims, keepdim=True).clamp_min(1e-4)
+        if valid is None:
+            loc = adv.mean(dim=reduce_dims, keepdim=True)
+            scale = adv.std(dim=reduce_dims, keepdim=True).clamp_min(1e-4)
+            return (adv - loc) / scale
+        mask = self._expand_to_match(valid, adv).to(adv.dtype)
+        count = mask.sum(dim=reduce_dims, keepdim=True).clamp_min(1)
+        loc = (adv * mask).sum(dim=reduce_dims, keepdim=True) / count
+        scale = (
+            (((adv - loc).pow(2) * mask).sum(dim=reduce_dims, keepdim=True) / count)
+            .sqrt()
+            .clamp_min(1e-4)
+        )
         return (adv - loc) / scale
 
 
@@ -2664,7 +2709,7 @@ class VTrace(ValueEstimatorBase):
             with hold_out_net(self.value_network):
                 # we may still need to pass gradient, but we don't want to assign grads to
                 # value net params
-                value, next_value = self._call_value_nets(
+                value, next_value, valid = self._call_value_nets(
                     data=tensordict,
                     params=params,
                     next_params=target_params,
@@ -2673,6 +2718,8 @@ class VTrace(ValueEstimatorBase):
                     detach_next=True,
                     vmap_randomness=self.vmap_randomness,
                 )
+                if valid is not None:
+                    tensordict.set("compact_drop_valid", valid)
         else:
             value = tensordict.get(self.tensor_keys.value)
             next_value = tensordict.get(("next", self.tensor_keys.value))
@@ -2694,7 +2741,7 @@ class VTrace(ValueEstimatorBase):
             log_pi = log_pi.view_as(value)
 
         time_dim = self._get_time_dim(time_dim, tensordict)
-        valid = self._compact_drop_valid
+        valid = tensordict.get("compact_drop_valid", default=None)
         data_for_value = self._prepare_compact_drop_tensordict(
             tensordict, valid, time_dim
         )

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -230,7 +230,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
         self,
         *,
         value_network: TensorDictModule,
-        shifted: bool | Literal["compact", "legacy"] = False,
+        shifted: bool | Literal["compact", "compact-drop", "legacy"] = False,
         differentiable: bool = False,
         skip_existing: bool | None = None,
         advantage_key: NestedKey = None,
@@ -257,6 +257,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
         self.deactivate_vmap = deactivate_vmap
         self.value_chunk_size = value_chunk_size
         self.compact_cat_dim = compact_cat_dim
+        self._compact_drop_valid = None
         self.skip_existing = skip_existing
         self.__dict__["value_network"] = value_network
         self.dep_keys = {}
@@ -501,8 +502,8 @@ class ValueEstimatorBase(TensorDictModuleBase):
 
     @staticmethod
     def _normalize_shifted(
-        shifted: bool | Literal["compact", "legacy"],
-    ) -> Literal[False, "compact", "legacy"]:
+        shifted: bool | Literal["compact", "compact-drop", "legacy"],
+    ) -> Literal[False, "compact", "compact-drop", "legacy"]:
         """Normalize the ``shifted`` argument.
 
         ``shifted=True`` is deprecated; users must opt in explicitly to
@@ -526,11 +527,11 @@ class ValueEstimatorBase(TensorDictModuleBase):
                 stacklevel=3,
             )
             return "legacy"
-        if shifted in ("compact", "legacy"):
+        if shifted in ("compact", "compact-drop", "legacy"):
             return shifted
         raise ValueError(
-            f"shifted must be one of False, 'compact', 'legacy' (or the "
-            f"deprecated True), got {shifted!r}."
+            "shifted must be one of False, 'compact', 'compact-drop', "
+            f"'legacy' (or the deprecated True), got {shifted!r}."
         )
 
     def _call_value_net_compact(
@@ -623,12 +624,133 @@ class ValueEstimatorBase(TensorDictModuleBase):
                 pass
         return value, value_
 
+    def _call_value_net_compact_drop(
+        self,
+        data: TensorDictBase,
+        params: TensorDictBase | None,
+        next_params: TensorDictBase | None,
+        value_key: NestedKey,
+        ndim: int,
+        value_net: TensorDictModuleBase,
+        _call_value_net,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Compact single-call path that inserts reset next-observations.
+
+        This backend keeps the value-network input length fixed to ``T + 1``.
+        It inserts true ``("next", ...)`` entries after internal reset steps,
+        shifts subsequent root entries to the right, and marks the displaced
+        suffix as invalid. Retained samples have exact root and next values.
+        """
+        if next_params is not None and next_params is not params:
+            raise ValueError(
+                "the value at t and t+1 cannot be retrieved in a single call when both params and next params are passed."
+            )
+        in_keys = value_net.in_keys
+        time_idx = ndim - 1
+        T = data.shape[time_idx]
+        root_part = data.select(*in_keys, value_key, strict=False)
+        next_part = data.get("next").select(*in_keys, value_key, strict=False)
+        next_part = self._fill_missing_next_inputs(next_part, root_part, in_keys)
+        done = data.get(("next", self.tensor_keys.done))
+        if done.shape[-1] == 1:
+            reset = done.squeeze(-1)
+        else:
+            reset = done.any(-1)
+        reset = reset.clone()
+        reset[(slice(None),) * time_idx + (-1,)] = False
+        reset_long = reset.to(torch.long)
+        reset_cs = reset_long.cumsum(time_idx)
+        zero_shape = list(reset.shape)
+        zero_shape[time_idx] = 1
+        reset_before = torch.cat(
+            [reset_cs.new_zeros(zero_shape), reset_cs.narrow(time_idx, 0, T - 1)],
+            dim=time_idx,
+        )
+        arange_shape = [1] * reset.ndim
+        arange_shape[time_idx] = T
+        arange = torch.arange(T, device=done.device).view(arange_shape)
+        root_slot = arange + reset_before
+        next_slot = root_slot + 1
+        valid = next_slot < (T + 1)
+        root_valid = root_slot < (T + 1)
+        reset_valid = reset & valid
+        boundary_slot = T + reset_long.sum(time_idx, keepdim=True)
+        boundary_valid = boundary_slot < (T + 1)
+        data_in_batch_size = list(root_part.batch_size)
+        data_in_batch_size[time_idx] = T + 1
+        data_in = root_part.new_zeros(data_in_batch_size)
+
+        def _expand_index(index: torch.Tensor, source: torch.Tensor) -> torch.Tensor:
+            while index.ndim < source.ndim:
+                index = index.unsqueeze(-1)
+            return index.expand_as(source)
+
+        def _expand_mask(mask: torch.Tensor, source: torch.Tensor) -> torch.Tensor:
+            while mask.ndim < source.ndim:
+                mask = mask.unsqueeze(-1)
+            return mask.expand_as(source)
+
+        def _scatter_time(
+            destination: torch.Tensor,
+            index: torch.Tensor,
+            source: torch.Tensor,
+            mask: torch.Tensor,
+        ) -> torch.Tensor:
+            index = index.clamp_max(T)
+            index_expand = _expand_index(index, source)
+            current = destination.gather(time_idx, index_expand)
+            source = torch.where(_expand_mask(mask, source), source, current)
+            return destination.scatter(time_idx, index_expand, source)
+
+        boundary_index = (slice(None),) * time_idx + (slice(T - 1, T),)
+        for key in in_keys:
+            root_value = root_part.get(key, default=None)
+            if root_value is None:
+                continue
+            data_value = data_in.get(key)
+            data_value = _scatter_time(data_value, root_slot, root_value, root_valid)
+            next_value = next_part.get(key, default=None)
+            if next_value is not None:
+                data_value = _scatter_time(
+                    data_value, next_slot, next_value, reset_valid
+                )
+                data_value = _scatter_time(
+                    data_value,
+                    boundary_slot,
+                    next_value[boundary_index],
+                    boundary_valid,
+                )
+            data_in.set(key, data_value)
+        if params is not None:
+            with params.to_module(value_net):
+                values_full = _call_value_net(data_in)
+        else:
+            values_full = _call_value_net(data_in)
+
+        def _gather_time(source: torch.Tensor, index: torch.Tensor) -> torch.Tensor:
+            index_expand = index.clamp_max(T)
+            while index_expand.ndim < source.ndim:
+                index_expand = index_expand.unsqueeze(-1)
+            target_shape = list(source.shape)
+            target_shape[time_idx] = index.shape[time_idx]
+            index_expand = index_expand.expand(target_shape)
+            return source.gather(time_idx, index_expand)
+
+        value = _gather_time(values_full, root_slot)
+        value_ = _gather_time(values_full, next_slot)
+        try:
+            value = value.view_as(done)
+            value_ = value_.view_as(done)
+        except RuntimeError:
+            pass
+        return value, value_, valid
+
     def _call_value_nets(
         self,
         data: TensorDictBase,
         params: TensorDictBase,
         next_params: TensorDictBase,
-        single_call: bool | Literal["compact", "legacy"],
+        single_call: bool | Literal["compact", "compact-drop", "legacy"],
         value_key: NestedKey,
         detach_next: bool,
         vmap_randomness: str = "error",
@@ -668,6 +790,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
                 values.append(value_net(chunk).get(value_key))
             return torch.cat(values, dim=0)
 
+        self._compact_drop_valid = None
         if single_call == "compact":
             value, value_ = self._call_value_net_compact(
                 data=data,
@@ -678,6 +801,17 @@ class ValueEstimatorBase(TensorDictModuleBase):
                 value_net=value_net,
                 _call_value_net=_call_value_net,
             )
+        elif single_call == "compact-drop":
+            value, value_, valid = self._call_value_net_compact_drop(
+                data=data,
+                params=params,
+                next_params=next_params,
+                value_key=value_key,
+                ndim=ndim,
+                value_net=value_net,
+                _call_value_net=_call_value_net,
+            )
+            self._compact_drop_valid = valid
         elif single_call:
             # We are going to flatten the data, then interleave the last observation of each trajectory in between its
             #  previous obs (from the root TD) and the first of the next trajectory. Eventually, each trajectory will
@@ -789,6 +923,59 @@ class ValueEstimatorBase(TensorDictModuleBase):
             value_ = value_.detach()
         return value, value_
 
+    def _compact_drop_last_valid(self, valid: torch.Tensor, time_dim: int):
+        next_valid = torch.cat(
+            [
+                valid.narrow(time_dim, 1, valid.shape[time_dim] - 1),
+                valid.new_zeros(
+                    [
+                        *valid.shape[:time_dim],
+                        1,
+                        *valid.shape[time_dim + 1 :],
+                    ]
+                ),
+            ],
+            dim=time_dim,
+        )
+        return valid & ~next_valid
+
+    @staticmethod
+    def _expand_to_match(source: torch.Tensor, target: torch.Tensor):
+        while source.ndim < target.ndim:
+            source = source.unsqueeze(-1)
+        return source.expand_as(target)
+
+    def _prepare_compact_drop_tensordict(
+        self, tensordict: TensorDictBase, valid: torch.Tensor | None, time_dim: int
+    ):
+        if valid is None:
+            return tensordict
+        last_valid = self._compact_drop_last_valid(valid, time_dim)
+        done = tensordict.get(("next", self.tensor_keys.done))
+        terminated = tensordict.get(("next", self.tensor_keys.terminated), default=done)
+        done_mask = self._expand_to_match(last_valid, done)
+        tensordict = tensordict.copy()
+        tensordict.set(
+            ("next", self.tensor_keys.done),
+            torch.where(done_mask, torch.ones_like(done), done),
+        )
+        tensordict.set(
+            ("next", self.tensor_keys.terminated),
+            torch.where(done_mask, torch.zeros_like(terminated), terminated),
+        )
+        return tensordict
+
+    def _mask_compact_drop_output(
+        self, tensordict: TensorDictBase, valid: torch.Tensor | None
+    ):
+        if valid is None:
+            return
+        tensordict.set("compact_drop_valid", valid)
+        for key in (self.tensor_keys.advantage, self.tensor_keys.value_target):
+            value = tensordict.get(key)
+            mask = self._expand_to_match(valid, value)
+            tensordict.set(key, torch.where(mask, value, torch.zeros_like(value)))
+
 
 class TD0Estimator(ValueEstimatorBase):
     """Temporal Difference (TD(0)) estimate of advantage function.
@@ -814,6 +1001,11 @@ class TD0Estimator(ValueEstimatorBase):
               the rollout was collected without ``compact_obs=True``,
               else copies ``V(obs[T-1])``. Compile-friendly — no Python
               branches on tensor values, no ``.item()`` syncs.
+            - ``"compact-drop"``: fixed ``T+1`` single-call path. Inserts
+              true ``next_obs`` after internal resets and masks the displaced
+              suffix samples via ``"compact_drop_valid"``. Retained samples
+              use exact next observations while keeping the old compact
+              compute budget.
             - ``"legacy"``: original flatten/interleave path. Builds a 1D
               sequence of size ``B*T + num_done`` with the real
               ``next_obs`` interleaved at every ``done`` index, giving
@@ -824,7 +1016,7 @@ class TD0Estimator(ValueEstimatorBase):
             - ``True`` (deprecated): aliased to ``"legacy"`` and emits a
               :class:`DeprecationWarning`. The alias is removed in v0.15.
 
-            Both single-call paths require that the parameters at time
+            All single-call paths require that the parameters at time
             ``t`` and ``t+1`` are identical (i.e. ``target_params`` is not
             used) and that the ``"next"`` value is shifted by exactly one
             time step (no multi-step returns). Defaults to ``False``.
@@ -867,7 +1059,7 @@ class TD0Estimator(ValueEstimatorBase):
         *,
         gamma: float | torch.Tensor,
         value_network: TensorDictModule,
-        shifted: bool | Literal["compact", "legacy"] = False,
+        shifted: bool | Literal["compact", "compact-drop", "legacy"] = False,
         average_rewards: bool = False,
         differentiable: bool = False,
         advantage_key: NestedKey = None,
@@ -997,9 +1189,14 @@ class TD0Estimator(ValueEstimatorBase):
             value = tensordict.get(self.tensor_keys.value)
             next_value = tensordict.get(("next", self.tensor_keys.value))
 
-        value_target = self.value_estimate(tensordict, next_value=next_value)
+        valid = self._compact_drop_valid
+        data_for_value = self._prepare_compact_drop_tensordict(
+            tensordict, valid, self._get_time_dim(None, tensordict)
+        )
+        value_target = self.value_estimate(data_for_value, next_value=next_value)
         tensordict.set(self.tensor_keys.advantage, value_target - value)
         tensordict.set(self.tensor_keys.value_target, value_target)
+        self._mask_compact_drop_output(tensordict, valid)
         return tensordict
 
     def value_estimate(
@@ -1081,6 +1278,11 @@ class TD1Estimator(ValueEstimatorBase):
               the rollout was collected without ``compact_obs=True``,
               else copies ``V(obs[T-1])``. Compile-friendly — no Python
               branches on tensor values, no ``.item()`` syncs.
+            - ``"compact-drop"``: fixed ``T+1`` single-call path. Inserts
+              true ``next_obs`` after internal resets and masks the displaced
+              suffix samples via ``"compact_drop_valid"``. Retained samples
+              use exact next observations while keeping the old compact
+              compute budget.
             - ``"legacy"``: original flatten/interleave path. Builds a 1D
               sequence of size ``B*T + num_done`` with the real
               ``next_obs`` interleaved at every ``done`` index, giving
@@ -1091,7 +1293,7 @@ class TD1Estimator(ValueEstimatorBase):
             - ``True`` (deprecated): aliased to ``"legacy"`` and emits a
               :class:`DeprecationWarning`. The alias is removed in v0.15.
 
-            Both single-call paths require that the parameters at time
+            All single-call paths require that the parameters at time
             ``t`` and ``t+1`` are identical (i.e. ``target_params`` is not
             used) and that the ``"next"`` value is shifted by exactly one
             time step (no multi-step returns). Defaults to ``False``.
@@ -1127,7 +1329,7 @@ class TD1Estimator(ValueEstimatorBase):
         advantage_key: NestedKey = None,
         value_target_key: NestedKey = None,
         value_key: NestedKey = None,
-        shifted: bool | Literal["compact", "legacy"] = False,
+        shifted: bool | Literal["compact", "compact-drop", "legacy"] = False,
         device: torch.device | None = None,
         time_dim: int | None = None,
         deactivate_vmap: bool = False,
@@ -1252,10 +1454,15 @@ class TD1Estimator(ValueEstimatorBase):
             value = tensordict.get(self.tensor_keys.value)
             next_value = tensordict.get(("next", self.tensor_keys.value))
 
-        value_target = self.value_estimate(tensordict, next_value=next_value)
+        valid = self._compact_drop_valid
+        data_for_value = self._prepare_compact_drop_tensordict(
+            tensordict, valid, self._get_time_dim(None, tensordict)
+        )
+        value_target = self.value_estimate(data_for_value, next_value=next_value)
 
         tensordict.set(self.tensor_keys.advantage, value_target - value)
         tensordict.set(self.tensor_keys.value_target, value_target)
+        self._mask_compact_drop_output(tensordict, valid)
         return tensordict
 
     def value_estimate(
@@ -1284,9 +1491,16 @@ class TD1Estimator(ValueEstimatorBase):
         if next_value is None:
             next_value = self._next_value(tensordict, target_params, kwargs=kwargs)
 
-        done = tensordict.get(("next", self.tensor_keys.done))
-        terminated = tensordict.get(("next", self.tensor_keys.terminated), default=done)
         time_dim = self._get_time_dim(time_dim, tensordict)
+        valid = self._compact_drop_valid
+        data_for_value = self._prepare_compact_drop_tensordict(
+            tensordict, valid, time_dim
+        )
+        reward = data_for_value.get(("next", self.tensor_keys.reward))
+        done = data_for_value.get(("next", self.tensor_keys.done))
+        terminated = data_for_value.get(
+            ("next", self.tensor_keys.terminated), default=done
+        )
         value_target = vec_td1_return_estimate(
             gamma,
             next_value,
@@ -1342,6 +1556,11 @@ class TDLambdaEstimator(ValueEstimatorBase):
               the rollout was collected without ``compact_obs=True``,
               else copies ``V(obs[T-1])``. Compile-friendly — no Python
               branches on tensor values, no ``.item()`` syncs.
+            - ``"compact-drop"``: fixed ``T+1`` single-call path. Inserts
+              true ``next_obs`` after internal resets and masks the displaced
+              suffix samples via ``"compact_drop_valid"``. Retained samples
+              use exact next observations while keeping the old compact
+              compute budget.
             - ``"legacy"``: original flatten/interleave path. Builds a 1D
               sequence of size ``B*T + num_done`` with the real
               ``next_obs`` interleaved at every ``done`` index, giving
@@ -1352,7 +1571,7 @@ class TDLambdaEstimator(ValueEstimatorBase):
             - ``True`` (deprecated): aliased to ``"legacy"`` and emits a
               :class:`DeprecationWarning`. The alias is removed in v0.15.
 
-            Both single-call paths require that the parameters at time
+            All single-call paths require that the parameters at time
             ``t`` and ``t+1`` are identical (i.e. ``target_params`` is not
             used) and that the ``"next"`` value is shifted by exactly one
             time step (no multi-step returns). Defaults to ``False``.
@@ -1390,7 +1609,7 @@ class TDLambdaEstimator(ValueEstimatorBase):
         advantage_key: NestedKey = None,
         value_target_key: NestedKey = None,
         value_key: NestedKey = None,
-        shifted: bool | Literal["compact", "legacy"] = False,
+        shifted: bool | Literal["compact", "compact-drop", "legacy"] = False,
         device: torch.device | None = None,
         time_dim: int | None = None,
         deactivate_vmap: bool = False,
@@ -1527,10 +1746,15 @@ class TDLambdaEstimator(ValueEstimatorBase):
         else:
             value = tensordict.get(self.tensor_keys.value)
             next_value = tensordict.get(("next", self.tensor_keys.value))
-        value_target = self.value_estimate(tensordict, next_value=next_value)
+        valid = self._compact_drop_valid
+        data_for_value = self._prepare_compact_drop_tensordict(
+            tensordict, valid, self._get_time_dim(None, tensordict)
+        )
+        value_target = self.value_estimate(data_for_value, next_value=next_value)
 
         tensordict.set(self.tensor_keys.advantage, value_target - value)
         tensordict.set(self.tensor_keys.value_target, value_target)
+        self._mask_compact_drop_output(tensordict, valid)
         return tensordict
 
     def value_estimate(
@@ -1564,9 +1788,16 @@ class TDLambdaEstimator(ValueEstimatorBase):
         if next_value is None:
             next_value = self._next_value(tensordict, target_params, kwargs=kwargs)
 
-        done = tensordict.get(("next", self.tensor_keys.done))
-        terminated = tensordict.get(("next", self.tensor_keys.terminated), default=done)
         time_dim = self._get_time_dim(time_dim, tensordict)
+        valid = self._compact_drop_valid
+        data_for_value = self._prepare_compact_drop_tensordict(
+            tensordict, valid, time_dim
+        )
+        reward = data_for_value.get(("next", self.tensor_keys.reward))
+        done = data_for_value.get(("next", self.tensor_keys.done))
+        terminated = data_for_value.get(
+            ("next", self.tensor_keys.terminated), default=done
+        )
         if self.vectorized:
             val = vec_td_lambda_return_estimate(
                 gamma,
@@ -1640,6 +1871,11 @@ class GAE(ValueEstimatorBase):
               the rollout was collected without ``compact_obs=True``,
               else copies ``V(obs[T-1])``. Compile-friendly — no Python
               branches on tensor values, no ``.item()`` syncs.
+            - ``"compact-drop"``: fixed ``T+1`` single-call path. Inserts
+              true ``next_obs`` after internal resets and masks the displaced
+              suffix samples via ``"compact_drop_valid"``. Retained samples
+              use exact next observations while keeping the old compact
+              compute budget.
             - ``"legacy"``: original flatten/interleave path. Builds a 1D
               sequence of size ``B*T + num_done`` with the real
               ``next_obs`` interleaved at every ``done`` index, giving
@@ -1650,7 +1886,7 @@ class GAE(ValueEstimatorBase):
             - ``True`` (deprecated): aliased to ``"legacy"`` and emits a
               :class:`DeprecationWarning`. The alias is removed in v0.15.
 
-            Both single-call paths require that the parameters at time
+            All single-call paths require that the parameters at time
             ``t`` and ``t+1`` are identical (i.e. ``target_params`` is not
             used) and that the ``"next"`` value is shifted by exactly one
             time step (no multi-step returns). Defaults to ``False``.
@@ -1717,7 +1953,7 @@ class GAE(ValueEstimatorBase):
         advantage_key: NestedKey = None,
         value_target_key: NestedKey = None,
         value_key: NestedKey = None,
-        shifted: bool | Literal["compact", "legacy"] = False,
+        shifted: bool | Literal["compact", "compact-drop", "legacy"] = False,
         device: torch.device | None = None,
         time_dim: int | None = None,
         auto_reset_env: bool = False,
@@ -1895,9 +2131,16 @@ class GAE(ValueEstimatorBase):
                     f"The tensor with key {('next', self.tensor_keys.value)} is missing, and no value network was provided."
                 )
 
-        done = tensordict.get(("next", self.tensor_keys.done))
-        terminated = tensordict.get(("next", self.tensor_keys.terminated), default=done)
         time_dim = self._get_time_dim(time_dim, tensordict)
+        valid = self._compact_drop_valid
+        data_for_value = self._prepare_compact_drop_tensordict(
+            tensordict, valid, time_dim
+        )
+        reward = data_for_value.get(("next", self.tensor_keys.reward))
+        done = data_for_value.get(("next", self.tensor_keys.done))
+        terminated = data_for_value.get(
+            ("next", self.tensor_keys.terminated), default=done
+        )
 
         # Subclass extension hook: lets subclasses reshape / broadcast the
         # reward and done signals to match the value tensor before the
@@ -1940,6 +2183,7 @@ class GAE(ValueEstimatorBase):
 
         tensordict.set(self.tensor_keys.advantage, adv)
         tensordict.set(self.tensor_keys.value_target, value_target)
+        self._mask_compact_drop_output(tensordict, valid)
 
         return tensordict
 
@@ -2189,6 +2433,11 @@ class VTrace(ValueEstimatorBase):
               the rollout was collected without ``compact_obs=True``,
               else copies ``V(obs[T-1])``. Compile-friendly — no Python
               branches on tensor values, no ``.item()`` syncs.
+            - ``"compact-drop"``: fixed ``T+1`` single-call path. Inserts
+              true ``next_obs`` after internal resets and masks the displaced
+              suffix samples via ``"compact_drop_valid"``. Retained samples
+              use exact next observations while keeping the old compact
+              compute budget.
             - ``"legacy"``: original flatten/interleave path. Builds a 1D
               sequence of size ``B*T + num_done`` with the real
               ``next_obs`` interleaved at every ``done`` index, giving
@@ -2199,7 +2448,7 @@ class VTrace(ValueEstimatorBase):
             - ``True`` (deprecated): aliased to ``"legacy"`` and emits a
               :class:`DeprecationWarning`. The alias is removed in v0.15.
 
-            Both single-call paths require that the parameters at time
+            All single-call paths require that the parameters at time
             ``t`` and ``t+1`` are identical (i.e. ``target_params`` is not
             used) and that the ``"next"`` value is shifted by exactly one
             time step (no multi-step returns). Defaults to ``False``.
@@ -2244,7 +2493,7 @@ class VTrace(ValueEstimatorBase):
         advantage_key: NestedKey | None = None,
         value_target_key: NestedKey | None = None,
         value_key: NestedKey | None = None,
-        shifted: bool | Literal["compact", "legacy"] = False,
+        shifted: bool | Literal["compact", "compact-drop", "legacy"] = False,
         device: torch.device | None = None,
         time_dim: int | None = None,
         value_chunk_size: int | None = None,
@@ -2444,11 +2693,17 @@ class VTrace(ValueEstimatorBase):
             )
             log_pi = log_pi.view_as(value)
 
-        # Compute the V-Trace correction
-        done = tensordict.get(("next", self.tensor_keys.done))
-        terminated = tensordict.get(("next", self.tensor_keys.terminated))
-
         time_dim = self._get_time_dim(time_dim, tensordict)
+        valid = self._compact_drop_valid
+        data_for_value = self._prepare_compact_drop_tensordict(
+            tensordict, valid, time_dim
+        )
+        reward = data_for_value.get(("next", self.tensor_keys.reward))
+
+        # Compute the V-Trace correction
+        done = data_for_value.get(("next", self.tensor_keys.done))
+        terminated = data_for_value.get(("next", self.tensor_keys.terminated))
+
         adv, value_target = vtrace_advantage_estimate(
             gamma,
             log_pi,
@@ -2471,6 +2726,7 @@ class VTrace(ValueEstimatorBase):
 
         tensordict.set(self.tensor_keys.advantage, adv)
         tensordict.set(self.tensor_keys.value_target, value_target)
+        self._mask_compact_drop_output(tensordict, valid)
 
         return tensordict
 


### PR DESCRIPTION
## Summary
- Add `shifted="compact-drop"`, a fixed `T+1` value-estimator backend that inserts true reset next-observations and masks displaced tail samples.
- Store `compact_drop_valid` on value-estimator output and thread it through shared actor-critic loss reductions so dropped samples do not affect mean losses.
- Cover retained-sample exactness, missing `("next", observation)` inputs, recurrent Isaac-shaped rollouts, and loss-mask reduction.

## Test plan
- `pytest test/objectives/test_values.py::TestValues::test_gae_shifted_compact_and_legacy test/objectives/test_values.py::TestValues::test_gae_shifted_compact_drop_retained_matches_unshifted test/objectives/test_values.py::TestValues::test_gae_shifted_compact_drop_without_next_observation test/objectives/test_values.py::TestValues::test_compact_drop_valid_masks_loss_reduction test/objectives/test_values.py::TestValues::test_gae_recurrent_shifted_compact_matches_unshifted_isaac_shape test/objectives/test_ppo.py::TestPPO::test_ppo_reduction test/objectives/test_ppo.py::TestA2C::test_a2c_reduction test/objectives/test_ppo.py::TestReinforce::test_reinforce_reduction -q`
- Compact-drop measurement smoke: `valid samples 464`, `dropped samples 48`, `adv abs max dropped 0.0`
- `git diff --check -- torchrl/objectives/value/advantages.py test/objectives/test_values.py torchrl/objectives/common.py torchrl/objectives/ppo.py torchrl/objectives/a2c.py torchrl/objectives/reinforce.py`


Made with [Cursor](https://cursor.com)