### PR TITLE
[Feature] Make VLA wrappers TensorDict-native

### DIFF
--- a/benchmarks/test_vla_preprocessing_benchmark.py
+++ b/benchmarks/test_vla_preprocessing_benchmark.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Benchmarks for OpenVLA-style image preprocessing.
+
+Run with:
+
+    python -m pytest benchmarks/test_vla_preprocessing_benchmark.py \
+        --benchmark-group-by=func
+"""
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+import torch
+
+from torchrl.data.vla import OpenVLAImagePreprocessor
+
+_has_pil = importlib.util.find_spec("PIL") is not None
+_has_torchvision = importlib.util.find_spec("torchvision") is not None
+
+
+def _make_images(batch_size: int, height: int, width: int) -> torch.Tensor:
+    return torch.randint(0, 256, (batch_size, 3, height, width), dtype=torch.uint8)
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 16, 64])
+@pytest.mark.parametrize("height,width", [(224, 224), (256, 256), (480, 640)])
+@pytest.mark.parametrize("backend", ["pil", "torchvision"])
+def test_openvla_preprocessing_throughput(
+    benchmark, batch_size: int, height: int, width: int, backend: str
+):
+    if backend == "pil" and not _has_pil:
+        pytest.skip("Pillow not found")
+    if backend == "torchvision" and not _has_torchvision:
+        pytest.skip("torchvision not found")
+    images = _make_images(batch_size, height, width)
+    preprocessor = OpenVLAImagePreprocessor(backend=backend, center_crop=True)
+    benchmark(preprocessor, images)

--- a/docs/source/reference/vla.rst
+++ b/docs/source/reference/vla.rst
@@ -185,24 +185,25 @@ backward-compatible composition:
 Chunked policies predict ``[*B, H, action_dim]`` while a standard env consumes
 ``[*B, action_dim]``. The bridge is explicit. Use
 :class:`~torchrl.modules.tensordict_module.MultiStepActorWrapper` when the env
-should keep its one-step MDP: copy ``"action_chunk"`` to the env action key
-``"action"``, let the wrapper cache the chunk, and re-query the expensive VLA
-only when the cache expires or an ``"is_init"`` reset flag is observed. Use
+should keep its one-step MDP: tell the wrapper which policy key contains the
+chunk (for example ``chunk_keys=["action_chunk"]``), let it cache the chunk and
+write the one-step env key (``"action"`` by default), and re-query the expensive
+VLA only when the cache expires or an ``"is_init"`` reset flag is observed. Use
 :class:`~torchrl.envs.transforms.MultiAction` only when you want the env-side
 transform to execute a whole chunk per policy call and accept the resulting
-re-timed MDP.
+re-timed MDP; in that case pass ``chunk_key="action_chunk"`` to make the env
+consume the policy chunk key directly.
 
 Inference loop sketch
 ---------------------
 
 The following pseudocode shows the default one-step env contract. The VLA
-returns chunks, a one-line TensorDict module exposes them as the env action key,
-and :class:`~torchrl.modules.tensordict_module.MultiStepActorWrapper` serves one
-cached action per environment step.
+returns chunks under ``"action_chunk"``, and
+:class:`~torchrl.modules.tensordict_module.MultiStepActorWrapper` serves one
+cached action under the env-facing ``"action"`` key per environment step.
 
 .. code-block:: python
 
-    from tensordict.nn import TensorDictModule, TensorDictSequential
     from torchrl.envs import InitTracker, TransformedEnv
     from torchrl.modules import MultiStepActorWrapper
     from torchrl.modules.vla import TinyVLA
@@ -218,14 +219,10 @@ cached action per environment step.
         output_mode="chunk",
     )
 
-    chunk_as_env_action = TensorDictModule(
-        lambda chunk: chunk,
-        in_keys=["action_chunk"],
-        out_keys=["action"],
-    )
     actor = MultiStepActorWrapper(
-        TensorDictSequential(policy, chunk_as_env_action),
+        policy,
         n_steps=H,
+        chunk_keys=["action_chunk"],
         replan_interval=None,  # open-loop: consume the full chunk before re-querying
     )
 
@@ -244,6 +241,8 @@ cached action per environment step.
 For token-output policies, request decoded chunks with ``output_mode="both"``
 and pass an ``action_tokenizer`` to the wrapper. The env still consumes
 ``"action"``; token fields remain available for logging or RL fine-tuning.
+If the base environment action key is not ``"action"``, pass
+``action_keys=[env_action_key]`` alongside ``chunk_keys``.
 
 Training loop sketch
 --------------------

--- a/docs/source/reference/vla.rst
+++ b/docs/source/reference/vla.rst
@@ -131,6 +131,207 @@ codecs, while ``backend="pil"`` remains available as a reference path.
 
     OpenVLAImagePreprocessor
 
+Policy and environment contract
+-------------------------------
+
+TorchRL keeps the environment boundary intentionally simple: base environments
+do **not** need to know about a model-specific VLA wrapper or its structured
+TensorClasses. The default env/policy contract is still the usual flat
+TensorDict contract:
+
+- on ``reset`` / ``step`` the environment writes observations under the
+  canonical keys, usually ``("observation", "image")``, optional
+  ``("observation", "state")`` and ``"language_instruction"``;
+- on ``step`` the environment consumes one continuous action under
+  ``"action"`` with shape ``[*B, action_dim]``;
+- datasets and replay buffers may additionally carry training targets such as
+  ``"action_chunk"``, ``"action_tokens"`` and ``"action_is_pad"``.
+
+The VLA TensorClasses are structured policy/data containers, not a required env
+API:
+
+- :class:`~torchrl.data.vla.VLAImages` groups primary, wrist and extra camera
+  tensors.
+- :class:`~torchrl.data.vla.VLAObservation` lets a data pipeline store a
+  structured or already-preprocessed observation under ``"vla_observation"``
+  when a wrapper is built with ``input_mode="preprocessed"``.
+- :class:`~torchrl.data.vla.VLAAction` mirrors policy outputs under
+  ``"vla_action"`` for structured consumers, while the flat compatibility keys
+  remain the default path for envs, transforms and losses.
+
+In other words, a wrapper may read either canonical env keys
+(``input_mode="canonical"``) or a preprocessed
+:class:`~torchrl.data.vla.VLAObservation`
+(``input_mode="preprocessed"``), but it always exposes flat outputs for
+backward-compatible composition:
+
+.. list-table:: Default policy outputs
+    :header-rows: 1
+
+    * - ``output_mode``
+      - Flat keys
+      - Structured mirror
+    * - ``"chunk"``
+      - ``"action_chunk"``
+      - ``"vla_action".chunk``
+    * - ``"tokens"``
+      - ``"action_tokens"``, optional ``"log_probs"`` /
+        ``"action_logits"`` / ``"action_mask"``
+      - ``"vla_action".tokens``, ``.log_probs``, ``.logits``, ``.mask``
+    * - ``"both"``
+      - ``"action_chunk"`` and ``"action_tokens"`` plus optional token fields
+      - Both ``"vla_action".chunk`` and ``"vla_action".tokens``
+
+Chunked policies predict ``[*B, H, action_dim]`` while a standard env consumes
+``[*B, action_dim]``. The bridge is explicit. Use
+:class:`~torchrl.modules.tensordict_module.MultiStepActorWrapper` when the env
+should keep its one-step MDP: copy ``"action_chunk"`` to the env action key
+``"action"``, let the wrapper cache the chunk, and re-query the expensive VLA
+only when the cache expires or an ``"is_init"`` reset flag is observed. Use
+:class:`~torchrl.envs.transforms.MultiAction` only when you want the env-side
+transform to execute a whole chunk per policy call and accept the resulting
+re-timed MDP.
+
+Inference loop sketch
+---------------------
+
+The following pseudocode shows the default one-step env contract. The VLA
+returns chunks, a one-line TensorDict module exposes them as the env action key,
+and :class:`~torchrl.modules.tensordict_module.MultiStepActorWrapper` serves one
+cached action per environment step.
+
+.. code-block:: python
+
+    from tensordict.nn import TensorDictModule, TensorDictSequential
+    from torchrl.envs import InitTracker, TransformedEnv
+    from torchrl.modules import MultiStepActorWrapper
+    from torchrl.modules.vla import TinyVLA
+
+    H = 8
+    base_env = make_robot_env()
+    # base_env writes observation.image, observation.state and language_instruction
+    env = TransformedEnv(base_env, InitTracker())  # writes is_init after reset
+
+    policy = TinyVLA(
+        action_dim=env.action_spec.shape[-1],
+        chunk_size=H,
+        output_mode="chunk",
+    )
+
+    chunk_as_env_action = TensorDictModule(
+        lambda chunk: chunk,
+        in_keys=["action_chunk"],
+        out_keys=["action"],
+    )
+    actor = MultiStepActorWrapper(
+        TensorDictSequential(policy, chunk_as_env_action),
+        n_steps=H,
+        replan_interval=None,  # open-loop: consume the full chunk before re-querying
+    )
+
+    td = env.reset()
+    for _ in range(max_steps):
+        td = actor(td)
+        # td now contains:
+        # - action_chunk: the predicted H-step chunk on re-plan steps
+        # - vla_action: the structured mirror of the policy output
+        # - action: the single env-facing action served from the cache
+        td = env.step(td)
+        td = td["next"]
+        if td["done"].any():
+            td = env.reset(td)
+
+For token-output policies, request decoded chunks with ``output_mode="both"``
+and pass an ``action_tokenizer`` to the wrapper. The env still consumes
+``"action"``; token fields remain available for logging or RL fine-tuning.
+
+Training loop sketch
+--------------------
+
+For offline chunked behavior cloning, the replay buffer stores canonical
+observations and raw actions. Transforms build the training target
+``"action_chunk"`` and its padding mask; the VLA wrapper reads observations and
+predicts a chunk with the same flat key that :class:`~torchrl.objectives.BCLoss`
+uses.
+
+.. code-block:: python
+
+    from torchrl.envs.transforms import ActionChunkTransform, Compose
+    from torchrl.modules.vla import TinyVLA
+    from torchrl.objectives import BCLoss
+
+    H = 8
+    replay_buffer = make_vla_replay_buffer(
+        transform=Compose(
+            # Optional: ActionScaling.from_metadata(...),
+            ActionChunkTransform(chunk_size=H),
+        )
+    )
+
+    policy = TinyVLA(action_dim=action_dim, chunk_size=H, output_mode="chunk")
+    loss_module = BCLoss(policy, loss_function="l1")
+    loss_module.set_keys(action="action_chunk", pad_mask="action_is_pad")
+
+    optimizer = make_optimizer(policy.parameters())
+    for _ in range(num_updates):
+        batch = replay_buffer.sample(batch_size)
+        loss_td = loss_module(batch)
+        loss = loss_td["loss_bc"]
+
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+Token RL fine-tuning uses the same policy contract. The rollout stores sampled
+``"action_tokens"`` and behavior-policy ``"log_probs"``. During the update,
+``get_dist`` / ``log_prob`` recompute the current policy probabilities from the
+same observations, and :class:`~torchrl.objectives.ClipPPOLoss` consumes the
+flat token keys.
+
+.. code-block:: python
+
+    from torchrl.modules.vla import TinyVLA
+    from torchrl.objectives import ClipPPOLoss
+
+    policy = TinyVLA(
+        action_dim=action_dim,
+        chunk_size=H,
+        action_head="tokens",
+        vocab_size=tokenizer.vocab_size,
+        action_tokenizer=tokenizer,
+        output_mode="both",  # tokens for the loss, decoded chunks for the env
+        return_log_probs=True,
+    )
+    ppo_loss = ClipPPOLoss(policy, critic_network=None, entropy_bonus=False)
+    ppo_loss.set_keys(
+        action="action_tokens",
+        sample_log_prob="log_probs",
+        advantage="advantage",
+    )
+
+    for _ in range(num_updates):
+        rollout = collector.next()  # contains sampled action_tokens and old log_probs
+        rollout["advantage"] = compute_group_relative_advantage(rollout)
+        # ClipPPOLoss calls the policy to recompute current token log-probs
+        # against the stored actions, while log_probs remains the behavior
+        # policy value collected during rollout.
+        loss_td = ppo_loss(rollout)
+        loss = loss_td["loss_objective"] + loss_td.get("loss_entropy", 0)
+
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+If you write a custom token objective instead of using
+:class:`~torchrl.objectives.ClipPPOLoss`, use :meth:`~torchrl.modules.vla.VLAWrapperBase.log_prob`
+with a separate output key so the behavior-policy log-probabilities remain
+available for ratios:
+
+.. code-block:: python
+
+    batch = policy.log_prob(batch, log_probs_key="new_log_probs")
+    ratio = (batch["new_log_probs"] - batch["log_probs"]).exp()
+
 Policies
 --------
 

--- a/docs/source/reference/vla.rst
+++ b/docs/source/reference/vla.rst
@@ -35,10 +35,14 @@ and the LeRobot dataset format::
         ),
         language_instruction: NonTensorData | Text,           # raw or tokenized (per-traj)
         action: float [*B, T, action_dim],                    # raw, per-step
-        action_chunk: float [*B, T, chunk, action_dim],       # built for training
+        vla_action: VLAAction(
+            chunk: float [*B, T, chunk, action_dim],          # built for training
+            tokens: long [*B, T, chunk, action_dim],          # tokenized actions
+            log_probs: float [*B, T] or [*B, T, chunk, action_dim],
+            logits: float [*B, T, chunk, action_dim, vocab],
+            mask: bool [*B, T, chunk, action_dim, vocab],
+        ),
         action_is_pad: bool [*B, T, chunk],                   # chunk validity mask
-        action_tokens: long [*B, T, chunk, action_dim],       # tokenized actions
-        vla_action: VLAAction(...),                           # structured policy output
         next: TensorDict(...),                                 # TED layout
     )
 
@@ -145,7 +149,8 @@ TensorDict contract:
 - on ``step`` the environment consumes one continuous action under
   ``"action"`` with shape ``[*B, action_dim]``;
 - datasets and replay buffers may additionally carry training targets such as
-  ``"action_chunk"``, ``"action_tokens"`` and ``"action_is_pad"``.
+  ``("vla_action", "chunk")``, ``("vla_action", "tokens")`` and
+  ``"action_is_pad"``.
 
 The VLA TensorClasses are structured policy/data containers, not a required env
 API:
@@ -155,50 +160,81 @@ API:
 - :class:`~torchrl.data.vla.VLAObservation` lets a data pipeline store a
   structured or already-preprocessed observation under ``"vla_observation"``
   when a wrapper is built with ``input_mode="preprocessed"``.
-- :class:`~torchrl.data.vla.VLAAction` mirrors policy outputs under
-  ``"vla_action"`` for structured consumers, while the flat compatibility keys
-  remain the default path for envs, transforms and losses.
+- :class:`~torchrl.data.vla.VLAAction` stores policy outputs under
+  ``"vla_action"``. Its fields are also regular nested TensorDict keys such as
+  ``("vla_action", "chunk")`` and can be discovered by collectors, transforms
+  and losses.
 
 In other words, a wrapper may read either canonical env keys
 (``input_mode="canonical"``) or a preprocessed
 :class:`~torchrl.data.vla.VLAObservation`
-(``input_mode="preprocessed"``), but it always exposes flat outputs for
-backward-compatible composition:
+(``input_mode="preprocessed"``), and it exposes structured output keys by
+default:
 
 .. list-table:: Default policy outputs
     :header-rows: 1
 
     * - ``output_mode``
-      - Flat keys
-      - Structured mirror
+      - Default keys
+      - TensorClass field
     * - ``"chunk"``
-      - ``"action_chunk"``
+      - ``("vla_action", "chunk")``
       - ``"vla_action".chunk``
     * - ``"tokens"``
-      - ``"action_tokens"``, optional ``"log_probs"`` /
-        ``"action_logits"`` / ``"action_mask"``
+      - ``("vla_action", "tokens")``, optional
+        ``("vla_action", "log_probs")`` / ``("vla_action", "logits")`` /
+        ``("vla_action", "mask")``
       - ``"vla_action".tokens``, ``.log_probs``, ``.logits``, ``.mask``
     * - ``"both"``
-      - ``"action_chunk"`` and ``"action_tokens"`` plus optional token fields
+      - ``("vla_action", "chunk")`` and ``("vla_action", "tokens")`` plus
+        optional token fields
       - Both ``"vla_action".chunk`` and ``"vla_action".tokens``
 
 Chunked policies predict ``[*B, H, action_dim]`` while a standard env consumes
 ``[*B, action_dim]``. The bridge is explicit. Use
 :class:`~torchrl.modules.tensordict_module.MultiStepActorWrapper` when the env
 should keep its one-step MDP: tell the wrapper which policy key contains the
-chunk (for example ``chunk_keys=["action_chunk"]``), let it cache the chunk and
-write the one-step env key (``"action"`` by default), and re-query the expensive
-VLA only when the cache expires or an ``"is_init"`` reset flag is observed. Use
+chunk, let it cache the chunk and write the one-step env key (``"action"`` by
+default), and re-query the expensive VLA only when the cache expires or an
+``"is_init"`` reset flag is observed. The wrapper auto-discovers the default
+VLA key ``("vla_action", "chunk")`` from the policy's ``out_keys``. Use
 :class:`~torchrl.envs.transforms.MultiAction` only when you want the env-side
 transform to execute a whole chunk per policy call and accept the resulting
-re-timed MDP; in that case pass ``chunk_key="action_chunk"`` to make the env
-consume the policy chunk key directly.
+re-timed MDP; in that case use :meth:`~torchrl.envs.transforms.MultiAction.from_vla`
+or pass ``chunk_key=("vla_action", "chunk")`` to make the env consume the
+policy chunk key directly.
+
+Choosing a chunk executor
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :class:`~torchrl.modules.tensordict_module.MultiStepActorWrapper` when you
+want the environment clock to stay unchanged:
+
+- one outer rollout step is one base-environment step;
+- the collector records one reward/done/next-observation per base step;
+- the VLA is called only on re-plan steps and skipped while the cached chunk is
+  being served;
+- ``replan_interval=None`` is open-loop over the whole chunk,
+  ``replan_interval=1`` is closed-loop, and intermediate values are
+  receding-horizon execution.
+
+Use :class:`~torchrl.envs.transforms.MultiAction` when you intentionally want a
+macro-action environment:
+
+- one outer rollout step executes the whole chunk inside the env transform;
+- rewards and observations can be stacked over the chunk or collapsed to the
+  last base step;
+- the MDP is re-timed, which can be convenient for evaluation or scripted
+  macro-actions but changes the meaning of the rollout time dimension for RL.
+
+For online VLA RL, prefer :class:`~torchrl.modules.tensordict_module.MultiStepActorWrapper`
+unless you explicitly want macro-steps.
 
 Inference loop sketch
 ---------------------
 
 The following pseudocode shows the default one-step env contract. The VLA
-returns chunks under ``"action_chunk"``, and
+returns chunks under ``("vla_action", "chunk")``, and
 :class:`~torchrl.modules.tensordict_module.MultiStepActorWrapper` serves one
 cached action under the env-facing ``"action"`` key per environment step.
 
@@ -222,7 +258,6 @@ cached action under the env-facing ``"action"`` key per environment step.
     actor = MultiStepActorWrapper(
         policy,
         n_steps=H,
-        chunk_keys=["action_chunk"],
         replan_interval=None,  # open-loop: consume the full chunk before re-querying
     )
 
@@ -230,8 +265,8 @@ cached action under the env-facing ``"action"`` key per environment step.
     for _ in range(max_steps):
         td = actor(td)
         # td now contains:
-        # - action_chunk: the predicted H-step chunk on re-plan steps
-        # - vla_action: the structured mirror of the policy output
+        # - ("vla_action", "chunk"): the predicted H-step chunk on re-plan steps
+        # - vla_action: the structured policy output
         # - action: the single env-facing action served from the cache
         td = env.step(td)
         td = td["next"]
@@ -242,16 +277,16 @@ For token-output policies, request decoded chunks with ``output_mode="both"``
 and pass an ``action_tokenizer`` to the wrapper. The env still consumes
 ``"action"``; token fields remain available for logging or RL fine-tuning.
 If the base environment action key is not ``"action"``, pass
-``action_keys=[env_action_key]`` alongside ``chunk_keys``.
+``action_keys=[env_action_key]``.
 
 Training loop sketch
 --------------------
 
 For offline chunked behavior cloning, the replay buffer stores canonical
 observations and raw actions. Transforms build the training target
-``"action_chunk"`` and its padding mask; the VLA wrapper reads observations and
-predicts a chunk with the same flat key that :class:`~torchrl.objectives.BCLoss`
-uses.
+``("vla_action", "chunk")`` and its padding mask; the VLA wrapper reads
+observations and predicts a chunk with the same nested key that
+:class:`~torchrl.objectives.BCLoss` uses.
 
 .. code-block:: python
 
@@ -269,7 +304,7 @@ uses.
 
     policy = TinyVLA(action_dim=action_dim, chunk_size=H, output_mode="chunk")
     loss_module = BCLoss(policy, loss_function="l1")
-    loss_module.set_keys(action="action_chunk", pad_mask="action_is_pad")
+    loss_module.set_keys(action=("vla_action", "chunk"), pad_mask="action_is_pad")
 
     optimizer = make_optimizer(policy.parameters())
     for _ in range(num_updates):
@@ -282,10 +317,11 @@ uses.
         optimizer.step()
 
 Token RL fine-tuning uses the same policy contract. The rollout stores sampled
-``"action_tokens"`` and behavior-policy ``"log_probs"``. During the update,
-``get_dist`` / ``log_prob`` recompute the current policy probabilities from the
-same observations, and :class:`~torchrl.objectives.ClipPPOLoss` consumes the
-flat token keys.
+``("vla_action", "tokens")`` and behavior-policy
+``("vla_action", "log_probs")``. During the update, ``get_dist`` /
+``log_prob`` recompute the current policy probabilities from the same
+observations, and :class:`~torchrl.objectives.ClipPPOLoss` consumes the nested
+token keys.
 
 .. code-block:: python
 
@@ -303,13 +339,13 @@ flat token keys.
     )
     ppo_loss = ClipPPOLoss(policy, critic_network=None, entropy_bonus=False)
     ppo_loss.set_keys(
-        action="action_tokens",
-        sample_log_prob="log_probs",
+        action=("vla_action", "tokens"),
+        sample_log_prob=("vla_action", "log_probs"),
         advantage="advantage",
     )
 
     for _ in range(num_updates):
-        rollout = collector.next()  # contains sampled action_tokens and old log_probs
+        rollout = collector.next()  # contains sampled tokens and old log_probs
         rollout["advantage"] = compute_group_relative_advantage(rollout)
         # ClipPPOLoss calls the policy to recompute current token log-probs
         # against the stored actions, while log_probs remains the behavior
@@ -329,7 +365,7 @@ available for ratios:
 .. code-block:: python
 
     batch = policy.log_prob(batch, log_probs_key="new_log_probs")
-    ratio = (batch["new_log_probs"] - batch["log_probs"]).exp()
+    ratio = (batch["new_log_probs"] - batch["vla_action", "log_probs"]).exp()
 
 Policies
 --------
@@ -340,10 +376,9 @@ action chunk (continuous), action tokens (discrete), or both.
 :class:`~torchrl.modules.vla.VLAWrapperBase` fixes that contract with explicit
 ``input_mode`` / ``output_mode`` settings, ``tensordict_out`` and
 ``logits_only`` forward paths, plus ``get_dist`` and ``log_prob`` methods for
-loss-time recomputation. Existing flat keys (``action_chunk``,
-``action_tokens``, ``action_logits``, ``action_mask`` and ``log_probs``) remain
-the loss/transform compatibility path; the same values are mirrored into a
-structured :class:`~torchrl.data.vla.VLAAction` under ``vla_action``.
+loss-time recomputation. The default output keys are the nested
+``VLAAction`` fields, and can still be overridden through ``set_keys`` when a
+legacy flat layout is required.
 :class:`~torchrl.modules.vla.TinyVLA` is a small reference policy for tests and
 tutorials.
 
@@ -381,7 +416,7 @@ apply directly:
   ``pad_mask`` key::
 
       loss = BCLoss(policy, loss_function="l1")
-      loss.set_keys(action="action_chunk", pad_mask="action_is_pad")
+      loss.set_keys(action=("vla_action", "chunk"), pad_mask="action_is_pad")
 
 - *Token RL fine-tuning* (GRPO-style, following SimpleVLA-RL / RL4VLA) is
   :class:`~torchrl.objectives.ClipPPOLoss` over the action tokens: advantages
@@ -392,5 +427,7 @@ apply directly:
 
       loss = ClipPPOLoss(policy, critic_network=None, entropy_bonus=False)
       loss.set_keys(
-          action="action_tokens", sample_log_prob="log_probs", advantage="advantage"
+          action=("vla_action", "tokens"),
+          sample_log_prob=("vla_action", "log_probs"),
+          advantage="advantage",
       )

--- a/docs/source/reference/vla.rst
+++ b/docs/source/reference/vla.rst
@@ -171,23 +171,37 @@ In other words, a wrapper may read either canonical env keys
 (``input_mode="preprocessed"``), and it exposes structured output keys by
 default:
 
+Here ``H`` is ``chunk_size`` and ``*B`` is the TensorDict batch shape.
+
 .. list-table:: Default policy outputs
     :header-rows: 1
 
     * - ``output_mode``
       - Default keys
+      - dtype
+      - shape
       - TensorClass field
     * - ``"chunk"``
       - ``("vla_action", "chunk")``
+      - floating point
+      - ``[*B, H, action_dim]``
       - ``"vla_action".chunk``
     * - ``"tokens"``
       - ``("vla_action", "tokens")``, optional
         ``("vla_action", "log_probs")`` / ``("vla_action", "logits")`` /
         ``("vla_action", "mask")``
+      - ``long`` for tokens, floating point for log-probs/logits, ``bool`` for
+        mask
+      - tokens: ``[*B, H, action_dim]``; log-probs: ``[*B]`` in
+        ``log_probs_mode="sequence"`` or ``[*B, H, action_dim]`` in
+        ``log_probs_mode="token"``; logits/mask:
+        ``[*B, H, action_dim, vocab_size]``
       - ``"vla_action".tokens``, ``.log_probs``, ``.logits``, ``.mask``
     * - ``"both"``
       - ``("vla_action", "chunk")`` and ``("vla_action", "tokens")`` plus
         optional token fields
+      - floating point for chunk; token-field dtypes as above
+      - chunk: ``[*B, H, action_dim]``; token-field shapes as above
       - Both ``"vla_action".chunk`` and ``"vla_action".tokens``
 
 Chunked policies predict ``[*B, H, action_dim]`` while a standard env consumes

--- a/docs/source/reference/vla.rst
+++ b/docs/source/reference/vla.rst
@@ -38,6 +38,7 @@ and the LeRobot dataset format::
         action_chunk: float [*B, T, chunk, action_dim],       # built for training
         action_is_pad: bool [*B, T, chunk],                   # chunk validity mask
         action_tokens: long [*B, T, chunk, action_dim],       # tokenized actions
+        vla_action: VLAAction(...),                           # structured policy output
         next: TensorDict(...),                                 # TED layout
     )
 
@@ -61,6 +62,9 @@ Data and metadata
     :template: rl_template_noinherit.rst
 
     RobotDatasetMetadata
+    VLAAction
+    VLAImages
+    VLAObservation
     validate_vla_tensordict
 
 Robot VLA trajectories can be loaded into the canonical schema from
@@ -110,14 +114,38 @@ a language-model head.
     UniformActionTokenizer
     VocabTailActionTokenizer
 
+Image preprocessing
+-------------------
+
+The reusable :class:`~torchrl.data.vla.OpenVLAImagePreprocessor` implements the
+OpenVLA-style image preprocessing order used by OpenVLA-OFT policies: square
+resize, JPEG quality-95 round trip, optional 0.9-area center crop and resize
+back. Its default backend keeps images as tensors and uses ``torchvision`` JPEG
+codecs, while ``backend="pil"`` remains available as a reference path.
+
+.. currentmodule:: torchrl.data.vla
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template_noinherit.rst
+
+    OpenVLAImagePreprocessor
+
 Policies
 --------
 
 A VLA policy is an ordinary :class:`~tensordict.nn.TensorDictModuleBase` that
 maps images, optional proprioceptive state and a language instruction to an
-action chunk (continuous) or action tokens (discrete). :class:`~torchrl.modules.vla.VLAWrapperBase`
-fixes that contract; :class:`~torchrl.modules.vla.TinyVLA` is a small reference
-policy for tests and tutorials.
+action chunk (continuous), action tokens (discrete), or both.
+:class:`~torchrl.modules.vla.VLAWrapperBase` fixes that contract with explicit
+``input_mode`` / ``output_mode`` settings, ``tensordict_out`` and
+``logits_only`` forward paths, plus ``get_dist`` and ``log_prob`` methods for
+loss-time recomputation. Existing flat keys (``action_chunk``,
+``action_tokens``, ``action_logits``, ``action_mask`` and ``log_probs``) remain
+the loss/transform compatibility path; the same values are mirrored into a
+structured :class:`~torchrl.data.vla.VLAAction` under ``vla_action``.
+:class:`~torchrl.modules.vla.TinyVLA` is a small reference policy for tests and
+tutorials.
 
 .. currentmodule:: torchrl.modules.vla
 

--- a/docs/source/reference/vla.rst
+++ b/docs/source/reference/vla.rst
@@ -253,7 +253,6 @@ cached action under the env-facing ``"action"`` key per environment step.
     policy = TinyVLA(
         action_dim=env.action_spec.shape[-1],
         chunk_size=H,
-        output_mode="chunk",
     )
 
     actor = MultiStepActorWrapper(
@@ -302,7 +301,7 @@ observations and predicts a chunk with the same nested key that
         )
     )
 
-    policy = TinyVLA(action_dim=action_dim, chunk_size=H, output_mode="chunk")
+    policy = TinyVLA(action_dim=action_dim, chunk_size=H)
     loss_module = BCLoss(policy, loss_function="l1")
     loss_module.set_keys(action=("vla_action", "chunk"), pad_mask="action_is_pad")
 

--- a/docs/source/reference/vla.rst
+++ b/docs/source/reference/vla.rst
@@ -197,7 +197,8 @@ should keep its one-step MDP: tell the wrapper which policy key contains the
 chunk, let it cache the chunk and write the one-step env key (``"action"`` by
 default), and re-query the expensive VLA only when the cache expires or an
 ``"is_init"`` reset flag is observed. The wrapper auto-discovers the default
-VLA key ``("vla_action", "chunk")`` from the policy's ``out_keys``. Use
+VLA key ``("vla_action", "chunk")`` from the policy's ``out_keys`` and keeps
+that key as the cache rather than copying it to a second root key. Use
 :class:`~torchrl.envs.transforms.MultiAction` only when you want the env-side
 transform to execute a whole chunk per policy call and accept the resulting
 re-timed MDP; in that case use :meth:`~torchrl.envs.transforms.MultiAction.from_vla`
@@ -265,8 +266,7 @@ cached action under the env-facing ``"action"`` key per environment step.
     for _ in range(max_steps):
         td = actor(td)
         # td now contains:
-        # - ("vla_action", "chunk"): the predicted H-step chunk on re-plan steps
-        # - vla_action: the structured policy output
+        # - ("vla_action", "chunk"): the cached H-step policy chunk
         # - action: the single env-facing action served from the cache
         td = env.step(td)
         td = td["next"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ video = ["torchcodec>=0.10.0"]
 notebook = ["jupyterlab"]
 # lerobot requires Python >= 3.12 (and lerobot <= 0.4 cannot resolve against
 # recent torch), so the extra is empty on older interpreters
-vla = ["lerobot>=0.5.0; python_version >= '3.12'"]
+vla = ["lerobot>=0.5.0; python_version >= '3.12'", "torchvision"]
 rendering = ["moviepy", "torchcodec>=0.10.0"]
 tests = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ explicit = true
 [tool.uv.sources]
 tensordict = { git = "https://github.com/pytorch/tensordict" }
 torch = { index = "pytorch-nightly", marker = "sys_platform == 'darwin' and python_version != '3.12'" }
+torchvision = { index = "pytorch-nightly", marker = "sys_platform == 'darwin' and python_version != '3.12'" }
 
 [[tool.uv.dependency-metadata]]
 name = "lerobot"
@@ -89,7 +90,7 @@ video = ["torchcodec>=0.10.0"]
 notebook = ["jupyterlab"]
 # lerobot requires Python >= 3.12 (and lerobot <= 0.4 cannot resolve against
 # recent torch), so the extra is empty on older interpreters
-vla = ["lerobot>=0.5.0; python_version >= '3.12'", "torchvision"]
+vla = ["lerobot>=0.5.0; python_version >= '3.12'", "torchvision>=0.17"]
 rendering = ["moviepy", "torchcodec>=0.10.0"]
 tests = [
     "pytest",

--- a/test/data/test_vla.py
+++ b/test/data/test_vla.py
@@ -32,6 +32,11 @@ from torchrl.data.vla import (
 _has_pil = importlib.util.find_spec("PIL") is not None
 _has_torchvision = importlib.util.find_spec("torchvision") is not None
 
+if _has_torchvision:
+    import torchvision.io as torchvision_io
+else:
+    torchvision_io = None
+
 
 def _make_vla_td(batch=2, action_dim=7, *, with_instruction=True, finite=True):
     obs = {"image": torch.zeros(batch, 3, 8, 8, dtype=torch.uint8)}
@@ -294,6 +299,48 @@ class TestOpenVLAImagePreprocessor:
         assert fast.shape == ref.shape == torch.Size([2, 3, 32, 32])
         assert fast.dtype == ref.dtype == torch.uint8
         assert (fast.float() - ref.float()).abs().mean() < 25.0
+
+    @pytest.mark.skipif(not _has_torchvision, reason="torchvision not found")
+    def test_torchvision_backend_falls_back_to_single_image_jpeg(self, monkeypatch):
+        original_encode_jpeg = torchvision_io.encode_jpeg
+
+        def encode_jpeg(input, quality=75):
+            if isinstance(input, list):
+                raise RuntimeError(
+                    "image::encode_jpeg() Expected a value of type 'Tensor'"
+                )
+            return original_encode_jpeg(input, quality=quality)
+
+        monkeypatch.setattr(torchvision_io, "encode_jpeg", encode_jpeg)
+        proc = OpenVLAImagePreprocessor(
+            size=32, backend="torchvision", center_crop=False
+        )
+        images = torch.randint(0, 256, (2, 3, 24, 40), dtype=torch.uint8)
+        out = proc(images)
+        assert out.shape == torch.Size([2, 3, 32, 32])
+        assert out.dtype == torch.uint8
+
+    @pytest.mark.skipif(not _has_torchvision, reason="torchvision not found")
+    def test_torchvision_backend_falls_back_to_single_image_decode(self, monkeypatch):
+        original_decode_jpeg = torchvision_io.decode_jpeg
+
+        def decode_jpeg(input, mode=None, device="cpu"):
+            if isinstance(input, list):
+                raise RuntimeError(
+                    "image::decode_jpeg() Expected a value of type 'Tensor'"
+                )
+            if mode is None:
+                mode = torchvision_io.ImageReadMode.UNCHANGED
+            return original_decode_jpeg(input, mode=mode, device=device)
+
+        monkeypatch.setattr(torchvision_io, "decode_jpeg", decode_jpeg)
+        proc = OpenVLAImagePreprocessor(
+            size=32, backend="torchvision", center_crop=False
+        )
+        images = torch.randint(0, 256, (2, 3, 24, 40), dtype=torch.uint8)
+        out = proc(images)
+        assert out.shape == torch.Size([2, 3, 32, 32])
+        assert out.dtype == torch.uint8
 
     @pytest.mark.skipif(not _has_pil, reason="Pillow not found")
     def test_normalization(self):

--- a/test/data/test_vla.py
+++ b/test/data/test_vla.py
@@ -7,6 +7,7 @@ robot-dataset metadata container and the action tokenizers."""
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 
 import numpy as np
