### PR TITLE
[Performance] Memory-map trainer checkpoints on load

### DIFF
--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -221,6 +221,32 @@ class TestSelectKeys:
         SelectKeys.load_state_dict = SelectKeys_load_state_dict
 
 
+class TestLoadFromFile:
+    def test_torch_backend_mmap_default(self, monkeypatch):
+        os.environ["CKPT_BACKEND"] = "torch"
+        captured = {}
+        true_load = torch.load
+
+        def spy_load(*args, **kwargs):
+            captured.update(kwargs)
+            return true_load(*args, **kwargs)
+
+        monkeypatch.setattr(torch, "load", spy_load)
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            file = path.join(tmpdirname, "file.pt")
+            trainer = mocking_trainer(file=file)
+            trainer.save_trainer(force_save=True)
+
+            trainer2 = mocking_trainer()
+            trainer2.load_from_file(file)
+            assert captured["mmap"] is True
+            assert captured["weights_only"] is True
+
+            captured.clear()
+            trainer2.load_from_file(file, mmap=False)
+            assert captured["mmap"] is False
+
+
 @pytest.mark.parametrize("prioritized", [False, True])
 class TestRB:
     def test_rb_trainer(self, prioritized):

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -223,7 +223,7 @@ class TestSelectKeys:
 
 class TestLoadFromFile:
     def test_torch_backend_mmap_default(self, monkeypatch):
-        os.environ["CKPT_BACKEND"] = "torch"
+        monkeypatch.setenv("CKPT_BACKEND", "torch")
         captured = {}
         true_load = torch.load
 
@@ -245,6 +245,62 @@ class TestLoadFromFile:
             captured.clear()
             trainer2.load_from_file(file, mmap=False)
             assert captured["mmap"] is False
+
+    def test_resume_and_resave_replay_buffer(self, monkeypatch):
+        # Resuming with mmap=True leaves the replay buffer storage backed by
+        # the checkpoint file; re-saving to the same path must not corrupt it.
+        monkeypatch.setenv("CKPT_BACKEND", "torch")
+
+        def make_trainer(file=None):
+            trainer = mocking_trainer(file=file)
+            replay_buffer = TensorDictReplayBuffer(storage=LazyTensorStorage(10))
+            ReplayBufferTrainer(replay_buffer=replay_buffer, batch_size=2).register(
+                trainer
+            )
+            return trainer, replay_buffer
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            file = path.join(tmpdirname, "file.pt")
+            data = TensorDict({"obs": torch.randn(10, 4)}, [10])
+
+            trainer, replay_buffer = make_trainer(file=file)
+            replay_buffer.extend(data)
+            trainer.save_trainer(force_save=True)
+
+            trainer2, replay_buffer2 = make_trainer(file=file)
+            trainer2.load_from_file(file)
+            trainer2.save_trainer(force_save=True)
+
+            trainer3, replay_buffer3 = make_trainer()
+            trainer3.load_from_file(file)
+            torch.testing.assert_close(replay_buffer3[:]["obs"], data["obs"])
+
+    def test_torch_backend_save_is_atomic(self, monkeypatch):
+        monkeypatch.setenv("CKPT_BACKEND", "torch")
+        true_save = torch.save
+
+        def failing_save(*args, **kwargs):
+            true_save(*args, **kwargs)
+            raise RuntimeError("interrupted save")
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            file = path.join(tmpdirname, "file.pt")
+            trainer = mocking_trainer(file=file)
+            trainer.save_trainer(force_save=True)
+            reference = torch.load(file, weights_only=True, mmap=False)
+
+            trainer.collected_frames = 42
+            monkeypatch.setattr(torch, "save", failing_save)
+            with pytest.raises(RuntimeError, match="interrupted save"):
+                trainer.save_trainer(force_save=True)
+
+            # the previous checkpoint is intact and no temp file is left over
+            loaded = torch.load(file, weights_only=True, mmap=False)
+            assert (
+                loaded["state"]["collected_frames"]
+                == reference["state"]["collected_frames"]
+            )
+            assert os.listdir(tmpdirname) == ["file.pt"]
 
 
 @pytest.mark.parametrize("prioritized", [False, True])

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -592,12 +592,23 @@ class Trainer:
             explicitly only if you have custom (non-stdlib) objects in your
             state dict.
 
