### PR TITLE
[Feature] Add async policy-server collector benchmark prototype

### DIFF
--- a/benchmarks/bench_collectors.py
+++ b/benchmarks/bench_collectors.py
@@ -1,72 +1,100 @@
-"""Benchmark: AsyncBatchedCollector vs Collector vs MultiCollector.
+"""Benchmark async policy-server collection against synchronous ParallelEnv.
 
-Supports a mock pixel environment or a real Atari env (ALE/Pong-v5)
-paired with a Nature-CNN policy.
+The default path is portable and uses a fake pixel environment with
+configurable environment and policy latency. Optional MuJoCo/Gymnasium pixel
+rendering can be enabled with ``--env gym-mujoco --from-pixels`` and, on Linux
+CUDA hosts, ``--mujoco-gl egl``.
 
-Usage:
-    python benchmarks/bench_collectors.py                    # mock env
-    python benchmarks/bench_collectors.py --env ALE/Pong-v5  # real Atari
-
-Collectors tested:
-  1. Collector (1 env)                  -- single-process, single env
-  2. Collector (ParallelEnv x N)        -- single-process, N envs in sub-procs
-  3. MultiCollector (sync, x N)         -- N sub-processes, sync delivery
-  4. MultiCollector (async, x N)        -- N sub-processes, async delivery
-  5. AsyncBatched (env=thread, pol=thread)  -- threading pool + threading transport
-  6. AsyncBatched (env=mp, pol=thread)      -- multiprocessing pool + threading transport
+Examples:
+    python benchmarks/bench_collectors.py --total-frames 2000
+    python benchmarks/bench_collectors.py --num-envs 1,2,4,8 --policy-delay-ms 20
+    MUJOCO_GL=egl python benchmarks/bench_collectors.py \
+        --env gym-mujoco --from-pixels --mujoco-gl egl --policy-device cuda:0
 """
 from __future__ import annotations
 
 import argparse
+import csv
+import importlib.util
+import json
+import os
 import time as time_module
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
 
 import torch
 import torch.nn as nn
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 
-from torchrl.collectors import AsyncBatchedCollector, Collector, MultiCollector
-from torchrl.data import Categorical, Composite, Unbounded
-from torchrl.envs import EnvBase, ParallelEnv
-from torchrl.envs.utils import check_env_specs
+from torchrl.collectors import AsyncBatchedCollector, Collector
+from torchrl.data import Bounded, Categorical, Composite, Unbounded
+from torchrl.envs import (
+    EnvBase,
+    GymEnv,
+    ParallelEnv,
+    Resize,
+    StepCounter,
+    ToTensorImage,
+    TransformedEnv,
+)
 from torchrl.modules import ConvNet, MLP
 
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
-NUM_ENVS = 8
-FRAMES_PER_BATCH = 800
-TOTAL_FRAMES = 8_000
-WARMUP_BATCHES = NUM_ENVS
-OBS_SHAPE = (4, 84, 84)  # used by mock env and policy
-NUM_ACTIONS = 6
+OBS_SHAPE = (3, 84, 84)
+ACTION_DIM = 6
 MAX_STEPS = 200
 
 
-# ---------------------------------------------------------------------------
-# Mock pixel environment (for --env mock)
-# ---------------------------------------------------------------------------
+@dataclass
+class BenchmarkResult:
+    collector: str
+    backend: str
+    batch_rule: str
+    env: str
+    num_envs: int
+    frames_per_batch: int
+    total_frames: int
+    policy_device: str
+    output_device: str
+    env_step_latency_ms: float
+    policy_delay_ms: float
+    status: str
+    frames: int = 0
+    elapsed_s: float = 0.0
+    frames_per_s: float = 0.0
+    decisions_per_s: float = 0.0
+    failure: str = ""
+    policy_stats: dict[str, float | int] = field(default_factory=dict)
 
 
 class PixelMockEnv(EnvBase):
-    """Fake pixel env producing (4, 84, 84) float observations with configurable step cost."""
+    """Fake pixel env producing configurable-latency continuous-control data."""
 
-    def __init__(self, max_steps=MAX_STEPS, step_cost=0.001, **kwargs):
+    def __init__(
+        self,
+        *,
+        max_steps: int = MAX_STEPS,
+        step_latency_s: float = 0.001,
+        action_dim: int = ACTION_DIM,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self.max_steps = max_steps
-        self.step_cost = step_cost
+        self.step_latency_s = step_latency_s
+        self.action_dim = action_dim
         self.observation_spec = Composite(
             pixels=Unbounded(
                 shape=(*self.batch_size, *OBS_SHAPE),
-                dtype=torch.float32,
+                dtype=torch.uint8,
                 device=self.device,
             ),
             shape=self.batch_size,
         )
-        self.action_spec = Categorical(
-            n=NUM_ACTIONS,
-            shape=(*self.batch_size,),
-            dtype=torch.int64,
+        self.action_spec = Bounded(
+            low=-1.0,
+            high=1.0,
+            shape=(*self.batch_size, action_dim),
+            dtype=torch.float32,
             device=self.device,
         )
         self.reward_spec = Unbounded(
@@ -82,14 +110,23 @@ class PixelMockEnv(EnvBase):
         )
         self._step_count = 0
 
-    def _set_seed(self, seed):
+    def _set_seed(self, seed: int) -> None:
         torch.manual_seed(seed)
 
-    def _reset(self, tensordict=None, **kwargs):
+    def _make_pixels(self) -> torch.Tensor:
+        return torch.randint(
+            0,
+            256,
+            (*self.batch_size, *OBS_SHAPE),
+            dtype=torch.uint8,
+            device=self.device,
+        )
+
+    def _reset(self, tensordict=None, **kwargs) -> TensorDict:
         self._step_count = 0
         return TensorDict(
             {
-                "pixels": torch.randn(*self.batch_size, *OBS_SHAPE, device=self.device),
+                "pixels": self._make_pixels(),
                 "done": torch.zeros(
                     *self.batch_size, 1, dtype=torch.bool, device=self.device
                 ),
@@ -101,14 +138,14 @@ class PixelMockEnv(EnvBase):
             device=self.device,
         )
 
-    def _step(self, tensordict):
-        if self.step_cost > 0:
-            time_module.sleep(self.step_cost)
+    def _step(self, tensordict: TensorDict) -> TensorDict:
+        if self.step_latency_s > 0:
+            time_module.sleep(self.step_latency_s)
         self._step_count += 1
         done = self._step_count >= self.max_steps
         return TensorDict(
             {
-                "pixels": torch.randn(*self.batch_size, *OBS_SHAPE, device=self.device),
+                "pixels": self._make_pixels(),
                 "reward": torch.randn(*self.batch_size, 1, device=self.device),
                 "done": torch.full(
                     (*self.batch_size, 1), done, dtype=torch.bool, device=self.device
@@ -122,298 +159,512 @@ class PixelMockEnv(EnvBase):
         )
 
 
-# ---------------------------------------------------------------------------
-# Atari env factory (for --env ALE/Pong-v5 etc.)
-# ---------------------------------------------------------------------------
+@dataclass
+class EnvFactory:
+    env: str = "fake-pixels"
+    gym_id: str = "HalfCheetah-v4"
+    from_pixels: bool = False
+    max_steps: int = MAX_STEPS
+    step_latency_s: float = 0.001
+    action_dim: int = ACTION_DIM
+
+    def __call__(self) -> EnvBase:
+        if self.env == "fake-pixels":
+            return PixelMockEnv(
+                max_steps=self.max_steps,
+                step_latency_s=self.step_latency_s,
+                action_dim=self.action_dim,
+            )
+        if self.env == "gym-mujoco":
+            env = GymEnv(
+                self.gym_id,
+                from_pixels=self.from_pixels,
+                pixels_only=False,
+            )
+            env = TransformedEnv(env, StepCounter(max_steps=self.max_steps))
+            if self.from_pixels:
+                env.append_transform(ToTensorImage())
+                env.append_transform(Resize(OBS_SHAPE[-2], OBS_SHAPE[-1]))
+            return env
+        raise ValueError(f"Unknown env {self.env!r}.")
 
 
-def make_atari_env(env_name, frame_skip=4):
-    """Atari env with standard DQN preprocessing pipeline."""
-    from torchrl.envs import (
-        CatFrames,
-        DoubleToFloat,
-        GrayScale,
-        GymEnv,
-        Resize,
-        StepCounter,
-        ToTensorImage,
-        TransformedEnv,
-    )
+class LatencyHead(nn.Module):
+    """Pixel policy head with configurable VLA-like latency."""
 
-    env = GymEnv(
-        env_name,
-        frame_skip=frame_skip,
-        from_pixels=True,
-        pixels_only=False,
-        categorical_action_encoding=True,
-    )
-    env = TransformedEnv(env)
-    env.append_transform(ToTensorImage())
-    env.append_transform(GrayScale())
-    env.append_transform(Resize(84, 84))
-    env.append_transform(CatFrames(N=4, dim=-3))
-    env.append_transform(StepCounter(max_steps=MAX_STEPS))
-    env.append_transform(DoubleToFloat())
-    return env
-
-
-# ---------------------------------------------------------------------------
-# Policy (module-level so it's picklable by MultiCollector)
-# ---------------------------------------------------------------------------
-
-
-class ArgmaxHead(nn.Module):
-    """Wraps a Q-network and returns the argmax action."""
-
-    def __init__(self, net):
+    def __init__(self, net: nn.Module, *, delay_s: float = 0.0) -> None:
         super().__init__()
         self.net = net
+        self.delay_s = delay_s
 
-    def forward(self, pixels):
-        logits = self.net(pixels)
-        return logits.argmax(dim=-1)
-
-
-# ---------------------------------------------------------------------------
-# Picklable env factory (module-level for multiprocessing)
-# ---------------------------------------------------------------------------
-
-_ENV_NAME = "mock"  # set by main() before any collector is created
-
-
-def make_env_fn():
-    """Module-level factory dispatching on _ENV_NAME."""
-    if _ENV_NAME == "mock":
-        return PixelMockEnv()
-    return make_atari_env(_ENV_NAME)
+    def forward(self, pixels: torch.Tensor) -> torch.Tensor:
+        if torch.is_floating_point(pixels):
+            pixels = pixels.to(torch.float32)
+        else:
+            pixels = pixels.to(torch.float32) / 255.0
+        action = torch.tanh(self.net(pixels))
+        if self.delay_s > 0:
+            if action.is_cuda:
+                torch.cuda.synchronize(action.device)
+            time_module.sleep(self.delay_s)
+        return action
 
 
-# ---------------------------------------------------------------------------
+@dataclass
+class PolicyFactory:
+    action_dim: int = ACTION_DIM
+    delay_s: float = 0.0
+
+    def __call__(self) -> TensorDictModule:
+        cnn = ConvNet(
+            activation_class=nn.ReLU,
+            num_cells=[16, 32, 32],
+            kernel_sizes=[8, 4, 3],
+            strides=[4, 2, 1],
+        )
+        with torch.no_grad():
+            cnn_out = cnn(torch.ones(OBS_SHAPE, dtype=torch.float32))
+        mlp = MLP(
+            in_features=cnn_out.shape[-1],
+            activation_class=nn.ReLU,
+            out_features=self.action_dim,
+            num_cells=[256],
+        )
+        return TensorDictModule(
+            LatencyHead(nn.Sequential(cnn, mlp), delay_s=self.delay_s),
+            in_keys=["pixels"],
+            out_keys=["action"],
+        )
 
 
-def make_policy(num_actions=NUM_ACTIONS):
-    """Nature-CNN: Conv(32,64,64) + MLP(512) -> argmax action."""
-    cnn = ConvNet(
-        activation_class=nn.ReLU,
-        num_cells=[32, 64, 64],
-        kernel_sizes=[8, 4, 3],
-        strides=[4, 2, 1],
-    )
-    with torch.no_grad():
-        cnn_out = cnn(torch.ones(OBS_SHAPE))
-    mlp = MLP(
-        in_features=cnn_out.shape[-1],
-        activation_class=nn.ReLU,
-        out_features=num_actions,
-        num_cells=[512],
-    )
-    return TensorDictModule(
-        ArgmaxHead(nn.Sequential(cnn, mlp)),
-        in_keys=["pixels"],
-        out_keys=["action"],
-    )
+def _parse_int_list(value: str) -> list[int]:
+    return [int(item) for item in value.split(",") if item]
 
 
-# ---------------------------------------------------------------------------
-# Harness
-# ---------------------------------------------------------------------------
+def _parse_backend_list(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
 
 
-def bench(name: str, factory, warmup=WARMUP_BATCHES, target_frames=TOTAL_FRAMES):
-    print(f"\n{'=' * 60}")
-    print(f"  {name}")
-    print(f"{'=' * 60}")
+def _auto_policy_device() -> str:
+    if torch.cuda.is_available():
+        return "cuda:0"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
 
-    collector = factory()
-    total = 0
-    idx = 0
-    t0 = None
 
+def _check_optional_env(factory: EnvFactory) -> tuple[bool, str, int]:
+    if factory.env == "fake-pixels":
+        return True, "", factory.action_dim
+    if factory.env == "gym-mujoco":
+        if importlib.util.find_spec("gymnasium") is None and importlib.util.find_spec(
+            "gym"
+        ) is None:
+            return False, "gymnasium/gym is not installed", factory.action_dim
+        if importlib.util.find_spec("mujoco") is None:
+            return False, "mujoco is not installed", factory.action_dim
     try:
-        for batch in collector:
-            idx += 1
+        env = factory()
+        action_shape = env.action_spec.shape
+        action_dim = int(action_shape[-1]) if action_shape else factory.action_dim
+        env.close()
+    except Exception as err:
+        return False, repr(err), factory.action_dim
+    return True, "", action_dim
+
+
+def bench(
+    *,
+    name: str,
+    backend: str,
+    batch_rule: str,
+    factory,
+    env_name: str,
+    num_envs: int,
+    frames_per_batch: int,
+    total_frames: int,
+    policy_device: str,
+    output_device: str,
+    env_step_latency_ms: float,
+    policy_delay_ms: float,
+    warmup_batches: int,
+) -> BenchmarkResult:
+    collector = None
+    total = 0
+    t0 = None
+    policy_stats: dict[str, float | int] = {}
+    try:
+        collector = factory()
+        iterator = iter(collector)
+        for _ in range(warmup_batches):
+            next(iterator)
+        t0 = time_module.perf_counter()
+        for batch in iterator:
             n = batch.numel()
-            if idx <= warmup:
-                print(f"  [warmup {idx}/{warmup}] {n} frames")
-                continue
-            if t0 is None:
-                t0 = time_module.perf_counter()
             total += n
-            elapsed_so_far = time_module.perf_counter() - t0
-            fps_so_far = total / elapsed_so_far if elapsed_so_far > 0 else 0
-            print(f"  [batch {idx}] {n} frames  total={total}  ({fps_so_far:.0f} fps)")
-            if total >= target_frames:
+            if total >= total_frames:
                 break
-    except Exception as e:
-        print(f"  ERROR: {e}")
-        import traceback
-
-        traceback.print_exc()
+        if collector is not None and hasattr(collector, "server_stats"):
+            policy_stats = collector.server_stats()
+        elapsed = time_module.perf_counter() - t0 if t0 is not None else 0.0
+        fps = total / elapsed if elapsed > 0 else 0.0
+        return BenchmarkResult(
+            collector=name,
+            backend=backend,
+            batch_rule=batch_rule,
+            env=env_name,
+            num_envs=num_envs,
+            frames_per_batch=frames_per_batch,
+            total_frames=total_frames,
+            policy_device=policy_device,
+            output_device=output_device,
+            env_step_latency_ms=env_step_latency_ms,
+            policy_delay_ms=policy_delay_ms,
+            status="ok",
+            frames=total,
+            elapsed_s=elapsed,
+            frames_per_s=fps,
+            decisions_per_s=fps,
+            policy_stats=policy_stats,
+        )
+    except Exception as err:
+        elapsed = time_module.perf_counter() - t0 if t0 is not None else 0.0
+        return BenchmarkResult(
+            collector=name,
+            backend=backend,
+            batch_rule=batch_rule,
+            env=env_name,
+            num_envs=num_envs,
+            frames_per_batch=frames_per_batch,
+            total_frames=total_frames,
+            policy_device=policy_device,
+            output_device=output_device,
+            env_step_latency_ms=env_step_latency_ms,
+            policy_delay_ms=policy_delay_ms,
+            status="error",
+            frames=total,
+            elapsed_s=elapsed,
+            frames_per_s=total / elapsed if elapsed > 0 else 0.0,
+            decisions_per_s=total / elapsed if elapsed > 0 else 0.0,
+            failure=repr(err),
+            policy_stats=policy_stats,
+        )
     finally:
-        elapsed = time_module.perf_counter() - t0 if t0 is not None else float("inf")
-        try:
-            collector.shutdown()
-        except Exception:
-            pass
-
-    fps = total / elapsed if elapsed > 0 else 0
-    print(f"  --> {total} frames in {elapsed:.2f}s = {fps:.0f} fps")
-    return name, fps, elapsed, total
+        if collector is not None:
+            try:
+                collector.shutdown()
+            except Exception:
+                pass
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Collector throughput benchmark")
-    parser.add_argument(
-        "--env",
-        default="mock",
-        help="Environment: 'mock' for PixelMockEnv, or a gym env id like 'ALE/Pong-v5'",
+def _write_results(
+    results: list[BenchmarkResult], jsonl_path: str | None, csv_path: str | None
+) -> None:
+    rows = [asdict(result) for result in results]
+    if jsonl_path:
+        path = Path(jsonl_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w") as file:
+            for row in rows:
+                file.write(json.dumps(row, sort_keys=True) + "\n")
+    if csv_path:
+        path = Path(csv_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        flat_rows = []
+        for row in rows:
+            policy_stats = row.pop("policy_stats")
+            for key, value in policy_stats.items():
+                row[f"policy_{key}"] = value
+            flat_rows.append(row)
+        fieldnames = sorted({key for row in flat_rows for key in row})
+        with path.open("w", newline="") as file:
+            writer = csv.DictWriter(file, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(flat_rows)
+
+
+def _print_summary(results: list[BenchmarkResult]) -> None:
+    print("\nCollector throughput summary")
+    print("=" * 132)
+    print(
+        f"{'collector':<28} {'backend':<16} {'batch rule':<18} "
+        f"{'envs':>5} {'status':<8} {'fps':>10} {'avg_bs':>8} "
+        f"{'p95_q_ms':>10} {'p95_fwd_ms':>11} failure"
     )
-    parser.add_argument("--num-envs", type=int, default=NUM_ENVS)
-    parser.add_argument("--frames-per-batch", type=int, default=FRAMES_PER_BATCH)
-    parser.add_argument("--total-frames", type=int, default=TOTAL_FRAMES)
+    print("-" * 132)
+    for result in results:
+        stats = result.policy_stats
+        print(
+            f"{result.collector:<28} {result.backend:<16} "
+            f"{result.batch_rule:<18} {result.num_envs:>5} "
+            f"{result.status:<8} {result.frames_per_s:>10.1f} "
+            f"{float(stats.get('avg_batch_size', 0.0)):>8.2f} "
+            f"{float(stats.get('p95_queue_ms', 0.0)):>10.2f} "
+            f"{float(stats.get('p95_forward_ms', 0.0)):>11.2f} "
+            f"{result.failure[:60]}"
+        )
+    print("=" * 132)
+
+
+def _resolve_batching_rule(rule: str, num_envs: int) -> tuple[int, int, float, str]:
+    if rule == "no-batch":
+        return 1, 1, 0.001, "max_bs=1"
+    if rule == "auto":
+        return num_envs, 1, 0.001, f"max_bs={num_envs}, min_bs=1"
+    if rule == "min4":
+        min_batch_size = min(4, num_envs)
+        return num_envs, min_batch_size, 0.01, (
+            f"max_bs={num_envs}, min_bs={min_batch_size}"
+        )
+    if rule == "full":
+        return num_envs, num_envs, 0.01, f"max_bs={num_envs}, min_bs={num_envs}"
+    raise ValueError(
+        f"Unknown batching rule {rule!r}. "
+        "Expected one of no-batch, auto, min4, full."
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--env", default="fake-pixels", choices=["fake-pixels", "gym-mujoco"]
+    )
+    parser.add_argument("--gym-id", default="HalfCheetah-v4")
+    parser.add_argument("--from-pixels", action="store_true")
+    parser.add_argument(
+        "--mujoco-gl",
+        default=None,
+        help="Set MUJOCO_GL/PYOPENGL_PLATFORM, e.g. egl",
+    )
+    parser.add_argument("--num-envs", default="1,2,4")
+    parser.add_argument(
+        "--backends",
+        default="parallel,async-thread,async-env-mp,async-process",
+        help="Comma-separated: parallel, async-thread, async-env-mp, async-process",
+    )
+    parser.add_argument(
+        "--batching-rules",
+        default="auto",
+        help=(
+            "Comma-separated async batching rules: no-batch, auto, min4, full. "
+            "ParallelEnv is run once with its synchronous barrier."
+        ),
+    )
+    parser.add_argument("--frames-per-batch", type=int, default=200)
+    parser.add_argument("--total-frames", type=int, default=1000)
+    parser.add_argument("--warmup-batches", type=int, default=1)
+    parser.add_argument("--env-step-latency-ms", type=float, default=1.0)
+    parser.add_argument("--policy-delay-ms", type=float, default=0.0)
+    parser.add_argument("--policy-device", default="auto")
+    parser.add_argument("--output-device", default="cpu")
+    parser.add_argument("--jsonl", default="bench_collectors_results.jsonl")
+    parser.add_argument("--csv", default="bench_collectors_results.csv")
     args = parser.parse_args()
 
-    num_envs = args.num_envs
-    frames_per_batch = args.frames_per_batch
-    total_frames = args.total_frames
+    if args.mujoco_gl:
+        os.environ["MUJOCO_GL"] = args.mujoco_gl
+        os.environ["PYOPENGL_PLATFORM"] = args.mujoco_gl
 
-    # Set module-level env name so make_env_fn is picklable
-    global _ENV_NAME
-    _ENV_NAME = args.env
+    policy_device = (
+        _auto_policy_device() if args.policy_device == "auto" else args.policy_device
+    )
+    output_device = args.output_device
+    num_env_values = _parse_int_list(args.num_envs)
+    backends = _parse_backend_list(args.backends)
+    batching_rules = _parse_backend_list(args.batching_rules)
 
-    if args.env == "mock":
-        env_label = f"PixelMockEnv {OBS_SHAPE}, step_cost=1ms"
-        num_actions = NUM_ACTIONS
-    else:
-        env_label = args.env
-        probe = make_env_fn()
-        num_actions = probe.action_spec.space.n
-        print(
-            f"Env: {args.env}, pixels: {probe.observation_spec['pixels'].shape}, actions: {num_actions}"
-        )
-        probe.close()
-
-    def policy_factory():
-        return make_policy(num_actions=num_actions)
-
-    # Verify
-    env = make_env_fn()
-    check_env_specs(env)
-    env.close()
-
-    results = []
-
-    # All collectors use total_frames=-1 (endless); the bench harness
-    # controls stopping after `target_frames` timed frames so that
-    # warmup batches don't eat into the measurement window.
-
-    # 1. Collector -- single env
-    results.append(
-        bench(
-            "Collector (1 env)",
-            lambda: Collector(
-                create_env_fn=make_env_fn,
-                policy=policy_factory(),
-                frames_per_batch=frames_per_batch,
-                total_frames=-1,
-                trust_policy=True,
-                use_buffers=False,
-            ),
-            target_frames=total_frames,
-        )
+    env_factory = EnvFactory(
+        env=args.env,
+        gym_id=args.gym_id,
+        from_pixels=args.from_pixels or args.env in ("fake-pixels", "gym-mujoco"),
+        step_latency_s=args.env_step_latency_ms / 1000.0,
+    )
+    available, reason, action_dim = _check_optional_env(env_factory)
+    env_factory.action_dim = action_dim
+    policy_factory = PolicyFactory(
+        action_dim=action_dim,
+        delay_s=args.policy_delay_ms / 1000.0,
     )
 
-    # 2. Collector -- ParallelEnv
-    results.append(
-        bench(
-            f"Collector (ParallelEnv x{num_envs})",
-            lambda: Collector(
-                create_env_fn=ParallelEnv(num_envs, make_env_fn),
-                policy=policy_factory(),
-                frames_per_batch=frames_per_batch,
-                total_frames=-1,
-                trust_policy=True,
-                use_buffers=False,
-            ),
-            target_frames=total_frames,
-        )
-    )
+    results: list[BenchmarkResult] = []
+    if not available:
+        for num_envs in num_env_values:
+            for backend in backends:
+                results.append(
+                    BenchmarkResult(
+                        collector=backend,
+                        backend=backend,
+                        batch_rule="",
+                        env=args.env,
+                        num_envs=num_envs,
+                        frames_per_batch=args.frames_per_batch,
+                        total_frames=args.total_frames,
+                        policy_device=policy_device,
+                        output_device=output_device,
+                        env_step_latency_ms=args.env_step_latency_ms,
+                        policy_delay_ms=args.policy_delay_ms,
+                        status="skipped",
+                        failure=reason,
+                    )
+                )
+        _print_summary(results)
+        _write_results(results, args.jsonl, args.csv)
+        return
 
-    # 3. MultiCollector sync
-    results.append(
-        bench(
-            f"MultiCollector sync (x{num_envs})",
-            lambda: MultiCollector(
-                create_env_fn=[make_env_fn] * num_envs,
-                policy_factory=policy_factory,
-                frames_per_batch=frames_per_batch,
-                total_frames=-1,
-                sync=True,
-            ),
-            target_frames=total_frames,
-        )
-    )
+    for num_envs in num_env_values:
+        for backend in backends:
+            if backend == "parallel":
+                results.append(
+                    bench(
+                        name="Collector + ParallelEnv",
+                        backend=backend,
+                        batch_rule="sync barrier",
+                        factory=lambda: Collector(
+                            create_env_fn=ParallelEnv(num_envs, env_factory),
+                            policy=policy_factory(),
+                            frames_per_batch=args.frames_per_batch,
+                            total_frames=-1,
+                            policy_device=policy_device,
+                            env_device=output_device,
+                            storing_device=output_device,
+                            trust_policy=True,
+                            use_buffers=False,
+                            auto_register_policy_transforms=False,
+                        ),
+                        env_name=args.env,
+                        num_envs=num_envs,
+                        frames_per_batch=args.frames_per_batch,
+                        total_frames=args.total_frames,
+                        policy_device=policy_device,
+                        output_device=output_device,
+                        env_step_latency_ms=args.env_step_latency_ms,
+                        policy_delay_ms=args.policy_delay_ms,
+                        warmup_batches=args.warmup_batches,
+                    )
+                )
+            elif backend == "async-thread":
+                for rule in batching_rules:
+                    max_batch_size, min_batch_size, timeout, label = (
+                        _resolve_batching_rule(rule, num_envs)
+                    )
+                    results.append(
+                        bench(
+                            name="AsyncBatched thread env",
+                            backend=backend,
+                            batch_rule=label,
+                            factory=lambda: AsyncBatchedCollector(
+                                create_env_fn=[env_factory] * num_envs,
+                                policy=policy_factory(),
+                                frames_per_batch=args.frames_per_batch,
+                                total_frames=-1,
+                                max_batch_size=max_batch_size,
+                                min_batch_size=min_batch_size,
+                                server_timeout=timeout,
+                                env_backend="threading",
+                                server_backend="thread",
+                                policy_device=policy_device,
+                                output_device=output_device,
+                            ),
+                            env_name=args.env,
+                            num_envs=num_envs,
+                            frames_per_batch=args.frames_per_batch,
+                            total_frames=args.total_frames,
+                            policy_device=policy_device,
+                            output_device=output_device,
+                            env_step_latency_ms=args.env_step_latency_ms,
+                            policy_delay_ms=args.policy_delay_ms,
+                            warmup_batches=args.warmup_batches,
+                        )
+                    )
+            elif backend == "async-env-mp":
+                for rule in batching_rules:
+                    max_batch_size, min_batch_size, timeout, label = (
+                        _resolve_batching_rule(rule, num_envs)
+                    )
+                    results.append(
+                        bench(
+                            name="AsyncBatched mp env",
+                            backend=backend,
+                            batch_rule=label,
+                            factory=lambda: AsyncBatchedCollector(
+                                create_env_fn=[env_factory] * num_envs,
+                                policy=policy_factory(),
+                                frames_per_batch=args.frames_per_batch,
+                                total_frames=-1,
+                                max_batch_size=max_batch_size,
+                                min_batch_size=min_batch_size,
+                                server_timeout=timeout,
+                                env_backend="multiprocessing",
+                                server_backend="thread",
+                                policy_device=policy_device,
+                                output_device=output_device,
+                            ),
+                            env_name=args.env,
+                            num_envs=num_envs,
+                            frames_per_batch=args.frames_per_batch,
+                            total_frames=args.total_frames,
+                            policy_device=policy_device,
+                            output_device=output_device,
+                            env_step_latency_ms=args.env_step_latency_ms,
+                            policy_delay_ms=args.policy_delay_ms,
+                            warmup_batches=args.warmup_batches,
+                        )
+                    )
+            elif backend == "async-process":
+                for rule in batching_rules:
+                    max_batch_size, min_batch_size, timeout, label = (
+                        _resolve_batching_rule(rule, num_envs)
+                    )
+                    results.append(
+                        bench(
+                            name="AsyncBatched process server",
+                            backend=backend,
+                            batch_rule=label,
+                            factory=lambda: AsyncBatchedCollector(
+                                create_env_fn=[env_factory] * num_envs,
+                                policy_factory=policy_factory,
+                                frames_per_batch=args.frames_per_batch,
+                                total_frames=-1,
+                                max_batch_size=max_batch_size,
+                                min_batch_size=min_batch_size,
+                                server_timeout=timeout,
+                                env_backend="multiprocessing",
+                                server_backend="process",
+                                policy_device=policy_device,
+                                output_device=output_device,
+                            ),
+                            env_name=args.env,
+                            num_envs=num_envs,
+                            frames_per_batch=args.frames_per_batch,
+                            total_frames=args.total_frames,
+                            policy_device=policy_device,
+                            output_device=output_device,
+                            env_step_latency_ms=args.env_step_latency_ms,
+                            policy_delay_ms=args.policy_delay_ms,
+                            warmup_batches=args.warmup_batches,
+                        )
+                    )
+            else:
+                results.append(
+                    BenchmarkResult(
+                        collector=backend,
+                        backend=backend,
+                        batch_rule="",
+                        env=args.env,
+                        num_envs=num_envs,
+                        frames_per_batch=args.frames_per_batch,
+                        total_frames=args.total_frames,
+                        policy_device=policy_device,
+                        output_device=output_device,
+                        env_step_latency_ms=args.env_step_latency_ms,
+                        policy_delay_ms=args.policy_delay_ms,
+                        status="skipped",
+                        failure=f"unknown backend {backend!r}",
+                    )
+                )
 
-    # 4. MultiCollector async
-    results.append(
-        bench(
-            f"MultiCollector async (x{num_envs})",
-            lambda: MultiCollector(
-                create_env_fn=[make_env_fn] * num_envs,
-                policy_factory=policy_factory,
-                frames_per_batch=frames_per_batch,
-                total_frames=-1,
-                sync=False,
-            ),
-            target_frames=total_frames,
-        )
-    )
-
-    # 5. AsyncBatchedCollector (env=threading, policy=threading)
-    results.append(
-        bench(
-            f"AsyncBatched env=thread pol=thread (x{num_envs})",
-            lambda: AsyncBatchedCollector(
-                create_env_fn=[make_env_fn] * num_envs,
-                policy=policy_factory(),
-                frames_per_batch=frames_per_batch,
-                total_frames=-1,
-                max_batch_size=num_envs,
-                env_backend="threading",
-            ),
-            target_frames=total_frames,
-        )
-    )
-
-    # 6. AsyncBatchedCollector (env=multiprocessing, policy=threading)
-    results.append(
-        bench(
-            f"AsyncBatched env=mp pol=thread (x{num_envs})",
-            lambda: AsyncBatchedCollector(
-                create_env_fn=[make_env_fn] * num_envs,
-                policy=policy_factory(),
-                frames_per_batch=frames_per_batch,
-                total_frames=-1,
-                max_batch_size=num_envs,
-                env_backend="multiprocessing",
-            ),
-            target_frames=total_frames,
-        )
-    )
-
-    # Summary
-    print("\n")
-    print("=" * 70)
-    print("  THROUGHPUT SUMMARY  (higher FPS is better)")
-    print(f"  Env: {env_label}")
-    print(f"  Nature-CNN policy, {num_envs} envs")
-    print(f"  {total_frames} total frames, {frames_per_batch} frames/batch")
-    print("=" * 70)
-    print(f"  {'Collector':<45s} {'FPS':>8s}  {'Time':>7s}")
-    print(f"  {'-' * 45} {'-' * 8}  {'-' * 7}")
-    for name, fps, elapsed, _total in sorted(results, key=lambda x: -x[1]):
-        print(f"  {name:<45s} {fps:>8.0f}  {elapsed:>6.2f}s")
-    print()
+    _print_summary(results)
+    _write_results(results, args.jsonl, args.csv)
 
 
 if __name__ == "__main__":

--- a/docs/source/reference/modules_inference_server.rst
+++ b/docs/source/reference/modules_inference_server.rst
@@ -17,6 +17,7 @@ Core API
     :template: rl_template_noinherit.rst
 
     InferenceServer
+    ProcessInferenceServer
     InferenceClient
     InferenceTransport
 

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -22,6 +22,7 @@ from torchrl.modules.inference_server import (
     InferenceServer,
     InferenceTransport,
     MPTransport,
+    ProcessInferenceServer,
     RayTransport,
     SlotTransport,
     ThreadingTransport,
@@ -211,6 +212,67 @@ class TestInferenceServerCore:
 
         for s in seen_sizes:
             assert s <= max_bs
+
+    def test_policy_and_output_device_handoff(self):
+        device = "mps" if torch.backends.mps.is_available() else "cpu"
+        transport = ThreadingTransport()
+        policy = _make_policy()
+        with InferenceServer(
+            policy,
+            transport,
+            max_batch_size=4,
+            policy_device=device,
+            output_device="cpu",
+        ):
+            client = transport.client()
+            td = TensorDict({"observation": torch.randn(4)}, device="cpu")
+            result = client(td)
+        assert result["action"].device.type == "cpu"
+        assert next(policy.parameters()).device.type == torch.device(device).type
+
+    def test_stats_accounting(self):
+        transport = ThreadingTransport()
+        policy = _make_policy()
+        n = 8
+        with InferenceServer(
+            policy,
+            transport,
+            max_batch_size=n,
+            min_batch_size=4,
+            timeout=0.5,
+        ) as server:
+            client = transport.client()
+            with concurrent.futures.ThreadPoolExecutor(max_workers=n) as pool:
+                futs = [
+                    pool.submit(
+                        lambda: client(TensorDict({"observation": torch.randn(4)}))
+                    )
+                    for _ in range(n)
+                ]
+                for fut in futs:
+                    fut.result(timeout=5.0)
+            stats = server.stats()
+        assert stats["requests"] == n
+        assert stats["batches"] >= 1
+        assert stats["avg_batch_size"] > 0
+        assert stats["p95_forward_ms"] >= 0
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    def test_cuda_policy_cpu_output(self):
+        transport = ThreadingTransport()
+        policy = _make_policy()
+        with InferenceServer(
+            policy,
+            transport,
+            max_batch_size=4,
+            policy_device="cuda:0",
+            output_device="cpu",
+        ):
+            client = transport.client()
+            result = client(TensorDict({"observation": torch.randn(4)}, device="cpu"))
+        assert result["action"].device.type == "cpu"
+        assert next(policy.parameters()).device.type == "cuda"
 
 
 class TestInferenceClient:
@@ -709,6 +771,51 @@ def _make_counting_policy():
     return _BatchCountingPolicy()
 
 
+class _BadProcessPolicy(nn.Module):
+    def forward(self, td: TensorDictBase) -> TensorDictBase:
+        raise RuntimeError("process model crash")
+
+
+def _make_bad_process_policy():
+    return _BadProcessPolicy()
+
+
+class TestProcessInferenceServer:
+    def test_process_server_start_shutdown(self):
+        ctx = mp.get_context("spawn")
+        transport = MPTransport(ctx=ctx)
+        client = transport.client()
+        with ProcessInferenceServer(
+            policy_factory=_make_counting_policy,
+            transport=transport,
+            max_batch_size=4,
+            mp_context=ctx,
+        ) as server:
+            assert server.is_alive
+            assert server.stats() == {}
+            result = client(TensorDict({"observation": torch.ones(1)}))
+        assert "action" in result.keys()
+        assert result["action"].shape == (1,)
+        assert not server.is_alive
+
+    def test_process_server_exception_propagates(self):
+        ctx = mp.get_context("spawn")
+        transport = MPTransport(ctx=ctx)
+        client = transport.client()
+        server = ProcessInferenceServer(
+            policy_factory=_make_bad_process_policy,
+            transport=transport,
+            max_batch_size=4,
+            mp_context=ctx,
+        )
+        server.start()
+        try:
+            with pytest.raises(RuntimeError, match="process model crash"):
+                client(TensorDict({"observation": torch.ones(1)}))
+        finally:
+            server.shutdown()
+
+
 class TestAsyncBatchedCollector:
     """Tests for :class:`AsyncBatchedCollector`."""
 
@@ -731,8 +838,10 @@ class TestAsyncBatchedCollector:
         for batch in collector:
             assert batch is not None
             total_collected += batch.numel()
+        stats = collector.server_stats()
         collector.shutdown()
         assert total_collected >= total_frames
+        assert stats["requests"] > 0
 
     def test_policy_factory(self):
         """policy_factory is called to create the policy."""
@@ -860,6 +969,40 @@ class TestAsyncBatchedCollector:
             pass
         collector.shutdown()
         assert called["count"] >= 1
+
+    @pytest.mark.parametrize("env_backend", ["threading", "multiprocessing"])
+    def test_env_backend_smoke(self, env_backend):
+        """Thread and multiprocessing env backends collect data."""
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * 2,
+            policy=_make_counting_policy(),
+            frames_per_batch=10,
+            total_frames=20,
+            max_batch_size=2,
+            env_backend=env_backend,
+        )
+        total = 0
+        for batch in collector:
+            total += batch.numel()
+        collector.shutdown()
+        assert total >= 20
+
+    def test_process_server_backend_smoke(self):
+        """Dedicated process server works through AsyncBatchedCollector."""
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * 2,
+            policy_factory=_make_counting_policy,
+            frames_per_batch=10,
+            total_frames=20,
+            max_batch_size=2,
+            env_backend="threading",
+            server_backend="process",
+        )
+        total = 0
+        for batch in collector:
+            total += batch.numel()
+        collector.shutdown()
+        assert total >= 20
 
 
 # =============================================================================
@@ -1042,3 +1185,7 @@ class TestWorkerCrashPropagation:
             for _ in collector:
                 pass
         collector.shutdown()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -16,7 +16,11 @@ from tensordict import lazy_stack, TensorDictBase
 from torchrl._utils import _maybe_record_function_decorator, logger as torchrl_logger
 from torchrl.collectors._base import BaseCollector
 from torchrl.envs import AsyncEnvPool, EnvBase
-from torchrl.modules.inference_server import InferenceServer, ThreadingTransport
+from torchrl.modules.inference_server import (
+    InferenceServer,
+    ProcessInferenceServer,
+    ThreadingTransport,
+)
 from torchrl.modules.inference_server._transport import InferenceTransport
 
 _ENV_IDX_KEY = "env_index"
@@ -64,7 +68,8 @@ def _make_transport(
 def _env_loop(
     pool: AsyncEnvPool,
     env_id: int,
-    transport: InferenceTransport,
+    transport: InferenceTransport | None,
+    client: Callable | None,
     result_queue: queue.Queue,
     shutdown_event: threading.Event,
 ):
@@ -77,7 +82,8 @@ def _env_loop(
 
         reset -> infer (blocking) -> step_send -> step_recv -> put transition -> infer -> ...
     """
