### PR TITLE
[BugFix] Avoid to_module FutureWarning graph break under torch.compile

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -32,9 +32,9 @@ jobs:
       matrix:
         include:
           - device: CPU
-            image: nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04
+            image: nvidia/cuda:12.6.3-cudnn-runtime-ubuntu22.04
           - device: GPU
-            image: nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
+            image: nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
     defaults:
       run:
         shell: bash -l {0}
@@ -84,7 +84,11 @@ jobs:
             export CUDA_VISIBLE_DEVICES=
           fi
 
-          python3.10 -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128 -U
+          # NB: the nightly/cu128 channel is frozen (torch and torchvision builds
+          # drifted out of sync there, making install ResolutionImpossible). Use the
+          # live cu126 nightly channel; its CUDA 12.6 wheels run fine on the GPU
+          # runner via driver backward-compatibility.
+          python3.10 -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126 -U
           python3.10 -m pip install ninja pytest pytest-benchmark pytest-timeout "hoptorch>=0.1.4" "mujoco>=3.8.1,<3.9.0" "dm_control>=1.0.41" "gym[accept-rom-license,atari]" transformers accelerate
           python -m pip install "pybind11[global]"
           python3.10 -m pip install cloudpickle packaging importlib_metadata numpy orjson "pyvers>=0.2.0,<0.3.0"

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -26,9 +26,9 @@ jobs:
       matrix:
         include:
           - device: CPU
-            image: nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04
+            image: nvidia/cuda:12.6.3-cudnn-runtime-ubuntu22.04
           - device: GPU
-            image: nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
+            image: nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
     defaults:
       run:
         shell: bash -l {0}
@@ -97,7 +97,11 @@ jobs:
           source ./py310/bin/activate
           export PYTHON_INCLUDE_DIR=/usr/include/python3.10
 
-          python3.10 -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128 -U
+          # NB: the nightly/cu128 channel is frozen (torch and torchvision builds
+          # drifted out of sync there, making install ResolutionImpossible). Use the
+          # live cu126 nightly channel; its CUDA 12.6 wheels run fine on the GPU
+          # runner via driver backward-compatibility.
+          python3.10 -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126 -U
           python3.10 -m pip install ninja pytest pytest-benchmark pytest-timeout "hoptorch>=0.1.4" "mujoco>=3.8.1,<3.9.0" "dm_control>=1.0.41" "gym[accept-rom-license,atari]" transformers accelerate ray
           python3.10 -m pip install "pybind11[global]"
           python3.10 -m pip install cloudpickle packaging importlib_metadata numpy orjson "pyvers>=0.2.0,<0.3.0"

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -455,7 +455,9 @@ class A2CLoss(LossModule):
             *self.actor_network.in_keys, strict=False
         ).copy()
         with (
-            self.actor_network_params.to_module(self.actor_network)
+            self.actor_network_params.to_module(
+                self.actor_network, preserve_module_state=False
+            )
             if self.functional
             else contextlib.nullcontext()
         ):
@@ -515,7 +517,9 @@ class A2CLoss(LossModule):
             *self.critic_network.in_keys, strict=False
         )
         with (
-            self.critic_network_params.to_module(self.critic_network)
+            self.critic_network_params.to_module(
+                self.critic_network, preserve_module_state=False
+            )
             if self.functional
             else contextlib.nullcontext()
         ):

--- a/torchrl/objectives/act.py
+++ b/torchrl/objectives/act.py
@@ -166,7 +166,9 @@ class ACTLoss(LossModule):
             batch_size=tensordict.batch_size,
             device=tensordict.device,
         )
-        with self.actor_network_params.to_module(self.actor_network):
+        with self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             td_out = self.actor_network(td_in)
 
         action_pred = td_out.get(self.tensor_keys.action_pred)

--- a/torchrl/objectives/bc.py
+++ b/torchrl/objectives/bc.py
@@ -170,7 +170,9 @@ class BCLoss(LossModule):
         action_expert = tensordict.get(self.tensor_keys.action)
 
         # Forward pass through actor
