### PR TITLE
[Refactor] Extract a cat_frames functional from the CatFrames transform

### DIFF
--- a/benchmarks/test_envs_benchmark.py
+++ b/benchmarks/test_envs_benchmark.py
@@ -10,6 +10,7 @@ import torch
 from tensordict import TensorDict
 from torchrl.envs import ParallelEnv, SerialEnv, step_mdp, StepCounter, TransformedEnv
 from torchrl.envs.libs.dm_control import DMControlEnv
+from torchrl.envs.transforms.functional import cat_frames
 
 
 def make_simple_env():
@@ -125,6 +126,22 @@ def test_step_mdp_speed(
         exclude_reward=exclude_reward,
         exclude_done=exclude_done,
         exclude_action=exclude_action,
+    )
+
+
+@pytest.mark.parametrize("padding", ["same", "constant"])
+@pytest.mark.parametrize("N", [4, 16])
+def test_cat_frames_functional(benchmark, padding, N):
+    device = "cuda:0" if torch.cuda.device_count() else "cpu"
+    # batch of trajectories: (batch, time, channels)
+    tensor = torch.randn(32, 200, 8, device=device)
+    benchmark(
+        cat_frames,
+        tensor,
+        N,
+        dim=-1,
+        padding=padding,
+        time_dim=-2,
     )
 
 

--- a/docs/source/reference/envs_transforms.rst
+++ b/docs/source/reference/envs_transforms.rst
@@ -331,6 +331,24 @@ Available Transforms
     VecNormV2
     gSDENoise
 
+Functional transforms
+---------------------
+
+Some transforms expose a pure, stateless functional core (the PyTorch
+``torch.nn.functional`` / ``torch.nn.Module`` split) that can be reused directly
+on plain tensors, outside the transform machinery. The stateful transform
+delegates to the functional so that the two stay equivalent.
+
+.. currentmodule:: torchrl.envs.transforms.functional
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template_noinherit.rst
+
+    cat_frames
+
+.. currentmodule:: torchrl.envs.transforms
+
 Environments with masked actions
 --------------------------------
 

--- a/test/transforms/test_observation_transforms.py
+++ b/test/transforms/test_observation_transforms.py
@@ -4,6 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import argparse
+
 import pytest
 
 import tensordict.tensordict
@@ -42,6 +44,7 @@ from torchrl.envs import (
     UnsqueezeTransform,
 )
 from torchrl.envs.libs.gym import _has_gym, GymEnv
+from torchrl.envs.transforms import functional as F
 from torchrl.envs.transforms.transforms import _has_tv
 from torchrl.envs.utils import check_env_specs, step_mdp
 
@@ -663,6 +666,142 @@ class TestCatFrames(TransformBase):
         assert (cat_td.get("cat_first_key") == padding_value).sum() == N - 3
         cat_td = cat_frames._call(cat_td)
         assert (cat_td.get("cat_first_key") == padding_value).sum() == N - 4
