### PR TITLE
[CI] Stabilize PR benchmark confirmations

### DIFF
--- a/.github/scripts/comment_pr_benchmarks.py
+++ b/.github/scripts/comment_pr_benchmarks.py
@@ -23,12 +23,15 @@ def _benchmark_name(benchmark: dict) -> str:
 
 def _benchmark_ops(benchmark: dict) -> float | None:
     stats = benchmark.get("stats", {})
-    ops = stats.get("ops")
-    if ops is not None:
-        return float(ops)
+    median = stats.get("median")
+    if median:
+        return 1.0 / float(median)
     mean = stats.get("mean")
     if mean:
         return 1.0 / float(mean)
+    ops = stats.get("ops")
+    if ops is not None:
+        return float(ops)
     return None
 
 
@@ -103,7 +106,7 @@ def _comparison_rows(result: dict) -> list[dict]:
 def _table(rows: list[dict], max_rows: int) -> list[str]:
     selected = sorted(rows, key=lambda row: abs(row["change"]), reverse=True)[:max_rows]
     lines = [
-        "| Benchmark | main ops | PR ops | Change | Measurement |",
+        "| Benchmark | main median ops | PR median ops | Change | Measurement |",
         "| --- | ---: | ---: | ---: | --- |",
     ]
     for row in selected:
@@ -113,7 +116,7 @@ def _table(rows: list[dict], max_rows: int) -> list[str]:
                 _format_number(row["baseline_ops"]),
                 _format_number(row["contender_ops"]),
                 _format_percent(row["change"]),
-                "same runner" if row["confirmed"] else "parallel",
+                "balanced same runner" if row["confirmed"] else "parallel",
             )
         )
     if len(rows) > max_rows:
@@ -138,7 +141,7 @@ def _device_section(result: dict, max_rows: int) -> list[str]:
         f"Compared {len(rows)} benchmarks. Regressions over "
         f"{reporting_threshold:g}%: {regressions}. Improvements over "
         f"{reporting_threshold:g}%: {improvements}.",
-        f"Sequential same-runner confirmations: {confirmations}.",
+        f"Balanced same-runner confirmations: {confirmations}.",
         "",
     ]
     lines.extend(_table(rows, max_rows))
@@ -164,7 +167,8 @@ def build_comment(results: list[dict], run_url: str) -> tuple[int, str]:
             "",
             f"Benchmark run: {run_url}",
             "",
-            "Higher ops/sec is better. Tables are sorted by largest absolute change.",
+            "Higher median ops/sec is better. Tables are sorted by largest "
+            "absolute change.",
             "",
         ]
         for result in sorted(results, key=lambda item: item["metadata"]["device"]):

--- a/.github/scripts/compare_pr_benchmarks.py
+++ b/.github/scripts/compare_pr_benchmarks.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import math
+import statistics
 from pathlib import Path
 
 
@@ -44,15 +46,23 @@ def _benchmark_name(benchmark: dict) -> str:
     return benchmark.get("fullname") or benchmark.get("name") or "<unknown>"
 
 
-def _benchmark_ops(benchmark: dict) -> float | None:
+def _benchmark_duration(benchmark: dict) -> float | None:
     stats = benchmark.get("stats", {})
-    ops = stats.get("ops")
-    if ops is not None:
-        return float(ops)
+    median = stats.get("median")
+    if median:
+        return float(median)
     mean = stats.get("mean")
     if mean:
-        return 1.0 / float(mean)
+        return float(mean)
+    ops = stats.get("ops")
+    if ops:
+        return 1.0 / float(ops)
     return None
+
+
+def _benchmark_ops(benchmark: dict) -> float | None:
+    duration = _benchmark_duration(benchmark)
+    return None if duration is None else 1.0 / duration
 
 
 def _benchmark_map(document: dict) -> dict[str, dict]:
@@ -85,11 +95,80 @@ def comparison_rows(baseline: dict, contender: dict) -> list[dict]:
 def needs_confirmation(
     change: float, reporting_threshold: float, threshold_margin: float
 ) -> bool:
-    significant_regression = change <= -reporting_threshold
+    significant_change = abs(change) >= reporting_threshold
     near_reporting_threshold = (
         abs(abs(change) - reporting_threshold) <= threshold_margin
     )
