### PR TITLE
[Feature] collectors internals docs

### DIFF
--- a/docs/source/reference/collectors.rst
+++ b/docs/source/reference/collectors.rst
@@ -134,6 +134,7 @@ Documentation Sections
 
    collectors_basics
    collectors_single
+   collectors_internals
    collectors_eval
    collectors_distributed
    collectors_weightsync

--- a/docs/source/reference/collectors_basics.rst
+++ b/docs/source/reference/collectors_basics.rst
@@ -58,6 +58,35 @@ Besides those compute parameters, users may choose to configure the following pa
   along with a ``"mask"`` key that will point to a boolean mask representing the valid values.
 - exploration_type: the exploration strategy to be used with the policy.
 - reset_when_done: whether environments should be reset when reaching a done state.
+- track_traj_ids: if ``True`` (default), the collector writes a unique
+  ``("collector", "traj_ids")`` integer per frame and updates it on every
+  env reset.  Setting it to ``False`` skips the per-step bookkeeping —
+  useful when neither :func:`~torchrl.collectors.utils.split_trajectories`
+  nor :class:`~torchrl.data.SliceSampler` are used downstream.  Note that
+  ``split_trajs=True`` requires ``track_traj_ids=True``.
+
+Trajectory IDs
+--------------
+
+When ``track_traj_ids=True``, every frame yielded by a collector carries a
+``("collector", "traj_ids")`` integer that uniquely identifies the trajectory
+it belongs to.  IDs are drawn from a process-local pool so they remain
+unique across resets within a single worker.
+
+This is what makes trajectory-aware downstream consumers possible:
+
+- :class:`~torchrl.data.SliceSampler` draws whole trajectories (or slices of
+  them) from a replay buffer by grouping frames by ``traj_ids``.
+- :func:`~torchrl.collectors.utils.split_trajectories` reshapes a flat batch
+  into a padded ``[n_trajs, max_len]`` tensordict using ``traj_ids`` to find
+  the boundaries.
+
+Set ``track_traj_ids=False`` only when the downstream consumer does not need
+trajectory identity — e.g. step-level off-policy training that samples
+i.i.d. transitions from a uniform buffer.
+
+See :ref:`ref_collectors_internals` for the per-step bookkeeping that
+maintains these IDs.
 
 Collectors and batch size
 -------------------------

--- a/docs/source/reference/collectors_internals.rst
+++ b/docs/source/reference/collectors_internals.rst
@@ -6,22 +6,23 @@ Collector Internals
 ===================
 
 This page describes how :class:`~torchrl.collectors.SyncDataCollector` (aliased
-as :class:`Collector`) actually steps through an environment.  It is meant for
-contributors and for users debugging unexpected rollout behaviour — the device
-casts, the per-step bookkeeping, and the trajectory-tracking machinery are not
-visible from the public API and have, until now, only been documented in
-inline comments inside ``torchrl/collectors/_single.py``.
+as :class:`Collector`) steps through an environment.  It is meant for
+contributors and for users debugging unexpected rollout behaviour: device
+casts, per-step bookkeeping, and trajectory tracking are implementation details
+that are not visible from the public API.
 
-The multi-process collectors (:class:`MultiSyncCollector`,
+The multi-process collectors (:class:`MultiSyncCollector` and
 :class:`MultiAsyncCollector`) delegate their per-worker rollouts to
-:class:`SyncDataCollector`, so everything on this page applies to them too.
+:class:`SyncDataCollector`, so the per-worker flow on this page applies to
+them too.
 
 Per-timestep flow
 -----------------
 
 A single iteration of :meth:`SyncDataCollector.rollout` corresponds to one
 environment step.  ``frames_per_batch`` such iterations are stacked into the
-batch yielded to the user (or written to the replay buffer).
+batch yielded to the user, extended into a replay buffer, or written directly
+with ``replay_buffer.add(...)`` when direct replay-buffer writes are enabled.
 
 .. code-block:: text
 
@@ -29,8 +30,8 @@ batch yielded to the user (or written to the replay buffer).
     │  for t in range(frames_per_batch):                                  │
     │                                                                     │
     │    ┌─ carrier ──────────────────────────────────────────────────┐   │
-    │    │  TensorDict — observation + collector metadata,            │   │
-    │    │  device-cleared if policy_device != env_device             │   │
+    │    │  TensorDict — observation + collector metadata;            │   │
+    │    │  device-cleared when needed for cross-device stepping      │   │
     │    └────────────┬───────────────────────────────────────────────┘   │
     │                 │                                                   │
     │                 │  (1) cast to policy_device if needed              │
@@ -59,10 +60,13 @@ batch yielded to the user (or written to the replay buffer).
     │    ┌─ carrier_for_out (snapshot for this step) ──────────────┐    │
     │    └────────────┬────────────────────────────────────────────┘    │
     │                 │                                                 │
-    │                 │  (3) cast to storing_device if needed           │
-    │                 │      → _sync_storage()                          │
+    │                 │  (3a) replay_buffer.add(carrier_for_out)        │
+    │                 │       for direct writes                         │
+    │                 │                                                 │
+    │                 │  (3b) otherwise cast to storing_device          │
+    │                 │       if needed → _sync_storage(), then append  │
     │                 ▼                                                 │
-    │           append to tensordicts list  OR  replay_buffer.add(...)  │
+    │           direct replay-buffer write OR append to tensordicts     │
     │                 │                                                 │
     │                 │  carrier = env_next_output  (post-reset state)  │
     │                 │  update traj_ids if any env finished            │
@@ -75,61 +79,59 @@ Implementation: :meth:`SyncDataCollector.rollout` in
 The carrier
 -----------
 
-The **carrier** (formerly called the *shuttle*) is the single
-:class:`~tensordict.TensorDictBase` instance that survives across timesteps and
-carries data between the environment and the policy.  It is allocated once by
-:meth:`SyncDataCollector._make_shuttle` and stored as ``self._carrier``.
+The **carrier** is the :class:`~tensordict.TensorDictBase` instance stored as
+``self._carrier``. It persists across calls to ``next(iter(collector))`` and
+holds the post-reset result of the previous environment step, which is the
+state that the next policy call must consume. It is initialized by
+:meth:`SyncDataCollector._make_carrier` and then advanced at the end of every
+timestep by assigning ``env_next_output`` back to ``self._carrier``.
 
 Why it exists
 ~~~~~~~~~~~~~
 
-- **Allocation amortization.**  Reallocating a tensordict every timestep would
-  dominate the wall-clock cost of fast environments.  Reusing one tensordict
-  keeps the per-step overhead at the cost of a few in-place updates.
-- **Deviceless semantics.**  When the policy and environment live on
-  *different* devices (e.g. policy on ``cuda:0``, env on ``cpu``), the carrier
-  is cleared of any device pin via ``clear_device_()`` so that subsequent
-  ``.to(device, non_blocking=True)`` calls do the right thing regardless of
-  which side wrote to it last.  The boolean flag
-  ``self._shuttle_has_no_device`` records whether this clearing happened —
-  see :meth:`_make_shuttle`.
-- **Single source of truth for collector metadata.**  Trajectory IDs and
-  any other ``("collector", ...)`` keys live on the carrier and persist
-  across steps without round-tripping through the env.
+- **State persistence across batches.**  Collection may stop at a batch
+  boundary while the environment trajectory continues. The carrier preserves
+  the latest reset-aware environment output so the next rollout resumes from
+  the correct observation and recurrent state.
+- **Allocation amortization.**  Reusing the same tensordict-shaped state avoids
+  allocating a fresh container for every policy/env exchange.
+- **Device-neutral handoff.**  When the policy and environment cannot share a
+  single device-owned tensordict, the carrier is cleared of its device with
+  ``clear_device_()``. The boolean flag ``self._carrier_has_no_device`` records
+  whether this invariant must be preserved when new ``"next"`` data is merged.
+- **Collector metadata.**  Trajectory IDs and other ``("collector", ...)`` keys
+  live on the carrier and persist across steps without round-tripping through
+  the env.
 
 Reading the carrier
 ~~~~~~~~~~~~~~~~~~~
 
-You should not normally touch ``self._carrier`` directly — it is an
-implementation detail.  If you need to instrument what the policy sees on
-step ``t``, use :attr:`SyncDataCollector.pre_collect_hook` or read the data
-yielded by iteration (which is a copy).  Mutating the carrier from a hook is
-undefined behaviour.
+You should not normally touch ``self._carrier`` directly; it is an
+implementation detail.  If you need to instrument collected data, use
+:attr:`SyncDataCollector.post_collect_hook` or read the data yielded by
+iteration. Mutating the carrier from a hook is undefined behaviour.
 
 Sync points
 -----------
 
-Three explicit synchronisation functions are installed at construction time
-in :meth:`SyncDataCollector._setup_devices` and called inside the rollout
-loop:
+Three explicit synchronisation functions are installed at construction time in
+:meth:`SyncDataCollector._setup_devices` and called inside the rollout loop
+when the corresponding explicit sync is not disabled by ``no_cuda_sync=True``:
 
 ``_sync_policy``
-    Called after copying the carrier to ``policy_device`` (rollout loop,
-    after the ``self._carrier.to(self.policy_device, ...)`` call).  Ensures
-    the host has seen the GPU→CPU transfer of whatever was on the carrier
-    before the policy reads it.
+    Called after copying the carrier to ``policy_device`` and before the
+    policy reads it.
 
 ``_sync_env``
-    Called after copying the carrier to ``env_device`` (rollout loop, after
-    the ``self._carrier.to(self.env_device, ...)`` call).  Same role on the
-    env side.
+    Called after copying the carrier to ``env_device`` and before the
+    environment reads it.
 
 ``_sync_storage``
-    Called after copying ``carrier_for_out`` to ``storing_device`` (rollout
-    loop, when appending to the per-step ``tensordicts`` list).  Ensures the
-    stored batch is consistent before it is returned or stacked.
+    Called after copying ``carrier_for_out`` to ``storing_device`` on the
+    append-to-list path. The direct ``replay_buffer.add(...)`` path does not
+    perform this cast or sync.
 
-What ``_sync_*`` actually is depends on the destination device — see
+What ``_sync_*`` actually is depends on the destination device; see
 :meth:`SyncDataCollector._get_sync_fn`:
 
 +-------------------+------------------------------------------------------+
@@ -138,10 +140,13 @@ What ``_sync_*`` actually is depends on the destination device — see
 | ``cuda`` device   | ``_do_nothing`` (CUDA handles ordering itself)       |
 +-------------------+------------------------------------------------------+
 | Non-CUDA, CUDA    | ``_cuda_sync_if_initialized`` (safe to call after a  |
-| available         | GPU→CPU transfer; no-op in fork subprocesses where   |
-|                   | CUDA was not initialised)                            |
+| available         | GPU-to-host transfer; no-op in fork subprocesses     |
+|                   | where CUDA was not initialised)                      |
 +-------------------+------------------------------------------------------+
 | Non-CUDA, MPS     | ``torch.mps.synchronize``                            |
