### PR TITLE
[CI] Gate subprocess coverage tracing to xdist runs

### DIFF
--- a/.github/unittest/helpers/coverage_run_parallel.py
+++ b/.github/unittest/helpers/coverage_run_parallel.py
@@ -60,7 +60,17 @@ def main(argv: list[str]) -> int:
         # pytest-xdist execnet workers): the coverage_process_startup.pth
         # installed in site-packages calls coverage.process_startup(), which
         # is a no-op unless COVERAGE_PROCESS_START points at a config file.
-        os.environ["COVERAGE_PROCESS_START"] = str(config_path)
+        #
+        # Opt-in via TORCHRL_COV_TRACE_SUBPROCESSES=1 (set by the xdist
+        # invocations in linux/scripts/run_all.sh). The variable reaches every
+        # Python interpreter spawned anywhere under the test run - parallel-env
+        # workers, collector workers, Ray workers - and starting a tracer in
+        # each of them roughly doubles worker startup (measured: torch+torchrl
+        # import 0.8s -> 1.5s) and line-traces everything the worker runs.
+        # Exporting it unconditionally pushed the serial optdeps job past its
+        # 2h CI timeout (~88min -> >120min of pytest).
+        if os.environ.get("TORCHRL_COV_TRACE_SUBPROCESSES") == "1":
+            os.environ["COVERAGE_PROCESS_START"] = str(config_path)
         write_config(config_path, argv)
         return subprocess.run(["coverage", "run"]).returncode
 

--- a/.github/unittest/linux/scripts/run_all.sh
+++ b/.github/unittest/linux/scripts/run_all.sh
@@ -455,6 +455,11 @@ run_non_distributed_tests() {
     timeout_args="--timeout=300"
     export OMP_NUM_THREADS=1
     export MKL_NUM_THREADS=1
+    # Let coverage_run_parallel.py export COVERAGE_PROCESS_START so the xdist
+    # execnet workers get traced. Only for xdist runs: the variable makes every
+    # spawned interpreter start a tracer, which roughly doubles worker startup
+    # and slows serial process-spawning suites far past their CI timeout.
+    export TORCHRL_COV_TRACE_SUBPROCESSES=1
     echo "Using pytest-xdist for parallel execution (${xdist_args})"
   fi
 
@@ -527,7 +532,7 @@ run_non_distributed_tests() {
           ${json_report_args} \
           ${common_args} ${timeout_args} || mp_status=$?
         echo "Running all tests, serial remainder (${quarantine_tests})"
-        env -u OMP_NUM_THREADS -u MKL_NUM_THREADS \
+        env -u OMP_NUM_THREADS -u MKL_NUM_THREADS -u TORCHRL_COV_TRACE_SUBPROCESSES \
         python .github/unittest/helpers/coverage_run_parallel.py -m pytest ${quarantine_tests} \
           "${GPU_MARKER_FILTER[@]}" \
           --json-report --json-report-file="${json_report_dir}/test-results-shard-${shard}-mp.json" --json-report-indent=2 \


### PR DESCRIPTION
## Description

`coverage_run_parallel.py` exported `COVERAGE_PROCESS_START` unconditionally, causing coverage's startup hook to attach a tracer to every Python interpreter spawned under a test run. This includes parallel environment workers, collector workers, and Ray workers in serial suites, not only the pytest-xdist workers the export was intended to cover. The added startup and line-tracing overhead pushed the process-heavy optdeps job beyond its two-hour timeout.

The export is now opt-in via `TORCHRL_COV_TRACE_SUBPROCESSES=1`:

- xdist invocations in the Linux test runner enable subprocess tracing so worker coverage is retained;
- serial suites keep the pre-xdist behavior;
- the serial quarantine remainder explicitly removes the opt-in variable when it runs after an xdist bulk pass.

After rebasing, the docs pull-request guard fix is already present on `main`, so this PR now contains only the remaining coverage fix.

## Validation

- `uvx --with autoflake pre-commit run --files .github/unittest/helpers/coverage_run_parallel.py .github/unittest/linux/scripts/run_all.sh`
- `bash -n .github/unittest/linux/scripts/run_all.sh`
- direct wrapper probe confirming `COVERAGE_PROCESS_START` is unset by default and populated when the opt-in flag is enabled
