### PR TITLE
[BugFix] Normalize reward loss over valid pairs

### DIFF
--- a/test/test_rlhf.py
+++ b/test/test_rlhf.py
@@ -444,13 +444,15 @@ def test_compute_reward_loss_normalizes_by_non_identical_sequences():
         [
             [0.0, 0.0, 10.0, 10.0, 0.0],
             [0.0, 0.0, 2.0, 2.0, 0.0],
-        ]
+        ],
+        requires_grad=True,
     )
     rejected_rewards = torch.tensor(
         [
             [0.0, 0.0, -10.0, -10.0, 0.0],
             [0.0, 0.0, 1.0, 1.0, 0.0],
-        ]
+        ],
+        requires_grad=True,
     )
     chosen_batch = SimpleNamespace(input_ids=chosen_ids, rewards=chosen_rewards)
     rejected_batch = SimpleNamespace(input_ids=rejected_ids, rewards=rejected_rewards)
@@ -460,6 +462,13 @@ def test_compute_reward_loss_normalizes_by_non_identical_sequences():
     )
     expected_loss = -F.logsigmoid(chosen_rewards[1, 2:4] - rejected_rewards[1, 2:4])
     torch.testing.assert_close(loss, expected_loss.mean())
+    loss.backward()
+    torch.testing.assert_close(
+        chosen_rewards.grad[0], torch.zeros_like(chosen_rewards[0])
+    )
+    torch.testing.assert_close(
+        rejected_rewards.grad[0], torch.zeros_like(rejected_rewards[0])
+    )
 
 
 @pytest.mark.skipif(

--- a/test/test_rlhf.py
+++ b/test/test_rlhf.py
@@ -406,17 +406,60 @@ def test_compute_reward_loss_identical_sequences():
 
     chosen_batch = SimpleNamespace(
         input_ids=input_ids,
-        rewards=torch.randn(1, seq_len),
+        rewards=torch.randn(1, seq_len, requires_grad=True),
     )
     rejected_batch = SimpleNamespace(
         input_ids=input_ids.clone(),
-        rewards=torch.randn(1, seq_len),
+        rewards=torch.randn(1, seq_len, requires_grad=True),
     )
     loss = GPT2RewardModel.compute_reward_loss(
         chosen_batch, rejected_batch, pad_token_id=pad_token_id
     )
     assert loss.shape == torch.Size([])
     assert loss.item() == 0.0
+    loss.backward()
+    torch.testing.assert_close(
+        chosen_batch.rewards.grad, torch.zeros_like(chosen_batch.rewards)
+    )
+    torch.testing.assert_close(
+        rejected_batch.rewards.grad, torch.zeros_like(rejected_batch.rewards)
+    )
+
+
+def test_compute_reward_loss_normalizes_by_non_identical_sequences():
+    pad_token_id = 50256
+    chosen_ids = torch.tensor(
+        [
+            [1, 2, 3, 4, pad_token_id],
+            [1, 2, 9, 4, pad_token_id],
+        ]
+    )
+    rejected_ids = torch.tensor(
+        [
+            [1, 2, 3, 4, pad_token_id],
+            [1, 2, 3, 4, pad_token_id],
+        ]
+    )
+    chosen_rewards = torch.tensor(
+        [
+            [0.0, 0.0, 10.0, 10.0, 0.0],
+            [0.0, 0.0, 2.0, 2.0, 0.0],
+        ]
+    )
+    rejected_rewards = torch.tensor(
+        [
+            [0.0, 0.0, -10.0, -10.0, 0.0],
+            [0.0, 0.0, 1.0, 1.0, 0.0],
+        ]
+    )
+    chosen_batch = SimpleNamespace(input_ids=chosen_ids, rewards=chosen_rewards)
+    rejected_batch = SimpleNamespace(input_ids=rejected_ids, rewards=rejected_rewards)
+
+    loss = GPT2RewardModel.compute_reward_loss(
+        chosen_batch, rejected_batch, pad_token_id=pad_token_id
+    )
+    expected_loss = -F.logsigmoid(chosen_rewards[1, 2:4] - rejected_rewards[1, 2:4])
+    torch.testing.assert_close(loss, expected_loss.mean())
 
 
 @pytest.mark.skipif(

--- a/torchrl/modules/models/llm.py
+++ b/torchrl/modules/models/llm.py
@@ -122,7 +122,7 @@ class GPT2RewardModel(nn.Module):
         rejected_rewards = rejected_batch.rewards
 
         bs = chosen_rewards.shape[0]
-        loss = chosen_rewards.sum() * 0.0 + rejected_rewards.sum() * 0.0
+        loss = None
         valid_count = 0
 
         # TODO: this loop can likely be made more efficient
@@ -145,10 +145,11 @@ class GPT2RewardModel(nn.Module):
             c_truncated_reward = chosen_rewards[i][divergence_ind:end_ind]
             r_truncated_reward = rejected_rewards[i][divergence_ind:end_ind]
 
-            loss = loss - F.logsigmoid(c_truncated_reward - r_truncated_reward).mean()
+            sample_loss = -F.logsigmoid(c_truncated_reward - r_truncated_reward).mean()
+            loss = sample_loss if loss is None else loss + sample_loss
             valid_count += 1
-        if valid_count == 0:
-            return loss
+        if loss is None:
+            return chosen_rewards.sum() * 0.0 + rejected_rewards.sum() * 0.0
         return loss / valid_count
 
     @classmethod

--- a/torchrl/modules/models/llm.py
+++ b/torchrl/modules/models/llm.py
@@ -122,7 +122,8 @@ class GPT2RewardModel(nn.Module):
         rejected_rewards = rejected_batch.rewards
 
         bs = chosen_rewards.shape[0]
-        loss = torch.tensor(0.0, device=chosen_rewards.device)
+        loss = chosen_rewards.sum() * 0.0 + rejected_rewards.sum() * 0.0
+        valid_count = 0
 
         # TODO: this loop can likely be made more efficient
         for i in range(bs):
@@ -144,8 +145,11 @@ class GPT2RewardModel(nn.Module):
             c_truncated_reward = chosen_rewards[i][divergence_ind:end_ind]
             r_truncated_reward = rejected_rewards[i][divergence_ind:end_ind]
 
-            loss += -F.logsigmoid(c_truncated_reward - r_truncated_reward).mean()
-        return loss / bs
+            loss = loss - F.logsigmoid(c_truncated_reward - r_truncated_reward).mean()
+            valid_count += 1
+        if valid_count == 0:
+            return loss
+        return loss / valid_count
 
     @classmethod
     def from_pretrained(cls, path):


### PR DESCRIPTION
## Summary
- Track how many chosen/rejected pairs actually contribute to `GPT2RewardModel.compute_reward_loss`.
- Normalize by that valid pair count instead of the original batch size when identical pairs are skipped.
- Keep all-identical batches returning a scalar zero, while preserving an autograd connection to the reward tensors.

## Root cause
The identical-sequence fix correctly skipped pairs with no preference signal, but the final loss still divided by the original batch size. Mixed batches with skipped samples therefore silently scaled the loss and gradients down.

## Tests
- `/Users/hoangvu/.pyenv/versions/3.10.13/bin/python -m pytest test/test_rlhf.py::test_compute_reward_loss_identical_sequences test/test_rlhf.py::test_compute_reward_loss_normalizes_by_non_identical_sequences`
- `/Users/hoangvu/.pyenv/versions/3.10.13/bin/python -m pytest test/test_rlhf.py` (`2 passed, 75 skipped`; optional LLM dependencies unavailable locally)