### PR TITLE
[Feature] Add unified collector backend construction

### DIFF
--- a/docs/source/reference/collectors.rst
+++ b/docs/source/reference/collectors.rst
@@ -9,27 +9,119 @@ Data collectors are the bridge between your environments and training loop, mana
 experience data using your policy. They handle environment resets, policy execution, and data aggregation,
 making it easy to collect high-quality training data efficiently.
 
-TorchRL provides several collector implementations optimized for different scenarios:
+Use :class:`Collector` to construct collectors in new code. It is the stable
+front door for local, multi-process, and distributed collection; changing the
+execution topology does not require changing the imported class. TorchRL also
+exposes the concrete implementations for type checks, subclassing, and
+implementation-specific integrations:
 
-- :class:`Collector`: Single-process collection on the training worker
+- :class:`Collector`: Main construction API, with direct collection as its
+  default
 - :class:`AsyncBatchedCollector`: Async environments + auto-batching inference server (see :class:`AsyncBatchedCollector`)
 - :class:`MultiCollector`: Parallel collection across multiple workers (see below)
 - :class:`Evaluator`: Sync or async evaluation during training (see :ref:`evaluation <collectors_eval>`)
 - **Distributed collectors**: For multi-node setups using Ray, RPC, or distributed backends (see :class:`~torchrl.collectors.distributed.DistributedCollector` / :class:`~torchrl.collectors.distributed.RPCCollector`)
 
-MultiCollector API
-------------------
+Backend selection
+-----------------
 
-The :class:`MultiCollector` class provides a unified interface for multi-process data collection.
-Use the ``sync`` parameter to choose between synchronous and asynchronous collection:
+:class:`Collector` constructs the appropriate concrete collector without
+changing the training code that consumes it. The default is direct collection
+in the training process. Passing ``num_collectors`` selects a process
+collector, while ``backend`` selects a backend explicitly:
 
 .. code-block:: python
 
-    from torchrl.collectors import MultiCollector
+    from torchrl.collectors import Collector
+
+    process_collector = Collector(
+        create_env_fn=make_env,
+        num_collectors=4,
+        policy=my_policy,
+        frames_per_batch=200,
+        total_frames=10_000,
+        sync=True,
+    )
+
+    ray_collector = Collector(
+        create_env_fn=make_env,
+        num_collectors=4,
+        backend="ray",
+        backend_options={
+            "remote_configs": {"num_cpus": 1, "num_gpus": 0},
+        },
+        policy=my_policy,
+        frames_per_batch=200,
+        total_frames=10_000,
+    )
+
+The available selectors are ``"direct"``, ``"process"``, ``"ray"``,
+``"rpc"``, ``"distributed"``, and ``"submitit"``. ``"submitit"`` is a
+shortcut for a distributed collector with ``launcher="submitit"``. For every
+non-direct backend, omitted ``sync`` defaults to ``False``.
+
+Selection precedence is explicit ``backend``, then an enclosing
+:func:`torchrl.service_backend`, then ``num_collectors`` implying
+``"process"``, and finally ``"direct"``. An explicit ``backend="direct"``
+accepts at most one collector.
+
+.. list-table:: Collector construction
+   :header-rows: 1
+
+   * - User-facing selection
+     - Concrete result
+     - Typical use
+   * - ``Collector(...)`` or ``backend="direct"``
+     - :class:`Collector`
+     - One collector in the training process
+   * - ``num_collectors=N`` or ``backend="process"``
+     - :class:`MultiCollector`
+     - Multiple local worker processes
+   * - ``backend="ray"``
+     - :class:`~torchrl.collectors.distributed.RayCollector`
+     - Ray-managed actors
+   * - ``backend="rpc"``
+     - :class:`~torchrl.collectors.distributed.RPCCollector`
+     - PyTorch RPC workers
+   * - ``backend="distributed"``
+     - :class:`~torchrl.collectors.distributed.DistributedCollector`
+     - Explicit distributed launcher and process-group configuration
+   * - ``backend="submitit"``
+     - :class:`~torchrl.collectors.distributed.DistributedCollector`
+     - Submitit launcher shortcut
+
+``backend_options`` forwards backend-specific options without mutating the
+input mapping. This is where launcher options, Ray resources, and the inner
+Gloo or NCCL ``backend`` are configured. Selector arguments cannot be repeated
+inside ``backend_options``.
+
+A callable environment factory is replicated to ``num_collectors`` workers.
+When a sequence is provided, its length determines the number of collectors;
+an explicitly supplied positive count must match. Empty sequences,
+non-positive counts, and mismatches are rejected before construction. The
+returned object keeps its concrete type, so a process selection returns
+:class:`MultiCollector` rather than an instance of the direct
+:class:`Collector`.
+
+Selection can also be scoped with :func:`torchrl.service_backend`; see
+:ref:`ref_services_workflow` for composing collector placement with replay and
+inference transports.
+
+Process collection
+------------------
+
+Pass ``num_collectors`` to the main :class:`Collector` entry point for local
+multi-process collection. Use ``sync`` to choose synchronous or asynchronous
+delivery:
+
+.. code-block:: python
+
+    from torchrl.collectors import Collector
 
     # Synchronous collection: all workers complete before delivering batch
