### PR TITLE
[BugFix] Set MINARI_DATASETS_PATH around minari.load_dataset in MinariExperienceReplay

### DIFF
--- a/test/libs/test_datasets.py
+++ b/test/libs/test_datasets.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import shutil
 import time
 import warnings
 from contextlib import nullcontext
@@ -726,6 +727,65 @@ class TestMinari:
         finally:
             if MINARI_DATASETS_PATH:
                 os.environ["MINARI_DATASETS_PATH"] = MINARI_DATASETS_PATH
+
+    @pytest.mark.skipif(
+        not _has_minari or not _has_gymnasium, reason="Minari or Gym not available"
+    )
+    def test_download_load_dataset_path(self, tmp_path, monkeypatch):
+        """Regression test for the ``MINARI_DATASETS_PATH`` handling on download.
+
+        ``_download_and_preproc`` downloads the dataset into a temporary directory
+        and then calls ``minari.load_dataset`` to read its metadata. Minari
+        resolves dataset locations through ``MINARI_DATASETS_PATH``; if that
+        variable is restored to a pre-existing value before the ``load_dataset``
+        call, Minari looks in the wrong directory and raises ``FileNotFoundError``.
+
+        Here we simulate a remote download by copying a locally-built dataset into
+        whatever directory torchrl points Minari at, while ``MINARI_DATASETS_PATH``
+        is set to an unrelated, empty cache. This used to fail before the fix.
+        """
+        import gymnasium
+        import minari
+        from minari import DataCollector
+
+        dataset_id = "cartpole/test-download-load-v1"
+
+        source_dir = tmp_path / "source"
+        monkeypatch.setenv("MINARI_DATASETS_PATH", str(source_dir))
+        env = DataCollector(gymnasium.make("CartPole-v1"), record_infos=True)
+        for _ in range(5):
+            env.reset(seed=123)
+            while True:
+                _, _, terminated, truncated, _ = env.step(env.action_space.sample())
+                if terminated or truncated:
+                    break
+        env.create_dataset(
+            dataset_id=dataset_id,
+            algorithm_name="RandomPolicy",
+            code_permalink="https://github.com/Farama-Foundation/Minari",
+            author="Farama",
+            author_email="contact@farama.org",
+            eval_env="CartPole-v1",
+        )
+
+        empty_cache = tmp_path / "empty_cache"
+        empty_cache.mkdir()
+        monkeypatch.setenv("MINARI_DATASETS_PATH", str(empty_cache))
+
+        def fake_download_dataset(dataset_id, *args, **kwargs):
+            dest = os.environ["MINARI_DATASETS_PATH"]
+            shutil.copytree(source_dir, dest, dirs_exist_ok=True)
+
+        monkeypatch.setattr(minari, "download_dataset", fake_download_dataset)
+
+        data = MinariExperienceReplay(
+            dataset_id=dataset_id,
+            batch_size=32,
+            root=str(tmp_path / "torchrl_root"),
+            download=True,
+        )
+        sample = data.sample()
+        assert sample.shape[0] == 32
 
     def test_correct_categorical_missions(self):
         try:

--- a/torchrl/data/datasets/minari_data.py
+++ b/torchrl/data/datasets/minari_data.py
@@ -10,8 +10,8 @@ import os.path
 import shutil
 import tempfile
 from collections import defaultdict
-from collections.abc import Callable
-from contextlib import nullcontext
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, nullcontext
 from dataclasses import asdict
 from pathlib import Path
 
@@ -38,6 +38,20 @@ from torchrl.envs.utils import _classproperty
 
 _has_tqdm = importlib.util.find_spec("tqdm", None) is not None
 _has_minari = importlib.util.find_spec("minari", None) is not None
+
+
+@contextmanager
+def _minari_datasets_path(path: str | Path) -> Iterator[None]:
+    prev = os.environ.get("MINARI_DATASETS_PATH")
+    os.environ["MINARI_DATASETS_PATH"] = str(path)
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("MINARI_DATASETS_PATH", None)
+        else:
+            os.environ["MINARI_DATASETS_PATH"] = prev
+
 
 _NAME_MATCH = KeyDependentDefaultDict(lambda key: key)
 _NAME_MATCH["observations"] = "observation"
@@ -295,17 +309,8 @@ class MinariExperienceReplay(BaseDatasetExperienceReplay):
 
                 else:
                     # temporarily change the minari cache path
-                    prev_minari_datasets_path_save2 = os.environ.get(
-                        "MINARI_DATASETS_PATH"
-                    )
-                    os.environ["MINARI_DATASETS_PATH"] = tmpdir
-                    try:
+                    with _minari_datasets_path(tmpdir):
                         minari.download_dataset(dataset_id=self.dataset_id)
-                    finally:
-                        if prev_minari_datasets_path_save2 is not None:
-                            os.environ[
-                                "MINARI_DATASETS_PATH"
-                            ] = prev_minari_datasets_path_save2
 
                     parent_dir = Path(tmpdir) / self.dataset_id / "data"
 
@@ -469,7 +474,12 @@ class MinariExperienceReplay(BaseDatasetExperienceReplay):
                         from torchrl.collectors.utils import split_trajectories
 
                         td_data = split_trajectories(td_data).memmap_(self.data_path)
-                with open(self.metadata_path, "w") as metadata_file:
+                load_path = (
+                    prev_minari_datasets_path if self.load_from_local_minari else tmpdir
+                )
+                with open(
+                    self.metadata_path, "w"
+                ) as metadata_file, _minari_datasets_path(load_path):
                     dataset = minari.load_dataset(self.dataset_id)
                     self.metadata = asdict(dataset.spec)
                     self.metadata["observation_space"] = _spec_to_dict(


### PR DESCRIPTION
## Description

Wrap minari.load_dataset with context manger to have correct Minari path.

## Motivation and Context

Fixes https://github.com/pytorch/rl/issues/3919
Minari.load_dataset line fails if the dataset is downloaded by TorchRL, thus saved in TorchRL's cache, instead of the default Minari path.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
