### PR TITLE
[Feature] Add shared-memory inference transport

### DIFF
--- a/docs/source/reference/modules_inference_server.rst
+++ b/docs/source/reference/modules_inference_server.rst
@@ -34,6 +34,7 @@ Transport Backends
     ThreadingTransport
     SlotTransport
     MPTransport
+    SharedMemoryTransport
     RayTransport
     MonarchTransport
 
@@ -69,6 +70,48 @@ threads in the same process:
         ...
 
     server.shutdown()
+
+Shared-memory transport
+^^^^^^^^^^^^^^^^^^^^^^^
+
+For cross-process actors with large request payloads (e.g. image
+observations), :class:`SharedMemoryTransport` preallocates request and
+response slot banks in CPU shared memory and passes only slot indices
+through the multiprocessing queues, removing per-request pickling from the
+hot path. The caller provides representative request and response
+TensorDicts that fix the slot layout (keys, shapes, dtypes); only the
+declared keys are transmitted:
+
+.. code-block:: python
+
+    import torch
+    from tensordict import TensorDict
+    from torchrl.modules.inference_server import (
+        InferenceServer,
+        SharedMemoryTransport,
+    )
+
+    transport = SharedMemoryTransport(
+        request_spec=TensorDict({"pixels": torch.zeros(3, 224, 224)}),
+        response_spec=TensorDict(
+            {
+                "action": torch.zeros(7),
+                "policy_version": torch.zeros((), dtype=torch.long),
+            }
+        ),
+        num_slots=64,
+    )
+    # Create clients before spawning env workers
+    clients = [transport.client() for _ in range(n_workers)]
+
+    server = InferenceServer(policy, transport, policy_device="cuda:0")
+    server.start()
+
+Slots are CPU-only: clients must submit CPU tensors, and the server owns
+all device transfers (batches are moved to ``policy_device`` before the
+forward pass, results copied back into the CPU response slots).
+``num_slots`` bounds the number of concurrently in-flight requests and
+provides natural backpressure.
 
 Structured Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -44,6 +44,7 @@ from torchrl.modules.inference_server import (
     PolicyClientModule,
     ProcessInferenceServer,
     RayTransport,
+    SharedMemoryTransport,
     SlotTransport,
     ThreadingTransport,
 )
@@ -1047,6 +1048,289 @@ class TestMPTransport:
             td = TensorDict({"observation": torch.randn(4)})
             with pytest.raises(ValueError, match="mp model error"):
                 client(td)
