### PR TITLE
[Performance] Write large ParallelEnv rollouts directly

### DIFF
--- a/test/envs/test_parallel.py
+++ b/test/envs/test_parallel.py
@@ -122,6 +122,28 @@ class TestParallel:
         finally:
             env.close(raise_if_closed=False)
 
+    def test_direct_collector_borrows_step_output(self, maybe_fork_ParallelEnv):
+        class DirectCollector:
+            _compact_next_keys = ()
+            _write_env_output_directly = True
+
+        env = maybe_fork_ParallelEnv(2, CountingEnv, use_buffers=True)
+        collector = DirectCollector()
+        env.register_collector(collector)
+        try:
+            data = env.rand_action(env.reset())
+            step, post_reset = env.step_and_maybe_reset(data)
+            assert (
+                step.get(("next", "observation")).data_ptr()
+                == env._shared_tensordict_parent_next.get("observation").data_ptr()
+            )
+            assert (
+                post_reset.get("observation").data_ptr()
+                == env._shared_tensordict_parent_root.get("observation").data_ptr()
+            )
+        finally:
+            env.close(raise_if_closed=False)
+
     @pytest.mark.gpu
     @pytest.mark.skipif(
         not torch.cuda.device_count(), reason="No cuda device detected."

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -155,6 +155,10 @@ TORCH_VERSION = version.parse(version.parse(torch.__version__).base_version)
 _has_cuda = torch.cuda.is_available()
 
 
+class _DirectOutputCollector(Collector):
+    _DIRECT_ENV_OUTPUT_MIN_BYTES = 0
+
+
 @pytest.mark.parametrize(
     ("backend", "scheme_cls"),
     [
@@ -1466,6 +1470,76 @@ if __name__ == "__main__":
             ref_next = ref_data.get(full)[..., :-1, :]
             root_shifted = ref_data.get(k)[..., 1:, :]
             torch.testing.assert_close(ref_next[mask], root_shifted[mask])
+
+    def test_parallel_env_direct_output_is_correct_and_immutable(self):
+        env = ParallelEnv(2, lambda: CountingEnv(max_steps=100))
+        with patch.object(Collector, "_DIRECT_ENV_OUTPUT_MIN_BYTES", 0):
+            collector = Collector(
+                env,
+                CountingEnvCountPolicy(env.action_spec),
+                frames_per_batch=8,
+                total_frames=16,
+                use_buffers=True,
+                auto_register_policy_transforms=False,
+            )
+        try:
+            iterator = iter(collector)
+            first = next(iterator)
+            first_copy = first.clone()
+            second = next(iterator)
+
+            expected_first = (
+                torch.arange(4, dtype=torch.int32).view(1, 4, 1).expand(2, -1, -1)
+            )
+            expected_second = (
+                torch.arange(4, 8, dtype=torch.int32).view(1, 4, 1).expand(2, -1, -1)
+            )
+            torch.testing.assert_close(first["observation"], expected_first)
+            torch.testing.assert_close(
+                first[("next", "observation")], expected_first + 1
+            )
+            torch.testing.assert_close(second["observation"], expected_second)
+            assert_allclose_td(first, first_copy)
+        finally:
+            collector.shutdown()
+
+    def test_multisync_parallel_env_direct_output_is_correct(self):
+        def make_env():
+            return ParallelEnv(2, lambda: CountingEnv(max_steps=100))
+
+        probe = make_env()
+        try:
+            action_spec = probe.action_spec
+        finally:
+            probe.close(raise_if_closed=False)
+        collector = MultiSyncCollector(
+            [make_env, make_env],
+            CountingEnvCountPolicy(action_spec),
+            collector_class=_DirectOutputCollector,
+            frames_per_batch=16,
+            total_frames=32,
+            cat_results="stack",
+            auto_register_policy_transforms=False,
+        )
+        try:
+            iterator = iter(collector)
+            first = next(iterator)
+            first_copy = first.clone()
+            second = next(iterator)
+
+            expected_first = (
+                torch.arange(4, dtype=torch.int32).view(1, 1, 4, 1).expand(2, 2, -1, -1)
+            )
+            expected_second = (
+                torch.arange(4, 8, dtype=torch.int32)
+                .view(1, 1, 4, 1)
+                .expand(2, 2, -1, -1)
+            )
+            torch.testing.assert_close(first["observation"], expected_first)
+            torch.testing.assert_close(second["observation"], expected_second)
+            assert_allclose_td(first, first_copy)
+        finally:
+            collector.shutdown()
 
     @pytest.mark.parametrize("use_buffers", [True, False])
     def test_fake_tensordict_single_matches_iter(self, use_buffers):

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -421,6 +421,7 @@ class Collector(BaseCollector):
     """
 
     _ignore_rb: bool = False
+    _DIRECT_ENV_OUTPUT_MIN_BYTES = 256 * 1024
 
     def __init__(
         self,
@@ -602,6 +603,7 @@ class Collector(BaseCollector):
         # Create carrier and rollout buffers
         self._make_carrier()
         self._maybe_make_final_rollout(make_rollout=self._use_buffers)
+        self._setup_direct_env_output()
         self._set_truncated_keys()
 
         # Set up interruptor and frame tracking
@@ -1365,6 +1367,54 @@ class Collector(BaseCollector):
                 )
             self._final_rollout.refine_names(..., "time")
 
+    def _setup_direct_env_output(self) -> None:
+        """Configure direct writes from borrowed environment output buffers."""
+        supports_direct_output = getattr(
+            type(self.env), "_supports_collector_direct_output", False
+        )
+        same_storage_device = (
+            self.storing_device is None or self.storing_device == self.env_device
+        )
+        rollout_step = self._final_rollout[..., 0] if self._use_buffers else None
+        rollout_step_bytes = (
+            sum(
+                value.numel() * value.element_size()
+                for value in rollout_step.values(True, True)
+                if isinstance(value, torch.Tensor)
+            )
+            if rollout_step is not None
+            else 0
+        )
+        # Per-step TensorDict updates have a fixed cost. Small payloads remain
+        # faster on the regular clone-and-stack path; direct writes are reserved
+        # for batches where memory traffic dominates that bookkeeping.
+        large_enough = rollout_step_bytes >= self._DIRECT_ENV_OUTPUT_MIN_BYTES
+        tensor_only = rollout_step is not None and all(
+            isinstance(value, torch.Tensor) for value in rollout_step.values(True, True)
+        )
+        self._write_env_output_directly = bool(
+            self._use_buffers
+            and supports_direct_output
+            and same_storage_device
+            and large_enough
+            and tensor_only
+        )
+        self._yield_owning_rollout = bool(
+            self._write_env_output_directly and not self.return_same_td
+        )
+        if not self._write_env_output_directly:
+            self._direct_output_root_keys = ()
+            self._direct_output_next_keys = ()
+            return
+        self._direct_output_root_keys = tuple(
+            key
+            for key in self._final_rollout.keys(True, True)
+            if not (isinstance(key, tuple) and key[0] == "next")
+        )
+        self._direct_output_next_keys = tuple(
+            self._final_rollout.get("next").keys(True, True)
+        )
+
     def _set_truncated_keys(self):
         self._truncated_keys = []
         if self.set_truncated:
@@ -1549,6 +1599,12 @@ class Collector(BaseCollector):
                     yield
                     continue
                 self._increment_frames(tensordict_out.numel())
+                if self._yield_owning_rollout:
+                    # Hand the completed allocation to the caller and replace
+                    # the internal buffer before user code can mutate it.
+                    self._final_rollout = self._final_rollout.new_empty(
+                        *self._final_rollout.batch_size
+                    )
                 tensordict_out = self._postproc(tensordict_out)
                 if self.return_same_td:
                     # This is used with multiprocessed collectors to use the buffers
@@ -1557,6 +1613,10 @@ class Collector(BaseCollector):
                         for event in events:
                             event.record()
                             event.synchronize()
+                    if self.post_collect_hook is not None:
+                        self.post_collect_hook(tensordict_out)
+                    yield tensordict_out
+                elif self._yield_owning_rollout:
                     if self.post_collect_hook is not None:
                         self.post_collect_hook(tensordict_out)
                     yield tensordict_out
@@ -1857,9 +1917,22 @@ class Collector(BaseCollector):
                         env_input = self._carrier
                 else:
                     env_input = self._carrier
+                if self._write_env_output_directly:
+                    direct_output = self._final_rollout[..., t]
+                    direct_output.update_(
+                        self._carrier,
+                        keys_to_update=self._direct_output_root_keys,
+                        non_blocking=self.no_cuda_sync,
+                    )
                 env_output, env_next_output = self.env.step_and_maybe_reset(env_input)
 
-                if self._carrier is not env_output:
+                if self._write_env_output_directly:
+                    direct_output.get("next").update_(
+                        env_output.get("next"),
+                        keys_to_update=self._direct_output_next_keys,
+                        non_blocking=self.no_cuda_sync,
+                    )
+                elif self._carrier is not env_output:
                     # ad-hoc update carrier
                     next_data = env_output.get("next")
                     if self._carrier_has_no_device:
@@ -1875,7 +1948,9 @@ class Collector(BaseCollector):
                 else:
                     carrier_for_out = self._carrier
 
-                if (
+                if self._write_env_output_directly:
+                    pass
+                elif (
                     self.replay_buffer is not None
                     and not self._ignore_rb
                     and not self.extend_buffer
@@ -1919,7 +1994,9 @@ class Collector(BaseCollector):
                     ):
                         return
                     result = self._final_rollout
-                    if self._use_buffers:
+                    if self._write_env_output_directly:
+                        pass
+                    elif self._use_buffers:
                         try:
                             torch.stack(
                                 tensordicts,
@@ -1944,7 +2021,9 @@ class Collector(BaseCollector):
                         result = TensorDict.maybe_dense_stack(tensordicts, dim=-1)
                     break
             else:
-                if self._use_buffers:
+                if self._write_env_output_directly:
+                    result = self._final_rollout
+                elif self._use_buffers:
                     result = self._final_rollout
                     try:
                         result = torch.stack(

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -1376,29 +1376,45 @@ class Collector(BaseCollector):
             self.storing_device is None or self.storing_device == self.env_device
         )
         rollout_step = self._final_rollout[..., 0] if self._use_buffers else None
-        rollout_step_bytes = (
-            sum(
-                value.numel() * value.element_size()
-                for value in rollout_step.values(True, True)
-                if isinstance(value, torch.Tensor)
+
+        def contains_lazy_stack(tensordict: TensorDictBase) -> bool:
+            if isinstance(tensordict, LazyStackedTensorDict):
+                return True
+            return any(
+                contains_lazy_stack(value)
+                for value in tensordict.values()
+                if isinstance(value, TensorDictBase)
             )
-            if rollout_step is not None
-            else 0
+
+        dense_rollout = rollout_step is not None and not contains_lazy_stack(
+            rollout_step
+        )
+        if not (
+            self._use_buffers
+            and supports_direct_output
+            and same_storage_device
+            and dense_rollout
+        ):
+            self._write_env_output_directly = False
+            self._yield_owning_rollout = False
+            self._direct_output_root_keys = ()
+            self._direct_output_next_keys = ()
+            return
+
+        rollout_step_values = tuple(rollout_step.values(True, True))
+        rollout_step_bytes = sum(
+            value.numel() * value.element_size()
+            for value in rollout_step_values
+            if isinstance(value, torch.Tensor)
         )
         # Per-step TensorDict updates have a fixed cost. Small payloads remain
         # faster on the regular clone-and-stack path; direct writes are reserved
         # for batches where memory traffic dominates that bookkeeping.
         large_enough = rollout_step_bytes >= self._DIRECT_ENV_OUTPUT_MIN_BYTES
-        tensor_only = rollout_step is not None and all(
-            isinstance(value, torch.Tensor) for value in rollout_step.values(True, True)
+        tensor_only = all(
+            isinstance(value, torch.Tensor) for value in rollout_step_values
         )
-        self._write_env_output_directly = bool(
-            self._use_buffers
-            and supports_direct_output
-            and same_storage_device
-            and large_enough
-            and tensor_only
-        )
+        self._write_env_output_directly = bool(large_enough and tensor_only)
         self._yield_owning_rollout = bool(
             self._write_env_output_directly and not self.return_same_td
         )

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -1810,6 +1810,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
     """
 
     __doc__ += BatchedEnvBase.__doc__
+    _supports_collector_direct_output = True
     __doc__ += """
 
     .. note:: ParallelEnv will timeout after one of the worker is idle for a determinate amount of time.
@@ -2298,7 +2299,19 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
             next_td = next_td.exclude(*next_keys_to_exclude)
         device = self.device
         shared_device = shared_tensordict_parent.device
-        if shared_device == device:
+        collector = self.collector
+        direct_collector_output = (
+            partial_steps is None
+            and collector is not None
+            and getattr(collector, "_write_env_output_directly", False)
+        )
+        if shared_device == device and direct_collector_output:
+            # The collector copies both root and next data into its rollout
+            # buffer before the workers can reuse these shared-memory views.
+            # Keep the input structure independent so adding ``next`` below
+            # does not mutate a borrowed root carrier.
+            tensordict = tensordict.copy()
+        elif shared_device == device:
             next_td = next_td.clone()
             tensordict_ = tensordict_.clone()
         elif device is not None:


### PR DESCRIPTION
## Summary

- let buffered, same-device `ParallelEnv` return internal shared-memory views to a registered collector
- write root and `next` values directly into their final rollout time slices instead of cloning in `ParallelEnv` and stacking afterward
- hand single collectors a fresh owning allocation, preserving returned-batch immutability without a final clone
- gate the path to tensor-only payloads of at least 256 KiB per batched step; smaller and unsupported cases retain the existing path

## Local benchmarks

Apple Silicon results for `Collector(ParallelEnv(4, ...), compact_obs=True)`, 128 frames per batch, compared with `origin/main` at `808b0ac`:

| Observation per environment | main median | stack median | change |
| --- | ---: | ---: | ---: |
| 256 KiB | 6.10 ms | 5.60 ms | -8.3% |
| 1 MiB | 11.10 ms | 7.39 ms | -33.4% |

Linux benchmark CI is enabled on this PR and is the authoritative performance check.

## Test plan

- `pytest test/test_collectors.py -k 'parallel_env_direct_output or multisync_parallel_env_direct_output'`
- `pytest test/envs/test_parallel.py -k 'compact_collector or direct_collector'`
- `pytest test/test_collectors.py::TestCollectorRB::test_parallel_env_with_multi_collector_and_replay_buffer`
- `pytest test/test_collectors.py::TestHeterogeneousEnvsCollector`
- `pytest benchmarks/test_collectors_benchmark.py::test_parallel_env_compact_obs --benchmark-only`

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #4008
* #4007
* #4006
