### PR TITLE
[CI] Stabilize PR benchmark measurements

### DIFF
--- a/.github/scripts/comment_pr_benchmarks.py
+++ b/.github/scripts/comment_pr_benchmarks.py
@@ -23,6 +23,9 @@ def _benchmark_name(benchmark: dict) -> str:
 
 def _benchmark_ops(benchmark: dict) -> float | None:
     stats = benchmark.get("stats", {})
+    median = stats.get("median")
+    if median is not None and float(median) > 0:
+        return 1.0 / float(median)
     ops = stats.get("ops")
     if ops is not None:
         return float(ops)
@@ -72,7 +75,6 @@ def _collect_results(root: Path) -> list[dict]:
 
 
 def _comparison_rows(result: dict) -> list[dict]:
-    confirmed_benchmarks = set(result["metadata"].get("confirmed_benchmarks", []))
     baseline = {
         _benchmark_name(benchmark): benchmark
         for benchmark in result["baseline"].get("benchmarks", [])
@@ -94,7 +96,6 @@ def _comparison_rows(result: dict) -> list[dict]:
                 "baseline_ops": baseline_ops,
                 "contender_ops": contender_ops,
                 "change": change,
-                "confirmed": name in confirmed_benchmarks,
             }
         )
     return rows
@@ -103,22 +104,21 @@ def _comparison_rows(result: dict) -> list[dict]:
 def _table(rows: list[dict], max_rows: int) -> list[str]:
     selected = sorted(rows, key=lambda row: abs(row["change"]), reverse=True)[:max_rows]
     lines = [
-        "| Benchmark | main ops | PR ops | Change | Measurement |",
-        "| --- | ---: | ---: | ---: | --- |",
+        "| Benchmark | main ops | PR ops | Change |",
+        "| --- | ---: | ---: | ---: |",
     ]
     for row in selected:
         lines.append(
-            "| `{}` | {} | {} | {} | {} |".format(
+            "| `{}` | {} | {} | {} |".format(
                 _truncate(row["name"]),
                 _format_number(row["baseline_ops"]),
                 _format_number(row["contender_ops"]),
                 _format_percent(row["change"]),
-                "same runner" if row["confirmed"] else "parallel",
             )
         )
     if len(rows) > max_rows:
         lines.append(
-            f"| ... | ... | ... | ... | Showing {max_rows} of {len(rows)} "
+            f"| ... | ... | ... | Showing {max_rows} of {len(rows)} "
             "comparisons, sorted by absolute change. |"
         )
     return lines
@@ -130,7 +130,6 @@ def _device_section(result: dict, max_rows: int) -> list[str]:
     reporting_threshold = float(metadata.get("reporting_threshold_pct", 5.0))
     regressions = sum(row["change"] <= -reporting_threshold for row in rows)
     improvements = sum(row["change"] >= reporting_threshold for row in rows)
-    confirmations = sum(row["confirmed"] for row in rows)
     device = metadata["device"]
     lines = [
         f"#### {device}",
@@ -138,7 +137,7 @@ def _device_section(result: dict, max_rows: int) -> list[str]:
         f"Compared {len(rows)} benchmarks. Regressions over "
         f"{reporting_threshold:g}%: {regressions}. Improvements over "
         f"{reporting_threshold:g}%: {improvements}.",
-        f"Sequential same-runner confirmations: {confirmations}.",
+        "Each revision was measured once on a separate pinned runner.",
         "",
     ]
     lines.extend(_table(rows, max_rows))
@@ -164,7 +163,8 @@ def build_comment(results: list[dict], run_url: str) -> tuple[int, str]:
             "",
             f"Benchmark run: {run_url}",
             "",
-            "Higher ops/sec is better. Tables are sorted by largest absolute change.",
+            "Rates use inverse median round duration; higher is better. Tables are "
+            "sorted by largest absolute change.",
             "",
         ]
         for result in sorted(results, key=lambda item: item["metadata"]["device"]):

--- a/.github/scripts/compare_pr_benchmarks.py
+++ b/.github/scripts/compare_pr_benchmarks.py
@@ -30,14 +30,11 @@ def _load_json(path: Path) -> dict:
         return json.load(file)
 
 
-def _write_json(path: Path, value: object, *, compact: bool = False) -> None:
+def _write_json(path: Path, value: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as file:
-        if compact:
-            json.dump(value, file, separators=(",", ":"), sort_keys=True)
-        else:
-            json.dump(value, file, indent=2, sort_keys=True)
-            file.write("\n")
+        json.dump(value, file, indent=2, sort_keys=True)
+        file.write("\n")
 
 
 def _benchmark_name(benchmark: dict) -> str:
@@ -45,7 +42,11 @@ def _benchmark_name(benchmark: dict) -> str:
 
 
 def _benchmark_ops(benchmark: dict) -> float | None:
+    """Return a rate based on the robust per-round duration statistic."""
     stats = benchmark.get("stats", {})
+    median = stats.get("median")
+    if median is not None and float(median) > 0:
+        return 1.0 / float(median)
     ops = stats.get("ops")
     if ops is not None:
         return float(ops)
@@ -80,16 +81,6 @@ def comparison_rows(baseline: dict, contender: dict) -> list[dict]:
             }
         )
     return rows
