### PR TITLE
[BugFix] Make PER alpha annealing exact and version sampler checkpoints

### DIFF
--- a/test/rb/test_prioritized.py
+++ b/test/rb/test_prioritized.py
@@ -532,39 +532,89 @@ def test_prb_alpha_zero_keeps_raw_max(max_priority_within_buffer):
     assert float(sampler.default_priority) == pytest.approx(100.0)
 
 
-def test_prb_alpha_setter_validates_and_warns():
-    """In ``max_priority_within_buffer`` mode the max-priority recomputation
-    inverts sum-tree values with the current ``alpha``, so changing ``alpha``
-    once priorities have been written must warn (once per sampler); the setter
-    must also reject negative values like ``__init__`` does. Without
-    ``max_priority_within_buffer`` the setter stays silent so that alpha
-    annealing (e.g. via ``LinearScheduler``) is warning-free."""
+def test_prb_alpha_setter_validates():
+    """The alpha setter must reject negative values like ``__init__`` does, and
+    annealing alpha (e.g. via ``LinearScheduler``) must be warning-free now that
+    the trees are re-transformed on change."""
     sampler = PrioritizedSampler(
         max_capacity=5, alpha=0.7, beta=0.9, max_priority_within_buffer=True
     )
-    # empty sampler: changing alpha is safe and must not warn
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        sampler.alpha = 0.6
-    sampler.update_priority(torch.tensor([0]), torch.tensor([100.0]))
-    # setting the same value is a no-op and must not warn
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        sampler.alpha = 0.6
-    with pytest.warns(UserWarning, match="does not re-transform"):
-        sampler.alpha = 0.5
-    # the warning is emitted once per sampler
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        sampler.alpha = 0.4
     with pytest.raises(ValueError, match="alpha must be greater or equal"):
         sampler.alpha = -1.0
-    # without max_priority_within_buffer, annealing alpha is warning-free
-    sampler = PrioritizedSampler(max_capacity=5, alpha=0.7, beta=0.9)
     sampler.update_priority(torch.tensor([0]), torch.tensor([100.0]))
     with warnings.catch_warnings():
         warnings.simplefilter("error")
+        sampler.alpha = 0.6
+        sampler.alpha = 0.6  # same-value no-op
         sampler.alpha = 0.5
