### PR TITLE
[BugFix] Bound direct off-policy replay collection

### DIFF
--- a/test/rb/test_rb_distributed.py
+++ b/test/rb/test_rb_distributed.py
@@ -10,6 +10,7 @@ import os
 import sys
 import time
 from functools import partial
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -18,8 +19,11 @@ import torch.multiprocessing as mp
 from _rb_common import _has_ray
 from tensordict import TensorDict
 from torchrl._utils import logger as torchrl_logger
-from torchrl.data import RayReplayBuffer, ReplayBuffer
-from torchrl.data.replay_buffers import RemoteTensorDictReplayBuffer
+from torchrl.data import RayReplayBuffer, ReplayBuffer, TensorDictReplayBuffer
+from torchrl.data.replay_buffers import (
+    ray_buffer as ray_buffer_module,
+    RemoteTensorDictReplayBuffer,
+)
 from torchrl.data.replay_buffers.samplers import (
     RandomSampler,
     SamplerWithoutReplacement,
@@ -42,6 +46,19 @@ class ReplayBufferNode(RemoteTensorDictReplayBuffer):
             writer=RoundRobinWriter(),
             collate_fn=lambda x: x,
         )
+
+
+class _RemoteResult:
+    def __init__(self, result):
+        self.result = result
+
+    def remote(self, *args, **kwargs):
+        return self.result
+
+
+class _RejectingRemoteResult:
+    def remote(self, *args, **kwargs):
+        raise AssertionError("A pre-bound transport used payload bootstrap.")
 
 
 def construct_buffer_test(rank, name, world_size):
@@ -293,6 +310,75 @@ class TestRayRB:
             assert not hasattr(client, "shutdown")
         finally:
             rb.shutdown()
+
+    def test_prebound_distributed_replay_skips_payload_bootstrap(self, monkeypatch):
+        extend_data = TensorDict({"value": torch.arange(8).reshape(8, 1)}, [8])
+        sample = TensorDict(
+            {
+                "value": torch.zeros(4, 1, dtype=torch.int64),
+                "index": torch.zeros(4, dtype=torch.int64),
+            },
+            [4],
+        )
+
+        def extend_endpoint(data, *, timeout=None):
+            assert data is extend_data
+            assert timeout == 30.0
+            return TensorDict({"result": torch.arange(8)}, [])
+
+        def sample_endpoint(request, *, timeout=None):
+            assert request["batch_size"].item() == 4
+            assert timeout == 30.0
+            return sample
+
+        actor = SimpleNamespace(
+            _distributed_control_client=_RemoteResult(object()),
+            _distributed_bound_extend_client=_RemoteResult(extend_endpoint),
+            _distributed_bound_sample_client=_RemoteResult((sample_endpoint, 4)),
+            _bootstrap_distributed_extend=_RejectingRemoteResult(),
+            _bootstrap_distributed_sample=_RejectingRemoteResult(),
+        )
+        monkeypatch.setattr(ray_buffer_module.ray, "get", lambda result: result)
+        monkeypatch.setattr(
+            ray_buffer_module,
+            "_set_ray_client_liveness",
+            lambda client, actor: None,
+        )
+        client = ray_buffer_module._LazyDistributedReplayClient(actor, batch_size=4)
+        assert client.extend(extend_data, timeout=30.0).shape == (8,)
+        assert client.sample(timeout=30.0) is sample
+
+    def test_ray_replay_with_prebound_gloo_transport(self):
+        extend_data = TensorDict({"value": torch.arange(8).reshape(8, 1)}, [8])
+        sample_spec = TensorDict(
+            {
+                "value": torch.zeros(4, 1, dtype=torch.int64),
+                "index": torch.zeros(4, dtype=torch.int64),
+            },
+            [4],
+        )
+        replay = TensorDictReplayBuffer(
+            storage=partial(LazyTensorStorage, 64),
+            batch_size=4,
+            service_backend="ray",
+            service_backend_options={"remote_config": {"num_cpus": 0}},
+            transport="distributed",
+            transport_options={
+                "backend": "gloo",
+                "timeout": 30.0,
+                "extend_spec": extend_data.clone().zero_(),
+                "sample_spec": sample_spec,
+            },
+        )
+        try:
+            writer = replay.client()
+            reader = replay.client()
+            assert writer.extend(extend_data).shape == (8,)
+            assert writer.write_count == 8
+            assert reader[0]["value"].item() == 0
+            assert reader.sample().shape == (4,)
+        finally:
+            replay.shutdown()
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/test/rb/test_rb_distributed.py
+++ b/test/rb/test_rb_distributed.py
@@ -375,7 +375,6 @@ class TestRayRB:
             reader = replay.client()
             assert writer.extend(extend_data).shape == (8,)
             assert writer.write_count == 8
