### PR TITLE
[BugFix] Version- and platform-aware defaults for trainer checkpoint loading

### DIFF
--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -42,6 +42,7 @@ from torchrl.trainers.helpers import transformed_env_constructor
 from torchrl.trainers.trainers import (
     _has_tqdm,
     _has_ts,
+    _torch_load_defaults,
     BatchSubSampler,
     CountFramesLog,
     DefaultOptimizationStepper,
@@ -239,8 +240,12 @@ class TestLoadFromFile:
 
             trainer2 = mocking_trainer()
             trainer2.load_from_file(file)
-            assert captured["mmap"] is True
-            assert captured["weights_only"] is True
+            # mmap defaults to False on Windows (a mapped checkpoint locks the
+            # file) and weights_only to False on torch < 2.4 (its weights-only
+            # unpickler rejects torch.device).
+            defaults = _torch_load_defaults()
+            assert captured["mmap"] is defaults["mmap"]
+            assert captured["weights_only"] is defaults["weights_only"]
 
             captured.clear()
             trainer2.load_from_file(file, mmap=False)

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -10,6 +10,7 @@ import itertools
 import json
 import math
 import pathlib
+import sys
 import time
 import warnings
 import weakref
@@ -29,6 +30,7 @@ from torch import nn, optim
 
 from torchrl._utils import (
     _CKPT_BACKEND,
+    implement_for,
     KeyDependentDefaultDict,
     logger as torchrl_logger,
     rl_warnings,
@@ -78,6 +80,24 @@ LOGGER_METHODS = {
 # Format strings for different data types in progress bar display
 TYPE_DESCR = {float: "4.4f", int: ""}
 REWARD_KEY = ("next", "reward")
+
+# On Windows, a memory-mapped checkpoint keeps the file locked for as long as
+# the loaded tensors are alive, so the checkpoint could neither be deleted nor
+# safely re-saved. Only default to ``mmap=True`` on other platforms.
+_MMAP_CKPT_DEFAULT = sys.platform != "win32"
+
+
+@implement_for("torch", "2.4")
+def _torch_load_defaults() -> dict[str, Any]:
+    return {"weights_only": True, "mmap": _MMAP_CKPT_DEFAULT}
+
+
+@implement_for("torch", None, "2.4")
+def _torch_load_defaults() -> dict[str, Any]:  # noqa: F811
+    # The weights-only unpickler of torch < 2.4 does not allow
+    # ``torch.device``, which TensorDict state-dicts carry as their
+    # ``__device`` metadata entry.
+    return {"weights_only": False, "mmap": _MMAP_CKPT_DEFAULT}
 
 
 def _state_dict_to_td(sd: dict) -> TensorDict:
@@ -602,22 +622,28 @@ class Trainer:
             When ``CKPT_BACKEND=torch``, ``weights_only=True`` is set by
             default for safer deserialization. Pass ``weights_only=False``
             explicitly only if you have custom (non-stdlib) objects in your
-            state dict.
+            state dict. On torch < 2.4 the default is ``weights_only=False``
+            because the weights-only unpickler of those versions cannot
+            deserialize the ``torch.device`` instances contained in
+            TensorDict state-dicts.
 
         .. note::
             When ``CKPT_BACKEND=torch``, ``mmap=True`` is set by default so
             the checkpoint is memory-mapped rather than materialized in RAM
             at load time. Pass ``mmap=False`` if the checkpoint was saved
             with the legacy (pre-zipfile) ``torch.save`` format or if
-            ``file`` is a file-like object rather than a path.
+            ``file`` is a file-like object rather than a path. On Windows
+            the default is ``mmap=False``: a mapped checkpoint would keep
+            the file locked, preventing it from being deleted or re-saved
+            while the loaded state is alive.
 
         """
         if _CKPT_BACKEND == "torchsnapshot":
             snapshot = Snapshot(path=file)
             snapshot.restore(app_state=self.app_state)
         elif _CKPT_BACKEND == "torch":
-            kwargs.setdefault("weights_only", True)
-            kwargs.setdefault("mmap", True)
+            for key, value in _torch_load_defaults().items():
+                kwargs.setdefault(key, value)
             loaded_dict: OrderedDict = torch.load(file, **kwargs)
             self.load_state_dict(loaded_dict)
         elif _CKPT_BACKEND == "memmap":


### PR DESCRIPTION
## Description

#3959 made `Trainer.load_from_file` (with `CKPT_BACKEND=torch`) default to `weights_only=True, mmap=True` unconditionally. This broke two CI configurations on main:

- **tests-olddeps (torch 2.1.1)**: `test/test_trainer.py::TestLoadFromFile::test_resume_and_resave_replay_buffer` fails with `UnpicklingError: Unsupported class torch.device`. `TensorDict.state_dict()` stores the replay-buffer storage device as a `__device` metadata entry, and torch only added `torch.device` to the weights-only unpickler allowlist in 2.4. (Failure: run 29008373573.)
- **Windows**: several `test_trainer.py` RB save tests fail with `PermissionError [WinError 5]` / `NotADirectoryError [WinError 267]` at tempdir teardown. With `mmap=True`, `load_state_dict` assigns the mmap-backed tensors directly into the replay-buffer storage, so the checkpoint file stays memory-mapped for as long as the trainer state is alive; Windows refuses to unlink a mapped file. Outside CI this means a Windows user cannot delete (and may not be able to overwrite) a checkpoint while the trainer is alive. (Failure: run 29008675236.)

## Fix

Dispatch the `torch.load` defaults through `implement_for` in a `_torch_load_defaults()` helper:

- `weights_only=True` only on torch >= 2.4; older versions fall back to `weights_only=False` (the pre-#3959 behavior), since their weights-only unpickler cannot deserialize these checkpoints at all.
- `mmap=True` only on non-Windows platforms.

Explicitly passed kwargs still take precedence, and the `load_from_file` docstring notes document both behaviors. `test_torch_backend_mmap_default` now asserts the captured `torch.load` kwargs against `_torch_load_defaults()` instead of hard-coded values, so it remains correct on Windows and old torch.

## Testing

- `TestLoadFromFile` (including `test_resume_and_resave_replay_buffer`) and the non-prioritized RB/SelectKeys/RewardNorm save tests pass locally; the prioritized variants fail identically on unmodified main in this environment (missing compiled `SumSegmentTreeFp32` extension) and are unaffected.
- Emulated the Windows configuration by forcing `_MMAP_CKPT_DEFAULT = False` and ran the full save/load/re-save/re-load replay-buffer scenario: data round-trips and the checkpoint can be deleted while the loaded state is alive.
- The torch 2.1 path is exercised by the tests-olddeps job; with `weights_only=False` the failing unpickler is bypassed entirely (`mmap` exists since torch 2.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)