+
+
+# =============================================================================
+# Tests: SharedMemoryTransport
+# =============================================================================
+
+
+class _Doubler(nn.Module):
+    def forward(self, x):
+        return x * 2.0
+
+
+def _make_shm_specs(obs_size=4, act_size=2, with_version=True):
+    request_spec = TensorDict({"observation": torch.zeros(obs_size)})
+    response = {"action": torch.zeros(act_size)}
+    if with_version:
+        response["policy_version"] = torch.zeros((), dtype=torch.long)
+    return request_spec, TensorDict(response)
+
+
+def _make_doubling_policy():
+    return TensorDictModule(_Doubler(), in_keys=["observation"], out_keys=["action"])
+
+
+def _shm_actor_fn(client, n_requests, result_queue):
+    """Actor that submits known values and checks the doubled response."""
+    for i in range(n_requests):
+        obs = torch.full((4,), float(i + 1))
+        result = client(TensorDict({"observation": obs}))
+        assert torch.allclose(result["action"], obs * 2.0)
+    result_queue.put(True)
+
+
+class TestSharedMemoryTransport:
+    def test_single_request_in_process(self):
+        """A client in the owning process gets a correct result."""
+        request_spec, response_spec = _make_shm_specs()
+        transport = SharedMemoryTransport(request_spec, response_spec, num_slots=4)
+        client = transport.client()
+        policy = _make_policy()
+        with InferenceServer(policy, transport, max_batch_size=4):
+            td = TensorDict({"observation": torch.randn(4)})
+            result = client(td)
+            assert "action" in result.keys()
+            assert "policy_version" in result.keys()
+            assert result["action"].shape == (2,)
+
+    def test_undeclared_keys_are_dropped(self):
+        """Only spec-declared keys travel through the transport."""
+        request_spec, response_spec = _make_shm_specs(act_size=4, with_version=False)
+        transport = SharedMemoryTransport(request_spec, response_spec, num_slots=2)
+        client = transport.client()
+        with InferenceServer(_make_doubling_policy(), transport, max_batch_size=2):
+            obs = torch.arange(4, dtype=torch.float32)
+            td = TensorDict({"observation": obs, "extra": torch.randn(3)})
+            result = client(td)
+            assert set(result.keys()) == {"action"}
+            assert torch.allclose(result["action"], obs * 2.0)
+
+    def test_missing_declared_key_raises(self):
+        """A request missing a declared key fails fast, before slot use."""
+        request_spec, response_spec = _make_shm_specs()
+        transport = SharedMemoryTransport(request_spec, response_spec, num_slots=1)
+        client = transport.client()
+        with pytest.raises(KeyError):
+            client.submit(TensorDict({"wrong_key": torch.zeros(4)}))
+
+    def test_multi_client_concurrent(self):
+        """Concurrent clients each get their own routed results."""
+        request_spec, response_spec = _make_shm_specs(act_size=4, with_version=False)
+        transport = SharedMemoryTransport(request_spec, response_spec, num_slots=8)
+        n_clients = 4
+        clients = [transport.client() for _ in range(n_clients)]
+        errors = []
+
+        def run(idx):
+            try:
+                for i in range(5):
+                    obs = torch.full((4,), float(idx * 10 + i))
+                    result = clients[idx](TensorDict({"observation": obs}))
+                    assert torch.allclose(result["action"], obs * 2.0)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        with InferenceServer(
+            _make_doubling_policy(), transport, max_batch_size=n_clients
+        ):
+            threads = [
+                threading.Thread(target=run, args=(i,)) for i in range(n_clients)
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=30.0)
+        assert not errors
+
+    def test_out_of_order_result_consumption(self):
+        """Futures can be consumed in any order (response buffering)."""
+        request_spec, response_spec = _make_shm_specs(act_size=4, with_version=False)
+        transport = SharedMemoryTransport(request_spec, response_spec, num_slots=4)
+        client = transport.client()
+        with InferenceServer(_make_doubling_policy(), transport, max_batch_size=4):
+            fut_a = client.submit(TensorDict({"observation": torch.full((4,), 1.0)}))
+            fut_b = client.submit(TensorDict({"observation": torch.full((4,), 2.0)}))
+            result_b = fut_b.result(timeout=10.0)
+            result_a = fut_a.result(timeout=10.0)
+        assert torch.allclose(result_b["action"], torch.full((4,), 4.0))
+        assert torch.allclose(result_a["action"], torch.full((4,), 2.0))
+
+    def test_exception_propagates_and_slot_is_released(self):
+        """Model errors reach the client and free the slot for reuse."""
+
+        def flaky_model(td):
+            if (td["observation"] < 0).any():
+                raise ValueError("shm model error")
+            return td.set("action", td["observation"] * 2.0)
+
+        request_spec, response_spec = _make_shm_specs(act_size=4, with_version=False)
+        transport = SharedMemoryTransport(request_spec, response_spec, num_slots=1)
+        client = transport.client()
+        with InferenceServer(flaky_model, transport, max_batch_size=1):
+            with pytest.raises(ValueError, match="shm model error"):
+                client(TensorDict({"observation": -torch.ones(4)}))
+            # With a single slot, this only completes if the failed request
+            # released its slot. Run in a thread so a leak fails the test
+            # instead of hanging it.
+            obs = torch.ones(4)
+            done = threading.Event()
+            out = {}
+
+            def resubmit():
+                out["result"] = client(TensorDict({"observation": obs}))
+                done.set()
+
+            t = threading.Thread(target=resubmit, daemon=True)
+            t.start()
+            assert done.wait(timeout=10.0), "slot was not released after exception"
+            assert torch.allclose(out["result"]["action"], obs * 2.0)
+
+    def test_nested_keys(self):
+        """Nested request and response keys round-trip through the slots."""
+        request_spec = TensorDict({"agent": {"observation": torch.zeros(4)}})
+        response_spec = TensorDict({"agent": {"action": torch.zeros(4)}})
+        transport = SharedMemoryTransport(request_spec, response_spec, num_slots=2)
+        client = transport.client()
+        model = TensorDictModule(
+            _Doubler(),
+            in_keys=[("agent", "observation")],
+            out_keys=[("agent", "action")],
+        )
+        with InferenceServer(model, transport, max_batch_size=2):
+            obs = torch.arange(4, dtype=torch.float32)
+            result = client(TensorDict({"agent": {"observation": obs}}))
+            assert torch.allclose(result["agent", "action"], obs * 2.0)
+
+    def test_slot_backpressure(self):
+        """With all slots in flight, submit blocks until a slot is freed."""
+        request_spec, response_spec = _make_shm_specs(with_version=False)
+        transport = SharedMemoryTransport(request_spec, response_spec, num_slots=1)
+        client = transport.client()
+        fut1 = client.submit(TensorDict({"observation": torch.ones(4)}))
+        submitted = threading.Event()
+        futures = {}
+
+        def second_submit():
+            futures["fut2"] = client.submit(
+                TensorDict({"observation": 2 * torch.ones(4)})
+            )
+            submitted.set()
+
+        t = threading.Thread(target=second_submit, daemon=True)
+        t.start()
+        # The only slot is held by the first in-flight request.
+        assert not submitted.wait(timeout=0.5)
+        # Resolve the first request manually (server side).
+        transport.wait_for_work(timeout=5.0)
+        items, callbacks = transport.drain(4)
+        assert len(items) == 1
+        assert torch.allclose(items[0]["observation"], torch.ones(4))
+        transport.resolve(callbacks[0], TensorDict({"action": torch.ones(2)}))
+        assert torch.allclose(fut1.result(timeout=5.0)["action"], torch.ones(2))
+        # Reading the result released the slot: the second submit unblocks.
+        assert submitted.wait(timeout=10.0)
+        transport.wait_for_work(timeout=5.0)
+        items, callbacks = transport.drain(4)
+        assert len(items) == 1
+        assert torch.allclose(items[0]["observation"], 2 * torch.ones(4))
+        transport.resolve(callbacks[0], TensorDict({"action": 2 * torch.ones(2)}))
+        assert torch.allclose(
+            futures["fut2"].result(timeout=5.0)["action"], 2 * torch.ones(2)
+        )
+        t.join(timeout=5.0)
+
+    def test_result_timeout_keeps_slot(self):
+        """A timed-out result() keeps the request in flight and retryable."""
+        request_spec, response_spec = _make_shm_specs(with_version=False)
+        transport = SharedMemoryTransport(request_spec, response_spec, num_slots=1)
+        client = transport.client()
+        fut = client.submit(TensorDict({"observation": torch.ones(4)}))
+        with pytest.raises(queue.Empty):
+            fut.result(timeout=0.1)
+        transport.wait_for_work(timeout=5.0)
+        items, callbacks = transport.drain(1)
+        assert len(items) == 1
+        transport.resolve(callbacks[0], TensorDict({"action": torch.ones(2)}))
+        assert torch.allclose(fut.result(timeout=5.0)["action"], torch.ones(2))
+
+    def test_copy_result_false_returns_borrowed_view(self):
+        """copy_result=False returns a view into the shared response slot."""
+        request_spec, response_spec = _make_shm_specs(with_version=False)
+        transport = SharedMemoryTransport(
+            request_spec, response_spec, num_slots=1, copy_result=False
+        )
+        client = transport.client()
+        fut = client.submit(TensorDict({"observation": torch.ones(4)}))
+        transport.wait_for_work(timeout=5.0)
+        items, callbacks = transport.drain(1)
+        transport.resolve(callbacks[0], TensorDict({"action": torch.ones(2)}))
+        result = fut.result(timeout=5.0)
+        assert (
+            result["action"].data_ptr()
+            == transport._response_slots["action"][0].data_ptr()
+        )
+
+    def test_spec_validation(self):
+        """Bad specs are rejected at construction time."""
+        response_spec = TensorDict({"action": torch.zeros(2)})
+        with pytest.raises(TypeError, match="tensor leaves"):
+            SharedMemoryTransport(
+                TensorDict({"instruction": "hello"}), response_spec, num_slots=1
+            )
+        with pytest.raises(ValueError, match="at least one tensor leaf"):
+            SharedMemoryTransport(TensorDict({}), response_spec, num_slots=1)
+        with pytest.raises(ValueError, match="num_slots"):
+            SharedMemoryTransport(
+                TensorDict({"observation": torch.zeros(4)}),
+                response_spec,
+                num_slots=0,
+            )
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    def test_cuda_input_raises(self):
+        """CUDA tensors are rejected: slots are CPU shared memory only."""
+        request_spec, response_spec = _make_shm_specs()
+        transport = SharedMemoryTransport(request_spec, response_spec, num_slots=1)
+        client = transport.client()
+        with pytest.raises(ValueError, match="CPU tensors"):
+            client.submit(TensorDict({"observation": torch.randn(4, device="cuda")}))
+        with pytest.raises(ValueError, match="CPU shared memory"):
+            SharedMemoryTransport(
+                TensorDict({"observation": torch.zeros(4, device="cuda")}),
+                response_spec,
+                num_slots=1,
+            )
+
+    @pytest.mark.slow
+    def test_cross_process_actors(self):
+        """Spawned child clients submit; the parent server resolves."""
+        ctx = mp.get_context("spawn")
+        request_spec, response_spec = _make_shm_specs(act_size=4, with_version=False)
+        transport = SharedMemoryTransport(
+            request_spec, response_spec, num_slots=8, ctx=ctx
+        )
+        n_actors = 2
+        n_requests = 10
+        result_queue = ctx.Queue()
+        # Create clients before spawning (queues and slots inherited)
+        clients = [transport.client() for _ in range(n_actors)]
+        with InferenceServer(_make_doubling_policy(), transport, max_batch_size=8):
+            procs = []
+            for i in range(n_actors):
+                p = ctx.Process(
+                    target=_shm_actor_fn,
+                    args=(clients[i], n_requests, result_queue),
+                )
+                p.start()
+                procs.append(p)
+            for p in procs:
+                p.join(timeout=60.0)
+                assert p.exitcode == 0
+        for _ in range(n_actors):
+            assert result_queue.get(timeout=1.0) is True
 
 
 # =============================================================================

