### PR TITLE
[Feature] Compile env step-and-reset

### DIFF
--- a/docs/source/reference/envs_api.rst
+++ b/docs/source/reference/envs_api.rst
@@ -126,6 +126,62 @@ Limitations:
   transforms manually with
   :func:`~torchrl.modules.utils.get_env_transforms_from_module`.
 
+.. _Environment-compile-arg:
+
+Compiling envs via the ``compile=`` constructor argument
+--------------------------------------------------------
+
+Every concrete :class:`~torchrl.envs.EnvBase` subclass and
+:class:`~torchrl.envs.TransformedEnv` inherit a ``compile`` keyword argument
+on their constructors. When provided, the :class:`~torchrl.envs.EnvBase`
+metaclass post-init hook calls :meth:`~torchrl.envs.EnvBase.compile` on the
+fully-built env (after spec locking, after auto-reset wrapping if any, after
+policy-driven transform appending if any). Accepted values:
+
+* ``False`` or ``None`` (default): no compilation.
+* ``True``: ``env.compile()`` with default :func:`torch.compile` settings.
+* a ``dict``: forwarded to :meth:`~torchrl.envs.EnvBase.compile`.
+
+Using a dict avoids name collisions between :func:`torch.compile` kwargs
+(``backend``, ``mode``, ``fullgraph``, ``dynamic``, ``warmup``, ...) and
+constructor kwargs of specific envs. ``warmup`` is the number of eager calls
+to :meth:`~torchrl.envs.EnvBase.step_and_maybe_reset` before tracing kicks in;
+it stabilizes the input TensorDict layout (e.g. post-:meth:`reset` vs.
+steady-state post-``step_mdp``) so the compiled function does not recompile.
+
+The same flag works equally well with collectors:
+
+.. code-block:: python
+
+    from functools import partial
+    from torchrl.collectors import SyncDataCollector
+    from torchrl.envs import GymEnv, TransformedEnv
+    from torchrl.envs.transforms import Compose
+
+    # Plain env, compiled with a 4-call warmup.
+    collector = SyncDataCollector(
+        partial(
+            GymEnv,
+            "HalfCheetah-v4",
+            compile={"warmup": 4, "fullgraph": True, "mode": "reduce-overhead"},
+        ),
+        ...,
+    )
+
+    # TransformedEnv: compile applies to the outermost env, which is what
+    # the collector calls step_and_maybe_reset on.
+    collector = SyncDataCollector(
+        lambda: TransformedEnv(
+            GymEnv("HalfCheetah-v4"),
+            Compose(...),
+            compile={"warmup": 4, "fullgraph": True},
+        ),
+        ...,
+    )
+
+See :meth:`~torchrl.envs.EnvBase.compile` and
+:meth:`~torchrl.envs.EnvBase.eager` for the underlying methods.
+
 Env methods
 -----------
 

