### PR TITLE
[Test] Consolidate reusable test mocks

### DIFF
--- a/test/collectors/test_evaluator.py
+++ b/test/collectors/test_evaluator.py
@@ -22,7 +22,6 @@ from torchrl.collectors._evaluator import (
     _freeze_vecnorm,
     _wrap_env_factory_frozen,
 )
-from torchrl.data import Unbounded
 from torchrl.envs import SerialEnv, TransformedEnv
 from torchrl.envs.env_creator import EnvCreator
 from torchrl.envs.transforms import (
@@ -34,6 +33,7 @@ from torchrl.envs.transforms import (
 )
 from torchrl.record import VideoRecorder
 from torchrl.record.loggers.process import ProcessLogger
+from torchrl.testing import AddPixelsTransform
 from torchrl.testing.mocking_classes import ContinuousActionVecMockEnv
 from torchrl.weight_update import WeightStrategy
 
@@ -81,31 +81,11 @@ class _VideoEventsLogger:
             file.write(f"{name}:{step}:{video.shape[1]}\n")
 
 
-class _AddPixels(Transform):
-    """Writes a constant uint8 image so ``VideoRecorder`` has frames to record."""
-
-    def __init__(self):
-        super().__init__(in_keys=[], out_keys=["pixels"])
-
-    def _call(self, next_tensordict):
-        next_tensordict.set("pixels", torch.zeros(3, 8, 8, dtype=torch.uint8))
-        return next_tensordict
-
-    def _reset(self, tensordict, tensordict_reset):
-        return self._call(tensordict_reset)
-
-    def transform_observation_spec(self, observation_spec):
-        observation_spec["pixels"] = Unbounded(
-            shape=(3, 8, 8), dtype=torch.uint8, device=observation_spec.device
-        )
-        return observation_spec
-
-
 def _make_video_env(video_logger):
     return TransformedEnv(
         _make_env(),
         Compose(
-            _AddPixels(),
+            AddPixelsTransform(),
             VideoRecorder(
                 video_logger,
                 tag="eval_video",

--- a/test/envs/test_auto_reset.py
+++ b/test/envs/test_auto_reset.py
@@ -51,7 +51,7 @@ from torchrl.envs.transforms.transforms import (
     UnsqueezeTransform,
 )
 from torchrl.envs.utils import check_env_specs
-from torchrl.testing import CARTPOLE_VERSIONED
+from torchrl.testing import CARTPOLE_VERSIONED, CountingVecNormV2
 from torchrl.testing.mocking_classes import (
     AutoResetHeteroCountingEnv,
     AutoResettingCountingEnv,
@@ -313,20 +313,6 @@ class TestAutoReset:
         assert env.base_env is base
 
     def test_native_auto_reset_wrapped_vecnorm_step_and_maybe_reset(self):
-        class CountingVecNormV2(VecNormV2):
-            def __init__(self, *args, **kwargs):
-                self.step_calls = 0
-                self.reset_calls = 0
-                super().__init__(*args, **kwargs)
-
-            def _step(self, tensordict, next_tensordict):
-                self.step_calls += 1
-                return super()._step(tensordict, next_tensordict)
-
-            def _reset(self, tensordict, tensordict_reset):
-                self.reset_calls += 1
-                return super()._reset(tensordict, tensordict_reset)
-
         env = TransformedEnv(AutoResettingCountingEnv(3), InitTracker())
         env._torchrl_native_autoreset = True
         vecnorm = CountingVecNormV2(in_keys=["observation"])

--- a/test/envs/test_model_based.py
+++ b/test/envs/test_model_based.py
@@ -20,7 +20,7 @@ from torchrl.envs.model_based import WorldModelEnv
 from torchrl.envs.utils import check_env_specs
 from torchrl.modules import SafeModule, WorldModel
 from torchrl.modules.tensordict_module import WorldModelWrapper
-from torchrl.testing import get_default_devices
+from torchrl.testing import CatLinear, get_default_devices
 from torchrl.testing.mocking_classes import ActionObsMergeLinear, DummyModelBasedEnvBase
 
 
@@ -124,17 +124,6 @@ _WM_ACTION_DIM = 2
 _WM_BATCH = 3
 
 
-class _CatLinear(torch.nn.Module):
-    """Concatenates all positional inputs along the last dim, then applies Linear."""
-
-    def __init__(self, in_features: int, out_features: int) -> None:
-        super().__init__()
-        self.linear = torch.nn.Linear(in_features, out_features)
-
-    def forward(self, *tensors: torch.Tensor) -> torch.Tensor:
-        return self.linear(torch.cat(tensors, dim=-1))
-
-
 def _make_linear_world_model(
     with_done_head: bool = False, with_decoder: bool = False
 ) -> WorldModel:
@@ -144,7 +133,7 @@ def _make_linear_world_model(
         out_keys=["latent"],
     )
     dynamics = TensorDictModule(
-        _CatLinear(_WM_LATENT_DIM + _WM_ACTION_DIM, _WM_LATENT_DIM),
+        CatLinear(_WM_LATENT_DIM + _WM_ACTION_DIM, _WM_LATENT_DIM),
         in_keys=["latent", "action"],
         out_keys=[("next", "latent")],
     )
@@ -269,7 +258,7 @@ class TestWorldModelForward:
             out_keys=[("encoded", "latent")],
         )
         dynamics = TensorDictModule(
-            _CatLinear(_WM_LATENT_DIM + _WM_ACTION_DIM, _WM_LATENT_DIM),
+            CatLinear(_WM_LATENT_DIM + _WM_ACTION_DIM, _WM_LATENT_DIM),
             in_keys=[("encoded", "latent"), "action"],
             out_keys=[("next", "encoded", "latent")],
         )

--- a/test/libs/test_isaac.py
+++ b/test/libs/test_isaac.py
@@ -29,12 +29,12 @@ from torchrl.collectors.distributed import RayCollector
 from torchrl.data import LazyMemmapStorage, RayReplayBuffer, ReplayBuffer
 from torchrl.data.replay_buffers.samplers import SliceSampler
 from torchrl.data.replay_buffers.storages import LazyTensorStorage
-from torchrl.envs import InitTracker, RewardSum, StepCounter, TransformedEnv, VecNormV2
+from torchrl.envs import InitTracker, RewardSum, StepCounter, TransformedEnv
 from torchrl.envs.libs import gym as gym_lib, isaac_lab as isaac_lab_lib
 from torchrl.envs.libs.isaac_lab import IsaacLabWrapper
 from torchrl.envs.utils import check_env_specs
 from torchrl.modules import LSTMModule, MLP
-from torchrl.testing import get_default_devices
+from torchrl.testing import CountingVecNormV2, get_default_devices
 from torchrl.testing.env_helper import (
     _isaac_app_launcher_init,
     make_isaac_env,
@@ -65,21 +65,6 @@ _isaac_env_maker_cuda1 = partial(
 # it can be used directly as a ``policy_factory``.
 _isaac_policy_maker = make_isaac_policy
 _isaac_policy_maker_cuda1 = partial(make_isaac_policy, device=torch.device("cuda:1"))
-
-
-class CountingVecNormV2(VecNormV2):
-    def __init__(self, *args, **kwargs):
-        self.step_calls = 0
-        self.reset_calls = 0
-        super().__init__(*args, **kwargs)
-
-    def _step(self, tensordict, next_tensordict):
-        self.step_calls += 1
-        return super()._step(tensordict, next_tensordict)
-
-    def _reset(self, tensordict, tensordict_reset):
-        self.reset_calls += 1
-        return super()._reset(tensordict, tensordict_reset)
 
 
 def _isaaclab_raw_env(env):

--- a/test/objectives/test_dreamer.py
+++ b/test/objectives/test_dreamer.py
@@ -38,6 +38,7 @@ from torchrl.objectives.world_model_loss import WorldModelLoss
 
 from torchrl.testing import (  # noqa
     call_value_nets as _call_value_nets,
+    CatLinear,
     dtype_fixture,
     get_available_devices,
     get_default_devices,
@@ -538,15 +539,6 @@ _WML_ACTION_DIM = 2
 _WML_BATCH = 3
 
 
-class _WMLCatLinear(torch.nn.Module):
-    def __init__(self, in_features: int, out_features: int) -> None:
-        super().__init__()
-        self.linear = torch.nn.Linear(in_features, out_features)
-
-    def forward(self, *tensors: torch.Tensor) -> torch.Tensor:
-        return self.linear(torch.cat(tensors, dim=-1))
-
-
 def _wml_make_world_model(
     with_done_head: bool = False, with_decoder: bool = False
 ) -> WorldModel:
@@ -558,7 +550,7 @@ def _wml_make_world_model(
         out_keys=["latent"],
     )
     dynamics = TensorDictModule(
-        _WMLCatLinear(_WML_LATENT_DIM + _WML_ACTION_DIM, _WML_LATENT_DIM),
+        CatLinear(_WML_LATENT_DIM + _WML_ACTION_DIM, _WML_LATENT_DIM),
         in_keys=["latent", "action"],
         out_keys=[("next", "latent")],
     )
@@ -627,7 +619,7 @@ class TestWorldModelLoss:
             out_keys=["latent"],
         )
         dynamics = TensorDictModule(
-            _WMLCatLinear(_WML_LATENT_DIM + _WML_ACTION_DIM, _WML_LATENT_DIM),
+            CatLinear(_WML_LATENT_DIM + _WML_ACTION_DIM, _WML_LATENT_DIM),
             in_keys=["latent", "action"],
             out_keys=["predicted_latent"],
         )

--- a/test/transforms/test_timer_video.py
+++ b/test/transforms/test_timer_video.py
@@ -17,19 +17,12 @@ from tensordict import LazyStackedTensorDict, TensorDict
 from torch import nn
 
 from torchrl._utils import logger as torchrl_logger
-from torchrl.data import Unbounded
-from torchrl.envs import (
-    Compose,
-    SerialEnv,
-    StepCounter,
-    Timer,
-    Transform,
-    TransformedEnv,
-)
+from torchrl.envs import Compose, SerialEnv, StepCounter, Timer, TransformedEnv
 from torchrl.envs.utils import check_env_specs
 from torchrl.record.recorder import VideoRecorder
 
 from torchrl.testing import (  # noqa
+    AddPixelsTransform,
     BREAKOUT_VERSIONED,
     dtype_fixture,
     get_default_devices,
@@ -140,31 +133,6 @@ class TestTimer(TransformBase):
         raise pytest.skip("Tested elsewhere")
 
 
-class _AddPixels(Transform):
-    """Writes a constant uint8 image so ``VideoRecorder`` has frames to record."""
-
-    def __init__(self):
-        super().__init__(in_keys=[], out_keys=["pixels"])
-
-    def _call(self, next_tensordict):
-        next_tensordict.set(
-            "pixels",
-            torch.zeros(*next_tensordict.batch_size, 3, 8, 8, dtype=torch.uint8),
-        )
-        return next_tensordict
-
-    def _reset(self, tensordict, tensordict_reset):
-        return self._call(tensordict_reset)
-
-    def transform_observation_spec(self, observation_spec):
-        observation_spec["pixels"] = Unbounded(
-            shape=(*observation_spec.shape, 3, 8, 8),
-            dtype=torch.uint8,
-            device=observation_spec.device,
-        )
-        return observation_spec
-
-
 class _CaptureVideoLogger:
     """Duck-typed logger that stores each ``log_video`` call."""
 
@@ -176,7 +144,7 @@ class _CaptureVideoLogger:
 
 
 def _make_pixels_env(max_steps=None):
-    transforms = [_AddPixels()]
+    transforms = [AddPixelsTransform()]
     if max_steps is not None:
         transforms.append(StepCounter(max_steps=max_steps))
     return TransformedEnv(ContinuousActionVecMockEnv(), Compose(*transforms))
@@ -295,7 +263,7 @@ class TestVideoRecorder:
                 2,
                 lambda: TransformedEnv(
                     ContinuousActionVecMockEnv(),
-                    Compose(_AddPixels(), VideoRecorder(None, None)),
+                    Compose(AddPixelsTransform(), VideoRecorder(None, None)),
                 ),
             )
         finally:

--- a/torchrl/testing/__init__.py
+++ b/torchrl/testing/__init__.py
@@ -34,10 +34,15 @@ from torchrl.testing.llm_mocks import (
     MockTransformerModel,
     MockTransformerOutput,
 )
-from torchrl.testing.mocking_classes import FastImageEnv
+from torchrl.testing.mocking_classes import (
+    AddPixelsTransform,
+    CountingVecNormV2,
+    FastImageEnv,
+)
 from torchrl.testing.modules import (
     BiasModule,
     call_value_nets,
+    CatLinear,
     LSTMNet,
     NonSerializableBiasModule,
 )
@@ -84,10 +89,13 @@ __all__ = [
     "MockTransformerModel",
     "MockTransformerOutput",
     # Mocking classes
+    "AddPixelsTransform",
+    "CountingVecNormV2",
     "FastImageEnv",
     # Modules
     "BiasModule",
     "call_value_nets",
+    "CatLinear",
     "LSTMNet",
     "NonSerializableBiasModule",
     # Ray helpers

--- a/torchrl/testing/mocking_classes.py
+++ b/torchrl/testing/mocking_classes.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import random
 import string
+from typing import Any
 
 import numpy as np
 import torch
@@ -26,7 +27,7 @@ from torchrl.data import (
     Unbounded,
 )
 from torchrl.data.utils import consolidate_spec
-from torchrl.envs import Transform
+from torchrl.envs import Transform, VecNormV2
 from torchrl.envs.common import EnvBase
 from torchrl.envs.model_based.common import ModelBasedEnvBase
 from torchrl.envs.utils import (
@@ -1057,6 +1058,74 @@ class DummyModelBasedEnvBase(ModelBasedEnvBase):
             device=self.device,
         )
         return td
+
+
+class AddPixelsTransform(Transform):
+    """Add a constant ``3 x 8 x 8`` uint8 pixel observation.
+
+    The transform preserves the input batch shape, making it useful for tests
+    that need inexpensive image observations without a rendering dependency.
+
+    Examples:
+        >>> transform = AddPixelsTransform()
+        >>> tensordict = transform._call(TensorDict({}, batch_size=[2]))
+        >>> tensordict["pixels"].shape
+        torch.Size([2, 3, 8, 8])
+    """
+
+    def __init__(self) -> None:
+        super().__init__(in_keys=[], out_keys=["pixels"])
+
+    def _call(self, next_tensordict: TensorDictBase) -> TensorDictBase:
+        next_tensordict.set(
+            "pixels",
+            torch.zeros(
+                (*next_tensordict.batch_size, 3, 8, 8),
+                dtype=torch.uint8,
+                device=next_tensordict.device,
+            ),
+        )
+        return next_tensordict
+
+    def _reset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        return self._call(tensordict_reset)
+
+    def transform_observation_spec(self, observation_spec: Composite) -> Composite:
+        observation_spec["pixels"] = Unbounded(
+            shape=(*observation_spec.shape, 3, 8, 8),
+            dtype=torch.uint8,
+            device=observation_spec.device,
+        )
+        return observation_spec
+
+
+class CountingVecNormV2(VecNormV2):
+    """A :class:`~torchrl.envs.VecNormV2` that counts step and reset calls.
+
+    Examples:
+        >>> transform = CountingVecNormV2(in_keys=["observation"])
+        >>> transform.step_calls, transform.reset_calls
+        (0, 0)
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.step_calls = 0
+        self.reset_calls = 0
+        super().__init__(*args, **kwargs)
+
+    def _step(
+        self, tensordict: TensorDictBase, next_tensordict: TensorDictBase
+    ) -> TensorDictBase:
+        self.step_calls += 1
+        return super()._step(tensordict, next_tensordict)
+
+    def _reset(
+        self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase
+    ) -> TensorDictBase:
+        self.reset_calls += 1
+        return super()._reset(tensordict, tensordict_reset)
 
 
 class ActionObsMergeLinear(nn.Module):

--- a/torchrl/testing/modules.py
+++ b/torchrl/testing/modules.py
@@ -11,6 +11,7 @@ from torchrl.objectives.value.advantages import _vmap_func
 
 __all__ = [
     "BiasModule",
+    "CatLinear",
     "LSTMNet",
     "NonSerializableBiasModule",
     "call_value_nets",
@@ -26,6 +27,27 @@ class BiasModule(nn.Module):
 
     def forward(self, x):
         return x + self.bias
+
+
+class CatLinear(nn.Module):
+    """Concatenate input tensors along the last dimension and apply a linear layer.
+
+    Args:
+        in_features: Size of the concatenated input.
+        out_features: Size of the output.
+
+    Examples:
+        >>> layer = CatLinear(5, 2)
+        >>> layer(torch.zeros(3), torch.zeros(2)).shape
+        torch.Size([2])
+    """
+
+    def __init__(self, in_features: int, out_features: int) -> None:
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_features)
+
+    def forward(self, *tensors: torch.Tensor) -> torch.Tensor:
+        return self.linear(torch.cat(tensors, dim=-1))
 
 
 class NonSerializableBiasModule(BiasModule):


### PR DESCRIPTION
## Summary

- move three reusable test helpers into `torchrl.testing`
- replace duplicated pixel transforms, VecNorm call counters, and concatenating linear modules in their test call sites
- keep scenario-specific fakes and stubs local to the tests that define their behavior

## Assessment

The audit found three helpers with clear cross-test reuse:

- `AddPixelsTransform`: duplicated by evaluator and video-recorder tests; the shared implementation preserves arbitrary batch shapes
- `CountingVecNormV2`: duplicated by auto-reset and IsaacLab tests with identical step/reset instrumentation
- `CatLinear`: duplicated by world-model environment and objective tests with identical multi-input concatenation behavior

Other recent mocks are coupled to a single subsystem or failure scenario, so moving them would widen the testing API without removing meaningful duplication.

## Validation

- all pre-commit hooks
- targeted video, evaluator, model-based environment, and world-model loss tests: 32 passed, 1 skipped
- native auto-reset VecNorm regression test: 1 passed
- IsaacLab VecNorm test collected successfully and skipped because IsaacLab is unavailable
- direct import and smoke checks for all three `torchrl.testing` exports
