### PR TITLE
[BugFix] Normalize nested replay write device metadata

### DIFF
--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -7194,6 +7194,25 @@ class TestTrajsPerBatchReplayBuffer:
         rb.extend(data)
         assert len(rb) == 5
 
+    def test_replay_buffer_device_normalization_normalizes_nested_metadata(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10, device="cpu"))
+        data = TensorDict(
+            {
+                "obs": torch.zeros(3),
+                "next": TensorDict({"obs": torch.ones(3)}, batch_size=[3]),
+            },
+            batch_size=[3],
+            device="cpu",
+        )
+        data["next"].clear_device_()
+
+        data = _maybe_normalize_replay_buffer_tensordict_device(data, rb)
+
+        assert data.device == torch.device("cpu")
+        assert data["next"].device == torch.device("cpu")
+        rb.extend(data)
+        assert len(rb) == 3
+
     def test_trajs_per_write_batches_replay_buffer_extends(self):
         max_steps = 4
         num_trajs = 2

--- a/torchrl/collectors/utils.py
+++ b/torchrl/collectors/utils.py
@@ -470,7 +470,7 @@ def _maybe_normalize_replay_buffer_tensordict_device(
     replay_buffer,
 ) -> TensorDictBase:
     """Align TensorDict root device metadata with replay-buffer storage when safe."""
-    if not isinstance(data, TensorDictBase) or data.device is not None:
+    if not isinstance(data, TensorDictBase):
         return data
 
     storage = getattr(replay_buffer, "_storage", None)
@@ -493,6 +493,8 @@ def _maybe_normalize_replay_buffer_tensordict_device(
         if value_device is not None and torch.device(value_device) != storage_device:
             return data
 
+    data = data.copy()
+    data.clear_device_()
     return data.to(storage_device)
 
 


### PR DESCRIPTION
## Summary
- normalize replay-write TensorDict device metadata even when only nested TensorDict metadata is missing
- preserve the existing safety check that concrete tensor leaves must already match the replay storage device
- add a regression test for root CPU metadata with nested metadata cleared

## Tests
- python -m pytest test/test_collectors.py::TestTrajsPerBatchReplayBuffer::test_replay_buffer_device_normalization_uses_initialized_storage test/test_collectors.py::TestTrajsPerBatchReplayBuffer::test_replay_buffer_device_normalization_normalizes_nested_metadata -q
- python -m py_compile torchrl/collectors/utils.py test/test_collectors.py
- git diff --check