-    client = transport.client()
+    if client is None:
+        client = transport.client()
 
     try:
         pool.async_reset_send(env_index=env_id)
@@ -153,7 +159,13 @@ class AsyncBatchedCollector(BaseCollector):
             ``policy_backend``.  When ``None`` (default) a transport is
             created automatically from the resolved ``policy_backend``.
         device (torch.device or str, optional): device for policy inference.
-            Passed to the inference server.  Defaults to ``None``.
+            Kept as an alias for ``policy_device``.  Defaults to ``None``.
+        policy_device (torch.device or str, optional): device used by the
+            inference server for policy execution.  If omitted, ``device`` is
+            used.
+        output_device (torch.device or str, optional): device where action
+            TensorDicts are moved before being sent back to env workers.
+            Defaults to ``None``.
         backend (str, optional): global default backend for both
             environments and policy inference.  Specific overrides
             ``env_backend`` and ``policy_backend`` take precedence when set.
@@ -170,6 +182,11 @@ class AsyncBatchedCollector(BaseCollector):
             ``"threading"``, ``"multiprocessing"``, ``"ray"``, or
             ``"monarch"``.  Falls back to ``backend`` when ``None``.
             Defaults to ``None``.
+        server_backend (str, optional): execution backend for the policy
+            server itself. ``"thread"`` runs the server loop in a background
+            thread in this process. ``"process"`` runs a dedicated process and
+            requires ``policy_factory`` with a multiprocessing policy
+            transport. Defaults to ``"thread"``.
         reset_at_each_iter (bool, optional): whether to reset all envs at the
             start of every collection batch.  Defaults to ``False``.
         postproc (Callable, optional): post-processing transform applied to
