### PR TITLE
[Feature] Add configurable transports to TorchRL services

### DIFF
--- a/docs/source/reference/collectors_distributed.rst
+++ b/docs/source/reference/collectors_distributed.rst
@@ -10,6 +10,14 @@ or PyTorch RPC with :class:`~.RPCCollector`) and launchers (``'ray'``,
 They can be efficiently used in synchronous or asynchronous mode, on a single
 node or across multiple nodes.
 
+``RayCollector`` uses Ray to place and control its worker actors, but an
+attached inference server or replay buffer selects its own payload transport.
+With a replay buffer attached, workers write rollouts directly through the
+replay endpoint instead of returning them to the driver. Without one, yielded
+rollouts use Ray's object store. See :ref:`ref_service_transports` for the
+backend/transport compatibility table and the recommended direct-to-replay
+topology.
+
 *Resources*: Find examples for these collectors in the
 `dedicated folder <https://github.com/pytorch/rl/examples/distributed/collectors>`_.
 

--- a/docs/source/reference/data_replaybuffers.rst
+++ b/docs/source/reference/data_replaybuffers.rst
@@ -13,7 +13,10 @@ Replay buffers use ``service_backend="direct"`` by default, where
 ``buffer.client() is buffer``. ``service_backend="ray"`` constructs a
 :class:`RayReplayBuffer` owner and ``client()`` returns the restricted,
 picklable handle intended for collector workers. Only the owner can shut down
-the actor.
+the actor. A Ray-owned replay buffer accepts either the flexible Ray payload
+transport or a fixed-layout Gloo/NCCL tensor transport. See
+:ref:`ref_service_transports` for the compatibility table, payload
+restrictions, and expected performance trade-offs.
 
 .. code-block:: python
 
@@ -24,6 +27,8 @@ the actor.
         storage=partial(LazyTensorStorage, 1000),
         service_backend="ray",
         service_backend_options={"remote_config": {"num_cpus": 1}},
+        transport="distributed",
+        transport_options={"backend": "gloo"},
     )
     worker_buffer = buffer.client()
     buffer.shutdown()

--- a/docs/source/reference/modules_inference_server.rst
+++ b/docs/source/reference/modules_inference_server.rst
@@ -27,6 +27,16 @@ Core API
 Transport Backends
 ------------------
 
+The transport can be selected behind the high-level
+:class:`InferenceServer` constructor. Both process- and Ray-owned servers can
+use ``transport="distributed"`` with Gloo/NCCL for fixed-layout TensorDict
+payloads. A process-owned server requires explicit ``request_spec`` and
+``response_spec`` values before its subprocess starts; a Ray-owned server can
+bind those layouts on first use. Ray-owned inference can instead use
+``transport="ray"`` for dynamic or non-tensor payloads. See
+:ref:`ref_service_transports` for supported owner/transport combinations,
+restrictions, and expected performance.
+
 .. autosummary::
     :toctree: generated/
     :template: rl_template_noinherit.rst

--- a/docs/source/reference/services_workflow.rst
+++ b/docs/source/reference/services_workflow.rst
@@ -107,6 +107,199 @@ process deployment can place inference and logging in child processes while
 keeping a replay buffer direct. This avoids presenting a process replay
 backend whose performance and data-movement contract have not been defined.
 
+.. _ref_service_transports:
+
+Choosing a payload transport
+----------------------------
+
+Ray can be used for ownership without requiring TensorDict payloads to travel
+through Ray. With ``service_backend="ray"``, Ray creates, places, monitors, and
+stops the service actor. The separate ``transport`` argument selects how
+clients exchange payloads with that actor:
+
+* ``transport="ray"`` uses Ray calls, queues, and the Ray object store. It is
+  the flexible option for changing layouts and Python or non-tensor values.
+* ``transport="distributed"`` uses standalone PyTorch distributed
+  point-to-point groups for fixed-layout TensorDict payloads. Gloo carries CPU
+  tensors and NCCL carries CUDA tensors.
+* ``transport="auto"`` selects the placement default. For a Ray-owned service
+  it currently resolves to ``"ray"``; it does not inspect the payload or
+  silently switch transports later.
+
+Ray remains the control and placement plane when the distributed payload path
+is selected. Transport-owned process groups do not replace or destroy the
+application's default process group. The current distributed implementation
+is point-to-point request/reply. Collective data movement can be added behind
+the same selector when a component has a collective communication pattern.
+
+The supported combinations are listed below. An em dash means that the
+combination is rejected during construction rather than falling back to a
+different transport.
+
+.. list-table:: Service-backend and transport compatibility
+   :header-rows: 1
+   :widths: 23 12 13 13 13 26
+
+   * - Component
+     - ``service_backend``
+     - ``auto``
+     - ``ray``
+     - ``distributed``
+     - Other supported transports
+   * - :class:`~torchrl.data.ReplayBuffer`
+     - ``direct``
+     - ``direct``
+     - --
+     - --
+     - ``direct``
+   * - :class:`~torchrl.data.RayReplayBuffer` or a replay buffer constructed
+       with ``service_backend="ray"``
+     - ``ray``
+     - ``ray``
+     - Yes
+     - Gloo or NCCL
+     - --
+   * - :class:`~torchrl.modules.inference_server.InferenceServer`
+     - ``thread``
+     - ``thread``
+     - --
+     - --
+     - ``thread``, ``queue``, or ``direct``
+   * - :class:`~torchrl.modules.inference_server.InferenceServer`
+     - ``process``
+     - ``process``
+     - --
+     - Gloo or NCCL [1]_
+     - ``process`` or ``shared_memory``
+   * - :class:`~torchrl.modules.inference_server.InferenceServer`
+     - ``ray``
+     - ``ray``
+     - Yes
+     - Gloo or NCCL
+     - --
+
+.. [1] Process-owned distributed inference requires explicit
+   ``request_spec`` and ``response_spec`` values. Ray-owned inference can bind
+   those layouts lazily on first use.
+
+Transport characteristics
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Performance depends on payload size, request rate, topology, and batching.
+The following table describes expected trade-offs rather than promising a
+universal ordering.
+
+.. list-table:: Payload transport characteristics
+   :header-rows: 1
+   :widths: 14 18 17 15 36
+
+   * - Transport
+     - Layout
+     - Payload values
+     - Device
+     - Expected behavior
+   * - ``thread`` / ``direct``
+     - Dynamic
+     - Values accepted by the component
+     - Same process
+     - Lowest communication overhead. There is no serialization boundary;
+       batching and model execution usually dominate.
+   * - ``process``
+     - Dynamic
+     - Pickle-compatible values, including non-tensor data
+     - Multiprocessing-supported
+     - Flexible, but queueing and serialization make large or frequent
+       payloads more expensive than a preallocated tensor path.
+   * - ``shared_memory``
+     - Fixed keys, shapes, dtypes, and batch sizes
+     - Tensor leaves only
+     - CPU
+     - Preallocated slots avoid pickling tensor contents. This is generally a
+       better process-local choice for large, stable CPU TensorDict payloads.
+   * - ``ray``
+     - Dynamic
+     - Ray-serializable values, including strings and non-tensor data
+     - Ray-supported
+     - Easiest remote option and the compatibility fallback. Ray RPC, queue,
+       and object-store overhead can dominate small, frequent RL messages.
+   * - ``distributed`` with Gloo
+     - Fixed keys, shapes, dtypes, devices, and batch sizes
+     - Tensor leaves only
+     - CPU
+     - Avoids putting steady-state tensor payloads through Ray. It is usually
+       preferable for stable CPU TensorDict traffic once rendezvous and group
+       setup costs are amortized.
+   * - ``distributed`` with NCCL
+     - Fixed keys, shapes, dtypes, devices, and batch sizes
+     - Tensor leaves only
+     - CUDA
+     - Sends CUDA tensors without CPU staging. It is intended for stable,
+       sufficiently large GPU payloads; setup and per-message latency may
+       outweigh the benefit for small requests. Assign each NCCL rank a
+       distinct GPU in normal deployments. Colocating ranks on one GPU is
+       supported by NCCL only when ``NCCL_MULTI_RANK_GPU_ENABLE=1`` is set in
+       every participating process.
+
+Distributed layouts are bound to an endpoint generation. Extra TensorDict
+keys are not transmitted, while a missing declared key or a later incompatible
+shape, dtype, device, or replay sample batch size raises an error. There is no
+automatic fallback to Ray for an incompatible payload. Choose ``"ray"`` when
+the data contains strings, :class:`~tensordict.NonTensorData`, arbitrary Python
+objects, or genuinely changing tensor layouts.
+
+Ray collectors and service transports
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:class:`~torchrl.collectors.distributed.RayCollector` deliberately has no
+``transport`` argument. A transport belongs to the endpoint that receives and
+serves the data:
+
+* policy requests use the attached inference server's transport;
+* replay writes use the attached replay buffer's transport; and
+* Ray continues to schedule and control the collector actors.
+
+When ``replay_buffer`` is provided, each collector worker receives its own
+restricted replay endpoint and writes its rollout directly to replay. The
+worker returns only completion to the driver, so the rollout is not copied
+through Ray a second time. This is the recommended high-throughput topology:
+
+.. code-block:: python
+
+    from functools import partial
+
+    from torchrl.collectors.distributed import RayCollector
+    from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
+    from torchrl.modules.inference_server import InferenceServer
+
+    replay = TensorDictReplayBuffer(
+        storage=partial(LazyTensorStorage, 100_000),
+        batch_size=256,
+        service_backend="ray",
+        service_backend_options={"remote_config": {"num_cpus": 1}},
+        transport="distributed",
+        transport_options={"backend": "gloo"},
+    )
+    inference = InferenceServer(
+        policy_factory=make_policy,
+        service_backend="ray",
+        service_backend_options={"remote_config": {"num_cpus": 1}},
+        transport="distributed",
+        transport_options={"backend": "gloo"},
+    )
+    collector = RayCollector(
+        create_env_fn=[make_env] * 8,
+        policy=inference,
+        replay_buffer=replay,
+        frames_per_batch=1024,
+    )
+
+If no replay buffer is attached, iterating over ``RayCollector`` returns
+rollouts to the driver through Ray's object store. That collector-to-driver
+path is not transport-selectable. Use direct-to-replay collection when the
+rollouts are large and do not need to be inspected by the driver. Use the Ray
+service transport instead of the distributed transport when the policy or
+replay payload contains non-tensor or dynamic data.
+
 Preserving domain APIs
 ----------------------
 

--- a/examples/services/README.md
+++ b/examples/services/README.md
@@ -10,7 +10,8 @@ to construction; the training loop consumes domain-compatible clients.
 | --- | --- |
 | `multi_service_single_process.py` | Direct logger and replay buffer with threaded inference |
 | `multi_service_multiprocess.py` | Process logger and inference server with a direct replay buffer |
-| `multi_service_ray.py` | Ray logger and replay-buffer owners with Ray inference transport |
+| `multi_service_ray.py` | Ray logger, replay-buffer, and inference owners |
+| `ray_collector_services.py` | Ray-owned replay and inference composed with `RayCollector` |
 | `multi_service_utils.py` | Shared service construction and training loop |
 | `distributed_services.py` | Basic service-registry usage |
 
@@ -37,6 +38,7 @@ From the repository root:
 python examples/services/multi_service_single_process.py
 python examples/services/multi_service_multiprocess.py
 python examples/services/multi_service_ray.py
