### PR TITLE
[CI] Add CI timing tracker workflow and gh-pages dashboard

### DIFF
--- a/.github/scripts/ci_timing_dashboard.html
+++ b/.github/scripts/ci_timing_dashboard.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TorchRL CI timing dashboard</title>
+<style>
+:root {
+  --paper:#f7f8f6; --card:#ffffff; --ink:#1d2733; --mut:#5c6b78;
+  --line:#dfe4e0; --acc:#2b6cb0; --red:#bf4433; --redbg:#faf0ee;
+}
+html { background:var(--paper); }
+body { color:var(--ink); font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+  max-width:1080px; margin:0 auto; padding:36px 24px 80px; }
+.mono { font-family:ui-monospace,"SF Mono",Menlo,monospace; font-variant-numeric:tabular-nums; }
+header { border-bottom:2px solid var(--ink); padding-bottom:14px; margin-bottom:20px;
+  display:flex; justify-content:space-between; align-items:baseline; flex-wrap:wrap; gap:8px; }
+h1 { font-size:24px; margin:0; letter-spacing:-0.01em; }
+.sub { color:var(--mut); font-size:13px; }
+.controls { display:flex; gap:14px; align-items:center; font-size:13px; color:var(--mut); margin-bottom:14px; }
+.controls label { display:flex; gap:5px; align-items:center; cursor:pointer; }
+table { border-collapse:collapse; width:100%; font-size:13.5px; margin:8px 0 28px; }
+th { text-align:left; font-size:11px; text-transform:uppercase; letter-spacing:0.06em; color:var(--mut);
+  font-weight:600; padding:6px 10px; border-bottom:1px solid var(--ink); }
+th.num, td.num { text-align:right; font-family:ui-monospace,Menlo,monospace; font-variant-numeric:tabular-nums; }
+td { padding:6px 10px; border-bottom:1px solid var(--line); }
+td.up { color:var(--red); font-weight:600; }
+td.down { color:#2f7d4f; font-weight:600; }
+.chip { background:var(--redbg); color:var(--red); font-size:10.5px; font-weight:600;
+  padding:2px 7px; border-radius:9px; white-space:nowrap; }
+.grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(320px,1fr)); gap:14px; }
+figure { margin:0; background:var(--card); border:1px solid var(--line); border-radius:4px; padding:10px 12px 6px; }
+figure.warn { border-top:3px solid var(--red); }
+figcaption { display:flex; justify-content:space-between; font-size:12.5px; font-weight:600; margin-bottom:4px; }
+figcaption .mono { color:var(--mut); font-weight:400; }
+svg { display:block; width:100%; height:auto; }
+.ax { font-size:9.5px; fill:#8a97a3; }
+.axb { font-size:10.5px; font-weight:700; fill:var(--acc); }
+.note { font-size:12.5px; color:var(--mut); margin-top:26px; }
+a { color:var(--acc); }
+#status { color:var(--mut); font-size:14px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>TorchRL CI timing</h1>
+  <div class="sub">Wall-clock duration of workflow runs on <span class="mono">main</span>
+    &middot; updated <span id="updated" class="mono">&hellip;</span></div>
+</header>
+
+<div class="controls">
+  <label><input type="checkbox" id="showRuns" checked> individual runs (last 120 days)</label>
+  <span>line = weekly median of successful runs &middot; dashed line = 30 min</span>
+</div>
+
+<p id="status">Loading data.json&hellip;</p>
+<table id="summary" hidden>
+  <thead>
+    <tr><th>Workflow</th><th class="num">Latest week (min)</th><th class="num">8 weeks ago</th>
+        <th class="num">Change</th><th></th></tr>
+  </thead>
+  <tbody></tbody>
+</table>
+<div class="grid" id="charts"></div>
+
+<p class="note">Duration is run start to completion of the last job; first attempts only; wheel builds
+not tracked. Data is refreshed daily by the <span class="mono">ci-timing-tracker</span> workflow.
+See also the <a href="../flaky/">flaky test dashboard</a>.</p>
+
+<script>
+"use strict";
+
+const THRESHOLD_MIN = 30;
+
+function weekToDate(wk) {
+  // "2026-W23" -> Date of that ISO week's Monday
+  const [y, w] = wk.split("-W").map(Number);
+  const jan4 = new Date(Date.UTC(y, 0, 4));
+  const monday = new Date(jan4);
+  monday.setUTCDate(jan4.getUTCDate() - ((jan4.getUTCDay() + 6) % 7) + (w - 1) * 7);
+  return monday;
+}
+
+function fmtMonth(d) {
+  return d.toLocaleDateString("en", { month: "short", timeZone: "UTC" });
+}
+
+function el(tag, attrs, text) {
+  const e = document.createElementNS("http://www.w3.org/2000/svg", tag);
+  for (const [k, v] of Object.entries(attrs)) e.setAttribute(k, v);
+  if (text !== undefined) e.textContent = text;
+  return e;
+}
+
+function renderChart(label, weekly, runs, showRuns) {
+  const W = 420, H = 150, PAD_L = 30, PAD_R = 10, PAD_T = 8, PAD_B = 18;
+  const weeks = Object.keys(weekly).sort();
+  if (!weeks.length) return null;
+
+  const pts = weeks.map(wk => ({ t: weekToDate(wk).getTime(), v: weekly[wk].median }));
+  const runPts = (runs || []).filter(r => r.ok)
+    .map(r => ({ t: new Date(r.date).getTime(), v: r.dur }));
+
+  const t0 = pts[0].t, t1 = Math.max(pts[pts.length - 1].t, Date.now());
+  const allV = pts.map(p => p.v).concat(showRuns ? runPts.map(p => p.v) : []);
+  const vmax = Math.max(Math.max(...allV), THRESHOLD_MIN + 5) * 1.12;
+
+  const X = t => PAD_L + (t - t0) / (t1 - t0 || 1) * (W - PAD_L - PAD_R);
+  const Y = v => (H - PAD_B) - v / vmax * (H - PAD_T - PAD_B);
+
+  const svg = el("svg", { viewBox: `0 0 ${W} ${H}`, role: "img" });
+
+  for (const gv of [0, vmax / 2 / 1.12, vmax / 1.12]) {
+    svg.append(el("line", { x1: PAD_L, y1: Y(gv), x2: W - PAD_R, y2: Y(gv),
+      stroke: "#e5e9e4", "stroke-width": 1 }));
+    svg.append(el("text", { x: PAD_L - 4, y: Y(gv) + 3, "text-anchor": "end",
+      class: "ax" }, gv.toFixed(0)));
+  }
+
+  // month ticks
+  const start = new Date(t0);
+  for (let d = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + 1, 1));
+       d.getTime() < t1; d.setUTCMonth(d.getUTCMonth() + 1)) {
+    svg.append(el("text", { x: X(d.getTime()), y: H - 4, "text-anchor": "middle",
+      class: "ax" }, fmtMonth(d)));
+  }
+
+  svg.append(el("line", { x1: PAD_L, y1: Y(THRESHOLD_MIN), x2: W - PAD_R, y2: Y(THRESHOLD_MIN),
+    stroke: "#bf4433", "stroke-width": 1, "stroke-dasharray": "3 3", opacity: 0.65 }));
+
+  if (showRuns) {
+    for (const p of runPts) {
+      svg.append(el("circle", { cx: X(p.t), cy: Y(p.v), r: 1.6, fill: "#2b6cb0", opacity: 0.25 }));
+    }
+  }
+
+  const path = pts.map((p, i) => `${i ? "L" : "M"}${X(p.t).toFixed(1)},${Y(p.v).toFixed(1)}`).join(" ");
+  const area = path + ` L${X(pts[pts.length - 1].t).toFixed(1)},${Y(0).toFixed(1)}` +
+               ` L${X(pts[0].t).toFixed(1)},${Y(0).toFixed(1)} Z`;
+  svg.append(el("path", { d: area, fill: "#2b6cb0", opacity: 0.07 }));
+  svg.append(el("path", { d: path, fill: "none", stroke: "#2b6cb0",
+    "stroke-width": 1.8, "stroke-linejoin": "round" }));
+
+  const last = pts[pts.length - 1];
+  svg.append(el("circle", { cx: X(last.t), cy: Y(last.v), r: 3, fill: "#2b6cb0" }));
+  svg.append(el("text", { x: X(last.t) - 6, y: Y(last.v) - 7, "text-anchor": "end",
+    class: "axb" }, `${last.v.toFixed(0)}m`));
+
+  const fig = document.createElement("figure");
+  if (last.v >= THRESHOLD_MIN) fig.classList.add("warn");
+  const cap = document.createElement("figcaption");
+  const name = document.createElement("span");
+  name.textContent = label;
+  const val = document.createElement("span");
+  val.className = "mono";
+  val.textContent = `${last.v.toFixed(0)} min`;
+  cap.append(name, val);
+  fig.append(cap, svg);
+  return { fig, latest: last.v };
+}
+
+function renderSummary(data) {
+  const tbody = document.querySelector("#summary tbody");
+  tbody.innerHTML = "";
+  const rows = [];
+  for (const [wf, label] of Object.entries(data.workflows)) {
+    const weekly = data.weekly[wf] || {};
+    const weeks = Object.keys(weekly).sort();
+    if (!weeks.length) continue;
+    const latest = weekly[weeks[weeks.length - 1]].median;
+    const refIdx = Math.max(0, weeks.length - 9);
+    const ref = weekly[weeks[refIdx]].median;
+    rows.push({ label, wf, latest, ref });
+  }
+  rows.sort((a, b) => b.latest - a.latest);
+  for (const r of rows) {
+    const tr = document.createElement("tr");
+    const delta = r.latest - r.ref;
+    const cls = delta > 3 ? "up" : delta < -3 ? "down" : "";
+    tr.innerHTML =
+      `<td>${r.label} <span class="mono" style="color:var(--mut);font-size:11px">${r.wf}</span></td>` +
+      `<td class="num">${r.latest.toFixed(0)}</td>` +
+      `<td class="num">${r.ref.toFixed(0)}</td>` +
+      `<td class="num ${cls}">${delta >= 0 ? "+" : ""}${delta.toFixed(0)}</td>` +
+      `<td>${r.latest >= THRESHOLD_MIN ? '<span class="chip">&gt;30 min</span>' : ""}</td>`;
+    tbody.append(tr);
+  }
+  document.getElementById("summary").hidden = false;
+}
+
+function renderAll(data) {
+  const charts = document.getElementById("charts");
+  charts.innerHTML = "";
+  const showRuns = document.getElementById("showRuns").checked;
+  const items = [];
+  for (const [wf, label] of Object.entries(data.workflows)) {
+    const out = renderChart(label, data.weekly[wf] || {}, data.runs[wf] || [], showRuns);
+    if (out) items.push(out);
+  }
+  items.sort((a, b) => b.latest - a.latest);
+  for (const it of items) charts.append(it.fig);
+}
+
+fetch("data.json")
+  .then(r => { if (!r.ok) throw new Error(`data.json: HTTP ${r.status}`); return r.json(); })
+  .then(data => {
+    document.getElementById("status").remove();
+    document.getElementById("updated").textContent = (data.updated_at || "").replace("T", " ");
+    renderSummary(data);
+    renderAll(data);
+    document.getElementById("showRuns").addEventListener("change", () => renderAll(data));
+  })
+  .catch(err => {
+    document.getElementById("status").textContent =
+      `Could not load data: ${err.message}. The tracker workflow may not have run yet.`;
+  });
+</script>
+</body>
+</html>

