### PR TITLE
[BugFix] Fix VLA preprocessing benchmark dispatch

### DIFF
--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -137,13 +137,35 @@ jobs:
             python -c "import torchrl._torchrl as ext; assert hasattr(ext, 'CudaSumSegmentTreeFp32')"
           fi
 
+          # The PR workflow compares against the base SHA. If the base
+          # checkout cannot repeatedly execute this benchmark, skip it in both
+          # legs so the remaining benchmark suite still compares like-for-like.
+          if ! python - <<'PY'
+          import torch
+          from torchrl.data.vla import OpenVLAImagePreprocessor
+
+          preprocessor = OpenVLAImagePreprocessor(size=32, backend="torchvision")
+          images = torch.zeros(1, 3, 32, 32, dtype=torch.uint8)
+          preprocessor(images)
+          preprocessor(images)
+          PY
+          then
+            echo "Skipping VLA preprocessing benchmarks because the baseline cannot run them."
+            echo "TORCHRL_BENCHMARK_IGNORE=test_vla_preprocessing_benchmark.py" >> "${GITHUB_ENV}"
+            export TORCHRL_BENCHMARK_IGNORE=test_vla_preprocessing_benchmark.py
+          fi
+
           REPO_ROOT="$(pwd)"
           cd "${REPO_ROOT}/benchmarks"
           export TORCHDYNAMO_INLINE_INBUILT_NN_MODULES=1
           export COMPOSITE_LP_AGGREGATE=0
           export TD_GET_DEFAULTS_TO_NONE=1
           export PYTHONPATH="${BENCHMARK_SITE_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
-          python -m pytest -vvv --rank 0 --timeout=240 --benchmark-only --benchmark-json "${BASELINE_JSON}" --ignore test_llm.py .
+          benchmark_ignore_args=()
+          if [ -n "${TORCHRL_BENCHMARK_IGNORE:-}" ]; then
+            benchmark_ignore_args=(--ignore "${TORCHRL_BENCHMARK_IGNORE}")
+          fi
+          python -m pytest -vvv --rank 0 --timeout=240 --benchmark-only --benchmark-json "${BASELINE_JSON}" --ignore test_llm.py "${benchmark_ignore_args[@]}" .
       - name: Run PR benchmarks
         run: |
           set -euxo pipefail
@@ -170,7 +192,11 @@ jobs:
           export COMPOSITE_LP_AGGREGATE=0
           export TD_GET_DEFAULTS_TO_NONE=1
           export PYTHONPATH="${BENCHMARK_SITE_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
-          python -m pytest -vvv --rank 0 --timeout=240 --benchmark-only --benchmark-json "${CONTENDER_JSON}" --ignore test_llm.py .
+          benchmark_ignore_args=()
+          if [ -n "${TORCHRL_BENCHMARK_IGNORE:-}" ]; then
+            benchmark_ignore_args=(--ignore "${TORCHRL_BENCHMARK_IGNORE}")
+          fi
+          python -m pytest -vvv --rank 0 --timeout=240 --benchmark-only --benchmark-json "${CONTENDER_JSON}" --ignore test_llm.py "${benchmark_ignore_args[@]}" .
       - name: Upload PR benchmark results
         if: ${{ always() }}
         run: |

--- a/test/data/test_vla.py
+++ b/test/data/test_vla.py
@@ -291,8 +291,9 @@ class TestOpenVLAImagePreprocessor:
         tv = OpenVLAImagePreprocessor(size=32, backend="torchvision", center_crop=False)
         ref = pil(images)
         fast = tv(images)
-        assert fast.shape == ref.shape == torch.Size([2, 3, 32, 32])
-        assert fast.dtype == ref.dtype == torch.uint8
+        fast_again = tv(images)
+        assert fast.shape == fast_again.shape == ref.shape == torch.Size([2, 3, 32, 32])
+        assert fast.dtype == fast_again.dtype == ref.dtype == torch.uint8
         assert (fast.float() - ref.float()).abs().mean() < 25.0
 
     @pytest.mark.skipif(not _has_pil, reason="Pillow not found")

--- a/torchrl/data/vla/preprocessing.py
+++ b/torchrl/data/vla/preprocessing.py
@@ -23,15 +23,10 @@ _CROP_AREA_SCALE = 0.9
 _CROP_LINEAR_SCALE = _CROP_AREA_SCALE**0.5
 
 
-@implement_for("torchvision")
+@implement_for("torchvision", None, "0.20")
 def _torchvision_jpeg_roundtrip(
     images: torch.Tensor, jpeg_quality: int, device: torch.device
 ) -> torch.Tensor:
-    raise ModuleNotFoundError("torchvision is required for JPEG preprocessing.")
-
-
-@_torchvision_jpeg_roundtrip.register(from_version=None, to_version="0.20")
-def _(images: torch.Tensor, jpeg_quality: int, device: torch.device) -> torch.Tensor:
     from torchvision.io import decode_jpeg, encode_jpeg, ImageReadMode
 
     encoded = [
@@ -43,8 +38,10 @@ def _(images: torch.Tensor, jpeg_quality: int, device: torch.device) -> torch.Te
     return torch.stack(decoded, 0)
 
 
-@_torchvision_jpeg_roundtrip.register(from_version="0.20")
-def _(images: torch.Tensor, jpeg_quality: int, device: torch.device) -> torch.Tensor:
+@implement_for("torchvision", "0.20")
+def _torchvision_jpeg_roundtrip(  # noqa: F811
+    images: torch.Tensor, jpeg_quality: int, device: torch.device
+) -> torch.Tensor:
     from torchvision.io import decode_jpeg, encode_jpeg, ImageReadMode
 
     encoded = encode_jpeg(list(images.unbind(0)), quality=jpeg_quality)


### PR DESCRIPTION
## Summary
- switch the OpenVLA torchvision JPEG dispatch back to direct `implement_for` overloads so repeated calls keep the selected implementation
- add a regression check that invokes the torchvision preprocessor twice
- make the PR benchmark workflow skip the VLA preprocessing benchmark in both baseline and contender legs if the base SHA cannot run it, preserving like-for-like comparisons for the rest of the suite

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/benchmarks_pr.yml"); puts "benchmarks_pr.yml yaml ok"'`
- `PYTHONPATH=/private/tmp/rl-fix-vla-benchmarks pytest -q test/data/test_vla.py --tb=short`
- `PYTHONPATH=/private/tmp/rl-fix-vla-benchmarks pytest -q benchmarks/test_vla_preprocessing_benchmark.py -k 'torchvision and 224-224-1' --benchmark-only --tb=short`
