### PR TITLE
[BugFix] Fix IsaacLab reset regressions

### DIFF
--- a/test/envs/test_env_base.py
+++ b/test/envs/test_env_base.py
@@ -25,7 +25,7 @@ from torch import nn
 from torchrl.data.tensor_specs import Binary, Composite, NonTensor, Unbounded
 from torchrl.envs import EnvBase, ParallelEnv, SerialEnv
 from torchrl.envs.libs.gym import gym_backend, GymEnv
-from torchrl.envs.transforms import StepCounter, TransformedEnv
+from torchrl.envs.transforms import StepCounter, Transform, TransformedEnv
 from torchrl.envs.utils import check_env_specs, make_composite_from_td, step_mdp
 from torchrl.modules import Actor
 from torchrl.testing import (
@@ -969,6 +969,51 @@ class _NestedStatelessEnv(EnvBase):
         ...
 
 
+class _KwargOnlySetStateEnv(EnvBase):
+    _supports_set_state = True
+
+    def __init__(self, **kwargs):
+        super().__init__(batch_size=(), **kwargs)
+        self.observation_spec = Composite(observation=Unbounded(shape=(1,)))
+        self.action_spec = Unbounded(shape=(1,))
+        self.reward_spec = Unbounded(shape=(1,))
+        self.done_spec = Binary(n=1, shape=(1,), dtype=torch.bool)
+
+    def _input_td_has_state(self, tensordict):
+        return False
+
+    def _reset(self, tensordict, **kwargs):
+        if kwargs.get("set_state"):
+            raise RuntimeError("unexpected implicit set_state")
+        return TensorDict(
+            {
+                "observation": torch.zeros(1),
+                "done": torch.zeros(1, dtype=torch.bool),
+            },
+            batch_size=(),
+        )
+
+    def _step(self, tensordict):
+        return TensorDict(
+            {
+                "observation": tensordict["observation"] + tensordict["action"],
+                "reward": torch.zeros(1),
+                "done": torch.zeros(1, dtype=torch.bool),
+            },
+            batch_size=(),
+        )
+
+    def _set_seed(self, *args, **kwargs):
+        ...
+
+
+class _OuterStateTransform(Transform):
+    def transform_state_spec(self, state_spec):
+        state_spec = state_spec.clone()
+        state_spec["outer_state"] = Unbounded(shape=(1,))
+        return state_spec
+
+
 class TestResetSetState:
     """Tests for the explicit ``reset(td, set_state=True)`` deterministic-reset kwarg."""
 
@@ -1028,6 +1073,14 @@ class TestResetSetState:
             assert (out["nested", "x"] == 5.0).all()
         finally:
             env.close()
+
+    def test_transformed_env_delegates_implicit_state_detection(self):
+        env = TransformedEnv(_KwargOnlySetStateEnv(), _OuterStateTransform())
+        td = TensorDict({"outer_state": torch.ones(1)}, batch_size=())
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            out = env.reset(td)
+        assert (out["observation"] == 0).all()
 
 
 if __name__ == "__main__":

--- a/test/libs/test_isaac.py
+++ b/test/libs/test_isaac.py
@@ -30,8 +30,7 @@ from torchrl.data import LazyMemmapStorage, RayReplayBuffer, ReplayBuffer
 from torchrl.data.replay_buffers.samplers import SliceSampler
 from torchrl.data.replay_buffers.storages import LazyTensorStorage
 from torchrl.envs import InitTracker, RewardSum, StepCounter, TransformedEnv, VecNormV2
-from torchrl.envs.libs import gym as gym_lib
-from torchrl.envs.libs import isaac_lab as isaac_lab_lib
+from torchrl.envs.libs import gym as gym_lib, isaac_lab as isaac_lab_lib
 from torchrl.envs.libs.isaac_lab import IsaacLabWrapper
 from torchrl.envs.utils import check_env_specs
 from torchrl.modules import LSTMModule, MLP

--- a/test/libs/test_isaac.py
+++ b/test/libs/test_isaac.py
@@ -9,15 +9,17 @@ import io
 import itertools
 import os
 import queue as queue_lib
+import sys
 import time
 import traceback
+import types
 from functools import partial
 
 import pytest
 import torch
 import torch.distributed as dist
 import torchrl.testing.env_helper
-from tensordict import assert_allclose_td
+from tensordict import assert_allclose_td, TensorDict
 from tensordict.nn import TensorDictModule as Mod, TensorDictSequential as Seq
 from torch import multiprocessing as mp
 
@@ -28,6 +30,9 @@ from torchrl.data import LazyMemmapStorage, RayReplayBuffer, ReplayBuffer
 from torchrl.data.replay_buffers.samplers import SliceSampler
 from torchrl.data.replay_buffers.storages import LazyTensorStorage
 from torchrl.envs import InitTracker, RewardSum, StepCounter, TransformedEnv, VecNormV2
+from torchrl.envs.libs import gym as gym_lib
+from torchrl.envs.libs import isaac_lab as isaac_lab_lib
+from torchrl.envs.libs.isaac_lab import IsaacLabWrapper
 from torchrl.envs.utils import check_env_specs
 from torchrl.modules import LSTMModule, MLP
 from torchrl.testing import get_default_devices
@@ -302,6 +307,105 @@ def _isaaclab_direct_native_autoreset(env_name: str, num_envs: int = 16):
     finally:
         queue.close()
         proc.join()
+
+
+def _install_fake_isaaclab(monkeypatch):
+    class ManagerBasedEnv:
+        pass
+
+    class DirectRLEnv:
+        pass
+
+    class DirectMARLEnv:
+        pass
+
+    fake_envs = types.ModuleType("isaaclab.envs")
+    fake_envs.ManagerBasedEnv = ManagerBasedEnv
+    fake_envs.DirectRLEnv = DirectRLEnv
+    fake_envs.DirectMARLEnv = DirectMARLEnv
+    fake_isaaclab = types.ModuleType("isaaclab")
+    fake_isaaclab.envs = fake_envs
+    monkeypatch.setitem(sys.modules, "isaaclab", fake_isaaclab)
+    monkeypatch.setitem(sys.modules, "isaaclab.envs", fake_envs)
+    return ManagerBasedEnv, DirectRLEnv, DirectMARLEnv
+
+
+def test_isaaclab_direct_env_detection_is_native_autoreset_opt_in(monkeypatch):
+    ManagerBasedEnv, DirectRLEnv, DirectMARLEnv = _install_fake_isaaclab(monkeypatch)
+    monkeypatch.setattr(gym_lib, "_has_isaaclab", True)
+    monkeypatch.setattr(isaac_lab_lib, "_has_isaaclab", True)
+
+    manager_env = ManagerBasedEnv()
+    direct_env = DirectRLEnv()
+    direct_marl_env = DirectMARLEnv()
+
+    assert IsaacLabWrapper._supports_native_autoreset(manager_env)
+    assert not IsaacLabWrapper._supports_native_autoreset(direct_env)
+    assert not IsaacLabWrapper._supports_native_autoreset(direct_marl_env)
+    assert IsaacLabWrapper._supports_native_autoreset(direct_env, native_autoreset=True)
+    assert IsaacLabWrapper._supports_native_autoreset(
+        direct_marl_env, native_autoreset=True
+    )
+
+    fake_vector = types.SimpleNamespace(VectorEnv=type("VectorEnv", (), {}))
+    monkeypatch.setattr(
+        gym_lib,
+        "gym_backend",
+        lambda name=None: fake_vector if name == "vector" else fake_vector,
+    )
+    wrapper = gym_lib.GymWrapper.__new__(gym_lib.GymWrapper)
+    wrapper._torchrl_native_autoreset_requested = False
+    wrapper._env = types.SimpleNamespace(unwrapped=manager_env)
+    assert wrapper._is_batched
+    wrapper._env = types.SimpleNamespace(unwrapped=direct_env)
+    assert not wrapper._is_batched
+    wrapper._torchrl_native_autoreset_requested = True
+    assert wrapper._is_batched
+
+    isaac_wrapper = IsaacLabWrapper.__new__(IsaacLabWrapper)
+    isaac_wrapper._env = types.SimpleNamespace(unwrapped=direct_env)
+    assert not isaac_wrapper._supports_set_state
+
+    def reset_to(*args, **kwargs):
+        return None
+
+    manager_env.reset_to = reset_to
+    isaac_wrapper._env = types.SimpleNamespace(unwrapped=manager_env)
+    assert isaac_wrapper._supports_set_state
+
+
+def test_isaaclab_observation_key_normalization_is_cached_and_non_clobbering():
+    env = IsaacLabWrapper.__new__(IsaacLabWrapper)
+    env._rename_policy_to_observation = False
+    policy = torch.ones(2, 3)
+    observations = {"policy": policy}
+    assert env._normalize_observation_keys(observations) is observations
+
+    env._rename_policy_to_observation = True
+    normalized = env._normalize_observation_keys(observations)
+    assert normalized is not observations
+    assert "policy" not in normalized
+    assert normalized["observation"] is policy
+
+    existing_observation = torch.zeros(2, 3)
+    observations = {"policy": policy, "observation": existing_observation}
+    assert env._normalize_observation_keys(observations) is observations
+    assert observations["observation"] is existing_observation
+
+
+def test_isaaclab_all_false_reset_to_state_is_no_op():
+    env = IsaacLabWrapper.__new__(IsaacLabWrapper)
+    td = TensorDict(
+        {
+            "_reset": torch.zeros(3, 1, dtype=torch.bool),
+            "policy": torch.ones(3, 2),
+        },
+        batch_size=(3,),
+    )
+    out = env._reset(td, set_state=True, scene_state=object())
+    assert "_reset" not in out.keys()
+    assert out is not td
+    assert (out["policy"] == td["policy"]).all()
 
 
 @pytest.mark.skipif(not _has_isaac, reason="IsaacGym not found")

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -873,6 +873,9 @@ class _GymAsyncMeta(_EnvPostInit):
         missing_obs_value = kwargs.pop("missing_obs_value", None)
         native_autoreset = kwargs.pop("native_autoreset", False)
         num_workers = kwargs.pop("num_workers", 1)
+        native_autoreset = kwargs.setdefault(
+            "_torchrl_native_autoreset_requested", native_autoreset
+        )
 
         if cls.__name__ == "GymEnv" and num_workers > 1:
             from torchrl.envs import EnvCreator, ParallelEnv
@@ -903,7 +906,9 @@ class _GymAsyncMeta(_EnvPostInit):
                 kwargs = {}
                 if missing_obs_value is not None:
                     kwargs["missing_obs_value"] = missing_obs_value
-                if IsaacLabWrapper._supports_native_autoreset(instance._env.unwrapped):
+                if IsaacLabWrapper._supports_native_autoreset(
+                    instance._env.unwrapped, native_autoreset=native_autoreset
+                ):
                     env = TransformedEnv(
                         instance,
                         VecGymEnvTransform(**kwargs, native_autoreset=native_autoreset),
@@ -1131,6 +1136,9 @@ class GymWrapper(GymLikeEnv, metaclass=_GymAsyncMeta):
         )
 
     def __init__(self, env=None, categorical_action_encoding=False, **kwargs):
+        self._torchrl_native_autoreset_requested = kwargs.pop(
+            "_torchrl_native_autoreset_requested", False
+        )
         self._seed_calls_reset = None
         self._categorical_action_encoding = categorical_action_encoding
         if env is not None:
@@ -1204,7 +1212,10 @@ class GymWrapper(GymLikeEnv, metaclass=_GymAsyncMeta):
             from torchrl.envs.libs.isaac_lab import IsaacLabWrapper
 
             tuple_of_classes = (
-                tuple_of_classes + IsaacLabWrapper._supported_isaac_env_classes()
+                tuple_of_classes
+                + IsaacLabWrapper._supported_isaac_env_classes(
+                    include_direct=self._torchrl_native_autoreset_requested
+                )
             )
         return isinstance(
             self._env.unwrapped, tuple_of_classes + (gym_backend("vector").VectorEnv,)

--- a/torchrl/envs/libs/isaac_lab.py
+++ b/torchrl/envs/libs/isaac_lab.py
@@ -131,11 +131,6 @@ class IsaacLabWrapper(GymWrapper):
 
     """
 
-    # Supports deterministic resets via ``reset(td, set_state=True,
-    # scene_state=...)`` (manager-based envs). The snapshot is honored through
-    # Isaac's ``reset_to`` rather than from tensordict state entries.
-    _supports_set_state = True
-
     def __init__(
         self,
         env: isaaclab.envs.ManagerBasedRLEnv,  # noqa: F821
@@ -289,25 +284,30 @@ class IsaacLabWrapper(GymWrapper):
 
     def _make_specs(self, env, batch_size=None) -> None:
         super()._make_specs(env, batch_size=batch_size)
-        if not self.from_tiled_camera:
-            return
-        camera = self._get_tiled_camera()
-        cfg = camera.cfg
-        channels = self.pixels_channels
-        if channels is None:
-            if self.tiled_camera_data_type == "rgb":
-                channels = 3
+        if self.from_tiled_camera:
+            camera = self._get_tiled_camera()
+            cfg = camera.cfg
+            channels = self.pixels_channels
+            if channels is None:
+                if self.tiled_camera_data_type == "rgb":
+                    channels = 3
+                else:
+                    channels = camera.data.output[self.tiled_camera_data_type].shape[-1]
+            dtype = self.pixels_dtype
+            if dtype is None:
+                dtype = camera.data.output[self.tiled_camera_data_type].dtype
+            shape = (*self.batch_size, cfg.height, cfg.width, channels)
+            if dtype == torch.uint8:
+                pixels_spec = Bounded(
+                    0, 255, shape=shape, dtype=dtype, device=self.device
+                )
             else:
-                channels = camera.data.output[self.tiled_camera_data_type].shape[-1]
-        dtype = self.pixels_dtype
-        if dtype is None:
-            dtype = camera.data.output[self.tiled_camera_data_type].dtype
-        shape = (*self.batch_size, cfg.height, cfg.width, channels)
-        if dtype == torch.uint8:
-            pixels_spec = Bounded(0, 255, shape=shape, dtype=dtype, device=self.device)
-        else:
-            pixels_spec = Unbounded(shape=shape, dtype=dtype, device=self.device)
-        self.observation_spec[self.pixels_key] = pixels_spec
+                pixels_spec = Unbounded(shape=shape, dtype=dtype, device=self.device)
+            self.observation_spec[self.pixels_key] = pixels_spec
+        obs_keys = frozenset(self.observation_spec.keys(True, True))
+        self._rename_policy_to_observation = (
+            "policy" not in obs_keys and "observation" in obs_keys
+        )
 
     def _get_tiled_camera(self):
         env = self._env.unwrapped
@@ -344,13 +344,15 @@ class IsaacLabWrapper(GymWrapper):
         return self._normalize_observation_keys(observations)
 
     def _normalize_observation_keys(self, observations):
-        if not isinstance(observations, Mapping):
+        if (
+            not self.__dict__.get("_rename_policy_to_observation", False)
+            or not isinstance(observations, Mapping)
+            or "policy" not in observations
+            or "observation" in observations
+        ):
             return observations
-        spec_keys = set(self.observation_spec.keys(True, True))
-        if "policy" in observations and "policy" not in spec_keys:
-            if "observation" in spec_keys:
-                observations = dict(observations)
-                observations["observation"] = observations.pop("policy")
+        observations = dict(observations)
+        observations["observation"] = observations.pop("policy")
         return observations
 
     def _reset_output_transform(self, reset_data):  # noqa: F811
@@ -379,7 +381,9 @@ class IsaacLabWrapper(GymWrapper):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _supported_isaac_env_classes() -> tuple[type, ...]:
+    def _supported_isaac_env_classes(
+        *, include_direct: bool = True
+    ) -> tuple[type, ...]:
         """Returns the tuple of Isaac Lab env classes this wrapper can bridge.
 
         ``ManagerBasedEnv`` and ``ManagerBasedRLEnv`` (subclass) expose
@@ -389,11 +393,15 @@ class IsaacLabWrapper(GymWrapper):
         """
         from isaaclab.envs import DirectMARLEnv, DirectRLEnv, ManagerBasedEnv
 
-        return (ManagerBasedEnv, DirectRLEnv, DirectMARLEnv)
+        if include_direct:
+            return (ManagerBasedEnv, DirectRLEnv, DirectMARLEnv)
+        return (ManagerBasedEnv,)
 
     @classmethod
-    def _supports_native_autoreset(cls, env: Any) -> bool:
-        """Return ``True`` iff ``env`` (assumed already unwrapped) is a batched Isaac Lab env.
+    def _supports_native_autoreset(
+        cls, env: Any, *, native_autoreset: bool = False
+    ) -> bool:
+        """Return whether ``env`` should receive TorchRL native-autoreset wiring.
 
         This is the single source of truth used by
         :class:`~torchrl.envs.libs.gym._GymAsyncMeta` to decide whether to
@@ -401,14 +409,28 @@ class IsaacLabWrapper(GymWrapper):
         adapter and register the ``_torchrl_native_autoreset`` flag for an
         Isaac Lab env (regardless of whether the env was wrapped via
         :class:`IsaacLabWrapper` or the generic :class:`GymWrapper`).
+        Direct envs are included only when ``native_autoreset=True`` to avoid
+        changing their default reset semantics.
         """
         if not _has_isaaclab:
             return False
-        return isinstance(env, cls._supported_isaac_env_classes())
+        return isinstance(
+            env, cls._supported_isaac_env_classes(include_direct=native_autoreset)
+        )
 
     @property
     def _isaac_unwrapped(self):
         return self._env.unwrapped
+
+    @property
+    def _supports_set_state(self) -> bool:
+        # Supports deterministic resets via ``reset(td, set_state=True,
+        # scene_state=...)`` on manager-based envs. The snapshot is honored
+        # through Isaac's ``reset_to`` rather than from tensordict state entries.
+        env = getattr(self, "_env", None)
+        if env is None:
+            return False
+        return hasattr(env.unwrapped, "reset_to")
 
     # ------------------------------------------------------------------
     # Per-index reset bridge
@@ -448,6 +470,8 @@ class IsaacLabWrapper(GymWrapper):
                     "reset(set_state=True) on an Isaac Lab env requires a "
                     "`scene_state` snapshot (obtained from `env.get_state()`)."
                 )
+            if reset is not None and not reset.any():
+                return tensordict.exclude("_reset")
             return self._reset_to_state_at(
                 scene_state, reset=reset, is_relative=is_relative, **kwargs
             )
@@ -461,12 +485,6 @@ class IsaacLabWrapper(GymWrapper):
                 tensordict = tensordict.exclude("_reset")
             return super()._reset(tensordict, **kwargs)
 
-        if not reset.any():
-            # Nothing to reset: return a sentinel reset tensordict so the
-            # surrounding _reset_proc_data / _update_during_reset machinery
-            # preserves the incoming state on every sub-env.
-            return tensordict.exclude("_reset")
-
         # Per-index reset path. Gated on native_autoreset=True: with
         # native_autoreset=False, partial-mask reset calls are issued by
         # EnvBase.maybe_reset on every step that has any "done" row, and
@@ -476,6 +494,12 @@ class IsaacLabWrapper(GymWrapper):
         # no-op semantics in that case so explicit partial resets
         # remain a feature you opt into via native_autoreset=True.
         if not self._native_autoreset_enabled:
+            return tensordict.exclude("_reset")
+
+        if not reset.any():
+            # Nothing to reset: return a sentinel reset tensordict so the
+            # surrounding _reset_proc_data / _update_during_reset machinery
+            # preserves the incoming state on every sub-env.
             return tensordict.exclude("_reset")
 
         env_ids = self._reset_mask_to_env_ids(reset)

--- a/torchrl/envs/transforms/_base.py
+++ b/torchrl/envs/transforms/_base.py
@@ -1409,6 +1409,16 @@ but got an object of type {type(transform)}."""
         tensordict_reset = self.transform._reset(tensordict, tensordict_reset)
         return tensordict_reset
 
+    def _input_td_has_state(self, tensordict: TensorDictBase | None) -> bool:
+        if tensordict is None:
+            return False
+        state_keys = list(self.state_spec.keys(True, True))
+        if not state_keys:
+            return False
+        tensordict = tensordict.select(*self.reset_keys, *state_keys, strict=False)
+        tensordict = self.transform._reset_env_preprocess(tensordict)
+        return self.base_env._input_td_has_state(tensordict)
+
     def _reset_proc_data(self, tensordict, tensordict_reset):
         # self._complete_done(self.full_done_spec, reset)
         self._reset_check_done(tensordict, tensordict_reset)


### PR DESCRIPTION
## Summary
- keep Isaac Lab Direct envs on their previous default reset path unless `native_autoreset=True` is requested
- avoid implicit `set_state=True` propagation through `TransformedEnv` when the wrapped env does not treat tensordict state keys as reset state
- cache Isaac Lab observation-key normalization and avoid clobbering an existing `observation` key
- avoid extra reset-mask synchronization on the default partial-reset no-op path and make all-false `reset_to_state` masks a no-op

## Tests
- `uv run pytest test/envs/test_env_base.py::TestResetSetState test/libs/test_isaac.py -q`

`uvx ruff check ...` still reports pre-existing file-level issues in `test/envs/test_env_base.py` and `torchrl/envs/libs/gym.py` that are unrelated to this change.