+python examples/services/ray_collector_services.py
 ```
 
 All entry points accept the same training arguments:
@@ -79,7 +81,7 @@ scalar tensor before backpropagation.
 | --- | --- | --- | --- | --- |
 | Single process | Background thread | Direct | Direct | Driver |
 | Multiprocess | Spawned process | Spawned process | Direct | Driver |
-| Ray | Ray transport to a driver-owned server | Ray actor | Ray actor | Driver |
+| Ray | Ray actor | Ray actor | Ray actor | Driver |
 
 Replay buffers expose direct and Ray service backends. The multiprocess profile
 therefore keeps its replay buffer in the driver while moving inference and

--- a/examples/services/multi_service_ray.py
+++ b/examples/services/multi_service_ray.py
@@ -4,9 +4,9 @@
 # LICENSE file in the root directory of this source tree.
 """Run the multi-service training example with Ray.
 
-The logger and replay buffer are Ray service owners, and policy requests use
-``RayTransport``. The driver runs the same ordinary TensorDict loop as the
-other examples through their restricted clients.
+The logger, replay buffer, and inference policy are Ray service owners. The
+driver runs the same ordinary TensorDict loop as the other examples through
+their restricted component clients.
 
 Install Ray and run from the repository root:
 

--- a/examples/services/multi_service_utils.py
+++ b/examples/services/multi_service_utils.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import importlib.util
-import multiprocessing as mp
 from contextlib import ExitStack
 from functools import partial
 from pathlib import Path
@@ -20,19 +19,10 @@ from torch import nn
 
 from torchrl.data import ListStorage, ReplayBuffer, TensorDictReplayBuffer
 from torchrl.envs import GymEnv
-from torchrl.modules.inference_server import (
-    InferenceServer,
-    MPTransport,
-    PolicyClientModule,
-    ProcessInferenceServer,
-    RayTransport,
-    ThreadingTransport,
-)
+from torchrl.modules.inference_server import InferenceServer, PolicyClientModule
 from torchrl.record import CSVLogger
 
 _has_ray = importlib.util.find_spec("ray") is not None
-if _has_ray:
-    import ray
 
 ExampleServiceBackend = Literal["direct", "process", "ray"]
 
@@ -96,17 +86,22 @@ def _make_replay_buffer(
 
 def _make_inference_server(service_backend: ExampleServiceBackend):
     if service_backend == "process":
-        context = mp.get_context("spawn")
-        transport = MPTransport(ctx=context)
-        server = ProcessInferenceServer(
+        server = InferenceServer(
             policy_factory=make_policy,
-            transport=transport,
-            mp_context=context,
+            service_backend="process",
+            service_backend_options={"mp_context": "spawn"},
+            transport="auto",
+        )
+    elif service_backend == "ray":
+        server = InferenceServer(
+            policy_factory=make_policy,
+            service_backend="ray",
+            service_backend_options={"remote_config": {"num_cpus": 1}},
+            transport="auto",
         )
     else:
-        transport = RayTransport() if service_backend == "ray" else ThreadingTransport()
-        server = InferenceServer(make_policy(), transport)
-    return server, transport
+        server = InferenceServer(make_policy(), transport="auto")
+    return server
 
 
 def run_training(
@@ -123,10 +118,6 @@ def run_training(
         raise ValueError("steps and batch_size must both be positive.")
 
     with ExitStack() as owners:
-        if service_backend == "ray" and not ray.is_initialized():
-            ray.init(num_cpus=4, ignore_reinit_error=True, log_to_driver=False)
-            owners.callback(ray.shutdown)
-
         logger_owner = _make_logger(service_backend, log_dir)
         owners.callback(logger_owner.shutdown)
         replay_owner = _make_replay_buffer(
@@ -135,10 +126,7 @@ def run_training(
             batch_size=batch_size,
         )
         owners.callback(replay_owner.shutdown)
-        inference_owner, transport = _make_inference_server(service_backend)
-        close_transport = getattr(transport, "close", None)
-        if callable(close_transport):
-            owners.callback(close_transport)
+        inference_owner = _make_inference_server(service_backend)
         owners.callback(inference_owner.shutdown)
         inference_owner.start()
 

--- a/examples/services/ray_collector_services.py
+++ b/examples/services/ray_collector_services.py
@@ -1,0 +1,95 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Collect with Ray-owned replay and inference services.
+
+The driver only constructs TorchRL objects. Replay storage, policy inference,
+and environment collection run in dedicated Ray actors; TorchRL creates and
+distributes the restricted transport clients internally.
+
+Run from the repository root with ``python examples/services/ray_collector_services.py``.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+
+from tensordict.nn import TensorDictModule
+from torch import nn
+
+from torchrl._utils import logger as torchrl_logger
+from torchrl.collectors.distributed import RayCollector
+from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
+from torchrl.envs import GymEnv
+from torchrl.modules.inference_server import InferenceServer
+
+
+def make_env() -> GymEnv:
+    """Create one CPU environment inside a collector actor."""
+    return GymEnv("Pendulum-v1", device="cpu")
+
+
+def make_policy() -> TensorDictModule:
+    """Create the policy inside the inference actor."""
+    return TensorDictModule(
+        nn.Sequential(nn.Linear(3, 1), nn.Tanh()),
+        in_keys=["observation"],
+        out_keys=["action"],
+    )
+
+
+def main() -> None:
+    ray_init_config = {
+        "num_cpus": 4,
+        "include_dashboard": False,
+        "log_to_driver": False,
+    }
+    replay = TensorDictReplayBuffer(
+        storage=partial(LazyTensorStorage, 1_000),
+        batch_size=4,
+        service_backend="ray",
+        service_backend_options={
+            "ray_init_config": ray_init_config,
+            "remote_config": {"num_cpus": 1},
+        },
+        transport="auto",
+    )
+    inference = InferenceServer(
+        policy_factory=make_policy,
+        service_backend="ray",
+        service_backend_options={
+            "remote_config": {"num_cpus": 1},
+        },
+        transport="auto",
+    )
+    collector = None
+    try:
+        collector = RayCollector(
+            create_env_fn=[make_env],
+            policy=inference,
+            replay_buffer=replay,
+            collector_class="single",
+            frames_per_batch=8,
+            total_frames=16,
+            remote_configs={"num_cpus": 1, "num_gpus": 0},
+            sync=True,
+        )
+        for _ in collector:
+            pass
+
+        sample = replay.sample()
+        torchrl_logger.info(
+            "Collected %s transitions; sampled batch shape is %s.",
+            len(replay),
+            tuple(sample.shape),
+        )
+    finally:
+        if collector is not None:
+            collector.shutdown()
+        inference.shutdown()
+        replay.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/rb/test_rb_distributed.py
+++ b/test/rb/test_rb_distributed.py
@@ -242,6 +242,8 @@ class TestRayRB:
             rb.close()
 
     def test_construct_from_replay_buffer_service_backend(self):
+        import ray
+
         rb = ReplayBuffer(
             storage=partial(LazyTensorStorage, 100),
             service_backend="ray",
@@ -254,12 +256,70 @@ class TestRayRB:
             assert isinstance(rb, RayReplayBuffer)
             assert isinstance(rb, ReplayBuffer)
             assert rb.service_backend == "ray"
+            assert rb.transport_kind == "ray"
+            clients = rb.clients(2)
+            assert clients[0] is not clients[1]
             rb.extend(TensorDict({"x": torch.ones(4)}, batch_size=4))
             assert len(rb.client()) == 4
         finally:
             rb.shutdown()
         assert not rb.is_alive
+        assert ray.is_initialized()
         rb.shutdown()
+
+    def test_ray_replay_with_gloo_transport(self):
+        rb = ReplayBuffer(
+            storage=partial(LazyTensorStorage, 100),
+            batch_size=4,
+            service_backend="ray",
+            service_backend_options={"remote_config": {"num_cpus": 0}},
+            transport="distributed",
+            transport_options={"backend": "gloo", "timeout": 30.0},
+        )
+        try:
+            client = rb.client()
+            indices = client.extend(
+                TensorDict({"x": torch.arange(8)}, batch_size=[8]), timeout=30.0
+            )
+            assert indices.tolist() == list(range(8))
+            assert len(client) == 8
+            assert client.write_count == 8
+            assert client.sample(timeout=30.0).shape == (4,)
+            with pytest.raises((RuntimeError, ValueError)):
+                client.extend(
+                    TensorDict({"x": torch.arange(4)}, batch_size=[4]),
+                    timeout=30.0,
+                )
+            assert not hasattr(client, "shutdown")
+        finally:
+            rb.shutdown()
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+    def test_ray_replay_with_nccl_transport(self):
+        rb = ReplayBuffer(
+            storage=partial(LazyTensorStorage, 100, device="cuda"),
+            batch_size=4,
+            service_backend="ray",
+            service_backend_options={"remote_config": {"num_gpus": 1}},
+            transport="distributed",
+            transport_options={"backend": "nccl", "timeout": 30.0},
+        )
+        try:
+            client = rb.client()
+            client.extend(
+                TensorDict(
+                    {"x": torch.arange(8, device="cuda")},
+                    batch_size=[8],
+                    device="cuda",
+                ),
+                timeout=30.0,
+            )
+            sample = client.sample(timeout=30.0)
+            assert sample.shape == (4,)
+            assert sample.device.type == "cuda"
+        finally:
+            rb.shutdown()
 
     def test_ray_rb_mcadvantage_transform_factory(self):
         rb = RayReplayBuffer(

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -42,9 +42,11 @@ from torchrl.data import (
     ReplayBuffer,
     RoundRobinWriter,
     SamplerWithoutReplacement,
+    TensorDictReplayBuffer,
 )
 from torchrl.envs import StepCounter, TransformedEnv
 from torchrl.modules import RandomPolicy
+from torchrl.modules.inference_server import InferenceServer
 from torchrl.testing.dist_utils import (
     assert_no_new_python_processes,
     snapshot_python_processes,
@@ -711,6 +713,41 @@ class TestRayCollector(DistributedCollectorBase):
         }
         return {"ray_init_config": ray_init_config, "remote_configs": remote_configs}
 
+    def test_ray_owned_inference_and_replay(self):
+        replay = TensorDictReplayBuffer(
+            storage=partial(LazyTensorStorage, 100),
+            batch_size=4,
+            service_backend="ray",
+            service_backend_options={"remote_config": {"num_cpus": 0}},
+            transport="auto",
+        )
+        inference = InferenceServer(
+            policy_factory=CountingPolicy,
+            service_backend="ray",
+            service_backend_options={"remote_config": {"num_cpus": 0}},
+            transport="auto",
+        )
+        collector = None
+        try:
+            collector = RayCollector(
+                create_env_fn=[CountingEnv],
+                policy=inference,
+                replay_buffer=replay,
+                collector_class=Collector,
+                frames_per_batch=8,
+                total_frames=16,
+                remote_configs={"num_cpus": 1, "num_gpus": 0},
+                sync=True,
+            )
+            assert all(batch is None for batch in collector)
+            assert len(replay) == 16
+            assert replay.sample().shape == (4,)
+        finally:
+            if collector is not None:
+                collector.shutdown()
+            inference.shutdown()
+            replay.shutdown()
+
     @classmethod
     def _start_worker(cls):
         pass
@@ -1023,7 +1060,7 @@ class TestRayTrajsPerBatch:
             "env_vars": {"PYTHONPATH": os.path.dirname(__file__)},
         }
         remote_configs = {"num_cpus": 1, "num_gpus": 0.0}
-        with pytest.raises(TypeError, match="RayReplayBuffer"):
+        with pytest.raises(TypeError, match="service_backend='ray'"):
             RayCollector(
                 [env_fn, env_fn],
                 policy,

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -14,6 +14,7 @@ import time
 
 import pytest
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 
 from tensordict import lazy_stack, TensorDict
@@ -273,6 +274,33 @@ class TestInferenceTransportABC:
 
 
 class TestInferenceServerCore:
+    def test_canonical_thread_constructor(self):
+        with InferenceServer(_make_policy(), transport="auto") as server:
+            assert server.service_backend == "thread"
+            assert server.transport_kind == "thread"
+            result = server.client()(
+                TensorDict({"observation": torch.randn(4)}, batch_size=[])
+            )
+        assert result["action"].shape == (2,)
+
+    @pytest.mark.parametrize(
+        ("service_backend", "transport"),
+        [("thread", "ray"), ("process", "ray"), ("ray", "shared_memory")],
+    )
+    def test_invalid_backend_transport_rejected_before_start(
+        self, service_backend, transport
+    ):
+        kwargs = {
+            "service_backend": service_backend,
+            "transport": transport,
+        }
+        if service_backend == "thread":
+            kwargs["model"] = _make_policy()
+        else:
+            kwargs["policy_factory"] = _make_policy
+        with pytest.raises(ValueError, match="incompatible"):
+            InferenceServer(**kwargs)
+
     def test_start_and_shutdown(self):
         transport = _MockTransport()
         policy = _make_policy()
@@ -1474,6 +1502,106 @@ class TestRayTransport:
             assert "action" in result.keys()
             assert result["action"].shape == (2,)
 
+    def test_canonical_ray_owned_inference(self):
+        ray = _ray_lib()
+        server = InferenceServer(
+            policy_factory=lambda: TensorDictModule(
+                nn.Linear(4, 2),
+                in_keys=["observation"],
+                out_keys=["action"],
+            ),
+            service_backend="ray",
+            service_backend_options={"remote_config": {"num_cpus": 0}},
+            transport="auto",
+        )
+        try:
+            assert server.service_backend == "ray"
+            assert server.transport_kind == "ray"
+            clients = server.clients(2)
+            assert clients[0] is not clients[1]
+            result = clients[0](
+                TensorDict({"observation": torch.randn(4)}, batch_size=[])
+            )
+            assert result["action"].shape == (2,)
+            assert not hasattr(clients[0], "shutdown")
+        finally:
+            server.shutdown()
+        # The fixture owns Ray; component shutdown must leave it running.
+        assert ray.is_initialized()
+
+    def test_ray_owned_inference_with_gloo_transport(self):
+        server = InferenceServer(
+            policy_factory=lambda: TensorDictModule(
+                nn.Linear(4, 2),
+                in_keys=["observation"],
+                out_keys=["action"],
+            ),
+            service_backend="ray",
+            service_backend_options={"remote_config": {"num_cpus": 0}},
+            transport="distributed",
+            transport_options={"backend": "gloo", "timeout": 30.0},
+        )
+        try:
+            client = server.client()
+            result = client(
+                TensorDict(
+                    {"observation": torch.randn(4)},
+                    batch_size=[],
+                    device="cpu",
+                ),
+                timeout=30.0,
+            )
+            assert result["action"].shape == (2,)
+            assert server.transport_kind == "distributed"
+            assert not dist.is_initialized()
+            server.shutdown()
+            started = time.monotonic()
+            with pytest.raises((MailboxPeerClosedError, MailboxTransportError)):
+                client(
+                    TensorDict({"observation": torch.randn(4)}, batch_size=[]),
+                    timeout=5.0,
+                )
+            assert time.monotonic() - started < 3.0
+        finally:
+            server.shutdown()
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+    def test_ray_owned_inference_with_nccl_transport(self, monkeypatch):
+        # This test runs both NCCL ranks on the single GPU provided by the CI
+        # worker. Production deployments should normally assign one GPU per rank.
+        monkeypatch.setenv("NCCL_MULTI_RANK_GPU_ENABLE", "1")
+        server = InferenceServer(
+            policy_factory=lambda: TensorDictModule(
+                nn.Linear(4, 2),
+                in_keys=["observation"],
+                out_keys=["action"],
+            ),
+            service_backend="ray",
+            service_backend_options={
+                "remote_config": {
+                    "num_gpus": 1,
+                    "runtime_env": {"env_vars": {"NCCL_MULTI_RANK_GPU_ENABLE": "1"}},
+                }
+            },
+            transport="distributed",
+            transport_options={"backend": "nccl", "timeout": 30.0},
+            output_device="cuda:0",
+        )
+        try:
+            result = server.client()(
+                TensorDict(
+                    {"observation": torch.randn(4, device="cuda")},
+                    batch_size=[],
+                    device="cuda",
+                ),
+                timeout=30.0,
+            )
+            assert result["action"].is_cuda
+            assert not dist.is_initialized()
+        finally:
+            server.shutdown()
+
     def test_concurrent_clients(self):
         """Multiple clients submit concurrently from threads (simulating Ray actors)."""
         transport = RayTransport()
@@ -1789,6 +1917,54 @@ def _make_slow_policy():
 
 
 class TestProcessInferenceServer:
+    def test_canonical_process_constructor(self):
+        server = InferenceServer(
+            policy_factory=_make_policy,
+            service_backend="process",
+            transport="auto",
+            service_backend_options={"mp_context": "spawn"},
+        )
+        try:
+            assert server.service_backend == "process"
+            assert server.transport_kind == "process"
+            with server:
+                result = server.client()(
+                    TensorDict({"observation": torch.randn(4)}, batch_size=[])
+                )
+            assert result["action"].shape == (2,)
+        finally:
+            server.shutdown()
+
+    def test_process_server_with_distributed_gloo_transport(self):
+        request_spec = TensorDict({"observation": torch.zeros(4)}, batch_size=[])
+        response_spec = TensorDict(
+            {
+                "action": torch.zeros(2),
+                "policy_version": torch.zeros((), dtype=torch.long),
+            },
+            batch_size=[],
+        )
+        server = InferenceServer(
+            policy_factory=_make_policy,
+            service_backend="process",
+            service_backend_options={"mp_context": "spawn"},
+            transport="distributed",
+            transport_options={"backend": "gloo", "timeout": 30.0},
+            request_spec=request_spec,
+            response_spec=response_spec,
+        )
+        try:
+            with server:
+                result = server.client()(
+                    TensorDict({"observation": torch.randn(4)}, batch_size=[]),
+                    timeout=30.0,
+                )
+                assert result["action"].shape == (2,)
+                assert server.transport_kind == "distributed"
+                assert not dist.is_initialized()
+        finally:
+            server.shutdown()
+
     def test_process_server_start_shutdown(self):
         ctx = mp.get_context("spawn")
         transport = MPTransport(ctx=ctx)

--- a/torchrl/_comm/distributed.py
+++ b/torchrl/_comm/distributed.py
@@ -1,0 +1,936 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Request/reply transport over torch.distributed point-to-point primitives.
+
+:class:`TorchDistributedTransport` serves actors that live in other processes or
+on other nodes (e.g. Ray actors) without touching the *default* process
+group: every server/client pair gets standalone
+:class:`~torch.distributed.ProcessGroupGloo` (and, for CUDA payloads,
+:class:`~torch.distributed.ProcessGroupNCCL`) objects rendezvoused through a
+transport-owned :class:`~torch.distributed.TCPStore`, so training code
+remains free to use ``init_process_group`` for its own collectives.
+
+Control messages (request/response headers, exceptions) always travel over
+gloo; fixed-spec tensor payloads travel over gloo (CPU) or NCCL (GPU-direct)
+depending on ``backend``. NCCL receives are only posted after a control
+header announces the payload, which keeps the NCCL watchdog away from idle
+receives and keeps each communicator single-threaded.
+"""
+from __future__ import annotations
+
+import pickle
+import queue
+import socket
+import threading
+import time
+from datetime import timedelta
+from typing import Literal
+
+import torch
+import torch.distributed as dist
+from tensordict.base import _is_leaf_nontensor, TensorDictBase
+from tensordict.utils import NestedKey
+
+from torchrl._comm.mailbox import MailboxPeerClosedError, MailboxTransportError
+from torchrl._comm.request_reply import (
+    Message,
+    MessageMetadata,
+    MetadataSpec,
+    RequestReplyTransport,
+)
+from torchrl._utils import logger as torchrl_logger
+
+_TAG_HEADER = 0
+_TAG_PAYLOAD_BASE = 1
+
+# Request header: (req_id, ...declared metadata). Response header:
+# (req_id, status) with status 0 = ok, 1 = exception (pickled under the
+# store key _exc_key), 2 = server shutdown. A negative req_id is a shutdown
+# sentinel, never a request.
+_RESPONSE_HEADER_NUMEL = 2
+
+_STATUS_OK = 0
+_STATUS_EXC = 1
+_STATUS_SHUTDOWN = 2
+
+_SHUTDOWN_REQ_ID = -1
+
+# Point-to-point op timeout. Deliberately much larger than the rendezvous
+# timeout: header receives block idle for as long as actors stay quiet.
+# A posted gloo unbound receive can only complete by consuming a real
+# message: Work.is_completed() never flips for send/recv, and a timed-out
+# wait() aborts the unbound buffer (an abort racing an arriving message
+# crashes gloo with "Cannot lock pointer to unbound buffer"). Receiver
+# threads therefore block in wait() and shutdown is a *message*: clients
+# send a goodbye header to release their server thread, and the server
+# sends a shutdown header to release connected client receivers.
+_OP_TIMEOUT_S = 86_400.0
+
+# Poll period for peer-liveness / receiver-health checks while a client
+# waits for a reply (mirrors torchrl._comm.mailbox._PEER_CHECK_INTERVAL).
+_HEALTH_CHECK_INTERVAL_S = 0.1
+
+
+def _send_sentinel_async(
+    pg, status: int, peer: int, *, header_numel: int = _RESPONSE_HEADER_NUMEL
+) -> threading.Thread:
+    """Fire-and-forget a shutdown/goodbye header from a daemon thread.
+
+    A gloo send blocks until the peer consumes it, so a sentinel aimed at a
+    dead or absent peer would otherwise hang ``close()`` for the full op
+    timeout. The caller joins the returned thread briefly and abandons it
+    if the peer never picks the message up.
+    """
+    header = torch.zeros(header_numel, dtype=torch.int64)
+    header[0] = _SHUTDOWN_REQ_ID
+    if header_numel > 1:
+        header[1] = status
+
+    def _send():
+        try:
+            pg.send([header], peer, _TAG_HEADER).wait()
+        except Exception as err:
+            torchrl_logger.debug(
+                f"TorchDistributedTransport: sentinel send failed with {err!r}."
+            )
+
+    thread = threading.Thread(target=_send, daemon=True, name="dt-sentinel-send")
+    thread.start()
+    return thread
+
+
+def _exc_key(prefix: str, client_idx: int, req_id: int) -> str:
+    return f"{prefix}/exc/{client_idx}/{req_id}"
+
+
+def _connect_key(prefix: str, client_idx: int) -> str:
+    return f"{prefix}/connect/{client_idx}"
+
+
+def _sorted_leaf_keys(spec: TensorDictBase) -> list[NestedKey]:
+    # _is_leaf_nontensor surfaces NonTensorData leaves (excluded by the
+    # default leaf iterator) so validation rejects them instead of ignoring
+    # them; the keys are sorted so both peers derive the same wire order.
+    keys = list(
+        spec.keys(include_nested=True, leaves_only=True, is_leaf=_is_leaf_nontensor)
+    )
+    return sorted(keys, key=lambda k: (k,) if isinstance(k, str) else tuple(k))
+
+
+def _validate_spec(spec: TensorDictBase, argname: str, backend: str) -> list[NestedKey]:
+    device_type = "cuda" if backend == "nccl" else "cpu"
+    keys = _sorted_leaf_keys(spec)
+    if not keys:
+        raise ValueError(f"{argname} must contain at least one tensor leaf.")
+    for key in keys:
+        value = spec.get(key)
+        if not isinstance(value, torch.Tensor):
+            raise TypeError(
+                f"TorchDistributedTransport specs only support tensor leaves; "
+                f"{argname} has a {type(value).__name__} at key {key!r}."
+            )
+        if value.device.type != device_type:
+            raise ValueError(
+                f"TorchDistributedTransport(backend={backend!r}) requires "
+                f"{device_type} spec tensors; {argname} has a "
+                f"{value.device} tensor at key {key!r}."
+            )
+    return keys
+
+
+def _retry_while(stop_event: threading.Event, fn, description: str):
+    """Run *fn* until it succeeds, retrying on rendezvous/op timeouts."""
+    while not stop_event.is_set():
+        try:
+            return fn()
+        except RuntimeError as err:  # noqa: PERF203
+            message = str(err).lower()
+            if "timed out" in message or "timeout" in message:
+                continue
+            torchrl_logger.warning(
+                f"TorchDistributedTransport: {description} failed with {err!r}."
+            )
+            raise
+    return None
+
+
+class _PairEndpoint:
+    """One side of a server/client pair: control (gloo) + data groups."""
+
+    def __init__(
+        self,
+        store,
+        client_idx: int,
+        rank: int,
+        backend: str,
+        timeout: float,
+        device: torch.device,
+        prefix: str,
+    ):
+        base = f"{prefix}/pair/{client_idx}"
+        pg_timeout = timedelta(seconds=_OP_TIMEOUT_S)
+        # Directional groups: one per (direction, plane) so that each group
+        # is only ever used by a single thread on each side (required for
+        # NCCL, hygienic for gloo).
+        self.ctrl_req = dist.ProcessGroupGloo(
+            dist.PrefixStore(f"{base}/ctrl_req", store), rank, 2, pg_timeout
+        )
+        self.ctrl_resp = dist.ProcessGroupGloo(
+            dist.PrefixStore(f"{base}/ctrl_resp", store), rank, 2, pg_timeout
+        )
+        if backend == "nccl":
+            self.data_req = dist.ProcessGroupNCCL(
+                dist.PrefixStore(f"{base}/data_req", store), rank, 2
+            )
+            self.data_resp = dist.ProcessGroupNCCL(
+                dist.PrefixStore(f"{base}/data_resp", store), rank, 2
+            )
+        else:
+            self.data_req = self.ctrl_req
+            self.data_resp = self.ctrl_resp
+        self.device = device
+
+    def new_header(self, numel: int = _RESPONSE_HEADER_NUMEL) -> torch.Tensor:
+        return torch.zeros(numel, dtype=torch.int64)
+
+    def send(self, pg, tensors: list[torch.Tensor], peer: int) -> None:
+        for tag_offset, tensor in enumerate(tensors):
+            pg.send([tensor], peer, _TAG_PAYLOAD_BASE + tag_offset).wait()
+
+    def recv(self, pg, tensors: list[torch.Tensor], peer: int) -> None:
+        for tag_offset, tensor in enumerate(tensors):
+            pg.recv([tensor], peer, _TAG_PAYLOAD_BASE + tag_offset).wait()
+
+
+class _DistributedFuture:
+    """Future for one in-flight :class:`TorchDistributedTransport` request."""
+
+    _MISSING = object()
+
+    def __init__(self, client: _DistributedClient, req_id: int):
+        self._client = client
+        self._req_id = req_id
+        self._outcome = self._MISSING
+
+    def done(self) -> bool:
+        """Return ``True`` when the result can be read without blocking."""
+        if self._outcome is not self._MISSING:
+            return True
+        try:
+            self._outcome = self._client._get_reply(self._req_id, timeout=0)
+        except queue.Empty:
+            return False
+        return True
+
+    def result(self, timeout: float | None = None) -> TensorDictBase:
+        """Return the inference result or raise its remote exception.
+
+        Raises :class:`queue.Empty` when *timeout* elapses before the server
+        replies; the request stays in flight and ``result`` can be retried.
+        """
+        if self._outcome is self._MISSING:
+            self._outcome = self._client._get_reply(self._req_id, timeout=timeout)
+        if isinstance(self._outcome, BaseException):
+            raise self._outcome
+        return self._outcome
+
+
+class _DistributedClient:
+    """Actor-side client for :class:`TorchDistributedTransport`.
+
+    Picklable: carries only the store coordinates, its client index, and the
+    payload specs. The pair process groups are built lazily in the actor
+    process on first use; the first request therefore blocks until the
+    server side has connected the pair.
+    """
+
+    def __init__(
+        self,
+        store_info: tuple[str, int],
+        client_idx: int,
+        request_spec: TensorDictBase,
+        response_spec: TensorDictBase,
+        backend: str,
+        timeout: float,
+        device: torch.device,
+        metadata_spec: MetadataSpec,
+        prefix: str,
+        peer_alive=None,
+    ):
+        self._store_info = store_info
+        self._client_idx = client_idx
+        self._request_spec = request_spec
+        self._response_spec = response_spec
+        self._backend = backend
+        self._timeout = timeout
+        self._device = device
+        self._metadata_spec = metadata_spec
+        self._prefix = prefix
+        self._peer_alive = peer_alive
+        self._request_keys = _sorted_leaf_keys(request_spec)
+        self._response_keys = _sorted_leaf_keys(response_spec)
+        self._endpoint: _PairEndpoint | None = None
+        self._lock = threading.Lock()
+        self._next_req_id = 0
+        self._reply_queue: queue.Queue | None = None
+        self._buffered: dict[int, object] = {}
+        self._reply_lock = threading.Lock()
+        self._stop_event: threading.Event | None = None
+        self._receiver_thread: threading.Thread | None = None
+        self._receiver_error: BaseException | None = None
+
+    @property
+    def client_id(self) -> int:
+        """The client index assigned by the owning transport."""
+        return self._client_idx
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state["_endpoint"] = None
+        state["_lock"] = None
+        state["_reply_queue"] = None
+        state["_reply_lock"] = None
+        state["_stop_event"] = None
+        state["_receiver_thread"] = None
+        state["_receiver_error"] = None
+        state["_buffered"] = {}
+        for post_connect in ("_store", "_send_buffer", "_recv_buffer"):
+            state.pop(post_connect, None)
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self._lock = threading.Lock()
+        self._reply_lock = threading.Lock()
+
+    def _ensure_connected(self) -> None:
+        if self._endpoint is not None:
+            return
+        host, port = self._store_info
+        store = dist.TCPStore(
+            host, port, is_master=False, timeout=timedelta(seconds=self._timeout)
+        )
+        self._store = store
+        # Reservation and process-group connection are separate. A domain
+        # client may own several named channels but use only a subset, so the
+        # server must not block constructing groups for unused handles.
+        store.set(_connect_key(self._prefix, self._client_idx), "1")
+        self._endpoint = _PairEndpoint(
+            store,
+            self._client_idx,
+            rank=1,
+            backend=self._backend,
+            timeout=self._timeout,
+            device=self._device,
+            prefix=self._prefix,
+        )
+        # contiguous(): gloo send/recv rejects non-contiguous tensors, and
+        # clone() preserves the strides of a transposed/sliced spec.
+        self._send_buffer = self._request_spec.clone().contiguous().to(self._device)
+        self._recv_buffer = self._response_spec.clone().contiguous().to(self._device)
+        self._reply_queue = queue.Queue()
+        self._stop_event = threading.Event()
+        self._receiver_thread = threading.Thread(
+            target=self._receive_loop,
+            daemon=True,
+            name=f"TorchDistributedTransport-client-{self._client_idx}",
+        )
+        self._receiver_thread.start()
+
+    def _receive_loop(self) -> None:
+        endpoint = self._endpoint
+        header = endpoint.new_header()
+        recv_leaves = [self._recv_buffer.get(key) for key in self._response_keys]
+        try:
+            while True:
+                done = _retry_while(
+                    self._stop_event,
+                    lambda: endpoint.ctrl_resp.recv([header], 0, _TAG_HEADER).wait(),
+                    "response header recv",
+                )
+                if done is None and self._stop_event.is_set():
+                    return
+                if self._stop_event.is_set():
+                    # Locally closed while the receive was in flight.
+                    return
+                req_id, status = int(header[0]), int(header[1])
+                if req_id < 0 or status == _STATUS_SHUTDOWN:
+                    self._receiver_error = MailboxPeerClosedError(
+                        "TorchDistributedTransport server closed the transport."
+                    )
+                    return
+                if status == _STATUS_OK:
+                    endpoint.recv(endpoint.data_resp, recv_leaves, 0)
+                    self._reply_queue.put((req_id, self._recv_buffer.clone()))
+                else:
+                    raw = self._store.get(
+                        _exc_key(self._prefix, self._client_idx, req_id)
+                    )
+                    try:
+                        exc = pickle.loads(raw)
+                    except Exception as err:  # pragma: no cover
+                        exc = RuntimeError(f"Remote exception (unpicklable): {err!r}")
+                    self._reply_queue.put((req_id, exc))
+        except BaseException as err:  # noqa: B036
+            # Surface receiver failures to every pending future instead of
+            # leaving them blocked on a reply that will never arrive.
+            self._receiver_error = err
+
+    def _check_health(self) -> None:
+        """Raise when a pending reply can no longer arrive."""
+        error = self._receiver_error
+        if error is not None:
+            if isinstance(error, MailboxPeerClosedError):
+                raise error
+            raise MailboxTransportError(
+                "TorchDistributedTransport client receiver thread failed."
+            ) from error
+        if self._stop_event is not None and self._stop_event.is_set():
+            raise MailboxTransportError(
+                "TorchDistributedTransport client was closed while waiting for a "
+                "reply."
+            )
+        if self._peer_alive is not None:
+            try:
+                peer_is_alive = self._peer_alive.is_set()
+            except Exception as err:
+                raise MailboxTransportError(
+                    "Failed to query the transport peer's liveness."
+                ) from err
+            if not peer_is_alive:
+                raise MailboxPeerClosedError(
+                    "TorchDistributedTransport peer closed before replying."
+                )
+
+    def _get_reply(self, req_id: int, timeout: float | None = None):
+        with self._reply_lock:
+            if req_id in self._buffered:
+                return self._buffered.pop(req_id)
+            deadline = None if timeout is None else time.monotonic() + timeout
+            while True:
+                remaining = (
+                    None if deadline is None else max(deadline - time.monotonic(), 0)
+                )
+                # Wake up periodically to observe server death and receiver
+                # failures even in the timeout=None case.
+                wait = (
+                    _HEALTH_CHECK_INTERVAL_S
+                    if remaining is None
+                    else min(remaining, _HEALTH_CHECK_INTERVAL_S)
+                )
+                try:
+                    if wait > 0:
+                        reply_id, payload = self._reply_queue.get(timeout=wait)
+                    else:
+                        reply_id, payload = self._reply_queue.get(block=False)
+                except queue.Empty:
+                    self._check_health()
+                    if deadline is not None and time.monotonic() >= deadline:
+                        raise queue.Empty(
+                            f"Timeout waiting for reply to request {req_id}."
+                        ) from None
+                    continue
+                if reply_id == req_id:
+                    return payload
+                self._buffered[reply_id] = payload
+
+    supports_metadata = True
+
+    def submit(
+        self,
+        td: TensorDictBase,
+        *,
+        metadata: MessageMetadata | None = None,
+    ) -> _DistributedFuture:
+        """Send a request to the server and return a future for the reply."""
+        # Check owner liveness before entering a blocking gloo send. This is
+        # especially important for Ray-owned services, whose actor may have
+        # failed without an opportunity to send a shutdown sentinel.
+        self._check_health()
+        with self._lock:
+            self._ensure_connected()
+            request = td.select(*self._request_keys, strict=True)
+            req_id = self._next_req_id
+            self._next_req_id += 1
+            self._send_buffer.update_(request)
+            endpoint = self._endpoint
+            metadata = {} if metadata is None else metadata
+            header = torch.tensor(
+                [req_id, *self._metadata_spec.encode(metadata)], dtype=torch.int64
+            )
+            endpoint.ctrl_req.send([header], 0, _TAG_HEADER).wait()
+            send_leaves = [self._send_buffer.get(key) for key in self._request_keys]
+            endpoint.send(endpoint.data_req, send_leaves, 0)
+        return _DistributedFuture(self, req_id)
+
+    def __call__(
+        self,
+        td: TensorDictBase,
+        timeout: float | None = None,
+        *,
+        metadata: MessageMetadata | None = None,
+    ) -> TensorDictBase:
+        """Submit a request and block for its result."""
+        return self.submit(td, metadata=metadata).result(timeout=timeout)
+
+    def close(self) -> None:
+        """Stop the receiver, send a goodbye to release the server thread.
+
+        The goodbye header lets the server-side receiver thread for this
+        client exit promptly. The local receiver thread is blocked in a
+        header receive that only a server message can complete; it exits on
+        the server's shutdown notice (``transport.close()``) or reply, and
+        is otherwise abandoned as a daemon thread.
+        """
+        if self._stop_event is not None:
+            self._stop_event.set()
+        endpoint = self._endpoint
+        if endpoint is not None:
+            _send_sentinel_async(
+                endpoint.ctrl_req,
+                _STATUS_SHUTDOWN,
+                0,
+                header_numel=1 + len(self._metadata_spec.fields),
+            ).join(timeout=1.0)
+        thread = self._receiver_thread
+        if thread is not None:
+            thread.join(timeout=1.0)
+            if not thread.is_alive():
+                self._receiver_thread = None
+                self._endpoint = None
+
+
+class TorchDistributedTransport(RequestReplyTransport):
+    """Cross-process/cross-node transport over torch.distributed p2p.
+
+    Serves actors that cannot share memory or multiprocessing queues with
+    the server -- typically Ray actors, possibly on other nodes. Each client
+    gets its own standalone server/client pair of process groups
+    rendezvoused through a transport-owned
+    :class:`~torch.distributed.TCPStore`; the *default* process group is
+    never touched, so training code can keep using ``init_process_group``
+    for its own collectives.
+
+    Small request/response headers (and pickled exceptions) travel over
+    gloo control groups. Fixed-spec tensor payloads travel over gloo
+    (``backend="gloo"``, CPU tensors) or NCCL (``backend="nccl"``, CUDA
+    tensors, GPU-direct -- no host round trip).
+
+    As with :class:`SharedMemoryTransport`, the payload contract is static:
+    the specs fix the transmitted keys, shapes, and dtypes, extra keys are
+    dropped, and a missing declared key raises. Domain control values use a
+    declared :class:`MetadataSpec` encoded directly in the fixed request
+    header; arbitrary objects are never pickled per request.
+
+    Args:
+        request_spec (TensorDictBase): a representative single request.
+        response_spec (TensorDictBase): a representative single response
+            (including server-added keys to forward, e.g.
+            ``"policy_version"``).
+
+    Keyword Args:
+        backend (str, optional): payload backend, ``"gloo"`` (CPU specs) or
+            ``"nccl"`` (CUDA specs). Control headers always use gloo.
+            Defaults to ``"gloo"``.
+        timeout (float, optional): rendezvous and store timeout in seconds.
+            Defaults to ``300.0``.
+        host (str, optional): interface for the rendezvous store. Defaults
+            to the local hostname address.
+        port (int, optional): port for the rendezvous store. Defaults to an
+            OS-assigned free port.
+        metadata_spec (MetadataSpec, optional): flat scalar control metadata
+            schema. Defaults to an empty schema.
+        channel_name (str, optional): stable name used to namespace rendezvous
+            keys when a provider owns multiple channels. Defaults to
+            ``"default"``.
+
+    .. note::
+        Clients are created with :meth:`client` and are picklable; the pair
+        process groups are built lazily in the actor process, so the first
+        request blocks until the server side is running. The server
+        discovers clients through the store, so clients may be created
+        before or after the server starts.
+
+    .. note::
+        Requests are copied into fixed staging buffers on both sides (one
+        payload copy per direction); nothing is pickled on the hot path.
+
+    .. warning::
+        Like all of :mod:`torch.distributed`, this transport provides no
+        authentication or encryption: the rendezvous
+        :class:`~torch.distributed.TCPStore` accepts any connection (and
+        listens on all network interfaces regardless of ``host``), and the
+        gloo/NCCL payload channels are unauthenticated. Note that received
+        exception payloads are deserialized with ``pickle``, which can execute
+        arbitrary code, so an attacker with network access
+        to the store or channel ports can compromise every participating
+        process. Only deploy on trusted, isolated networks (e.g. a cluster
+        fabric behind a firewall), as with any ``torch.distributed`` job.
+
+    """
+
+    def __init__(
+        self,
+        request_spec: TensorDictBase,
+        response_spec: TensorDictBase,
+        *,
+        backend: Literal["gloo", "nccl"] = "gloo",
+        timeout: float = 300.0,
+        host: str | None = None,
+        port: int | None = None,
+        metadata_spec: MetadataSpec | None = None,
+        channel_name: str = "default",
+        _store_info: tuple[str, int] | None = None,
+        _store=None,
+    ):
+        if not dist.is_available():
+            raise RuntimeError(
+                "torch.distributed is not available; TorchDistributedTransport "
+                "requires a torch build with distributed support."
+            )
+        if backend not in ("gloo", "nccl"):
+            raise ValueError(
+                f"Unsupported TorchDistributedTransport backend {backend!r}. "
+                "Expected 'gloo' or 'nccl'."
+            )
+        device_type = "cuda" if backend == "nccl" else "cpu"
+        _validate_spec(request_spec, "request_spec", backend)
+        _validate_spec(response_spec, "response_spec", backend)
+        # contiguous(): gloo/NCCL send/recv reject non-contiguous tensors,
+        # and clone() preserves the strides of a transposed/sliced spec. All
+        # staging buffers derive from these normalized specs.
+        self._request_spec = request_spec.clone().contiguous()
+        self._response_spec = response_spec.clone().contiguous()
+        self._request_keys = _sorted_leaf_keys(self._request_spec)
+        self._response_keys = _sorted_leaf_keys(self._response_spec)
+        self._backend = backend
+        self._timeout = timeout
+        self._device = torch.device(device_type)
+        self._metadata_spec = MetadataSpec() if metadata_spec is None else metadata_spec
+        if not channel_name or "/" in channel_name:
+            raise ValueError("channel_name must be non-empty and cannot contain '/'.")
+        self._prefix = f"torchrl/request_reply/{channel_name}"
+        self._client_count_key = f"{self._prefix}/num_clients"
+        self._peer_alive = None
+
+        if _store_info is not None:
+            host, port = _store_info
+        elif host is None:
+            host = socket.gethostbyname(socket.gethostname())
+        # Let TCPStore bind the ephemeral port itself. Probing with a temporary
+        # socket and closing it before constructing the store leaves a race in
+        # which another process can claim the advertised port.
+        if _store is None and _store_info is None:
+            _store = dist.TCPStore(
+                host,
+                0 if port is None else port,
+                is_master=True,
+                timeout=timedelta(seconds=timeout),
+                wait_for_workers=False,
+            )
+            port = int(_store.port)
+        elif port is None:
+            port = int(_store.port)
+        self._store_info = (host, port)
+        # The owner keeps the master store alive; unpickled copies (e.g. a
+        # ProcessInferenceServer child) reconnect as store clients.
+        self._store = _store
+        self._get_store().add(self._client_count_key, 0)
+
+        self._ready_queue: queue.Queue | None = None
+        self._peeked = None
+        self._stop_event: threading.Event | None = None
+        self._listener: threading.Thread | None = None
+        self._server_threads: list[threading.Thread] = []
+        self._endpoints: dict[int, _PairEndpoint] = {}
+        self._response_buffers: dict[int, TensorDictBase] = {}
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        # Server-side runtime state is rebuilt in the process that runs the
+        # serve loop; the master store handle stays with the owner.
+        state["_store"] = None
+        state["_ready_queue"] = None
+        state["_peeked"] = None
+        state["_stop_event"] = None
+        state["_listener"] = None
+        state["_server_threads"] = []
+        state["_endpoints"] = {}
+        state["_response_buffers"] = {}
+        return state
+
+    def _set_peer_alive(self, alive_event) -> None:
+        """Attach the server-liveness flag propagated to new clients.
+
+        :class:`ProcessInferenceServer` installs an event that its monitor
+        clears when the server process exits, so blocked client waits raise
+        :class:`~torchrl._comm.MailboxPeerClosedError` instead of hanging.
+        """
+        self._peer_alive = alive_event
+
+    def _get_store(self):
+        if self._store is None:
+            host, port = self._store_info
+            self._store = dist.TCPStore(
+                host,
+                port,
+                is_master=False,
+                timeout=timedelta(seconds=self._timeout),
+            )
+        return self._store
+
+    # -- actor API ------------------------------------------------------------
+
+    def client(self) -> _DistributedClient:
+        """Create a picklable actor-side client.
+
+        Each call reserves a new client index through the rendezvous store,
+        so clients can be created from the owner or from an unpickled copy
+        of the transport.
+        """
+        client_idx = int(self._get_store().add(self._client_count_key, 1)) - 1
+        return _DistributedClient(
+            self._store_info,
+            client_idx,
+            self._request_spec,
+            self._response_spec,
+            self._backend,
+            self._timeout,
+            self._device,
+            self._metadata_spec,
+            self._prefix,
+            peer_alive=self._peer_alive,
+        )
+
+    def submit(
+        self,
+        td: TensorDictBase,
+        *,
+        metadata: MessageMetadata | None = None,
+    ):
+        """Not supported -- use :meth:`client` to obtain an actor handle."""
+        raise RuntimeError(
+            "TorchDistributedTransport.submit() is not supported. "
+            "Call transport.client() to create a client."
+        )
+
+    # -- server side ------------------------------------------------------------
+
+    def _ensure_server(self) -> None:
+        if self._listener is not None:
+            return
+        self._ready_queue = queue.Queue()
+        self._stop_event = threading.Event()
+        self._listener = threading.Thread(
+            target=self._listen_for_clients,
+            daemon=True,
+            name="TorchDistributedTransport-listener",
+        )
+        self._listener.start()
+
+    def _listen_for_clients(self) -> None:
+        store = self._get_store()
+        known = 0
+        pending: set[int] = set()
+        while not self._stop_event.is_set():
+            count = int(store.add(self._client_count_key, 0))
+            pending.update(range(known, count))
+            known = max(known, count)
+            connecting = [
+                client_idx
+                for client_idx in pending
+                if store.check([_connect_key(self._prefix, client_idx)])
+            ]
+            for client_idx in connecting:
+                thread = threading.Thread(
+                    target=self._serve_client,
+                    args=(client_idx,),
+                    daemon=True,
+                    name=f"TorchDistributedTransport-server-{client_idx}",
+                )
+                self._server_threads.append(thread)
+                thread.start()
+                pending.remove(client_idx)
+            time.sleep(0.1)
+
+    def _serve_client(self, client_idx: int) -> None:
+        endpoint = _retry_while(
+            self._stop_event,
+            lambda: _PairEndpoint(
+                self._get_store(),
+                client_idx,
+                rank=0,
+                backend=self._backend,
+                timeout=self._timeout,
+                device=self._device,
+                prefix=self._prefix,
+            ),
+            f"pair rendezvous for client {client_idx}",
+        )
+        if endpoint is None:
+            return
+        self._endpoints[client_idx] = endpoint
+        self._response_buffers[client_idx] = self._response_spec.clone().to(
+            self._device
+        )
+        request_buffer = self._request_spec.clone().to(self._device)
+        recv_leaves = [request_buffer.get(key) for key in self._request_keys]
+        header = endpoint.new_header(1 + len(self._metadata_spec.fields))
+        try:
+            while True:
+                done = _retry_while(
+                    self._stop_event,
+                    lambda: endpoint.ctrl_req.recv([header], 1, _TAG_HEADER).wait(),
+                    f"request header recv for client {client_idx}",
+                )
+                if done is None and self._stop_event.is_set():
+                    return
+                if self._stop_event.is_set():
+                    return
+                req_id = int(header[0])
+                if req_id < 0:
+                    # Client goodbye; stop serving this pair.
+                    return
+                endpoint.recv(endpoint.data_req, recv_leaves, 1)
+                # Clone: the staging buffer is reused for this client's next
+                # request, which may be drained before this item is consumed.
+                item = request_buffer.clone()
+                metadata = self._metadata_spec.decode(
+                    [int(value) for value in header[1:]]
+                )
+                self._ready_queue.put(
+                    (Message(item, metadata), (client_idx, req_id), time.monotonic())
+                )
+        except Exception as err:
+            if not self._stop_event.is_set():
+                torchrl_logger.warning(
+                    f"TorchDistributedTransport: receiver for client {client_idx} "
+                    f"failed with {err!r}."
+                )
+
+    # -- RequestReplyTransport interface -------------------------------------------
+
+    def wait_for_work(self, timeout: float) -> None:
+        """Block until a request has been received or *timeout* elapses."""
+        self._ensure_server()
+        if self._peeked is not None:
+            return
+        try:
+            self._peeked = self._ready_queue.get(timeout=timeout)
+        except queue.Empty:
+            return
+
+    def drain(
+        self, max_items: int
+    ) -> tuple[list[TensorDictBase], list[tuple[int, int]]]:
+        """Dequeue up to *max_items* received requests (non-blocking)."""
+        items, callbacks, _received_at = self.drain_with_timing(max_items)
+        return items, callbacks
+
+    def drain_with_timing(
+        self, max_items: int
+    ) -> tuple[list[TensorDictBase], list[tuple[int, int]], list[float | None]]:
+        """Dequeue requests with server-side arrival timestamps.
+
+        Timestamps are recorded when the receiver thread finished reading
+        the payload (clocks are not comparable across nodes, so actor-side
+        submission times are not transmitted); queue-wait statistics
+        therefore measure server-side queueing only.
+        """
+        messages, callbacks, received_at = self.drain_messages_with_timing(max_items)
+        return [message.payload for message in messages], callbacks, received_at
+
+    def drain_messages_with_timing(
+        self, max_items: int
+    ) -> tuple[list[Message], list[tuple[int, int]], list[float | None]]:
+        """Dequeue messages with server-side arrival timestamps."""
+        self._ensure_server()
+        messages: list[Message] = []
+        callbacks: list[tuple[int, int]] = []
+        received_at: list[float | None] = []
+
+        def append(entry) -> None:
+            message, callback, timestamp = entry
+            messages.append(message)
+            callbacks.append(callback)
+            received_at.append(timestamp)
+
+        if self._peeked is not None:
+            append(self._peeked)
+            self._peeked = None
+        while len(messages) < max_items:
+            try:
+                append(self._ready_queue.get(block=False))
+            except queue.Empty:
+                break
+        return messages, callbacks, received_at
+
+    def resolve(self, callback: tuple[int, int], result: TensorDictBase) -> None:
+        """Send the result back to the client that submitted the request."""
+        client_idx, req_id = callback
+        endpoint = self._endpoints[client_idx]
+        buffer = self._response_buffers[client_idx]
+        buffer.update_(result.select(*self._response_keys, strict=True))
+        header = torch.tensor([req_id, _STATUS_OK], dtype=torch.int64)
+        endpoint.ctrl_resp.send([header], 1, _TAG_HEADER).wait()
+        send_leaves = [buffer.get(key) for key in self._response_keys]
+        endpoint.send(endpoint.data_resp, send_leaves, 1)
+
+    def resolve_exception(self, callback: tuple[int, int], exc: BaseException) -> None:
+        """Propagate an exception through the store plus a status header."""
+        client_idx, req_id = callback
+        endpoint = self._endpoints[client_idx]
+        try:
+            raw = pickle.dumps(exc)
+        except Exception:
+            raw = pickle.dumps(RuntimeError(repr(exc)))
+        self._get_store().set(_exc_key(self._prefix, client_idx, req_id), raw)
+        header = torch.tensor([req_id, _STATUS_EXC], dtype=torch.int64)
+        endpoint.ctrl_resp.send([header], 1, _TAG_HEADER).wait()
+
+    def close(self) -> None:
+        """Stop server-side threads, notify connected clients, release groups.
+
+        Connected clients receive a shutdown header so their receiver
+        threads exit and pending futures raise
+        :class:`~torchrl._comm.MailboxPeerClosedError` instead of blocking
+        forever. A posted gloo receive can only complete by consuming a
+        message, so server receiver threads whose client never sent a
+        goodbye (see ``_DistributedClient.close``) and threads still
+        blocked in the pair rendezvous are daemonic and are abandoned after
+        a short join grace period.
+        """
+        if self._stop_event is not None:
+            self._stop_event.set()
+        # Best-effort shutdown notice to connected clients, sent from
+        # daemon threads: a blocking send aimed at a dead client would
+        # otherwise hang close() for the full op timeout.
+        notice_threads = [
+            _send_sentinel_async(endpoint.ctrl_resp, _STATUS_SHUTDOWN, 1)
+            for endpoint in self._endpoints.values()
+        ]
+        for thread in notice_threads:
+            thread.join(timeout=1.0)
+        listener = self._listener
+        if listener is not None:
+            listener.join(timeout=5.0)
+            self._listener = None
+        for thread in self._server_threads:
+            thread.join(timeout=1.0)
+            if thread.is_alive():
+                torchrl_logger.debug(
+                    f"TorchDistributedTransport: abandoning server thread "
+                    f"{thread.name} still blocked in a header receive or "
+                    "rendezvous."
+                )
+        self._server_threads = []
+        self._endpoints.clear()
+        self._response_buffers.clear()
+
+
+# Compatibility spelling retained for the existing inference-server API.
+_DistributedTransport = TorchDistributedTransport
+
+__all__ = ["_DistributedTransport"]

--- a/torchrl/_comm/ray_runtime.py
+++ b/torchrl/_comm/ray_runtime.py
@@ -1,0 +1,82 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import importlib.util
+import threading
+from typing import Any
+
+_has_ray = importlib.util.find_spec("ray") is not None
+
+
+class _RayRuntimeLease:
+    """Process-local lease for a Ray runtime used by TorchRL owners."""
+
+    _lock = threading.RLock()
+    _leases = 0
+    _owns_runtime = False
+
+    def __init__(self) -> None:
+        self._released = False
+
+    @classmethod
+    def acquire(cls, ray_init_config: dict[str, Any] | None = None) -> _RayRuntimeLease:
+        if not _has_ray:
+            raise ImportError("Ray is required for service_backend='ray'.")
+        import ray
+
+        with cls._lock:
+            if not ray.is_initialized():
+                ray.init(**dict(ray_init_config or {}))
+                cls._owns_runtime = True
+            cls._leases += 1
+        return cls()
+
+    def release(self) -> None:
+        if self._released:
+            return
+        import ray
+
+        type(self)._lock.acquire()
+        try:
+            if self._released:
+                return
+            self._released = True
+            type(self)._leases -= 1
+            if type(self)._leases == 0 and type(self)._owns_runtime:
+                if ray.is_initialized():
+                    ray.shutdown()
+                type(self)._owns_runtime = False
+        finally:
+            type(self)._lock.release()
+
+
+class _RayActorLiveness:
+    """Picklable liveness flag backed by a Ray actor system probe."""
+
+    def __init__(self, actor) -> None:
+        self._actor = actor
+
+    def is_set(self) -> bool:
+        import ray
+
+        try:
+            ray.get(self._actor.__ray_ready__.remote(), timeout=0.5)
+            return True
+        except Exception:
+            return False
+
+
+def _set_ray_client_liveness(client, actor) -> None:
+    """Attach actor liveness to a private distributed client."""
+    if hasattr(client, "_peer_alive"):
+        client._peer_alive = _RayActorLiveness(actor)
+
+
+__all__ = [
+    "_RayActorLiveness",
+    "_RayRuntimeLease",
+    "_set_ray_client_liveness",
+]

--- a/torchrl/_comm/replay_service.py
+++ b/torchrl/_comm/replay_service.py
@@ -1,0 +1,344 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import torch
+from tensordict import TensorDict
+from tensordict.base import TensorDictBase
+
+from torchrl._comm.distributed import _DistributedTransport
+from torchrl._comm.request_reply import ChannelServer, Message
+
+
+def _extend_reply(
+    result: Any, device: torch.device | str | None = None
+) -> TensorDictBase:
+    if isinstance(result, torch.Tensor):
+        if device is not None:
+            result = result.to(device)
+        return TensorDict({"result": result}, batch_size=[], device=device)
+    return TensorDict(
+        {"completed": torch.ones((), dtype=torch.bool, device=device)},
+        batch_size=[],
+        device=device,
+    )
+
+
+class _DistributedReplayClient:
+    """Restricted replay client backed by isolated distributed channels."""
+
+    def __init__(
+        self,
+        extend_client,
+        sample_client,
+        control_client,
+        priority_client,
+        *,
+        batch_size: int | None,
+        sample_batch_size: int,
+    ) -> None:
+        self._extend_client = extend_client
+        self._sample_client = sample_client
+        self._control_client = control_client
+        self._priority_client = priority_client
+        self._batch_size = batch_size
+        self._sample_batch_size = sample_batch_size
+
+    @property
+    def batch_size(self) -> int | None:
+        return self._batch_size
+
+    @property
+    def write_count(self) -> int:
+        return int(self._stats()["write_count"].item())
+
+    def extend(self, data: TensorDictBase, *, timeout: float | None = None):
+        response = self._extend_client(data, timeout=timeout)
+        return response.get("result", None)
+
+    def sample(self, batch_size: int | None = None, *, timeout: float | None = None):
+        if batch_size is None:
+            batch_size = self.batch_size
+        if batch_size is None:
+            raise RuntimeError("A sample batch size must be provided.")
+        if batch_size != self._sample_batch_size:
+            raise ValueError(
+                "The distributed replay transport has a fixed sample layout: "
+                f"expected {self._sample_batch_size}, got {batch_size}."
+            )
+        request = TensorDict(
+            {"batch_size": torch.tensor(batch_size, dtype=torch.int64)},
+            batch_size=[],
+        )
+        return self._sample_client(request, timeout=timeout)
+
+    def update_tensordict_priority(
+        self, data: TensorDictBase, *, timeout: float | None = None
+    ) -> None:
+        self._priority_client(data, timeout=timeout)
+
+    def _stats(self, *, timeout: float | None = None) -> TensorDictBase:
+        request = TensorDict(
+            {"operation": torch.zeros((), dtype=torch.int64)}, batch_size=[]
+        )
+        return self._control_client(request, timeout=timeout)
+
+    def __len__(self) -> int:
+        return int(self._stats()["size"].item())
+
+    def __getattr__(self, name: str):
+        if name in {"start", "shutdown", "close", "client", "clients"}:
+            raise AttributeError(
+                f"{type(self).__name__} has no lifecycle capability {name!r}."
+            )
+        raise AttributeError(name)
+
+
+class _DistributedReplayService:
+    """Serve replay operations over fixed-layout distributed transports."""
+
+    def __init__(
+        self,
+        replay_buffer: Any,
+        *,
+        extend_spec: TensorDictBase | None = None,
+        sample_spec: TensorDictBase | None = None,
+        priority_spec: TensorDictBase | None = None,
+        backend: str = "gloo",
+        timeout: float = 300.0,
+    ) -> None:
+        self.replay_buffer = replay_buffer
+        self._lock = threading.Lock()
+        self._batch_size = getattr(replay_buffer, "batch_size", None)
+        self._sample_batch_size = None
+        self._wire_device = torch.device("cuda" if backend == "nccl" else "cpu")
+        control_request = TensorDict(
+            {"operation": torch.zeros((), dtype=torch.int64)}, batch_size=[]
+        )
+        control_response = TensorDict(
+            {
+                "size": torch.zeros((), dtype=torch.int64),
+                "write_count": torch.zeros((), dtype=torch.int64),
+            },
+            batch_size=[],
+        )
+        self._common = {"backend": backend, "timeout": timeout}
+        self.control_transport = _DistributedTransport(
+            control_request,
+            control_response,
+            channel_name="replay.control",
+            backend="gloo",
+            timeout=timeout,
+        )
+        self._shared = {
+            "_store": self.control_transport._store,
+            "_store_info": self.control_transport._store_info,
+            **self._common,
+        }
+        self.extend_transport = None
+        self.sample_transport = None
+        self.priority_transport = None
+        self._servers = []
+        self._started = False
+        self._servers.append(
+            ChannelServer(self.control_transport, self._control, name="ReplayControl")
+        )
+        if extend_spec is not None:
+            # An explicit contract cannot know custom writer return values, so
+            # use the standard tensor-index layout.
+            extend_response = TensorDict(
+                {
+                    "result": torch.zeros(
+                        extend_spec.batch_size,
+                        dtype=torch.int64,
+                        device=self._wire_device,
+                    )
+                },
+                batch_size=[],
+                device=self._wire_device,
+            )
+            self.bind_extend(extend_spec, extend_response)
+        if sample_spec is not None:
+            self.bind_sample(sample_spec)
+            self.bind_priority(sample_spec if priority_spec is None else priority_spec)
+
+    def _add_server(self, server: ChannelServer) -> None:
+        self._servers.append(server)
+        if self._started:
+            server.start()
+
+    def bind_extend(
+        self, request_spec: TensorDictBase, response_spec: TensorDictBase
+    ) -> None:
+        if self.extend_transport is not None:
+            return
+        self.extend_transport = _DistributedTransport(
+            request_spec,
+            response_spec,
+            channel_name="replay.extend",
+            **self._shared,
+        )
+        self._add_server(
+            ChannelServer(self.extend_transport, self._extend, name="ReplayExtend")
+        )
+
+    def bind_sample(self, sample_spec: TensorDictBase) -> None:
+        if self.sample_transport is not None:
+            return
+        if not sample_spec.batch_size:
+            raise ValueError("sample_spec must have a non-empty batch size.")
+        self._sample_batch_size = int(sample_spec.batch_size[0])
+        sample_request = TensorDict(
+            {
+                "batch_size": torch.zeros(
+                    (), dtype=torch.int64, device=self._wire_device
+                )
+            },
+            batch_size=[],
+            device=self._wire_device,
+        )
+        self.sample_transport = _DistributedTransport(
+            sample_request,
+            sample_spec,
+            channel_name="replay.sample",
+            **self._shared,
+        )
+        self._add_server(
+            ChannelServer(self.sample_transport, self._sample, name="ReplaySample")
+        )
+
+    def bind_priority(self, priority_spec: TensorDictBase) -> None:
+        if self.priority_transport is not None:
+            return
+        priority_response = TensorDict(
+            {"updated": torch.zeros((), dtype=torch.bool, device=self._wire_device)},
+            batch_size=[],
+            device=self._wire_device,
+        )
+        self.priority_transport = _DistributedTransport(
+            priority_spec,
+            priority_response,
+            channel_name="replay.priority",
+            **self._shared,
+        )
+        self._add_server(
+            ChannelServer(
+                self.priority_transport, self._priority, name="ReplayPriority"
+            )
+        )
+
+    def _extend(self, messages: list[Message]) -> list[TensorDictBase]:
+        results = []
+        with self._lock:
+            for message in messages:
+                results.append(
+                    _extend_reply(
+                        self.replay_buffer.extend(message.payload), self._wire_device
+                    )
+                )
+        return results
+
+    def _sample(self, messages: list[Message]) -> list[TensorDictBase]:
+        with self._lock:
+            return [
+                self.replay_buffer.sample(int(message.payload["batch_size"].item())).to(
+                    self._wire_device
+                )
+                for message in messages
+            ]
+
+    def _control(self, messages: list[Message]) -> list[TensorDictBase]:
+        with self._lock:
+            size = len(self.replay_buffer)
+            write_count = int(getattr(self.replay_buffer, "write_count", size))
+        return [
+            TensorDict(
+                {
+                    "size": torch.tensor(size, dtype=torch.int64),
+                    "write_count": torch.tensor(write_count, dtype=torch.int64),
+                },
+                batch_size=[],
+            )
+            for _ in messages
+        ]
+
+    def _priority(self, messages: list[Message]) -> list[TensorDictBase]:
+        update = getattr(self.replay_buffer, "update_tensordict_priority", None)
+        results = []
+        with self._lock:
+            for message in messages:
+                if update is not None:
+                    update(message.payload)
+                results.append(
+                    TensorDict(
+                        {
+                            "updated": torch.tensor(
+                                update is not None, device=self._wire_device
+                            )
+                        },
+                        batch_size=[],
+                        device=self._wire_device,
+                    )
+                )
+        return results
+
+    def start(self) -> _DistributedReplayService:
+        self._started = True
+        for server in self._servers:
+            server.start()
+        return self
+
+    def extend_client(self):
+        if self.extend_transport is None:
+            raise RuntimeError("The replay extend schema has not been established.")
+        return self.extend_transport.client()
+
+    def sample_client(self):
+        if self.sample_transport is None:
+            raise RuntimeError("The replay sample schema has not been established.")
+        return self.sample_transport.client()
+
+    def priority_client(self):
+        if self.priority_transport is None:
+            raise RuntimeError("The replay priority schema has not been established.")
+        return self.priority_transport.client()
+
+    def control_client(self):
+        return self.control_transport.client()
+
+    def client(self) -> _DistributedReplayClient:
+        if (
+            self.extend_transport is None
+            or self.sample_transport is None
+            or self.priority_transport is None
+            or self._sample_batch_size is None
+        ):
+            raise RuntimeError("The replay transport schemas are not established.")
+        return _DistributedReplayClient(
+            self.extend_transport.client(),
+            self.sample_transport.client(),
+            self.control_transport.client(),
+            self.priority_transport.client(),
+            batch_size=self._batch_size,
+            sample_batch_size=self._sample_batch_size,
+        )
+
+    def shutdown(self) -> None:
+        for server in reversed(self._servers):
+            server.shutdown(timeout=5.0)
+        for transport in (
+            self.priority_transport,
+            self.sample_transport,
+            self.extend_transport,
+            self.control_transport,
+        ):
+            if transport is not None:
+                transport.close()
+
+
+__all__ = ["_DistributedReplayClient", "_DistributedReplayService"]

--- a/torchrl/_comm/request_reply.py
+++ b/torchrl/_comm/request_reply.py
@@ -1,0 +1,448 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Typed request/reply channels and their shared serving loop."""
+from __future__ import annotations
+
+import abc
+import struct
+import threading
+import time
+from collections.abc import Callable, Mapping, Sequence
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+from statistics import mean
+from typing import Any, Literal, TypeAlias
+
+from tensordict.base import TensorDictBase
+
+MetadataValue: TypeAlias = bool | int | float | str
+MessageMetadata: TypeAlias = Mapping[str, MetadataValue]
+MetadataDType: TypeAlias = Literal["bool", "int64", "float64"]
+
+
+@dataclass(frozen=True)
+class MetadataField:
+    """One scalar field carried in a fixed transport header."""
+
+    name: str
+    dtype: MetadataDType
+
+
+@dataclass(frozen=True)
+class MetadataSpec:
+    """Fixed schema for request metadata used by tensor transports."""
+
+    fields: tuple[MetadataField, ...] = ()
+
+    def __post_init__(self) -> None:
+        names = [metadata_field.name for metadata_field in self.fields]
+        if len(names) != len(set(names)):
+            raise ValueError("Metadata field names must be unique.")
+
+    def validate(self, metadata: MessageMetadata) -> None:
+        expected = {metadata_field.name for metadata_field in self.fields}
+        actual = set(metadata)
+        if actual != expected:
+            raise ValueError(
+                "Metadata does not match the declared schema; "
+                f"missing={sorted(expected - actual)}, "
+                f"extra={sorted(actual - expected)}."
+            )
+        for metadata_field in self.fields:
+            value = metadata[metadata_field.name]
+            if metadata_field.dtype == "bool" and not isinstance(value, bool):
+                raise TypeError(f"Metadata field {metadata_field.name!r} must be bool.")
+            if metadata_field.dtype == "int64" and (
+                not isinstance(value, int) or isinstance(value, bool)
+            ):
+                raise TypeError(f"Metadata field {metadata_field.name!r} must be int.")
+            if metadata_field.dtype == "float64" and not isinstance(
+                value, (int, float)
+            ):
+                raise TypeError(
+                    f"Metadata field {metadata_field.name!r} must be float."
+                )
+
+    def encode(self, metadata: MessageMetadata) -> list[int]:
+        self.validate(metadata)
+        result = []
+        for metadata_field in self.fields:
+            value = metadata[metadata_field.name]
+            if metadata_field.dtype == "float64":
+                result.append(struct.unpack("q", struct.pack("d", float(value)))[0])
+            else:
+                result.append(int(value))
+        return result
+
+    def decode(self, values: Sequence[int]) -> dict[str, MetadataValue]:
+        if len(values) != len(self.fields):
+            raise ValueError(
+                f"Expected {len(self.fields)} metadata values, got {len(values)}."
+            )
+        result: dict[str, MetadataValue] = {}
+        for metadata_field, value in zip(self.fields, values):
+            if metadata_field.dtype == "bool":
+                result[metadata_field.name] = bool(value)
+            elif metadata_field.dtype == "int64":
+                result[metadata_field.name] = int(value)
+            else:
+                result[metadata_field.name] = struct.unpack(
+                    "d", struct.pack("q", int(value))
+                )[0]
+        return result
+
+
+@dataclass(frozen=True)
+class Message:
+    """One request/reply-channel message.
+
+    Args:
+        payload: TensorDict payload owned by the domain protocol.
+        metadata: Small control-plane values interpreted by the domain, not
+            by the physical transport.
+
+    """
+
+    payload: TensorDictBase
+    metadata: MessageMetadata = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+
+def _as_message(
+    payload: Message | TensorDictBase,
+    metadata: MessageMetadata | None = None,
+) -> Message:
+    """Normalize a payload and optional metadata into a :class:`Message`."""
+    if isinstance(payload, Message):
+        if metadata:
+            raise ValueError("metadata cannot be added to an existing Message.")
+        return payload
+    return Message(payload, {} if metadata is None else metadata)
+
+
+class RequestReplyClient:
+    """Lightweight client for a :class:`RequestReplyTransport`.
+
+    Args:
+        transport: Bound request/reply channel.
+
+    """
+
+    supports_metadata = False
+
+    def __init__(self, transport: RequestReplyTransport) -> None:
+        self._transport = transport
+        self.supports_metadata = bool(getattr(transport, "supports_metadata", False))
+
+    def submit(
+        self,
+        payload: TensorDictBase,
+        *,
+        metadata: MessageMetadata | None = None,
+    ) -> Future[TensorDictBase]:
+        """Submit a request and immediately return its future."""
+        if metadata is None:
+            return self._transport.submit(payload)
+        return self._transport.submit(payload, metadata=metadata)
+
+    def __call__(
+        self,
+        payload: TensorDictBase,
+        timeout: float | None = None,
+        *,
+        metadata: MessageMetadata | None = None,
+    ) -> TensorDictBase:
+        """Submit a request and block for its reply."""
+        return self.submit(payload, metadata=metadata).result(timeout=timeout)
+
+
+class RequestReplyTransport(abc.ABC):
+    """Physical transport bound to one typed request/reply channel.
+
+    Domain services consume this interface and remain independent of whether
+    payloads travel by reference, queue, shared memory, object store, or
+    ``torch.distributed`` point-to-point operations.
+
+    """
+
+    @abc.abstractmethod
+    def submit(
+        self,
+        payload: TensorDictBase,
+        *,
+        metadata: MessageMetadata | None = None,
+    ) -> Future[TensorDictBase]:
+        """Submit one request and return a future for its reply."""
+
+    @abc.abstractmethod
+    def drain(self, max_items: int) -> tuple[list[TensorDictBase], list[Any]]:
+        """Drain payloads and opaque reply callbacks."""
+
+    @abc.abstractmethod
+    def wait_for_work(self, timeout: float) -> None:
+        """Wait until work is available or ``timeout`` expires."""
+
+    @abc.abstractmethod
+    def resolve(self, callback: Any, result: TensorDictBase) -> None:
+        """Resolve one callback with a successful reply."""
+
+    @abc.abstractmethod
+    def resolve_exception(self, callback: Any, exc: BaseException) -> None:
+        """Resolve one callback with an exception."""
+
+    def drain_messages_with_timing(
+        self, max_items: int
+    ) -> tuple[list[Message], list[Any], list[float | None]]:
+        """Drain messages, callbacks, and optional submission timestamps.
+
+        The default adapter preserves compatibility with transports that only
+        implement the historical payload-only ``drain`` contract.
+        """
+        drain_with_timing = getattr(self, "drain_with_timing", None)
+        if drain_with_timing is None:
+            payloads, callbacks = self.drain(max_items)
+            submitted_at = [None] * len(payloads)
+        else:
+            payloads, callbacks, submitted_at = drain_with_timing(max_items)
+        return [_as_message(payload) for payload in payloads], callbacks, submitted_at
+
+    def _set_peer_alive(self, alive_event) -> None:  # noqa: B027
+        """Attach an optional liveness flag used by process-aware clients."""
+
+    def client(self) -> RequestReplyClient:
+        """Return a restricted client bound to this channel."""
+        return RequestReplyClient(self)
+
+
+BatchHandler: TypeAlias = Callable[[Sequence[Message]], Sequence[TensorDictBase]]
+
+
+class ChannelServer:
+    """Shared lifecycle, batching, and fan-out loop for request/reply services.
+
+    The server is intentionally domain-neutral. The handler receives a batch
+    of :class:`Message` objects and must return one TensorDict reply per
+    request. Inference, replay buffers, and future TorchRL services can share
+    the same queueing and failure semantics while keeping their domain logic
+    in small handlers.
+
+    Args:
+        channel: Bound request/reply transport.
+        handler: Callable returning one reply per input message.
+
+    Keyword Args:
+        max_batch_size: Maximum requests handled together. Defaults to ``64``.
+        min_batch_size: Minimum batch size accumulated before dispatch.
+            Defaults to ``1``.
+        timeout: Maximum accumulation delay in seconds. Defaults to ``0.01``.
+        before_wait: Optional non-blocking maintenance hook.
+        collect_stats: Whether to collect batching and latency statistics.
+            Defaults to ``True``.
+        stats_window_size: Number of recent samples retained. Defaults to
+            ``1024``.
+        shutdown_event: Optional externally owned event.
+        name: Worker-thread name prefix. Defaults to ``"ChannelServer"``.
+
+    """
+
+    def __init__(
+        self,
+        channel: RequestReplyTransport,
+        handler: BatchHandler,
+        *,
+        max_batch_size: int = 64,
+        min_batch_size: int = 1,
+        timeout: float = 0.01,
+        before_wait: Callable[[], None] | None = None,
+        collect_stats: bool = True,
+        stats_window_size: int = 1024,
+        shutdown_event=None,
+        name: str = "ChannelServer",
+    ) -> None:
+        if max_batch_size < 1:
+            raise ValueError("max_batch_size must be at least 1.")
+        if min_batch_size < 1 or min_batch_size > max_batch_size:
+            raise ValueError("min_batch_size must be between 1 and max_batch_size.")
+        if timeout < 0:
+            raise ValueError("timeout must be non-negative.")
+        if stats_window_size < 1:
+            raise ValueError("stats_window_size must be at least 1.")
+        self.channel = channel
+        self.handler = handler
+        self.max_batch_size = max_batch_size
+        self.min_batch_size = min_batch_size
+        self.timeout = timeout
+        self.before_wait = before_wait
+        self.collect_stats = collect_stats
+        self.stats_window_size = stats_window_size
+        self._shutdown_event = (
+            threading.Event() if shutdown_event is None else shutdown_event
+        )
+        self._name = name
+        self._worker: threading.Thread | None = None
+        self._stats_lock = threading.Lock()
+        self._reset_stats()
+
+    def _reset_stats(self) -> None:
+        self._stats_started_at = time.monotonic()
+        self._num_requests = 0
+        self._num_batches = 0
+        self._batch_sizes: list[int] = []
+        self._queue_wait_ms: list[float] = []
+        self._handler_ms: list[float] = []
+
+    @staticmethod
+    def _percentile(values: list[float], percentile: float) -> float:
+        if not values:
+            return 0.0
+        values = sorted(values)
+        index = int(round((len(values) - 1) * percentile))
+        return float(values[index])
+
+    def _extend_window(self, target: list, values: list) -> None:
+        target.extend(values)
+        excess = len(target) - self.stats_window_size
+        if excess > 0:
+            del target[:excess]
+
+    def _record_stats(
+        self,
+        batch_size: int,
+        queue_wait_ms: Sequence[float],
+        handler_ms: float,
+    ) -> None:
+        if not self.collect_stats:
+            return
+        with self._stats_lock:
+            self._num_requests += batch_size
+            self._num_batches += 1
+            self._extend_window(self._batch_sizes, [batch_size])
+            self._extend_window(self._queue_wait_ms, queue_wait_ms)
+            self._extend_window(self._handler_ms, [handler_ms])
+
+    def stats(self, *, reset: bool = False) -> dict[str, float | int]:
+        """Return generic request, batching, queue, and handler statistics."""
+        with self._stats_lock:
+            elapsed = max(time.monotonic() - self._stats_started_at, 1e-12)
+            requests = self._num_requests
+            batches = self._num_batches
+            result = {
+                "requests": requests,
+                "batches": batches,
+                "requests_per_s": requests / elapsed,
+                "batches_per_s": batches / elapsed,
+                "avg_batch_size": (
+                    float(mean(self._batch_sizes)) if self._batch_sizes else 0.0
+                ),
+                "p50_queue_ms": self._percentile(self._queue_wait_ms, 0.50),
+                "p95_queue_ms": self._percentile(self._queue_wait_ms, 0.95),
+                "p50_handler_ms": self._percentile(self._handler_ms, 0.50),
+                "p95_handler_ms": self._percentile(self._handler_ms, 0.95),
+            }
+            if reset:
+                self._reset_stats()
+            return result
+
+    def start(self) -> ChannelServer:
+        """Start the background serve loop."""
+        if self.is_alive:
+            raise RuntimeError("Server is already running.")
+        self._shutdown_event.clear()
+        self._worker = threading.Thread(
+            target=self._run,
+            daemon=True,
+            name=f"{self._name}-worker",
+        )
+        self._worker.start()
+        return self
+
+    def shutdown(self, timeout: float | None = 5.0) -> None:
+        """Stop the serve loop and reject work that has not started."""
+        self._shutdown_event.set()
+        if self._worker is not None:
+            self._worker.join(timeout=timeout)
+            self._worker = None
+
+    @property
+    def is_alive(self) -> bool:
+        """Whether the serve-loop thread is alive."""
+        return self._worker is not None and self._worker.is_alive()
+
+    def client(self) -> Any:
+        """Return a restricted client for the bound channel."""
+        return self.channel.client()
+
+    def _drain(
+        self, max_items: int
+    ) -> tuple[list[Message], list[Any], list[float | None]]:
+        return self.channel.drain_messages_with_timing(max_items)
+
+    def _run(self) -> None:
+        try:
+            while not self._shutdown_event.is_set():
+                if self.before_wait is not None:
+                    self.before_wait()
+                self.channel.wait_for_work(timeout=self.timeout)
+                messages, callbacks, submitted_at = self._drain(self.max_batch_size)
+                if not messages:
+                    continue
+                if len(messages) < self.min_batch_size:
+                    deadline = time.monotonic() + self.timeout
+                    while len(messages) < self.min_batch_size:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            break
+                        self.channel.wait_for_work(timeout=remaining)
+                        more_messages, more_callbacks, more_submitted_at = self._drain(
+                            self.max_batch_size - len(messages)
+                        )
+                        messages.extend(more_messages)
+                        callbacks.extend(more_callbacks)
+                        submitted_at.extend(more_submitted_at)
+                try:
+                    now = time.monotonic()
+                    queue_wait_ms = [
+                        (now - timestamp) * 1000.0
+                        for timestamp in submitted_at
+                        if timestamp is not None
+                    ]
+                    started = time.monotonic()
+                    results = list(self.handler(messages))
+                    handler_ms = (time.monotonic() - started) * 1000.0
+                    if len(results) != len(callbacks):
+                        raise RuntimeError(
+                            f"Channel handler returned {len(results)} replies for "
+                            f"{len(callbacks)} requests."
+                        )
+                    self._record_stats(len(callbacks), queue_wait_ms, handler_ms)
+                    for callback, result in zip(callbacks, results):
+                        self.channel.resolve(callback, result)
+                except Exception as exc:
+                    for callback in callbacks:
+                        self.channel.resolve_exception(callback, exc)
+        finally:
+            self._drain_pending_on_shutdown()
+
+    def _drain_pending_on_shutdown(self) -> None:
+        error = RuntimeError(f"{self._name} is shutting down.")
+        while True:
+            messages, callbacks, _ = self._drain(self.max_batch_size)
+            if not messages:
+                break
+            for callback in callbacks:
+                self.channel.resolve_exception(callback, error)
+
+    def __enter__(self) -> ChannelServer:
+        return self.start()
+
+    def __exit__(self, *exc_info) -> None:
+        self.shutdown()
+
+    def __del__(self) -> None:
+        worker = getattr(self, "_worker", None)
+        if worker is not None and worker.is_alive():
+            self.shutdown(timeout=1.0)

--- a/torchrl/collectors/distributed/ray.py
+++ b/torchrl/collectors/distributed/ray.py
@@ -15,6 +15,7 @@ import torch
 import torch.nn as nn
 from tensordict import TensorDict, TensorDictBase
 
+from torchrl._comm.ray_runtime import _RayRuntimeLease
 from torchrl._utils import as_remote, logger as torchrl_logger
 from torchrl.collectors._base import _ProfilerHook, BaseCollector, ProfileConfig
 from torchrl.collectors._constants import DEFAULT_EXPLORATION_TYPE
@@ -23,7 +24,7 @@ from torchrl.collectors._multi_sync import MultiSyncCollector
 from torchrl.collectors._single import Collector
 from torchrl.collectors.utils import _NON_NN_POLICY_WEIGHTS, split_trajectories
 from torchrl.collectors.weight_update import RayWeightUpdater, WeightUpdaterBase
-from torchrl.data import RayReplayBuffer, ReplayBuffer
+from torchrl.data import ReplayBuffer
 from torchrl.envs.common import EnvBase
 from torchrl.envs.env_creator import EnvCreator
 from torchrl.weight_update.weight_sync_schemes import WeightSyncScheme
@@ -131,6 +132,11 @@ class RayCollector(BaseCollector):
 
             .. note:: If the policy needs to be passed as a policy factory (e.g., in case it mustn't be serialized /
                 pickled directly), the ``policy_factory`` should be used instead.
+
+            A Ray-owned
+            :class:`~torchrl.modules.inference_server.InferenceServer` is also
+            accepted. In that case each collector worker receives an independent
+            restricted inference client and keeps no local policy copy.
 
     Keyword Args:
         policy_factory (Callable[[], Callable], list of Callable[[], Callable], optional): a callable
@@ -255,11 +261,10 @@ class RayCollector(BaseCollector):
             parameters being updated for a certain time even if ``update_after_each_batch``
             is turned on.
             Defaults to -1 (no forced update).
-        replay_buffer (RayReplayBuffer, optional): if provided, the collector will not yield tensordicts
-            but populate the buffer instead. Must be a :class:`~torchrl.data.RayReplayBuffer` instance.
-            Regular :class:`~torchrl.data.ReplayBuffer` instances cannot be shared across Ray actor
-            boundaries (workers write to serialized copies, not the main process buffer).
-            Defaults to ``None``.
+        replay_buffer (ReplayBuffer, optional): if provided, the collector will
+            populate it instead of yielding TensorDicts. The replay buffer must
+            use ``service_backend="ray"``; the collector creates restricted
+            worker clients internally. Defaults to ``None``.
         weight_updater (WeightUpdaterBase or constructor, optional): (Deprecated) An instance of :class:`~torchrl.collectors.WeightUpdaterBase`
             or its subclass, responsible for updating the policy weights on remote inference workers managed by Ray.
             If not provided, a :class:`~torchrl.collectors.RayWeightUpdater` will be used by default, leveraging
@@ -396,20 +401,15 @@ class RayCollector(BaseCollector):
                 for ck in collector_kwargs:
                     ck.setdefault("post_collect_hook", post_collect_hook)
         if replay_buffer is not None:
-            if not isinstance(replay_buffer, RayReplayBuffer):
+            if not (
+                getattr(replay_buffer, "service_backend", None) == "ray"
+                and callable(getattr(replay_buffer, "client", None))
+            ):
                 raise TypeError(
-                    "RayCollector requires a RayReplayBuffer instance when "
-                    "replay_buffer is provided. Regular ReplayBuffer instances "
-                    "cannot be shared across Ray actor boundaries — workers "
-                    "write to serialized copies, not the main process buffer. "
-                    "Use torchrl.data.RayReplayBuffer instead."
+                    "RayCollector requires a replay buffer with "
+                    "service_backend='ray' and a client() method. Construct it "
+                    "with ReplayBuffer(..., service_backend='ray')."
                 )
-            replay_buffer_client = replay_buffer.client()
-            if isinstance(collector_kwargs, dict):
-                collector_kwargs.setdefault("replay_buffer", replay_buffer_client)
-            else:
-                for ck in collector_kwargs:
-                    ck.setdefault("replay_buffer", replay_buffer_client)
         if trajs_per_batch is not None:
             if isinstance(collector_kwargs, dict):
                 collector_kwargs.setdefault("trajs_per_batch", trajs_per_batch)
@@ -472,6 +472,15 @@ class RayCollector(BaseCollector):
         create_env_fn, collector_kwargs, remote_configs = out_lists
         num_collectors = len(create_env_fn)
 
+        # Every worker gets its own restricted endpoint. This matters for
+        # transports with point-to-point connection state and is harmless for
+        # the default Ray actor client.
+        if replay_buffer is not None:
+            clients = replay_buffer.clients(num_collectors)
+            collector_kwargs = [dict(kwargs) for kwargs in collector_kwargs]
+            for kwargs, client in zip(collector_kwargs, clients):
+                kwargs.setdefault("replay_buffer", client)
+
         if use_env_creator:
             for i in range(len(create_env_fn)):
                 if not isinstance(create_env_fn[i], (EnvBase, EnvCreator)):
@@ -482,10 +491,24 @@ class RayCollector(BaseCollector):
             raise RuntimeError(
                 "ray library not found, unable to create a DistributedCollector. "
             ) from RAY_ERR
-        if not ray.is_initialized():
-            ray.init(**ray_init_config)
+        self._runtime_lease = _RayRuntimeLease.acquire(ray_init_config)
         if not ray.is_initialized():
             raise RuntimeError("Ray could not be initialized.")
+
+        policy_service = None
+        if (
+            policy is not None
+            and getattr(policy, "service_backend", None) == "ray"
+            and callable(getattr(policy, "client", None))
+        ):
+            if policy_factory is not None:
+                raise ValueError(
+                    "policy_factory cannot be combined with an inference service."
+                )
+            policy_service = policy
+            policy = policy.clients(num_collectors)
+            if trust_policy is None:
+                trust_policy = True
 
         # Define collector_class, monkey patch it with as_remote and print_remote_collector_info methods
         if collector_class == "async":
@@ -508,14 +531,15 @@ class RayCollector(BaseCollector):
         if not isinstance(policy_factory, Sequence):
             policy_factory = [policy_factory] * len(create_env_fn)
         self.policy_factory = policy_factory
-        self.policy = policy  # Store policy for weight extraction
+        self.policy = policy_service if policy_service is not None else policy
+        self._policy_service = policy_service
         self.trust_policy = trust_policy
-        if isinstance(policy, nn.Module):
-            policy_weights = TensorDict.from_module(policy)
+        if isinstance(self.policy, nn.Module):
+            policy_weights = TensorDict.from_module(self.policy)
             policy_weights = policy_weights.data.lock_()
         else:
             policy_weights = TensorDict(lock=True)
-            if weight_updater is None:
+            if weight_updater is None and policy_service is None:
                 warnings.warn(_NON_NN_POLICY_WEIGHTS)
         self.policy_weights = policy_weights
         self.collector_class = collector_class
@@ -616,7 +640,11 @@ class RayCollector(BaseCollector):
                 remote_configs,
             )
         # Set up weight synchronization - prefer new schemes over legacy updater
-        if weight_updater is None and weight_sync_schemes is None:
+        if policy_service is not None and weight_sync_schemes is None:
+            # Collectors call the centrally owned inference policy and do not
+            # keep policy parameters of their own.
+            weight_sync_schemes = {}
+        elif weight_updater is None and weight_sync_schemes is None:
             # Default to Ray weight sync scheme for Ray collectors
             from torchrl.weight_update import RayWeightSyncScheme
 
@@ -743,6 +771,20 @@ class RayCollector(BaseCollector):
         When using policy_factory without a central policy, weight synchronization
         is deferred until this method is called with actual weights.
         """
+        if self._policy_service is not None:
+            weights = policy_or_weights
+            if weights is None and weights_dict is not None:
+                weights = weights_dict.get(model_id or "policy")
+            if isinstance(weights, nn.Module):
+                weights = TensorDict.from_module(weights).data
+            if weights is None:
+                raise ValueError(
+                    "Weights must be provided when updating a centralized "
+                    "inference service."
+                )
+            self._policy_service.update_model_weights(weights)
+            return None
+
         # Trigger lazy initialization if not already done
         if not self._weight_sync_initialized:
             self._lazy_initialize_weight_sync()
@@ -871,6 +913,7 @@ class RayCollector(BaseCollector):
             other_params["worker_idx"] = i
 
             cls = self.collector_class.as_remote(remote_config).remote
+            worker_policy = policy[i] if isinstance(policy, Sequence) else policy
             collector = self._make_collector(
                 cls,
                 env_maker=[env_maker] * num_envs
@@ -880,7 +923,7 @@ class RayCollector(BaseCollector):
                     and not issubclass(self.collector_class, Collector)
                 )
                 else env_maker,
-                policy=policy,
+                policy=worker_policy,
                 other_params=other_params,
             )
             self._remote_collectors.append(collector)
@@ -1128,6 +1171,7 @@ class RayCollector(BaseCollector):
         if self._collection_thread is not None and self._collection_thread.is_alive():
             self._collection_thread.join(timeout=5.0)
         self.stop_remote_collectors()
+        self._runtime_lease.release()
         if shutdown_ray:
             ray.shutdown()
 
@@ -1238,8 +1282,25 @@ class RayCollector(BaseCollector):
                     )
             self._weight_sync_schemes = None
 
+        self._runtime_lease.release()
         if shutdown_ray:
             ray.shutdown()
+
+    def __del__(self) -> None:
+        # Construction can fail after the runtime lease is acquired (for
+        # example while starting a worker). Release only resources already
+        # attached to this collector; service owners remain independent.
+        for collector in list(getattr(self, "_remote_collectors", ())):
+            try:
+                ray.kill(collector, no_restart=True)
+            except Exception:
+                pass
+        lease = getattr(self, "_runtime_lease", None)
+        if lease is not None:
+            try:
+                lease.release()
+            except Exception:
+                pass
 
     def __repr__(self) -> str:
         string = f"{self.__class__.__name__}()"

--- a/torchrl/data/replay_buffers/ray_buffer.py
+++ b/torchrl/data/replay_buffers/ray_buffer.py
@@ -8,9 +8,13 @@ import contextlib
 import importlib
 from collections.abc import Callable, Iterator
 
-from typing import Any
+from typing import Any, Literal
 
 import torch
+from tensordict import TensorDict
+from tensordict.base import TensorDictBase
+
+from torchrl._comm.ray_runtime import _RayRuntimeLease, _set_ray_client_liveness
 from torchrl._utils import logger as torchrl_logger
 from torchrl.data.replay_buffers.replay_buffers import ReplayBuffer
 from torchrl.envs.transforms.transforms import Transform
@@ -141,6 +145,119 @@ def _to_cpu(value: Any) -> Any:
     return value
 
 
+class _LazyDistributedReplayClient:
+    """Restricted replay client with schemas bound by first use."""
+
+    def __init__(self, actor, *, batch_size: int | None) -> None:
+        self._actor = actor
+        self._batch_size = batch_size
+        self._extend_client = None
+        self._sample_client = None
+        self._sample_batch_size = None
+        self._priority_client = None
+        self._control_client = ray.get(actor._distributed_control_client.remote())
+        _set_ray_client_liveness(self._control_client, actor)
+
+    @property
+    def batch_size(self) -> int | None:
+        return self._batch_size
+
+    @property
+    def write_count(self) -> int:
+        return int(self._stats()["write_count"].item())
+
+    @property
+    def dim_extend(self):
+        return ray.get(self._actor._getattr.remote("dim_extend"))
+
+    @dim_extend.setter
+    def dim_extend(self, value) -> None:
+        ray.get(self._actor._setattr.remote("dim_extend", value))
+
+    def _stats(self, timeout: float | None = None) -> TensorDictBase:
+        request = TensorDict(
+            {"operation": torch.zeros((), dtype=torch.int64)}, batch_size=[]
+        )
+        return self._control_client(request, timeout=timeout)
+
+    def extend(self, data: TensorDictBase, *, timeout: float | None = None):
+        if self._extend_client is None:
+            self._extend_client, result, handled = ray.get(
+                self._actor._bootstrap_distributed_extend.remote(data)
+            )
+            _set_ray_client_liveness(self._extend_client, self._actor)
+            if handled:
+                return result
+        response = self._extend_client(data, timeout=timeout)
+        return response.get("result", None)
+
+    def add(self, data: TensorDictBase, *, timeout: float | None = None):
+        result = self.extend(data.unsqueeze(0), timeout=timeout)
+        if isinstance(result, torch.Tensor) and result.numel() == 1:
+            return result.reshape(()).item()
+        return result
+
+    def sample(self, batch_size: int | None = None, *, timeout: float | None = None):
+        if batch_size is None:
+            batch_size = self.batch_size
+        if batch_size is None:
+            raise RuntimeError("A sample batch size must be provided.")
+        if self._sample_client is None:
+            (
+                self._sample_client,
+                result,
+                handled,
+                self._sample_batch_size,
+            ) = ray.get(self._actor._bootstrap_distributed_sample.remote(batch_size))
+            _set_ray_client_liveness(self._sample_client, self._actor)
+            if batch_size != self._sample_batch_size:
+                raise ValueError(
+                    "The distributed replay schema is bound to sample batch size "
+                    f"{self._sample_batch_size}, got {batch_size}."
+                )
+            if handled:
+                return result
+        elif batch_size != self._sample_batch_size:
+            raise ValueError(
+                "The distributed replay schema is bound to sample batch size "
+                f"{self._sample_batch_size}, got {batch_size}."
+            )
+        request = TensorDict(
+            {
+                "batch_size": torch.tensor(
+                    batch_size,
+                    dtype=torch.int64,
+                    device=getattr(self._sample_client, "_device", None),
+                )
+            },
+            batch_size=[],
+            device=getattr(self._sample_client, "_device", None),
+        )
+        return self._sample_client(request, timeout=timeout)
+
+    def update_tensordict_priority(
+        self, data: TensorDictBase, *, timeout: float | None = None
+    ) -> None:
+        if self._priority_client is None:
+            self._priority_client, handled = ray.get(
+                self._actor._bootstrap_distributed_priority.remote(data)
+            )
+            _set_ray_client_liveness(self._priority_client, self._actor)
+            if handled:
+                return
+        self._priority_client(data, timeout=timeout)
+
+    def __len__(self) -> int:
+        return int(self._stats()["size"].item())
+
+    def __getattr__(self, name: str):
+        if name in {"start", "shutdown", "close", "client", "clients"}:
+            raise AttributeError(
+                f"{type(self).__name__} has no lifecycle capability {name!r}."
+            )
+        raise AttributeError(name)
+
+
 class RayReplayBuffer(ReplayBuffer):
     """A Ray implementation of the Replay Buffer that can be extended and sampled remotely.
 
@@ -158,56 +275,21 @@ class RayReplayBuffer(ReplayBuffer):
     Transforms constructors should be passed through the `transform_factory` argument.
 
     Example:
-        >>> import asyncio
-        >>> from tensordict.nn import TensorDictModule
-        >>> from torch import nn
-        >>> from torchrl.collectors.distributed.ray import RayCollector
-        >>> from torchrl.data.replay_buffers.ray_buffer import RayReplayBuffer
-        >>> from torchrl.envs.libs.gym import GymEnv
-        >>>
-        >>> async def main():
-        ...     # 1. Create environment factory
-        ...     def env_maker():
-        ...         return GymEnv("Pendulum-v1", device="cpu")
-        ...
-        ...     policy = TensorDictModule(
-        ...         nn.Linear(3, 1), in_keys=["observation"], out_keys=["action"]
-        ...     )
-        ...
-        ...     buffer = RayReplayBuffer()
-        ...
-        ...     # 2. Define distributed collector
-        ...     remote_config = {
-        ...         "num_cpus": 1,
-        ...         "num_gpus": 0,
-        ...         "memory": 5 * 1024**3,
-        ...         "object_store_memory": 2 * 1024**3,
-        ...     }
-        ...     distributed_collector = RayCollector(
-        ...         [env_maker],
-        ...         policy,
-        ...         total_frames=600,
-        ...         frames_per_batch=200,
-        ...         remote_configs=remote_config,
-        ...         replay_buffer=buffer,
-        ...     )
-        ...
-        ...     print("start")
-        ...     distributed_collector.start()
-        ...
-        ...     while True:
-        ...         while not len(buffer):
-        ...             print("waiting")
-        ...             await asyncio.sleep(1)  # Use asyncio.sleep instead of time.sleep
-        ...         print("sample", buffer.sample(32))
-        ...         # break at some point
-        ...         break
-        ...
-        ...     await distributed_collector.async_shutdown(shutdown_ray=False)
-        ...     buffer.close()  # Close buffer after collector
-        >>>
-        >>> if __name__ == "__main__":
-        ...     asyncio.run(main())
+        >>> from functools import partial
+        >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from torchrl.data import LazyTensorStorage, ReplayBuffer
+        >>> buffer = ReplayBuffer(
+        ...     storage=partial(LazyTensorStorage, 100),
+        ...     batch_size=4,
+        ...     service_backend="ray",
+        ...     service_backend_options={"remote_config": {"num_cpus": 0}},
+        ...     transport="auto",
+        ... )
+        >>> buffer.extend(TensorDict({"value": torch.arange(8)}, batch_size=[8]))
+        >>> buffer.sample().shape
+        torch.Size([4])
+        >>> buffer.shutdown()
 
     """
 
@@ -217,6 +299,8 @@ class RayReplayBuffer(ReplayBuffer):
         replay_buffer_cls: type[ReplayBuffer] = ReplayBuffer,
         ray_init_config: dict[str, Any] | None = None,
         remote_config: dict[str, Any] | None = None,
+        transport: Literal["auto", "ray", "distributed"] = "auto",
+        transport_options: dict[str, Any] | None = None,
         delayed_init: bool = False,
         **kwargs,
     ) -> None:
@@ -224,24 +308,55 @@ class RayReplayBuffer(ReplayBuffer):
             raise RuntimeError(
                 "ray library not found, unable to create a RayReplayBuffer. "
             ) from RAY_ERR
-        if not ray.is_initialized():
-            if ray_init_config is None:
-                from torchrl.collectors.distributed.ray import DEFAULT_RAY_INIT_CONFIG
+        if transport not in ("auto", "ray", "distributed"):
+            raise ValueError(
+                "RayReplayBuffer transport must be 'auto', 'ray', or 'distributed'."
+            )
+        if transport in ("auto", "ray") and transport_options:
+            raise ValueError(
+                "transport_options are not used by the Ray replay transport."
+            )
+        if ray_init_config is None:
+            from torchrl.collectors.distributed.ray import DEFAULT_RAY_INIT_CONFIG
 
-                ray_init_config = DEFAULT_RAY_INIT_CONFIG
-            ray.init(**ray_init_config)
+            ray_init_config = DEFAULT_RAY_INIT_CONFIG
+        self._runtime_lease = _RayRuntimeLease.acquire(ray_init_config)
 
-        self._service_cls = replay_buffer_cls
-        remote_cls = replay_buffer_cls.as_remote(remote_config).remote
-        # We can detect if the buffer has a GPU allocated, if not
-        #  we'll make sure that the data is sent to CPU when needed.
-        if remote_config is not None:
-            self.has_gpu = remote_config.get("num_gpus", 0) > 0
-        else:
-            self.has_gpu = False
-        self._rb = remote_cls(*args, delayed_init=delayed_init, **kwargs)
-        self._delayed_init = False
-        self._client = _RayReplayBufferClient(self._rb, has_gpu=self.has_gpu)
+        try:
+            self._service_cls = replay_buffer_cls
+            remote_cls = replay_buffer_cls.as_remote(remote_config).remote
+            # We can detect if the buffer has a GPU allocated, if not
+            #  we'll make sure that the data is sent to CPU when needed.
+            if remote_config is not None:
+                self.has_gpu = remote_config.get("num_gpus", 0) > 0
+            else:
+                self.has_gpu = False
+            self._rb = remote_cls(*args, delayed_init=delayed_init, **kwargs)
+            self._delayed_init = False
+            if transport == "distributed":
+                ray.get(
+                    self._rb._start_distributed_service.remote(
+                        dict(transport_options or {})
+                    )
+                )
+                self._distributed_batch_size = ray.get(
+                    self._rb._getattr.remote("_batch_size")
+                )
+                self._client = _LazyDistributedReplayClient(
+                    self._rb, batch_size=self._distributed_batch_size
+                )
+                self._transport_kind = "distributed"
+            else:
+                self._client = _RayReplayBufferClient(self._rb, has_gpu=self.has_gpu)
+                self._transport_kind = "ray"
+        except BaseException:
+            actor = getattr(self, "_rb", None)
+            if actor is not None:
+                with contextlib.suppress(Exception):
+                    ray.kill(actor, no_restart=True)
+                del self._rb
+            self._runtime_lease.release()
+            raise
 
     def start(self) -> RayReplayBuffer:
         """Return this already-started Ray replay-buffer owner."""
@@ -259,11 +374,28 @@ class RayReplayBuffer(ReplayBuffer):
         """The canonical deployment backend for this replay buffer."""
         return "ray"
 
-    def client(self) -> _RayReplayBufferClient:
+    @property
+    def transport_kind(self) -> str:
+        """Physical transport used for replay payloads."""
+        return self._transport_kind
+
+    def client(self) -> Any:
         """Return a picklable client without actor shutdown rights."""
         if not self.is_alive:
             raise RuntimeError("RayReplayBuffer is closed.")
+        if self.transport_kind == "distributed":
+            return _LazyDistributedReplayClient(
+                self._rb, batch_size=self._distributed_batch_size
+            )
         return _RayReplayBufferClient(self._rb, has_gpu=self.has_gpu)
+
+    def clients(self, num_clients: int) -> list[Any]:
+        """Return one independently routed client per concurrent consumer."""
+        if isinstance(num_clients, bool) or not isinstance(num_clients, int):
+            raise TypeError("num_clients must be an integer.")
+        if num_clients < 1:
+            raise ValueError("num_clients must be at least 1.")
+        return [self.client() for _ in range(num_clients)]
 
     def shutdown(self, timeout: float | None = None) -> None:
         """Terminate the owned Ray actor."""
@@ -275,6 +407,11 @@ class RayReplayBuffer(ReplayBuffer):
         if hasattr(self, "_rb"):
             try:
                 torchrl_logger.info("Killing Ray actor.")
+                if self.transport_kind == "distributed":
+                    try:
+                        ray.get(self._rb._shutdown_distributed_service.remote())
+                    except (ValueError, RuntimeError):
+                        pass
                 ray.kill(self._rb, no_restart=True)  # Forcefully terminate the actor
                 torchrl_logger.info("Ray actor killed.")
             except (ValueError, RuntimeError) as e:
@@ -284,6 +421,7 @@ class RayReplayBuffer(ReplayBuffer):
                 )
             finally:
                 delattr(self, "_rb")  # Remove the reference to the terminated actor
+                self._runtime_lease.release()
 
     @property
     def _replay_lock(self):
@@ -307,7 +445,19 @@ class RayReplayBuffer(ReplayBuffer):
         return self._client.add(*args, **kwargs)
 
     def update_priority(self, *args, **kwargs):
+        if self.transport_kind == "distributed":
+            if len(args) == 1 and isinstance(args[0], TensorDictBase) and not kwargs:
+                return self._client.update_tensordict_priority(args[0])
+            raise NotImplementedError(
+                "The distributed replay transport updates priorities through "
+                "update_tensordict_priority(sample)."
+            )
         return self._client.update_priority(*args, **kwargs)
+
+    def update_tensordict_priority(self, data: TensorDictBase) -> None:
+        if self.transport_kind == "distributed":
+            return self._client.update_tensordict_priority(data)
+        return ray.get(self._rb.update_tensordict_priority.remote(data))
 
     def append_transform(self, *args, **kwargs):
         return ray.get(self._rb.append_transform.remote(*args, **kwargs))

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -51,6 +51,7 @@ except ImportError:
         return tree_flat
 
 
+from torchrl._comm.replay_service import _DistributedReplayService, _extend_reply
 from torchrl._utils import (
     _RayServiceMetaClass,
     accept_remote_rref_udf_invocation,
@@ -225,6 +226,12 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             ``"ray"``. Defaults to ``"direct"``.
         service_backend_options (dict, optional): Ray initialization options.
             Accepted keys are ``ray_init_config`` and ``remote_config``.
+        transport (str, optional): physical transport used by a remote replay
+            owner. ``"auto"`` selects the backend default. Defaults to
+            ``"auto"``.
+        transport_options (dict, optional): options for the selected transport.
+            For ``transport="distributed"``, ``backend`` selects ``"gloo"``
+            or ``"nccl"``. TensorDict layouts are bound lazily on first use.
 
     Examples:
         >>> import torch
@@ -349,8 +356,18 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
         delayed_init: bool | None = None,
         service_backend: Literal["direct", "ray"] = "direct",
         service_backend_options: dict[str, Any] | None = None,
+        transport: Literal["auto", "direct", "ray", "distributed"] = "auto",
+        transport_options: dict[str, Any] | None = None,
     ) -> None:
-        del service_backend, service_backend_options
+        if service_backend == "direct" and transport not in ("auto", "direct"):
+            raise ValueError(
+                "A direct ReplayBuffer only supports transport='auto' or 'direct'."
+            )
+        if service_backend == "direct" and transport_options:
+            raise ValueError(
+                "transport_options are only valid for a remote ReplayBuffer."
+            )
+        del service_backend, service_backend_options, transport, transport_options
         if consume_after_n_samples is not None:
             if isinstance(consume_after_n_samples, bool) or not isinstance(
                 consume_after_n_samples, INT_CLASSES
@@ -534,6 +551,78 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
     def client(self) -> Self:
         """Return ``self`` for the zero-overhead direct backend."""
         return self
+
+    def _start_distributed_service(self, transport_options: dict[str, Any]) -> None:
+        """Start the private tensor transport inside a remote owner."""
+        if hasattr(self, "_distributed_service"):
+            raise RuntimeError("The distributed replay service is already running.")
+        options = dict(transport_options)
+        extend_spec = options.pop("extend_spec", None)
+        sample_spec = options.pop("sample_spec", None)
+        priority_spec = options.pop("priority_spec", None)
+        self._distributed_service = _DistributedReplayService(
+            self,
+            extend_spec=extend_spec,
+            sample_spec=sample_spec,
+            priority_spec=priority_spec,
+            **options,
+        ).start()
+
+    def _bootstrap_distributed_extend(self, data: TensorDictBase):
+        """Bind the extend schema and apply exactly one first operation."""
+        service = self._distributed_service
+        with service._lock:
+            if service.extend_transport is None:
+                result = self.extend(data)
+                reply = _extend_reply(result, service._wire_device)
+                service.bind_extend(data, reply)
+                return service.extend_client(), reply.get("result", None), True
+            return service.extend_client(), None, False
+
+    def _bootstrap_distributed_sample(self, batch_size: int):
+        """Bind the sample schema and return exactly one first sample."""
+        service = self._distributed_service
+        with service._lock:
+            if service.sample_transport is None:
+                result = self.sample(batch_size).to(service._wire_device)
+                service.bind_sample(result)
+                return service.sample_client(), result, True, batch_size
+            return (
+                service.sample_client(),
+                None,
+                False,
+                service._sample_batch_size,
+            )
+
+    def _bootstrap_distributed_priority(self, data: TensorDictBase):
+        """Bind the priority schema and apply exactly one first update."""
+        service = self._distributed_service
+        with service._lock:
+            if service.priority_transport is None:
+                update = getattr(self, "update_tensordict_priority", None)
+                if update is not None:
+                    update(data)
+                service.bind_priority(data)
+                return service.priority_client(), True
+            return service.priority_client(), False
+
+    def _distributed_control_client(self):
+        """Return a restricted control endpoint for length and write count."""
+        return self._distributed_service.control_client()
+
+    def _distributed_service_client(self):
+        """Create an independently routed client for the private service."""
+        service = getattr(self, "_distributed_service", None)
+        if service is None:
+            raise RuntimeError("The distributed replay service is not running.")
+        return service.client()
+
+    def _shutdown_distributed_service(self) -> None:
+        """Stop the private tensor transport when the remote owner closes."""
+        service = getattr(self, "_distributed_service", None)
+        if service is not None:
+            service.shutdown()
+            del self._distributed_service
 
     def shutdown(self, timeout: float | None = None) -> None:
         """Mark this direct replay-buffer owner as shut down."""

--- a/torchrl/modules/inference_server/_config.py
+++ b/torchrl/modules/inference_server/_config.py
@@ -204,7 +204,8 @@ class InferenceServerConfig:
             ``"thread"`` runs the serve loop in a background thread of the
             constructing process; ``"process"`` runs a dedicated server
             process (which requires a picklable ``policy_factory`` and a
-            multiprocessing-capable transport). Defaults to ``"thread"``.
+            multiprocessing-capable transport); ``"ray"`` runs a dedicated
+            Ray actor and requires ``policy_factory``. Defaults to ``"thread"``.
         max_batch_size (int, optional): maximum number of requests per forward
             pass. Defaults to ``64``.
         min_batch_size (int, optional): minimum number of requests to
@@ -230,15 +231,13 @@ class InferenceServerConfig:
         >>> from torchrl.modules.inference_server import (
         ...     InferenceServer,
         ...     InferenceServerConfig,
-        ...     ThreadingTransport,
         ... )
         >>> policy = TensorDictModule(
         ...     nn.Linear(4, 2), in_keys=["observation"], out_keys=["action"]
         ... )
-        >>> transport = ThreadingTransport()
         >>> config = InferenceServerConfig(max_batch_size=8, timeout=0.001)
-        >>> with InferenceServer(policy, transport, server_config=config) as server:
-        ...     client = transport.client()
+        >>> with InferenceServer(policy, transport="auto", server_config=config) as server:
+        ...     client = server.client()
         ...     result = client(TensorDict({"observation": torch.randn(4)}))
         >>> result["action"].shape
         torch.Size([2])
@@ -246,7 +245,7 @@ class InferenceServerConfig:
         8
     """
 
-    service_backend: Literal["thread", "process"] = "thread"
+    service_backend: Literal["thread", "process", "ray"] = "thread"
     max_batch_size: int = 64
     min_batch_size: int = 1
     timeout: float = 0.01
@@ -255,10 +254,10 @@ class InferenceServerConfig:
     max_inflight_per_env: int | None = None
 
     def __post_init__(self) -> None:
-        if self.service_backend not in ("thread", "process"):
+        if self.service_backend not in ("thread", "process", "ray"):
             raise ValueError(
                 f"service_backend={self.service_backend!r} is not supported. "
-                "Expected 'thread' or 'process'."
+                "Expected 'thread', 'process', or 'ray'."
             )
         if self.max_inflight_per_env is not None and self.max_inflight_per_env < 1:
             raise ValueError(

--- a/torchrl/modules/inference_server/_distributed.py
+++ b/torchrl/modules/inference_server/_distributed.py
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+from torchrl._comm.distributed import _DistributedTransport
+from torchrl.modules.inference_server._transport import InferenceTransport
+
+
+class _DistributedInferenceTransport(_DistributedTransport, InferenceTransport):
+    """Private inference adapter for the tensor request/reply transport."""
+
+
+__all__ = ["_DistributedInferenceTransport"]

--- a/torchrl/modules/inference_server/_factory.py
+++ b/torchrl/modules/inference_server/_factory.py
@@ -1,0 +1,178 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+from typing import Any
+
+from tensordict.base import TensorDictBase
+
+from torchrl.modules.inference_server._distributed import _DistributedInferenceTransport
+from torchrl.modules.inference_server._monarch import MonarchTransport
+from torchrl.modules.inference_server._mp import MPTransport
+from torchrl.modules.inference_server._ray import RayTransport
+from torchrl.modules.inference_server._shared_memory import SharedMemoryTransport
+from torchrl.modules.inference_server._slot import SlotTransport
+from torchrl.modules.inference_server._threading import ThreadingTransport
+from torchrl.modules.inference_server._transport import InferenceTransport
+
+
+def _validate_inference_transport_selection(
+    transport: InferenceTransport | str | None,
+    *,
+    service_backend: str,
+    transport_options: dict[str, Any] | None,
+    request_spec: TensorDictBase | None,
+    response_spec: TensorDictBase | None,
+) -> None:
+    """Reject unsupported explicit selectors before creating an owner."""
+    if isinstance(transport, InferenceTransport):
+        if transport_options:
+            raise ValueError(
+                "transport_options cannot be used with an explicit transport instance."
+            )
+        return
+    kind = "auto" if transport is None else transport
+    allowed = {
+        "thread": {"auto", "thread", "queue", "direct"},
+        "process": {"auto", "process", "shared_memory", "distributed"},
+        "ray": {"auto", "ray", "distributed"},
+    }[service_backend]
+    if kind not in allowed:
+        raise ValueError(
+            f"transport={kind!r} is incompatible with "
+            f"service_backend={service_backend!r}."
+        )
+    if (request_spec is None) != (response_spec is None):
+        raise ValueError("request_spec and response_spec must be provided together.")
+    if kind == "shared_memory" and request_spec is None:
+        raise ValueError(
+            "transport='shared_memory' requires request_spec and response_spec."
+        )
+    if kind == "distributed" and service_backend == "process" and request_spec is None:
+        raise ValueError(
+            "Process-owned distributed inference requires request_spec and response_spec."
+        )
+
+
+def _make_inference_transport(
+    transport: InferenceTransport | str | None,
+    *,
+    service_backend: str,
+    transport_options: dict[str, Any] | None = None,
+    request_spec: TensorDictBase | None = None,
+    response_spec: TensorDictBase | None = None,
+    num_clients: int | None = None,
+) -> InferenceTransport:
+    """Resolve an inference transport without exposing deployment machinery."""
+    _validate_inference_transport_selection(
+        transport,
+        service_backend=service_backend,
+        transport_options=transport_options,
+        request_spec=request_spec,
+        response_spec=response_spec,
+    )
+    if isinstance(transport, InferenceTransport):
+        if transport_options:
+            raise ValueError(
+                "transport_options cannot be used with an explicit transport instance."
+            )
+        return transport
+
+    options = dict(transport_options or {})
+    kind = "auto" if transport is None else transport
+    if kind == "auto":
+        kind = {
+            "thread": "thread",
+            "process": "process",
+            "ray": "ray",
+            "monarch": "monarch",
+        }[service_backend]
+
+    if kind in ("thread", "queue"):
+        if service_backend != "thread":
+            raise ValueError(
+                f"transport={transport!r} is incompatible with "
+                f"service_backend={service_backend!r}."
+            )
+        return ThreadingTransport(**options)
+    if kind == "process":
+        if service_backend != "process":
+            raise ValueError(
+                f"transport='process' is incompatible with "
+                f"service_backend={service_backend!r}."
+            )
+        options.setdefault("use_manager", True)
+        return MPTransport(**options)
+    if kind == "ray":
+        if service_backend != "ray":
+            raise ValueError(
+                f"transport='ray' is incompatible with "
+                f"service_backend={service_backend!r}."
+            )
+        return RayTransport(**options)
+    if kind == "monarch":
+        if service_backend != "monarch":
+            raise ValueError(
+                f"transport='monarch' is incompatible with "
+                f"service_backend={service_backend!r}."
+            )
+        return MonarchTransport(**options)
+    if kind == "shared_memory":
+        if service_backend != "process":
+            raise ValueError(
+                "transport='shared_memory' requires service_backend='process'."
+            )
+        if request_spec is None or response_spec is None:
+            raise ValueError(
+                "transport='shared_memory' requires request_spec and response_spec."
+            )
+        options.setdefault("num_slots", num_clients or 1)
+        return SharedMemoryTransport(request_spec, response_spec, **options)
+    if kind == "direct":
+        if service_backend != "thread":
+            raise ValueError("transport='direct' requires service_backend='thread'.")
+        if num_clients is None:
+            raise ValueError("transport='direct' requires num_clients.")
+        return SlotTransport(num_clients, **options)
+    if kind == "distributed":
+        if service_backend not in ("ray", "process"):
+            raise ValueError(
+                "transport='distributed' requires service_backend='ray' or 'process'."
+            )
+        if request_spec is None or response_spec is None:
+            raise ValueError(
+                "transport='distributed' requires request_spec and response_spec."
+            )
+        return _DistributedInferenceTransport(request_spec, response_spec, **options)
+    raise ValueError(
+        f"Unknown inference transport {transport!r}. Expected one of 'auto', "
+        "'thread', 'process', 'ray', 'shared_memory', 'direct', or 'distributed'."
+    )
+
+
+def _inference_transport_kind(transport: InferenceTransport) -> str:
+    """Return the compact selector for a resolved inference transport."""
+    if isinstance(transport, SharedMemoryTransport):
+        return "shared_memory"
+    if isinstance(transport, SlotTransport):
+        return "direct"
+    if isinstance(transport, RayTransport):
+        return "ray"
+    if isinstance(transport, MonarchTransport):
+        return "monarch"
+    if isinstance(transport, MPTransport):
+        return "process"
+    if isinstance(transport, ThreadingTransport):
+        return "thread"
+    if isinstance(transport, _DistributedInferenceTransport):
+        return "distributed"
+    return "custom"
+
+
+__all__ = [
+    "_inference_transport_kind",
+    "_make_inference_transport",
+    "_validate_inference_transport_selection",
+]

--- a/torchrl/modules/inference_server/_server.py
+++ b/torchrl/modules/inference_server/_server.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import contextlib
+import importlib.util
+import inspect
 import multiprocessing as mp
 
 import queue
@@ -12,18 +14,20 @@ import threading
 import time
 from collections.abc import Callable
 from concurrent.futures import Future
+from dataclasses import replace
 from multiprocessing.synchronize import Event as MPEvent
 from statistics import mean
 from typing import Any, Literal
 
 import torch
-from tensordict import lazy_stack
+from tensordict import lazy_stack, TensorDict
 from tensordict.base import TensorDictBase
 from tensordict.nn.probabilistic import InteractionType, set_interaction_type
 from tensordict.utils import NestedKey
 from torch import nn
 
 from torchrl._comm import CommandChannel, Mailbox, watch_process_liveness
+from torchrl._comm.ray_runtime import _RayRuntimeLease, _set_ray_client_liveness
 from torchrl.modules.inference_server._client import (
     _NO_INTERACTION_TYPE_CODE,
     _REMOTE_INTERACTION_TYPE_KEY,
@@ -33,6 +37,12 @@ from torchrl.modules.inference_server._config import (
     InferenceDeviceConfig,
     InferenceServerConfig,
 )
+from torchrl.modules.inference_server._factory import (
+    _inference_transport_kind,
+    _make_inference_transport,
+    _validate_inference_transport_selection,
+)
+from torchrl.modules.inference_server._threading import ThreadingTransport
 from torchrl.modules.inference_server._transport import InferenceTransport
 from torchrl.weight_update import (
     SharedMemWeightSyncScheme,
@@ -47,6 +57,119 @@ _CODE_TO_INTERACTION_TYPE = {
     3: InteractionType.RANDOM,
     4: InteractionType.DETERMINISTIC,
 }
+_has_ray = importlib.util.find_spec("ray") is not None
+
+
+class _InferenceServerMeta(type):
+    """Select a private owner while keeping InferenceServer as the API."""
+
+    def __call__(cls, *args, **kwargs):
+        if cls is not InferenceServer:
+            return super().__call__(*args, **kwargs)
+
+        if len(args) > 2:
+            raise TypeError(
+                "InferenceServer accepts at most model and transport positionally."
+            )
+        model = args[0] if args else kwargs.pop("model", None)
+        transport = args[1] if len(args) > 1 else kwargs.pop("transport", None)
+        policy_factory = kwargs.pop("policy_factory", None)
+        server_config = kwargs.get("server_config")
+        configured_backend = (
+            server_config.service_backend if server_config is not None else "thread"
+        )
+        service_backend = kwargs.pop("service_backend", None)
+        if service_backend is None:
+            service_backend = configured_backend
+        elif server_config is not None and configured_backend not in (
+            "thread",
+            service_backend,
+        ):
+            raise ValueError(
+                "service_backend conflicts with server_config.service_backend."
+            )
+        if service_backend not in ("thread", "process", "ray"):
+            raise ValueError(
+                "InferenceServer service_backend must be 'thread', 'process', or 'ray'."
+            )
+
+        service_options = dict(kwargs.pop("service_backend_options", None) or {})
+        transport_options = kwargs.pop("transport_options", None)
+        request_spec = kwargs.pop("request_spec", None)
+        response_spec = kwargs.pop("response_spec", None)
+        num_clients = kwargs.pop("num_clients", None)
+        _validate_inference_transport_selection(
+            transport,
+            service_backend=service_backend,
+            transport_options=transport_options,
+            request_spec=request_spec,
+            response_spec=response_spec,
+        )
+
+        if service_backend == "ray":
+            if model is not None:
+                raise ValueError(
+                    "service_backend='ray' requires policy_factory so the policy "
+                    "is constructed on the Ray actor."
+                )
+            if policy_factory is None:
+                raise ValueError(
+                    "policy_factory is required for service_backend='ray'."
+                )
+            return _RayInferenceServer(
+                policy_factory=policy_factory,
+                transport=transport,
+                transport_options=transport_options,
+                service_backend_options=service_options,
+                request_spec=request_spec,
+                response_spec=response_spec,
+                num_clients=num_clients,
+                **kwargs,
+            )
+
+        resolved_transport = _make_inference_transport(
+            transport,
+            service_backend=service_backend,
+            transport_options=transport_options,
+            request_spec=request_spec,
+            response_spec=response_spec,
+            num_clients=num_clients,
+        )
+        if service_backend == "process":
+            if model is not None:
+                raise ValueError(
+                    "service_backend='process' requires policy_factory so the policy "
+                    "is constructed in the child process."
+                )
+            if policy_factory is None:
+                raise ValueError(
+                    "policy_factory is required for service_backend='process'."
+                )
+            allowed_options = {"mp_context", "startup_timeout"}
+            extra_options = set(service_options) - allowed_options
+            if extra_options:
+                raise ValueError(
+                    "Unsupported process service_backend_options: "
+                    f"{sorted(extra_options)}."
+                )
+            return ProcessInferenceServer(
+                policy_factory=policy_factory,
+                transport=resolved_transport,
+                **service_options,
+                **kwargs,
+            )
+
+        if service_options:
+            raise ValueError(
+                "service_backend_options are only valid for process or Ray services."
+            )
+        if model is None:
+            if policy_factory is None:
+                raise ValueError("Either model or policy_factory must be provided.")
+            model = policy_factory()
+        elif policy_factory is not None:
+            raise ValueError("model and policy_factory are mutually exclusive.")
+        return super().__call__(model, resolved_transport, **kwargs)
 
 
 def _normalize_tensordict_device_metadata(data: TensorDictBase) -> TensorDictBase:
@@ -91,7 +214,7 @@ def _default_collate(items: list[TensorDictBase]) -> TensorDictBase:
     )
 
 
-class InferenceServer:
+class InferenceServer(metaclass=_InferenceServerMeta):
     """Auto-batching inference server.
 
     Actors submit individual TensorDicts via the *transport* and receive
@@ -99,12 +222,35 @@ class InferenceServer:
     batches inputs, runs the model, and fans results back to the callers.
 
     Args:
-        model (nn.Module or Callable): a callable that maps a batched
+        model (nn.Module or Callable, optional): callable that maps a batched
             TensorDictBase to a batched TensorDictBase (e.g. a
-            :class:`~tensordict.nn.TensorDictModule`).
-        transport (InferenceTransport): the communication backend.
+            :class:`~tensordict.nn.TensorDictModule`). Pass ``policy_factory``
+            instead when a process or Ray actor owns the policy.
+        transport (InferenceTransport or str, optional): payload transport.
+            ``"auto"`` selects a backend-appropriate transport and is the
+            recommended default.
 
     Keyword Args:
+        policy_factory (Callable, optional): zero-argument policy constructor.
+            Required for ``service_backend="process"`` and
+            ``service_backend="ray"`` so policy parameters are created by the
+            process that owns them.
+        service_backend (str, optional): where inference runs: ``"thread"``,
+            ``"process"``, or ``"ray"``. Defaults to ``"thread"``.
+        service_backend_options (dict, optional): owner configuration. The Ray
+            backend accepts ``ray_init_config`` and ``remote_config``; the
+            process backend accepts ``mp_context`` and ``startup_timeout``.
+        transport_options (dict, optional): options forwarded to the selected
+            transport. For ``"distributed"``, ``backend`` selects ``"gloo"``
+            or ``"nccl"``. Explicit selectors never fall back to another
+            transport.
+        request_spec (TensorDictBase, optional): static request layout for
+            shared-memory or process-owned distributed transports. Ray-owned
+            distributed transports infer and bind this layout on first use.
+        response_spec (TensorDictBase, optional): static response layout paired
+            with ``request_spec``.
+        num_clients (int, optional): expected concurrent client count for
+            transports that allocate a fixed number of slots.
         max_batch_size (int, optional): upper bound on the number of requests
             processed in a single forward pass. Default: ``64``.
         min_batch_size (int, optional): minimum number of requests to
@@ -157,28 +303,44 @@ class InferenceServer:
             annotations. Defaults to ``"policy_version"``.
 
     Example:
+        >>> import torch
+        >>> from tensordict import TensorDict
         >>> from tensordict.nn import TensorDictModule
-        >>> from torchrl.modules.inference_server import (
-        ...     InferenceServer,
-        ...     ThreadingTransport,
-        ... )
+        >>> from torchrl.modules.inference_server import InferenceServer
         >>> import torch.nn as nn
         >>> policy = TensorDictModule(
         ...     nn.Linear(4, 2), in_keys=["obs"], out_keys=["act"]
         ... )
-        >>> transport = ThreadingTransport()
-        >>> server = InferenceServer(policy, transport, max_batch_size=8)
-        >>> server.start()
-        >>> client = transport.client()
-        >>> # client(td) can now be called from any thread
-        >>> server.shutdown()
+        >>> with InferenceServer(policy, transport="auto", max_batch_size=8) as server:
+        ...     result = server.client()(TensorDict({"obs": torch.randn(4)}))
+        >>> result["act"].shape
+        torch.Size([2])
     """
 
     def __init__(
         self,
-        model: nn.Module,
-        transport: InferenceTransport,
+        model: nn.Module | Callable[[TensorDictBase], TensorDictBase] | None = None,
+        transport: InferenceTransport
+        | Literal[
+            "auto",
+            "thread",
+            "process",
+            "ray",
+            "shared_memory",
+            "direct",
+            "distributed",
+        ] = "auto",
         *,
+        policy_factory: Callable[
+            [], nn.Module | Callable[[TensorDictBase], TensorDictBase]
+        ]
+        | None = None,
+        service_backend: Literal["thread", "process", "ray"] = "thread",
+        service_backend_options: dict[str, Any] | None = None,
+        transport_options: dict[str, Any] | None = None,
+        request_spec: TensorDictBase | None = None,
+        response_spec: TensorDictBase | None = None,
+        num_clients: int | None = None,
         max_batch_size: int | None = None,
         min_batch_size: int | None = None,
         timeout: float | None = None,
@@ -196,6 +358,23 @@ class InferenceServer:
         policy_version: int = 0,
         policy_version_key: NestedKey | None = "policy_version",
     ):
+        # Deployment keywords are consumed by the metaclass before this local
+        # implementation is constructed. Keeping them in the signature makes
+        # the canonical API discoverable to help() and static tooling.
+        del (
+            policy_factory,
+            service_backend,
+            service_backend_options,
+            transport_options,
+            request_spec,
+            response_spec,
+            num_clients,
+        )
+        if model is None or not isinstance(transport, InferenceTransport):
+            raise RuntimeError(
+                "InferenceServer deployment arguments were not resolved before "
+                "constructing the local server."
+            )
         if server_config is not None and any(
             kwarg is not None
             for kwarg in (
@@ -422,9 +601,27 @@ class InferenceServer:
         """Whether the background worker thread is running."""
         return self._worker is not None and self._worker.is_alive()
 
+    @property
+    def service_backend(self) -> str:
+        """Execution backend that owns the policy."""
+        return "thread"
+
+    @property
+    def transport_kind(self) -> str:
+        """Physical transport used for inference payloads."""
+        return _inference_transport_kind(self.transport)
+
     def client(self) -> Any:
         """Return a restricted inference client from the owned transport."""
         return self.transport.client()
+
+    def clients(self, num_clients: int) -> list[Any]:
+        """Return one independently routed client per concurrent consumer."""
+        if isinstance(num_clients, bool) or not isinstance(num_clients, int):
+            raise TypeError("num_clients must be an integer.")
+        if num_clients < 1:
+            raise ValueError("num_clients must be at least 1.")
+        return [self.client() for _ in range(num_clients)]
 
     # -- background loop ------------------------------------------------------
 
@@ -611,6 +808,12 @@ class InferenceServer:
         worker = getattr(self, "_worker", None)
         if worker is not None and worker.is_alive():
             self.shutdown(timeout=1.0)
+
+
+_inference_server_signature = inspect.signature(InferenceServer.__init__)
+InferenceServer.__signature__ = _inference_server_signature.replace(
+    parameters=tuple(_inference_server_signature.parameters.values())[1:]
+)
 
 
 def _process_server_entry(
@@ -994,9 +1197,28 @@ class ProcessInferenceServer:
         """Whether the child process is alive."""
         return self._process is not None and self._process.is_alive()
 
+    @property
+    def service_backend(self) -> str:
+        """Execution backend that owns the policy."""
+        return "process"
+
+    @property
+    def transport_kind(self) -> str:
+        """Physical transport used for inference payloads."""
+        return _inference_transport_kind(self.transport)
+
     def client(self) -> Any:
         """Return a restricted inference client from the owned transport."""
         return self._service_client
+
+    def clients(self, num_clients: int) -> list[Any]:
+        """Return one independently routed client per concurrent consumer."""
+        if isinstance(num_clients, bool) or not isinstance(num_clients, int):
+            raise TypeError("num_clients must be an integer.")
+        if num_clients < 1:
+            raise ValueError("num_clients must be at least 1.")
+        # MPTransport routes replies per client, so reserve a fresh endpoint.
+        return [self.transport.client() for _ in range(num_clients)]
 
     def stats(
         self, *, reset: bool = False, timeout: float = 5.0
@@ -1084,6 +1306,353 @@ class ProcessInferenceServer:
         process = getattr(self, "_process", None)
         if process is not None and process.is_alive():
             self.shutdown(timeout=1.0)
+
+
+class _RayInferenceServerActor:
+    """Ray actor that owns a policy, transport, and local inference loop."""
+
+    def __init__(
+        self,
+        policy_factory: Callable[[], nn.Module],
+        transport: InferenceTransport | str | None,
+        transport_options: dict[str, Any] | None,
+        request_spec: TensorDictBase | None,
+        response_spec: TensorDictBase | None,
+        num_clients: int | None,
+        server_kwargs: dict[str, Any],
+    ) -> None:
+        self.model = policy_factory()
+        self._transport = transport
+        self._transport_options = transport_options
+        self._num_clients = num_clients
+        self._bootstrap_lock = threading.Lock()
+        config = server_kwargs.get("server_config")
+        if config is not None and config.service_backend != "thread":
+            server_kwargs["server_config"] = replace(config, service_backend="thread")
+        self._server_kwargs = server_kwargs
+        self.server = None
+        if request_spec is not None or response_spec is not None:
+            if request_spec is None or response_spec is None:
+                raise ValueError(
+                    "request_spec and response_spec must be provided together."
+                )
+            self._start_server(request_spec, response_spec)
+        elif transport != "distributed":
+            resolved_transport = _make_inference_transport(
+                transport,
+                service_backend="ray",
+                transport_options=transport_options,
+                request_spec=None,
+                response_spec=None,
+                num_clients=num_clients,
+            )
+            self.server = InferenceServer(
+                self.model,
+                resolved_transport,
+                service_backend="thread",
+                **server_kwargs,
+            ).start()
+
+    def _start_server(
+        self, request_spec: TensorDictBase, response_spec: TensorDictBase
+    ) -> None:
+        resolved_transport = _make_inference_transport(
+            self._transport,
+            service_backend="ray",
+            transport_options=self._transport_options,
+            request_spec=request_spec,
+            response_spec=response_spec,
+            num_clients=self._num_clients,
+        )
+        self.server = InferenceServer(
+            self.model,
+            resolved_transport,
+            service_backend="thread",
+            **self._server_kwargs,
+        ).start()
+
+    def bootstrap_distributed(self, request: TensorDictBase):
+        """Bind the distributed layout on the first endpoint generation."""
+        with self._bootstrap_lock:
+            if self.server is None:
+                # Reuse InferenceServer's collation, placement, and versioning
+                # rules to derive the reply layout without publishing a second
+                # public configuration surface.
+                probe = InferenceServer(
+                    self.model,
+                    ThreadingTransport(),
+                    service_backend="thread",
+                    **self._server_kwargs,
+                )
+                # Collation may return a lazy stack backed by the request. A
+                # TensorDictModule then writes its output keys into that stack,
+                # which must not widen the request schema used by the transport.
+                batch = probe.collate_fn([request.clone()])
+                if probe.policy_device is not None:
+                    batch = batch.to(probe.policy_device)
+                interaction_context, batch = probe._interaction_type_context(batch)
+                with interaction_context:
+                    response = self.model(batch)
+                if probe.output_device is not None:
+                    response = response.to(probe.output_device)
+                response = probe._set_policy_version(response).unbind(0)[0]
+                self._start_server(request, response)
+            return self.server.client()
+
+    def client(self):
+        if self.server is None:
+            raise RuntimeError(
+                "The distributed transport has not established its schema yet."
+            )
+        return self.server.client()
+
+    def stats(self, reset: bool = False) -> dict[str, float | int]:
+        if self.server is None:
+            return {"num_requests": 0, "num_batches": 0}
+        return self.server.stats(reset=reset)
+
+    def health(self) -> dict[str, Any]:
+        return {
+            "is_alive": self.server is None or self.server.is_alive,
+            "policy_version": (
+                int(self._server_kwargs.get("policy_version", 0))
+                if self.server is None
+                else self.server.policy_version
+            ),
+            "transport": (
+                "distributed"
+                if self.server is None
+                else _inference_transport_kind(self.server.transport)
+            ),
+        }
+
+    def update_model_weights(
+        self, weights: TensorDictBase, mark_weight_update: bool = True
+    ) -> None:
+        if self.server is None:
+            weights.to_module(self.model)
+            if mark_weight_update:
+                self._server_kwargs["policy_version"] = (
+                    int(self._server_kwargs.get("policy_version", 0)) + 1
+                )
+        else:
+            self.server.update_model(
+                lambda model: weights.to_module(model),
+                mark_weight_update=mark_weight_update,
+            )
+
+    def shutdown(self) -> None:
+        if self.server is not None:
+            self.server.shutdown(timeout=None)
+            close = getattr(self.server.transport, "close", None)
+            if close is not None:
+                close()
+
+
+class _RayDistributedInferenceClient:
+    """Restricted client that lazily binds a distributed TensorDict schema."""
+
+    def __init__(self, actor) -> None:
+        self._actor = actor
+        self._client = None
+
+    def __call__(
+        self, payload: TensorDictBase, timeout: float | None = None
+    ) -> TensorDictBase:
+        if self._client is None:
+            import ray
+
+            self._client = ray.get(self._actor.bootstrap_distributed.remote(payload))
+            _set_ray_client_liveness(self._client, self._actor)
+        return self._client(payload, timeout=timeout)
+
+
+class _RayInferenceServer(InferenceServer):
+    """Private Ray owner returned by ``InferenceServer`` dispatch."""
+
+    def __init__(
+        self,
+        *,
+        policy_factory: Callable[[], nn.Module],
+        transport: InferenceTransport | str | None = "auto",
+        transport_options: dict[str, Any] | None = None,
+        service_backend_options: dict[str, Any] | None = None,
+        request_spec: TensorDictBase | None = None,
+        response_spec: TensorDictBase | None = None,
+        num_clients: int | None = None,
+        **server_kwargs,
+    ) -> None:
+        if not _has_ray:
+            raise ImportError("Ray is required for service_backend='ray'.")
+        import ray
+
+        options = dict(service_backend_options or {})
+        ray_init_config = options.pop("ray_init_config", None)
+        remote_config = dict(options.pop("remote_config", None) or {})
+        if options:
+            raise ValueError(
+                f"Unsupported Ray service_backend_options: {sorted(options)}."
+            )
+        if remote_config.get("num_gpus", 0):
+            if (
+                server_kwargs.get("device") is None
+                and server_kwargs.get("policy_device") is None
+                and server_kwargs.get("device_config") is None
+            ):
+                server_kwargs["policy_device"] = "cuda:0"
+            if (
+                server_kwargs.get("output_device") is None
+                and server_kwargs.get("device_config") is None
+            ):
+                server_kwargs["output_device"] = "cpu"
+
+        self._runtime_lease = _RayRuntimeLease.acquire(ray_init_config)
+        self._actor = None
+        self._lazy_distributed = (
+            transport == "distributed"
+            and request_spec is None
+            and response_spec is None
+        )
+        self._distributed = transport == "distributed"
+        try:
+            actor_cls = ray.remote(**remote_config)(_RayInferenceServerActor)
+            self._actor = actor_cls.remote(
+                policy_factory,
+                transport,
+                transport_options,
+                request_spec,
+                response_spec,
+                num_clients,
+                server_kwargs,
+            )
+            ray.get(self._actor.health.remote())
+        except BaseException:
+            if self._actor is not None:
+                with contextlib.suppress(Exception):
+                    ray.kill(self._actor, no_restart=True)
+                self._actor = None
+            self._runtime_lease.release()
+            raise
+
+    @property
+    def service_backend(self) -> str:
+        return "ray"
+
+    @property
+    def is_alive(self) -> bool:
+        actor = getattr(self, "_actor", None)
+        if actor is None:
+            return False
+        import ray
+
+        try:
+            return bool(ray.get(actor.health.remote())["is_alive"])
+        except Exception:
+            return False
+
+    @property
+    def policy_version(self) -> int:
+        return int(self.health()["policy_version"])
+
+    @property
+    def transport_kind(self) -> str:
+        return str(self.health()["transport"])
+
+    def start(self) -> _RayInferenceServer:
+        if not self.is_alive:
+            raise RuntimeError("The Ray inference server is not alive.")
+        return self
+
+    def client(self):
+        if self._actor is None:
+            raise RuntimeError("The Ray inference server is closed.")
+        if self._lazy_distributed:
+            return _RayDistributedInferenceClient(self._actor)
+        import ray
+
+        client = ray.get(self._actor.client.remote())
+        if self._distributed:
+            _set_ray_client_liveness(client, self._actor)
+        return client
+
+    def clients(self, num_clients: int) -> list[Any]:
+        if isinstance(num_clients, bool) or not isinstance(num_clients, int):
+            raise TypeError("num_clients must be an integer.")
+        if num_clients < 1:
+            raise ValueError("num_clients must be at least 1.")
+        return [self.client() for _ in range(num_clients)]
+
+    def stats(self, *, reset: bool = False) -> dict[str, float | int]:
+        if self._actor is None:
+            raise RuntimeError("The Ray inference server is closed.")
+        import ray
+
+        return ray.get(self._actor.stats.remote(reset))
+
+    def health(self) -> dict[str, Any]:
+        if self._actor is None:
+            return {"is_alive": False}
+        import ray
+
+        return ray.get(self._actor.health.remote())
+
+    def update_model_weights(
+        self,
+        weights: TensorDictBase,
+        *,
+        mark_weight_update: bool = True,
+    ) -> None:
+        if self._actor is None:
+            raise RuntimeError("The Ray inference server is closed.")
+        import ray
+
+        ray.get(self._actor.update_model_weights.remote(weights, mark_weight_update))
+
+    def update_policy_weights_(
+        self, model_id=None, policy_or_weights=None, **kwargs
+    ) -> None:
+        del kwargs
+        if (
+            policy_or_weights is None
+            and model_id is not None
+            and not isinstance(model_id, str)
+        ):
+            policy_or_weights = model_id
+        if isinstance(policy_or_weights, nn.Module):
+            policy_or_weights = TensorDict.from_module(policy_or_weights).data
+        if policy_or_weights is None:
+            raise ValueError("Policy weights must be provided.")
+        self.update_model_weights(policy_or_weights)
+
+    def shutdown(self, timeout: float | None = 5.0) -> None:
+        actor = getattr(self, "_actor", None)
+        if actor is None:
+            return
+        import ray
+
+        try:
+            ray.get(actor.shutdown.remote(), timeout=timeout)
+        except Exception:
+            pass
+        try:
+            ray.kill(actor, no_restart=True)
+        except Exception:
+            pass
+        self._actor = None
+        self._runtime_lease.release()
+
+    close = shutdown
+
+    def __enter__(self) -> _RayInferenceServer:
+        return self.start()
+
+    def __exit__(self, *exc_info) -> None:
+        self.shutdown()
+
+    def __del__(self) -> None:
+        if getattr(self, "_actor", None) is not None:
+            with contextlib.suppress(BaseException):
+                self.shutdown(timeout=1.0)
 
 
 class InferenceClient:


### PR DESCRIPTION
## Summary

Adds configurable payload transports behind the TorchRL APIs users already construct:

- `ReplayBuffer(..., service_backend=..., transport=...)`
- `InferenceServer(..., service_backend=..., transport=...)`
- `RayCollector(policy=inference, replay_buffer=replay)`

The user-facing choices are deliberately small:

- `service_backend` decides where replay or inference runs.
- `transport="auto"` selects the backend-appropriate payload path.
- An explicit transport selector is available when the physical data path matters.

This PR does **not** add public providers, placements, channels, replay services, replay clients, or generic service wrappers. Ray actors, request/reply channels, rendezvous state, and process groups remain implementation details.

## Public API

### Replay ownership

Ray-capable replay-buffer construction now accepts:

- `transport="auto" | "ray" | "distributed"`
- `transport_options=None`

`"auto"` uses the existing Ray actor/RPC path. `"distributed"` uses isolated Gloo or NCCL point-to-point groups selected with `transport_options["backend"]`.

### Inference ownership

`InferenceServer` now accepts:

- `policy_factory` for process- or Ray-owned policies;
- `service_backend="thread" | "process" | "ray"`;
- `service_backend_options`, with `ray_init_config` and `remote_config` for Ray;
- `transport="auto" | "shared_memory" | "ray" | "distributed"` as appropriate for the selected owner;
- `transport_options=None`.

Unsupported owner/transport combinations fail before an owner is started. Existing explicit transport objects and `ProcessInferenceServer` remain supported.

### Collector composition

`RayCollector` recognizes Ray-owned inference and replay objects by capability:

- it creates one restricted endpoint per collector worker;
- workers can invoke component operations but cannot stop or reconfigure owners;
- centralized inference means collectors keep no local policy copy;
- replay writes still use the ordinary collector/replay integration.

## Canonical Ray example

This is also available as `examples/services/ray_collector_services.py`. It runs on CPU and contains no `ray.remote`, `ray.get`, provider, placement, channel, or explicit client construction.

```python
from functools import partial

