### PR TITLE
[CI] Fix release CI dependency checks

### DIFF
--- a/.github/unittest/linux/scripts/run_all.sh
+++ b/.github/unittest/linux/scripts/run_all.sh
@@ -250,7 +250,7 @@ else
   uv_pip_install -e . --no-build-isolation --no-deps
 fi
 
-# install torchcodec (from source for nightly, from PyPI for stable)
+# install torchcodec (from source for nightly, from the PyTorch wheel index for stable)
 if [[ "$TORCH_VERSION" == "nightly" ]]; then
   torchcodec_dir=$(mktemp -d)
   git clone --depth 1 https://github.com/pytorch/torchcodec.git "$torchcodec_dir"
@@ -260,7 +260,7 @@ if [[ "$TORCH_VERSION" == "nightly" ]]; then
     uv_pip_install --no-build-isolation "$torchcodec_dir"
   rm -rf "$torchcodec_dir"
 else
-  uv_pip_install torchcodec
+  uv_pip_install --index-url "https://download.pytorch.org/whl/${CU_VERSION}" torchcodec
 fi
 
 if [ "${CU_VERSION:-}" != cpu ] ; then

--- a/.github/unittest/linux_libs/scripts_brax/install.sh
+++ b/.github/unittest/linux_libs/scripts_brax/install.sh
@@ -44,7 +44,11 @@ else
 fi
 
 # install tensordict
-pip install git+https://github.com/pytorch/tensordict.git --progress-bar off
+if [[ "$RELEASE" == 0 ]]; then
+  pip install git+https://github.com/pytorch/tensordict.git --progress-bar off
+else
+  pip install tensordict --progress-bar off
+fi
 
 # smoke test
 python -c "import functorch;import tensordict"

--- a/.github/unittest/linux_olddeps/scripts_gym_0_13/batch_scripts.sh
+++ b/.github/unittest/linux_olddeps/scripts_gym_0_13/batch_scripts.sh
@@ -7,5 +7,10 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 
 $DIR/install.sh
 PYTHON=./env/bin/python bash "$(git rev-parse --show-toplevel)/.github/unittest/helpers/assert_torch_version.sh" stable
-PYTHON=./env/bin/python bash "$(git rev-parse --show-toplevel)/.github/unittest/helpers/assert_torch_tensordict_versions.sh" stable main
+if [[ "$RELEASE" == 0 ]]; then
+  tensordict_expectation=main
+else
+  tensordict_expectation=stable
+fi
+PYTHON=./env/bin/python bash "$(git rev-parse --show-toplevel)/.github/unittest/helpers/assert_torch_tensordict_versions.sh" stable "$tensordict_expectation"
 $DIR/run_test.sh

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -839,8 +839,7 @@ def check_env_specs(
 
             fake = fake.apply(expand, real, named=True, nested_keys=True)
             if (
-                _zeros_like_on_common_device(real)
-                != _zeros_like_on_common_device(fake)
+                _zeros_like_on_common_device(real) != _zeros_like_on_common_device(fake)
             ).any():
                 raise AssertionError(zeroing_err_msg())
 

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -818,6 +818,9 @@ def check_env_specs(
             f"Check for discrepancies:\nFake=\n{fake_tensordict}\nReal=\n{real_tensordict}"
         )
 
+    def _zeros_like_on_common_device(data):
+        return torch.zeros_like(data).to(torch.device("cpu"))
+
     from torchrl.envs.common import _has_dynamic_specs
 
     if _has_dynamic_specs(env.specs):
@@ -835,7 +838,10 @@ def check_env_specs(
                     ) from e
 
             fake = fake.apply(expand, real, named=True, nested_keys=True)
-            if (torch.zeros_like(real) != torch.zeros_like(fake)).any():
+            if (
+                _zeros_like_on_common_device(real)
+                != _zeros_like_on_common_device(fake)
+            ).any():
                 raise AssertionError(zeroing_err_msg())
 
             # Checks shapes and eventually dtypes of keys at all nesting levels
@@ -843,8 +849,8 @@ def check_env_specs(
 
     else:
         if (
-            torch.zeros_like(fake_tensordict_select)
-            != torch.zeros_like(real_tensordict_select)
+            _zeros_like_on_common_device(fake_tensordict_select)
+            != _zeros_like_on_common_device(real_tensordict_select)
         ).any():
             raise AssertionError(zeroing_err_msg())
 

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -1665,14 +1665,20 @@ class GRU(GRUBase):
             _maybe_warm_scan_backward(device)
 
     @staticmethod
-    def _gru_cell(x, hx, weight_ih, bias_ih, weight_hh, bias_hh):
+    def _gru_cell(
+        x, hx, weight_ih, bias_ih, weight_hh, bias_hh, hidden_size: int | None = None
+    ):
         x = x.view(-1, x.size(1))
 
         gate_x = F.linear(x, weight_ih, bias_ih)
         gate_h = F.linear(hx, weight_hh, bias_hh)
 
-        i_r, i_i, i_n = gate_x.chunk(3, 1)
-        h_r, h_i, h_n = gate_h.chunk(3, 1)
+        if hidden_size is None:
+            i_r, i_i, i_n = gate_x.chunk(3, 1)
+            h_r, h_i, h_n = gate_h.chunk(3, 1)
+        else:
+            i_r, i_i, i_n = gate_x.split(hidden_size, 1)
+            h_r, h_i, h_n = gate_h.split(hidden_size, 1)
 
         resetgate = (i_r + h_r).sigmoid()
         inputgate = (i_i + h_i).sigmoid()
@@ -1728,6 +1734,7 @@ class GRU(GRUBase):
                     bias_ih[layer],
                     weight_hh[layer],
                     bias_hh[layer],
+                    self.hidden_size,
                 )
                 if m_t is not None:
                     # Freeze hidden state for batch entries whose trajectory
@@ -1774,6 +1781,7 @@ class GRU(GRUBase):
             mask = torch.ones(x.shape[0], x.shape[1], dtype=torch.bool, device=x.device)
 
         num_layers = self.num_layers
+        hidden_size = self.hidden_size
 
         def step(carry, inputs):
             h_layers = carry  # [num_layers, B, H]
@@ -1790,6 +1798,7 @@ class GRU(GRUBase):
                     bias_ihs[layer],
                     weight_hhs[layer],
                     bias_hhs[layer],
+                    hidden_size,
                 )
                 h_new = torch.where(m_t, h_new, h_prev)
                 new_h.append(h_new)
