### PR TITLE
[BugFix] Copy tensors in load_state_dict instead of aliasing the source

### DIFF
--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -937,6 +937,33 @@ class TestReplayBufferConsumption:
         assert write_index.tolist() == consumed.tolist()
         assert rb2.storage.get(write_index).tolist() == [100, 101]
 
+    def test_replay_buffer_consume_load_state_dict_decouples_from_source(self):
+        # loading a state dict must clone the incoming tensors so that
+        # mutating the source afterwards does not corrupt the sampler state
+        # (e.g. tensors mmap-backed by torch.load(mmap=True))
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(5),
+            batch_size=2,
+            consume_after_n_samples=1,
+        )
+        rb.extend(torch.arange(5))
+        rb.sample()
+
+        sampler_sd = rb.sampler.state_dict()
+        sampler2 = ConsumingSampler()
+        sampler2.load_state_dict(sampler_sd)
+
+        before_count = sampler2._sample_count.clone()
+        before_mask = sampler2._live_mask.clone()
+        sampler_sd["_sample_count"].fill_(42)
+        sampler_sd["_live_mask"].fill_(False)
+        assert (sampler2._sample_count == before_count).all()
+        assert (sampler2._live_mask == before_mask).all()
+        if sampler_sd["_free_indices"] is not None:
+            before_free = sampler2._free_indices.clone()
+            sampler_sd["_free_indices"].fill_(-1)
+            assert (sampler2._free_indices == before_free).all()
+
     def test_replay_buffer_consume_dumps_loads(self, tmpdir):
         torch.manual_seed(0)
         rb = ReplayBuffer(

--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -83,6 +83,41 @@ def test_samplerwithoutrep(size, samples, drop_last):
         assert not visited
 
 
+def test_samplerwithoutrep_load_state_dict_decouples_from_source():
+    # loading a state dict must clone the incoming tensors so that mutating
+    # the source afterwards does not corrupt the sampler state (e.g. tensors
+    # mmap-backed by a checkpoint file loaded with torch.load(mmap=True))
+    torch.manual_seed(0)
+    storage = ListStorage(10)
+    storage.set(range(10), range(10))
+    sampler = SamplerWithoutReplacement()
+    sampler.sample(storage, 4)
+    sd = sampler.state_dict()
+    sampler2 = SamplerWithoutReplacement()
+    sampler2.load_state_dict(sd)
+    before = sampler2._sample_list.clone()
+    sd["_sample_list"].fill_(-1)
+    assert (sampler2._sample_list == before).all()
+
+
+def test_prioritized_sampler_load_state_dict_decouples_from_source():
+    sampler = PrioritizedSampler(max_capacity=10, alpha=0.7, beta=0.9)
+    sampler.extend(torch.arange(5))
+    sampler.update_priority(torch.arange(5), torch.arange(1.0, 6.0))
+    sd = sampler.state_dict()
+    sampler2 = PrioritizedSampler(max_capacity=10, alpha=0.7, beta=0.9)
+    sampler2.load_state_dict(sd)
+    # the source state dict is left intact (keys are not popped)
+    assert "_sum_tree" in sd
+    assert "_min_tree" in sd
+    # the trees are decoupled from the source state dict
+    assert sampler2._sum_tree is not sd["_sum_tree"]
+    assert sampler2._min_tree is not sd["_min_tree"]
+    before = sampler2._sum_tree[0]
+    sd["_sum_tree"][0] = before + 1000.0
+    assert sampler2._sum_tree[0] == before
+
+
 class TestSamplers:
     @pytest.mark.parametrize(
         "backend", ["torch"] + (["torchsnapshot"] if _has_snapshot else [])

--- a/test/rb/test_storages.py
+++ b/test/rb/test_storages.py
@@ -163,6 +163,50 @@ class TestStorages:
             storage2.get(range(10))
         )
 
+    @staticmethod
+    def _zero_state_dict_tensors(sd):
+        for value in sd.values():
+            if isinstance(value, torch.Tensor):
+                value.zero_()
+            elif isinstance(value, dict):
+                TestStorages._zero_state_dict_tensors(value)
+
+    @pytest.mark.parametrize("data_type", ["tensor", "tensordict"])
+    def test_load_state_dict_decouples_from_source(self, data_type):
+        # loading a state dict onto an uninitialized storage must clone the
+        # incoming tensors: aliasing them keeps e.g. mmap-backed tensors from
+        # torch.load(mmap=True) alive in the storage and leaks later mutations
+        # of the source state dict into the loaded data
+        if data_type == "tensor":
+            data = self._get_tensor()
+        else:
+            data = self._get_tensordict()
+        storage = TensorStorage(data)
+        sd = storage.state_dict()
+        storage2 = LazyTensorStorage(max_size=data.shape[0])
+        storage2.load_state_dict(sd)
+        before = storage2.get(range(10)).clone()
+        self._zero_state_dict_tensors(sd)
+        after = storage2.get(range(10))
+        if data_type == "tensor":
+            assert (after == before).all()
+        else:
+            assert_allclose_td(after, before)
+
+    def test_list_storage_load_state_dict_decouples_from_source(self):
+        storage = ListStorage(10)
+        storage.set(0, torch.randn(3))
+        storage.set(1, TensorDict({"a": torch.randn(3)}, [3]))
+        sd = storage.state_dict()
+        storage2 = ListStorage(10)
+        storage2.load_state_dict(sd)
+        before_tensor = storage2.get(0).clone()
+        before_td = storage2.get(1).clone()
+        sd["_storage"][0].zero_()
+        self._zero_state_dict_tensors(sd["_storage"][1])
+        assert (storage2.get(0) == before_tensor).all()
+        assert_allclose_td(storage2.get(1), before_td)
+
     @pytest.mark.gpu
     @pytest.mark.skipif(
         not torch.cuda.device_count(),

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -42,6 +42,7 @@ from torchrl.trainers.helpers import transformed_env_constructor
 from torchrl.trainers.trainers import (
     _has_tqdm,
     _has_ts,
+    _load_weights_only_default,
     BatchSubSampler,
     CountFramesLog,
     DefaultOptimizationStepper,
@@ -240,7 +241,7 @@ class TestLoadFromFile:
             trainer2 = mocking_trainer()
             trainer2.load_from_file(file)
             assert captured["mmap"] is True
-            assert captured["weights_only"] is True
+            assert captured["weights_only"] is _load_weights_only_default()
 
             captured.clear()
             trainer2.load_from_file(file, mmap=False)

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -734,6 +734,30 @@ class TestRewardNorm:
         for key, item in reward_normalizer._reward_stats.items():
             assert item == reward_normalizer2._reward_stats[key]
 
+    def test_reward_norm_load_state_dict_decouples_from_source(self):
+        # loading a state dict must clone the incoming tensors so that
+        # mutating the source afterwards does not corrupt the normalizer
+        # stats (e.g. tensors mmap-backed by torch.load(mmap=True))
+        torch.manual_seed(0)
+        reward_normalizer = RewardNormalizer()
+        batch = 10
+        reward = torch.randn(batch, 1)
+        td = TensorDict({REWARD_KEY: reward.clone()}, [batch])
+        reward_normalizer.update_reward_stats(td)
+        state_dict = reward_normalizer.state_dict()
+
+        reward_normalizer2 = RewardNormalizer()
+        reward_normalizer2.load_state_dict(state_dict)
+        before = {
+            key: item.clone() if isinstance(item, torch.Tensor) else item
+            for key, item in reward_normalizer2._reward_stats.items()
+        }
+        for item in state_dict["_reward_stats"].values():
+            if isinstance(item, torch.Tensor):
+                item.fill_(1e9)
+        for key, item in before.items():
+            assert reward_normalizer2._reward_stats[key] == item
+
     @pytest.mark.parametrize(
         "backend",
         [

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -545,11 +545,16 @@ class ConsumingSampler(Sampler):
         )
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        # clone incoming tensors to decouple the sampler state from the
+        # caller's objects (which may e.g. be mmap-backed by a checkpoint file)
+        def _clone(value):
+            return value.clone() if isinstance(value, torch.Tensor) else value
+
         self.max_sample_count = int(state_dict["max_sample_count"])
-        self._sample_count = state_dict["_sample_count"]
-        self._live_mask = state_dict["_live_mask"]
+        self._sample_count = _clone(state_dict["_sample_count"])
+        self._live_mask = _clone(state_dict["_live_mask"])
         self._known_storage_len = int(state_dict["_known_storage_len"])
-        self._free_indices = state_dict.get("_free_indices")
+        self._free_indices = _clone(state_dict.get("_free_indices"))
         self._free_head = int(state_dict.get("_free_head", 0))
         self._ran_out = bool(state_dict["_ran_out"])
         if "_free_indices" not in state_dict:
@@ -702,7 +707,13 @@ class SamplerWithoutReplacement(Sampler):
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         self.len_storage = state_dict["len_storage"]
-        self._sample_list = state_dict["_sample_list"]
+        # clone to decouple the sampler state from the caller's tensor
+        _sample_list = state_dict["_sample_list"]
+        self._sample_list = (
+            _sample_list.clone()
+            if isinstance(_sample_list, torch.Tensor)
+            else _sample_list
+        )
         self.drop_last = state_dict["drop_last"]
         self._ran_out = state_dict["_ran_out"]
 
@@ -1510,9 +1521,11 @@ class PrioritizedSampler(Sampler):
         self._alpha = state_dict["_alpha"]
         self._beta = state_dict["_beta"]
         self._eps = state_dict["_eps"]
-        self._max_priority = state_dict["_max_priority"]
-        self._sum_tree = state_dict.pop("_sum_tree")
-        self._min_tree = state_dict.pop("_min_tree")
+        # deepcopy to decouple the sampler state from the caller's objects
+        # (this also clones any tensor held in _max_priority)
+        self._max_priority = deepcopy(state_dict["_max_priority"])
+        self._sum_tree = deepcopy(state_dict["_sum_tree"])
+        self._min_tree = deepcopy(state_dict["_min_tree"])
 
     @implement_for("torch", None, "2.5.0")
     def dumps(self, path):

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -19,7 +19,7 @@ import warnings
 import weakref
 from collections import OrderedDict
 from collections.abc import Callable, Mapping, Sequence
-from copy import copy
+from copy import copy, deepcopy
 from multiprocessing.context import get_spawning_popen
 from typing import Any
 
@@ -512,10 +512,14 @@ class ListStorage(Storage):
         _storage = state_dict["_storage"]
         self._storage = []
         for elt in _storage:
+            # clone to decouple the storage from the caller's tensors (which may
+            # e.g. be mmap-backed views over a checkpoint file)
             if isinstance(elt, torch.Tensor):
-                self._storage.append(elt)
+                self._storage.append(elt.clone())
             elif isinstance(elt, (dict, OrderedDict)):
-                self._storage.append(TensorDict().load_state_dict(elt, strict=False))
+                self._storage.append(
+                    TensorDict().load_state_dict(elt, strict=False).clone()
+                )
             else:
                 raise TypeError(
                     f"Objects of type {type(elt)} are not supported by ListStorage.load_state_dict"
@@ -977,7 +981,9 @@ class TensorStorage(Storage):
             if isinstance(self._storage, torch.Tensor):
                 self._storage.copy_(_storage)
             elif self._storage is None:
-                self._storage = _storage
+                # clone to decouple the storage from the caller's tensor (which
+                # may e.g. be mmap-backed by a checkpoint file)
+                self._storage = _storage.clone()
             else:
                 raise RuntimeError(
                     f"Cannot copy a storage of type {type(_storage)} onto another of type {type(self._storage)}"
@@ -986,7 +992,11 @@ class TensorStorage(Storage):
             if is_tensor_collection(self._storage):
                 self._storage.load_state_dict(_storage, strict=False)
             elif self._storage is None:
-                self._storage = TensorDict().load_state_dict(_storage, strict=False)
+                # loading on an empty TensorDict assigns the state-dict tensors
+                # by reference: clone to decouple from the caller's tensors
+                self._storage = (
+                    TensorDict().load_state_dict(_storage, strict=False).clone()
+                )
             else:
                 raise RuntimeError(
                     f"Cannot copy a storage of type {type(_storage)} onto another of type {type(self._storage)}. If your storage is pytree-based, use the dumps/load API instead."
@@ -2196,8 +2206,13 @@ class CompressedListStorage(ListStorage):
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         """Load the storage state."""
-        self._storage = state_dict["_storage"]
-        self._metadata = state_dict["_metadata"]
+        # clone tensors and copy containers to decouple the storage from the
+        # caller's objects
+        self._storage = [
+            elt.clone() if isinstance(elt, torch.Tensor) else elt
+            for elt in state_dict["_storage"]
+        ]
+        self._metadata = deepcopy(state_dict["_metadata"])
 
     def to_bytestream(self, data_to_bytestream: torch.Tensor | np.array | Any) -> bytes:
         """Convert data to a byte stream."""

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -1761,8 +1761,10 @@ class RewardNormalizer(TrainerHookBase):
         }
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        # deepcopy to decouple the normalizer stats from the caller's tensors
+        # (which may e.g. be mmap-backed by a checkpoint file)
         for key, value in state_dict.items():
-            setattr(self, key, value)
+            setattr(self, key, deepcopy(value))
 
     def register(self, trainer: Trainer, name: str = "reward_normalizer"):
         trainer.register_op("batch_process", self.update_reward_stats)

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -29,6 +29,7 @@ from torch import nn, optim
 
 from torchrl._utils import (
     _CKPT_BACKEND,
+    implement_for,
     KeyDependentDefaultDict,
     logger as torchrl_logger,
     rl_warnings,
@@ -78,6 +79,19 @@ LOGGER_METHODS = {
 # Format strings for different data types in progress bar display
 TYPE_DESCR = {float: "4.4f", int: ""}
 REWARD_KEY = ("next", "reward")
+
+
+@implement_for("torch", "2.4")
+def _load_weights_only_default() -> bool:
+    # Trainer checkpoints contain tensordict state-dict metadata such as
+    # torch.device entries, which the weights-only unpickler only allowlists
+    # from torch 2.4 onwards.
+    return True
+
+
+@implement_for("torch", None, "2.4")
+def _load_weights_only_default() -> bool:  # noqa: F811
+    return False
 
 
 def _state_dict_to_td(sd: dict) -> TensorDict:
@@ -602,7 +616,10 @@ class Trainer:
             When ``CKPT_BACKEND=torch``, ``weights_only=True`` is set by
             default for safer deserialization. Pass ``weights_only=False``
             explicitly only if you have custom (non-stdlib) objects in your
-            state dict.
+            state dict. On torch < 2.4, ``weights_only`` defaults to
+            ``False`` instead, because the weights-only unpickler of those
+            versions cannot deserialize the ``torch.device`` entries found
+            in checkpoint metadata.
 
         .. note::
             When ``CKPT_BACKEND=torch``, ``mmap=True`` is set by default so
@@ -616,7 +633,7 @@ class Trainer:
             snapshot = Snapshot(path=file)
             snapshot.restore(app_state=self.app_state)
         elif _CKPT_BACKEND == "torch":
-            kwargs.setdefault("weights_only", True)
+            kwargs.setdefault("weights_only", _load_weights_only_default())
             kwargs.setdefault("mmap", True)
             loaded_dict: OrderedDict = torch.load(file, **kwargs)
             self.load_state_dict(loaded_dict)


### PR DESCRIPTION
## Description

Several `load_state_dict` implementations retained caller tensors by reference, aliasing external state into live components. With `Trainer.load_from_file` now defaulting to `torch.load(mmap=True)` (#3959), this pins the checkpoint file mapping for the process lifetime (`PermissionError` on Windows when overwriting the file, unspecified reads if it is rewritten externally) and lets later mutations of the source state dict corrupt the loaded component.

This PR makes `load_state_dict` clone/deepcopy incoming tensors so loaded state is decoupled from the caller's objects, matching `nn.Module.load_state_dict` semantics.

Root cause for the storage paths: `TensorDict.load_state_dict` calls `set(key, item, inplace=True)`, which copies in place for existing keys but assigns by reference for missing ones, so loading onto an empty `TensorDict()` aliased every tensor.

Fixed sites:

- `TensorStorage.load_state_dict`: clone the tensor / TensorDict when loading onto an uninitialized storage. Initialized destinations already copied in place and are unchanged.
- `ListStorage.load_state_dict`: clone tensor elements and the TensorDicts rebuilt from dict elements.
- `CompressedListStorage.load_state_dict`: copy the storage list (cloning tensor entries) and deepcopy the metadata.
- `ConsumingSampler.load_state_dict`: clone `_sample_count`, `_live_mask`, `_free_indices`.
- `SamplerWithoutReplacement.load_state_dict` (also covers `SliceSamplerWithoutReplacement`): clone `_sample_list`.
- `PrioritizedSampler.load_state_dict`: deepcopy the sum/min trees and `_max_priority` (mirroring `state_dict()`), and stop popping keys out of the caller's dict.
- `RewardNormalizer.load_state_dict`: deepcopy loaded values (the reward stats tensors).

Writers were audited as well: they only persist scalar cursors (or raise `NotImplementedError`), so no change is needed. `LazyMemmapStorage` was already safe since its uninitialized paths copy into fresh memmap files.

## Tests

Regression tests added to the existing test files (`test/rb/test_storages.py`, `test/rb/test_samplers.py`, `test/rb/test_rb_core.py`, `test/test_trainer.py`) asserting that mutating the source state dict after loading does not affect the component. All 7 new tests fail without the library fix and pass with it. Also verified end-to-end that a state dict loaded via `torch.load(mmap=True)` no longer shares storage with the checkpoint mapping.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My change requires a change to the documentation: no.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note on the olddeps CI failure

The `tests-olddeps` (torch 2.1) failure previously visible on this PR (`test_resume_and_resave_replay_buffer` failing with `Unsupported class torch.device` under `weights_only=True`) was a pre-existing `main` breakage from #3959. A version- and platform-aware fix landed on `main` in #3974 and is now merged into this branch; the interim fix that briefly lived here was dropped in favor of it during the merge.