+| available         |                                                      |
++-------------------+------------------------------------------------------+
+| Non-CUDA, NPU     | ``torch.npu.synchronize``                            |
 | available         |                                                      |
 +-------------------+------------------------------------------------------+
 | ``cpu`` (no GPU)  | ``_do_nothing``                                      |
@@ -150,8 +155,8 @@ What ``_sync_*`` actually is depends on the destination device — see
 +-------------------+------------------------------------------------------+
 
 Setting ``no_cuda_sync=True`` on the collector skips the explicit ``_sync_*``
-calls — only do this if you know all your transfers are CUDA-stream-ordered
-or if you are running pure-CPU.
+calls. Only do this if you know the transfers are already correctly ordered or
+if you are running pure CPU.
 
 Device casting flags
 --------------------
@@ -159,26 +164,25 @@ Device casting flags
 Two cached booleans short-circuit the per-step device logic:
 
 ``_cast_to_policy_device``
-    Set once in :meth:`_setup_devices`.  ``True`` iff
-    ``policy_device != env_device``.  When ``True``, the carrier is copied
-    to ``policy_device`` before the policy is invoked.
+    Set in :meth:`SyncDataCollector._setup_devices`.  ``True`` iff
+    ``policy_device != env_device``.  When ``True``, the carrier is copied to
+    ``policy_device`` before the policy is invoked.
 
 ``_cast_to_env_device``
-    Set once in :meth:`_setup_devices` (with an extra refinement at
-    :meth:`_make_final_rollout`-time).  ``True`` iff a cast is required on
-    the env side — either because the policy device differs from the env
-    device, or because the policy lives on a device the env cannot consume
-    directly.
+    Set in :meth:`SyncDataCollector._apply_env_device`, after the environment
+    device has been applied or inferred.  It is ``True`` when
+    ``_cast_to_policy_device`` is already ``True`` or when
+    ``env.device != storing_device``.  When ``True``, the carrier is copied to
+    ``env_device`` before ``env.step_and_maybe_reset``.
 
-These are computed once so that the per-step branches degenerate into a
-single bool check when everything lives on the same device — the common
-single-GPU case pays essentially no device-management overhead.
+These are computed once so that the per-step branches degenerate into a single
+bool check when everything lives on the same device.
 
-The companion flag ``_shuttle_has_no_device`` (set in :meth:`_make_shuttle`)
-records whether the carrier was stripped of its device.  When ``True``, any
-new ``"next"`` data merged into the carrier after an env step is also
-device-stripped (see the ``if self._shuttle_has_no_device`` block in the
-rollout loop) so the deviceless invariant is preserved.
+The companion flag ``_carrier_has_no_device`` (set in
+:meth:`SyncDataCollector._make_carrier`) records whether the carrier was
+stripped of its device.  When ``True``, any new ``"next"`` data merged into the
+carrier after an env step is also device-stripped so the deviceless invariant
+is preserved.
 
 Trajectory IDs
 --------------
@@ -188,44 +192,45 @@ When ``track_traj_ids=True`` (the default), every frame carries a
 it belongs to.  Two pieces of machinery cooperate:
 
 - :meth:`SyncDataCollector._traj_pool` returns a process-local
-  :class:`_TrajectoryPool` that hands out fresh IDs and guarantees they do
-  not collide across resets.
-- :meth:`SyncDataCollector._update_traj_ids` runs after each env step.  It
-  reads the aggregated end-of-trajectory signal from ``("next", "done")``
-  via :func:`_aggregate_end_of_traj`, draws as many fresh IDs from the pool
-  as there are envs that finished, and ``masked_scatter``-s them into the
-  per-env ``traj_ids`` tensor on the carrier.
+  :class:`torchrl.collectors.utils._TrajectoryPool` that hands out fresh IDs.
+  In multi-process collectors, workers share a locked pool created by the
+  parent collector so IDs do not collide across worker resets.
+- :meth:`SyncDataCollector._update_traj_ids` runs after each env step. It reads
+  the aggregated end-of-trajectory signal from ``("next", "done")`` via
+  :func:`_aggregate_end_of_traj`, draws as many fresh IDs from the pool as
+  there are envs that finished, and ``masked_scatter``-s them into the per-env
+  ``traj_ids`` tensor on the carrier.
 
 Setting ``track_traj_ids=False`` skips both the per-step bookkeeping and the