from tensordict.nn import TensorDictModule
from torch import nn

from torchrl.collectors.distributed import RayCollector
from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
from torchrl.envs import GymEnv
from torchrl.modules.inference_server import InferenceServer


def make_env():
    return GymEnv("Pendulum-v1", device="cpu")


def make_policy():
    return TensorDictModule(
        nn.Sequential(nn.Linear(3, 1), nn.Tanh()),
        in_keys=["observation"],
        out_keys=["action"],
    )


ray_init_config = {
    "num_cpus": 4,
    "include_dashboard": False,
    "log_to_driver": False,
}
replay = TensorDictReplayBuffer(
    storage=partial(LazyTensorStorage, 1_000),
    batch_size=4,
    service_backend="ray",
    service_backend_options={
        "ray_init_config": ray_init_config,
        "remote_config": {"num_cpus": 1},
    },
    transport="auto",
)
inference = InferenceServer(
    policy_factory=make_policy,
    service_backend="ray",
    service_backend_options={
        "remote_config": {"num_cpus": 1},
    },
    transport="auto",
)
collector = None
try:
    collector = RayCollector(
        create_env_fn=[make_env],
        policy=inference,
        replay_buffer=replay,
        collector_class="single",
        frames_per_batch=8,
        total_frames=16,
        remote_configs={"num_cpus": 1, "num_gpus": 0},
        sync=True,
    )
    for _ in collector:
        pass

    sample = replay.sample()
    assert len(replay) == 16
    assert sample.shape == (4,)
