### PR TITLE
[LLM] WS4 Post-Training Observability: Implement PostTrainingLogger

### DIFF
--- a/docs/source/reference/llms.rst
+++ b/docs/source/reference/llms.rst
@@ -564,3 +564,16 @@ Distillation
     :template: rl_template.rst
 
     TopKRewardSelector
+
+Loggers
+-------
+
+Standardized logging utilities for LLM post-training loops.
+
+.. currentmodule:: torchrl.record.loggers
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template.rst
+
+    PostTrainingLogger

--- a/docs/source/reference/llms_loggers.rst
+++ b/docs/source/reference/llms_loggers.rst
@@ -1,0 +1,14 @@
+:orphan:
+
+.. currentmodule:: torchrl.record.loggers
+
+Post-Training Loggers
+=====================
+
+Standardized logging utilities for LLM post-training loops.
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template.rst
+
+    PostTrainingLogger

--- a/docs/source/reference/trainers_loggers.rst
+++ b/docs/source/reference/trainers_loggers.rst
@@ -91,3 +91,14 @@ Recording utils
     VideoRecorder
     TensorDictRecorder
     PixelRenderTransform
+
+Post-Training Loggers
+---------------------
+
+.. currentmodule:: torchrl.record.loggers
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template_fun.rst
+
+    PostTrainingLogger

--- a/sota-implementations/expert-iteration/ei_utils.py
+++ b/sota-implementations/expert-iteration/ei_utils.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import time
+import warnings
 from typing import Any, Literal
 
 import torch
@@ -19,6 +20,7 @@ from torchrl.envs.llm.datasets.countdown import CountdownEnv
 from torchrl.envs.llm.datasets.ifeval import IFEvalEnv
 from torchrl.envs.llm.datasets.math import MATHEnv
 from torchrl.modules.llm import TransformersWrapper, vLLMWrapper
+from torchrl.record.loggers.llm import PostTrainingLogger
 from torchrl.weight_update.llm import VLLMWeightSyncScheme
 from transformers.models.auto.modeling_auto import AutoModelForCausalLM
 from transformers.tokenization_utils import PreTrainedTokenizer
@@ -651,30 +653,75 @@ def log_training_metrics(
 ):
     """Log training metrics to wandb.
 
-    Args:
-        wandb_logger: The wandb logger instance
-        replay_buffer: The replay buffer containing collected data
-        batch: The current training batch
-        loss: The computed loss object
-        grad_norm: The gradient norm value
-        global_step: Current global training step
-        data_read_count: Total data read count
-        collector: The collector instance
-        start_time: Training start time
-        gradient_accumulation_steps: Number of gradient accumulation steps
-        history_str: Optional history string for logging
-    """
-    with torch.no_grad():
-        rb_content = replay_buffer[:]
-        batch_policy_version = batch["next", "policy_version"].view(-1).min()
-        batch_policy_age = collector.policy_version - batch_policy_version
+    Delegates standard metrics to :class:`~torchrl.record.loggers.PostTrainingLogger`.
 
