### PR TITLE
[BugFix] Reset native autoreset transforms with masks

### DIFF
--- a/test/envs/test_auto_reset.py
+++ b/test/envs/test_auto_reset.py
@@ -24,10 +24,17 @@ from tensordict import (
 
 from torchrl import set_auto_unwrap_transformed_env
 from torchrl.data import LazyStackStorage, ReplayBuffer, SliceSampler
-from torchrl.data.tensor_specs import NonTensor
+from torchrl.data.tensor_specs import Composite, NonTensor, Unbounded
 from torchrl.envs import CatFrames, ParallelEnv, SerialEnv, TrajCounter
 from torchrl.envs.libs.gym import GymEnv
-from torchrl.envs.transforms import InitTracker, StepCounter, TransformedEnv, VecNormV2
+from torchrl.envs.transforms import (
+    Compose,
+    InitTracker,
+    RewardSum,
+    StepCounter,
+    TransformedEnv,
+    VecNormV2,
+)
 from torchrl.envs.transforms.transforms import (
     AutoResetEnv,
     AutoResetTransform,
@@ -49,6 +56,108 @@ from torchrl.testing.mocking_classes import (
 
 
 class TestAutoReset:
+    @staticmethod
+    def _step_native_auto_reset_until_done(env):
+        tensordict = env.reset()
+        for _ in range(10):
+            tensordict.update(env.full_action_spec.one())
+            tensordict, tensordict_ = env.step_and_maybe_reset(
+                tensordict,
+            )
+            if tensordict["next", "done"].all():
+                return tensordict, tensordict_
+            tensordict = tensordict_
+        raise RuntimeError("Auto-resetting counting env did not terminate.")
+
+    def test_native_auto_reset_resets_transform_state(self):
+        class RewardingAutoResettingCountingEnv(AutoResettingCountingEnv):
+            def _step(self, tensordict):
+                tensordict = super()._step(tensordict)
+                tensordict["reward"] = torch.ones_like(tensordict["reward"])
+                return tensordict
+
+        env = TransformedEnv(
+            RewardingAutoResettingCountingEnv(3),
+            Compose(StepCounter(), RewardSum(), TrajCounter()),
+        )
+        env._torchrl_native_autoreset = True
+        env.full_observation_spec
+
+        tensordict, tensordict_ = self._step_native_auto_reset_until_done(env)
+
+        assert tensordict["next", "done"].all()
+        assert not tensordict_["done"].any()
+        assert (tensordict_["observation"] == 0).all()
+        assert (tensordict_["step_count"] == 0).all()
+        assert (tensordict_["episode_reward"] == 0).all()
+        assert (tensordict_["traj_count"] == 1).all()
+
+    def test_native_auto_reset_reset_mask_reaches_all_transforms(self):
+        class ResetMaskRecorder(Transform):
+            def __init__(self, key):
+                super().__init__()
+                self.key = key
+
+            def _reset_on_native_autoreset(self, tensordict, tensordict_reset):
+                tensordict_reset.set(self.key, tensordict.get("_reset"))
+                return tensordict_reset
+
+        env = TransformedEnv(
+            AutoResettingCountingEnv(3),
+            Compose(
+                ResetMaskRecorder("reset_before"),
+                StepCounter(),
+                ResetMaskRecorder("reset_after"),
+            ),
+        )
+        env._torchrl_native_autoreset = True
+        env.full_observation_spec
+
+        tensordict, tensordict_ = self._step_native_auto_reset_until_done(env)
+
+        assert tensordict["next", "done"].all()
+        assert not tensordict_["done"].any()
+        assert tensordict_["reset_before"].all()
+        assert tensordict_["reset_after"].all()
+        assert (tensordict_["step_count"] == 0).all()
+
+    def test_native_auto_reset_resets_catframes_state(self):
+        class FloatAutoResettingCountingEnv(AutoResettingCountingEnv):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.observation_spec = Composite(
+                    observation=Unbounded(
+                        (*self.batch_size, 1),
+                        dtype=torch.float32,
+                        device=self.device,
+                    ),
+                    shape=self.batch_size,
+                    device=self.device,
+                )
+
+            def _reset(self, tensordict=None):
+                tensordict = super()._reset(tensordict)
+                tensordict["observation"] = tensordict["observation"].to(torch.float32)
+                return tensordict
+
+            def _step(self, tensordict):
+                tensordict = super()._step(tensordict)
+                tensordict["observation"] = tensordict["observation"].to(torch.float32)
+                return tensordict
+
+        env = TransformedEnv(
+            FloatAutoResettingCountingEnv(3),
+            CatFrames(N=2, dim=-1, in_keys=["observation"]),
+        )
+        env._torchrl_native_autoreset = True
+        env.full_observation_spec
+
+        tensordict, tensordict_ = self._step_native_auto_reset_until_done(env)
+
+        assert tensordict["next", "done"].all()
+        assert not tensordict_["done"].any()
+        assert (tensordict_["observation"] == 0).all()
+
     def test_native_auto_reset_wrapped_vecnorm_step_and_maybe_reset(self):
         class CountingVecNormV2(VecNormV2):
             def __init__(self, *args, **kwargs):

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -24,7 +24,7 @@ from tensordict import (
     unravel_key,
 )
 from tensordict.base import _is_leaf_nontensor, NO_DEFAULT
-from tensordict.utils import is_non_tensor, NestedKey
+from tensordict.utils import expand_as_right, is_non_tensor, NestedKey
 from torchrl._utils import (
     _ends_with,
     _make_ordinal_device,
@@ -3680,10 +3680,11 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
         self, tensordict: TensorDictBase
     ) -> dict[NestedKey, torch.Tensor]:
         next_tensordict = tensordict.get("next")
-        done = False
+        done = None
         for done_key in self.done_keys:
-            done = done | next_tensordict.get(done_key)
-        if done is False or not done.any():
+            done_value = next_tensordict.get(done_key)
+            done = done_value if done is None else done | done_value
+        if done is None:
             return {}
         done = done.squeeze(-1)
 
@@ -3693,10 +3694,12 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
             if obs is None or not isinstance(obs, torch.Tensor):
                 continue
             reset_observations[obs_key] = obs.clone()
+            done_obs = expand_as_right(done, obs)
             if obs.is_floating_point():
-                obs[done] = torch.nan
+                obs = torch.where(done_obs, torch.full_like(obs, torch.nan), obs)
             else:
-                obs[done] = 0
+                obs = torch.where(done_obs, torch.zeros_like(obs), obs)
+            next_tensordict.set(obs_key, obs)
         return reset_observations
 
     @property
@@ -3907,8 +3910,20 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
             for obs_key, obs in reset_observations.items():
                 if obs_key in tensordict_.keys(True, True):
                     tensordict_.set(obs_key, obs)
+            done_by_key = {
+                done_key: tensordict_.get(done_key).clone()
+                for done_key in self.done_keys
+            }
+            for done_group in self.done_keys_groups:
+                reset = False
+                for done_key in done_group:
+                    reset = reset | done_by_key[done_key]
+                tensordict_.set(_replace_last(done_group[0], "_reset"), reset.clone())
+            tensordict_ = self._reset_on_native_autoreset(tensordict_, tensordict_)
+            for reset_key in self.reset_keys:
+                tensordict_.pop(reset_key, None)
             for done_key in self.done_keys:
-                done = tensordict_.get(done_key).clone()
+                done = done_by_key[done_key]
                 init_key = _replace_last(done_key, "is_init")
                 if init_key in tensordict_.keys(True, True):
                     tensordict_.set(init_key, done.clone())
@@ -3936,6 +3951,11 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
     it are expected to expose a ``_post_step_mdp_hooks`` method themselves and
     rely on :class:`~torchrl.envs.TransformedEnv` to delegate the call.
     """
+
+    def _reset_on_native_autoreset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        return tensordict_reset
 
     @property
     @_cache_value

--- a/torchrl/envs/transforms/_base.py
+++ b/torchrl/envs/transforms/_base.py
@@ -314,6 +314,17 @@ class Transform(nn.Module):
         """Resets a transform if it is stateful."""
         return tensordict_reset
 
+    def _reset_on_native_autoreset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        """Updates transform state after an environment-side auto-reset.
+
+        Native auto-reset envs have already reset their base state during
+        ``step``. The reset mask is carried through regular reset keys in the
+        input tensordict.
+        """
+        return tensordict_reset
+
     def _reset_env_preprocess(self, tensordict: TensorDictBase) -> TensorDictBase:
         """Inverts the input to :meth:`TransformedEnv._reset`, if needed."""
         if self.enable_inv_on_reset and tensordict is not None:
@@ -1091,6 +1102,17 @@ class TransformedEnv(EnvBase, metaclass=_TEnvPostInit):
             )
         return tensordict, tensordict_
 
+    def _reset_on_native_autoreset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        """Run native-autoreset transform hooks in reset order."""
+        base_env = self.base_env
+        if base_env is not None:
+            tensordict_reset = base_env._reset_on_native_autoreset(
+                tensordict, tensordict_reset
+            )
+        return self.transform._reset_on_native_autoreset(tensordict, tensordict_reset)
+
     def fake_tensordict(self) -> TensorDictBase:
         """Build a fake tensordict and let the transform chain post-process it."""
         fake_td = super().fake_tensordict()
@@ -1802,6 +1824,15 @@ class Compose(Transform):
     ) -> TensorDictBase:
         for t in self.transforms:
             tensordict_reset = t._reset(tensordict, tensordict_reset)
+        return tensordict_reset
+
+    def _reset_on_native_autoreset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        for t in self.transforms:
+            tensordict_reset = t._reset_on_native_autoreset(
+                tensordict, tensordict_reset
+            )
         return tensordict_reset
 
     def _reset_env_preprocess(self, tensordict: TensorDictBase) -> TensorDictBase:

--- a/torchrl/envs/transforms/_env.py
+++ b/torchrl/envs/transforms/_env.py
@@ -564,6 +564,11 @@ class TensorDictPrimer(Transform):
             return tensordict_reset
         return self._reset_func(tensordict, tensordict_reset)
 
+    def _reset_on_native_autoreset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        return self._reset(tensordict, tensordict_reset)
+
     def _reset_env_preprocess(self, tensordict: TensorDictBase) -> TensorDictBase:
         if not self.call_before_env_reset:
             return tensordict
@@ -936,6 +941,11 @@ class StepCounter(Transform):
                     tensordict_reset.set(done_key, truncated)
                 tensordict_reset.set(truncated_key, truncated)
         return tensordict_reset
+
+    def _reset_on_native_autoreset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        return self._reset(tensordict, tensordict_reset)
 
     def _step(
         self, tensordict: TensorDictBase, next_tensordict: TensorDictBase
@@ -1346,6 +1356,11 @@ class RandomTruncationTransform(Transform):
                 # First episode is over for these envs
                 self._first_episode[mask] = False
         return tensordict_reset
+
+    def _reset_on_native_autoreset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        return self._reset(tensordict, tensordict_reset)
 
     def transform_output_spec(self, output_spec: Composite) -> Composite:
         full_done_spec = self.parent.output_spec["full_done_spec"]
@@ -2318,6 +2333,11 @@ class TrajCounter(Transform):
             )
             tensordict_reset.set(traj_count_key, episodes)
         return tensordict_reset
+
+    def _reset_on_native_autoreset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        return self._reset(tensordict, tensordict_reset)
 
     def _step(
         self, tensordict: TensorDictBase, next_tensordict: TensorDictBase

--- a/torchrl/envs/transforms/_misc.py
+++ b/torchrl/envs/transforms/_misc.py
@@ -211,6 +211,11 @@ class TimeMaxPool(Transform):
                     raise KeyError(f"Could not find {in_key} in the reset data.")
             return self._call(tensordict_reset, _reset=_reset)
 
+    def _reset_on_native_autoreset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        return self._reset(tensordict, tensordict_reset)
+
     def _make_missing_buffer(self, tensordict, in_key, buffer_name):
         buffer = getattr(self, buffer_name)
         data = tensordict.get(in_key)

--- a/torchrl/envs/transforms/_observation.py
+++ b/torchrl/envs/transforms/_observation.py
@@ -1129,6 +1129,25 @@ class CatFrames(ObservationTransform):
 
         return tensordict_reset
 
+    def _reset_on_native_autoreset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        tensordict_reset = tensordict_reset.copy()
+        for in_key in self.in_keys:
+            buffer_name = f"_cat_buffers_{in_key}"
+            buffer = getattr(self, buffer_name)
+            if isinstance(buffer, torch.nn.parameter.UninitializedBuffer):
+                continue
+            data = tensordict_reset.get(in_key)
+            if data.size(self.dim) != buffer.size(self.dim):
+                continue
+            d = data.size(self.dim) // self.N
+            dim = data.ndim + self.dim if self.dim < 0 else self.dim
+            index = [slice(None, None) for _ in range(data.ndim)]
+            index[dim] = slice(-d, None)
+            tensordict_reset.set(in_key, data[tuple(index)])
+        return self._reset(tensordict, tensordict_reset)
+
     def _make_missing_buffer(self, data, buffer_name):
         shape = list(data.shape)
         d = shape[self.dim]

--- a/torchrl/envs/transforms/_reward.py
+++ b/torchrl/envs/transforms/_reward.py
@@ -191,6 +191,11 @@ class TargetReturn(Transform):
             )
         return tensordict_reset
 
+    def _reset_on_native_autoreset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        return self._reset(tensordict, tensordict_reset)
+
     def _call(self, next_tensordict: TensorDict) -> TensorDict:
         for in_key, out_key in _zip_strict(self.in_keys, self.out_keys):
             val_in = next_tensordict.get(in_key, None)
@@ -538,6 +543,11 @@ class RewardSum(Transform):
                 value = torch.where(expand_as_right(~_reset, value), value, 0.0)
             tensordict_reset.set(out_key, value)
         return tensordict_reset
+
+    def _reset_on_native_autoreset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        return self._reset(tensordict, tensordict_reset)
 
     def _step(
         self, tensordict: TensorDictBase, next_tensordict: TensorDictBase


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3795
* #3794
* #3791
* #3790
* __->__ #3789

Keep native autoreset step and reset phases separate while carrying reset masks through TensorDict reset keys, avoiding done.any control flow in the hot path.