@@ -236,14 +253,23 @@ class AsyncBatchedCollector(BaseCollector):
         weight_sync_model_id: str = "policy",
         verbose: bool = False,
         create_env_kwargs: dict | list[dict] | None = None,
+        policy_device: torch.device | str | None = None,
+        output_device: torch.device | str | None = None,
+        server_backend: Literal["thread", "process"] = "thread",
     ):
         if policy is not None and policy_factory is not None:
             raise TypeError("policy and policy_factory are mutually exclusive.")
         if policy is None and policy_factory is None:
             raise TypeError("One of policy or policy_factory must be provided.")
+        if server_backend == "process" and policy_factory is None:
+            raise TypeError(
+                "server_backend='process' requires policy_factory so the policy "
+                "can be constructed inside the server process."
+            )
 
         # ---- resolve policy ---------------------------------------------------
-        if policy_factory is not None:
+        self._policy_factory = policy_factory
+        if policy_factory is not None and server_backend != "process":
             policy = policy_factory()
         self._policy = policy
 
@@ -265,6 +291,14 @@ class AsyncBatchedCollector(BaseCollector):
                 f"Expected one of {_ENV_BACKENDS}."
             )
         self._env_backend = effective_env_backend
+        self._server_backend = server_backend
+        if server_backend == "process":
+            if policy_backend not in (None, "multiprocessing"):
+                raise ValueError(
+                    "server_backend='process' requires policy_backend=None or "
+                    "'multiprocessing'."
+                )
+            effective_policy_backend = "multiprocessing"
         self._policy_backend = effective_policy_backend
 
         # ---- build transport --------------------------------------------------