-
-
-def needs_confirmation(
-    change: float, reporting_threshold: float, threshold_margin: float
-) -> bool:
-    significant_regression = change <= -reporting_threshold
-    near_reporting_threshold = (
-        abs(abs(change) - reporting_threshold) <= threshold_margin
-    )
-    return significant_regression or near_reporting_threshold
 
 
 def _device_directories(raw_root: Path) -> list[Path]:
@@ -138,75 +129,6 @@ def _load_raw_pair(device_dir: Path) -> tuple[dict, dict, dict, dict]:
     return baseline, contender, baseline_metadata, contender_metadata
 
 
-def create_confirmation_plan(
-    raw_root: Path,
-    plan_root: Path,
-    matrix_output: Path,
-    image_by_device: dict[str, str],
-    reporting_threshold: float,
-    threshold_margin: float,
-) -> dict:
-    device_dirs = _device_directories(raw_root)
-    if not device_dirs:
-        raise RuntimeError(f"No raw benchmark pairs were found under {raw_root}.")
-
-    matrix = {"include": []}
-    for device_dir in device_dirs:
-        baseline, contender, baseline_metadata, _ = _load_raw_pair(device_dir)
-        device = baseline_metadata["device"]
-        if device not in image_by_device:
-            raise RuntimeError(f"No pinned container image was supplied for {device}.")
-        if baseline_metadata["image"] != image_by_device[device]:
-            raise RuntimeError(
-                f"{device} used {baseline_metadata['image']}, not the pinned image "
-                f"{image_by_device[device]}."
-            )
-        rows = comparison_rows(baseline, contender)
-        if not rows:
-            raise RuntimeError(f"No comparable {device} benchmarks were found.")
-        candidates = [
-            row
-            for row in rows
-            if needs_confirmation(row["change"], reporting_threshold, threshold_margin)
-        ]
-        plan = {
-            "device": device,
-            "image": image_by_device[device],
-            "reporting_threshold_pct": reporting_threshold,
-            "threshold_margin_pct": threshold_margin,
-            "nodeids": [row["name"] for row in candidates],
-            "pytest_nodeids": [
-                row["name"].removeprefix("benchmark-definitions/benchmarks/")
-                for row in candidates
-            ],
-            "initial_changes": {row["name"]: row["change"] for row in candidates},
-        }
-        _write_json(plan_root / f"{device}.json", plan)
-        if candidates:
-            matrix["include"].append(
-                {"device": device, "image": image_by_device[device]}
-            )
-    _write_json(matrix_output, matrix, compact=True)
-    return matrix
-
-
-def _merge_confirmed(document: dict, confirmed: dict, names: set[str]) -> dict:
-    confirmed_by_name = _benchmark_map(confirmed)
-    missing = names - set(confirmed_by_name)
-    if missing:
-        raise RuntimeError(
-            "Confirmation output is missing benchmarks: " + ", ".join(sorted(missing))
-        )
-    merged = dict(document)
-    merged["benchmarks"] = [
-        confirmed_by_name.get(_benchmark_name(benchmark), benchmark)
-        if _benchmark_name(benchmark) in names
-        else benchmark
-        for benchmark in document.get("benchmarks", [])
-    ]
-    return merged
-
-
 def _format_number(value: float) -> str:
     if not math.isfinite(value):
         return "n/a"
@@ -218,10 +140,7 @@ def _format_number(value: float) -> str:
 
 
 def _summary_section(
-    device: str,
-    rows: list[dict],
-    confirmed_names: set[str],
-    reporting_threshold: float,
+    device: str, rows: list[dict], reporting_threshold: float
 ) -> list[str]:
     regressions = sum(row["change"] <= -reporting_threshold for row in rows)
     improvements = sum(row["change"] >= reporting_threshold for row in rows)
@@ -230,32 +149,34 @@ def _summary_section(
         "",
         f"Compared {len(rows)} benchmarks: {regressions} regressions and "
         f"{improvements} improvements at the {reporting_threshold:g}% threshold. "
-        f"Replaced {len(confirmed_names)} parallel measurements with sequential "
-        "same-runner confirmations.",
+        "Each revision was measured once on a separate pinned runner.",
         "",
-        "| Benchmark | Baseline ops | PR ops | Change | Measurement |",
-        "| --- | ---: | ---: | ---: | --- |",
+        "| Benchmark | Baseline ops | PR ops | Change |",
+        "| --- | ---: | ---: | ---: |",
     ]
     selected = sorted(rows, key=lambda row: abs(row["change"]), reverse=True)[:50]
     for row in selected:
-        measurement = "same runner" if row["name"] in confirmed_names else "parallel"
         lines.append(
             f"| `{row['name']}` | {_format_number(row['baseline_ops'])} | "
-            f"{_format_number(row['contender_ops'])} | {row['change']:+.2f}% | "
-            f"{measurement} |"
+            f"{_format_number(row['contender_ops'])} | {row['change']:+.2f}% |"
         )
     lines.append("")
     return lines
 
 