-        metrics = {
-            "reward from buffer": float(
+    .. deprecated::
+        The legacy flat metric keys (``"reward from buffer"``,
+        ``"loss_sft, from loss"``, etc.) are deprecated and will be removed
+        in v0.15.0.  The new ``namespace/metric`` keys are already being
+        emitted in parallel — update any dashboards to use those.
+
+    Args:
+        wandb_logger: The wandb logger instance.
+        replay_buffer: The replay buffer containing collected data.
+        batch: The current training batch.
+        loss: The computed loss object.
+        grad_norm: The gradient norm value.
+        global_step: Current global training step.
+        data_read_count: Total data read count.
+        collector: The collector instance.
+        start_time: Training start time (``time.time()`` at loop start).
+        gradient_accumulation_steps: Number of gradient accumulation steps.
+        history_str: Optional history string for logging.
+    """
+    pt_logger = PostTrainingLogger(logger=wandb_logger, start_time=start_time)
+
+    pt_logger.log_training_step(
+        loss=loss,
+        step=global_step,
+        grad_norm=grad_norm,
+        gradient_accumulation_steps=gradient_accumulation_steps,
+    )
+    pt_logger.log_collection_step(
+        batch=batch,
+        replay_buffer=replay_buffer,
+        collector=collector,
+        step=global_step,
+    )
+
+    # Legacy flat keys emitted in parallel until v0.15.0 (see CLAUDE.md §12).
+    # Each key here maps to the new namespace/metric equivalent listed in the
+    # deprecation warning string below.
+    _LEGACY_KEY_MAP = {
+        "reward from buffer": "buffer/reward_mean",
+        "loss_sft, from loss": "training/loss_sft",
+        "loss_kl_to_ref, from loss": "training/loss_kl_to_ref",
+        "kl_to_ref, from loss": "training/kl_to_ref",
+        "grad_norm": "training/grad_norm",
+        "write_count, from buffer": "buffer/write_count",
+        "gradient_step_throughput (gradient step per write)": "throughput/gradient_steps_per_write",
+        "optim_step_throughput (optim step per write)": "throughput/optim_steps_per_write",
+        "data_read_count (total)": "buffer/data_read_count",
+        "current_policy_version (collector)": "inference/policy_version",
+        "throughput (steps per second)": "throughput/gradient_steps_per_second",
+    }
+    for old_key, new_key in _LEGACY_KEY_MAP.items():
+        warnings.warn(
+            f'EI metric key "{old_key}" is deprecated and will be removed in v0.15.0. '
+            f'Use "{new_key}" instead.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    with torch.no_grad():
+        optim_steps = global_step // gradient_accumulation_steps
+        legacy_metrics: dict[str, Any] = {}
+        try:
+            rb_content = replay_buffer[:]
+            legacy_metrics["reward from buffer"] = float(
                 torch.cat(rb_content.get(("next", "reward"), as_list=True)).mean()
-            ),
-            "reward from batch": float(batch["next", "reward"].mean()),
-            "seq_length from buffer": float(
+            )
+            legacy_metrics["seq_length from buffer"] = float(
                 torch.tensor(
                     [
                         t.numel()
@@ -682,38 +729,44 @@ def log_training_metrics(
                     ],
                     dtype=torch.float,
                 ).mean()
-            ),
-            "loss_sft, from loss": float(loss.loss_sft),
-            "loss_kl_to_ref, from loss": float(loss.loss_kl_to_ref),
-            "kl_to_ref, from loss": float(loss.kl_to_ref),
-            "grad_norm": float(grad_norm)
-            if global_step % gradient_accumulation_steps == 0
-            else 0.0,
-            "write_count, from buffer": int(replay_buffer.write_count),
-            # how many gradient steps per write
-            "gradient_step_throughput (gradient step per write)": float(
-                global_step / replay_buffer.write_count
-            ),
-            # how many optim steps per write
-            "optim_step_throughput (optim step per write)": float(
-                (global_step // gradient_accumulation_steps) / replay_buffer.write_count
-            ),
-            "data_read_count (total)": data_read_count,
-            "current_policy_version (collector)": collector.policy_version,
-            # FIXME: Assume batch is a single trajectory
-            # FIXME: The addition of the transform after the env instantiation + _shuttle creation
-            #  is messed up - we need the next data
-            "batch_policy_version (sampled batch)": batch_policy_version,
-            "batch_policy_age (sampled batch)": batch_policy_age,
-            "throughput (steps per second)": float(
-                global_step / (time.time() - start_time)
-            ),
-        }
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        legacy_metrics["reward from batch"] = float(batch["next", "reward"].mean())
+        legacy_metrics["loss_sft, from loss"] = float(loss.loss_sft)
+        kl_to_ref = getattr(loss, "loss_kl_to_ref", None)
+        if kl_to_ref is not None:
+            legacy_metrics["loss_kl_to_ref, from loss"] = float(kl_to_ref)
+        kl_val = getattr(loss, "kl_to_ref", None)
+        if kl_val is not None:
+            legacy_metrics["kl_to_ref, from loss"] = float(kl_val)
+        legacy_metrics["grad_norm"] = (
+            float(grad_norm) if global_step % gradient_accumulation_steps == 0 else 0.0
+        )
+        legacy_metrics["write_count, from buffer"] = int(replay_buffer.write_count)
+        if replay_buffer.write_count > 0:
+            legacy_metrics[
+                "gradient_step_throughput (gradient step per write)"
+            ] = float(global_step / replay_buffer.write_count)
+            legacy_metrics["optim_step_throughput (optim step per write)"] = float(
+                optim_steps / replay_buffer.write_count
+            )
+        legacy_metrics["data_read_count (total)"] = data_read_count
+        legacy_metrics["current_policy_version (collector)"] = collector.policy_version
+        batch_policy_version = batch["next", "policy_version"].view(-1).min()
+        legacy_metrics["batch_policy_version (sampled batch)"] = batch_policy_version
+        legacy_metrics["batch_policy_age (sampled batch)"] = (
+            collector.policy_version - batch_policy_version
+        )
+        elapsed = time.time() - start_time
+        if elapsed > 0:
+            legacy_metrics["throughput (steps per second)"] = float(
+                global_step / elapsed
+            )
+        wandb_logger.log_metrics(legacy_metrics, step=global_step)
 
-        wandb_logger.log_metrics(metrics, step=global_step)
-
-        if history_str is not None:
-            wandb_logger.log_str("history", history_str, step=global_step)
+    if history_str is not None:
+        wandb_logger.log_str("history", history_str, step=global_step)
 
 
 class RemoteDataLogger:

--- a/sota-implementations/expert-iteration/ei_utils.py
+++ b/sota-implementations/expert-iteration/ei_utils.py
@@ -25,6 +25,10 @@ from torchrl.weight_update.llm import VLLMWeightSyncScheme
 from transformers.models.auto.modeling_auto import AutoModelForCausalLM
 from transformers.tokenization_utils import PreTrainedTokenizer
 
+# Tracks which legacy EI metric keys have already fired a DeprecationWarning
+# so that long training runs don't spam the user with repeat warnings.
+_EI_WARNED: set[str] = set()
+
 try:
     import ray
 except ImportError:
@@ -706,12 +710,14 @@ def log_training_metrics(
         "throughput (steps per second)": "throughput/gradient_steps_per_second",
     }
     for old_key, new_key in _LEGACY_KEY_MAP.items():
-        warnings.warn(
-            f'EI metric key "{old_key}" is deprecated and will be removed in v0.15.0. '
-            f'Use "{new_key}" instead.',
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        if old_key not in _EI_WARNED:
+            warnings.warn(
+                f'EI metric key "{old_key}" is deprecated and will be removed in v0.15.0. '
+                f'Use "{new_key}" instead.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            _EI_WARNED.add(old_key)
 
     with torch.no_grad():
         optim_steps = global_step // gradient_accumulation_steps
@@ -732,14 +738,19 @@ def log_training_metrics(
             )
         except Exception:  # noqa: BLE001
             pass
-        legacy_metrics["reward from batch"] = float(batch["next", "reward"].mean())
-        legacy_metrics["loss_sft, from loss"] = float(loss.loss_sft)
-        kl_to_ref = getattr(loss, "loss_kl_to_ref", None)
-        if kl_to_ref is not None:
-            legacy_metrics["loss_kl_to_ref, from loss"] = float(kl_to_ref)
-        kl_val = getattr(loss, "kl_to_ref", None)
-        if kl_val is not None:
-            legacy_metrics["kl_to_ref, from loss"] = float(kl_val)
+        try:
+            legacy_metrics["reward from batch"] = float(
+                batch["next", "reward"].mean()
+            )
+            legacy_metrics["loss_sft, from loss"] = float(loss.loss_sft)
+            kl_to_ref = getattr(loss, "loss_kl_to_ref", None)
+            if kl_to_ref is not None:
+                legacy_metrics["loss_kl_to_ref, from loss"] = float(kl_to_ref)
+            kl_val = getattr(loss, "kl_to_ref", None)
+            if kl_val is not None:
+                legacy_metrics["kl_to_ref, from loss"] = float(kl_val)
+        except Exception:  # noqa: BLE001
+            pass
         legacy_metrics["grad_norm"] = (
             float(grad_norm) if global_step % gradient_accumulation_steps == 0 else 0.0
         )

--- a/sota-implementations/expert-iteration/ei_utils.py
+++ b/sota-implementations/expert-iteration/ei_utils.py
@@ -20,7 +20,6 @@ from torchrl.envs.llm.datasets.countdown import CountdownEnv
 from torchrl.envs.llm.datasets.ifeval import IFEvalEnv
 from torchrl.envs.llm.datasets.math import MATHEnv
 from torchrl.modules.llm import TransformersWrapper, vLLMWrapper
-from torchrl.record.loggers.llm import PostTrainingLogger
 from torchrl.weight_update.llm import VLLMWeightSyncScheme
 from transformers.models.auto.modeling_auto import AutoModelForCausalLM
 from transformers.tokenization_utils import PreTrainedTokenizer
@@ -644,6 +643,7 @@ def get_wandb_run_id(wandb_logger):
 
 def log_training_metrics(
     wandb_logger,
+    post_training_logger,
     replay_buffer,
     batch,
     loss,
@@ -667,6 +667,7 @@ def log_training_metrics(
 
     Args:
         wandb_logger: The wandb logger instance.
+        post_training_logger: Persistent post-training logger for this run.
         replay_buffer: The replay buffer containing collected data.
         batch: The current training batch.
         loss: The computed loss object.
@@ -678,15 +679,13 @@ def log_training_metrics(
         gradient_accumulation_steps: Number of gradient accumulation steps.
         history_str: Optional history string for logging.
     """
-    pt_logger = PostTrainingLogger(logger=wandb_logger, start_time=start_time)
-
-    pt_logger.log_training_step(
+    post_training_logger.log_training_step(
         loss=loss,
         step=global_step,
         grad_norm=grad_norm,
         gradient_accumulation_steps=gradient_accumulation_steps,
     )
-    pt_logger.log_collection_step(
+    post_training_logger.log_collection_step(
         batch=batch,
         replay_buffer=replay_buffer,
         collector=collector,

--- a/sota-implementations/expert-iteration/ei_utils.py
+++ b/sota-implementations/expert-iteration/ei_utils.py
@@ -25,7 +25,7 @@ from torchrl.weight_update.llm import VLLMWeightSyncScheme
 from transformers.models.auto.modeling_auto import AutoModelForCausalLM
 from transformers.tokenization_utils import PreTrainedTokenizer
 
-# Tracks which legacy EI metric keys have already fired a DeprecationWarning
+# Tracks which legacy EI metric keys have already fired a FutureWarning
 # so that long training runs don't spam the user with repeat warnings.
 _EI_WARNED: set[str] = set()
 
@@ -662,7 +662,7 @@ def log_training_metrics(
     .. deprecated::
         The legacy flat metric keys (``"reward from buffer"``,
         ``"loss_sft, from loss"``, etc.) are deprecated and will be removed
-        in v0.15.0.  The new ``namespace/metric`` keys are already being
+        in v0.16.0.  The new ``namespace/metric`` keys are already being
         emitted in parallel — update any dashboards to use those.
 
     Args:
@@ -693,7 +693,7 @@ def log_training_metrics(
         step=global_step,
     )
 
-    # Legacy flat keys emitted in parallel until v0.15.0 (see CLAUDE.md §12).
+    # Legacy flat keys emitted in parallel until v0.16.0 (see CLAUDE.md §12).
     # Each key here maps to the new namespace/metric equivalent listed in the
     # deprecation warning string below.
     _LEGACY_KEY_MAP = {
@@ -712,9 +712,9 @@ def log_training_metrics(
     for old_key, new_key in _LEGACY_KEY_MAP.items():
         if old_key not in _EI_WARNED:
             warnings.warn(
-                f'EI metric key "{old_key}" is deprecated and will be removed in v0.15.0. '
+                f'EI metric key "{old_key}" is deprecated and will be removed in v0.16.0. '
                 f'Use "{new_key}" instead.',
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=2,
             )
             _EI_WARNED.add(old_key)
@@ -739,9 +739,7 @@ def log_training_metrics(
         except Exception:  # noqa: BLE001
             pass
         try:
-            legacy_metrics["reward from batch"] = float(
-                batch["next", "reward"].mean()
-            )
+            legacy_metrics["reward from batch"] = float(batch["next", "reward"].mean())
             legacy_metrics["loss_sft, from loss"] = float(loss.loss_sft)
             kl_to_ref = getattr(loss, "loss_kl_to_ref", None)
             if kl_to_ref is not None:

--- a/sota-implementations/expert-iteration/expert-iteration-async.py
+++ b/sota-implementations/expert-iteration/expert-iteration-async.py
@@ -14,6 +14,7 @@ import hydra
 
 from torchrl import merge_ray_runtime_env, torchrl_logger
 from torchrl.data.llm.history import History
+from torchrl.record.loggers import PostTrainingLogger
 from torchrl.record.loggers.wandb import WandbLogger
 from torchrl.weight_update.llm import get_model_metadata
 
@@ -236,6 +237,7 @@ def train(
     data_read_count = 0
     optim_step = 0
     start_time = time.time()
+    post_training_logger = PostTrainingLogger(wandb_logger, start_time=start_time)
 
     for step in range(total_steps):
         pbar.update(1)
@@ -319,6 +321,7 @@ def train(
         if (step % cfg.train.logging_frequency) == 0:
             log_training_metrics(
                 wandb_logger=wandb_logger,
+                post_training_logger=post_training_logger,
                 replay_buffer=replay_buffer,
                 batch=batch,
                 loss=loss,

--- a/sota-implementations/expert-iteration/expert-iteration-sync.py
+++ b/sota-implementations/expert-iteration/expert-iteration-sync.py
@@ -14,6 +14,7 @@ import hydra
 
 from torchrl import merge_ray_runtime_env, torchrl_logger
 from torchrl.data.llm.history import History
+from torchrl.record.loggers import PostTrainingLogger
 from torchrl.record.loggers.wandb import WandbLogger
 from torchrl.weight_update.llm import get_model_metadata
 
@@ -219,6 +220,7 @@ def train(
     global_step = 0
     optim_step = 0  # Track optimization steps separately for scheduler
     start_time = time.time()
+    post_training_logger = PostTrainingLogger(wandb_logger, start_time=start_time)
     write_count = replay_buffer.write_count
     for data in collector:
         new_write_count = replay_buffer.write_count
@@ -312,6 +314,7 @@ def train(
                 if (global_step % cfg.train.logging_frequency) == 0:
                     log_training_metrics(
                         wandb_logger=wandb_logger,
+                        post_training_logger=post_training_logger,
                         replay_buffer=replay_buffer,
                         batch=batch,
                         loss=loss,

--- a/sota-implementations/expert-iteration/expert-iteration-sync.py
+++ b/sota-implementations/expert-iteration/expert-iteration-sync.py
@@ -275,7 +275,7 @@ def train(
                         loss_val.backward()
 
                 # Optimization step
-                if ((global_step + 1) % cfg.train.gradient_accumulation_steps) == 0:
+                if (global_step % cfg.train.gradient_accumulation_steps) == 0:
                     with timeit("optim_step"):
                         if (
                             cfg.train.mixed_precision

--- a/sota-implementations/grpo/grpo-async.py
+++ b/sota-implementations/grpo/grpo-async.py
@@ -17,6 +17,7 @@ from omegaconf import OmegaConf
 
 from torchrl import merge_ray_runtime_env, torchrl_logger
 from torchrl.data.llm.history import History
+from torchrl.record.loggers import PostTrainingLogger
 from torchrl.record.loggers.wandb import WandbLogger
 from torchrl.weight_update.llm import get_model_metadata
 
@@ -215,6 +216,7 @@ def train(
     optim_steps = 0  # Track optimizer steps for weight update scheduling
     skipped_nonfinite_updates = 0
     start_time = time.time()
+    post_training_logger = PostTrainingLogger(wandb_logger, start_time=start_time)
     exit_code = 1
     try:
         for step in range(total_steps):
@@ -335,6 +337,7 @@ def train(
             if (step % cfg.train.logging_frequency) == 0:
                 log_training_metrics(
                     wandb_logger=wandb_logger,
+                    post_training_logger=post_training_logger,
                     replay_buffer=replay_buffer,
                     batch=batch,
                     loss=loss,

--- a/sota-implementations/grpo/grpo-sync.py
+++ b/sota-implementations/grpo/grpo-sync.py
@@ -242,7 +242,7 @@ def train(
                     else:
                         loss_val.backward()
 
-                if ((global_step + 1) % cfg.train.gradient_accumulation_steps) == 0:
+                if (global_step % cfg.train.gradient_accumulation_steps) == 0:
                     with timeit("optim_step"):
                         if (
                             cfg.train.mixed_precision

--- a/sota-implementations/grpo/grpo-sync.py
+++ b/sota-implementations/grpo/grpo-sync.py
@@ -15,6 +15,7 @@ import hydra
 
 from torchrl import merge_ray_runtime_env, torchrl_logger
 from torchrl.data.llm.history import History
+from torchrl.record.loggers import PostTrainingLogger
 from torchrl.record.loggers.wandb import WandbLogger
 from torchrl.weight_update.llm import get_model_metadata
 
@@ -184,6 +185,7 @@ def train(
 
     global_step = 0
     start_time = time.time()
+    post_training_logger = PostTrainingLogger(wandb_logger, start_time=start_time)
     for data in pbar:
         # Wait for the replay buffer to be filled - when reasoning, we collect trajectories
         #  so the buffer may not be filled straight away
@@ -271,6 +273,7 @@ def train(
                 if (global_step % cfg.train.logging_frequency) == 0:
                     log_training_metrics(
                         wandb_logger=wandb_logger,
+                        post_training_logger=post_training_logger,
                         replay_buffer=replay_buffer,
                         batch=batch,
                         loss=loss,

--- a/sota-implementations/grpo/grpo_utils.py
+++ b/sota-implementations/grpo/grpo_utils.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import functools
 
-import time
 import warnings
 from typing import Any, Literal
 
@@ -20,6 +19,7 @@ from torchrl.envs.llm.datasets.countdown import CountdownEnv
 from torchrl.envs.llm.datasets.ifeval import IFEvalEnv
 from torchrl.envs.llm.datasets.math import MATHEnv
 from torchrl.modules.llm import SGLangWrapper, TransformersWrapper, vLLMWrapper
+from torchrl.record.loggers.llm import PostTrainingLogger
 from torchrl.weight_update.llm import SGLangWeightSyncScheme, VLLMWeightSyncScheme
 from transformers.models.auto.modeling_auto import AutoModelForCausalLM
 from transformers.tokenization_utils import PreTrainedTokenizer
@@ -931,91 +931,55 @@ def log_training_metrics(
 ):
     """Log training metrics to wandb.
 
+    Delegates standard metrics to :class:`~torchrl.record.loggers.PostTrainingLogger`
+    and appends GRPO-recipe-specific metrics directly.
+
     Args:
-        wandb_logger: The wandb logger instance
-        replay_buffer: The replay buffer containing collected data
-        batch: The current training batch
-        loss: The computed loss object
-        grad_norm: The gradient norm value
-        global_step: Current global training step
-        data_read_count: Total data read count
-        collector: The collector instance
-        start_time: Training start time
-        gradient_accumulation_steps: Number of gradient accumulation steps
-        history_str: Optional history string for logging
+        wandb_logger: The wandb logger instance.
+        replay_buffer: The replay buffer containing collected data.
+        batch: The current training batch.
+        loss: The computed loss object.
+        grad_norm: The gradient norm value.
+        global_step: Current global training step.
+        data_read_count: Total data read count.
+        collector: The collector instance.
+        start_time: Training start time (``time.time()`` at loop start).
+        gradient_accumulation_steps: Number of gradient accumulation steps.
+        history_str: Optional history string for logging.
+        use_kl_to_ref: Whether KL-to-reference metrics are available.
     """
+    pt_logger = PostTrainingLogger(logger=wandb_logger, start_time=start_time)
+
+    pt_logger.log_training_step(
+        loss=loss,
+        step=global_step,
+        grad_norm=grad_norm,
+        gradient_accumulation_steps=gradient_accumulation_steps,
+    )
+    pt_logger.log_collection_step(
+        batch=batch,
+        replay_buffer=replay_buffer,
+        collector=collector,
+        step=global_step,
+    )
+
+    # GRPO-specific extras: step_count and kl_penalty live in the buffer
+    # but are not part of the standard PostTrainingLogger interface.
     with torch.no_grad():
-        rb_content = replay_buffer[:]
-        step_count = rb_content.get(("next", "step_count")).view(-1).float().mean()
-        batch_policy_version = batch["next", "policy_version"].view(-1).min()
-        batch_policy_age = collector.policy_version - batch_policy_version
+        extra_metrics = {"buffer/data_read_count": data_read_count}
+        try:
+            rb_content = replay_buffer[:]
+            step_count = rb_content.get(("next", "step_count")).view(-1).float().mean()
+            extra_metrics["buffer/step_count_mean"] = float(step_count)
+            if use_kl_to_ref:
+                extra_metrics["buffer/kl_penalty_to_ref_mean"] = float(
+                    torch.cat(
+                        rb_content.get(("next", "kl_penalty"), as_list=True)
+                    ).mean()
+                )
+        except Exception:  # noqa: BLE001
+            pass
+        wandb_logger.log_metrics(extra_metrics, step=global_step)
 
-        # Buffer-level staleness stats
-        buffer_policy_versions = (
-            rb_content.get(("next", "policy_version")).view(-1).float()
-        )
-        current_version = collector.policy_version
-        buffer_staleness = current_version - buffer_policy_versions
-        buffer_staleness_mean = float(buffer_staleness.mean())
-        buffer_staleness_max = float(buffer_staleness.max())
-
-        elapsed = time.time() - start_time
-        optim_steps = global_step // gradient_accumulation_steps
-
-        metrics = {
-            # --- training/ : loss components and optimizer state ---
-            "training/loss_objective": float(loss.loss_objective),
-            "training/clip_fraction": float(loss.clip_fraction),
-            "training/ESS": float(loss.ESS),
-            "training/entropy_loss": float(loss.loss_entropy.mean()),
-            "training/kl_approx_to_inference": float(loss.kl_approx),
-            "training/kl_to_inference": float(loss.kl_to_inference.mean()),
-            "training/loss_kl_to_inference": float(loss.loss_kl_to_inference.mean()),
-            "training/grad_norm": float(grad_norm)
-            if global_step % gradient_accumulation_steps == 0
-            else 0.0,
-            "training/gradient_steps": global_step,
-            "training/optim_steps": optim_steps,
-            # --- inference/ : collection and policy version state ---
-            "inference/policy_version": collector.policy_version,
-            "inference/batch_policy_version": batch_policy_version,
-            "inference/batch_policy_age": batch_policy_age,
-            "inference/staleness_mean": buffer_staleness_mean,
-            "inference/staleness_max": buffer_staleness_max,
-            # --- buffer/ : replay buffer statistics ---
-            "buffer/write_count": int(replay_buffer.write_count),
-            "buffer/reward_mean": float(
-                torch.cat(rb_content.get(("next", "reward"), as_list=True)).mean()
-            ),
-            "buffer/seq_length_mean": float(
-                torch.tensor(
-                    [
-                        t.numel()
-                        for t in rb_content.get(("tokens", "response"), as_list=True)
-                    ],
-                    dtype=torch.float,
-                ).mean()
-            ),
-            "buffer/step_count_mean": float(step_count),
-            "buffer/data_read_count": data_read_count,
-            # --- throughput/ : training speed metrics ---
-            "throughput/gradient_steps_per_second": float(global_step / elapsed),
-            "throughput/optim_steps_per_second": float(optim_steps / elapsed),
-            "throughput/gradient_steps_per_write": float(
-                global_step / replay_buffer.write_count
-            ),
-            "throughput/optim_steps_per_write": float(
-                optim_steps / replay_buffer.write_count
-            ),
-        }
-        if use_kl_to_ref:
-            metrics["training/kl_to_ref"] = float(loss.kl_to_ref.mean())
-            metrics["training/loss_kl_to_ref"] = float(loss.loss_kl_to_ref.mean())
-            metrics["buffer/kl_penalty_to_ref_mean"] = float(
-                torch.cat(rb_content.get(("next", "kl_penalty"), as_list=True)).mean()
-            )
-
-        wandb_logger.log_metrics(metrics, step=global_step)
-
-        if history_str is not None:
-            wandb_logger.log_str("history", history_str, step=global_step)
+    if history_str is not None:
+        wandb_logger.log_str("history", history_str, step=global_step)

--- a/sota-implementations/grpo/grpo_utils.py
+++ b/sota-implementations/grpo/grpo_utils.py
@@ -24,6 +24,9 @@ from torchrl.weight_update.llm import SGLangWeightSyncScheme, VLLMWeightSyncSche
 from transformers.models.auto.modeling_auto import AutoModelForCausalLM
 from transformers.tokenization_utils import PreTrainedTokenizer
 
+# Tracks which legacy GRPO metric keys have already fired a DeprecationWarning.
+_GRPO_WARNED: set[str] = set()
+
 
 def check_grpo_dependencies(backend: str = "vllm") -> None:
     """Check for required GRPO dependencies and provide helpful error messages.
@@ -962,6 +965,25 @@ def log_training_metrics(
         collector=collector,
         step=global_step,
     )
+
+    # Keys renamed by this PR: emit one-time DeprecationWarnings so downstream
+    # dashboards that still reference the old names get a clear migration signal.
+    _GRPO_LEGACY_KEY_MAP = {
+        "buffer/reward_mean": "batch/reward_mean",
+        "buffer/reward_std": "batch/reward_std",
+        "buffer/reward_min": "batch/reward_min",
+        "buffer/reward_max": "batch/reward_max",
+        "buffer/seq_length_mean": "batch/seq_length_mean",
+    }
+    for old_key, new_key in _GRPO_LEGACY_KEY_MAP.items():
+        if old_key not in _GRPO_WARNED:
+            warnings.warn(
+                f'GRPO metric key "{old_key}" has been renamed to "{new_key}". '
+                f'The old key will be removed in v0.15.0.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            _GRPO_WARNED.add(old_key)
 
     # GRPO-specific extras: step_count and kl_penalty live in the buffer
     # but are not part of the standard PostTrainingLogger interface.

--- a/sota-implementations/grpo/grpo_utils.py
+++ b/sota-implementations/grpo/grpo_utils.py
@@ -20,7 +20,6 @@ from torchrl.envs.llm.datasets.countdown import CountdownEnv
 from torchrl.envs.llm.datasets.ifeval import IFEvalEnv
 from torchrl.envs.llm.datasets.math import MATHEnv
 from torchrl.modules.llm import SGLangWrapper, TransformersWrapper, vLLMWrapper
-from torchrl.record.loggers.llm import PostTrainingLogger
 from torchrl.weight_update.llm import SGLangWeightSyncScheme, VLLMWeightSyncScheme
 from transformers.models.auto.modeling_auto import AutoModelForCausalLM
 from transformers.tokenization_utils import PreTrainedTokenizer
@@ -921,6 +920,7 @@ def add_kl_transforms_to_replay_buffer(replay_buffer, cfg: DictConfig):
 @timeit("Logging metrics")
 def log_training_metrics(
     wandb_logger,
+    post_training_logger,
     replay_buffer,
     batch,
     loss,
@@ -940,6 +940,7 @@ def log_training_metrics(
 
     Args:
         wandb_logger: The wandb logger instance.
+        post_training_logger: Persistent post-training logger for this run.
         replay_buffer: The replay buffer containing collected data.
         batch: The current training batch.
         loss: The computed loss object.
@@ -952,15 +953,13 @@ def log_training_metrics(
         history_str: Optional history string for logging.
         use_kl_to_ref: Whether KL-to-reference metrics are available.
     """
-    pt_logger = PostTrainingLogger(logger=wandb_logger, start_time=start_time)
-
-    pt_logger.log_training_step(
+    post_training_logger.log_training_step(
         loss=loss,
         step=global_step,
         grad_norm=grad_norm,
         gradient_accumulation_steps=gradient_accumulation_steps,
     )
-    pt_logger.log_collection_step(
+    post_training_logger.log_collection_step(
         batch=batch,
         replay_buffer=replay_buffer,
         collector=collector,
@@ -981,9 +980,8 @@ def log_training_metrics(
             "'training/kl_approx_to_inference' are deprecated and will be removed "
             "in v0.16.0. Use the batch/* keys emitted by PostTrainingLogger "
             "(computed over the sampled batch rather than the whole buffer), "
-            "'training/loss_entropy' and 'training/kl_approx'. Note that "
-            "'inference/staleness_mean'/'_max' keep their names but are now "
-            "computed over the sampled batch instead of the whole buffer.",
+            "'training/loss_entropy', 'training/kl_approx' and "
+            "'batch/staleness_mean'/'batch/staleness_max'.",
             FutureWarning,
             stacklevel=2,
         )

--- a/sota-implementations/grpo/grpo_utils.py
+++ b/sota-implementations/grpo/grpo_utils.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import functools
 
+import time
 import warnings
 from typing import Any, Literal
 
@@ -24,7 +25,7 @@ from torchrl.weight_update.llm import SGLangWeightSyncScheme, VLLMWeightSyncSche
 from transformers.models.auto.modeling_auto import AutoModelForCausalLM
 from transformers.tokenization_utils import PreTrainedTokenizer
 
-# Tracks which legacy GRPO metric keys have already fired a DeprecationWarning.
+# Tracks which one-time deprecation warnings have already fired.
 _GRPO_WARNED: set[str] = set()
 
 
@@ -966,40 +967,75 @@ def log_training_metrics(
         step=global_step,
     )
 
-    # Keys renamed by this PR: emit one-time DeprecationWarnings so downstream
-    # dashboards that still reference the old names get a clear migration signal.
-    _GRPO_LEGACY_KEY_MAP = {
-        "buffer/reward_mean": "batch/reward_mean",
-        "buffer/reward_std": "batch/reward_std",
-        "buffer/reward_min": "batch/reward_min",
-        "buffer/reward_max": "batch/reward_max",
-        "buffer/seq_length_mean": "batch/seq_length_mean",
-    }
-    for old_key, new_key in _GRPO_LEGACY_KEY_MAP.items():
-        if old_key not in _GRPO_WARNED:
-            warnings.warn(
-                f'GRPO metric key "{old_key}" has been renamed to "{new_key}". '
-                f'The old key will be removed in v0.15.0.',
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            _GRPO_WARNED.add(old_key)
+    # Legacy keys superseded by PostTrainingLogger's batch/* metrics (computed
+    # over the sampled batch, where these are computed over the whole buffer or
+    # from recipe-local state). Per the deprecation policy they stay emitted,
+    # under their old names and with their old semantics, for two minor
+    # releases: deprecated in v0.14, removed in v0.16.0.
+    if "grpo-legacy-keys" not in _GRPO_WARNED:
+        _GRPO_WARNED.add("grpo-legacy-keys")
+        warnings.warn(
+            "The GRPO metric keys 'buffer/reward_mean', 'buffer/seq_length_mean', "
+            "'inference/batch_policy_version', 'inference/batch_policy_age', "
+            "'throughput/optim_steps_per_second', 'training/entropy_loss' and "
+            "'training/kl_approx_to_inference' are deprecated and will be removed "
+            "in v0.16.0. Use the batch/* keys emitted by PostTrainingLogger "
+            "(computed over the sampled batch rather than the whole buffer), "
+            "'training/loss_entropy' and 'training/kl_approx'. Note that "
+            "'inference/staleness_mean'/'_max' keep their names but are now "
+            "computed over the sampled batch instead of the whole buffer.",
+            FutureWarning,
+            stacklevel=2,
+        )
 
-    # GRPO-specific extras: step_count and kl_penalty live in the buffer
-    # but are not part of the standard PostTrainingLogger interface.
+    # GRPO-specific extras (step_count, kl_penalty, read counts) plus the
+    # deprecated legacy keys above, all of which need recipe-local state
+    # (whole-buffer contents, the collector, the wall clock) that is not part
+    # of the standard PostTrainingLogger interface.
     with torch.no_grad():
         extra_metrics = {"buffer/data_read_count": data_read_count}
+        loss_entropy = getattr(loss, "loss_entropy", None)
+        if loss_entropy is not None:
+            extra_metrics["training/entropy_loss"] = float(loss_entropy.mean())
+        kl_approx = getattr(loss, "kl_approx", None)
+        if kl_approx is not None:
+            extra_metrics["training/kl_approx_to_inference"] = float(kl_approx.mean())
+        try:
+            batch_policy_version = int(batch["next", "policy_version"].view(-1).min())
+            extra_metrics["inference/batch_policy_version"] = batch_policy_version
+            extra_metrics["inference/batch_policy_age"] = (
+                int(collector.policy_version) - batch_policy_version
+            )
+        except (AttributeError, KeyError, RuntimeError, TypeError):
+            pass
+        elapsed = time.time() - start_time
+        if elapsed > 0:
+            extra_metrics["throughput/optim_steps_per_second"] = float(
+                (global_step // gradient_accumulation_steps) / elapsed
+            )
         try:
             rb_content = replay_buffer[:]
             step_count = rb_content.get(("next", "step_count")).view(-1).float().mean()
             extra_metrics["buffer/step_count_mean"] = float(step_count)
+            extra_metrics["buffer/reward_mean"] = float(
+                torch.cat(rb_content.get(("next", "reward"), as_list=True)).mean()
+            )
+            extra_metrics["buffer/seq_length_mean"] = float(
+                torch.tensor(
+                    [
+                        t.numel()
+                        for t in rb_content.get(("tokens", "response"), as_list=True)
+                    ],
+                    dtype=torch.float,
+                ).mean()
+            )
             if use_kl_to_ref:
                 extra_metrics["buffer/kl_penalty_to_ref_mean"] = float(
                     torch.cat(
                         rb_content.get(("next", "kl_penalty"), as_list=True)
                     ).mean()
                 )
-        except Exception:  # noqa: BLE001
+        except (AttributeError, KeyError, RuntimeError, TypeError):
             pass
         wandb_logger.log_metrics(extra_metrics, step=global_step)
 

--- a/test/test_loggers.py
+++ b/test/test_loggers.py
@@ -1710,6 +1710,49 @@ class TestPostTrainingLogger:
         assert m["training/grad_norm"] == 1.0
         assert m["training/optim_steps"] == 1
 
+    def test_log_training_step_accumulation_matches_caller_loop(self, csv_logger):
+        """Integration: simulate the actual caller-loop pattern and verify the
+        logger's grad_norm gate fires at exactly the same steps.
+
+        Recipe loops do:
+            global_step += 1          # increment first
+            loss.backward()
+            if global_step % accum == 0:   # FIXED: was (global_step+1) % accum
+                optimizer.step()
+                grad_norm = clip_grad_norm_(...)
+            log_training_metrics(..., grad_norm=grad_norm, global_step=global_step)
+
+        With accum=4 the optimizer fires at steps 4, 8, 12, ...
+        The logger must emit training/grad_norm on exactly those steps.
+        """
+        loss = SFTLossOutput(loss_sft=torch.tensor(0.5))
+        pt = PostTrainingLogger(logger=csv_logger)
+        accum = 4
+        grad_norm = 0.0
+        optim_steps_logged = []
+        grad_norm_steps = []
+
+        for global_step in range(1, 13):  # simulate 12 gradient steps
+            # Simulate optimizer boundary — matches fixed callers
+            if global_step % accum == 0:
+                grad_norm = 1.0  # pretend clip_grad_norm_ returned 1.0
+            m = pt.log_training_step(
+                loss=loss,
+                step=global_step,
+                grad_norm=grad_norm,
+                gradient_accumulation_steps=accum,
+            )
+            if "training/grad_norm" in m:
+                grad_norm_steps.append(global_step)
+            optim_steps_logged.append(m["training/optim_steps"])
+
+        # Optimizer fired at steps 4, 8, 12
+        assert grad_norm_steps == [4, 8, 12], grad_norm_steps
+        # optim_steps should be 0 for steps 1-3, then 1 for steps 4-7, etc.
+        assert optim_steps_logged[3] == 1   # step 4
+        assert optim_steps_logged[7] == 2   # step 8
+        assert optim_steps_logged[11] == 3  # step 12
+
     # --- log_collection_step ---
 
     def test_log_collection_step_minimal(self, csv_logger):

--- a/test/test_loggers.py
+++ b/test/test_loggers.py
@@ -6,25 +6,36 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import logging
 import multiprocessing as mp
 import os
 import os.path
 import pathlib
 import tempfile
 import threading
+import time
 from time import sleep
+from types import SimpleNamespace
 
 import pytest
 import torch
-from tensordict import MemoryMappedTensor
+from tensordict import (
+    lazy_stack,
+    MemoryMappedTensor,
+    set_list_to_stack,
+    TensorClass,
+    TensorDict,
+)
 
 from torchrl._comm import MailboxPeerClosedError
 from torchrl.checkpoint import Checkpoint
-from torchrl.data import LazyTensorStorage, ReplayBuffer
+from torchrl.data import LazyStackStorage, LazyTensorStorage, ReplayBuffer
 from torchrl.envs import check_env_specs, GymEnv, ParallelEnv
+from torchrl.objectives.llm.grpo import GRPOLossOutput
+from torchrl.objectives.llm.sft import SFTLossOutput
+from torchrl.record.loggers import PostTrainingLogger
 from torchrl.record.loggers.common import _has_torchcodec, Logger
 from torchrl.record.loggers.csv import CSVLogger
-from torchrl.record.loggers.llm import PostTrainingLogger
 from torchrl.record.loggers.mlflow import _has_mlflow, MLFlowLogger
 from torchrl.record.loggers.monitoring import Every, LoggerMonitor
 from torchrl.record.loggers.process import ProcessLogger
@@ -1529,11 +1540,6 @@ class TestLoggerMonitor:
         logger.close()
 
 
-if __name__ == "__main__":
-    args, unknown = argparse.ArgumentParser().parse_known_args()
-    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)
-
-
 # ---------------------------------------------------------------------------
 # PostTrainingLogger tests
 # ---------------------------------------------------------------------------
@@ -1556,8 +1562,6 @@ class TestPostTrainingLogger:
 
     def test_log_training_step_grpo_loss(self, csv_logger):
         """Standard GRPO loss output with all optional fields set."""
-        from torchrl.objectives.llm.grpo import GRPOLossOutput
-
         loss = GRPOLossOutput(
             loss_objective=torch.tensor(0.42),
             clip_fraction=torch.tensor(0.10),
@@ -1586,8 +1590,6 @@ class TestPostTrainingLogger:
 
     def test_log_training_step_sft_loss(self, csv_logger):
         """SFTLossOutput with all optional fields set."""
-        from torchrl.objectives.llm.sft import SFTLossOutput
-
         loss = SFTLossOutput(
             loss_sft=torch.tensor(0.77),
             loss_kl_to_ref=torch.tensor(0.02),
@@ -1606,8 +1608,6 @@ class TestPostTrainingLogger:
 
     def test_log_training_step_sft_loss_no_kl(self, csv_logger):
         """SFTLossOutput with only the required field — None fields skipped."""
-        from torchrl.objectives.llm.sft import SFTLossOutput
-
         loss = SFTLossOutput(loss_sft=torch.tensor(0.5))
         pt = PostTrainingLogger(logger=csv_logger)
         metrics = pt.log_training_step(loss=loss, step=1)
@@ -1619,8 +1619,6 @@ class TestPostTrainingLogger:
 
     def test_log_training_step_grpo_none_optionals(self, csv_logger):
         """GRPOLossOutput with optional fields left as None — must not appear."""
-        from torchrl.objectives.llm.grpo import GRPOLossOutput
-
         loss = GRPOLossOutput(
             loss_objective=torch.tensor(0.42),
             clip_fraction=torch.tensor(0.10),
@@ -1640,7 +1638,6 @@ class TestPostTrainingLogger:
         """Fields are discovered by iterating the tensorclass, not from a
         hardcoded list: a loss subclass gaining a new term is logged without
         touching the logger."""
-        from tensordict import TensorClass
 
         class MyLossOutput(TensorClass["nocast"]):
             loss_sft: torch.Tensor
@@ -1655,8 +1652,6 @@ class TestPostTrainingLogger:
 
     def test_log_collection_step_single_reward_no_std(self, csv_logger):
         """std of a single element is NaN; the key is omitted instead."""
-        from tensordict import TensorDict
-
         batch = TensorDict({("next", "reward"): torch.tensor([[1.0]])}, batch_size=[1])
         pt = PostTrainingLogger(logger=csv_logger)
         metrics = pt.log_collection_step(batch)
@@ -1666,9 +1661,6 @@ class TestPostTrainingLogger:
     def test_metric_failure_warns_once(self, csv_logger, caplog):
         """A metric that cannot be computed warns at WARNING level on the first
         failure and stays quiet afterwards -- never a silent empty emit."""
-        import logging
-
-        from tensordict import TensorDict
 
         class BadBuffer:
             @property
@@ -1687,8 +1679,6 @@ class TestPostTrainingLogger:
 
     def test_log_training_step_custom_duck_type(self, csv_logger):
         """Arbitrary object exposing only loss_sft — duck-typing must not crash."""
-        from types import SimpleNamespace
-
         loss = SimpleNamespace(loss_sft=torch.tensor(0.5))
         pt = PostTrainingLogger(logger=csv_logger)
         metrics = pt.log_training_step(loss=loss, step=1)
@@ -1703,8 +1693,6 @@ class TestPostTrainingLogger:
         On accumulation steps the key is absent -- logging a literal 0.0 there
         would pollute any aggregate (mean, min, histogram) over the series.
         """
-        from torchrl.objectives.llm.sft import SFTLossOutput
-
         loss = SFTLossOutput(loss_sft=torch.tensor(0.5))
         pt = PostTrainingLogger(logger=csv_logger)
 
@@ -1726,8 +1714,6 @@ class TestPostTrainingLogger:
 
     def test_log_collection_step_minimal(self, csv_logger):
         """Minimal call: only batch and step.  Must not crash."""
-        from tensordict import lazy_stack, set_list_to_stack, TensorDict
-
         with set_list_to_stack(True):
             batch = lazy_stack(
                 [
@@ -1754,9 +1740,6 @@ class TestPostTrainingLogger:
 
     def test_log_collection_step_with_buffer(self, csv_logger):
         """With replay buffer: utilization and write_count emitted."""
-        from tensordict import lazy_stack, set_list_to_stack, TensorDict
-        from torchrl.data import LazyStackStorage, ReplayBuffer
-
         with set_list_to_stack(True):
             td = TensorDict(
                 {"next": TensorDict({"reward": torch.tensor([1.0])}, [])}, []
@@ -1772,12 +1755,66 @@ class TestPostTrainingLogger:
         assert "buffer/utilization" in metrics
         assert abs(metrics["buffer/utilization"] - 0.3) < 1e-5
 
+    def test_log_collection_step_dense_response_uses_assistant_mask(self, csv_logger):
+        """Padding in a dense response tensor is excluded from sequence lengths."""
+        batch = TensorDict(
+            {
+                ("tokens", "response"): torch.tensor([[11, 12, 0, 0], [21, 0, 0, 0]]),
+                ("masks", "all_assistant_mask"): torch.tensor(
+                    [[True, True, False, False], [True, False, False, False]]
+                ),
+            },
+            batch_size=[2],
+        )
+        metrics = PostTrainingLogger(logger=csv_logger).log_collection_step(batch)
+
+        assert metrics["batch/seq_length_mean"] == 1.5
+
+    def test_log_collection_step_dense_response_without_mask_omits_length(
+        self, csv_logger
+    ):
+        """A padded dense width is never reported as an inferred token count."""
+        batch = TensorDict(
+            {("tokens", "response"): torch.tensor([[11, 12, 0, 0]])},
+            batch_size=[1],
+        )
+        metrics = PostTrainingLogger(logger=csv_logger).log_collection_step(batch)
+
+        assert "batch/seq_length_mean" not in metrics
+
+    def test_log_collection_step_uses_public_buffer_stats(self, csv_logger):
+        """Remote-style buffers need no local storage or write-count property."""
+
+        class StatsOnlyBuffer:
+            def stats(self):
+                return {"write_count": 8, "utilization": 0.4}
+
+        metrics = PostTrainingLogger(logger=csv_logger).log_collection_step(
+            TensorDict({}, batch_size=[1]), replay_buffer=StatsOnlyBuffer()
+        )
+
+        assert metrics["buffer/write_count"] == 8
+        assert metrics["buffer/utilization"] == 0.4
+
+    def test_log_collection_step_batch_staleness_namespace(self, csv_logger):
+        """Sampled policy staleness is identified as a batch metric."""
+        batch = TensorDict(
+            {("next", "policy_version"): torch.tensor([3, 4])}, batch_size=[2]
+        )
+        collector = SimpleNamespace(policy_version=5)
+
+        metrics = PostTrainingLogger(logger=csv_logger).log_collection_step(
+            batch, collector=collector
+        )
+
+        assert metrics["batch/staleness_mean"] == 1.5
+        assert metrics["batch/staleness_max"] == 2.0
+        assert "inference/staleness_mean" not in metrics
+
     def test_log_collection_step_throughput_omitted_without_start_time(
         self, csv_logger
     ):
         """throughput/* must not appear when start_time=None."""
-        from tensordict import lazy_stack, set_list_to_stack, TensorDict
-
         with set_list_to_stack(True):
             batch = lazy_stack(
                 [
@@ -1793,10 +1830,6 @@ class TestPostTrainingLogger:
 
     def test_log_collection_step_throughput_emitted_with_start_time(self, csv_logger):
         """throughput/* emitted as a positive float when start_time is set."""
-        import time
-
-        from tensordict import lazy_stack, set_list_to_stack, TensorDict
-
         with set_list_to_stack(True):
             batch = lazy_stack(
                 [
@@ -1829,6 +1862,9 @@ class TestPostTrainingLogger:
 
     def test_importable_from_package(self):
         """PostTrainingLogger must be importable from the top-level package."""
-        from torchrl.record.loggers import PostTrainingLogger as PTL
+        assert PostTrainingLogger.__name__ == "PostTrainingLogger"
 
-        assert PTL is PostTrainingLogger
+
+if __name__ == "__main__":
+    args, unknown = argparse.ArgumentParser().parse_known_args()
+    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_loggers.py
+++ b/test/test_loggers.py
@@ -1689,11 +1689,11 @@ class TestPostTrainingLogger:
             pt = PostTrainingLogger(logger=csv_logger)
             metrics = pt.log_collection_step(batch, step=1)
 
-        assert "buffer/reward_mean" in metrics
-        assert abs(metrics["buffer/reward_mean"] - 1.5) < 1e-5
-        assert "buffer/reward_std" in metrics
-        assert "buffer/reward_min" in metrics
-        assert "buffer/reward_max" in metrics
+        assert "batch/reward_mean" in metrics
+        assert abs(metrics["batch/reward_mean"] - 1.5) < 1e-5
+        assert "batch/reward_std" in metrics
+        assert "batch/reward_min" in metrics
+        assert "batch/reward_max" in metrics
         # Optional metrics absent when not provided
         assert "buffer/utilization" not in metrics
         assert "inference/policy_version" not in metrics

--- a/test/test_loggers.py
+++ b/test/test_loggers.py
@@ -1636,6 +1636,55 @@ class TestPostTrainingLogger:
         assert "training/loss_entropy" not in metrics
         assert "training/kl_to_ref" not in metrics
 
+    def test_log_training_step_discovers_new_fields(self, csv_logger):
+        """Fields are discovered by iterating the tensorclass, not from a
+        hardcoded list: a loss subclass gaining a new term is logged without
+        touching the logger."""
+        from tensordict import TensorClass
+
+        class MyLossOutput(TensorClass["nocast"]):
+            loss_sft: torch.Tensor
+            loss_my_new_term: torch.Tensor | None = None
+
+        loss = MyLossOutput(
+            loss_sft=torch.tensor(0.5), loss_my_new_term=torch.tensor(0.25)
+        )
+        pt = PostTrainingLogger(logger=csv_logger)
+        metrics = pt.log_training_step(loss=loss, step=1)
+        assert metrics["training/loss_my_new_term"] == 0.25
+
+    def test_log_collection_step_single_reward_no_std(self, csv_logger):
+        """std of a single element is NaN; the key is omitted instead."""
+        from tensordict import TensorDict
+
+        batch = TensorDict({("next", "reward"): torch.tensor([[1.0]])}, batch_size=[1])
+        pt = PostTrainingLogger(logger=csv_logger)
+        metrics = pt.log_collection_step(batch)
+        assert metrics["batch/reward_mean"] == 1.0
+        assert "batch/reward_std" not in metrics
+
+    def test_metric_failure_warns_once(self, csv_logger, caplog):
+        """A metric that cannot be computed warns at WARNING level on the first
+        failure and stays quiet afterwards -- never a silent empty emit."""
+        import logging
+
+        from tensordict import TensorDict
+
+        class BadBuffer:
+            @property
+            def write_count(self):
+                raise RuntimeError("boom")
+
+        batch = TensorDict({}, batch_size=[1])
+        pt = PostTrainingLogger(logger=csv_logger)
+        with caplog.at_level(logging.WARNING, logger="torchrl"):
+            pt.log_collection_step(batch, replay_buffer=BadBuffer())
+            pt.log_collection_step(batch, replay_buffer=BadBuffer())
+        warnings_seen = [
+            rec for rec in caplog.records if "could not compute 'buffer'" in rec.message
+        ]
+        assert len(warnings_seen) == 1
+
     def test_log_training_step_custom_duck_type(self, csv_logger):
         """Arbitrary object exposing only loss_sft — duck-typing must not crash."""
         from types import SimpleNamespace
@@ -1649,17 +1698,21 @@ class TestPostTrainingLogger:
         assert "training/loss_objective" not in metrics
 
     def test_log_training_step_gradient_accumulation(self, csv_logger):
-        """grad_norm is 0.0 on accumulation steps, real value on optimizer steps."""
+        """grad_norm is only emitted on optimizer steps.
+
+        On accumulation steps the key is absent -- logging a literal 0.0 there
+        would pollute any aggregate (mean, min, histogram) over the series.
+        """
         from torchrl.objectives.llm.sft import SFTLossOutput
 
         loss = SFTLossOutput(loss_sft=torch.tensor(0.5))
         pt = PostTrainingLogger(logger=csv_logger)
 
-        # step=3, accumulation=4: not an optimizer step -> grad_norm = 0.0
+        # step=3, accumulation=4: not an optimizer step -> no grad_norm key
         m = pt.log_training_step(
             loss=loss, step=3, grad_norm=1.0, gradient_accumulation_steps=4
         )
-        assert m["training/grad_norm"] == 0.0
+        assert "training/grad_norm" not in m
         assert m["training/optim_steps"] == 0
 
         # step=4, accumulation=4: optimizer step -> grad_norm = 1.0

--- a/test/test_loggers.py
+++ b/test/test_loggers.py
@@ -24,6 +24,7 @@ from torchrl.data import LazyTensorStorage, ReplayBuffer
 from torchrl.envs import check_env_specs, GymEnv, ParallelEnv
 from torchrl.record.loggers.common import _has_torchcodec, Logger
 from torchrl.record.loggers.csv import CSVLogger
+from torchrl.record.loggers.llm import PostTrainingLogger
 from torchrl.record.loggers.mlflow import _has_mlflow, MLFlowLogger
 from torchrl.record.loggers.monitoring import Every, LoggerMonitor
 from torchrl.record.loggers.process import ProcessLogger
@@ -1531,3 +1532,250 @@ class TestLoggerMonitor:
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)
+
+
+# ---------------------------------------------------------------------------
+# PostTrainingLogger tests
+# ---------------------------------------------------------------------------
+
+
+class TestPostTrainingLogger:
+    """Tests for torchrl.record.loggers.llm.PostTrainingLogger.
+
+    All tests use CSVLogger with a temporary directory so no external
+    services are required.  Loss output objects are constructed directly
+    with dummy tensors — no real model is needed.
+    """
+
+    @pytest.fixture()
+    def csv_logger(self, tmp_path):
+        """A fresh CSVLogger for each test."""
+        return CSVLogger(exp_name="pt_test", log_dir=str(tmp_path))
+
+    # --- log_training_step ---
+
+    def test_log_training_step_grpo_loss(self, csv_logger):
+        """Standard GRPO loss output with all optional fields set."""
+        from torchrl.objectives.llm.grpo import GRPOLossOutput
+
+        loss = GRPOLossOutput(
+            loss_objective=torch.tensor(0.42),
+            clip_fraction=torch.tensor(0.10),
+            kl_approx=torch.tensor(0.05),
+            ESS=torch.tensor(0.88),
+            entropy=torch.tensor(1.23),
+            loss_entropy=torch.tensor(-0.12),
+            loss_kl_to_ref=torch.tensor(0.03),
+            kl_to_ref=torch.tensor(0.04),
+            loss_kl_to_inference=torch.tensor(0.02),
+            kl_to_inference=torch.tensor(0.01),
+        )
+        pt = PostTrainingLogger(logger=csv_logger)
+        metrics = pt.log_training_step(loss=loss, step=10, grad_norm=1.5)
+
+        assert "training/loss_objective" in metrics
+        assert abs(metrics["training/loss_objective"] - 0.42) < 1e-5
+        assert "training/ESS" in metrics
+        assert "training/entropy" in metrics
+        assert "training/kl_to_ref" in metrics
+        assert "training/grad_norm" in metrics
+        assert metrics["training/gradient_steps"] == 10
+        assert metrics["training/optim_steps"] == 10  # accumulation=1
+        # SFT-only field must NOT appear
+        assert "training/loss_sft" not in metrics
+
+    def test_log_training_step_sft_loss(self, csv_logger):
+        """SFTLossOutput with all optional fields set."""
+        from torchrl.objectives.llm.sft import SFTLossOutput
+
+        loss = SFTLossOutput(
+            loss_sft=torch.tensor(0.77),
+            loss_kl_to_ref=torch.tensor(0.02),
+            kl_to_ref=torch.tensor(0.03),
+        )
+        pt = PostTrainingLogger(logger=csv_logger)
+        metrics = pt.log_training_step(loss=loss, step=5)
+
+        assert "training/loss_sft" in metrics
+        assert abs(metrics["training/loss_sft"] - 0.77) < 1e-5
+        assert "training/loss_kl_to_ref" in metrics
+        assert "training/kl_to_ref" in metrics
+        # GRPO-only fields must NOT appear
+        assert "training/loss_objective" not in metrics
+        assert "training/clip_fraction" not in metrics
+
+    def test_log_training_step_sft_loss_no_kl(self, csv_logger):
+        """SFTLossOutput with only the required field — None fields skipped."""
+        from torchrl.objectives.llm.sft import SFTLossOutput
+
+        loss = SFTLossOutput(loss_sft=torch.tensor(0.5))
+        pt = PostTrainingLogger(logger=csv_logger)
+        metrics = pt.log_training_step(loss=loss, step=1)
+
+        assert "training/loss_sft" in metrics
+        # Optional None fields must be absent, not zero
+        assert "training/kl_to_ref" not in metrics
+        assert "training/loss_kl_to_ref" not in metrics
+
+    def test_log_training_step_grpo_none_optionals(self, csv_logger):
+        """GRPOLossOutput with optional fields left as None — must not appear."""
+        from torchrl.objectives.llm.grpo import GRPOLossOutput
+
+        loss = GRPOLossOutput(
+            loss_objective=torch.tensor(0.42),
+            clip_fraction=torch.tensor(0.10),
+            kl_approx=torch.tensor(0.05),
+            ESS=torch.tensor(0.88),
+            # entropy, loss_entropy, kl_to_ref, etc. remain None
+        )
+        pt = PostTrainingLogger(logger=csv_logger)
+        metrics = pt.log_training_step(loss=loss, step=1)
+
+        assert "training/loss_objective" in metrics
+        assert "training/entropy" not in metrics
+        assert "training/loss_entropy" not in metrics
+        assert "training/kl_to_ref" not in metrics
+
+    def test_log_training_step_custom_duck_type(self, csv_logger):
+        """Arbitrary object exposing only loss_sft — duck-typing must not crash."""
+        from types import SimpleNamespace
+
+        loss = SimpleNamespace(loss_sft=torch.tensor(0.5))
+        pt = PostTrainingLogger(logger=csv_logger)
+        metrics = pt.log_training_step(loss=loss, step=1)
+
+        assert "training/loss_sft" in metrics
+        # All other fields absent (SimpleNamespace has no other attrs)
+        assert "training/loss_objective" not in metrics
+
+    def test_log_training_step_gradient_accumulation(self, csv_logger):
+        """grad_norm is 0.0 on accumulation steps, real value on optimizer steps."""
+        from torchrl.objectives.llm.sft import SFTLossOutput
+
+        loss = SFTLossOutput(loss_sft=torch.tensor(0.5))
+        pt = PostTrainingLogger(logger=csv_logger)
+
+        # step=3, accumulation=4: not an optimizer step -> grad_norm = 0.0
+        m = pt.log_training_step(
+            loss=loss, step=3, grad_norm=1.0, gradient_accumulation_steps=4
+        )
+        assert m["training/grad_norm"] == 0.0
+        assert m["training/optim_steps"] == 0
+
+        # step=4, accumulation=4: optimizer step -> grad_norm = 1.0
+        m = pt.log_training_step(
+            loss=loss, step=4, grad_norm=1.0, gradient_accumulation_steps=4
+        )
+        assert m["training/grad_norm"] == 1.0
+        assert m["training/optim_steps"] == 1
+
+    # --- log_collection_step ---
+
+    def test_log_collection_step_minimal(self, csv_logger):
+        """Minimal call: only batch and step.  Must not crash."""
+        from tensordict import lazy_stack, set_list_to_stack, TensorDict
+
+        with set_list_to_stack(True):
+            batch = lazy_stack(
+                [
+                    TensorDict(
+                        {"next": TensorDict({"reward": torch.tensor([1.0])}, [])}, []
+                    ),
+                    TensorDict(
+                        {"next": TensorDict({"reward": torch.tensor([2.0])}, [])}, []
+                    ),
+                ]
+            )
+            pt = PostTrainingLogger(logger=csv_logger)
+            metrics = pt.log_collection_step(batch, step=1)
+
+        assert "buffer/reward_mean" in metrics
+        assert abs(metrics["buffer/reward_mean"] - 1.5) < 1e-5
+        assert "buffer/reward_std" in metrics
+        assert "buffer/reward_min" in metrics
+        assert "buffer/reward_max" in metrics
+        # Optional metrics absent when not provided
+        assert "buffer/utilization" not in metrics
+        assert "inference/policy_version" not in metrics
+        assert "throughput/gradient_steps_per_second" not in metrics
+
+    def test_log_collection_step_with_buffer(self, csv_logger):
+        """With replay buffer: utilization and write_count emitted."""
+        from tensordict import lazy_stack, set_list_to_stack, TensorDict
+        from torchrl.data import LazyStackStorage, ReplayBuffer
+
+        with set_list_to_stack(True):
+            td = TensorDict(
+                {"next": TensorDict({"reward": torch.tensor([1.0])}, [])}, []
+            )
+            rb = ReplayBuffer(storage=LazyStackStorage(10))
+            rb.extend(lazy_stack([td, td, td]))
+            batch = rb[:]
+            pt = PostTrainingLogger(logger=csv_logger)
+            metrics = pt.log_collection_step(batch, replay_buffer=rb, step=1)
+
+        assert "buffer/write_count" in metrics
+        assert metrics["buffer/write_count"] == 3
+        assert "buffer/utilization" in metrics
+        assert abs(metrics["buffer/utilization"] - 0.3) < 1e-5
+
+    def test_log_collection_step_throughput_omitted_without_start_time(
+        self, csv_logger
+    ):
+        """throughput/* must not appear when start_time=None."""
+        from tensordict import lazy_stack, set_list_to_stack, TensorDict
+
+        with set_list_to_stack(True):
+            batch = lazy_stack(
+                [
+                    TensorDict(
+                        {"next": TensorDict({"reward": torch.tensor([1.0])}, [])}, []
+                    ),
+                ]
+            )
+            pt = PostTrainingLogger(logger=csv_logger, start_time=None)
+            metrics = pt.log_collection_step(batch, step=100)
+
+        assert "throughput/gradient_steps_per_second" not in metrics
+
+    def test_log_collection_step_throughput_emitted_with_start_time(self, csv_logger):
+        """throughput/* emitted as a positive float when start_time is set."""
+        import time
+
+        from tensordict import lazy_stack, set_list_to_stack, TensorDict
+
+        with set_list_to_stack(True):
+            batch = lazy_stack(
+                [
+                    TensorDict(
+                        {"next": TensorDict({"reward": torch.tensor([1.0])}, [])}, []
+                    ),
+                ]
+            )
+            t0 = time.time() - 10  # pretend training started 10 seconds ago
+            pt = PostTrainingLogger(logger=csv_logger, start_time=t0)
+            metrics = pt.log_collection_step(batch, step=50)
+
+        assert "throughput/gradient_steps_per_second" in metrics
+        assert metrics["throughput/gradient_steps_per_second"] > 0
+
+    # --- log_weight_sync ---
+
+    def test_log_weight_sync(self, csv_logger):
+        pt = PostTrainingLogger(logger=csv_logger)
+        metrics = pt.log_weight_sync(latency_s=0.042, step=100)
+        assert metrics == {"weight_sync/latency_s": 0.042}
+
+    def test_log_weight_sync_no_step(self, csv_logger):
+        """Calling without step must not raise."""
+        pt = PostTrainingLogger(logger=csv_logger)
+        metrics = pt.log_weight_sync(latency_s=0.1)
+        assert "weight_sync/latency_s" in metrics
+
+    # --- Export / import ---
+
+    def test_importable_from_package(self):
+        """PostTrainingLogger must be importable from the top-level package."""
+        from torchrl.record.loggers import PostTrainingLogger as PTL
+
+        assert PTL is PostTrainingLogger

--- a/torchrl/record/loggers/__init__.py
+++ b/torchrl/record/loggers/__init__.py
@@ -6,6 +6,7 @@
 from .common import Logger
 
 from .csv import CSVLogger
+from .llm import PostTrainingLogger
 from .mlflow import MLFlowLogger
 from .monitoring import Every, LoggerMonitor
 from .process import ProcessLogger
@@ -20,6 +21,7 @@ __all__ = [
     "LoggerMonitor",
     "Every",
     "ProcessLogger",
+    "PostTrainingLogger",
     "RayLogger",
     "CSVLogger",
     "MLFlowLogger",

--- a/torchrl/record/loggers/llm.py
+++ b/torchrl/record/loggers/llm.py
@@ -1,0 +1,220 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import time
+from typing import Any, TYPE_CHECKING
+
+import torch
+from tensordict import TensorDictBase
+
+from torchrl._utils import logger as torchrl_logger
+from torchrl.record.loggers.common import Logger
+
+if TYPE_CHECKING:
+    from torchrl.collectors.llm import LLMCollector
+    from torchrl.data.replay_buffers import ReplayBuffer
+    from torchrl.objectives.llm.grpo import LLMLossOutput
+    from torchrl.objectives.llm.sft import SFTLossOutput
+
+
+__all__ = ["PostTrainingLogger"]
+
+# Fields inspected via duck-typing. GRPOLossOutput and SFTLossOutput each
+# expose a subset; absent or None fields are silently skipped.
+_LOSS_FIELDS: tuple[str, ...] = (
+    "loss_objective",
+    "loss_sft",
+    "clip_fraction",
+    "kl_approx",
+    "ESS",
+    "entropy",
+    "loss_entropy",
+    "loss_kl_to_ref",
+    "kl_to_ref",
+    "loss_kl_to_inference",
+    "kl_to_inference",
+)
+
+
+class PostTrainingLogger:
+    """Standardized logger for LLM post-training metrics.
+
+    Loss fields are read via ``getattr`` duck-typing, so this class works
+    with :class:`~torchrl.objectives.llm.GRPOLossOutput` and
+    :class:`~torchrl.objectives.llm.SFTLossOutput`. Fields that are absent
+    or ``None`` are silently skipped.
+
+    Args:
+        logger (Logger): Backend logger to emit to.
+        start_time (float, optional): ``time.time()`` value captured at the
+            start of training for throughput computation.
+    """
+
+    def __init__(
+        self,
+        logger: Logger,
+        start_time: float | None = None,
+    ) -> None:
+        self._logger = logger
+        self._start_time = start_time
+
+    def log_training_step(
+        self,
+        loss: LLMLossOutput | SFTLossOutput,
+        step: int,
+        *,
+        grad_norm: float | None = None,
+        gradient_accumulation_steps: int = 1,
+    ) -> dict[str, Any]:
+        """Log loss components and optimizer state for one gradient step.
+
+        Metric keys follow the ``training/<field>`` convention.
+
+        Args:
+            loss (LLMLossOutput | SFTLossOutput): Loss output object.
+            step (int): Current global gradient-step counter.
+
+        Keyword Args:
+            grad_norm (float, optional): Gradient norm after clipping.
+            gradient_accumulation_steps (int): Number of gradient steps per optimizer step.
+
+        Returns:
+            dict[str, Any]: The metrics dict that was logged.
+        """
+        metrics: dict[str, Any] = {}
+
+        for field in _LOSS_FIELDS:
+            val = getattr(loss, field, None)
+            if val is not None:
+                scalar = val.mean() if isinstance(val, torch.Tensor) else val
+                metrics[f"training/{field}"] = float(scalar)
+
+        if grad_norm is not None:
+            emit_val = (
+                float(grad_norm) if step % gradient_accumulation_steps == 0 else 0.0
+            )
+            metrics["training/grad_norm"] = emit_val
+
+        metrics["training/gradient_steps"] = step
+        metrics["training/optim_steps"] = step // gradient_accumulation_steps
+
+        self._logger.log_metrics(metrics, step=step)
+        torchrl_logger.debug(f"PostTrainingLogger.log_training_step: {list(metrics)}")
+        return metrics
+
+    def log_collection_step(
+        self,
+        batch: TensorDictBase,
+        *,
+        replay_buffer: ReplayBuffer | None = None,
+        collector: LLMCollector | None = None,
+        step: int | None = None,
+    ) -> dict[str, Any]:
+        """Log reward stats, buffer utilization, and policy staleness.
+
+        Args:
+            batch (TensorDictBase): The batch sampled from the replay buffer.
+
+        Keyword Args:
+            replay_buffer (ReplayBuffer, optional): The active replay buffer.
+            collector (LLMCollector, optional): The active collector.
+            step (int, optional): Global gradient-step counter.
+
+        Returns:
+            dict[str, Any]: The metrics dict that was logged.
+        """
+        metrics: dict[str, Any] = {}
+
+        with torch.no_grad():
+            try:
+                reward_list = batch.get(("next", "reward"), default=None, as_list=True)
+                if reward_list is not None:
+                    reward_tensor = torch.cat(reward_list).float()
+                    metrics["buffer/reward_mean"] = float(reward_tensor.mean())
+                    metrics["buffer/reward_std"] = float(reward_tensor.std())
+                    metrics["buffer/reward_min"] = float(reward_tensor.min())
+                    metrics["buffer/reward_max"] = float(reward_tensor.max())
+            except Exception as exc:  # noqa: BLE001
+                torchrl_logger.debug(
+                    f"PostTrainingLogger: could not read reward from batch: {exc}"
+                )
+
+            try:
+                response_list = batch.get(
+                    ("tokens", "response"), default=None, as_list=True
+                )
+                if response_list is not None:
+                    lengths = torch.tensor(
+                        [t.numel() for t in response_list], dtype=torch.float
+                    )
+                    metrics["buffer/seq_length_mean"] = float(lengths.mean())
+            except Exception as exc:  # noqa: BLE001
+                torchrl_logger.debug(
+                    f"PostTrainingLogger: could not read response tokens: {exc}"
+                )
+
+            if replay_buffer is not None:
+                try:
+                    metrics["buffer/write_count"] = int(replay_buffer.write_count)
+                    # _storage is private; max_size is a public plain attribute on Storage.
+                    storage = replay_buffer._storage  # noqa: SLF001
+                    if hasattr(storage, "max_size") and storage.max_size > 0:
+                        metrics["buffer/utilization"] = (
+                            len(replay_buffer) / storage.max_size
+                        )
+                except Exception as exc:  # noqa: BLE001
+                    torchrl_logger.debug(
+                        f"PostTrainingLogger: could not read replay buffer stats: {exc}"
+                    )
+
+            if collector is not None and hasattr(collector, "policy_version"):
+                try:
+                    current_version = int(collector.policy_version)
+                    metrics["inference/policy_version"] = current_version
+
+                    version_list = batch.get(
+                        ("next", "policy_version"), default=None, as_list=True
+                    )
+                    if version_list is not None:
+                        versions = torch.stack(version_list).float()
+                        staleness = current_version - versions
+                        metrics["inference/staleness_mean"] = float(staleness.mean())
+                        metrics["inference/staleness_max"] = float(staleness.max())
+                except Exception as exc:  # noqa: BLE001
+                    torchrl_logger.debug(
+                        f"PostTrainingLogger: could not compute staleness: {exc}"
+                    )
+
+            if self._start_time is not None and step is not None:
+                elapsed = time.time() - self._start_time
+                if elapsed > 0:
+                    metrics["throughput/gradient_steps_per_second"] = float(
+                        step / elapsed
+                    )
+
+        if metrics:
+            self._logger.log_metrics(metrics, step=step)
+        torchrl_logger.debug(f"PostTrainingLogger.log_collection_step: {list(metrics)}")
+        return metrics
+
+    def log_weight_sync(
+        self,
+        latency_s: float,
+        step: int | None = None,
+    ) -> dict[str, Any]:
+        """Log weight synchronization latency.
+
+        Args:
+            latency_s (float): Time in seconds taken for the weight synchronization.
+            step (int, optional): Global gradient-step counter.
+
+        Returns:
+            dict[str, Any]: The metrics dict that was logged.
+        """
+        metrics: dict[str, Any] = {"weight_sync/latency_s": float(latency_s)}
+        self._logger.log_metrics(metrics, step=step)
+        torchrl_logger.debug(f"PostTrainingLogger.log_weight_sync: {metrics}")
+        return metrics

--- a/torchrl/record/loggers/llm.py
+++ b/torchrl/record/loggers/llm.py
@@ -22,35 +22,34 @@ if TYPE_CHECKING:
 
 __all__ = ["PostTrainingLogger"]
 
-# Fields inspected via duck-typing. GRPOLossOutput and SFTLossOutput each
-# expose a subset; absent or None fields are silently skipped.
-_LOSS_FIELDS: tuple[str, ...] = (
-    "loss_objective",
-    "loss_sft",
-    "clip_fraction",
-    "kl_approx",
-    "ESS",
-    "entropy",
-    "loss_entropy",
-    "loss_kl_to_ref",
-    "kl_to_ref",
-    "loss_kl_to_inference",
-    "kl_to_inference",
-)
-
 
 class PostTrainingLogger:
     """Standardized logger for LLM post-training metrics.
 
-    Loss fields are read via ``getattr`` duck-typing, so this class works
-    with :class:`~torchrl.objectives.llm.GRPOLossOutput` and
-    :class:`~torchrl.objectives.llm.SFTLossOutput`. Fields that are absent
-    or ``None`` are silently skipped.
+    Loss outputs are :class:`~tensordict.TensorClass` instances
+    (:class:`~torchrl.objectives.llm.GRPOLossOutput`,
+    :class:`~torchrl.objectives.llm.SFTLossOutput`, ...), so their populated
+    tensor fields are discovered by iterating the tensorclass rather than
+    through a hardcoded field list: a new loss term added to a loss output is
+    logged automatically.
 
     Args:
         logger (Logger): Backend logger to emit to.
         start_time (float, optional): ``time.time()`` value captured at the
-            start of training for throughput computation.
+            start of training for throughput computation. (A wall-clock
+            timestamp rather than :func:`torchrl.timeit`, which measures code
+            blocks, not an anchor shared with the caller's loop.)
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.objectives.llm.sft import SFTLossOutput
+        >>> from torchrl.record.loggers import CSVLogger, PostTrainingLogger
+        >>> logger = PostTrainingLogger(CSVLogger("my_exp"))
+        >>> metrics = logger.log_training_step(
+        ...     SFTLossOutput(loss_sft=torch.tensor(0.5)), step=1, grad_norm=1.2
+        ... )
+        >>> sorted(metrics)
+        ['training/grad_norm', 'training/gradient_steps', 'training/loss_sft', 'training/optim_steps']
     """
 
     def __init__(
@@ -60,6 +59,19 @@ class PostTrainingLogger:
     ) -> None:
         self._logger = logger
         self._start_time = start_time
+        self._warned_sites: set[str] = set()
+
+    def _warn_once(self, site: str, exc: Exception) -> None:
+        # An observability component that silently emits nothing is worse than
+        # one that raises: surface the first failure per site at WARNING level,
+        # then stay quiet so a structural mismatch does not flood the logs.
+        if site not in self._warned_sites:
+            self._warned_sites.add(site)
+            torchrl_logger.warning(
+                f"PostTrainingLogger: could not compute {site!r} metrics and "
+                f"will not retry the warning ({type(exc).__name__}: {exc}). "
+                "The corresponding keys are missing from the logged metrics."
+            )
 
     def log_training_step(
         self,
@@ -86,17 +98,21 @@ class PostTrainingLogger:
         """
         metrics: dict[str, Any] = {}
 
-        for field in _LOSS_FIELDS:
-            val = getattr(loss, field, None)
-            if val is not None:
-                scalar = val.mean() if isinstance(val, torch.Tensor) else val
-                metrics[f"training/{field}"] = float(scalar)
+        # TensorClass iteration only yields populated fields, so every loss
+        # term and diagnostic the loss output carries is logged, including
+        # fields added after this logger was written. Plain objects (duck
+        # typing) fall back to their attribute dict.
+        fields = loss.items() if hasattr(loss, "items") else vars(loss).items()
+        for field, val in fields:
+            if val is None:
+                continue
+            scalar = val.mean() if isinstance(val, torch.Tensor) else val
+            metrics[f"training/{field}"] = float(scalar)
 
-        if grad_norm is not None:
-            emit_val = (
-                float(grad_norm) if step % gradient_accumulation_steps == 0 else 0.0
-            )
-            metrics["training/grad_norm"] = emit_val
+        # Only emitted on actual optimizer steps: logging a literal 0.0 on
+        # accumulation steps would pollute every aggregate over the series.
+        if grad_norm is not None and step % gradient_accumulation_steps == 0:
+            metrics["training/grad_norm"] = float(grad_norm)
 
         metrics["training/gradient_steps"] = step
         metrics["training/optim_steps"] = step // gradient_accumulation_steps
@@ -132,29 +148,35 @@ class PostTrainingLogger:
             try:
                 reward_list = batch.get(("next", "reward"), default=None, as_list=True)
                 if reward_list is not None:
-                    reward_tensor = torch.cat(reward_list).float()
+                    # as_list=True returns a plain tensor when the batch is
+                    # dense (padded) rather than ragged.
+                    if isinstance(reward_list, torch.Tensor):
+                        reward_tensor = reward_list.reshape(-1).float()
+                    else:
+                        reward_tensor = torch.cat(reward_list).float()
                     metrics["batch/reward_mean"] = float(reward_tensor.mean())
-                    metrics["batch/reward_std"] = float(reward_tensor.std())
+                    if reward_tensor.numel() > 1:
+                        # std of a single element is NaN
+                        metrics["batch/reward_std"] = float(reward_tensor.std())
                     metrics["batch/reward_min"] = float(reward_tensor.min())
                     metrics["batch/reward_max"] = float(reward_tensor.max())
-            except Exception as exc:  # noqa: BLE001
-                torchrl_logger.debug(
-                    f"PostTrainingLogger: could not read reward from batch: {exc}"
-                )
+            except (AttributeError, KeyError, RuntimeError, TypeError) as exc:
+                self._warn_once("batch/reward", exc)
 
             try:
                 response_list = batch.get(
                     ("tokens", "response"), default=None, as_list=True
                 )
-                if response_list is not None:
+                if isinstance(response_list, torch.Tensor):
+                    # dense (padded) batch: one row per sequence
+                    metrics["batch/seq_length_mean"] = float(response_list.shape[-1])
+                elif response_list is not None:
                     lengths = torch.tensor(
                         [t.numel() for t in response_list], dtype=torch.float
                     )
                     metrics["batch/seq_length_mean"] = float(lengths.mean())
-            except Exception as exc:  # noqa: BLE001
-                torchrl_logger.debug(
-                    f"PostTrainingLogger: could not read response tokens: {exc}"
-                )
+            except (AttributeError, KeyError, RuntimeError, TypeError) as exc:
+                self._warn_once("batch/seq_length", exc)
 
             if replay_buffer is not None:
                 try:
@@ -169,10 +191,8 @@ class PostTrainingLogger:
                         metrics["buffer/utilization"] = (
                             len(replay_buffer) / storage.max_size
                         )
-                except Exception as exc:  # noqa: BLE001
-                    torchrl_logger.debug(
-                        f"PostTrainingLogger: could not read replay buffer stats: {exc}"
-                    )
+                except (AttributeError, RuntimeError, TypeError) as exc:
+                    self._warn_once("buffer", exc)
 
             if collector is not None and hasattr(collector, "policy_version"):
                 try:
@@ -182,15 +202,18 @@ class PostTrainingLogger:
                     version_list = batch.get(
                         ("next", "policy_version"), default=None, as_list=True
                     )
-                    if version_list is not None:
+                    if isinstance(version_list, torch.Tensor):
+                        versions = version_list.float()
+                    elif version_list is not None:
                         versions = torch.stack(version_list).float()
+                    else:
+                        versions = None
+                    if versions is not None:
                         staleness = current_version - versions
                         metrics["inference/staleness_mean"] = float(staleness.mean())
                         metrics["inference/staleness_max"] = float(staleness.max())
-                except Exception as exc:  # noqa: BLE001
-                    torchrl_logger.debug(
-                        f"PostTrainingLogger: could not compute staleness: {exc}"
-                    )
+                except (AttributeError, KeyError, RuntimeError, TypeError) as exc:
+                    self._warn_once("inference/staleness", exc)
 
             if self._start_time is not None and step is not None:
                 elapsed = time.time() - self._start_time

--- a/torchrl/record/loggers/llm.py
+++ b/torchrl/record/loggers/llm.py
@@ -168,8 +168,23 @@ class PostTrainingLogger:
                     ("tokens", "response"), default=None, as_list=True
                 )
                 if isinstance(response_list, torch.Tensor):
-                    # dense (padded) batch: one row per sequence
-                    metrics["batch/seq_length_mean"] = float(response_list.shape[-1])
+                    # Dense response tensors may be padded, so their trailing
+                    # dimension is not a sequence length. The assistant mask
+                    # is the only reliable source of the unpadded lengths.
+                    assistant_mask = batch.get(
+                        ("masks", "all_assistant_mask"),
+                        default=None,
+                        as_list=True,
+                    )
+                    if assistant_mask is not None:
+                        if isinstance(assistant_mask, torch.Tensor):
+                            lengths = assistant_mask.bool().sum(-1).float().reshape(-1)
+                        else:
+                            lengths = torch.tensor(
+                                [mask.bool().sum().item() for mask in assistant_mask],
+                                dtype=torch.float,
+                            )
+                        metrics["batch/seq_length_mean"] = float(lengths.mean())
                 elif response_list is not None:
                     lengths = torch.tensor(
                         [t.numel() for t in response_list], dtype=torch.float
@@ -180,16 +195,12 @@ class PostTrainingLogger:
 
             if replay_buffer is not None:
                 try:
-                    metrics["buffer/write_count"] = int(replay_buffer.write_count)
-                    # RayReplayBuffer has no _storage; guard with getattr.
-                    storage = getattr(replay_buffer, "_storage", None)  # noqa: SLF001
-                    if (
-                        storage is not None
-                        and hasattr(storage, "max_size")
-                        and storage.max_size > 0
-                    ):
-                        metrics["buffer/utilization"] = (
-                            len(replay_buffer) / storage.max_size
+                    buffer_stats = replay_buffer.stats()
+                    if "write_count" in buffer_stats:
+                        metrics["buffer/write_count"] = int(buffer_stats["write_count"])
+                    if "utilization" in buffer_stats:
+                        metrics["buffer/utilization"] = float(
+                            buffer_stats["utilization"]
                         )
                 except (AttributeError, RuntimeError, TypeError) as exc:
                     self._warn_once("buffer", exc)
@@ -210,8 +221,8 @@ class PostTrainingLogger:
                         versions = None
                     if versions is not None:
                         staleness = current_version - versions
-                        metrics["inference/staleness_mean"] = float(staleness.mean())
-                        metrics["inference/staleness_max"] = float(staleness.max())
+                        metrics["batch/staleness_mean"] = float(staleness.mean())
+                        metrics["batch/staleness_max"] = float(staleness.max())
                 except (AttributeError, KeyError, RuntimeError, TypeError) as exc:
                     self._warn_once("inference/staleness", exc)
 

--- a/torchrl/record/loggers/llm.py
+++ b/torchrl/record/loggers/llm.py
@@ -133,10 +133,10 @@ class PostTrainingLogger:
                 reward_list = batch.get(("next", "reward"), default=None, as_list=True)
                 if reward_list is not None:
                     reward_tensor = torch.cat(reward_list).float()
-                    metrics["buffer/reward_mean"] = float(reward_tensor.mean())
-                    metrics["buffer/reward_std"] = float(reward_tensor.std())
-                    metrics["buffer/reward_min"] = float(reward_tensor.min())
-                    metrics["buffer/reward_max"] = float(reward_tensor.max())
+                    metrics["batch/reward_mean"] = float(reward_tensor.mean())
+                    metrics["batch/reward_std"] = float(reward_tensor.std())
+                    metrics["batch/reward_min"] = float(reward_tensor.min())
+                    metrics["batch/reward_max"] = float(reward_tensor.max())
             except Exception as exc:  # noqa: BLE001
                 torchrl_logger.debug(
                     f"PostTrainingLogger: could not read reward from batch: {exc}"
@@ -150,7 +150,7 @@ class PostTrainingLogger:
                     lengths = torch.tensor(
                         [t.numel() for t in response_list], dtype=torch.float
                     )
-                    metrics["buffer/seq_length_mean"] = float(lengths.mean())
+                    metrics["batch/seq_length_mean"] = float(lengths.mean())
             except Exception as exc:  # noqa: BLE001
                 torchrl_logger.debug(
                     f"PostTrainingLogger: could not read response tokens: {exc}"
@@ -159,9 +159,13 @@ class PostTrainingLogger:
             if replay_buffer is not None:
                 try:
                     metrics["buffer/write_count"] = int(replay_buffer.write_count)
-                    # _storage is private; max_size is a public plain attribute on Storage.
-                    storage = replay_buffer._storage  # noqa: SLF001
-                    if hasattr(storage, "max_size") and storage.max_size > 0:
+                    # RayReplayBuffer has no _storage; guard with getattr.
+                    storage = getattr(replay_buffer, "_storage", None)  # noqa: SLF001
+                    if (
+                        storage is not None
+                        and hasattr(storage, "max_size")
+                        and storage.max_size > 0
+                    ):
                         metrics["buffer/utilization"] = (
                             len(replay_buffer) / storage.max_size
                         )


### PR DESCRIPTION
## Description

This PR implements the Observability workstream (WS4) from RFC #3948. It introduces a modular `PostTrainingLogger` that unifies metric emission across TorchRL's post-training algorithms, making the observability stack consumable by external training loops.

**Key Changes:**
* **`PostTrainingLogger`**: New backend-agnostic logger for tracking loss components, buffer utilization, and inference staleness. Uses `getattr` duck-typing to safely ingest both `GRPOLossOutput` and `SFTLossOutput`.
* **Recipe Refactoring**: Updated GRPO and Expert Iteration (EI) recipes to delegate to the new logger. 
* **Deprecation Handling**: EI legacy metric keys are temporarily emitted in parallel with explicit `DeprecationWarning`s (targeted for removal in `v0.15.0` per `CLAUDE.md`).
* **Docs & Tests**: Added full Sphinx documentation and comprehensive unit testing in `test_loggers.py`.

## Motivation and Context

Solves the need for component-level interoperability in TorchRL's LLM stack. Users can now drop this logger into their own existing loops without migrating their entire workflow. 

close #3948

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [ ] New feature (non-breaking change which adds core functionality)
- [x] Documentation (update in the documentation)
- [x] Example (update in the folder of examples)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
