### PR TITLE
[Feature] Unify TorchRL checkpointing

### DIFF
--- a/docs/source/reference/checkpoint.rst
+++ b/docs/source/reference/checkpoint.rst
@@ -38,13 +38,39 @@ Basic usage
 
 Replay buffers use their ``dump`` and ``load`` implementations, including the
 configured storage checkpointer and compression. Other TorchRL and PyTorch
-objects normally use ``state_dict`` and ``load_state_dict``. JSON-compatible
-configuration, metrics, and metadata are stored without pickle.
+objects normally use ``state_dict`` and ``load_state_dict``. Their tensor state
+is stored with :func:`tensordict.save` by default, while a JSON schema preserves
+the state-dict structure without pickle. JSON-compatible configuration,
+metrics, and metadata are also stored without pickle.
 
 Set ``save_components={"policy", "optimizer", "trainer_state"}`` on a
 :class:`Checkpoint` to keep large components such as replay buffers out of
 scheduled Trainer saves. An explicit ``components=`` argument to
 :meth:`Checkpoint.save` overrides this default selection.
+
+State-dict payload formats
+--------------------------
+
+The inferred :class:`StateDictCheckpointAdapter` writes a TensorDict directory.
+The same adapter can write a TensorDict ZIP archive or consolidated file, and
+loads auto-detect all of these payloads. This component payload choice is
+independent of the outer :class:`Checkpoint` directory or archive container.
+
+.. code-block:: python
+
+    from torchrl.checkpoint import Checkpoint, StateDictCheckpointAdapter
+
+    checkpoint = Checkpoint().register(
+        "policy",
+        policy,
+        adapter=StateDictCheckpointAdapter(payload_format="archive"),
+    )
+
+Use ``payload_format="consolidated"`` for consolidated TensorDict storage.
+Pickle-based :func:`torch.save` remains available explicitly with
+``payload_format="torch"``. TensorDict payloads reject unsupported Python
+objects with an error that points to this opt-in rather than silently falling
+back to pickle.
 
 Custom components
 -----------------
@@ -97,3 +123,4 @@ API
     GlobalRNGState
     JSONCheckpointAdapter
     StateDictCheckpointAdapter
+    StateDictFormat

--- a/docs/source/reference/checkpoint.rst
+++ b/docs/source/reference/checkpoint.rst
@@ -41,6 +41,11 @@ configured storage checkpointer and compression. Other TorchRL and PyTorch
 objects normally use ``state_dict`` and ``load_state_dict``. JSON-compatible
 configuration, metrics, and metadata are stored without pickle.
 
+Set ``save_components={"policy", "optimizer", "trainer_state"}`` on a
+:class:`Checkpoint` to keep large components such as replay buffers out of
+scheduled Trainer saves. An explicit ``components=`` argument to
+:meth:`Checkpoint.save` overrides this default selection.
+
 Custom components
 -----------------
 
@@ -68,6 +73,11 @@ Trainer's legacy ``CKPT_BACKEND`` path remains available during the migration
 window. Passing ``checkpoint=Checkpoint(...)`` to a trainer opts into the
 unified format. Existing torch, torchsnapshot, and memmap trainer checkpoints
 remain readable.
+
+The :func:`torchrl.render.save_render_checkpoint` helper also keeps its legacy
+``torch.save`` payload by default during the compatibility window. Pass
+``format="archive"`` or ``format="directory"`` to opt into the unified format;
+the default changes in v0.15.
 
 API
 ---

--- a/docs/source/reference/checkpoint.rst
+++ b/docs/source/reference/checkpoint.rst
@@ -12,9 +12,9 @@ checkpoints are the default and are best suited to large replay buffers;
 archives are convenient single-file artifacts. Loading either container is
 automatic.
 
-Format v1 targets local filesystems. URI paths and coordinated distributed
-rank checkpoints are rejected rather than importing an optional remote-storage
-stack implicitly.
+TorchRL checkpoints target local filesystems. URI paths and coordinated
+distributed rank checkpoints are rejected rather than importing an optional
+remote-storage stack implicitly.
 
 Basic usage
 -----------

--- a/docs/source/reference/checkpoint.rst
+++ b/docs/source/reference/checkpoint.rst
@@ -1,0 +1,89 @@
+.. currentmodule:: torchrl.checkpoint
+
+Checkpointing
+=============
+
+TorchRL checkpoints use one manifest-driven format for standalone scripts,
+trainers, and policy-only consumers. Components are registered independently,
+so a checkpoint may contain only a policy or a complete training state.
+
+The directory and archive containers share the same logical layout. Directory
+checkpoints are the default and are best suited to large replay buffers;
+archives are convenient single-file artifacts. Loading either container is
+automatic.
+
+Format v1 targets local filesystems. URI paths and coordinated distributed
+rank checkpoints are rejected rather than importing an optional remote-storage
+stack implicitly.
+
+Basic usage
+-----------
+
+.. code-block:: python
+
+    from torchrl.checkpoint import Checkpoint, GlobalRNGState
+
+    checkpoint = Checkpoint(
+        policy=policy,
+        optimizer=optimizer,
+        replay_buffer=replay_buffer,
+        rng=GlobalRNGState(),
+    )
+    checkpoint.save("run/checkpoint")
+    checkpoint.load(
+        "run/checkpoint",
+        components={"policy", "optimizer", "rng"},
+        map_location="cpu",
+    )
+
+Replay buffers use their ``dump`` and ``load`` implementations, including the
+configured storage checkpointer and compression. Other TorchRL and PyTorch
+objects normally use ``state_dict`` and ``load_state_dict``. JSON-compatible
+configuration, metrics, and metadata are stored without pickle.
+
+Custom components
+-----------------
+
+Objects exposing ``dump(path, ...)`` and ``load(path, ...)`` are detected before
+objects exposing ``state_dict`` and ``load_state_dict``. A custom
+:class:`CheckpointAdapter` can instead be supplied to
+:meth:`Checkpoint.register`, or registered by type on one checkpoint with
+:meth:`Checkpoint.register_adapter`.
+
+Use :class:`CheckpointOptions` to preserve component-specific arguments. Options
+registered with a component are the baseline; operation-level keyword arguments
+override matching entries and explicitly supplied positional arguments replace
+the baseline tuple.
+
+Compatibility
+-------------
+
+The manifest records the checkpoint format version, adapter versions, component
+files, and TorchRL, TensorDict, and PyTorch versions. Newer unsupported formats
+and incompatible adapters fail clearly. Partial restoration reports loaded,
+missing, incompatible, and unrequested components through
+:class:`CheckpointLoadResult`.
+
+Trainer's legacy ``CKPT_BACKEND`` path remains available during the migration
+window. Passing ``checkpoint=Checkpoint(...)`` to a trainer opts into the
+unified format. Existing torch, torchsnapshot, and memmap trainer checkpoints
+remain readable.
+
+API
+---
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template.rst
+
+    Checkpoint
+    CheckpointAdapter
+    CheckpointError
+    CheckpointLoadResult
+    CheckpointOptions
+    CheckpointFormat
+    CheckpointStrictness
+    DumpLoadCheckpointAdapter
+    GlobalRNGState
+    JSONCheckpointAdapter
+    StateDictCheckpointAdapter

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -5,6 +5,7 @@ API Reference
     :maxdepth: 3
 
     collectors
+    checkpoint
     data
     data_layout
     envs

--- a/docs/source/reference/trainers.rst
+++ b/docs/source/reference/trainers.rst
@@ -13,8 +13,11 @@ Key Features
 ------------
 
 - **Modular hook system**: Customize training at 18 different points in the loop
-- **Checkpointing support**: Save and restore training state with ``torch``, ``torchsnapshot``, or ``memmap`` (set via the ``CKPT_BACKEND`` environment variable)
-- **Algorithm trainers**: High-level trainers for PPO, SAC, DQN, DDPG, IQL, CQL with Hydra configuration
+- **Checkpointing support**: Pass a :class:`torchrl.checkpoint.Checkpoint` for
+  the unified manifest format. Legacy ``torch``, ``torchsnapshot``, and
+  ``memmap`` backends remain readable during the migration window.
+- **Algorithm trainers**: High-level trainers for PPO, A2C, REINFORCE, SAC,
+  offline-to-online SAC, DQN, DDPG, IQL, CQL, and TD3 with Hydra configuration
 - **Builder helpers**: Utilities for constructing collectors, losses, and replay buffers
 
 Quick Example

--- a/sota-implementations/dqn/README.md
+++ b/sota-implementations/dqn/README.md
@@ -31,10 +31,12 @@ python dqn_atari.py
 
 ## Rendering a CartPole checkpoint with `rlrender`
 
-The CartPole DQN script writes a local checkpoint that is directly
-loadable by `rlrender`. The checkpoint stores the policy state dict, the Gym
-environment name, the resolved Hydra config, the frame count, and the metrics
-recorded at checkpoint time.
+The CartPole DQN script writes a unified TorchRL checkpoint that is directly
+loadable by `rlrender`. It stores the policy, loss and target-update state,
+optimizer, replay buffer, collector and exploration progress, RNG state,
+resolved Hydra config, frame count, metrics, and environment metadata. Set
+`checkpoint.format=directory` for an unpacked manifest or
+`checkpoint.format=archive` for a single file.
 
 ### Smoke test
 
@@ -51,7 +53,7 @@ uv run --frozen python sota-implementations/dqn/dqn_cartpole.py \
   buffer.batch_size=32 \
   logger.test_interval=200 \
   logger.num_test_episodes=1 \
-  checkpoint.path=/tmp/torchrl_dqn_cartpole_smoke.pt
+  checkpoint.path=/tmp/torchrl_dqn_cartpole_smoke.torchrl
 ```
 
 ### Training run with W&B
@@ -72,12 +74,16 @@ uv run --frozen python sota-implementations/dqn/dqn_cartpole.py \
   buffer.batch_size=128 \
   logger.test_interval=25000 \
   logger.num_test_episodes=5 \
-  checkpoint.path=/tmp/torchrl_dqn_cartpole.pt \
+  checkpoint.path=/tmp/torchrl_dqn_cartpole.torchrl \
   checkpoint.interval=50000
 ```
 
 This default-scale command is intended to produce a visible training curve and
 a solved CartPole checkpoint.
+
+Resume the complete training state by reusing the same configuration and adding
+`checkpoint.resume=true`. Policy-only consumers such as `rlrender` read only the
+policy and environment metadata entries and do not materialize the replay buffer.
 
 The Gymnasium CartPole RGB renderer uses the optional `pygame` dependency,
 which is included in TorchRL's `rendering` extra.
@@ -86,7 +92,7 @@ Render an MP4 from the checkpoint:
 
 ```bash
 uv run --frozen --extra rendering python -m torchrl.render \
-  --ckpt /tmp/torchrl_dqn_cartpole.pt \
+  --ckpt /tmp/torchrl_dqn_cartpole.torchrl \
   --policy sota-implementations/dqn/utils_cartpole.py:make_render_policy \
   --env sota-implementations/dqn/utils_cartpole.py:make_render_env \
   --from-pixels \
@@ -101,7 +107,7 @@ Render an inspection notebook from the same checkpoint:
 
 ```bash
 uv run --frozen --extra rendering python -m torchrl.render \
-  --ckpt /tmp/torchrl_dqn_cartpole.pt \
+  --ckpt /tmp/torchrl_dqn_cartpole.torchrl \
   --policy sota-implementations/dqn/utils_cartpole.py:make_render_policy \
   --env sota-implementations/dqn/utils_cartpole.py:make_render_env \
   --from-pixels \

--- a/sota-implementations/dqn/README.md
+++ b/sota-implementations/dqn/README.md
@@ -84,6 +84,8 @@ a solved CartPole checkpoint.
 Resume the complete training state by reusing the same configuration and adding
 `checkpoint.resume=true`. Policy-only consumers such as `rlrender` read only the
 policy and environment metadata entries and do not materialize the replay buffer.
+Set `checkpoint.include_replay_buffer=false` for smaller scheduled checkpoints
+when replay data is not required for resumption.
 
 The Gymnasium CartPole RGB renderer uses the optional `pygame` dependency,
 which is included in TorchRL's `rendering` extra.

--- a/sota-implementations/dqn/config_cartpole.yaml
+++ b/sota-implementations/dqn/config_cartpole.yaml
@@ -32,6 +32,9 @@ logger:
 checkpoint:
   path: null
   interval: 0
+  format: archive
+  strict: error
+  resume: false
 
 # Optim
 optim:

--- a/sota-implementations/dqn/config_cartpole.yaml
+++ b/sota-implementations/dqn/config_cartpole.yaml
@@ -35,6 +35,7 @@ checkpoint:
   format: archive
   strict: error
   resume: false
+  include_replay_buffer: true
 
 # Optim
 optim:

--- a/sota-implementations/dqn/dqn_cartpole.py
+++ b/sota-implementations/dqn/dqn_cartpole.py
@@ -69,7 +69,29 @@ def _save_checkpoint(
     checkpoint.components["trainer_state"]["collected_frames"] = collected_frames
     checkpoint.components["metrics"].clear()
     checkpoint.components["metrics"].update(metrics)
-    return checkpoint.save(path)
+    components = None
+    if not cfg.checkpoint.get("include_replay_buffer", True):
+        components = set(checkpoint.components).difference({"replay_buffer"})
+    return checkpoint.save(path, components=components)
+
+
+def _resume_checkpoint(
+    checkpoint: Checkpoint,
+    path: str | Path,
+    map_location: str | torch.device,
+    *,
+    include_replay_buffer: bool = True,
+):
+    """Restore mutable training state without replacing the current config."""
+    components = set(checkpoint.components).difference({"config"})
+    if not include_replay_buffer:
+        components.discard("replay_buffer")
+    return checkpoint.load(
+        path,
+        components=components,
+        map_location=map_location,
+        tensor_load_kwargs={"weights_only": True, "mmap": True},
+    )
 
 
 @hydra.main(config_path="", config_name="config_cartpole", version_base="1.1")
@@ -182,6 +204,7 @@ def main(cfg: DictConfig):
 
     checkpoint_state = {"collected_frames": 0}
     checkpoint_metrics = {}
+    checkpoint_config = OmegaConf.to_container(cfg, resolve=True)
     checkpoint = Checkpoint(
         format=cfg.checkpoint.format,
         strict=cfg.checkpoint.strict,
@@ -195,7 +218,7 @@ def main(cfg: DictConfig):
         trainer_state=checkpoint_state,
         rng=GlobalRNGState(),
         environment_metadata={"env_name": cfg.env.env_name},
-        config=OmegaConf.to_container(cfg, resolve=True),
+        config=checkpoint_config,
         metrics=checkpoint_metrics,
     )
 
@@ -204,14 +227,19 @@ def main(cfg: DictConfig):
     if cfg.checkpoint.resume:
         if not checkpoint_path:
             raise ValueError("checkpoint.path must be set when checkpoint.resume=True.")
-        checkpoint.load(checkpoint_path, map_location=device)
+        _resume_checkpoint(
+            checkpoint,
+            checkpoint_path,
+            device,
+            include_replay_buffer=cfg.checkpoint.get("include_replay_buffer", True),
+        )
     collected_frames = checkpoint_state["collected_frames"]
     num_updates = cfg.loss.num_updates
     batch_size = cfg.buffer.batch_size
     test_interval = cfg.logger.test_interval
     num_test_episodes = cfg.logger.num_test_episodes
     frames_per_batch = cfg.collector.frames_per_batch
-    pbar = tqdm.tqdm(total=cfg.collector.total_frames)
+    pbar = tqdm.tqdm(total=cfg.collector.total_frames, initial=collected_frames)
     init_random_frames = cfg.collector.init_random_frames
     q_losses = torch.zeros(num_updates, device=device)
     checkpoint_interval = int(cfg.checkpoint.interval or 0)

--- a/sota-implementations/dqn/dqn_cartpole.py
+++ b/sota-implementations/dqn/dqn_cartpole.py
@@ -15,6 +15,7 @@ import tqdm
 from omegaconf import DictConfig, OmegaConf
 from tensordict.nn import CudaGraphModule, TensorDictSequential
 from torchrl._utils import get_available_device, timeit
+from torchrl.checkpoint import Checkpoint, CheckpointFormat, GlobalRNGState
 from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
 from torchrl.envs import ExplorationType, set_exploration_type
@@ -35,6 +36,8 @@ def _save_checkpoint(
     model: torch.nn.Module,
     collected_frames: int,
     metrics: dict,
+    checkpoint: Checkpoint | None = None,
+    format: CheckpointFormat = "archive",
 ) -> Path | None:
     """Saves a DQN checkpoint that can be consumed by ``rlrender``.
 
@@ -44,18 +47,29 @@ def _save_checkpoint(
         model: DQN policy module.
         collected_frames: Number of training frames collected so far.
         metrics: Scalar metrics recorded at checkpoint time.
+        checkpoint: Full training-state checkpoint. When omitted, a render-only
+            checkpoint is constructed for backwards compatibility.
+        format: Output container format for the compatibility path.
 
     Returns:
         The written checkpoint path, or ``None`` when checkpointing is disabled.
     """
-    return save_render_checkpoint(
-        path,
-        model,
-        env_metadata={"env_name": cfg.env.env_name},
-        frames=collected_frames,
-        metrics=metrics,
-        config=OmegaConf.to_container(cfg, resolve=True),
-    )
+    if path in (None, ""):
+        return None
+    if checkpoint is None:
+        return save_render_checkpoint(
+            path,
+            model,
+            env_metadata={"env_name": cfg.env.env_name},
+            frames=collected_frames,
+            metrics=metrics,
+            config=OmegaConf.to_container(cfg, resolve=True),
+            format=format,
+        )
+    checkpoint.components["trainer_state"]["collected_frames"] = collected_frames
+    checkpoint.components["metrics"].clear()
+    checkpoint.components["metrics"].update(metrics)
+    return checkpoint.save(path)
 
 
 @hydra.main(config_path="", config_name="config_cartpole", version_base="1.1")
@@ -166,8 +180,32 @@ def main(cfg: DictConfig):
         cudagraph_policy={"warmup": 10} if cfg.compile.cudagraphs else False,
     )
 
+    checkpoint_state = {"collected_frames": 0}
+    checkpoint_metrics = {}
+    checkpoint = Checkpoint(
+        format=cfg.checkpoint.format,
+        strict=cfg.checkpoint.strict,
+        policy=model,
+        loss_module=loss_module,
+        optimizer=optimizer,
+        replay_buffer=replay_buffer,
+        collector=collector,
+        exploration=greedy_module,
+        target_updater=target_net_updater,
+        trainer_state=checkpoint_state,
+        rng=GlobalRNGState(),
+        environment_metadata={"env_name": cfg.env.env_name},
+        config=OmegaConf.to_container(cfg, resolve=True),
+        metrics=checkpoint_metrics,
+    )
+
     # Main loop
-    collected_frames = 0
+    checkpoint_path = cfg.checkpoint.path
+    if cfg.checkpoint.resume:
+        if not checkpoint_path:
+            raise ValueError("checkpoint.path must be set when checkpoint.resume=True.")
+        checkpoint.load(checkpoint_path, map_location=device)
+    collected_frames = checkpoint_state["collected_frames"]
     num_updates = cfg.loss.num_updates
     batch_size = cfg.buffer.batch_size
     test_interval = cfg.logger.test_interval
@@ -176,16 +214,19 @@ def main(cfg: DictConfig):
     pbar = tqdm.tqdm(total=cfg.collector.total_frames)
     init_random_frames = cfg.collector.init_random_frames
     q_losses = torch.zeros(num_updates, device=device)
-    checkpoint_path = cfg.checkpoint.path
     checkpoint_interval = int(cfg.checkpoint.interval or 0)
-    last_checkpoint_frame = 0
+    last_checkpoint_frame = collected_frames
 
     c_iter = iter(collector)
     total_iter = len(collector)
+    metrics_to_log = dict(checkpoint_metrics)
     for i in range(total_iter):
         timeit.printevery(1000, total_iter, erase=True)
         with timeit("collecting"):
-            data = next(c_iter)
+            try:
+                data = next(c_iter)
+            except StopIteration:
+                break
 
         metrics_to_log = {}
         pbar.update(data.numel())
@@ -268,6 +309,7 @@ def main(cfg: DictConfig):
                 model=model,
                 collected_frames=collected_frames,
                 metrics=metrics_to_log,
+                checkpoint=checkpoint,
             )
             last_checkpoint_frame = collected_frames
 
@@ -280,6 +322,7 @@ def main(cfg: DictConfig):
         model=model,
         collected_frames=collected_frames,
         metrics=metrics_to_log,
+        checkpoint=checkpoint,
     )
     collector.shutdown()
     if not test_env.is_closed:

--- a/test/collectors/test_evaluator.py
+++ b/test/collectors/test_evaluator.py
@@ -15,6 +15,7 @@ import torch
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 from torch import nn
+from torchrl.checkpoint import Checkpoint
 from torchrl.collectors import Evaluator
 from torchrl.collectors._evaluator import (
     _extract_metrics_from_trajectories,
@@ -122,6 +123,26 @@ def _read_video_events(log_dir):
 
 
 class TestEvaluatorSync:
+    def test_checkpoint_state(self, tmp_path):
+        evaluator = Evaluator(_make_env(), _make_policy(), max_steps=50)
+        restored = Evaluator(_make_env(), _make_policy(), max_steps=50)
+        try:
+            evaluator._step_counter = 12
+            restored.load_state_dict(evaluator.state_dict())
+            assert restored._step_counter == 12
+            path = tmp_path / "evaluator"
+            Checkpoint(evaluator=evaluator).save(path)
+            restored._ready_results.append(object())
+            result = Checkpoint(strict="ignore", evaluator=restored).load(path)
+            assert "pending, queued, or unread" in result.incompatible["evaluator"]
+            restored._ready_results.clear()
+            evaluator._async_requests.append((None, 13))
+            with pytest.raises(RuntimeError, match="pending, queued, or unread"):
+                evaluator.state_dict()
+        finally:
+            evaluator.shutdown()
+            restored.shutdown()
+
     def test_evaluate_basic(self):
         env = _make_env()
         policy = _make_policy(env)

--- a/test/rb/test_storages.py
+++ b/test/rb/test_storages.py
@@ -984,6 +984,18 @@ class TestSharedStorageInit:
         assert sample["index"].device.type == "cpu"
 
 
+def test_compressed_storage_checkpointing_releases_staging_memmaps(tmp_path):
+    storage = CompressedListStorage(max_size=4)
+    storage.set(0, TensorDict({"observation": torch.randn(3)}, batch_size=[]))
+
+    checkpoint_path = tmp_path / "checkpoint"
+    storage.dumps(checkpoint_path)
+
+    assert (checkpoint_path / "compressed_data").is_dir()
+    assert (checkpoint_path / "metadata.json").is_file()
+    assert (checkpoint_path / "data_indices.json").is_file()
+
+
 @pytest.mark.skipif(not _has_zstandard, reason="zstandard required for this test.")
 class TestCompressedListStorage:
     """Test cases for CompressedListStorage."""

--- a/test/test_checkpoint.py
+++ b/test/test_checkpoint.py
@@ -21,6 +21,7 @@ from torchrl.checkpoint import (
     CheckpointError,
     CheckpointOptions,
     GlobalRNGState,
+    StateDictCheckpointAdapter,
 )
 from torchrl.data import CompressedListStorage, ReplayBuffer
 
@@ -130,7 +131,11 @@ def test_state_dict_json_and_manifest_roundtrip(tmp_path, format):
     assert result.manifest["container"] == format
     assert result.manifest["versions"]["tensordict"] == tensordict.__version__
     assert result.manifest["metadata"] == {"run": "test"}
-    assert result.manifest["components"]["policy"]["files"] == ["state.pt"]
+    policy_files = result.manifest["components"]["policy"]["files"]
+    assert "state.json" in policy_files
+    assert "state/meta.json" in policy_files
+    assert any(name.endswith(".memmap") for name in policy_files)
+    assert not any(name.endswith((".pt", ".pickle")) for name in policy_files)
     torch.testing.assert_close(source.weight, target.weight)
 
 
@@ -174,9 +179,28 @@ def test_deflate_archive(tmp_path):
         )
 
 
-def test_state_dict_tensor_load_options(tmp_path, monkeypatch):
+def test_default_state_dict_does_not_use_torch_load(tmp_path, monkeypatch):
     path = tmp_path / "checkpoint"
-    Checkpoint(policy=torch.nn.Linear(2, 2)).save(path)
+    source = torch.nn.Linear(2, 2)
+    target = torch.nn.Linear(2, 2)
+    Checkpoint(policy=source).save(path)
+
+    def load(*args, **kwargs):
+        raise AssertionError("torch.load must not be used for the default payload")
+
+    monkeypatch.setattr(torch, "load", load)
+    Checkpoint(policy=target).load(path, map_location="cpu")
+    torch.testing.assert_close(source.weight, target.weight)
+
+
+def test_torch_state_dict_tensor_load_options(tmp_path, monkeypatch):
+    path = tmp_path / "checkpoint"
+    source = torch.nn.Linear(2, 2)
+    Checkpoint().register(
+        "policy",
+        source,
+        adapter=StateDictCheckpointAdapter(payload_format="torch"),
+    ).save(path)
     torch_load = torch.load
     calls = []
 
@@ -191,6 +215,54 @@ def test_state_dict_tensor_load_options(tmp_path, monkeypatch):
         tensor_load_kwargs={"weights_only": True, "mmap": False},
     )
     assert calls == [{"weights_only": True, "mmap": False, "map_location": "cpu"}]
+
+
+@pytest.mark.parametrize(
+    ("payload_format", "payload_file"),
+    [
+        ("directory", "state/meta.json"),
+        ("archive", "state.tdz"),
+        ("consolidated", "state.tdc"),
+        ("torch", "state.pt"),
+    ],
+)
+def test_state_dict_payload_formats(tmp_path, payload_format, payload_file):
+    path = tmp_path / "checkpoint"
+    source = torch.nn.Linear(2, 2)
+    target = torch.nn.Linear(2, 2)
+    Checkpoint().register(
+        "policy",
+        source,
+        adapter=StateDictCheckpointAdapter(payload_format=payload_format),
+    ).save(path)
+
+    files = Checkpoint.manifest(path)["components"]["policy"]["files"]
+    assert payload_file in files
+    Checkpoint(policy=target).load(path, map_location="cpu")
+    torch.testing.assert_close(source.weight, target.weight)
+
+
+def test_tensordict_optimizer_state_roundtrip(tmp_path):
+    path = tmp_path / "checkpoint"
+    source = torch.nn.Linear(3, 2)
+    source_optimizer = torch.optim.Adam(source.parameters(), lr=0.03)
+    source(torch.randn(4, 3)).sum().backward()
+    source_optimizer.step()
+    target = torch.nn.Linear(3, 2)
+    target_optimizer = torch.optim.Adam(target.parameters(), lr=0.1)
+    Checkpoint(policy=source, optimizer=source_optimizer).save(path)
+
+    Checkpoint(policy=target, optimizer=target_optimizer).load(path, map_location="cpu")
+
+    assert target_optimizer.param_groups[0]["lr"] == 0.03
+    source_state = source_optimizer.state_dict()["state"]
+    target_state = target_optimizer.state_dict()["state"]
+    assert source_state.keys() == target_state.keys()
+    for parameter_id in source_state:
+        for key in ("step", "exp_avg", "exp_avg_sq"):
+            torch.testing.assert_close(
+                source_state[parameter_id][key], target_state[parameter_id][key]
+            )
 
 
 def test_archive_accepts_windows_manifest_separators(tmp_path):

--- a/test/test_checkpoint.py
+++ b/test/test_checkpoint.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import random
 import zipfile
 
 import numpy as np
 import pytest