--- a/.github/scripts/track_ci_timing.py
+++ b/.github/scripts/track_ci_timing.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Track wall-clock duration of CI workflows over time.
+
+This script:
+1. Fetches recent workflow runs on main via the GitHub API
+2. Computes wall-clock duration per run (first attempts only)
+3. Merges them into a persistent history file (data.json on gh-pages)
+4. Recomputes weekly median durations
+
+Raw per-run records are retained for RUNS_RETENTION_DAYS; weekly medians
+are kept forever, so the history file stays small. Run with a large
+``--days`` value (e.g. 190) once to backfill.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import requests
+
+
+def log(msg: str = "") -> None:
+    """Print with flush to ensure output is visible even if the runner dies."""
+    print(msg, flush=True)
+
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+# Workflow file -> human-readable label shown on the dashboard.
+# Wheel builds are intentionally not tracked.
+TRACKED_WORKFLOWS: dict[str, str] = {
+    "test-linux.yml": "Unit tests (Linux)",
+    "docs.yml": "Doc build",
+    "test-linux-libs.yml": "Libs tests",
+    "test-windows-optdepts.yml": "Windows (optional deps)",
+    "benchmarks.yml": "Benchmarks",
+    "test-linux-sota.yml": "SOTA smoke tests",
+    "test-linux-habitat.yml": "Habitat",
+    "test-linux-llm.yml": "LLM tests",
+    "test-linux-tutorials.yml": "Tutorials tests",
+    "test-linux-mujoco.yml": "MuJoCo custom envs",
+    "lint.yml": "Lint",
+}
+
+# Days of raw per-run records kept in the history file.
+RUNS_RETENTION_DAYS = 120
+
+# Sanity bounds on a single run's wall-clock duration (minutes).
+MIN_DURATION_MIN = 0.5
+MAX_DURATION_MIN = 24 * 60
+
+
+# =============================================================================
+# GitHub API helpers
+# =============================================================================
+
+
+def get_github_token() -> str:
+    """Get GitHub token from environment."""
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        log("Error: GH_TOKEN or GITHUB_TOKEN environment variable required")
+        sys.exit(1)
+    return token
+
+
+def get_repo() -> str:
+    """Get repository from environment."""
+    return os.environ.get("GITHUB_REPOSITORY", "pytorch/rl")
+
+
+def _check_rate_limit(response: requests.Response) -> None:
+    """Sleep if we're close to hitting the GitHub API rate limit."""
+    remaining = response.headers.get("X-RateLimit-Remaining")
+    if remaining is not None and int(remaining) < 50:
+        reset_at = int(response.headers.get("X-RateLimit-Reset", 0))
+        wait = max(0, reset_at - int(time.time())) + 5
+        log(f"Rate limit low ({remaining} left), sleeping {wait}s")
+        time.sleep(wait)
+
+
+def fetch_workflow_runs(
+    session: requests.Session, repo: str, workflow_file: str, since: datetime
+) -> list[dict]:
+    """Fetch completed first-attempt runs on main for one workflow."""
+    runs: list[dict] = []
+    url = (
+        f"https://api.github.com/repos/{repo}/actions/workflows/"
+        f"{workflow_file}/runs"
+    )
+    params = {
+        "branch": "main",
+        "status": "completed",
+        "created": f">={since.strftime('%Y-%m-%d')}",
+        "per_page": 100,
+        "page": 1,
+    }
+    while True:
+        resp = session.get(url, params=params, timeout=60)
+        if resp.status_code == 404:
+            log(f"  {workflow_file}: not found (404), skipping")
+            return runs
+        resp.raise_for_status()
+        _check_rate_limit(resp)
+        page_runs = resp.json().get("workflow_runs", [])
+        runs.extend(page_runs)
+        if len(page_runs) < params["per_page"]:
+            return runs
+        params["page"] += 1
+
+
+def parse_ts(ts: str) -> datetime:
+    """Parse a GitHub API UTC timestamp."""
+    return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+
+
+def run_to_record(run: dict) -> dict | None:
+    """Convert an API run object to a compact history record, or None."""
+    if run.get("run_attempt", 1) != 1:
+        # Re-run attempts report misleading wall-clock durations.
+        return None
+    started, updated = run.get("run_started_at"), run.get("updated_at")
+    if not started or not updated:
+        return None
+    duration_min = (parse_ts(updated) - parse_ts(started)).total_seconds() / 60
+    if not MIN_DURATION_MIN <= duration_min <= MAX_DURATION_MIN:
+        return None
+    return {
+        "id": run["id"],
+        "date": started,
+        "dur": round(duration_min, 1),
+        "ok": run.get("conclusion") == "success",
+        "event": run.get("event", ""),
+    }
+
+
+# =============================================================================
+# History merge
+# =============================================================================
+
+
+def load_history(path: Path) -> dict:
+    """Load an existing history file, or return an empty skeleton."""
+    if path.is_file():
+        with open(path) as f:
+            return json.load(f)
+    return {"runs": {}, "weekly": {}}
+
+
+def week_key(dt: datetime) -> str:
+    """ISO week key, e.g. 2026-W23."""
+    iso = dt.isocalendar()
+    return f"{iso[0]}-W{iso[1]:02d}"
+
+
+def merge_history(history: dict, new_records: dict[str, list[dict]]) -> dict:
+    """Merge new run records into the history and refresh weekly medians."""
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=RUNS_RETENTION_DAYS)
+    runs: dict[str, list[dict]] = history.get("runs", {})
+    weekly: dict[str, dict[str, dict]] = history.get("weekly", {})
+
+    for wf, records in new_records.items():
+        by_id = {r["id"]: r for r in runs.get(wf, [])}
+        for rec in records:
+            by_id[rec["id"]] = rec
+        merged = sorted(by_id.values(), key=lambda r: r["date"])
+        # Refresh weekly medians for every week we still have raw runs for;
+        # weeks older than the retention window keep their stored value.
+        by_week: dict[str, list[float]] = {}
+        for rec in merged:
+            if rec["ok"]:
+                by_week.setdefault(week_key(parse_ts(rec["date"])), []).append(
+                    rec["dur"]
+                )
+        wf_weekly = weekly.setdefault(wf, {})
+        for wk, durations in by_week.items():
+            wf_weekly[wk] = {
+                "median": round(statistics.median(durations), 1),
+                "n": len(durations),
+            }
+        weekly[wf] = dict(sorted(wf_weekly.items()))
+        runs[wf] = [r for r in merged if parse_ts(r["date"]) >= cutoff]
+
+    return {
+        "updated_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "runs_retention_days": RUNS_RETENTION_DAYS,
+        "workflows": TRACKED_WORKFLOWS,
+        "runs": runs,
+        "weekly": weekly,
+    }
+
+
+# =============================================================================
+# Main
+# =============================================================================
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=4,
+        help="Lookback window in days (use ~190 to backfill history)",
+    )
+    parser.add_argument(
+        "--history",
+        type=Path,
+        default=None,
+        help="Existing data.json to merge into (e.g. gh-pages/ci-timing/data.json)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("ci-timing-out"),
+        help="Directory to write the merged data.json to",
+    )
+    args = parser.parse_args()
+
+    repo = get_repo()
+    session = requests.Session()
+    session.headers.update(
+        {
+            "Authorization": f"Bearer {get_github_token()}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+    )
+
+    since = datetime.now(timezone.utc) - timedelta(days=args.days)
+    log(f"Fetching runs on main since {since:%Y-%m-%d} for {repo}")
+
+    new_records: dict[str, list[dict]] = {}
+    for wf in TRACKED_WORKFLOWS:
+        api_runs = fetch_workflow_runs(session, repo, wf, since)
+        records = [rec for run in api_runs if (rec := run_to_record(run))]
+        new_records[wf] = records
+        log(f"  {wf}: {len(api_runs)} runs fetched, {len(records)} kept")
+
+    history = load_history(args.history) if args.history else {"runs": {}, "weekly": {}}
+    merged = merge_history(history, new_records)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = args.output_dir / "data.json"
+    with open(out_path, "w") as f:
+        json.dump(merged, f, separators=(",", ":"))
+    size_kb = out_path.stat().st_size / 1024
+    n_runs = sum(len(v) for v in merged["runs"].values())
+    n_weeks = sum(len(v) for v in merged["weekly"].values())
+    log(f"Wrote {out_path} ({size_kb:.0f} kB, {n_runs} runs, {n_weeks} week entries)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci-timing-tracker.yml
+++ b/.github/workflows/ci-timing-tracker.yml
@@ -52,7 +52,11 @@ jobs:
         with:
           ref: gh-pages
           path: gh-pages
-          fetch-depth: 1
+          # Depth 2 so the tip's parent is present: the deploy step amends the
+          # previous dashboard commit, and amending at the shallow boundary
+          # (depth 1) would create a parentless commit and rewrite the whole
+          # branch history on force-push.
+          fetch-depth: 2
 
       - name: Update CI timing history
         env:
@@ -66,25 +70,44 @@ jobs:
 
       - name: Deploy to GitHub Pages
         run: |
-          mkdir -p gh-pages/ci-timing
-          cp ci-timing-out/data.json gh-pages/ci-timing/
-          cp .github/scripts/ci_timing_dashboard.html gh-pages/ci-timing/index.html
-
           cd gh-pages
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git add ci-timing/
-          if git diff --staged --quiet; then
-            echo "No changes to deploy"
-            exit 0
-          fi
-          git commit -m "Update CI timing dashboard - $(date -u +%Y-%m-%d)"
+
+          # Each run overwrites the previous dashboard commit (amend +
+          # force-with-lease) instead of stacking a daily commit, to keep
+          # gh-pages history shallow. When another workflow's commit sits at
+          # the tip, fall back to a regular commit; the scheduled gh-pages
+          # squash reclaims those eventually.
+          deploy() {
+            mkdir -p ci-timing
+            cp ../ci-timing-out/data.json ci-timing/
+            cp ../.github/scripts/ci_timing_dashboard.html ci-timing/index.html
+            git add ci-timing/
+            if git diff --staged --quiet; then
+              echo "No changes to deploy"
+              return 0
+            fi
+            local msg="Update CI timing dashboard - $(date -u +%Y-%m-%d)"
+            local tip_msg
+            tip_msg="$(git log -1 --format=%s)"
+            if [[ "$tip_msg" == "Update CI timing dashboard"* ]] \
+                && git rev-parse -q --verify HEAD^ >/dev/null; then
+              git commit --amend -m "$msg"
+              git push --force-with-lease=refs/heads/gh-pages
+            else
+              git commit -m "$msg"
+              git push
+            fi
+          }
+
           # Other workflows (benchmarks, flaky tracker) also push to gh-pages;
-          # rebase and retry to avoid non-fast-forward failures.
+          # on a lost race, re-sync to the remote tip and retry.
           for i in 1 2 3; do
-            if git push; then
+            if deploy; then
               exit 0
             fi
-            git pull --rebase
+            git fetch --depth 2 origin gh-pages
+            git reset --hard origin/gh-pages
           done
-          git push
+          deploy

--- a/.github/workflows/ci-timing-tracker.yml
+++ b/.github/workflows/ci-timing-tracker.yml
@@ -1,0 +1,90 @@
+name: CI Timing Tracker
+
+on:
+  schedule:
+    # Run daily at 6:45 UTC, after the nightly test workflows. Concurrent
+    # pushes to gh-pages (benchmarks, flaky tracker) are handled by
+    # rebase-and-retry in the deploy step.
+    - cron: '45 6 * * *'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Lookback window in days (use ~190 to backfill history)'
+        required: false
+        default: '4'
+        type: string
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  group: ci-timing-tracker
+  cancel-in-progress: false
+
+env:
+  PYTHONUNBUFFERED: "1"
+  LOOKBACK_DAYS: ${{ inputs.days || '4' }}
+
+jobs:
+  track-ci-timing:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+          fetch-depth: 1
+
+      - name: Update CI timing history
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          python .github/scripts/track_ci_timing.py \
+            --days "$LOOKBACK_DAYS" \
+            --history gh-pages/ci-timing/data.json \
+            --output-dir ci-timing-out
+
+      - name: Deploy to GitHub Pages
+        run: |
+          mkdir -p gh-pages/ci-timing
+          cp ci-timing-out/data.json gh-pages/ci-timing/
+          cp .github/scripts/ci_timing_dashboard.html gh-pages/ci-timing/index.html
+
+          cd gh-pages
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add ci-timing/
+          if git diff --staged --quiet; then
+            echo "No changes to deploy"
+            exit 0
+          fi
+          git commit -m "Update CI timing dashboard - $(date -u +%Y-%m-%d)"
+          # Other workflows (benchmarks, flaky tracker) also push to gh-pages;
+          # rebase and retry to avoid non-fast-forward failures.
+          for i in 1 2 3; do
+            if git push; then
+              exit 0
+            fi
+            git pull --rebase
+          done
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -202,6 +202,8 @@ setup-and-run.sh
 dev/
 main/
 *.html
+# CI dashboard template deployed to gh-pages
+!.github/scripts/*.html
 
 # Additional cache directories
 .ruff_cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,13 @@ We actively welcome your pull requests.
 
 When submitting a PR, we encourage you to link it to the related issue (if any) and add some tags to it.
 
+The health of the CI is tracked on public dashboards:
+[CI timing](https://pytorch.github.io/rl/ci-timing/) (wall-clock trend of each
+workflow), [flaky tests](https://pytorch.github.io/rl/flaky/) and
+[benchmarks](https://pytorch.github.io/rl/dev/bench/). They can help you tell
+apart a slowdown or failure introduced by your PR from one that ships with
+`main`.
+
 ## Contributor License Agreement ("CLA")
 In order to accept your pull request, we need you to submit a CLA. You only need
 to do this once to work on any of Facebook's open source projects.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Nightly](https://github.com/pytorch/rl/actions/workflows/nightly_orchestrator.yml/badge.svg)](https://pytorch.github.io/rl/nightly-status/)
 [![Documentation](https://img.shields.io/badge/Documentation-blue.svg)](https://pytorch.org/rl/)
 [![Benchmarks](https://img.shields.io/badge/Benchmarks-blue.svg)](https://pytorch.github.io/rl/dev/bench/)
+[![CI Timing](https://img.shields.io/badge/CI%20Timing-blue.svg)](https://pytorch.github.io/rl/ci-timing/)
 [![codecov](https://codecov.io/gh/pytorch/rl/branch/main/graph/badge.svg?token=HcpK1ILV6r)](https://codecov.io/gh/pytorch/rl)
 [![Flaky Tests](https://img.shields.io/endpoint?url=https://pytorch.github.io/rl/flaky/badge.json)](https://pytorch.github.io/rl/flaky/)
 [![X / Twitter Follow](https://img.shields.io/twitter/follow/torchrl1?style=social)](https://twitter.com/torchrl1)


### PR DESCRIPTION
## Description

Adds a daily-updated dashboard tracking the wall-clock duration of the main CI workflows over time, published to `https://pytorch.github.io/rl/ci-timing/` in the same mold as the flaky-test dashboard (`/flaky/`).

Motivation: several workflows have slowed significantly over the past months (doc build 26 -> 77 min, unit tests 64 -> 98 min, windows 47 -> 65 min) and there was no visibility into the trend. This makes regressions like a heavyweight tutorial landing in the doc build visible within a day instead of months later.

## Changes

- `.github/scripts/track_ci_timing.py`: fetches completed first-attempt runs on `main` for the tracked workflows (unit tests, docs, libs, windows, benchmarks, sota, habitat, llm, tutorials, mujoco, lint; wheel builds excluded) and merges per-run durations into `ci-timing/data.json` on gh-pages. Raw runs are retained 120 days; weekly medians are kept forever, so the file stays small (~190 kB fully backfilled).
- `.github/scripts/ci_timing_dashboard.html`: self-contained static dashboard (no external deps): summary table (latest week vs 8 weeks ago) plus per-workflow charts with weekly-median line, individual-run scatter, and a 30-minute reference line.
- `.github/workflows/ci-timing-tracker.yml`: daily cron at 6:45 UTC. Each run amends the previous dashboard commit on gh-pages (force-with-lease) so the dashboard occupies a single commit instead of one per day; it falls back to a regular commit when another workflow (benchmarks, flaky tracker) holds the tip, and re-syncs and retries on lost push races.
- `.gitignore`: exempt `.github/scripts/*.html` from the global `*.html` ignore.

## Rollout

After merge, dispatch the workflow once manually with `days=190` to backfill history to January; the daily cron maintains it from there.

## Testing

Ran the script locally against the live API: full 190-day backfill (2159 runs, 233 weekly entries), then an incremental `--days 4` merge on top to verify dedup and weekly-median refresh. Rendered the dashboard in a browser against the backfilled data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
