### PR TITLE
[Performance] Rework MultiSyncCollector preemption: shared-memory interruptor, no busy-wait, macOS support

### DIFF
--- a/benchmarks/test_collectors_benchmark.py
+++ b/benchmarks/test_collectors_benchmark.py
@@ -55,6 +55,31 @@ def sync_collector_setup():
     return ((c,), {})
 
 
+def sync_collector_setup_preempt():
+    """Sync collector with preemption: exercises the per-step interruptor polling
+    in the workers and the masking path in the main process."""
+    device = "cuda:0" if torch.cuda.device_count() else "cpu"
+    env = EnvCreator(
+        lambda: TransformedEnv(
+            DMControlEnv("cheetah", "run", device=device), StepCounter(50)
+        )
+    )
+    c = MultiSyncCollector(
+        [env, env],
+        RandomPolicy(env().action_spec),
+        total_frames=-1,
+        frames_per_batch=100,
+        device=device,
+        preemptive_threshold=0.9,
+        cat_results="stack",
+    )
+    c = iter(c)
+    for i, _ in enumerate(c):
+        if i == 10:
+            break
+    return ((c,), {})
+
+
 def async_collector_setup():
     device = "cuda:0" if torch.cuda.device_count() else "cpu"
     env = EnvCreator(
@@ -217,6 +242,11 @@ def test_single(benchmark):
 
 def test_sync(benchmark):
     (c,), _ = sync_collector_setup()
+    benchmark(execute_collector, c)
+
+
+def test_sync_preempt(benchmark):
+    (c,), _ = sync_collector_setup_preempt()
     benchmark(execute_collector, c)
 
 

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -2342,11 +2342,6 @@ if __name__ == "__main__":
         We create num_envs environments, each returning its env_id as the observation.
         After collection, we verify that the observations correspond to the correct env_ids in order
         """
-        if with_preempt and IS_OSX:
-            pytest.skip(
-                "Cannot use preemption on OSX due to Queue.qsize() not being implemented on this platform."
-            )
-
         # Create environment factories using partial - one for each env_id
         # This pattern mirrors CrossPlayEvaluator._rollout usage
         env_factories = [
@@ -3509,8 +3504,62 @@ def weight_reset(m):
         m.reset_parameters()
 
 
-@pytest.mark.skipif(IS_OSX, reason="Queue.qsize does not work on osx.")
+def _stop_interruptor(interruptor):
+    interruptor.stop_collection()
+
+
 class TestPreemptiveThreshold:
+    def test_interruptor_shared_memory(self):
+        """_Interruptor is a shared-memory flag: no manager process, no proxies.
+
+        The flag must hold its start/stop semantics in-process and be visible
+        from a child process when inherited at process-creation time.
+        """
+        interruptor = _Interruptor()
+        assert not interruptor.collection_stopped()
+        interruptor.stop_collection()
+        assert interruptor.collection_stopped()
+        interruptor.start_collection()
+        assert not interruptor.collection_stopped()
+
+        ctx = torch.multiprocessing.get_context("spawn")
+        proc = ctx.Process(target=_stop_interruptor, args=(interruptor,))
+        proc.start()
+        proc.join(timeout=100)
+        assert proc.exitcode == 0
+        assert interruptor.collection_stopped()
+
+    def test_preemptive_threshold_validation(self):
+        """Out-of-range thresholds raise; 1.0 disables the interruptor machinery."""
+        env_fn = make_make_env("vec")
+        for bad_threshold in (-0.1, 1.5):
+            with pytest.raises(ValueError, match="preemptive_threshold"):
+                MultiSyncCollector(
+                    create_env_fn=[env_fn] * 2,
+                    policy=make_policy("vec"),
+                    frames_per_batch=20,
+                    total_frames=20,
+                    preemptive_threshold=bad_threshold,
+                )
+
+        collector = MultiSyncCollector(
+            create_env_fn=[env_fn] * 2,
+            policy=make_policy("vec"),
+            frames_per_batch=20,
+            total_frames=20,
+            preemptive_threshold=1.0,
+            cat_results="stack",
+        )
+        try:
+            # Preemption can never fire at 1.0: no interruptor should be built
+            # and every collected frame should be valid.
+            assert collector.interruptor is None
+            assert collector.preemptive_threshold == 1.0
+            for batch in collector:
+                assert (batch["collector", "traj_ids"] != -1).all()
+        finally:
+            collector.shutdown()
+
     @pytest.mark.parametrize("env_name", ["conv", "vec"])
     def test_sync_collector_interruptor_mechanism(self, env_name, seed=100):
         def env_fn(seed):

--- a/torchrl/collectors/_constants.py
+++ b/torchrl/collectors/_constants.py
@@ -51,30 +51,32 @@ _is_osx = sys.platform.startswith("darwin")
 
 
 class _Interruptor:
-    """A class for managing the collection state of a process.
+    """A shared-memory flag for interrupting rollout collection across processes.
 
-    This class provides methods to start and stop collection, and to check
-    whether collection has been stopped. The collection state is protected
-    by a lock to ensure thread-safety.
+    The main process raises the flag with ``start_collection`` and clears it
+    with ``stop_collection``; workers poll ``collection_stopped`` once per env
+    step and cut their rollout short when it returns ``True``.
+
+    The flag is a single shared-memory byte with exactly one writer (the main
+    process), so no lock is needed: one-byte reads cannot be torn and workers
+    only ever read. Like any ``multiprocessing.sharedctypes`` value, the object
+    must be handed to workers at process-creation time (it is inherited and
+    cannot be sent through queues or pipes afterwards).
     """
 
     # interrupter vs interruptor: google trends seems to indicate that "or" is more
     # widely used than "er" even if my IDE complains about that...
     def __init__(self):
-        self._collect = True
-        self._lock = mp.Lock()
+        self._collect = mp.Value("b", True, lock=False)
 
     def start_collection(self):
-        with self._lock:
-            self._collect = True
+        self._collect.value = True
 
     def stop_collection(self):
-        with self._lock:
-            self._collect = False
+        self._collect.value = False
 
     def collection_stopped(self):
-        with self._lock:
-            return self._collect is False
+        return not self._collect.value
 
 
 class _InterruptorManager(SyncManager):
@@ -82,6 +84,11 @@ class _InterruptorManager(SyncManager):
 
     This class extends the SyncManager class and allows to share an Interruptor object
     between processes.
+
+    .. note::
+        No longer used internally: :class:`_Interruptor` is now backed by shared
+        memory and inherited directly by worker processes. Kept for backward
+        compatibility.
     """
 
 

--- a/torchrl/collectors/_multi_base.py
+++ b/torchrl/collectors/_multi_base.py
@@ -27,8 +27,7 @@ from torchrl._utils import (
 )
 from torchrl.collectors._base import _ProfilerHook, BaseCollector, ProfileConfig
 from torchrl.collectors._constants import (
-    _InterruptorManager,
-    _is_osx,
+    _Interruptor,
     DEFAULT_EXPLORATION_TYPE,
     ExplorationType,
     INSTANTIATE_TIMEOUT,
@@ -221,7 +220,11 @@ class MultiCollector(BaseCollector, metaclass=_MultiCollectorMeta):
             will be called before (sync) or after (async) each data collection.
             Defaults to ``False``.
         preemptive_threshold (:obj:`float`, optional): a value between 0.0 and 1.0 that specifies the ratio of workers
-            that will be allowed to finished collecting their rollout before the rest are forced to end early.
+            that will be allowed to finish collecting their rollout before the rest are forced to end early.
+            Frames that were not collected by the preempted workers are marked invalid: their
+            ``("collector", "traj_ids")`` entry is ``-1`` and, with ``cat_results="stack"``, a
+            ``("collector", "mask")`` entry flags the valid frames (with ``cat_results=-1`` the
+            invalid frames are dropped from the batch instead).
         num_threads (int, optional): number of threads for this process.
             Defaults to the number of workers.
         num_sub_threads (int, optional): number of threads of the subprocesses.
@@ -899,14 +902,15 @@ class MultiCollector(BaseCollector, metaclass=_MultiCollectorMeta):
     def _setup_preemptive_threshold(self, preemptive_threshold: float | None) -> None:
         """Set up preemptive threshold for early stopping."""
         if preemptive_threshold is not None:
-            if _is_osx:
-                raise NotImplementedError(
-                    "Cannot use preemption on OSX due to Queue.qsize() not being implemented on this platform."
+            preemptive_threshold = float(preemptive_threshold)
+            if not 0.0 <= preemptive_threshold <= 1.0:
+                raise ValueError(
+                    f"preemptive_threshold must be between 0.0 and 1.0, got {preemptive_threshold}."
                 )
-            self.preemptive_threshold = np.clip(preemptive_threshold, 0.0, 1.0)
-            manager = _InterruptorManager()
-            manager.start()
-            self.interruptor = manager._Interruptor()
+            self.preemptive_threshold = preemptive_threshold
+            # A threshold of 1.0 waits for every worker, so preemption can never
+            # fire: skip the interruptor and its per-step polling in the workers.
+            self.interruptor = _Interruptor() if preemptive_threshold < 1.0 else None
         else:
             self.preemptive_threshold = 1.0
             self.interruptor = None

--- a/torchrl/collectors/_multi_sync.py
+++ b/torchrl/collectors/_multi_sync.py
@@ -230,6 +230,13 @@ class MultiSyncCollector(MultiCollector):
             if self.update_at_each_batch:
                 self.update_policy_weights_()
 
+            if preempt:
+                # Raise the flag before dispatching "continue": a fast worker
+                # could otherwise complete its first step while the flag still
+                # carries the previous batch's stop signal and preempt its whole
+                # rollout after a single step.
+                self.interruptor.start_collection()
+
             for idx in range(self.num_workers):
                 if self._should_use_random_frames():
                     msg = "continue_random"
@@ -239,17 +246,6 @@ class MultiSyncCollector(MultiCollector):
 
             self._iter += 1
 
-            if preempt:
-                self.interruptor.start_collection()
-                while self.queue_out.qsize() < int(
-                    self.num_workers * self.preemptive_threshold
-                ):
-                    continue
-                self.interruptor.stop_collection()
-                # Now wait for stragglers to return
-                while self.queue_out.qsize() < int(self.num_workers):
-                    continue
-
             recv = collections.deque()
             t0 = time.time()
             # We pull one worker output at a time and re-check ``len(recv)`` on
@@ -257,9 +253,25 @@ class MultiSyncCollector(MultiCollector):
             # ``queue_out.get(timeout=_TIMEOUT)`` even after every worker has
             # already reported, wasting up to ``(num_workers - 1) * _TIMEOUT``
             # seconds on doomed gets whenever an earlier get timed out (see #3840).
+            # With preemption, once the threshold count of workers has reported we
+            # clear the interruptor flag so the stragglers deliver whatever they
+            # have at the next step boundary, then keep gathering until everyone
+            # has reported. Going through ``queue_out.get`` rather than spinning
+            # on ``queue_out.qsize()`` keeps the faulty-process checks and the
+            # time budget active while waiting (a dead straggler used to hang
+            # this loop forever) and works on platforms where ``qsize`` is not
+            # implemented (e.g. macOS).
+            if preempt:
+                # int() truncates, so preempt_count < num_workers always holds and
+                # the flag is guaranteed to be cleared before the last get.
+                preempt_count = int(self.num_workers * self.preemptive_threshold)
+                stop_sent = False
             while len(recv) < self.num_workers and (
                 (time.time() - t0) < (_TIMEOUT * _MAX_IDLE_COUNT)
             ):
+                if preempt and not stop_sent and len(recv) >= preempt_count:
+                    self.interruptor.stop_collection()
+                    stop_sent = True
                 try:
                     new_data, j = self.queue_out.get(timeout=_TIMEOUT)
                     recv.append((new_data, j))
@@ -274,6 +286,7 @@ class MultiSyncCollector(MultiCollector):
                         f"Increase the MAX_IDLE_COUNT environment variable to bypass this error."
                     )
 
+            received_idxs = []
             for _ in range(self.num_workers):
                 new_data, j = recv.popleft()
                 use_buffers = self._use_buffers
@@ -297,41 +310,7 @@ class MultiSyncCollector(MultiCollector):
                             raise
                 else:
                     idx = new_data
-
-                if preempt:
-                    # mask buffers if cat, and create a mask if stack
-                    if cat_results != "stack":
-                        buffers = [None] * self.num_workers
-                        for worker_idx, buffer in enumerate(self.buffers):
-                            # Skip preempted envs:
-                            if buffer is None:
-                                continue
-                            valid = buffer.get(("collector", "traj_ids")) != -1
-                            if valid.ndim > 2:
-                                valid = valid.flatten(0, -2)
-                            if valid.ndim == 2:
-                                valid = valid.any(0)
-                            buffers[worker_idx] = buffer[..., valid]
-                    else:
-                        for buffer in filter(lambda x: x is not None, self.buffers):
-                            with buffer.unlock_():
-                                buffer.set(
-                                    ("collector", "mask"),
-                                    buffer.get(("collector", "traj_ids")) != -1,
-                                )
-                        buffers = self.buffers
-                else:
-                    buffers = self.buffers
-
-                # Skip frame counting if this worker didn't send data this iteration
-                # (happens when reusing buffers or on first iteration with some workers)
-                if self.buffers[idx] is None:
-                    continue
-
-                workers_frames[idx] = workers_frames[idx] + buffers[idx].numel()
-
-                if workers_frames[idx] >= self.total_frames:
-                    dones[idx] = True
+                received_idxs.append(idx)
 
             if self.replay_buffer is not None:
                 yield
@@ -340,6 +319,41 @@ class MultiSyncCollector(MultiCollector):
                     for worker_idx in range(self.num_workers)
                 )
                 continue
+
+            if preempt:
+                # mask buffers if cat, and create a mask if stack; done once now
+                # that every worker's buffer is final for this batch
+                if cat_results != "stack":
+                    buffers = [None] * self.num_workers
+                    for worker_idx, buffer in enumerate(self.buffers):
+                        # Skip preempted envs:
+                        if buffer is None:
+                            continue
+                        valid = buffer.get(("collector", "traj_ids")) != -1
+                        if valid.ndim > 2:
+                            valid = valid.flatten(0, -2)
+                        if valid.ndim == 2:
+                            valid = valid.any(0)
+                        buffers[worker_idx] = buffer[..., valid]
+                else:
+                    for buffer in filter(lambda x: x is not None, self.buffers):
+                        with buffer.unlock_():
+                            buffer.set(
+                                ("collector", "mask"),
+                                buffer.get(("collector", "traj_ids")) != -1,
+                            )
+                    buffers = self.buffers
+            else:
+                buffers = self.buffers
+
+            for idx in received_idxs:
+                # Skip frame counting if this worker didn't send data this iteration
+                # (happens when reusing buffers or on first iteration with some workers)
+                if self.buffers[idx] is None:
+                    continue
+                workers_frames[idx] = workers_frames[idx] + buffers[idx].numel()
+                if workers_frames[idx] >= self.total_frames:
+                    dones[idx] = True
 
             # we have to correct the traj_ids to make sure that they don't overlap
             # We can count the number of frames collected for free in this loop

--- a/torchrl/collectors/_single_async.py
+++ b/torchrl/collectors/_single_async.py
@@ -141,7 +141,7 @@ class AsyncCollector(MultiAsyncCollector):
             will be called before (sync) or after (async) each data collection.
             Defaults to ``False``.
         preemptive_threshold (:obj:`float`, optional): a value between 0.0 and 1.0 that specifies the ratio of workers
-            that will be allowed to finished collecting their rollout before the rest are forced to end early.
+            that will be allowed to finish collecting their rollout before the rest are forced to end early.
         num_threads (int, optional): number of threads for this process.
             Defaults to the number of workers.
         num_sub_threads (int, optional): number of threads of the subprocesses.


### PR DESCRIPTION
## Description

Reworks the `preemptive_threshold` implementation in `MultiSyncCollector` with **no API change**. Stacked on #3841 (the gather-loop fix for #3840); this PR's gather-loop restructure builds directly on that commit.

### 1. Shared-memory `_Interruptor` (no manager process, no per-step IPC)

`_Interruptor` was hosted in a dedicated `SyncManager` *process* spawned per collector, solely to hold a boolean and a lock. Every per-step `collection_stopped()` poll in every worker was an IPC round trip (socket + pickling) to that process.

The flag is now a single shared-memory byte (`mp.Value("b", ..., lock=False)`) inherited at process creation. There is exactly one writer (the main process) and workers only read, so one-byte reads cannot tear and no lock is needed. This removes one process per collector and turns the per-step poll into a shared-memory read. `_InterruptorManager` is kept (functional) for backward compatibility but no longer used internally.

### 2. Preemption driven through the gather loop (no `qsize` busy-wait)

The trigger logic was two pure spin loops on `queue_out.qsize()`:

```python
while self.queue_out.qsize() < int(self.num_workers * self.preemptive_threshold):
    continue
self.interruptor.stop_collection()
while self.queue_out.qsize() < int(self.num_workers):
    continue
```

These pegged a core at 100% during every preemptive batch, never called `_check_for_faulty_process` (a worker dying mid-batch hung the main process **forever**), ignored the `_MAX_IDLE_COUNT` budget, and relied on `Queue.qsize()` -- unimplemented on macOS, which is why preemption was hard-disabled there with a `NotImplementedError`.

Now the regular gather loop handles it: once `len(recv)` reaches `int(threshold * num_workers)` the interruptor flag is cleared (since `int()` truncates, this always happens strictly before the last worker is awaited), and gathering continues until everyone has reported. Faulty-process checks and the time budget stay active throughout, and **preemption now works on macOS** -- the OSX guard and test skips are removed.

### 3. Start-of-batch race fix

`"continue"` was dispatched to the workers *before* `start_collection()` raised the flag, which still carried the previous batch's stop signal. A fast worker completing its first step in that window observed the stale signal and preempted its entire rollout after one step, silently delivering a near-empty batch. The flag is now raised before dispatching.

### 4. Masking hoisted out of the drain loop

The preemption masking block ran once per received worker output, and each pass re-masked *all* workers' buffers -- O(n^2) mask computation (and n^2 idempotent `set` calls under `unlock_()` in the `"stack"` branch). It now runs once per batch, after all outputs are in. Frame counting moves to a small loop over the received indices; behavior is unchanged.

### 5. No machinery when it cannot fire + validation

`preemptive_threshold=1.0` used to build the manager process and wire proxies into every worker even though preemption can never fire at 1.0 (the case from #3840). The interruptor is now only created for `threshold < 1.0`. Out-of-range values raise a `ValueError` instead of being silently clamped by `np.clip`.

## Tests

- The `TestPreemptiveThreshold` suite and the preempt variants of `test_multi_sync_data_collector_ordering` now run on macOS (skips removed) -- verified locally on an OSX machine, where these tests could never run before.
- New `test_interruptor_shared_memory`: flag semantics plus visibility from a spawn-created child process (validates process-creation inheritance).
- New `test_preemptive_threshold_validation`: out-of-range thresholds raise; `threshold=1.0` builds no interruptor and produces fully valid batches.
- Existing end-to-end preemption tests (`test_sync_collector_interruptor_mechanism`, `test_multisync_collector_interruptor_mechanism`) pass unchanged, as do the #3840 regression test and the replay-buffer / cat_results multisync tests.

## Benchmarks

Adds `test_sync_preempt` to `benchmarks/test_collectors_benchmark.py`: the sync collector benchmark with `preemptive_threshold=0.9`, exercising the per-step interruptor polling and the masking path.