### PR TITLE
[CI] Install scikit-build-core before building torchcodec from source

### DIFF
--- a/.github/unittest/linux/scripts/run_all.sh
+++ b/.github/unittest/linux/scripts/run_all.sh
@@ -254,6 +254,9 @@ fi
 
 # install torchcodec (from source for nightly, from the PyTorch wheel index for stable)
 if [[ "$TORCH_VERSION" == "nightly" ]]; then
+  # torchcodec builds with scikit-build-core; --no-build-isolation requires the
+  # build backend to be present in the environment (pybind11/ninja/cmake already are).
+  uv_pip_install "scikit-build-core>=0.10"
   torchcodec_dir=$(mktemp -d)
   git clone --depth 1 https://github.com/pytorch/torchcodec.git "$torchcodec_dir"
   python_base="$(python -c 'import sys; print(sys.base_prefix)')"

--- a/.github/unittest/tutorials/scripts/run_all.sh
+++ b/.github/unittest/tutorials/scripts/run_all.sh
@@ -117,7 +117,9 @@ bash "${root_dir}/.github/unittest/helpers/assert_torch_version.sh" "$TORCH_VERS
 
 printf "* Installing torchcodec\n"
 if [[ "$RELEASE" == 0 ]]; then
-  uv pip install --no-progress setuptools ninja packaging "pybind11[global]"
+  # torchcodec builds with scikit-build-core; --no-build-isolation requires the
+  # build backend to be present in the environment.
+  uv pip install --no-progress setuptools ninja packaging "pybind11[global]" "scikit-build-core>=0.10"
   torchcodec_dir="$(mktemp -d)"
   git clone --depth 1 https://github.com/pytorch/torchcodec.git "$torchcodec_dir"
   python_base="$(python -c 'import sys; print(sys.base_prefix)')"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,6 +74,9 @@ jobs:
           python -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu -U --quiet --root-user-action=ignore
           python -m pip install cloudpickle packaging importlib_metadata numpy orjson "pyvers>=0.2.3,<0.3.0" --quiet --root-user-action=ignore
           python -m pip install git+https://github.com/pytorch/tensordict.git --no-deps --quiet --root-user-action=ignore
+          # torchcodec builds with scikit-build-core; --no-build-isolation requires
+          # the build backend to be present in the environment.
+          python -m pip install "scikit-build-core>=0.10" pybind11 ninja --quiet --root-user-action=ignore
           torchcodec_dir=$(mktemp -d)
           git clone --depth 1 https://github.com/pytorch/torchcodec.git "$torchcodec_dir"
           python_base="$(python -c 'import sys; print(sys.base_prefix)')"


### PR DESCRIPTION
## Summary

All CI jobs on the nightly-torch path (tests-cpu, tests-gpu, tests-stable-gpu, docs) currently fail during environment setup with:

```
ModuleNotFoundError: No module named 'scikit_build_core'
```

torchcodec switched its build backend from setuptools to scikit-build-core (pytorch/torchcodec#1436, merged 2026-07-16 12:22 UTC). Our CI builds torchcodec from a source clone with `--no-build-isolation` so that it compiles against the already-installed nightly torch; with build isolation disabled, the build backend must be present in the environment. Every run started after the torchcodec merge fails at env setup, before any tests execute (the last green main run predates the merge).

## Fix

Pre-install `scikit-build-core>=0.10` before the torchcodec source build in the three places that perform it:

- `.github/unittest/linux/scripts/run_all.sh` (pybind11/ninja/cmake are already installed earlier in the script)
- `.github/unittest/tutorials/scripts/run_all.sh` (added to the existing build-deps install line)
- `.github/workflows/docs.yml` (also adds pybind11 and ninja, which this workflow did not install; torchcodec declares `build-system.requires = ["scikit-build-core>=0.10", "pybind11"]`)

The stable/release paths install torchcodec wheels and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)