@@ -275,16 +309,31 @@ class AsyncBatchedCollector(BaseCollector):
         self._transport = transport
 
         # ---- build inference server -------------------------------------------
-        self._server = InferenceServer(
-            model=policy,
-            transport=transport,
-            max_batch_size=max_batch_size,
-            min_batch_size=min_batch_size,
-            timeout=server_timeout,
-            device=device,
-            weight_sync=weight_sync,
-            weight_sync_model_id=weight_sync_model_id,
-        )
+        policy_device = device if policy_device is None else policy_device
+        if server_backend == "process":
+            self._server = ProcessInferenceServer(
+                policy_factory=policy_factory,
+                transport=transport,
+                max_batch_size=max_batch_size,
+                min_batch_size=min_batch_size,
+                timeout=server_timeout,
+                policy_device=policy_device,
+                output_device=output_device,
+                weight_sync=weight_sync,
+                weight_sync_model_id=weight_sync_model_id,
+            )
+        else:
+            self._server = InferenceServer(
+                model=policy,
+                transport=transport,
+                max_batch_size=max_batch_size,
+                min_batch_size=min_batch_size,
+                timeout=server_timeout,
+                policy_device=policy_device,
+                output_device=output_device,
+                weight_sync=weight_sync,
+                weight_sync_model_id=weight_sync_model_id,
+            )
 
         # ---- collector settings -----------------------------------------------
         self.requested_frames_per_batch = frames_per_batch
