### PR TITLE
[BugFix] Normalize collector replay buffer device metadata

### DIFF
--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -149,6 +149,10 @@ TORCH_VERSION = version.parse(version.parse(torch.__version__).base_version)
 _has_cuda = torch.cuda.is_available()
 
 
+def _clear_tensordict_device(tensordict: TensorDictBase) -> TensorDictBase:
+    return tensordict.clear_device_()
+
+
 @implement_for("torch", "2.5")
 def has_mps():
     return torch.mps.is_available()
@@ -5523,6 +5527,36 @@ class TestCollectorRB:
                 ).all(), steps_counts
                 assert (idsdiff >= 0).all()
 
+    def test_multi_async_replay_buffer_device_metadata(self):
+        probe = CountingEnv()
+        try:
+            policy = RandomPolicy(probe.action_spec)
+        finally:
+            probe.close(raise_if_closed=False)
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(128, device="cpu"),
+            batch_size=4,
+            shared=True,
+        )
+
+        collector = MultiAsyncCollector(
+            [CountingEnv, CountingEnv],
+            policy,
+            replay_buffer=rb,
+            total_frames=32,
+            frames_per_batch=16,
+            postproc=_clear_tensordict_device,
+        )
+        try:
+            for data in collector:
+                assert data is None
+        finally:
+            collector.shutdown()
+
+        assert rb.write_count >= 32
+        assert len(rb) > 0
+        assert rb.storage[: len(rb)].device == torch.device("cpu")
+
     @pytest.mark.skipif(not _has_gym, reason="requires gym.")
     @pytest.mark.parametrize(
         "collector_class", [MultiSyncCollector, MultiAsyncCollector]
@@ -7107,6 +7141,41 @@ class TestTrajsPerBatchReplayBuffer:
         sample = rb.sample(num_trajs)
         assert sample.ndim == 1, "sampled entries should be individual timesteps (1-D)"
         assert ("collector", "traj_ids") in sample.keys(True)
+        self._assert_rb_trajectories_complete(rb)
+
+    def test_trajs_per_batch_replay_buffer_device_metadata(self):
+        max_steps = 4
+        num_trajs = 2
+        env_fn, policy = self._make_env_and_policy(max_steps)
+        rb = ReplayBuffer(storage=LazyTensorStorage(200, device="cpu"))
+        extend_devices = []
+        extend = rb.extend
+
+        def counted_extend(td):
+            extend_devices.append(td.device)
+            return extend(td)
+
+        rb.extend = counted_extend
+        env = env_fn()
+        collector = Collector(
+            env,
+            policy,
+            replay_buffer=rb,
+            frames_per_batch=max_steps * 3,
+            total_frames=max_steps * 12,
+            trajs_per_batch=num_trajs,
+            trajs_per_write=1,
+            postproc=_clear_tensordict_device,
+        )
+        try:
+            list(collector)
+        finally:
+            collector.shutdown()
+            env.close(raise_if_closed=False)
+
+        assert len(extend_devices) >= 2
+        assert all(device == torch.device("cpu") for device in extend_devices)
+        assert len(rb) > 0, "replay buffer must be non-empty"
         self._assert_rb_trajectories_complete(rb)
 
     def test_trajs_per_write_batches_replay_buffer_extends(self):

--- a/torchrl/collectors/_base.py
+++ b/torchrl/collectors/_base.py
@@ -18,7 +18,12 @@ from tensordict.base import NO_DEFAULT
 from tensordict.nn import TensorDictModule, TensorDictModuleBase
 from torch import nn as nn
 from torch.utils.data import IterableDataset
-from torchrl.collectors.utils import _map_weight, _traj_emit, _traj_ingest
+from torchrl.collectors.utils import (
+    _map_weight,
+    _maybe_normalize_replay_buffer_tensordict_device,
+    _traj_emit,
+    _traj_ingest,
+)
 
 from torchrl.collectors.weight_update import WeightUpdaterBase
 from torchrl.weight_update.utils import _resolve_attr
@@ -1377,9 +1382,13 @@ class BaseCollector(IterableDataset, metaclass=abc.ABCMeta):
                         trajs = complete_trajs[:trajs_per_write]
                         del complete_trajs[:trajs_per_write]
                         if len(trajs) == 1:
-                            rb.extend(trajs[0])
+                            trajs = trajs[0]
                         else:
-                            rb.extend(torch.cat(trajs, dim=0))
+                            trajs = torch.cat(trajs, dim=0)
+                        trajs = _maybe_normalize_replay_buffer_tensordict_device(
+                            trajs, rb
+                        )
+                        rb.extend(trajs)
                     yield
                 else:
                     while len(complete_trajs) >= self.trajs_per_batch:

--- a/torchrl/collectors/_runner.py
+++ b/torchrl/collectors/_runner.py
@@ -23,6 +23,7 @@ from torchrl.collectors.utils import (
     _cast,
     _make_policy_factory,
     _map_to_cpu_if_needed,
+    _maybe_normalize_replay_buffer_tensordict_device,
     _TrajectoryPool,
 )
 from torchrl.data import ReplayBuffer
@@ -313,6 +314,9 @@ def _main_async_collector(
             if replay_buffer is not None:
                 if extend_buffer and next_data is not None:
                     next_data.names = None
+                    next_data = _maybe_normalize_replay_buffer_tensordict_device(
+                        next_data, replay_buffer
+                    )
                     replay_buffer.extend(next_data)
 
                 if run_free:

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -33,6 +33,7 @@ from torchrl.collectors._constants import (
 )
 from torchrl.collectors.utils import (
     _TrajectoryPool,
+    _maybe_normalize_replay_buffer_tensordict_device,
     _validate_traj_format,
     split_trajectories,
 )
@@ -1559,6 +1560,11 @@ class Collector(BaseCollector):
                         self.post_collect_hook(tensordict_out)
                     yield tensordict_out
                 elif self.replay_buffer is not None and not self._ignore_rb:
+                    tensordict_out = (
+                        _maybe_normalize_replay_buffer_tensordict_device(
+                            tensordict_out, self.replay_buffer
+                        )
+                    )
                     self.replay_buffer.extend(tensordict_out)
                     yield
                 else:

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -32,8 +32,8 @@ from torchrl.collectors._constants import (
     ExplorationType,
 )
 from torchrl.collectors.utils import (
-    _TrajectoryPool,
     _maybe_normalize_replay_buffer_tensordict_device,
+    _TrajectoryPool,
     _validate_traj_format,
     split_trajectories,
 )
@@ -1560,10 +1560,8 @@ class Collector(BaseCollector):
                         self.post_collect_hook(tensordict_out)
                     yield tensordict_out
                 elif self.replay_buffer is not None and not self._ignore_rb:
-                    tensordict_out = (
-                        _maybe_normalize_replay_buffer_tensordict_device(
-                            tensordict_out, self.replay_buffer
-                        )
+                    tensordict_out = _maybe_normalize_replay_buffer_tensordict_device(
+                        tensordict_out, self.replay_buffer
                     )
                     self.replay_buffer.extend(tensordict_out)
                     yield

--- a/torchrl/collectors/utils.py
+++ b/torchrl/collectors/utils.py
@@ -21,7 +21,7 @@ from tensordict import (
     TensorDict,
     TensorDictBase,
 )
-from tensordict.base import _is_leaf_nontensor
+from tensordict.base import _is_leaf_nontensor, _NESTED_TENSORS_AS_LISTS
 from tensordict.utils import Buffer
 from torch import multiprocessing as mp, nn as nn
 from torch.nn import Parameter
@@ -463,6 +463,34 @@ def _traj_chunk_ends_done(chunk: TensorDictBase) -> bool:
         if signal is not None and signal[-1].any().item():
             return True
     return False
+
+
+def _maybe_normalize_replay_buffer_tensordict_device(
+    data: TensorDictBase,
+    replay_buffer,
+) -> TensorDictBase:
+    """Align TensorDict root device metadata with replay-buffer storage when safe."""
+    if not isinstance(data, TensorDictBase) or data.device is not None:
+        return data
+
+    storage = getattr(replay_buffer, "_storage", None)
+    if storage is None:
+        storage = getattr(replay_buffer, "storage", None)
+    storage_device = getattr(storage, "device", None)
+    if storage_device is None or storage_device == "auto":
+        return data
+    storage_device = torch.device(storage_device)
+
+    for value in data.values(
+        include_nested=True,
+        leaves_only=True,
+        is_leaf=_NESTED_TENSORS_AS_LISTS,
+    ):
+        value_device = getattr(value, "device", None)
+        if value_device is not None and torch.device(value_device) != storage_device:
+            return data
+
+    return data.to(storage_device)
 
 
 def _traj_ingest(


### PR DESCRIPTION
## Summary
- Normalize collector TensorDict root device metadata to the replay-buffer storage device before safe `extend(...)` writes.
- Apply the normalization to multi-worker collector writes and `trajs_per_batch` complete-trajectory writes.
- Add CPU regression coverage for collector replay-buffer writes into CPU `LazyTensorStorage` when incoming TensorDict roots have `device=None`.

## Tests
- `uv run pytest test/test_collectors.py -k "replay_buffer and device_metadata" -q`
- `uv run pytest test/test_collectors.py -q -k "test_collector_rb_multiasync or test_trajs_per_batch_replay_buffer_sync or test_trajs_per_write_batches_replay_buffer_extends or test_multi_async_replay_buffer_device_metadata"`