+import tensordict
 import torch
 from tensordict import TensorDict
 from torchrl.checkpoint import (
@@ -56,8 +58,17 @@ class BoxAdapter(CheckpointAdapter):
         path.mkdir(parents=True, exist_ok=True)
         (path / "box.json").write_text(json.dumps(component.value))
 
-    def load(self, component, path, *, map_location, args, kwargs):
-        del map_location, args, kwargs
+    def load(
+        self,
+        component,
+        path,
+        *,
+        map_location,
+        tensor_load_kwargs,
+        args,
+        kwargs,
+    ):
+        del map_location, tensor_load_kwargs, args, kwargs
         component.value = json.loads((path / "box.json").read_text())
 
 
@@ -117,6 +128,7 @@ def test_state_dict_json_and_manifest_roundtrip(tmp_path, format):
     assert result.manifest["format"] == "torchrl.checkpoint"
     assert result.manifest["format_version"] == 1
     assert result.manifest["container"] == format
+    assert result.manifest["versions"]["tensordict"] == tensordict.__version__
     assert result.manifest["metadata"] == {"run": "test"}
     assert result.manifest["components"]["policy"]["files"] == ["state.pt"]
     torch.testing.assert_close(source.weight, target.weight)
@@ -138,6 +150,16 @@ def test_component_save_selection_and_restored_value(tmp_path, format):
     assert result.values["value"] == 3
 
 
+def test_default_save_component_selection(tmp_path):
+    path = tmp_path / "checkpoint"
+    Checkpoint(
+        save_components={"policy"},
+        policy=torch.nn.Linear(2, 2),
+        replay_buffer={"large": True},
+    ).save(path)
+    assert set(Checkpoint.manifest(path)["components"]) == {"policy"}
+
+
 def test_deflate_archive(tmp_path):
     path = tmp_path / "checkpoint.torchrl"
     Checkpoint(
@@ -150,6 +172,52 @@ def test_deflate_archive(tmp_path):
             member.compress_type == zipfile.ZIP_DEFLATED
             for member in archive.infolist()
         )
+
+
+def test_state_dict_tensor_load_options(tmp_path, monkeypatch):
+    path = tmp_path / "checkpoint"
+    Checkpoint(policy=torch.nn.Linear(2, 2)).save(path)
+    torch_load = torch.load
+    calls = []
+
+    def load(*args, **kwargs):
+        calls.append(kwargs.copy())
+        return torch_load(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "load", load)
+    Checkpoint(policy=torch.nn.Linear(2, 2)).load(
+        path,
+        map_location="cpu",
+        tensor_load_kwargs={"weights_only": True, "mmap": False},
+    )
+    assert calls == [{"weights_only": True, "mmap": False, "map_location": "cpu"}]
+
+
+def test_archive_accepts_windows_manifest_separators(tmp_path):
+    path = tmp_path / "checkpoint.torchrl"
+    source = torch.nn.Linear(2, 2)
+    Checkpoint(format="archive", policy=source).save(path)
+    with zipfile.ZipFile(path) as archive:
+        members = {name: archive.read(name) for name in archive.namelist()}
+    manifest = json.loads(members["manifest.json"])
+    for record in manifest["components"].values():
+        record["path"] = record["path"].replace("/", "\\")
+        record["files"] = [name.replace("/", "\\") for name in record["files"]]
+    members["manifest.json"] = json.dumps(manifest).encode()
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, payload in members.items():
+            archive.writestr(name, payload)
+
+    target = torch.nn.Linear(2, 2)
+    Checkpoint(policy=target).load(path)
+    torch.testing.assert_close(source.weight, target.weight)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are required")
+def test_directory_uses_normal_directory_permissions(tmp_path):
+    path = tmp_path / "checkpoint"
+    Checkpoint(value={"ok": True}).save(path)
+    assert path.stat().st_mode & 0o050 == 0o050
 
 
 @pytest.mark.parametrize("format", ["directory", "archive"])
@@ -262,7 +330,8 @@ def test_manifest_migration(tmp_path, monkeypatch):
     manifest_path.write_text(json.dumps(manifest))
     with pytest.raises(CheckpointError, match="no migration"):
         Checkpoint.manifest(path)
-    monkeypatch.setattr(Checkpoint, "_format_migrations", {0: migrate_v0_manifest})
+    monkeypatch.setattr(Checkpoint, "_format_migrations", {})
+    Checkpoint.register_migration(0, migrate_v0_manifest)
     assert Checkpoint.manifest(path)["metadata"]["migrated"] is True
 
 

--- a/test/test_checkpoint.py
+++ b/test/test_checkpoint.py
@@ -15,6 +15,7 @@ import pytest
 import tensordict
 import torch
 from tensordict import TensorDict
+from tensordict.memmap import MemoryMappedTensor
 from torchrl.checkpoint import (
     Checkpoint,
     CheckpointAdapter,
@@ -485,6 +486,8 @@ def test_compressed_replay_buffer_roundtrip(tmp_path, format):
     ]
     assert len(target) == len(source)
     torch.testing.assert_close(target.storage.get(0), source.storage.get(0))
+    loaded_observation = target.storage._storage[0]["observation"]
+    assert isinstance(loaded_observation, MemoryMappedTensor) is (format == "directory")
 
 
 @pytest.mark.gpu

--- a/test/test_checkpoint.py
+++ b/test/test_checkpoint.py
@@ -1,0 +1,368 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import zipfile
+
+import numpy as np
+import pytest
+import torch
+from tensordict import TensorDict
+from torchrl.checkpoint import (
+    Checkpoint,
+    CheckpointAdapter,
+    CheckpointError,
+    CheckpointOptions,
+    GlobalRNGState,
+)
+from torchrl.data import CompressedListStorage, ReplayBuffer
+
+
+class DumpObject:
+    def __init__(self, value=0):
+        self.value = value
+        self.calls = []
+
+    def dump(self, path, label, *, enabled):
+        self.calls.append(("dump", label, enabled))
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "value.json").write_text(json.dumps(self.value))
+
+    def load(self, path, label, *, enabled):
+        self.calls.append(("load", label, enabled))
+        self.value = json.loads((path / "value.json").read_text())
+
+
+class NeverLoadDump(DumpObject):
+    def load(self, path, label="unused", *, enabled=False):
+        raise AssertionError("unrequested payload was loaded")
+
+
+class Box:
+    def __init__(self, value=0):
+        self.value = value
+
+
+class BoxAdapter(CheckpointAdapter):
+    adapter_id = "test.box"
+
+    def save(self, component, path, *, args, kwargs):
+        del args, kwargs
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "box.json").write_text(json.dumps(component.value))
+
+    def load(self, component, path, *, map_location, args, kwargs):
+        del map_location, args, kwargs
+        component.value = json.loads((path / "box.json").read_text())
+
+
+class FailingAdapter(BoxAdapter):
+    adapter_id = "test.failing"
+
+    def save(self, component, path, *, args, kwargs):
+        super().save(component, path, args=args, kwargs=kwargs)
+        raise RuntimeError("interrupted")
+
+
+class VersionedBoxAdapter(BoxAdapter):
+    format_version = 2
+
+
+class OptionReplayBuffer(ReplayBuffer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.checkpoint_calls = []
+
+    def dump(self, path, *args, **kwargs):
+        self.checkpoint_calls.append(("dump", args, kwargs))
+        return super().dump(path)
+
+    def load(self, path, *args, **kwargs):
+        self.checkpoint_calls.append(("load", args, kwargs))
+        return super().load(path)
+
+
+def migrate_v0_manifest(manifest):
+    manifest["format_version"] = 1
+    manifest["metadata"]["migrated"] = True
+    return manifest
+
+
+@pytest.mark.parametrize("format", ["directory", "archive"])
+def test_state_dict_json_and_manifest_roundtrip(tmp_path, format):
+    source = torch.nn.Linear(3, 2)
+    target = torch.nn.Linear(3, 2)
+    optimizer = torch.optim.Adam(source.parameters(), lr=0.03)
+    path = tmp_path / "checkpoint"
+    Checkpoint(
+        format=format,
+        policy=source,
+        optimizer=optimizer,
+        metadata={"step": 12, "tags": ["unit"], "score": torch.tensor(1.5)},
+    ).save(path, metadata={"run": "test"})
+
+    target_metadata = {}
+    result = Checkpoint(policy=target, metadata=target_metadata).load(
+        path, components={"policy", "metadata"}, map_location="cpu"
+    )
+
+    assert result.loaded == {"policy", "metadata"}
+    assert result.unrequested == {"optimizer"}
+    assert target_metadata == {"step": 12, "tags": ["unit"], "score": 1.5}
+    assert result.manifest["format"] == "torchrl.checkpoint"
+    assert result.manifest["format_version"] == 1
+    assert result.manifest["container"] == format
+    assert result.manifest["metadata"] == {"run": "test"}
+    assert result.manifest["components"]["policy"]["files"] == ["state.pt"]
+    torch.testing.assert_close(source.weight, target.weight)
+
+
+@pytest.mark.parametrize("format", ["directory", "archive"])
+def test_component_save_selection_and_restored_value(tmp_path, format):
+    path = tmp_path / "checkpoint"
+    Checkpoint(
+        format=format,
+        policy=torch.nn.Linear(2, 2),
+        value=3,
+        omitted={"large": True},
+    ).save(path, components={"policy", "value"})
+    assert set(Checkpoint.manifest(path)["components"]) == {"policy", "value"}
+
+    result = Checkpoint(policy=torch.nn.Linear(2, 2), value=0).load(path)
+    assert result.loaded == {"policy", "value"}
+    assert result.values["value"] == 3
+
+
+def test_deflate_archive(tmp_path):
+    path = tmp_path / "checkpoint.torchrl"
+    Checkpoint(
+        format="archive",
+        archive_compression="deflate",
+        value={"payload": "x" * 1024},
+    ).save(path)
+    with zipfile.ZipFile(path) as archive:
+        assert all(
+            member.compress_type == zipfile.ZIP_DEFLATED
+            for member in archive.infolist()
+        )
+
+
+@pytest.mark.parametrize("format", ["directory", "archive"])
+def test_dump_load_options_and_partial_restore(tmp_path, format):
+    source = DumpObject(17)
+    target = DumpObject()
+    path = tmp_path / "checkpoint"
+    saver = (
+        Checkpoint(format=format, metadata={"ok": True})
+        .register(
+            "payload",
+            source,
+            options=CheckpointOptions(
+                save_args=("registered",), save_kwargs={"enabled": False}
+            ),
+        )
+        .register(
+            "never",
+            NeverLoadDump(99),
+            options=CheckpointOptions(
+                save_args=("unused",), save_kwargs={"enabled": False}
+            ),
+        )
+    )
+    saver.save(
+        path,
+        component_options={
+            "payload": CheckpointOptions(
+                save_args=("operation",), save_kwargs={"enabled": True}
+            )
+        },
+    )
+    assert source.calls == [("dump", "operation", True)]
+
+    loader = Checkpoint().register(
+        "payload",
+        target,
+        options=CheckpointOptions(
+            load_args=("registered",), load_kwargs={"enabled": False}
+        ),
+    )
+    result = loader.load(
+        path,
+        components={"payload"},
+        component_options={
+            "payload": CheckpointOptions(
+                load_args=("operation",), load_kwargs={"enabled": True}
+            )
+        },
+    )
+    assert target.value == 17
+    assert target.calls == [("load", "operation", True)]
+    assert result.unrequested == {"metadata", "never"}
+
+
+@pytest.mark.parametrize("format", ["directory", "archive"])
+def test_scoped_adapter(tmp_path, format):
+    path = tmp_path / "checkpoint"
+    source = Box(5)
+    saver = Checkpoint(format=format)
+    saver.register_adapter(Box, BoxAdapter()).register("box", source).save(path)
+
+    target = Box()
+    loader = Checkpoint()
+    loader.register_adapter(Box, BoxAdapter()).register("box", target).load(path)
+    assert target.value == 5
+
+
+def test_strict_modes(tmp_path, caplog):
+    path = tmp_path / "checkpoint"
+    Checkpoint(policy=torch.nn.Linear(2, 2)).save(path)
+    checkpoint = Checkpoint(policy=torch.nn.Linear(2, 2), optimizer={"json": "target"})
+    with pytest.raises(CheckpointError, match="missing"):
+        checkpoint.load(path)
+    result = checkpoint.load(path, strict="ignore")
+    assert result.loaded == {"policy"}
+    assert result.missing == {"optimizer"}
+    result = checkpoint.load(path, strict="warn")
+    assert result.missing == {"optimizer"}
+    assert "Checkpoint restore issues" in caplog.text
+
+
+def test_incompatible_adapter(tmp_path):
+    path = tmp_path / "checkpoint"
+    Checkpoint(value=torch.nn.Linear(2, 2)).save(path)
+    result = Checkpoint(strict="ignore", value={}).load(path)
+    assert "value" in result.incompatible
+    assert not result.loaded
+
+    version_path = tmp_path / "versioned"
+    Checkpoint().register("box", Box(1), adapter=BoxAdapter()).save(version_path)
+    result = (
+        Checkpoint(strict="ignore")
+        .register("box", Box(), adapter=VersionedBoxAdapter())
+        .load(version_path)
+    )
+    assert "adapter version" in result.incompatible["box"]
+
+
+def test_manifest_migration(tmp_path, monkeypatch):
+    path = tmp_path / "checkpoint"
+    Checkpoint(value={"version": 1}).save(path)
+    manifest_path = path / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["format_version"] = 2
+    manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(CheckpointError, match="newer"):
+        Checkpoint.manifest(path)
+    manifest["format_version"] = 0
+    manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(CheckpointError, match="no migration"):
+        Checkpoint.manifest(path)
+    monkeypatch.setattr(Checkpoint, "_format_migrations", {0: migrate_v0_manifest})
+    assert Checkpoint.manifest(path)["metadata"]["migrated"] is True
+
+
+@pytest.mark.parametrize("format", ["directory", "archive"])
+def test_interrupted_write_preserves_checkpoint(tmp_path, format):
+    path = tmp_path / "checkpoint"
+    Checkpoint(format=format, value={"version": 1}).save(path)
+    checkpoint_id = Checkpoint.manifest(path)["checkpoint_id"]
+    with pytest.raises(RuntimeError, match="interrupted"):
+        Checkpoint(format=format).register(
+            "value", Box(2), adapter=FailingAdapter()
+        ).save(path)
+    assert Checkpoint.manifest(path)["checkpoint_id"] == checkpoint_id
+    value = {}
+    Checkpoint(value=value).load(path)
+    assert value == {"version": 1}
+
+
+@pytest.mark.parametrize("format", ["directory", "archive"])
+def test_global_rng_roundtrip(tmp_path, format):
+    random.seed(0)
+    np.random.seed(0)
+    torch.manual_seed(0)
+    path = tmp_path / "checkpoint"
+    Checkpoint(format=format, rng=GlobalRNGState()).save(path)
+    expected = (random.random(), np.random.rand(), torch.rand(()))
+    random.seed(9)
+    np.random.seed(9)
+    torch.manual_seed(9)
+    Checkpoint(rng=GlobalRNGState()).load(path)
+    actual = (random.random(), np.random.rand(), torch.rand(()))
+    assert actual[:2] == expected[:2]
+    torch.testing.assert_close(actual[2], expected[2])
+
+
+@pytest.mark.parametrize("format", ["directory", "archive"])
+def test_compressed_replay_buffer_roundtrip(tmp_path, format):
+    path = tmp_path / "checkpoint"
+    source = OptionReplayBuffer(storage=CompressedListStorage(10), batch_size=1)
+    data = TensorDict({"observation": torch.randn(4, 3)}, [4])
+    source.extend(data)
+    Checkpoint(format=format).register(
+        "replay_buffer",
+        source,
+        options=CheckpointOptions(
+            save_args=("baseline",),
+            save_kwargs={"enabled": False, "preserved": 1},
+        ),
+    ).save(
+        path,
+        component_options={
+            "replay_buffer": CheckpointOptions(
+                save_args=("operation",), save_kwargs={"enabled": True}
+            )
+        },
+    )
+    assert source.checkpoint_calls == [
+        ("dump", ("operation",), {"enabled": True, "preserved": 1})
+    ]
+
+    target = OptionReplayBuffer(storage=CompressedListStorage(10), batch_size=1)
+    Checkpoint().register(
+        "replay_buffer",
+        target,
+        options=CheckpointOptions(
+            load_args=("baseline",),
+            load_kwargs={"enabled": False, "preserved": 2},
+        ),
+    ).load(
+        path,
+        component_options={
+            "replay_buffer": CheckpointOptions(
+                load_args=("operation",), load_kwargs={"enabled": True}
+            )
+        },
+    )
+    assert target.checkpoint_calls == [
+        ("load", ("operation",), {"enabled": True, "preserved": 2})
+    ]
+    assert len(target) == len(source)
+    torch.testing.assert_close(target.storage.get(0), source.storage.get(0))
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_cuda_map_location_and_rng(tmp_path):
+    path = tmp_path / "checkpoint"
+    source = torch.nn.Linear(2, 2, device="cuda")
+    torch.cuda.manual_seed_all(0)
+    Checkpoint(format="archive", policy=source, rng=GlobalRNGState()).save(path)
+    target = torch.nn.Linear(2, 2)
+    Checkpoint(policy=target).load(path, components={"policy"}, map_location="cpu")
+    assert target.weight.device.type == "cpu"
+
+
+def test_reject_remote_path():
+    with pytest.raises(ValueError, match="Only local"):
+        Checkpoint(value={}).save("s3://bucket/checkpoint")
+
+
+if __name__ == "__main__":
+    args, unknown = argparse.ArgumentParser().parse_known_args()
+    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -1019,12 +1019,14 @@ class TestCollectorGeneric:
         collector_frames = collector._frames
         collector_iter = collector._iter
         collector_state_dict = collector.state_dict()
+        saved_traj_id = collector_state_dict["traj_pool"]["traj_id"].item()
         collector.shutdown()
 
         collector = collector_class(**collector_kwargs)
         collector.load_state_dict(collector_state_dict)
         assert collector._frames == collector_frames
         assert collector._iter == collector_iter
+        assert collector.state_dict()["traj_pool"]["traj_id"].item() > saved_traj_id
         for _ in enumerate(collector):
             raise AssertionError
         collector.shutdown()
@@ -4389,6 +4391,77 @@ class TestPolicyVersion:
             assert (batch4["next", "policy_version"] == v0[0] + 2).all()
         finally:
             collector.shutdown()
+
+    def test_single_collector_restores_policy_version(self):
+        """Collector state preserves its policy revision across reconstruction."""
+        collector = Collector(
+            self._Env,
+            policy=self._make_policy(),
+            total_frames=60,
+            frames_per_batch=10,
+            track_policy_version=True,
+        )
+        try:
+            collector.update_policy_weights_()
+            collector.update_policy_weights_()
+            state_dict = collector.state_dict()
+            saved_version = collector.policy_version
+        finally:
+            collector.shutdown()
+
+        restored = Collector(
+            self._Env,
+            policy=self._make_policy(),
+            total_frames=60,
+            frames_per_batch=10,
+            track_policy_version=True,
+        )
+        try:
+            restored.load_state_dict(state_dict)
+            assert restored.policy_version == saved_version
+            restored.update_policy_weights_()
+            assert restored.policy_version == saved_version + 1
+        finally:
+            restored.shutdown()
+
+    def test_multi_collector_restores_worker_policy_versions(self):
+        """Multiprocess restore preserves each worker's policy revision."""
+        collector = MultiSyncCollector(
+            [self._Env, self._Env],
+            policy=self._make_policy(),
+            frames_per_batch=20,
+            total_frames=200,
+            cat_results="stack",
+            track_policy_version=True,
+            weight_sync_schemes={"policy": MultiProcessWeightSyncScheme()},
+        )
+        try:
+            collector.update_policy_weights_()
+            collector.update_policy_weights_()
+            state_dict = collector.state_dict()
+            saved_versions = [
+                state_dict[f"worker{idx}"]["policy_version"] for idx in range(2)
+            ]
+        finally:
+            collector.shutdown()
+
+        restored = MultiSyncCollector(
+            [self._Env, self._Env],
+            policy=self._make_policy(),
+            frames_per_batch=20,
+            total_frames=200,
+            cat_results="stack",
+            track_policy_version=True,
+            weight_sync_schemes={"policy": MultiProcessWeightSyncScheme()},
+        )
+        try:
+            restored.load_state_dict(state_dict)
+            restored_state = restored.state_dict()
+            assert [
+                restored_state[f"worker{idx}"]["policy_version"] for idx in range(2)
+            ] == saved_versions
+        finally:
+            restored.shutdown()
 
     @pytest.mark.parametrize(
         "collector_cls",

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -62,6 +62,7 @@ from torchrl.trainers.trainers import CountFramesLog
 
 # Test if configs can be imported (requires hydra)
 try:
+    from torchrl.trainers.algorithms import configs as algorithm_configs
     from torchrl.trainers.algorithms.configs.modules import (
         ActivationConfig,
         LayerConfig,
@@ -1592,6 +1593,27 @@ class TestLoggerConfigs:
     not _configs_available, reason="Config system requires hydra-core and omegaconf"
 )
 class TestTrainerConfigs:
+    @pytest.mark.parametrize(
+        "config_name",
+        [
+            "A2CTrainerConfig",
+            "CQLTrainerConfig",
+            "DDPGTrainerConfig",
+            "DQNTrainerConfig",
+            "IQLTrainerConfig",
+            "OfflineToOnlineTrainerConfig",
+            "PPOTrainerConfig",
+            "ReinforceTrainerConfig",
+            "SACTrainerConfig",
+            "TD3TrainerConfig",
+        ],
+    )
+    def test_checkpoint_config_parity(self, config_name):
+        field = getattr(algorithm_configs, config_name).__dataclass_fields__[
+            "checkpoint"
+        ]
+        assert field.default is None
+
     def test_nested_key_normalization_for_hydra_lists(self):
         from omegaconf import ListConfig
         from torchrl.trainers.algorithms.configs.common import (

--- a/test/test_loggers.py
+++ b/test/test_loggers.py
@@ -195,6 +195,15 @@ class TestTensorboard:
 
 
 class TestCSVLogger:
+    def test_checkpoint_state(self, tmp_path):
+        logger = CSVLogger(log_dir=tmp_path, exp_name="source")
+        restored = CSVLogger(log_dir=tmp_path, exp_name="restored")
+        logger.log_scalar("reward", 2.0)
+        logger.experiment.videos_counter["evaluation"] = 3
+        restored.load_state_dict(logger.state_dict())
+        assert restored.experiment.scalars["reward"] == [(0, 2.0)]
+        assert restored.experiment.videos_counter["evaluation"] == 3
+
     def test_direct_service_client_is_identity(self, tmpdir):
         logger = CSVLogger(log_dir=tmpdir, exp_name="direct")
         assert logger.client() is logger

--- a/test/test_loggers.py
+++ b/test/test_loggers.py
@@ -17,7 +17,9 @@ from time import sleep
 import pytest
 import torch
 from tensordict import MemoryMappedTensor
+
 from torchrl._comm import MailboxPeerClosedError
+from torchrl.checkpoint import Checkpoint
 from torchrl.envs import check_env_specs, GymEnv, ParallelEnv
 from torchrl.record.loggers.common import _has_torchcodec, Logger
 from torchrl.record.loggers.csv import CSVLogger
@@ -200,7 +202,12 @@ class TestCSVLogger:
         restored = CSVLogger(log_dir=tmp_path, exp_name="restored")
         logger.log_scalar("reward", 2.0)
         logger.experiment.videos_counter["evaluation"] = 3
-        restored.load_state_dict(logger.state_dict())
+        checkpoint_path = tmp_path / "checkpoint"
+        Checkpoint(logger=logger).save(checkpoint_path)
+        Checkpoint(logger=restored).load(
+            checkpoint_path,
+            tensor_load_kwargs={"weights_only": True, "mmap": True},
+        )
         assert restored.experiment.scalars["reward"] == [(0, 2.0)]
         assert restored.experiment.videos_counter["evaluation"] == 3
 

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -19,6 +19,7 @@ import torchrl.render.artifacts as artifacts_module
 import torchrl.render.mujoco_wasm as mujoco_wasm_module
 from tensordict import TensorDict
 
+from torchrl.checkpoint import Checkpoint
 from torchrl.data import Composite, Unbounded
 from torchrl.envs import EnvBase, ObservationNorm, set_gym_backend, StepCounter, VecNorm
 from torchrl.record.loggers.common import _has_torchcodec
@@ -52,6 +53,15 @@ _has_pil = importlib.util.find_spec("PIL") is not None
 _has_gym = importlib.util.find_spec("gym") is not None
 _has_gymnasium = importlib.util.find_spec("gymnasium") is not None
 _has_pygame = importlib.util.find_spec("pygame") is not None
+
+
+class UnrequestedLargeComponent:
+    def dump(self, path):
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "payload.bin").write_bytes(b"large component placeholder")
+
+    def load(self, path):
+        raise AssertionError(f"Unrequested component was read from {path}")
 
 
 class FakeIFrame:
@@ -341,6 +351,18 @@ class TestRenderCheckpoint:
         assert payload["frames"] == 7
         assert payload["metrics"] == {"eval/reward": 1.0}
         assert infer_state_dict(payload)["weight"].shape == (2, 2)
+
+    def test_unified_policy_load_does_not_read_large_components(self, tmp_path):
+        path = tmp_path / "policy.torchrl"
+        Checkpoint(
+            format="archive",
+            policy=torch.nn.Linear(2, 2),
+            replay_buffer=UnrequestedLargeComponent(),
+            environment_metadata={"env_name": "CartPole-v1"},
+        ).save(path)
+        payload = load_checkpoint(path)
+        assert payload["env_name"] == "CartPole-v1"
+        assert "model_state_dict" in payload
 
 
 class TestRenderPolicy:
@@ -966,7 +988,7 @@ class TestSotaCheckpointFactories:
             collected_frames=12,
             metrics={"eval/reward": 10.0},
         )
-        saved = torch.load(saved_path, weights_only=False)
+        saved = load_checkpoint(saved_path)
         assert saved["frames"] == 12
         assert saved["env_name"] == "CartPole-v1"
         assert "model_state_dict" in saved
@@ -1107,7 +1129,7 @@ class TestSotaCheckpointFactories:
             collected_frames=24,
             metrics={"eval/reward": 20.0},
         )
-        saved = torch.load(saved_path, weights_only=False)
+        saved = load_checkpoint(saved_path)
         assert saved["frames"] == 24
         assert saved["env_backend"] == "gym"
         assert saved["normalize_observation"] is False

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib.util
 import json
 import socket
@@ -62,6 +63,17 @@ class UnrequestedLargeComponent:
 
     def load(self, path):
         raise AssertionError(f"Unrequested component was read from {path}")
+
+
+class TrainerStateComponent:
+    def __init__(self, frames=0):
+        self.frames = frames
+
+    def state_dict(self):
+        return {"collected_frames": self.frames}
+
+    def load_state_dict(self, state_dict):
+        self.frames = state_dict["collected_frames"]
 
 
 class FakeIFrame:
@@ -328,7 +340,7 @@ class TestRenderCheckpoint:
         payload = {"model_state_dict": {"bias": torch.ones(1)}}
         torch.save(payload, path)
         assert load_checkpoint(path)["model_state_dict"]["bias"].item() == 1
-        assert len(checkpoint_hash(path)) == 64
+        assert checkpoint_hash(path) == hashlib.sha256(path.read_bytes()).hexdigest()
         assert infer_state_dict(payload)["bias"].item() == 1
         with pytest.raises(ValueError, match="Only local checkpoint"):
             load_checkpoint("https://example.com/policy.pt")
@@ -337,20 +349,47 @@ class TestRenderCheckpoint:
         module = torch.nn.Linear(2, 2)
         assert save_render_checkpoint(None, module) is None
         assert save_render_checkpoint("", module) is None
