### PR TITLE
[Feature] ActionChunkTransform for VLA action chunking

### DIFF
--- a/docs/source/reference/envs_transforms.rst
+++ b/docs/source/reference/envs_transforms.rst
@@ -245,6 +245,7 @@ Available Transforms
 
     Transform
     TransformedEnv
+    ActionChunkTransform
     ActionDiscretizer
     ActionMask
     ActionScaling

--- a/docs/source/reference/vla.rst
+++ b/docs/source/reference/vla.rst
@@ -56,3 +56,15 @@ Data and metadata
 
     RobotDatasetMetadata
     validate_vla_tensordict
+
+Transforms
+----------
+
+VLA-specific transforms are standard :class:`~torchrl.envs.transforms.Transform`
+subclasses, so they compose with :class:`~torchrl.envs.transforms.Compose`,
+replay buffers and transformed environments. They are documented in full on the
+:ref:`transforms reference page <transforms>`.
+
+- :class:`~torchrl.envs.transforms.ActionChunkTransform` -- build fixed-length
+  action chunks (``[*B, T, H, action_dim]``) and a padding mask from a sampled
+  trajectory window, the standard training target for chunked VLA policies.

--- a/test/transforms/test_action_transforms.py
+++ b/test/transforms/test_action_transforms.py
@@ -89,6 +89,7 @@ from torchrl.testing.mocking_classes import (
     CountingEnv,
     DiscreteActionConvMockEnvNumpy,
     EnvWithScalarAction,
+    NestedCountingEnv,
     StateLessCountingEnv,
 )
 
@@ -2145,14 +2146,122 @@ class TestFlattenAction(TransformBase):
         assert r["action"].shape == (4, 15)
 
 
-class TestActionChunkTransform:
-    def test_shapes(self):
+class TestActionChunkTransform(TransformBase):
+    @staticmethod
+    def _env(chunk_size=3):
+        return TransformedEnv(
+            ContinuousActionVecMockEnv(), ActionChunkTransform(chunk_size=chunk_size)
+        )
+
+    def test_single_trans_env_check(self):
+        env = self._env()
+        check_env_specs(env)
+        # the policy-facing action spec is the chunked one
+        assert env.full_action_spec["action_chunk"].shape[-2:] == torch.Size([3, 7])
+        assert "action" not in env.full_action_spec.keys(True, True)
+
+    def test_serial_trans_env_check(self):
+        env = SerialEnv(2, self._env)
+        check_env_specs(env)
+
+    def test_parallel_trans_env_check(self, maybe_fork_ParallelEnv):
+        env = maybe_fork_ParallelEnv(2, self._env)
+        try:
+            check_env_specs(env)
+        finally:
+            try:
+                env.close()
+            except RuntimeError:
+                pass
+
+    def test_trans_serial_env_check(self):
+        env = TransformedEnv(
+            SerialEnv(2, ContinuousActionVecMockEnv), ActionChunkTransform(3)
+        )
+        check_env_specs(env)
+        assert env.full_action_spec["action_chunk"].shape == torch.Size([2, 3, 7])
+
+    def test_trans_parallel_env_check(self, maybe_fork_ParallelEnv):
+        env = TransformedEnv(
+            maybe_fork_ParallelEnv(2, ContinuousActionVecMockEnv),
+            ActionChunkTransform(3),
+        )
+        try:
+            check_env_specs(env)
+        finally:
+            try:
+                env.close()
+            except RuntimeError:
+                pass
+
+    def test_transform_no_env(self):
         t = ActionChunkTransform(chunk_size=4)
         out = t(TensorDict({"action": torch.randn(2, 6, 3)}, batch_size=[2, 6]))
         assert out["action_chunk"].shape == torch.Size([2, 6, 4, 3])
         assert out["action_is_pad"].shape == torch.Size([2, 6, 4])
         assert out["action_is_pad"].dtype == torch.bool
 
+    def test_transform_compose(self):
+        t = Compose(ActionChunkTransform(chunk_size=2))
+        out = t(TensorDict({"action": torch.randn(5, 3)}, batch_size=[5]))
+        assert out["action_chunk"].shape == torch.Size([5, 2, 3])
+        assert out["action_is_pad"].shape == torch.Size([5, 2])
+
+    def test_transform_env(self):
+        captured = {}
+
+        class CaptureEnv(ContinuousActionVecMockEnv):
+            def _step(self, td):
+                captured["action"] = td["action"].clone()
+                return super()._step(td)
+
+        env = TransformedEnv(CaptureEnv(), ActionChunkTransform(chunk_size=3))
+        td = env.reset()
+        assert "reward" not in td.keys()
+        td["action_chunk"] = torch.arange(21, dtype=torch.float).view(3, 7) / 21
+        env.step(td)
+        # the base env consumes the first action of the chunk
+        torch.testing.assert_close(captured["action"], td["action_chunk"][0])
+        r = env.rollout(3)
+        assert r["action_chunk"].shape == torch.Size([3, 3, 7])
+
+    def test_transform_model(self):
+        t = ActionChunkTransform(chunk_size=3)
+        model = nn.Sequential(t)
+        td = TensorDict({"action": torch.arange(4).view(1, 4, 1).float()}, [1, 4])
+        out = model(td)
+        expected_chunk = torch.tensor(
+            [[0, 1, 2], [1, 2, 3], [2, 3, 3], [3, 3, 3]]
+        ).float()
+        torch.testing.assert_close(out["action_chunk"][0, :, :, 0], expected_chunk)
+        expected_pad = torch.tensor([[0, 0, 0], [0, 0, 0], [0, 0, 1], [0, 1, 1]]).bool()
+        assert torch.equal(out["action_is_pad"][0], expected_pad)
+
+    def test_transform_rb(self):
+        rb = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(10),
+            transform=ActionChunkTransform(3),
+            batch_size=4,
+        )
+        # extend with raw (chunk-less) trajectory windows: the inverse is a
+        # no-op, and the chunks are built on the sample path only
+        rb.extend(TensorDict({"action": torch.randn(10, 5, 2)}, batch_size=[10]))
+        stored = rb._storage._storage
+        assert "action_chunk" not in stored.keys()
+        sample = rb.sample()
+        assert sample["action_chunk"].shape[-2:] == torch.Size([3, 2])
+        assert sample["action_is_pad"].shape[-1] == 3
+
+    def test_transform_inverse(self):
+        t = ActionChunkTransform(chunk_size=3)
+        chunk = torch.randn(2, 3, 5)
+        td = t.inv(TensorDict({"action_chunk": chunk}, batch_size=[2]))
+        torch.testing.assert_close(td["action"], chunk[..., 0, :])
+        # absent chunk: the inverse is a no-op
+        td = t.inv(TensorDict({"action": torch.randn(2, 5)}, batch_size=[2]))
+        assert "action_chunk" not in td.keys()
+
+    # ActionChunkTransform-specific tests
     def test_values_and_padding(self):
         t = ActionChunkTransform(chunk_size=3)
         action = torch.arange(4).view(1, 4, 1).float()