finally:
    if collector is not None:
        collector.shutdown()
    inference.shutdown()
    replay.shutdown()
```

## Other supported forms

### Ordinary local replay

The direct path remains an ordinary replay buffer; the transport default adds no wrapper:

```python
import torch
from tensordict import TensorDict
from torchrl.data import LazyTensorStorage, ReplayBuffer

replay = ReplayBuffer(
    storage=LazyTensorStorage(100),
    batch_size=4,
    transport="auto",
)
replay.extend(TensorDict({"value": torch.arange(8)}, batch_size=[8]))
assert replay.sample().shape == (4,)
replay.shutdown()
```

### Process-owned inference

A factory makes ownership explicit: the policy is constructed in the child process rather than serialized after construction.

```python
import torch
from tensordict import TensorDict
from tensordict.nn import TensorDictModule
from torch import nn
from torchrl.modules.inference_server import InferenceServer, PolicyClientModule


def make_policy():
    return TensorDictModule(
        nn.Linear(4, 2), in_keys=["observation"], out_keys=["action"]
    )


with InferenceServer(
    policy_factory=make_policy,
    service_backend="process",
    service_backend_options={"mp_context": "spawn"},
    transport="auto",
) as inference:
    policy = PolicyClientModule(
        inference,
        in_keys=["observation"],
        out_keys=["action", "policy_version"],
    )
    result = policy(
        TensorDict({"observation": torch.randn(4)}, batch_size=[])
    )

