### PR TITLE
[CI] Shard the SOTA smoke tests into two parallel jobs

### DIFF
--- a/.github/unittest/linux_sota/scripts/run_test.sh
+++ b/.github/unittest/linux_sota/scripts/run_test.sh
@@ -27,16 +27,23 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$lib_dir
 export MKL_THREADING_LAYER=GNU
 export CUDA_LAUNCH_BLOCKING=1
 
-# JSON report for flaky test tracking
+# JSON report for flaky test tracking. Distinct file names per invocation
+# (the smoke and sota reports previously shared one name, so the second
+# overwrote the first) and per shard, so parallel shard jobs don't collide.
+sota_shard="${SOTA_SHARD:-all}"
 json_report_dir="${RUNNER_ARTIFACT_DIR:-${root_dir}}"
-json_report_args="--json-report --json-report-file=${json_report_dir}/test-results-sota.json --json-report-indent=2"
+smoke_json_report_args="--json-report --json-report-file=${json_report_dir}/test-results-sota-smoke-shard-${sota_shard}.json --json-report-indent=2"
+sota_json_report_args="--json-report --json-report-file=${json_report_dir}/test-results-sota-shard-${sota_shard}.json --json-report-indent=2"
 
-python .github/unittest/helpers/coverage_run_parallel.py -m pytest test/smoke_test.py ${json_report_args} -v --durations 200
+python .github/unittest/helpers/coverage_run_parallel.py -m pytest test/smoke_test.py ${smoke_json_report_args} -v --durations 200
 
-coverage run -m pytest .github/unittest/linux_sota/scripts/test_sota.py ${json_report_args} --instafail --durations 200 -vvv --capture no
+coverage run -m pytest .github/unittest/linux_sota/scripts/test_sota.py ${sota_json_report_args} --instafail --durations 200 -vvv --capture no
 
-# unit tests living next to the recipes they cover (tiny models, no downloads)
-python .github/unittest/helpers/coverage_run_parallel.py -m pytest sota-implementations/vla_grpo/test_openvla.py -v --durations 20
+# unit tests living next to the recipes they cover (tiny models, no
+# downloads). Run once, on the first (or only) shard.
+if [ "${sota_shard}" = "all" ] || [ "${sota_shard}" = "1" ]; then
+  python .github/unittest/helpers/coverage_run_parallel.py -m pytest sota-implementations/vla_grpo/test_openvla.py -v --durations 20
+fi
 
 coverage combine -q
 coverage xml -i

--- a/.github/unittest/linux_sota/scripts/test_sota.py
+++ b/.github/unittest/linux_sota/scripts/test_sota.py
@@ -347,6 +347,26 @@ commands = {
 """,
 }
 
+# CI sharding: the smoke list runs as SOTA_NUM_SHARDS parallel jobs, each
+# selecting an interleaved slice of the sorted command list via SOTA_SHARD
+# (1-based). Interleaving keeps the heavy neighbors (dreamer/dreamer_v3) on
+# different shards. Both variables unset (the local default) runs everything.
+_num_shards = int(os.environ.get("SOTA_NUM_SHARDS", "1"))
+_shard = os.environ.get("SOTA_SHARD")
+if _num_shards > 1:
+    if _shard is None:
+        raise RuntimeError("SOTA_NUM_SHARDS is set but SOTA_SHARD is not.")
+    _shard_index = int(_shard) - 1
+    if not 0 <= _shard_index < _num_shards:
+        raise RuntimeError(
+            f"SOTA_SHARD={_shard} is out of range for SOTA_NUM_SHARDS={_num_shards}."
+        )
+    commands = {
+        algo: command
+        for index, (algo, command) in enumerate(sorted(commands.items()))
+        if index % _num_shards == _shard_index
+    }
+
 
 def run_command(command):
     # Get the current coverage settings

--- a/.github/workflows/test-linux-sota.yml
+++ b/.github/workflows/test-linux-sota.yml
@@ -41,6 +41,7 @@ jobs:
       gpu-arch-type: cuda
       gpu-arch-version: ${{ matrix.cuda_arch_version }}
       timeout: 90
+      upload-artifact: test-results-sota-shard-${{ matrix.shard }}
       script: |
         # Set env vars from matrix
         export PYTHON_VERSION=${{ matrix.python_version }}

--- a/.github/workflows/test-linux-sota.yml
+++ b/.github/workflows/test-linux-sota.yml
@@ -29,6 +29,9 @@ jobs:
       matrix:
         python_version: ["3.10"]
         cuda_arch_version: ["13.0"]
+        # Two parallel shards over the smoke-test list; see the SOTA_SHARD
+        # filtering in .github/unittest/linux_sota/scripts/test_sota.py.
+        shard: ["1", "2"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
@@ -60,6 +63,8 @@ jobs:
         echo "PYTHON_VERSION: $PYTHON_VERSION"
         echo "CU_VERSION: $CU_VERSION"
         export TD_GET_DEFAULTS_TO_NONE=1
+        export SOTA_SHARD=${{ matrix.shard }}
+        export SOTA_NUM_SHARDS=2
 
         ## setup_env.sh
         bash .github/unittest/linux_sota/scripts/run_all.sh


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3993
* #3992
* #3983
* #3982
* #3981
* __->__ #3980
* #3979
* #3978
* #3977
* #3976
* #3991

The SOTA smoke list runs as a single serial job (33-36 minutes) that
grows with every algorithm. Fan it out over two jobs: test_sota.py
selects an interleaved slice of the sorted command list via SOTA_SHARD
/ SOTA_NUM_SHARDS (unset = run everything, so local behavior is
unchanged), and the workflow adds shard: ["1", "2"] to the matrix.

Verified with pytest --collect-only: shards of 18 and 17 tests, union
identical to the full list, no overlap, and the two heavy dreamer
entries land on different shards thanks to the interleaving.

The per-recipe openvla unit tests now run on shard 1 only, and the
smoke/sota JSON reports get distinct per-shard file names (previously
both invocations wrote test-results-sota.json, the second overwriting
the first, so the flaky tracker never saw the smoke results).

Costs one duplicated GPU environment build per push; the wall-clock
halving of the dominant pytest phase outweighs it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>