### PR TITLE
[CI] Fix optional library dependency conflicts

### DIFF
--- a/.github/unittest/linux_libs/scripts_chess/install.sh
+++ b/.github/unittest/linux_libs/scripts_chess/install.sh
@@ -42,18 +42,22 @@ fi
 # submodules
 git submodule sync && git submodule update --init --recursive
 
-printf "Installing PyTorch with cu128"
+printf "Installing PyTorch and torchvision with cu128"
 if [[ "$TORCH_VERSION" == "nightly" ]]; then
   if [ "${CU_VERSION:-}" == cpu ] ; then
-      pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu -U
+      pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu -U
+      pip3 install --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cpu -U --no-deps
   else
-      pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128 -U
+      pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128 -U
+      pip3 install --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cu128 -U --no-deps
   fi
 elif [[ "$TORCH_VERSION" == "stable" ]]; then
     if [ "${CU_VERSION:-}" == cpu ] ; then
-      pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+      pip3 install torch --index-url https://download.pytorch.org/whl/cpu
+      pip3 install torchvision --index-url https://download.pytorch.org/whl/cpu --no-deps
   else
-      pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cu128
+      pip3 install torch --index-url https://download.pytorch.org/whl/cu128
+      pip3 install torchvision --index-url https://download.pytorch.org/whl/cu128 --no-deps
   fi
 else
   printf "Failed to install pytorch"

--- a/.github/unittest/linux_libs/scripts_jumanji/install.sh
+++ b/.github/unittest/linux_libs/scripts_jumanji/install.sh
@@ -25,18 +25,22 @@ fi
 # submodules
 git submodule sync && git submodule update --init --recursive
 
-printf "Installing PyTorch with cu128"
+printf "Installing PyTorch and torchvision with cu128"
 if [[ "$TORCH_VERSION" == "nightly" ]]; then
   if [ "${CU_VERSION:-}" == cpu ] ; then
-      pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu -U
+      pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu -U
+      pip3 install --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cpu -U --no-deps
   else
-      pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128 -U
+      pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128 -U
+      pip3 install --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cu128 -U --no-deps
   fi
 elif [[ "$TORCH_VERSION" == "stable" ]]; then
     if [ "${CU_VERSION:-}" == cpu ] ; then
-      pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+      pip3 install torch --index-url https://download.pytorch.org/whl/cpu
+      pip3 install torchvision --index-url https://download.pytorch.org/whl/cpu --no-deps
   else
-      pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cu128
+      pip3 install torch --index-url https://download.pytorch.org/whl/cu128
+      pip3 install torchvision --index-url https://download.pytorch.org/whl/cu128 --no-deps
   fi
 else
   printf "Failed to install pytorch"

--- a/.github/unittest/linux_libs/scripts_libero/install.sh
+++ b/.github/unittest/linux_libs/scripts_libero/install.sh
@@ -74,6 +74,7 @@ libero_dir="${root_dir}/libero-src"
 rm -rf "${libero_dir}"
 git clone --depth 1 https://github.com/Lifelong-Robot-Learning/LIBERO.git "${libero_dir}"
 
+# robosuite 1.4.0 calls the pre-3.10 mj_fullM signature.
 uv_pip_install \
   "bddl==1.0.1" \
   easydict \
@@ -81,6 +82,7 @@ uv_pip_install \
   h5py \
   imageio \
   matplotlib \
+  "mujoco<3.10.0" \
   "numpy<2" \
   opencv-python \
   "robosuite==1.4.0" \

--- a/torchrl/envs/custom/chess.py
+++ b/torchrl/envs/custom/chess.py
@@ -22,6 +22,8 @@ from torchrl.envs import EnvBase
 from torchrl.envs.common import _EnvPostInit
 from torchrl.envs.utils import _classproperty
 
+_has_torchvision = importlib.util.find_spec("torchvision") is not None
+
 
 class _ChessMeta(_EnvPostInit):
     def __call__(cls, *args, **kwargs):
@@ -333,7 +335,7 @@ class ChessEnv(EnvBase, metaclass=_ChessMeta):
                 raise ImportError(
                     "Please install cairosvg to use this environment with pixel rendering."
                 )
-            if importlib.util.find_spec("torchvision") is None:
+            if not _has_torchvision:
                 raise ImportError(
                     "Please install torchvision to use this environment with pixel rendering."
                 )
@@ -466,19 +468,19 @@ class ChessEnv(EnvBase, metaclass=_ChessMeta):
     @classmethod
     def _get_tensor_image(cls, board):
         try:
-            from PIL import Image
-
             svg = board._repr_svg_()
             # Convert SVG to PNG using cairosvg
             png_data = io.BytesIO()
             cls._cairosvg.svg2png(bytestring=svg.encode("utf-8"), write_to=png_data)
             png_data.seek(0)