@@ -303,6 +352,7 @@ class AsyncBatchedCollector(BaseCollector):
         self._result_queue: queue.Queue | None = None
         self._env_pool: AsyncEnvPool | None = None
         self._workers: list[threading.Thread] = []
+        self._clients: list[Callable] | None = None
 
         # Per-env trajectory accumulators (for yield_completed_trajectories)
         self._yield_queues: list[deque] = [deque() for _ in range(self._num_envs)]
@@ -327,6 +377,11 @@ class AsyncBatchedCollector(BaseCollector):
             **kwargs,
         )
 
+        # Create clients before a process server starts so response queues are
+        # inherited by the child process.
+        if self._clients is None:
+            self._clients = [self._transport.client() for _ in range(self._num_envs)]
+
         # Start inference server
         if not self._server.is_alive:
             self._server.start()
@@ -343,6 +398,7 @@ class AsyncBatchedCollector(BaseCollector):
                     "pool": self._env_pool,
                     "env_id": i,
                     "transport": self._transport,
+                    "client": self._clients[i],
                     "result_queue": self._result_queue,
                     "shutdown_event": self._shutdown_event,
                 },
@@ -361,7 +417,16 @@ class AsyncBatchedCollector(BaseCollector):
     @property
     def policy(self) -> Callable:
         """The policy passed to the inference server."""
-        return self._policy
+        if self._policy is not None:
+            return self._policy
+        return self._policy_factory
+
+    def server_stats(self, *, reset: bool = False) -> dict[str, float | int]:
+        """Return inference-server statistics when available."""
+        stats = getattr(self._server, "stats", None)
+        if stats is None:
+            return {}
+        return stats(reset=reset)
 
     # ------------------------------------------------------------------
     # Rollout: drain the result queue

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -2090,14 +2090,30 @@ class SliceSampler(Sampler):
             out_of_traj = relative_starts < 0
             if out_of_traj.any():
                 # a negative start means sampling fewer elements