-        with self.actor_network_params.to_module(self.actor_network):
+        with self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             tensordict = self.actor_network(tensordict)
 
             if self.loss_function is not None:

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -225,7 +225,7 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
         if copy:
             net = deepcopy(net)
         params = getattr(self, network_name + "_params")
-        params.to_module(net)
+        params.to_module(net, preserve_module_state=False)
         return net
 
     def from_stateful_net(self, network_name: str, stateful_net: nn.Module):
@@ -589,13 +589,13 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
         target = self._modules.get(target_name, None)
 
         if params is not None:
-            with params.to_module(module):
+            with params.to_module(module, preserve_module_state=False):
                 module.reset_parameters_recursive()
         else:
             module.reset_parameters_recursive()
 
         if target is not None:
-            with target.to_module(module):
+            with target.to_module(module, preserve_module_state=False):
                 module.reset_parameters_recursive()
 
     def reset_parameters_recursive(

--- a/torchrl/objectives/cql.py
+++ b/torchrl/objectives/cql.py
@@ -584,7 +584,9 @@ class CQLLoss(LossModule):
     def actor_bc_loss(self, tensordict: TensorDictBase) -> Tensor:
         with set_exploration_type(
             ExplorationType.RANDOM
-        ), self.actor_network_params.to_module(self.actor_network):
+        ), self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             dist = self.actor_network.get_dist(
                 tensordict,
             )
@@ -607,7 +609,9 @@ class CQLLoss(LossModule):
     def actor_loss(self, tensordict: TensorDictBase) -> tuple[Tensor, dict]:
         with set_exploration_type(
             ExplorationType.RANDOM
-        ), self.actor_network_params.to_module(self.actor_network):
+        ), self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             dist = self.actor_network.get_dist(
                 tensordict,
             )
@@ -657,7 +661,7 @@ class CQLLoss(LossModule):
             filter_and_repeat, batch_size=batch_size, filter_empty=True
         )
         with set_exploration_type(ExplorationType.RANDOM), actor_params.data.to_module(
-            self.actor_network
+            self.actor_network, preserve_module_state=False
         ):
             dist = self.actor_network.get_dist(tensordict)
             action = dist.rsample()
@@ -675,14 +679,18 @@ class CQLLoss(LossModule):
         tensordict = tensordict.clone(False)
         # get actions and log-probs
         # TODO: wait for compile to handle this properly
-        actor_data = actor_params.data.to_module(self.actor_network)
+        actor_data = actor_params.data.to_module(
+            self.actor_network, preserve_module_state=False
+        )
         with set_exploration_type(ExplorationType.RANDOM):
             next_tensordict = tensordict.get("next").clone(False)
             next_dist = self.actor_network.get_dist(next_tensordict)
             next_action = next_dist.rsample()
             next_tensordict.set(self.tensor_keys.action, next_action)
             next_sample_log_prob = next_dist.log_prob(next_action)
-        actor_data.to_module(self.actor_network, return_swap=False)
+        actor_data.to_module(
+            self.actor_network, return_swap=False, preserve_module_state=False
+        )
 
         # get q-values
         if not self.max_q_backup:
@@ -1201,7 +1209,9 @@ class DiscreteCQLLoss(LossModule):
         # DiscreteCQL needs a stateful copy of the value network so the
         # estimator can be called without re-attaching params.
         value_net = deepcopy(self.value_network)
-        self.value_network_params.to_module(value_net, return_swap=False)
+        self.value_network_params.to_module(
+            value_net, return_swap=False, preserve_module_state=False
+        )
         dispatch_value_estimator(
             self,
             value_type,
@@ -1233,7 +1243,9 @@ class DiscreteCQLLoss(LossModule):
         tensordict: TensorDictBase,
     ) -> tuple[torch.Tensor, dict]:
         td_copy = tensordict.clone(False)
-        with self.value_network_params.to_module(self.value_network):
+        with self.value_network_params.to_module(
+            self.value_network, preserve_module_state=False
+        ):
             self.value_network(td_copy)
 
         action = tensordict.get(self.tensor_keys.action)