@@ -2193,23 +2302,41 @@ class TestActionChunkTransform:
         out = t(td)
         assert out["data", "chunk"].shape == torch.Size([2, 4, 2, 3])
         assert out["data", "pad"].shape == torch.Size([2, 4, 2])
+        # the inverse also resolves nested keys
+        back = t.inv(
+            TensorDict({"data": {"chunk": torch.randn(2, 2, 3)}}, batch_size=[2])
+        )
+        assert back["data", "action"].shape == torch.Size([2, 3])
+
+    def test_nested_action_key_env(self):
+        # the spec rewrite handles nested (tuple) action keys on a real env
+        env = TransformedEnv(
+            NestedCountingEnv(),
+            ActionChunkTransform(
+                2,
+                action_key=("data", "action"),
+                chunk_key=("data", "chunk"),
+                pad_key=("data", "pad"),
+            ),
+        )
+        check_env_specs(env)
+        assert ("data", "chunk") in env.full_action_spec.keys(True, True)
+        assert ("data", "action") not in env.full_action_spec.keys(True, True)
+        env.rollout(3)
+
+    def test_env_missing_chunk_raises(self):
+        # a policy mistakenly writing the raw action key must not silently
+        # bypass the transform when it is attached to an env
+        env = self._env()
+        td = env.reset()
+        td["action"] = torch.zeros(7)
+        with pytest.raises(KeyError, match="action_chunk"):
+            env.step(td)
 
     def test_missing_action_raises(self):
         t = ActionChunkTransform(chunk_size=2)
         with pytest.raises(KeyError):
             t(TensorDict({"other": torch.randn(2, 4, 3)}, batch_size=[2, 4]))
-
-    def test_replay_buffer_integration(self):
-        rb = TensorDictReplayBuffer(
-            storage=LazyTensorStorage(10),
-            transform=ActionChunkTransform(3),
-            batch_size=4,
-        )
-        # each stored item is a [T=5, A=2] trajectory window
-        rb.extend(TensorDict({"action": torch.randn(10, 5, 2)}, batch_size=[10]))
-        sample = rb.sample()
-        assert sample["action_chunk"].shape[-2:] == torch.Size([3, 2])
-        assert sample["action_is_pad"].shape[-1] == 3
 
     def test_no_cross_boundary_after_reshape(self):
         # Emulate a flat SliceSampler batch of two length-4 slices, then reshape
@@ -2226,11 +2353,6 @@ class TestActionChunkTransform:
         assert chunk[1].min() >= 10
         # the window tail is padded
         assert out["action_is_pad"][0, -1].tolist() == [False, True, True]
-
-    def test_cannot_be_env_transform(self):
-        t = ActionChunkTransform(2)
-        with pytest.raises(ValueError, match="replay-buffer"):
-            t._call(TensorDict({"action": torch.randn(2, 3)}, batch_size=[2]))
 
     def test_trailing_dim_enforced(self):
         # time_dim must point to the second-to-last dim (action_dim is last)

--- a/test/transforms/test_action_transforms.py
+++ b/test/transforms/test_action_transforms.py
@@ -66,6 +66,7 @@ from torchrl.envs import (
     URScriptPrimitiveTransform,
 )
 from torchrl.envs.libs.gym import _has_gym, GymEnv
+from torchrl.envs.transforms import ActionChunkTransform
 from torchrl.envs.transforms.transforms import (
     ActionDiscretizer,
     FORWARD_NOT_IMPLEMENTED,
@@ -2142,6 +2143,109 @@ class TestFlattenAction(TransformBase):
         )
         r = env.rollout(4)
         assert r["action"].shape == (4, 15)
