### PR TITLE
[BugFix] Fix double-alpha transform in PrioritizedSampler

### DIFF
--- a/test/rb/test_prioritized.py
+++ b/test/rb/test_prioritized.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import functools
+import warnings
 
 import numpy as np
 import pytest
@@ -510,6 +511,60 @@ def test_prb_within_buffer_max_priority_stays_raw():
     sampler.mark_update(torch.tensor([2]))
     expected = (50.0 + sampler._eps) ** alpha
     assert float(sampler._sum_tree[2]) == pytest.approx(expected, rel=1e-3)
+
+
+@pytest.mark.parametrize("max_priority_within_buffer", [False, True])
+def test_prb_alpha_zero_keeps_raw_max(max_priority_within_buffer):
+    """With ``alpha == 0`` every tree entry is ``(p + eps) ** 0 == 1``, so the
+    within-buffer recompute cannot recover raw priorities from the tree. It must
+    keep the previously tracked raw max rather than store the transformed value
+    (1.0) into ``_max_priority``."""
+    sampler = PrioritizedSampler(
+        max_capacity=5,
+        alpha=0.0,
+        beta=0.9,
+        max_priority_within_buffer=max_priority_within_buffer,
+    )
+    sampler.update_priority(torch.tensor([0, 1]), torch.tensor([100.0, 10.0]))
+    # updating the tracked max index triggers the within-buffer recompute
+    sampler.update_priority(torch.tensor([0]), torch.tensor([50.0]))
+    assert float(sampler._max_priority[0]) == pytest.approx(100.0)
+    assert float(sampler.default_priority) == pytest.approx(100.0)
+
+
+def test_prb_alpha_setter_validates_and_warns():
+    """In ``max_priority_within_buffer`` mode the max-priority recomputation
+    inverts sum-tree values with the current ``alpha``, so changing ``alpha``
+    once priorities have been written must warn (once per sampler); the setter
+    must also reject negative values like ``__init__`` does. Without
+    ``max_priority_within_buffer`` the setter stays silent so that alpha
+    annealing (e.g. via ``LinearScheduler``) is warning-free."""
+    sampler = PrioritizedSampler(
+        max_capacity=5, alpha=0.7, beta=0.9, max_priority_within_buffer=True
+    )
+    # empty sampler: changing alpha is safe and must not warn
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        sampler.alpha = 0.6
+    sampler.update_priority(torch.tensor([0]), torch.tensor([100.0]))
+    # setting the same value is a no-op and must not warn
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        sampler.alpha = 0.6
+    with pytest.warns(UserWarning, match="does not re-transform"):
+        sampler.alpha = 0.5
+    # the warning is emitted once per sampler
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        sampler.alpha = 0.4
+    with pytest.raises(ValueError, match="alpha must be greater or equal"):
+        sampler.alpha = -1.0
+    # without max_priority_within_buffer, annealing alpha is warning-free
+    sampler = PrioritizedSampler(max_capacity=5, alpha=0.7, beta=0.9)
+    sampler.update_priority(torch.tensor([0]), torch.tensor([100.0]))
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        sampler.alpha = 0.5
 
 
 if __name__ == "__main__":

--- a/test/rb/test_prioritized.py
+++ b/test/rb/test_prioritized.py
@@ -462,6 +462,56 @@ def test_prb(priority_key, contiguous, device):
     torch.testing.assert_close(td2[idx0].get("a").view(1), s.get("a").unique().view(1))
 
 