-            assert reader[0]["value"].item() == 0
             assert reader.sample().shape == (4,)
         finally:
             replay.shutdown()

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -64,7 +64,7 @@ from torchrl.trainers._distributed import (
 )
 from torchrl.trainers._ray_execution import _RayTrainerExecution
 from torchrl.trainers.algorithms import DDPGTrainer, DQNTrainer, SACTrainer, TD3Trainer
-from torchrl.trainers.trainers import OptimizationStepper
+from torchrl.trainers.trainers import OptimizationStepper, Trainer
 
 _has_ray = importlib.util.find_spec("ray") is not None
 if _has_ray:
@@ -94,6 +94,12 @@ class CountingPolicy(TensorDictModuleBase):
 
     def forward(self, tensordict):
         tensordict.set("action", self.weight.expand(tensordict.shape).clone())
+        return tensordict
+
+
+class BatchedCountingPolicy(CountingPolicy):
+    def forward(self, tensordict):
+        tensordict.set("action", self.weight.expand(*tensordict.shape, 1).clone())
         return tensordict
 
 
@@ -135,6 +141,10 @@ class CountingTargetUpdater(TargetNetUpdater):
 
     def load_state_dict(self, state_dict):
         self.calls = state_dict["calls"]
+
+
+def flatten_batch(tensordict):
+    return tensordict.reshape(-1)
 
 
 class MultiOptimizerRayLoss(LossModule):
@@ -1412,6 +1422,114 @@ class TestRayCollector(DistributedCollectorBase):
             if collector is not None:
                 collector.shutdown()
             inference.shutdown()
