### PR TITLE
[Benchmark] Add RNN reset rollout benchmarks

### DIFF
--- a/benchmarks/test_rnn_reset_backends_benchmark.py
+++ b/benchmarks/test_rnn_reset_backends_benchmark.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Iterator
 from typing import Literal
 
 import pytest
@@ -78,6 +79,13 @@ def _call(module: torch.nn.Module, tensordict: TensorDict) -> TensorDict:
         return module(tensordict)
 
 
+@pytest.fixture(autouse=True)
+def _reset_compile_cache() -> Iterator[None]:
+    torch.compiler.reset()
+    yield
+    torch.compiler.reset()
+
+
 @pytest.mark.parametrize("rnn_type", ["gru", "lstm"])
 @pytest.mark.parametrize("reset_seed", [0])
 @pytest.mark.parametrize(
@@ -109,26 +117,13 @@ def test_rnn_rollout_with_intermediate_resets(
         if backend == "triton":
             pytest.skip(f"triton recurrent backend unavailable: {err}")
         raise
-    prev_capture = torch._dynamo.config.capture_scalar_outputs
-    torch._dynamo.config.capture_scalar_outputs = compile
-    try:
-        if compile:
-            module = torch.compile(module)
-        for _ in range(3 if compile else 1):
-            try:
-                _call(module, tensordict)
-                _sync(device)
-            except Exception as err:
-                if compile:
-                    pytest.xfail(
-                        f"torch.compile currently fails for public {rnn_type} "
-                        f"{backend} TensorDict rollout: {err}"
-                    )
-                raise
-        benchmark(_call, module, tensordict)
+    if compile:
+        module = torch.compile(module)
+    for _ in range(3 if compile else 1):
+        _call(module, tensordict)
         _sync(device)
-    finally:
-        torch._dynamo.config.capture_scalar_outputs = prev_capture
+    benchmark(_call, module, tensordict)
+    _sync(device)
 
 
 if __name__ == "__main__":

--- a/benchmarks/test_rnn_reset_backends_benchmark.py
+++ b/benchmarks/test_rnn_reset_backends_benchmark.py
@@ -1,0 +1,429 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from typing import Literal
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from torchrl.modules import GRUModule, LSTMModule
+from torchrl.objectives.value.functional import _split_and_pad_sequence
+from torchrl.objectives.value.utils import _get_num_per_traj_init
+
+
+RNNType = Literal["gru", "lstm"]
+Backend = Literal["cudnn", "scan", "triton"]
+
+
+def _device() -> torch.device:
+    if torch.cuda.device_count():
+        return torch.device("cuda:0")
+    return torch.device("cpu")
+
+
+def _sync(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def _make_modules(
+    rnn_type: RNNType,
+    input_size: int,
+    hidden_size: int,
+    num_layers: int,
+    device: torch.device,
+) -> tuple[
+    GRUModule | LSTMModule,
+    GRUModule | LSTMModule,
+    GRUModule | LSTMModule,
+    GRUModule | LSTMModule | None,
+]:
+    if rnn_type == "lstm":
+        cudnn_pad = LSTMModule(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            in_keys=["obs", "hidden0", "hidden1"],
+            out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
+            default_recurrent_mode=True,
+            device=device,
+        )
+        scan_eager = LSTMModule(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            in_keys=["obs", "hidden0", "hidden1"],
+            out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
+            recurrent_backend="scan",
+            default_recurrent_mode=True,
+            device=device,
+        )
+        scan_compile = LSTMModule(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            in_keys=["obs", "hidden0", "hidden1"],
+            out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
+            recurrent_backend="scan",
+            default_recurrent_mode=True,
+            python_based=True,
+            device=device,
+        )
+        triton_mod = None
+        if device.type == "cuda":
+            try:
+                triton_mod = LSTMModule(
+                    input_size=input_size,
+                    hidden_size=hidden_size,
+                    num_layers=num_layers,
+                    in_keys=["obs", "hidden0", "hidden1"],
+                    out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
+                    recurrent_backend="triton",
+                    default_recurrent_mode=True,
+                    device=device,
+                )
+            except RuntimeError:
+                triton_mod = None
+    else:
+        cudnn_pad = GRUModule(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            in_keys=["obs", "hidden"],
+            out_keys=["feat", ("next", "hidden")],
+            default_recurrent_mode=True,
+            device=device,
+        )
+        scan_eager = GRUModule(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            in_keys=["obs", "hidden"],
+            out_keys=["feat", ("next", "hidden")],
+            recurrent_backend="scan",
+            default_recurrent_mode=True,
+            device=device,
+        )
+        scan_compile = GRUModule(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            in_keys=["obs", "hidden"],
+            out_keys=["feat", ("next", "hidden")],
+            recurrent_backend="scan",
+            default_recurrent_mode=True,
+            python_based=True,
+            device=device,
+        )
+        triton_mod = None
+        if device.type == "cuda":
+            try:
+                triton_mod = GRUModule(
+                    input_size=input_size,
+                    hidden_size=hidden_size,
+                    num_layers=num_layers,
+                    in_keys=["obs", "hidden"],
+                    out_keys=["feat", ("next", "hidden")],
+                    recurrent_backend="triton",
+                    default_recurrent_mode=True,
+                    device=device,
+                )
+            except RuntimeError:
+                triton_mod = None
+
+    scan_eager.load_state_dict(cudnn_pad.state_dict())
+    scan_compile.load_state_dict(cudnn_pad.state_dict())
+    if triton_mod is not None:
+        triton_mod.load_state_dict(cudnn_pad.state_dict())
+    return cudnn_pad, scan_eager, scan_compile, triton_mod
+
+
+def _make_intermediate_resets(
+    batch: int,
+    steps: int,
+    reset_prob: float,
+    device: torch.device,
+    generator: torch.Generator,
+) -> torch.Tensor:
+    is_init = torch.rand(
+        batch,
+        steps,
+        1,
+        device=device,
+        generator=generator,
+    ).lt(reset_prob)
+    # Keep the first step as a normal continuation so the benchmark measures
+    # intermediate reset handling rather than a full-sequence initial reset.
+    is_init[:, 0] = False
+    return is_init
+
+
+def _execute(
+    fn: Callable[[TensorDict], object],
+    tensordict: TensorDict,
+    device: torch.device,
+) -> object:
+    with torch.inference_mode():
+        result = fn(tensordict)
+    _sync(device)
+    return result
+
+
+def _make_tensordict(
+    rnn_type: RNNType,
+    obs: torch.Tensor,
+    hidden: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+    is_init: torch.Tensor,
+) -> TensorDict:
+    if rnn_type == "gru":
+        return TensorDict(
+            {
+                "obs": obs,
+                "hidden": hidden,
+                "is_init": is_init,
+            },
+            obs.shape[:2],
+        )
+    hidden0, hidden1 = hidden
+    return TensorDict(
+        {
+            "obs": obs,
+            "hidden0": hidden0,
+            "hidden1": hidden1,
+            "is_init": is_init,
+        },
+        obs.shape[:2],
+    )
+
+
+def _make_backend_tensordict(
+    rnn_type: RNNType,
+    backend: Backend,
+    obs: torch.Tensor,
+    hidden: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+    is_init: torch.Tensor,
+) -> tuple[TensorDict, torch.Tensor | None]:
+    tensordict = _make_tensordict(rnn_type, obs, hidden, is_init)
+    if backend != "cudnn":
+        return tensordict, None
+
+    splits = _get_num_per_traj_init(is_init.squeeze(-1))
+    # The pad/cuDNN backend consumes padded trajectory chunks. Create that
+    # TensorDict once so the compiled callable still receives a TensorDict
+    # input, while the timed region targets the recurrent backend rather than
+    # data-dependent split/pad bookkeeping.
+    return _split_and_pad_sequence(tensordict, splits), splits
+
+
+def _make_backend_fn(
+    rnn_type: RNNType,
+    backend: Backend,
+    cudnn_pad,
+    scan_mod,
+    triton_mod,
+    splits: torch.Tensor | None,
+) -> Callable[[TensorDict], object]:
+    if backend == "cudnn":
+        if splits is None:
+            raise RuntimeError("cudnn backend requires precomputed trajectory splits")
+        if rnn_type == "gru":
+
+            def fn(tensordict: TensorDict) -> object:
+                obs = tensordict["obs"]
+                return cudnn_pad._gru(
+                    obs,
+                    tensordict.shape[0],
+                    tensordict.shape[1],
+                    obs.device,
+                    obs.dtype,
+                    tensordict["hidden"],
+                    splits=splits,
+                    is_init=None,
+                    backend="pad",
+                )
+
+            return fn
+
+        def fn(tensordict: TensorDict) -> object:
+            obs = tensordict["obs"]
+            return cudnn_pad._lstm(
+                obs,
+                tensordict.shape[0],
+                tensordict.shape[1],
+                obs.device,
+                obs.dtype,
+                tensordict["hidden0"],
+                tensordict["hidden1"],
+                splits=splits,
+                is_init=None,
+                backend="pad",
+            )
+
+        return fn
+
+    if backend == "scan":
+        if rnn_type == "gru":
+
+            def fn(tensordict: TensorDict) -> object:
+                obs = tensordict["obs"]
+                return scan_mod._gru(
+                    obs,
+                    tensordict.shape[0],
+                    tensordict.shape[1],
+                    obs.device,
+                    obs.dtype,
+                    tensordict["hidden"],
+                    None,
+                    is_init=tensordict["is_init"].squeeze(-1),
+                    backend="scan",
+                )
+
+            return fn
+
+        def fn(tensordict: TensorDict) -> object:
+            obs = tensordict["obs"]
+            return scan_mod._lstm(
+                obs,
+                tensordict.shape[0],
+                tensordict.shape[1],
+                obs.device,
+                obs.dtype,
+                tensordict["hidden0"],
+                tensordict["hidden1"],
+                None,
+                is_init=tensordict["is_init"].squeeze(-1),
+                backend="scan",
+            )
+
+        return fn
+
+    if triton_mod is None:
+        raise RuntimeError("triton recurrent backend is unavailable")
+    if rnn_type == "gru":
+
+        def fn(tensordict: TensorDict) -> object:
+            obs = tensordict["obs"]
+            return triton_mod._gru(
+                obs,
+                tensordict.shape[0],
+                tensordict.shape[1],
+                obs.device,
+                obs.dtype,
+                tensordict["hidden"],
+                None,
+                is_init=tensordict["is_init"].squeeze(-1),
+                backend="triton",
+            )
+
+        return fn
+
+    def fn(tensordict: TensorDict) -> object:
+        obs = tensordict["obs"]
+        return triton_mod._lstm(
+            obs,
+            tensordict.shape[0],
+            tensordict.shape[1],
+            obs.device,
+            obs.dtype,
+            tensordict["hidden0"],
+            tensordict["hidden1"],
+            None,
+            is_init=tensordict["is_init"].squeeze(-1),
+            backend="triton",
+        )
+
+    return fn
+
+
+@pytest.mark.parametrize("rnn_type", ["gru", "lstm"])
+@pytest.mark.parametrize("reset_seed", [0])
+@pytest.mark.parametrize(
+    ("backend", "compile"),
+    [
+        ("cudnn", False),
+        ("cudnn", True),
+        ("scan", False),
+        ("scan", True),
+        pytest.param("triton", False, marks=pytest.mark.gpu),
+        pytest.param("triton", True, marks=pytest.mark.gpu),
+    ],
+)
+def test_rnn_rollout_with_intermediate_resets(
+    benchmark,
+    rnn_type: RNNType,
+    reset_seed: int,
+    backend: Backend,
+    compile: bool,
+) -> None:
+    device = _device()
+    if backend == "triton" and device.type != "cuda":
+        pytest.skip("triton recurrent backend requires CUDA")
+
+    batch = 128
+    steps = 128
+    input_size = 32
+    hidden_size = 256
+    num_layers = 1
+    reset_prob = 0.03
+    generator = torch.Generator(device=device).manual_seed(reset_seed)
+    cudnn_pad, scan_eager, scan_compile, triton_mod = _make_modules(
+        rnn_type,
+        input_size,
+        hidden_size,
+        num_layers,
+        device,
+    )
+    obs = torch.randn(batch, steps, input_size, device=device, generator=generator)
+    hidden0 = torch.zeros(batch, steps, num_layers, hidden_size, device=device)
+    hidden = hidden0 if rnn_type == "gru" else (hidden0, torch.zeros_like(hidden0))
+    is_init = _make_intermediate_resets(
+        batch,
+        steps,
+        reset_prob,
+        device,
+        generator,
+    )
+
+    if backend == "triton" and triton_mod is None:
+        pytest.skip("triton recurrent backend unavailable for this configuration")
+
+    # Build a direct recurrent rollout whose callable accepts a TensorDict, so
+    # compile-mode benchmarks include TensorDict input guards. The cudnn path
+    # still receives precomputed intermediate-reset segments via ``splits``.
+    scan_mod = scan_compile if compile else scan_eager
+    tensordict, splits = _make_backend_tensordict(
+        rnn_type,
+        backend,
+        obs,
+        hidden,
+        is_init,
+    )
+    fn = _make_backend_fn(
+        rnn_type,
+        backend,
+        cudnn_pad,
+        scan_mod,
+        triton_mod,
+        splits,
+    )
+    if compile:
+        fn = torch.compile(fn, fullgraph=backend == "scan")
+
+    # Trigger setup and compilation before timing steady-state rollout
+    # throughput. Compiled runs get three warmup executions to stabilize the
+    # compiled path before pytest-benchmark starts timing. The benchmark result
+    # is uploaded by the continuous benchmark workflow and stored on gh-pages.
+    for _ in range(3 if compile else 1):
+        _execute(fn, tensordict, device)
+    benchmark(_execute, fn, tensordict, device)
+
+
+if __name__ == "__main__":
+    _, unknown = argparse.ArgumentParser().parse_known_args()
+    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires-python = ">=3.10"
 dependencies = [
     "torch>=2.1.0",
     "pyvers",
-    "hoptorch>=0.1.1",
+    "hoptorch>=0.1.4",
     "numpy",
     "packaging",
     "cloudpickle",

--- a/test/modules/test_rnn.py
+++ b/test/modules/test_rnn.py
@@ -1532,6 +1532,64 @@ class TestLSTMModule:
             torch._dynamo.config.capture_scalar_outputs = prev
         assert "feat" in out.keys(True, True)
 
+    @pytest.mark.parametrize("rnn_type", ["gru", "lstm"])
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.6.0"),
+        reason="torch.compile recurrent path requires Torch >= 2.6.0",
+    )
+    def test_module_pad_backend_compile_with_resets(self, rnn_type):
+        # Regression: the pad (cuDNN) backend cuts multi-trajectory rollouts via
+        # the data-dependent _split_and_pad_sequence / _inv_pad_sequence. Under
+        # torch.compile the boolean-mask reconstruction (tensor[mask]) produced
+        # a data-dependent shape and crashed with "torch.Size() takes an
+        # iterable of 'int' (item 0 is 'FakeTensor')". _split_and_pad_for_reset /
+        # _inv_pad_for_reset now run those as eager islands so the pad backend
+        # compiles; the compiled output must still match eager. Note there is no
+        # capture_scalar_outputs toggle here: the pad path must compile under the
+        # default config.
+        torch.manual_seed(0)
+        B, T, F_in, H, L = 4, 8, 3, 8, 1
+        obs = torch.randn(B, T, F_in)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool)
+        is_init[:, 0] = True
+        is_init[1, 4] = True  # mid-row reset -> exercises split/pad/unpad
+        if rnn_type == "gru":
+            module = GRUModule(
+                input_size=F_in,
+                hidden_size=H,
+                num_layers=L,
+                in_keys=["obs", "hidden"],
+                out_keys=["feat", ("next", "hidden")],
+                recurrent_backend="pad",
+            )
+            hidden = {"hidden": torch.zeros(B, T, L, H)}
+        else:
+            module = LSTMModule(
+                input_size=F_in,
+                hidden_size=H,
+                num_layers=L,
+                in_keys=["obs", "hidden0", "hidden1"],
+                out_keys=["feat", ("next", "hidden0"), ("next", "hidden1")],
+                recurrent_backend="pad",
+            )
+            hidden = {
+                "hidden0": torch.zeros(B, T, L, H),
+                "hidden1": torch.zeros(B, T, L, H),
+            }
+        data = TensorDict({"obs": obs, "is_init": is_init, **hidden}, [B, T])
+
+        with set_recurrent_mode(True), torch.no_grad():
+            ref = module(data.clone())
+
+        @torch.compile
+        def call(td):
+            with set_recurrent_mode(True):
+                return module(td)
+
+        with torch.no_grad():
+            out = call(data.clone())
+        torch.testing.assert_close(out["feat"], ref["feat"])
+
     @pytest.mark.skipif(
         TORCH_VERSION < version.parse("2.6.0"),
         reason="torch._higher_order_ops.scan requires Torch >= 2.6.0",

--- a/test/modules/test_rnn.py
+++ b/test/modules/test_rnn.py
@@ -1537,6 +1537,9 @@ class TestLSTMModule:
         TORCH_VERSION < version.parse("2.6.0"),
         reason="torch.compile recurrent path requires Torch >= 2.6.0",
     )
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="torch.compile tests need a C compiler"
+    )
     def test_module_pad_backend_compile_with_resets(self, rnn_type):
         # Regression: the pad (cuDNN) backend cuts multi-trajectory rollouts via
         # the data-dependent _split_and_pad_sequence / _inv_pad_sequence. Under

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -39,7 +39,7 @@ def _get_hoptorch_scan() -> tuple[Any, Any]:
     if not _has_hoptorch:
         raise NotImplementedError(
             "recurrent_backend='scan' requires hoptorch. Install it with "
-            "`pip install hoptorch>=0.1.1`."
+            "`pip install hoptorch>=0.1.4`."
         )
     if _hoptorch_scan is None or _ensure_scan_backward is None:
         # Optional dependency: keep the import lazy because CI jobs install
@@ -147,6 +147,53 @@ def _scan(*args: Any, **kwargs: Any) -> Any:
 def _scan(*args: Any, **kwargs: Any) -> Any:  # noqa: F811
     scan, _ = _get_hoptorch_scan()
     return scan(*args, **kwargs)
+
+
+@torch.compiler.disable
+def _split_and_pad_for_reset(
+    tensordict_shaped: TensorDictBase,
+    in_keys: list,
+) -> tuple[TensorDictBase | None, torch.Tensor | None, torch.Size | None]:
+    """Split a flattened rollout into per-trajectory padded windows on reset.
+
+    Returns ``(padded_td, splits, original_shape)`` when ``is_init`` fires
+    mid-row (so the rollout must be cut into per-trajectory windows of shape
+    ``[N, T']`` before the RNN runs), or ``(None, None, None)`` otherwise.
+
+    This is an eager island under :func:`torch.compile` (``compiler.disable``):
+    the per-trajectory lengths are data-dependent, so both the padded shape and
+    the boolean-mask reconstruction in :func:`_inv_pad_for_reset`
+    (``tensor[mask]``) produce data-dependent shapes that FakeTensor tracing
+    cannot represent -- Inductor otherwise raises ``torch.Size() takes an
+    iterable of 'int' (item 0 is 'FakeTensor')`` from ``broadcast_shapes``. The
+    surrounding RNN compute still compiles; only this glue runs eagerly.
+    """
+    from torchrl.objectives.value.utils import (
+        _get_num_per_traj_init,
+        _split_and_pad_sequence,
+    )
+
+    is_init = tensordict_shaped["is_init"].squeeze(-1)
+    if not is_init[..., 1:].any():
+        return None, None, None
+    splits = _get_num_per_traj_init(is_init)
+    original_shape = tensordict_shaped.shape
+    padded = _split_and_pad_sequence(
+        tensordict_shaped.select(*in_keys, strict=False), splits
+    )
+    return padded, splits, original_shape
+
+
+@torch.compiler.disable
+def _inv_pad_for_reset(
+    tensordict_shaped: TensorDictBase,
+    splits: torch.Tensor,
+    shape: torch.Size,
+) -> TensorDictBase:
+    """Inverse of :func:`_split_and_pad_for_reset` (eager island, see there)."""
+    from torchrl.objectives.value.utils import _inv_pad_sequence
+
+    return _inv_pad_sequence(tensordict_shaped, splits).reshape(shape)
 
 
 def _place_at_traj_end(
@@ -1029,11 +1076,6 @@ class LSTMModule(ModuleBase):
         env side; without that transform there is no signal for boundary
         resets and hidden state will silently leak across episodes.
         """
-        from torchrl.objectives.value.functional import (
-            _inv_pad_sequence,
-            _split_and_pad_sequence,
-        )
-
         # we want to get an error if the value input is missing, but not the hidden states
         defaults = [NO_DEFAULT, None, None]
         shape = tensordict.shape
@@ -1068,24 +1110,20 @@ class LSTMModule(ModuleBase):
             backend = "scan" if is_compiling() else "pad"
         use_scan = self.recurrent_mode and backend == "scan"
         use_triton = self.recurrent_mode and backend == "triton"
-        if (
-            self.recurrent_mode
-            and not use_scan
-            and not use_triton
-            and is_init[..., 1:].any()
-        ):
-            from torchrl.objectives.value.utils import _get_num_per_traj_init
-
+        if self.recurrent_mode and not use_scan and not use_triton:
             # Multi-trajectory rollouts under the pad backend: split each row
             # into per-trajectory windows of shape [N, T'], run the LSTM on
             # the padded result, then stitch them back. Required for correctness
-            # whenever ``is_init`` fires mid-row.
-            splits = _get_num_per_traj_init(is_init)
-            tensordict_shaped_shape = tensordict_shaped.shape
-            tensordict_shaped = _split_and_pad_sequence(
-                tensordict_shaped.select(*self.in_keys, strict=False), splits
+            # whenever ``is_init`` fires mid-row. The split/unpad runs as an
+            # eager island so the pad backend stays usable under torch.compile
+            # (see _split_and_pad_for_reset).
+            padded, splits_maybe, tensordict_shaped_shape = _split_and_pad_for_reset(
+                tensordict_shaped, self.in_keys
             )
-            is_init = tensordict_shaped["is_init"].squeeze(-1)
+            if padded is not None:
+                tensordict_shaped = padded
+                splits = splits_maybe
+                is_init = tensordict_shaped["is_init"].squeeze(-1)
 
         value, hidden0, hidden1 = (
             tensordict_shaped.get(key, default)
@@ -1125,8 +1163,8 @@ class LSTMModule(ModuleBase):
         tensordict_shaped.set(self.out_keys[1], hidden0)
         tensordict_shaped.set(self.out_keys[2], hidden1)
         if splits is not None:
-            tensordict_shaped = _inv_pad_sequence(tensordict_shaped, splits).reshape(
-                tensordict_shaped_shape
+            tensordict_shaped = _inv_pad_for_reset(
+                tensordict_shaped, splits, tensordict_shaped_shape
             )
 
         if shape != tensordict_shaped.shape or tensordict_shaped is not tensordict:
@@ -2325,11 +2363,6 @@ class GRUModule(ModuleBase):
     @dispatch
     @set_lazy_legacy(False)
     def forward(self, tensordict: TensorDictBase):
-        from torchrl.objectives.value.functional import (
-            _inv_pad_sequence,
-            _split_and_pad_sequence,
-        )
-
         # we want to get an error if the value input is missing, but not the hidden states
         defaults = [NO_DEFAULT, None]
         shape = tensordict.shape
@@ -2358,20 +2391,19 @@ class GRUModule(ModuleBase):
             backend = "scan" if is_compiling() else "pad"
         use_scan = self.recurrent_mode and backend == "scan"
         use_triton = self.recurrent_mode and backend == "triton"
-        if (
-            self.recurrent_mode
-            and not use_scan
-            and not use_triton
-            and is_init[..., 1:].any()
-        ):
-            from torchrl.objectives.value.utils import _get_num_per_traj_init
-
-            splits = _get_num_per_traj_init(is_init)
-            tensordict_shaped_shape = tensordict_shaped.shape
-            tensordict_shaped = _split_and_pad_sequence(
-                tensordict_shaped.select(*self.in_keys, strict=False), splits
+        if self.recurrent_mode and not use_scan and not use_triton:
+            # Multi-trajectory rollouts under the pad backend: split each row
+            # into per-trajectory windows, run the GRU on the padded result,
+            # then stitch them back. The split/unpad runs as an eager island so
+            # the pad backend stays usable under torch.compile (see
+            # _split_and_pad_for_reset).
+            padded, splits_maybe, tensordict_shaped_shape = _split_and_pad_for_reset(
+                tensordict_shaped, self.in_keys
             )
-            is_init = tensordict_shaped["is_init"].squeeze(-1)
+            if padded is not None:
+                tensordict_shaped = padded
+                splits = splits_maybe
+                is_init = tensordict_shaped["is_init"].squeeze(-1)
 
         value, hidden = (
             tensordict_shaped.get(key, default)
@@ -2397,8 +2429,8 @@ class GRUModule(ModuleBase):
         tensordict_shaped.set(self.out_keys[0], val)
         tensordict_shaped.set(self.out_keys[1], hidden)
         if splits is not None:
-            tensordict_shaped = _inv_pad_sequence(tensordict_shaped, splits).reshape(
-                tensordict_shaped_shape
+            tensordict_shaped = _inv_pad_for_reset(
+                tensordict_shaped, splits, tensordict_shaped_shape
             )
 
         if shape != tensordict_shaped.shape or tensordict_shaped is not tensordict:

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -101,6 +101,40 @@ def _canonical_contiguous(value: Tensor) -> Tensor:
     return result.copy_(value)
 
 
+def _split_gru_gate_param(
+    param: Tensor | None,
+    hidden_size: int,
+) -> tuple[Tensor | None, Tensor | None, Tensor | None]:
+    if param is None:
+        return None, None, None
+    gate_chunks = (hidden_size, hidden_size, hidden_size)
+    return tuple(gate.clone() for gate in param.split(gate_chunks, 0))
+
+
+def _gru_cell_from_gate_params(
+    x: Tensor,
+    hx: Tensor,
+    weight_ih: tuple[Tensor, Tensor, Tensor],
+    bias_ih: tuple[Tensor | None, Tensor | None, Tensor | None],
+    weight_hh: tuple[Tensor, Tensor, Tensor],
+    bias_hh: tuple[Tensor | None, Tensor | None, Tensor | None],
+) -> Tensor:
+    x = x.view(-1, x.size(1))
+
+    i_r = F.linear(x, weight_ih[0], bias_ih[0])
+    i_i = F.linear(x, weight_ih[1], bias_ih[1])
+    i_n = F.linear(x, weight_ih[2], bias_ih[2])
+    h_r = F.linear(hx, weight_hh[0], bias_hh[0])
+    h_i = F.linear(hx, weight_hh[1], bias_hh[1])
+    h_n = F.linear(hx, weight_hh[2], bias_hh[2])
+
+    resetgate = (i_r + h_r).sigmoid()
+    inputgate = (i_i + h_i).sigmoid()
+    newgate = (i_n + (resetgate * h_n)).tanh()
+
+    return newgate + inputgate * (hx - newgate)
+
+
 @implement_for("torch", None, "2.6.0", compilable=True)
 def _scan(*args: Any, **kwargs: Any) -> Any:
     raise NotImplementedError(
@@ -1677,8 +1711,13 @@ class GRU(GRUBase):
             i_r, i_i, i_n = gate_x.chunk(3, 1)
             h_r, h_i, h_n = gate_h.chunk(3, 1)
         else:
-            i_r, i_i, i_n = gate_x.split(hidden_size, 1)
-            h_r, h_i, h_n = gate_h.split(hidden_size, 1)
+            # In scan's compiled backward, ``chunk(3, dim)`` derives gate sizes
+            # from a symbolic ``3 * hidden_size`` dim, while ``split(hidden_size)``
+            # can leak that composite SymInt through the HOP partitioner. Passing
+            # explicit sections keeps the sections concrete and the graph valid.
+            gate_chunks = (hidden_size, hidden_size, hidden_size)
+            i_r, i_i, i_n = gate_x.split(gate_chunks, 1)
+            h_r, h_i, h_n = gate_h.split(gate_chunks, 1)
 
         resetgate = (i_r + h_r).sigmoid()
         inputgate = (i_i + h_i).sigmoid()
@@ -1765,13 +1804,26 @@ class GRU(GRUBase):
                 "GRU(use_scan=True) does not support dropout yet."
             )
 
+        hidden_size = self.hidden_size
         weight_ihs, weight_hhs, bias_ihs, bias_hhs = [], [], [], []
         for layer in range(self.num_layers):
             weights = self._all_weights[layer]
-            weight_ihs.append(getattr(self, weights[0]).clone())
-            weight_hhs.append(getattr(self, weights[1]).clone())
-            bias_ihs.append(getattr(self, weights[2]).clone() if self.bias else None)
-            bias_hhs.append(getattr(self, weights[3]).clone() if self.bias else None)
+            weight_ihs.append(
+                _split_gru_gate_param(getattr(self, weights[0]), hidden_size)
+            )
+            weight_hhs.append(
+                _split_gru_gate_param(getattr(self, weights[1]), hidden_size)
+            )
+            bias_ihs.append(
+                _split_gru_gate_param(
+                    getattr(self, weights[2]) if self.bias else None, hidden_size
+                )
+            )
+            bias_hhs.append(
+                _split_gru_gate_param(
+                    getattr(self, weights[3]) if self.bias else None, hidden_size
+                )
+            )
 
         if self.batch_first:
             x = x.transpose(0, 1)
@@ -1781,7 +1833,6 @@ class GRU(GRUBase):
             mask = torch.ones(x.shape[0], x.shape[1], dtype=torch.bool, device=x.device)
 
         num_layers = self.num_layers
-        hidden_size = self.hidden_size
 
         def step(carry, inputs):
             h_layers = carry  # [num_layers, B, H]
@@ -1791,14 +1842,13 @@ class GRU(GRUBase):
             h_unbound = h_layers.unbind(0)
             for layer in range(num_layers):
                 h_prev = h_unbound[layer]
-                h_new = self._gru_cell(
+                h_new = _gru_cell_from_gate_params(
                     x_t,
                     h_prev,
                     weight_ihs[layer],
                     bias_ihs[layer],
                     weight_hhs[layer],
                     bias_hhs[layer],
-                    hidden_size,
                 )
                 h_new = torch.where(m_t, h_new, h_prev)
                 new_h.append(h_new)
@@ -2544,26 +2594,40 @@ class GRUModule(ModuleBase):
                 "GRUModule(recurrent_backend='scan') does not support bidirectional GRUs yet."
             )
 
-        # See _lstm_scan_with_resets: cuDNN flattens GRU parameters into a
-        # single storage, so the views alias each other and the scan tracer
-        # rejects them as inputs. Cloning produces independent allocations.
+        # Split the packed GRU gate parameters outside the scan body. This keeps
+        # the scan step from producing intermediate tensors whose width is the
+        # composite symbolic expression ``3 * hidden_size`` and avoids the
+        # chunk/split-on-activations path in scan's compiled backward. Each gate
+        # clone is an independent allocation, preserving the existing scan
+        # input-aliasing workaround for cuDNN-flattened RNN parameters while
+        # keeping gradients connected to the packed parameters.
+        hidden_size = self.gru.hidden_size
         weight_ihs, weight_hhs, bias_ihs, bias_hhs = [], [], [], []
         for layer in range(self.gru.num_layers):
             weights = self.gru._all_weights[layer]
-            weight_ihs.append(getattr(self.gru, weights[0]).clone())
-            weight_hhs.append(getattr(self.gru, weights[1]).clone())
+            weight_ihs.append(
+                _split_gru_gate_param(getattr(self.gru, weights[0]), hidden_size)
+            )
+            weight_hhs.append(
+                _split_gru_gate_param(getattr(self.gru, weights[1]), hidden_size)
+            )
             bias_ihs.append(
-                getattr(self.gru, weights[2]).clone() if self.gru.bias else None
+                _split_gru_gate_param(
+                    getattr(self.gru, weights[2]) if self.gru.bias else None,
+                    hidden_size,
+                )
             )
             bias_hhs.append(
-                getattr(self.gru, weights[3]).clone() if self.gru.bias else None
+                _split_gru_gate_param(
+                    getattr(self.gru, weights[3]) if self.gru.bias else None,
+                    hidden_size,
+                )
             )
 
         input = _canonical_contiguous(input.transpose(0, 1))
         is_init = _canonical_contiguous(is_init.transpose(0, 1))
         reset_hidden = _canonical_contiguous(hidden_in.permute(1, 2, 0, 3))
         num_layers = self.gru.num_layers
-        hidden_size = self.gru.hidden_size
 
         def step(carry, inputs):
             h_layers = carry
@@ -2573,14 +2637,13 @@ class GRUModule(ModuleBase):
             h_unbound = h_layers.unbind(0)
             new_h = []
             for layer in range(num_layers):
-                h_new = GRU._gru_cell(
+                h_new = _gru_cell_from_gate_params(
                     x_t,
                     h_unbound[layer],
                     weight_ihs[layer],
                     bias_ihs[layer],
                     weight_hhs[layer],
                     bias_hhs[layer],
-                    hidden_size,
                 )
                 new_h.append(h_new)
                 x_t = h_new

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -29,6 +29,21 @@ from torchrl._utils import (
 from torchrl.data.tensor_specs import Unbounded
 from torchrl.modules.tensordict_module._rnn_precision import _validate_user_precision
 
+try:
+    # ``torch.compiler`` was added in torch 2.0; on older builds (exercised by
+    # the olddeps CI job) the module import below would otherwise raise
+    # ``AttributeError: module 'torch' has no attribute 'compiler'``.
+    from torch.compiler import disable as _compiler_disable
+except (ImportError, AttributeError):
+
+    def _compiler_disable(fn=None, *args, **kwargs):
+        # No-op passthrough: on torch builds without ``torch.compiler`` there is
+        # no graph to break out of, and the wrapped helpers run eagerly anyway.
+        if fn is None:
+            return lambda inner: inner
+        return fn
+
+
 _has_hoptorch = importlib.util.find_spec("hoptorch") is not None
 _hoptorch_scan = None
 _ensure_scan_backward = None
@@ -149,7 +164,7 @@ def _scan(*args: Any, **kwargs: Any) -> Any:  # noqa: F811
     return scan(*args, **kwargs)
 
 
-@torch.compiler.disable
+@_compiler_disable
 def _split_and_pad_for_reset(
     tensordict_shaped: TensorDictBase,
     in_keys: list,
@@ -184,7 +199,7 @@ def _split_and_pad_for_reset(
     return padded, splits, original_shape
 
 
-@torch.compiler.disable
+@_compiler_disable
 def _inv_pad_for_reset(
     tensordict_shaped: TensorDictBase,
     splits: torch.Tensor,


### PR DESCRIPTION
## Summary

- add a pytest-benchmark suite for GRU/LSTM rollout-through-time workloads with intermediate `is_init` resets
- benchmark the exact public path: create a raw `TensorDict`, create a `torchrl.modules.GRUModule` / `LSTMModule`, optionally `torch.compile` the module, and call `module(td)`
- include the pad/cuDNN backend's own split/pad overhead in the timed call, so scan/triton improvements are measured against the real public-module baseline
- use 128 batch, 128 time steps, 256 recurrent cells, and a deterministic 3% intermediate-reset mask from a parametrized `torch.Generator`
- run three warmup calls for compiled runs before pytest-benchmark timing

No private `_gru` / `_lstm` calls, no pre-padding, and no manual `_split_and_pad_sequence` / `_get_num_per_traj_init` path are used by the benchmark.

## Validation

```bash
PYTHONPATH=$PWD/benchmarks:$PWD pytest -q benchmarks/test_rnn_reset_backends_benchmark.py \
  --benchmark-only --benchmark-min-rounds=1 --benchmark-warmup=off \
  --benchmark-max-time=0.01 -vv --tb=short
```

Local CPU/macOS result: 6 passed, 4 skipped CUDA-only triton variants, 2 xfailed compiled cudnn/pad variants. The compiled cudnn/pad xfails are from the real public TensorDict padding path not compiling locally; they are not hidden by pre-padding.
