### PR TITLE
[CI] Demote the Windows suite to nightly

### DIFF
--- a/.github/workflows/test-windows-optdepts.yml
+++ b/.github/workflows/test-windows-optdepts.yml
@@ -1,11 +1,12 @@
 name: Unit-tests on Windows
 
+# The full-suite Windows run takes ~70 minutes. It no longer runs on pull
+# requests or pushes to main: the nightly orchestrator drives it daily via
+# workflow_call (and feeds the nightly dashboard). For an on-demand run on a
+# PR branch, use workflow_dispatch on that branch.
 on:
-  pull_request:
   push:
     branches:
-      - nightly
-      - main
       - release/*
   workflow_dispatch:
   workflow_call:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3993
* #3992
* #3983
* #3982
* __->__ #3981
* #3980
* #3979
* #3978
* #3977
* #3976
* #3991

The Windows job runs the full test suite serially and took 71 minutes
(60 minutes of pytest) on the last measured run, on every pull request
and every push to main.

Drop the pull_request and main/nightly push triggers. The nightly
orchestrator keeps running it daily via workflow_call, where its result
feeds the nightly dashboard, and release/* pushes still get the full
run. For an on-demand check of a PR branch, dispatch the workflow on
that branch.

Nightly Windows failures will now implicate a day of commits rather
than a single push; the runner-hour and queue-contention savings on
every PR are worth that coarser attribution.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>