### PR TITLE
[Quality] Add docstring argument checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,13 @@ repos:
       files: ^docs/.*\.rst$
       pass_filenames: true
       description: Ensure Sphinx section underline lengths match section titles.
+    - id: check-docstring-args
+      name: Check docstring argument descriptions
+      entry: ./scripts/check-docstring-args
+      language: script
+      files: ^torchrl/.*\.py$
+      pass_filenames: true
+      description: Ensure Args and Keyword Args sections document signature arguments.
     - id: forbid-version-file
       name: Forbid committing _version.py
       entry: bash -c 'git diff --cached --diff-filter=ACM --name-only | grep -qE "(^|/)_version\.py$" && { echo "ERROR - _version.py is auto-generated and must not be committed"; exit 1; } || exit 0'

--- a/scripts/check-docstring-args
+++ b/scripts/check-docstring-args
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Check that Google-style docstrings document signature arguments."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import configparser
+import fnmatch
+import inspect
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ARGUMENT_SECTION_NAMES = {
+    "args",
+    "arguments",
+    "parameters",
+    "keyword args",
+    "keyword arguments",
+    "keyword parameters",
+}
+IGNORED_ARGUMENT_NAMES = {"self", "cls"}
+SECTION_RE = re.compile(r"^(?P<indent>\s*)(?P<name>[A-Za-z][A-Za-z ]+):\s*$")
+ARGUMENT_RE = re.compile(
+    r"^(?P<indent>\s{2,})(?P<names>(?:\*\*|\*)?`?[A-Za-z_]\w*`?"
+    r"(?:\s*,\s*(?:\*\*|\*)?`?[A-Za-z_]\w*`?)*)"
+    r"(?:\s*\([^)]*\))?\s*:"
+)
+
+
+@dataclass(frozen=True)
+class MissingArgument:
+    """A missing argument description found in a docstring."""
+
+    path: Path
+    line: int
+    qualified_name: str
+    names: tuple[str, ...]
+
+
+def _iter_python_files(paths: list[Path]) -> list[Path]:
+    if not paths:
+        paths = [Path("torchrl")]
+
+    files: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            files.extend(sorted(path.rglob("*.py")))
+        elif path.suffix == ".py":
+            files.append(path)
+    return files
+
+
+def _load_ignore_decorator_patterns(config_path: Path) -> tuple[str, ...]:
+    if not config_path.exists():
+        return ()
+
+    config = configparser.ConfigParser()
+    config.read(config_path)
+    if not config.has_option("pydocstyle", "ignore-decorators"):
+        return ()
+
+    raw_patterns = config.get("pydocstyle", "ignore-decorators")
+    return tuple(
+        pattern.strip()
+        for pattern in raw_patterns.splitlines()
+        if pattern.strip() and not pattern.lstrip().startswith(";")
+    )
+
+
+def _decorator_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Call):
+        return _decorator_name(node.func)
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _decorator_name(node.value)
+        if parent is None:
+            return node.attr
+        return f"{parent}.{node.attr}"
+    return None
+
+
+def _is_public_name(name: str) -> bool:
+    return not name.startswith("_") or (name.startswith("__") and name.endswith("__"))
+
+
+def _has_ignored_decorator(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ignore_decorators: tuple[str, ...],
+) -> bool:
+    if not ignore_decorators:
+        return False
+
+    for decorator in node.decorator_list:
+        name = _decorator_name(decorator)
+        if name is None:
+            continue
+        short_name = name.rsplit(".", 1)[-1]
+        if any(
+            fnmatch.fnmatchcase(name, pattern)
+            or fnmatch.fnmatchcase(short_name, pattern)
+            for pattern in ignore_decorators
+        ):
+            return True
+    return False
+
+
+def _signature_argument_names(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> list[str]:
+    names = [
+        arg.arg
+        for arg in (
+            *node.args.posonlyargs,
+            *node.args.args,
+        )
+    ]
+    names.extend(arg.arg for arg in node.args.kwonlyargs)
+    return [name for name in names if name not in IGNORED_ARGUMENT_NAMES]
+
+
+def _iter_documented_arguments(docstring: str) -> set[str] | None:
+    """Return documented args, or ``None`` if no argument section is present."""
+    documented: set[str] = set()
+    in_argument_section = False
+    found_argument_section = False
+
+    for line in inspect.cleandoc(docstring).splitlines():
+        section_match = SECTION_RE.match(line)
+        if section_match and not section_match.group("indent"):
+            section_name = section_match.group("name").strip().lower()
+            in_argument_section = section_name in ARGUMENT_SECTION_NAMES
+            found_argument_section = found_argument_section or in_argument_section
+            continue
+
+        if not in_argument_section:
+            continue
+
+        argument_match = ARGUMENT_RE.match(line)
+        if argument_match is None:
+            continue
+
+        for name in argument_match.group("names").split(","):
+            documented.add(name.strip().strip("`").lstrip("*"))
+
+    if not found_argument_section:
+        return None
+    return documented
+
+
+class DocstringArgumentVisitor(ast.NodeVisitor):
+    """AST visitor that records missing argument documentation."""
+
+    def __init__(
+        self,
+        path: Path,
+        ignore_decorators: tuple[str, ...],
+    ) -> None:
+        self.path = path
+        self.ignore_decorators = ignore_decorators
+        self.qualified_name: list[str] = []
+        self.missing_arguments: list[MissingArgument] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.qualified_name.append(node.name)
+        self.generic_visit(node)
+        self.qualified_name.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        if not _is_public_name(node.name):
+            return
+
+        if _has_ignored_decorator(node, self.ignore_decorators):
+            return
+
+        docstring = ast.get_docstring(node, clean=False)
+        if docstring is not None:
+            documented_arguments = _iter_documented_arguments(docstring)
+            if documented_arguments is not None:
+                signature_arguments = _signature_argument_names(node)
+                missing = tuple(
+                    name
+                    for name in signature_arguments
+                    if name not in documented_arguments
+                )
+                if missing:
+                    qualified_name = ".".join((*self.qualified_name, node.name))
+                    self.missing_arguments.append(
+                        MissingArgument(
+                            path=self.path,
+                            line=node.lineno,
+                            qualified_name=qualified_name,
+                            names=missing,
+                        )
+                    )
+
+        self.qualified_name.append(node.name)
+        self.generic_visit(node)
+        self.qualified_name.pop()
+
+
+def _check_file(
+    path: Path,
+    ignore_decorators: tuple[str, ...],
+) -> list[MissingArgument]:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as err:
+        print(f"{path}: failed to read as UTF-8: {err}", file=sys.stderr)
+        return [MissingArgument(path=path, line=1, qualified_name="<file>", names=())]
+
+    try:
+        module = ast.parse(source, filename=str(path))
+    except SyntaxError as err:
+        print(
+            f"{path}:{err.lineno}: failed to parse Python: {err.msg}", file=sys.stderr
+        )
+        return [
+            MissingArgument(
+                path=path,
+                line=err.lineno or 1,
+                qualified_name="<file>",
+                names=(),
+            )
+        ]
+
+    visitor = DocstringArgumentVisitor(
+        path=path,
+        ignore_decorators=ignore_decorators,
+    )
+    visitor.visit(module)
+    return visitor.missing_arguments
+
+
+def _format_missing_argument(missing: MissingArgument) -> str:
+    names = ", ".join(missing.names)
+    plural = "s" if len(missing.names) > 1 else ""
+    return (
+        f"{missing.path}:{missing.line}: {missing.qualified_name}: "
+        f"missing docstring description{plural} for argument{plural}: {names}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="Python files or directories to check. Defaults to torchrl/.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("setup.cfg"),
+        help="Config file to read pydocstyle ignore-decorators from.",
+    )
+    args = parser.parse_args()
+
+    ignore_decorators = _load_ignore_decorator_patterns(args.config)
+    missing_arguments: list[MissingArgument] = []
+    for path in _iter_python_files(args.paths):
+        missing_arguments.extend(_check_file(path, ignore_decorators))
+
+    for missing_argument in missing_arguments:
+        print(_format_missing_argument(missing_argument))
+
+    return 1 if missing_arguments else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ extend-select = B901, C401, C408, C409, TOR0, TOR1, TOR2
 match = .*\.py
 ;match_dir = ^(?!(.circlecli|test)).*
 convention = google
-add-ignore = D100, D104, D105, D107, D102
+add-ignore = D100, D104, D105, D107, D102, D417
 ignore-decorators =
     test_*
 ;    test/*.py

--- a/test/test_docstring_args_checker.py
+++ b/test/test_docstring_args_checker.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_CHECKER = _ROOT / "scripts" / "check-docstring-args"
+
+
+def _run_checker(tmp_path: Path, source: str) -> subprocess.CompletedProcess[str]:
+    path = tmp_path / "sample.py"
+    path.write_text(source, encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, str(_CHECKER), str(path)],
+        cwd=_ROOT,
+        text=True,
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+
+def test_args_section_documents_positional_args(tmp_path: Path):
+    result = _run_checker(
+        tmp_path,
+        '''
+def helper(first, second):
+    """Do work.
+
+    Args:
+        first: The first value.
+        second: The second value.
+    """
+''',
+    )
+
+    assert result.returncode == 0, result.stdout
+    assert result.stdout == ""
+
+
+def test_keyword_args_section_documents_keyword_only_args(tmp_path: Path):
+    result = _run_checker(
+        tmp_path,
+        '''
+def register_coeff_buffer(name, value, *, persistent=True, target=True):
+    """Register a coefficient buffer.
+
+    Args:
+        name: The buffer name.
+        value: The buffer value.
+
+    Keyword Args:
+        persistent: Whether the buffer is persistent.
+        target: Whether the buffer is mirrored on the target module.
+    """
+''',
+    )
+
+    assert result.returncode == 0, result.stdout
+    assert result.stdout == ""
+
+
+def test_mixed_args_and_keyword_args_sections(tmp_path: Path):
+    result = _run_checker(
+        tmp_path,
+        '''
+def helper(first, second, *, mode="strict", retries=0):
+    """Do work.
+
+    Args:
+        first: The first value.
+        second: The second value.
+
+    Keyword Args:
+        mode: The execution mode.
+        retries: The retry count.
+    """
+''',
+    )
+
+    assert result.returncode == 0, result.stdout
+    assert result.stdout == ""
+
+
+def test_missing_args_still_fail(tmp_path: Path):
+    result = _run_checker(
+        tmp_path,
+        '''
+def helper(first, second, *, mode="strict", retries=0):
+    """Do work.
+
+    Args:
+        first: The first value.
+
+    Keyword Args:
+        mode: The execution mode.
+    """
+''',
+    )
+
+    assert result.returncode == 1
+    assert "sample.py:2: helper" in result.stdout
+    assert "second" in result.stdout
+    assert "retries" in result.stdout
+    assert "mode" not in result.stdout
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/torchrl/data/datasets/common.py
+++ b/torchrl/data/datasets/common.py
@@ -70,11 +70,33 @@ class BaseDatasetExperienceReplay(TensorDictReplayBuffer):
 
         The data transform must be unitary (work on a single sample of the dataset).
 
-        Args and Keyword Args are forwarded to :meth:`~tensordict.TensorDictBase.map`.
-
         The dataset can subsequently be deleted using :meth:`delete`.
 
+        Args:
+            fn (Callable[[TensorDictBase], TensorDictBase]): transform to apply to each sample.
+            dim (int, optional): dimension along which the dataset is mapped. Defaults to ``0``.
+            num_workers (int, optional): number of worker processes to use.
+                Defaults to ``None``.
+
         Keyword Args:
+            chunksize (int, optional): chunk size forwarded to
+                :meth:`~tensordict.TensorDictBase.map`.
+            num_chunks (int, optional): number of chunks forwarded to
+                :meth:`~tensordict.TensorDictBase.map`.
+            pool (multiprocessing.Pool, optional): worker pool forwarded to
+                :meth:`~tensordict.TensorDictBase.map`.
+            generator (torch.Generator, optional): random generator forwarded to
+                :meth:`~tensordict.TensorDictBase.map`.
+            max_tasks_per_child (int, optional): maximum number of tasks per child
+                process forwarded to :meth:`~tensordict.TensorDictBase.map`.
+            worker_threads (int, optional): number of threads per worker forwarded to
+                :meth:`~tensordict.TensorDictBase.map`. Defaults to ``1``.
+            index_with_generator (bool, optional): whether to index with the generator
+                when mapping. Defaults to ``False``.
+            pbar (bool, optional): whether to display a progress bar. Defaults to
+                ``False``.
+            mp_start_method (str, optional): multiprocessing start method forwarded to
+                :meth:`~tensordict.TensorDictBase.map`.
             dest (path or equivalent): a path to the location of the new dataset.
             num_frames (int, optional): if provided, only the first `num_frames` will be
                 transformed. This is useful to debug the transform at first.

--- a/torchrl/data/llm/history.py
+++ b/torchrl/data/llm/history.py
@@ -848,6 +848,7 @@ class History(TensorClass["nocast"]):
         Args:
             text (str | list[str]): The chat template to invert.
             chat_template_name (str, optional): The name of the chat template to use.
+            chat_template (str, optional): The chat template string to use.
             tokenizer (transformers.AutoTokenizer | transformers.AutoProcessor, optional): The tokenizer to use.
 
         Returns:

--- a/torchrl/data/llm/reward.py
+++ b/torchrl/data/llm/reward.py
@@ -85,6 +85,8 @@ class PairwiseDataset:
             from_disk (bool, optional): if ``True``, :func:`datasets.load_from_disk`
                 will be used. Otherwise, :func:`datasets.load_dataset` will be used.
                 Defaults to ``False``.
+            num_workers (int, optional): number of workers to use when processing
+                the dataset. Defaults to ``None``.
 
         Returns: a :class:`PairwiseDataset` instance containing a memory-mapped
             version of the required dataset.

--- a/torchrl/data/map/tdstorage.py
+++ b/torchrl/data/map/tdstorage.py
@@ -204,6 +204,8 @@ class TensorDictMap(
                 storage. Defaults to a custom value for each known storage type (stack for
                 :class:`~torchrl.data.ListStorage`, identity for :class:`~torchrl.data.TensorStorage`
                 subtypes and others).
+            write_fn (callable, optional): a function used to write values into
+                the storage. Defaults to ``None``.
             consolidated (bool, optional): whether to consolidate the storage in a single storage tensor.
                 Defaults to ``False``.
 

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -1966,6 +1966,7 @@ class TensorDictReplayBuffer(ReplayBuffer):
                 by the sampler.
             return_info (bool): whether to return info. If True, the result
                 is a tuple (data, info). If False, the result is the data.
+            include_info (bool, optional): deprecated alias for ``return_info``.
 
         Returns:
             A tensordict containing a batch of data selected in the replay buffer.

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -3524,6 +3524,8 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
                 ``done_spec``, an exception is raised.
                 Truncated keys can be set through ``env.add_truncated_keys``.
                 Defaults to ``False``.
+            out (TensorDict, optional): output tensordict where rollout data is
+                written. Defaults to ``None``.
             trust_policy (bool, optional): if ``True``, a non-TensorDictModule policy will be trusted to be
                 assumed to be compatible with the collector. This defaults to ``True`` for CudaGraphModules
                 and ``False`` otherwise.

--- a/torchrl/envs/llm/envs.py
+++ b/torchrl/envs/llm/envs.py
@@ -347,6 +347,8 @@ class LLMEnv(EnvBase):
 
             primers (Composite | None, optional): The primers to use for each key in the dataloader.
                 Defaults to ``None`` (inferred automatically from the first batch of data).
+            example_data (Any, optional): example batch used to infer primer specs.
+                Defaults to ``None``.
             stack_method (Callable[[Any], Any] | Literal["as_nested_tensor", "as_padded_tensor"], optional): The
                 method to use for stacking the data. Defaults to ``None``.
             repeats (int, optional): How many times the same sample needs to appear successively. This can be useful in

--- a/torchrl/envs/llm/libs/mlgym.py
+++ b/torchrl/envs/llm/libs/mlgym.py
@@ -761,7 +761,7 @@ def get_args(
     """Parse command line arguments and return a ScriptArguments object.
 
     Args:
-        args: Optional list of arguments to parse. If not provided, uses sys.argv.
+        task: Task identifier used to build the ML Gym task config path.
     """
     import mlgym.environment.registration  # noqa
     from mlgym import CONFIG_DIR

--- a/torchrl/modules/llm/backends/vllm/vllm_async.py
+++ b/torchrl/modules/llm/backends/vllm/vllm_async.py
@@ -218,6 +218,7 @@ class _AsyncLLMEngine:
             prompt_token_ids: Alternative to prompts - token IDs for generation.
             use_tqdm: Whether to show progress bar (not used in async engine).
             lora_request: LoRA request for adapter-based generation.
+            prompt_adapter_request: prompt adapter request forwarded to vLLM.
             guided_options_request: Guided decoding options.
             timeout_seconds: Timeout for generation in seconds.
 

--- a/torchrl/modules/models/multiagent.py
+++ b/torchrl/modules/models/multiagent.py
@@ -868,6 +868,7 @@ class Mixer(nn.Module):
 
         Args:
             chosen_action_value: Tensor of shape [*B, n_agents]
+            state: State tensor used by the mixer.
 
         Returns:
             chosen_action_value: Tensor of shape [*B]

--- a/torchrl/record/loggers/wandb.py
+++ b/torchrl/record/loggers/wandb.py
@@ -308,6 +308,9 @@ class WandbLogger(Logger):
             step: Optional step value for all metrics.
             keys_sep: Separator used to flatten nested TensorDict keys into strings.
                 Defaults to "/". Only used for TensorDict inputs.
+            override_global_step: If ``True``, bypasses per-group step injection
+                and forwards ``step`` to wandb's global ``step`` argument.
+                Defaults to ``False``.
 
         Returns:
             The converted metrics dictionary (with tensors converted to Python types).


### PR DESCRIPTION
## Summary
- add a local docstring-argument checker that accepts both Args and Keyword Args sections
- disable pydocstyle D417 so the local checker owns argument coverage
- audit keyword-only public signatures and fill missing docstring argument entries

## Tests
- ./scripts/check-docstring-args
- pytest test/test_docstring_args_checker.py -q
- uvx --from pydocstyle==6.3.0 pydocstyle torchrl
- uvx --from black==22.3.0 black --check scripts/check-docstring-args test/test_docstring_args_checker.py