### PR TITLE
[Performance] Avoid rollout copies before multi-collector replay writes

### DIFF
--- a/benchmarks/test_collectors_benchmark.py
+++ b/benchmarks/test_collectors_benchmark.py
@@ -3,18 +3,72 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import argparse
+import functools
 import time
 
 import pytest
 import torch.cuda
 import tqdm
+from tensordict import TensorDict, TensorDictBase
 
 from torchrl.collectors import Collector, MultiAsyncCollector, MultiSyncCollector
-from torchrl.data import LazyTensorStorage, ReplayBuffer
+from torchrl.data import (
+    Binary,
+    Categorical,
+    Composite,
+    LazyTensorStorage,
+    ReplayBuffer,
+    Unbounded,
+)
 from torchrl.data.utils import CloudpickleWrapper
-from torchrl.envs import EnvCreator, GymEnv, ParallelEnv, StepCounter, TransformedEnv
+from torchrl.envs import (
+    EnvBase,
+    EnvCreator,
+    GymEnv,
+    ParallelEnv,
+    StepCounter,
+    TransformedEnv,
+)
 from torchrl.envs.libs.dm_control import DMControlEnv
 from torchrl.modules import RandomPolicy
+
+
+class _PayloadEnv(EnvBase):
+    """Zero-work environment with a configurable observation payload."""
+
+    def __init__(self, payload_size: int = 65536):
+        super().__init__()
+        self.observation_spec = Composite(
+            observation=Unbounded((payload_size,)), shape=self.batch_size
+        )
+        self.action_spec = Binary(1, shape=(1,))
+        self.reward_spec = Unbounded((1,))
+        self.done_spec = Categorical(2, shape=(1,), dtype=torch.bool)
+        self.register_buffer("observation", torch.zeros(payload_size))
+
+    def _set_seed(self, seed: int | None) -> None:
+        return None
+
+    def _reset(self, tensordict: TensorDictBase | None = None) -> TensorDictBase:
+        return TensorDict(
+            {
+                "observation": self.observation,
+                "done": torch.zeros(1, dtype=torch.bool),
+                "terminated": torch.zeros(1, dtype=torch.bool),
+            },
+            batch_size=self.batch_size,
+        )
+
+    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
+        return TensorDict(
+            {
+                "observation": self.observation,
+                "reward": torch.zeros(1),
+                "done": torch.zeros(1, dtype=torch.bool),
+                "terminated": torch.zeros(1, dtype=torch.bool),
+            },
+            batch_size=self.batch_size,
+        )
 
 
 def single_collector_setup():
@@ -99,6 +153,21 @@ def async_collector_setup():
         if i == 10:
             break
     return ((c,), {})
+
+
+def parallel_env_compact_obs_setup(payload_size):
+    env = ParallelEnv(4, functools.partial(_PayloadEnv, payload_size))
+    collector = Collector(
+        env,
+        RandomPolicy(env.action_spec),
+        total_frames=-1,
+        frames_per_batch=128,
+        compact_obs=True,
+    )
+    collector = iter(collector)
+    next(collector)
+    next(collector)
+    return ((collector,), {})
 
 
 def single_collector_setup_pixels():
@@ -222,9 +291,62 @@ def single_collector_with_rb_setup_pixels():
     return ((c, rb), {})
 
 
+def sync_collector_with_rb_setup():
+    """Setup a multi-process collector whose workers write whole rollouts."""
+    device = "cuda:0" if torch.cuda.device_count() else "cpu"
+    env = EnvCreator(
+        lambda: TransformedEnv(
+            DMControlEnv("cheetah", "run", device=device), StepCounter(50)
+        )
+    )
+    rb = ReplayBuffer(storage=LazyTensorStorage(10000))
+    c = MultiSyncCollector(
+        [env, env],
+        RandomPolicy(env().action_spec),
+        total_frames=-1,
+        frames_per_batch=100,
+        device=device,
+        replay_buffer=rb,
+    )
+    c = iter(c)
+    for i, _ in enumerate(c):
+        if i == 10:
+            break
+    return ((c, rb), {})
+
+
+def sync_payload_collector_with_rb_setup():
+    """Setup replay writes where rollout materialization dominates env work."""
+    env = EnvCreator(_PayloadEnv)
+    rb = ReplayBuffer(storage=LazyTensorStorage(512))
+    c = MultiSyncCollector(
+        [env, env],
+        RandomPolicy(env().action_spec),
+        total_frames=-1,
+        frames_per_batch=64,
+        replay_buffer=rb,
+    )
+    c = iter(c)
+    next(c)
+    next(c)
+    return ((c, rb), {})
+
+
 def test_single_with_rb(benchmark):
     """Benchmark single collector with replay buffer (lazy stack path)."""
     (c, rb), _ = single_collector_with_rb_setup()
