### PR TITLE
[Doc] Fix non-resolving API cross-references across docs and tutorials

### DIFF
--- a/docs/source/reference/collectors.rst
+++ b/docs/source/reference/collectors.rst
@@ -15,7 +15,7 @@ TorchRL provides several collector implementations optimized for different scena
 - :class:`AsyncBatchedCollector`: Async environments + auto-batching inference server (see :class:`AsyncBatchedCollector`)
 - :class:`MultiCollector`: Parallel collection across multiple workers (see below)
 - :class:`Evaluator`: Sync or async evaluation during training (see :ref:`evaluation <collectors_eval>`)
-- **Distributed collectors**: For multi-node setups using Ray, RPC, or distributed backends (see :class:`DistributedCollector` / :class:`RPCCollector`)
+- **Distributed collectors**: For multi-node setups using Ray, RPC, or distributed backends (see :class:`~torchrl.collectors.distributed.DistributedCollector` / :class:`~torchrl.collectors.distributed.RPCCollector`)
 
 MultiCollector API
 ------------------
@@ -58,7 +58,7 @@ Key Features
 - **Weight synchronization**: Keep inference policies up-to-date with training weights
 - **Replay buffer integration**: Seamless compatibility with TorchRL's replay buffers
 - **Trajectory assembly**: Collect complete trajectories with ``trajs_per_batch`` for
-  clean :class:`~torchrl.data.SliceSampler` sampling — see :ref:`collectors_replay_trajs`
+  clean :class:`~torchrl.data.replay_buffers.SliceSampler` sampling — see :ref:`collectors_replay_trajs`
 - **Batching strategies**: Multiple ways to organize collected data
 - **Profiler-ready**: Set ``TORCHRL_PROFILING=1`` to emit named ranges on the
   collector, env, and policy hot paths — see :ref:`ref_profiling`

--- a/docs/source/reference/collectors_basics.rst
+++ b/docs/source/reference/collectors_basics.rst
@@ -62,7 +62,7 @@ Besides those compute parameters, users may choose to configure the following pa
   ``("collector", "traj_ids")`` integer per frame and updates it on every
   env reset.  Setting it to ``False`` skips the per-step bookkeeping —
   useful when neither :func:`~torchrl.collectors.utils.split_trajectories`
-  nor :class:`~torchrl.data.SliceSampler` are used downstream.  Note that
+  nor :class:`~torchrl.data.replay_buffers.SliceSampler` are used downstream.  Note that
   ``split_trajs=True`` requires ``track_traj_ids=True``.
 
 Trajectory IDs
@@ -75,7 +75,7 @@ unique across resets within a single worker.
 
 This is what makes trajectory-aware downstream consumers possible:
 
-- :class:`~torchrl.data.SliceSampler` draws whole trajectories (or slices of
+- :class:`~torchrl.data.replay_buffers.SliceSampler` draws whole trajectories (or slices of
   them) from a replay buffer by grouping frames by ``traj_ids``.
 - :func:`~torchrl.collectors.utils.split_trajectories` reshapes a flat batch
   into a padded ``[n_trajs, max_len]`` tensordict using ``traj_ids`` to find

--- a/docs/source/reference/collectors_distributed.rst
+++ b/docs/source/reference/collectors_distributed.rst
@@ -43,7 +43,7 @@ node or across multiple nodes.
   All distributed collectors support ``trajs_per_batch`` combined with
   ``replay_buffer``.  When set, each remote worker assembles **complete
   trajectories** and writes them to the shared buffer as flat 1-D sequences,
-  which is directly compatible with :class:`~torchrl.data.SliceSampler`.
+  which is directly compatible with :class:`~torchrl.data.replay_buffers.SliceSampler`.
   See :ref:`collectors_replay_trajs` for examples and best practices.
 
 .. autosummary::

--- a/docs/source/reference/collectors_replay.rst
+++ b/docs/source/reference/collectors_replay.rst
@@ -93,7 +93,7 @@ Complete trajectory collection with ``trajs_per_batch``
 When using a multi-process collector
 (:class:`~torchrl.collectors.MultiSyncCollector` or
 :class:`~torchrl.collectors.MultiAsyncCollector`) with fixed-frame batches
-and a :class:`~torchrl.data.SliceSampler`, adjacent frames in the buffer can
+and a :class:`~torchrl.data.replay_buffers.SliceSampler`, adjacent frames in the buffer can
 come from **different workers and different episodes** without an intervening
 ``done`` signal.  The sampler has no way to detect these invisible boundaries,
 so it may draw slices that straddle unrelated trajectories — silently
@@ -104,7 +104,7 @@ assembles **complete trajectories** (episodes whose last step carries
 ``("next", "done") == True``) before writing them to the buffer as flat 1-D
 sequences — no padding, no artificial boundaries.  Every trajectory in the
 buffer is guaranteed to be a genuine episode segment, making it directly
-compatible with :class:`~torchrl.data.SliceSampler`.
+compatible with :class:`~torchrl.data.replay_buffers.SliceSampler`.
 
 **Synchronous iteration (for-loop)**
 
@@ -179,7 +179,7 @@ replay-buffer semantics:
 
     Without ``trajs_per_batch``, a multi-process collector writes fixed-frame
     batches from each worker.  If the buffer uses a
-    :class:`~torchrl.data.SliceSampler`, the sampler will reconstruct episode
+    :class:`~torchrl.data.replay_buffers.SliceSampler`, the sampler will reconstruct episode
     boundaries from ``done`` signals, but worker batch boundaries are invisible
     — consecutive frames in the buffer may belong to completely different
     episodes.
@@ -196,7 +196,7 @@ replay-buffer semantics:
 
     - :class:`~torchrl.collectors.BaseCollector` for the full ``trajs_per_batch``
       API, completeness guarantee, and batched-environment behaviour.
-    - :class:`~torchrl.data.SliceSampler` for configuring sub-sequence sampling
+    - :class:`~torchrl.data.replay_buffers.SliceSampler` for configuring sub-sequence sampling
       from the buffer.
     - :ref:`The trajectory batching section <collectors_single>` in the
       single-node collector docs for the non-replay-buffer usage

--- a/docs/source/reference/collectors_single.rst
+++ b/docs/source/reference/collectors_single.rst
@@ -58,7 +58,7 @@ internally; it does **not** determine the output batch size when
 **Replay buffer integration**: when a ``replay_buffer`` is also provided,
 complete trajectories are written to the buffer as **flat 1-D sequences** (no
 padding) instead of being yielded.  This is the recommended pattern for
-off-policy training with :class:`~torchrl.data.SliceSampler`, especially
+off-policy training with :class:`~torchrl.data.replay_buffers.SliceSampler`, especially
 with multi-process collectors where fixed-frame batches can silently mix
 episodes.  See :ref:`collectors_replay_trajs` for full details and examples.
 
@@ -71,7 +71,7 @@ Using AsyncBatchedCollector
 ---------------------------
 
 The :class:`AsyncBatchedCollector` pairs an :class:`~torchrl.envs.AsyncEnvPool`
-with an :class:`~torchrl.modules.InferenceServer` to pipeline environment
+with an :class:`~torchrl.modules.inference_server.InferenceServer` to pipeline environment
 stepping and batched GPU inference.  You only need to supply **env factories**
 and a **policy** -- all internal wiring is handled automatically:
 
@@ -192,7 +192,7 @@ Data collectors that have been started with `start()` should be shut down using
 
     For maximum throughput with trajectory-based training (e.g. recurrent
     policies, decision transformers), combine ``start()`` with
-    ``trajs_per_batch`` and a :class:`~torchrl.data.SliceSampler`:
+    ``trajs_per_batch`` and a :class:`~torchrl.data.replay_buffers.SliceSampler`:
 
     .. code-block:: python
 

--- a/docs/source/reference/collectors_weightsync.rst
+++ b/docs/source/reference/collectors_weightsync.rst
@@ -548,7 +548,7 @@ Common patterns:
    * - ``"env.transform[0]"``
      - First transform on the env
    * - ``"env.transform[0].module"``
-     - The ``module`` attribute of a :class:`ModuleTransform`
+     - The ``module`` attribute of a :class:`~torchrl.envs.transforms.ModuleTransform`
    * - ``"replay_buffer.transform[0].module"``
      - Module inside a replay-buffer transform
 

--- a/docs/source/reference/data_layout.rst
+++ b/docs/source/reference/data_layout.rst
@@ -30,8 +30,8 @@ Two main patterns coexist in TorchRL:
   trajectory / slice, ``("next", "done")`` at the last). No padding, no
   mask, no wasted FLOPs. Every TorchRL primitive that needs to know about
   trajectory structure (recurrent modules under
-  :func:`~torchrl.modules.set_recurrent_mode`,
-  :class:`~torchrl.data.SliceSampler`, value estimators in
+  :class:`~torchrl.modules.set_recurrent_mode`,
+  :class:`~torchrl.data.replay_buffers.SliceSampler`, value estimators in
   ``shifted=True`` value estimators) consumes this layout natively.
 
 The rest of this page walks through the building blocks.
@@ -53,7 +53,7 @@ Four per-step boolean keys jointly describe a trajectory:
     the key recurrent modules
     (:class:`~torchrl.modules.LSTMModule`,
     :class:`~torchrl.modules.GRUModule`) split on under
-    :func:`~torchrl.modules.set_recurrent_mode` ``("recurrent")``: each
+    :class:`~torchrl.modules.set_recurrent_mode` ``("recurrent")``: each
     ``is_init=True`` position resets the hidden state to whatever was stored
     at that index, letting the RNN process a flat batch of concatenated
     trajectories as if it had been called recursively on each one.
@@ -63,7 +63,7 @@ Four per-step boolean keys jointly describe a trajectory:
     ``truncated`` (TorchRL's
     :class:`~torchrl.envs.EnvBase` metaclass guarantees both are flanked
     with their dual). Used by collectors to decide when to reset, by
-    :class:`~torchrl.data.SliceSampler` to reconstruct trajectory boundaries
+    :class:`~torchrl.data.replay_buffers.SliceSampler` to reconstruct trajectory boundaries
     when no ``traj_ids`` key is available, and by
     :func:`~torchrl.collectors.utils.split_trajectories` (legacy).
 
@@ -81,7 +81,7 @@ Four per-step boolean keys jointly describe a trajectory:
 ``("collector", "traj_ids")``
     *Optional integer per-step trajectory identifier.* Written by every
     :class:`~torchrl.collectors.BaseCollector` subclass. When present,
-    :class:`~torchrl.data.SliceSampler` uses this directly instead of
+    :class:`~torchrl.data.replay_buffers.SliceSampler` uses this directly instead of
     reconstructing boundaries from ``done``. Auto-detected on the first
     sample call when no ``traj_key`` is passed at construction.
 
@@ -104,7 +104,7 @@ preserve when extending. The natural mapping is:
   writes ``B`` rows of ``T`` consecutive frames each. Useful when the
   collector itself produces ``[num_envs, frames_per_env]`` batches (e.g.
   :class:`~torchrl.envs.ParallelEnv` rollouts), because that lets the
-  :class:`~torchrl.data.SliceSampler` infer one trajectory per row without
+  :class:`~torchrl.data.replay_buffers.SliceSampler` infer one trajectory per row without
   scanning ``done`` keys.
 * ``ndim=3`` and beyond — when both an outer worker dim and an env dim
   exist, e.g. ``MultiSyncCollector([ParallelEnv(2, …)] * 4, …)``.
@@ -124,7 +124,7 @@ many actors — the inter-worker write order is uncontrolled. Without
 boundary markers, a given row of the ``[N, T]`` storage can stitch
 together frames from a worker's two consecutive but unrelated episodes
 (or from different workers if a postprocessing step rearranges the extend
-order), and a :class:`~torchrl.data.SliceSampler` drawing whole rows would
+order), and a :class:`~torchrl.data.replay_buffers.SliceSampler` drawing whole rows would
 silently span them.
 
 Two existing knobs mitigate this without giving up ``ndim >= 2``:
@@ -141,7 +141,7 @@ Two existing knobs mitigate this without giving up ``ndim >= 2``:
   where complete-trajectory writes are an option.
 
 * **One buffer per worker, glued by a**
-  :class:`~torchrl.data.replay_buffers.ReplayBufferEnsemble`. Each member
+  :class:`~torchrl.data.ReplayBufferEnsemble`. Each member
   storage is written by exactly one worker, so its write order is
   deterministic and ``ndim >= 2`` is sound for that member. The ensemble
   samples uniformly across members at training time:
@@ -259,7 +259,7 @@ or more **complete trajectories** (last step has
 so even when worker A's flush interleaves with worker B's, the resulting
 storage is just a concatenation of complete episodes. No intra-episode
 boundary ever sits at a worker-handoff seam, and the
-:class:`~torchrl.data.SliceSampler`'s boundary detection works on a flat
+:class:`~torchrl.data.replay_buffers.SliceSampler`'s boundary detection works on a flat
 ``ndim = 1`` buffer regardless of write order.
 
 If complete-trajectory writes are not an option (e.g. very long episodes,
@@ -295,7 +295,7 @@ Defaults that match the recommended layout:
   from ``("next", "done")`` if neither key is present.
 
 The flat 1-D output plugs directly into a recurrent policy under
-:func:`~torchrl.modules.set_recurrent_mode` ``("recurrent")``: the
+:class:`~torchrl.modules.set_recurrent_mode` ``("recurrent")``: the
 RNN splits on ``is_init``, treats each slice as an independent
 sub-trajectory, and uses each slice's stored hidden state at position 0
 as its initial hidden state. The output is identical (bitwise) to what a
@@ -404,7 +404,7 @@ release. The recommended replacement is to keep the collector output
 flat (``split_trajs=False``, the default) and:
 
 * If you need to draw sub-sequences for training, write the data into a
-  buffer with a :class:`~torchrl.data.SliceSampler`.
+  buffer with a :class:`~torchrl.data.replay_buffers.SliceSampler`.
 * If you need per-trajectory aggregates (returns, lengths) for logging,
   group by ``("collector", "traj_ids")`` directly on the flat tensor.
 * If you need a ragged ``[N_traj, T_var]`` view for a custom op, prefer
@@ -461,7 +461,7 @@ See also
   sampler used throughout this page.
 * :class:`~torchrl.modules.LSTMModule`,
   :class:`~torchrl.modules.GRUModule`,
-  :func:`~torchrl.modules.set_recurrent_mode` — the recurrent modules
+  :class:`~torchrl.modules.set_recurrent_mode` — the recurrent modules
   that consume the contiguous-trajectory layout natively.
 * :func:`~torchrl.modules.canonicalize_rnn_subset` — narrow
   canonicalization for multi-RNN learners.

--- a/docs/source/reference/data_replaybuffers.rst
+++ b/docs/source/reference/data_replaybuffers.rst
@@ -72,7 +72,7 @@ storage entries.
     >>> assert (rb[:] == data).all()
 
 TED-format conversion
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 The following helpers convert between the TorchRL Episode Data (TED) layout and
 a flat, storage-friendly representation when serializing or restoring a buffer:

--- a/docs/source/reference/data_replaybuffers.rst
+++ b/docs/source/reference/data_replaybuffers.rst
@@ -36,7 +36,7 @@ Supported data types and choosing a storage
 
 In theory, replay buffers support any data type but we can't guarantee that each
 component will support any data type. The most crude replay buffer implementation
-is made of a :class:`~torchrl.data.replay_buffers.ReplayBuffer` base with a
+is made of a :class:`~torchrl.data.ReplayBuffer` base with a
 :class:`~torchrl.data.replay_buffers.ListStorage` storage. This is very inefficient
 but it will allow you to store complex data structures with non-tensor data.
 Storages in contiguous memory include :class:`~torchrl.data.replay_buffers.TensorStorage`,

--- a/docs/source/reference/data_replaybuffers.rst
+++ b/docs/source/reference/data_replaybuffers.rst
@@ -70,3 +70,18 @@ storage entries.
     >>> data["target"] = data["obs"] + 1
     >>> rb.write_all(data)
     >>> assert (rb[:] == data).all()
+
+TED-format conversion
+~~~~~~~~~~~~~~~~~~~~~~
+
+The following helpers convert between the TorchRL Episode Data (TED) layout and
+a flat, storage-friendly representation when serializing or restoring a buffer:
+
+.. currentmodule:: torchrl.data
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template.rst
+
+    TED2Flat
+    Flat2TED

--- a/docs/source/reference/data_storage.rst
+++ b/docs/source/reference/data_storage.rst
@@ -34,7 +34,7 @@ Storage Performance
 
 Storage choice is very influential on replay buffer sampling latency, especially
 in distributed reinforcement learning settings with larger data volumes.
-:class:`~torchrl.data.replay_buffers.storages.LazyMemmapStorage` is highly
+:class:`~torchrl.data.replay_buffers.LazyMemmapStorage` is highly
 advised in distributed settings with shared storage due to the lower serialization
 cost of MemoryMappedTensors as well as the ability to specify file storage locations
 for improved node failure recovery.

--- a/docs/source/reference/envs_api.rst
+++ b/docs/source/reference/envs_api.rst
@@ -124,7 +124,7 @@ Limitations:
   inspected without instantiation, so auto-wrapping is skipped for them.
   Either build the policy once and pass it via ``policy=``, or attach
   transforms manually with
-  :func:`~torchrl.modules.utils.get_env_transforms_from_module`.
+  :func:`~torchrl.modules.get_env_transforms_from_module`.
 
 .. _Environment-compile-arg:
 
@@ -132,7 +132,7 @@ Compiling envs via the ``compile=`` constructor argument
 --------------------------------------------------------
 
 Every concrete :class:`~torchrl.envs.EnvBase` subclass and
-:class:`~torchrl.envs.TransformedEnv` inherit a ``compile`` keyword argument
+:class:`~torchrl.envs.transforms.TransformedEnv` inherit a ``compile`` keyword argument
 on their constructors. When provided, the :class:`~torchrl.envs.EnvBase`
 metaclass post-init hook calls :meth:`~torchrl.envs.EnvBase.compile` on the
 fully-built env (after spec locking, after auto-reset wrapping if any, after
@@ -211,7 +211,7 @@ With these, the following methods are implemented:
   environments if it needs to. It returns the updated input with a ``"next"``
   key containing the data of the next step, as well as a tensordict containing
   the input data for the next step (ie, reset or result or
-  :func:`~torchrl.envs.utils.step_mdp`)
+  :func:`~torchrl.envs.step_mdp`)
   This is done by reading the ``done_keys`` and
   assigning a ``"_reset"`` signal to each done state. This method allows
   to code non-stopping rollout functions with little effort:
@@ -247,7 +247,7 @@ In brief, a TensorDict is created by the :meth:`~.EnvBase.reset` method,
 then populated with an action by the policy before being passed to the
 :meth:`~.EnvBase.step` method which writes the observations, done flag(s) and
 reward under the ``"next"`` entry. The result of this call is stored for
-delivery and the ``"next"`` entry is gathered by the :func:`~.utils.step_mdp`
+delivery and the ``"next"`` entry is gathered by the :func:`~torchrl.envs.step_mdp`
 function.
 
 .. note::
@@ -280,7 +280,7 @@ function.
 .. note::
 
   In some contexts, it can be useful to mark the first step of a trajectory.
-  TorchRL provides such functionality through the :class:`~torchrl.envs.InitTracker`
+  TorchRL provides such functionality through the :class:`~torchrl.envs.transforms.InitTracker`
   transform.
 
 

--- a/docs/source/reference/envs_libraries.rst
+++ b/docs/source/reference/envs_libraries.rst
@@ -37,12 +37,12 @@ in the relevant functions:
     >>> print(env2._env.env.env)
     <gym.envs.classic_control.pendulum.PendulumEnv at 0x1629916a0>
 
-We can see that the two libraries modify the value returned by :func:`~torchrl.envs.gym.gym_backend()`
+We can see that the two libraries modify the value returned by :func:`~torchrl.envs.gym_backend`
 which can be further used to indicate which library needs to be used for
 the current computation. :class:`~.gym.set_gym_backend` is also a decorator:
 we can use it to tell to a specific function what gym backend needs to be used
 during its execution.
-The :func:`torchrl.envs.libs.gym.gym_backend` function allows you to gather
+The :func:`~torchrl.envs.gym_backend` function allows you to gather
 the current gym backend or any of its modules:
 
         >>> import mo_gymnasium
@@ -56,7 +56,7 @@ the current gym backend or any of its modules:
         <module 'gymnasium.wrappers' from '/path/to/venv/python3.10/site-packages/gymnasium/wrappers/__init__.py'>
 
 Another tool that comes in handy with gym and other external dependencies is
-the :class:`torchrl._utils.implement_for` class. Decorating a function
+the :class:`~torchrl.implement_for` class. Decorating a function
 with ``@implement_for`` will tell torchrl that, depending on the version
 indicated, a specific behavior is to be expected. This allows us to easily
 support multiple versions of gym without requiring any effort from the user side.
@@ -130,7 +130,7 @@ Usually, in such cases the observations delivered with the done and reward (whic
 action in the environment) are actually the first observations of a new episode, and not the last observations of the
 current episode.
 
-To handle these cases, torchrl provides a :class:`~torchrl.envs.AutoResetTransform` that will copy the observations
+To handle these cases, torchrl provides a :class:`~torchrl.envs.transforms.AutoResetTransform` that will copy the observations
 that result from the call to `step` to the next `reset` and skip the calls to `reset` during rollouts (in both
 :meth:`~torchrl.envs.EnvBase.rollout` and :class:`~torchrl.collectors.Collector` iterations).
 This transform class also provides a fine-grained control over the behavior to be adopted for the invalid observations,
@@ -277,6 +277,6 @@ Here is a working example:
   single process, as serializing and deserializing large numbers of tensors
   can be very expensive.
 
-Currently, :func:`~torchrl.envs.utils.check_env_specs` will pass for dynamic specs where a shape varies along some
+Currently, :func:`~torchrl.envs.check_env_specs` will pass for dynamic specs where a shape varies along some
 dimensions, but not when a key is present during a step and absent during others, or when the number of dimensions
 varies.

--- a/docs/source/reference/envs_recorders.rst
+++ b/docs/source/reference/envs_recorders.rst
@@ -21,9 +21,9 @@ Recording videos
 Several backends offer the possibility of recording rendered images from the environment.
 If the pixels are already part of the environment output (e.g. Atari or other game simulators), a
 :class:`~torchrl.record.VideoRecorder` can be appended to the environment. This environment transform takes as input
-a logger capable of recording videos (e.g. :class:`~torchrl.record.loggers.CSVLogger`, :class:`~torchrl.record.loggers.WandbLogger`
+a logger capable of recording videos (e.g. :class:`~torchrl.record.loggers.csv.CSVLogger`, :class:`~torchrl.record.loggers.wandb.WandbLogger`
 or :class:`~torchrl.record.loggers.TensorBoardLogger`) as well as a tag indicating where the video should be saved.
-For instance, to save mp4 videos on disk, one can use :class:`~torchrl.record.loggers.CSVLogger` with a `video_format="mp4"`
+For instance, to save mp4 videos on disk, one can use :class:`~torchrl.record.loggers.csv.CSVLogger` with a `video_format="mp4"`
 argument.
 
 The :class:`~torchrl.record.VideoRecorder` transform can handle batched images and automatically detects numpy or PyTorch

--- a/docs/source/reference/envs_transforms.rst
+++ b/docs/source/reference/envs_transforms.rst
@@ -48,7 +48,7 @@ pixels or states etc).
 Forward and inverse transforms
 ------------------------------
 
-Transforms also have an :meth:`~torchrl.envs.Transform.inv` method that is called before the action is applied in reverse
+Transforms also have an :meth:`~torchrl.envs.transforms.Transform.inv` method that is called before the action is applied in reverse
 order over the composed transform chain. This allows applying transforms to data in the environment before the action is
 taken in the environment. The keys to be included in this inverse transform are passed through the `"in_keys_inv"`
 keyword argument, and the out-keys default to these values in most cases:
@@ -67,7 +67,7 @@ In transforms, `in_keys` and `out_keys` define the interaction between the base 
 (e.g., your policy):
 
 - `in_keys` refers to the base environment's perspective (inner = `base_env` of the
-  :class:`~torchrl.envs.TransformedEnv`).
+  :class:`~torchrl.envs.transforms.TransformedEnv`).
 - `out_keys` refers to the outside world (outer = `policy`, `agent`, etc.).
 
 For example, with `in_keys=["obs"]` and `out_keys=["obs_standardized"]`, the policy will "see" a standardized