assert result["action"].shape == (2,)
```

### Explicit distributed payloads

For Ray-owned replay and inference, replace the two transport arguments in the canonical example with:

```python
transport = "distributed"
transport_options = {"backend": "gloo", "timeout": 30.0}
```

Schemas are inferred on first use and bound to that endpoint generation. Later incompatible shapes, keys, dtypes, devices, or replay sample batch sizes fail instead of silently changing the wire contract. `backend="nccl"` selects GPU-direct payloads.

### Existing `RayReplayBuffer` API

The explicit class remains compatible and now shares the same runtime-lifecycle behavior:

```python
from functools import partial
import torch
from tensordict import TensorDict
from torchrl.data import LazyTensorStorage, RayReplayBuffer

replay = RayReplayBuffer(
    storage=partial(LazyTensorStorage, 100),
    batch_size=4,
    remote_config={"num_cpus": 0},
    transport="auto",
)
try:
    replay.extend(TensorDict({"value": torch.arange(8)}, batch_size=[8]))
    assert replay.sample().shape == (4,)
finally:
    replay.shutdown()
```

## Lifecycle and isolation

- TorchRL initializes Ray only when needed.
- A process-local lease tracks whether TorchRL owns the runtime.
- Closing one component kills only its own actor.
- Caller-owned Ray remains running after component shutdown.
- A TorchRL-owned runtime shuts down only after its last local owner releases it.
- Distributed inference/replay groups are standalone and never replace or destroy the default process group.
- Distributed schemas are established lazily and tied to the owner generation.
- Actor-backed liveness checks make stale distributed endpoints fail promptly instead of waiting indefinitely.

## Validation

- Full non-GPU inference-server suite: 115 passed, 7 skipped, 5 deselected.
- Ray replay-buffer class suite: 6 passed.
- Ray-owned inference + replay + `RayCollector` integration passed.
- Explicit Gloo inference and replay tests passed without initializing the default process group.
- The CPU Ray example passed with both `transport="auto"` and explicit Gloo transport.
- NCCL inference and replay coverage is marked `@pytest.mark.gpu`.
- Full pre-commit suite passed.
