### PR TITLE
[Feature] Mask-aware BCLoss; LossModule._reduce_loss honors ("collect…

### DIFF
--- a/test/objectives/test_bc.py
+++ b/test/objectives/test_bc.py
@@ -388,3 +388,130 @@ class TestBCLoss:
         full = loss(td.exclude("masks"))["loss_bc"]
         masked = loss(td)["loss_bc"]
         assert masked < full
+
+
+class TestBCLossMaskAware:
+    """Tests for mask-aware time-averaging in :class:`BCLoss`.
+
+    Padded positions written by ``SliceSampler(pad_output=True)`` are
+    flagged via the ``("collector", "mask")`` key (False for padding,
+    True for real steps). When that key is present, ``BCLoss`` should
+    exclude the padded positions from its time-averaging so duplicated
+    last-step values do not contribute to the gradient.
+
+    Back-compat: when the key is absent the loss must reduce to exactly
+    the same value (and gradient) as before this feature.
+    """
+
+    @staticmethod
+    def _make_actor(action_dim: int = 2, obs_dim: int = 4) -> Actor:
+        spec = Bounded(-torch.ones(action_dim), torch.ones(action_dim), (action_dim,))
+        module = torch.nn.Linear(obs_dim, action_dim)
+        return Actor(module=module, spec=spec)
+
+    @staticmethod
+    def _make_batch(
+        batch_size: int = 8, action_dim: int = 2, obs_dim: int = 4
+    ) -> TensorDict:
+        return TensorDict(
+            {
+                "observation": torch.randn(batch_size, obs_dim),
+                "action": torch.randn(batch_size, action_dim),
+            },
+            batch_size=[batch_size],
+        )
+
+    def test_no_mask_key_is_backward_compatible(self):
+        """Without the mask key, output is identical to the prior path."""
+        torch.manual_seed(0)
+        actor = self._make_actor()
+        loss_fn = BCLoss(actor, loss_function="l2")
+        batch = self._make_batch(batch_size=8)
+
+        baseline = loss_fn(batch.clone())["loss_bc"]
+        assert ("collector", "mask") not in batch.keys(include_nested=True)
+        repeat = loss_fn(batch.clone())["loss_bc"]
+        torch.testing.assert_close(baseline, repeat)
+
+    def test_all_true_mask_equals_unmasked(self):
+        """A mask of all True is a no-op for the masked-mean reduction."""
+        torch.manual_seed(0)
+        actor = self._make_actor()
+        loss_fn = BCLoss(actor, loss_function="l2")
+        batch = self._make_batch(batch_size=8)
+
+        unmasked = loss_fn(batch.clone())["loss_bc"]
+
+        masked_batch = batch.clone()
+        masked_batch[("collector", "mask")] = torch.ones(8, dtype=torch.bool)
+        masked = loss_fn(masked_batch)["loss_bc"]
+
+        torch.testing.assert_close(unmasked, masked)
+
+    def test_partial_mask_matches_manual_subset_loss(self):
+        """A partially-False mask must drop padded positions from the average."""
+        torch.manual_seed(0)
+        actor = self._make_actor()
+        loss_fn = BCLoss(actor, loss_function="l2")
+
+        batch = self._make_batch(batch_size=8)
+        mask = torch.tensor([True, True, True, True, False, False, False, False])
+
+        masked_batch = batch.clone()
+        masked_batch[("collector", "mask")] = mask
+        with_mask = loss_fn(masked_batch)["loss_bc"]
+
+        # Compute the loss on only the real (mask=True) positions and compare.
+        # Padded positions must never contribute to the reported loss.
+        real_only = batch[mask]
+        manual = loss_fn(real_only.clone())["loss_bc"]
+
+        torch.testing.assert_close(with_mask, manual, rtol=1e-5, atol=1e-6)
+
+    def test_partial_mask_gradient_matches_manual_subset(self):
+        """Backward through the masked loss matches backward through the subset."""
+        torch.manual_seed(0)
+        actor_a = self._make_actor()
+        actor_b = self._make_actor()
+        actor_b.load_state_dict(actor_a.state_dict())
+
+        loss_a = BCLoss(actor_a, loss_function="l2")
+        loss_b = BCLoss(actor_b, loss_function="l2")
+
+        batch = self._make_batch(batch_size=8)
+        mask = torch.tensor([True, True, True, True, False, False, False, False])
+
+        masked_batch = batch.clone()
+        masked_batch[("collector", "mask")] = mask
+        loss_a(masked_batch)["loss_bc"].backward()
+
+        real_only = batch[mask]
+        loss_b(real_only.clone())["loss_bc"].backward()
+
+        for p_a, p_b in zip(actor_a.parameters(), actor_b.parameters()):
+            assert p_a.grad is not None and p_b.grad is not None
+            torch.testing.assert_close(p_a.grad, p_b.grad, rtol=1e-5, atol=1e-6)
+
+    def test_all_false_mask_produces_zero_loss(self):
+        """A fully-padded batch (no real positions) reduces to a zero loss.
+
+        ``_reduce_loss`` clamps the denominator at 1, so the reduction stays
+        well-defined (no NaN); the numerator is zero because every element
+        is masked out, giving a loss of zero.
+        """
+        torch.manual_seed(0)
+        actor = self._make_actor()
+        loss_fn = BCLoss(actor, loss_function="l2")
+        batch = self._make_batch(batch_size=4)
+        batch[("collector", "mask")] = torch.zeros(4, dtype=torch.bool)
+
+        out = loss_fn(batch)["loss_bc"]
+        torch.testing.assert_close(out, torch.zeros_like(out))
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    args, unknown = argparse.ArgumentParser().parse_known_args()
+    sys.exit(pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown))