@@ -78,7 +78,7 @@ Similarly, for inverse keys:
 - `in_keys_inv` refers to entries as seen by the base environment.
 - `out_keys_inv` refers to entries as seen or produced by the policy.
 
-The following figure illustrates this concept for the :class:`~torchrl.envs.RenameTransform` class: the input
+The following figure illustrates this concept for the :class:`~torchrl.envs.transforms.RenameTransform` class: the input
 `TensorDict` of the `step` function must include the `out_keys_inv` as they are part of the outside world. The
 transform changes these names to match the names of the inner, base environment using the `in_keys_inv`.
 The inverse process is executed with the output tensordict, where the `in_keys` are mapped to the corresponding
@@ -120,7 +120,7 @@ Exposing Specs to the Outside World
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `TransformedEnv` will expose the specs corresponding to the `out_keys_inv` for actions and states.
-For example, with :class:`~torchrl.envs.ActionDiscretizer`, the environment's action (e.g., `"action"`) is a float-valued
+For example, with :class:`~torchrl.envs.transforms.ActionDiscretizer`, the environment's action (e.g., `"action"`) is a float-valued
 tensor that should not be generated when using :meth:`~torchrl.envs.EnvBase.rand_action` with the transformed
 environment. Instead, `"action_discrete"` should be generated, and its continuous counterpart obtained from the
 transform. Therefore, the user should see the `"action_discrete"` entry being exposed, but not `"action"`.
@@ -148,22 +148,22 @@ Tips for subclassing `Transform`
 There are various ways of subclassing a transform. The things to take into considerations are:
 
 - Is the transform identical for each tensor / item being transformed? Use
-  :meth:`~torchrl.envs.Transform._apply_transform` and :meth:`~torchrl.envs.Transform._inv_apply_transform`.
+  :meth:`~torchrl.envs.transforms.Transform._apply_transform` and :meth:`~torchrl.envs.transforms.Transform._inv_apply_transform`.
 - The transform needs access to the input data to env.step as well as output? Rewrite
-  :meth:`~torchrl.envs.Transform._step`.
-  Otherwise, rewrite :meth:`~torchrl.envs.Transform._call` (or :meth:`~torchrl.envs.Transform._inv_call`).
-- Is the transform to be used within a replay buffer? Overwrite :meth:`~torchrl.envs.Transform.forward`,
-  :meth:`~torchrl.envs.Transform.inv`, :meth:`~torchrl.envs.Transform._apply_transform` or
-  :meth:`~torchrl.envs.Transform._inv_apply_transform`.
+  :meth:`~torchrl.envs.transforms.Transform._step`.
+  Otherwise, rewrite :meth:`~torchrl.envs.transforms.Transform._call` (or :meth:`~torchrl.envs.transforms.Transform._inv_call`).
+- Is the transform to be used within a replay buffer? Overwrite :meth:`~torchrl.envs.transforms.Transform.forward`,
+  :meth:`~torchrl.envs.transforms.Transform.inv`, :meth:`~torchrl.envs.transforms.Transform._apply_transform` or
+  :meth:`~torchrl.envs.transforms.Transform._inv_apply_transform`.
 - Within a transform, you can access (and make calls to) the parent environment using
-  :attr:`~torchrl.envs.Transform.parent` (the base env + all transforms till this one) or
-  :meth:`~torchrl.envs.Transform.container` (The object that encapsulates the transform).
-- Don't forget to edits the specs if needed: top level: :meth:`~torchrl.envs.Transform.transform_output_spec`,
-  :meth:`~torchrl.envs.Transform.transform_input_spec`.
-  Leaf level: :meth:`~torchrl.envs.Transform.transform_observation_spec`,
-  :meth:`~torchrl.envs.Transform.transform_action_spec`, :meth:`~torchrl.envs.Transform.transform_state_spec`,
-  :meth:`~torchrl.envs.Transform.transform_reward_spec` and
-  :meth:`~torchrl.envs.Transform.transform_reward_spec`.
+  :attr:`~torchrl.envs.transforms.Transform.parent` (the base env + all transforms till this one) or
+  :meth:`~torchrl.envs.transforms.Transform.container` (The object that encapsulates the transform).
+- Don't forget to edits the specs if needed: top level: :meth:`~torchrl.envs.transforms.Transform.transform_output_spec`,
+  :meth:`~torchrl.envs.transforms.Transform.transform_input_spec`.
+  Leaf level: :meth:`~torchrl.envs.transforms.Transform.transform_observation_spec`,
+  :meth:`~torchrl.envs.transforms.Transform.transform_action_spec`, :meth:`~torchrl.envs.transforms.Transform.transform_state_spec`,
+  :meth:`~torchrl.envs.transforms.Transform.transform_reward_spec` and
+  :meth:`~torchrl.envs.transforms.Transform.transform_reward_spec`.
 
 For practical examples, see the methods listed above.
 

--- a/docs/source/reference/envs_vectorized.rst
+++ b/docs/source/reference/envs_vectorized.rst
@@ -22,7 +22,7 @@ Of course, a :class:`ParallelEnv` will have a batch size that corresponds to its
 
 It is important that your environment specs match the input and output that it sends and receives, as
 :class:`ParallelEnv` will create buffers from these specs to communicate with the spawn processes.
-Check the :func:`~torchrl.envs.utils.check_env_specs` method for a sanity check.
+Check the :func:`~torchrl.envs.check_env_specs` method for a sanity check.
 
 .. code-block::
    :caption: Parallel environment
@@ -59,7 +59,7 @@ one can simply call:
   will create data buffers based on the environment specs to pass data from one process
   to another. This means that a misspecified spec (input, observation or reward) will
   cause a breakage at runtime as the data can't be written on the preallocated buffer.
-  In general, an environment should be tested using the :func:`~.utils.check_env_specs`
+  In general, an environment should be tested using the :func:`~torchrl.envs.check_env_specs`
   test function before being used in a :class:`ParallelEnv`. This function will raise
   an assertion error whenever the preallocated buffer and the collected data mismatch.
 
@@ -131,8 +131,8 @@ size of the tensordict that holds it. The classes armed to deal with this are:
 - Batch-unlocked environments;
 - Unbatched environments (i.e., environments without batch size). In these environments, the :meth:`~torchrl.envs.EnvBase.step`
   method will first look for a `"_step"` entry and, if present, act accordingly.
-  If a :class:`~torchrl.envs.Transform` instance passes a `"_step"` entry to the tensordict, it is also captured by
-  :class:`~torchrl.envs.TransformedEnv`'s own `_step` method which will skip the `base_env.step` as well as any further
+  If a :class:`~torchrl.envs.transforms.Transform` instance passes a `"_step"` entry to the tensordict, it is also captured by
+  :class:`~torchrl.envs.transforms.TransformedEnv`'s own `_step` method which will skip the `base_env.step` as well as any further
   transformation.
 
 When dealing with partial steps, the strategy is always to use the step output and mask missing values with the previous
@@ -144,7 +144,7 @@ is not observed because these classes handle the passing of data properly.
 Partial steps are an essential feature of :meth:`~torchrl.envs.EnvBase.rollout` when `break_when_all_done` is `True`,
 as the environments with a `True` done state will need to be skipped during calls to `_step`.
 
-The :class:`~torchrl.envs.ConditionalSkip` transform allows you to programmatically ask for (partial) step skips.
+The :class:`~torchrl.envs.transforms.ConditionalSkip` transform allows you to programmatically ask for (partial) step skips.
 
 Partial Resets
 ~~~~~~~~~~~~~~
@@ -290,7 +290,7 @@ the output of others.
 This family of classes is particularly interesting when dealing with environments that have a high (and/or variable)
 latency.
 
-.. note:: This class and its subclasses should work when nested in with :class:`~torchrl.envs.TransformedEnv` and
+.. note:: This class and its subclasses should work when nested in with :class:`~torchrl.envs.transforms.TransformedEnv` and
     batched environments, but users won't currently be able to use the async features of the base environment when
     it's nested in these classes. One should prefer nested transformed envs within an `AsyncEnvPool` instead.
     If this is not possible, please raise an issue.

--- a/docs/source/reference/glossary.rst
+++ b/docs/source/reference/glossary.rst
@@ -23,8 +23,8 @@ terms with the minimum context needed to find the relevant code.
       A TorchRL environment that owns more than one environment instance under
       a single :class:`~torchrl.envs.EnvBase` interface. The common
       implementations are :class:`~torchrl.envs.SerialEnv` and
-      :class:`~torchrl.envs.ParallelEnv`, both subclasses of
-      :class:`~torchrl.envs.batched_envs.BatchedEnvBase`. Their ``batch_size`` is the
+      :class:`~torchrl.envs.ParallelEnv`, both subclasses of the internal
+      ``BatchedEnvBase``. Their ``batch_size`` is the
       leading shape of reset, step, and collector outputs.
 
    carrier
@@ -62,8 +62,8 @@ terms with the minimum context needed to find the relevant code.
       Short for environment: an object implementing the
       :class:`~torchrl.envs.EnvBase` API, including ``reset``, ``step``, specs,
       device handling, and a tensordict-based input/output contract. TorchRL env
-      wrappers usually subclass :class:`~torchrl.envs.Transform` or compose a
-      :class:`~torchrl.envs.TransformedEnv` rather than following the Gym
+      wrappers usually subclass :class:`~torchrl.envs.transforms.Transform` or compose a
+      :class:`~torchrl.envs.transforms.TransformedEnv` rather than following the Gym
       wrapper API directly.
 
    env batch size
@@ -106,7 +106,7 @@ terms with the minimum context needed to find the relevant code.
 
    is_init
       A boolean key (default name: ``"is_init"``) written by
-      :class:`~torchrl.envs.InitTracker` immediately after every env reset.
+      :class:`~torchrl.envs.transforms.InitTracker` immediately after every env reset.
       Recurrent modules and advantage estimators read this key to know where
       trajectories begin so they can zero out stale hidden state or reset the
       bootstrap target.
@@ -166,26 +166,26 @@ terms with the minimum context needed to find the relevant code.
       :meth:`~torchrl.objectives.LossModule.set_keys` to modify them.
 
    TensorDictPrimer
-      A :class:`~torchrl.envs.Transform` that injects keys into the
+      A :class:`~torchrl.envs.transforms.Transform` that injects keys into the
       environment's reset / step output that the policy needs but the env does
       not natively produce, most commonly RNN hidden states. Without a primer,
       the first call to a recurrent policy after reset would have no hidden
-      state to read. See :class:`~torchrl.envs.TensorDictPrimer` and
+      state to read. See :class:`~torchrl.envs.transforms.TensorDictPrimer` and
       :meth:`torchrl.modules.LSTMModule.make_tensordict_primer`.
 
    trajectory ID
       An integer that uniquely identifies which trajectory each frame belongs
       to. Written by :class:`~torchrl.collectors.SyncDataCollector` as
       ``("collector", "traj_ids")`` when ``track_traj_ids=True``. Used by
