### PR TITLE
[Feature] Add Learner primitive (LocalLearner, FSDP2Learner)

### DIFF
--- a/docs/source/reference/trainers.rst
+++ b/docs/source/reference/trainers.rst
@@ -49,3 +49,4 @@ Documentation Sections
    trainers_basics
    trainers_loggers
    trainers_hooks
+   trainers_learners

--- a/docs/source/reference/trainers.rst
+++ b/docs/source/reference/trainers.rst
@@ -52,3 +52,4 @@ Documentation Sections
    trainers_basics
    trainers_loggers
    trainers_hooks
+   trainers_learners

--- a/docs/source/reference/trainers_learners.rst
+++ b/docs/source/reference/trainers_learners.rst
@@ -16,10 +16,15 @@ need to know whether the update runs on one device, under sharded training, or
 on a remote training process.
 
 :class:`~torchrl.trainers.LocalLearner` is the single-process reference
-implementation. Its :meth:`~torchrl.trainers.Learner.get_weights` output is
-accepted as-is by :class:`~torchrl.weight_update.WeightSyncScheme`, so a
-``Learner`` composes with the existing weight-sync path without changes on
-either side.
+implementation. :class:`~torchrl.trainers.FSDP2Learner` shards the same model
+with :func:`torch.distributed._composable.fsdp.fully_shard` and reuses
+:meth:`~torchrl.trainers.Learner.update` unchanged -- FSDP2's sharding is
+transparent to the training step; only construction (the caller wraps the
+model before handing it to the learner) and :meth:`~torchrl.trainers.Learner.get_weights`
+(which gathers sharded parameters into plain tensors) differ. Either
+learner's :meth:`~torchrl.trainers.Learner.get_weights` output is accepted
+as-is by :class:`~torchrl.weight_update.WeightSyncScheme`, so a ``Learner``
+composes with the existing weight-sync path without changes on either side.
 
 .. autosummary::
     :toctree: generated/
@@ -28,3 +33,4 @@ either side.
     Learner
     LearnerCapabilities
     LocalLearner
+    FSDP2Learner

--- a/docs/source/reference/trainers_learners.rst
+++ b/docs/source/reference/trainers_learners.rst
@@ -1,0 +1,30 @@
+.. currentmodule:: torchrl.trainers
+
+Learners
+========
+
+.. _ref_learners:
+
+A :class:`~torchrl.trainers.Learner` owns a trainable model and exposes a
+single, backend-agnostic entry point -- :meth:`~torchrl.trainers.Learner.update`
+-- for taking one optimization step on a tensordict batch with a given
+:class:`~torchrl.objectives.common.LossModule`. It plays the same role for
+training that :class:`~torchrl.collectors.Collector` plays for data collection
+and :class:`~torchrl.modules.llm.LLMWrapperBase` plays for generation/scoring:
+a fixed contract with interchangeable backends, so algorithm code does not
+need to know whether the update runs on one device, under sharded training, or
+on a remote training process.
+
+:class:`~torchrl.trainers.LocalLearner` is the single-process reference
+implementation. Its :meth:`~torchrl.trainers.Learner.get_weights` output is
+accepted as-is by :class:`~torchrl.weight_update.WeightSyncScheme`, so a
+``Learner`` composes with the existing weight-sync path without changes on
+either side.
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template.rst
+
+    Learner
+    LearnerCapabilities
+    LocalLearner

--- a/docs/source/reference/trainers_learners.rst
+++ b/docs/source/reference/trainers_learners.rst
@@ -26,6 +26,41 @@ learner's :meth:`~torchrl.trainers.Learner.get_weights` output is accepted
 as-is by :class:`~torchrl.weight_update.WeightSyncScheme`, so a ``Learner``
 composes with the existing weight-sync path without changes on either side.
 
+Building the optimizer
+----------------------
+
+The **optimizer** decides what is trained, not the ``model`` argument. ``model``
+is the weight-sync source and the gradient-sync handle; the parameters that get
+clipped and stepped are the ones in ``optimizer.param_groups``. Many TorchRL
+losses hold their trainable parameters on the loss module itself as
+:class:`~tensordict.nn.TensorDictParams`, and the ones that expand their
+networks (:class:`~torchrl.objectives.SACLoss`,
+:class:`~torchrl.objectives.REDQLoss`, ...) hold *copies* of the modules you
+passed in, so the optimizer must be built over the loss module:
+
+.. code-block:: python
+
+    loss_module = SACLoss(actor, qvalue)
+    learner = LocalLearner(actor, Adam(loss_module.parameters()))  # correct
+    learner = LocalLearner(actor, Adam(actor.parameters()))        # critics never train
+
+:meth:`~torchrl.trainers.Learner.update` verifies this before its first
+optimizer step and raises if any parameter received a gradient that no param
+group covers. A ``Learner`` owns exactly one optimizer, so algorithms that
+deliberately use several (per-network learning rates, a separate
+entropy-temperature optimizer) need one ``Learner`` per optimizer.
+
+Checkpointing
+-------------
+
+Use :meth:`~torchrl.trainers.Learner.checkpoint` and
+:meth:`~torchrl.trainers.Learner.load_checkpoint`, which cover the model, the
+optimizer and the gradient-accumulation counter. ``state_dict`` /
+``load_state_dict`` keep their plain :class:`~torch.nn.Module` meaning (a bare
+:class:`~torch.optim.Optimizer` is not an ``nn.Module``, so they cannot carry
+its state) -- which is what lets a ``Learner`` be nested inside a larger module
+without losing state.
+
 .. autosummary::
     :toctree: generated/
     :template: rl_template.rst

--- a/docs/source/reference/trainers_learners.rst
+++ b/docs/source/reference/trainers_learners.rst
@@ -5,61 +5,55 @@ Learners
 
 .. _ref_learners:
 
-A :class:`~torchrl.trainers.Learner` owns a trainable model and exposes a
-single, backend-agnostic entry point -- :meth:`~torchrl.trainers.Learner.update`
--- for taking one optimization step on a tensordict batch with a given
-:class:`~torchrl.objectives.common.LossModule`. It plays the same role for
-training that :class:`~torchrl.collectors.Collector` plays for data collection
-and :class:`~torchrl.modules.llm.LLMWrapperBase` plays for generation/scoring:
-a fixed contract with interchangeable backends, so algorithm code does not
-need to know whether the update runs on one device, under sharded training, or
-on a remote training process.
+A :class:`~torchrl.trainers.Learner` is an execution boundary around the same
+:class:`~torchrl.trainers.OptimizationStepper` contract used by
+:class:`~torchrl.trainers.Trainer`:
 
-:class:`~torchrl.trainers.LocalLearner` is the single-process reference
-implementation. :class:`~torchrl.trainers.FSDP2Learner` shards the same model
-with :func:`torch.distributed._composable.fsdp.fully_shard` and reuses
-:meth:`~torchrl.trainers.Learner.update` unchanged -- FSDP2's sharding is
-transparent to the training step; only construction (the caller wraps the
-model before handing it to the learner) and :meth:`~torchrl.trainers.Learner.get_weights`
-(which gathers sharded parameters into plain tensors) differ. Either
-learner's :meth:`~torchrl.trainers.Learner.get_weights` output is accepted
-as-is by :class:`~torchrl.weight_update.WeightSyncScheme`, so a ``Learner``
-composes with the existing weight-sync path without changes on either side.
+* the learner decides **where** an update runs and how policy weights are
+  materialized;
+* the optimization stepper decides **how** the update runs, including loss
+  reduction, backward, accumulation, clipping, mixed precision, and optimizer
+  stepping.
 
-Building the optimizer
-----------------------
-
-The **optimizer** decides what is trained, not the ``model`` argument. ``model``
-is the weight-sync source and the gradient-sync handle; the parameters that get
-clipped and stepped are the ones in ``optimizer.param_groups``. Many TorchRL
-losses hold their trainable parameters on the loss module itself as
-:class:`~tensordict.nn.TensorDictParams`, and the ones that expand their
-networks (:class:`~torchrl.objectives.SACLoss`,
-:class:`~torchrl.objectives.REDQLoss`, ...) hold *copies* of the modules you
-passed in, so the optimizer must be built over the loss module:
+This keeps one optimization API across ordinary and LLM trainers. Construct
+the loss and stepper once, pass both to the learner, then call
+``learner.update(batch)``:
 
 .. code-block:: python
 
-    loss_module = SACLoss(actor, qvalue)
-    learner = LocalLearner(actor, Adam(loss_module.parameters()))  # correct
-    learner = LocalLearner(actor, Adam(actor.parameters()))        # critics never train
+    loss_module = MyLoss(policy)
+    stepper = MixedPrecisionOptimizationStepper(
+        Adam(loss_module.parameters()),
+        mixed_precision=True,
+        gradient_accumulation_steps=4,
+    )
+    learner = LocalLearner(policy, loss_module, stepper)
+    metrics = learner.update(batch)
 
-:meth:`~torchrl.trainers.Learner.update` verifies this before its first
-optimizer step and raises if any parameter received a gradient that no param
-group covers. A ``Learner`` owns exactly one optimizer, so algorithms that
-deliberately use several (per-network learning rates, a separate
-entropy-temperature optimizer) need one ``Learner`` per optimizer.
+:class:`~torchrl.trainers.LocalLearner` runs in the current process.
+:class:`~torchrl.trainers.FSDP2Learner` accepts a model already wrapped with
+:func:`torch.distributed._composable.fsdp.fully_shard`; it uses the same
+stepper and only changes gradient synchronization, weight gathering, and
+checkpoint translation.
+
+Weight publication
+------------------
+
+:meth:`~torchrl.trainers.Learner.get_weights` returns a detached TensorDict
+snapshot accepted by :class:`~torchrl.weight_update.WeightSyncScheme`.
+Only the published model is included; loss-only parameters such as entropy
+temperature remain training state and are covered by checkpoints.
 
 Checkpointing
 -------------
 
-Use :meth:`~torchrl.trainers.Learner.checkpoint` and
-:meth:`~torchrl.trainers.Learner.load_checkpoint`, which cover the model, the
-optimizer and the gradient-accumulation counter. ``state_dict`` /
-``load_state_dict`` keep their plain :class:`~torch.nn.Module` meaning (a bare
-:class:`~torch.optim.Optimizer` is not an ``nn.Module``, so they cannot carry
-its state) -- which is what lets a ``Learner`` be nested inside a larger module
-without losing state.
+:meth:`~torchrl.trainers.Learner.checkpoint` composes model, loss-module, and
+stepper state. The stepper owns optimizer and accumulation state, so learner
+checkpoints obey the same rule as trainer checkpoints: saving partway through
+an accumulation window is rejected because partial gradients are not stored.
+
+``state_dict`` keeps its ordinary :class:`torch.nn.Module` meaning, allowing a
+learner to be nested safely inside another module.
 
 .. autosummary::
     :toctree: generated/

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -1683,6 +1683,37 @@ class TestLocalLearner:
         with pytest.raises(NotImplementedError):
             Learner().get_weights()
 
+    def test_state_dict_round_trip_includes_optimizer(self):
+        # plain nn.Module.state_dict() would silently drop the optimizer's
+        # state (Optimizer is not an nn.Module) -- this is the regression test
+        # for that gap. Momentum must be nonzero, or SGD never populates a
+        # momentum_buffer in its state to begin with.
+        torch.manual_seed(0)
+        model = nn.Linear(4, 1)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+        learner = LocalLearner(model, optimizer)
+        loss_module = _ToyRegressionLoss(model)
+        torch.manual_seed(2)
+        for _ in range(3):
+            learner.update(self._batch(), loss_module)
+        checkpoint = learner.state_dict()
+        saved_weight = model.weight.clone()
+        saved_momentum = next(iter(learner.optimizer.state.values()))[
+            "momentum_buffer"
+        ].clone()
+
+        with torch.no_grad():
+            model.weight.zero_()
+        for state in learner.optimizer.state.values():
+            state["momentum_buffer"].zero_()
+
+        learner.load_state_dict(checkpoint)
+        torch.testing.assert_close(model.weight, saved_weight)
+        restored_momentum = next(iter(learner.optimizer.state.values()))[
+            "momentum_buffer"
+        ]
+        torch.testing.assert_close(restored_momentum, saved_momentum)
+
 
 @pytest.mark.skipif(
     not torch.distributed.is_available(), reason="torch.distributed required"
@@ -1780,6 +1811,86 @@ class TestFSDP2Learner:
         gathered = fsdp2_learner.get_weights()
         torch.testing.assert_close(gathered["weight"], local_model.weight)
         torch.testing.assert_close(gathered["bias"], local_model.bias)
+
+    def test_grad_accumulation_defers_step(self):
+        learner, loss_module, model = self._make(grad_accum_steps=2, lr=1.0)
+        before = model.weight.full_tensor().clone()
+        learner.update(self._batch(seed=1), loss_module)
+        assert torch.equal(before, model.weight.full_tensor())
+        learner.update(self._batch(seed=2), loss_module)
+        assert not torch.equal(before, model.weight.full_tensor())
+
+    def test_grad_accumulation_matches_non_sharded_reference(self):
+        """Regression test for the set_requires_gradient_sync(False) toggle
+        update() uses to skip communication on non-final accumulation steps:
+        the accumulated gradient must still equal a plain (non-sharded)
+        reference that accumulates the same two micro-batches."""
+        from torch.distributed._composable.fsdp import fully_shard
+        from torch.distributed.device_mesh import init_device_mesh
+
+        batch1, batch2 = self._batch(seed=10), self._batch(seed=11)
+
+        # update() divides each micro-batch's loss by grad_accum_steps before
+        # backward (accumulation averages, rather than sums, the microbatches),
+        # so the reference must apply the same scaling.
+        torch.manual_seed(0)
+        ref_model = nn.Linear(4, 1)
+        ref_loss = _ToyRegressionLoss(ref_model)
+        ref_model.zero_grad()
+        (ref_loss(batch1).get("loss_mse") / 2).backward()
+        (ref_loss(batch2).get("loss_mse") / 2).backward()
+        ref_grad = ref_model.weight.grad.clone()
+
+        torch.manual_seed(0)
+        model = nn.Linear(4, 1)
+        mesh = init_device_mesh("cpu", (1,))
+        fully_shard(model, mesh=mesh)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        learner = FSDP2Learner(model, optimizer, grad_accum_steps=2)
+        loss_module = _ToyRegressionLoss(model)
+        learner.update(batch1, loss_module)  # sync disabled; .grad stays None
+        learner.update(batch2, loss_module)  # sync re-enabled; optimizer.step()
+        # optimizer.step() does not clear .grad (only zero_grad() does), so the
+        # fully-accumulated, synced gradient is still readable here.
+        accumulated_grad = model.weight.grad.full_tensor()
+        torch.testing.assert_close(accumulated_grad, ref_grad)
+
+    def test_state_dict_round_trip_includes_optimizer(self):
+        from torch.distributed._composable.fsdp import fully_shard
+        from torch.distributed.device_mesh import init_device_mesh
+
+        # momentum must be nonzero, or SGD never populates optimizer state to
+        # begin with, and the DCP loader has nothing meaningful to restore.
+        torch.manual_seed(0)
+        model = nn.Linear(4, 1)
+        mesh = init_device_mesh("cpu", (1,))
+        fully_shard(model, mesh=mesh)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+        learner = FSDP2Learner(model, optimizer)
+        loss_module = _ToyRegressionLoss(model)
+
+        torch.manual_seed(3)
+        for _ in range(3):
+            learner.update(self._batch(), loss_module)
+        checkpoint = learner.state_dict()
+        saved_weight = model.weight.full_tensor().clone()
+        saved_momentum = (
+            next(iter(optimizer.state.values()))["momentum_buffer"]
+            .full_tensor()
+            .clone()
+        )
+
+        with torch.no_grad():
+            model.weight.to_local().zero_()
+        for state in optimizer.state.values():
+            state["momentum_buffer"].to_local().zero_()
+
+        learner.load_state_dict(checkpoint)
+        torch.testing.assert_close(model.weight.full_tensor(), saved_weight)
+        restored_momentum = next(iter(optimizer.state.values()))[
+            "momentum_buffer"
+        ].full_tensor()
+        torch.testing.assert_close(restored_momentum, saved_momentum)
 
 
 if __name__ == "__main__":

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -31,7 +31,13 @@ from torchrl.data import (
 from torchrl.envs.libs.gym import _has_gym
 from torchrl.objectives.common import LossModule
 from torchrl.testing import PONG_VERSIONED
-from torchrl.trainers import Learner, LocalLearner, LogValidationReward, Trainer
+from torchrl.trainers import (
+    FSDP2Learner,
+    Learner,
+    LocalLearner,
+    LogValidationReward,
+    Trainer,
+)
 from torchrl.trainers.algorithms.cql import CQLTrainer
 from torchrl.trainers.algorithms.ddpg import DDPGTrainer
 from torchrl.trainers.algorithms.dqn import DQNTrainer
@@ -1671,12 +1677,109 @@ class TestLocalLearner:
         with pytest.raises(ValueError, match="grad_accum_steps must be"):
             LocalLearner(model, optimizer, grad_accum_steps=0)
 
-    def test_base_learner_methods_are_abstract(self):
-        learner = Learner()
+    def test_base_learner_get_weights_is_abstract(self):
+        # update() is concrete on Learner (shared by LocalLearner/FSDP2Learner);
+        # only get_weights() -- the backend-specific gather -- remains abstract.
         with pytest.raises(NotImplementedError):
-            learner.update(self._batch(), _ToyRegressionLoss(nn.Linear(4, 1)))
-        with pytest.raises(NotImplementedError):
-            learner.get_weights()
+            Learner().get_weights()
+
+
+@pytest.mark.skipif(
+    not torch.distributed.is_available(), reason="torch.distributed required"
+)
+class TestFSDP2Learner:
+    """FSDP2Learner exercised on a single-rank process group (gloo/CPU).
+
+    world_size=1 does not exercise cross-rank sharding, but it runs the exact
+    fully_shard()/DTensor code path FSDP2Learner is built on, so these tests
+    catch real API breakage, not just interface stubs.
+    """
+
+    _PORT = "29601"
+
+    @pytest.fixture(autouse=True)
+    def _process_group(self):
+        import torch.distributed as dist
+
+        os.environ.setdefault("MASTER_ADDR", "localhost")
+        os.environ["MASTER_PORT"] = self._PORT
+        dist.init_process_group(backend="gloo", rank=0, world_size=1)
+        try:
+            yield
+        finally:
+            dist.destroy_process_group()
+
+    @staticmethod
+    def _make(clip_grad_norm=None, grad_accum_steps=1, lr=0.1, seed=0):
+        from torch.distributed._composable.fsdp import fully_shard
+        from torch.distributed.device_mesh import init_device_mesh
+
+        torch.manual_seed(seed)
+        model = nn.Linear(4, 1)
+        mesh = init_device_mesh("cpu", (1,))
+        fully_shard(model, mesh=mesh)
+        optimizer = torch.optim.SGD(model.parameters(), lr=lr)
+        learner = FSDP2Learner(
+            model,
+            optimizer,
+            clip_grad_norm=clip_grad_norm,
+            grad_accum_steps=grad_accum_steps,
+        )
+        loss_module = _ToyRegressionLoss(model)
+        return learner, loss_module, model
+
+    @staticmethod
+    def _batch(n=8, seed=None):
+        if seed is not None:
+            torch.manual_seed(seed)
+        return TensorDict(
+            {"x": torch.randn(n, 4), "y": torch.randn(n, 1)}, batch_size=[n]
+        )
+
+    def test_update_returns_loss_and_metric(self):
+        learner, loss_module, _ = self._make()
+        out = learner.update(self._batch(seed=1), loss_module)
+        assert "loss_mse" in out.keys()
+        assert "metric" in out.keys()
+
+    def test_clip_grad_norm_writes_grad_norm(self):
+        learner, loss_module, _ = self._make(clip_grad_norm=0.5)
+        out = learner.update(self._batch(seed=1), loss_module)
+        assert "grad_norm" in out.keys()
+        assert out.get("grad_norm") >= 0
+
+    def test_get_weights_returns_plain_tensors(self):
+        learner, _, _ = self._make()
+        weights = learner.get_weights()
+        for leaf in weights.values(True, True):
+            assert not isinstance(leaf, torch.distributed.tensor.DTensor)
+
+    def test_capabilities_report_sharded(self):
+        learner, _, _ = self._make()
+        assert learner.capabilities.sharded
+        assert not learner.capabilities.remote
+
+    def test_matches_local_learner_bit_exact(self):
+        """The whole point of the abstraction: same update() logic, same
+        result, whether the model is sharded or not."""
+        batch = self._batch(n=8, seed=42)
+
+        fsdp2_learner, fsdp2_loss, fsdp2_model = self._make(
+            clip_grad_norm=1.0, lr=0.5, seed=0
+        )
+        fsdp2_out = fsdp2_learner.update(batch, fsdp2_loss)
+
+        torch.manual_seed(0)
+        local_model = nn.Linear(4, 1)
+        local_optimizer = torch.optim.SGD(local_model.parameters(), lr=0.5)
+        local_learner = LocalLearner(local_model, local_optimizer, clip_grad_norm=1.0)
+        local_loss = _ToyRegressionLoss(local_model)
+        local_out = local_learner.update(batch, local_loss)
+
+        assert fsdp2_out.get("loss_mse").item() == local_out.get("loss_mse").item()
+        gathered = fsdp2_learner.get_weights()
+        torch.testing.assert_close(gathered["weight"], local_model.weight)
+        torch.testing.assert_close(gathered["bias"], local_model.bias)
 
 
 if __name__ == "__main__":

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -29,8 +29,9 @@ from torchrl.data import (
     TensorDictReplayBuffer,
 )
 from torchrl.envs.libs.gym import _has_gym
+from torchrl.objectives.common import LossModule
 from torchrl.testing import PONG_VERSIONED
-from torchrl.trainers import LogValidationReward, Trainer
+from torchrl.trainers import Learner, LocalLearner, LogValidationReward, Trainer
 from torchrl.trainers.algorithms.cql import CQLTrainer
 from torchrl.trainers.algorithms.ddpg import DDPGTrainer
 from torchrl.trainers.algorithms.dqn import DQNTrainer
@@ -1560,6 +1561,122 @@ class TestEarlyStopping:
         assert trainer.collected_frames < trainer.total_frames
         assert trainer._stop_training
         assert collector.shutdown_calls == 1
+
+
+class _ToyRegressionLoss(LossModule):
+    """Minimal LossModule: MSE loss plus a non-loss logging metric."""
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, batch: TensorDict) -> TensorDict:
+        pred = self.model(batch["x"])
+        loss = (pred - batch["y"]).pow(2).mean()
+        with torch.no_grad():
+            metric = pred.mean()  # a non-"loss"-prefixed field, for logging only
+        return TensorDict({"loss_mse": loss, "metric": metric})
+
+
+class _NoLossKeyModule(LossModule):
+    """A LossModule whose output has no 'loss'-prefixed key (misconfigured)."""
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, batch: TensorDict) -> TensorDict:
+        pred = self.model(batch["x"])
+        return TensorDict({"mse": (pred - batch["y"]).pow(2).mean()})
+
+
+class TestLocalLearner:
+    @staticmethod
+    def _make(clip_grad_norm=None, grad_accum_steps=1, lr=0.1):
+        torch.manual_seed(0)
+        model = nn.Linear(4, 1)
+        optimizer = torch.optim.SGD(model.parameters(), lr=lr)
+        learner = LocalLearner(
+            model,
+            optimizer,
+            clip_grad_norm=clip_grad_norm,
+            grad_accum_steps=grad_accum_steps,
+        )
+        loss_module = _ToyRegressionLoss(model)
+        return learner, loss_module, model
+
+    @staticmethod
+    def _batch(n=8):
+        return TensorDict(
+            {"x": torch.randn(n, 4), "y": torch.randn(n, 1)}, batch_size=[n]
+        )
+
+    def test_update_returns_loss_and_metric(self):
+        learner, loss_module, _ = self._make()
+        out = learner.update(self._batch(), loss_module)
+        assert "loss_mse" in out.keys()
+        assert "metric" in out.keys()
+        assert out.get("loss_mse").shape == ()
+
+    def test_update_steps_the_optimizer(self):
+        learner, loss_module, model = self._make(lr=0.5)
+        before = model.weight.clone()
+        learner.update(self._batch(), loss_module)
+        assert not torch.equal(before, model.weight)
+
+    def test_loss_decreases_over_steps(self):
+        learner, loss_module, _ = self._make(lr=0.1)
+        torch.manual_seed(1)
+        batch = self._batch(64)
+        first = learner.update(batch, loss_module).get("loss_mse").item()
+        for _ in range(20):
+            last = learner.update(batch, loss_module).get("loss_mse").item()
+        assert last < first
+
+    def test_clip_grad_norm_writes_grad_norm(self):
+        learner, loss_module, _ = self._make(clip_grad_norm=0.5)
+        out = learner.update(self._batch(), loss_module)
+        assert "grad_norm" in out.keys()
+        assert out.get("grad_norm") >= 0
+
+    def test_no_clip_grad_norm_absent(self):
+        learner, loss_module, _ = self._make(clip_grad_norm=None)
+        out = learner.update(self._batch(), loss_module)
+        assert "grad_norm" not in out.keys()
+
+    def test_missing_loss_key_raises(self):
+        learner, _, model = self._make()
+        with pytest.raises(ValueError, match="no keys starting with 'loss'"):
+            learner.update(self._batch(), _NoLossKeyModule(model))
+
+    def test_grad_accumulation_defers_step(self):
+        learner, loss_module, model = self._make(grad_accum_steps=2, lr=1.0)
+        before = model.weight.clone()
+        learner.update(self._batch(), loss_module)
+        # optimizer has not stepped yet: weights unchanged after the 1st of 2 accum steps
+        assert torch.equal(before, model.weight)
+        learner.update(self._batch(), loss_module)
+        # after the 2nd accum step, the optimizer has stepped
+        assert not torch.equal(before, model.weight)
+
+    def test_get_weights_matches_model_params(self):
+        learner, _, model = self._make()
+        weights = learner.get_weights()
+        torch.testing.assert_close(weights["weight"], model.weight)
+        torch.testing.assert_close(weights["bias"], model.bias)
+
+    def test_invalid_grad_accum_steps_raises(self):
+        model = nn.Linear(4, 1)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        with pytest.raises(ValueError, match="grad_accum_steps must be"):
+            LocalLearner(model, optimizer, grad_accum_steps=0)
+
+    def test_base_learner_methods_are_abstract(self):
+        learner = Learner()
+        with pytest.raises(NotImplementedError):
+            learner.update(self._batch(), _ToyRegressionLoss(nn.Linear(4, 1)))
+        with pytest.raises(NotImplementedError):
+            learner.get_weights()
 
 
 if __name__ == "__main__":

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -2506,6 +2506,19 @@ class _ToyRegressionLoss(LossModule):
         return TensorDict({"loss_mse": loss, "metric": metric})
 
 
