### PR TITLE
[CI] Contain hard hangs in the optdeps job

### DIFF
--- a/.github/unittest/linux_optdeps/scripts/run_all.sh
+++ b/.github/unittest/linux_optdeps/scripts/run_all.sh
@@ -186,18 +186,20 @@ EXIT_STATUS=0
 #   and kills the process, so the first hard hang fails the run loudly in
 #   minutes instead of silently eating the job. The tradeoff (a per-test
 #   timeout aborts the whole run) is acceptable here: a 120s+ test in this
-#   serial suite has always meant a hang, not a slow test.
+#   serial suite has meant a hang, with one known exception -- the
+#   test_setup.py install tests, which carry their own 600s marker.
 # - timeout(1) guard: last-resort process-level bound in case even the
-#   timer thread cannot run; 100 minutes leaves room for coverage combine
-#   and artifact upload within the 120-minute job budget.
-timeout -k 60 100m \
+#   timer thread cannot run; 105 minutes leaves room for coverage combine
+#   and artifact upload within the 120-minute job budget (a healthy run
+#   under memory pressure has been observed at 98 minutes of pytest).
+timeout -k 60 105m \
 python .github/unittest/helpers/coverage_run_parallel.py -m pytest test \
   --instafail --durations 200 -vv --capture no --ignore test/test_rlhf.py \
   --ignore test/test_distributed.py \
   --ignore test/llm \
   --timeout=120 --timeout-method=thread --mp_fork_if_no_cuda || EXIT_STATUS=$?
 if [ $EXIT_STATUS -eq 124 ]; then
-  echo "pytest was killed by the 100-minute hang guard"
+  echo "pytest was killed by the 105-minute hang guard"
 elif [ $EXIT_STATUS -ne 0 ]; then
   echo "Some tests failed with exit status $EXIT_STATUS"
 fi

--- a/.github/unittest/linux_optdeps/scripts/run_all.sh
+++ b/.github/unittest/linux_optdeps/scripts/run_all.sh
@@ -179,34 +179,64 @@ export BATCHED_PIPE_TIMEOUT=60
 # script aborted on the pytest failure via set -e, before coverage upload.)
 EXIT_STATUS=0
 
-# Hang containment, two layers (an uninterruptible C-level teardown once
-# consumed the full two-hour job budget while producing no output):
-# - --timeout-method=thread: the default signal method provably failed to
-#   interrupt that teardown. The thread method dumps every thread's stack
-#   and kills the process, so the first hard hang fails the run loudly in
-#   minutes instead of silently eating the job. The tradeoff (a per-test
-#   timeout aborts the whole run) is acceptable here: a 120s+ test in this
-#   serial suite has meant a hang, with one known exception -- the
-#   test_setup.py install tests, which carry their own 600s marker.
-# - timeout(1) guard: last-resort process-level bound in case even the
-#   timer thread cannot run; 105 minutes leaves room for coverage combine
-#   and artifact upload within the 120-minute job budget (a healthy run
-#   under memory pressure has been observed at 98 minutes of pytest).
-timeout -k 60 105m \
+# Hang containment (an uninterruptible C-level teardown once consumed the
+# full two-hour job budget while producing no output). A fixed wall-clock
+# guard cannot work here: healthy runs have been measured anywhere between
+# 76 and 105+ minutes of pytest, so any budget tight enough to save the job
+# also kills slow-but-progressing runs. Neither can pytest-timeout's thread
+# method: its killer thread needs the GIL, which the native hang holds, and
+# it turns any legitimately slow test into a whole-run abort. The reliable
+# signal is inactivity -- the suite prints a line every few seconds under
+# -vv while the observed hang was a full hour of silence -- so a watchdog
+# kills the run only after 20 minutes without output.
+pytest_log="${root_dir}/optdeps-pytest.log"
+stall_flag="${root_dir}/optdeps-stalled"
+rm -f "${stall_flag}"
+: > "${pytest_log}"
+# Line-buffer python output through the tee pipe so the log's mtime tracks
+# real pytest activity (and CI log streaming stays live).
+export PYTHONUNBUFFERED=1
+
+# setsid gives pytest its own process group so the watchdog can kill the
+# whole tree without touching this script.
+setsid bash -c '
 python .github/unittest/helpers/coverage_run_parallel.py -m pytest test \
   --instafail --durations 200 -vv --capture no --ignore test/test_rlhf.py \
   --ignore test/test_distributed.py \
   --ignore test/llm \
