### PR TITLE
[CI] Move benchmarks to the nightly run, label opt-in on PRs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,8 +1,9 @@
 name: Continuous Benchmark
+# No longer runs on every push to main (2 x ~40-60 min GPU jobs per push):
+# the nightly orchestrator calls it daily via workflow_call and uploads the
+# results to the gh-pages trend dashboard. workflow_dispatch remains for
+# on-demand runs.
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
   workflow_call:
     inputs:

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -1,6 +1,11 @@
 name: Continuous Benchmark (PR)
+# Opt-in only: the baseline-vs-head comparison costs 2 x ~40-60 min GPU jobs
+# per PR push, and most PRs don't touch performance-relevant code. Add the
+# "benchmarks" label to a PR to run it (the "labeled" trigger starts the run
+# as soon as the label is applied).
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read
@@ -16,6 +21,7 @@ jobs:
 
   benchmark:
     name: ${{ matrix.device }} Pytest benchmark
+    if: contains(github.event.pull_request.labels.*.name, 'benchmarks')
     runs-on: linux.g5.4xlarge.nvidia.gpu
     env:
       PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}

--- a/.github/workflows/benchmarks_pr_comment.yml
+++ b/.github/workflows/benchmarks_pr_comment.yml
@@ -36,6 +36,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BENCHMARK_RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
+          # On unlabeled PRs the benchmark job is skipped (label opt-in) and
+          # the run completes without artifacts; there is nothing to comment.
+          if [ ! -d benchmark-artifacts ] || [ -z "$(ls -A benchmark-artifacts)" ]; then
+            echo "No benchmark artifacts found (benchmark job was skipped); nothing to comment."
+            exit 0
+          fi
           python .github/scripts/comment_pr_benchmarks.py \
             --artifact-root benchmark-artifacts \
             --repository "${{ github.repository }}" \

--- a/.github/workflows/nightly_orchestrator.yml
+++ b/.github/workflows/nightly_orchestrator.yml
@@ -139,7 +139,10 @@ jobs:
     if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/benchmarks.yml
     with:
-      skip-upload: true
+      # The nightly run is now the sole feed of the gh-pages benchmark trend
+      # (benchmarks.yml no longer triggers on pushes to main). Only "full"
+      # mode uploads; dry-run and smoke-test must not touch gh-pages.
+      skip-upload: ${{ needs.config.outputs.mode != 'full' }}
     secrets: inherit
     permissions:
       id-token: write


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3993
* #3992
* #3983
* __->__ #3982
* #3981
* #3980
* #3979
* #3978
* #3977
* #3976
* #3991

Benchmarks cost 2 x ~40-60 min GPU jobs on every push to main and on
every PR push, while their only consumers are trend dashboards.

- benchmarks.yml: drop the push-to-main trigger. The nightly
  orchestrator's daily workflow_call becomes the sole feed of the
  gh-pages trend: its skip-upload flag now derives from the run mode
  (upload in "full" mode only, so dry-run and smoke-test runs cannot
  touch gh-pages). workflow_dispatch remains for on-demand runs.
- benchmarks_pr.yml: opt-in via the "benchmarks" PR label, with the
  "labeled" trigger type so applying the label starts the comparison
  immediately.
- benchmarks_pr_comment.yml: exit cleanly when the benchmark job was
  skipped and no artifacts exist, instead of failing on an empty
  download.

Accepted tradeoffs: the trend granularity drops from per-push to
daily, and the 200% regression alert now implicates a day of commits
rather than a single push.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>