-allocation of the ``traj_ids`` tensor — worth it in throughput-sensitive
-setups that do not need trajectory-aware sampling.  Note that
+allocation of the ``traj_ids`` tensor. This is useful in throughput-sensitive
+setups that do not need trajectory-aware sampling. Note that
 ``split_trajs=True`` requires ``track_traj_ids=True``; the constructor will
 raise if you ask for the former without the latter.
 
 Collection hooks
 ----------------
 
-Two opt-in callbacks let you instrument the rollout without subclassing:
+Two opt-in callbacks let you instrument collection without subclassing:
 
 ``pre_collect_hook``
     Called once at the top of :meth:`rollout`, before the per-timestep loop
-    starts (and before any ``reset_at_each_iter`` reset).  Receives no
-    arguments.  Use it to step a profiler, mark a section in NVTX, or update
-    a worker-local counter.
+    starts and before any ``reset_at_each_iter`` reset. Receives no arguments.
+    Use it to step a profiler, mark a section in NVTX, or update a
+    worker-local counter.
 
 ``post_collect_hook``
-    Called with the batch tensordict immediately before it is yielded to
-    the consumer.  Receives the :class:`~tensordict.TensorDictBase` that
-    will be yielded.  Return value is ignored.  Use it to log metrics
-    derived from the batch.
+    Called with the batch tensordict immediately before it is yielded to the
+    consumer. Receives the :class:`~tensordict.TensorDictBase` that will be
+    yielded. Return value is ignored. Use it to log metrics derived from the
+    batch.
 
 Hooks are worker-local: in :class:`MultiSyncCollector` /
-:class:`MultiAsyncCollector` they run inside each worker process, not on
-the training worker.  Exceptions raised by a hook propagate up and stop
-collection — they are not swallowed.
+:class:`MultiAsyncCollector` they run inside each worker process, not on the
+training worker. Exceptions raised by a hook propagate up and stop collection;
+they are not swallowed.
 
-For batch *transformations* (rather than instrumentation), use ``postproc``
-on the collector constructor instead.
+For batch *transformations* (rather than instrumentation), use ``postproc`` on
+the collector constructor instead.
 
 Where to look in the code
 -------------------------
@@ -238,10 +243,12 @@ Where to look in the code
      - File / function
    * - Per-step rollout loop
      - :meth:`SyncDataCollector.rollout` in ``torchrl/collectors/_single.py``
-   * - Carrier allocation
-     - :meth:`SyncDataCollector._make_shuttle`
-   * - Device setup, cast flags
+   * - Carrier initialization
+     - :meth:`SyncDataCollector._make_carrier`
+   * - Device setup and policy cast flag
      - :meth:`SyncDataCollector._setup_devices`
+   * - Environment device application and env cast flag
+     - :meth:`SyncDataCollector._apply_env_device`
    * - Sync function dispatch
      - :meth:`SyncDataCollector._get_sync_fn`
    * - Trajectory ID update