-        path = save_render_checkpoint(
-            tmp_path / "checkpoints" / "policy.pt",
-            module,
-            env_metadata={"env_name": "CartPole-v1", "vecnorm": None},
-            frames=7,
-            metrics={"eval/reward": 1.0},
-            config={"env": {"env_name": "CartPole-v1"}},
-        )
+        with pytest.warns(FutureWarning, match="v0.15"):
+            path = save_render_checkpoint(
+                tmp_path / "checkpoints" / "policy.pt",
+                module,
+                env_metadata={
+                    "env_name": "CartPole-v1",
+                    "vecnorm": {"loc": torch.ones(2), "scale": torch.ones(2)},
+                },
+                frames=7,
+                metrics={"eval/reward": 1.0},
+                config={"env": {"env_name": "CartPole-v1"}},
+            )
+        assert "model_state_dict" in torch.load(path, weights_only=True)
         payload = load_checkpoint(path)
         assert payload["env_name"] == "CartPole-v1"
-        assert payload["vecnorm"] is None
+        torch.testing.assert_close(payload["vecnorm"]["loc"], torch.ones(2))
         assert payload["frames"] == 7
         assert payload["metrics"] == {"eval/reward": 1.0}
         assert infer_state_dict(payload)["weight"].shape == (2, 2)
+
+    def test_unified_tensor_metadata_and_trainer_state(self, tmp_path):
+        path = save_render_checkpoint(
+            tmp_path / "policy.torchrl",
+            torch.nn.Linear(2, 2),
+            env_metadata={
+                "vecnorm": {"loc": torch.ones(2), "scale": torch.full((2,), 2)}
+            },
+            format="archive",
+        )
+        payload = load_checkpoint(path)
+        assert checkpoint_hash(path) == hashlib.sha256(path.read_bytes()).hexdigest()
+        torch.testing.assert_close(payload["vecnorm"]["loc"], torch.ones(2))
+        torch.testing.assert_close(payload["vecnorm"]["scale"], torch.full((2,), 2))
+
+        trainer_path = tmp_path / "trainer.torchrl"
+        Checkpoint(
+            format="archive",
+            policy=torch.nn.Linear(2, 2),
+            trainer_state=TrainerStateComponent(37),
+        ).save(trainer_path)
+        assert load_checkpoint(trainer_path)["frames"] == 37
 
     def test_unified_policy_load_does_not_read_large_components(self, tmp_path):
         path = tmp_path / "policy.torchrl"
@@ -980,6 +1019,9 @@ class TestSotaCheckpointFactories:
         save_checkpoint = import_from_string(
             f"{dqn_dir / 'dqn_cartpole.py'}:_save_checkpoint"
         )
+        resume_checkpoint = import_from_string(
+            f"{dqn_dir / 'dqn_cartpole.py'}:_resume_checkpoint"
+        )
         saved_path = tmp_path / "saved_dqn.pt"
         save_checkpoint(
             saved_path,
@@ -992,6 +1034,53 @@ class TestSotaCheckpointFactories:
         assert saved["frames"] == 12
         assert saved["env_name"] == "CartPole-v1"
         assert "model_state_dict" in saved
+
+        resume_path = tmp_path / "resume_dqn.torchrl"
+        Checkpoint(
+            format="archive",
+            trainer_state={"collected_frames": 9},
+            config={"learning_rate": 1e-3},
+            replay_buffer=UnrequestedLargeComponent(),
+        ).save(resume_path)
+        current_config = {"learning_rate": 2e-3}
+        current_state = {"collected_frames": 0}
+        resume_target = Checkpoint(
+            trainer_state=current_state,
+            config=current_config,
+            replay_buffer=UnrequestedLargeComponent(),
+        )
+        result = resume_checkpoint(
+            resume_target,
+            resume_path,
+            "cpu",
+            include_replay_buffer=False,
+        )
+        assert current_config == {"learning_rate": 2e-3}
+        assert current_state == {"collected_frames": 9}
+        assert result.unrequested == {"config", "replay_buffer"}
+
+        compact_path = tmp_path / "compact_dqn.torchrl"
+        compact_checkpoint = Checkpoint(
+            format="archive",
+            policy=model,
+            replay_buffer=UnrequestedLargeComponent(),
+            trainer_state={},
+            metrics={},
+        )
+        save_checkpoint(
+            compact_path,
+            cfg=OmegaConf.create(
+                {
+                    "env": {"env_name": "CartPole-v1"},
+                    "checkpoint": {"include_replay_buffer": False},
+                }
+            ),
+            model=model,
+            collected_frames=13,
+            metrics={},
+            checkpoint=compact_checkpoint,
+        )
+        assert "replay_buffer" not in Checkpoint.manifest(compact_path)["components"]
 
         make_render_policy = import_from_string(f"{utils_path}:make_render_policy")
         calls = []
@@ -1110,25 +1199,27 @@ class TestSotaCheckpointFactories:
             f"{ppo_dir / 'ppo_mujoco.py'}:_save_checkpoint"
         )
         saved_path = tmp_path / "saved_ppo.pt"
