### PR TITLE
[BugFix] MultiSyncCollector: stop gathering once all worker outputs arrive (#3840)

### DIFF
--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -2242,17 +2242,24 @@ if __name__ == "__main__":
             env_id: int,
             max_steps: int = 10,
             sleep_odd_only: bool = False,
+            step_sleep: float = 0.0,
             **kwargs,
         ):
             """
             Args:
                 env_id: The ID to return as observation. This will be returned as a tensor.
                 max_steps: Maximum number of steps before the environment terminates.
+                sleep_odd_only: If ``True``, only odd ``env_id`` workers sleep (used
+                    to test preemption).
+                step_sleep: If ``> 0``, every worker sleeps this many seconds on each
+                    step regardless of ``env_id`` (used to make a rollout slower than
+                    ``_TIMEOUT``).
             """
             super().__init__(device="cpu", batch_size=torch.Size([]))
             self.env_id = env_id
             self.max_steps = max_steps
             self.sleep_odd_only = sleep_odd_only
+            self.step_sleep = step_sleep
             self._step_count = 0
 
             # Define specs
@@ -2301,6 +2308,8 @@ if __name__ == "__main__":
 
             if self.sleep_odd_only and self.env_id % 2 == 1:
                 time.sleep(0.1)
+            if self.step_sleep:
+                time.sleep(self.step_sleep)
 
             return TensorDict(
                 {
@@ -2407,6 +2416,60 @@ if __name__ == "__main__":
                     ), f"Environment {env_idx} should produce observation {expected_id}, but got {actual_ids[0].item()}"
         finally:
             collector.shutdown()
+
+    def test_multi_sync_no_idle_after_all_outputs(self, monkeypatch):
+        """Regression test for https://github.com/pytorch/rl/issues/3840.
+
+        Without preemption, the worker-output gathering loop used to run a
+        fixed-length inner ``for _ in range(self.num_workers)`` that kept calling
+        ``queue_out.get(timeout=_TIMEOUT)`` even after every worker had already
+        reported. When an earlier ``get`` timed out (i.e. the first rollout takes
+        longer than ``_TIMEOUT``), ``len(recv)`` reached ``num_workers`` partway
+        through a later inner loop, leaving its remaining iterations to each waste
+        a full ``_TIMEOUT`` -- a total idle penalty of ``num_workers * _TIMEOUT``.
+
+        We shrink ``_TIMEOUT`` and make each worker's single step sleep longer than
+        it (so the first ``get`` is guaranteed to time out, which is the trigger),
+        then assert the batch is gathered well within ``num_workers * _TIMEOUT``.
+        """
+        timeout = 0.3
+        # The gather loop in the main process reads ``_TIMEOUT`` as a module global.
+        monkeypatch.setattr("torchrl.collectors._multi_sync._TIMEOUT", timeout)
+
+        num_workers = 8
+        # Each worker collects a single frame whose step sleeps > timeout, so the
+        # first ``queue_out.get(timeout=timeout)`` necessarily times out before any
+        # worker reports -- the precondition that used to shift the inner loop.
+        step_sleep = timeout * 1.5
+        env_factories = [
+            functools.partial(
+                self.FixedIDEnv, env_id=i, max_steps=10, step_sleep=step_sleep
+            )
+            for i in range(num_workers)
+        ]
+        collector = MultiSyncCollector(
+            create_env_fn=env_factories,
+            frames_per_batch=num_workers,
+            total_frames=num_workers,
+            device="cpu",
+            init_random_frames=num_workers,  # random actions, no policy needed
+            use_buffers=True,
+        )
+        try:
+            t0 = time.time()
+            next(iter(collector))
+            elapsed = time.time() - t0
+        finally:
+            collector.shutdown()
+
+        # Buggy path: ~num_workers * timeout (1 initial + num_workers - 1 trailing
+        # timeouts). Fixed path: ~step_sleep plus a little worker overhead. Half of
+        # the buggy budget is a comfortable separator that tolerates scheduling jitter.
+        max_elapsed = num_workers * timeout / 2
+        assert elapsed < max_elapsed, (
+            f"gathering took {elapsed:.3f}s, expected well under {max_elapsed:.3f}s; "
+            f"redundant get(timeout=_TIMEOUT) calls likely regressed (issue #3840)"
+        )
 
     def test_collector_next_method(self):
         """Non-regression test: next() should work correctly after __iter__.

--- a/torchrl/collectors/_multi_sync.py
+++ b/torchrl/collectors/_multi_sync.py
@@ -252,15 +252,19 @@ class MultiSyncCollector(MultiCollector):
 
             recv = collections.deque()
             t0 = time.time()
+            # We pull one worker output at a time and re-check ``len(recv)`` on
+            # every iteration. A fixed-length inner loop would keep calling
+            # ``queue_out.get(timeout=_TIMEOUT)`` even after every worker has
+            # already reported, wasting up to ``(num_workers - 1) * _TIMEOUT``
+            # seconds on doomed gets whenever an earlier get timed out (see #3840).
             while len(recv) < self.num_workers and (
                 (time.time() - t0) < (_TIMEOUT * _MAX_IDLE_COUNT)
             ):
-                for _ in range(self.num_workers):
-                    try:
-                        new_data, j = self.queue_out.get(timeout=_TIMEOUT)
-                        recv.append((new_data, j))
-                    except (TimeoutError, Empty):
-                        _check_for_faulty_process(self.procs)
+                try:
+                    new_data, j = self.queue_out.get(timeout=_TIMEOUT)
+                    recv.append((new_data, j))
+                except (TimeoutError, Empty):
+                    _check_for_faulty_process(self.procs)
             if (time.time() - t0) > (_TIMEOUT * _MAX_IDLE_COUNT):
                 try:
                     self.shutdown()


### PR DESCRIPTION
## Description

Fixes #3840.

`MultiSyncCollector.iterator` gathers worker outputs with a blocking
`queue_out.get(timeout=_TIMEOUT)`. That `get` was wrapped in a fixed-length
`for _ in range(self.num_workers)` inner loop *inside* the outer `while`:

```python
while len(recv) < self.num_workers and ((time.time() - t0) < (_TIMEOUT * _MAX_IDLE_COUNT)):
    for _ in range(self.num_workers):
        try:
            new_data, j = self.queue_out.get(timeout=_TIMEOUT)
            recv.append((new_data, j))
        except (TimeoutError, Empty):
            _check_for_faulty_process(self.procs)
```

The outer `while` already re-checks `len(recv) < self.num_workers` after every
append, so the inner `for` could only ever over-run. Whenever an earlier `get`
timed out (e.g. the very first rollout takes slightly longer than `_TIMEOUT`),
`recv` reached `num_workers` partway through a *later* inner loop, and each of
its remaining iterations then blocked for a full `_TIMEOUT` on a queue that was
already empty.

With the default `preemptive_threshold=1.0` (no preemption) this adds up to
`(num_workers - 1) * _TIMEOUT` of pure idle time per batch — the ~16 s vs ~1 s
gap reported in #3840 for 16 workers.

## Fix

Drop the inner `for` loop and let the outer `while` drive the gathering one
output at a time. The loop now exits the instant `recv` reaches `num_workers`,
and the `_MAX_IDLE_COUNT` time-budget guard is evaluated before every `get`
(slightly more precise) instead of once per `num_workers` gets. No change to
the timeout budget or the faulty-process check.

## Verification

Scaled-down reproduction (shrinking `_TIMEOUT` to 0.3 s, 8 workers, each first
rollout sleeping 0.45 s):

| version | `next()` time | `queue_out.get` calls |
| --- | --- | --- |
| before | 2.58 s | 16 (1 initial + 7 trailing timeouts) |
| after | 0.47 s | 9 (1 initial + 8 data) |

The trailing timeouts are gone and the loop exits as soon as all outputs are in.

## Test

Adds `TestCollectorGeneric::test_multi_sync_no_idle_after_all_outputs`, which
shrinks `_TIMEOUT`, makes each worker's first rollout slower than it (the
trigger), and asserts the batch is gathered well within `num_workers * _TIMEOUT`.
Verified the test fails on the old code (2.58 s > 1.2 s) and passes on the fix.
The existing `test_multi_sync_data_collector_ordering` still passes.