### PR TITLE
[CI] Add common PR title label prefixes

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -7,18 +7,27 @@
 #  - Labels are ONLY ADDED, never removed (preserves manual labels)
 #
 # Supported prefixes (supports common variations):
+#  - [Algorithm], [Algorithms] → new algo
+#  - [BE] → BE
+#  - [Benchmark], [Benchmarks] → Benchmarks
 #  - [BugFix], [Bugfix] → BugFix
+#  - [Example], [Examples] → Examples
 #  - [Feature], [Features] → Feature
 #  - [Doc], [Docs], [Documentation] → Documentation
 #  - [Refactor], [Refactoring] → Refactoring
 #  - [CI] → CI
 #  - [Test], [Tests] → Tests
+#  - [Trainer], [Trainers] → Trainers
 #  - [Environment], [Environments] → Environments
 #  - [Data] → Data
+#  - [LLM] → llm/
+#  - [Minor] → small change
 #  - [Performance], [Perf] → Performance
 #  - [BC-Breaking], [BCBreaking] → bc breaking
 #  - [Deprecation], [Deprecated] → Deprecation
 #  - [Quality] → Quality
+#  - [Versioning] → versioning
+#  - [WIP] → WIP
 #------------------------------------------------------------
 
 name: PR Label
@@ -57,18 +66,27 @@ jobs:
 
           | Prefix | Label Applied | Example |
           |--------|---------------|---------|
+          | `[Algorithm]` | new algo | `[Algorithm] Add new RL objective` |
+          | `[BE]` | BE | `[BE] Improve error messages` |
+          | `[Benchmark]` or `[Benchmarks]` | Benchmarks | `[Benchmark] Add collector benchmark` |
           | `[BugFix]` | BugFix | `[BugFix] Fix memory leak in collector` |
+          | `[Example]` or `[Examples]` | Examples | `[Example] Add training script` |
           | `[Feature]` | Feature | `[Feature] Add new optimizer` |
           | `[Doc]` or `[Docs]` | Documentation | `[Doc] Update installation guide` |
           | `[Refactor]` | Refactoring | `[Refactor] Clean up module imports` |
           | `[CI]` | CI | `[CI] Fix workflow permissions` |
           | `[Test]` or `[Tests]` | Tests | `[Tests] Add unit tests for buffer` |
+          | `[Trainer]` or `[Trainers]` | Trainers | `[Trainer] Add trainer config` |
           | `[Environment]` or `[Environments]` | Environments | `[Environments] Add Gymnasium support` |
           | `[Data]` | Data | `[Data] Fix replay buffer sampling` |
+          | `[LLM]` | llm/ | `[LLM] Add reward model integration` |
+          | `[Minor]` | small change | `[Minor] Fix typo in error message` |
           | `[Performance]` or `[Perf]` | Performance | `[Performance] Optimize tensor ops` |
           | `[BC-Breaking]` | bc breaking | `[BC-Breaking] Remove deprecated API` |
           | `[Deprecation]` | Deprecation | `[Deprecation] Mark old function` |
           | `[Quality]` | Quality | `[Quality] Fix typos and add codespell` |
+          | `[Versioning]` | versioning | `[Versioning] Bump release version` |
+          | `[WIP]` | WIP | `[WIP] Draft implementation` |
 
           **Note:** Common variations like singular/plural are supported (e.g., `[Doc]` or `[Docs]`).
           TABLE
@@ -91,8 +109,20 @@ jobs:
 
           # Map prefixes to GitHub label names (supports common variations)
           case "$PREFIX" in
+            Algorithm|Algorithms|algorithm|algorithms)
+              LABEL="new algo"
+              ;;
+            BE|be)
+              LABEL="BE"
+              ;;
+            Benchmark|Benchmarks|benchmark|benchmarks)
+              LABEL="Benchmarks"
+              ;;
             BugFix|Bugfix|bugfix)
               LABEL="BugFix"
+              ;;
+            Example|Examples|example|examples)
+              LABEL="Examples"
               ;;
             Feature|Features|feature|features)
               LABEL="Feature"
@@ -109,11 +139,20 @@ jobs:
             Test|Tests|test|tests)
               LABEL="Tests"
               ;;
+            Trainer|Trainers|trainer|trainers)
+              LABEL="Trainers"
+              ;;
             Environment|Environments|environment|environments)
               LABEL="Environments"
               ;;
             Data|data)
               LABEL="Data"
+              ;;
+            LLM|llm)
+              LABEL="llm/"
+              ;;
+            Minor|minor)
+              LABEL="small change"
               ;;
             Performance|Perf|performance|perf)
               LABEL="Performance"
@@ -126,6 +165,12 @@ jobs:
               ;;
             Quality|quality)
               LABEL="Quality"
+              ;;
+            Versioning|versioning)
+              LABEL="versioning"
+              ;;
+            WIP|wip)
+              LABEL="WIP"
               ;;
             *)
               echo "::error::Unknown or invalid prefix '[$PREFIX]'."


### PR DESCRIPTION
## Summary
- Add regular PR title prefixes to the auto-tag workflow: Algorithm, BE, Benchmark(s), Example(s), LLM, Trainer(s), Minor, Versioning, and WIP.
- Map `[Minor]` to `small change` and `[WIP]` to `WIP`.
- Keep multi-prefix titles like `[Feature, Example]` invalid so PR titles continue to choose a single primary prefix.

## Validation
- `git diff --check -- .github/workflows/auto-tag.yml`
- `bash -n` on the extracted workflow shell script
- Stubbed `gh` and checked accepted/rejected mappings locally

## Note
The live repository label list currently does not include `small change` or `WIP`; those labels should be created in GitHub before relying on the new `[Minor]` and `[WIP]` mappings.
