### PR TITLE
[BugFix] Gate scan RNN backward support

### DIFF
--- a/.github/unittest/linux/scripts/run_all.sh
+++ b/.github/unittest/linux/scripts/run_all.sh
@@ -240,6 +240,9 @@ else
   uv_pip_install --no-deps tensordict
 fi
 
+printf "* Installing hoptorch\n"
+uv_pip_install "hoptorch>=0.1.1"
+
 printf "* Installing torchrl\n"
 if [[ "$RELEASE" == 0 ]]; then
   uv_pip_install -e . --no-build-isolation --no-deps

--- a/.github/unittest/linux_optdeps/scripts/run_all.sh
+++ b/.github/unittest/linux_optdeps/scripts/run_all.sh
@@ -142,6 +142,9 @@ else
   pip3 install --no-deps tensordict
 fi
 
+printf "* Installing hoptorch\n"
+python -m pip install "hoptorch>=0.1.1"
+
 printf "* Installing torchrl\n"
 python -m pip install -e . --no-build-isolation --no-deps
 

--- a/.github/unittest/windows_optdepts/scripts/unittest.sh
+++ b/.github/unittest/windows_optdepts/scripts/unittest.sh
@@ -122,6 +122,9 @@ print('successfully imported tensordict')
 echo "=== Setting up CUDA environment ==="
 source "$this_dir/set_cuda_envs.sh"
 
+printf "* Installing hoptorch\n"
+python -m pip install "hoptorch>=0.1.1"
+
 printf "* Installing torchrl\n"
 python -m pip install -e . --no-build-isolation --no-deps
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ requires-python = ">=3.10"
 dependencies = [
     "torch>=2.1.0",
     "pyvers",
+    "hoptorch>=0.1.1",
     "numpy",
     "packaging",
     "cloudpickle",

--- a/test/modules/test_rnn.py
+++ b/test/modules/test_rnn.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import functools
+import importlib.util
 import sys
 import threading
 
@@ -65,6 +66,8 @@ from torchrl.testing.mocking_classes import (
     CountingEnvCountPolicy,
     DiscreteActionVecMockEnv,
 )
+
+_has_hoptorch = importlib.util.find_spec("hoptorch") is not None
 
 if _has_functorch:
     try:
@@ -1258,6 +1261,7 @@ class TestLSTMModule:
         TORCH_VERSION < version.parse("2.7.0"),
         reason="hoptorch requires torch >= 2.7.0",
     )
+    @pytest.mark.skipif(not _has_hoptorch, reason="hoptorch is not installed")
     def test_scan_backend_backward_matches_pad(self, rnn_type):
         torch.manual_seed(0)
         B, T, F, H, L = 3, 5, 4, 8, 1

--- a/test/modules/test_rnn.py
+++ b/test/modules/test_rnn.py
@@ -1253,6 +1253,86 @@ class TestLSTMModule:
                 pad_out[key], triton_out[key], atol=5e-3, rtol=5e-3
             )
 
+    @pytest.mark.parametrize("rnn_type", ["lstm", "gru"])
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.7.0"),
+        reason="hoptorch requires torch >= 2.7.0",
+    )
+    def test_scan_backend_backward_matches_pad(self, rnn_type):
+        torch.manual_seed(0)
+        B, T, F, H, L = 3, 5, 4, 8, 1
+        if rnn_type == "lstm":
+            kwargs = {
+                "input_size": F,
+                "hidden_size": H,
+                "num_layers": L,
+                "in_keys": ["obs", "hidden0", "hidden1"],
+                "out_keys": ["feat", ("next", "hidden0"), ("next", "hidden1")],
+            }
+            pad_module = LSTMModule(**kwargs)
+            scan_module = LSTMModule(**kwargs, recurrent_backend="scan")
+        else:
+            kwargs = {
+                "input_size": F,
+                "hidden_size": H,
+                "num_layers": L,
+                "in_keys": ["obs", "hidden"],
+                "out_keys": ["feat", ("next", "hidden")],
+            }
+            pad_module = GRUModule(**kwargs)
+            scan_module = GRUModule(**kwargs, recurrent_backend="scan")
+        scan_module.load_state_dict(pad_module.state_dict())
+
+        obs_source = torch.randn(B, T, F)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool)
+        is_init[:, 0] = True
+        is_init[1, 3] = True
+        is_init[2, 2] = True
+
+        def make_data():
+            obs = obs_source.detach().clone().requires_grad_()
+            if rnn_type == "lstm":
+                hidden0 = torch.zeros(B, T, L, H)
+                hidden1 = torch.zeros(B, T, L, H)
+                data = TensorDict(
+                    {
+                        "obs": obs,
+                        "hidden0": hidden0,
+                        "hidden1": hidden1,
+                        "is_init": is_init.clone(),
+                    },
+                    [B, T],
+                )
+            else:
+                hidden = torch.zeros(B, T, L, H)
+                data = TensorDict(
+                    {"obs": obs, "hidden": hidden, "is_init": is_init.clone()},
+                    [B, T],
+                )
+            return data, obs
+
+        def grads(module):
+            data, obs = make_data()
+            with set_recurrent_mode(True):
+                out = module(data)
+                loss = out["feat"].square().mean()
+            loss.backward()
+            param_grads = [
+                (name, param.grad.detach().clone())
+                for name, param in module.named_parameters()
+            ]
+            return obs.grad.detach().clone(), param_grads
+
+        pad_obs_grad, pad_param_grads = grads(pad_module)
+        scan_obs_grad, scan_param_grads = grads(scan_module)
+
+        torch.testing.assert_close(pad_obs_grad, scan_obs_grad, atol=5e-3, rtol=5e-3)
+        for (pad_name, pad_grad), (scan_name, scan_grad) in zip(
+            pad_param_grads, scan_param_grads
+        ):
+            assert pad_name == scan_name
+            torch.testing.assert_close(pad_grad, scan_grad, atol=5e-3, rtol=5e-3)
+
     @pytest.mark.gpu
     @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
     @pytest.mark.parametrize("backend", ["scan", "triton"])

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import contextvars
 import importlib.metadata
