### PR TITLE
[Feature] Re-enable prefix caching for GRPO online weight updates

### DIFF
--- a/sota-implementations/grpo/config/grpo_countdown.yaml
+++ b/sota-implementations/grpo/config/grpo_countdown.yaml
@@ -61,7 +61,7 @@ inference_model:
   max_tokens: 512
   include_stop_str_in_output: true
   enforce_eager: false
-  enable_prefix_caching: false
+  enable_prefix_caching: true  # safe with online updates: caches are reset on weight sync
 
 ref_model:
   gradient_checkpointing: false

--- a/sota-implementations/grpo/config/grpo_gsm8k.yaml
+++ b/sota-implementations/grpo/config/grpo_gsm8k.yaml
@@ -104,7 +104,7 @@ inference_model:
   max_tokens: 1024
   include_stop_str_in_output: true
   enforce_eager: false
-  enable_prefix_caching: false
+  enable_prefix_caching: true  # safe with online updates: caches are reset on weight sync
   # compile: false  # Whether to enable model compilation (disabled by default for GRPO)
   # verbose: true   # Whether to show vLLM throughput statistics (enabled by default)
 

--- a/sota-implementations/grpo/config/grpo_ifeval.yaml
+++ b/sota-implementations/grpo/config/grpo_ifeval.yaml
@@ -103,7 +103,7 @@ inference_model:
   max_tokens: 2048
   include_stop_str_in_output: true
   enforce_eager: false
-  enable_prefix_caching: false
+  enable_prefix_caching: true  # safe with online updates: caches are reset on weight sync
   # compile: false  # Whether to enable model compilation (disabled by default for GRPO)
   # verbose: true   # Whether to show vLLM throughput statistics (enabled by default)
 

--- a/sota-implementations/grpo/config/grpo_math.yaml
+++ b/sota-implementations/grpo/config/grpo_math.yaml
@@ -63,7 +63,7 @@ inference_model:
   max_tokens: 2048
   include_stop_str_in_output: true
   enforce_eager: false
-  enable_prefix_caching: false
+  enable_prefix_caching: true  # safe with online updates: caches are reset on weight sync
   max_model_len: 4096
 
 ref_model:

--- a/sota-implementations/grpo/config/grpo_math_7b.yaml
+++ b/sota-implementations/grpo/config/grpo_math_7b.yaml
@@ -63,7 +63,7 @@ inference_model:
   max_tokens: 2048
   include_stop_str_in_output: true
   enforce_eager: false
-  enable_prefix_caching: false
+  enable_prefix_caching: true  # safe with online updates: caches are reset on weight sync
 
 ref_model:
   gradient_checkpointing: false

--- a/sota-implementations/grpo/config/grpo_math_7b_sync.yaml
+++ b/sota-implementations/grpo/config/grpo_math_7b_sync.yaml
@@ -62,7 +62,7 @@ inference_model:
   max_tokens: 2048
   include_stop_str_in_output: true
   enforce_eager: false
-  enable_prefix_caching: false
+  enable_prefix_caching: true  # safe with online updates: caches are reset on weight sync
 
 ref_model:
   gradient_checkpointing: false

--- a/sota-implementations/grpo/grpo_utils.py
+++ b/sota-implementations/grpo/grpo_utils.py
@@ -404,6 +404,18 @@ def _get_sglang_inference_model(
         inference_params[
             "disable_radix_cache"
         ] = not cfg.inference_model.enable_prefix_caching
+    if not inference_params.get("disable_radix_cache", False):
+        # SGLang can only flush the radix cache on weight sync when generation
+        # is paused with the 'abort' mode (the scheduler must be idle); under
+        # the default 'retract' mode stale prefixes survive weight updates.
+        warnings.warn(
+            "The SGLang radix cache is enabled. To keep cached prefixes "
+            "consistent with online weight updates, set "
+            "TORCHRL_SGLANG_PAUSE_GENERATION_MODE=abort (in-flight requests "
+            "are cancelled at each sync) or disable the radix cache with "
+            "inference_model.enable_prefix_caching=false.",
+            stacklevel=2,
+        )
 
     # Pin SGLang server to allocated GPUs via CUDA_VISIBLE_DEVICES
     if sglang_devices is not None:

--- a/test/llm/test_llm_objectives.py
+++ b/test/llm/test_llm_objectives.py
@@ -136,6 +136,40 @@ class TestMCAdvantage:
         for chunk, exp in zip(out["advantage"].squeeze(-1).split([2, 3, 2]), expected):
             torch.testing.assert_close(chunk, exp.expand_as(chunk))
 
+    def test_mc_advantage_string_prompt_survives_contiguous(self):
+        # String prompts are stored as NonTensorData in lazy-stacked
+        # trajectories. TensorDict.contiguous() can silently turn those stacks
+        # into empty TensorDicts, so the group id must be read from the lazy
+        # input rather than the materialized trajectory (regression test).
+        from tensordict import NonTensorData
+
+        def traj(prompt, reward, n_steps=2, n_tokens=4):
+            # tokens are uniform within a trajectory (contiguous() succeeds on
+            # the single trajectory) but ragged across trajectories, like real
+            # variable-length generations
+            steps = [
+                TensorDict(
+                    {
+                        "query": NonTensorData(prompt),
+                        "tokens": torch.zeros(n_tokens, dtype=torch.long),
+                        ("next", "reward"): torch.tensor([reward]),
+                        ("next", "done"): torch.tensor([i == n_steps - 1]),
+                    }
+                )
+                for i in range(n_steps)
+            ]
+            return lazy_stack(steps)
+
+        adv_t = MCAdvantage(grpo_size=2, prompt_key="query")
+        # uniform tensor shapes within a trajectory: contiguous() succeeds
+        assert traj("p", 0.0).contiguous() is not None
+        assert adv_t.inv(traj("prompt-a", 0.0, n_steps=2, n_tokens=4)) is None
+        out = adv_t.inv(traj("prompt-a", 1.0, n_steps=3, n_tokens=6))
+        assert out is not None
+        assert "advantage" in out.keys()
+        # the stored trajectories keep their prompt strings intact
+        assert out[0]["query"] in ("prompt-a",)
+
     @pytest.mark.parametrize("group_key", ["group_id", ("meta", "group_id")])
     def test_mc_advantage_tensor_group_key(self, group_key):
         # tensor group identifiers (under a flat or nested key) are grouped by

--- a/test/llm/test_llm_updaters.py
+++ b/test/llm/test_llm_updaters.py
@@ -257,7 +257,9 @@ class TestVLLMUpdaterV2WithAsyncVLLM(BaseVLLMUpdaterTest):
             dtype="float16",
             max_model_len=512,  # Short context for minimal KV cache
             max_num_seqs=1,  # Minimal batch size
-            enable_prefix_caching=False,  # Disable to save memory
+            # Enabled so weight-update tests exercise the automatic
+            # prefix-cache reset path.
+            enable_prefix_caching=True,
         )
 
         logger.info(f"Created AsyncVLLM service with {service.num_replicas} replicas")
@@ -290,6 +292,16 @@ class TestVLLMUpdaterV2WithAsyncVLLM(BaseVLLMUpdaterTest):
         assert target_vllm_engine._launched is True
 
         logger.info("✓ AsyncVLLM-specific tests passed")
+
+    def test_prefix_cache_reset_after_update(self, target_vllm_engine):
+        """Prefix-cache opt-in must survive launch and reset must run cleanly."""
+        # The opt-in must reach the engine args (regression: launch() used to
+        # clobber enable_prefix_caching back to False).
+        assert target_vllm_engine.engine_args.enable_prefix_caching is True
+
+        # The reset RPC must round-trip on a live engine; update_weights calls
+        # this automatically after every weight sync.
+        target_vllm_engine.reset_prefix_cache()
 
 
 @pytest.mark.skipif(not _has_ray, reason="missing ray dependencies")
@@ -465,6 +477,9 @@ class TestWeightSyncVLLMNCCL:
         async_engine = AsyncVLLM.from_pretrained(
             model_name,
             num_replicas=2,  # Number of engine replicas
+            # Enabled so the NCCL weight-sync path exercises the automatic
+            # prefix-cache reset before generation resumes.
+            enable_prefix_caching=True,
         )
         wrapper = vLLMWrapper(async_engine, input_mode="history")
         return wrapper

--- a/test/llm/test_llm_updaters.py
+++ b/test/llm/test_llm_updaters.py
@@ -740,6 +740,48 @@ class TestWeightSyncVLLMDoubleBuffer:
                 ray.shutdown()
 
 