-  --timeout=120 --timeout-method=thread --mp_fork_if_no_cuda || EXIT_STATUS=$?
-if [ $EXIT_STATUS -eq 124 ]; then
-  echo "pytest was killed by the 105-minute hang guard"
+  --timeout=120 --mp_fork_if_no_cuda
+' > >(tee "${pytest_log}") 2>&1 &
+pytest_pid=$!
+
+(
+  set +x
+  stall_limit=$((20 * 60))
+  while kill -0 "${pytest_pid}" 2>/dev/null; do
+    sleep 60
+    last_output=$(stat -c %Y "${pytest_log}" 2>/dev/null || echo 0)
+    if [ $(( $(date +%s) - last_output )) -ge "${stall_limit}" ]; then
+      touch "${stall_flag}"
+      echo "No pytest output for ${stall_limit}s; killing the hung run"
+      kill -TERM -- "-${pytest_pid}" 2>/dev/null
+      sleep 60
+      kill -KILL -- "-${pytest_pid}" 2>/dev/null
+      break
+    fi
+  done
+) &
+watchdog_pid=$!
+
+wait "${pytest_pid}" || EXIT_STATUS=$?
+kill "${watchdog_pid}" 2>/dev/null || true
+if [ -f "${stall_flag}" ]; then
+  echo "pytest was killed by the 20-minute inactivity watchdog"
 elif [ $EXIT_STATUS -ne 0 ]; then
   echo "Some tests failed with exit status $EXIT_STATUS"
 fi
 
-# Tolerate combine failures: a run killed by the hang guard may leave no
+# Tolerate combine failures: a run killed by the watchdog may leave no
 # usable coverage data, and the remaining artifacts should still upload.
-coverage combine -q || echo "coverage combine failed (expected after a hang-guard kill)"
+coverage combine -q || echo "coverage combine failed (expected after a watchdog kill)"
 coverage xml -i || true
 
 # Copy coverage report for Codecov artifact upload

--- a/.github/unittest/linux_optdeps/scripts/run_all.sh
+++ b/.github/unittest/linux_optdeps/scripts/run_all.sh
@@ -179,17 +179,33 @@ export BATCHED_PIPE_TIMEOUT=60
 # script aborted on the pytest failure via set -e, before coverage upload.)
 EXIT_STATUS=0
 
+# Hang containment, two layers (an uninterruptible C-level teardown once
+# consumed the full two-hour job budget while producing no output):
+# - --timeout-method=thread: the default signal method provably failed to
+#   interrupt that teardown. The thread method dumps every thread's stack
+#   and kills the process, so the first hard hang fails the run loudly in
+#   minutes instead of silently eating the job. The tradeoff (a per-test
+#   timeout aborts the whole run) is acceptable here: a 120s+ test in this
+#   serial suite has always meant a hang, not a slow test.
+# - timeout(1) guard: last-resort process-level bound in case even the
+#   timer thread cannot run; 100 minutes leaves room for coverage combine
+#   and artifact upload within the 120-minute job budget.
+timeout -k 60 100m \
 python .github/unittest/helpers/coverage_run_parallel.py -m pytest test \
   --instafail --durations 200 -vv --capture no --ignore test/test_rlhf.py \
   --ignore test/test_distributed.py \
   --ignore test/llm \
