### PR TITLE
[BugFix] Restore W&B scalar commit behavior

### DIFF
--- a/sota-implementations/vla_grpo/utils.py
+++ b/sota-implementations/vla_grpo/utils.py
@@ -1388,9 +1388,8 @@ def load_checkpoint(path, policy: torch.nn.Module, optim, scheduler, device) -> 
 
 
 def log_metrics(logger, metrics: dict, step: int) -> None:
-    # One log_metrics call per step (not a per-key log_scalar loop): log_scalar
-    # defaults to commit=False, so looping it never advances WandB's step and
-    # every iteration collapses into a single history record. log_metrics
-    # commits the whole step at once -- the pattern every other sota script uses.
+    # One log_metrics call per step (not a per-key log_scalar loop): this keeps
+    # all metrics of an iteration in a single W&B history row -- the pattern
+    # every other sota script uses.
     if logger is not None:
         logger.log_metrics(metrics, step)

--- a/test/test_loggers.py
+++ b/test/test_loggers.py
@@ -392,7 +392,6 @@ class TestWandbLogger:
                 value=scalar_value,
                 name=scalar_name,
                 step=steps[i] if steps else None,
-                commit=True,
             )
 
         assert len(logged) == 3
@@ -402,6 +401,25 @@ class TestWandbLogger:
             expected_step = i if not steps else steps[i]
             assert payload == {"foo": values[i].item(), "step": expected_step}
             assert kwargs == {"commit": True}
+
+    def test_log_scalar_commit_false_batches(self, wandb_tmp_logger, monkeypatch):
+        logged = []
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment,
+            "log",
+            lambda payload, **kwargs: logged.append((payload, kwargs)),
+        )
+        monkeypatch.setattr(
+            wandb_tmp_logger.experiment, "define_metric", lambda *args, **kwargs: None
+        )
+
+        wandb_tmp_logger.log_scalar("train/loss", 1.0, step=7, commit=False)
+        wandb_tmp_logger.log_scalar("train/reward", 2.0, step=7)
+
+        assert logged == [
+            ({"train/loss": 1.0, "train/step": 7}, {"commit": False}),
+            ({"train/reward": 2.0, "train/step": 7}, {"commit": True}),
+        ]
 
     @pytest.mark.skipif(not _has_moviepy, reason="moviepy not installed")
     def test_log_video(self, wandb_logger):

--- a/torchrl/record/loggers/wandb.py
+++ b/torchrl/record/loggers/wandb.py
@@ -177,7 +177,7 @@ class WandbLogger(Logger):
         name: str,
         value: float,
         step: int | None = None,
-        commit: bool = False,
+        commit: bool = True,
         *,
         override_global_step: bool = False,
     ) -> None:
@@ -188,8 +188,10 @@ class WandbLogger(Logger):
             value (float): The value of the scalar.
             step (int, optional): The step at which the scalar is logged.
                 Defaults to None.
-            commit: If true, data for current step is assumed to be final (and
-                no further data for this step should be logged).
+            commit (bool, optional): If ``True``, data for the current step is
+                assumed to be final (and no further data for this step should
+                be logged). Set to ``False`` to batch multiple calls into the
+                same W&B history row. Defaults to ``True``.
             override_global_step (bool, optional): If ``True``, bypasses
                 per-group step injection and forwards ``step`` to wandb's
                 global ``step`` argument. Defaults to ``False``.


### PR DESCRIPTION
## Summary

- make `WandbLogger.log_scalar()` commit its W&B history row by default
- preserve explicit `commit=False` for callers that intentionally batch multiple scalar calls into one row
- document the default and batching behavior
- add focused coverage for both paths

## Root cause

Before #2999, `log_scalar()` called `wandb.Run.log()` without overriding `commit`, so ordinary scalar calls used W&B's flushing behavior and produced a history row per call. #2999 exposed a `commit` argument while changing W&B step handling, but gave it a default of `False`. The accompanying logger test then passed `commit=True` explicitly, leaving the public default untested. The later per-group step implementation retained that default.

`Trainer._log()` sends metrics through separate `log_scalar()` calls and does not request batching. With the changed default, every Trainer metric was sent with `commit=False`. W&B therefore kept updating its pending history row instead of finalizing rows as training progressed. Only the final pending state was flushed when the run finished, so time-series metrics appeared as a single point (and often as bar charts), while an active run could show no history at all.

## Fix

Restore `commit=True` as the `log_scalar()` default. A normal scalar call now finalizes its history row immediately, matching the behavior callers relied on before #2999. Callers that deliberately want to combine multiple scalar calls can still pass `commit=False`; a subsequent default call commits the accumulated row.

The regression test now exercises the default rather than supplying `commit=True`, and an additional test verifies that explicit `commit=False` is forwarded and can be followed by the default committing call.

## Validation

- `python -m pytest test/test_loggers.py -k 'TestWandbLogger and log_scalar' -q` (3 passed)
- `pre-commit run --files torchrl/record/loggers/wandb.py test/test_loggers.py`
