### PR TITLE
[Test] Gate autoreset compile tests to recent PyTorch

### DIFF
--- a/test/envs/test_auto_reset.py
+++ b/test/envs/test_auto_reset.py
@@ -14,6 +14,7 @@ import pytest
 import torch
 
 from _envs_common import _has_gym, _has_transformers, mp_ctx
+from packaging import version
 from tensordict import (
     assert_allclose_td,
     LazyStackedTensorDict,
@@ -60,6 +61,8 @@ from torchrl.testing.mocking_classes import (
     EnvWithTensorClass,
     Str2StrEnv,
 )
+
+TORCH_VERSION = version.parse(version.parse(torch.__version__).base_version)
 
 
 class TestAutoReset:
@@ -165,6 +168,11 @@ class TestAutoReset:
         assert not tensordict_["done"].any()
         assert (tensordict_["observation"] == 0).all()
 
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.5.0"),
+        reason="Dynamo cannot trace `EnvBase.device` (a class-level property "
+        "using `self.__dict__.get`) on PyTorch < 2.5.",
+    )
     def test_native_auto_reset_compile_step_and_maybe_reset(self):
         class BranchlessAutoResetCountingEnv(EnvBase):
             def __init__(self, max_steps=3, **kwargs):
@@ -231,6 +239,29 @@ class TestAutoReset:
         assert tensordict["step_count"].le(3).all()
         assert tensordict["episode_reward"].le(3).all()
         assert "_compiled_step_and_maybe_reset" not in env.__dict__
+
+    def test_env_constructor_compile_kwarg(self):
+        env = CountingEnv(3, compile=False)
+        assert "_compiled_step_and_maybe_reset" not in env.__dict__
+
+        env = CountingEnv(3, compile=True)
+        assert "_compiled_step_and_maybe_reset" in env.__dict__
+
+        env = CountingEnv(
+            3,
+            compile={"warmup": 2, "backend": "eager", "fullgraph": True},
+        )
+        assert "_compiled_step_and_maybe_reset" in env.__dict__
+
+        env_t = TransformedEnv(
+            CountingEnv(3),
+            StepCounter(),
+            compile={"warmup": 1, "backend": "eager"},
+        )
+        assert "_compiled_step_and_maybe_reset" in env_t.__dict__
+
+        with pytest.raises(TypeError, match="compile must be"):
+            CountingEnv(3, compile="please")
 
     def test_native_auto_reset_wrapped_vecnorm_step_and_maybe_reset(self):
         class CountingVecNormV2(VecNormV2):

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -4006,7 +4006,27 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
                 because the first post-:meth:`reset` tensordict and the
                 steady-state post-``step_mdp`` tensordict have different
                 layouts. Defaults to ``None`` (compile immediately).
-            **kwargs: forwarded to :func:`torch.compile`.
+            **kwargs: forwarded to :func:`torch.compile`. Common ones include
+                ``backend``, ``mode``, ``fullgraph``, and ``dynamic``.
+
+        The same behavior is reachable directly from the constructor of every
+        :class:`EnvBase` subclass (and of
+        :class:`~torchrl.envs.TransformedEnv`) via the ``compile=`` kwarg:
+
+        .. code-block:: python
+
+            env = GymEnv(
+                "HalfCheetah-v4",
+                compile={"warmup": 4, "fullgraph": True, "mode": "reduce-overhead"},
+            )
+
+            env = TransformedEnv(
+                GymEnv("HalfCheetah-v4"),
+                Compose(...),
+                compile={"warmup": 4, "fullgraph": True},
+            )
+
+        See :meth:`eager` to undo it.
         """
         from torchrl._utils import compile_with_warmup
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #3795
* #3794
* #3791
* #3790
* #3789

