### PR TITLE
[Test] Make RewardScaling round-trip assertions robust to near-zero rewards

### DIFF
--- a/test/transforms/test_reward_transforms.py
+++ b/test/transforms/test_reward_transforms.py
@@ -418,7 +418,7 @@ class TestRewardScaling(TransformBase):
         if standard_normal:
             assert torch.allclose((reward - loc) / scale, td["reward"])
         else:
-            assert torch.allclose((td["reward"] - loc) / scale, reward)
+            assert torch.allclose(reward * scale + loc, td["reward"])
 
     @pytest.mark.parametrize("standard_normal", [True, False])
     def test_transform_compose(self, standard_normal):
@@ -432,7 +432,7 @@ class TestRewardScaling(TransformBase):
         if standard_normal:
             assert torch.allclose((reward - loc) / scale, td["reward"])
         else:
-            assert torch.allclose((td["reward"] - loc) / scale, reward)
+            assert torch.allclose(reward * scale + loc, td["reward"])
 
     @pytest.mark.skipif(not _has_gym, reason="No Gym")
     @pytest.mark.parametrize("standard_normal", [True, False])
@@ -451,7 +451,7 @@ class TestRewardScaling(TransformBase):
         if standard_normal:
             assert torch.allclose((reward - loc) / scale, td["next", "reward"])
         else:
-            assert torch.allclose((td["next", "reward"] - loc) / scale, reward)
+            assert torch.allclose(reward * scale + loc, td["next", "reward"])
 
     @pytest.mark.parametrize("standard_normal", [True, False])
     def test_transform_model(self, standard_normal):
@@ -465,7 +465,7 @@ class TestRewardScaling(TransformBase):
         if standard_normal:
             assert torch.allclose((reward - loc) / scale, td["reward"])
         else:
-            assert torch.allclose((td["reward"] - loc) / scale, reward)
+            assert torch.allclose(reward * scale + loc, td["reward"])
 
     @pytest.mark.parametrize("rbclass", [ReplayBuffer, TensorDictReplayBuffer])
     @pytest.mark.parametrize("standard_normal", [True, False])
@@ -482,7 +482,7 @@ class TestRewardScaling(TransformBase):
         if standard_normal:
             assert torch.allclose((reward - loc) / scale, td["reward"])
         else:
-            assert torch.allclose((td["reward"] - loc) / scale, reward)
+            assert torch.allclose(reward * scale + loc, td["reward"])
 
     def test_transform_inverse(self):
         raise pytest.skip("No inverse for RewardScaling")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3993
* #3992
* #3983
* #3982
* #3981
* #3980
* #3979
* #3978
* #3977
* #3976
* __->__ #3991

The standard_normal=False assertions inverted the affine map and compared
(td["reward"] - loc) / scale against the original reward with default
allclose tolerances. When torch.randn produces an element within ~1e-3 of
zero, the loc-add/loc-subtract round trip loses enough precision through
catastrophic cancellation that the relative tolerance fails on that
element (observed in CI: reward element 3.93e-4, round-trip error ~7e-8
vs an allowed ~1.4e-8). The failure is seed-dependent and hits roughly
0.3% of runs.

Compare in the forward direction instead, recomputing reward * scale +
loc: identical operations on identical inputs round identically, making
the comparison exact regardless of magnitude -- the same pattern the
standard_normal=True branch already uses.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>