### PR TITLE
[Feature] Propagate interaction types through inference-server clients

### DIFF
--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -17,6 +17,11 @@ import torch.nn as nn
 from tensordict import lazy_stack, TensorDict
 from tensordict.base import TensorDictBase
 from tensordict.nn import TensorDictModule
+from tensordict.nn.probabilistic import (
+    interaction_type,
+    InteractionType,
+    set_interaction_type,
+)
 
 from torchrl.modules.inference_server import (
     InferenceClient,
@@ -1098,6 +1103,27 @@ class TestWeightSyncIntegration:
             td = TensorDict({"observation": torch.randn(4)})
             result = client(td)
             assert "action" in result.keys()
+
+    def test_policy_client_can_propagate_interaction_type(self):
+        class _InteractionPolicy(nn.Module):
+            def forward(self, td: TensorDictBase) -> TensorDictBase:
+                value = 1 if interaction_type() is InteractionType.RANDOM else 0
+                return TensorDict(
+                    {"action": torch.full(td.batch_size, value)},
+                    batch_size=td.batch_size,
+                )
+
+        transport = ThreadingTransport()
+        policy = _InteractionPolicy()
+        with InferenceServer(policy, transport, max_batch_size=4):
+            client = PolicyClientModule(
+                transport,
+                out_keys=["action"],
+                propagate_interaction_type=True,
+            )
+            with set_interaction_type(InteractionType.RANDOM):
+                result = client(TensorDict({}, batch_size=[1]))
+            assert result["action"].item() == 1
 
 
 # ---------------------------------------------------------------------------

--- a/torchrl/modules/inference_server/_client.py
+++ b/torchrl/modules/inference_server/_client.py
@@ -13,10 +13,20 @@ from typing import Any
 import torch
 from tensordict.base import TensorDictBase
 from tensordict.nn import TensorDictModuleBase
+from tensordict.nn.probabilistic import interaction_type
 from tensordict.utils import NestedKey
 
 from torchrl._utils import logger as torchrl_logger
 from torchrl.modules.inference_server._transport import InferenceTransport
+
+_REMOTE_INTERACTION_TYPE_KEY = "_torchrl_inference_interaction_type"
+_INTERACTION_TYPE_TO_CODE = {
+    "mode": 0,
+    "median": 1,
+    "mean": 2,
+    "random": 3,
+    "deterministic": 4,
+}
 
 
 class _ImmediateFuture:
@@ -141,6 +151,10 @@ class PolicyClientModule(TensorDictModuleBase):
             server's ``policy_version_key``; a mismatch triggers a one-time
             warning when the staleness guard is enabled. ``None`` disables the
             guard. Defaults to ``"policy_version"``.
+        propagate_interaction_type (bool, optional): if ``True``, the active
+            :func:`tensordict.nn.interaction_type` is attached to each request
+            so the server can execute the remote policy under the caller's
+            exploration context. Defaults to ``False``.
 
     .. note::
         The server-side version counter is independent from the
@@ -184,6 +198,7 @@ class PolicyClientModule(TensorDictModuleBase):
         target_policy_version: int | Callable[[], int] | None = None,
         max_policy_lag: int | None = None,
         policy_version_key: NestedKey | None = "policy_version",
+        propagate_interaction_type: bool = False,
     ) -> None:
         super().__init__()
         if isinstance(client, InferenceTransport):
@@ -201,6 +216,7 @@ class PolicyClientModule(TensorDictModuleBase):
         self.max_policy_lag = max_policy_lag
         self.policy_version_key = policy_version_key
         self._warned_missing_version = False
