### PR TITLE
[Refactor] Migrate remaining LossModules to mask-aware reduction (#3866)

### DIFF
--- a/torchrl/objectives/cql.py
+++ b/torchrl/objectives/cql.py
@@ -535,7 +535,9 @@ class CQLLoss(LossModule):
             metadata.update(alpha_prime_metadata)
         loss_actor_bc, bc_metadata = self.actor_bc_loss(tensordict)
         loss_actor, actor_metadata = self.actor_loss(tensordict)
-        loss_alpha, alpha_metadata = self.alpha_loss(actor_metadata)
+        loss_alpha, alpha_metadata = self.alpha_loss(
+            actor_metadata, mask_tensordict=tensordict
+        )
         metadata.update(bc_metadata)
         metadata.update(cql_metadata)
         metadata.update(actor_metadata)
@@ -939,11 +941,17 @@ class CQLLoss(LossModule):
             )
 
         alpha_prime = torch.clamp_max(self.log_alpha_prime.exp(), max=1000000.0)
-        min_qf1_loss = alpha_prime * (cql_q1_loss.mean() - self.target_action_gap)
-        min_qf2_loss = alpha_prime * (cql_q2_loss.mean() - self.target_action_gap)
+        cql_q1_loss = self._reduce_loss(
+            cql_q1_loss, tensordict=tensordict, reduction="mean"
+        )
+        cql_q2_loss = self._reduce_loss(
+            cql_q2_loss, tensordict=tensordict, reduction="mean"
+        )
+
+        min_qf1_loss = alpha_prime * (cql_q1_loss - self.target_action_gap)
+        min_qf2_loss = alpha_prime * (cql_q2_loss - self.target_action_gap)
 
         alpha_prime_loss = (-min_qf1_loss - min_qf2_loss) * 0.5
-        alpha_prime_loss = self._reduce_loss(alpha_prime_loss, tensordict=tensordict)
         self._clear_weakrefs(
             tensordict,
             "actor_network_params",
@@ -953,7 +961,11 @@ class CQLLoss(LossModule):
         )
         return alpha_prime_loss, {}
 
-    def alpha_loss(self, tensordict: TensorDictBase) -> Tensor:
+    def alpha_loss(
+        self,
+        tensordict: TensorDictBase | dict[NestedKey, Tensor],
+        mask_tensordict: TensorDictBase | None = None,
+    ) -> tuple[Tensor, dict]:
         log_pi = tensordict.get(self.tensor_keys.log_prob)
         if self.target_entropy is not None:
             # we can compute this loss even if log_alpha is not a parameter
@@ -961,9 +973,9 @@ class CQLLoss(LossModule):
         else:
             # placeholder
             alpha_loss = torch.zeros_like(log_pi)
