### PR TITLE
[Performance] Add Collector.clone_data to skip yield clones

### DIFF
--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -5297,6 +5297,108 @@ class TestCollectorRemoteHelpers:
             collector.shutdown()
 
 
+class TestCollectorCloneData:
+    """Regression tests for Collector.clone_data yield ownership."""
+
+    def _make_collector(self, **kwargs):
+        env = ContinuousActionVecMockEnv()
+        defaults = {
+            "create_env_fn": env,
+            "policy": RandomPolicy(env.action_spec),
+            "frames_per_batch": 20,
+            "total_frames": 60,
+            "device": "cpu",
+        }
+        defaults.update(kwargs)
+        return Collector(**defaults)
+
+    @staticmethod
+    def _obs_ptr(td):
+        return td["observation"].untyped_storage().data_ptr()
+
+    def test_default_yields_are_isolated(self):
+        """Default clone_data=True: successive yields must not alias."""
+        collector = self._make_collector()
+        try:
+            assert collector.clone_data is True
+            it = iter(collector)
+            data0 = next(it)
+            data1 = next(it)
+            assert data0 is not data1
+            assert self._obs_ptr(data0) != self._obs_ptr(data1)
+            before = data0["observation"].clone()
+            data1["observation"].zero_()
+            assert torch.equal(data0["observation"], before)
+        finally:
+            collector.shutdown()
+
+    def test_clone_data_false_allows_aliasing(self):
+        """clone_data=False: successive yields may share storage (expected)."""
+        collector = self._make_collector(clone_data=False)
+        try:
+            assert collector.clone_data is False
+            it = iter(collector)
+            data0 = next(it)
+            data1 = next(it)
+            # Live buffer is reused; holding data0 across next() is unsafe.
+            assert self._obs_ptr(data0) == self._obs_ptr(data1)
+            before = data0["observation"].clone()
+            data1["observation"].zero_()
+            # Aliasing: mutating the later yield mutates the earlier reference.
+            assert not torch.equal(data0["observation"], before)
+            assert torch.equal(data0["observation"], data1["observation"])
+        finally:
+            collector.shutdown()
+
+    def test_return_same_td_takes_precedence(self):
+        """return_same_td=True yields the same object; clone_data is ignored."""
+        collector = self._make_collector(return_same_td=True, clone_data=True)
+        try:
+            it = iter(collector)
+            data0 = next(it)
+            data1 = next(it)
+            assert data0 is data1
+            assert self._obs_ptr(data0) == self._obs_ptr(data1)
+        finally:
+            collector.shutdown()
+
+    def test_replay_buffer_path_unaffected_by_clone_data(self):
+        """Attached replay_buffer still extends once and yields None."""
+        rb = ReplayBuffer(storage=LazyTensorStorage(200), batch_size=8)
+        collector = self._make_collector(
+            replay_buffer=rb,
+            extend_buffer=True,
+            clone_data=False,
+            total_frames=40,
+            frames_per_batch=20,
+        )
+        try:
+            yielded = []
+            for batch in collector:
+                yielded.append(batch)
+            assert all(b is None for b in yielded)
+            assert len(rb) == 40
+        finally:
+            collector.shutdown()
+
+    def test_post_collect_hook_runs_without_clone(self):
+        """post_collect_hook still fires when clone_data=False."""
+        seen = []
+
+        def hook(td):
+            seen.append(self._obs_ptr(td))
+
+        collector = self._make_collector(clone_data=False, post_collect_hook=hook)
+        try:
+            it = iter(collector)
+            next(it)
+            next(it)
+            assert len(seen) == 2
+            assert seen[0] == seen[1]
+        finally:
+            collector.shutdown()
+
+
 class TestCollectorRB:
     @pytest.mark.skipif(not _has_gym, reason="requires gym.")
     def test_collector_rb_sync(self):

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -232,6 +232,17 @@ class Collector(BaseCollector):
             tensordict is added to a replay buffer for instance,
             the whole content of the buffer will be identical.
             Default is ``False``.
+            When ``return_same_td=True``, :attr:`clone_data` is ignored because
+            the collector already yields the live buffer without cloning.
+        clone_data (bool, optional): if ``True`` (default), each yielded
+            TensorDict is a clone of the collector's internal rollout buffer.
+            This guarantees that successive batches do not alias each other when
+            the caller keeps references across iterations. Set ``clone_data=False``
+            to skip that defensive copy when each batch is fully consumed before
+            the next ``next(collector)`` call. Prefer attaching a
+            :class:`~torchrl.data.ReplayBuffer` via ``replay_buffer=`` for
+            off-policy loops, which avoids the yield clone entirely.
+            Defaults to ``True``.
         interruptor (_Interruptor, optional):
             An _Interruptor object that can be used from outside the class to control rollout collection.
             The _Interruptor class has methods ´start_collection´ and ´stop_collection´, which allow to implement
@@ -446,6 +457,7 @@ class Collector(BaseCollector):
         track_traj_ids: bool = True,
         exploration_type: ExplorationType = DEFAULT_EXPLORATION_TYPE,
         return_same_td: bool = False,
+        clone_data: bool = True,
         reset_when_done: bool = True,
         interruptor=None,
         set_truncated: bool = False,
@@ -575,6 +587,7 @@ class Collector(BaseCollector):
             exploration_type if exploration_type else DEFAULT_EXPLORATION_TYPE
         )
         self.return_same_td = return_same_td
+        self.clone_data = bool(clone_data)
         self.set_truncated = set_truncated
 
         # Set split trajectories option
@@ -1552,7 +1565,7 @@ class Collector(BaseCollector):
                 tensordict_out = self._postproc(tensordict_out)
                 if self.return_same_td:
                     # This is used with multiprocessed collectors to use the buffers
-                    # stored in the tensordict.
+                    # stored in the tensordict. Takes precedence over clone_data.
                     if events:
                         for event in events:
                             event.record()
@@ -1567,8 +1580,10 @@ class Collector(BaseCollector):
                     self.replay_buffer.extend(tensordict_out)
                     yield
                 else:
-                    # we must clone the values, as the tensordict is updated in-place.
-                    # otherwise the following code may break:
+                    # By default, clone so successive yields do not alias the
+                    # in-place buffer. Set clone_data=False to skip when each
+                    # batch is fully consumed before the next iteration.
+                    # otherwise the following code may break under the default:
                     # >>> for i, data in enumerate(collector):
                     # >>>      if i == 0:
                     # >>>          data0 = data
@@ -1577,7 +1592,8 @@ class Collector(BaseCollector):
                     # >>>      else:
                     # >>>          break
                     # >>> assert data0["done"] is not data1["done"]
-                    tensordict_out = tensordict_out.clone()
+                    if self.clone_data:
+                        tensordict_out = tensordict_out.clone()
                     if self.post_collect_hook is not None:
                         self.post_collect_hook(tensordict_out)
                     yield tensordict_out


### PR DESCRIPTION
## Summary: 
- added a clone_data field to the collectors to prevent redundant clones 
- each yield is still a clone so successive batches do not alias the collector’s in-place rollout buffer.
- return_same_td=True still takes precedence; attaching replay_buffer= remains the preferred zero-clone path for off-policy loops.