### PR TITLE
[CI] Benchmarks: add PyPI extra-index-url so torch-nightly sdist build deps resolve

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -88,7 +88,13 @@ jobs:
           # drifted out of sync there, making install ResolutionImpossible). Use the
           # live cu126 nightly channel; its CUDA 12.6 wheels run fine on the GPU
           # runner via driver backward-compatibility.
-          python3.10 -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126 -U
+          # The --extra-index-url onto PyPI is required: torch nightly pulls in
+          # transitive deps (e.g. spmd-types) that are only shipped as sdists on the
+          # torch channel, and building those sdists needs setuptools/wheel which the
+          # torch index does not host. torch/torchvision still resolve from nightly
+          # (their dev versions outrank any PyPI stable), and assert_torch_version.sh
+          # below fails the job loudly if that ever stops holding.
+          python3.10 -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126 --extra-index-url https://pypi.org/simple -U
           python3.10 -m pip install ninja pytest pytest-benchmark pytest-timeout "hoptorch>=0.1.4" "mujoco>=3.8.1,<3.9.0" "dm_control>=1.0.41" "gym[accept-rom-license,atari]" transformers accelerate
           python -m pip install "pybind11[global]"
           python3.10 -m pip install cloudpickle packaging importlib_metadata numpy orjson "pyvers>=0.2.0,<0.3.0"

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -101,7 +101,13 @@ jobs:
           # drifted out of sync there, making install ResolutionImpossible). Use the
           # live cu126 nightly channel; its CUDA 12.6 wheels run fine on the GPU
           # runner via driver backward-compatibility.
-          python3.10 -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126 -U
+          # The --extra-index-url onto PyPI is required: torch nightly pulls in
+          # transitive deps (e.g. spmd-types) that are only shipped as sdists on the
+          # torch channel, and building those sdists needs setuptools/wheel which the
+          # torch index does not host. torch/torchvision still resolve from nightly
+          # (their dev versions outrank any PyPI stable), and assert_torch_version.sh
+          # below fails the job loudly if that ever stops holding.
+          python3.10 -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126 --extra-index-url https://pypi.org/simple -U
           python3.10 -m pip install ninja pytest pytest-benchmark pytest-timeout "hoptorch>=0.1.4" "mujoco>=3.8.1,<3.9.0" "dm_control>=1.0.41" "gym[accept-rom-license,atari]" transformers accelerate ray
           python3.10 -m pip install "pybind11[global]"
           python3.10 -m pip install cloudpickle packaging importlib_metadata numpy orjson "pyvers>=0.2.0,<0.3.0"


### PR DESCRIPTION
## Problem

The `CPU Pytest benchmark` and `GPU Pytest benchmark` jobs (workflows `benchmarks_pr.yml` and `benchmarks.yml`) started failing at the **Install benchmark dependencies** step:

```
ERROR: Could not find a version that satisfies the requirement wheel (from versions: none)
ERROR: No matching distribution found for wheel
```

Root cause: torch nightly now pulls in a transitive dependency, `spmd-types==0.2.0`. pip discards its wheel because the wheel's `METADATA` `Name:` is non-canonical (`spmd_types` vs the requested `spmd-types`), so it falls back to building the sdist. Building the sdist needs `setuptools`/`wheel`, but the install was restricted to:

```
--index-url https://download.pytorch.org/whl/nightly/cu126
```

`--index-url` *replaces* PyPI, and the torch nightly channel does not host `wheel`, so the build-backend requirements can't be resolved and the job dies.

## Fix

Add `--extra-index-url https://pypi.org/simple` to the torch/torchvision install line in both benchmark workflows. This lets build dependencies (and any other non-torch transitive deps) resolve from PyPI.

`torch`/`torchvision` still resolve from the nightly channel, since their `.dev` versions outrank any PyPI stable release, and the existing `assert_torch_version.sh nightly` guard immediately after fails the job loudly if that ever stops holding.

## Failing runs

- https://github.com/pytorch/rl/actions/runs/27260474708/job/80504691293
- https://github.com/pytorch/rl/actions/runs/27260474708/job/80504691246

Generated with Claude Code.