### PR TITLE
[CI] Grant pull-requests write to the benchmark PR-comment workflow

### DIFF
--- a/.github/workflows/benchmarks_pr_comment.yml
+++ b/.github/workflows/benchmarks_pr_comment.yml
@@ -10,7 +10,10 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: read
+  # Creating an issue comment on a *pull request* requires pull-requests
+  # write for the app-scoped GITHUB_TOKEN (issues write only covers actual
+  # issues); with read the final POST in comment_pr_benchmarks.py 403s.
+  pull-requests: write
 
 jobs:
   benchmark-comment:


### PR DESCRIPTION
## Motivation

The `Continuous Benchmark (PR Comment)` workflow (`benchmarks_pr_comment.yml`) has never successfully posted a benchmark comparison comment to a PR. Every non-skipped run since it was introduced in #3705 fails the same way: 0 successes in its last 200 runs (98 failures, 102 skipped because the parent benchmark run failed).

The failure is always the final step of `.github/scripts/comment_pr_benchmarks.py`:

```
POST /repos/pytorch/rl/issues/{pr}/comments
urllib.error.HTTPError: HTTP Error 403: Forbidden
```

Example: run [27351930841](https://github.com/pytorch/rl/actions/runs/27351930841) (triggered by benchmark run [27348228939](https://github.com/pytorch/rl/actions/runs/27348228939) for #3838) downloaded the artifacts and built the comparison fine, then 403'd on the create-comment call.

## Root cause

The workflow requests `issues: write` but `pull-requests: read`, and the job log's `GITHUB_TOKEN Permissions` block confirms the token gets exactly that. Creating an issue comment on a **pull request** through the shared `/issues/{n}/comments` endpoint requires the `pull-requests: write` permission for app-scoped tokens (the `GITHUB_TOKEN`); `issues: write` only covers comments on actual issues. That is also why the preceding GET listing existing comments succeeds (read access is enough) while the POST is rejected.

## Fix

Grant `pull-requests: write` in the workflow's permissions block (one line, plus a comment explaining why).

Note: `workflow_run` workflows execute the workflow file version on the default branch, so this can only be fully verified after merge -- the next benchmark run completing on any PR should then post (or update) its comparison comment.

Generated with [Claude Code](https://claude.com/claude-code)