### PR TITLE
[BugFix] Buffer prefetching off by one

### DIFF
--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -623,6 +623,30 @@ def test_replay_buffer_iter(size, drop_last):
         assert i == (size - 1) // 3
 
 
+def test_replay_buffer_prefetch_queue_length():
+    """Test that the prefetch queue maintains the correct length.
+    
+    This test verifies that after sampling from a replay buffer with prefetching
+    enabled, the prefetch queue has exactly `prefetch` items computing in the
+    background (no off-by-one error).
+    """
+    torch.manual_seed(0)
+    
+    rb = ReplayBuffer(
+        storage=ListStorage(max_size=100),
+        batch_size=2,
+        prefetch=2
+    )
+
+    rb.extend(torch.arange(100))
+
+    _ = rb.sample()
+
+    assert len(rb._prefetch_queue) == 2, (
+        f"Expected prefetch queue to have 2 items, but got {len(rb._prefetch_queue)}."
+    )
+
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -625,26 +625,22 @@ def test_replay_buffer_iter(size, drop_last):
 
 def test_replay_buffer_prefetch_queue_length():
     """Test that the prefetch queue maintains the correct length.
-    
+
     This test verifies that after sampling from a replay buffer with prefetching
     enabled, the prefetch queue has exactly `prefetch` items computing in the
     background (no off-by-one error).
     """
     torch.manual_seed(0)
-    
-    rb = ReplayBuffer(
-        storage=ListStorage(max_size=100),
-        batch_size=2,
-        prefetch=2
-    )
+
+    rb = ReplayBuffer(storage=ListStorage(max_size=100), batch_size=2, prefetch=2)
 
     rb.extend(torch.arange(100))
 
     _ = rb.sample()
 
-    assert len(rb._prefetch_queue) == 2, (
-        f"Expected prefetch queue to have 2 items, but got {len(rb._prefetch_queue)}."
-    )
+    assert (
+        len(rb._prefetch_queue) == 2
+    ), f"Expected prefetch queue to have 2 items, but got {len(rb._prefetch_queue)}."
 
 
 if __name__ == "__main__":

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -1154,14 +1154,17 @@ class ReplayBuffer:
             result = self._sample(batch_size)
         else:
             with self._futures_lock:
+                if len(self._prefetch_queue):
+                    result = self._prefetch_queue.popleft().result()
+                else:
+                    result = self._sample(batch_size)
                 while (
                     len(self._prefetch_queue)
                     < min(self._sampler._remaining_batches, self._prefetch_cap)
                     and not self._sampler.ran_out
-                ) or not len(self._prefetch_queue):
+                ):
                     fut = self._prefetch_executor.submit(self._sample, batch_size)
                     self._prefetch_queue.append(fut)
-                result = self._prefetch_queue.popleft().result()
 
         if return_info:
             out, info = result


### PR DESCRIPTION
## Description

This PR refactors the multithreaded prefetching logic in ReplayBuffer._sample to resolve an off-by-one error.

## Motivation and Context
 close #3870 

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
