### PR TITLE
[BugFix] Dump Evaluator videos through the collector-owned env

### DIFF
--- a/test/collectors/test_evaluator.py
+++ b/test/collectors/test_evaluator.py
@@ -21,6 +21,7 @@ from torchrl.collectors._evaluator import (
     _freeze_vecnorm,
     _wrap_env_factory_frozen,
 )
+from torchrl.data import Unbounded
 from torchrl.envs import SerialEnv, TransformedEnv
 from torchrl.envs.env_creator import EnvCreator
 from torchrl.envs.transforms import (
@@ -30,6 +31,8 @@ from torchrl.envs.transforms import (
     Transform,
     VecNormV2,
 )
+from torchrl.record import VideoRecorder
+from torchrl.record.loggers.process import ProcessLogger
 from torchrl.testing.mocking_classes import ContinuousActionVecMockEnv
 from torchrl.weight_update import WeightStrategy
 
@@ -62,6 +65,60 @@ class _DumpStep(Transform):
 
 def _make_dump_env(path: str):
     return TransformedEnv(_make_env(), Compose(_DumpStep(path)))
+
+
+class _VideoEventsLogger:
+    """Duck-typed logger that appends each ``log_video`` call to a file."""
+
+    def __init__(self, log_dir):
+        self.exp_name = "evaluator-video-test"
+        self.log_dir = str(log_dir)
+
+    def log_video(self, name, video, step=None, **kwargs):
+        del kwargs
+        with open(Path(self.log_dir) / "videos", "a") as file:
+            file.write(f"{name}:{step}:{video.shape[1]}\n")
+
+
+class _AddPixels(Transform):
+    """Writes a constant uint8 image so ``VideoRecorder`` has frames to record."""
+
+    def __init__(self):
+        super().__init__(in_keys=[], out_keys=["pixels"])
+
+    def _call(self, next_tensordict):
+        next_tensordict.set("pixels", torch.zeros(3, 8, 8, dtype=torch.uint8))
+        return next_tensordict
+
+    def _reset(self, tensordict, tensordict_reset):
+        return self._call(tensordict_reset)
+
+    def transform_observation_spec(self, observation_spec):
+        observation_spec["pixels"] = Unbounded(
+            shape=(3, 8, 8), dtype=torch.uint8, device=observation_spec.device
+        )
+        return observation_spec
+
+
+def _make_video_env(video_logger):
+    return TransformedEnv(
+        _make_env(),
+        Compose(
+            _AddPixels(),
+            VideoRecorder(
+                video_logger,
+                tag="eval_video",
+                in_keys=["pixels"],
+                skip=1,
+                make_grid=False,
+            ),
+        ),
+    )
+
+
+def _read_video_events(log_dir):
+    lines = (Path(log_dir) / "videos").read_text().splitlines()
+    return [line.split(":") for line in lines]
 
 
 class TestEvaluatorSync:
@@ -114,6 +171,27 @@ class TestEvaluatorSync:
         try:
             metrics = evaluator.evaluate(weights=train_policy, step=0)
             assert "eval/reward" in metrics
+        finally:
+            evaluator.shutdown()
+
+    def test_video_recorder_dump(self, tmp_path):
+        # Thread/same-process backend: the recorder is dumped locally by
+        # walking the env transform, once per eval at the requested step.
+        logger = _VideoEventsLogger(str(tmp_path))
+        env = _make_video_env(logger)
+        policy = _make_policy(env)
+        evaluator = Evaluator(
+            env, policy, num_trajectories=2, max_steps=10, dump_video=True
+        )
+        try:
+            evaluator.evaluate(step=11)
+            evaluator.evaluate(step=22)
+            records = _read_video_events(tmp_path)
+            assert [record[:2] for record in records] == [
+                ["eval_video", "11"],
+                ["eval_video", "22"],
+            ]
+            assert all(int(record[2]) > 0 for record in records)
         finally:
             evaluator.shutdown()
 
@@ -626,6 +704,34 @@ class TestEvaluatorProcess:
             assert metrics["eval/step"] == 456
         finally:
             evaluator.shutdown()
+
+    def test_video_recorder_dumps_to_process_logger(self, tmp_path):
+        # End-to-end: the eval env (with a VideoRecorder) lives in the
+        # collector worker process; the recorder logs through a picklable
+        # ProcessLogger client back to the parent-owned logger service.
+        process_logger = ProcessLogger(_VideoEventsLogger, str(tmp_path))
+        evaluator = Evaluator(
+            partial(_make_video_env, process_logger.client()),
+            policy_factory=_make_policy,
+            num_trajectories=2,
+            max_steps=10,
+            dump_video=True,
+            backend="process",
+        )
+        try:
+            evaluator.evaluate(step=3)
+            evaluator.evaluate(step=7)
+            process_logger.flush(timeout=30)
+            records = _read_video_events(tmp_path)
+            # exactly one worker-side dump per eval, at the requested step
+            assert [record[:2] for record in records] == [
+                ["eval_video", "3"],
+                ["eval_video", "7"],
+            ]
+            assert all(int(record[2]) > 0 for record in records)
+        finally:
+            evaluator.shutdown()
+            process_logger.shutdown(timeout=30)
 
     def test_dump_video_dispatches_compose_dump_in_worker(self, tmp_path):
         dump_path = tmp_path / "dump-step"

--- a/torchrl/collectors/_evaluator.py
+++ b/torchrl/collectors/_evaluator.py
@@ -156,6 +156,33 @@ class Evaluator:
     env so that per-episode returns are tracked.  Without it, the
     evaluator falls back to summing raw rewards over each trajectory.
 
+    **Eval video logging**: when the eval env contains a
+    :class:`~torchrl.record.VideoRecorder`, each evaluation ends with a
+    ``dump(step=...)`` on the env transforms of the collector that ran
+    the rollout (disable with ``dump_video=False``).  With
+    ``backend="process"`` the recorder lives inside the collector worker,
+    so build it in the env factory around a picklable logger client such
+    as :meth:`ProcessLogger.client()
+    <torchrl.record.loggers.process.ProcessLogger.client>`::
+
+        from torchrl.record import VideoRecorder
+        from torchrl.record.loggers import CSVLogger, ProcessLogger
+
+        logger = ProcessLogger(CSVLogger, exp_name="run", log_dir="logs")
+        video_client = logger.client()
+
+        def make_eval_env():
+            env = make_env()
+            env.append_transform(VideoRecorder(video_client, tag="eval/video"))
+            return env
+
+        evaluator = Evaluator(
+            make_eval_env,
+            policy_factory=make_eval_policy,
+            max_steps=1000,
+            backend="process",
+        )
+
     Args:
         env: An :class:`~torchrl.envs.EnvBase` instance **or** a callable
             that returns one.  For the ``"process"`` and ``"ray"`` backends
@@ -1248,29 +1275,21 @@ class _ThreadEvalBackend(_EvalBackend):
         """Dump accumulated video frames from VideoRecorder transforms.
 
         Process-backed evaluator collectors dispatch ``Compose.dump`` to the
-        worker that owns the environment. Direct evaluators call it locally.
+        worker that owns the environment. Same-process evaluators dump the
+        collector's own env: the collector may wrap the user env (e.g. to add
+        a ``StepCounter``), cloning its transforms, so the recorder that
+        accumulated frames is the collector-side one, not the transform of
+        the env handed to the evaluator.
         """
-        if self._use_multi_collector and self._collector is not None:
+        if self._collector is None:
+            return
+        if self._use_multi_collector:
             self._collector.map_fn(
                 "_dump_env_transform",
                 list_of_kwargs=[{"step": step}] * self._collector.num_workers,
             )
             return
-        if self._env is None or not hasattr(self._env, "transform"):
-            return
-        transform = self._env.transform
-        dump = getattr(transform, "dump", None)
-        if callable(dump):
-            dump(step=step)
-            return
-        try:
-            transforms = iter(transform)
-        except TypeError:
-            return
-        for item in transforms:
-            dump = getattr(item, "dump", None)
-            if callable(dump):
-                dump(step=step)
+        self._collector._dump_env_transform(step=step)
 
 
 # ======================================================================

--- a/torchrl/collectors/_evaluator.py
+++ b/torchrl/collectors/_evaluator.py
@@ -159,10 +159,14 @@ class Evaluator:
     **Eval video logging**: when the eval env contains a
     :class:`~torchrl.record.VideoRecorder`, each evaluation ends with a
     ``dump(step=...)`` on the env transforms of the collector that ran
-    the rollout (disable with ``dump_video=False``).  With
-    ``backend="process"`` the recorder lives inside the collector worker,
-    so build it in the env factory around a picklable logger client such
-    as :meth:`ProcessLogger.client()
+    the rollout (disable with ``dump_video=False``).  The recorder must
+    be attached to the *outermost* env: recorders nested inside the
+    worker envs of a :class:`~torchrl.envs.SerialEnv` /
+    :class:`~torchrl.envs.ParallelEnv` are not reached by the dump and
+    would accumulate frames indefinitely.  With ``backend="process"``
+    the recorder lives inside the collector worker, so build it in the
+    env factory around a picklable logger client such as
+    :meth:`ProcessLogger.client()
     <torchrl.record.loggers.process.ProcessLogger.client>`::
 
         from torchrl.record import VideoRecorder

--- a/torchrl/record/recorder.py
+++ b/torchrl/record/recorder.py
@@ -93,6 +93,17 @@ class VideoRecorder(ObservationTransform):
 
         >>> env.transform.dump()
 
+    .. note::
+        When recording a batched env (:class:`~torchrl.envs.SerialEnv` or
+        :class:`~torchrl.envs.ParallelEnv`), attach the recorder to the
+        *outer* env, e.g.
+        ``TransformedEnv(ParallelEnv(N, make_env), VideoRecorder(...))``,
+        so that the batch is tiled into a single grid video
+        (``make_grid=True``). Recorders living inside the worker envs of a
+        batched env are not reached by ``dump`` calls issued on the outer
+        env or by collectors and evaluators, and would accumulate frames
+        indefinitely.
+
         The transform can also be used within a dataset to save the video collected. Unlike in the environment case,
         images will come in a batch. The ``skip`` argument will enable to save the images only at specific intervals.
 


### PR DESCRIPTION
## Description

`Evaluator` video dumping had two gaps:

1. **Same-process (thread) backend bug**: `_ThreadEvalBackend.dump_video()` walked the transform of the env handed to the evaluator. When the internal `Collector` wraps that env (e.g. to add a `StepCounter`), the transforms are cloned, and the cloned `VideoRecorder` initially shares its frame list with the original. The first dump therefore worked by accident; `dump()` then reassigns the frame list, the two recorders diverge, and every subsequent evaluation silently dumped nothing while frames accumulated unboundedly in the collector-side recorder.
2. **Process backend**: the worker-side dump dispatch (`map_fn("_dump_env_transform")` over the collector pipes) landed with the service/client unification but had no end-to-end coverage with a real `VideoRecorder` writing through a `ProcessLogger` client.

## Changes

- `_ThreadEvalBackend.dump_video()` now dumps through the collector's own env (via the collector's `_dump_env_transform`), which is the env that actually collected the frames. The process backend keeps dispatching the dump to the worker that owns the env.
- End-to-end tests:
  - `backend="process"`: eval env factory builds a `VideoRecorder` around a picklable `ProcessLogger` client in the collector worker; each `evaluate(step=...)` triggers exactly one worker-side dump at the requested step, and the video reaches the parent-owned logger service.
  - thread backend: same exactly-once-per-eval assertions with a local logger.
- Documented the process-backend video wiring (`ProcessLogger.client()` inside the env factory) in the `Evaluator` docstring.

## Tests

```
pytest test/collectors/test_evaluator.py  # 79 passed, 2 skipped (multi-GPU)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)