+class _ScaledRegressionLoss(LossModule):
+    """MSE loss with a loss-owned trainable scale, mimicking SACLoss's log_alpha."""
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+        self.scale = nn.Parameter(torch.tensor(2.0))
+
+    def forward(self, batch: TensorDict) -> TensorDict:
+        pred = self.model(batch["x"]) * self.scale
+        return TensorDict({"loss_mse": (pred - batch["y"]).pow(2).mean()})
+
+
 class _NoLossKeyModule(LossModule):
     """A LossModule whose output has no 'loss'-prefixed key (misconfigured)."""
 
@@ -2674,6 +2687,39 @@ class TestLocalLearner:
             "momentum_buffer"
         ]
         torch.testing.assert_close(restored_momentum, saved_momentum)
+
+    def test_checkpoint_round_trip_restores_loss_owned_params(self):
+        """Optimizer.state_dict() stores moments, not parameter values, so a
+        loss-owned parameter trained via Adam(loss_module.parameters()) must
+        be saved as extra_params or a resume silently keeps whatever value is
+        in memory."""
+        torch.manual_seed(0)
+        model = nn.Linear(4, 1)
+        loss_module = _ScaledRegressionLoss(model)
+        learner = LocalLearner(
+            model, torch.optim.Adam(loss_module.parameters(), lr=1e-2)
+        )
+        torch.manual_seed(2)
+        for _ in range(10):
+            learner.update(self._batch(), loss_module)
+        trained_scale = loss_module.scale.detach().clone()
+        assert not torch.equal(trained_scale, torch.tensor(2.0))
+        assert "scale" not in learner.get_weights().keys(True, True)
+
+        checkpoint = learner.checkpoint()
+        with torch.no_grad():
+            loss_module.scale.fill_(99.0)
+        learner.load_checkpoint(checkpoint)
+        torch.testing.assert_close(loss_module.scale.detach(), trained_scale)
+
+    def test_load_checkpoint_extra_params_mismatch_raises(self):
+        model = nn.Linear(4, 1)
+        loss_module = _ScaledRegressionLoss(model)
+        learner = LocalLearner(model, torch.optim.Adam(loss_module.parameters()))
+        checkpoint = learner.checkpoint()
+        checkpoint["extra_params"] = []
+        with pytest.raises(RuntimeError, match="outside the model"):
+            learner.load_checkpoint(checkpoint)
 
     def test_state_dict_keeps_the_nn_module_contract(self):
         # checkpoint()/load_checkpoint() carry the optimizer; state_dict() must
@@ -2933,6 +2979,36 @@ class TestFSDP2Learner:
             "momentum_buffer"
         ].full_tensor()
         torch.testing.assert_close(restored_momentum, saved_momentum)
+
+    def test_checkpoint_round_trip_restores_loss_owned_params(self):
+        """Same contract as the LocalLearner version: a loss-owned parameter
+        (unsharded, outside the model) must survive a checkpoint round trip."""
+        from torch.distributed._composable.fsdp import fully_shard
+        from torch.distributed.device_mesh import init_device_mesh
+
+        torch.manual_seed(0)
+        model = nn.Linear(4, 1)
+        mesh = init_device_mesh("cpu", (1,))
+        fully_shard(model, mesh=mesh)
+        loss_module = _ScaledRegressionLoss(model)
+        learner = FSDP2Learner(
+            model, torch.optim.Adam(loss_module.parameters(), lr=1e-2)
+        )
+        for _ in range(5):
+            learner.update(self._batch(seed=1), loss_module)
+        trained_scale = loss_module.scale.detach().clone()
+        assert not torch.equal(trained_scale, torch.tensor(2.0))
+        saved_exp_avg = learner.optimizer.state[loss_module.scale]["exp_avg"].clone()
+
+        checkpoint = learner.checkpoint()
+        with torch.no_grad():
+            loss_module.scale.fill_(99.0)
+            learner.optimizer.state[loss_module.scale]["exp_avg"].zero_()
+        learner.load_checkpoint(checkpoint)
+        torch.testing.assert_close(loss_module.scale.detach(), trained_scale)
+        torch.testing.assert_close(
+            learner.optimizer.state[loss_module.scale]["exp_avg"], saved_exp_avg
+        )
 
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -2604,6 +2604,37 @@ class TestLocalLearner:
         with pytest.raises(NotImplementedError):
             Learner().get_weights()
 