--- a/torchrl/modules/inference_server/__init__.py
+++ b/torchrl/modules/inference_server/__init__.py
@@ -16,6 +16,7 @@ from torchrl.modules.inference_server._server import (
     InferenceServer,
     ProcessInferenceServer,
 )
+from torchrl.modules.inference_server._shared_memory import SharedMemoryTransport
 from torchrl.modules.inference_server._slot import SlotTransport
 from torchrl.modules.inference_server._threading import ThreadingTransport
 from torchrl.modules.inference_server._transport import InferenceTransport
@@ -31,6 +32,7 @@ __all__ = [
     "PolicyClientModule",
     "ProcessInferenceServer",
     "RayTransport",
+    "SharedMemoryTransport",
     "SlotTransport",
     "ThreadingTransport",
 ]

--- a/torchrl/modules/inference_server/_shared_memory.py
+++ b/torchrl/modules/inference_server/_shared_memory.py
@@ -1,0 +1,356 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import multiprocessing as mp
+import queue
+
+import torch
+from tensordict.base import _is_leaf_nontensor, TensorDictBase
+from tensordict.utils import NestedKey
+
+from torchrl._comm import MailboxClient, MailboxFuture
+from torchrl.modules.inference_server._queue_transport import QueueBasedTransport
+
+_MISSING = object()
+
+
+class _SharedMemoryFuture:
+    """Future for one in-flight :class:`SharedMemoryTransport` request.
+
+    Wraps a :class:`~torchrl._comm.MailboxFuture` that resolves to the slot
+    index; on success the response is read from the shared response slot and
+    the slot is released back to the free-slot pool.
+    """
+
+    def __init__(
+        self,
+        inner: MailboxFuture,
+        slot: int,
+        response_slots: TensorDictBase,
+        free_slots,
+        copy_result: bool,
+    ):
+        self._inner = inner
+        self._slot = slot
+        self._response_slots = response_slots
+        self._free_slots = free_slots
+        self._copy_result = copy_result
+        self._outcome = _MISSING
+
+    def done(self) -> bool:
+        """Return ``True`` when the result can be read without blocking."""
+        if self._outcome is not _MISSING:
+            return True
+        return self._inner.done()
+
+    def result(self, timeout: float | None = None) -> TensorDictBase:
+        """Return the inference result or raise its remote exception.
+
+        Raises :class:`queue.Empty` when *timeout* elapses before the server
+        replies; the request stays in flight and the slot is kept, so
+        ``result`` can be called again.
+        """
+        if self._outcome is _MISSING:
+            try:
+                self._inner.result(timeout=timeout)
+            except queue.Empty:
+                # Timeout: the request is still in flight and the server may
+                # still write to the slot -- do not release it.
+                raise
+            except BaseException as exc:
+                self._free_slots.put(self._slot)
+                self._outcome = exc
+            else:
+                result = self._response_slots[self._slot]
+                if self._copy_result:
+                    result = result.clone()
+                self._free_slots.put(self._slot)
+                self._outcome = result
+        if isinstance(self._outcome, BaseException):
+            raise self._outcome
+        return self._outcome
+
+
+class _SharedMemorySlotClient:
+    """Actor-side client for :class:`SharedMemoryTransport`.
+
+    Writes request tensors into a shared-memory slot and submits only the
+    slot index through the request queue.
+    """
+
+    def __init__(
+        self,
+        mailbox_client: MailboxClient,
+        request_slots: TensorDictBase,
+        response_slots: TensorDictBase,
+        free_slots,
+        request_keys: list[NestedKey],
+        *,
+        copy_result: bool,
+    ):
+        self._mailbox_client = mailbox_client
+        self._request_slots = request_slots
+        self._response_slots = response_slots
+        self._free_slots = free_slots
+        self._request_keys = request_keys
+        self._copy_result = copy_result
+
+    @property
+    def client_id(self) -> int:
+        """The identifier assigned by the owning transport."""
+        return self._mailbox_client.client_id
+
+    def submit(self, td: TensorDictBase) -> _SharedMemoryFuture:
+        """Copy the request into a free slot and enqueue its header.
+
+        Blocks until a slot is available when all ``num_slots`` slots hold
+        in-flight requests (backpressure).
+        """
+        request = td.select(*self._request_keys, strict=True)
+        for key, value in request.items(include_nested=True, leaves_only=True):
+            device = getattr(value, "device", None)
+            if device is None or device.type != "cpu":
+                raise ValueError(
+                    f"SharedMemoryTransport only accepts CPU tensors; got "
+                    f"device {device} for key {key!r}. Keep env workers "
+                    "CPU-side and let the server move batches to the policy "
+                    "device."
+                )
+        slot = self._free_slots.get()
+        try:
+            self._request_slots[slot].update_(request)
+            inner = self._mailbox_client.submit(slot)
+        except BaseException:
+            self._free_slots.put(slot)
+            raise
+        return _SharedMemoryFuture(
+            inner,
+            slot,
+            self._response_slots,
+            self._free_slots,
+            self._copy_result,
+        )
+
+    def __call__(
+        self, td: TensorDictBase, timeout: float | None = None
+    ) -> TensorDictBase:
+        """Submit a request and block for its result."""
+        return self.submit(td).result(timeout=timeout)
+
+
+class SharedMemoryTransport(QueueBasedTransport):
+    """Cross-process transport backed by shared-memory TensorDict slots.
+
+    Unlike :class:`~torchrl.modules.inference_server.MPTransport`, which
+    pickles full request/response TensorDicts through multiprocessing queues,
+    this transport preallocates two CPU shared-memory slot banks (one for
+    requests, one for responses) and passes only slot indices through the
+    queues. This removes per-request serialization of large payloads (e.g.
+    image observations) from the hot path.
+
+    A slot is owned by exactly one in-flight request: the client acquires a
+    slot from a shared free-slot pool, copies the request tensors into it,
+    and releases it once the response has been read. ``num_slots`` therefore
+    bounds the number of concurrently in-flight requests; when all slots are
+    busy, :meth:`~._SharedMemorySlotClient.submit` blocks until one is
+    released.
+
+    Device rules: slots live in CPU shared memory, clients must submit CPU
+    tensors (a CUDA leaf raises a :class:`ValueError`), and the server owns
+    all device transfers -- batches are moved to the policy device by
+    :class:`~torchrl.modules.inference_server.InferenceServer` and results
+    are copied back into the CPU response slots by :meth:`resolve`.
+
+    Args:
+        request_spec (TensorDictBase): a representative single request. Its
+            keys, shapes, dtypes, and batch size define the request slot
+            layout. All leaves must be CPU tensors.
+        response_spec (TensorDictBase): a representative single response
+            (including any server-added keys to forward, such as
+            ``"policy_version"``). All leaves must be CPU tensors.
+
+    Keyword Args:
+        num_slots (int): number of preallocated slots, i.e. the maximum
+            number of concurrently in-flight requests across all clients.
+        ctx (multiprocessing context, optional): the multiprocessing context
+            used for the control queues. Defaults to
+            ``mp.get_context("spawn")``.
+        copy_result (bool, optional): if ``True`` (default),
+            ``Future.result()`` returns a clone of the response slot. If
+            ``False``, it returns a view into the shared response slot that
+            is only valid until the slot is reused by a later request;
+            callers must consume (or copy) it before submitting again.
+
+    .. note::
+        Only the keys declared in the specs are transmitted: extra keys on
+        submitted tensordicts and on model outputs are silently dropped, and
+        a missing declared key raises a :class:`KeyError`. Non-tensor leaves
+        are not supported; encode small metadata as tensors (e.g. static
+        instruction ids) or use :class:`MPTransport`.
+
+    .. note::
+        As with :class:`MPTransport`, clients must be created with
+        :meth:`client` in the owning process **before** spawning child
+        processes, so that their response queues and the shared slot banks
+        are inherited by the workers.
+
+    Example:
+        >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from tensordict.nn import TensorDictModule
+        >>> from torchrl.modules.inference_server import (
+        ...     InferenceServer,
+        ...     SharedMemoryTransport,
+        ... )
+        >>> request_spec = TensorDict({"observation": torch.zeros(4)})
+        >>> response_spec = TensorDict(
+        ...     {
+        ...         "action": torch.zeros(2),
+        ...         "policy_version": torch.zeros((), dtype=torch.long),
+        ...     }
+        ... )
+        >>> transport = SharedMemoryTransport(
+        ...     request_spec, response_spec, num_slots=8
+        ... )
+        >>> client = transport.client()  # create before spawning workers
+        >>> policy = TensorDictModule(
+        ...     torch.nn.Linear(4, 2), in_keys=["observation"], out_keys=["action"]
+        ... )
+        >>> with InferenceServer(policy, transport, max_batch_size=4):
+        ...     result = client(TensorDict({"observation": torch.randn(4)}))
+        >>> assert result["action"].shape == (2,)
+    """
+
+    def __init__(
+        self,
+        request_spec: TensorDictBase,
+        response_spec: TensorDictBase,
+        *,
+        num_slots: int,
+        ctx: mp.context.BaseContext | None = None,
+        copy_result: bool = True,
+    ):
+        super().__init__()
+        if num_slots < 1:
+            raise ValueError(f"num_slots must be a positive integer, got {num_slots}.")
+        self._num_slots = int(num_slots)
+        self._ctx = ctx if ctx is not None else mp.get_context("spawn")
+        self._copy_result = bool(copy_result)
+
+        self._request_slots = self._make_slots(request_spec, "request_spec")
+        self._response_slots = self._make_slots(response_spec, "response_spec")
+        self._request_keys = list(
+            request_spec.keys(include_nested=True, leaves_only=True)
+        )
+        self._response_keys = list(
+            response_spec.keys(include_nested=True, leaves_only=True)
+        )
+
+        self._free_slots = self._ctx.Queue()
+        for slot in range(self._num_slots):
+            self._free_slots.put(slot)
+
+        self._request_queue = self._ctx.Queue()
+        self._response_queues: dict[int, mp.Queue] = {}
+        # Server-liveness flag baked into every client (see MPTransport): a
+        # process-backed server owner clears it when the server process exits
+        # so blocked clients raise MailboxPeerClosedError instead of hanging.
+        peer_alive = self._ctx.Event()
+        peer_alive.set()
+        self._set_peer_alive(peer_alive)
+
+    def _make_slots(self, spec: TensorDictBase, argname: str) -> TensorDictBase:
+        # _is_leaf_nontensor surfaces NonTensorData leaves (excluded by the
+        # default leaf iterator) so they are rejected instead of ignored.
+        leaves = list(
+            spec.items(
+                include_nested=True, leaves_only=True, is_leaf=_is_leaf_nontensor
+            )
+        )
+        if not leaves:
+            raise ValueError(f"{argname} must contain at least one tensor leaf.")
+        for key, value in leaves:
+            if not isinstance(value, torch.Tensor):
+                raise TypeError(
+                    f"SharedMemoryTransport specs only support tensor leaves; "
+                    f"{argname} has a {type(value).__name__} at key {key!r}. "
+                    "Encode small metadata as tensors or use MPTransport."
+                )
+            if value.device.type != "cpu":
+                raise ValueError(
+                    f"SharedMemoryTransport slots live in CPU shared memory; "
+                    f"{argname} has a {value.device} tensor at key {key!r}."
+                )
+        return (
+            spec.unsqueeze(0)
+            .expand(self._num_slots, *spec.batch_size)
+            .clone()
+            .share_memory_()
+        )
+
+    def _make_response_queue(self) -> mp.Queue:
+        return self._ctx.Queue()
+
+    # -- actor API ------------------------------------------------------------
+
+    def client(self) -> _SharedMemorySlotClient:
+        """Create an actor-side client with a dedicated response queue.
+
+        Must be called in the owning process **before** spawning children so
+        that the response queue and the shared slot banks are inherited.
+
+        Returns:
+            A :class:`_SharedMemorySlotClient` that can be passed to a child
+            process as an argument to :class:`multiprocessing.Process`.
+        """
+        inner = self._ensure_mailbox().client()
+        return _SharedMemorySlotClient(
+            inner,
+            self._request_slots,
+            self._response_slots,
+            self._free_slots,
+            self._request_keys,
+            copy_result=self._copy_result,
+        )
+
+    # -- server API -----------------------------------------------------------
+
+    def drain_with_timing(
+        self, max_items: int
+    ) -> tuple[
+        list[TensorDictBase],
+        list[tuple[tuple[int, int], int]],
+        list[float | None],
+    ]:
+        """Dequeue request headers and return views into the request slots."""
+        slots, mailbox_callbacks, submitted_at = self._ensure_mailbox().drain(max_items)
+        # Shallow copies keep the leaf tensors zero-copy (shared storage) but
+        # are unlocked, so the model can write its output keys into the
+        # collated batch (share_memory_() locks the slot bank and its views).
+        items = [self._request_slots[slot].copy() for slot in slots]
+        callbacks = list(zip(mailbox_callbacks, slots))
+        return items, callbacks, submitted_at
+
+    def resolve(
+        self, callback: tuple[tuple[int, int], int], result: TensorDictBase
+    ) -> None:
+        """Copy the result into the response slot and notify the client.
+
+        Result tensors on a non-CPU device are copied back to the CPU slots
+        leaf-by-leaf, so no CUDA tensor ever crosses a queue.
+        """
+        mailbox_callback, slot = callback
+        self._response_slots[slot].update_(
+            result.select(*self._response_keys, strict=True)
+        )
+        self._ensure_mailbox().resolve(mailbox_callback, slot)
+
+    def resolve_exception(
+        self, callback: tuple[tuple[int, int], int], exc: BaseException
+    ) -> None:
+        """Propagate an exception; the client releases the slot on receipt."""
+        mailbox_callback, _slot = callback
+        self._ensure_mailbox().reject(mailbox_callback, exc)