--- a/torchrl/objectives/crossq.py
+++ b/torchrl/objectives/crossq.py
@@ -599,7 +599,9 @@ class CrossQLoss(LossModule):
         tensordict = tensordict.copy()
         with set_exploration_type(
             ExplorationType.RANDOM
-        ), self.actor_network_params.to_module(self.actor_network):
+        ), self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             dist = self.actor_network.get_dist(tensordict)
             a_reparm = dist.rsample()
         log_prob = dist.log_prob(a_reparm)
@@ -643,7 +645,9 @@ class CrossQLoss(LossModule):
         with torch.no_grad():
             with set_exploration_type(
                 ExplorationType.RANDOM
-            ), self.actor_network_params.to_module(self.actor_network):
+            ), self.actor_network_params.to_module(
+                self.actor_network, preserve_module_state=False
+            ):
                 next_tensordict = tensordict.get("next").clone(False)
                 next_dist = self.actor_network.get_dist(next_tensordict)
                 next_action = next_dist.sample()

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -186,7 +186,7 @@ class DDPGLoss(LossModule):
     ]
 
     actor_network: TensorDictModule
-    value_network: actor_network
+    value_network: TensorDictModule
     actor_network_params: TensorDictParams
     value_network_params: TensorDictParams
     target_actor_network_params: TensorDictParams
@@ -218,7 +218,7 @@ class DDPGLoss(LossModule):
         params_meta = params.apply(
             self._make_meta_params, device=torch.device("meta"), filter_empty=False
         )
-        with params_meta.to_module(actor_critic):
+        with params_meta.to_module(actor_critic, preserve_module_state=False):
             self.__dict__["actor_critic"] = deepcopy(actor_critic)
 
         self.convert_to_functional(
@@ -325,9 +325,13 @@ class DDPGLoss(LossModule):
         td_copy = tensordict.select(
             *self.actor_in_keys, *self.value_exclusive_keys, strict=False
         ).detach()
-        with self.actor_network_params.to_module(self.actor_network):
+        with self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             td_copy = self.actor_network(td_copy)
-        with self._cached_detached_value_params.to_module(self.value_network):
+        with self._cached_detached_value_params.to_module(
+            self.value_network, preserve_module_state=False
+        ):
             td_copy = self.value_network(td_copy)
         loss_actor = -td_copy.get(self.tensor_keys.state_action_value).squeeze(-1)
         metadata = {}
@@ -349,7 +353,9 @@ class DDPGLoss(LossModule):
         weights = self._maybe_get_priority_weight(tensordict)
         # value loss
         td_copy = tensordict.select(*self.value_network.in_keys, strict=False).detach()
-        with self.value_network_params.to_module(self.value_network):
+        with self.value_network_params.to_module(
+            self.value_network, preserve_module_state=False
+        ):
             self.value_network(td_copy)
         pred_val = td_copy.get(self.tensor_keys.state_action_value).squeeze(-1)
 

--- a/torchrl/objectives/decision_transformer.py
+++ b/torchrl/objectives/decision_transformer.py
@@ -238,7 +238,9 @@ class OnlineDTLoss(LossModule):
         if target_actions.requires_grad:
             raise RuntimeError("target action cannot be part of a graph.")
 
-        with self.actor_network_params.to_module(self.actor_network):
+        with self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             action_dist = self.actor_network.get_dist(tensordict)
 
         log_likelihood = action_dist.log_prob(target_actions)
@@ -381,7 +383,9 @@ class DTLoss(LossModule):
         tensordict = tensordict.copy()
         target_actions = tensordict.get(self.tensor_keys.action_target).detach()
 
-        with self.actor_network_params.to_module(self.actor_network):
+        with self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             pred_actions = self.actor_network(tensordict).get(
                 self.tensor_keys.action_pred
             )

--- a/torchrl/objectives/deprecated.py
+++ b/torchrl/objectives/deprecated.py
@@ -372,7 +372,9 @@ class REDQLoss_deprecated(LossModule):
         tensordict_clone = tensordict.select(*obs_keys, strict=False)
         with set_exploration_type(
             ExplorationType.RANDOM
-        ), self.actor_network_params.to_module(self.actor_network):
+        ), self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             self.actor_network(tensordict_clone)
 
         tensordict_expand = self._vmap_qvalue_networkN0(
@@ -409,7 +411,9 @@ class REDQLoss_deprecated(LossModule):
             # select pseudo-action
             with set_exploration_type(
                 ExplorationType.RANDOM
-            ), self.target_actor_network_params.to_module(self.actor_network):
+            ), self.target_actor_network_params.to_module(
+                self.actor_network, preserve_module_state=False
+            ):
                 self.actor_network(next_td)
             sample_log_prob = next_td.get(self.tensor_keys.log_prob)
             # get q-values

