### PR TITLE
[Test] Make mock environment observation keys deterministic

### DIFF
--- a/test/envs/test_env_base.py
+++ b/test/envs/test_env_base.py
@@ -8,6 +8,8 @@ import argparse
 import functools
 import gc
 import pickle
+import subprocess
+import sys
 import warnings
 from functools import partial
 from typing import Any
@@ -1081,6 +1083,49 @@ class TestResetSetState:
             warnings.simplefilter("error", FutureWarning)
             out = env.reset(td)
         assert (out["observation"] == 0).all()
+
+
+_MOCK_ENV_KEY_CASES = [
+    # (class name, out_key, pixel shape or None for vector obs)
+    ("DiscreteActionVecMockEnv", "observation", None),
+    ("ContinuousActionVecMockEnv", "observation", None),
+    ("DiscreteActionConvMockEnv", "pixels", (1, 7, 7)),
+    ("DiscreteActionConvMockEnvNumpy", "pixels", (7, 7, 3)),
+    ("ContinuousActionConvMockEnv", "pixels", (1, 7, 7)),
+    ("ContinuousActionConvMockEnvNumpy", "pixels", (7, 7, 3)),
+]
+
+
+@pytest.mark.parametrize("cls_name,out_key,pixel_shape", _MOCK_ENV_KEY_CASES)
+def test_mock_env_keys_first_instance_explicit_specs(cls_name, out_key, pixel_shape):
+    # Regression test: the mock envs used to set cls.out_key/_out_key inside
+    # their __new__, guarded behind `observation_spec is None`. Constructing
+    # a mock with an explicit observation_spec as the FIRST instance in the
+    # process then failed with AttributeError (exposed by pytest-xdist
+    # ordering), and unconditional assignment in a parent stomped the keys
+    # of Conv subclasses delegating to it. The keys are now class-level
+    # attributes; a subprocess guarantees true first-instance conditions.
+    shape = list(pixel_shape) if pixel_shape is not None else [7]
+    orig_key = "pixels_orig" if out_key == "pixels" else "observation_orig"
+    script = f"""
+import torch
+from torchrl.data.tensor_specs import Composite, Unbounded
+from torchrl.testing.mocking_classes import {cls_name}
+
+spec = Composite(
+    {out_key}=Unbounded(shape=torch.Size({shape})),
+    {orig_key}=Unbounded(shape=torch.Size({shape})),
+)
+env = {cls_name}(observation_spec=spec)
+assert env.out_key == {out_key!r}, env.out_key
+assert env._out_key == {orig_key!r}, env._out_key
+td = env.reset()
+assert {out_key!r} in td.keys(), list(td.keys())
+td = env.rand_step(td)
+assert ("next", {out_key!r}) in td.keys(True), list(td.keys(True))
+env.rollout(3)
+"""
+    subprocess.run([sys.executable, "-c", script], check=True, timeout=300)
 
 
 if __name__ == "__main__":

--- a/torchrl/testing/mocking_classes.py
+++ b/torchrl/testing/mocking_classes.py
@@ -516,6 +516,15 @@ class StateLessCountingEnv(EnvBase):
 class DiscreteActionVecMockEnv(_MockEnv):
     """Mock env with vector observations and discrete (one-hot/categorical) actions."""
 