-      :class:`~torchrl.data.SliceSampler` to draw whole trajectories from a
+      :class:`~torchrl.data.replay_buffers.SliceSampler` to draw whole trajectories from a
       buffer and by :func:`~torchrl.collectors.utils.split_trajectories` to
       slice a flat batch into per-trajectory chunks.
 
    Transform
       TorchRL's tensordict-native environment transform abstraction,
-      :class:`~torchrl.envs.Transform`. A transform can modify input specs,
+      :class:`~torchrl.envs.transforms.Transform`. A transform can modify input specs,
       output specs, reset data, step data, or inverse action data, and is
-      usually installed through :class:`~torchrl.envs.TransformedEnv`. This is
+      usually installed through :class:`~torchrl.envs.transforms.TransformedEnv`. This is
       distinct from a Gym wrapper, which operates on non-tensordict values.
 
 See also

--- a/docs/source/reference/isaaclab.rst
+++ b/docs/source/reference/isaaclab.rst
@@ -15,7 +15,7 @@ For general IsaacLab installation and cluster setup (not specific to TorchRL), s
 IsaacLabWrapper
 ---------------
 
-Use :class:`~torchrl.envs.libs.isaac_lab.IsaacLabWrapper` to wrap a gymnasium
+Use :class:`~torchrl.envs.IsaacLabWrapper` to wrap a gymnasium
 IsaacLab environment into a TorchRL-compatible :class:`~torchrl.envs.EnvBase`:
 
 .. code-block:: python
@@ -244,7 +244,7 @@ If you need distributed collection across multiple GPUs/nodes, use
 Replay Buffer
 -------------
 
-The :class:`~torchrl.data.SliceSampler` needs enough sequential data.  With
+The :class:`~torchrl.data.replay_buffers.SliceSampler` needs enough sequential data.  With
 ``batch_length=50``, you need at least 50 time steps per trajectory before
 sampling::
 
@@ -253,7 +253,7 @@ sampling::
                         = 204,800
 
 For GPU-resident replay buffers, use
-:class:`~torchrl.data.LazyTensorStorage` with the target CUDA device.
+:class:`~torchrl.data.replay_buffers.LazyTensorStorage` with the target CUDA device.
 This avoids CPU→GPU transfer at sample time (but adds it at extend time).
 
 TorchRL-Specific Gotchas
@@ -268,7 +268,7 @@ TorchRL-Specific Gotchas
 
 3. **``TensorDictPrimer`` ``expand_specs``**: When adding primers (e.g.,
    ``state``, ``belief``) to a pre-vectorized env, you MUST pass
-   ``expand_specs=True`` to :class:`~torchrl.envs.TensorDictPrimer`.
+   ``expand_specs=True`` to :class:`~torchrl.envs.transforms.TensorDictPrimer`.
    Otherwise the primer shapes ``()`` conflict with the env's ``batch_size``
    ``(4096,)``.
 

