### PR TITLE
[Feature] Partial pose constraints in the macro-action Cartesian IK API

### DIFF
--- a/docs/source/reference/envs_transforms.rst
+++ b/docs/source/reference/envs_transforms.rst
@@ -284,6 +284,7 @@ Available Transforms
     MacroPrimitive
     MacroPrimitiveTransform
     TargetMacroAction
+    CartesianSolver
     RobotMacroAction
     RobotMacroActionMode
     SatelliteMacroAction

--- a/docs/source/reference/macro_primitives.rst
+++ b/docs/source/reference/macro_primitives.rst
@@ -283,6 +283,87 @@ and executes it when ``execute=True``.
      <source src="../_static/videos/macro_cube_bowl.mp4" type="video/mp4">
    </video>
 
+Custom Cartesian solvers and partial pose constraints
+-----------------------------------------------------
+
+:class:`~torchrl.envs.URScriptPrimitiveTransform` maps ``reach_pose`` targets to
+joint destinations through a Cartesian solver. The solver is the sanctioned
+extension point for custom inverse-kinematics behavior; its contract is
+documented by the :class:`~torchrl.envs.CartesianSolver` protocol. A plain
+two-argument callable ``(target_pose, start_action) -> action`` remains a valid
+solver: the transform inspects the signature and only forwards the optional
+keyword arguments the solver declares.
+
+Two flavors of Cartesian target need no extra arguments: a position-only target
+(quaternion omitted, all three rotational degrees of freedom free) and a full
+6D pose (all three rotational degrees of freedom locked). Many practical
+constraints live in between: keep the gripper level, hold a rod vertically,
+keep a camera pointing at a target with the roll free. These use one to two
+rotational degrees of freedom and are expressed with ``orientation_mask``:
+
+.. code-block:: python
+
+   # Keep the tool axis aligned with the target orientation ("stay level"),
+   # leave the spin about the world z axis free.
+   td["action"] = RobotMacroAction.reach_pose(
+       position=target_position,
+       quaternion=td["pinch_quat"],
+       orientation_mask=(1.0, 1.0, 0.0),
+       steps=36,
+   )
+
+The mask entries are per-axis weights on the world-frame rotation error inside
+the damped-least-squares loop: a zero entry removes the corresponding error row
+so rotation about that world axis remains unconstrained, avoiding the
+over-constrained full-quaternion solve near singularities.
+
+Constraints applied only at the endpoint can still be violated mid-macro,
+because the default expansion interpolates in joint space between the start
+configuration and the endpoint solution. Passing ``path="cartesian"`` re-solves
+the inverse kinematics at every interpolation waypoint along the straight-line
+Cartesian path (linear in position, geodesic in orientation), so constraints
+such as "stay on the line" and "stay level" hold along the whole macro action:
+
+.. code-block:: python
+
+   # Translate a vertically held rod along a line, no lateral motion.
+   td["action"] = RobotMacroAction.reach_pose(
+       position=target_position,
+       quaternion=vertical_quat,
+       orientation_mask=(1.0, 1.0, 0.0),
+       path="cartesian",
+       steps=36,
+   )
+
+The :meth:`~torchrl.envs.CubeBowlEnv.make_urscript_transform` preset honors
+both keywords out of the box. A custom solver opts in by declaring the
+corresponding keyword arguments; the sketch below shows the shape of a
+partial-orientation damped-least-squares solver (compare
+``CubeBowlEnv._cartesian_pose_to_joint_target`` for a complete MuJoCo
+implementation):
+
+.. code-block:: python
+
+   def cartesian_solver(target_pose, start_action, *, orientation_mask=None, waypoints=None):
+       # target_pose: (*batch, 7) position + (w, x, y, z) quaternion, world frame
+       # start_action: (*batch, action_dim); trailing entry is the gripper
+       q = start_action[..., :-1]
+       weights = orientation_mask if orientation_mask is not None else ones3
+       for wp_pose in interpolate_cartesian(fk(q), target_pose, waypoints or 1):
+           for _ in range(iterations):
+               pos_err = wp_pose[..., :3] - fk(q).position
+               rot_err = weights * world_rotation_error(wp_pose[..., 3:], fk(q).rotation)
+               err = concat([pos_err, rot_err])
+               jac = concat([jac_pos(q), weights[..., None] * jac_rot(q)])
+               q = q + damped_least_squares_step(jac, err)
+       # single endpoint (*batch, action_dim) or a (*batch, waypoints, action_dim) path
+       return assemble_actions(q, start_action)
+
+If a macro action requests ``orientation_mask`` or ``path="cartesian"`` and the
+configured solver does not declare the matching keyword, the transform raises a
+``TypeError`` pointing at the :class:`~torchrl.envs.CartesianSolver` contract
+rather than silently dropping the constraint.
+
 Designing target-driven macros for a new environment
 ----------------------------------------------------
 

--- a/test/libs/test_mujoco.py
+++ b/test/libs/test_mujoco.py
@@ -50,6 +50,9 @@ from torchrl.envs.custom.mujoco._math import (
 )
 from torchrl.envs.utils import check_env_specs, step_mdp
 
+if _has_mujoco:
+    import mujoco
+
 _AVAILABLE_BACKENDS: list[str] = []
 if _has_mujoco_torch:
     _AVAILABLE_BACKENDS.append("mujoco-torch")
@@ -1535,6 +1538,120 @@ class TestMujoco:
 
         out = env.step(td)
         assert torch.isfinite(out.get(("next", "reward"))).all()