+class TestDoubleBufferPrefixCacheReset:
+    """CPU-only: double-buffer weight loads must invalidate the prefix cache."""
+
+    def test_apply_weights_resets_prefix_cache_direct_path(self):
+        from types import SimpleNamespace
+
+        from tensordict import TensorDict
+        from torchrl.weight_update.llm.vllm_double_buffer import (
+            VLLMDoubleBufferWeightReceiver,
+        )
+
+        loaded, resets = [], []
+
+        class FakeEngine:
+            # no collective_rpc attribute: exercises the direct-load branch
+            llm_engine = SimpleNamespace(
+                model_executor=SimpleNamespace(
+                    driver_worker=SimpleNamespace(
+                        model_runner=SimpleNamespace(
+                            model=SimpleNamespace(
+                                load_weights=lambda w: loaded.append(list(w))
+                            )
+                        )
+                    )
+                )
+            )
+
+            def reset_prefix_cache(self):
+                resets.append(True)
+                # first attempt reports blocks still in use, second succeeds
+                return len(resets) > 1
+
+        receiver = VLLMDoubleBufferWeightReceiver.__new__(
+            VLLMDoubleBufferWeightReceiver
+        )
+        receiver._vllm_engine = FakeEngine()
+        receiver.apply_weights(TensorDict(w=torch.zeros(2)))
+
+        assert len(loaded) == 1
+        assert len(resets) == 2  # retried once after the partial clear
+
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/llm/test_sglang_updaters.py
+++ b/test/llm/test_sglang_updaters.py
@@ -129,8 +129,8 @@ class TestSGLangFlushCacheFlag:
 
     def test_scheme_flush_default_threads_to_transport(self):
         scheme = SGLangWeightSyncScheme(server_url="http://localhost:30000", num_gpus=1)
-        assert scheme.flush_cache_on_update is True
-        assert scheme.create_transport().flush_cache_on_update is True
+        assert scheme.flush_cache_on_update is None
+        assert scheme.create_transport().flush_cache_on_update is None
 
         scheme_off = SGLangWeightSyncScheme(
             server_url="http://localhost:30000",
@@ -139,47 +139,89 @@ class TestSGLangFlushCacheFlag:
         )
         assert scheme_off.create_transport().flush_cache_on_update is False
 
-    def test_update_payload_flush_flag(self, monkeypatch):
+        scheme_abort = SGLangWeightSyncScheme(
+            server_url="http://localhost:30000",
+            num_gpus=1,
+            flush_cache_on_update=True,
+            pause_mode="abort",
+        )
+        transport = scheme_abort.create_transport()
+        assert transport.flush_cache_on_update is True
+        assert transport.pause_mode == "abort"
+
+    def test_flush_requires_abort_pause_mode(self):
+        # SGLang only flushes when idle; retract/in_place leave requests queued.
+        with pytest.raises(ValueError, match="pause_mode='abort'"):
+            SGLangWeightSyncScheme(
+                server_url="http://localhost:30000",
+                num_gpus=1,
+                flush_cache_on_update=True,
+                pause_mode="retract",
+            )
+        with pytest.raises(ValueError, match="pause_mode='abort'"):
+            self._make_transport(flush_cache_on_update=True, pause_mode="retract")
+        # The default (env-resolved) pause mode is retract: explicit True
+        # without an abort pause mode fails fast at transport creation.
+        with pytest.raises(ValueError, match="pause_mode='abort'"):
+            self._make_transport(flush_cache_on_update=True)
+
+    def test_update_payload_flush_follows_pause_mode(self, monkeypatch):
         monkeypatch.delenv(_SGLANG_FLUSH_CACHE_ENV, raising=False)
 
+        # Default pause mode (retract) cannot honor a flush: off.
         payload = self._make_transport()._build_update_payload(
             ["w"], ["bfloat16"], [[2]]
         )
-        assert payload["flush_cache"] is True
+        assert payload["flush_cache"] is False
         assert payload["abort_all_requests"] is False
         assert payload["names"] == ["w"]
 
+        # Abort pause mode guarantees an idle scheduler: flush by default.
+        payload = self._make_transport(pause_mode="abort")._build_update_payload(
+            ["w"], ["bfloat16"], [[2]]
+        )
+        assert payload["flush_cache"] is True
+
+        # Explicit off wins even under abort.
         payload = self._make_transport(
-            flush_cache_on_update=False
+            flush_cache_on_update=False, pause_mode="abort"
         )._build_update_payload(["w"], ["bfloat16"], [[2]])
         assert payload["flush_cache"] is False
 
     def test_update_payload_env_override(self, monkeypatch):
-        # The env var overrides the configured flag in either direction.
+        # The env var overrides the configured flag but cannot force a flush
+        # the pause mode cannot honor.
         monkeypatch.setenv(_SGLANG_FLUSH_CACHE_ENV, "0")
