### PR TITLE
[BugFix] Fix _skip_tensordict typo in EnvBase.step batch-locked branch

### DIFF
--- a/test/envs/test_special.py
+++ b/test/envs/test_special.py
@@ -615,6 +615,26 @@ class TestPartialSteps:
             assert_allclose_td(td[2].get("next"), td[2], intersection=True)
             assert (td[3].get("next") != 0).any()
 
+    def test_batch_locked_partial_steps_all_false(self, device, env_device):
+        # Regression test: EnvBase.step on a batch-locked env receiving an
+        # all-False "_step" mask must skip _step entirely and return the skip
+        # tensordict instead of raising.
+        with torch.device(device) if device is not None else contextlib.nullcontext():
+            env = CountingEnv(
+                max_steps=10, start_val=2, batch_size=(4,), device=env_device
+            )
+            assert env.batch_locked
+            td = env.reset()
+            td.set("_step", torch.zeros(4, dtype=torch.bool, device=td.device))
+            td.set("action", env.full_action_spec[env.action_key].one())
+            td = env.step(td)
+            # every step was skipped: observations carry over, reward is zeroed
+            # and the counter never advanced
+            assert_allclose_td(td.get("next"), td, intersection=True)
+            assert (td["next", "observation"] == 2).all()
+            assert (td["next", "reward"] == 0).all()
+            assert (env.count == 2).all()
+
 
 class TestEnvWithHistory:
     @pytest.fixture(autouse=True, scope="class")

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -2340,7 +2340,7 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
                     tensordict = tensordict[partial_steps]
             else:
                 if not partial_steps.any():
-                    next_tensordict = self._skip_tensordic(tensordict)
+                    next_tensordict = self._skip_tensordict(tensordict)
                 else:
                     # trust that the _step can handle this!
                     tensordict.set("_step", partial_steps)


### PR DESCRIPTION
## Description

`EnvBase.step` called `self._skip_tensordic(tensordict)` (missing trailing `t`) in the batch-locked partial-step branch. Any batch-locked env whose `step()` received an all-False `"_step"` mask raised `AttributeError` instead of producing the skip tensordict.

The `TransformedEnv` counterpart in `torchrl/envs/transforms/_base.py` spells the method correctly, which is why the bug went unnoticed.

## Changes

- Fix the typo in `torchrl/envs/common.py`.
- Add a regression test to `TestPartialSteps` in `test/envs/test_special.py`: a batch-locked `CountingEnv` stepped with an all-False `"_step"` mask must return the skip tensordict (observations carried over, reward zeroed, internal counter untouched).

Verified with `git grep -n "_skip_tensordic\b"` that no other call site has the typo. The new test fails with `AttributeError` on the unfixed code and passes after the fix; the full `TestPartialSteps` class (36 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)