### PR TITLE
[CI] Shard the olddeps job

### DIFF
--- a/.github/unittest/linux_olddeps/scripts_gym_0_13/environment.yml
+++ b/.github/unittest/linux_olddeps/scripts_gym_0_13/environment.yml
@@ -17,6 +17,7 @@ dependencies:
     - pytest-mock
     - pytest-instafail
     - pytest-rerunfailures
+    - pytest-json-report
     - expecttest
     - pyyaml
     - scipy

--- a/.github/unittest/linux_olddeps/scripts_gym_0_13/run_test.sh
+++ b/.github/unittest/linux_olddeps/scripts_gym_0_13/run_test.sh
@@ -28,14 +28,68 @@ python .github/unittest/helpers/coverage_run_parallel.py -m pytest test/smoke_te
 export DISPLAY=:99
 Xvfb :99 -screen 0 1400x900x24 > /dev/null 2>&1 &
 
-CKPT_BACKEND=torch MUJOCO_GL=egl python .github/unittest/helpers/coverage_run_parallel.py -m pytest \
-    --instafail -v \
-    --durations 200 \
-    --ignore test/test_distributed.py \
-    --ignore test/test_rlhf.py \
-    --ignore test/llm \
-    -k "not HalfCheetah-v2" \
-    --mp_fork_if_no_cuda
+# Test sharding: the single serial run of the full suite reached 84 minutes,
+# making olddeps the critical path of the unit-test workflows. The workflow
+# fans the job out over three shards (TORCHRL_TEST_SHARD); "all" keeps the
+# previous single-invocation behavior. The union of the three shards equals
+# "all". Every shard stays serial inside its job: these tests share one GPU
+# and the process-spawning set flakes next to parallel workers.
+# - transforms: test/transforms plus the test_setup.py install tests (both
+#   off the critical path of the big remainder);
+# - quarantine: the process-spawning set (mirrors linux/scripts/run_all.sh);
+# - remainder: everything else.
+TORCHRL_TEST_SHARD="${TORCHRL_TEST_SHARD:-all}"
+
+quarantine_tests="test/envs/test_parallel.py test/envs/test_special.py \
+test/envs/test_auto_reset.py test/envs/test_env_base.py \
+test/envs/test_nested.py test/envs/test_step_mdp.py test/test_collectors.py \
+test/services test/test_inference_server.py test/test_loggers.py"
+quarantine_ignores=""
+for quarantine_path in ${quarantine_tests}; do
+    quarantine_ignores+="--ignore ${quarantine_path} "
+done
+
+# JSON report for flaky-test tracking and future shard balancing; lands in
+# the job artifact when RUNNER_ARTIFACT_DIR is set.
+json_report_dir="${RUNNER_ARTIFACT_DIR:-${root_dir}}"
+json_report_args="--json-report --json-report-file=${json_report_dir}/test-results-olddeps-shard-${TORCHRL_TEST_SHARD}.json --json-report-indent=2"
+
+common_args=(--instafail -v --durations 200 -k "not HalfCheetah-v2" --mp_fork_if_no_cuda ${json_report_args})
+
+case "${TORCHRL_TEST_SHARD}" in
+    transforms)
+        CKPT_BACKEND=torch MUJOCO_GL=egl python .github/unittest/helpers/coverage_run_parallel.py -m pytest \
+            test/transforms test/test_setup.py \
+            "${common_args[@]}"
+        ;;
+    quarantine)
+        CKPT_BACKEND=torch MUJOCO_GL=egl python .github/unittest/helpers/coverage_run_parallel.py -m pytest \
+            ${quarantine_tests} \
+            "${common_args[@]}"
+        ;;
+    remainder)
+        CKPT_BACKEND=torch MUJOCO_GL=egl python .github/unittest/helpers/coverage_run_parallel.py -m pytest \
+            test \
+            --ignore test/test_distributed.py \
+            --ignore test/test_rlhf.py \
+            --ignore test/llm \
+            --ignore test/transforms \
+            --ignore test/test_setup.py \
+            ${quarantine_ignores} \
+            "${common_args[@]}"
+        ;;
+    all)
+        CKPT_BACKEND=torch MUJOCO_GL=egl python .github/unittest/helpers/coverage_run_parallel.py -m pytest \
+            --ignore test/test_distributed.py \
+            --ignore test/test_rlhf.py \
+            --ignore test/llm \
+            "${common_args[@]}"
+        ;;
+    *)
+        echo "Unknown TORCHRL_TEST_SHARD='${TORCHRL_TEST_SHARD}'. Expected: all|transforms|quarantine|remainder."
+        exit 2
+        ;;
+esac
 
 #pytest --instafail -v --durations 200
 #python test/libs

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -221,6 +221,10 @@ jobs:
       matrix:
         python_version: ["3.10"]
         cuda_arch_version: ["11.8"]
+        # The single serial run reached 84 min of pytest (96 min job wall),
+        # the critical path of the unit-test workflows. Fan out into three
+        # serial shards; see linux_olddeps/scripts_gym_0_13/run_test.sh.
+        shard: ["transforms", "quarantine", "remainder"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
@@ -230,6 +234,7 @@ jobs:
       gpu-arch-type: cuda
       gpu-arch-version: ${{ matrix.cuda_arch_version }}
       timeout: 120
+      upload-artifact: test-results-olddeps-shard-${{ matrix.shard }}
       script: |
         set -euo pipefail
         export PYTHON_VERSION="3.10"
@@ -244,6 +249,7 @@ jobs:
         fi
         export TF_CPP_MIN_LOG_LEVEL=0
         export TD_GET_DEFAULTS_TO_NONE=1
+        export TORCHRL_TEST_SHARD=${{ matrix.shard }}
 
 
         bash .github/unittest/linux_olddeps/scripts_gym_0_13/setup_env.sh


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3993
* #3992
* #3983
* #3982
* #3981
* #3980
* #3979
* __->__ #3978
* #3977
* #3976
* #3991

tests-olddeps spent 84 minutes in one serial pytest invocation (96
minutes end to end) on the last measured run, making it the critical
path of the unit-test workflows.

Parameterize its run_test.sh with TORCHRL_TEST_SHARD and fan the job
out over three shards, each still serial inside its runner (shared GPU;
the process-spawning set flakes next to parallel workers):

- transforms: test/transforms plus the two test_setup.py install tests
  (243s on the last run), both moved off the remainder critical path;
- quarantine: the process-spawning set, mirroring the list in
  linux/scripts/run_all.sh;
- remainder: everything else.

The union of the shards equals the previous selection (verified with
pytest --collect-only: 29,597 tests, identical set, no overlap); "all"
preserves the single-invocation behavior for local use.

Also add pytest-json-report to the olddeps environment and upload
per-shard JSON reports as artifacts, so the next balancing pass has
duration data.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>