### PR TITLE
[Doc] Cut doc-build time: MujocoEnv render_every, tutorial CI fast path, per-example time budget

### DIFF
--- a/.github/scripts/check_tutorial_time_budget.py
+++ b/.github/scripts/check_tutorial_time_budget.py
@@ -1,0 +1,114 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Fail the docs build when a sphinx-gallery example exceeds its time budget.
+
+Sphinx-gallery executes every tutorial during the docs build. A single
+heavyweight tutorial can multiply the build time without anyone noticing (the
+MuJoCo macros tutorial landed at 45 minutes per build before this check
+existed). This script parses the ``sg_execution_times.rst`` file that
+sphinx-gallery writes (``write_computation_times: True`` in ``conf.py``) and
+exits non-zero when any example exceeds the per-example budget.
+
+Usage:
+    python check_tutorial_time_budget.py [times_file] [--budget SECONDS]
+
+The budget can also be set via the TORCHRL_TUTORIAL_TIME_BUDGET environment
+variable (seconds); the --budget flag wins.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_TIMES_FILE = "docs/source/tutorials/sg_execution_times.rst"
+DEFAULT_BUDGET_SECONDS = 420.0
+
+# Matches list-table rows of the form:
+#    * - :ref:`sphx_glr_tutorials_coding_dqn.py` (``coding_dqn.py``)
+#      - 01:22.965
+_ROW = re.compile(
+    r"\(``(?P<name>[^`]+)``\)\s*\n\s*- (?P<time>[0-9:.]+)",
+    re.MULTILINE,
+)
+
+
+def _to_seconds(stamp: str) -> float:
+    """Convert ``[HH:]MM:SS.mmm`` to seconds."""
+    parts = stamp.split(":")
+    seconds = 0.0
+    for part in parts:
+        seconds = seconds * 60 + float(part)
+    return seconds
+
+
+def parse_times(text: str) -> dict[str, float]:
+    return {m["name"]: _to_seconds(m["time"]) for m in _ROW.finditer(text)}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("times_file", nargs="?", default=DEFAULT_TIMES_FILE)
+    parser.add_argument(
+        "--budget",
+        type=float,
+        default=float(
+            os.environ.get("TORCHRL_TUTORIAL_TIME_BUDGET", DEFAULT_BUDGET_SECONDS)
+        ),
+        help="Per-example budget in seconds.",
+    )
+    args = parser.parse_args(argv)
+
+    times_file = Path(args.times_file)
+    if not times_file.exists():
+        print(
+            f"ERROR: {times_file} not found. Either the docs build did not run, "
+            "sphinx-gallery stopped writing computation times "
+            "(write_computation_times in docs/source/conf.py), or the gallery "
+            "output moved. Update this check rather than deleting it."
+        )
+        return 1
+
+    times = parse_times(times_file.read_text(encoding="utf-8"))
+    if not times:
+        print(
+            f"ERROR: no execution times parsed from {times_file}. The "
+            "sphinx-gallery output format may have changed; update the parser "
+            "in this script."
+        )
+        return 1
+
+    print(f"Per-example budget: {args.budget:.0f}s. Parsed {len(times)} examples:")
+    over_budget = []
+    for name, seconds in sorted(times.items(), key=lambda item: -item[1]):
+        marker = " OVER BUDGET" if seconds > args.budget else ""
+        print(f"  {seconds:8.1f}s  {name}{marker}")
+        if seconds > args.budget:
+            over_budget.append((name, seconds))
+
+    if over_budget:
+        print(
+            f"\nERROR: {len(over_budget)} example(s) exceed the "
+            f"{args.budget:.0f}s budget:"
+        )
+        for name, seconds in over_budget:
+            print(f"  - {name}: {seconds:.1f}s")
+        print(
+            "Reduce the example's workload (fewer steps/rollouts, smaller "
+            "renders, TORCHRL_TUTORIALS_FAST gating) or, if the cost is "
+            "genuinely justified, raise TORCHRL_TUTORIAL_TIME_BUDGET in "
+            ".github/workflows/docs.yml."
+        )
+        return 1
+
+    print("All examples within budget.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -129,11 +129,18 @@ jobs:
         # 12. Build doc
         export MAX_IDLE_COUNT=180 # Max 180 secs before killing an unresponsive collector
         export BATCHED_PIPE_TIMEOUT=180
+        # Reduced tutorial workloads in CI (fewer rollouts, smaller renders);
+        # see the TUTORIAL_FAST blocks in tutorials/sphinx-tutorials/.
+        export TORCHRL_TUTORIALS_FAST=1
         cd ./docs
         # timeout 7m bash -ic "MUJOCO_GL=egl sphinx-build ./source _local_build" || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; fi
         # bash -ic "PYOPENGL_PLATFORM=egl MUJOCO_GL=egl sphinx-build ./source _local_build" || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; fi
         PYOPENGL_PLATFORM=egl MUJOCO_GL=egl TORCHRL_CONSOLE_STREAM=stdout sphinx-build ./source _local_build -v -j 4
         cd ..
+
+        # 13. Per-example time budget: fail loudly when a tutorial regresses
+        # the build (a single tutorial once tripled it, unnoticed for weeks).
+        python .github/scripts/check_tutorial_time_budget.py docs/source/tutorials/sg_execution_times.rst
 
         cp -r docs/_local_build/* "${RUNNER_ARTIFACT_DIR}"
         echo $(ls "${RUNNER_ARTIFACT_DIR}")

--- a/test/libs/test_mujoco.py
+++ b/test/libs/test_mujoco.py
@@ -1091,6 +1091,39 @@ class TestMujoco:
         assert rgb.shape == torch.Size([n, 24, 24, 3])
         assert rgb.dtype == torch.uint8
 
+    @pytest.mark.parametrize("backend", _AVAILABLE_BACKENDS)
+    def test_render_every(self, backend):
+        """``render_every=k`` reuses the cached frame on off-cadence steps
+        and renders fresh on resets and every k-th step."""
+        n = 1 if backend == "mujoco" else 2
+        env = SatelliteEnv(
+            num_cmgs=4,
+            num_envs=n,
+            seed=0,
+            backend=backend,
+            from_pixels=True,
+            render_width=32,
+            render_height=32,
+            render_every=3,
+        )
+        td = env.reset()
+        first = td["pixels"]
+        # Steps 1 and 2 reuse the reset frame (same tensor object).
+        for _ in range(2):
+            td = env.step(env.full_action_spec.zero())
+            assert td["next", "pixels"] is first
+        # Step 3 renders fresh.
+        td = env.step(env.full_action_spec.zero())
+        assert td["next", "pixels"] is not first
+        # A reset always renders fresh.
+        before_reset = env._last_pixels
+        td = env.reset()
+        assert td["pixels"] is not before_reset
+
+    def test_render_every_validation(self):
+        with pytest.raises(ValueError, match="render_every"):
+            SatelliteEnv(num_cmgs=4, num_envs=1, seed=0, render_every=0)
+
     @pytest.mark.skipif(not _has_mujoco, reason="CubeBowlEnv uses MuJoCo C bindings.")
     def test_cube_bowl_specs_and_rollout(self):
         env = CubeBowlEnv(**self._cube_bowl_kwargs(), seed=0, max_episode_steps=3)

--- a/torchrl/envs/custom/mujoco/base.py
+++ b/torchrl/envs/custom/mujoco/base.py
@@ -209,6 +209,13 @@ class MujocoEnv(EnvBase, abc.ABC, metaclass=_MujocoMeta):
             Requires ``from_pixels=True``.
         render_width: pixel observation width used when ``from_pixels=True``.
         render_height: pixel observation height used when ``from_pixels=True``.
+        render_every: render a fresh frame every ``render_every`` steps and
+            reuse the previous frame in between; resets always render fresh.
+            Rendering often dominates step cost, so consumers that subsample
+            frames anyway (e.g. :class:`~torchrl.record.VideoRecorder` with
+            ``skip``) should set this to the same stride instead of paying
+            for frames that are dropped. Defaults to ``1`` (render every
+            step).
         camera_id: MuJoCo camera id used for pixel observations and by
             :meth:`render` when no camera override is provided.
 
@@ -259,6 +266,7 @@ class MujocoEnv(EnvBase, abc.ABC, metaclass=_MujocoMeta):
         pixels_only: bool = False,
         render_width: int = 64,
         render_height: int = 64,
+        render_every: int = 1,
         camera_id: int = 0,
     ) -> None:
         super().__init__(device=device, batch_size=torch.Size([num_envs]))
@@ -278,6 +286,11 @@ class MujocoEnv(EnvBase, abc.ABC, metaclass=_MujocoMeta):
             raise ValueError("pixels_only=True requires from_pixels=True.")
         self.render_width = int(render_width)
         self.render_height = int(render_height)
+        self.render_every = int(render_every)
+        if self.render_every < 1:
+            raise ValueError(f"render_every must be >= 1, got {render_every}.")
+        self._last_pixels: torch.Tensor | None = None
+        self._render_counter = 0
         self.camera_id = int(camera_id)
 
         xml_string = self._load_xml(xml_path)
@@ -465,18 +478,37 @@ class MujocoEnv(EnvBase, abc.ABC, metaclass=_MujocoMeta):
     # Spec construction
     # ------------------------------------------------------------------
 
+    def _render_pixels(self) -> torch.Tensor:
+        """Render the pixel observation, honoring ``render_every``.
+
+        Off-cadence steps return the previous frame unchanged (the cached
+        tensor is replaced, never mutated in place, so handing it out
+        repeatedly is safe). ``_reset`` clears the cache so the first frame
+        of an episode is always fresh.
+        """
+        last = self._last_pixels
+        if (
+            self.render_every <= 1
+            or last is None
+            or last.shape[0] != self.num_envs
+            or self._render_counter % self.render_every == 0
+        ):
+            last = self._backend.render(
+                camera_id=self.camera_id,
+                width=self.render_width,
+                height=self.render_height,
+                background=self.RENDER_BACKGROUND,
+            )
+            self._last_pixels = last
+        return last
+
     def _build_obs_dict(self, state: TensorDictBase) -> dict[str, torch.Tensor]:
         """Assemble the obs dict, including ``pixels`` when ``from_pixels``."""
         out: dict[str, torch.Tensor] = {}
         if not self.pixels_only:
             out["observation"] = self._make_obs(state)
         if self.from_pixels:
-            out["pixels"] = self._backend.render(
-                camera_id=self.camera_id,
-                width=self.render_width,
-                height=self.render_height,
-                background=self.RENDER_BACKGROUND,
-            )
+            out["pixels"] = self._render_pixels()
         return out
 
     def _make_specs(self) -> None:
@@ -682,6 +714,10 @@ class MujocoEnv(EnvBase, abc.ABC, metaclass=_MujocoMeta):
             )
             self._on_reset_mask(reset_mask, tensordict)
 
+        # Force a fresh render on the first frame of the episode.
+        self._render_counter = 0
+        self._last_pixels = None
+
         state = self._state_td()
         obs = self._build_obs_dict(state)
         zero_flag = torch.zeros(self.num_envs, 1, dtype=torch.bool, device=self.device)
@@ -724,6 +760,7 @@ class MujocoEnv(EnvBase, abc.ABC, metaclass=_MujocoMeta):
         self._backend.step(ctrl, self.frame_skip)
         next_state = self._state_td()
         self._step_count += 1
+        self._render_counter += 1
 
         reward = self._compute_reward(state, action, next_state).to(self.dtype)
         if reward.ndim == 1:

--- a/torchrl/envs/custom/mujoco/cube_bowl.py
+++ b/torchrl/envs/custom/mujoco/cube_bowl.py
@@ -676,12 +676,7 @@ class CubeBowlEnv(MujocoEnv):
     def _build_obs_dict(self, state: TensorDictBase) -> dict[str, torch.Tensor]:
         out = self._make_obs_split(state) if not self.pixels_only else {}
         if self.from_pixels:
-            out["pixels"] = self._backend.render(
-                camera_id=self.camera_id,
-                width=self.render_width,
-                height=self.render_height,
-                background=self.RENDER_BACKGROUND,
-            )
+            out["pixels"] = self._render_pixels()
         return out
 
     def _make_obs_split(self, state: TensorDictBase) -> dict[str, torch.Tensor]:

--- a/torchrl/envs/custom/mujoco/satellite.py
+++ b/torchrl/envs/custom/mujoco/satellite.py
@@ -553,12 +553,7 @@ class SatelliteEnv(MujocoEnv):
         if not self.pixels_only:
             out.update(self._make_obs_split(state))
         if self.from_pixels:
-            out["pixels"] = self._backend.render(
-                camera_id=self.camera_id,
-                width=self.render_width,
-                height=self.render_height,
-                background=self.RENDER_BACKGROUND,
-            )
+            out["pixels"] = self._render_pixels()
         return out
 
     def _compute_reward(

--- a/tutorials/sphinx-tutorials/mujoco_cube_bowl_macros.py
+++ b/tutorials/sphinx-tutorials/mujoco_cube_bowl_macros.py
@@ -79,9 +79,21 @@ if MENAGERIE_PATH is None:
         "before running this tutorial."
     )
 
+# %%
+# CI fast path
+# ------------
+#
+# Rendering dominates the runtime of this tutorial, and the doc build does not
+# need four randomized rollouts to illustrate the API. When
+# ``TORCHRL_TUTORIALS_FAST=1`` (set in the docs CI workflow), we render at a
+# smaller resolution and run a single randomized rollout. Local builds keep
+# the full-quality settings.
+
+TUTORIAL_FAST = os.environ.get("TORCHRL_TUTORIALS_FAST", "0") == "1"
+
 MAX_EPISODE_STEPS = 12000
-RENDER_WIDTH = 480
-RENDER_HEIGHT = 360
+RENDER_WIDTH = 320 if TUTORIAL_FAST else 480
+RENDER_HEIGHT = 240 if TUTORIAL_FAST else 360
 VIDEO_FRAME_SKIP = 16
 VIDEO_INTERVAL_MS = 55
 IK_KWARGS = {
@@ -129,6 +141,9 @@ IK_KWARGS = {
 # ``env.step`` accepts a ``RobotMacroAction`` directly under ``td["action"]`` and
 # executes the expanded low-level sequence internally.
 
+# ``render_every`` matches the recorder's ``skip``: the recorder keeps one
+# frame in ``VIDEO_FRAME_SKIP``, so rendering the frames it drops would only
+# burn time (rendering dominates the cost of a step in this scene).
 env = CubeBowlEnv(
     seed=0,
     max_episode_steps=MAX_EPISODE_STEPS,
@@ -137,6 +152,7 @@ env = CubeBowlEnv(
     pixels_only=False,
     render_width=RENDER_WIDTH,
     render_height=RENDER_HEIGHT,
+    render_every=VIDEO_FRAME_SKIP,
 )
 assert env.action_spec.shape[-1] == 7
 assert env.robot_home_qpos is not None
@@ -584,7 +600,9 @@ scripted_macro_animation = recorder.to_animation(
 # appending frames until we ask it to render, so the final video is one long
 # clip containing all four randomized rollouts.
 
-rollout_count = len(workspace_layouts)
+# In the CI fast path a single randomized rollout is enough to demonstrate
+# the reset-onto-new-layout mechanics.
+rollout_count = 1 if TUTORIAL_FAST else len(workspace_layouts)
 for rollout_index in range(rollout_count):
     td = env.reset(random_scene_reset(rollout_index))
     td = run_scripted_rollout(td)


### PR DESCRIPTION
## Motivation

The doc build went from ~33 to ~78 min on June 3 when the MuJoCo macros tutorial landed. Profiling the sphinx-gallery computation times: `mujoco_cube_bowl_macros.py` executes for **2,695 s (~45 min)** per build. The root cause is wasted rendering: five scripted rollouts of ~2,600 low-level steps each render a 480x360 frame through software GL on **every** physics step, while the `VideoRecorder` (`skip=16`) drops 15 of every 16 frames.

## Changes

### 1. `MujocoEnv.render_every` (new kwarg)

Render a fresh frame every k-th step and reuse the cached frame in between; resets always render fresh, and the cache is replaced (never mutated in place) so handing the same tensor out repeatedly is safe. The render call moves into a shared `_render_pixels()` helper used by the base class and the `CubeBowlEnv` / `SatelliteEnv` `_build_obs_dict` overrides (which previously duplicated the render block). `render_every=1` (default) preserves current behavior exactly.

The tutorial sets `render_every=VIDEO_FRAME_SKIP` so the env only renders the frames the recorder keeps: ~16x on the dominant cost. Kept frames can lag the sim by up to `render_every - 1` low-level steps (a constant phase shift at the same temporal stride) which is invisible in practice.

### 2. Tutorial CI fast path

With `TORCHRL_TUTORIALS_FAST=1` (now exported in `docs.yml`) the macros tutorial renders at 320x240 and runs one randomized rollout instead of four. Local builds keep full quality. The scripted-policy asserts are unaffected (rendering does not touch physics).

### 3. Per-example time budget

`.github/scripts/check_tutorial_time_budget.py` parses sphinx-gallery's `sg_execution_times.rst` after the build and fails when any example exceeds the budget (`TORCHRL_TUTORIAL_TIME_BUDGET`, default 420 s). The June 3 regression sat unnoticed for a month; this makes the next one fail the PR that introduces it. The script also errors when the times file is missing or unparseable, so the guard cannot rot silently. Verified against a reproduction of the actual regression (flags the 2,695 s entry, passes current-shaped data, correct exit codes on missing/empty input).

## Expected effect

Macros tutorial ~45 min -> ~2-4 min; doc build back to roughly 30 min (the remaining next-biggest entry is `llm_wrappers.py` at ~245 s, under budget but worth its own look).

## Tests

- `test_render_every` (frame reuse + fresh on cadence and resets) and `test_render_every_validation` added to `test/libs/test_mujoco.py`; pass locally on the available backends (the `mujoco-torch` backend fails locally on an unrelated pre-existing `mjENBL_MULTICCD` version incompatibility that also affects the existing pixel tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)