+import importlib.util
 import typing
 from typing import Any
 
@@ -28,17 +29,34 @@ from torchrl._utils import (
 from torchrl.data.tensor_specs import Unbounded
 from torchrl.modules.tensordict_module._rnn_precision import _validate_user_precision
 
-# ``torch._higher_order_ops.scan`` was introduced in PyTorch 2.6. hoptorch
-# wraps it and owns the scan backward health check / temporary compatibility
-# patching needed by older PyTorch versions.
-from hoptorch import scan as _torch_scan
-from hoptorch.scan import ensure_scan_backward as _ensure_scan_backward
+_has_hoptorch = importlib.util.find_spec("hoptorch") is not None
+_hoptorch_scan = None
+_ensure_scan_backward = None
+
+
+def _get_hoptorch_scan() -> tuple[Any, Any]:
+    global _hoptorch_scan, _ensure_scan_backward
+    if not _has_hoptorch:
+        raise NotImplementedError(
+            "recurrent_backend='scan' requires hoptorch. Install it with "
+            "`pip install hoptorch>=0.1.1`."
+        )
+    if _hoptorch_scan is None or _ensure_scan_backward is None:
+        # Optional dependency: keep the import lazy because CI jobs install
+        # TorchRL with --no-deps, even though hoptorch is a core dependency.
+        from hoptorch import scan
+        from hoptorch.scan import ensure_scan_backward
+
+        _hoptorch_scan = scan
+        _ensure_scan_backward = ensure_scan_backward
+    return _hoptorch_scan, _ensure_scan_backward
 
 
 def _maybe_warm_scan_backward(device: torch.device | str | int | None) -> None:
     device = torch.device("cpu") if device is None else torch.device(device)
     if device.type != "meta":
-        _ensure_scan_backward(device)
+        _, ensure_scan_backward = _get_hoptorch_scan()
+        ensure_scan_backward(device)
 
 
 def _check_triton_available() -> bool:
@@ -93,7 +111,8 @@ def _scan(*args: Any, **kwargs: Any) -> Any:
 
 @implement_for("torch", "2.6.0", compilable=True)
 def _scan(*args: Any, **kwargs: Any) -> Any:  # noqa: F811
-    return _torch_scan(*args, **kwargs)
+    scan, _ = _get_hoptorch_scan()
+    return scan(*args, **kwargs)
 
 
 def _place_at_traj_end(

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -28,15 +28,17 @@ from torchrl._utils import (
 from torchrl.data.tensor_specs import Unbounded
 from torchrl.modules.tensordict_module._rnn_precision import _validate_user_precision
 
-# ``torch._higher_order_ops.scan`` was introduced in PyTorch 2.6. Gate the
-# import on the runtime torch version: probing via ``importlib.util.find_spec``
-# would eagerly import the (missing) ``torch._higher_order_ops`` parent on
-# older builds and crash this module at load time.
-_has_torch_scan = version.parse(torch.__version__) >= version.parse("2.6.0")
-if _has_torch_scan:
-    from torch._higher_order_ops import scan as _torch_scan
-else:
-    _torch_scan = None
+# ``torch._higher_order_ops.scan`` was introduced in PyTorch 2.6. hoptorch
+# wraps it and owns the scan backward health check / temporary compatibility
+# patching needed by older PyTorch versions.
+from hoptorch import scan as _torch_scan
+from hoptorch.scan import ensure_scan_backward as _ensure_scan_backward
+
+
+def _maybe_warm_scan_backward(device: torch.device | str | int | None) -> None:
+    device = torch.device("cpu") if device is None else torch.device(device)
+    if device.type != "meta":
+        _ensure_scan_backward(device)
 
 
 def _check_triton_available() -> bool:
@@ -91,11 +93,6 @@ def _scan(*args: Any, **kwargs: Any) -> Any:
 
 @implement_for("torch", "2.6.0", compilable=True)
 def _scan(*args: Any, **kwargs: Any) -> Any:  # noqa: F811
-    if _torch_scan is None:
-        raise NotImplementedError(
-            "torch._higher_order_ops.scan is required for the scan recurrent "
-            "backend but is not available in this PyTorch build."
-        )
     return _torch_scan(*args, **kwargs)
 
 
@@ -329,6 +326,8 @@ class LSTM(LSTMBase):
         # to capture the scan; eager use will fail. Dropout is not supported
         # on this path. See :meth:`_lstm_scan`.
         self.use_scan = use_scan
+        if use_scan:
+            _maybe_warm_scan_backward(device)
 
     @staticmethod
     def _lstm_cell(x, hx, cx, weight_ih, bias_ih, weight_hh, bias_hh):
@@ -573,7 +572,8 @@ class LSTMModule(ModuleBase):
         recurrent_backend: backend used in recurrent mode when trajectories reset
             in the middle of a batch. ``"pad"`` keeps the existing split/pad
             strategy. ``"scan"`` uses a scan loop over the time dimension and
-            avoids materializing padded trajectory chunks. ``"triton"``
+            avoids materializing padded trajectory chunks via ``hoptorch``.
+            ``"triton"``
             (prototype, CUDA only) uses Triton kernels where available and
             otherwise preserves pad-backend recurrent semantics for dropout,
             projections and bidirectional layers. ``"auto"`` uses ``"pad"``
@@ -793,6 +793,9 @@ class LSTMModule(ModuleBase):
         self.recurrent_backend = recurrent_backend
         self.recurrent_compute_dtype = recurrent_compute_dtype
         self.recurrent_matmul_precision = recurrent_matmul_precision
+        if recurrent_backend == "scan":
+            param = next(lstm.parameters(), None)
+            _maybe_warm_scan_backward(device if param is None else param.device)
 
     def make_python_based(self) -> LSTMModule:
         """Transforms the LSTM layer in its python-based version.
@@ -1639,6 +1642,8 @@ class GRU(GRUBase):
         )
         # Opt-in prototype: see :meth:`_gru_scan` and :class:`LSTM`.
         self.use_scan = use_scan
+        if use_scan:
+            _maybe_warm_scan_backward(device)
 
     @staticmethod
     def _gru_cell(x, hx, weight_ih, bias_ih, weight_hh, bias_hh):
@@ -1842,7 +1847,8 @@ class GRUModule(ModuleBase):
         recurrent_backend: backend used in recurrent mode when trajectories reset
             in the middle of a batch. ``"pad"`` keeps the existing split/pad
             strategy. ``"scan"`` uses a scan loop over the time dimension and
-            avoids materializing padded trajectory chunks. ``"triton"``
+            avoids materializing padded trajectory chunks via ``hoptorch``.
+            ``"triton"``
             (prototype, CUDA only) uses Triton kernels where available and
             otherwise preserves pad-backend recurrent semantics for dropout
             and bidirectional layers.
@@ -2084,6 +2090,9 @@ class GRUModule(ModuleBase):
         self.recurrent_backend = recurrent_backend
         self.recurrent_compute_dtype = recurrent_compute_dtype
         self.recurrent_matmul_precision = recurrent_matmul_precision
+        if recurrent_backend == "scan":
+            param = next(gru.parameters(), None)
+            _maybe_warm_scan_backward(device if param is None else param.device)
 
     def make_python_based(self) -> GRUModule:
         """Transforms the GRU layer in its python-based version.


### PR DESCRIPTION
## Summary
- make `hoptorch>=0.1.1` a core dependency and delegate the scan backend to `hoptorch.scan`
- pre-warm `hoptorch` scan backward checks for explicit scan modules so compiled scan paths can use the cached/patched implementation
- keep the hoptorch import lazy for `--no-deps` CI installs while installing hoptorch in scan-covering CI jobs
- add one scan-vs-pad backward regression test for GRU/LSTM with non-grad hidden state and trainable parameters

## Test plan
- python3 -m py_compile torchrl/modules/tensordict_module/rnn.py test/modules/test_rnn.py
- ../rl-dev/.venv/bin/python -m pre_commit run --files .github/unittest/linux_optdeps/scripts/run_all.sh torchrl/modules/tensordict_module/rnn.py test/modules/test_rnn.py .github/unittest/linux/scripts/run_all.sh .github/unittest/windows_optdepts/scripts/unittest.sh
- PYTHONPATH=/Users/vmoens/repos/rl-shifted-budget ../rl-dev/.venv/bin/python -m pytest test/modules/test_rnn.py -k "scan" -q

## CI notes
- Current remaining failures are unrelated to this change:
  - Build M1 Wheels: macOS runner lacks `conda` during cleanup/setup.
  - Libs Tests on Linux / `unittests-gym`: `ale_py.gym` no longer exposes `ALGymEnv` for Pong-v4 tests.
