### PR TITLE
[CI] Run the middle CPU Python versions on main and nightly only

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -46,22 +46,12 @@ jobs:
   tests-cpu:
     strategy:
       matrix:
-        # Every Python version runs the xdist bulk (24k tests in ~5 min --
-        # the smoke subset for the middle versions). The serial quarantine
-        # shards (collectors + mp, the expensive part) run on the oldest and
-        # newest Python only; the middle versions get them on non-PR events
-        # via tests-cpu-quarantine-mid below.
-        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        shard: ["bulk"]
-        include:
-          - python_version: "3.10"
-            shard: "collectors"
-          - python_version: "3.10"
-            shard: "mp"
-          - python_version: "3.14"
-            shard: "collectors"
-          - python_version: "3.14"
-            shard: "mp"
+        # PR version set: 3.10 (oldest), 3.13 (newest with the full optional
+        # dependency stack) and 3.14 (newest, cheap -- most optional deps do
+        # not install there) run all three shards on every event. 3.11 and
+        # 3.12 run only on non-PR events via tests-cpu-mid below.
+        python_version: ["3.10", "3.13", "3.14"]
+        shard: ["bulk", "collectors", "mp"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
@@ -90,16 +80,16 @@ jobs:
         ## setup_env.sh
         bash .github/unittest/linux/scripts/run_all.sh
 
-  # Serial quarantine shards for the middle Python versions. Skipped on pull
-  # requests (3.10 and 3.14 bracket the version range there); pushes to main
-  # and the nightly orchestrator keep full five-version coverage. For an
-  # on-demand full run on a PR branch, use workflow_dispatch.
-  tests-cpu-quarantine-mid:
+  # All shards for the middle Python versions. Skipped on pull requests
+  # (3.10/3.13/3.14 bracket the version range there); pushes to main and the
+  # nightly orchestrator keep full five-version coverage. For an on-demand
+  # full run on a PR branch, use workflow_dispatch.
+  tests-cpu-mid:
     if: github.event_name != 'pull_request'
     strategy:
       matrix:
-        python_version: ["3.11", "3.12", "3.13"]
-        shard: ["collectors", "mp"]
+        python_version: ["3.11", "3.12"]
+        shard: ["bulk", "collectors", "mp"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
@@ -382,7 +372,7 @@ jobs:
   upload-codecov:
     needs:
       - tests-cpu
-      - tests-cpu-quarantine-mid
+      - tests-cpu-mid
       - tests-gpu
       - tests-gpu-distributed
       - tests-optdeps


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3993
* __->__ #3992
* #3983
* #3982
* #3981
* #3980
* #3979
* #3978
* #3977
* #3976
* #3991

Tighten the PR-time CPU matrix to one consistent rule: 3.10 (oldest),
3.13 (newest with the full optional dependency stack) and 3.14 (newest,
cheap since most optional deps do not install there) run all three
shards (bulk, collectors, mp) on every event; 3.11 and 3.12 run all
three shards only on non-PR events (pushes to main, the nightly
orchestrator, workflow_dispatch), replacing the previous split where
every version ran the bulk on PRs but only 3.10/3.14 ran the
quarantine.

Net effect on PRs: 3.11/3.12 bulk jobs are dropped and the 3.13
quarantine shards are added, trading a small runner-time increase on
3.13 for the full shard set on every PR-tested version. Middle-version
coverage remains on every push to main and every nightly run.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>