### PR TITLE
[Feature] VideoRecorder frame cap, dump-on-done and batched-worker warning

### DIFF
--- a/test/collectors/test_evaluator.py
+++ b/test/collectors/test_evaluator.py
@@ -21,6 +21,7 @@ from torchrl.collectors._evaluator import (
     _freeze_vecnorm,
     _wrap_env_factory_frozen,
 )
+from torchrl.data import Unbounded
 from torchrl.envs import SerialEnv, TransformedEnv
 from torchrl.envs.env_creator import EnvCreator
 from torchrl.envs.transforms import (
@@ -30,6 +31,8 @@ from torchrl.envs.transforms import (
     Transform,
     VecNormV2,
 )
+from torchrl.record import VideoRecorder
+from torchrl.record.loggers.process import ProcessLogger
 from torchrl.testing.mocking_classes import ContinuousActionVecMockEnv
 from torchrl.weight_update import WeightStrategy
 
@@ -62,6 +65,60 @@ class _DumpStep(Transform):
 
 def _make_dump_env(path: str):
     return TransformedEnv(_make_env(), Compose(_DumpStep(path)))
+
+
+class _VideoEventsLogger:
+    """Duck-typed logger that appends each ``log_video`` call to a file."""
+
+    def __init__(self, log_dir):
+        self.exp_name = "evaluator-video-test"
+        self.log_dir = str(log_dir)
+
+    def log_video(self, name, video, step=None, **kwargs):
+        del kwargs
+        with open(Path(self.log_dir) / "videos", "a") as file:
+            file.write(f"{name}:{step}:{video.shape[1]}\n")
+
+
+class _AddPixels(Transform):
+    """Writes a constant uint8 image so ``VideoRecorder`` has frames to record."""
+
+    def __init__(self):
+        super().__init__(in_keys=[], out_keys=["pixels"])
+
+    def _call(self, next_tensordict):
+        next_tensordict.set("pixels", torch.zeros(3, 8, 8, dtype=torch.uint8))
+        return next_tensordict
+
+    def _reset(self, tensordict, tensordict_reset):
+        return self._call(tensordict_reset)
+
+    def transform_observation_spec(self, observation_spec):
+        observation_spec["pixels"] = Unbounded(
+            shape=(3, 8, 8), dtype=torch.uint8, device=observation_spec.device
+        )
+        return observation_spec
+
+
+def _make_video_env(video_logger):
+    return TransformedEnv(
+        _make_env(),
+        Compose(
+            _AddPixels(),
+            VideoRecorder(
+                video_logger,
+                tag="eval_video",
+                in_keys=["pixels"],
+                skip=1,
+                make_grid=False,
+            ),
+        ),
+    )
+
+
+def _read_video_events(log_dir):
+    lines = (Path(log_dir) / "videos").read_text().splitlines()
+    return [line.split(":") for line in lines]
 
 
 class TestEvaluatorSync:
@@ -114,6 +171,27 @@ class TestEvaluatorSync:
         try:
             metrics = evaluator.evaluate(weights=train_policy, step=0)
             assert "eval/reward" in metrics
+        finally:
+            evaluator.shutdown()
+
+    def test_video_recorder_dump(self, tmp_path):
+        # Thread/same-process backend: the recorder is dumped locally by
+        # walking the env transform, once per eval at the requested step.
+        logger = _VideoEventsLogger(str(tmp_path))
+        env = _make_video_env(logger)
+        policy = _make_policy(env)
+        evaluator = Evaluator(
+            env, policy, num_trajectories=2, max_steps=10, dump_video=True
+        )
+        try:
+            evaluator.evaluate(step=11)
+            evaluator.evaluate(step=22)
+            records = _read_video_events(tmp_path)
+            assert [record[:2] for record in records] == [
+                ["eval_video", "11"],
+                ["eval_video", "22"],
+            ]
+            assert all(int(record[2]) > 0 for record in records)
         finally:
             evaluator.shutdown()
 
@@ -626,6 +704,34 @@ class TestEvaluatorProcess:
             assert metrics["eval/step"] == 456
         finally:
             evaluator.shutdown()
+
+    def test_video_recorder_dumps_to_process_logger(self, tmp_path):
+        # End-to-end: the eval env (with a VideoRecorder) lives in the
+        # collector worker process; the recorder logs through a picklable
+        # ProcessLogger client back to the parent-owned logger service.
+        process_logger = ProcessLogger(_VideoEventsLogger, str(tmp_path))
+        evaluator = Evaluator(
+            partial(_make_video_env, process_logger.client()),
+            policy_factory=_make_policy,
+            num_trajectories=2,
+            max_steps=10,
+            dump_video=True,
+            backend="process",
+        )
+        try:
+            evaluator.evaluate(step=3)
+            evaluator.evaluate(step=7)
+            process_logger.flush(timeout=30)
+            records = _read_video_events(tmp_path)
+            # exactly one worker-side dump per eval, at the requested step
+            assert [record[:2] for record in records] == [
+                ["eval_video", "3"],
+                ["eval_video", "7"],
+            ]
+            assert all(int(record[2]) > 0 for record in records)
+        finally:
+            evaluator.shutdown()
+            process_logger.shutdown(timeout=30)
 
     def test_dump_video_dispatches_compose_dump_in_worker(self, tmp_path):
         dump_path = tmp_path / "dump-step"

--- a/test/transforms/test_timer_video.py
+++ b/test/transforms/test_timer_video.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import importlib.util
+import logging
 import sys
 
 import pytest
@@ -15,7 +16,16 @@ from _transforms_common import TransformBase
 from tensordict import LazyStackedTensorDict, TensorDict
 from torch import nn
 
-from torchrl.envs import Compose, SerialEnv, StepCounter, Timer, TransformedEnv
+from torchrl._utils import logger as torchrl_logger
+from torchrl.data import Unbounded
+from torchrl.envs import (
+    Compose,
+    SerialEnv,
+    StepCounter,
+    Timer,
+    Transform,
+    TransformedEnv,
+)
 from torchrl.envs.utils import check_env_specs
 from torchrl.record.recorder import VideoRecorder
 
@@ -130,6 +140,48 @@ class TestTimer(TransformBase):
         raise pytest.skip("Tested elsewhere")
 
 
+class _AddPixels(Transform):
+    """Writes a constant uint8 image so ``VideoRecorder`` has frames to record."""
+
+    def __init__(self):
+        super().__init__(in_keys=[], out_keys=["pixels"])
+
+    def _call(self, next_tensordict):
+        next_tensordict.set(
+            "pixels",
+            torch.zeros(*next_tensordict.batch_size, 3, 8, 8, dtype=torch.uint8),
+        )
+        return next_tensordict
+
+    def _reset(self, tensordict, tensordict_reset):
+        return self._call(tensordict_reset)
+
+    def transform_observation_spec(self, observation_spec):
+        observation_spec["pixels"] = Unbounded(
+            shape=(*observation_spec.shape, 3, 8, 8),
+            dtype=torch.uint8,
+            device=observation_spec.device,
+        )
+        return observation_spec
+
+
+class _CaptureVideoLogger:
+    """Duck-typed logger that stores each ``log_video`` call."""
+
+    def __init__(self):
+        self.calls = []
+
+    def log_video(self, name=None, video=None, step=None, **kwargs):
+        self.calls.append({"name": name, "video": video, "step": step, **kwargs})
+
+
+def _make_pixels_env(max_steps=None):
+    transforms = [_AddPixels()]
+    if max_steps is not None:
+        transforms.append(StepCounter(max_steps=max_steps))
+    return TransformedEnv(ContinuousActionVecMockEnv(), Compose(*transforms))
+
+
 class TestVideoRecorder:
     # TODO: add more tests
     def test_can_init_with_fps(self):
@@ -174,3 +226,78 @@ class TestVideoRecorder:
         assert len(recorder.obs) == 4
         for frame in recorder.obs:
             assert frame.shape == (3, 64, 64)
+
+    def test_video_recorder_batched_env_grid(self):
+        """A recorder attached outside a batched env records one grid video."""
+        logger = _CaptureVideoLogger()
+        env = TransformedEnv(
+            SerialEnv(2, _make_pixels_env),
+            VideoRecorder(logger, tag="grid_video"),
+        )
+        env.rollout(3)
+        env.transform.dump(step=0)
+        env.close()
+        assert len(logger.calls) == 1
+        video = logger.calls[0]["video"]
+        # one reset frame + 3 step frames, each a 1x2 grid of 8x8 workers
+        assert video.shape == (1, 4, 3, 8, 16)
+
+    def test_video_recorder_max_frames(self):
+        with pytest.raises(ValueError, match="max_frames"):
+            VideoRecorder(None, None, max_frames=0)
+
+        recorder = VideoRecorder(None, None, max_frames=3)
+        for _ in range(5):
+            recorder._apply_transform(torch.zeros(3, 16, 16, dtype=torch.uint8))
+        assert len(recorder.obs) == 3
+        # dump empties the buffer, then recording resumes
+        recorder.dump()
+        recorder._apply_transform(torch.zeros(3, 16, 16, dtype=torch.uint8))
+        assert len(recorder.obs) == 1
+
+    def test_video_recorder_max_frames_batched(self):
+        """The frame cap also truncates flattened batch extensions."""
+        recorder = VideoRecorder(None, None, max_frames=5, make_grid=False)
+        recorder._apply_transform(torch.zeros(4, 3, 16, 16, dtype=torch.uint8))
+        recorder._apply_transform(torch.zeros(4, 3, 16, 16, dtype=torch.uint8))
+        recorder._apply_transform(torch.zeros(4, 3, 16, 16, dtype=torch.uint8))
+        assert len(recorder.obs) == 5
+
+    @pytest.mark.parametrize("batched", [False, True])
+    def test_video_recorder_dump_on_done(self, batched):
+        logger = _CaptureVideoLogger()
+        recorder = VideoRecorder(logger, tag="done_video", dump_on_done=True, skip=1)
+        if batched:
+            base = SerialEnv(2, lambda: _make_pixels_env(max_steps=4))
+        else:
+            base = _make_pixels_env(max_steps=4)
+        env = TransformedEnv(base, recorder)
+        env.rollout(10)
+        env.close()
+        # the episode-ending step (StepCounter truncation) triggered the dump
+        assert len(logger.calls) == 1
+        video = logger.calls[0]["video"]
+        # one reset frame + 4 step frames
+        assert video.shape[1] == 5
+        assert not recorder.obs
+
+    def test_video_recorder_in_batched_worker_warns(self):
+        records = []
+
+        class _Handler(logging.Handler):
+            def emit(self, record):
+                records.append(record.getMessage())
+
+        handler = _Handler()
+        torchrl_logger.addHandler(handler)
+        try:
+            SerialEnv(
+                2,
+                lambda: TransformedEnv(
+                    ContinuousActionVecMockEnv(),
+                    Compose(_AddPixels(), VideoRecorder(None, None)),
+                ),
+            )
+        finally:
+            torchrl_logger.removeHandler(handler)
+        assert any("VideoRecorder" in message for message in records)

--- a/torchrl/collectors/_evaluator.py
+++ b/torchrl/collectors/_evaluator.py
@@ -156,6 +156,33 @@ class Evaluator:
     env so that per-episode returns are tracked.  Without it, the
     evaluator falls back to summing raw rewards over each trajectory.
 
+    **Eval video logging**: when the eval env contains a
+    :class:`~torchrl.record.VideoRecorder`, each evaluation ends with a
+    ``dump(step=...)`` on the env transforms of the collector that ran
+    the rollout (disable with ``dump_video=False``).  With
+    ``backend="process"`` the recorder lives inside the collector worker,
+    so build it in the env factory around a picklable logger client such
+    as :meth:`ProcessLogger.client()
+    <torchrl.record.loggers.process.ProcessLogger.client>`::
+
+        from torchrl.record import VideoRecorder
+        from torchrl.record.loggers import CSVLogger, ProcessLogger
+
+        logger = ProcessLogger(CSVLogger, exp_name="run", log_dir="logs")
+        video_client = logger.client()
+
+        def make_eval_env():
+            env = make_env()
+            env.append_transform(VideoRecorder(video_client, tag="eval/video"))
+            return env
+
+        evaluator = Evaluator(
+            make_eval_env,
+            policy_factory=make_eval_policy,
+            max_steps=1000,
+            backend="process",
+        )
+
     Args:
         env: An :class:`~torchrl.envs.EnvBase` instance **or** a callable
             that returns one.  For the ``"process"`` and ``"ray"`` backends
@@ -1248,29 +1275,21 @@ class _ThreadEvalBackend(_EvalBackend):
         """Dump accumulated video frames from VideoRecorder transforms.
 
         Process-backed evaluator collectors dispatch ``Compose.dump`` to the
-        worker that owns the environment. Direct evaluators call it locally.
+        worker that owns the environment. Same-process evaluators dump the
+        collector's own env: the collector may wrap the user env (e.g. to add
+        a ``StepCounter``), cloning its transforms, so the recorder that
+        accumulated frames is the collector-side one, not the transform of
+        the env handed to the evaluator.
         """
-        if self._use_multi_collector and self._collector is not None:
+        if self._collector is None:
+            return
+        if self._use_multi_collector:
             self._collector.map_fn(
                 "_dump_env_transform",
                 list_of_kwargs=[{"step": step}] * self._collector.num_workers,
             )
             return
-        if self._env is None or not hasattr(self._env, "transform"):
-            return
-        transform = self._env.transform
-        dump = getattr(transform, "dump", None)
-        if callable(dump):
-            dump(step=step)
-            return
-        try:
-            transforms = iter(transform)
-        except TypeError:
-            return
-        for item in transforms:
-            dump = getattr(item, "dump", None)
-            if callable(dump):
-                dump(step=step)
+        self._collector._dump_env_transform(step=step)
 
 
 # ======================================================================

--- a/torchrl/collectors/_evaluator.py
+++ b/torchrl/collectors/_evaluator.py
@@ -159,10 +159,14 @@ class Evaluator:
     **Eval video logging**: when the eval env contains a
     :class:`~torchrl.record.VideoRecorder`, each evaluation ends with a
     ``dump(step=...)`` on the env transforms of the collector that ran
-    the rollout (disable with ``dump_video=False``).  With
-    ``backend="process"`` the recorder lives inside the collector worker,
-    so build it in the env factory around a picklable logger client such
-    as :meth:`ProcessLogger.client()
+    the rollout (disable with ``dump_video=False``).  The recorder must
+    be attached to the *outermost* env: recorders nested inside the
+    worker envs of a :class:`~torchrl.envs.SerialEnv` /
+    :class:`~torchrl.envs.ParallelEnv` are not reached by the dump and
+    would accumulate frames indefinitely.  With ``backend="process"``
+    the recorder lives inside the collector worker, so build it in the
+    env factory around a picklable logger client such as
+    :meth:`ProcessLogger.client()
     <torchrl.record.loggers.process.ProcessLogger.client>`::
 
         from torchrl.record import VideoRecorder

--- a/torchrl/record/recorder.py
+++ b/torchrl/record/recorder.py
@@ -14,7 +14,7 @@ import numpy as np
 import torch
 from tensordict import NonTensorData, TensorDictBase
 from tensordict.utils import NestedKey
-from torchrl._utils import _can_be_pickled
+from torchrl._utils import _can_be_pickled, _ends_with, logger as torchrl_logger
 from torchrl.data.tensor_specs import NonTensor, TensorSpec, Unbounded
 from torchrl.data.utils import CloudpickleWrapper
 from torchrl.envs import EnvBase
@@ -65,6 +65,16 @@ class VideoRecorder(ObservationTransform):
             to ``in_keys`` if not provided.
         fps (int, optional): Frames per second of the output video. Defaults to the logger predefined ``fps``,
             and overrides it if provided.
+        max_frames (int, optional): maximum number of frames held in the
+            recorder buffer. Once the buffer is full, new frames are
+            discarded until :meth:`dump` empties it. Use this to bound
+            memory when dumps are infrequent (or could be missed
+            altogether). Unbounded by default.
+        dump_on_done (bool, optional): if ``True``, the recorder calls
+            :meth:`dump` on its own whenever a step ends the episode, i.e.
+            whenever all the ``"done"`` entries of the root tensordict are
+            ``True`` (for a batched env, this means every sub-env is done
+            at the same step). Defaults to ``False``.
         **kwargs (Dict[str, Any], optional): additional keyword arguments for
             :meth:`~torchrl.record.loggers.Logger.log_video`.
 
@@ -139,11 +149,17 @@ class VideoRecorder(ObservationTransform):
         make_grid: bool | None = None,
         out_keys: Sequence[NestedKey] | None = None,
         fps: int | None = None,
+        max_frames: int | None = None,
+        dump_on_done: bool = False,
         **kwargs,
     ) -> None:
         client = getattr(logger, "client", None)
         if callable(client):
             logger = client()
+        if max_frames is not None and max_frames <= 0:
+            raise ValueError(
+                f"max_frames must be a positive integer, got {max_frames}."
+            )
         if in_keys is None:
             in_keys = ["pixels"]
         if out_keys is None:
@@ -161,6 +177,8 @@ class VideoRecorder(ObservationTransform):
         self.count = 0
         self.center_crop = center_crop
         self.make_grid = make_grid
+        self.max_frames = max_frames
+        self.dump_on_done = dump_on_done
         if center_crop and not _has_tv:
             raise ImportError(
                 "Could not load center_crop from torchvision. Make sure torchvision is installed."
@@ -207,6 +225,8 @@ class VideoRecorder(ObservationTransform):
             observation_trsf = observation
         self.count += 1
         if self.count % self.skip == 0:
+            if self.max_frames is not None and len(self.obs) >= self.max_frames:
+                return observation
             if (
                 observation_trsf.ndim >= 3
                 and observation_trsf.shape[-3] in (1, 3)
@@ -258,13 +278,49 @@ class VideoRecorder(ObservationTransform):
                 observation_trsf = _make_video_grid(obs_flat)
                 self.obs.append(observation_trsf.to("cpu", torch.uint8))
             elif observation_trsf.ndimension() >= 4:
-                self.obs.extend(observation_trsf.to("cpu", torch.uint8).flatten(0, -4))
+                frames = observation_trsf.to("cpu", torch.uint8).flatten(0, -4)
+                if self.max_frames is not None:
+                    frames = frames[: self.max_frames - len(self.obs)]
+                self.obs.extend(frames)
             else:
                 self.obs.append(observation_trsf.to("cpu", torch.uint8))
         return observation
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         return self._call(tensordict)
+
+    def _step(
+        self, tensordict: TensorDictBase, next_tensordict: TensorDictBase
+    ) -> TensorDictBase:
+        next_tensordict = super()._step(tensordict, next_tensordict)
+        if self.dump_on_done and self._all_done(next_tensordict):
+            self.dump()
+        return next_tensordict
+
+    def _all_done(self, next_tensordict: TensorDictBase) -> bool:
+        """Whether every ``"done"`` entry of the post-step data is ``True``."""
+        parent = self.parent
+        if parent is not None:
+            done_keys = [key for key in parent.done_keys if _ends_with(key, "done")]
+        else:
+            done_keys = ["done"]
+        dones = [next_tensordict.get(key, None) for key in done_keys]
+        dones = [done for done in dones if done is not None]
+        if not dones:
+            return False
+        return all(bool(done.all()) for done in dones)
+
+    def _check_batched_worker_compat(self) -> None:
+        torchrl_logger.warning(
+            "A VideoRecorder was found among the transforms of a "
+            "SerialEnv/ParallelEnv worker env. Worker-side transforms are not "
+            "reached by `dump` calls issued on the outer env or by collectors "
+            "and evaluators, so recorded frames accumulate until dumped "
+            "manually (consider `max_frames` or `dump_on_done` to bound "
+            "memory). Prefer attaching the recorder to the outer env, e.g. "
+            "TransformedEnv(ParallelEnv(N, make_env), VideoRecorder(...)), "
+            "which records all worker envs into a single grid video."
+        )
 
     def to_animation(
         self,

--- a/torchrl/record/recorder.py
+++ b/torchrl/record/recorder.py
@@ -93,6 +93,17 @@ class VideoRecorder(ObservationTransform):
 
         >>> env.transform.dump()
 
+    .. note::
+        When recording a batched env (:class:`~torchrl.envs.SerialEnv` or
+        :class:`~torchrl.envs.ParallelEnv`), attach the recorder to the
+        *outer* env, e.g.
+        ``TransformedEnv(ParallelEnv(N, make_env), VideoRecorder(...))``,
+        so that the batch is tiled into a single grid video
+        (``make_grid=True``). Recorders living inside the worker envs of a
+        batched env are not reached by ``dump`` calls issued on the outer
+        env or by collectors and evaluators, and would accumulate frames
+        indefinitely.
+
         The transform can also be used within a dataset to save the video collected. Unlike in the environment case,
         images will come in a batch. The ``skip`` argument will enable to save the images only at specific intervals.
 


### PR DESCRIPTION
## Description

Follow-up to #3954 (stacked on it — its two commits appear here until it merges).

Recorders nested inside `SerialEnv`/`ParallelEnv` worker envs are not reached by `dump` calls issued on the outer env or by collectors/evaluators, so they silently accumulate frames forever. #3954 documents this; this PR makes the footgun announce itself and rounds out the recorder for batched usage.

## Changes

- **Batched-worker warning**: `VideoRecorder` now overrides `Transform._check_batched_worker_compat`, which `SerialEnv`/`ParallelEnv` invoke on every worker-env transform at construction. Building a batched env whose workers contain a recorder logs a warning pointing to the supported pattern (recorder on the outer env). A warning rather than a raise, since manual per-worker dumping does function on a bare `ParallelEnv` through attribute dispatch.
- **`max_frames` (new kwarg)**: bounds the recorder buffer. Once full, new frames are discarded until the next `dump` empties the buffer (flattened batch extensions are truncated to the cap). Bounds memory when dumps are infrequent or missed.
- **`dump_on_done` (new kwarg)**: when `True`, the recorder dumps on its own whenever a step ends the episode, i.e. when all `"done"` entries of the post-step data are `True` — for a batched env, every sub-env done at the same step.
- **Grid recording from batched envs**: already worked (`make_grid` tiles the `[B, ...]` batch into one frame via `_make_video_grid`); now covered by an end-to-end `SerialEnv` test asserting the tiled video shape.

## Tests

New tests in `test/transforms/test_timer_video.py::TestVideoRecorder`:

- `test_video_recorder_batched_env_grid`: recorder outside a `SerialEnv(2)` records a single `(1, T, 3, 8, 16)` grid video.
- `test_video_recorder_max_frames` / `test_video_recorder_max_frames_batched`: cap enforcement on both the append and the flattened-batch extend paths, plus recording resumption after `dump`.
- `test_video_recorder_dump_on_done` (parametrized single/batched): the episode-ending step triggers exactly one autonomous dump with all recorded frames.
- `test_video_recorder_in_batched_worker_warns`: constructing a batched env with a worker-side recorder emits the warning.

```
pytest test/transforms/test_timer_video.py  # 19 passed, 2 skipped (matplotlib / tested elsewhere)
pytest test/collectors/test_evaluator.py -k "video or dump"  # 3 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)