--- a/docs/source/reference/llms.rst
+++ b/docs/source/reference/llms.rst
@@ -253,7 +253,7 @@ We provide a few task-specific environments, such as :class:`~torchrl.envs.llm.G
 :class:`~torchrl.envs.llm.IFEvalEnv` for the IFEval dataset, and :class:`~torchrl.envs.llm.MLGymEnv` for MLGym integration.
 
 These environments wrap a :class:`~torchrl.envs.llm.ChatEnv` and add a :class:`~torchrl.envs.llm.transforms.DataLoadingPrimer` transform
-(plus an optional reward parsing transform) in a :class:`~torchrl.envs.TransformedEnv` class.
+(plus an optional reward parsing transform) in a :class:`~torchrl.envs.transforms.TransformedEnv` class.
 
 
 

--- a/docs/source/reference/macro_primitives.rst
+++ b/docs/source/reference/macro_primitives.rst
@@ -1,4 +1,4 @@
-.. currentmodule:: torchrl.envs
+.. currentmodule:: torchrl.envs.transforms
 
 .. _macro-primitives-guide:
 
@@ -184,7 +184,7 @@ to set it is the domain action object, exactly like the other two examples:
 
 That is the whole policy-side command: "make the satellite attitude match this
 target frame". The :class:`SatelliteAttitudeTransform` maps this semantic target
-to the low-level action. It reads these :class:`SatelliteEnv` observations:
+to the low-level action. It reads these :class:`~torchrl.envs.SatelliteEnv` observations:
 
 * ``bus_quat``: current satellite attitude quaternion, shape ``(..., 4)``;
 * ``bus_omega``: current body angular velocity, shape ``(..., 3)``;
@@ -217,7 +217,7 @@ CMG count and action scale:
    )
 
 The reset state still contains ``target_quat`` and ``init_bus_quat``. The target
-attitude frame is also rendered by :class:`SatelliteEnv` as a non-colliding RGB
+attitude frame is also rendered by :class:`~torchrl.envs.SatelliteEnv` as a non-colliding RGB
 visual frame, while the satellite body is semi-transparent so the attitude error
 is visible.
 
@@ -262,7 +262,7 @@ A policy can therefore use observations such as ``cube_pos``, ``bowl_pos`` and
 
 Here the position is the coordinate of an object that needs to be moved by the
 robot, expressed in the same world frame as the gripper observations. The
-:meth:`CubeBowlEnv.make_urscript_transform` preset maps that Cartesian pose to a
+:meth:`~torchrl.envs.CubeBowlEnv.make_urscript_transform` preset maps that Cartesian pose to a
 low-level joint target using the env-provided MuJoCo IK helper, fills the
 requested gripper command, interpolates the seven-dimensional action sequence,
 and executes it when ``execute=True``.
@@ -327,14 +327,14 @@ Comparison
      - Where shape and dtype come from
    * - Humanoid
      - :meth:`HumanoidMacroAction.reach_control <HumanoidMacroAction.reach_control>`
-     - :meth:`HumanoidEnv.make_control_transform <HumanoidEnv.make_control_transform>`
+     - :meth:`HumanoidEnv.make_control_transform <torchrl.envs.HumanoidEnv.make_control_transform>`
        / :class:`MacroPrimitiveTransform`
      - A low-level MuJoCo actuator-control destination
      - ``base_env.action_spec``
    * - Satellite
      - :meth:`SatelliteMacroAction.slew_attitude <SatelliteMacroAction.slew_attitude>`
        (a ``("action", "target")`` quaternion)
-     - :meth:`SatelliteEnv.make_attitude_transform <SatelliteEnv.make_attitude_transform>`
+     - :meth:`SatelliteEnv.make_attitude_transform <torchrl.envs.SatelliteEnv.make_attitude_transform>`
        / :class:`SatelliteAttitudeTransform`
      - A desired target attitude quaternion; the transform computes the
        normalized CMG gimbal-rate command
@@ -344,7 +344,7 @@ Comparison
        ``action_spec`` for final commands
    * - Cube bowl
      - :class:`RobotMacroAction` commands such as ``reach_pose`` and ``close_gripper``
-     - :meth:`CubeBowlEnv.make_urscript_transform` /
+     - :meth:`~torchrl.envs.CubeBowlEnv.make_urscript_transform` /
        :class:`URScriptPrimitiveTransform`
      - A semantic Cartesian pose, joint target or gripper command; the transform
        maps it to the seven-dimensional robot action

--- a/docs/source/reference/modules_critics.rst
+++ b/docs/source/reference/modules_critics.rst
@@ -10,6 +10,9 @@ Value networks estimate the value of states or state-action pairs.
     :template: rl_template_noinherit.rst
 
     ValueOperator
+    ValueNorm
+    PopArtValueNorm
+    RunningValueNorm
     DuelingCnnDQNet
     DistributionalDQNnet
     ConvNet
@@ -23,6 +26,7 @@ Value networks estimate the value of states or state-action pairs.
     LSTMModule
     GRUModule
     canonicalize_rnn_subset
+    set_recurrent_mode
     OnlineDTActor
     DTActor
     DecisionTransformer

--- a/docs/source/reference/modules_rnn.rst
+++ b/docs/source/reference/modules_rnn.rst
@@ -23,7 +23,7 @@ environment, the previous recurrent state is read from the TensorDict, and the
 next recurrent state is written under ``("next", ...)``.
 
 During training, wrap the recurrent policy with
-:func:`set_recurrent_mode` to process complete rollouts or replay-buffer
+:class:`set_recurrent_mode` to process complete rollouts or replay-buffer
 slices:
 
 .. code-block:: python
@@ -149,7 +149,7 @@ For most recurrent RL pipelines:
 * Store replay data in the flat contiguous layout and sample with
   :class:`~torchrl.data.replay_buffers.SliceSampler`.
 * Run collection in single-step mode and training under
-  :func:`set_recurrent_mode`.
+  :class:`set_recurrent_mode`.
 * Start with ``recurrent_backend="pad"`` for correctness, then benchmark
   ``"scan"`` or ``"triton"`` for the target hardware.
 
@@ -160,7 +160,7 @@ See also
   handoff.
 * :class:`LSTMModule` and :class:`GRUModule` for constructor arguments and
   examples.
-* :func:`set_recurrent_mode` for switching between single-step and recurrent
+* :class:`set_recurrent_mode` for switching between single-step and recurrent
   execution.
 * :func:`set_recurrent_matmul_precision` and
   :func:`get_recurrent_matmul_precision` for Triton precision control.

--- a/docs/source/reference/objectives_multiagent.rst
+++ b/docs/source/reference/objectives_multiagent.rst
@@ -6,8 +6,8 @@ Multi-Agent Objectives
 Loss modules for multi-agent reinforcement learning algorithms. These losses
 follow the torchrl multi-agent tensordict convention (per-agent tensors
 nested under group keys such as ``("agents", "observation")``; see
-:class:`~torchrl.envs.libs.vmas.VmasEnv` and
-:class:`~torchrl.envs.libs.pettingzoo.PettingZooEnv`).
+:class:`~torchrl.envs.VmasEnv` and
+:class:`~torchrl.envs.PettingZooEnv`).
 
 MAPPO and IPPO
 --------------

--- a/docs/source/reference/profiling.rst
+++ b/docs/source/reference/profiling.rst
@@ -6,7 +6,7 @@ Profiling collectors and envs
 TorchRL ships with a lightweight, opt-in profiling layer built on top of
 ``torch.profiler.record_function``. When enabled, the collector pipeline,
 environment ``step`` / ``reset`` / ``rollout``, vectorised environments,
-``TransformedEnv``, and the policy call inside the collector all emit named
+:class:`~torchrl.envs.transforms.TransformedEnv`, and the policy call inside the collector all emit named
 ranges that show up directly in a Chrome trace or TensorBoard timeline.
 
 When disabled — which is the default — every instrumentation site is a true

--- a/docs/source/reference/recurrent_state_lifecycle.rst
+++ b/docs/source/reference/recurrent_state_lifecycle.rst
@@ -9,13 +9,13 @@ Recurrent policies are not a special or dangerous path in TorchRL. In the
 standard collection setup, most of the wiring is automated: passing a policy
 to an environment, or constructing a collector with
 ``auto_register_policy_transforms=True``, lets TorchRL inspect the policy,
-append :class:`~torchrl.envs.InitTracker`, and add the recurrent-state
+append :class:`~torchrl.envs.transforms.InitTracker`, and add the recurrent-state
 primer required by :class:`~torchrl.modules.LSTMModule` or
 :class:`~torchrl.modules.GRUModule`.
 
 The main rule to keep in mind is simple: if the loss should replay
 sequences, sample sequences. For replay-buffer training, use
-:class:`~torchrl.data.SliceSampler` or another trajectory-aware sampler so
+:class:`~torchrl.data.replay_buffers.SliceSampler` or another trajectory-aware sampler so
 the loss receives contiguous time chunks with ``is_init`` boundaries
 preserved. The rest of this page explains what the automated path wires up,
 and what to check when building a custom loop, custom replay transform, or
@@ -198,12 +198,12 @@ What ``is_init`` means
 ----------------------
 
 ``is_init`` is a boolean key shaped like the env's batch (``(*B, 1)``),
-set by :class:`~torchrl.envs.InitTracker` to ``True`` on the *first* step
+set by :class:`~torchrl.envs.transforms.InitTracker` to ``True`` on the *first* step
 of every trajectory and ``False`` everywhere else. A trajectory begins
 at an explicit :meth:`~torchrl.envs.EnvBase.reset` or right after a
 ``done`` from the previous step.
 
-If you do not append :class:`~torchrl.envs.InitTracker` to your env,
+If you do not append :class:`~torchrl.envs.transforms.InitTracker` to your env,
 ``is_init`` will be absent and :class:`~torchrl.modules.LSTMModule` will
 raise a ``KeyError``. If the key is present but always ``False`` (or if a
 custom replay buffer / transform drops or rewrites the true boundary
@@ -232,7 +232,7 @@ collection):
       hidden1 = torch.where(is_init_expand, zeros, hidden1)
 
 - The new hidden is written under the ``("next", ...)`` keys and
-  :meth:`~torchrl.envs.utils.step_mdp` promotes it to the root for the
+  :func:`~torchrl.envs.step_mdp` promotes it to the root for the
   following step. This is how the carry-forward happens between
   non-boundary steps.
 
@@ -243,7 +243,7 @@ TorchRL loss / advantage code):
 - With the default eager ``"pad"`` backend, if any ``is_init`` in time
   positions ``1..T-1`` is true, the batch contains multiple trajectories
   packed together. The module calls ``_get_num_per_traj_init`` (see
-  :func:`torchrl.objectives.value.utils._get_num_per_traj_init`) to count
+  ``torchrl.objectives.value.utils._get_num_per_traj_init``) to count
   per-trajectory lengths, then ``_split_and_pad_sequence`` to break the
   batch into shape ``(N, T')`` with one trajectory per row.
 - :class:`torch.nn.LSTM` is run on each clean row, then results are
@@ -278,7 +278,7 @@ checkpoints at trajectory ends, not as valid per-step hidden states at every
 position.
 
 With the pad backend, :class:`torch.nn.LSTM` only returns the final hidden
-state for a sequence. :meth:`LSTMModule._lstm` therefore fills hidden slots
+state for a sequence. ``LSTMModule._lstm`` therefore fills hidden slots
 at non-terminal positions with zeros and writes the real final hidden at the
 sequence end. If a batch contains multiple trajectories, the split path
 packs or masks padded steps and writes the final hidden state back at each
@@ -306,7 +306,7 @@ Common debugging symptoms
 -------------------------
 
 **Symptom: reward looks fine but the policy never learns long-horizon behaviour.**
-    Check that :class:`~torchrl.envs.InitTracker` is actually appended to
+    Check that :class:`~torchrl.envs.transforms.InitTracker` is actually appended to
     the environment, and that ``is_init`` appears in the collected
     tensordict with true values at episode starts. A missing key usually
     raises quickly; a present-but-wrong all-false ``is_init`` signal is the
@@ -314,22 +314,22 @@ Common debugging symptoms
 
 **Symptom: training loss diverges or oscillates when you raise the batch's time horizon.**
     Likely hidden-state leakage across trajectory boundaries inside the
-    replay batch. Use :class:`~torchrl.data.SliceSampler` or another
+    replay batch. Use :class:`~torchrl.data.replay_buffers.SliceSampler` or another
     sequence-aware sampler, verify that the recurrent loss path is wrapped
     in ``with set_recurrent_mode(True):``, and check that ``is_init`` is
     preserved through your replay buffer (some transforms drop unknown
     keys).
 
-**Symptom: shapes mismatch in** :meth:`LSTMModule._lstm` **with cryptic transpose errors.**
+**Symptom: shapes mismatch in** ``LSTMModule._lstm`` **with cryptic transpose errors.**
     The module expects the tensordict-native hidden layout
     ``(batch, steps, num_layers, hidden_size)``. A custom
     :class:`~torchrl.envs.transforms.TensorDictPrimer` with a different
     shape, or a manually-constructed hidden, will fail here. Prefer
-    :meth:`LSTMModule.make_tensordict_primer` to avoid drift.
+    :meth:`~torchrl.modules.LSTMModule.make_tensordict_primer` to avoid drift.
 
 **Symptom: "fresh" trajectory inherits the previous episode's behaviour.**
     Either ``is_init`` is not being set at the right step (check
-    :class:`InitTracker`'s placement relative to other transforms that
+    :class:`~torchrl.envs.transforms.InitTracker`'s placement relative to other transforms that
     might reset state), or you are reusing a final hidden as a starting
     state across rollouts (see the previous section).
 
@@ -349,8 +349,8 @@ What to check, in order
 3. ``is_init`` is present in the collected tensordict and is ``True`` on
    reset / immediately after a ``done``.
 4. The recurrent state keys you pass to the LSTM module match the
-   primer's keys (use :meth:`LSTMModule.make_tensordict_primer`).
-5. Replay-buffer training uses :class:`~torchrl.data.SliceSampler` or
+   primer's keys (use :meth:`~torchrl.modules.LSTMModule.make_tensordict_primer`).
+5. Replay-buffer training uses :class:`~torchrl.data.replay_buffers.SliceSampler` or
    another trajectory-aware sampler when the loss consumes sequences.
 6. Loss / advantage code runs under ``with set_recurrent_mode(True):``.
 7. The replay buffer preserves ``is_init`` (and any custom recurrent
@@ -365,7 +365,7 @@ See also
   state.
 - :class:`~torchrl.modules.set_recurrent_mode` — context manager for
   switching execution paths.
-- :class:`~torchrl.envs.InitTracker` — the source of ``is_init``.
-- :func:`torchrl.objectives.value.utils._get_num_per_traj_init` and
-  :func:`torchrl.objectives.value.functional._split_and_pad_sequence` —
+- :class:`~torchrl.envs.transforms.InitTracker` — the source of ``is_init``.
+- ``torchrl.objectives.value.utils._get_num_per_traj_init`` and
+  ``torchrl.objectives.value.functional._split_and_pad_sequence`` —
   the trajectory-boundary plumbing.

--- a/tutorials/sphinx-tutorials/coding_ddpg.py
+++ b/tutorials/sphinx-tutorials/coding_ddpg.py
@@ -156,8 +156,8 @@ collector_device = torch.device("cpu")  # Change the device to ``cuda`` to use C
 # network to this, and generate an action and fit the policy such that its
 # value estimate is maximized.
 #
-# The crucial step of the :meth:`LossModule.__init__` method is the call to
-# :meth:`~torchrl.LossModule.convert_to_functional`. This method will extract
+# The crucial step of the :meth:`LossModule.__init__ <torchrl.objectives.LossModule.__init__>` method is the call to
+# :meth:`~torchrl.objectives.LossModule.convert_to_functional`. This method will extract
 # the parameters from the module and convert it to a functional module.
 # Strictly speaking, this is not necessary and one may perfectly code all
 # the losses without it. However, we encourage its usage for the following
@@ -228,7 +228,7 @@ def _init(
 # intermediate estimator (TD(:math:`\lambda`)) can also be used to compromise
 # bias and variance.
 # TorchRL makes it easy to use one or the other estimator via the
-# :class:`~torchrl.objectives.utils.ValueEstimators` Enum class, which contains
+# :class:`~torchrl.objectives.ValueEstimators` Enum class, which contains
 # pointers to all the value estimators implemented. Let us define the default
 # value function here. We will take the simplest version (TD(0)), and show later
 # on how this can be changed.
@@ -475,7 +475,7 @@ def make_env(from_pixels=False):
 #
 # Now that we have a base environment, we may want to modify its representation
 # to make it more policy-friendly. In TorchRL, transforms are appended to the
-# base environment in a specialized :class:`torchr.envs.TransformedEnv` class.
+# base environment in a specialized :class:`~torchrl.envs.transforms.TransformedEnv` class.
 #
 # - It is common in DDPG to rescale the reward using some heuristic value. We
 #   will multiply the reward by 5 in this example.
@@ -486,12 +486,12 @@ def make_env(from_pixels=False):
 #   both ways: when calling :func:`env.step`, our actions will need to be
 #   represented in double precision, and the output will need to be transformed
 #   to single precision.
-#   The :class:`~torchrl.envs.DoubleToFloat` transform does exactly this: the
+#   The :class:`~torchrl.envs.transforms.DoubleToFloat` transform does exactly this: the
 #   ``in_keys`` list refers to the keys that will need to be transformed from
 #   double to float, while the ``in_keys_inv`` refers to those that need to
 #   be transformed to double before being passed to the environment.
 #
-# - We concatenate the state keys together using the :class:`~torchrl.envs.CatTensors`
+# - We concatenate the state keys together using the :class:`~torchrl.envs.transforms.CatTensors`
 #   transform.
 #
 # - Finally, we also leave the possibility of normalizing the states: we will
@@ -826,7 +826,7 @@ if device == torch.device("cpu"):
 #   .. note::
 #
 #     The ``max_frames_per_traj`` passed to the collector will have the effect
-#     of registering a new :class:`~torchrl.envs.StepCounter` transform
+#     of registering a new :class:`~torchrl.envs.transforms.StepCounter` transform
 #     with the environment used for inference. We can achieve the same result
 #     manually, as we do in this script.
 #

--- a/tutorials/sphinx-tutorials/coding_dqn.py
+++ b/tutorials/sphinx-tutorials/coding_dqn.py
@@ -176,7 +176,7 @@ def is_notebook() -> bool:
 #
 # We will be using five transforms:
 #
-# - :class:`~torchrl.envs.StepCounter` to count the number of steps in each trajectory;
+# - :class:`~torchrl.envs.transforms.StepCounter` to count the number of steps in each trajectory;
 # - :class:`~torchrl.envs.transforms.ToTensorImage` will convert a ``[W, H, C]`` uint8
 #   tensor in a floating point tensor in the ``[0, 1]`` space with shape
 #   ``[C, W, H]``;
@@ -201,7 +201,7 @@ def is_notebook() -> bool:
 #   technically work with every single environment attached to its own set of
 #   transforms.
 # - ``obs_norm_sd`` will contain the normalizing constants for
-#   the :class:`~torchrl.envs.ObservationNorm` transform.
+#   the :class:`~torchrl.envs.transforms.ObservationNorm` transform.
 #
 
 
@@ -260,7 +260,7 @@ def make_env(
 # with a full ``[C, W, H]`` normalizing mask, but with simpler ``[C, 1, 1]``
 # shaped set of normalizing constants (loc and scale parameters).
 # We will be using the ``reduce_dim`` argument
-# of :meth:`~torchrl.envs.ObservationNorm.init_stats` to instruct which
+# of :meth:`~torchrl.envs.transforms.ObservationNorm.init_stats` to instruct which
 # dimensions must be reduced, and the ``keep_dims`` parameter to ensure that
 # not all dimensions disappear in the process:
 #
@@ -273,7 +273,7 @@ def get_norm_stats():
     )
     obs_norm_sd = test_env.transform[-1].state_dict()
     # let's check that normalizing constants have a size of ``[C, 1, 1]`` where
-    # ``C=4`` (because of :class:`~torchrl.envs.CatFrames`).
+    # ``C=4`` (because of :class:`~torchrl.envs.transforms.CatFrames`).
     print("state dict of the observation norm:", obs_norm_sd)
     test_env.close()
     del test_env
@@ -361,7 +361,7 @@ def make_model(dummy_env):
 # could improve the performance significantly.
 #
 # We place the storage on disk using
-# :class:`~torchrl.data.replay_buffers.storages.LazyMemmapStorage` class. This
+# :class:`~torchrl.data.replay_buffers.LazyMemmapStorage` class. This
 # storage is created in a lazy manner: it will only be instantiated once the
 # first batch of data is passed to it.
 #

--- a/tutorials/sphinx-tutorials/coding_ppo.py
+++ b/tutorials/sphinx-tutorials/coding_ppo.py
@@ -299,8 +299,8 @@ print("normalization constant shape:", env.transform[0].loc.shape)
 # For efficiency purposes, TorchRL is quite stringent when it comes to
 # environment specs, but you can easily check that your environment specs are
 # adequate.
-# In our example, the :class:`~torchrl.envs.libs.gym.GymWrapper` and
-# :class:`~torchrl.envs.libs.gym.GymEnv` that inherits
+# In our example, the :class:`~torchrl.envs.GymWrapper` and
+# :class:`~torchrl.envs.GymEnv` that inherits
 # from it already take care of setting the proper specs for your environment so
 # you should not have to care about this.
 #
@@ -318,7 +318,7 @@ print("input_spec:", env.input_spec)
 print("action_spec (as defined by input_spec):", env.action_spec)
 
 ######################################################################
-# the :func:`check_env_specs` function runs a small rollout and compares its output against the environment
+# the :func:`~torchrl.envs.check_env_specs` function runs a small rollout and compares its output against the environment
 # specs. If no error is raised, we can be confident that the specs are properly defined:
 #
 check_env_specs(env)

--- a/tutorials/sphinx-tutorials/collector_trajectory_assembly.py
+++ b/tutorials/sphinx-tutorials/collector_trajectory_assembly.py
@@ -188,7 +188,7 @@ print(traj_data["collector", "mask"])
 #
 # In off-policy training the standard pattern is to store **flat
 # transitions** in a :class:`~torchrl.data.ReplayBuffer` and let a
-# :class:`~torchrl.data.SliceSampler` carve out contiguous
+# :class:`~torchrl.data.replay_buffers.SliceSampler` carve out contiguous
 # sub-sequences that respect episode boundaries. The sampler uses
 # ``("next", "done")`` to locate where episodes end, so you never get a
 # slice that straddles two unrelated trajectories.
@@ -199,8 +199,8 @@ print(traj_data["collector", "mask"])
 # .. seealso::
 #   The :ref:`replay buffer tutorial <tuto_rb_traj>` covers trajectory
 #   storage in more depth, including alternative samplers such as
-#   :class:`~torchrl.data.PrioritizedSliceSampler` and
-#   :class:`~torchrl.data.SliceSamplerWithoutReplacement`.
+#   :class:`~torchrl.data.replay_buffers.PrioritizedSliceSampler` and
+#   :class:`~torchrl.data.replay_buffers.SliceSamplerWithoutReplacement`.
 
 from torchrl.data import SliceSampler
 

--- a/tutorials/sphinx-tutorials/dqn_with_rnn.py
+++ b/tutorials/sphinx-tutorials/dqn_with_rnn.py
@@ -53,7 +53,7 @@ import tempfile
 # As this figure shows, our environment populates the TensorDict with zeroed recurrent
 # states which are read by the policy together with the observation to produce an
 # action, and recurrent states that will be used for the next step.
-# When the :func:`~torchrl.envs.utils.step_mdp` function is called, the recurrent states
+# When the :func:`~torchrl.envs.step_mdp` function is called, the recurrent states
 # from the next state are brought to the current TensorDict. Let's see how this
 # is implemented in practice.
 
@@ -252,7 +252,7 @@ print("out_keys", lstm.out_keys)
 # as well as recurrent key names. The out_keys are preceded by a "next" prefix
 # that indicates that they will need to be written in the "next" TensorDict.
 # We use this convention (which can be overridden by passing the in_keys/out_keys
-# arguments) to make sure that a call to :func:`~torchrl.envs.utils.step_mdp` will
+# arguments) to make sure that a call to :func:`~torchrl.envs.step_mdp` will
 # move the recurrent state to the root TensorDict, making it available to the
 # RNN during the following call (see figure in the intro).
 #
@@ -293,7 +293,7 @@ mlp = Mod(mlp, in_keys=["embed"], out_keys=["action_value"])
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # The last part of our policy is the Q-Value Module.
-# The Q-Value module :class:`~torchrl.modules.tensordict_module.QValueModule`
+# The Q-Value module :class:`~torchrl.modules.QValueModule`
 # will read the ``"action_values"`` key that is produced by our MLP and
 # from it, gather the action that has the maximum value.
 # The only thing we need to do is to specify the action space, which can be done
@@ -305,7 +305,7 @@ qval = QValueModule(action_space=None, spec=env.action_spec)
 ######################################################################
 # .. note::
 #   TorchRL also provides a wrapper class :class:`torchrl.modules.QValueActor` that
-#   wraps a module in a Sequential together with a :class:`~torchrl.modules.tensordict_module.QValueModule`
+#   wraps a module in a Sequential together with a :class:`~torchrl.modules.QValueModule`
 #   like we are doing explicitly here. There is little advantage to do this
 #   and the process is less transparent, but the end results will be similar to
 #   what we do here.
@@ -355,7 +355,7 @@ policy(env.reset())
 #
 # Out DQN loss requires us to pass the policy and, again, the action-space.
 # While this may seem redundant, it is important as we want to make sure that
-# the :class:`~torchrl.objectives.DQNLoss` and the :class:`~torchrl.modules.tensordict_module.QValueModule`
+# the :class:`~torchrl.objectives.DQNLoss` and the :class:`~torchrl.modules.QValueModule`
 # classes are compatible, but aren't strongly dependent on each other.
 #
 # To use the Double-DQN, we ask for a ``delay_value`` argument that will
@@ -377,7 +377,7 @@ optim = torch.optim.Adam(policy.parameters(), lr=3e-4)
 # ---------------------------
 #
 # For RNN-based policies, we need to sample sequences of consecutive transitions
-# rather than independent transitions. We'll use a :class:`~torchrl.data.replay_buffers.samplers.SliceSampler`
+# rather than independent transitions. We'll use a :class:`~torchrl.data.replay_buffers.SliceSampler`
 # to sample trajectory slices of length 50. This ensures that the LSTM hidden states
 # can be properly propagated through the sequence during training.
 #

--- a/tutorials/sphinx-tutorials/getting-started-0.py
+++ b/tutorials/sphinx-tutorials/getting-started-0.py
@@ -127,7 +127,7 @@ print(stepped_data)
 #
 # The last bit of information you need to run a rollout in the environment is
 # how to bring that ``"next"`` entry at the root to perform the next step.
-# TorchRL provides a dedicated :func:`~torchrl.envs.utils.step_mdp` function
+# TorchRL provides a dedicated :func:`~torchrl.envs.step_mdp` function
 # that does just that: it filters out the information you won't need and
 # delivers a data structure corresponding to your observation after a step in
 # the Markov Decision Process, or MDP.
@@ -226,7 +226,7 @@ print(rollout["next", "truncated"])
 #
 # - The :meth:`~torchrl.envs.EnvBase.step_and_maybe_reset` method that packs
 #   together :meth:`~torchrl.envs.EnvBase.step`,
-#   :func:`~torchrl.envs.utils.step_mdp` and
+#   :func:`~torchrl.envs.step_mdp` and
 #   :meth:`~torchrl.envs.EnvBase.reset`.
 # - Some environments like :class:`~torchrl.envs.GymEnv` support rendering
 #   through the ``from_pixels`` argument. Check the class docstrings to know

--- a/tutorials/sphinx-tutorials/getting-started-1.py
+++ b/tutorials/sphinx-tutorials/getting-started-1.py
@@ -74,8 +74,8 @@ print(rollout)
 # codebase, TorchRL offers a range of specialized wrappers designed to be
 # used as actors, including :class:`~torchrl.modules.tensordict_module.Actor`,
 # # :class:`~torchrl.modules.tensordict_module.ProbabilisticActor`,
-# # :class:`~torchrl.modules.tensordict_module.ActorValueOperator` or
-# # :class:`~torchrl.modules.tensordict_module.ActorCriticOperator`.
+# # :class:`~torchrl.modules.ActorValueOperator` or
+# # :class:`~torchrl.modules.ActorCriticOperator`.
 # For example, :class:`~torchrl.modules.tensordict_module.Actor` provides
 # default values for the ``in_keys`` and ``out_keys``, making integration
 # with many common environments straightforward:
@@ -168,7 +168,7 @@ print(rollout)
 # You can control the sampling of the action to use the expected value or
 # other properties of the distribution instead of using random samples if
 # your application requires it. This can be controlled via the
-# :func:`~torchrl.envs.utils.set_exploration_type` function:
+# :func:`~torchrl.envs.set_exploration_type` function:
 
 from torchrl.envs.utils import ExplorationType, set_exploration_type
 
@@ -265,7 +265,7 @@ value_net = TensorDictModule(
 
 ###################################
 # We can easily build our Q-Value actor by adding a
-# :class:`~torchrl.modules.tensordict_module.QValueModule` after our value
+# :class:`~torchrl.modules.QValueModule` after our value
 # network:
 
 from torchrl.modules import QValueModule
@@ -287,7 +287,7 @@ print(rollout)
 ###################################
 # Because it relies on the ``argmax`` operator, this policy is deterministic.
 # During data collection, we will need to explore the environment. For that,
-# we are using the :class:`~torchrl.modules.tensordict_module.EGreedyModule`
+# we are using the :class:`~torchrl.modules.EGreedyModule`
 # once again:
 
 policy_explore = TensorDictSequential(policy, EGreedyModule(env.action_spec))

--- a/tutorials/sphinx-tutorials/getting-started-3.py
+++ b/tutorials/sphinx-tutorials/getting-started-3.py
@@ -132,7 +132,7 @@ print(data["collector", "traj_ids"])
 # technique, the writing heuristic or the transforms applied to them. We will
 # leave the fancy stuff for a dedicated in-depth tutorial. The generic replay
 # buffer only needs to know what storage it has to use. In general, we
-# recommend a :class:`~torchrl.data.TensorStorage` subclass, which will work
+# recommend a :class:`~torchrl.data.replay_buffers.TensorStorage` subclass, which will work
 # fine in most cases. We'll be using
 # :class:`~torchrl.data.replay_buffers.LazyMemmapStorage`
 # in this tutorial, which enjoys two nice properties: first, being "lazy",
@@ -197,7 +197,7 @@ print(sample)
 #   equivalent to calling ``rb.sample()`` within a loop!
 # - For trajectory-based training (recurrent policies, decision transformers),
 #   see :ref:`collectors_replay_trajs` — it shows how to use
-#   ``trajs_per_batch`` with a :class:`~torchrl.data.SliceSampler` to store
+#   ``trajs_per_batch`` with a :class:`~torchrl.data.replay_buffers.SliceSampler` to store
 #   and sample clean trajectory slices from the replay buffer, especially
 #   with multi-process collectors.
 #

--- a/tutorials/sphinx-tutorials/getting-started-4.py
+++ b/tutorials/sphinx-tutorials/getting-started-4.py
@@ -49,7 +49,7 @@ logger = CSVLogger(exp_name="my_exp")
 
 #####################################
 # Once the logger is instantiated, the only thing left to do is call the
-# logging methods! For example, :meth:`~torchrl.record.CSVLogger.log_scalar`
+# logging methods! For example, :meth:`~torchrl.record.loggers.csv.CSVLogger.log_scalar`
 # is used in several places across the training examples to log values such as
 # reward, loss value or time elapsed for executing a piece of code.
 

--- a/tutorials/sphinx-tutorials/llm_browser.py
+++ b/tutorials/sphinx-tutorials/llm_browser.py
@@ -193,8 +193,8 @@ env = env.append_transform(RewardTransform())
 # that simulates LLM responses and executes tool actions.
 #
 # In a real scenario, this would be handled by an LLM policy (like
-# :class:`~torchrl.modules.llm.policies.TransformersWrapper` or
-# :class:`~torchrl.modules.llm.policies.vLLMWrapper`). Here we simulate the
+# :class:`~torchrl.modules.llm.TransformersWrapper` or
+# :class:`~torchrl.modules.llm.vLLMWrapper`). Here we simulate the
 # LLM's output manually to demonstrate the environment flow.
 #
 # The key insight is that the ChatEnv works with a :class:`~torchrl.data.llm.History`
@@ -347,7 +347,7 @@ env.close()
 #
 # 1. **ChatEnv**: The base environment that manages conversation state using
 #    :class:`~torchrl.data.llm.History` objects
-# 2. **Tool Transforms**: Like :class:`~torchrl.envs.llm.BrowserTransform` that
+# 2. **Tool Transforms**: Like :class:`~torchrl.envs.llm.transforms.BrowserTransform` that
 #    execute tools and inject results back into the conversation
 # 3. **Reward Transforms**: Custom transforms that assign rewards based on
 #    conversation content
@@ -356,5 +356,5 @@ env.close()
 #
 # In a real application, you would replace the `simulate_llm_response` helper
 # with an actual LLM policy. See the :ref:`ref_llms` documentation for examples
-# of using :class:`~torchrl.modules.llm.policies.TransformersWrapper` and
-# :class:`~torchrl.modules.llm.policies.vLLMWrapper` with these environments.
+# of using :class:`~torchrl.modules.llm.TransformersWrapper` and
+# :class:`~torchrl.modules.llm.vLLMWrapper` with these environments.

--- a/tutorials/sphinx-tutorials/llm_wrappers.py
+++ b/tutorials/sphinx-tutorials/llm_wrappers.py
@@ -5,8 +5,8 @@ LLM Wrappers in TorchRL
 This tutorial demonstrates how to use TorchRL's LLM wrappers for integrating Large Language Models
 into reinforcement learning workflows. TorchRL provides two main wrappers:
 
-- :class:`~torchrl.modules.llm.policies.vLLMWrapper` for vLLM models
-- :class:`~torchrl.modules.llm.policies.TransformersWrapper` for Hugging Face Transformers models
+- :class:`~torchrl.modules.llm.vLLMWrapper` for vLLM models
+- :class:`~torchrl.modules.llm.TransformersWrapper` for Hugging Face Transformers models
 
 Both wrappers provide a unified API with consistent input/output interfaces using TensorClass objects,
 making them interchangeable in RL environments.

--- a/tutorials/sphinx-tutorials/mujoco_cube_bowl_macros.py
+++ b/tutorials/sphinx-tutorials/mujoco_cube_bowl_macros.py
@@ -20,8 +20,8 @@ What you will learn
 -------------------
 
 - how to instantiate a Menagerie-backed custom MuJoCo environment;
-- how to use :class:`~torchrl.envs.RobotMacroAction` as a readable action object;
-- how :class:`~torchrl.envs.URScriptPrimitiveTransform` lets ``env.step(td)``
+- how to use :class:`~torchrl.envs.transforms.RobotMacroAction` as a readable action object;
+- how :class:`~torchrl.envs.transforms.URScriptPrimitiveTransform` lets ``env.step(td)``
   consume those actions directly;
 - how to write a scripted contact-rich cube-to-bowl policy as an explicit list
   of poses and gripper commands;
@@ -565,13 +565,13 @@ assert reset_td["robot_qpos"].shape == td["robot_qpos"].shape
 #    - :class:`~torchrl.envs.CubeBowlEnv` for the custom MuJoCo task used here.
 #    - :class:`~torchrl.envs.MujocoEnv` for the base class behind custom MuJoCo
 #      environments.
-#    - :class:`~torchrl.envs.RobotMacroAction` for the structured action object used
+#    - :class:`~torchrl.envs.transforms.RobotMacroAction` for the structured action object used
 #      by the scripted policy.
-#    - :class:`~torchrl.envs.MacroPrimitiveTransform` for robot-agnostic macro
+#    - :class:`~torchrl.envs.transforms.MacroPrimitiveTransform` for robot-agnostic macro
 #      expansion that domain transforms specialize via ``_resolve`` hooks.
-#    - :class:`~torchrl.envs.URScriptPrimitiveTransform` for the URScript-style
+#    - :class:`~torchrl.envs.transforms.URScriptPrimitiveTransform` for the URScript-style
 #      preset used in this tutorial.
-#    - :class:`~torchrl.envs.MultiAction` for executing batched low-level action
+#    - :class:`~torchrl.envs.transforms.MultiAction` for executing batched low-level action
 #      sequences.
 
 env.close()

--- a/tutorials/sphinx-tutorials/multiagent_competitive_ddpg.py
+++ b/tutorials/sphinx-tutorials/multiagent_competitive_ddpg.py
@@ -201,7 +201,7 @@ polyak_tau = 0.005  # Tau for the soft-update of the target network
 # tensordict. The data of agents within a group is stacked together. Therefore, by choosing how to group your agents,
 # you can decide which data is stacked/kept as separate entries.
 # The grouping strategy can be specified at construction in environments like VMAS and PettingZoo.
-# For more info on grouping, see :class:`~torchrl.envs.utils.MarlGroupMapType`.
+# For more info on grouping, see :class:`~torchrl.envs.MarlGroupMapType`.
 #
 # In the *simple_tag* environment
 # there are two teams of agents: the chasers (or "adversaries") (red circles) and the evaders (or "agents") (green circles).
@@ -352,7 +352,7 @@ env = TransformedEnv(
 
 
 ######################################################################
-# the :func:`check_env_specs` function runs a small rollout and compares its output against the environment
+# the :func:`~torchrl.envs.check_env_specs` function runs a small rollout and compares its output against the environment
 # specs. If no error is raised, we can be confident that the specs are properly defined:
 #
 check_env_specs(env)
@@ -464,10 +464,10 @@ for group, agents in env.group_map.items():
 
 
 ######################################################################
-# **Second**: wrap the :class:`~tensodrdict.nn.TensorDictModule` in a :class:`~torchrl.modules.ProbabilisticActor`
+# **Second**: wrap the :class:`~tensodrdict.nn.TensorDictModule` in a :class:`~torchrl.modules.tensordict_module.ProbabilisticActor`
 #
 # We now need to build the TanhDelta distribution.
-# We instruct the :class:`~torchrl.modules.ProbabilisticActor`
+# We instruct the :class:`~torchrl.modules.tensordict_module.ProbabilisticActor`
 # class to build a :class:`~torchrl.modules.TanhDelta` out of the policy action
 # parameters. We also provide the minimum and maximum values of this
 # distribution, which we gather from the environment specs.
@@ -655,9 +655,9 @@ collector = Collector(
 # There are many types of buffers, in this tutorial we use a basic buffer to store and sample tensordict
 # data randomly.
 #
-# This buffer uses :class:`~.data.LazyMemmapStorage`, which stores data on disk.
+# This buffer uses :class:`~torchrl.data.replay_buffers.LazyMemmapStorage`, which stores data on disk.
 # This allows to use the disk memory, but can result in slower sampling as it requires data to be cast to the training device.
-# To store your buffer on the GPU, you can use :class:`~.data.LazyTensorStorage`, passing the desired device.
+# To store your buffer on the GPU, you can use :class:`~torchrl.data.replay_buffers.LazyTensorStorage`, passing the desired device.
 # This will result in faster sampling but is subject to the memory constraints of the selected device.
 #
 
@@ -684,7 +684,7 @@ for group, _agents in env.group_map.items():
 # -------------
 #
 # The DDPG loss can be directly imported from TorchRL for convenience using the
-# :class:`~.objectives.DDPGLoss` class. This is the easiest way of utilising DDPG:
+# :class:`~torchrl.objectives.DDPGLoss` class. This is the easiest way of utilising DDPG:
 # it hides away the mathematical operations of DDPG and the control flow that
 # goes with it.
 #

--- a/tutorials/sphinx-tutorials/multiagent_ppo.py
+++ b/tutorials/sphinx-tutorials/multiagent_ppo.py
@@ -249,7 +249,7 @@ env = VmasEnv(
 # For efficiency purposes, TorchRL is quite stringent when it comes to
 # environment specs, but you can easily check that your environment specs are
 # adequate.
-# In our example, the :class:`~.envs.libs.vmas.VmasEnv` takes care of setting the proper specs for your env so
+# In our example, the :class:`~torchrl.envs.VmasEnv` takes care of setting the proper specs for your env so
 # you should not have to care about this.
 #
 # There are four specs to look at:
@@ -315,7 +315,7 @@ env = TransformedEnv(
 
 
 ######################################################################
-# the :func:`check_env_specs` function runs a small rollout and compares its output against the environment
+# the :func:`~torchrl.envs.check_env_specs` function runs a small rollout and compares its output against the environment
 # specs. If no error is raised, we can be confident that the specs are properly defined:
 #
 check_env_specs(env)
@@ -434,17 +434,17 @@ policy_module = TensorDictModule(
 )
 
 ######################################################################
-# **Third**: wrap the :class:`TensorDictModule` in a :class:`ProbabilisticActor`
+# **Third**: wrap the :class:`TensorDictModule` in a :class:`~torchrl.modules.tensordict_module.ProbabilisticActor`
 #
 # We now need to build a distribution out of the location and scale of our
-# normal distribution. To do so, we instruct the :class:`ProbabilisticActor`
-# class to build a :class:`TanhNormal` out of the location and scale
+# normal distribution. To do so, we instruct the :class:`~torchrl.modules.tensordict_module.ProbabilisticActor`
+# class to build a :class:`~torchrl.modules.TanhNormal` out of the location and scale
 # parameters. We also provide the minimum and maximum values of this
 # distribution, which we gather from the environment specs.
 #
 # The name of the ``in_keys`` (and hence the name of the ``out_keys`` from
 # the :class:`TensorDictModule` above) has to end with the
-# :class:`TanhNormal` distribution constructor keyword arguments (loc and scale).
+# :class:`~torchrl.modules.TanhNormal` distribution constructor keyword arguments (loc and scale).
 #
 
 policy = ProbabilisticActor(
@@ -577,7 +577,7 @@ replay_buffer = ReplayBuffer(
 # -------------
 #
 # The PPO loss can be directly imported from TorchRL for convenience using the
-# :class:`~.objectives.ClipPPOLoss` class. This is the easiest way of utilising PPO:
+# :class:`~torchrl.objectives.ClipPPOLoss` class. This is the easiest way of utilising PPO:
 # it hides away the mathematical operations of PPO and the control flow that
 # goes with it.
 #
@@ -591,7 +591,7 @@ replay_buffer = ReplayBuffer(
 # ``"value_target"`` entries.
 # The ``"value_target"`` is a gradient-free tensor that represents the empirical
 # value that the value network should represent with the input observation.
-# Both of these will be used by :class:`ClipPPOLoss` to
+# Both of these will be used by :class:`~torchrl.objectives.ClipPPOLoss` to
 # return the policy and value losses.
 #
 

--- a/tutorials/sphinx-tutorials/pendulum.py
+++ b/tutorials/sphinx-tutorials/pendulum.py
@@ -116,10 +116,10 @@ DEFAULT_Y = 1.0
 # There are four things you must take care of when designing a new environment
 # class:
 #
-# * :meth:`EnvBase._reset`, which codes for the resetting of the simulator
+# * :meth:`EnvBase._reset <torchrl.envs.EnvBase._reset>`, which codes for the resetting of the simulator
 #   at a (potentially random) initial state;
-# * :meth:`EnvBase._step` which codes for the state transition dynamic;
-# * :meth:`EnvBase._set_seed` which implements the seeding mechanism;
+# * :meth:`EnvBase._step <torchrl.envs.EnvBase._step>` which codes for the state transition dynamic;
+# * :meth:`EnvBase._set_seed <torchrl.envs.EnvBase._set_seed>` which implements the seeding mechanism;
 # * the environment specs.
 #
 # Let us first describe the problem at hand: we would like to model a simple
@@ -160,7 +160,7 @@ DEFAULT_Y = 1.0
 #
 # The step method is the first thing to consider, as it will encode
 # the simulation that is of interest to us. In TorchRL, the
-# :class:`~torchrl.envs.EnvBase` class has a :meth:`EnvBase.step`
+# :class:`~torchrl.envs.EnvBase` class has a :meth:`EnvBase.step <torchrl.envs.EnvBase.step>`
 # method that receives a :class:`tensordict.TensorDict`
 # instance with an ``"action"`` entry indicating what action is to be taken.
 #
@@ -231,7 +231,7 @@ DEFAULT_Y = 1.0
 # Indeed, we want to discourage positions that are far from being "upward"
 # and/or speeds that are far from 0.
 #
-# In our example, :meth:`EnvBase._step` is encoded as a static method since our
+# In our example, :meth:`EnvBase._step <torchrl.envs.EnvBase._step>` is encoded as a static method since our
 # environment is stateless. In stateful settings, the ``self`` argument is
 # needed as the state needs to be read from the environment.
 #
@@ -291,13 +291,13 @@ def angle_normalize(x):
 # also expects a ``tensordict`` as input, albeit it may perfectly be empty or
 # ``None``.
 #
-# The parent :meth:`EnvBase.reset` does some simple checks like the
-# :meth:`EnvBase.step` does, such as making sure that a ``"done"`` state
+# The parent :meth:`EnvBase.reset <torchrl.envs.EnvBase.reset>` does some simple checks like the
+# :meth:`EnvBase.step <torchrl.envs.EnvBase.step>` does, such as making sure that a ``"done"`` state
 # is returned in the output ``tensordict`` and that the shapes match what is
 # expected from the specs.
 #
 # For us, the only important thing to consider is whether
-# :meth:`EnvBase._reset` contains all the expected observations. Once more,
+# :meth:`EnvBase._reset <torchrl.envs.EnvBase._reset>` contains all the expected observations. Once more,
 # since we are working with a stateless environment, we pass the configuration
 # of the pendulum in a nested ``tensordict`` named ``"params"``.
 #
@@ -397,7 +397,7 @@ def _reset(self, tensordict):
 # There are four specs that we must code in our environment:
 #
 # * :obj:`EnvBase.observation_spec`: This will be a :class:`~torchrl.data.Composite`
-#   instance where each key is an observation (a :class:`Composite` can be
+#   instance where each key is an observation (a :class:`~torchrl.data.Composite` can be
 #   viewed as a dictionary of specs).
 # * :obj:`EnvBase.action_spec`: It can be any type of spec, but it is required
 #   that it corresponds to the ``"action"`` entry in the input ``tensordict``;
@@ -586,7 +586,7 @@ class PendulumEnv(EnvBase):
 # Testing our environment
 # -----------------------
 #
-# TorchRL provides a simple function :func:`~torchrl.envs.utils.check_env_specs`
+# TorchRL provides a simple function :func:`~torchrl.envs.check_env_specs`
 # to check that a (transformed) environment has an input/output structure that
 # matches the one dictated by its specs.
 # Let us try it out:
@@ -961,7 +961,7 @@ plot()
 #   We saw how these methods and classes interact with the
 #   :class:`~tensordict.TensorDict` class;
 # * How to test that an environment is properly coded using
-#   :func:`~torchrl.envs.utils.check_env_specs`;
+#   :func:`~torchrl.envs.check_env_specs`;
 # * How to append transforms in the context of stateless environments and how
 #   to write custom transformations;
 # * How to train a policy on a fully differentiable simulator.

--- a/tutorials/sphinx-tutorials/rb_tutorial.py
+++ b/tutorials/sphinx-tutorials/rb_tutorial.py
@@ -102,10 +102,10 @@ print("length after adding elements:", len(buffer))
 #
 # TorchRL proposes three types of storages:
 #
-# - The :class:`~torchrl.data.ListStorage` stores elements independently in a
+# - The :class:`~torchrl.data.replay_buffers.ListStorage` stores elements independently in a
 #   list. It supports any data type, but this flexibility comes at the cost
 #   of efficiency;
-# - The :class:`~torchrl.data.LazyTensorStorage` stores tensors data
+# - The :class:`~torchrl.data.replay_buffers.LazyTensorStorage` stores tensors data
 #   structures contiguously.
 #   It works naturally with :class:`~tensordidct.TensorDict`
 #   (or :class:`~torchrl.data.tensorclass`)
@@ -116,8 +116,8 @@ print("length after adding elements:", len(buffer))
 #   was used to instantiate the buffer.
 #   Passing data that does not match this requirement will either raise an
 #   exception or lead to some undefined behaviors.
-# - The :class:`~torchrl.data.LazyMemmapStorage` works as the
-#   :class:`~torchrl.data.LazyTensorStorage` in that it is lazy (i.e., it
+# - The :class:`~torchrl.data.replay_buffers.LazyMemmapStorage` works as the
+#   :class:`~torchrl.data.replay_buffers.LazyTensorStorage` in that it is lazy (i.e., it
 #   expects the first batch of data to be instantiated), and it requires data
 #   that match in shape and dtype for each batch stored. What makes this
 #   storage unique is that it points to disk files (or uses the filesystem
@@ -141,9 +141,9 @@ print(buffer_list.sample(3))
 
 ######################################################################
 # Because it is the one with the lowest amount of assumption, the
-# :class:`~torchrl.data.ListStorage` is the default storage in TorchRL.
+# :class:`~torchrl.data.replay_buffers.ListStorage` is the default storage in TorchRL.
 #
-# A :class:`~torchrl.data.LazyTensorStorage` can store data contiguously.
+# A :class:`~torchrl.data.replay_buffers.LazyTensorStorage` can store data contiguously.
 # This should be the preferred option when dealing with complicated but
 # unchanging data structures of medium size:
 
@@ -182,7 +182,7 @@ sample = buffer_lazytensor.sample(5)
 print("samples", sample["a"], sample["b", "c"])
 
 ######################################################################
-# A :class:`~torchrl.data.LazyMemmapStorage` is created in the same manner.
+# A :class:`~torchrl.data.replay_buffers.LazyMemmapStorage` is created in the same manner.
 # We can also customize the storage location on disk:
 #
 
@@ -797,7 +797,7 @@ assert (data.exclude("collector") == s.squeeze(0).exclude("index", "collector"))
 # than simple transitions. TorchRL offers multiple ways of achieving this.
 #
 # The preferred way is currently to store trajectories along the first
-# dimension of the buffer and use a :class:`~torchrl.data.SliceSampler` to
+# dimension of the buffer and use a :class:`~torchrl.data.replay_buffers.SliceSampler` to
 # sample these batches of data. This class only needs a couple of information
 # about your data structure to do its job (not that as of now it is only
 # compatible with tensordict-structured data): the number of slices or their
@@ -847,7 +847,7 @@ gc.collect()
 # collecting data with a :class:`~torchrl.collectors.Collector` (or its
 # multi-process variants).  The collector already tags every transition with
 # a ``("collector", "traj_ids")`` key, so the
-# :class:`~torchrl.data.SliceSampler` can reconstruct episode boundaries
+# :class:`~torchrl.data.replay_buffers.SliceSampler` can reconstruct episode boundaries
 # automatically.
 #
 # For **single-process** collectors the setup is straightforward — just
@@ -912,8 +912,8 @@ gc.collect()
 # - Check the data API reference to learn about offline datasets in TorchRL,
 #   which are based on our Replay Buffer API;
 # - Check other samplers such as
-#   :class:`~torchrl.data.SamplerWithoutReplacement`,
-#   :class:`~torchrl.data.PrioritizedSliceSampler` and
-#   :class:`~torchrl.data.SliceSamplerWithoutReplacement`, or other writers
-#   such as :class:`~torchrl.data.TensorDictMaxValueWriter`.
+#   :class:`~torchrl.data.replay_buffers.SamplerWithoutReplacement`,
+#   :class:`~torchrl.data.replay_buffers.PrioritizedSliceSampler` and
+#   :class:`~torchrl.data.replay_buffers.SliceSamplerWithoutReplacement`, or other writers
+#   such as :class:`~torchrl.data.replay_buffers.TensorDictMaxValueWriter`.
 # - Check how to checkpoint ReplayBuffers in :ref:`the doc <checkpoint-rb>`.

--- a/tutorials/sphinx-tutorials/torchrl_demo.py
+++ b/tutorials/sphinx-tutorials/torchrl_demo.py
@@ -357,7 +357,7 @@ sample = buffer.sample(32)
 print("Sampled batch:", sample.batch_size)
 
 ###############################################################################
-# The :class:`~torchrl.data.LazyTensorStorage` allocates memory lazily based
+# The :class:`~torchrl.data.replay_buffers.LazyTensorStorage` allocates memory lazily based
 # on the first batch added. For prioritized experience replay (used in DQN
 # variants), use :class:`~torchrl.data.PrioritizedReplayBuffer`:
 


### PR DESCRIPTION
## Summary

Many Sphinx cross-references (`:class:` / `:meth:` / `:func:`) across the docs and tutorials used a module path that does **not** match the generated API page, so they **silently rendered as plain text** — no link, and no build error (the docs are not built with `-n`). This started as a fix for the new MuJoCo-macro / recurrent / collector pages, then swept repo-wide on request.

Concretely, e.g. `torchrl.envs.transforms.URScriptPrimitiveTransform.html` exists (200) but `torchrl.envs.URScriptPrimitiveTransform.html` does not (404), so `:class:`~torchrl.envs.URScriptPrimitiveTransform`` did not link. Sphinx does not fuzzy-match a fully-qualified target.

## Method

A static checker harvested every documented symbol (autosummary / autoclass × `currentmodule`) across the reference tree, then flagged every Python-domain xref in `docs/source/**/*.rst` + `tutorials/**/*.py` that does not resolve to a generated page. Each proposed target was **verified against the live pages on docs.pytorch.org (all 200)** before applying. Display text is preserved (`Class.member` refs keep their shown text via the `text <target>` form; everything else uses `~`). Tutorial-local classes (e.g. `PendulumEnv` defined inside `pendulum.py`) are guarded out. Ambiguous leaves, private helpers with no page, and the `SyncDataCollector → Collector` rename (separate PR) are left untouched.

## Commits

1. **New pages** (12 files) — the originally-reported set. Also documents previously-undocumented public API that had no page at all (`set_recurrent_mode`, `ValueNorm`/`PopArtValueNorm`/`RunningValueNorm`, `TED2Flat`/`Flat2TED`) and fixes wrong roles (`set_recurrent_mode` is a class; `step_mdp` is a function).
2. **Repo-wide sweep** (30 files, 140 refs) — same canonical-path fix everywhere:
   - Transforms `torchrl.envs.*` → `torchrl.envs.transforms.*` (Transform, TransformedEnv, InitTracker, StepCounter, CatFrames, CatTensors, DoubleToFloat, ObservationNorm, RenameTransform, ActionDiscretizer, AutoResetTransform, ConditionalSkip, TensorDictPrimer, ModuleTransform, …).
   - Samplers/storages `torchrl.data.*` → `torchrl.data.replay_buffers.*`; `ReplayBuffer` → `torchrl.data.ReplayBuffer`.
   - Public functions via their submodule → re-export (`step_mdp`, `check_env_specs`, `set_exploration_type`, `gym_backend`, `implement_for`, `get_env_transforms_from_module`).
   - Classes via internal paths (`envs.libs.vmas.VmasEnv` → `envs.VmasEnv`, `modules.tensordict_module.ProbabilisticActor`, `QValueModule`, `ActorValueOperator`, `DDPGLoss`, `ClipPPOLoss`, `ValueEstimators`, loggers under `record.loggers.csv`/`wandb`, …).
   - One typo (`torchr.envs.TransformedEnv`).

## Test plan
- Static checker reports **0 remaining auto-fixable** broken Python-domain xrefs across all docs + tutorials (excluding intentional private internals, ambiguous leaves, and the deferred rename).
- All distinct target pages verified to return 200 on docs.pytorch.org.
- All edited `.py` tutorials compile; no role tokens malformed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)