+
+
+@pytest.mark.parametrize("max_priority_within_buffer", [False, True])
+@pytest.mark.parametrize("new_alpha", [0.5, 0.0])
+def test_prb_alpha_change_retransforms_trees(max_priority_within_buffer, new_alpha):
+    """Setting a new ``alpha`` re-transforms the ``(p + eps) ** alpha`` values
+    stored in the sum/min trees in closed form, so sampling probabilities (and
+    the within-buffer max recomputation, which inverts tree values with the
+    current ``alpha``) stay exact under alpha annealing."""
+    rb = ReplayBuffer(
+        storage=LazyTensorStorage(10),
+        sampler=PrioritizedSampler(
+            max_capacity=10,
+            alpha=1.0,
+            beta=1.0,
+            max_priority_within_buffer=max_priority_within_buffer,
+        ),
+    )
+    eps = rb.sampler._eps
+    idx = rb.extend(torch.arange(6))
+    priorities = torch.arange(1.0, 7.0)
+    rb.update_priority(idx, priorities)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        rb.sampler.alpha = new_alpha
+    assert rb.sampler.alpha == new_alpha
+    sum_tree = torch.as_tensor(
+        [rb.sampler._sum_tree[i] for i in range(rb.sampler._max_capacity)]
+    )
+    min_tree = torch.as_tensor(
+        [rb.sampler._min_tree[i] for i in range(rb.sampler._max_capacity)]
+    )
+    expected = ((priorities.double() + eps) ** new_alpha).to(sum_tree.dtype)
+    torch.testing.assert_close(sum_tree[:6], expected, rtol=1e-4, atol=1e-6)
+    torch.testing.assert_close(min_tree[:6], expected, rtol=1e-4, atol=1e-6)
+    # slots that were never written keep the sum-tree neutral value
+    assert (sum_tree[6:] == 0).all()
+    # the tracked max stays in the raw domain
+    assert float(rb.sampler._max_priority[0]) == pytest.approx(6.0, rel=1e-4)
+    rb.sample(5)
+    if max_priority_within_buffer and new_alpha != 0:
+        # the within-buffer recompute inverts the re-transformed tree values
+        # with the new alpha and recovers the raw max exactly
+        rb.update_priority(torch.tensor([5]), torch.tensor([2.0]))
+        assert float(rb.sampler._max_priority[0]) == pytest.approx(5.0, rel=1e-4)
+        assert int(rb.sampler._max_priority[1]) == 4
+
+
+def test_prb_alpha_change_from_zero_warns():
+    """With ``alpha == 0`` every written tree entry is 1.0, so the raw
+    priorities cannot be recovered when annealing away from 0: the setter warns
+    and keeps the stored (uniform) values until entries are next updated."""
+    sampler = PrioritizedSampler(max_capacity=10, alpha=0.0, beta=1.0)
+    # an empty sampler has nothing to re-transform and must not warn
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        sampler.alpha = 0.5
+        sampler.alpha = 0.0
+    sampler.update_priority(torch.tensor([0, 1]), torch.tensor([3.0, 4.0]))
+    with pytest.warns(UserWarning, match="away from 0"):
+        sampler.alpha = 0.5
+    # written entries keep their uniform value until the next priority update
+    assert float(sampler._sum_tree[0]) == 1.0
+    assert float(sampler._sum_tree[1]) == 1.0
+    sampler.update_priority(torch.tensor([0]), torch.tensor([3.0]))
+    assert float(sampler._sum_tree[0]) == pytest.approx(
+        (3.0 + sampler._eps) ** 0.5, rel=1e-4
+    )
 
 
 if __name__ == "__main__":

--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import pickle
 import warnings
@@ -1373,6 +1374,83 @@ class TestSamplers:
         assert rb.sampler._beta == rb2.sampler._beta
         assert rb.sampler._max_priority[0] == rb2.sampler._max_priority[0]
         assert rb.sampler._max_priority[1] == rb2.sampler._max_priority[1]