-    return significant_regression or near_reporting_threshold
+    return significant_change or near_reporting_threshold
+
+
+def aggregate_benchmark_documents(documents: list[dict]) -> dict:
+    if not documents:
+        raise ValueError("At least one benchmark document is required.")
+
+    benchmark_maps = [_benchmark_map(document) for document in documents]
+    expected_names = set(benchmark_maps[0])
+    for index, benchmarks in enumerate(benchmark_maps[1:], start=2):
+        names = set(benchmarks)
+        if names != expected_names:
+            missing = sorted(expected_names - names)
+            unexpected = sorted(names - expected_names)
+            raise RuntimeError(
+                f"Confirmation repetition {index} has different benchmarks. "
+                f"Missing: {missing}; unexpected: {unexpected}."
+            )
+
+    result = copy.deepcopy(documents[0])
+    aggregated_benchmarks = []
+    for first_benchmark in documents[0].get("benchmarks", []):
+        name = _benchmark_name(first_benchmark)
+        durations = [
+            _benchmark_duration(benchmarks[name]) for benchmarks in benchmark_maps
+        ]
+        if any(duration is None for duration in durations):
+            raise RuntimeError(f"Confirmation repetitions lack timing data for {name}.")
+        durations = [float(duration) for duration in durations]
+        duration = statistics.median(durations)
+        if len(durations) == 1:
+            q1 = q3 = duration
+            stddev = 0.0
+        else:
+            q1, _, q3 = statistics.quantiles(durations, n=4, method="inclusive")
+            stddev = statistics.stdev(durations)
+
+        benchmark = copy.deepcopy(first_benchmark)
+        total_measurement_rounds = sum(
+            int(benchmarks[name].get("stats", {}).get("rounds", 0))
+            for benchmarks in benchmark_maps
+        )
+        benchmark["stats"] = {
+            "data": durations,
+            "iqr": q3 - q1,
+            "max": max(durations),
+            "mean": statistics.fmean(durations),
+            "median": duration,
+            "min": min(durations),
+            "ops": 1.0 / duration,
+            "q1": q1,
+            "q3": q3,
+            "rounds": len(durations),
+            "stddev": stddev,
+            "total": sum(durations),
+        }
+        extra_info = dict(benchmark.get("extra_info", {}))
+        extra_info.update(
+            {
+                "confirmation_repetitions": len(durations),
+                "confirmation_run_medians": durations,
+                "confirmation_total_measurement_rounds": total_measurement_rounds,
+            }
+        )
+        benchmark["extra_info"] = extra_info
+        aggregated_benchmarks.append(benchmark)
+
+    result["benchmarks"] = aggregated_benchmarks
+    result["confirmation_repetitions"] = len(documents)
+    return result
 
 
 def _device_directories(raw_root: Path) -> list[Path]:
@@ -170,6 +249,8 @@ def create_confirmation_plan(
             if needs_confirmation(row["change"], reporting_threshold, threshold_margin)
         ]
         plan = {
+            "comparison_statistic": "median duration",
+            "confirmation_repetitions_per_revision": 2,
             "device": device,
             "image": image_by_device[device],
             "reporting_threshold_pct": reporting_threshold,
@@ -231,14 +312,16 @@ def _summary_section(
         f"Compared {len(rows)} benchmarks: {regressions} regressions and "
         f"{improvements} improvements at the {reporting_threshold:g}% threshold. "
         f"Replaced {len(confirmed_names)} parallel measurements with sequential "
-        "same-runner confirmations.",
+        "balanced same-runner confirmations.",
         "",
-        "| Benchmark | Baseline ops | PR ops | Change | Measurement |",
+        "| Benchmark | Baseline median ops | PR median ops | Change | Measurement |",
         "| --- | ---: | ---: | ---: | --- |",
     ]
     selected = sorted(rows, key=lambda row: abs(row["change"]), reverse=True)[:50]
     for row in selected:
-        measurement = "same runner" if row["name"] in confirmed_names else "parallel"
+        measurement = (
+            "balanced same runner" if row["name"] in confirmed_names else "parallel"
+        )
         lines.append(
             f"| `{row['name']}` | {_format_number(row['baseline_ops'])} | "
             f"{_format_number(row['contender_ops'])} | {row['change']:+.2f}% | "
@@ -290,9 +373,16 @@ def finalize_results(
         metadata.update(
             {
                 "confirmed_benchmarks": sorted(confirmed_names),
+                "comparison_statistic": "median duration",
                 "reporting_threshold_pct": plan["reporting_threshold_pct"],
                 "threshold_margin_pct": plan["threshold_margin_pct"],
-                "confirmation_order": ["baseline", "contender"],
+                "confirmation_order": [
+                    "baseline-1",
+                    "contender-1",
+                    "contender-2",
+                    "baseline-2",
+                ],
+                "confirmation_repetitions_per_revision": 2,
             }
         )
         _write_json(output_dir / "baseline.json", baseline)
@@ -341,6 +431,10 @@ def main() -> None:
     finalize_parser.add_argument("--output-root", required=True, type=Path)
     finalize_parser.add_argument("--summary", required=True, type=Path)
 
+    aggregate_parser = subparsers.add_parser("aggregate")
+    aggregate_parser.add_argument("--output", required=True, type=Path)
+    aggregate_parser.add_argument("inputs", nargs="+", type=Path)
+
     args = parser.parse_args()
     if args.command == "plan":
         create_confirmation_plan(
@@ -351,7 +445,7 @@ def main() -> None:
             reporting_threshold=args.reporting_threshold,
             threshold_margin=args.threshold_margin,
         )
-    else:
+    elif args.command == "finalize":
         finalize_results(
             raw_root=args.raw_root,
             plan_root=args.plan_root,
@@ -359,6 +453,9 @@ def main() -> None:
             output_root=args.output_root,
             summary_path=args.summary,
         )
+    else:
+        documents = [_load_json(path) for path in args.inputs]
+        _write_json(args.output, aggregate_benchmark_documents(documents))
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_pr_benchmark_workflow.py
+++ b/.github/scripts/test_pr_benchmark_workflow.py
@@ -55,6 +55,24 @@ def _metadata(device: str, revision: str) -> dict:
     }
 
 
+def test_workflow_uses_balanced_confirmation_order():
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "benchmarks_pr.yml").read_text(
+        encoding="utf-8"
+    )
+    expected_order = [
+        'run_revision "${PR_BASE_SHA}" baseline 1',
+        'run_revision "${PR_HEAD_SHA}" contender 1',
+        'run_revision "${PR_HEAD_SHA}" contender 2',
+        'run_revision "${PR_BASE_SHA}" baseline 2',
+    ]
+
+    positions = [workflow.index(command) for command in expected_order]
+
+    assert positions == sorted(positions)
+    assert "--benchmark-min-rounds 10" in workflow
+    assert workflow.count("compare_pr_benchmarks.py aggregate") == 2
+
+
 def _write_raw_pair(root: Path) -> None:
     device_root = root / "CPU"
     device_root.mkdir(parents=True)
@@ -90,10 +108,95 @@ def _write_raw_pair(root: Path) -> None:
 
 @pytest.mark.parametrize(
     ("change", "expected"),
-    [(-20.0, True), (-8.0, True), (-4.0, True), (4.0, True), (8.0, False)],
+    [
+        (-20.0, True),
+        (-8.0, True),
+        (-4.0, True),
+        (2.0, False),
+        (4.0, True),
+        (8.0, True),
+        (20.0, True),
+    ],
 )
 def test_confirmation_selection(change, expected):
     assert comparison.needs_confirmation(change, 5.0, 2.0) is expected
+
+
+def test_comparison_prefers_median_duration_to_mean_ops():
+    baseline = {
+        "benchmarks": [
+            {
+                "fullname": "test_bench.py::test_noisy",
+                "stats": {"median": 1.0, "ops": 0.1},
+            }
+        ]
+    }
+    contender = {
+        "benchmarks": [
+            {
+                "fullname": "test_bench.py::test_noisy",
+                "stats": {"median": 2.0, "ops": 0.1},
+            }
+        ]
+    }
+
+    [row] = comparison.comparison_rows(baseline, contender)
+
+    assert row["baseline_ops"] == pytest.approx(1.0)
+    assert row["contender_ops"] == pytest.approx(0.5)
+    assert row["change"] == pytest.approx(-50.0)
+
+
+def test_comment_prefers_median_duration_to_mean_ops():
+    result = {
+        "metadata": {"confirmed_benchmarks": []},
+        "baseline": {
+            "benchmarks": [
+                {"fullname": "test_noisy", "stats": {"median": 1.0, "ops": 0.1}}
+            ]
+        },
+        "contender": {
+            "benchmarks": [
+                {"fullname": "test_noisy", "stats": {"median": 2.0, "ops": 0.1}}
+            ]
+        },
+    }
+
+    [row] = comments._comparison_rows(result)
+
+    assert row["change"] == pytest.approx(-50.0)
+
+
+def test_aggregate_uses_equal_weight_per_confirmation_repetition():
+    documents = [
+        {
+            "benchmarks": [
+                {
+                    "fullname": "test_bench.py::test_noisy",
+                    "extra_info": {},
+                    "stats": {"median": duration, "rounds": rounds},
+                }
+            ]
+        }
+        for duration, rounds in ((1.0, 100), (3.0, 10))
+    ]
+
+    result = comparison.aggregate_benchmark_documents(documents)
+    [benchmark] = result["benchmarks"]
+
+    assert benchmark["stats"]["median"] == pytest.approx(2.0)
+    assert benchmark["stats"]["ops"] == pytest.approx(0.5)
+    assert benchmark["stats"]["data"] == [1.0, 3.0]
+    assert benchmark["stats"]["rounds"] == 2
+    assert benchmark["extra_info"]["confirmation_repetitions"] == 2
+    assert benchmark["extra_info"]["confirmation_total_measurement_rounds"] == 110
+
+
+def test_aggregate_rejects_different_benchmark_sets():
+    with pytest.raises(RuntimeError, match="different benchmarks"):
+        comparison.aggregate_benchmark_documents(
+            [_document({"test_a": 1.0}), _document({"test_b": 1.0})]
+        )
 
 
 def test_plan_and_finalize_replace_only_confirmed_results(tmp_path):
@@ -116,6 +219,7 @@ def test_plan_and_finalize_replace_only_confirmed_results(tmp_path):
     assert set(plan["nodeids"]) == {
         "test_bench.py::test_regression",
         "test_bench.py::test_near_threshold",
+        "test_bench.py::test_clear_improvement",
     }
     assert set(plan["pytest_nodeids"]) == set(plan["nodeids"])
 
@@ -127,6 +231,7 @@ def test_plan_and_finalize_replace_only_confirmed_results(tmp_path):
                 {
                     "test_bench.py::test_regression": 100.0,
                     "test_bench.py::test_near_threshold": 100.0,
+                    "test_bench.py::test_clear_improvement": 100.0,
                 }
             )
         ),