-        # Note: tensordict here is actor_metadata (a plain dict), not a TensorDictBase.
-        # Pass None so _reduce_loss skips the mask lookup.
-        alpha_loss = self._reduce_loss(alpha_loss, tensordict=None)
+        if mask_tensordict is None and isinstance(tensordict, TensorDictBase):
+            mask_tensordict = tensordict
+        alpha_loss = self._reduce_loss(alpha_loss, tensordict=mask_tensordict)
         self._clear_weakrefs(
             tensordict,
             "actor_network_params",

--- a/torchrl/objectives/cql.py
+++ b/torchrl/objectives/cql.py
@@ -26,7 +26,6 @@ from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
     _GAMMA_LMBDA_DEPREC_ERROR,
-    _reduce,
     _vmap_func,
     dispatch_value_estimator,
     distance_loss,
@@ -595,7 +594,7 @@ class CQLLoss(LossModule):
         bc_log_prob = dist.log_prob(tensordict.get(self.tensor_keys.action))
 
         bc_actor_loss = self._alpha * log_prob - bc_log_prob
-        bc_actor_loss = _reduce(bc_actor_loss, reduction=self.reduction)
+        bc_actor_loss = self._reduce_loss(bc_actor_loss, tensordict=tensordict)
         metadata = {"bc_log_prob": bc_log_prob.mean().detach()}
         self._clear_weakrefs(
             tensordict,
@@ -638,7 +637,7 @@ class CQLLoss(LossModule):
         metadata = {}
         metadata[self.tensor_keys.log_prob] = log_prob.detach()
         actor_loss = self._alpha * log_prob - min_q_logprob
-        actor_loss = _reduce(actor_loss, reduction=self.reduction)
+        actor_loss = self._reduce_loss(actor_loss, tensordict=tensordict)
         self._clear_weakrefs(
             tensordict,
             "actor_network_params",
@@ -762,7 +761,7 @@ class CQLLoss(LossModule):
             target_value.expand_as(q_pred),
             loss_function=self.loss_function,
         ).sum(0)
-        loss_qval = _reduce(loss_qval, reduction=self.reduction)
+        loss_qval = self._reduce_loss(loss_qval, tensordict=tensordict)
         td_error = (q_pred - target_value).pow(2)
         metadata = {"td_error": td_error.detach()}
         self._clear_weakrefs(
@@ -913,7 +912,7 @@ class CQLLoss(LossModule):
         tensordict.set(self.tensor_keys.cql_q2_loss, cql_q2_loss)
 
         cql_q_loss = (cql_q1_loss + cql_q2_loss).mean(-1)
-        cql_q_loss = _reduce(cql_q_loss, reduction=self.reduction)
+        cql_q_loss = self._reduce_loss(cql_q_loss, tensordict=tensordict)
 
         self._clear_weakrefs(
             tensordict,
@@ -944,7 +943,7 @@ class CQLLoss(LossModule):
         min_qf2_loss = alpha_prime * (cql_q2_loss.mean() - self.target_action_gap)
 
         alpha_prime_loss = (-min_qf1_loss - min_qf2_loss) * 0.5
-        alpha_prime_loss = _reduce(alpha_prime_loss, reduction=self.reduction)
+        alpha_prime_loss = self._reduce_loss(alpha_prime_loss, tensordict=tensordict)
         self._clear_weakrefs(
             tensordict,
             "actor_network_params",
@@ -962,7 +961,9 @@ class CQLLoss(LossModule):
         else:
             # placeholder
             alpha_loss = torch.zeros_like(log_pi)
-        alpha_loss = _reduce(alpha_loss, reduction=self.reduction)
+        # Note: tensordict here is actor_metadata (a plain dict), not a TensorDictBase.
+        # Pass None so _reduce_loss skips the mask lookup.
+        alpha_loss = self._reduce_loss(alpha_loss, tensordict=None)
         self._clear_weakrefs(
             tensordict,
             "actor_network_params",
@@ -1279,7 +1280,7 @@ class DiscreteCQLLoss(LossModule):
             inplace=True,
         )
         loss = 0.5 * distance_loss(pred_val_index, target_value, self.loss_function)
-        loss = _reduce(loss, reduction=self.reduction)
+        loss = self._reduce_loss(loss, tensordict=tensordict)
 
         metadata = {
             "td_error": td_error.mean(0).detach(),
@@ -1343,5 +1344,5 @@ class DiscreteCQLLoss(LossModule):
             q_a = (qvalues * current_action).sum(dim=-1, keepdim=True)
 
         loss_cql = (logsumexp - q_a).squeeze(-1)
-        loss_cql = _reduce(loss_cql, reduction=self.reduction)
+        loss_cql = self._reduce_loss(loss_cql, tensordict=tensordict)
         return loss_cql, {}

--- a/torchrl/objectives/crossq.py
+++ b/torchrl/objectives/crossq.py
@@ -20,7 +20,6 @@ from torchrl.envs.utils import ExplorationType, set_exploration_type
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
-    _reduce,
     _vmap_func,
     dispatch_value_estimator,
     distance_loss,
@@ -541,7 +540,9 @@ class CrossQLoss(LossModule):
         """
         loss_qvalue, value_metadata = self.qvalue_loss(tensordict)
         loss_actor, metadata_actor = self.actor_loss(tensordict)
-        loss_alpha = self.alpha_loss(log_prob=metadata_actor["log_prob"])
+        loss_alpha = self.alpha_loss(
+            log_prob=metadata_actor["log_prob"], tensordict=tensordict
+        )
         tensordict.set(self.tensor_keys.priority, value_metadata["td_error"])
         if loss_actor.shape != loss_qvalue.shape:
             raise RuntimeError(
@@ -622,7 +623,7 @@ class CrossQLoss(LossModule):
                 f"Losses shape mismatch: {log_prob.shape} and {min_q.shape}"
             )
         actor_loss = self._alpha * log_prob - min_q
-        return _reduce(actor_loss, reduction=self.reduction), {
+        return self._reduce_loss(actor_loss, tensordict=tensordict), {
             "log_prob": log_prob.detach()
         }
 
@@ -693,15 +694,18 @@ class CrossQLoss(LossModule):
             loss_function=self.loss_function,
         ).sum(0)
         metadata = {"td_error": td_error.detach().max(0)[0]}
-        return _reduce(loss_qval, reduction=self.reduction), metadata
+        return self._reduce_loss(loss_qval, tensordict=tensordict), metadata
 
-    def alpha_loss(self, log_prob: Tensor) -> Tensor:
+    def alpha_loss(
+        self, log_prob: Tensor, tensordict: TensorDictBase | None = None
+    ) -> Tensor:
         """Compute the entropy loss.
 
         The entropy loss should be computed last.
 
         Args:
             log_prob (torch.Tensor): a log-probability as computed by the :meth:`~.actor_loss` and returned in the `metadata`.
+            tensordict (TensorDictBase, optional): the input tensordict.
 
         Returns: a differentiable tensor with the entropy loss.
         """
@@ -711,7 +715,7 @@ class CrossQLoss(LossModule):
         else:
             # placeholder
             alpha_loss = torch.zeros_like(log_prob)
-        return _reduce(alpha_loss, reduction=self.reduction)
+        return self._reduce_loss(alpha_loss, tensordict=tensordict)
 
     @property
     def _alpha(self):

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -18,7 +18,6 @@ from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
     _GAMMA_LMBDA_DEPREC_ERROR,
-    _reduce,
     dispatch_value_estimator,
     distance_loss,
     ValueEstimators,
@@ -335,7 +334,9 @@ class DDPGLoss(LossModule):
             td_copy = self.value_network(td_copy)
         loss_actor = -td_copy.get(self.tensor_keys.state_action_value).squeeze(-1)
         metadata = {}
-        loss_actor = _reduce(loss_actor, self.reduction, weights=weights)
+        loss_actor = self._reduce_loss(
+            loss_actor, tensordict=tensordict, weights=weights
+        )
         self._clear_weakrefs(
             tensordict,
             loss_actor,
@@ -385,7 +386,9 @@ class DDPGLoss(LossModule):
                 "target_value_max": target_value.max(),
                 "pred_value_max": pred_val.max(),
             }
-        loss_value = _reduce(loss_value, self.reduction, weights=weights)
+        loss_value = self._reduce_loss(
+            loss_value, tensordict=tensordict, weights=weights
+        )
         self._clear_weakrefs(
             tensordict,
             "value_network_params",

--- a/torchrl/objectives/decision_transformer.py
+++ b/torchrl/objectives/decision_transformer.py
@@ -15,7 +15,7 @@ from tensordict.utils import NestedKey
 from torch import distributions as d
 
 from torchrl.objectives.common import LossModule
-from torchrl.objectives.utils import _reduce, distance_loss
+from torchrl.objectives.utils import distance_loss
 
 
 class OnlineDTLoss(LossModule):
@@ -267,7 +267,9 @@ class OnlineDTLoss(LossModule):
             out["alpha"] = self.alpha.detach()
             td_out = TensorDict(out, [])
             td_out = td_out.named_apply(
-                lambda name, value: _reduce(value, reduction=self.reduction).squeeze(-1)
+                lambda name, value: self._reduce_loss(
+                    value, tensordict=tensordict
+                ).squeeze(-1)
                 if name.startswith("loss_")
                 else value,
             )
@@ -394,7 +396,7 @@ class DTLoss(LossModule):
             target_actions,
             loss_function=self.loss_function,
         )
-        loss = _reduce(loss, reduction=self.reduction)
+        loss = self._reduce_loss(loss, tensordict=tensordict)
         td_out = TensorDict(loss=loss)
         self._clear_weakrefs(
             tensordict,

--- a/torchrl/objectives/deprecated.py
+++ b/torchrl/objectives/deprecated.py
@@ -22,7 +22,6 @@ from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
     _GAMMA_LMBDA_DEPREC_ERROR,
-    _reduce,
     _vmap_func,
     dispatch_value_estimator,
 )
@@ -347,7 +346,7 @@ class REDQLoss_deprecated(LossModule):
             [],
         )
         td_out = td_out.named_apply(
-            lambda name, value: _reduce(value, reduction=self.reduction)
+            lambda name, value: self._reduce_loss(value, tensordict=tensordict)
             if name.startswith("loss_")
             else value,
             batch_size=[],

--- a/torchrl/objectives/dqn.py
+++ b/torchrl/objectives/dqn.py
@@ -24,7 +24,6 @@ from torchrl.modules.tensordict_module.common import ensure_tensordict_compatibl
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _GAMMA_LMBDA_DEPREC_ERROR,
-    _reduce,
     dispatch_value_estimator,
     distance_loss,
     ValueEstimators,
@@ -374,7 +373,7 @@ class DQNLoss(LossModule):
             and self.tensor_keys.priority_weight in tensordict.keys()
         ):
             weights = tensordict.get(self.tensor_keys.priority_weight)
-        loss = _reduce(loss, reduction=self.reduction, weights=weights)
+        loss = self._reduce_loss(loss, tensordict=tensordict, weights=weights)
         td_out = TensorDict(loss=loss)
 
         self._clear_weakrefs(
@@ -640,7 +639,7 @@ class DistributionalDQNLoss(LossModule):
             and self.tensor_keys.priority_weight in tensordict.keys()
         ):
             weights = tensordict.get(self.tensor_keys.priority_weight)
-        loss = _reduce(loss, reduction=self.reduction, weights=weights)
+        loss = self._reduce_loss(loss, tensordict=tensordict, weights=weights)
         td_out = TensorDict(loss=loss)
         self._clear_weakrefs(
             tensordict,

--- a/torchrl/objectives/gail.py
+++ b/torchrl/objectives/gail.py
@@ -14,7 +14,6 @@ from tensordict.nn import dispatch, TensorDictModule
 from tensordict.utils import NestedKey
 
 from torchrl.objectives.common import LossModule
-from torchrl.objectives.utils import _reduce
 
 
 class GAILLoss(LossModule):
@@ -248,7 +247,7 @@ class GAILLoss(LossModule):
 
             loss += gp_loss
             out["gp_loss"] = gp_loss.detach()
-        loss = _reduce(loss, reduction=self.reduction)
+        loss = self._reduce_loss(loss, tensordict=tensordict)
         out["loss"] = loss
         td_out = TensorDict(out)
         self._clear_weakrefs(

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -19,7 +19,6 @@ from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _GAMMA_LMBDA_DEPREC_ERROR,
     _pseudo_vmap,
-    _reduce,
     _vmap_func,
     dispatch_value_estimator,
     distance_loss,
@@ -480,7 +479,7 @@ class IQLLoss(LossModule):
         # write log_prob in tensordict for alpha loss
         tensordict.set(self.tensor_keys.log_prob, log_prob.detach())
         loss_actor = -(exp_a * log_prob)
-        loss_actor = _reduce(loss_actor, reduction=self.reduction)
+        loss_actor = self._reduce_loss(loss_actor, tensordict=tensordict)
         self._clear_weakrefs(
             tensordict,
             "actor_network_params",
@@ -505,7 +504,7 @@ class IQLLoss(LossModule):
             self.value_network(td_copy)
         value = td_copy.get(self.tensor_keys.value).squeeze(-1)
         value_loss = self.loss_value_diff(min_q - value, self.expectile)
-        value_loss = _reduce(value_loss, reduction=self.reduction)
+        value_loss = self._reduce_loss(value_loss, tensordict=tensordict)
         self._clear_weakrefs(
             tensordict,
             "actor_network_params",
@@ -539,7 +538,7 @@ class IQLLoss(LossModule):
             target_value.expand_as(pred_val),
             loss_function=self.loss_function,
         ).sum(0)
-        loss_qval = _reduce(loss_qval, reduction=self.reduction)
+        loss_qval = self._reduce_loss(loss_qval, tensordict=tensordict)
         metadata = {"td_error": td_error.detach()}
         self._clear_weakrefs(
             tensordict,
@@ -908,7 +907,7 @@ class DiscreteIQLLoss(IQLLoss):
         # write log_prob in tensordict for alpha loss
         tensordict.set(self.tensor_keys.log_prob, log_prob.detach())
         loss_actor = -(exp_a * log_prob)
-        loss_actor = _reduce(loss_actor, reduction=self.reduction)
+        loss_actor = self._reduce_loss(loss_actor, tensordict=tensordict)
         self._clear_weakrefs(
             tensordict,
             "actor_network_params",
@@ -958,7 +957,7 @@ class DiscreteIQLLoss(IQLLoss):
             self.value_network(td_copy)
         value = td_copy.get(self.tensor_keys.value).squeeze(-1)
         value_loss = self.loss_value_diff(min_Q - value, self.expectile)
-        value_loss = _reduce(value_loss, reduction=self.reduction)
+        value_loss = self._reduce_loss(value_loss, tensordict=tensordict)
         self._clear_weakrefs(
             tensordict,
             "actor_network_params",
@@ -1011,7 +1010,7 @@ class DiscreteIQLLoss(IQLLoss):
             target_value.expand_as(pred_val),
             loss_function=self.loss_function,
         ).sum(0)
-        loss_qval = _reduce(loss_qval, reduction=self.reduction)
+        loss_qval = self._reduce_loss(loss_qval, tensordict=tensordict)
         metadata = {"td_error": td_error.detach()}
         self._clear_weakrefs(
             tensordict,

--- a/torchrl/objectives/llm/grpo.py
+++ b/torchrl/objectives/llm/grpo.py
@@ -639,12 +639,7 @@ class GRPOLoss(LossModule):
             td_out.set("entropy", entropy.detach().mean())  # for logging
             td_out.set("loss_entropy", -self.entropy_coeff * entropy)
 
-        td_out.set(
-            "ESS",
-            self._reduce_loss(
-                ess / batch, tensordict=tensordict, reduction=self.reduction
-            ),
-        )
+        td_out.set("ESS", ess / batch)
         # Aggregate loss terms according to aggregation strategy
         for key in list(td_out.keys()):
             if isinstance(key, tuple) or not isinstance(key, str):

--- a/torchrl/objectives/llm/grpo.py
+++ b/torchrl/objectives/llm/grpo.py
@@ -33,7 +33,7 @@ from torchrl._utils import logger as torchrl_logger, VERBOSE
 from torchrl.envs.transforms.transforms import Transform
 from torchrl.modules.llm import LLMWrapperBase
 from torchrl.objectives.common import LossModule
-from torchrl.objectives.utils import _reduce, _sum_td_features, _validate_clip_epsilon
+from torchrl.objectives.utils import _sum_td_features, _validate_clip_epsilon
 
 
 class LLMLossOutput(TensorClass["nocast"]):
@@ -639,14 +639,21 @@ class GRPOLoss(LossModule):
             td_out.set("entropy", entropy.detach().mean())  # for logging
             td_out.set("loss_entropy", -self.entropy_coeff * entropy)
 
-        td_out.set("ESS", _reduce(ess / batch, self.reduction))
+        td_out.set(
+            "ESS",
+            self._reduce_loss(
+                ess / batch, tensordict=tensordict, reduction=self.reduction
+            ),
+        )
         # Aggregate loss terms according to aggregation strategy
         for key in list(td_out.keys()):
             if isinstance(key, tuple) or not isinstance(key, str):
                 continue
             if key.startswith("loss_"):
                 val = td_out.get(key)
-                td_out.set(key, self._aggregate_loss_value(val, mask))
+                td_out.set(
+                    key, self._aggregate_loss_value(val, mask, tensordict=tensordict)
+                )
         if self.kl_to_ref_coeff is not None and self.kl_to_ref_coeff > 0:
             # FIXME: parameterize this
             loss_kl, kl_penalty = self._kl_to_ref(
@@ -691,7 +698,10 @@ class GRPOLoss(LossModule):
         return -gain, clip_fraction
 
     def _aggregate_loss_value(
-        self, value: torch.Tensor, mask: torch.Tensor
+        self,
+        value: torch.Tensor,
+        mask: torch.Tensor,
+        tensordict: TensorDictBase | None = None,
     ) -> torch.Tensor:
         """Aggregate a per-token loss tensor using the configured strategy.
 
@@ -717,7 +727,9 @@ class GRPOLoss(LossModule):
 
         # token_mean (global masked mean)
         mask_exp = expand_as_right(mask, value)
-        return _reduce(value, reduction="mean", mask=mask_exp).squeeze(-1)
+        return self._reduce_loss(
+            value, tensordict=tensordict, reduction="mean", mask=mask_exp
+        ).squeeze(-1)
 
     def _get_entropy(
         self, dist: d.Distribution, adv_shape: torch.Size

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -1459,11 +1459,7 @@ class ClipPPOLoss(PPOLoss):
             if explained_variance is not None:
                 td_out.set("explained_variance", explained_variance)
 
-        td_out.set(
-            "ESS",
-            self._reduce_loss(ess, tensordict=tensordict, reduction=self.reduction)
-            / batch,
-        )
+        td_out.set("ESS", ess / batch)
         with torch.no_grad():
             ratio = log_weight.exp()
             td_out.set("max_ratio", ratio.max())

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -36,7 +36,6 @@ from torchrl.objectives.utils import (
     _GAMMA_LMBDA_DEPREC_ERROR,
     _maybe_add_or_extend_key,
     _maybe_get_or_select,
-    _reduce,
     _sum_td_features,
     _validate_clip_epsilon,
     dispatch_value_estimator,
@@ -1460,7 +1459,11 @@ class ClipPPOLoss(PPOLoss):
             if explained_variance is not None:
                 td_out.set("explained_variance", explained_variance)
 
-        td_out.set("ESS", _reduce(ess, self.reduction) / batch)
+        td_out.set(
+            "ESS",
+            self._reduce_loss(ess, tensordict=tensordict, reduction=self.reduction)
+            / batch,
+        )
         with torch.no_grad():
             ratio = log_weight.exp()
             td_out.set("max_ratio", ratio.max())

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -21,7 +21,6 @@ from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
     _GAMMA_LMBDA_DEPREC_ERROR,
-    _reduce,
     _vmap_func,
     dispatch_value_estimator,
     distance_loss,
@@ -638,7 +637,7 @@ class REDQLoss(LossModule):
             td_out = TensorDict(out, [])
             if self.reduction != "none":
                 td_out = td_out.named_apply(
-                    lambda name, value: _reduce(value, reduction=self.reduction)
+                    lambda name, value: self._reduce_loss(value, tensordict=tensordict)
                     if name.startswith("loss_")
                     else value,
                 )

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -636,8 +636,11 @@ class REDQLoss(LossModule):
             }
             td_out = TensorDict(out, [])
             if self.reduction != "none":
+                loss_mask = tensordict.get("shifted_valid", default=None)
+                if loss_mask is not None:
+                    loss_mask = loss_mask.unsqueeze(0)
                 td_out = td_out.named_apply(
-                    lambda name, value: self._reduce_loss(value, tensordict=tensordict)
+                    lambda name, value: self._reduce_loss(value, mask=loss_mask)
                     if name.startswith("loss_")
                     else value,
                 )

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -32,7 +32,6 @@ from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
     _GAMMA_LMBDA_DEPREC_ERROR,
-    _reduce,
     _vmap_func,
     dispatch_value_estimator,
     distance_loss,
@@ -668,7 +667,9 @@ class SACLoss(LossModule):
         loss_actor, metadata_actor = self.actor_loss(tensordict)
         loss_alpha = self._alpha_loss(log_prob=metadata_actor["log_prob"])
         weights = self._maybe_get_priority_weight(tensordict)
-        loss_alpha = _reduce(loss_alpha, reduction=self.reduction, weights=weights)
+        loss_alpha = self._reduce_loss(
+            loss_alpha, tensordict=tensordict, weights=weights
+        )
         tensordict.set(self.tensor_keys.priority, value_metadata["td_error"])
         if (loss_actor.shape != loss_qvalue.shape) or (
             loss_value is not None and loss_actor.shape != loss_value.shape
@@ -746,7 +747,9 @@ class SACLoss(LossModule):
                 f"Losses shape mismatch: {log_prob.shape} and {min_q_logprob.shape}"
             )
         loss_actor = self._alpha * log_prob - min_q_logprob
-        loss_actor = _reduce(loss_actor, reduction=self.reduction, weights=weights)
+        loss_actor = self._reduce_loss(
+            loss_actor, tensordict=tensordict, weights=weights
+        )
         return loss_actor, {"log_prob": log_prob.detach()}
 
     def alpha_loss(self, log_prob: Tensor) -> Tensor:
@@ -818,7 +821,9 @@ class SACLoss(LossModule):
         loss_value = distance_loss(
             pred_val, target_chunks, loss_function=self.loss_function
         ).view(*shape)
-        loss_value = _reduce(loss_value, reduction=self.reduction, weights=weights)
+        loss_value = self._reduce_loss(
+            loss_value, tensordict=tensordict, weights=weights
+        )
         metadata = {"td_error": (pred_val - target_chunks).pow(2).flatten(0, 1)}
 
         return loss_value, metadata
@@ -923,7 +928,7 @@ class SACLoss(LossModule):
             target_value.expand_as(pred_val),
             loss_function=self.loss_function,
         ).sum(0)
-        loss_qval = _reduce(loss_qval, reduction=self.reduction, weights=weights)
+        loss_qval = self._reduce_loss(loss_qval, tensordict=tensordict, weights=weights)
         metadata = {"td_error": td_error.detach().max(0)[0]}
         return loss_qval, metadata
 
@@ -966,7 +971,9 @@ class SACLoss(LossModule):
         loss_value = distance_loss(
             pred_val, target_val, loss_function=self.loss_function
         )
-        loss_value = _reduce(loss_value, reduction=self.reduction, weights=weights)
+        loss_value = self._reduce_loss(
+            loss_value, tensordict=tensordict, weights=weights
+        )
         return loss_value, {}
 
     def _alpha_loss(self, log_prob: Tensor) -> Tensor:
@@ -1357,7 +1364,9 @@ class DiscreteSACLoss(LossModule):
             log_prob=metadata_actor["log_prob"],
         )
         weights = self._maybe_get_priority_weight(tensordict)
-        loss_alpha = _reduce(loss_alpha, reduction=self.reduction, weights=weights)
+        loss_alpha = self._reduce_loss(
+            loss_alpha, tensordict=tensordict, weights=weights
+        )
 
         tensordict.set(self.tensor_keys.priority, metadata_value["td_error"])
         if loss_actor.shape != loss_qvalue.shape:
@@ -1513,7 +1522,7 @@ class DiscreteSACLoss(LossModule):
             target_value.expand_as(chosen_action_value),
             loss_function=self.loss_function,
         ).sum(0)
-        loss_qval = _reduce(loss_qval, reduction=self.reduction, weights=weights)
+        loss_qval = self._reduce_loss(loss_qval, tensordict=tensordict, weights=weights)
 
         metadata = {
             "td_error": td_error.detach().max(0)[0],
@@ -1548,7 +1557,7 @@ class DiscreteSACLoss(LossModule):
         loss = self._alpha * log_prob - min_q
         # unlike in continuous SAC, we can compute the exact expectation over all discrete actions
         loss = (prob * loss).sum(-1)
-        loss = _reduce(loss, reduction=self.reduction, weights=weights)
+        loss = self._reduce_loss(loss, tensordict=tensordict, weights=weights)
 
         return loss, {"log_prob": (log_prob * prob).sum(-1).detach()}
 

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -17,7 +17,6 @@ from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
     _GAMMA_LMBDA_DEPREC_ERROR,
-    _reduce,
     _vmap_func,
     dispatch_value_estimator,
     distance_loss,
@@ -407,7 +406,9 @@ class TD3Loss(LossModule):
         metadata = {
             "state_action_value_actor": state_action_value_actor.detach(),
         }
-        loss_actor = _reduce(loss_actor, reduction=self.reduction, weights=weights)
+        loss_actor = self._reduce_loss(
+            loss_actor, tensordict=tensordict, weights=weights
+        )
         self._clear_weakrefs(
             tensordict,
             "actor_network_params",
@@ -494,7 +495,7 @@ class TD3Loss(LossModule):
             "pred_value": current_qvalue.detach(),
             "target_value": target_value.detach(),
         }
-        loss_qval = _reduce(loss_qval, reduction=self.reduction, weights=weights)
+        loss_qval = self._reduce_loss(loss_qval, tensordict=tensordict, weights=weights)
         self._clear_weakrefs(
             tensordict,
             "actor_network_params",

--- a/torchrl/objectives/td3_bc.py
+++ b/torchrl/objectives/td3_bc.py
@@ -16,7 +16,6 @@ from torchrl.envs.utils import step_mdp
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
-    _reduce,
     _vmap_func,
     dispatch_value_estimator,
     distance_loss,
@@ -442,7 +441,9 @@ class TD3BCLoss(LossModule):
             "bc_loss": bc_loss.detach(),
             "lmbd": lmbd,
         }
-        loss_actor = _reduce(loss_actor, reduction=self.reduction, weights=weights)
+        loss_actor = self._reduce_loss(
+            loss_actor, tensordict=tensordict, weights=weights
+        )
         self._clear_weakrefs(
             tensordict,
             "actor_network_params",
@@ -539,7 +540,7 @@ class TD3BCLoss(LossModule):
             "pred_value": current_qvalue.detach(),
             "target_value": target_value.detach(),
         }
-        loss_qval = _reduce(loss_qval, reduction=self.reduction, weights=weights)
+        loss_qval = self._reduce_loss(loss_qval, tensordict=tensordict, weights=weights)
         self._clear_weakrefs(
             tensordict,
             "actor_network_params",


### PR DESCRIPTION
## Description
Migrates remaining `LossModule` subclasses to use the mask-aware `self._reduce_loss(loss, tensordict=tensordict)` helper instead of direct `_reduce(loss, reduction=self.reduction)` calls, as requested in #3866.

**Modules migrated:**
- `cql.py` (CQLLoss, DiscreteCQLLoss)
- `crossq.py` (CrossQLoss)
- `ddpg.py` (DDPGLoss)
- `decision_transformer.py` (DTLoss, OnlineDTLoss)
- `deprecated.py`
- `dqn.py` (DQNLoss, DistributionalDQNLoss)
- `gail.py` (GAILLoss)
- `iql.py` (IQLLoss, DiscreteIQLLoss)
- `llm/grpo.py` (GRPOLoss)
- `ppo.py` (PPOLoss, ClipPPOLoss, KLPENPPOLoss)
- `redq.py` (REDQLoss)
- `sac.py` (SACLoss, DiscreteSACLoss)
- `td3.py` (TD3Loss)
- `td3_bc.py` (TD3BCLoss)

`bc.py` was intentionally left untouched (already migrated in #3850 as the reference case).

## Motivation and Context
Closes the loss-side gap from the sequence-RL composability work.

- #3695 added `SliceSampler(pad_output=True)` which produces batches with a `("collector", "mask")` key.
- #3850 introduced `LossModule._reduce_loss` and migrated BCLoss.

Behaviour is byte-identical when no mask is present. When the mask exists, padded positions are correctly excluded from reduction.

## Types of changes
- [x] New feature / improvement (non-breaking change which adds core functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide
- [x] Tests pass (`pytest test/objectives/`)
- [ ] Documentation updated (if needed)