+            replay.shutdown()
+
+    @pytest.mark.parametrize("flatten", [False, True])
+    def test_async_trainer_requires_transition_replay(self, flatten):
+        num_envs = 2
+        frames_per_batch = 8
+        total_frames = 16
+        replay = TensorDictReplayBuffer(
+            storage=partial(LazyTensorStorage, 100),
+            batch_size=2,
+            service_backend="ray",
+            service_backend_options={"remote_config": {"num_cpus": 0}},
+            transport="auto",
+        )
+        policy = BatchedCountingPolicy()
+        collector = RayCollector(
+            create_env_fn=[partial(CountingEnv, batch_size=[num_envs])],
+            policy=policy,
+            replay_buffer=replay,
+            collector_class=Collector,
+            collector_kwargs={"postproc": flatten_batch} if flatten else None,
+            frames_per_batch=frames_per_batch,
+            total_frames=total_frames,
+            remote_configs={"num_cpus": 1, "num_gpus": 0},
+            sync=True,
+        )
+        loss = ScalarRayLoss()
+        trainer_kwargs = {
+            "collector": collector,
+            "total_frames": total_frames,
+            "frame_skip": 1,
+            "optim_steps_per_batch": 1,
+            "loss_module": loss,
+            "optimizer": torch.optim.SGD(loss.parameters(), lr=0.1),
+            "replay_buffer": replay,
+            "async_collection": True,
+            "progress_bar": False,
+        }
+        if flatten:
+            trainer = Trainer(**trainer_kwargs)
+        else:
+            with pytest.warns(UserWarning, match="experimental"):
+                trainer = DQNTrainer(
+                    **trainer_kwargs,
+                    batch_size=2,
+                    target_net_updater=CountingTargetUpdater(loss),
+                    learner_backend="ray",
+                    learner_backend_options={
+                        "world_size": 2,
+                        "resources_per_rank": {"num_cpus": 1, "num_gpus": 0},
+                        "backend": "gloo",
+                        "setup_timeout": 60.0,
+                        "command_timeout": 60.0,
+                    },
+                    enable_logging=False,
+                )
+        try:
+            if not flatten:
+                with pytest.raises(RuntimeError, match="individual transitions"):
+                    trainer.train()
+                assert replay[0].shape == (frames_per_batch // num_envs,)
+                assert replay.write_count < collector.collected_frames
+                return
+
+            collector.update_policy_weights_(policy)
+            assert all(batch is None for batch in collector)
+            assert collector.collected_frames == total_frames
+            assert replay.write_count == total_frames
+            assert replay.sample().shape == (2,)
+            trainer._validate_transition_replay()
+            sentinel = object()
+            assert next(trainer._async_iterator(), sentinel) is sentinel
+        finally:
+            collector.shutdown()
+            replay.shutdown()
+
+    def test_async_ray_collector_does_not_write_unreserved_batches(self):
+        num_envs = 2
+        frames_per_batch = 4
+        total_frames = 16
+        replay = TensorDictReplayBuffer(
+            storage=partial(LazyTensorStorage, 100),
+            batch_size=2,
+            service_backend="ray",
+            service_backend_options={"remote_config": {"num_cpus": 0}},
+            transport="auto",
+        )
+        policy = BatchedCountingPolicy()
+        env_fn = partial(CountingEnv, batch_size=[num_envs])
+        collector = RayCollector(
+            create_env_fn=[env_fn, env_fn],
+            policy=policy,
+            replay_buffer=replay,
+            collector_class=Collector,
+            collector_kwargs={"postproc": flatten_batch},
+            frames_per_batch=frames_per_batch,
+            total_frames=total_frames,
+            remote_configs={"num_cpus": 1, "num_gpus": 0},
+            sync=False,
+        )
+        try:
+            collector.update_policy_weights_(policy)
+            assert all(batch is None for batch in collector)
+            assert collector.collected_frames == total_frames
+            assert replay.write_count == total_frames
+            assert replay.sample().shape == (2,)
+        finally:
+            collector.shutdown()
             replay.shutdown()
 
     def test_ray_collector_pause_drains_and_resumes(self):

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -64,7 +64,7 @@ from torchrl.trainers._distributed import (
 )
 from torchrl.trainers._ray_execution import _RayTrainerExecution
 from torchrl.trainers.algorithms import DDPGTrainer, DQNTrainer, SACTrainer, TD3Trainer
-from torchrl.trainers.trainers import OptimizationStepper, Trainer
+from torchrl.trainers.trainers import OptimizationStepper
 
 _has_ray = importlib.util.find_spec("ray") is not None
 if _has_ray:
@@ -1425,7 +1425,7 @@ class TestRayCollector(DistributedCollectorBase):
             replay.shutdown()
 
     @pytest.mark.parametrize("flatten", [False, True])
-    def test_async_trainer_requires_transition_replay(self, flatten):
+    def test_async_trainer_tracks_frames_independently_of_replay_shape(self, flatten):
         num_envs = 2
         frames_per_batch = 8
         total_frames = 16
@@ -1449,51 +1449,47 @@ class TestRayCollector(DistributedCollectorBase):
             sync=True,
         )
         loss = ScalarRayLoss()