+
+    @staticmethod
+    def _unfold_done(done, N, ndim):
+        # Mirror of ``CatFrames.unfolding.unfold_done`` (window-padding mask)
+        # used to drive the ``cat_frames`` functional in multi-trajectory
+        # tests with an explicit ``done_mask``.
+        prefix = (slice(None),) * (ndim - 1)
+        reset = torch.cat(
+            [
+                torch.zeros_like(done[prefix + (slice(N - 1),)]),
+                torch.ones_like(done[prefix + (slice(1),)]),
+                done[prefix + (slice(None, -1),)],
+            ],
+            ndim - 1,
+        )
+        reset_unfold = reset.unfold(ndim - 1, N, 1)
+        reset_unfold_list = [torch.zeros_like(reset_unfold[..., -1])]
+        for r in reversed(reset_unfold.unbind(-1)):
+            reset_unfold_list.append(r | reset_unfold_list[-1])
+        return torch.stack(list(reversed(reset_unfold_list))[1:], -1)
+
+    def test_cat_frames_functional_basic(self):
+        # documented example: a single trajectory of 4 frames stacked over a
+        # window of N=3 along the feature dim.
+        frames = torch.arange(8.0).view(4, 2)
+        out = F.cat_frames(frames, N=3, dim=-1, time_dim=-2, padding="constant")
+        assert out.shape == torch.Size([4, 6])
+        expected = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 2.0, 3.0],
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+                [2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+            ]
+        )
+        torch.testing.assert_close(out, expected)
+
+    def test_cat_frames_functional_validation(self):
+        x = torch.randn(1, 5, 2)
+        with pytest.raises(ValueError, match="dim must be < 0"):
+            F.cat_frames(x, N=2, dim=0, time_dim=-2)
+        with pytest.raises(ValueError, match="time_dim must be < 0"):
+            F.cat_frames(x, N=2, dim=-1, time_dim=1)
+        with pytest.raises(ValueError, match="padding must be one of"):
+            F.cat_frames(x, N=2, dim=-1, time_dim=-2, padding="zeros")
+
+    @pytest.mark.parametrize("device", get_default_devices())
+    def test_cat_frames_functional_dtype_device(self, device):
+        # dtype and device are preserved, and padding_value is honored.
+        x = torch.arange(24, dtype=torch.int64, device=device).view(1, 12, 2)
+        out = F.cat_frames(
+            x, N=3, dim=-1, time_dim=-2, padding="constant", padding_value=7
+        )
+        assert out.dtype == torch.int64
+        assert out.device == x.device
+        # the first frame has N-1 padded frames of value 7 + the real frame.
+        assert (out[0, 0, :4] == 7).all()
+        assert (out[0, 0, 4:] == x[0, 0]).all()
+
+    @pytest.mark.parametrize("padding", ["same", "constant"])
+    @pytest.mark.parametrize("padding_value", [0, 2, -1.5])
+    @pytest.mark.parametrize("dim", [-1, -2, -3])
+    @pytest.mark.parametrize("N", [2, 3, 5])
+    @pytest.mark.parametrize("batch_size", [(1,), (2,), (2, 3)])
+    def test_cat_frames_functional_matches_unfolding(
+        self, padding, padding_value, dim, N, batch_size
+    ):
+        # The functional reproduces CatFrames' offline (unfolding) output
+        # byte-for-byte on a single contiguous trajectory.
+        torch.manual_seed(0)
+        time_len = 12
+        extra = (4,) * (-dim - 1)
+        x = torch.randn(*batch_size, time_len, 3, *extra)
+        done = torch.zeros(*batch_size, time_len, 1, dtype=torch.bool)
+        td = TensorDict({"obs": x, ("next", "done"): done}, [*batch_size, time_len])
+        td.names = [None] * len(batch_size) + ["time"]
+        cf = CatFrames(
+            N=N,
+            dim=dim,
+            in_keys=["obs"],
+            out_keys=["out"],
+            padding=padding,
+            padding_value=padding_value,
+        )
+        out_td = cf.unfolding(td.clone())["out"]
+        time_dim = len(batch_size) - x.ndim
+        out_f = F.cat_frames(
+            x,
+            N=N,
+            dim=dim,
+            padding=padding,
+            padding_value=padding_value,
+            time_dim=time_dim,
+        )
+        torch.testing.assert_close(out_td, out_f)
+
+    @pytest.mark.parametrize("padding", ["same", "constant"])
+    def test_cat_frames_functional_matches_unfolding_multitraj(self, padding):
+        # With an explicit done_mask the functional also reproduces the
+        # multi-trajectory (mid-sequence reset) offline output.
+        torch.manual_seed(1)
+        N = 4
+        time_len = 15
+        x = torch.randn(2, time_len, 3)
+        done = torch.zeros(2, time_len, 1, dtype=torch.bool)
+        done[0, 5, 0] = True
+        done[1, 9, 0] = True
+        td = TensorDict({"obs": x, ("next", "done"): done}, [2, time_len])
+        td.names = [None, "time"]
+        cf = CatFrames(N=N, dim=-1, in_keys=["obs"], out_keys=["out"], padding=padding)
+        out_td = cf.unfolding(td.clone())["out"]
+        done_mask = self._unfold_done(done, N, 2)
+        out_f = F.cat_frames(
+            x, N=N, dim=-1, time_dim=-2, padding=padding, done_mask=done_mask
+        )
+        torch.testing.assert_close(out_td, out_f)
+
+    @pytest.mark.parametrize("padding", ["same", "constant"])
+    @pytest.mark.parametrize("dim", [-1, -2])
+    def test_catframes_delegates_to_functional(self, padding, dim):
+        # CatFrames.unfolding stays equivalent to a direct cat_frames call on
+        # the offline path (drop-in / no behavior change check).
+        torch.manual_seed(2)
+        N = 3
+        time_len = 8
+        extra = (4,) * (-dim - 1)
+        x = torch.randn(2, time_len, 3, *extra)
+        done = torch.zeros(2, time_len, 1, dtype=torch.bool)
+        td = TensorDict({"obs": x, ("next", "done"): done}, [2, time_len])
+        td.names = [None, "time"]
+        cf = CatFrames(N=N, dim=dim, in_keys=["obs"], out_keys=["out"], padding=padding)
+        out_td = cf.unfolding(td.clone())["out"]
+        out_f = F.cat_frames(
+            x, N=N, dim=dim, padding=padding, time_dim=len(x.shape[:1]) - x.ndim
+        )
+        torch.testing.assert_close(out_td, out_f)
 
 
 @pytest.mark.skipif(not _has_tv, reason="no torchvision")
