### PR TITLE
[Doc] Fix unused frame_skip in PPO tutorial

### DIFF
--- a/tutorials/sphinx-tutorials/coding_ppo.py
+++ b/tutorials/sphinx-tutorials/coding_ppo.py
@@ -151,10 +151,6 @@ from tqdm import tqdm
 # We set the hyperparameters for our algorithm. Depending on the resources
 # available, one may choose to execute the policy on GPU or on another
 # device.
-# The ``frame_skip`` will control how for how many frames is a single
-# action being executed. The rest of the arguments that count frames
-# must be corrected for this value (since one environment step will
-# actually return ``frame_skip`` frames).
 #
 
 is_fork = multiprocessing.get_start_method() == "fork"


### PR DESCRIPTION
## Description

The "Define Hyperparameters" section of the PPO coding tutorial (`tutorials/sphinx-tutorials/coding_ppo.py`) contained a paragraph describing a `frame_skip` hyperparameter:

> The `frame_skip` will control how for how many frames is a single action being executed. The rest of the arguments that count frames must be corrected for this value (since one environment step will actually return `frame_skip` frames).

However, `frame_skip` is never defined or used anywhere in the tutorial: there is no `frame_skip` variable, no `FrameSkipTransform` in the environment's transform stack, and no `GymEnv(frame_skip=...)` argument. The promised "correction" of the frame-counting arguments (`frames_per_batch`, `total_frames`, ...) never happens either. The paragraph is orphaned and misleads readers into looking for a hyperparameter that does not exist.

This PR removes the orphaned paragraph so the section matches what the tutorial actually does. It is a documentation-only change with no effect on the tutorial's executed code, behaviour, or output.

I chose to remove the description rather than to implement `frame_skip` because faithfully implementing it would be a behaviour-changing feature addition: it would require defining the transform/kwarg and then correcting every frame-counting argument, exactly as the original text promised. That is out of scope for fixing the documentation inconsistency reported in the issue and would be better handled as a separate, dedicated change.

## Motivation and Context

A reader was confused by the tutorial referencing a `frame_skip` hyperparameter that is never used. This removes the misleading text so the section is self-consistent.

close #3132

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes) — addressing existing issue #3132, which this PR closes.

## Types of changes

- [x] Documentation (update in the documentation)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation. — N/A: this change is itself the documentation correction and needs no further docs updates.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*). — N/A: tutorial files under `tutorials/sphinx-tutorials/` are exercised by the Sphinx-gallery docs build, not the unit test suite, so there is no unit test to add for removing a comment.
- [x] I have updated the documentation accordingly.