--- a/docs/source/reference/collectors_internals.rst
+++ b/docs/source/reference/collectors_internals.rst
@@ -1,0 +1,260 @@
+.. currentmodule:: torchrl.collectors
+
+.. _ref_collectors_internals:
+
+Collector Internals
+===================
+
+This page describes how :class:`~torchrl.collectors.SyncDataCollector` (aliased
+as :class:`Collector`) actually steps through an environment.  It is meant for
+contributors and for users debugging unexpected rollout behaviour — the device
+casts, the per-step bookkeeping, and the trajectory-tracking machinery are not
+visible from the public API and have, until now, only been documented in
+inline comments inside ``torchrl/collectors/_single.py``.
+
+The multi-process collectors (:class:`MultiSyncCollector`,
+:class:`MultiAsyncCollector`) delegate their per-worker rollouts to
+:class:`SyncDataCollector`, so everything on this page applies to them too.
+
+Per-timestep flow
+-----------------
+
+A single iteration of :meth:`SyncDataCollector.rollout` corresponds to one
+environment step.  ``frames_per_batch`` such iterations are stacked into the
+batch yielded to the user (or written to the replay buffer).
+
+.. code-block:: text
+
+    ┌─────────────────────────────────────────────────────────────────────┐
+    │  for t in range(frames_per_batch):                                  │
+    │                                                                     │
+    │    ┌─ carrier ──────────────────────────────────────────────────┐   │
+    │    │  TensorDict — observation + collector metadata,            │   │
+    │    │  device-cleared if policy_device != env_device             │   │
+    │    └────────────┬───────────────────────────────────────────────┘   │
+    │                 │                                                   │
+    │                 │  (1) cast to policy_device if needed              │
+    │                 │      → _sync_policy()                             │
+    │                 ▼                                                   │
+    │           ┌──────────┐                                              │
+    │           │  policy  │  ← reads obs, writes action + log_prob       │
+    │           └────┬─────┘                                              │
+    │                │                                                   │
+    │                │  carrier.update(policy_output)                     │
+    │                ▼                                                   │
+    │    ┌─ carrier (now has action) ──────────────────────────────┐     │
+    │    └────────────┬────────────────────────────────────────────┘     │
+    │                 │                                                  │
+    │                 │  (2) cast to env_device if needed                │
+    │                 │      → _sync_env()                               │
+    │                 ▼                                                  │
+    │           ┌──────────────┐                                         │
+    │           │  env.step_   │  ← returns (env_output, env_next_output)│
+    │           │  and_maybe_  │    auto-resets done envs                │
+    │           │  reset       │                                         │
+    │           └────┬─────────┘                                         │
+    │                │                                                  │
+    │                │  carrier.set("next", env_output["next"])         │
+    │                ▼                                                  │
+    │    ┌─ carrier_for_out (snapshot for this step) ──────────────┐    │
+    │    └────────────┬────────────────────────────────────────────┘    │
+    │                 │                                                 │
+    │                 │  (3) cast to storing_device if needed           │
+    │                 │      → _sync_storage()                          │
+    │                 ▼                                                 │
+    │           append to tensordicts list  OR  replay_buffer.add(...)  │
+    │                 │                                                 │
+    │                 │  carrier = env_next_output  (post-reset state)  │
+    │                 │  update traj_ids if any env finished            │
+    │                 └─→ next iteration                                │
+    └─────────────────────────────────────────────────────────────────────┘
+
+Implementation: :meth:`SyncDataCollector.rollout` in
+``torchrl/collectors/_single.py``.
+
+The carrier
+-----------
+
+The **carrier** (formerly called the *shuttle*) is the single
+:class:`~tensordict.TensorDictBase` instance that survives across timesteps and
+carries data between the environment and the policy.  It is allocated once by
+:meth:`SyncDataCollector._make_shuttle` and stored as ``self._carrier``.
+
+Why it exists
+~~~~~~~~~~~~~
+
+- **Allocation amortization.**  Reallocating a tensordict every timestep would
+  dominate the wall-clock cost of fast environments.  Reusing one tensordict
+  keeps the per-step overhead at the cost of a few in-place updates.
+- **Deviceless semantics.**  When the policy and environment live on
+  *different* devices (e.g. policy on ``cuda:0``, env on ``cpu``), the carrier
+  is cleared of any device pin via ``clear_device_()`` so that subsequent
+  ``.to(device, non_blocking=True)`` calls do the right thing regardless of
+  which side wrote to it last.  The boolean flag
+  ``self._shuttle_has_no_device`` records whether this clearing happened —
+  see :meth:`_make_shuttle`.
+- **Single source of truth for collector metadata.**  Trajectory IDs and
+  any other ``("collector", ...)`` keys live on the carrier and persist
+  across steps without round-tripping through the env.
+
+Reading the carrier
+~~~~~~~~~~~~~~~~~~~
+
+You should not normally touch ``self._carrier`` directly — it is an
+implementation detail.  If you need to instrument what the policy sees on
+step ``t``, use :attr:`SyncDataCollector.pre_collect_hook` or read the data
+yielded by iteration (which is a copy).  Mutating the carrier from a hook is
+undefined behaviour.
+
+Sync points
+-----------
+
+Three explicit synchronisation functions are installed at construction time
+in :meth:`SyncDataCollector._setup_devices` and called inside the rollout
+loop:
+
+``_sync_policy``
+    Called after copying the carrier to ``policy_device`` (rollout loop,
+    after the ``self._carrier.to(self.policy_device, ...)`` call).  Ensures
+    the host has seen the GPU→CPU transfer of whatever was on the carrier
+    before the policy reads it.
+
+``_sync_env``
+    Called after copying the carrier to ``env_device`` (rollout loop, after
+    the ``self._carrier.to(self.env_device, ...)`` call).  Same role on the
+    env side.
+
+``_sync_storage``
+    Called after copying ``carrier_for_out`` to ``storing_device`` (rollout
+    loop, when appending to the per-step ``tensordicts`` list).  Ensures the
+    stored batch is consistent before it is returned or stacked.
+
+What ``_sync_*`` actually is depends on the destination device — see
+:meth:`SyncDataCollector._get_sync_fn`:
+
++-------------------+------------------------------------------------------+
+| Destination       | Sync function                                        |
++===================+======================================================+
+| ``cuda`` device   | ``_do_nothing`` (CUDA handles ordering itself)       |
++-------------------+------------------------------------------------------+
+| Non-CUDA, CUDA    | ``_cuda_sync_if_initialized`` (safe to call after a  |
+| available         | GPU→CPU transfer; no-op in fork subprocesses where   |
+|                   | CUDA was not initialised)                            |
++-------------------+------------------------------------------------------+
+| Non-CUDA, MPS     | ``torch.mps.synchronize``                            |
+| available         |                                                      |
++-------------------+------------------------------------------------------+
+| ``cpu`` (no GPU)  | ``_do_nothing``                                      |
++-------------------+------------------------------------------------------+
+| ``None``          | ``_do_nothing``                                      |
++-------------------+------------------------------------------------------+
+
+Setting ``no_cuda_sync=True`` on the collector skips the explicit ``_sync_*``
+calls — only do this if you know all your transfers are CUDA-stream-ordered
+or if you are running pure-CPU.
+
+Device casting flags
+--------------------
+
+Two cached booleans short-circuit the per-step device logic:
+
+``_cast_to_policy_device``
+    Set once in :meth:`_setup_devices`.  ``True`` iff
+    ``policy_device != env_device``.  When ``True``, the carrier is copied
+    to ``policy_device`` before the policy is invoked.
+
+``_cast_to_env_device``
+    Set once in :meth:`_setup_devices` (with an extra refinement at
+    :meth:`_make_final_rollout`-time).  ``True`` iff a cast is required on
+    the env side — either because the policy device differs from the env
+    device, or because the policy lives on a device the env cannot consume
+    directly.
+
+These are computed once so that the per-step branches degenerate into a
+single bool check when everything lives on the same device — the common
+single-GPU case pays essentially no device-management overhead.
+
+The companion flag ``_shuttle_has_no_device`` (set in :meth:`_make_shuttle`)
+records whether the carrier was stripped of its device.  When ``True``, any
+new ``"next"`` data merged into the carrier after an env step is also
+device-stripped (see the ``if self._shuttle_has_no_device`` block in the
+rollout loop) so the deviceless invariant is preserved.
+
+Trajectory IDs
+--------------
+
+When ``track_traj_ids=True`` (the default), every frame carries a
+``("collector", "traj_ids")`` integer that uniquely identifies the trajectory
+it belongs to.  Two pieces of machinery cooperate:
+
+- :meth:`SyncDataCollector._traj_pool` returns a process-local
+  :class:`_TrajectoryPool` that hands out fresh IDs and guarantees they do
+  not collide across resets.
+- :meth:`SyncDataCollector._update_traj_ids` runs after each env step.  It
+  reads the aggregated end-of-trajectory signal from ``("next", "done")``
+  via :func:`_aggregate_end_of_traj`, draws as many fresh IDs from the pool
+  as there are envs that finished, and ``masked_scatter``-s them into the
+  per-env ``traj_ids`` tensor on the carrier.
+
+Setting ``track_traj_ids=False`` skips both the per-step bookkeeping and the
+allocation of the ``traj_ids`` tensor — worth it in throughput-sensitive
+setups that do not need trajectory-aware sampling.  Note that
+``split_trajs=True`` requires ``track_traj_ids=True``; the constructor will
+raise if you ask for the former without the latter.
+
+Collection hooks
+----------------
+
+Two opt-in callbacks let you instrument the rollout without subclassing:
+
+``pre_collect_hook``
+    Called once at the top of :meth:`rollout`, before the per-timestep loop
+    starts (and before any ``reset_at_each_iter`` reset).  Receives no
+    arguments.  Use it to step a profiler, mark a section in NVTX, or update
+    a worker-local counter.
+
+``post_collect_hook``
+    Called with the batch tensordict immediately before it is yielded to
+    the consumer.  Receives the :class:`~tensordict.TensorDictBase` that
+    will be yielded.  Return value is ignored.  Use it to log metrics
+    derived from the batch.
+
+Hooks are worker-local: in :class:`MultiSyncCollector` /
+:class:`MultiAsyncCollector` they run inside each worker process, not on
+the training worker.  Exceptions raised by a hook propagate up and stop
+collection — they are not swallowed.
+
+For batch *transformations* (rather than instrumentation), use ``postproc``
+on the collector constructor instead.
+
+Where to look in the code
+-------------------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Concept
+     - File / function
+   * - Per-step rollout loop
+     - :meth:`SyncDataCollector.rollout` in ``torchrl/collectors/_single.py``
+   * - Carrier allocation
+     - :meth:`SyncDataCollector._make_shuttle`
+   * - Device setup, cast flags
+     - :meth:`SyncDataCollector._setup_devices`
+   * - Sync function dispatch
+     - :meth:`SyncDataCollector._get_sync_fn`
+   * - Trajectory ID update
+     - :meth:`SyncDataCollector._update_traj_ids`
+   * - Trajectory ID pool
+     - :class:`torchrl.collectors.utils._TrajectoryPool`
+   * - Hooks
+     - ``pre_collect_hook`` / ``post_collect_hook`` constructor arguments
+
+See also
+--------
+
+- :ref:`ref_collectors` for the high-level API
+- :ref:`ref_profiling` for ``TORCHRL_PROFILING=1`` instrumentation that emits
+  named ranges on the carrier / policy / env transitions described above
+- :doc:`data_layout` for the shape and key conventions the carrier follows