@@ -18,11 +19,18 @@ from torchrl.data.vla import (
     ACTION_KEY,
     ActionTokenizerBase,
     INSTRUCTION_KEY,
+    OpenVLAImagePreprocessor,
     RobotDatasetMetadata,
     UniformActionTokenizer,
     validate_vla_tensordict,
+    VLAAction,
+    VLAImages,
+    VLAObservation,
     VocabTailActionTokenizer,
 )
+
+_has_pil = importlib.util.find_spec("PIL") is not None
+_has_torchvision = importlib.util.find_spec("torchvision") is not None
 
 
 def _make_vla_td(batch=2, action_dim=7, *, with_instruction=True, finite=True):
@@ -239,6 +247,62 @@ class TestVLASchema:
             )
             == []
         )
+
+
+class TestVLAContainers:
+    def test_action_container(self):
+        action = VLAAction(
+            chunk=torch.zeros(2, 4, 7),
+            tokens=torch.zeros(2, 4, 7, dtype=torch.long),
+            batch_size=[2],
+        )
+        assert action.chunk.shape == torch.Size([2, 4, 7])
+        assert action.tokens.dtype == torch.long
+
+    def test_observation_container(self):
+        images = VLAImages(
+            image=torch.zeros(2, 3, 16, 16, dtype=torch.uint8), batch_size=[2]
+        )
+        obs = VLAObservation(
+            images=images,
+            state=torch.zeros(2, 5),
+            instruction=["pick", "place"],
+            batch_size=[2],
+        )
+        assert obs.images.image.shape == torch.Size([2, 3, 16, 16])
+        assert obs.state.shape == torch.Size([2, 5])
+
+
+class TestOpenVLAImagePreprocessor:
+    @pytest.mark.skipif(not _has_pil, reason="Pillow not found")
+    def test_pil_backend_shapes(self):
+        proc = OpenVLAImagePreprocessor(size=32, backend="pil", center_crop=True)
+        images = torch.randint(0, 256, (2, 3, 24, 40), dtype=torch.uint8)
+        out = proc(images)
+        assert out.shape == torch.Size([2, 3, 32, 32])
+        assert out.dtype == torch.uint8
+
+    @pytest.mark.skipif(
+        not (_has_pil and _has_torchvision), reason="Pillow/torchvision not found"
+    )
+    def test_torchvision_backend_matches_reference_shape(self):
+        images = torch.randint(0, 256, (2, 3, 24, 40), dtype=torch.uint8)
+        pil = OpenVLAImagePreprocessor(size=32, backend="pil", center_crop=False)
+        tv = OpenVLAImagePreprocessor(size=32, backend="torchvision", center_crop=False)
+        ref = pil(images)
+        fast = tv(images)
+        assert fast.shape == ref.shape == torch.Size([2, 3, 32, 32])
+        assert fast.dtype == ref.dtype == torch.uint8
+        assert (fast.float() - ref.float()).abs().mean() < 25.0
+
+    @pytest.mark.skipif(not _has_pil, reason="Pillow not found")
+    def test_normalization(self):
+        proc = OpenVLAImagePreprocessor(
+            size=16, backend="pil", mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]
+        )
+        out = proc(torch.zeros(3, 16, 16, dtype=torch.uint8))
+        assert out.shape == torch.Size([3, 16, 16])
+        assert out.dtype == torch.float32
 
 
 class TestActionTokenizer:

