### PR TITLE
[BugFix] Restore torchrl-nightly PyPI uploads

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -68,6 +68,10 @@ jobs:
           export PATH="/opt/python/${{ matrix.python_version[1] }}/bin:$PATH"
           python -mpip install build wheel
           ./build_nightly.sh
+          find dist -name '*whl' -exec bash -c ' mv $0 ${0/linux/manylinux1}' {} \;
+      # PyPI rejects the plain linux_x86_64 platform tag. pytorch/pytorch
+      # binaries are manylinux_2_17 compliant but pretend to be manylinux1
+      # compliant, so we do the same.
       - name: Upload wheel for the test-wheel job
         uses: actions/upload-artifact@v4
         with:
@@ -156,7 +160,9 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') }}
     needs: test-wheel-unix
     runs-on: ${{ matrix.os[1] }}
-    continue-on-error: true
+    # No continue-on-error here: a failed PyPI upload must turn the run red.
+    # Silent upload failures kept the workflow green while torchrl-nightly
+    # went stale on PyPI for months.
     strategy:
       matrix:
         os: [['linux', 'ubuntu-22.04'], ['macos', 'macos-latest']]
@@ -314,7 +320,7 @@ jobs:
     # Don't run on forked repos.
     if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') }}
     needs: test-wheel-windows
-    continue-on-error: true
+    # No continue-on-error here: a failed PyPI upload must turn the run red.
     runs-on: windows-latest
     strategy:
       matrix:

--- a/build_nightly.sh
+++ b/build_nightly.sh
@@ -36,7 +36,12 @@ rm -f pyproject.toml.bak
 
 # Set nightly version (YYYY.MM.DD format)
 echo "Setting nightly version..."
-echo "$(date +%Y.%m.%d)" > version.txt
+NIGHTLY_VERSION="$(date +%Y.%m.%d)"
+echo "$NIGHTLY_VERSION" > version.txt
+# PyPI rejects PEP 440 local version identifiers (e.g. "+g<sha>"). Pin the
+# build version explicitly: setup.py uses TORCHRL_BUILD_VERSION verbatim and
+# skips the local "+g<sha>" suffix it would otherwise append.
+export TORCHRL_BUILD_VERSION="$NIGHTLY_VERSION"
 
 # Build the package
 echo "Building nightly package..."

--- a/packaging/verify_nightly_version.py
+++ b/packaging/verify_nightly_version.py
@@ -24,28 +24,31 @@ print(f"Checking version: {version}")
 
 date_pattern = r"^\d{4}\.\d{1,2}\.\d{1,2}$"
 if not isinstance(version, str) or not version:
