### PR TITLE
[Feature] Replay buffer consume-after-sample support

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -454,6 +454,7 @@ Replay Buffer and Storage Configurations
 
     ReplayBufferConfig
     TensorDictReplayBufferConfig
+    ConsumingSamplerConfig
     RandomSamplerConfig
     SamplerWithoutReplacementConfig
     PrioritizedSamplerConfig

--- a/docs/source/reference/data_replaybuffers.rst
+++ b/docs/source/reference/data_replaybuffers.rst
@@ -82,6 +82,40 @@ storage entries.
     >>> rb.write_all(data)
     >>> assert (rb[:] == data).all()
 
+Consuming replay buffers
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Replay buffers can consume items as they are sampled by passing
+``consume_after_n_samples``. This is useful in online loops where a collector
+keeps writing new data while the trainer should avoid reusing old samples after
+they have contributed to an update.
+
+    >>> import torch
+    >>> from torchrl.data import ListStorage, ReplayBuffer
+    >>> rb = ReplayBuffer(
+    ...     storage=ListStorage(8),
+    ...     batch_size=2,
+    ...     consume_after_n_samples=1,
+    ... )
+    >>> rb.extend([torch.tensor(i) for i in range(3)])
+    tensor([0, 1, 2])
+    >>> batch = rb.sample()
+    >>> assert len(batch) == 2
+    >>> assert len(rb) == 1
+    >>> rb.extend([torch.tensor(3), torch.tensor(4)])
+    tensor([3, 4])
+    >>> assert len(rb) == 3
+
+The consumed entries remain in physical storage until they are overwritten, but
+they are removed from the sampleable set and are not returned by future calls to
+:meth:`~torchrl.data.ReplayBuffer.sample`. New writes reuse consumed slots before
+falling back to the writer's normal cursor, so consumed data behaves as freed
+capacity without scanning the full storage on every write. This mode supports
+1-dimensional ``ListStorage``,
+``TensorStorage``, ``LazyTensorStorage`` and ``LazyMemmapStorage`` with uniform
+random sampling. Prefetching, prioritized replay and multidimensional storages
+are rejected explicitly.
+
 TED-format conversion
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/reference/data_samplers.rst
+++ b/docs/source/reference/data_samplers.rst
@@ -11,6 +11,7 @@ Samplers control how data is retrieved from the replay buffer storage.
 
     PrioritizedSampler
     PrioritizedSliceSampler