-        payload = self._make_transport()._build_update_payload(
+        payload = self._make_transport(pause_mode="abort")._build_update_payload(
             ["w"], ["bfloat16"], [[2]]
         )
         assert payload["flush_cache"] is False
 
         monkeypatch.setenv(_SGLANG_FLUSH_CACHE_ENV, "1")
-        payload = self._make_transport(
-            flush_cache_on_update=False
-        )._build_update_payload(["w"], ["bfloat16"], [[2]])
+        payload = self._make_transport(pause_mode="abort")._build_update_payload(
+            ["w"], ["bfloat16"], [[2]]
+        )
         assert payload["flush_cache"] is True
 
-    def test_flush_retract_warning_emitted_once(self, monkeypatch):
-        monkeypatch.delenv(_SGLANG_FLUSH_CACHE_ENV, raising=False)
+        # Env-forced flush under retract is downgraded, not honored.
+        payload = self._make_transport()._build_update_payload(
+            ["w"], ["bfloat16"], [[2]]
+        )
+        assert payload["flush_cache"] is False
+
+    def test_flush_downgrade_warning_emitted_once(self, monkeypatch):
+        monkeypatch.setenv(_SGLANG_FLUSH_CACHE_ENV, "1")
         warnings_seen = []
         monkeypatch.setattr(
             sglang_nccl.torchrl_logger,
             "warning",
             lambda msg, *args, **kwargs: warnings_seen.append(msg),
         )
-        transport = self._make_transport()
+        transport = self._make_transport()  # default retract pause mode
         transport._build_update_payload(["w"], ["bfloat16"], [[2]])
         transport._build_update_payload(["w"], ["bfloat16"], [[2]])
         assert len(warnings_seen) == 1
+        assert "Skipping the SGLang radix-cache flush" in warnings_seen[0]
 
 
 @pytest.mark.gpu

--- a/test/llm/test_sglang_updaters.py
+++ b/test/llm/test_sglang_updaters.py
@@ -12,6 +12,7 @@ import inspect
 
 import pytest
 import torch
+import torchrl.weight_update.llm.sglang_nccl as sglang_nccl
 from torch.distributed.distributed_c10d import _new_process_group_helper
 from torchrl._utils import logger
 from torchrl.weight_update.llm import (
@@ -20,7 +21,10 @@ from torchrl.weight_update.llm import (
     SGLangWeightSender,
     SGLangWeightSyncScheme,
 )
-from torchrl.weight_update.llm.sglang_nccl import _process_group_options_kwargs
+from torchrl.weight_update.llm.sglang_nccl import (
+    _process_group_options_kwargs,
+    _SGLANG_FLUSH_CACHE_ENV,
+)
 
 # Check for dependencies
 _has_sglang = importlib.util.find_spec("sglang") is not None
@@ -108,6 +112,74 @@ class TestSGLangWeightSyncScheme:
 
         receiver = scheme.create_receiver()
         assert receiver is None
+
+
+class TestSGLangFlushCacheFlag:
+    """CPU-only tests for the flush_cache_on_update flag (no server needed)."""
+
+    def _make_transport(self, **kwargs):
+        return SGLangCollectiveTransport(
+            server_url="http://localhost:30000",
+            master_address="localhost",
+            master_port=29500,
+            rank=0,
+            world_size=2,
+            **kwargs,
+        )
+
+    def test_scheme_flush_default_threads_to_transport(self):
+        scheme = SGLangWeightSyncScheme(server_url="http://localhost:30000", num_gpus=1)
+        assert scheme.flush_cache_on_update is True
+        assert scheme.create_transport().flush_cache_on_update is True
+
+        scheme_off = SGLangWeightSyncScheme(
+            server_url="http://localhost:30000",
+            num_gpus=1,
+            flush_cache_on_update=False,
+        )
+        assert scheme_off.create_transport().flush_cache_on_update is False
+
+    def test_update_payload_flush_flag(self, monkeypatch):
+        monkeypatch.delenv(_SGLANG_FLUSH_CACHE_ENV, raising=False)
+
+        payload = self._make_transport()._build_update_payload(
+            ["w"], ["bfloat16"], [[2]]
+        )
+        assert payload["flush_cache"] is True
+        assert payload["abort_all_requests"] is False
+        assert payload["names"] == ["w"]
+
+        payload = self._make_transport(
+            flush_cache_on_update=False
+        )._build_update_payload(["w"], ["bfloat16"], [[2]])
+        assert payload["flush_cache"] is False
+
+    def test_update_payload_env_override(self, monkeypatch):
+        # The env var overrides the configured flag in either direction.
+        monkeypatch.setenv(_SGLANG_FLUSH_CACHE_ENV, "0")
+        payload = self._make_transport()._build_update_payload(
+            ["w"], ["bfloat16"], [[2]]
+        )
+        assert payload["flush_cache"] is False
+
+        monkeypatch.setenv(_SGLANG_FLUSH_CACHE_ENV, "1")
+        payload = self._make_transport(
+            flush_cache_on_update=False
+        )._build_update_payload(["w"], ["bfloat16"], [[2]])
+        assert payload["flush_cache"] is True
+
+    def test_flush_retract_warning_emitted_once(self, monkeypatch):
+        monkeypatch.delenv(_SGLANG_FLUSH_CACHE_ENV, raising=False)
+        warnings_seen = []
+        monkeypatch.setattr(
+            sglang_nccl.torchrl_logger,
+            "warning",
+            lambda msg, *args, **kwargs: warnings_seen.append(msg),
+        )
+        transport = self._make_transport()
+        transport._build_update_payload(["w"], ["bfloat16"], [[2]])
+        transport._build_update_payload(["w"], ["bfloat16"], [[2]])
+        assert len(warnings_seen) == 1
 
 
 @pytest.mark.gpu

--- a/test/llm/test_wrapper.py
+++ b/test/llm/test_wrapper.py
@@ -232,6 +232,57 @@ def test_async_vllm_prefix_caching_defaults_to_false(monkeypatch):
     assert captured["engine_args"].enable_prefix_caching is True
 
 
+def test_async_vllm_constructor_respects_engine_args_prefix_caching(monkeypatch):
+    """AsyncVLLM.__init__ must not clobber an explicit enable_prefix_caching value."""
+
+    class FakeAsyncEngineArgs:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    monkeypatch.setattr(vllm_async, "_has_vllm", True)
+    actor_class = object()
+
+    # Opt-in carried by engine_args survives construction.
+    engine_args = FakeAsyncEngineArgs(enable_prefix_caching=True)
+    service = vllm_async.AsyncVLLM(engine_args, actor_class=actor_class)
+    assert service.engine_args.enable_prefix_caching is True
+
+    # Unset engine args fall back to the conservative default.
+    engine_args = FakeAsyncEngineArgs(enable_prefix_caching=None)
+    vllm_async.AsyncVLLM(engine_args, actor_class=actor_class)
+    assert engine_args.enable_prefix_caching is False
+
+    # An explicit constructor argument wins over engine_args.
+    engine_args = FakeAsyncEngineArgs(enable_prefix_caching=True)
+    vllm_async.AsyncVLLM(
+        engine_args, actor_class=actor_class, enable_prefix_caching=False
+    )
+    assert engine_args.enable_prefix_caching is False
+
+
+def test_async_vllm_launch_preserves_prefix_caching(monkeypatch):
+    """AsyncVLLM.launch must forward the engine_args prefix-caching opt-in."""
+
+    class FakeAsyncEngineArgs:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    monkeypatch.setattr(vllm_async, "_has_vllm", True)
+    monkeypatch.setattr(
+        vllm_async,
+        "_get_ray",
+        lambda: types.SimpleNamespace(remote=lambda **kwargs: (lambda cls: cls)),
+    )
+    monkeypatch.setattr(vllm_async.AsyncVLLM, "_launch", lambda self: None)
+    monkeypatch.setattr(
+        vllm_async.AsyncVLLM, "create_load_balancer", lambda self, *a, **kw: None
+    )
+
+    engine_args = FakeAsyncEngineArgs(enable_prefix_caching=True)
+    service = vllm_async.AsyncVLLM.launch(engine_args, num_replicas=2)
+    assert service.engine_args.enable_prefix_caching is True
+
+
 @pytest.fixture
 def sample_text():
     """Create sample text for testing."""

--- a/test/llm/test_wrapper.py
+++ b/test/llm/test_wrapper.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import gc
 import importlib.util
 import sys
@@ -281,6 +282,144 @@ def test_async_vllm_launch_preserves_prefix_caching(monkeypatch):
     engine_args = FakeAsyncEngineArgs(enable_prefix_caching=True)
     service = vllm_async.AsyncVLLM.launch(engine_args, num_replicas=2)
     assert service.engine_args.enable_prefix_caching is True
+
+
+class _FakeActorMethod:
+    """Records invocations of a remote actor method and returns a canned result."""
+
+    def __init__(self, name: str, events: list[str], result=None):
+        self._name = name
+        self._events = events
+        self._result = result
+
+    def remote(self, *args, **kwargs):
+        self._events.append(self._name)
+        return self._result
+
+
+class _FakeVLLMActor:
+    def __init__(self, events: list[str], reset_result=True):
+        self.sleep = _FakeActorMethod("sleep", events)
+        self.update_weights_native = _FakeActorMethod("update_weights_native", events)
+        self.reset_prefix_cache = _FakeActorMethod(
+            "reset_prefix_cache", events, reset_result
+        )
+        self.wake_up = _FakeActorMethod("wake_up", events)
+
+
+def _make_offline_async_vllm(monkeypatch, *, enable_prefix_caching, events):
+    """Build an AsyncVLLM wired to fake actors, ray and vllm modules."""
+
+    class FakeAsyncEngineArgs:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    @dataclasses.dataclass
+    class FakeUpdateInfo:
+        names: list
+        dtype_names: list
+        shapes: list
+        packed: bool
+
+    @dataclasses.dataclass
+    class FakeSendArgs:
+        group: Any
+        packed: bool
+
+    fake_transfer_base = types.SimpleNamespace(
+        WeightTransferUpdateRequest=lambda **kwargs: kwargs
+    )
+    fake_transfer_nccl = types.SimpleNamespace(
+        NCCLTrainerSendWeightsArgs=FakeSendArgs,
+        NCCLWeightTransferEngine=types.SimpleNamespace(
+            trainer_send_weights=lambda **kwargs: None
+        ),
+        NCCLWeightTransferUpdateInfo=FakeUpdateInfo,
+    )
+    monkeypatch.setitem(
+        sys.modules, "vllm.distributed.weight_transfer.base", fake_transfer_base
+    )
+    monkeypatch.setitem(
+        sys.modules, "vllm.distributed.weight_transfer.nccl_engine", fake_transfer_nccl
+    )
+    monkeypatch.setattr(vllm_async, "_has_vllm", True)
+    monkeypatch.setattr(
+        vllm_async,
+        "_get_ray",
+        lambda: types.SimpleNamespace(get=lambda refs, **kwargs: refs),
+    )
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda *args, **kwargs: None)
+
+    service = vllm_async.AsyncVLLM(
+        FakeAsyncEngineArgs(enable_prefix_caching=enable_prefix_caching),
+        actor_class=object(),
+    )
+    service._launched = True
+    service._trainer_nccl_group = object()
+    service.actors = [_FakeVLLMActor(events)]
+    return service
+
+
+def test_async_vllm_update_weights_resets_prefix_cache(monkeypatch):
+    """Weight updates must invalidate the prefix cache before scheduling resumes."""
+    events = []
+    service = _make_offline_async_vllm(
+        monkeypatch, enable_prefix_caching=True, events=events
+    )
+    service.update_weights(iter([("weight", torch.zeros(2))]))
+    assert events == ["sleep", "update_weights_native", "reset_prefix_cache", "wake_up"]
+
+
+def test_async_vllm_update_weights_skips_reset_when_caching_disabled(monkeypatch):
+    events = []
+    service = _make_offline_async_vllm(
+        monkeypatch, enable_prefix_caching=False, events=events
+    )
+    service.update_weights(iter([("weight", torch.zeros(2))]))
+    assert events == ["sleep", "update_weights_native", "wake_up"]
+
+
+def test_async_vllm_reset_prefix_cache_fanout(monkeypatch):
+    """reset_prefix_cache hits every replica and warns when a reset is refused."""
+
+    class FakeAsyncEngineArgs:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    monkeypatch.setattr(vllm_async, "_has_vllm", True)
+    monkeypatch.setattr(
+        vllm_async,
+        "_get_ray",
+        lambda: types.SimpleNamespace(get=lambda refs, **kwargs: refs),
+    )
+    warnings_seen = []
+    monkeypatch.setattr(
+        vllm_async.torchrl_logger,
+        "warning",
+        lambda msg, *a, **kw: warnings_seen.append(msg),
+    )
+
+    service = vllm_async.AsyncVLLM(
+        FakeAsyncEngineArgs(enable_prefix_caching=True), actor_class=object()
+    )
+    events = []
+    service.actors = [
+        _FakeVLLMActor(events),
+        _FakeVLLMActor(events, reset_result=False),
+        _FakeVLLMActor(events),
+    ]
+    service.reset_prefix_cache()
+    assert events == ["reset_prefix_cache"] * 3
+    assert len(warnings_seen) == 1
+
+    # A replica refusing the reset is only a warning, never an error; with all
+    # replicas succeeding no warning is emitted.
+    warnings_seen.clear()
+    events.clear()
+    service.actors = [_FakeVLLMActor(events), _FakeVLLMActor(events)]
+    service.reset_prefix_cache()
+    assert events == ["reset_prefix_cache"] * 2
+    assert not warnings_seen
 
 
 @pytest.fixture

--- a/torchrl/collectors/llm/weight_update/vllm.py
+++ b/torchrl/collectors/llm/weight_update/vllm.py
@@ -280,6 +280,12 @@ class vLLMUpdater(WeightUpdaterBase, metaclass=vLLMUpdaterMeta):
         torchrl_logger.debug("done broadcasting")
         torch.cuda.synchronize()
 
+        # Invalidate prefix caches: cached prefixes are keyed by prompt content
+        # and are stale now that weights changed. Guarded for older actors that
+        # do not expose the method.
+        if hasattr(model_ref, "reset_prefix_cache"):
+            ray.get(model_ref.reset_prefix_cache.remote())
+
     def _get_server_weights(self) -> TensorDictBase | None:
         """Not used - weights must be passed directly via policy."""
         return None

--- a/torchrl/modules/llm/backends/vllm/base.py
+++ b/torchrl/modules/llm/backends/vllm/base.py
@@ -70,3 +70,12 @@ class RLvLLMEngine(abc.ABC):
         Args:
             weights: Iterator yielding (parameter_name, tensor) tuples
         """
+
+    def reset_prefix_cache(self) -> None:
+        """Invalidate cached KV prefixes after a weight update.
+
+        Prefix caches are keyed by prompt content, not by the weights that
+        produced them, so engines that enable prefix caching must clear the
+        cache whenever new weights are loaded. The default implementation is
+        a no-op for engines without a prefix cache.
+        """

--- a/torchrl/modules/llm/backends/vllm/base.py
+++ b/torchrl/modules/llm/backends/vllm/base.py
@@ -71,7 +71,7 @@ class RLvLLMEngine(abc.ABC):
             weights: Iterator yielding (parameter_name, tensor) tuples
         """
 
-    def reset_prefix_cache(self) -> None:
+    def reset_prefix_cache(self) -> None:  # noqa: B027
         """Invalidate cached KV prefixes after a weight update.
 
         Prefix caches are keyed by prompt content, not by the weights that

--- a/torchrl/modules/llm/backends/vllm/vllm_async.py
+++ b/torchrl/modules/llm/backends/vllm/vllm_async.py
@@ -135,11 +135,17 @@ class _AsyncLLMEngine:
         engine_args (AsyncEngineArgs): Arguments for creating the AsyncLLMEngine instances.
         bundle_indices (list[int], optional): Bundle indices for the engine.
         enable_prefix_caching (bool, optional): Whether to enable prefix caching.
+            ``None`` (default) leaves ``engine_args.enable_prefix_caching``
+            untouched.
 
-            .. warning::
-                enable_prefix_caching is set to False by default, which is recommended if prompt log probs are needed.
-                Set it to True if prompt log probs are not needed.
-                See `this issue <https://github.com/vllm-project/vllm/issues/8268>`_ for more details.
+            .. note::
+                Prefix caching used to be discouraged with online weight
+                updates because cached KV prefixes are keyed by prompt content,
+                not by the weights that produced them. Caches are now reset
+                automatically after each weight update (see
+                :meth:`reset_prefix_cache`), and truncated prompt log-probs
+                from cached prefixes are zero-padded by the vLLM wrapper, so
+                enabling it for online RL is supported.
     """
 
     def __init__(
@@ -147,7 +153,7 @@ class _AsyncLLMEngine:
         *,
         engine_args: AsyncEngineArgs,
         bundle_indices: list[int] | None = None,
-        enable_prefix_caching: bool = False,
+        enable_prefix_caching: bool | None = None,
     ):
         if not _has_vllm:
             raise ImportError(
@@ -160,7 +166,8 @@ class _AsyncLLMEngine:
         if bundle_indices is not None:
             os.environ["VLLM_RAY_BUNDLE_INDICES"] = ",".join(map(str, bundle_indices))
 
-        engine_args.enable_prefix_caching = enable_prefix_caching
+        if enable_prefix_caching is not None:
+            engine_args.enable_prefix_caching = enable_prefix_caching
 
         # Enable native weight transfer support (vLLM 0.17+)
         engine_args.weight_transfer_config = WeightTransferConfig(backend="nccl")
@@ -505,12 +512,17 @@ class AsyncVLLM(RLvLLMEngine):
         engine_args (AsyncEngineArgs): Configuration for the vLLM engines.
         num_replicas (int, optional): Number of engine replicas to create. Defaults to 1.
         actor_class (optional): Custom Ray actor class. Defaults to the internal actor implementation.
-        enable_prefix_caching (bool, optional): Whether to enable prefix caching. Defaults to False.
+        enable_prefix_caching (bool, optional): Whether to enable prefix caching.
+            ``None`` (default) respects ``engine_args.enable_prefix_caching`` when it
+            is set, and falls back to ``False`` otherwise.
 
-            .. warning::
-                enable_prefix_caching is set to False by default, which is recommended if prompt log probs are needed.
-                Set it to True if prompt log probs are not needed.
-                See `this issue <https://github.com/vllm-project/vllm/issues/8268>`_ for more details.
+            .. note::
+                Prefix caching used to be discouraged with online weight updates
+                because cached KV prefixes are keyed by prompt content, not by the
+                weights that produced them. Caches are now reset automatically after
+                each weight update (see :meth:`reset_prefix_cache`), and truncated
+                prompt log-probs from cached prefixes are zero-padded by the vLLM
+                wrapper, so enabling it for online RL is supported.
 
     Example:
         >>> from torchrl.modules.llm import AsyncVLLM
@@ -569,7 +581,8 @@ class AsyncVLLM(RLvLLMEngine):
 
         **Performance Considerations**
 
-        - Prefix caching is enabled by default for better performance with repeated prompts
+        - Prefix caching is disabled by default (conservative); when enabled, caches are
+          reset automatically after each weight update
         - Tensor parallelism is supported for large models that don't fit on single GPUs
         - Multiple replicas allow concurrent processing of different requests
         - Native vLLM batching is used within each replica for optimal throughput
@@ -586,7 +599,7 @@ class AsyncVLLM(RLvLLMEngine):
         engine_args: AsyncEngineArgs,
         num_replicas: int = 1,
         actor_class=None,
-        enable_prefix_caching: bool = False,
+        enable_prefix_caching: bool | None = None,
     ):
         if not _has_vllm:
             raise ImportError(
@@ -594,8 +607,13 @@ class AsyncVLLM(RLvLLMEngine):
             )
         # Lazily import ray only when constructing the actor class to avoid global import
 
-        # Enable prefix caching by default for better performance
-        engine_args.enable_prefix_caching = enable_prefix_caching
+        if enable_prefix_caching is not None:
+            # Explicit request wins over whatever engine_args carries.
+            engine_args.enable_prefix_caching = enable_prefix_caching
+        elif getattr(engine_args, "enable_prefix_caching", None) is None:
+            # vLLM defaults None -> True; keep TorchRL's conservative default
+            # (prefix caches go stale across online weight updates).
+            engine_args.enable_prefix_caching = False
 
         self.engine_args = engine_args
         self.num_replicas = num_replicas

--- a/torchrl/modules/llm/backends/vllm/vllm_async.py
+++ b/torchrl/modules/llm/backends/vllm/vllm_async.py
@@ -489,7 +489,13 @@ class _AsyncLLMEngine:
             Whether the cache was fully reset, when reported by vLLM. ``False``
             means some cached blocks are still held by in-flight requests.
         """
-        return await self.engine.reset_prefix_cache()
+        try:
+            # Also reset KV-connector-backed entries: vLLM defaults
+            # reset_connector=False, which only clears the local cache.
+            return await self.engine.reset_prefix_cache(reset_connector=True)
+        except TypeError:
+            # Older vLLM without the reset_connector kwarg.
+            return await self.engine.reset_prefix_cache()
 
 
 def _gpus_per_replica(engine_args: AsyncEngineArgs) -> int:

--- a/torchrl/modules/llm/backends/vllm/vllm_async.py
+++ b/torchrl/modules/llm/backends/vllm/vllm_async.py
@@ -482,6 +482,15 @@ class _AsyncLLMEngine:
             tags = ["scheduling"]
         return await self.engine.wake_up(tags=tags)
 
+    async def reset_prefix_cache(self) -> bool | None:
+        """Invalidate cached KV prefixes (stale after an online weight update).
+
+        Returns:
+            Whether the cache was fully reset, when reported by vLLM. ``False``
+            means some cached blocks are still held by in-flight requests.
+        """
+        return await self.engine.reset_prefix_cache()
+
 
 def _gpus_per_replica(engine_args: AsyncEngineArgs) -> int:
     """Get the number of GPUs per replica for the given engine args."""
@@ -1066,6 +1075,26 @@ class AsyncVLLM(RLvLLMEngine):
             futures.append(actor_collective_rpc.remote(method, timeout, args, kwargs))
         return futures
 
+    def reset_prefix_cache(self) -> None:
+        """Reset the KV prefix cache on all replicas.
+
+        Called automatically after each weight update: cached prefixes are
+        keyed by prompt content, not by the weights that produced them, so
+        they are stale once new weights are loaded. This is a no-op when
+        prefix caching is disabled.
+        """
+        if not getattr(self.engine_args, "enable_prefix_caching", False):
+            return
+        ray = _get_ray()
+        torchrl_logger.info("Resetting prefix caches...")
+        results = ray.get([actor.reset_prefix_cache.remote() for actor in self.actors])
+        if any(result is False for result in results):
+            torchrl_logger.warning(
+                "reset_prefix_cache could not fully clear the prefix cache on "
+                "some replicas (in-flight requests may still hold KV blocks); "
+                "stale prefixes may persist until those requests complete."
+            )
+
     def shutdown(self):
         """Shutdown all actors and clean up resources."""
         torchrl_logger.info(
@@ -1281,6 +1310,10 @@ class AsyncVLLM(RLvLLMEngine):
 
         # Step 3: Wait for all actors to finish receiving
         ray.get(refs)
+
+        # Invalidate prefix caches before resuming scheduling: cached prefixes
+        # are keyed by prompt content and are stale now that weights changed.
+        self.reset_prefix_cache()
 
         # Wake up vLLM engines after weight update
         torchrl_logger.info("Waking up vLLM engines after weight update...")
@@ -2024,8 +2057,9 @@ def make_async_vllm_engine(
         pipeline_parallel_size = 1
 
     # Prefix caches are keyed by prompt content, not by the model weights that
-    # produced their KV entries. AsyncVLLM is commonly used with online weight
-    # updates, so keep prefix caching off unless the caller explicitly opts in.
+    # produced their KV entries. TorchRL resets the cache after each weight
+    # update (AsyncVLLM.reset_prefix_cache), so opting in is safe for online
+    # RL, but stay conservative unless the caller explicitly opts in.
     kwargs.setdefault("enable_prefix_caching", False)
 
     # Set compilation flag - this controls whether vLLM will compile the model for better performance

--- a/torchrl/modules/llm/backends/vllm/vllm_sync.py
+++ b/torchrl/modules/llm/backends/vllm/vllm_sync.py
@@ -143,12 +143,22 @@ class RayLLMWorker(RLvLLMEngine):
     standardized interface for weight updates and configuration access.
     """
 
-    def __init__(self, ray_actor, tensor_parallel_size: int, model_name: str):
+    def __init__(
+        self,
+        ray_actor,
+        tensor_parallel_size: int,
+        model_name: str,
+        enable_prefix_caching: bool = True,
+    ):
         self.ray_actor = ray_actor
         self._tensor_parallel_size = tensor_parallel_size
         self._model_name = model_name
         self._master_address = None
         self._master_port = None
+        # vLLM enables prefix caching by default (V1), so unless the caller
+        # explicitly disabled it we must assume the cache exists and reset it
+        # after weight updates.
+        self._enable_prefix_caching = enable_prefix_caching
 
     def get_tp_size(self) -> int:
         """Get the tensor parallel size."""
@@ -302,12 +312,31 @@ class RayLLMWorker(RLvLLMEngine):
 
             ray.get(ref)
 
+            # Invalidate prefix caches before resuming scheduling: cached
+            # prefixes are keyed by prompt content and are stale now that
+            # weights changed.
+            self.reset_prefix_cache()
+
             # Wake up vLLM engine after weight transfer
             ray.get(self.ray_actor.wake_up.remote(tags=["scheduling"]))
             torchrl_logger.info("Ray worker weight update completed")
 
         except ImportError:
             raise ImportError("Ray not available for weight updates")
+
+    def reset_prefix_cache(self) -> None:
+        """Reset the KV prefix cache on the Ray worker.
+
+        No-op when prefix caching was explicitly disabled at construction.
+        """
+        if not self._enable_prefix_caching:
+            return
+        try:
+            import ray
+
+            ray.get(self.ray_actor.reset_prefix_cache.remote())
+        except ImportError:
+            raise ImportError("Ray not available for prefix cache reset")
 
     # Delegate generation methods to the Ray actor
     def generate(self, *args, **kwargs):
@@ -376,6 +405,10 @@ class LocalLLMWrapper(RLvLLMEngine):
         torchrl_logger.info(
             f"Local LLM weight update (no-op) for {len(weights_list)} parameters"
         )
+
+    def reset_prefix_cache(self) -> None:
+        """Reset the KV prefix cache on the wrapped local LLM instance."""
+        self.llm_instance.reset_prefix_cache()
 
     # Delegate generation methods to the local LLM
     def generate(self, *args, **kwargs):
@@ -485,7 +518,12 @@ def make_vllm_worker(
         ray.get(worker.initialize.remote())
 
         # Wrap the Ray actor in RayLLMWorker to provide RLvLLMEngine interface
-        return RayLLMWorker(worker, num_devices or 1, model_name)
+        return RayLLMWorker(
+            worker,
+            num_devices or 1,
+            model_name,
+            enable_prefix_caching=kwargs.get("enable_prefix_caching") is not False,
+        )
 
     else:
         # Local non-Ray mode - use LLM directly

--- a/torchrl/modules/llm/backends/vllm/vllm_sync.py
+++ b/torchrl/modules/llm/backends/vllm/vllm_sync.py
@@ -333,10 +333,15 @@ class RayLLMWorker(RLvLLMEngine):
             return
         try:
             import ray
-
-            ray.get(self.ray_actor.reset_prefix_cache.remote())
         except ImportError:
             raise ImportError("Ray not available for prefix cache reset")
+        try:
+            # Also reset KV-connector-backed entries: vLLM defaults
+            # reset_connector=False, which only clears the local cache.
+            ray.get(self.ray_actor.reset_prefix_cache.remote(reset_connector=True))
+        except TypeError:
+            # Older vLLM without the reset_connector kwarg.
+            ray.get(self.ray_actor.reset_prefix_cache.remote())
 
     # Delegate generation methods to the Ray actor
     def generate(self, *args, **kwargs):
@@ -408,7 +413,13 @@ class LocalLLMWrapper(RLvLLMEngine):
 
     def reset_prefix_cache(self) -> None:
         """Reset the KV prefix cache on the wrapped local LLM instance."""
-        self.llm_instance.reset_prefix_cache()
+        try:
+            # Also reset KV-connector-backed entries: vLLM defaults
+            # reset_connector=False, which only clears the local cache.
+            self.llm_instance.reset_prefix_cache(reset_connector=True)
+        except TypeError:
+            # Older vLLM without the reset_connector kwarg.
+            self.llm_instance.reset_prefix_cache()
 
     # Delegate generation methods to the local LLM
     def generate(self, *args, **kwargs):

--- a/torchrl/objectives/llm/grpo.py
+++ b/torchrl/objectives/llm/grpo.py
@@ -1387,10 +1387,17 @@ class MCAdvantage(Transform):
         trajectory groups should nevertheless have a consistent concrete
         representation, both to avoid backend-specific lazy-stack assumptions
         and to keep replay-buffer storage writes predictable.
+
+        Trajectories whose leaves are ragged across (but uniform within)
+        trajectories materialize individually yet cannot be concatenated into
+        a contiguous result; those fall back to a lazy concatenation.
         """
-        return torch.cat(
-            [MCAdvantage._concrete_if_possible(td) for td in tensordicts], dim
-        )
+        concrete = [MCAdvantage._concrete_if_possible(td) for td in tensordicts]
+        try:
+            return torch.cat(concrete, dim)
+        except RuntimeError:
+            steps = [step for td in tensordicts for step in td.unbind(dim)]
+            return lazy_stack(steps, dim)
 
     def _inv_call(self, tensordict: TensorDictBase) -> TensorDictBase | None:
         if self.verbose:

--- a/torchrl/objectives/llm/grpo.py
+++ b/torchrl/objectives/llm/grpo.py
@@ -25,6 +25,7 @@ from tensordict import (
     TensorDict,
     TensorDictBase,
 )
+from tensordict.base import _is_leaf_nontensor
 from tensordict.nn import (
     CompositeDistribution,
     ProbabilisticTensorDictModule,
@@ -1356,12 +1357,24 @@ class MCAdvantage(Transform):
         (version-dependent) error message.
         """
         try:
-            return tensordict.contiguous()
+            out = tensordict.contiguous()
         except RuntimeError as err:
             torchrl_logger.debug(
                 f"MCAdvantage: keeping lazy tensordict; contiguous() failed with: {err}"
             )
             return tensordict
+        # contiguous() can silently turn stacked NonTensorData entries (e.g.
+        # string prompts) into empty TensorDicts. Keep the lazy input whenever
+        # materialization would lose entries.
+        lazy_keys = set(tensordict.keys(True, True, is_leaf=_is_leaf_nontensor))
+        concrete_keys = set(out.keys(True, True, is_leaf=_is_leaf_nontensor))
+        if lazy_keys - concrete_keys:
+            torchrl_logger.debug(
+                "MCAdvantage: keeping lazy tensordict; contiguous() dropped "
+                f"entries {lazy_keys - concrete_keys}"
+            )
+            return tensordict
+        return out
 
     @staticmethod
     def _cat_tensordicts(
@@ -1486,10 +1499,12 @@ class MCAdvantage(Transform):
             self.completed_groups += 1
             # Cat is the most robust way to combine the trajs
             tds = self._cat_tensordicts(trajs, -1)
-            # Collect rewards
+            # Collect rewards. Same-length trajectories concatenate into a
+            # regular strided tensor rather than a nested one.
             reward = tds.get(self.rewards_key, as_nested_tensor=True)
-            reward_mean = reward.values().mean()
-            reward_scale = reward.values().std()
+            reward_values = reward.values() if reward.is_nested else reward
+            reward_mean = reward_values.mean()
+            reward_scale = reward_values.std()
             advantage = (reward - reward_mean) / reward_scale.clamp_min(1e-6)
             if self.verbose:
                 torchrl_logger.info(f"Advantage: {reward_mean=} {reward_scale=}")

--- a/torchrl/weight_update/llm/sglang_nccl.py
+++ b/torchrl/weight_update/llm/sglang_nccl.py
@@ -207,10 +207,20 @@ class SGLangCollectiveTransport:
         device: Device to use for communication.
         timeout: HTTP request timeout in seconds.
         flush_cache_on_update: Whether to ask the server to flush its radix
-            (prefix) cache as part of each weight update. Defaults to ``True``;
-            cached prefixes are keyed by prompt content and go stale when the
-            weights change. The ``TORCHRL_SGLANG_WEIGHT_SYNC_FLUSH_CACHE``
-            environment variable, when set, overrides this in either direction.
+            (prefix) cache as part of each weight update. ``None`` (default)
+            flushes exactly when the pause mode is ``"abort"`` -- the only mode
+            under which SGLang can honor the flush, since it requires an idle
+            scheduler and retracted requests stay queued. ``True`` requires the
+            ``"abort"`` pause mode and raises otherwise. The
+            ``TORCHRL_SGLANG_WEIGHT_SYNC_FLUSH_CACHE`` environment variable,
+            when set, overrides this in either direction (downgraded with a
+            warning when the pause mode cannot honor it).
+        pause_mode: How to pause generation for the update: ``"abort"`` cancels
+            in-flight requests (callers must tolerate transient generation
+            failures), ``"retract"`` re-queues them, ``"in_place"`` freezes
+            them. ``None`` (default) defers to the
+            ``TORCHRL_SGLANG_PAUSE_GENERATION_MODE`` environment variable and
+            falls back to ``"retract"``.
     """
 
     def __init__(
@@ -222,7 +232,8 @@ class SGLangCollectiveTransport:
         world_size: int,
         device: torch.device | str | int | None = None,
         timeout: float = 300.0,
-        flush_cache_on_update: bool = True,
+        flush_cache_on_update: bool | None = None,
+        pause_mode: Literal["abort", "retract", "in_place"] | None = None,
     ):
         self.server_url = server_url.rstrip("/")
         self.master_address = master_address
@@ -231,11 +242,20 @@ class SGLangCollectiveTransport:
         self.world_size = world_size
         self.timeout = timeout
         self.flush_cache_on_update = flush_cache_on_update
+        self.pause_mode = pause_mode
+        if flush_cache_on_update and self._effective_pause_mode() != "abort":
+            raise ValueError(
+                "flush_cache_on_update=True requires pause_mode='abort': SGLang "
+                "only flushes its radix cache when the scheduler is idle, and "
+                "the 'retract'/'in_place' pause modes leave requests queued, so "
+                "the requested flush would fail server-side after the weights "
+                "have already been swapped."
+            )
         self._comm_group = None
         self._group_name = None
         self._model_metadata = None
         self._http_executor = ThreadPoolExecutor(max_workers=1)
-        self._flush_retract_warned = False
+        self._flush_downgrade_warned = False
 
         # Handle device specification
         if device is None:
@@ -255,30 +275,36 @@ class SGLangCollectiveTransport:
     ) -> dict:
         """Build the JSON payload for ``/update_weights_from_distributed``.
 
-        The ``flush_cache`` flag defaults to :attr:`flush_cache_on_update`
-        (``True``) so the radix cache is invalidated together with the weight
-        swap; stale prefixes are keyed by prompt content and would otherwise
-        be reused after the update. ``TORCHRL_SGLANG_WEIGHT_SYNC_FLUSH_CACHE``
-        overrides the flag in either direction when set.
+        The ``flush_cache`` flag is resolved from :attr:`flush_cache_on_update`
+        and the pause mode: SGLang only flushes its radix cache when the
+        scheduler is idle, which only the ``"abort"`` pause mode guarantees, so
+        the flag is sent exactly when the effective pause mode is ``"abort"``.
+        ``TORCHRL_SGLANG_WEIGHT_SYNC_FLUSH_CACHE`` overrides the request in
+        either direction when set; a request the pause mode cannot honor is
+        downgraded with a warning rather than crashing the server-side update.
         """
-        flush_cache = _truthy_env(
-            _SGLANG_FLUSH_CACHE_ENV, default=self.flush_cache_on_update
+        mode = self._effective_pause_mode()
+        default = (
+            self.flush_cache_on_update
+            if self.flush_cache_on_update is not None
+            else mode == "abort"
         )
-        if (
-            flush_cache
-            and not self._flush_retract_warned
-            and _pause_generation_mode() == "retract"
-        ):
-            # SGLang skips the flush when retracted requests still sit in the
-            # waiting queue; those requests keep their (old-weights) prefixes
-            # until they complete.
+        requested = _truthy_env(_SGLANG_FLUSH_CACHE_ENV, default=default)
+        flush_cache = requested and mode == "abort"
+        if requested and not flush_cache and not self._flush_downgrade_warned:
+            # Retracted/frozen requests keep the scheduler non-idle: SGLang
+            # would fail the flush server-side after the weights already
+            # landed. Skip it and surface the correctness gap instead.
             torchrl_logger.warning(
-                "flush_cache is requested during SGLang weight sync while the "
-                "pause mode is 'retract'; the server may skip the flush if "
-                "retracted requests are still queued, in which case stale "
-                "prefix-cache entries persist until those requests complete."
+                "Skipping the SGLang radix-cache flush during weight sync: the "
+                f"pause mode is '{mode}', which leaves requests queued, and "
+                "SGLang only flushes when idle. Stale prefix-cache entries "
+                "persist across this update. Set "
+                f"{_SGLANG_PAUSE_GENERATION_MODE_ENV}=abort (or "
+                "pause_mode='abort') to flush on every sync, or disable the "
+                "radix cache."
             )
-            self._flush_retract_warned = True
+            self._flush_downgrade_warned = True
         return {
             "names": names,
             "dtypes": dtypes,
@@ -290,20 +316,26 @@ class SGLangCollectiveTransport:
             "abort_all_requests": False,
         }
 
+    def _effective_pause_mode(self) -> Literal["abort", "retract", "in_place"]:
+        """Pause mode for weight updates: explicit kwarg, else env/default."""
+        if self.pause_mode is not None:
+            return self.pause_mode
+        return _pause_generation_mode()
+
     def _pause_generation_for_update(self, model_id: str) -> None:
         """Pause SGLang generation before a live weight update.
 
-        The pause mode can be selected through
-        ``TORCHRL_SGLANG_PAUSE_GENERATION_MODE``. ``retract`` pauses scheduling
-        and moves active requests back to the waiting queue; ``abort`` cancels
-        in-flight requests before the update and requires callers to tolerate
-        transient generation failures.
+        The pause mode comes from the ``pause_mode`` constructor argument or,
+        when unset, ``TORCHRL_SGLANG_PAUSE_GENERATION_MODE``. ``retract`` pauses
+        scheduling and moves active requests back to the waiting queue;
+        ``abort`` cancels in-flight requests before the update and requires
+        callers to tolerate transient generation failures.
 
         The pause endpoint can return before a just-dispatched scheduler step
         has drained. Poll load metrics until no request is still running before
         starting the collective weight update.
         """
-        mode = _pause_generation_mode()
+        mode = self._effective_pause_mode()
         try:
             response = requests.post(
                 f"{self.server_url}/pause_generation",
@@ -640,10 +672,22 @@ class SGLangWeightSyncScheme(WeightSyncScheme):
         strategy: Weight extraction strategy ("tensordict" or "state_dict").
         device: Device index for the trainer. Defaults to 0.
         flush_cache_on_update: Whether to flush the server's radix (prefix)
-            cache as part of each weight update. Defaults to ``True``; cached
-            prefixes are keyed by prompt content and go stale when the weights
-            change. The ``TORCHRL_SGLANG_WEIGHT_SYNC_FLUSH_CACHE`` environment
-            variable, when set, overrides this in either direction.
+            cache as part of each weight update. Cached prefixes are keyed by
+            prompt content and go stale when the weights change, but SGLang can
+            only flush when the scheduler is idle, which only the ``"abort"``
+            pause mode guarantees. ``None`` (default) flushes exactly when the
+            pause mode is ``"abort"``; ``True`` requires ``pause_mode="abort"``
+            and raises otherwise. The
+            ``TORCHRL_SGLANG_WEIGHT_SYNC_FLUSH_CACHE`` environment variable,
+            when set, overrides this in either direction (downgraded with a
+            warning when the pause mode cannot honor it).
+        pause_mode: How generation is paused around weight updates:
+            ``"abort"`` cancels in-flight requests (callers must tolerate
+            transient generation failures) and allows the radix-cache flush;
+            ``"retract"`` re-queues in-flight requests; ``"in_place"`` freezes
+            them. ``None`` (default) defers to
+            ``TORCHRL_SGLANG_PAUSE_GENERATION_MODE`` and falls back to
+            ``"retract"``.
 
     Example:
         >>> scheme = SGLangWeightSyncScheme(
@@ -665,7 +709,8 @@ class SGLangWeightSyncScheme(WeightSyncScheme):
         num_gpus: int = 1,
         strategy: Literal["tensordict", "state_dict"] = "tensordict",
         device: torch.device | str | int = 0,
-        flush_cache_on_update: bool = True,
+        flush_cache_on_update: bool | None = None,
+        pause_mode: Literal["abort", "retract", "in_place"] | None = None,
     ):
         self.server_url = server_url.rstrip("/")
         self.master_address = master_address or get_local_ip_address()
@@ -674,6 +719,13 @@ class SGLangWeightSyncScheme(WeightSyncScheme):
         self.strategy_name = strategy
         self.device = device
         self.flush_cache_on_update = flush_cache_on_update
+        self.pause_mode = pause_mode
+        if flush_cache_on_update and pause_mode is not None and pause_mode != "abort":
+            raise ValueError(
+                "flush_cache_on_update=True requires pause_mode='abort': SGLang "
+                "only flushes its radix cache when the scheduler is idle, and "
+                f"the '{pause_mode}' pause mode leaves requests queued."
+            )
 
     @property
     def world_size(self) -> int:
@@ -690,6 +742,7 @@ class SGLangWeightSyncScheme(WeightSyncScheme):
             world_size=self.world_size,
             device=self.device,
             flush_cache_on_update=self.flush_cache_on_update,
+            pause_mode=self.pause_mode,
         )
 
     def create_sender(self) -> SGLangWeightSender:

--- a/torchrl/weight_update/llm/sglang_nccl.py
+++ b/torchrl/weight_update/llm/sglang_nccl.py
@@ -206,6 +206,11 @@ class SGLangCollectiveTransport:
         world_size: Total number of processes.
         device: Device to use for communication.
         timeout: HTTP request timeout in seconds.
+        flush_cache_on_update: Whether to ask the server to flush its radix
+            (prefix) cache as part of each weight update. Defaults to ``True``;
+            cached prefixes are keyed by prompt content and go stale when the
+            weights change. The ``TORCHRL_SGLANG_WEIGHT_SYNC_FLUSH_CACHE``
+            environment variable, when set, overrides this in either direction.
     """
 
     def __init__(
@@ -217,6 +222,7 @@ class SGLangCollectiveTransport:
         world_size: int,
         device: torch.device | str | int | None = None,
         timeout: float = 300.0,
+        flush_cache_on_update: bool = True,
     ):
         self.server_url = server_url.rstrip("/")
         self.master_address = master_address
@@ -224,10 +230,12 @@ class SGLangCollectiveTransport:
         self.rank = rank
         self.world_size = world_size
         self.timeout = timeout
+        self.flush_cache_on_update = flush_cache_on_update
         self._comm_group = None
         self._group_name = None
         self._model_metadata = None
         self._http_executor = ThreadPoolExecutor(max_workers=1)
+        self._flush_retract_warned = False
 
         # Handle device specification
         if device is None:
@@ -238,6 +246,49 @@ class SGLangCollectiveTransport:
             self.device = device.index if device.index is not None else 0
         else:
             self.device = device
+
+    def _build_update_payload(
+        self,
+        names: list[str],
+        dtypes: list[str],
+        shapes: list[list[int]],
+    ) -> dict:
+        """Build the JSON payload for ``/update_weights_from_distributed``.
+
+        The ``flush_cache`` flag defaults to :attr:`flush_cache_on_update`
+        (``True``) so the radix cache is invalidated together with the weight
+        swap; stale prefixes are keyed by prompt content and would otherwise
+        be reused after the update. ``TORCHRL_SGLANG_WEIGHT_SYNC_FLUSH_CACHE``
+        overrides the flag in either direction when set.
+        """
+        flush_cache = _truthy_env(
+            _SGLANG_FLUSH_CACHE_ENV, default=self.flush_cache_on_update
+        )
+        if (
+            flush_cache
+            and not self._flush_retract_warned
+            and _pause_generation_mode() == "retract"
+        ):
+            # SGLang skips the flush when retracted requests still sit in the
+            # waiting queue; those requests keep their (old-weights) prefixes
+            # until they complete.
+            torchrl_logger.warning(
+                "flush_cache is requested during SGLang weight sync while the "
+                "pause mode is 'retract'; the server may skip the flush if "
+                "retracted requests are still queued, in which case stale "
+                "prefix-cache entries persist until those requests complete."
+            )
+            self._flush_retract_warned = True
+        return {
+            "names": names,
+            "dtypes": dtypes,
+            "shapes": shapes,
+            "group_name": self._group_name,
+            "flush_cache": flush_cache,
+            # Keep SGLang's endpoint-level abort disabled: the explicit
+            # pause_generation call provides the scheduling barrier.
+            "abort_all_requests": False,
+        }
 
     def _pause_generation_for_update(self, model_id: str) -> None:
         """Pause SGLang generation before a live weight update.
@@ -520,18 +571,7 @@ class SGLangCollectiveTransport:
 
             # Step 1: Send a single HTTP request with all weight metadata.
             # The server will enter a broadcast-receive loop for each parameter.
-            # Keep SGLang's endpoint-level abort disabled: the explicit
-            # pause_generation call above provides the scheduling barrier.
-            # Cache flushing remains opt-in because retracted requests can sit
-            # in SGLang's waiting queue while paused.
-            update_data = {
-                "names": names,
-                "dtypes": dtypes,
-                "shapes": shapes,
-                "group_name": self._group_name,
-                "flush_cache": _truthy_env(_SGLANG_FLUSH_CACHE_ENV),
-                "abort_all_requests": False,
-            }
+            update_data = self._build_update_payload(names, dtypes, shapes)
             update_future = self._http_executor.submit(
                 requests.post,
                 f"{self.server_url}/update_weights_from_distributed",
@@ -599,6 +639,11 @@ class SGLangWeightSyncScheme(WeightSyncScheme):
         num_gpus: Number of GPUs used by the SGLang server (tp_size * dp_size).
         strategy: Weight extraction strategy ("tensordict" or "state_dict").
         device: Device index for the trainer. Defaults to 0.
+        flush_cache_on_update: Whether to flush the server's radix (prefix)
+            cache as part of each weight update. Defaults to ``True``; cached
+            prefixes are keyed by prompt content and go stale when the weights
+            change. The ``TORCHRL_SGLANG_WEIGHT_SYNC_FLUSH_CACHE`` environment
+            variable, when set, overrides this in either direction.
 
     Example:
         >>> scheme = SGLangWeightSyncScheme(
@@ -620,6 +665,7 @@ class SGLangWeightSyncScheme(WeightSyncScheme):
         num_gpus: int = 1,
         strategy: Literal["tensordict", "state_dict"] = "tensordict",
         device: torch.device | str | int = 0,
+        flush_cache_on_update: bool = True,
     ):
         self.server_url = server_url.rstrip("/")
         self.master_address = master_address or get_local_ip_address()
@@ -627,6 +673,7 @@ class SGLangWeightSyncScheme(WeightSyncScheme):
         self.num_gpus = num_gpus
         self.strategy_name = strategy
         self.device = device
+        self.flush_cache_on_update = flush_cache_on_update
 
     @property
     def world_size(self) -> int:
@@ -642,6 +689,7 @@ class SGLangWeightSyncScheme(WeightSyncScheme):
             rank=0,
             world_size=self.world_size,
             device=self.device,
+            flush_cache_on_update=self.flush_cache_on_update,
         )
 
     def create_sender(self) -> SGLangWeightSender:

--- a/torchrl/weight_update/llm/vllm_double_buffer.py
+++ b/torchrl/weight_update/llm/vllm_double_buffer.py
@@ -355,6 +355,26 @@ class VLLMDoubleBufferWeightReceiver:
             model.load_weights(weights_list)
             logger.info("Weights loaded successfully")
 
+        # Prefix caches are keyed by prompt content, not by the weights that
+        # produced them; without a reset, entries cached before this load are
+        # reused with the new weights. Unlike the NCCL path there is no
+        # scheduling barrier here, so in-flight requests can keep the reset
+        # from fully clearing the cache; retry once and warn if it still
+        # cannot complete. AsyncVLLM's fan-out reset returns None and reports
+        # partial clears itself; a raw vllm.LLM returns False on failure.
+        reset = getattr(self._vllm_engine, "reset_prefix_cache", None)
+        if callable(reset):
+            result = reset()
+            if result is False:
+                result = reset()
+            if result is False:
+                logger.warning(
+                    "reset_prefix_cache could not fully clear the prefix cache "
+                    "after a double-buffer weight load (in-flight requests may "
+                    "still hold KV blocks); stale prefixes may persist until "
+                    "those requests complete."
+                )
+
     def poll_and_apply(self, timeout: float = 180.0) -> bool:
         """Poll for and apply weights from shared storage.
 

--- a/torchrl/weight_update/llm/vllm_nccl.py
+++ b/torchrl/weight_update/llm/vllm_nccl.py
@@ -360,6 +360,10 @@ class VLLMCollectiveTransport:
         ray.get(refs)
         torch.cuda.synchronize()
 
+        # Invalidate prefix caches before resuming scheduling: cached prefixes
+        # are keyed by prompt content and are stale now that weights changed.
+        self.vllm_engine.reset_prefix_cache()
+
         # Wake up vLLM engine after weight transfer
         wake_refs = []
         for actor in self.vllm_engine.actors:


### PR DESCRIPTION
## Motivation

Prefix caching was disabled for GRPO inference backends (#3809) because cached KV prefixes are keyed by prompt content, not by the weights that produced them: after an online weight update, cached prefixes are stale and corrupt behavior-policy logprobs. This PR restores prefix caching safely by invalidating the caches as part of every weight sync.

## Changes

- **[BugFix] Respect enable_prefix_caching in AsyncVLLM launch path** - opting in was silently broken: `AsyncVLLM.__init__` overwrote `engine_args.enable_prefix_caching` with its own `False` default and `launch()` never forwarded the flag, so `enable_prefix_caching=True` never reached the engine.
- **[Feature] Reset vLLM prefix caches on weight updates** - new `reset_prefix_cache()` on `_AsyncLLMEngine`, `AsyncVLLM` (fan-out over replicas, no-op when caching is disabled, warns when a replica cannot fully clear), `RayLLMWorker`, `LocalLLMWrapper`, and a no-op default on `RLvLLMEngine`. Invoked automatically in every weight-update path after weights land and before `wake_up`, so no request can be scheduled against a stale prefix.
- **[Feature] Flush SGLang radix cache on weight updates** - `flush_cache_on_update` on `SGLangWeightSyncScheme` defaults to auto: the flush is requested exactly when the pause mode is `abort`, the only mode under which SGLang (which flushes only when idle) can honor it. Explicit `True` requires `pause_mode="abort"` and raises otherwise; an env-forced flush under other pause modes is downgraded with a warning. `pause_mode` is now a scheme argument alongside the `TORCHRL_SGLANG_PAUSE_GENERATION_MODE` env var.
- **[BugFix] Keep MCAdvantage trajectories lazy when contiguous() drops entries** - found while validating: `TensorDict.contiguous()` silently turns stacked `NonTensorData` entries (the string prompts GRPO groups by) into empty TensorDicts, which broke grpo-async on gsm8k for single-turn trajectories. `_concrete_if_possible` now keeps the lazy input when materialization would lose entries; the per-step advantage path also handles same-length groups whose concatenated rewards come back strided. The underlying data-loss bug will be fixed in tensordict separately.
- **[Feature] Enable prefix caching in GRPO configs** - flips `enable_prefix_caching: false -> true` in the 6 GRPO yaml configs after validation.

## Validation

A/B on an H200 node, grpo-async gsm8k, Qwen2.5-1.5B, 3200 dialog turns per arm, two rounds (second round with weight syncs every 2 optim steps to stress the reset path):

| metric | off r1 | on r1 | off r2 | on r2 |
|---|---|---|---|---|
| reward (avg over run) | 0.050 | 0.029 | 0.026 | 0.034 |
| KL to inference (final) | 0.00029 | 0.00028 | 0.00039 | 0.00049 |
| gradient steps/s | 1.385 | 1.369 | 1.293 | 1.295 |
| automatic cache resets | 0 | 2 | 0 | 7 |

No stale-logprob signature (KL to the inference policy is indistinguishable from baseline even with frequent syncs), no reset refusals or warnings, rewards match within seed noise, throughput neutral on this training-dominated smoke. New unit tests cover the launch-path regression, the reset ordering/gating (mock-based, no GPU), the SGLang flush flag resolution, and the MCAdvantage NonTensor regression; the GPU updater suites now run with prefix caching enabled end-to-end.

## Full-scale run with caching enabled

Stock grpo-async gsm8k on Qwen2.5-3B (8xH200, 100k dialog turns, 3,125 optim batches, ~30 min wall clock) with the flipped config, on post-#1746 tensordict main ([W&B run](https://wandb.ai/vmoens/grpo-async/runs/k6atjz3c)). Reward 0.201 -> 0.532; 40 weight syncs, each followed by an automatic prefix-cache reset, none refused; zero errors.

![Mean trajectory reward, raw and EMA-smoothed, climbing from 0.201 to 0.532 over 3125 gradient steps](https://gist.githubusercontent.com/vmoens/81065db1113bc37b34676989d0225de6/raw/fig_reward.png)

KL to the inference policy stays at ~1e-4 across all 40 syncs (one transient self-recovering spike at step 830); throughput and sequence-length statistics are steady throughout:

![Run health panel: KL to inference policy on log scale flat at 1e-4, mean sequence length, gradient steps per second, and objective loss over training](https://gist.githubusercontent.com/vmoens/81065db1113bc37b34676989d0225de6/raw/fig_health.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
