### PR TITLE
[CI] Fix PyPI publishing for CPU wheels

### DIFF
--- a/.github/scripts/td_script.sh
+++ b/.github/scripts/td_script.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
 export TORCHRL_BUILD_VERSION="${BUILD_VERSION:-0.13.0}"
+# PyPI rejects local versions such as X.Y.Z+cpu. CPU wheels are the
+# default PyPI artifacts, so strip only the CPU build suffix while keeping
+# CUDA/ROCm suffixes for the extra-index wheels.
+if [[ "${TORCHRL_BUILD_VERSION}" == *+cpu ]]; then
+    export TORCHRL_BUILD_VERSION="${TORCHRL_BUILD_VERSION%+cpu}"
+fi
 ${CONDA_RUN} pip install --upgrade setuptools packaging
 
 # Always install pybind11 - required for building C++ extensions

--- a/.github/scripts/version_script.bat
+++ b/.github/scripts/version_script.bat
@@ -4,6 +4,12 @@ if "%BUILD_VERSION%" == "" (
 ) else (
     set TORCHRL_BUILD_VERSION=%BUILD_VERSION%
 )
+rem PyPI rejects local versions such as X.Y.Z+cpu. CPU wheels are the
+rem default PyPI artifacts, so strip only the CPU build suffix while keeping
+rem CUDA suffixes for the extra-index wheels.
+if "%TORCHRL_BUILD_VERSION:~-4%" == "+cpu" (
+    set TORCHRL_BUILD_VERSION=%TORCHRL_BUILD_VERSION:~0,-4%
+)
 echo TORCHRL_BUILD_VERSION is set to %TORCHRL_BUILD_VERSION%
 
 @echo on

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -612,6 +612,16 @@ jobs:
           echo "Wheels prepared for upload:"
           ls -la dist/
 
+      - name: Filter PyPI-incompatible local-version wheels
+        run: |
+          # PyPI rejects local versions such as X.Y.Z+cpu or X.Y.Z+cu128.
+          # Keep the default CPU wheels (built without +cpu above) and macOS
+          # wheels, but do not send CUDA/local-version artifacts to PyPI.
+          find dist -name "*+*.whl" -type f -print -delete
+          echo "Wheels remaining for PyPI upload:"
+          ls -la dist/
+          test -n "$(find dist -name '*.whl' -type f -print -quit)"
+
       - name: Publish to PyPI (OIDC)
         if: ${{ env.DRY_RUN != 'true' }}
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/tutorials/sphinx-tutorials/memory_efficient_rl.py
+++ b/tutorials/sphinx-tutorials/memory_efficient_rl.py
@@ -494,9 +494,7 @@ print("any -inf or +inf?", torch.isinf(out["advantage"]).any().item())
 # identical parameters at ``t`` and ``t + 1`` (no distinct target
 # network) and is unsupported with multi-step returns.
 
-gae_shifted = GAE(
-    gamma=0.99, lmbda=0.95, value_network=value_net, shifted=True
-)
+gae_shifted = GAE(gamma=0.99, lmbda=0.95, value_network=value_net, shifted=True)
 shifted_out = gae_shifted(sample.reshape(-1, 20).clone())
 print(
     "shifted GAE advantage finite?",


### PR DESCRIPTION
## Summary
- strip the `+cpu` local-version suffix from CPU release wheel build versions
- keep CUDA/local-version wheels out of the PyPI upload set
- preserve the release sanity check's expected `TORCHRL_BUILD_VERSION` export shape

## Motivation
PyPI rejects wheel uploads with local version identifiers such as `X.Y.Z+cpu`. CPU wheels are the default PyPI artifacts, while CUDA wheels are distributed through the extra-index path, so the PyPI publish job should only upload non-local-version wheels.

## Testing
- `bash -n .github/scripts/td_script.sh`
- checked that `.github/scripts/td_script.sh` still contains the parser-compatible `export TORCHRL_BUILD_VERSION="${BUILD_VERSION:-0.13.0}"`
- checked that the PyPI filtering step is present in `.github/workflows/release.yml`
