### PR TITLE
[Feature] Add OpenVLA-OFT L1 reference wrapper and SimpleVLA parity tooling

### DIFF
--- a/sota-implementations/vla_grpo/README.md
+++ b/sota-implementations/vla_grpo/README.md
@@ -43,7 +43,10 @@ benchmarks.
 
 ## The pieces in this directory
 
-The directory contains two versions of the same idea.
+The directory contains two versions of the same idea, plus
+`compare_simplevla_rollouts.py`, a standalone script that rolls the same
+checkpoint through both the TorchRL stack and the SimpleVLA-RL/VeRL reference
+rollout and writes a JSON parity report.
 
 ### Toy scale: learn the algorithm without a robot simulator
 
@@ -179,6 +182,27 @@ policy = OpenVLAOFTWrapper.from_pretrained(
 )
 tokenizer = policy.action_tokenizer  # decode tokens -> env actions
 ```
+
+The wrapper also has an explicit `policy.mode=l1` path for the official
+continuous OpenVLA-OFT reference checkpoints. That mode loads the released
+`action_head--150000_checkpoint.pt` and
+`proprio_projector--150000_checkpoint.pt` components, uses two images
+(`agentview` plus wrist) and the 8-D OpenVLA proprio vector, and writes a
+continuous `("vla_action", "chunk")`. It is meant to validate the environment,
+image preprocessing, proprio normalization, and evaluator/collector path
+against the supervised reference policy:
+
+```text
+policy.mode=l1
+policy.checkpoint=moojink/openvla-7b-oft-finetuned-libero-spatial
+policy.use_wrist_image=true
+policy.use_proprio=true
+policy.num_images_in_input=2
+policy.lora_rank=0
+```
+
+The PPO update still expects token log-probabilities, so this mode is for
+reference/evaluation probes until a continuous-action GRPO loss is added.
 
 Before spending RL compute on a checkpoint, validate the loading path by
 evaluating the SFT checkpoint greedily on its LIBERO suite through
@@ -328,7 +352,10 @@ path before the gripper transform is applied once in the environment. Use
 `env.train_init_state_mode=fixed env.train_init_state_id=<id>` for a fixed
 LIBERO initial state. `collector.policy_micro_batch_size` only slices actual
 model calls inside the inference-server policy; it does not change PPO
-minibatching.
+minibatching. `compare_simplevla_rollouts.py` automates the parity check: it
+evaluates the same `(task_id, init-state id)` trajectories through the TorchRL
+stack and the SimpleVLA-RL/VeRL reference rollout side by side and reports
+per-trajectory token/action/success agreement.
 
 ## Hardware notes
 

--- a/sota-implementations/vla_grpo/compare_simplevla_rollouts.py
+++ b/sota-implementations/vla_grpo/compare_simplevla_rollouts.py
@@ -1,0 +1,889 @@
+#!/usr/bin/env python
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Compare TorchRL VLA rollouts against the SimpleVLA-RL/VeRL rollout.
+
+The script loads one OpenVLA-OFT token policy and evaluates the same
+``(task_id, LIBERO init-state id)`` trajectories through two rollout stacks:
+
+* TorchRL: ``LiberoEnv`` + VLA GRPO transforms + TorchRL policy wrapper.
+* SimpleVLA-RL: the reference ``verl.workers.rollout.RobHFRollout`` trajectory
+  generator from the paper codebase.
+
+The output is a JSON file with per-trajectory records and side-by-side success
+rates. Run it from a checkout with both LIBERO and SimpleVLA-RL available, for
+example:
+
+.. code-block:: bash
+
+    export SIMPLEVLA_RL_ROOT=/path/to/SimpleVLA-RL
+    export LIBERO_ROOT=/path/to/LIBERO
+    export PYTHONPATH="${SIMPLEVLA_RL_ROOT}:${LIBERO_ROOT}:${PYTHONPATH:-}"
+    python sota-implementations/vla_grpo/compare_simplevla_rollouts.py \
+        --task-ids 0 --trial-ids 0 --policy-device cuda:0 --render-gpu 0
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import random
+import subprocess
+import sys
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from datetime import datetime, UTC
+from pathlib import Path
+from typing import Any, Literal
+
+os.environ.setdefault("LIBERO_CONFIG_PATH", os.path.expanduser("~/.libero"))
+os.environ.setdefault("ROBOT_PLATFORM", "LIBERO")
+os.environ.setdefault("MUJOCO_GL", "egl")
+os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+os.environ.setdefault("WANDB_MODE", "disabled")
+
+_SIMPLEVLA_ROOT_ENV = os.environ.get("SIMPLEVLA_RL_ROOT")
+_LIBERO_ROOT_ENV = os.environ.get("LIBERO_ROOT")
+for _path in (_SIMPLEVLA_ROOT_ENV, _LIBERO_ROOT_ENV):
+    if _path and _path not in sys.path:
+        sys.path.insert(0, _path)
+
+import numpy as np
+import torch
+
+import utils as vla_utils
+from omegaconf import DictConfig, OmegaConf
+from tensordict import TensorDict
+from tensordict.nn import InteractionType, set_interaction_type
+from torchrl._utils import logger as torchrl_logger
+from torchrl.data.vla import ACTION_TOKENS_KEY
+from torchrl.envs import LiberoEnv, TransformedEnv
+from torchrl.envs.utils import step_mdp
+
+_has_verl = importlib.util.find_spec("verl") is not None
+_DataProto = None
+_RobHFRollout = None
+_ORIGINAL_TORCH_LOAD = torch.load
+
+
+def _torch_load_trusted_init_state(*args, **kwargs):
+    """Compatibility shim for LIBERO init-state files under torch>=2.6."""
+    kwargs.setdefault("weights_only", False)
+    return _ORIGINAL_TORCH_LOAD(*args, **kwargs)
+
+
+@dataclass
+class _TrajectorySpec:
+    """One LIBERO task / init-state pair to evaluate."""
+
+    task_id: int
+    trial_id: int
+
+
+@dataclass
+class _TrajectoryResult:
+    """Per-trajectory rollout summary."""
+
+    stack: Literal["torchrl", "simplevla"]
+    task_id: int
+    trial_id: int
+    success: bool
+    outer_steps: int | None
+    env_steps: int
+    reward_sum: float | None = None
+    first_tokens: list[int] | None = None
+    first_action: list[float] | None = None
+    tokens: list[list[int]] | None = None
+    actions: list[list[float]] | None = None
+
+
+@dataclass
+class _StackSummary:
+    """Success-rate summary for one rollout stack."""
+
+    stack: Literal["torchrl", "simplevla"]
+    trajectories: int
+    successes: int
+    success_rate: float
+    env_steps: int
+
+
+@dataclass
+class _ParityResult:
+    """Per-trajectory parity metrics between the two rollout stacks."""
+
+    task_id: int
+    trial_id: int
+    success_agreement: bool
+    torchrl_success: bool
+    simplevla_success: bool
+    first_token_exact_match: bool | None
+    first_tokens_exact_match: bool | None
+    first_token_compare_count: int
+    first_token_mismatch_index: int | None
+    torchrl_first_token_at_mismatch: int | None
+    simplevla_first_token_at_mismatch: int | None
+    first_action_compare_count: int
+    first_action_max_abs_diff: float | None
+    first_action_mismatch_index: int | None
+
+
+@dataclass
+class _ParitySummary:
+    """Aggregate parity metrics for the report header."""
+
+    trajectories: int
+    success_agreements: int
+    success_agreement_rate: float
+    first_token_exact_matches: int
+    first_token_exact_match_rate: float
+    first_tokens_exact_matches: int
+    first_tokens_exact_match_rate: float
+    first_action_max_abs_diff: float | None
+
+
+def _insert_optional_root(root: str | None) -> None:
+    if root and root not in sys.path:
+        sys.path.insert(0, root)
+
+
+def _load_verl_rollout(simplevla_root: str | None):
+    """Load SimpleVLA-RL's VeRL rollout class as an optional dependency."""
+    global _DataProto, _RobHFRollout, _has_verl
+    _insert_optional_root(simplevla_root)
+    if not _has_verl:
+        _has_verl = importlib.util.find_spec("verl") is not None
+    if not _has_verl:
+        raise ImportError(
+            "Could not import 'verl'. Set SIMPLEVLA_RL_ROOT or pass "
+            "--simplevla-root pointing to the SimpleVLA-RL checkout."
+        )
+    if _DataProto is None or _RobHFRollout is None:
+        from verl import DataProto
+        from verl.workers.rollout import RobHFRollout
+
+        _DataProto = DataProto
+        _RobHFRollout = RobHFRollout
+    return _DataProto, _RobHFRollout
+
+
+def _git_commit(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(path), "rev-parse", "HEAD"], text=True
+        ).strip()
+    except Exception:
+        return None
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, torch.Tensor):
+        data = value.detach().cpu()
+        if data.numel() == 1:
+            return data.reshape(()).item()
+        return data.tolist()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(key): _jsonable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def _parse_int_list(value: str) -> list[int]:
+    values: list[int] = []
+    for part in value.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            start, end = part.split("-", 1)
+            values.extend(range(int(start), int(end) + 1))
+        else:
+            values.append(int(part))
+    return values
+
+
+def _trajectory_specs(
+    task_ids: Iterable[int],
+    trial_ids: Iterable[int],
+) -> list[_TrajectorySpec]:
+    return [
+        _TrajectorySpec(task_id=int(task_id), trial_id=int(trial_id))
+        for task_id in task_ids
+        for trial_id in trial_ids
+    ]
+
+
+def _set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def _load_cfg(args: argparse.Namespace, task_id: int) -> DictConfig:
+    cfg = OmegaConf.load(Path(args.config))
+    cfg.env.backend = "libero"
+    cfg.env.task_suite = args.task_suite
+    cfg.env.task_ids = [int(task_id)]
+    cfg.env.num_envs = 1
+    cfg.env.eval_num_envs = 1
+    cfg.env.parallel_group_repeats = False
+    cfg.env.render_gpu_ids = [int(args.render_gpu)]
+    cfg.env.eval_render_gpu_ids = [int(args.render_gpu)]
+    # honor the CLI rollout bounds: the chunk transform's StepCounter truncates
+    # at cfg.env.max_outer_steps, which would silently cap a larger
+    # --max-outer-steps at the yaml default otherwise
+    cfg.env.max_outer_steps = int(args.max_outer_steps)
+    cfg.env.max_env_steps = int(args.max_env_steps)
+    cfg.env.seed = int(args.seed)
+    cfg.policy.backend = "openvla"
+    cfg.policy.mode = "tokens"
+    cfg.policy.checkpoint = args.checkpoint
+    cfg.policy.unnorm_key = args.unnorm_key
+    cfg.policy.dataset_statistics = args.dataset_statistics
+    cfg.policy.device = str(args.policy_device)
+    cfg.policy.temperature = float(args.temperature)
+    cfg.policy.top_k = args.top_k
+    cfg.policy.use_wrist_image = False
+    cfg.policy.use_proprio = False
+    cfg.policy.num_images_in_input = 1
+    cfg.policy.center_crop = bool(args.center_crop)
+    cfg.policy.image_backend = args.torchrl_image_backend
+    cfg.policy.gripper_binarize = True
+    cfg.policy.gripper_binarize_threshold = float(args.gripper_binarize_threshold)
+    cfg.policy.gripper_invert = bool(args.gripper_invert)
+    cfg.policy.lora_rank = int(args.lora_rank)
+    cfg.logger.backend = "none"
+    cfg.logger.mode = "disabled"
+    return cfg
+
+
+def _simplevla_cfg(args: argparse.Namespace) -> DictConfig:
+    return OmegaConf.create(
+        {
+            "vla": "openvla-oft",
+            "pretrained_checkpoint": args.checkpoint,
+            "unnorm_key": args.unnorm_key,
+            "model_family": "openvla",
+            "task_suite_name": args.task_suite,
+            "num_steps_wait": int(args.settle_steps),
+            "center_crop": bool(args.center_crop),
+            "num_images_in_input": 1,
+            "use_proprio": False,
+            "action_chunks_len": int(args.chunk_size),
+            "temperature": float(args.temperature),
+            "do_sample": bool(args.sample_actions),
+            "micro_batch_size": int(args.simplevla_batch_size),
+            "val_micro_batch_size": int(args.simplevla_batch_size),
+            "max_prompt_length": int(args.max_prompt_length),
+            "experiment_name": args.experiment_name,
+        }
+    )
+
+
+def _policy_and_tokenizer(args: argparse.Namespace):
+    device = torch.device(args.policy_device)
+    cfg = _load_cfg(args, int(args.task_ids[0]))
+    policy = vla_utils.make_policy(cfg, device)
+    policy.eval()
+    tokenizer = vla_utils.make_action_tokenizer(cfg, policy)
+    return cfg, policy, tokenizer
+
+
+def _make_torchrl_env(
+    cfg: DictConfig,
+    tokenizer,
+    spec: _TrajectorySpec,
+    args: argparse.Namespace,
+) -> TransformedEnv:
+    env_kwargs = dict(cfg.env.env_kwargs or {})
+    env_kwargs["render_gpu_device_id"] = int(args.render_gpu)
+    base = LiberoEnv(
+        args.task_suite,
+        task_id=int(spec.task_id),
+        camera_height=int(cfg.env.camera_height),
+        camera_width=int(cfg.env.camera_width),
+        env_kwargs=env_kwargs,
+        wrist_camera=None,
+        from_pixels=False,
+        max_episode_steps=int(args.max_env_steps),
+        settle_steps=int(args.settle_steps),
+        init_state_mode="fixed",
+        init_state_id=int(spec.trial_id),
+    )
+    return TransformedEnv(base, vla_utils._chunk_transform(cfg, tokenizer))
+
+
+def _tensor_bool(value: torch.Tensor | None) -> bool:
+    if value is None:
+        return False
+    return bool(torch.as_tensor(value).reshape(-1).any().item())
+
+
+def _first_flat(value: torch.Tensor, limit: int) -> list[int] | list[float]:
+    data = value.detach().cpu()
+    while data.ndim > 2:
+        data = data[0]
+    return data.reshape(-1)[: min(data.numel(), limit)].tolist()
+
+
+def _decode_env_actions(policy, tokenizer, tokens: torch.Tensor) -> torch.Tensor:
+    decoded = tokenizer.decode(tokens)
+    gripper_postprocess = getattr(policy, "gripper_postprocess", None)
+    if gripper_postprocess is not None:
+        decoded = gripper_postprocess.postprocess(decoded)
+    return decoded
+
+
+def _torchrl_rollout_one(
+    cfg: DictConfig,
+    policy,
+    tokenizer,
+    spec: _TrajectorySpec,
+    args: argparse.Namespace,
+) -> _TrajectoryResult:
+    env = _make_torchrl_env(cfg, tokenizer, spec, args)
+    reward_sum = 0.0
+    first_tokens: list[int] | None = None
+    first_action: list[float] | None = None
+    tokens: list[list[int]] = []
+    actions: list[list[float]] = []
+    env_steps = 0
+    outer_steps = 0
+    success = False
+    try:
+        env.set_seed(int(args.seed))
+        td = env.reset()
+        interaction = (
+            InteractionType.RANDOM
+            if bool(args.sample_actions)
+            else InteractionType.DETERMINISTIC
+        )
+        with torch.no_grad(), set_interaction_type(interaction):
+            for _ in range(int(args.max_outer_steps)):
+                outer_steps += 1
+                policy_td = policy(td)
+                action_tokens = policy_td.get(ACTION_TOKENS_KEY).detach().cpu()
+                decoded = _decode_env_actions(policy, tokenizer, action_tokens)
+                tokens.append(_first_flat(action_tokens, action_tokens.numel()))
+                actions.append(_first_flat(decoded.float(), decoded.numel()))
+                if first_tokens is None:
+                    first_tokens = tokens[-1][:32]
+                    first_action = _first_flat(decoded.float(), 16)
+                next_td = env.step(policy_td)
+                reward = next_td.get(("next", "reward"), None)
+                if reward is not None:
+                    reward_sum += float(torch.as_tensor(reward).sum().item())
+                env_steps += int(args.chunk_size)
+                success = success or _tensor_bool(
+                    next_td.get(("next", "success"), None)
+                )
+                done = _tensor_bool(next_td.get(("next", "done"), None))
+                if done or success:
+                    break
+                td = step_mdp(next_td)
+    finally:
+        env.close()
+    return _TrajectoryResult(
+        stack="torchrl",
+        task_id=int(spec.task_id),
+        trial_id=int(spec.trial_id),
+        success=bool(success),
+        outer_steps=outer_steps,
+        env_steps=int(min(env_steps, int(args.max_env_steps))),
+        reward_sum=float(reward_sum),
+        first_tokens=first_tokens,
+        first_action=first_action,
+        tokens=tokens,
+        actions=actions,
+    )
+
+
+def _run_torchrl_stack(
+    args: argparse.Namespace,
+    specs: list[_TrajectorySpec],
+    policy,
+    tokenizer,
+) -> list[_TrajectoryResult]:
+    results = []
+    cfg_cache: dict[int, DictConfig] = {}
+    for spec in specs:
+        cfg = cfg_cache.setdefault(spec.task_id, _load_cfg(args, spec.task_id))
+        result = _torchrl_rollout_one(cfg, policy, tokenizer, spec, args)
+        torchrl_logger.info(
+            "TorchRL rollout task=%s trial=%s success=%s env_steps=%s",
+            spec.task_id,
+            spec.trial_id,
+            result.success,
+            result.env_steps,
+        )
+        results.append(result)
+    return results
+
+
+def _make_simplevla_prompts(specs: list[_TrajectorySpec], meta_info: dict[str, Any]):
+    DataProto, _ = _load_verl_rollout(None)
+    batch = TensorDict(
+        {
+            "task_id": torch.tensor(
+                [[spec.task_id] for spec in specs], dtype=torch.int64
+            ),
+            "trial_id": torch.tensor(
+                [[spec.trial_id] for spec in specs], dtype=torch.int64
+            ),
+            "trial_seed": torch.full((len(specs), 1), -1, dtype=torch.int64),
+        },
+        batch_size=[len(specs)],
+    )
+    non_tensor_batch = {
+        "task_suite_name": np.array(
+            [meta_info["task_suite_name"] for _ in specs], dtype=object
+        )
+    }
+    return DataProto(
+        batch=batch,
+        non_tensor_batch=non_tensor_batch,
+        meta_info={"n_samples": 1},
+    )
+
+
+def _run_simplevla_batch(
+    rollout,
+    specs: list[_TrajectorySpec],
+    task_suite_name: str,
+    policy,
+    tokenizer,
+) -> list[_TrajectoryResult]:
+    prompts = _make_simplevla_prompts(
+        specs,
+        {"task_suite_name": task_suite_name},
+    )
+    output = rollout.generate_sequences(prompts)
+    complete = output.batch["complete"].detach().cpu().bool()
+    finish_step = output.batch["finish_step"].detach().cpu().long()
+    responses = output.batch["responses"].detach().cpu().long()
+    vocab_size = getattr(rollout.module, "vocab_size", None)
+    num_bins = getattr(tokenizer, "num_bins", 256)
+    results = []
+    for index, spec in enumerate(specs):
+        trajectory_tokens = responses[index].detach().cpu().long()
+        if vocab_size is not None:
+            trajectory_tokens = trajectory_tokens - (int(vocab_size) - int(num_bins))
+        trajectory_actions = [
+            _decode_env_actions(
+                policy,
+                tokenizer,
+                step_tokens.reshape(int(step_tokens.numel() // 7), 7),
+            )
+            for step_tokens in trajectory_tokens
+        ]
+        results.append(
+            _TrajectoryResult(
+                stack="simplevla",
+                task_id=int(spec.task_id),
+                trial_id=int(spec.trial_id),
+                success=bool(complete[index].item()),
+                outer_steps=None,
+                env_steps=int(finish_step[index].item()),
+                first_tokens=trajectory_tokens[0].reshape(-1)[:32].tolist(),
+                first_action=trajectory_actions[0]
+                .detach()
+                .cpu()
+                .float()
+                .reshape(-1)[:16]
+                .tolist(),
+                tokens=[step.reshape(-1).tolist() for step in trajectory_tokens],
+                actions=[
+                    step.detach().cpu().float().reshape(-1).tolist()
+                    for step in trajectory_actions
+                ],
+            )
+        )
+    return results
+
+
+def _run_simplevla_stack(
+    args: argparse.Namespace,
+    specs: list[_TrajectorySpec],
+    policy,
+) -> list[_TrajectoryResult]:
+    _, RobHFRollout = _load_verl_rollout(args.simplevla_root)
+    rollout = RobHFRollout(policy.model, _simplevla_cfg(args))
+    results: list[_TrajectoryResult] = []
+    batch_size = int(args.simplevla_batch_size)
+    # SimpleVLA-RL calls LIBERO's ``get_task_init_states``, which still uses
+    # ``torch.load(path)``.  Torch>=2.6 defaults ``weights_only=True`` and
+    # rejects these trusted benchmark numpy arrays.  Use PyTorch's process-wide
+    # compatibility knob so SimpleVLA's worker process also sees it.
+    old_force_no_weights_only = os.environ.get("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD")
+    os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"
+    torch.load = _torch_load_trusted_init_state
+    try:
+        for start in range(0, len(specs), batch_size):
+            batch_specs = specs[start : start + batch_size]
+            batch_results = _run_simplevla_batch(
+                rollout,
+                batch_specs,
+                args.task_suite,
+                policy,
+                policy.action_tokenizer,
+            )
+            for result in batch_results:
+                torchrl_logger.info(
+                    "SimpleVLA rollout task=%s trial=%s success=%s env_steps=%s",
+                    result.task_id,
+                    result.trial_id,
+                    result.success,
+                    result.env_steps,
+                )
+            results.extend(batch_results)
+    finally:
+        torch.load = _ORIGINAL_TORCH_LOAD
+        if old_force_no_weights_only is None:
+            os.environ.pop("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", None)
+        else:
+            os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = old_force_no_weights_only
+    return results
+
+
+def _summary(
+    stack: Literal["torchrl", "simplevla"],
+    results: list[_TrajectoryResult],
+) -> _StackSummary:
+    successes = sum(int(result.success) for result in results)
+    trajectories = len(results)
+    return _StackSummary(
+        stack=stack,
+        trajectories=trajectories,
+        successes=successes,
+        success_rate=float(successes / trajectories) if trajectories else float("nan"),
+        env_steps=sum(result.env_steps for result in results),
+    )
+
+
+def _first_mismatch(
+    torchrl_values: list[int] | list[float] | None,
+    simplevla_values: list[int] | list[float] | None,
+    *,
+    atol: float = 0.0,
+) -> tuple[int, int | None]:
+    if torchrl_values is None or simplevla_values is None:
+        return 0, 0 if torchrl_values != simplevla_values else None
+    compare_count = min(len(torchrl_values), len(simplevla_values))
+    for index in range(compare_count):
+        if abs(float(torchrl_values[index]) - float(simplevla_values[index])) > atol:
+            return compare_count, index
+    if len(torchrl_values) != len(simplevla_values):
+        return compare_count, compare_count
+    return compare_count, None
+
+
+def _value_at(values: list[int] | None, index: int | None) -> int | None:
+    if values is None or index is None or index >= len(values):
+        return None
+    return int(values[index])
+
+
+def _max_abs_diff(
+    torchrl_values: list[float] | None,
+    simplevla_values: list[float] | None,
+) -> float | None:
+    if torchrl_values is None or simplevla_values is None:
+        return None
+    count = min(len(torchrl_values), len(simplevla_values))
+    if count == 0:
+        return None
+    torchrl_array = np.asarray(torchrl_values[:count], dtype=np.float64)
+    simplevla_array = np.asarray(simplevla_values[:count], dtype=np.float64)
+    return float(np.abs(torchrl_array - simplevla_array).max())
+
+
+def _parity_results(
+    torchrl_results: list[_TrajectoryResult],
+    simplevla_results: list[_TrajectoryResult],
+    *,
+    action_diff_atol: float,
+) -> list[_ParityResult]:
+    parity = []
+    for torchrl_result, simplevla_result in zip(
+        torchrl_results, simplevla_results, strict=True
+    ):
+        if (torchrl_result.task_id, torchrl_result.trial_id) != (
+            simplevla_result.task_id,
+            simplevla_result.trial_id,
+        ):
+            raise RuntimeError(
+                "TorchRL and SimpleVLA results are not aligned: "
+                f"{torchrl_result.task_id}/{torchrl_result.trial_id} vs "
+                f"{simplevla_result.task_id}/{simplevla_result.trial_id}."
+            )
+        token_count, token_mismatch = _first_mismatch(
+            torchrl_result.first_tokens,
+            simplevla_result.first_tokens,
+        )
+        action_count, action_mismatch = _first_mismatch(
+            torchrl_result.first_action,
+            simplevla_result.first_action,
+            atol=float(action_diff_atol),
+        )
+        first_token_exact_match = None
+        if (
+            torchrl_result.first_tokens is not None
+            and simplevla_result.first_tokens is not None
+        ):
+            first_token_exact_match = (
+                bool(torchrl_result.first_tokens)
+                and bool(simplevla_result.first_tokens)
+                and torchrl_result.first_tokens[0] == simplevla_result.first_tokens[0]
+            )
+        parity.append(
+            _ParityResult(
+                task_id=int(torchrl_result.task_id),
+                trial_id=int(torchrl_result.trial_id),
+                success_agreement=(
+                    bool(torchrl_result.success) == bool(simplevla_result.success)
+                ),
+                torchrl_success=bool(torchrl_result.success),
+                simplevla_success=bool(simplevla_result.success),
+                first_token_exact_match=first_token_exact_match,
+                first_tokens_exact_match=token_mismatch is None,
+                first_token_compare_count=int(token_count),
+                first_token_mismatch_index=token_mismatch,
+                torchrl_first_token_at_mismatch=_value_at(
+                    torchrl_result.first_tokens, token_mismatch
+                ),
+                simplevla_first_token_at_mismatch=_value_at(
+                    simplevla_result.first_tokens, token_mismatch
+                ),
+                first_action_compare_count=int(action_count),
+                first_action_max_abs_diff=_max_abs_diff(
+                    torchrl_result.first_action,
+                    simplevla_result.first_action,
+                ),
+                first_action_mismatch_index=action_mismatch,
+            )
+        )
+    return parity
+
+
+def _parity_summary(parity: list[_ParityResult]) -> _ParitySummary:
+    trajectories = len(parity)
+    success_agreements = sum(int(item.success_agreement) for item in parity)
+    first_token_exact_matches = sum(
+        int(bool(item.first_token_exact_match)) for item in parity
+    )
+    first_tokens_exact_matches = sum(
+        int(bool(item.first_tokens_exact_match)) for item in parity
+    )
+    first_action_diffs = [
+        item.first_action_max_abs_diff
+        for item in parity
+        if item.first_action_max_abs_diff is not None
+    ]
+    return _ParitySummary(
+        trajectories=trajectories,
+        success_agreements=success_agreements,
+        success_agreement_rate=(
+            float(success_agreements / trajectories) if trajectories else float("nan")
+        ),
+        first_token_exact_matches=first_token_exact_matches,
+        first_token_exact_match_rate=(
+            float(first_token_exact_matches / trajectories)
+            if trajectories
+            else float("nan")
+        ),
+        first_tokens_exact_matches=first_tokens_exact_matches,
+        first_tokens_exact_match_rate=(
+            float(first_tokens_exact_matches / trajectories)
+            if trajectories
+            else float("nan")
+        ),
+        first_action_max_abs_diff=(
+            float(max(first_action_diffs)) if first_action_diffs else None
+        ),
+    )
+
+
+def _first_mismatch_boundary(parity: list[_ParityResult]) -> dict[str, Any] | None:
+    for item in parity:
+        if item.first_token_mismatch_index is not None:
+            return {
+                "kind": "first_tokens",
+                "task_id": item.task_id,
+                "trial_id": item.trial_id,
+                "index": item.first_token_mismatch_index,
+                "torchrl": item.torchrl_first_token_at_mismatch,
+                "simplevla": item.simplevla_first_token_at_mismatch,
+            }
+        if item.first_action_mismatch_index is not None:
+            return {
+                "kind": "first_action",
+                "task_id": item.task_id,
+                "trial_id": item.trial_id,
+                "index": item.first_action_mismatch_index,
+                "max_abs_diff": item.first_action_max_abs_diff,
+            }
+        if not item.success_agreement:
+            return {
+                "kind": "success",
+                "task_id": item.task_id,
+                "trial_id": item.trial_id,
+                "torchrl": item.torchrl_success,
+                "simplevla": item.simplevla_success,
+            }
+    return None
+
+
+def _write_report(
+    args: argparse.Namespace,
+    specs: list[_TrajectorySpec],
+    torchrl_results: list[_TrajectoryResult],
+    simplevla_results: list[_TrajectoryResult],
+) -> Path:
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+    out_path = out_dir / f"simplevla_torchrl_rollout_compare_{stamp}.json"
+    simplevla_root = Path(args.simplevla_root) if args.simplevla_root else None
+    parity = _parity_results(
+        torchrl_results,
+        simplevla_results,
+        action_diff_atol=float(args.action_diff_atol),
+    )
+    report = {
+        "script": str(Path(__file__).resolve()),
+        "created_utc": datetime.now(UTC).isoformat(),
+        "args": vars(args),
+        "torch": torch.__version__,
+        "torchrl": getattr(__import__("torchrl"), "__version__", None),
+        "simplevla_root": str(simplevla_root) if simplevla_root is not None else None,
+        "simplevla_commit": (
+            _git_commit(simplevla_root) if simplevla_root is not None else None
+        ),
+        "specs": [asdict(spec) for spec in specs],
+        "summaries": {
+            "torchrl": asdict(_summary("torchrl", torchrl_results)),
+            "simplevla": asdict(_summary("simplevla", simplevla_results)),
+            "parity": asdict(_parity_summary(parity)),
+        },
+        "first_mismatch_boundary": _first_mismatch_boundary(parity),
+        "parity": [asdict(result) for result in parity],
+        "trajectories": {
+            "torchrl": [asdict(result) for result in torchrl_results],
+            "simplevla": [asdict(result) for result in simplevla_results],
+        },
+    }
+    out_path.write_text(json.dumps(_jsonable(report), indent=2), encoding="utf-8")
+    torchrl_logger.info("Wrote rollout comparison report to %s", out_path)
+    return out_path
+
+
+def main() -> None:
+    default_config = Path(__file__).parent / "config" / "vla_grpo_libero.yaml"
+    parser = argparse.ArgumentParser(
+        description="Compare TorchRL VLA and SimpleVLA-RL/VeRL LIBERO rollouts."
+    )
+    parser.add_argument("--config", default=str(default_config))
+    parser.add_argument("--simplevla-root", default=os.environ.get("SIMPLEVLA_RL_ROOT"))
+    parser.add_argument("--task-suite", default="libero_spatial")
+    parser.add_argument("--task-ids", type=_parse_int_list, default=[0])
+    parser.add_argument("--trial-ids", type=_parse_int_list, default=[0])
+    parser.add_argument(
+        "--checkpoint", default="Haozhan72/Openvla-oft-SFT-libero-spatial-traj1"
+    )
+    parser.add_argument(
+        "--dataset-statistics",
+        default="moojink/openvla-7b-oft-finetuned-libero-spatial",
+    )
+    parser.add_argument("--unnorm-key", default="libero_spatial_no_noops")
+    parser.add_argument("--policy-device", default="cuda:0")
+    parser.add_argument("--render-gpu", type=int, default=0)
+    parser.add_argument("--temperature", type=float, default=1.0)
+    parser.add_argument("--top-k", type=int, default=None)
+    parser.add_argument(
+        "--sample-actions",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Use sampled token actions in both TorchRL and SimpleVLA rollouts.",
+    )
+    parser.add_argument(
+        "--action-diff-atol",
+        type=float,
+        default=1e-6,
+        help="Tolerance for reporting the first decoded-action mismatch.",
+    )
+    parser.add_argument("--gripper-binarize-threshold", type=float, default=0.0)
+    parser.add_argument(
+        "--gripper-invert",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    parser.add_argument("--lora-rank", type=int, default=0)
+    parser.add_argument(
+        "--center-crop",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    parser.add_argument(
+        "--torchrl-image-backend",
+        choices=["torchvision", "pil", "tensorflow"],
+        default="torchvision",
+    )
+    parser.add_argument("--settle-steps", type=int, default=10)
+    parser.add_argument("--chunk-size", type=int, default=8)
+    parser.add_argument("--max-env-steps", type=int, default=512)
+    parser.add_argument("--max-outer-steps", type=int, default=64)
+    parser.add_argument("--max-prompt-length", type=int, default=512)
+    parser.add_argument("--simplevla-batch-size", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--out-dir", default="/tmp")
+    parser.add_argument("--experiment-name", default="simplevla_torchrl_compare")
+    args = parser.parse_args()
+
+    if args.simplevla_root is None:
+        raise ValueError(
+            "Pass --simplevla-root or set SIMPLEVLA_RL_ROOT to the "
+            "SimpleVLA-RL checkout."
+        )
+    _set_seed(int(args.seed))
+    specs = _trajectory_specs(args.task_ids, args.trial_ids)
+    _, policy, tokenizer = _policy_and_tokenizer(args)
+    try:
+        _set_seed(int(args.seed))
+        torchrl_results = _run_torchrl_stack(args, specs, policy, tokenizer)
+        _set_seed(int(args.seed))
+        simplevla_results = _run_simplevla_stack(args, specs, policy)
+    finally:
+        del policy
+        torch.cuda.empty_cache()
+    report = _write_report(args, specs, torchrl_results, simplevla_results)
+    parity = _parity_results(
+        torchrl_results,
+        simplevla_results,
+        action_diff_atol=float(args.action_diff_atol),
+    )
+    summaries = {
+        "torchrl": asdict(_summary("torchrl", torchrl_results)),
+        "simplevla": asdict(_summary("simplevla", simplevla_results)),
+        "parity": asdict(_parity_summary(parity)),
+        "first_mismatch_boundary": _first_mismatch_boundary(parity),
+        "report": str(report),
+    }
+    sys.stdout.write(json.dumps(_jsonable(summaries), indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/sota-implementations/vla_grpo/openvla.py
+++ b/sota-implementations/vla_grpo/openvla.py
@@ -10,6 +10,11 @@ The token wrapper covers the vendored SimpleVLA-RL token-OFT model (see
 autoregressive loop), sampled from the 256-way categorical over the
 action-token window at the tail of the LLaMA-2 vocabulary.
 
+The module also provides a separate continuous L1-head wrapper for the official
+OpenVLA-OFT checkpoint family. That path is deterministic and intended for
+reference/evaluation rollouts; the token GRPO training semantics stay
+unchanged.
+
 The wrappers own ALL model-side preprocessing (prompt construction, image
 transforms) and, for token heads, the temperature scaling. Both rollout and
 loss-time recomputation go through the same :meth:`get_dist`, so with
@@ -73,6 +78,73 @@ _JPEG_QUALITY = 95
 _OPENVLA_INPUT_IDS_KEY = ("openvla", "input_ids")
 _OPENVLA_ATTENTION_MASK_KEY = ("openvla", "attention_mask")
 _OPENVLA_PIXEL_VALUES_KEY = ("openvla", "pixel_values")
+
+
+class _MLPResNetBlock(nn.Module):
+    """Residual MLP block used by the OpenVLA-OFT L1 action head."""
+
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.ffn = nn.Sequential(nn.LayerNorm(dim), nn.Linear(dim, dim), nn.ReLU())
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.ffn(x) + x
+
+
+class _MLPResNet(nn.Module):
+    """Small residual MLP used by the OpenVLA-OFT L1 action head."""
+
+    def __init__(
+        self,
+        *,
+        num_blocks: int,
+        input_dim: int,
+        hidden_dim: int,
+        output_dim: int,
+    ) -> None:
+        super().__init__()
+        self.layer_norm1 = nn.LayerNorm(input_dim)
+        self.fc1 = nn.Linear(input_dim, hidden_dim)
+        self.relu = nn.ReLU()
+        self.mlp_resnet_blocks = nn.ModuleList(
+            [_MLPResNetBlock(hidden_dim) for _ in range(num_blocks)]
+        )
+        self.layer_norm2 = nn.LayerNorm(hidden_dim)
+        self.fc2 = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.relu(self.fc1(self.layer_norm1(x)))
+        for block in self.mlp_resnet_blocks:
+            x = block(x)
+        return self.fc2(self.layer_norm2(x))
+
+
+class _L1RegressionActionHead(nn.Module):
+    """Continuous OpenVLA-OFT L1 action head."""
+
+    def __init__(
+        self,
+        *,
+        input_dim: int = 4096,
+        hidden_dim: int = 4096,
+        action_dim: int = 7,
+    ) -> None:
+        super().__init__()
+        from openvla_oft.constants import ACTION_DIM, NUM_ACTIONS_CHUNK
+
+        self.action_dim = int(action_dim)
+        self.chunk_size = int(NUM_ACTIONS_CHUNK)
+        self.model = _MLPResNet(
+            num_blocks=2,
+            input_dim=input_dim * ACTION_DIM,
+            hidden_dim=hidden_dim,
+            output_dim=action_dim,
+        )
+
+    def predict_action(self, actions_hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size = actions_hidden_states.shape[0]
+        rearranged = actions_hidden_states.reshape(batch_size, self.chunk_size, -1)
+        return self.model(rearranged)
 
 
 def _hf_hub_download_fn():
@@ -1001,6 +1073,284 @@ class OpenVLAOFTWrapper(VLAWrapperBase):
         if hasattr(action, "chunk"):
             action.chunk = chunk
         return out
+
+
+class OpenVLAOFTL1Wrapper(OpenVLAOFTWrapper):
+    """Continuous L1-head OpenVLA-OFT policy for reference/evaluation rollouts.
+
+    This wrapper targets the official OpenVLA-OFT LIBERO checkpoints that use
+    two camera images and an 8-D proprio vector. It reads the canonical TorchRL
+    LIBERO observation, converts the default 9-D quaternion state to the
+    OpenVLA 8-D axis-angle state when needed, normalizes proprio using the
+    checkpoint statistics, and writes a continuous ``("vla_action", "chunk")``.
+    """
+
+    def __init__(
+        self,
+        model,
+        processor,
+        action_head: nn.Module,
+        proprio_projector: nn.Module | None,
+        *,
+        unnorm_key: str | None = None,
+        default_interaction_type: InteractionType = InteractionType.DETERMINISTIC,
+        use_proprio: bool = True,
+        use_wrist_image: bool = True,
+        center_crop: bool = True,
+        image_backend: Literal["torchvision", "pil", "tensorflow"] = "torchvision",
+        gripper_binarize: bool = True,
+        gripper_binarize_threshold: float = 0.0,
+        gripper_invert: bool = True,
+        return_vla_action_container: bool = True,
+    ) -> None:
+        from openvla_oft.constants import ACTION_DIM, NUM_ACTIONS_CHUNK
+
+        if unnorm_key is None and model.norm_stats is not None:
+            if len(model.norm_stats) != 1:
+                raise ValueError(
+                    "the checkpoint carries statistics for several datasets; "
+                    f"pass unnorm_key explicitly (options: {sorted(model.norm_stats)})."
+                )
+            unnorm_key = next(iter(model.norm_stats))
+        if model.norm_stats is not None and unnorm_key not in model.norm_stats:
+            no_noops_key = f"{unnorm_key}_no_noops"
+            if no_noops_key in model.norm_stats:
+                unnorm_key = no_noops_key
+        VLAWrapperBase.__init__(
+            self,
+            action_dim=ACTION_DIM,
+            chunk_size=NUM_ACTIONS_CHUNK,
+            action_head="continuous",
+            use_state=use_proprio,
+            default_interaction_type=default_interaction_type,
+            return_vla_action_container=return_vla_action_container,
+        )
+        self.model = model
+        self.processor = processor
+        self.action_head_module = action_head
+        self.proprio_projector = proprio_projector
+        self.unnorm_key = unnorm_key
+        self.use_proprio = bool(use_proprio)
+        self.use_wrist_image = bool(use_wrist_image)
+        self.center_crop = bool(center_crop)
+        self.image_backend = image_backend
+        self.gripper_binarize = bool(gripper_binarize)
+        self.gripper_binarize_threshold = float(gripper_binarize_threshold)
+        self.gripper_invert = bool(gripper_invert)
+        device = next(model.parameters()).device
+        dtype = next(model.parameters()).dtype
+        self.input_transform = OpenVLAInputTransform(
+            processor,
+            use_wrist_image=use_wrist_image,
+            center_crop=center_crop,
+            image_backend=image_backend,
+            image_key=self.tensor_keys.image,
+            wrist_image_key=self.tensor_keys.wrist_image,
+            instruction_key=self.tensor_keys.instruction,
+            device=device,
+            dtype=dtype,
+        )
+        self.gripper_postprocess = GripperPostProcessTransform(
+            action_key=self.tensor_keys.action_chunk,
+            rescale=True,
+            binarize=gripper_binarize,
+            threshold=gripper_binarize_threshold,
+            invert=gripper_invert,
+        )
+        self._prompt_cache = self.input_transform._prompt_cache
+        self._image_preprocessor = self.input_transform._image_preprocessor
+        self.image_backend = self.input_transform.image_backend
+        if self.use_wrist_image:
+            self.in_keys = [*self.in_keys, ("observation", "wrist_image")]
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *,
+        torch_dtype: torch.dtype = torch.bfloat16,
+        device: torch.device | str | None = None,
+        dataset_statistics: str | None = None,
+        action_head_file: str = "action_head--150000_checkpoint.pt",
+        proprio_projector_file: str = "proprio_projector--150000_checkpoint.pt",
+        use_proprio: bool = True,
+        num_images_in_input: int = 2,
+        **kwargs,
+    ) -> OpenVLAOFTL1Wrapper:
+        """Load an official continuous-head OpenVLA-OFT checkpoint."""
+        from openvla_oft.constants import ACTION_DIM
+        from openvla_oft.modeling_prismatic import (
+            OpenVLAForActionPrediction,
+            ProprioProjector,
+        )
+        from openvla_oft.processing_prismatic import PrismaticProcessor
+        from openvla_oft.train_utils import load_component_state_dict
+        from transformers import AutoConfig
+
+        register_openvla_oft()
+        config = AutoConfig.from_pretrained(
+            pretrained_model_name_or_path, trust_remote_code=False
+        )
+        config.use_proprio = False
+        config.proprio_dim = 8
+        model = OpenVLAForActionPrediction.from_pretrained(
+            pretrained_model_name_or_path,
+            config=config,
+            torch_dtype=torch_dtype,
+            low_cpu_mem_usage=True,
+            trust_remote_code=False,
+            attn_implementation="eager",
+        )
+        model.vision_backbone.set_num_images_in_input(int(num_images_in_input))
+        if dataset_statistics is not None:
+            model.norm_stats = _load_dataset_statistics(dataset_statistics)
+        if device is not None:
+            model = model.to(device)
+        model.eval()
+        processor = PrismaticProcessor.from_pretrained(
+            pretrained_model_name_or_path, trust_remote_code=False
+        )
+        device = next(model.parameters()).device
+        dtype = next(model.parameters()).dtype
+        action_head = _L1RegressionActionHead(
+            input_dim=model.llm_dim,
+            hidden_dim=model.llm_dim,
+            action_dim=ACTION_DIM,
+        ).to(device=device, dtype=dtype)
+        action_head.load_state_dict(
+            load_component_state_dict(
+                _resolve_component_checkpoint(
+                    pretrained_model_name_or_path,
+                    action_head_file,
+                    "action_head",
+                )
+            )
+        )
+        action_head.eval()
+        proprio_projector = None
+        if use_proprio:
+            proprio_projector = ProprioProjector(
+                llm_dim=model.llm_dim, proprio_dim=8
+            ).to(device=device, dtype=dtype)
+            proprio_projector.load_state_dict(
+                load_component_state_dict(
+                    _resolve_component_checkpoint(
+                        pretrained_model_name_or_path,
+                        proprio_projector_file,
+                        "proprio_projector",
+                    )
+                )
+            )
+            proprio_projector.eval()
+        return cls(
+            model,
+            processor,
+            action_head,
+            proprio_projector,
+            use_proprio=use_proprio,
+            **kwargs,
+        )
+
+    def _openvla_state(self, state: torch.Tensor) -> torch.Tensor:
+        if state.shape[-1] == 8:
+            return state
+        if state.shape[-1] != 9:
+            raise ValueError(
+                "OpenVLA L1 proprio expects an 8-D axis-angle state or the "
+                f"default 9-D LIBERO quaternion state, got shape {state.shape}."
+            )
+        position = state[..., :3]
+        quat = state[..., 3:7]
+        gripper = state[..., 7:]
+        xyz = quat[..., :3]
+        w = quat[..., 3].clamp(-1.0, 1.0)
+        den = (1.0 - w.square()).clamp_min(0.0).sqrt()
+        angle = 2.0 * torch.acos(w)
+        axis_angle = torch.where(
+            den.unsqueeze(-1) > 1e-6,
+            xyz * angle.unsqueeze(-1) / den.clamp_min(1e-6).unsqueeze(-1),
+            torch.zeros_like(xyz),
+        )
+        return torch.cat((position, axis_angle, gripper), dim=-1)
+
+    def _normalize_proprio(self, state: torch.Tensor) -> np.ndarray:
+        if not self.use_proprio:
+            raise RuntimeError("OpenVLA L1 proprio normalization requires state input.")
+        stats = self.model.norm_stats[self.unnorm_key]["proprio"]
+        if "q01" in stats:
+            low = torch.as_tensor(stats["q01"], dtype=state.dtype, device=state.device)
+            high = torch.as_tensor(stats["q99"], dtype=state.dtype, device=state.device)
+        else:
+            low = torch.as_tensor(stats["min"], dtype=state.dtype, device=state.device)
+            high = torch.as_tensor(stats["max"], dtype=state.dtype, device=state.device)
+        mask = torch.as_tensor(
+            stats.get("mask", np.ones(low.shape, dtype=bool)),
+            dtype=torch.bool,
+            device=state.device,
+        )
+        normalized = 2.0 * (state - low) / (high - low).clamp_min(1e-8) - 1.0
+        normalized = torch.where(mask, normalized, state)
+        return normalized.clamp(-1.0, 1.0).detach().cpu().numpy().astype(np.float32)
+
+    def _sort_padding_for_predict_action(self, input_ids, attention_mask):
+        pad_token_id = self.processor.tokenizer.pad_token_id
+        padding_mask = (~input_ids.ne(pad_token_id)).int()
+        sorted_indices = torch.argsort(
+            padding_mask, dim=1, descending=True, stable=True
+        )
+        return (
+            torch.gather(input_ids, 1, sorted_indices),
+            torch.gather(attention_mask, 1, sorted_indices),
+        )
+
+    def _postprocess_actions(self, actions: torch.Tensor) -> torch.Tensor:
+        return self.gripper_postprocess.postprocess(actions)
+
+    def _predict_chunk(self, tensordict: TensorDictBase) -> torch.Tensor:
+        images = tensordict.get(self.tensor_keys.image)
+        batch_dims = images.shape[:-3]
+        images = images.reshape(-1, *images.shape[-3:])
+        wrist_images = None
+        if self.use_wrist_image:
+            wrist_images = tensordict.get(("observation", "wrist_image"))
+            wrist_images = wrist_images.reshape(-1, *wrist_images.shape[-3:])
+        instructions = self._instructions(tensordict, images.shape[0])
+        input_ids, attention_mask, pixel_values = self._preprocess(
+            images, wrist_images, instructions
+        )
+        input_ids, attention_mask = self._sort_padding_for_predict_action(
+            input_ids, attention_mask
+        )
+        proprio = None
+        if self.use_proprio:
+            state = self._get_state(tensordict).reshape(images.shape[0], -1).float()
+            proprio = self._normalize_proprio(self._openvla_state(state))
+        chunks = []
+        for index in range(images.shape[0]):
+            row_proprio = None if proprio is None else proprio[index : index + 1]
+            with torch.no_grad():
+                actions, _ = self.model.predict_action(
+                    input_ids=input_ids[index : index + 1],
+                    pixel_values=pixel_values[index : index + 1],
+                    attention_mask=attention_mask[index : index + 1],
+                    unnorm_key=self.unnorm_key,
+                    proprio=row_proprio,
+                    proprio_projector=self.proprio_projector,
+                    action_head=self.action_head_module,
+                    noisy_action_projector=None,
+                    use_film=False,
+                )
+            actions = np.asarray(actions, dtype=np.float32)
+            if actions.ndim == 3 and actions.shape[0] == 1:
+                actions = actions[0]
+            chunks.append(torch.as_tensor(actions, device=images.device))
+        chunk = torch.stack(chunks, dim=0).reshape(
+            *batch_dims, self.chunk_size, self.action_dim
+        )
+        return self._postprocess_actions(chunk)
+
+    def _predict(self, tensordict: TensorDictBase) -> torch.Tensor:
+        return self._predict_chunk(tensordict).flatten(-2)
 
 
 def _resolve_component_checkpoint(

--- a/sota-implementations/vla_grpo/test_openvla.py
+++ b/sota-implementations/vla_grpo/test_openvla.py
@@ -45,6 +45,7 @@ _has_deps = all(
 if _has_deps:
     from openvla import (
         GripperPostProcessTransform,
+        OpenVLAOFTL1Wrapper,
         OpenVLAOFTWrapper,
     )
     from openvla_oft.modeling_prismatic import OpenVLAForActionPrediction
@@ -281,6 +282,44 @@ if _has_deps:
 
         def get_input_embeddings(self):
             return self.embed
+
+    class _TinyL1OFT(nn.Module):
+        """Tiny deterministic stand-in for the continuous OpenVLA-OFT head."""
+
+        def __init__(self):
+            super().__init__()
+            self.param = nn.Parameter(torch.zeros(()))
+            self.norm_stats = {
+                "libero_spatial_no_noops": {
+                    "proprio": {
+                        "q01": [-1.0] * 8,
+                        "q99": [1.0] * 8,
+                        "mask": [True] * 8,
+                    }
+                }
+            }
+            self.proprios = []
+            self.pixel_shapes = []
+
+        def predict_action(
+            self,
+            *,
+            input_ids,
+            pixel_values,
+            attention_mask,
+            unnorm_key,
+            proprio,
+            proprio_projector,
+            action_head,
+            noisy_action_projector,
+            use_film,
+        ):
+            self.pixel_shapes.append(tuple(pixel_values.shape))
+            self.proprios.append(None if proprio is None else proprio.copy())
+            action = np.zeros((CHUNK, ACT_DIM), dtype=np.float32)
+            action[:, :-1] = 0.25
+            action[:, -1] = 1.0
+            return action, None
 
 
 class _FakeProcessor:
@@ -689,7 +728,15 @@ class TestReplayBufferFactory:
 
 
 class TestTokenizerAndTransforms:
-
+    def test_make_action_tokenizer_returns_none_for_l1_openvla(self):
+        cfg = SimpleNamespace(
+            policy=SimpleNamespace(backend="openvla", mode="l1"),
+            tokenizer=SimpleNamespace(vocab_size=16),
+        )
+        assert (
+            utils.make_action_tokenizer(cfg, SimpleNamespace(action_tokenizer=None))
+            is None
+        )
 
     def test_chunk_transform_without_tokenizer_consumes_vla_chunk(self):
         cfg = SimpleNamespace(env=SimpleNamespace(max_outer_steps=1))
@@ -1012,6 +1059,39 @@ class TestOpenVLAOFTWrapper:
         assert (actions[..., -1].abs() <= 1.0 + 1e-5).all()
         # decode -> encode is the identity on emitted tokens
         torch.testing.assert_close(tokenizer.encode(actions), out[ACTION_TOKENS_KEY])
+
+    def test_l1_forward_uses_wrist_image_and_quaternion_proprio(self):
+        model = _TinyL1OFT()
+        policy = OpenVLAOFTL1Wrapper(
+            model,
+            _BatchProcessor(),
+            nn.Identity(),
+            nn.Identity(),
+            use_proprio=True,
+            use_wrist_image=True,
+            center_crop=False,
+            image_backend="pil",
+        )
+        obs = _make_obs(batch=2)
+        obs["observation", "wrist_image"] = torch.randint(
+            0, 256, (2, 3, 32, 32), dtype=torch.uint8
+        )
+        state = torch.zeros(2, 9)
+        state[:, 6] = 1.0  # identity quaternion in xyzw convention
+        obs["observation", "state"] = state
+
+        out = policy(obs)
+
+        assert out[ACTION_CHUNK_KEY].shape == (2, CHUNK, ACT_DIM)
+        assert model.pixel_shapes == [(1, 6, 224, 224), (1, 6, 224, 224)]
+        assert len(model.proprios) == 2
+        for proprio in model.proprios:
+            assert proprio.shape == (1, 8)
+            np.testing.assert_allclose(proprio[0, 3:6], np.zeros(3))
+        torch.testing.assert_close(
+            out[ACTION_CHUNK_KEY][..., -1],
+            -torch.ones(2, CHUNK),
+        )
 
     @pytest.mark.parametrize("ratio_level", ["sequence", "token"])
     def test_clip_ppo_loss_integration(self, ratio_level):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #3942
* #3940
* #3941
* #3897
* #3896
* #3895
* #3894
* #3893
* #3939

OpenVLAOFTL1Wrapper serves the official continuous L1-head OpenVLA-OFT
checkpoints (released action head + proprio projector, wrist image, 8-D
proprio) for deterministic reference and evaluation rollouts; token GRPO
training semantics are unchanged and the PPO loss still requires token
log-probabilities.

compare_simplevla_rollouts.py rolls the same (task, init-state) trajectories
through the TorchRL stack and the SimpleVLA-RL/VeRL reference and writes a
JSON parity report of per-trajectory token/action/success agreement.

The mode-selection plumbing (policy.mode=l1) ships in the commit below; on
its own that mode fails with an ImportError until this commit is applied.