-        trainer_kwargs = {
-            "collector": collector,
-            "total_frames": total_frames,
-            "frame_skip": 1,
-            "optim_steps_per_batch": 1,
-            "loss_module": loss,
-            "optimizer": torch.optim.SGD(loss.parameters(), lr=0.1),
-            "replay_buffer": replay,
-            "async_collection": True,
-            "progress_bar": False,
-        }
-        if flatten:
-            trainer = Trainer(**trainer_kwargs)
-        else:
-            with pytest.warns(UserWarning, match="experimental"):
-                trainer = DQNTrainer(
-                    **trainer_kwargs,
-                    batch_size=2,
-                    target_net_updater=CountingTargetUpdater(loss),
-                    learner_backend="ray",
-                    learner_backend_options={
-                        "world_size": 2,
-                        "resources_per_rank": {"num_cpus": 1, "num_gpus": 0},
-                        "backend": "gloo",
-                        "setup_timeout": 60.0,
-                        "command_timeout": 60.0,
-                    },
-                    enable_logging=False,
-                )
+        with pytest.warns(UserWarning, match="experimental"):
+            trainer = DQNTrainer(
+                collector=collector,
+                total_frames=total_frames,
+                frame_skip=1,
+                optim_steps_per_batch=1,
+                loss_module=loss,
+                optimizer=torch.optim.SGD(loss.parameters(), lr=0.1),
+                replay_buffer=replay,
+                async_collection=True,
+                progress_bar=False,
+                batch_size=2,
+                target_net_updater=CountingTargetUpdater(loss),
+                learner_backend="ray",
+                learner_backend_options={
+                    "world_size": 2,
+                    "resources_per_rank": {"num_cpus": 1, "num_gpus": 0},
+                    "backend": "gloo",
+                    "setup_timeout": 60.0,
+                    "command_timeout": 60.0,
+                },
+                enable_logging=False,
+            )
         try:
-            if not flatten:
-                with pytest.raises(RuntimeError, match="individual transitions"):
-                    trainer.train()
-                assert replay[0].shape == (frames_per_batch // num_envs,)
-                assert replay.write_count < collector.collected_frames
-                return
-
-            collector.update_policy_weights_(policy)
-            assert all(batch is None for batch in collector)
+            trainer.train()
+            assert trainer.collected_frames == total_frames
             assert collector.collected_frames == total_frames
-            assert replay.write_count == total_frames
-            assert replay.sample().shape == (2,)
-            trainer._validate_transition_replay()
-            sentinel = object()
-            assert next(trainer._async_iterator(), sentinel) is sentinel
+            assert trainer._optim_count > 0
+            assert trainer._published_model_version == trainer._optim_count
+            if flatten:
+                assert replay.write_count == total_frames
+                assert replay.sample().shape == (2,)
+            else:
+                assert replay.write_count == total_frames // (
+                    frames_per_batch // num_envs
+                )
+                assert replay[0].shape == (frames_per_batch // num_envs,)
+                assert replay.sample().shape == (
+                    2,
+                    frames_per_batch // num_envs,
+                )
         finally:
             collector.shutdown()
             replay.shutdown()

--- a/torchrl/collectors/distributed/ray.py
+++ b/torchrl/collectors/distributed/ray.py
@@ -1273,15 +1273,24 @@ class RayCollector(BaseCollector):
     def _async_iterator(self) -> Iterator[TensorDictBase]:
         """Collects a data batch from a single remote collector in each iteration."""
         pending_tasks = {}
+
+        def can_schedule() -> bool:
+            return self.total_frames < 0 or (
+                self.collected_frames + len(pending_tasks) * self.frames_per_batch
+                < self.total_frames
+            )
+
         for index, collector in enumerate(self.remote_collectors):
+            if not can_schedule():
+                break
             future = collector.next.remote()
             pending_tasks[future] = index
 
         while (
-            self.collected_frames < self.total_frames and not self._stop_event.is_set()
-        ):
-            if not len(list(pending_tasks.keys())) == len(self.remote_collectors):
-                raise RuntimeError("Missing pending tasks, something went wrong")
+            self.total_frames < 0 or self.collected_frames < self.total_frames
+        ) and not self._stop_event.is_set():
+            if not pending_tasks:
+                raise RuntimeError("No pending Ray collector tasks remain.")
 
             # Wait for first worker to finish
             wait_results = ray.wait(list(pending_tasks.keys()))
