### PR TITLE
[Feature] Add TensorFlow-free OpenVLA reference preprocessing

### DIFF
--- a/benchmarks/test_vla_preprocessing_benchmark.py
+++ b/benchmarks/test_vla_preprocessing_benchmark.py
@@ -11,7 +11,9 @@ Run with:
 """
 from __future__ import annotations
 
+import argparse
 import importlib.util
+from typing import Literal
 
 import pytest
 import torch
@@ -28,14 +30,23 @@ def _make_images(batch_size: int, height: int, width: int) -> torch.Tensor:
 
 @pytest.mark.parametrize("batch_size", [1, 4, 16, 64])
 @pytest.mark.parametrize("height,width", [(224, 224), (256, 256), (480, 640)])
-@pytest.mark.parametrize("backend", ["pil", "torchvision"])
+@pytest.mark.parametrize("backend", ["pil", "torchvision", "torch_reference"])
 def test_openvla_preprocessing_throughput(
-    benchmark, batch_size: int, height: int, width: int, backend: str
+    benchmark,
+    batch_size: int,
+    height: int,
+    width: int,
+    backend: Literal["pil", "torchvision", "torch_reference"],
 ):
     if backend == "pil" and not _has_pil:
         pytest.skip("Pillow not found")
-    if backend == "torchvision" and not _has_torchvision:
+    if backend in ("torchvision", "torch_reference") and not _has_torchvision:
         pytest.skip("torchvision not found")
     images = _make_images(batch_size, height, width)
     preprocessor = OpenVLAImagePreprocessor(backend=backend, center_crop=True)
     benchmark(preprocessor, images)
+
+
+if __name__ == "__main__":
+    args, unknown = argparse.ArgumentParser().parse_known_args()
+    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/docs/source/reference/vla.rst
+++ b/docs/source/reference/vla.rst
@@ -124,11 +124,14 @@ a language-model head.
 Image preprocessing
 -------------------
 
-The reusable :class:`~torchrl.data.vla.OpenVLAImagePreprocessor` implements the
-OpenVLA-style image preprocessing order used by OpenVLA-OFT policies: square
-resize, JPEG quality-95 round trip, optional 0.9-area center crop and resize
-back. Its default backend keeps images as tensors and uses ``torchvision`` JPEG
-codecs, while ``backend="pil"`` remains available as a reference path.
+The reusable :class:`~torchrl.data.vla.OpenVLAImagePreprocessor` implements
+OpenVLA-style image preprocessing. The ``backend="torch_reference"`` path uses
+``torchvision`` for a JPEG round trip followed by an antialiased Lanczos3
+resize and the optional fractional 0.9-area center crop. It follows the
+TensorFlow reference operation order and interpolation semantics without
+requiring TensorFlow and is the default. The ``backend="torchvision"`` option
+uses a faster bicubic tensor path, while ``backend="tensorflow"`` remains
+available for reference comparisons.
 
 .. currentmodule:: torchrl.data.vla
 

--- a/sota-implementations/vla_grpo/README.md
+++ b/sota-implementations/vla_grpo/README.md
@@ -350,10 +350,14 @@ Requirements beyond the toy scale: LIBERO (see the `torchrl.envs.LiberoEnv`
 docs for install notes), `transformers`, `timm`, `Pillow`, and `peft` when
 `policy.lora_rank` is set.
 
-For reference-parity rollouts, set `policy.image_backend=tensorflow`. This uses
-the SimpleVLA JPEG, Lanczos resize, and center-crop order. Normalized
-vocabulary-tail action tokens are detokenized through the NumPy float64 CPU
-path before the gripper transform is applied once in the environment. Use
+The default `policy.image_backend=torch_reference` uses torchvision's JPEG
+codec and matches SimpleVLA's JPEG-before-resize order, antialiased Lanczos3
+resize, and fractional center-crop interpolation semantics without requiring
+TensorFlow. Set `policy.image_backend=torchvision` for the faster bicubic path,
+or `policy.image_backend=tensorflow` when the TensorFlow codec itself is
+required for exact reference comparisons. Normalized vocabulary-tail action
+tokens are detokenized through the NumPy float64 CPU path before the gripper
+transform is applied once in the environment. Use
 `env.train_init_state_mode=fixed env.train_init_state_id=<id>` for a fixed
 LIBERO initial state. `collector.policy_micro_batch_size` only slices actual
 model calls inside the inference-server policy; it does not change PPO

--- a/sota-implementations/vla_grpo/config/vla_grpo_libero.yaml
+++ b/sota-implementations/vla_grpo/config/vla_grpo_libero.yaml
@@ -69,7 +69,8 @@ policy:
   use_proprio: false
   num_images_in_input: 1
   center_crop: true # the SimpleVLA-RL checkpoints are trained with augmentations
-  image_backend: torchvision # OpenVLA preprocessing: torchvision | pil | tensorflow (reference)
+  # OpenVLA preprocessing: torchvision | torch_reference | pil | tensorflow
+  image_backend: torch_reference
   # the model emits a continuous gripper; LIBERO/robosuite needs a firm +/-1
   # open/close (demo gripper is binary, -1 open / +1 close). SimpleVLA-RL
   # applies sign(2 * g - 1) then inverts, so threshold 0.0 here is equivalent

--- a/sota-implementations/vla_grpo/openvla.py
+++ b/sota-implementations/vla_grpo/openvla.py
@@ -36,6 +36,7 @@ from tensordict.nn import InteractionType, TensorDictSequential
 from tensordict.utils import NestedKey, unravel_key
 from torch import nn
 from torch.nn.utils.rnn import pad_sequence
+from torchrl._utils import logger as torchrl_logger
 
 from torchrl.data.vla import (
     ACTION_CHUNK_KEY,
@@ -188,7 +189,9 @@ class OpenVLAInputTransform(Transform):
         *,
         use_wrist_image: bool = False,
         center_crop: bool = False,
-        image_backend: Literal["torchvision", "pil", "tensorflow"] = "torchvision",
+        image_backend: Literal[
+            "torchvision", "torch_reference", "pil", "tensorflow"
+        ] = "torch_reference",
         image_key: NestedKey = ("observation", "image"),
         wrist_image_key: NestedKey | None = ("observation", "wrist_image"),
         instruction_key: NestedKey = "language_instruction",
@@ -339,7 +342,7 @@ class OpenVLAInputTransform(Transform):
     def _make_image_preprocessor(
         self,
         processor,
-        image_backend: Literal["torchvision", "pil", "tensorflow"],
+        image_backend: Literal["torchvision", "torch_reference", "pil", "tensorflow"],
     ) -> OpenVLAImagePreprocessor | None:
         image_processor = getattr(processor, "image_processor", None)
         if image_processor is None:
@@ -357,9 +360,15 @@ class OpenVLAInputTransform(Transform):
                 mean=mean,
                 std=std,
             )
-        except ImportError:
-            if image_backend != "torchvision":
+        except ImportError as err:
+            if image_backend not in ("torchvision", "torch_reference"):
                 raise
+            torchrl_logger.warning(
+                "OpenVLA image backend %r is unavailable (%s); falling back to "
+                "'pil', which does not preserve reference preprocessing semantics.",
+                image_backend,
+                err,
+            )
             return OpenVLAImagePreprocessor(
                 size=size,
                 jpeg_quality=_JPEG_QUALITY,
@@ -783,10 +792,12 @@ class OpenVLAOFTWrapper(VLAWrapperBase):
             augmented training. Defaults to ``False``.
         image_backend (str, optional): backend passed to
             :class:`~torchrl.data.vla.OpenVLAImagePreprocessor` for the fast
-            batched image path. ``"torchvision"`` keeps preprocessing in tensor
-            form when available; ``"tensorflow"`` is the exact LIBERO
-            reference path and ``"pil"`` is a lightweight debugging path.
-            Defaults to ``"torchvision"``.
+            batched image path. ``"torch_reference"`` follows the LIBERO
+            reference operation order and interpolation semantics without a
+            TensorFlow dependency; ``"tensorflow"`` runs the reference
+            implementation, ``"torchvision"`` selects the faster bicubic path,
+            and ``"pil"`` is a lightweight debugging path. Defaults to
+            ``"torch_reference"``.
         gripper_binarize (bool, optional): binarize the decoded gripper action
             to +/-1. The model emits a continuous gripper value but robots
             (LIBERO/robosuite) need a firm open/close, so without this the
@@ -815,7 +826,9 @@ class OpenVLAOFTWrapper(VLAWrapperBase):
         output_mode: Literal["chunk", "tokens", "both"] | None = None,
         use_wrist_image: bool = False,
         center_crop: bool = False,
-        image_backend: Literal["torchvision", "pil", "tensorflow"] = "torchvision",
+        image_backend: Literal[
+            "torchvision", "torch_reference", "pil", "tensorflow"
+        ] = "torch_reference",
         gripper_binarize: bool = False,
         gripper_binarize_threshold: float = 0.0,
         gripper_invert: bool = False,
@@ -1025,7 +1038,7 @@ class OpenVLAOFTWrapper(VLAWrapperBase):
     def _make_image_preprocessor(
         self,
         processor,
-        image_backend: Literal["torchvision", "pil", "tensorflow"],
+        image_backend: Literal["torchvision", "torch_reference", "pil", "tensorflow"],
     ) -> OpenVLAImagePreprocessor | None:
         return self.input_transform._make_image_preprocessor(processor, image_backend)
 
@@ -1097,7 +1110,9 @@ class OpenVLAOFTL1Wrapper(OpenVLAOFTWrapper):
         use_proprio: bool = True,
         use_wrist_image: bool = True,
         center_crop: bool = True,
-        image_backend: Literal["torchvision", "pil", "tensorflow"] = "torchvision",
+        image_backend: Literal[
+            "torchvision", "torch_reference", "pil", "tensorflow"
+        ] = "torch_reference",
         gripper_binarize: bool = True,
         gripper_binarize_threshold: float = 0.0,
         gripper_invert: bool = True,

--- a/sota-implementations/vla_grpo/test_openvla.py
+++ b/sota-implementations/vla_grpo/test_openvla.py
@@ -41,8 +41,10 @@ _has_deps = all(
     importlib.util.find_spec(name) is not None
     for name in ("transformers", "timm", "PIL", "tokenizers")
 )
+_has_torchvision = importlib.util.find_spec("torchvision") is not None
 
 if _has_deps:
+    import openvla
     from openvla import (
         GripperPostProcessTransform,
         OpenVLAOFTL1Wrapper,
@@ -1078,6 +1080,37 @@ class TestOpenVLAOFTWrapper:
         policy._preprocess(images, None, instructions)
 
         assert processor.tokenizer.calls == 2
+
+    @pytest.mark.skipif(not _has_torchvision, reason="torchvision not found")
+    def test_preprocess_default_torch_reference_backend(self):
+        processor = _BatchProcessor()
+        policy = OpenVLAOFTWrapper(_TinyOFT(), processor)
+        images = torch.randint(0, 256, (2, 3, 31, 47), dtype=torch.uint8)
+
+        _, _, pixel_values = policy._preprocess(
+            images, None, ["pick up the bowl", "open drawer"]
+        )
+
+        assert policy.image_backend == "torch_reference"
+        assert pixel_values.shape == (2, 3, 224, 224)
+        assert pixel_values.dtype == torch.float32
+        assert processor.image_processor.calls == 0
+
+    def test_preprocess_fallback_warns(self, caplog, monkeypatch):
+        def fake_image_preprocessor(**kwargs):
+            backend = kwargs["backend"]
+            if backend == "torch_reference":
+                raise ImportError("torchvision is unavailable")
+            return SimpleNamespace(backend=backend)
+
+        monkeypatch.setattr(
+            openvla, "OpenVLAImagePreprocessor", fake_image_preprocessor
+        )
+        with caplog.at_level("WARNING"):
+            policy = OpenVLAOFTWrapper(_TinyOFT(), _BatchProcessor())
+
+        assert policy.image_backend == "pil"
+        assert "does not preserve reference preprocessing semantics" in caplog.text
 
     def test_unbatched_input(self, policy):
         obs = TensorDict(

--- a/test/data/test_vla.py
+++ b/test/data/test_vla.py
@@ -28,6 +28,7 @@ from torchrl.data.vla import (
     VLAObservation,
     VocabTailActionTokenizer,
 )
+from torchrl.data.vla.preprocessing import _fractional_center_crop, _lanczos3_resize
 
 _has_pil = importlib.util.find_spec("PIL") is not None
 _has_tensorflow = importlib.util.find_spec("tensorflow") is not None
@@ -275,6 +276,12 @@ class TestVLAContainers:
 
 
 class TestOpenVLAImagePreprocessor:
+    @pytest.mark.skipif(not _has_torchvision, reason="torchvision not found")
+    def test_default_backend(self):
+        proc = OpenVLAImagePreprocessor()
+
+        assert proc.backend == "torch_reference"
+
     @pytest.mark.skipif(not _has_pil, reason="Pillow not found")
     def test_pil_backend_shapes(self):
         proc = OpenVLAImagePreprocessor(size=32, backend="pil", center_crop=True)
@@ -296,6 +303,199 @@ class TestOpenVLAImagePreprocessor:
         assert fast.shape == fast_again.shape == ref.shape == torch.Size([2, 3, 32, 32])
         assert fast.dtype == fast_again.dtype == ref.dtype == torch.uint8
         assert (fast.float() - ref.float()).abs().mean() < 25.0
+
+    @pytest.mark.skipif(not _has_torchvision, reason="torchvision not found")
+    @pytest.mark.parametrize("channels", [1, 3])
+    def test_torch_reference_backend(self, channels):
+        proc = OpenVLAImagePreprocessor(
+            size=32, backend="torch_reference", center_crop=True
+        )
+        images = torch.full((2, channels, 25, 39), 73, dtype=torch.uint8)
+
+        out = proc(images)
+        unbatched = proc(images[0])
+
+        assert out.shape == torch.Size([2, 3, 32, 32])
+        assert unbatched.shape == torch.Size([3, 32, 32])
+        assert out.dtype == unbatched.dtype == torch.uint8
+        torch.testing.assert_close(out[0], unbatched)
+        torch.testing.assert_close(out[:, 0], out[:, 1])
+        torch.testing.assert_close(out[:, 1], out[:, 2])
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    @pytest.mark.skipif(not _has_torchvision, reason="torchvision not found")
+    def test_torch_reference_cuda_input(self):
+        proc = OpenVLAImagePreprocessor(
+            size=16, backend="torch_reference", center_crop=True
+        )
+        images = torch.randint(0, 256, (2, 3, 17, 23), dtype=torch.uint8, device="cuda")
+
+        out = proc(images)
+
+        assert out.device == images.device
+        assert out.shape == (2, 3, 16, 16)
+
+    def test_torch_reference_interpolation_matches_tensorflow_golden(self):
+        image = torch.arange(20, dtype=torch.float32).reshape(1, 1, 4, 5) * 7
+        expected_resize = torch.tensor(
+            [
+                [6.495448, 15.063237, 24.094267, 32.662056],
+                [53.416706, 61.9845, 71.015526, 79.58331],
+                [100.33795, 108.90575, 117.93678, 126.50456],
+            ]
+        ).reshape(1, 1, 3, 4)
+        torch.testing.assert_close(
+            _lanczos3_resize(image, (3, 4)),
+            expected_resize,
+            rtol=0,
+            atol=1e-4,
+        )
+        expected_upscale = torch.tensor(
+            [
+                [-1.605574, 3.354574, 10.117878, 15.132814, 21.896118, 26.856264],
+                [21.150263, 26.110410, 32.873714, 37.888645, 44.651955, 49.612103],
+                [52.269077, 57.229220, 63.992523, 69.007450, 75.770770, 80.730910],
+                [83.387886, 88.348030, 95.111336, 100.126270, 106.889580, 111.849724],
+                [
+                    106.143720,
+                    111.103874,
+                    117.867180,
+                    122.882100,
+                    129.645420,
+                    134.605560,
+                ],
+            ]
+        ).reshape(1, 1, 5, 6)
+        torch.testing.assert_close(
+            _lanczos3_resize(image, (5, 6)),
+            expected_upscale,
+            rtol=0,
+            atol=2e-4,
+        )
+
+        crop_input = torch.tensor(
+            [
+                [0, 17, 41, 83],
+                [11, 59, 101, 131],
+                [29, 73, 149, 191],
+                [47, 97, 211, 255],
+            ],
+            dtype=torch.uint8,
+        ).reshape(1, 1, 4, 4)
+        expected_crop = torch.tensor(
+            [
+                [2, 20, 45, 83],
+                [15, 60, 101, 130],
+                [31, 74, 146, 186],
+                [49, 98, 203, 247],
+            ],
+            dtype=torch.uint8,
+        ).reshape(1, 1, 4, 4)
+        torch.testing.assert_close(
+            _fractional_center_crop(crop_input, (4, 4)), expected_crop
+        )
+
+    def test_lanczos3_resize_batch_matches_sequential_and_compiles(self):
+        generator = torch.Generator().manual_seed(0)
+        images = torch.rand(4, 3, 37, 53, generator=generator)
+        expected = torch.cat(
+            [_lanczos3_resize(image.unsqueeze(0), (41, 59)) for image in images]
+        )
+
+        actual = _lanczos3_resize(images, (41, 59))
+        compiled = torch.compile(_lanczos3_resize, backend="eager", fullgraph=True)(
+            images, (41, 59)
+        )
+
+        torch.testing.assert_close(actual, expected)
+        torch.testing.assert_close(compiled, expected)
+
+    def test_fractional_center_crop_does_not_mutate_and_compiles(self):
+        generator = torch.Generator().manual_seed(1)
+        images = torch.randint(
+            0, 256, (4, 3, 17, 23), dtype=torch.uint8, generator=generator
+        ).to(torch.float32)
+        original = images.clone()
+
+        expected = _fractional_center_crop(images, (19, 21))
+        compiled = torch.compile(
+            _fractional_center_crop, backend="eager", fullgraph=True
+        )(images, (19, 21))
+
+        torch.testing.assert_close(images, original)
+        torch.testing.assert_close(compiled, expected)
+
+    @pytest.mark.skipif(not _has_tensorflow, reason="TensorFlow not found")
+    def test_torch_reference_interpolation_matches_tensorflow(self):
+        tensorflow = importlib.import_module("tensorflow")
+        generator = torch.Generator().manual_seed(0)
+        images = torch.randint(
+            0, 256, (2, 3, 37, 53), dtype=torch.uint8, generator=generator
+        )
+        expected_resize = tensorflow.image.resize(
+            images.permute(0, 2, 3, 1).numpy(),
+            (32, 32),
+            method="lanczos3",
+            antialias=True,
+        )
+        expected_resize = torch.from_numpy(expected_resize.numpy().copy()).permute(
+            0, 3, 1, 2
+        )
+        resize = _lanczos3_resize(images.float(), (32, 32))
+        torch.testing.assert_close(resize, expected_resize, rtol=0, atol=2e-4)
+
+        quantized = expected_resize.round().clamp(0, 255).to(torch.uint8)
+        crop_size = tensorflow.sqrt(tensorflow.constant(0.9))
+        offset = (1 - crop_size) / 2
+        boxes = tensorflow.stack(
+            [[offset, offset, offset + crop_size, offset + crop_size]] * 2
+        )
+        expected_crop = tensorflow.image.crop_and_resize(
+            tensorflow.image.convert_image_dtype(
+                quantized.permute(0, 2, 3, 1).numpy(), tensorflow.float32
+            ),
+            boxes,
+            tensorflow.range(2),
+            (32, 32),
+        )
+        expected_crop = tensorflow.image.convert_image_dtype(
+            tensorflow.clip_by_value(expected_crop, 0, 1),
+            tensorflow.uint8,
+            saturate=True,
+        )
+        expected_crop = torch.from_numpy(expected_crop.numpy().copy()).permute(
+            0, 3, 1, 2
+        )
+        crop = _fractional_center_crop(quantized, (32, 32))
+        error = (crop.to(torch.int16) - expected_crop).abs()
+        assert error.max() <= 1
+        assert error.to(torch.float32).mean() < 1e-3
+
+    @pytest.mark.skipif(
+        not (_has_tensorflow and _has_torchvision),
+        reason="TensorFlow/torchvision not found",
+    )
+    @pytest.mark.parametrize("channels", [1, 3])
+    @pytest.mark.parametrize("center_crop", [False, True])
+    def test_torch_reference_is_closer_to_tensorflow(self, channels, center_crop):
+        generator = torch.Generator().manual_seed(10 + channels)
+        images = torch.randint(
+            0, 256, (1, channels, 37, 53), dtype=torch.uint8, generator=generator
+        )
+        tensorflow = OpenVLAImagePreprocessor(
+            size=32, backend="tensorflow", center_crop=center_crop
+        )(images)
+        torch_reference = OpenVLAImagePreprocessor(
+            size=32, backend="torch_reference", center_crop=center_crop
+        )(images)
+        torchvision = OpenVLAImagePreprocessor(
+            size=32, backend="torchvision", center_crop=center_crop
+        )(images)
+
+        reference_error = (torch_reference.float() - tensorflow.float()).abs().mean()
+        torchvision_error = (torchvision.float() - tensorflow.float()).abs().mean()
+        assert reference_error < torchvision_error
 
     @pytest.mark.skipif(not _has_tensorflow, reason="TensorFlow not found")
     def test_tensorflow_reference_backend(self):

--- a/torchrl/data/vla/preprocessing.py
+++ b/torchrl/data/vla/preprocessing.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 import importlib.util
 import io
 from collections.abc import Sequence
+from functools import lru_cache
 from typing import Literal
 
 import numpy as np
 import torch
 import torch.nn.functional as F
 
-from torchrl._utils import implement_for
+from torchrl._utils import implement_for, is_compiling
 
 _has_pil = importlib.util.find_spec("PIL") is not None
 _has_tensorflow = importlib.util.find_spec("tensorflow") is not None
@@ -24,6 +25,175 @@ __all__ = ["OpenVLAImagePreprocessor"]
 
 _CROP_AREA_SCALE = 0.9
 _CROP_LINEAR_SCALE = _CROP_AREA_SCALE**0.5
+_LANCZOS_RADIUS = 3
+_REFERENCE_RESIZE_BATCH_SIZE = 8
+
+
+def _make_lanczos3_spans(
+    input_size: int,
+    output_size: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build the sampling spans used by TensorFlow's ScaleAndTranslate op."""
+    scale = torch.tensor(
+        output_size, dtype=torch.float32, device=device
+    ) / torch.tensor(input_size, dtype=torch.float32, device=device)
+    inv_scale = scale.reciprocal()
+    kernel_scale = inv_scale.clamp_min(1.0)
+    radius = torch.tensor(_LANCZOS_RADIUS, dtype=torch.float32, device=device)
+    # ceil(3 * max(input_size / output_size, 1)) using integer arithmetic.
+    # The extra sample on each side matches TensorFlow's span allocation.
+    kernel_radius = max(
+        (_LANCZOS_RADIUS * input_size + output_size - 1) // output_size,
+        _LANCZOS_RADIUS,
+    )
+    span_size = min(
+        2 * kernel_radius + 1,
+        input_size,
+    )
+    samples = (
+        torch.arange(output_size, dtype=torch.float32, device=device) + 0.5
+    ) * inv_scale
+    span_starts = torch.ceil(samples - radius * kernel_scale - 0.5)
+    span_starts = span_starts.to(torch.long).clamp(0, input_size - 1)
+    span_ends = torch.floor(samples + radius * kernel_scale - 0.5)
+    span_ends = span_ends.to(torch.long).clamp(0, input_size - 1) + 1
+
+    span_offsets = torch.arange(span_size, device=device)
+    source_indices = span_starts.unsqueeze(1) + span_offsets
+    valid = source_indices < span_ends.unsqueeze(1)
+    indices = source_indices.masked_fill(~valid, 0)
+
+    kernel_positions = (
+        (source_indices.to(torch.float32) + 0.5 - samples.unsqueeze(1)) / kernel_scale
+    ).abs()
+    near_zero = kernel_positions <= 1e-3
+    safe_positions = kernel_positions.masked_fill(near_zero, 1.0)
+    pi = torch.tensor(3.14159265359, dtype=torch.float32, device=device)
+    weights = (
+        radius
+        * torch.sin(pi * safe_positions)
+        * torch.sin(pi * safe_positions / radius)
+        / (pi * pi * safe_positions * safe_positions)
+    )
+    weights = torch.where(near_zero, 1.0, weights)
+    weights = weights.masked_fill(~valid | (kernel_positions > radius), 0.0)
+    total_weight = weights.sum(-1, keepdim=True)
+    normalizable = total_weight.abs() >= 1000.0 * torch.finfo(torch.float32).tiny
+    normalizer = torch.where(normalizable, total_weight.reciprocal(), 1.0)
+    return indices, weights * normalizer
+
+
+@lru_cache(maxsize=32)
+def _cached_lanczos3_spans(
+    input_size: int,
+    output_size: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return _make_lanczos3_spans(input_size, output_size, device)
+
+
+def _lanczos3_spans(
+    input_size: int,
+    output_size: int,
+    device: torch.device | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if device is None:
+        device = torch.device("cpu")
+    if is_compiling():
+        return _make_lanczos3_spans(input_size, output_size, device)
+    return _cached_lanczos3_spans(input_size, output_size, device)
+
+
+def _apply_spans(
+    values: torch.Tensor, indices: torch.Tensor, weights: torch.Tensor
+) -> torch.Tensor:
+    output_size, span_size = indices.shape
+    sampled = values.index_select(-1, indices.flatten()).reshape(
+        *values.shape[:-1], output_size, span_size
+    )
+    weight_shape = (1,) * (values.ndim - 1) + (output_size, span_size)
+    return (sampled * weights.reshape(weight_shape)).sum(-1)
+
+
+def _lanczos3_resize(images: torch.Tensor, size: tuple[int, int]) -> torch.Tensor:
+    """Resize NCHW float images with TensorFlow-compatible Lanczos3 spans."""
+    output_height, output_width = size
+    height_indices, height_weights = _lanczos3_spans(
+        images.shape[-2], output_height, images.device
+    )
+    width_indices, width_weights = _lanczos3_spans(
+        images.shape[-1], output_width, images.device
+    )
+
+    resized = _apply_spans(images, width_indices, width_weights)
+    resized = _apply_spans(
+        resized.transpose(-2, -1), height_indices, height_weights
+    ).transpose(-2, -1)
+    return resized
+
+
+def _make_crop_axis(
+    input_size: int, output_size: int, device: torch.device
+) -> tuple[torch.Tensor, ...]:
+    crop_size = torch.tensor(
+        _CROP_AREA_SCALE, dtype=torch.float32, device=device
+    ).sqrt()
+    offset = (1.0 - crop_size) / 2.0
+    end = offset + crop_size
+    if output_size > 1:
+        scale = (end - offset) * (input_size - 1) / (output_size - 1)
+        coordinates = (
+            offset * (input_size - 1)
+            + torch.arange(output_size, dtype=torch.float32, device=device) * scale
+        )
+    else:
+        coordinates = (0.5 * (offset + end) * (input_size - 1)).unsqueeze(0)
+    lower = coordinates.floor().to(torch.long)
+    upper = coordinates.ceil().to(torch.long)
+    return lower, upper, coordinates - lower.to(torch.float32)
+
+
+@lru_cache(maxsize=32)
+def _cached_crop_axis(
+    input_size: int, output_size: int, device: torch.device
+) -> tuple[torch.Tensor, ...]:
+    return _make_crop_axis(input_size, output_size, device)
+
+
+def _crop_axis(
+    input_size: int,
+    output_size: int,
+    device: torch.device | None = None,
+) -> tuple[torch.Tensor, ...]:
+    if device is None:
+        device = torch.device("cpu")
+    if is_compiling():
+        return _make_crop_axis(input_size, output_size, device)
+    return _cached_crop_axis(input_size, output_size, device)
+
+
+def _fractional_center_crop(
+    images: torch.Tensor, size: tuple[int, int]
+) -> torch.Tensor:
+    """Apply TensorFlow CropAndResize's 0.9-area centered bilinear crop."""
+    output_height, output_width = size
+    top, bottom, y_lerp = _crop_axis(images.shape[-2], output_height, images.device)
+    left, right, x_lerp = _crop_axis(images.shape[-1], output_width, images.device)
+
+    values = images.to(torch.float32).div(255.0)
+    left_values = values.index_select(-1, left)
+    right_values = values.index_select(-1, right)
+    x_lerp = x_lerp.reshape((1,) * (values.ndim - 1) + (output_width,))
+    values = left_values + (right_values - left_values) * x_lerp
+
+    top_values = values.index_select(-2, top)
+    bottom_values = values.index_select(-2, bottom)
+    y_lerp = y_lerp.reshape((1,) * (values.ndim - 2) + (output_height, 1))
+    values = top_values + (bottom_values - top_values) * y_lerp
+    # TensorFlow's float-to-uint8 conversion multiplies by max + 0.5 before
+    # truncating, rather than rounding after multiplying by max.
+    return values.mul_(255.5).clamp_(0, 255).to(torch.uint8)
 
 
 @implement_for("torchvision", None, "0.20")
@@ -59,18 +229,19 @@ class OpenVLAImagePreprocessor:
 
     The ``"tensorflow"`` backend mirrors the OpenVLA-OFT evaluation path:
     JPEG encode/decode at the requested quality, resize with Lanczos3,
-    optionally apply a 0.9-area center crop, and resize back. The default
-    ``"torchvision"`` backend keeps data as tensors and uses
-    ``torchvision.io`` JPEG codecs; ``"pil"`` is a lightweight debugging
-    backend.
+    optionally apply a 0.9-area center crop, and resize back. The
+    ``"torch_reference"`` backend follows the same order and interpolation
+    semantics using PyTorch and ``torchvision`` only, and is the default. The
+    ``"torchvision"`` backend keeps data as tensors but uses a faster bicubic
+    path; ``"pil"`` is a lightweight debugging backend.
 
     Args:
         size (int): Square output size. Defaults to ``224``.
         jpeg_quality (int): JPEG quality. Defaults to ``95``.
         center_crop (bool): Whether to apply the OpenVLA 0.9-area center crop.
             Defaults to ``False``.
-        backend (str): ``"torchvision"``, ``"pil"`` or ``"tensorflow"``.
-            Defaults to ``"torchvision"``.
+        backend (str): ``"torchvision"``, ``"torch_reference"``, ``"pil"``
+            or ``"tensorflow"``. Defaults to ``"torch_reference"``.
         mean (torch.Tensor | sequence, optional): Per-channel normalization mean.
             A two-dimensional sequence applies multiple normalizations to the
             same image and concatenates the results along the channel axis,
@@ -97,7 +268,9 @@ class OpenVLAImagePreprocessor:
         size: int = 224,
         jpeg_quality: int = 95,
         center_crop: bool = False,
-        backend: Literal["torchvision", "pil", "tensorflow"] = "torchvision",
+        backend: Literal[
+            "torchvision", "torch_reference", "pil", "tensorflow"
+        ] = "torch_reference",
         mean: torch.Tensor | Sequence[float] | Sequence[Sequence[float]] | None = None,
         std: torch.Tensor | Sequence[float] | Sequence[Sequence[float]] | None = None,
     ) -> None:
@@ -107,15 +280,15 @@ class OpenVLAImagePreprocessor:
             raise ValueError(
                 f"jpeg_quality must be between 1 and 100, got {jpeg_quality}."
             )
-        if backend not in ("torchvision", "pil", "tensorflow"):
+        if backend not in ("torchvision", "torch_reference", "pil", "tensorflow"):
             raise ValueError(
-                "backend must be 'torchvision', 'pil' or 'tensorflow', "
-                f"got {backend!r}."
+                "backend must be 'torchvision', 'torch_reference', 'pil' or "
+                f"'tensorflow', got {backend!r}."
             )
-        if backend == "torchvision" and not _has_torchvision:
+        if backend in ("torchvision", "torch_reference") and not _has_torchvision:
             raise ImportError(
-                "OpenVLAImagePreprocessor backend='torchvision' requires "
-                "torchvision. Install the TorchRL vla extra or pass backend='pil'."
+                f"OpenVLAImagePreprocessor backend={backend!r} requires torchvision. "
+                "Install the TorchRL vla extra or pass backend='pil'."
             )
         if backend == "pil" and not _has_pil:
             raise ImportError("OpenVLAImagePreprocessor backend='pil' requires Pillow.")
@@ -159,6 +332,8 @@ class OpenVLAImagePreprocessor:
         flat = self._to_uint8(flat)
         if self.backend == "torchvision":
             processed = self._torchvision(flat)
+        elif self.backend == "torch_reference":
+            processed = self._torch_reference(flat)
         elif self.backend == "tensorflow":
             processed = self._tensorflow(flat)
         else:
@@ -225,6 +400,26 @@ class OpenVLAImagePreprocessor:
         decoded = self._center_crop(decoded)
         decoded = self._resize(decoded)
         return decoded
+
+    def _torch_reference(self, images: torch.Tensor) -> torch.Tensor:
+        device = images.device
+        # torchvision's reference JPEG codec is CPU-only. Keep the subsequent
+        # interpolation on its decoded CPU output and restore the caller's
+        # device only after preprocessing is complete.
+        images = images.cpu()
+        if images.shape[1] == 1:
+            images = images.expand(-1, 3, -1, -1).contiguous()
+        decoded = _torchvision_jpeg_roundtrip(
+            images, self.jpeg_quality, torch.device("cpu")
+        )
+        resized = []
+        for chunk in decoded.split(_REFERENCE_RESIZE_BATCH_SIZE):
+            chunk = _lanczos3_resize(chunk.to(torch.float32), (self.size, self.size))
+            resized.append(chunk.round_().clamp_(0, 255).to(torch.uint8))
+        decoded = torch.cat(resized, 0)
+        if self.center_crop:
+            decoded = _fractional_center_crop(decoded, (self.size, self.size))
+        return decoded.to(device)
 
     def _tensorflow(self, images: torch.Tensor) -> torch.Tensor:
         import tensorflow as tf


### PR DESCRIPTION
## Summary

- add a `torch_reference` OpenVLA image backend that performs the JPEG round trip before resize, reproduces TensorFlow's antialiased Lanczos3 sampling spans, and applies the fractional 0.9-area center crop with TensorFlow-compatible uint8 conversion
- vectorize Lanczos3 span construction with device-native PyTorch operations, preserve eager caching, and support batched full-graph `torch.compile` execution without host-to-device span copies
- make fractional crop coordinates device-native and compile-safe, avoid mutating float inputs, and warn when dependency fallback changes preprocessing semantics
- make `torch_reference` the default for the reusable preprocessor, OpenVLA wrappers, and the LIBERO VLA-GRPO recipe; retain `torchvision` as the faster bicubic opt-in path
- propagate the backend through the OpenVLA wrappers and document how it differs from the faster `torchvision` path and the TensorFlow reference path
- add TensorFlow-generated interpolation goldens, optional live TensorFlow comparisons, default-backend coverage, wrapper coverage, and preprocessing benchmark coverage

## Motivation

The existing TensorFlow backend follows the reference preprocessing path but requires TensorFlow at runtime. The existing torchvision backend avoids that dependency, but changes the operation order and uses bicubic resize plus an integer crop. The new default provides a TensorFlow-free path with the reference order and interpolation semantics while retaining torchvision's JPEG codec. Users can explicitly select `torchvision` when throughput is more important than reference parity.

## Equivalence

Using Torch 2.13, torchvision 0.28, and TensorFlow 2.21 on CPU, absolute uint8-pixel errors were aggregated over odd and non-square RGB and grayscale inputs, random and structured images, and center crop enabled and disabled:

| Backend compared with TensorFlow | Mean | Max | p95 | p99 |
| --- | ---: | ---: | ---: | ---: |
| `torch_reference` | 1.463 | 18 | 4 | 6 |
| `torchvision` | 15.408 | 212 | 51 | 80 |

When the JPEG input is shared, the Lanczos3 resize differs from TensorFlow by a mean of `9.8e-6` and a maximum of `1.07e-4`. The quantized crop is 99.996% bitwise equal, with mean error `3.65e-5` and maximum error 1. The remaining end-to-end difference is dominated by the TensorFlow and torchvision JPEG codecs; the JPEG round trips alone differed by roughly 1.5-1.6 mean pixel levels on the representative inputs.

On 256x256 input, the new reference-oriented path took 1.84 ms for batch 1 and 7.36 ms for batch 4 in the local CPU benchmark, compared with 0.85 ms and 2.80 ms for the faster torchvision path.

## Validation

- `python -m pytest -q test/data/test_vla.py sota-implementations/vla_grpo/test_openvla.py` (`97 passed, 3 skipped`)
- batched Lanczos3 resize under `torch.compile(fullgraph=True)` with both eager and inductor backends
- selected preprocessing benchmarks for torchvision and torch_reference, batch sizes 1 and 4
- all pre-commit hooks on the changed files