-            # Open the PNG image using Pillow
-            img = Image.open(png_data)
-            img = cls._torchvision.transforms.functional.pil_to_tensor(img)
+            # Decode the PNG bytes directly into a CHW tensor.
+            img = cls._torchvision.io.decode_image(
+                torch.frombuffer(png_data.getbuffer(), dtype=torch.uint8),
+                mode=cls._torchvision.io.ImageReadMode.RGB,
+            )
         except ImportError:
             raise ImportError(
-                "Chess rendering requires cairosvg, PIL and torchvision to be installed."
+                "Chess rendering requires cairosvg and torchvision to be installed."
             )
         return img
 

--- a/torchrl/envs/libs/jumanji.py
+++ b/torchrl/envs/libs/jumanji.py
@@ -14,6 +14,7 @@ from torchrl.envs.common import _EnvPostInit
 from torchrl.envs.utils import _classproperty
 
 _has_jumanji = importlib.util.find_spec("jumanji") is not None
+_has_torchvision = importlib.util.find_spec("torchvision") is not None
 
 from torchrl.data.tensor_specs import (
     Bounded,
@@ -352,6 +353,17 @@ class JumanjiWrapper(GymLikeEnv, metaclass=_JumanjiMakeRender):
             raise ImportError("jumanji version must be >= 1.0.0")
         return jumanji
 
+    _torchvision_lib = None
+
+    @_classproperty
+    def _torchvision(cls):
+        tv = cls._torchvision_lib
+        if tv is None:
+            import torchvision
+
+            tv = cls._torchvision_lib = torchvision
+        return tv
+
     def __init__(
         self,
         env: jumanji.env.Environment = None,  # noqa: F821
@@ -579,14 +591,17 @@ class JumanjiWrapper(GymLikeEnv, metaclass=_JumanjiMakeRender):
         import jax.numpy as jnp
         import jumanji
 
+        if not _has_torchvision:
+            raise ImportError(
+                "Rendering with Jumanji requires torchvision to be installed."
+            )
+
         try:
             import matplotlib
             import matplotlib.pyplot as plt
-            import PIL
-            import torchvision.transforms.v2.functional
         except ImportError as err:
             raise ImportError(
-                "Rendering with Jumanji requires torchvision, matplotlib and PIL to be installed."
+                "Rendering with Jumanji requires matplotlib to be installed."
             ) from err
 
         if matplotlib_backend is not None:
@@ -615,15 +630,17 @@ class JumanjiWrapper(GymLikeEnv, metaclass=_JumanjiMakeRender):
             self._env.render(state, **kwargs)
             plt.savefig(buf, format="png")
             buf.seek(0)
-            # Load the image into a PIL object.
-            img = PIL.Image.open(buf)
-            img_array = torchvision.transforms.v2.functional.pil_to_tensor(img)
+            # Decode the PNG bytes directly into a CHW tensor.
+            img_array = self._torchvision.io.decode_image(
+                torch.frombuffer(buf.getbuffer(), dtype=torch.uint8),
+                mode=self._torchvision.io.ImageReadMode.RGB,
+            )
             if not isinteractive:
                 plt.ioff()
             plt.close()
             if not as_numpy:
-                return img_array[:3]
-            return img_array[:3].numpy().copy()
+                return img_array
+            return img_array.numpy().copy()
         finally:
             jumanji.environments.is_notebook = is_notebook
 


### PR DESCRIPTION
## Summary
- install torch first, then install torchvision with `--no-deps` in chess and Jumanji CI jobs to avoid resolver failures from stale nightly wheel metadata
- keep rendering on the tensor image path by decoding PNG bytes with `torchvision.io.decode_image`
- remove PIL-based image conversion from chess and Jumanji rendering
- pin Libero CI to `mujoco<3.10.0` for robosuite 1.4.0 compatibility with the `mj_fullM` binding

## Tests
- `python -m compileall -q torchrl/envs/custom/chess.py torchrl/envs/libs/jumanji.py`
- `bash -n .github/unittest/linux_libs/scripts_chess/install.sh .github/unittest/linux_libs/scripts_jumanji/install.sh`
- `bash -n .github/unittest/linux_libs/scripts_libero/install.sh .github/unittest/linux_libs/scripts_libero/run_test.sh`
- `python -m pip install --dry-run --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128 --platform manylinux_2_28_x86_64 --platform manylinux_2_27_x86_64 --platform manylinux_2_24_x86_64 --platform manylinux_2_17_x86_64 --platform manylinux2014_x86_64 --python-version 3.10 --implementation cp --abi cp310 --only-binary=:all:`
- `python -m pip install --dry-run --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cu128 --no-deps --platform manylinux_2_28_x86_64 --platform manylinux_2_27_x86_64 --platform manylinux_2_24_x86_64 --platform manylinux_2_17_x86_64 --platform manylinux2014_x86_64 --python-version 3.10 --implementation cp --abi cp310 --only-binary=:all:`
- `uv pip install --dry-run --target /tmp/rl-libero-dryrun --python-version 3.10 --python-platform x86_64-manylinux_2_28 "bddl==1.0.1" easydict "gym==0.25.2" h5py imageio matplotlib "mujoco<3.10.0" "numpy<2" opencv-python "robosuite==1.4.0" termcolor tqdm`