+@pytest.mark.parametrize("alpha", [0.4, 0.7])
+@pytest.mark.parametrize("max_priority_within_buffer", [False, True])
+def test_prb_new_item_gets_max_priority(alpha, max_priority_within_buffer):
+    """A freshly added item with no priority key must be written to the sum-tree at
+    the current max priority, transformed by ``alpha`` exactly once.
+
+    This is PER's "new experience is sampled at least once" guarantee. Regression
+    test for the double-``alpha`` transform in
+    :meth:`~torchrl.data.replay_buffers.samplers.PrioritizedSampler.default_priority`,
+    which wrote new items at ``((p + eps) ** alpha + eps) ** alpha`` and so
+    systematically under-prioritized them for ``alpha < 1``.
+    """
+    sampler = PrioritizedSampler(
+        max_capacity=10,
+        alpha=alpha,
+        beta=0.9,
+        max_priority_within_buffer=max_priority_within_buffer,
+    )
+    # index 0 receives a large TD-error priority
+    sampler.update_priority(torch.tensor([0]), torch.tensor([100.0]))
+    # index 1 is a fresh item written at the default (max) priority, as writers do
+    sampler.mark_update(torch.tensor([1]))
+    eps = sampler._eps
+    expected = (100.0 + eps) ** alpha
+    got = float(sampler._sum_tree[1])
+    assert got == pytest.approx(expected, rel=1e-4), (got, expected)
+    # the new item is exactly as sample-able as the current max item
+    assert got == pytest.approx(float(sampler._sum_tree[0]), rel=1e-4)
+
+
+def test_prb_within_buffer_max_priority_stays_raw():
+    """In ``max_priority_within_buffer`` mode, updating the current max item must keep
+    ``_max_priority`` as a raw priority (not the transformed sum-tree value), so a
+    subsequently added default item still lands at the true max tree priority.
+    """
+    alpha = 0.6
+    sampler = PrioritizedSampler(
+        max_capacity=5, alpha=alpha, beta=0.9, max_priority_within_buffer=True
+    )
+    sampler.update_priority(torch.tensor([0, 1]), torch.tensor([100.0, 10.0]))
+    # updating the current max index (0) triggers the within-buffer recompute
+    sampler.update_priority(torch.tensor([0]), torch.tensor([50.0]))
+    # _max_priority must hold the raw current max (50), not (50 + eps) ** alpha
+    assert float(sampler._max_priority[0]) == pytest.approx(50.0, rel=1e-3)
+    # a fresh default item then lands at (50 + eps) ** alpha
+    sampler.mark_update(torch.tensor([2]))
+    expected = (50.0 + sampler._eps) ** alpha
+    assert float(sampler._sum_tree[2]) == pytest.approx(expected, rel=1e-3)
+
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -1170,9 +1170,7 @@ class TestSamplers:
             rb.update_priority(idx, 21 - data)
             if data <= 10 or not max_priority_within_buffer:
                 # The max is (or remains, historically) the first value
-                assert float(rb.sampler._max_priority[0]) == pytest.approx(
-                    21, rel=1e-4
-                )
+                assert float(rb.sampler._max_priority[0]) == pytest.approx(21, rel=1e-4)
                 assert rb.sampler._max_priority[1] == 0
             else:
                 # the max is the current max: the oldest item still in the buffer

--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -1150,41 +1150,51 @@ class TestSamplers:
             assert found_traj_0
 
     @pytest.mark.parametrize("max_priority_within_buffer", [True, False])
-    def test_prb_update_max_priority(self, max_priority_within_buffer):
+    @pytest.mark.parametrize("alpha", [1.0, 0.6])
+    def test_prb_update_max_priority(self, max_priority_within_buffer, alpha):
+        # alpha < 1 makes raw and transformed priorities numerically distinct,
+        # so these assertions pin that _max_priority stays in the RAW domain
+        # while the sum-tree holds (p + eps) ** alpha.
         rb = ReplayBuffer(
             storage=LazyTensorStorage(11),
             sampler=PrioritizedSampler(
                 max_capacity=11,
-                alpha=1.0,
+                alpha=alpha,
                 beta=1.0,
                 max_priority_within_buffer=max_priority_within_buffer,
             ),
         )
+        eps = rb.sampler._eps
         for data in torch.arange(20):
             idx = rb.add(data)
             rb.update_priority(idx, 21 - data)
