### PR TITLE
[Doc] Refresh TorchRL README for 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Benchmarks](https://img.shields.io/badge/Benchmarks-blue.svg)](https://pytorch.github.io/rl/dev/bench/)
 [![codecov](https://codecov.io/gh/pytorch/rl/branch/main/graph/badge.svg?token=HcpK1ILV6r)](https://codecov.io/gh/pytorch/rl)
 [![Flaky Tests](https://img.shields.io/endpoint?url=https://pytorch.github.io/rl/flaky/badge.json)](https://pytorch.github.io/rl/flaky/)
-[![Twitter Follow](https://img.shields.io/twitter/follow/torchrl1?style=social)](https://twitter.com/torchrl1)
+[![X / Twitter Follow](https://img.shields.io/twitter/follow/torchrl1?style=social)](https://twitter.com/torchrl1)
 [![Python version](https://img.shields.io/pypi/pyversions/torchrl.svg)](https://www.python.org/downloads/)
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/pytorch/rl/blob/main/LICENSE)
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 <a href="https://pypi.org/project/torchrl"><img src="https://img.shields.io/pypi/v/torchrl" alt="pypi version"></a>
 <a href="https://pypi.org/project/torchrl-nightly"><img src="https://img.shields.io/pypi/v/torchrl-nightly?label=nightly" alt="pypi nightly version"></a>
 [![Downloads](https://static.pepy.tech/personalized-badge/torchrl?period=total&units=international_system&left_color=blue&right_color=orange&left_text=Downloads)](https://pepy.tech/project/torchrl)
@@ -16,1022 +16,506 @@
 # TorchRL
 
 <p align="center">
-  <img src="docs/source/_static/img/icon.png"  width="200" >
+  <img src="docs/source/_static/img/icon.png" width="200" alt="TorchRL logo">
 </p>
 
-[**What's New**](#-whats-new) | [**LLM API**](#llm-api---complete-framework-for-language-model-fine-tuning) | [**Getting Started**](#getting-started) | [**Documentation**](#documentation-and-knowledge-base) | [**TensorDict**](#writing-simplified-and-portable-rl-codebase-with-tensordict) |
-[**Features**](#features) | [**Examples, tutorials and demos**](#examples-tutorials-and-demos) | [**Citation**](#citation) | [**Installation**](#installation) |
-[**Asking a question**](#asking-a-question) | [**Contributing**](#contributing)
+TorchRL is a PyTorch-native toolkit for reinforcement learning, decision making,
+robotics, and simulation. It is not a single algorithm implementation or a
+narrow benchmark suite: it is a collection of composable pieces for building RL
+systems while keeping the code close to the PyTorch programming model. Recent
+work has made this especially strong for recurrent RL, MuJoCo-based control,
+multi-agent training, replay-buffer and collector infrastructure, and reusable
+loss/value-estimation components.
 
-**TorchRL** is an open-source Reinforcement Learning (RL) library for PyTorch.
+The library is built around three ideas:
 
-## 🚀 What's New
+1. Data should have names, structure, batch dimensions, and devices all the way
+   through the training loop.
+2. Environments, policies, replay buffers, objectives, and collectors should be
+   independent modules that can be swapped without rewriting the rest of the
+   stack.
+3. Research code should scale from a local prototype to vectorized,
+   multiprocess, distributed, compiled, recurrent, multi-agent, model-based, or
+   offline workflows without changing the data model.
 
-### 🚀 **Command-Line Training Interface** - Train RL Agents Without Writing Code! (Experimental)
+That common data model is [TensorDict](https://github.com/pytorch/tensordict/),
+a dictionary-like tensor container with PyTorch operations, device transfers,
+shared-memory support, memmaps, lazy views, and `nn.Module` wrappers.
 
-TorchRL now provides a **powerful command-line interface** that lets you train state-of-the-art RL agents with simple bash commands! No Python scripting required - just run training with customizable parameters:
+[Getting started](https://pytorch.org/rl/stable/index.html#getting-started) |
+[API reference](https://pytorch.org/rl/stable/reference/index.html) |
+[Tutorials](https://pytorch.org/rl/stable#tutorials) |
+[Knowledge base](https://pytorch.org/rl/stable/reference/knowledge_base.html) |
+[Examples](examples/) |
+[SOTA implementations](sota-implementations/)
 
-- 🎯 **One-Command Training**: `python sota-implementations/ppo_trainer/train.py`
-- ⚙️ **Full Customization**: Override any parameter via command line: `trainer.total_frames=2000000 optimizer.lr=0.0003`
-- 🌍 **Multi-Environment Support**: Switch between Gym, Brax, DM Control, and more with `env=gym training_env.create_env_fn.base_env.env_name=HalfCheetah-v4`
-- 📊 **Built-in Logging**: TensorBoard, Weights & Biases, CSV logging out of the box
-- 🔧 **Hydra-Powered**: Leverages Hydra's powerful configuration system for maximum flexibility
-- 🏃‍♂️ **Production Ready**: Same robust training pipeline as our SOTA implementations
+## Recent highlights
 
-**Perfect for**: Researchers, practitioners, and anyone who wants to train RL agents without diving into implementation details. 
+TorchRL 0.13 and the preceding development cycle bring several user-visible
+improvements that are worth surfacing up front:
 
-⚠️ **Note**: This is an experimental feature. The API may change in future versions. We welcome feedback and contributions to help improve this implementation!
+- faster recurrent RL paths, including scan and Triton GRU/LSTM reset handling;
+- custom MuJoCo environments, satellite examples, and macro-control policies;
+- stronger multi-agent coverage through MAPPO, IPPO, `MultiAgentGAE`,
+  value-normalization utilities, and mixer configs;
+- better collector and replay-buffer ergonomics, including async prioritized
+  writes, ordered storage access, compact observations, and HER;
+- new transforms and value-estimator improvements such as `ActionScaling`,
+  `FlattenAction`, `NextObservationDelta`, compact shifted estimators, and
+  chunked forwards.
 
-📋 **Prerequisites**: The training interface requires Hydra for configuration management. Install with:
-```bash
-pip install "torchrl[utils]"
-# or manually:
-pip install hydra-core omegaconf
+## A quick mental model
+
+TorchRL represents an RL interaction as a TensorDict that moves through a small
+number of reusable components:
+
+```text
+TensorDict
+  -> policy module writes actions and log-probs
+  -> environment reads actions and writes next observations, rewards, done flags
+  -> collector batches trajectories from one or many workers
+  -> replay buffer stores, samples, prioritizes, and transforms data
+  -> loss module reads named keys and writes differentiable losses
+  -> optimizer updates ordinary PyTorch parameters
 ```
 
-Check out the [complete CLI documentation](https://github.com/pytorch/rl/tree/main/sota-implementations/ppo_trainer) to get started!
+The same object can carry observations, pixels, actions, rewards, masks,
+recurrent states, agent groups, sampled indices, priorities, or custom task
+fields. The result is less glue code and fewer hidden assumptions about
+what each algorithm or environment returns.
 
-### 🚀 **vLLM Revamp** - Major Enhancement to LLM Infrastructure (v0.10)
+## Quick demo
 
-This release introduces a comprehensive revamp of TorchRL's vLLM integration, delivering significant improvements in performance, scalability, and usability for large language model inference and training workflows:
-
-- 🔥 **AsyncVLLM Service**: Production-ready distributed vLLM inference with multi-replica scaling and automatic Ray actor management
-- ⚖️ **Multiple Load Balancing Strategies**: Routing strategies including prefix-aware, request-based, and KV-cache load balancing for optimal performance
-- 🏗️ **Unified vLLM Architecture**: New `RLvLLMEngine` interface standardizing all vLLM backends with simplified `vLLMUpdaterV2` for seamless weight updates
-- 🌐 **Distributed Data Loading**: New `RayDataLoadingPrimer` for shared, distributed data loading across multiple environments
-- 📈 **Enhanced Performance**: Native vLLM batching, concurrent request processing, and optimized resource allocation via Ray placement groups
+A local rollout is just a TensorDict passed between a PyTorch module and an
+environment:
 
 ```python
-# Simple AsyncVLLM usage - production ready!
-from torchrl.modules.llm import AsyncVLLM, vLLMWrapper
+import torch
+from tensordict.nn import TensorDictModule
+from torch import nn
 
-# Create distributed vLLM service with load balancing
-service = AsyncVLLM.from_pretrained(
-    "Qwen/Qwen2.5-7B",
-    num_devices=2,      # Tensor parallel across 2 GPUs
-    num_replicas=4,     # 4 replicas for high throughput
-    max_model_len=4096
+from torchrl.envs import PendulumEnv, StepCounter, TransformedEnv
+
+# A PyTorch-native environment with an ordinary transform stack.
+env = TransformedEnv(PendulumEnv(), StepCounter(max_steps=200))
+
+# Policies are regular nn.Modules wrapped with explicit TensorDict keys.
+policy = TensorDictModule(
+    nn.Sequential(
+        nn.LazyLinear(64),
+        nn.Tanh(),
+        nn.Linear(64, 1),
+        nn.Tanh(),
+    ),
+    in_keys=["observation"],
+    out_keys=["action"],
 )
 
-# Use with TorchRL's LLM wrappers
-wrapper = vLLMWrapper(service, input_mode="history")
-
-# Simplified weight updates
-from torchrl.collectors.llm import vLLMUpdaterV2
-updater = vLLMUpdaterV2(service)  # Auto-configures from engine
+rollout = env.rollout(max_steps=32, policy=policy)
+assert rollout.batch_size == torch.Size([32])
+assert rollout["next", "reward"].shape[:1] == torch.Size([32])
 ```
 
-This revamp positions TorchRL as the leading platform for scalable LLM inference and training, providing production-ready tools for both research and deployment scenarios.
+Nothing in this pattern is specific to Pendulum. The same keys-and-TensorDict
+interface is used by batched environments, multi-agent tasks, collectors,
+replay buffers, recurrent modules, transforms, and losses.
 
-### 🧪 PPOTrainer (Experimental) - High-Level Training Interface
+## What TorchRL is today
 
-TorchRL now includes an **experimental PPOTrainer** that provides a complete, configurable PPO training solution! This prototype feature combines TorchRL's modular components into a cohesive training system with sensible defaults:
+### TensorDict-first pipelines
 
-- 🎯 **Complete Training Pipeline**: Handles environment setup, data collection, loss computation, and optimization automatically
-- ⚙️ **Extensive Configuration**: Comprehensive Hydra-based config system for easy experimentation and hyperparameter tuning
-- 📊 **Built-in Logging**: Automatic tracking of rewards, actions, episode completion rates, and training statistics
-- 🔧 **Modular Design**: Built on existing TorchRL components (collectors, losses, replay buffers) for maximum flexibility
-- 📝 **Minimal Code**: Complete SOTA implementation in [just ~20 lines](sota-implementations/ppo_trainer/train.py)!
+RL code tends to accumulate special cases: tuples from one environment, dicts
+from another, separate arrays for recurrent states, masks next to data rather
+than inside it, and losses that silently assume a particular batch layout.
+TorchRL uses TensorDict to make those assumptions explicit.
 
-**Working Example**: See [`sota-implementations/ppo_trainer/`](sota-implementations/ppo_trainer/) for a complete, working PPO implementation that trains on Pendulum-v1 with full Hydra configuration support.
-
-**Prerequisites**: Requires Hydra for configuration management: `pip install "torchrl[utils]"`
-
-<details>
-  <summary>Complete Training Script (sota-implementations/ppo_trainer/train.py)</summary>
+TensorDict supports common tensor operations while preserving named fields:
 
 ```python
-import hydra
-from torchrl.trainers.algorithms.configs import *
+# These operations preserve the structure and operate on every compatible value.
+batch = torch.stack(list_of_tensordicts, dim=0)
+batch = batch.reshape(-1)
+batch = batch.to("cuda")
+mini_batch = batch[:128]
 
-@hydra.main(config_path="config", config_name="config", version_base="1.1")
-def main(cfg):
-    trainer = hydra.utils.instantiate(cfg.trainer)
-    trainer.train()
-
-if __name__ == "__main__":
-    main()
-```
-*Complete PPO training in ~20 lines with full configurability.*
-
-</details>
-
-<details>
-  <summary>API Usage Examples</summary>
-
-```bash
-# Basic usage - train PPO on Pendulum-v1 with default settings
-python sota-implementations/ppo_trainer/train.py
-
-# Custom configuration with command-line overrides
-python sota-implementations/ppo_trainer/train.py \
-    trainer.total_frames=2000000 \
-    training_env.create_env_fn.base_env.env_name=HalfCheetah-v4 \
-    networks.policy_network.num_cells=[256,256] \
-    optimizer.lr=0.0003
-
-# Use different environment and logger
-python sota-implementations/ppo_trainer/train.py \
-    env=gym \
-    training_env.create_env_fn.base_env.env_name=Walker2d-v4 \
-    logger=tensorboard
-
-# See all available options
-python sota-implementations/ppo_trainer/train.py --help
+# Nested keys make multi-agent, recurrent, and next-state data explicit.
+reward = batch["next", "reward"]
+agent_obs = batch["agents", "observation"]
+hidden = batch["recurrent_state", "h"]
 ```
 
-</details>
+This is the reason TorchRL components compose: a collector can emit a TensorDict,
+a replay buffer can store it without losing structure, a transform can add or
+remove keys, and a loss can read exactly the keys it needs.
 
-**Future Plans**: Additional algorithm trainers (SAC, TD3, DQN) and full integration of all TorchRL components within the configuration system are planned for upcoming releases.
+### Environments and transforms
 
-## LLM API - Complete Framework for Language Model Fine-tuning
+TorchRL includes native environments, wrappers for popular environment libraries,
+and vectorized containers for running many environments at once. The environment
+API exposes specs for observations, actions, rewards, and done flags, so policies
+and transforms can check shapes, devices, dtypes, and bounds before a training
+job runs for hours.
 
-TorchRL includes a comprehensive **LLM API** for post-training and fine-tuning of language models! This framework provides everything you need for RLHF, supervised fine-tuning, and tool-augmented training:
+Environment support includes:
 
-- 🤖 **Unified LLM Wrappers**: Seamless integration with Hugging Face models and vLLM inference engines
-- 💬 **Conversation Management**: Advanced [`History`](torchrl/data/llm/history.py) class for multi-turn dialogue with automatic chat template detection
-- 🛠️ **Tool Integration**: [Built-in support](torchrl/envs/llm/transforms/) for Python code execution, function calling, and custom tool transforms
-- 🎯 **Specialized Objectives**: [GRPO](torchrl/objectives/llm/grpo.py) (Group Relative Policy Optimization) and [SFT](torchrl/objectives/llm/sft.py) loss functions optimized for language models
-- ⚡ **High-Performance Collectors**: [Async data collection](torchrl/collectors/llm/) with distributed training support
-- 🔄 **Flexible Environments**: Transform-based architecture for reward computation, data loading, and conversation augmentation
+- PyTorch-native environments such as `PendulumEnv` and custom MuJoCo tasks.
+- Wrappers for Gymnasium, Gym, DM Control, Brax, Jumanji, PettingZoo, VMAS,
+  OpenSpiel, Safety-Gymnasium, Isaac Lab, and other optional libraries.
+- `SerialEnv`, `ParallelEnv`, and batched wrappers for local vectorization and
+  multiprocessing.
+- Environment transforms for observation normalization, image conversion,
+  reward transforms, action masking, action scaling, auto-reset, frame stacking,
+  state reconstruction, and more.
 
-The LLM API follows TorchRL's modular design principles, allowing you to mix and match components for your specific use case. Check out the [complete documentation](https://pytorch.org/rl/main/reference/llms.html) and [GRPO implementation example](https://github.com/pytorch/rl/tree/main/sota-implementations/grpo) to get started!
-
-<details>
-  <summary>Quick LLM API Example</summary>
+Transforms are first-class TorchRL modules. They can run on-device, participate
+in specs, and be inserted, removed, or composed without wrapping the whole
+environment in opaque adapter layers.
 
 ```python
-from torchrl.envs.llm import ChatEnv
-from torchrl.modules.llm import TransformersWrapper
-from torchrl.objectives.llm import GRPOLoss
-from torchrl.collectors.llm import LLMCollector
+from torchrl.envs import Compose, DoubleToFloat, ObservationNorm, TransformedEnv
+from torchrl.envs.libs.gym import GymEnv
 
-# Create environment with Python tool execution
-env = ChatEnv(
-    tokenizer=tokenizer,
-    system_prompt="You are an assistant that can execute Python code.",
-    batch_size=[1]
-).append_transform(PythonInterpreter())
+base_env = GymEnv("HalfCheetah-v4", device="cuda:0")
+env = TransformedEnv(
+    base_env,
+    Compose(
+        ObservationNorm(in_keys=["observation"]),
+        DoubleToFloat(),
+    ),
+)
+```
 
-# Wrap your language model
-llm = TransformersWrapper(
-    model=model,
-    tokenizer=tokenizer,
-    input_mode="history"
+### Collectors and execution models
+
+Collectors are the bridge between policies and environments. A collector owns
+the execution loop, batches trajectories, handles devices, and can update policy
+weights while environments keep running.
+
+TorchRL includes single-process, async, multiprocess, and distributed
+collectors. This lets the same policy and loss code be used across small smoke
+tests, GPU-heavy simulation, CPU environment farms, or asynchronous evaluation
+setups.
+
+```python
+from torchrl.collectors import Collector
+
+collector = Collector(
+    create_env_fn=env,
+    policy=policy,
+    frames_per_batch=1024,
+    total_frames=1_000_000,
 )
 
-# Set up GRPO training
-loss_fn = GRPOLoss(llm, critic, gamma=0.99)
-collector = LLMCollector(env, llm, frames_per_batch=100)
-
-# Training loop
 for data in collector:
-    loss = loss_fn(data)
-    loss.backward()
-    optimizer.step()
+    # data is a TensorDict with time, environment, and key structure preserved.
+    train_step(data)
 ```
 
-</details>
+For larger jobs, the collector family adds async execution, multiple worker
+processes, weight updaters, evaluator loops, profiling hooks, and fake-data
+helpers for testing downstream code without stepping an expensive environment.
 
-## Key features
+### Replay buffers and offline data
 
-- 🐍 **Python-first**: Designed with Python as the primary language for ease of use and flexibility
-- ⏱️ **Efficient**: Optimized for performance to support demanding RL research applications
-- 🧮 **Modular, customizable, extensible**: Highly modular architecture allows for easy swapping, transformation, or creation of new components
-- 📚 **Documented**: Thorough documentation ensures that users can quickly understand and utilize the library
-- ✅ **Tested**: Rigorously tested to ensure reliability and stability
-- ⚙️ **Reusable functionals**: Provides a set of highly reusable functions for cost functions, returns, and data processing
+TorchRL replay buffers are modular: storage, sampler, writer, collate function,
+transforms, prefetching, priority updates, and device movement are separate
+pieces. That makes it possible to use the same interface for simple in-memory
+replay, memmap-backed storage, prioritized replay, CUDA-aware sampling, offline
+datasets, HER, or custom storage layouts.
 
-### Design Principles
+```python
+from torchrl.data import LazyMemmapStorage, TensorDictPrioritizedReplayBuffer
 
-- 🔥 **Aligns with PyTorch ecosystem**: Follows the structure and conventions of popular PyTorch libraries
-  (e.g., dataset pillar, transforms, models, data utilities)
-- ➖ Minimal dependencies: Only requires Python standard library, NumPy, and PyTorch; optional dependencies for
-  common environment libraries (e.g., OpenAI Gym) and datasets (D4RL, OpenX...)
+buffer = TensorDictPrioritizedReplayBuffer(
+    storage=LazyMemmapStorage(1_000_000),
+    alpha=0.7,
+    beta=0.5,
+    batch_size=256,
+    prefetch=2,
+)
 
-Read the [full paper](https://arxiv.org/abs/2306.00577) for a more curated description of the library.
+buffer.extend(collector_batch)
+sample = buffer.sample()
+```
 
-## Getting started
+Replay buffers understand TensorDict structure, so they can store trajectories,
+nested agent data, recurrent states, HER relabeling metadata, or offline
+datasets without flattening everything into parallel Python containers.
 
-Check our [Getting Started tutorials](https://pytorch.org/rl/stable/index.html#getting-started) for quickly ramp up with the basic 
-features of the library!
+### Modules, distributions, and policies
 
-<p align="center">
-  <img src="docs/ppo.png"  width="800" >
-</p>
+TorchRL modules are ordinary PyTorch modules with explicit input and output
+keys. The library provides actors, critics, actor-critic operators, recurrent
+modules, distribution wrappers, exploration modules, world models, decision
+transformers, robot-learning models, and helper utilities for inferring specs
+from environments.
 
-## Documentation and knowledge base
+A stochastic actor can be assembled from familiar PyTorch layers:
 
-The TorchRL documentation can be found [here](https://pytorch.org/rl).
-It contains tutorials and the API reference.
+```python
+from tensordict.nn import TensorDictModule
+from tensordict.nn.distributions import NormalParamExtractor
+from torch import nn
+from torchrl.modules import ProbabilisticActor, TanhNormal
 
-TorchRL also provides a RL knowledge base to help you debug your code, or simply
-learn the basics of RL. Check it out [here](https://pytorch.org/rl/stable/reference/knowledge_base.html).
-
-We have some introductory videos for you to get to know the library better, check them out:
-
-- [TalkRL podcast](https://www.talkrl.com/episodes/vincent-moens-on-torchrl)
-- [TorchRL intro at PyTorch day 2022](https://youtu.be/cIKMhZoykEE)
-- [PyTorch 2.0 Q&A: TorchRL](https://www.youtube.com/live/myEfUoYrbts?feature=share)
-
-## Spotlight publications
-
-TorchRL being domain-agnostic, you can use it across many different fields. Here are a few examples:
-
-- [ACEGEN](https://pubs.acs.org/doi/10.1021/acs.jcim.4c00895): Reinforcement Learning of Generative Chemical Agents
-  for Drug Discovery
-- [BenchMARL](https://www.jmlr.org/papers/v25/23-1612.html): Benchmarking Multi-Agent Reinforcement Learning
-- [BricksRL](https://arxiv.org/abs/2406.17490): A Platform for Democratizing Robotics and Reinforcement Learning
-  Research and Education with LEGO
-- [OmniDrones](https://ieeexplore.ieee.org/abstract/document/10409589): An Efficient and Flexible Platform for Reinforcement Learning in Drone Control
-- [RL4CO](https://arxiv.org/abs/2306.17100): an Extensive Reinforcement Learning for Combinatorial Optimization Benchmark
-- [Robohive](https://proceedings.neurips.cc/paper_files/paper/2023/file/8a84a4341c375b8441b36836bb343d4e-Paper-Datasets_and_Benchmarks.pdf): A unified framework for robot learning
-
-## Writing simplified and portable RL codebase with `TensorDict`
-
-RL algorithms are very heterogeneous, and it can be hard to recycle a codebase
-across settings (e.g. from online to offline, from state-based to pixel-based 
-learning).
-TorchRL solves this problem through [`TensorDict`](https://github.com/pytorch/tensordict/),
-a convenient data structure<sup>(1)</sup> that can be used to streamline one's
-RL codebase.
-With this tool, one can write a *complete PPO training script in less than 100
-lines of code*!
-
-  <details>
-    <summary>Code</summary>
-
-  ```python
-  import torch
-  from tensordict.nn import TensorDictModule
-  from tensordict.nn.distributions import NormalParamExtractor
-  from torch import nn
-  
-  from torchrl.collectors import Collector
-  from torchrl.data.replay_buffers import TensorDictReplayBuffer, \
-    LazyTensorStorage, SamplerWithoutReplacement
-  from torchrl.envs.libs.gym import GymEnv
-  from torchrl.modules import ProbabilisticActor, ValueOperator, TanhNormal
-  from torchrl.objectives import ClipPPOLoss
-  from torchrl.objectives.value import GAE
-  
-  env = GymEnv("Pendulum-v1") 
-  model = TensorDictModule(
+params = TensorDictModule(
     nn.Sequential(
-        nn.Linear(3, 128), nn.Tanh(),
-        nn.Linear(128, 128), nn.Tanh(),
-        nn.Linear(128, 128), nn.Tanh(),
-        nn.Linear(128, 2),
-        NormalParamExtractor()
+        nn.LazyLinear(256),
+        nn.Tanh(),
+        nn.Linear(256, 2),
+        NormalParamExtractor(),
     ),
     in_keys=["observation"],
-    out_keys=["loc", "scale"]
-  )
-  critic = ValueOperator(
-    nn.Sequential(
-        nn.Linear(3, 128), nn.Tanh(),
-        nn.Linear(128, 128), nn.Tanh(),
-        nn.Linear(128, 128), nn.Tanh(),
-        nn.Linear(128, 1),
-    ),
-    in_keys=["observation"],
-  )
-  actor = ProbabilisticActor(
-    model,
+    out_keys=["loc", "scale"],
+)
+
+actor = ProbabilisticActor(
+    params,
     in_keys=["loc", "scale"],
+    out_keys=["action"],
     distribution_class=TanhNormal,
     distribution_kwargs={"low": -1.0, "high": 1.0},
-    return_log_prob=True
-    )
-  buffer = TensorDictReplayBuffer(
-    storage=LazyTensorStorage(1000),
-    sampler=SamplerWithoutReplacement(),
-    batch_size=50,
-    )
-  collector = Collector(
-    env,
-    actor,
-    frames_per_batch=1000,
-    total_frames=1_000_000,
-  )
-  loss_fn = ClipPPOLoss(actor, critic)
-  adv_fn = GAE(value_network=critic, average_gae=True, gamma=0.99, lmbda=0.95)
-  optim = torch.optim.Adam(loss_fn.parameters(), lr=2e-4)
-  
-  for data in collector:  # collect data
-    for epoch in range(10):
-        adv_fn(data)  # compute advantage
-        buffer.extend(data)
-        for sample in buffer:  # consume data
-            loss_vals = loss_fn(sample)
-            loss_val = sum(
-                value for key, value in loss_vals.items() if
-                key.startswith("loss")
-                )
-            loss_val.backward()
-            optim.step()
-            optim.zero_grad()
-    print(f"avg reward: {data['next', 'reward'].mean().item(): 4.4f}")
-  ```
-  </details>
+    return_log_prob=True,
+)
+```
 
-Here is an example of how the [environment API](https://pytorch.org/rl/stable/reference/envs.html)
-relies on tensordict to carry data from one function to another during a rollout
-execution:
-![Alt Text](https://github.com/pytorch/rl/blob/main/docs/source/_static/img/rollout.gif)
+The explicit key contract makes it clear what data a module consumes and
+produces, and it allows losses, collectors, and transforms to be reconfigured
+without editing the model itself.
 
-`TensorDict` makes it easy to reuse pieces of code across environments, models and
-algorithms.
-  <details>
-    <summary>Code</summary>
-  
-  For instance, here's how to code a rollout in TorchRL:
+### Objectives, returns, and trainers
 
-  ```diff
-  - obs, done = env.reset()
-  + tensordict = env.reset()
-  policy = SafeModule(
-      model,
-      in_keys=["observation_pixels", "observation_vector"],
-      out_keys=["action"],
-  )
-  out = []
-  for i in range(n_steps):
-  -     action, log_prob = policy(obs)
-  -     next_obs, reward, done, info = env.step(action)
-  -     out.append((obs, next_obs, action, log_prob, reward, done))
-  -     obs = next_obs
-  +     tensordict = policy(tensordict)
-  +     tensordict = env.step(tensordict)
-  +     out.append(tensordict)
-  +     tensordict = step_mdp(tensordict)  # renames next_observation_* keys to observation_*
-  - obs, next_obs, action, log_prob, reward, done = [torch.stack(vals, 0) for vals in zip(*out)]
-  + out = torch.stack(out, 0)  # TensorDict supports multiple tensor operations
-  ```
-  </details>
+TorchRL objectives are loss modules that read TensorDict keys, compute losses,
+and expose configurable key mappings. They cover policy-gradient methods,
+actor-critic algorithms, Q-learning, offline RL, imitation learning, model-based
+RL, and multi-agent RL.
 
-Using this, TorchRL abstracts away the input / output signatures of the modules, env, 
-collectors, replay buffers and losses of the library, allowing all primitives
-to be easily recycled across settings.
+Examples include PPO, SAC, DQN, TD3, REDQ, IQL, CQL, Decision Transformer,
+Dreamer, CrossQ, GAIL, behavior cloning, ACT, MAPPO, IPPO, and QMIX/VDN.
+Value-estimator utilities provide GAE, TD(lambda), V-trace, lambda returns,
+multi-agent advantages, and vectorized return computation.
 
-  <details>
-    <summary>Code</summary>
+```python
+from torchrl.objectives import ClipPPOLoss
+from torchrl.objectives.value import GAE
 
-  Here's another example of an off-policy training loop in TorchRL (assuming 
-  that a data collector, a replay buffer, a loss and an optimizer have been instantiated):
-  
-  ```diff
-  - for i, (obs, next_obs, action, hidden_state, reward, done) in enumerate(collector):
-  + for i, tensordict in enumerate(collector):
-  -     replay_buffer.add((obs, next_obs, action, log_prob, reward, done))
-  +     replay_buffer.add(tensordict)
-      for j in range(num_optim_steps):
-  -         obs, next_obs, action, hidden_state, reward, done = replay_buffer.sample(batch_size)
-  -         loss = loss_fn(obs, next_obs, action, hidden_state, reward, done)
-  +         tensordict = replay_buffer.sample(batch_size)
-  +         loss = loss_fn(tensordict)
-          loss.backward()
-          optim.step()
-          optim.zero_grad()
-  ```
-  This training loop can be reused across algorithms as it makes a minimal number of assumptions about the structure of the data.
-  </details>
+loss = ClipPPOLoss(actor_network=actor, critic_network=critic)
+advantage = GAE(value_network=critic, gamma=0.99, lmbda=0.95)
 
-  TensorDict supports multiple tensor operations on its device and shape
-  (the shape of TensorDict, or its batch size, is the common arbitrary N first dimensions of all its contained tensors):
+data = advantage(data)
+losses = loss(data)
+loss_value = losses["loss_objective"] + losses["loss_critic"] + losses["loss_entropy"]
+```
 
-  <details>
-    <summary>Code</summary>
+For higher-level workflows, TorchRL also provides trainer utilities and Hydra
+configuration dataclasses that assemble environments, networks, collectors,
+losses, optimizers, loggers, hooks, and schedules into reproducible recipes.
 
-  ```python
-  # stack and cat
-  tensordict = torch.stack(list_of_tensordicts, 0)
-  tensordict = torch.cat(list_of_tensordicts, 0)
-  # reshape
-  tensordict = tensordict.view(-1)
-  tensordict = tensordict.permute(0, 2, 1)
-  tensordict = tensordict.unsqueeze(-1)
-  tensordict = tensordict.squeeze(-1)
-  # indexing
-  tensordict = tensordict[:2]
-  tensordict[:, 2] = sub_tensordict
-  # device and memory location
-  tensordict.cuda()
-  tensordict.to("cuda:1")
-  tensordict.share_memory_()
-  ```
-  </details>
+### Multi-agent, model-based, and imitation learning
 
-TensorDict comes with a dedicated [`tensordict.nn`](https://pytorch.github.io/tensordict/reference/nn.html)
-module that contains everything you might need to write your model with it.
-And it is `functorch` and `torch.compile` compatible!
+Multi-agent data is represented as TensorDict structure rather than a separate
+parallel convention. Agent observations, actions, rewards, masks, and shared
+state can live under nested keys such as `("agents", "observation")`, while
+losses and modules declare which keys they use.
 
-  <details>
-    <summary>Code</summary>
+TorchRL supports multi-agent environments and algorithms through VMAS,
+PettingZoo, Melting Pot, SMACv2, OpenSpiel, multi-agent trainers, and dedicated
+objectives. The 0.13 line adds MAPPO, IPPO, `MultiAgentGAE`, `ValueNorm`,
+`PopArtValueNorm`, `RunningValueNorm`, and cross-agent critic utilities.
 
-  ```diff
-  transformer_model = nn.Transformer(nhead=16, num_encoder_layers=12)
-  + td_module = SafeModule(transformer_model, in_keys=["src", "tgt"], out_keys=["out"])
-  src = torch.rand((10, 32, 512))
-  tgt = torch.rand((20, 32, 512))
-  + tensordict = TensorDict({"src": src, "tgt": tgt}, batch_size=[20, 32])
-  - out = transformer_model(src, tgt)
-  + td_module(tensordict)
-  + out = tensordict["out"]
-  ```
+The same component style also covers model-based and imitation-learning work:
+Dreamer/DreamerV3 objectives and RSSM modules, Decision Transformer components,
+behavior cloning losses, and ACT-style action chunking all share the same
+TensorDict and key-dispatch conventions as the online RL algorithms.
 
-  The `TensorDictSequential` class allows to branch sequences of `nn.Module` instances in a highly modular way.
-  For instance, here is an implementation of a transformer using the encoder and decoder blocks:
-  ```python
-  encoder_module = TransformerEncoder(...)
-  encoder = TensorDictSequential(encoder_module, in_keys=["src", "src_mask"], out_keys=["memory"])
-  decoder_module = TransformerDecoder(...)
-  decoder = TensorDictModule(decoder_module, in_keys=["tgt", "memory"], out_keys=["output"])
-  transformer = TensorDictSequential(encoder, decoder)
-  assert transformer.in_keys == ["src", "src_mask", "tgt"]
-  assert transformer.out_keys == ["memory", "output"]
-  ```
+### Additional specialized workflows
 
-  `TensorDictSequential` allows to isolate subgraphs by querying a set of desired input / output keys:
-  ```python
-  transformer.select_subsequence(out_keys=["memory"])  # returns the encoder
-  transformer.select_subsequence(in_keys=["tgt", "memory"])  # returns the decoder
-  ```
-  </details>
+TorchRL also includes support for specialized workflows, including LLM
+post-training experiments. The LLM stack provides conversation containers,
+Hugging Face/vLLM/SGLang integration points, GRPO and SFT objectives, async
+collectors, weight-update helpers, and tool-use transforms. Entry points include
+the [LLM reference](https://pytorch.org/rl/stable/reference/llms.html) and the
+[GRPO implementation](sota-implementations/grpo).
 
-  Check [TensorDict tutorials](https://pytorch.github.io/tensordict/) to
-  learn more!
+### Performance and PyTorch integration
 
+TorchRL is designed to stay close to PyTorch execution. Components are
+TensorDict-aware, vectorized where possible, and increasingly friendly to
+`torch.compile`, CUDA, shared memory, memmaps, and distributed execution.
 
-## Features
+Performance-sensitive areas include:
 
-- A common [interface for environments](https://github.com/pytorch/rl/blob/main/torchrl/envs)
-  which supports common libraries (OpenAI gym, deepmind control lab, etc.)<sup>(1)</sup> and state-less execution 
-  (e.g. Model-based environments).
-  The [batched environments](https://github.com/pytorch/rl/blob/main/torchrl/envs/batched_envs.py) containers allow parallel execution<sup>(2)</sup>.
-  A common PyTorch-first class of [tensor-specification class](https://github.com/pytorch/rl/blob/main/torchrl/data/tensor_specs.py) is also provided.
-  TorchRL's environments API is simple but stringent and specific. Check the 
-  [documentation](https://pytorch.org/rl/stable/reference/envs.html)
-  and [tutorial](https://pytorch.org/rl/stable/tutorials/pendulum.html) to learn more!
-  <details>
-    <summary>Code</summary>
+- vectorized return and advantage computation;
+- recurrent GRU/LSTM reset handling with scan and Triton backends;
+- compact sequence layouts for recurrent value estimation;
+- async collectors and policy weight synchronization;
+- prioritized replay and CUDA-aware replay-buffer paths;
+- memmap-backed data movement for large offline or distributed jobs.
 
-  ```python
-  env_make = lambda: GymEnv("Pendulum-v1", from_pixels=True)
-  env_parallel = ParallelEnv(4, env_make)  # creates 4 envs in parallel
-  tensordict = env_parallel.rollout(max_steps=20, policy=None)  # random rollout (no policy given)
-  assert tensordict.shape == [4, 20]  # 4 envs, 20 steps rollout
-  env_parallel.action_spec.is_in(tensordict["action"])  # spec check returns True
-  ```
-  </details>
+## What is new in TorchRL 0.13
 
-- multiprocess and distributed [data collectors](https://github.com/pytorch/rl/blob/main/torchrl/collectors/collectors.py)<sup>(2)</sup>
-  that work synchronously or asynchronously.
-  Through the use of TensorDict, TorchRL's training loops are made very similar
-  to regular training loops in supervised
-  learning (although the "dataloader" -- read data collector -- is modified on-the-fly):
-  <details>
-    <summary>Code</summary>
+TorchRL 0.13 is a broad release. The most impactful changes are in recurrent
+RL performance, MuJoCo-native workflows, multi-agent training, model-based and
+imitation-learning components, replay/collector throughput, and compatibility
+with old or optional dependency stacks.
 
-  ```python
-  env_make = lambda: GymEnv("Pendulum-v1", from_pixels=True)
-  collector = MultiAsyncCollector(
-      [env_make, env_make],
-      policy=policy,
-      devices=["cuda:0", "cuda:0"],
-      total_frames=10000,
-      frames_per_batch=50,
-      ...
-  )
-  for i, tensordict_data in enumerate(collector):
-      loss = loss_module(tensordict_data)
-      loss.backward()
-      optim.step()
-      optim.zero_grad()
-      collector.update_policy_weights_()
-  ```
-  </details>
+### Recurrent RL
 
-  Check our [distributed collector examples](https://github.com/pytorch/rl/blob/main/examples/distributed/collectors) to
-  learn more about ultra-fast data collection with TorchRL.
+- Triton and scan recurrent backends for GRU/LSTM reset handling.
+- Recurrent integration tests and a recurrent state lifecycle guide.
+- Compact and shifted value-estimator improvements, chunked forwards, and a
+  dynamic value-estimator registry across loss modules.
+- Recurrent matmul precision controls exposed through public module utilities.
 
-- efficient<sup>(2)</sup> and generic<sup>(1)</sup> [replay buffers](https://github.com/pytorch/rl/blob/main/torchrl/data/replay_buffers/replay_buffers.py) with modularized storage:
-  <details>
-    <summary>Code</summary>
+### MuJoCo, robotics, and macro control
 
-  ```python
-  storage = LazyMemmapStorage(  # memory-mapped (physical) storage
-      cfg.buffer_size,
-      scratch_dir="/tmp/"
-  )
-  buffer = TensorDictPrioritizedReplayBuffer(
-      alpha=0.7,
-      beta=0.5,
-      collate_fn=lambda x: x,
-      pin_memory=device != torch.device("cpu"),
-      prefetch=10,  # multi-threaded sampling
-      storage=storage
-  )
-  ```
-  </details>
+- Custom MuJoCo environments with selectable physics backends.
+- New `MujocoEnv` task base plus locomotion tasks, `SatelliteEnv`, and
+  `CubeBowlEnv`.
+- Satellite MuJoCo SAC examples.
+- Macro-control primitives and tutorials for low-frequency semantic actions
+  expanded into multi-step low-level control sequences.
 
-  Replay buffers are also offered as wrappers around common datasets for *offline RL*:
-  <details>
-    <summary>Code</summary>
+### Multi-agent, imitation, and model-based RL
 
-  ```python
-  from torchrl.data.replay_buffers import SamplerWithoutReplacement
-  from torchrl.data.datasets.d4rl import D4RLExperienceReplay
-  data = D4RLExperienceReplay(
-      "maze2d-open-v0",
-      split_trajs=True,
-      batch_size=128,
-      sampler=SamplerWithoutReplacement(drop_last=True),
-  )
-  for sample in data:  # or alternatively sample = data.sample()
-      fun(sample)
-  ```
-  </details>
+- MAPPO and IPPO losses.
+- `MultiAgentGAE` and value-normalization utilities.
+- DreamerV3 losses and RSSM V3 modules.
+- `BCLoss`, `ACTLoss`, and `ACTModel` for behavior cloning and action chunking.
+- QMIX/VDN trainer configuration support and improved multi-agent trainer
+  ergonomics.
 
+### Data, transforms, and compatibility
 
-- cross-library [environment transforms](https://github.com/pytorch/rl/blob/main/torchrl/envs/transforms/transforms.py)<sup>(1)</sup>,
-  executed on device and in a vectorized fashion<sup>(2)</sup>,
-  which process and prepare the data coming out of the environments to be used by the agent:
-  <details>
-    <summary>Code</summary>
+- HER support through `HERReplayBuffer` and `HindsightStrategy`.
+- Action and observation transforms such as `ActionScaling`, `FlattenAction`,
+  `ExpandAs`, `NextObservationDelta`, `NextStateReconstructor`, and
+  `TerminateTransform`.
+- Async prioritized replay-buffer writes, ordered read/write APIs, optional
+  trajectory IDs, compact observations, and safer collector weight syncs.
+- Compatibility fixes across Gym/Atari, PettingZoo, Robohive, optional
+  dependency, setup, documentation, vLLM, and SGLang workflows.
 
-  ```python
-  env_make = lambda: GymEnv("Pendulum-v1", from_pixels=True)
-  env_base = ParallelEnv(4, env_make, device="cuda:0")  # creates 4 envs in parallel
-  env = TransformedEnv(
-      env_base,
-      Compose(
-          ToTensorImage(),
-          ObservationNorm(loc=0.5, scale=1.0)),  # executes the transforms once and on device
-  )
-  tensordict = env.reset()
-  assert tensordict.device == torch.device("cuda:0")
-  ```
-  Other transforms include: reward scaling (`RewardScaling`), shape operations (concatenation of tensors, unsqueezing etc.), concatenation of
-  successive operations (`CatFrames`), resizing (`Resize`) and many more.
+## Where to start
 
-  Unlike other libraries, the transforms are stacked as a list (and not wrapped in each other), which makes it
-  easy to add and remove them at will:
-  ```python
-  env.insert_transform(0, NoopResetEnv())  # inserts the NoopResetEnv transform at the index 0
-  ```
-  Nevertheless, transforms can access and execute operations on the parent environment:
-  ```python
-  transform = env.transform[1]  # gathers the second transform of the list
-  parent_env = transform.parent  # returns the base environment of the second transform, i.e. the base env + the first transform
-  ```
-  </details>
+| If you want to... | Start with... |
+| --- | --- |
+| Learn the basic environment and TensorDict loop | [Getting started](https://pytorch.org/rl/stable/index.html#getting-started) and the quick demo above |
+| Train a classic continuous-control agent | [PPO](sota-implementations/ppo/), [SAC](sota-implementations/sac/), or [TD3](sota-implementations/td3/) implementations |
+| Build custom environment preprocessing | [Environment transforms](https://pytorch.org/rl/stable/reference/envs_transforms.html) |
+| Scale data collection | [Collectors](https://pytorch.org/rl/stable/reference/collectors.html) and [distributed collectors](examples/distributed/collectors/) |
+| Store large or prioritized data | [Replay buffers](https://pytorch.org/rl/stable/reference/data_replaybuffers.html) |
+| Work with recurrent policies | [Recurrent modules](https://pytorch.org/rl/stable/reference/modules_rnn.html) and [state lifecycle docs](https://pytorch.org/rl/stable/reference/recurrent_state_lifecycle.html) |
+| Train multi-agent systems | [Multi-agent objectives](https://pytorch.org/rl/stable/reference/objectives_multiagent.html) and [multi-agent examples](examples/multiagent/) |
+| Explore MuJoCo macro policies | [Macro primitives](https://pytorch.org/rl/stable/reference/macro_primitives.html) and MuJoCo tutorials |
+| Try language-model post-training experiments | [LLM reference](https://pytorch.org/rl/stable/reference/llms.html) and [GRPO](sota-implementations/grpo/) |
 
-- various tools for distributed learning (e.g. [memory mapped tensors](https://github.com/pytorch/tensordict/blob/main/tensordict/memmap.py))<sup>(2)</sup>;
-- various [architectures](https://github.com/pytorch/rl/blob/main/torchrl/modules/models/) and models (e.g. [actor-critic](https://github.com/pytorch/rl/blob/main/torchrl/modules/tensordict_module/actors.py))<sup>(1)</sup>:
-  <details>
-    <summary>Code</summary>
+## Installation
 
-  ```python
-  # create an nn.Module
-  common_module = ConvNet(
-      bias_last_layer=True,
-      depth=None,
-      num_cells=[32, 64, 64],
-      kernel_sizes=[8, 4, 3],
-      strides=[4, 2, 1],
-  )
-  # Wrap it in a SafeModule, indicating what key to read in and where to
-  # write out the output
-  common_module = SafeModule(
-      common_module,
-      in_keys=["pixels"],
-      out_keys=["hidden"],
-  )
-  # Wrap the policy module in NormalParamsWrapper, such that the output
-  # tensor is split in loc and scale, and scale is mapped onto a positive space
-  policy_module = SafeModule(
-      NormalParamsWrapper(
-          MLP(num_cells=[64, 64], out_features=32, activation=nn.ELU)
-      ),
-      in_keys=["hidden"],
-      out_keys=["loc", "scale"],
-  )
-  # Use a SafeProbabilisticTensorDictSequential to combine the SafeModule with a
-  # SafeProbabilisticModule, indicating how to build the
-  # torch.distribution.Distribution object and what to do with it
-  policy_module = SafeProbabilisticTensorDictSequential(  # stochastic policy
-      policy_module,
-      SafeProbabilisticModule(
-          in_keys=["loc", "scale"],
-          out_keys="action",
-          distribution_class=TanhNormal,
-      ),
-  )
-  value_module = MLP(
-      num_cells=[64, 64],
-      out_features=1,
-      activation=nn.ELU,
-  )
-  # Wrap the policy and value function in a common module
-  actor_value = ActorValueOperator(common_module, policy_module, value_module)
-  # standalone policy from this
-  standalone_policy = actor_value.get_policy_operator()
-  ```
-  </details>
+TorchRL 0.13 targets Python 3.10+, PyTorch 2.1+, and TensorDict 0.13.x.
 
-- exploration [wrappers](https://github.com/pytorch/rl/blob/main/torchrl/modules/tensordict_module/exploration.py) and
-  [modules](https://github.com/pytorch/rl/blob/main/torchrl/modules/models/exploration.py) to easily swap between exploration and exploitation<sup>(1)</sup>:
-  <details>
-    <summary>Code</summary>
+Install the stable release:
 
-  ```python
-  policy_explore = EGreedyWrapper(policy)
-  with set_exploration_type(ExplorationType.RANDOM):
-      tensordict = policy_explore(tensordict)  # will use eps-greedy
-  with set_exploration_type(ExplorationType.DETERMINISTIC):
-      tensordict = policy_explore(tensordict)  # will not use eps-greedy
-  ```
-  </details>
+```bash
+pip install torchrl
+```
 
-- A series of efficient [loss modules](https://github.com/pytorch/rl/tree/main/torchrl/objectives)
-  and highly vectorized
-  [functional return and advantage](https://github.com/pytorch/rl/blob/main/torchrl/objectives/value/functional.py)
-  computation.
+Install common optional dependencies:
 
-  <details>
-    <summary>Code</summary>
+```bash
+pip install "torchrl[utils]"              # Hydra, logging, and development utilities
+pip install "torchrl[gym_continuous]"     # Gymnasium continuous-control environments
+pip install "torchrl[atari]"              # Atari support
+pip install "torchrl[offline-data]"       # Offline datasets and data helpers
+pip install "torchrl[marl]"               # Multi-agent environment libraries
+pip install "torchrl[llm-vllm]"           # LLM API with vLLM backend on Linux
+pip install "torchrl[llm-sglang]"         # LLM API with SGLang backend on Linux
+```
 
-  ### Loss modules
-  ```python
-  from torchrl.objectives import DQNLoss
-  loss_module = DQNLoss(value_network=value_network, gamma=0.99)
-  tensordict = replay_buffer.sample(batch_size)
-  loss = loss_module(tensordict)
-  ```
+Some optional libraries are platform- or Python-version-specific. If you are
+building a reproducible environment, install PyTorch first from the appropriate
+[PyTorch installation selector](https://pytorch.org/get-started/locally/), then
+install TorchRL and the optional extras you need.
 
-  ### Advantage computation
-  ```python
-  from torchrl.objectives.value.functional import vec_td_lambda_return_estimate
-  advantage = vec_td_lambda_return_estimate(gamma, lmbda, next_state_value, reward, done, terminated)
-  ```
+Install the nightly builds when working against nightly PyTorch:
 
-  </details>
+```bash
+pip install --pre tensordict-nightly torchrl-nightly
+```
 
-- a generic [trainer class](https://github.com/pytorch/rl/blob/main/torchrl/trainers/trainers.py)<sup>(1)</sup> that
-  executes the aforementioned training loop. Through a hooking mechanism,
-  it also supports any logging or data transformation operation at any given
-  time.
+For local development, keep the TorchRL and TensorDict checkouts on compatible
+branches and avoid re-resolving an already selected PyTorch build:
 
-- various [recipes](https://github.com/pytorch/rl/blob/main/torchrl/trainers/helpers/models.py) to build models that
-    correspond to the environment being deployed.
+```bash
+git clone https://github.com/pytorch/tensordict
+git clone https://github.com/pytorch/rl
+uv pip install --no-deps -e tensordict
+uv pip install --no-deps -e rl
+```
 
-- **LLM API**: Complete framework for language model fine-tuning with unified wrappers for Hugging Face and vLLM backends, 
-  conversation management with automatic chat template detection, tool integration (Python execution, function calling), 
-  specialized objectives (GRPO, SFT), and high-performance async collectors. Perfect for RLHF, supervised fine-tuning, 
-  and tool-augmented training scenarios.
-  <details>
-    <summary>Code</summary>
+The C++ extension paths used by prioritized replay buffers require a compatible
+PyTorch version. If you see undefined-symbol errors, consult the
+[versioning issues guide](knowledge_base/VERSIONING_ISSUES.md).
 
-  ```python
-  from torchrl.envs.llm import ChatEnv
-  from torchrl.modules.llm import TransformersWrapper
-  from torchrl.envs.llm.transforms import PythonInterpreter
-  
-  # Create environment with tool execution
-  env = ChatEnv(
-      tokenizer=tokenizer,
-      system_prompt="You can execute Python code.",
-      batch_size=[1]
-  ).append_transform(PythonInterpreter())
-  
-  # Wrap language model for training
-  llm = TransformersWrapper(
-      model=model,
-      tokenizer=tokenizer,
-      input_mode="history"
-  )
-  
-  # Multi-turn conversation with tool use
-  obs = env.reset(TensorDict({"query": "Calculate 2+2"}, batch_size=[1]))
-  llm_output = llm(obs)  # Generates response
-  obs = env.step(llm_output)  # Environment processes response
-  ```
-  </details>
+## Documentation and learning resources
 
-If you feel a feature is missing from the library, please submit an issue!
-If you would like to contribute to new features, check our [call for contributions](https://github.com/pytorch/rl/issues/509) and our [contribution](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) page.
+- [Stable documentation](https://pytorch.org/rl/stable/)
+- [API reference](https://pytorch.org/rl/stable/reference/index.html)
+- [Tutorials](https://pytorch.org/rl/stable#tutorials)
+- [Knowledge base](https://pytorch.org/rl/stable/reference/knowledge_base.html)
+- [Benchmarks](https://pytorch.github.io/rl/dev/bench/)
+- [Nightly CI status](https://pytorch.github.io/rl/nightly-status/)
 
+Introductory material:
 
-## Examples, tutorials and demos
+- [TorchRL paper](https://arxiv.org/abs/2306.00577)
+- [TalkRL podcast episode](https://www.talkrl.com/episodes/vincent-moens-on-torchrl)
+- [TorchRL intro at PyTorch Day 2022](https://youtu.be/cIKMhZoykEE)
+- [PyTorch 2.0 Q&A: TorchRL](https://www.youtube.com/live/myEfUoYrbts?feature=share)
 
-A series of [State-of-the-Art implementations](https://github.com/pytorch/rl/blob/main/sota-implementations/) are provided with an illustrative purpose:
+## Examples, tutorials, and implementations
 
-<table>
-  <tr>
-   <td><strong>Algorithm</strong>
-   </td>
-   <td><strong>Compile Support**</strong>
-   </td>
-   <td><strong>Tensordict-free API</strong>
-   </td>
-   <td><strong>Modular Losses</strong>
-   </td>
-   <td><strong>Continuous and Discrete</strong>
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/dqn">DQN</a>
-   </td>
-   <td> 1.9x
-   </td>
-   <td> +
-   </td>
-   <td> NA
-   </td>
-   <td> + (through <a href="https://pytorch.org/rl/stable/reference/generated/torchrl.envs.transforms.ActionDiscretizer.html?highlight=actiondiscretizer">ActionDiscretizer</a> transform)
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/ddpg/ddpg.py">DDPG</a>
-   </td>
-   <td> 1.87x
-   </td>
-   <td> +
-   </td>
-   <td> +
-   </td>
-   <td> - (continuous only)
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/iql/">IQL</a>
-   </td>
-   <td> 3.22x
-   </td>
-   <td> +
-   </td>
-   <td> +
-   </td>
-   <td> +
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/cql/cql_offline.py">CQL</a>
-   </td>
-   <td> 2.68x
-   </td>
-   <td> +
-   </td>
-   <td> +
-   </td>
-   <td> +
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/td3/td3.py">TD3</a>
-   </td>
-   <td> 2.27x
-   </td>
-   <td> +
-   </td>
-   <td> +
-   </td>
-   <td> - (continuous only)
-   </td>
-  </tr>
-  <tr>
-   <td>
-    <a href="https://github.com/pytorch/rl/blob/main/sota-implementations/td3_bc/td3_bc.py">TD3+BC</a>
-   </td>
-   <td> untested
-   </td>
-   <td> +
-   </td>
-   <td> +
-   </td>
-   <td> - (continuous only)
-   </td>
-  </tr>
-  <tr>
-   <td>
-    <a href="https://github.com/pytorch/rl/blob/main/examples/a2c/">A2C</a>
-   </td>
-   <td> 2.67x
-   </td>
-   <td> +
-   </td>
-   <td> -
-   </td>
-   <td> +
-   </td>
-  </tr>
-  <tr>
-   <td>
-    <a href="https://github.com/pytorch/rl/blob/main/sota-implementations/ppo/">PPO</a>
-   </td>
-   <td> 2.42x
-   </td>
-   <td> +
-   </td>
-   <td> -
-   </td>
-   <td> +
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/sac/sac.py">SAC</a>
-   </td>
-   <td> 2.62x
-   </td>
-   <td> +
-   </td>
-   <td> -
-   </td>
-   <td> +
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/redq/redq.py">REDQ</a>
-   </td>
-   <td> 2.28x
-   </td>
-   <td> +
-   </td>
-   <td> -
-   </td>
-   <td> - (continuous only)
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/dreamer/dreamer.py">Dreamer v1</a>
-   </td>
-   <td> untested
-   </td>
-   <td> +
-   </td>
-   <td> + (<a href="https://pytorch.org/rl/stable/reference/objectives.html#dreamer">different classes</a>)
-   </td>
-   <td> - (continuous only)
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/decision_transformer">Decision Transformers</a>
-   </td>
-   <td> untested
-   </td>
-   <td> +
-   </td>
-   <td> NA
-   </td>
-   <td> - (continuous only)
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/crossq">CrossQ</a>
-   </td>
-   <td> untested
-   </td>
-   <td> +
-   </td>
-   <td> +
-   </td>
-   <td> - (continuous only)
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/gail">Gail</a>
-   </td>
-   <td> untested
-   </td>
-   <td> +
-   </td>
-   <td> NA
-   </td>
-   <td> +
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/impala">Impala</a>
-   </td>
-   <td> untested
-   </td>
-   <td> +
-   </td>
-   <td> -
-   </td>
-   <td> +
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/multiagent/iql.py">IQL (MARL)</a>
-   </td>
-   <td> untested
-   </td>
-   <td> +
-   </td>
-   <td> +
-   </td>
-   <td> +
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/multiagent/maddpg_iddpg.py">DDPG (MARL)</a>
-   </td>
-   <td> untested
-   </td>
-   <td> +
-   </td>
-   <td> +
-   </td>
-   <td> - (continuous only)
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/multiagent/mappo_ippo.py">PPO (MARL)</a>
-   </td>
-   <td> untested
-   </td>
-   <td> +
-   </td>
-   <td> -
-   </td>
-   <td> +
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/multiagent/qmix_vdn.py">QMIX-VDN (MARL)</a>
-   </td>
-   <td> untested
-   </td>
-   <td> +
-   </td>
-   <td> NA
-   </td>
-   <td> +
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/multiagent/sac.py">SAC (MARL)</a>
-   </td>
-   <td> untested
-   </td>
-   <td> +
-   </td>
-   <td> -
-   </td>
-   <td> +
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/examples/rlhf">RLHF</a>
-   </td>
-   <td> NA
-   </td>
-   <td> +
-   </td>
-   <td> NA
-   </td>
-   <td> NA
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/pytorch/rl/blob/main/sota-implementations/grpo">LLM API (GRPO)</a>
-   </td>
-   <td> NA
-   </td>
-   <td> +
-   </td>
-   <td> +
-   </td>
-   <td> NA
-   </td>
-  </tr>
-</table>
+TorchRL ships examples for small features and complete training recipes:
 
-** The number indicates expected speed-up compared to eager mode when executed on CPU. Numbers may vary depending on
-  architecture and device.
+- [SOTA implementations](sota-implementations/) for PPO, SAC, DQN, TD3, REDQ,
+  Decision Transformer, Dreamer, CrossQ, GAIL, IMPALA, multi-agent algorithms,
+  GRPO, and more.
+- [Examples](examples/) for distributed collectors, replay buffers, RLHF,
+  MuJoCo satellite control, and other focused workflows.
+- [Tutorials](https://pytorch.org/rl/stable#tutorials) for environment design,
+  transforms, collectors, losses, recurrent state handling, MuJoCo macros, and
+  end-to-end training.
 
-and many more to come!
+The implementations are meant to be readable starting points, not black-box
+benchmarks. They show how TorchRL components fit together and can be copied into
+research code when a full trainer abstraction is not the right fit.
 
-[Code examples](examples/) displaying toy code snippets and training scripts are also available 
-- [LLM API & GRPO](sota-implementations/grpo) - Complete language model fine-tuning pipeline
-- [RLHF](examples/rlhf)
-- [Memory-mapped replay buffers](examples/torchrl_features)
+## Ecosystem and publications
 
+TorchRL is domain-agnostic and is used across robotics, control, simulation,
+drug discovery, multi-agent RL, combinatorial optimization, and research
+infrastructure. Selected projects and papers include:
 
-Check the [examples](https://github.com/pytorch/rl/blob/main/sota-implementations/) directory for more details 
-about handling the various configuration settings.
-
-We also provide [tutorials and demos](https://pytorch.org/rl/stable#tutorials) that give a sense of
-what the library can do.
+- [ACEGEN](https://pubs.acs.org/doi/10.1021/acs.jcim.4c00895): Reinforcement
+  learning of generative chemical agents for drug discovery.
+- [BenchMARL](https://www.jmlr.org/papers/v25/23-1612.html): Benchmarking
+  multi-agent reinforcement learning.
+- [BricksRL](https://arxiv.org/abs/2406.17490): A platform for democratizing
+  robotics and reinforcement learning research and education with LEGO.
+- [OmniDrones](https://ieeexplore.ieee.org/abstract/document/10409589): An
+  efficient and flexible platform for reinforcement learning in drone control.
+- [RL4CO](https://arxiv.org/abs/2306.17100): Reinforcement learning for
+  combinatorial optimization.
+- [Robohive](https://proceedings.neurips.cc/paper_files/paper/2023/file/8a84a4341c375b8441b36836bb343d4e-Paper-Datasets_and_Benchmarks.pdf):
+  A unified framework for robot learning.
 
 ## Citation
 
-If you're using TorchRL, please refer to this BibTeX entry to cite this work:
-```
+If you use TorchRL, please cite:
+
+```bibtex
 @misc{bou2023torchrl,
-      title={TorchRL: A data-driven decision-making library for PyTorch}, 
+      title={TorchRL: A data-driven decision-making library for PyTorch},
       author={Albert Bou and Matteo Bettini and Sebastian Dittert and Vikash Kumar and Shagun Sodhani and Xiaomeng Yang and Gianni De Fabritiis and Vincent Moens},
       year={2023},
       eprint={2306.00577},
@@ -1040,147 +524,27 @@ If you're using TorchRL, please refer to this BibTeX entry to cite this work:
 }
 ```
 
-## Installation
+## Asking questions
 
-### Create a new virtual environment:
-```bash
-python -m venv torchrl
-source torchrl/bin/activate  # On Windows use: venv\Scripts\activate
-```
-
-Or create a conda environment where the packages will be installed.
-
-```
-conda create --name torchrl python=3.10
-conda activate torchrl
-```
-
-### Install dependencies:
-
-#### PyTorch
-
-Depending on the use of torchrl that you want to make, you may want to 
-install the latest (nightly) PyTorch release or the latest stable version of PyTorch.
-See [here](https://pytorch.org/get-started/locally/) for a detailed list of commands, 
-including `pip3` or other special installation instructions.
-
-TorchRL offers a few pre-defined dependencies such as `"torchrl[tests]"`, `"torchrl[atari]"`, `"torchrl[utils]"` etc. 
-
-For the experimental training interface and configuration system, install:
-```bash
-pip3 install "torchrl[utils]"  # Includes hydra-core and other utilities
-``` 
-
-#### Torchrl
-
-You can install the **latest stable release** by using
-```bash
-pip3 install torchrl
-```
-This should work on linux (including AArch64 machines), Windows 10 and OsX (Metal chips only).
-On certain Windows machines (Windows 11), one should build the library locally.
-This can be done in two ways:
-
-```bash
-# Install and build locally v0.8.1 of the library without cloning
-pip3 install git+https://github.com/pytorch/rl@v0.8.1
-# Clone the library and build it locally
-git clone https://github.com/pytorch/tensordict
-git clone https://github.com/pytorch/rl
-pip install -e tensordict
-pip install -e rl
-```
-
-If you use `uv` (instead of `pip`) and you have already installed a specific PyTorch build (e.g. nightly),
-make sure `uv` doesn't re-resolve dependencies (which can downgrade PyTorch). Use `--no-deps` for the local installs:
-
-```bash
-uv pip install --no-deps -e tensordict
-uv pip install --no-deps -e rl
-```
-
-Note that tensordict local build requires `cmake` to be installed via [homebrew](https://brew.sh/) (MacOS) or another package manager
-such as `apt`, `apt-get`, `conda` or `yum` but NOT `pip`, as well as `pip install "pybind11[global]"`.   
-
-One can also build the wheels to distribute to co-workers using
-```bash
-pip install build
-python -m build --wheel
-```
-Your wheels will be stored there `./dist/torchrl<name>.whl` and installable via
-```bash
-pip install torchrl<name>.whl
-```
-
-The **nightly build** can be installed via
-```bash
-pip3 install tensordict-nightly torchrl-nightly
-```
-which we currently only ship for Linux machines.
-Importantly, the nightly builds require the nightly builds of PyTorch too.
-Also, a local build of torchrl with the nightly build of tensordict may fail - install both nightlies or both local builds but do not mix them.
-
-
-**Disclaimer**: As of today, TorchRL requires Python 3.10+ and is roughly compatible with any pytorch version >= 2.1. Installing it will not
-directly require a newer version of pytorch to be installed. Indirectly though, tensordict still requires the latest
-PyTorch to be installed and we are working hard to loosen that requirement. 
-The C++ binaries of TorchRL (mainly for prioritized replay buffers) will only work with PyTorch 2.7.0 and above.
-Some features (e.g., working with nested jagged tensors) may also
-be limited with older versions of pytorch. It is recommended to use the latest TorchRL with the latest PyTorch version
-unless there is a strong reason not to do so.
-
-**Optional dependencies**
-
-The following libraries can be installed depending on the usage one wants to
-make of torchrl:
-```
-# diverse
-pip3 install tqdm tensorboard "hydra-core>=1.1" hydra-submitit-launcher
-
-# rendering
-pip3 install "moviepy<2.0.0"
-
-# deepmind control suite
-pip3 install dm_control
-
-# gym, atari games
-pip3 install "gym[atari]" "gym[accept-rom-license]" pygame
-
-# tests
-pip3 install pytest pyyaml pytest-instafail
-
-# tensorboard
-pip3 install tensorboard
-
-# wandb
-pip3 install wandb
-```
-
-Versioning issues can cause error message of the type ```undefined symbol```
-and such. For these, refer to the [versioning issues document](https://github.com/pytorch/rl/blob/main/knowledge_base/VERSIONING_ISSUES.md)
-for a complete explanation and proposed workarounds.
-
-## Asking a question
-
-If you spot a bug in the library, please raise an issue in this repo.
-
-If you have a more generic question regarding RL in PyTorch, post it on
-the [PyTorch forum](https://discuss.pytorch.org/c/reinforcement-learning/6).
+If you find a bug, please open an issue in this repository. For broader RL in
+PyTorch questions, use the [PyTorch reinforcement learning forum](https://discuss.pytorch.org/c/reinforcement-learning/6).
 
 ## Contributing
 
-Internal collaborations to torchrl are welcome! Feel free to fork, submit issues and PRs.
-You can checkout the detailed contribution guide [here](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md).
-As mentioned above, a list of open contributions can be found in [here](https://github.com/pytorch/rl/issues/509).
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full
+contribution guide and the [call for contributions](https://github.com/pytorch/rl/issues/509)
+for open areas where help is especially useful.
 
-Contributors are recommended to install [pre-commit hooks](https://pre-commit.com/) (using `pre-commit install`). pre-commit will check for linting related issues when the code is committed locally. You can disable th check by appending `-n` to your commit command: `git commit -m <commit message> -n`
+For local development, install pre-commit hooks with:
 
+```bash
+pre-commit install
+```
 
-## Disclaimer
+## Status and license
 
-This library is released as a PyTorch beta feature.
-BC-breaking changes are likely to happen but they will be introduced with a deprecation
-warranty after a few release cycles.
+TorchRL is released as a PyTorch beta feature. Breaking changes can happen, but
+TorchRL aims to introduce them with deprecation warnings over multiple release
+cycles.
 
-# License
-TorchRL is licensed under the MIT License. See [LICENSE](https://github.com/pytorch/rl/blob/main/LICENSE) for details.
+TorchRL is licensed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

- Refresh the top-level README for the TorchRL 0.13 release cycle.
- Replace stale release-era highlights with a current high-level overview of TorchRL today.
- Add a compact quick demo and reorganize the README around TensorDict-first pipelines, environments/transforms, collectors/replay buffers, objectives/modules/trainers, LLM post-training, performance, installation, and learning resources.

## Validation

- `git diff --check README.md`
- Runtime demo not executed in this local environment because PyTorch is not installed; this is a documentation-only change.