-  --timeout=120 --mp_fork_if_no_cuda || EXIT_STATUS=$?
-if [ $EXIT_STATUS -ne 0 ]; then
+  --timeout=120 --timeout-method=thread --mp_fork_if_no_cuda || EXIT_STATUS=$?
+if [ $EXIT_STATUS -eq 124 ]; then
+  echo "pytest was killed by the 100-minute hang guard"
+elif [ $EXIT_STATUS -ne 0 ]; then
   echo "Some tests failed with exit status $EXIT_STATUS"
 fi
 
-coverage combine -q
-coverage xml -i
+# Tolerate combine failures: a run killed by the hang guard may leave no
+# usable coverage data, and the remaining artifacts should still upload.
+coverage combine -q || echo "coverage combine failed (expected after a hang-guard kill)"
+coverage xml -i || true
 
 # Copy coverage report for Codecov artifact upload
 mkdir -p artifacts-to-be-uploaded

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 import os
 import shutil
@@ -9,6 +10,14 @@ import pytest
 
 _ROOT = Path(__file__).resolve().parents[1]
 _IS_WINDOWS = sys.platform == "win32"
+_has_pytest_timeout = importlib.util.find_spec("pytest_timeout") is not None
+
+# The install tests shell out to full pip/uv builds and legitimately run for
+# minutes, so a suite-wide --timeout=120 is too tight for them; under
+# --timeout-method=thread (optdeps) an over-budget test kills the whole pytest
+# process. The marker is applied only when pytest-timeout is installed: the
+# minimal setup-test job runs this file without the plugin.
+pytestmark = [pytest.mark.timeout(600)] if _has_pytest_timeout else []
 
 
 def _run(cmd, *, cwd, env=None, timeout=60 * 60) -> str:

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -13,10 +13,10 @@ _IS_WINDOWS = sys.platform == "win32"
 _has_pytest_timeout = importlib.util.find_spec("pytest_timeout") is not None
 
 # The install tests shell out to full pip/uv builds and legitimately run for
-# minutes, so a suite-wide --timeout=120 is too tight for them; under
-# --timeout-method=thread (optdeps) an over-budget test kills the whole pytest
-# process. The marker is applied only when pytest-timeout is installed: the
-# minimal setup-test job runs this file without the plugin.
+# minutes (243s observed in CI, longer on a loaded runner), so a suite-wide
+# --timeout=120 is too tight for them. The marker is applied only when
+# pytest-timeout is installed: the minimal setup-test job runs this file
+# without the plugin.
 pytestmark = [pytest.mark.timeout(600)] if _has_pytest_timeout else []
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3993
* #3992
* #3983
* #3982
* #3981
* #3980
* __->__ #3979
* #3978
* #3977
* #3976
* #3991

On the last measured run, optdeps stopped producing output right before
a TestComposableBuffers.test_pickable teardown and was still alive an
hour later, despite --timeout=120: the default signal method cannot
interrupt an uninterruptible C-level teardown, so the hang consumed the
full two-hour job budget as a silent cancellation.

Fixed budgets do not work here. Two earlier attempts on this PR proved
it on real runs: a per-test thread-method timeout killed the whole run
when a legitimately slow install test exceeded 120s on a swapping
runner, and a 105-minute wall-clock guard killed a healthy run that was
still passing tests (the suite has been measured anywhere between 76
and 105+ minutes). The thread method also cannot interrupt the original
hang: its killer thread needs the GIL that the native teardown holds.

The reliable signal is inactivity. Under -vv the suite prints a line
every few seconds, while the observed hang was a full hour of silence,
so pytest output is now teed to a log whose mtime a watchdog polls; the
run is killed (process group, TERM then KILL) only after 20 minutes
with no output, with a distinct message. PYTHONUNBUFFERED keeps the
pipe line-buffered so mtime tracks real activity.

The test_setup.py install tests keep a pytest.mark.timeout(600) module
marker (applied only when pytest-timeout is installed): they shell out
to full pip/uv builds and legitimately exceed the suite-wide 120s on a
loaded runner.

coverage combine/xml stay tolerant of missing data so a watchdog-killed
run still uploads whatever artifacts it produced. No layout change: the
job stays a single serial pytest (a split was measured net-slower).