+    ConsumingSampler
     RandomSampler
     Sampler
     SamplerEnsemble

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -22,6 +22,7 @@ from torchrl.data import (
     TensorDictReplayBuffer,
 )
 from torchrl.data.replay_buffers.samplers import (
+    ConsumingSampler,
     PrioritizedSampler,
     RandomSampler,
     SamplerWithoutReplacement,
@@ -599,6 +600,395 @@ def test_shared_storage_prioritized_sampler():
     assert rb1._sampler._sum_tree.query(0, 10) == 10
     assert rb1._sampler._sum_tree.query(0, 50) == 50
     assert rb1._sampler._sum_tree.query(0, 70) == 50
+
+
+class TestReplayBufferConsumption:
+    def test_replay_buffer_consume_after_one_list_storage(self):
+        torch.manual_seed(0)
+        data = [torch.tensor(i) for i in range(5)]
+        rb = ReplayBuffer(
+            storage=ListStorage(5),
+            batch_size=3,
+            consume_after_n_samples=1,
+        )
+        rb.extend(data)
+
+        sample, info = rb.sample(return_info=True)
+
+        assert len(sample) == 3
+        assert len(rb) == 2
+        assert set(sample.tolist()) == set(info["index"].tolist())
+
+        sample = rb.sample()
+        assert len(sample) == 2
+        assert len(rb) == 0
+        with pytest.raises(RuntimeError, match="Cannot sample from an empty storage"):
+            rb.sample()
+
+    def test_replay_buffer_consume_after_two_list_storage(self):
+        torch.manual_seed(0)
+        data = [torch.tensor(i) for i in range(4)]
+        rb = ReplayBuffer(
+            storage=ListStorage(4),
+            batch_size=4,
+            consume_after_n_samples=2,
+        )
+        rb.extend(data)
+
+        first = rb.sample()
+        assert set(first.tolist()) == set(range(4))
+        assert len(rb) == 4
+
+        second = rb.sample()
+        assert set(second.tolist()) == set(range(4))
+        assert len(rb) == 0
+
+    def test_replay_buffer_consume_add_extend_after_exhaustion(self):
+        torch.manual_seed(0)
+        rb = ReplayBuffer(
+            storage=ListStorage(10),
+            consume_after_n_samples=1,
+        )
+        rb.extend([torch.tensor(0), torch.tensor(1)])
+        assert set(rb.sample(2).tolist()) == {0, 1}
+        assert len(rb) == 0
+
+        rb.add(torch.tensor(2))
+        assert len(rb) == 1
+        assert rb.sample(1).item() == 2
+        assert len(rb) == 0
+
+        rb.extend([torch.tensor(3), torch.tensor(4), torch.tensor(5)])
+        assert len(rb) == 3
+        assert set(rb.sample(10).tolist()) == {3, 4, 5}
+        assert len(rb) == 0
+
+    def test_replay_buffer_consume_interleaved_writes(self):
+        torch.manual_seed(0)
+        rb = ReplayBuffer(
+            storage=ListStorage(10),
+            consume_after_n_samples=1,
+        )
+        rb.extend([torch.tensor(0), torch.tensor(1), torch.tensor(2)])
+        first = set(rb.sample(2).tolist())
+        assert len(first) == 2
+        assert len(rb) == 1
+
+        rb.extend([torch.tensor(3), torch.tensor(4)])
+        second = set(rb.sample(10).tolist())
+        assert second == set(range(5)) - first
+        assert len(rb) == 0
+
+    def test_replay_buffer_consume_reuses_consumed_slots_before_cursor(self):
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(100),
+            consume_after_n_samples=1,
+        )
+        rb.extend(torch.arange(100))
+        rb._writer._cursor = 99
+
+        consumed_index = torch.tensor([10, 20, 30, 40])
+        rb._sampler._sample_count[consumed_index] = 1
+        rb._sampler._live_mask[consumed_index] = False
+        rb._sampler._append_free_indices(consumed_index)
+
+        write_index = rb.extend(torch.arange(1000, 1004))
+
+        assert write_index.tolist() == consumed_index.tolist()
+        assert rb._writer._cursor == 99
+        assert len(rb) == 100
+        assert rb.storage.get(consumed_index).tolist() == [1000, 1001, 1002, 1003]
+
+    def test_replay_buffer_consume_reuses_slots_then_cursor(self):
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(100),
+            consume_after_n_samples=1,
+        )
+        rb.extend(torch.arange(100))
+        rb._writer._cursor = 99
+
+        consumed_index = torch.tensor([10, 20])
+        rb._sampler._sample_count[consumed_index] = 1
+        rb._sampler._live_mask[consumed_index] = False
+        rb._sampler._append_free_indices(consumed_index)
+
+        write_index = rb.extend(torch.arange(1000, 1004))
+
+        assert write_index.tolist() == [10, 20, 99, 0]
+        assert rb._writer._cursor == 1
+        assert len(rb) == 100
+        assert rb.storage.get(torch.tensor([10, 20, 99, 0])).tolist() == [
+            1000,
+            1001,
+            1002,
+            1003,
+        ]
+
+    def test_replay_buffer_consume_reuses_slots_then_wraparound_cursor(self):
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(100),
+            consume_after_n_samples=1,
+        )
+        rb.extend(torch.arange(100))
+        rb._writer._cursor = 99
+
+        consumed_index = torch.tensor([10, 20, 30, 40])
+        rb._sampler._sample_count[consumed_index] = 1
+        rb._sampler._live_mask[consumed_index] = False
+        rb._sampler._append_free_indices(consumed_index)
+
+        write_index = rb.extend(torch.arange(1000, 1008))
+
+        expected_index = torch.tensor([10, 20, 30, 40, 99, 0, 1, 2])
+        assert write_index.tolist() == expected_index.tolist()
+        assert rb._writer._cursor == 3
+        assert len(rb) == 100
+        assert rb.storage.get(expected_index).tolist() == list(range(1000, 1008))
+
+    def test_replay_buffer_consume_skips_reused_slots_after_wraparound(self):
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(100),
+            consume_after_n_samples=1,
+        )
+        rb.extend(torch.arange(100))
+        rb._writer._cursor = 0
+
+        consumed_index = torch.tensor([10, 20, 30, 40])
+        rb._sampler._sample_count[consumed_index] = 1
+        rb._sampler._live_mask[consumed_index] = False
+        rb._sampler._append_free_indices(consumed_index)
+
+        write_index = rb.extend(torch.arange(1000, 1015))
+
+        expected_index = torch.tensor(
+            [10, 20, 30, 40, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11]
+        )
+        assert write_index.tolist() == expected_index.tolist()
+        assert rb._writer._cursor == 12
+        assert len(rb) == 100
+        assert rb.storage.get(expected_index).tolist() == list(range(1000, 1015))
+
+    def test_replay_buffer_consume_skips_reused_slots_when_advancing_cursor(self):
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(8),
+            consume_after_n_samples=1,
+        )
+        rb.extend(torch.arange(8))
+        rb._writer._cursor = 0
+
+        consumed_index = torch.tensor([1, 2])
+        rb._sampler._sample_count[consumed_index] = 1
+        rb._sampler._live_mask[consumed_index] = False
+        rb._sampler._append_free_indices(consumed_index)
+
+        write_index = rb.extend(torch.arange(100, 106))
+
+        assert write_index.tolist() == [1, 2, 0, 3, 4, 5]
+        assert rb._writer._cursor == 6
+        assert rb.storage.get(write_index).tolist() == [100, 101, 102, 103, 104, 105]
+
+    def test_replay_buffer_consume_reuse_and_append_keeps_tensor_storage_len(self):
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(10),
+            consume_after_n_samples=1,
+        )
+        rb.extend(torch.arange(5))
+
+        consumed_index = torch.tensor([1, 2])
+        rb._sampler._sample_count[consumed_index] = 1
+        rb._sampler._live_mask[consumed_index] = False
+        rb._sampler._append_free_indices(consumed_index)
+
+        write_index = rb.extend(torch.arange(100, 104))
+
+        assert write_index.tolist() == [1, 2, 5, 6]
+        assert len(rb.storage) == 7
+        assert len(rb) == 7
+        assert rb.storage.get(write_index).tolist() == [100, 101, 102, 103]
+
+    def test_replay_buffer_consume_iterates_until_exhausted(self):
+        torch.manual_seed(0)
+        rb = ReplayBuffer(
+            storage=ListStorage(5),
+            batch_size=2,
+            sampler=ConsumingSampler(),
+        )
+        rb.extend([torch.tensor(i) for i in range(5)])
+
+        samples = []
+        for i, batch in enumerate(rb):
+            if i == 5:
+                raise RuntimeError("Iteration didn't terminate")
+            samples.extend(batch.tolist())
+
+        assert set(samples) == set(range(5))
+        assert len(samples) == 5
+        assert len(rb) == 0
+
+    def test_replay_buffer_consume_state_dict_roundtrip(self):
+        torch.manual_seed(0)
+        data = [torch.tensor(i) for i in range(5)]
+        rb = ReplayBuffer(
+            storage=ListStorage(5),
+            batch_size=5,
+            consume_after_n_samples=2,
+        )
+        rb.extend(data)
+        assert set(rb.sample().tolist()) == set(range(5))
+        assert len(rb) == 5
+
+        rb2 = ReplayBuffer(
+            storage=ListStorage(5),
+            batch_size=5,
+            consume_after_n_samples=2,
+        )
+        rb2.load_state_dict(rb.state_dict())
+
+        assert len(rb2) == 5
+        assert set(rb2.sample().tolist()) == set(range(5))
+        assert len(rb2) == 0
+
+    def test_replay_buffer_consume_state_dict_preserves_free_slots(self):
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(5),
+            batch_size=2,
+            consume_after_n_samples=1,
+        )
+        rb.extend(torch.arange(5))
+        consumed = rb.sample(return_info=True)[1]["index"]
+
+        rb2 = ReplayBuffer(
+            storage=LazyTensorStorage(5),
+            batch_size=2,
+            consume_after_n_samples=1,
+        )
+        rb2.load_state_dict(rb.state_dict())
+
+        write_index = rb2.extend(torch.arange(100, 102))
+
+        assert write_index.tolist() == consumed.tolist()
+        assert rb2.storage.get(write_index).tolist() == [100, 101]
+
+    def test_replay_buffer_consume_dumps_loads(self, tmpdir):
+        torch.manual_seed(0)
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(5),
+            batch_size=5,
+            consume_after_n_samples=2,
+        )
+        rb.extend(torch.arange(5))
+        assert set(rb.sample().tolist()) == set(range(5))
+
+        rb2 = ReplayBuffer(
+            storage=LazyTensorStorage(5),
+            batch_size=5,
+            consume_after_n_samples=2,
+        )
+        rb2.extend(torch.zeros(5, dtype=torch.long))
+        rb.dumps(tmpdir)
+        rb2.loads(tmpdir)
+
+        assert len(rb2) == 5
+        assert set(rb2.sample().tolist()) == set(range(5))
+        assert len(rb2) == 0
+
+    def test_replay_buffer_consume_tensor_storage_prepopulated(self):
+        torch.manual_seed(0)
+        rb = ReplayBuffer(
+            storage=TensorStorage(torch.arange(5)),
+            batch_size=3,
+            consume_after_n_samples=1,
+        )
+
+        assert len(rb) == 5
+        assert len(rb.sample()) == 3
+        assert len(rb) == 2
+        assert len(rb.sample()) == 2
+        assert len(rb) == 0
+
+    def test_tensordict_replay_buffer_consume_lazy_tensor_storage(self):
+        torch.manual_seed(0)
+        rb = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(5),
+            consume_after_n_samples=1,
+        )
+        rb.extend(TensorDict({"a": torch.arange(4)}, [4]))
+
+        sample = rb.sample(2)
+        assert sample["index"].numel() == 2
+        assert sample["index"].unique().numel() == 2
+        assert len(rb) == 2
+
+        sample = rb.sample(10)
+        assert sample["index"].numel() == 2
+        assert len(rb) == 0
+
+    def test_tensordict_replay_buffer_consume_lazy_memmap_storage(self, tmpdir):
+        torch.manual_seed(0)
+        rb = TensorDictReplayBuffer(
+            storage=LazyMemmapStorage(5, scratch_dir=tmpdir),
+            consume_after_n_samples=1,
+        )
+        rb.extend(TensorDict({"a": torch.arange(4)}, [4]))
+
+        assert rb.sample(2)["index"].numel() == 2
+        assert len(rb) == 2
+        assert rb.sample(10)["index"].numel() == 2
+        assert len(rb) == 0
+
+    def test_replay_buffer_consume_unsupported_modes(self):
+        with pytest.raises(ValueError, match="Prefetching is not supported"):
+            ReplayBuffer(
+                storage=ListStorage(10),
+                batch_size=2,
+                consume_after_n_samples=1,
+                prefetch=1,
+            )
+
+        with pytest.raises(ValueError, match="Prefetching is not supported"):
+            ReplayBuffer(
+                storage=ListStorage(10),
+                sampler=ConsumingSampler(),
+                batch_size=2,
+                prefetch=1,
+            )
+
+        with pytest.raises(ValueError, match="only supports the default RandomSampler"):
+            ReplayBuffer(
+                storage=ListStorage(10),
+                sampler=SamplerWithoutReplacement(),
+                consume_after_n_samples=1,
+            )
+
+        try:
+            prioritized_sampler = PrioritizedSampler(10, 1.0, 1.0)
+        except RuntimeError as err:
+            if "SumSegmentTree" not in str(err):
+                raise
+        else:
+            with pytest.raises(ValueError, match="only supports the default RandomSampler"):
+                ReplayBuffer(
+                    storage=ListStorage(10),
+                    sampler=prioritized_sampler,
+                    consume_after_n_samples=1,
+                )
+
+        with pytest.raises(ValueError, match="1-dimensional storages"):
+            ReplayBuffer(
+                storage=LazyTensorStorage(10, ndim=2),
+                sampler=ConsumingSampler(),
+            )
+
+    def test_replay_buffer_consume_requires_write_at_writer(self):
+        class WriterWithoutWriteAt(RoundRobinWriter):
+            write_at = None
+
+        with pytest.raises(TypeError, match="requires a writer with a callable"):
+            ReplayBuffer(
+                storage=ListStorage(10),
+                writer=WriterWithoutWriteAt(),
+                consume_after_n_samples=1,
+            )
 
 
 @pytest.mark.parametrize("size", [10, 15, 20])

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -966,7 +966,9 @@ class TestReplayBufferConsumption:
             if "SumSegmentTree" not in str(err):
                 raise
         else:
