### PR TITLE
[CI] Fix M1 wheel builds broken by py3.14 runner base conda

### DIFF
--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -87,3 +87,9 @@ jobs:
       smoke-test-script: ${{ matrix.smoke-test-script }}
       trigger-event: ${{ github.event_name }}
       env-var-script: .github/scripts/td_script.sh
+      # The M1 runners' preinstalled miniconda base env moved to python 3.14,
+      # which test-infra's "conda install -y conda=25.3.0" cannot solve
+      # (conda 25.3.0 has no py3.14 build). setup-miniconda provisions a fresh
+      # miniconda with an active py3.10 env, where that pin still solves.
+      # Can be dropped once pytorch/test-infra bumps the conda pin to >=26.1.
+      setup-miniconda: true


### PR DESCRIPTION
## Problem

All **Build M1 Wheels** runs started failing repo-wide around 2026-07-08 20:00 UTC, on every branch and every matrix python version (the py3.10 job fails just like the others). Example: https://github.com/pytorch/rl/actions/runs/28971958178/job/85973758390

Root cause: the M1 runners' preinstalled Homebrew miniconda **base** environment was updated to Python 3.14. test-infra's `setup-binary-builds` action runs `conda install -y conda=25.3.0` in the active (base) env, which now fails with:

```
LibMambaUnsatisfiableError: Encountered problems while solving:
  - package conda-25.3.0-py310hca03da5_0 requires python >=3.10,<3.11.0a0, ...
└─ pin on python =3.14 * is not installable ...
```

`conda=25.3.0` has no Python 3.14 build — the defaults channel only ships py3.14 conda builds from **26.1.0** onward. The failure is unrelated to the build matrix (the `python=3.14` pin is the runner base env's own python), so excluding 3.14 from the matrix would not help. pytorch/vision's M1 wheel builds broke the same way at the same time.

## Fix

Pass `setup-miniconda: true` to the reusable `build_wheels_macos.yml` workflow. The job then provisions a fresh miniconda via `conda-incubator/setup-miniconda` with an active py3.10 env, where the `conda=25.3.0` pin still solves. pytorch/executorch already uses this configuration and its macOS wheel builds are green after the runner update (e.g. run 28999099110, 2026-07-09 06:35 UTC, where the same `conda install -y conda=25.3.0` solves fine in `envs/test`).

This is a workaround until pytorch/test-infra bumps its conda pin to a py3.14-compatible version (>=26.1); https://github.com/pytorch/test-infra/pull/7951 tracks bumping that pin but needs to target >=26.1 now.

The Build M1 Wheels run on this PR is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)