--- a/test/data/test_vla.py
+++ b/test/data/test_vla.py
@@ -32,11 +32,6 @@ from torchrl.data.vla import (
 _has_pil = importlib.util.find_spec("PIL") is not None
 _has_torchvision = importlib.util.find_spec("torchvision") is not None
 
-if _has_torchvision:
-    import torchvision.io as torchvision_io
-else:
-    torchvision_io = None
-
 
 def _make_vla_td(batch=2, action_dim=7, *, with_instruction=True, finite=True):
     obs = {"image": torch.zeros(batch, 3, 8, 8, dtype=torch.uint8)}
@@ -299,48 +294,6 @@ class TestOpenVLAImagePreprocessor:
         assert fast.shape == ref.shape == torch.Size([2, 3, 32, 32])
         assert fast.dtype == ref.dtype == torch.uint8
         assert (fast.float() - ref.float()).abs().mean() < 25.0
-
-    @pytest.mark.skipif(not _has_torchvision, reason="torchvision not found")
-    def test_torchvision_backend_falls_back_to_single_image_jpeg(self, monkeypatch):
-        original_encode_jpeg = torchvision_io.encode_jpeg
-
-        def encode_jpeg(input, quality=75):
-            if isinstance(input, list):
-                raise RuntimeError(
-                    "image::encode_jpeg() Expected a value of type 'Tensor'"
-                )
-            return original_encode_jpeg(input, quality=quality)
-
-        monkeypatch.setattr(torchvision_io, "encode_jpeg", encode_jpeg)
-        proc = OpenVLAImagePreprocessor(
-            size=32, backend="torchvision", center_crop=False
-        )
-        images = torch.randint(0, 256, (2, 3, 24, 40), dtype=torch.uint8)
-        out = proc(images)
-        assert out.shape == torch.Size([2, 3, 32, 32])
-        assert out.dtype == torch.uint8
-
-    @pytest.mark.skipif(not _has_torchvision, reason="torchvision not found")
-    def test_torchvision_backend_falls_back_to_single_image_decode(self, monkeypatch):
-        original_decode_jpeg = torchvision_io.decode_jpeg
-
-        def decode_jpeg(input, mode=None, device="cpu"):
-            if isinstance(input, list):
-                raise RuntimeError(
-                    "image::decode_jpeg() Expected a value of type 'Tensor'"
-                )
-            if mode is None:
-                mode = torchvision_io.ImageReadMode.UNCHANGED
-            return original_decode_jpeg(input, mode=mode, device=device)
-
-        monkeypatch.setattr(torchvision_io, "decode_jpeg", decode_jpeg)
-        proc = OpenVLAImagePreprocessor(
-            size=32, backend="torchvision", center_crop=False
-        )
-        images = torch.randint(0, 256, (2, 3, 24, 40), dtype=torch.uint8)
-        out = proc(images)
-        assert out.shape == torch.Size([2, 3, 32, 32])
-        assert out.dtype == torch.uint8
 
     @pytest.mark.skipif(not _has_pil, reason="Pillow not found")
     def test_normalization(self):

--- a/test/modules/test_actor.py
+++ b/test/modules/test_actor.py
@@ -767,6 +767,63 @@ class TestBatchedActor:
         assert executed == expected
         assert len(calls) == -(-6 // interval)  # ceil division
 
+    def test_replan_interval_chunk_key(self):
+        # VLA-style policies write action_chunk while the environment consumes
+        # action: no extra TensorDictModule should be needed to bridge the keys.
+        n_steps, calls = 4, []
+
+        def make_chunk(x):
+            calls.append(1)
+            chunk = torch.full((x.shape[0], n_steps, 1), float(len(calls)))
+            chunk += torch.arange(n_steps).view(1, n_steps, 1) / 10
+            return chunk
+
+        actor_base = TensorDictModule(
+            make_chunk, in_keys=["observation"], out_keys=["action_chunk"]
+        )
+        actor = MultiStepActorWrapper(
+            actor_base, n_steps=n_steps, chunk_keys=["action_chunk"]
+        )
+        td = TensorDict(
+            {
+                "observation": torch.zeros(2, 1),
+                "is_init": torch.ones(2, 1, dtype=torch.bool),
+            },
+            batch_size=[2],
+        )
+        executed = []
+        for _ in range(6):
+            td = actor(td.exclude("action"))
+            executed.append(round(td["action"][0, 0].item(), 1))
+            td["is_init"] = torch.zeros(2, 1, dtype=torch.bool)
+        assert executed == [1.0, 1.1, 1.2, 1.3, 2.0, 2.1]
+        assert len(calls) == 2
+        assert actor.out_keys == ["action_chunk", "action", "action_orig", "counter"]
+
+    def test_replan_interval_chunk_key_to_custom_action_key(self):
+        n_steps = 3
+        actor_base = TensorDictModule(
+            lambda x: torch.zeros(x.shape[0], n_steps, 1),
+            in_keys=["observation"],
+            out_keys=["action_chunk"],
+        )
+        actor = MultiStepActorWrapper(
+            actor_base,
+            n_steps=n_steps,
+            action_keys=["motor_action"],
+            chunk_keys=["action_chunk"],
+        )
+        td = TensorDict(
+            {
+                "observation": torch.zeros(2, 1),
+                "is_init": torch.ones(2, 1, dtype=torch.bool),
+            },
+            batch_size=[2],
+        )
+        td = actor(td)
+        assert td["motor_action"].shape == torch.Size([2, 1])
+        assert "motor_action_orig" in td.keys()
+
     def test_replan_interval_validation(self):
         actor_base = TensorDictModule(
             lambda x: x, in_keys=["observation"], out_keys=["action"]

--- a/test/modules/test_actor.py
+++ b/test/modules/test_actor.py
@@ -794,13 +794,14 @@ class TestBatchedActor:
         for _ in range(6):
             td = actor(td.exclude("action"))
             executed.append(round(td["action"][0, 0].item(), 1))
+            assert td["vla_action", "chunk"].shape == torch.Size([2, n_steps, 1])
+            assert "action_orig" not in td.keys(True, True)
             td["is_init"] = torch.zeros(2, 1, dtype=torch.bool)
         assert executed == [1.0, 1.1, 1.2, 1.3, 2.0, 2.1]
         assert len(calls) == 2
         assert actor.out_keys == [
             ("vla_action", "chunk"),
             "action",
-            "action_orig",
             "counter",
         ]
 
@@ -826,7 +827,8 @@ class TestBatchedActor:
         )
         td = actor(td)
         assert td["motor_action"].shape == torch.Size([2, 1])
-        assert "motor_action_orig" in td.keys()
+        assert td["vla_action", "chunk"].shape == torch.Size([2, n_steps, 1])
+        assert "motor_action_orig" not in td.keys(True, True)
 
     def test_replan_interval_validation(self):
         actor_base = TensorDictModule(
@@ -978,6 +980,17 @@ class TestTinyVLA:
         assert "action_chunk" not in out.keys(True, True)
         assert policy.out_keys == [("vla_action", "chunk")]
         assert ("observation", "image") in policy.in_keys
+
+    def test_multistep_actor_uses_vla_chunk_as_cache(self):
+        policy = TinyVLA(action_dim=3, chunk_size=2)
+        actor = MultiStepActorWrapper(policy, n_steps=2)
+        td = _make_obs_td()
+        td["is_init"] = torch.ones(2, 1, dtype=torch.bool)
+        out = actor(td)
+        assert isinstance(out["vla_action"], VLAAction)
+        assert out["vla_action", "chunk"].shape == torch.Size([2, 2, 3])
+        assert out["action"].shape == torch.Size([2, 3])
+        assert "action_orig" not in out.keys(True, True)
 
     def test_tokens(self):
         policy = TinyVLA(

--- a/test/modules/test_actor.py
+++ b/test/modules/test_actor.py
@@ -1143,6 +1143,22 @@ class TestTinyVLA:
         assert out["vla_action", "tokens"].shape == torch.Size([2, 4, 2, 3])
         assert out["vla_action", "log_probs"].shape == torch.Size([2, 4])
 
+    def test_num_samples_inplace(self):
+        policy = TinyVLA(
+            action_dim=3,
+            chunk_size=2,
+            action_head="tokens",
+            vocab_size=16,
+            num_samples=4,
+            inplace=True,
+        )
+        td = _make_obs_td()
+        out = policy(td)
+        assert out is td
+        assert out.batch_size == torch.Size([2])
+        assert out["vla_action", "tokens"].shape == torch.Size([2, 4, 2, 3])
+        assert out["vla_action", "log_probs"].shape == torch.Size([2, 4])
+
     def test_num_samples_log_prob_recompute(self):
         policy = TinyVLA(
             action_dim=3,

--- a/test/modules/test_actor.py
+++ b/test/modules/test_actor.py
@@ -17,6 +17,12 @@ from tensordict.nn.distributions import NormalParamExtractor
 from torch import distributions as dist, nn
 
 from torchrl.data import Bounded, Composite
+from torchrl.data.vla import (
+    UniformActionTokenizer,
+    VLAAction,
+    VLAImages,
+    VLAObservation,
+)
 from torchrl.envs import CatFrames, Compose, InitTracker, SerialEnv, TransformedEnv
 from torchrl.envs.utils import ExplorationType, set_exploration_type
 from torchrl.modules import (
@@ -875,6 +881,12 @@ class TestVLAWrapperBase:
         with pytest.raises(ValueError, match="action_head"):
             VLAWrapperBase(action_dim=2, chunk_size=2, action_head="diffusion")
 
+    def test_invalid_modes(self):
+        with pytest.raises(ValueError, match="input_mode"):
+            VLAWrapperBase(action_dim=2, chunk_size=2, input_mode="features")
+        with pytest.raises(ValueError, match="output_mode"):
+            VLAWrapperBase(action_dim=2, chunk_size=2, output_mode="actions")
+
     def test_invalid_interaction_type(self):
         with pytest.raises(ValueError, match="default_interaction_type"):
             VLAWrapperBase(action_dim=2, chunk_size=2, default_interaction_type="beam")
@@ -900,7 +912,9 @@ class TestTinyVLA:
         policy = TinyVLA(action_dim=7, chunk_size=4)
         out = policy(_make_obs_td())
         assert out["action_chunk"].shape == torch.Size([2, 4, 7])
-        assert policy.out_keys == ["action_chunk"]
+        assert isinstance(out["vla_action"], VLAAction)
+        assert out["vla_action"].chunk.shape == torch.Size([2, 4, 7])
+        assert policy.out_keys == ["vla_action", "action_chunk"]
         assert ("observation", "image") in policy.in_keys
 
     def test_tokens(self):
@@ -908,7 +922,9 @@ class TestTinyVLA:
             action_dim=7, chunk_size=4, action_head="tokens", vocab_size=64
         )
         out = policy(_make_obs_td())
+        assert isinstance(out["vla_action"], VLAAction)
         assert out["action_tokens"].shape == torch.Size([2, 4, 7])
+        assert out["vla_action"].tokens.shape == torch.Size([2, 4, 7])
         # one sequence-level log-prob per sample (summed over the chunk): the
         # contract PPO-style objectives expect from sample_log_prob
         assert out["log_probs"].shape == torch.Size([2])
@@ -956,9 +972,13 @@ class TestTinyVLA:
 
     def test_set_keys(self):
         policy = TinyVLA(action_dim=3, chunk_size=2)
-        policy.set_keys(instruction="instr", action_chunk=("pred", "chunk"))
+        policy.set_keys(
+            instruction="instr",
+            action_chunk=("pred", "chunk"),
+            vla_action=("pred", "vla_action"),
+        )
         assert "instr" in policy.in_keys
-        assert policy.out_keys == [("pred", "chunk")]
+        assert policy.out_keys == [("pred", "vla_action"), ("pred", "chunk")]
         td = TensorDict(
             {
                 "observation": {
@@ -970,6 +990,133 @@ class TestTinyVLA:
             batch_size=[2],
         )
         assert policy(td)["pred", "chunk"].shape == torch.Size([2, 2, 3])
+        assert policy(td)["pred", "vla_action"].chunk.shape == torch.Size([2, 2, 3])
+
+    def test_preprocessed_vla_observation(self):
+        obs = VLAObservation(
+            images=VLAImages(
+                image=torch.zeros(2, 3, 16, 16, dtype=torch.uint8),
+                batch_size=[2],
+            ),
+            state=torch.randn(2, 5),
+            instruction=NonTensorStack("a", "b"),
+            batch_size=[2],
+        )
+        td = TensorDict({"vla_observation": obs}, batch_size=[2])
+        policy = TinyVLA(action_dim=3, chunk_size=2, input_mode="preprocessed")
+        out = policy(td)
+        assert policy.in_keys == ["vla_observation"]
+        assert out["action_chunk"].shape == torch.Size([2, 2, 3])
+
+    def test_tensordict_out_and_inplace_false(self):
+        policy = TinyVLA(action_dim=3, chunk_size=2, inplace=False)
+        td = _make_obs_td()
+        out = policy(td)
+        assert "action_chunk" not in td.keys(True, True)
+        assert out["action_chunk"].shape == torch.Size([2, 2, 3])
+        td_out = TensorDict({}, batch_size=[2])
+        result = policy(td, tensordict_out=td_out)
+        assert result is td_out
+        assert td_out["vla_action"].chunk.shape == torch.Size([2, 2, 3])
+
+    def test_logits_only_and_log_prob(self):
+        policy = TinyVLA(
+            action_dim=3,
+            chunk_size=2,
+            action_head="tokens",
+            vocab_size=16,
+            return_logits=False,
+        )
+        td = _make_obs_td()
+        logits_only = policy(td.clone(), logits_only=True)
+        assert logits_only["action_logits"].shape == torch.Size([2, 2, 3, 16])
+        assert "action_tokens" not in logits_only.keys(True, True)
+        rollout = policy(td.clone())
+        data = td.clone()
+        data["action_tokens"] = rollout["action_tokens"]
+        data = policy.log_prob(data)
+        torch.testing.assert_close(
+            data["log_probs"],
+            policy.get_dist(td.clone()).log_prob(rollout["action_tokens"]),
+        )
+
+    def test_logits_only_constructor(self):
+        policy = TinyVLA(
+            action_dim=3,
+            chunk_size=2,
+            action_head="tokens",
+            vocab_size=16,
+            logits_only=True,
+        )
+        out = policy(_make_obs_td())
+        assert policy.out_keys == ["vla_action", "action_logits"]
+        assert out["action_logits"].shape == torch.Size([2, 2, 3, 16])
+        assert "action_tokens" not in out.keys(True, True)
+
+    def test_num_samples(self):
+        policy = TinyVLA(
+            action_dim=3,
+            chunk_size=2,
+            action_head="tokens",
+            vocab_size=16,
+            num_samples=4,
+            inplace=False,
+        )
+        out = policy(_make_obs_td())
+        assert out.batch_size == torch.Size([2, 4])
+        assert out["action_tokens"].shape == torch.Size([2, 4, 2, 3])
+        assert out["log_probs"].shape == torch.Size([2, 4])
+
+    def test_num_samples_log_prob_recompute(self):
+        policy = TinyVLA(
+            action_dim=3,
+            chunk_size=2,
+            action_head="tokens",
+            vocab_size=16,
+            num_samples=4,
+            inplace=False,
+        )
+        td = _make_obs_td()
+        out = policy(td.clone())
+        data = td.clone()
+        data["action_tokens"] = out["action_tokens"]
+        data = policy.log_prob(data)
+        assert data["log_probs"].shape == torch.Size([2, 4])
+
+    def test_output_mode_both_decodes_tokens(self):
+        policy = TinyVLA(
+            action_dim=3,
+            chunk_size=2,
+            action_head="tokens",
+            vocab_size=16,
+            output_mode="both",
+            action_tokenizer=UniformActionTokenizer(16, low=-1.0, high=1.0),
+        )
+        out = policy(_make_obs_td())
+        assert out["action_tokens"].shape == torch.Size([2, 2, 3])
+        assert out["action_chunk"].shape == torch.Size([2, 2, 3])
+        assert out["vla_action"].chunk.shape == torch.Size([2, 2, 3])
+
+    def test_token_output_mode_chunk_only(self):
+        policy = TinyVLA(
+            action_dim=3,
+            chunk_size=2,
+            action_head="tokens",
+            vocab_size=16,
+            output_mode="chunk",
+            action_tokenizer=UniformActionTokenizer(16, low=-1.0, high=1.0),
+        )
+        out = policy(_make_obs_td())
+        assert out["action_chunk"].shape == torch.Size([2, 2, 3])
+        assert "action_tokens" not in out.keys(True, True)
+
+    def test_get_new_version(self):
+        policy = TinyVLA(action_dim=3, chunk_size=2)
+        other = policy.get_new_version(inplace=False, action_chunk_key=("pred", "a"))
+        assert other is not policy
+        assert other.inplace is False
+        assert other.tensor_keys.action_chunk == ("pred", "a")
+        assert policy.tensor_keys.action_chunk == "action_chunk"
 
     def test_greedy_deterministic(self):
         policy = TinyVLA(
@@ -1035,7 +1182,8 @@ class TestLeRobotPolicyWrapper:
         )
         out = policy(_make_obs_td())
         assert out["action_chunk"].shape == torch.Size([2, 4, 7])
-        assert policy.out_keys == ["action_chunk"]
+        assert out["vla_action"].chunk.shape == torch.Size([2, 4, 7])
+        assert policy.out_keys == ["vla_action", "action_chunk"]
 
     def test_builds_lerobot_batch(self):
         dummy = _DummyChunkPolicy(2, 3)

--- a/test/modules/test_actor.py
+++ b/test/modules/test_actor.py
@@ -767,9 +767,10 @@ class TestBatchedActor:
         assert executed == expected
         assert len(calls) == -(-6 // interval)  # ceil division
 
-    def test_replan_interval_chunk_key(self):
-        # VLA-style policies write action_chunk while the environment consumes
-        # action: no extra TensorDictModule should be needed to bridge the keys.
+    def test_replan_interval_vla_chunk_key_autodiscovery(self):
+        # VLA-style policies write ("vla_action", "chunk") while the
+        # environment consumes action: no extra TensorDictModule or explicit
+        # chunk_keys should be needed to bridge the keys.
         n_steps, calls = 4, []
 
         def make_chunk(x):
@@ -779,11 +780,9 @@ class TestBatchedActor:
             return chunk
 
         actor_base = TensorDictModule(
-            make_chunk, in_keys=["observation"], out_keys=["action_chunk"]
+            make_chunk, in_keys=["observation"], out_keys=[("vla_action", "chunk")]
         )
-        actor = MultiStepActorWrapper(
-            actor_base, n_steps=n_steps, chunk_keys=["action_chunk"]
-        )
+        actor = MultiStepActorWrapper(actor_base, n_steps=n_steps)
         td = TensorDict(
             {
                 "observation": torch.zeros(2, 1),
@@ -798,20 +797,25 @@ class TestBatchedActor:
             td["is_init"] = torch.zeros(2, 1, dtype=torch.bool)
         assert executed == [1.0, 1.1, 1.2, 1.3, 2.0, 2.1]
         assert len(calls) == 2
-        assert actor.out_keys == ["action_chunk", "action", "action_orig", "counter"]
+        assert actor.out_keys == [
+            ("vla_action", "chunk"),
+            "action",
+            "action_orig",
+            "counter",
+        ]
 
     def test_replan_interval_chunk_key_to_custom_action_key(self):
         n_steps = 3
         actor_base = TensorDictModule(
             lambda x: torch.zeros(x.shape[0], n_steps, 1),
             in_keys=["observation"],
-            out_keys=["action_chunk"],
+            out_keys=[("vla_action", "chunk")],
         )
         actor = MultiStepActorWrapper(
             actor_base,
             n_steps=n_steps,
             action_keys=["motor_action"],
-            chunk_keys=["action_chunk"],
+            chunk_keys=[("vla_action", "chunk")],
         )
         td = TensorDict(
             {
@@ -968,10 +972,11 @@ class TestTinyVLA:
     def test_continuous(self):
         policy = TinyVLA(action_dim=7, chunk_size=4)
         out = policy(_make_obs_td())
-        assert out["action_chunk"].shape == torch.Size([2, 4, 7])
         assert isinstance(out["vla_action"], VLAAction)
         assert out["vla_action"].chunk.shape == torch.Size([2, 4, 7])
-        assert policy.out_keys == ["vla_action", "action_chunk"]
+        assert out["vla_action", "chunk"].shape == torch.Size([2, 4, 7])
+        assert "action_chunk" not in out.keys(True, True)
+        assert policy.out_keys == [("vla_action", "chunk")]
         assert ("observation", "image") in policy.in_keys
 
     def test_tokens(self):
@@ -980,15 +985,16 @@ class TestTinyVLA:
         )
         out = policy(_make_obs_td())
         assert isinstance(out["vla_action"], VLAAction)
-        assert out["action_tokens"].shape == torch.Size([2, 4, 7])
         assert out["vla_action"].tokens.shape == torch.Size([2, 4, 7])
+        assert out["vla_action", "tokens"].shape == torch.Size([2, 4, 7])
         # one sequence-level log-prob per sample (summed over the chunk): the
         # contract PPO-style objectives expect from sample_log_prob
-        assert out["log_probs"].shape == torch.Size([2])
-        assert (out["action_tokens"] >= 0).all() and (out["action_tokens"] < 64).all()
+        assert out["vla_action", "log_probs"].shape == torch.Size([2])
+        assert (out["vla_action", "tokens"] >= 0).all()
+        assert (out["vla_action", "tokens"] < 64).all()
         dist = policy.get_dist(_make_obs_td())
         assert dist.base_dist.logits.shape == torch.Size([2, 4, 7, 64])
-        assert dist.log_prob(out["action_tokens"]).shape == torch.Size([2])
+        assert dist.log_prob(out["vla_action", "tokens"]).shape == torch.Size([2])
 
     def test_tokens_per_token_log_probs(self):
         # log_probs_mode="token": per-token log-probabilities, the groundwork
@@ -1002,10 +1008,10 @@ class TestTinyVLA:
         )
         obs = _make_obs_td()
         out = policy(obs.clone())
-        assert out["action_tokens"].shape == torch.Size([2, 4, 7])
-        assert out["log_probs"].shape == torch.Size([2, 4, 7])
+        assert out["vla_action", "tokens"].shape == torch.Size([2, 4, 7])
+        assert out["vla_action", "log_probs"].shape == torch.Size([2, 4, 7])
         dist = policy.get_dist(obs.clone())
-        per_token = dist.log_prob(out["action_tokens"])
+        per_token = dist.log_prob(out["vla_action", "tokens"])
         assert per_token.shape == torch.Size([2, 4, 7])
         # per-token log-probs sum to the sequence-level ones for the same
         # weights, observations and tokens
@@ -1013,7 +1019,7 @@ class TestTinyVLA:
             action_dim=7, chunk_size=4, action_head="tokens", vocab_size=64
         )
         policy_seq.load_state_dict(policy.state_dict())
-        seq = policy_seq.get_dist(obs.clone()).log_prob(out["action_tokens"])
+        seq = policy_seq.get_dist(obs.clone()).log_prob(out["vla_action", "tokens"])
         torch.testing.assert_close(per_token.sum((-2, -1)), seq)
 
     def test_get_dist_continuous_raises(self):
@@ -1025,17 +1031,16 @@ class TestTinyVLA:
         policy = TinyVLA(action_dim=3, chunk_size=2, use_state=False)
         assert ("observation", "state") not in policy.in_keys
         out = policy(_make_obs_td(with_state=False))
-        assert out["action_chunk"].shape == torch.Size([2, 2, 3])
+        assert out["vla_action", "chunk"].shape == torch.Size([2, 2, 3])
 
     def test_set_keys(self):
         policy = TinyVLA(action_dim=3, chunk_size=2)
         policy.set_keys(
             instruction="instr",
-            action_chunk=("pred", "chunk"),
             vla_action=("pred", "vla_action"),
         )
         assert "instr" in policy.in_keys
-        assert policy.out_keys == [("pred", "vla_action"), ("pred", "chunk")]
+        assert policy.out_keys == [("pred", "vla_action", "chunk")]
         td = TensorDict(
             {
                 "observation": {
@@ -1046,8 +1051,9 @@ class TestTinyVLA:
             },
             batch_size=[2],
         )
-        assert policy(td)["pred", "chunk"].shape == torch.Size([2, 2, 3])
-        assert policy(td)["pred", "vla_action"].chunk.shape == torch.Size([2, 2, 3])
+        out = policy(td)
+        assert out["pred", "vla_action", "chunk"].shape == torch.Size([2, 2, 3])
+        assert out["pred", "vla_action"].chunk.shape == torch.Size([2, 2, 3])
 
     def test_preprocessed_vla_observation(self):
         obs = VLAObservation(
@@ -1063,14 +1069,14 @@ class TestTinyVLA:
         policy = TinyVLA(action_dim=3, chunk_size=2, input_mode="preprocessed")
         out = policy(td)
         assert policy.in_keys == ["vla_observation"]
-        assert out["action_chunk"].shape == torch.Size([2, 2, 3])
+        assert out["vla_action", "chunk"].shape == torch.Size([2, 2, 3])
 
     def test_tensordict_out_and_inplace_false(self):
         policy = TinyVLA(action_dim=3, chunk_size=2, inplace=False)
         td = _make_obs_td()
         out = policy(td)
         assert "action_chunk" not in td.keys(True, True)
-        assert out["action_chunk"].shape == torch.Size([2, 2, 3])
+        assert out["vla_action", "chunk"].shape == torch.Size([2, 2, 3])
         td_out = TensorDict({}, batch_size=[2])
         result = policy(td, tensordict_out=td_out)
         assert result is td_out
@@ -1086,15 +1092,15 @@ class TestTinyVLA:
         )
         td = _make_obs_td()
         logits_only = policy(td.clone(), logits_only=True)
-        assert logits_only["action_logits"].shape == torch.Size([2, 2, 3, 16])
+        assert logits_only["vla_action", "logits"].shape == torch.Size([2, 2, 3, 16])
         assert "action_tokens" not in logits_only.keys(True, True)
         rollout = policy(td.clone())
         data = td.clone()
-        data["action_tokens"] = rollout["action_tokens"]
+        data["vla_action", "tokens"] = rollout["vla_action", "tokens"]
         data = policy.log_prob(data)
         torch.testing.assert_close(
-            data["log_probs"],
-            policy.get_dist(td.clone()).log_prob(rollout["action_tokens"]),
+            data["vla_action", "log_probs"],
+            policy.get_dist(td.clone()).log_prob(rollout["vla_action", "tokens"]),
         )
 
     def test_logits_only_constructor(self):
@@ -1106,8 +1112,8 @@ class TestTinyVLA:
             logits_only=True,
         )
         out = policy(_make_obs_td())
-        assert policy.out_keys == ["vla_action", "action_logits"]
-        assert out["action_logits"].shape == torch.Size([2, 2, 3, 16])
+        assert policy.out_keys == [("vla_action", "logits")]
+        assert out["vla_action", "logits"].shape == torch.Size([2, 2, 3, 16])
         assert "action_tokens" not in out.keys(True, True)
 
     def test_num_samples(self):
@@ -1121,8 +1127,8 @@ class TestTinyVLA:
         )
         out = policy(_make_obs_td())
         assert out.batch_size == torch.Size([2, 4])
-        assert out["action_tokens"].shape == torch.Size([2, 4, 2, 3])
-        assert out["log_probs"].shape == torch.Size([2, 4])
+        assert out["vla_action", "tokens"].shape == torch.Size([2, 4, 2, 3])
+        assert out["vla_action", "log_probs"].shape == torch.Size([2, 4])
 
     def test_num_samples_log_prob_recompute(self):
         policy = TinyVLA(
@@ -1136,9 +1142,9 @@ class TestTinyVLA:
         td = _make_obs_td()
         out = policy(td.clone())
         data = td.clone()
-        data["action_tokens"] = out["action_tokens"]
+        data["vla_action", "tokens"] = out["vla_action", "tokens"]
         data = policy.log_prob(data)
-        assert data["log_probs"].shape == torch.Size([2, 4])
+        assert data["vla_action", "log_probs"].shape == torch.Size([2, 4])
 
     def test_output_mode_both_decodes_tokens(self):
         policy = TinyVLA(
@@ -1150,8 +1156,8 @@ class TestTinyVLA:
             action_tokenizer=UniformActionTokenizer(16, low=-1.0, high=1.0),
         )
         out = policy(_make_obs_td())
-        assert out["action_tokens"].shape == torch.Size([2, 2, 3])
-        assert out["action_chunk"].shape == torch.Size([2, 2, 3])
+        assert out["vla_action", "tokens"].shape == torch.Size([2, 2, 3])
+        assert out["vla_action", "chunk"].shape == torch.Size([2, 2, 3])
         assert out["vla_action"].chunk.shape == torch.Size([2, 2, 3])
 
     def test_token_output_mode_chunk_only(self):
@@ -1164,7 +1170,7 @@ class TestTinyVLA:
             action_tokenizer=UniformActionTokenizer(16, low=-1.0, high=1.0),
         )
         out = policy(_make_obs_td())
-        assert out["action_chunk"].shape == torch.Size([2, 2, 3])
+        assert out["vla_action", "chunk"].shape == torch.Size([2, 2, 3])
         assert "action_tokens" not in out.keys(True, True)
 
     def test_get_new_version(self):
@@ -1173,7 +1179,7 @@ class TestTinyVLA:
         assert other is not policy
         assert other.inplace is False
         assert other.tensor_keys.action_chunk == ("pred", "a")
-        assert policy.tensor_keys.action_chunk == "action_chunk"
+        assert policy.tensor_keys.action_chunk == ("vla_action", "chunk")
 
     def test_greedy_deterministic(self):
         policy = TinyVLA(
@@ -1181,7 +1187,8 @@ class TestTinyVLA:
         )
         td = _make_obs_td()
         torch.testing.assert_close(
-            policy(td.clone())["action_tokens"], policy(td.clone())["action_tokens"]
+            policy(td.clone())["vla_action", "tokens"],
+            policy(td.clone())["vla_action", "tokens"],
         )
 
     def test_exploration_type_dispatch(self):
@@ -1195,24 +1202,24 @@ class TestTinyVLA:
         td = _make_obs_td()
         with set_exploration_type(ExplorationType.RANDOM):
             a, b = (
-                policy(td.clone())["action_tokens"],
-                policy(td.clone())["action_tokens"],
+                policy(td.clone())["vla_action", "tokens"],
+                policy(td.clone())["vla_action", "tokens"],
             )
         assert not torch.equal(a, b)  # sampled -> differs across calls
         with set_exploration_type(ExplorationType.DETERMINISTIC):
             c, d = (
-                policy(td.clone())["action_tokens"],
-                policy(td.clone())["action_tokens"],
+                policy(td.clone())["vla_action", "tokens"],
+                policy(td.clone())["vla_action", "tokens"],
             )
         assert torch.equal(c, d)  # argmax -> deterministic
         # no active context -> the default (DETERMINISTIC) argmax
         assert policy.default_interaction_type == InteractionType.DETERMINISTIC
-        torch.testing.assert_close(policy(td.clone())["action_tokens"], c)
+        torch.testing.assert_close(policy(td.clone())["vla_action", "tokens"], c)
 
     def test_gradient_flow(self):
         policy = TinyVLA(action_dim=3, chunk_size=2)
         out = policy(_make_obs_td())
-        out["action_chunk"].sum().backward()
+        out["vla_action", "chunk"].sum().backward()
         grads = [p.grad for p in policy.parameters() if p.requires_grad]
         assert any(g is not None and g.abs().sum() > 0 for g in grads)
 
@@ -1238,9 +1245,8 @@ class TestLeRobotPolicyWrapper:
             _DummyChunkPolicy(4, 7), action_dim=7, chunk_size=4
         )
         out = policy(_make_obs_td())
-        assert out["action_chunk"].shape == torch.Size([2, 4, 7])
         assert out["vla_action"].chunk.shape == torch.Size([2, 4, 7])
-        assert policy.out_keys == ["vla_action", "action_chunk"]
+        assert policy.out_keys == [("vla_action", "chunk")]
 
     def test_builds_lerobot_batch(self):
         dummy = _DummyChunkPolicy(2, 3)
@@ -1265,7 +1271,8 @@ class TestLeRobotPolicyWrapper:
             object(), action_dim=3, chunk_size=2, predict_fn=predict_fn
         )
         out = policy(_make_obs_td())
-        assert called.get("yes") and out["action_chunk"].shape == torch.Size([2, 2, 3])
+        assert called.get("yes")
+        assert out["vla_action", "chunk"].shape == torch.Size([2, 2, 3])
 
     def test_callable_policy(self):
         def model(batch):
@@ -1273,7 +1280,9 @@ class TestLeRobotPolicyWrapper:
             return torch.zeros(b, 2, 3)
 
         policy = LeRobotPolicyWrapper(model, action_dim=3, chunk_size=2)
-        assert policy(_make_obs_td())["action_chunk"].shape == torch.Size([2, 2, 3])
+        assert policy(_make_obs_td())["vla_action", "chunk"].shape == torch.Size(
+            [2, 2, 3]
+        )
 
     def test_bad_policy_raises(self):
         policy = LeRobotPolicyWrapper(object(), action_dim=3, chunk_size=2)

--- a/test/objectives/test_act.py
+++ b/test/objectives/test_act.py
@@ -9,6 +9,8 @@ import torch
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 
+from torchrl.data.vla import ACTION_CHUNK_KEY
+from torchrl.envs.transforms import ActionChunkTransform
 from torchrl.modules.models import ACTModel
 from torchrl.modules.models.act import _sinusoidal_pos_enc
 from torchrl.objectives import ACTLoss
@@ -40,7 +42,7 @@ def _make_batch(
     return TensorDict(
         {
             "observation": torch.randn(batch_size, obs_dim),
-            "action_chunk": torch.randn(batch_size, chunk_size, action_dim),
+            ACTION_CHUNK_KEY: torch.randn(batch_size, chunk_size, action_dim),
         },
         batch_size=[batch_size],
     )
@@ -261,7 +263,7 @@ class TestACTLoss:
         actor = _make_actor()
         loss_fn = ACTLoss(actor)
         assert "observation" in loss_fn.in_keys
-        assert "action_chunk" in loss_fn.in_keys
+        assert ACTION_CHUNK_KEY in loss_fn.in_keys
 
     def test_out_keys(self):
         actor = _make_actor()
@@ -331,7 +333,7 @@ class TestACTLoss:
         td = TensorDict(
             {
                 "observation": torch.randn(*batch_shape, OBS_DIM),
-                "action_chunk": torch.randn(*batch_shape, CHUNK_SIZE, ACTION_DIM),
+                ACTION_CHUNK_KEY: torch.randn(*batch_shape, CHUNK_SIZE, ACTION_DIM),
             },
             batch_size=list(batch_shape),
         )
@@ -339,6 +341,21 @@ class TestACTLoss:
         assert loss_td["loss_act"].shape == torch.Size(batch_shape)
         assert loss_td["loss_reconstruction"].shape == torch.Size(batch_shape)
         assert loss_td["loss_kl"].shape == torch.Size(batch_shape)
+
+    def test_action_chunk_transform_default_key(self):
+        actor = _make_actor()
+        loss_fn = ACTLoss(actor)
+        td = TensorDict(
+            {
+                "observation": torch.randn(4, CHUNK_SIZE, OBS_DIM),
+                "action": torch.randn(4, CHUNK_SIZE, ACTION_DIM),
+            },
+            batch_size=[4, CHUNK_SIZE],
+        )
+        td = ActionChunkTransform(CHUNK_SIZE)(td)
+        td = td[:, 0].clone()
+        loss_td = loss_fn(td)
+        assert loss_td["loss_act"].isfinite()
 
     def test_reset_parameters_recursive(self):
         actor = _make_actor()

--- a/test/objectives/test_vla.py
+++ b/test/objectives/test_vla.py
@@ -14,8 +14,11 @@ import pytest
 import torch
 from tensordict import NonTensorStack, TensorDict
 
+from torchrl.data.vla import ACTION_CHUNK_KEY, ACTION_TOKENS_KEY
 from torchrl.modules.vla import TinyVLA
 from torchrl.objectives import BCLoss, ClipPPOLoss
+
+LOG_PROBS_KEY = ("vla_action", "log_probs")
 
 
 def _make_bc_td(batch=4, chunk=4, action_dim=3, pad=False):
@@ -30,7 +33,7 @@ def _make_bc_td(batch=4, chunk=4, action_dim=3, pad=False):
         {
             "observation": obs,
             "language_instruction": NonTensorStack(*[f"t{i}" for i in range(batch)]),
-            "action_chunk": torch.randn(batch, chunk, action_dim),
+            ACTION_CHUNK_KEY: torch.randn(batch, chunk, action_dim),
             "action_is_pad": is_pad,
         },
         batch_size=[batch],
@@ -42,7 +45,7 @@ def _make_chunked_bc_loss(policy, **kwargs):
     # the action and the padding mask excluded from the loss
     kwargs.setdefault("loss_function", "l1")
     loss = BCLoss(policy, **kwargs)
-    loss.set_keys(action="action_chunk", pad_mask="action_is_pad")
+    loss.set_keys(action=ACTION_CHUNK_KEY, pad_mask="action_is_pad")
     return loss
 
 
@@ -75,12 +78,12 @@ class TestChunkedBC:
     def test_masking_excludes_padded_steps(self):
         loss = _make_chunked_bc_loss(self._policy())
         td = _make_bc_td(pad=True)
-        td["action_chunk"][:, -1, :] = 1e6  # huge target on the padded step
+        td[ACTION_CHUNK_KEY][:, -1, :] = 1e6  # huge target on the padded step
         masked = loss(td)["loss_bc"]
         unmasked = loss(td.exclude("action_is_pad"))["loss_bc"]
         assert masked < unmasked  # the padded (huge) step is ignored when masked
 
-    def test_nested_action_chunk_key(self):
+    def test_custom_action_chunk_key(self):
         policy = TinyVLA(action_dim=2, chunk_size=3)
         policy.set_keys(action_chunk=("targets", "chunk"))
         td = TensorDict(
@@ -134,7 +137,7 @@ def _make_token_ppo_loss(policy, **kwargs):
     kwargs.setdefault("clip_epsilon", 0.2)
     loss = ClipPPOLoss(policy, critic_network=None, entropy_bonus=False, **kwargs)
     loss.set_keys(
-        action="action_tokens", sample_log_prob="log_probs", advantage="advantage"
+        action=ACTION_TOKENS_KEY, sample_log_prob=LOG_PROBS_KEY, advantage="advantage"
     )
     return loss
 
@@ -150,8 +153,8 @@ class TestTokenPPO:
         with torch.no_grad():
             coll = policy(obs.clone())
         td = obs.clone()
-        td["action_tokens"] = coll["action_tokens"]
-        td["log_probs"] = coll["log_probs"].detach()
+        td[ACTION_TOKENS_KEY] = coll[ACTION_TOKENS_KEY]
+        td[LOG_PROBS_KEY] = coll[LOG_PROBS_KEY].detach()
         # the advantage carries the trailing singleton value-dim the PPO
         # losses expect; a flat [batch] advantage would broadcast wrong
         td["advantage"] = torch.full((batch, 1), float(advantage))
@@ -168,14 +171,17 @@ class TestTokenPPO:
         # the token head emits one (summed) log-prob per sample, matching the
         # sample_log_prob contract of the PPO losses
         policy, obs, td = self._setup(batch=3)
-        assert td["log_probs"].shape == torch.Size([3])
+        assert td[LOG_PROBS_KEY].shape == torch.Size([3])
         dist = policy.get_dist(obs.clone())
-        assert dist.log_prob(td["action_tokens"]).shape == torch.Size([3])
+        assert dist.log_prob(td[ACTION_TOKENS_KEY]).shape == torch.Size([3])
 
     def _taken_logprob(self, policy, obs, td):
         with torch.no_grad():
             return (
-                policy.get_dist(obs.clone()).log_prob(td["action_tokens"]).sum().item()
+                policy.get_dist(obs.clone())
+                .log_prob(td[ACTION_TOKENS_KEY])
+                .sum()
+                .item()
             )
 
     def test_positive_advantage_increases_logprob(self):
@@ -211,13 +217,13 @@ class TestTokenPPO:
         # [batch, batch] outer product inside the PPO loss
         policy, obs, td = self._setup(batch=4)
         td["advantage"] = torch.tensor([[1.0], [-1.0], [2.0], [0.5]])
-        td["log_probs"] = td["log_probs"] + 0.3  # ratio != 1 so clipping bites
+        td[LOG_PROBS_KEY] = td[LOG_PROBS_KEY] + 0.3  # ratio != 1 so clipping bites
         out = _make_token_ppo_loss(policy, reduction="none")(td)["loss_objective"]
         assert out.shape == torch.Size([4])
         with torch.no_grad():
             log_weight = (
-                policy.get_dist(obs.clone()).log_prob(td["action_tokens"])
-                - td["log_probs"]
+                policy.get_dist(obs.clone()).log_prob(td[ACTION_TOKENS_KEY])
+                - td[LOG_PROBS_KEY]
             )
         ratio = log_weight.exp().unsqueeze(-1)
         gain = torch.min(

--- a/test/transforms/test_action_transforms.py
+++ b/test/transforms/test_action_transforms.py
@@ -1665,6 +1665,28 @@ class TestMultiAction(TransformBase):
         # one reward slot per executed base step
         assert rollout["next", "reward"].shape == (4, h, 1)
 
+    def test_action_chunk_key(self):
+        h, a = 3, 2
+
+        class ChunkPolicy(TensorDictModuleBase):
+            in_keys = [("observation", "state")]
+            out_keys = ["action_chunk"]
+
+            def forward(self, td):
+                chunk = torch.zeros(*td.batch_size, h, a)
+                td.set("action_chunk", chunk)
+                return td
+
+        env = TransformedEnv(
+            ToyVLAEnv(action_dim=a, state_dim=2 * a),
+            MultiAction(action_key="action", chunk_key="action_chunk"),
+        )
+        check_env_specs(env)
+        assert env.full_action_spec["action_chunk"].shape == torch.Size([-1, a])
+        rollout = env.rollout(4, ChunkPolicy())
+        assert rollout["action_chunk"].shape == (4, h, a)
+        assert rollout["next", "reward"].shape == (4, h, 1)
+
     @pytest.mark.parametrize("batch_size", [(), (1,)])
     def test_token_policy_pipeline(self, batch_size):
         # token-head policy: emits only action tokens + log-probs; the

--- a/test/transforms/test_action_transforms.py
+++ b/test/transforms/test_action_transforms.py
@@ -42,6 +42,7 @@ from torchrl.data import (
 )
 from torchrl.data.vla import (
     ACTION_CHUNK_KEY,
+    ACTION_TOKENS_KEY,
     RobotDatasetMetadata,
     UniformActionTokenizer,
 )
@@ -1712,12 +1713,12 @@ class TestMultiAction(TransformBase):
 
         class TokenPolicy(TensorDictModuleBase):
             in_keys = [("observation", "state")]
-            out_keys = ["action_tokens", "log_probs"]
+            out_keys = [ACTION_TOKENS_KEY, "log_probs"]
 
             def forward(self, td):
                 target = td.get(("observation", "state"))[..., a : 2 * a]
                 chunk = target.unsqueeze(-2).expand(*td.batch_size, h, a)
-                td.set("action_tokens", tok.encode(chunk))
+                td.set(ACTION_TOKENS_KEY, tok.encode(chunk))
                 td.set("log_probs", torch.full((*td.batch_size,), 0.5))
                 return td
 
@@ -1733,13 +1734,13 @@ class TestMultiAction(TransformBase):
         )
         # the policy-facing action spec is the token interface with the
         # dynamic chunk dim
-        token_spec = env.full_action_spec["action_tokens"]
+        token_spec = env.full_action_spec[ACTION_TOKENS_KEY]
         assert token_spec.shape == torch.Size([*batch_size, -1, a])
         assert token_spec.dtype == torch.long
         check_env_specs(env)
         rollout = env.rollout(2, TokenPolicy())
         assert rollout.batch_size == (*batch_size, 2)
-        assert rollout["action_tokens"].shape == (*batch_size, 2, h, a)
+        assert rollout[ACTION_TOKENS_KEY].shape == (*batch_size, 2, h, a)
         assert rollout["log_probs"].shape == (*batch_size, 2)
         # the tracking task succeeds through the decode path: 2 * h
         # in-tolerance base steps reached exactly at the 2nd chunk boundary
@@ -2735,7 +2736,7 @@ class TestActionTokenizerTransform(TransformBase):
         env = self._env()
         check_env_specs(env)
         # the policy-facing action spec is the token interface
-        token_spec = env.full_action_spec["action_tokens"]
+        token_spec = env.full_action_spec[ACTION_TOKENS_KEY]
         assert isinstance(token_spec, Categorical)
         assert token_spec.shape == torch.Size([7])
         assert token_spec.dtype == torch.long
@@ -2761,7 +2762,7 @@ class TestActionTokenizerTransform(TransformBase):
             SerialEnv(2, ContinuousActionVecMockEnv), ActionTokenizerTransform(tok)
         )
         check_env_specs(env)
-        assert env.full_action_spec["action_tokens"].shape == torch.Size([2, 7])
+        assert env.full_action_spec[ACTION_TOKENS_KEY].shape == torch.Size([2, 7])
 
     def test_trans_parallel_env_check(self, maybe_fork_ParallelEnv):
         tok = UniformActionTokenizer(16, low=-1.0, high=1.0)
@@ -2781,13 +2782,13 @@ class TestActionTokenizerTransform(TransformBase):
         tok = UniformActionTokenizer(256, low=-1.0, high=1.0)
         t = ActionTokenizerTransform(tok)
         td = t(TensorDict({"action": torch.tensor([[-1.0, 0.0, 1.0]])}, batch_size=[1]))
-        assert td["action_tokens"].tolist() == [[0, 128, 255]]
+        assert td[ACTION_TOKENS_KEY].tolist() == [[0, 128, 255]]
 
     def test_transform_compose(self):
         tok = UniformActionTokenizer(256, low=-1.0, high=1.0)
         t = Compose(ActionTokenizerTransform(tok))
         td = t(TensorDict({"action": torch.tensor([[-1.0, 0.0, 1.0]])}, batch_size=[1]))
-        assert td["action_tokens"].tolist() == [[0, 128, 255]]
+        assert td[ACTION_TOKENS_KEY].tolist() == [[0, 128, 255]]
 
     def test_transform_env(self):
         captured = {}
@@ -2800,13 +2801,15 @@ class TestActionTokenizerTransform(TransformBase):
 
         env = TransformedEnv(CaptureEnv(), ActionTokenizerTransform(tok))
         td = env.reset()
-        td["action_tokens"] = torch.arange(7, dtype=torch.long)
+        td[ACTION_TOKENS_KEY] = torch.arange(7, dtype=torch.long)
         env.step(td)
         # the base env consumes the decoded (continuous) action
-        torch.testing.assert_close(captured["action"], tok.decode(td["action_tokens"]))
+        torch.testing.assert_close(
+            captured["action"], tok.decode(td[ACTION_TOKENS_KEY])
+        )
         r = env.rollout(3)
-        assert r["action_tokens"].dtype == torch.long
-        assert (r["action_tokens"] < 16).all()
+        assert r[ACTION_TOKENS_KEY].dtype == torch.long
+        assert (r[ACTION_TOKENS_KEY] < 16).all()
 
     def test_transform_model(self):
         tok = UniformActionTokenizer(256, low=-1.0, high=1.0)
@@ -2815,7 +2818,7 @@ class TestActionTokenizerTransform(TransformBase):
         td = model(
             TensorDict({"action": torch.tensor([[-1.0, 0.0, 1.0]])}, batch_size=[1])
         )
-        assert td["action_tokens"].tolist() == [[0, 128, 255]]
+        assert td[ACTION_TOKENS_KEY].tolist() == [[0, 128, 255]]
 
     def test_transform_rb(self):
         tok = UniformActionTokenizer(16, low=-1.0, high=1.0)
@@ -2828,10 +2831,10 @@ class TestActionTokenizerTransform(TransformBase):
         # tokens are built on the sample path only
         rb.extend(TensorDict({"action": torch.rand(10, 3) * 2 - 1}, batch_size=[10]))
         stored = rb._storage._storage
-        assert "action_tokens" not in stored.keys()
+        assert ACTION_TOKENS_KEY not in stored.keys(True, True)
         sample = rb.sample()
-        assert sample["action_tokens"].dtype == torch.long
-        assert (sample["action_tokens"] < 16).all()
+        assert sample[ACTION_TOKENS_KEY].dtype == torch.long
+        assert (sample[ACTION_TOKENS_KEY] < 16).all()
 
     def test_transform_inverse(self):
         # forward encodes, inv decodes (within half a bin)
@@ -2839,11 +2842,13 @@ class TestActionTokenizerTransform(TransformBase):
         t = ActionTokenizerTransform(tok)
         action = torch.tensor([[-0.5, 0.25, 0.5]])
         enc = t(TensorDict({"action": action}, batch_size=[1]))
-        dec = t.inv(TensorDict({"action_tokens": enc["action_tokens"]}, batch_size=[1]))
+        dec = t.inv(
+            TensorDict({ACTION_TOKENS_KEY: enc[ACTION_TOKENS_KEY]}, batch_size=[1])
+        )
         assert (dec["action"] - action).abs().max() <= (2.0 / (2 * 256)) + 1e-5
         # absent tokens: the inverse is a no-op
         td = t.inv(TensorDict({"action": action}, batch_size=[1]))
-        assert "action_tokens" not in td.keys()
+        assert ACTION_TOKENS_KEY not in td.keys(True, True)
 
     # ActionTokenizerTransform-specific tests
     def test_decode_via_tokenizer(self):
@@ -2852,7 +2857,7 @@ class TestActionTokenizerTransform(TransformBase):
         assert t.tokenizer is tok
         action = torch.tensor([[-0.5, 0.25, 0.5]])
         td = t(TensorDict({"action": action}, batch_size=[1]))
-        recon = t.tokenizer.decode(td["action_tokens"])
+        recon = t.tokenizer.decode(td[ACTION_TOKENS_KEY])
         assert (recon - action).abs().max() <= (2.0 / (2 * 256)) + 1e-5
 
     def test_nested_keys_and_chunk(self):
@@ -2892,8 +2897,16 @@ class TestActionTokenizerTransform(TransformBase):
         env = self._env()
         td = env.reset()
         td["action"] = torch.zeros(7)
-        with pytest.raises(KeyError, match="action_tokens"):
+        with pytest.raises(KeyError, match="vla_action.*tokens"):
             env.step(td)
+
+    def test_flat_out_key_compatibility(self):
+        tok = UniformActionTokenizer(256, low=-1.0, high=1.0)
+        t = ActionTokenizerTransform(tok, out_key="action_tokens")
+        td = t(TensorDict({"action": torch.tensor([[-1.0, 0.0, 1.0]])}, batch_size=[1]))
+        assert td["action_tokens"].tolist() == [[0, 128, 255]]
+        dec = t.inv(TensorDict({"action_tokens": td["action_tokens"]}, batch_size=[1]))
+        assert dec["action"].shape == torch.Size([1, 3])
 
     def test_requires_tokenizer(self):
         with pytest.raises(TypeError, match="ActionTokenizerBase"):

--- a/test/transforms/test_action_transforms.py
+++ b/test/transforms/test_action_transforms.py
@@ -40,7 +40,11 @@ from torchrl.data import (
     TensorSpec,
     Unbounded,
 )
-from torchrl.data.vla import RobotDatasetMetadata, UniformActionTokenizer
+from torchrl.data.vla import (
+    ACTION_CHUNK_KEY,
+    RobotDatasetMetadata,
+    UniformActionTokenizer,
+)
 from torchrl.envs import (
     ActionMask,
     ActionScaling,
@@ -1670,22 +1674,31 @@ class TestMultiAction(TransformBase):
 
         class ChunkPolicy(TensorDictModuleBase):
             in_keys = [("observation", "state")]
-            out_keys = ["action_chunk"]
+            out_keys = [ACTION_CHUNK_KEY]
 
             def forward(self, td):
                 chunk = torch.zeros(*td.batch_size, h, a)
-                td.set("action_chunk", chunk)
+                td.set(ACTION_CHUNK_KEY, chunk)
                 return td
 
         env = TransformedEnv(
             ToyVLAEnv(action_dim=a, state_dim=2 * a),
-            MultiAction(action_key="action", chunk_key="action_chunk"),
+            MultiAction.from_vla(),
         )
         check_env_specs(env)
-        assert env.full_action_spec["action_chunk"].shape == torch.Size([-1, a])
+        assert env.full_action_spec[ACTION_CHUNK_KEY].shape == torch.Size([-1, a])
         rollout = env.rollout(4, ChunkPolicy())
-        assert rollout["action_chunk"].shape == (4, h, a)
+        assert rollout[ACTION_CHUNK_KEY].shape == (4, h, a)
         assert rollout["next", "reward"].shape == (4, h, 1)
+
+    def test_missing_vla_chunk_key_error(self):
+        env = TransformedEnv(
+            ToyVLAEnv(action_dim=2, state_dim=4),
+            MultiAction.from_vla(),
+        )
+        td = env.reset()
+        with pytest.raises(KeyError, match="MultiAction.from_vla"):
+            env.step(td)
 
     @pytest.mark.parametrize("batch_size", [(), (1,)])
     def test_token_policy_pipeline(self, batch_size):
@@ -2528,7 +2541,7 @@ class TestActionChunkTransform(TransformBase):
         env = self._env()
         check_env_specs(env)
         assert "action" in env.full_action_spec.keys(True, True)
-        assert "action_chunk" not in env.full_action_spec.keys(True, True)
+        assert ACTION_CHUNK_KEY not in env.full_action_spec.keys(True, True)
 
     def test_serial_trans_env_check(self):
         env = SerialEnv(2, self._env)
@@ -2567,14 +2580,14 @@ class TestActionChunkTransform(TransformBase):
     def test_transform_no_env(self):
         t = ActionChunkTransform(chunk_size=4)
         out = t(TensorDict({"action": torch.randn(2, 6, 3)}, batch_size=[2, 6]))
-        assert out["action_chunk"].shape == torch.Size([2, 6, 4, 3])
+        assert out[ACTION_CHUNK_KEY].shape == torch.Size([2, 6, 4, 3])
         assert out["action_is_pad"].shape == torch.Size([2, 6, 4])
         assert out["action_is_pad"].dtype == torch.bool
 
     def test_transform_compose(self):
         t = Compose(ActionChunkTransform(chunk_size=2))
         out = t(TensorDict({"action": torch.randn(5, 3)}, batch_size=[5]))
-        assert out["action_chunk"].shape == torch.Size([5, 2, 3])
+        assert out[ACTION_CHUNK_KEY].shape == torch.Size([5, 2, 3])
         assert out["action_is_pad"].shape == torch.Size([5, 2])
 
     def test_transform_env(self):
@@ -2593,7 +2606,7 @@ class TestActionChunkTransform(TransformBase):
         env.step(td)
         torch.testing.assert_close(captured["action"], td["action"])
         r = env.rollout(3)
-        assert "action_chunk" not in r.keys()
+        assert ACTION_CHUNK_KEY not in r.keys(True, True)
 
     def test_transform_model(self):
         t = ActionChunkTransform(chunk_size=3)
@@ -2603,7 +2616,7 @@ class TestActionChunkTransform(TransformBase):
         expected_chunk = torch.tensor(
             [[0, 1, 2], [1, 2, 3], [2, 3, 3], [3, 3, 3]]
         ).float()
-        torch.testing.assert_close(out["action_chunk"][0, :, :, 0], expected_chunk)
+        torch.testing.assert_close(out[ACTION_CHUNK_KEY][0, :, :, 0], expected_chunk)
         expected_pad = torch.tensor([[0, 0, 0], [0, 0, 0], [0, 0, 1], [0, 1, 1]]).bool()
         assert torch.equal(out["action_is_pad"][0], expected_pad)
 
@@ -2617,9 +2630,9 @@ class TestActionChunkTransform(TransformBase):
         # no-op, and the chunks are built on the sample path only
         rb.extend(TensorDict({"action": torch.randn(10, 5, 2)}, batch_size=[10]))
         stored = rb._storage._storage
-        assert "action_chunk" not in stored.keys()
+        assert ACTION_CHUNK_KEY not in stored.keys(True, True)
         sample = rb.sample()
-        assert sample["action_chunk"].shape[-2:] == torch.Size([3, 2])
+        assert sample[ACTION_CHUNK_KEY].shape[-2:] == torch.Size([3, 2])
         assert sample["action_is_pad"].shape[-1] == 3
 
     def test_transform_inverse(self):
@@ -2628,7 +2641,7 @@ class TestActionChunkTransform(TransformBase):
         action = torch.randn(2, 5)
         td = t.inv(TensorDict({"action": action}, batch_size=[2]))
         torch.testing.assert_close(td["action"], action)
-        assert "action_chunk" not in td.keys()
+        assert ACTION_CHUNK_KEY not in td.keys(True, True)
 
     # ActionChunkTransform-specific tests
     def test_values_and_padding(self):
@@ -2638,20 +2651,20 @@ class TestActionChunkTransform(TransformBase):
         expected_chunk = torch.tensor(
             [[0, 1, 2], [1, 2, 3], [2, 3, 3], [3, 3, 3]]
         ).float()
-        torch.testing.assert_close(out["action_chunk"][0, :, :, 0], expected_chunk)
+        torch.testing.assert_close(out[ACTION_CHUNK_KEY][0, :, :, 0], expected_chunk)
         expected_pad = torch.tensor([[0, 0, 0], [0, 0, 0], [0, 0, 1], [0, 1, 1]]).bool()
         assert torch.equal(out["action_is_pad"][0], expected_pad)
 
     def test_no_batch_dim(self):
         t = ActionChunkTransform(chunk_size=2)
         out = t(TensorDict({"action": torch.randn(5, 3)}, batch_size=[5]))
-        assert out["action_chunk"].shape == torch.Size([5, 2, 3])
+        assert out[ACTION_CHUNK_KEY].shape == torch.Size([5, 2, 3])
         assert out["action_is_pad"].shape == torch.Size([5, 2])
 
     def test_chunk_larger_than_horizon(self):
         t = ActionChunkTransform(chunk_size=10)
         out = t(TensorDict({"action": torch.arange(3).view(1, 3, 1).float()}, [1, 3]))
-        assert out["action_chunk"].shape == torch.Size([1, 3, 10, 1])
+        assert out[ACTION_CHUNK_KEY].shape == torch.Size([1, 3, 10, 1])
         # first chunk: steps 0,1,2 valid then padded
         assert not out["action_is_pad"][0, 0, :3].any()
         assert out["action_is_pad"][0, 0, 3:].all()
@@ -2686,7 +2699,7 @@ class TestActionChunkTransform(TransformBase):
         )
         windows = flat.reshape(2, 4)
         out = ActionChunkTransform(3)(windows)
-        chunk = out["action_chunk"][..., 0]
+        chunk = out[ACTION_CHUNK_KEY][..., 0]
         # neither slice pulls the other slice's actions across the boundary
         assert chunk[0].max() <= 3
         assert chunk[1].min() >= 10

--- a/torchrl/data/vla/__init__.py
+++ b/torchrl/data/vla/__init__.py
@@ -23,6 +23,7 @@ from torchrl.data.vla.schema import (
     OBSERVATION_KEY,
     STATE_KEY,
     validate_vla_tensordict,
+    VLA_ACTION_KEY,
 )
 from torchrl.data.vla.tokenizers import (
     ActionTokenizerBase,
@@ -47,6 +48,7 @@ __all__ = [
     "STATE_KEY",
     "INSTRUCTION_KEY",
     "ACTION_KEY",
+    "VLA_ACTION_KEY",
     "ACTION_CHUNK_KEY",
     "ACTION_IS_PAD_KEY",
     "ACTION_TOKENS_KEY",

--- a/torchrl/data/vla/__init__.py
+++ b/torchrl/data/vla/__init__.py
@@ -10,7 +10,9 @@ dataset metadata, and action tokenizers.
 """
 from __future__ import annotations
 
+from torchrl.data.vla.containers import VLAAction, VLAImages, VLAObservation
 from torchrl.data.vla.metadata import ActionSpace, GripperMode, RobotDatasetMetadata
+from torchrl.data.vla.preprocessing import OpenVLAImagePreprocessor
 from torchrl.data.vla.schema import (
     ACTION_CHUNK_KEY,
     ACTION_IS_PAD_KEY,
@@ -32,8 +34,12 @@ __all__ = [
     "ActionSpace",
     "ActionTokenizerBase",
     "GripperMode",
+    "OpenVLAImagePreprocessor",
     "RobotDatasetMetadata",
     "UniformActionTokenizer",
+    "VLAAction",
+    "VLAImages",
+    "VLAObservation",
     "VocabTailActionTokenizer",
     "validate_vla_tensordict",
     "OBSERVATION_KEY",

--- a/torchrl/data/vla/containers.py
+++ b/torchrl/data/vla/containers.py
@@ -1,0 +1,104 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Structured TensorClass containers for Vision-Language-Action data."""
+from __future__ import annotations
+
+import torch
+from tensordict import TensorDictBase
+from tensordict.tensorclass import TensorClass
+
+__all__ = ["VLAAction", "VLAImages", "VLAObservation"]
+
+
+class VLAImages(TensorClass["nocast"]):
+    """Container for VLA image observations.
+
+    Args:
+        image (torch.Tensor | None): Primary camera image tensor.
+        wrist_image (torch.Tensor | None): Optional wrist-camera image tensor.
+        extra (TensorDictBase | None): Optional additional camera/features data.
+        padded (bool | None): Whether images were padded to a common shape.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.data.vla import VLAImages
+        >>> images = VLAImages(image=torch.zeros(2, 3, 16, 16), batch_size=[2])
+        >>> images.image.shape
+        torch.Size([2, 3, 16, 16])
+    """
+
+    image: torch.Tensor | None = None
+    wrist_image: torch.Tensor | None = None
+    extra: TensorDictBase | None = None
+    padded: bool | None = None
+
+
+class VLAObservation(TensorClass["nocast"]):
+    """Container for VLA observations.
+
+    Args:
+        images (VLAImages | None): Structured camera observations.
+        state (torch.Tensor | None): Optional proprioceptive state.
+        instruction (object | None): Raw or tokenized language instruction.
+        preprocessed (TensorDictBase | None): Backend-ready model inputs.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.data.vla import VLAImages, VLAObservation
+        >>> obs = VLAObservation(
+        ...     images=VLAImages(image=torch.zeros(2, 3, 16, 16), batch_size=[2]),
+        ...     state=torch.zeros(2, 5),
+        ...     instruction=["pick", "place"],
+        ...     batch_size=[2],
+        ... )
+        >>> obs.images.image.shape
+        torch.Size([2, 3, 16, 16])
+    """
+
+    images: VLAImages | None = None
+    state: torch.Tensor | None = None
+    instruction: object | None = None
+    preprocessed: TensorDictBase | None = None
+
+
+class VLAAction(TensorClass["nocast", "shadow"]):
+    """Container for VLA policy outputs.
+
+    Args:
+        chunk (torch.Tensor | None): Continuous action chunk.
+        tokens (torch.Tensor | None): Action-token ids in the policy vocabulary.
+        raw_tokens (torch.Tensor | None): Backend-native token ids when they differ
+            from action-token window ids.
+        logits (torch.Tensor | None): Token logits with a trailing vocabulary dim.
+        log_probs (torch.Tensor | None): Log-probabilities of the selected tokens.
+        mask (torch.Tensor | None): Optional valid-token/action mask.
+        padded (bool | None): Whether variable-length outputs were padded.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.data.vla import VLAAction
+        >>> action = VLAAction(chunk=torch.zeros(2, 4, 7), batch_size=[2])
+        >>> action.chunk.shape
+        torch.Size([2, 4, 7])
+    """
+
+    chunk: torch.Tensor | None = None
+    tokens: torch.Tensor | None = None
+    raw_tokens: torch.Tensor | None = None
+    logits: torch.Tensor | None = None
+    log_probs: torch.Tensor | None = None
+    mask: torch.Tensor | None = None
+    padded: bool | None = None
+
+
+def _get_action_chunk(action: VLAAction) -> torch.Tensor | None:
+    return action._tensordict.get("chunk", None)
+
+
+def _set_action_chunk(action: VLAAction, value: torch.Tensor | None) -> None:
+    action._tensordict.set("chunk", value)
+
+
+VLAAction.chunk = property(_get_action_chunk, _set_action_chunk)

--- a/torchrl/data/vla/containers.py
+++ b/torchrl/data/vla/containers.py
@@ -101,4 +101,8 @@ def _set_action_chunk(action: VLAAction, value: torch.Tensor | None) -> None:
     action._tensordict.set("chunk", value)
 
 
+# ``chunk`` also names a TensorDictBase method. ``shadow`` lets the field be
+# stored, but the generated descriptor would otherwise expose the method rather
+# than the action tensor. Re-install the descriptor explicitly so
+# ``vla_action.chunk`` and ``td["vla_action", "chunk"]`` stay equivalent.
 VLAAction.chunk = property(_get_action_chunk, _set_action_chunk)

--- a/torchrl/data/vla/preprocessing.py
+++ b/torchrl/data/vla/preprocessing.py
@@ -1,0 +1,193 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Image preprocessing helpers for Vision-Language-Action policies."""
+from __future__ import annotations
+
+import importlib.util
+import io
+from typing import Literal
+
+import torch
+import torch.nn.functional as F
+
+_has_pil = importlib.util.find_spec("PIL") is not None
+_has_torchvision = importlib.util.find_spec("torchvision") is not None
+
+__all__ = ["OpenVLAImagePreprocessor"]
+
+_CROP_AREA_SCALE = 0.9
+_CROP_LINEAR_SCALE = _CROP_AREA_SCALE**0.5
+
+
+class OpenVLAImagePreprocessor:
+    """OpenVLA-style image resize, JPEG round-trip and optional center crop.
+
+    The operation order mirrors the OpenVLA-OFT evaluation path: resize to a
+    square image, JPEG encode/decode at the requested quality, optionally apply
+    a 0.9-area center crop, and resize back. The default ``"torchvision"``
+    backend keeps data as tensors and uses ``torchvision.io`` JPEG codecs;
+    ``"pil"`` is the reference/debugging backend.
+
+    Args:
+        size (int): Square output size. Defaults to ``224``.
+        jpeg_quality (int): JPEG quality. Defaults to ``95``.
+        center_crop (bool): Whether to apply the OpenVLA 0.9-area center crop.
+            Defaults to ``False``.
+        backend (str): ``"torchvision"`` or ``"pil"``. Defaults to
+            ``"torchvision"``.
+        mean (torch.Tensor | sequence, optional): Per-channel normalization mean.
+        std (torch.Tensor | sequence, optional): Per-channel normalization std.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.data.vla import OpenVLAImagePreprocessor
+        >>> proc = OpenVLAImagePreprocessor(backend="pil")
+        >>> out = proc(torch.zeros(2, 3, 32, 32, dtype=torch.uint8))
+        >>> out.shape
+        torch.Size([2, 3, 224, 224])
+    """
+
+    def __init__(
+        self,
+        *,
+        size: int = 224,
+        jpeg_quality: int = 95,
+        center_crop: bool = False,
+        backend: Literal["torchvision", "pil"] = "torchvision",
+        mean: torch.Tensor | list[float] | tuple[float, ...] | None = None,
+        std: torch.Tensor | list[float] | tuple[float, ...] | None = None,
+    ) -> None:
+        if size < 1:
+            raise ValueError(f"size must be >= 1, got {size}.")
+        if not 1 <= jpeg_quality <= 100:
+            raise ValueError(
+                f"jpeg_quality must be between 1 and 100, got {jpeg_quality}."
+            )
+        if backend not in ("torchvision", "pil"):
+            raise ValueError(
+                f"backend must be 'torchvision' or 'pil', got {backend!r}."
+            )
+        if backend == "torchvision" and not _has_torchvision:
+            raise ImportError(
+                "OpenVLAImagePreprocessor backend='torchvision' requires "
+                "torchvision. Install the TorchRL vla extra or pass backend='pil'."
+            )
+        if backend == "pil" and not _has_pil:
+            raise ImportError("OpenVLAImagePreprocessor backend='pil' requires Pillow.")
+        if (mean is None) != (std is None):
+            raise ValueError("mean and std must be provided together.")
+        self.size = int(size)
+        self.jpeg_quality = int(jpeg_quality)
+        self.center_crop = bool(center_crop)
+        self.backend = backend
+        self.mean = None if mean is None else torch.as_tensor(mean, dtype=torch.float32)
+        self.std = None if std is None else torch.as_tensor(std, dtype=torch.float32)
+
+    def __call__(self, images: torch.Tensor) -> torch.Tensor:
+        """Preprocess one image ``[C, H, W]`` or a batch ``[..., C, H, W]``."""
+        if images.ndim < 3:
+            raise ValueError(
+                f"images must have shape [..., C, H, W], got {tuple(images.shape)}."
+            )
+        if images.shape[-3] not in (1, 3):
+            raise ValueError(
+                "images must have one or three channels in the third-to-last "
+                f"dimension, got shape {tuple(images.shape)}."
+            )
+        original_shape = images.shape[:-3]
+        flat = images.reshape(-1, *images.shape[-3:])
+        flat = self._to_uint8(flat)
+        if self.backend == "torchvision":
+            processed = self._torchvision(flat)
+        else:
+            processed = self._pil(flat)
+        processed = processed.reshape(*original_shape, *processed.shape[-3:])
+        if self.mean is not None:
+            processed = processed.to(torch.float32).div_(255.0)
+            view_shape = *((1,) * (processed.ndim - 3)), -1, 1, 1
+            mean = self.mean.to(device=processed.device, dtype=processed.dtype).view(
+                view_shape
+            )
+            std = self.std.to(device=processed.device, dtype=processed.dtype).view(
+                view_shape
+            )
+            processed = processed.sub_(mean).div_(std)
+        return processed
+
+    @staticmethod
+    def _to_uint8(images: torch.Tensor) -> torch.Tensor:
+        if images.dtype == torch.uint8:
+            return images.contiguous()
+        if images.is_floating_point():
+            scale = 1.0
+            if images.numel() and float(images.detach().max()) <= 1.0:
+                scale = 255.0
+            return images.mul(scale).clamp(0, 255).to(torch.uint8).contiguous()
+        return images.clamp(0, 255).to(torch.uint8).contiguous()
+
+    def _resize(self, images: torch.Tensor, size: int | None = None) -> torch.Tensor:
+        size = self.size if size is None else int(size)
+        if images.shape[-2:] == (size, size):
+            return images
+        resized = F.interpolate(
+            images.to(torch.float32),
+            size=(size, size),
+            mode="bicubic",
+            align_corners=False,
+            antialias=True,
+        )
+        return resized.round_().clamp_(0, 255).to(torch.uint8)
+
+    def _center_crop(self, images: torch.Tensor) -> torch.Tensor:
+        if not self.center_crop:
+            return images
+        height, width = images.shape[-2:]
+        crop_h = int(round(height * _CROP_LINEAR_SCALE))
+        crop_w = int(round(width * _CROP_LINEAR_SCALE))
+        top = (height - crop_h) // 2
+        left = (width - crop_w) // 2
+        return images[..., top : top + crop_h, left : left + crop_w]
+
+    def _torchvision(self, images: torch.Tensor) -> torch.Tensor:
+        from torchvision.io import decode_jpeg, encode_jpeg, ImageReadMode
+
+        device = images.device
+        images = self._resize(images)
+        encoded = encode_jpeg(list(images.unbind(0)), quality=self.jpeg_quality)
+        decoded = decode_jpeg(encoded, mode=ImageReadMode.RGB, device=device)
+        if isinstance(decoded, list):
+            decoded = torch.stack(decoded, 0)
+        decoded = self._center_crop(decoded)
+        decoded = self._resize(decoded)
+        return decoded
+
+    def _pil(self, images: torch.Tensor) -> torch.Tensor:
+        import numpy as np
+        from PIL import Image
+
+        out = []
+        for image in images.cpu():
+            array = image.permute(1, 2, 0).numpy().astype("uint8")
+            pil = Image.fromarray(array.squeeze(-1) if array.shape[-1] == 1 else array)
+            pil = pil.convert("RGB")
+            if pil.size != (self.size, self.size):
+                pil = pil.resize((self.size, self.size), Image.LANCZOS)
+            buffer = io.BytesIO()
+            pil.save(buffer, format="JPEG", quality=self.jpeg_quality)
+            buffer.seek(0)
+            pil = Image.open(buffer).convert("RGB")
+            if self.center_crop:
+                width, height = pil.size
+                crop_w = int(round(width * _CROP_LINEAR_SCALE))
+                crop_h = int(round(height * _CROP_LINEAR_SCALE))
+                left = (width - crop_w) // 2
+                top = (height - crop_h) // 2
+                pil = pil.crop((left, top, left + crop_w, top + crop_h)).resize(
+                    (width, height), Image.LANCZOS
+                )
+            out.append(
+                torch.from_numpy(np.asarray(pil, dtype="uint8").copy()).permute(2, 0, 1)
+            )
+        return torch.stack(out, 0).to(images.device)

--- a/torchrl/data/vla/preprocessing.py
+++ b/torchrl/data/vla/preprocessing.py
@@ -40,6 +40,11 @@ class OpenVLAImagePreprocessor:
         mean (torch.Tensor | sequence, optional): Per-channel normalization mean.
         std (torch.Tensor | sequence, optional): Per-channel normalization std.
 
+    .. note::
+        Floating-point inputs are ambiguous: this helper treats float images with
+        maximum value at most ``1`` as normalized ``[0, 1]`` data and rescales
+        them to uint8; other float images are interpreted as ``[0, 255]`` data.
+
     Examples:
         >>> import torch
         >>> from torchrl.data.vla import OpenVLAImagePreprocessor
@@ -122,6 +127,8 @@ class OpenVLAImagePreprocessor:
             return images.contiguous()
         if images.is_floating_point():
             scale = 1.0
+            # Float inputs are accepted either as normalized [0, 1] images or
+            # as [0, 255] images; use the max value to disambiguate.
             if images.numel() and float(images.detach().max()) <= 1.0:
                 scale = 255.0
             return images.mul(scale).clamp(0, 255).to(torch.uint8).contiguous()

--- a/torchrl/data/vla/preprocessing.py
+++ b/torchrl/data/vla/preprocessing.py
@@ -162,8 +162,29 @@ class OpenVLAImagePreprocessor:
 
         device = images.device
         images = self._resize(images)
-        encoded = encode_jpeg(list(images.unbind(0)), quality=self.jpeg_quality)
-        decoded = decode_jpeg(encoded, mode=ImageReadMode.RGB, device=device)
+        image_list = list(images.unbind(0))
+        try:
+            encoded = encode_jpeg(image_list, quality=self.jpeg_quality)
+        except (RuntimeError, TypeError):
+            encoded = [
+                encode_jpeg(image, quality=self.jpeg_quality) for image in image_list
+            ]
+            decoded = [
+                decode_jpeg(image, mode=ImageReadMode.RGB, device=device)
+                for image in encoded
+            ]
+            decoded = torch.stack(decoded, 0)
+        else:
+            try:
+                decoded = decode_jpeg(encoded, mode=ImageReadMode.RGB, device=device)
+            except (RuntimeError, TypeError):
+                if not isinstance(encoded, list):
+                    encoded = [encoded]
+                decoded = [
+                    decode_jpeg(image, mode=ImageReadMode.RGB, device=device)
+                    for image in encoded
+                ]
+                decoded = torch.stack(decoded, 0)
         if isinstance(decoded, list):
             decoded = torch.stack(decoded, 0)
         decoded = self._center_crop(decoded)

--- a/torchrl/data/vla/preprocessing.py
+++ b/torchrl/data/vla/preprocessing.py
@@ -12,6 +12,8 @@ from typing import Literal
 import torch
 import torch.nn.functional as F
 
+from torchrl._utils import implement_for
+
 _has_pil = importlib.util.find_spec("PIL") is not None
 _has_torchvision = importlib.util.find_spec("torchvision") is not None
 
@@ -19,6 +21,37 @@ __all__ = ["OpenVLAImagePreprocessor"]
 
 _CROP_AREA_SCALE = 0.9
 _CROP_LINEAR_SCALE = _CROP_AREA_SCALE**0.5
+
+
+@implement_for("torchvision")
+def _torchvision_jpeg_roundtrip(
+    images: torch.Tensor, jpeg_quality: int, device: torch.device
+) -> torch.Tensor:
+    raise ModuleNotFoundError("torchvision is required for JPEG preprocessing.")
+
+
+@_torchvision_jpeg_roundtrip.register(from_version=None, to_version="0.20")
+def _(images: torch.Tensor, jpeg_quality: int, device: torch.device) -> torch.Tensor:
+    from torchvision.io import decode_jpeg, encode_jpeg, ImageReadMode
+
+    encoded = [
+        encode_jpeg(image.cpu(), quality=jpeg_quality) for image in images.unbind(0)
+    ]
+    decoded = [
+        decode_jpeg(image, mode=ImageReadMode.RGB, device=device) for image in encoded
+    ]
+    return torch.stack(decoded, 0)
+
+
+@_torchvision_jpeg_roundtrip.register(from_version="0.20")
+def _(images: torch.Tensor, jpeg_quality: int, device: torch.device) -> torch.Tensor:
+    from torchvision.io import decode_jpeg, encode_jpeg, ImageReadMode
+
+    encoded = encode_jpeg(list(images.unbind(0)), quality=jpeg_quality)
+    decoded = decode_jpeg(encoded, mode=ImageReadMode.RGB, device=device)
+    if isinstance(decoded, list):
+        decoded = torch.stack(decoded, 0)
+    return decoded
 
 
 class OpenVLAImagePreprocessor:
@@ -158,35 +191,9 @@ class OpenVLAImagePreprocessor:
         return images[..., top : top + crop_h, left : left + crop_w]
 
     def _torchvision(self, images: torch.Tensor) -> torch.Tensor:
-        from torchvision.io import decode_jpeg, encode_jpeg, ImageReadMode
-
         device = images.device
         images = self._resize(images)
-        image_list = list(images.unbind(0))
-        try:
-            encoded = encode_jpeg(image_list, quality=self.jpeg_quality)
-        except (RuntimeError, TypeError):
-            encoded = [
-                encode_jpeg(image, quality=self.jpeg_quality) for image in image_list
-            ]
-            decoded = [
-                decode_jpeg(image, mode=ImageReadMode.RGB, device=device)
-                for image in encoded
-            ]
-            decoded = torch.stack(decoded, 0)
-        else:
-            try:
-                decoded = decode_jpeg(encoded, mode=ImageReadMode.RGB, device=device)
-            except (RuntimeError, TypeError):
-                if not isinstance(encoded, list):
-                    encoded = [encoded]
-                decoded = [
-                    decode_jpeg(image, mode=ImageReadMode.RGB, device=device)
-                    for image in encoded
-                ]
-                decoded = torch.stack(decoded, 0)
-        if isinstance(decoded, list):
-            decoded = torch.stack(decoded, 0)
+        decoded = _torchvision_jpeg_roundtrip(images, self.jpeg_quality, device)
         decoded = self._center_crop(decoded)
         decoded = self._resize(decoded)
         return decoded

--- a/torchrl/data/vla/schema.py
+++ b/torchrl/data/vla/schema.py
@@ -20,9 +20,11 @@ format::
         ),
         language_instruction: NonTensorData | Text,           # raw or tokenized (per-traj)
         action: float [*B, T, action_dim],                    # raw, per-step
-        action_chunk: float [*B, T, chunk, action_dim],       # built for training
+        vla_action: VLAAction(
+            chunk: float [*B, T, chunk, action_dim],          # built for training
+            tokens: long [*B, T, chunk, action_dim],          # tokenized actions
+        ),
         action_is_pad: bool [*B, T, chunk],                   # chunk validity mask
-        action_tokens: long [*B, T, chunk, action_dim],       # tokenized actions
         next: TensorDict(...),                                 # TED layout
     )
 
@@ -42,6 +44,7 @@ __all__ = [
     "STATE_KEY",
     "INSTRUCTION_KEY",
     "ACTION_KEY",
+    "VLA_ACTION_KEY",
     "ACTION_CHUNK_KEY",
     "ACTION_IS_PAD_KEY",
     "ACTION_TOKENS_KEY",
@@ -63,12 +66,14 @@ INSTRUCTION_KEY: NestedKey = "language_instruction"
 # -- Action keys -------------------------------------------------------------
 #: Raw per-step continuous action ``[*B, T, action_dim]`` (dataset native).
 ACTION_KEY: NestedKey = "action"
+#: Structured action output container.
+VLA_ACTION_KEY: NestedKey = "vla_action"
 #: Continuous action chunk ``[*B, T, chunk, action_dim]`` (training target).
-ACTION_CHUNK_KEY: NestedKey = "action_chunk"
+ACTION_CHUNK_KEY: NestedKey = (VLA_ACTION_KEY, "chunk")
 #: Boolean mask ``[*B, T, chunk]`` marking valid (non-padded) chunk steps.
 ACTION_IS_PAD_KEY: NestedKey = "action_is_pad"
 #: Discrete action tokens ``[*B, T, chunk, action_dim]`` or ``[*B, T, L]``.
-ACTION_TOKENS_KEY: NestedKey = "action_tokens"
+ACTION_TOKENS_KEY: NestedKey = (VLA_ACTION_KEY, "tokens")
 
 
 def validate_vla_tensordict(
@@ -95,7 +100,7 @@ def validate_vla_tensordict(
 
     Keyword Args:
         instruction_key (NestedKey): language-instruction key.
-            Defaults to ``("observation", "language_instruction")``.
+            Defaults to ``"language_instruction"``.
         action_key (NestedKey): action key. Defaults to ``"action"``.
         image_key (NestedKey): image key.
             Defaults to ``("observation", "image")``.

--- a/torchrl/envs/transforms/_action.py
+++ b/torchrl/envs/transforms/_action.py
@@ -708,6 +708,13 @@ class MultiAction(Transform):
         stack_observations (bool, optional): if ``True``, each step's observation will be stack in the output tensordict.
             If ``False``, only the last observation will be returned. The observation spec is adapted accordingly. The
             stack dimension is the same as the action stack dimension. Defaults to ``False``.
+        action_key (NestedKey, optional): the one-step action key consumed by
+            the base environment. Defaults to the parent environment action key.
+        chunk_key (NestedKey, optional): the policy-facing key that holds the
+            stacked actions. Defaults to ``action_key`` for backward
+            compatibility. Set this to values such as ``"action_chunk"`` when a
+            chunk policy should act through :class:`MultiAction` without
+            re-keying its output.
 
     .. seealso:: :class:`~torchrl.envs.transforms.ActionChunkTransform` -- when
         the stacked actions are a chunk policy's *prediction* (overlapping
@@ -724,8 +731,16 @@ class MultiAction(Transform):
         dim: int = 1,
         stack_rewards: bool = True,
         stack_observations: bool = False,
+        action_key: NestedKey | None = None,
+        chunk_key: NestedKey | None = None,
     ):
-        super().__init__()
+        if action_key is None and chunk_key is not None:
+            action_key = "action"
+        if action_key is not None and chunk_key is None:
+            chunk_key = action_key
+        in_keys_inv = None if action_key is None else [action_key]
+        out_keys_inv = None if chunk_key is None else [chunk_key]
+        super().__init__(in_keys_inv=in_keys_inv, out_keys_inv=out_keys_inv)
         self.stack_rewards = stack_rewards
         self.stack_observations = stack_observations
         self.dim = dim
@@ -764,8 +779,17 @@ class MultiAction(Transform):
     def _inv_call(self, tensordict: TensorDictBase) -> TensorDictBase:
         # Get the actions
         parent = self.parent
-        action_keys = parent.action_keys
-        actions = tensordict.select(*action_keys)
+        action_keys = self.in_keys_inv or parent.action_keys
+        chunk_keys = self.out_keys_inv or action_keys
+        if len(action_keys) != len(chunk_keys):
+            raise ValueError(
+                "action_key and chunk_key lists must have the same length, got "
+                f"{len(action_keys)} and {len(chunk_keys)}."
+            )
+        actions = tensordict.empty()
+        for action_key, chunk_key in zip(action_keys, chunk_keys):
+            action = tensordict.get(chunk_key)
+            actions.set(action_key, action)
         actions = actions.auto_batch_size_(batch_dims=tensordict.ndim + self.dim)
         actions = actions.unbind(-1)
         td = tensordict
@@ -882,15 +906,27 @@ class MultiAction(Transform):
             raise KeyError(
                 f"{type(self).__name__} requires an action spec to be present."
             )
-        for _ in range(self.dim):
-            action_spec = action_spec.unsqueeze(input_spec.ndim)
-        # Make the dim dynamic
-        action_spec = action_spec.expand(
-            tuple(
-                d if i != (input_spec.ndim + self.dim - 1) else -1
-                for i, d in enumerate(action_spec.shape)
+        action_keys = self.in_keys_inv or list(action_spec.keys(True, True))
+        chunk_keys = self.out_keys_inv or action_keys
+        if len(action_keys) != len(chunk_keys):
+            raise ValueError(
+                "action_key and chunk_key lists must have the same length, got "
+                f"{len(action_keys)} and {len(chunk_keys)}."
             )
-        )
+        for action_key, chunk_key in zip(action_keys, chunk_keys):
+            leaf_spec = action_spec[action_key]
+            for _ in range(self.dim):
+                leaf_spec = leaf_spec.unsqueeze(input_spec.ndim)
+            # Make the dim dynamic
+            leaf_spec = leaf_spec.expand(
+                tuple(
+                    d if i != (input_spec.ndim + self.dim - 1) else -1
+                    for i, d in enumerate(leaf_spec.shape)
+                )
+            )
+            action_spec[chunk_key] = leaf_spec
+            if chunk_key != action_key:
+                del action_spec[action_key]
         input_spec["full_action_spec"] = action_spec
         return input_spec
 

--- a/torchrl/envs/transforms/_action.py
+++ b/torchrl/envs/transforms/_action.py
@@ -712,9 +712,10 @@ class MultiAction(Transform):
             the base environment. Defaults to the parent environment action key.
         chunk_key (NestedKey, optional): the policy-facing key that holds the
             stacked actions. Defaults to ``action_key`` for backward
-            compatibility. Set this to values such as ``"action_chunk"`` when a
-            chunk policy should act through :class:`MultiAction` without
-            re-keying its output.
+            compatibility. Set this to values such as
+            ``("vla_action", "chunk")`` when a chunk policy should act through
+            :class:`MultiAction` without re-keying its output. See also
+            :meth:`from_vla`.
 
     .. seealso:: :class:`~torchrl.envs.transforms.ActionChunkTransform` -- when
         the stacked actions are a chunk policy's *prediction* (overlapping
@@ -744,6 +745,25 @@ class MultiAction(Transform):
         self.stack_rewards = stack_rewards
         self.stack_observations = stack_observations
         self.dim = dim
+
+    @classmethod
+    def from_vla(cls, *, action_key: NestedKey = ACTION_KEY, **kwargs) -> MultiAction:
+        """Build a :class:`MultiAction` that consumes the default VLA chunk key.
+
+        Args:
+            action_key (NestedKey): the one-step action key consumed by the base
+                environment. Defaults to ``"action"``.
+
+        Keyword Args:
+            Additional :class:`MultiAction` keyword arguments.
+
+        Examples:
+            >>> from torchrl.envs.transforms import MultiAction
+            >>> transform = MultiAction.from_vla(stack_rewards=False)
+            >>> transform.out_keys_inv
+            [('vla_action', 'chunk')]
+        """
+        return cls(action_key=action_key, chunk_key=ACTION_CHUNK_KEY, **kwargs)
 
     def _stack_tds(self, td_list, next_tensordict, keys):
         td = torch.stack(td_list + [next_tensordict.select(*keys)], -1)
@@ -788,7 +808,15 @@ class MultiAction(Transform):
             )
         actions = tensordict.empty()
         for action_key, chunk_key in zip(action_keys, chunk_keys):
-            action = tensordict.get(chunk_key)
+            action = tensordict.get(chunk_key, None)
+            if action is None:
+                raise KeyError(
+                    f"{type(self).__name__} expected stacked actions at key "
+                    f"{chunk_key!r} before env.step, but the key was missing. "
+                    "For VLA policies, use MultiAction.from_vla() or pass "
+                    "chunk_key=('vla_action', 'chunk'). Available keys are "
+                    f"{list(tensordict.keys(True, True))}."
+                )
             actions.set(action_key, action)
         actions = actions.auto_batch_size_(batch_dims=tensordict.ndim + self.dim)
         actions = actions.unbind(-1)
@@ -1787,7 +1815,7 @@ class ActionChunkTransform(Transform):
     OpenVLA-OFT, pi0, SmolVLA): instead of predicting a single action, the
     policy predicts a short horizon ``H`` of future actions. This transform
     turns a per-step action tensor ``[*B, T, action_dim]`` into the
-    corresponding training target ``action_chunk`` of shape
+    corresponding training target ``("vla_action", "chunk")`` of shape
     ``[*B, T, H, action_dim]`` -- for each time step ``t`` it gathers the
     actions ``a[t], a[t+1], ..., a[t+H-1]`` -- together with a boolean
     ``action_is_pad`` mask ``[*B, T, H]`` marking the steps that ran past the
@@ -1838,7 +1866,7 @@ class ActionChunkTransform(Transform):
         action_key (NestedKey): the per-step action to read.
             Defaults to ``"action"``.
         chunk_key (NestedKey): where to write the action chunk.
-            Defaults to ``"action_chunk"``.
+            Defaults to ``("vla_action", "chunk")``.
         pad_key (NestedKey): where to write the padding mask.
             Defaults to ``"action_is_pad"``.
         time_dim (int): the time dimension of the action tensor (the action
@@ -1855,7 +1883,7 @@ class ActionChunkTransform(Transform):
         ...     {"action": torch.arange(4).view(1, 4, 1).float()}, batch_size=[1, 4]
         ... )
         >>> td = t(td)
-        >>> td["action_chunk"][0, :, :, 0]
+        >>> td["vla_action", "chunk"][0, :, :, 0]
         tensor([[0., 1., 2.],
                 [1., 2., 3.],
                 [2., 3., 3.],
@@ -1877,7 +1905,7 @@ class ActionChunkTransform(Transform):
         ...     {"action": torch.randn(8, 4, 1)}, batch_size=[8]
         ... )  # 8 trajectory windows of T=4 steps each
         >>> indices = rb.extend(windows)
-        >>> rb.sample()["action_chunk"].shape  # [batch, T, chunk_size, action_dim]
+        >>> rb.sample()["vla_action", "chunk"].shape  # [batch, T, chunk_size, action_dim]
         torch.Size([2, 4, 3, 1])
     """
 

--- a/torchrl/envs/transforms/_action.py
+++ b/torchrl/envs/transforms/_action.py
@@ -2013,7 +2013,8 @@ class ActionTokenizerTransform(Transform):
     Keyword Args:
         in_key (NestedKey): the continuous action. Defaults to ``"action"``.
         out_key (NestedKey): the discrete token ids. Defaults to
-            ``"action_tokens"``.
+            ``("vla_action", "tokens")``. Pass ``"action_tokens"`` for the
+            flat compatibility key.
 
     Examples:
         >>> import torch
@@ -2023,10 +2024,10 @@ class ActionTokenizerTransform(Transform):
         >>> tok = UniformActionTokenizer(256, low=-1.0, high=1.0)
         >>> t = ActionTokenizerTransform(tok)
         >>> td = t(TensorDict({"action": torch.tensor([[-1.0, 0.0, 1.0]])}, batch_size=[1]))
-        >>> td["action_tokens"]
+        >>> td["vla_action", "tokens"]
         tensor([[  0, 128, 255]])
         >>> # the inverse decodes tokens back to a continuous action
-        >>> back = t.inv(TensorDict({"action_tokens": td["action_tokens"]}, batch_size=[1]))
+        >>> back = t.inv(TensorDict({("vla_action", "tokens"): td["vla_action", "tokens"]}, batch_size=[1]))
         >>> back["action"].shape
         torch.Size([1, 3])
         >>> # on a replay buffer: raw actions written through extend are stored
@@ -2040,7 +2041,7 @@ class ActionTokenizerTransform(Transform):
         >>> indices = rb.extend(
         ...     TensorDict({"action": torch.rand(8, 3) * 2 - 1}, batch_size=[8])
         ... )
-        >>> rb.sample()["action_tokens"].shape
+        >>> rb.sample()["vla_action", "tokens"].shape
         torch.Size([2, 3])
         >>> # on an environment: the policy-facing action spec becomes the token
         >>> # interface, and emitted tokens are decoded before the base env
@@ -2048,9 +2049,9 @@ class ActionTokenizerTransform(Transform):
         >>> from torchrl.envs import GymEnv, TransformedEnv
         >>> tok_env = UniformActionTokenizer(256, low=-2.0, high=2.0)  # Pendulum bounds
         >>> env = TransformedEnv(GymEnv("Pendulum-v1"), ActionTokenizerTransform(tok_env))
-        >>> env.full_action_spec["action_tokens"].shape
+        >>> env.full_action_spec["vla_action", "tokens"].shape
         torch.Size([1])
-        >>> env.rollout(2)["action_tokens"].dtype
+        >>> env.rollout(2)["vla_action", "tokens"].dtype
         torch.int64
 
     .. seealso:: :class:`~torchrl.envs.transforms.ActionDiscretizer` -- the

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -2481,6 +2481,9 @@ class MultiStepActorWrapper(TensorDictModuleBase):
                         raise self._NO_INIT_ERR
                 else:
                     is_init_expand = expand_as_right(is_init, cached_action)
+                    # Only the chunk/cache tensor is refreshed on partial
+                    # re-plans; auxiliary VLA leaves such as tokens or
+                    # log-probs are not used for action dispatch.
                     action_computed = torch.masked_scatter(
                         cached_action, is_init_expand, action_computed
                     )

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -2312,6 +2312,10 @@ class MultiStepActorWrapper(TensorDictModuleBase):
             wrapped actor that hold action chunks. Defaults to VLA-style chunk
             outputs (``("vla_action", "chunk")`` first, then keys ending in
             ``"_chunk"``) when present, and to ``action_keys`` otherwise.
+            When a chunk key differs from the corresponding environment action
+            key, the chunk key itself is used as the cache. A separate
+            ``*_orig`` cache key is only introduced when the chunk key and the
+            action key are the same.
         init_key (NestedKey, optional): the key of the entry indicating
             when the environment has gone through a reset.
             Defaults to ``"is_init"`` which is the ``out_key`` from the
@@ -2468,19 +2472,24 @@ class MultiStepActorWrapper(TensorDictModuleBase):
             tensordict_filtered = tensordict[is_init.reshape(tensordict.shape)]
             output = self.actor(tensordict_filtered)
 
-            for action_key, action_key_orig in self._actor_keys_map.items():
+            for action_key, cache_key in self._actor_keys_map.items():
                 chunk_key = self._chunk_keys_map[action_key]
                 action_computed = output.get(chunk_key, default=None)
-                action_orig = tensordict.get(action_key_orig, default=None)
-                if action_orig is None:
+                cached_action = tensordict.get(cache_key, default=None)
+                if cached_action is None:
                     if not is_init.all():
                         raise self._NO_INIT_ERR
                 else:
-                    is_init_expand = expand_as_right(is_init, action_orig)
+                    is_init_expand = expand_as_right(is_init, cached_action)
                     action_computed = torch.masked_scatter(
-                        action_orig, is_init_expand, action_computed
+                        cached_action, is_init_expand, action_computed
                     )
-                tensordict.set(action_key_orig, action_computed)
+                if cached_action is None and not isinstance(cache_key, str):
+                    cache_parent = output.get(cache_key[:-1], default=None)
+                    if cache_parent is not None:
+                        tensordict.set(cache_key[:-1], cache_parent)
+                        continue
+                tensordict.set(cache_key, action_computed)
         tensordict.set(self.counter_key, counter + 1)
 
     def forward(
@@ -2488,14 +2497,14 @@ class MultiStepActorWrapper(TensorDictModuleBase):
         tensordict: TensorDictBase,
     ) -> TensorDictBase:
         self._init(tensordict)
-        for action_key, action_key_orig in self._actor_keys_map.items():
-            # get orig
-            if isinstance(action_key_orig, str):
+        counter = tensordict.get(self.counter_key)
+        for action_key, cache_key in self._actor_keys_map.items():
+            if isinstance(cache_key, str):
                 parent_td = tensordict
-                action_entry = parent_td.get(action_key_orig, None)
+                action_entry = parent_td.get(cache_key, None)
             else:
-                parent_td = tensordict.get(action_key_orig[:-1])
-                action_entry = parent_td.get(action_key_orig[-1], None)
+                parent_td = tensordict.get(cache_key[:-1])
+                action_entry = parent_td.get(cache_key[-1], None)
             if action_entry is None:
                 raise self._NO_INIT_ERR
             if (
@@ -2516,20 +2525,28 @@ class MultiStepActorWrapper(TensorDictModuleBase):
                     f"({action_entry.shape[parent_td.ndim]}): the cache would "
                     "replay stale actions before re-planning."
                 )
-            base_idx = (
-                slice(
-                    None,
-                ),
-            ) * parent_td.ndim
-            if not self.keep_dim:
-                cur_action = action_entry[base_idx + (0,)]
-            else:
-                cur_action = action_entry[base_idx + (slice(1),)]
-            tensordict.set(action_key, cur_action)
-            tensordict.set(
-                action_key_orig,
-                torch.roll(action_entry, shifts=-1, dims=parent_td.ndim),
+            action_index = (
+                (counter - 1)
+                .to(torch.long)
+                .reshape(action_entry.shape[: parent_td.ndim])
             )
+            if self.n_steps is None and self.replan_interval is None:
+                action_index = action_index.remainder(
+                    action_entry.shape[parent_td.ndim]
+                )
+            index = action_index.reshape(
+                *action_entry.shape[: parent_td.ndim],
+                1,
+                *([1] * (action_entry.ndim - parent_td.ndim - 1)),
+            ).expand(
+                *action_entry.shape[: parent_td.ndim],
+                1,
+                *action_entry.shape[parent_td.ndim + 1 :],
+            )
+            cur_action = action_entry.gather(parent_td.ndim, index)
+            if not self.keep_dim:
+                cur_action = cur_action.squeeze(parent_td.ndim)
+            tensordict.set(action_key, cur_action)
         return tensordict
 
     @property
@@ -2622,6 +2639,7 @@ class MultiStepActorWrapper(TensorDictModuleBase):
     def chunk_keys(self, value):
         if value is None:
             return
+        self.__dict__["_actor_keys_map_values"] = None
         self.__dict__["_chunk_keys_map_values"] = None
         if not isinstance(value, list):
             value = [value]
@@ -2647,14 +2665,15 @@ class MultiStepActorWrapper(TensorDictModuleBase):
         val = self.__dict__.get("_actor_keys_map_values", None)
         if val is None:
 
-            def _replace_last(action_key):
+            def _default_cache_key(action_key):
+                chunk_key = self._chunk_keys_map[action_key]
+                if chunk_key != action_key:
+                    return chunk_key
                 if isinstance(action_key, tuple):
-                    action_key_orig = (*action_key[:-1], action_key[-1] + "_orig")
-                else:
-                    action_key_orig = action_key + "_orig"
-                return action_key_orig
+                    return (*action_key[:-1], action_key[-1] + "_orig")
+                return action_key + "_orig"
 
-            val = {key: _replace_last(key) for key in self.action_keys}
+            val = {key: _default_cache_key(key) for key in self.action_keys}
             self.__dict__["_actor_keys_map_values"] = val
         return val
 

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -2303,7 +2303,15 @@ class MultiStepActorWrapper(TensorDictModuleBase):
         action_keys (list of NestedKeys, optional): the action keys from
             the environment. Can be retrieved from ``env.action_keys``.
             Defaults to all ``out_keys`` of the ``actor`` which end
-            with the ``"action"`` string.
+            with the ``"action"`` string. If ``chunk_keys`` is provided and
+            ``action_keys`` is omitted, the action keys are inferred from the
+            chunk keys by stripping a trailing ``"_chunk"`` suffix, e.g.
+            ``"action_chunk"`` maps to ``"action"``.
+        chunk_keys (list of NestedKeys, optional): the keys written by the
+            wrapped actor that hold action chunks. Defaults to ``action_keys``
+            for backward compatibility. Set this when a chunk policy writes a
+            policy-facing key such as ``"action_chunk"`` while the environment
+            consumes a one-step key such as ``"action"``.
         init_key (NestedKey, optional): the key of the entry indicating
             when the environment has gone through a reset.
             Defaults to ``"is_init"`` which is the ``out_key`` from the
@@ -2390,11 +2398,13 @@ class MultiStepActorWrapper(TensorDictModuleBase):
         n_steps: int | None = None,
         *,
         action_keys: list[NestedKey] | None = None,
+        chunk_keys: list[NestedKey] | None = None,
         init_key: list[NestedKey] | None = None,
         keep_dim: bool = False,
         replan_interval: int | None = None,
     ):
         self.action_keys = action_keys
+        self.chunk_keys = chunk_keys
         self.init_key = init_key
         self.n_steps = n_steps
         self.keep_dim = keep_dim
@@ -2418,11 +2428,13 @@ class MultiStepActorWrapper(TensorDictModuleBase):
 
     @property
     def out_keys(self):
-        return (
-            self.actor.out_keys
-            + list(self._actor_keys_map.values())
-            + [self.counter_key]
-        )
+        out_keys = list(self.actor.out_keys)
+        for key in (
+            self.action_keys + list(self._actor_keys_map.values()) + [self.counter_key]
+        ):
+            if key not in out_keys:
+                out_keys.append(key)
+        return out_keys
 
     def _get_and_move(self, tensordict: TensorDictBase) -> TensorDictBase:
         for action_key in self.action_keys:
@@ -2457,7 +2469,8 @@ class MultiStepActorWrapper(TensorDictModuleBase):
             output = self.actor(tensordict_filtered)
 
             for action_key, action_key_orig in self._actor_keys_map.items():
-                action_computed = output.get(action_key, default=None)
+                chunk_key = self._chunk_keys_map[action_key]
+                action_computed = output.get(chunk_key, default=None)
                 action_orig = tensordict.get(action_key_orig, default=None)
                 if action_orig is None:
                     if not is_init.all():
@@ -2523,6 +2536,13 @@ class MultiStepActorWrapper(TensorDictModuleBase):
     def action_keys(self) -> list[NestedKey]:
         action_keys = self.__dict__.get("_action_keys", None)
         if action_keys is None:
+            chunk_keys = self.__dict__.get("_chunk_keys", None)
+            if chunk_keys is not None:
+                action_keys = [
+                    self._infer_action_key_from_chunk_key(key) for key in chunk_keys
+                ]
+                self.__dict__["_action_keys"] = action_keys
+                return action_keys
 
             def ends_with_action(key):
                 if isinstance(key, str):
@@ -2539,9 +2559,55 @@ class MultiStepActorWrapper(TensorDictModuleBase):
         if value is None:
             return
         self.__dict__["_actor_keys_map_values"] = None
+        self.__dict__["_chunk_keys_map_values"] = None
         if not isinstance(value, list):
             value = [value]
         self._action_keys = [unravel_key(key) for key in value]
+
+    @staticmethod
+    def _infer_action_key_from_chunk_key(chunk_key: NestedKey) -> NestedKey:
+        chunk_key = unravel_key(chunk_key)
+        if isinstance(chunk_key, str):
+            if chunk_key.endswith("_chunk"):
+                action_key = chunk_key[: -len("_chunk")]
+                return action_key or chunk_key
+            return chunk_key
+        last = chunk_key[-1]
+        if last.endswith("_chunk"):
+            action_key = last[: -len("_chunk")]
+            return (*chunk_key[:-1], action_key or last)
+        return chunk_key
+
+    @property
+    def chunk_keys(self) -> list[NestedKey]:
+        chunk_keys = self.__dict__.get("_chunk_keys", None)
+        if chunk_keys is None:
+            return self.action_keys
+        return chunk_keys
+
+    @chunk_keys.setter
+    def chunk_keys(self, value):
+        if value is None:
+            return
+        self.__dict__["_chunk_keys_map_values"] = None
+        if not isinstance(value, list):
+            value = [value]
+        self._chunk_keys = [unravel_key(key) for key in value]
+
+    @property
+    def _chunk_keys_map(self) -> dict[NestedKey, NestedKey]:
+        val = self.__dict__.get("_chunk_keys_map_values", None)
+        if val is None:
+            action_keys = self.action_keys
+            chunk_keys = self.chunk_keys
+            if len(action_keys) != len(chunk_keys):
+                raise ValueError(
+                    "action_keys and chunk_keys must have the same length, got "
+                    f"{len(action_keys)} and {len(chunk_keys)}."
+                )
+            val = dict(zip(action_keys, chunk_keys))
+            self.__dict__["_chunk_keys_map_values"] = val
+        return val
 
     @property
     def _actor_keys_map(self) -> dict[NestedKey, NestedKey]:

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -2303,15 +2303,15 @@ class MultiStepActorWrapper(TensorDictModuleBase):
         action_keys (list of NestedKeys, optional): the action keys from
             the environment. Can be retrieved from ``env.action_keys``.
             Defaults to all ``out_keys`` of the ``actor`` which end
-            with the ``"action"`` string. If ``chunk_keys`` is provided and
-            ``action_keys`` is omitted, the action keys are inferred from the
-            chunk keys by stripping a trailing ``"_chunk"`` suffix, e.g.
-            ``"action_chunk"`` maps to ``"action"``.
+            with the ``"action"`` string. If ``chunk_keys`` is provided (or
+            can be inferred from the actor's output keys) and ``action_keys`` is
+            omitted, the action keys are inferred from the chunk keys. For
+            example ``"action_chunk"`` and ``("vla_action", "chunk")`` both map
+            to ``"action"``.
         chunk_keys (list of NestedKeys, optional): the keys written by the
-            wrapped actor that hold action chunks. Defaults to ``action_keys``
-            for backward compatibility. Set this when a chunk policy writes a
-            policy-facing key such as ``"action_chunk"`` while the environment
-            consumes a one-step key such as ``"action"``.
+            wrapped actor that hold action chunks. Defaults to VLA-style chunk
+            outputs (``("vla_action", "chunk")`` first, then keys ending in
+            ``"_chunk"``) when present, and to ``action_keys`` otherwise.
         init_key (NestedKey, optional): the key of the entry indicating
             when the environment has gone through a reset.
             Defaults to ``"is_init"`` which is the ``out_key`` from the
@@ -2536,21 +2536,14 @@ class MultiStepActorWrapper(TensorDictModuleBase):
     def action_keys(self) -> list[NestedKey]:
         action_keys = self.__dict__.get("_action_keys", None)
         if action_keys is None:
-            chunk_keys = self.__dict__.get("_chunk_keys", None)
-            if chunk_keys is not None:
+            chunk_keys = self.chunk_keys
+            if chunk_keys != self._default_action_keys_from_actor():
                 action_keys = [
                     self._infer_action_key_from_chunk_key(key) for key in chunk_keys
                 ]
                 self.__dict__["_action_keys"] = action_keys
                 return action_keys
-
-            def ends_with_action(key):
-                if isinstance(key, str):
-                    return key == "action"
-                return key[-1] == "action"
-
-            action_keys = [key for key in self.actor.out_keys if ends_with_action(key)]
-
+            action_keys = chunk_keys
             self.__dict__["_action_keys"] = action_keys
         return action_keys
 
@@ -2573,16 +2566,56 @@ class MultiStepActorWrapper(TensorDictModuleBase):
                 return action_key or chunk_key
             return chunk_key
         last = chunk_key[-1]
+        if last == "chunk" and len(chunk_key) >= 2 and chunk_key[-2] == "vla_action":
+            return "action"
         if last.endswith("_chunk"):
             action_key = last[: -len("_chunk")]
             return (*chunk_key[:-1], action_key or last)
         return chunk_key
 
+    @staticmethod
+    def _is_vla_chunk_key(key: NestedKey) -> bool:
+        return (
+            isinstance(key, tuple)
+            and len(key) >= 2
+            and key[-2:]
+            == (
+                "vla_action",
+                "chunk",
+            )
+        )
+
+    @staticmethod
+    def _is_chunk_key(key: NestedKey) -> bool:
+        if MultiStepActorWrapper._is_vla_chunk_key(key):
+            return True
+        if isinstance(key, str):
+            return key.endswith("_chunk")
+        return key[-1].endswith("_chunk")
+
+    def _default_action_keys_from_actor(self) -> list[NestedKey]:
+        def ends_with_action(key):
+            if isinstance(key, str):
+                return key == "action"
+            return key[-1] == "action"
+
+        return [key for key in self.actor.out_keys if ends_with_action(key)]
+
+    def _default_chunk_keys_from_actor(self) -> list[NestedKey]:
+        out_keys = list(self.actor.out_keys)
+        vla_chunk_keys = [key for key in out_keys if self._is_vla_chunk_key(key)]
+        if vla_chunk_keys:
+            return vla_chunk_keys
+        return [key for key in out_keys if self._is_chunk_key(key)]
+
     @property
     def chunk_keys(self) -> list[NestedKey]:
         chunk_keys = self.__dict__.get("_chunk_keys", None)
         if chunk_keys is None:
-            return self.action_keys
+            chunk_keys = self._default_chunk_keys_from_actor()
+            if not chunk_keys:
+                chunk_keys = self._default_action_keys_from_actor()
+            self.__dict__["_chunk_keys"] = chunk_keys
         return chunk_keys
 
     @chunk_keys.setter

--- a/torchrl/modules/vla/common.py
+++ b/torchrl/modules/vla/common.py
@@ -5,97 +5,98 @@
 """Base class for Vision-Language-Action (VLA) policies."""
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
 from typing import Literal
 
 import torch
-from tensordict import TensorDictBase
+from tensordict import TensorDict, TensorDictBase
 from tensordict.nn import InteractionType, TensorDictModuleBase
 from tensordict.nn.probabilistic import interaction_type
 from tensordict.utils import NestedKey
 from torch import distributions as torch_dist
 
+from torchrl.data.vla.containers import VLAAction, VLAObservation
 from torchrl.data.vla.schema import (
     ACTION_CHUNK_KEY,
+    ACTION_KEY,
     ACTION_TOKENS_KEY,
     IMAGE_KEY,
     INSTRUCTION_KEY,
     STATE_KEY,
 )
+from torchrl.data.vla.tokenizers import ActionTokenizerBase
 
 __all__ = ["VLAWrapperBase"]
 
 ActionHead = Literal["continuous", "tokens"]
+InputMode = Literal["canonical", "preprocessed"]
 LogProbsMode = Literal["sequence", "token"]
+OutputMode = Literal["chunk", "tokens", "both"]
 SamplingMode = Literal["greedy", "sample"]
 
 
 class VLAWrapperBase(TensorDictModuleBase):
-    """Base class for Vision-Language-Action policies.
+    """Base class for TensorDict-native Vision-Language-Action policies.
 
-    A VLA policy maps multimodal robot observations -- one or more camera
-    images, optional proprioceptive state, and a natural-language instruction --
-    to a short *action chunk*. This base owns the TensorDict key contract and
-    the :meth:`forward` / :meth:`get_dist` orchestration; concrete policies only
-    implement the prediction hooks :meth:`_predict_chunk` (continuous head) and
-    :meth:`_predict_logits` (discrete-token head).
-
-    Two action heads are supported via ``action_head``:
-
-    - ``"continuous"``: :meth:`forward` writes a continuous action chunk of
-      shape ``[*B, chunk_size, action_dim]`` under ``action_chunk``;
-    - ``"tokens"``: :meth:`forward` writes discrete action tokens
-      ``[*B, chunk_size, action_dim]`` under ``action_tokens`` and their
-      log-probabilities under ``log_probs``; :meth:`get_dist` returns
-      the token distribution for log-prob/entropy-based RL fine-tuning.
-      With ``log_probs_mode="sequence"`` (default) the log-probabilities are
-      summed over the chunk (one scalar per sample, the ``sample_log_prob``
-      contract of the PPO losses); with ``log_probs_mode="token"`` they are
-      per-token, shaped ``[*B, chunk_size, action_dim]`` (the groundwork for
-      token-level DAPO-style ratios).
-
-    Keys are configurable through :meth:`set_keys`. The wrapper is a
-    :class:`~tensordict.nn.TensorDictModuleBase`, so it composes with the
-    standard collectors, losses and transforms.
+    A VLA policy maps images, optional proprioceptive state, and a language
+    instruction to either a continuous action chunk or discrete action tokens.
+    This base keeps the flat key contract used by existing TorchRL losses and
+    transforms while also mirroring outputs into a structured
+    :class:`~torchrl.data.vla.VLAAction` container under ``"vla_action"``.
 
     Keyword Args:
-        action_dim (int): the dimensionality of a single action.
-        chunk_size (int): the action-chunk horizon ``H``.
-        action_head (str): ``"continuous"`` (default) or ``"tokens"``.
-        vocab_size (int, optional): number of action-token bins per dimension
-            (required for the ``"tokens"`` head).
-        use_state (bool): whether to read the proprioceptive state.
-            Defaults to ``True``.
-        default_interaction_type (InteractionType): how the ``"tokens"`` head
-            turns logits into action tokens when no exploration context is
-            active. The forward consults the ambient
-            :func:`~torchrl.envs.utils.exploration_type` (set by collectors
-            and :func:`~torchrl.envs.utils.set_exploration_type`):
-            ``InteractionType.RANDOM`` samples, every other type (and this
-            default) takes the argmax. This mirrors
-            :class:`~torchrl.modules.tensordict_module.ProbabilisticActor`, so
-            the same code drives rollouts (the collector's ``exploration_type``
-            defaults to ``RANDOM``) and greedy evaluation
-            (``with set_exploration_type(ExplorationType.DETERMINISTIC):``)
-            without mutating the policy. Defaults to
-            ``InteractionType.DETERMINISTIC`` (argmax). Ignored by the
-            continuous head.
-        log_probs_mode (str): ``"sequence"`` (default; one summed
-            log-probability per sample) or ``"token"`` (per-token
-            log-probabilities, ``[*B, chunk_size, action_dim]``) for the
-            ``"tokens"`` head.
-        mode (str, optional): backward-compatible alias for
-            ``default_interaction_type``. ``"sample"`` maps to
-            ``InteractionType.RANDOM`` and ``"greedy"`` maps to
-            ``InteractionType.DETERMINISTIC``. Defaults to ``None``.
+        action_dim (int): The dimensionality of a single action.
+        chunk_size (int): The action-chunk horizon.
+        action_head (str): ``"continuous"`` or ``"tokens"``.
+        input_mode (str): ``"canonical"`` reads raw VLA keys. ``"preprocessed"``
+            reads a :class:`~torchrl.data.vla.VLAObservation` or
+            :class:`~tensordict.TensorDictBase` from ``observation_key``.
+        output_mode (str, optional): ``"chunk"``, ``"tokens"`` or ``"both"``.
+            Defaults to ``"chunk"`` for continuous heads and ``"tokens"`` for
+            token heads.
+        vocab_size (int, optional): Number of action-token bins, required for
+            token heads.
+        action_tokenizer (ActionTokenizerBase, optional): Token/chunk codec used
+            when ``output_mode`` asks for both representations.
+        return_log_probs (bool, optional): Whether token ``forward`` writes
+            log-probabilities. Defaults to ``True`` for token heads.
+        return_logits (bool): Whether token ``forward`` writes ``action_logits``.
+        logits_only (bool): Whether token ``forward`` returns logits without
+            sampling actions by default. A per-call ``logits_only=True`` argument
+            also enables this path.
+        log_probs_mode (str): ``"sequence"`` returns one summed log-probability
+            per sample; ``"token"`` returns per-token log-probabilities.
+        use_state (bool): Whether canonical mode reads the state key.
+        default_interaction_type (InteractionType): Token readout when no
+            exploration context is active.
+        mode (str, optional): Backward-compatible alias mapping ``"sample"`` to
+            ``InteractionType.RANDOM`` and ``"greedy"`` to deterministic.
+        inplace (bool | "empty" | None): Output TensorDict behavior. ``True``
+            updates the input, ``False`` returns a new output TensorDict, and
+            ``"empty"`` returns an empty TensorDict populated with outputs.
+        num_samples (int, optional): Number of token samples to draw per input.
 
-    .. note::
-        This base deliberately does **not** inherit from the text-generation
-        :class:`~torchrl.modules.llm.LLMWrapperBase`: a VLA policy emits robot
-        actions, not text, so it carries only the small multimodal-to-action
-        contract.
-
-    .. seealso:: :class:`~torchrl.modules.vla.TinyVLA` (reference policy).
+    Examples:
+        >>> import torch
+        >>> from tensordict import NonTensorStack, TensorDict
+        >>> from torchrl.modules.vla import TinyVLA
+        >>> policy = TinyVLA(action_dim=7, chunk_size=4)
+        >>> td = TensorDict(
+        ...     {
+        ...         "observation": {
+        ...             "image": torch.zeros(2, 3, 16, 16, dtype=torch.uint8),
+        ...             "state": torch.zeros(2, 5),
+        ...         },
+        ...         "language_instruction": NonTensorStack("pick", "place"),
+        ...     },
+        ...     batch_size=[2],
+        ... )
+        >>> out = policy(td)
+        >>> out["action_chunk"].shape
+        torch.Size([2, 4, 7])
+        >>> out["vla_action"].chunk.shape
+        torch.Size([2, 4, 7])
     """
 
     @dataclass
@@ -103,30 +104,70 @@ class VLAWrapperBase(TensorDictModuleBase):
         """Configurable tensordict keys for a VLA policy."""
 
         image: NestedKey = IMAGE_KEY
-        state: NestedKey = STATE_KEY
+        wrist_image: NestedKey | None = ("observation", "wrist_image")
+        state: NestedKey | None = STATE_KEY
         instruction: NestedKey = INSTRUCTION_KEY
+        observation: NestedKey = "vla_observation"
+        action: NestedKey = ACTION_KEY
+        vla_action: NestedKey = "vla_action"
         action_chunk: NestedKey = ACTION_CHUNK_KEY
         action_tokens: NestedKey = ACTION_TOKENS_KEY
+        action_logits: NestedKey = "action_logits"
+        action_mask: NestedKey = "action_mask"
         log_probs: NestedKey = "log_probs"
 
     def __init__(
         self,
+        model=None,
         *,
+        processor=None,
+        input_mode: InputMode = "canonical",
+        output_mode: OutputMode | None = None,
         action_dim: int,
         chunk_size: int,
         action_head: ActionHead = "continuous",
         vocab_size: int | None = None,
+        action_tokenizer: ActionTokenizerBase | None = None,
+        action_kwargs: dict | None = None,
+        return_log_probs: bool | None = None,
+        return_logits: bool = False,
+        logits_only: bool = False,
         use_state: bool = True,
         default_interaction_type: InteractionType = InteractionType.DETERMINISTIC,
         log_probs_mode: LogProbsMode = "sequence",
         mode: SamplingMode | None = None,
+        image_key: NestedKey = IMAGE_KEY,
+        wrist_image_key: NestedKey | None = ("observation", "wrist_image"),
+        state_key: NestedKey | None = STATE_KEY,
+        instruction_key: NestedKey = INSTRUCTION_KEY,
+        observation_key: NestedKey = "vla_observation",
+        action_key: NestedKey = ACTION_KEY,
+        vla_action_key: NestedKey = "vla_action",
+        action_chunk_key: NestedKey = ACTION_CHUNK_KEY,
+        action_tokens_key: NestedKey = ACTION_TOKENS_KEY,
+        action_logits_key: NestedKey = "action_logits",
+        action_mask_key: NestedKey = "action_mask",
+        log_probs_key: NestedKey = "log_probs",
+        inplace: Literal[True, False, "empty"] | None = True,
+        device: torch.device | str | None = None,
+        num_samples: int | None = None,
     ) -> None:
         super().__init__()
         if action_head not in ("continuous", "tokens"):
             raise ValueError(
                 f"action_head must be 'continuous' or 'tokens', got {action_head!r}."
             )
-        if action_head == "tokens" and not vocab_size:
+        if input_mode not in ("canonical", "preprocessed"):
+            raise ValueError(
+                f"input_mode must be 'canonical' or 'preprocessed', got {input_mode!r}."
+            )
+        if output_mode is None:
+            output_mode = "chunk" if action_head == "continuous" else "tokens"
+        if output_mode not in ("chunk", "tokens", "both"):
+            raise ValueError(
+                f"output_mode must be 'chunk', 'tokens' or 'both', got {output_mode!r}."
+            )
+        if action_head == "tokens" and vocab_size is None:
             raise ValueError("vocab_size must be set for the 'tokens' action head.")
         if mode is not None:
             if mode == "sample":
@@ -144,14 +185,49 @@ class VLAWrapperBase(TensorDictModuleBase):
             raise ValueError(
                 f"log_probs_mode must be 'sequence' or 'token', got {log_probs_mode!r}."
             )
+        if inplace not in (True, False, "empty", None):
+            raise ValueError(
+                "inplace must be True, False, 'empty' or None, got " f"{inplace!r}."
+            )
+        if num_samples is not None and int(num_samples) < 1:
+            raise ValueError(f"num_samples must be >= 1, got {num_samples}.")
+        self.model = model
+        self.processor = processor
         self.action_dim = int(action_dim)
         self.chunk_size = int(chunk_size)
         self.action_head = action_head
-        self.vocab_size = vocab_size
+        self.input_mode = input_mode
+        self.output_mode = output_mode
+        self.vocab_size = None if vocab_size is None else int(vocab_size)
+        self.action_tokenizer = action_tokenizer
+        self.action_kwargs = {} if action_kwargs is None else dict(action_kwargs)
+        self.return_log_probs = (
+            action_head == "tokens"
+            if return_log_probs is None
+            else bool(return_log_probs)
+        )
+        self.return_logits = bool(return_logits)
+        self.logits_only = bool(logits_only)
         self.use_state = bool(use_state)
         self.default_interaction_type = default_interaction_type
         self.log_probs_mode = log_probs_mode
-        self._tensor_keys = self._AcceptedKeys()
+        self.inplace = True if inplace is None else inplace
+        self.device = None if device is None else torch.device(device)
+        self.num_samples = None if num_samples is None else int(num_samples)
+        self._tensor_keys = self._AcceptedKeys(
+            image=image_key,
+            wrist_image=wrist_image_key,
+            state=state_key,
+            instruction=instruction_key,
+            observation=observation_key,
+            action=action_key,
+            vla_action=vla_action_key,
+            action_chunk=action_chunk_key,
+            action_tokens=action_tokens_key,
+            action_logits=action_logits_key,
+            action_mask=action_mask_key,
+            log_probs=log_probs_key,
+        )
         self._update_keys()
 
     @property
@@ -159,99 +235,370 @@ class VLAWrapperBase(TensorDictModuleBase):
         return self._tensor_keys
 
     def set_keys(self, **kwargs) -> VLAWrapperBase:
-        """Set the tensordict key names used by the policy (see ``_AcceptedKeys``)."""
+        """Set the tensordict key names used by the policy."""
         for key, value in kwargs.items():
             if key not in self._AcceptedKeys.__dataclass_fields__:
                 raise ValueError(
                     f"{key!r} is not an accepted key. Accepted keys are "
                     f"{list(self._AcceptedKeys.__dataclass_fields__)}."
                 )
-            if value is not None:
-                setattr(self._tensor_keys, key, value)
+            setattr(self._tensor_keys, key, value)
         self._update_keys()
         return self
 
     def _update_keys(self) -> None:
-        in_keys = [self._tensor_keys.image]
-        if self.use_state:
-            in_keys.append(self._tensor_keys.state)
-        in_keys.append(self._tensor_keys.instruction)
-        self.in_keys = in_keys
-        if self.action_head == "continuous":
-            self.out_keys = [self._tensor_keys.action_chunk]
+        if self.input_mode == "canonical":
+            in_keys = [self._tensor_keys.image]
+            if self.use_state and self._tensor_keys.state is not None:
+                in_keys.append(self._tensor_keys.state)
+            in_keys.append(self._tensor_keys.instruction)
         else:
-            self.out_keys = [
-                self._tensor_keys.action_tokens,
-                self._tensor_keys.log_probs,
-            ]
+            in_keys = [self._tensor_keys.observation]
+        self.in_keys = in_keys
+        out_keys = [self._tensor_keys.vla_action]
+        if self.action_head == "tokens" and self.logits_only:
+            out_keys.append(self._tensor_keys.action_logits)
+            self.out_keys = out_keys
+            return
+        if self.output_mode in ("chunk", "both"):
+            out_keys.append(self._tensor_keys.action_chunk)
+        if self.output_mode in ("tokens", "both"):
+            out_keys.append(self._tensor_keys.action_tokens)
+        if self.action_head == "tokens" and self.return_log_probs:
+            out_keys.append(self._tensor_keys.log_probs)
+        if self.action_head == "tokens" and self.return_logits:
+            out_keys.append(self._tensor_keys.action_logits)
+        self.out_keys = out_keys
 
-    # -- hook implemented by concrete policies ---------------------------------
+    # -- input helpers -----------------------------------------------------
+    def _preprocessed_observation(self, tensordict: TensorDictBase):
+        obs = tensordict.get(self._tensor_keys.observation)
+        if isinstance(obs, VLAObservation) and obs.preprocessed is not None:
+            return obs.preprocessed
+        return obs
+
+    def _get_image(self, tensordict: TensorDictBase) -> torch.Tensor:
+        if self.input_mode == "canonical":
+            return tensordict.get(self._tensor_keys.image)
+        obs = self._preprocessed_observation(tensordict)
+        if isinstance(obs, VLAObservation):
+            if obs.images is None or obs.images.image is None:
+                raise KeyError("preprocessed VLAObservation has no primary image.")
+            return obs.images.image
+        if isinstance(obs, TensorDictBase):
+            value = obs.get(self._tensor_keys.image, None)
+            if value is None:
+                value = obs.get("image")
+            return value
+        raise TypeError(
+            "preprocessed input must be a VLAObservation or TensorDictBase, got "
+            f"{type(obs)}."
+        )
+
+    def _get_state(self, tensordict: TensorDictBase) -> torch.Tensor:
+        if self.input_mode == "canonical":
+            return tensordict.get(self._tensor_keys.state)
+        obs = self._preprocessed_observation(tensordict)
+        if isinstance(obs, VLAObservation):
+            return obs.state
+        if isinstance(obs, TensorDictBase):
+            value = None
+            if self._tensor_keys.state is not None:
+                value = obs.get(self._tensor_keys.state, None)
+            if value is None:
+                value = obs.get("state")
+            return value
+        raise TypeError(
+            "preprocessed input must be a VLAObservation or TensorDictBase, got "
+            f"{type(obs)}."
+        )
+
+    def _get_instruction(self, tensordict: TensorDictBase):
+        if self.input_mode == "canonical":
+            return tensordict.get(self._tensor_keys.instruction)
+        obs = self._preprocessed_observation(tensordict)
+        if isinstance(obs, VLAObservation):
+            return obs.instruction
+        if isinstance(obs, TensorDictBase):
+            value = obs.get(self._tensor_keys.instruction, None)
+            if value is None:
+                value = obs.get("instruction")
+            return value
+        raise TypeError(
+            "preprocessed input must be a VLAObservation or TensorDictBase, got "
+            f"{type(obs)}."
+        )
+
+    # -- hooks implemented by concrete policies ---------------------------
     def _predict(self, tensordict: TensorDictBase) -> torch.Tensor:
-        """Return the raw head output for a batch of observations.
-
-        Shape ``[*B, chunk_size * action_dim]`` for the continuous head, or
-        ``[*B, chunk_size * action_dim * vocab_size]`` for the token head; the
-        base reshapes it into an action chunk or per-token logits.
-        """
+        """Return flattened continuous chunks or token logits."""
         raise NotImplementedError
 
-    def _action_logits(self, tensordict: TensorDictBase) -> torch.Tensor:
+    def _predict_chunk(self, tensordict: TensorDictBase) -> torch.Tensor:
+        return self._predict(tensordict).unflatten(
+            -1, (self.chunk_size, self.action_dim)
+        )
+
+    def _predict_logits(self, tensordict: TensorDictBase) -> torch.Tensor:
         return self._predict(tensordict).unflatten(
             -1, (self.chunk_size, self.action_dim, self.vocab_size)
         )
 
-    # -- TensorDict API --------------------------------------------------------
-    def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
+    def _action_logits(self, tensordict: TensorDictBase) -> torch.Tensor:
+        return self._predict_logits(tensordict)
+
+    # -- output helpers ----------------------------------------------------
+    def _output_tensordict(
+        self, tensordict: TensorDictBase, out: TensorDictBase, tensordict_out=None
+    ) -> TensorDictBase:
+        if tensordict_out is None:
+            if self.inplace is True:
+                tensordict_out = tensordict
+            elif self.inplace is False:
+                tensordict_out = out
+            else:
+                tensordict_out = TensorDict(
+                    {}, batch_size=out.batch_size, device=out.device
+                )
+        if tensordict_out is not out:
+            vla_action_key = self._tensor_keys.vla_action
+            if out.get(vla_action_key, None) is not None:
+                tensordict_out.set(vla_action_key, out.get(vla_action_key))
+            vla_action_prefix = (
+                (vla_action_key,)
+                if isinstance(vla_action_key, str)
+                else tuple(vla_action_key)
+            )
+            for key in out.keys(True, True):
+                key_tuple = (key,) if isinstance(key, str) else tuple(key)
+                if key_tuple[: len(vla_action_prefix)] == vla_action_prefix:
+                    continue
+                tensordict_out.set(key, out.get(key))
+            return tensordict_out
+        return out
+
+    def _set_action(
+        self,
+        out: TensorDictBase,
+        *,
+        chunk: torch.Tensor | None = None,
+        tokens: torch.Tensor | None = None,
+        logits: torch.Tensor | None = None,
+        log_probs: torch.Tensor | None = None,
+        mask: torch.Tensor | None = None,
+    ) -> None:
+        if chunk is not None:
+            out.set(self._tensor_keys.action_chunk, chunk)
+        if tokens is not None:
+            out.set(self._tensor_keys.action_tokens, tokens)
+        if logits is not None:
+            out.set(self._tensor_keys.action_logits, logits)
+        if log_probs is not None:
+            out.set(self._tensor_keys.log_probs, log_probs)
+        if mask is not None:
+            out.set(self._tensor_keys.action_mask, mask)
+        action = VLAAction(
+            chunk=chunk,
+            tokens=tokens,
+            logits=logits,
+            log_probs=log_probs,
+            mask=mask,
+            batch_size=out.batch_size,
+            device=out.device,
+        )
+        out.set(self._tensor_keys.vla_action, action)
+
+    def _dist_from_logits(
+        self, logits: torch.Tensor, mask: torch.Tensor | None = None
+    ) -> torch_dist.Distribution:
+        if mask is not None:
+            logits = logits.masked_fill(~mask.to(torch.bool), -torch.inf)
+        dist = torch_dist.Categorical(logits=logits)
+        if self.log_probs_mode == "sequence":
+            return torch_dist.Independent(dist, 2)
+        return dist
+
+    def _sample_tokens(
+        self, dist: torch_dist.Distribution, logits: torch.Tensor
+    ) -> torch.Tensor:
+        interaction = interaction_type()
+        if interaction is None:
+            interaction = self.default_interaction_type
+        batch_ndim = logits.ndim - 3
+        greedy = logits.argmax(-1)
+        if self.num_samples is None:
+            return dist.sample() if interaction == InteractionType.RANDOM else greedy
+        if interaction == InteractionType.RANDOM:
+            tokens = dist.sample((self.num_samples,))
+            return tokens.movedim(0, batch_ndim)
+        return greedy.unsqueeze(batch_ndim).expand(
+            *greedy.shape[:batch_ndim],
+            self.num_samples,
+            *greedy.shape[batch_ndim:],
+        )
+
+    def _log_prob_tokens(
+        self, dist: torch_dist.Distribution, tokens: torch.Tensor, logits: torch.Tensor
+    ) -> torch.Tensor:
+        if self.num_samples is None or tokens.ndim == logits.ndim - 1:
+            return dist.log_prob(tokens)
+        batch_ndim = logits.ndim - 3
+        tokens_for_dist = tokens.movedim(batch_ndim, 0)
+        log_probs = dist.log_prob(tokens_for_dist)
+        return log_probs.movedim(0, batch_ndim)
+
+    # -- TensorDict API ----------------------------------------------------
+    def forward(
+        self,
+        tensordict: TensorDictBase,
+        *,
+        tensordict_out: TensorDictBase | None = None,
+        logits_only: bool = False,
+        **kwargs,
+    ) -> TensorDictBase:
         if self.action_head == "continuous":
-            chunk = self._predict(tensordict).unflatten(
-                -1, (self.chunk_size, self.action_dim)
+            chunk = self._predict_chunk(tensordict)
+            tokens = None
+            if self.output_mode in ("tokens", "both"):
+                if self.action_tokenizer is None:
+                    raise RuntimeError(
+                        "output_mode requires action tokens but no action_tokenizer "
+                        "was provided."
+                    )
+                tokens = self.action_tokenizer.encode(chunk)
+            out = TensorDict({}, batch_size=chunk.shape[:-2], device=chunk.device)
+            self._set_action(
+                out,
+                chunk=chunk if self.output_mode in ("chunk", "both") else None,
+                tokens=tokens,
             )
-            tensordict.set(self._tensor_keys.action_chunk, chunk)
-        else:
-            dist = self.get_dist(tensordict)
-            logits = (
-                dist.base_dist.logits
-                if isinstance(dist, torch_dist.Independent)
-                else dist.logits
-            )
-            # consult the ambient exploration context (set by the collector
-            # during rollout, or by set_exploration_type at eval); fall back
-            # to the policy's default when no context is active
-            interaction = interaction_type()
-            if interaction is None:
-                interaction = self.default_interaction_type
-            tokens = (
-                dist.sample()
-                if interaction == InteractionType.RANDOM
-                else logits.argmax(-1)
-            )
-            tensordict.set(self._tensor_keys.action_tokens, tokens)
-            tensordict.set(self._tensor_keys.log_probs, dist.log_prob(tokens))
-        return tensordict
+            return self._output_tensordict(tensordict, out, tensordict_out)
 
-    def get_dist(self, tensordict: TensorDictBase) -> torch_dist.Distribution:
-        """Return the action-token distribution.
+        logits = self._action_logits(tensordict)
+        mask = tensordict.get(self._tensor_keys.action_mask, None)
+        dist = self._dist_from_logits(logits, mask)
+        logits_only = self.logits_only or logits_only
+        if logits_only:
+            out = TensorDict({}, batch_size=logits.shape[:-3], device=logits.device)
+            self._set_action(out, logits=logits, mask=mask)
+            return self._output_tensordict(tensordict, out, tensordict_out)
 
-        Only defined for the ``"tokens"`` action head: a
-        :class:`~torch.distributions.Categorical` over the vocabulary. With
-        ``log_probs_mode="sequence"`` (default) it is wrapped in
-        :class:`~torch.distributions.Independent` over the
-        ``(chunk_size, action_dim)`` token dims, so ``log_prob`` returns one
-        *sequence-level* log-probability per sample. This is the contract
-        PPO-style objectives expect: token RL fine-tuning works directly with
-        :class:`~torchrl.objectives.ClipPPOLoss` (pass
-        ``critic_network=None``, ``entropy_bonus=False`` and remap the keys
-        via ``set_keys``). With ``log_probs_mode="token"``, the bare
-        per-token :class:`~torch.distributions.Categorical` is returned and
-        ``log_prob`` is per token, ``[*B, chunk_size, action_dim]`` -- one
-        importance ratio per token for DAPO-style objectives.
-        """
+        tokens = self._sample_tokens(dist, logits)
+        log_probs = self._log_prob_tokens(dist, tokens, logits)
+        chunk = None
+        if self.output_mode in ("chunk", "both"):
+            if self.action_tokenizer is None:
+                raise RuntimeError(
+                    "output_mode requires decoded chunks but no action_tokenizer "
+                    "was provided."
+                )
+            chunk = self.action_tokenizer.decode(tokens)
+        logits_out = logits if self.return_logits else None
+        mask_out = mask
+        if logits_out is not None and self.num_samples is not None:
+            batch_ndim = logits.ndim - 3
+            logits_out = logits.unsqueeze(batch_ndim).expand(
+                *logits.shape[:batch_ndim],
+                self.num_samples,
+                *logits.shape[batch_ndim:],
+            )
+        if mask_out is not None and self.num_samples is not None:
+            batch_ndim = logits.ndim - 3
+            mask_out = mask.unsqueeze(batch_ndim).expand(
+                *mask.shape[:batch_ndim],
+                self.num_samples,
+                *mask.shape[batch_ndim:],
+            )
+        out = TensorDict({}, batch_size=tokens.shape[:-2], device=tokens.device)
+        self._set_action(
+            out,
+            chunk=chunk,
+            tokens=tokens if self.output_mode in ("tokens", "both") else None,
+            logits=logits_out,
+            log_probs=log_probs if self.return_log_probs else None,
+            mask=mask_out,
+        )
+        return self._output_tensordict(tensordict, out, tensordict_out)
+
+    def get_dist(
+        self,
+        tensordict: TensorDictBase,
+        *,
+        tensordict_out: TensorDictBase | None = None,
+        logits_key: NestedKey | None = None,
+        mask_key: NestedKey | None = None,
+        **kwargs,
+    ) -> torch_dist.Distribution:
+        """Return the action-token distribution for loss-time recomputation."""
         if self.action_head != "tokens":
             raise RuntimeError(
                 "get_dist is only defined for the 'tokens' action head; the "
                 "'continuous' head is a deterministic regressor."
             )
-        dist = torch_dist.Categorical(logits=self._action_logits(tensordict))
-        if self.log_probs_mode == "sequence":
-            return torch_dist.Independent(dist, 2)
-        return dist
+        logits_key = (
+            self._tensor_keys.action_logits if logits_key is None else logits_key
+        )
+        mask_key = self._tensor_keys.action_mask if mask_key is None else mask_key
+        logits = None
+        if tensordict_out is not None:
+            logits = tensordict_out.get(logits_key, None)
+        if logits is None:
+            logits = tensordict.get(logits_key, None)
+        if logits is None:
+            logits = self._action_logits(tensordict)
+        mask = None
+        if mask_key is not None:
+            if tensordict_out is not None:
+                mask = tensordict_out.get(mask_key, None)
+            if mask is None:
+                mask = tensordict.get(mask_key, None)
+        return self._dist_from_logits(logits, mask)
+
+    def log_prob(
+        self,
+        tensordict: TensorDictBase,
+        *,
+        action_key: NestedKey | None = None,
+        log_probs_key: NestedKey | None = None,
+        **kwargs,
+    ) -> TensorDictBase:
+        """Recompute and write token log-probabilities for stored actions."""
+        if self.action_head != "tokens":
+            raise RuntimeError("log_prob is only defined for token VLA policies.")
+        action_key = (
+            self._tensor_keys.action_tokens if action_key is None else action_key
+        )
+        log_probs_key = (
+            self._tensor_keys.log_probs if log_probs_key is None else log_probs_key
+        )
+        tokens = tensordict.get(action_key)
+        logits = tensordict.get(self._tensor_keys.action_logits, None)
+        if logits is None:
+            logits = self._action_logits(tensordict)
+        mask = tensordict.get(self._tensor_keys.action_mask, None)
+        dist = self._dist_from_logits(logits, mask)
+        log_probs = self._log_prob_tokens(dist, tokens, logits)
+        tensordict.set(log_probs_key, log_probs)
+        action = tensordict.get(self._tensor_keys.vla_action, None)
+        if isinstance(action, VLAAction):
+            action.log_probs = log_probs
+        return tensordict
+
+    def get_new_version(self, **kwargs) -> VLAWrapperBase:
+        """Return a shallow wrapper copy with altered runtime parameters."""
+        new = copy.copy(self)
+        new._modules = self._modules.copy()
+        new._parameters = self._parameters.copy()
+        new._buffers = self._buffers.copy()
+        new._tensor_keys = copy.copy(self._tensor_keys)
+        for key, value in kwargs.items():
+            if key.endswith("_key"):
+                field = key[: -len("_key")]
+                if field in self._AcceptedKeys.__dataclass_fields__:
+                    setattr(new._tensor_keys, field, value)
+                    continue
+            if not hasattr(new, key):
+                raise TypeError(f"{type(self).__name__} has no parameter {key!r}.")
+            setattr(new, key, value)
+        new._update_keys()
+        return new

--- a/torchrl/modules/vla/common.py
+++ b/torchrl/modules/vla/common.py
@@ -24,6 +24,7 @@ from torchrl.data.vla.schema import (
     IMAGE_KEY,
     INSTRUCTION_KEY,
     STATE_KEY,
+    VLA_ACTION_KEY,
 )
 from torchrl.data.vla.tokenizers import ActionTokenizerBase
 
@@ -41,9 +42,9 @@ class VLAWrapperBase(TensorDictModuleBase):
 
     A VLA policy maps images, optional proprioceptive state, and a language
     instruction to either a continuous action chunk or discrete action tokens.
-    This base keeps the flat key contract used by existing TorchRL losses and
-    transforms while also mirroring outputs into a structured
-    :class:`~torchrl.data.vla.VLAAction` container under ``"vla_action"``.
+    Outputs are stored in a structured :class:`~torchrl.data.vla.VLAAction`
+    container under ``"vla_action"`` by default. Its fields are ordinary nested
+    TensorDict keys, e.g. ``("vla_action", "chunk")`` for continuous chunks.
 
     Keyword Args:
         action_dim (int): The dimensionality of a single action.
@@ -93,9 +94,9 @@ class VLAWrapperBase(TensorDictModuleBase):
         ...     batch_size=[2],
         ... )
         >>> out = policy(td)
-        >>> out["action_chunk"].shape
-        torch.Size([2, 4, 7])
         >>> out["vla_action"].chunk.shape
+        torch.Size([2, 4, 7])
+        >>> out["vla_action", "chunk"].shape
         torch.Size([2, 4, 7])
     """
 
@@ -109,12 +110,12 @@ class VLAWrapperBase(TensorDictModuleBase):
         instruction: NestedKey = INSTRUCTION_KEY
         observation: NestedKey = "vla_observation"
         action: NestedKey = ACTION_KEY
-        vla_action: NestedKey = "vla_action"
+        vla_action: NestedKey = VLA_ACTION_KEY
         action_chunk: NestedKey = ACTION_CHUNK_KEY
         action_tokens: NestedKey = ACTION_TOKENS_KEY
-        action_logits: NestedKey = "action_logits"
-        action_mask: NestedKey = "action_mask"
-        log_probs: NestedKey = "log_probs"
+        action_logits: NestedKey = (VLA_ACTION_KEY, "logits")
+        action_mask: NestedKey = (VLA_ACTION_KEY, "mask")
+        log_probs: NestedKey = (VLA_ACTION_KEY, "log_probs")
 
     def __init__(
         self,
@@ -142,12 +143,12 @@ class VLAWrapperBase(TensorDictModuleBase):
         instruction_key: NestedKey = INSTRUCTION_KEY,
         observation_key: NestedKey = "vla_observation",
         action_key: NestedKey = ACTION_KEY,
-        vla_action_key: NestedKey = "vla_action",
-        action_chunk_key: NestedKey = ACTION_CHUNK_KEY,
-        action_tokens_key: NestedKey = ACTION_TOKENS_KEY,
-        action_logits_key: NestedKey = "action_logits",
-        action_mask_key: NestedKey = "action_mask",
-        log_probs_key: NestedKey = "log_probs",
+        vla_action_key: NestedKey = VLA_ACTION_KEY,
+        action_chunk_key: NestedKey | None = None,
+        action_tokens_key: NestedKey | None = None,
+        action_logits_key: NestedKey | None = None,
+        action_mask_key: NestedKey | None = None,
+        log_probs_key: NestedKey | None = None,
         inplace: Literal[True, False, "empty"] | None = True,
         device: torch.device | str | None = None,
         num_samples: int | None = None,
@@ -214,6 +215,16 @@ class VLAWrapperBase(TensorDictModuleBase):
         self.inplace = True if inplace is None else inplace
         self.device = None if device is None else torch.device(device)
         self.num_samples = None if num_samples is None else int(num_samples)
+        if action_chunk_key is None:
+            action_chunk_key = self._vla_field_key(vla_action_key, "chunk")
+        if action_tokens_key is None:
+            action_tokens_key = self._vla_field_key(vla_action_key, "tokens")
+        if action_logits_key is None:
+            action_logits_key = self._vla_field_key(vla_action_key, "logits")
+        if action_mask_key is None:
+            action_mask_key = self._vla_field_key(vla_action_key, "mask")
+        if log_probs_key is None:
+            log_probs_key = self._vla_field_key(vla_action_key, "log_probs")
         self._tensor_keys = self._AcceptedKeys(
             image=image_key,
             wrist_image=wrist_image_key,
@@ -234,8 +245,29 @@ class VLAWrapperBase(TensorDictModuleBase):
     def tensor_keys(self) -> _AcceptedKeys:
         return self._tensor_keys
 
+    @staticmethod
+    def _vla_field_key(vla_action_key: NestedKey, field: str) -> NestedKey:
+        if isinstance(vla_action_key, str):
+            return (vla_action_key, field)
+        return (*vla_action_key, field)
+
+    def _is_vla_field_key(self, key: NestedKey, field: str) -> bool:
+        return key == self._vla_field_key(self._tensor_keys.vla_action, field)
+
     def set_keys(self, **kwargs) -> VLAWrapperBase:
         """Set the tensordict key names used by the policy."""
+        old_vla_action_key = self._tensor_keys.vla_action
+        vla_field_keys = (
+            ("action_chunk", "chunk"),
+            ("action_tokens", "tokens"),
+            ("action_logits", "logits"),
+            ("action_mask", "mask"),
+            ("log_probs", "log_probs"),
+        )
+        old_default_field_keys = {
+            key: self._vla_field_key(old_vla_action_key, field)
+            for key, field in vla_field_keys
+        }
         for key, value in kwargs.items():
             if key not in self._AcceptedKeys.__dataclass_fields__:
                 raise ValueError(
@@ -243,6 +275,16 @@ class VLAWrapperBase(TensorDictModuleBase):
                     f"{list(self._AcceptedKeys.__dataclass_fields__)}."
                 )
             setattr(self._tensor_keys, key, value)
+        if "vla_action" in kwargs:
+            for key, field in vla_field_keys:
+                if key not in kwargs and (
+                    getattr(self._tensor_keys, key) == old_default_field_keys[key]
+                ):
+                    setattr(
+                        self._tensor_keys,
+                        key,
+                        self._vla_field_key(self._tensor_keys.vla_action, field),
+                    )
         self._update_keys()
         return self
 
@@ -255,7 +297,7 @@ class VLAWrapperBase(TensorDictModuleBase):
         else:
             in_keys = [self._tensor_keys.observation]
         self.in_keys = in_keys
-        out_keys = [self._tensor_keys.vla_action]
+        out_keys = []
         if self.action_head == "tokens" and self.logits_only:
             out_keys.append(self._tensor_keys.action_logits)
             self.out_keys = out_keys
@@ -387,16 +429,6 @@ class VLAWrapperBase(TensorDictModuleBase):
         log_probs: torch.Tensor | None = None,
         mask: torch.Tensor | None = None,
     ) -> None:
-        if chunk is not None:
-            out.set(self._tensor_keys.action_chunk, chunk)
-        if tokens is not None:
-            out.set(self._tensor_keys.action_tokens, tokens)
-        if logits is not None:
-            out.set(self._tensor_keys.action_logits, logits)
-        if log_probs is not None:
-            out.set(self._tensor_keys.log_probs, log_probs)
-        if mask is not None:
-            out.set(self._tensor_keys.action_mask, mask)
         action = VLAAction(
             chunk=chunk,
             tokens=tokens,
@@ -407,6 +439,26 @@ class VLAWrapperBase(TensorDictModuleBase):
             device=out.device,
         )
         out.set(self._tensor_keys.vla_action, action)
+        if chunk is not None and not self._is_vla_field_key(
+            self._tensor_keys.action_chunk, "chunk"
+        ):
+            out.set(self._tensor_keys.action_chunk, chunk)
+        if tokens is not None and not self._is_vla_field_key(
+            self._tensor_keys.action_tokens, "tokens"
+        ):
+            out.set(self._tensor_keys.action_tokens, tokens)
+        if logits is not None and not self._is_vla_field_key(
+            self._tensor_keys.action_logits, "logits"
+        ):
+            out.set(self._tensor_keys.action_logits, logits)
+        if log_probs is not None and not self._is_vla_field_key(
+            self._tensor_keys.log_probs, "log_probs"
+        ):
+            out.set(self._tensor_keys.log_probs, log_probs)
+        if mask is not None and not self._is_vla_field_key(
+            self._tensor_keys.action_mask, "mask"
+        ):
+            out.set(self._tensor_keys.action_mask, mask)
 
     def _dist_from_logits(
         self, logits: torch.Tensor, mask: torch.Tensor | None = None

--- a/torchrl/modules/vla/models.py
+++ b/torchrl/modules/vla/models.py
@@ -13,11 +13,14 @@ from tensordict.nn import InteractionType
 from torch import nn
 
 from torchrl.data.utils import DEVICE_TYPING
+from torchrl.data.vla import ActionTokenizerBase
 from torchrl.modules.models.models import ConvNet, MLP
 
 from torchrl.modules.vla.common import (
     ActionHead,
+    InputMode,
     LogProbsMode,
+    OutputMode,
     SamplingMode,
     VLAWrapperBase,
 )
@@ -100,6 +103,14 @@ class TinyVLA(VLAWrapperBase):
         log_probs_mode: LogProbsMode = "sequence",
         mode: SamplingMode | None = None,
         device: DEVICE_TYPING | None = None,
+        input_mode: InputMode = "canonical",
+        output_mode: OutputMode | None = None,
+        action_tokenizer: ActionTokenizerBase | None = None,
+        return_log_probs: bool | None = None,
+        return_logits: bool = False,
+        logits_only: bool = False,
+        inplace: bool | str | None = True,
+        num_samples: int | None = None,
     ) -> None:
         super().__init__(
             action_dim=action_dim,
@@ -107,9 +118,18 @@ class TinyVLA(VLAWrapperBase):
             action_head=action_head,
             vocab_size=vocab_size,
             use_state=use_state,
+            input_mode=input_mode,
+            output_mode=output_mode,
+            action_tokenizer=action_tokenizer,
             default_interaction_type=default_interaction_type,
             log_probs_mode=log_probs_mode,
+            return_log_probs=return_log_probs,
+            return_logits=return_logits,
+            logits_only=logits_only,
+            inplace=inplace,
+            num_samples=num_samples,
             mode=mode,
+            device=device,
         )
         self.hidden_dim = int(hidden_dim)
         self.text_vocab = int(text_vocab)
@@ -138,7 +158,7 @@ class TinyVLA(VLAWrapperBase):
         return torch.tensor(indices, dtype=torch.long, device=device)
 
     def _instruction_strings(self, tensordict: TensorDictBase, batch: int) -> list[str]:
-        instruction = tensordict.get(self.tensor_keys.instruction)
+        instruction = self._get_instruction(tensordict)
         data = getattr(instruction, "tolist", lambda: instruction)()
         if isinstance(data, str):
             data = [data] * batch
@@ -147,7 +167,7 @@ class TinyVLA(VLAWrapperBase):
         return data
 
     def _features(self, tensordict: TensorDictBase) -> torch.Tensor:
-        image = tensordict.get(self.tensor_keys.image)
+        image = self._get_image(tensordict)
         if image.dtype == torch.uint8:
             image = image.float() / 255.0
         else:
@@ -155,9 +175,7 @@ class TinyVLA(VLAWrapperBase):
         batch = image.shape[0]
         feats = [self.image_encoder(image)]
         if self.use_state:
-            feats.append(
-                self.state_encoder(tensordict.get(self.tensor_keys.state).float())
-            )
+            feats.append(self.state_encoder(self._get_state(tensordict).float()))
         strings = self._instruction_strings(tensordict, batch)
         feats.append(self.text_embedding(self._hash_text(strings, image.device)))
         return self.trunk(torch.cat(feats, dim=-1))

--- a/torchrl/modules/vla/models.py
+++ b/torchrl/modules/vla/models.py
@@ -84,7 +84,7 @@ class TinyVLA(VLAWrapperBase):
         ...     },
         ...     batch_size=[2],
         ... )
-        >>> policy(td)["action_chunk"].shape
+        >>> policy(td)["vla_action", "chunk"].shape
         torch.Size([2, 4, 7])
     """
 

--- a/torchrl/modules/vla/wrappers.py
+++ b/torchrl/modules/vla/wrappers.py
@@ -31,7 +31,8 @@ class LeRobotPolicyWrapper(VLAWrapperBase):
     TorchRL stack. On :meth:`forward` it builds a LeRobot-style batch dict from
     the canonical observation keys (``observation.state``,
     ``observation.images.<camera>``, ``task``), calls the wrapped policy, and
-    writes the returned continuous action chunk under ``action_chunk``.
+    writes the returned continuous action chunk under
+    ``("vla_action", "chunk")``.
 
     The wrapped object can be any callable / module that maps a LeRobot batch
     dict to an action chunk of shape ``[B, chunk_size, action_dim]``; by default
@@ -60,8 +61,8 @@ class LeRobotPolicyWrapper(VLAWrapperBase):
         integration are tested with a stand-in policy.
 
     .. note::
-        Only the continuous (``action_chunk``) head is supported -- external
-        policies emit continuous chunks, not TorchRL action-token logits.
+        Only the continuous chunk head is supported -- external policies emit
+        continuous chunks, not TorchRL action-token logits.
 
     Examples:
         >>> import torch
@@ -82,7 +83,7 @@ class LeRobotPolicyWrapper(VLAWrapperBase):
         ...     },
         ...     batch_size=[2],
         ... )
-        >>> policy(td)["action_chunk"].shape
+        >>> policy(td)["vla_action", "chunk"].shape
         torch.Size([2, 4, 7])
     """
 

--- a/torchrl/modules/vla/wrappers.py
+++ b/torchrl/modules/vla/wrappers.py
@@ -14,7 +14,7 @@ from tensordict import TensorDictBase
 from tensordict.utils import NestedKey
 
 from torchrl.data.vla.schema import IMAGE_KEY, INSTRUCTION_KEY, STATE_KEY
-from torchrl.modules.vla.common import VLAWrapperBase
+from torchrl.modules.vla.common import InputMode, OutputMode, VLAWrapperBase
 
 _has_lerobot = importlib.util.find_spec("lerobot") is not None
 
@@ -98,12 +98,18 @@ class LeRobotPolicyWrapper(VLAWrapperBase):
         image_key: NestedKey = IMAGE_KEY,
         state_key: NestedKey = STATE_KEY,
         instruction_key: NestedKey = INSTRUCTION_KEY,
+        input_mode: InputMode = "canonical",
+        output_mode: OutputMode | None = None,
+        inplace: bool | str | None = True,
     ) -> None:
         super().__init__(
             action_dim=action_dim,
             chunk_size=chunk_size,
             action_head="continuous",
             use_state=use_state,
+            input_mode=input_mode,
+            output_mode=output_mode,
+            inplace=inplace,
         )
         self.set_keys(image=image_key, state=state_key, instruction=instruction_key)
         self.policy = policy
@@ -111,14 +117,10 @@ class LeRobotPolicyWrapper(VLAWrapperBase):
         self.camera_name = camera_name
 
     def _to_lerobot_batch(self, tensordict: TensorDictBase) -> dict:
-        batch = {
-            f"observation.images.{self.camera_name}": tensordict.get(
-                self.tensor_keys.image
-            )
-        }
+        batch = {f"observation.images.{self.camera_name}": self._get_image(tensordict)}
         if self.use_state:
-            batch["observation.state"] = tensordict.get(self.tensor_keys.state)
-        instruction = tensordict.get(self.tensor_keys.instruction)
+            batch["observation.state"] = self._get_state(tensordict)
+        instruction = self._get_instruction(tensordict)
         batch["task"] = getattr(instruction, "tolist", lambda: instruction)()
         return batch
 

--- a/torchrl/objectives/act.py
+++ b/torchrl/objectives/act.py
@@ -62,7 +62,6 @@ class ACTLoss(LossModule):
         >>> import torch
         >>> from tensordict import TensorDict
         >>> from tensordict.nn import TensorDictModule
-        >>> from torchrl.data.vla import ACTION_CHUNK_KEY
         >>> from torchrl.modules.models import ACTModel
         >>> from torchrl.objectives import ACTLoss
         >>> model = ACTModel(obs_dim=14, action_dim=7, chunk_size=10)
@@ -75,7 +74,7 @@ class ACTLoss(LossModule):
         >>> td = TensorDict(
         ...     {
         ...         "observation": torch.randn(4, 14),
-        ...         ACTION_CHUNK_KEY: torch.randn(4, 10, 7),
+        ...         ("vla_action", "chunk"): torch.randn(4, 10, 7),
         ...     },
         ...     batch_size=[4],
         ... )

--- a/torchrl/objectives/act.py
+++ b/torchrl/objectives/act.py
@@ -12,6 +12,7 @@ from tensordict import TensorDict, TensorDictBase, TensorDictParams
 from tensordict.nn import TensorDictModule
 from tensordict.utils import NestedKey
 
+from torchrl.data.vla import ACTION_CHUNK_KEY
 from torchrl.objectives.common import LossModule
 
 
@@ -32,10 +33,12 @@ class ACTLoss(LossModule):
         \underbrace{D_{\mathrm{KL}}\!\left(q(z|o,a)\,\|\,
         \mathcal{N}(0,I)\right)}_{\text{KL}}
 
-    The ``actor_network`` must read ``"observation"`` and ``"action_chunk"``
-    and write ``"action_pred"``, ``"mu"``, and ``"log_var"``.  This matches
-    the contract of :class:`~torchrl.modules.models.ACTModel` when wrapped
-    with a :class:`~tensordict.nn.TensorDictModule`.
+    The input tensordict stores expert chunks under
+    ``("vla_action", "chunk")`` by default. The ``actor_network`` itself must
+    read ``"observation"`` and ``"action_chunk"`` and write
+    ``"action_pred"``, ``"mu"``, and ``"log_var"``. This matches the contract
+    of :class:`~torchrl.modules.models.ACTModel` when wrapped with a
+    :class:`~tensordict.nn.TensorDictModule`.
 
     Three values are returned in the output TensorDict:
 
@@ -45,9 +48,9 @@ class ACTLoss(LossModule):
     * ``"loss_kl"`` — detached KL term (for logging).
 
     Args:
-        actor_network (TensorDictModule): ACT policy.  Must expose
-            ``in_keys`` containing ``"observation"`` and ``"action_chunk"``
-            and write ``"action_pred"``, ``"mu"``, ``"log_var"``.
+        actor_network (TensorDictModule): ACT policy. Must expose ``in_keys``
+            containing ``"observation"`` and ``"action_chunk"`` and write
+            ``"action_pred"``, ``"mu"``, ``"log_var"``.
 
     Keyword Args:
         kl_weight (float, optional): β — weight on the KL divergence term.
@@ -59,6 +62,7 @@ class ACTLoss(LossModule):
         >>> import torch
         >>> from tensordict import TensorDict
         >>> from tensordict.nn import TensorDictModule
+        >>> from torchrl.data.vla import ACTION_CHUNK_KEY
         >>> from torchrl.modules.models import ACTModel
         >>> from torchrl.objectives import ACTLoss
         >>> model = ACTModel(obs_dim=14, action_dim=7, chunk_size=10)
@@ -71,7 +75,7 @@ class ACTLoss(LossModule):
         >>> td = TensorDict(
         ...     {
         ...         "observation": torch.randn(4, 14),
-        ...         "action_chunk": torch.randn(4, 10, 7),
+        ...         ACTION_CHUNK_KEY: torch.randn(4, 10, 7),
         ...     },
         ...     batch_size=[4],
         ... )
@@ -86,7 +90,8 @@ class ACTLoss(LossModule):
         Attributes:
             observation (NestedKey): Observation key. Default ``"observation"``.
             action_chunk (NestedKey): Expert action chunk
-                ``(..., T, action_dim)``. Default ``"action_chunk"``.
+                ``(..., T, action_dim)``. Default
+                ``("vla_action", "chunk")``.
             action_pred (NestedKey): Predicted chunk written by the policy.
                 Default ``"action_pred"``.
             mu (NestedKey): CVAE encoder mean. Default ``"mu"``.
@@ -95,7 +100,7 @@ class ACTLoss(LossModule):
         """
 
         observation: NestedKey = "observation"
-        action_chunk: NestedKey = "action_chunk"
+        action_chunk: NestedKey = ACTION_CHUNK_KEY
         action_pred: NestedKey = "action_pred"
         mu: NestedKey = "mu"
         log_var: NestedKey = "log_var"
@@ -151,7 +156,7 @@ class ACTLoss(LossModule):
 
         Args:
             tensordict (TensorDictBase): Input data containing
-                ``"observation"`` and ``"action_chunk"``.
+                ``"observation"`` and ``("vla_action", "chunk")`` by default.
 
         Returns:
             TensorDict with keys ``"loss_act"``, ``"loss_reconstruction"``,

--- a/torchrl/objectives/bc.py
+++ b/torchrl/objectives/bc.py
@@ -101,13 +101,13 @@ class BCLoss(LossModule):
         >>> chunk_actor = TensorDictModule(
         ...     nn.Sequential(nn.Linear(n_obs, 8), nn.Unflatten(-1, (2, 4))),
         ...     in_keys=["observation"],
-        ...     out_keys=["action_chunk"],
+        ...     out_keys=[("vla_action", "chunk")],
         ... )
         >>> loss = BCLoss(chunk_actor, loss_function="l1")
-        >>> loss.set_keys(action="action_chunk", pad_mask="action_is_pad")
+        >>> loss.set_keys(action=("vla_action", "chunk"), pad_mask="action_is_pad")
         >>> data = TensorDict({
         ...     "observation": torch.randn(2, n_obs),
-        ...     "action_chunk": torch.randn(2, 2, 4),
+        ...     "vla_action": {"chunk": torch.randn(2, 2, 4)},
         ...     "action_is_pad": torch.tensor([[False, False], [False, True]]),
         ... }, [2])
         >>> loss(data)["loss_bc"].shape

--- a/torchrl/trainers/algorithms/configs/transforms.py
+++ b/torchrl/trainers/algorithms/configs/transforms.py
@@ -743,8 +743,8 @@ class MultiActionConfig(TransformConfig):
     dim: int = 1
     stack_rewards: bool = True
     stack_observations: bool = False
-    action_key: str | None = None
-    chunk_key: str | None = None
+    action_key: Any | None = None
+    chunk_key: Any | None = None
     _target_: str = "torchrl.envs.transforms.transforms.MultiAction"
 
     def __post_init__(self) -> None:

--- a/torchrl/trainers/algorithms/configs/transforms.py
+++ b/torchrl/trainers/algorithms/configs/transforms.py
@@ -743,6 +743,8 @@ class MultiActionConfig(TransformConfig):
     dim: int = 1
     stack_rewards: bool = True
     stack_observations: bool = False
+    action_key: str | None = None
+    chunk_key: str | None = None
     _target_: str = "torchrl.envs.transforms.transforms.MultiAction"
 
     def __post_init__(self) -> None:

--- a/tutorials/sphinx-tutorials/vla.py
+++ b/tutorials/sphinx-tutorials/vla.py
@@ -160,6 +160,7 @@ def make_observation(batch=batch):
 
 
 obs = make_observation()
+obs
 
 ##############################################################################
 # Action chunking and normalization
@@ -261,6 +262,7 @@ expert = (
     data["observation", "state"] @ torch.randn(state_dim, H * action_dim)
 ).reshape(batch, H, action_dim)
 data["vla_action", "chunk"] = expert
+data["action_is_pad"] = torch.zeros(batch, H, dtype=torch.bool)
 
 bc_loss = BCLoss(policy, loss_function="l1")
 bc_loss.set_keys(action=("vla_action", "chunk"), pad_mask="action_is_pad")
@@ -320,44 +322,30 @@ base_env.action_spec
 ##############################################################################
 # The wrapper auto-discovers the policy's ``("vla_action", "chunk")`` output
 # and serves the base env's ``"action"`` key from it. ``InitTracker`` provides
-# the ``is_init`` flag the wrapper uses to re-plan on resets. We also count the
-# policy calls to see the receding horizon at work.
+# the ``is_init`` flag the wrapper uses to re-plan on resets.
 
-from tensordict.nn import WrapModule
 from torchrl.envs.transforms import InitTracker, TransformedEnv
 from torchrl.modules import MultiStepActorWrapper
 
-policy_calls = []
-
-
-def counted_policy(td):
-    policy_calls.append(1)
-    return policy(td)
-
-
-actor = MultiStepActorWrapper(
-    WrapModule(counted_policy, in_keys=policy.in_keys, out_keys=policy.out_keys),
-    n_steps=H,
-    replan_interval=2,
-)
+actor = MultiStepActorWrapper(policy, n_steps=H, replan_interval=2)
 env = TransformedEnv(base_env, InitTracker())
 
 ##############################################################################
 # A plain :meth:`~torchrl.envs.EnvBase.rollout` runs the interaction loop. The
-# executed per-step actions are recorded under ``action``; the policy itself
-# only ran on the re-plan steps (0, 2 and 4 -- three calls for six steps,
-# instead of six).
+# executed per-step actions are recorded under ``action``. The wrapper counter
+# shows the receding-horizon cadence: with ``replan_interval=2`` it serves two
+# actions from the cache, then re-plans.
 
 eval_rollout = env.rollout(6, actor)
 eval_rollout["action"].shape  # [2, 6, action_dim]: the executed actions
 
 ##############################################################################
-# The call count proves the skipping, and the env's state echo confirms the
-# executed cadence matches what the wrapper served from its cache:
-
-len(policy_calls)  # 3: the wrapped policy ran every replan_interval=2 steps
+eval_rollout["counter"][0, :, 0]  # tensor([1, 2, 1, 2, 1, 2])
 
 ##############################################################################
+# The env's state echo confirms that the executed cadence matches what the
+# wrapper served from its cache:
+
 executed = eval_rollout["next", "observation", "state"][..., :action_dim]
 torch.allclose(executed, eval_rollout["action"])  # True: echo of what env got
 
@@ -390,7 +378,7 @@ token_policy = TinyVLA(
 # evaluation uses ``set_exploration_type(ExplorationType.DETERMINISTIC)``. We
 # sample here to mimic a behavior-policy rollout -- no policy mutation needed.
 with set_exploration_type(ExplorationType.RANDOM):
-    rollout = token_policy(make_observation())  # writes tokens + log_probs
+    rollout = token_policy(make_observation())  # writes nested tokens + log-probs
 # one advantage per sample, with the trailing singleton value-dim the PPO
 # losses expect (a flat [batch] advantage would silently broadcast wrong)
 rollout["advantage"] = torch.randn(batch, 1)

--- a/tutorials/sphinx-tutorials/vla.py
+++ b/tutorials/sphinx-tutorials/vla.py
@@ -126,8 +126,10 @@ warnings.filterwarnings("ignore")
 
 import torch
 from tensordict import NonTensorStack, TensorDict
+from torchrl.data.vla import ACTION_CHUNK_KEY, ACTION_TOKENS_KEY
 
 torch.manual_seed(0)
+LOG_PROBS_KEY = ("vla_action", "log_probs")
 
 ##############################################################################
 # The canonical VLA schema
@@ -167,9 +169,10 @@ obs = make_observation()
 #
 # :class:`~torchrl.envs.transforms.ActionChunkTransform` turns a per-step action
 # tensor ``[*B, T, action_dim]`` into the chunked training target
-# ``action_chunk`` ``[*B, T, H, action_dim]`` (plus an ``action_is_pad`` mask):
-# for every step ``t`` it gathers the next ``H`` actions. This is the training
-# target of modern chunked VLA policies (ACT, OpenVLA-OFT, pi0).
+# ``("vla_action", "chunk")`` ``[*B, T, H, action_dim]`` (plus an
+# ``action_is_pad`` mask): for every step ``t`` it gathers the next ``H``
+# actions. This is the training target of modern chunked VLA policies (ACT,
+# OpenVLA-OFT, pi0).
 #
 # Chunks mean different things on the two sides of the pipeline, and keeping
 # the two pictures apart avoids a classic confusion::
@@ -210,7 +213,7 @@ from torchrl.envs.transforms import ActionChunkTransform, ActionScaling
 T, H = 6, 4
 window = TensorDict({"action": torch.randn(2, T, action_dim)}, batch_size=[2, T])
 chunked = ActionChunkTransform(chunk_size=H)(window)
-chunked["action_chunk"].shape  # [2, T, H, action_dim]
+chunked[ACTION_CHUNK_KEY].shape  # [2, T, H, action_dim]
 
 ##############################################################################
 # :class:`~torchrl.envs.transforms.ActionScaling` handles action normalization.
@@ -240,7 +243,7 @@ normalized["action"]  # all ones
 from torchrl.modules.vla import TinyVLA
 
 policy = TinyVLA(action_dim=action_dim, chunk_size=H, hidden_dim=64)
-policy(make_observation())["action_chunk"].shape  # [batch, H, action_dim]
+policy(make_observation())[ACTION_CHUNK_KEY].shape  # [batch, H, action_dim]
 
 ##############################################################################
 # Behavior cloning
@@ -259,10 +262,10 @@ data = make_observation()
 expert = (
     data["observation", "state"] @ torch.randn(state_dim, H * action_dim)
 ).reshape(batch, H, action_dim)
-data["action_chunk"] = expert
+data[ACTION_CHUNK_KEY] = expert
 
 bc_loss = BCLoss(policy, loss_function="l1")
-bc_loss.set_keys(action="action_chunk", pad_mask="action_is_pad")
+bc_loss.set_keys(action=ACTION_CHUNK_KEY, pad_mask="action_is_pad")
 initial = bc_loss(data)["loss_bc"].item()
 optimizer = torch.optim.Adam(bc_loss.parameters(), lr=1e-2)
 for _ in range(100):
@@ -317,13 +320,12 @@ base_env.observation_spec
 base_env.action_spec
 
 ##############################################################################
-# The wrapper expects its actor to write the *env action key* with a leading
-# time dimension, so we append a one-line rename of the policy's
-# ``action_chunk``; ``InitTracker`` provides the ``is_init`` flag the wrapper
-# uses to re-plan on resets. We also count the policy calls to see the
-# receding horizon at work.
+# The wrapper auto-discovers the policy's ``("vla_action", "chunk")`` output
+# and serves the base env's ``"action"`` key from it. ``InitTracker`` provides
+# the ``is_init`` flag the wrapper uses to re-plan on resets. We also count the
+# policy calls to see the receding horizon at work.
 
-from tensordict.nn import TensorDictModule, TensorDictSequential, WrapModule
+from tensordict.nn import WrapModule
 from torchrl.envs.transforms import InitTracker, TransformedEnv
 from torchrl.modules import MultiStepActorWrapper
 
@@ -335,11 +337,8 @@ def counted_policy(td):
     return policy(td)
 
 
-chunk_as_action = TensorDictModule(
-    lambda chunk: chunk, in_keys=["action_chunk"], out_keys=["action"]
-)
 actor = MultiStepActorWrapper(
-    TensorDictSequential(WrapModule(counted_policy), chunk_as_action),
+    WrapModule(counted_policy, in_keys=policy.in_keys, out_keys=policy.out_keys),
     n_steps=H,
     replan_interval=2,
 )
@@ -393,17 +392,17 @@ token_policy = TinyVLA(
 # evaluation uses ``set_exploration_type(ExplorationType.DETERMINISTIC)``. We
 # sample here to mimic a behavior-policy rollout -- no policy mutation needed.
 with set_exploration_type(ExplorationType.RANDOM):
-    rollout = token_policy(make_observation())  # writes action_tokens + log_probs
+    rollout = token_policy(make_observation())  # writes tokens + log_probs
 # one advantage per sample, with the trailing singleton value-dim the PPO
 # losses expect (a flat [batch] advantage would silently broadcast wrong)
 rollout["advantage"] = torch.randn(batch, 1)
-rollout["log_probs"] = rollout["log_probs"].detach()  # behavior log-probs are fixed
+rollout[LOG_PROBS_KEY] = rollout[LOG_PROBS_KEY].detach()
 
 grpo_loss = ClipPPOLoss(
     token_policy, critic_network=None, entropy_bonus=False, clip_epsilon=0.2
 )
 grpo_loss.set_keys(
-    action="action_tokens", sample_log_prob="log_probs", advantage="advantage"
+    action=ACTION_TOKENS_KEY, sample_log_prob=LOG_PROBS_KEY, advantage="advantage"
 )
 grpo_optimizer = torch.optim.Adam(grpo_loss.parameters(), lr=1e-3)
 grpo_optimizer.zero_grad()

--- a/tutorials/sphinx-tutorials/vla.py
+++ b/tutorials/sphinx-tutorials/vla.py
@@ -48,15 +48,24 @@ warnings.filterwarnings("ignore")
 # ------------------
 #
 # Structurally, a VLA is a vision-language model (VLM) with an *action head*.
-# The backbone -- a pretrained multimodal transformer such as PaliGemma (pi0),
-# SmolVLM (SmolVLA) or Llama/SigLIP stacks (OpenVLA) -- encodes the camera
-# images and the instruction; a comparatively small head turns that
-# representation into robot actions. Two head families dominate:
+# The backbone -- a pretrained multimodal transformer such as
+# `PaliGemma <https://huggingface.co/google/paligemma-3b-pt-224>`__ (used by
+# `pi0 <https://github.com/Physical-Intelligence/openpi>`__),
+# `SmolVLM <https://huggingface.co/HuggingFaceTB/SmolVLM-Instruct>`__ (used by
+# `SmolVLA <https://huggingface.co/lerobot/smolvla_base>`__) or the
+# `OpenVLA <https://github.com/openvla/openvla>`__ Llama/SigLIP stack --
+# encodes the camera images and the instruction; a comparatively small head
+# turns that representation into robot actions. Two head families dominate:
 #
-# - **token heads** (RT-2, OpenVLA): actions are discretized into tokens and
-#   emitted through the language-model head, autoregressively -- which is what
-#   makes LLM-style RL objectives applicable to robotics;
-# - **continuous chunk heads** (ACT, OpenVLA-OFT, pi0, SmolVLA): a regression,
+# - **token heads** (`RT-2 <https://robotics-transformer2.github.io/>`__,
+#   `OpenVLA <https://huggingface.co/openvla/openvla-7b>`__): actions are
+#   discretized into tokens and emitted through the language-model head,
+#   autoregressively -- which is what makes LLM-style RL objectives applicable
+#   to robotics;
+# - **continuous chunk heads** (`ACT <https://github.com/tonyzhaozh/act>`__,
+#   `OpenVLA-OFT <https://github.com/moojink/openvla-oft>`__,
+#   `pi0 <https://huggingface.co/lerobot/pi0_base>`__,
+#   `SmolVLA <https://huggingface.co/lerobot/smolvla_base>`__): a regression,
 #   diffusion or flow-matching head predicts a short horizon of ``H`` future
 #   actions (an *action chunk*) in one forward pass.
 #

--- a/tutorials/sphinx-tutorials/vla.py
+++ b/tutorials/sphinx-tutorials/vla.py
@@ -126,10 +126,8 @@ warnings.filterwarnings("ignore")
 
 import torch
 from tensordict import NonTensorStack, TensorDict
-from torchrl.data.vla import ACTION_CHUNK_KEY, ACTION_TOKENS_KEY
 
 torch.manual_seed(0)
-LOG_PROBS_KEY = ("vla_action", "log_probs")
 
 ##############################################################################
 # The canonical VLA schema
@@ -213,7 +211,7 @@ from torchrl.envs.transforms import ActionChunkTransform, ActionScaling
 T, H = 6, 4
 window = TensorDict({"action": torch.randn(2, T, action_dim)}, batch_size=[2, T])
 chunked = ActionChunkTransform(chunk_size=H)(window)
-chunked[ACTION_CHUNK_KEY].shape  # [2, T, H, action_dim]
+chunked["vla_action", "chunk"].shape  # [2, T, H, action_dim]
 
 ##############################################################################
 # :class:`~torchrl.envs.transforms.ActionScaling` handles action normalization.
@@ -243,7 +241,7 @@ normalized["action"]  # all ones
 from torchrl.modules.vla import TinyVLA
 
 policy = TinyVLA(action_dim=action_dim, chunk_size=H, hidden_dim=64)
-policy(make_observation())[ACTION_CHUNK_KEY].shape  # [batch, H, action_dim]
+policy(make_observation())["vla_action", "chunk"].shape  # [batch, H, action_dim]
 
 ##############################################################################
 # Behavior cloning
@@ -262,10 +260,10 @@ data = make_observation()
 expert = (
     data["observation", "state"] @ torch.randn(state_dim, H * action_dim)
 ).reshape(batch, H, action_dim)
-data[ACTION_CHUNK_KEY] = expert
+data["vla_action", "chunk"] = expert
 
 bc_loss = BCLoss(policy, loss_function="l1")
-bc_loss.set_keys(action=ACTION_CHUNK_KEY, pad_mask="action_is_pad")
+bc_loss.set_keys(action=("vla_action", "chunk"), pad_mask="action_is_pad")
 initial = bc_loss(data)["loss_bc"].item()
 optimizer = torch.optim.Adam(bc_loss.parameters(), lr=1e-2)
 for _ in range(100):
@@ -396,13 +394,15 @@ with set_exploration_type(ExplorationType.RANDOM):
 # one advantage per sample, with the trailing singleton value-dim the PPO
 # losses expect (a flat [batch] advantage would silently broadcast wrong)
 rollout["advantage"] = torch.randn(batch, 1)
-rollout[LOG_PROBS_KEY] = rollout[LOG_PROBS_KEY].detach()
+rollout["vla_action", "log_probs"] = rollout["vla_action", "log_probs"].detach()
 
 grpo_loss = ClipPPOLoss(
     token_policy, critic_network=None, entropy_bonus=False, clip_epsilon=0.2
 )
 grpo_loss.set_keys(
-    action=ACTION_TOKENS_KEY, sample_log_prob=LOG_PROBS_KEY, advantage="advantage"
+    action=("vla_action", "tokens"),
+    sample_log_prob=("vla_action", "log_probs"),
+    advantage="advantage",
 )
 grpo_optimizer = torch.optim.Adam(grpo_loss.parameters(), lr=1e-3)
 grpo_optimizer.zero_grad()


### PR DESCRIPTION
## Summary
- Add TensorClass VLA containers and export them from `torchrl.data.vla`.
- Make VLA wrappers TensorDict-native with explicit input/output modes, `tensordict_out`, `logits_only`, `log_prob`, `get_dist`, `get_new_version`, and structured `vla_action` outputs while preserving flat compatibility keys.
- Port `TinyVLA` and `LeRobotPolicyWrapper` to the richer base contract.
- Add OpenVLA-style image preprocessing with a torchvision tensor JPEG backend plus a PIL reference path, and add a preprocessing benchmark.

## Tests
- `uv run pytest test/data/test_vla.py test/modules/test_actor.py::TestVLAWrapperBase test/modules/test_actor.py::TestTinyVLA test/modules/test_actor.py::TestLeRobotPolicyWrapper test/objectives/test_vla.py -q`
- `uv run pre-commit run --files torchrl/data/vla/containers.py torchrl/data/vla/preprocessing.py torchrl/data/vla/__init__.py torchrl/modules/vla/common.py torchrl/modules/vla/models.py torchrl/modules/vla/wrappers.py test/data/test_vla.py test/modules/test_actor.py test/objectives/test_vla.py docs/source/reference/vla.rst benchmarks/test_vla_preprocessing_benchmark.py pyproject.toml`
