### PR TITLE
[BugFix] Make collector weight syncs idempotent

### DIFF
--- a/test/collectors/test_evaluator.py
+++ b/test/collectors/test_evaluator.py
@@ -64,6 +64,22 @@ class TestEvaluatorSync:
         finally:
             evaluator.shutdown()
 
+    def test_evaluate_plain_tensordict_weights_preserves_state_dict(self):
+        env = _make_env()
+        policy = _make_policy(env)
+        evaluator = Evaluator(env, policy, max_steps=5)
+        try:
+            weights = TensorDict.from_module(policy).data.detach().clone().cpu()
+            state_dict_keys = set(policy.state_dict())
+            assert state_dict_keys
+
+            evaluator.evaluate(weights=weights, step=0)
+            evaluator.evaluate(weights=weights, step=1)
+
+            assert set(policy.state_dict()) == state_dict_keys
+        finally:
+            evaluator.shutdown()
+
     def test_evaluate_with_module_weights(self):
         env = _make_env()
         policy = _make_policy(env)
@@ -878,6 +894,40 @@ class TestWeightStrategyExtraState:
         assert torch.allclose(dst.running_mean, torch.tensor(99.0).expand(4))
         assert torch.allclose(dst.running_var, torch.tensor(2.0).expand(4))
         assert dst.count.item() == 50
+
+    def test_apply_extra_state_is_idempotent(self):
+        """apply_weights does not consume __extra_state__ from the input weights."""
+        src = _ModuleWithExtraState(dim=4)
+        src.running_mean.fill_(11.0)
+        src.count.fill_(9)
+        dst = _ModuleWithExtraState(dim=4)
+
+        strategy = WeightStrategy(extract_as="tensordict")
+        weights = strategy.extract_weights(src)
+
+        strategy.apply_weights(dst, weights, inplace=True)
+        dst.running_mean.zero_()
+        dst.count.zero_()
+        strategy.apply_weights(dst, weights, inplace=True)
+
+        assert "__extra_state__" in weights.keys()
+        assert torch.allclose(dst.running_mean, torch.tensor(11.0).expand(4))
+        assert dst.count.item() == 9
+
+    def test_apply_plain_tensor_weights_outofplace_preserves_state_dict(self):
+        """Out-of-place application casts plain tensors back to parameters."""
+        src = nn.Linear(4, 4)
+        dst = nn.Linear(4, 4)
+        strategy = WeightStrategy(extract_as="tensordict")
+        weights = TensorDict.from_module(src).data.detach().clone()
+        state_dict_keys = set(dst.state_dict())
+
+        strategy.apply_weights(dst, weights, inplace=False)
+        strategy.apply_weights(dst, weights, inplace=False)
+
+        assert set(dst.state_dict()) == state_dict_keys
+        assert torch.allclose(dst.weight, src.weight)
+        assert torch.allclose(dst.bias, src.bias)
 
     def test_apply_extra_state_outofplace(self):
         """apply_weights out-of-place also restores extra_state."""

--- a/torchrl/collectors/_evaluator.py
+++ b/torchrl/collectors/_evaluator.py
@@ -87,6 +87,7 @@ from tensordict.nn import TensorDictModuleBase
 
 from torchrl.envs import EnvBase
 from torchrl.envs.utils import ExplorationType, set_exploration_type
+from torchrl.weight_update.weight_sync_schemes import WeightStrategy
 
 _has_ray = importlib.util.find_spec("ray") is not None
 
@@ -1166,15 +1167,18 @@ class _ThreadEvalBackend(_EvalBackend):
                 # Multi-process: use scheme-based sync via the collector
                 self._collector.update_policy_weights_(weights_dict=weights_dict)
             else:
-                # Same process: apply weights directly
+                # Same process: copy weights into the registered parameters and
+                # buffers. Calling TensorDict.to_module() with plain tensors would
+                # replace nn.Parameters with tensors and make state_dict() empty.
+                strategy = WeightStrategy(extract_as="tensordict")
                 for model_id, w in weights_dict.items():
                     if model_id == "policy":
-                        w.to(self._device).to_module(self._policy)
+                        strategy.apply_weights(self._policy, w.to(self._device))
                     else:
                         from torchrl.weight_update.utils import _resolve_model
 
                         target = _resolve_model(self._collector, model_id)
