### PR TITLE
[BugFix] Fix nightly version check false positive and upload fail-fast

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -164,6 +164,10 @@ jobs:
     # Silent upload failures kept the workflow green while torchrl-nightly
     # went stale on PyPI for months.
     strategy:
+      # Without continue-on-error, one failed upload would otherwise fail-fast
+      # cancel every sibling upload; each platform/python must report its own
+      # result.
+      fail-fast: false
       matrix:
         os: [['linux', 'ubuntu-22.04'], ['macos', 'macos-latest']]
         python_version: [
@@ -323,6 +327,10 @@ jobs:
     # No continue-on-error here: a failed PyPI upload must turn the run red.
     runs-on: windows-latest
     strategy:
+      # Without continue-on-error, one failed upload would otherwise fail-fast
+      # cancel every sibling upload; each platform/python must report its own
+      # result.
+      fail-fast: false
       matrix:
         python_version: [
           ["3.10", "3.10.3"],

--- a/packaging/verify_nightly_version.py
+++ b/packaging/verify_nightly_version.py
@@ -31,12 +31,10 @@ if not isinstance(version, str) or not version:
         "a YYYY.M.D version string."
     )
 
-# Check that version is not the major version (0.9.0)
-if re.match(r"^\d+\.\d+\.\d+$", version):
-    raise ValueError(f"Version should not be the major version: {version}")
-
-# Check that version matches date format (YYYY.M.D). This also rejects PEP 440
-# local version identifiers (e.g. 2026.6.9+g<sha>), which PyPI refuses.
+# Check that version matches date format (YYYY.M.D). The 4-digit-year
+# requirement rejects stable versions (e.g. 0.13.0), and the anchored pattern
+# rejects PEP 440 local version identifiers (e.g. 2026.6.9+g<sha>), which
+# PyPI refuses.
 if not re.match(date_pattern, version):
     raise ValueError(f"Version should match date format YYYY.M.D, got: {version}")
 
@@ -44,9 +42,7 @@ if not re.match(date_pattern, version):
 today = date.today()
 expected_version = f"{today.year}.{today.month}.{today.day}"
 if version != expected_version:
-    raise ValueError(
-        f"Version should be today date {expected_version}, got: {version}"
-    )
+    raise ValueError(f"Version should be today date {expected_version}, got: {version}")
 
 print(f"Version {version} is correctly formatted as nightly date")
 


### PR DESCRIPTION
Follow-up to #3844 and #3845, fixing two issues exposed by the [orchestrator validation run](https://github.com/pytorch/rl/actions/runs/27282262423) - the first run in months in which the nightly verify step saw a real version string.

## What broke

1. **`verify_nightly_version.py` rejects every valid nightly version.** The "major version" guard `^\d+\.\d+\.\d+$` also matches date versions (`2026.6.10`), so all 15 `test-wheel-*` jobs failed with `ValueError: Version should not be the major version: 2026.6.10`. The check was dead code while `torchrl.__version__` was `None` (pre-#3844, the script warning-skipped) and could never have passed once a real version reached it.
2. **One failed upload cancels all the others.** With `continue-on-error` removed from the upload jobs in #3844, the default matrix `fail-fast` kicked in: 2 upload failures cancelled the 13 sibling uploads. Each platform/python upload should report its own result.

## Fixes

- Drop the major-version guard. The anchored `YYYY.M.D` pattern (4-digit year) plus the today's-date equality already reject stable versions (`0.13.0`), stale dates, and PEP 440 local identifiers. Also reformat the today's-date error to a single line, which is what black 22.3.0 wants at this indent (the `lint / python-source-and-configs` failure in the validation run); `ufmt check` passes with the repo's pinned versions.
- `fail-fast: false` on both upload-wheel matrices.

## Validation

- Version logic exercised locally: today's date accepted; `0.13.0`, `2026.6.10+g<sha>`, and stale dates rejected.
- `ufmt check` (ufmt 2.8.0 / black 22.3.0 / usort 1.0.3) reports the file already formatted.

## Heads-up: uploads are still blocked by the PyPI project size quota

The 2 genuine upload failures in the validation run were `400 Project size too large. Limit for project 'torchrl-nightly'`: the project sits at exactly 10.00 GiB (the default PyPI limit) across 230 releases, all from 2025. This cannot be fixed from the repo - a project owner needs to delete old releases on PyPI and/or request a size-limit increase (https://pypi.org/help/#project-size-limit). At ~135 MB/day (15 wheels x ~9 MB) the freed space refills in roughly 75 days per 10 GiB, so a periodic retention policy will be needed. With this PR plus that cleanup, scheduled nightlies should publish again end to end.

Generated with [Claude Code](https://claude.com/claude-code)