--- a/torchrl/objectives/bc.py
+++ b/torchrl/objectives/bc.py
@@ -17,7 +17,6 @@ from tensordict.nn import dispatch, TensorDictModule
 from tensordict.utils import NestedKey
 
 from torchrl.objectives.common import LossModule
-from torchrl.objectives.utils import _reduce
 
 
 class BCLoss(LossModule):
@@ -312,6 +311,13 @@ class BCLoss(LossModule):
                 log_prob = dist.log_prob(action_expert)
                 loss = -log_prob
 
+        # Precedence:
+        # 1. An explicit ``tensor_keys.pad_mask`` (set by VLA / chunked-BC
+        #    callers) wins — it carries domain-specific dimension validation.
+        # 2. Otherwise, ``_reduce_loss`` auto-detects ``("collector", "mask")``
+        #    from SliceSampler(pad_output=True) (PR #3695), falling back to
+        #    the legacy ``shifted_valid`` key. When neither is present, the
+        #    behavior is byte-identical to the old plain ``.mean()`` path.
         mask = None
         if self.tensor_keys.pad_mask is not None:
             pad = tensordict.get(self.tensor_keys.pad_mask, default=None)
@@ -328,7 +334,7 @@ class BCLoss(LossModule):
                 while mask.ndim < loss.ndim:
                     mask = mask.unsqueeze(-1)
                 mask = mask.expand_as(loss)
-        loss = _reduce(loss, reduction=self.reduction, mask=mask)
+        loss = self._reduce_loss(loss, tensordict=tensordict, mask=mask)
 
         td_out = TensorDict({"loss_bc": loss})
         self._clear_weakrefs(

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -279,7 +279,13 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
         if reduction is None:
             reduction = self.reduction
         if mask is None and tensordict is not None:
-            mask = tensordict.get("shifted_valid", default=None)
+            # Prefer the modern sequence-aware mask written by SliceSampler
+            # (``pad_output=True`` since PR #3695). Fall back to the legacy
+            # ``shifted_valid`` key used by recurrent value estimators
+            # so reinforce / a2c / ppo callers retain their behavior.
+            mask = tensordict.get(("collector", "mask"), default=None)
+            if mask is None:
+                mask = tensordict.get("shifted_valid", default=None)
         if mask is not None:
             mask = self._expand_loss_mask(mask, loss)
             if weights is not None and weights.shape != loss.shape:


### PR DESCRIPTION
Closes the loss-side gap from the sequence-RL composability work landed in #3695: SliceSampler(pad_output=True) writes ("collector", "mask") alongside the padded batch, but no loss in the repo was reading that mask. Padded positions were silently averaged into the gradient.

This PR:

- Extends LossModule._reduce_loss (torchrl/objectives/common.py) to look up ("collector", "mask") first, falling back to the legacy "shifted_valid" key so the existing PPO / A2C / Reinforce callers retain their behavior exactly.

- Migrates BCLoss.forward() from `_reduce(loss, reduction=self.reduction)` to `self._reduce_loss(loss, tensordict=tensordict)` as the reference adoption. When the mask key is absent the output is byte-identical to the old path; when present, padded positions are excluded from the time-averaging.

- Adds 5 mask-aware tests in test/objectives/test_bc.py:
  * back-compat without mask key
  * all-True mask is a no-op
  * partial mask matches the loss computed on the real subset
  * gradient through masked loss matches gradient through subset
  * all-False mask reduces to 0 without NaN (denominator clamp)

Follow-up PRs can adopt the same one-line change in PPO, A2C, IQL, CQL, SAC, DDPG, TD3, GAIL, DT, and Reinforce. Each is reviewable in minutes once this base pattern lands.

The reduction infrastructure on _reduce(..., mask=, weights=) already existed; this PR just wires the input-side tensordict lookup into the common helper that losses already inherit.