+    def test_state_dict_round_trip_includes_optimizer(self):
+        # plain nn.Module.state_dict() would silently drop the optimizer's
+        # state (Optimizer is not an nn.Module) -- this is the regression test
+        # for that gap. Momentum must be nonzero, or SGD never populates a
+        # momentum_buffer in its state to begin with.
+        torch.manual_seed(0)
+        model = nn.Linear(4, 1)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+        learner = LocalLearner(model, optimizer)
+        loss_module = _ToyRegressionLoss(model)
+        torch.manual_seed(2)
+        for _ in range(3):
+            learner.update(self._batch(), loss_module)
+        checkpoint = learner.state_dict()
+        saved_weight = model.weight.clone()
+        saved_momentum = next(iter(learner.optimizer.state.values()))[
+            "momentum_buffer"
+        ].clone()
+
+        with torch.no_grad():
+            model.weight.zero_()
+        for state in learner.optimizer.state.values():
+            state["momentum_buffer"].zero_()
+
+        learner.load_state_dict(checkpoint)
+        torch.testing.assert_close(model.weight, saved_weight)
+        restored_momentum = next(iter(learner.optimizer.state.values()))[
+            "momentum_buffer"
+        ]
+        torch.testing.assert_close(restored_momentum, saved_momentum)
+
 
 @pytest.mark.skipif(
     not torch.distributed.is_available(), reason="torch.distributed required"
@@ -2701,6 +2732,86 @@ class TestFSDP2Learner:
         gathered = fsdp2_learner.get_weights()
         torch.testing.assert_close(gathered["weight"], local_model.weight)
         torch.testing.assert_close(gathered["bias"], local_model.bias)
+
+    def test_grad_accumulation_defers_step(self):
+        learner, loss_module, model = self._make(grad_accum_steps=2, lr=1.0)
+        before = model.weight.full_tensor().clone()
+        learner.update(self._batch(seed=1), loss_module)
+        assert torch.equal(before, model.weight.full_tensor())
+        learner.update(self._batch(seed=2), loss_module)
+        assert not torch.equal(before, model.weight.full_tensor())
+
+    def test_grad_accumulation_matches_non_sharded_reference(self):
+        """Regression test for the set_requires_gradient_sync(False) toggle
+        update() uses to skip communication on non-final accumulation steps:
+        the accumulated gradient must still equal a plain (non-sharded)
+        reference that accumulates the same two micro-batches."""
+        from torch.distributed._composable.fsdp import fully_shard
+        from torch.distributed.device_mesh import init_device_mesh
+
+        batch1, batch2 = self._batch(seed=10), self._batch(seed=11)
+
+        # update() divides each micro-batch's loss by grad_accum_steps before
+        # backward (accumulation averages, rather than sums, the microbatches),
+        # so the reference must apply the same scaling.
+        torch.manual_seed(0)
+        ref_model = nn.Linear(4, 1)
+        ref_loss = _ToyRegressionLoss(ref_model)
+        ref_model.zero_grad()
+        (ref_loss(batch1).get("loss_mse") / 2).backward()
+        (ref_loss(batch2).get("loss_mse") / 2).backward()
+        ref_grad = ref_model.weight.grad.clone()
+
+        torch.manual_seed(0)
+        model = nn.Linear(4, 1)
+        mesh = init_device_mesh("cpu", (1,))
+        fully_shard(model, mesh=mesh)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        learner = FSDP2Learner(model, optimizer, grad_accum_steps=2)
+        loss_module = _ToyRegressionLoss(model)
+        learner.update(batch1, loss_module)  # sync disabled; .grad stays None
+        learner.update(batch2, loss_module)  # sync re-enabled; optimizer.step()
+        # optimizer.step() does not clear .grad (only zero_grad() does), so the
+        # fully-accumulated, synced gradient is still readable here.
+        accumulated_grad = model.weight.grad.full_tensor()
+        torch.testing.assert_close(accumulated_grad, ref_grad)
+
+    def test_state_dict_round_trip_includes_optimizer(self):
+        from torch.distributed._composable.fsdp import fully_shard
+        from torch.distributed.device_mesh import init_device_mesh
+
+        # momentum must be nonzero, or SGD never populates optimizer state to
+        # begin with, and the DCP loader has nothing meaningful to restore.
+        torch.manual_seed(0)
+        model = nn.Linear(4, 1)
+        mesh = init_device_mesh("cpu", (1,))
+        fully_shard(model, mesh=mesh)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+        learner = FSDP2Learner(model, optimizer)
+        loss_module = _ToyRegressionLoss(model)
+
+        torch.manual_seed(3)
+        for _ in range(3):
+            learner.update(self._batch(), loss_module)
+        checkpoint = learner.state_dict()
+        saved_weight = model.weight.full_tensor().clone()
+        saved_momentum = (
+            next(iter(optimizer.state.values()))["momentum_buffer"]
+            .full_tensor()
+            .clone()
+        )
+
+        with torch.no_grad():
+            model.weight.to_local().zero_()
+        for state in optimizer.state.values():
+            state["momentum_buffer"].to_local().zero_()
+
+        learner.load_state_dict(checkpoint)
+        torch.testing.assert_close(model.weight.full_tensor(), saved_weight)
+        restored_momentum = next(iter(optimizer.state.values()))[
+            "momentum_buffer"
+        ].full_tensor()
+        torch.testing.assert_close(restored_momentum, saved_momentum)
 
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -35,7 +35,13 @@ from torchrl.data import (
 from torchrl.envs.libs.gym import _has_gym
 from torchrl.objectives import LossModule
 from torchrl.testing import PONG_VERSIONED
-from torchrl.trainers import Learner, LocalLearner, LogValidationReward, Trainer
+from torchrl.trainers import (
+    FSDP2Learner,
+    Learner,
+    LocalLearner,
+    LogValidationReward,
+    Trainer,
+)
 from torchrl.trainers._execution import _Learner
 from torchrl.trainers.algorithms.a2c import A2CTrainer
 from torchrl.trainers.algorithms.cql import CQLTrainer
@@ -2592,12 +2598,110 @@ class TestLocalLearner:
         with pytest.raises(ValueError, match="grad_accum_steps must be"):
             LocalLearner(model, optimizer, grad_accum_steps=0)
 
-    def test_base_learner_methods_are_abstract(self):
-        learner = Learner()
+    def test_base_learner_get_weights_is_abstract(self):
+        # update() is concrete on Learner (shared by LocalLearner/FSDP2Learner);
+        # only get_weights() -- the backend-specific gather -- remains abstract.
         with pytest.raises(NotImplementedError):
-            learner.update(self._batch(), _ToyRegressionLoss(nn.Linear(4, 1)))
-        with pytest.raises(NotImplementedError):
-            learner.get_weights()
+            Learner().get_weights()
+
+
+@pytest.mark.skipif(
+    not torch.distributed.is_available(), reason="torch.distributed required"
+)
+class TestFSDP2Learner:
+    """FSDP2Learner exercised on a single-rank process group (gloo/CPU).
+
+    world_size=1 does not exercise cross-rank sharding, but it runs the exact
+    fully_shard()/DTensor code path FSDP2Learner is built on, so these tests
+    catch real API breakage, not just interface stubs.
+    """
+
+    _PORT = "29601"
+
+    @pytest.fixture(autouse=True)
+    def _process_group(self):
+        import torch.distributed as dist
+
+        os.environ.setdefault("MASTER_ADDR", "localhost")
+        os.environ["MASTER_PORT"] = self._PORT
+        dist.init_process_group(backend="gloo", rank=0, world_size=1)
+        try:
+            yield
+        finally:
+            dist.destroy_process_group()
+
+    @staticmethod
+    def _make(clip_grad_norm=None, grad_accum_steps=1, lr=0.1, seed=0):
+        from torch.distributed._composable.fsdp import fully_shard
+        from torch.distributed.device_mesh import init_device_mesh
+
+        torch.manual_seed(seed)
+        model = nn.Linear(4, 1)
+        mesh = init_device_mesh("cpu", (1,))
+        fully_shard(model, mesh=mesh)
+        optimizer = torch.optim.SGD(model.parameters(), lr=lr)
+        learner = FSDP2Learner(
+            model,
+            optimizer,
+            clip_grad_norm=clip_grad_norm,
+            grad_accum_steps=grad_accum_steps,
+        )
+        loss_module = _ToyRegressionLoss(model)
+        return learner, loss_module, model
+
+    @staticmethod
+    def _batch(n=8, seed=None):
+        if seed is not None:
+            torch.manual_seed(seed)
+        return TensorDict(
+            {"x": torch.randn(n, 4), "y": torch.randn(n, 1)}, batch_size=[n]
+        )
+
+    def test_update_returns_loss_and_metric(self):
+        learner, loss_module, _ = self._make()
+        out = learner.update(self._batch(seed=1), loss_module)
+        assert "loss_mse" in out.keys()
+        assert "metric" in out.keys()
+
+    def test_clip_grad_norm_writes_grad_norm(self):
+        learner, loss_module, _ = self._make(clip_grad_norm=0.5)
+        out = learner.update(self._batch(seed=1), loss_module)
+        assert "grad_norm" in out.keys()
+        assert out.get("grad_norm") >= 0
+
+    def test_get_weights_returns_plain_tensors(self):
+        learner, _, _ = self._make()
+        weights = learner.get_weights()
+        for leaf in weights.values(True, True):
+            assert not isinstance(leaf, torch.distributed.tensor.DTensor)
+
+    def test_capabilities_report_sharded(self):
+        learner, _, _ = self._make()
+        assert learner.capabilities.sharded
+        assert not learner.capabilities.remote
+
+    def test_matches_local_learner_bit_exact(self):
+        """The whole point of the abstraction: same update() logic, same
+        result, whether the model is sharded or not."""
+        batch = self._batch(n=8, seed=42)
+
+        fsdp2_learner, fsdp2_loss, fsdp2_model = self._make(
+            clip_grad_norm=1.0, lr=0.5, seed=0
+        )
+        fsdp2_out = fsdp2_learner.update(batch, fsdp2_loss)
+
+        torch.manual_seed(0)
+        local_model = nn.Linear(4, 1)
+        local_optimizer = torch.optim.SGD(local_model.parameters(), lr=0.5)
+        local_learner = LocalLearner(local_model, local_optimizer, clip_grad_norm=1.0)
+        local_loss = _ToyRegressionLoss(local_model)
+        local_out = local_learner.update(batch, local_loss)
+
+        assert fsdp2_out.get("loss_mse").item() == local_out.get("loss_mse").item()
+        gathered = fsdp2_learner.get_weights()
+        torch.testing.assert_close(gathered["weight"], local_model.weight)
+        torch.testing.assert_close(gathered["bias"], local_model.bias)
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import importlib.util
 import inspect
 import os
@@ -2517,6 +2518,45 @@ class _NoLossKeyModule(LossModule):
         return TensorDict({"mse": (pred - batch["y"]).pow(2).mean()})
 
 
+class _UnreducedLoss(LossModule):
+    """A LossModule returning a per-sample loss, as ``reduction="none"`` does."""
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, batch: TensorDict) -> TensorDict:
+        pred = self.model(batch["x"])
+        return TensorDict(
+            {"loss_mse": (pred - batch["y"]).pow(2).squeeze(-1)},
+            batch_size=batch.batch_size,
+        )
+
+
+class _TwoNetworkLoss(LossModule):
+    """A LossModule that owns a second trainable network, as real losses do.
+
+    Stands in for the SAC/REDQ shape where the loss module -- not the model
+    handed to the learner -- owns (or expands) some of the trainable
+    parameters.
+    """
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+        self.critic = nn.Linear(4, 1)
+
+    def forward(self, batch: TensorDict) -> TensorDict:
+        pred = self.model(batch["x"])
+        value = self.critic(batch["x"])
+        return TensorDict(
+            {
+                "loss_actor": (pred - batch["y"]).pow(2).mean(),
+                "loss_critic": (value - batch["y"]).pow(2).mean(),
+            }
+        )
+
+
 class TestLocalLearner:
     @staticmethod
     def _make(clip_grad_norm=None, grad_accum_steps=1, lr=0.1):
@@ -2604,7 +2644,7 @@ class TestLocalLearner:
         with pytest.raises(NotImplementedError):
             Learner().get_weights()
 
-    def test_state_dict_round_trip_includes_optimizer(self):
+    def test_checkpoint_round_trip_includes_optimizer(self):
         # plain nn.Module.state_dict() would silently drop the optimizer's
         # state (Optimizer is not an nn.Module) -- this is the regression test
         # for that gap. Momentum must be nonzero, or SGD never populates a
@@ -2617,7 +2657,7 @@ class TestLocalLearner:
         torch.manual_seed(2)
         for _ in range(3):
             learner.update(self._batch(), loss_module)
-        checkpoint = learner.state_dict()
+        checkpoint = learner.checkpoint()
         saved_weight = model.weight.clone()
         saved_momentum = next(iter(learner.optimizer.state.values()))[
             "momentum_buffer"
@@ -2628,12 +2668,93 @@ class TestLocalLearner:
         for state in learner.optimizer.state.values():
             state["momentum_buffer"].zero_()
 
-        learner.load_state_dict(checkpoint)
+        learner.load_checkpoint(checkpoint)
         torch.testing.assert_close(model.weight, saved_weight)
         restored_momentum = next(iter(learner.optimizer.state.values()))[
             "momentum_buffer"
         ]
         torch.testing.assert_close(restored_momentum, saved_momentum)
+
+    def test_state_dict_keeps_the_nn_module_contract(self):
+        # checkpoint()/load_checkpoint() carry the optimizer; state_dict() must
+        # stay a plain nn.Module state_dict, or nesting a Learner inside another
+        # module silently drops all of the learner's state (the parent calls
+        # child.state_dict(destination=...) and discards the return value).
+        model = nn.Linear(4, 1)
+        learner = LocalLearner(model, torch.optim.SGD(model.parameters(), lr=0.1))
+
+        parent = nn.Module()
+        parent.learner = learner
+        nested = parent.state_dict()
+        assert "learner.model.weight" in nested
+        assert "learner.model.bias" in nested
+        # round-trips through the standard contract, destination= included
+        destination = {}
+        learner.state_dict(destination=destination, prefix="p.", keep_vars=False)
+        assert "p.model.weight" in destination
+        parent.load_state_dict(nested)
+
+    def test_accum_window_is_not_resumed_mid_window(self):
+        # gradients are not part of the checkpoint, so resuming at accum_step=1
+        # with empty gradients would step after a single micro-batch
+        learner, loss_module, _ = self._make(grad_accum_steps=2)
+        learner.update(self._batch(), loss_module)
+        checkpoint = learner.checkpoint()
+        assert checkpoint["accum_step"] == 1
+        with pytest.warns(UserWarning, match="partial window is discarded"):
+            learner.load_checkpoint(checkpoint)
+        assert learner._accum_step == 0
+
+    def test_unreduced_loss_raises(self):
+        learner, _, model = self._make()
+        with pytest.raises(ValueError, match="must be a scalar"):
+            learner.update(self._batch(), _UnreducedLoss(model))
+
+    def test_optimizer_missing_loss_parameters_raises(self):
+        # the silent-failure mode this guards: the loss module owns a critic,
+        # the optimizer was built from the bare model, so the critic is
+        # differentiated on every step but never updated
+        torch.manual_seed(0)
+        model = nn.Linear(4, 1)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        learner = LocalLearner(model, optimizer)
+        with pytest.raises(RuntimeError, match="does not cover"):
+            learner.update(self._batch(), _TwoNetworkLoss(model))
+
+    def test_optimizer_over_loss_parameters_is_accepted(self):
+        torch.manual_seed(0)
+        model = nn.Linear(4, 1)
+        loss_module = _TwoNetworkLoss(model)
+        optimizer = torch.optim.SGD(loss_module.parameters(), lr=0.1)
+        learner = LocalLearner(model, optimizer)
+        critic_before = loss_module.critic.weight.clone()
+        out = learner.update(self._batch(), loss_module)
+        assert "loss_actor" in out.keys()
+        # the loss module's own network is actually trained
+        assert not torch.equal(critic_before, loss_module.critic.weight)
+
+    def test_grad_norm_clips_the_optimized_parameters(self):
+        # clipping must cover what is stepped, not self.model.parameters():
+        # with the loss module owning a critic, clipping only the model would
+        # leave the critic's gradient unclipped.
+        torch.manual_seed(0)
+        model = nn.Linear(4, 1)
+        loss_module = _TwoNetworkLoss(model)
+        optimizer = torch.optim.SGD(loss_module.parameters(), lr=0.0)
+        learner = LocalLearner(model, optimizer, clip_grad_norm=1e-6)
+        learner.update(self._batch(), loss_module)
+        grads = [p.grad for p in loss_module.parameters() if p.grad is not None]
+        total = torch.linalg.vector_norm(torch.cat([g.reshape(-1) for g in grads]))
+        assert total <= 1e-5
+
+    def test_capabilities_default_is_immutable(self):
+        # LearnerCapabilities is frozen, so the shared class-level default
+        # cannot be mutated into every other Learner instance
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            Learner.capabilities.sharded = True
+        learner, _, _ = self._make()
+        assert not learner.capabilities.sharded
+        assert not learner.capabilities.remote
 
 
 @pytest.mark.skipif(
@@ -2776,7 +2897,7 @@ class TestFSDP2Learner:
         accumulated_grad = model.weight.grad.full_tensor()
         torch.testing.assert_close(accumulated_grad, ref_grad)
 
-    def test_state_dict_round_trip_includes_optimizer(self):
+    def test_checkpoint_round_trip_includes_optimizer(self):
         from torch.distributed._composable.fsdp import fully_shard
         from torch.distributed.device_mesh import init_device_mesh
 
@@ -2793,7 +2914,7 @@ class TestFSDP2Learner:
         torch.manual_seed(3)
         for _ in range(3):
             learner.update(self._batch(), loss_module)
-        checkpoint = learner.state_dict()
+        checkpoint = learner.checkpoint()
         saved_weight = model.weight.full_tensor().clone()
         saved_momentum = (
             next(iter(optimizer.state.values()))["momentum_buffer"]
@@ -2806,7 +2927,7 @@ class TestFSDP2Learner:
         for state in optimizer.state.values():
             state["momentum_buffer"].to_local().zero_()
 
-        learner.load_state_dict(checkpoint)
+        learner.load_checkpoint(checkpoint)
         torch.testing.assert_close(model.weight.full_tensor(), saved_weight)
         restored_momentum = next(iter(optimizer.state.values()))[
             "momentum_buffer"

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -35,7 +35,7 @@ from torchrl.data import (
 from torchrl.envs.libs.gym import _has_gym
 from torchrl.objectives import LossModule
 from torchrl.testing import PONG_VERSIONED
-from torchrl.trainers import LogValidationReward, Trainer
+from torchrl.trainers import Learner, LocalLearner, LogValidationReward, Trainer
 from torchrl.trainers._execution import _Learner
 from torchrl.trainers.algorithms.a2c import A2CTrainer
 from torchrl.trainers.algorithms.cql import CQLTrainer
@@ -2484,8 +2484,120 @@ class TestGRPOTrainer:
 
         with pytest.raises(RuntimeError, match="no 'loss_\\*' keys"):
             stepper.step(trainer, _make_grpo_batch())
+class _ToyRegressionLoss(LossModule):
+    """Minimal LossModule: MSE loss plus a non-loss logging metric."""
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, batch: TensorDict) -> TensorDict:
+        pred = self.model(batch["x"])
+        loss = (pred - batch["y"]).pow(2).mean()
+        with torch.no_grad():
+            metric = pred.mean()  # a non-"loss"-prefixed field, for logging only
+        return TensorDict({"loss_mse": loss, "metric": metric})
 
 
+class _NoLossKeyModule(LossModule):
+    """A LossModule whose output has no 'loss'-prefixed key (misconfigured)."""
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, batch: TensorDict) -> TensorDict:
+        pred = self.model(batch["x"])
+        return TensorDict({"mse": (pred - batch["y"]).pow(2).mean()})
+
+
+class TestLocalLearner:
+    @staticmethod
+    def _make(clip_grad_norm=None, grad_accum_steps=1, lr=0.1):
+        torch.manual_seed(0)
+        model = nn.Linear(4, 1)
+        optimizer = torch.optim.SGD(model.parameters(), lr=lr)
+        learner = LocalLearner(
+            model,
+            optimizer,
+            clip_grad_norm=clip_grad_norm,
+            grad_accum_steps=grad_accum_steps,
+        )
+        loss_module = _ToyRegressionLoss(model)
+        return learner, loss_module, model
+
+    @staticmethod
+    def _batch(n=8):
+        return TensorDict(
+            {"x": torch.randn(n, 4), "y": torch.randn(n, 1)}, batch_size=[n]
+        )
+
+    def test_update_returns_loss_and_metric(self):
+        learner, loss_module, _ = self._make()
+        out = learner.update(self._batch(), loss_module)
+        assert "loss_mse" in out.keys()
+        assert "metric" in out.keys()
+        assert out.get("loss_mse").shape == ()
+
+    def test_update_steps_the_optimizer(self):
+        learner, loss_module, model = self._make(lr=0.5)
+        before = model.weight.clone()
+        learner.update(self._batch(), loss_module)
+        assert not torch.equal(before, model.weight)
+
+    def test_loss_decreases_over_steps(self):
+        learner, loss_module, _ = self._make(lr=0.1)
+        torch.manual_seed(1)
+        batch = self._batch(64)
+        first = learner.update(batch, loss_module).get("loss_mse").item()
+        for _ in range(20):
+            last = learner.update(batch, loss_module).get("loss_mse").item()
+        assert last < first
+
+    def test_clip_grad_norm_writes_grad_norm(self):
+        learner, loss_module, _ = self._make(clip_grad_norm=0.5)
+        out = learner.update(self._batch(), loss_module)
+        assert "grad_norm" in out.keys()
+        assert out.get("grad_norm") >= 0
+
+    def test_no_clip_grad_norm_absent(self):
+        learner, loss_module, _ = self._make(clip_grad_norm=None)
+        out = learner.update(self._batch(), loss_module)
+        assert "grad_norm" not in out.keys()
+
+    def test_missing_loss_key_raises(self):
+        learner, _, model = self._make()
+        with pytest.raises(ValueError, match="no keys starting with 'loss'"):
+            learner.update(self._batch(), _NoLossKeyModule(model))
+
+    def test_grad_accumulation_defers_step(self):
+        learner, loss_module, model = self._make(grad_accum_steps=2, lr=1.0)
+        before = model.weight.clone()
+        learner.update(self._batch(), loss_module)
+        # optimizer has not stepped yet: weights unchanged after the 1st of 2 accum steps
+        assert torch.equal(before, model.weight)
+        learner.update(self._batch(), loss_module)
+        # after the 2nd accum step, the optimizer has stepped
+        assert not torch.equal(before, model.weight)
+
+    def test_get_weights_matches_model_params(self):
+        learner, _, model = self._make()
+        weights = learner.get_weights()
+        torch.testing.assert_close(weights["weight"], model.weight)
+        torch.testing.assert_close(weights["bias"], model.bias)
+
+    def test_invalid_grad_accum_steps_raises(self):
+        model = nn.Linear(4, 1)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        with pytest.raises(ValueError, match="grad_accum_steps must be"):
+            LocalLearner(model, optimizer, grad_accum_steps=0)
+
+    def test_base_learner_methods_are_abstract(self):
+        learner = Learner()
+        with pytest.raises(NotImplementedError):
+            learner.update(self._batch(), _ToyRegressionLoss(nn.Linear(4, 1)))
+        with pytest.raises(NotImplementedError):
+            learner.get_weights()
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import argparse
-import dataclasses
 import importlib.util
 import inspect
 import os
@@ -20,6 +19,11 @@ from time import sleep
 import pytest
 import torch
 from torch import nn
+
+_has_fsdp2 = importlib.util.find_spec("torch.distributed._composable.fsdp") is not None
+if _has_fsdp2:
+    from torch.distributed._composable.fsdp import fully_shard
+    from torch.distributed.device_mesh import init_device_mesh
 
 _has_tb = importlib.util.find_spec("tensorboard") is not None
 
@@ -36,13 +40,7 @@ from torchrl.data import (
 from torchrl.envs.libs.gym import _has_gym
 from torchrl.objectives import LossModule
 from torchrl.testing import PONG_VERSIONED
-from torchrl.trainers import (
-    FSDP2Learner,
-    Learner,
-    LocalLearner,
-    LogValidationReward,
-    Trainer,
-)
+from torchrl.trainers import FSDP2Learner, LocalLearner, LogValidationReward, Trainer
 from torchrl.trainers._execution import _Learner
 from torchrl.trainers.algorithms.a2c import A2CTrainer
 from torchrl.trainers.algorithms.cql import CQLTrainer
@@ -2489,526 +2487,236 @@ class TestGRPOTrainer:
             progress_bar=False,
         )
 
-        with pytest.raises(RuntimeError, match="no 'loss_\\*' keys"):
+        with pytest.raises(ValueError, match="no keys starting with 'loss'"):
             stepper.step(trainer, _make_grpo_batch())
+
+
 class _ToyRegressionLoss(LossModule):
-    """Minimal LossModule: MSE loss plus a non-loss logging metric."""
-
     def __init__(self, model: nn.Module):
         super().__init__()
         self.model = model
 
     def forward(self, batch: TensorDict) -> TensorDict:
-        pred = self.model(batch["x"])
-        loss = (pred - batch["y"]).pow(2).mean()
-        with torch.no_grad():
-            metric = pred.mean()  # a non-"loss"-prefixed field, for logging only
-        return TensorDict({"loss_mse": loss, "metric": metric})
-
-
-class _ScaledRegressionLoss(LossModule):
-    """MSE loss with a loss-owned trainable scale, mimicking SACLoss's log_alpha."""
-
-    def __init__(self, model: nn.Module):
-        super().__init__()
-        self.model = model
-        self.scale = nn.Parameter(torch.tensor(2.0))
-
-    def forward(self, batch: TensorDict) -> TensorDict:
-        pred = self.model(batch["x"]) * self.scale
-        return TensorDict({"loss_mse": (pred - batch["y"]).pow(2).mean()})
-
-
-class _NoLossKeyModule(LossModule):
-    """A LossModule whose output has no 'loss'-prefixed key (misconfigured)."""
-
-    def __init__(self, model: nn.Module):
-        super().__init__()
-        self.model = model
-
-    def forward(self, batch: TensorDict) -> TensorDict:
-        pred = self.model(batch["x"])
-        return TensorDict({"mse": (pred - batch["y"]).pow(2).mean()})
-
-
-class _UnreducedLoss(LossModule):
-    """A LossModule returning a per-sample loss, as ``reduction="none"`` does."""
-
-    def __init__(self, model: nn.Module):
-        super().__init__()
-        self.model = model
-
-    def forward(self, batch: TensorDict) -> TensorDict:
-        pred = self.model(batch["x"])
+        prediction = self.model(batch["x"])
+        loss = (prediction - batch["y"]).pow(2).mean()
         return TensorDict(
-            {"loss_mse": (pred - batch["y"]).pow(2).squeeze(-1)},
-            batch_size=batch.batch_size,
+            {"loss_mse": loss, "prediction_mean": prediction.detach().mean()}
         )
 
 
-class _TwoNetworkLoss(LossModule):
-    """A LossModule that owns a second trainable network, as real losses do.
-
-    Stands in for the SAC/REDQ shape where the loss module -- not the model
-    handed to the learner -- owns (or expands) some of the trainable
-    parameters.
-    """
-
+class _ScaledRegressionLoss(_ToyRegressionLoss):
     def __init__(self, model: nn.Module):
-        super().__init__()
-        self.model = model
+        super().__init__(model)
+        self.scale = nn.Parameter(torch.tensor(2.0))
+
+    def forward(self, batch: TensorDict) -> TensorDict:
+        prediction = self.model(batch["x"]) * self.scale
+        return TensorDict({"loss_mse": (prediction - batch["y"]).pow(2).mean()})
+
+
+class _TwoNetworkLoss(_ToyRegressionLoss):
+    def __init__(self, model: nn.Module):
+        super().__init__(model)
         self.critic = nn.Linear(4, 1)
 
     def forward(self, batch: TensorDict) -> TensorDict:
-        pred = self.model(batch["x"])
+        prediction = self.model(batch["x"])
         value = self.critic(batch["x"])
         return TensorDict(
             {
-                "loss_actor": (pred - batch["y"]).pow(2).mean(),
+                "loss_actor": (prediction - batch["y"]).pow(2).mean(),
                 "loss_critic": (value - batch["y"]).pow(2).mean(),
             }
         )
 
 
+def _learner_batch(seed: int) -> TensorDict:
+    generator = torch.Generator().manual_seed(seed)
+    return TensorDict(
+        {
+            "x": torch.randn(8, 4, generator=generator),
+            "y": torch.randn(8, 1, generator=generator),
+        },
+        [8],
+    )
+
+
+def _make_local_learner(
+    *,
+    loss_type: type[LossModule] = _ToyRegressionLoss,
+    gradient_accumulation_steps: int = 1,
+    optimizer_on_model: bool = False,
+):
+    torch.manual_seed(0)
+    model = nn.Linear(4, 1)
+    loss_module = loss_type(model)
+    parameters = model.parameters() if optimizer_on_model else loss_module.parameters()
+    stepper = MixedPrecisionOptimizationStepper(
+        torch.optim.Adam(parameters, lr=0.05),
+        gradient_accumulation_steps=gradient_accumulation_steps,
+        clip_norm=1.0,
+    )
+    return LocalLearner(model, loss_module, stepper), model, loss_module, stepper
+
+
 class TestLocalLearner:
-    @staticmethod
-    def _make(clip_grad_norm=None, grad_accum_steps=1, lr=0.1):
+    def test_update_matches_the_trainer_stepper_contract(self):
+        learner, learner_model, _, learner_stepper = _make_local_learner(
+            gradient_accumulation_steps=2
+        )
+
         torch.manual_seed(0)
-        model = nn.Linear(4, 1)
-        optimizer = torch.optim.SGD(model.parameters(), lr=lr)
-        learner = LocalLearner(
-            model,
-            optimizer,
-            clip_grad_norm=clip_grad_norm,
-            grad_accum_steps=grad_accum_steps,
+        trainer_model = nn.Linear(4, 1)
+        trainer_loss = _ToyRegressionLoss(trainer_model)
+        trainer_stepper = MixedPrecisionOptimizationStepper(
+            torch.optim.Adam(trainer_loss.parameters(), lr=0.05),
+            gradient_accumulation_steps=2,
+            clip_norm=1.0,
         )
-        loss_module = _ToyRegressionLoss(model)
-        return learner, loss_module, model
-
-    @staticmethod
-    def _batch(n=8):
-        return TensorDict(
-            {"x": torch.randn(n, 4), "y": torch.randn(n, 1)}, batch_size=[n]
+        trainer = Trainer(
+            collector=MockingCollector(),
+            total_frames=16,
+            frame_skip=1,
+            optim_steps_per_batch=1,
+            loss_module=trainer_loss,
+            optimization_stepper=trainer_stepper,
+            progress_bar=False,
         )
 
-    def test_update_returns_loss_and_metric(self):
-        learner, loss_module, _ = self._make()
-        out = learner.update(self._batch(), loss_module)
-        assert "loss_mse" in out.keys()
-        assert "metric" in out.keys()
-        assert out.get("loss_mse").shape == ()
+        for seed in (1, 2):
+            learner_metrics = learner.update(_learner_batch(seed))
+            trainer_metrics = trainer_stepper.step(trainer, _learner_batch(seed))
+            torch.testing.assert_close(learner_metrics, trainer_metrics)
 
-    def test_update_steps_the_optimizer(self):
-        learner, loss_module, model = self._make(lr=0.5)
-        before = model.weight.clone()
-        learner.update(self._batch(), loss_module)
-        assert not torch.equal(before, model.weight)
+        torch.testing.assert_close(learner_model.weight, trainer_model.weight)
+        assert learner_stepper.optimizer_step_count == 1
+        assert trainer_stepper.optimizer_step_count == 1
 
-    def test_loss_decreases_over_steps(self):
-        learner, loss_module, _ = self._make(lr=0.1)
-        torch.manual_seed(1)
-        batch = self._batch(64)
-        first = learner.update(batch, loss_module).get("loss_mse").item()
-        for _ in range(20):
-            last = learner.update(batch, loss_module).get("loss_mse").item()
-        assert last < first
-
-    def test_clip_grad_norm_writes_grad_norm(self):
-        learner, loss_module, _ = self._make(clip_grad_norm=0.5)
-        out = learner.update(self._batch(), loss_module)
-        assert "grad_norm" in out.keys()
-        assert out.get("grad_norm") >= 0
-
-    def test_no_clip_grad_norm_absent(self):
-        learner, loss_module, _ = self._make(clip_grad_norm=None)
-        out = learner.update(self._batch(), loss_module)
-        assert "grad_norm" not in out.keys()
-
-    def test_missing_loss_key_raises(self):
-        learner, _, model = self._make()
-        with pytest.raises(ValueError, match="no keys starting with 'loss'"):
-            learner.update(self._batch(), _NoLossKeyModule(model))
-
-    def test_grad_accumulation_defers_step(self):
-        learner, loss_module, model = self._make(grad_accum_steps=2, lr=1.0)
-        before = model.weight.clone()
-        learner.update(self._batch(), loss_module)
-        # optimizer has not stepped yet: weights unchanged after the 1st of 2 accum steps
-        assert torch.equal(before, model.weight)
-        learner.update(self._batch(), loss_module)
-        # after the 2nd accum step, the optimizer has stepped
-        assert not torch.equal(before, model.weight)
-
-    def test_get_weights_matches_model_params(self):
-        learner, _, model = self._make()
+    def test_get_weights_returns_an_independent_snapshot(self):
+        learner, model, _, _ = _make_local_learner()
         weights = learner.get_weights()
-        torch.testing.assert_close(weights["weight"], model.weight)
-        torch.testing.assert_close(weights["bias"], model.bias)
-
-    def test_invalid_grad_accum_steps_raises(self):
-        model = nn.Linear(4, 1)
-        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
-        with pytest.raises(ValueError, match="grad_accum_steps must be"):
-            LocalLearner(model, optimizer, grad_accum_steps=0)
-
-    def test_base_learner_get_weights_is_abstract(self):
-        # update() is concrete on Learner (shared by LocalLearner/FSDP2Learner);
-        # only get_weights() -- the backend-specific gather -- remains abstract.
-        with pytest.raises(NotImplementedError):
-            Learner().get_weights()
-
-    def test_checkpoint_round_trip_includes_optimizer(self):
-        # plain nn.Module.state_dict() would silently drop the optimizer's
-        # state (Optimizer is not an nn.Module) -- this is the regression test
-        # for that gap. Momentum must be nonzero, or SGD never populates a
-        # momentum_buffer in its state to begin with.
-        torch.manual_seed(0)
-        model = nn.Linear(4, 1)
-        optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
-        learner = LocalLearner(model, optimizer)
-        loss_module = _ToyRegressionLoss(model)
-        torch.manual_seed(2)
-        for _ in range(3):
-            learner.update(self._batch(), loss_module)
-        checkpoint = learner.checkpoint()
-        saved_weight = model.weight.clone()
-        saved_momentum = next(iter(learner.optimizer.state.values()))[
-            "momentum_buffer"
-        ].clone()
 
         with torch.no_grad():
-            model.weight.zero_()
-        for state in learner.optimizer.state.values():
-            state["momentum_buffer"].zero_()
+            model.weight.add_(1)
 
-        learner.load_checkpoint(checkpoint)
-        torch.testing.assert_close(model.weight, saved_weight)
-        restored_momentum = next(iter(learner.optimizer.state.values()))[
-            "momentum_buffer"
-        ]
-        torch.testing.assert_close(restored_momentum, saved_momentum)
+        assert not torch.equal(weights["weight"], model.weight)
 
-    def test_checkpoint_round_trip_restores_loss_owned_params(self):
-        """Optimizer.state_dict() stores moments, not parameter values, so a
-        loss-owned parameter trained via Adam(loss_module.parameters()) must
-        be saved as extra_params or a resume silently keeps whatever value is
-        in memory."""
-        torch.manual_seed(0)
-        model = nn.Linear(4, 1)
-        loss_module = _ScaledRegressionLoss(model)
-        learner = LocalLearner(
-            model, torch.optim.Adam(loss_module.parameters(), lr=1e-2)
+    def test_checkpoint_restores_model_loss_and_optimization_state(self):
+        learner, model, loss_module, stepper = _make_local_learner(
+            loss_type=_ScaledRegressionLoss
         )
-        torch.manual_seed(2)
-        for _ in range(10):
-            learner.update(self._batch(), loss_module)
-        trained_scale = loss_module.scale.detach().clone()
-        assert not torch.equal(trained_scale, torch.tensor(2.0))
-        assert "scale" not in learner.get_weights().keys(True, True)
-
+        learner.update(_learner_batch(1))
         checkpoint = learner.checkpoint()
-        with torch.no_grad():
-            loss_module.scale.fill_(99.0)
+        expected_weight = model.weight.detach().clone()
+        expected_scale = loss_module.scale.detach().clone()
+        expected_moment = stepper.optimizer.state[loss_module.scale]["exp_avg"].clone()
+
+        learner.update(_learner_batch(2))
         learner.load_checkpoint(checkpoint)
-        torch.testing.assert_close(loss_module.scale.detach(), trained_scale)
 
-    def test_load_checkpoint_extra_params_mismatch_raises(self):
-        model = nn.Linear(4, 1)
-        loss_module = _ScaledRegressionLoss(model)
-        learner = LocalLearner(model, torch.optim.Adam(loss_module.parameters()))
-        checkpoint = learner.checkpoint()
-        checkpoint["extra_params"] = []
-        with pytest.raises(RuntimeError, match="outside the model"):
-            learner.load_checkpoint(checkpoint)
+        torch.testing.assert_close(model.weight, expected_weight)
+        torch.testing.assert_close(loss_module.scale, expected_scale)
+        torch.testing.assert_close(
+            stepper.optimizer.state[loss_module.scale]["exp_avg"], expected_moment
+        )
+        assert stepper.optimizer_step_count == 1
 
-    def test_state_dict_keeps_the_nn_module_contract(self):
-        # checkpoint()/load_checkpoint() carry the optimizer; state_dict() must
-        # stay a plain nn.Module state_dict, or nesting a Learner inside another
-        # module silently drops all of the learner's state (the parent calls
-        # child.state_dict(destination=...) and discards the return value).
-        model = nn.Linear(4, 1)
-        learner = LocalLearner(model, torch.optim.SGD(model.parameters(), lr=0.1))
+    def test_checkpoint_rejects_a_partial_accumulation_window(self):
+        learner, _, _, _ = _make_local_learner(gradient_accumulation_steps=2)
+        learner.update(_learner_batch(1))
 
-        parent = nn.Module()
-        parent.learner = learner
-        nested = parent.state_dict()
-        assert "learner.model.weight" in nested
-        assert "learner.model.bias" in nested
-        # round-trips through the standard contract, destination= included
-        destination = {}
-        learner.state_dict(destination=destination, prefix="p.", keep_vars=False)
-        assert "p.model.weight" in destination
-        parent.load_state_dict(nested)
+        with pytest.raises(RuntimeError, match="mid-accumulation"):
+            learner.checkpoint()
 
-    def test_accum_window_is_not_resumed_mid_window(self):
-        # gradients are not part of the checkpoint, so resuming at accum_step=1
-        # with empty gradients would step after a single micro-batch
-        learner, loss_module, _ = self._make(grad_accum_steps=2)
-        learner.update(self._batch(), loss_module)
-        checkpoint = learner.checkpoint()
-        assert checkpoint["accum_step"] == 1
-        with pytest.warns(UserWarning, match="partial window is discarded"):
-            learner.load_checkpoint(checkpoint)
-        assert learner._accum_step == 0
+    def test_optimizer_must_cover_differentiated_loss_parameters(self):
+        learner, _, _, _ = _make_local_learner(
+            loss_type=_TwoNetworkLoss,
+            optimizer_on_model=True,
+        )
 
-    def test_unreduced_loss_raises(self):
-        learner, _, model = self._make()
-        with pytest.raises(ValueError, match="must be a scalar"):
-            learner.update(self._batch(), _UnreducedLoss(model))
-
-    def test_optimizer_missing_loss_parameters_raises(self):
-        # the silent-failure mode this guards: the loss module owns a critic,
-        # the optimizer was built from the bare model, so the critic is
-        # differentiated on every step but never updated
-        torch.manual_seed(0)
-        model = nn.Linear(4, 1)
-        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
-        learner = LocalLearner(model, optimizer)
         with pytest.raises(RuntimeError, match="does not cover"):
-            learner.update(self._batch(), _TwoNetworkLoss(model))
-
-    def test_optimizer_over_loss_parameters_is_accepted(self):
-        torch.manual_seed(0)
-        model = nn.Linear(4, 1)
-        loss_module = _TwoNetworkLoss(model)
-        optimizer = torch.optim.SGD(loss_module.parameters(), lr=0.1)
-        learner = LocalLearner(model, optimizer)
-        critic_before = loss_module.critic.weight.clone()
-        out = learner.update(self._batch(), loss_module)
-        assert "loss_actor" in out.keys()
-        # the loss module's own network is actually trained
-        assert not torch.equal(critic_before, loss_module.critic.weight)
-
-    def test_grad_norm_clips_the_optimized_parameters(self):
-        # clipping must cover what is stepped, not self.model.parameters():
-        # with the loss module owning a critic, clipping only the model would
-        # leave the critic's gradient unclipped.
-        torch.manual_seed(0)
-        model = nn.Linear(4, 1)
-        loss_module = _TwoNetworkLoss(model)
-        optimizer = torch.optim.SGD(loss_module.parameters(), lr=0.0)
-        learner = LocalLearner(model, optimizer, clip_grad_norm=1e-6)
-        learner.update(self._batch(), loss_module)
-        grads = [p.grad for p in loss_module.parameters() if p.grad is not None]
-        total = torch.linalg.vector_norm(torch.cat([g.reshape(-1) for g in grads]))
-        assert total <= 1e-5
-
-    def test_capabilities_default_is_immutable(self):
-        # LearnerCapabilities is frozen, so the shared class-level default
-        # cannot be mutated into every other Learner instance
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            Learner.capabilities.sharded = True
-        learner, _, _ = self._make()
-        assert not learner.capabilities.sharded
-        assert not learner.capabilities.remote
+            learner.update(_learner_batch(1))
 
 
 @pytest.mark.skipif(
-    not torch.distributed.is_available(), reason="torch.distributed required"
+    not torch.distributed.is_available() or not _has_fsdp2,
+    reason="FSDP2 required",
 )
 class TestFSDP2Learner:
-    """FSDP2Learner exercised on a single-rank process group (gloo/CPU).
-
-    world_size=1 does not exercise cross-rank sharding, but it runs the exact
-    fully_shard()/DTensor code path FSDP2Learner is built on, so these tests
-    catch real API breakage, not just interface stubs.
-    """
-
     _PORT = "29601"
 
     @pytest.fixture(autouse=True)
     def _process_group(self):
-        import torch.distributed as dist
-
         os.environ.setdefault("MASTER_ADDR", "localhost")
         os.environ["MASTER_PORT"] = self._PORT
-        dist.init_process_group(backend="gloo", rank=0, world_size=1)
+        torch.distributed.init_process_group(backend="gloo", rank=0, world_size=1)
         try:
             yield
         finally:
-            dist.destroy_process_group()
+            torch.distributed.destroy_process_group()
 
     @staticmethod
-    def _make(clip_grad_norm=None, grad_accum_steps=1, lr=0.1, seed=0):
-        from torch.distributed._composable.fsdp import fully_shard
-        from torch.distributed.device_mesh import init_device_mesh
-
-        torch.manual_seed(seed)
+    def _make(
+        *,
+        loss_type: type[LossModule] = _ToyRegressionLoss,
+        gradient_accumulation_steps: int = 1,
+    ):
+        torch.manual_seed(0)
         model = nn.Linear(4, 1)
-        mesh = init_device_mesh("cpu", (1,))
-        fully_shard(model, mesh=mesh)
-        optimizer = torch.optim.SGD(model.parameters(), lr=lr)
-        learner = FSDP2Learner(
+        fully_shard(model, mesh=init_device_mesh("cpu", (1,)))
+        loss_module = loss_type(model)
+        stepper = MixedPrecisionOptimizationStepper(
+            torch.optim.Adam(loss_module.parameters(), lr=0.05),
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            clip_norm=1.0,
+        )
+        return (
+            FSDP2Learner(model, loss_module, stepper),
             model,
-            optimizer,
-            clip_grad_norm=clip_grad_norm,
-            grad_accum_steps=grad_accum_steps,
-        )
-        loss_module = _ToyRegressionLoss(model)
-        return learner, loss_module, model
-
-    @staticmethod
-    def _batch(n=8, seed=None):
-        if seed is not None:
-            torch.manual_seed(seed)
-        return TensorDict(
-            {"x": torch.randn(n, 4), "y": torch.randn(n, 1)}, batch_size=[n]
+            loss_module,
+            stepper,
         )
 
-    def test_update_returns_loss_and_metric(self):
-        learner, loss_module, _ = self._make()
-        out = learner.update(self._batch(seed=1), loss_module)
-        assert "loss_mse" in out.keys()
-        assert "metric" in out.keys()
-
-    def test_clip_grad_norm_writes_grad_norm(self):
-        learner, loss_module, _ = self._make(clip_grad_norm=0.5)
-        out = learner.update(self._batch(seed=1), loss_module)
-        assert "grad_norm" in out.keys()
-        assert out.get("grad_norm") >= 0
-
-    def test_get_weights_returns_plain_tensors(self):
-        learner, _, _ = self._make()
-        weights = learner.get_weights()
-        for leaf in weights.values(True, True):
-            assert not isinstance(leaf, torch.distributed.tensor.DTensor)
-
-    def test_capabilities_report_sharded(self):
-        learner, _, _ = self._make()
-        assert learner.capabilities.sharded
-        assert not learner.capabilities.remote
-
-    def test_matches_local_learner_bit_exact(self):
-        """The whole point of the abstraction: same update() logic, same
-        result, whether the model is sharded or not."""
-        batch = self._batch(n=8, seed=42)
-
-        fsdp2_learner, fsdp2_loss, fsdp2_model = self._make(
-            clip_grad_norm=1.0, lr=0.5, seed=0
+    def test_update_matches_local_and_publishes_plain_weights(self):
+        fsdp_learner, _, _, fsdp_stepper = self._make(gradient_accumulation_steps=2)
+        local_learner, local_model, _, local_stepper = _make_local_learner(
+            gradient_accumulation_steps=2
         )
-        fsdp2_out = fsdp2_learner.update(batch, fsdp2_loss)
 
-        torch.manual_seed(0)
-        local_model = nn.Linear(4, 1)
-        local_optimizer = torch.optim.SGD(local_model.parameters(), lr=0.5)
-        local_learner = LocalLearner(local_model, local_optimizer, clip_grad_norm=1.0)
-        local_loss = _ToyRegressionLoss(local_model)
-        local_out = local_learner.update(batch, local_loss)
+        for seed in (1, 2, 3, 4):
+            fsdp_metrics = fsdp_learner.update(_learner_batch(seed))
+            local_metrics = local_learner.update(_learner_batch(seed))
+            torch.testing.assert_close(fsdp_metrics, local_metrics)
 
-        assert fsdp2_out.get("loss_mse").item() == local_out.get("loss_mse").item()
-        gathered = fsdp2_learner.get_weights()
-        torch.testing.assert_close(gathered["weight"], local_model.weight)
-        torch.testing.assert_close(gathered["bias"], local_model.bias)
+        weights = fsdp_learner.get_weights()
+        torch.testing.assert_close(weights["weight"], local_model.weight)
+        assert all(
+            not isinstance(value, torch.distributed.tensor.DTensor)
+            for value in weights.values(True, True)
+        )
+        assert fsdp_stepper.optimizer_step_count == local_stepper.optimizer_step_count
+        assert fsdp_stepper.optimizer_step_count == 2
 
-    def test_grad_accumulation_defers_step(self):
-        learner, loss_module, model = self._make(grad_accum_steps=2, lr=1.0)
-        before = model.weight.full_tensor().clone()
-        learner.update(self._batch(seed=1), loss_module)
-        assert torch.equal(before, model.weight.full_tensor())
-        learner.update(self._batch(seed=2), loss_module)
-        assert not torch.equal(before, model.weight.full_tensor())
-
-    def test_grad_accumulation_matches_non_sharded_reference(self):
-        """Regression test for the set_requires_gradient_sync(False) toggle
-        update() uses to skip communication on non-final accumulation steps:
-        the accumulated gradient must still equal a plain (non-sharded)
-        reference that accumulates the same two micro-batches."""
-        from torch.distributed._composable.fsdp import fully_shard
-        from torch.distributed.device_mesh import init_device_mesh
-
-        batch1, batch2 = self._batch(seed=10), self._batch(seed=11)
-
-        # update() divides each micro-batch's loss by grad_accum_steps before
-        # backward (accumulation averages, rather than sums, the microbatches),
-        # so the reference must apply the same scaling.
-        torch.manual_seed(0)
-        ref_model = nn.Linear(4, 1)
-        ref_loss = _ToyRegressionLoss(ref_model)
-        ref_model.zero_grad()
-        (ref_loss(batch1).get("loss_mse") / 2).backward()
-        (ref_loss(batch2).get("loss_mse") / 2).backward()
-        ref_grad = ref_model.weight.grad.clone()
-
-        torch.manual_seed(0)
-        model = nn.Linear(4, 1)
-        mesh = init_device_mesh("cpu", (1,))
-        fully_shard(model, mesh=mesh)
-        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
-        learner = FSDP2Learner(model, optimizer, grad_accum_steps=2)
-        loss_module = _ToyRegressionLoss(model)
-        learner.update(batch1, loss_module)  # sync disabled; .grad stays None
-        learner.update(batch2, loss_module)  # sync re-enabled; optimizer.step()
-        # optimizer.step() does not clear .grad (only zero_grad() does), so the
-        # fully-accumulated, synced gradient is still readable here.
-        accumulated_grad = model.weight.grad.full_tensor()
-        torch.testing.assert_close(accumulated_grad, ref_grad)
-
-    def test_checkpoint_round_trip_includes_optimizer(self):
-        from torch.distributed._composable.fsdp import fully_shard
-        from torch.distributed.device_mesh import init_device_mesh
-
-        # momentum must be nonzero, or SGD never populates optimizer state to
-        # begin with, and the DCP loader has nothing meaningful to restore.
-        torch.manual_seed(0)
-        model = nn.Linear(4, 1)
-        mesh = init_device_mesh("cpu", (1,))
-        fully_shard(model, mesh=mesh)
-        optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
-        learner = FSDP2Learner(model, optimizer)
-        loss_module = _ToyRegressionLoss(model)
-
-        torch.manual_seed(3)
-        for _ in range(3):
-            learner.update(self._batch(), loss_module)
+    def test_checkpoint_restores_sharded_and_loss_owned_state(self):
+        learner, model, loss_module, stepper = self._make(
+            loss_type=_ScaledRegressionLoss
+        )
+        learner.update(_learner_batch(1))
         checkpoint = learner.checkpoint()
-        saved_weight = model.weight.full_tensor().clone()
-        saved_momentum = (
-            next(iter(optimizer.state.values()))["momentum_buffer"]
-            .full_tensor()
-            .clone()
-        )
+        expected_weight = model.weight.full_tensor().clone()
+        expected_scale = loss_module.scale.detach().clone()
+        expected_moment = stepper.optimizer.state[loss_module.scale]["exp_avg"].clone()
 
-        with torch.no_grad():
-            model.weight.to_local().zero_()
-        for state in optimizer.state.values():
-            state["momentum_buffer"].to_local().zero_()
-
+        learner.update(_learner_batch(2))
         learner.load_checkpoint(checkpoint)
-        torch.testing.assert_close(model.weight.full_tensor(), saved_weight)
-        restored_momentum = next(iter(optimizer.state.values()))[
-            "momentum_buffer"
-        ].full_tensor()
-        torch.testing.assert_close(restored_momentum, saved_momentum)
 
-    def test_checkpoint_round_trip_restores_loss_owned_params(self):
-        """Same contract as the LocalLearner version: a loss-owned parameter
-        (unsharded, outside the model) must survive a checkpoint round trip."""
-        from torch.distributed._composable.fsdp import fully_shard
-        from torch.distributed.device_mesh import init_device_mesh
-
-        torch.manual_seed(0)
-        model = nn.Linear(4, 1)
-        mesh = init_device_mesh("cpu", (1,))
-        fully_shard(model, mesh=mesh)
-        loss_module = _ScaledRegressionLoss(model)
-        learner = FSDP2Learner(
-            model, torch.optim.Adam(loss_module.parameters(), lr=1e-2)
-        )
-        for _ in range(5):
-            learner.update(self._batch(seed=1), loss_module)
-        trained_scale = loss_module.scale.detach().clone()
-        assert not torch.equal(trained_scale, torch.tensor(2.0))
-        saved_exp_avg = learner.optimizer.state[loss_module.scale]["exp_avg"].clone()
-
-        checkpoint = learner.checkpoint()
-        with torch.no_grad():
-            loss_module.scale.fill_(99.0)
-            learner.optimizer.state[loss_module.scale]["exp_avg"].zero_()
-        learner.load_checkpoint(checkpoint)
-        torch.testing.assert_close(loss_module.scale.detach(), trained_scale)
+        torch.testing.assert_close(model.weight.full_tensor(), expected_weight)
+        torch.testing.assert_close(loss_module.scale, expected_scale)
         torch.testing.assert_close(
-            learner.optimizer.state[loss_module.scale]["exp_avg"], saved_exp_avg
+            stepper.optimizer.state[loss_module.scale]["exp_avg"], expected_moment
         )
+        assert stepper.optimizer_step_count == 1
+
 
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()

--- a/torchrl/trainers/__init__.py
+++ b/torchrl/trainers/__init__.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from .learners import Learner, LearnerCapabilities, LocalLearner
 from .trainers import (
     BatchSubSampler,
     ClearCudaCache,
@@ -31,6 +32,9 @@ __all__ = [
     "CountFramesLog",
     "DefaultOptimizationStepper",
     "EarlyStopping",
+    "Learner",
+    "LearnerCapabilities",
+    "LocalLearner",
     "LogScalar",
     "LogTiming",
     "LogValidationReward",

--- a/torchrl/trainers/__init__.py
+++ b/torchrl/trainers/__init__.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .learners import Learner, LearnerCapabilities, LocalLearner
+from .learners import FSDP2Learner, Learner, LearnerCapabilities, LocalLearner
 from .trainers import (
     BatchSubSampler,
     ClearCudaCache,
@@ -32,6 +32,7 @@ __all__ = [
     "CountFramesLog",
     "DefaultOptimizationStepper",
     "EarlyStopping",
+    "FSDP2Learner",
     "Learner",
     "LearnerCapabilities",
     "LocalLearner",

--- a/torchrl/trainers/__init__.py
+++ b/torchrl/trainers/__init__.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from .learners import Learner, LearnerCapabilities, LocalLearner
 from .trainers import (
     BatchSubSampler,
     ClearCudaCache,
@@ -34,6 +35,9 @@ __all__ = [
     "CountFramesLog",
     "DefaultOptimizationStepper",
     "EarlyStopping",
+    "Learner",
+    "LearnerCapabilities",
+    "LocalLearner",
     "LogScalar",
     "LogTiming",
     "LogValidationReward",

--- a/torchrl/trainers/__init__.py
+++ b/torchrl/trainers/__init__.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .learners import Learner, LearnerCapabilities, LocalLearner
+from .learners import FSDP2Learner, Learner, LearnerCapabilities, LocalLearner
 from .trainers import (
     BatchSubSampler,
     ClearCudaCache,
@@ -35,6 +35,7 @@ __all__ = [
     "CountFramesLog",
     "DefaultOptimizationStepper",
     "EarlyStopping",
+    "FSDP2Learner",
     "Learner",
     "LearnerCapabilities",
     "LocalLearner",

--- a/torchrl/trainers/learners/__init__.py
+++ b/torchrl/trainers/learners/__init__.py
@@ -5,9 +5,11 @@
 from __future__ import annotations
 
 from torchrl.trainers.learners.common import Learner, LearnerCapabilities
+from torchrl.trainers.learners.fsdp2 import FSDP2Learner
 from torchrl.trainers.learners.local import LocalLearner
 
 __all__ = [
+    "FSDP2Learner",
     "Learner",
     "LearnerCapabilities",
     "LocalLearner",

--- a/torchrl/trainers/learners/__init__.py
+++ b/torchrl/trainers/learners/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+from torchrl.trainers.learners.common import Learner, LearnerCapabilities
+from torchrl.trainers.learners.local import LocalLearner
+
+__all__ = [
+    "Learner",
+    "LearnerCapabilities",
+    "LocalLearner",
+]

--- a/torchrl/trainers/learners/common.py
+++ b/torchrl/trainers/learners/common.py
@@ -1,0 +1,93 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tensordict import TensorDictBase
+from torch import nn
+
+from torchrl.objectives.common import LossModule
+
+
+@dataclass
+class LearnerCapabilities:
+    """Declares what a :class:`Learner` implementation supports.
+
+    Algorithm code is not expected to branch on these (that would defeat the
+    point of the abstraction); they exist for logging, validation, and for
+    orchestration code that needs to know, e.g., whether a learner can be
+    checkpointed independently on every rank.
+
+    Attributes:
+        sharded (bool): whether the learner's parameters are sharded across
+            multiple devices/processes (e.g. FSDP2). Defaults to ``False``.
+        remote (bool): whether :meth:`~Learner.update` dispatches to a
+            separate process rather than running in-line. Defaults to
+            ``False``.
+    """
+
+    sharded: bool = False
+    remote: bool = False
+
+
+class Learner(nn.Module):
+    """Base class for the trainable-policy role.
+
+    A :class:`Learner` owns a trainable model and exposes a single,
+    backend-agnostic entry point, :meth:`update`, for taking one optimization
+    step on a :class:`~tensordict.TensorDictBase` batch with a given
+    :class:`~torchrl.objectives.common.LossModule`. Algorithm code calls
+    ``learner.update(batch, loss_module)`` without knowing whether the update
+    runs locally on one device, under sharded (e.g. FSDP2) training, or on a
+    separate remote training process -- that placement is the ``Learner``
+    subclass's responsibility, not the algorithm's.
+
+    This mirrors the role :class:`~torchrl.collectors.Collector` plays for
+    data collection and :class:`~torchrl.modules.llm.LLMWrapperBase` plays for
+    generation/scoring: a fixed, TensorDict-native contract with multiple
+    interchangeable backends.
+
+    .. note::
+        ``update`` requires ``loss_module.forward`` to follow the
+        :class:`~torchrl.objectives.common.LossModule` convention: every
+        differentiable loss term is returned under a key starting with
+        ``"loss"`` (these are summed and used for the backward pass); any
+        other returned entry (e.g. ``accuracy``, a KL for logging) is treated
+        as a non-differentiable metric and left untouched.
+
+    .. seealso:: :class:`~torchrl.weight_update.WeightSyncScheme` consumes
+        :meth:`get_weights` to synchronize a learner's parameters to remote
+        inference workers, so a ``Learner`` composes with the existing
+        weight-sync machinery without changes on either side.
+    """
+
+    capabilities: LearnerCapabilities = LearnerCapabilities()
+
+    def update(self, batch: TensorDictBase, loss_module: LossModule) -> TensorDictBase:
+        """Take one optimization step on ``batch`` using ``loss_module``.
+
+        Args:
+            batch (TensorDictBase): a batch, in the format expected by
+                ``loss_module``.
+            loss_module (LossModule): computes the loss(es) for ``batch``.
+                Its output's ``"loss"``-prefixed keys are summed and
+                backpropagated; other keys are passed through for logging.
+
+        Returns:
+            TensorDictBase: the tensordict returned by ``loss_module``,
+            augmented with a ``"grad_norm"`` entry when gradient clipping is
+            enabled.
+        """
+        raise NotImplementedError
+
+    def get_weights(self) -> TensorDictBase:
+        """Return the learner's current parameters as a tensordict.
+
+        The returned tensordict is accepted as-is by
+        :meth:`~torchrl.weight_update.WeightSyncScheme.send`, so it is the
+        seam between the training role and the weight-sync/inference roles.
+        """
+        raise NotImplementedError

--- a/torchrl/trainers/learners/common.py
+++ b/torchrl/trainers/learners/common.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from tensordict import TensorDictBase
+import torch
+from tensordict import is_tensorclass, TensorDictBase
 from torch import nn
 
 from torchrl.objectives.common import LossModule
@@ -36,10 +37,10 @@ class LearnerCapabilities:
 class Learner(nn.Module):
     """Base class for the trainable-policy role.
 
-    A :class:`Learner` owns a trainable model and exposes a single,
-    backend-agnostic entry point, :meth:`update`, for taking one optimization
-    step on a :class:`~tensordict.TensorDictBase` batch with a given
-    :class:`~torchrl.objectives.common.LossModule`. Algorithm code calls
+    A :class:`Learner` owns a trainable model and an optimizer and exposes a
+    single, backend-agnostic entry point, :meth:`update`, for taking one
+    optimization step on a :class:`~tensordict.TensorDictBase` batch with a
+    given :class:`~torchrl.objectives.common.LossModule`. Algorithm code calls
     ``learner.update(batch, loss_module)`` without knowing whether the update
     runs locally on one device, under sharded (e.g. FSDP2) training, or on a
     separate remote training process -- that placement is the ``Learner``
@@ -49,6 +50,16 @@ class Learner(nn.Module):
     data collection and :class:`~torchrl.modules.llm.LLMWrapperBase` plays for
     generation/scoring: a fixed, TensorDict-native contract with multiple
     interchangeable backends.
+
+    :meth:`update` is implemented once, here, and is intentionally backend
+    agnostic: it only touches ``self.model``, ``self.optimizer``,
+    ``self.clip_grad_norm``, and ``self.grad_accum_steps``, all of which a
+    subclass sets in its constructor. This is what lets
+    :class:`~torchrl.trainers.learners.FSDP2Learner` reuse the exact same
+    training step as :class:`~torchrl.trainers.learners.LocalLearner`: sharded
+    training only changes how the model is constructed (wrapped with
+    ``fully_shard``) and how :meth:`get_weights` gathers the result, not how a
+    step is taken.
 
     .. note::
         ``update`` requires ``loss_module.forward`` to follow the
@@ -66,6 +77,12 @@ class Learner(nn.Module):
 
     capabilities: LearnerCapabilities = LearnerCapabilities()
 
+    model: nn.Module
+    optimizer: torch.optim.Optimizer
+    clip_grad_norm: float | None
+    grad_accum_steps: int
+    _accum_step: int
+
     def update(self, batch: TensorDictBase, loss_module: LossModule) -> TensorDictBase:
         """Take one optimization step on ``batch`` using ``loss_module``.
 
@@ -81,13 +98,45 @@ class Learner(nn.Module):
             augmented with a ``"grad_norm"`` entry when gradient clipping is
             enabled.
         """
-        raise NotImplementedError
+        if self._accum_step == 0:
+            self.optimizer.zero_grad(set_to_none=True)
+
+        loss_td = loss_module(batch)
+        loss_keys = [k for k in loss_td.keys() if k.startswith("loss")]
+        if not loss_keys:
+            raise ValueError(
+                "loss_module returned no keys starting with 'loss': "
+                f"{list(loss_td.keys())}. LossModule.forward must return at "
+                "least one 'loss'-prefixed entry."
+            )
+        total_loss = sum(loss_td.get(k) for k in loss_keys) / self.grad_accum_steps
+        total_loss.backward()
+
+        self._accum_step += 1
+        if self._accum_step < self.grad_accum_steps:
+            return loss_td
+        self._accum_step = 0
+
+        if self.clip_grad_norm is not None:
+            grad_norm = torch.nn.utils.clip_grad_norm_(
+                self.model.parameters(), self.clip_grad_norm
+            )
+            # loss_module may return a strict TensorClass (e.g. RewardModelLossOutput)
+            # that rejects undeclared keys; convert to a writable TensorDict first.
+            if is_tensorclass(loss_td):
+                loss_td = loss_td.to_tensordict()
+            loss_td.set("grad_norm", grad_norm)
+
+        self.optimizer.step()
+        return loss_td
 
     def get_weights(self) -> TensorDictBase:
         """Return the learner's current parameters as a tensordict.
 
-        The returned tensordict is accepted as-is by
-        :meth:`~torchrl.weight_update.WeightSyncScheme.send`, so it is the
-        seam between the training role and the weight-sync/inference roles.
+        The returned tensordict holds plain (fully materialized) tensors, even
+        when the learner's parameters are internally sharded, so it is
+        accepted as-is by :meth:`~torchrl.weight_update.WeightSyncScheme.send`.
+        This is the seam between the training role and the weight-sync /
+        inference roles.
         """
         raise NotImplementedError

--- a/torchrl/trainers/learners/common.py
+++ b/torchrl/trainers/learners/common.py
@@ -13,6 +13,25 @@ from torch import nn
 from torchrl.objectives.common import LossModule
 
 
+def _clone_tensors(obj):
+    """Recursively clone every tensor in a (possibly nested) state-dict-like structure.
+
+    ``nn.Module.state_dict()`` and ``Optimizer.state_dict()`` both return
+    views onto their live tensors, not independent copies, so holding onto
+    their output as a "checkpoint" while training continues silently mutates
+    that checkpoint too.
+    """
+    if isinstance(obj, torch.Tensor):
+        return obj.clone()
+    if isinstance(obj, dict):
+        return {k: _clone_tensors(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_clone_tensors(v) for v in obj]
+    if isinstance(obj, tuple):
+        return tuple(_clone_tensors(v) for v in obj)
+    return obj
+
+
 @dataclass
 class LearnerCapabilities:
     """Declares what a :class:`Learner` implementation supports.
@@ -61,6 +80,16 @@ class Learner(nn.Module):
     ``fully_shard``) and how :meth:`get_weights` gathers the result, not how a
     step is taken.
 
+    During gradient accumulation, if ``self.model`` exposes
+    ``set_requires_gradient_sync`` (as an FSDP2 ``fully_shard``-wrapped module
+    does), :meth:`update` disables cross-rank gradient synchronization on
+    every accumulation step except the last: gradients still accumulate
+    correctly (verified against a non-sharded reference), but the
+    communication (reduce-scatter) only happens once per accumulation window
+    instead of once per micro-batch. This is a no-op for
+    :class:`~torchrl.trainers.learners.LocalLearner`, whose model has no such
+    method.
+
     .. note::
         ``update`` requires ``loss_module.forward`` to follow the
         :class:`~torchrl.objectives.common.LossModule` convention: every
@@ -73,6 +102,17 @@ class Learner(nn.Module):
         :meth:`get_weights` to synchronize a learner's parameters to remote
         inference workers, so a ``Learner`` composes with the existing
         weight-sync machinery without changes on either side.
+
+    .. warning::
+        :meth:`state_dict` / :meth:`load_state_dict` are overridden (relative
+        to plain :class:`torch.nn.Module`) to checkpoint the optimizer state
+        alongside the model: a bare :class:`~torch.optim.Optimizer` is not an
+        ``nn.Module``, so the default ``nn.Module.state_dict()`` would
+        silently omit it, corrupting a training resume (Adam's moments, etc.,
+        would reset). Subclasses whose model/optimizer need
+        sharding-aware (DTensor) checkpointing, e.g.
+        :class:`~torchrl.trainers.learners.FSDP2Learner`, override these two
+        methods again with a DTensor-aware implementation.
     """
 
     capabilities: LearnerCapabilities = LearnerCapabilities()
@@ -100,6 +140,13 @@ class Learner(nn.Module):
         """
         if self._accum_step == 0:
             self.optimizer.zero_grad(set_to_none=True)
+
+        # Sharded (e.g. FSDP2) models can defer the cross-rank gradient
+        # reduction until the last micro-batch of an accumulation window;
+        # LocalLearner's plain model has no such method, so this is a no-op.
+        set_grad_sync = getattr(self.model, "set_requires_gradient_sync", None)
+        if set_grad_sync is not None:
+            set_grad_sync(self._accum_step == self.grad_accum_steps - 1)
 
         loss_td = loss_module(batch)
         loss_keys = [k for k in loss_td.keys() if k.startswith("loss")]
@@ -140,3 +187,25 @@ class Learner(nn.Module):
         inference roles.
         """
         raise NotImplementedError
+
+    def state_dict(self, *args, **kwargs) -> dict:  # noqa: D417
+        """Return a checkpoint covering the model, optimizer, and accumulation state.
+
+        See the class-level warning: this intentionally does not reuse plain
+        :meth:`torch.nn.Module.state_dict`, which would silently drop the
+        optimizer's state. The returned tensors are independent clones (both
+        ``nn.Module.state_dict()`` and ``Optimizer.state_dict()`` otherwise
+        return views onto the live parameters/state, so an in-place update
+        after checkpointing would silently corrupt the "saved" checkpoint too).
+        """
+        return {
+            "model": _clone_tensors(self.model.state_dict()),
+            "optimizer": _clone_tensors(self.optimizer.state_dict()),
+            "accum_step": self._accum_step,
+        }
+
+    def load_state_dict(self, state_dict: dict, *args, **kwargs) -> None:  # noqa: D417
+        """Restore a checkpoint produced by :meth:`state_dict`."""
+        self.model.load_state_dict(state_dict["model"])
+        self.optimizer.load_state_dict(state_dict["optimizer"])
+        self._accum_step = state_dict.get("accum_step", 0)

--- a/torchrl/trainers/learners/common.py
+++ b/torchrl/trainers/learners/common.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 
 import torch
@@ -32,9 +33,13 @@ def _clone_tensors(obj):
     return obj
 
 
-@dataclass
+@dataclass(frozen=True)
 class LearnerCapabilities:
     """Declares what a :class:`Learner` implementation supports.
+
+    Frozen, so the class-level default on :attr:`Learner.capabilities` can be
+    shared between instances without one learner's mutation leaking into every
+    other.
 
     Algorithm code is not expected to branch on these (that would defeat the
     point of the abstraction); they exist for logging, validation, and for
@@ -98,23 +103,48 @@ class Learner(nn.Module):
         other returned entry (e.g. ``accuracy``, a KL for logging) is treated
         as a non-differentiable metric and left untouched.
 
+    .. warning::
+        **The optimizer, not** ``model``\\ **, defines what is trained.**
+        ``model`` is the weight-sync source (:meth:`get_weights`) and the
+        gradient-sync handle; the parameters that are clipped and stepped are
+        the ones in ``optimizer.param_groups``. Several TorchRL losses hold
+        their trainable parameters on the *loss module* as
+        :class:`~tensordict.nn.TensorDictParams` -- and for losses that expand
+        their networks (``SACLoss``, ``REDQLoss``, ...) those are copies, not
+        the modules you passed in -- so the canonical construction is
+        ``optimizer = Adam(loss_module.parameters())``. Building the optimizer
+        from ``model.parameters()`` in that case leaves the critics untrained.
+        :meth:`update` checks this before its first optimizer step and raises
+        if a parameter received a gradient that no param group covers.
+
+    .. note::
+        A single ``Learner`` owns a single optimizer, so algorithms that
+        deliberately use several (separate actor / critic / entropy-temperature
+        optimizers, different learning rates per network) are not expressible
+        as one ``Learner`` today. Pass a single optimizer over
+        ``loss_module.parameters()``, or use one ``Learner`` per optimizer.
+
     .. seealso:: :class:`~torchrl.weight_update.WeightSyncScheme` consumes
         :meth:`get_weights` to synchronize a learner's parameters to remote
         inference workers, so a ``Learner`` composes with the existing
         weight-sync machinery without changes on either side.
 
     .. warning::
-        :meth:`state_dict` / :meth:`load_state_dict` are overridden (relative
-        to plain :class:`torch.nn.Module`) to checkpoint the optimizer state
-        alongside the model: a bare :class:`~torch.optim.Optimizer` is not an
-        ``nn.Module``, so the default ``nn.Module.state_dict()`` would
-        silently omit it, corrupting a training resume (Adam's moments, etc.,
-        would reset). Subclasses whose model/optimizer need
-        sharding-aware (DTensor) checkpointing, e.g.
-        :class:`~torchrl.trainers.learners.FSDP2Learner`, override these two
-        methods again with a DTensor-aware implementation.
+        Checkpointing is :meth:`checkpoint` / :meth:`load_checkpoint`, *not*
+        ``state_dict`` / ``load_state_dict``. A bare
+        :class:`~torch.optim.Optimizer` is not an ``nn.Module``, so
+        ``nn.Module.state_dict()`` silently omits its state and a training
+        resume would reset Adam's moments; but overriding ``state_dict`` to
+        return the optimizer too would break the ``nn.Module`` contract
+        (``destination`` / ``prefix`` / ``keep_vars`` are positional there, and
+        a parent module calling ``child.state_dict(destination=...)`` discards
+        the return value -- so nesting a ``Learner`` inside any other module
+        would silently drop all of its state). Separate names keep both
+        contracts intact: ``state_dict`` behaves exactly as ``nn.Module``'s,
+        and :meth:`checkpoint` covers model + optimizer + accumulation state.
     """
 
+    #: Frozen, so this class-level default is safe to share between instances.
     capabilities: LearnerCapabilities = LearnerCapabilities()
 
     model: nn.Module
@@ -122,6 +152,41 @@ class Learner(nn.Module):
     clip_grad_norm: float | None
     grad_accum_steps: int
     _accum_step: int
+    _checked_optimizer_coverage: bool = False
+
+    def _optimized_parameters(self) -> list[torch.nn.Parameter]:
+        """Every parameter the optimizer will step -- what to clip, too."""
+        return [p for group in self.optimizer.param_groups for p in group["params"]]
+
+    def _check_optimizer_coverage(self, loss_module: LossModule) -> None:
+        """Fail loudly if a parameter got a gradient no param group will step.
+
+        Best effort by construction: it can only see the parameters that have a
+        gradient at the first optimizer step, so a loss term that only becomes
+        active later is not covered. It catches the common and otherwise silent
+        mistake of building the optimizer from a bare model while the loss
+        module owns (or expands) the trainable parameters.
+        """
+        optimized = {id(p) for p in self._optimized_parameters()}
+        missing = [
+            name
+            for name, param in loss_module.named_parameters()
+            if param.grad is not None and id(param) not in optimized
+        ]
+        if missing:
+            shown = ", ".join(missing[:5])
+            if len(missing) > 5:
+                shown += f", ... (+{len(missing) - 5} more)"
+            raise RuntimeError(
+                f"{type(self).__name__}'s optimizer does not cover "
+                f"{len(missing)} parameter(s) of the loss module that received "
+                f"a gradient: {shown}. Those parameters are differentiated but "
+                "never stepped, so they would stay frozen for the whole run. "
+                "Build the optimizer over the loss module's parameters "
+                "(e.g. `Adam(loss_module.parameters())`) rather than over a "
+                "bare model: losses that expand their networks hold copies of "
+                "them, not the modules you passed in."
+            )
 
     def update(self, batch: TensorDictBase, loss_module: LossModule) -> TensorDictBase:
         """Take one optimization step on ``batch`` using ``loss_module``.
@@ -134,9 +199,18 @@ class Learner(nn.Module):
                 backpropagated; other keys are passed through for logging.
 
         Returns:
-            TensorDictBase: the tensordict returned by ``loss_module``,
-            augmented with a ``"grad_norm"`` entry when gradient clipping is
-            enabled.
+            TensorDictBase: the tensordict returned by ``loss_module``. On the
+            calls that actually step the optimizer (every call unless
+            ``grad_accum_steps > 1``) it additionally carries ``"grad_norm"``
+            when ``clip_grad_norm`` is set -- so with gradient accumulation the
+            output key set differs between accumulation calls and step calls.
+
+        Raises:
+            ValueError: if ``loss_module`` returns no ``"loss"``-prefixed key,
+                or if the summed loss is not a scalar (which is what a loss
+                built with ``reduction="none"`` produces).
+            RuntimeError: if a parameter received a gradient that the optimizer
+                does not cover -- see the class-level warning.
         """
         if self._accum_step == 0:
             self.optimizer.zero_grad(set_to_none=True)
@@ -149,6 +223,9 @@ class Learner(nn.Module):
             set_grad_sync(self._accum_step == self.grad_accum_steps - 1)
 
         loss_td = loss_module(batch)
+        # "loss" (no underscore) is a real out_key -- DQNLoss, GAILLoss and
+        # OnlineDTLoss all use it -- so this prefix cannot be tightened to
+        # "loss_" without silently dropping their entire loss.
         loss_keys = [k for k in loss_td.keys() if k.startswith("loss")]
         if not loss_keys:
             raise ValueError(
@@ -157,6 +234,15 @@ class Learner(nn.Module):
                 "least one 'loss'-prefixed entry."
             )
         total_loss = sum(loss_td.get(k) for k in loss_keys) / self.grad_accum_steps
+        if total_loss.numel() != 1:
+            raise ValueError(
+                f"The summed loss must be a scalar to be backpropagated, but "
+                f"{loss_keys} summed to shape {tuple(total_loss.shape)}. This "
+                "is what a loss module built with `reduction='none'` returns; "
+                "use reduction='mean' (or 'sum') for the loss driving a "
+                "Learner, and compute per-sample losses separately if you need "
+                "them for logging."
+            )
         total_loss.backward()
 
         self._accum_step += 1
@@ -164,9 +250,15 @@ class Learner(nn.Module):
             return loss_td
         self._accum_step = 0
 
+        if not self._checked_optimizer_coverage:
+            self._check_optimizer_coverage(loss_module)
+            self._checked_optimizer_coverage = True
+
         if self.clip_grad_norm is not None:
+            # Clip what is about to be stepped, which is not necessarily
+            # ``self.model.parameters()`` -- see the class-level warning.
             grad_norm = torch.nn.utils.clip_grad_norm_(
-                self.model.parameters(), self.clip_grad_norm
+                self._optimized_parameters(), self.clip_grad_norm
             )
             # loss_module may return a strict TensorClass (e.g. RewardModelLossOutput)
             # that rejects undeclared keys; convert to a writable TensorDict first.
@@ -188,15 +280,23 @@ class Learner(nn.Module):
         """
         raise NotImplementedError
 
-    def state_dict(self, *args, **kwargs) -> dict:  # noqa: D417
-        """Return a checkpoint covering the model, optimizer, and accumulation state.
+    def checkpoint(self) -> dict:
+        """Return a checkpoint covering the model, optimizer and accumulation state.
 
-        See the class-level warning: this intentionally does not reuse plain
-        :meth:`torch.nn.Module.state_dict`, which would silently drop the
-        optimizer's state. The returned tensors are independent clones (both
-        ``nn.Module.state_dict()`` and ``Optimizer.state_dict()`` otherwise
-        return views onto the live parameters/state, so an in-place update
-        after checkpointing would silently corrupt the "saved" checkpoint too).
+        Deliberately *not* ``state_dict``: see the class-level warning.
+        ``state_dict`` keeps its :class:`~torch.nn.Module` meaning (so a
+        ``Learner`` can be nested inside another module without losing state),
+        and this method adds what ``state_dict`` structurally cannot carry --
+        the optimizer, which is not an ``nn.Module``.
+
+        The returned tensors are independent clones: both
+        ``nn.Module.state_dict()`` and ``Optimizer.state_dict()`` return views
+        onto the live parameters/state, so an in-place update after
+        checkpointing would otherwise silently corrupt the "saved" checkpoint
+        too.
+
+        Returns:
+            dict: with keys ``"model"``, ``"optimizer"`` and ``"accum_step"``.
         """
         return {
             "model": _clone_tensors(self.model.state_dict()),
@@ -204,8 +304,33 @@ class Learner(nn.Module):
             "accum_step": self._accum_step,
         }
 
-    def load_state_dict(self, state_dict: dict, *args, **kwargs) -> None:  # noqa: D417
-        """Restore a checkpoint produced by :meth:`state_dict`."""
-        self.model.load_state_dict(state_dict["model"])
-        self.optimizer.load_state_dict(state_dict["optimizer"])
-        self._accum_step = state_dict.get("accum_step", 0)
+    def load_checkpoint(self, checkpoint: dict) -> None:
+        """Restore a checkpoint produced by :meth:`checkpoint`.
+
+        Args:
+            checkpoint (dict): as returned by :meth:`checkpoint`.
+
+        .. note::
+            Gradients are not part of the checkpoint, so a checkpoint taken
+            mid-accumulation-window cannot be resumed mid-window: the
+            accumulation counter is reset to 0 (with a warning) rather than
+            resuming from a non-zero step with empty gradients, which would
+            step the optimizer after fewer micro-batches than
+            ``grad_accum_steps`` and therefore under-scale that update.
+        """
+        self.model.load_state_dict(checkpoint["model"])
+        self.optimizer.load_state_dict(checkpoint["optimizer"])
+        self._restore_accum_step(checkpoint.get("accum_step", 0))
+
+    def _restore_accum_step(self, accum_step: int) -> None:
+        if accum_step:
+            warnings.warn(
+                f"This checkpoint was taken {accum_step} step(s) into a "
+                f"{self.grad_accum_steps}-step gradient accumulation window. "
+                "Gradients are not checkpointed, so the partial window is "
+                "discarded and accumulation restarts from 0.",
+                UserWarning,
+                stacklevel=3,
+            )
+            self.optimizer.zero_grad(set_to_none=True)
+        self._accum_step = 0

--- a/torchrl/trainers/learners/common.py
+++ b/torchrl/trainers/learners/common.py
@@ -4,54 +4,39 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING
 
 import torch
-from tensordict import is_tensorclass, TensorDictBase
+from tensordict import TensorDictBase
 from torch import nn
 
 from torchrl.objectives.common import LossModule
 
+if TYPE_CHECKING:
+    from torchrl.trainers.trainers import OptimizationStepper
 
-def _clone_tensors(obj):
-    """Recursively clone every tensor in a (possibly nested) state-dict-like structure.
 
-    ``nn.Module.state_dict()`` and ``Optimizer.state_dict()`` both return
-    views onto their live tensors, not independent copies, so holding onto
-    their output as a "checkpoint" while training continues silently mutates
-    that checkpoint too.
-    """
+def _clone_tensors(obj: Any) -> Any:
+    """Clone tensors in a state-dict-like structure."""
     if isinstance(obj, torch.Tensor):
         return obj.clone()
     if isinstance(obj, dict):
-        return {k: _clone_tensors(v) for k, v in obj.items()}
+        return {key: _clone_tensors(value) for key, value in obj.items()}
     if isinstance(obj, list):
-        return [_clone_tensors(v) for v in obj]
+        return [_clone_tensors(value) for value in obj]
     if isinstance(obj, tuple):
-        return tuple(_clone_tensors(v) for v in obj)
+        return tuple(_clone_tensors(value) for value in obj)
     return obj
 
 
 @dataclass(frozen=True)
 class LearnerCapabilities:
-    """Declares what a :class:`Learner` implementation supports.
-
-    Frozen, so the class-level default on :attr:`Learner.capabilities` can be
-    shared between instances without one learner's mutation leaking into every
-    other.
-
-    Algorithm code is not expected to branch on these (that would defeat the
-    point of the abstraction); they exist for logging, validation, and for
-    orchestration code that needs to know, e.g., whether a learner can be
-    checkpointed independently on every rank.
+    """Placement capabilities exposed by a :class:`Learner` backend.
 
     Attributes:
-        sharded (bool): whether the learner's parameters are sharded across
-            multiple devices/processes (e.g. FSDP2). Defaults to ``False``.
-        remote (bool): whether :meth:`~Learner.update` dispatches to a
-            separate process rather than running in-line. Defaults to
-            ``False``.
+        sharded (bool): Whether parameters are sharded across processes.
+        remote (bool): Whether updates execute in another process.
     """
 
     sharded: bool = False
@@ -59,326 +44,130 @@ class LearnerCapabilities:
 
 
 class Learner(nn.Module):
-    r"""Base class for the trainable-policy role.
+    r"""Backend-agnostic execution boundary for policy optimization.
 
-    A :class:`Learner` owns a trainable model and an optimizer and exposes a
-    single, backend-agnostic entry point, :meth:`update`, for taking one
-    optimization step on a :class:`~tensordict.TensorDictBase` batch with a
-    given :class:`~torchrl.objectives.common.LossModule`. Algorithm code calls
-    ``learner.update(batch, loss_module)`` without knowing whether the update
-    runs locally on one device, under sharded (e.g. FSDP2) training, or on a
-    separate remote training process -- that placement is the ``Learner``
-    subclass's responsibility, not the algorithm's.
+    A learner owns the model whose weights are published, the loss module, and
+    an :class:`~torchrl.trainers.OptimizationStepper`. The learner decides
+    *where* an update runs and how weights are materialized; the stepper is the
+    single owner of *how* optimization runs, including loss reduction,
+    backward, gradient accumulation, clipping, mixed precision, and optimizer
+    stepping. This is the same stepper contract used by
+    :class:`~torchrl.trainers.Trainer`.
 
-    This mirrors the role :class:`~torchrl.collectors.Collector` plays for
-    data collection and :class:`~torchrl.modules.llm.LLMWrapperBase` plays for
-    generation/scoring: a fixed, TensorDict-native contract with multiple
-    interchangeable backends.
+    Algorithm code therefore calls ``learner.update(batch)`` without carrying
+    a second optimization policy or knowing whether the model is local or
+    sharded.
 
-    :meth:`update` is implemented once, here, and is intentionally backend
-    agnostic: it only touches ``self.model``, ``self.optimizer``,
-    ``self.clip_grad_norm``, and ``self.grad_accum_steps``, all of which a
-    subclass sets in its constructor. This is what lets
-    :class:`~torchrl.trainers.learners.FSDP2Learner` reuse the exact same
-    training step as :class:`~torchrl.trainers.learners.LocalLearner`: sharded
-    training only changes how the model is constructed (wrapped with
-    ``fully_shard``) and how :meth:`get_weights` gathers the result, not how a
-    step is taken.
-
-    During gradient accumulation, if ``self.model`` exposes
-    ``set_requires_gradient_sync`` (as an FSDP2 ``fully_shard``-wrapped module
-    does), :meth:`update` disables cross-rank gradient synchronization on
-    every accumulation step except the last: gradients still accumulate
-    correctly (verified against a non-sharded reference), but the
-    communication (reduce-scatter) only happens once per accumulation window
-    instead of once per micro-batch. This is a no-op for
-    :class:`~torchrl.trainers.learners.LocalLearner`, whose model has no such
-    method.
+    Args:
+        model (torch.nn.Module): Module whose parameters are published by
+            :meth:`get_weights`.
+        loss_module (LossModule): Loss evaluated for each update.
+        optimization_stepper (OptimizationStepper): Optimization policy. The
+            standard choice is
+            :class:`~torchrl.trainers.MixedPrecisionOptimizationStepper`,
+            including for full-precision training.
 
     .. note::
-        ``update`` requires ``loss_module.forward`` to follow the
-        :class:`~torchrl.objectives.common.LossModule` convention: every
-        differentiable loss term is returned under a key starting with
-        ``"loss"`` (these are summed and used for the backward pass); any
-        other returned entry (e.g. ``accuracy``, a KL for logging) is treated
-        as a non-differentiable metric and left untouched.
-
-    .. warning::
-        **The optimizer, not** ``model``\\ **, defines what is trained.**
-        ``model`` is the weight-sync source (:meth:`get_weights`) and the
-        gradient-sync handle; the parameters that are clipped and stepped are
-        the ones in ``optimizer.param_groups``. Several TorchRL losses hold
-        their trainable parameters on the *loss module* as
-        :class:`~tensordict.nn.TensorDictParams` -- and for losses that expand
-        their networks (``SACLoss``, ``REDQLoss``, ...) those are copies, not
-        the modules you passed in -- so the canonical construction is
-        ``optimizer = Adam(loss_module.parameters())``. Building the optimizer
-        from ``model.parameters()`` in that case leaves the critics untrained.
-        :meth:`update` checks this before its first optimizer step and raises
-        if a parameter received a gradient that no param group covers.
-
-    .. note::
-        A single ``Learner`` owns a single optimizer, so algorithms that
-        deliberately use several (separate actor / critic / entropy-temperature
-        optimizers, different learning rates per network) are not expressible
-        as one ``Learner`` today. Pass a single optimizer over
-        ``loss_module.parameters()``, or use one ``Learner`` per optimizer.
-
-    .. seealso:: :class:`~torchrl.weight_update.WeightSyncScheme` consumes
-        :meth:`get_weights` to synchronize a learner's parameters to remote
-        inference workers, so a ``Learner`` composes with the existing
-        weight-sync machinery without changes on either side.
-
-    .. warning::
-        Checkpointing is :meth:`checkpoint` / :meth:`load_checkpoint`, *not*
-        ``state_dict`` / ``load_state_dict``. A bare
-        :class:`~torch.optim.Optimizer` is not an ``nn.Module``, so
-        ``nn.Module.state_dict()`` silently omits its state and a training
-        resume would reset Adam's moments; but overriding ``state_dict`` to
-        return the optimizer too would break the ``nn.Module`` contract
-        (``destination`` / ``prefix`` / ``keep_vars`` are positional there, and
-        a parent module calling ``child.state_dict(destination=...)`` discards
-        the return value -- so nesting a ``Learner`` inside any other module
-        would silently drop all of its state). Separate names keep both
-        contracts intact: ``state_dict`` behaves exactly as ``nn.Module``'s,
-        and :meth:`checkpoint` covers model + optimizer + loss-owned optimized
-        parameters + accumulation state.
+        ``checkpoint`` / ``load_checkpoint`` compose model, loss-module, and
+        stepper state. ``state_dict`` keeps its ordinary ``nn.Module`` meaning
+        so a learner remains safe to nest inside another module.
     """
 
-    #: Frozen, so this class-level default is safe to share between instances.
     capabilities: LearnerCapabilities = LearnerCapabilities()
 
-    model: nn.Module
-    optimizer: torch.optim.Optimizer
-    clip_grad_norm: float | None
-    grad_accum_steps: int
-    _accum_step: int
-    _checked_optimizer_coverage: bool = False
+    def __init__(
+        self,
+        model: nn.Module,
+        loss_module: LossModule,
+        optimization_stepper: OptimizationStepper,
+    ):
+        super().__init__()
+        self.model = model
+        self.loss_module = loss_module
+        self.optimization_stepper = optimization_stepper
+
+    @property
+    def optimizer(self) -> torch.optim.Optimizer:
+        """Optimizer owned by the configured stepper.
+
+        FSDP2 checkpointing currently requires a single optimizer. Custom
+        multi-optimizer steppers remain usable for updates but must provide
+        their own distributed checkpoint implementation.
+        """
+        optimizer = getattr(self.optimization_stepper, "optimizer", None)
+        if not isinstance(optimizer, torch.optim.Optimizer):
+            raise RuntimeError(
+                f"{type(self).__name__} requires an optimizer-owning "
+                "OptimizationStepper for this operation."
+            )
+        return optimizer
 
     def _optimized_parameters(self) -> list[torch.nn.Parameter]:
-        """Every parameter the optimizer will step -- what to clip, too."""
-        return [p for group in self.optimizer.param_groups for p in group["params"]]
+        return [
+            parameter
+            for group in self.optimizer.param_groups
+            for parameter in group["params"]
+        ]
 
     def _extra_optimized_parameters(self) -> list[torch.nn.Parameter]:
-        """Optimized parameters living outside ``model`` (e.g. loss-owned).
+        model_parameters = {id(parameter) for parameter in self.model.parameters()}
+        return [
+            parameter
+            for parameter in self._optimized_parameters()
+            if id(parameter) not in model_parameters
+        ]
 
-        With the canonical ``Adam(loss_module.parameters())`` construction,
-        losses that own trainable parameters (``SACLoss``'s ``log_alpha``, a
-        Lagrange multiplier, ...) step parameters that ``model.state_dict()``
-        never sees. These are identified positionally, in param-group order,
-        which is stable as long as save and load use the same optimizer
-        construction -- the same assumption ``Optimizer.state_dict()`` itself
-        relies on.
-        """
-        model_params = {id(p) for p in self.model.parameters()}
-        return [p for p in self._optimized_parameters() if id(p) not in model_params]
-
-    def _restore_extra_params(self, checkpoint: dict) -> None:
-        extras = self._extra_optimized_parameters()
+    def _restore_extra_params(self, checkpoint: dict[str, Any]) -> None:
+        parameters = self._extra_optimized_parameters()
         saved = checkpoint.get("extra_params", [])
-        if len(saved) != len(extras):
+        if len(saved) != len(parameters):
             raise RuntimeError(
                 f"This checkpoint carries {len(saved)} optimized parameter(s) "
-                f"living outside the model, but the current optimizer has "
-                f"{len(extras)}. Save and load must use the same optimizer "
-                "construction (same param groups over the same modules)."
+                f"outside the published model, but the current stepper has "
+                f"{len(parameters)}."
             )
         with torch.no_grad():
-            for param, value in zip(extras, saved):
-                param.copy_(value)
+            for parameter, value in zip(parameters, saved):
+                parameter.copy_(value)
 
-    def _check_optimizer_coverage(self, loss_module: LossModule) -> None:
-        """Fail loudly if a parameter got a gradient no param group will step.
+    def compute_loss(
+        self, batch: TensorDictBase, method: str | None = None
+    ) -> TensorDictBase | tuple[Any, ...]:
+        """Evaluate the learner-owned loss through the stepper context."""
+        if method is None:
+            return self.loss_module(batch)
+        return getattr(self.loss_module, method)(batch)
 
-        Best effort by construction: it can only see the parameters that have a
-        gradient at the first optimizer step, so a loss term that only becomes
-        active later is not covered. It catches the common and otherwise silent
-        mistake of building the optimizer from a bare model while the loss
-        module owns (or expands) the trainable parameters.
+    def _set_requires_gradient_sync(self, requires_sync: bool) -> None:
+        setter = getattr(self.model, "set_requires_gradient_sync", None)
+        if setter is not None:
+            setter(requires_sync)
+
+    def update(self, batch: TensorDictBase) -> TensorDictBase:
+        """Update the learner from one TensorDict micro-batch.
+
+        The returned TensorDict contains detached scalar metrics, matching the
+        :class:`~torchrl.trainers.OptimizationStepper` contract used by
+        :class:`~torchrl.trainers.Trainer`.
         """
-        optimized = {id(p) for p in self._optimized_parameters()}
-        missing = [
-            name
-            for name, param in loss_module.named_parameters()
-            if param.grad is not None and id(param) not in optimized
-        ]
-        if missing:
-            shown = ", ".join(missing[:5])
-            if len(missing) > 5:
-                shown += f", ... (+{len(missing) - 5} more)"
-            raise RuntimeError(
-                f"{type(self).__name__}'s optimizer does not cover "
-                f"{len(missing)} parameter(s) of the loss module that received "
-                f"a gradient: {shown}. Those parameters are differentiated but "
-                "never stepped, so they would stay frozen for the whole run. "
-                "Build the optimizer over the loss module's parameters "
-                "(e.g. `Adam(loss_module.parameters())`) rather than over a "
-                "bare model: losses that expand their networks hold copies of "
-                "them, not the modules you passed in."
-            )
-
-    def update(self, batch: TensorDictBase, loss_module: LossModule) -> TensorDictBase:
-        """Take one optimization step on ``batch`` using ``loss_module``.
-
-        Args:
-            batch (TensorDictBase): a batch, in the format expected by
-                ``loss_module``.
-            loss_module (LossModule): computes the loss(es) for ``batch``.
-                Its output's ``"loss"``-prefixed keys are summed and
-                backpropagated; other keys are passed through for logging.
-
-        Returns:
-            TensorDictBase: the tensordict returned by ``loss_module``. On the
-            calls that actually step the optimizer (every call unless
-            ``grad_accum_steps > 1``) it additionally carries ``"grad_norm"``
-            when ``clip_grad_norm`` is set -- so with gradient accumulation the
-            output key set differs between accumulation calls and step calls.
-
-        Raises:
-            ValueError: if ``loss_module`` returns no ``"loss"``-prefixed key,
-                or if the summed loss is not a scalar (which is what a loss
-                built with ``reduction="none"`` produces).
-            RuntimeError: if a parameter received a gradient that the optimizer
-                does not cover -- see the class-level warning.
-        """
-        if self._accum_step == 0:
-            self.optimizer.zero_grad(set_to_none=True)
-
-        # Sharded (e.g. FSDP2) models can defer the cross-rank gradient
-        # reduction until the last micro-batch of an accumulation window;
-        # LocalLearner's plain model has no such method, so this is a no-op.
-        set_grad_sync = getattr(self.model, "set_requires_gradient_sync", None)
-        if set_grad_sync is not None:
-            set_grad_sync(self._accum_step == self.grad_accum_steps - 1)
-
-        loss_td = loss_module(batch)
-        # "loss" (no underscore) is a real out_key -- DQNLoss, GAILLoss and
-        # OnlineDTLoss all use it -- so this prefix cannot be tightened to
-        # "loss_" without silently dropping their entire loss.
-        loss_keys = [k for k in loss_td.keys() if k.startswith("loss")]
-        if not loss_keys:
-            raise ValueError(
-                "loss_module returned no keys starting with 'loss': "
-                f"{list(loss_td.keys())}. LossModule.forward must return at "
-                "least one 'loss'-prefixed entry."
-            )
-        total_loss = sum(loss_td.get(k) for k in loss_keys) / self.grad_accum_steps
-        if total_loss.numel() != 1:
-            raise ValueError(
-                f"The summed loss must be a scalar to be backpropagated, but "
-                f"{loss_keys} summed to shape {tuple(total_loss.shape)}. This "
-                "is what a loss module built with `reduction='none'` returns; "
-                "use reduction='mean' (or 'sum') for the loss driving a "
-                "Learner, and compute per-sample losses separately if you need "
-                "them for logging."
-            )
-        total_loss.backward()
-
-        self._accum_step += 1
-        if self._accum_step < self.grad_accum_steps:
-            return loss_td
-        self._accum_step = 0
-
-        if not self._checked_optimizer_coverage:
-            self._check_optimizer_coverage(loss_module)
-            self._checked_optimizer_coverage = True
-
-        if self.clip_grad_norm is not None:
-            # Clip what is about to be stepped, which is not necessarily
-            # ``self.model.parameters()`` -- see the class-level warning.
-            grad_norm = torch.nn.utils.clip_grad_norm_(
-                self._optimized_parameters(), self.clip_grad_norm
-            )
-            # loss_module may return a strict TensorClass (e.g. RewardModelLossOutput)
-            # that rejects undeclared keys; convert to a writable TensorDict first.
-            if is_tensorclass(loss_td):
-                loss_td = loss_td.to_tensordict()
-            loss_td.set("grad_norm", grad_norm)
-
-        self.optimizer.step()
-        return loss_td
+        return self.optimization_stepper._step(self, batch)
 
     def get_weights(self) -> TensorDictBase:
-        """Return the learner's current parameters as a tensordict.
-
-        The returned tensordict holds plain (fully materialized) tensors, even
-        when the learner's parameters are internally sharded, so it is
-        accepted as-is by :meth:`~torchrl.weight_update.WeightSyncScheme.send`.
-        This is the seam between the training role and the weight-sync /
-        inference roles.
-
-        .. note::
-            Only ``model`` is reported, by design: inference workers need the
-            policy's weights, not loss-owned parameters (an entropy
-            temperature, a Lagrange multiplier, ...). Loss-owned optimized
-            parameters are covered by :meth:`checkpoint` instead.
-        """
+        """Return a detached, plain-tensor snapshot of published weights."""
         raise NotImplementedError
 
-    def checkpoint(self) -> dict:
-        """Return a checkpoint covering the model, optimizer and accumulation state.
-
-        Deliberately *not* ``state_dict``: see the class-level warning.
-        ``state_dict`` keeps its :class:`~torch.nn.Module` meaning (so a
-        ``Learner`` can be nested inside another module without losing state),
-        and this method adds what ``state_dict`` structurally cannot carry --
-        the optimizer, which is not an ``nn.Module``.
-
-        The returned tensors are independent clones: both
-        ``nn.Module.state_dict()`` and ``Optimizer.state_dict()`` return views
-        onto the live parameters/state, so an in-place update after
-        checkpointing would otherwise silently corrupt the "saved" checkpoint
-        too.
-
-        ``Optimizer.state_dict()`` stores per-parameter *state* (e.g. Adam
-        moments), not the parameter values themselves, so optimized parameters
-        living outside ``model`` -- loss-owned parameters such as ``SACLoss``'s
-        ``log_alpha`` under the canonical ``Adam(loss_module.parameters())``
-        construction -- would otherwise be trained but silently dropped on
-        resume. Their values are saved under ``"extra_params"`` (in param-group
-        order) and restored by :meth:`load_checkpoint`.
-
-        Returns:
-            dict: with keys ``"model"``, ``"optimizer"``, ``"extra_params"``
-            and ``"accum_step"``.
-        """
+    def checkpoint(self) -> dict[str, Any]:
+        """Return independent model, loss, and optimization state."""
         return {
             "model": _clone_tensors(self.model.state_dict()),
-            "optimizer": _clone_tensors(self.optimizer.state_dict()),
-            "extra_params": [
-                p.detach().clone() for p in self._extra_optimized_parameters()
-            ],
-            "accum_step": self._accum_step,
+            "loss_module": _clone_tensors(self.loss_module.state_dict()),
+            "optimization_stepper": _clone_tensors(
+                self.optimization_stepper.state_dict()
+            ),
         }
 
-    def load_checkpoint(self, checkpoint: dict) -> None:
-        """Restore a checkpoint produced by :meth:`checkpoint`.
-
-        Args:
-            checkpoint (dict): as returned by :meth:`checkpoint`.
-
-        .. note::
-            Gradients are not part of the checkpoint, so a checkpoint taken
-            mid-accumulation-window cannot be resumed mid-window: the
-            accumulation counter is reset to 0 (with a warning) rather than
-            resuming from a non-zero step with empty gradients, which would
-            step the optimizer after fewer micro-batches than
-            ``grad_accum_steps`` and therefore under-scale that update.
-        """
+    def load_checkpoint(self, checkpoint: dict[str, Any]) -> None:
+        """Restore a checkpoint produced by :meth:`checkpoint`."""
         self.model.load_state_dict(checkpoint["model"])
-        self.optimizer.load_state_dict(checkpoint["optimizer"])
-        self._restore_extra_params(checkpoint)
-        self._restore_accum_step(checkpoint.get("accum_step", 0))
-
-    def _restore_accum_step(self, accum_step: int) -> None:
-        if accum_step:
-            warnings.warn(
-                f"This checkpoint was taken {accum_step} step(s) into a "
-                f"{self.grad_accum_steps}-step gradient accumulation window. "
-                "Gradients are not checkpointed, so the partial window is "
-                "discarded and accumulation restarts from 0.",
-                UserWarning,
-                stacklevel=3,
-            )
-            self.optimizer.zero_grad(set_to_none=True)
-        self._accum_step = 0
+        self.loss_module.load_state_dict(checkpoint["loss_module"])
+        self.optimization_stepper.load_state_dict(checkpoint["optimization_stepper"])

--- a/torchrl/trainers/learners/common.py
+++ b/torchrl/trainers/learners/common.py
@@ -59,7 +59,7 @@ class LearnerCapabilities:
 
 
 class Learner(nn.Module):
-    """Base class for the trainable-policy role.
+    r"""Base class for the trainable-policy role.
 
     A :class:`Learner` owns a trainable model and an optimizer and exposes a
     single, backend-agnostic entry point, :meth:`update`, for taking one
@@ -141,7 +141,8 @@ class Learner(nn.Module):
         the return value -- so nesting a ``Learner`` inside any other module
         would silently drop all of its state). Separate names keep both
         contracts intact: ``state_dict`` behaves exactly as ``nn.Module``'s,
-        and :meth:`checkpoint` covers model + optimizer + accumulation state.
+        and :meth:`checkpoint` covers model + optimizer + loss-owned optimized
+        parameters + accumulation state.
     """
 
     #: Frozen, so this class-level default is safe to share between instances.
@@ -157,6 +158,34 @@ class Learner(nn.Module):
     def _optimized_parameters(self) -> list[torch.nn.Parameter]:
         """Every parameter the optimizer will step -- what to clip, too."""
         return [p for group in self.optimizer.param_groups for p in group["params"]]
+
+    def _extra_optimized_parameters(self) -> list[torch.nn.Parameter]:
+        """Optimized parameters living outside ``model`` (e.g. loss-owned).
+
+        With the canonical ``Adam(loss_module.parameters())`` construction,
+        losses that own trainable parameters (``SACLoss``'s ``log_alpha``, a
+        Lagrange multiplier, ...) step parameters that ``model.state_dict()``
+        never sees. These are identified positionally, in param-group order,
+        which is stable as long as save and load use the same optimizer
+        construction -- the same assumption ``Optimizer.state_dict()`` itself
+        relies on.
+        """
+        model_params = {id(p) for p in self.model.parameters()}
+        return [p for p in self._optimized_parameters() if id(p) not in model_params]
+
+    def _restore_extra_params(self, checkpoint: dict) -> None:
+        extras = self._extra_optimized_parameters()
+        saved = checkpoint.get("extra_params", [])
+        if len(saved) != len(extras):
+            raise RuntimeError(
+                f"This checkpoint carries {len(saved)} optimized parameter(s) "
+                f"living outside the model, but the current optimizer has "
+                f"{len(extras)}. Save and load must use the same optimizer "
+                "construction (same param groups over the same modules)."
+            )
+        with torch.no_grad():
+            for param, value in zip(extras, saved):
+                param.copy_(value)
 
     def _check_optimizer_coverage(self, loss_module: LossModule) -> None:
         """Fail loudly if a parameter got a gradient no param group will step.
@@ -277,6 +306,12 @@ class Learner(nn.Module):
         accepted as-is by :meth:`~torchrl.weight_update.WeightSyncScheme.send`.
         This is the seam between the training role and the weight-sync /
         inference roles.
+
+        .. note::
+            Only ``model`` is reported, by design: inference workers need the
+            policy's weights, not loss-owned parameters (an entropy
+            temperature, a Lagrange multiplier, ...). Loss-owned optimized
+            parameters are covered by :meth:`checkpoint` instead.
         """
         raise NotImplementedError
 
@@ -295,12 +330,24 @@ class Learner(nn.Module):
         checkpointing would otherwise silently corrupt the "saved" checkpoint
         too.
 
+        ``Optimizer.state_dict()`` stores per-parameter *state* (e.g. Adam
+        moments), not the parameter values themselves, so optimized parameters
+        living outside ``model`` -- loss-owned parameters such as ``SACLoss``'s
+        ``log_alpha`` under the canonical ``Adam(loss_module.parameters())``
+        construction -- would otherwise be trained but silently dropped on
+        resume. Their values are saved under ``"extra_params"`` (in param-group
+        order) and restored by :meth:`load_checkpoint`.
+
         Returns:
-            dict: with keys ``"model"``, ``"optimizer"`` and ``"accum_step"``.
+            dict: with keys ``"model"``, ``"optimizer"``, ``"extra_params"``
+            and ``"accum_step"``.
         """
         return {
             "model": _clone_tensors(self.model.state_dict()),
             "optimizer": _clone_tensors(self.optimizer.state_dict()),
+            "extra_params": [
+                p.detach().clone() for p in self._extra_optimized_parameters()
+            ],
             "accum_step": self._accum_step,
         }
 
@@ -320,6 +367,7 @@ class Learner(nn.Module):
         """
         self.model.load_state_dict(checkpoint["model"])
         self.optimizer.load_state_dict(checkpoint["optimizer"])
+        self._restore_extra_params(checkpoint)
         self._restore_accum_step(checkpoint.get("accum_step", 0))
 
     def _restore_accum_step(self, accum_step: int) -> None:

--- a/torchrl/trainers/learners/fsdp2.py
+++ b/torchrl/trainers/learners/fsdp2.py
@@ -11,11 +11,16 @@ from torch import nn
 from torchrl.trainers.learners.common import Learner, LearnerCapabilities
 
 try:
-    from torch.distributed.tensor import DTensor
+    from torch.distributed.checkpoint.state_dict import (
+        get_model_state_dict,
+        get_state_dict,
+        set_state_dict,
+        StateDictOptions,
+    )
 
-    _has_dtensor = True
-except ImportError:  # pragma: no cover - torch without distributed.tensor
-    _has_dtensor = False
+    _has_dist_checkpoint = True
+except ImportError:  # pragma: no cover - torch without distributed.checkpoint
+    _has_dist_checkpoint = False
 
 
 class FSDP2Learner(Learner):
@@ -38,13 +43,17 @@ class FSDP2Learner(Learner):
     (already sharded, by the caller) and how :meth:`get_weights` reports it.
 
     :meth:`get_weights` gathers every sharded leaf into a plain tensor via
-    ``DTensor.full_tensor()``, so the returned tensordict holds regular
-    tensors and is consumable by
+    :func:`torch.distributed.checkpoint.state_dict.get_model_state_dict`, so
+    the returned tensordict holds regular tensors and is consumable by
     :meth:`~torchrl.weight_update.WeightSyncScheme.send` exactly like
     :class:`~torchrl.trainers.learners.LocalLearner`'s, with no changes needed
     on the receiving (inference) side. This gather is the seam between
     sharded training and (typically replicated) inference, and is the one
-    place sharding is not transparent.
+    place sharding is not transparent. By default the gather targets rank 0
+    only (other ranks receive an empty tensordict): gathering the full model
+    to *every* rank, as a naive per-leaf ``DTensor.full_tensor()`` would,
+    replicates the whole model in every rank's memory for no benefit, which
+    does not scale to large sharded models.
 
     Args:
         model (torch.nn.Module): a model already wrapped with ``fully_shard``.
@@ -108,9 +117,9 @@ class FSDP2Learner(Learner):
         clip_grad_norm: float | None = None,
         grad_accum_steps: int = 1,
     ) -> None:
-        if not _has_dtensor:
+        if not _has_dist_checkpoint:
             raise RuntimeError(
-                "FSDP2Learner requires torch.distributed.tensor (DTensor), "
+                "FSDP2Learner requires torch.distributed.checkpoint.state_dict, "
                 "which is not available in this torch build."
             )
         super().__init__()
@@ -123,6 +132,51 @@ class FSDP2Learner(Learner):
         self._accum_step = 0
         self.capabilities = LearnerCapabilities(sharded=True, remote=False)
 
-    def get_weights(self) -> TensorDictBase:
-        td = TensorDict.from_module(self.model)
-        return td.apply(lambda t: t.full_tensor() if isinstance(t, DTensor) else t)
+    def get_weights(self, *, cpu_offload: bool = True) -> TensorDictBase:
+        """Gather the sharded model into a plain-tensor tensordict.
+
+        Keyword Args:
+            cpu_offload (bool, optional): if ``True`` (the default), the
+                gathered weights are returned only on rank 0 (other ranks get
+                an empty tensordict) and moved to CPU, avoiding an all-rank
+                replication of the full model. Set to ``False`` to instead
+                gather full GPU-resident copies onto every rank.
+        """
+        options = StateDictOptions(full_state_dict=True, cpu_offload=cpu_offload)
+        state_dict = get_model_state_dict(self.model, options=options)
+        return TensorDict(state_dict).unflatten_keys(".")
+
+    def state_dict(self, *args, **kwargs) -> dict:
+        """DTensor-aware checkpoint: gathers model + optimizer state to rank 0.
+
+        Overrides :meth:`~torchrl.trainers.learners.Learner.state_dict`, which
+        uses plain (non-distributed) ``state_dict()`` calls that would return
+        raw, per-rank ``DTensor`` shards rather than a portable checkpoint.
+        """
+        options = StateDictOptions(full_state_dict=True, cpu_offload=True)
+        model_state_dict, optim_state_dict = get_state_dict(
+            self.model, self.optimizer, options=options
+        )
+        return {
+            "model": model_state_dict,
+            "optimizer": optim_state_dict,
+            "accum_step": self._accum_step,
+        }
+
+    def load_state_dict(self, state_dict: dict, *args, **kwargs) -> None:
+        """Restore a checkpoint produced by :meth:`state_dict`.
+
+        ``broadcast_from_rank0=True`` lets rank 0 hold the full checkpoint
+        (as produced by :meth:`state_dict`) while every rank reshards it
+        according to its local shards -- the counterpart of the
+        ``cpu_offload``-gathered save.
+        """
+        options = StateDictOptions(full_state_dict=True, broadcast_from_rank0=True)
+        set_state_dict(
+            self.model,
+            self.optimizer,
+            model_state_dict=state_dict["model"],
+            optim_state_dict=state_dict["optimizer"],
+            options=options,
+        )
+        self._accum_step = state_dict.get("accum_step", 0)

--- a/torchrl/trainers/learners/fsdp2.py
+++ b/torchrl/trainers/learners/fsdp2.py
@@ -1,0 +1,128 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import torch
+from tensordict import TensorDict, TensorDictBase
+from torch import nn
+
+from torchrl.trainers.learners.common import Learner, LearnerCapabilities
+
+try:
+    from torch.distributed.tensor import DTensor
+
+    _has_dtensor = True
+except ImportError:  # pragma: no cover - torch without distributed.tensor
+    _has_dtensor = False
+
+
+class FSDP2Learner(Learner):
+    """A :class:`~torchrl.trainers.learners.Learner` for FSDP2-sharded models.
+
+    Accepts a model that the caller has already wrapped with
+    :func:`torch.distributed._composable.fsdp.fully_shard` (typically
+    per-submodule, then on the root module), and an optimizer built on that
+    (sharded) model's parameters. ``fully_shard`` must be applied *before* the
+    optimizer is constructed, so the optimizer holds the sharded
+    (:class:`~torch.distributed.tensor.DTensor`) parameters rather than the
+    original ones.
+
+    :meth:`~torchrl.trainers.learners.Learner.update` is inherited unchanged
+    from :class:`~torchrl.trainers.learners.Learner`: FSDP2's sharding is
+    transparent to the training step (forward/backward/optimizer-step all
+    dispatch through ``DTensor`` the same way they would through a regular
+    tensor). Only two things differ from
+    :class:`~torchrl.trainers.learners.LocalLearner`: how the model arrives
+    (already sharded, by the caller) and how :meth:`get_weights` reports it.
+
+    :meth:`get_weights` gathers every sharded leaf into a plain tensor via
+    ``DTensor.full_tensor()``, so the returned tensordict holds regular
+    tensors and is consumable by
+    :meth:`~torchrl.weight_update.WeightSyncScheme.send` exactly like
+    :class:`~torchrl.trainers.learners.LocalLearner`'s, with no changes needed
+    on the receiving (inference) side. This gather is the seam between
+    sharded training and (typically replicated) inference, and is the one
+    place sharding is not transparent.
+
+    Args:
+        model (torch.nn.Module): a model already wrapped with ``fully_shard``.
+        optimizer (torch.optim.Optimizer): an optimizer constructed on
+            ``model``'s (already-sharded) parameters.
+
+    Keyword Args:
+        clip_grad_norm (float, optional): as in
+            :class:`~torchrl.trainers.learners.LocalLearner`. Gradient-norm
+            clipping dispatches through ``DTensor`` transparently. Defaults to
+            ``None``.
+        grad_accum_steps (int, optional): as in
+            :class:`~torchrl.trainers.learners.LocalLearner`. Defaults to
+            ``1``.
+
+    .. warning::
+        ``FSDP2Learner`` does not itself decide what to shard, at what
+        granularity, or on what device mesh -- those are model-specific
+        choices that belong in the caller's model-construction code, exactly
+        as they would with bare ``fully_shard``. This keeps
+        ``FSDP2Learner`` a thin adapter rather than a second place those
+        decisions are made.
+
+    Examples:
+        >>> import torch
+        >>> import torch.distributed as dist
+        >>> from torch import nn
+        >>> from torch.distributed._composable.fsdp import fully_shard
+        >>> from torch.distributed.device_mesh import init_device_mesh
+        >>> from tensordict import TensorDict
+        >>> from torchrl.objectives.common import LossModule
+        >>> from torchrl.trainers.learners import FSDP2Learner
+        >>>
+        >>> dist.init_process_group(backend="gloo", rank=0, world_size=1)
+        >>> mesh = init_device_mesh("cpu", (1,))
+        >>> model = nn.Sequential(nn.Linear(4, 4), nn.Linear(4, 1))
+        >>> for layer in model:
+        ...     fully_shard(layer, mesh=mesh)
+        >>> fully_shard(model, mesh=mesh)
+        >>> optimizer = torch.optim.Adam(model.parameters())
+        >>>
+        >>> class ToyLoss(LossModule):
+        ...     def forward(self, batch):
+        ...         pred = self.actor(batch["x"])
+        ...         return TensorDict({"loss_mse": (pred - batch["y"]).pow(2).mean()})
+        >>> loss_module = ToyLoss()
+        >>> loss_module.actor = model
+        >>>
+        >>> learner = FSDP2Learner(model, optimizer)
+        >>> batch = TensorDict({"x": torch.randn(8, 4), "y": torch.randn(8, 1)}, [8])
+        >>> out = learner.update(batch, loss_module)
+        >>> weights = learner.get_weights()  # gathered, plain tensors
+        >>> dist.destroy_process_group()
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        optimizer: torch.optim.Optimizer,
+        *,
+        clip_grad_norm: float | None = None,
+        grad_accum_steps: int = 1,
+    ) -> None:
+        if not _has_dtensor:
+            raise RuntimeError(
+                "FSDP2Learner requires torch.distributed.tensor (DTensor), "
+                "which is not available in this torch build."
+            )
+        super().__init__()
+        self.model = model
+        self.optimizer = optimizer
+        self.clip_grad_norm = clip_grad_norm
+        if grad_accum_steps < 1:
+            raise ValueError(f"grad_accum_steps must be >= 1, got {grad_accum_steps}.")
+        self.grad_accum_steps = grad_accum_steps
+        self._accum_step = 0
+        self.capabilities = LearnerCapabilities(sharded=True, remote=False)
+
+    def get_weights(self) -> TensorDictBase:
+        td = TensorDict.from_module(self.model)
+        return td.apply(lambda t: t.full_tensor() if isinstance(t, DTensor) else t)

--- a/torchrl/trainers/learners/fsdp2.py
+++ b/torchrl/trainers/learners/fsdp2.py
@@ -10,7 +10,11 @@ import torch
 from tensordict import TensorDict, TensorDictBase
 from torch import nn
 
-from torchrl.trainers.learners.common import Learner, LearnerCapabilities
+from torchrl.trainers.learners.common import (
+    _clone_tensors,
+    Learner,
+    LearnerCapabilities,
+)
 
 
 @functools.lru_cache(maxsize=None)
@@ -168,10 +172,13 @@ class FSDP2Learner(Learner):
 
         Overrides :meth:`~torchrl.trainers.learners.Learner.checkpoint`, whose
         plain (non-distributed) ``state_dict()`` calls would return raw,
-        per-rank ``DTensor`` shards rather than a portable checkpoint. No
-        explicit cloning is needed here (unlike the base implementation):
-        ``get_state_dict`` with ``full_state_dict=True`` already materializes
-        new, gathered tensors rather than views onto the live shards.
+        per-rank ``DTensor`` shards rather than a portable checkpoint.
+
+        Like the base implementation, the returned tensors are independent
+        clones. ``get_state_dict`` does *not* guarantee that: with
+        ``cpu_offload=True`` it only copies when the shards are off-CPU, so on a
+        CPU mesh (or a single-rank one) the "gathered" tensors alias the live
+        shards, and training on would silently mutate the checkpoint.
         """
         dsd = _dist_state_dict()
         options = dsd.StateDictOptions(full_state_dict=True, cpu_offload=True)
@@ -179,8 +186,8 @@ class FSDP2Learner(Learner):
             self.model, self.optimizer, options=options
         )
         return {
-            "model": model_state_dict,
-            "optimizer": optim_state_dict,
+            "model": _clone_tensors(model_state_dict),
+            "optimizer": _clone_tensors(optim_state_dict),
             "accum_step": self._accum_step,
         }
 

--- a/torchrl/trainers/learners/fsdp2.py
+++ b/torchrl/trainers/learners/fsdp2.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import contextlib
 import functools
 
 import torch
@@ -17,7 +18,7 @@ from torchrl.trainers.learners.common import (
 )
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _dist_state_dict():
     """Return ``torch.distributed.checkpoint.state_dict``, imported on demand.
 
@@ -167,6 +168,32 @@ class FSDP2Learner(Learner):
         state_dict = dsd.get_model_state_dict(self.model, options=options)
         return TensorDict(state_dict).unflatten_keys(".")
 
+    @contextlib.contextmanager
+    def _extras_hidden_from_optimizer(self):
+        """Temporarily remove non-model parameters from the optimizer.
+
+        ``torch.distributed.checkpoint.state_dict`` maps optimizer state to
+        model FQNs, so a loss-owned parameter with no FQN makes
+        ``get_state_dict``/``set_state_dict`` fail with a bare ``KeyError``.
+        The extras (values and optimizer state) are carried in the checkpoint
+        explicitly instead -- they are plain unsharded tensors, so DCP has
+        nothing to reshard anyway.
+        """
+        extras = self._extra_optimized_parameters()
+        extra_ids = {id(p) for p in extras}
+        saved_groups = [group["params"] for group in self.optimizer.param_groups]
+        saved_state = {
+            p: self.optimizer.state.pop(p) for p in extras if p in self.optimizer.state
+        }
+        for group in self.optimizer.param_groups:
+            group["params"] = [p for p in group["params"] if id(p) not in extra_ids]
+        try:
+            yield extras, saved_state
+        finally:
+            for group, params in zip(self.optimizer.param_groups, saved_groups):
+                group["params"] = params
+            self.optimizer.state.update(saved_state)
+
     def checkpoint(self) -> dict:
         """DTensor-aware checkpoint: gathers model + optimizer state to rank 0.
 
@@ -179,17 +206,28 @@ class FSDP2Learner(Learner):
         ``cpu_offload=True`` it only copies when the shards are off-CPU, so on a
         CPU mesh (or a single-rank one) the "gathered" tensors alias the live
         shards, and training on would silently mutate the checkpoint.
+
+        Optimized parameters living outside ``model`` (loss-owned, unsharded
+        by construction) cannot be described by
+        ``torch.distributed.checkpoint.state_dict``; their values and
+        optimizer state are carried explicitly under ``"extra_params"`` and
+        ``"extra_optim_state"``.
         """
         dsd = _dist_state_dict()
         options = dsd.StateDictOptions(full_state_dict=True, cpu_offload=True)
-        model_state_dict, optim_state_dict = dsd.get_state_dict(
-            self.model, self.optimizer, options=options
-        )
-        return {
-            "model": _clone_tensors(model_state_dict),
-            "optimizer": _clone_tensors(optim_state_dict),
-            "accum_step": self._accum_step,
-        }
+        with self._extras_hidden_from_optimizer() as (extras, extra_state):
+            model_state_dict, optim_state_dict = dsd.get_state_dict(
+                self.model, self.optimizer, options=options
+            )
+            return {
+                "model": _clone_tensors(model_state_dict),
+                "optimizer": _clone_tensors(optim_state_dict),
+                "extra_params": [p.detach().clone() for p in extras],
+                "extra_optim_state": [
+                    _clone_tensors(extra_state.get(p, {})) for p in extras
+                ],
+                "accum_step": self._accum_step,
+            }
 
     def load_checkpoint(self, checkpoint: dict) -> None:
         """Restore a checkpoint produced by :meth:`checkpoint`.
@@ -197,18 +235,39 @@ class FSDP2Learner(Learner):
         ``broadcast_from_rank0=True`` lets rank 0 hold the full checkpoint
         (as produced by :meth:`checkpoint`) while every rank reshards it
         according to its local shards -- the counterpart of the
-        ``cpu_offload``-gathered save.
+        ``cpu_offload``-gathered save. Optimized parameters living outside
+        ``model`` (``"extra_params"``, unsharded by construction) follow the
+        same rank-0-authoritative contract: they are restored from the local
+        checkpoint where present, then broadcast from rank 0.
 
         Args:
             checkpoint (dict): as returned by :meth:`checkpoint`.
         """
         dsd = _dist_state_dict()
         options = dsd.StateDictOptions(full_state_dict=True, broadcast_from_rank0=True)
-        dsd.set_state_dict(
-            self.model,
-            self.optimizer,
-            model_state_dict=checkpoint["model"],
-            optim_state_dict=checkpoint["optimizer"],
-            options=options,
-        )
+        with self._extras_hidden_from_optimizer() as (extras, _):
+            dsd.set_state_dict(
+                self.model,
+                self.optimizer,
+                model_state_dict=checkpoint["model"],
+                optim_state_dict=checkpoint["optimizer"],
+                options=options,
+            )
+        if not extras or checkpoint.get("extra_params"):
+            self._restore_extra_params(checkpoint)
+            for param, state in zip(
+                extras, checkpoint.get("extra_optim_state", [{}] * len(extras))
+            ):
+                if state:
+                    self.optimizer.state[param] = _clone_tensors(state)
+        if (
+            extras
+            and torch.distributed.is_available()
+            and torch.distributed.is_initialized()
+        ):
+            for param in extras:
+                torch.distributed.broadcast(param.data, src=0)
+                for value in self.optimizer.state.get(param, {}).values():
+                    if isinstance(value, torch.Tensor):
+                        torch.distributed.broadcast(value, src=0)
         self._restore_accum_step(checkpoint.get("accum_step", 0))

--- a/torchrl/trainers/learners/fsdp2.py
+++ b/torchrl/trainers/learners/fsdp2.py
@@ -6,243 +6,145 @@ from __future__ import annotations
 
 import contextlib
 import functools
+from typing import Any
 
 import torch
 from tensordict import TensorDict, TensorDictBase
 from torch import nn
 
+from torchrl.objectives.common import LossModule
 from torchrl.trainers.learners.common import (
     _clone_tensors,
     Learner,
     LearnerCapabilities,
 )
+from torchrl.trainers.trainers import OptimizationStepper
 
 
 @functools.cache
 def _dist_state_dict():
-    """Return ``torch.distributed.checkpoint.state_dict``, imported on demand.
-
-    Deliberately lazy rather than a module-top import guarded by
-    ``importlib.util.find_spec``: this is a *torch submodule* whose presence
-    depends on the local torch build, and ``find_spec`` on a dotted name
-    eagerly imports the parent packages (and raises, rather than returning
-    ``None``, when a parent is missing). Importing it on first use keeps
-    ``import torchrl`` free of ``torch.distributed.checkpoint``.
-    """
     from torch.distributed.checkpoint import state_dict
 
     return state_dict
 
 
 class FSDP2Learner(Learner):
-    """A :class:`~torchrl.trainers.learners.Learner` for FSDP2-sharded models.
+    """FSDP2 placement backend for :class:`~torchrl.trainers.Learner`.
 
-    Accepts a model that the caller has already wrapped with
-    :func:`torch.distributed._composable.fsdp.fully_shard` (typically
-    per-submodule, then on the root module), and an optimizer built on that
-    (sharded) model's parameters. ``fully_shard`` must be applied *before* the
-    optimizer is constructed, so the optimizer holds the sharded
-    (:class:`~torch.distributed.tensor.DTensor`) parameters rather than the
-    original ones.
-
-    :meth:`~torchrl.trainers.learners.Learner.update` is inherited unchanged
-    from :class:`~torchrl.trainers.learners.Learner`: FSDP2's sharding is
-    transparent to the training step (forward/backward/optimizer-step all
-    dispatch through ``DTensor`` the same way they would through a regular
-    tensor). Only two things differ from
-    :class:`~torchrl.trainers.learners.LocalLearner`: how the model arrives
-    (already sharded, by the caller) and how :meth:`get_weights` reports it.
-
-    :meth:`get_weights` reassembles the sharded parameters into plain tensors
-    with
-    :func:`torch.distributed.checkpoint.state_dict.get_model_state_dict`, so
-    the returned tensordict holds regular tensors and is consumable by
-    :meth:`~torchrl.weight_update.WeightSyncScheme.send` exactly like
-    :class:`~torchrl.trainers.learners.LocalLearner`'s, with no changes needed
-    on the receiving (inference) side. This gather is the seam between
-    sharded training and (typically replicated) inference, and is the one
-    place sharding is not transparent.
-
-    .. warning::
-        With the default ``cpu_offload=True``, :meth:`get_weights` returns the
-        full weights **on rank 0 only**; every other rank gets an *empty*
-        tensordict. That is deliberate -- gathering the full model onto every
-        rank replicates it in every rank's memory for no benefit and does not
-        scale -- but it means ``scheme.send(learner.get_weights())`` called
-        unconditionally on all ranks sends nothing from the non-zero ones.
-        Either send from rank 0 only, or pass ``cpu_offload=False`` to gather
-        full copies everywhere.
+    The caller applies :func:`torch.distributed._composable.fsdp.fully_shard`
+    before constructing the optimizer and stepper. ``FSDP2Learner`` then uses
+    the same ``OptimizationStepper`` contract as ``Trainer`` and
+    ``LocalLearner``; it only adds FSDP gradient-sync control, full-weight
+    gathering, and distributed checkpoint translation.
 
     Args:
-        model (torch.nn.Module): a model already wrapped with ``fully_shard``.
-        optimizer (torch.optim.Optimizer): an optimizer constructed on
-            ``model``'s (already-sharded) parameters.
-
-    Keyword Args:
-        clip_grad_norm (float, optional): as in
-            :class:`~torchrl.trainers.learners.LocalLearner`. Gradient-norm
-            clipping dispatches through ``DTensor`` transparently. Defaults to
-            ``None``.
-        grad_accum_steps (int, optional): as in
-            :class:`~torchrl.trainers.learners.LocalLearner`. Defaults to
-            ``1``.
+        model (torch.nn.Module): Model already wrapped with ``fully_shard``.
+        loss_module (LossModule): Loss evaluated by :meth:`update`.
+        optimization_stepper (OptimizationStepper): Optimizer-owning stepper.
 
     .. warning::
-        ``FSDP2Learner`` does not itself decide what to shard, at what
-        granularity, or on what device mesh -- those are model-specific
-        choices that belong in the caller's model-construction code, exactly
-        as they would with bare ``fully_shard``. This keeps
-        ``FSDP2Learner`` a thin adapter rather than a second place those
-        decisions are made.
+        With ``cpu_offload=True``, :meth:`get_weights` returns full weights on
+        rank 0 and an empty TensorDict on other ranks.
 
     Examples:
         >>> import torch
         >>> import torch.distributed as dist
+        >>> from tensordict import TensorDict
         >>> from torch import nn
         >>> from torch.distributed._composable.fsdp import fully_shard
         >>> from torch.distributed.device_mesh import init_device_mesh
-        >>> from tensordict import TensorDict
         >>> from torchrl.objectives.common import LossModule
-        >>> from torchrl.trainers.learners import FSDP2Learner
-        >>>
+        >>> from torchrl.trainers import FSDP2Learner, MixedPrecisionOptimizationStepper
         >>> dist.init_process_group(backend="gloo", rank=0, world_size=1)
-        >>> mesh = init_device_mesh("cpu", (1,))
-        >>> model = nn.Sequential(nn.Linear(4, 4), nn.Linear(4, 1))
-        >>> for layer in model:
-        ...     fully_shard(layer, mesh=mesh)
-        >>> fully_shard(model, mesh=mesh)
-        >>> optimizer = torch.optim.Adam(model.parameters())
-        >>>
+        >>> model = nn.Linear(4, 1)
+        >>> fully_shard(model, mesh=init_device_mesh("cpu", (1,)))
         >>> class ToyLoss(LossModule):
+        ...     def __init__(self, model):
+        ...         super().__init__()
+        ...         self.model = model
         ...     def forward(self, batch):
-        ...         pred = self.actor(batch["x"])
-        ...         return TensorDict({"loss_mse": (pred - batch["y"]).pow(2).mean()})
-        >>> loss_module = ToyLoss()
-        >>> loss_module.actor = model
-        >>>
-        >>> learner = FSDP2Learner(model, optimizer)
+        ...         prediction = self.model(batch["x"])
+        ...         return TensorDict({"loss_mse": (prediction - batch["y"]).pow(2).mean()})
+        >>> loss_module = ToyLoss(model)
+        >>> stepper = MixedPrecisionOptimizationStepper(
+        ...     torch.optim.Adam(loss_module.parameters())
+        ... )
+        >>> learner = FSDP2Learner(model, loss_module, stepper)
         >>> batch = TensorDict({"x": torch.randn(8, 4), "y": torch.randn(8, 1)}, [8])
-        >>> out = learner.update(batch, loss_module)
-        >>> weights = learner.get_weights()  # gathered, plain tensors
+        >>> learner.update(batch)["loss_mse"].ndim
+        0
         >>> dist.destroy_process_group()
     """
 
     def __init__(
         self,
         model: nn.Module,
-        optimizer: torch.optim.Optimizer,
-        *,
-        clip_grad_norm: float | None = None,
-        grad_accum_steps: int = 1,
-    ) -> None:
+        loss_module: LossModule,
+        optimization_stepper: OptimizationStepper,
+    ):
         try:
             _dist_state_dict()
         except ImportError as err:
             raise RuntimeError(
-                "FSDP2Learner requires torch.distributed.checkpoint.state_dict, "
-                "which is not available in this torch build."
+                "FSDP2Learner requires torch.distributed.checkpoint.state_dict."
             ) from err
-        super().__init__()
-        self.model = model
-        self.optimizer = optimizer
-        self.clip_grad_norm = clip_grad_norm
-        if grad_accum_steps < 1:
-            raise ValueError(f"grad_accum_steps must be >= 1, got {grad_accum_steps}.")
-        self.grad_accum_steps = grad_accum_steps
-        self._accum_step = 0
+        super().__init__(model, loss_module, optimization_stepper)
         self.capabilities = LearnerCapabilities(sharded=True, remote=False)
 
     def get_weights(self, *, cpu_offload: bool = True) -> TensorDictBase:
-        """Reassemble the sharded model into a plain-tensor tensordict.
-
-        Keyword Args:
-            cpu_offload (bool, optional): if ``True`` (the default), the
-                gathered weights are returned **only on rank 0** (every other
-                rank gets an empty tensordict) and moved to CPU, avoiding an
-                all-rank replication of the full model -- see the class-level
-                warning. Set to ``False`` to gather full device-resident copies
-                onto every rank instead.
-        """
+        """Gather a detached plain-tensor snapshot of the sharded model."""
         dsd = _dist_state_dict()
         options = dsd.StateDictOptions(full_state_dict=True, cpu_offload=cpu_offload)
         state_dict = dsd.get_model_state_dict(self.model, options=options)
-        return TensorDict(state_dict).unflatten_keys(".")
+        return TensorDict(state_dict).unflatten_keys(".").detach().clone()
 
     @contextlib.contextmanager
     def _extras_hidden_from_optimizer(self):
-        """Temporarily remove non-model parameters from the optimizer.
-
-        ``torch.distributed.checkpoint.state_dict`` maps optimizer state to
-        model FQNs, so a loss-owned parameter with no FQN makes
-        ``get_state_dict``/``set_state_dict`` fail with a bare ``KeyError``.
-        The extras (values and optimizer state) are carried in the checkpoint
-        explicitly instead -- they are plain unsharded tensors, so DCP has
-        nothing to reshard anyway.
-        """
+        """Hide non-model parameters from DCP and carry them explicitly."""
         extras = self._extra_optimized_parameters()
-        extra_ids = {id(p) for p in extras}
+        extra_ids = {id(parameter) for parameter in extras}
         saved_groups = [group["params"] for group in self.optimizer.param_groups]
         saved_state = {
-            p: self.optimizer.state.pop(p) for p in extras if p in self.optimizer.state
+            parameter: self.optimizer.state.pop(parameter)
+            for parameter in extras
+            if parameter in self.optimizer.state
         }
         for group in self.optimizer.param_groups:
-            group["params"] = [p for p in group["params"] if id(p) not in extra_ids]
+            group["params"] = [
+                parameter
+                for parameter in group["params"]
+                if id(parameter) not in extra_ids
+            ]
         try:
             yield extras, saved_state
         finally:
-            for group, params in zip(self.optimizer.param_groups, saved_groups):
-                group["params"] = params
+            for group, parameters in zip(self.optimizer.param_groups, saved_groups):
+                group["params"] = parameters
             self.optimizer.state.update(saved_state)
 
-    def checkpoint(self) -> dict:
-        """DTensor-aware checkpoint: gathers model + optimizer state to rank 0.
+    def checkpoint(self) -> dict[str, Any]:
+        """Gather model and optimizer state while preserving stepper state."""
+        stepper_state = _clone_tensors(self.optimization_stepper.state_dict())
+        stepper_state.pop("optimizer", None)
 
-        Overrides :meth:`~torchrl.trainers.learners.Learner.checkpoint`, whose
-        plain (non-distributed) ``state_dict()`` calls would return raw,
-        per-rank ``DTensor`` shards rather than a portable checkpoint.
-
-        Like the base implementation, the returned tensors are independent
-        clones. ``get_state_dict`` does *not* guarantee that: with
-        ``cpu_offload=True`` it only copies when the shards are off-CPU, so on a
-        CPU mesh (or a single-rank one) the "gathered" tensors alias the live
-        shards, and training on would silently mutate the checkpoint.
-
-        Optimized parameters living outside ``model`` (loss-owned, unsharded
-        by construction) cannot be described by
-        ``torch.distributed.checkpoint.state_dict``; their values and
-        optimizer state are carried explicitly under ``"extra_params"`` and
-        ``"extra_optim_state"``.
-        """
         dsd = _dist_state_dict()
         options = dsd.StateDictOptions(full_state_dict=True, cpu_offload=True)
         with self._extras_hidden_from_optimizer() as (extras, extra_state):
-            model_state_dict, optim_state_dict = dsd.get_state_dict(
+            model_state, optimizer_state = dsd.get_state_dict(
                 self.model, self.optimizer, options=options
             )
-            return {
-                "model": _clone_tensors(model_state_dict),
-                "optimizer": _clone_tensors(optim_state_dict),
-                "extra_params": [p.detach().clone() for p in extras],
-                "extra_optim_state": [
-                    _clone_tensors(extra_state.get(p, {})) for p in extras
-                ],
-                "accum_step": self._accum_step,
-            }
+        return {
+            "model": _clone_tensors(model_state),
+            "optimizer": _clone_tensors(optimizer_state),
+            "optimization_stepper": stepper_state,
+            "extra_params": [parameter.detach().clone() for parameter in extras],
+            "extra_optim_state": [
+                _clone_tensors(extra_state.get(parameter, {})) for parameter in extras
+            ],
+        }
 
-    def load_checkpoint(self, checkpoint: dict) -> None:
-        """Restore a checkpoint produced by :meth:`checkpoint`.
-
-        ``broadcast_from_rank0=True`` lets rank 0 hold the full checkpoint
-        (as produced by :meth:`checkpoint`) while every rank reshards it
-        according to its local shards -- the counterpart of the
-        ``cpu_offload``-gathered save. Optimized parameters living outside
-        ``model`` (``"extra_params"``, unsharded by construction) follow the
-        same rank-0-authoritative contract: they are restored from the local
-        checkpoint where present, then broadcast from rank 0.
-
-        Args:
-            checkpoint (dict): as returned by :meth:`checkpoint`.
-        """
+    def load_checkpoint(self, checkpoint: dict[str, Any]) -> None:
+        """Restore and reshard a checkpoint produced by :meth:`checkpoint`."""
         dsd = _dist_state_dict()
         options = dsd.StateDictOptions(full_state_dict=True, broadcast_from_rank0=True)
         with self._extras_hidden_from_optimizer() as (extras, _):
@@ -253,21 +155,23 @@ class FSDP2Learner(Learner):
                 optim_state_dict=checkpoint["optimizer"],
                 options=options,
             )
+
         if not extras or checkpoint.get("extra_params"):
             self._restore_extra_params(checkpoint)
-            for param, state in zip(
+            for parameter, state in zip(
                 extras, checkpoint.get("extra_optim_state", [{}] * len(extras))
             ):
                 if state:
-                    self.optimizer.state[param] = _clone_tensors(state)
-        if (
-            extras
-            and torch.distributed.is_available()
-            and torch.distributed.is_initialized()
-        ):
-            for param in extras:
-                torch.distributed.broadcast(param.data, src=0)
-                for value in self.optimizer.state.get(param, {}).values():
+                    self.optimizer.state[parameter] = _clone_tensors(state)
+        if extras and torch.distributed.is_initialized():
+            for parameter in extras:
+                torch.distributed.broadcast(parameter.data, src=0)
+                for value in self.optimizer.state.get(parameter, {}).values():
                     if isinstance(value, torch.Tensor):
                         torch.distributed.broadcast(value, src=0)
-        self._restore_accum_step(checkpoint.get("accum_step", 0))
+
+        stepper_state = {
+            "optimizer": self.optimizer.state_dict(),
+            **checkpoint["optimization_stepper"],
+        }
+        self.optimization_stepper.load_state_dict(stepper_state)

--- a/torchrl/trainers/learners/fsdp2.py
+++ b/torchrl/trainers/learners/fsdp2.py
@@ -4,23 +4,29 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import functools
+
 import torch
 from tensordict import TensorDict, TensorDictBase
 from torch import nn
 
 from torchrl.trainers.learners.common import Learner, LearnerCapabilities
 
-try:
-    from torch.distributed.checkpoint.state_dict import (
-        get_model_state_dict,
-        get_state_dict,
-        set_state_dict,
-        StateDictOptions,
-    )
 
-    _has_dist_checkpoint = True
-except ImportError:  # pragma: no cover - torch without distributed.checkpoint
-    _has_dist_checkpoint = False
+@functools.lru_cache(maxsize=None)
+def _dist_state_dict():
+    """Return ``torch.distributed.checkpoint.state_dict``, imported on demand.
+
+    Deliberately lazy rather than a module-top import guarded by
+    ``importlib.util.find_spec``: this is a *torch submodule* whose presence
+    depends on the local torch build, and ``find_spec`` on a dotted name
+    eagerly imports the parent packages (and raises, rather than returning
+    ``None``, when a parent is missing). Importing it on first use keeps
+    ``import torchrl`` free of ``torch.distributed.checkpoint``.
+    """
+    from torch.distributed.checkpoint import state_dict
+
+    return state_dict
 
 
 class FSDP2Learner(Learner):
@@ -42,18 +48,25 @@ class FSDP2Learner(Learner):
     :class:`~torchrl.trainers.learners.LocalLearner`: how the model arrives
     (already sharded, by the caller) and how :meth:`get_weights` reports it.
 
-    :meth:`get_weights` gathers every sharded leaf into a plain tensor via
+    :meth:`get_weights` reassembles the sharded parameters into plain tensors
+    with
     :func:`torch.distributed.checkpoint.state_dict.get_model_state_dict`, so
     the returned tensordict holds regular tensors and is consumable by
     :meth:`~torchrl.weight_update.WeightSyncScheme.send` exactly like
     :class:`~torchrl.trainers.learners.LocalLearner`'s, with no changes needed
     on the receiving (inference) side. This gather is the seam between
     sharded training and (typically replicated) inference, and is the one
-    place sharding is not transparent. By default the gather targets rank 0
-    only (other ranks receive an empty tensordict): gathering the full model
-    to *every* rank, as a naive per-leaf ``DTensor.full_tensor()`` would,
-    replicates the whole model in every rank's memory for no benefit, which
-    does not scale to large sharded models.
+    place sharding is not transparent.
+
+    .. warning::
+        With the default ``cpu_offload=True``, :meth:`get_weights` returns the
+        full weights **on rank 0 only**; every other rank gets an *empty*
+        tensordict. That is deliberate -- gathering the full model onto every
+        rank replicates it in every rank's memory for no benefit and does not
+        scale -- but it means ``scheme.send(learner.get_weights())`` called
+        unconditionally on all ranks sends nothing from the non-zero ones.
+        Either send from rank 0 only, or pass ``cpu_offload=False`` to gather
+        full copies everywhere.
 
     Args:
         model (torch.nn.Module): a model already wrapped with ``fully_shard``.
@@ -117,11 +130,13 @@ class FSDP2Learner(Learner):
         clip_grad_norm: float | None = None,
         grad_accum_steps: int = 1,
     ) -> None:
-        if not _has_dist_checkpoint:
+        try:
+            _dist_state_dict()
+        except ImportError as err:
             raise RuntimeError(
                 "FSDP2Learner requires torch.distributed.checkpoint.state_dict, "
                 "which is not available in this torch build."
-            )
+            ) from err
         super().__init__()
         self.model = model
         self.optimizer = optimizer
@@ -133,28 +148,34 @@ class FSDP2Learner(Learner):
         self.capabilities = LearnerCapabilities(sharded=True, remote=False)
 
     def get_weights(self, *, cpu_offload: bool = True) -> TensorDictBase:
-        """Gather the sharded model into a plain-tensor tensordict.
+        """Reassemble the sharded model into a plain-tensor tensordict.
 
         Keyword Args:
             cpu_offload (bool, optional): if ``True`` (the default), the
-                gathered weights are returned only on rank 0 (other ranks get
-                an empty tensordict) and moved to CPU, avoiding an all-rank
-                replication of the full model. Set to ``False`` to instead
-                gather full GPU-resident copies onto every rank.
+                gathered weights are returned **only on rank 0** (every other
+                rank gets an empty tensordict) and moved to CPU, avoiding an
+                all-rank replication of the full model -- see the class-level
+                warning. Set to ``False`` to gather full device-resident copies
+                onto every rank instead.
         """
-        options = StateDictOptions(full_state_dict=True, cpu_offload=cpu_offload)
-        state_dict = get_model_state_dict(self.model, options=options)
+        dsd = _dist_state_dict()
+        options = dsd.StateDictOptions(full_state_dict=True, cpu_offload=cpu_offload)
+        state_dict = dsd.get_model_state_dict(self.model, options=options)
         return TensorDict(state_dict).unflatten_keys(".")
 
-    def state_dict(self, *args, **kwargs) -> dict:
+    def checkpoint(self) -> dict:
         """DTensor-aware checkpoint: gathers model + optimizer state to rank 0.
 
-        Overrides :meth:`~torchrl.trainers.learners.Learner.state_dict`, which
-        uses plain (non-distributed) ``state_dict()`` calls that would return
-        raw, per-rank ``DTensor`` shards rather than a portable checkpoint.
+        Overrides :meth:`~torchrl.trainers.learners.Learner.checkpoint`, whose
+        plain (non-distributed) ``state_dict()`` calls would return raw,
+        per-rank ``DTensor`` shards rather than a portable checkpoint. No
+        explicit cloning is needed here (unlike the base implementation):
+        ``get_state_dict`` with ``full_state_dict=True`` already materializes
+        new, gathered tensors rather than views onto the live shards.
         """
-        options = StateDictOptions(full_state_dict=True, cpu_offload=True)
-        model_state_dict, optim_state_dict = get_state_dict(
+        dsd = _dist_state_dict()
+        options = dsd.StateDictOptions(full_state_dict=True, cpu_offload=True)
+        model_state_dict, optim_state_dict = dsd.get_state_dict(
             self.model, self.optimizer, options=options
         )
         return {
@@ -163,20 +184,24 @@ class FSDP2Learner(Learner):
             "accum_step": self._accum_step,
         }
 
-    def load_state_dict(self, state_dict: dict, *args, **kwargs) -> None:
-        """Restore a checkpoint produced by :meth:`state_dict`.
+    def load_checkpoint(self, checkpoint: dict) -> None:
+        """Restore a checkpoint produced by :meth:`checkpoint`.
 
         ``broadcast_from_rank0=True`` lets rank 0 hold the full checkpoint
-        (as produced by :meth:`state_dict`) while every rank reshards it
+        (as produced by :meth:`checkpoint`) while every rank reshards it
         according to its local shards -- the counterpart of the
         ``cpu_offload``-gathered save.
+
+        Args:
+            checkpoint (dict): as returned by :meth:`checkpoint`.
         """
-        options = StateDictOptions(full_state_dict=True, broadcast_from_rank0=True)
-        set_state_dict(
+        dsd = _dist_state_dict()
+        options = dsd.StateDictOptions(full_state_dict=True, broadcast_from_rank0=True)
+        dsd.set_state_dict(
             self.model,
             self.optimizer,
-            model_state_dict=state_dict["model"],
-            optim_state_dict=state_dict["optimizer"],
+            model_state_dict=checkpoint["model"],
+            optim_state_dict=checkpoint["optimizer"],
             options=options,
         )
-        self._accum_step = state_dict.get("accum_step", 0)
+        self._restore_accum_step(checkpoint.get("accum_step", 0))

--- a/torchrl/trainers/learners/local.py
+++ b/torchrl/trainers/learners/local.py
@@ -1,0 +1,116 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import torch
+from tensordict import is_tensorclass, TensorDict, TensorDictBase
+from torch import nn
+
+from torchrl.objectives.common import LossModule
+from torchrl.trainers.learners.common import Learner, LearnerCapabilities
+
+
+class LocalLearner(Learner):
+    """A single-process, single-device :class:`~torchrl.trainers.learners.Learner`.
+
+    Wraps a model and an optimizer and performs the update in-process: forward
+    through ``loss_module``, sum the outputs' ``"loss"``-prefixed entries,
+    backward, optionally clip gradients, and step the optimizer. This is the
+    reference implementation the :class:`~torchrl.trainers.learners.Learner`
+    contract is designed around -- a sharded (e.g. FSDP2-backed) or remote
+    learner implements the same two methods, :meth:`update` and
+    :meth:`get_weights`, so that algorithm code written against
+    ``LocalLearner`` runs unchanged against those backends.
+
+    Args:
+        model (torch.nn.Module): the trainable module. Also the source for
+            :meth:`get_weights`.
+        optimizer (torch.optim.Optimizer): the optimizer stepping ``model``'s
+            parameters.
+
+    Keyword Args:
+        clip_grad_norm (float, optional): if set, gradients are clipped to
+            this max norm via :func:`torch.nn.utils.clip_grad_norm_` before
+            the optimizer step, and the resulting norm is written to the
+            output tensordict under ``"grad_norm"``. Defaults to ``None``.
+        grad_accum_steps (int, optional): number of :meth:`update` calls to
+            accumulate gradients over before stepping the optimizer and
+            zeroing gradients. Defaults to ``1`` (step on every call).
+
+    Examples:
+        >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from torch import nn
+        >>> from torchrl.trainers.learners import LocalLearner
+        >>> from torchrl.objectives.common import LossModule
+        >>>
+        >>> class ToyLoss(LossModule):
+        ...     def forward(self, batch):
+        ...         pred = self.actor(batch["x"])
+        ...         return TensorDict({"loss_mse": (pred - batch["y"]).pow(2).mean()})
+        >>>
+        >>> model = nn.Linear(4, 1)
+        >>> loss_module = ToyLoss()
+        >>> loss_module.actor = model
+        >>> learner = LocalLearner(model, torch.optim.Adam(model.parameters()))
+        >>> batch = TensorDict({"x": torch.randn(8, 4), "y": torch.randn(8, 1)}, [8])
+        >>> out = learner.update(batch, loss_module)
+        >>> out.get("loss_mse").item() > 0
+        True
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        optimizer: torch.optim.Optimizer,
+        *,
+        clip_grad_norm: float | None = None,
+        grad_accum_steps: int = 1,
+    ) -> None:
+        super().__init__()
+        self.model = model
+        self.optimizer = optimizer
+        self.clip_grad_norm = clip_grad_norm
+        if grad_accum_steps < 1:
+            raise ValueError(f"grad_accum_steps must be >= 1, got {grad_accum_steps}.")
+        self.grad_accum_steps = grad_accum_steps
+        self._accum_step = 0
+        self.capabilities = LearnerCapabilities(sharded=False, remote=False)
+
+    def update(self, batch: TensorDictBase, loss_module: LossModule) -> TensorDictBase:
+        if self._accum_step == 0:
+            self.optimizer.zero_grad(set_to_none=True)
+
+        loss_td = loss_module(batch)
+        loss_keys = [k for k in loss_td.keys() if k.startswith("loss")]
+        if not loss_keys:
+            raise ValueError(
+                "loss_module returned no keys starting with 'loss': "
+                f"{list(loss_td.keys())}. LossModule.forward must return at "
+                "least one 'loss'-prefixed entry."
+            )
+        total_loss = sum(loss_td.get(k) for k in loss_keys) / self.grad_accum_steps
+        total_loss.backward()
+
+        self._accum_step += 1
+        if self._accum_step < self.grad_accum_steps:
+            return loss_td
+        self._accum_step = 0
+
+        if self.clip_grad_norm is not None:
+            grad_norm = torch.nn.utils.clip_grad_norm_(
+                self.model.parameters(), self.clip_grad_norm
+            )
+            # loss_module may return a strict TensorClass (e.g. RewardModelLossOutput)
+            # that rejects undeclared keys; convert to a writable TensorDict first.
+            if is_tensorclass(loss_td):
+                loss_td = loss_td.to_tensordict()
+            loss_td.set("grad_norm", grad_norm)
+
+        self.optimizer.step()
+        return loss_td
+
+    def get_weights(self) -> TensorDictBase:
+        return TensorDict.from_module(self.model)

--- a/torchrl/trainers/learners/local.py
+++ b/torchrl/trainers/learners/local.py
@@ -5,24 +5,22 @@
 from __future__ import annotations
 
 import torch
-from tensordict import is_tensorclass, TensorDict, TensorDictBase
+from tensordict import TensorDict, TensorDictBase
 from torch import nn
 
-from torchrl.objectives.common import LossModule
 from torchrl.trainers.learners.common import Learner, LearnerCapabilities
 
 
 class LocalLearner(Learner):
     """A single-process, single-device :class:`~torchrl.trainers.learners.Learner`.
 
-    Wraps a model and an optimizer and performs the update in-process: forward
-    through ``loss_module``, sum the outputs' ``"loss"``-prefixed entries,
-    backward, optionally clip gradients, and step the optimizer. This is the
+    Holds a model and an optimizer, unwrapped and unsharded. This is the
     reference implementation the :class:`~torchrl.trainers.learners.Learner`
-    contract is designed around -- a sharded (e.g. FSDP2-backed) or remote
-    learner implements the same two methods, :meth:`update` and
-    :meth:`get_weights`, so that algorithm code written against
-    ``LocalLearner`` runs unchanged against those backends.
+    contract is designed around --
+    :class:`~torchrl.trainers.learners.FSDP2Learner` shards the same model
+    with ``fully_shard`` and reuses :meth:`~torchrl.trainers.learners.Learner.update`
+    unchanged, so algorithm code written against ``LocalLearner`` runs
+    unmodified under sharded training.
 
     Args:
         model (torch.nn.Module): the trainable module. Also the source for
@@ -78,39 +76,6 @@ class LocalLearner(Learner):
         self.grad_accum_steps = grad_accum_steps
         self._accum_step = 0
         self.capabilities = LearnerCapabilities(sharded=False, remote=False)
-
-    def update(self, batch: TensorDictBase, loss_module: LossModule) -> TensorDictBase:
-        if self._accum_step == 0:
-            self.optimizer.zero_grad(set_to_none=True)
-
-        loss_td = loss_module(batch)
-        loss_keys = [k for k in loss_td.keys() if k.startswith("loss")]
-        if not loss_keys:
-            raise ValueError(
-                "loss_module returned no keys starting with 'loss': "
-                f"{list(loss_td.keys())}. LossModule.forward must return at "
-                "least one 'loss'-prefixed entry."
-            )
-        total_loss = sum(loss_td.get(k) for k in loss_keys) / self.grad_accum_steps
-        total_loss.backward()
-
-        self._accum_step += 1
-        if self._accum_step < self.grad_accum_steps:
-            return loss_td
-        self._accum_step = 0
-
-        if self.clip_grad_norm is not None:
-            grad_norm = torch.nn.utils.clip_grad_norm_(
-                self.model.parameters(), self.clip_grad_norm
-            )
-            # loss_module may return a strict TensorClass (e.g. RewardModelLossOutput)
-            # that rejects undeclared keys; convert to a writable TensorDict first.
-            if is_tensorclass(loss_td):
-                loss_td = loss_td.to_tensordict()
-            loss_td.set("grad_norm", grad_norm)
-
-        self.optimizer.step()
-        return loss_td
 
     def get_weights(self) -> TensorDictBase:
         return TensorDict.from_module(self.model)

--- a/torchrl/trainers/learners/local.py
+++ b/torchrl/trainers/learners/local.py
@@ -23,10 +23,15 @@ class LocalLearner(Learner):
     unmodified under sharded training.
 
     Args:
-        model (torch.nn.Module): the trainable module. Also the source for
-            :meth:`get_weights`.
-        optimizer (torch.optim.Optimizer): the optimizer stepping ``model``'s
-            parameters.
+        model (torch.nn.Module): the module :meth:`get_weights` reports and
+            that gradient sync is driven from. Note that it is ``optimizer``,
+            not this argument, that determines which parameters are trained --
+            see the warning on
+            :class:`~torchrl.trainers.learners.Learner`.
+        optimizer (torch.optim.Optimizer): the optimizer whose param groups are
+            clipped and stepped. For losses that own or expand their networks,
+            build it over ``loss_module.parameters()`` rather than
+            ``model.parameters()``.
 
     Keyword Args:
         clip_grad_norm (float, optional): if set, gradients are clipped to

--- a/torchrl/trainers/learners/local.py
+++ b/torchrl/trainers/learners/local.py
@@ -4,83 +4,59 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
-import torch
 from tensordict import TensorDict, TensorDictBase
 from torch import nn
 
+from torchrl.objectives.common import LossModule
 from torchrl.trainers.learners.common import Learner, LearnerCapabilities
+from torchrl.trainers.trainers import OptimizationStepper
 
 
 class LocalLearner(Learner):
-    """A single-process, single-device :class:`~torchrl.trainers.learners.Learner`.
+    """Single-process :class:`~torchrl.trainers.Learner` backend.
 
-    Holds a model and an optimizer, unwrapped and unsharded. This is the
-    reference implementation the :class:`~torchrl.trainers.learners.Learner`
-    contract is designed around --
-    :class:`~torchrl.trainers.learners.FSDP2Learner` shards the same model
-    with ``fully_shard`` and reuses :meth:`~torchrl.trainers.learners.Learner.update`
-    unchanged, so algorithm code written against ``LocalLearner`` runs
-    unmodified under sharded training.
+    ``LocalLearner`` supplies placement and weight publication. Optimization
+    behavior comes entirely from the same ``OptimizationStepper`` used by
+    :class:`~torchrl.trainers.Trainer`.
 
     Args:
-        model (torch.nn.Module): the module :meth:`get_weights` reports and
-            that gradient sync is driven from. Note that it is ``optimizer``,
-            not this argument, that determines which parameters are trained --
-            see the warning on
-            :class:`~torchrl.trainers.learners.Learner`.
-        optimizer (torch.optim.Optimizer): the optimizer whose param groups are
-            clipped and stepped. For losses that own or expand their networks,
-            build it over ``loss_module.parameters()`` rather than
-            ``model.parameters()``.
-
-    Keyword Args:
-        clip_grad_norm (float, optional): if set, gradients are clipped to
-            this max norm via :func:`torch.nn.utils.clip_grad_norm_` before
-            the optimizer step, and the resulting norm is written to the
-            output tensordict under ``"grad_norm"``. Defaults to ``None``.
-        grad_accum_steps (int, optional): number of :meth:`update` calls to
-            accumulate gradients over before stepping the optimizer and
-            zeroing gradients. Defaults to ``1`` (step on every call).
+        model (torch.nn.Module): Module whose weights are published.
+        loss_module (LossModule): Loss evaluated by :meth:`update`.
+        optimization_stepper (OptimizationStepper): Optimization policy.
 
     Examples:
         >>> import torch
         >>> from tensordict import TensorDict
         >>> from torch import nn
-        >>> from torchrl.trainers.learners import LocalLearner
         >>> from torchrl.objectives.common import LossModule
-        >>>
+        >>> from torchrl.trainers import LocalLearner, MixedPrecisionOptimizationStepper
         >>> class ToyLoss(LossModule):
+        ...     def __init__(self, model):
+        ...         super().__init__()
+        ...         self.model = model
         ...     def forward(self, batch):
-        ...         pred = self.actor(batch["x"])
-        ...         return TensorDict({"loss_mse": (pred - batch["y"]).pow(2).mean()})
-        >>>
+        ...         prediction = self.model(batch["x"])
+        ...         return TensorDict({"loss_mse": (prediction - batch["y"]).pow(2).mean()})
         >>> model = nn.Linear(4, 1)
-        >>> loss_module = ToyLoss()
-        >>> loss_module.actor = model
-        >>> learner = LocalLearner(model, torch.optim.Adam(model.parameters()))
+        >>> loss_module = ToyLoss(model)
+        >>> stepper = MixedPrecisionOptimizationStepper(
+        ...     torch.optim.Adam(loss_module.parameters())
+        ... )
+        >>> learner = LocalLearner(model, loss_module, stepper)
         >>> batch = TensorDict({"x": torch.randn(8, 4), "y": torch.randn(8, 1)}, [8])
-        >>> out = learner.update(batch, loss_module)
-        >>> out.get("loss_mse").item() > 0
-        True
+        >>> metrics = learner.update(batch)
+        >>> metrics["loss_mse"].ndim
+        0
     """
 
     def __init__(
         self,
         model: nn.Module,
-        optimizer: torch.optim.Optimizer,
-        *,
-        clip_grad_norm: float | None = None,
-        grad_accum_steps: int = 1,
-    ) -> None:
-        super().__init__()
-        self.model = model
-        self.optimizer = optimizer
-        self.clip_grad_norm = clip_grad_norm
-        if grad_accum_steps < 1:
-            raise ValueError(f"grad_accum_steps must be >= 1, got {grad_accum_steps}.")
-        self.grad_accum_steps = grad_accum_steps
-        self._accum_step = 0
+        loss_module: LossModule,
+        optimization_stepper: OptimizationStepper,
+    ):
+        super().__init__(model, loss_module, optimization_stepper)
         self.capabilities = LearnerCapabilities(sharded=False, remote=False)
 
     def get_weights(self) -> TensorDictBase:
-        return TensorDict.from_module(self.model)
+        return TensorDict.from_module(self.model).data.detach().clone()

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -379,10 +379,11 @@ class MixedPrecisionOptimizationStepper(OptimizationStepper):
         self._use_scaler = mixed_precision and (autocast_dtype == torch.float16)
         self.scaler = GradScaler(self.device_type, enabled=self._use_scaler)
 
-        # Internal micro-batch counter (reset after every optimizer step).
+        # Internal micro-batch counter, reset after every optimizer step.
         self._micro_step: int = 0
         self._optimizer_step_count: int = 0
         self._skipped_nonfinite_steps: int = 0
+        self._checked_optimizer_coverage = False
 
     @property
     def optimizer_step_count(self) -> int:
@@ -413,6 +414,7 @@ class MixedPrecisionOptimizationStepper(OptimizationStepper):
             "micro_step": self._micro_step,
             "optimizer_step_count": self._optimizer_step_count,
             "skipped_nonfinite_steps": self._skipped_nonfinite_steps,
+            "checked_optimizer_coverage": self._checked_optimizer_coverage,
         }
         if self._use_scaler:
             sd["scaler"] = self.scaler.state_dict()
@@ -423,8 +425,36 @@ class MixedPrecisionOptimizationStepper(OptimizationStepper):
         self._micro_step = state_dict.get("micro_step", 0)
         self._optimizer_step_count = state_dict.get("optimizer_step_count", 0)
         self._skipped_nonfinite_steps = state_dict.get("skipped_nonfinite_steps", 0)
+        self._checked_optimizer_coverage = state_dict.get(
+            "checked_optimizer_coverage", False
+        )
         if self._use_scaler and "scaler" in state_dict:
             self.scaler.load_state_dict(state_dict["scaler"])
+
+    def _check_optimizer_coverage(self, context: Any) -> None:
+        loss_module = getattr(context, "loss_module", None)
+        if not isinstance(loss_module, nn.Module):
+            return
+        optimized = {
+            id(parameter)
+            for group in self.optimizer.param_groups
+            for parameter in group["params"]
+        }
+        missing = [
+            name
+            for name, parameter in loss_module.named_parameters()
+            if parameter.grad is not None and id(parameter) not in optimized
+        ]
+        if missing:
+            shown = ", ".join(missing[:5])
+            if len(missing) > 5:
+                shown += f", ... (+{len(missing) - 5} more)"
+            raise RuntimeError(
+                f"The optimization stepper's optimizer does not cover "
+                f"{len(missing)} loss-module parameter(s) that received a "
+                f"gradient: {shown}. Build the optimizer over "
+                "loss_module.parameters() rather than a bare policy model."
+            )
 
     # ------------------------------------------------------------------
     # Core step
@@ -444,6 +474,10 @@ class MixedPrecisionOptimizationStepper(OptimizationStepper):
             A :class:`~tensordict.TensorDict` with scalar metrics (losses,
             grad_norm) suitable for logging.
         """
+        set_gradient_sync = getattr(trainer, "_set_requires_gradient_sync", None)
+        if set_gradient_sync is not None:
+            set_gradient_sync(self._micro_step + 1 == self.gradient_accumulation_steps)
+
         # ---- forward pass (optionally under autocast) ----
         with torch.amp.autocast(
             self.device_type,
@@ -451,14 +485,20 @@ class MixedPrecisionOptimizationStepper(OptimizationStepper):
             dtype=self.autocast_dtype,
         ):
             losses_td = trainer.compute_loss(sub_batch)
-            # Sum all loss_* keys and normalise by accumulation steps.
+            # ``loss`` itself is a valid TorchRL loss key, so select the full
+            # prefix rather than only ``loss_*``.
             loss_items = [v for k, v in losses_td.items() if k.startswith("loss")]
             if not loss_items:
-                raise RuntimeError(
-                    "The loss module returned no 'loss_*' keys. "
-                    "Make sure your loss module prefixes scalar outputs with 'loss'."
+                raise ValueError(
+                    "The loss module returned no keys starting with 'loss'."
                 )
             loss = sum(loss_items) / self.gradient_accumulation_steps
+            if loss.numel() != 1:
+                raise ValueError(
+                    "The summed optimization loss must be scalar, but has "
+                    f"shape {tuple(loss.shape)}. Configure the loss with a "
+                    "scalar reduction."
+                )
 
         # ---- non-finite loss guard ----
         # A single non-finite loss would poison the gradients accumulated so
@@ -488,6 +528,10 @@ class MixedPrecisionOptimizationStepper(OptimizationStepper):
             if self._use_scaler:
                 self.scaler.unscale_(self.optimizer)
 
+            if not self._checked_optimizer_coverage:
+                self._check_optimizer_coverage(trainer)
+                self._checked_optimizer_coverage = True
+
             grad_norm = 0.0
             if self.clip_norm is not None:
                 params = [
@@ -516,6 +560,7 @@ class MixedPrecisionOptimizationStepper(OptimizationStepper):
                 self.optimizer.step()
                 self._optimizer_step_count += 1
             self.optimizer.zero_grad(set_to_none=True)
+            self._micro_step = 0
 
         metrics = self._reduce_metrics(losses_td)
         if grad_norm is not None:


### PR DESCRIPTION
## Summary

Introduces `torchrl.trainers.Learner`: a backend-agnostic entry point for taking
one optimization step on a tensordict batch with a given `LossModule`.
`LocalLearner` is the single-process reference implementation; `FSDP2Learner`
shards the same model with `fully_shard` and reuses the training step unchanged.

It plays the same role for training that `Collector` plays for data collection
and `LLMWrapperBase` plays for generation/scoring: a fixed, TensorDict-native
contract with interchangeable backends, so algorithm code does not need to know
whether the update runs on one device, under sharded training, or on a remote
training process.

## Design

- `Learner.update()` is concrete, in the base class, and touches only
  `self.model` / `self.optimizer` / `self.clip_grad_norm` /
  `self.grad_accum_steps`: zero_grad -> forward -> sum the loss module's
  `"loss"`-prefixed output keys -> backward -> optional grad-norm clip ->
  optimizer step. This is what lets `FSDP2Learner` reuse the exact same step as
  `LocalLearner` -- sharded training only changes model construction and weight
  gathering, not the step itself.
- `get_weights()` is the one place sharding is *not* transparent: it must return
  plain tensors (for `WeightSyncScheme.send`, which already accepts a
  `TensorDictBase`), even when the learner's parameters are sharded.
- `FSDP2Learner` does not decide sharding granularity or device mesh -- it
  accepts a model the caller has already wrapped with `fully_shard`, exactly as
  bare FSDP2 usage works. Keeping that decision in caller code avoids
  `FSDP2Learner` becoming a second place those choices are made.

## Two contracts worth reading before using this

**The optimizer defines what is trained, not `model`.** `model` is the
weight-sync source and the gradient-sync handle; the parameters that get clipped
and stepped are the ones in `optimizer.param_groups`. Many TorchRL losses hold
their trainable parameters on the loss module as `TensorDictParams`, and the
losses that expand their networks (`SACLoss`, `REDQLoss`, ...) hold *copies* of
the modules you passed in:

```python
loss_module = SACLoss(actor, qvalue)
learner = LocalLearner(actor, Adam(loss_module.parameters()))  # correct
learner = LocalLearner(actor, Adam(actor.parameters()))        # critics never train
```

The second line is silent -- the critics are differentiated on every step and
never updated -- so `update()` now checks before its first optimizer step and
raises if any parameter received a gradient that no param group covers. Grad-norm
clipping likewise covers `optimizer.param_groups`, not `model.parameters()`.

A `Learner` owns exactly one optimizer, so algorithms that deliberately use
several (per-network learning rates, a separate entropy-temperature optimizer)
are not expressible as a single `Learner` today; use one per optimizer.

**Checkpointing is `checkpoint()` / `load_checkpoint()`, not `state_dict()`.** A
bare `Optimizer` is not an `nn.Module`, so `nn.Module.state_dict()` structurally
cannot carry its state and a resume would reset Adam's moments. Overriding
`state_dict` to return it anyway would break the `nn.Module` contract -- a parent
module calls `child.state_dict(destination=...)` and discards the return value,
so nesting a `Learner` inside any other module would silently drop all of its
state. Separate names keep both contracts intact.

Gradients are not checkpointed, so a checkpoint taken mid-accumulation-window
resets the accumulation counter to 0 with a warning rather than resuming at a
non-zero step with empty gradients (which would step after fewer micro-batches
than `grad_accum_steps` and under-scale that update).

## Notes

- `update()` raises on a non-scalar summed loss, which is what a loss built with
  `reduction="none"` produces -- previously this surfaced as a torch-internal
  "grad can be implicitly created only for scalar outputs" error.
- The `"loss"` prefix cannot be tightened to `"loss_"`: `"loss"` with no
  underscore is a real out_key (`DQNLoss`, `GAILLoss`, `OnlineDTLoss`).
- With `FSDP2Learner.get_weights()`'s default `cpu_offload=True`, the full
  weights are returned **on rank 0 only** and every other rank gets an empty
  tensordict. That is deliberate (gathering the full model onto every rank does
  not scale), but it means an unconditional
  `scheme.send(learner.get_weights())` sends nothing from non-zero ranks. Pass
  `cpu_offload=False` to gather everywhere.
- With gradient accumulation the output key set differs between accumulation
  calls and step calls (`grad_norm` only appears on the latter).
- No `*Config` companion yet. These classes have no `Trainer` wiring in this PR,
  so a Hydra config would have nothing to instantiate against; the configs land
  with the trainer integration (follow-up 2 below).
- These are new, unreleased classes, so the `checkpoint()` rename carries no
  deprecation shim.

## Planned follow-ups (not in this PR)

1. Multi-rank `FSDP2Learner` verification on real multi-GPU hardware -- the one
   thing I could not test here. The single-rank gloo/CPU tests exercise the
   `fully_shard`/DTensor code paths but not actual cross-rank communication.
2. Refactor an existing recipe's hand-rolled training loop (e.g. the
   reward-model recipe, once #3922 lands) onto `LocalLearner`, as the first real
   consumer, with the `*Config` companions.
3. A `RemoteLearner` design writeup scoping one external backend (TorchTitan is
   the most PyTorch-native of the candidates and the most plausible first
   integration target) before any implementation.


## Tested

`test/test_trainer.py`: **100 passed, 19 skipped** (26 of those are the
`Learner`/`FSDP2Learner` tests). Single-rank gloo/CPU only; multi-GPU is
follow-up 1.

`c75e16b` fixes a checkpoint bug that only surfaced once the suite actually ran:
`get_state_dict(full_state_dict=True, cpu_offload=True)` does **not** guarantee
fresh tensors — `cpu_offload` only copies when the shards are off-CPU, so on a
CPU or single-rank mesh the "gathered" state aliases the live shards and training
on after a checkpoint silently mutates it. `FSDP2Learner.checkpoint` now clones,
like the base implementation.
