### PR TITLE
[Doc] Resolve tutorial code links to torchrl docs, not base classes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -139,6 +139,11 @@ sphinx_gallery_conf = {
     "gallery_dirs": "tutorials",  # path to where to save gallery generated output
     "backreferences_dir": "gen_modules/backreferences",
     "doc_module": ("torchrl",),
+    # resolve torchrl identifiers in example code blocks against this build
+    # (None = local docs); without it, code links fall back to the first
+    # documented base class found via intersphinx (e.g. a TensorDictModule
+    # subclass links to tensordict.nn.TensorDictModuleBase)
+    "reference_url": {"torchrl": None},
     "filename_pattern": "reference/generated/tutorials/",  # files to parse
     "notebook_images": "reference/generated/tutorials/media/",  # images to parse
     "download_all_examples": True,


### PR DESCRIPTION
## What

Clicking a torchrl identifier in any tutorial code cell (e.g. `MultiStepActorWrapper` in the VLA tutorial) currently lands on the nearest documented *base class* in an external inventory -- `tensordict.nn.TensorDictModuleBase` for TensorDictModule subclasses and losses, `torch.nn.Module` for envs -- instead of the torchrl class page.

## Why

sphinx-gallery linkifies code identifiers by generating candidates from the object's own qualified names first, then walking its base-class chain (`NameFinder.get_mapping` in `backreferences.py`). For `MultiStepActorWrapper` the candidate list is:

```
torchrl.modules.tensordict_module.actors.MultiStepActorWrapper
torchrl.modules.tensordict_module.MultiStepActorWrapper   <- correct, documented path
torchrl.modules.MultiStepActorWrapper
torchrl.MultiStepActorWrapper
tensordict.nn.TensorDictModuleBase                        <- what currently wins
torch.nn.Module
```

`_embed_code_links` links the first candidate it can resolve, trying (1) the doc resolvers built from `sphinx_gallery_conf["reference_url"]` and (2) intersphinx. `reference_url` was never configured (defaults to `{}`) and `torchrl` is deliberately not in `intersphinx_mapping`, so no torchrl candidate could ever resolve and every code token fell through to the first base class found in the tensordict/torch inventories.

## Fix

Set `"reference_url": {"torchrl": None}` -- `None` means "resolve against the docs being built", the standard sphinx-gallery setup (scikit-learn, MNE, etc.). The torchrl candidates are tried before the base-class fallbacks, so code tokens now link to the torchrl class pages. Prose `:class:` references were always fine; only the code-cell links were affected.

Generated with [Claude Code](https://claude.com/claude-code)