+
+    @staticmethod
+    def _cube_bowl_pinch_fk(env, qpos6):
+        model = env._backend._m
+        data = mujoco.MjData(model)
+        data.qpos[:] = env._backend._d.qpos.copy()
+        q = data.qpos.copy()
+        q[list(env._robot_qpos_indices)] = np.asarray(qpos6, dtype=np.float64)
+        data.qpos[:] = q
+        mujoco.mj_forward(model, data)
+        return (
+            data.site_xpos[env._pinch_site_id].copy(),
+            data.site_xmat[env._pinch_site_id].reshape(3, 3).copy(),
+        )
+
+    @pytest.mark.skipif(not _has_mujoco, reason="CubeBowlEnv uses MuJoCo C bindings.")
+    def test_cube_bowl_partial_orientation_ik(self):
+        env = CubeBowlEnv(**self._cube_bowl_kwargs(), seed=0, max_episode_steps=3)
+        td = env.reset()
+        start_action = torch.zeros(1, 7, dtype=env.dtype)
+        start_action[0, :6] = td["robot_qpos"][0]
+        pinch_quat = env._pinch_quat()
+        target_pos = env._pinch_pos() + torch.tensor(
+            [[0.10, 0.0, -0.05]], dtype=env.dtype
+        )
+        pose = CubeBowlEnv.pose_at(target_pos, pinch_quat)
+
+        out = env._cartesian_pose_to_joint_target(
+            pose,
+            start_action,
+            iterations=200,
+            orientation_mask=(1.0, 1.0, 0.0),
+        )
+        assert out.shape == torch.Size([1, 7])
+        pos, rot = self._cube_bowl_pinch_fk(env, out[0, :6].cpu().numpy())
+        assert np.linalg.norm(pos - target_pos[0].cpu().numpy()) < 1e-3
+        target_mat = np.zeros(9)
+        mujoco.mju_quat2Mat(target_mat, pinch_quat[0].double().cpu().numpy())
+        target_mat = target_mat.reshape(3, 3)
+        # the constrained axes hold: solved tool z-axis parallel to the target
+        # tool z-axis even though the spin about world z is left free
+        assert float(rot[:, 2] @ target_mat[:, 2]) > 1.0 - 1e-4
+        env.close()
+
+    @pytest.mark.skipif(not _has_mujoco, reason="CubeBowlEnv uses MuJoCo C bindings.")
+    def test_cube_bowl_cartesian_waypoint_ik(self):
+        env = CubeBowlEnv(**self._cube_bowl_kwargs(), seed=0, max_episode_steps=3)
+        td = env.reset()
+        start_action = torch.zeros(1, 7, dtype=env.dtype)
+        start_action[0, :6] = td["robot_qpos"][0]
+        pinch_quat = env._pinch_quat()
+        target_pos = env._pinch_pos() + torch.tensor(
+            [[0.10, 0.0, -0.05]], dtype=env.dtype
+        )
+        pose = CubeBowlEnv.pose_at(target_pos, pinch_quat)
+        waypoints = 8
+
+        seq = env._cartesian_pose_to_joint_target(
+            pose,
+            start_action,
+            iterations=100,
+            orientation_mask=(1.0, 1.0, 0.0),
+            waypoints=waypoints,
+        )
+        assert seq.shape == torch.Size([1, waypoints, 7])
+
+        start_pos, _ = self._cube_bowl_pinch_fk(env, start_action[0, :6].cpu().numpy())
+        line = target_pos[0].cpu().numpy() - start_pos
+        line_dir = line / np.linalg.norm(line)
+
+        def max_lateral_deviation(joint_rows):
+            deviation = 0.0
+            for qpos6 in joint_rows:
+                pos, _ = self._cube_bowl_pinch_fk(env, qpos6)
+                offset = pos - start_pos
+                lateral = offset - (offset @ line_dir) * line_dir
+                deviation = max(deviation, float(np.linalg.norm(lateral)))
+            return deviation
+
+        cartesian_deviation = max_lateral_deviation(seq[0, :, :6].cpu().numpy())
+        # joint-space interpolation between the same endpoints drifts off the
+        # straight-line path; the per-waypoint solve must not
+        endpoint = env._cartesian_pose_to_joint_target(
+            pose,
+            start_action,
+            iterations=200,
+            orientation_mask=(1.0, 1.0, 0.0),
+        )
+        alphas = np.linspace(1.0 / waypoints, 1.0, waypoints)[:, None]
+        joint_rows = (1.0 - alphas) * start_action[0, :6].cpu().numpy()[
+            None
+        ] + alphas * endpoint[0, :6].cpu().numpy()[None]
+        joint_deviation = max_lateral_deviation(joint_rows)
+        assert cartesian_deviation < 5e-4
+        assert cartesian_deviation < joint_deviation
+
+        # end-to-end through the transform: reach_pose(path="cartesian")
+        transform = env.make_urscript_transform(
+            macro_steps=waypoints, execute=False, ik_kwargs={"iterations": 100}
+        )
+        macro_td = td.clone()
+        macro_td["action"] = RobotMacroAction.reach_pose(
+            position=target_pos,
+            quaternion=pinch_quat,
+            orientation_mask=(1.0, 1.0, 0.0),
+            path="cartesian",
+            steps=waypoints,
+        )
+        expanded = transform.inv(macro_td)["action"]
+        assert expanded.shape == torch.Size([1, waypoints, 7])
+        torch.testing.assert_close(
+            expanded[..., :6].double(), seq[..., :6].double(), atol=1e-6, rtol=0
+        )
+        env.close()
 
     def test_xml_path_kwarg_overrides_class_attr(self, tmp_path):
         """Custom ``xml_path=`` overrides the class-level :attr:`XML_PATH`."""

--- a/test/transforms/test_action_transforms.py
+++ b/test/transforms/test_action_transforms.py
@@ -1286,7 +1286,13 @@ class TestMacroPrimitiveTransform:
             orientation_mask=None,
             waypoints=None,
         ):
-            calls.append({"orientation_mask": orientation_mask, "waypoints": waypoints})
+            calls.append(
+                {
+                    "target_pose": target_pose,
+                    "orientation_mask": orientation_mask,
+                    "waypoints": waypoints,
+                }
+            )
             if waypoints is not None:
                 out = (
                     start_action.unsqueeze(-2)
@@ -1333,6 +1339,10 @@ class TestMacroPrimitiveTransform:
         torch.testing.assert_close(
             calls[0]["orientation_mask"], torch.tensor([[1.0, 1.0, 0.0]])
         )
+        torch.testing.assert_close(
+            calls[0]["target_pose"][..., 3:],
+            torch.tensor([[1.0, 0.0, 0.0, 0.0]]),
+        )
         assert calls[0]["waypoints"] is None
 
     def test_reach_pose_without_mask_passes_none(self):
@@ -1352,6 +1362,33 @@ class TestMacroPrimitiveTransform:
         )
         transform.inv(td)
         assert calls[0]["orientation_mask"] is None