--- a/test/envs/test_auto_reset.py
+++ b/test/envs/test_auto_reset.py
@@ -24,8 +24,14 @@ from tensordict import (
 
 from torchrl import set_auto_unwrap_transformed_env
 from torchrl.data import LazyStackStorage, ReplayBuffer, SliceSampler
-from torchrl.data.tensor_specs import Composite, NonTensor, Unbounded
-from torchrl.envs import CatFrames, ParallelEnv, SerialEnv, TrajCounter
+from torchrl.data.tensor_specs import (
+    Binary,
+    Categorical,
+    Composite,
+    NonTensor,
+    Unbounded,
+)
+from torchrl.envs import CatFrames, EnvBase, ParallelEnv, SerialEnv, TrajCounter
 from torchrl.envs.libs.gym import GymEnv
 from torchrl.envs.transforms import (
     Compose,
@@ -157,6 +163,68 @@ class TestAutoReset:
         assert tensordict["next", "done"].all()
         assert not tensordict_["done"].any()
         assert (tensordict_["observation"] == 0).all()
+
+    def test_native_auto_reset_compile_step_and_maybe_reset(self):
+        class BranchlessAutoResetCountingEnv(EnvBase):
+            def __init__(self, max_steps=3, **kwargs):
+                super().__init__(**kwargs)
+                self.max_steps = max_steps
+                self.observation_spec = Composite(
+                    observation=Unbounded((1,), dtype=torch.float32)
+                )
+                self.reward_spec = Unbounded((1,))
+                self.done_spec = Categorical(2, dtype=torch.bool, shape=(1,))
+                self.action_spec = Binary(n=1, shape=(1,))
+                self.register_buffer("count", torch.zeros(1, dtype=torch.float32))
+
+            def _reset(self, tensordict=None, **kwargs):
+                self.count.zero_()
+                done = self.count.bool()
+                return TensorDict(
+                    {
+                        "observation": self.count.clone(),
+                        "done": done,
+                        "terminated": done,
+                    },
+                    [],
+                )
+
+            def _step(self, tensordict):
+                next_count = self.count + tensordict["action"].to(torch.float32)
+                done = next_count > self.max_steps
+                count = torch.where(done, torch.zeros_like(next_count), next_count)
+                self.count.copy_(count)
+                return TensorDict(
+                    {
+                        "observation": count.clone(),
+                        "done": done,
+                        "terminated": done,
+                        "reward": torch.ones_like(count),
+                    },
+                    [],
+                )
+
+            def _set_seed(self, seed):
+                return None
+
+        env = TransformedEnv(
+            BranchlessAutoResetCountingEnv(3),
+            Compose(StepCounter(), RewardSum(), VecNormV2(in_keys=["observation"])),
+        )
+        env._torchrl_native_autoreset = True
+        env.full_observation_spec
+        tensordict = env.reset()
+
+        env.compile(backend="eager", fullgraph=True)
+        for _ in range(4):
+            tensordict.update(env.full_action_spec.one())
+            tensordict, tensordict_ = env.step_and_maybe_reset(tensordict)
+            tensordict = tensordict_
+        env.eager()
+
+        assert tensordict["step_count"].eq(0).all()
+        assert tensordict["episode_reward"].eq(0).all()
+        assert "_compiled_step_and_maybe_reset" not in env.__dict__
 
     def test_native_auto_reset_wrapped_vecnorm_step_and_maybe_reset(self):
         class CountingVecNormV2(VecNormV2):

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -256,12 +256,43 @@ class EnvMetaData:
         )
 
 
+_NO_COMPILE = object()
+
+
+def _pop_compile_kwargs(kwargs: dict) -> dict | None:
+    """Pop and normalize the ``compile`` kwarg.
+
+    Accepts ``True``/``False``/``None`` for "compile with defaults" /
+    "do not compile", or a ``dict`` of kwargs forwarded to
+    :meth:`EnvBase.compile`. Using a dict avoids name collisions with env
+    constructor kwargs (``backend``, ``mode``, ``fullgraph``, ``warmup``, ...).
+    """
+    compile_arg = kwargs.pop("compile", _NO_COMPILE)
+    if compile_arg is _NO_COMPILE or compile_arg is False or compile_arg is None:
+        return None
+    if compile_arg is True:
+        return {}
+    if isinstance(compile_arg, dict):
+        return dict(compile_arg)
+    raise TypeError(
+        f"compile must be a bool, None, or a dict of torch.compile kwargs; "
+        f"got {type(compile_arg).__name__}"
+    )
+
+
+def _maybe_compile_env(instance, compile_kwargs):
+    if compile_kwargs is None:
+        return instance
+    return instance.compile(**compile_kwargs)
+
+
 class _EnvPostInit(abc.ABCMeta):
     def __call__(cls, *args, **kwargs):
         spec_locked = kwargs.pop("spec_locked", True)
         auto_reset = kwargs.pop("auto_reset", False)
         auto_reset_replace = kwargs.pop("auto_reset_replace", True)
         policy = kwargs.pop("policy", None)
+        compile_kwargs = _pop_compile_kwargs(kwargs)
         instance: EnvBase = super().__call__(*args, **kwargs)
         if "_cache" not in instance.__dict__:
             instance._cache = {}
@@ -296,7 +327,7 @@ class _EnvPostInit(abc.ABCMeta):
                 )
 
                 instance = _maybe_append_env_transforms_from_module(instance, policy)
