### PR TITLE
[CI] Record coverage from pytest-xdist workers

### DIFF
--- a/.github/unittest/helpers/coverage_run_parallel.py
+++ b/.github/unittest/helpers/coverage_run_parallel.py
@@ -56,6 +56,11 @@ def main(argv: list[str]) -> int:
         os.environ["COVERAGE_RCFILE"] = str(
             config_path
         )  # This gets passed down to subprocesses
+        # Trace subprocesses that are not multiprocessing children (notably
+        # pytest-xdist execnet workers): the coverage_process_startup.pth
+        # installed in site-packages calls coverage.process_startup(), which
+        # is a no-op unless COVERAGE_PROCESS_START points at a config file.
+        os.environ["COVERAGE_PROCESS_START"] = str(config_path)
         write_config(config_path, argv)
         return subprocess.run(["coverage", "run"]).returncode
 

--- a/.github/unittest/linux_optdeps/scripts/run_all.sh
+++ b/.github/unittest/linux_optdeps/scripts/run_all.sh
@@ -174,11 +174,19 @@ export CKPT_BACKEND=torch
 export MAX_IDLE_COUNT=100
 export BATCHED_PIPE_TIMEOUT=60
 
+# Track test failures but keep going, so coverage is still combined and
+# uploaded; the script exits with this status at the end. (Previously the
+# script aborted on the pytest failure via set -e, before coverage upload.)
+EXIT_STATUS=0
+
 python .github/unittest/helpers/coverage_run_parallel.py -m pytest test \
   --instafail --durations 200 -vv --capture no --ignore test/test_rlhf.py \
   --ignore test/test_distributed.py \
   --ignore test/llm \
-  --timeout=120 --mp_fork_if_no_cuda
+  --timeout=120 --mp_fork_if_no_cuda || EXIT_STATUS=$?
+if [ $EXIT_STATUS -ne 0 ]; then
+  echo "Some tests failed with exit status $EXIT_STATUS"
+fi
 
 coverage combine -q
 coverage xml -i
@@ -191,3 +199,6 @@ cp coverage.xml artifacts-to-be-uploaded/ || true
 # ================================ Post-proc ========================================= #
 
 bash ${this_dir}/post_process.sh
+
+# Exit with failure if any tests failed
+exit $EXIT_STATUS


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3973
* __->__ #3972
* #3971
* #3970
* #3969

pytest-xdist's execnet workers are plain subprocesses, not
multiprocessing children, so coverage's concurrency=multiprocessing never
saw them: GPU shard 3 (running under xdist for months) has silently
contributed no worker coverage. coverage.py already ships a .pth hook
(a1_coverage.pth) that calls coverage.process_startup() in every new
interpreter whenever COVERAGE_PROCESS_START is set - the missing piece
was exporting it. coverage_run_parallel.py now sets
COVERAGE_PROCESS_START to the same generated config it passes via
COVERAGE_RCFILE.

Verified locally on an xdist run (-n 2 --dist worksteal) of a transforms
test file: without the export, coverage combine sees 1 data file and 105
traced lines (the wrapper process only); with it, 7 data files and the
full 66k-line report, matching a serial run.

Also let the optdeps script keep going on test failure so coverage is
still combined and uploaded, propagating the exit status at the end
(previously set -e aborted before the upload).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>