### PR TITLE
[CI] Stop daily cancellation of Nightly Orchestrator runs

### DIFF
--- a/.github/workflows/nightly_orchestrator.yml
+++ b/.github/workflows/nightly_orchestrator.yml
@@ -162,6 +162,15 @@ jobs:
       id-token: write
       contents: read
 
+  # The four build-wheels-* jobs run sequentially, not in parallel. The
+  # pytorch/test-infra build_wheels_{linux,macos,windows}.yml reusable
+  # workflows they call each define a workflow-level concurrency group keyed
+  # on the caller's workflow name and sha (identical for all four when called
+  # from this orchestrator) with cancel-in-progress: true. When invoked in
+  # parallel, each new claim of the group cancels the previous child's jobs,
+  # which marked every scheduled orchestrator run as cancelled. Chaining via
+  # needs serializes the claims; !cancelled() keeps the chain (and the status
+  # dashboard coverage) going when an earlier wheel build fails.
   build-wheels-linux:
     needs: config
     if: needs.config.outputs.run_tests == 'true'
@@ -172,8 +181,10 @@ jobs:
       contents: read
 
   build-wheels-m1:
-    needs: config
-    if: needs.config.outputs.run_tests == 'true'
+    needs:
+      - config
+      - build-wheels-linux
+    if: ${{ !cancelled() && needs.config.outputs.run_tests == 'true' }}
     uses: ./.github/workflows/build-wheels-m1.yml
     secrets: inherit
     permissions:
@@ -181,8 +192,10 @@ jobs:
       contents: read
 
   build-wheels-windows:
-    needs: config
-    if: needs.config.outputs.run_tests == 'true'
+    needs:
+      - config
+      - build-wheels-m1
+    if: ${{ !cancelled() && needs.config.outputs.run_tests == 'true' }}
     uses: ./.github/workflows/build-wheels-windows.yml
     secrets: inherit
     permissions:
@@ -190,8 +203,10 @@ jobs:
       contents: read
 
   build-wheels-aarch64-linux:
-    needs: config
-    if: needs.config.outputs.run_tests == 'true'
+    needs:
+      - config
+      - build-wheels-windows
+    if: ${{ !cancelled() && needs.config.outputs.run_tests == 'true' }}
     uses: ./.github/workflows/build-wheels-aarch64-linux.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/test-windows-optdepts.yml
+++ b/.github/workflows/test-windows-optdepts.yml
@@ -33,7 +33,10 @@ jobs:
     with:
       repository: pytorch/rl
       runner: ${{ matrix.runner }}
-      timeout: 60
+      # The suite takes ~60 minutes; with timeout: 60 it regularly hit the
+      # limit, and a timed-out job is reported as "cancelled", polluting the
+      # nightly orchestrator's conclusion and dashboard.
+      timeout: 90
       test-infra-ref: main
       script: |
         set -euxo pipefail


### PR DESCRIPTION
Follow-up to #3844. Every scheduled Nightly Orchestrator run has ended with conclusion `cancelled` for (at least) the past 10 days, so the status dashboard never sees a clean nightly.

## Root cause

The four `build-wheels-*` children call the pytorch/test-infra `build_wheels_{linux,macos,windows}.yml` reusable workflows, which all define:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}
  cancel-in-progress: true
```

Workflow-level concurrency in a called workflow applies to the caller's run, and `github.workflow` resolves to the **caller's** workflow name. So when the orchestrator invokes all four in parallel, they all claim the same group (`Nightly Orchestrator-<sha>-pytorch/rl-false`) and each new claim cancels the previous child's jobs. [Today's scheduled run](https://github.com/pytorch/rl/actions/runs/27261224073) shows the mechanism exactly: the linux/m1/windows wheel jobs are cancelled within seconds of run start, while `build-wheels-aarch64-linux` - the last claimer - survives and builds successfully. The cancelled jobs mark the whole run cancelled.

Standalone triggers are unaffected: on `pull_request`/`push` the four workflows run as separate top-level runs with distinct `github.workflow` names, so the groups never collide. Only the orchestrator hits this.

A second, independent source of `cancelled`: the windows optdepts suite takes about 60 minutes against `timeout: 60` (it ran 60:16 today, [59:51 on June 8](https://github.com/pytorch/rl/actions/runs/27124012424)), and a timed-out job is also reported as cancelled.

## Fix

- Chain `build-wheels-linux -> m1 -> windows -> aarch64-linux` via `needs` so the concurrency-group claims happen sequentially; a completed claim is no longer in-progress, so nothing gets cancelled. `!cancelled()` keeps the chain (and dashboard coverage) going if an earlier wheel build fails. Trade-off: wheel builds inside the orchestrator are serialized, adding roughly 30-60 minutes of wall clock to a nightly run; standalone PR/push wheel builds still run in parallel as before.
- Bump the windows optdepts `timeout` from 60 to 90 minutes.

The status collector (`collect_nightly_status.py`) keys off job-name prefixes inside the orchestrator run, so keeping the children in the call graph (rather than dispatching them separately) preserves the dashboard without collector changes.

## Validation

Dispatched a `dry-run` orchestrator on this branch: [run 27282262423](https://github.com/pytorch/rl/actions/runs/27282262423). With the chaining in place: `build-wheels-linux` 41/41 jobs success (previously cancelled within seconds), `build-wheels-m1` started only after linux completed and finished 11/11 success, `build-wheels-windows` running next in sequence - zero cancelled wheel jobs.

Generated with [Claude Code](https://claude.com/claude-code)