-            with pytest.raises(ValueError, match="only supports the default RandomSampler"):
+            with pytest.raises(
+                ValueError, match="only supports the default RandomSampler"
+            ):
                 ReplayBuffer(
                     storage=ListStorage(10),
                     sampler=prioritized_sampler,

--- a/torchrl/data/__init__.py
+++ b/torchrl/data/__init__.py
@@ -34,6 +34,7 @@ from .postprocs import DensifyReward, MultiStep
 from .replay_buffers import (
     CompressedListStorage,
     CompressedListStorageCheckpointer,
+    ConsumingSampler,
     Flat2TED,
     FlatStorageCheckpointer,
     H5Combine,
@@ -124,6 +125,7 @@ __all__ = [
     "CompressedListStorageCheckpointer",
     "ConstantKLController",
     "ContentBase",
+    "ConsumingSampler",
     "DEVICE_TYPING",
     "DensifyReward",
     "Flat2TED",

--- a/torchrl/data/replay_buffers/__init__.py
+++ b/torchrl/data/replay_buffers/__init__.py
@@ -25,6 +25,7 @@ from .replay_buffers import (
     TensorDictReplayBuffer,
 )
 from .samplers import (
+    ConsumingSampler,
     PrioritizedSampler,
     PrioritizedSliceSampler,
     RandomSampler,
@@ -75,6 +76,7 @@ __all__ = [
     "ReplayBufferEnsemble",
     "TensorDictPrioritizedReplayBuffer",
     "TensorDictReplayBuffer",
+    "ConsumingSampler",
     "PrioritizedSampler",
     "PrioritizedSliceSampler",
     "RandomSampler",

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -40,10 +40,11 @@ from tensordict import (
 from tensordict.nn.utils import _set_dispatch_td_nn_modules
 from tensordict.utils import expand_as_right, expand_right
 from torch import Tensor
-from torch.utils._pytree import tree_map
+from torch.utils._pytree import tree_leaves, tree_map
 
 from torchrl._utils import accept_remote_rref_udf_invocation, rl_warnings
 from torchrl.data.replay_buffers.samplers import (
+    ConsumingSampler,
     PrioritizedSampler,
     RandomSampler,
     Sampler,
@@ -55,6 +56,7 @@ from torchrl.data.replay_buffers.storages import (
     ListStorage,
     Storage,
     StorageEnsemble,
+    TensorStorage,
 )
 from torchrl.data.replay_buffers.utils import (
     _is_int,
@@ -187,6 +189,11 @@ class ReplayBuffer:
             Defaults to ``None`` (global default generator).
 
             .. warning:: As of now, the generator has no effect on the transforms.
+        consume_after_n_samples (int, optional): if provided, sampled items are
+            removed from the sampleable set after they have been returned this
+            many times. The default value of ``None`` keeps the standard replay
+            buffer behavior. Passing ``1`` makes each item available for a
+            single sample before it is consumed.
         shared (bool, optional): whether the buffer will be shared using multiprocessing or not.
             Defaults to ``False``.
         compilable (bool, optional): whether the writer is compilable.
@@ -286,10 +293,22 @@ class ReplayBuffer:
         | Callable[[], StorageCheckpointerBase]  # noqa: F821
         | None = None,  # noqa: F821
         generator: torch.Generator | None = None,
+        consume_after_n_samples: int | None = None,
         shared: bool = False,
         compilable: bool | None = None,
         delayed_init: bool | None = None,
     ) -> None:
+        if consume_after_n_samples is not None:
+            if isinstance(consume_after_n_samples, bool) or not isinstance(
+                consume_after_n_samples, INT_CLASSES
+            ):
+                raise TypeError("consume_after_n_samples must be a positive integer.")
+            if consume_after_n_samples < 1:
+                raise ValueError(
+                    "consume_after_n_samples must be a positive integer."
+                )
+            consume_after_n_samples = int(consume_after_n_samples)
+
         self._delayed_init = delayed_init
         self._initialized = False
 
@@ -303,6 +322,8 @@ class ReplayBuffer:
         self._init_checkpointer = checkpointer
         self._init_generator = generator
         self._init_compilable = compilable
+        self._init_consume_after_n_samples = consume_after_n_samples
+        self._consume_after_n_samples = consume_after_n_samples
 
         if transform is not None and transform_factory is not None:
             raise TypeError(
@@ -331,6 +352,10 @@ class ReplayBuffer:
                 "with multithreaded sampling. "
                 "When using prefetch, the batch-size must be specified in "
                 "advance. "
+            )
+        if consume_after_n_samples is not None and prefetch:
+            raise ValueError(
+                "Prefetching is not supported when consume_after_n_samples is set."
             )
 
         if dim_extend is not None and dim_extend < 0:
@@ -374,10 +399,13 @@ class ReplayBuffer:
 
             # Initialize sampler
             self._sampler = self._maybe_make_sampler(self._init_sampler)
+            self._maybe_make_consuming_sampler()
+            self._validate_consuming_sampler()
 
             # Initialize writer
             self._writer = self._maybe_make_writer(self._init_writer)
             self._writer.register_storage(self._storage)
+            self._validate_consuming_writer()
 
             # Initialize collate function
             self._get_collate_fn(self._init_collate_fn)
@@ -423,6 +451,7 @@ class ReplayBuffer:
             self._init_checkpointer = None
             self._init_generator = None
             self._init_compilable = None
+            self._init_consume_after_n_samples = None
         except Exception as e:
             self._initialized = False
             raise e
@@ -486,6 +515,53 @@ class ReplayBuffer:
                 "sampler must be either a Sampler or a callable returning a sampler instance."
             )
         return sampler
+
+    def _maybe_make_consuming_sampler(self) -> None:
+        consume_after_n_samples = self._init_consume_after_n_samples
+        if consume_after_n_samples is None:
+            if isinstance(self._sampler, ConsumingSampler):
+                self._consume_after_n_samples = self._sampler.max_sample_count
+            return
+
+        if isinstance(self._sampler, ConsumingSampler):
+            if self._sampler.max_sample_count != consume_after_n_samples:
+                raise ValueError(
+                    "consume_after_n_samples conflicts with the provided "
+                    "ConsumingSampler.max_sample_count."
+                )
+            return
+        if not isinstance(self._sampler, RandomSampler):
+            raise ValueError(
+                "consume_after_n_samples only supports the default RandomSampler "
+                "or an explicit ConsumingSampler. Prioritized, slice and "
+                "without-replacement samplers are not supported."
+            )
+        self._sampler = ConsumingSampler(max_sample_count=consume_after_n_samples)
+
+    def _validate_consuming_sampler(self) -> None:
+        if not isinstance(self._sampler, ConsumingSampler):
+            return
+        if self._prefetch:
+            raise ValueError("Prefetching is not supported with ConsumingSampler.")
+        if self._storage.ndim != 1:
+            raise ValueError(
+                "ConsumingSampler only supports 1-dimensional storages. "
+                f"Got storage.ndim={self._storage.ndim}."
+            )
+        if not isinstance(self._storage, (ListStorage, TensorStorage)):
+            raise TypeError(
+                "ConsumingSampler only supports ListStorage, TensorStorage, "
+                "LazyTensorStorage and LazyMemmapStorage."
+            )
+
+    def _validate_consuming_writer(self) -> None:
+        if not isinstance(self._sampler, ConsumingSampler):
+            return
+        if not callable(getattr(self._writer, "write_at", None)):
+            raise TypeError(
+                "ConsumingSampler requires a writer with a callable "
+                "write_at(index, data) method."
+            )
 
     def _maybe_make_writer(
         self, writer: Writer | Callable[[], Writer] | None
@@ -608,6 +684,7 @@ class ReplayBuffer:
         """
         prev_storage = self._storage
         self._storage = storage
+        self._validate_consuming_sampler()
         self._get_collate_fn(collate_fn)
 
         return prev_storage
@@ -625,11 +702,18 @@ class ReplayBuffer:
         """Sets a new sampler in the replay buffer and returns the previous sampler."""
         prev_sampler = self._sampler
         self._sampler = sampler
+        if isinstance(sampler, ConsumingSampler):
+            self._consume_after_n_samples = sampler.max_sample_count
+        elif isinstance(prev_sampler, ConsumingSampler):
+            self._consume_after_n_samples = None
+        self._validate_consuming_sampler()
         return prev_sampler
 
     @_maybe_delay_init
     def __len__(self) -> int:
         with self._replay_lock:
+            if isinstance(self._sampler, ConsumingSampler):
+                return self._sampler._num_sampleable(self._storage)
             return len(self._storage)
 
     def _getattr(self, attr):
@@ -833,6 +917,7 @@ class ReplayBuffer:
             "_writer": self._writer.state_dict(),
             "_transforms": self._transform.state_dict(),
             "_batch_size": self._batch_size,
+            "_consume_after_n_samples": self._consume_after_n_samples,
             "_rng": (self._rng.get_state().clone(), str(self._rng.device))
             if self._rng is not None
             else None,
@@ -845,6 +930,7 @@ class ReplayBuffer:
         self._writer.load_state_dict(state_dict["_writer"])
         self._transform.load_state_dict(state_dict["_transforms"])
         self._batch_size = state_dict["_batch_size"]
+        self._consume_after_n_samples = state_dict.get("_consume_after_n_samples")
         rng = state_dict.get("_rng")
         if rng is not None:
             state, device = rng
@@ -907,7 +993,13 @@ class ReplayBuffer:
         if transform_sd:
             torch.save(transform_sd, path / "transform.t")
         with open(path / "buffer_metadata.json", "w") as file:
-            json.dump({"batch_size": self._batch_size}, file)
+            json.dump(
+                {
+                    "batch_size": self._batch_size,
+                    "consume_after_n_samples": self._consume_after_n_samples,
+                },
+                file,
+            )
 
     @_maybe_delay_init
     def loads(self, path):
@@ -936,6 +1028,7 @@ class ReplayBuffer:
         with open(path / "buffer_metadata.json") as file:
             metadata = json.load(file)
         self._batch_size = metadata["batch_size"]
+        self._consume_after_n_samples = metadata.get("consume_after_n_samples")
 
     @_maybe_delay_init
     def save(self, *args, **kwargs):
@@ -1010,8 +1103,53 @@ class ReplayBuffer:
 
         return self._add(data)
 
+    def _is_consuming(self) -> bool:
+        return isinstance(self._sampler, ConsumingSampler)
+
+    def _get_batch_size(self, data) -> int:
+        if is_tensor_collection(data) or isinstance(data, torch.Tensor):
+            return len(data)
+        if isinstance(data, list):
+            return len(data)
+        return len(tree_leaves(data)[0])
+
+    def _cat_write_indices(self, first, second):
+        if _is_int(first):
+            first = torch.as_tensor([first], dtype=torch.long)
+        if _is_int(second):
+            second = torch.as_tensor([second], dtype=torch.long)
+        if isinstance(first, torch.Tensor) and isinstance(second, torch.Tensor):
+            return torch.cat([first.reshape(-1), second.to(first.device).reshape(-1)])
+        raise RuntimeError(
+            "Cannot concatenate write indices with different structures in "
+            "a consuming replay buffer."
+        )
+
+    def _cursor_write_indices(
+        self, data, batch_size: int, skip_index: torch.Tensor
+    ) -> torch.Tensor:
+        device = data.device if hasattr(data, "device") else skip_index.device
+        max_size = self._storage._max_size_along_dim0(batched_data=data)
+        skip = set(skip_index.cpu().tolist())
+        cursor = self._writer._cursor
+        write_indices = []
+        scanned = 0
+        while len(write_indices) < batch_size:
+            if cursor not in skip or scanned >= max_size:
+                write_indices.append(cursor)
+            cursor = (cursor + 1) % max_size
+            scanned += 1
+        self._writer._cursor = cursor
+        return torch.as_tensor(write_indices, dtype=torch.long, device=device)
+
     def _add(self, data):
         with self._replay_lock, self._write_lock:
+            if self._is_consuming():
+                consumed_index = self._sampler._pop_consumed_indices(self._storage, 1)
+                if consumed_index.numel():
+                    index = self._writer.write_at(int(consumed_index.item()), data)
+                    self._sampler.add(index)
+                    return index
             index = self._writer.add(data)
             self._sampler.add(index)
         return index
@@ -1022,6 +1160,23 @@ class ReplayBuffer:
         with self._replay_lock if not is_comp else nc, self._write_lock if not is_comp else nc:
             if self.dim_extend > 0:
                 data = self._transpose(data)
+            if self._is_consuming():
+                batch_size = self._get_batch_size(data)
+                consumed_index = self._sampler._pop_consumed_indices(
+                    self._storage, batch_size
+                )
+                consumed_batch_size = consumed_index.numel()
+                if consumed_batch_size:
+                    if consumed_batch_size < batch_size:
+                        cursor_index = self._cursor_write_indices(
+                            data, batch_size - consumed_batch_size, consumed_index
+                        )
+                        index = self._cat_write_indices(consumed_index, cursor_index)
+                    else:
+                        index = consumed_index
+                    index = self._writer.write_at(index, data)
+                    self._sampler.extend(index)
+                    return index
             index = self._writer.extend(data)
             self._sampler.extend(index)
         return index
@@ -1725,6 +1880,11 @@ class TensorDictReplayBuffer(ReplayBuffer):
             Defaults to ``None`` (global default generator).
 
             .. warning:: As of now, the generator has no effect on the transforms.
+        consume_after_n_samples (int, optional): if provided, sampled items are
+            removed from the sampleable set after they have been returned this
+            many times. The default value of ``None`` keeps the standard replay
+            buffer behavior. Passing ``1`` makes each item available for a
+            single sample before it is consumed.
         shared (bool, optional): whether the buffer will be shared using multiprocessing or not.
             Defaults to ``False``.
         compilable (bool, optional): whether the writer is compilable.

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -304,9 +304,7 @@ class ReplayBuffer:
             ):
                 raise TypeError("consume_after_n_samples must be a positive integer.")
             if consume_after_n_samples < 1:
-                raise ValueError(
-                    "consume_after_n_samples must be a positive integer."
-                )
+                raise ValueError("consume_after_n_samples must be a positive integer.")
             consume_after_n_samples = int(consume_after_n_samples)
 
         self._delayed_init = delayed_init

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -319,9 +319,7 @@ class ConsumingSampler(Sampler):
             old_sample_count = self._sample_count
             old_live_mask = self._live_mask
             old_free_indices = self._free_indices
-            self._sample_count = torch.zeros(
-                capacity, dtype=torch.long, device=device
-            )
+            self._sample_count = torch.zeros(capacity, dtype=torch.long, device=device)
             self._live_mask = torch.zeros(capacity, dtype=torch.bool, device=device)
             if old_sample_count is not None and old_live_mask is not None:
                 copy_len = min(old_sample_count.numel(), capacity)
@@ -371,9 +369,8 @@ class ConsumingSampler(Sampler):
             self._free_indices = None
             self._free_head = 0
             return
-        consumed_mask = (
-            ~self._live_mask[: self._known_storage_len]
-            & (self._sample_count[: self._known_storage_len] >= self.max_sample_count)
+        consumed_mask = ~self._live_mask[: self._known_storage_len] & (
+            self._sample_count[: self._known_storage_len] >= self.max_sample_count
         )
         self._free_indices = torch.nonzero(consumed_mask, as_tuple=False).flatten()
         self._free_head = 0

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -218,6 +218,354 @@ class RandomSampler(Sampler):
         return
 
 
+class ConsumingSampler(Sampler):
+    """A random sampler that consumes entries after they have been sampled.
+
+    ``ConsumingSampler`` tracks how many times each storage index has been
+    returned by :meth:`sample`. Once an index has been returned
+    ``max_sample_count`` times, it is removed from the set of sampleable
+    indices until that slot is overwritten by the replay-buffer writer. When
+    used through :class:`~torchrl.data.ReplayBuffer`, consumed indices are kept
+    in a free-list so writes can reuse those slots before advancing the normal
+    writer cursor.
+
+    Args:
+        max_sample_count (int, optional): number of returned samples after which
+            an item is consumed. Defaults to ``1``.
+
+    Examples:
+        >>> import torch
+        >>>
+        >>> from torchrl.data import ConsumingSampler, ListStorage, ReplayBuffer
+        >>> rb = ReplayBuffer(
+        ...     storage=ListStorage(10),
+        ...     sampler=ConsumingSampler(),
+        ...     batch_size=3,
+        ... )
+        >>> rb.extend([torch.tensor(i) for i in range(4)])
+        tensor([0, 1, 2, 3])
+        >>> sample = rb.sample()
+        >>> len(sample)
+        3
+        >>> len(rb)
+        1
+
+    .. note::
+        ``ConsumingSampler`` only supports 1-dimensional storages and uniform
+        random sampling without replacement within each sampled batch.
+        Prefetching and prioritized replay are not supported.
+    """
+
+    def __init__(self, max_sample_count: int = 1):
+        if isinstance(max_sample_count, bool) or not isinstance(
+            max_sample_count, (int, np.integer)
+        ):
+            raise TypeError("max_sample_count must be a positive integer.")
+        if max_sample_count < 1:
+            raise ValueError("max_sample_count must be a positive integer.")
+        self.max_sample_count = int(max_sample_count)
+        self._sample_count = None
+        self._live_mask = None
+        self._known_storage_len = 0
+        self._free_indices = None
+        self._free_head = 0
+        self._ran_out = False
+        self._remaining_batches = 0
+
+    @staticmethod
+    def _storage_device(storage: Storage | None):
+        if storage is None:
+            return None
+        device = getattr(storage, "device", None)
+        if device == "auto":
+            return None
+        return device
+
+    def _ensure_state(
+        self,
+        storage: Storage | None = None,
+        *,
+        min_capacity: int = 0,
+    ) -> None:
+        if storage is not None:
+            if storage.ndim != 1:
+                raise ValueError(
+                    f"{type(self).__name__} only supports 1-dimensional storages, "
+                    f"got storage.ndim={storage.ndim}."
+                )
+            storage_len = len(storage)
+            min_capacity = max(min_capacity, storage_len)
+            device = self._storage_device(storage)
+        else:
+            storage_len = self._known_storage_len
+            device = (
+                self._sample_count.device if self._sample_count is not None else None
+            )
+
+        current_capacity = (
+            0 if self._sample_count is None else self._sample_count.numel()
+        )
+        capacity = max(current_capacity, int(min_capacity))
+
+        needs_init = self._sample_count is None or self._live_mask is None
+        needs_resize = current_capacity < capacity
+        needs_device = (
+            not needs_init
+            and device is not None
+            and self._sample_count.device != torch.device(device)
+        )
+
+        if needs_init or needs_resize or needs_device:
+            old_sample_count = self._sample_count
+            old_live_mask = self._live_mask
+            old_free_indices = self._free_indices
+            self._sample_count = torch.zeros(
+                capacity, dtype=torch.long, device=device
+            )
+            self._live_mask = torch.zeros(capacity, dtype=torch.bool, device=device)
+            if old_sample_count is not None and old_live_mask is not None:
+                copy_len = min(old_sample_count.numel(), capacity)
+                self._sample_count[:copy_len] = old_sample_count[:copy_len].to(
+                    self._sample_count.device
+                )
+                self._live_mask[:copy_len] = old_live_mask[:copy_len].to(
+                    self._live_mask.device
+                )
+            if old_free_indices is not None:
+                self._free_indices = old_free_indices.to(self._sample_count.device)
+
+        if storage is not None:
+            if storage_len > self._known_storage_len:
+                self._sample_count[self._known_storage_len : storage_len] = 0
+                self._live_mask[self._known_storage_len : storage_len] = True
+            elif storage_len < self._known_storage_len:
+                self._sample_count[storage_len : self._known_storage_len] = 0
+                self._live_mask[storage_len : self._known_storage_len] = False
+            self._known_storage_len = storage_len
+
+        if self._live_mask is not None and self._sample_count is not None:
+            self._live_mask &= self._sample_count < self.max_sample_count
+
+    def _compact_free_indices(self) -> None:
+        if self._free_indices is None:
+            self._free_head = 0
+            return
+        if self._free_head:
+            self._free_indices = self._free_indices[self._free_head :]
+            self._free_head = 0
+        if not self._free_indices.numel():
+            self._free_indices = None
+
+    def _append_free_indices(self, index: torch.Tensor) -> None:
+        if index.numel() == 0:
+            return
+        index = index.to(self._sample_count.device, dtype=torch.long).reshape(-1)
+        self._compact_free_indices()
+        if self._free_indices is None:
+            self._free_indices = index.clone()
+        else:
+            self._free_indices = torch.cat([self._free_indices, index])
+
+    def _rebuild_free_indices(self) -> None:
+        if self._live_mask is None or self._sample_count is None:
+            self._free_indices = None
+            self._free_head = 0
+            return
+        consumed_mask = (
+            ~self._live_mask[: self._known_storage_len]
+            & (self._sample_count[: self._known_storage_len] >= self.max_sample_count)
+        )
+        self._free_indices = torch.nonzero(consumed_mask, as_tuple=False).flatten()
+        self._free_head = 0
+        if not self._free_indices.numel():
+            self._free_indices = None
+
+    def _index_to_tensor(self, index: int | torch.Tensor | tuple) -> torch.Tensor:
+        if isinstance(index, tuple):
+            raise ValueError(
+                f"{type(self).__name__} only supports flat 1-dimensional indices."
+            )
+        if _is_int(index):
+            min_capacity = int(index) + 1
+        else:
+            index = torch.as_tensor(index, dtype=torch.long)
+            min_capacity = int(index.max().item()) + 1 if index.numel() else 0
+        self._ensure_state(min_capacity=min_capacity)
+        if _is_int(index):
+            return torch.as_tensor(
+                [int(index)], dtype=torch.long, device=self._sample_count.device
+            )
+        return torch.as_tensor(
+            index, dtype=torch.long, device=self._sample_count.device
+        ).reshape(-1)
+
+    def _mark_indices_live(self, index: int | torch.Tensor | tuple) -> None:
+        index = self._index_to_tensor(index)
+        if index.numel() == 0:
+            return
+        self._sample_count[index] = 0
+        self._live_mask[index] = True
+        self._known_storage_len = max(
+            self._known_storage_len, int(index.max().item()) + 1
+        )
+        self._ran_out = False
+
+    def add(self, index: int) -> None:
+        self._mark_indices_live(index)
+
+    def extend(self, index: torch.Tensor) -> None:
+        self._mark_indices_live(index)
+
+    def mark_update(
+        self, index: int | torch.Tensor | tuple, *, storage: Storage | None = None
+    ) -> None:
+        if storage is not None:
+            min_capacity = len(storage)
+            if not _is_int(index) and not isinstance(index, tuple):
+                index_tensor = torch.as_tensor(index)
+                if index_tensor.numel():
+                    min_capacity = max(
+                        min_capacity, int(index_tensor.reshape(-1).max().item()) + 1
+                    )
+            elif _is_int(index):
+                min_capacity = max(min_capacity, int(index) + 1)
+            self._ensure_state(storage, min_capacity=min_capacity)
+        self._mark_indices_live(index)
+
+    def _num_sampleable(self, storage: Storage | None = None) -> int:
+        self._ensure_state(storage)
+        if self._live_mask is None:
+            return 0
+        return int(self._live_mask[: self._known_storage_len].sum().item())
+
+    def _pop_consumed_indices(
+        self, storage: Storage | None = None, max_count: int | None = None
+    ) -> torch.Tensor:
+        self._ensure_state(storage)
+        if (
+            self._live_mask is None
+            or self._sample_count is None
+            or self._free_indices is None
+        ):
+            return torch.zeros(0, dtype=torch.long)
+
+        popped = []
+        while self._free_head < self._free_indices.numel():
+            if max_count is not None and len(popped) >= max_count:
+                break
+            candidate = self._free_indices[self._free_head]
+            self._free_head += 1
+            if candidate >= self._known_storage_len:
+                continue
+            if self._live_mask[candidate]:
+                continue
+            if self._sample_count[candidate] < self.max_sample_count:
+                continue
+            popped.append(candidate)
+
+        if self._free_head >= self._free_indices.numel():
+            self._free_indices = None
+            self._free_head = 0
+
+        if not popped:
+            device = self._sample_count.device
+            return torch.zeros(0, dtype=torch.long, device=device)
+        return torch.stack(popped)
+
+    def _update_remaining_batches(self, batch_size: int, storage: Storage) -> None:
+        num_sampleable = self._num_sampleable(storage)
+        self._remaining_batches = -(num_sampleable // -batch_size)
+        self._ran_out = num_sampleable == 0
+
+    def sample(self, storage: Storage, batch_size: int) -> tuple[torch.Tensor, dict]:
+        self._ensure_state(storage)
+        if len(storage) == 0 or self._num_sampleable(storage) == 0:
+            self._ran_out = True
+            self._remaining_batches = 0
+            raise RuntimeError(_EMPTY_STORAGE_ERROR)
+
+        live_indices = torch.nonzero(
+            self._live_mask[: self._known_storage_len], as_tuple=False
+        ).flatten()
+        sample_size = min(batch_size, live_indices.numel())
+        permutation = torch.randperm(
+            live_indices.numel(),
+            generator=self._rng,
+            device=live_indices.device,
+        )[:sample_size]
+        index = live_indices[permutation]
+
+        self._sample_count[index] += 1
+        self._live_mask[index] = self._sample_count[index] < self.max_sample_count
+        newly_consumed = index[~self._live_mask[index]]
+        self._append_free_indices(newly_consumed)
+        self._update_remaining_batches(batch_size, storage)
+        return index, {}
+
+    @property
+    def ran_out(self):
+        return self._ran_out
+
+    @ran_out.setter
+    def ran_out(self, value):
+        self._ran_out = value
+
+    def _empty(self):
+        self._sample_count = None
+        self._live_mask = None
+        self._known_storage_len = 0
+        self._free_indices = None
+        self._free_head = 0
+        self._ran_out = False
+        self._remaining_batches = 0
+
+    def dumps(self, path):
+        path = Path(path)
+        path.mkdir(exist_ok=True)
+        torch.save(self.state_dict(), path / "consuming_sampler.pt")
+
+    def loads(self, path):
+        self.load_state_dict(torch.load(Path(path) / "consuming_sampler.pt"))
+
+    def state_dict(self) -> dict[str, Any]:
+        return OrderedDict(
+            max_sample_count=self.max_sample_count,
+            _sample_count=self._sample_count,
+            _live_mask=self._live_mask,
+            _known_storage_len=self._known_storage_len,
+            _free_indices=None
+            if self._free_indices is None
+            else self._free_indices[self._free_head :],
+            _free_head=0,
+            _ran_out=self._ran_out,
+        )
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        self.max_sample_count = int(state_dict["max_sample_count"])
+        self._sample_count = state_dict["_sample_count"]
+        self._live_mask = state_dict["_live_mask"]
+        self._known_storage_len = int(state_dict["_known_storage_len"])
+        self._free_indices = state_dict.get("_free_indices")
+        self._free_head = int(state_dict.get("_free_head", 0))
+        self._ran_out = bool(state_dict["_ran_out"])
+        if "_free_indices" not in state_dict:
+            self._rebuild_free_indices()
+        if self._live_mask is not None:
+            num_sampleable = int(
+                self._live_mask[: self._known_storage_len].sum().item()
+            )
+            self._remaining_batches = num_sampleable
+        else:
+            self._remaining_batches = 0
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"max_sample_count={self.max_sample_count}, "
+            f"sampleable={self._num_sampleable()})"
+        )
+
+
 class SamplerWithoutReplacement(Sampler):
     """A data-consuming sampler that ensures that the same sample is not present in consecutive batches.
 

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -215,6 +215,36 @@ class RoundRobinWriter(Writer):
         self._mark_update_entities(index)
         return index
 
+    def write_at(self, index: int | torch.Tensor, data: Any) -> int | torch.Tensor:
+        """Writes data at explicit storage indices without moving the cursor."""
+        if _is_int(index):
+            batch_size = 1
+        else:
+            index = torch.as_tensor(index, dtype=torch.long)
+            if hasattr(data, "device") and data.device is not None:
+                index = index.to(data.device)
+            batch_size = index.numel()
+        self._write_count += batch_size
+        self._storage.set(index, data, set_cursor=False)
+        self._update_storage_len_for_write_at(index)
+        index = self._replicate_index(index)
+        self._mark_update_entities(index)
+        return index
+
+    def _update_storage_len_for_write_at(self, index: int | torch.Tensor) -> None:
+        if not hasattr(self._storage, "_len"):
+            return
+        if _is_int(index):
+            max_index = int(index)
+        else:
+            index = torch.as_tensor(index)
+            if index.numel() == 0:
+                return
+            max_index = int(index.max().item())
+        self._storage._len = min(
+            max(len(self._storage), max_index + 1), self._storage.max_size
+        )
+
     def state_dict(self) -> dict[str, Any]:
         return {"_cursor": self._cursor}
 
@@ -357,6 +387,22 @@ class TensorDictRoundRobinWriter(RoundRobinWriter):
         # Other than that, a "flat" (1d) index is ok to write the data
         self._storage.set(index, data)
         index = self._replicate_index(index)
+        self._mark_update_entities(index)
+        return index
+
+    def write_at(self, index: int | torch.Tensor, data: Any) -> int | torch.Tensor:
+        if _is_int(index):
+            batch_size = 1
+            index_tensor = torch.as_tensor(index, device=data.device, dtype=torch.long)
+        else:
+            index_tensor = torch.as_tensor(index, device=data.device, dtype=torch.long)
+            batch_size = index_tensor.numel()
+        self._write_count += batch_size
+        if not is_tensorclass(data):
+            data.set("index", expand_as_right(index_tensor, data))
+        self._storage.set(index_tensor, data, set_cursor=False)
+        self._update_storage_len_for_write_at(index_tensor)
+        index = self._replicate_index(index_tensor)
         self._mark_update_entities(index)
         return index
 

--- a/torchrl/trainers/algorithms/configs/__init__.py
+++ b/torchrl/trainers/algorithms/configs/__init__.py
@@ -31,6 +31,7 @@ from torchrl.trainers.algorithms.configs.collectors import (
 
 from torchrl.trainers.algorithms.configs.common import ConfigBase
 from torchrl.trainers.algorithms.configs.data import (
+    ConsumingSamplerConfig,
     LazyMemmapStorageConfig,
     LazyStackStorageConfig,
     LazyTensorStorageConfig,
@@ -376,6 +377,7 @@ __all__ = [
     "TensorDictReplayBufferConfig",
     "TensorStorageConfig",
     # Samplers
+    "ConsumingSamplerConfig",
     "PrioritizedSamplerConfig",
     "RandomSamplerConfig",
     "SamplerWithoutReplacementConfig",
@@ -636,6 +638,7 @@ def _register_configs():
         group="replay_buffer", name="tensordict", node=TensorDictReplayBufferConfig
     )
     cs.store(group="sampler", name="random", node=RandomSamplerConfig)
+    cs.store(group="sampler", name="consuming", node=ConsumingSamplerConfig)
     cs.store(
         group="sampler",
         name="without_replacement",

--- a/torchrl/trainers/algorithms/configs/data.py
+++ b/torchrl/trainers/algorithms/configs/data.py
@@ -57,6 +57,18 @@ class RandomSamplerConfig(SamplerConfig):
 
 
 @dataclass
+class ConsumingSamplerConfig(SamplerConfig):
+    """Hydra configuration for :class:`~torchrl.data.replay_buffers.ConsumingSampler`.
+
+    Every kwarg accepted by ``ConsumingSampler.__init__`` is exposed as a field
+    here.
+    """
+
+    _target_: str = "torchrl.data.replay_buffers.ConsumingSampler"
+    max_sample_count: int = 1
+
+
+@dataclass
 class WriterEnsembleConfig(WriterConfig):
     """Configuration for ensemble writer that combines multiple writers."""
 
@@ -316,6 +328,7 @@ class TensorDictReplayBufferConfig(ReplayBufferBaseConfig):
     dim_extend: int | None = None
     checkpointer: Any = None
     generator: Any = None
+    consume_after_n_samples: int | None = None
     shared: bool = False
     compilable: bool | None = None
     delayed_init: bool | None = None
@@ -345,6 +358,7 @@ class ReplayBufferConfig(ReplayBufferBaseConfig):
     dim_extend: int | None = None
     checkpointer: Any = None
     generator: Any = None
+    consume_after_n_samples: int | None = None
     shared: bool = False
     compilable: bool | None = None
     delayed_init: bool | None = None


### PR DESCRIPTION
## Summary
- Add opt-in replay-buffer consumption via `consume_after_n_samples` and a public `ConsumingSampler`.
- Keep default replay-buffer behavior unchanged.
- Track per-index sample counts, logical liveness, and a consumed-slot free-list so new writes can reuse consumed slots before falling back to the normal round-robin cursor.

## Details
- Supports 1-D `ListStorage`, `TensorStorage`, `LazyTensorStorage`, and `LazyMemmapStorage`.
- Preserves pre-consumption physical index semantics for `return_info=True`.
- Persists consuming sampler state, including the free-list, through `state_dict`, `load_state_dict`, `dumps`, and `loads`.
- Adds Hydra config parity for replay-buffer `consume_after_n_samples` and `ConsumingSamplerConfig`.
- Documents limitations and a runnable example.
- Explicitly rejects prefetching, prioritized replay, multidimensional storages, and unsupported sampler combinations.

## Cost model
- Non-consuming replay buffers stay on the existing write paths.
- Consuming writes do not scan the full storage to find reusable slots. Sampling appends newly consumed indices to a free-list; writes pop only the entries they reuse, filtering stale free-list entries as they are encountered.
- For an `extend` of size `B` that reuses `F` consumed slots, target-index construction after the free-list pop is `O(B + F)` and therefore `O(B)` because `F <= B`. If stale free-list entries are encountered, the pop additionally costs `O(S)` for the `S` stale entries discarded by that call; those entries are removed once, so this cost is amortized over writes. The cursor portion skips slots already reused by the same call, so a wraparound write does not overwrite freshly written consumed slots.
- `add` remains `O(1)` aside from the explicit indexed write when a consumed slot is reused.
- The main runtime cost relative to the original contiguous cursor path is that mixed free-list/cursor writes become explicit, potentially non-contiguous indexed writes.
- Sampling in consuming mode maintains per-index liveness and builds the live-index set, so sample-time overhead is separate from write-time overhead.

## Test Plan
- `python3 -m py_compile torchrl/data/replay_buffers/samplers.py torchrl/data/replay_buffers/replay_buffers.py torchrl/data/replay_buffers/writers.py test/rb/test_rb_core.py`
- `uv run --no-sync python -m pytest test/rb/test_rb_core.py -k 'consume' -q`
- `uv run --no-sync python -m pytest test/rb/test_rb_core.py test/rb/test_samplers.py -q` *(fails in this local environment because the TorchRL C++ prioritized segment-tree extension is unavailable: `SumSegmentTreeFp32 is not available`)*