-                        w.to(self._device).to_module(target)
+                        strategy.apply_weights(target, w.to(self._device))
 
         if not self._use_multi_collector and isinstance(self._policy, nn.Module):
             self._policy.eval()

--- a/torchrl/collectors/distributed/_ray_eval_runtime.py
+++ b/torchrl/collectors/distributed/_ray_eval_runtime.py
@@ -1,0 +1,108 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch
+
+from torchrl.envs.utils import ExplorationType, set_exploration_type, step_mdp
+from torchrl.weight_update.weight_sync_schemes import WeightStrategy
+
+
+class RayEvalRuntime:
+    """Torch-dependent runtime for :class:`~torchrl.collectors.RayEvalWorker`."""
+
+    def __init__(self, env: Any, policy: Any) -> None:
+        self.env = env
+        self.policy = policy
+        # Cache device before any weight application can affect parameter
+        # registration.
+        self._device = next(self.policy.parameters()).device
+        self._weight_strategy = WeightStrategy(extract_as="tensordict")
+
+    def eval(
+        self,
+        weights: Any,
+        max_steps: int,
+        reward_keys: tuple[str, ...],
+        deterministic: bool,
+        break_when_any_done: bool,
+    ) -> dict:
+        """Run an evaluation rollout with the given weights."""
+        # Load weights into the eval policy (move to policy device first).
+        # ``weights`` can legitimately be None when the caller asks for an
+        # evaluation of the current policy (no fresh weights to inject).
+        if weights is not None:
+            self._weight_strategy.apply_weights(self.policy, weights.to(self._device))
+
+        frames = []
+        total_reward = 0.0
+        num_steps = 0
+
+        exploration = (
+            ExplorationType.DETERMINISTIC if deterministic else ExplorationType.RANDOM
+        )
+        with set_exploration_type(exploration), torch.no_grad():
+            td = self.env.reset()
+            for _i in range(max_steps):
+                td = self.policy(td)
+                td = self.env.step(td)
+
+                total_reward += td[reward_keys].mean().item()
+                num_steps += 1
+
+                frame = self._try_render()
+                if frame is not None:
+                    frames.append(frame)
+
+                done = td.get(("next", "done"), None)
+                if break_when_any_done and done is not None and done.any():
+                    break
+
+                td = step_mdp(td)
+
+        mean_reward = total_reward / max(1, num_steps)
+
+        # Format video: (1, T, C, H, W) uint8 CPU tensor.
+        video = None
+        if frames:
+            video = torch.stack(frames, dim=0).unsqueeze(0).cpu()
+
+        return {"reward": mean_reward, "frames": video}
+
+    def _try_render(self) -> torch.Tensor | None:
+        """Render one frame from the underlying environment, if available."""
+        # Walk through TransformedEnv / wrapper chain to the base env.
+        env = self.env
+        while hasattr(env, "base_env"):
+            env = env.base_env
+        render_fn = getattr(env, "render", None)
+        # If the base env delegates to a gymnasium env, prefer that.
+        if hasattr(env, "_env") and hasattr(env._env, "render"):
+            render_fn = env._env.render
+        if render_fn is None:
+            return None
+
+        raw = render_fn()
+        if raw is None:
+            return None
+
+        if isinstance(raw, np.ndarray):
+            raw = torch.from_numpy(raw.copy())
+
+        # (H, W, C) -> (C, H, W).
+        if raw.ndim == 3 and raw.shape[-1] in (3, 4):
+            raw = raw[..., :3]
+            raw = raw.permute(2, 0, 1)
+
+        return raw.to(torch.uint8)
+
+    def shutdown(self) -> None:
+        """Shut down the environment."""
+        is_closed = getattr(self.env, "is_closed", False)
+        if not is_closed:
+            self.env.close()

--- a/torchrl/collectors/distributed/ray_eval_worker.py
+++ b/torchrl/collectors/distributed/ray_eval_worker.py
@@ -297,12 +297,15 @@ class _EvalActor:
         import torch
 
         from torchrl.envs.utils import ExplorationType, set_exploration_type, step_mdp