-def finalize_results(
+def compare_results(
     raw_root: Path,
-    plan_root: Path,
-    confirmation_root: Path,
     output_root: Path,
     summary_path: Path,
+    image_by_device: dict[str, str],
+    reporting_threshold: float,
 ) -> None:
-    summary_lines = ["## Final PR benchmark comparison", ""]
+    summary_lines = [
+        "## PR benchmark comparison",
+        "",
+        "Rates use inverse median round duration to limit isolated-stall bias.",
+        "",
+    ]
     device_dirs = _device_directories(raw_root)
     if not device_dirs:
         raise RuntimeError(f"No raw benchmark pairs were found under {raw_root}.")
@@ -263,24 +184,21 @@ def finalize_results(
     for device_dir in device_dirs:
         baseline, contender, baseline_metadata, _ = _load_raw_pair(device_dir)
         device = baseline_metadata["device"]
-        plan = _load_json(plan_root / f"{device}.json")
-        confirmed_names = set(plan["nodeids"])
-        if confirmed_names:
-            confirmation_dir = confirmation_root / device
-            confirmed_baseline = _load_json(confirmation_dir / "baseline.json")
-            confirmed_contender = _load_json(confirmation_dir / "contender.json")
-            baseline = _merge_confirmed(baseline, confirmed_baseline, confirmed_names)
-            contender = _merge_confirmed(
-                contender, confirmed_contender, confirmed_names
+        expected_image = image_by_device.get(device)
+        if expected_image is None:
+            raise RuntimeError(f"No pinned container image was supplied for {device}.")
+        if baseline_metadata["image"] != expected_image:
+            raise RuntimeError(
+                f"{device} used {baseline_metadata['image']}, not the pinned image "
+                f"{expected_image}."
             )
 
         rows = comparison_rows(baseline, contender)
+        if not rows:
+            raise RuntimeError(f"No comparable {device} benchmarks were found.")
         for row in rows:
-            row["measurement"] = (
-                "same-runner-confirmation"
-                if row["name"] in confirmed_names
-                else "parallel-runners"
-            )
+            row["measurement"] = "separate-pinned-runners"
+
         output_dir = output_root / device
         metadata = {
             key: value
@@ -289,24 +207,16 @@ def finalize_results(
         }
         metadata.update(
             {
-                "confirmed_benchmarks": sorted(confirmed_names),
-                "reporting_threshold_pct": plan["reporting_threshold_pct"],
-                "threshold_margin_pct": plan["threshold_margin_pct"],
-                "confirmation_order": ["baseline", "contender"],
+                "comparison_statistic": "median duration",
+                "measurements_per_revision": 1,
+                "reporting_threshold_pct": reporting_threshold,
             }
         )
         _write_json(output_dir / "baseline.json", baseline)
         _write_json(output_dir / "contender.json", contender)
         _write_json(output_dir / "metadata.json", metadata)
         _write_json(output_dir / "comparison.json", {"benchmarks": rows})
-        summary_lines.extend(
-            _summary_section(
-                device,
-                rows,
-                confirmed_names,
-                float(plan["reporting_threshold_pct"]),
-            )
-        )
+        summary_lines.extend(_summary_section(device, rows, reporting_threshold))
 
     summary_path.parent.mkdir(parents=True, exist_ok=True)
     summary_path.write_text("\n".join(summary_lines), encoding="utf-8")
@@ -324,41 +234,19 @@ def _image_mapping(values: list[str]) -> dict[str, str]:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers(dest="command", required=True)
-
-    plan_parser = subparsers.add_parser("plan")
-    plan_parser.add_argument("--raw-root", required=True, type=Path)
-    plan_parser.add_argument("--plan-root", required=True, type=Path)
-    plan_parser.add_argument("--matrix-output", required=True, type=Path)
-    plan_parser.add_argument("--image", action="append", required=True)
-    plan_parser.add_argument("--reporting-threshold", type=float, default=5.0)
-    plan_parser.add_argument("--threshold-margin", type=float, default=2.0)
-
-    finalize_parser = subparsers.add_parser("finalize")
-    finalize_parser.add_argument("--raw-root", required=True, type=Path)
-    finalize_parser.add_argument("--plan-root", required=True, type=Path)
-    finalize_parser.add_argument("--confirmation-root", required=True, type=Path)
-    finalize_parser.add_argument("--output-root", required=True, type=Path)
-    finalize_parser.add_argument("--summary", required=True, type=Path)
-
+    parser.add_argument("--raw-root", required=True, type=Path)
+    parser.add_argument("--output-root", required=True, type=Path)
+    parser.add_argument("--summary", required=True, type=Path)
+    parser.add_argument("--image", action="append", required=True)
+    parser.add_argument("--reporting-threshold", type=float, default=5.0)
     args = parser.parse_args()
-    if args.command == "plan":
-        create_confirmation_plan(
-            raw_root=args.raw_root,
-            plan_root=args.plan_root,
-            matrix_output=args.matrix_output,
-            image_by_device=_image_mapping(args.image),
-            reporting_threshold=args.reporting_threshold,
-            threshold_margin=args.threshold_margin,
-        )
-    else:
-        finalize_results(
-            raw_root=args.raw_root,
-            plan_root=args.plan_root,
-            confirmation_root=args.confirmation_root,
-            output_root=args.output_root,
-            summary_path=args.summary,
-        )
+    compare_results(
+        raw_root=args.raw_root,
+        output_root=args.output_root,
+        summary_path=args.summary,
+        image_by_device=_image_mapping(args.image),
+        reporting_threshold=args.reporting_threshold,
+    )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_pr_benchmark_workflow.py
+++ b/.github/scripts/test_pr_benchmark_workflow.py
@@ -24,11 +24,18 @@ comparison = _load_script("compare_pr_benchmarks.py")
 comments = _load_script("comment_pr_benchmarks.py")
 
 
-def _document(ops_by_name: dict[str, float]) -> dict:
+def _document(durations_by_name: dict[str, float]) -> dict:
     return {
         "benchmarks": [
-            {"fullname": name, "stats": {"ops": ops}}
-            for name, ops in ops_by_name.items()
+            {
+                "fullname": name,
+                "stats": {
+                    "mean": duration,
+                    "median": duration,
+                    "ops": 1.0 / duration,
+                },
+            }
+            for name, duration in durations_by_name.items()
         ]
     }
 
@@ -62,9 +69,8 @@ def _write_raw_pair(root: Path) -> None:
         json.dumps(
             _document(
                 {
-                    "test_bench.py::test_regression": 100.0,
-                    "test_bench.py::test_near_threshold": 100.0,
-                    "test_bench.py::test_clear_improvement": 100.0,
+                    "test_bench.py::test_regression": 0.010,
+                    "test_bench.py::test_improvement": 0.010,
                 }
             )
         ),
@@ -74,9 +80,8 @@ def _write_raw_pair(root: Path) -> None:
         json.dumps(
             _document(
                 {
-                    "test_bench.py::test_regression": 90.0,
-                    "test_bench.py::test_near_threshold": 104.0,
-                    "test_bench.py::test_clear_improvement": 108.0,
+                    "test_bench.py::test_regression": 1.0 / 90.0,
+                    "test_bench.py::test_improvement": 1.0 / 108.0,
                 }
             )
         ),
@@ -88,86 +93,61 @@ def _write_raw_pair(root: Path) -> None:
         )
 
 
-@pytest.mark.parametrize(
-    ("change", "expected"),
-    [(-20.0, True), (-8.0, True), (-4.0, True), (4.0, True), (8.0, False)],
-)
-def test_confirmation_selection(change, expected):
-    assert comparison.needs_confirmation(change, 5.0, 2.0) is expected
+def test_comparison_prefers_median_over_mean_and_ops():
+    baseline = {
+        "benchmarks": [
+            {
+                "fullname": "test_bench.py::test_stall",
+                "stats": {"median": 1.0, "mean": 1.0, "ops": 1.0},
+            }
+        ]
+    }
+    contender = {
+        "benchmarks": [
+            {
+                "fullname": "test_bench.py::test_stall",
+                "stats": {"median": 1.0, "mean": 10.0, "ops": 0.1},
+            }
+        ]
+    }
+
+    [row] = comparison.comparison_rows(baseline, contender)
+    assert row["baseline_ops"] == pytest.approx(1.0)
+    assert row["contender_ops"] == pytest.approx(1.0)
+    assert row["change"] == pytest.approx(0.0)
 
 
-def test_plan_and_finalize_replace_only_confirmed_results(tmp_path):
+def test_compare_writes_single_measurement_results(tmp_path):
     raw_root = tmp_path / "raw"
-    plan_root = tmp_path / "plan"
-    confirmation_root = tmp_path / "confirmation"
     output_root = tmp_path / "output"
+    summary_path = tmp_path / "summary.md"
     _write_raw_pair(raw_root)
 
-    matrix = comparison.create_confirmation_plan(
+    comparison.compare_results(
         raw_root,
-        plan_root,
-        tmp_path / "matrix.json",
+        output_root,
+        summary_path,
         {"CPU": "pinned-image"},
         reporting_threshold=5.0,
-        threshold_margin=2.0,
-    )
-    assert matrix == {"include": [{"device": "CPU", "image": "pinned-image"}]}
-    plan = json.loads((plan_root / "CPU.json").read_text(encoding="utf-8"))
-    assert set(plan["nodeids"]) == {
-        "test_bench.py::test_regression",
-        "test_bench.py::test_near_threshold",
-    }
-    assert set(plan["pytest_nodeids"]) == set(plan["nodeids"])
-
-    confirmation_device = confirmation_root / "CPU"
-    confirmation_device.mkdir(parents=True)
-    (confirmation_device / "baseline.json").write_text(
-        json.dumps(
-            _document(
-                {
-                    "test_bench.py::test_regression": 100.0,
-                    "test_bench.py::test_near_threshold": 100.0,
-                }
-            )
-        ),
-        encoding="utf-8",
-    )
-    (confirmation_device / "contender.json").write_text(
-        json.dumps(
-            _document(
-                {
-                    "test_bench.py::test_regression": 98.0,
-                    "test_bench.py::test_near_threshold": 106.0,
-                }
-            )
-        ),
-        encoding="utf-8",
     )
 
-    comparison.finalize_results(
-        raw_root,
-        plan_root,
-        confirmation_root,
-        output_root,
-        tmp_path / "summary.md",
-    )
     result = json.loads(
         (output_root / "CPU" / "comparison.json").read_text(encoding="utf-8")
     )
     rows = {row["name"]: row for row in result["benchmarks"]}
-    assert rows["test_bench.py::test_regression"]["change"] == pytest.approx(-2.0)
-    assert rows["test_bench.py::test_near_threshold"]["change"] == pytest.approx(6.0)
-    assert rows["test_bench.py::test_clear_improvement"]["change"] == pytest.approx(8.0)
-    assert rows["test_bench.py::test_regression"]["measurement"] == (
-        "same-runner-confirmation"
-    )
-    assert rows["test_bench.py::test_clear_improvement"]["measurement"] == (
-        "parallel-runners"
-    )
+    assert rows["test_bench.py::test_regression"]["change"] == pytest.approx(-10.0)
+    assert rows["test_bench.py::test_improvement"]["change"] == pytest.approx(8.0)
+    assert {row["measurement"] for row in rows.values()} == {"separate-pinned-runners"}
 
     final_metadata = json.loads(
         (output_root / "CPU" / "metadata.json").read_text(encoding="utf-8")
     )
+    assert final_metadata["comparison_statistic"] == "median duration"
+    assert final_metadata["measurements_per_revision"] == 1
+    assert "confirmed_benchmarks" not in final_metadata
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "once on a separate pinned runner" in summary
+
     _, body = comments.build_comment(
         [
             {
@@ -182,43 +162,12 @@ def test_plan_and_finalize_replace_only_confirmed_results(tmp_path):
         ],
         "https://example.com/run",
     )
-    assert "Sequential same-runner confirmations: 2." in body
-    assert "same runner" in body
+    assert "once on a separate pinned runner" in body
+    assert "inverse median round duration" in body
+    assert "same runner" not in body
 
 
-def test_plan_uses_nodeids_relative_to_benchmark_working_directory(tmp_path):
-    raw_root = tmp_path / "raw"
-    _write_raw_pair(raw_root)
-    for revision in ("baseline", "contender"):
-        result_path = raw_root / "CPU" / f"{revision}.json"
-        result = json.loads(result_path.read_text(encoding="utf-8"))
-        for benchmark in result["benchmarks"]:
-            benchmark["fullname"] = (
-                "benchmark-definitions/benchmarks/" + benchmark["fullname"]
-            )
-        result_path.write_text(json.dumps(result), encoding="utf-8")
-
-    comparison.create_confirmation_plan(
-        raw_root,
-        tmp_path / "plan",
-        tmp_path / "matrix.json",
-        {"CPU": "pinned-image"},
-        reporting_threshold=5.0,
-        threshold_margin=2.0,
-    )
-
-    plan = json.loads((tmp_path / "plan" / "CPU.json").read_text(encoding="utf-8"))
-    assert all(
-        nodeid.startswith("benchmark-definitions/benchmarks/")
-        for nodeid in plan["nodeids"]
-    )
-    assert all(
-        not nodeid.startswith("benchmark-definitions/benchmarks/")
-        for nodeid in plan["pytest_nodeids"]
-    )
-
-
-def test_plan_rejects_mismatched_environments(tmp_path):
+def test_compare_rejects_mismatched_environments(tmp_path):
     raw_root = tmp_path / "raw"
     _write_raw_pair(raw_root)
     metadata_path = raw_root / "CPU" / "contender-metadata.json"
@@ -227,14 +176,42 @@ def test_plan_rejects_mismatched_environments(tmp_path):
     metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
 
     with pytest.raises(RuntimeError, match="metadata differs for image"):
-        comparison.create_confirmation_plan(
+        comparison.compare_results(
             raw_root,
-            tmp_path / "plan",
-            tmp_path / "matrix.json",
+            tmp_path / "output",
+            tmp_path / "summary.md",
             {"CPU": "pinned-image"},
             reporting_threshold=5.0,
-            threshold_margin=2.0,
         )
+
+
+def test_compare_rejects_unpinned_image(tmp_path):
+    raw_root = tmp_path / "raw"
+    _write_raw_pair(raw_root)
+
+    with pytest.raises(RuntimeError, match="not the pinned image"):
+        comparison.compare_results(
+            raw_root,
+            tmp_path / "output",
+            tmp_path / "summary.md",
+            {"CPU": "different-image"},
+            reporting_threshold=5.0,
+        )
+
+
+def test_workflow_runs_only_four_primary_measurements():
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "benchmarks_pr.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert workflow.count("          - device: CPU") == 2
+    assert workflow.count("          - device: GPU") == 2
+    assert workflow.count("            revision: baseline") == 2
+    assert workflow.count("            revision: contender") == 2
+    assert "\n  confirmation:" not in workflow
+    assert "\n  finalize:" not in workflow
+    assert "same-runner" not in workflow
+    assert "needs: benchmark" in workflow
 
 
 if __name__ == "__main__":

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -1,8 +1,8 @@
 name: Continuous Benchmark (PR)
 # Opt-in only: add the "benchmarks/upload" label to run the comparison. The
-# baseline and PR legs run concurrently on separate runners. Measurements that
-# could change the 5% report are repeated sequentially on one runner. Both legs
-# use the benchmark definitions archived from the PR base SHA.
+# baseline and PR legs run once on separate pinned runners for CPU and GPU. The
+# downstream job compares those four artifacts. Both revisions use benchmark
+# definitions archived from the PR base SHA.
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
@@ -357,12 +357,10 @@ jobs:
           retention-days: 3
 
   compare:
-    name: Compare parallel benchmark results
+    name: Compare benchmark results
     if: contains(github.event.pull_request.labels.*.name, 'benchmarks/upload')
     needs: benchmark
     runs-on: ubuntu-22.04
-    outputs:
-      confirmation_matrix: ${{ steps.plan.outputs.matrix }}
     steps:
       - name: Checkout comparison tooling
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -376,205 +374,16 @@ jobs:
           merge-multiple: true
           path: raw-results
           pattern: '*-benchmark-json'
-      - name: Compare results and plan confirmations
-        id: plan
+      - name: Compare benchmark results
         run: |
           set -euxo pipefail
-          python .github/scripts/compare_pr_benchmarks.py plan \
+          python .github/scripts/compare_pr_benchmarks.py \
             --raw-root raw-results \
-            --plan-root confirmation-plan \
-            --matrix-output confirmation-matrix.json \
+            --output-root final-results \
+            --summary final-summary.md \
             --reporting-threshold 5 \
-            --threshold-margin 2 \
             --image 'CPU=nvidia/cuda:12.6.3-cudnn-runtime-ubuntu22.04@sha256:5f0d2d827f6436b3cb7468fd8acbdc8c1d41261614e579ae49afe6141da51133' \
             --image 'GPU=nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04@sha256:b3e7fba84d169f46939f00c25be7d016f712a8d651f4756d6a55e693d84d94f2'
-          echo "matrix=$(cat confirmation-matrix.json)" >> "${GITHUB_OUTPUT}"
-      - name: Upload confirmation plan
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: benchmark-confirmation-plan
-          path: confirmation-plan
-          retention-days: 3
-
-  confirmation:
-    name: ${{ matrix.device }} same-runner confirmation
-    if: needs.compare.outputs.confirmation_matrix != '{"include":[]}'
-    needs: compare
-    runs-on: linux.g5.4xlarge.nvidia.gpu
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.compare.outputs.confirmation_matrix) }}
-    container:
-      image: ${{ matrix.image }}
-      options: --gpus all --shm-size=8g
-    defaults:
-      run:
-        shell: bash -l {0}
-    env:
-      COMPOSITE_LP_AGGREGATE: '0'
-      LANG: C.UTF-8
-      LC_ALL: C.UTF-8
-      MKL_NUM_THREADS: '1'
-      OMP_NUM_THREADS: '1'
-      PIP_DISABLE_PIP_VERSION_CHECK: '1'
-      PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
-      PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      PYTHONHASHSEED: '0'
-      PYTHONNOUSERSITE: '1'
-      TD_GET_DEFAULTS_TO_NONE: '1'
-      TORCHDYNAMO_INLINE_INBUILT_NN_MODULES: '1'
-      TORCHRL_BENCHMARK_DEVICE: ${{ matrix.device }}
-      TZ: Europe/London
-    steps:
-      - name: Install pinned system environment
-        run: |
-          apt-get update -y
-          apt-get install -y --no-install-recommends \
-            ca-certificates g++ gcc git libgl1-mesa-glx libgles2-mesa-dev \
-            libglew-dev libglfw3-dev libglu1-mesa libosmesa6 libz-dev
-          rm -rf /var/lib/apt/lists/*
-      - name: Checkout workflow inputs
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          fetch-depth: 1
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Checkout PR source
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          fetch-depth: 1
-          path: source
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Fetch baseline source
-        run: |
-          git -C source fetch --no-tags --depth=1 \
-            "https://github.com/${PR_BASE_REPO}.git" "${PR_BASE_SHA}"
-      - name: Set up pinned Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: '3.10.20'
-      - name: Restore pinned benchmark environment
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          fail-on-cache-miss: true
-          path: .benchmark-venv
-          key: pr-benchmark-venv-v1-${{ runner.os }}-${{ hashFiles('.github/benchmark-versions.env', '.github/benchmark-requirements.txt') }}
-      - name: Download pinned benchmark definitions
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: benchmark-definitions
-          path: benchmark-definitions
-      - name: Download confirmation plan
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: benchmark-confirmation-plan
-          path: confirmation-plan
-      - name: Run baseline then PR on the same runner
-        run: |
-          set -euxo pipefail
-          source .benchmark-venv/bin/activate
-          if [ "${TORCHRL_BENCHMARK_DEVICE}" = CPU ]; then
-            export CUDA_VISIBLE_DEVICES=
-          else
-            export CUDA_VISIBLE_DEVICES=0
-          fi
-          mkdir -p .benchmark-site "confirmation-result/${TORCHRL_BENCHMARK_DEVICE}"
-          cat > .benchmark-site/sitecustomize.py <<'PY'
-          import warnings
-
-          try:
-              import torch
-
-              torch._dynamo.config.reorderable_logging_functions.add(warnings.warn)
-          except (AttributeError, ImportError):
-              pass
-          PY
-          export PYTHONPATH="${GITHUB_WORKSPACE}/.benchmark-site"
-          tar -xzf benchmark-definitions/benchmark-definitions.tar.gz \
-            -C benchmark-definitions
-          mapfile -t NODEIDS < <(
-            python -c 'import json, sys; print("\n".join(json.load(open(sys.argv[1]))["pytest_nodeids"]))' \
-              "confirmation-plan/${TORCHRL_BENCHMARK_DEVICE}.json"
-          )
-          test "${#NODEIDS[@]}" -gt 0
-
-          run_revision() {
-            local sha="$1"
-            local revision="$2"
-            git -C source checkout --detach "${sha}"
-            git -C source clean -ffdx
-            rm -rf source/build
-            rm -rf "${HOME}/.cache/torch" /tmp/torchinductor_* /tmp/triton*
-            python -m pip install -e source --no-build-isolation --no-deps
-            if [ "${TORCHRL_BENCHMARK_DEVICE}" = GPU ]; then
-              nvcc --version
-              python -c "import torch; assert torch.cuda.device_count()"
-              python -c "import torchrl._torchrl as ext; assert hasattr(ext, 'CudaSumSegmentTreeFp32')"
-            fi
-            local result_json="${GITHUB_WORKSPACE}/confirmation-result/${TORCHRL_BENCHMARK_DEVICE}/${revision}.json"
-            (
-              cd benchmark-definitions/benchmarks
-              python -m pytest -vvv --rank 0 --timeout=240 --benchmark-only \
-                --benchmark-json "${result_json}" "${NODEIDS[@]}"
-            )
-          }
-
-          run_revision "${PR_BASE_SHA}" baseline
-          run_revision "${PR_HEAD_SHA}" contender
-      - name: Upload same-runner confirmation JSON
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: ${{ matrix.device }}-benchmark-confirmation
-          path: confirmation-result
-          retention-days: 3
-
-  finalize:
-    name: Finalize benchmark comparison
-    if: >-
-      always() &&
-      contains(github.event.pull_request.labels.*.name, 'benchmarks/upload') &&
-      needs.compare.result == 'success' &&
-      (needs.confirmation.result == 'success' || needs.confirmation.result == 'skipped')
-    needs: [compare, confirmation]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout comparison tooling
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          fetch-depth: 1
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Download baseline and PR JSON artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          merge-multiple: true
-          path: raw-results
-          pattern: '*-benchmark-json'
-      - name: Download confirmation plan
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: benchmark-confirmation-plan
-          path: confirmation-plan
-      - name: Download same-runner confirmations
-        if: needs.confirmation.result == 'success'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          merge-multiple: true
-          path: confirmation-results
-          pattern: '*-benchmark-confirmation'
-      - name: Replace noisy measurements and compare
-        run: |
-          set -euxo pipefail
-          mkdir -p confirmation-results
-          python .github/scripts/compare_pr_benchmarks.py finalize \
-            --raw-root raw-results \
-            --plan-root confirmation-plan \
-            --confirmation-root confirmation-results \
-            --output-root final-results \
-            --summary final-summary.md
           cat final-summary.md >> "${GITHUB_STEP_SUMMARY}"
       - name: Upload final CPU benchmark comparison
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/benchmarks/test_collectors_benchmark.py
+++ b/benchmarks/test_collectors_benchmark.py
@@ -148,11 +148,12 @@ def async_collector_setup():
         frames_per_batch=100,
         device=device,
     )
-    c = iter(c)
+    collector = c
+    c = iter(collector)
     for i, _ in enumerate(c):
         if i == 10:
             break
-    return ((c,), {})
+    return ((c, collector), {})
 
 
 def parallel_env_compact_obs_setup(payload_size):
@@ -164,10 +165,10 @@ def parallel_env_compact_obs_setup(payload_size):
         frames_per_batch=128,
         compact_obs=True,
     )
-    collector = iter(collector)
-    next(collector)
-    next(collector)
-    return ((collector,), {})
+    collector_iterator = iter(collector)
+    for _ in range(10):
+        next(collector_iterator)
+    return ((collector_iterator, collector), {})
 
 
 def single_collector_setup_pixels():
@@ -326,10 +327,11 @@ def sync_payload_collector_with_rb_setup():
         frames_per_batch=64,
         replay_buffer=rb,
     )
-    c = iter(c)
-    next(c)
-    next(c)
-    return ((c, rb), {})
+    collector = c
+    c = iter(collector)
+    for _ in range(10):
+        next(c)
+    return ((c, rb, collector), {})
 
 
 def test_single_with_rb(benchmark):
@@ -346,8 +348,16 @@ def test_sync_with_rb(benchmark):
 
 def test_sync_payload_with_rb(benchmark):
     """Benchmark clone avoidance for large runner-managed rollouts."""
-    (c, rb), _ = sync_payload_collector_with_rb_setup()
-    benchmark(execute_collector_with_rb, c, rb)
+    (c, rb, collector), _ = sync_payload_collector_with_rb_setup()
+    try:
+        benchmark.pedantic(
+            execute_collector_with_rb,
+            args=(c, rb),
+            iterations=5,
+            rounds=10,
+        )
+    finally:
+        collector.shutdown()
 
 
 @pytest.mark.skipif(not torch.cuda.device_count(), reason="no rendering without cuda")
@@ -373,15 +383,31 @@ def test_sync_preempt(benchmark):
 
 
 def test_async(benchmark):
-    (c,), _ = async_collector_setup()
-    benchmark(execute_collector, c)
+    (c, collector), _ = async_collector_setup()
+    try:
+        benchmark.pedantic(
+            execute_collector,
+            args=(c,),
+            iterations=10,
+            rounds=10,
+        )
+    finally:
+        collector.shutdown()
 
 
 @pytest.mark.parametrize("payload_size", [65536, 262144], ids=["256KiB", "1MiB"])
 def test_parallel_env_compact_obs(benchmark, payload_size):
     """Benchmark copies for a collector over a large-payload ParallelEnv."""
-    (c,), _ = parallel_env_compact_obs_setup(payload_size)
-    benchmark(execute_collector, c)
+    (c, collector), _ = parallel_env_compact_obs_setup(payload_size)
+    try:
+        benchmark.pedantic(
+            execute_collector,
+            args=(c,),
+            iterations=2,
+            rounds=10,
+        )
+    finally:
+        collector.shutdown()
 
 
 @pytest.mark.skipif(not torch.cuda.device_count(), reason="no rendering without cuda")


### PR DESCRIPTION
## Summary

- run exactly one merge-base and one PR benchmark for each of CPU and GPU, then compare the four JSON artifacts in one downstream job
- compare inverse median round duration instead of mean-derived operations per second so isolated stalls do not dominate the report
- stabilize the collector benchmarks that show intrinsic warm-up or phase variability with explicit pedantic sampling, additional untimed warm-up, and deterministic worker shutdown
- retain the pinned runner type, images, dependency environment, and merge-base benchmark definitions

## Artifact evidence

The analysis used the raw and repeated JSON artifacts from runs [29431181113](https://github.com/pytorch/rl/actions/runs/29431181113), [29448547891](https://github.com/pytorch/rl/actions/runs/29448547891), and [29481883042](https://github.com/pytorch/rl/actions/runs/29481883042). The latter two used the same base SHA, benchmark-definition hash, dependency hash, images, environment, and runner type while containing no relevant library changes.

The artifacts separate three cases:

- **Isolated stalls:** `test_a2c_speed[False-backward]` reported a 76.5% GPU regression when mean-derived ops included one round about 166 times slower than the median. Baseline and PR medians differed by approximately 0.2%. Median duration removes this single-stall bias without adding measurements.
- **Intrinsic collector variability:** `test_async` had 108-200% IQR and mixed ready-batch/waiting-batch latencies. `test_sync_payload_with_rb` had 35-53% IQR, first-round overhead of 31-100%, and 27-41% improvement across a pass. One compact-observation pass had 54% IQR and 42% drift. These definitions now average multiple collector iterations per round, warm the persistent collectors before timing, and shut workers down explicitly.
- **Runner-level shifts:** VLA preprocessing commonly had sub-1% within-pass IQR while complete-pass medians moved by 20-43%. Replay-buffer tests already collected hundreds of rounds but still moved with the runner leg. The recorded runner CPU frequencies ranged from approximately 2.52 to 3.30 GHz. Increasing rounds for these tests would add runtime without addressing the observed pass-level effect, so they are unchanged.

A repeated-run artifact also showed that some large initial differences disappeared on one machine, while individual pass medians could still switch regimes. This supports removing repeat-based replacement rather than expanding it.

## Validation

- `pre-commit run --files` for all changed files
- `actionlint -ignore 'label .* is unknown' .github/workflows/benchmarks_pr.yml`
- `5 passed` in `.github/scripts/test_pr_benchmark_workflow.py`
- replayed the comparison against all four primary artifacts from run 29481883042: 238 CPU and 248 GPU benchmarks compared successfully
- built the source in a clean Python 3.12 environment and ran the three changed CPU collector benchmarks:
  - `test_async`: 10 rounds x 10 iterations, approximately 1% IQR
  - `test_sync_payload_with_rb`: 10 rounds x 5 iterations, approximately 5% IQR
  - compact observations: 10 rounds x 2 iterations, approximately 0.4-1.3% IQR

The PR workflow intentionally continues to archive benchmark definitions from the merge base, so definition changes in this PR are validated separately and will become active for subsequent PR comparisons after merge.