### PR DESCRIPTION
## Description

Adds `SharedMemoryTransport`, a cross-process `InferenceTransport` that preallocates request/response TensorDict slot banks in CPU shared memory and passes only slot indices (plus small headers) through multiprocessing queues.

## Motivation

With a shared policy server fronting many collector/env workers, the queue-based transports pickle and copy full request/response TensorDicts through multiprocessing queues on every request. For image-heavy workloads (e.g. LIBERO + OpenVLA-OFT with hundreds of env workers sharing one policy server), this serialization path becomes a substantial CPU and IPC bottleneck: measured shared-server benchmarks show throughput *degrading* when scaling from 280 to 560 env workers, with p95 queue latencies growing from ~6s to ~12s. Moving payloads to preallocated shared memory removes per-request pickling from the hot path entirely.

## Design

- **Explicit specs (Mode A):** the caller provides representative request/response TensorDicts that fix the slot layout (keys, shapes, dtypes, batch size) at construction. Only declared keys are transmitted; a missing declared key raises.
- **Slot ownership and backpressure:** a shared free-slot pool bounds concurrently in-flight requests; `submit` blocks when all `num_slots` slots are busy, and the slot is released when the client reads the result (or observes an exception).
- **CPU-only slots:** CUDA inputs raise; the server owns all device transfers (`InferenceServer` moves batches to `policy_device`, `resolve` copies results back into CPU slots leaf-by-leaf). No CUDA tensor ever crosses a queue.
- **Header plumbing reuses `Mailbox`:** out-of-order response buffering, `result(timeout=...)`, exception propagation, and server-liveness detection (`MailboxPeerClosedError`) come from the same machinery as `MPTransport`, so `InferenceServer` / `ProcessInferenceServer` work unchanged.
- **Zero-copy drain:** the server drains shallow copies of the slot views (leaf storage shared, structure unlocked) so `TensorDictModule` output writes work against the collated batch.

## Tests

Extends `test/test_inference_server.py` with a `TestSharedMemoryTransport` suite: in-process smoke test, undeclared-key dropping, concurrent multi-client routing, out-of-order future consumption, exception propagation + slot-release regression, nested keys, slot backpressure, result timeout semantics, borrowed-view mode, spec validation, CUDA guard (gpu-marked), and spawned child-process actors with a parent-process server (the topology where `MPTransport` previously hit bad-FD failures).

## Follow-ups (intentionally out of scope)

- Benchmark A/B against the manager-queue transport on the LIBERO/OpenVLA shared-server benchmark (H100).
- Collector-level backend selection (`AsyncBatchedCollector` transport factory) once benchmarks confirm the win.
- Lazy slot allocation from the first request (Mode B), if the explicit-spec API proves too rigid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)