-                seq_length = torch.where(
-                    ~out_of_traj, seq_length, seq_length + relative_starts
+                # Convert seq_length to tensor to avoid torch.compile inductor C++ codegen
+                # bug with mixed scalar/tensor int64 in blendv operations (see PyTorch #xyz)
+                seq_length_t = torch.as_tensor(
+                    seq_length,
+                    dtype=relative_starts.dtype,
+                    device=relative_starts.device,
                 )
-                relative_starts = torch.where(~out_of_traj, relative_starts, 0)
+                seq_length = torch.where(
+                    ~out_of_traj, seq_length_t, seq_length_t + relative_starts
+                )
+                relative_starts = torch.where(
+                    ~out_of_traj, relative_starts, torch.zeros_like(relative_starts)
+                )
         if self.span[1]:
             out_of_traj = relative_starts + seq_length > lengths[traj_idx]
             if out_of_traj.any():
                 # a negative start means sampling fewer elements
+                # Convert seq_length to tensor if it's still a scalar
+                if not isinstance(seq_length, torch.Tensor):
+                    seq_length = torch.as_tensor(
+                        seq_length,
+                        dtype=relative_starts.dtype,
+                        device=relative_starts.device,
+                    )
                 seq_length = torch.minimum(
                     seq_length, lengths[traj_idx] - relative_starts
                 )

--- a/torchrl/modules/inference_server/__init__.py
+++ b/torchrl/modules/inference_server/__init__.py
@@ -6,7 +6,11 @@
 from torchrl.modules.inference_server._monarch import MonarchTransport
 from torchrl.modules.inference_server._mp import MPTransport
 from torchrl.modules.inference_server._ray import RayTransport
-from torchrl.modules.inference_server._server import InferenceClient, InferenceServer
+from torchrl.modules.inference_server._server import (
+    InferenceClient,
+    InferenceServer,
+    ProcessInferenceServer,
+)
 from torchrl.modules.inference_server._slot import SlotTransport
 from torchrl.modules.inference_server._threading import ThreadingTransport
 from torchrl.modules.inference_server._transport import InferenceTransport
@@ -17,6 +21,7 @@ __all__ = [
     "InferenceTransport",
     "MonarchTransport",
     "MPTransport",
+    "ProcessInferenceServer",
     "RayTransport",
     "SlotTransport",
     "ThreadingTransport",

--- a/torchrl/modules/inference_server/_queue_transport.py
+++ b/torchrl/modules/inference_server/_queue_transport.py
@@ -94,7 +94,7 @@ class _QueueInferenceClient:
         """Submit a request and return a :class:`_QueueFuture`."""
         req_id = self._next_req_id
         self._next_req_id += 1
-        self._request_queue.put((self._actor_id, req_id, td))
+        self._request_queue.put((self._actor_id, req_id, time.monotonic(), td))
         return _QueueFuture(self, req_id)
 
     # -- internal -------------------------------------------------------------
@@ -147,6 +147,15 @@ class QueueBasedTransport(InferenceTransport):
         self._next_actor_id = 0
         self._peeked = None
 
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state["_lock"] = None
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self._lock = threading.Lock()
+
     # -- to be implemented by subclasses --------------------------------------
 
     def _make_response_queue(self):
@@ -181,22 +190,41 @@ class QueueBasedTransport(InferenceTransport):
         self, max_items: int
     ) -> tuple[list[TensorDictBase], list[tuple[int, int]]]:
         """Dequeue up to *max_items* pending requests (non-blocking)."""
+        items, callbacks, _submitted_at = self.drain_with_timing(max_items)
+        return items, callbacks
+
+    def drain_with_timing(
+        self, max_items: int
+    ) -> tuple[list[TensorDictBase], list[tuple[int, int]], list[float | None]]:
+        """Dequeue requests and include actor-side submission timestamps."""
         items: list[TensorDictBase] = []
         callbacks: list[tuple[int, int]] = []
+        submitted_at: list[float | None] = []
         peeked = self._peeked
         if peeked is not None:
             self._peeked = None
-            actor_id, req_id, td = peeked
+            if len(peeked) == 4:
+                actor_id, req_id, item_submitted_at, td = peeked
+            else:
+                actor_id, req_id, td = peeked
+                item_submitted_at = None
             items.append(td)
             callbacks.append((actor_id, req_id))
+            submitted_at.append(item_submitted_at)
         for _ in range(max_items - len(items)):
             try:
-                actor_id, req_id, td = self._request_queue.get(block=False)
+                item = self._request_queue.get(block=False)
             except Exception:
                 break
+            if len(item) == 4:
+                actor_id, req_id, item_submitted_at, td = item
+            else:
+                actor_id, req_id, td = item
+                item_submitted_at = None
             items.append(td)
             callbacks.append((actor_id, req_id))
-        return items, callbacks
+            submitted_at.append(item_submitted_at)
+        return items, callbacks, submitted_at
 
     def wait_for_work(self, timeout: float) -> None:
         """Block until at least one request is available or *timeout* elapses."""

--- a/torchrl/modules/inference_server/_server.py
+++ b/torchrl/modules/inference_server/_server.py
@@ -8,6 +8,9 @@ import threading
 import time
 from collections.abc import Callable
 from concurrent.futures import Future
+import multiprocessing as mp
+from multiprocessing.synchronize import Event as MPEvent
+from statistics import mean
 
 import torch
 from tensordict import lazy_stack
@@ -43,7 +46,20 @@ class InferenceServer:
         collate_fn (Callable, optional): function used to stack a list of
             TensorDicts into a batch. Default: :func:`~tensordict.lazy_stack`.
         device (torch.device or str, optional): device to move batches to
-            before calling the model. ``None`` means no device transfer.
+            before calling the model. This is kept as an alias for
+            ``policy_device`` for backward compatibility. ``None`` means no
+            device transfer.
+        policy_device (torch.device or str, optional): device that owns the
+            policy and receives batched requests before model execution.
+            If omitted, ``device`` is used.
+        output_device (torch.device or str, optional): device where individual
+            inference results are moved before being returned to actors. This
+            is useful when a CUDA policy serves CPU environment workers.
+        collect_stats (bool, optional): if ``True``, collect lightweight
+            batching, queue-wait, and forward-latency statistics. Defaults to
+            ``True``.
+        stats_window_size (int, optional): number of recent timing samples
+            kept for percentile statistics. Defaults to ``1024``.
         weight_sync: an optional
             :class:`~torchrl.weight_update.WeightSyncScheme` used to receive
             updated model weights from a trainer. When set, the server polls
@@ -80,8 +96,13 @@ class InferenceServer:
         timeout: float = 0.01,
         collate_fn: Callable | None = None,
         device: torch.device | str | None = None,
+        policy_device: torch.device | str | None = None,
+        output_device: torch.device | str | None = None,
+        collect_stats: bool = True,
+        stats_window_size: int = 1024,
         weight_sync=None,
         weight_sync_model_id: str = "policy",
+        shutdown_event: threading.Event | MPEvent | None = None,
     ):
         self.model = model
         self.transport = transport
@@ -89,14 +110,103 @@ class InferenceServer:
         self.min_batch_size = min_batch_size
         self.timeout = timeout
         self.collate_fn = collate_fn if collate_fn is not None else lazy_stack
-        self.device = torch.device(device) if device is not None else None
+        policy_device = device if policy_device is None else policy_device
+        self.policy_device = (
+            torch.device(policy_device) if policy_device is not None else None
+        )
+        self.device = self.policy_device
+        self.output_device = (
+            torch.device(output_device) if output_device is not None else None
+        )
         self.weight_sync = weight_sync
         self._weight_sync_model_id = weight_sync_model_id
+        self.collect_stats = collect_stats
+        self.stats_window_size = stats_window_size
 
-        self._shutdown_event = threading.Event()
+        self._shutdown_event = (
+            threading.Event() if shutdown_event is None else shutdown_event
+        )
         self._worker: threading.Thread | None = None
         # Protects model access during weight updates
         self._model_lock = threading.Lock()
+        self._stats_lock = threading.Lock()
+        self._reset_stats()
+
+        if self.policy_device is not None and hasattr(self.model, "to"):
+            self.model.to(self.policy_device)
+
+    # -- stats ---------------------------------------------------------------
+
+    def _reset_stats(self) -> None:
+        self._stats_started_at = time.monotonic()
+        self._num_requests = 0
+        self._num_batches = 0
+        self._batch_sizes: list[int] = []
+        self._queue_wait_ms: list[float] = []
+        self._forward_ms: list[float] = []
+
+    @staticmethod
+    def _percentile(values: list[float], percentile: float) -> float:
+        if not values:
+            return 0.0
+        sorted_values = sorted(values)
+        index = int(round((len(sorted_values) - 1) * percentile))
+        return float(sorted_values[index])
+
+    def _extend_window(self, target: list, values: list) -> None:
+        target.extend(values)
+        excess = len(target) - self.stats_window_size
+        if excess > 0:
+            del target[:excess]
+
+    def _record_batch_stats(
+        self,
+        *,
+        batch_size: int,
+        queue_wait_ms: list[float],
+        forward_ms: float,
+    ) -> None:
+        if not self.collect_stats:
+            return
+        with self._stats_lock:
+            self._num_requests += batch_size
+            self._num_batches += 1
+            self._extend_window(self._batch_sizes, [batch_size])
+            self._extend_window(self._queue_wait_ms, queue_wait_ms)
+            self._extend_window(self._forward_ms, [forward_ms])
+
+    def stats(self, *, reset: bool = False) -> dict[str, float | int]:
+        """Return lightweight inference-server throughput statistics.
+
+        Args:
+            reset (bool, optional): if ``True``, clear counters after taking
+                the snapshot. Defaults to ``False``.
+
+        Returns:
+            A dictionary with request/batch counts, rates, average batch size,
+            and p50/p95 queue and forward latencies in milliseconds.
+        """
+        with self._stats_lock:
+            elapsed = max(time.monotonic() - self._stats_started_at, 1e-12)
+            num_requests = self._num_requests
+            num_batches = self._num_batches
+            batch_sizes = list(self._batch_sizes)
+            queue_wait_ms = list(self._queue_wait_ms)
+            forward_ms = list(self._forward_ms)
+            result = {
+                "requests": num_requests,
+                "batches": num_batches,
+                "requests_per_s": num_requests / elapsed,
+                "batches_per_s": num_batches / elapsed,
+                "avg_batch_size": float(mean(batch_sizes)) if batch_sizes else 0.0,
+                "p50_queue_ms": self._percentile(queue_wait_ms, 0.50),
+                "p95_queue_ms": self._percentile(queue_wait_ms, 0.95),
+                "p50_forward_ms": self._percentile(forward_ms, 0.50),
+                "p95_forward_ms": self._percentile(forward_ms, 0.95),
+            }
+            if reset:
+                self._reset_stats()
+            return result
 
     # -- lifecycle ------------------------------------------------------------
 
