### PR TITLE
[BugFix] Set "next" obs to current if native_autoreset

### DIFF
--- a/test/envs/test_auto_reset.py
+++ b/test/envs/test_auto_reset.py
@@ -99,7 +99,7 @@ class TestAutoReset:
             )
 
         assert tensordict["next", "done"].all()
-        assert (tensordict["next", "observation"] == 0).all()
+        assert (tensordict["next", "observation"] == tensordict["observation"]).all()
         assert not tensordict_["done"].any()
         assert tensordict_["is_init"].all()
 

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -3694,10 +3694,8 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
                 continue
             reset_observations[obs_key] = obs.clone()
             current_obs = tensordict.get(obs_key, None)
-            if current_obs is not None:
+            if obs.is_floating_point():
                 obs[done] = current_obs[done]
-            elif obs.is_floating_point():
-                obs[done] = torch.nan
             else:
                 obs[done] = 0
         return reset_observations

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -3693,7 +3693,10 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
             if obs is None or not isinstance(obs, torch.Tensor):
                 continue
             reset_observations[obs_key] = obs.clone()
-            if obs.is_floating_point():
+            current_obs = tensordict.get(obs_key, None)
+            if current_obs is not None:
+                obs[done] = current_obs[done]
+            elif obs.is_floating_point():
                 obs[done] = torch.nan
             else:
                 obs[done] = 0

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -955,8 +955,8 @@ class GymWrapper(GymLikeEnv, metaclass=_GymAsyncMeta):
             observation returned by the environment as the next root observation
             instead of calling reset from
             :meth:`~torchrl.envs.EnvBase.step_and_maybe_reset`. The terminal
-            ``"next"`` observation is still invalid and filled with ``NaN`` for
-            floating point observations. Defaults to ``False``.
+            ``"next"`` observation is replaced with the current (root)
+            observation. Defaults to ``False``.
 
     Attributes:
         available_envs (List[str]): a list of environments to build.

--- a/torchrl/envs/libs/isaac_lab.py
+++ b/torchrl/envs/libs/isaac_lab.py
@@ -61,6 +61,7 @@ class IsaacLabWrapper(GymWrapper):
         allow_done_after_reset: bool = True,
         convert_actions_to_numpy: bool = False,
         device: torch.device | None = None,
+        native_autoreset: bool = False,
         **kwargs,
     ):
         if device is None:

--- a/torchrl/envs/libs/isaac_lab.py
+++ b/torchrl/envs/libs/isaac_lab.py
@@ -72,6 +72,7 @@ class IsaacLabWrapper(GymWrapper):
             categorical_action_encoding=categorical_action_encoding,
             allow_done_after_reset=allow_done_after_reset,
             convert_actions_to_numpy=convert_actions_to_numpy,
+            native_autoreset=native_autoreset,
             **kwargs,
         )
 

--- a/torchrl/envs/libs/isaac_lab.py
+++ b/torchrl/envs/libs/isaac_lab.py
@@ -61,7 +61,6 @@ class IsaacLabWrapper(GymWrapper):
         allow_done_after_reset: bool = True,
         convert_actions_to_numpy: bool = False,
         device: torch.device | None = None,
-        native_autoreset: bool = False,
         **kwargs,
     ):
         if device is None:
@@ -72,7 +71,6 @@ class IsaacLabWrapper(GymWrapper):
             categorical_action_encoding=categorical_action_encoding,
             allow_done_after_reset=allow_done_after_reset,
             convert_actions_to_numpy=convert_actions_to_numpy,
-            native_autoreset=native_autoreset,
             **kwargs,
         )
 

--- a/torchrl/envs/transforms/_misc.py
+++ b/torchrl/envs/transforms/_misc.py
@@ -408,8 +408,8 @@ class VecGymEnvTransform(Transform):
         native_autoreset (bool, optional): if ``True``, leaves the native
             auto-reset observation available to the environment wrapper so it
             can be cloned into the next root observation, while the terminal
-            floating point ``"next"`` observation is marked with ``NaN``.
-            Defaults to ``False``.
+            ``"next"`` observation is replaced with the current (root)
+            observation. Defaults to ``False``.
 
     .. note:: In general, this class should not be handled directly. It is
         created whenever a vectorized environment is placed within a :class:`GymWrapper`.


### PR DESCRIPTION
## Description

This PR changes the "next" obs of the terminal state to the obs from the terminal state instead of setting it to NaN.

## Motivation and Context

When using `native_autoreset` the next obs at a terminal state is set to NaN. However, this causes errors when calculating GAE. We could artificially replace it with a value like `missing_obs_value` (e.g. setting it to 0), but could lead to confusion or silent errors potentially. This PR proposes to just set it to the current obs, as that is what is assumed when calculating GAE. We could consider removing `auto_reset_env` in GAE, but I'm keeping it in for now to allow the flexibility.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