@@ -138,6 +243,7 @@ def test_plan_and_finalize_replace_only_confirmed_results(tmp_path):
                 {
                     "test_bench.py::test_regression": 98.0,
                     "test_bench.py::test_near_threshold": 106.0,
+                    "test_bench.py::test_clear_improvement": 102.0,
                 }
             )
         ),
@@ -157,12 +263,12 @@ def test_plan_and_finalize_replace_only_confirmed_results(tmp_path):
     rows = {row["name"]: row for row in result["benchmarks"]}
     assert rows["test_bench.py::test_regression"]["change"] == pytest.approx(-2.0)
     assert rows["test_bench.py::test_near_threshold"]["change"] == pytest.approx(6.0)
-    assert rows["test_bench.py::test_clear_improvement"]["change"] == pytest.approx(8.0)
+    assert rows["test_bench.py::test_clear_improvement"]["change"] == pytest.approx(2.0)
     assert rows["test_bench.py::test_regression"]["measurement"] == (
         "same-runner-confirmation"
     )
     assert rows["test_bench.py::test_clear_improvement"]["measurement"] == (
-        "parallel-runners"
+        "same-runner-confirmation"
     )
 
     final_metadata = json.loads(
@@ -182,8 +288,8 @@ def test_plan_and_finalize_replace_only_confirmed_results(tmp_path):
         ],
         "https://example.com/run",
     )
-    assert "Sequential same-runner confirmations: 2." in body
-    assert "same runner" in body
+    assert "Balanced same-runner confirmations: 3." in body
+    assert "balanced same runner" in body
 
 
 def test_plan_uses_nodeids_relative_to_benchmark_working_directory(tmp_path):

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -1,8 +1,9 @@
 name: Continuous Benchmark (PR)
 # Opt-in only: add the "benchmarks/upload" label to run the comparison. The
 # baseline and PR legs run concurrently on separate runners. Measurements that
-# could change the 5% report are repeated sequentially on one runner. Both legs
-# use the benchmark definitions archived from the PR base SHA.
+# could change the 5% report are repeated twice in balanced order on one runner
+# and compared using median duration. Both legs use benchmark definitions
+# archived from the PR base SHA.
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
@@ -471,7 +472,7 @@ jobs:
         with:
           name: benchmark-confirmation-plan
           path: confirmation-plan
-      - name: Run baseline then PR on the same runner
+      - name: Run balanced baseline and PR repetitions on the same runner
         run: |
           set -euxo pipefail
           source .benchmark-venv/bin/activate
@@ -480,7 +481,10 @@ jobs:
           else
             export CUDA_VISIBLE_DEVICES=0
           fi
