### PR TITLE
[Feature] Add satellite MuJoCo SAC examples

### DIFF
--- a/examples/satellite/_utils.py
+++ b/examples/satellite/_utils.py
@@ -1,0 +1,939 @@
+"""Shared utilities for the satellite PPO and SAC training scripts.
+
+Houses everything both scripts need so the entry-points stay short and the
+PPO-vs-SAC comparison is apples-to-apples (same env wrapping, same eval
+protocol, same metric definitions, same WandB project / group).
+
+Public surface:
+
+* :func:`pick_device` -- one-line GPU/MPS/CPU selection.
+* :func:`make_train_env` -- vmapped :class:`SatelliteEnv` + transform stack.
+* :func:`make_eval_env` -- same stack plus a stateless :class:`TestSetPrimer`
+  feeding fixed `(init_bus_quat, target_quat)` rows from a CSV.
+* :class:`TestSetPrimer` -- thin :class:`TensorDictPrimer` subclass that
+  emits a deterministic batch of test-set rows on every reset (with safe
+  tiling when ``num_envs != len(test_set)``).
+* :func:`generate_test_set` / :func:`dump_test_set_csv` /
+  :func:`load_test_set_csv` -- (re)producible eval set on disk.
+* :func:`make_actor` / :func:`make_value_critic` /
+  :func:`make_qvalue_critic` -- shared TanhNormal actor and MLP critics.
+* :func:`eval_metrics_fn` -- per-category metrics for the
+  :class:`Evaluator`.
+* :func:`setup_wandb_key` -- compatibility no-op; configure WandB with
+  ``WANDB_API_KEY`` or ``wandb login`` before running.
+
+Run ``python -m examples.satellite._utils generate-test-set`` to materialize
+the deterministic eval CSV; otherwise the default eval set is generated in memory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from tensordict import NestedKey, TensorDictBase
+from tensordict.nn import (
+    AddStateIndependentNormalScale,
+    NormalParamExtractor,
+    TensorDictModule,
+)
+
+from torchrl.data.tensor_specs import Composite, TensorSpec, Unbounded
+from torchrl.envs import (
+    CatTensors,
+    ObservationNorm,
+    RandomTruncationTransform,
+    RewardScaling,
+    RewardSum,
+    StepCounter,
+    TensorDictPrimer,
+    TransformedEnv,
+)
+from torchrl.envs.custom.mujoco import SatelliteEnv
+from torchrl.envs.custom.mujoco._math import (
+    cmg_jacobian,
+    manipulability,
+    pyramid_4cmg_geometry,
+    quat_conj,
+    quat_log,
+    quat_mul,
+)
+from torchrl.modules import MLP, ProbabilisticActor, TanhNormal, ValueOperator
+
+
+# ---------------------------------------------------------------------------
+# Constants -- a single source of truth for layout / file paths.
+# ---------------------------------------------------------------------------
+
+PACKAGE_DIR = Path(__file__).resolve().parent
+DEFAULT_TEST_SET_PATH = PACKAGE_DIR / "test_set.csv"
+DEFAULT_OBS_NORM_PATH = PACKAGE_DIR / "obs_norm_stats.pt"
+
+# Observation sub-keys fed to the policy / critic. Manipulability is
+# kept *outside* this list so the network never sees it -- it's a
+# logging-only signal.
+POLICY_OBS_KEYS: list[str] = [
+    "quat_err",
+    "bus_omega",
+    "gimbal_angles",
+    "gimbal_rates",
+]
+
+# Eval / test-set categories. Kept here so the metric reporter and the
+# generator stay in sync.
+CATEGORIES: tuple[str, ...] = (
+    "uniform",
+    "large_err",
+    "near_singular",
+    "precision",
+    "off_axis",
+)
+
+
+# ---------------------------------------------------------------------------
+# Device selection
+# ---------------------------------------------------------------------------
+
+
+def pick_device(prefer: str | None = None) -> torch.device:
+    """Return the best available device.
+
+    Order: explicit ``prefer`` argument > ``CUDA`` > ``CPU``.
+
+    .. note::
+
+        We deliberately skip MPS: the ``mujoco-torch`` backend keeps its
+        physics model in float64 internally, which MPS doesn't support.
+        For these backends, "GPU if available, CPU otherwise" maps Apple
+        silicon to CPU rather than MPS.
+    """
+    if prefer is not None:
+        return torch.device(prefer)
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+# ---------------------------------------------------------------------------
+# Test-set generation
+# ---------------------------------------------------------------------------
+
+
+def _normalize_quat(q: torch.Tensor) -> torch.Tensor:
+    return q / q.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+
+
+def _attitude_error_norm(init_q: torch.Tensor, target_q: torch.Tensor) -> torch.Tensor:
+    """Magnitude of the quaternion log-map between two attitudes (radians)."""
+    q_err = quat_mul(quat_conj(init_q), target_q)
+    return quat_log(q_err).norm(dim=-1)
+
+
+def _manip_at_angles(angles: torch.Tensor, num_cmgs: int = 4) -> torch.Tensor:
+    """Manipulability at given gimbal angles for the 4-CMG pyramid geometry."""
+    g, r0 = pyramid_4cmg_geometry(device=angles.device, dtype=angles.dtype)
+    jac = cmg_jacobian(angles, g, r0, 100.0)
+    return manipulability(jac)
+
+
+def generate_test_set(
+    n: int = 256,
+    seed: int = 42,
+    num_cmgs: int = 4,
+    device: torch.device | str = "cpu",
+) -> dict[str, torch.Tensor | list[str]]:
+    """Generate a deterministic test set covering the four hard categories.
+
+    Returns a dict with keys ``init_bus_quat`` (n, 4), ``target_quat``
+    (n, 4) and ``category`` (list[str]). Every category gets ``n // 5``
+    rows (the residual is padded with ``uniform``).
+
+    The generation is fully seeded by ``seed`` so re-running this
+    function with the same arguments yields a byte-identical CSV.
+    """
+    if num_cmgs != 4:
+        # The generator below only knows the 4-CMG pyramid geometry --
+        # extending to 6-CMG is straightforward but unnecessary now.
+        raise NotImplementedError("Test-set generation currently assumes 4 CMGs.")
+
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    per_cat = n // len(CATEGORIES)
+    residual = n - per_cat * len(CATEGORIES)
+    counts = {c: per_cat for c in CATEGORIES}
+    counts["uniform"] += residual  # absorb any leftover
+
+    inits: list[torch.Tensor] = []
+    targets: list[torch.Tensor] = []
+    cats: list[str] = []
+
+    # uniform -- pure random pairs; the dynamics-relevant baseline.
+    n_u = counts["uniform"]
+    inits.append(_normalize_quat(torch.randn(n_u, 4, generator=g)))
+    targets.append(_normalize_quat(torch.randn(n_u, 4, generator=g)))
+    cats.extend(["uniform"] * n_u)
+
+    # large_err -- reject any pair with attitude error < 120 degrees.
+    n_l = counts["large_err"]
+    LARGE_THRESHOLD = math.radians(120.0)
+    accepted_init: list[torch.Tensor] = []
+    accepted_target: list[torch.Tensor] = []
+    while len(accepted_init) < n_l:
+        batch = max(64, n_l * 4)
+        i = _normalize_quat(torch.randn(batch, 4, generator=g))
+        t = _normalize_quat(torch.randn(batch, 4, generator=g))
+        err = _attitude_error_norm(i, t)
+        keep = err >= LARGE_THRESHOLD
+        for j in range(batch):
+            if keep[j]:
+                accepted_init.append(i[j])
+                accepted_target.append(t[j])
+                if len(accepted_init) == n_l:
+                    break
+    inits.append(torch.stack(accepted_init))
+    targets.append(torch.stack(accepted_target))
+    cats.extend(["large_err"] * n_l)
+
+    # near_singular -- pick (init, target) pairs whose initial slew
+    # direction (the quat-log of the relative attitude) aligns with a
+    # near-null direction of the gimbal Jacobian at the satellite's
+    # nominal posture. We can't prescribe ``qpos[7:]`` (gimbal angles)
+    # via the reset API, so the proxy here is: among many random pairs,
+    # pick the ones where the slew axis is most poorly conditioned for
+    # the *nominal* CMG configuration, i.e. has the lowest projection
+    # onto the column span of the Jacobian at gimbal angles=0. The
+    # bottom-N by that score is the "hardest to slew" family.
+    n_s = counts["near_singular"]
+    pool = max(8 * n_s, 4096)
+    pool_init = _normalize_quat(torch.randn(pool, 4, generator=g))
+    pool_target = _normalize_quat(torch.randn(pool, 4, generator=g))
+    # Initial slew direction: the quaternion log of the relative
+    # attitude error.
+    pool_qerr = quat_mul(quat_conj(pool_init), pool_target)
+    pool_log = quat_log(pool_qerr)  # (pool, 3)
+    # Jacobian at nominal (zero) gimbal angles; shape (3, 4). We
+    # measure how poorly the slew direction aligns with the J column
+    # span by 1 - (||J^T s|| / ||s|| / sigma_max), where s is the slew
+    # direction. A small alignment score => the satellite has to push
+    # mostly through the null space => harder maneuver.
+    g_axes, r0 = pyramid_4cmg_geometry(device="cpu", dtype=torch.float32)
+    jac = cmg_jacobian(torch.zeros(1, 4), g_axes, r0, 100.0).squeeze(0)  # (3, 4)
+    sigma_max = torch.linalg.svdvals(jac).max()
+    s_unit = pool_log / pool_log.norm(dim=-1, keepdim=True).clamp_min(1e-6)
+    alignment = (jac.T @ s_unit.T).norm(dim=0) / sigma_max  # (pool,)
+    worst_idx = torch.topk(-alignment, k=n_s).indices
+    inits.append(pool_init.index_select(0, worst_idx))
+    targets.append(pool_target.index_select(0, worst_idx))
+    cats.extend(["near_singular"] * n_s)
+
+    # precision -- pairs with moderate attitude error so success at the
+    # 0.05 rad threshold is genuinely informative rather than trivial.
+    n_p = counts["precision"]
+    accepted_init = []
+    accepted_target = []
+    LO, HI = math.radians(30.0), math.radians(90.0)
+    while len(accepted_init) < n_p:
+        batch = max(64, n_p * 4)
+        i = _normalize_quat(torch.randn(batch, 4, generator=g))
+        t = _normalize_quat(torch.randn(batch, 4, generator=g))
+        err = _attitude_error_norm(i, t)
+        keep = (err >= LO) & (err <= HI)
+        for j in range(batch):
+            if keep[j]:
+                accepted_init.append(i[j])
+                accepted_target.append(t[j])
+                if len(accepted_init) == n_p:
+                    break
+    inits.append(torch.stack(accepted_init))
+    targets.append(torch.stack(accepted_target))
+    cats.extend(["precision"] * n_p)
+
+    # off_axis -- targets oriented along non-principal axes. We sample
+    # a random axis with all components > 0.4 in absolute value and a
+    # random angle, then build the quaternion (cos a/2, sin a/2 * axis).
+    n_o = counts["off_axis"]
+    accepted_init = []
+    accepted_target = []
+    while len(accepted_init) < n_o:
+        ax = torch.randn(1, 3, generator=g)
+        if (ax.abs() < 0.4).any():
+            continue
+        ax = ax / ax.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+        angle = torch.empty(1).uniform_(
+            math.radians(60.0), math.radians(160.0), generator=g
+        )
+        half = 0.5 * angle
+        target_q = torch.cat(
+            [half.cos().unsqueeze(0), half.sin().unsqueeze(0) * ax], dim=-1
+        ).squeeze(0)
+        init_q = _normalize_quat(torch.randn(1, 4, generator=g)).squeeze(0)
+        accepted_init.append(init_q)
+        accepted_target.append(_normalize_quat(target_q.unsqueeze(0)).squeeze(0))
+    inits.append(torch.stack(accepted_init))
+    targets.append(torch.stack(accepted_target))
+    cats.extend(["off_axis"] * n_o)
+
+    init_t = torch.cat(inits, dim=0).to(device).float()
+    target_t = torch.cat(targets, dim=0).to(device).float()
+    assert init_t.shape == (n, 4) and target_t.shape == (n, 4)
+    return {"init_bus_quat": init_t, "target_quat": target_t, "category": cats}
+
+
+def dump_test_set_csv(test_set: dict[str, Any], path: str | Path) -> None:
+    """Write the test set to a CSV (12 floats + 1 category string per row)."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    init = test_set["init_bus_quat"]
+    target = test_set["target_quat"]
+    cats = test_set["category"]
+    n = init.shape[0]
+    cols = (
+        ["init_w", "init_x", "init_y", "init_z"]
+        + ["target_w", "target_x", "target_y", "target_z"]
+        + ["category"]
+    )
+    with path.open("w") as f:
+        f.write(",".join(cols) + "\n")
+        for k in range(n):
+            row = (
+                [f"{init[k, j].item():.10f}" for j in range(4)]
+                + [f"{target[k, j].item():.10f}" for j in range(4)]
+                + [cats[k]]
+            )
+            f.write(",".join(row) + "\n")
+
+
+def load_test_set_csv(
+    path: str | Path,
+) -> tuple[torch.Tensor, torch.Tensor, list[str]]:
+    """Read the CSV back into ``(init_bus_quat, target_quat, categories)``."""
+    path = Path(path)
+    init_rows: list[list[float]] = []
+    target_rows: list[list[float]] = []
+    cats: list[str] = []
+    with path.open() as f:
+        header = f.readline().strip().split(",")  # noqa: F841 -- documented schema
+        for line in f:
+            parts = line.strip().split(",")
+            init_rows.append([float(x) for x in parts[:4]])
+            target_rows.append([float(x) for x in parts[4:8]])
+            cats.append(parts[8])
+    init = torch.tensor(init_rows, dtype=torch.float32)
+    target = torch.tensor(target_rows, dtype=torch.float32)
+    return init, target, cats
+
+
+# ---------------------------------------------------------------------------
+# Stateless test-set primer
+# ---------------------------------------------------------------------------
+
+
+class TestSetPrimer(TensorDictPrimer):
+    """Inject fixed ``(init_bus_quat, target_quat)`` pairs at every reset.
+
+    Stateless and vectorized: the primer holds the full test set and
+    deterministically slices / tiles it to fill a reset of any size.
+    Designed to pair with the modified :class:`SatelliteEnv` whose
+    :meth:`_reset` reads these keys from the input tensordict.
+
+    With ``num_envs == len(test_set)`` and full resets only (the standard
+    eval flow), each env always receives the same row -- so two
+    consecutive eval rollouts replay the exact same starts.
+    """
+
+    def __init__(
+        self,
+        init_bus_quat: torch.Tensor,
+        target_quat: torch.Tensor,
+        *,
+        device: torch.device | str = "cpu",
+    ) -> None:
+        n = init_bus_quat.shape[0]
+        if target_quat.shape[0] != n:
+            raise ValueError(
+                f"init/target length mismatch: {init_bus_quat.shape[0]} vs "
+                f"{target_quat.shape[0]}"
+            )
+        device = torch.device(device)
+        self._init = init_bus_quat.to(device)
+        self._target = target_quat.to(device)
+        self._n = n
+
+        # Specs declare the keys to the framework. ``random=False`` and
+        # ``default_value=callable`` triggers the per-reset closure
+        # below, which sees the reset mask shape and returns matching
+        # rows.
+        primer_specs = Composite(
+            init_bus_quat=Unbounded(shape=(4,), dtype=torch.float32, device=device),
+            target_quat=Unbounded(shape=(4,), dtype=torch.float32, device=device),
+        )
+        super().__init__(
+            primers=primer_specs,
+            random=False,
+            default_value=self._sample,
+            single_default_value=True,
+            expand_specs=True,
+            call_before_env_reset=True,
+        )
+
+    def _sample(
+        self, reset: torch.Tensor | None = None, **_: Any
+    ) -> dict[str, torch.Tensor]:
+        # ``reset`` is the bool mask, shape ``(B,)`` or ``(B, 1)``;
+        # may be ``None`` when called from a full-batch reset path.
+        # Strategy: generate ``arange(B) % n`` over the *full* batch
+        # then sub-select by the mask. This keeps row k always paired
+        # with env k for the standard ``B == n`` setup, and gracefully
+        # tiles / truncates otherwise.
+        if reset is None:
+            B = self._n
+            sel = torch.arange(B, device=self._init.device) % self._n
+        else:
+            mask = reset
+            if mask.ndim > 1:
+                mask = mask.squeeze(-1)
+            B = mask.shape[0]
+            full = torch.arange(B, device=self._init.device) % self._n
+            sel = full[mask]
+        return {
+            "init_bus_quat": self._init.index_select(0, sel),
+            "target_quat": self._target.index_select(0, sel),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Env factories
+# ---------------------------------------------------------------------------
+
+
+def _attach_obs_norm(
+    env: TransformedEnv,
+    obs_norm_stats: tuple[torch.Tensor, torch.Tensor] | None,
+    device: torch.device,
+) -> ObservationNorm:
+    """Append an :class:`ObservationNorm`, optionally pre-loaded with stats.
+
+    Returns the transform instance so the caller can ``init_stats`` on
+    it later when ``obs_norm_stats is None``.
+    """
+    if obs_norm_stats is not None:
+        loc, scale = obs_norm_stats
+        norm = ObservationNorm(
+            loc=loc.to(device),
+            scale=scale.to(device),
+            in_keys=["observation"],
+            standard_normal=True,
+        )
+    else:
+        # Lazy: stats filled in later via ``init_stats``.
+        norm = ObservationNorm(
+            in_keys=["observation"],
+            standard_normal=True,
+        )
+    env.append_transform(norm)
+    return norm
+
+
+def make_train_env(
+    *,
+    num_envs: int,
+    device: torch.device,
+    max_steps: int = 1500,
+    min_random_horizon: int | None = None,
+    random_horizon_prob: float = 0.0,
+    compile_step: bool = False,
+    obs_norm_stats: tuple[torch.Tensor, torch.Tensor] | None = None,
+    use_obs_norm: bool = True,
+    num_cmgs: int = 4,
+    action_scale: float = 3.0,
+    singularity_weight: float = 0.5,
+    singularity_clamp_min: float = 1e-6,
+    singularity_mode: str = "inverse",
+    singularity_exp_k: float = 5.0,
+    omega_weight: float = 0.1,
+    ctrl_cost_weight: float = 0.01,
+    frame_skip: int | None = None,
+    reward_scale: float = 1.0,
+    seed: int | None = None,
+) -> tuple[TransformedEnv, ObservationNorm | None]:
+    """Vmapped training env. Returns ``(env, observation_norm_transform)``.
+
+    When ``use_obs_norm=False`` the :class:`ObservationNorm` transform
+    is omitted entirely and the second tuple element is ``None``. The
+    raw observation is in physically meaningful units already
+    (``quat_err`` in radians, ``bus_omega`` in rad/s, gimbal sin/cos in
+    [-1, 1], gimbal_rates in rad/s) so a network with reasonable init
+    can train on them directly.
+
+    When ``use_obs_norm=True``, the caller is expected to either:
+
+    * pass ``obs_norm_stats=(loc, scale)`` so eval / training share stats; or
+    * leave ``obs_norm_stats=None``, then call
+      ``observation_norm_transform.init_stats(num_iter=N, ...)`` once.
+    """
+    base = SatelliteEnv(
+        num_cmgs=num_cmgs,
+        num_envs=num_envs,
+        backend="mujoco-torch",
+        device=device,
+        seed=seed,
+        max_episode_steps=max_steps,
+        compile_step=compile_step,
+        compile_kwargs={"dynamic": False} if compile_step else None,
+        action_scale=action_scale,
+        singularity_weight=singularity_weight,
+        singularity_clamp_min=singularity_clamp_min,
+        singularity_mode=singularity_mode,
+        singularity_exp_k=singularity_exp_k,
+        omega_weight=omega_weight,
+        ctrl_cost_weight=ctrl_cost_weight,
+        frame_skip=frame_skip,
+    )
+    env = TransformedEnv(base)
+    # 1) Pack the dynamics-relevant sub-keys into a single ``observation``
+    #    tensor. Keep ``manipulability`` outside (logging-only).
+    env.append_transform(
+        CatTensors(
+            in_keys=POLICY_OBS_KEYS,
+            out_key="observation",
+            dim=-1,
+            del_keys=False,
+            sort=False,
+        )
+    )
+    # 2) Per-dim normalization, shared across PPO / SAC / eval. Skipped
+    #    when ``use_obs_norm=False`` -- the network sees raw observations.
+    obs_norm: ObservationNorm | None = None
+    if use_obs_norm:
+        obs_norm = _attach_obs_norm(env, obs_norm_stats, device)
+    # 3) Episodic step counter (logging) + episode-return aggregator
+    #    (consumed by the Evaluator).
+    env.append_transform(StepCounter(max_steps=max_steps))
+    if min_random_horizon is not None:
+        env.append_transform(
+            RandomTruncationTransform(
+                min_horizon=min_random_horizon,
+                max_horizon=max_steps,
+                prob=random_horizon_prob,
+            )
+        )
+    if reward_scale != 1.0:
+        # ``reward = reward * scale + 0`` -- scale rewards before
+        # downstream consumers (RewardSum, replay buffer, loss). With
+        # raw reward in [-3.5, 0] and scale=1/3 the post-scale range
+        # is [-1.17, 0], much friendlier for Q-target regression.
+        env.append_transform(
+            RewardScaling(loc=0.0, scale=reward_scale, in_keys=["reward"])
+        )
+    env.append_transform(RewardSum())
+    return env, obs_norm
+
+
+def make_eval_env(
+    *,
+    device: torch.device,
+    test_set_csv: str | Path = DEFAULT_TEST_SET_PATH,
+    test_set_size: int = 256,
+    test_set_seed: int = 42,
+    max_steps: int = 1500,
+    obs_norm_stats: tuple[torch.Tensor, torch.Tensor] | None,
+    use_obs_norm: bool = True,
+    num_cmgs: int = 4,
+    action_scale: float = 3.0,
+    singularity_weight: float = 0.5,
+    singularity_clamp_min: float = 1e-6,
+    singularity_mode: str = "inverse",
+    singularity_exp_k: float = 5.0,
+    omega_weight: float = 0.1,
+    ctrl_cost_weight: float = 0.01,
+    frame_skip: int | None = None,
+    compile_step: bool = False,
+    reward_scale: float = 1.0,
+    seed: int = 0,
+) -> TransformedEnv:
+    """Eval env: ``num_envs == len(test_set)`` so one rollout = full eval.
+
+    The :class:`TestSetPrimer` injects matching ``init_bus_quat`` /
+    ``target_quat`` rows on every reset so the eval is byte-stable across
+    iterations. The ``action_scale`` / ``singularity_weight`` /
+    ``use_obs_norm`` settings must match the training env so eval
+    rewards are directly comparable. If the default CSV was not
+    materialized, the same deterministic test set is generated in memory.
+    """
+    test_set_csv = Path(test_set_csv)
+    if test_set_csv.exists():
+        init_q, target_q, _cats = load_test_set_csv(test_set_csv)
+    elif test_set_csv == DEFAULT_TEST_SET_PATH:
+        test_set = generate_test_set(
+            n=test_set_size, seed=test_set_seed, num_cmgs=num_cmgs
+        )
+        init_q = test_set["init_bus_quat"]
+        target_q = test_set["target_quat"]
+    else:
+        raise FileNotFoundError(f"Could not find eval test-set CSV: {test_set_csv}")
+    n = init_q.shape[0]
+    base = SatelliteEnv(
+        num_cmgs=num_cmgs,
+        num_envs=n,
+        backend="mujoco-torch",
+        device=device,
+        seed=seed,
+        max_episode_steps=max_steps,
+        action_scale=action_scale,
+        singularity_weight=singularity_weight,
+        singularity_clamp_min=singularity_clamp_min,
+        singularity_mode=singularity_mode,
+        singularity_exp_k=singularity_exp_k,
+        omega_weight=omega_weight,
+        ctrl_cost_weight=ctrl_cost_weight,
+        frame_skip=frame_skip,
+        compile_step=compile_step,
+        compile_kwargs={"dynamic": False} if compile_step else None,
+    )
+    env = TransformedEnv(base)
+    env.append_transform(TestSetPrimer(init_q, target_q, device=device))
+    env.append_transform(
+        CatTensors(
+            in_keys=POLICY_OBS_KEYS,
+            out_key="observation",
+            dim=-1,
+            del_keys=False,
+            sort=False,
+        )
+    )
+    if use_obs_norm:
+        if obs_norm_stats is None:
+            raise ValueError(
+                "make_eval_env(use_obs_norm=True) requires obs_norm_stats "
+                "so the eval env shares normalization with training. "
+                "Either compute stats once and save them, or load from "
+                "disk -- or pass use_obs_norm=False to skip the transform."
+            )
+        _attach_obs_norm(env, obs_norm_stats, device)
+    env.append_transform(StepCounter(max_steps=max_steps))
+    if reward_scale != 1.0:
+        env.append_transform(
+            RewardScaling(loc=0.0, scale=reward_scale, in_keys=["reward"])
+        )
+    env.append_transform(RewardSum())
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Networks
+# ---------------------------------------------------------------------------
+
+
+def _obs_dim(obs_spec: TensorSpec) -> int:
+    """Resolve the policy-input dimension from the (possibly composite) spec."""
+    if isinstance(obs_spec, Composite):
+        return obs_spec["observation"].shape[-1]
+    return obs_spec.shape[-1]
+
+
+_ACTIVATIONS: dict[str, type[nn.Module]] = {
+    "relu": nn.ReLU,
+    "tanh": nn.Tanh,
+    "elu": nn.ELU,
+    "gelu": nn.GELU,
+    "silu": nn.SiLU,
+}
+
+
+def _activation_class(name: str | type[nn.Module]) -> type[nn.Module]:
+    if isinstance(name, str):
+        try:
+            return _ACTIVATIONS[name.lower()]
+        except KeyError as e:
+            raise ValueError(
+                f"Unknown activation {name!r}; valid: {sorted(_ACTIVATIONS)}."
+            ) from e
+    return name
+
+
+def _small_gain_last_linear(module: nn.Module, gain: float = 0.01) -> None:
+    """Re-init the *last* :class:`nn.Linear` in ``module`` with
+    orthogonal weights at ``gain`` and zero bias.
+
+    Standard policy-gradient init from Mnih et al. and the PPO paper:
+    keeps the output near zero so the policy starts as a near-uniform
+    sample (loc = 0, scale = whatever the param extractor emits) and
+    avoids the "confidently wrong" behaviour from default Kaiming init
+    on a 256-wide last layer.
+    """
+    last_linear = None
+    for sub in module.modules():
+        if isinstance(sub, nn.Linear):
+            last_linear = sub
+    if last_linear is None:
+        raise RuntimeError("No nn.Linear found inside module to re-init.")
+    nn.init.orthogonal_(last_linear.weight, gain=gain)
+    if last_linear.bias is not None:
+        nn.init.zeros_(last_linear.bias)
+
+
+def make_actor(
+    *,
+    obs_spec: TensorSpec,
+    action_spec: TensorSpec,
+    device: torch.device,
+    hidden: tuple[int, ...] = (256, 256),
+    activation: str | type[nn.Module] = "relu",
+    state_independent_scale: bool = False,
+    layer_norm: bool = False,
+    small_init_last_layer: bool = False,
+    scale_init: float = 1.0,
+) -> ProbabilisticActor:
+    """TanhNormal actor.
+
+    ``state_independent_scale=True`` matches the canonical PPO setup
+    (scale is a learned bias). ``False`` matches SAC (head outputs both
+    loc and scale). ``activation`` is the hidden-layer non-linearity;
+    string aliases (``"relu"``, ``"tanh"``, ``"elu"``, ``"gelu"``,
+    ``"silu"``) or a class are accepted.
+    """
+    in_dim = _obs_dim(obs_spec)
+    action_dim = action_spec.shape[-1]
+    act_cls = _activation_class(activation)
+    norm_kwargs = (
+        {
+            "norm_class": nn.LayerNorm,
+            "norm_kwargs": [{"normalized_shape": h} for h in hidden],
+        }
+        if layer_norm
+        else {}
+    )
+
+    if state_independent_scale:
+        body = MLP(
+            in_features=in_dim,
+            num_cells=list(hidden),
+            out_features=action_dim,
+            activation_class=act_cls,
+            device=device,
+            **norm_kwargs,
+        )
+        mlp = nn.Sequential(
+            body,
+            AddStateIndependentNormalScale(action_dim, scale_lb=1e-4).to(device),
+        )
+    else:
+        body = MLP(
+            in_features=in_dim,
+            num_cells=list(hidden),
+            out_features=2 * action_dim,
+            activation_class=act_cls,
+            device=device,
+            **norm_kwargs,
+        )
+        mlp = nn.Sequential(
+            body,
+            NormalParamExtractor(
+                scale_mapping=f"biased_softplus_{scale_init:.4f}",
+                scale_lb=1e-4,
+            ).to(device),
+        )
+
+    if small_init_last_layer:
+        _small_gain_last_linear(body, gain=0.01)
+
+    td_module = TensorDictModule(
+        mlp, in_keys=["observation"], out_keys=["loc", "scale"]
+    )
+    # Pass shape-``[action_dim]`` bounds (not batched per env): vmapped
+    # specs make ``space.low/high`` shape ``[num_envs, action_dim]``, which
+    # breaks broadcasting inside ``TanhNormal.update`` under ``torch.compile``
+    # (the loc batch dim differs from num_envs after replay sampling).
+    low_b = action_spec.space.low
+    high_b = action_spec.space.high
+    while low_b.ndim > 1:
+        low_b = low_b[0]
+    while high_b.ndim > 1:
+        high_b = high_b[0]
+    actor = ProbabilisticActor(
+        module=td_module,
+        in_keys=["loc", "scale"],
+        spec=action_spec,
+        distribution_class=TanhNormal,
+        distribution_kwargs={
+            "low": low_b,
+            "high": high_b,
+            "tanh_loc": True,
+        },
+        return_log_prob=True,
+    )
+    return actor
+
+
+def make_value_critic(
+    *,
+    obs_spec: TensorSpec,
+    device: torch.device,
+    hidden: tuple[int, ...] = (256, 256),
+    activation: str | type[nn.Module] = "tanh",
+) -> ValueOperator:
+    in_dim = _obs_dim(obs_spec)
+    net = MLP(
+        in_features=in_dim,
+        num_cells=list(hidden),
+        out_features=1,
+        activation_class=_activation_class(activation),
+        device=device,
+    )
+    return ValueOperator(net, in_keys=["observation"])
+
+
+def make_qvalue_critic(
+    *,
+    obs_spec: TensorSpec,
+    action_spec: TensorSpec,
+    device: torch.device,
+    hidden: tuple[int, ...] = (256, 256),
+    activation: str | type[nn.Module] = "relu",
+    layer_norm: bool = False,
+    small_init_last_layer: bool = False,
+) -> ValueOperator:
+    in_dim = _obs_dim(obs_spec) + action_spec.shape[-1]
+    norm_kwargs = (
+        {
+            "norm_class": nn.LayerNorm,
+            "norm_kwargs": [{"normalized_shape": h} for h in hidden],
+        }
+        if layer_norm
+        else {}
+    )
+    net = MLP(
+        in_features=in_dim,
+        num_cells=list(hidden),
+        out_features=1,
+        activation_class=_activation_class(activation),
+        device=device,
+        **norm_kwargs,
+    )
+    if small_init_last_layer:
+        _small_gain_last_linear(net, gain=0.01)
+    return ValueOperator(net, in_keys=["observation", "action"])
+
+
+# ---------------------------------------------------------------------------
+# Eval metrics
+# ---------------------------------------------------------------------------
+
+
+def make_eval_metrics_fn(
+    categories: list[str],
+) -> Callable[[TensorDictBase], dict[str, float]]:
+    """Return a metrics function that breaks down by ``categories``.
+
+    ``categories`` must be the per-row category list from the same CSV
+    the eval primer uses, in the same order. The eval env is built with
+    ``num_envs == len(categories)`` so positions line up.
+    """
+    cat_tensor_idx: dict[str, list[int]] = {}
+    for i, c in enumerate(categories):
+        cat_tensor_idx.setdefault(c, []).append(i)
+
+    def _flatten(td: TensorDictBase, key: NestedKey) -> torch.Tensor:
+        # Eval rollouts come back with shape ``(B, T, ...)``; reduce over T.
+        return td.get(key)
+
+    def fn(td: TensorDictBase) -> dict[str, float]:
+        # Episode return: collected by ``RewardSum`` under ``("next",
+        # "episode_reward")``. We take the *last* value per env.
+        ep_ret = _flatten(td, ("next", "episode_reward"))[..., -1, :]
+        # Final attitude error (radians) at the end of the rollout.
+        quat_err = _flatten(td, ("next", "quat_err"))  # (B, T, 3)
+        final_err = quat_err[..., -1, :].norm(dim=-1)
+        # Manipulability per step: shape (B, T, 1).
+        manip = _flatten(td, ("next", "manipulability")).squeeze(-1)
+        min_manip = manip.min(dim=-1).values
+        mean_manip = manip.mean(dim=-1)
+        sum_inv_manip = (1.0 / manip.clamp_min(1e-6)).sum(dim=-1)
+
+        out: dict[str, float] = {
+            "eval/return": ep_ret.mean().item(),
+            "eval/final_attitude_error_rad": final_err.mean().item(),
+            "eval/success_rate@0.10": (final_err <= 0.10).float().mean().item(),
+            "eval/success_rate@0.05": (final_err <= 0.05).float().mean().item(),
+            "eval/min_manipulability": min_manip.mean().item(),
+            "eval/mean_manipulability": mean_manip.mean().item(),
+            "eval/sum_inv_manipulability": sum_inv_manip.mean().item(),
+        }
+        for cat, idx_list in cat_tensor_idx.items():
+            if not idx_list:
+                continue
+            idx = torch.tensor(idx_list, device=ep_ret.device)
+            out[f"eval/{cat}/return"] = ep_ret.index_select(0, idx).mean().item()
+            out[f"eval/{cat}/final_err"] = final_err.index_select(0, idx).mean().item()
+            out[f"eval/{cat}/success@0.10"] = (
+                (final_err.index_select(0, idx) <= 0.10).float().mean().item()
+            )
+            out[f"eval/{cat}/min_manipulability"] = (
+                min_manip.index_select(0, idx).mean().item()
+            )
+        return out
+
+    return fn
+
+
+# ---------------------------------------------------------------------------
+# WandB key bootstrap
+# ---------------------------------------------------------------------------
+
+
+def setup_wandb_key() -> None:
+    """No-op stub kept for backwards compatibility.
+
+    Configure WandB outside this module, for example by exporting
+    ``WANDB_API_KEY`` or running ``wandb login``, before enabling
+    WandB logging in the example scripts.
+    """
+
+
+# ---------------------------------------------------------------------------
+# CLI: dump the test set CSV
+# ---------------------------------------------------------------------------
+
+
+def _cli_generate_test_set(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(prog="examples.satellite._utils generate-test-set")
+    p.add_argument("--out", default=str(DEFAULT_TEST_SET_PATH))
+    p.add_argument("--n", type=int, default=256)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--num-cmgs", type=int, default=4)
+    args = p.parse_args(argv)
+    test_set = generate_test_set(n=args.n, seed=args.seed, num_cmgs=args.num_cmgs)
+    dump_test_set_csv(test_set, args.out)
+    cats = test_set["category"]
+    counts = {c: cats.count(c) for c in CATEGORIES}
+    print(f"Wrote {args.n} rows to {args.out}")
+    print("Per-category counts:", counts)
+    err = _attitude_error_norm(test_set["init_bus_quat"], test_set["target_quat"])
+    print(f"Mean attitude error (rad): {err.mean().item():.3f}")
+    print(f"Max  attitude error (rad): {err.max().item():.3f}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv:
+        print(
+            "usage: python -m examples.satellite._utils generate-test-set [...]",
+            file=sys.stderr,
+        )
+        return 2
+    cmd, rest = argv[0], argv[1:]
+    if cmd == "generate-test-set":
+        return _cli_generate_test_set(rest)
+    print(f"unknown command: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/satellite/sac_per.py
+++ b/examples/satellite/sac_per.py
@@ -1,0 +1,1036 @@
+"""SAC + Prioritized Replay Buffer training for the satellite task.
+
+Same env / eval / logging conventions as ``examples/satellite/ppo.py`` so the
+two are directly comparable on the CSV-backed test set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from functools import partial
+from pathlib import Path
+
+import torch
+
+from torchrl._utils import logger as torchrl_logger
+from torchrl.collectors import Collector, Evaluator, MultiCollector
+from torchrl.data import (
+    LazyTensorStorage,
+    TensorDictPrioritizedReplayBuffer,
+    TensorDictReplayBuffer,
+)
+from torchrl.data.postprocs import MultiStep
+from torchrl.envs.utils import ExplorationType
+from torchrl.objectives import SACLoss, SoftUpdate
+from torchrl.record.loggers import generate_exp_name, get_logger
+from torchrl.weight_update import MultiProcessWeightSyncScheme
+
+PACKAGE_DIR = Path(__file__).resolve().parent
+if str(PACKAGE_DIR.parent.parent) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_DIR.parent.parent))
+
+from examples.satellite._utils import (  # noqa: E402
+    DEFAULT_OBS_NORM_PATH,
+    DEFAULT_TEST_SET_PATH,
+    load_test_set_csv,
+    make_actor,
+    make_eval_env,
+    make_eval_metrics_fn,
+    make_qvalue_critic,
+    make_train_env,
+    pick_device,
+    setup_wandb_key,
+)
+
+
+# Module-level eval-process factories. The ``backend="process"``
+# Evaluator pickles these and re-constructs the env + policy inside a
+# child process, so they must be importable top-level callables (not
+# closures over local state).
+
+
+def _train_env_factory(
+    *,
+    num_envs: int,
+    device_str: str,
+    max_steps: int,
+    min_random_horizon: int | None,
+    random_horizon_prob: float,
+    compile_step: bool,
+    obs_norm_stats: tuple[torch.Tensor, torch.Tensor] | None,
+    use_obs_norm: bool,
+    num_cmgs: int,
+    action_scale: float,
+    singularity_weight: float,
+    singularity_clamp_min: float,
+    singularity_mode: str,
+    singularity_exp_k: float,
+    omega_weight: float,
+    ctrl_cost_weight: float,
+    frame_skip: int,
+    reward_scale: float = 1.0,
+    seed: int | None = None,
+):
+    """Picklable training-env factory for ``aSyncDataCollector``."""
+    env, _ = make_train_env(
+        num_envs=num_envs,
+        device=torch.device(device_str),
+        max_steps=max_steps,
+        min_random_horizon=min_random_horizon,
+        random_horizon_prob=random_horizon_prob,
+        compile_step=compile_step,
+        obs_norm_stats=obs_norm_stats,
+        use_obs_norm=use_obs_norm,
+        num_cmgs=num_cmgs,
+        action_scale=action_scale,
+        singularity_weight=singularity_weight,
+        singularity_clamp_min=singularity_clamp_min,
+        singularity_mode=singularity_mode,
+        singularity_exp_k=singularity_exp_k,
+        omega_weight=omega_weight,
+        ctrl_cost_weight=ctrl_cost_weight,
+        frame_skip=frame_skip,
+        reward_scale=reward_scale,
+        seed=seed,
+    )
+    return env
+
+
+def _eval_env_factory(
+    *,
+    device_str: str,
+    test_set_csv: str,
+    max_steps: int,
+    obs_norm_stats: tuple[torch.Tensor, torch.Tensor] | None,
+    use_obs_norm: bool,
+    num_cmgs: int,
+    action_scale: float,
+    singularity_weight: float,
+    singularity_clamp_min: float,
+    singularity_mode: str,
+    singularity_exp_k: float,
+    omega_weight: float,
+    ctrl_cost_weight: float,
+    frame_skip: int,
+    compile_step: bool,
+    reward_scale: float = 1.0,
+):
+    return make_eval_env(
+        device=torch.device(device_str),
+        test_set_csv=test_set_csv,
+        max_steps=max_steps,
+        obs_norm_stats=obs_norm_stats,
+        use_obs_norm=use_obs_norm,
+        num_cmgs=num_cmgs,
+        action_scale=action_scale,
+        singularity_weight=singularity_weight,
+        singularity_clamp_min=singularity_clamp_min,
+        singularity_mode=singularity_mode,
+        singularity_exp_k=singularity_exp_k,
+        omega_weight=omega_weight,
+        ctrl_cost_weight=ctrl_cost_weight,
+        frame_skip=frame_skip,
+        compile_step=compile_step,
+        reward_scale=reward_scale,
+    )
+
+
+def _eval_policy_factory(
+    env=None,
+    *,
+    obs_spec=None,
+    action_spec=None,
+    hidden: tuple[int, ...],
+    activation: str,
+    device_str: str,
+):
+    """Build an actor identical to the trainer's.
+
+    The ``MultiProcessWeightSyncScheme`` calls this factory **without**
+    args on the sender side (just to enumerate parameter shapes), and
+    again **with** an env on the receiver side. We accept either by
+    falling back to specs passed via :func:`functools.partial`.
+    """
+    if env is not None:
+        obs_spec = env.observation_spec
+        action_spec = env.action_spec
+    if obs_spec is None or action_spec is None:
+        raise RuntimeError(
+            "_eval_policy_factory needs either env or pre-bound "
+            "(obs_spec, action_spec) via partial."
+        )
+    return make_actor(
+        obs_spec=obs_spec,
+        action_spec=action_spec,
+        device=torch.device(device_str),
+        hidden=hidden,
+        activation=activation,
+        state_independent_scale=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--num-envs", type=int, default=32_768)
+    p.add_argument("--num-cmgs", type=int, default=4)
+    p.add_argument("--max-steps", type=int, default=300)
+    p.add_argument(
+        "--frame-skip",
+        type=int,
+        default=50,
+        help=(
+            "Number of physics sub-steps per agent step. dt=0.001s, so "
+            "frame_skip=50 means each step is 50ms of sim time. Larger "
+            "frame skip = bigger per-step dynamics = stronger Q-action "
+            "signal."
+        ),
+    )
+    p.add_argument(
+        "--min-random-horizon",
+        type=int,
+        default=None,
+        help=(
+            "If set, decorrelate vectorized env phases by sampling train "
+            "episode truncation horizons in [min_random_horizon, max_steps]."
+        ),
+    )
+    p.add_argument(
+        "--random-horizon-prob",
+        type=float,
+        default=0.0,
+        help="Probability of resampling a shortened horizon after first reset.",
+    )
+    p.add_argument(
+        "--frames-per-env",
+        type=int,
+        default=8,
+        help=(
+            "Env-steps per collection iteration. Higher = fewer "
+            "Python collector cycles per env transition; lower = more "
+            "frequent grad-step updates with fresher data."
+        ),
+    )
+    p.add_argument("--total-iters", type=int, default=3000)
+    # Replay buffer
+    p.add_argument("--buffer-size", type=int, default=1_000_000)
+    p.add_argument("--batch-size", type=int, default=8_192)
+    p.add_argument("--prb-alpha", type=float, default=0.7)
+    p.add_argument("--prb-beta", type=float, default=0.5)
+    p.add_argument(
+        "--no-prb",
+        action="store_true",
+        help=(
+            "Use a uniform replay buffer instead of prioritized. "
+            "Disables priority updates (no td_error key required)."
+        ),
+    )
+    p.add_argument(
+        "--lr-decay-end-frac",
+        type=float,
+        default=None,
+        help=(
+            "If set (e.g. 0.1), cosine-anneal actor/critic/alpha LR "
+            "from --lr to lr*frac over the full --total-iters span."
+        ),
+    )
+    p.add_argument("--gradient-steps", type=int, default=8)
+    p.add_argument(
+        "--init-random-frames-per-env",
+        type=int,
+        default=4,
+        help="Random-action warm-up steps per env before SAC updates start.",
+    )
+    # Optim / SAC
+    p.add_argument("--lr", type=float, default=3e-4)
+    p.add_argument(
+        "--critic-lr",
+        type=float,
+        default=None,
+        help="Optional critic learning-rate override. Defaults to --lr.",
+    )
+    p.add_argument("--gamma", type=float, default=0.99)
+    p.add_argument("--alpha-init", type=float, default=1.0)
+    p.add_argument(
+        "--fixed-alpha",
+        action="store_true",
+        help="Keep SAC temperature fixed at --alpha-init.",
+    )
+    p.add_argument("--min-alpha", type=float, default=None)
+    p.add_argument("--max-alpha", type=float, default=None)
+    p.add_argument("--target-update-polyak", type=float, default=0.995)
+    p.add_argument("--max-grad-norm", type=float, default=0.0)
+    p.add_argument(
+        "--action-scale",
+        type=float,
+        default=3.0,
+        help="Scaling from agent action [-1, 1] to commanded gimbal rate (rad/s).",
+    )
+    p.add_argument(
+        "--singularity-weight",
+        type=float,
+        default=0.5,
+        help="Weight on -1/manip_norm in the reward (rotor-speed-invariant).",
+    )
+    p.add_argument(
+        "--singularity-clamp-min",
+        type=float,
+        default=1e-6,
+        help=(
+            "Floor on manip_norm before division (only used when "
+            "--singularity-mode=inverse). Higher values bound the worst-case "
+            "spike: max penalty = singularity_weight / singularity_clamp_min."
+        ),
+    )
+    p.add_argument(
+        "--singularity-mode",
+        type=str,
+        default="inverse",
+        choices=["inverse", "exp"],
+        help=(
+            "Singularity penalty form. 'inverse' (default): -w/manip_norm "
+            "(unbounded near singularity, controllable via --singularity-clamp-min). "
+            "'exp': -w*exp(-k*manip_norm), bounded at -w."
+        ),
+    )
+    p.add_argument(
+        "--singularity-exp-k",
+        type=float,
+        default=5.0,
+        help="Curvature for --singularity-mode=exp. Larger = steeper falloff.",
+    )
+    p.add_argument(
+        "--omega-weight",
+        type=float,
+        default=0.1,
+        help="Weight on -||bus_omega||^2 in the reward (slew-and-stop incentive).",
+    )
+    p.add_argument(
+        "--ctrl-cost-weight",
+        type=float,
+        default=0.01,
+        help="Weight on -||action||^2. Set to 0 to remove the control penalty.",
+    )
+    p.add_argument(
+        "--reward-scale",
+        type=float,
+        default=1.0,
+        help=(
+            "Multiplicative scaling on the per-step reward (applied as "
+            "a transform). Brings raw reward in [-3.5, 0] into a Q-friendly "
+            "range. 1.0=no change; 0.333 maps to roughly [-1, 0]."
+        ),
+    )
+    p.add_argument(
+        "--hidden",
+        type=int,
+        nargs="+",
+        default=[256, 256],
+        help="Hidden-layer sizes for both actor and critic MLPs.",
+    )
+    p.add_argument(
+        "--activation",
+        type=str,
+        default="relu",
+        choices=["relu", "tanh", "elu", "gelu", "silu"],
+        help="Activation for both actor and critic hidden layers.",
+    )
+    p.add_argument(
+        "--layer-norm",
+        action="store_true",
+        help="Add LayerNorm in actor + critic MLP hidden layers.",
+    )
+    p.add_argument(
+        "--small-init-last-layer",
+        action="store_true",
+        help=(
+            "Orthogonal-init the last Linear of the actor and critic "
+            "MLPs with gain=0.01 (zero bias). Initial actor mean is 0, "
+            "initial Q is ~0 -- avoids 'confidently wrong' default init."
+        ),
+    )
+    p.add_argument(
+        "--scale-init",
+        type=float,
+        default=1.0,
+        help=(
+            "Initial value of the actor's TanhNormal scale at "
+            "zero-input (via biased_softplus). 1.0 saturates samples "
+            "near +/-1 (heavy exploration); 0.31 gives moderate "
+            "samples in [-0.3, 0.3]; 0.5 is a middle ground."
+        ),
+    )
+    p.add_argument(
+        "--n-step",
+        type=int,
+        default=1,
+        help=(
+            "n in n-step returns. >1 wraps the collector with a "
+            "MultiStep postproc (gamma already taken from --gamma) so "
+            "Q learns from n-step rewards."
+        ),
+    )
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--device", default=None)
+    p.add_argument(
+        "--eval-device",
+        default=None,
+        help=(
+            "Device for the eval-process env+policy. Defaults to --device. "
+            "Use a separate CUDA index (e.g. cuda:1) to run eval on a "
+            "different GPU than training."
+        ),
+    )
+    p.add_argument(
+        "--buffer-device",
+        default=None,
+        help=(
+            "Device for the replay buffer storage. Defaults to --device. "
+            "Use 'cpu' on environments where TorchRL was not built with "
+            "CUDA support (no CUDA PRB extension)."
+        ),
+    )
+    p.add_argument("--compile-env", action="store_true")
+    p.add_argument(
+        "--compile-eval-env",
+        action="store_true",
+        help="Pass compile_step=True to the eval env (separate from --compile-env).",
+    )
+    p.add_argument(
+        "--compile-policy",
+        action="store_true",
+        help="torch.compile the policy forward pass during collection.",
+    )
+    p.add_argument(
+        "--compile-loss",
+        action="store_true",
+        help=(
+            "torch.compile(loss_module) so the SAC objective is JIT-traced "
+            "and runs as a fused graph each gradient step."
+        ),
+    )
+    p.add_argument(
+        "--async-collector",
+        action="store_true",
+        help=(
+            "Use aSyncDataCollector (collection runs in a separate process "
+            "and overlaps with gradient updates). Requires that the env "
+            "constructor be picklable; weights are synced once per outer "
+            "iter via MultiProcessWeightSyncScheme."
+        ),
+    )
+    p.add_argument("--no-wandb", action="store_true")
+    p.add_argument("--wandb-project", default="torchrl-sat")
+    p.add_argument("--wandb-group", default="sac-per")
+    p.add_argument(
+        "--wandb-mode",
+        default="online",
+        choices=["online", "offline", "disabled"],
+        help=(
+            "wandb run mode. Use 'offline' when wandb.init() "
+            "handshake keeps timing out; sync later with "
+            "'wandb sync torchrl-sat/wandb/offline-run-*'."
+        ),
+    )
+    p.add_argument("--test-set-csv", default=str(DEFAULT_TEST_SET_PATH))
+    p.add_argument("--obs-norm-path", default=str(DEFAULT_OBS_NORM_PATH))
+    p.add_argument(
+        "--no-obs-norm",
+        action="store_true",
+        help=(
+            "Skip the ObservationNorm transform; the policy sees raw "
+            "observations (already in physical units after the env's "
+            "sin/cos gimbal encoding)."
+        ),
+    )
+    p.add_argument("--eval-every", type=int, default=10)
+    p.add_argument(
+        "--no-eval",
+        action="store_true",
+        help="Skip the periodic eval rollout entirely (focus on train metrics only).",
+    )
+    p.add_argument("--obs-norm-warmup", type=int, default=1024)
+    return p.parse_args(argv)
+
+
+def _ensure_obs_norm_stats(
+    *,
+    num_envs: int,
+    device: torch.device,
+    max_steps: int,
+    num_cmgs: int,
+    action_scale: float,
+    singularity_weight: float,
+    omega_weight: float,
+    ctrl_cost_weight: float,
+    frame_skip: int,
+    seed: int,
+    path: Path,
+    warmup: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if path.exists():
+        torchrl_logger.info(f"Loading ObservationNorm stats from {path}")
+        d = torch.load(path, map_location="cpu", weights_only=True)
+        loc, scale = d["loc"], d["scale"]
+        expected_dim = 6 + 3 * num_cmgs
+        if loc.shape[-1] == expected_dim and scale.shape[-1] == expected_dim:
+            return loc, scale
+        torchrl_logger.warning(
+            f"Ignoring stale ObservationNorm stats at {path}: expected "
+            f"last dim {expected_dim}, got loc={tuple(loc.shape)} "
+            f"scale={tuple(scale.shape)}."
+        )
+    torchrl_logger.info(
+        f"No ObservationNorm stats at {path}; running {warmup} warm-up steps."
+    )
+    env, obs_norm = make_train_env(
+        num_envs=min(num_envs, 1024),
+        device=device,
+        max_steps=max_steps,
+        min_random_horizon=None,
+        compile_step=False,
+        obs_norm_stats=None,
+        num_cmgs=num_cmgs,
+        action_scale=action_scale,
+        singularity_weight=singularity_weight,
+        omega_weight=omega_weight,
+        ctrl_cost_weight=ctrl_cost_weight,
+        frame_skip=frame_skip,
+        seed=seed,
+    )
+    obs_norm.init_stats(
+        num_iter=warmup, reduce_dim=(0, 1), cat_dim=1, key="observation"
+    )
+    loc = obs_norm.loc.detach().cpu()
+    scale = obs_norm.scale.detach().cpu()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save({"loc": loc, "scale": scale}, path)
+    torchrl_logger.info(f"Wrote ObservationNorm stats to {path}")
+    env.close()
+    return loc, scale
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    cfg = parse_args(argv)
+    device = pick_device(cfg.device)
+    eval_device = (
+        torch.device(cfg.eval_device) if cfg.eval_device is not None else device
+    )
+    torchrl_logger.info(
+        f"Device: {device} | eval_device: {eval_device} | "
+        f"num_envs={cfg.num_envs} | frames_per_env={cfg.frames_per_env} | "
+        f"total_iters={cfg.total_iters}"
+    )
+
+    if not cfg.no_wandb:
+        setup_wandb_key()
+
+    obs_norm_stats: tuple[torch.Tensor, torch.Tensor] | None
+    if cfg.no_obs_norm:
+        torchrl_logger.info("ObservationNorm disabled (--no-obs-norm).")
+        obs_norm_stats = None
+    else:
+        loc, scale = _ensure_obs_norm_stats(
+            num_envs=cfg.num_envs,
+            device=device,
+            max_steps=cfg.max_steps,
+            num_cmgs=cfg.num_cmgs,
+            action_scale=cfg.action_scale,
+            singularity_weight=cfg.singularity_weight,
+            omega_weight=cfg.omega_weight,
+            ctrl_cost_weight=cfg.ctrl_cost_weight,
+            frame_skip=cfg.frame_skip,
+            seed=cfg.seed,
+            path=Path(cfg.obs_norm_path),
+            warmup=cfg.obs_norm_warmup,
+        )
+        obs_norm_stats = (loc, scale)
+
+    train_env, _ = make_train_env(
+        num_envs=cfg.num_envs,
+        device=device,
+        max_steps=cfg.max_steps,
+        min_random_horizon=cfg.min_random_horizon,
+        random_horizon_prob=cfg.random_horizon_prob,
+        compile_step=cfg.compile_env,
+        obs_norm_stats=obs_norm_stats,
+        use_obs_norm=not cfg.no_obs_norm,
+        num_cmgs=cfg.num_cmgs,
+        action_scale=cfg.action_scale,
+        singularity_weight=cfg.singularity_weight,
+        singularity_clamp_min=cfg.singularity_clamp_min,
+        singularity_mode=cfg.singularity_mode,
+        singularity_exp_k=cfg.singularity_exp_k,
+        omega_weight=cfg.omega_weight,
+        ctrl_cost_weight=cfg.ctrl_cost_weight,
+        frame_skip=cfg.frame_skip,
+        reward_scale=cfg.reward_scale,
+        seed=cfg.seed,
+    )
+    obs_spec = train_env.observation_spec
+    action_spec = train_env.action_spec
+
+    hidden = tuple(cfg.hidden)
+    actor = make_actor(
+        obs_spec=obs_spec,
+        action_spec=action_spec,
+        device=device,
+        hidden=hidden,
+        activation=cfg.activation,
+        state_independent_scale=False,
+        layer_norm=cfg.layer_norm,
+        small_init_last_layer=cfg.small_init_last_layer,
+        scale_init=cfg.scale_init,
+    )
+    qvalue = make_qvalue_critic(
+        obs_spec=obs_spec,
+        action_spec=action_spec,
+        device=device,
+        hidden=hidden,
+        activation=cfg.activation,
+        layer_norm=cfg.layer_norm,
+        small_init_last_layer=cfg.small_init_last_layer,
+    )
+
+    with torch.no_grad():
+        td0 = train_env.reset()
+        actor(td0)
+        qvalue(actor(td0))
+
+    # ----- Loss + target net -----
+    loss_module = SACLoss(
+        actor_network=actor,
+        qvalue_network=qvalue,
+        num_qvalue_nets=2,
+        loss_function="l2",
+        alpha_init=cfg.alpha_init,
+        min_alpha=cfg.min_alpha,
+        max_alpha=cfg.max_alpha,
+        fixed_alpha=cfg.fixed_alpha,
+        delay_actor=False,
+        delay_qvalue=True,
+        delay_value=True,
+        target_entropy="auto",
+        action_spec=action_spec,
+    )
+    loss_module.make_value_estimator(gamma=cfg.gamma)
+    target_updater = SoftUpdate(loss_module, eps=cfg.target_update_polyak)
+
+    # Optional torch.compile of the loss objective. The SACLoss forward
+    # is a fixed graph over a single sample TD; compiling it fuses
+    # actor + twin-Q + alpha computation per gradient step. The
+    # uncompiled module is kept around for soft-update bookkeeping
+    # (target_updater walks loss_module.qvalue_network_params).
+    if cfg.compile_loss:
+        torchrl_logger.info("torch.compile(loss_module) enabled.")
+        loss_call = torch.compile(loss_module)
+    else:
+        loss_call = loss_module
+
+    critic_lr = cfg.critic_lr if cfg.critic_lr is not None else cfg.lr
+    optim_actor = torch.optim.Adam(
+        loss_module.actor_network_params.flatten_keys().values(),
+        lr=cfg.lr,
+    )
+    optim_critic = torch.optim.Adam(
+        loss_module.qvalue_network_params.flatten_keys().values(),
+        lr=critic_lr,
+    )
+    optim_alpha = None
+    if not cfg.fixed_alpha:
+        optim_alpha = torch.optim.Adam([loss_module.log_alpha], lr=cfg.lr)
+
+    # Optional cosine LR decay across the full training span. Decays
+    # to ``lr * lr_decay_end_frac`` by ``total_iters``.
+    schedulers: list[torch.optim.lr_scheduler.LRScheduler] = []
+    if cfg.lr_decay_end_frac is not None:
+        eta_min_actor = cfg.lr * cfg.lr_decay_end_frac
+        eta_min_critic = critic_lr * cfg.lr_decay_end_frac
+        schedulers.append(
+            torch.optim.lr_scheduler.CosineAnnealingLR(
+                optim_actor,
+                T_max=cfg.total_iters,
+                eta_min=eta_min_actor,
+            )
+        )
+        schedulers.append(
+            torch.optim.lr_scheduler.CosineAnnealingLR(
+                optim_critic,
+                T_max=cfg.total_iters,
+                eta_min=eta_min_critic,
+            )
+        )
+        if optim_alpha is not None:
+            schedulers.append(
+                torch.optim.lr_scheduler.CosineAnnealingLR(
+                    optim_alpha,
+                    T_max=cfg.total_iters,
+                    eta_min=eta_min_actor,
+                )
+            )
+        torchrl_logger.info(
+            f"Cosine LR decay enabled: lr {cfg.lr:.4g} -> "
+            f"{eta_min_actor:.4g} over {cfg.total_iters} iters."
+        )
+
+    # ----- Replay buffer -----
+    buffer_device = (
+        torch.device(cfg.buffer_device) if cfg.buffer_device is not None else device
+    )
+    storage = LazyTensorStorage(cfg.buffer_size, device=buffer_device)
+    if cfg.no_prb:
+        replay_buffer = TensorDictReplayBuffer(
+            storage=storage,
+            batch_size=cfg.batch_size,
+            prefetch=3,
+        )
+        torchrl_logger.info("Using uniform TensorDictReplayBuffer (no PER).")
+    else:
+        replay_buffer = TensorDictPrioritizedReplayBuffer(
+            alpha=cfg.prb_alpha,
+            beta=cfg.prb_beta,
+            storage=storage,
+            batch_size=cfg.batch_size,
+            priority_key="td_error",
+            prefetch=3,
+        )
+
+    # ----- Collector -----
+    frames_per_batch = cfg.num_envs * cfg.frames_per_env
+    init_random_frames = cfg.num_envs * cfg.init_random_frames_per_env
+    total_frames = frames_per_batch * cfg.total_iters
+    postproc = (
+        MultiStep(gamma=cfg.gamma, n_steps=cfg.n_step) if cfg.n_step > 1 else None
+    )
+    if postproc is not None:
+        torchrl_logger.info(
+            f"Using {cfg.n_step}-step returns "
+            f"(MultiStep postproc with gamma={cfg.gamma})."
+        )
+    if cfg.async_collector:
+        # Build a picklable env factory; the worker process re-creates
+        # the env there. The actor lives in the main process and gets
+        # synced to the worker once per outer iter via update_policy_weights_.
+        train_env_factory = partial(
+            _train_env_factory,
+            num_envs=cfg.num_envs,
+            device_str=str(device),
+            max_steps=cfg.max_steps,
+            min_random_horizon=cfg.min_random_horizon,
+            random_horizon_prob=cfg.random_horizon_prob,
+            compile_step=cfg.compile_env,
+            obs_norm_stats=obs_norm_stats,
+            use_obs_norm=not cfg.no_obs_norm,
+            num_cmgs=cfg.num_cmgs,
+            action_scale=cfg.action_scale,
+            singularity_weight=cfg.singularity_weight,
+            singularity_clamp_min=cfg.singularity_clamp_min,
+            singularity_mode=cfg.singularity_mode,
+            singularity_exp_k=cfg.singularity_exp_k,
+            omega_weight=cfg.omega_weight,
+            ctrl_cost_weight=cfg.ctrl_cost_weight,
+            frame_skip=cfg.frame_skip,
+            reward_scale=cfg.reward_scale,
+            seed=cfg.seed,
+        )
+        # Free the in-process train env: the worker will build its own.
+        train_env.close()
+        torchrl_logger.info(
+            "Async collector enabled (MultiCollector sync=False, 1 worker). "
+            "Collection runs in a separate process and overlaps with grad updates."
+        )
+        collector = MultiCollector(
+            create_env_fn=[train_env_factory],
+            policy=actor,
+            frames_per_batch=frames_per_batch,
+            total_frames=total_frames,
+            device=device,
+            init_random_frames=init_random_frames,
+            exploration_type=ExplorationType.RANDOM,
+            postproc=postproc,
+            update_at_each_batch=True,
+            sync=False,
+        )
+    else:
+        collector = Collector(
+            train_env,
+            policy=actor,
+            frames_per_batch=frames_per_batch,
+            total_frames=total_frames,
+            device=device,
+            init_random_frames=init_random_frames,
+            exploration_type=ExplorationType.RANDOM,
+            compile_policy=cfg.compile_policy,
+            postproc=postproc,
+        )
+
+    # ----- WandB -----
+    logger = None
+    if not cfg.no_wandb:
+        exp = generate_exp_name("SAC-PER", "satellite")
+        # ``--wandb-mode offline`` avoids the 90s wandb.init() handshake
+        # timeout that has been intermittently failing on this host.
+        # Sync offline runs with
+        # ``wandb sync torchrl-sat/wandb/offline-run-*``.
+        wandb_mode = cfg.wandb_mode
+        logger = get_logger(
+            "wandb",
+            logger_name="torchrl-sat",
+            experiment_name=exp,
+            wandb_kwargs={
+                "project": cfg.wandb_project,
+                "group": cfg.wandb_group,
+                "config": vars(cfg),
+                "mode": wandb_mode,
+            },
+        )
+
+    # ----- Eval (process-isolated, non-blocking) -----
+    evaluator = None
+    if not cfg.no_eval:
+        _, _, cats = load_test_set_csv(cfg.test_set_csv)
+        metrics_fn = make_eval_metrics_fn(cats)
+
+        def _on_eval_result(result):
+            # Logged from the evaluator's coordination thread.
+            torchrl_logger.info(
+                f"[eval] step={int(result.get('eval/step', -1))} "
+                f"return={float(result.get('eval/eval/return', float('nan'))):.3f} "
+                f"final_err={float(result.get('eval/eval/final_attitude_error_rad', float('nan'))):.3f} "
+                f"success@0.10={float(result.get('eval/eval/success_rate@0.10', float('nan'))):.3f}"
+            )
+            if logger is not None:
+                # The Evaluator emits keys with the prefix it was
+                # configured with (default ``eval/``); we store them as-is.
+                flat = {
+                    k: v.item() if hasattr(v, "item") else float(v)
+                    for k, v in result.items()
+                }
+                step = int(flat.pop("eval/step", -1))
+                logger.log_metrics(flat, step=max(0, step))
+
+        n_eval_envs = len(cats)
+        env_factory = partial(
+            _eval_env_factory,
+            device_str=str(eval_device),
+            test_set_csv=cfg.test_set_csv,
+            max_steps=cfg.max_steps,
+            obs_norm_stats=obs_norm_stats,
+            use_obs_norm=not cfg.no_obs_norm,
+            num_cmgs=cfg.num_cmgs,
+            action_scale=cfg.action_scale,
+            singularity_weight=cfg.singularity_weight,
+            singularity_clamp_min=cfg.singularity_clamp_min,
+            singularity_mode=cfg.singularity_mode,
+            singularity_exp_k=cfg.singularity_exp_k,
+            omega_weight=cfg.omega_weight,
+            ctrl_cost_weight=cfg.ctrl_cost_weight,
+            frame_skip=cfg.frame_skip,
+            compile_step=cfg.compile_eval_env,
+            reward_scale=cfg.reward_scale,
+        )
+        policy_factory = partial(
+            _eval_policy_factory,
+            obs_spec=obs_spec,
+            action_spec=action_spec,
+            hidden=tuple(cfg.hidden),
+            activation=cfg.activation,
+            device_str=str(eval_device),
+        )
+        evaluator = Evaluator(
+            env=env_factory,
+            policy_factory=policy_factory,
+            num_trajectories=n_eval_envs,
+            # ``max_steps`` is intentionally None: the eval env already
+            # has a :class:`StepCounter` set to ``cfg.max_steps``, and
+            # the process-backend collector raises if both sources try
+            # to enforce the same horizon.
+            max_steps=None,
+            exploration_type=ExplorationType.DETERMINISTIC,
+            metrics_fn=metrics_fn,
+            on_result=_on_eval_result,
+            backend="process",
+            weight_sync_schemes={"policy": MultiProcessWeightSyncScheme()},
+        )
+        torchrl_logger.info(
+            "Evaluator(backend='process') ready; first eval will spawn "
+            "the child process on the first trigger."
+        )
+    else:
+        torchrl_logger.info("Eval disabled (--no-eval); training-only metrics.")
+
+    def _check_finite(td, key: tuple[str, ...], context: str) -> None:
+        value = td.get(key)
+        if not torch.isfinite(value).all():
+            raise RuntimeError(f"Non-finite tensor at {context}: {key}")
+
+    # ----- Training loop -----
+    pbar_t0 = time.perf_counter()
+    collected_frames = 0
+    for it, batch in enumerate(collector):
+        _check_finite(batch, ("next", "reward"), f"collector iter {it}")
+        _check_finite(batch, ("next", "observation"), f"collector iter {it}")
+        # Flatten (num_envs, frames_per_env, ...) -> (N, ...)
+        flat = batch.reshape(-1)
+        replay_buffer.extend(flat)
+        collected_frames += frames_per_batch
+
+        # Skip SAC updates while warming up the buffer.
+        if collected_frames < init_random_frames:
+            torchrl_logger.info(f"iter={it} (warmup) frames={collected_frames}")
+            continue
+
+        # ----- SAC updates -----
+        last_loss = None
+        for _ in range(cfg.gradient_steps):
+            sample = replay_buffer.sample().to(device)
+            losses = loss_call(sample)
+
+            optim_actor.zero_grad(set_to_none=True)
+            optim_critic.zero_grad(set_to_none=True)
+            if optim_alpha is not None:
+                optim_alpha.zero_grad(set_to_none=True)
+            loss = losses["loss_actor"] + losses["loss_qvalue"] + losses["loss_alpha"]
+            if not torch.isfinite(loss):
+                loss_summary = {
+                    key: value.detach().item()
+                    for key, value in losses.items()
+                    if value.numel() == 1
+                }
+                raise RuntimeError(f"Non-finite SAC loss at iter {it}: {loss_summary}")
+            loss.backward()
+            # Per-component grad-norm logging. ``clip_grad_norm_``
+            # returns the total norm BEFORE clipping, so we can log it
+            # directly. Calling it per parameter group also clips each
+            # group independently rather than treating actor + critic
+            # + alpha as one big vector.
+            grad_norm_actor = torch.nn.utils.clip_grad_norm_(
+                list(loss_module.actor_network_params.flatten_keys().values()),
+                cfg.max_grad_norm if cfg.max_grad_norm > 0 else float("inf"),
+            )
+            grad_norm_critic = torch.nn.utils.clip_grad_norm_(
+                list(loss_module.qvalue_network_params.flatten_keys().values()),
+                cfg.max_grad_norm if cfg.max_grad_norm > 0 else float("inf"),
+            )
+            if optim_alpha is not None:
+                grad_norm_alpha = torch.nn.utils.clip_grad_norm_(
+                    [loss_module.log_alpha],
+                    cfg.max_grad_norm if cfg.max_grad_norm > 0 else float("inf"),
+                )
+            else:
+                grad_norm_alpha = torch.zeros((), device=device)
+            optim_actor.step()
+            optim_critic.step()
+            if optim_alpha is not None:
+                optim_alpha.step()
+            target_updater.step()
+
+            # Push the per-sample TD error back as the priority signal
+            # (only meaningful for prioritized replay).
+            if not cfg.no_prb:
+                replay_buffer.update_tensordict_priority(sample)
+            last_loss = losses
+
+        done_mask = batch["next", "done"]
+        ep_reward = batch["next", "episode_reward"][done_mask]
+        ep_length = batch["next", "step_count"][done_mask].to(torch.float32)
+        ep_reward_mean = ep_reward.mean().item() if ep_reward.numel() else None
+        ep_length_mean = ep_length.mean().item() if ep_length.numel() else None
+        # Per-step reward is the policy-quality signal: cumulative
+        # reward divided by episode length removes the artifact where
+        # ``episode_reward`` drifts more negative simply because
+        # ``RandomTruncationTransform`` lengthens episodes once the
+        # first uniformly-sampled horizons clear out.
+        ep_reward_per_step = (
+            (ep_reward / ep_length.clamp_min(1.0)).mean().item()
+            if ep_reward.numel()
+            else None
+        )
+        ep_reward_text = (
+            f"{ep_reward_mean:.3f}" if ep_reward_mean is not None else "n/a"
+        )
+        # ``batch_reward_per_step`` is the snapshot of "how is the
+        # policy doing right now": mean reward across the current
+        # 1024-sample collection batch. Decoupled from episode length
+        # and episode-completion rate, so it is the cleanest training
+        # signal.
+        batch_reward_per_step = batch.get(("next", "reward")).mean().item()
+        # Mean ||bus_omega||² this batch -- shows whether the policy
+        # is actually moving the satellite (>>0) or sitting still (~0).
+        batch_omega_sq = (
+            (batch.get(("next", "bus_omega")) ** 2).sum(dim=-1).mean().item()
+        )
+        # Mean ||quat_err|| this batch -- direct read of how far the
+        # bus is from the target on average right now.
+        batch_att_err = batch.get(("next", "quat_err")).norm(dim=-1).mean().item()
+        if logger is not None and last_loss is not None:
+            metrics = {
+                "train/loss_actor": last_loss["loss_actor"].item(),
+                "train/loss_qvalue": last_loss["loss_qvalue"].item(),
+                "train/loss_alpha": last_loss["loss_alpha"].item(),
+                "train/alpha": loss_module.log_alpha.detach().exp().item(),
+                "train/iter_per_sec": (it + 1)
+                / max(1e-6, time.perf_counter() - pbar_t0),
+                "train/buffer_size": len(replay_buffer),
+                "train/critic_lr": optim_critic.param_groups[0]["lr"],
+                "train/batch_reward_per_step": batch_reward_per_step,
+                "train/batch_omega_sq": batch_omega_sq,
+                "train/batch_attitude_error": batch_att_err,
+                "train/grad_norm_actor": grad_norm_actor.item(),
+                "train/grad_norm_critic": grad_norm_critic.item(),
+                "train/grad_norm_alpha": grad_norm_alpha.item(),
+            }
+            if ep_reward_mean is not None:
+                metrics["train/episode_reward"] = ep_reward_mean
+                metrics["train/episode_reward_per_step"] = ep_reward_per_step
+                metrics["train/episode_length"] = ep_length_mean
+            logger.log_metrics(metrics, step=collected_frames)
+        if last_loss is not None:
+            torchrl_logger.info(
+                f"iter={it} frames={collected_frames} "
+                f"r/step={batch_reward_per_step:.3f} "
+                f"|omega|²={batch_omega_sq:.3f} "
+                f"|q_err|={batch_att_err:.3f} "
+                f"ep_r={ep_reward_text} "
+                f"loss_q={last_loss['loss_qvalue'].item():.3f} "
+                f"loss_a={last_loss['loss_actor'].item():.3f} "
+                f"alpha={loss_module.log_alpha.detach().exp().item():.3f}"
+            )
+
+        # Step LR schedulers once per outer iteration (each iter is one
+        # collector batch; gradient_steps inner steps share the same lr).
+        for sched in schedulers:
+            sched.step()
+
+        if (
+            evaluator is not None
+            and (it + 1) % cfg.eval_every == 0
+            and not evaluator.pending
+        ):
+            evaluator.trigger_eval(actor, step=collected_frames)
+
+    if evaluator is not None:
+        # Drain any pending eval, then shut the worker process down.
+        if evaluator.pending:
+            try:
+                evaluator.wait(timeout=120.0)
+            except Exception as e:  # noqa: BLE001
+                torchrl_logger.warning(f"Final eval wait failed: {e}")
+        evaluator.shutdown()
+    collector.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/satellite/sac_per_fully_async.py
+++ b/examples/satellite/sac_per_fully_async.py
@@ -1,0 +1,688 @@
+"""SAC + Prioritized Replay Buffer with fully-async collection.
+
+Like ``sac_per.py`` but the collector and trainer are fully decoupled:
+the collector is constructed with ``replay_buffer=rb`` and started via
+``collector.start()`` so it pushes new transitions to the buffer in the
+background. The main loop only iterates over gradient steps, sampling
+from the buffer and updating the policy/value/alpha networks.
+
+Defaults match the ``1rlrmzo4`` configuration (the strongest
+synchronous run so far): 16k vmapped envs, 64 grad steps per "outer
+chunk", 6400 outer chunks => 409,600 gradient updates total. UTD ratio
+is no longer enforced -- collection and training proceed at their own
+hardware-determined rates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from functools import partial
+from pathlib import Path
+
+import torch
+
+from torchrl._utils import logger as torchrl_logger
+from torchrl.collectors import Evaluator, MultiCollector
+from torchrl.data import (
+    LazyTensorStorage,
+    TensorDictPrioritizedReplayBuffer,
+    TensorDictReplayBuffer,
+)
+from torchrl.envs.utils import ExplorationType
+from torchrl.objectives import SACLoss, SoftUpdate
+from torchrl.record.loggers import generate_exp_name, get_logger
+from torchrl.weight_update import MultiProcessWeightSyncScheme
+
+PACKAGE_DIR = Path(__file__).resolve().parent
+if str(PACKAGE_DIR.parent.parent) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_DIR.parent.parent))
+
+from examples.satellite._utils import (  # noqa: E402
+    DEFAULT_OBS_NORM_PATH,
+    DEFAULT_TEST_SET_PATH,
+    load_test_set_csv,
+    make_actor,
+    make_eval_metrics_fn,
+    make_qvalue_critic,
+    make_train_env,
+    pick_device,
+    setup_wandb_key,
+)
+from examples.satellite.sac_per import (  # noqa: E402
+    _eval_env_factory,
+    _eval_policy_factory,
+    _train_env_factory,
+)
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """CLI mirroring ``sac_per.py`` so launch commands are interchangeable.
+
+    The async-only knobs are at the bottom. Unused-in-async flags
+    (``--init-random-frames-per-env``, ``--gradient-steps``,
+    ``--frames-per-env``) are still parsed so launch scripts don't break,
+    but their semantics shift -- see help text on each.
+    """
+    p = argparse.ArgumentParser(description=__doc__)
+    # Env / collection sizing.
+    p.add_argument("--num-envs", type=int, default=16_384)
+    p.add_argument("--num-cmgs", type=int, default=4)
+    p.add_argument("--max-steps", type=int, default=300)
+    p.add_argument("--frame-skip", type=int, default=50)
+    p.add_argument("--min-random-horizon", type=int, default=100)
+    p.add_argument("--random-horizon-prob", type=float, default=0.02)
+    p.add_argument("--frames-per-env", type=int, default=1)
+    p.add_argument(
+        "--total-iters",
+        type=int,
+        default=6400,
+        help=(
+            "Number of outer chunks. Each chunk runs --gradient-steps "
+            "grad updates. Total grad updates = total_iters * "
+            "gradient_steps. Eval cadence and LR scheduler horizon both "
+            "use total_iters."
+        ),
+    )
+    p.add_argument("--gradient-steps", type=int, default=64)
+    p.add_argument("--buffer-size", type=int, default=1_000_000)
+    p.add_argument(
+        "--init-buffer-size",
+        type=int,
+        default=16_384,
+        help=(
+            "Number of transitions the collector must produce before "
+            "the trainer starts taking gradient steps. Default = "
+            "num_envs (one outer-iter's worth)."
+        ),
+    )
+    p.add_argument(
+        "--init-random-frames-per-env",
+        type=int,
+        default=0,
+        help="Parsed for CLI parity; not used by the async loop.",
+    )
+    p.add_argument("--batch-size", type=int, default=4096)
+    p.add_argument("--prb-alpha", type=float, default=0.7)
+    p.add_argument("--prb-beta", type=float, default=0.5)
+    p.add_argument("--no-prb", action="store_true")
+    # SAC.
+    p.add_argument("--lr", type=float, default=9e-4)
+    p.add_argument("--critic-lr", type=float, default=9e-4)
+    p.add_argument("--gamma", type=float, default=0.99)
+    p.add_argument("--alpha-init", type=float, default=1.0)
+    p.add_argument("--fixed-alpha", action="store_true")
+    p.add_argument("--min-alpha", type=float, default=None)
+    p.add_argument("--max-alpha", type=float, default=None)
+    p.add_argument("--target-update-polyak", type=float, default=0.995)
+    p.add_argument("--max-grad-norm", type=float, default=1.0)
+    p.add_argument(
+        "--lr-decay-end-frac",
+        type=float,
+        default=0.1,
+        help="Cosine LR end value as a fraction of starting lr.",
+    )
+    p.add_argument(
+        "--lr-warmup-iters",
+        type=int,
+        default=0,
+        help=(
+            "Linear warmup over this many outer iters from "
+            "lr * 1/start_div -> lr, then cosine decay over the remaining "
+            "(total_iters - lr_warmup_iters) iters."
+        ),
+    )
+    p.add_argument(
+        "--lr-warmup-start-factor",
+        type=float,
+        default=1e-2,
+        help="Start factor for the warmup phase. lr_start = lr * start_factor.",
+    )
+    # Reward / env physics.
+    p.add_argument("--action-scale", type=float, default=3.0)
+    p.add_argument("--singularity-weight", type=float, default=0.0)
+    p.add_argument("--singularity-clamp-min", type=float, default=1e-6)
+    p.add_argument(
+        "--singularity-mode",
+        type=str,
+        default="inverse",
+        choices=["inverse", "exp"],
+    )
+    p.add_argument("--singularity-exp-k", type=float, default=5.0)
+    p.add_argument("--omega-weight", type=float, default=0.1)
+    p.add_argument("--ctrl-cost-weight", type=float, default=0.0)
+    p.add_argument("--reward-scale", type=float, default=0.333)
+    # Networks.
+    p.add_argument("--hidden", type=int, nargs="+", default=[256, 256, 256, 256])
+    p.add_argument("--activation", type=str, default="tanh")
+    p.add_argument("--small-init-last-layer", action="store_true", default=True)
+    p.add_argument(
+        "--no-small-init-last-layer", dest="small_init_last_layer", action="store_false"
+    )
+    p.add_argument("--scale-init", type=float, default=0.31)
+    p.add_argument("--layer-norm", action="store_true")
+    p.add_argument("--no-obs-norm", action="store_true", default=True)
+    p.add_argument("--obs-norm-path", type=str, default=str(DEFAULT_OBS_NORM_PATH))
+    p.add_argument("--obs-norm-warmup", type=int, default=10_000)
+    # Devices / compile.
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--device", default=None)
+    p.add_argument("--eval-device", default=None)
+    p.add_argument(
+        "--buffer-device",
+        default="cpu",
+        help=(
+            "Device for the replay buffer storage. Must be 'cpu' for "
+            "shared-memory multiprocess use unless TorchRL was built "
+            "with CUDA support."
+        ),
+    )
+    p.add_argument("--compile-env", action="store_true")
+    p.add_argument("--compile-eval-env", action="store_true")
+    p.add_argument("--compile-policy", action="store_true")
+    p.add_argument("--compile-loss", action="store_true")
+    # Eval.
+    p.add_argument(
+        "--eval-every", type=int, default=50, help="Eval every N outer chunks."
+    )
+    p.add_argument("--no-eval", action="store_true")
+    p.add_argument("--test-set-csv", type=str, default=str(DEFAULT_TEST_SET_PATH))
+    # WandB.
+    p.add_argument("--no-wandb", action="store_true")
+    p.add_argument("--wandb-project", default="torchrl-sat")
+    p.add_argument("--wandb-group", default="sac-per-async")
+    p.add_argument(
+        "--wandb-mode",
+        default="online",
+        choices=["online", "offline", "disabled"],
+    )
+    return p.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    cfg = parse_args(argv)
+    device = pick_device(cfg.device)
+    eval_device = (
+        torch.device(cfg.eval_device) if cfg.eval_device is not None else device
+    )
+    total_grad_steps = cfg.total_iters * cfg.gradient_steps
+    torchrl_logger.info(
+        f"Device: {device} | eval_device: {eval_device} | "
+        f"num_envs={cfg.num_envs} | total_iters={cfg.total_iters} | "
+        f"gradient_steps={cfg.gradient_steps} | "
+        f"total_grad_steps={total_grad_steps}"
+    )
+
+    # ----- Reference env (for spec extraction only) -----
+    # The async collector builds its own env in a worker. We only need
+    # one in the main process so we can read obs/action specs to build
+    # the actor + critic. Closed immediately after.
+    spec_env, _ = make_train_env(
+        num_envs=cfg.num_envs,
+        device=device,
+        max_steps=cfg.max_steps,
+        min_random_horizon=cfg.min_random_horizon,
+        random_horizon_prob=cfg.random_horizon_prob,
+        compile_step=False,
+        obs_norm_stats=None,
+        use_obs_norm=not cfg.no_obs_norm,
+        num_cmgs=cfg.num_cmgs,
+        action_scale=cfg.action_scale,
+        singularity_weight=cfg.singularity_weight,
+        singularity_clamp_min=cfg.singularity_clamp_min,
+        singularity_mode=cfg.singularity_mode,
+        singularity_exp_k=cfg.singularity_exp_k,
+        omega_weight=cfg.omega_weight,
+        ctrl_cost_weight=cfg.ctrl_cost_weight,
+        frame_skip=cfg.frame_skip,
+        reward_scale=cfg.reward_scale,
+        seed=cfg.seed,
+    )
+    obs_spec = spec_env.observation_spec
+    action_spec = spec_env.action_spec
+    spec_env.close()
+    obs_norm_stats = None  # --no-obs-norm only path supported in async
+
+    # ----- Networks + loss -----
+    hidden = tuple(cfg.hidden)
+    actor = make_actor(
+        obs_spec=obs_spec,
+        action_spec=action_spec,
+        device=device,
+        hidden=hidden,
+        activation=cfg.activation,
+        state_independent_scale=False,
+        layer_norm=cfg.layer_norm,
+        small_init_last_layer=cfg.small_init_last_layer,
+        scale_init=cfg.scale_init,
+    )
+    qvalue = make_qvalue_critic(
+        obs_spec=obs_spec,
+        action_spec=action_spec,
+        device=device,
+        hidden=hidden,
+        activation=cfg.activation,
+        layer_norm=cfg.layer_norm,
+    )
+    loss_module = SACLoss(
+        actor_network=actor,
+        qvalue_network=qvalue,
+        num_qvalue_nets=2,
+        loss_function="l2",
+        alpha_init=cfg.alpha_init,
+        min_alpha=cfg.min_alpha,
+        max_alpha=cfg.max_alpha,
+        fixed_alpha=cfg.fixed_alpha,
+        delay_actor=False,
+        delay_qvalue=True,
+        delay_value=True,
+        target_entropy="auto",
+        action_spec=action_spec,
+    )
+    loss_module.make_value_estimator(gamma=cfg.gamma)
+    target_updater = SoftUpdate(loss_module, eps=cfg.target_update_polyak)
+
+    if cfg.compile_loss:
+        torchrl_logger.info("torch.compile(loss_module) enabled.")
+        loss_call = torch.compile(loss_module)
+    else:
+        loss_call = loss_module
+
+    critic_lr = cfg.critic_lr if cfg.critic_lr is not None else cfg.lr
+    optim_actor = torch.optim.Adam(
+        loss_module.actor_network_params.flatten_keys().values(),
+        lr=cfg.lr,
+    )
+    optim_critic = torch.optim.Adam(
+        loss_module.qvalue_network_params.flatten_keys().values(),
+        lr=critic_lr,
+    )
+    optim_alpha = None
+    if not cfg.fixed_alpha:
+        optim_alpha = torch.optim.Adam([loss_module.log_alpha], lr=cfg.lr)
+
+    schedulers: list[torch.optim.lr_scheduler.LRScheduler] = []
+
+    def _build_lr_scheduler(optim, eta_min):
+        """Linear warmup -> cosine decay (or just cosine if warmup=0)."""
+        decay_iters = max(1, cfg.total_iters - cfg.lr_warmup_iters)
+        cosine = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optim,
+            T_max=decay_iters,
+            eta_min=eta_min,
+        )
+        if cfg.lr_warmup_iters > 0:
+            warmup = torch.optim.lr_scheduler.LinearLR(
+                optim,
+                start_factor=cfg.lr_warmup_start_factor,
+                end_factor=1.0,
+                total_iters=cfg.lr_warmup_iters,
+            )
+            return torch.optim.lr_scheduler.SequentialLR(
+                optim,
+                schedulers=[warmup, cosine],
+                milestones=[cfg.lr_warmup_iters],
+            )
+        return cosine
+
+    if cfg.lr_decay_end_frac is not None:
+        eta_min_actor = cfg.lr * cfg.lr_decay_end_frac
+        eta_min_critic = critic_lr * cfg.lr_decay_end_frac
+        schedulers.append(_build_lr_scheduler(optim_actor, eta_min_actor))
+        schedulers.append(_build_lr_scheduler(optim_critic, eta_min_critic))
+        if optim_alpha is not None:
+            schedulers.append(_build_lr_scheduler(optim_alpha, eta_min_actor))
+        if cfg.lr_warmup_iters > 0:
+            torchrl_logger.info(
+                f"LR schedule: linear warmup {cfg.lr * cfg.lr_warmup_start_factor:.4g} "
+                f"-> {cfg.lr:.4g} over {cfg.lr_warmup_iters} iters, then "
+                f"cosine decay -> {eta_min_actor:.4g} over the remaining "
+                f"{cfg.total_iters - cfg.lr_warmup_iters} iters."
+            )
+        else:
+            torchrl_logger.info(
+                f"Cosine LR decay: lr {cfg.lr:.4g} -> {eta_min_actor:.4g} "
+                f"over {cfg.total_iters} outer chunks."
+            )
+
+    # ----- Replay buffer (shared across processes) -----
+    buffer_device = torch.device(cfg.buffer_device)
+    storage = LazyTensorStorage(cfg.buffer_size, device=buffer_device)
+    # Note: ``prefetch`` is incompatible with ``shared=True`` (the
+    # multiprocess SyncManager wrappers can't pickle the prefetch
+    # thread state).
+    if cfg.no_prb:
+        replay_buffer = TensorDictReplayBuffer(
+            storage=storage,
+            batch_size=cfg.batch_size,
+            shared=True,
+        )
+        torchrl_logger.info("Using uniform TensorDictReplayBuffer (no PER), shared.")
+    else:
+        # ``sync=False`` (added in PR pytorch/rl#3714): writer procs use a
+        # shareable RandomSampler, while the learner owns a local
+        # PrioritizedSampler that catches up from shared write_count
+        # before sampling. Required for the fully-async collector flow.
+        replay_buffer = TensorDictPrioritizedReplayBuffer(
+            alpha=cfg.prb_alpha,
+            beta=cfg.prb_beta,
+            storage=storage,
+            batch_size=cfg.batch_size,
+            priority_key="td_error",
+            shared=True,
+            sync=False,
+        )
+        torchrl_logger.info(
+            f"Using TensorDictPrioritizedReplayBuffer "
+            f"(alpha={cfg.prb_alpha}, beta={cfg.prb_beta}), shared, sync=False."
+        )
+
+    # ----- Async collector -----
+    train_env_factory = partial(
+        _train_env_factory,
+        num_envs=cfg.num_envs,
+        device_str=str(device),
+        max_steps=cfg.max_steps,
+        min_random_horizon=cfg.min_random_horizon,
+        random_horizon_prob=cfg.random_horizon_prob,
+        compile_step=cfg.compile_env,
+        obs_norm_stats=obs_norm_stats,
+        use_obs_norm=not cfg.no_obs_norm,
+        num_cmgs=cfg.num_cmgs,
+        action_scale=cfg.action_scale,
+        singularity_weight=cfg.singularity_weight,
+        singularity_clamp_min=cfg.singularity_clamp_min,
+        singularity_mode=cfg.singularity_mode,
+        singularity_exp_k=cfg.singularity_exp_k,
+        omega_weight=cfg.omega_weight,
+        ctrl_cost_weight=cfg.ctrl_cost_weight,
+        frame_skip=cfg.frame_skip,
+        reward_scale=cfg.reward_scale,
+        seed=cfg.seed,
+    )
+    frames_per_batch = cfg.num_envs * cfg.frames_per_env
+    collector = MultiCollector(
+        create_env_fn=[train_env_factory],
+        policy=actor,
+        replay_buffer=replay_buffer,
+        frames_per_batch=frames_per_batch,
+        total_frames=-1,
+        device=device,
+        exploration_type=ExplorationType.RANDOM,
+        update_at_each_batch=True,
+        sync=False,
+    )
+    torchrl_logger.info(
+        "MultiCollector(sync=False, replay_buffer=rb) ready -- starting "
+        "async collection now."
+    )
+
+    # ----- WandB -----
+    logger = None
+    if not cfg.no_wandb:
+        setup_wandb_key()
+        exp = generate_exp_name("SAC-PER-async", "satellite")
+        logger = get_logger(
+            "wandb",
+            logger_name="torchrl-sat",
+            experiment_name=exp,
+            wandb_kwargs={
+                "project": cfg.wandb_project,
+                "group": cfg.wandb_group,
+                "mode": cfg.wandb_mode,
+                "config": vars(cfg),
+            },
+        )
+
+    # ----- Eval setup (process backend, identical to sac_per.py) -----
+    metrics_fn = None
+    evaluator = None
+    if not cfg.no_eval:
+        _, _, cats = load_test_set_csv(cfg.test_set_csv)
+        metrics_fn = make_eval_metrics_fn(cats)
+
+        def _on_eval_result(result):
+            torchrl_logger.info(
+                f"[eval] step={int(result.get('eval/step', -1))} "
+                f"return={float(result.get('eval/eval/return', float('nan'))):.3f} "
+                f"final_err={float(result.get('eval/eval/final_attitude_error_rad', float('nan'))):.3f} "
+                f"success@0.10={float(result.get('eval/eval/success_rate@0.10', float('nan'))):.3f}"
+            )
+            if logger is not None:
+                flat = {
+                    k: v.item() if hasattr(v, "item") else float(v)
+                    for k, v in result.items()
+                }
+                step = int(flat.pop("eval/step", -1))
+                logger.log_metrics(flat, step=max(0, step))
+
+        env_factory = partial(
+            _eval_env_factory,
+            device_str=str(eval_device),
+            test_set_csv=cfg.test_set_csv,
+            max_steps=cfg.max_steps,
+            obs_norm_stats=obs_norm_stats,
+            use_obs_norm=not cfg.no_obs_norm,
+            num_cmgs=cfg.num_cmgs,
+            action_scale=cfg.action_scale,
+            singularity_weight=cfg.singularity_weight,
+            singularity_clamp_min=cfg.singularity_clamp_min,
+            singularity_mode=cfg.singularity_mode,
+            singularity_exp_k=cfg.singularity_exp_k,
+            omega_weight=cfg.omega_weight,
+            ctrl_cost_weight=cfg.ctrl_cost_weight,
+            frame_skip=cfg.frame_skip,
+            compile_step=cfg.compile_eval_env,
+            reward_scale=cfg.reward_scale,
+        )
+        policy_factory = partial(
+            _eval_policy_factory,
+            obs_spec=obs_spec,
+            action_spec=action_spec,
+            hidden=tuple(cfg.hidden),
+            activation=cfg.activation,
+            device_str=str(eval_device),
+        )
+        evaluator = Evaluator(
+            env=env_factory,
+            policy_factory=policy_factory,
+            num_trajectories=len(cats),
+            max_steps=None,
+            exploration_type=ExplorationType.DETERMINISTIC,
+            metrics_fn=metrics_fn,
+            on_result=_on_eval_result,
+            backend="process",
+            weight_sync_schemes={"policy": MultiProcessWeightSyncScheme()},
+        )
+
+    # ----- Start async collection -----
+    collector.start()
+
+    # Wait for the buffer to warm up enough to start sampling.
+    while len(replay_buffer) < cfg.init_buffer_size:
+        torchrl_logger.info(
+            f"warmup: buffer size = {len(replay_buffer)} "
+            f"< {cfg.init_buffer_size}; sleeping 1s"
+        )
+        time.sleep(1.0)
+    torchrl_logger.info(
+        f"warmup done: buffer size = {len(replay_buffer)}; "
+        f"starting gradient updates."
+    )
+
+    # ----- Training loop -----
+    pbar_t0 = time.perf_counter()
+    grad_step = 0
+    last_log_t = pbar_t0
+    last_loss = None
+
+    for outer_iter in range(cfg.total_iters):
+        for _ in range(cfg.gradient_steps):
+            sample = replay_buffer.sample().to(device)
+            losses = loss_call(sample)
+
+            optim_actor.zero_grad(set_to_none=True)
+            optim_critic.zero_grad(set_to_none=True)
+            if optim_alpha is not None:
+                optim_alpha.zero_grad(set_to_none=True)
+            loss = losses["loss_actor"] + losses["loss_qvalue"] + losses["loss_alpha"]
+            if not torch.isfinite(loss):
+                loss_summary = {
+                    key: value.detach().item()
+                    for key, value in losses.items()
+                    if value.numel() == 1
+                }
+                raise RuntimeError(
+                    f"Non-finite SAC loss at grad_step {grad_step}: " f"{loss_summary}"
+                )
+            loss.backward()
+            grad_norm_actor = torch.nn.utils.clip_grad_norm_(
+                list(loss_module.actor_network_params.flatten_keys().values()),
+                cfg.max_grad_norm if cfg.max_grad_norm > 0 else float("inf"),
+            )
+            grad_norm_critic = torch.nn.utils.clip_grad_norm_(
+                list(loss_module.qvalue_network_params.flatten_keys().values()),
+                cfg.max_grad_norm if cfg.max_grad_norm > 0 else float("inf"),
+            )
+            if optim_alpha is not None:
+                grad_norm_alpha = torch.nn.utils.clip_grad_norm_(
+                    [loss_module.log_alpha],
+                    cfg.max_grad_norm if cfg.max_grad_norm > 0 else float("inf"),
+                )
+            else:
+                grad_norm_alpha = torch.zeros((), device=device)
+            optim_actor.step()
+            optim_critic.step()
+            if optim_alpha is not None:
+                optim_alpha.step()
+            target_updater.step()
+
+            if not cfg.no_prb:
+                replay_buffer.update_tensordict_priority(sample)
+            last_loss = losses
+            grad_step += 1
+
+        for sched in schedulers:
+            sched.step()
+
+        # Per-outer-iter logging.
+        now = time.perf_counter()
+        log_dt = now - last_log_t
+        last_log_t = now
+        # Reproduce the same step semantic as ``sac_per.py``: "frames"
+        # in wandb step indexing tracks collector frames; use the
+        # collector's running write counter as the canonical step.
+        try:
+            collected_frames = int(replay_buffer.write_count)
+        except (AttributeError, TypeError):
+            collected_frames = len(replay_buffer)
+        torchrl_logger.info(
+            f"iter={outer_iter} grad_step={grad_step} "
+            f"buffer={len(replay_buffer)} "
+            f"frames={collected_frames} "
+            f"loss_q={last_loss['loss_qvalue'].item():.3f} "
+            f"loss_a={last_loss['loss_actor'].item():.3f} "
+            f"alpha={loss_module.log_alpha.detach().exp().item():.3f} "
+            f"dt={log_dt:.2f}s"
+        )
+        # Diagnostic batch metrics from the most recent sampled minibatch.
+        # Mirrors what ``sac_per.py`` and ``ppo_buffer.py`` log so all
+        # three scripts share a comparable training-quality dashboard.
+        with torch.no_grad():
+            batch_reward_per_step = sample.get(("next", "reward")).mean().item()
+            qerr_t = sample.get(("next", "quat_err"), default=None)
+            batch_attitude_error = (
+                qerr_t.norm(dim=-1).mean().item()
+                if qerr_t is not None
+                else float("nan")
+            )
+            omega_t = sample.get(("next", "bus_omega"), default=None)
+            batch_omega_sq = (
+                (omega_t**2).sum(dim=-1).mean().item()
+                if omega_t is not None
+                else float("nan")
+            )
+            done_mask = sample.get(("next", "done"))
+            ep_r_t = sample.get(("next", "episode_reward"), default=None)
+            episode_reward = (
+                ep_r_t[done_mask].mean().item()
+                if ep_r_t is not None and done_mask.any()
+                else None
+            )
+
+        if logger is not None and last_loss is not None:
+            metrics = {
+                "train/loss_actor": last_loss["loss_actor"].item(),
+                "train/loss_qvalue": last_loss["loss_qvalue"].item(),
+                "train/loss_alpha": last_loss["loss_alpha"].item(),
+                "train/alpha": loss_module.log_alpha.detach().exp().item(),
+                "train/n_updates": grad_step,
+                "train/buffer_size": len(replay_buffer),
+                # ``train/lr`` is the canonical key shared with PPO; keep
+                # ``train/critic_lr`` as a back-compat alias.
+                "train/lr": optim_critic.param_groups[0]["lr"],
+                "train/critic_lr": optim_critic.param_groups[0]["lr"],
+                "train/grad_norm_actor": grad_norm_actor.item(),
+                "train/grad_norm_critic": grad_norm_critic.item(),
+                "train/grad_norm_alpha": grad_norm_alpha.item()
+                if isinstance(grad_norm_alpha, torch.Tensor)
+                else grad_norm_alpha,
+                "train/iter_per_sec": (outer_iter + 1) / max(1e-6, now - pbar_t0),
+                "train/iter_dt_sec": log_dt,
+                "train/batch_reward_per_step": batch_reward_per_step,
+                "train/batch_attitude_error": batch_attitude_error,
+                "train/batch_omega_sq": batch_omega_sq,
+            }
+            if episode_reward is not None:
+                metrics["train/episode_reward"] = episode_reward
+            logger.log_metrics(metrics, step=collected_frames)
+
+        # Eval trigger -- skip if the previous eval is still running
+        # (the async Evaluator's default ``busy_policy='error'`` raises
+        # when overlapping triggers come in faster than eval can drain).
+        if (
+            evaluator is not None
+            and (outer_iter + 1) % cfg.eval_every == 0
+            and not evaluator.pending
+        ):
+            evaluator.trigger_eval(actor, step=collected_frames)
+
+    # ----- Shutdown -----
+    torchrl_logger.info(
+        f"Training complete: {grad_step} gradient updates. " "Shutting down collector."
+    )
+    try:
+        collector.async_shutdown(timeout=30.0)
+    except Exception as e:
+        torchrl_logger.warning(f"collector.async_shutdown failed: {e}")
+    if evaluator is not None:
+        if evaluator.pending:
+            try:
+                evaluator.wait(timeout=120.0)
+            except Exception as e:
+                torchrl_logger.warning(f"Final eval wait failed: {e}")
+        try:
+            evaluator.shutdown()
+        except Exception as e:
+            torchrl_logger.warning(f"evaluator.shutdown failed: {e}")
+    if logger is not None:
+        try:
+            logger.experiment.finish()
+        except Exception:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/libs/test_mujoco.py
+++ b/test/libs/test_mujoco.py
@@ -348,6 +348,43 @@ class TestMujoco:
         expected_qerr = quat_log(quat_mul(quat_conj(init_q_norm), target_q_norm))
         torch.testing.assert_close(td["quat_err"], expected_qerr, rtol=1e-4, atol=1e-4)
 
+    @pytest.mark.skipif(not _has_mujoco_torch, reason="mujoco-torch not installed")
+    def test_satellite_eval_primer_runs_before_env_reset(self, tmp_path):
+        """The eval test-set primer must feed fixed starts into reset."""
+        from examples.satellite._utils import make_eval_env
+
+        csv = tmp_path / "satellite_eval.csv"
+        csv.write_text(
+            "\n".join(
+                [
+                    "init_w,init_x,init_y,init_z,target_w,target_x,target_y,target_z,category",
+                    "1.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0,identity_to_x",
+                    "0.0,0.0,1.0,0.0,1.0,0.0,0.0,0.0,y_to_identity",
+                ]
+            )
+            + "\n"
+        )
+        env = make_eval_env(
+            device=torch.device("cpu"),
+            test_set_csv=csv,
+            max_steps=5,
+            obs_norm_stats=None,
+            use_obs_norm=False,
+        )
+        env.reset()
+        base = env.base_env
+        expected = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
+            dtype=base.dtype,
+            device=base.device,
+        )
+        torch.testing.assert_close(
+            base._backend.qpos[..., 3:7].to(base.dtype),
+            expected,
+            rtol=1e-4,
+            atol=1e-4,
+        )
+
     @pytest.mark.parametrize("backend", _VMAP_BACKENDS)
     def test_satellite_quat_err_is_zero_at_target(self, backend):
         """Setting ``init_bus_quat == target_quat`` makes the


### PR DESCRIPTION
## Summary

- Adds synchronous SAC + PER training for the satellite MuJoCo task.
- Adds a fully asynchronous SAC + PER variant for the same task.
- Adds shared satellite-example helpers for environment construction, evaluation setup, model creation, logging, and deterministic in-memory eval starts.
- Adds a regression test that checks eval starts are applied before the wrapped environment reset.

## Stack status

#3700 has landed and this branch has been rebased onto `main`. The PR diff now contains only the satellite example files plus the example-specific regression test.

## Test plan

- [x] `python3 -m py_compile test/libs/test_mujoco.py examples/satellite/_utils.py examples/satellite/sac_per.py examples/satellite/sac_per_fully_async.py`
- [ ] `python examples/satellite/sac_per.py`
- [ ] `python examples/satellite/sac_per_fully_async.py`
- [ ] `pytest test/libs/test_mujoco.py -k eval_primer -v`