+
+    @pytest.mark.parametrize("alpha", [0.6, 1.0])
+    def test_prb_load_legacy_within_buffer_state_dict(self, alpha):
+        """A version-less ``state_dict`` predates pytorch/rl#3925, whose
+        within-buffer recompute persisted the transformed sum-tree value in
+        ``_max_priority``. On load, the raw max must be recomputed from the
+        restored trees instead of trusting the persisted value."""
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(10),
+            sampler=PrioritizedSampler(
+                max_capacity=10, alpha=alpha, beta=1.0, max_priority_within_buffer=True
+            ),
+        )
+        eps = rb.sampler._eps
+        idx = rb.extend(torch.arange(6))
+        rb.update_priority(idx, torch.arange(1.0, 7.0))
+        sd = rb.sampler.state_dict()
+        assert sd["_schema_version"] == 1
+
+        # a version-tagged payload is trusted verbatim
+        sampler = PrioritizedSampler(
+            max_capacity=10, alpha=alpha, beta=1.0, max_priority_within_buffer=True
+        )
+        sampler.load_state_dict(sd)
+        assert float(sampler._max_priority[0]) == pytest.approx(6.0, rel=1e-4)
+
+        # simulate a pre-#3925 checkpoint: no version key, and the transformed
+        # tree value stored in _max_priority after a within-buffer recompute
+        legacy = dict(sd)
+        del legacy["_schema_version"]
+        legacy["_max_priority"] = (
+            torch.tensor((6.0 + eps) ** alpha, dtype=torch.float64),
+            torch.tensor(5),
+        )
+        sampler = PrioritizedSampler(
+            max_capacity=10, alpha=alpha, beta=1.0, max_priority_within_buffer=True
+        )
+        sampler.load_state_dict(legacy)
+        assert float(sampler._max_priority[0]) == pytest.approx(6.0, rel=1e-4)
+        assert int(sampler._max_priority[1]) == 5
+
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.5.0"), reason="requires Torch >= 2.5.0"
+    )
+    def test_prb_loads_legacy_within_buffer_metadata(self, tmpdir):
+        """Same as ``test_prb_load_legacy_within_buffer_state_dict`` but for the
+        ``dumps``/``loads`` JSON metadata path."""
+        alpha = 0.6
+        rb = ReplayBuffer(
+            storage=LazyTensorStorage(10),
+            sampler=PrioritizedSampler(
+                max_capacity=10, alpha=alpha, beta=1.0, max_priority_within_buffer=True
+            ),
+        )
+        eps = rb.sampler._eps
+        idx = rb.extend(torch.arange(6))
+        rb.update_priority(idx, torch.arange(1.0, 7.0))
+        rb.sampler.dumps(tmpdir)
+
+        metadata_path = os.path.join(tmpdir, "sampler_metadata.json")
+        with open(metadata_path) as file:
+            metadata = json.load(file)
+        assert metadata["_schema_version"] == 1
+
+        # rewrite the metadata as pre-#3925 code persisted it: no version key
+        # and a transformed tree value in _max_priority
+        del metadata["_schema_version"]
+        metadata["_max_priority"] = [float((6.0 + eps) ** alpha), 5.0]
+        with open(metadata_path, "w") as file:
+            json.dump(metadata, file)
+
+        sampler = PrioritizedSampler(
+            max_capacity=10, alpha=alpha, beta=1.0, max_priority_within_buffer=True
+        )
+        sampler.loads(tmpdir)
+        assert float(sampler._max_priority[0]) == pytest.approx(6.0, rel=1e-4)
+        assert int(sampler._max_priority[1]) == 5
 
     @pytest.mark.skipif(
         TORCH_VERSION < version.parse("2.5.0"), reason="requires Torch >= 2.5.0"

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -1048,6 +1048,11 @@ class PrioritizedSampler(Sampler):
 
     """
 
+    # Version of the state_dict / dumps payload schema. Version 1 marks
+    # payloads whose _max_priority is stored in the raw priority domain
+    # (pytorch/rl#3925); version-less payloads are treated as pre-#3925.
+    _STATE_SCHEMA_VERSION: int = 1
+
     def __init__(
         self,
         max_capacity: int,
@@ -1073,7 +1078,6 @@ class PrioritizedSampler(Sampler):
         self.reduction = reduction
         self.dtype = dtype
         self._max_priority_within_buffer = max_priority_within_buffer
-        self._warned_alpha_change = False
         self._device = torch.device(device) if device is not None else None
         self._init()
         if rl_warnings() and SumSegmentTreeFp32 is None:
@@ -1099,12 +1103,16 @@ class PrioritizedSampler(Sampler):
     def alpha(self):
         """The priority exponent.
 
-        .. note:: Changing ``alpha`` on a sampler that already holds priorities
+        .. note:: Setting ``alpha`` on a sampler that already holds priorities
           (e.g. when annealing it with a
           :class:`~torchrl.data.replay_buffers.scheduler.ParameterScheduler`)
-          does not re-transform the ``(p + eps) ** alpha`` values already
-          written to the sum/min trees: old and new exponents mix until every
-          entry's priority is updated again.
+          re-transforms the ``(p + eps) ** alpha`` values stored in the
+          sum/min trees to the new exponent in a single O(capacity) pass, so
+          sampling probabilities stay consistent with the new value. The one
+          exception is changing ``alpha`` away from exactly ``0``: the raw
+          priorities cannot be recovered from the trees in that regime, so the
+          stored (uniform) values are kept -- and a warning is emitted --
+          until each entry's priority is next updated.
         """
         return self._alpha
 
@@ -1114,23 +1122,10 @@ class PrioritizedSampler(Sampler):
             raise ValueError(
                 f"alpha must be greater or equal than 0, got alpha={value}"
             )
-        if (
-            value != self._alpha
-            and self._max_priority_within_buffer
-            and not self._warned_alpha_change
-            and self._max_priority[0] is not None
-        ):
-            self._warned_alpha_change = True
-            warnings.warn(
-                "Changing alpha on a PrioritizedSampler with "
-                "max_priority_within_buffer=True does not re-transform the "
-                "(p + eps) ** alpha values already stored in the sum/min trees, "
-                "and the max-priority recomputation inverts tree values with the "
-                "new alpha. Large changes to alpha can corrupt the tracked max "
-                "priority until the corresponding entries are updated again. "
-                "This warning is emitted once per sampler."
-            )
+        old_alpha = self._alpha
         self._alpha = value
+        if value != old_alpha:
+            self._retransform_priority_trees(old_alpha, value)
 
     @property
     def beta(self):
@@ -1277,6 +1272,71 @@ class PrioritizedSampler(Sampler):
             is_overwritten = bool(is_overwritten.item())
         if is_overwritten:
             self._max_priority = None
+
+    def _tree_argmax(self) -> tuple[torch.Tensor, torch.Tensor]:
+        device = self.device
+        indices = torch.arange(self._max_capacity, dtype=torch.long, device=device)
+        values = torch.as_tensor(self._sum_tree[indices], device=device)
+        return values.max(0)
+
+    def _retransform_priority_trees(self, old_alpha: float, new_alpha: float) -> None:
+        """Rewrites the tree entries from ``(p + eps) ** old_alpha`` to ``(p + eps) ** new_alpha``.
+
+        A single O(capacity) pass keeps the sampling probabilities (and the
+        within-buffer max-priority recomputation, which inverts tree values
+        with the current ``alpha``) consistent when ``alpha`` changes, e.g.
+        when annealed by a
+        :class:`~torchrl.data.replay_buffers.scheduler.ParameterScheduler`.
+        ``_max_priority`` is tracked in the raw domain and needs no update.
+        """
+        device = self.device
+        indices = torch.arange(self._max_capacity, dtype=torch.long, device=device)
+        values = torch.as_tensor(self._sum_tree[indices], device=device)
+        # Entries that were never written hold the sum-tree neutral value 0
+        # and must stay 0; written entries hold (p + eps) ** alpha > 0.
+        written = values > 0
+        if not written.any():
+            return
+        if old_alpha == 0:
+            # With alpha == 0 every written entry is 1.0, so the raw
+            # priorities cannot be recovered from the trees. Keep the stored
+            # (uniform) values; they are corrected as entries get their
+            # priority updated.
+            warnings.warn(
+                "Changing alpha away from 0 on a PrioritizedSampler that "
+                "already holds priorities cannot recover the raw priorities "
+                "from the sum/min trees (alpha == 0 stores 1.0 for every "
+                "written entry). Sampling stays uniform for those entries "
+                "until their priority is next updated, so annealing away "
+                "from exactly 0 is approximate."
+            )
+            return
+        indices = indices[written]
+        raw = (values[written].double() ** (1.0 / old_alpha) - self._eps).clamp_min(0)
+        new_values = ((raw + self._eps) ** new_alpha).to(self.dtype)
+        self._sum_tree[indices] = new_values
+        self._min_tree[indices] = new_values
+
+    def _recompute_max_priority_from_tree(self) -> None:
+        """Recomputes the raw ``_max_priority`` from the sum-tree entries.
+
+        The sum-tree stores ``(p + eps) ** alpha`` while the tracked max
+        priority lives in the raw domain, so the tree max is inverted before
+        being stored. Used when restoring a checkpoint saved before the
+        raw-domain convention (pytorch/rl#3925), whose persisted
+        ``_max_priority`` may hold a transformed tree value.
+        """
+        if self._alpha == 0:
+            # (p + eps) ** 0 == 1 for every written entry: the raw max cannot
+            # be recovered from the tree. Keep the restored value.
+            return
+        maxval, maxidx = self._tree_argmax()
+        if maxval <= 0:
+            # nothing was ever written to the trees
+            self._max_priority = None
+            return
+        maxval = (maxval ** (1.0 / self._alpha) - self._eps).clamp_min(0)
+        self._max_priority = (maxval, maxidx)
 
     @property
     def default_priority(self) -> float | torch.Tensor:
@@ -1487,14 +1547,9 @@ class PrioritizedSampler(Sampler):
                 # is raised later (see the ``alpha`` setter).
                 return
             if tree_device.type == "cuda":
-                all_indices = torch.arange(
-                    self._max_capacity, dtype=torch.long, device=tree_device
-                )
-                maxval, maxidx = self._sum_tree[all_indices].max(0)
+                maxval, maxidx = self._tree_argmax()
             elif (index == cur_max_priority_index).any():
-                maxval, maxidx = torch.tensor(
-                    [self._sum_tree[i] for i in range(self._max_capacity)]
-                ).max(0)
+                maxval, maxidx = self._tree_argmax()
             else:
                 return
             # ``maxval`` is read from the sum-tree, which stores (p + eps) ** alpha.
@@ -1511,6 +1566,7 @@ class PrioritizedSampler(Sampler):
 
     def state_dict(self) -> dict[str, Any]:
         return {
+            "_schema_version": self._STATE_SCHEMA_VERSION,
             "_alpha": self._alpha,
             "_beta": self._beta,
             "_eps": self._eps,
@@ -1520,6 +1576,9 @@ class PrioritizedSampler(Sampler):
         }
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        # Version-less payloads predate pytorch/rl#3925, whose within-buffer
+        # recompute stored the transformed tree value in _max_priority.
+        version = state_dict.get("_schema_version", 0)
         self._alpha = state_dict["_alpha"]
         self._beta = state_dict["_beta"]
         self._eps = state_dict["_eps"]
@@ -1528,6 +1587,12 @@ class PrioritizedSampler(Sampler):
         self._max_priority = deepcopy(state_dict["_max_priority"])
         self._sum_tree = deepcopy(state_dict["_sum_tree"])
         self._min_tree = deepcopy(state_dict["_min_tree"])
+        if (
+            version < 1
+            and self._max_priority_within_buffer
+            and self._max_priority[0] is not None
+        ):
+            self._recompute_max_priority_from_tree()
 
     @implement_for("torch", None, "2.5.0")
     def dumps(self, path):
@@ -1565,20 +1630,19 @@ class PrioritizedSampler(Sampler):
         mm_mt.copy_(
             torch.as_tensor([self._min_tree[i] for i in range(self._max_capacity)])
         )
+        metadata = tree_map(
+            float,
+            {
+                "_alpha": self._alpha,
+                "_beta": self._beta,
+                "_eps": self._eps,
+                "_max_priority": self._max_priority,
+                "_max_capacity": self._max_capacity,
+            },
+        )
+        metadata["_schema_version"] = self._STATE_SCHEMA_VERSION
         with open(path / "sampler_metadata.json", "w") as file:
-            json.dump(
-                tree_map(
-                    float,
-                    {
-                        "_alpha": self._alpha,
-                        "_beta": self._beta,
-                        "_eps": self._eps,
-                        "_max_priority": self._max_priority,
-                        "_max_capacity": self._max_capacity,
-                    },
-                ),
-                file,
-            )
+            json.dump(metadata, file)
 
     @implement_for("torch", None, "2.5.0")
     def loads(self, path):
@@ -1589,6 +1653,9 @@ class PrioritizedSampler(Sampler):
         path = Path(path).absolute()
         with open(path / "sampler_metadata.json") as file:
             metadata = json.load(file)
+        # Version-less payloads predate pytorch/rl#3925, whose within-buffer
+        # recompute stored the transformed tree value in _max_priority.
+        version = metadata.get("_schema_version", 0)
         self._alpha = metadata["_alpha"]
         self._beta = metadata["_beta"]
         self._eps = metadata["_eps"]
@@ -1618,6 +1685,12 @@ class PrioritizedSampler(Sampler):
             self._sum_tree[i] = elt
         for i, elt in enumerate(mm_mt.tolist()):
             self._min_tree[i] = elt
+        if (
+            version < 1
+            and self._max_priority_within_buffer
+            and self._max_priority[0] is not None
+        ):
+            self._recompute_max_priority_from_tree()
 
 
 class SliceSampler(Sampler):


### PR DESCRIPTION
## Description

Two follow-ups to #3925, which moved `PrioritizedSampler._max_priority` to the raw priority domain and made `update_priority` the single place the `(p + eps) ** alpha` transform is applied.

### 1. Re-transform the sum/min trees when `alpha` changes

`LinearScheduler`/`StepScheduler` anneal `sampler.alpha` as a shipped feature, but tree entries written under the old alpha kept their old exponent until each entry was next updated, and the `max_priority_within_buffer` recompute inverted old-alpha tree values with the new alpha (hence the once-per-sampler warning in the setter).

Since `_max_priority` is now raw, the fix is closed-form: on `alpha` change the setter rewrites each written tree entry as

```python
new_val = ((old_val ** (1 / old_alpha) - eps).clamp_min(0) + eps) ** new_alpha
```

in a single O(capacity) vectorized pass; `_max_priority` needs no touching and the setter warning is deleted. Alpha annealing is now exact, including in within-buffer mode.

The one exception is annealing away from exactly `alpha == 0`: every written entry is `1.0` in that regime, so the raw priorities cannot be recovered from the trees. The setter warns and keeps the stored (uniform) values until entries are next updated.

### 2. Checkpoint compatibility for pre-#3925 within-buffer checkpoints

`state_dict`/`dumps` persisted `_max_priority` verbatim with no version marker. A checkpoint saved before #3925 with `max_priority_within_buffer=True` after a recompute holds the transformed tree value in `_max_priority[0]`; restored under post-#3925 code it would be treated as raw and transformed again -- a one-shot recurrence of the double-alpha bug that persists until the max entry is next updated or overwritten.

`state_dict()` and the `dumps` metadata now embed a `_schema_version` key. On `load_state_dict`/`loads`, version-less payloads in within-buffer mode get their raw max recomputed from the restored sum-tree via the inverse transform, so both old and new checkpoints restore correctly. Version-tagged payloads are trusted verbatim.

## Tests

- `test_prb_alpha_change_retransforms_trees`: tree values match `(p + eps) ** new_alpha` after a setter call, unwritten slots stay at the neutral value, the raw max is preserved, and the within-buffer recompute inverts consistently after the change.
- `test_prb_alpha_change_from_zero_warns`: annealing away from 0 warns, keeps uniform values, and corrects entries on their next priority update; empty samplers stay silent.
- `test_prb_alpha_setter_validates`: negative values rejected; annealing is warning-free.
- `test_prb_load_legacy_within_buffer_state_dict` / `test_prb_loads_legacy_within_buffer_metadata`: version-less payloads carrying a transformed `_max_priority` are recomputed to the raw max on load, for both the `state_dict` and `dumps`/`loads` paths; version-tagged payloads round-trip verbatim.

Generated with [Claude Code](https://claude.com/claude-code)
