### PR TITLE
[Performance] Skip compact next-state copies in ParallelEnv

### DIFF
--- a/test/envs/test_parallel.py
+++ b/test/envs/test_parallel.py
@@ -104,6 +104,24 @@ class TestParallel:
                 4, make_env, create_env_kwargs=[{"seed": 0}, {"seed": 1}]
             )
 
+    def test_compact_collector_skips_next_observation_copy(
+        self, maybe_fork_ParallelEnv
+    ):
+        class CompactCollector:
+            _compact_next_keys = (("next", "observation"),)
+
+        env = maybe_fork_ParallelEnv(2, CountingEnv, use_buffers=True)
+        collector = CompactCollector()
+        env.register_collector(collector)
+        try:
+            data = env.rand_action(env.reset())
+            step, post_reset = env.step_and_maybe_reset(data)
+            assert ("next", "observation") not in step.keys(True, True)
+            assert ("next", "reward") in step.keys(True, True)
+            assert "observation" in post_reset.keys()
+        finally:
+            env.close(raise_if_closed=False)
+
     @pytest.mark.gpu
     @pytest.mark.skipif(
         not torch.cuda.device_count(), reason="No cuda device detected."

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -2178,6 +2178,24 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
             return result
         return out
 
+    def _get_collector_next_keys_to_exclude(self) -> tuple:
+        """Return keys that the registered collector will discard immediately."""
+        collector_ref = self._collector
+        if collector_ref is None or (collector := collector_ref()) is None:
+            return ()
+        cache = self.__dict__.get("_collector_next_keys_to_exclude")
+        if cache is not None and cache[0] is collector_ref:
+            return cache[1]
+        keys = []
+        for key in getattr(collector, "_compact_next_keys", ()):
+            if not isinstance(key, tuple) or not key or key[0] != "next":
+                continue
+            key = key[1:]
+            keys.append(key[0] if len(key) == 1 else key)
+        keys = tuple(keys)
+        self.__dict__["_collector_next_keys_to_exclude"] = (collector_ref, keys)
+        return keys
+
     @torch.no_grad()
     @_check_start
     @_maybe_record_function_decorator("ParallelEnv.step_and_maybe_reset")
@@ -2273,6 +2291,11 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
 
         # We must pass a clone of the tensordict, as the values of this tensordict
         # will be modified in-place at further steps
+        next_keys_to_exclude = self._get_collector_next_keys_to_exclude()
+        if next_keys_to_exclude:
+            # The post-reset root still carries these values for the next policy
+            # call. Avoid copying only the duplicate values in the step output.
+            next_td = next_td.exclude(*next_keys_to_exclude)
         device = self.device
         shared_device = shared_tensordict_parent.device
         if shared_device == device:


### PR DESCRIPTION
## Summary

- let a directly registered collector tell `ParallelEnv` which compact `next` observation/state keys it will discard
- exclude those keys before the parent clones or transfers the shared worker result
- retain the complete post-reset root required by the next policy call

## Local benchmarks

Apple Silicon results for `Collector(ParallelEnv(4, ...), compact_obs=True)`, 128 frames per batch, compared with `origin/main` at `808b0ac`:

| Observation per environment | main median | PR median | change |
| --- | ---: | ---: | ---: |
| 256 KiB | 6.40 ms | 5.73 ms | -10.4% |
| 1 MiB | 12.36 ms | 11.08 ms | -10.3% |

Linux benchmark CI is enabled on this PR and is the authoritative performance check.

## Test plan

- `pytest test/test_collectors.py::TestCollectorGeneric::test_compact_obs_drops_next_obs`
- `pytest test/envs/test_parallel.py::TestParallel::test_compact_collector_skips_next_observation_copy`

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #4007
* #4006