-            return instance
+            return _maybe_compile_env(instance, compile_kwargs)
 
         done_keys = set(instance.full_done_spec.keys(True, True))
         obs_keys = set(instance.full_observation_spec.keys(True, True))
@@ -325,7 +356,7 @@ class _EnvPostInit(abc.ABCMeta):
             )
 
             instance = _maybe_append_env_transforms_from_module(instance, policy)
-        return instance
+        return _maybe_compile_env(instance, compile_kwargs)
 
 
 class EnvBase(nn.Module, metaclass=_EnvPostInit):
@@ -377,6 +408,29 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
 
             .. seealso:: The :ref:`auto-resetting environments API <autoresetting_envs>` section in the API
                 documentation.
+
+        compile (bool or dict, optional): if truthy, the env is compiled right
+            after construction by calling :meth:`~torchrl.envs.EnvBase.compile`.
+
+            * ``False`` / ``None`` (default): no compilation.
+            * ``True``: compile with default :func:`torch.compile` settings.
+            * ``dict``: kwargs forwarded to :meth:`~torchrl.envs.EnvBase.compile`,
+              for example ``{"warmup": 4, "fullgraph": True, "mode": "reduce-overhead"}``.
+
+            A dict is the recommended form: passing torch.compile kwargs through
+            the env constructor as top-level keywords would risk colliding with
+            env-specific kwargs.
+
+            .. note:: The compile step is achieved by the `EnvBase` metaclass.
+                It does not appear in the `__init__` method and is included
+                in the keyword arguments strictly for type-hinting purpose. It
+                also applies to :class:`~torchrl.envs.TransformedEnv`, so
+                wrapping with transforms and asking for compile in one shot is
+                supported, e.g.
+                ``TransformedEnv(env, transform, compile={"warmup": 4})``.
+
+            .. seealso:: :meth:`~torchrl.envs.EnvBase.compile` and
+                :meth:`~torchrl.envs.EnvBase.eager`.
 
     Attributes:
         done_spec (Composite): equivalent to ``full_done_spec`` as all

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -3854,6 +3854,14 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
     def step_and_maybe_reset(
         self, tensordict: TensorDictBase
     ) -> tuple[TensorDictBase, TensorDictBase]:
+        compiled = self.__dict__.get("_compiled_step_and_maybe_reset", None)
+        if compiled is not None:
+            return compiled(tensordict)
+        return self._step_and_maybe_reset(tensordict)
+
+    def _step_and_maybe_reset(
+        self, tensordict: TensorDictBase
+    ) -> tuple[TensorDictBase, TensorDictBase]:
         """Runs a step in the environment and (partially) resets it if needed.
 
         Args:
@@ -3931,6 +3939,18 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
         else:
             tensordict_ = self.maybe_reset(tensordict_)
         return tensordict, tensordict_
+
+    def compile(self, **kwargs):
+        """Compile :meth:`step_and_maybe_reset` and return ``self``."""
+        self.__dict__["_compiled_step_and_maybe_reset"] = torch.compile(
+            self._step_and_maybe_reset, **kwargs
+        )
+        return self
+
+    def eager(self):
+        """Restore eager :meth:`step_and_maybe_reset` execution and return ``self``."""
+        self.__dict__.pop("_compiled_step_and_maybe_reset", None)
+        return self
 
     _post_step_mdp_hooks: Callable[
         [TensorDictBase, TensorDictBase], tuple[TensorDictBase, TensorDictBase]

--- a/torchrl/envs/transforms/_base.py
+++ b/torchrl/envs/transforms/_base.py
@@ -31,7 +31,13 @@ from torchrl._utils import (
 )
 
 from torchrl.data.tensor_specs import Composite, TensorSpec
-from torchrl.envs.common import _EnvPostInit, _maybe_unlock, EnvBase
+from torchrl.envs.common import (
+    _EnvPostInit,
+    _maybe_compile_env,
+    _maybe_unlock,
+    _pop_compile_kwargs,
+    EnvBase,
+)
 from torchrl.envs.transforms.utils import _set_missing_tolerance
 from torchrl.envs.utils import _update_during_reset
 
@@ -891,10 +897,11 @@ class Transform(nn.Module):
 
 class _TEnvPostInit(_EnvPostInit):
     def __call__(self, *args, **kwargs):
+        compile_kwargs = _pop_compile_kwargs(kwargs)
         instance: EnvBase = super(_EnvPostInit, self).__call__(*args, **kwargs)
         # we skip the materialization of the specs, because this can't be done with lazy
         # transforms such as ObservationNorm.
-        return instance
+        return _maybe_compile_env(instance, compile_kwargs)
 
 
 class TransformedEnv(EnvBase, metaclass=_TEnvPostInit):

--- a/torchrl/envs/transforms/_base.py
+++ b/torchrl/envs/transforms/_base.py
@@ -1724,7 +1724,8 @@ class Compose(Transform):
             t._check_batched_worker_compat()
 
     def _inv_call(self, tensordict: TensorDictBase) -> TensorDictBase:
-        for t in reversed(self.transforms):
+        for i in range(len(self.transforms) - 1, -1, -1):
+            t = self.transforms[i]
             tensordict = t._inv_call(tensordict)
         return tensordict
 
@@ -1836,7 +1837,8 @@ class Compose(Transform):
         return tensordict_reset
 
     def _reset_env_preprocess(self, tensordict: TensorDictBase) -> TensorDictBase:
-        for t in reversed(self.transforms):
+        for i in range(len(self.transforms) - 1, -1, -1):
+            t = self.transforms[i]
             tensordict = t._reset_env_preprocess(tensordict)
         return tensordict
 

--- a/torchrl/envs/transforms/vecnorm.py
+++ b/torchrl/envs/transforms/vecnorm.py
@@ -17,6 +17,12 @@ import torch
 from tensordict import NestedKey, TensorDict, TensorDictBase, unravel_key
 from tensordict.utils import _zip_strict
 from torch import multiprocessing as mp
+
+try:
+    from torch.compiler import is_compiling
+except ImportError:
+    from torch._dynamo import is_compiling
+
 from torchrl.data.tensor_specs import Bounded, Composite, Unbounded
 
 from torchrl.envs.common import EnvBase
@@ -411,8 +417,9 @@ class VecNormV2(Transform):
     def _step(
         self, tensordict: TensorDictBase, next_tensordict: TensorDictBase
     ) -> TensorDictBase:
-        if self.lock is not None:
-            self.lock.acquire()
+        lock = None if is_compiling() else self.lock
+        if lock is not None:
+            lock.acquire()
         try:
             if self.stateful:
                 self._maybe_stateful_init(next_tensordict)
@@ -447,8 +454,8 @@ class VecNormV2(Transform):
 
             next_tensordict.update(next_tensordict_norm)
         finally:
-            if self.lock is not None:
-                self.lock.release()
+            if lock is not None:
+                lock.release()
 
         return next_tensordict
 
@@ -521,6 +528,10 @@ class VecNormV2(Transform):
         return x.to(torch.get_default_dtype())
 
     def _maybe_stateful_init(self, data):
+        if is_compiling():
+            if self._loc is None:
+                raise RuntimeError("VecNormV2 must be initialized before compile.")
+            return
         if not self.initialized:
             self.initialized.copy_(True)
             #  Some keys (specifically rewards) may be missing, but we can use the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3795
* #3794
* #3791
* __->__ #3790
* #3789

Add compile/eager toggles for step_and_maybe_reset and make VecNormV2 avoid compile-time graph breaks from lock and initialization checks.