@@ -1305,13 +1314,17 @@ class RayCollector(BaseCollector):
                 torchrl_logger.debug(f"Updating weights on worker {collector_index}")
                 self.update_policy_weights_(worker_ids=collector_index)
 
-            # Schedule a new collection task
-            future = collector.next.remote()
-            pending_tasks[future] = collector_index
+            # Reserve in-flight batches against total_frames. Without this guard,
+            # every worker writes one extra direct-replay batch while the iterator
+            # drains pending actor calls after reaching the collection target.
+            if can_schedule():
+                future = collector.next.remote()
+                pending_tasks[future] = collector_index
 
         # Wait for the in-process collections tasks to finish.
         refs = list(pending_tasks.keys())
-        ray.wait(refs, num_returns=len(refs))
+        if refs:
+            ray.wait(refs, num_returns=len(refs))
 
         # Cancel the in-process collections tasks
         # for ref in refs:

--- a/torchrl/data/replay_buffers/ray_buffer.py
+++ b/torchrl/data/replay_buffers/ray_buffer.py
@@ -181,13 +181,19 @@ class _LazyDistributedReplayClient:
         return self._control_client(request, timeout=timeout)
 
     def extend(self, data: TensorDictBase, *, timeout: float | None = None):
+        handled = False
+        result = None
         if self._extend_client is None:
