### PR TITLE
[CI] Skip gym-dependent SOTA checkpoint factory tests when gym is absent

### DIFF
--- a/test/test_render.py
+++ b/test/test_render.py
@@ -49,6 +49,7 @@ from torchrl.render.mujoco_wasm import extract_qpos_trajectory
 from torchrl.render.video import compose_frame_grid, normalize_frame_output
 
 _has_pil = importlib.util.find_spec("PIL") is not None
+_has_gym = importlib.util.find_spec("gym") is not None
 _has_gymnasium = importlib.util.find_spec("gymnasium") is not None
 _has_pygame = importlib.util.find_spec("pygame") is not None
 
@@ -919,6 +920,10 @@ class TestMujocoWasm:
 
 
 class TestSotaCheckpointFactories:
+    @pytest.mark.skipif(
+        not (_has_gym or _has_gymnasium),
+        reason="gym or gymnasium is required to build the CartPole DQN env",
+    )
     def test_dqn_cartpole_checkpoint_render_factories(self, tmp_path, monkeypatch):
         OmegaConf = pytest.importorskip("omegaconf").OmegaConf
         dqn_dir = Path("sota-implementations/dqn").resolve()
@@ -1344,6 +1349,10 @@ class TestSotaCheckpointFactories:
         assert make_eval_env_kwargs(cfg)["num_envs"] == 1
         assert make_eval_env_kwargs(cfg)["batch_mode"] == "parallel"
 
+    @pytest.mark.skipif(
+        not (_has_gym or _has_gymnasium),
+        reason="gym or gymnasium is required to build the CartPole PPO env",
+    )
     def test_ppo_vecnorm_checkpoint_roundtrip(self, tmp_path):
         utils_path = Path("sota-implementations/ppo/utils_mujoco.py").resolve()
         ppo_make_env = import_from_string(f"{utils_path}:make_env")


### PR DESCRIPTION
## Description

`test/test_render.py::TestSotaCheckpointFactories::test_ppo_vecnorm_checkpoint_roundtrip` fails on the unified Linux CI (`tests-optdeps`) and Windows CPU CI with:

    ModuleNotFoundError: Supported version of 'torchrl.envs.libs.gym.GymEnv._set_gym_args' has not been found.

Example failing runs on main: https://github.com/pytorch/rl/actions/runs/28950927137 and https://github.com/pytorch/rl/actions/runs/28947052296.

Root cause: those CI environments install neither `gym` nor `gymnasium` (see `.github/unittest/linux_optdeps/scripts/environment.yml` and `.github/unittest/windows_optdepts/scripts/environment.yml`), so the `implement_for` dispatch on `GymEnv._set_gym_args` finds no backend at all. The test builds a real `GymEnv("CartPole-v1")` through the PPO `utils_mujoco.make_env` factory but carried no skip guard. The `implement_for` version ranges themselves are fine - they cover all gym/gymnasium versions; the problem is purely the missing backend.

`test_dqn_cartpole_checkpoint_render_factories` has the same latent issue: it builds a `GymEnv` via `make_dqn_model` and only survived those jobs because its `pytest.importorskip("omegaconf")` happened to skip first (omegaconf is also absent there).

Fix: add a `_has_gym` flag and skip both tests when neither gym nor gymnasium is installed, matching the guards already present on the other tests in the class.

Verified locally with `uv run pytest test/test_render.py -k "vecnorm or dqn_cartpole_checkpoint"`: 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)