--- a/docs/source/reference/glossary.rst
+++ b/docs/source/reference/glossary.rst
@@ -1,0 +1,132 @@
+.. _ref_glossary:
+
+Glossary
+========
+
+TorchRL borrows much of its vocabulary from :mod:`tensordict` and the broader
+RL literature, but a handful of terms appear in error messages and source
+code without a dedicated definition in the API reference.  This page lists
+those terms with the minimum context needed to find the relevant code.
+
+.. glossary::
+   :sorted:
+
+   carrier
+   shuttle
+      The single :class:`~tensordict.TensorDictBase` instance that survives
+      across timesteps inside :meth:`~torchrl.collectors.SyncDataCollector.rollout`
+      and carries data between the environment and the policy.  Stored as
+      ``self._carrier`` (the older name ``shuttle`` is kept in some
+      comments).  See :ref:`ref_collectors_internals` for the full lifecycle.
+
+   in_keys
+   out_keys
+      The list of tensordict keys a module *reads from* (``in_keys``) and
+      *writes to* (``out_keys``).  Both :class:`~tensordict.nn.TensorDictModule`
+      and most of TorchRL's loss / value-estimator components expose these
+      as constructor arguments.  Modifying them lets you wire a module into
+      a tensordict layout that differs from the defaults — see
+      :class:`~tensordict.nn.TensorDictModule` and the
+      :ref:`data_layout <ref_data_layout>` page for naming conventions.
+
+   _AcceptedKeys
+      A dataclass nested inside most :class:`~torchrl.objectives.LossModule`
+      subclasses that declares the tensordict keys the loss expects to read
+      or write.  Each field is a :class:`~tensordict.utils.NestedKey` with a
+      default value.  Override the defaults via
+      :meth:`~torchrl.objectives.LossModule.set_keys` rather than mutating
+      the dataclass directly — ``set_keys`` also propagates the change to
+      the underlying value estimator.
+
+   set_keys
+      The public method on :class:`~torchrl.objectives.LossModule` (and on
+      value estimators) used to override the default tensordict keys a loss
+      expects.  Example: ``loss.set_keys(value=("agents", "state_value"),
+      action=("agents", "action"))``.  Prefer this over reaching into
+      ``loss.tensor_keys`` directly because it also wires the changes into
+      the loss's value estimator if one exists.
+
+   recurrent mode
+      The flag controlling whether an RNN-bearing module
+      (:class:`~torchrl.modules.LSTMModule`,
+      :class:`~torchrl.modules.GRUModule`) treats the time dimension
+      sequentially or one step at a time.  Toggled per-call via
+      :meth:`~torchrl.modules.LSTMModule.set_recurrent_mode` or globally via
+      the ``recurrent_mode_state_manager`` context manager.  Collectors set
+      it to step-by-step during rollout; losses set it to sequential during
+      backprop over a trajectory chunk.
+
+   TensorDictPrimer
+      A :class:`~torchrl.envs.Transform` that injects keys into the
+      environment's reset / step output that the policy needs but the env
+      does not natively produce — most commonly RNN hidden states.  Without
+      a primer, the first call to a recurrent policy after reset would have
+      no hidden state to read.  See
+      :class:`~torchrl.envs.TensorDictPrimer` and
+      :meth:`torchrl.modules.LSTMModule.make_tensordict_primer`.
+
+   is_init
+      A boolean key (default name: ``"is_init"``) written by
+      :class:`~torchrl.envs.InitTracker` immediately after every env reset.
+      Recurrent modules and advantage estimators read this key to know
+      where trajectories begin so they can zero out stale hidden state or
+      reset the bootstrap target.  If ``is_init`` is missing or wrongly
+      wired, hidden state from a previous trajectory will leak into the
+      next — a class of bug that looks like a learning regression rather
+      than a key-routing error.
+
+   trajectory ID
+      An integer that uniquely identifies which trajectory each frame
+      belongs to.  Written by
+      :class:`~torchrl.collectors.SyncDataCollector` as
+      ``("collector", "traj_ids")`` when ``track_traj_ids=True``.  Used by
+      :class:`~torchrl.data.SliceSampler` to draw whole trajectories from
+      a buffer and by :func:`~torchrl.collectors.utils.split_trajectories`
+      to slice a flat batch into per-trajectory chunks.
+
+   storing_device
+   policy_device
+   env_device
+      The three device slots a collector tracks separately.  ``policy_device``
+      is where the policy network lives; ``env_device`` is where the
+      environment's step / reset run; ``storing_device`` is where the
+      collected batch is materialised before being yielded.  When any two
+      differ, the collector inserts explicit ``.to(...)`` casts and the
+      matching ``_sync_*`` call — see :ref:`ref_collectors_internals`.
+
+   no_cuda_sync
+      A collector flag that suppresses the explicit
+      ``torch.cuda.synchronize`` (or MPS/NPU equivalent) inserted after
+      cross-device transfers.  Safe to set only when all transfers are
+      CUDA-stream-ordered or when running pure-CPU.  Defaults to ``False``.
+
+   compact_obs
+      Collector setting that drops observation keys from the ``("next",
+      ...)`` sub-tensordict of every persisted step.  The observations are
+      recoverable from the root keys of the *following* step, so the
+      collected batch is smaller without information loss — at the cost
+      of indirection at sampling time.  See the ``compact_next_keys``
+      argument on :class:`~torchrl.collectors.SyncDataCollector`.
+
+   functional (loss)
+      A :class:`~torchrl.objectives.LossModule` is *functional* when it
+      stores its actor / critic parameters as a stateless tensordict and
+      invokes the networks with :meth:`~tensordict.TensorDictParams.to_module`
+      at call time.  This is what makes ``soft / target update``,
+      ``separate_losses=True``, and per-parameter optimiser groups possible
+      without deep-copying the underlying ``nn.Module``.  Check ``loss.functional``
+      to see which mode a given loss is in.
+
+   tensor_keys
+      The instance attribute on every :class:`~torchrl.objectives.LossModule`
+      holding the *current* values of the keys declared in ``_AcceptedKeys``.
+      Read-only by convention — use :meth:`~torchrl.objectives.LossModule.set_keys`
+      to modify them.
+
+See also
+--------
+
+- :ref:`ref_data_layout` — naming conventions for keys in collected batches
+- :ref:`ref_collectors_internals` — where carrier / sync / device flags
+  appear in the rollout loop
+- :doc:`knowledge_base` — longer-form debugging notes

--- a/docs/source/reference/glossary.rst
+++ b/docs/source/reference/glossary.rst
@@ -4,135 +4,194 @@ Glossary
 ========
 
 TorchRL borrows much of its vocabulary from :mod:`tensordict` and the broader
-RL literature, but a handful of terms appear in error messages and source
-code without a dedicated definition in the API reference.  This page lists
-those terms with the minimum context needed to find the relevant code.
+RL literature, but a handful of terms appear in error messages and source code
+without a dedicated definition in the API reference. This page lists those
+terms with the minimum context needed to find the relevant code.
 
 .. glossary::
-   :sorted:
-
-   carrier
-   shuttle
-      The single :class:`~tensordict.TensorDictBase` instance that survives
-      across timesteps inside :meth:`~torchrl.collectors.SyncDataCollector.rollout`
-      and carries data between the environment and the policy.  Stored as
-      ``self._carrier`` (the older name ``shuttle`` is kept in some
-      comments).  See :ref:`ref_collectors_internals` for the full lifecycle.
-
-   in_keys
-   out_keys
-      The list of tensordict keys a module *reads from* (``in_keys``) and
-      *writes to* (``out_keys``).  Both :class:`~tensordict.nn.TensorDictModule`
-      and most of TorchRL's loss / value-estimator components expose these
-      as constructor arguments.  Modifying them lets you wire a module into
-      a tensordict layout that differs from the defaults — see
-      :class:`~tensordict.nn.TensorDictModule` and the
-      :ref:`data_layout <ref_data_layout>` page for naming conventions.
 
    _AcceptedKeys
       A dataclass nested inside most :class:`~torchrl.objectives.LossModule`