+        torch.testing.assert_close(calls[0]["target_pose"][..., 3:], torch.zeros(1, 4))
+
+    @pytest.mark.parametrize(
+        ("reach_pose_kwargs", "match"),
+        [
+            ({"orientation_mask": (1.0, 1.0, 0.0)}, "orientation_mask"),
+            ({"path": "cartesian"}, "path='cartesian'"),
+        ],
+    )
+    def test_reach_pose_constraint_without_solver_raises(
+        self, reach_pose_kwargs, match
+    ):
+        transform = URScriptPrimitiveTransform(macro_steps=2)
+        td = TensorDict(
+            {
+                "action": RobotMacroAction.reach_pose(
+                    position=torch.tensor([[1.0, 2.0, 3.0]]),
+                    steps=2,
+                    **reach_pose_kwargs,
+                ),
+                "robot_qpos": torch.zeros(1, 6),
+                "gripper_qpos": torch.zeros(1, 2),
+            },
+            batch_size=[1],
+        )
+        with pytest.raises(TypeError, match=match):
+            transform.inv(td)
 
     def test_reach_pose_orientation_mask_legacy_solver_raises(self):
         transform = URScriptPrimitiveTransform(

--- a/test/transforms/test_action_transforms.py
+++ b/test/transforms/test_action_transforms.py
@@ -49,6 +49,7 @@ from torchrl.data.vla import (
 from torchrl.envs import (
     ActionMask,
     ActionScaling,
+    CartesianSolver,
     Compose,
     ConditionalPolicySwitch,
     ConditionalSkip,
@@ -1275,6 +1276,184 @@ class TestMacroPrimitiveTransform:
         )
         action = transform.inv(td)["action"]
         torch.testing.assert_close(action[..., -1], torch.full((1, 4), 154.0))
+
+    @staticmethod
+    def _recording_ik_solver(calls):
+        def solver(
+            target_pose,
+            start_action,
+            *,
+            orientation_mask=None,
+            waypoints=None,
+        ):
+            calls.append({"orientation_mask": orientation_mask, "waypoints": waypoints})
+            if waypoints is not None:
+                out = (
+                    start_action.unsqueeze(-2)
+                    .expand(
+                        start_action.shape[:-1] + (waypoints, start_action.shape[-1])
+                    )
+                    .clone()
+                )
+                out[..., :6] = torch.arange(1, waypoints + 1, dtype=out.dtype).reshape(
+                    (1,) * (start_action.ndim - 1) + (waypoints, 1)
+                )
+                return out
+            out = start_action.clone()
+            out[..., :3] = target_pose[..., :3]
+            return out
+
+        return solver
+
+    def test_cartesian_solver_protocol(self):
+        calls = []
+        assert isinstance(self._ik_solver(), CartesianSolver)
+        assert isinstance(self._recording_ik_solver(calls), CartesianSolver)
+
+    def test_reach_pose_orientation_mask_passed_to_solver(self):
+        calls = []
+        transform = URScriptPrimitiveTransform(
+            macro_steps=2, cartesian_solver=self._recording_ik_solver(calls)
+        )
+        td = TensorDict(
+            {
+                "action": RobotMacroAction.reach_pose(
+                    position=torch.tensor([[1.0, 2.0, 3.0]]),
+                    quaternion=torch.tensor([[1.0, 0.0, 0.0, 0.0]]),
+                    orientation_mask=(1.0, 1.0, 0.0),
+                    steps=2,
+                ),
+                "robot_qpos": torch.zeros(1, 6),
+                "gripper_qpos": torch.zeros(1, 2),
+            },
+            batch_size=[1],
+        )
+        transform.inv(td)
+        assert len(calls) == 1
+        torch.testing.assert_close(
+            calls[0]["orientation_mask"], torch.tensor([[1.0, 1.0, 0.0]])
+        )
+        assert calls[0]["waypoints"] is None
+
+    def test_reach_pose_without_mask_passes_none(self):
+        calls = []
+        transform = URScriptPrimitiveTransform(
+            macro_steps=2, cartesian_solver=self._recording_ik_solver(calls)
+        )
+        td = TensorDict(
+            {
+                "action": RobotMacroAction.reach_pose(
+                    position=torch.tensor([[1.0, 2.0, 3.0]]), steps=2
+                ),
+                "robot_qpos": torch.zeros(1, 6),
+                "gripper_qpos": torch.zeros(1, 2),
+            },
+            batch_size=[1],
+        )
+        transform.inv(td)
+        assert calls[0]["orientation_mask"] is None
+
+    def test_reach_pose_orientation_mask_legacy_solver_raises(self):
+        transform = URScriptPrimitiveTransform(
+            macro_steps=2, cartesian_solver=self._ik_solver()
+        )
+        td = TensorDict(
+            {
+                "action": RobotMacroAction.reach_pose(
+                    position=torch.tensor([[1.0, 2.0, 3.0]]),
+                    quaternion=torch.tensor([[1.0, 0.0, 0.0, 0.0]]),
+                    orientation_mask=(1.0, 1.0, 0.0),
+                    steps=2,
+                ),
+                "robot_qpos": torch.zeros(1, 6),
+                "gripper_qpos": torch.zeros(1, 2),
+            },
+            batch_size=[1],
+        )
+        with pytest.raises(TypeError, match="orientation_mask"):
+            transform.inv(td)
+
+    def test_reach_pose_cartesian_path_uses_waypoints(self):
+        calls = []
+        transform = URScriptPrimitiveTransform(
+            macro_steps=3, cartesian_solver=self._recording_ik_solver(calls)
+        )
+        td = TensorDict(
+            {
+                "action": RobotMacroAction.reach_pose(
+                    position=torch.tensor([[1.0, 2.0, 3.0]]),
+                    path="cartesian",
+                    gripper="closed",
+                    steps=3,
+                    settle_steps=2,
+                ),
+                "robot_qpos": torch.zeros(1, 6),
+                "gripper_qpos": torch.zeros(1, 2),
+            },
+            batch_size=[1],
+        )
+        action = transform.inv(td)["action"]
+        assert action.shape == torch.Size([1, 5, 7])
+        # the endpoint solve plus the per-waypoint solve
+        assert [call["waypoints"] for call in calls] == [None, 3]
+        # arm columns follow the solver-provided waypoints, and the settle
+        # segment holds the final waypoint
+        torch.testing.assert_close(
+            action[0, :, 0], torch.tensor([1.0, 2.0, 3.0, 3.0, 3.0])
+        )
+        # the gripper column still follows the interpolated gripper command
+        torch.testing.assert_close(action[0, -1, -1], torch.tensor(255.0))
+
+    def test_reach_pose_cartesian_path_legacy_solver_raises(self):
+        transform = URScriptPrimitiveTransform(
+            macro_steps=2, cartesian_solver=self._ik_solver()
+        )
+        td = TensorDict(
+            {
+                "action": RobotMacroAction.reach_pose(
+                    position=torch.tensor([[1.0, 2.0, 3.0]]),
+                    path="cartesian",
+                    steps=2,
+                ),
+                "robot_qpos": torch.zeros(1, 6),
+                "gripper_qpos": torch.zeros(1, 2),
+            },
+            batch_size=[1],
+        )
+        with pytest.raises(TypeError, match="waypoints"):
+            transform.inv(td)
+
+    def test_reach_pose_invalid_path_raises(self):
+        with pytest.raises(ValueError, match="path must be"):
+            RobotMacroAction.reach_pose(position=torch.zeros(1, 3), path="linear")
+
+    def test_reach_pose_cartesian_path_nested_action_key(self):
+        calls = []
+        transform = URScriptPrimitiveTransform(
+            action_key=("agent", "action"),
+            macro_steps=2,
+            cartesian_solver=self._recording_ik_solver(calls),
+        )
+        td = TensorDict(
+            {
+                ("agent", "action"): RobotMacroAction.reach_pose(
+                    position=torch.tensor([[1.0, 2.0, 3.0]]),
+                    orientation_mask=(0.0, 1.0, 1.0),
+                    path="cartesian",
+                    steps=2,
+                ),
+                "robot_qpos": torch.zeros(1, 6),
+                "gripper_qpos": torch.zeros(1, 2),
+            },
+            batch_size=[1],
+        )
+        action = transform.inv(td)[("agent", "action")]
+        assert action.shape == torch.Size([1, 2, 7])
+        assert calls[-1]["waypoints"] == 2
+        torch.testing.assert_close(
+            calls[-1]["orientation_mask"], torch.tensor([[0.0, 1.0, 1.0]])
+        )
+        torch.testing.assert_close(action[0, :, 0], torch.tensor([1.0, 2.0]))
 
     def test_close_gripper_keeps_arm(self):
         transform = URScriptPrimitiveTransform(macro_steps=4)

--- a/torchrl/envs/__init__.py
+++ b/torchrl/envs/__init__.py
@@ -27,6 +27,7 @@ from .custom.mujoco._satellite_primitives import (
     SatelliteMacroAction,
 )
 from .custom.mujoco._ur_primitives import (
+    CartesianSolver,
     RobotMacroAction,
     RobotMacroActionMode,
     URScriptPrimitive,
@@ -206,6 +207,7 @@ __all__ = [
     "BraxEnv",
     "BraxWrapper",
     "BurnInTransform",
+    "CartesianSolver",
     "CatFrames",
     "CatTensors",
     "CenterCrop",

--- a/torchrl/envs/custom/mujoco/_ur_primitives.py
+++ b/torchrl/envs/custom/mujoco/_ur_primitives.py
@@ -20,9 +20,10 @@ how to specialize :class:`~torchrl.envs.transforms.MacroPrimitiveTransform`:
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import inspect
+
 from enum import IntEnum
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, Protocol, runtime_checkable
 
 import torch
 from tensordict import TensorDictBase
@@ -43,7 +44,91 @@ __all__ = [
 ]
 
 GripperCommand = Literal["keep", "open", "closed"]
-CartesianSolver = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+
+
+@runtime_checkable
+class CartesianSolver(Protocol):
+    r"""Contract of the Cartesian inverse-kinematics hook used by ``movel``.
+
+    A Cartesian solver maps a target end-effector pose to a low-level
+    joint-position action. It is the sanctioned extension point for custom
+    inverse-kinematics behavior in the macro-action stack: pass one to
+    :class:`~torchrl.envs.URScriptPrimitiveTransform` via the
+    ``cartesian_solver`` argument, or let the transform fall back to a parent
+    environment's ``_cartesian_pose_to_joint_target`` hook (e.g.
+    :class:`~torchrl.envs.CubeBowlEnv`).
+
+    The call signature is::
+
+        solver(target_pose, start_action, *, orientation_mask=None, waypoints=None)
+
+    Args:
+        target_pose (torch.Tensor): target end-effector pose of shape
+            ``(*batch, 7)``: three position coordinates followed by a
+            ``(w, x, y, z)`` unit quaternion, all in the world frame. A zero
+            (or otherwise invalid) quaternion means "position only": all three
+            rotational degrees of freedom are free.
+        start_action (torch.Tensor): current low-level action of shape
+            ``(*batch, action_dim)``. The leading ``action_dim - 1`` entries
+            are joint positions used to seed the solve; the trailing entry is
+            the gripper command and must be copied through unchanged.
+
+    Keyword Args:
+        orientation_mask (torch.Tensor, optional): per-axis weights of shape
+            ``(*batch, 3)`` applied to the world-frame rotation error. A zero
+            entry leaves rotation about that world axis unconstrained; e.g.
+            ``(1.0, 1.0, 0.0)`` constrains rotations about the world x and y
+            axes (keep a tool axis parallel to world z, i.e. "stay level")
+            while leaving the spin about world z free. Non-finite entries mean
+            "no mask" for that batch element. Solvers that only support the
+            position-only / full-6D endpoints may omit this parameter from
+            their signature; the transform then raises when a macro action
+            requests a partial constraint.
+        waypoints (int, optional): when provided, solve the inverse kinematics
+            along a straight-line Cartesian path from the current end-effector
+            pose to ``target_pose`` and return the whole joint-space sequence
+            of shape ``(*batch, waypoints, action_dim)`` instead of a single
+            endpoint of shape ``(*batch, action_dim)``. Constraints (full or
+            partial orientation) must hold at every waypoint, not only at the
+            endpoint. Solvers that do not support per-waypoint solving may
+            omit this parameter; the transform then raises when a macro action
+            requests ``path="cartesian"``.
+
+    Returns:
+        torch.Tensor: the low-level action(s) realizing the target pose:
+        ``(*batch, action_dim)`` without ``waypoints``, or
+        ``(*batch, waypoints, action_dim)`` with it.
+
+    A plain two-argument callable ``(target_pose, start_action) -> action`` is
+    a valid (endpoint-only, fully-constrained-or-free) solver;
+    :class:`~torchrl.envs.URScriptPrimitiveTransform` inspects the signature
+    and only forwards the keyword arguments the solver declares.
+
+    Examples:
+        >>> import torch
+        >>> def keep_level_solver(target_pose, start_action, *, orientation_mask=None, waypoints=None):
+        ...     # A stub that ignores kinematics and returns the seed action:
+        ...     # a real solver would run damped least squares, weighting the
+        ...     # world-frame rotation error rows by ``orientation_mask``.
+        ...     if waypoints is not None:
+        ...         return start_action.unsqueeze(-2).expand(
+        ...             *start_action.shape[:-1], waypoints, start_action.shape[-1]
+        ...         ).clone()
+        ...     return start_action.clone()
+        >>> from torchrl.envs import CartesianSolver
+        >>> isinstance(keep_level_solver, CartesianSolver)
+        True
+    """
+
+    def __call__(
+        self,
+        target_pose: torch.Tensor,
+        start_action: torch.Tensor,
+        *,
+        orientation_mask: torch.Tensor | None = None,
+        waypoints: int | None = None,
+    ) -> torch.Tensor:
+        ...
 
 
 class URScriptPrimitive(IntEnum):
@@ -132,6 +217,26 @@ def _gripper_code(gripper: GripperCommand) -> int:
     )
 
 
+def _unsupported_solver_kwargs(
+    solver: CartesianSolver, kwargs: dict[str, Any]
+) -> set[str]:
+    """Return the keyword arguments in ``kwargs`` that ``solver`` cannot accept."""
+    try:
+        signature = inspect.signature(solver)
+    except (TypeError, ValueError):
+        return set()
+    parameters = signature.parameters.values()
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters):
+        return set()
+    names = {
+        p.name
+        for p in parameters
+        if p.kind
+        in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+    }
+    return {name for name in kwargs if name not in names}
+
+
 def _batch_size(batch_size: torch.Size | tuple[int, ...] | None) -> torch.Size:
     if batch_size is None:
         return torch.Size([1])
@@ -176,10 +281,14 @@ class RobotMacroAction(MacroAction):
     joints: torch.Tensor
     gripper: torch.Tensor
     gripper_command: torch.Tensor
+    orientation_mask: torch.Tensor | None = None
+    path: torch.Tensor | None = None
 
     GRIPPER_KEEP: ClassVar[int] = -1
     GRIPPER_OPEN: ClassVar[int] = 0
     GRIPPER_CLOSED: ClassVar[int] = 1
+    PATH_JOINT: ClassVar[int] = 0
+    PATH_CARTESIAN: ClassVar[int] = 1
     RESET: ClassVar[_RobotMacroActionReset]
 
     @classmethod
@@ -188,12 +297,43 @@ class RobotMacroAction(MacroAction):
         *,
         position: torch.Tensor,
         quaternion: torch.Tensor | None = None,
+        orientation_mask: torch.Tensor | tuple[float, float, float] | None = None,
+        path: Literal["joint", "cartesian"] = "joint",
         gripper: GripperCommand = "keep",
         gripper_command: float | torch.Tensor | None = None,
         steps: int = 16,
         settle_steps: int = 0,
     ) -> RobotMacroAction:
-        """Ask the end effector to reach a Cartesian pose."""
+        """Ask the end effector to reach a Cartesian pose.
+
+        Args:
+            position: target position, shape ``(*batch, 3)``.
+            quaternion: optional target orientation as a ``(w, x, y, z)``
+                quaternion, shape ``(*batch, 4)``. When omitted, all three
+                rotational degrees of freedom are free.
+
+        Keyword Args:
+            orientation_mask: optional per-axis weights of shape
+                ``(*batch, 3)`` (or a 3-tuple) applied to the world-frame
+                rotation error during the inverse-kinematics solve. A zero
+                entry leaves rotation about that world axis free; e.g.
+                ``(1.0, 1.0, 0.0)`` keeps the tool axis aligned with the
+                target orientation while leaving the spin about the world
+                z axis unconstrained ("keep the gripper level"). Requires a
+                solver honoring the :class:`~torchrl.envs.CartesianSolver`
+                ``orientation_mask`` keyword.
+            path: ``"joint"`` (default) interpolates in joint space between
+                the current configuration and the endpoint inverse-kinematics
+                solution; ``"cartesian"`` re-solves the inverse kinematics at
+                every interpolation waypoint along the straight-line Cartesian
+                path so pose constraints hold along the whole macro action.
+                Requires a solver honoring the
+                :class:`~torchrl.envs.CartesianSolver` ``waypoints`` keyword.
+            gripper: gripper command (``"keep"``, ``"open"`` or ``"closed"``).
+            gripper_command: optional raw low-level gripper command override.
+            steps: number of interpolated low-level actions.
+            settle_steps: number of repeated final actions.
+        """
         position = _as_batch(position, 3)
         if quaternion is None:
             quaternion = _identity_quaternion_like(position)
@@ -201,10 +341,21 @@ class RobotMacroAction(MacroAction):
             quaternion = _as_batch(quaternion, 4).to(
                 dtype=position.dtype, device=position.device
             )
+        if orientation_mask is not None:
+            orientation_mask = _as_batch(
+                torch.as_tensor(
+                    orientation_mask, dtype=position.dtype, device=position.device
+                ),
+                3,
+            )
+        if path not in ("joint", "cartesian"):
+            raise ValueError(f"path must be 'joint' or 'cartesian', got {path!r}.")
         return cls._make(
             RobotMacroActionMode.REACH_POSE,
             position=position,
             quaternion=quaternion,
+            orientation_mask=orientation_mask,
+            path=cls.PATH_CARTESIAN if path == "cartesian" else cls.PATH_JOINT,
             gripper=gripper,
             gripper_command=gripper_command,
             steps=steps,
@@ -377,6 +528,8 @@ class RobotMacroAction(MacroAction):
         position: torch.Tensor | None = None,
         quaternion: torch.Tensor | None = None,
         joints: torch.Tensor | None = None,
+        orientation_mask: torch.Tensor | None = None,
+        path: int = 0,
         gripper: GripperCommand = "keep",
         gripper_command: float | torch.Tensor | None = None,
         steps: int = 16,
@@ -406,11 +559,23 @@ class RobotMacroAction(MacroAction):
             quaternion = _as_batch(quaternion, 4).to(dtype=dtype, device=device)
         if joints is None:
             joints = torch.zeros(batch_size + (6,), dtype=dtype, device=device)
+        if orientation_mask is None:
+            orientation_mask = torch.full(
+                batch_size + (3,), float("nan"), dtype=dtype, device=device
+            )
+        else:
+            orientation_mask = orientation_mask.to(dtype=dtype, device=device).expand(
+                batch_size + (3,)
+            )
 
         return cls(
             position=position,
             quaternion=quaternion,
             joints=joints,
+            orientation_mask=orientation_mask,
+            path=torch.full(
+                batch_size + (1,), int(path), dtype=torch.long, device=device
+            ),
             gripper=torch.full(
                 batch_size + (1,),
                 _gripper_code(gripper),
@@ -454,9 +619,15 @@ class URScriptPrimitiveTransform(MacroPrimitiveTransform):
         macro_steps: interpolated low-level actions per primitive.
         settle_steps: repeated final actions appended per primitive.
         action_dim: low-level action dimension (six joints + one gripper).
-        cartesian_solver: optional callable mapping ``(target_pose,
-            start_action)`` to a low-level action. When omitted, the transform
-            uses a parent env's ``_cartesian_pose_to_joint_target`` hook.
+        cartesian_solver: optional :class:`~torchrl.envs.CartesianSolver`
+            mapping ``(target_pose, start_action)`` to a low-level action.
+            A plain two-argument callable is accepted; the optional
+            ``orientation_mask`` and ``waypoints`` keyword arguments are only
+            forwarded when the solver declares them (they are required for
+            :meth:`RobotMacroAction.reach_pose` partial orientation
+            constraints and ``path="cartesian"`` respectively). When omitted,
+            the transform uses a parent env's
+            ``_cartesian_pose_to_joint_target`` hook.
         open_gripper_ctrl: low-level gripper command for an open gripper.
         close_gripper_ctrl: low-level gripper command for a closed gripper.
 
@@ -731,8 +902,13 @@ class URScriptPrimitiveTransform(MacroPrimitiveTransform):
         gripper = self._structured_gripper(action, start, batch_shape, dtype, device)
 
         pose = torch.cat([position, quaternion], dim=-1)
+        orientation_mask = self._action_orientation_mask(
+            action, batch_shape, dtype, device
+        )
         movej_target = self.low_level_action(joints)
-        movel_target = self._solve_cartesian(pose, start)
+        movel_target = self._solve_cartesian(
+            pose, start, orientation_mask=orientation_mask
+        )
 
         target = start.clone()
         target = torch.where(primitive_id == int(lib.MOVEJ), movej_target, target)
@@ -768,13 +944,130 @@ class URScriptPrimitiveTransform(MacroPrimitiveTransform):
             )
         return start, target, steps, settle_steps
 
-    def _solve_cartesian(self, pose: torch.Tensor, start: torch.Tensor) -> torch.Tensor:
-        if self.cartesian_solver is not None:
-            return self.cartesian_solver(pose, start)
-        env = self._find_parent_env_with("_cartesian_pose_to_joint_target")
-        if env is None:
+    def _inv_call(self, tensordict: TensorDictBase) -> TensorDictBase:
+        action = tensordict.get(self.action_key, default=None)
+        start, target, steps, settle_steps = self._resolve(tensordict, action)
+        sequence = self._interpolate_sequence(start, target, steps, settle_steps)
+        structured = _unwrap_robot_macro_action(action)
+        if isinstance(structured, (TensorDictBase, MacroAction)):
+            sequence = self._apply_cartesian_path(
+                tensordict, structured, start, sequence, steps
+            )
+        return tensordict.set(self.action_key, sequence)
+
+    def _apply_cartesian_path(
+        self,
+        tensordict: TensorDictBase,
+        action: TensorDictBase,
+        start: torch.Tensor,
+        sequence: torch.Tensor,
+        steps: int,
+    ) -> torch.Tensor:
+        """Replace joint-interpolated ``movel`` segments with per-waypoint solves.
+
+        When a macro action requests ``path="cartesian"``, the Cartesian solver
+        is asked for the full joint-space sequence along the straight-line
+        Cartesian path (``waypoints=steps``) so pose constraints hold at every
+        waypoint instead of only at the endpoint.
+        """
+        keys = action.keys(True, True)
+        if "path" not in keys or "mode" not in keys:
+            return sequence
+        batch_shape = tensordict.batch_size
+        device = start.device
+        dtype = start.dtype
+        mode = action.get("mode").to(torch.long).reshape(batch_shape + (1,))
+        path = action.get("path").to(torch.long).reshape(batch_shape + (1,))
+        cartesian = (mode == int(self.primitive_enum.MOVEL)) & (
+            path == RobotMacroAction.PATH_CARTESIAN
+        )
+        if not cartesian.any():
+            return sequence
+        position = self._field(action, "position", batch_shape, dtype, device, 3)
+        quaternion_default = torch.zeros(batch_shape + (4,), dtype=dtype, device=device)
+        quaternion_default[..., 0] = 1.0
+        quaternion = self._field(
+            action, "quaternion", batch_shape, dtype, device, 4, quaternion_default
+        )
+        pose = torch.cat([position, quaternion], dim=-1)
+        orientation_mask = self._action_orientation_mask(
+            action, batch_shape, dtype, device
+        )
+        waypoint_actions = self._solve_cartesian(
+            pose, start, orientation_mask=orientation_mask, waypoints=steps
+        )
+        joint_dim = self.action_dim - 1
+        select = cartesian.unsqueeze(-2)
+        out = sequence.clone()
+        out[..., :steps, :joint_dim] = torch.where(
+            select, waypoint_actions[..., :joint_dim], out[..., :steps, :joint_dim]
+        )
+        if out.shape[-2] > steps:
+            out[..., steps:, :joint_dim] = torch.where(
+                select,
+                waypoint_actions[..., -1:, :joint_dim],
+                out[..., steps:, :joint_dim],
+            )
+        return out
+
+    @staticmethod
+    def _action_orientation_mask(
+        action: TensorDictBase,
+        batch_shape: torch.Size,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor | None:
+        if "orientation_mask" not in action.keys(True, True):
+            return None
+        mask = action.get("orientation_mask")
+        if mask is None:
+            return None
+        mask = mask.to(dtype=dtype, device=device).reshape(batch_shape + (3,))
+        if not torch.isfinite(mask).any():
+            return None
+        return mask
+
+    def _solve_cartesian(
+        self,
+        pose: torch.Tensor,
+        start: torch.Tensor,
+        *,
+        orientation_mask: torch.Tensor | None = None,
+        waypoints: int | None = None,
+    ) -> torch.Tensor:
+        solver = self.cartesian_solver
+        if solver is None:
+            env = self._find_parent_env_with("_cartesian_pose_to_joint_target")
+            if env is not None:
+                solver = env._cartesian_pose_to_joint_target
+        if solver is None:
+            if waypoints is not None:
+                return (
+                    start.unsqueeze(-2)
+                    .expand(start.shape[:-1] + (waypoints, start.shape[-1]))
+                    .clone()
+                )
             return start
-        return env._cartesian_pose_to_joint_target(pose, start)
+        kwargs: dict[str, Any] = {}
+        if orientation_mask is not None:
+            kwargs["orientation_mask"] = orientation_mask
+        if waypoints is not None:
+            kwargs["waypoints"] = waypoints
+        if kwargs:
+            unsupported = _unsupported_solver_kwargs(solver, kwargs)
+            if unsupported:
+                features = {
+                    "orientation_mask": "RobotMacroAction.reach_pose(orientation_mask=...)",
+                    "waypoints": "RobotMacroAction.reach_pose(path='cartesian')",
+                }
+                requested = " and ".join(features[name] for name in sorted(unsupported))
+                raise TypeError(
+                    f"The configured Cartesian solver does not accept the keyword "
+                    f"argument(s) {sorted(unsupported)} required by {requested}. "
+                    "Extend the solver signature to the documented "
+                    "torchrl.envs.CartesianSolver contract."
+                )
+        return solver(pose, start, **kwargs)
 
     # ------------------------------------------------------------------ #
     # Specs

--- a/torchrl/envs/custom/mujoco/_ur_primitives.py
+++ b/torchrl/envs/custom/mujoco/_ur_primitives.py
@@ -21,7 +21,7 @@ how to specialize :class:`~torchrl.envs.transforms.MacroPrimitiveTransform`:
 from __future__ import annotations
 
 import inspect
-
+from collections.abc import Callable
 from enum import IntEnum
 from typing import Any, ClassVar, Literal, Protocol, runtime_checkable
 
@@ -218,7 +218,8 @@ def _gripper_code(gripper: GripperCommand) -> int:
 
 
 def _unsupported_solver_kwargs(
-    solver: CartesianSolver, kwargs: dict[str, Any]
+    solver: CartesianSolver | Callable[[torch.Tensor, torch.Tensor], torch.Tensor],
+    kwargs: dict[str, Any],
 ) -> set[str]:
     """Return the keyword arguments in ``kwargs`` that ``solver`` cannot accept."""
     try:
@@ -336,7 +337,11 @@ class RobotMacroAction(MacroAction):
         """
         position = _as_batch(position, 3)
         if quaternion is None:
-            quaternion = _identity_quaternion_like(position)
+            quaternion = torch.zeros(
+                position.shape[:-1] + (4,),
+                dtype=position.dtype,
+                device=position.device,
+            )
         else:
             quaternion = _as_batch(quaternion, 4).to(
                 dtype=position.dtype, device=position.device
@@ -665,7 +670,9 @@ class URScriptPrimitiveTransform(MacroPrimitiveTransform):
         macro_steps: int = 16,
         settle_steps: int = 0,
         action_dim: int = 7,
-        cartesian_solver: CartesianSolver | None = None,
+        cartesian_solver: CartesianSolver
+        | Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+        | None = None,
         open_gripper_ctrl: float = 0.0,
         close_gripper_ctrl: float = 255.0,
     ) -> None:
@@ -1035,24 +1042,30 @@ class URScriptPrimitiveTransform(MacroPrimitiveTransform):
         orientation_mask: torch.Tensor | None = None,
         waypoints: int | None = None,
     ) -> torch.Tensor:
+        kwargs: dict[str, Any] = {}
+        if orientation_mask is not None:
+            kwargs["orientation_mask"] = orientation_mask
+        if waypoints is not None:
+            kwargs["waypoints"] = waypoints
+
         solver = self.cartesian_solver
         if solver is None:
             env = self._find_parent_env_with("_cartesian_pose_to_joint_target")
             if env is not None:
                 solver = env._cartesian_pose_to_joint_target
         if solver is None:
-            if waypoints is not None:
-                return (
-                    start.unsqueeze(-2)
-                    .expand(start.shape[:-1] + (waypoints, start.shape[-1]))
-                    .clone()
+            if kwargs:
+                features = {
+                    "orientation_mask": "RobotMacroAction.reach_pose(orientation_mask=...)",
+                    "waypoints": "RobotMacroAction.reach_pose(path='cartesian')",
+                }
+                requested = " and ".join(features[name] for name in sorted(kwargs))
+                raise TypeError(
+                    "No Cartesian solver is configured, but "
+                    f"{requested} requires one implementing the documented "
+                    "torchrl.envs.CartesianSolver contract."
                 )
             return start
-        kwargs: dict[str, Any] = {}
-        if orientation_mask is not None:
-            kwargs["orientation_mask"] = orientation_mask
-        if waypoints is not None:
-            kwargs["waypoints"] = waypoints
         if kwargs:
             unsupported = _unsupported_solver_kwargs(solver, kwargs)
             if unsupported:

--- a/torchrl/envs/custom/mujoco/cube_bowl.py
+++ b/torchrl/envs/custom/mujoco/cube_bowl.py
@@ -956,10 +956,19 @@ class CubeBowlEnv(MujocoEnv):
             ik_kwargs = dict(ik_kwargs)
 
         def cartesian_solver(
-            target_pose: torch.Tensor, start_action: torch.Tensor
+            target_pose: torch.Tensor,
+            start_action: torch.Tensor,
+            *,
+            orientation_mask: torch.Tensor | None = None,
+            waypoints: int | None = None,
         ) -> torch.Tensor:
+            kwargs = dict(ik_kwargs)
+            if orientation_mask is not None:
+                kwargs["orientation_mask"] = orientation_mask
+            if waypoints is not None:
+                kwargs["waypoints"] = waypoints
             return self._cartesian_pose_to_joint_target(
-                target_pose, start_action, **ik_kwargs
+                target_pose, start_action, **kwargs
             )
 
         return URScriptPrimitiveTransform(
@@ -1083,12 +1092,27 @@ class CubeBowlEnv(MujocoEnv):
         damping: float = 1e-4,
         step_size: float = 0.7,
         orientation_weight: float = 0.0,
+        orientation_mask: torch.Tensor | None = None,
+        waypoints: int | None = None,
     ) -> torch.Tensor:
         """Best-effort MuJoCo damped-least-squares IK for ``movel``.
 
-        The solver optimizes the ``pinch`` site over the first six arm joints.
+        The solver optimizes the ``pinch`` site over the first six arm joints
+        and honors the :class:`~torchrl.envs.CartesianSolver` contract:
+
+        * ``orientation_mask`` applies per-axis weights to the world-frame
+          rotation error rows (a zero entry leaves rotation about that world
+          axis free). Providing a mask enables orientation tracking even when
+          ``orientation_weight`` is zero; a positive ``orientation_weight``
+          scales the masked rows.
+        * ``waypoints`` re-solves the inverse kinematics along a straight-line
+          Cartesian path (linear position, geodesic orientation) from the
+          current end-effector pose to ``target_pose``, returning the joint
+          sequence of shape ``(1, waypoints, 7)``.
+
         If the active backend is not the official MuJoCo C backend, the input
-        action is returned unchanged.
+        action is returned unchanged (expanded across waypoints when
+        requested).
         """
         if start_action is None:
             start_action = torch.zeros(
@@ -1096,14 +1120,26 @@ class CubeBowlEnv(MujocoEnv):
                 dtype=self.dtype,
                 device=target_pose.device,
             )
+
+        def fallback() -> torch.Tensor:
+            if waypoints is None:
+                return start_action
+            return (
+                start_action.unsqueeze(-2)
+                .expand(start_action.shape[:-1] + (waypoints, start_action.shape[-1]))
+                .clone()
+            )
+
         if (
             not _has_mujoco
             or self._pinch_site_id is None
             or not hasattr(self._backend, "_m")
         ):
-            return start_action
+            return fallback()
         if target_pose.shape[0] != 1:
-            return start_action
+            return fallback()
+        if waypoints is not None and waypoints <= 0:
+            raise ValueError("waypoints must be strictly positive.")
         import mujoco
 
         model = self._backend._m
@@ -1111,16 +1147,33 @@ class CubeBowlEnv(MujocoEnv):
         data.qpos[:] = self._backend._d.qpos.copy()
         data.qvel[:] = 0.0
         q = data.qpos.copy()
+        qpos_idx = list(self._robot_qpos_indices)
+        dof_idx = list(self._robot_qvel_indices)
         if start_action.shape[-1] >= self.ROBOT_QPOS_DIM:
-            q[list(self._robot_qpos_indices)] = (
+            q[qpos_idx] = (
                 start_action[0, : self.ROBOT_QPOS_DIM].detach().cpu().double().numpy()
             )
         ctrl_low = model.actuator_ctrlrange[: self.ROBOT_QPOS_DIM, 0]
         ctrl_high = model.actuator_ctrlrange[: self.ROBOT_QPOS_DIM, 1]
         target = target_pose[0, :3].detach().cpu().double().numpy()
+        mask = None
+        if orientation_mask is not None:
+            mask_np = (
+                torch.as_tensor(orientation_mask)
+                .detach()
+                .cpu()
+                .double()
+                .numpy()
+                .reshape(-1)[:3]
+            )
+            if np.all(np.isfinite(mask_np)):
+                mask = mask_np
         target_quat = None
         target_mat = None
-        if target_pose.shape[-1] >= 7 and orientation_weight > 0.0:
+        rot_weights = None
+        if target_pose.shape[-1] >= 7 and (
+            orientation_weight > 0.0 or mask is not None
+        ):
             quat = target_pose[0, 3:7].detach().cpu().double().numpy()
             norm = float(np.linalg.norm(quat))
             if norm > 1e-6:
@@ -1128,41 +1181,73 @@ class CubeBowlEnv(MujocoEnv):
                 target_mat = np.zeros(9)
                 mujoco.mju_quat2Mat(target_mat, target_quat)
                 target_mat = target_mat.reshape(3, 3)
+                base_weight = orientation_weight if orientation_weight > 0.0 else 1.0
+                rot_weights = base_weight * (mask if mask is not None else np.ones(3))
         jacp = np.zeros((3, model.nv))
         jacr = np.zeros((3, model.nv))
-        err_dim = 6 if target_quat is not None else 3
+        err_dim = 3 if rot_weights is None else 6
         eye = np.eye(err_dim)
-        for _ in range(iterations):
-            data.qpos[:] = q
-            mujoco.mj_forward(model, data)
-            pos_err = target - data.site_xpos[self._pinch_site_id]
-            mujoco.mj_jacSite(model, data, jacp, jacr, self._pinch_site_id)
-            if target_quat is None:
-                err = pos_err
-                jac = jacp[:, list(self._robot_qvel_indices)]
-            else:
-                rot_err = self._rotation_error(
-                    target_mat, data.site_xmat[self._pinch_site_id].reshape(3, 3)
-                )
-                err = np.concatenate([pos_err, orientation_weight * rot_err])
-                jac = np.concatenate(
-                    [
-                        jacp[:, list(self._robot_qvel_indices)],
-                        orientation_weight * jacr[:, list(self._robot_qvel_indices)],
-                    ],
-                    axis=0,
-                )
-            if float(np.linalg.norm(err)) < 1e-4:
-                break
-            lhs = jac @ jac.T + damping * eye
-            dq = jac.T @ np.linalg.solve(lhs, err)
-            q[list(self._robot_qpos_indices)] += step_size * dq
-            q[list(self._robot_qpos_indices)] = self._wrap_ctrl_range(
-                q[list(self._robot_qpos_indices)], ctrl_low, ctrl_high
+
+        def solve(q: np.ndarray, wp_pos: np.ndarray, wp_mat: np.ndarray | None):
+            for _ in range(iterations):
+                data.qpos[:] = q
+                mujoco.mj_forward(model, data)
+                pos_err = wp_pos - data.site_xpos[self._pinch_site_id]
+                mujoco.mj_jacSite(model, data, jacp, jacr, self._pinch_site_id)
+                if rot_weights is None:
+                    err = pos_err
+                    jac = jacp[:, dof_idx]
+                else:
+                    rot_err = self._rotation_error(
+                        wp_mat, data.site_xmat[self._pinch_site_id].reshape(3, 3)
+                    )
+                    err = np.concatenate([pos_err, rot_weights * rot_err])
+                    jac = np.concatenate(
+                        [jacp[:, dof_idx], rot_weights[:, None] * jacr[:, dof_idx]],
+                        axis=0,
+                    )
+                if float(np.linalg.norm(err)) < 1e-4:
+                    break
+                lhs = jac @ jac.T + damping * eye
+                dq = jac.T @ np.linalg.solve(lhs, err)
+                q[qpos_idx] += step_size * dq
+                q[qpos_idx] = self._wrap_ctrl_range(q[qpos_idx], ctrl_low, ctrl_high)
+            return q
+
+        if waypoints is None:
+            q = solve(q, target, target_mat)
+            out = start_action.clone()
+            out[0, : self.ROBOT_QPOS_DIM] = torch.as_tensor(
+                q[qpos_idx], dtype=out.dtype, device=out.device
             )
-        out = start_action.clone()
-        out[0, : self.ROBOT_QPOS_DIM] = torch.as_tensor(
-            q[list(self._robot_qpos_indices)], dtype=out.dtype, device=out.device
+            return out
+
+        data.qpos[:] = q
+        mujoco.mj_forward(model, data)
+        start_pos = data.site_xpos[self._pinch_site_id].copy()
+        rot_vel = None
+        start_quat = None
+        if target_quat is not None:
+            start_quat = np.zeros(4)
+            mujoco.mju_mat2Quat(start_quat, data.site_xmat[self._pinch_site_id].copy())
+            rot_vel = np.zeros(3)
+            mujoco.mju_subQuat(rot_vel, target_quat, start_quat)
+        rows = []
+        for k in range(1, waypoints + 1):
+            alpha = k / waypoints
+            wp_pos = start_pos + alpha * (target - start_pos)
+            wp_mat = target_mat
+            if rot_vel is not None:
+                wp_quat = start_quat.copy()
+                mujoco.mju_quatIntegrate(wp_quat, rot_vel, alpha)
+                wp_mat9 = np.zeros(9)
+                mujoco.mju_quat2Mat(wp_mat9, wp_quat)
+                wp_mat = wp_mat9.reshape(3, 3)
+            q = solve(q, wp_pos, wp_mat)
+            rows.append(q[qpos_idx].copy())
+        out = fallback()
+        out[0, :, : self.ROBOT_QPOS_DIM] = torch.as_tensor(
+            np.stack(rows), dtype=out.dtype, device=out.device
         )
         return out
 

--- a/torchrl/envs/transforms/__init__.py
+++ b/torchrl/envs/transforms/__init__.py
@@ -95,6 +95,7 @@ from .vecnorm import VecNormV2
 from .vip import VIPRewardTransform, VIPTransform
 
 _UR_PRIMITIVE_EXPORTS = {
+    "CartesianSolver",
     "RobotMacroAction",
     "RobotMacroActionMode",
     "URScriptPrimitive",
@@ -138,6 +139,7 @@ __all__ = [
     "BatchSizeTransform",
     "BinarizeReward",
     "BurnInTransform",
+    "CartesianSolver",
     "CatFrames",
     "CatTensors",
     "CenterCrop",


### PR DESCRIPTION
## Description

Fixes #3934.

The macro-action stack (`RobotMacroAction.reach_pose` + `URScriptPrimitiveTransform` + `CartesianSolver`) previously supported only two flavors of Cartesian target: position-only (all 3 rotational DOF free) and full 6D pose (all 3 locked). Constraints in between ("keep the gripper level", "hold a rod vertically while translating it") required hand-rolled solver closures, and constraints only held at the macro endpoint because expansion interpolates in joint space.

This PR addresses all three points of the issue:

1. **Docs first — `CartesianSolver` contract.** `CartesianSolver` is now a runtime-checkable `Protocol` with a full docstring (signature, shapes, batching, gripper passthrough) documenting it as the sanctioned extension point for custom IK. It is exported from `torchrl.envs` / `torchrl.envs.transforms`, added to the transforms API reference, and the macro-primitives guide gains a "Custom Cartesian solvers and partial pose constraints" section with a worked partial-orientation solver sketch. Plain `(target_pose, start_action)` callables remain valid solvers: the transform inspects the signature and only forwards the keyword arguments the solver declares. If a macro action requests a feature the solver cannot honor, the transform raises a descriptive `TypeError` instead of silently dropping the constraint.

2. **Partial orientation constraints.** `RobotMacroAction.reach_pose(..., orientation_mask=(1.0, 1.0, 0.0))` applies per-axis weights to the world-frame rotation error inside the DLS loop (row reweighting/selection): a zero entry leaves rotation about that world axis free. `(1, 1, 0)` with a level target quaternion keeps the tool axis level while leaving the spin about world z unconstrained, without burning all 3 rotational DOF. Providing a mask enables orientation tracking even when the scalar `orientation_weight` is zero; a positive `orientation_weight` scales the masked rows.

3. **Path (per-waypoint) constraints.** `reach_pose(..., path="cartesian")` re-solves the IK at every interpolation waypoint along the straight-line Cartesian path (linear in position, geodesic in orientation via quaternion integration), warm-starting each waypoint from the previous solution, instead of joint-space interpolation between endpoint solutions. Constraints such as "stay on the line" and "stay level" then hold along the whole macro action. On the cube-bowl UR5e scene, a 10 cm translation shows ~3.3 mm of mid-macro lateral drift with joint-space interpolation vs ~0.001 mm with `path="cartesian"` (measured by MuJoCo FK at each waypoint; asserted in the new test).

`CubeBowlEnv._cartesian_pose_to_joint_target` and the `make_urscript_transform` preset honor both keywords out of the box. The new `RobotMacroAction` fields (`orientation_mask`, `path`) are optional with backward-compatible defaults, and are deliberately kept out of the policy-facing action spec (same as `gripper_command`), so random/spec-driven actions are unchanged.

## Tests

- `test/transforms/test_action_transforms.py`: solver protocol check, mask/waypoints forwarding to capable solvers, descriptive `TypeError` for legacy two-argument solvers, cartesian-path sequence assembly (waypoint arm columns, settle-segment hold, gripper column), invalid `path` value, and a nested action-key exercise of the new path.
- `test/libs/test_mujoco.py`: FK-verified partial-orientation endpoint solve (position reached, constrained tool axis held with spin free) and per-waypoint path straightness (cartesian deviation < 0.5 mm and strictly below the joint-interpolation drift), plus an end-to-end `reach_pose(path="cartesian")` expansion through `make_urscript_transform`.

All existing macro/URScript tests pass; the `test_mujoco.py` failures on my machine (`mjENBL_MULTICCD` with mujoco 3.10) pre-exist on `main`.