+        from torchrl.weight_update.weight_sync_schemes import WeightStrategy
 
         # Load weights into the eval policy (move to policy device first).
         # ``weights`` can legitimately be None when the caller asks for an
         # evaluation of the current policy (no fresh weights to inject).
         if weights is not None:
-            weights.to(self._device).to_module(self.policy)
+            WeightStrategy(extract_as="tensordict").apply_weights(
+                self.policy, weights.to(self._device)
+            )
 
         frames = []
         total_reward = 0.0

--- a/torchrl/collectors/distributed/ray_eval_worker.py
+++ b/torchrl/collectors/distributed/ray_eval_worker.py
@@ -42,11 +42,24 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-import numpy as np
 
 _has_ray = importlib.util.find_spec("ray") is not None
+_ray = None
 
 logger = logging.getLogger(__name__)
+
+
+def _get_ray():
+    """Lazily import the optional Ray dependency."""
+    if not _has_ray:
+        raise RuntimeError(
+            "Ray is required for RayEvalWorker but could not be found. "
+            "Install it with: pip install ray"
+        )
+    global _ray
+    if _ray is None:
+        _ray = importlib.import_module("ray")
+    return _ray
 
 
 class RayEvalWorker:
@@ -103,12 +116,7 @@ class RayEvalWorker:
         name: str | None = None,
         **remote_kwargs: Any,
     ) -> None:
-        if not _has_ray:
-            raise RuntimeError(
-                "Ray is required for RayEvalWorker but could not be found. "
-                "Install it with: pip install ray"
-            )
-        import ray
+        ray = _get_ray()
 
         self._reward_keys = reward_keys
 
@@ -147,12 +155,7 @@ class RayEvalWorker:
             reward_keys: Nested key(s) used to read the reward from the
                 rollout tensordict.  Defaults to ``("next", "reward")``.
         """
-        if not _has_ray:
-            raise RuntimeError(
-                "Ray is required for RayEvalWorker but could not be found. "
-                "Install it with: pip install ray"
-            )
-        import ray
+        ray = _get_ray()
 
         worker = object.__new__(cls)
         worker._reward_keys = reward_keys
@@ -210,7 +213,7 @@ class RayEvalWorker:
         if self._pending_ref is None:
             return None
 
-        import ray
+        ray = _get_ray()
 
         ready, _ = ray.wait([self._pending_ref], timeout=timeout)
         if not ready:
@@ -226,7 +229,7 @@ class RayEvalWorker:
         Safe to call multiple times or after ``ray.shutdown()`` has already
         torn down the actor (e.g. via a test fixture).
         """
-        import ray
+        ray = _get_ray()
 
         if self._actor is None:
             return
@@ -251,13 +254,10 @@ class RayEvalWorker:
 class _EvalActor:
     """Plain class turned into a Ray actor by :class:`RayEvalWorker`.
 
-    **Why local imports?**  Environments like Isaac Lab **require** their
-    ``AppLauncher`` to be initialised before ``import torch`` even happens.
-    The *init_fn* callback (called first in ``__init__``) takes care of that.
-    Every ``import torch`` and ``from torchrl ...`` therefore lives inside a
-    method body so that the actor process can control import order via
-    *init_fn*.  Only stdlib / pure-Python imports (``numpy``, ``logging``,
-    etc.) are safe at module level.
+    Environments like Isaac Lab require their ``AppLauncher`` to be initialised
+    before ``torch`` is imported. The torch-dependent runtime is therefore kept
+    in a private module and imported only after *init_fn* has run in the actor
+    process.
     """
 
     def __init__(
@@ -266,119 +266,32 @@ class _EvalActor:
         env_maker: Callable[[], Any],
         policy_maker: Callable[[Any], Any],
     ) -> None:
-        # --- process-level initialisation ---
-        # This MUST run before any torch import.  For Isaac Lab the init_fn
-        # calls AppLauncher which configures the GPU, the Omniverse runtime,
-        # and various environment variables that torch and CUDA rely on.
         if init_fn is not None:
             init_fn()
 