-            if data <= 10:
-                # The max is always going to be the first value
-                assert rb.sampler._max_priority[0] == 21
-                assert rb.sampler._max_priority[1] == 0
-            elif not max_priority_within_buffer:
-                # The max is the historical max, which was at idx 0
-                assert rb.sampler._max_priority[0] == 21
+            if data <= 10 or not max_priority_within_buffer:
+                # The max is (or remains, historically) the first value
+                assert float(rb.sampler._max_priority[0]) == pytest.approx(
+                    21, rel=1e-4
+                )
                 assert rb.sampler._max_priority[1] == 0
             else:
-                # the max is the current max. Find it and compare
+                # the max is the current max: the oldest item still in the buffer
+                expected_raw = float(31 - data)
+                assert float(rb.sampler._max_priority[0]) == pytest.approx(
+                    expected_raw, rel=1e-4
+                )
+                assert rb.sampler._max_priority[1] == data - 10
                 sumtree = torch.as_tensor(
                     [rb.sampler._sum_tree[i] for i in range(rb.sampler._max_capacity)]
                 )
-                assert rb.sampler._max_priority[0] == sumtree.max()
-                assert rb.sampler._max_priority[1] == sumtree.argmax()
+                assert float(sumtree.max()) == pytest.approx(
+                    (expected_raw + eps) ** alpha, rel=1e-4
+                )
+                assert sumtree.argmax() == data - 10
         idx = rb.extend(torch.arange(10))
         rb.update_priority(idx, 12)
         if max_priority_within_buffer:
-            assert rb.sampler._max_priority[0] == 12
+            assert float(rb.sampler._max_priority[0]) == pytest.approx(12, rel=1e-4)
             assert rb.sampler._max_priority[1] == 0
         else:
-            assert rb.sampler._max_priority[0] == 21
+            assert float(rb.sampler._max_priority[0]) == pytest.approx(21, rel=1e-4)
             assert rb.sampler._max_priority[1] == 0
 
     @pytest.mark.skipif(

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -1230,12 +1230,18 @@ class PrioritizedSampler(Sampler):
 
     @property
     def default_priority(self) -> float:
+        # Return the RAW max priority. Every consumer feeds this value back through
+        # ``update_priority``, which applies the ``(p + eps) ** alpha`` transform
+        # exactly once. Returning an already-transformed value here caused new items
+        # to be transformed twice (``((p + eps) ** alpha + eps) ** alpha``), which
+        # systematically under-prioritized them (for ``alpha < 1``) and broke PER's
+        # "new experience is sampled at least once" guarantee.
         mp = self._max_priority[0]
         if mp is None:
             mp = 1
         if isinstance(mp, torch.Tensor):
             mp = mp.to(self.device)
-        return (mp + self._eps) ** self._alpha
+        return mp
 
     def sample(self, storage: Storage, batch_size: int) -> torch.Tensor:
         self._maybe_init_from_storage(storage)
@@ -1433,6 +1439,12 @@ class PrioritizedSampler(Sampler):
                 ).max(0)
             else:
                 return
