### PR TITLE
[BugFix] Preserve PPO ESS dimensions for singleton batches

### DIFF
--- a/sota-implementations/vla_grpo/test_openvla.py
+++ b/sota-implementations/vla_grpo/test_openvla.py
@@ -31,6 +31,7 @@ from tensordict import NonTensorStack, TensorDict
 from tensordict.nn import InteractionType
 from torch import nn
 from torchrl.data.vla import ACTION_TOKENS_KEY
+from torchrl.objectives import ClipPPOLoss
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -608,8 +609,6 @@ class TestOpenVLAOFTWrapper:
 
     @pytest.mark.parametrize("ratio_level", ["sequence", "token"])
     def test_clip_ppo_loss_integration(self, ratio_level):
-        from torchrl.objectives import ClipPPOLoss
-
         torch.manual_seed(0)
         policy = OpenVLAOFTWrapper(
             _TinyOFT(),
@@ -618,21 +617,6 @@ class TestOpenVLAOFTWrapper:
             default_interaction_type=InteractionType.RANDOM,
             log_probs_mode=ratio_level,
         )
-        obs = _make_obs()
-        with torch.no_grad():
-            rollout = policy(obs.clone())
-        data = obs.clone()
-        data[ACTION_TOKENS_KEY] = rollout[ACTION_TOKENS_KEY]
-        data[LOG_PROBS_KEY] = rollout[LOG_PROBS_KEY].detach()
-        advantage = torch.tensor([[1.0], [-0.5]])
-        if ratio_level == "token":
-            # one ratio per token: the decision's advantage is broadcast over
-            # the token dims (as the training script does)
-            data["advantage"] = advantage.view(-1, 1, 1, 1).expand(
-                *rollout[ACTION_TOKENS_KEY].shape, 1
-            )
-        else:
-            data["advantage"] = advantage
         loss = ClipPPOLoss(
             policy,
             critic_network=None,
@@ -644,11 +628,36 @@ class TestOpenVLAOFTWrapper:
             sample_log_prob=LOG_PROBS_KEY,
             advantage="advantage",
         )
-        out = loss(data)
-        # identical weights: ratio == 1 everywhere, so the (negative) gain is
-        # exactly the negated mean advantage and nothing is clipped
-        torch.testing.assert_close(out["loss_objective"], -advantage.mean())
-        assert out["clip_fraction"].item() == 0.0
+        ess = []
+        for batch_size in (2, 1):
+            obs = _make_obs(batch=batch_size)
+            with torch.no_grad():
+                rollout = policy(obs.clone())
+            data = obs.clone()
+            data[ACTION_TOKENS_KEY] = rollout[ACTION_TOKENS_KEY]
+            data[LOG_PROBS_KEY] = rollout[LOG_PROBS_KEY].detach()
+            advantage = torch.linspace(1.0, -0.5, batch_size).unsqueeze(-1)
+            if ratio_level == "token":
+                # one ratio per token: the decision's advantage is broadcast over
+                # the token dims (as the training script does)
+                data["advantage"] = advantage.view(-1, 1, 1, 1).expand(
+                    *rollout[ACTION_TOKENS_KEY].shape, 1
+                )
+                expected_ess_shape = (CHUNK, ACT_DIM)
+            else:
+                data["advantage"] = advantage
+                expected_ess_shape = ()
+
+            out = loss(data)
+            # identical weights: ratio == 1 everywhere, so the (negative) gain is
+            # exactly the negated mean advantage and nothing is clipped
+            torch.testing.assert_close(out["loss_objective"], -advantage.mean())
+            assert out["clip_fraction"].item() == 0.0
+            assert out["ESS"].shape == expected_ess_shape
+            torch.testing.assert_close(out["ESS"], torch.ones_like(out["ESS"]))
+            ess.append(out["ESS"].detach().mean())
+
+        assert torch.stack(ess).shape == (2,)
 
 
 if __name__ == "__main__":

--- a/sota-implementations/vla_grpo/vla-grpo.py
+++ b/sota-implementations/vla_grpo/vla-grpo.py
@@ -654,7 +654,10 @@ def main(cfg):  # noqa: F821
                     micro_batches += 1
                     losses.append(loss_vals["loss_objective"].detach())
                     clip_fractions.append(loss_vals["clip_fraction"])