@@ -166,7 +276,14 @@ class InferenceServer:
 
                 self.transport.wait_for_work(timeout=self.timeout)
 
-                items, callbacks = self.transport.drain(self.max_batch_size)
+                drain_with_timing = getattr(self.transport, "drain_with_timing", None)
+                if drain_with_timing is None:
+                    items, callbacks = self.transport.drain(self.max_batch_size)
+                    submitted_at = [None] * len(items)
+                else:
+                    items, callbacks, submitted_at = drain_with_timing(
+                        self.max_batch_size
+                    )
                 if not items:
                     continue
 
@@ -178,19 +295,42 @@ class InferenceServer:
                         if remaining <= 0:
                             break
                         self.transport.wait_for_work(timeout=remaining)
-                        more_items, more_cbs = self.transport.drain(
-                            self.max_batch_size - len(items)
-                        )
+                        if drain_with_timing is None:
+                            more_items, more_cbs = self.transport.drain(
+                                self.max_batch_size - len(items)
+                            )
+                            more_submitted_at = [None] * len(more_items)
+                        else:
+                            more_items, more_cbs, more_submitted_at = (
+                                drain_with_timing(self.max_batch_size - len(items))
+                            )
                         items.extend(more_items)
                         callbacks.extend(more_cbs)
+                        submitted_at.extend(more_submitted_at)
 
                 batch = self.collate_fn(items)
-                if self.device is not None:
-                    batch = batch.to(self.device)
+                if self.policy_device is not None:
+                    batch = batch.to(self.policy_device)
 
                 try:
+                    now = time.monotonic()
+                    queue_wait_ms = [
+                        (now - item_submitted_at) * 1000.0
+                        for item_submitted_at in submitted_at
+                        if item_submitted_at is not None
+                    ]
+                    forward_start = time.monotonic()
                     with self._model_lock:
-                        results = self.model(batch).unbind(0)
+                        result_batch = self.model(batch)
+                    if self.output_device is not None:
+                        result_batch = result_batch.to(self.output_device)
+                    forward_ms = (time.monotonic() - forward_start) * 1000.0
+                    self._record_batch_stats(
+                        batch_size=len(callbacks),
+                        queue_wait_ms=queue_wait_ms,
+                        forward_ms=forward_ms,
+                    )
+                    results = result_batch.unbind(0)
                     if len(results) != len(callbacks):
                         raise RuntimeError(
                             f"Model returned {len(results)} results for a "
@@ -224,6 +364,182 @@ class InferenceServer:
 
     def __del__(self) -> None:
         if self._worker is not None and self._worker.is_alive():
+            self.shutdown(timeout=1.0)
+
+
+def _process_server_entry(
+    policy_factory: Callable[[], nn.Module],
+    transport: InferenceTransport,
+    server_kwargs: dict,
+    shutdown_event: MPEvent,
+    ready_queue,
+) -> None:
+    """Run an :class:`InferenceServer` loop inside a child process."""
+    try:
+        model = policy_factory()
+        server = InferenceServer(
+            model=model,
+            transport=transport,
+            shutdown_event=shutdown_event,
+            **server_kwargs,
+        )
+        ready_queue.put((True, None))
+        server._run()
+    except BaseException as exc:
+        ready_queue.put((False, repr(exc)))
+        raise
+
+
+class ProcessInferenceServer:
+    """Dedicated-process wrapper around :class:`InferenceServer`.
+
+    This server is intended for actor/env workers that communicate through a
+    queue-based transport such as :class:`~torchrl.modules.inference_server.MPTransport`.
+    Clients must be created from the transport before :meth:`start` so that the
+    child process inherits their response queues.
+
+    Args:
+        policy_factory (Callable[[], nn.Module]): picklable factory that creates
+            the policy inside the server process.
+        transport (InferenceTransport): transport shared with actor clients.
+
+    Keyword Args:
+        max_batch_size (int, optional): maximum requests per forward pass.
+        min_batch_size (int, optional): minimum requests to accumulate before
+            dispatching a partial batch.
+        timeout (float, optional): wait timeout in seconds.
+        collate_fn (Callable, optional): collate function for requests.
+        device (torch.device or str, optional): alias for ``policy_device``.
+        policy_device (torch.device or str, optional): policy execution device.
+        output_device (torch.device or str, optional): actor response device.
+        collect_stats (bool, optional): forwarded to :class:`InferenceServer`.
+        stats_window_size (int, optional): forwarded to :class:`InferenceServer`.
+        weight_sync: optional weight synchronization scheme.
+        weight_sync_model_id (str, optional): model id for weight sync.
+        mp_context: multiprocessing context or start-method name. Defaults to
+            ``"spawn"``.
+
+    Examples:
+        >>> import multiprocessing as mp
+        >>> import torch.nn as nn
+        >>> from tensordict.nn import TensorDictModule
+        >>> from torchrl.modules.inference_server import MPTransport
+        >>> def make_policy():
+        ...     return TensorDictModule(
+        ...         nn.Linear(4, 2), in_keys=["observation"], out_keys=["action"]
+        ...     )
+        >>> ctx = mp.get_context("spawn")
+        >>> transport = MPTransport(ctx=ctx)
+        >>> client = transport.client()
+        >>> server = ProcessInferenceServer(
+        ...     policy_factory=make_policy,
+        ...     transport=transport,
+        ...     mp_context=ctx,
+        ... )
+        >>> server.start()
+        >>> server.shutdown()
+    """
+
+    def __init__(
+        self,
+        *,
+        policy_factory: Callable[[], nn.Module],
+        transport: InferenceTransport,
+        max_batch_size: int = 64,
+        min_batch_size: int = 1,
+        timeout: float = 0.01,
+        collate_fn: Callable | None = None,
+        device: torch.device | str | None = None,
+        policy_device: torch.device | str | None = None,
+        output_device: torch.device | str | None = None,
+        collect_stats: bool = True,
+        stats_window_size: int = 1024,
+        weight_sync=None,
+        weight_sync_model_id: str = "policy",
+        mp_context: str | mp.context.BaseContext | None = None,
+    ) -> None:
+        self.policy_factory = policy_factory
+        self.transport = transport
+        if isinstance(mp_context, str):
+            self._ctx = mp.get_context(mp_context)
+        elif mp_context is None:
+            self._ctx = mp.get_context("spawn")
+        else:
+            self._ctx = mp_context
+        self._shutdown_event = self._ctx.Event()
+        self._ready_queue = self._ctx.Queue()
+        self._process: mp.Process | None = None
+        self._server_kwargs = {
+            "max_batch_size": max_batch_size,
+            "min_batch_size": min_batch_size,
+            "timeout": timeout,
+            "collate_fn": collate_fn,
+            "device": device,
+            "policy_device": policy_device,
+            "output_device": output_device,
+            "collect_stats": collect_stats,
+            "stats_window_size": stats_window_size,
+            "weight_sync": weight_sync,
+            "weight_sync_model_id": weight_sync_model_id,
+        }
+
+    def start(self) -> ProcessInferenceServer:
+        """Start the child process and wait until the policy is initialized."""
+        if self.is_alive:
+            raise RuntimeError("Server is already running.")
+        self._shutdown_event.clear()
+        self._process = self._ctx.Process(
+            target=_process_server_entry,
+            kwargs={
+                "policy_factory": self.policy_factory,
+                "transport": self.transport,
+                "server_kwargs": self._server_kwargs,
+                "shutdown_event": self._shutdown_event,
+                "ready_queue": self._ready_queue,
+            },
+            daemon=True,
+            name="ProcessInferenceServer",
+        )
+        self._process.start()
+        ok, payload = self._ready_queue.get(timeout=30.0)
+        if not ok:
+            self.shutdown(timeout=1.0)
+            raise RuntimeError(f"ProcessInferenceServer failed to start: {payload}")
+        return self
+
+    def shutdown(self, timeout: float | None = 5.0) -> None:
+        """Signal the child process to stop and wait for it to exit."""
+        self._shutdown_event.set()
+        process = self._process
+        if process is None:
+            return
+        process.join(timeout=timeout)
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=timeout)
+        self._process = None
+
+    @property
+    def is_alive(self) -> bool:
+        """Whether the child process is alive."""
+        return self._process is not None and self._process.is_alive()
+
+    def stats(self, *, reset: bool = False) -> dict[str, float | int]:
+        """Return process-server stats.
+
+        Live stats are not shared across processes yet, so this currently
+        returns an empty dictionary.
+        """
+        return {}
+
+    def __enter__(self) -> ProcessInferenceServer:
+        return self.start()
+
+    def __exit__(self, *exc_info) -> None:
+        self.shutdown()
+
+    def __del__(self) -> None:
+        if self.is_alive:
             self.shutdown(timeout=1.0)
 
 

--- a/torchrl/modules/inference_server/_slot.py
+++ b/torchrl/modules/inference_server/_slot.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import itertools
 import threading
+import time
 
 from tensordict.base import TensorDictBase
 
@@ -79,6 +80,7 @@ class SlotTransport(InferenceTransport):
         # Per-slot readiness flag (True = observation ready for server)
         # Under CPython's GIL, bool assignment is atomic.
         self._obs_ready: list[bool] = [False] * num_slots