+
+
+class TestActionChunkTransform:
+    def test_shapes(self):
+        t = ActionChunkTransform(chunk_size=4)
+        out = t(TensorDict({"action": torch.randn(2, 6, 3)}, batch_size=[2, 6]))
+        assert out["action_chunk"].shape == torch.Size([2, 6, 4, 3])
+        assert out["action_is_pad"].shape == torch.Size([2, 6, 4])
+        assert out["action_is_pad"].dtype == torch.bool
+
+    def test_values_and_padding(self):
+        t = ActionChunkTransform(chunk_size=3)
+        action = torch.arange(4).view(1, 4, 1).float()
+        out = t(TensorDict({"action": action}, batch_size=[1, 4]))
+        expected_chunk = torch.tensor(
+            [[0, 1, 2], [1, 2, 3], [2, 3, 3], [3, 3, 3]]
+        ).float()
+        torch.testing.assert_close(out["action_chunk"][0, :, :, 0], expected_chunk)
+        expected_pad = torch.tensor([[0, 0, 0], [0, 0, 0], [0, 0, 1], [0, 1, 1]]).bool()
+        assert torch.equal(out["action_is_pad"][0], expected_pad)
+
+    def test_no_batch_dim(self):
+        t = ActionChunkTransform(chunk_size=2)
+        out = t(TensorDict({"action": torch.randn(5, 3)}, batch_size=[5]))
+        assert out["action_chunk"].shape == torch.Size([5, 2, 3])
+        assert out["action_is_pad"].shape == torch.Size([5, 2])
+
+    def test_chunk_larger_than_horizon(self):
+        t = ActionChunkTransform(chunk_size=10)
+        out = t(TensorDict({"action": torch.arange(3).view(1, 3, 1).float()}, [1, 3]))
+        assert out["action_chunk"].shape == torch.Size([1, 3, 10, 1])
+        # first chunk: steps 0,1,2 valid then padded
+        assert not out["action_is_pad"][0, 0, :3].any()
+        assert out["action_is_pad"][0, 0, 3:].all()
+
+    def test_invalid_chunk_size(self):
+        with pytest.raises(ValueError, match="chunk_size"):
+            ActionChunkTransform(chunk_size=0)
+
+    def test_nested_action_key(self):
+        t = ActionChunkTransform(
+            chunk_size=2,
+            action_key=("data", "action"),
+            chunk_key=("data", "chunk"),
+            pad_key=("data", "pad"),
+        )
+        td = TensorDict({"data": {"action": torch.randn(2, 4, 3)}}, batch_size=[2, 4])
+        out = t(td)
+        assert out["data", "chunk"].shape == torch.Size([2, 4, 2, 3])
+        assert out["data", "pad"].shape == torch.Size([2, 4, 2])
+
+    def test_missing_action_raises(self):
+        t = ActionChunkTransform(chunk_size=2)
+        with pytest.raises(KeyError):
+            t(TensorDict({"other": torch.randn(2, 4, 3)}, batch_size=[2, 4]))
+
+    def test_replay_buffer_integration(self):
+        rb = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(10),
+            transform=ActionChunkTransform(3),
+            batch_size=4,
+        )
+        # each stored item is a [T=5, A=2] trajectory window
+        rb.extend(TensorDict({"action": torch.randn(10, 5, 2)}, batch_size=[10]))
+        sample = rb.sample()
+        assert sample["action_chunk"].shape[-2:] == torch.Size([3, 2])
+        assert sample["action_is_pad"].shape[-1] == 3
+
+    def test_no_cross_boundary_after_reshape(self):
+        # Emulate a flat SliceSampler batch of two length-4 slices, then reshape
+        # to [num_slices, slice_len] before chunking (the documented workflow).
+        flat = TensorDict(
+            {"action": torch.tensor([0.0, 1, 2, 3, 10, 11, 12, 13]).view(8, 1)},
+            batch_size=[8],
+        )
+        windows = flat.reshape(2, 4)
+        out = ActionChunkTransform(3)(windows)
+        chunk = out["action_chunk"][..., 0]
+        # neither slice pulls the other slice's actions across the boundary
+        assert chunk[0].max() <= 3
+        assert chunk[1].min() >= 10
+        # the window tail is padded
+        assert out["action_is_pad"][0, -1].tolist() == [False, True, True]
+
+    def test_cannot_be_env_transform(self):
+        t = ActionChunkTransform(2)
+        with pytest.raises(ValueError, match="replay-buffer"):
+            t._call(TensorDict({"action": torch.randn(2, 3)}, batch_size=[2]))
+
+    def test_trailing_dim_enforced(self):
+        # time_dim must point to the second-to-last dim (action_dim is last)
+        t = ActionChunkTransform(2, time_dim=0)
+        with pytest.raises(ValueError, match="immediately follow"):
+            t(TensorDict({"action": torch.randn(2, 4, 3)}, batch_size=[2, 4]))
+
+    def test_compile_build_chunk(self):
+        t = ActionChunkTransform(chunk_size=3)
+        action = torch.randn(2, 5, 2)
+        eager_chunk, eager_pad = t._build_chunk(action)
+        compiled = torch.compile(t._build_chunk, fullgraph=True)
+        c_chunk, c_pad = compiled(action)
+        torch.testing.assert_close(c_chunk, eager_chunk)
+        assert torch.equal(c_pad, eager_pad)
 
 
 if __name__ == "__main__":

--- a/test/transforms/test_action_transforms.py
+++ b/test/transforms/test_action_transforms.py
@@ -89,7 +89,6 @@ from torchrl.testing.mocking_classes import (
     CountingEnv,
     DiscreteActionConvMockEnvNumpy,
     EnvWithScalarAction,
-    NestedCountingEnv,
     StateLessCountingEnv,
 )
 
@@ -2154,11 +2153,11 @@ class TestActionChunkTransform(TransformBase):
         )
 
     def test_single_trans_env_check(self):
+        # a pure data-path transform: env attachment is a documented no-op
         env = self._env()
         check_env_specs(env)
-        # the policy-facing action spec is the chunked one
-        assert env.full_action_spec["action_chunk"].shape[-2:] == torch.Size([3, 7])
-        assert "action" not in env.full_action_spec.keys(True, True)
+        assert "action" in env.full_action_spec.keys(True, True)
+        assert "action_chunk" not in env.full_action_spec.keys(True, True)
 
     def test_serial_trans_env_check(self):
         env = SerialEnv(2, self._env)
@@ -2179,7 +2178,7 @@ class TestActionChunkTransform(TransformBase):
             SerialEnv(2, ContinuousActionVecMockEnv), ActionChunkTransform(3)
         )
         check_env_specs(env)
