### PR TITLE
[BugFix] Fix flaky Pendulum spec check and collector preemption ordering test (#3798)

### DIFF
--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -2286,7 +2286,10 @@ if __name__ == "__main__":
                 # Random sleep up to 10ms
                 time.sleep(torch.rand(1).item() * 0.01)
             elif self.env_id % 2 == 1:
-                time.sleep(0.1)
+                # Long enough that the preemption stop flag lands well before
+                # the slow envs can complete a full rollout, even on loaded CI
+                # runners (#3798)
+                time.sleep(0.3)
 
             self._step_count = 0
             return TensorDict(
@@ -2307,7 +2310,7 @@ if __name__ == "__main__":
             done = self._step_count >= self.max_steps
 
             if self.sleep_odd_only and self.env_id % 2 == 1:
-                time.sleep(0.1)
+                time.sleep(0.3)
             if self.step_sleep:
                 time.sleep(self.step_sleep)
 
@@ -2389,16 +2392,30 @@ if __name__ == "__main__":
 
                 #
                 for env_idx in range(num_envs):
+                    traj_ids = batch["collector", "traj_ids"][env_idx]
                     if with_preempt and env_idx % 2 == 1:
-                        # This is a slow env, should have been preempted after first step
-                        assert (batch["collector", "traj_ids"][env_idx, 1:] == -1).all()
-                        continue
-                    # This is a fast env, no preemption happened
-                    assert (batch["collector", "traj_ids"][env_idx] != -1).all()
+                        # This is a slow env: it must have been preempted before
+                        # completing its rollout. The stop flag is only raised
+                        # once the fastest workers have reported and is polled
+                        # by the worker once per step, so on a loaded machine
+                        # the slow env can log a couple of valid steps before
+                        # stopping; requiring exactly one step made this test
+                        # flaky (#3798).
+                        n_valid = (traj_ids != -1).sum().item()
+                        assert 1 <= n_valid < n_steps, traj_ids
+                        # the valid steps form a contiguous prefix, padding
+                        # closes the row
+                        assert (traj_ids[:n_valid] != -1).all(), traj_ids
+                        assert (traj_ids[n_valid:] == -1).all(), traj_ids
+                    else:
+                        # This is a fast env, no preemption happened
+                        assert (traj_ids != -1).all()
+                        n_valid = traj_ids.numel()
 
                     env_data = batch[env_idx]
-                    observations = env_data["observation"]
-                    # All observations from this environment should equal its env_id
+                    # All valid observations from this environment should equal
+                    # its env_id (padded rows are excluded for preempted envs)
+                    observations = env_data["observation"][:n_valid]
                     expected_id = float(env_idx)
                     actual_ids = observations.flatten().unique()
 

--- a/test/test_custom_envs.py
+++ b/test/test_custom_envs.py
@@ -139,6 +139,20 @@ class TestPendulum:
             r = env.rollout(10, tensordict=TensorDict(batch_size=[5], device=device))
             assert r.shape == torch.Size((5, 10))
 
+    def test_pendulum_angle_wrapped(self):
+        # ``th`` must stay within the ``Bounded(-pi, pi)`` observation/state
+        # spec even when the dynamics push the angle past the boundary;
+        # unbounded drift made ``check_env_specs`` flaky (#3798).
+        env = PendulumEnv()
+        td = env.reset()
+        td["th"] = torch.tensor(torch.pi - 1e-3)
+        td["thdot"] = torch.tensor(8.0)  # max speed, pushes past +pi
+        td["action"] = torch.ones(1)
+        for _ in range(10):
+            td = env.step(td)["next"]
+            assert env.observation_spec["th"].is_in(td["th"]), td["th"]
+            td["action"] = torch.ones(1)
+
     def test_pendulum_set_state(self):
         env = PendulumEnv()
         torch.manual_seed(0)

--- a/torchrl/envs/custom/pendulum.py
+++ b/torchrl/envs/custom/pendulum.py
@@ -255,7 +255,11 @@ class PendulumEnv(EnvBase):
         new_thdot = new_thdot.clamp(
             -tensordict["params", "max_speed"], tensordict["params", "max_speed"]
         )
-        new_th = th + new_thdot * dt
+        # wrap the angle so that the state stays within the bounds promised by
+        # the ``th`` spec, ``Bounded(-pi, pi)``. The dynamics only depend on
+        # ``th`` through ``sin`` and ``angle_normalize``, both 2*pi-periodic,
+        # so this does not change the trajectory.
+        new_th = cls.angle_normalize(th + new_thdot * dt)
         reward = -costs.view(*tensordict.shape, 1)
         done = torch.zeros_like(reward, dtype=torch.bool)
         out = TensorDict(


### PR DESCRIPTION
## Description

The three tracked flakes have two independent causes: a real bug in `PendulumEnv`, and an over-constrained timing assertion in the collector ordering test.

**PendulumEnv lets `th` drift out of its spec.** `_step` computes `new_th = th + new_thdot * dt` without wrapping, while the `th` observation/state spec is `Bounded(-pi, pi)`, so `check_env_specs` fails whenever the random rollout pushes the angle past the boundary — 8/500 seeds locally. The failure is value-domain, not device-dependent, which is why both the cpu and cuda variants flake. Fixed by wrapping with `angle_normalize`, which the pendulum tutorial's copy of this env already does; behavior-preserving, since the dynamics see `th` only through `sin` and `angle_normalize`, both 2*pi-periodic. Added a deterministic regression test that drives the pendulum across +pi at max speed and asserts spec containment.

**The ordering test over-constrains preemption timing.** It asserted slow envs are preempted after exactly one step, but the stop flag is only raised once the fastest workers have reported and workers poll it once per step, so on a loaded runner a slow env can legitimately log a second valid step before stopping (the CI failure shows traj_ids `[4, 4, -1, -1, -1]`). The `_Interruptor` itself is sound; only the test needed recalibrating. It now asserts a preempted env stops with a contiguous valid prefix shorter than a full rollout and extends the observation==env_id check to the valid rows of preempted envs (previously skipped). Slow-env step time widened 0.1s -> 0.3s for margin.

Tested: 500-seed `check_env_specs` sweep goes 8 failures -> 0; TestPendulum passes 100x repeat; the ordering test passes both normally and with an injected 0.25s stop-flag delay that reproduced the CI failure verbatim before the fix, plus 10x repeat under background CPU load.

## Motivation and Context

Fixes #3798.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