-      subclasses that declares the tensordict keys the loss expects to read
-      or write.  Each field is a :class:`~tensordict.utils.NestedKey` with a
-      default value.  Override the defaults via
-      :meth:`~torchrl.objectives.LossModule.set_keys` rather than mutating
-      the dataclass directly — ``set_keys`` also propagates the change to
-      the underlying value estimator.
+      subclasses that declares the tensordict keys the loss expects to read or
+      write. Each field is a :class:`~tensordict.utils.NestedKey` with a
+      default value. Override the defaults via
+      :meth:`~torchrl.objectives.LossModule.set_keys` rather than mutating the
+      dataclass directly; ``set_keys`` also propagates the change to the
+      underlying value estimator.
 
-   set_keys
-      The public method on :class:`~torchrl.objectives.LossModule` (and on
-      value estimators) used to override the default tensordict keys a loss
-      expects.  Example: ``loss.set_keys(value=("agents", "state_value"),
-      action=("agents", "action"))``.  Prefer this over reaching into
-      ``loss.tensor_keys`` directly because it also wires the changes into
-      the loss's value estimator if one exists.
+   BatchedEnv
+      A TorchRL environment that owns more than one environment instance under
+      a single :class:`~torchrl.envs.EnvBase` interface. The common
+      implementations are :class:`~torchrl.envs.SerialEnv` and
+      :class:`~torchrl.envs.ParallelEnv`, both subclasses of
+      :class:`~torchrl.envs.batched_envs.BatchedEnvBase`. Their ``batch_size`` is the
+      leading shape of reset, step, and collector outputs.
 
-   recurrent mode
-      The flag controlling whether an RNN-bearing module
-      (:class:`~torchrl.modules.LSTMModule`,
-      :class:`~torchrl.modules.GRUModule`) processes a single timestep per
-      call (*sequential*) or a full ``(B, T, ...)`` sequence in one call
-      (*recurrent*).  Toggled via the
-      :class:`~torchrl.modules.set_recurrent_mode` context manager; the
-      per-module ``LSTMModule.set_recurrent_mode`` method was removed in
-      v0.8 in favour of this context manager.  Backed by the process-wide
-      ``recurrent_mode_state_manager`` singleton, which is thread- and
-      asyncio-task-local via :class:`contextvars.ContextVar`.  Collectors
-      run in **sequential** mode (one step per call, hidden state shuttled
-      via the tensordict); losses run in **recurrent** mode so the module
-      can split-and-pad on trajectory boundaries inside a single replayed
-      batch.
+   carrier
+      The :class:`~tensordict.TensorDictBase` stored as ``self._carrier`` inside
+      :meth:`~torchrl.collectors.SyncDataCollector.rollout`. It persists across
+      collector batches and holds the post-reset environment output that the
+      next policy call consumes. See :ref:`ref_collectors_internals` for the
+      full lifecycle.
 
-   TensorDictPrimer
-      A :class:`~torchrl.envs.Transform` that injects keys into the
-      environment's reset / step output that the policy needs but the env
-      does not natively produce — most commonly RNN hidden states.  Without
-      a primer, the first call to a recurrent policy after reset would have
-      no hidden state to read.  See
-      :class:`~torchrl.envs.TensorDictPrimer` and
-      :meth:`torchrl.modules.LSTMModule.make_tensordict_primer`.
+   Collector
+      The single-process data collector, exposed as
+      :class:`~torchrl.collectors.Collector`. It alternates policy calls and
+      environment steps to produce rollout tensordicts; the legacy name
+      :class:`~torchrl.collectors.SyncDataCollector` aliases the same
+      implementation.
+
+   compact_obs
+      Collector setting that drops observation and state keys from the
+      ``("next", ...)`` sub-tensordict of every persisted step. Within a
+      contiguous same-trajectory sample, those values can be reconstructed from
+      the root keys of the following step. At trajectory boundaries or in
+      non-contiguous random samples, reconstruction must use the configured fill
+      value; see :class:`~torchrl.envs.transforms.NextStateReconstructor` and the
+      ``compact_obs`` argument on :class:`~torchrl.collectors.SyncDataCollector`.
+
+   Composite
+   CompositeSpec
+      A nested spec container, currently named :class:`~torchrl.data.Composite`,
+      that maps tensordict keys to leaf :class:`~torchrl.data.TensorSpec`
+      objects. Environment specs such as ``observation_spec``, ``action_spec``,
+      and ``reward_spec`` are usually composites. ``CompositeSpec`` is an older
+      name that may still appear in discussions and issue reports.
+
+   Env
+      Short for environment: an object implementing the
+      :class:`~torchrl.envs.EnvBase` API, including ``reset``, ``step``, specs,
+      device handling, and a tensordict-based input/output contract. TorchRL env
+      wrappers usually subclass :class:`~torchrl.envs.Transform` or compose a
+      :class:`~torchrl.envs.TransformedEnv` rather than following the Gym
+      wrapper API directly.
+
+   env batch size
+      The leading batch shape of an environment, exposed as
+      :attr:`~torchrl.envs.EnvBase.batch_size`. A single unbatched env has an
+      empty batch size; a :class:`~torchrl.envs.ParallelEnv` with ``N`` workers
+      usually has batch size ``[N]``. Collectors append a time dimension to this
+      shape when they stack rollout steps.
+
+   env_device
+      The collector device slot used for environment ``reset`` and ``step``
+      operations. When it differs from ``policy_device`` or from the storage
+      layout, the collector inserts the casts and sync points described in
+      :ref:`ref_collectors_internals`.
+
+   EnvCreator
+      A small callable wrapper, :class:`~torchrl.envs.EnvCreator`, used to build
+      environments lazily or in worker processes. It is useful when constructors
+      need to be serialized for :class:`~torchrl.collectors.MultiSyncCollector`,
+      :class:`~torchrl.collectors.MultiAsyncCollector`, or distributed
+      collectors.
+
+   functional (loss)
+      A :class:`~torchrl.objectives.LossModule` is *functional* when it stores
+      its actor / critic parameters as a stateless tensordict and invokes the
+      networks with :meth:`~tensordict.TensorDictParams.to_module` at call time.
+      This is what makes soft / target update, ``separate_losses=True``, and
+      per-parameter optimiser groups possible without deep-copying the
+      underlying ``nn.Module``. Check ``loss.functional`` to see which mode a
+      given loss is in.
+
+   in_keys
+   out_keys
+      The list of tensordict keys a module reads from (``in_keys``) and writes
+      to (``out_keys``). Both :class:`~tensordict.nn.TensorDictModule` and most
+      TorchRL loss / value-estimator components expose these as constructor
+      arguments. Modifying them lets you wire a module into a tensordict layout
+      that differs from the defaults; see :ref:`data_layout <ref_data_layout>`
+      for naming conventions.
 
    is_init
       A boolean key (default name: ``"is_init"``) written by
       :class:`~torchrl.envs.InitTracker` immediately after every env reset.
-      Recurrent modules and advantage estimators read this key to know
-      where trajectories begin so they can zero out stale hidden state or
-      reset the bootstrap target.  If ``is_init`` is missing or wrongly
-      wired, hidden state from a previous trajectory will leak into the
-      next — a class of bug that looks like a learning regression rather
-      than a key-routing error.
-
-   trajectory ID
-      An integer that uniquely identifies which trajectory each frame
-      belongs to.  Written by
-      :class:`~torchrl.collectors.SyncDataCollector` as
-      ``("collector", "traj_ids")`` when ``track_traj_ids=True``.  Used by
-      :class:`~torchrl.data.SliceSampler` to draw whole trajectories from
-      a buffer and by :func:`~torchrl.collectors.utils.split_trajectories`
-      to slice a flat batch into per-trajectory chunks.
-
-   storing_device
-   policy_device
-   env_device
-      The three device slots a collector tracks separately.  ``policy_device``
-      is where the policy network lives; ``env_device`` is where the
-      environment's step / reset run; ``storing_device`` is where the
-      collected batch is materialised before being yielded.  When any two
-      differ, the collector inserts explicit ``.to(...)`` casts and the
-      matching ``_sync_*`` call — see :ref:`ref_collectors_internals`.
+      Recurrent modules and advantage estimators read this key to know where
+      trajectories begin so they can zero out stale hidden state or reset the
+      bootstrap target.
 
    no_cuda_sync
