### PR TITLE
[BugFix] Preserve dynamic specs and batched NonTensor state

### DIFF
--- a/test/envs/test_auto_reset.py
+++ b/test/envs/test_auto_reset.py
@@ -671,6 +671,44 @@ class TestNonTensorEnv:
             time.sleep(0.1)
             gc.collect()
 
+    @pytest.mark.parametrize("use_buffers", [False, True])
+    def test_parallel_partial_reset(self, use_buffers, maybe_fork_ParallelEnv):
+        """Regression: a *partial* reset (subset of workers) with NonTensor data.
+
+        ``out`` carries no NonTensor leaf (NonTensor is not shared-memory
+        backed), so a partial fancy-index assignment used to raise
+        ``IndexError: list index out of range``. The reset workers must get the
+        fresh value while the untouched worker keeps its current value.
+        """
+        env = maybe_fork_ParallelEnv(3, EnvWithMetadata, use_buffers=use_buffers)
+        try:
+            env.set_seed(0)
+            td = env.reset()
+            for _ in range(4):
+                td.set("action", torch.zeros(3, 1))
+                td = env.step_mdp(env.step(td))
+            assert td.get("non_tensor").tolist() == [4, 4, 4]
+            # partial reset: workers 0 and 2 only; worker 1 keeps its state
+            reset = td.select("non_tensor")
+            reset.set("_reset", torch.tensor([True, False, True]).reshape(3, 1))
+            out = env.reset(reset)
+            assert out.get("non_tensor").tolist() == [0, 4, 0]
+            if use_buffers:
+                # maybe_reset can call reset with only the reset mask;
+                # NonTensor values for workers that are not reset must come
+                # from the shared-buffer cache.
+                reset = TensorDict(
+                    {"_reset": torch.tensor([False, True, False]).reshape(3, 1)},
+                    batch_size=[3],
+                )
+                out = env.reset(reset)
+                assert out.get("non_tensor").tolist() == [0, 0, 0]
+        finally:
+            env.close(raise_if_closed=False)
+            del env
+            time.sleep(0.1)
+            gc.collect()
+
     @pytest.mark.skipif(
         platform == "win32", reason="signal-based timeout not supported."
     )

--- a/test/envs/test_parallel.py
+++ b/test/envs/test_parallel.py
@@ -1318,6 +1318,31 @@ def test_single_task_share_individual_td():
 
 
 @set_list_to_stack(True)
+@pytest.mark.parametrize("cls", [SerialEnv, ParallelEnv])
+def test_heterogeneous_non_tensor_workers(cls, maybe_fork_ParallelEnv):
+    # workers with DIFFERENT NonTensor observations (e.g. per-task language
+    # instructions) stack their specs into a Stacked spec: the batched env
+    # must still register the entry as non-tensor and route it through the
+    # non-tensor channel instead of the shared buffers
+    from torchrl.envs import ToyVLAEnv
+
+    if cls is ParallelEnv:
+        cls = maybe_fork_ParallelEnv
+
+    def make(instruction):
+        return lambda: ToyVLAEnv(action_dim=2, state_dim=2, instruction=instruction)
+
+    env = cls(2, [make("pick up the apple"), make("pick up the pear")])
+    try:
+        rollout = env.rollout(3)
+        assert "language_instruction" in env._non_tensor_keys
+        instructions = rollout["language_instruction"]
+        assert instructions[0][0] == "pick up the apple"
+        assert instructions[1][0] == "pick up the pear"
+    finally:
+        env.close(raise_if_closed=False)
+
+
 def test_stackable():
     # Tests the _stackable util
     stack = [TensorDict({"a": 0}, []), TensorDict({"b": 1}, [])]

--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -3492,6 +3492,26 @@ def test_invalid_indexing(spec_class, idx):
         spec[idx]
 
 
