### PR TITLE
[Feature] Compile random truncation reset

### DIFF
--- a/examples/envs/benchmark_compile_step_and_maybe_reset.py
+++ b/examples/envs/benchmark_compile_step_and_maybe_reset.py
@@ -1,0 +1,260 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Benchmark ``env.step_and_maybe_reset`` with and without ``env.compile()``.
+
+This benchmark uses a branchless native-autoreset counting environment so the
+compiled graph measures TorchRL's transform/reset machinery rather than Python
+control flow in the toy environment. The transform chain is:
+
+    ``StepCounter -> [RandomTruncationTransform] -> RewardSum -> VecNormV2``
+
+Reference results from an Apple Silicon CPU run with torch
+``2.13.0.dev20260523``, 10 torch threads, batch size ``16_384``, compile time
+excluded:
+
+=======================  ======  ==========  =======  ===================
+Case                     Mode    Median      Speedup  Reset envs / step
+=======================  ======  ==========  =======  ===================
+Synchronized resets      eager    584.86 us   1.00x   128.7
+Synchronized resets      default  309.02 us   1.89x   128.7
+Random truncation resets eager    996.22 us   1.00x   3708.0
+Random truncation resets default  401.28 us   2.48x   3708.0
+=======================  ======  ==========  =======  ===================
+
+The random truncation case uses
+``RandomTruncationTransform(prob=1.0, min_horizon=1, max_horizon=8)`` to
+desynchronize resets across sub-envs.
+
+Example:
+    python examples/envs/benchmark_compile_step_and_maybe_reset.py \\
+        --batch-size 16384 --steps 200 --repeats 7 --warmup 25
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import statistics
+import time
+
+import torch
+from tensordict import TensorDict
+
+try:
+    import torch._dynamo as dynamo
+except ImportError:
+    dynamo = None
+
+from torchrl.data.tensor_specs import Binary, Categorical, Composite, Unbounded
+from torchrl.envs import (
+    Compose,
+    EnvBase,
+    RandomTruncationTransform,
+    RewardSum,
+    StepCounter,
+    TransformedEnv,
+    VecNormV2,
+)
+
+
+class BranchlessNativeAutoResetCountingEnv(EnvBase):
+    """Tensor-only counting env that resets internally without Python branching."""
+
+    def __init__(self, max_steps: int = 128, **kwargs):
+        super().__init__(**kwargs)
+        self.max_steps = max_steps
+        shape = (*self.batch_size, 1)
+        self.observation_spec = Composite(
+            observation=Unbounded(shape, dtype=torch.float32, device=self.device),
+            shape=self.batch_size,
+            device=self.device,
+        )
+        self.reward_spec = Unbounded(shape, device=self.device)
+        self.done_spec = Categorical(
+            2, dtype=torch.bool, shape=shape, device=self.device
+        )
+        self.action_spec = Binary(n=1, shape=shape, device=self.device)
+        self.register_buffer("count", torch.zeros(shape, dtype=torch.float32))
+
+    def _reset(self, tensordict=None, **kwargs):
+        self.count.zero_()
+        done = self.count.bool()
+        return TensorDict(
+            {
+                "observation": self.count.clone(),
+                "done": done,
+                "terminated": done,
+            },
+            self.batch_size,
+            device=self.device,
+        )
+
+    def _step(self, tensordict):
+        next_count = self.count + tensordict["action"].to(torch.float32)
+        done = next_count > self.max_steps
+        count = torch.where(done, torch.zeros_like(next_count), next_count)
+        self.count.copy_(count)
+        return TensorDict(
+            {
+                "observation": count.clone(),
+                "done": done,
+                "terminated": done,
+                "reward": torch.ones_like(count),
+            },
+            self.batch_size,
+            device=self.device,
+        )
+
+    def _set_seed(self, seed: int | None) -> None:
+        return None
+
+
+def make_env(args: argparse.Namespace, *, random_truncation: bool):
+    transforms = [StepCounter()]
+    if random_truncation:
+        transforms.append(
+            RandomTruncationTransform(
+                prob=args.truncation_prob,
+                min_horizon=args.min_horizon,
+                max_horizon=args.max_horizon,
+            )
+        )
+    transforms.extend([RewardSum(), VecNormV2(in_keys=["observation"])])
+
+    env = TransformedEnv(
+        BranchlessNativeAutoResetCountingEnv(
+            args.env_max_steps,
+            batch_size=[args.batch_size],
+            device=args.device,
+        ),
+        Compose(*transforms),
+    )
+    env._torchrl_native_autoreset = True
+    env.full_observation_spec
+    tensordict = env.reset()
+    return env, tensordict
+
+
+def run_steps(env, tensordict, action, num_steps: int):
+    reset_count = 0
+    for _ in range(num_steps):
+        tensordict.update(action)
+        step_data, tensordict = env.step_and_maybe_reset(tensordict)
+        reset_count += int(step_data["next", "done"].sum().item())
+    return tensordict, reset_count
+
+
+COMPILE_MODES = {
+    "default": {},
+    "reduce-overhead": {"mode": "reduce-overhead"},
+    "max-autotune": {"mode": "max-autotune"},
+}
+
+
+def measure(args: argparse.Namespace, *, compile_mode: str, random_truncation: bool):
+    torch.manual_seed(args.seed)
+    env, tensordict = make_env(args, random_truncation=random_truncation)
+    action = env.full_action_spec.one()
+    if compile_mode != "eager":
+        if dynamo is not None:
+            dynamo.reset()
+        compile_kwargs = dict(COMPILE_MODES[compile_mode])
+        compile_kwargs["fullgraph"] = True
+        if args.backend is not None:
+            compile_kwargs["backend"] = args.backend
+        env.compile(warmup=args.compile_warmup, **compile_kwargs)
+
+    tensordict, _ = run_steps(env, tensordict, action, args.warmup)
+    times = []
+    resets = []
+    for _ in range(args.repeats):
+        start = time.perf_counter()
+        tensordict, reset_count = run_steps(env, tensordict, action, args.steps)
+        if env.device is not None and torch.device(env.device).type == "cuda":
+            torch.cuda.synchronize()
+        times.append((time.perf_counter() - start) / args.steps)
+        resets.append(reset_count / args.steps)
+
+    env.eager()
+    env.close()
+    gc.collect()
+    return {
+        "median": statistics.median(times),
+        "mean": statistics.mean(times),
+        "resets": statistics.mean(resets),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark env.step_and_maybe_reset with env.compile()."
+    )
+    parser.add_argument("--batch-size", type=int, default=16_384)
+    parser.add_argument("--steps", type=int, default=200)
+    parser.add_argument("--repeats", type=int, default=7)
+    parser.add_argument("--warmup", type=int, default=25)
+    parser.add_argument(
+        "--compile-warmup",
+        type=int,
+        default=1,
+        help=(
+            "Number of eager calls before tracing kicks in. Forwarded to "
+            "env.compile(warmup=...). Stabilizes the input TensorDict layout "
+            "so the first compiled call sees the steady-state schema."
+        ),
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--device", default=None)
+    parser.add_argument("--backend", default=None)
+    parser.add_argument(
+        "--compile-modes",
+        nargs="+",
+        default=["default", "reduce-overhead", "max-autotune"],
+        choices=sorted(COMPILE_MODES),
+        help="Compile modes to compare against eager.",
+    )
+    parser.add_argument("--env-max-steps", type=int, default=128)
+    parser.add_argument("--min-horizon", type=int, default=1)
+    parser.add_argument("--max-horizon", type=int, default=8)
+    parser.add_argument("--truncation-prob", type=float, default=1.0)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    print(
+        f"torch={torch.__version__} threads={torch.get_num_threads()} "
+        f"batch={args.batch_size} device={args.device or 'cpu'}"
+    )
+    print("case,mode,median_us,mean_us,speedup_vs_eager,resets_per_step")
+    for random_truncation, name in (
+        (False, "sync_resets"),
+        (True, "with_random_truncation"),
+    ):
+        eager = measure(args, compile_mode="eager", random_truncation=random_truncation)
+        print(
+            f"{name},"
+            "eager,"
+            f"{eager['median'] * 1e6:.2f},"
+            f"{eager['mean'] * 1e6:.2f},"
+            "1.000,"
+            f"{eager['resets']:.1f}"
+        )
+        for compile_mode in args.compile_modes:
+            compiled = measure(
+                args, compile_mode=compile_mode, random_truncation=random_truncation
+            )
+            print(
+                f"{name},"
+                f"{compile_mode},"
+                f"{compiled['median'] * 1e6:.2f},"
+                f"{compiled['mean'] * 1e6:.2f},"
+                f"{eager['median'] / compiled['median']:.3f},"
+                f"{compiled['resets']:.1f}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "gymnasium",
     "hydra-core>=1.1",
     "hydra-submitit-launcher",
+    "imageio",
     "mujoco",
     "mujoco-torch",
     "pytest",
@@ -70,7 +71,7 @@ explicit = true
 
 [tool.uv.sources]
 tensordict = { git = "https://github.com/pytorch/tensordict" }
-torch = { index = "pytorch-nightly" }
+torch = { index = "pytorch-nightly", marker = "sys_platform == 'darwin' and python_version != '3.12'" }
 
 [project.optional-dependencies]
 atari = ["gymnasium[atari]"]

--- a/test/envs/test_auto_reset.py
+++ b/test/envs/test_auto_reset.py
@@ -36,6 +36,7 @@ from torchrl.envs.libs.gym import GymEnv
 from torchrl.envs.transforms import (
     Compose,
     InitTracker,
+    RandomTruncationTransform,
     RewardSum,
     StepCounter,
     TransformedEnv,
@@ -209,21 +210,26 @@ class TestAutoReset:
 
         env = TransformedEnv(
             BranchlessAutoResetCountingEnv(3),
-            Compose(StepCounter(), RewardSum(), VecNormV2(in_keys=["observation"])),
+            Compose(
+                StepCounter(),
+                RandomTruncationTransform(prob=1.0, min_horizon=1, max_horizon=3),
+                RewardSum(),
+                VecNormV2(in_keys=["observation"]),
+            ),
         )
         env._torchrl_native_autoreset = True
         env.full_observation_spec
         tensordict = env.reset()
 
         env.compile(backend="eager", fullgraph=True)
-        for _ in range(4):
+        for _ in range(6):
             tensordict.update(env.full_action_spec.one())
             tensordict, tensordict_ = env.step_and_maybe_reset(tensordict)
             tensordict = tensordict_
         env.eager()
 
-        assert tensordict["step_count"].eq(0).all()
-        assert tensordict["episode_reward"].eq(0).all()
+        assert tensordict["step_count"].le(3).all()
+        assert tensordict["episode_reward"].le(3).all()
         assert "_compiled_step_and_maybe_reset" not in env.__dict__
 
     def test_native_auto_reset_wrapped_vecnorm_step_and_maybe_reset(self):

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -3940,11 +3940,29 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
             tensordict_ = self.maybe_reset(tensordict_)
         return tensordict, tensordict_
 
-    def compile(self, **kwargs):
-        """Compile :meth:`step_and_maybe_reset` and return ``self``."""
-        self.__dict__["_compiled_step_and_maybe_reset"] = torch.compile(
-            self._step_and_maybe_reset, **kwargs
-        )
+    def compile(self, *, warmup: int | None = None, **kwargs):
+        """Compile :meth:`step_and_maybe_reset` and return ``self``.
+
+        Args:
+            warmup (int, optional): if provided, the first ``warmup`` calls to
+                :meth:`step_and_maybe_reset` will run eagerly so the input
+                :class:`~tensordict.TensorDict` layout (keys, names, nesting)
+                stabilizes before tracing. Compilation kicks in on call
+                ``warmup``. This avoids the recompile that otherwise happens
+                because the first post-:meth:`reset` tensordict and the
+                steady-state post-``step_mdp`` tensordict have different
+                layouts. Defaults to ``None`` (compile immediately).
+            **kwargs: forwarded to :func:`torch.compile`.
+        """
+        from torchrl._utils import compile_with_warmup
+
+        if warmup is None:
+            compiled = torch.compile(self._step_and_maybe_reset, **kwargs)
+        else:
+            compiled = compile_with_warmup(
+                self._step_and_maybe_reset, warmup=warmup, **kwargs
+            )
+        self.__dict__["_compiled_step_and_maybe_reset"] = compiled
         return self
 
     def eager(self):

--- a/torchrl/envs/transforms/_env.py
+++ b/torchrl/envs/transforms/_env.py
@@ -36,6 +36,11 @@ from torchrl.envs.common import EnvBase
 from torchrl.envs.transforms.utils import _get_reset
 from torchrl.envs.utils import step_mdp
 
+try:
+    from torch.compiler import is_compiling
+except ImportError:
+    from torch._dynamo import is_compiling
+
 if TYPE_CHECKING:
     pass
 
@@ -1330,6 +1335,36 @@ class RandomTruncationTransform(Transform):
         reset_mask = tensordict.get("_reset", None)
         if reset_mask is not None:
             mask = reset_mask.view_as(self._horizons).bool()
+            if is_compiling():
+                new_h = torch.randint(
+                    self.min_horizon,
+                    self.max_horizon + 1,
+                    self._horizons.shape,
+                    device=self._horizons.device,
+                )
+                effective_prob = torch.where(
+                    self._first_episode,
+                    torch.full_like(
+                        self._horizons,
+                        self.first_episode_prob,
+                        dtype=torch.get_default_dtype(),
+                    ),
+                    torch.full_like(
+                        self._horizons,
+                        self.prob,
+                        dtype=torch.get_default_dtype(),
+                    ),
+                )
+                keep_full = (
+                    torch.rand(self._horizons.shape, device=self._horizons.device)
+                    > effective_prob
+                )
+                new_h = torch.where(keep_full, self.max_horizon, new_h)
+                self._horizons = torch.where(mask, new_h, self._horizons)
+                self._first_episode = torch.where(
+                    mask, torch.zeros_like(self._first_episode), self._first_episode
+                )
+                return tensordict_reset
             if mask.any():
                 if self.prob == 0.0 and self.first_episode_prob == 0.0:
                     self._horizons[mask] = self.max_horizon


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3795
* #3794
* __->__ #3791
* #3790
* #3789

Use a fixed-shape reset resampling path while compiling so RandomTruncationTransform avoids data-dependent branches and dynamic random tensor shapes.