-    collector = MultiCollector(
-        create_env_fn=[make_env] * 4,  # 4 parallel workers
+    collector = Collector(
+        create_env_fn=make_env,
+        num_collectors=4,
         policy=my_policy,
         frames_per_batch=200,
         total_frames=10000,
@@ -37,8 +129,9 @@ Use the ``sync`` parameter to choose between synchronous and asynchronous collec
     )
 
     # Asynchronous collection: first-come-first-serve delivery
-    collector = MultiCollector(
-        create_env_fn=[make_env] * 4,
+    collector = Collector(
+        create_env_fn=make_env,
+        num_collectors=4,
         policy=my_policy,
         frames_per_batch=200,
         total_frames=10000,
@@ -78,8 +171,9 @@ Hooks are intended for instrumentation and worker-local side effects, such as
 stepping a profiler or recording rollout metrics.  Use ``postproc`` when the
 collected data itself should be transformed before training.
 
-For :class:`MultiCollector`, :class:`MultiSyncCollector`, and
-:class:`MultiAsyncCollector`, hooks run in each worker process.  The helper
+When :class:`Collector` selects the process backend, hooks run in each worker
+process. The concrete return types are :class:`MultiSyncCollector` and
+:class:`MultiAsyncCollector`. The helper
 methods :meth:`~torchrl.collectors.BaseCollector.map_fn` and
 :meth:`~torchrl.collectors.BaseCollector.get_distant_attr` broadcast to each
 worker for multi-process collectors and to each actor for
@@ -121,9 +215,10 @@ Quick Example
 Removed legacy names
 --------------------
 
-The deprecated collector aliases were removed in v0.13. Use the canonical
-collector classes directly: ``Collector``, ``MultiCollector``,
-``MultiSyncCollector``, ``MultiAsyncCollector``, and ``BaseCollector``.
+The deprecated collector aliases were removed in v0.13. Use ``Collector`` as
+the construction entry point. ``MultiCollector``, ``MultiSyncCollector``,
+``MultiAsyncCollector``, and ``BaseCollector`` remain available when code must
+name a concrete implementation.
 
 Documentation Sections
 ----------------------

--- a/docs/source/reference/collectors.rst
+++ b/docs/source/reference/collectors.rst
@@ -114,6 +114,21 @@ Selection can also be scoped with :func:`torchrl.service_backend`; see
 :ref:`ref_services_workflow` for composing collector placement with replay and
 inference transports.
 
+.. note::
+
+   **High-throughput Ray data path.** For large, fixed-layout TensorDict
+   payloads, prefer a Ray-owned replay buffer configured with
+   ``service_backend="ray"`` and ``transport="distributed"``. Collector actors
+   then write directly to the shared replay service over Gloo (CPU) or NCCL
+   (CUDA), and the learner samples it as the training dataset without routing
+   each rollout through the driver. A regular in-process replay buffer is
+   rejected by the Ray collector: copying it into distant actors would create
+   independent buffers, not populate the original object. If no replay buffer
+   is attached, yielded batches return to the driver through Ray's object
+   store. Use ``transport="ray"`` instead when payloads contain dynamic shapes,
+   non-tensor values, or arbitrary Python objects. See
+   :ref:`ref_service_transports` for the full compatibility table.
+
 Process collection
 ------------------
 

--- a/docs/source/reference/collectors.rst
+++ b/docs/source/reference/collectors.rst
@@ -60,6 +60,12 @@ The available selectors are ``"direct"``, ``"process"``, ``"ray"``,
 shortcut for a distributed collector with ``launcher="submitit"``. For every
 non-direct backend, omitted ``sync`` defaults to ``False``.
 
+.. important::
+
+   Process and distributed selection is asynchronous when ``sync`` is omitted.
+   On-policy algorithms should normally pass ``sync=True`` explicitly so every
+   worker contributes to each synchronized batch.
+
 Selection precedence is explicit ``backend``, then an enclosing
 :func:`torchrl.service_backend`, then ``num_collectors`` implying
 ``"process"``, and finally ``"direct"``. An explicit ``backend="direct"``
@@ -101,7 +107,8 @@ an explicitly supplied positive count must match. Empty sequences,
 non-positive counts, and mismatches are rejected before construction. The
 returned object keeps its concrete type, so a process selection returns
 :class:`MultiCollector` rather than an instance of the direct
-:class:`Collector`.
+:class:`Collector`. Use :class:`BaseCollector` for an ``isinstance`` check that
+must accept every collector returned by the unified constructor.
 
 Selection can also be scoped with :func:`torchrl.service_backend`; see
 :ref:`ref_services_workflow` for composing collector placement with replay and

--- a/docs/source/reference/collectors_basics.rst
+++ b/docs/source/reference/collectors_basics.rst
@@ -1,6 +1,6 @@
 .. currentmodule:: torchrl.collectors
 
-.. _ref_collectors:
+.. _ref_collectors_basics:
 
 Collector Basics
 ================
@@ -18,18 +18,20 @@ state, and/or after a predefined number of steps.
 Because data collection is a potentially compute heavy process, it is crucial to
 configure the execution hyperparameters appropriately.
 The first parameter to take into consideration is whether the data collection should
-occur serially with the optimization step or in parallel. The :class:`Collector`
-class will execute the data collection on the training worker. The :class:`MultiSyncCollector`
-(or ``MultiCollector(sync=True)``) will split the workload across a number of workers and aggregate the results that
-will be delivered to the training worker. Finally, the :class:`MultiAsyncCollector`
-(or ``MultiCollector(sync=False)``) will execute the data collection on several workers and deliver the first batch of results
-that it can gather. This execution will occur continuously and concomitantly with
+occur serially with the optimization step or in parallel. Construct all of these
+topologies through :class:`Collector`. ``Collector(...)`` executes collection on
+the training worker. ``Collector(num_collectors=N, sync=True)`` splits the
+workload across local processes and aggregates their results (its concrete return
+type is :class:`MultiSyncCollector`). ``Collector(num_collectors=N, sync=False)``
+delivers the first worker result it can gather (its concrete return type is
+:class:`MultiAsyncCollector`). This asynchronous execution occurs continuously and concomitantly with
 the training of the networks: this implies that the weights of the policy that
 is used for the data collection may slightly lag the configuration of the policy
 on the training worker. Therefore, although this class may be the fastest to collect
 data, it comes at the price of being suitable only in settings where it is acceptable
 to gather data asynchronously (e.g. off-policy RL or curriculum RL).
-For remotely executed rollouts (:class:`MultiCollector` with ``sync=True`` or ``sync=False``)
+For worker-executed rollouts (``Collector(num_collectors=N)`` with either
+``sync=True`` or ``sync=False``)
 it is necessary to synchronise the weights of the remote policy with the weights
 from the training worker using either the :meth:`collector.update_policy_weights_` or
 by setting ``update_at_each_batch=True`` in the constructor.
@@ -98,7 +100,7 @@ be expected when collecting data:
 
 
 +--------------------+---------------------+--------------------------------------------+------------------------------+
-|                    | Collector           |   MultiCollector(sync=True) (n=B)          |MultiCollector(sync=False)    |
+|                    | Collector (direct)  | Collector(num_collectors=B, sync=True)     |Collector(..., sync=False)    |
 +====================+=====================+=============+==============+===============+==============================+
 |   `cat_results`    |          NA         |  `"stack"`  |      `0`     |      `-1`     |             NA               |
 +--------------------+---------------------+-------------+--------------+---------------+------------------------------+
@@ -111,7 +113,8 @@ In each of these cases, the last dimension (``T`` for ``time``) is adapted such
 that the batch size equals the ``frames_per_batch`` argument passed to the
 collector.
 
-.. warning:: :class:`~torchrl.collectors.MultiSyncCollector` (i.e., ``MultiCollector(sync=True)``) should not be
+.. warning:: ``Collector(num_collectors=N, sync=True)`` (a
+  :class:`~torchrl.collectors.MultiSyncCollector`) should not be
   used with ``cat_results=0``, as the data will be stacked along the batch
   dimension with batched environment, or the time dimension for single environments,
   which can introduce some confusion when swapping one with the other.
@@ -120,9 +123,11 @@ collector.
   better interchangeability between configurations, collector classes and other
   components.
 
-Whereas :class:`~torchrl.collectors.MultiSyncCollector` (i.e., ``MultiCollector(sync=True)``)
-has a dimension corresponding to the number of sub-collectors being run (``B``),
-:class:`~torchrl.collectors.MultiAsyncCollector` (i.e., ``MultiCollector(sync=False)``) doesn't. This
+Whereas ``Collector(num_collectors=B, sync=True)`` has a dimension corresponding
+to the number of sub-collectors being run (``B``), the asynchronous
+``Collector(num_collectors=B, sync=False)`` form does not. The concrete
+implementations are :class:`~torchrl.collectors.MultiSyncCollector` and
+:class:`~torchrl.collectors.MultiAsyncCollector`, respectively. This
 is easily understood when considering that :class:`~torchrl.collectors.MultiAsyncCollector`
 delivers batches of data on a first-come, first-serve basis, whereas
 :class:`~torchrl.collectors.MultiSyncCollector` gathers data from

--- a/docs/source/reference/collectors_distributed.rst
+++ b/docs/source/reference/collectors_distributed.rst
@@ -54,6 +54,16 @@ rollouts use Ray's object store. See :ref:`ref_service_transports` for the
 backend/transport compatibility table and the recommended direct-to-replay
 topology.
 
+.. note::
+
+  For large, fixed-layout TensorDict rollouts, the preferred Ray topology is a
+  replay buffer owned by Ray (``service_backend="ray"``) with a distributed
+  payload transport (Gloo for CPU or NCCL for CUDA). The replay service acts as
+  the shared dataset between collector actors and learners. Ray collectors
+  reject regular in-process replay buffers because each actor would otherwise
+  receive an independent serialized copy rather than write into the original
+  driver object.
+
 *Resources*: Find examples for these collectors in the
 `dedicated folder <https://github.com/pytorch/rl/examples/distributed/collectors>`_.
 

--- a/docs/source/reference/collectors_distributed.rst
+++ b/docs/source/reference/collectors_distributed.rst
@@ -3,14 +3,50 @@
 Distributed Collectors
 ======================
 
-TorchRL provides a set of distributed data collectors. These tools support
-multiple backends (``'gloo'``, ``'nccl'``, ``'mpi'`` with the :class:`~.DistributedCollector`
-or PyTorch RPC with :class:`~.RPCCollector`) and launchers (``'ray'``,
-``submitit`` or ``torch.multiprocessing``).
-They can be efficiently used in synchronous or asynchronous mode, on a single
-node or across multiple nodes.
+Construct distributed collectors through
+:class:`torchrl.collectors.Collector`, the same entry point used for direct and
+local process collection. Its ``backend`` selector covers Ray, PyTorch RPC,
+and process-group-based collection; ``backend_options`` carries the concrete
+backend's launcher, resources, and communication settings:
 
-``RayCollector`` uses Ray to place and control its worker actors, but an
+.. code-block:: python
+
+    from torchrl.collectors import Collector
+
+    ray_collector = Collector(
+        make_env,
+        policy,
+        backend="ray",
+        num_collectors=8,
+        frames_per_batch=1024,
+        backend_options={"remote_configs": {"num_cpus": 1}},
+    )
+    rpc_collector = Collector(
+        make_env,
+        policy,
+        backend="rpc",
+        num_collectors=8,
+        frames_per_batch=1024,
+        backend_options={"launcher": "submitit"},
+    )
+    distributed_collector = Collector(
+        make_env,
+        policy,
+        backend="distributed",
+        num_collectors=8,
+        frames_per_batch=1024,
+        backend_options={"launcher": "mp", "backend": "gloo"},
+    )
+
+The concrete implementations support Gloo, NCCL, MPI, or UCC with
+:class:`~.DistributedCollector`, PyTorch RPC with :class:`~.RPCCollector`, and
+Ray actor placement with :class:`~.RayCollector`. They can run synchronously
+or asynchronously on a single node or across multiple nodes. Name the
+concrete classes directly only when subclassing or working with an
+implementation-specific API.
+
+``Collector(backend="ray")`` uses Ray to place and control its worker actors,
+but an
 attached inference server or replay buffer selects its own payload transport.
 With a replay buffer attached, workers write rollouts directly through the
 replay endpoint instead of returning them to the driver. Without one, yielded
@@ -22,8 +58,10 @@ topology.
 `dedicated folder <https://github.com/pytorch/rl/examples/distributed/collectors>`_.
 
 .. note::
-  *Choosing the sub-collector*: All distributed collectors support the various single machine collectors.
-  One may wonder why using a :class:`~torchrl.collectors.MultiSyncCollector` or a :class:`~torchrl.envs.ParallelEnv`
+  *Choosing the sub-collector*: Distributed collector implementations support
+  the various single-machine collector classes through ``backend_options``.
+  One may wonder why using a process-backed :class:`torchrl.collectors.Collector`
+  or a :class:`~torchrl.envs.ParallelEnv`
   instead. In general, multiprocessed collectors have a lower IO footprint than
   parallel environments which need to communicate at each step. Yet, the model specs
   play a role in the opposite direction, since using parallel environments will
@@ -69,5 +107,7 @@ Removed legacy names
 --------------------
 
 The deprecated distributed collector aliases were removed in v0.13. Use
-``DistributedCollector``, ``RPCCollector``, and ``DistributedSyncCollector``
-directly.
+:class:`torchrl.collectors.Collector` for construction. The canonical concrete
+names ``DistributedCollector``, ``RPCCollector``, and
+``DistributedSyncCollector`` remain available for implementation-specific
+code.

--- a/docs/source/reference/collectors_internals.rst
+++ b/docs/source/reference/collectors_internals.rst
@@ -5,15 +5,17 @@
 Collector Internals
 ===================
 
-This page describes how :class:`~torchrl.collectors.Collector` steps through an
-environment.  It is meant for
+This page describes the direct implementation returned by
+:class:`~torchrl.collectors.Collector` and how it steps through an environment.
+It is meant for
 contributors and for users debugging unexpected rollout behaviour: device
 casts, per-step bookkeeping, and trajectory tracking are implementation details
 that are not visible from the public API.
 
-The multi-process collectors (:class:`MultiSyncCollector` and
-:class:`MultiAsyncCollector`) delegate their per-worker rollouts to
-:class:`Collector`, so the per-worker flow on this page applies to
+When the main constructor selects the process backend with
+``Collector(num_collectors=N)``, the concrete :class:`MultiSyncCollector` and
+:class:`MultiAsyncCollector` implementations delegate their per-worker
+rollouts to :class:`Collector`, so the per-worker flow on this page applies to
 them too.
 
 Per-timestep flow
@@ -224,10 +226,10 @@ Two opt-in callbacks let you instrument collection without subclassing:
     yielded. Return value is ignored. Use it to log metrics derived from the
     batch.
 
-Hooks are worker-local: in :class:`MultiSyncCollector` /
-:class:`MultiAsyncCollector` they run inside each worker process, not on the
-training worker. Exceptions raised by a hook propagate up and stop collection;
-they are not swallowed.
+Hooks are worker-local: when ``Collector(num_collectors=N)`` selects
+:class:`MultiSyncCollector` or :class:`MultiAsyncCollector`, they run inside
+each worker process, not on the training worker. Exceptions raised by a hook
+propagate up and stop collection; they are not swallowed.
 
 For batch *transformations* (rather than instrumentation), use ``postproc`` on
 the collector constructor instead.

--- a/docs/source/reference/collectors_replay.rst
+++ b/docs/source/reference/collectors_replay.rst
@@ -50,25 +50,27 @@ will work:
     >>> collector = Collector(env, policy, frames_per_batch=N, total_frames=-1)
     >>> for data in collector:
     ...     memory.extend(data)
-    >>> # MultiSyncCollector + regular env: behaves like a ParallelEnv if cat_results="stack"
+    >>> # Synchronous process collection behaves like ParallelEnv if cat_results="stack"
     >>> memory = ReplayBuffer(
     ...     storage=LazyTensorStorage(N, ndim=2),
     ...     sampler=SliceSampler(num_slices=4, trajectory_key=("collector", "traj_ids"))
     ... )
-    >>> collector = MultiSyncCollector([make_env] * 4,
-    ...     policy,
+    >>> collector = Collector(make_env, policy,
+    ...     num_collectors=4,
+    ...     sync=True,
     ...     frames_per_batch=N,
     ...     total_frames=-1,
     ...     cat_results="stack")
     >>> for data in collector:
     ...     memory.extend(data)
-    >>> # MultiSyncCollector + parallel env: the ndim must be adapted accordingly
+    >>> # Process collection + parallel env: adapt ndim for both batch dimensions
     >>> memory = ReplayBuffer(
     ...     storage=LazyTensorStorage(N, ndim=3),
     ...     sampler=SliceSampler(num_slices=4, trajectory_key=("collector", "traj_ids"))
     ... )
-    >>> collector = MultiSyncCollector([ParallelEnv(2, make_env)] * 4,
-    ...     policy,
+    >>> collector = Collector(lambda: ParallelEnv(2, make_env), policy,
+    ...     num_collectors=4,
+    ...     sync=True,
     ...     frames_per_batch=N,
     ...     total_frames=-1,
     ...     cat_results="stack")
@@ -90,9 +92,9 @@ will work:
 Complete trajectory collection with ``trajs_per_batch``
 -------------------------------------------------------
 
-When using a multi-process collector
-(:class:`~torchrl.collectors.MultiSyncCollector` or
-:class:`~torchrl.collectors.MultiAsyncCollector`) with fixed-frame batches
+When using ``Collector(num_collectors=N)`` with fixed-frame batches (the
+concrete result is :class:`~torchrl.collectors.MultiSyncCollector` or
+:class:`~torchrl.collectors.MultiAsyncCollector`)
 and a :class:`~torchrl.data.replay_buffers.SliceSampler`, adjacent frames in the buffer can
 come from **different workers and different episodes** without an intervening
 ``done`` signal.  The sampler has no way to detect these invisible boundaries,
@@ -167,7 +169,7 @@ lengths vary a lot or frames are large (images, token sequences):
 
 .. code-block:: python
 
-    from torchrl.collectors import MultiCollector
+    from torchrl.collectors import Collector
     from torchrl.data import ReplayBuffer, LazyTensorStorage, SliceSampler
 
     rb = ReplayBuffer(
@@ -175,9 +177,10 @@ lengths vary a lot or frames are large (images, token sequences):
         sampler=SliceSampler(slice_len=32, end_key=("next", "done")),
         batch_size=256,
     )
-    collector = MultiCollector(
-        [make_env] * 4,
+    collector = Collector(
+        make_env,
         policy,
+        num_collectors=4,
         replay_buffer=rb,
         frames_per_batch=200,
         total_frames=500_000,
@@ -196,9 +199,10 @@ concurrently, use :meth:`~torchrl.collectors.BaseCollector.start`:
 
 .. code-block:: python
 
-    collector = MultiCollector(
-        [make_env] * 4,
+    collector = Collector(
+        make_env,
         policy,
+        num_collectors=4,
         replay_buffer=rb,
         frames_per_batch=200,
         total_frames=-1,
@@ -217,13 +221,14 @@ This pattern fully decouples data collection from training and is the
 recommended way to maximise inference throughput on multi-core machines or
 GPU-accelerated environments.
 
-**Single-process collectors** also support ``trajs_per_batch`` with the same
+**Direct collectors** also support ``trajs_per_batch`` with the same
 replay-buffer semantics:
 
 .. code-block:: python
 
     collector = Collector(
         env, policy,
+        backend="direct",
         replay_buffer=rb,
         frames_per_batch=200,
         total_frames=-1,

--- a/docs/source/reference/collectors_single.rst
+++ b/docs/source/reference/collectors_single.rst
@@ -3,7 +3,9 @@
 Single Node Collectors
 ======================
 
-TorchRL provides several collector classes for single-node data collection, each with different execution strategies.
+Use :class:`Collector` as the construction entry point for direct and local
+multi-process collection. The concrete classes below remain public for
+advanced use and document the implementation returned by each selection.
 
 Single node data collectors
 ---------------------------
@@ -78,9 +80,10 @@ with multi-process collectors where fixed-frame batches can silently mix
 episodes.  See :ref:`collectors_replay_trajs` for full details and examples.
 
 .. note::
-    The deprecated collector aliases were removed in v0.13. Use the canonical
-    classes directly: ``BaseCollector``, ``Collector``, ``AsyncCollector``,
-    ``MultiCollector``, ``MultiSyncCollector``, and ``MultiAsyncCollector``.
+    The deprecated collector aliases were removed in v0.13. Construct new
+    collectors with ``Collector``. ``BaseCollector``, ``AsyncCollector``,
+    ``MultiCollector``, ``MultiSyncCollector``, and ``MultiAsyncCollector``
+    remain available as concrete implementation APIs.
 
 Using AsyncBatchedCollector
 ---------------------------
@@ -117,7 +120,7 @@ and a **policy** -- all internal wiring is handled automatically:
 
     collector.shutdown()
 
-**Key advantages over** :class:`Collector`:
+**Key advantages over direct collection through** :class:`Collector`:
 
 - The inference server automatically **batches policy forward passes** from
   all environments, maximising GPU utilisation.
@@ -125,23 +128,26 @@ and a **policy** -- all internal wiring is handled automatically:
   idle time.
 - Supports ``yield_completed_trajectories=True`` for episode-level yields.
 
-Using MultiCollector
---------------------
+Scaling ``Collector`` across local processes
+--------------------------------------------
 
-The :class:`MultiCollector` class is the recommended way to run parallel data collection.
-It uses a ``sync`` parameter to dispatch to either :class:`MultiSyncCollector` or :class:`MultiAsyncCollector`:
+Pass ``num_collectors`` to :class:`Collector` to run parallel local collection.
+The ``sync`` parameter selects synchronous or asynchronous delivery and the
+constructor returns :class:`MultiSyncCollector` or :class:`MultiAsyncCollector`,
+respectively:
 
 .. code-block:: python
 
-    from torchrl.collectors import MultiCollector
+    from torchrl.collectors import Collector
     from torchrl.envs import GymEnv
 
     def make_env():
         return GymEnv("CartPole-v1")
 
     # Synchronous multi-worker collection (recommended for on-policy algorithms)
-    sync_collector = MultiCollector(
-        create_env_fn=[make_env] * 4,  # 4 parallel workers
+    sync_collector = Collector(
+        create_env_fn=make_env,
+        num_collectors=4,
         policy=my_policy,
         frames_per_batch=1000,
         total_frames=100000,
@@ -149,8 +155,9 @@ It uses a ``sync`` parameter to dispatch to either :class:`MultiSyncCollector` o
     )
 
     # Asynchronous multi-worker collection (recommended for off-policy algorithms)
-    async_collector = MultiCollector(
-        create_env_fn=[make_env] * 4,
+    async_collector = Collector(
+        create_env_fn=make_env,
+        num_collectors=4,
         policy=my_policy,
         frames_per_batch=1000,
         total_frames=100000,
@@ -194,7 +201,8 @@ If you want to run a data collector in the background, simply run :meth:`~torchr
     ...     data = rb.sample()  # Sampling from the replay buffer
     ...     # rest of the training loop
 
-Single-process collectors (:class:`~torchrl.collectors.Collector`) will run the process using multithreading,
+Direct collectors (``Collector(backend="direct")``) run background collection
+using multithreading,
 so be mindful of Python's GIL and related multithreading restrictions.
 
 Multiprocessed collectors will on the other hand let the child processes handle the filling of the buffer on their own,
@@ -217,9 +225,10 @@ Data collectors that have been started with `start()` should be shut down using
             batch_size=256,
             shared=True,
         )
-        collector = MultiCollector(
-            [make_env] * 4,
+        collector = Collector(
+            make_env,
             policy,
+            num_collectors=4,
             replay_buffer=rb,
             frames_per_batch=200,
             total_frames=-1,

--- a/docs/source/reference/collectors_weightsync.rst
+++ b/docs/source/reference/collectors_weightsync.rst
@@ -396,7 +396,7 @@ Weight sync schemes integrate seamlessly with TorchRL collectors. The collector 
 
     import torch.nn as nn
     from tensordict.nn import TensorDictModule
-    from torchrl.collectors import MultiCollector
+    from torchrl.collectors import Collector
     from torchrl.envs import GymEnv
     from torchrl.weight_update import SharedMemWeightSyncScheme
 
@@ -412,9 +412,10 @@ Weight sync schemes integrate seamlessly with TorchRL collectors. The collector 
     # Create scheme - collector handles initialization
     scheme = SharedMemWeightSyncScheme(strategy="tensordict")
 
-    collector = MultiCollector(
+    collector = Collector(
+        create_env_fn=lambda: GymEnv("CartPole-v1"),
+        num_collectors=3,
         sync=True,
-        create_env_fn=[lambda: GymEnv("CartPole-v1")] * 3,
         policy=policy,
         frames_per_batch=192,
         total_frames=10000,
@@ -560,7 +561,7 @@ Example: Policy + Env Transform + Replay Buffer
 
 .. code-block:: python
 
-    from torchrl.collectors import MultiSyncCollector
+    from torchrl.collectors import Collector
     from torchrl.weight_update import MultiProcessWeightSyncScheme
 
     weight_sync_schemes = {
@@ -573,8 +574,10 @@ Example: Policy + Env Transform + Replay Buffer
         ),
     }
 
-    collector = MultiSyncCollector(
-        create_env_fn=[make_env, make_env],
+    collector = Collector(
+        create_env_fn=make_env,
+        num_collectors=2,
+        sync=True,
         policy_factory=policy_factory,
         frames_per_batch=200,
         total_frames=10000,
@@ -621,7 +624,7 @@ only the training process accumulates statistics:
 
 .. code-block:: python
 
-    from torchrl.collectors import MultiSyncCollector
+    from torchrl.collectors import Collector
     from torchrl.weight_update import MultiProcessWeightSyncScheme
 
     def make_worker_env():
@@ -640,8 +643,10 @@ only the training process accumulates statistics:
         ),
     }
 
-    collector = MultiSyncCollector(
-        create_env_fn=[make_worker_env, make_worker_env],
+    collector = Collector(
+        create_env_fn=make_worker_env,
+        num_collectors=2,
+        sync=True,
         policy_factory=policy_factory,
         frames_per_batch=200,
         total_frames=10000,

--- a/docs/source/reference/data_layout.rst
+++ b/docs/source/reference/data_layout.rst
@@ -19,7 +19,7 @@ Two main patterns coexist in TorchRL:
   advantage estimator, normalizer) must mask-out the padded entries. This
   is the layout produced by
   :func:`~torchrl.collectors.utils.split_trajectories`,
-  :class:`~torchrl.collectors.MultiCollector` with ``split_trajs=True``,
+  ``Collector(num_collectors=N, split_trajs=True)``,
   and :class:`~torchrl.data.replay_buffers.SliceSampler` with
   ``pad_output=True``. It is **discouraged for new code** — see
   :ref:`data-layout-padded-discouraged` below.
@@ -212,7 +212,8 @@ preserve when extending. The natural mapping is:
   :class:`~torchrl.data.replay_buffers.SliceSampler` infer one trajectory per row without
   scanning ``done`` keys.
 * ``ndim=3`` and beyond — when both an outer worker dim and an env dim
-  exist, e.g. ``MultiSyncCollector([ParallelEnv(2, …)] * 4, …)``.
+  exist, e.g. ``Collector(lambda: ParallelEnv(2, ...),
+  num_collectors=4, sync=True, ...)``.
 
 It looks attractive: the buffer stores its data in the same shape the
 collector produces, no reshape needed.
@@ -222,8 +223,8 @@ storage.** With ``ndim >= 2`` every ``extend`` call commits one row's
 worth of frames along the time axis, and that row is implicitly assumed to
 be a contiguous run of frames from a single env. When several worker
 processes write into the same storage concurrently — e.g.
-:class:`~torchrl.collectors.MultiCollector` ``(sync=False)``,
-:class:`~torchrl.collectors.distributed.RayCollector`, an external pool of
+``Collector(num_collectors=N, sync=False)``, ``Collector(backend="ray")``,
+an external pool of
 producers, or any cluster setup where a learner aggregates batches from
 many actors — the inter-worker write order is uncontrolled. Without
 boundary markers, a given row of the ``[N, T]`` storage can stitch
@@ -253,7 +254,7 @@ Two existing knobs mitigate this without giving up ``ndim >= 2``:
 
   .. code-block:: python
 
-      from torchrl.collectors import MultiCollector
+      from torchrl.collectors import Collector
       from torchrl.data import (
           LazyTensorStorage, ReplayBufferEnsemble, TensorDictReplayBuffer,
       )
@@ -270,8 +271,10 @@ Two existing knobs mitigate this without giving up ``ndim >= 2``:
       rb = ReplayBufferEnsemble(
           *buffers, sample_from_all=True, batch_size=256,
       )
-      collector = MultiCollector(
-          [make_env] * num_workers, policy,
+      collector = Collector(
+          make_env, policy,
+          num_collectors=num_workers,
+          sync=False,
           replay_buffer=rb,                              # see note below
           frames_per_batch=200, total_frames=-1,
       )
@@ -292,14 +295,14 @@ Concretely, ``ndim >= 2`` is straightforward for:
 
 * Single-process :class:`~torchrl.collectors.Collector` with a batched
   env (one process writes; the env dim is stable).
-* Synchronous :class:`~torchrl.collectors.MultiCollector` ``(sync=True)``
+* Synchronous ``Collector(num_collectors=N, sync=True)``
   with ``cat_results="stack"``, which delivers one ``[num_workers, T]``
   batch at a time *atomically*.
 
 It needs the ``set_truncated`` or ensemble mitigation above for:
 
-* :class:`~torchrl.collectors.MultiCollector` ``(sync=False)``.
-* :class:`~torchrl.collectors.distributed.RayCollector`,
+* ``Collector(num_collectors=N, sync=False)``.
+* ``Collector(backend="ray")``,
   :class:`~torchrl.collectors.distributed.DistributedSyncCollector`,
   RPC-based collectors.
 * Any setup where multiple producers ``extend`` the same shared storage
@@ -321,7 +324,7 @@ This is what passing the buffer directly to the collector and setting
 
 .. code-block:: python
 
-    from torchrl.collectors import MultiCollector
+    from torchrl.collectors import Collector
     from torchrl.data import LazyTensorStorage, SliceSampler, TensorDictReplayBuffer
 
     rb = TensorDictReplayBuffer(
@@ -329,9 +332,10 @@ This is what passing the buffer directly to the collector and setting
         sampler=SliceSampler(slice_len=32),         # auto-detects ("collector", "traj_ids")
         batch_size=256,
     )
-    collector = MultiCollector(
-        [make_env] * 4,
+    collector = Collector(
+        make_env,
         policy,
+        num_collectors=4,
         replay_buffer=rb,
         frames_per_batch=200,
         total_frames=-1,

--- a/docs/source/reference/glossary.rst
+++ b/docs/source/reference/glossary.rst
@@ -35,9 +35,11 @@ terms with the minimum context needed to find the relevant code.
       full lifecycle.
 
    Collector
-      The single-process data collector, exposed as
-      :class:`~torchrl.collectors.Collector`. It alternates policy calls and
-      environment steps to produce rollout tensordicts.
+      The main collector construction API,
+      :class:`~torchrl.collectors.Collector`. By default it alternates policy
+      calls and environment steps in the training process. ``backend`` and
+      ``num_collectors`` select local process, Ray, RPC, or distributed
+      implementations without changing the entry point.
 
    compact_obs
       Collector setting that drops observation and state keys from the
@@ -80,9 +82,8 @@ terms with the minimum context needed to find the relevant code.
    EnvCreator
       A small callable wrapper, :class:`~torchrl.envs.EnvCreator`, used to build
       environments lazily or in worker processes. It is useful when constructors
-      need to be serialized for :class:`~torchrl.collectors.MultiSyncCollector`,
-      :class:`~torchrl.collectors.MultiAsyncCollector`, or distributed
-      collectors.
+      need to be serialized for ``Collector(num_collectors=N)`` or another
+      distributed ``Collector`` backend.
 
    functional (loss)
       A :class:`~torchrl.objectives.LossModule` is *functional* when it stores

--- a/docs/source/reference/isaaclab.rst
+++ b/docs/source/reference/isaaclab.rst
@@ -160,7 +160,7 @@ Collector
 Because IsaacLab environments are **pre-vectorized** (a single ``gym.make``
 creates ~4096 parallel environments on the GPU), use a single
 :class:`~torchrl.collectors.Collector` — there is no need for
-``ParallelEnv`` or ``MultiCollector``:
+``ParallelEnv`` or a process-backed ``Collector``:
 
 .. code-block:: python
 
@@ -221,23 +221,28 @@ Key points:
   only GPU 0).
 - Falls back gracefully to single-GPU if only 1 GPU is available.
 
-RayCollector (alternative)
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ray backend (alternative)
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you need distributed collection across multiple GPUs/nodes, use
-:class:`~torchrl.collectors.distributed.RayCollector`:
+the main :class:`~torchrl.collectors.Collector` entry point with
+``backend="ray"``:
 
 .. code-block:: python
 
-    from torchrl.collectors.distributed import RayCollector
+    from torchrl.collectors import Collector
 
-    collector = RayCollector(
-        [make_env] * num_collectors,
+    collector = Collector(
+        make_env,
         policy,
+        backend="ray",
+        num_collectors=num_collectors,
         frames_per_batch=8192,
-        collector_kwargs={
-            "trust_policy": True,
-            "no_cuda_sync": True,
+        backend_options={
+            "collector_kwargs": {
+                "trust_policy": True,
+                "no_cuda_sync": True,
+            },
         },
     )
 

--- a/docs/source/reference/profiling.rst
+++ b/docs/source/reference/profiling.rst
@@ -75,10 +75,12 @@ warmup, active rollouts, ``export_chrome_trace`` on completion.
     os.environ["TORCHRL_PROFILING"] = "1"  # arms named ranges in every process
 
     import torchrl  # noqa: F401  -- import after the env var is set
-    from torchrl.collectors import MultiSyncCollector
+    from torchrl.collectors import Collector
 
-    collector = MultiSyncCollector(
-        create_env_fn=[make_env] * 4,
+    collector = Collector(
+        create_env_fn=make_env,
+        num_collectors=4,
+        sync=True,
         policy=policy,
         frames_per_batch=200,
         total_frames=20_000,
@@ -93,8 +95,8 @@ warmup, active rollouts, ``export_chrome_trace`` on completion.
         train(data)
     collector.shutdown()
 
-The same call works for a single-process :class:`~torchrl.collectors.Collector`
-and for :class:`~torchrl.collectors.distributed.RayCollector`. Per-worker
+The same call works for ``Collector(backend="direct")`` and
+``Collector(backend="ray")``. Per-worker
 ``_ProfilerHook`` instances are constructed with each worker's index, so
 ``{worker_idx}`` resolves correctly in ``save_path``.
 
@@ -166,7 +168,7 @@ The decorator's import-time gate runs in **every process** that imports
 - **Multi-process collectors / ParallelEnv subprocesses** — ``os.environ`` is
   inherited by spawned children, so setting ``TORCHRL_PROFILING=1`` in the
   parent before launching is sufficient.
-- **Ray actors** — TorchRL's :class:`~torchrl.collectors.distributed.RayCollector`
+- **Ray actors** — TorchRL's ``Collector(backend="ray")``
   and ``as_remote(...)`` automatically inject ``TORCHRL_PROFILING`` into each
   actor's ``runtime_env.env_vars`` when it is set on the driver, so remote
   workers are armed identically to the driver.

--- a/docs/source/reference/services_workflow.rst
+++ b/docs/source/reference/services_workflow.rst
@@ -24,6 +24,90 @@ answer:
 TorchRL services answer these questions with a common ownership model while
 preserving the domain API of each component.
 
+Scoped backend defaults
+-----------------------
+
+Backend contexts provide nestable defaults for objects constructed within a
+scope. They are task- and thread-local, restore the previous value after an
+exception, and are not inherited as construction defaults by forked collector
+workers.
+
+.. currentmodule:: torchrl
+
+.. autosummary::
+
+    service_backend
+    transport_backend
+
+.. code-block:: python
+
+    from functools import partial
+
+    from torchrl import service_backend, transport_backend
+    from torchrl.collectors import Collector
+    from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
+    from torchrl.modules.inference_server import InferenceServer
+
+    with service_backend("ray"), transport_backend("distributed"):
+        replay = TensorDictReplayBuffer(
+            storage=partial(LazyTensorStorage, 100_000),
+            batch_size=256,
+            service_backend_options={"remote_config": {"num_cpus": 1}},
+            transport_options={"backend": "gloo"},
+        )
+        inference = InferenceServer(
+            policy_factory=make_policy,
+            service_backend_options={"remote_config": {"num_cpus": 1}},
+            transport_options={"backend": "gloo"},
+        )
+        collector = Collector(
+            create_env_fn=make_env,
+            num_collectors=8,
+            policy=inference,
+            replay_buffer=replay,
+            backend_options={
+                "remote_configs": {"num_cpus": 1, "num_gpus": 0}
+            },
+            frames_per_batch=1024,
+        )
+
+The contexts select names only. Resource and protocol configuration remains in
+``service_backend_options``, ``transport_options``, or collector
+``backend_options``. Distributed transport uses Gloo by default; set
+``transport_options={"backend": "nccl"}`` for CUDA tensors. An explicit
+constructor value, including ``"auto"``, takes precedence over a contextual
+default. Unsupported component and backend combinations raise during
+construction, before workers or owners are launched.
+
+Collector placement may instead be selected explicitly. These forms leave the
+corresponding concrete collector classes available for existing code:
+
+.. code-block:: python
+
+    process_collector = Collector(
+        create_env_fn=make_env,
+        num_collectors=4,
+        backend="process",
+        frames_per_batch=1024,
+        sync=True,
+    )
+    ray_collector = Collector(
+        create_env_fn=make_env,
+        num_collectors=4,
+        backend="ray",
+        backend_options={"remote_configs": {"num_cpus": 1}},
+        frames_per_batch=1024,
+    )
+    distributed_collector = Collector(
+        create_env_fn=make_env,
+        num_collectors=4,
+        backend="distributed",
+        backend_options={"backend": "gloo", "launcher": "mp"},
+        frames_per_batch=1024,
+    )
+
+.. currentmodule:: torchrl.services
+
 Owners and clients
 ------------------
 
@@ -63,9 +147,11 @@ Placement does not define communication
 ---------------------------------------
 
 ``service_backend`` selects where ownership lives. TorchRL uses the canonical
-backend vocabulary ``direct``, ``thread``, ``process``, ``ray``, ``monarch``,
-and ``distributed``, but each service supports only the placements that fit
-its implementation.
+backend vocabulary ``direct``, ``thread``, ``process``, ``ray``, ``rpc``,
+``submitit``, ``monarch``, and ``distributed``, but each service supports only
+the placements that fit its implementation. ``rpc`` and ``submitit`` are
+collector construction choices; selecting either for a component that does
+not implement it fails that component's validation.
 
 Placement is intentionally separate from the operation protocol. The domains
 have incompatible communication requirements:
@@ -250,9 +336,10 @@ objects, or genuinely changing tensor layouts.
 Ray collectors and service transports
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:class:`~torchrl.collectors.distributed.RayCollector` deliberately has no
-``transport`` argument. A transport belongs to the endpoint that receives and
-serves the data:
+``Collector(backend="ray")`` returns a
+:class:`~torchrl.collectors.distributed.RayCollector`, which deliberately has
+no ``transport`` argument. A transport belongs to the endpoint that receives
+and serves the data:
 
 * policy requests use the attached inference server's transport;
 * replay writes use the attached replay buffer's transport; and
@@ -267,7 +354,7 @@ through Ray a second time. This is the recommended high-throughput topology:
 
     from functools import partial
 
-    from torchrl.collectors.distributed import RayCollector
+    from torchrl.collectors import Collector
     from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
     from torchrl.modules.inference_server import InferenceServer
 
@@ -286,14 +373,16 @@ through Ray a second time. This is the recommended high-throughput topology:
         transport="distributed",
         transport_options={"backend": "gloo"},
     )
-    collector = RayCollector(
-        create_env_fn=[make_env] * 8,
+    collector = Collector(
+        create_env_fn=make_env,
+        num_collectors=8,
+        backend="ray",
         policy=inference,
         replay_buffer=replay,
         frames_per_batch=1024,
     )
 
-If no replay buffer is attached, iterating over ``RayCollector`` returns
+If no replay buffer is attached, iterating over a Ray-backed ``Collector`` returns
 rollouts to the driver through Ray's object store. That collector-to-driver
 path is not transport-selectable. Use direct-to-replay collection when the
 rollouts are large and do not need to be inspected by the driver. Use the Ray

--- a/docs/source/reference/services_workflow.rst
+++ b/docs/source/reference/services_workflow.rst
@@ -34,10 +34,8 @@ workers.
 
 .. currentmodule:: torchrl
 
-.. autosummary::
-
-    service_backend
-    transport_backend
+.. autofunction:: service_backend
+.. autofunction:: transport_backend
 
 .. code-block:: python
 

--- a/examples/collectors/isaaclab_rnn_ppo_memory.py
+++ b/examples/collectors/isaaclab_rnn_ppo_memory.py
@@ -5,13 +5,14 @@
 """Recurrent PPO on Isaac Lab with configurable recurrent rollout storage.
 
 Demonstrates running large-vectorized Isaac Lab environments with an LSTM
-policy through a :class:`~torchrl.collectors.MultiCollector`. Isaac Lab is
+policy through a process-backed :class:`~torchrl.collectors.Collector`. Isaac Lab is
 launched only in the worker subprocesses (the main process never imports
 ``isaaclab``) so the main process can stay light and own the trainer.
 
 Key TorchRL features exercised:
 
-- :class:`~torchrl.collectors.MultiCollector` with ``policy_factory`` (each
+- :class:`~torchrl.collectors.Collector` with ``num_collectors`` and
+  ``policy_factory`` (each
   worker builds its own policy copy and receives weights via
   :class:`~torchrl.weight_update.MultiProcessWeightSyncScheme`).
 - Optional ``compact_obs=True`` to drop the redundant ``("next", obs)``.
@@ -64,7 +65,7 @@ from isaaclab_rnn_ppo_memory_utils import (
 )
 from tensordict.nn import CudaGraphModule
 from torchrl._utils import logger as torchrl_logger, timeit
-from torchrl.collectors import Evaluator, MultiCollector
+from torchrl.collectors import Collector, Evaluator
 from torchrl.data import LazyTensorStorage, ReplayBuffer
 from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
 from torchrl.envs import ExplorationType, set_exploration_type
@@ -214,7 +215,7 @@ def parse_args() -> argparse.Namespace:
         "--sync-collector",
         action=argparse.BooleanOptionalAction,
         default=False,
-        help="Synchronous MultiCollector. Async (default) yields per-worker batches.",
+        help="Synchronous process collection. Async yields per-worker batches.",
     )
     # Evaluation
     parser.add_argument(
@@ -384,8 +385,9 @@ def main() -> None:
         rnn_backend=args.rnn_backend,
         device=collector_device,
     )
-    collector = MultiCollector(
-        [make_env_fn] * args.num_collectors,
+    collector = Collector(
+        make_env_fn,
+        num_collectors=args.num_collectors,
         sync=args.sync_collector,
         policy_factory=collector_policy_factory,
         frames_per_batch=frames_per_batch,

--- a/examples/collectors/mp_collector_mps.py
+++ b/examples/collectors/mp_collector_mps.py
@@ -45,7 +45,7 @@ import torch
 from tensordict import TensorDictBase
 from tensordict.nn import TensorDictModule
 from torch import nn
-from torchrl.collectors import MultiSyncCollector, WeightUpdaterBase
+from torchrl.collectors import Collector, WeightUpdaterBase
 
 from torchrl.envs.libs.gym import GymEnv
 
@@ -91,8 +91,10 @@ if __name__ == "__main__":
     policy = policy_factory()
     policy_weights = tensordict.from_module(policy)
 
-    collector = MultiSyncCollector(
-        create_env_fn=[env_maker, env_maker],
+    collector = Collector(
+        create_env_fn=env_maker,
+        num_collectors=2,
+        sync=True,
         policy_factory=policy_factory,
         total_frames=2000,
         max_frames_per_traj=50,

--- a/examples/collectors/multi_weight_updates.py
+++ b/examples/collectors/multi_weight_updates.py
@@ -21,7 +21,7 @@ import torch.nn as nn
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 
-from torchrl.collectors import MultiSyncCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, ReplayBuffer
 from torchrl.envs.libs.gym import GymEnv
 from torchrl.envs.transforms.module import ModuleTransform
@@ -71,8 +71,10 @@ def main():
         "env.transform[0].module": MultiProcessWeightSyncScheme(strategy="tensordict"),
     }
 
-    collector = MultiSyncCollector(
-        create_env_fn=[make_env, make_env],
+    collector = Collector(
+        create_env_fn=make_env,
+        num_collectors=2,
+        sync=True,
         policy_factory=policy_factory,
         total_frames=2000,
         max_frames_per_traj=50,
@@ -82,7 +84,7 @@ def main():
         storing_device="cpu",
         weight_sync_schemes=weight_sync_schemes,
         replay_buffer=rb,
-        # extend_buffer=True is the default for MultiSyncCollector
+        # extend_buffer=True is the default for process-backed Collector
     )
 
     policy_weights = TensorDict.from_module(policy).data

--- a/examples/collectors/weight_sync_collectors.py
+++ b/examples/collectors/weight_sync_collectors.py
@@ -17,7 +17,7 @@ single collectors, multiple collectors, multiple models, and no synchronization.
 import torch.nn as nn
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
-from torchrl.collectors import Collector, MultiSyncCollector
+from torchrl.collectors import Collector
 from torchrl.envs import GymEnv
 from torchrl.weight_update import (
     MultiProcessWeightSyncScheme,
@@ -93,12 +93,10 @@ def example_multi_collector_shared_memory():
     scheme = SharedMemWeightSyncScheme(strategy="tensordict")
 
     print("Creating multi-collector with shared memory...")
-    collector = MultiSyncCollector(
-        create_env_fn=[
-            lambda: GymEnv("CartPole-v1"),
-            lambda: GymEnv("CartPole-v1"),
-            lambda: GymEnv("CartPole-v1"),
-        ],
+    collector = Collector(
+        create_env_fn=lambda: GymEnv("CartPole-v1"),
+        num_collectors=3,
+        sync=True,
         policy=policy,
         frames_per_batch=192,
         total_frames=400,

--- a/examples/distributed/ray_dqn_trainer.py
+++ b/examples/distributed/ray_dqn_trainer.py
@@ -19,7 +19,7 @@ import torch
 from tensordict.nn import TensorDictModule
 from torch import nn
 
-from torchrl.collectors.distributed import RayCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
 from torchrl.envs import GymEnv
 from torchrl.modules import QValueActor
@@ -68,14 +68,18 @@ def main() -> None:
         service_backend_options={"remote_config": {"num_cpus": 1}},
         transport="auto",
     )
-    collector = RayCollector(
-        create_env_fn=[make_env],
+    collector = Collector(
+        create_env_fn=make_env,
+        backend="ray",
+        num_collectors=1,
         policy=inference,
         replay_buffer=replay,
-        collector_class="single",
+        backend_options={
+            "collector_class": "single",
+            "remote_configs": {"num_cpus": 1, "num_gpus": 0},
+        },
         frames_per_batch=32,
         total_frames=128,
-        remote_configs={"num_cpus": 1, "num_gpus": 0},
         sync=True,
     )
 

--- a/examples/satellite/sac_per.py
+++ b/examples/satellite/sac_per.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import torch
 
 from torchrl._utils import logger as torchrl_logger
-from torchrl.collectors import Collector, Evaluator, MultiCollector
+from torchrl.collectors import Collector, Evaluator
 from torchrl.data import (
     LazyTensorStorage,
     TensorDictPrioritizedReplayBuffer,
@@ -747,20 +747,21 @@ def main(argv: list[str] | None = None) -> int:
         # Free the in-process train env: the worker will build its own.
         train_env.close()
         torchrl_logger.info(
-            "Async collector enabled (MultiCollector sync=False, 1 worker). "
+            "Async process collector enabled (sync=False, 1 worker). "
             "Collection runs in a separate process and overlaps with grad updates."
         )
-        collector = MultiCollector(
-            create_env_fn=[train_env_factory],
+        collector = Collector(
+            create_env_fn=train_env_factory,
+            num_collectors=1,
             policy=actor,
             frames_per_batch=frames_per_batch,
             total_frames=total_frames,
+            sync=False,
             device=device,
             init_random_frames=init_random_frames,
             exploration_type=ExplorationType.RANDOM,
             postproc=postproc,
             update_at_each_batch=True,
-            sync=False,
         )
     else:
         collector = Collector(

--- a/examples/satellite/sac_per_fully_async.py
+++ b/examples/satellite/sac_per_fully_async.py
@@ -24,7 +24,7 @@ from pathlib import Path
 import torch
 
 from torchrl._utils import logger as torchrl_logger
-from torchrl.collectors import Evaluator, MultiCollector
+from torchrl.collectors import Collector, Evaluator
 from torchrl.data import (
     LazyTensorStorage,
     TensorDictPrioritizedReplayBuffer,
@@ -412,8 +412,9 @@ def main(argv: list[str] | None = None) -> int:
         seed=cfg.seed,
     )
     frames_per_batch = cfg.num_envs * cfg.frames_per_env
-    collector = MultiCollector(
-        create_env_fn=[train_env_factory],
+    collector = Collector(
+        create_env_fn=train_env_factory,
+        num_collectors=1,
         policy=actor,
         replay_buffer=replay_buffer,
         frames_per_batch=frames_per_batch,
@@ -424,7 +425,7 @@ def main(argv: list[str] | None = None) -> int:
         sync=False,
     )
     torchrl_logger.info(
-        "MultiCollector(sync=False, replay_buffer=rb) ready -- starting "
+        "Collector(num_collectors=1, sync=False, replay_buffer=rb) ready -- starting "
         "async collection now."
     )
 

--- a/examples/services/README.md
+++ b/examples/services/README.md
@@ -11,7 +11,7 @@ to construction; the training loop consumes domain-compatible clients.
 | `multi_service_single_process.py` | Direct logger and replay buffer with threaded inference |
 | `multi_service_multiprocess.py` | Process logger and inference server with a direct replay buffer |
 | `multi_service_ray.py` | Ray logger, replay-buffer, and inference owners |
-| `ray_collector_services.py` | Ray-owned replay and inference composed with `RayCollector` |
+| `ray_collector_services.py` | Scoped Ray ownership and Gloo transport composed through `Collector` |
 | `multi_service_utils.py` | Shared service construction and training loop |
 | `distributed_services.py` | Basic service-registry usage |
 

--- a/examples/services/ray_collector_services.py
+++ b/examples/services/ray_collector_services.py
@@ -2,11 +2,11 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-"""Collect with Ray-owned replay and inference services.
+"""Collect with scoped Ray ownership and distributed tensor transports.
 
 The driver only constructs TorchRL objects. Replay storage, policy inference,
-and environment collection run in dedicated Ray actors; TorchRL creates and
-distributes the restricted transport clients internally.
+and environment collection run in dedicated Ray actors. TensorDict payloads
+use Gloo while TorchRL creates and distributes the restricted clients.
 
 Run from the repository root with ``python examples/services/ray_collector_services.py``.
 """
@@ -18,8 +18,9 @@ from functools import partial
 from tensordict.nn import TensorDictModule
 from torch import nn
 
+from torchrl import service_backend, transport_backend
 from torchrl._utils import logger as torchrl_logger
-from torchrl.collectors.distributed import RayCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
 from torchrl.envs import GymEnv
 from torchrl.modules.inference_server import InferenceServer
@@ -45,36 +46,38 @@ def main() -> None:
         "include_dashboard": False,
         "log_to_driver": False,
     }
-    replay = TensorDictReplayBuffer(
-        storage=partial(LazyTensorStorage, 1_000),
-        batch_size=4,
-        service_backend="ray",
-        service_backend_options={
-            "ray_init_config": ray_init_config,
-            "remote_config": {"num_cpus": 1},
-        },
-        transport="auto",
-    )
-    inference = InferenceServer(
-        policy_factory=make_policy,
-        service_backend="ray",
-        service_backend_options={
-            "remote_config": {"num_cpus": 1},
-        },
-        transport="auto",
-    )
-    collector = None
+    replay = inference = collector = None
     try:
-        collector = RayCollector(
-            create_env_fn=[make_env],
-            policy=inference,
-            replay_buffer=replay,
-            collector_class="single",
-            frames_per_batch=8,
-            total_frames=16,
-            remote_configs={"num_cpus": 1, "num_gpus": 0},
-            sync=True,
-        )
+        with service_backend("ray"), transport_backend("distributed"):
+            replay = TensorDictReplayBuffer(
+                storage=partial(LazyTensorStorage, 1_000),
+                batch_size=4,
+                service_backend_options={
+                    "ray_init_config": ray_init_config,
+                    "remote_config": {"num_cpus": 1},
+                },
+                transport_options={"backend": "gloo"},
+            )
+            inference = InferenceServer(
+                policy_factory=make_policy,
+                service_backend_options={
+                    "remote_config": {"num_cpus": 1},
+                },
+                transport_options={"backend": "gloo"},
+            )
+            collector = Collector(
+                create_env_fn=make_env,
+                num_collectors=1,
+                policy=inference,
+                replay_buffer=replay,
+                backend_options={
+                    "collector_class": "single",
+                    "remote_configs": {"num_cpus": 1, "num_gpus": 0},
+                },
+                frames_per_batch=8,
+                total_frames=16,
+                sync=True,
+            )
         for _ in collector:
             pass
 
@@ -87,8 +90,10 @@ def main() -> None:
     finally:
         if collector is not None:
             collector.shutdown()
-        inference.shutdown()
-        replay.shutdown()
+        if inference is not None:
+            inference.shutdown()
+        if replay is not None:
+            replay.shutdown()
 
 
 if __name__ == "__main__":

--- a/sota-implementations/dreamer/dreamer.py
+++ b/sota-implementations/dreamer/dreamer.py
@@ -268,7 +268,7 @@ def main(cfg: DictConfig):  # noqa: F821
 
         # Note: We do NOT compile rssm_prior/rssm_posterior here because they are
         # shared with the policy used in the collector. Compiling them would cause
-        # issues with the MultiCollector workers.
+        # issues with the process collector workers.
         #
         # Instead, we compile the loss modules themselves which wraps the forward pass.
         # fullgraph=False allows graph breaks which can help with inductor issues.

--- a/sota-implementations/dreamer/dreamer_utils.py
+++ b/sota-implementations/dreamer/dreamer_utils.py
@@ -22,7 +22,7 @@ from tensordict.nn import (
 )
 from torchrl import logger as torchrl_logger
 from torchrl._utils import set_profiling_enabled
-from torchrl.collectors import MultiCollector
+from torchrl.collectors import Collector
 
 from torchrl.data import (
     Bounded,
@@ -553,7 +553,7 @@ def make_environments(cfg, parallel_envs=1, logger=None):
     """Make environments for training and evaluation.
 
     Returns:
-        train_env_factory: A callable that creates a training environment (for MultiCollector)
+        train_env_factory: A callable that creates a training environment.
         eval_env: The evaluation environment instance
     """
 
@@ -898,7 +898,7 @@ def make_collector(
             Can also be a PolicyVersion instance for custom versioning.
 
     Returns:
-        MultiCollector in async mode with multiple worker processes
+        The process-backed collector in async mode with multiple workers.
 
     Device allocation:
         - If training on CUDA with multiple GPUs: collectors use cuda:1, cuda:2, etc.
@@ -925,8 +925,9 @@ def make_collector(
         if compile_cfg.cudagraphs:
             cudagraph_policy = True
 
-    collector = MultiCollector(
-        create_env_fn=[train_env_factory] * num_collectors,
+    collector = Collector(
+        create_env_fn=train_env_factory,
+        num_collectors=num_collectors,
         policy=actor_model_explore,
         frames_per_batch=cfg.collector.frames_per_batch,
         total_frames=-1,  # Run indefinitely until async_shutdown() is called

--- a/sota-implementations/impala/impala_multi_node_ray.py
+++ b/sota-implementations/impala/impala_multi_node_ray.py
@@ -23,7 +23,6 @@ def main(cfg: DictConfig):  # noqa: F821
 
     from tensordict import TensorDict
     from torchrl.collectors import Collector
-    from torchrl.collectors.distributed import RayCollector
     from torchrl.data import LazyMemmapStorage, TensorDictReplayBuffer
     from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
     from torchrl.envs import ExplorationType, set_exploration_type
@@ -90,16 +89,19 @@ def main(cfg: DictConfig):  # noqa: F821
         else 0,
         "memory": cfg.remote_worker_resources.memory,
     }
-    collector = RayCollector(
-        create_env_fn=[make_env(cfg.env.env_name, device, gym_backend=cfg.env.backend)]
-        * num_workers,
+    collector = Collector(
+        create_env_fn=make_env(cfg.env.env_name, device, gym_backend=cfg.env.backend),
+        backend="ray",
+        num_collectors=num_workers,
         policy=actor,
-        collector_class=Collector,
         frames_per_batch=frames_per_batch,
         total_frames=total_frames,
         max_frames_per_traj=-1,
-        ray_init_config=ray_init_config,
-        remote_configs=remote_config,
+        backend_options={
+            "collector_class": Collector,
+            "ray_init_config": ray_init_config,
+            "remote_configs": remote_config,
+        },
         sync=False,
         update_after_each_batch=True,
     )

--- a/sota-implementations/impala/impala_multi_node_submitit.py
+++ b/sota-implementations/impala/impala_multi_node_submitit.py
@@ -25,7 +25,6 @@ def main(cfg: DictConfig):  # noqa: F821
 
     from tensordict import TensorDict
     from torchrl.collectors import Collector
-    from torchrl.collectors.distributed import DistributedCollector
     from torchrl.data import LazyMemmapStorage, TensorDictReplayBuffer
     from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
     from torchrl.envs import ExplorationType, set_exploration_type
@@ -80,20 +79,22 @@ def main(cfg: DictConfig):  # noqa: F821
         raise NotImplementedError(
             f"device assignment not implemented for backend {cfg.collector.backend}"
         )
-    collector = DistributedCollector(
-        create_env_fn=[make_env(cfg.env.env_name, device, gym_backend=cfg.env.backend)]
-        * num_workers,
+    collector = Collector(
+        create_env_fn=make_env(cfg.env.env_name, device, gym_backend=cfg.env.backend),
+        backend="submitit",
+        num_collectors=num_workers,
         policy=actor,
-        num_workers_per_collector=1,
         frames_per_batch=frames_per_batch,
         total_frames=total_frames,
-        collector_class=Collector,
-        collector_kwargs=collector_kwargs,
-        slurm_kwargs=slurm_kwargs,
+        backend_options={
+            "backend": cfg.collector.backend,
+            "collector_class": Collector,
+            "collector_kwargs": collector_kwargs,
+            "num_workers_per_collector": 1,
+            "slurm_kwargs": slurm_kwargs,
+        },
         storing_device="cuda:0" if cfg.collector.backend == "nccl" else "cpu",
-        launcher="submitit",
         # update_after_each_batch=True,
-        backend=cfg.collector.backend,
     )
 
     # Create data buffer

--- a/sota-implementations/impala/impala_single_node.py
+++ b/sota-implementations/impala/impala_single_node.py
@@ -22,7 +22,7 @@ def main(cfg: DictConfig):  # noqa: F821
     import tqdm
 
     from tensordict import TensorDict
-    from torchrl.collectors import MultiAsyncCollector
+    from torchrl.collectors import Collector
     from torchrl.data import LazyMemmapStorage, TensorDictReplayBuffer
     from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
     from torchrl.envs import ExplorationType, set_exploration_type
@@ -61,9 +61,11 @@ def main(cfg: DictConfig):  # noqa: F821
     actor, critic = make_ppo_models(cfg.env.env_name, cfg.env.backend)
 
     # Create collector
-    collector = MultiAsyncCollector(
-        create_env_fn=[make_env(cfg.env.env_name, device, gym_backend=cfg.env.backend)]
-        * num_workers,
+    collector = Collector(
+        create_env_fn=make_env(cfg.env.env_name, device, gym_backend=cfg.env.backend),
+        backend="process",
+        num_collectors=num_workers,
+        sync=False,
         policy=actor,
         frames_per_batch=frames_per_batch,
         total_frames=total_frames,

--- a/sota-implementations/ppo-async/ppo_async_mujoco.py
+++ b/sota-implementations/ppo-async/ppo_async_mujoco.py
@@ -29,7 +29,7 @@ Supports three collection/advantage modes (configured via YAML):
     collector workers.
 
 Key components:
-  - MultiAsyncCollector for continuous background collection
+  - Collector with the async process backend for continuous collection
   - Replay buffer with StalenessAwareSampler for freshness-weighted sampling
   - Policy version tracking for staleness computation
   - IS diagnostics: ESS, max_ratio, mean_ratio, kl_approx

--- a/sota-implementations/ppo-async/train.py
+++ b/sota-implementations/ppo-async/train.py
@@ -19,7 +19,7 @@ from functools import partial
 import torch
 import tqdm
 
-from torchrl.collectors import Evaluator, MultiAsyncCollector
+from torchrl.collectors import Collector, Evaluator
 from torchrl.weight_update import SharedMemWeightSyncScheme
 from utils_mujoco import (
     ActorWithCritic,
@@ -110,19 +110,19 @@ def train_start(
         collector_policy = actor
         postproc = LearnerPostproc(version_counter)
 
-    create_env_fn = [
-        partial(
-            make_env,
-            cfg.env.env_name,
-            collect_device,
-            cfg.env.num_envs,
-            cfg.env.compile,
-        )
-    ]
+    create_env_fn = partial(
+        make_env,
+        cfg.env.env_name,
+        collect_device,
+        cfg.env.num_envs,
+        cfg.env.compile,
+    )
 
     # Collector init compiles the collector env in a subprocess
-    collector = MultiAsyncCollector(
+    collector = Collector(
         create_env_fn=create_env_fn,
+        num_collectors=1,
+        sync=False,
         policy=collector_policy,
         frames_per_batch=cfg.collector.frames_per_batch,
         total_frames=total_frames,
@@ -362,19 +362,19 @@ def train_iterate(
     """Semi-async training: for data in collector, gated on collector output."""
     collector_policy = ActorWithCritic(actor, critic)
 
-    create_env_fn = [
-        partial(
-            make_env,
-            cfg.env.env_name,
-            collect_device,
-            cfg.env.num_envs,
-            cfg.env.compile,
-        )
-    ]
+    create_env_fn = partial(
+        make_env,
+        cfg.env.env_name,
+        collect_device,
+        cfg.env.num_envs,
+        cfg.env.compile,
+    )
 
     # Collector init compiles the collector env in a subprocess
-    collector = MultiAsyncCollector(
+    collector = Collector(
         create_env_fn=create_env_fn,
+        num_collectors=1,
+        sync=False,
         policy=collector_policy,
         frames_per_batch=cfg.collector.frames_per_batch,
         total_frames=total_frames,

--- a/sota-implementations/vla_grpo/README.md
+++ b/sota-implementations/vla_grpo/README.md
@@ -235,9 +235,10 @@ lightweight logger client. Evaluation video is one synchronized grid recorded
 from the same ``env.eval_num_envs`` parallel rollouts used for reward and
 success metrics; it does not launch an extra rollout or select a single task.
 
-The collector path is fixed: a TorchRL `MultiCollector` launches rollout
-workers, each worker owns a sync `ParallelEnv(envs_per_collector)`, and all
-workers plus the evaluator share one process policy server.
+The collector path is fixed: TorchRL's `Collector` uses its process backend to
+launch rollout workers, each worker owns a sync
+`ParallelEnv(envs_per_collector)`, and all workers plus the evaluator share one
+process policy server.
 
 ```bash
 python sota-implementations/vla_grpo/vla-grpo.py --config-name vla_grpo_libero
@@ -290,8 +291,8 @@ A sequence-level ratio remains available as a config switch for ablations, but
 for a 56-token action chunk it saturates the clip range much more easily than
 per-token ratios.
 
-LIBERO simulation runs through `collector.num_collectors` MultiCollector
-workers. Each worker hosts a synchronous
+LIBERO simulation runs through `collector.num_collectors` process-backed
+collector workers. Each worker hosts a synchronous
 `ParallelEnv(collector.envs_per_collector)`. Policy inference runs on the
 shared process server and each worker owns a disjoint `group_id` block so
 advantages never mix across unrelated groups.

--- a/sota-implementations/vla_grpo/test_openvla.py
+++ b/sota-implementations/vla_grpo/test_openvla.py
@@ -483,7 +483,7 @@ def _complete_logger_cfg(**logger_overrides):
 
 
 class TestCollectorFactory:
-    def test_make_collector_uses_multicollector_policy_server(self, monkeypatch):
+    def test_make_collector_uses_process_backend_policy_server(self, monkeypatch):
         captured = {}
 
         class _FakeMultiCollector:
@@ -517,7 +517,7 @@ class TestCollectorFactory:
         )
         replay_buffer = object()
 
-        monkeypatch.setattr(utils, "MultiCollector", _FakeMultiCollector)
+        monkeypatch.setattr(utils, "Collector", _FakeMultiCollector)
         monkeypatch.setattr(utils, "ProcessInferenceServer", _FakeServer)
         monkeypatch.setattr(utils, "MPTransport", _FakeTransport)
 
@@ -618,7 +618,7 @@ class TestCollectorFactory:
         )
         replay_buffer = SimpleNamespace(shared=True)
 
-        monkeypatch.setattr(utils, "MultiCollector", _FakeMultiCollector)
+        monkeypatch.setattr(utils, "Collector", _FakeMultiCollector)
         monkeypatch.setattr(utils, "ProcessInferenceServer", _FakeServer)
         monkeypatch.setattr(utils, "MPTransport", _FakeTransport)
 

--- a/sota-implementations/vla_grpo/utils.py
+++ b/sota-implementations/vla_grpo/utils.py
@@ -34,7 +34,7 @@ import torch
 
 from tensordict import NonTensorData, TensorDict, TensorDictBase
 from torchrl._utils import logger as torchrl_logger, timeit
-from torchrl.collectors import Evaluator, MultiCollector
+from torchrl.collectors import BaseCollector, Collector, Evaluator
 from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
 from torchrl.data.vla import (
     ACTION_TOKENS_KEY,
@@ -859,13 +859,13 @@ def make_collector(
     tokenizer: ActionTokenizerBase | None,
     replay_buffer: TensorDictReplayBuffer,
     post_collect_hook: Callable[[TensorDictBase], None] | None = None,
-) -> tuple[MultiCollector, ProcessInferenceServer, PolicyClientModule]:
+) -> tuple[BaseCollector, ProcessInferenceServer, PolicyClientModule]:
     """Build the TorchRL-native VLA rollout stack.
 
-    The stack is always a ``MultiCollector`` whose workers own batched
-    ``ParallelEnv`` instances and call a shared process policy server through
-    ``PolicyClientModule``. The collector writes complete trajectories directly
-    into the replay buffer.
+    The stack uses the process backend of ``Collector``. Its concrete
+    ``MultiCollector`` workers own batched ``ParallelEnv`` instances and call a
+    shared process policy server through ``PolicyClientModule``. The collector
+    writes complete trajectories directly into the replay buffer.
     """
     num_collectors = int(cfg.collector.num_collectors)
     envs_per_collector = int(cfg.collector.envs_per_collector)
@@ -961,8 +961,9 @@ def make_collector(
         in_keys=policy_in_keys,
         out_keys=policy_out_keys,
     )
-    collector = MultiCollector(
+    collector = Collector(
         env_factories,
+        backend="process",
         policy=None,
         policy_factory=policy_client_factories,
         frames_per_batch=envs_per_collector,
@@ -1236,7 +1237,7 @@ _WORKER_ADVANTAGE_PATH = "replay_buffer._transform[0]"
 
 
 def _advantage_stats(
-    advantage: MCAdvantage, collector: MultiCollector | None = None
+    advantage: MCAdvantage, collector: BaseCollector | None = None
 ) -> list[dict[str, float | int]]:
     if collector is not None and not advantage.is_shared:
         return collector.map_fn(f"{_WORKER_ADVANTAGE_PATH}.get_stats")
@@ -1244,7 +1245,7 @@ def _advantage_stats(
 
 
 def reset_advantage_state(
-    advantage: MCAdvantage, collector: MultiCollector | None = None
+    advantage: MCAdvantage, collector: BaseCollector | None = None
 ) -> None:
     """Clear incomplete groups and reset counters at a policy boundary."""
     advantage.clear_queues()
@@ -1254,14 +1255,14 @@ def reset_advantage_state(
         collector.map_fn(f"{_WORKER_ADVANTAGE_PATH}.reset_stats")
 
 
-def reset_collection_state(advantage: MCAdvantage, collector: MultiCollector) -> None:
+def reset_collection_state(advantage: MCAdvantage, collector: BaseCollector) -> None:
     """Drop partial trajectories before advancing the behavior policy."""
     reset_advantage_state(advantage, collector)
     collector.map_fn("reset")
 
 
 def advantage_metrics(
-    advantage: MCAdvantage, collector: MultiCollector | None = None
+    advantage: MCAdvantage, collector: BaseCollector | None = None
 ) -> dict[str, float | int]:
     """Compact metrics snapshot from GRPO replay-transform writer states."""
     stats = _advantage_stats(advantage, collector)

--- a/test/rb/test_rb_distributed.py
+++ b/test/rb/test_rb_distributed.py
@@ -17,6 +17,7 @@ import torch.distributed.rpc as rpc
 import torch.multiprocessing as mp
 from _rb_common import _has_ray
 from tensordict import TensorDict
+from torchrl import service_backend, transport_backend
 from torchrl._utils import logger as torchrl_logger
 from torchrl.data import RayReplayBuffer, ReplayBuffer
 from torchrl.data.replay_buffers import RemoteTensorDictReplayBuffer
@@ -244,14 +245,14 @@ class TestRayRB:
     def test_construct_from_replay_buffer_service_backend(self):
         import ray
 
-        rb = ReplayBuffer(
-            storage=partial(LazyTensorStorage, 100),
-            service_backend="ray",
-            service_backend_options={
-                "ray_init_config": {"num_cpus": 1},
-                "remote_config": {"num_cpus": 0},
-            },
-        )
+        with service_backend("ray"):
+            rb = ReplayBuffer(
+                storage=partial(LazyTensorStorage, 100),
+                service_backend_options={
+                    "ray_init_config": {"num_cpus": 1},
+                    "remote_config": {"num_cpus": 0},
+                },
+            )
         try:
             assert isinstance(rb, RayReplayBuffer)
             assert isinstance(rb, ReplayBuffer)
@@ -268,14 +269,13 @@ class TestRayRB:
         rb.shutdown()
 
     def test_ray_replay_with_gloo_transport(self):
-        rb = ReplayBuffer(
-            storage=partial(LazyTensorStorage, 100),
-            batch_size=4,
-            service_backend="ray",
-            service_backend_options={"remote_config": {"num_cpus": 0}},
-            transport="distributed",
-            transport_options={"backend": "gloo", "timeout": 30.0},
-        )
+        with service_backend("ray"), transport_backend("distributed"):
+            rb = ReplayBuffer(
+                storage=partial(LazyTensorStorage, 100),
+                batch_size=4,
+                service_backend_options={"remote_config": {"num_cpus": 0}},
+                transport_options={"timeout": 30.0},
+            )
         try:
             client = rb.client()
             indices = client.extend(

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -758,6 +758,21 @@ class TestCollectorGeneric:
         finally:
             collector.shutdown()
 
+    def test_ray_backend_rejects_direct_replay_buffer(self):
+        replay = ReplayBuffer()
+        try:
+            with pytest.raises(
+                TypeError, match="cannot be shared with distant Ray actors"
+            ):
+                Collector(
+                    ContinuousActionVecMockEnv,
+                    backend="ray",
+                    replay_buffer=replay,
+                    frames_per_batch=20,
+                )
+        finally:
+            replay.shutdown()
+
     def test_concrete_default_divergences_are_pinned(self):
         collector_parameters = inspect.signature(Collector.__init__).parameters
         expected = {

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -61,7 +61,9 @@ from torchrl.collectors import (
 from torchrl.collectors._base import _ProfilerHook
 from torchrl.collectors._constants import _Interruptor
 from torchrl.collectors._multi_base import MultiCollector
+from torchrl.collectors.distributed.generic import DistributedCollector
 from torchrl.collectors.distributed.ray import _has_ray, RayCollector
+from torchrl.collectors.distributed.rpc import RPCCollector
 
 from torchrl.collectors.utils import (
     _make_policy_factory,
@@ -743,6 +745,60 @@ class TestCollectorGeneric:
         assert result is sentinel
         assert target.call_args.kwargs["sync"] is False
 
+    def test_explicit_direct_backend_overrides_context(self):
+        with service_backend("ray"):
+            collector = Collector(
+                ContinuousActionVecMockEnv,
+                backend="direct",
+                frames_per_batch=20,
+                total_frames=20,
+            )
+        try:
+            assert type(collector) is Collector
+        finally:
+            collector.shutdown()
+
+    def test_concrete_default_divergences_are_pinned(self):
+        collector_parameters = inspect.signature(Collector.__init__).parameters
+        expected = {
+            MultiCollector: set(),
+            RayCollector: {
+                "init_random_frames",
+                "max_frames_per_traj",
+                "no_cuda_sync",
+                "split_trajs",
+            },
+            RPCCollector: {
+                "init_random_frames",
+                "max_frames_per_traj",
+                "split_trajs",
+            },
+            DistributedCollector: {
+                "init_random_frames",
+                "max_frames_per_traj",
+                "split_trajs",
+            },
+        }
+        ignored = {
+            "self",
+            "backend",
+            "backend_options",
+            "num_collectors",
+            "sync",
+            "kwargs",
+        }
+        for target, expected_divergences in expected.items():
+            target_parameters = inspect.signature(target.__init__).parameters
+            divergences = {
+                name
+                for name, parameter in collector_parameters.items()
+                if name not in ignored
+                and parameter.default is not inspect.Parameter.empty
+                and name in target_parameters
+                and target_parameters[name].default != parameter.default
+            }
+            assert divergences == expected_divergences
+
     def test_sequence_inference_and_options_are_not_mutated(self):
         options = {"remote_configs": {"num_cpus": 1}}
         with patch("torchrl.collectors.distributed.ray.RayCollector") as target:
@@ -847,6 +903,14 @@ class TestCollectorGeneric:
                 ContinuousActionVecMockEnv,
                 backend="submitit",
                 backend_options={"launcher": "mp"},
+                frames_per_batch=20,
+            )
+        with pytest.raises(TypeError, match="at most"):
+            Collector(
+                ContinuousActionVecMockEnv,
+                None,
+                3,
+                backend="process",
                 frames_per_batch=20,
             )
 

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -8,6 +8,7 @@ import argparse
 import contextlib
 import functools
 import gc
+import inspect
 import os
 import subprocess
 import sys
@@ -40,6 +41,7 @@ from tensordict.nn import (
     TensorDictSequential,
 )
 from torch import nn
+from torchrl import service_backend
 from torchrl._utils import (
     _make_ordinal_device,
     _replace_last,
@@ -676,6 +678,195 @@ class TestRandomPolicyLazyInit:
 
 
 class TestCollectorGeneric:
+    def test_public_signature(self):
+        signature = inspect.signature(Collector)
+        assert "self" not in signature.parameters
+        assert signature.parameters["backend"].default is None
+        assert signature.parameters["backend_options"].default is None
+        assert signature.parameters["num_collectors"].default is None
+        assert signature.parameters["sync"].default is None
+
+    @pytest.mark.parametrize(
+        ("backend", "target_path"),
+        [
+            ("process", "torchrl.collectors._multi_base.MultiCollector"),
+            ("multiprocessing", "torchrl.collectors._multi_base.MultiCollector"),
+            ("ray", "torchrl.collectors.distributed.ray.RayCollector"),
+            ("rpc", "torchrl.collectors.distributed.rpc.RPCCollector"),
+            (
+                "distributed",
+                "torchrl.collectors.distributed.generic.DistributedCollector",
+            ),
+            (
+                "submitit",
+                "torchrl.collectors.distributed.generic.DistributedCollector",
+            ),
+        ],
+    )
+    def test_backend_dispatch(self, backend, target_path):
+        sentinel = object()
+        with patch(target_path) as target:
+            target.return_value = sentinel
+            result = Collector(
+                ContinuousActionVecMockEnv,
+                backend=backend,
+                backend_options={"test_backend_option": 1},
+                num_collectors=2,
+                frames_per_batch=20,
+                total_frames=20,
+            )
+
+        assert result is sentinel
+        call_args, call_kwargs = target.call_args
+        assert call_args[0] == [
+            ContinuousActionVecMockEnv,
+            ContinuousActionVecMockEnv,
+        ]
+        assert call_kwargs["sync"] is False
+        assert call_kwargs["test_backend_option"] == 1
+        if backend == "ray":
+            assert call_kwargs["num_collectors"] == 2
+        if backend == "submitit":
+            assert call_kwargs["launcher"] == "submitit"
+
+    def test_context_backend_dispatch(self):
+        sentinel = object()
+        with patch("torchrl.collectors.distributed.rpc.RPCCollector") as target:
+            target.return_value = sentinel
+            with service_backend("rpc"):
+                result = Collector(
+                    ContinuousActionVecMockEnv,
+                    num_collectors=2,
+                    frames_per_batch=20,
+                    total_frames=20,
+                )
+        assert result is sentinel
+        assert target.call_args.kwargs["sync"] is False
+
+    def test_sequence_inference_and_options_are_not_mutated(self):
+        options = {"remote_configs": {"num_cpus": 1}}
+        with patch("torchrl.collectors.distributed.ray.RayCollector") as target:
+            Collector(
+                [ContinuousActionVecMockEnv, ContinuousActionVecMockEnv],
+                backend="ray",
+                backend_options=options,
+                frames_per_batch=20,
+            )
+        assert target.call_args.kwargs["num_collectors"] == 2
+        assert options == {"remote_configs": {"num_cpus": 1}}
+
+        with patch(
+            "torchrl.collectors.distributed.generic.DistributedCollector"
+        ) as target:
+            Collector(
+                ContinuousActionVecMockEnv,
+                backend="distributed",
+                backend_options={"backend": "gloo", "launcher": "mp"},
+                frames_per_batch=20,
+            )
+        assert target.call_args.kwargs["backend"] == "gloo"
+        assert target.call_args.kwargs["launcher"] == "mp"
+
+        direct = Collector(
+            [ContinuousActionVecMockEnv],
+            backend="direct",
+            num_collectors=1,
+            frames_per_batch=20,
+        )
+        try:
+            assert type(direct) is Collector
+        finally:
+            direct.shutdown()
+
+    def test_backend_dispatch_validation(self):
+        with pytest.raises(ValueError, match="does not match"):
+            Collector(
+                [ContinuousActionVecMockEnv],
+                backend="process",
+                num_collectors=2,
+                frames_per_batch=20,
+            )
+        with pytest.raises(ValueError, match="duplicate"):
+            Collector(
+                ContinuousActionVecMockEnv,
+                backend="ray",
+                backend_options={"remote_configs": {}},
+                remote_configs={},
+                frames_per_batch=20,
+            )
+        with pytest.raises(ValueError, match="reserved"):
+            Collector(
+                ContinuousActionVecMockEnv,
+                backend="process",
+                backend_options={"sync": True},
+                frames_per_batch=20,
+            )
+        with pytest.raises(ValueError, match="at most one"):
+            Collector(
+                ContinuousActionVecMockEnv,
+                backend="direct",
+                num_collectors=2,
+                frames_per_batch=20,
+            )
+        with pytest.raises(ValueError, match="exactly one"):
+            Collector(
+                [ContinuousActionVecMockEnv, ContinuousActionVecMockEnv],
+                backend="direct",
+                frames_per_batch=20,
+            )
+        with pytest.raises(ValueError, match="positive integer"):
+            Collector(
+                ContinuousActionVecMockEnv,
+                backend="process",
+                num_collectors=0,
+                frames_per_batch=20,
+            )
+        with pytest.raises(TypeError, match="positive integer"):
+            Collector(
+                ContinuousActionVecMockEnv,
+                backend="process",
+                num_collectors=True,
+                frames_per_batch=20,
+            )
+        with pytest.raises(ValueError, match="duplicate"):
+            Collector(
+                ContinuousActionVecMockEnv,
+                None,
+                backend="process",
+                backend_options={"policy": None},
+                frames_per_batch=20,
+            )
+        with service_backend("thread"):
+            with pytest.raises(ValueError, match="does not support"):
+                Collector(
+                    ContinuousActionVecMockEnv,
+                    frames_per_batch=20,
+                )
+        with pytest.raises(ValueError, match="requires launcher='submitit'"):
+            Collector(
+                ContinuousActionVecMockEnv,
+                backend="submitit",
+                backend_options={"launcher": "mp"},
+                frames_per_batch=20,
+            )
+
+    def test_process_backend_smoke_and_context_isolation(self):
+        with service_backend("process"):
+            collector = Collector(
+                ContinuousActionVecMockEnv,
+                num_collectors=2,
+                sync=True,
+                frames_per_batch=20,
+                total_frames=20,
+            )
+            try:
+                assert isinstance(collector, MultiSyncCollector)
+                assert not isinstance(collector, Collector)
+                batch = next(iter(collector))
+                assert batch.numel() == 20
+            finally:
+                collector.shutdown()
+
     def test_collector_without_traj_ids(self):
         env = CountingEnv(max_steps=3)
         collector = Collector(

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -893,7 +893,9 @@ class TestCollectorGeneric:
                 frames_per_batch=20,
             )
         with service_backend("thread"):
-            with pytest.raises(ValueError, match="does not support"):
+            with pytest.raises(
+                ValueError, match="enclosing torchrl.service_backend context"
+            ):
                 Collector(
                     ContinuousActionVecMockEnv,
                     frames_per_batch=20,

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -1101,6 +1101,28 @@ class TestModuleConfigs:
     not _configs_available, reason="Config system requires hydra-core and omegaconf"
 )
 class TestCollectorsConfig:
+    @pytest.mark.skipif(not _has_gymnasium, reason="Gymnasium is not installed")
+    @pytest.mark.skipif(not _has_hydra, reason="Hydra is not installed")
+    def test_generic_collector_backend_fields(self):
+        from hydra.utils import instantiate
+        from torchrl.trainers.algorithms.configs.collectors import CollectorConfig
+        from torchrl.trainers.algorithms.configs.envs_libs import GymEnvConfig
+
+        cfg = CollectorConfig(
+            create_env_fn=GymEnvConfig(env_name="Pendulum-v1"),
+            backend="process",
+            num_collectors=1,
+            sync=True,
+            frames_per_batch=10,
+            total_frames=10,
+        )
+        collector = instantiate(cfg)
+        try:
+            assert isinstance(collector, MultiSyncCollector)
+            assert next(iter(collector)).numel() == 10
+        finally:
+            collector.shutdown()
+
     @pytest.mark.parametrize("factory", [True, False])
     @pytest.mark.parametrize("collector", ["async", "multi_sync", "multi_async"])
     @pytest.mark.skipif(not _has_gymnasium, reason="Gymnasium is not installed")

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -27,6 +27,7 @@ from tensordict import NestedKey, TensorDict
 from tensordict.nn import TensorDictModule, TensorDictModuleBase, TensorDictSequential
 
 from torch import multiprocessing as mp, nn
+from torchrl import service_backend
 from torchrl._utils import logger as torchrl_logger
 from torchrl.checkpoint import Checkpoint
 
@@ -1380,39 +1381,43 @@ class TestRayCollector(DistributedCollectorBase):
             replay.shutdown()
 
     def test_ray_owned_inference_and_replay(self):
-        replay = TensorDictReplayBuffer(
-            storage=partial(LazyTensorStorage, 100),
-            batch_size=4,
-            service_backend="ray",
-            service_backend_options={"remote_config": {"num_cpus": 0}},
-            transport="auto",
-        )
-        inference = InferenceServer(
-            policy_factory=CountingPolicy,
-            service_backend="ray",
-            service_backend_options={"remote_config": {"num_cpus": 0}},
-            transport="auto",
-        )
-        collector = None
+        replay = inference = collector = None
         try:
-            collector = RayCollector(
-                create_env_fn=[CountingEnv],
-                policy=inference,
-                replay_buffer=replay,
-                collector_class=Collector,
-                frames_per_batch=8,
-                total_frames=16,
-                remote_configs={"num_cpus": 1, "num_gpus": 0},
-                sync=True,
-            )
+            with service_backend("ray"):
+                replay = TensorDictReplayBuffer(
+                    storage=partial(LazyTensorStorage, 100),
+                    batch_size=4,
+                    service_backend_options={"remote_config": {"num_cpus": 0}},
+                    transport="auto",
+                )
+                inference = InferenceServer(
+                    policy_factory=CountingPolicy,
+                    service_backend_options={"remote_config": {"num_cpus": 0}},
+                    transport="auto",
+                )
+                collector = Collector(
+                    create_env_fn=CountingEnv,
+                    num_collectors=1,
+                    policy=inference,
+                    replay_buffer=replay,
+                    backend_options={
+                        "collector_class": Collector,
+                        "remote_configs": {"num_cpus": 1, "num_gpus": 0},
+                    },
+                    frames_per_batch=8,
+                    total_frames=16,
+                    sync=True,
+                )
             assert all(batch is None for batch in collector)
             assert len(replay) == 16
             assert replay.sample().shape == (4,)
         finally:
             if collector is not None:
                 collector.shutdown()
-            inference.shutdown()
-            replay.shutdown()
+            if inference is not None:
+                inference.shutdown()
+            if replay is not None:
+                replay.shutdown()
 
     def test_ray_collector_pause_drains_and_resumes(self):
         replay = TensorDictReplayBuffer(

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -25,6 +25,7 @@ from tensordict.nn.probabilistic import (
     InteractionType,
     set_interaction_type,
 )
+from torchrl import service_backend, transport_backend
 from torchrl._comm import (
     CommandChannel,
     Mailbox,
@@ -275,6 +276,23 @@ class TestInferenceTransportABC:
 
 
 class TestInferenceServerCore:
+    def test_contextual_thread_service_and_transport(self):
+        with service_backend("thread"), transport_backend("direct"):
+            server = InferenceServer(_make_policy(), num_clients=1)
+        try:
+            assert server.service_backend == "thread"
+            assert server.transport_kind == "direct"
+        finally:
+            server.shutdown()
+
+    def test_explicit_auto_transport_overrides_context(self):
+        with transport_backend("distributed"):
+            server = InferenceServer(_make_policy(), transport="auto")
+        try:
+            assert server.transport_kind == "thread"
+        finally:
+            server.shutdown()
+
     def test_canonical_thread_constructor(self):
         with InferenceServer(_make_policy(), transport="auto") as server:
             assert server.service_backend == "thread"
@@ -1548,16 +1566,16 @@ class TestRayTransport:
 
     def test_canonical_ray_owned_inference(self):
         ray = _ray_lib()
-        server = InferenceServer(
-            policy_factory=lambda: TensorDictModule(
-                nn.Linear(4, 2),
-                in_keys=["observation"],
-                out_keys=["action"],
-            ),
-            service_backend="ray",
-            service_backend_options={"remote_config": {"num_cpus": 0}},
-            transport="auto",
-        )
+        with service_backend("ray"):
+            server = InferenceServer(
+                policy_factory=lambda: TensorDictModule(
+                    nn.Linear(4, 2),
+                    in_keys=["observation"],
+                    out_keys=["action"],
+                ),
+                service_backend_options={"remote_config": {"num_cpus": 0}},
+                transport="auto",
+            )
         try:
             assert server.service_backend == "ray"
             assert server.transport_kind == "ray"

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -293,6 +293,19 @@ class TestInferenceServerCore:
         finally:
             server.shutdown()
 
+    def test_contextual_backend_errors_report_the_context(self):
+        with service_backend("distributed"):
+            with pytest.raises(
+                ValueError, match="enclosing torchrl.service_backend context"
+            ):
+                InferenceServer(_make_policy())
+
+        with transport_backend("distributed"):
+            with pytest.raises(
+                ValueError, match="enclosing torchrl.transport_backend context"
+            ):
+                InferenceServer(_make_policy())
+
     def test_canonical_thread_constructor(self):
         with InferenceServer(_make_policy(), transport="auto") as server:
             assert server.service_backend == "thread"

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,8 +5,10 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import os
 import sys
+import threading
 from copy import copy
 from importlib import import_module
 from unittest import mock
@@ -22,8 +24,12 @@ from torchrl import (
     cuda_memory_profile,
     cuda_memory_stats,
     reset_cuda_peak_stats,
+    service_backend,
+    transport_backend,
 )
+from torchrl._comm.backends import _get_service_backend, _get_transport_backend
 from torchrl._utils import _rng_decorator, as_remote, get_binary_env_var, implement_for
+from torchrl.data import ReplayBuffer
 from torchrl.envs.libs.gym import gym_backend, GymWrapper, set_gym_backend
 
 from torchrl.objectives.utils import _pseudo_vmap
@@ -31,6 +37,71 @@ from torchrl.objectives.utils import _pseudo_vmap
 from torchrl.testing import get_default_devices, gym_helpers as _gym_helpers
 
 TORCH_VERSION = version.parse(version.parse(torch.__version__).base_version)
+
+
+def test_backend_contexts_are_nested_and_process_local():
+    assert _get_service_backend() is None
+    assert _get_transport_backend() is None
+
+    with service_backend("ray"), transport_backend("distributed"):
+        assert _get_service_backend() == "ray"
+        assert _get_transport_backend() == "distributed"
+        with service_backend("process"):
+            assert _get_service_backend() == "process"
+        assert _get_service_backend() == "ray"
+        with transport_backend("ray"):
+            assert _get_transport_backend() == "ray"
+        assert _get_transport_backend() == "distributed"
+
+        with mock.patch(
+            "torchrl._comm.backends.os.getpid", return_value=os.getpid() + 1
+        ):
+            assert _get_service_backend() is None
+            assert _get_transport_backend() is None
+
+    assert _get_service_backend() is None
+    assert _get_transport_backend() is None
+
+
+def test_backend_contexts_restore_after_error_and_do_not_cross_threads():
+    thread_values = []
+
+    with pytest.raises(RuntimeError, match="context failure"):
+        with service_backend("ray"), transport_backend("distributed"):
+            thread = threading.Thread(
+                target=lambda: thread_values.append(
+                    (_get_service_backend(), _get_transport_backend())
+                )
+            )
+            thread.start()
+            thread.join()
+            raise RuntimeError("context failure")
+
+    assert thread_values == [(None, None)]
+    assert _get_service_backend() is None
+    assert _get_transport_backend() is None
+
+
+def test_backend_contexts_are_isolated_between_async_tasks():
+    async def read_in_context(backend):
+        with service_backend(backend):
+            await asyncio.sleep(0)
+            return _get_service_backend()
+
+    async def gather_values():
+        return await asyncio.gather(read_in_context("ray"), read_in_context("process"))
+
+    assert asyncio.run(gather_values()) == ["ray", "process"]
+    assert _get_service_backend() is None
+
+
+def test_explicit_backend_values_override_context():
+    with service_backend("ray"), transport_backend("distributed"):
+        replay = ReplayBuffer(service_backend="direct", transport="auto")
+    try:
+        assert replay.service_backend == "direct"
+    finally:
+        replay.shutdown()
 
 
 def _clear_gym_implement_for_state():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -104,6 +104,20 @@ def test_explicit_backend_values_override_context():
         replay.shutdown()
 
 
+def test_context_selected_backend_errors_report_the_context():
+    with service_backend("process"):
+        with pytest.raises(
+            ValueError, match="enclosing torchrl.service_backend context"
+        ):
+            ReplayBuffer()
+
+    with transport_backend("distributed"):
+        with pytest.raises(
+            ValueError, match="enclosing torchrl.transport_backend context"
+        ):
+            ReplayBuffer()
+
+
 def _clear_gym_implement_for_state():
     """Clear all gym/gymnasium-related state from implement_for caches.
 

--- a/torchrl/__init__.py
+++ b/torchrl/__init__.py
@@ -58,6 +58,7 @@ except ImportError:
 
 _init_extension()
 
+from torchrl._comm.backends import service_backend, transport_backend  # noqa: E402
 from torchrl._utils import (  # noqa: E402
     _get_default_mp_start_method,
     auto_unwrap_transformed_env,
@@ -150,6 +151,8 @@ __all__ = [
     "merge_ray_runtime_env",
     "reset_cuda_peak_stats",
     "set_auto_unwrap_transformed_env",
+    "service_backend",
     "timeit",
     "torchrl_logger",
+    "transport_backend",
 ]

--- a/torchrl/_comm/__init__.py
+++ b/torchrl/_comm/__init__.py
@@ -6,8 +6,11 @@ from __future__ import annotations
 
 from torchrl._comm.backends import (
     normalize_service_backend,
+    service_backend,
     ServiceBackend,
     ServiceBackendAlias,
+    transport_backend,
+    TransportBackend,
 )
 from torchrl._comm.command import CommandChannel, CommandClient, CommandRequest
 from torchrl._comm.mailbox import (
@@ -42,6 +45,9 @@ __all__ = [
     "ServiceBackendAlias",
     "SharedBlock",
     "TCPStoreRendezvous",
+    "TransportBackend",
     "normalize_service_backend",
+    "service_backend",
+    "transport_backend",
     "watch_process_liveness",
 ]

--- a/torchrl/_comm/backends.py
+++ b/torchrl/_comm/backends.py
@@ -143,6 +143,24 @@ def _get_transport_backend() -> TransportBackend | None:
     return cast(TransportBackend | None, _context_value(_TRANSPORT_BACKEND_CONTEXT))
 
 
+def _contextual_backend_error(
+    message: str,
+    *,
+    service: bool = False,
+    transport: bool = False,
+) -> str:
+    """Annotate a validation error with the scoped default that selected it."""
+    contexts = []
+    if service:
+        contexts.append("torchrl.service_backend")
+    if transport:
+        contexts.append("torchrl.transport_backend")
+    if not contexts:
+        return message
+    context_names = " and ".join(contexts)
+    return f"{message} (selected by an enclosing {context_names} context.)"
+
+
 def _resolve_service_backend(
     backend: ServiceBackend | ServiceBackendAlias | str | None,
     *,

--- a/torchrl/_comm/backends.py
+++ b/torchrl/_comm/backends.py
@@ -4,19 +4,72 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import contextlib
+import contextvars
+import os
+from collections.abc import Iterator
 from typing import cast, Literal, TypeAlias
 
 ServiceBackend: TypeAlias = Literal[
-    "direct", "thread", "process", "ray", "monarch", "distributed"
+    "direct",
+    "thread",
+    "process",
+    "ray",
+    "rpc",
+    "submitit",
+    "monarch",
+    "distributed",
 ]
 ServiceBackendAlias: TypeAlias = Literal["threading", "multiprocessing"]
+TransportBackend: TypeAlias = Literal[
+    "auto",
+    "direct",
+    "thread",
+    "queue",
+    "process",
+    "shared_memory",
+    "ray",
+    "monarch",
+    "distributed",
+]
 
 _SERVICE_BACKEND_ALIASES = {
     "threading": "thread",
     "multiprocessing": "process",
 }
 _SERVICE_BACKENDS = frozenset(
-    {"direct", "thread", "process", "ray", "monarch", "distributed"}
+    {
+        "direct",
+        "thread",
+        "process",
+        "ray",
+        "rpc",
+        "submitit",
+        "monarch",
+        "distributed",
+    }
+)
+_TRANSPORT_BACKENDS = frozenset(
+    {
+        "auto",
+        "direct",
+        "thread",
+        "queue",
+        "process",
+        "shared_memory",
+        "ray",
+        "monarch",
+        "distributed",
+    }
+)
+
+_SERVICE_BACKEND_CONTEXT: contextvars.ContextVar[tuple[int, ServiceBackend] | None]
+_SERVICE_BACKEND_CONTEXT = contextvars.ContextVar(
+    "torchrl_service_backend", default=None
+)
+_TRANSPORT_BACKEND_CONTEXT: contextvars.ContextVar[tuple[int, TransportBackend] | None]
+_TRANSPORT_BACKEND_CONTEXT = contextvars.ContextVar(
+    "torchrl_transport_backend", default=None
 )
 
 
@@ -45,3 +98,130 @@ def normalize_service_backend(
             f"Unsupported service backend {backend!r}. Expected one of {choices}."
         )
     return cast(ServiceBackend, canonical)
+
+
+def _normalize_transport_backend(backend: TransportBackend | str) -> TransportBackend:
+    """Return the canonical spelling of a TorchRL payload transport.
+
+    Args:
+        backend: Transport selector to validate.
+
+    Returns:
+        The validated transport selector.
+
+    Raises:
+        ValueError: If the transport is unknown.
+    """
+    if backend not in _TRANSPORT_BACKENDS:
+        raise ValueError(
+            f"Unsupported transport backend {backend!r}. "
+            f"Expected one of {sorted(_TRANSPORT_BACKENDS)}."
+        )
+    return cast(TransportBackend, backend)
+
+
+def _context_value(
+    context: contextvars.ContextVar[tuple[int, str] | None]
+) -> str | None:
+    value = context.get()
+    if value is None:
+        return None
+    pid, backend = value
+    if pid != os.getpid():
+        # ``ContextVar`` state is copied by ``fork``. Backend construction
+        # defaults belong to the process that entered the context and must not
+        # recursively select another owner inside a worker process.
+        return None
+    return backend
+
+
+def _get_service_backend() -> ServiceBackend | None:
+    return cast(ServiceBackend | None, _context_value(_SERVICE_BACKEND_CONTEXT))
+
+
+def _get_transport_backend() -> TransportBackend | None:
+    return cast(TransportBackend | None, _context_value(_TRANSPORT_BACKEND_CONTEXT))
+
+
+def _resolve_service_backend(
+    backend: ServiceBackend | ServiceBackendAlias | str | None,
+    *,
+    default: ServiceBackend | ServiceBackendAlias | str,
+) -> ServiceBackend:
+    if backend is not None:
+        return normalize_service_backend(backend)
+    contextual_backend = _get_service_backend()
+    if contextual_backend is not None:
+        return contextual_backend
+    return normalize_service_backend(default)
+
+
+def _resolve_transport_backend(
+    backend: TransportBackend | str | None,
+    *,
+    default: TransportBackend | str,
+) -> TransportBackend:
+    if backend is not None:
+        return _normalize_transport_backend(backend)
+    contextual_backend = _get_transport_backend()
+    if contextual_backend is not None:
+        return contextual_backend
+    return _normalize_transport_backend(default)
+
+
+@contextlib.contextmanager
+def service_backend(
+    backend: ServiceBackend | ServiceBackendAlias | str,
+) -> Iterator[None]:
+    """Set the default service backend within the current context.
+
+    Explicit constructor arguments take precedence over this scoped default.
+    The context is local to the current execution context and process, restores
+    the previous value on exit, and is not inherited by forked workers.
+
+    Args:
+        backend: Service backend used by compatible objects constructed in the
+            context.
+
+    Examples:
+        >>> from torchrl import service_backend
+        >>> from torchrl.data import ReplayBuffer
+        >>> with service_backend("direct"):
+        ...     replay = ReplayBuffer()
+        >>> replay.service_backend
+        'direct'
+    """
+    backend = normalize_service_backend(backend)
+    token = _SERVICE_BACKEND_CONTEXT.set((os.getpid(), backend))
+    try:
+        yield
+    finally:
+        _SERVICE_BACKEND_CONTEXT.reset(token)
+
+
+@contextlib.contextmanager
+def transport_backend(backend: TransportBackend | str) -> Iterator[None]:
+    """Set the default payload transport within the current context.
+
+    Explicit ``transport`` constructor arguments take precedence. Components
+    still validate whether the selected transport is compatible with their
+    service backend.
+
+    Args:
+        backend: Transport used by compatible objects constructed in the
+            context.
+
+    Examples:
+        >>> from torchrl import service_backend, transport_backend
+        >>> from torchrl.data import ReplayBuffer
+        >>> with service_backend("direct"), transport_backend("direct"):
+        ...     replay = ReplayBuffer()
+        >>> replay.service_backend
+        'direct'
+    """
+    backend = _normalize_transport_backend(backend)
+    token = _TRANSPORT_BACKEND_CONTEXT.set((os.getpid(), backend))
+    try:
+        yield
+    finally:
+        _TRANSPORT_BACKEND_CONTEXT.reset(token)

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import collections
+import contextvars
 import functools
 import inspect
 import logging
@@ -31,7 +32,7 @@ from tensordict.utils import NestedKey
 from torch import multiprocessing as mp, Tensor
 from torch.autograd.profiler import record_function
 
-from torchrl._comm.backends import normalize_service_backend
+from torchrl._comm.backends import _resolve_service_backend, _resolve_transport_backend
 
 try:
     from torch.compiler import is_compiling
@@ -1532,6 +1533,11 @@ class cuda_memory_profile(_DecoratorContextManager):
             )
 
 
+_SERVICE_BACKEND_DISPATCHING = contextvars.ContextVar(
+    "torchrl_service_backend_dispatching", default=None
+)
+
+
 class _RayServiceMetaClass(type):
     """Metaclass that selects direct or service-backed implementations.
 
@@ -1592,10 +1598,22 @@ class _RayServiceMetaClass(type):
             )
             service_backend = "ray"
 
-        if service_backend is None:
+        if service_backend is None and (
+            _SERVICE_BACKEND_DISPATCHING.get() == os.getpid()
+            or getattr(cls, "_service_backend_resolved", False)
+        ):
+            # A service factory may construct a wrapper that uses this same
+            # metaclass (for example RayReplayBuffer). The backend has already
+            # been resolved by the outer construction and must not dispatch a
+            # second time from the still-active context.
             service_backend = "direct"
-        service_backend = normalize_service_backend(service_backend)
+        service_backend = _resolve_service_backend(service_backend, default="direct")
         options = dict(service_backend_options or {})
+
+        if getattr(cls, "_accepts_transport_backend", False):
+            transport = kwargs.get("transport")
+            if transport is None:
+                kwargs["transport"] = _resolve_transport_backend(None, default="auto")
 
         if service_backend == "direct":
             if options:
@@ -1605,12 +1623,16 @@ class _RayServiceMetaClass(type):
             return super().__call__(*args, **kwargs)
 
         if hasattr(cls, "_ServiceClass"):
-            return cls._ServiceClass(
-                service_backend,
-                *args,
-                service_backend_options=options,
-                **kwargs,
-            )
+            token = _SERVICE_BACKEND_DISPATCHING.set(os.getpid())
+            try:
+                return cls._ServiceClass(
+                    service_backend,
+                    *args,
+                    service_backend_options=options,
+                    **kwargs,
+                )
+            finally:
+                _SERVICE_BACKEND_DISPATCHING.reset(token)
         if service_backend == "ray" and hasattr(cls, "_RayServiceClass"):
             if options and "ray_actor_options" not in kwargs:
                 kwargs["ray_actor_options"] = options.get("actor_options", options)

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -32,7 +32,13 @@ from tensordict.utils import NestedKey
 from torch import multiprocessing as mp, Tensor
 from torch.autograd.profiler import record_function
 
-from torchrl._comm.backends import _resolve_service_backend, _resolve_transport_backend
+from torchrl._comm.backends import (
+    _contextual_backend_error,
+    _get_service_backend,
+    _get_transport_backend,
+    _resolve_service_backend,
+    _resolve_transport_backend,
+)
 
 try:
     from torch.compiler import is_compiling
@@ -1607,38 +1613,70 @@ class _RayServiceMetaClass(type):
             # been resolved by the outer construction and must not dispatch a
             # second time from the still-active context.
             service_backend = "direct"
+        service_backend_from_context = (
+            service_backend is None and _get_service_backend() is not None
+        )
         service_backend = _resolve_service_backend(service_backend, default="direct")
         options = dict(service_backend_options or {})
 
+        transport_backend_from_context = False
         if getattr(cls, "_accepts_transport_backend", False):
             transport = kwargs.get("transport")
             if transport is None:
+                transport_backend_from_context = _get_transport_backend() is not None
                 kwargs["transport"] = _resolve_transport_backend(None, default="auto")
+
+        def construct(factory):
+            try:
+                return factory()
+            except ValueError as err:
+                message = str(err)
+                service_error = (
+                    service_backend_from_context and "service_backend" in message
+                )
+                transport_error = (
+                    transport_backend_from_context and "transport" in message
+                )
+                if not service_error and not transport_error:
+                    raise
+                raise ValueError(
+                    _contextual_backend_error(
+                        message,
+                        service=service_error,
+                        transport=transport_error,
+                    )
+                ) from err
 
         if service_backend == "direct":
             if options:
                 raise ValueError(
                     "service_backend_options are only valid for non-direct services."
                 )
-            return super().__call__(*args, **kwargs)
+            direct_constructor = super().__call__
+            return construct(lambda: direct_constructor(*args, **kwargs))
 
         if hasattr(cls, "_ServiceClass"):
             token = _SERVICE_BACKEND_DISPATCHING.set(os.getpid())
             try:
-                return cls._ServiceClass(
-                    service_backend,
-                    *args,
-                    service_backend_options=options,
-                    **kwargs,
+                return construct(
+                    lambda: cls._ServiceClass(
+                        service_backend,
+                        *args,
+                        service_backend_options=options,
+                        **kwargs,
+                    )
                 )
             finally:
                 _SERVICE_BACKEND_DISPATCHING.reset(token)
         if service_backend == "ray" and hasattr(cls, "_RayServiceClass"):
             if options and "ray_actor_options" not in kwargs:
                 kwargs["ray_actor_options"] = options.get("actor_options", options)
-            return cls._RayServiceClass(*args, **kwargs)
+            return construct(lambda: cls._RayServiceClass(*args, **kwargs))
         raise ValueError(
-            f"{cls.__name__} does not support service_backend={service_backend!r}."
+            _contextual_backend_error(
+                f"{cls.__name__} does not support service_backend={service_backend!r}.",
+                service=service_backend_from_context,
+            )
         )
 
 

--- a/torchrl/collectors/__init__.py
+++ b/torchrl/collectors/__init__.py
@@ -25,9 +25,11 @@ from .weight_update import (
 )
 
 __all__ = [
-    # New canonical names (preferred)
+    # Shared collector API
     "BaseCollector",
+    # Main construction API
     "Collector",
+    # Specialized and concrete implementations
     "AsyncCollector",
     "MultiCollector",
     "MultiSyncCollector",

--- a/torchrl/collectors/_multi_async.py
+++ b/torchrl/collectors/_multi_async.py
@@ -25,6 +25,10 @@ from torchrl.collectors.utils import split_trajectories
 class MultiAsyncCollector(MultiCollector):
     """Runs a given number of DataCollectors on separate processes asynchronously.
 
+    .. note::
+        Prefer ``Collector(num_collectors=N, sync=False)`` for construction in
+        new code. This class is the concrete asynchronous result.
+
     .. aafig::
 
 

--- a/torchrl/collectors/_multi_base.py
+++ b/torchrl/collectors/_multi_base.py
@@ -79,6 +79,11 @@ class _MultiCollectorMeta(abc.ABCMeta):
 class MultiCollector(BaseCollector, metaclass=_MultiCollectorMeta):
     """Runs a given number of DataCollectors on separate processes.
 
+    .. note::
+        Use :class:`~torchrl.collectors.Collector` with ``num_collectors`` and
+        ``sync`` to construct local process collectors in new code. This class
+        remains the concrete process-collector API.
+
     Args:
         create_env_fn (List[Callabled]): list of Callables, each returning an
             instance of :class:`~torchrl.envs.EnvBase`.

--- a/torchrl/collectors/_multi_sync.py
+++ b/torchrl/collectors/_multi_sync.py
@@ -27,6 +27,10 @@ from torchrl.collectors.utils import split_trajectories
 class MultiSyncCollector(MultiCollector):
     """Runs a given number of DataCollectors on separate processes synchronously.
 
+    .. note::
+        Prefer ``Collector(num_collectors=N, sync=True)`` for construction in
+        new code. This class is the concrete synchronous result.
+
     .. aafig::
 
             +----------------------------------------------------------------------+

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import abc
 import contextlib
+import inspect
 import threading
 import warnings
 import weakref
@@ -15,6 +17,7 @@ from tensordict import LazyStackedTensorDict, TensorDict, TensorDictBase
 from tensordict.nn import CudaGraphModule, TensorDictModule, TensorDictModuleBase
 from torch import nn
 from torchrl import compile_with_warmup
+from torchrl._comm.backends import _get_service_backend, normalize_service_backend
 from torchrl._utils import (
     _ends_with,
     _maybe_record_function,
@@ -68,9 +71,219 @@ def _cuda_sync_if_initialized():
         torch.cuda.synchronize()
 
 
+class _CollectorMeta(abc.ABCMeta):
+    """Dispatch the public Collector constructor to an execution backend."""
+
+    _BACKENDS = frozenset(
+        {"direct", "process", "ray", "rpc", "distributed", "submitit"}
+    )
+    _RESERVED_OPTIONS = frozenset(
+        {"backend_options", "num_collectors", "num_workers", "sync"}
+    )
+
+    @property
+    def __signature__(cls):
+        signature = inspect.signature(cls.__init__)
+        return signature.replace(parameters=tuple(signature.parameters.values())[1:])
+
+    @staticmethod
+    def _normalize_direct_env_fn(args, kwargs):
+        if args:
+            create_env_fn = args[0]
+            set_env_fn = "args"
+        elif "create_env_fn" in kwargs:
+            create_env_fn = kwargs["create_env_fn"]
+            set_env_fn = "kwargs"
+        else:
+            return args, kwargs
+
+        is_sequence = isinstance(create_env_fn, Sequence) and not isinstance(
+            create_env_fn, (str, bytes)
+        )
+        if not is_sequence:
+            return args, kwargs
+        if len(create_env_fn) != 1:
+            raise ValueError(
+                "backend='direct' requires exactly one environment constructor."
+            )
+        create_env_fn = create_env_fn[0]
+        if set_env_fn == "args":
+            args = (create_env_fn, *args[1:])
+        else:
+            kwargs["create_env_fn"] = create_env_fn
+        return args, kwargs
+
+    @staticmethod
+    def _normalize_env_fns(args, kwargs, num_collectors):
+        if args:
+            create_env_fn = args[0]
+            set_env_fn = "args"
+        elif "create_env_fn" in kwargs:
+            create_env_fn = kwargs["create_env_fn"]
+            set_env_fn = "kwargs"
+        else:
+            return args, kwargs, num_collectors
+
+        is_sequence = isinstance(create_env_fn, Sequence) and not isinstance(
+            create_env_fn, (str, bytes)
+        )
+        if is_sequence:
+            create_env_fn = list(create_env_fn)
+            inferred_num_collectors = len(create_env_fn)
+            if not inferred_num_collectors:
+                raise ValueError("create_env_fn must contain at least one environment.")
+            if num_collectors is not None and num_collectors != inferred_num_collectors:
+                raise ValueError(
+                    "num_collectors does not match the number of environment "
+                    f"constructors: {num_collectors} != {inferred_num_collectors}."
+                )
+            num_collectors = inferred_num_collectors
+        else:
+            if num_collectors is None:
+                num_collectors = 1
+            create_env_fn = [create_env_fn] * num_collectors
+
+        if set_env_fn == "args":
+            args = (create_env_fn, *args[1:])
+        else:
+            kwargs["create_env_fn"] = create_env_fn
+        return args, kwargs, num_collectors
+
+    @staticmethod
+    def _drop_inapplicable_defaults(target, kwargs):
+        """Let a selected backend apply its defaults to generic config values."""
+        target_parameters = inspect.signature(target.__init__).parameters
+        collector_parameters = inspect.signature(Collector.__init__).parameters
+        for name, parameter in collector_parameters.items():
+            if name not in kwargs or parameter.default is inspect.Parameter.empty:
+                continue
+            value = kwargs[name]
+            default = parameter.default
+            if value is not default and value != default:
+                continue
+            target_parameter = target_parameters.get(name)
+            if target_parameter is None or target_parameter.default != default:
+                kwargs.pop(name)
+
+    def __call__(
+        cls,
+        *args,
+        backend=None,
+        backend_options=None,
+        num_collectors=None,
+        sync=None,
+        **kwargs,
+    ):
+        if cls is not Collector:
+            if any(
+                value is not None
+                for value in (backend, backend_options, num_collectors, sync)
+            ):
+                raise TypeError(
+                    "backend, backend_options, num_collectors, and sync are "
+                    "only supported when constructing Collector directly."
+                )
+            return super().__call__(*args, **kwargs)
+
+        if num_collectors is not None:
+            if isinstance(num_collectors, bool) or not isinstance(num_collectors, int):
+                raise TypeError("num_collectors must be a positive integer.")
+            if num_collectors < 1:
+                raise ValueError("num_collectors must be a positive integer.")
+
+        if backend is not None:
+            backend = normalize_service_backend(backend)
+        else:
+            backend = _get_service_backend()
+            if backend is None:
+                backend = "process" if num_collectors is not None else "direct"
+        if backend not in cls._BACKENDS:
+            raise ValueError(
+                f"Collector does not support backend={backend!r}. Expected one "
+                f"of {sorted(cls._BACKENDS)}."
+            )
+
+        options = dict(backend_options or {})
+        reserved = cls._RESERVED_OPTIONS.intersection(options)
+        if reserved:
+            raise ValueError(
+                "backend_options contains reserved selector keys: "
+                f"{sorted(reserved)}."
+            )
+        duplicates = options.keys() & kwargs.keys()
+        positional_names = ("create_env_fn", "policy")
+        duplicates.update(options.keys() & set(positional_names[: len(args)]))
+        if duplicates:
+            raise ValueError(
+                "Backend options duplicate top-level collector arguments: "
+                f"{sorted(duplicates)}."
+            )
+
+        if backend == "direct":
+            if num_collectors not in (None, 1):
+                raise ValueError("backend='direct' supports at most one collector.")
+            if sync is not None:
+                raise ValueError("sync is only valid for non-direct collectors.")
+            if options:
+                raise ValueError(
+                    "backend_options are only valid for non-direct collectors."
+                )
+            args, kwargs = cls._normalize_direct_env_fn(args, kwargs)
+            return super().__call__(*args, **kwargs)
+
+        if sync is None:
+            sync = False
+        elif not isinstance(sync, bool):
+            raise TypeError("sync must be a boolean or None.")
+
+        kwargs.update(options)
+        args, kwargs, num_collectors = cls._normalize_env_fns(
+            args, kwargs, num_collectors
+        )
+
+        if backend == "process":
+            from torchrl.collectors._multi_base import MultiCollector
+
+            cls._drop_inapplicable_defaults(MultiCollector, kwargs)
+            return MultiCollector(*args, sync=sync, **kwargs)
+        if backend == "ray":
+            from torchrl.collectors.distributed.ray import RayCollector
+
+            cls._drop_inapplicable_defaults(RayCollector, kwargs)
+            return RayCollector(
+                *args,
+                num_collectors=num_collectors,
+                sync=sync,
+                **kwargs,
+            )
+        if backend == "rpc":
+            from torchrl.collectors.distributed.rpc import RPCCollector
+
+            cls._drop_inapplicable_defaults(RPCCollector, kwargs)
+            return RPCCollector(*args, sync=sync, **kwargs)
+
+        from torchrl.collectors.distributed.generic import DistributedCollector
+
+        cls._drop_inapplicable_defaults(DistributedCollector, kwargs)
+        if backend == "submitit":
+            launcher = kwargs.setdefault("launcher", "submitit")
+            if launcher != "submitit":
+                raise ValueError("backend='submitit' requires launcher='submitit'.")
+        return DistributedCollector(*args, sync=sync, **kwargs)
+
+
 @accept_remote_rref_udf_invocation
-class Collector(BaseCollector):
-    """Generic data collector for RL problems. Requires an environment constructor and a policy.
+class Collector(BaseCollector, metaclass=_CollectorMeta):
+    """Main construction entry point for TorchRL data collectors.
+
+    ``Collector(...)`` performs direct collection by default. ``num_collectors``
+    selects local process collection, while ``backend`` selects direct, process,
+    Ray, RPC, or distributed execution. Dispatch occurs only when constructing
+    this exact class; the returned object retains its concrete implementation
+    type. Existing concrete collector classes remain available for subclassing
+    and implementation-specific APIs.
+
+    A collector requires an environment constructor and a policy.
 
     Args:
         create_env_fn (Callable or EnvBase): a callable that returns an instance of
@@ -99,6 +312,22 @@ class Collector(BaseCollector):
                 pickled directly), the ``policy_factory`` should be used instead.
 
     Keyword Args:
+        backend (str, optional): execution backend selected by this generic
+            constructor. One of ``"direct"``, ``"process"``, ``"ray"``,
+            ``"rpc"``, ``"distributed"``, or ``"submitit"``. When omitted,
+            an enclosing :func:`torchrl.service_backend` provides the default;
+            otherwise passing ``num_collectors`` selects ``"process"`` and the
+            direct collection remains the final default.
+        backend_options (dict, optional): backend-specific constructor options.
+            Keys are merged into the selected concrete collector arguments;
+            duplicates with top-level arguments are rejected.
+        num_collectors (int, optional): number of collector workers. A single
+            environment constructor is repeated this many times. A sequence of
+            constructors is validated against this value. Passing this argument
+            without a backend selects the process backend.
+        sync (bool, optional): whether a non-direct collector waits for every
+            worker before yielding. Defaults to ``False`` for non-direct
+            backends. Invalid for the direct backend.
         policy_factory (Callable[[], Callable], optional): a callable that returns
             a policy instance. This is exclusive with the `policy` argument.
 
@@ -431,6 +660,11 @@ class Collector(BaseCollector):
         | (TensorDictModule | Callable[[TensorDictBase], TensorDictBase]) = None,
         *,
         policy_factory: Callable[[], Callable] | None = None,
+        backend: Literal["direct", "process", "ray", "rpc", "distributed", "submitit"]
+        | None = None,
+        backend_options: dict[str, Any] | None = None,
+        num_collectors: int | None = None,
+        sync: bool | None = None,
         frames_per_batch: int,
         total_frames: int = -1,
         device: DEVICE_TYPING | None = None,
@@ -472,6 +706,11 @@ class Collector(BaseCollector):
         compact_obs: bool = False,
         **kwargs,
     ):
+        # These arguments are consumed by _CollectorMeta for the public class.
+        # They remain in the signature so introspection and Hydra expose the
+        # complete constructor API. Subclasses reach this implementation with
+        # the defaults only.
+        del backend, backend_options, num_collectors, sync
         self.closed = True
         self.worker_idx = worker_idx
         self.trajs_per_batch = trajs_per_batch

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -17,7 +17,11 @@ from tensordict import LazyStackedTensorDict, TensorDict, TensorDictBase
 from tensordict.nn import CudaGraphModule, TensorDictModule, TensorDictModuleBase
 from torch import nn
 from torchrl import compile_with_warmup
-from torchrl._comm.backends import _get_service_backend, normalize_service_backend
+from torchrl._comm.backends import (
+    _contextual_backend_error,
+    _get_service_backend,
+    normalize_service_backend,
+)
 from torchrl._utils import (
     _ends_with,
     _maybe_record_function,
@@ -203,16 +207,21 @@ class _CollectorMeta(abc.ABCMeta):
             if num_collectors < 1:
                 raise ValueError("num_collectors must be a positive integer.")
 
+        backend_from_context = False
         if backend is not None:
             backend = normalize_service_backend(backend)
         else:
             backend = _get_service_backend()
+            backend_from_context = backend is not None
             if backend is None:
                 backend = "process" if num_collectors is not None else "direct"
         if backend not in cls._BACKENDS:
             raise ValueError(
-                f"Collector does not support backend={backend!r}. Expected one "
-                f"of {sorted(cls._BACKENDS)}."
+                _contextual_backend_error(
+                    f"Collector does not support backend={backend!r}. Expected one "
+                    f"of {sorted(cls._BACKENDS)}.",
+                    service=backend_from_context,
+                )
             )
 
         options = dict(backend_options or {})

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -151,7 +151,14 @@ class _CollectorMeta(abc.ABCMeta):
 
     @staticmethod
     def _drop_inapplicable_defaults(target, kwargs):
-        """Let a selected backend apply its defaults to generic config values."""
+        """Let a selected backend apply its defaults to generic config values.
+
+        Generic structured configs materialize every ``Collector`` default,
+        whereas concrete backends have a few different but semantically
+        equivalent defaults. Because an explicitly passed value equal to the
+        generic default is indistinguishable from a materialized config value,
+        tests pin the allowed concrete-default divergences.
+        """
         target_parameters = inspect.signature(target.__init__).parameters
         collector_parameters = inspect.signature(Collector.__init__).parameters
         for name, parameter in collector_parameters.items():
@@ -184,6 +191,11 @@ class _CollectorMeta(abc.ABCMeta):
                     "only supported when constructing Collector directly."
                 )
             return super().__call__(*args, **kwargs)
+
+        if len(args) > 2:
+            raise TypeError(
+                "Collector accepts at most create_env_fn and policy positionally."
+            )
 
         if num_collectors is not None:
             if isinstance(num_collectors, bool) or not isinstance(num_collectors, int):
@@ -281,7 +293,9 @@ class Collector(BaseCollector, metaclass=_CollectorMeta):
     Ray, RPC, or distributed execution. Dispatch occurs only when constructing
     this exact class; the returned object retains its concrete implementation
     type. Existing concrete collector classes remain available for subclassing
-    and implementation-specific APIs.
+    and implementation-specific APIs. Use :class:`BaseCollector` rather than
+    ``Collector`` as the target of an ``isinstance`` check that must accept
+    every dispatched collector.
 
     A collector requires an environment constructor and a policy.
 

--- a/torchrl/collectors/distributed/generic.py
+++ b/torchrl/collectors/distributed/generic.py
@@ -353,6 +353,12 @@ class DistributedCollector(BaseCollector):
 
     Supports sync and async data collection.
 
+    .. note::
+        Prefer ``Collector(backend="distributed", ...)`` or
+        ``Collector(backend="submitit", ...)`` for construction in new code.
+        Pass launcher and process-group settings through ``backend_options``.
+        This class remains the concrete distributed implementation API.
+
     Args:
         create_env_fn (Callable or List[Callabled]): list of Callables, each returning an
             instance of :class:`~torchrl.envs.EnvBase`.

--- a/torchrl/collectors/distributed/ray.py
+++ b/torchrl/collectors/distributed/ray.py
@@ -271,7 +271,12 @@ class RayCollector(BaseCollector):
         replay_buffer (ReplayBuffer, optional): if provided, the collector will
             populate it instead of yielding TensorDicts. The replay buffer must
             use ``service_backend="ray"``; the collector creates restricted
-            worker clients internally. Defaults to ``None``.
+            worker clients internally. A regular in-process replay buffer is
+            rejected because serializing it into Ray actors would create remote
+            copies rather than populate the driver-owned buffer. For large,
+            fixed-layout TensorDict payloads, ``transport="distributed"`` is
+            the recommended data path (Gloo for CPU tensors and NCCL for CUDA
+            tensors). Defaults to ``None``.
         weight_updater (WeightUpdaterBase or constructor, optional): (Deprecated) An instance of :class:`~torchrl.collectors.WeightUpdaterBase`
             or its subclass, responsible for updating the policy weights on remote inference workers managed by Ray.
             If not provided, a :class:`~torchrl.collectors.RayWeightUpdater` will be used by default, leveraging
@@ -416,7 +421,10 @@ class RayCollector(BaseCollector):
                 raise TypeError(
                     "RayCollector requires a replay buffer with "
                     "service_backend='ray' and a client() method. Construct it "
-                    "with ReplayBuffer(..., service_backend='ray')."
+                    "with ReplayBuffer(..., service_backend='ray'). A regular "
+                    "in-process replay buffer cannot be shared with distant Ray "
+                    "actors. For large fixed-layout TensorDict payloads, consider "
+                    "transport='distributed'."
                 )
         if trajs_per_batch is not None:
             if isinstance(collector_kwargs, dict):

--- a/torchrl/collectors/distributed/ray.py
+++ b/torchrl/collectors/distributed/ray.py
@@ -81,6 +81,11 @@ def print_remote_collector_info(self):
 class RayCollector(BaseCollector):
     """Distributed data collector with `Ray <https://docs.ray.io/>`_ backend.
 
+    .. note::
+        Prefer ``Collector(backend="ray", ...)`` for construction in new code.
+        Pass Ray-specific arguments through ``backend_options``. This class
+        remains the concrete Ray implementation API.
+
     This Python class serves as a ray-based solution to instantiate and coordinate multiple
     data collectors in a distributed cluster. Like TorchRL non-distributed collectors, this
     collector is an iterable that yields TensorDicts until a target number of collected

--- a/torchrl/collectors/distributed/rpc.py
+++ b/torchrl/collectors/distributed/rpc.py
@@ -109,6 +109,11 @@ class RPCCollector(BaseCollector):
 
     Supports sync and async data collection.
 
+    .. note::
+        Prefer ``Collector(backend="rpc", ...)`` for construction in new code.
+        Pass RPC launcher and communication settings through
+        ``backend_options``. This class remains the concrete RPC API.
+
     Args:
         create_env_fn (Callable or List[Callabled]): list of Callables, each returning an
             instance of :class:`~torchrl.envs.EnvBase`.

--- a/torchrl/data/replay_buffers/ray_buffer.py
+++ b/torchrl/data/replay_buffers/ray_buffer.py
@@ -293,6 +293,8 @@ class RayReplayBuffer(ReplayBuffer):
 
     """
 
+    _service_backend_resolved = True
+
     def __init__(
         self,
         *args,

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -302,6 +302,8 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
 
     """
 
+    _accepts_transport_backend = True
+
     @classmethod
     def _ServiceClass(
         cls,

--- a/torchrl/modules/inference_server/_server.py
+++ b/torchrl/modules/inference_server/_server.py
@@ -27,6 +27,7 @@ from tensordict.utils import NestedKey
 from torch import nn
 
 from torchrl._comm import CommandChannel, Mailbox, watch_process_liveness
+from torchrl._comm.backends import _resolve_service_backend, _resolve_transport_backend
 from torchrl._comm.ray_runtime import _RayRuntimeLease, _set_ray_client_liveness
 from torchrl.modules.inference_server._client import (
     _NO_INTERACTION_TYPE_CODE,
@@ -81,8 +82,15 @@ class _InferenceServerMeta(type):
         )
         service_backend = kwargs.pop("service_backend", None)
         if service_backend is None:
-            service_backend = configured_backend
-        elif server_config is not None and configured_backend not in (
+            service_backend = _resolve_service_backend(
+                configured_backend if server_config is not None else None,
+                default="thread",
+            )
+        else:
+            service_backend = _resolve_service_backend(
+                service_backend, default="thread"
+            )
+        if server_config is not None and configured_backend not in (
             "thread",
             service_backend,
         ):
@@ -95,6 +103,8 @@ class _InferenceServerMeta(type):
             )
 
         service_options = dict(kwargs.pop("service_backend_options", None) or {})
+        if transport is None:
+            transport = _resolve_transport_backend(None, default="auto")
         transport_options = kwargs.pop("transport_options", None)
         request_spec = kwargs.pop("request_spec", None)
         response_spec = kwargs.pop("response_spec", None)

--- a/torchrl/modules/inference_server/_server.py
+++ b/torchrl/modules/inference_server/_server.py
@@ -27,7 +27,13 @@ from tensordict.utils import NestedKey
 from torch import nn
 
 from torchrl._comm import CommandChannel, Mailbox, watch_process_liveness
-from torchrl._comm.backends import _resolve_service_backend, _resolve_transport_backend
+from torchrl._comm.backends import (
+    _contextual_backend_error,
+    _get_service_backend,
+    _get_transport_backend,
+    _resolve_service_backend,
+    _resolve_transport_backend,
+)
 from torchrl._comm.ray_runtime import _RayRuntimeLease, _set_ray_client_liveness
 from torchrl.modules.inference_server._client import (
     _NO_INTERACTION_TYPE_CODE,
@@ -81,6 +87,11 @@ class _InferenceServerMeta(type):
             server_config.service_backend if server_config is not None else "thread"
         )
         service_backend = kwargs.pop("service_backend", None)
+        service_backend_from_context = (
+            service_backend is None
+            and server_config is None
+            and _get_service_backend() is not None
+        )
         if service_backend is None:
             service_backend = _resolve_service_backend(
                 configured_backend if server_config is not None else None,
@@ -99,23 +110,45 @@ class _InferenceServerMeta(type):
             )
         if service_backend not in ("thread", "process", "ray"):
             raise ValueError(
-                "InferenceServer service_backend must be 'thread', 'process', or 'ray'."
+                _contextual_backend_error(
+                    "InferenceServer service_backend must be 'thread', 'process', or 'ray'.",
+                    service=service_backend_from_context,
+                )
             )
 
         service_options = dict(kwargs.pop("service_backend_options", None) or {})
+        transport_backend_from_context = (
+            transport is None and _get_transport_backend() is not None
+        )
         if transport is None:
             transport = _resolve_transport_backend(None, default="auto")
         transport_options = kwargs.pop("transport_options", None)
         request_spec = kwargs.pop("request_spec", None)
         response_spec = kwargs.pop("response_spec", None)
         num_clients = kwargs.pop("num_clients", None)
-        _validate_inference_transport_selection(
-            transport,
-            service_backend=service_backend,
-            transport_options=transport_options,
-            request_spec=request_spec,
-            response_spec=response_spec,
-        )
+        try:
+            _validate_inference_transport_selection(
+                transport,
+                service_backend=service_backend,
+                transport_options=transport_options,
+                request_spec=request_spec,
+                response_spec=response_spec,
+            )
+        except ValueError as err:
+            message = str(err)
+            service_error = (
+                service_backend_from_context and "service_backend" in message
+            )
+            transport_error = transport_backend_from_context and "transport" in message
+            if not service_error and not transport_error:
+                raise
+            raise ValueError(
+                _contextual_backend_error(
+                    message,
+                    service=service_error,
+                    transport=transport_error,
+                )
+            ) from err
 
         if service_backend == "ray":
             if model is not None:

--- a/torchrl/trainers/algorithms/configs/collectors.py
+++ b/torchrl/trainers/algorithms/configs/collectors.py
@@ -7,12 +7,21 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Any
+from typing import Any, Literal, TYPE_CHECKING
 
 from omegaconf import MISSING
 
 from torchrl.trainers.algorithms.configs.common import ConfigBase
 from torchrl.trainers.algorithms.configs.envs import EnvConfig
+
+if TYPE_CHECKING:
+    _CollectorBackend = Literal[
+        "direct", "process", "ray", "rpc", "distributed", "submitit"
+    ]
+else:
+    # OmegaConf structured configs do not support Literal on all supported
+    # versions.
+    _CollectorBackend = str
 
 
 @dataclass
@@ -30,9 +39,13 @@ class CollectorConfig(BaseCollectorConfig):
     create_env_fn: ConfigBase = MISSING
     policy: Any = None
     policy_factory: Any = None
+    backend: _CollectorBackend | None = None
+    backend_options: dict[str, Any] | None = None
+    num_collectors: int | None = None
+    sync: bool | None = None
     frames_per_batch: int | None = None
     total_frames: int = -1
-    init_random_frames: int | None = 0
+    init_random_frames: int | None = None
     device: str | None = None
     storing_device: str | None = None
     policy_device: str | None = None
@@ -41,16 +54,17 @@ class CollectorConfig(BaseCollectorConfig):
     max_frames_per_traj: int | None = None
     reset_at_each_iter: bool = False
     postproc: Any = None
-    split_trajs: bool = False
+    split_trajs: bool | None = None
+    track_traj_ids: bool = True
     exploration_type: str = "RANDOM"
     return_same_td: bool = False
     reset_when_done: bool = True
     interruptor: Any = None
     set_truncated: bool = False
-    use_buffers: bool = False
+    use_buffers: bool | None = None
     replay_buffer: Any = None
-    extend_buffer: bool = False
-    trust_policy: bool = True
+    extend_buffer: bool = True
+    trust_policy: bool | None = None
     compile_policy: Any = None
     cudagraph_policy: Any = None
     no_cuda_sync: bool = False
@@ -62,6 +76,10 @@ class CollectorConfig(BaseCollectorConfig):
     trajs_per_batch: int | None = None
     trajs_per_write: int | None = None
     traj_format: str | None = None
+    auto_register_policy_transforms: bool | None = None
+    pre_collect_hook: Any = None
+    post_collect_hook: Any = None
+    compact_obs: bool = False
 
     _target_: str = "torchrl.collectors.Collector"
     _partial_: bool = False

--- a/tutorials/sphinx-tutorials/coding_ddpg.py
+++ b/tutorials/sphinx-tutorials/coding_ddpg.py
@@ -807,13 +807,11 @@ if device == torch.device("cpu"):
 # collection and on the resources allocated to the data collection (for example
 # GPU, number of workers, and so on).
 #
-# Here we will use
-# :class:`~torchrl.collectors.Collector`, a simple, single-process
-# data collector. TorchRL offers other collectors, such as
-# :class:`~torchrl.collectors.MultiAsyncCollector`, which executed the
-# rollouts in an asynchronous manner (for example, data will be collected while
-# the policy is being optimized, thereby decoupling the training and
-# data collection).
+# Here we use :class:`~torchrl.collectors.Collector`, TorchRL's main collector
+# construction API, with its direct single-process default. The same entry
+# point can execute rollouts asynchronously with
+# ``Collector(num_collectors=N, sync=False)`` so data is collected while the
+# policy is optimized, decoupling training and data collection.
 #
 # The parameters to specify are:
 #

--- a/tutorials/sphinx-tutorials/coding_dqn.py
+++ b/tutorials/sphinx-tutorials/coding_dqn.py
@@ -86,6 +86,7 @@ TorchRL trainer: A DQN example
 # sphinx_gallery_start_ignore
 import tempfile
 import warnings
+from functools import partial
 
 from tensordict.nn import TensorDictSequential
 
@@ -105,7 +106,7 @@ import uuid
 
 import torch
 from torch import nn
-from torchrl.collectors import Collector, MultiAsyncCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyMemmapStorage, MultiStep, TensorDictReplayBuffer
 from torchrl.envs import (
     EnvCreator,
@@ -397,8 +398,8 @@ def get_replay_buffer(buffer_size, n_optim, batch_size, device):
 # .. note::
 #   This feature is only available when running the code within the "spawn"
 #   start method of python multiprocessing library. If this tutorial is run
-#   directly as a script (thereby using the "fork" method) we will be using
-#   a regular :class:`~torchrl.collectors.Collector`.
+#   directly as a script (thereby using the "fork" method) we select the
+#   direct backend of :class:`~torchrl.collectors.Collector`.
 #
 # The advantage of this configuration is that we can balance the amount of
 # compute that is executed in batch with what we want to be executed
@@ -430,14 +431,17 @@ def get_collector(
 ):
     # We can't use nested child processes with mp_start_method="fork"
     if is_fork:
-        cls = Collector
         env_arg = make_env(parallel=True, obs_norm_sd=stats, num_workers=num_workers)
+        backend_kwargs = {"backend": "direct"}
     else:
-        cls = MultiAsyncCollector
-        env_arg = [
-            make_env(parallel=True, obs_norm_sd=stats, num_workers=num_workers)
-        ] * num_collectors
-    data_collector = cls(
+        env_arg = partial(
+            make_env,
+            parallel=True,
+            obs_norm_sd=stats,
+            num_workers=num_workers,
+        )
+        backend_kwargs = {"num_collectors": num_collectors, "sync": False}
+    data_collector = Collector(
         env_arg,
         policy=actor_explore,
         frames_per_batch=frames_per_batch,
@@ -450,6 +454,7 @@ def get_collector(
         storing_device=device,
         split_trajs=False,
         postproc=MultiStep(gamma=gamma, n_steps=5),
+        **backend_kwargs,
     )
     return data_collector
 

--- a/tutorials/sphinx-tutorials/coding_ppo.py
+++ b/tutorials/sphinx-tutorials/coding_ppo.py
@@ -483,8 +483,9 @@ value_module.eval()
 # Data collector
 # --------------
 #
-# TorchRL provides a set of :ref:`DataCollector classes <ref_collectors>`.
-# Briefly, these classes execute three operations: reset an environment,
+# TorchRL provides the :class:`~torchrl.collectors.Collector` construction API
+# for the execution strategies in :ref:`ref_collectors`. Briefly, collectors
+# execute three operations: reset an environment,
 # compute an action given the latest observation, execute a step in the environment,
 # and repeat the last two steps until the environment signals a stop (or reaches
 # a done state).
@@ -495,14 +496,12 @@ value_module.eval()
 # on which ``device`` the policy should be executed, etc. They are also
 # designed to work efficiently with batched and multiprocessed environments.
 #
-# The simplest data collector is the :class:`~torchrl.collectors.Collector`:
-# it is an iterator that you can use to get batches of data of a given length, and
-# that will stop once a total number of frames (``total_frames``) have been
-# collected.
-# Other data collectors (:class:`~torchrl.collectors.MultiSyncCollector` and
-# :class:`~torchrl.collectors.MultiAsyncCollector`) will execute
-# the same operations in synchronous and asynchronous manner over a
-# set of multiprocessed workers.
+# :class:`~torchrl.collectors.Collector` is the main construction entry point.
+# It is an iterator that yields batches of a given length and stops once a
+# total number of frames (``total_frames``) has been collected. The default
+# runs directly in the training process; ``num_collectors`` and ``sync`` select
+# synchronous or asynchronous local worker processes, while ``backend`` selects
+# Ray, RPC, or distributed execution.
 #
 # As for the policy and environment before, the data collector will return
 # :class:`~tensordict.TensorDict` instances with a total number of elements that will

--- a/tutorials/sphinx-tutorials/getting-started-3.py
+++ b/tutorials/sphinx-tutorials/getting-started-3.py
@@ -41,9 +41,10 @@ import tempfile
 # .. _gs_storage_collector:
 #
 #
-# The primary data collector discussed here is the
-# :class:`~torchrl.collectors.Collector`, which is the focus of this
-# documentation. At a fundamental level, a collector is a straightforward
+# :class:`~torchrl.collectors.Collector` is the main construction entry point
+# for TorchRL data collection. It can build a direct, local multi-process, Ray,
+# RPC, or distributed collector without changing the class imported by the
+# training code. At a fundamental level, a collector is a straightforward
 # class responsible for executing your policy within the environment,
 # resetting the environment when necessary, and providing batches of a
 # predefined size. Unlike the :meth:`~torchrl.envs.EnvBase.rollout` method
@@ -93,6 +94,52 @@ for data in collector:
 
 print(data["collector", "traj_ids"])
 
+#################################
+# Changing the execution topology
+# --------------------------------
+#
+# The default above collects directly in the training process. Scale the same
+# entry point to local worker processes with ``num_collectors``. ``sync=True``
+# waits for every worker and is a natural fit for on-policy algorithms;
+# ``sync=False`` delivers the first available worker batch and is usually used
+# for off-policy training:
+#
+# .. code-block:: python
+#
+#     def make_env():
+#         return GymEnv("CartPole-v1")
+#
+#     process_collector = Collector(
+#         make_env,
+#         policy,
+#         num_collectors=4,
+#         sync=False,
+#         frames_per_batch=200,
+#         total_frames=-1,
+#     )
+#
+# Distributed placement uses the same constructor. Backend-specific resources
+# and launcher settings belong in ``backend_options``:
+#
+# .. code-block:: python
+#
+#     ray_collector = Collector(
+#         make_env,
+#         policy,
+#         backend="ray",
+#         num_collectors=4,
+#         backend_options={
+#             "remote_configs": {"num_cpus": 1, "num_gpus": 0}
+#         },
+#         frames_per_batch=200,
+#         total_frames=-1,
+#     )
+#
+# The resulting object retains its concrete implementation type, but the
+# iteration, replay-buffer, lifecycle, and weight-update APIs stay the same.
+# See :ref:`ref_collectors` for RPC, distributed, submitit, and scoped backend
+# selection.
+#
 #################################
 # Data collectors are very useful when it comes to coding state-of-the-art
 # algorithms, as performance is usually measured by the capability of a
@@ -180,12 +227,10 @@ print(sample)
 # Next steps
 # ----------
 #
-# - You can have look at other multiprocessed
-#   collectors such as :class:`~torchrl.collectors.MultiSyncCollector` or
-#   :class:`~torchrl.collectors.MultiAsyncCollector`.
-# - TorchRL also offers distributed collectors if you have multiple nodes to
-#   use for inference. Check them out in the
-#   :ref:`API reference <ref_collectors>`.
+# - Scale collection with ``Collector(num_collectors=N, sync=...)`` or select
+#   Ray, RPC, and distributed execution through ``Collector(backend=...)``.
+#   See the :ref:`API reference <ref_collectors>` for the full selection and
+#   configuration rules.
 # - Check the dedicated :ref:`Replay Buffer tutorial <rb_tuto>` to know
 #   more about the options you have when building a buffer, or the
 #   :ref:`API reference <ref_data>` which covers all the features in

--- a/tutorials/sphinx-tutorials/memory_efficient_rl.py
+++ b/tutorials/sphinx-tutorials/memory_efficient_rl.py
@@ -183,8 +183,8 @@ print(
 # under ``("next", ...)`` *before* stacking per-step data.
 # ``("next", "reward")``, ``("next", "done")`` and
 # ``("next", "truncated")`` are preserved — they cannot be reconstructed
-# from the root keys. The flag works for ``MultiSyncCollector`` and
-# ``MultiAsyncCollector`` too.
+# from the root keys. The flag also works when ``Collector`` selects a process
+# or distributed backend.
 
 compact_collector = Collector(
     create_env_fn=env_maker,

--- a/tutorials/sphinx-tutorials/multiagent_competitive_ddpg.py
+++ b/tutorials/sphinx-tutorials/multiagent_competitive_ddpg.py
@@ -623,14 +623,16 @@ for group, _agents in env.group_map.items():
 # Data collector
 # --------------
 #
-# TorchRL provides a set of data collector classes. Briefly, these
-# classes execute three operations: reset an environment, compute an action
+# TorchRL provides :class:`~torchrl.collectors.Collector` as the main data
+# collector construction API. It executes three operations: reset an
+# environment, compute an action
 # using the policy and the latest observation, execute a step in the environment, and repeat
 # the last two steps until the environment signals a stop (or reaches a done
 # state).
 #
-# We will use the simplest possible data collector, which has the same output as an environment rollout,
-# with the only difference that it will auto reset done states until the desired frames are collected.
+# We use its direct default, which has the same output as an environment
+# rollout except that it auto-resets done states until the desired frames are
+# collected. The same constructor can select process or distributed execution.
 #
 # We need to feed it our exploration policies. Furthermore, to run the policies from all groups as if they were one,
 # we put them in a sequence. They will not interfere with each other as each group writes and reads keys in different places.

--- a/tutorials/sphinx-tutorials/multiagent_ppo.py
+++ b/tutorials/sphinx-tutorials/multiagent_ppo.py
@@ -532,14 +532,16 @@ print("Running value:", critic(env.reset()))
 # Data collector
 # --------------
 #
-# TorchRL provides a set of data collector classes. Briefly, these
-# classes execute three operations: reset an environment, compute an action
+# TorchRL provides :class:`~torchrl.collectors.Collector` as the main data
+# collector construction API. It executes three operations: reset an
+# environment, compute an action
 # using the policy and the latest observation, execute a step in the environment, and repeat
 # the last two steps until the environment signals a stop (or reaches a done
 # state).
 #
-# We will use the simplest possible data collector, which has the same output as an environment rollout,
-# with the only difference that it will auto reset done states until the desired frames are collected.
+# We use its direct default, which has the same output as an environment
+# rollout except that it auto-resets done states until the desired frames are
+# collected. The same constructor can select process or distributed execution.
 #
 collector = Collector(
     env,

--- a/tutorials/sphinx-tutorials/torchrl_demo.py
+++ b/tutorials/sphinx-tutorials/torchrl_demo.py
@@ -333,8 +333,8 @@ for batch in collector:
 collector.shutdown()
 
 ###############################################################################
-# For async collection (useful when training takes longer than collecting),
-# see :class:`~torchrl.collectors.MultiAsyncCollector`.
+# For asynchronous collection (useful when training takes longer than
+# collecting), use ``Collector(num_collectors=N, sync=False)``.
 #
 # Replay Buffers
 # --------------


### PR DESCRIPTION
## Summary

- make `Collector` the unified construction entry point for direct, process, Ray, RPC, distributed, and submitit collection
- add nestable, exception-safe `service_backend` and `transport_backend` scoped defaults with PID isolation
- integrate contextual service and transport resolution with replay buffers and inference servers
- add collector configuration parity, backend validation, environment-factory normalization, and backend option forwarding
- update the collector reference, service workflow, tutorials, examples, and SOTA implementations to use the unified entry point

## API behavior

`Collector` dispatches only when the exact public class is constructed and preserves the selected concrete return type. Selection follows explicit `backend`, scoped service default, `num_collectors` implying process collection, then direct collection.

Backend-specific arguments remain available through `backend_options`, including launchers, Ray resources, and inner Gloo/NCCL backend selection. Explicit constructor values override scoped defaults.

## Validation

- pre-commit hooks
- generic collector dispatch, validation, concrete-type, and multiprocessing smoke tests
- backend context nesting, exception restoration, thread/task isolation, and PID isolation tests
- collector Hydra configuration tests
- replay-buffer and inference-server service/transport tests, including Ray ownership and distributed Gloo transport
- migrated VLA collector tests
- Sphinx HTML build across 930 pages with gallery execution disabled
- Python compilation and `git diff --check`

The changed getting-started collector tutorial also executed successfully in an execution-enabled documentation build; that full gallery run later stopped in an unrelated video tutorial because `torchcodec` was unavailable.