-            self._extend_client, result, handled = ray.get(
-                self._actor._bootstrap_distributed_extend.remote(data)
+            self._extend_client = ray.get(
+                self._actor._distributed_bound_extend_client.remote()
             )
+            if self._extend_client is None:
+                self._extend_client, result, handled = ray.get(
+                    self._actor._bootstrap_distributed_extend.remote(data)
+                )
             _set_ray_client_liveness(self._extend_client, self._actor)
-            if handled:
-                return result
+        if handled:
+            return result
         response = self._extend_client(data, timeout=timeout)
         return response.get("result", None)
 
@@ -202,26 +208,29 @@ class _LazyDistributedReplayClient:
             batch_size = self.batch_size
         if batch_size is None:
             raise RuntimeError("A sample batch size must be provided.")
+        handled = False
+        result = None
         if self._sample_client is None:
-            (
-                self._sample_client,
-                result,
-                handled,
-                self._sample_batch_size,
-            ) = ray.get(self._actor._bootstrap_distributed_sample.remote(batch_size))
-            _set_ray_client_liveness(self._sample_client, self._actor)
-            if batch_size != self._sample_batch_size:
-                raise ValueError(
-                    "The distributed replay schema is bound to sample batch size "
-                    f"{self._sample_batch_size}, got {batch_size}."
+            self._sample_client, self._sample_batch_size = ray.get(
+                self._actor._distributed_bound_sample_client.remote()
+            )
+            if self._sample_client is None:
+                (
+                    self._sample_client,
+                    result,
+                    handled,
+                    self._sample_batch_size,
+                ) = ray.get(
+                    self._actor._bootstrap_distributed_sample.remote(batch_size)
                 )
-            if handled:
-                return result
-        elif batch_size != self._sample_batch_size:
+            _set_ray_client_liveness(self._sample_client, self._actor)
+        if batch_size != self._sample_batch_size:
             raise ValueError(
                 "The distributed replay schema is bound to sample batch size "
                 f"{self._sample_batch_size}, got {batch_size}."
             )
+        if handled:
+            return result
         request = TensorDict(
             {
                 "batch_size": torch.tensor(
@@ -249,6 +258,9 @@ class _LazyDistributedReplayClient:
 
     def __len__(self) -> int:
         return int(self._stats()["size"].item())
+
+    def __getitem__(self, index):
+        return ray.get(self._actor.__getitem__.remote(index))
 
     def __getattr__(self, name: str):
         if name in {"start", "shutdown", "close", "client", "clients"}:

--- a/torchrl/data/replay_buffers/ray_buffer.py
+++ b/torchrl/data/replay_buffers/ray_buffer.py
@@ -259,9 +259,6 @@ class _LazyDistributedReplayClient:
     def __len__(self) -> int:
         return int(self._stats()["size"].item())
 
-    def __getitem__(self, index):
-        return ray.get(self._actor.__getitem__.remote(index))
-
     def __getattr__(self, name: str):
         if name in {"start", "shutdown", "close", "client", "clients"}:
             raise AttributeError(

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -610,6 +610,20 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
         """Return a restricted control endpoint for length and write count."""
         return self._distributed_service.control_client()
 
+    def _distributed_bound_extend_client(self):
+        """Return the pre-bound extend endpoint without transferring payload data."""
+        service = self._distributed_service
+        if service.extend_transport is None:
+            return None
+        return service.extend_client()
+
+    def _distributed_bound_sample_client(self):
+        """Return the pre-bound sample endpoint and its fixed batch size."""
+        service = self._distributed_service
+        if service.sample_transport is None:
+            return None, None
+        return service.sample_client(), service._sample_batch_size
+
     def _distributed_service_client(self):
         """Create an independently routed client for the private service."""
         service = getattr(self, "_distributed_service", None)

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -1360,11 +1360,10 @@ class Trainer:
 
         if self.async_collection:
             self.collector.start()
-            while self._replay_write_count() == 0:
+            while self._collector_frame_count() == 0:
                 time.sleep(0.1)
-            self._validate_transition_replay()
 
-            # Create async iterator that monitors write_count progress
+            # Create async iterator that monitors collection progress.
             iterator = self._async_iterator()
         else:
             iterator = self.collector
@@ -1382,10 +1381,10 @@ class Trainer:
                 )
                 self.collected_frames += current_frames
             else:
-                # In async mode, batch is None and we track frames via write_count
+                # In async mode, batch is None and the collector tracks frames.
                 batch = None
                 cf = self.collected_frames
-                self.collected_frames = self._replay_write_count()
+                self.collected_frames = self._collector_frame_count()
                 current_frames = self.collected_frames - cf
 
             # LOGGING POINT 1: Pre-optimization logging (e.g., rewards, frame counts)
@@ -1434,14 +1433,13 @@ class Trainer:
             self._setup_hook()
             setup_complete = True
 
-            previous_write_count = self._replay_write_count()
+            previous_collector_frames = self._collector_frame_count()
             if self.async_collection:
                 self.collector.start()
                 iterator = itertools.repeat(None)
             else:
                 iterator = iter(self.collector)
 
-            transition_replay_validated = False
             for batch in iterator:
                 previous_frames = self.collected_frames
                 if batch is not None:
@@ -1462,14 +1460,12 @@ class Trainer:
                     self.collected_frames += current_frames * self.frame_skip
                     self._pre_steps_log_hook(batch)
                 else:
-                    write_count = self._replay_write_count()
-                    current_frames = max(0, write_count - previous_write_count)
-                    previous_write_count = write_count
+                    collector_frames = self._collector_frame_count()
+                    current_frames = max(
+                        0, collector_frames - previous_collector_frames
+                    )
+                    previous_collector_frames = collector_frames
                     self.collected_frames += current_frames * self.frame_skip
-
-                if current_frames > 0 and not transition_replay_validated:
-                    self._validate_transition_replay()
-                    transition_replay_validated = True
 
                 if (
                     self.collected_frames
@@ -1587,32 +1583,24 @@ class Trainer:
             write_count = write_count()
         return int(write_count)
 
-    def _validate_transition_replay(self) -> None:
-        replay_buffer = self.replay_buffer
-        if replay_buffer is None or not len(replay_buffer):
-            return
-        replay_item = replay_buffer[0]
-        if isinstance(replay_item, TensorDictBase) and replay_item.ndim:
-            raise RuntimeError(
-                "Trainer expected direct replay to contain individual transitions, "
-                f"but one replay item has batch size {replay_item.batch_size}. "
-                "Flatten collector rollouts before insertion, for example with "
-                "collector_kwargs={'postproc': flatten_batch}, where flatten_batch "
-                "returns data.reshape(-1). Use a custom training loop when grouped "
-                "sequence replay is intentional."
-            )
+    def _collector_frame_count(self) -> int:
+        """Return collected transitions independently of replay item layout."""
+        collected_frames = getattr(self.collector, "collected_frames", None)
+        if collected_frames is None:
+            return self._replay_write_count()
+        return int(collected_frames)
 
     def _async_iterator(self):
-        """Create an iterator for async collection that monitors replay buffer write_count.
+        """Create an iterator that monitors asynchronous collector progress.
 
         This iterator yields None batches and terminates when total_frames is reached
-        based on the replay buffer's write_count rather than using a fixed range.
-        This ensures the training loop properly consumes the entire collector output.
+        based on the collector's frame count rather than using a fixed range. Replay
+        ``write_count`` is not a frame counter when one stored item is a sequence.
         """
         while True:
-            current_write_count = self._replay_write_count()
+            current_frames = self._collector_frame_count()
             # Check if we've reached the target frames
-            if current_write_count >= self.total_frames:
+            if current_frames >= self.total_frames:
                 break
             else:
                 yield None

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -1360,8 +1360,9 @@ class Trainer:
 
         if self.async_collection:
             self.collector.start()
-            while self.collector.getattr_rb("write_count") == 0:
+            while self._replay_write_count() == 0:
                 time.sleep(0.1)
+            self._validate_transition_replay()
 
             # Create async iterator that monitors write_count progress
             iterator = self._async_iterator()
@@ -1384,7 +1385,7 @@ class Trainer:
                 # In async mode, batch is None and we track frames via write_count
                 batch = None
                 cf = self.collected_frames
-                self.collected_frames = self.collector.getattr_rb("write_count")
+                self.collected_frames = self._replay_write_count()
                 current_frames = self.collected_frames - cf
 
             # LOGGING POINT 1: Pre-optimization logging (e.g., rewards, frame counts)
@@ -1440,6 +1441,7 @@ class Trainer:
             else:
                 iterator = iter(self.collector)
 
+            transition_replay_validated = False
             for batch in iterator:
                 previous_frames = self.collected_frames
                 if batch is not None:
@@ -1464,6 +1466,10 @@ class Trainer:
                     current_frames = max(0, write_count - previous_write_count)
                     previous_write_count = write_count
                     self.collected_frames += current_frames * self.frame_skip
+
+                if current_frames > 0 and not transition_replay_validated:
+                    self._validate_transition_replay()
+                    transition_replay_validated = True
 
                 if (
                     self.collected_frames
@@ -1573,10 +1579,28 @@ class Trainer:
         self._published_model_version = -1
 
     def _replay_write_count(self) -> int:
-        write_count = self.replay_buffer.write_count
+        replay_buffer = self.replay_buffer
+        if replay_buffer is None:
+            return int(self.collector.getattr_rb("write_count"))
+        write_count = replay_buffer.write_count
         if callable(write_count):
             write_count = write_count()
         return int(write_count)
+
+    def _validate_transition_replay(self) -> None:
+        replay_buffer = self.replay_buffer
+        if replay_buffer is None or not len(replay_buffer):
+            return
+        replay_item = replay_buffer[0]
+        if isinstance(replay_item, TensorDictBase) and replay_item.ndim:
+            raise RuntimeError(
+                "Trainer expected direct replay to contain individual transitions, "
+                f"but one replay item has batch size {replay_item.batch_size}. "
+                "Flatten collector rollouts before insertion, for example with "
+                "collector_kwargs={'postproc': flatten_batch}, where flatten_batch "
+                "returns data.reshape(-1). Use a custom training loop when grouped "
+                "sequence replay is intentional."
+            )
 
     def _async_iterator(self):
         """Create an iterator for async collection that monitors replay buffer write_count.
@@ -1586,7 +1610,7 @@ class Trainer:
         This ensures the training loop properly consumes the entire collector output.
         """
         while True:
-            current_write_count = self.collector.getattr_rb("write_count")
+            current_write_count = self._replay_write_count()
             # Check if we've reached the target frames
             if current_write_count >= self.total_frames:
                 break


### PR DESCRIPTION
## Summary

- reserve asynchronous Ray collector batches against `total_frames` before launching actor calls, preventing direct replay writes after the collection target
- track asynchronous Trainer progress with the collector's transition count instead of replay `write_count`, preserving multidimensional replay items
- connect lazy distributed replay clients to explicitly pre-bound extend and sample endpoints before falling back to payload bootstrap
- retain explicit `[B, T] -> [B * T]` collector postprocessing for standard feed-forward off-policy workloads without imposing that layout on general replay usage

## Root causes

### Frame accounting versus replay item accounting

A vectorized collector can emit a rollout with batch shape `[num_envs, time]`. A replay buffer may intentionally store that rollout as `num_envs` sequence items, or a workload may flatten it into `num_envs * time` transition items before insertion. Both layouts are valid.

Replay `write_count` counts stored items, so it is not necessarily a transition counter. Using it to drive Trainer progress made collection accounting depend on replay layout: grouped sequence storage advanced `write_count` by `num_envs` while the collector had produced `num_envs * time` transitions.

The Trainer now uses `collector.collected_frames` for asynchronous progress and termination. Replay `write_count` retains its normal item-count semantics. Regression coverage runs the same Ray Trainer with both grouped `[N, T]` samples and flat `[N]` samples and verifies that each completes at the same collected-frame target.

DQN, SAC, DDPG, and TD3 in the validation suite still explicitly flatten collector rollouts before direct insertion because those particular workloads use transition replay. That policy remains in the workload configuration rather than the generic Trainer.

### In-flight collection

The asynchronous iterator previously launched one replacement task after every completed batch. Once the target was reached, it waited for the remaining tasks to finish. Direct-replay collectors write inside those actor calls, so every in-flight call completed an extra replay insertion even though its result was never yielded.

The iterator now includes in-flight batches when deciding whether another actor call can be scheduled. This bounds both collected frames and direct replay writes without constraining the shape of each stored replay item.

### Pre-bound distributed transport

When `extend_spec` and `sample_spec` are supplied, the replay owner establishes the distributed payload endpoints during startup. The lazy client nevertheless used the first extend payload and first sampled result to call the Ray bootstrap methods. The actor did not need those payloads once the schemas were bound, but Ray had already serialized and transferred them.

The lazy client now asks the owner for an existing endpoint first. It retains first-use payload bootstrap as the fallback when no explicit schema was supplied. This keeps dynamic schemas working while avoiding a full Ray transfer of the initial large collector and learner batches.

## Tests

- `python -m pytest -q test/rb/test_rb_distributed.py::TestRayRB::test_prebound_distributed_replay_skips_payload_bootstrap test/rb/test_rb_distributed.py::TestRayRB::test_ray_replay_with_prebound_gloo_transport test/rb/test_rb_distributed.py::TestRayRB::test_ray_replay_with_gloo_transport test/test_distributed.py::TestRayCollector::test_async_ray_collector_does_not_write_unreserved_batches test/test_distributed.py::TestRayCollector::test_async_trainer_tracks_frames_independently_of_replay_shape test/test_distributed.py::TestRayCollector::test_dqn_trainer_ray_backend test/test_distributed.py::TestRayCollector::test_offpolicy_trainer_ray_backend test/test_distributed.py::TestRayCollector::test_ray_collector_pause_drains_and_resumes test/test_distributed.py::TestRayCollector::test_distributed_collector_sync` (13 passed)
- `pre-commit run --files torchrl/collectors/distributed/ray.py torchrl/data/replay_buffers/ray_buffer.py torchrl/data/replay_buffers/replay_buffers.py torchrl/trainers/trainers.py test/rb/test_rb_distributed.py test/test_distributed.py`
- 100K-environment SAC validation completed 1,000,000 exact replay writes with flat transition samples after the pre-bound endpoint change