-    print(
-        "WARNING: torchrl.__version__ is missing; skipping nightly version "
-        "format validation."
+    # A missing version must be fatal: when __version__ was None this check
+    # silently passed while PyPI rejected the wheels.
+    raise ValueError(
+        "torchrl.__version__ is missing or empty; nightly wheels must expose "
+        "a YYYY.M.D version string."
     )
-else:
-    # Check that version is not the major version (0.9.0)
-    if re.match(r"^\d+\.\d+\.\d+$", version):
-        raise ValueError(f"Version should not be the major version: {version}")
 
-    # Check that version matches date format (YYYY.M.D)
-    if not re.match(date_pattern, version):
-        raise ValueError(f"Version should match date format YYYY.M.D, got: {version}")
+# Check that version is not the major version (0.9.0)
+if re.match(r"^\d+\.\d+\.\d+$", version):
+    raise ValueError(f"Version should not be the major version: {version}")
 
-    # Verify it's today's date
-    today = date.today()
-    expected_version = f"{today.year}.{today.month}.{today.day}"
-    if version != expected_version:
-        raise ValueError(
-            f"Version should be today date {expected_version}, got: {version}"
-        )
+# Check that version matches date format (YYYY.M.D). This also rejects PEP 440
+# local version identifiers (e.g. 2026.6.9+g<sha>), which PyPI refuses.
+if not re.match(date_pattern, version):
+    raise ValueError(f"Version should match date format YYYY.M.D, got: {version}")
 
-    print(f"Version {version} is correctly formatted as nightly date")
+# Verify it's today's date
+today = date.today()
+expected_version = f"{today.year}.{today.month}.{today.day}"
+if version != expected_version:
+    raise ValueError(
+        f"Version should be today date {expected_version}, got: {version}"
+    )
+
+print(f"Version {version} is correctly formatted as nightly date")
 
 # Check that tensordict-nightly is installed (not stable tensordict)
 try:

--- a/torchrl/__init__.py
+++ b/torchrl/__init__.py
@@ -37,7 +37,11 @@ try:
     except ImportError:  # pragma: no cover
         from importlib_metadata import version as _dist_version  # type: ignore
 
-    __version__ = _dist_version("torchrl")
+    try:
+        __version__ = _dist_version("torchrl")
+    except Exception:
+        # Nightly builds ship under a different distribution name.
+        __version__ = _dist_version("torchrl-nightly")
 except Exception:
     try:
         from ._version import __version__


### PR DESCRIPTION
## What's broken

[torchrl-nightly on PyPI](https://pypi.org/project/torchrl-nightly/#history) has been stale since `2025.9.1`. The scheduled nightly workflow builds and tests wheels every day and shows green, but every PyPI upload job fails; `continue-on-error: true` masks it (see e.g. [this scheduled run](https://github.com/pytorch/rl/actions/runs/27219651435) - all 15 upload jobs red, run green).

Two upload blockers:

1. **Local version identifiers.** Nightly wheels are versioned e.g. `2026.6.9+ga1a1070`: `setup.py` appends `+g<sha>` to the date written by `build_nightly.sh`. PyPI rejects any PEP 440 local version with `400: The use of local versions in '2026.6.9+ga1a1070' is not allowed`.
2. **Platform tag.** #3799 dropped the `linux_x86_64` -> `manylinux1_x86_64` wheel rename, and PyPI rejects plain `linux_x86_64` wheels, so Linux uploads would keep failing even with the version fixed (the last published nightlies were `manylinux1_x86_64`).

Two masking bugs let this rot silently:

3. `continue-on-error: true` on the upload jobs keeps scheduled runs green when uploads fail.
4. `torchrl.__version__` is `None` in nightly wheels: the distribution is named `torchrl-nightly` but `torchrl/__init__.py` only queries `torchrl`, and no `_version.py` fallback is generated since setuptools_scm is not installed in the nightly build env. `packaging/verify_nightly_version.py` treats a missing version as a warning and passes, so the `+g<sha>` version sailed through the test job instead of failing it.

## Fixes

- `build_nightly.sh`: export `TORCHRL_BUILD_VERSION="$(date +%Y.%m.%d)"`. `setup.py` uses this override verbatim, so the wheel version is the plain (normalized) date with no local suffix. Dev builds from source keep the `+g<sha>` behavior.
- `.github/workflows/nightly_build.yml`: restore the manylinux1 rename (with the original rationale comment, matching what pytorch/pytorch binaries do) and drop `continue-on-error` from the two upload jobs so a failed upload turns the run red.
- `torchrl/__init__.py`: fall back to the `torchrl-nightly` distribution name so nightly wheels report a real `__version__`.
- `packaging/verify_nightly_version.py`: a missing/empty `__version__` is now a hard failure instead of a warning-skip.

## Validation

- `set_version()` exercised locally: with `TORCHRL_BUILD_VERSION=2026.06.10` the build version is `2026.06.10` (no local part, normalizes to `2026.6.10` which is what the verify script expects); without the override the dev path is unchanged (`0.13.0+g<sha>`).
- The rename `find` command verified against dummy wheel filenames (linux wheel renamed to manylinux1, macos wheel untouched).
- The build/test halves of `nightly_build.yml` run on this PR's own CI (`pull_request` trigger); the upload path gets exercised by the next 15:15 UTC scheduled run.

Note: the Nightly Orchestrator's scheduled runs are currently cancelled every day (separate concurrency issue, not addressed here), but `nightly_build.yml` has its own 15:15 UTC schedule that uploads independently, so nightlies resume regardless.

Generated with [Claude Code](https://claude.com/claude-code)