+        self.propagate_interaction_type = bool(propagate_interaction_type)
         self._inflight_sem = (
             threading.BoundedSemaphore(max_inflight)
             if max_inflight is not None
@@ -266,6 +282,19 @@ class PolicyClientModule(TensorDictModuleBase):
             and errors are deferred to ``result()`` on a reduced future that
             only implements ``done()`` and ``result()``.
         """
+        if self.propagate_interaction_type:
+            current_interaction_type = interaction_type()
+            if current_interaction_type is not None:
+                tensordict = tensordict.clone(recurse=False)
+                tensordict.set(
+                    _REMOTE_INTERACTION_TYPE_KEY,
+                    torch.full(
+                        tensordict.batch_size,
+                        _INTERACTION_TYPE_TO_CODE[current_interaction_type.value],
+                        dtype=torch.int8,
+                        device=tensordict.device or torch.device("cpu"),
+                    ),
+                )
         release = self._acquire_inflight()
         submit = getattr(self.client, "submit", None)
         if submit is None:

--- a/torchrl/modules/inference_server/_server.py
+++ b/torchrl/modules/inference_server/_server.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import contextlib
 import multiprocessing as mp
 
 import queue
@@ -18,15 +19,25 @@ from typing import Literal
 import torch
 from tensordict import lazy_stack
 from tensordict.base import TensorDictBase
+from tensordict.nn.probabilistic import InteractionType, set_interaction_type
 from tensordict.utils import NestedKey
 from torch import nn
 
+from torchrl.modules.inference_server._client import _REMOTE_INTERACTION_TYPE_KEY
 from torchrl.modules.inference_server._config import (
     InferenceDeviceConfig,
     InferenceServerConfig,
 )
 from torchrl.modules.inference_server._transport import InferenceTransport
 from torchrl.weight_update import SharedMemWeightSyncScheme, WeightSyncScheme
+
+_CODE_TO_INTERACTION_TYPE = {
+    0: InteractionType.MODE,
+    1: InteractionType.MEDIAN,
+    2: InteractionType.MEAN,
+    3: InteractionType.RANDOM,
+    4: InteractionType.DETERMINISTIC,
+}
 
 
 class InferenceServer:
@@ -408,6 +419,30 @@ class InferenceServer:
         )
         return result_batch.set(self.policy_version_key, version)
 
+    def _interaction_type_context(self, batch: TensorDictBase):
+        code = batch.get(_REMOTE_INTERACTION_TYPE_KEY, default=None)
+        if code is None:
+            return contextlib.nullcontext(), batch
+        if not isinstance(code, torch.Tensor):
+            interaction_type_value = _CODE_TO_INTERACTION_TYPE[int(code)]
+        else:
+            flat_code = code.reshape(-1)
+            if flat_code.numel() == 0:
+                return contextlib.nullcontext(), batch.exclude(
+                    _REMOTE_INTERACTION_TYPE_KEY, inplace=False
+                )
+            interaction_code = int(flat_code[0].item())
+            if not flat_code.eq(interaction_code).all():
+                raise RuntimeError(
+                    "InferenceServer received a mixed interaction-type batch. "
+                    "Use homogeneous server requests or a smaller max_batch_size."
+                )
+            interaction_type_value = _CODE_TO_INTERACTION_TYPE[interaction_code]
+        return (
+            set_interaction_type(interaction_type_value),
+            batch.exclude(_REMOTE_INTERACTION_TYPE_KEY, inplace=False),
+        )
+
     @torch.no_grad()
     def _run(self) -> None:
         self._init_weight_sync()
@@ -462,10 +497,14 @@ class InferenceServer:
                         batch = batch.to(self.policy_device)
                     forward_start = time.monotonic()
                     with self._model_lock:
-                        result_batch = self.model(batch)
-                    if self.output_device is not None:
-                        result_batch = result_batch.to(self.output_device)
-                    result_batch = self._set_policy_version(result_batch)
+                        interaction_context, batch = self._interaction_type_context(
+                            batch
+                        )
+                        with interaction_context:
+                            result_batch = self.model(batch)
+                        if self.output_device is not None:
+                            result_batch = result_batch.to(self.output_device)
+                        result_batch = self._set_policy_version(result_batch)
                     forward_ms = (time.monotonic() - forward_start) * 1000.0
                     self._record_batch_stats(
                         batch_size=len(callbacks),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3942
* #3940
* __->__ #3941
* #3897
* #3896
* #3895
* #3894
* #3893
* #3939

PolicyClientModule(propagate_interaction_type=True) attaches the caller's
active tensordict interaction type to each request as a compact int8 code;
the server decodes it and runs the batched forward under the corresponding
set_interaction_type context, so remote policies honor the client-side
exploration context (e.g. RANDOM vs DETERMINISTIC). Mixed-type batches are
rejected with a clear error. The server-side forward, output-device move,
and version stamping now all run under the model lock so responses cannot
be stamped with a version that does not match the weights used.