+        .. note::
+            When ``CKPT_BACKEND=torch``, ``mmap=True`` is set by default so
+            tensors in the checkpoint are memory-mapped rather than
+            materialized in RAM at load time. Restoring then only requires
+            evictable page-cache memory instead of an anonymous allocation
+            the size of the checkpoint, which matters for trainers whose
+            state includes a large replay buffer. Pass ``mmap=False`` for
+            the previous behavior (required for checkpoints saved with the
+            legacy, pre-zipfile ``torch.save`` format).
+
         """
         if _CKPT_BACKEND == "torchsnapshot":
             snapshot = Snapshot(path=file)
             snapshot.restore(app_state=self.app_state)
         elif _CKPT_BACKEND == "torch":
             kwargs.setdefault("weights_only", True)
+            kwargs.setdefault("mmap", True)
             loaded_dict: OrderedDict = torch.load(file, **kwargs)
             self.load_state_dict(loaded_dict)
         elif _CKPT_BACKEND == "memmap":

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -550,7 +550,19 @@ class Trainer:
                 )
             Snapshot.take(app_state=self.app_state, path=self.save_trainer_file)
         elif _CKPT_BACKEND == "torch":
-            torch.save(self.state_dict(), self.save_trainer_file)
+            # Write to a temporary file and atomically swap it in: an
+            # interrupted save cannot destroy the previous checkpoint, and
+            # tensors still memory-mapped from a previous
+            # ``load_from_file(mmap=True)`` keep reading from the old inode
+            # instead of from a truncated file.
+            file = pathlib.Path(self.save_trainer_file)
+            tmp_file = file.with_name(file.name + ".tmp")
+            try:
+                torch.save(self.state_dict(), tmp_file)
+                tmp_file.replace(file)
+            except BaseException:
+                tmp_file.unlink(missing_ok=True)
+                raise
         elif _CKPT_BACKEND == "memmap":
             state = self.state_dict()
             path = pathlib.Path(self.save_trainer_file)
@@ -594,13 +606,10 @@ class Trainer:
 
         .. note::
             When ``CKPT_BACKEND=torch``, ``mmap=True`` is set by default so
-            tensors in the checkpoint are memory-mapped rather than
-            materialized in RAM at load time. Restoring then only requires
-            evictable page-cache memory instead of an anonymous allocation
-            the size of the checkpoint, which matters for trainers whose
-            state includes a large replay buffer. Pass ``mmap=False`` for
-            the previous behavior (required for checkpoints saved with the
-            legacy, pre-zipfile ``torch.save`` format).
+            the checkpoint is memory-mapped rather than materialized in RAM
+            at load time. Pass ``mmap=False`` if the checkpoint was saved
+            with the legacy (pre-zipfile) ``torch.save`` format or if
+            ``file`` is a file-like object rather than a path.
 
         """
         if _CKPT_BACKEND == "torchsnapshot":


### PR DESCRIPTION
##Summary: 
- The fix: kwargs.setdefault("mmap", True) in Trainer.load_from_file plus the docstring note
- restoring a checkpoint through TorchRL's default torch backend materializes the entire checkpoint as non-evictable RAM before a single byte reaches the destination
<img width="889" height="440" alt="image" src="https://github.com/user-attachments/assets/6c294eb5-6ebd-49df-9791-b9fbda010ca9" />
<img width="889" height="290" alt="image" src="https://github.com/user-attachments/assets/a555c9af-4c71-4238-8bf2-c3a61aded30a" />
