### PR TITLE
[Test] Gate ActionChunkTransform test_compile on torch>=2.5

### DIFF
--- a/test/transforms/test_action_transforms.py
+++ b/test/transforms/test_action_transforms.py
@@ -3003,6 +3003,11 @@ class TestActionChunkTransform(TransformBase):
         assert t(td)[ACTION_CHUNK_KEY].shape == torch.Size([2, 4, 3, 3])
 
     @pytest.mark.skipif(IS_WIN, reason="torch.compile requires a C++ compiler")
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.5.0"),
+        reason="requires torch>=2.5 (old dynamo cannot trace the tensordict-based "
+        "transform stack, e.g. InternalTorchDynamoError: next on torch 2.1)",
+    )
     def test_compile(self):
         t = ActionChunkTransform(chunk_size=3)
         td = TensorDict({"action": torch.randn(2, 5, 2)}, batch_size=[2, 5])

--- a/test/transforms/test_compose_and_env.py
+++ b/test/transforms/test_compose_and_env.py
@@ -19,10 +19,7 @@ from _transforms_common import mp_ctx, TransformBase
 from tensordict import TensorDict, TensorDictBase
 from tensordict.utils import assert_allclose_td
 from torch import nn
-from torchrl._utils import (
-    auto_unwrap_transformed_env,
-    set_auto_unwrap_transformed_env,
-)
+from torchrl._utils import auto_unwrap_transformed_env, set_auto_unwrap_transformed_env
 
 from torchrl.data import (
     Bounded,


### PR DESCRIPTION
## Description

`TestActionChunkTransform::test_compile` (added in #3853) fails on the `tests-olddeps` CI job with `torch._dynamo.exc.InternalTorchDynamoError: next`. That job pins torch 2.1.1, whose dynamo predates support for tracing the iterator protocol used by the tensordict-based transform stack, and tensordict's own `torch.compile` support requires torch >= 2.5 anyway.

This gates the test with the same `TORCH_VERSION < version.parse("2.5.0")` skipif used by the other compile tests in the suite (e.g. `test/compile/test_compile_objectives.py`), matching the existing gate at line 410 of the same file.

The test still runs and passes on current torch; on olddeps it is now skipped instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)