+    # Observation keys read/written by _reset and _step. Class-level defaults
+    # (overridden by the Conv subclasses) rather than assignments in __new__:
+    # mutating them per-instantiation made explicit-spec instances depend on
+    # which class was constructed first in the process (broke under
+    # pytest-xdist test-order shuffling), and unconditional assignment in the
+    # parent stomped the keys selected by Conv subclasses delegating here.
+    out_key = "observation"
+    _out_key = "observation_orig"
+
     @classmethod
     def __new__(
         cls,
@@ -532,7 +541,6 @@ class DiscreteActionVecMockEnv(_MockEnv):
         batch_size = kwargs.setdefault("batch_size", torch.Size([]))
         size = cls.size = 7
         if observation_spec is None:
-            cls.out_key = "observation"
             observation_spec = Composite(
                 observation=Unbounded(shape=torch.Size([*batch_size, size])),
                 observation_orig=Unbounded(shape=torch.Size([*batch_size, size])),
@@ -553,7 +561,6 @@ class DiscreteActionVecMockEnv(_MockEnv):
             )
 
         if state_spec is None:
-            cls._out_key = "observation_orig"
             state_spec = Composite(
                 {
                     cls._out_key: observation_spec["observation"],
@@ -623,6 +630,9 @@ class ContinuousActionVecMockEnv(_MockEnv):
     """Mock env with vector observations and continuous (bounded) actions."""
 
     adapt_dtype: bool = True
+    # See DiscreteActionVecMockEnv for why these are class-level defaults.
+    out_key = "observation"
+    _out_key = "observation_orig"
 
     @classmethod
     def __new__(
@@ -639,7 +649,6 @@ class ContinuousActionVecMockEnv(_MockEnv):
         batch_size = kwargs.setdefault("batch_size", torch.Size([]))
         size = cls.size = 7
         if observation_spec is None:
-            cls.out_key = "observation"
             observation_spec = Composite(
                 observation=Unbounded(shape=torch.Size([*batch_size, size])),
                 observation_orig=Unbounded(shape=torch.Size([*batch_size, size])),
@@ -660,7 +669,6 @@ class ContinuousActionVecMockEnv(_MockEnv):
             done_spec = Categorical(2, dtype=torch.bool, shape=(*batch_size, 1))
 
         if state_spec is None:
-            cls._out_key = "observation_orig"
             state_spec = Composite(
                 {
                     cls._out_key: observation_spec["observation"],
@@ -760,6 +768,9 @@ class DiscreteActionVecPolicy(TensorDictModuleBase):
 class DiscreteActionConvMockEnv(DiscreteActionVecMockEnv):
     """Mock env with image-like observations and discrete (one-hot) actions."""
 
+    out_key = "pixels"
+    _out_key = "pixels_orig"
+
     @classmethod
     def __new__(
         cls,
@@ -774,7 +785,6 @@ class DiscreteActionConvMockEnv(DiscreteActionVecMockEnv):
     ):
         batch_size = kwargs.setdefault("batch_size", torch.Size([]))
         if observation_spec is None:
-            cls.out_key = "pixels"
             observation_spec = Composite(
                 pixels=Unbounded(shape=torch.Size([*batch_size, 1, 7, 7])),
                 pixels_orig=Unbounded(shape=torch.Size([*batch_size, 1, 7, 7])),
@@ -788,7 +798,6 @@ class DiscreteActionConvMockEnv(DiscreteActionVecMockEnv):
             done_spec = Categorical(2, dtype=torch.bool, shape=(*batch_size, 1))
 
         if state_spec is None:
-            cls._out_key = "pixels_orig"
             state_spec = Composite(
                 {
                     cls._out_key: observation_spec["pixels_orig"].clone(),
@@ -832,7 +841,6 @@ class DiscreteActionConvMockEnvNumpy(DiscreteActionConvMockEnv):
     ):
         batch_size = kwargs.setdefault("batch_size", torch.Size([]))
         if observation_spec is None:
-            cls.out_key = "pixels"
             observation_spec = Composite(
                 pixels=Unbounded(shape=torch.Size([*batch_size, 7, 7, 3])),
                 pixels_orig=Unbounded(shape=torch.Size([*batch_size, 7, 7, 3])),
@@ -842,7 +850,6 @@ class DiscreteActionConvMockEnvNumpy(DiscreteActionConvMockEnv):
             action_spec_cls = Categorical if categorical_action_encoding else OneHot
             action_spec = action_spec_cls(7, shape=(*batch_size, 7))
         if state_spec is None:
-            cls._out_key = "pixels_orig"
             state_spec = Composite(
                 {
                     cls._out_key: observation_spec["pixels_orig"],
@@ -876,6 +883,9 @@ class DiscreteActionConvMockEnvNumpy(DiscreteActionConvMockEnv):
 class ContinuousActionConvMockEnv(ContinuousActionVecMockEnv):
     """Mock env with image-like observations and continuous (bounded) actions."""
 
+    out_key = "pixels"
+    _out_key = "pixels_orig"
+
     @classmethod
     def __new__(
         cls,
@@ -893,7 +903,6 @@ class ContinuousActionConvMockEnv(ContinuousActionVecMockEnv):
         if pixel_shape is None:
             pixel_shape = [1, 7, 7]
         if observation_spec is None:
-            cls.out_key = "pixels"
             observation_spec = Composite(
                 pixels=Unbounded(shape=torch.Size([*batch_size, *pixel_shape])),
                 pixels_orig=Unbounded(shape=torch.Size([*batch_size, *pixel_shape])),
@@ -907,7 +916,6 @@ class ContinuousActionConvMockEnv(ContinuousActionVecMockEnv):
         if done_spec is None:
             done_spec = Categorical(2, dtype=torch.bool, shape=(*batch_size, 1))
         if state_spec is None:
-            cls._out_key = "pixels_orig"
             state_spec = Composite(
                 {cls._out_key: observation_spec["pixels"]}, shape=batch_size
             )
@@ -948,7 +956,6 @@ class ContinuousActionConvMockEnvNumpy(ContinuousActionConvMockEnv):
     ):
         batch_size = kwargs.setdefault("batch_size", torch.Size([]))
         if observation_spec is None:
-            cls.out_key = "pixels"
             observation_spec = Composite(
                 pixels=Unbounded(shape=torch.Size([*batch_size, 7, 7, 3])),
                 pixels_orig=Unbounded(shape=torch.Size([*batch_size, 7, 7, 3])),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3973
* #3972
* #3971
* __->__ #3970
* #3969

The Vec/Conv mock envs set cls.out_key/_out_key inside __new__, guarded
behind 'observation_spec is None'. Two consequences:

- Constructing a mock with an explicit observation_spec as the first
  instance in a process raised AttributeError: the class attribute was
  only populated by an earlier default instantiation. Serial CI always
  had such an instantiation first; pytest-xdist's scheduling produced
  pristine workers where TestNextObservationDelta::test_multi_in_keys_explicit
  failed on 3 of 5 CPU jobs.
- Any unconditional assignment in the parent would stomp the
  pixels/pixels_orig keys selected by Conv subclasses that delegate to
  the parent __new__ with explicit specs.

Define the keys as class-level attributes instead - observation/
observation_orig on DiscreteActionVecMockEnv and ContinuousActionVecMockEnv,
overridden with pixels/pixels_orig on the Conv subclasses - and remove
every per-instantiation cls mutation. Add a parametrized regression test
that constructs each of the six mock classes with explicit specs as the
first instance of a fresh interpreter and exercises reset(), rand_step()
and rollout(); it fails on the previous code for all six classes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>