+            # ``maxval`` is read from the sum-tree, which stores (p + eps) ** alpha.
+            # Convert it back to the raw priority so ``_max_priority`` is always the
+            # raw max, matching the non-recomputed path and what ``default_priority``
+            # expects (it re-applies the alpha transform once via ``update_priority``).
+            if self._alpha != 0:
+                maxval = (maxval ** (1.0 / self._alpha) - self._eps).clamp_min(0)
             self._max_priority = (maxval, maxidx)
 
     def mark_update(

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -1053,6 +1053,7 @@ class PrioritizedSampler(Sampler):
         self.reduction = reduction
         self.dtype = dtype
         self._max_priority_within_buffer = max_priority_within_buffer
+        self._warned_alpha_change = False
         self._device = torch.device(device) if device is not None else None
         self._init()
         if rl_warnings() and SumSegmentTreeFp32 is None:
@@ -1076,10 +1077,39 @@ class PrioritizedSampler(Sampler):
 
     @property
     def alpha(self):
+        """The priority exponent.
+
+        .. note:: Changing ``alpha`` on a sampler that already holds priorities
+          (e.g. when annealing it with a
+          :class:`~torchrl.data.replay_buffers.scheduler.ParameterScheduler`)
+          does not re-transform the ``(p + eps) ** alpha`` values already
+          written to the sum/min trees: old and new exponents mix until every
+          entry's priority is updated again.
+        """
         return self._alpha
 
     @alpha.setter
     def alpha(self, value):
+        if value < 0:
+            raise ValueError(
+                f"alpha must be greater or equal than 0, got alpha={value}"
+            )
+        if (
+            value != self._alpha
+            and self._max_priority_within_buffer
+            and not self._warned_alpha_change
+            and self._max_priority[0] is not None
+        ):
+            self._warned_alpha_change = True
+            warnings.warn(
+                "Changing alpha on a PrioritizedSampler with "
+                "max_priority_within_buffer=True does not re-transform the "
+                "(p + eps) ** alpha values already stored in the sum/min trees, "
+                "and the max-priority recomputation inverts tree values with the "
+                "new alpha. Large changes to alpha can corrupt the tracked max "
+                "priority until the corresponding entries are updated again. "
+                "This warning is emitted once per sampler."
+            )
         self._alpha = value
 
     @property
@@ -1229,7 +1259,7 @@ class PrioritizedSampler(Sampler):
             self._max_priority = None
 
     @property
-    def default_priority(self) -> float:
+    def default_priority(self) -> float | torch.Tensor:
         # Return the RAW max priority. Every consumer feeds this value back through
         # ``update_priority``, which applies the ``(p + eps) ** alpha`` transform
         # exactly once. Returning an already-transformed value here caused new items
@@ -1238,7 +1268,7 @@ class PrioritizedSampler(Sampler):
         # "new experience is sampled at least once" guarantee.
         mp = self._max_priority[0]
         if mp is None:
-            mp = 1
+            mp = 1.0
         if isinstance(mp, torch.Tensor):
             mp = mp.to(self.device)
         return mp
@@ -1428,6 +1458,14 @@ class PrioritizedSampler(Sampler):
         self._sum_tree[index] = priority
         self._min_tree[index] = priority
         if self._max_priority_within_buffer and cur_max_priority_index is not None:
+            if self._alpha == 0:
+                # With alpha == 0 the tree stores (p + eps) ** 0 == 1 for every
+                # entry, so the raw priorities of untouched entries cannot be
+                # recovered from it. Keep the raw max tracked above instead of
+                # storing a transformed value in ``_max_priority``; sampling is
+                # uniform in this regime, so a stale max only matters if alpha
+                # is raised later (see the ``alpha`` setter).
+                return
             if tree_device.type == "cuda":
                 all_indices = torch.arange(
                     self._max_capacity, dtype=torch.long, device=tree_device
@@ -1443,8 +1481,7 @@ class PrioritizedSampler(Sampler):
             # Convert it back to the raw priority so ``_max_priority`` is always the
             # raw max, matching the non-recomputed path and what ``default_priority``
             # expects (it re-applies the alpha transform once via ``update_priority``).
-            if self._alpha != 0:
-                maxval = (maxval ** (1.0 / self._alpha) - self._eps).clamp_min(0)
+            maxval = (maxval ** (1.0 / self._alpha) - self._eps).clamp_min(0)
             self._max_priority = (maxval, maxidx)
 
     def mark_update(


### PR DESCRIPTION
## Summary 
- Prioritized replay stores priorities in the sum-tree, and update_priority is the single place that transform is applied, so every caller is meant to pass a raw priority.
- default_priority returns the raw max, so the single transform in update_priority produces the correct value
