### PR TITLE
[CI] Gate olddeps and the full optdeps suite behind PR labels

### DIFF
--- a/.github/unittest/linux_optdeps/scripts/run_all.sh
+++ b/.github/unittest/linux_optdeps/scripts/run_all.sh
@@ -174,6 +174,15 @@ export CKPT_BACKEND=torch
 export MAX_IDLE_COUNT=100
 export BATCHED_PIPE_TIMEOUT=60
 
+# PR smoke mode (tests-optdeps-smoke): prove the optional-dependency
+# environment builds and imports cleanly, then stop before the full suite.
+# The full suite runs on main/nightly, or on PRs with the ci/optdeps label.
+if [ "${TORCHRL_OPTDEPS_SMOKE:-0}" = "1" ]; then
+  python -m pytest test/smoke_test.py -v --durations 20
+  echo "Optdeps smoke mode: imports OK, skipping the full suite."
+  exit 0
+fi
+
 # Track test failures but keep going, so coverage is still combined and
 # uploaded; the script exits with this status at the end. (Previously the
 # script aborted on the pytest failure via set -e, before coverage upload.)

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -206,7 +206,13 @@ jobs:
         ## setup_env.sh
         bash .github/unittest/linux/scripts/run_all.sh
 
+  # Oldest-supported-torch compatibility suite. Not run on PRs by default:
+  # add the ci/olddeps label when a change uses a torch API that may not
+  # exist in the oldest supported stable torch (see CLAUDE.md section 7b).
+  # Labels do not retrigger the workflow -- label, then push or rerun.
+  # Full runs happen on every push to main and on the nightly orchestrator.
   tests-olddeps:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci/olddeps')
     strategy:
       matrix:
         python_version: ["3.10"]
@@ -246,7 +252,14 @@ jobs:
         bash .github/unittest/linux_olddeps/scripts_gym_0_13/batch_scripts.sh
         bash .github/unittest/linux_olddeps/scripts_gym_0_13/post_process.sh
 
+  # Full optional-dependencies suite (~2h serial). Not run on PRs by
+  # default: PRs get tests-optdeps-smoke below; add the ci/optdeps label
+  # when a change touches optional-dependency integrations (see CLAUDE.md
+  # section 7b). Labels do not retrigger the workflow -- label, then push
+  # or rerun. Full runs happen on every push to main and on the nightly
+  # orchestrator.
   tests-optdeps:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci/optdeps')
     strategy:
       matrix:
         python_version: ["3.12"]
@@ -275,6 +288,46 @@ jobs:
           export TORCH_VERSION=nightly
         fi
         export TD_GET_DEFAULTS_TO_NONE=1
+
+        echo "PYTHON_VERSION: $PYTHON_VERSION"
+        echo "CU_VERSION: $CU_VERSION"
+
+        ## setup_env.sh
+        bash .github/unittest/linux_optdeps/scripts/run_all.sh
+
+  # PR-time replacement for tests-optdeps: builds the same optional-deps
+  # environment but only proves it imports cleanly (test/smoke_test.py)
+  # instead of running the ~2h suite. Skipped when ci/optdeps requests the
+  # full run, and on non-PR events where tests-optdeps runs anyway.
+  tests-optdeps-smoke:
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci/optdeps')
+    strategy:
+      matrix:
+        python_version: ["3.12"]
+        cuda_arch_version: ["13.0"]
+      fail-fast: false
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      runner: linux.g5.4xlarge.nvidia.gpu
+      repository: pytorch/rl
+      docker-image: "nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04"
+      gpu-arch-type: cuda
+      gpu-arch-version: ${{ matrix.cuda_arch_version }}
+      timeout: 60
+      script: |
+        # Set env vars from matrix
+        export PYTHON_VERSION=${{ matrix.python_version }}
+        export CUDA_ARCH_VERSION=${{ matrix.cuda_arch_version }}
+        export CU_VERSION="cu${CUDA_ARCH_VERSION:0:2}${CUDA_ARCH_VERSION:3:1}"
+        if [[ "${{ github.ref }}" =~ release/* ]]; then
+          export RELEASE=1
+          export TORCH_VERSION=stable
+        else
+          export RELEASE=0
+          export TORCH_VERSION=nightly
+        fi
+        export TD_GET_DEFAULTS_TO_NONE=1
+        export TORCHRL_OPTDEPS_SMOKE=1
 
         echo "PYTHON_VERSION: $PYTHON_VERSION"
         echo "CU_VERSION: $CU_VERSION"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,28 @@ CPU and GPU paths via parametrization (e.g.
 `device = "cpu" if torch.cuda.device_count() == 0 else "cuda"`); those
 must continue to run on the CPU side.
 
+### 7b. PR-gated CI suites: `ci/olddeps` and `ci/optdeps` labels
+
+Two expensive suites in `.github/workflows/test-linux.yml` do NOT run on
+pull requests by default. They run fully on every push to main and on the
+nightly orchestrator, so breakage still surfaces there -- but a PR that
+needs their signal must opt in via a label:
+
+- **`ci/olddeps`** runs `tests-olddeps` (oldest supported stable torch,
+  cu118, gym 0.13). Add this label whenever your change uses a torch API
+  that was added recently (anything you would only find in the current
+  stable/nightly torch, e.g. a new `torch.*` function, kwarg, or behavior
+  flag). If in doubt whether the oldest supported torch has it, add the
+  label. Without it, an incompatibility lands on main and only fails
+  post-merge.
+- **`ci/optdeps`** runs the full `tests-optdeps` suite (~2h). Add it when
+  your change touches optional-dependency integrations or their import
+  paths. PRs otherwise get `tests-optdeps-smoke`, which only builds the
+  optional-deps environment and checks imports.
+
+Adding a label does NOT retrigger CI: apply the label first, then push a
+commit or re-run the workflow so the gate sees it.
+
 ## 8. Documentation
 
 - Every new public class / function referenced in `docs/source/reference/*.rst`.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #3993

tests-olddeps (3 shards, ~60-70 min wall bounded by the old-torch
quarantine) and tests-optdeps (~2h serial) are the two remaining
long-pole unit-test jobs on every PR, while their signal -- oldest
supported torch compatibility and optional-dependency integration -- is
irrelevant to most changes.

- tests-olddeps: skipped on PRs unless the ci/olddeps label is applied.
- tests-optdeps: skipped on PRs unless the ci/optdeps label is applied;
  PRs instead get tests-optdeps-smoke, which builds the same
  optional-deps environment and runs test/smoke_test.py (import checks
  only) via a TORCHRL_OPTDEPS_SMOKE early exit in the run script.
- Both suites still run fully on every push to main and on the nightly
  orchestrator, so unlabeled breakage surfaces post-merge and nightly.
- CLAUDE.md section 7b documents the contract for agents and humans:
  changes using recently-added torch APIs must carry ci/olddeps, changes
  touching optional-dependency integrations must carry ci/optdeps, and
  labels do not retrigger CI (label first, then push or rerun).

Both labels exist on the repository.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>