### PR TITLE
[Doc] Explain Cartesian constraints in macro tutorial

### DIFF
--- a/tutorials/sphinx-tutorials/mujoco_cube_bowl_macros.py
+++ b/tutorials/sphinx-tutorials/mujoco_cube_bowl_macros.py
@@ -23,6 +23,8 @@ What you will learn
 - how to use :class:`~torchrl.envs.transforms.RobotMacroAction` as a readable action object;
 - how :class:`~torchrl.envs.transforms.URScriptPrimitiveTransform` lets ``env.step(td)``
   consume those actions directly;
+- how to hold the end effector still for gripper-only commands and keep its
+  orientation constrained along a Cartesian motion;
 - how to write a scripted contact-rich cube-to-bowl policy as an explicit list
   of poses and gripper commands;
 - how to request rendered pixels from the environment and record them with
@@ -103,6 +105,8 @@ IK_KWARGS = {
 #   where it is;
 # - ``RobotMacroAction.reach_pose(..., gripper="closed")`` moves the arm and closes
 #   the gripper in one macro action;
+# - ``RobotMacroAction.wait()`` holds the complete low-level target, while
+#   ``open_gripper`` and ``close_gripper`` preserve the six arm-joint targets;
 # - ``RobotMacroAction.RESET`` asks the environment to return to its configured home
 #   joint posture.
 #
@@ -245,6 +249,46 @@ assert td["action"].mode.shape == torch.Size([1, 1])
 
 
 # %%
+# Keeping the end effector constrained
+# -------------------------------------
+#
+# There are two different ways to keep the end effector in place. When only the
+# gripper should move, :meth:`~torchrl.envs.RobotMacroAction.open_gripper` and
+# :meth:`~torchrl.envs.RobotMacroAction.close_gripper` copy the current arm
+# target and modify only the gripper command. A
+# :meth:`~torchrl.envs.RobotMacroAction.wait` action holds both the arm and the
+# gripper target.
+#
+# During a Cartesian move, keeping the tool *orientation* fixed requires an
+# orientation constraint. A full target quaternion locks all three rotational
+# degrees of freedom. Often two are enough: for a level gripper, rotations about
+# the world x and y axes must remain constrained, while spin about world z can
+# stay free. ``orientation_mask=(1.0, 1.0, 0.0)`` expresses exactly that
+# constraint and avoids over-constraining the inverse-kinematics solve.
+#
+# By default, ``reach_pose`` solves inverse kinematics at the endpoint and then
+# interpolates the arm joints. Both endpoint poses can be valid even though the
+# tool tilts or leaves the straight Cartesian line between them. Setting
+# ``path="cartesian"`` asks the solver to warm-start a new IK solve at every
+# waypoint, so the position and orientation constraints hold throughout the
+# motion. The carry actions below use both options:
+#
+# .. code-block:: python
+#
+#    RobotMacroAction.reach_pose(
+#        position=target_position,
+#        quaternion=level_quaternion,
+#        orientation_mask=(1.0, 1.0, 0.0),
+#        path="cartesian",
+#        gripper="closed",
+#    )
+#
+# Cartesian waypoint solving is more expensive than joint interpolation. It is
+# most useful when intermediate geometry matters, such as transporting a held
+# object without tilting it or drifting sideways.
+
+
+# %%
 # A scripted cube-to-bowl macro
 # -----------------------------
 #
@@ -295,6 +339,8 @@ def carry_action(alpha: float, bowl: torch.Tensor) -> RobotMacroAction:
     return RobotMacroAction.reach_pose(
         position=position,
         quaternion=quaternion,
+        orientation_mask=(1.0, 1.0, 0.0),
+        path="cartesian",
         gripper="closed",
         gripper_command=gripper_close_command,
         steps=80,
@@ -366,8 +412,10 @@ def gen_actions(td: TensorDictBase) -> Iterator:
     # bowl, the fingers can drag faster than the cube can safely follow: the
     # cube may slide inside the grasp, get pushed out, or arrive shifted enough
     # that the final drop misses the bowl. We therefore carry it through a few
-    # intermediate waypoints in the table plane. After each waypoint, the next
-    # command uses the latest observed cube and finger positions.
+    # intermediate macro targets in the table plane. Within each macro,
+    # ``path="cartesian"`` keeps the pinch site on the straight Cartesian line
+    # and ``orientation_mask`` keeps the gripper level. After each target, the
+    # next command uses the latest observed cube and finger positions.
     policy_state["carry_start_cube"] = policy_state["td"]["cube_pos"].clone()
 
     # Action 6: Carry the cube one quarter of the way toward the bowl.
@@ -577,7 +625,9 @@ assert reset_td["robot_qpos"].shape == td["robot_qpos"].shape
 # still depend on calibration, solver quality and reachable waypoints. Their
 # practical value is that they provide a strong baseline, a source of
 # demonstrations, and a structured action space for residual policies or RL fine
-# tuning.
+# tuning. Use gripper-only actions or ``wait`` when the arm must remain still;
+# use an orientation mask and a Cartesian path when pose constraints must hold
+# while the arm is moving.
 #
 # .. seealso::
 #


### PR DESCRIPTION
## Description

- explain how gripper-only macros and `wait` keep the arm target stationary
- document partial orientation masks and per-waypoint Cartesian IK in the MuJoCo macros tutorial
- use the new constraints in the cube carry sequence to keep the gripper level and the pinch site on each Cartesian segment

Follow-up to #3935.

## Tests

- `TORCHRL_MUJOCO_MENAGERIE_PATH=/Users/vmoens/repos/mujoco_menagerie MPLBACKEND=Agg uv run --with matplotlib python tutorials/sphinx-tutorials/mujoco_cube_bowl_macros.py`
- pre-commit hooks