@@ -2554,6 +2563,7 @@ class GRUModule(ModuleBase):
         is_init = _canonical_contiguous(is_init.transpose(0, 1))
         reset_hidden = _canonical_contiguous(hidden_in.permute(1, 2, 0, 3))
         num_layers = self.gru.num_layers
+        hidden_size = self.gru.hidden_size
 
         def step(carry, inputs):
             h_layers = carry
@@ -2570,6 +2580,7 @@ class GRUModule(ModuleBase):
                     bias_ihs[layer],
                     weight_hhs[layer],
                     bias_hhs[layer],
+                    hidden_size,
                 )
                 new_h.append(h_new)
                 x_t = h_new


### PR DESCRIPTION
## Summary
- install stable TorchCodec from the matching PyTorch wheel index so CPU release jobs get CPU TorchCodec wheels instead of CUDA-linked PyPI wheels
- keep TensorDict source expectations aligned with release vs main CI for brax and olddeps jobs
- make `check_env_specs` compare zeroed fake/real TensorDicts on a common CPU device for mixed-device transformed envs
- avoid symbolic `chunk(3, ...)` guards in GRU scan paths by splitting gates with the module's static hidden size

## Validation
- `bash -n .github/unittest/linux/scripts/run_all.sh .github/unittest/linux_libs/scripts_brax/install.sh .github/unittest/linux_olddeps/scripts_gym_0_13/batch_scripts.sh`
- `.venv/bin/python -m py_compile torchrl/envs/utils.py torchrl/modules/tensordict_module/rnn.py`
- `.venv/bin/python -m pytest test/modules/test_rnn.py::TestGRUModule::test_gru_module_scan_backend_matches_pad -q`
- `.venv/bin/python -m pytest test/modules/test_rnn.py::TestGRUModule::test_gru_module_scan_non_canonical_hidden_strides -q`
- `.venv/bin/python -m pytest test/transforms/test_device_transforms.py::TestDeviceCastTransformPart::test_serial_trans_env_check -q`

Note: the local macOS parallel device-cast variant still crashes workers when the fixture selects MPS and forks; the Linux CI failure this PR targets is the CUDA/CPU TensorDict comparison in `check_env_specs`.