-          mkdir -p .benchmark-site "confirmation-result/${TORCHRL_BENCHMARK_DEVICE}"
+          mkdir -p \
+            .benchmark-site \
+            "confirmation-result/${TORCHRL_BENCHMARK_DEVICE}" \
+            "confirmation-result/repetitions/${TORCHRL_BENCHMARK_DEVICE}"
           cat > .benchmark-site/sitecustomize.py <<'PY'
           import warnings
 
@@ -503,6 +507,7 @@ jobs:
           run_revision() {
             local sha="$1"
             local revision="$2"
+            local repetition="$3"
             git -C source checkout --detach "${sha}"
             git -C source clean -ffdx
             rm -rf source/build
@@ -513,16 +518,28 @@ jobs:
               python -c "import torch; assert torch.cuda.device_count()"
               python -c "import torchrl._torchrl as ext; assert hasattr(ext, 'CudaSumSegmentTreeFp32')"
             fi
-            local result_json="${GITHUB_WORKSPACE}/confirmation-result/${TORCHRL_BENCHMARK_DEVICE}/${revision}.json"
+            local result_json="${GITHUB_WORKSPACE}/confirmation-result/repetitions/${TORCHRL_BENCHMARK_DEVICE}/${revision}-${repetition}.json"
             (
               cd benchmark-definitions/benchmarks
               python -m pytest -vvv --rank 0 --timeout=240 --benchmark-only \
+                --benchmark-min-rounds 10 \
                 --benchmark-json "${result_json}" "${NODEIDS[@]}"
             )
           }
 
-          run_revision "${PR_BASE_SHA}" baseline
-          run_revision "${PR_HEAD_SHA}" contender
+          run_revision "${PR_BASE_SHA}" baseline 1
+          run_revision "${PR_HEAD_SHA}" contender 1
+          run_revision "${PR_HEAD_SHA}" contender 2
+          run_revision "${PR_BASE_SHA}" baseline 2
+
+          python .github/scripts/compare_pr_benchmarks.py aggregate \
+            --output "confirmation-result/${TORCHRL_BENCHMARK_DEVICE}/baseline.json" \
+            "confirmation-result/repetitions/${TORCHRL_BENCHMARK_DEVICE}/baseline-1.json" \
+            "confirmation-result/repetitions/${TORCHRL_BENCHMARK_DEVICE}/baseline-2.json"
+          python .github/scripts/compare_pr_benchmarks.py aggregate \
+            --output "confirmation-result/${TORCHRL_BENCHMARK_DEVICE}/contender.json" \
+            "confirmation-result/repetitions/${TORCHRL_BENCHMARK_DEVICE}/contender-1.json" \
+            "confirmation-result/repetitions/${TORCHRL_BENCHMARK_DEVICE}/contender-2.json"
       - name: Upload same-runner confirmation JSON
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
## Summary

- compare benchmark median duration instead of mean-based throughput
- confirm significant improvements as well as regressions and near-threshold changes
- repeat selected baseline and PR benchmarks in balanced baseline/PR/PR/baseline order
- aggregate repetitions with equal weight and retain the per-run JSON measurements
- require at least 10 rounds for non-pedantic confirmation benchmarks

## Root cause

Follow-up analysis of #4010 showed three sources of false signal:

1. The confirmation planner selected significant regressions and changes near 5%, but omitted improvements above the threshold window. In the completed run, 9 CPU and 16 GPU large improvements therefore remained comparisons between different runners.
2. The comparator preferred pytest-benchmark's mean-based `ops` value. Rare stalls could dominate that value: one CPU replay-buffer result reported +279% by mean but was about +1% by median; two GPU outliers reported +32.5% and +31.1% by mean but were -2.6% and -0.3% by median.
3. A single fixed baseline-then-PR confirmation did not balance cold-start effects or temporal drift on the runner.

The follow-up uses the median for outlier resistance, sends every change that can cross the reporting threshold through confirmation, and balances two repetitions per revision in ABBA order before taking the median of the per-run medians.

## Impact

The opt-in workflow spends more time only when a comparison needs confirmation. Final reports should contain fewer false improvements and regressions, while the uploaded repetition JSON makes remaining variability diagnosable.

## Validation

- `uvx --from pytest pytest -q .github/scripts/test_pr_benchmark_workflow.py` (15 passed)
- `actionlint -ignore 'label .* is unknown' .github/workflows/benchmarks_pr.yml`
- `pre-commit run --files .github/workflows/benchmarks_pr.yml .github/scripts/compare_pr_benchmarks.py .github/scripts/comment_pr_benchmarks.py .github/scripts/test_pr_benchmark_workflow.py`
- replayed confirmation planning and aggregation against the JSON artifacts from run 29431181113
