### PR TITLE
[BugFix] Close Ray learner ranks concurrently

### DIFF
--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -104,38 +104,6 @@ class MismatchedCountingPolicy(CountingPolicy):
         self.unexpected = nn.Parameter(torch.ones(()))
 
 
-def test_private_ray_trainer_execution_closes_ranks_concurrently(monkeypatch):
-    calls = MagicMock()
-    actors = [MagicMock(), MagicMock()]
-    close_refs = [object(), object()]
-    ray_runtime = MagicMock()
-    for rank, (actor, close_ref) in enumerate(zip(actors, close_refs)):
-        actor.close.remote.return_value = close_ref
-        calls.attach_mock(actor.close.remote, f"close_rank_{rank}")
-    calls.attach_mock(ray_runtime.get, "get")
-    calls.attach_mock(ray_runtime.kill, "kill")
-    backend = object.__new__(_RayTrainerExecution)
-    backend._actors = actors
-    backend._placement_group = None
-    backend._runtime_lease = None
-    monkeypatch.setattr(
-        "torchrl.trainers._ray_execution.ray",
-        ray_runtime,
-        raising=False,
-    )
-
-    backend.shutdown(timeout=7.0)
-
-    assert calls.mock_calls == [
-        call.close_rank_0(),
-        call.close_rank_1(),
-        call.get(close_refs, timeout=7.0),
-        call.kill(actors[1], no_restart=True),
-        call.kill(actors[0], no_restart=True),
-    ]
-    assert backend._actors == []
-
-
 class ScalarRayLoss(LossModule):
     @dataclass
     class _AcceptedKeys:
@@ -286,6 +254,38 @@ def test_private_ddp_matches_global_batch_and_preserves_default_group():
     torch.testing.assert_close(torch.tensor(weights[1]), expected)
     assert not dist.is_initialized()
     del master_store
+
+
+def test_private_ray_trainer_execution_closes_ranks_concurrently(monkeypatch):
+    calls = MagicMock()
+    actors = [MagicMock(), MagicMock()]
+    close_refs = [object(), object()]
+    ray_runtime = MagicMock()
+    for rank, (actor, close_ref) in enumerate(zip(actors, close_refs)):
+        actor.close.remote.return_value = close_ref
+        calls.attach_mock(actor.close.remote, f"close_rank_{rank}")
+    calls.attach_mock(ray_runtime.wait, "wait")
+    calls.attach_mock(ray_runtime.kill, "kill")
+    backend = object.__new__(_RayTrainerExecution)
+    backend._actors = actors
+    backend._placement_group = None
+    backend._runtime_lease = None
+    monkeypatch.setattr(
+        "torchrl.trainers._ray_execution.ray",
+        ray_runtime,
+        raising=False,
+    )
+
+    backend.shutdown(timeout=7.0)
+
+    assert calls.mock_calls == [
+        call.close_rank_0(),
+        call.close_rank_1(),
+        call.wait(close_refs, num_returns=2, timeout=7.0),
+        call.kill(actors[1], no_restart=True),
+        call.kill(actors[0], no_restart=True),
+    ]
+    assert backend._actors == []
 
 
 class DistributedCollectorBase:

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -18,6 +18,7 @@ import time
 import traceback
 from dataclasses import dataclass
 from functools import partial
+from unittest.mock import call, MagicMock
 
 import pytest
 
@@ -101,6 +102,38 @@ class MismatchedCountingPolicy(CountingPolicy):
     def __init__(self):
         super().__init__()
         self.unexpected = nn.Parameter(torch.ones(()))
+
+
+def test_private_ray_trainer_execution_closes_ranks_concurrently(monkeypatch):
+    calls = MagicMock()
+    actors = [MagicMock(), MagicMock()]
+    close_refs = [object(), object()]
+    ray_runtime = MagicMock()
+    for rank, (actor, close_ref) in enumerate(zip(actors, close_refs)):
+        actor.close.remote.return_value = close_ref
+        calls.attach_mock(actor.close.remote, f"close_rank_{rank}")
+    calls.attach_mock(ray_runtime.get, "get")
+    calls.attach_mock(ray_runtime.kill, "kill")
+    backend = object.__new__(_RayTrainerExecution)
+    backend._actors = actors
+    backend._placement_group = None
+    backend._runtime_lease = None
+    monkeypatch.setattr(
+        "torchrl.trainers._ray_execution.ray",
+        ray_runtime,
+        raising=False,
+    )
+
+    backend.shutdown(timeout=7.0)
+
+    assert calls.mock_calls == [
+        call.close_rank_0(),
+        call.close_rank_1(),
+        call.get(close_refs, timeout=7.0),
+        call.kill(actors[1], no_restart=True),
+        call.kill(actors[0], no_restart=True),
+    ]
+    assert backend._actors == []
 
 
 class ScalarRayLoss(LossModule):

--- a/torchrl/trainers/_ray_execution.py
+++ b/torchrl/trainers/_ray_execution.py
@@ -525,8 +525,11 @@ class _RayTrainerExecution:
             with contextlib.suppress(Exception):
                 close_refs.append(actor.close.remote())
         if close_refs:
+            # ray.wait, unlike ray.get, does not abandon the remaining ranks
+            # when one rank's close raises, so every rank keeps its chance to
+            # finish process-group teardown before the kill pass below.
             with contextlib.suppress(Exception):
-                ray.get(close_refs, timeout=timeout)
+                ray.wait(close_refs, num_returns=len(close_refs), timeout=timeout)
         for actor in reversed(actors):
             with contextlib.suppress(Exception):
                 ray.kill(actor, no_restart=True)

--- a/torchrl/trainers/_ray_execution.py
+++ b/torchrl/trainers/_ray_execution.py
@@ -520,9 +520,14 @@ class _RayTrainerExecution:
     def shutdown(self, timeout: float | None = None) -> None:
         timeout = self.command_timeout if timeout is None else timeout
         actors, self._actors = self._actors, []
-        for actor in reversed(actors):
+        close_refs = []
+        for actor in actors:
             with contextlib.suppress(Exception):
-                ray.get(actor.close.remote(), timeout=timeout)
+                close_refs.append(actor.close.remote())
+        if close_refs:
+            with contextlib.suppress(Exception):
+                ray.get(close_refs, timeout=timeout)
+        for actor in reversed(actors):
             with contextlib.suppress(Exception):
                 ray.kill(actor, no_restart=True)
         if self._placement_group is not None:


### PR DESCRIPTION
## Summary
- launch close RPCs for every Ray learner rank before waiting for completion
- retain best-effort shutdown and actor cleanup behavior
- add focused regression coverage for close, wait, and kill ordering

## Root cause
Distributed process-group teardown may require all learner ranks to participate concurrently. Waiting for each actor's close RPC before launching the next rank's close can block the first rank until the command timeout.

## Validation
- `python -m pytest -q test/test_distributed.py::test_private_ray_trainer_execution_closes_ranks_concurrently`
- `python -m pytest -q test/test_distributed.py::TestRayCollector::test_private_ray_trainer_execution_uses_replay_clients`
- `pre-commit run --files torchrl/trainers/_ray_execution.py test/test_distributed.py`