+    benchmark(execute_collector_with_rb, c, rb)
+
+
+def test_sync_with_rb(benchmark):
+    """Benchmark the runner-managed replay-buffer write path."""
+    (c, rb), _ = sync_collector_with_rb_setup()
+    benchmark(execute_collector_with_rb, c, rb)
+
+
+def test_sync_payload_with_rb(benchmark):
+    """Benchmark clone avoidance for large runner-managed rollouts."""
+    (c, rb), _ = sync_payload_collector_with_rb_setup()
     benchmark(execute_collector_with_rb, c, rb)
 
 
@@ -252,6 +374,13 @@ def test_sync_preempt(benchmark):
 
 def test_async(benchmark):
     (c,), _ = async_collector_setup()
+    benchmark(execute_collector, c)
+
+
+@pytest.mark.parametrize("payload_size", [65536, 262144], ids=["256KiB", "1MiB"])
+def test_parallel_env_compact_obs(benchmark, payload_size):
+    """Benchmark copies for a collector over a large-payload ParallelEnv."""
+    (c,), _ = parallel_env_compact_obs_setup(payload_size)
     benchmark(execute_collector, c)
 
 

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -5666,6 +5666,36 @@ class TestCollectorRB:
         assert len(rb) > 0
         assert rb.storage[: len(rb)].device == torch.device("cpu")
 
+    def test_runner_managed_replay_buffer_returns_uncloned_rollout(self):
+        class RunnerManagedCollector(Collector):
+            _ignore_rb = True
+
+        env = CountingEnv()
+        rb = ReplayBuffer(storage=LazyTensorStorage(32), batch_size=4)
+        postproc_inputs = []
+
+        def postproc(data):
+            postproc_inputs.append(data)
+            return data
+
+        collector = RunnerManagedCollector(
+            env,
+            RandomPolicy(env.action_spec),
+            frames_per_batch=8,
+            total_frames=8,
+            replay_buffer=rb,
+            extend_buffer=True,
+            return_same_td=True,
+            postproc=postproc,
+        )
+        try:
+            data = next(iter(collector))
+            assert data is postproc_inputs[0]
+            rb.extend(data)
+            assert len(rb) == 8
+        finally:
+            collector.shutdown()
+
     @pytest.mark.skipif(not _has_gym, reason="requires gym.")
     @pytest.mark.parametrize(
         "collector_class", [MultiSyncCollector, MultiAsyncCollector]

--- a/torchrl/collectors/_runner.py
+++ b/torchrl/collectors/_runner.py
@@ -105,6 +105,9 @@ def _main_async_collector(
         # (with proper padding stripping for 1-D storage). Set _ignore_rb=False so
         # it detects the RB. When trajs_per_batch is None, keep existing behavior.
         collector_class._ignore_rb = extend_buffer if trajs_per_batch is None else False
+        runner_handles_replay_buffer = replay_buffer is not None and bool(
+            collector_class._ignore_rb
+        )
         inner_collector = collector_class(
             create_env_fn,
             create_env_kwargs=create_env_kwargs,
@@ -121,7 +124,10 @@ def _main_async_collector(
             env_device=env_device,
             exploration_type=exploration_type,
             reset_when_done=reset_when_done,
-            return_same_td=replay_buffer is None,
+            # The runner consumes this rollout immediately and writes it to the
+            # replay buffer before asking the collector for another one. There
+            # is no need to clone a rollout solely to protect it from reuse.
+            return_same_td=replay_buffer is None or runner_handles_replay_buffer,
             interruptor=interruptor,
             set_truncated=set_truncated,
             use_buffers=use_buffers,


### PR DESCRIPTION
## Summary

- avoid cloning worker rollouts that the multi-collector runner consumes immediately
- preserve dense rollout materialization, which is faster than lazy storage writes for small batches
- add replay-buffer and large-payload collector benchmarks used by the rest of the stack

## Test plan

- `pytest test/test_collectors.py -k 'runner_managed_replay_buffer or collector_rb_multisync or collector_rb_multiasync or multi_async_replay_buffer_device_metadata'`
- `pytest benchmarks/test_collectors_benchmark.py::test_sync_with_rb benchmarks/test_collectors_benchmark.py::test_sync_payload_with_rb --benchmark-only`

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #4007
* __->__ #4006
