### PR TITLE
[BugFix] Normalize replay write TensorDict device from initialized storage

### DIFF
--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -62,6 +62,7 @@ from torchrl.collectors.distributed.ray import _has_ray, RayCollector
 
 from torchrl.collectors.utils import (
     _make_policy_factory,
+    _maybe_normalize_replay_buffer_tensordict_device,
     _traj_chunk_ends_done,
     _traj_emit,
     _traj_ingest,
@@ -7177,6 +7178,21 @@ class TestTrajsPerBatchReplayBuffer:
         assert all(device == torch.device("cpu") for device in extend_devices)
         assert len(rb) > 0, "replay buffer must be non-empty"
         self._assert_rb_trajectories_complete(rb)
+
+    def test_replay_buffer_device_normalization_uses_initialized_storage(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10, device="cpu"))
+        rb.extend(TensorDict({"obs": torch.zeros(2)}, batch_size=[2]))
+        assert rb.storage._storage.device == torch.device("cpu")
+
+        rb.storage.device = None
+        data = TensorDict({"obs": torch.ones(3)}, batch_size=[3])
+        assert data.device is None
+
+        data = _maybe_normalize_replay_buffer_tensordict_device(data, rb)
+
+        assert data.device == torch.device("cpu")
+        rb.extend(data)
+        assert len(rb) == 5
 
     def test_trajs_per_write_batches_replay_buffer_extends(self):
         max_steps = 4

--- a/torchrl/collectors/utils.py
+++ b/torchrl/collectors/utils.py
@@ -477,6 +477,9 @@ def _maybe_normalize_replay_buffer_tensordict_device(
     if storage is None:
         storage = getattr(replay_buffer, "storage", None)
     storage_device = getattr(storage, "device", None)
+    if storage_device is None:
+        storage_data = getattr(storage, "_storage", None)
+        storage_device = getattr(storage_data, "device", None)
     if storage_device is None or storage_device == "auto":
         return data
     storage_device = torch.device(storage_device)


### PR DESCRIPTION
## Summary
- normalize replay-buffer write TensorDict root device from initialized storage payload when storage metadata device is unavailable
- preserve existing behavior when no concrete storage device is discoverable or the storage device is `auto`
- add a regression test covering initialized CPU LazyTensorStorage with cleared metadata device

## Tests
- `python -m pytest test/test_collectors.py::TestTrajsPerBatchReplayBuffer::test_replay_buffer_device_normalization_uses_initialized_storage -q`
- `python -m py_compile torchrl/collectors/utils.py test/test_collectors.py`
- `git diff --check`
