### PR TITLE
[BugFix] Do not leak AUTO_UNWRAP_TRANSFORMED_ENV='None' into the environment

### DIFF
--- a/test/transforms/test_compose_and_env.py
+++ b/test/transforms/test_compose_and_env.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import itertools
+import os
 
 from copy import copy
 from functools import partial
@@ -18,7 +19,10 @@ from _transforms_common import mp_ctx, TransformBase
 from tensordict import TensorDict, TensorDictBase
 from tensordict.utils import assert_allclose_td
 from torch import nn
-from torchrl._utils import set_auto_unwrap_transformed_env
+from torchrl._utils import (
+    auto_unwrap_transformed_env,
+    set_auto_unwrap_transformed_env,
+)
 
 from torchrl.data import (
     Bounded,
@@ -224,6 +228,22 @@ class TestTransformedEnv:
 
         with set_auto_unwrap_transformed_env(False):
             test_wrap()
+
+    def test_auto_unwrap_env_var_restored_on_exit(self, monkeypatch):
+        # Regression test: exiting set_auto_unwrap_transformed_env when the
+        # setting was previously unset used to write the literal string
+        # "None" into os.environ. Subprocesses spawned afterwards (collector
+        # workers) inherited it and crashed with "Invalid truth value 'none'"
+        # when parsing the value with strtobool.
+        monkeypatch.setattr("torchrl._utils._AUTO_UNWRAP", None)
+        monkeypatch.delenv("AUTO_UNWRAP_TRANSFORMED_ENV", raising=False)
+
+        with set_auto_unwrap_transformed_env(False):
+            assert os.environ["AUTO_UNWRAP_TRANSFORMED_ENV"] == "False"
+        assert "AUTO_UNWRAP_TRANSFORMED_ENV" not in os.environ
+        # The parse path a fresh subprocess takes must not raise.
+        assert auto_unwrap_transformed_env() is True
+        assert auto_unwrap_transformed_env(allow_none=True) is None
 
     def test_attr_error(self):
         class BuggyTransform(Transform):

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -1322,7 +1322,13 @@ class set_auto_unwrap_transformed_env(_DecoratorContextManager):
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         global _AUTO_UNWRAP
         _AUTO_UNWRAP = self._old_mode
-        os.environ["AUTO_UNWRAP_TRANSFORMED_ENV"] = str(_AUTO_UNWRAP)
+        if _AUTO_UNWRAP is None:
+            # Restoring the unset state must remove the variable: writing
+            # str(None) would poison subprocesses spawned later, which parse
+            # the inherited value with strtobool.
+            os.environ.pop("AUTO_UNWRAP_TRANSFORMED_ENV", None)
+        else:
+            os.environ["AUTO_UNWRAP_TRANSFORMED_ENV"] = str(_AUTO_UNWRAP)
 
 
 def auto_unwrap_transformed_env(allow_none=False):


### PR DESCRIPTION
## Bug

`set_auto_unwrap_transformed_env.__exit__` restores the previous setting with `os.environ["AUTO_UNWRAP_TRANSFORMED_ENV"] = str(_AUTO_UNWRAP)`. When the previous state was **unset** (`None`), this writes the literal string `'None'` into the process environment. Every subprocess spawned afterwards (collector workers, `Evaluator(backend="process")`) inherits it, and the child crashes at its first `TransformedEnv` construction:

```
ValueError: Invalid truth value 'none'
```

(`auto_unwrap_transformed_env` -> `strtobool("None")`.)

The bug has been latent for a long time, masked by test ordering: serially, the tests that use the context manager happen to run after the process-spawning ones. It surfaced deterministically on #3953 where pytest-xdist scheduling put a context-manager test before `TestEvaluatorProcess::test_dump_video_dispatches_compose_dump_in_worker` (added in #3957) in the same worker: the poisoned environment was inherited by the evaluator's collector worker, failing `tests-cpu` jobs.

## Fix

Restore the unset state by removing the variable (`os.environ.pop`) instead of stringifying `None`.

## Test

Regression test in `test/transforms/test_compose_and_env.py` simulates the unset state, exercises the context manager, and asserts the variable is gone after exit and the subprocess parse path (`auto_unwrap_transformed_env()`) does not raise. Also verified end-to-end locally: before the fix a child process inherits `AUTO_UNWRAP_TRANSFORMED_ENV=None` and crashes; after the fix the variable is unset and the child parses fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)