-        save_checkpoint(
-            saved_path,
-            cfg=OmegaConf.create(
-                {
-                    "env": {
-                        "env_name": "InvertedPendulum-v4",
-                        "backend": "gym",
-                        "config_overrides": {},
-                        "num_envs": 1,
-                        "batch_mode": "parallel",
-                        "normalize_observation": False,
-                        "max_episode_steps": 7,
+        with pytest.warns(FutureWarning, match="v0.15"):
+            save_checkpoint(
+                saved_path,
+                cfg=OmegaConf.create(
+                    {
+                        "env": {
+                            "env_name": "InvertedPendulum-v4",
+                            "backend": "gym",
+                            "config_overrides": {},
+                            "num_envs": 1,
+                            "batch_mode": "parallel",
+                            "normalize_observation": False,
+                            "max_episode_steps": 7,
+                        }
                     }
-                }
-            ),
-            model=actor,
-            collected_frames=24,
-            metrics={"eval/reward": 20.0},
-        )
+                ),
+                model=actor,
+                collected_frames=24,
+                metrics={"eval/reward": 20.0},
+            )
+        assert "model_state_dict" in torch.load(saved_path, weights_only=True)
         saved = load_checkpoint(saved_path)
         assert saved["frames"] == 24
         assert saved["env_backend"] == "gym"

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -12,6 +12,7 @@ import tempfile
 import warnings
 from argparse import Namespace
 from collections import OrderedDict
+from copy import deepcopy
 from os import path, walk
 from time import sleep
 
@@ -83,24 +84,36 @@ class MockingOptim:
 class MockingCollector:
     called_update_policy_weights_ = False
 
+    def __init__(self, source_policy=None):
+        self.source_policy = source_policy
+        self.policy = deepcopy(source_policy) if source_policy is not None else None
+        self.called_update_policy_weights_ = False
+
     def set_seed(self, seed, **kwargs):
         return seed
 
-    def update_policy_weights_(self):
+    def update_policy_weights_(self, policy=None):
         self.called_update_policy_weights_ = True
+        policy = self.source_policy if policy is None else policy
+        if policy is not None:
+            self.policy.load_state_dict(policy.state_dict())
 
     def shutdown(self):
         pass
 
     def state_dict(self):
-        return {}
+        if self.policy is None:
+            return {}
+        return {"policy": self.policy.state_dict()}
 
     def load_state_dict(self, state_dict):
-        pass
+        if self.policy is not None:
+            self.policy.load_state_dict(state_dict["policy"])
 
 
 class MockingIterableCollector(MockingCollector):
     def __init__(self, batches):
+        super().__init__()
         self._batches = batches
         self.init_random_frames = 10**9
         self.shutdown_calls = 0
@@ -143,14 +156,22 @@ _mocking_optim = MockingOptim()
 
 
 def mocking_trainer(
-    file=None, optimizer=_mocking_optim, checkpoint=None, logger=None
+    file=None,
+    optimizer=_mocking_optim,
+    checkpoint=None,
+    logger=None,
+    with_policy=False,
 ) -> Trainer:
+    loss_module = MockingLossModule()
+    if with_policy:
+        loss_module.actor_network = nn.Linear(2, 2)
+    collector = MockingCollector(getattr(loss_module, "actor_network", None))
     trainer = Trainer(
-        collector=MockingCollector(),
+        collector=collector,
         total_frames=None,
         frame_skip=None,
         optim_steps_per_batch=None,
-        loss_module=MockingLossModule(),
+        loss_module=loss_module,
         optimizer=optimizer,
         logger=logger,
         save_trainer_file=file,
@@ -182,6 +203,31 @@ def test_unified_trainer_checkpoint(tmp_path, format):
     restored.load_from_file(path)
     assert restored.collected_frames == 41
     assert restored._optim_count == 7
+
+
+@pytest.mark.parametrize("format", ["directory", "archive"])
+def test_unified_trainer_resyncs_collector_policy_after_load(tmp_path, format):
+    path = tmp_path / "trainer-checkpoint"
+    source = mocking_trainer(
+        file=path,
+        checkpoint=Checkpoint(format=format),
+        with_policy=True,
+    )
+    with torch.no_grad():
+        for parameter in source.loss_module.actor_network.parameters():
+            parameter.fill_(3.0)
+    assert any(
+        not torch.equal(source.collector.policy.state_dict()[key], value)
+        for key, value in source.loss_module.actor_network.state_dict().items()
+    )
+    source.save_trainer(force_save=True)
+
+    restored = mocking_trainer(checkpoint=Checkpoint(), with_policy=True)
+    restored.load_from_file(path)
+
+    assert restored.collector.called_update_policy_weights_
+    for key, value in restored.loss_module.actor_network.state_dict().items():
+        torch.testing.assert_close(restored.collector.policy.state_dict()[key], value)
 
 
 def test_unified_trainer_default_component_selection(tmp_path):
@@ -1287,6 +1333,30 @@ def test_updateweights():
         trainer._post_steps_hook()
         assert trainer.collector.called_update_policy_weights_ is (t == T - 1)
     assert trainer.collector.called_update_policy_weights_
+
+
+@pytest.mark.parametrize("format", ["directory", "archive"])
+def test_updateweights_checkpoint_counter(tmp_path, format):
+    checkpoint_path = tmp_path / "trainer-checkpoint"
+    trainer = mocking_trainer(
+        file=checkpoint_path, checkpoint=Checkpoint(format=format)
+    )
+    update_weights = UpdateWeights(trainer.collector, 5)
+    update_weights.register(trainer)
+    for _ in range(3):
+        trainer._post_steps_hook()
+    trainer.save_trainer(force_save=True)
+
+    restored = mocking_trainer(checkpoint=Checkpoint())
+    restored_update_weights = UpdateWeights(restored.collector, 5)
+    restored_update_weights.register(restored)
+    restored.load_from_file(checkpoint_path)
+
+    assert restored_update_weights.counter == 3
+    restored._post_steps_hook()
+    assert not restored.collector.called_update_policy_weights_
+    restored._post_steps_hook()
+    assert restored.collector.called_update_policy_weights_
 
 
 class TestCountFrames:

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -9,6 +9,7 @@ import importlib.util
 import inspect
 import os
 import tempfile
+import warnings
 from argparse import Namespace
 from collections import OrderedDict
 from os import path, walk
@@ -114,10 +115,35 @@ class MockingLossModule(nn.Module):
     pass
 
 
+class MockingLogger:
+    def __init__(self):
+        self.value = 0
+
+    def state_dict(self):
+        return {"value": self.value}
+
+    def load_state_dict(self, state_dict):
+        self.value = state_dict["value"]
+
+
+class MockingReplayBufferHook:
+    def __init__(self, fraction=0.0):
+        self.replay_buffer = object()
+        self.fraction = fraction
+
+    def state_dict(self):
+        return {"fraction": self.fraction}
+
+    def load_state_dict(self, state_dict):
+        self.fraction = state_dict["fraction"]
+
+
 _mocking_optim = MockingOptim()
 
 
-def mocking_trainer(file=None, optimizer=_mocking_optim, checkpoint=None) -> Trainer:
+def mocking_trainer(
+    file=None, optimizer=_mocking_optim, checkpoint=None, logger=None
+) -> Trainer:
     trainer = Trainer(
         collector=MockingCollector(),
         total_frames=None,
@@ -125,6 +151,7 @@ def mocking_trainer(file=None, optimizer=_mocking_optim, checkpoint=None) -> Tra
         optim_steps_per_batch=None,
         loss_module=MockingLossModule(),
         optimizer=optimizer,
+        logger=logger,
         save_trainer_file=file,
         checkpoint=checkpoint,
     )
@@ -154,6 +181,16 @@ def test_unified_trainer_checkpoint(tmp_path, format):
     restored.load_from_file(path)
     assert restored.collected_frames == 41
     assert restored._optim_count == 7
+
+
+def test_unified_trainer_default_component_selection(tmp_path):
+    path = tmp_path / "trainer-checkpoint"
+    trainer = mocking_trainer(
+        file=path,
+        checkpoint=Checkpoint(save_components={"trainer_state"}),
+    )
+    trainer.save_trainer(force_save=True)
+    assert set(Checkpoint.manifest(path)["components"]) == {"trainer_state"}
 
 
 class TestSelectKeys:
@@ -251,6 +288,107 @@ class TestSelectKeys:
 
 
 class TestLoadFromFile:
+    def test_unified_load_options_strictness_and_save_format(
+        self, tmp_path, monkeypatch
+    ):
+        file = tmp_path / "unified"
+        source = mocking_trainer(file=file, checkpoint=Checkpoint())
+        source.collected_frames = 11
+        source.save_trainer(force_save=True)
+
+        captured = []
+        true_load = torch.load
+
+        def spy_load(*args, **kwargs):
+            captured.append(kwargs.copy())
+            return true_load(*args, **kwargs)
+
+        monkeypatch.setattr(torch, "load", spy_load)
+        restored_default = mocking_trainer()
+        restored_default.load_from_file(file)
+        assert restored_default.collected_frames == 11
+        assert restored_default.checkpoint is None
+        assert captured
+        assert all(
+            call
+            == {
+                "weights_only": True,
+                "mmap": True,
+                "map_location": "cpu",
+            }
+            for call in captured
+        )
+
+        captured.clear()
+        restored = mocking_trainer(logger=MockingLogger())
+        restored.load_from_file(
+            file,
+            strict="ignore",
+            map_location="cpu",
+            weights_only=True,
+            mmap=False,
+        )
+        assert restored.collected_frames == 11
+        assert restored.checkpoint is None
+        assert captured
+        assert all(
+            call
+            == {
+                "weights_only": True,
+                "mmap": False,
+                "map_location": "cpu",
+            }
+            for call in captured
+        )
+
+    @pytest.mark.parametrize("format", ["directory", "archive"])
+    def test_unified_hook_replay_buffer_roundtrip(self, tmp_path, format):
+        file = tmp_path / "unified"
+        source = mocking_trainer(file=file, checkpoint=Checkpoint(format=format))
+        replay_buffer = TensorDictReplayBuffer(storage=LazyTensorStorage(10))
+        ReplayBufferTrainer(replay_buffer=replay_buffer, batch_size=2).register(source)
+        data = TensorDict({"obs": torch.randn(6, 4)}, [6])
+        replay_buffer.extend(data)
+        source.save_trainer(force_save=True)
+        assert "replay_buffer" in Checkpoint.manifest(file)["components"]
+
+        restored = mocking_trainer(checkpoint=Checkpoint())
+        restored_replay_buffer = TensorDictReplayBuffer(storage=LazyTensorStorage(10))
+        ReplayBufferTrainer(
+            replay_buffer=restored_replay_buffer, batch_size=2
+        ).register(restored)
+        restored.load_from_file(file)
+        torch.testing.assert_close(restored_replay_buffer[:]["obs"], data["obs"])
+
+    def test_unified_hook_owned_replay_buffer_state(self, tmp_path):
+        file = tmp_path / "unified"
+        source = mocking_trainer(file=file, checkpoint=Checkpoint())
+        source_hook = MockingReplayBufferHook(0.75)
+        source.register_module("replay_buffer", source_hook)
+        assert source.checkpoint.components["replay_buffer"] is source_hook
+        source.save_trainer(force_save=True)
+
+        restored = mocking_trainer(checkpoint=Checkpoint())
+        restored_hook = MockingReplayBufferHook()
+        restored.register_module("replay_buffer", restored_hook)
+        restored.load_from_file(file)
+        assert restored_hook.fraction == 0.75
+
+    def test_legacy_save_warning_categories(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CKPT_BACKEND", "torch")
+        trainer = mocking_trainer(file=tmp_path / "legacy.pt")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            trainer.save_trainer(force_save=True)
+        assert any(
+            item.category is FutureWarning and "v0.15" in str(item.message)
+            for item in caught
+        )
+        assert any(
+            item.category is DeprecationWarning and "v0.16" in str(item.message)
+            for item in caught
+        )
+
     def test_torch_backend_mmap_default(self, monkeypatch):
         monkeypatch.setenv("CKPT_BACKEND", "torch")
         captured = {}

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -21,6 +21,7 @@ from torch import nn
 _has_tb = importlib.util.find_spec("tensorboard") is not None
 
 from tensordict import TensorDict
+from torchrl.checkpoint import Checkpoint
 from torchrl.data import (
     LazyMemmapStorage,
     LazyTensorStorage,
@@ -31,11 +32,14 @@ from torchrl.data import (
 from torchrl.envs.libs.gym import _has_gym
 from torchrl.testing import PONG_VERSIONED
 from torchrl.trainers import LogValidationReward, Trainer
+from torchrl.trainers.algorithms.a2c import A2CTrainer
 from torchrl.trainers.algorithms.cql import CQLTrainer
 from torchrl.trainers.algorithms.ddpg import DDPGTrainer
 from torchrl.trainers.algorithms.dqn import DQNTrainer
 from torchrl.trainers.algorithms.iql import IQLTrainer
+from torchrl.trainers.algorithms.offline_to_online import OfflineToOnlineTrainer
 from torchrl.trainers.algorithms.ppo import PPOTrainer
+from torchrl.trainers.algorithms.reinforce import ReinforceTrainer
 from torchrl.trainers.algorithms.sac import SACTrainer
 from torchrl.trainers.algorithms.td3 import TD3Trainer
 from torchrl.trainers.helpers import transformed_env_constructor
@@ -113,7 +117,7 @@ class MockingLossModule(nn.Module):
 _mocking_optim = MockingOptim()
 
 
-def mocking_trainer(file=None, optimizer=_mocking_optim) -> Trainer:
+def mocking_trainer(file=None, optimizer=_mocking_optim, checkpoint=None) -> Trainer:
     trainer = Trainer(
         collector=MockingCollector(),
         total_frames=None,
@@ -122,9 +126,34 @@ def mocking_trainer(file=None, optimizer=_mocking_optim) -> Trainer:
         loss_module=MockingLossModule(),
         optimizer=optimizer,
         save_trainer_file=file,
+        checkpoint=checkpoint,
     )
     trainer._pbar_str = OrderedDict()
     return trainer
+
+
+@pytest.mark.parametrize("format", ["directory", "archive"])
+def test_unified_trainer_checkpoint(tmp_path, format):
+    path = tmp_path / "trainer-checkpoint"
+    trainer = mocking_trainer(
+        file=path,
+        checkpoint=Checkpoint(format=format),
+    )
+    assert {"collector", "loss_module", "trainer_state"}.issubset(
+        trainer.checkpoint.components
+    )
+    trainer.collected_frames = 41
+    trainer._optim_count = 7
+    trainer.save_trainer(force_save=True)
+    manifest = Checkpoint.manifest(path)
+    assert {"collector", "loss_module", "trainer_state"}.issubset(
+        manifest["components"]
+    )
+
+    restored = mocking_trainer(checkpoint=Checkpoint())
+    restored.load_from_file(path)
+    assert restored.collected_frames == 41
+    assert restored._optim_count == 7
 
 
 class TestSelectKeys:
@@ -1388,6 +1417,26 @@ class TestPostOptimCompleteLog:
             "auto_log_optim_steps" in sig.parameters
         ), f"{trainer_cls.__name__}.__init__ must accept auto_log_optim_steps"
         assert sig.parameters["auto_log_optim_steps"].default is True
+
+    @pytest.mark.parametrize(
+        "trainer_cls",
+        [
+            A2CTrainer,
+            CQLTrainer,
+            DDPGTrainer,
+            DQNTrainer,
+            IQLTrainer,
+            OfflineToOnlineTrainer,
+            PPOTrainer,
+            ReinforceTrainer,
+            SACTrainer,
+            TD3Trainer,
+        ],
+    )
+    def test_subclass_exposes_checkpoint(self, trainer_cls):
+        """Every algorithm trainer must expose the unified checkpoint argument."""
+        parameter = inspect.signature(trainer_cls.__init__).parameters["checkpoint"]
+        assert parameter.default is None
 
 
 class TestDefaultOptimizationStepper:

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -309,9 +309,7 @@ class TestLoadFromFile:
         restored_default.load_from_file(file)
         assert restored_default.collected_frames == 11
         assert restored_default.checkpoint is None
-        assert captured
-        expected_defaults = {**_torch_load_defaults(), "map_location": "cpu"}
-        assert all(call == expected_defaults for call in captured)
+        assert not captured
 
         captured.clear()
         restored = mocking_trainer(logger=MockingLogger())
@@ -324,16 +322,7 @@ class TestLoadFromFile:
         )
         assert restored.collected_frames == 11
         assert restored.checkpoint is None
-        assert captured
-        assert all(
-            call
-            == {
-                "weights_only": True,
-                "mmap": False,
-                "map_location": "cpu",
-            }
-            for call in captured
-        )
+        assert not captured
 
     @pytest.mark.parametrize("format", ["directory", "archive"])
     def test_unified_hook_replay_buffer_roundtrip(self, tmp_path, format):

--- a/torchrl/checkpoint/__init__.py
+++ b/torchrl/checkpoint/__init__.py
@@ -1,0 +1,33 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+from ._checkpoint import (
+    Checkpoint,
+    CheckpointAdapter,
+    CheckpointError,
+    CheckpointFormat,
+    CheckpointLoadResult,
+    CheckpointOptions,
+    CheckpointStrictness,
+    DumpLoadCheckpointAdapter,
+    GlobalRNGState,
+    JSONCheckpointAdapter,
+    StateDictCheckpointAdapter,
+)
+
+__all__ = [
+    "Checkpoint",
+    "CheckpointAdapter",
+    "CheckpointError",
+    "CheckpointFormat",
+    "CheckpointLoadResult",
+    "CheckpointOptions",
+    "CheckpointStrictness",
+    "DumpLoadCheckpointAdapter",
+    "GlobalRNGState",
+    "JSONCheckpointAdapter",
+    "StateDictCheckpointAdapter",
+]

--- a/torchrl/checkpoint/__init__.py
+++ b/torchrl/checkpoint/__init__.py
@@ -16,6 +16,7 @@ from ._checkpoint import (
     GlobalRNGState,
     JSONCheckpointAdapter,
     StateDictCheckpointAdapter,
+    StateDictFormat,
 )
 
 __all__ = [
@@ -30,4 +31,5 @@ __all__ = [
     "GlobalRNGState",
     "JSONCheckpointAdapter",
     "StateDictCheckpointAdapter",
+    "StateDictFormat",
 ]

--- a/torchrl/checkpoint/_checkpoint.py
+++ b/torchrl/checkpoint/_checkpoint.py
@@ -607,7 +607,7 @@ class GlobalRNGState:
         numpy_state = np.random.get_state()
         state["numpy"] = (
             numpy_state[0],
-            torch.from_numpy(numpy_state[1].copy()),
+            torch.from_numpy(numpy_state[1].astype(np.int64, copy=True)),
             numpy_state[2],
             numpy_state[3],
             numpy_state[4],

--- a/torchrl/checkpoint/_checkpoint.py
+++ b/torchrl/checkpoint/_checkpoint.py
@@ -947,7 +947,7 @@ class Checkpoint:
     def _local_path(path: str | Path) -> Path:
         if "://" in str(path):
             raise ValueError(
-                f"Only local checkpoint paths are supported in format v1, got {path!s}."
+                f"Only local checkpoint paths are supported, got {path!s}."
             )
         return Path(path).expanduser().absolute()
 

--- a/torchrl/checkpoint/_checkpoint.py
+++ b/torchrl/checkpoint/_checkpoint.py
@@ -1,0 +1,998 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import abc
+import hashlib
+import importlib.metadata
+import json
+import os
+import random
+import shutil
+import tempfile
+import uuid
+import zipfile
+from collections.abc import Callable, Collection, Mapping, MutableMapping
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import quote
+
+import numpy as np
+import torch
+
+from torchrl import __version__ as torchrl_version
+from torchrl._utils import logger as torchrl_logger
+
+CheckpointFormat = Literal["directory", "archive"]
+CheckpointStrictness = Literal["error", "warn", "ignore"]
+ArchiveCompression = Literal["stored", "deflate"]
+
+_MANIFEST_NAME = "manifest.json"
+_FORMAT_NAME = "torchrl.checkpoint"
+_FORMAT_VERSION = 1
+
+
+def _to_json_value(value: Any) -> Any:
+    if isinstance(value, torch.Tensor):
+        value = value.detach().cpu()
+        return value.item() if value.numel() == 1 else value.tolist()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(key): _to_json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_json_value(item) for item in value]
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    raise TypeError(f"Value of type {type(value).__name__} is not JSON-compatible.")
+
+
+class CheckpointError(RuntimeError):
+    """Error raised when a checkpoint cannot be saved or restored.
+
+    Args:
+        message: Description of the checkpoint failure.
+        result: Optional partial load result associated with the failure.
+
+    Examples:
+        >>> from torchrl.checkpoint import CheckpointError
+        >>> error = CheckpointError("invalid checkpoint")
+        >>> str(error)
+        'invalid checkpoint'
+    """
+
+    def __init__(
+        self, message: str, result: CheckpointLoadResult | None = None
+    ) -> None:
+        super().__init__(message)
+        self.result = result
+
+
+@dataclass(frozen=True)
+class CheckpointOptions:
+    """Arguments forwarded to a component's serialization methods.
+
+    Operation-level options are merged over registration-time options. Keyword
+    arguments are shallow-merged and explicitly supplied positional arguments
+    replace the registration-time tuple.
+
+    Args:
+        save_args: Positional arguments forwarded after the checkpoint path for
+            ``dump`` adapters, or to ``state_dict`` for state-dict adapters.
+        save_kwargs: Keyword arguments forwarded during saving.
+        load_args: Positional arguments forwarded after the checkpoint path for
+            ``load`` adapters, or after the state mapping for state-dict adapters.
+        load_kwargs: Keyword arguments forwarded during restoration.
+
+    Examples:
+        >>> from torchrl.checkpoint import CheckpointOptions
+        >>> options = CheckpointOptions(save_kwargs={"compression": "zstd"})
+        >>> options.save_kwargs["compression"]
+        'zstd'
+    """
+
+    save_args: tuple[Any, ...] | None = None
+    save_kwargs: Mapping[str, Any] | None = None
+    load_args: tuple[Any, ...] | None = None
+    load_kwargs: Mapping[str, Any] | None = None
+
+    def merged(self, override: CheckpointOptions | None) -> CheckpointOptions:
+        """Return these options with an operation-level override applied."""
+        if override is None:
+            return self
+        save_kwargs = dict(self.save_kwargs or {})
+        save_kwargs.update(override.save_kwargs or {})
+        load_kwargs = dict(self.load_kwargs or {})
+        load_kwargs.update(override.load_kwargs or {})
+        return CheckpointOptions(
+            save_args=self.save_args
+            if override.save_args is None
+            else override.save_args,
+            save_kwargs=save_kwargs,
+            load_args=self.load_args
+            if override.load_args is None
+            else override.load_args,
+            load_kwargs=load_kwargs,
+        )
+
+
+@dataclass
+class CheckpointLoadResult:
+    """Structured result returned by :meth:`Checkpoint.load`.
+
+    Args:
+        loaded: Components restored successfully.
+        missing: Requested components absent from the checkpoint.
+        incompatible: Components that could not be restored, mapped to reasons.
+        unrequested: Manifest components intentionally not requested.
+        values: Values returned by adapters, including immutable JSON components.
+        manifest: Parsed checkpoint manifest.
+
+    Examples:
+        >>> from torchrl.checkpoint import CheckpointLoadResult
+        >>> result = CheckpointLoadResult()
+        >>> result.loaded
+        set()
+    """
+
+    loaded: set[str] = field(default_factory=set)
+    missing: set[str] = field(default_factory=set)
+    incompatible: dict[str, str] = field(default_factory=dict)
+    unrequested: set[str] = field(default_factory=set)
+    values: dict[str, Any] = field(default_factory=dict)
+    manifest: dict[str, Any] = field(default_factory=dict)
+
+
+class CheckpointAdapter(abc.ABC):
+    """Interface used to save and restore one checkpoint component.
+
+    Adapters receive a real local directory even when the outer checkpoint is
+    an archive. Custom adapters can therefore write any number of files without
+    depending on the container implementation.
+
+    Examples:
+        >>> from torchrl.checkpoint import CheckpointAdapter
+        >>> issubclass(CheckpointAdapter, object)
+        True
+    """
+
+    adapter_id: str
+    format_version: int = 1
+
+    @abc.abstractmethod
+    def save(
+        self,
+        component: Any,
+        path: Path,
+        *,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        """Save ``component`` below ``path``."""
+
+    @abc.abstractmethod
+    def load(
+        self,
+        component: Any,
+        path: Path,
+        *,
+        map_location: Any,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        """Restore ``component`` from ``path`` and optionally return a value."""
+
+
+class DumpLoadCheckpointAdapter(CheckpointAdapter):
+    """Adapter for objects exposing ``dump(path)`` and ``load(path)``.
+
+    Examples:
+        >>> from torchrl.checkpoint import DumpLoadCheckpointAdapter
+        >>> DumpLoadCheckpointAdapter().adapter_id
+        'torchrl.dump_load'
+    """
+
+    adapter_id = "torchrl.dump_load"
+
+    def save(
+        self,
+        component: Any,
+        path: Path,
+        *,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        path.mkdir(parents=True, exist_ok=True)
+        return component.dump(path, *args, **kwargs)
+
+    def load(
+        self,
+        component: Any,
+        path: Path,
+        *,
+        map_location: Any,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        del map_location
+        component.load(path, *args, **kwargs)
+        return None
+
+
+class StateDictCheckpointAdapter(CheckpointAdapter):
+    """Adapter for ``state_dict`` / ``load_state_dict`` objects.
+
+    Examples:
+        >>> from torchrl.checkpoint import StateDictCheckpointAdapter
+        >>> StateDictCheckpointAdapter().adapter_id
+        'torchrl.state_dict'
+    """
+
+    adapter_id = "torchrl.state_dict"
+    state_filename = "state.pt"
+
+    def save(
+        self,
+        component: Any,
+        path: Path,
+        *,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        path.mkdir(parents=True, exist_ok=True)
+        state = component.state_dict(*args, **kwargs)
+        torch.save(state, path / self.state_filename)
+        return state
+
+    def load(
+        self,
+        component: Any,
+        path: Path,
+        *,
+        map_location: Any,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        load_kwargs: dict[str, Any] = {"weights_only": False}
+        if map_location is not None:
+            load_kwargs["map_location"] = map_location
+        state = torch.load(path / self.state_filename, **load_kwargs)
+        component.load_state_dict(state, *args, **kwargs)
+        return None
+
+
+class JSONCheckpointAdapter(CheckpointAdapter):
+    """Adapter for JSON-compatible configuration, metrics, and metadata.
+
+    Mutable mappings and lists are updated in place during restoration. Other
+    values are returned through :attr:`CheckpointLoadResult.values`.
+
+    Examples:
+        >>> from torchrl.checkpoint import JSONCheckpointAdapter
+        >>> JSONCheckpointAdapter().adapter_id
+        'torchrl.json'
+    """
+
+    adapter_id = "torchrl.json"
+    state_filename = "value.json"
+
+    def save(
+        self,
+        component: Any,
+        path: Path,
+        *,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        if args or kwargs:
+            raise TypeError("JSON checkpoint components do not accept save options.")
+        path.mkdir(parents=True, exist_ok=True)
+        with (path / self.state_filename).open("w", encoding="utf-8") as file:
+            json.dump(_to_json_value(component), file, indent=2, sort_keys=True)
+        return component
+
+    def load(
+        self,
+        component: Any,
+        path: Path,
+        *,
+        map_location: Any,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        del map_location
+        if args or kwargs:
+            raise TypeError("JSON checkpoint components do not accept load options.")
+        with (path / self.state_filename).open(encoding="utf-8") as file:
+            value = json.load(file)
+        if isinstance(component, MutableMapping) and isinstance(value, Mapping):
+            component.clear()
+            component.update(value)
+            return component
+        if isinstance(component, list) and isinstance(value, list):
+            component[:] = value
+            return component
+        return value
+
+
+class GlobalRNGState:
+    """Checkpointable process-global random-number-generator state.
+
+    The object captures Python, NumPy, Torch CPU, and initialized accelerator
+    RNGs when :meth:`state_dict` is called.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.checkpoint import GlobalRNGState
+        >>> state = GlobalRNGState().state_dict()
+        >>> "torch_cpu" in state
+        True
+    """
+
+    def state_dict(self) -> dict[str, Any]:
+        """Capture all supported process-global RNG state."""
+        state: dict[str, Any] = {
+            "python": random.getstate(),
+            "numpy": np.random.get_state(),
+            "torch_cpu": torch.random.get_rng_state(),
+        }
+        if torch.cuda.is_initialized() and torch.cuda.is_available():
+            state["torch_cuda"] = torch.cuda.get_rng_state_all()
+        xpu = getattr(torch, "xpu", None)
+        if (
+            xpu is not None
+            and getattr(xpu, "is_initialized", lambda: False)()
+            and xpu.is_available()
+        ):
+            state["torch_xpu"] = xpu.get_rng_state_all()
+        mps = getattr(torch, "mps", None)
+        mps_backend = getattr(torch.backends, "mps", None)
+        if (
+            mps is not None
+            and mps_backend is not None
+            and getattr(mps, "_default_mps_generator", None) is not None
+            and mps_backend.is_available()
+        ):
+            state["torch_mps"] = mps.get_rng_state()
+        return state
+
+    def load_state_dict(self, state_dict: Mapping[str, Any]) -> None:
+        """Restore process-global RNG state."""
+        random.setstate(state_dict["python"])
+        np.random.set_state(state_dict["numpy"])
+        torch.random.set_rng_state(state_dict["torch_cpu"].cpu())
+        if "torch_cuda" in state_dict:
+            if not torch.cuda.is_available():
+                raise RuntimeError(
+                    "Checkpoint contains CUDA RNG state but CUDA is unavailable."
+                )
+            torch.cuda.set_rng_state_all(
+                [rng_state.cpu() for rng_state in state_dict["torch_cuda"]]
+            )
+        if "torch_xpu" in state_dict:
+            xpu = getattr(torch, "xpu", None)
+            if xpu is None or not xpu.is_available():
+                raise RuntimeError(
+                    "Checkpoint contains XPU RNG state but XPU is unavailable."
+                )
+            xpu.set_rng_state_all(
+                [rng_state.cpu() for rng_state in state_dict["torch_xpu"]]
+            )
+        if "torch_mps" in state_dict:
+            mps = getattr(torch, "mps", None)
+            mps_backend = getattr(torch.backends, "mps", None)
+            if mps is None or mps_backend is None or not mps_backend.is_available():
+                raise RuntimeError(
+                    "Checkpoint contains MPS RNG state but MPS is unavailable."
+                )
+            mps.set_rng_state(state_dict["torch_mps"].cpu())
+
+
+@dataclass
+class _Component:
+    value: Any
+    adapter: CheckpointAdapter | None
+    options: CheckpointOptions
+
+
+class Checkpoint:
+    """Standard TorchRL checkpoint coordinator.
+
+    Components are bound to the checkpoint and may be independently selected
+    for each save or restore. The default directory format supports direct,
+    lazy access to component payloads; ``format="archive"`` stores the same
+    manifest and component tree in one ZIP file.
+
+    Args:
+        format: Default output format, ``"directory"`` or ``"archive"``.
+        strict: Default restoration behavior for missing or incompatible
+            requested components.
+        archive_compression: ``"stored"`` avoids recompressing payloads;
+            ``"deflate"`` enables ZIP deflate compression.
+        **components: Named objects or JSON-compatible values to register.
+
+    Examples:
+        >>> import tempfile
+        >>> import torch
+        >>> from torchrl.checkpoint import Checkpoint
+        >>> source = torch.nn.Linear(2, 1)
+        >>> target = torch.nn.Linear(2, 1)
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     Checkpoint(policy=source).save(f"{tmpdir}/checkpoint")
+        ...     result = Checkpoint(policy=target).load(f"{tmpdir}/checkpoint")
+        >>> result.loaded
+        {'policy'}
+    """
+
+    _format_migrations: dict[int, Callable[[dict[str, Any]], dict[str, Any]]] = {}
+
+    def __init__(
+        self,
+        *,
+        format: CheckpointFormat = "directory",
+        strict: CheckpointStrictness = "error",
+        archive_compression: ArchiveCompression = "stored",
+        **components: Any,
+    ) -> None:
+        self._validate_format(format)
+        self._validate_strict(strict)
+        if archive_compression not in ("stored", "deflate"):
+            raise ValueError(
+                "archive_compression must be 'stored' or 'deflate', got "
+                f"{archive_compression!r}."
+            )
+        self.format = format
+        self.strict = strict
+        self.archive_compression = archive_compression
+        self._components: dict[str, _Component] = {}
+        self._adapter_registry: list[tuple[type, CheckpointAdapter]] = []
+        for name, component in components.items():
+            self.register(name, component)
+
+    @property
+    def components(self) -> Mapping[str, Any]:
+        """Read-only mapping view of registered component values."""
+        return {name: component.value for name, component in self._components.items()}
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._components
+
+    def register(
+        self,
+        name: str,
+        component: Any,
+        *,
+        adapter: CheckpointAdapter | None = None,
+        options: CheckpointOptions | None = None,
+    ) -> Checkpoint:
+        """Register a named component and return ``self``.
+
+        Args:
+            name: Stable manifest component name.
+            component: Live object or JSON-compatible value.
+            adapter: Optional explicit serialization adapter.
+            options: Persistent component method arguments.
+
+        Returns:
+            This checkpoint.
+        """
+        self._validate_component_name(name)
+        if name in self._components:
+            raise KeyError(f"Checkpoint component {name!r} is already registered.")
+        if adapter is not None and not isinstance(adapter, CheckpointAdapter):
+            raise TypeError("adapter must be a CheckpointAdapter instance.")
+        self._components[name] = _Component(
+            component, adapter, options or CheckpointOptions()
+        )
+        return self
+
+    def register_adapter(
+        self, component_type: type, adapter: CheckpointAdapter
+    ) -> Checkpoint:
+        """Register an adapter for a type on this checkpoint instance."""
+        if not isinstance(component_type, type):
+            raise TypeError("component_type must be a type.")
+        if not isinstance(adapter, CheckpointAdapter):
+            raise TypeError("adapter must be a CheckpointAdapter instance.")
+        self._adapter_registry.insert(0, (component_type, adapter))
+        return self
+
+    def save(
+        self,
+        path: str | Path,
+        *,
+        components: Collection[str] | None = None,
+        component_options: Mapping[str, CheckpointOptions] | None = None,
+        format: CheckpointFormat | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Path:
+        """Save selected registered components atomically.
+
+        Args:
+            path: Local checkpoint destination.
+            components: Component names to save. ``None`` saves all.
+            component_options: Per-operation option overrides.
+            format: Per-operation container override.
+            metadata: JSON-compatible manifest metadata.
+
+        Returns:
+            Expanded destination path.
+        """
+        destination = self._local_path(path)
+        output_format = self.format if format is None else format
+        self._validate_format(output_format)
+        selected = self._selection(components)
+        options = component_options or {}
+        unknown_options = set(options).difference(selected)
+        if unknown_options:
+            raise KeyError(
+                "Options were provided for unselected checkpoint components: "
+                f"{sorted(unknown_options)}."
+            )
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        stage = Path(
+            tempfile.mkdtemp(
+                prefix=f".{destination.name}.stage-", dir=destination.parent
+            )
+        )
+        try:
+            component_records: dict[str, Any] = {}
+            for index, name in enumerate(sorted(selected)):
+                registration = self._components[name]
+                adapter = self._resolve_adapter(registration)
+                relative_path = Path("components") / self._component_dir(index, name)
+                component_path = stage / relative_path
+                resolved_options = registration.options.merged(options.get(name))
+                adapter.save(
+                    registration.value,
+                    component_path,
+                    args=resolved_options.save_args or (),
+                    kwargs=resolved_options.save_kwargs or {},
+                )
+                files = sorted(
+                    str(file.relative_to(component_path))
+                    for file in component_path.rglob("*")
+                    if file.is_file()
+                )
+                component_records[name] = {
+                    "adapter": adapter.adapter_id,
+                    "adapter_version": adapter.format_version,
+                    "path": str(relative_path),
+                    "files": files,
+                }
+            manifest = self._new_manifest(
+                output_format, component_records, metadata or {}
+            )
+            with (stage / _MANIFEST_NAME).open("w", encoding="utf-8") as file:
+                json.dump(manifest, file, indent=2, sort_keys=True)
+                file.write("\n")
+            if output_format == "directory":
+                self._publish_path(stage, destination)
+                stage = None
+            else:
+                archive = destination.parent / (
+                    f".{destination.name}.archive-{uuid.uuid4().hex}"
+                )
+                try:
+                    compression = (
+                        zipfile.ZIP_STORED
+                        if self.archive_compression == "stored"
+                        else zipfile.ZIP_DEFLATED
+                    )
+                    with zipfile.ZipFile(archive, "w", compression=compression) as file:
+                        for source in sorted(stage.rglob("*")):
+                            if source.is_file():
+                                file.write(source, source.relative_to(stage))
+                    self._publish_path(archive, destination)
+                finally:
+                    self._remove_path(archive)
+            return destination
+        finally:
+            if stage is not None:
+                self._remove_path(stage)
+
+    def load(
+        self,
+        path: str | Path,
+        *,
+        components: Collection[str] | None = None,
+        component_options: Mapping[str, CheckpointOptions] | None = None,
+        map_location: Any = None,
+        strict: CheckpointStrictness | None = None,
+    ) -> CheckpointLoadResult:
+        """Restore selected components from a local checkpoint.
+
+        Args:
+            path: Directory or archive checkpoint.
+            components: Registered names to restore. ``None`` selects all
+                registered components.
+            component_options: Per-operation option overrides.
+            map_location: Device mapping used while reading tensor payloads.
+            strict: Per-operation strictness override.
+
+        Returns:
+            A structured component load report.
+        """
+        source = self._local_path(path)
+        load_strict = self.strict if strict is None else strict
+        self._validate_strict(load_strict)
+        manifest = self.manifest(source)
+        requested = self._selection(components)
+        manifest_components: Mapping[str, Any] = manifest["components"]
+        result = CheckpointLoadResult(
+            missing=requested.difference(manifest_components),
+            unrequested=set(manifest_components).difference(requested),
+            manifest=manifest,
+        )
+        options = component_options or {}
+        unknown_options = set(options).difference(requested)
+        if unknown_options:
+            raise KeyError(
+                "Options were provided for unrequested checkpoint components: "
+                f"{sorted(unknown_options)}."
+            )
+        adapters: dict[str, CheckpointAdapter] = {}
+        for name in requested.intersection(manifest_components):
+            registration = self._components[name]
+            try:
+                adapter = self._resolve_adapter(registration)
+            except Exception as error:
+                result.incompatible[name] = str(error)
+                continue
+            record = manifest_components[name]
+            if record["adapter"] != adapter.adapter_id:
+                result.incompatible[name] = (
+                    f"manifest adapter is {record['adapter']!r}, target adapter is "
+                    f"{adapter.adapter_id!r}"
+                )
+                continue
+            if record["adapter_version"] != adapter.format_version:
+                result.incompatible[name] = (
+                    f"manifest adapter version is {record['adapter_version']}, target "
+                    f"adapter version is {adapter.format_version}"
+                )
+                continue
+            adapters[name] = adapter
+        self._handle_load_issues(result, load_strict)
+        selected_records = {name: manifest_components[name] for name in adapters}
+        with self._materialize(source, manifest, selected_records) as root:
+            for name in sorted(adapters):
+                registration = self._components[name]
+                resolved_options = registration.options.merged(options.get(name))
+                record = manifest_components[name]
+                try:
+                    value = adapters[name].load(
+                        registration.value,
+                        root / record["path"],
+                        map_location=map_location,
+                        args=resolved_options.load_args or (),
+                        kwargs=resolved_options.load_kwargs or {},
+                    )
+                except Exception as error:
+                    result.incompatible[name] = str(error)
+                    if load_strict == "error":
+                        raise CheckpointError(
+                            f"Failed to load checkpoint component {name!r}: {error}",
+                            result,
+                        ) from error
+                    if load_strict == "warn":
+                        torchrl_logger.warning(
+                            "Failed to load checkpoint component %r: %s", name, error
+                        )
+                    continue
+                result.loaded.add(name)
+                if value is not None:
+                    result.values[name] = value
+        return result
+
+    @classmethod
+    def is_checkpoint(cls, path: str | Path) -> bool:
+        """Return whether ``path`` contains a TorchRL checkpoint manifest."""
+        try:
+            cls.manifest(path)
+        except (CheckpointError, OSError, TypeError, ValueError):
+            return False
+        return True
+
+    @classmethod
+    def register_migration(
+        cls,
+        from_version: int,
+        migration: Callable[[dict[str, Any]], dict[str, Any]],
+    ) -> None:
+        """Register one manifest migration from ``from_version`` to the next.
+
+        Migrations must return a new manifest whose ``format_version`` is
+        exactly ``from_version + 1``. Payload migrations remain the
+        responsibility of the component adapter identified by the migrated
+        manifest.
+        """
+        if not isinstance(from_version, int) or from_version < 0:
+            raise ValueError("from_version must be a non-negative integer.")
+        if not callable(migration):
+            raise TypeError("migration must be callable.")
+        cls._format_migrations[from_version] = migration
+
+    @classmethod
+    def manifest(cls, path: str | Path) -> dict[str, Any]:
+        """Read and validate a checkpoint manifest without loading payloads."""
+        source = cls._local_path(path)
+        if not source.exists():
+            raise FileNotFoundError(f"Checkpoint path does not exist: {source}.")
+        try:
+            if source.is_dir():
+                with (source / _MANIFEST_NAME).open(encoding="utf-8") as file:
+                    manifest = json.load(file)
+            elif zipfile.is_zipfile(source):
+                with zipfile.ZipFile(source) as archive:
+                    with archive.open(_MANIFEST_NAME) as file:
+                        manifest = json.load(file)
+            else:
+                raise CheckpointError(
+                    f"Path is not a TorchRL checkpoint directory or archive: {source}."
+                )
+        except (KeyError, json.JSONDecodeError, zipfile.BadZipFile) as error:
+            raise CheckpointError(
+                f"Invalid checkpoint manifest at {source}."
+            ) from error
+        if manifest.get("format") != _FORMAT_NAME:
+            raise CheckpointError(
+                f"Path does not contain a TorchRL checkpoint: {source}."
+            )
+        version = manifest.get("format_version")
+        if (
+            isinstance(version, int)
+            and not isinstance(version, bool)
+            and version < _FORMAT_VERSION
+        ):
+            while version < _FORMAT_VERSION:
+                migration = cls._format_migrations.get(version)
+                if migration is None:
+                    raise CheckpointError(
+                        f"Unsupported older checkpoint format version {version!r}; "
+                        f"no migration to version {version + 1} is registered."
+                    )
+                manifest = migration(dict(manifest))
+                next_version = manifest.get("format_version")
+                if next_version != version + 1 or isinstance(next_version, bool):
+                    raise CheckpointError(
+                        f"Checkpoint migration from version {version} returned "
+                        f"version {next_version!r}; expected {version + 1}."
+                    )
+                version = next_version
+        if version != _FORMAT_VERSION or isinstance(version, bool):
+            direction = (
+                "newer"
+                if isinstance(version, int)
+                and not isinstance(version, bool)
+                and version > 1
+                else "invalid"
+            )
+            raise CheckpointError(
+                f"Unsupported {direction} checkpoint format version {version!r}; "
+                f"this build supports version {_FORMAT_VERSION}."
+            )
+        if not isinstance(manifest.get("components"), dict):
+            raise CheckpointError("Checkpoint manifest has no component mapping.")
+        for name, record in manifest["components"].items():
+            cls._validate_component_record(name, record)
+        return manifest
+
+    def _resolve_adapter(self, component: _Component) -> CheckpointAdapter:
+        if component.adapter is not None:
+            return component.adapter
+        for component_type, adapter in self._adapter_registry:
+            if isinstance(component.value, component_type):
+                return adapter
+        dump = getattr(component.value, "dump", None)
+        load = getattr(component.value, "load", None)
+        if callable(dump) and callable(load):
+            return DumpLoadCheckpointAdapter()
+        state_dict = getattr(component.value, "state_dict", None)
+        load_state_dict = getattr(component.value, "load_state_dict", None)
+        if callable(state_dict) and callable(load_state_dict):
+            return StateDictCheckpointAdapter()
+        if self._is_json_value(component.value):
+            return JSONCheckpointAdapter()
+        raise TypeError(
+            f"No checkpoint adapter could be inferred for {type(component.value).__name__}. "
+            "Provide an adapter, implement dump/load, or implement "
+            "state_dict/load_state_dict."
+        )
+
+    def _selection(self, components: Collection[str] | None) -> set[str]:
+        selected = set(self._components) if components is None else set(components)
+        unknown = selected.difference(self._components)
+        if unknown:
+            raise KeyError(f"Unregistered checkpoint components: {sorted(unknown)}.")
+        return selected
+
+    @staticmethod
+    def _new_manifest(
+        format: CheckpointFormat,
+        components: Mapping[str, Any],
+        metadata: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        if not Checkpoint._is_json_value(metadata):
+            raise TypeError("Checkpoint manifest metadata must be JSON-compatible.")
+        try:
+            tensordict_version = importlib.metadata.version("tensordict")
+        except importlib.metadata.PackageNotFoundError:
+            tensordict_version = None
+        return {
+            "format": _FORMAT_NAME,
+            "format_version": _FORMAT_VERSION,
+            "container": format,
+            "checkpoint_id": uuid.uuid4().hex,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "versions": {
+                "torchrl": torchrl_version,
+                "tensordict": tensordict_version,
+                "torch": torch.__version__,
+            },
+            "metadata": _to_json_value(metadata),
+            "components": dict(components),
+        }
+
+    @classmethod
+    @contextmanager
+    def _materialize(
+        cls,
+        source: Path,
+        manifest: Mapping[str, Any],
+        records: Mapping[str, Mapping[str, Any]],
+    ):
+        if source.is_dir():
+            yield source
+            return
+        temporary = Path(tempfile.mkdtemp(prefix="torchrl-checkpoint-load-"))
+        try:
+            with zipfile.ZipFile(source) as archive:
+                for record in records.values():
+                    root = Path(record["path"])
+                    (temporary / root).mkdir(parents=True, exist_ok=True)
+                    for relative_file in record["files"]:
+                        member = root / relative_file
+                        cls._validate_archive_member(member)
+                        destination = temporary / member
+                        destination.parent.mkdir(parents=True, exist_ok=True)
+                        with archive.open(str(member)) as source_file:
+                            with destination.open("wb") as destination_file:
+                                shutil.copyfileobj(source_file, destination_file)
+            yield temporary
+        finally:
+            cls._remove_path(temporary)
+
+    @staticmethod
+    def _handle_load_issues(
+        result: CheckpointLoadResult, strict: CheckpointStrictness
+    ) -> None:
+        if not result.missing and not result.incompatible:
+            return
+        parts = []
+        if result.missing:
+            parts.append(f"missing={sorted(result.missing)}")
+        if result.incompatible:
+            parts.append(f"incompatible={result.incompatible}")
+        message = "Checkpoint restore issues: " + ", ".join(parts)
+        if strict == "error":
+            raise CheckpointError(message, result)
+        if strict == "warn":
+            torchrl_logger.warning(message)
+
+    @staticmethod
+    def _publish_path(source: Path, destination: Path) -> None:
+        backup = destination.parent / f".{destination.name}.backup-{uuid.uuid4().hex}"
+        moved_destination = False
+        try:
+            if destination.exists() or destination.is_symlink():
+                os.replace(destination, backup)
+                moved_destination = True
+            os.replace(source, destination)
+        except Exception:
+            if moved_destination and not destination.exists() and backup.exists():
+                os.replace(backup, destination)
+            raise
+        finally:
+            Checkpoint._remove_path(backup)
+
+    @staticmethod
+    def _remove_path(path: Path) -> None:
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+
+    @staticmethod
+    def _local_path(path: str | Path) -> Path:
+        if "://" in str(path):
+            raise ValueError(
+                f"Only local checkpoint paths are supported in format v1, got {path!s}."
+            )
+        return Path(path).expanduser().absolute()
+
+    @staticmethod
+    def _component_dir(index: int, name: str) -> str:
+        return f"{index:04d}-{quote(name, safe='._-')}"
+
+    @staticmethod
+    def _validate_component_name(name: str) -> None:
+        if not isinstance(name, str) or not name or name in (".", ".."):
+            raise ValueError("Checkpoint component names must be non-empty strings.")
+        if "/" in name or "\\" in name:
+            raise ValueError(
+                "Checkpoint component names cannot contain path separators."
+            )
+
+    @staticmethod
+    def _validate_archive_member(path: Path) -> None:
+        if path.is_absolute() or ".." in path.parts:
+            raise CheckpointError(f"Unsafe archive member path: {path}.")
+
+    @classmethod
+    def _validate_component_record(cls, name: Any, record: Any) -> None:
+        if not isinstance(name, str) or not isinstance(record, Mapping):
+            raise CheckpointError("Checkpoint manifest has an invalid component entry.")
+        if (
+            not isinstance(record.get("adapter"), str)
+            or not isinstance(record.get("adapter_version"), int)
+            or isinstance(record.get("adapter_version"), bool)
+        ):
+            raise CheckpointError(
+                f"Checkpoint component {name!r} has invalid adapter metadata."
+            )
+        relative_path = record.get("path")
+        files = record.get("files")
+        if not isinstance(relative_path, str) or not isinstance(files, list):
+            raise CheckpointError(
+                f"Checkpoint component {name!r} has an invalid file inventory."
+            )
+        cls._validate_archive_member(Path(relative_path))
+        for relative_file in files:
+            if not isinstance(relative_file, str):
+                raise CheckpointError(
+                    f"Checkpoint component {name!r} has an invalid file inventory."
+                )
+            cls._validate_archive_member(Path(relative_file))
+
+    @staticmethod
+    def _validate_format(format: str) -> None:
+        if format not in ("directory", "archive"):
+            raise ValueError(
+                f"Checkpoint format must be 'directory' or 'archive', got {format!r}."
+            )
+
+    @staticmethod
+    def _validate_strict(strict: str) -> None:
+        if strict not in ("error", "warn", "ignore"):
+            raise ValueError(
+                "Checkpoint strictness must be 'error', 'warn', or 'ignore', got "
+                f"{strict!r}."
+            )
+
+    @staticmethod
+    def _is_json_value(value: Any) -> bool:
+        try:
+            json.dumps(_to_json_value(value))
+        except (TypeError, ValueError, OverflowError):
+            return False
+        return True
+
+
+def checkpoint_manifest_hash(path: str | Path) -> str:
+    """Return a stable SHA256 digest of a checkpoint manifest."""
+    manifest = Checkpoint.manifest(path)
+    payload = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(payload).hexdigest()

--- a/torchrl/checkpoint/_checkpoint.py
+++ b/torchrl/checkpoint/_checkpoint.py
@@ -5,8 +5,6 @@
 from __future__ import annotations
 
 import abc
-import hashlib
-import importlib.metadata
 import json
 import os
 import random
@@ -23,6 +21,7 @@ from typing import Any, Literal
 from urllib.parse import quote
 
 import numpy as np
+import tensordict
 import torch
 
 from torchrl import __version__ as torchrl_version
@@ -186,6 +185,7 @@ class CheckpointAdapter(abc.ABC):
         path: Path,
         *,
         map_location: Any,
+        tensor_load_kwargs: Mapping[str, Any],
         args: tuple[Any, ...],
         kwargs: Mapping[str, Any],
     ) -> Any:
@@ -220,10 +220,11 @@ class DumpLoadCheckpointAdapter(CheckpointAdapter):
         path: Path,
         *,
         map_location: Any,
+        tensor_load_kwargs: Mapping[str, Any],
         args: tuple[Any, ...],
         kwargs: Mapping[str, Any],
     ) -> Any:
-        del map_location
+        del map_location, tensor_load_kwargs
         component.load(path, *args, **kwargs)
         return None
 
@@ -259,10 +260,12 @@ class StateDictCheckpointAdapter(CheckpointAdapter):
         path: Path,
         *,
         map_location: Any,
+        tensor_load_kwargs: Mapping[str, Any],
         args: tuple[Any, ...],
         kwargs: Mapping[str, Any],
     ) -> Any:
-        load_kwargs: dict[str, Any] = {"weights_only": False}
+        load_kwargs: dict[str, Any] = {"weights_only": True}
+        load_kwargs.update(tensor_load_kwargs)
         if map_location is not None:
             load_kwargs["map_location"] = map_location
         state = torch.load(path / self.state_filename, **load_kwargs)
@@ -306,10 +309,11 @@ class JSONCheckpointAdapter(CheckpointAdapter):
         path: Path,
         *,
         map_location: Any,
+        tensor_load_kwargs: Mapping[str, Any],
         args: tuple[Any, ...],
         kwargs: Mapping[str, Any],
     ) -> Any:
-        del map_location
+        del map_location, tensor_load_kwargs
         if args or kwargs:
             raise TypeError("JSON checkpoint components do not accept load options.")
         with (path / self.state_filename).open(encoding="utf-8") as file:
@@ -342,9 +346,16 @@ class GlobalRNGState:
         """Capture all supported process-global RNG state."""
         state: dict[str, Any] = {
             "python": random.getstate(),
-            "numpy": np.random.get_state(),
             "torch_cpu": torch.random.get_rng_state(),
         }
+        numpy_state = np.random.get_state()
+        state["numpy"] = (
+            numpy_state[0],
+            torch.from_numpy(numpy_state[1].copy()),
+            numpy_state[2],
+            numpy_state[3],
+            numpy_state[4],
+        )
         if torch.cuda.is_initialized() and torch.cuda.is_available():
             state["torch_cuda"] = torch.cuda.get_rng_state_all()
         xpu = getattr(torch, "xpu", None)
@@ -368,7 +379,16 @@ class GlobalRNGState:
     def load_state_dict(self, state_dict: Mapping[str, Any]) -> None:
         """Restore process-global RNG state."""
         random.setstate(state_dict["python"])
-        np.random.set_state(state_dict["numpy"])
+        numpy_state = state_dict["numpy"]
+        if isinstance(numpy_state[1], torch.Tensor):
+            numpy_state = (
+                numpy_state[0],
+                numpy_state[1].cpu().numpy().astype(np.uint32, copy=False),
+                numpy_state[2],
+                numpy_state[3],
+                numpy_state[4],
+            )
+        np.random.set_state(numpy_state)
         torch.random.set_rng_state(state_dict["torch_cpu"].cpu())
         if "torch_cuda" in state_dict:
             if not torch.cuda.is_available():
@@ -418,6 +438,8 @@ class Checkpoint:
             requested components.
         archive_compression: ``"stored"`` avoids recompressing payloads;
             ``"deflate"`` enables ZIP deflate compression.
+        save_components: Optional default component selection for saves. This
+            is useful for excluding large components from scheduled saves.
         **components: Named objects or JSON-compatible values to register.
 
     Examples:
@@ -441,6 +463,7 @@ class Checkpoint:
         format: CheckpointFormat = "directory",
         strict: CheckpointStrictness = "error",
         archive_compression: ArchiveCompression = "stored",
+        save_components: Collection[str] | None = None,
         **components: Any,
     ) -> None:
         self._validate_format(format)
@@ -453,6 +476,9 @@ class Checkpoint:
         self.format = format
         self.strict = strict
         self.archive_compression = archive_compression
+        self.save_components = (
+            None if save_components is None else frozenset(save_components)
+        )
         self._components: dict[str, _Component] = {}
         self._adapter_registry: list[tuple[type, CheckpointAdapter]] = []
         for name, component in components.items():
@@ -519,7 +545,9 @@ class Checkpoint:
 
         Args:
             path: Local checkpoint destination.
-            components: Component names to save. ``None`` saves all.
+            components: Component names to save. ``None`` uses
+                ``save_components`` from construction, or saves all when no
+                default selection was configured.
             component_options: Per-operation option overrides.
             format: Per-operation container override.
             metadata: JSON-compatible manifest metadata.
@@ -530,7 +558,9 @@ class Checkpoint:
         destination = self._local_path(path)
         output_format = self.format if format is None else format
         self._validate_format(output_format)
-        selected = self._selection(components)
+        selected = self._selection(
+            self.save_components if components is None else components
+        )
         options = component_options or {}
         unknown_options = set(options).difference(selected)
         if unknown_options:
@@ -539,11 +569,8 @@ class Checkpoint:
                 f"{sorted(unknown_options)}."
             )
         destination.parent.mkdir(parents=True, exist_ok=True)
-        stage = Path(
-            tempfile.mkdtemp(
-                prefix=f".{destination.name}.stage-", dir=destination.parent
-            )
-        )
+        stage = destination.parent / (f".{destination.name}.stage-{uuid.uuid4().hex}")
+        stage.mkdir(mode=0o777)
         try:
             component_records: dict[str, Any] = {}
             for index, name in enumerate(sorted(selected)):
@@ -559,14 +586,14 @@ class Checkpoint:
                     kwargs=resolved_options.save_kwargs or {},
                 )
                 files = sorted(
-                    str(file.relative_to(component_path))
+                    file.relative_to(component_path).as_posix()
                     for file in component_path.rglob("*")
                     if file.is_file()
                 )
                 component_records[name] = {
                     "adapter": adapter.adapter_id,
                     "adapter_version": adapter.format_version,
-                    "path": str(relative_path),
+                    "path": relative_path.as_posix(),
                     "files": files,
                 }
             manifest = self._new_manifest(
@@ -591,7 +618,7 @@ class Checkpoint:
                     with zipfile.ZipFile(archive, "w", compression=compression) as file:
                         for source in sorted(stage.rglob("*")):
                             if source.is_file():
-                                file.write(source, source.relative_to(stage))
+                                file.write(source, source.relative_to(stage).as_posix())
                     self._publish_path(archive, destination)
                 finally:
                     self._remove_path(archive)
@@ -607,6 +634,7 @@ class Checkpoint:
         components: Collection[str] | None = None,
         component_options: Mapping[str, CheckpointOptions] | None = None,
         map_location: Any = None,
+        tensor_load_kwargs: Mapping[str, Any] | None = None,
         strict: CheckpointStrictness | None = None,
     ) -> CheckpointLoadResult:
         """Restore selected components from a local checkpoint.
@@ -617,6 +645,9 @@ class Checkpoint:
                 registered components.
             component_options: Per-operation option overrides.
             map_location: Device mapping used while reading tensor payloads.
+            tensor_load_kwargs: Additional keyword arguments passed to
+                :func:`torch.load` for state-dict components. ``weights_only``
+                defaults to ``True``.
             strict: Per-operation strictness override.
 
         Returns:
@@ -672,8 +703,9 @@ class Checkpoint:
                 try:
                     value = adapters[name].load(
                         registration.value,
-                        root / record["path"],
+                        root / record["path"].replace("\\", "/"),
                         map_location=map_location,
+                        tensor_load_kwargs=tensor_load_kwargs or {},
                         args=resolved_options.load_args or (),
                         kwargs=resolved_options.load_kwargs or {},
                     )
@@ -824,10 +856,6 @@ class Checkpoint:
     ) -> dict[str, Any]:
         if not Checkpoint._is_json_value(metadata):
             raise TypeError("Checkpoint manifest metadata must be JSON-compatible.")
-        try:
-            tensordict_version = importlib.metadata.version("tensordict")
-        except importlib.metadata.PackageNotFoundError:
-            tensordict_version = None
         return {
             "format": _FORMAT_NAME,
             "format_version": _FORMAT_VERSION,
@@ -836,7 +864,7 @@ class Checkpoint:
             "created_at": datetime.now(timezone.utc).isoformat(),
             "versions": {
                 "torchrl": torchrl_version,
-                "tensordict": tensordict_version,
+                "tensordict": tensordict.__version__,
                 "torch": torch.__version__,
             },
             "metadata": _to_json_value(metadata),
@@ -858,14 +886,14 @@ class Checkpoint:
         try:
             with zipfile.ZipFile(source) as archive:
                 for record in records.values():
-                    root = Path(record["path"])
+                    root = Path(record["path"].replace("\\", "/"))
                     (temporary / root).mkdir(parents=True, exist_ok=True)
                     for relative_file in record["files"]:
-                        member = root / relative_file
+                        member = root / relative_file.replace("\\", "/")
                         cls._validate_archive_member(member)
                         destination = temporary / member
                         destination.parent.mkdir(parents=True, exist_ok=True)
-                        with archive.open(str(member)) as source_file:
+                        with archive.open(member.as_posix()) as source_file:
                             with destination.open("wb") as destination_file:
                                 shutil.copyfileobj(source_file, destination_file)
             yield temporary
@@ -959,13 +987,13 @@ class Checkpoint:
             raise CheckpointError(
                 f"Checkpoint component {name!r} has an invalid file inventory."
             )
-        cls._validate_archive_member(Path(relative_path))
+        cls._validate_archive_member(Path(relative_path.replace("\\", "/")))
         for relative_file in files:
             if not isinstance(relative_file, str):
                 raise CheckpointError(
                     f"Checkpoint component {name!r} has an invalid file inventory."
                 )
-            cls._validate_archive_member(Path(relative_file))
+            cls._validate_archive_member(Path(relative_file.replace("\\", "/")))
 
     @staticmethod
     def _validate_format(format: str) -> None:
@@ -989,10 +1017,3 @@ class Checkpoint:
         except (TypeError, ValueError, OverflowError):
             return False
         return True
-
-
-def checkpoint_manifest_hash(path: str | Path) -> str:
-    """Return a stable SHA256 digest of a checkpoint manifest."""
-    manifest = Checkpoint.manifest(path)
-    payload = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
-    return hashlib.sha256(payload).hexdigest()

--- a/torchrl/checkpoint/_checkpoint.py
+++ b/torchrl/checkpoint/_checkpoint.py
@@ -194,6 +194,10 @@ class CheckpointAdapter(abc.ABC):
     ) -> Any:
         """Restore ``component`` from ``path`` and optionally return a value."""
 
+    def _detach_from_load_path(self, component: Any) -> None:
+        """Detach a loaded component from temporary archive payload files."""
+        del component
+
 
 class DumpLoadCheckpointAdapter(CheckpointAdapter):
     """Adapter for objects exposing ``dump(path)`` and ``load(path)``.
@@ -230,6 +234,11 @@ class DumpLoadCheckpointAdapter(CheckpointAdapter):
         del map_location, tensor_load_kwargs
         component.load(path, *args, **kwargs)
         return None
+
+    def _detach_from_load_path(self, component: Any) -> None:
+        detach = getattr(component, "_torchrl_checkpoint_detach_from_load_path", None)
+        if detach is not None:
+            detach()
 
 
 def _encode_state_dict_value(value: Any, tensors: dict[str, torch.Tensor]) -> Any:
@@ -966,6 +975,8 @@ class Checkpoint:
                         args=resolved_options.load_args or (),
                         kwargs=resolved_options.load_kwargs or {},
                     )
+                    if not source.is_dir():
+                        adapters[name]._detach_from_load_path(registration.value)
                 except Exception as error:
                     result.incompatible[name] = str(error)
                     if load_strict == "error":

--- a/torchrl/checkpoint/_checkpoint.py
+++ b/torchrl/checkpoint/_checkpoint.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import abc
+import base64
 import json
 import os
 import random
@@ -12,6 +13,7 @@ import shutil
 import tempfile
 import uuid
 import zipfile
+from collections import OrderedDict
 from collections.abc import Callable, Collection, Mapping, MutableMapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -30,6 +32,7 @@ from torchrl._utils import logger as torchrl_logger
 CheckpointFormat = Literal["directory", "archive"]
 CheckpointStrictness = Literal["error", "warn", "ignore"]
 ArchiveCompression = Literal["stored", "deflate"]
+StateDictFormat = Literal["directory", "archive", "consolidated", "torch"]
 
 _MANIFEST_NAME = "manifest.json"
 _FORMAT_NAME = "torchrl.checkpoint"
@@ -229,17 +232,225 @@ class DumpLoadCheckpointAdapter(CheckpointAdapter):
         return None
 
 
+def _encode_state_dict_value(value: Any, tensors: dict[str, torch.Tensor]) -> Any:
+    if isinstance(value, torch.Tensor):
+        key = f"tensor_{len(tensors):08d}"
+        tensors[key] = value.detach()
+        return {"kind": "tensor", "key": key, "device": str(value.device)}
+    if isinstance(value, np.ndarray):
+        key = f"tensor_{len(tensors):08d}"
+        tensors[key] = torch.from_numpy(value.copy())
+        return {"kind": "numpy", "key": key, "dtype": value.dtype.str}
+    if isinstance(value, Mapping):
+        metadata = getattr(value, "_metadata", None)
+        mapping_type = (
+            "ordered_dict"
+            if isinstance(value, OrderedDict) or metadata is not None
+            else "dict"
+        )
+        result = {
+            "kind": mapping_type,
+            "items": [
+                [
+                    _encode_state_dict_value(key, tensors),
+                    _encode_state_dict_value(item, tensors),
+                ]
+                for key, item in value.items()
+            ],
+        }
+        if metadata is not None:
+            result["metadata"] = _encode_state_dict_value(metadata, tensors)
+        return result
+    if isinstance(value, torch.Size):
+        return {"kind": "torch_size", "items": list(value)}
+    if isinstance(value, tuple):
+        return {
+            "kind": "tuple",
+            "items": [_encode_state_dict_value(item, tensors) for item in value],
+        }
+    if isinstance(value, list):
+        return {
+            "kind": "list",
+            "items": [_encode_state_dict_value(item, tensors) for item in value],
+        }
+    if isinstance(value, set):
+        return {
+            "kind": "set",
+            "items": [_encode_state_dict_value(item, tensors) for item in value],
+        }
+    if isinstance(value, frozenset):
+        return {
+            "kind": "frozenset",
+            "items": [_encode_state_dict_value(item, tensors) for item in value],
+        }
+    if isinstance(value, slice):
+        return {
+            "kind": "slice",
+            "items": [
+                _encode_state_dict_value(item, tensors)
+                for item in (value.start, value.stop, value.step)
+            ],
+        }
+    if isinstance(value, range):
+        return {
+            "kind": "range",
+            "items": [value.start, value.stop, value.step],
+        }
+    if isinstance(value, torch.device):
+        return {"kind": "torch_device", "value": str(value)}
+    if isinstance(value, torch.dtype):
+        return {"kind": "torch_dtype", "value": str(value).removeprefix("torch.")}
+    if isinstance(value, Path):
+        return {"kind": "path", "value": str(value)}
+    if isinstance(value, bytes):
+        return {
+            "kind": "bytes",
+            "value": base64.b64encode(value).decode("ascii"),
+        }
+    if isinstance(value, bytearray):
+        return {
+            "kind": "bytearray",
+            "value": base64.b64encode(value).decode("ascii"),
+        }
+    if isinstance(value, complex):
+        return {"kind": "complex", "real": value.real, "imag": value.imag}
+    if isinstance(value, np.generic):
+        return {
+            "kind": "numpy_scalar",
+            "dtype": value.dtype.str,
+            "value": _to_json_value(value),
+        }
+    if value is Ellipsis:
+        return {"kind": "ellipsis"}
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return {"kind": "value", "value": value}
+    raise TypeError(
+        f"State-dict value of type {type(value).__name__} is not supported by "
+        "the TensorDict checkpoint format. Register "
+        "StateDictCheckpointAdapter(payload_format='torch') for state dicts "
+        "that require pickle serialization."
+    )
+
+
+def _mapped_device(saved_device: str, map_location: Any) -> torch.device:
+    if map_location is None:
+        return torch.device(saved_device)
+    if isinstance(map_location, Mapping):
+        target = map_location.get(saved_device)
+        if target is None:
+            target = map_location.get(torch.device(saved_device), saved_device)
+        return torch.device(target)
+    if callable(map_location):
+        raise TypeError(
+            "Callable map_location is only supported by the torch state-dict "
+            "payload format."
+        )
+    return torch.device(map_location)
+
+
+def _decode_state_dict_value(
+    value: Mapping[str, Any], tensors: Mapping[str, torch.Tensor], map_location: Any
+) -> Any:
+    kind = value["kind"]
+    if kind == "tensor":
+        tensor = tensors[value["key"]]
+        return tensor.to(_mapped_device(value["device"], map_location), copy=True)
+    if kind == "numpy":
+        return tensors[value["key"]].cpu().numpy().astype(value["dtype"], copy=True)
+    if kind in ("dict", "ordered_dict"):
+        mapping = OrderedDict() if kind == "ordered_dict" else {}
+        for key, item in value["items"]:
+            mapping[
+                _decode_state_dict_value(key, tensors, map_location)
+            ] = _decode_state_dict_value(item, tensors, map_location)
+        metadata = value.get("metadata")
+        if metadata is not None:
+            mapping._metadata = _decode_state_dict_value(  # type: ignore[attr-defined]
+                metadata, tensors, map_location
+            )
+        return mapping
+    if kind == "torch_size":
+        return torch.Size(value["items"])
+    if kind in ("tuple", "list", "set", "frozenset"):
+        items = [
+            _decode_state_dict_value(item, tensors, map_location)
+            for item in value["items"]
+        ]
+        return {"tuple": tuple, "list": list, "set": set, "frozenset": frozenset,}[
+            kind
+        ](items)
+    if kind == "slice":
+        return slice(
+            *(
+                _decode_state_dict_value(item, tensors, map_location)
+                for item in value["items"]
+            )
+        )
+    if kind == "range":
+        return range(*value["items"])
+    if kind == "torch_device":
+        return torch.device(value["value"])
+    if kind == "torch_dtype":
+        dtype = getattr(torch, value["value"], None)
+        if not isinstance(dtype, torch.dtype):
+            raise TypeError(f"Unknown torch dtype {value['value']!r} in checkpoint.")
+        return dtype
+    if kind == "path":
+        return Path(value["value"])
+    if kind in ("bytes", "bytearray"):
+        decoded = base64.b64decode(value["value"])
+        return decoded if kind == "bytes" else bytearray(decoded)
+    if kind == "complex":
+        return complex(value["real"], value["imag"])
+    if kind == "numpy_scalar":
+        return np.dtype(value["dtype"]).type(value["value"])
+    if kind == "ellipsis":
+        return Ellipsis
+    if kind == "value":
+        return value["value"]
+    raise TypeError(f"Unknown state-dict schema kind {kind!r}.")
+
+
 class StateDictCheckpointAdapter(CheckpointAdapter):
     """Adapter for ``state_dict`` / ``load_state_dict`` objects.
 
+    TensorDict directory payloads are used by default. ``payload_format`` can
+    select a TensorDict archive, a consolidated TensorDict, or the pickle-based
+    :func:`torch.save` format. Loading auto-detects all four payload formats.
+
+    Args:
+        payload_format: Format used for new payloads. One of ``"directory"``,
+            ``"archive"``, ``"consolidated"``, or ``"torch"``.
+        archive_compression: Compression passed to TensorDict archive saves.
+
     Examples:
         >>> from torchrl.checkpoint import StateDictCheckpointAdapter
-        >>> StateDictCheckpointAdapter().adapter_id
-        'torchrl.state_dict'
+        >>> StateDictCheckpointAdapter().payload_format
+        'directory'
+        >>> StateDictCheckpointAdapter(payload_format="torch").payload_format
+        'torch'
     """
 
     adapter_id = "torchrl.state_dict"
-    state_filename = "state.pt"
+    state_directory = "state"
+    state_archive = "state.tdz"
+    state_consolidated = "state.tdc"
+    state_torch = "state.pt"
+    schema_filename = "state.json"
+
+    def __init__(
+        self,
+        payload_format: StateDictFormat = "directory",
+        *,
+        archive_compression: str | int | None = None,
+    ) -> None:
+        if payload_format not in ("directory", "archive", "consolidated", "torch"):
+            raise ValueError(
+                "payload_format must be 'directory', 'archive', 'consolidated', "
+                f"or 'torch', got {payload_format!r}."
+            )
+        self.payload_format = payload_format
+        self.archive_compression = archive_compression
 
     def save(
         self,
@@ -251,7 +462,25 @@ class StateDictCheckpointAdapter(CheckpointAdapter):
     ) -> Any:
         path.mkdir(parents=True, exist_ok=True)
         state = component.state_dict(*args, **kwargs)
-        torch.save(state, path / self.state_filename)
+        if self.payload_format == "torch":
+            torch.save(state, path / self.state_torch)
+            return state
+        tensors: dict[str, torch.Tensor] = {}
+        schema = _encode_state_dict_value(state, tensors)
+        tensor_state = tensordict.TensorDict(tensors, batch_size=[])
+        if self.payload_format == "directory":
+            tensordict.save(tensor_state, path / self.state_directory)
+        elif self.payload_format == "archive":
+            tensor_state.save(
+                path / self.state_archive,
+                archive=True,
+                compression=self.archive_compression,
+            )
+        else:
+            tensor_state.consolidate(path / self.state_consolidated)
+        with (path / self.schema_filename).open("w", encoding="utf-8") as file:
+            json.dump(schema, file, separators=(",", ":"))
+            file.write("\n")
         return state
 
     def load(
@@ -264,11 +493,38 @@ class StateDictCheckpointAdapter(CheckpointAdapter):
         args: tuple[Any, ...],
         kwargs: Mapping[str, Any],
     ) -> Any:
-        load_kwargs: dict[str, Any] = {"weights_only": True}
-        load_kwargs.update(tensor_load_kwargs)
-        if map_location is not None:
-            load_kwargs["map_location"] = map_location
-        state = torch.load(path / self.state_filename, **load_kwargs)
+        torch_path = path / self.state_torch
+        if torch_path.exists():
+            load_kwargs: dict[str, Any] = {"weights_only": True}
+            load_kwargs.update(tensor_load_kwargs)
+            if map_location is not None:
+                load_kwargs["map_location"] = map_location
+            state = torch.load(torch_path, **load_kwargs)
+        else:
+            unsupported_load_kwargs = set(tensor_load_kwargs).difference(
+                {"mmap", "weights_only"}
+            )
+            if unsupported_load_kwargs:
+                raise TypeError(
+                    "The following tensor_load_kwargs are only accepted for torch "
+                    f"state-dict payloads: {sorted(unsupported_load_kwargs)}."
+                )
+            directory = path / self.state_directory
+            archive = path / self.state_archive
+            consolidated = path / self.state_consolidated
+            if directory.is_dir():
+                tensor_state = tensordict.load(directory)
+            elif archive.is_file():
+                tensor_state = tensordict.load(archive)
+            elif consolidated.is_file():
+                tensor_state = tensordict.from_consolidated(consolidated)
+            else:
+                raise FileNotFoundError(
+                    f"No state-dict payload was found below {path!s}."
+                )
+            with (path / self.schema_filename).open(encoding="utf-8") as file:
+                schema = json.load(file)
+            state = _decode_state_dict_value(schema, tensor_state, map_location)
         component.load_state_dict(state, *args, **kwargs)
         return None
 
@@ -646,8 +902,9 @@ class Checkpoint:
             component_options: Per-operation option overrides.
             map_location: Device mapping used while reading tensor payloads.
             tensor_load_kwargs: Additional keyword arguments passed to
-                :func:`torch.load` for state-dict components. ``weights_only``
-                defaults to ``True``.
+                :func:`torch.load` for state-dict components explicitly saved
+                with the torch payload format. ``weights_only`` defaults to
+                ``True``.
             strict: Per-operation strictness override.
 
         Returns:

--- a/torchrl/collectors/_evaluator.py
+++ b/torchrl/collectors/_evaluator.py
@@ -77,7 +77,7 @@ import logging
 import threading
 import time
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any
 
 import torch
@@ -521,6 +521,40 @@ class Evaluator:
         if self._async_thread is not None and self._async_thread.is_alive():
             self._async_thread.join(timeout=timeout)
         self._backend.shutdown(timeout)
+
+    def state_dict(self) -> dict[str, Any]:
+        """Return evaluator progress when no asynchronous work is pending."""
+        with self._async_lock:
+            if self._backend.pending or self._async_requests or self._ready_results:
+                raise RuntimeError(
+                    "Evaluator checkpointing requires no pending, queued, or unread "
+                    "evaluation results."
+                )
+            state: dict[str, Any] = {"step_counter": self._step_counter}
+            backend_state_dict = getattr(self._backend, "state_dict", None)
+            if callable(backend_state_dict):
+                state["backend"] = backend_state_dict()
+            return state
+
+    def load_state_dict(self, state_dict: Mapping[str, Any]) -> None:
+        """Restore evaluator progress when no asynchronous work is pending."""
+        with self._async_lock:
+            if self._backend.pending or self._async_requests or self._ready_results:
+                raise RuntimeError(
+                    "Evaluator state cannot be restored while evaluation work is "
+                    "pending, queued, or unread."
+                )
+            self._step_counter = state_dict.get("step_counter", 0)
+            if "backend" in state_dict:
+                backend_load_state_dict = getattr(
+                    self._backend, "load_state_dict", None
+                )
+                if not callable(backend_load_state_dict):
+                    raise RuntimeError(
+                        "Checkpoint contains evaluator backend state, but this backend "
+                        "cannot restore it."
+                    )
+                backend_load_state_dict(state_dict["backend"])
 
     def __del__(self):
         try:

--- a/torchrl/collectors/_multi_base.py
+++ b/torchrl/collectors/_multi_base.py
@@ -2009,12 +2009,20 @@ also that the state dict is synchronised across processes if needed."""
         for idx in range(self.num_workers):
             self.pipes[idx].send((None, "state_dict"))
         state_dict = OrderedDict()
+        traj_pool_state = None
         for idx in range(self.num_workers):
             _state_dict, msg = self._recv_and_check(self.pipes[idx], worker_idx=idx)
             if msg != "state_dict":
                 raise RuntimeError(f"Expected msg='state_dict', got {msg}")
+            worker_traj_pool_state = _state_dict.pop("traj_pool", None)
+            if traj_pool_state is None and worker_traj_pool_state is not None:
+                traj_pool_state = worker_traj_pool_state
             state_dict[f"worker{idx}"] = _state_dict
         state_dict.update({"frames": self._frames, "iter": self._iter})
+        if traj_pool_state is not None:
+            state_dict["traj_pool"] = traj_pool_state
+        if self.policy_version_tracker is not None:
+            state_dict["policy_version"] = self.policy_version
 
         return state_dict
 
@@ -2026,6 +2034,9 @@ also that the state dict is synchronised across processes if needed."""
                 ``{"worker0": state_dict0, "worker1": state_dict1}``.
 
         """
+        traj_pool_state = state_dict.get("traj_pool")
+        if traj_pool_state is not None:
+            self._traj_pool.load_state_dict(traj_pool_state)
         for idx in range(self.num_workers):
             self.pipes[idx].send((state_dict[f"worker{idx}"], "load_state_dict"))
         for idx in range(self.num_workers):
@@ -2034,6 +2045,9 @@ also that the state dict is synchronised across processes if needed."""
                 raise RuntimeError(f"Expected msg='loaded', got {msg}")
         self._frames = state_dict["frames"]
         self._iter = state_dict["iter"]
+        policy_version = state_dict.get("policy_version")
+        if policy_version is not None and self.policy_version_tracker is not None:
+            self.policy_version_tracker.version = policy_version
 
     def increment_version(self):
         """Increment the policy version."""

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -2132,6 +2132,10 @@ class Collector(BaseCollector):
             state_dict = OrderedDict(env_state_dict=env_state_dict)
 
         state_dict.update({"frames": self._frames, "iter": self._iter})
+        if self.track_traj_ids:
+            state_dict["traj_pool"] = self._traj_pool.state_dict()
+        if self.policy_version_tracker is not None:
+            state_dict["policy_version"] = self.policy_version
 
         return state_dict
 
@@ -2156,6 +2160,20 @@ class Collector(BaseCollector):
             )
         self._frames = state_dict["frames"]
         self._iter = state_dict["iter"]
+        if self.track_traj_ids:
+            traj_pool_state = state_dict.get("traj_pool")
+            if traj_pool_state is not None:
+                self._traj_pool.load_state_dict(traj_pool_state)
+            # Runtime environment state is not generally serializable. The new
+            # carrier therefore starts a fresh trajectory whose identifier must
+            # be allocated after restoring the global trajectory counter.
+            traj_ids = self._traj_pool.get_traj_and_increment(
+                self.n_env, device=self.storing_device
+            ).view(self.env.batch_size)
+            self._carrier.set(("collector", "traj_ids"), traj_ids)
+        policy_version = state_dict.get("policy_version")
+        if policy_version is not None and self.policy_version_tracker is not None:
+            self.policy_version_tracker.version = policy_version
 
     def __repr__(self) -> str:
         try:

--- a/torchrl/collectors/utils.py
+++ b/torchrl/collectors/utils.py
@@ -446,6 +446,16 @@ class _TrajectoryPool:
             self._traj_id.copy_(1 + out[-1].item())
         return out
 
+    def state_dict(self) -> dict[str, torch.Tensor]:
+        """Return the next trajectory identifier without exposing shared storage."""
+        with self.lock:
+            return {"traj_id": self._traj_id.clone()}
+
+    def load_state_dict(self, state_dict: dict[str, torch.Tensor]) -> None:
+        """Restore the next trajectory identifier in-place."""
+        with self.lock:
+            self._traj_id.copy_(state_dict["traj_id"])
+
 
 def _map_weight(
     weight,

--- a/torchrl/data/replay_buffers/checkpointers.py
+++ b/torchrl/data/replay_buffers/checkpointers.py
@@ -21,7 +21,6 @@ from tensordict import (
 )
 from tensordict.memmap import MemoryMappedTensor
 from tensordict.utils import _zip_strict
-from torch.utils._pytree import tree_map
 from torchrl._utils import _STRDTYPE2DTYPE
 
 from torchrl.data.replay_buffers.utils import (
@@ -33,6 +32,23 @@ from torchrl.data.replay_buffers.utils import (
     TED2Flat,
     TED2Nested,
 )
+
+
+def _map_metadata(function, metadata, *, is_leaf):
+    if is_leaf(metadata):
+        return function(metadata)
+    if isinstance(metadata, dict):
+        return {
+            key: _map_metadata(function, value, is_leaf=is_leaf)
+            for key, value in metadata.items()
+        }
+    if isinstance(metadata, list):
+        return [_map_metadata(function, value, is_leaf=is_leaf) for value in metadata]
+    if isinstance(metadata, tuple):
+        return tuple(
+            _map_metadata(function, value, is_leaf=is_leaf) for value in metadata
+        )
+    return function(metadata)
 
 
 class StorageCheckpointerBase:
@@ -221,7 +237,7 @@ class CompressedListStorageCheckpointer(StorageCheckpointerBase):
                     return {"__type__": "NonTensorData", "value": item.data}
                 return item
 
-            serializable_metadata = tree_map(
+            serializable_metadata = _map_metadata(
                 map_to_json_serializable, metadata, is_leaf=is_leaf
             )
 
@@ -292,7 +308,7 @@ class CompressedListStorageCheckpointer(StorageCheckpointerBase):
                     return NonTensorData(item["value"])
             return item
 
-        metadata = tree_map(
+        metadata = _map_metadata(
             map_from_json_serializable, serializable_metadata, is_leaf=is_leaf
         )
 

--- a/torchrl/data/replay_buffers/checkpointers.py
+++ b/torchrl/data/replay_buffers/checkpointers.py
@@ -5,7 +5,10 @@
 from __future__ import annotations
 
 import abc
+import gc
 import json
+import os
+import shutil
 import tempfile
 import warnings
 from pathlib import Path
@@ -51,6 +54,36 @@ def _map_metadata(function, metadata, *, is_leaf):
     return function(metadata)
 
 
+def _write_compressed_data_to_memmap(compressed_data, path):
+    processed_data = []
+    for item in compressed_data:
+        if item is None:
+            processed_data.append(None)
+        elif isinstance(item, torch.Tensor):
+            processed_data.append(TensorDict({"data": item}, batch_size=[]))
+        elif isinstance(item, dict):
+            processed_data.append(TensorDict(item, batch_size=[]))
+        else:
+            processed_data.append(TensorDict({"data": item}, batch_size=[]))
+
+    non_none_data = [item for item in processed_data if item is not None]
+    if not non_none_data:
+        return []
+
+    stacked_data = lazy_stack(non_none_data)
+    stacked_data.memmap_(path / "compressed_data")
+
+    data_indices = []
+    current_idx = 0
+    for item in processed_data:
+        if item is None:
+            data_indices.append(None)
+        else:
+            data_indices.append(current_idx)
+            current_idx += 1
+    return data_indices
+
+
 class StorageCheckpointerBase:
     """Public base class for storage checkpointers.
 
@@ -70,6 +103,9 @@ class StorageCheckpointerBase:
     def register_load_hook(self, hook):
         """Registers a load hook for this checkpointer."""
         self._load_hooks.append(hook)
+
+    def _detach_from_load_path(self, storage):
+        del storage
 
     def _get_shift_from_last_cursor(self, last_cursor):
         """Computes shift from the last cursor position."""
@@ -165,47 +201,17 @@ class CompressedListStorageCheckpointer(StorageCheckpointerBase):
         # Create a temporary directory for processing
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
-
-            # Process compressed data for memmap storage
-            processed_data = []
-            for item in compressed_data:
-                if item is None:
-                    processed_data.append(None)
-                    continue
-
-                if isinstance(item, torch.Tensor):
-                    # For tensor data, create a TensorDict with the tensor
-                    processed_item = TensorDict({"data": item}, batch_size=[])
-                elif isinstance(item, dict):
-                    # For dict data (tensordict fields), convert to TensorDict
-                    processed_item = TensorDict(item, batch_size=[])
-                else:
-                    # For other types, wrap in TensorDict
-                    processed_item = TensorDict({"data": item}, batch_size=[])
-
-                processed_data.append(processed_item)
-
-            # Stack all non-None items into a single TensorDict for memmap
-            non_none_data = [item for item in processed_data if item is not None]
-            if non_none_data:
-                # Use lazy_stack to handle heterogeneous structures
-                stacked_data = lazy_stack(non_none_data)
-
-                # Save to memmap
-                stacked_data.memmap_(tmp_path / "compressed_data")
-
-                # Create index mapping for None values
-                data_indices = []
-                current_idx = 0
-                for item in processed_data:
-                    if item is None:
-                        data_indices.append(None)
-                    else:
-                        data_indices.append(current_idx)
-                        current_idx += 1
-            else:
-                # No data to save
-                data_indices = []
+            try:
+                data_indices = _write_compressed_data_to_memmap(
+                    compressed_data, tmp_path
+                )
+            finally:
+                # Windows cannot remove a file while a mapping is alive. The helper
+                # owns all temporary TensorDict references, so collecting after it
+                # returns releases any reference cycles before TemporaryDirectory
+                # removes the staging tree.
+                if os.name == "nt":
+                    gc.collect()
 
             # Process metadata for JSON serialization
             def is_leaf(item):
@@ -251,8 +257,6 @@ class CompressedListStorageCheckpointer(StorageCheckpointerBase):
                 json.dump(data_indices, f, indent=2)
 
             # Copy all files from temp directory to final destination
-            import shutil
-
             for item in tmp_path.iterdir():
                 if item.is_file():
                     shutil.copy2(item, path / item.name)
@@ -337,6 +341,15 @@ class CompressedListStorageCheckpointer(StorageCheckpointerBase):
         # Load into storage
         storage._storage = compressed_data
         storage._metadata = metadata
+
+    def _detach_from_load_path(self, storage):
+        storage._storage = _map_metadata(
+            lambda item: item.clone() if isinstance(item, MemoryMappedTensor) else item,
+            storage._storage,
+            is_leaf=lambda item: isinstance(item, torch.Tensor),
+        )
+        if os.name == "nt":
+            gc.collect()
 
 
 class TensorStorageCheckpointer(StorageCheckpointerBase):

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -1150,6 +1150,11 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
         """Alias for :meth:`loads`."""
         return self.loads(*args, **kwargs)
 
+    def _torchrl_checkpoint_detach_from_load_path(self):
+        detach = getattr(self._storage.checkpointer, "_detach_from_load_path", None)
+        if detach is not None:
+            detach(self._storage)
+
     @_maybe_delay_init
     def register_save_hook(self, hook: Callable[[Any], Any]):
         """Registers a save hook for the storage.

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -8,7 +8,7 @@ import functools
 import importlib
 import re
 import warnings
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from copy import copy
 from enum import Enum
 from typing import Any, TypeVar
@@ -506,6 +506,19 @@ class TargetNetUpdater:
 
     def _step(self, p_source: Tensor, p_target: Tensor) -> None:
         raise NotImplementedError
+
+    def state_dict(self) -> dict[str, Any]:
+        """Return target-update progress not already owned by the loss module."""
+        state = {"initialized": self.initialized}
+        if hasattr(self, "counter"):
+            state["counter"] = self.counter
+        return state
+
+    def load_state_dict(self, state_dict: Mapping[str, Any]) -> None:
+        """Restore target-update progress."""
+        self.initialized = state_dict.get("initialized", self.initialized)
+        if "counter" in state_dict and hasattr(self, "counter"):
+            self.counter = state_dict["counter"]
 
     def __repr__(self) -> str:
         string = (

--- a/torchrl/record/loggers/common.py
+++ b/torchrl/record/loggers/common.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import abc
 import importlib.util
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 from typing import Any, TYPE_CHECKING
 
@@ -306,6 +306,39 @@ class Logger(metaclass=_RayServiceMetaClass):
     def close(self, timeout: float | None = None) -> None:
         """Alias for :meth:`shutdown`."""
         self.shutdown(timeout=timeout)
+
+    def state_dict(self) -> dict[str, Any]:
+        """Return local logger identifiers and counters for checkpointing."""
+        self.flush()
+        state: dict[str, Any] = {
+            "exp_name": self.exp_name,
+            "log_dir": self.log_dir,
+        }
+        for name in ("id", "video_log_counter"):
+            if hasattr(self, name):
+                state[name] = getattr(self, name)
+        experiment_state = {}
+        for name in ("scalars", "videos_counter", "text_counter"):
+            if hasattr(self.experiment, name):
+                experiment_state[name] = dict(getattr(self.experiment, name))
+        if experiment_state:
+            state["experiment"] = experiment_state
+        return state
+
+    def load_state_dict(self, state_dict: Mapping[str, Any]) -> None:
+        """Restore local logger counters without recreating external services."""
+        for name in ("id", "video_log_counter"):
+            if name in state_dict and hasattr(self, name):
+                setattr(self, name, state_dict[name])
+        for name, value in state_dict.get("experiment", {}).items():
+            target = getattr(self.experiment, name, None)
+            if (
+                target is not None
+                and hasattr(target, "clear")
+                and hasattr(target, "update")
+            ):
+                target.clear()
+                target.update(value)
 
     @abc.abstractmethod
     def _create_experiment(self) -> Experiment:  # noqa: F821

--- a/torchrl/record/loggers/common.py
+++ b/torchrl/record/loggers/common.py
@@ -312,33 +312,24 @@ class Logger(metaclass=_RayServiceMetaClass):
         self.flush()
         state: dict[str, Any] = {
             "exp_name": self.exp_name,
-            "log_dir": self.log_dir,
+            "log_dir": str(self.log_dir),
         }
-        for name in ("id", "video_log_counter"):
-            if hasattr(self, name):
-                state[name] = getattr(self, name)
-        experiment_state = {}
-        for name in ("scalars", "videos_counter", "text_counter"):
-            if hasattr(self.experiment, name):
-                experiment_state[name] = dict(getattr(self.experiment, name))
-        if experiment_state:
-            state["experiment"] = experiment_state
+        local_state = self._checkpoint_state()
+        if local_state:
+            state["local"] = local_state
         return state
 
     def load_state_dict(self, state_dict: Mapping[str, Any]) -> None:
         """Restore local logger counters without recreating external services."""
-        for name in ("id", "video_log_counter"):
-            if name in state_dict and hasattr(self, name):
-                setattr(self, name, state_dict[name])
-        for name, value in state_dict.get("experiment", {}).items():
-            target = getattr(self.experiment, name, None)
-            if (
-                target is not None
-                and hasattr(target, "clear")
-                and hasattr(target, "update")
-            ):
-                target.clear()
-                target.update(value)
+        self._load_checkpoint_state(state_dict.get("local", {}))
+
+    def _checkpoint_state(self) -> dict[str, Any]:
+        """Return logger-specific local state without external connections."""
+        return {}
+
+    def _load_checkpoint_state(self, state_dict: Mapping[str, Any]) -> None:
+        """Restore logger-specific local state."""
+        del state_dict
 
     @abc.abstractmethod
     def _create_experiment(self) -> Experiment:  # noqa: F821

--- a/torchrl/record/loggers/csv.py
+++ b/torchrl/record/loggers/csv.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import os
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 import tensordict.utils
@@ -168,6 +168,19 @@ class CSVLogger(Logger):
         return CSVExperiment(
             log_dir, video_format=self.video_format, video_fps=self.video_fps
         )
+
+    def _checkpoint_state(self) -> dict[str, object]:
+        return {
+            "scalars": dict(self.experiment.scalars),
+            "videos_counter": dict(self.experiment.videos_counter),
+            "text_counter": dict(self.experiment.text_counter),
+        }
+
+    def _load_checkpoint_state(self, state_dict: Mapping[str, object]) -> None:
+        for name in ("scalars", "videos_counter", "text_counter"):
+            target = getattr(self.experiment, name)
+            target.clear()
+            target.update(state_dict.get(name, {}))
 
     def log_scalar(self, name: str, value: float, step: int | None = None) -> None:
         """Logs a scalar value to the tensorboard.

--- a/torchrl/record/loggers/mlflow.py
+++ b/torchrl/record/loggers/mlflow.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import importlib.util
 
 import os
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from tempfile import TemporaryDirectory
 from typing import Any
 
@@ -69,6 +69,15 @@ class MLFlowLogger(Logger):
         super().__init__(exp_name=exp_name, log_dir=tracking_uri)
         self.video_log_counter = 0
         self.video_fps = video_fps
+
+    def _checkpoint_state(self) -> dict[str, Any]:
+        return {"id": self.id, "video_log_counter": self.video_log_counter}
+
+    def _load_checkpoint_state(self, state_dict: Mapping[str, Any]) -> None:
+        if "id" in state_dict:
+            self.id = state_dict["id"]
+        if "video_log_counter" in state_dict:
+            self.video_log_counter = state_dict["video_log_counter"]
 
     def _create_experiment(self) -> mlflow.ActiveRun:  # noqa
         import mlflow

--- a/torchrl/record/loggers/wandb.py
+++ b/torchrl/record/loggers/wandb.py
@@ -11,7 +11,7 @@ import json
 import os
 import platform
 import sys
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from tensordict import TensorDictBase
@@ -137,6 +137,22 @@ class WandbLogger(Logger):
                 self.experiment.config.update({"env": _collect_env_metadata()})
         if self.offline:
             os.environ["WANDB_MODE"] = "dryrun"
+
+    def _checkpoint_state(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "step_registry": dict(self._step_registry),
+            "defined_step_metrics": sorted(self._defined_step_metrics),
+            "defined_metrics": sorted(self._defined_metrics),
+        }
+
+    def _load_checkpoint_state(self, state_dict: Mapping[str, Any]) -> None:
+        if "id" in state_dict:
+            self.id = state_dict["id"]
+        self._step_registry.clear()
+        self._step_registry.update(state_dict.get("step_registry", {}))
+        self._defined_step_metrics = set(state_dict.get("defined_step_metrics", ()))
+        self._defined_metrics = set(state_dict.get("defined_metrics", ()))
 
     def _create_experiment(self):
         """Creates a wandb experiment.

--- a/torchrl/render/checkpoint.py
+++ b/torchrl/render/checkpoint.py
@@ -5,14 +5,15 @@
 from __future__ import annotations
 
 import hashlib
+import warnings
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
 import torch
 from torch import Tensor
+
 from torchrl.checkpoint import Checkpoint, CheckpointFormat
-from torchrl.checkpoint._checkpoint import checkpoint_manifest_hash
 
 __all__ = [
     "checkpoint_hash",
@@ -46,7 +47,7 @@ def save_render_checkpoint(
     metrics: Mapping[str, Any] | None = None,
     config: Mapping[str, Any] | None = None,
     extra: Mapping[str, Any] | None = None,
-    format: CheckpointFormat = "archive",
+    format: CheckpointFormat | None = None,
 ) -> Path | None:
     """Writes a checkpoint in the layout expected by rlrender factories.
 
@@ -68,8 +69,8 @@ def save_render_checkpoint(
         metrics: Scalar metrics recorded at checkpoint time.
         config: JSON-serializable training configuration.
         extra: Additional payload entries merged last.
-        format: Unified checkpoint container format. Defaults to ``"archive"``
-            to preserve the existing single-path rlrender workflow.
+        format: Unified checkpoint container format. When omitted, writes the
+            legacy :func:`torch.save` payload during the compatibility window.
 
     Returns:
         The written checkpoint path, or ``None`` when checkpointing is disabled.
@@ -81,7 +82,10 @@ def save_render_checkpoint(
         >>> module = torch.nn.Linear(2, 2)
         >>> with tempfile.TemporaryDirectory() as tmpdir:
         ...     path = save_render_checkpoint(
-        ...         f"{tmpdir}/policy.pt", module, env_metadata={"env_name": "CartPole-v1"}
+        ...         f"{tmpdir}/policy.pt",
+        ...         module,
+        ...         env_metadata={"env_name": "CartPole-v1"},
+        ...         format="archive",
         ...     )
         ...     payload = load_checkpoint(path)
         >>> payload["env_name"]
@@ -89,10 +93,41 @@ def save_render_checkpoint(
     """
     if path in (None, ""):
         return None
+    path = Path(path).expanduser()
+    if format is None:
+        warnings.warn(
+            "The default save_render_checkpoint output will change from the "
+            "legacy torch.save payload to a unified TorchRL checkpoint in v0.15. "
+            "Pass format='archive' or format='directory' to opt in now.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        payload: dict[str, Any] = {
+            "model_state_dict": model
+            if isinstance(model, Mapping)
+            else model.state_dict()
+        }
+        if env_metadata:
+            payload.update(dict(env_metadata))
+        if frames is not None:
+            payload["frames"] = int(frames)
+        if metrics is not None:
+            payload["metrics"] = dict(metrics)
+        if config is not None:
+            payload["config"] = dict(config)
+        if extra:
+            payload.update(dict(extra))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(payload, path)
+        return path
+
     policy = _StateDictComponent(model) if isinstance(model, Mapping) else model
     components: dict[str, Any] = {"policy": policy}
     if env_metadata is not None:
-        components["environment_metadata"] = dict(env_metadata)
+        metadata = dict(env_metadata)
+        components["environment_metadata"] = (
+            _StateDictComponent(metadata) if _contains_tensor(metadata) else metadata
+        )
     if frames is not None:
         components["trainer_state"] = {"frames": int(frames)}
     if metrics is not None:
@@ -100,17 +135,29 @@ def save_render_checkpoint(
     if config is not None:
         components["config"] = dict(config)
     if extra is not None:
-        components["extra"] = dict(extra)
-    path = Path(path).expanduser()
+        extra_payload = dict(extra)
+        components["extra"] = (
+            _StateDictComponent(extra_payload)
+            if _contains_tensor(extra_payload)
+            else extra_payload
+        )
     return Checkpoint(format=format, **components).save(path)
 
 
-def load_checkpoint(path: str | Path, map_location: str | torch.device = "cpu") -> Any:
+def load_checkpoint(
+    path: str | Path,
+    map_location: str | torch.device = "cpu",
+    *,
+    weights_only: bool | None = None,
+) -> Any:
     """Loads a local PyTorch checkpoint.
 
     Args:
         path: Local checkpoint path.
         map_location: Device mapping passed to :func:`torch.load`.
+        weights_only: Whether payloads are restricted to safe weight-only
+            types. Unified checkpoints default to ``True``. Legacy payloads
+            retain their historical ``False`` default for compatibility.
 
     Returns:
         The checkpoint payload.
@@ -124,8 +171,16 @@ def load_checkpoint(path: str | Path, map_location: str | torch.device = "cpu") 
         raise FileNotFoundError(f"Checkpoint path does not exist: {path!s}.")
     try:
         if Checkpoint.is_checkpoint(path):
-            return _load_unified_checkpoint(path, map_location)
-        return torch.load(path, map_location=map_location, weights_only=False)
+            return _load_unified_checkpoint(
+                path,
+                map_location,
+                weights_only=True if weights_only is None else weights_only,
+            )
+        return torch.load(
+            path,
+            map_location=map_location,
+            weights_only=False if weights_only is None else weights_only,
+        )
     except Exception as err:
         raise RuntimeError(
             f"Could not load checkpoint {path!s}. If this checkpoint uses a custom "
@@ -134,31 +189,37 @@ def load_checkpoint(path: str | Path, map_location: str | torch.device = "cpu") 
 
 
 def checkpoint_hash(path: str | Path) -> str:
-    """Compute a checkpoint digest without reading unrequested payloads.
-
-    Unified checkpoints hash their canonical manifest. Legacy checkpoint files
-    retain the historical whole-file SHA256 behavior.
-    """
+    """Compute a SHA256 digest over all checkpoint bytes."""
     path = Path(path).expanduser()
-    if Checkpoint.is_checkpoint(path):
-        return checkpoint_manifest_hash(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Checkpoint path does not exist: {path!s}.")
     digest = hashlib.sha256()
-    with path.open("rb") as file:
-        for chunk in iter(lambda: file.read(1024 * 1024), b""):
-            digest.update(chunk)
+    files = [path] if path.is_file() else sorted(path.rglob("*"))
+    for file_path in files:
+        if not file_path.is_file():
+            continue
+        if path.is_dir():
+            digest.update(file_path.relative_to(path).as_posix().encode())
+            digest.update(b"\0")
+        with file_path.open("rb") as file:
+            for chunk in iter(lambda: file.read(1024 * 1024), b""):
+                digest.update(chunk)
     return digest.hexdigest()
 
 
 def _load_unified_checkpoint(
-    path: Path, map_location: str | torch.device
+    path: Path,
+    map_location: str | torch.device,
+    *,
+    weights_only: bool,
 ) -> dict[str, Any]:
     manifest = Checkpoint.manifest(path)
     policy = _StateDictComponent()
-    environment_metadata: dict[str, Any] = {}
-    trainer_state: dict[str, Any] = {}
-    metrics: dict[str, Any] = {}
-    config: dict[str, Any] = {}
-    extra: dict[str, Any] = {}
+    environment_metadata = _restore_target(manifest, "environment_metadata")
+    trainer_state = _restore_target(manifest, "trainer_state")
+    metrics = _restore_target(manifest, "metrics")
+    config = _restore_target(manifest, "config")
+    extra = _restore_target(manifest, "extra")
     checkpoint = Checkpoint(
         strict="ignore",
         policy=policy,
@@ -173,8 +234,14 @@ def _load_unified_checkpoint(
         path,
         components=requested,
         map_location=map_location,
+        tensor_load_kwargs={"weights_only": weights_only, "mmap": True},
         strict="ignore",
     )
+    environment_metadata = _restored_mapping(environment_metadata)
+    trainer_state = _restored_mapping(trainer_state)
+    metrics = _restored_mapping(metrics)
+    config = _restored_mapping(config)
+    extra = _restored_mapping(extra)
     payload: dict[str, Any] = {}
     if policy.value is not None:
         payload["model_state_dict"] = policy.value
@@ -188,6 +255,29 @@ def _load_unified_checkpoint(
         payload["config"] = config
     payload.update(extra)
     return payload
+
+
+def _restore_target(manifest: Mapping[str, Any], name: str) -> Any:
+    record = manifest["components"].get(name)
+    if record is not None and record["adapter"] == "torchrl.state_dict":
+        return _StateDictComponent()
+    return {}
+
+
+def _restored_mapping(component: Any) -> dict[str, Any]:
+    if isinstance(component, _StateDictComponent):
+        return dict(component.value or {})
+    return component
+
+
+def _contains_tensor(value: Any) -> bool:
+    if isinstance(value, Tensor):
+        return True
+    if isinstance(value, Mapping):
+        return any(_contains_tensor(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_contains_tensor(item) for item in value)
+    return False
 
 
 def infer_state_dict(payload: Any, key: str | None = None) -> Mapping[str, Tensor]:

--- a/torchrl/render/checkpoint.py
+++ b/torchrl/render/checkpoint.py
@@ -11,6 +11,8 @@ from typing import Any
 
 import torch
 from torch import Tensor
+from torchrl.checkpoint import Checkpoint, CheckpointFormat
+from torchrl.checkpoint._checkpoint import checkpoint_manifest_hash
 
 __all__ = [
     "checkpoint_hash",
@@ -22,6 +24,19 @@ __all__ = [
 _STATE_DICT_KEYS = ("model_state_dict", "policy", "state_dict")
 
 
+class _StateDictComponent:
+    def __init__(self, state_dict: Mapping[str, Any] | None = None) -> None:
+        self.value = state_dict
+
+    def state_dict(self) -> Mapping[str, Any]:
+        if self.value is None:
+            raise RuntimeError("No state dict has been assigned.")
+        return self.value
+
+    def load_state_dict(self, state_dict: Mapping[str, Any]) -> None:
+        self.value = state_dict
+
+
 def save_render_checkpoint(
     path: str | Path | None,
     model: Any,
@@ -31,6 +46,7 @@ def save_render_checkpoint(
     metrics: Mapping[str, Any] | None = None,
     config: Mapping[str, Any] | None = None,
     extra: Mapping[str, Any] | None = None,
+    format: CheckpointFormat = "archive",
 ) -> Path | None:
     """Writes a checkpoint in the layout expected by rlrender factories.
 
@@ -52,6 +68,8 @@ def save_render_checkpoint(
         metrics: Scalar metrics recorded at checkpoint time.
         config: JSON-serializable training configuration.
         extra: Additional payload entries merged last.
+        format: Unified checkpoint container format. Defaults to ``"archive"``
+            to preserve the existing single-path rlrender workflow.
 
     Returns:
         The written checkpoint path, or ``None`` when checkpointing is disabled.
@@ -71,22 +89,20 @@ def save_render_checkpoint(
     """
     if path in (None, ""):
         return None
-    state_dict = model if isinstance(model, Mapping) else model.state_dict()
-    payload: dict[str, Any] = {"model_state_dict": state_dict}
-    if env_metadata:
-        payload.update(dict(env_metadata))
+    policy = _StateDictComponent(model) if isinstance(model, Mapping) else model
+    components: dict[str, Any] = {"policy": policy}
+    if env_metadata is not None:
+        components["environment_metadata"] = dict(env_metadata)
     if frames is not None:
-        payload["frames"] = int(frames)
+        components["trainer_state"] = {"frames": int(frames)}
     if metrics is not None:
-        payload["metrics"] = dict(metrics)
+        components["metrics"] = dict(metrics)
     if config is not None:
-        payload["config"] = dict(config)
-    if extra:
-        payload.update(dict(extra))
+        components["config"] = dict(config)
+    if extra is not None:
+        components["extra"] = dict(extra)
     path = Path(path).expanduser()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    torch.save(payload, path)
-    return path
+    return Checkpoint(format=format, **components).save(path)
 
 
 def load_checkpoint(path: str | Path, map_location: str | torch.device = "cpu") -> Any:
@@ -107,6 +123,8 @@ def load_checkpoint(path: str | Path, map_location: str | torch.device = "cpu") 
     if not path.exists():
         raise FileNotFoundError(f"Checkpoint path does not exist: {path!s}.")
     try:
+        if Checkpoint.is_checkpoint(path):
+            return _load_unified_checkpoint(path, map_location)
         return torch.load(path, map_location=map_location, weights_only=False)
     except Exception as err:
         raise RuntimeError(
@@ -116,13 +134,60 @@ def load_checkpoint(path: str | Path, map_location: str | torch.device = "cpu") 
 
 
 def checkpoint_hash(path: str | Path) -> str:
-    """Computes the SHA256 digest of a local checkpoint file."""
+    """Compute a checkpoint digest without reading unrequested payloads.
+
+    Unified checkpoints hash their canonical manifest. Legacy checkpoint files
+    retain the historical whole-file SHA256 behavior.
+    """
     path = Path(path).expanduser()
+    if Checkpoint.is_checkpoint(path):
+        return checkpoint_manifest_hash(path)
     digest = hashlib.sha256()
     with path.open("rb") as file:
         for chunk in iter(lambda: file.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _load_unified_checkpoint(
+    path: Path, map_location: str | torch.device
+) -> dict[str, Any]:
+    manifest = Checkpoint.manifest(path)
+    policy = _StateDictComponent()
+    environment_metadata: dict[str, Any] = {}
+    trainer_state: dict[str, Any] = {}
+    metrics: dict[str, Any] = {}
+    config: dict[str, Any] = {}
+    extra: dict[str, Any] = {}
+    checkpoint = Checkpoint(
+        strict="ignore",
+        policy=policy,
+        environment_metadata=environment_metadata,
+        trainer_state=trainer_state,
+        metrics=metrics,
+        config=config,
+        extra=extra,
+    )
+    requested = set(checkpoint.components).intersection(manifest["components"])
+    checkpoint.load(
+        path,
+        components=requested,
+        map_location=map_location,
+        strict="ignore",
+    )
+    payload: dict[str, Any] = {}
+    if policy.value is not None:
+        payload["model_state_dict"] = policy.value
+    payload.update(environment_metadata)
+    frames = trainer_state.get("frames", trainer_state.get("collected_frames"))
+    if frames is not None:
+        payload["frames"] = frames
+    if metrics:
+        payload["metrics"] = metrics
+    if config:
+        payload["config"] = config
+    payload.update(extra)
+    return payload
 
 
 def infer_state_dict(payload: Any, key: str | None = None) -> Mapping[str, Tensor]:

--- a/torchrl/trainers/algorithms/configs/trainers.py
+++ b/torchrl/trainers/algorithms/configs/trainers.py
@@ -91,6 +91,7 @@ class SACTrainerConfig(TrainerConfig):
     action_key: Any = "action"
     observation_key: Any = "observation"
     hooks: list[Any] | None = None
+    checkpoint: Any = None
 
     _target_: str = "torchrl.trainers.algorithms.configs.trainers._make_sac_trainer"
 
@@ -118,6 +119,7 @@ def _make_sac_trainer(*args, **kwargs) -> SACTrainer:
     save_trainer_interval = kwargs.pop("save_trainer_interval", 10000)
     log_interval = kwargs.pop("log_interval", 10000)
     save_trainer_file = kwargs.pop("save_trainer_file")
+    checkpoint = kwargs.pop("checkpoint", None)
     seed = kwargs.pop("seed")
     actor_network = kwargs.pop("actor_network")
     critic_network = kwargs.pop("critic_network")
@@ -200,6 +202,7 @@ def _make_sac_trainer(*args, **kwargs) -> SACTrainer:
         save_trainer_interval=save_trainer_interval,
         log_interval=log_interval,
         save_trainer_file=save_trainer_file,
+        checkpoint=checkpoint,
         replay_buffer=replay_buffer,
         batch_size=batch_size,
         enable_logging=enable_logging,
@@ -261,6 +264,7 @@ def _make_offline_to_online_trainer(*args, **kwargs) -> OfflineToOnlineTrainer:
     save_trainer_interval = kwargs.pop("save_trainer_interval", 10000)
     log_interval = kwargs.pop("log_interval", 10000)
     save_trainer_file = kwargs.pop("save_trainer_file")
+    checkpoint = kwargs.pop("checkpoint", None)
     seed = kwargs.pop("seed")
     actor_network = kwargs.pop("actor_network")
     critic_network = kwargs.pop("critic_network")
@@ -340,6 +344,7 @@ def _make_offline_to_online_trainer(*args, **kwargs) -> OfflineToOnlineTrainer:
         save_trainer_interval=save_trainer_interval,
         log_interval=log_interval,
         save_trainer_file=save_trainer_file,
+        checkpoint=checkpoint,
         enable_logging=enable_logging,
         log_rewards=log_rewards,
         log_actions=log_actions,
@@ -461,6 +466,7 @@ class OnPolicyTrainerConfig(TrainerConfig):
     action_key: Any = "action"
     observation_key: Any = "observation"
     hooks: list[Any] | None = None
+    checkpoint: Any = None
 
     def __post_init__(self) -> None:
         """Post-initialization hook for on-policy trainer configurations."""
@@ -527,6 +533,7 @@ def _make_onpolicy_trainer(trainer_cls, *args, **kwargs):
     save_trainer_interval = kwargs.pop("save_trainer_interval", 10000)
     log_interval = kwargs.pop("log_interval", 10000)
     save_trainer_file = kwargs.pop("save_trainer_file", None)
+    checkpoint = kwargs.pop("checkpoint", None)
     seed = kwargs.pop("seed", None)
     actor_network = kwargs.pop("actor_network", None)
     critic_network = kwargs.pop("critic_network", None)
@@ -630,6 +637,7 @@ def _make_onpolicy_trainer(trainer_cls, *args, **kwargs):
         save_trainer_interval=save_trainer_interval,
         log_interval=log_interval,
         save_trainer_file=save_trainer_file,
+        checkpoint=checkpoint,
         replay_buffer=replay_buffer,
         batch_size=batch_size,
         gamma=gamma,
@@ -703,6 +711,7 @@ class DQNTrainerConfig(TrainerConfig):
     log_rewards: bool = True
     log_observations: bool = False
     hooks: list[Any] | None = None
+    checkpoint: Any = None
     mixing_strategy: str | None = None
     done_key: Any = "done"
     terminated_key: Any = "terminated"
@@ -741,6 +750,7 @@ def _make_dqn_trainer(*args, **kwargs) -> DQNTrainer:
     save_trainer_interval = kwargs.pop("save_trainer_interval", 10000)
     log_interval = kwargs.pop("log_interval", 10000)
     save_trainer_file = kwargs.pop("save_trainer_file")
+    checkpoint = kwargs.pop("checkpoint", None)
     seed = kwargs.pop("seed")
     value_network = kwargs.pop("value_network")
     kwargs.pop("create_env_fn", None)
@@ -844,6 +854,7 @@ def _make_dqn_trainer(*args, **kwargs) -> DQNTrainer:
         save_trainer_interval=save_trainer_interval,
         log_interval=log_interval,
         save_trainer_file=save_trainer_file,
+        checkpoint=checkpoint,
         replay_buffer=replay_buffer,
         enable_logging=enable_logging,
         log_rewards=log_rewards,
@@ -907,6 +918,7 @@ class DDPGTrainerConfig(TrainerConfig):
     action_key: Any = "action"
     observation_key: Any = "observation"
     hooks: list[Any] | None = None
+    checkpoint: Any = None
 
     _target_: str = "torchrl.trainers.algorithms.configs.trainers._make_ddpg_trainer"
 
@@ -933,6 +945,7 @@ def _make_ddpg_trainer(*args, **kwargs) -> DDPGTrainer:
     save_trainer_interval = kwargs.pop("save_trainer_interval", 10000)
     log_interval = kwargs.pop("log_interval", 10000)
     save_trainer_file = kwargs.pop("save_trainer_file")
+    checkpoint = kwargs.pop("checkpoint", None)
     seed = kwargs.pop("seed")
     actor_network = kwargs.pop("actor_network")
     critic_network = kwargs.pop("critic_network")
@@ -1000,6 +1013,7 @@ def _make_ddpg_trainer(*args, **kwargs) -> DDPGTrainer:
         save_trainer_interval=save_trainer_interval,
         log_interval=log_interval,
         save_trainer_file=save_trainer_file,
+        checkpoint=checkpoint,
         replay_buffer=replay_buffer,
         enable_logging=enable_logging,
         log_rewards=log_rewards,
@@ -1055,6 +1069,7 @@ class IQLTrainerConfig(TrainerConfig):
     log_actions: bool = True
     log_observations: bool = False
     hooks: list[Any] | None = None
+    checkpoint: Any = None
 
     _target_: str = "torchrl.trainers.algorithms.configs.trainers._make_iql_trainer"
 
@@ -1081,6 +1096,7 @@ def _make_iql_trainer(*args, **kwargs) -> IQLTrainer:
     save_trainer_interval = kwargs.pop("save_trainer_interval", 10000)
     log_interval = kwargs.pop("log_interval", 10000)
     save_trainer_file = kwargs.pop("save_trainer_file")
+    checkpoint = kwargs.pop("checkpoint", None)
     seed = kwargs.pop("seed")
     actor_network = kwargs.pop("actor_network")
     qvalue_network = kwargs.pop("qvalue_network")
@@ -1146,6 +1162,7 @@ def _make_iql_trainer(*args, **kwargs) -> IQLTrainer:
         save_trainer_interval=save_trainer_interval,
         log_interval=log_interval,
         save_trainer_file=save_trainer_file,
+        checkpoint=checkpoint,
         replay_buffer=replay_buffer,
         enable_logging=enable_logging,
         log_rewards=log_rewards,
@@ -1194,6 +1211,7 @@ class CQLTrainerConfig(TrainerConfig):
     log_actions: bool = True
     log_observations: bool = False
     hooks: list[Any] | None = None
+    checkpoint: Any = None
 
     _target_: str = "torchrl.trainers.algorithms.configs.trainers._make_cql_trainer"
 
@@ -1220,6 +1238,7 @@ def _make_cql_trainer(*args, **kwargs) -> CQLTrainer:
     save_trainer_interval = kwargs.pop("save_trainer_interval", 10000)
     log_interval = kwargs.pop("log_interval", 10000)
     save_trainer_file = kwargs.pop("save_trainer_file")
+    checkpoint = kwargs.pop("checkpoint", None)
     seed = kwargs.pop("seed")
     actor_network = kwargs.pop("actor_network")
     qvalue_network = kwargs.pop("qvalue_network")
@@ -1280,6 +1299,7 @@ def _make_cql_trainer(*args, **kwargs) -> CQLTrainer:
         save_trainer_interval=save_trainer_interval,
         log_interval=log_interval,
         save_trainer_file=save_trainer_file,
+        checkpoint=checkpoint,
         replay_buffer=replay_buffer,
         enable_logging=enable_logging,
         log_rewards=log_rewards,
@@ -1334,6 +1354,7 @@ class TD3TrainerConfig(TrainerConfig):
     policy_update_delay: int = 2
     value_estimator_gamma: float | None = None
     hooks: list[Any] | None = None
+    checkpoint: Any = None
     _target_: str = "torchrl.trainers.algorithms.configs.trainers._make_td3_trainer"
 
     def __post_init__(self) -> None:
@@ -1365,6 +1386,7 @@ def _make_td3_trainer(*args, **kwargs):
     save_trainer_interval = kwargs.pop("save_trainer_interval", 10000)
     log_interval = kwargs.pop("log_interval", 10000)
     save_trainer_file = kwargs.pop("save_trainer_file")
+    checkpoint = kwargs.pop("checkpoint", None)
     seed = kwargs.pop("seed")
     num_epochs = kwargs.pop("num_epochs", 1)
     async_collection = kwargs.pop("async_collection", False)
@@ -1491,6 +1513,7 @@ def _make_td3_trainer(*args, **kwargs):
         save_trainer_interval=save_trainer_interval,
         log_interval=log_interval,
         save_trainer_file=save_trainer_file,
+        checkpoint=checkpoint,
         num_epochs=num_epochs,
         replay_buffer=replay_buffer,
         enable_logging=enable_logging,

--- a/torchrl/trainers/algorithms/cql.py
+++ b/torchrl/trainers/algorithms/cql.py
@@ -185,9 +185,6 @@ class CQLTrainer(Trainer):
         if self.enable_logging:
             self._setup_cql_logging()
 
-        if self.checkpoint is not None:
-            self._sync_checkpoint_components()
-
     def _pass_action_spec_from_collector_to_loss(
         self, collector: BaseCollector, loss: LossModule
     ):

--- a/torchrl/trainers/algorithms/cql.py
+++ b/torchrl/trainers/algorithms/cql.py
@@ -15,6 +15,7 @@ from functools import partial
 from tensordict import TensorDict, TensorDictBase
 from torch import optim
 
+from torchrl.checkpoint import Checkpoint
 from torchrl.collectors import BaseCollector
 
 from torchrl.data.replay_buffers.replay_buffers import ReplayBuffer
@@ -96,6 +97,7 @@ class CQLTrainer(Trainer):
         save_trainer_interval: int = 10000,
         log_interval: int = 10000,
         save_trainer_file: str | pathlib.Path | None = None,
+        checkpoint: Checkpoint | None = None,
         replay_buffer: ReplayBuffer | None = None,
         enable_logging: bool = True,
         log_rewards: bool = True,
@@ -142,6 +144,7 @@ class CQLTrainer(Trainer):
             save_trainer_interval=save_trainer_interval,
             log_interval=log_interval,
             save_trainer_file=save_trainer_file,
+            checkpoint=checkpoint,
             async_collection=async_collection,
             log_timings=log_timings,
             auto_log_optim_steps=auto_log_optim_steps,
@@ -163,6 +166,7 @@ class CQLTrainer(Trainer):
             self.register_op("process_optim_batch", rb_trainer.sample)
             self.register_op("post_loss", rb_trainer.update_priority)
 
+        self.target_net_updater = target_net_updater
         self.register_op("post_optim", TargetNetUpdaterHook(target_net_updater))
 
         policy_weights_getter = partial(
@@ -180,6 +184,9 @@ class CQLTrainer(Trainer):
 
         if self.enable_logging:
             self._setup_cql_logging()
+
+        if self.checkpoint is not None:
+            self._sync_checkpoint_components()
 
     def _pass_action_spec_from_collector_to_loss(
         self, collector: BaseCollector, loss: LossModule

--- a/torchrl/trainers/algorithms/ddpg.py
+++ b/torchrl/trainers/algorithms/ddpg.py
@@ -16,6 +16,7 @@ from tensordict import TensorDict, TensorDictBase
 from tensordict.utils import NestedKey
 from torch import optim
 
+from torchrl.checkpoint import Checkpoint
 from torchrl.collectors import BaseCollector
 
 from torchrl.data.replay_buffers.replay_buffers import ReplayBuffer
@@ -100,6 +101,7 @@ class DDPGTrainer(Trainer):
         save_trainer_interval: int = 10000,
         log_interval: int = 10000,
         save_trainer_file: str | pathlib.Path | None = None,
+        checkpoint: Checkpoint | None = None,
         replay_buffer: ReplayBuffer | None = None,
         enable_logging: bool = True,
         log_rewards: bool = True,
@@ -137,6 +139,7 @@ class DDPGTrainer(Trainer):
             save_trainer_interval=save_trainer_interval,
             log_interval=log_interval,
             save_trainer_file=save_trainer_file,
+            checkpoint=checkpoint,
             async_collection=async_collection,
             log_timings=log_timings,
             auto_log_optim_steps=auto_log_optim_steps,
@@ -158,6 +161,7 @@ class DDPGTrainer(Trainer):
             self.register_op("process_optim_batch", rb_trainer.sample)
             self.register_op("post_loss", rb_trainer.update_priority)
 
+        self.target_net_updater = target_net_updater
         self.register_op("post_optim", TargetNetUpdaterHook(target_net_updater))
 
         policy_weights_getter = partial(
@@ -188,6 +192,9 @@ class DDPGTrainer(Trainer):
 
         if self.enable_logging:
             self._setup_ddpg_logging()
+
+        if self.checkpoint is not None:
+            self._sync_checkpoint_components()
 
     def _setup_ddpg_logging(self):
         """Set up logging hooks for DDPG-specific metrics."""

--- a/torchrl/trainers/algorithms/ddpg.py
+++ b/torchrl/trainers/algorithms/ddpg.py
@@ -193,9 +193,6 @@ class DDPGTrainer(Trainer):
         if self.enable_logging:
             self._setup_ddpg_logging()
 
-        if self.checkpoint is not None:
-            self._sync_checkpoint_components()
-
     def _setup_ddpg_logging(self):
         """Set up logging hooks for DDPG-specific metrics."""
         hook_dest = "pre_steps_log" if not self.async_collection else "post_optim_log"

--- a/torchrl/trainers/algorithms/dqn.py
+++ b/torchrl/trainers/algorithms/dqn.py
@@ -259,9 +259,6 @@ class DQNTrainer(Trainer):
         if self.enable_logging:
             self._setup_dqn_logging()
 
-        if self.checkpoint is not None:
-            self._sync_checkpoint_components()
-
     def _step_greedy(self):
         """Advance epsilon-greedy annealing by the number of frames collected since last call."""
         delta = self.collected_frames - self._greedy_last_frames

--- a/torchrl/trainers/algorithms/dqn.py
+++ b/torchrl/trainers/algorithms/dqn.py
@@ -16,6 +16,7 @@ from tensordict import TensorDict, TensorDictBase
 from tensordict.utils import NestedKey
 from torch import optim
 
+from torchrl.checkpoint import Checkpoint
 from torchrl.collectors import BaseCollector
 
 from torchrl.data.replay_buffers.replay_buffers import ReplayBuffer
@@ -143,6 +144,7 @@ class DQNTrainer(Trainer):
         save_trainer_interval: int = 10000,
         log_interval: int = 10000,
         save_trainer_file: str | pathlib.Path | None = None,
+        checkpoint: Checkpoint | None = None,
         replay_buffer: ReplayBuffer | None = None,
         enable_logging: bool = True,
         log_rewards: bool = True,
@@ -183,6 +185,7 @@ class DQNTrainer(Trainer):
             save_trainer_interval=save_trainer_interval,
             log_interval=log_interval,
             save_trainer_file=save_trainer_file,
+            checkpoint=checkpoint,
             async_collection=async_collection,
             log_timings=log_timings,
             auto_log_optim_steps=auto_log_optim_steps,
@@ -213,6 +216,7 @@ class DQNTrainer(Trainer):
             self.register_op("process_optim_batch", rb_trainer.sample)
             self.register_op("post_loss", rb_trainer.update_priority)
 
+        self.target_net_updater = target_net_updater
         self.register_op("post_optim", TargetNetUpdaterHook(target_net_updater))
 
         self.greedy_module = greedy_module
@@ -254,6 +258,9 @@ class DQNTrainer(Trainer):
 
         if self.enable_logging:
             self._setup_dqn_logging()
+
+        if self.checkpoint is not None:
+            self._sync_checkpoint_components()
 
     def _step_greedy(self):
         """Advance epsilon-greedy annealing by the number of frames collected since last call."""

--- a/torchrl/trainers/algorithms/iql.py
+++ b/torchrl/trainers/algorithms/iql.py
@@ -172,9 +172,6 @@ class IQLTrainer(Trainer):
         if self.enable_logging:
             self._setup_iql_logging()
 
-        if self.checkpoint is not None:
-            self._sync_checkpoint_components()
-
     def _setup_iql_logging(self):
         """Set up logging hooks for IQL-specific metrics."""
         hook_dest = "pre_steps_log" if not self.async_collection else "post_optim_log"

--- a/torchrl/trainers/algorithms/iql.py
+++ b/torchrl/trainers/algorithms/iql.py
@@ -15,6 +15,7 @@ from functools import partial
 from tensordict import TensorDict, TensorDictBase
 from torch import optim
 
+from torchrl.checkpoint import Checkpoint
 from torchrl.collectors import BaseCollector
 
 from torchrl.data.replay_buffers.replay_buffers import ReplayBuffer
@@ -98,6 +99,7 @@ class IQLTrainer(Trainer):
         save_trainer_interval: int = 10000,
         log_interval: int = 10000,
         save_trainer_file: str | pathlib.Path | None = None,
+        checkpoint: Checkpoint | None = None,
         replay_buffer: ReplayBuffer | None = None,
         enable_logging: bool = True,
         log_rewards: bool = True,
@@ -129,6 +131,7 @@ class IQLTrainer(Trainer):
             save_trainer_interval=save_trainer_interval,
             log_interval=log_interval,
             save_trainer_file=save_trainer_file,
+            checkpoint=checkpoint,
             async_collection=async_collection,
             log_timings=log_timings,
             auto_log_optim_steps=auto_log_optim_steps,
@@ -150,6 +153,7 @@ class IQLTrainer(Trainer):
             self.register_op("process_optim_batch", rb_trainer.sample)
             self.register_op("post_loss", rb_trainer.update_priority)
 
+        self.target_net_updater = target_net_updater
         self.register_op("post_optim", TargetNetUpdaterHook(target_net_updater))
 
         policy_weights_getter = partial(
@@ -167,6 +171,9 @@ class IQLTrainer(Trainer):
 
         if self.enable_logging:
             self._setup_iql_logging()
+
+        if self.checkpoint is not None:
+            self._sync_checkpoint_components()
 
     def _setup_iql_logging(self):
         """Set up logging hooks for IQL-specific metrics."""

--- a/torchrl/trainers/algorithms/offline_to_online.py
+++ b/torchrl/trainers/algorithms/offline_to_online.py
@@ -13,6 +13,7 @@ from tensordict import TensorDictBase
 from tensordict.utils import NestedKey
 from torch import optim
 
+from torchrl.checkpoint import Checkpoint
 from torchrl.collectors import BaseCollector
 from torchrl.data.replay_buffers.offline_to_online import OfflineToOnlineReplayBuffer
 from torchrl.objectives.common import LossModule
@@ -199,6 +200,7 @@ class OfflineToOnlineTrainer(SACTrainer):
         save_trainer_interval: int = 10000,
         log_interval: int = 10000,
         save_trainer_file: str | pathlib.Path | None = None,
+        checkpoint: Checkpoint | None = None,
         enable_logging: bool = True,
         log_rewards: bool = True,
         log_actions: bool = True,
@@ -242,6 +244,7 @@ class OfflineToOnlineTrainer(SACTrainer):
             save_trainer_interval=save_trainer_interval,
             log_interval=log_interval,
             save_trainer_file=save_trainer_file,
+            checkpoint=checkpoint,
             replay_buffer=None,
             enable_logging=enable_logging,
             log_rewards=log_rewards,
@@ -271,3 +274,6 @@ class OfflineToOnlineTrainer(SACTrainer):
             OfflineToOnlineAnnealHook(self, replay_buffer, self.anneal_frames).register(
                 self
             )
+
+        if self.checkpoint is not None:
+            self._sync_checkpoint_components()

--- a/torchrl/trainers/algorithms/offline_to_online.py
+++ b/torchrl/trainers/algorithms/offline_to_online.py
@@ -274,6 +274,3 @@ class OfflineToOnlineTrainer(SACTrainer):
             OfflineToOnlineAnnealHook(self, replay_buffer, self.anneal_frames).register(
                 self
             )
-
-        if self.checkpoint is not None:
-            self._sync_checkpoint_components()

--- a/torchrl/trainers/algorithms/on_policy.py
+++ b/torchrl/trainers/algorithms/on_policy.py
@@ -16,6 +16,7 @@ from tensordict import TensorDict, TensorDictBase
 from tensordict.utils import NestedKey
 from torch import optim
 
+from torchrl.checkpoint import Checkpoint
 from torchrl.collectors import BaseCollector
 
 from torchrl.data.replay_buffers.replay_buffers import ReplayBuffer
@@ -124,6 +125,7 @@ class OnPolicyTrainer(Trainer):
         save_trainer_interval: int = 10000,
         log_interval: int = 10000,
         save_trainer_file: str | pathlib.Path | None = None,
+        checkpoint: Checkpoint | None = None,
         num_epochs: int | None = None,
         replay_buffer: ReplayBuffer | None = None,
         batch_size: int | None = None,
@@ -170,6 +172,7 @@ class OnPolicyTrainer(Trainer):
             save_trainer_interval=save_trainer_interval,
             log_interval=log_interval,
             save_trainer_file=save_trainer_file,
+            checkpoint=checkpoint,
             num_epochs=num_epochs,
             async_collection=async_collection,
             log_timings=log_timings,
@@ -310,6 +313,9 @@ class OnPolicyTrainer(Trainer):
         # Set up comprehensive logging for on-policy training
         if self.enable_logging:
             self._setup_logging()
+
+        if self.checkpoint is not None:
+            self._sync_checkpoint_components()
 
     def _setup_logging(self):
         """Set up logging hooks for on-policy training metrics.

--- a/torchrl/trainers/algorithms/on_policy.py
+++ b/torchrl/trainers/algorithms/on_policy.py
@@ -314,9 +314,6 @@ class OnPolicyTrainer(Trainer):
         if self.enable_logging:
             self._setup_logging()
 
-        if self.checkpoint is not None:
-            self._sync_checkpoint_components()
-
     def _setup_logging(self):
         """Set up logging hooks for on-policy training metrics.
 

--- a/torchrl/trainers/algorithms/sac.py
+++ b/torchrl/trainers/algorithms/sac.py
@@ -229,9 +229,6 @@ class SACTrainer(Trainer):
         if self.enable_logging:
             self._setup_sac_logging()
 
-        if self.checkpoint is not None:
-            self._sync_checkpoint_components()
-
     def _pass_action_spec_from_collector_to_loss(
         self, collector: BaseCollector, loss: LossModule
     ):

--- a/torchrl/trainers/algorithms/sac.py
+++ b/torchrl/trainers/algorithms/sac.py
@@ -16,6 +16,7 @@ from tensordict import TensorDict, TensorDictBase
 from tensordict.utils import NestedKey
 from torch import optim
 
+from torchrl.checkpoint import Checkpoint
 from torchrl.collectors import BaseCollector
 
 from torchrl.data.replay_buffers.replay_buffers import ReplayBuffer
@@ -128,6 +129,7 @@ class SACTrainer(Trainer):
         save_trainer_interval: int = 10000,
         log_interval: int = 10000,
         save_trainer_file: str | pathlib.Path | None = None,
+        checkpoint: Checkpoint | None = None,
         replay_buffer: ReplayBuffer | None = None,
         batch_size: int | None = None,
         enable_logging: bool = True,
@@ -169,6 +171,7 @@ class SACTrainer(Trainer):
             save_trainer_interval=save_trainer_interval,
             log_interval=log_interval,
             save_trainer_file=save_trainer_file,
+            checkpoint=checkpoint,
             async_collection=async_collection,
             log_timings=log_timings,
             auto_log_optim_steps=auto_log_optim_steps,
@@ -191,6 +194,7 @@ class SACTrainer(Trainer):
                 self.register_op("pre_epoch", rb_trainer.extend)
             self.register_op("process_optim_batch", rb_trainer.sample)
             self.register_op("post_loss", rb_trainer.update_priority)
+        self.target_net_updater = target_net_updater
         self.register_op("post_optim", TargetNetUpdaterHook(target_net_updater))
 
         policy_weights_getter = partial(
@@ -224,6 +228,9 @@ class SACTrainer(Trainer):
         # Set up comprehensive logging for SAC training
         if self.enable_logging:
             self._setup_sac_logging()
+
+        if self.checkpoint is not None:
+            self._sync_checkpoint_components()
 
     def _pass_action_spec_from_collector_to_loss(
         self, collector: BaseCollector, loss: LossModule

--- a/torchrl/trainers/algorithms/td3.py
+++ b/torchrl/trainers/algorithms/td3.py
@@ -299,9 +299,6 @@ class TD3Trainer(Trainer):
         if self.enable_logging:
             self._setup_td3_logging()
 
-        if self.checkpoint is not None:
-            self._sync_checkpoint_components()
-
     def _setup_td3_logging(self):
         """Set up logging hooks for TD3-specific metrics."""
         hook_dest = "pre_steps_log" if not self.async_collection else "post_optim_log"

--- a/torchrl/trainers/algorithms/td3.py
+++ b/torchrl/trainers/algorithms/td3.py
@@ -7,6 +7,7 @@ import torch
 from tensordict import TensorDict, TensorDictBase
 from torch import optim
 
+from torchrl.checkpoint import Checkpoint
 from torchrl.collectors import BaseCollector
 from torchrl.data.replay_buffers.replay_buffers import ReplayBuffer
 from torchrl.objectives.common import LossModule
@@ -212,6 +213,7 @@ class TD3Trainer(Trainer):
         save_trainer_interval: int = 10000,
         log_interval: int = 10000,
         save_trainer_file: str | pathlib.Path | None = None,
+        checkpoint: Checkpoint | None = None,
         num_epochs: int = 1,
         replay_buffer: ReplayBuffer | None = None,
         enable_logging: bool = True,
@@ -246,6 +248,7 @@ class TD3Trainer(Trainer):
             save_trainer_interval=save_trainer_interval,
             log_interval=log_interval,
             save_trainer_file=save_trainer_file,
+            checkpoint=checkpoint,
             num_epochs=num_epochs,
             async_collection=async_collection,
             log_timings=log_timings,
@@ -269,7 +272,10 @@ class TD3Trainer(Trainer):
         # Note: the replay buffer priorities are updated as part of the optimization
         # stepper, as this step requires access to the critic loss.
 
+        self.target_net_updater = target_net_updater
         self.register_op("post_optim", TargetNetUpdaterHook(target_net_updater))
+
+        self.exploration_module = exploration_module
 
         # Here, we build a weight source that mirrors the collector policy structure when
         # an exploration module is used, to allow for simpler weight synchronization.
@@ -292,6 +298,9 @@ class TD3Trainer(Trainer):
 
         if self.enable_logging:
             self._setup_td3_logging()
+
+        if self.checkpoint is not None:
+            self._sync_checkpoint_components()
 
     def _setup_td3_logging(self):
         """Set up logging hooks for TD3-specific metrics."""

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -737,28 +737,28 @@ class Trainer:
     def load_from_file(self, file: str | pathlib.Path, **kwargs) -> Trainer:
         """Loads a file and its state-dict in the trainer.
 
-        Keyword arguments are passed to the :func:`~torch.load` function.
-        Unified checkpoints additionally accept ``strict`` to control missing
-        or incompatible components. Arguments are ignored when
-        ``CKPT_BACKEND=memmap``.
+        Keyword arguments are passed to the :func:`~torch.load` function for
+        legacy torch checkpoints and unified components explicitly saved with
+        the torch state-dict payload format. Unified checkpoints additionally
+        accept ``strict`` to control missing or incompatible components.
+        Arguments are ignored when ``CKPT_BACKEND=memmap``.
 
         .. note::
-            For unified and ``CKPT_BACKEND=torch`` checkpoints,
-            ``weights_only=True`` is the default for safer deserialization.
-            Pass ``weights_only=False``
-            explicitly only if you have custom (non-stdlib) objects in your
-            state dict. On torch < 2.4 the default is ``weights_only=False``
-            because the weights-only unpickler of those versions cannot
-            deserialize the ``torch.device`` instances contained in
-            TensorDict state-dicts.
+            Unified state-dict components use TensorDict storage by default and
+            do not invoke the pickle loader. For explicit torch payloads and
+            ``CKPT_BACKEND=torch`` checkpoints, ``weights_only=True`` is the
+            default for safer deserialization. Pass ``weights_only=False``
+            explicitly only if the state dict contains custom objects. On
+            torch < 2.4 the default is ``weights_only=False`` because the
+            weights-only unpickler of those versions cannot deserialize the
+            ``torch.device`` instances contained in TensorDict state-dicts.
 
         .. note::
-            For unified and ``CKPT_BACKEND=torch`` checkpoints,
-            ``mmap=True`` is set by default so the checkpoint is memory-mapped
-            rather than materialized in RAM at load time. Pass ``mmap=False``
-            for legacy pre-zipfile ``torch.save`` files or file-like objects.
-            On Windows the default is ``mmap=False`` because a mapped
-            checkpoint keeps the file locked, preventing deletion or re-save.
+            Explicit torch payloads and ``CKPT_BACKEND=torch`` checkpoints use
+            ``mmap=True`` by default. Pass ``mmap=False`` for legacy pre-zipfile
+            ``torch.save`` files or file-like objects. On Windows the default
+            is ``mmap=False`` because a mapped checkpoint keeps the file locked,
+            preventing deletion or re-save.
 
         .. note::
             Unified checkpoint tensors are mapped to CPU by default. Pass an

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -398,6 +398,7 @@ class Trainer:
         self.save_trainer_file = save_trainer_file
         self.checkpoint = checkpoint
         self._checkpoint_state = _TrainerCheckpointState(self)
+        self._checkpoint_skip_warnings: set[str] = set()
         self.auto_log_optim_steps = auto_log_optim_steps
 
         self._log_dict = defaultdict(list)
@@ -503,31 +504,61 @@ class Trainer:
                 return policy
         return None
 
-    def _sync_checkpoint_components(self) -> Checkpoint:
-        checkpoint = self.checkpoint
+    def _sync_checkpoint_components(
+        self, checkpoint: Checkpoint | None = None
+    ) -> Checkpoint:
         if checkpoint is None:
-            checkpoint = self.checkpoint = Checkpoint()
+            checkpoint = self.checkpoint
+        if checkpoint is None:
+            checkpoint = Checkpoint()
 
         def register(name: str, component: Any) -> None:
-            if (
-                name not in checkpoint
-                and component is not None
-                and self._is_checkpointable(component)
-            ):
+            if name in checkpoint or component is None:
+                return
+            if self._is_checkpointable(component):
                 checkpoint.register(name, component)
+            elif name not in self._checkpoint_skip_warnings:
+                torchrl_logger.warning(
+                    "Skipping non-checkpointable Trainer component %r (%s).",
+                    name,
+                    type(component).__name__,
+                )
+                self._checkpoint_skip_warnings.add(name)
 
         register("policy", self._checkpoint_policy())
         register("loss_module", self.loss_module)
-        register("optimizer", self.optimizer)
+
+        optimizer = self.optimizer
+        if not self._is_checkpointable(optimizer):
+            optimizer_hook = self._modules.get("optimizer")
+            hook_optimizer = getattr(optimizer_hook, "optimizer", optimizer_hook)
+            optimizer = (
+                hook_optimizer
+                if self._is_checkpointable(hook_optimizer)
+                else optimizer_hook
+            )
+        register("optimizer", optimizer)
+
         register("collector", self.collector)
-        register("replay_buffer", getattr(self, "replay_buffer", None))
+        replay_buffer = getattr(self, "replay_buffer", None)
+        if not self._is_checkpointable(replay_buffer):
+            replay_buffer_hook = self._modules.get("replay_buffer")
+            hook_replay_buffer = getattr(
+                replay_buffer_hook, "replay_buffer", replay_buffer_hook
+            )
+            replay_buffer = (
+                hook_replay_buffer
+                if self._is_checkpointable(hook_replay_buffer)
+                else replay_buffer_hook
+            )
+        register("replay_buffer", replay_buffer)
         register("logger", self.logger)
         register("exploration", getattr(self, "greedy_module", None))
         register("exploration", getattr(self, "exploration_module", None))
         register("target_updater", getattr(self, "target_net_updater", None))
         register("trainer_state", self._checkpoint_state)
         for name, module in self._modules.items():
-            if name in ("optimizer", "replay_buffer"):
+            if name in ("optimizer", "replay_buffer") and name in checkpoint:
                 continue
             register(f"trainer_module.{name}", module)
         return checkpoint
@@ -621,11 +652,16 @@ class Trainer:
             self._sync_checkpoint_components().save(self.save_trainer_file)
             return
         warnings.warn(
-            "The legacy CKPT_BACKEND trainer checkpoint format is deprecated. "
-            "The default will change to torchrl.checkpoint in v0.15 and the "
-            "legacy backend path will be removed in v0.16. Pass "
+            "The default Trainer checkpoint format will change from the legacy "
+            "CKPT_BACKEND format to torchrl.checkpoint in v0.15. Pass "
             "checkpoint=Checkpoint(...) to opt in now.",
             FutureWarning,
+            stacklevel=2,
+        )
+        warnings.warn(
+            "The legacy CKPT_BACKEND trainer checkpoint path is deprecated and "
+            "will be removed in v0.16. Use checkpoint=Checkpoint(...).",
+            DeprecationWarning,
             stacklevel=2,
         )
         if _CKPT_BACKEND == "torchsnapshot":
@@ -682,25 +718,40 @@ class Trainer:
         """Loads a file and its state-dict in the trainer.
 
         Keyword arguments are passed to the :func:`~torch.load` function.
-        They are ignored when ``CKPT_BACKEND=memmap``.
+        Unified checkpoints additionally accept ``strict`` to control missing
+        or incompatible components. Arguments are ignored when
+        ``CKPT_BACKEND=memmap``.
 
         .. note::
-            When ``CKPT_BACKEND=torch``, ``weights_only=True`` is set by
-            default for safer deserialization. Pass ``weights_only=False``
-            explicitly only if you have custom (non-stdlib) objects in your
-            state dict.
+            For unified and ``CKPT_BACKEND=torch`` checkpoints,
+            ``weights_only=True`` is set by default for safer deserialization.
+            Pass ``weights_only=False`` explicitly only if you have custom
+            objects in your state dict and trust the checkpoint source.
 
         .. note::
-            When ``CKPT_BACKEND=torch``, ``mmap=True`` is set by default so
-            the checkpoint is memory-mapped rather than materialized in RAM
-            at load time. Pass ``mmap=False`` if the checkpoint was saved
-            with the legacy (pre-zipfile) ``torch.save`` format or if
-            ``file`` is a file-like object rather than a path.
+            For unified and ``CKPT_BACKEND=torch`` checkpoints, ``mmap=True``
+            is set by default so tensor payloads are memory-mapped rather than
+            materialized in RAM at load time. Pass ``mmap=False`` for legacy
+            pre-zipfile ``torch.save`` files or file-like objects.
+
+        .. note::
+            Unified checkpoint tensors are mapped to CPU by default. Pass an
+            explicit ``map_location`` to select another device mapping.
 
         """
         if Checkpoint.is_checkpoint(file):
-            self._sync_checkpoint_components().load(
-                file, map_location=kwargs.pop("map_location", None)
+            checkpoint = self.checkpoint
+            if checkpoint is None:
+                checkpoint = Checkpoint()
+            map_location = kwargs.pop("map_location", "cpu")
+            strict = kwargs.pop("strict", None)
+            kwargs.setdefault("weights_only", True)
+            kwargs.setdefault("mmap", True)
+            self._sync_checkpoint_components(checkpoint).load(
+                file,
+                map_location=map_location,
+                tensor_load_kwargs=kwargs,
+                strict=strict,
             )
         elif _CKPT_BACKEND == "torchsnapshot":
             snapshot = Snapshot(path=file)

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -764,6 +764,11 @@ class Trainer:
             Unified checkpoint tensors are mapped to CPU by default. Pass an
             explicit ``map_location`` to select another device mapping.
 
+        .. note::
+            After restoring an independently registered policy component, the
+            trainer synchronizes the collector once so local policy copies and
+            remote workers observe the restored learner weights.
+
         """
         if Checkpoint.is_checkpoint(file):
             checkpoint = self.checkpoint
@@ -773,12 +778,22 @@ class Trainer:
             strict = kwargs.pop("strict", None)
             for key, value in _torch_load_defaults().items():
                 kwargs.setdefault(key, value)
-            self._sync_checkpoint_components(checkpoint).load(
+            result = self._sync_checkpoint_components(checkpoint).load(
                 file,
                 map_location=map_location,
                 tensor_load_kwargs=kwargs,
                 strict=strict,
             )
+            if "policy" in result.loaded:
+                # The collector payload is restored before the independently
+                # registered policy component. Synchronize once more after all
+                # components have loaded so local copies, remote workers, and
+                # weight-transport caches observe the restored learner policy.
+                policy = checkpoint.components["policy"]
+                if policy is self._checkpoint_policy():
+                    self.collector.update_policy_weights_()
+                else:
+                    self.collector.update_policy_weights_(policy)
         elif _CKPT_BACKEND == "torchsnapshot":
             snapshot = Snapshot(path=file)
             snapshot.restore(app_state=self.app_state)
@@ -2386,10 +2401,10 @@ class UpdateWeights(TrainerHookBase):
         )
 
     def state_dict(self) -> dict:
-        return {}
+        return {"counter": self.counter}
 
     def load_state_dict(self, state_dict) -> None:
-        return
+        self.counter = state_dict.get("counter", 0)
 
 
 class CountFramesLog(TrainerHookBase):

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -14,7 +14,7 @@ import time
 import warnings
 import weakref
 from collections import defaultdict, OrderedDict
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
 from textwrap import indent
 from typing import Any, Literal
@@ -26,7 +26,6 @@ from tensordict._tensorcollection import TensorCollection
 from tensordict.nn import TensorDictModule
 from tensordict.utils import expand_right
 from torch import nn, optim
-
 from torchrl._utils import (
     _CKPT_BACKEND,
     KeyDependentDefaultDict,
@@ -35,6 +34,8 @@ from torchrl._utils import (
     timeit,
     VERBOSE,
 )
+
+from torchrl.checkpoint import Checkpoint
 from torchrl.collectors import BaseCollector
 from torchrl.collectors.utils import split_trajectories
 from torchrl.data.replay_buffers import (
@@ -78,6 +79,22 @@ LOGGER_METHODS = {
 # Format strings for different data types in progress bar display
 TYPE_DESCR = {float: "4.4f", int: ""}
 REWARD_KEY = ("next", "reward")
+
+
+class _TrainerCheckpointState:
+    """State-dict view over Trainer progress counters."""
+
+    def __init__(self, trainer: Trainer) -> None:
+        self.trainer = trainer
+
+    def state_dict(self) -> dict[str, Any]:
+        return dict(self.trainer._get_state())
+
+    def load_state_dict(self, state_dict: Mapping[str, Any]) -> None:
+        self.trainer.collected_frames = state_dict["collected_frames"]
+        self.trainer._last_log = state_dict["_last_log"]
+        self.trainer._last_save = state_dict["_last_save"]
+        self.trainer._optim_count = state_dict["_optim_count"]
 
 
 def _state_dict_to_td(sd: dict) -> TensorDict:
@@ -292,6 +309,10 @@ class Trainer:
             in frame count. Default is 10000.
         save_trainer_file (path, optional): path where to save the trainer.
             Default is None (no saving)
+        checkpoint (Checkpoint, optional): unified checkpoint object used for
+            scheduled saves and restores. The trainer registers any missing
+            standard components on this object. When omitted, the legacy
+            ``CKPT_BACKEND`` path is retained during the compatibility window.
         async_collection (bool, optional): Whether to collect data asynchronously.
             This will only work if the replay buffer is registered within the data collector.
             If using this, the UTD ratio (Update to Data) will be logged under the key "utd_ratio".
@@ -339,6 +360,7 @@ class Trainer:
         save_trainer_interval: int = 10000,
         log_interval: int = 10000,
         save_trainer_file: str | pathlib.Path | None = None,
+        checkpoint: Checkpoint | None = None,
         num_epochs: int = 1,
         async_collection: bool = False,
         log_timings: bool = False,
@@ -374,6 +396,8 @@ class Trainer:
         self.progress_bar = progress_bar and _has_tqdm
         self.save_trainer_interval = save_trainer_interval
         self.save_trainer_file = save_trainer_file
+        self.checkpoint = checkpoint
+        self._checkpoint_state = _TrainerCheckpointState(self)
         self.auto_log_optim_steps = auto_log_optim_steps
 
         self._log_dict = defaultdict(list)
@@ -450,12 +474,63 @@ class Trainer:
             log_timing_hook = LogTiming(prefix="time", percall=True, erase=False)
             log_timing_hook.register(self)
 
+        if self.checkpoint is not None:
+            self._sync_checkpoint_components()
+
     def register_module(self, module_name: str, module: Any) -> None:
         if module_name in self._modules:
             raise RuntimeError(
                 f"{module_name} is already registered, choose a different name."
             )
         self._modules[module_name] = module
+        if self.checkpoint is not None:
+            self._sync_checkpoint_components()
+
+    @staticmethod
+    def _is_checkpointable(component: Any) -> bool:
+        return (
+            callable(getattr(component, "dump", None))
+            and callable(getattr(component, "load", None))
+        ) or (
+            callable(getattr(component, "state_dict", None))
+            and callable(getattr(component, "load_state_dict", None))
+        )
+
+    def _checkpoint_policy(self) -> Any | None:
+        for name in ("actor_network", "value_network", "local_value_network"):
+            policy = getattr(self.loss_module, name, None)
+            if policy is not None:
+                return policy
+        return None
+
+    def _sync_checkpoint_components(self) -> Checkpoint:
+        checkpoint = self.checkpoint
+        if checkpoint is None:
+            checkpoint = self.checkpoint = Checkpoint()
+
+        def register(name: str, component: Any) -> None:
+            if (
+                name not in checkpoint
+                and component is not None
+                and self._is_checkpointable(component)
+            ):
+                checkpoint.register(name, component)
+
+        register("policy", self._checkpoint_policy())
+        register("loss_module", self.loss_module)
+        register("optimizer", self.optimizer)
+        register("collector", self.collector)
+        register("replay_buffer", getattr(self, "replay_buffer", None))
+        register("logger", self.logger)
+        register("exploration", getattr(self, "greedy_module", None))
+        register("exploration", getattr(self, "exploration_module", None))
+        register("target_updater", getattr(self, "target_net_updater", None))
+        register("trainer_state", self._checkpoint_state)
+        for name, module in self._modules.items():
+            if name in ("optimizer", "replay_buffer"):
+                continue
+            register(f"trainer_module.{name}", module)
+        return checkpoint
 
     def _wrap_hook_with_timing(
         self, op: Callable, hook_name: str | None = None
@@ -542,6 +617,17 @@ class Trainer:
         self._stop_reason = reason
 
     def _save_trainer(self) -> None:
+        if self.checkpoint is not None:
+            self._sync_checkpoint_components().save(self.save_trainer_file)
+            return
+        warnings.warn(
+            "The legacy CKPT_BACKEND trainer checkpoint format is deprecated. "
+            "The default will change to torchrl.checkpoint in v0.15 and the "
+            "legacy backend path will be removed in v0.16. Pass "
+            "checkpoint=Checkpoint(...) to opt in now.",
+            FutureWarning,
+            stacklevel=2,
+        )
         if _CKPT_BACKEND == "torchsnapshot":
             if not _has_ts:
                 raise ImportError(
@@ -612,7 +698,11 @@ class Trainer:
             ``file`` is a file-like object rather than a path.
 
         """
-        if _CKPT_BACKEND == "torchsnapshot":
+        if Checkpoint.is_checkpoint(file):
+            self._sync_checkpoint_components().load(
+                file, map_location=kwargs.pop("map_location", None)
+            )
+        elif _CKPT_BACKEND == "torchsnapshot":
             snapshot = Snapshot(path=file)
             snapshot.restore(app_state=self.app_state)
         elif _CKPT_BACKEND == "torch":

--- a/tutorials/sphinx-tutorials/checkpointing.py
+++ b/tutorials/sphinx-tutorials/checkpointing.py
@@ -22,6 +22,7 @@ from torchrl.checkpoint import (
     CheckpointAdapter,
     CheckpointOptions,
     GlobalRNGState,
+    StateDictCheckpointAdapter,
 )
 
 
@@ -74,6 +75,27 @@ assert load_result.unrequested == {
 archive_path = checkpoint.save(root / "step-128.torchrl", format="archive")
 archive_manifest = Checkpoint.manifest(archive_path)
 assert archive_manifest["container"] == "archive"
+
+
+# State-dict payload formats
+# --------------------------
+# Modules, optimizers, and other state-dict components use TensorDict files by
+# default. The component payload can instead be a TensorDict ZIP archive or a
+# consolidated TensorDict, independently of the outer checkpoint container.
+# Pickle-based torch serialization is available only when selected explicitly.
+
+consolidated_policy_path = root / "consolidated-policy"
+Checkpoint().register(
+    "policy",
+    policy,
+    adapter=StateDictCheckpointAdapter(payload_format="consolidated"),
+).save(consolidated_policy_path)
+
+torch_policy_checkpoint = Checkpoint().register(
+    "policy",
+    policy,
+    adapter=StateDictCheckpointAdapter(payload_format="torch"),
+)
 
 
 # Trainer integration

--- a/tutorials/sphinx-tutorials/checkpointing.py
+++ b/tutorials/sphinx-tutorials/checkpointing.py
@@ -1,0 +1,151 @@
+"""
+Unified checkpointing in TorchRL
+===============================
+
+**What you will learn**
+
+This tutorial shows how to save a standalone training state, restore selected
+components, choose a directory or archive container, integrate the same object
+with a Trainer, and extend checkpointing for a custom component.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import torch
+
+from torchrl.checkpoint import (
+    Checkpoint,
+    CheckpointAdapter,
+    CheckpointOptions,
+    GlobalRNGState,
+)
+
+
+# Standalone training state
+# -------------------------
+# Components are independent. Omitting the replay buffer, optimizer, or RNG is
+# valid, and restoration can select a smaller subset than was saved.
+
+temporary_directory = tempfile.TemporaryDirectory()
+root = Path(temporary_directory.name)
+policy = torch.nn.Linear(4, 2)
+optimizer = torch.optim.Adam(policy.parameters(), lr=3e-4)
+progress = {"frames": 128}
+
+checkpoint = Checkpoint(
+    policy=policy,
+    optimizer=optimizer,
+    trainer_state=progress,
+    rng=GlobalRNGState(),
+    config={"learning_rate": 3e-4},
+)
+directory_path = checkpoint.save(root / "step-128")
+
+
+# Partial restoration and device remapping
+# ----------------------------------------
+# Only the policy file is read. Large unrequested components, such as replay
+# buffers, are neither opened nor materialized.
+
+restored_policy = torch.nn.Linear(4, 2)
+load_result = Checkpoint(policy=restored_policy).load(
+    directory_path,
+    components={"policy"},
+    map_location="cpu",
+)
+assert load_result.loaded == {"policy"}
+assert load_result.unrequested == {
+    "config",
+    "optimizer",
+    "rng",
+    "trainer_state",
+}
+
+
+# Single-file archives
+# --------------------
+# Archives contain the same manifest and component tree. Stored ZIP entries are
+# the default so a replay buffer's own compression is not repeated.
+
+archive_path = checkpoint.save(root / "step-128.torchrl", format="archive")
+archive_manifest = Checkpoint.manifest(archive_path)
+assert archive_manifest["container"] == "archive"
+
+
+# Trainer integration
+# -------------------
+# Every TorchRL algorithm trainer accepts ``checkpoint=``. The trainer adds its
+# known policy, loss, optimizer, collector, replay buffer, progress, and hooks to
+# registrations that the caller has not already supplied. Scheduled saves use
+# this same manifest and adapter implementation.
+
+trainer_checkpoint = Checkpoint(format="directory", rng=GlobalRNGState())
+# trainer = PPOTrainer(..., checkpoint=trainer_checkpoint,
+#                      save_trainer_file="run/checkpoint")
+
+
+# Custom serialization
+# --------------------
+# ``dump`` and ``load`` objects work automatically. An adapter is useful when a
+# third-party class cannot be changed or needs a different on-disk layout.
+
+
+class Cursor:
+    def __init__(self, offset: int = 0) -> None:
+        self.offset = offset
+
+
+class CursorAdapter(CheckpointAdapter):
+    adapter_id = "tutorial.cursor"
+
+    def save(self, component, path, *, args, kwargs):
+        del args, kwargs
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "cursor.json").write_text(json.dumps(component.offset))
+
+    def load(self, component, path, *, map_location, args, kwargs):
+        del map_location, args, kwargs
+        component.offset = json.loads((path / "cursor.json").read_text())
+
+
+cursor_path = root / "cursor-checkpoint"
+Checkpoint().register(
+    "cursor",
+    Cursor(7),
+    adapter=CursorAdapter(),
+    options=CheckpointOptions(),
+).save(cursor_path)
+restored_cursor = Cursor()
+Checkpoint().register("cursor", restored_cursor, adapter=CursorAdapter()).load(
+    cursor_path
+)
+assert restored_cursor.offset == 7
+
+
+# Compatibility
+# -------------
+# Unified loads validate the manifest version and each component adapter
+# version before touching payload files. Trainer checkpoints written through
+# the legacy torch, torchsnapshot, and memmap backends remain readable during
+# the compatibility window; pass ``checkpoint=Checkpoint(...)`` to opt into
+# unified scheduled saves.
+
+
+# Conclusion
+# ----------
+# A single Checkpoint object now covers standalone scripts and trainers while
+# keeping every component optional. The manifest makes partial loading,
+# compatibility reporting, and user-defined adapters explicit.
+
+
+# Further reading
+# ---------------
+# See :class:`torchrl.checkpoint.Checkpoint`,
+# :class:`torchrl.checkpoint.CheckpointAdapter`, and the replay-buffer tutorial
+# for storage-specific checkpoint configuration.
+
+temporary_directory.cleanup()

--- a/tutorials/sphinx-tutorials/checkpointing.py
+++ b/tutorials/sphinx-tutorials/checkpointing.py
@@ -107,8 +107,17 @@ class CursorAdapter(CheckpointAdapter):
         path.mkdir(parents=True, exist_ok=True)
         (path / "cursor.json").write_text(json.dumps(component.offset))
 
-    def load(self, component, path, *, map_location, args, kwargs):
-        del map_location, args, kwargs
+    def load(
+        self,
+        component,
+        path,
+        *,
+        map_location,
+        tensor_load_kwargs,
+        args,
+        kwargs,
+    ):
+        del map_location, tensor_load_kwargs, args, kwargs
         component.offset = json.loads((path / "cursor.json").read_text())
 
 


### PR DESCRIPTION
## Summary

- add the manifest-driven `torchrl.checkpoint` API with directory and ZIP archive containers, atomic replacement, partial loading, adapter/version checks, scoped adapters, operation options, migrations, and process-global RNG state
- bind unified checkpoints across the base Trainer and PPO, A2C, REINFORCE, SAC, offline-to-online SAC, DQN, DDPG, IQL, CQL, and TD3 while retaining versioned legacy backend compatibility
- migrate DQN CartPole and rlrender checkpoint helpers, including full-state resume and policy-only rendering that avoids replay-buffer payloads
- persist target-update, evaluator, logger, hook, and trainer progress and add API documentation plus a Sphinx tutorial

## Testing

- `uv run pytest -q test/test_checkpoint.py test/test_render.py`
- `uv run pytest -q test/test_trainer.py -k 'unified_trainer_checkpoint or subclass_exposes_checkpoint or stepper_checkpoint_roundtrip'`
- `uv run pytest -q test/test_configs.py -k 'checkpoint_config_parity or (TrainerConfigs and trainer_config)'`
- `uv run pytest -q test/collectors/test_evaluator.py -k checkpoint_state`
- `uv run pytest -q test/test_loggers.py -k checkpoint_state`
- DQN CartPole archive save and resume smoke tests
- `uv run python tutorials/sphinx-tutorials/checkpointing.py`
- pre-commit hooks on all changed files