+def test_dynamic_dim_indexing():
+    # a full slice over a dynamic (-1) dimension preserves it; any other
+    # slice is undefined and raises. Integer indexing of the leading dim of
+    # a [B, -1, ...] spec (e.g. unbatching a MultiAction-expanded action
+    # spec) must keep the dynamic dim intact.
+    leaf = Categorical(n=4, shape=(1, 1, 2)).expand(1, -1, 2)
+    assert leaf[0].shape == torch.Size([-1, 2])
+    assert leaf[(0, slice(None))].shape == torch.Size([-1, 2])
+    assert leaf[:, :, 0].shape == torch.Size([1, -1])
+    with pytest.raises(IndexError, match="dynamic"):
+        leaf[(0, slice(1, 2))]
+    # the composite path (used by full_action_spec_unbatched) extends the
+    # index with full slices over the leaf's extra dims
+    comp = Composite(action=Categorical(n=4, shape=(1, 2)), shape=(1,))
+    comp = comp.unsqueeze(1).expand(1, -1)
+    indexed = comp[(0,)]
+    assert indexed.shape == torch.Size([-1])
+    assert indexed["action"].shape == torch.Size([-1, 2])
+
+
 # Bounded, MultiCategorical: Pending resolution of https://github.com/pytorch/pytorch/issues/100080.
 @pytest.mark.parametrize(
     "spec_class",

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -179,6 +179,16 @@ def _slice_indexing(shape: list[int], idx: slice) -> list[int]:
     if len(shape) == 0:
         return shape
 
+    if shape[0] == -1:
+        # dynamic dimension: a full slice preserves it, anything else is
+        # undefined (the actual extent is unknown)
+        if idx.start is idx.stop is None and idx.step in (None, 1):
+            return shape
+        raise IndexError(
+            f"cannot slice a dynamic (-1) dimension with {idx}: the extent of "
+            "the dimension is unknown."
+        )
+
     if idx.start is None:
         start = 0
     else:

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -993,7 +993,7 @@ class BatchedEnvBase(EnvBase):
         def _is_non_tensor(spec) -> bool:
             if isinstance(spec, NonTensor):
                 return True
-            return isinstance(spec, Stacked) and isinstance(spec[0], NonTensor)
+            return isinstance(spec, Stacked) and isinstance(spec._specs[0], NonTensor)
 
         non_tensor_keys = []
         for spec in (

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -44,7 +44,7 @@ from torchrl._utils import (
     timeit,
     VERBOSE,
 )
-from torchrl.data.tensor_specs import Composite, NonTensor
+from torchrl.data.tensor_specs import Composite, NonTensor, Stacked
 from torchrl.data.utils import CloudpickleWrapper, contains_lazy_spec, DEVICE_TYPING
 from torchrl.envs.common import _do_nothing, _EnvPostInit, EnvBase, EnvMetaData
 
@@ -987,7 +987,14 @@ class BatchedEnvBase(EnvBase):
                 "batched environment base tensordict has the wrong shape"
             )
 
-        # Non-tensor keys
+        # Non-tensor keys. Heterogeneous workers (e.g. different language
+        # instructions) stack NonTensor leaves into a Stacked spec, so the
+        # check must look through the stack as well.
+        def _is_non_tensor(spec) -> bool:
+            if isinstance(spec, NonTensor):
+                return True
+            return isinstance(spec, Stacked) and isinstance(spec[0], NonTensor)
+
         non_tensor_keys = []
         for spec in (
             self.full_action_spec,
@@ -997,9 +1004,10 @@ class BatchedEnvBase(EnvBase):
             self.full_done_spec,
         ):
             for key, _spec in spec.items(True, True):
-                if isinstance(_spec, NonTensor):
+                if _is_non_tensor(_spec):
                     non_tensor_keys.append(key)
         self._non_tensor_keys = non_tensor_keys
+        self._non_tensor_cache = None
 
         if self._single_task:
             self._env_input_keys = sorted(
@@ -1134,6 +1142,32 @@ class BatchedEnvBase(EnvBase):
         self._shared_tensordict_parent_root = self.shared_tensordict_parent.exclude(
             "next", *self.reset_keys
         )
+
+    def _update_non_tensor_cache(self, non_tensor_tds, workers_range=None):
+        if not self._non_tensor_keys:
+            return None
+        root_non_tensor = non_tensor_tds.select(*self._non_tensor_keys, strict=False)
+        if workers_range is None:
+            self._non_tensor_cache = root_non_tensor
+            return root_non_tensor
+        workers = list(workers_range)
+        if workers == list(range(self.num_workers)):
+            self._non_tensor_cache = root_non_tensor
+            return root_non_tensor
+        if self._non_tensor_cache is None:
+            raise RuntimeError(
+                "Cannot preserve NonTensor values for non-updated workers before "
+                "a full reset or step."
+            )
+        worker_to_offset = {worker: offset for offset, worker in enumerate(workers)}
+        rows = []
+        for i in range(self.num_workers):
+            if i in worker_to_offset:
+                rows.append(root_non_tensor[worker_to_offset[i]])
+            else:
+                rows.append(self._non_tensor_cache[i])
+        self._non_tensor_cache = LazyStackedTensorDict(*rows)
+        return root_non_tensor
 
     def _start_workers(self) -> None:
         """Starts the various envs."""
@@ -2078,11 +2112,17 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
         tensordict.set("next", next_td)
         if self._non_tensor_keys:
             non_tensor_tds = LazyStackedTensorDict(*non_tensor_tds)
+            root_non_tensor_tds = self._update_non_tensor_cache(
+                non_tensor_tds,
+                workers_range if partial_steps is not None else None,
+            )
             tensordict.update(
                 non_tensor_tds,
                 keys_to_update=[("next", key) for key in self._non_tensor_keys],
             )
-            tensordict_.update(non_tensor_tds, keys_to_update=self._non_tensor_keys)
+            tensordict_.update(
+                root_non_tensor_tds, keys_to_update=self._non_tensor_keys
+            )
 
         if partial_steps is not None:
             result = tensordict.new_zeros(tensordict_save.shape)
@@ -2414,10 +2454,12 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
             device=device,
         )
         if self._non_tensor_keys:
-            out.update(
-                LazyStackedTensorDict(*non_tensor_tds),
-                keys_to_update=self._non_tensor_keys,
+            non_tensor_tds = LazyStackedTensorDict(*non_tensor_tds)
+            self._update_non_tensor_cache(
+                non_tensor_tds,
+                workers_range if partial_steps is not None else None,
             )
+            out.update(non_tensor_tds, keys_to_update=self._non_tensor_keys)
         if next_td_passthrough is not None:
             out.update(next_td_passthrough)
 
@@ -2606,9 +2648,41 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
         )
         if self._non_tensor_keys:
             workers, nontensor = zip(*workers_nontensor)
-            out[torch.tensor(workers)] = LazyStackedTensorDict(*nontensor).select(
+            reset_stack = LazyStackedTensorDict(*nontensor).select(
                 *self._non_tensor_keys
             )
+            if len(workers) == self.num_workers:
+                # full reset: every worker has a freshly reset value, so the
+                # fancy-index assignment creates the (absent) NonTensor keys.
+                out[torch.tensor(workers)] = reset_stack
+                self._non_tensor_cache = reset_stack
+            else:
+                # partial reset: ``out`` has no NonTensor leaves (NonTensor is
+                # not shared-memory backed, so ``named_apply`` over the shared
+                # parent skips it), and a NonTensor key cannot be created by a
+                # *partial* fancy-index assignment. Build the full-width
+                # NonTensor explicitly -- reset workers take the fresh values,
+                # the others keep their last cached current value (correct,
+                # since they are not being reset).
+                worker_to_offset = {w: o for o, w in enumerate(workers)}
+                rows = []
+                for i in range(self.num_workers):
+                    if i in worker_to_offset:
+                        rows.append(reset_stack[worker_to_offset[i]])
+                    elif self._non_tensor_cache is not None:
+                        rows.append(self._non_tensor_cache[i])
+                    else:
+                        non_tensor = tensordict[i].select(
+                            *self._non_tensor_keys, strict=False
+                        )
+                        if non_tensor.is_empty():
+                            raise RuntimeError(
+                                "Cannot preserve NonTensor values for non-reset "
+                                "workers before a full reset or step."
+                            )
+                        rows.append(non_tensor)
+                self._non_tensor_cache = LazyStackedTensorDict(*rows)
+                out.update(self._non_tensor_cache)
         self._sync_w2m()
         return out
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3879
* #3878
* #3877
* #3876
* #3875
* #3874
* __->__ #3873