-        assert env.full_action_spec["action_chunk"].shape == torch.Size([2, 3, 7])
+        assert env.full_action_spec["action"].shape == torch.Size([2, 7])
 
     def test_trans_parallel_env_check(self, maybe_fork_ParallelEnv):
         env = TransformedEnv(
@@ -2208,6 +2207,8 @@ class TestActionChunkTransform(TransformBase):
         assert out["action_is_pad"].shape == torch.Size([5, 2])
 
     def test_transform_env(self):
+        # attached to an env, the transform leaves stepping untouched (chunk
+        # execution is the job of MultiStepActorWrapper / MultiAction)
         captured = {}
 
         class CaptureEnv(ContinuousActionVecMockEnv):
@@ -2217,13 +2218,11 @@ class TestActionChunkTransform(TransformBase):
 
         env = TransformedEnv(CaptureEnv(), ActionChunkTransform(chunk_size=3))
         td = env.reset()
-        assert "reward" not in td.keys()
-        td["action_chunk"] = torch.arange(21, dtype=torch.float).view(3, 7) / 21
+        td["action"] = torch.full((7,), 0.5)
         env.step(td)
-        # the base env consumes the first action of the chunk
-        torch.testing.assert_close(captured["action"], td["action_chunk"][0])
+        torch.testing.assert_close(captured["action"], td["action"])
         r = env.rollout(3)
-        assert r["action_chunk"].shape == torch.Size([3, 3, 7])
+        assert "action_chunk" not in r.keys()
 
     def test_transform_model(self):
         t = ActionChunkTransform(chunk_size=3)
@@ -2253,12 +2252,11 @@ class TestActionChunkTransform(TransformBase):
         assert sample["action_is_pad"].shape[-1] == 3
 
     def test_transform_inverse(self):
+        # no inverse: extend-time data passes through untouched
         t = ActionChunkTransform(chunk_size=3)
-        chunk = torch.randn(2, 3, 5)
-        td = t.inv(TensorDict({"action_chunk": chunk}, batch_size=[2]))
-        torch.testing.assert_close(td["action"], chunk[..., 0, :])
-        # absent chunk: the inverse is a no-op
-        td = t.inv(TensorDict({"action": torch.randn(2, 5)}, batch_size=[2]))
+        action = torch.randn(2, 5)
+        td = t.inv(TensorDict({"action": action}, batch_size=[2]))
+        torch.testing.assert_close(td["action"], action)
         assert "action_chunk" not in td.keys()
 
     # ActionChunkTransform-specific tests
@@ -2302,36 +2300,6 @@ class TestActionChunkTransform(TransformBase):
         out = t(td)
         assert out["data", "chunk"].shape == torch.Size([2, 4, 2, 3])
         assert out["data", "pad"].shape == torch.Size([2, 4, 2])
-        # the inverse also resolves nested keys
-        back = t.inv(
-            TensorDict({"data": {"chunk": torch.randn(2, 2, 3)}}, batch_size=[2])
-        )
-        assert back["data", "action"].shape == torch.Size([2, 3])
-
-    def test_nested_action_key_env(self):
-        # the spec rewrite handles nested (tuple) action keys on a real env
-        env = TransformedEnv(
-            NestedCountingEnv(),
-            ActionChunkTransform(
-                2,
-                action_key=("data", "action"),
-                chunk_key=("data", "chunk"),
-                pad_key=("data", "pad"),
-            ),
-        )
-        check_env_specs(env)
-        assert ("data", "chunk") in env.full_action_spec.keys(True, True)
-        assert ("data", "action") not in env.full_action_spec.keys(True, True)
-        env.rollout(3)
-
-    def test_env_missing_chunk_raises(self):
-        # a policy mistakenly writing the raw action key must not silently
-        # bypass the transform when it is attached to an env
-        env = self._env()
-        td = env.reset()
-        td["action"] = torch.zeros(7)
-        with pytest.raises(KeyError, match="action_chunk"):
-            env.step(td)
 
     def test_missing_action_raises(self):
         t = ActionChunkTransform(chunk_size=2)

--- a/torchrl/envs/__init__.py
+++ b/torchrl/envs/__init__.py
@@ -74,6 +74,7 @@ from .libs import (
 )
 from .model_based import DreamerDecoder, DreamerEnv, ImaginedEnv, ModelBasedEnvBase
 from .transforms import (
+    ActionChunkTransform,
     ActionDiscretizer,
     ActionMask,
     ActionScaling,
@@ -168,6 +169,7 @@ from .utils import (
 )
 
 __all__ = [
+    "ActionChunkTransform",
     "ActionDiscretizer",
     "ActionMask",
     "ActionScaling",

--- a/torchrl/envs/transforms/__init__.py
+++ b/torchrl/envs/transforms/__init__.py
@@ -18,6 +18,7 @@ from .r3m import R3MTransform
 from .ray_service import RayTransform
 from .rb_transforms import MultiStepTransform, NextStateReconstructor
 from .transforms import (
+    ActionChunkTransform,
     ActionDiscretizer,
     ActionMask,
     ActionScaling,
@@ -124,6 +125,7 @@ def __getattr__(name: str):
 
 
 __all__ = [
+    "ActionChunkTransform",
     "ActionDiscretizer",
     "ActionMask",
     "ActionScaling",

--- a/torchrl/envs/transforms/_action.py
+++ b/torchrl/envs/transforms/_action.py
@@ -40,7 +40,6 @@ else:
     Self = Any
 
 from torchrl.data.vla.schema import ACTION_CHUNK_KEY, ACTION_IS_PAD_KEY, ACTION_KEY
-from torchrl.envs.common import EnvBase
 from torchrl.envs.transforms._base import FORWARD_NOT_IMPLEMENTED, Transform
 
 __all__ = [
@@ -1486,12 +1485,19 @@ class ActionChunkTransform(Transform):
     ``action_is_pad`` mask ``[*B, T, H]`` marking the steps that ran past the
     end of the window (and were filled by repeating the last available action).
 
-    It is a replay-buffer / offline transform that operates on **time-structured**
-    data: the action tensor must be shaped ``[*B, T, action_dim]`` and each row
-    along ``time_dim`` must be a single contiguous trajectory window. Chunks are
+    The forward (data) path operates on **time-structured** data: the action
+    tensor must be shaped ``[*B, T, action_dim]`` and each row along
+    ``time_dim`` must be a single contiguous trajectory window. Chunks are
     built independently per row and never cross a row boundary; the downstream
     chunked behavior-cloning loss masks the padded steps out using
     ``action_is_pad``.
+
+    The transform can also be attached to a :class:`~torchrl.envs.TransformedEnv`:
+    the policy-facing action spec is rewritten to the chunked shape
+    ``[H, action_dim]`` and, on the inverse (action-input) path, the first
+    action of the predicted ``action_chunk`` is forwarded to the base
+    environment. This re-plans at every step (closed-loop chunked control),
+    which calls the policy once per env step.
 
     .. note::
         A :class:`~torchrl.data.SliceSampler` returns a *flat* ``[B * T, ...]``
@@ -1500,8 +1506,10 @@ class ActionChunkTransform(Transform):
         Datasets that store one trajectory window per item (e.g.
         :class:`~torchrl.data.datasets.OpenXExperienceReplay`) already yield
         time-structured ``[batch, T, ...]`` samples and can use this transform
-        directly. This transform cannot be used as a
-        :class:`~torchrl.envs.TransformedEnv` transform.
+        directly. When this transform is appended to a replay buffer,
+        ``extend`` leaves raw (chunk-less) data untouched: the inverse pass is
+        a no-op when the chunk entry is absent. Attached to an environment, a
+        missing chunk on the step path raises instead.
 
     Args:
         chunk_size (int): the horizon ``H`` of the action chunk.
@@ -1537,12 +1545,8 @@ class ActionChunkTransform(Transform):
                 [False, False, False],
                 [False, False,  True],
                 [False,  True,  True]])
-    """
 
-    ENV_ERR = (
-        "ActionChunkTransform is a replay-buffer / offline transform and cannot "
-        "be used as an environment transform."
-    )
+    """
 
     def __init__(
         self,
@@ -1557,19 +1561,30 @@ class ActionChunkTransform(Transform):
             raise ValueError(f"chunk_size must be >= 1, got {chunk_size}.")
         self.chunk_size = int(chunk_size)
         self.time_dim = int(time_dim)
-        super().__init__(in_keys=[action_key], out_keys=[chunk_key, pad_key])
+        # ``forward`` is fully overridden (it writes the chunk and the pad mask
+        # from the action), so no forward keys are declared: the chunk and pad
+        # entries only exist on the data path, never in the env's output specs.
+        # The inverse direction reads ``out_keys_inv`` (the chunk) and writes
+        # ``in_keys_inv`` (the action passed to the base env).
+        super().__init__(
+            in_keys=[],
+            out_keys=[],
+            in_keys_inv=[action_key],
+            out_keys_inv=[chunk_key],
+        )
+        self._pad_key = pad_key
 
     @property
     def action_key(self) -> NestedKey:
-        return self.in_keys[0]
+        return self.in_keys_inv[0]
 
     @property
     def chunk_key(self) -> NestedKey:
-        return self.out_keys[0]
+        return self.out_keys_inv[0]
 
     @property
     def pad_key(self) -> NestedKey:
-        return self.out_keys[1]
+        return self._pad_key
 
     def _build_chunk(self, action: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         H = self.chunk_size
@@ -1607,13 +1622,54 @@ class ActionChunkTransform(Transform):
         tensordict.set(self.pad_key, is_pad)
         return tensordict
 
-    def _call(self, next_tensordict: TensorDictBase) -> TensorDictBase:
-        raise ValueError(self.ENV_ERR)
+    def _inv_apply_transform(self, chunk: torch.Tensor) -> torch.Tensor:
+        if chunk.dim() < 2:
+            raise ValueError(
+                f"{type(self).__name__} expects an action chunk shaped "
+                f"[..., chunk_size, action_dim]; got shape {tuple(chunk.shape)}."
+            )
+        return chunk[..., 0, :]
 
-    def set_container(self, container) -> None:
-        if (
-            isinstance(container, EnvBase)
-            or getattr(container, "parent", None) is not None
-        ):
-            raise ValueError(self.ENV_ERR)
-        super().set_container(container)
+    def _inv_call(self, tensordict: TensorDictBase) -> TensorDictBase:
+        # Without a parent env (replay-buffer ``extend``), raw chunk-less data
+        # passes through untouched. Attached to an env, a missing chunk on the
+        # step path is an error (the rewritten action spec advertises it; a
+        # policy writing the raw action key by mistake should not silently
+        # bypass the transform), while the reset preprocess runs with missing
+        # tolerance and skips.
+        if self.parent is None and tensordict.get(self.chunk_key, default=None) is None:
+            return tensordict
+        return super()._inv_call(tensordict)
+
+    def transform_input_spec(self, input_spec: Composite) -> Composite:
+        # Expose the chunked action to the policy: replace the base env's
+        # per-step action spec with a [chunk_size, action_dim] version. The
+        # per-step spec is removed rather than moved to the state spec: the
+        # per-step action is written on the inverse path's working copy and
+        # consumed by the base env, so it never surfaces in the outer
+        # tensordict (which keeps single and batched envs consistent).
+        action_key = unravel_key(self.action_key)
+        chunk_key = unravel_key(self.chunk_key)
+        try:
+            leaf_spec = self.parent.full_action_spec_unbatched[action_key]
+        except KeyError:
+            raise RuntimeError(
+                f"{type(self).__name__} could not find key {action_key!r} in "
+                f"the parent environment's action spec. Available keys: "
+                f"{list(self.parent.full_action_spec.keys(True, True))}."
+            )
+        if not leaf_spec.shape:
+            raise RuntimeError(
+                f"{type(self).__name__} requires an action spec with a "
+                f"trailing action dimension; got shape {tuple(leaf_spec.shape)}."
+            )
+        chunk_spec = leaf_spec.unsqueeze(-2).expand(
+            *leaf_spec.shape[:-1], self.chunk_size, leaf_spec.shape[-1]
+        )
+        batch_size = self.parent.batch_size
+        if batch_size:
+            chunk_spec = chunk_spec.expand(batch_size + chunk_spec.shape)
+        input_spec["full_action_spec", chunk_key] = chunk_spec
+        if chunk_key != action_key:
+            del input_spec["full_action_spec", action_key]
+        return input_spec

--- a/torchrl/envs/transforms/_action.py
+++ b/torchrl/envs/transforms/_action.py
@@ -1496,21 +1496,21 @@ class ActionChunkTransform(Transform):
         of a chunk are *predictions* -- overlapping, stride-1 training targets
         (each dataset step ``t`` gets its own window ``a[t..t+H-1]``, so a
         given action appears in up to ``H`` different chunks) -- not a macro
-        action to be replayed verbatim. This transform never re-times the
-        environment: one outer step is always one base step, and on the
-        inverse path only the *first* action of a chunk is executed (the rest
-        are re-predicted at the next step). How many of the ``H`` predicted
-        actions actually get executed per policy call is a separate,
-        execution-time choice:
+        action to be replayed verbatim. This transform is a pure *data*
+        transform (it builds training targets) and never touches the
+        environment; how many of the ``H`` predicted actions actually get
+        executed per policy call is a separate, execution-time choice:
 
         - :class:`~torchrl.envs.transforms.MultiAction` executes every action
-          in the tensor by stepping the base env once per action (one outer
-          step = ``H`` base steps, rewards stacked or aggregated);
+          in the tensor by stepping the base env once per action with a
+          single policy call per chunk (one outer step = ``H`` base steps,
+          rewards stacked or aggregated);
         - :class:`~torchrl.modules.tensordict_module.MultiStepActorWrapper`
-          keeps the env timing unchanged and caches the actions on the policy
-          side, emitting one per step (open-loop);
-        - this transform's inverse path re-plans at every step (closed-loop:
-          only ``a[t]`` is executed).
+          keeps the env timing unchanged: it caches the predicted actions and
+          emits one per step, skipping the actor call while the cache lasts
+          -- open-loop by default, receding horizon with
+          ``replan_interval < n_steps``, closed loop with
+          ``replan_interval=1``.
 
     The forward (data) path operates on **time-structured** data: the action
     tensor must be shaped ``[*B, T, action_dim]`` and each row along
@@ -1519,13 +1519,6 @@ class ActionChunkTransform(Transform):
     chunked behavior-cloning loss masks the padded steps out using
     ``action_is_pad``.
 
-    The transform can also be attached to a :class:`~torchrl.envs.TransformedEnv`:
-    the policy-facing action spec is rewritten to the chunked shape
-    ``[H, action_dim]`` and, on the inverse (action-input) path, the first
-    action of the predicted ``action_chunk`` is forwarded to the base
-    environment. This re-plans at every step (closed-loop chunked control),
-    which calls the policy once per env step.
-
     .. note::
         A :class:`~torchrl.data.SliceSampler` returns a *flat* ``[B * T, ...]``
         batch -- reshape it to ``[num_slices, slice_len, ...]`` before applying
@@ -1533,10 +1526,9 @@ class ActionChunkTransform(Transform):
         Datasets that store one trajectory window per item (e.g.
         :class:`~torchrl.data.datasets.OpenXExperienceReplay`) already yield
         time-structured ``[batch, T, ...]`` samples and can use this transform
-        directly. When this transform is appended to a replay buffer,
-        ``extend`` leaves raw (chunk-less) data untouched: the inverse pass is
-        a no-op when the chunk entry is absent. Attached to an environment, a
-        missing chunk on the step path raises instead.
+        directly. When this transform is appended to a replay buffer, the
+        chunks are built on the ``sample`` path only; ``extend`` leaves the
+        stored (raw, per-step) data untouched.
 
     Args:
         chunk_size (int): the horizon ``H`` of the action chunk.
@@ -1586,16 +1578,6 @@ class ActionChunkTransform(Transform):
         >>> indices = rb.extend(windows)
         >>> rb.sample()["action_chunk"].shape  # [batch, T, chunk_size, action_dim]
         torch.Size([2, 4, 3, 1])
-        >>> # on an environment: the policy-facing action spec becomes the chunk
-        >>> # and the base env executes the first action of each predicted chunk
-        >>> from torchrl.envs import GymEnv, TransformedEnv
-        >>> env = TransformedEnv(
-        ...     GymEnv("Pendulum-v1"), ActionChunkTransform(chunk_size=3)
-        ... )
-        >>> env.full_action_spec["action_chunk"].shape  # [chunk_size, action_dim]
-        torch.Size([3, 1])
-        >>> env.rollout(2)["action_chunk"].shape
-        torch.Size([2, 3, 1])
     """
 
     def __init__(
@@ -1612,25 +1594,21 @@ class ActionChunkTransform(Transform):
         self.chunk_size = int(chunk_size)
         self.time_dim = int(time_dim)
         # ``forward`` is fully overridden (it writes the chunk and the pad mask
-        # from the action), so no forward keys are declared: the chunk and pad
-        # entries only exist on the data path, never in the env's output specs.
-        # The inverse direction reads ``out_keys_inv`` (the chunk) and writes
-        # ``in_keys_inv`` (the action passed to the base env).
-        super().__init__(
-            in_keys=[],
-            out_keys=[],
-            in_keys_inv=[action_key],
-            out_keys_inv=[chunk_key],
-        )
+        # from the action), so no transform keys are declared: this is a pure
+        # data-path transform and the chunk/pad entries never appear in env
+        # specs.
+        super().__init__(in_keys=[], out_keys=[])
+        self._action_key = action_key
+        self._chunk_key = chunk_key
         self._pad_key = pad_key
 
     @property
     def action_key(self) -> NestedKey:
-        return self.in_keys_inv[0]
+        return self._action_key
 
     @property
     def chunk_key(self) -> NestedKey:
-        return self.out_keys_inv[0]
+        return self._chunk_key
 
     @property
     def pad_key(self) -> NestedKey:
@@ -1671,55 +1649,3 @@ class ActionChunkTransform(Transform):
         tensordict.set(self.chunk_key, chunk)
         tensordict.set(self.pad_key, is_pad)
         return tensordict
-
-    def _inv_apply_transform(self, chunk: torch.Tensor) -> torch.Tensor:
-        if chunk.dim() < 2:
-            raise ValueError(
-                f"{type(self).__name__} expects an action chunk shaped "
-                f"[..., chunk_size, action_dim]; got shape {tuple(chunk.shape)}."
-            )
-        return chunk[..., 0, :]
-
-    def _inv_call(self, tensordict: TensorDictBase) -> TensorDictBase:
-        # Without a parent env (replay-buffer ``extend``), raw chunk-less data
-        # passes through untouched. Attached to an env, a missing chunk on the
-        # step path is an error (the rewritten action spec advertises it; a
-        # policy writing the raw action key by mistake should not silently
-        # bypass the transform), while the reset preprocess runs with missing
-        # tolerance and skips.
-        if self.parent is None and tensordict.get(self.chunk_key, default=None) is None:
-            return tensordict
-        return super()._inv_call(tensordict)
-
-    def transform_input_spec(self, input_spec: Composite) -> Composite:
-        # Expose the chunked action to the policy: replace the base env's
-        # per-step action spec with a [chunk_size, action_dim] version. The
-        # per-step spec is removed rather than moved to the state spec: the
-        # per-step action is written on the inverse path's working copy and
-        # consumed by the base env, so it never surfaces in the outer
-        # tensordict (which keeps single and batched envs consistent).
-        action_key = unravel_key(self.action_key)
-        chunk_key = unravel_key(self.chunk_key)
-        try:
-            leaf_spec = self.parent.full_action_spec_unbatched[action_key]
-        except KeyError:
-            raise RuntimeError(
-                f"{type(self).__name__} could not find key {action_key!r} in "
-                f"the parent environment's action spec. Available keys: "
-                f"{list(self.parent.full_action_spec.keys(True, True))}."
-            )
-        if not leaf_spec.shape:
-            raise RuntimeError(
-                f"{type(self).__name__} requires an action spec with a "
-                f"trailing action dimension; got shape {tuple(leaf_spec.shape)}."
-            )
-        chunk_spec = leaf_spec.unsqueeze(-2).expand(
-            *leaf_spec.shape[:-1], self.chunk_size, leaf_spec.shape[-1]
-        )
-        batch_size = self.parent.batch_size
-        if batch_size:
-            chunk_spec = chunk_spec.expand(batch_size + chunk_spec.shape)
-        input_spec["full_action_spec", chunk_key] = chunk_spec
-        if chunk_key != action_key:
-            del input_spec["full_action_spec", action_key]
-        return input_spec

--- a/torchrl/envs/transforms/_action.py
+++ b/torchrl/envs/transforms/_action.py
@@ -39,9 +39,12 @@ if TYPE_CHECKING:
 else:
     Self = Any
 
+from torchrl.data.vla.schema import ACTION_CHUNK_KEY, ACTION_IS_PAD_KEY, ACTION_KEY
+from torchrl.envs.common import EnvBase
 from torchrl.envs.transforms._base import FORWARD_NOT_IMPLEMENTED, Transform
 
 __all__ = [
+    "ActionChunkTransform",
     "ActionDiscretizer",
     "ActionMask",
     "ActionScaling",
@@ -1468,3 +1471,149 @@ class FlattenAction(Transform):
             f"first_dim={int(self.first_dim)}, last_dim={int(self.last_dim)}, "
             f"in_keys_inv={self.in_keys_inv}, out_keys_inv={self.out_keys_inv})"
         )
+
+
+class ActionChunkTransform(Transform):
+    """Build fixed-length action chunks from a trajectory window.
+
+    Action *chunking* is the defining trait of modern VLA policies (ACT,
+    OpenVLA-OFT, pi0, SmolVLA): instead of predicting a single action, the
+    policy predicts a short horizon ``H`` of future actions. This transform
+    turns a per-step action tensor ``[*B, T, action_dim]`` into the
+    corresponding training target ``action_chunk`` of shape
+    ``[*B, T, H, action_dim]`` -- for each time step ``t`` it gathers the
+    actions ``a[t], a[t+1], ..., a[t+H-1]`` -- together with a boolean
+    ``action_is_pad`` mask ``[*B, T, H]`` marking the steps that ran past the
+    end of the window (and were filled by repeating the last available action).
+
+    It is a replay-buffer / offline transform that operates on **time-structured**
+    data: the action tensor must be shaped ``[*B, T, action_dim]`` and each row
+    along ``time_dim`` must be a single contiguous trajectory window. Chunks are
+    built independently per row and never cross a row boundary; the downstream
+    chunked behavior-cloning loss masks the padded steps out using
+    ``action_is_pad``.
+
+    .. note::
+        A :class:`~torchrl.data.SliceSampler` returns a *flat* ``[B * T, ...]``
+        batch -- reshape it to ``[num_slices, slice_len, ...]`` before applying
+        this transform, otherwise chunks would span across trajectory boundaries.
+        Datasets that store one trajectory window per item (e.g.
+        :class:`~torchrl.data.datasets.OpenXExperienceReplay`) already yield
+        time-structured ``[batch, T, ...]`` samples and can use this transform
+        directly. This transform cannot be used as a
+        :class:`~torchrl.envs.TransformedEnv` transform.
+
+    Args:
+        chunk_size (int): the horizon ``H`` of the action chunk.
+
+    Keyword Args:
+        action_key (NestedKey): the per-step action to read.
+            Defaults to ``"action"``.
+        chunk_key (NestedKey): where to write the action chunk.
+            Defaults to ``"action_chunk"``.
+        pad_key (NestedKey): where to write the padding mask.
+            Defaults to ``"action_is_pad"``.
+        time_dim (int): the time dimension of the action tensor (the action
+            dimension must come right after it). Defaults to ``-2``.
+
+    Examples:
+        >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from torchrl.envs.transforms import ActionChunkTransform
+        >>> t = ActionChunkTransform(chunk_size=3)
+        >>> td = TensorDict(
+        ...     {"action": torch.arange(4).view(1, 4, 1).float()}, batch_size=[1, 4]
+        ... )
+        >>> td = t(td)
+        >>> td["action_chunk"].shape
+        torch.Size([1, 4, 3, 1])
+        >>> td["action_chunk"][0, :, :, 0]
+        tensor([[0., 1., 2.],
+                [1., 2., 3.],
+                [2., 3., 3.],
+                [3., 3., 3.]])
+        >>> td["action_is_pad"][0]
+        tensor([[False, False, False],
+                [False, False, False],
+                [False, False,  True],
+                [False,  True,  True]])
+    """
+
+    ENV_ERR = (
+        "ActionChunkTransform is a replay-buffer / offline transform and cannot "
+        "be used as an environment transform."
+    )
+
+    def __init__(
+        self,
+        chunk_size: int,
+        *,
+        action_key: NestedKey = ACTION_KEY,
+        chunk_key: NestedKey = ACTION_CHUNK_KEY,
+        pad_key: NestedKey = ACTION_IS_PAD_KEY,
+        time_dim: int = -2,
+    ) -> None:
+        if chunk_size < 1:
+            raise ValueError(f"chunk_size must be >= 1, got {chunk_size}.")
+        self.chunk_size = int(chunk_size)
+        self.time_dim = int(time_dim)
+        super().__init__(in_keys=[action_key], out_keys=[chunk_key, pad_key])
+
+    @property
+    def action_key(self) -> NestedKey:
+        return self.in_keys[0]
+
+    @property
+    def chunk_key(self) -> NestedKey:
+        return self.out_keys[0]
+
+    @property
+    def pad_key(self) -> NestedKey:
+        return self.out_keys[1]
+
+    def _build_chunk(self, action: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        H = self.chunk_size
+        dim = self.time_dim if self.time_dim >= 0 else action.dim() + self.time_dim
+        if dim != action.dim() - 2:
+            raise ValueError(
+                f"{type(self).__name__} expects the action dimension to immediately "
+                f"follow the time dimension (action shaped [..., T, action_dim]); got "
+                f"action.shape={tuple(action.shape)} with time_dim={self.time_dim}."
+            )
+        T = action.shape[dim]
+        device = action.device
+        # idx[t, h] = t + h, clamped to the last valid step; is_pad marks h that
+        # ran past the end of the window.
+        idx = torch.arange(T, device=device).unsqueeze(-1) + torch.arange(
+            H, device=device
+        ).unsqueeze(0)
+        is_pad = idx >= T
+        idx = idx.clamp_max(T - 1).reshape(-1)
+        chunk = action.index_select(dim, idx).unflatten(dim, (T, H))
+        is_pad = is_pad.expand(chunk.shape[:-1]).contiguous()
+        return chunk, is_pad
+
+    def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
+        action = tensordict.get(self.action_key, default=None)
+        if action is None:
+            if self.missing_tolerance:
+                return tensordict
+            raise KeyError(
+                f"{type(self).__name__}: '{self.action_key}' not found in tensordict "
+                f"{tensordict}."
+            )
+        chunk, is_pad = self._build_chunk(action)
+        tensordict.set(self.chunk_key, chunk)
+        tensordict.set(self.pad_key, is_pad)
+        return tensordict
+
+    def _call(self, next_tensordict: TensorDictBase) -> TensorDictBase:
+        raise ValueError(self.ENV_ERR)
+
+    def set_container(self, container) -> None:
+        if (
+            isinstance(container, EnvBase)
+            or getattr(container, "parent", None) is not None
+        ):
+            raise ValueError(self.ENV_ERR)
+        super().set_container(container)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -12,6 +12,7 @@ The implementations have been split into per-category modules
 from __future__ import annotations
 
 from torchrl.envs.transforms._action import (
+    ActionChunkTransform,
     ActionDiscretizer,
     ActionMask,
     ActionScaling,
@@ -109,6 +110,7 @@ from torchrl.envs.transforms._timer import Timer
 from torchrl.envs.transforms._video import DecodeVideoTransform
 
 __all__ = [
+    "ActionChunkTransform",
     "ActionDiscretizer",
     "ActionMask",
     "ActionScaling",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3838
* #3837
* #3836
* #3835
* #3834
* #3833
* #3832
* #3831
* #3830
* __->__ #3829
* #3828

Add ActionChunkTransform, a replay-buffer / offline transform that turns a
per-step action tensor [*B, T, action_dim] into the chunked training target
action_chunk [*B, T, H, action_dim] plus a boolean action_is_pad mask: for each
step t it gathers a[t..t+H-1], repeating the last action past the window end
(those steps flagged as pad). Action chunking is the defining trait of modern
VLA policies (ACT, OpenVLA-OFT, pi0, SmolVLA).

Operates on time-structured data (each row along time_dim is one contiguous
trajectory window); chunks never cross a row boundary. Guards against misuse as
an environment transform. The chunking math (arange + clamp + index_select +
unflatten) is torch.compile-clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>