-                    ess.append(loss_vals["ESS"].detach())
+                    # Token-level ESS retains action feature dimensions. Reduce
+                    # each minibatch before aggregation so partial batches do
+                    # not make the diagnostic shapes heterogeneous.
+                    ess.append(loss_vals["ESS"].detach().mean())
                     if micro_batches % accumulate == 0:
                         optimizer_step()
             if micro_batches % accumulate:

--- a/test/objectives/test_ppo.py
+++ b/test/objectives/test_ppo.py
@@ -1694,6 +1694,52 @@ class TestPPO(LossModuleTestBase):
         assert isinstance(explained_variance, TensorDict)
 
 
+def test_ppo_ess_preserves_feature_shape_for_singleton_batch():
+    class TokenActor(nn.Module):
+        def __init__(self, vocab_size):
+            super().__init__()
+            self.bias = nn.Parameter(torch.zeros(vocab_size))
+            self.in_keys = ["logits"]
+
+        def get_dist(self, tensordict):
+            return torch.distributions.Categorical(
+                logits=tensordict["logits"] + self.bias
+            )
+
+    chunk_size, action_dim, vocab_size = 8, 7, 4
+    actor = TokenActor(vocab_size)
+    loss = ClipPPOLoss(actor, critic_network=None, entropy_bonus=False)
+    loss.set_keys(
+        action="action",
+        sample_log_prob="sample_log_prob",
+        advantage="advantage",
+    )
+
+    ess = []
+    for batch_size in (2, 1):
+        logits = torch.randn(batch_size, chunk_size, action_dim, vocab_size)
+        action = torch.randint(vocab_size, (batch_size, chunk_size, action_dim))
+        sample_log_prob = torch.distributions.Categorical(logits=logits).log_prob(
+            action
+        )
+        data = TensorDict(
+            {
+                "logits": logits,
+                "action": action,
+                "sample_log_prob": sample_log_prob,
+                "advantage": torch.ones(batch_size, chunk_size, action_dim, 1),
+            },
+            batch_size=[batch_size],
+        )
+
+        output = loss(data)
+        assert output["ESS"].shape == (chunk_size, action_dim)
+        torch.testing.assert_close(output["ESS"], torch.ones(chunk_size, action_dim))
+        ess.append(output["ESS"])
+
+    assert torch.stack(ess).shape == (2, chunk_size, action_dim)
+
+
 class TestA2C(LossModuleTestBase):
     seed = 0
 
@@ -3015,3 +3061,7 @@ class TestReinforce(LossModuleTestBase):
             # Test it works with value key
             loss = loss_fn(td)
             assert "loss_value" in loss.keys()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -1393,7 +1393,7 @@ class ClipPPOLoss(PPOLoss):
             # In theory, ESS should be computed on particles sampled from the same source. Here we sample according
             # to different, unrelated trajectories, which is not standard. Still, it can give an idea of the weights'
             # dispersion.
-            lw = log_weight.squeeze()
+            lw = log_weight.squeeze(-1)
             ess = (2 * lw.logsumexp(0) - (2 * lw).logsumexp(0)).exp()
             batch = log_weight.shape[0]
 


### PR DESCRIPTION
## Summary
- preserve batch and action-feature dimensions when computing PPO effective sample size for singleton minibatches
- reduce each VLA-GRPO minibatch ESS diagnostic to a scalar before cross-minibatch aggregation
- cover full-to-partial minibatch transitions in the PPO and tiny-OpenVLA regression suites

## Test plan
- `uv run --extra tests --with transformers python -m pytest test/objectives/test_ppo.py -q` (2327 passed, 20 skipped)
- `uv run --extra tests --with transformers --with timm --with pillow --with tokenizers python -m pytest sota-implementations/vla_grpo/test_openvla.py -q` (20 passed)
- `uv run pre-commit run --files torchrl/objectives/ppo.py test/objectives/test_ppo.py sota-implementations/vla_grpo/vla-grpo.py sota-implementations/vla_grpo/test_openvla.py`