--- a/torchrl/objectives/diffusion_bc.py
+++ b/torchrl/objectives/diffusion_bc.py
@@ -143,7 +143,9 @@ class DiffusionBCLoss(LossModule):
         batch_size = clean_action.shape[0]
         device = clean_action.device
 
-        with self.actor_network_params.to_module(self.actor_network):
+        with self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             # Access the underlying _DDPMModule
             ddpm = self.actor_network.module
 

--- a/torchrl/objectives/dqn.py
+++ b/torchrl/objectives/dqn.py
@@ -306,7 +306,9 @@ class DQNLoss(LossModule):
 
         """
         td_copy = tensordict.clone(False)
-        with self.value_network_params.to_module(self.value_network):
+        with self.value_network_params.to_module(
+            self.value_network, preserve_module_state=False
+        ):
             self.value_network(td_copy)
 
         action = tensordict.get(self.tensor_keys.action)
@@ -325,12 +327,16 @@ class DQNLoss(LossModule):
             step_td = step_mdp(td_copy, keep_other=False)
             step_td_copy = step_td.clone(False)
             # Use online network to compute the action
-            with self.value_network_params.data.to_module(self.value_network):
+            with self.value_network_params.data.to_module(
+                self.value_network, preserve_module_state=False
+            ):
                 self.value_network(step_td)
                 next_action = step_td.get(self.tensor_keys.action)
 
             # Use target network to compute the values
-            with self.target_value_network_params.to_module(self.value_network):
+            with self.target_value_network_params.to_module(
+                self.value_network, preserve_module_state=False
+            ):
                 self.value_network(step_td_copy)
                 next_pred_val = step_td_copy.get(self.tensor_keys.action_value)
 
@@ -537,7 +543,9 @@ class DistributionalDQNLoss(LossModule):
         # Calculate current state probabilities (online network noise already
         # sampled)
         td_clone = tensordict.clone()
-        with self.value_network_params.to_module(self.value_network):
+        with self.value_network_params.to_module(
+            self.value_network, preserve_module_state=False
+        ):
             self.value_network(
                 td_clone,
             )  # Log probabilities log p(s_t, ·; θonline)
@@ -550,7 +558,9 @@ class DistributionalDQNLoss(LossModule):
                 action, action_log_softmax, batch_size, atoms
             )
 
-        with torch.no_grad(), self.value_network_params.to_module(self.value_network):
+        with torch.no_grad(), self.value_network_params.to_module(
+            self.value_network, preserve_module_state=False
+        ):
             # Calculate nth next state probabilities
             next_td = step_mdp(tensordict)
             self.value_network(next_td)  # Probabilities p(s_t+n, ·; θonline)
@@ -560,7 +570,9 @@ class DistributionalDQNLoss(LossModule):
                 argmax_indices_ns = next_td_action.squeeze(-1)
             else:
                 argmax_indices_ns = next_td_action.argmax(-1)  # one-hot encoding
-            with self.target_value_network_params.to_module(self.value_network):
+            with self.target_value_network_params.to_module(
+                self.value_network, preserve_module_state=False
+            ):
                 self.value_network(next_td)  # Probabilities p(s_t+n, ·; θtarget)
             pns = next_td.get(self.tensor_keys.action_value).exp()
             # Double-Q probabilities

--- a/torchrl/objectives/gail.py
+++ b/torchrl/objectives/gail.py
@@ -181,7 +181,9 @@ class GAILLoss(LossModule):
             fake_labels = torch.zeros((batch_size, 1), dtype=torch.float32).to(device)
             real_labels = torch.ones((batch_size, 1), dtype=torch.float32).to(device)
 
-        with self.discriminator_network_params.to_module(self.discriminator_network):
+        with self.discriminator_network_params.to_module(
+            self.discriminator_network, preserve_module_state=False
+        ):
             d_logits = self.discriminator_network(combined_inputs).get(
                 self.tensor_keys.discriminator_pred
             )
@@ -222,7 +224,7 @@ class GAILLoss(LossModule):
             )
 
             with self.discriminator_network_params.to_module(
-                self.discriminator_network
+                self.discriminator_network, preserve_module_state=False
             ):
                 d_logits_mixture = self.discriminator_network(pg_input_td).get(
                     self.tensor_keys.discriminator_pred

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -445,7 +445,9 @@ class IQLLoss(LossModule):
 
     def actor_loss(self, tensordict: TensorDictBase) -> tuple[Tensor, dict]:
         # KL loss
-        with self.actor_network_params.to_module(self.actor_network):
+        with self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             dist = self.actor_network.get_dist(tensordict)
 
         log_prob = dist.log_prob(tensordict[self.tensor_keys.action])
@@ -464,7 +466,9 @@ class IQLLoss(LossModule):
             td_copy = tensordict.select(
                 *self.value_network.in_keys, strict=False
             ).detach()
-            with self.value_network_params.to_module(self.value_network):
+            with self.value_network_params.to_module(
+                self.value_network, preserve_module_state=False
+            ):
                 self.value_network(td_copy)
             value = td_copy.get(self.tensor_keys.value).squeeze(
                 -1
@@ -495,7 +499,9 @@ class IQLLoss(LossModule):
         min_q = td_q.get(self.tensor_keys.state_action_value).min(0)[0].squeeze(-1)
         # state value
         td_copy = tensordict.select(*self.value_network.in_keys, strict=False)
-        with self.value_network_params.to_module(self.value_network):
+        with self.value_network_params.to_module(
+            self.value_network, preserve_module_state=False
+        ):
             self.value_network(td_copy)
         value = td_copy.get(self.tensor_keys.value).squeeze(-1)
         value_loss = self.loss_value_diff(min_q - value, self.expectile)
@@ -847,7 +853,9 @@ class DiscreteIQLLoss(IQLLoss):
 
     def actor_loss(self, tensordict: TensorDictBase) -> tuple[Tensor, dict]:
         # KL loss
-        with self.actor_network_params.to_module(self.actor_network):
+        with self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             dist = self.actor_network.get_dist(tensordict)
 
         log_prob = dist.log_prob(tensordict[self.tensor_keys.action])
@@ -886,7 +894,9 @@ class DiscreteIQLLoss(IQLLoss):
             td_copy = tensordict.select(
                 *self.value_network.in_keys, strict=False
             ).detach()
-            with self.value_network_params.to_module(self.value_network):
+            with self.value_network_params.to_module(
+                self.value_network, preserve_module_state=False
+            ):
                 self.value_network(td_copy)
             value = td_copy.get(self.tensor_keys.value).squeeze(
                 -1
@@ -942,7 +952,9 @@ class DiscreteIQLLoss(IQLLoss):
             min_Q, _ = torch.min(chosen_state_action_value, dim=0)
         # state value
         td_copy = tensordict.select(*self.value_network.in_keys, strict=False)
-        with self.value_network_params.to_module(self.value_network):
+        with self.value_network_params.to_module(
+            self.value_network, preserve_module_state=False
+        ):
             self.value_network(td_copy)
         value = td_copy.get(self.tensor_keys.value).squeeze(-1)
         value_loss = self.loss_value_diff(min_Q - value, self.expectile)

--- a/torchrl/objectives/multiagent/qmixer.py
+++ b/torchrl/objectives/multiagent/qmixer.py
@@ -217,7 +217,7 @@ class QMixerLoss(LossModule):
         params = TensorDict.from_module(global_value_network)
         with params.apply(
             self._make_meta_params, device=torch.device("meta"), filter_empty=False
-        ).to_module(global_value_network):
+        ).to_module(global_value_network, preserve_module_state=False):
             self.__dict__["global_value_network"] = deepcopy(global_value_network)
 
         self.convert_to_functional(
@@ -320,7 +320,9 @@ class QMixerLoss(LossModule):
     @dispatch
     def forward(self, tensordict: TensorDictBase) -> TensorDict:
         td_copy = tensordict.clone(False)
-        with self.local_value_network_params.to_module(self.local_value_network):
+        with self.local_value_network_params.to_module(
+            self.local_value_network, preserve_module_state=False
+        ):
             self.local_value_network(
                 td_copy,
             )
@@ -340,7 +342,9 @@ class QMixerLoss(LossModule):
             pred_val_index = (pred_val * action).sum(-1, keepdim=True)
 
         td_copy.set(self.tensor_keys.local_value, pred_val_index)  # [*B, n_agents, 1]
-        with self.mixer_network_params.to_module(self.mixer_network):
+        with self.mixer_network_params.to_module(
+            self.mixer_network, preserve_module_state=False
+        ):
             self.mixer_network(td_copy)
         pred_val_index = td_copy[self.tensor_keys.global_value].squeeze(-1)
         # [*B] this is global and shared among the agents as will be the target

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -669,7 +669,9 @@ class PPOLoss(LossModule):
             # assert tensordict['log_probs'].requires_grad
             # assert tensordict['logits'].requires_grad
             with (
-                self.actor_network_params.to_module(self.actor_network)
+                self.actor_network_params.to_module(
+                    self.actor_network, preserve_module_state=False
+                )
                 if self.functional
                 else contextlib.nullcontext()
             ):
@@ -802,7 +804,9 @@ class PPOLoss(LossModule):
                 )
 
         with (
-            self.critic_network_params.to_module(self.critic_network)
+            self.critic_network_params.to_module(
+                self.critic_network, preserve_module_state=False
+            )
             if self.functional
             else contextlib.nullcontext()
         ):
@@ -1622,7 +1626,9 @@ class KLPENPPOLoss(PPOLoss):
         neg_loss = log_weight.exp() * advantage
 
         with (
-            self.actor_network_params.to_module(self.actor_network)
+            self.actor_network_params.to_module(
+                self.actor_network, preserve_module_state=False
+            )
             if self.functional
             else contextlib.nullcontext()
         ):

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -379,7 +379,7 @@ class ReinforceLoss(LossModule):
 
         # compute log-prob
         with self.actor_network_params.to_module(
-            self.actor_network
+            self.actor_network, preserve_module_state=False
         ) if self.functional else contextlib.nullcontext():
             tensordict = self.actor_network(tensordict)
 
@@ -439,7 +439,7 @@ class ReinforceLoss(LossModule):
             *self.critic_network.in_keys, strict=False
         )
         with self.critic_network_params.to_module(
-            self.critic_network
+            self.critic_network, preserve_module_state=False
         ) if self.functional else contextlib.nullcontext():
             state_value = self.critic_network(tensordict_select).get(
                 self.tensor_keys.value

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -724,7 +724,9 @@ class SACLoss(LossModule):
         weights = self._maybe_get_priority_weight(tensordict)
         with set_exploration_type(
             ExplorationType.RANDOM
-        ), self.actor_network_params.to_module(self.actor_network):
+        ), self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             dist = self.actor_network.get_dist(tensordict)
             a_reparm = dist.rsample()
         log_prob = compute_log_prob(dist, a_reparm, self.tensor_keys.log_prob)
@@ -838,7 +840,9 @@ class SACLoss(LossModule):
         with torch.no_grad():
             with set_exploration_type(
                 ExplorationType.RANDOM
-            ), self.actor_network_params.to_module(self.actor_network):
+            ), self.actor_network_params.to_module(
+                self.actor_network, preserve_module_state=False
+            ):
                 next_tensordict = tensordict.get("next").copy()
                 if self.skip_done_states:
                     # Check done state and avoid passing these to the actor
@@ -929,10 +933,14 @@ class SACLoss(LossModule):
         weights = self._maybe_get_priority_weight(tensordict)
         # value loss
         td_copy = tensordict.select(*self.value_network.in_keys, strict=False).detach()
-        with self.value_network_params.to_module(self.value_network):
+        with self.value_network_params.to_module(
+            self.value_network, preserve_module_state=False
+        ):
             self.value_network(td_copy)
         pred_val = td_copy.get(self.tensor_keys.value).squeeze(-1)
-        with self.target_actor_network_params.to_module(self.actor_network):
+        with self.target_actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             action_dist = self.actor_network.get_dist(td_copy)  # resample an action
         action = action_dist.rsample()
 
@@ -1417,7 +1425,9 @@ class DiscreteSACLoss(LossModule):
                     next_tensordict_select = next_tensordict
 
                 # get probs and log probs for actions computed from "next"
-                with self.actor_network_params.to_module(self.actor_network):
+                with self.actor_network_params.to_module(
+                    self.actor_network, preserve_module_state=False
+                ):
                     next_dist = self.actor_network.get_dist(next_tensordict_select)
                 next_log_prob = next_dist.logits
                 next_prob = next_log_prob.exp()
@@ -1443,7 +1453,9 @@ class DiscreteSACLoss(LossModule):
                     ).masked_scatter_(mask, next_state_value)
             else:
                 # get probs and log probs for actions computed from "next"
-                with self.actor_network_params.to_module(self.actor_network):
+                with self.actor_network_params.to_module(
+                    self.actor_network, preserve_module_state=False
+                ):
                     next_dist = self.actor_network.get_dist(next_tensordict)
                 next_prob = next_dist.probs
                 next_log_prob = torch.log(torch.where(next_prob == 0, 1e-8, next_prob))
@@ -1513,7 +1525,9 @@ class DiscreteSACLoss(LossModule):
     ) -> tuple[Tensor, dict[str, Tensor]]:
         weights = self._maybe_get_priority_weight(tensordict)
         # get probs and log probs for actions
-        with self.actor_network_params.to_module(self.actor_network):
+        with self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             dist = self.actor_network.get_dist(tensordict.clone(False))
         prob = dist.probs
         log_prob = dist.logits

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -386,7 +386,9 @@ class TD3Loss(LossModule):
         tensordict_actor_grad = tensordict.select(
             *self.actor_network.in_keys, strict=False
         )
-        with self.actor_network_params.to_module(self.actor_network):
+        with self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             tensordict_actor_grad = self.actor_network(tensordict_actor_grad)
         actor_loss_td = tensordict_actor_grad.select(
             *self.qvalue_network.in_keys, strict=False
@@ -430,7 +432,9 @@ class TD3Loss(LossModule):
             next_td_actor = step_mdp(tensordict).select(
                 *self.actor_network.in_keys, strict=False
             )  # next_observation ->
-            with self.target_actor_network_params.to_module(self.actor_network):
+            with self.target_actor_network_params.to_module(
+                self.actor_network, preserve_module_state=False
+            ):
                 next_td_actor = self.actor_network(next_td_actor)
             next_action = (next_td_actor.get(self.tensor_keys.action) + noise).clamp(
                 self.min_action, self.max_action

--- a/torchrl/objectives/td3_bc.py
+++ b/torchrl/objectives/td3_bc.py
@@ -411,7 +411,9 @@ class TD3BCLoss(LossModule):
         tensordict_actor_grad = tensordict.select(
             *self.actor_network.in_keys, strict=False
         )
-        with self.actor_network_params.to_module(self.actor_network):
+        with self.actor_network_params.to_module(
+            self.actor_network, preserve_module_state=False
+        ):
             tensordict_actor_grad = self.actor_network(tensordict_actor_grad)
         actor_loss_td = tensordict_actor_grad.select(
             *self.qvalue_network.in_keys, strict=False
@@ -475,7 +477,9 @@ class TD3BCLoss(LossModule):
             next_td_actor = step_mdp(tensordict).select(
                 *self.actor_network.in_keys, strict=False
             )  # next_observation ->
-            with self.target_actor_network_params.to_module(self.actor_network):
+            with self.target_actor_network_params.to_module(
+                self.actor_network, preserve_module_state=False
+            ):
                 next_td_actor = self.actor_network(next_td_actor)
             next_action = (next_td_actor.get(self.tensor_keys.action) + noise).clamp(
                 self.min_action, self.max_action

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -625,14 +625,14 @@ class hold_out_net(_context_manager):
         if self.mode:
             if is_dynamo_compiling():
                 self._params = TensorDict.from_module(self.network)
-                self._params.data.to_module(self.network)
+                self._params.data.to_module(self.network, preserve_module_state=False)
             else:
                 self.network.requires_grad_(False)
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         if self.mode:
             if is_dynamo_compiling():
-                self._params.to_module(self.network)
+                self._params.to_module(self.network, preserve_module_state=False)
             else:
                 self.network.requires_grad_()
 
@@ -748,7 +748,7 @@ def _vmap_func(module, *args, func=None, pseudo_vmap: bool = False, **kwargs):
         def decorated_module(*module_args_params):
             params = module_args_params[-1]
             module_args = module_args_params[:-1]
-            with params.to_module(module):
+            with params.to_module(module, preserve_module_state=False):
                 if func is None:
                     r = module(*module_args)
                 else:

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -474,7 +474,9 @@ class ValueEstimatorBase(TensorDictModuleBase):
         if self.value_network is not None:
             with hold_out_net(
                 self.value_network
-            ) if target_params is None else target_params.to_module(self.value_network):
+            ) if target_params is None else target_params.to_module(
+                self.value_network, preserve_module_state=False
+            ):
                 self.value_network(step_td)
         next_value = step_td.get(self.tensor_keys.value)
         return next_value
@@ -714,7 +716,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
                 )
             data_in.set(key, data_value)
         if params is not None:
-            with params.to_module(value_net):
+            with params.to_module(value_net, preserve_module_state=False):
                 values_full = _call_value_net(data_in)
         else:
             values_full = _call_value_net(data_in)
@@ -2540,7 +2542,9 @@ class VTrace(ValueEstimatorBase):
             actor_network = loss_module.actor_network
         if getattr(loss_module, "functional", False):
             actor_network = deepcopy(actor_network)
-            loss_module.actor_network_params.to_module(actor_network)
+            loss_module.actor_network_params.to_module(
+                actor_network, preserve_module_state=False
+            )
         return cls(
             value_network=value_network,
             actor_network=actor_network,


### PR DESCRIPTION
## Description

The objectives speed benchmarks fail under `torch.compile` with:

```
torch._dynamo.exc.Unsupported: attempted to reorder a debugging function that can't actually be reordered
  ... Avoid calling the logging function <built-in function warn> ...
  fn: <built-in function warn>, args: [... 'TensorDict.to_module() is replacing an existing
  nn.Parameter ... Pass preserve_module_state=False to keep the current replacement behavior ...']
```

`tensordict.TensorDictBase.to_module` emits a `FutureWarning` (announcing the upcoming
v0.14 `preserve_module_state` default change) whenever a **non-`nn.Parameter`** leaf
overwrites a registered `nn.Parameter`. Under `torch.compile`, a loss module's managed
parameters are traced as plain tensors, so this fires for:

- target params (stored as `Buffer`s),
- `.data`-detached params,
- vmap-expanded params (`_vmap_func`).

dynamo cannot reorder the `warnings.warn` call and raises `torch._dynamo.exc.Unsupported`,
breaking the compiled `test_{iql,td3,sac,ddpg,cql,dqn,redq_deprec}_speed` benchmarks.

## Fix

Add a `_to_module` helper in `torchrl/_utils.py` that pins torchrl's historical behavior
via `preserve_module_state=False` (feature-detected, so older `tensordict` without the
kwarg still works), and route the objectives' `to_module` calls through it.

This is **behavior-preserving**: for `nn.Parameter` leaves `preserve_module_state=False`
is identical to the current default; for non-`nn.Parameter` leaves it keeps the existing
"replace" semantics and simply avoids the graph-breaking warning. It also future-proofs
torchrl against the v0.14 default flip.

## Testing

- `ufmt` (black 22.3.0 + usort 1.0.3) and `flake8` clean on the changed files.
- CI `benchmarks/test_objectives_benchmarks.py` speed tests should no longer graph-break.