+        self._submitted_at: list[float | None] = [None] * num_slots
 
         # Per-slot action storage (written by server, read by env thread)
         self._actions: list[TensorDictBase | BaseException | None] = [None] * num_slots
@@ -107,6 +109,7 @@ class SlotTransport(InferenceTransport):
         else:
             self._obs[slot_id] = td
         self._obs_ready[slot_id] = True
+        self._submitted_at[slot_id] = time.monotonic()
         with self._work_cond:
             self._work_cond.notify()
 
@@ -150,6 +153,13 @@ class SlotTransport(InferenceTransport):
 
     def drain(self, max_items: int) -> tuple[list[TensorDictBase], list[int]]:
         """Sweep slots and return (observations, slot_ids) for ready ones."""
+        items, slot_ids, _submitted_at = self.drain_with_timing(max_items)
+        return items, slot_ids
+
+    def drain_with_timing(
+        self, max_items: int
+    ) -> tuple[list[TensorDictBase], list[int], list[float | None]]:
+        """Sweep slots and include actor-side submission timestamps."""
         # Lazily initialise the pre-allocated buffer on the first drain
         # that finds ready observations.
         if self._preallocate and self._obs_buffer is None:
@@ -166,9 +176,12 @@ class SlotTransport(InferenceTransport):
 
         items: list[TensorDictBase] = []
         slot_ids: list[int] = []
+        submitted_at: list[float | None] = []
         for i in range(self._num_slots):
             if self._obs_ready[i]:
                 self._obs_ready[i] = False
+                submitted_at.append(self._submitted_at[i])
+                self._submitted_at[i] = None
                 if self._obs_buffer is not None:
                     # Flush first-time observations that arrived before the
                     # buffer existed into the buffer.
@@ -182,7 +195,7 @@ class SlotTransport(InferenceTransport):
                 slot_ids.append(i)
                 if len(slot_ids) >= max_items:
                     break
-        return items, slot_ids
+        return items, slot_ids, submitted_at
 
     def resolve(self, callback: int, result: TensorDictBase) -> None:
         """Write the action into the slot and wake the waiting env thread."""

--- a/torchrl/modules/inference_server/_threading.py
+++ b/torchrl/modules/inference_server/_threading.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from concurrent.futures import Future
 
 from tensordict.base import TensorDictBase
@@ -26,6 +27,7 @@ class ThreadingTransport(InferenceTransport):
     def __init__(self):
         self._queue: list[TensorDictBase] = []
         self._futures: list[Future] = []
+        self._submitted_at: list[float] = []
         self._cond = threading.Condition(threading.Lock())
 
     def submit(self, td: TensorDictBase) -> Future[TensorDictBase]:
@@ -34,18 +36,28 @@ class ThreadingTransport(InferenceTransport):
         with self._cond:
             self._queue.append(td)
             self._futures.append(fut)
+            self._submitted_at.append(time.monotonic())
             self._cond.notify()
         return fut
 
     def drain(self, max_items: int) -> tuple[list[TensorDictBase], list[Future]]:
         """Dequeue up to *max_items* pending requests."""
+        items, futs, _submitted_at = self.drain_with_timing(max_items)
+        return items, futs
+
+    def drain_with_timing(
+        self, max_items: int
+    ) -> tuple[list[TensorDictBase], list[Future], list[float]]:
+        """Dequeue requests with actor-side submission timestamps."""
         with self._cond:
             n = min(len(self._queue), max_items)
             items = self._queue[:n]
             futs = self._futures[:n]
+            submitted_at = self._submitted_at[:n]
             del self._queue[:n]
             del self._futures[:n]
-        return items, futs
+            del self._submitted_at[:n]
+        return items, futs, submitted_at
 
     def wait_for_work(self, timeout: float) -> None:
         """Block until at least one request is enqueued or *timeout* elapses."""

--- a/torchrl/modules/models/model_based.py
+++ b/torchrl/modules/models/model_based.py
@@ -18,10 +18,23 @@ from torch import nn
 
 # from torchrl.modules.tensordict_module.rnn import GRUCell
 from torch.nn import GRUCell
+from torchrl._utils import _maybe_record_function_decorator
 
 from torchrl.modules.models.models import MLP
 
 UNSQUEEZE_RNN_INPUT = version.parse(torch.__version__) < version.parse("1.11")
+
+
+class _Contiguous(nn.Module):
+    """Helper module that makes a tensor contiguous.
+
+    This is useful inside nn.Sequential for torch.compile inductor compatibility.
+    Inductor sometimes needs explicit contiguous() calls after reshape operations
+    for efficient memory layout.
+    """
+
+    def forward(self, x):
+        return x.contiguous()
 
 
 class DreamerActor(nn.Module):
@@ -129,16 +142,18 @@ class ObsEncoder(nn.Module):
             k = k * 2
         self.encoder = nn.Sequential(*layers)
 
+    @_maybe_record_function_decorator("ObsEncoder.forward")
     def forward(self, observation):
         *batch_sizes, C, H, W = observation.shape
-        if len(batch_sizes) == 0:
-            end_dim = 0
-        else:
-            end_dim = len(batch_sizes) - 1
-        observation = torch.flatten(observation, start_dim=0, end_dim=end_dim)
+        # Flatten all batch dimensions into one for conv
+        # Use contiguous() for inductor compatibility
+        observation = observation.flatten(
+            0, len(batch_sizes) - 1 if batch_sizes else 0
+        ).contiguous()
         obs_encoded = self.encoder(observation)
-        latent = obs_encoded.reshape(*batch_sizes, -1)
-        return latent
+        # Reshape back to original batch dims + latent
+        latent = obs_encoded.unflatten(0, batch_sizes) if batch_sizes else obs_encoded
+        return latent.reshape(*batch_sizes, -1).contiguous()
 
 
 class ObsDecoder(nn.Module):
@@ -238,14 +253,25 @@ class ObsDecoder(nn.Module):
         self.decoder = nn.Sequential(*layers)
         self._depth = channels
 
+    @_maybe_record_function_decorator("ObsDecoder.forward")
     def forward(self, state, rnn_hidden):
+        # Concatenate and project to latent space
         latent = self.state_to_latent(torch.cat([state, rnn_hidden], dim=-1))
         *batch_sizes, D = latent.shape
-        latent = latent.view(-1, D, 1, 1)
+        # Flatten batch dimensions and reshape for conv
+        latent = (
+            latent.flatten(0, len(batch_sizes) - 1 if batch_sizes else 0)
+            .unsqueeze(-1)
+            .unsqueeze(-1)
+            .contiguous()
+        )
         obs_decoded = self.decoder(latent)
         _, C, H, W = obs_decoded.shape
-        obs_decoded = obs_decoded.view(*batch_sizes, C, H, W)
-        return obs_decoded
+        # Unflatten back to original batch dims
+        obs_decoded = (
+            obs_decoded.unflatten(0, batch_sizes) if batch_sizes else obs_decoded
+        )
+        return obs_decoded.contiguous()
 
 
 class RSSMRollout(TensorDictModuleBase):


### PR DESCRIPTION
## Summary
- harden `InferenceServer` with `policy_device` / `output_device` handoff and lightweight batching/latency stats
- add an experimental `ProcessInferenceServer` and wire `AsyncBatchedCollector(server_backend=...)`
- extend `benchmarks/bench_collectors.py` to compare regular `Collector + ParallelEnv` against async policy-server collection across env counts, env backends, process/thread server mode, and batching rules

## Local benchmark notes
- MacBook local fake-pixel sweeps run end-to-end with JSONL/CSV output
- no CUDA/EGL validation on this machine; CUDA-only test is marked `gpu` and skips without CUDA
- with cheap policy inference, async-thread is comparable to `ParallelEnv` and slightly ahead at 8 envs in the fake-env sweep
- with 20 ms synthetic policy latency, explicit batching rules matter: `min_bs=1` often under-batches, while full-batch async nearly matches the synchronous barrier in the homogeneous fake-env benchmark

## Test plan
- `uv run pytest -q test/test_inference_server.py`
- `uv run python benchmarks/bench_collectors.py --num-envs 1,2,4,8 --total-frames 600 --frames-per-batch 100 --warmup-batches 1 --env-step-latency-ms 5 --policy-delay-ms 0 --backends parallel,async-thread,async-env-mp,async-process --batching-rules auto --policy-device cpu --jsonl /tmp/async_collector_bench/no_policy_delay_fixed.jsonl --csv /tmp/async_collector_bench/no_policy_delay_fixed.csv`
- `uv run python benchmarks/bench_collectors.py --num-envs 1,2,4,8 --total-frames 200 --frames-per-batch 100 --warmup-batches 0 --env-step-latency-ms 5 --policy-delay-ms 20 --backends parallel,async-thread --batching-rules no-batch,auto,min4,full --policy-device cpu --jsonl /tmp/async_collector_bench/thread_batching_20ms_fixed.jsonl --csv /tmp/async_collector_bench/thread_batching_20ms_fixed.csv`
- `uv run python benchmarks/bench_collectors.py --num-envs 1,2,4,8 --total-frames 200 --frames-per-batch 100 --warmup-batches 0 --env-step-latency-ms 5 --policy-delay-ms 20 --backends async-env-mp --batching-rules auto --policy-device cpu --jsonl /tmp/async_collector_bench/mp_auto_20ms_fixed.jsonl --csv /tmp/async_collector_bench/mp_auto_20ms_fixed.csv`

## Follow-ups
- validate CUDA policy + CPU env workers on a Linux CUDA host
- validate MuJoCo `from_pixels=True` with EGL rendering
- export process-server stats back to the parent process