### PR TITLE
[Test] Skip PPO vecnorm checkpoint roundtrip test without a gym backend

### DIFF
--- a/test/test_render.py
+++ b/test/test_render.py
@@ -49,6 +49,7 @@ from torchrl.render.mujoco_wasm import extract_qpos_trajectory
 from torchrl.render.video import compose_frame_grid, normalize_frame_output
 
 _has_pil = importlib.util.find_spec("PIL") is not None
+_has_gym = importlib.util.find_spec("gym") is not None
 _has_gymnasium = importlib.util.find_spec("gymnasium") is not None
 _has_pygame = importlib.util.find_spec("pygame") is not None
 
@@ -1344,6 +1345,10 @@ class TestSotaCheckpointFactories:
         assert make_eval_env_kwargs(cfg)["num_envs"] == 1
         assert make_eval_env_kwargs(cfg)["batch_mode"] == "parallel"
 
+    @pytest.mark.skipif(
+        not (_has_gym or _has_gymnasium),
+        reason="gym or gymnasium is required for the CartPole PPO env",
+    )
     def test_ppo_vecnorm_checkpoint_roundtrip(self, tmp_path):
         utils_path = Path("sota-implementations/ppo/utils_mujoco.py").resolve()
         ppo_make_env = import_from_string(f"{utils_path}:make_env")


### PR DESCRIPTION
## Description

`test/test_render.py::TestSotaCheckpointFactories::test_ppo_vecnorm_checkpoint_roundtrip` fails deterministically on main's push CI in the tests-optdeps job and the Windows unittests job with:

```
ModuleNotFoundError: Supported version of 'torchrl.envs.libs.gym.GymEnv._set_gym_args' has not been found.
```

Those jobs install neither gym nor gymnasium. The test builds a `GymEnv("CartPole-v1")` via the PPO sota-implementations `make_env` factory but, unlike its siblings in `TestSotaCheckpointFactories`, carries no gym-backend skip guard. With no backend installed, `implement_for` dispatch on `_set_gym_args` fails in `GymEnv.__init__` before `_build_env` can raise its friendlier "gym not found" error.

The `implement_for` version ranges on `_set_gym_args` are exhaustive, and the test passes in the tests-cpu jobs, so this is purely a missing skip guard rather than a dispatch or version-range bug.

## Fix

Add a `skipif` guard that skips the test when neither gym nor gymnasium is importable. The guard accepts either backend because tests-olddeps runs the test with only `gym==0.13` (no gymnasium) and passes, so guarding on gymnasium alone would regress coverage there.

Generated with [Claude Code](https://claude.com/claude-code)