@@ -3183,3 +3322,8 @@ class TestNextObservationDeltaForward:
         out = NextObservationDelta(in_keys=["observation"])(td)
         assert "some_other_key" in out.keys(True, True)
         assert ("next", "observation") not in out.keys(True, True)
+
+
+if __name__ == "__main__":
+    args, unknown = argparse.ArgumentParser().parse_known_args()
+    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/torchrl/envs/transforms/_observation.py
+++ b/torchrl/envs/transforms/_observation.py
@@ -13,7 +13,7 @@ from typing import Any, Literal, TYPE_CHECKING
 import torch
 
 from tensordict import set_lazy_legacy, TensorDictBase, unravel_key
-from tensordict.utils import _zip_strict, expand_as_right, expand_right, NestedKey
+from tensordict.utils import _zip_strict, expand_right, NestedKey
 
 from torchrl.data.tensor_specs import ContinuousBox, TensorSpec
 from torchrl.envs.transforms import functional as F
@@ -965,6 +965,11 @@ class CatFrames(ObservationTransform):
         - A modified version of the transform suitable for use in replay buffers
         - A corresponding :class:`SliceSampler` to use with the buffer
 
+    .. seealso:: The offline (contiguous trajectory slice) windowing performed
+        by this transform is also available as a pure functional,
+        :func:`torchrl.envs.transforms.functional.cat_frames`, which operates
+        directly on a plain tensor.
+
     """
 
     inplace = False
@@ -1254,29 +1259,8 @@ class CatFrames(ObservationTransform):
             return self.unfolding(tensordict)
 
     def _apply_same_padding(self, dim, data, done_mask):
-        d = data.ndim + dim - 1
-        res = data.clone()
-        num_repeats_per_sample = done_mask.sum(dim=-1)
-
-        if num_repeats_per_sample.dim() > 2:
-            extra_dims = num_repeats_per_sample.dim() - 2
-            num_repeats_per_sample = num_repeats_per_sample.flatten(0, extra_dims)
-            res_flat_series = res.flatten(0, extra_dims)
-        else:
-            extra_dims = 0
-            res_flat_series = res
-
-        if d - 1 > extra_dims:
-            res_flat_series_flat_batch = res_flat_series.flatten(1, d - 1)
-        else:
-            res_flat_series_flat_batch = res_flat_series[:, None]
-
-        for sample_idx, num_repeats in enumerate(num_repeats_per_sample):
-            if num_repeats > 0:
-                res_slice = res_flat_series_flat_batch[sample_idx]
-                res_slice[:, :num_repeats] = res_slice[:, num_repeats : num_repeats + 1]
-
-        return res
+        # Kept for backward compatibility; delegates to the functional core.
+        return F._apply_same_padding(dim, data, done_mask)
 
     @set_lazy_legacy(False)
     def unfolding(self, tensordict: TensorDictBase) -> TensorDictBase:
@@ -1357,40 +1341,29 @@ class CatFrames(ObservationTransform):
                         data.ndim + self.dim, (self.N, n_feat)
                     )
 
-            idx = [slice(None)] * (tensordict.ndim - 1) + [0]
-            data0 = [
-                torch.full_like(data[tuple(idx)], self.padding_value).unsqueeze(
-                    tensordict.ndim - 1
-                )
-            ] * (self.N - 1)
-
-            data = torch.cat(data0 + [data], tensordict.ndim - 1)
-
-            data = data.unfold(tensordict.ndim - 1, self.N, 1)
-
-            # Place -1 dim at self.dim place before squashing
-            done_mask_expand = done_mask.view(
-                *done_mask.shape[: tensordict.ndim],
-                *(1,) * (data.ndim - 1 - tensordict.ndim),
-                done_mask.shape[-1],
+            # The time axis sits at ``tensordict.ndim - 1`` within ``data`` (the
+            # tensordict batch dims lead the tensor). Expressed relative to
+            # ``data`` it is the following negative ``time_dim``. Delegate the
+            # pure padding + sliding-window + done-mask concatenation to the
+            # ``cat_frames`` functional so that the offline transform stays
+            # byte-for-byte identical to its stateless core.
+            time_dim = (tensordict.ndim - 1) - data.ndim
+            data = F._cat_frames_windows(
+                data,
+                self.N,
+                self.dim,
+                padding=self.padding,
+                padding_value=self.padding_value,
+                time_dim=time_dim,
+                done_mask=done_mask,
             )
-            done_mask_expand = expand_as_right(done_mask_expand, data)
-            data = data.permute(
-                *range(0, data.ndim + self.dim - 1),
-                -1,
-                *range(data.ndim + self.dim - 1, data.ndim - 1),
-            )
-            done_mask_expand = done_mask_expand.permute(
-                *range(0, done_mask_expand.ndim + self.dim - 1),
-                -1,
-                *range(done_mask_expand.ndim + self.dim - 1, done_mask_expand.ndim - 1),
-            )
-            if self.padding != "same":
-                data = torch.where(done_mask_expand, self.padding_value, data)
-            else:
-                data = self._apply_same_padding(self.dim, data, done_mask)
 
             if first_val is not None:
+                data0_pad = torch.full_like(
+                    data_orig[tuple([slice(None)] * (tensordict.ndim - 1) + [0])],
+                    self.padding_value,
+                ).unsqueeze(tensordict.ndim - 1)
+                data0 = [data0_pad] * (self.N - 1)
                 # Aggregate reset along last dim
                 reset_any = reset.any(-1, False)
                 rexp = expand_right(

--- a/torchrl/envs/transforms/functional.py
+++ b/torchrl/envs/transforms/functional.py
@@ -4,7 +4,16 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+from typing import Literal
+
+import torch
+from tensordict.utils import expand_as_right
 from torch import Tensor
+
+__all__ = [
+    "cat_frames",
+    "rgb_to_grayscale",
+]
 
 
 # copied from torchvision
@@ -46,3 +55,236 @@ def rgb_to_grayscale(img: Tensor, num_output_channels: int = 1) -> Tensor:
         return l_img.expand(img.shape)
 
     return l_img
+
+
+def _apply_same_padding(dim: int, data: Tensor, done_mask: Tensor) -> Tensor:
+    """Replaces frames flagged by ``done_mask`` with the first valid frame of the window.
+
+    This implements the ``padding="same"`` semantics of :func:`cat_frames`: within
+    each sliding window, the entries that reach across a trajectory boundary
+    (marked by ``done_mask``) are overwritten with the earliest in-trajectory
+    frame of that window. ``data`` is the permuted, windowed tensor (the window
+    axis already moved to ``data.ndim + dim - 1``); ``done_mask`` is the
+    un-permuted boolean mask of shape ``(*batch, time, N)``.
+    """
+    d = data.ndim + dim - 1
+    res = data.clone()
+    num_repeats_per_sample = done_mask.sum(dim=-1)
+
+    if num_repeats_per_sample.dim() > 2:
+        extra_dims = num_repeats_per_sample.dim() - 2
+        num_repeats_per_sample = num_repeats_per_sample.flatten(0, extra_dims)
+        res_flat_series = res.flatten(0, extra_dims)
+    else:
+        extra_dims = 0
+        res_flat_series = res
+
+    if d - 1 > extra_dims:
+        res_flat_series_flat_batch = res_flat_series.flatten(1, d - 1)
+    else:
+        res_flat_series_flat_batch = res_flat_series[:, None]
+
+    for sample_idx, num_repeats in enumerate(num_repeats_per_sample):
+        if num_repeats > 0:
+            res_slice = res_flat_series_flat_batch[sample_idx]
+            res_slice[:, :num_repeats] = res_slice[:, num_repeats : num_repeats + 1]
+
+    return res
+
+
+def _cat_frames_windows(
+    tensor: Tensor,
+    N: int,
+    dim: int,
+    *,
+    padding: Literal["same", "constant"] = "same",
+    padding_value: float = 0.0,
+    time_dim: int = -1,
+    done_mask: Tensor | None = None,
+) -> Tensor:
+    """Builds the padded, windowed (but **not** flattened) frame stack.
+
+    This is the shared core of :func:`cat_frames`. It returns the unfolded tensor
+    with the window axis placed just before the concatenation axis (``dim``), so
+    that a caller can either flatten it (as :func:`cat_frames` does) or run an
+    extra fixup before flattening (as :class:`~torchrl.envs.transforms.CatFrames`
+    does for ``("next", key)`` inputs).
+
+    ``time_dim`` and ``dim`` are both negative and independent: the sliding
+    window moves along ``time_dim`` and the resulting ``N`` frames are
+    concatenated along ``dim``. ``done_mask`` (if provided) has its time axis at
+    position ``time_dim`` and its window axis appended last, i.e. shape
+    ``tensor.shape`` (up to ``time_dim``) followed by a trailing ``N``.
+    """
+    if dim >= 0:
+        raise ValueError(
+            "dim must be < 0 to accommodate for tensors of different batch-sizes "
+            "(since negative dims are batch invariant)."
+        )
+    if time_dim >= 0:
+        raise ValueError("time_dim must be < 0.")
+    # absolute index of the time axis within ``tensor``
+    time_pos = tensor.ndim + time_dim
+    # pad N-1 frames at the start of the trajectory
+    idx = [slice(None)] * time_pos + [0]
+    data0 = [torch.full_like(tensor[tuple(idx)], padding_value).unsqueeze(time_pos)] * (
+        N - 1
+    )
+    data = torch.cat(data0 + [tensor], time_pos)
+    # unfold along time: appends a trailing window axis of size N
+    data = data.unfold(time_pos, N, 1)
+
+    # move the trailing window axis to just before the cat axis ``dim``
+    data = data.permute(
+        *range(0, data.ndim + dim - 1),
+        -1,
+        *range(data.ndim + dim - 1, data.ndim - 1),
+    )
+
+    if padding != "same":
+        if done_mask is not None:
+            done_mask_expand = done_mask.view(
+                *done_mask.shape[: time_pos + 1],
+                *(1,) * (data.ndim - 2 - time_pos),
+                done_mask.shape[-1],
+            )
+            # expand_as_right needs the window axis last, so expand before
+            # permuting the window axis into place.
+            data_win_last = data.movedim(data.ndim + dim - 1, -1)
+            done_mask_expand = expand_as_right(done_mask_expand, data_win_last)
+            done_mask_expand = done_mask_expand.movedim(-1, data.ndim + dim - 1)
+            data = torch.where(done_mask_expand, padding_value, data)
+    else:
+        if done_mask is not None:
+            data = _apply_same_padding(dim, data, done_mask)
+    return data
+
+
+def cat_frames(
+    tensor: Tensor,
+    N: int,
+    dim: int,
+    *,
+    padding: Literal["same", "constant"] = "same",
+    padding_value: float = 0.0,
+    time_dim: int = -1,
+    done_mask: Tensor | None = None,
+) -> Tensor:
+    r"""Stacks a sliding window of ``N`` successive frames along ``dim``.
+
+    This is the pure, stateless core of the
+    :class:`~torchrl.envs.transforms.CatFrames` transform (the PyTorch
+    ``F.x`` / ``nn.X`` split): :class:`~torchrl.envs.transforms.CatFrames`
+    delegates its offline / replay-buffer (contiguous trajectory slice)
+    windowing to this function so that the two stay byte-for-byte identical.
+
+    For every position ``t`` along ``time_dim``, the ``N`` frames
+    ``[t - N + 1, ..., t]`` are concatenated along ``dim``. The first ``N - 1``
+    positions of a trajectory have fewer than ``N`` real frames; the missing
+    frames are filled according to ``padding``. This matches the offline
+    behavior of :class:`~torchrl.envs.transforms.CatFrames`; see the
+    "Examples" of that class for the online (stateful, per-step) usage.
+
+    It was first proposed in "Playing Atari with Deep Reinforcement Learning"
+    (https://arxiv.org/abs/1312.5602).
+
+    Args:
+        tensor (torch.Tensor): the frames to stack. One of its dimensions
+            (``time_dim``) is the time axis along which the sliding window
+            moves; ``dim`` is the (channel/feature) axis along which the
+            ``N`` frames are concatenated.
+        N (int): number of successive frames to concatenate.
+        dim (int): the dimension along which the frames are concatenated.
+            Must be negative so that it is invariant to leading batch
+            dimensions. The size of ``tensor`` along ``dim`` is multiplied by
+            ``N`` in the output.
+
+    Keyword Args:
+        padding (str, optional): the padding method, one of ``"same"`` or
+            ``"constant"``. With ``"same"`` (default) the first real frame of
+            the trajectory is repeated; with ``"constant"`` the missing frames
+            are filled with ``padding_value``.
+        padding_value (float, optional): the value used to pad when
+            ``padding="constant"``. Defaults to ``0``.
+        time_dim (int, optional): the dimension of ``tensor`` that holds the
+            time axis. Must be negative. Defaults to ``-1``.
+        done_mask (torch.Tensor, optional): an optional boolean mask flagging,
+            for each sliding window, which of its ``N`` positions reach across
+            a trajectory boundary (and must therefore be padded). Its shape is
+            ``(*batch, time, N)`` where ``time`` matches the size of ``tensor``
+            along ``time_dim``. When ``None`` (default), the input is treated as
+            a single trajectory and only the leading ``N - 1`` start-of-sequence
+            frames are padded. :class:`~torchrl.envs.transforms.CatFrames`
+            builds this mask from the environment ``done`` signal.
+
+    Returns:
+        torch.Tensor: a tensor identical to ``tensor`` except that its size
+        along ``dim`` is multiplied by ``N`` (the concatenated window) and its
+        dtype / device are preserved.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.envs.transforms.functional import cat_frames
+        >>> # a single trajectory of 4 frames, each a length-2 feature vector,
+        >>> # stacked over a window of N=3 along the feature dim (-1).
+        >>> frames = torch.arange(8.0).view(4, 2)
+        >>> frames
+        tensor([[0., 1.],
+                [2., 3.],
+                [4., 5.],
+                [6., 7.]])
+        >>> out = cat_frames(frames, N=3, dim=-1, time_dim=-2, padding="constant")
+        >>> out.shape
+        torch.Size([4, 6])
+        >>> out
+        tensor([[0., 0., 0., 0., 0., 1.],
+                [0., 0., 0., 1., 2., 3.],
+                [0., 1., 2., 3., 4., 5.],
+                [2., 3., 4., 5., 6., 7.]])
+
+    .. note:: This functional covers the **offline** (contiguous trajectory
+        slice) windowing used by
+        :class:`~torchrl.envs.transforms.CatFrames`. The transform's
+        **online** path (per-:meth:`~torchrl.envs.EnvBase.step` buffer
+        accumulation) is inherently stateful and is not expressed as a pure
+        function.
+
+    .. seealso:: :class:`~torchrl.envs.transforms.CatFrames`.
+    """
+    if padding not in ("same", "constant"):
+        raise ValueError(
+            f"padding must be one of 'same' or 'constant', got {padding!r}."
+        )
+    if time_dim >= 0:
+        raise ValueError("time_dim must be < 0.")
+    if done_mask is None:
+        # Treat the input as a single contiguous trajectory: only the leading
+        # N - 1 start-of-sequence windows have padded (out-of-trajectory)
+        # positions. Window position ``j`` of output step ``t`` reads source
+        # step ``t - (N - 1) + j``; it is padded when that index is < 0.
+        time_pos = tensor.ndim + time_dim
+        time_len = tensor.shape[time_pos]
+        steps = torch.arange(time_len, device=tensor.device)
+        positions = torch.arange(N, device=tensor.device)
+        # shape (time_len, N): True where the source index is before the start
+        mask = positions[None, :] < (N - 1 - steps)[:, None]
+        # broadcast over the leading batch dims (everything before time) and
+        # add a trailing singleton "done feature" dim so the mask matches the
+        # ``(*batch, time, 1, N)`` layout produced from a per-step done signal.
+        shape = [1] * (time_pos + 1) + [1, N]
+        shape[time_pos] = time_len
+        done_mask = (
+            mask.unsqueeze(-2)
+            .reshape(shape)
+            .expand(*tensor.shape[: time_pos + 1], 1, N)
+        )
+    data = _cat_frames_windows(
+        tensor,
+        N,
+        dim,
+        padding=padding,
+        padding_value=padding_value,
+        time_dim=time_dim,
+        done_mask=done_mask,
+    )
+    return data.flatten(data.ndim + dim - 1, data.ndim + dim)


### PR DESCRIPTION
## Summary

Extracts the sliding-window frame-concatenation logic of the `CatFrames`
transform into a pure, stateless functional, following the PyTorch
`torch.nn.functional` / `torch.nn.Module` split:

```python
torchrl.envs.transforms.functional.cat_frames(
    tensor, N, dim, *, padding="same", padding_value=0.0, time_dim=-1, done_mask=None
)
```

`CatFrames` now delegates its offline windowing to this functional. There is
**no public API or behavior change**: `CatFrames` remains a drop-in, its
signature is untouched, and all 107 pre-existing `CatFrames` tests pass
unchanged.

## What was extracted

- `cat_frames(...)`: operates on a plain tensor whose `time_dim` axis is the
  time axis along which the window slides, concatenating the `N` frames of each
  window along `dim`. It implements the exact `"same"` / `"constant"` padding
  semantics of `CatFrames`, preserves dtype/device, and handles
  trajectory-edge padding. With `done_mask=None` it treats the input as a
  single contiguous trajectory (only the leading `N-1` start-of-sequence
  windows are padded); an explicit `done_mask` reproduces the multi-trajectory
  (mid-sequence reset) behavior.
- `CatFrames.unfolding` (the offline / replay-buffer contiguous-slice path) and
  `CatFrames._apply_same_padding` now delegate to the functional core, so the
  transform and the functional stay byte-for-byte identical.

## Offline vs online decision

The functional covers the **offline** path (contiguous trajectory slice /
replay-buffer windowing via `unfolding`). The **online** stateful path
(`_call`, which incrementally rolls and writes into a registered buffer across
`env.step`) is inherently stateful and is intentionally **not** expressed as a
pure function; it is left unchanged. This boundary is documented in the
`cat_frames` docstring.

## Tests

Added to the existing `test/transforms/test_observation_transforms.py`
(`TestCatFrames`):

- `test_cat_frames_functional_basic`: the documented example output.
- `test_cat_frames_functional_validation`: `dim`/`time_dim`/`padding`
  validation.
- `test_cat_frames_functional_dtype_device`: dtype, device, and
  `padding_value` preservation (parametrized over default devices; CPU path
  stays unmarked).
- `test_cat_frames_functional_matches_unfolding`: byte-for-byte equivalence
  with `CatFrames.unfolding` over `padding` x `padding_value` x `dim` x `N` x
  `batch_size` (single contiguous trajectory).
- `test_cat_frames_functional_matches_unfolding_multitraj`: equivalence with an
  explicit `done_mask` (mid-sequence resets).
- `test_catframes_delegates_to_functional`: confirms the offline transform
  delegates equivalently.

A module `if __name__ == "__main__": pytest.main([__file__, ...])` block was
also added so the file can be run directly.

## Docs

`cat_frames` is documented under a new "Functional transforms" section in
`docs/source/reference/envs_transforms.rst` (Sphinx docstring with a runnable
`>>>` example, verified via doctest). `CatFrames` gets a `.. seealso::`
cross-reference to the functional.

## Benchmark

`CatFrames` is a hot-path transform, so a `test_cat_frames_functional`
benchmark case (parametrized over `padding` and `N`) was added to
`benchmarks/test_envs_benchmark.py`.

## Verification

- `uv run python -m pytest test/transforms/test_observation_transforms.py -k "CatFrames or cat_frames" -q`
  -> 278 passed, 1 skipped.
- Lint (`prek run --files ...`): all hooks pass.
- Docstring example verified through `doctest`.