-      A collector flag that suppresses the explicit
-      ``torch.cuda.synchronize`` (or MPS/NPU equivalent) inserted after
-      cross-device transfers.  Safe to set only when all transfers are
-      CUDA-stream-ordered or when running pure-CPU.  Defaults to ``False``.
+      A collector flag that suppresses the explicit CUDA, MPS, or NPU
+      synchronizations inserted after cross-device transfers. Safe to set only
+      when transfers are already correctly ordered or when running pure CPU.
+      Defaults to ``False``.
 
-   compact_obs
-      Collector setting that drops observation keys from the ``("next",
-      ...)`` sub-tensordict of every persisted step.  The observations are
-      recoverable from the root keys of the *following* step, so the
-      collected batch is smaller without information loss — at the cost
-      of indirection at sampling time.  See the ``compact_next_keys``
-      argument on :class:`~torchrl.collectors.SyncDataCollector`.
+   policy_device
+      The collector device slot where the policy network runs. When it differs
+      from ``env_device``, the collector casts the carrier before policy and env
+      calls.
 
-   functional (loss)
-      A :class:`~torchrl.objectives.LossModule` is *functional* when it
-      stores its actor / critic parameters as a stateless tensordict and
-      invokes the networks with :meth:`~tensordict.TensorDictParams.to_module`
-      at call time.  This is what makes ``soft / target update``,
-      ``separate_losses=True``, and per-parameter optimiser groups possible
-      without deep-copying the underlying ``nn.Module``.  Check ``loss.functional``
-      to see which mode a given loss is in.
+   recurrent mode
+      The flag controlling whether an RNN-bearing module
+      (:class:`~torchrl.modules.LSTMModule`,
+      :class:`~torchrl.modules.GRUModule`) processes a single timestep per call
+      (*sequential*) or a full ``(B, T, ...)`` sequence in one call
+      (*recurrent*). Toggled via the
+      :class:`~torchrl.modules.set_recurrent_mode` context manager. Collectors
+      run in sequential mode; losses run in recurrent mode so the module can
+      split and pad on trajectory boundaries inside a replayed batch.
+
+   set_keys
+      The public method on :class:`~torchrl.objectives.LossModule` and value
+      estimators used to override the default tensordict keys a loss expects.
+      Example: ``loss.set_keys(value=("agents", "state_value"),
+      action=("agents", "action"))``. Prefer this over reaching into
+      ``loss.tensor_keys`` directly because it
+      also wires changes into the loss's value estimator if one exists.
+
+   Specs
+      Tensor constraints that describe valid values, shapes, dtypes, and
+      devices. TorchRL uses :class:`~torchrl.data.TensorSpec` leaves, such as
+      :class:`~torchrl.data.Bounded` and :class:`~torchrl.data.Unbounded`, and
+      :class:`~torchrl.data.Composite` containers to validate and generate env
+      inputs and outputs.
+
+   storing_device
+      The collector device slot where a rollout batch is materialised before it
+      is yielded or extended into a replay buffer. Direct ``replay_buffer.add``
+      writes bypass this materialisation path.
+
+   TED
+      TorchRL Episode Data: the standard offline dataset layout described in
+      :ref:`TED-format`. It stores a transition with root keys for the current
+      step and a ``("next", ...)`` sub-tensordict for next-step values.
+      Conversion helpers such as :class:`~torchrl.data.TED2Flat` and
+      :class:`~torchrl.data.Flat2TED` serialize and restore this layout.
 
    tensor_keys
       The instance attribute on every :class:`~torchrl.objectives.LossModule`
-      holding the *current* values of the keys declared in ``_AcceptedKeys``.
-      Read-only by convention — use :meth:`~torchrl.objectives.LossModule.set_keys`
-      to modify them.
+      holding the current values of the keys declared in ``_AcceptedKeys``.
+      Read-only by convention; use
+      :meth:`~torchrl.objectives.LossModule.set_keys` to modify them.
+
+   TensorDictPrimer
+      A :class:`~torchrl.envs.Transform` that injects keys into the
+      environment's reset / step output that the policy needs but the env does
+      not natively produce, most commonly RNN hidden states. Without a primer,
+      the first call to a recurrent policy after reset would have no hidden
+      state to read. See :class:`~torchrl.envs.TensorDictPrimer` and
+      :meth:`torchrl.modules.LSTMModule.make_tensordict_primer`.
+
+   trajectory ID
+      An integer that uniquely identifies which trajectory each frame belongs
+      to. Written by :class:`~torchrl.collectors.SyncDataCollector` as
+      ``("collector", "traj_ids")`` when ``track_traj_ids=True``. Used by
+      :class:`~torchrl.data.SliceSampler` to draw whole trajectories from a
+      buffer and by :func:`~torchrl.collectors.utils.split_trajectories` to
+      slice a flat batch into per-trajectory chunks.
+
+   Transform
+      TorchRL's tensordict-native environment transform abstraction,
+      :class:`~torchrl.envs.Transform`. A transform can modify input specs,
+      output specs, reset data, step data, or inverse action data, and is
+      usually installed through :class:`~torchrl.envs.TransformedEnv`. This is
+      distinct from a Gym wrapper, which operates on non-tensordict values.
 
 See also
 --------
 
 - :ref:`ref_data_layout` — naming conventions for keys in collected batches
-- :ref:`ref_collectors_internals` — where carrier / sync / device flags
-  appear in the rollout loop
+- :ref:`ref_collectors_internals` — where carrier / sync / device flags appear
+  in the rollout loop
 - :doc:`knowledge_base` — longer-form debugging notes

--- a/docs/source/reference/glossary.rst
+++ b/docs/source/reference/glossary.rst
@@ -49,12 +49,18 @@ those terms with the minimum context needed to find the relevant code.
    recurrent mode
       The flag controlling whether an RNN-bearing module
       (:class:`~torchrl.modules.LSTMModule`,
-      :class:`~torchrl.modules.GRUModule`) treats the time dimension
-      sequentially or one step at a time.  Toggled per-call via
-      :meth:`~torchrl.modules.LSTMModule.set_recurrent_mode` or globally via
-      the ``recurrent_mode_state_manager`` context manager.  Collectors set
-      it to step-by-step during rollout; losses set it to sequential during
-      backprop over a trajectory chunk.
+      :class:`~torchrl.modules.GRUModule`) processes a single timestep per
+      call (*sequential*) or a full ``(B, T, ...)`` sequence in one call
+      (*recurrent*).  Toggled via the
+      :class:`~torchrl.modules.set_recurrent_mode` context manager; the
+      per-module ``LSTMModule.set_recurrent_mode`` method was removed in
+      v0.8 in favour of this context manager.  Backed by the process-wide
+      ``recurrent_mode_state_manager`` singleton, which is thread- and
+      asyncio-task-local via :class:`contextvars.ContextVar`.  Collectors
+      run in **sequential** mode (one step per call, hidden state shuttled
+      via the tensordict); losses run in **recurrent** mode so the module
+      can split-and-pad on trajectory boundaries inside a single replayed
+      batch.
 
    TensorDictPrimer
       A :class:`~torchrl.envs.Transform` that injects keys into the

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -16,3 +16,4 @@ API Reference
     utils
     config
     profiling
+    glossary

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -529,8 +529,8 @@ class Collector(BaseCollector):
         self.track_traj_ids = track_traj_ids
         self._exclude_private_keys = True
 
