### PR TITLE
[CI] Run the CPU quarantine shards on the oldest and newest Python only

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -46,11 +46,60 @@ jobs:
   tests-cpu:
     strategy:
       matrix:
+        # Every Python version runs the xdist bulk (24k tests in ~5 min --
+        # the smoke subset for the middle versions). The serial quarantine
+        # shards (collectors + mp, the expensive part) run on the oldest and
+        # newest Python only; the middle versions get them on non-PR events
+        # via tests-cpu-quarantine-mid below.
         python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        # Fan the job out into the xdist bulk and the two halves of the
-        # process-spawning quarantine (collectors dominates it), so the job
-        # wall is the max of the three instead of their sum.
-        shard: ["bulk", "collectors", "mp"]
+        shard: ["bulk"]
+        include:
+          - python_version: "3.10"
+            shard: "collectors"
+          - python_version: "3.10"
+            shard: "mp"
+          - python_version: "3.14"
+            shard: "collectors"
+          - python_version: "3.14"
+            shard: "mp"
+      fail-fast: false
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      runner: linux.12xlarge
+      repository: pytorch/rl
+      docker-image: "nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04"
+      timeout: 120
+      upload-artifact: test-results-cpu-${{ matrix.python_version }}-shard-${{ matrix.shard }}
+      script: |
+        if [[ "${{ github.ref }}" =~ release/* ]]; then
+          export RELEASE=1
+          export TORCH_VERSION=stable
+        else
+          export RELEASE=0
+          export TORCH_VERSION=nightly
+        fi
+        export TD_GET_DEFAULTS_TO_NONE=1
+        # Set env vars from matrix
+        export PYTHON_VERSION=${{ matrix.python_version }}
+        export CU_VERSION="cpu"
+        export TORCHRL_TEST_SHARD=${{ matrix.shard }}
+
+        echo "PYTHON_VERSION: $PYTHON_VERSION"
+        echo "CU_VERSION: $CU_VERSION"
+
+        ## setup_env.sh
+        bash .github/unittest/linux/scripts/run_all.sh
+
+  # Serial quarantine shards for the middle Python versions. Skipped on pull
+  # requests (3.10 and 3.14 bracket the version range there); pushes to main
+  # and the nightly orchestrator keep full five-version coverage. For an
+  # on-demand full run on a PR branch, use workflow_dispatch.
+  tests-cpu-quarantine-mid:
+    if: github.event_name != 'pull_request'
+    strategy:
+      matrix:
+        python_version: ["3.11", "3.12", "3.13"]
+        shard: ["collectors", "mp"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
@@ -327,6 +376,7 @@ jobs:
   upload-codecov:
     needs:
       - tests-cpu
+      - tests-cpu-quarantine-mid
       - tests-gpu
       - tests-gpu-distributed
       - tests-optdeps


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3993
* #3992
* #3983
* #3982
* #3981
* #3980
* #3979
* #3978
* __->__ #3977
* #3976
* #3991

All five tests-cpu Python versions previously paid the full serial
quarantine on every PR push. Keep the xdist bulk (24k tests in ~5 min)
on all five versions as the middle-version smoke subset, and run the
expensive collectors/mp quarantine shards on 3.10 and 3.14 only, which
bracket the supported range.

A separate tests-cpu-quarantine-mid job covers 3.11-3.13 and is skipped
on pull requests: pushes to main and the nightly orchestrator retain
full five-version quarantine coverage, and workflow_dispatch provides
an on-demand full run for a PR branch. No PR-label gate: a "labeled"
trigger type would retrigger the whole workflow and the ref-keyed
cancel-in-progress group would cancel in-flight runs.

upload-codecov now also waits on the mid job so its coverage artifacts
are included on non-PR events (skipped needs do not block if: always()).

Saves roughly two linux.12xlarge runner-hours per PR push.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>