-        # --- now safe to import torch / torchrl ---
-        # (kept local: see class docstring for rationale)
-        import torch  # noqa: F401
-
-        self.env = env_maker()
-        self.policy = policy_maker(self.env)
-        # Cache device before any to_module call can replace nn.Parameter
-        # with plain tensors (which makes .parameters() empty).
-        self._device = next(self.policy.parameters()).device
+        runtime_mod = importlib.import_module(
+            "torchrl.collectors.distributed._ray_eval_runtime"
+        )
+        env = env_maker()
+        self._runtime = runtime_mod.RayEvalRuntime(env, policy_maker(env))
 
     def eval(
         self,
-        weights,
+        weights: Any,
         max_steps: int,
         reward_keys: tuple[str, ...],
         deterministic: bool,
         break_when_any_done: bool,
     ) -> dict:
         """Run an evaluation rollout with the given weights."""
-        # Local imports: torch/torchrl must not be imported before init_fn
-        # has run (see class docstring -- this is critical for Isaac Lab).
-        import torch
-
-        from torchrl.envs.utils import ExplorationType, set_exploration_type, step_mdp
-        from torchrl.weight_update.weight_sync_schemes import WeightStrategy
-
-        # Load weights into the eval policy (move to policy device first).
-        # ``weights`` can legitimately be None when the caller asks for an
-        # evaluation of the current policy (no fresh weights to inject).
-        if weights is not None:
-            WeightStrategy(extract_as="tensordict").apply_weights(
-                self.policy, weights.to(self._device)
-            )
-
-        frames = []
-        total_reward = 0.0
-        num_steps = 0
-
-        exploration = (
-            ExplorationType.DETERMINISTIC if deterministic else ExplorationType.RANDOM
+        return self._runtime.eval(
+            weights=weights,
+            max_steps=max_steps,
+            reward_keys=reward_keys,
+            deterministic=deterministic,
+            break_when_any_done=break_when_any_done,
         )
-        with set_exploration_type(exploration), torch.no_grad():
-            td = self.env.reset()
-            for _i in range(max_steps):
-                td = self.policy(td)
-                td = self.env.step(td)
-
-                total_reward += td[reward_keys].mean().item()
-                num_steps += 1
-
-                frame = self._try_render()
-                if frame is not None:
-                    frames.append(frame)
-
-                done = td.get(("next", "done"), None)
-                if break_when_any_done and done is not None and done.any():
-                    break
-
-                td = step_mdp(td)
-
-        mean_reward = total_reward / max(1, num_steps)
-
-        # Format video: (1, T, C, H, W) uint8 CPU tensor
-        video = None
-        if frames:
-            video = torch.stack(frames, dim=0).unsqueeze(0).cpu()
-
-        return {"reward": mean_reward, "frames": video}
-
-    def _try_render(self):
-        """Render one frame from the underlying environment.
-
-        Walks the wrapper chain to find a callable ``render()`` method
-        and returns the result as a ``(C, H, W)`` uint8 tensor, or
-        ``None`` if rendering is unavailable.
-        """
-        # Local import: torch must not be imported at module level
-        # (see class docstring -- this is critical for Isaac Lab).
-        import torch
-
-        # Walk through TransformedEnv / wrapper chain to the base env.
-        env = self.env
-        while hasattr(env, "base_env"):
-            env = env.base_env
-        render_fn = getattr(env, "render", None)
-        # If the base env delegates to a gymnasium env, prefer that.
-        if hasattr(env, "_env") and hasattr(env._env, "render"):
-            render_fn = env._env.render
-        if render_fn is None:
-            return None
-
-        raw = render_fn()
-        if raw is None:
-            return None
-
-        if isinstance(raw, np.ndarray):
-            raw = torch.from_numpy(raw.copy())
-
-        # (H, W, C) -> (C, H, W)
-        if raw.ndim == 3 and raw.shape[-1] in (3, 4):
-            raw = raw[..., :3]
-            raw = raw.permute(2, 0, 1)
-
-        return raw.to(torch.uint8)
 
     def shutdown(self) -> None:
         """Shut down the environment."""
-        if hasattr(self, "env") and not self.env.is_closed:
-            self.env.close()
+        self._runtime.shutdown()

--- a/torchrl/weight_update/_ray.py
+++ b/torchrl/weight_update/_ray.py
@@ -272,7 +272,9 @@ class RayTransport:
         if strategy is not None:
             strategy.apply_weights(model, weights_buffer)
         else:
-            weights_buffer.to_module(model)
+            WeightStrategy(extract_as="tensordict").apply_weights(
+                model, weights_buffer, inplace=False
+            )
 
         return weights_buffer
 

--- a/torchrl/weight_update/weight_sync_schemes.py
+++ b/torchrl/weight_update/weight_sync_schemes.py
@@ -15,6 +15,7 @@ from typing import Any, Literal, overload, Protocol
 import torch
 
 from tensordict import TensorDict, TensorDictBase
+from tensordict.utils import Buffer
 from torch import nn
 from torchrl._utils import logger as torchrl_logger
 
@@ -100,6 +101,20 @@ class TransportBackend(Protocol):
 # ============================================================================
 # Weight Strategies
 # ============================================================================
+
+
+def _to_module_compatible_tensor(
+    tensor: torch.Tensor,
+    destination_tensor: torch.Tensor,
+) -> torch.Tensor:
+    """Cast a tensor so ``TensorDict.to_module`` preserves module registration."""
+    if isinstance(tensor, (nn.Parameter, Buffer)):
+        return tensor
+    if isinstance(destination_tensor, nn.Parameter):
+        return nn.Parameter(tensor, requires_grad=destination_tensor.requires_grad)
+    if isinstance(destination_tensor, Buffer):
+        return Buffer(tensor)
+    return tensor
 
 
 class WeightStrategy:
@@ -213,16 +228,31 @@ class WeightStrategy:
             if any("." in key for key in weights.keys()):
                 weights = weights.unflatten_keys(".")
 
-        # Pop extra_state before applying parameter weights
+        # Exclude extra_state before applying parameter weights, without mutating
+        # the input weights. Reusing the same weight container for repeated syncs
+        # must be idempotent.
         extra_state = None
         if isinstance(weights, TensorDictBase) and "__extra_state__" in weights.keys():
-            extra_state = weights.pop("__extra_state__").flatten_keys(".").to_dict()
+            extra_state = weights["__extra_state__"].clone().flatten_keys(".").to_dict()
+            weights = weights.exclude("__extra_state__")
+
+        if not isinstance(weights, TensorDictBase):
+            raise ValueError(
+                f"Unsupported weights type: {type(weights)}. "
+                "Must be dict or TensorDictBase."
+            )
 
         destination_module = None
         if isinstance(destination, nn.Module):
             destination_module = destination
             # Do not update in-place
             if not inplace:
+                destination_params = TensorDict.from_module(destination)
+                weights = weights.apply(
+                    _to_module_compatible_tensor,
+                    destination_params,
+                    filter_empty=False,
+                )
                 weights.to_module(destination)
                 if extra_state is not None:
                     destination_module.set_extra_state(extra_state)
@@ -236,10 +266,6 @@ class WeightStrategy:
             if any(isinstance(key, str) and "." in key for key in destination.keys()):
                 destination = destination.unflatten_keys(".")
 
-        if not isinstance(weights, TensorDictBase):
-            raise ValueError(
-                f"Unsupported weights type: {type(weights)}. Must be dict or TensorDictBase."
-            )
         if not isinstance(destination, TensorDictBase):
             if not weights.is_empty():
                 raise ValueError(


### PR DESCRIPTION
## Description

Fixes #3804.

This makes collector/evaluator weight sync paths idempotent when weights are provided as detached TensorDicts with plain tensor leaves:

- routes same-process evaluator and Ray eval weight application through `WeightStrategy.apply_weights` instead of raw `TensorDict.to_module()`;
- preserves destination `nn.Parameter` / buffer registration for out-of-place TensorDict application by casting source leaves according to the destination module state;
- avoids consuming or aliasing `__extra_state__` during weight application;
- adds regressions that repeated weight syncs preserve `state_dict()` keys and extra state.

Follow-up TensorDict API tightening is tracked at https://github.com/pytorch/tensordict/issues/1719.

## Testing

- `python3 -m compileall -q torchrl/weight_update/weight_sync_schemes.py torchrl/weight_update/_ray.py torchrl/collectors/_evaluator.py torchrl/collectors/distributed/ray_eval_worker.py test/collectors/test_evaluator.py`
- `/opt/homebrew/bin/python3.13 -m pytest test/collectors/test_evaluator.py::TestWeightStrategyExtraState test/collectors/test_evaluator.py::TestEvaluatorSync -q`