-        # Create shuttle and rollout buffers
-        self._make_shuttle()
+        # Create carrier and rollout buffers
+        self._make_carrier()
         self._maybe_make_final_rollout(make_rollout=self._use_buffers)
         self._set_truncated_keys()
 
@@ -1053,15 +1053,15 @@ class Collector(BaseCollector):
             pool = self._traj_pool_val = _TrajectoryPool()
         return pool
 
-    def _make_shuttle(self):
-        # Shuttle is a deviceless tensordict that just carried data from env to policy and policy to env
+    def _make_carrier(self):
+        # The carrier holds rollout state across iterations and calls.
         with torch.no_grad():
             self._carrier = self.env.reset()
         if self.policy_device != self.env_device or self.env_device is None:
-            self._shuttle_has_no_device = True
+            self._carrier_has_no_device = True
             self._carrier.clear_device_()
         else:
-            self._shuttle_has_no_device = False
+            self._carrier_has_no_device = False
 
         if self.track_traj_ids:
             traj_ids = self._traj_pool.get_traj_and_increment(
@@ -1680,9 +1680,9 @@ class Collector(BaseCollector):
         Each call runs ``frames_per_batch`` env steps and returns (or writes
         to the replay buffer) the resulting batch.  The per-timestep flow is:
 
-        1. **Carrier prep** — read ``self._carrier``, the deviceless
+        1. **Carrier prep** — read ``self._carrier``, the persistent
            tensordict that survives across timesteps (allocated once in
-           :meth:`_make_shuttle`).  If ``reset_at_each_iter=True``, reset
+           :meth:`_make_carrier`).  If ``reset_at_each_iter=True``, reset
            the env first.
         2. **Policy step** — cast the carrier to ``policy_device`` if it
            differs from ``env_device`` (then ``_sync_policy()``), invoke
@@ -1691,9 +1691,10 @@ class Collector(BaseCollector):
            (then ``_sync_env()``), call ``env.step_and_maybe_reset``, and
            write the returned ``"next"`` sub-tensordict back into the
            carrier.
-        4. **Persist** — append the per-step snapshot to a list (or
-           ``replay_buffer.add(...)``) after casting to ``storing_device``
-           and ``_sync_storage()`` if needed.
+        4. **Persist** — append the per-step snapshot to a list after
+           casting to ``storing_device`` and ``_sync_storage()`` if needed,
+           or write it directly with ``replay_buffer.add(...)`` when direct
+           replay-buffer writes are enabled.
         5. **Advance** — swap the carrier for the post-reset
            ``env_next_output`` and update ``("collector", "traj_ids")`` for
            any envs that finished.
@@ -1711,7 +1712,7 @@ class Collector(BaseCollector):
         if self.reset_at_each_iter:
             self._carrier.update(self.env.reset())
 
-        # self._shuttle.fill_(("collector", "step_count"), 0)
+        # self._carrier.fill_(("collector", "step_count"), 0)
         if self._use_buffers and self.track_traj_ids:
             self._final_rollout.fill_(("collector", "traj_ids"), -1)
         else:
@@ -1739,7 +1740,8 @@ class Collector(BaseCollector):
                 else:
                     if self._cast_to_policy_device:
                         if self.policy_device is not None:
-                            # This is unsafe if the shuttle is in pin_memory -- otherwise cuda will be happy with non_blocking
+                            # This is unsafe if the carrier is in pin_memory;
+                            # otherwise CUDA will be happy with non_blocking.
                             non_blocking = (
                                 not self.no_cuda_sync
                                 or self.policy_device.type == "cuda"
@@ -1753,7 +1755,7 @@ class Collector(BaseCollector):
                         elif self.policy_device is None:
                             # we know the tensordict has a device otherwise we would not be here
                             # we can pass this, clear_device_ must have been called earlier
-                            # policy_input = self._shuttle.clear_device_()
+                            # policy_input = self._carrier.clear_device_()
                             policy_input = self._carrier
                     else:
                         policy_input = self._carrier
@@ -1765,7 +1767,7 @@ class Collector(BaseCollector):
                     if self.compiled_policy:
                         policy_output = policy_output.clone()
                     if self._carrier is not policy_output:
-                        # ad-hoc update shuttle
+                        # ad-hoc update carrier
                         self._carrier.update(
                             policy_output, keys_to_update=self._policy_output_keys
                         )
@@ -1783,16 +1785,16 @@ class Collector(BaseCollector):
                     elif self.env_device is None:
                         # we know the tensordict has a device otherwise we would not be here
                         # we can pass this, clear_device_ must have been called earlier
-                        # env_input = self._shuttle.clear_device_()
+                        # env_input = self._carrier.clear_device_()
                         env_input = self._carrier
                 else:
                     env_input = self._carrier
                 env_output, env_next_output = self.env.step_and_maybe_reset(env_input)
 
                 if self._carrier is not env_output:
-                    # ad-hoc update shuttle
+                    # ad-hoc update carrier
                     next_data = env_output.get("next")
-                    if self._shuttle_has_no_device:
+                    if self._carrier_has_no_device:
                         # Make sure
                         next_data.clear_device_()
                     self._carrier.set("next", next_data)
@@ -1832,7 +1834,7 @@ class Collector(BaseCollector):
                     # carry over collector data without messing up devices
                     collector_data = self._carrier.get("collector").copy()
                 self._carrier = env_next_output
-                if self._shuttle_has_no_device:
+                if self._carrier_has_no_device:
                     self._carrier.clear_device_()
                 if self.track_traj_ids:
                     self._carrier.set("collector", collector_data)

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -1677,6 +1677,30 @@ class Collector(BaseCollector):
     def rollout(self) -> TensorDictBase:
         """Computes a rollout in the environment using the provided policy.
 
+        Each call runs ``frames_per_batch`` env steps and returns (or writes
+        to the replay buffer) the resulting batch.  The per-timestep flow is:
+
+        1. **Carrier prep** — read ``self._carrier``, the deviceless
+           tensordict that survives across timesteps (allocated once in
+           :meth:`_make_shuttle`).  If ``reset_at_each_iter=True``, reset
+           the env first.
+        2. **Policy step** — cast the carrier to ``policy_device`` if it
+           differs from ``env_device`` (then ``_sync_policy()``), invoke
+           the policy, and merge its outputs back into the carrier.
+        3. **Env step** — cast the carrier to ``env_device`` if needed
+           (then ``_sync_env()``), call ``env.step_and_maybe_reset``, and
+           write the returned ``"next"`` sub-tensordict back into the
+           carrier.
+        4. **Persist** — append the per-step snapshot to a list (or
+           ``replay_buffer.add(...)``) after casting to ``storing_device``
+           and ``_sync_storage()`` if needed.
+        5. **Advance** — swap the carrier for the post-reset
+           ``env_next_output`` and update ``("collector", "traj_ids")`` for
+           any envs that finished.
+
+        See :ref:`ref_collectors_internals` for the full flow diagram and
+        an explanation of the carrier / sync / device-cast machinery.
+
         Returns:
             TensorDictBase containing the computed rollout.
 


### PR DESCRIPTION
Fixes #3746 

## Summary

Adds the architecture / internals layer between the API reference and tutorials that contributors and debuggers have been missing for the collector subsystem and TorchRL-specific vocabulary. **Docs-only.** No runtime changes.

Targets the gap where `SyncDataCollector`'s per-step mechanics (`_carrier`, the three sync points, the device-cast flags) are load-bearing for anyone debugging RNN, replay, or device-placement issues but have until now only lived in inline comments inside [`torchrl/collectors/_single.py`](torchrl/collectors/_single.py).
