### PR TITLE
[Feature] Add reliable VLA-GRPO LIBERO recipe

### DIFF
--- a/.github/unittest/linux_sota/scripts/test_sota.py
+++ b/.github/unittest/linux_sota/scripts/test_sota.py
@@ -9,13 +9,22 @@ from pathlib import Path
 import pytest
 from tensordict.nn import composite_lp_aggregate
 
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
 # Check that we're using the new behavior
 assert (
     not composite_lp_aggregate()
 ), "Composite LP must be set to False. Run this test with COMPOSITE_LP_AGGREGATE=0"
 
+REPO_ROOT = Path(__file__).resolve().parents[4]
+RECIPE_PATHS = sorted((REPO_ROOT / "sota-implementations").glob("*/recipe.toml"))
+
 commands = {
     "vla_grpo": """python sota-implementations/vla_grpo/vla-grpo.py \
+  --config-name vla_grpo_toy \
   collector.groups_per_iter=2 \
   collector.group_size=2 \
   collector.total_iters=3 \
@@ -391,6 +400,37 @@ def run_command(command):
     return_code = process.wait()
     if return_code != 0:
         raise subprocess.CalledProcessError(return_code, command)
+
+
+def _load_recipe(path):
+    with path.open("rb") as file:
+        return tomllib.load(file)
+
+
+def test_recipe_ids_are_unique():
+    recipe_ids = [_load_recipe(path)["id"] for path in RECIPE_PATHS]
+    assert len(recipe_ids) == len(set(recipe_ids))
+
+
+@pytest.mark.parametrize("recipe_path", RECIPE_PATHS, ids=lambda path: path.parent.name)
+def test_recipe_manifest(recipe_path):
+    recipe = _load_recipe(recipe_path)
+    assert recipe["schema_version"] == 1
+    assert recipe["id"]
+    assert recipe["description"]
+    assert recipe["entrypoint"]
+    assert recipe["healthcheck"]["command"]
+
+    with (REPO_ROOT / "pyproject.toml").open("rb") as file:
+        optional_dependencies = set(
+            tomllib.load(file)["project"]["optional-dependencies"]
+        )
+    assert set(recipe.get("python", {}).get("extras", ())) <= optional_dependencies
+
+    for command in (recipe["entrypoint"], recipe["healthcheck"]["command"]):
+        for argument in command:
+            if argument.endswith(".py"):
+                assert (REPO_ROOT / argument).is_file()
 
 
 @pytest.mark.parametrize("algo", list(commands))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,13 +95,23 @@ replay_buffer = ["torch>=2.7.0"]
 gym_continuous = ["gymnasium<1.0", "mujoco"]
 video = ["torchcodec>=0.10.0"]
 notebook = ["jupyterlab"]
-# lerobot requires Python >= 3.12 (and lerobot <= 0.4 cannot resolve against
-# recent torch), so the extra is empty on older interpreters
-vla = ["lerobot>=0.5.0; python_version >= '3.12'", "torchvision>=0.17"]
+# lerobot requires Python >= 3.12, while the remaining VLA runtime dependencies
+# are also used by the vendored OpenVLA-OFT path.
+vla = [
+    "accelerate>=0.25.0",
+    "lerobot>=0.5.0; python_version >= '3.12'",
+    "peft==0.11.1",
+    "pillow",
+    "timm==0.9.10",
+    "tokenizers==0.19.1",
+    "transformers==4.40.1",
+    "torchvision>=0.17",
+]
 rendering = ["moviepy", "pygame", "pyyaml", "torchcodec>=0.10.0"]
 tests = [
     "pytest",
     "pyyaml",
+    "tomli>=1.1.0; python_version < '3.11'",
     "pytest-instafail",
     "scipy",
     "psutil",

--- a/sota-check/run_vla_grpo.sh
+++ b/sota-check/run_vla_grpo.sh
@@ -12,6 +12,7 @@ project_name="torchrl-example-check-$current_commit"
 group_name="vla_grpo"
 export PYTHONPATH=$(dirname $(dirname $PWD))
 python $PYTHONPATH/sota-implementations/vla_grpo/vla-grpo.py \
+  --config-name vla_grpo_toy \
   logger.backend=wandb \
   logger.project_name="$project_name" \
   logger.group_name="$group_name"

--- a/sota-implementations/README.md
+++ b/sota-implementations/README.md
@@ -30,6 +30,21 @@ or similar. Hyperparameters can be easily changed by providing the arguments to 
 python sac.py collector.frames_per_batch=63
 ```
 
+## Execution recipes
+
+Environment-heavy implementations can provide a versioned `recipe.toml` next
+to their entrypoint. The recipe is a backend-neutral description of the
+Python extras, pinned source checkouts, system capabilities, environment
+variables, resource requirements, artifacts, entrypoint, and end-to-end
+health check needed by the implementation.
+
+Recipe-aware executors are responsible for satisfying that contract on their
+platform. Cluster-specific hostnames, storage paths, scheduler arguments, and
+IDE configuration do not belong in the recipe. Every committed recipe is
+validated as part of the SOTA test suite.
+
+See [`vla_grpo/recipe.toml`](vla_grpo/recipe.toml) for an example.
+
 [//]: # (# Results)
 
 [//]: # ()

--- a/sota-implementations/vla_grpo/README.md
+++ b/sota-implementations/vla_grpo/README.md
@@ -50,8 +50,9 @@ rollout and writes a JSON parity report.
 
 ### Toy scale: learn the algorithm without a robot simulator
 
-The default config, `config/vla_grpo_toy.yaml`, trains `TinyVLA` on
-`ToyVLAEnv`. This is the quickest way to understand and test the stack.
+The opt-in `config/vla_grpo_toy.yaml` config trains `TinyVLA` on
+`ToyVLAEnv`. This is the quickest way to understand and test the stack; the
+script default is the at-scale LIBERO recipe described below.
 
 `ToyVLAEnv` is a tiny TorchRL environment that speaks the same TensorDict schema
 as a real VLA robot environment:
@@ -84,7 +85,7 @@ same TorchRL tokenizer transform used for the larger VLA policy.
 Run the toy recipe with:
 
 ```bash
-python sota-implementations/vla_grpo/vla-grpo.py
+python sota-implementations/vla_grpo/vla-grpo.py --config-name vla_grpo_toy
 ```
 
 The greedy evaluation success rate should climb from zero (a randomly
@@ -124,20 +125,27 @@ policy forward
   -> ("vla_action", "tokens") [B, H, A]
   -> ActionTokenizerTransform.inverse   tokens -> continuous action_chunk
   -> MultiAction(stack_rewards=False)   execute H base-env actions
-  -> SuccessReward                      convert task success into decision reward
   -> StepCounter(max_outer_steps)       truncate in policy decisions
 ```
 
-`MCAdvantage` sits on the replay-buffer path. It receives completed
-trajectories, groups trajectories that started from the same initial state, and
-computes a Monte-Carlo advantage from the group-normalized return. With
-`trajectory_return="sum"`, the trajectory-level success return is broadcast to
-every chunk decision in that trajectory, which is the shape PPO needs.
+LIBERO emits `reward=float(success)` from the base environment step. When a
+chunk terminates early, `MultiAction(stack_rewards=False)` keeps the reward from
+the last action that actually executed, so the outer transition preserves the
+terminal success reward instead of reporting a zero from a skipped trailing
+action slot.
 
-The loss is `ClipPPOLoss` configured like a GRPO policy update: no critic, no
-entropy bonus, no KL-to-reference term, and asymmetric DAPO Clip-Higher bounds.
-For token policies the ratio can be computed per token, which matches the
-SimpleVLA-RL semantics used by the OpenVLA configuration.
+`MCAdvantage` sits on the replay-buffer path. It consumes `("next", "reward")`,
+receives completed trajectories, groups trajectories that started from the same
+initial state, and computes a Monte-Carlo advantage from the group-normalized
+return. With `trajectory_return="sum"`, the trajectory-level success return is
+broadcast to every chunk decision in that trajectory, which is the shape PPO
+needs.
+
+The loss is `ClipPPOLoss` configured like a GRPO policy update: no critic, zero
+entropy coefficient, no KL-to-reference term, and asymmetric DAPO Clip-Higher
+bounds. Entropy is still reported as a diagnostic. For token policies the ratio
+can be computed per token, which matches the SimpleVLA-RL semantics used by the
+OpenVLA configuration.
 
 ## What is OpenVLA-OFT (token)?
 
@@ -176,8 +184,8 @@ training. Use the SimpleVLA-RL SFT checkpoints, for example `Haozhan72/*`:
 from openvla import OpenVLAOFTWrapper
 
 policy = OpenVLAOFTWrapper.from_pretrained(
-    "Haozhan72/Openvla-oft-SFT-libero10-traj1",
-    temperature=1.6,
+    "Haozhan72/Openvla-oft-SFT-libero-spatial-trajall",
+    temperature=1.0,
     device="cuda",
 )
 tokenizer = policy.action_tokenizer  # decode tokens -> env actions
@@ -222,7 +230,12 @@ pytest sota-implementations/vla_grpo/test_openvla.py
 With a logger configured (`logger.backend=wandb`, the default), each iteration
 logs the training success rate (`train/success_rate`), trajectory-return
 aggregates (`collector/trajectory_return_sum`,
-`collector/trajectory_return_max`), and throughput split into collection and
+`collector/trajectory_return_max`), frozen and periodic greedy evaluation
+success (`eval/success_rate`), PPO diagnostics (`train/loss_objective`,
+`train/kl_approx`, `train/mean_ratio`, `train/clip_fraction`, `train/ESS`,
+`train/entropy`), group filtering (`buffer/kept_groups`,
+`buffer/skipped_groups`, `buffer/rescued_groups`,
+`buffer/queued_trajectories`), and throughput split into collection and
 optimization:
 
 - `throughput/inference_env_steps_per_s`
@@ -231,36 +244,65 @@ optimization:
 - `throughput/optim_steps_per_s`
 
 LIBERO uses ``logger.service_backend=process`` so evaluator workers receive a
-lightweight logger client. Evaluation video is one synchronized grid recorded
-from the same ``env.eval_num_envs`` parallel rollouts used for reward and
-success metrics; it does not launch an extra rollout or select a single task.
+lightweight logger client. Scalar evaluation and video recording are split:
+the scalar evaluator runs the full `logger.eval_episodes` sweep without pixels,
+while `logger.record_video=true` launches a separate bounded visual evaluator.
+By default it records `logger.video_episodes=1` trajectory with
+`logger.video_num_envs=1`; set `logger.video_episodes` to an integer count or a
+fraction in `(0, 1)` to record a larger sample without making every scalar eval
+rollout video-capable.
 
 The collector path is fixed: a TorchRL `MultiCollector` launches rollout
 workers, each worker owns a sync `ParallelEnv(envs_per_collector)`, and all
-workers plus the evaluator share one process policy server.
+workers plus the evaluator share one process policy server. The rollout
+builder receives a policy factory rather than the learner model; only the
+inference-server child invokes that factory. The main process owns the distinct
+trainable learner policy required by the PPO loss and optimizer.
+
+Each nested `ParallelEnv` is built from one homogeneous environment factory and
+per-worker `create_env_kwargs`. Worker-specific task ids, init-state groups,
+language instructions, seeds, and render-device assignments still come from the
+real worker index, but metadata collection only needs the homogeneous schema
+instead of constructing every LIBERO worker once in the parent and again in the
+subprocesses.
+The LIBERO recipe also enables `env.metadata_from_workers=true`, so the
+metadata schema comes from the real subprocess environments and no parent-side
+temporary MuJoCo/EGL environment is needed for those rollout and eval pools.
 
 ```bash
-python sota-implementations/vla_grpo/vla-grpo.py --config-name vla_grpo_libero
+python sota-implementations/vla_grpo/vla-grpo.py
 ```
 
 Rollout clients request random sampling; eval and video clients request
 deterministic decoding from the same server, so rollout and eval are synced by
 one explicit TensorDict weight update after each optimizer step. The replay
 buffer is passed to the collector and receives complete trajectories as they
-finish; training waits until the consuming replay buffer has enough sampleable
-decisions.
+finish; training waits for the configured number of complete, non-degenerate
+GRPO groups. An optional decision-count floor can be added, but it is not used
+as a proxy for complete groups.
 
-With the thread evaluator backend, eval rollouts are rendered to video whenever
-a logger is configured. A dedicated single-environment evaluator is built with
-`from_pixels=True`: `ToyVLAEnv` renders the tracking scene, while `LiberoEnv`
-exposes its camera. `torchrl.record.VideoRecorder` writes the evaluator rollout
-to `eval/video` on every eval. wandb video encoding needs `moviepy` from the
-`dev` dependency group. Process-backend evaluator video dumping still needs a
-TorchRL-side remote `VideoRecorder.dump` path.
+The environment-side OpenVLA action tokenizer is constructed directly from
+`dataset_statistics.json`. It therefore does not require access to either the
+learner model or the inference-server model.
+
+The at-scale LIBERO config is set up for a single eight-GPU node: GPU 0 holds
+the learner, GPU 1 holds the shared inference server, GPUs 2-6 render rollout
+workers, and GPU 7 renders evaluation/video. It uses `candidate_group_size=32`,
+`candidate_selection_min_size=32`, and balanced selection to collect more
+rollouts than PPO consumes, while dropping all-failure and all-success groups
+from optimization because they have zero group-relative advantage.
+
+With `logger.record_video=true`, the bounded video evaluator is rendered through
+the configured evaluator backend with `from_pixels=True`: `ToyVLAEnv` renders
+the tracking scene, while `LiberoEnv` exposes its camera.
+`torchrl.record.VideoRecorder` writes the sampled visual rollout to
+`eval/video` on every scheduled eval. wandb video encoding needs `moviepy` from
+the `dev` dependency group.
 
 Checkpointing is shared by the toy and LIBERO configs. `checkpoint_latest`
 is written as a TensorDict directory in the hydra run directory every
-`checkpoint.save_iter` iterations;
+`checkpoint.save_iter` iterations. It includes the optimizer iteration and
+completed-trajectory count so a resumed paper-budget run stops correctly;
 resume with:
 
 ```bash
@@ -270,21 +312,47 @@ python sota-implementations/vla_grpo/vla-grpo.py \
 
 ## LIBERO configuration details
 
-The full LIBERO config follows the SimpleVLA-RL hyper-parameter shape:
+### Canonical execution recipe
+
+[`recipe.toml`](recipe.toml) describes the complete LIBERO execution
+environment independently of any particular scheduler. It declares the
+TorchRL extras, compatible LIBERO source revision and Python packages,
+headless EGL requirement, environment variables, resource shape, optional
+demonstration data, persistent cache categories, entrypoint, and
+[`smoke.py`](smoke.py) readiness check.
+
+A compatible executor must not report the recipe as ready until the smoke
+check has verified CUDA, the TensorFlow-free OpenVLA image preprocessor, and
+an actual headless `LiberoEnv.reset()` call. The LIBERO demonstration dataset
+is intentionally optional because the online GRPO configuration uses the
+simulator tasks and assets but does not consume demonstrations.
+
+The default LIBERO config follows the SimpleVLA-RL hyper-parameter shape:
 
 - groups of `n=8` rollouts per initial state;
-- 40 initial states per iteration (`collector.groups_per_iter`), for 320
-  trajectories before dynamic filtering -- one aligned group wave across the
-  320 rollout envs; the paper uses 64 initial states (512 trajectories) per
-  iteration, which is a known deviation of the shipped config;
+- 64 complete useful initial-state groups per update
+  (`collector.groups_per_iter`), for 512 selected trajectories;
+- 700 optimizer iterations; with 512 selected trajectories per update, this
+  matches the paper-scale selected-trajectory budget while allowing discarded
+  oversampled candidates not to shorten training;
 - 512 base environment steps, or 64 chunk decisions, per episode;
-- rollout temperature 1.6 and greedy evaluation;
+- rollout temperature 1.0 and greedy evaluation;
+- 500 suite-wide greedy evaluation rollouts over cycled initial states,
+  including an asynchronous frozen-policy baseline launched before the first
+  update so collection and optimization are not blocked by the full eval sweep;
 - dynamic sampling bounds `(0.1, 0.9)` to drop groups that are all failure or
   all success;
 - learning rate `5e-6` with constant-with-warmup scheduling;
-- gradient accumulation and gradient clipping at 1.0;
+- optimizer batches of 128 trajectories, with model forwards limited to 16
+  decisions and gradient clipping at 1.0;
 - asymmetric clip `(0.2, 0.28)` applied to per-token importance ratios by
   default (`loss.ratio_level: token`).
+
+The optimizer reduction is trajectory-aware: token losses are averaged into
+one loss per decision, decisions are averaged within each trajectory, and
+trajectories are averaged within the optimizer batch. Thus short successful
+trajectories and long failed trajectories have equal trajectory weight, and
+`loss.mini_batch_size` changes memory use without changing this objective.
 
 A sequence-level ratio remains available as a config switch for ablations, but
 for a 56-token action chunk it saturates the clip range much more easily than
@@ -297,46 +365,47 @@ shared process server and each worker owns a disjoint `group_id` block so
 advantages never mix across unrelated groups.
 
 Without `env.parallel_group_repeats`, groups are repeated serially within each
-worker, so the total rollout worker count should not exceed
-`collector.groups_per_iter`. For that serial mode, set
-`collector.num_collectors * collector.envs_per_collector` to a divisor of
-`collector.groups_per_iter`, often the same value.
+worker. The total rollout worker count controls collection concurrency, while
+`collector.groups_per_iter` independently controls optimizer-update cadence.
 
 When `env.parallel_group_repeats=true`, the shared replay buffer centralizes
 `MCAdvantage` write state, so same-initial-state groups may straddle
 subcollectors. The logical worker count is the total rollout worker count
-divided by `collector.group_size`. In this mode, prefer setting
-`collector.groups_per_iter` to that logical worker count so one target group
-wave is aligned. If `collector.candidate_group_size` is larger than
-`collector.group_size`, each worker in a logical group repeats the same initial
-state serially enough times to produce up to the requested candidate count. For
-example, 8 parallel workers x 2 serial repeats gives at most 16 candidates.
-Groups can be written earlier if the candidates already contain a useful
-selected subset.
+divided by `collector.group_size`, but `collector.groups_per_iter` need not be a
+multiple of it: the setting is only the minimum number of complete useful
+groups that triggers an optimizer update. If `collector.candidate_group_size`
+is larger than `collector.group_size`, each worker in a logical group repeats
+the same initial state serially enough times to produce up to the requested
+candidate count. For example, 8 parallel workers x 2 serial repeats gives at
+most 16 candidates. Groups can be written earlier if the candidates already
+contain a useful selected subset.
 
-The training script starts the collector once, waits until the consuming replay
-buffer has enough sampleable decisions, pauses collection, runs the PPO update,
-clears incomplete same-policy advantage queues and partial trajectories, pushes
-the TensorDict policy weights to the shared policy server, and then lets the
-collector resume.
-`MCAdvantage` runs as the replay-buffer transform and keeps incomplete groups
-queued only within a single policy window. `collector.min_replay_decisions` can
-require a minimum number of useful replay decisions before the PPO update.
-Set `TORCHRL_MC_ADVANTAGE_LOCAL_QUEUES=1` to keep grouping state in each replay
-writer instead of a multiprocessing manager. At every policy boundary the
-trainer reads those worker-local counters while collection is paused, clears
-their queues, and resets in-flight collector trajectories before the policy
-version advances.
+The training script evaluates the frozen SFT policy at step 0, starts the
+collector once, waits for the target number of complete kept groups, pauses
+collection, runs the PPO update, pushes the TensorDict policy weights to the
+shared policy server, and then lets the collector resume. Incomplete
+`MCAdvantage` groups and in-flight environment trajectories are preserved
+across that boundary. Each inference response carries its actual
+`policy_version`; PPO uses the corresponding stored action log-probability,
+while the trainer reports decision staleness and policy-version spans within
+trajectories and GRPO groups.
+
+`collector.min_replay_decisions` can require a minimum number of useful replay
+decisions before the PPO update. Set `TORCHRL_MC_ADVANTAGE_LOCAL_QUEUES=1` to
+keep grouping state in each replay writer instead of a multiprocessing manager.
+At every policy boundary the trainer reads and resets worker-local accounting
+counters while collection is paused, without clearing queues or resetting
+in-flight trajectories, before the policy version advances.
 
 Candidate selection is delegated to `MCAdvantageSelector` (`first`, `uniform`,
 or `balanced`), so the replay-buffer transform owns the sample-selection policy
-while the collector only supplies same-policy completed trajectories. The
-consuming replay buffer removes sampled decisions after
+while the collector supplies completed trajectories with per-decision behavior
+policy metadata. The consuming replay buffer removes sampled decisions after
 `buffer.consume_after_n_samples` samples, and the policy-boundary pause keeps
 rollout and optimization phases explicit. LIBERO workers stamp
 parallel-repeat group ids from the cycled initial-state id so fast and slow
-sibling workers can still complete a same-initial-state GRPO group under the
-same policy even when their episode lengths differ.
+sibling workers can still complete a same-initial-state GRPO group even when
+their episode lengths cross a policy update.
 
 Run the LIBERO recipe with:
 
@@ -348,7 +417,15 @@ python sota-implementations/vla_grpo/vla-grpo.py --config-name vla_grpo_libero
 
 Requirements beyond the toy scale: LIBERO (see the `torchrl.envs.LiberoEnv`
 docs for install notes), `transformers`, `timm`, `Pillow`, and `peft` when
-`policy.lora_rank` is set.
+`policy.lora_rank` is set. The VLA extra pins the OpenVLA-compatible
+`transformers`, `tokenizers`, `timm`, and `peft` versions because their newer
+APIs are not backward-compatible with the vendored OpenVLA-OFT model.
+
+Install the Python requirements with the TorchRL VLA extra:
+
+```bash
+pip install -e '.[vla]'
+```
 
 The default `policy.image_backend=torch_reference` uses torchvision's JPEG
 codec and matches SimpleVLA's JPEG-before-resize order, antialiased Lanczos3
@@ -370,22 +447,23 @@ per-trajectory token/action/success agreement.
 
 - The default H100 configuration trains a LoRA adapter
   (`policy.lora_rank: 32`) on `policy.device: cuda:0` and serves rollout plus
-  evaluator inference from `collector.policy_device: cuda:1`. Four
-  collectors each run `ParallelEnv(80)` for 320 rollout envs total. On
+  evaluator inference from `collector.policy_device: cuda:1`. Five
+  collectors each run `ParallelEnv(64)` for 320 rollout envs total. They
+  asynchronously fill the 64-group/512-selected-trajectory update batch. On
   single-GPU runs, override `policy.device=null`,
   `collector.policy_device=null`, `collector.num_collectors=1`, and
   `collector.envs_per_collector` to the number of local envs.
 - Rollout wall-clock dominates, so scale `collector.num_collectors` and
   `collector.envs_per_collector` with the available CPU cores while keeping
   the GRPO grouping constraint above. The H100 default uses
-  `collector.num_collectors=4`, `collector.envs_per_collector=80`,
-  `collector.groups_per_iter=40`, and parallel group repeats enabled. The
+  `collector.num_collectors=5`, `collector.envs_per_collector=64`,
+  `collector.groups_per_iter=64`, and parallel group repeats enabled. The
   training loop pushes TensorDict policy weights to the shared policy server
   after optimizer updates.
 - Headless LIBERO rendering uses MuJoCo/robosuite EGL by default
   (`env.render_backend: egl`). `env.render_gpu_ids` controls the EGL-visible
   render device ids assigned to rollout workers, round-robin. The H100 default
-  spreads rollout rendering over `[2,3,4,5]` and reserves
+  spreads rollout rendering over `[2,3,4,5,6]` and reserves
   `env.eval_render_gpu_ids=[7]` for eval/video rendering. These ids are the
   devices visible to EGL inside the process/container and may not match global
   CUDA ordinals.

--- a/sota-implementations/vla_grpo/compare_simplevla_rollouts.py
+++ b/sota-implementations/vla_grpo/compare_simplevla_rollouts.py
@@ -299,7 +299,7 @@ def _policy_and_tokenizer(args: argparse.Namespace):
     cfg = _load_cfg(args, int(args.task_ids[0]))
     policy = vla_utils.make_policy(cfg, device)
     policy.eval()
-    tokenizer = vla_utils.make_action_tokenizer(cfg, policy)
+    tokenizer = vla_utils.make_action_tokenizer(cfg)
     return cfg, policy, tokenizer
 
 
@@ -802,7 +802,7 @@ def main() -> None:
     parser.add_argument("--task-ids", type=_parse_int_list, default=[0])
     parser.add_argument("--trial-ids", type=_parse_int_list, default=[0])
     parser.add_argument(
-        "--checkpoint", default="Haozhan72/Openvla-oft-SFT-libero-spatial-traj1"
+        "--checkpoint", default="Haozhan72/Openvla-oft-SFT-libero-spatial-trajall"
     )
     parser.add_argument(
         "--dataset-statistics",

--- a/sota-implementations/vla_grpo/config/vla_grpo_libero.yaml
+++ b/sota-implementations/vla_grpo/config/vla_grpo_libero.yaml
@@ -3,8 +3,11 @@
 # MultiCollector rollout workers; see the README for the multi-GPU notes and
 # the LoRA fallback. Requires LIBERO (and its deps) plus transformers/timm.
 #
-# Per-target-wave accounting: groups_per_iter x group_size = 320 trajectories,
-# each up to max_outer_steps = 64 chunk decisions (512 env steps / chunk 8).
+# Per-update accounting: groups_per_iter x group_size = 512 selected
+# trajectories. With candidate_group_size=32, collection oversamples 2,048
+# completed trajectories per update and balanced selection keeps the 512
+# useful mixed-group rollouts for PPO. Each trajectory is capped at
+# max_outer_steps = 64 chunk decisions (512 env steps / chunk 8).
 
 env:
   backend: libero
@@ -21,21 +24,19 @@ env:
   # collector.envs_per_collector) to be a multiple of collector.group_size and,
   # to cover all tasks in one wave, that total to be at least
   # len(task_ids) * collector.group_size.
-  # For lowest boundary waste, set collector.groups_per_iter to the logical
-  # worker count (collector env total / collector.group_size). Asking each
-  # logical worker to advance through multiple group ids in one collector batch
-  # creates partial groups when episodes have variable lengths. Additional
-  # collector batches can overcollect under one policy, but without a group
-  # barrier they may also drift; the LIBERO wrapper groups parallel repeats by
-  # cycled init-state id to reduce this waste.
+  # collector.groups_per_iter is independent of this logical worker count.
+  # Completed trajectories waiting for the rest of a group and in-flight
+  # trajectories survive optimizer boundaries; each decision retains the
+  # policy_version that generated it so any resulting lag is observable.
   parallel_group_repeats: true
   eval_num_envs: 10 # parallel MuJoCo processes (evaluation); >= len(task_ids)
   camera_height: 256
   camera_width: 256
   render_backend: egl # egl (GPU/headless) | osmesa (CPU fallback)
-  render_gpu_ids: [2, 3, 4, 5] # H100 fast mode render GPUs for rollout workers
+  render_gpu_ids: [2, 3, 4, 5, 6] # H100 fast mode render GPUs for rollout workers
   eval_render_gpu_ids: [7] # reserve GPU 7 for eval/video rendering
   render_gpu_device_zero_fallback: true
+  metadata_from_workers: true # avoid parent-side shadow LIBERO/EGL env construction
   env_kwargs: null
   chunk_size: 8 # NUM_ACTIONS_CHUNK of the checkpoint
   max_env_steps: 512 # base env steps per episode (the paper's cap)
@@ -45,21 +46,21 @@ env:
   seed: 0
 
 tokenizer:
-  vocab_size: 256 # unused for the openvla backend (codec comes from the checkpoint)
+  vocab_size: 256 # OpenVLA action-token window; stats are loaded without the model
 
 policy:
   backend: openvla
   mode: tokens # tokens: SimpleVLA-RL GRPO path; l1: official continuous OFT reference/eval path
   # the checkpoint MUST match task_suite (it fixes the SFT policy AND the
   # action statistics unnorm_key resolves into)
-  checkpoint: Haozhan72/Openvla-oft-SFT-libero-spatial-traj1
+  checkpoint: Haozhan72/Openvla-oft-SFT-libero-spatial-trajall
   unnorm_key: libero_spatial_no_noops
   # the SimpleVLA-RL checkpoints omit their LIBERO fine-tuning stats; pull the
   # matching official OFT release's dataset_statistics.json (same LIBERO data).
   # Must match unnorm_key's suite (libero-object/goal/10 for the other suites).
   dataset_statistics: moojink/openvla-7b-oft-finetuned-libero-spatial
   dtype: bfloat16
-  temperature: 1.6 # rollout sampling temperature (greedy eval)
+  temperature: 1.0 # rollout sampling temperature (greedy eval)
   top_k: null # null = full categorical; small values keep token exploration local
   use_wrist_image: false
   # L1 reference path: set mode=l1, checkpoint=moojink/openvla-7b-oft-finetuned-libero-spatial,
@@ -84,23 +85,28 @@ policy:
 
 collector:
   group_size: 8 # n: rollouts per initial state (GRPO group)
-  candidate_group_size: null # null = group_size; e.g. 16 samples 16 and selects 8
-  # Initial states per iteration (320 trajectories). With shared fast mode and
-  # env.parallel_group_repeats=true, use
-  # num_collectors * envs_per_collector / group_size.
-  groups_per_iter: 40
-  # null/0 = one full selected rollout set:
-  # groups_per_iter * group_size * max_outer_steps decisions.
+  candidate_group_size: 32 # oversample 32 candidates and select 8 mixed returns
+  # Useful initial-state groups per policy update. This matches the paper's
+  # 64 groups x 8 rollouts = 512 selected trajectories; readiness is measured
+  # from complete kept groups rather than an estimated decision count.
+  groups_per_iter: 64
+  # Optional additional decision floor. null relies on the complete kept-group
+  # target above, so variable-length trajectories cannot trigger an early update.
   min_replay_decisions: null
-  total_iters: 100 # the paper's total_epochs
+  # The 500-state dataset yields floor(500 / 64) = 7 actor batches per epoch.
+  # 700 updates is the paper-scale selected-trajectory budget. Leave
+  # total_trajectories unset when oversampling so the selected budget is not
+  # cut short by discarded candidates.
+  total_iters: 700
+  total_trajectories: null
   policy_device: cuda:1 # H100 default: rollout/eval inference server device
-  # null = one model forward for the complete request batch. Set to 1 for
-  # single-environment numerical parity while keeping batched env collection.
-  policy_micro_batch_size: null
+  # Limits only real OpenVLA forwards inside the inference server. Eight is
+  # the largest size validated against sequential real-checkpoint inference.
+  policy_micro_batch_size: 8
   replay_wait_s: 0.5
   replay_log_s: 30.0
-  num_collectors: 4
-  envs_per_collector: 80
+  num_collectors: 5
+  envs_per_collector: 64
   num_threads: 1
   server_max_batch_size: 1 # one batched ParallelEnv request; avoids mixed eval/rollout modes
   server_min_batch_size: 1
@@ -116,24 +122,26 @@ advantage:
   trajectory_return: sum # binary success return per trajectory
   keep_return_bounds: [0.1, 0.9] # dynamic sampling: drop all-fail / all-success groups
   candidate_selection: balanced # first | uniform | balanced, used if candidate_group_size > group_size
-  # null = try selecting as soon as group_size candidates are available; keep
-  # queueing up to candidate_group_size only if no useful subset exists yet.
-  candidate_selection_min_size: null
+  # Wait for the full candidate group so balanced selection can pick a mixed
+  # subset even when successes are sparse.
+  candidate_selection_min_size: 32
   candidate_selection_max_combinations: 100000
 
 buffer:
   device: cpu # decisions hold raw uint8 images; keep the buffer off-GPU
   shared_init: true
-  capacity_group_waves: 7 # replay capacity as multiples of one target group wave
+  capacity_group_waves: 2 # headroom for asynchronous collector overrun
   consume_after_n_samples: 1 # sampled decisions leave the buffer after one update pass
 
 loss:
   clip_epsilon: [0.2, 0.28] # asymmetric DAPO Clip-Higher (per-token, see ratio_level)
   ratio_level: token # the paper's semantics: one clipped ratio per action token
-  # epochs are controlled by buffer.consume_after_n_samples: each decision
-  # leaves the buffer after that many sampling passes
-  mini_batch_size: 16 # decisions per micro-batch (one forward)
-  accumulate_batches: 8 # optimizer step every N micro-batches (grad accumulation)
+  # epochs are controlled by buffer.consume_after_n_samples. The update
+  # averages decisions within each trajectory, then averages 128 trajectories
+  # per optimizer step, matching the reference implementation. mini_batch_size
+  # only limits the number of decisions in an actual training-model forward.
+  mini_batch_size: 16
+  trajectories_per_optimizer_step: 128
 
 optim:
   lr: 5e-6
@@ -147,6 +155,10 @@ train:
   # TensorDict in place, so frozen base weights stay untouched. false ships
   # the full parameter/buffer set (~14 GB in bf16 for the 7B policy).
   weight_sync_trainable_only: true
+  # Behavior-policy lag is reported explicitly. These distribution-level
+  # guards still catch excessive lag or misrouted weights before PPO proceeds.
+  pre_update_min_ess: 0.95
+  pre_update_max_clip_fraction: 0.05
 
 logger:
   backend: wandb
@@ -155,15 +167,20 @@ logger:
   group_name: null
   exp_name: vla_grpo_libero
   mode: online
+  eval_before_train: true # frozen SFT baseline at step 0
   eval_iter: 4 # evaluate every N iterations (the paper's cadence)
-  eval_episodes: 50 # greedy episodes per evaluation (cycled init states)
+  eval_episodes: 500 # suite-wide cycled rollouts across all 10 tasks
   eval_backend: process # TorchRL Evaluator backend: thread | process | ray
-  eval_async: false # submit eval and log result later
+  eval_async: true # submit full 500-episode eval and log result later
   eval_busy_policy: skip # skip | error | queue
   eval_timeout_s: 1800.0
   eval_device: cpu # eval env/client device; inference stays on the policy-server device
+  record_video: true # record a bounded visual eval alongside scalar curves
+  video_episodes: 1 # int count, or a fraction in (0, 1) of eval_episodes
+  video_num_envs: 1 # parallel envs in the separate video evaluator
   video_fps: 8 # frames per second of the logged video (one frame per decision)
-  # VideoRecorder logs a synchronized grid from these same scalar-eval envs.
+  # The scalar evaluator still runs eval_episodes without pixels; this separate
+  # visual evaluator renders only video_episodes trajectories.
 
 checkpoint:
   save_iter: 25

--- a/sota-implementations/vla_grpo/config/vla_grpo_toy.yaml
+++ b/sota-implementations/vla_grpo/config/vla_grpo_toy.yaml
@@ -36,6 +36,7 @@ collector:
   groups_per_iter: 8 # initial states per iteration
   min_replay_decisions: null # null/0 = collect one target group wave
   total_iters: 200
+  total_trajectories: null
   replay_wait_s: 0.05
   replay_log_s: 30.0
   policy_device: null
@@ -75,7 +76,7 @@ loss:
   # epochs are controlled by buffer.consume_after_n_samples: each decision
   # leaves the buffer after that many sampling passes
   mini_batch_size: 64 # decisions per micro-batch
-  accumulate_batches: 1 # optimizer step every N micro-batches
+  trajectories_per_optimizer_step: 16
 
 optim:
   lr: 1e-3
@@ -89,6 +90,8 @@ train:
   # the full parameter/buffer set. TinyVLA trains all parameters, so this only
   # skips buffers at toy scale; it matters for the LoRA LIBERO config.
   weight_sync_trainable_only: true
+  pre_update_min_ess: null
+  pre_update_max_clip_fraction: null
 
 logger:
   backend: wandb
@@ -97,6 +100,7 @@ logger:
   group_name: null
   exp_name: vla_grpo_toy
   mode: online
+  eval_before_train: false
   eval_iter: 10 # evaluate every N iterations
   eval_episodes: 50 # greedy episodes per evaluation
   eval_backend: thread # TorchRL Evaluator backend: thread | process | ray
@@ -104,8 +108,12 @@ logger:
   eval_busy_policy: skip # skip | error | queue
   eval_timeout_s: 300.0
   eval_device: cpu # eval env/client device; inference stays on the policy-server device
+  record_video: true # record a bounded visual eval alongside scalar curves
+  video_episodes: 1 # int count, or a fraction in (0, 1) of eval_episodes
+  video_num_envs: 1 # parallel envs in the separate video evaluator
   video_fps: 4 # frames per second of the logged video (one frame per decision)
-  # VideoRecorder logs the frames from the same rollout used for eval metrics.
+  # The scalar evaluator still runs eval_episodes without pixels; this separate
+  # visual evaluator renders only video_episodes trajectories.
 
 checkpoint:
   save_iter: 25 # save every N iterations (0 disables)

--- a/sota-implementations/vla_grpo/openvla.py
+++ b/sota-implementations/vla_grpo/openvla.py
@@ -381,6 +381,8 @@ class OpenVLAInputTransform(Transform):
     def _pixel_values_from_images(self, images: torch.Tensor) -> torch.Tensor | None:
         if self._image_preprocessor is None:
             return None
+        if images.device.type != "cpu":
+            images = images.cpu()
         return self._image_preprocessor(images)
 
     def _preprocess(self, images, wrist_images, instructions):

--- a/sota-implementations/vla_grpo/recipe.toml
+++ b/sota-implementations/vla_grpo/recipe.toml
@@ -1,0 +1,73 @@
+schema_version = 1
+id = "vla-grpo-libero"
+description = "OpenVLA GRPO training on the LIBERO simulator"
+capabilities = [
+    "cuda",
+    "pytorch-nightly",
+    "tensordict-main",
+    "torchrl",
+    "headless-egl",
+    "libero",
+]
+caches = ["huggingface", "torch", "uv", "wandb"]
+entrypoint = [
+    "python",
+    "sota-implementations/vla_grpo/vla-grpo.py",
+    "--config-name",
+    "vla_grpo_libero",
+]
+
+[python]
+requires = "3.12"
+extras = ["rendering", "utils", "vla"]
+packages = [
+    "bddl==1.0.1",
+    "cloudpickle",
+    "easydict",
+    "future",
+    "gym==0.25.2",
+    "imageio[ffmpeg]",
+    "matplotlib",
+    "mujoco==3.2.3",
+    "opencv-python<5",
+    "pyopengl<4",
+    "robosuite==1.4.1",
+]
+
+[resources]
+gpus = 8
+gpu_memory_gb = 80
+time = "24:00:00"
+
+[environment]
+MUJOCO_GL = "egl"
+PYOPENGL_PLATFORM = "egl"
+ROBOT_PLATFORM = "LIBERO"
+
+[[sources]]
+name = "libero"
+url = "https://github.com/Lifelong-Robot-Learning/LIBERO.git"
+revision = "8f1084e3132a39270c3a13ebe37270a43ece2a01"
+target = "LIBERO"
+pythonpath = true
+create_directories = ["libero/datasets"]
+
+[[artifacts]]
+id = "libero-simulator-assets"
+kind = "source-assets"
+required = true
+description = "Task definitions, simulator assets, and initial states shipped by LIBERO"
+
+[[artifacts]]
+id = "libero-demonstrations"
+kind = "dataset"
+required = false
+description = "Optional demonstrations used for imitation or offline training"
+
+[healthcheck]
+command = [
+    "python",
+    "sota-implementations/vla_grpo/smoke.py",
+    "--expected-gpus",
+    "8",
+]

--- a/sota-implementations/vla_grpo/smoke.py
+++ b/sota-implementations/vla_grpo/smoke.py
@@ -1,0 +1,77 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""End-to-end environment readiness check for the LIBERO VLA recipe."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import sys
+
+import moviepy
+import timm
+import torch
+from tensordict import TensorDictBase
+
+from torchrl.data.vla import OpenVLAImagePreprocessor
+from torchrl.envs import LiberoEnv
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expected-gpus", type=int, default=0)
+    args = parser.parse_args()
+
+    gpu_count = torch.cuda.device_count()
+    if gpu_count < args.expected_gpus:
+        raise RuntimeError(
+            f"Expected at least {args.expected_gpus} CUDA devices, found {gpu_count}."
+        )
+
+    preprocessor = OpenVLAImagePreprocessor(
+        size=32, backend="torch_reference", center_crop=True
+    )
+    image = torch.arange(3 * 24 * 40, dtype=torch.int64).reshape(1, 3, 24, 40)
+    processed = preprocessor(image.remainder(256).to(torch.uint8))
+    if processed.shape != (1, 3, 32, 32) or processed.dtype != torch.uint8:
+        raise RuntimeError(
+            "The OpenVLA torch_reference preprocessor returned an invalid result."
+        )
+
+    env = LiberoEnv(
+        "libero_spatial",
+        task_id=0,
+        camera_height=32,
+        camera_width=32,
+        max_episode_steps=2,
+        settle_steps=2,
+    )
+    try:
+        reset = env.reset()
+        if not isinstance(reset, TensorDictBase):
+            raise RuntimeError("LiberoEnv.reset() did not return a TensorDict.")
+        if reset["observation", "image"].shape != (3, 32, 32):
+            raise RuntimeError("LiberoEnv returned an unexpected image shape.")
+        instruction = reset["language_instruction"]
+        if not isinstance(instruction, str) or not instruction:
+            raise RuntimeError("LiberoEnv did not return a language instruction.")
+    finally:
+        env.close(raise_if_closed=False)
+
+    payload = {
+        "cuda_device_count": gpu_count,
+        "libero_reset": True,
+        "moviepy": importlib.metadata.version("moviepy"),
+        "moviepy_module": moviepy.__name__,
+        "preprocessor": "torch_reference",
+        "timm": timm.__version__,
+    }
+    sys.stdout.write("TORCHRL_RECIPE_READY=" + json.dumps(payload, sort_keys=True))
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/sota-implementations/vla_grpo/test_openvla.py
+++ b/sota-implementations/vla_grpo/test_openvla.py
@@ -22,6 +22,7 @@ import argparse
 import importlib.util
 import os
 import sys
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import numpy as np
@@ -918,6 +919,11 @@ class TestCollectorFactory:
         assert captured["kwargs"]["mp_start_method"] == "spawn"
         assert captured["kwargs"]["device"] == torch.device("cpu")
         assert captured["kwargs"]["metadata_from_workers"]
+        assert captured["create_env_fn"].keywords["group_repeats"] == 2
+        assert captured["create_env_fn"].keywords["seed"] == 5
+        assert captured["create_env_fn"].keywords["device"] is None
+        assert captured["create_env_fn"].keywords["worker_idx_offset"] == 8
+        assert captured["create_env_fn"].keywords["render_gpu_device_id"] == 3
         assert (
             captured["first_workers"][0]["language_instruction"]
             != captured["first_workers"][1]["language_instruction"]
@@ -925,6 +931,112 @@ class TestCollectorFactory:
         assert captured["first_workers"][0]["group_id"] == 4
         assert captured["first_workers"][1]["group_id"] == 4
         assert captured["first_workers"][2]["group_id"] == 5
+
+    def test_make_libero_env_uses_common_factory_with_worker_kwargs(self, monkeypatch):
+        captured = {}
+
+        class _FakeLiberoEnv:
+            def __init__(self, task_suite, *, task_id, group_id_offset, **kwargs):
+                self.task_suite = task_suite
+                self.task_id = task_id
+                self.group_id = group_id_offset
+                self.language_instruction = f"instruction-{task_id}"
+                self.kwargs = kwargs
+
+        class _FakeParallelEnv:
+            def __init__(
+                self,
+                num_envs,
+                create_env_fn,
+                *,
+                create_env_kwargs,
+                **kwargs,
+            ):
+                captured["num_envs"] = num_envs
+                captured["create_env_fn"] = create_env_fn
+                captured["create_env_kwargs"] = create_env_kwargs
+                captured["kwargs"] = kwargs
+                captured["workers"] = [
+                    create_env_fn(**worker_kwargs)
+                    for worker_kwargs in create_env_kwargs
+                ]
+
+            def set_seed(self, seed):
+                captured["seed"] = seed
+
+        monkeypatch.setattr(utils, "LiberoEnv", _FakeLiberoEnv)
+        monkeypatch.setattr(utils, "ParallelEnv", _FakeParallelEnv)
+        monkeypatch.setattr(utils, "TransformedEnv", lambda base, transform: base)
+        monkeypatch.setattr(utils, "_chunk_transform", lambda *args, **kwargs: object())
+        monkeypatch.setattr(utils, "_configure_mujoco_rendering", lambda cfg: None)
+        monkeypatch.setattr(
+            utils,
+            "_worker_render_gpu_context",
+            lambda cfg, render_gpu_device_id: nullcontext(render_gpu_device_id),
+        )
+        cfg = SimpleNamespace(
+            collector=_complete_collector_cfg(
+                group_size=2,
+                candidate_group_size=4,
+            ),
+            env=_complete_toy_env_cfg(
+                backend="libero",
+                task_ids=[8, 9],
+                task_suite="libero_spatial",
+                camera_height=256,
+                camera_width=256,
+                max_env_steps=512,
+                train_init_state_id=3,
+            ),
+            policy=SimpleNamespace(use_wrist_image=False),
+        )
+
+        env = utils.make_env(
+            cfg,
+            tokenizer=None,
+            group_repeats=2,
+            seed=17,
+            num_envs=4,
+            worker_idx_offset=4,
+            render_gpu_device_id=3,
+        )
+
+        assert isinstance(env, _FakeParallelEnv)
+        assert callable(captured["create_env_fn"])
+        assert captured["create_env_kwargs"] == [
+            {"worker_idx": 0},
+            {"worker_idx": 1},
+            {"worker_idx": 2},
+            {"worker_idx": 3},
+        ]
+        assert captured["kwargs"]["mp_start_method"] == "spawn"
+        assert captured["kwargs"]["device"] == "cpu"
+        assert captured["seed"] == 17
+        assert captured["create_env_fn"].keywords["group_repeats"] == 2
+        assert captured["create_env_fn"].keywords["worker_idx_offset"] == 4
+        assert captured["create_env_fn"].keywords["render_gpu_device_id"] == 3
+        assert [worker.task_id for worker in captured["workers"]] == [8, 8, 9, 9]
+        assert [worker.group_id for worker in captured["workers"]] == [
+            2 * utils.GROUP_ID_OFFSET,
+            2 * utils.GROUP_ID_OFFSET,
+            3 * utils.GROUP_ID_OFFSET,
+            3 * utils.GROUP_ID_OFFSET,
+        ]
+        assert [worker.language_instruction for worker in captured["workers"]] == [
+            "instruction-8",
+            "instruction-8",
+            "instruction-9",
+            "instruction-9",
+        ]
+        assert all(
+            worker.kwargs["env_kwargs"]["render_gpu_device_id"] == 3
+            for worker in captured["workers"]
+        )
+        assert all(
+            worker.kwargs["init_state_mode"] == "cycle"
+            and worker.kwargs["init_state_id"] == 3
+            for worker in captured["workers"]
+        )
 
 
 class TestEvaluatorFactory:

--- a/sota-implementations/vla_grpo/test_openvla.py
+++ b/sota-implementations/vla_grpo/test_openvla.py
@@ -98,6 +98,20 @@ class TestAdvantageMetrics:
                 return [None]
 
         collector = FakeCollector()
+        partial_group = TensorDict(
+            {
+                "group_id": torch.full((2,), 7),
+                "next": {
+                    "reward": torch.zeros(2, 1),
+                    "done": torch.tensor([[False], [True]]),
+                },
+            },
+            batch_size=[2],
+        )
+        assert advantage.inv(partial_group) is None
+        assert advantage.queued_groups == 1
+        assert advantage.queued_trajectories == 1
+
         metrics = utils.advantage_metrics(advantage, collector)
         assert metrics["buffer/complete_groups"] == 2
         assert metrics["buffer/kept_groups"] == 1
@@ -106,11 +120,216 @@ class TestAdvantageMetrics:
         assert metrics["collector/successful_trajectories"] == 1
 
         utils.reset_collection_state(advantage, collector)
-        assert collector.calls[-3:] == [
-            "replay_buffer._transform[0].clear_queues",
-            "replay_buffer._transform[0].reset_stats",
-            "reset",
-        ]
+        assert collector.calls[-1:] == ["replay_buffer._transform[0].reset_stats"]
+        assert advantage.queued_groups == 1
+        assert advantage.queued_trajectories == 1
+        assert advantage.completed_trajectories == 0
+
+    def test_replay_readiness_requires_complete_kept_groups(self):
+        assert not utils._replay_ready(
+            sampleable_decisions=1_000,
+            kept_groups=63,
+            min_replay_groups=64,
+            min_replay_decisions=0,
+        )
+        assert not utils._replay_ready(
+            sampleable_decisions=100,
+            kept_groups=64,
+            min_replay_groups=64,
+            min_replay_decisions=128,
+        )
+        assert utils._replay_ready(
+            sampleable_decisions=128,
+            kept_groups=64,
+            min_replay_groups=64,
+            min_replay_decisions=128,
+        )
+
+    def test_replay_ready_targets_do_not_estimate_trajectory_lengths(self):
+        cfg = SimpleNamespace(
+            collector=SimpleNamespace(
+                groups_per_iter=64,
+                min_replay_decisions=None,
+            )
+        )
+        assert utils.replay_ready_targets(cfg) == (64, 0)
+
+
+class _SinglePassReplay:
+    def __init__(self, data):
+        self.data = data
+        self.remaining = data.shape[0]
+
+    def __len__(self):
+        return self.remaining
+
+    def sample(self, batch_size=None):
+        assert batch_size == self.data.shape[0]
+        assert self.remaining
+        self.remaining = 0
+        return self.data.clone()
+
+
+class _UnreducedLoss(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.zeros(()))
+
+    def forward(self, data):
+        batch = data.shape[0]
+        loss = data["base_loss"].reshape(batch, 1) + self.weight * 0
+        return TensorDict(
+            {
+                "loss_objective": loss,
+                "clip_fraction": torch.zeros(()),
+                "ESS": torch.ones(()),
+                "kl_approx": torch.zeros(()),
+                "max_ratio": torch.ones(()),
+                "mean_ratio": torch.ones(()),
+                "entropy": torch.full((), 0.5),
+                "loss_entropy": torch.zeros(()),
+            },
+            batch_size=[],
+        )
+
+
+class TestTrajectoryAwareUpdate:
+    def test_inference_policy_disables_training_only_state(self, monkeypatch):
+        policy = nn.Sequential(nn.Linear(2, 2), nn.Dropout(p=0.5))
+        policy.train()
+
+        monkeypatch.setattr(utils, "make_policy", lambda *args, **kwargs: policy)
+
+        result = utils.make_inference_policy(object(), torch.device("cpu"))
+
+        assert result is policy
+        assert not result.training
+        assert not result[1].training
+
+    def test_tiny_policy_is_materialized_before_server_sync(self):
+        cfg = SimpleNamespace(
+            env=SimpleNamespace(
+                action_dim=2,
+                chunk_size=4,
+                image_shape=[3, 16, 16],
+                state_dim=4,
+            ),
+            tokenizer=SimpleNamespace(vocab_size=64),
+            policy=SimpleNamespace(backend="tiny", hidden_dim=32),
+            loss=SimpleNamespace(ratio_level="sequence"),
+        )
+        policy = utils.make_policy(cfg, torch.device("cpu"))
+        in_keys, out_keys = utils.policy_io_keys(cfg)
+        assert in_keys == policy.in_keys
+        assert out_keys == policy.out_keys
+        assert not any(
+            isinstance(param, torch.nn.parameter.UninitializedParameter)
+            for param in policy.parameters()
+        )
+
+    def test_optimizer_batches_count_trajectories_not_decisions(self):
+        # The three trajectories have lengths 1, 3 and 2. Their mean losses
+        # are 1, 2 and 4, so equal trajectory weighting yields 7 / 3 rather
+        # than the decision-weighted value 15 / 6.
+        replay = _SinglePassReplay(
+            TensorDict(
+                {
+                    "collector": {
+                        "traj_ids": torch.tensor([[10], [20], [20], [20], [30], [30]])
+                    },
+                    "group_id": torch.tensor([100, 100, 100, 100, 200, 200]),
+                    "policy_version": torch.tensor([3, 2, 2, 3, 1, 1]),
+                    "base_loss": torch.tensor([1.0, 2.0, 2.0, 2.0, 4.0, 4.0]),
+                },
+                batch_size=[6],
+            )
+        )
+        loss = _UnreducedLoss()
+        optim = torch.optim.SGD(loss.parameters(), lr=0.1)
+        scheduler = torch.optim.lr_scheduler.LambdaLR(optim, lambda _: 1.0)
+        cfg = SimpleNamespace(
+            buffer=SimpleNamespace(consume_after_n_samples=1),
+            loss=SimpleNamespace(
+                mini_batch_size=2,
+                trajectories_per_optimizer_step=2,
+            ),
+            optim=SimpleNamespace(max_grad_norm=1.0),
+            train=SimpleNamespace(
+                pre_update_min_ess=0.95,
+                pre_update_max_clip_fraction=0.05,
+            ),
+        )
+
+        metrics = utils.update(
+            replay,
+            loss,
+            optim,
+            scheduler,
+            cfg,
+            torch.device("cpu"),
+            iteration=1,
+            current_policy_version=3,
+        )
+
+        assert metrics["train/decisions"] == 6
+        assert metrics["train/trajectories"] == 3
+        assert metrics["train/optim_steps"] == 2
+        assert metrics["train/trajectories_per_optim_step"] == 1.5
+        assert metrics["train/loss_objective"] == pytest.approx(7 / 3)
+        assert metrics["train/entropy"] == 0.5
+        assert metrics["train/loss_entropy"] == 0.0
+        assert metrics["train/pre_update_ESS"] == 1.0
+        assert metrics["train/pre_update_clip_fraction"] == 0.0
+        assert metrics["train/policy_staleness_mean"] == 1.0
+        assert metrics["train/policy_staleness_max"] == 2
+        assert metrics["train/stale_decision_fraction"] == pytest.approx(4 / 6)
+        assert metrics["train/mixed_policy_trajectory_fraction"] == pytest.approx(1 / 3)
+        assert metrics["train/trajectory_policy_version_span_max"] == 1
+        assert metrics["train/mixed_policy_group_fraction"] == 0.5
+        assert metrics["train/group_policy_version_span_max"] == 1
+
+    def test_checkpoint_tracks_completed_trajectory_budget(self):
+        policy = nn.Linear(2, 2)
+        optim = torch.optim.SGD(policy.parameters(), lr=0.1)
+        scheduler = torch.optim.lr_scheduler.LambdaLR(optim, lambda _: 1.0)
+        checkpoint = utils.checkpoint_tensordict(
+            policy,
+            optim,
+            scheduler,
+            iteration=3,
+            total_episodes=42,
+        )
+        assert checkpoint["iteration"].item() == 3
+        assert checkpoint["total_episodes"].item() == 42
+
+    @pytest.mark.parametrize(
+        ("metrics", "match"),
+        [
+            (
+                {
+                    "train/pre_update_ESS": 0.8,
+                    "train/pre_update_clip_fraction": 0.0,
+                },
+                "ESS",
+            ),
+            (
+                {
+                    "train/pre_update_ESS": 1.0,
+                    "train/pre_update_clip_fraction": 0.2,
+                },
+                "clip fraction",
+            ),
+        ],
+    )
+    def test_pre_update_policy_mismatch_fails_fast(self, metrics, match):
+        cfg = SimpleNamespace(
+            train=SimpleNamespace(
+                pre_update_min_ess=0.95,
+                pre_update_max_clip_fraction=0.05,
+            )
+        )
+        with pytest.raises(RuntimeError, match=match):
+            utils._check_pre_update_policy_match(metrics, cfg)
 
 
 @pytest.mark.gpu
@@ -464,6 +683,7 @@ def _complete_toy_env_cfg(**env_overrides):
         "render_gpu_ids": [2, 3],
         "eval_render_gpu_ids": None,
         "render_gpu_device_zero_fallback": True,
+        "metadata_from_workers": False,
         "env_kwargs": None,
     }
     env.update(env_overrides)
@@ -476,6 +696,9 @@ def _complete_logger_cfg(**logger_overrides):
         "eval_backend": "thread",
         "eval_busy_policy": "skip",
         "service_backend": "direct",
+        "record_video": False,
+        "video_episodes": 1,
+        "video_num_envs": 1,
         "video_fps": 4,
     }
     logger.update(logger_overrides)
@@ -495,6 +718,7 @@ class TestCollectorFactory:
             def __init__(self, **kwargs):
                 captured["server_kwargs"] = kwargs
                 self.transport = kwargs["transport"]
+                self.policy_version = 0
 
             def start(self):
                 captured["server_started"] = True
@@ -510,10 +734,15 @@ class TestCollectorFactory:
                 self.clients.append(client)
                 return client
 
-        policy = _fake_token_policy()
         cfg = SimpleNamespace(
-            collector=_complete_collector_cfg(policy_micro_batch_size=1),
+            # Four logical group workers may feed a three-group update target;
+            # incomplete work carries across the policy boundary.
+            collector=_complete_collector_cfg(
+                policy_micro_batch_size=1,
+                groups_per_iter=3,
+            ),
             env=_complete_toy_env_cfg(),
+            policy=SimpleNamespace(backend="tiny"),
         )
         replay_buffer = object()
 
@@ -523,8 +752,8 @@ class TestCollectorFactory:
 
         collector, server, eval_policy = utils.make_collector(
             cfg,
-            policy,
             torch.device("cpu"),
+            policy_factory=_fake_token_policy,
             tokenizer=utils.UniformActionTokenizer(16, low=-1.0, high=1.0),
             replay_buffer=replay_buffer,
         )
@@ -535,12 +764,7 @@ class TestCollectorFactory:
         assert captured["transport_kwargs"]["use_manager"]
         assert captured["server_started"]
         assert captured["server_kwargs"]["server_config"].max_batch_size == 1
-        assert (
-            captured["server_kwargs"]["policy_factory"].keywords[
-                "policy_micro_batch_size"
-            ]
-            == 1
-        )
+        assert captured["server_kwargs"]["policy_factory"] is _fake_token_policy
         env_factories = captured["multi_args"][0]
         assert [
             factory.keywords["render_gpu_device_id"] for factory in env_factories
@@ -562,7 +786,6 @@ class TestCollectorFactory:
     def test_make_collector_rejects_cross_subcollector_parallel_groups_without_shared_rb(
         self,
     ):
-        policy = _fake_token_policy()
         cfg = SimpleNamespace(
             collector=_complete_collector_cfg(
                 num_collectors=4,
@@ -571,13 +794,14 @@ class TestCollectorFactory:
                 groups_per_iter=10,
             ),
             env=_complete_toy_env_cfg(parallel_group_repeats=True),
+            policy=SimpleNamespace(backend="tiny"),
         )
 
         with pytest.raises(ValueError, match="collector.envs_per_collector"):
             utils.make_collector(
                 cfg,
-                policy,
                 torch.device("cpu"),
+                policy_factory=_fake_token_policy,
                 tokenizer=utils.UniformActionTokenizer(16, low=-1.0, high=1.0),
                 replay_buffer=SimpleNamespace(shared=False),
             )
@@ -595,6 +819,7 @@ class TestCollectorFactory:
         class _FakeServer:
             def __init__(self, **kwargs):
                 self.transport = kwargs["transport"]
+                self.policy_version = 0
 
             def start(self):
                 return self
@@ -606,7 +831,6 @@ class TestCollectorFactory:
             def client(self):
                 return object()
 
-        policy = _fake_token_policy()
         cfg = SimpleNamespace(
             collector=_complete_collector_cfg(
                 num_collectors=4,
@@ -615,6 +839,7 @@ class TestCollectorFactory:
                 groups_per_iter=10,
             ),
             env=_complete_toy_env_cfg(parallel_group_repeats=True),
+            policy=SimpleNamespace(backend="tiny"),
         )
         replay_buffer = SimpleNamespace(shared=True)
 
@@ -624,14 +849,82 @@ class TestCollectorFactory:
 
         collector, _, _ = utils.make_collector(
             cfg,
-            policy,
             torch.device("cpu"),
+            policy_factory=_fake_token_policy,
             tokenizer=utils.UniformActionTokenizer(16, low=-1.0, high=1.0),
             replay_buffer=replay_buffer,
         )
 
         assert isinstance(collector, _FakeMultiCollector)
         assert len(captured["multi_args"][0]) == 4
+
+    def test_make_collector_env_uses_common_factory_with_worker_kwargs(
+        self, monkeypatch
+    ):
+        captured = {}
+
+        def _fake_make_env_worker(cfg, tokenizer, worker_idx, **kwargs):
+            worker_idx_with_offset = worker_idx + kwargs["worker_idx_offset"]
+            return {
+                "group_id": worker_idx_with_offset // kwargs["group_repeats"],
+                "language_instruction": f"instruction-{worker_idx_with_offset}",
+            }
+
+        class _FakeParallelEnv:
+            def __init__(
+                self,
+                num_envs,
+                create_env_fn,
+                *,
+                create_env_kwargs,
+                **kwargs,
+            ):
+                captured["num_envs"] = num_envs
+                captured["create_env_fn"] = create_env_fn
+                captured["create_env_kwargs"] = create_env_kwargs
+                captured["kwargs"] = kwargs
+                captured["first_workers"] = [
+                    create_env_fn(**create_env_kwargs[index]) for index in range(3)
+                ]
+
+        monkeypatch.setattr(utils, "_make_env_worker", _fake_make_env_worker)
+        monkeypatch.setattr(utils, "ParallelEnv", _FakeParallelEnv)
+        cfg = SimpleNamespace(
+            collector=_complete_collector_cfg(group_size=2),
+            env=_complete_toy_env_cfg(backend="libero", metadata_from_workers=True),
+            policy=SimpleNamespace(backend="openvla"),
+        )
+
+        env = utils._make_collector_env(
+            cfg,
+            tokenizer=None,
+            num_envs=4,
+            group_repeats=2,
+            seed=5,
+            device=torch.device("cpu"),
+            worker_idx_offset=8,
+            render_gpu_device_id=3,
+        )
+
+        assert isinstance(env, _FakeParallelEnv)
+        assert captured["num_envs"] == 4
+        assert callable(captured["create_env_fn"])
+        assert captured["create_env_kwargs"] == [
+            {"worker_idx": 0},
+            {"worker_idx": 1},
+            {"worker_idx": 2},
+            {"worker_idx": 3},
+        ]
+        assert captured["kwargs"]["mp_start_method"] == "spawn"
+        assert captured["kwargs"]["device"] == torch.device("cpu")
+        assert captured["kwargs"]["metadata_from_workers"]
+        assert (
+            captured["first_workers"][0]["language_instruction"]
+            != captured["first_workers"][1]["language_instruction"]
+        )
+        assert captured["first_workers"][0]["group_id"] == 4
+        assert captured["first_workers"][1]["group_id"] == 4
+        assert captured["first_workers"][2]["group_id"] == 5
 
 
 class TestEvaluatorFactory:
@@ -672,7 +965,7 @@ class TestEvaluatorFactory:
         assert transform.tag == "eval/video"
         assert transform.video_kwargs == {"fps": 8}
 
-    def test_make_evaluator_process_backend_uses_factories(self, monkeypatch):
+    def test_make_video_evaluator_process_backend_uses_factories(self, monkeypatch):
         captured = {}
         logger_client = object()
 
@@ -694,9 +987,14 @@ class TestEvaluatorFactory:
         policy = _fake_token_policy()
         cfg = SimpleNamespace(
             env=_complete_toy_env_cfg(),
-            logger=_complete_logger_cfg(eval_backend="process"),
+            logger=_complete_logger_cfg(
+                eval_backend="process",
+                record_video=True,
+                video_episodes=2,
+                video_num_envs=1,
+            ),
         )
-        evaluator = utils.make_evaluator(
+        evaluator = utils.make_video_evaluator(
             cfg,
             utils.UniformActionTokenizer(16, low=-1.0, high=1.0),
             policy,
@@ -707,11 +1005,44 @@ class TestEvaluatorFactory:
         assert isinstance(evaluator, _FakeEvaluator)
         assert callable(captured["env"])
         assert captured["env"].args[2] is logger_client
+        assert captured["env"].args[4] == 1
         assert captured["policy"] is None
         assert captured["policy_factory"]() is policy
         assert captured["kwargs"]["dump_video"]
+        assert captured["kwargs"]["num_trajectories"] == 2
         assert captured["kwargs"]["backend"] == "process"
         assert captured["kwargs"]["max_steps"] == 0
+
+    def test_make_evaluator_skips_video_by_default(self, monkeypatch):
+        captured = {}
+
+        class _FakeLogger:
+            service_backend = "direct"
+
+            def client(self):
+                raise AssertionError("video logger should not be requested")
+
+        class _FakeEvaluator:
+            def __init__(self, env, policy=None, policy_factory=None, **kwargs):
+                captured["env"] = env
+                captured["kwargs"] = kwargs
+
+        monkeypatch.setattr(utils, "Evaluator", _FakeEvaluator)
+
+        cfg = SimpleNamespace(
+            env=_complete_toy_env_cfg(),
+            logger=_complete_logger_cfg(record_video=False),
+        )
+        utils.make_evaluator(
+            cfg,
+            utils.UniformActionTokenizer(16, low=-1.0, high=1.0),
+            _fake_token_policy(),
+            logger=_FakeLogger(),
+            device=torch.device("cpu"),
+        )
+
+        assert captured["env"].args[2] is None
+        assert not captured["kwargs"]["dump_video"]
 
 
 class TestReplayBufferFactory:
@@ -738,11 +1069,46 @@ class TestReplayBufferFactory:
             ),
         )
 
-        replay_buffer, _ = utils.make_replay_buffer(cfg, torch.device("cpu"))
+        replay_buffer, advantage = utils.make_replay_buffer(cfg, torch.device("cpu"))
 
         assert replay_buffer._storage.max_size == 2 * 3 * 5 * 4
         assert replay_buffer._storage.shared_init
         assert replay_buffer.shared
+        assert advantage.rewards_key == ("next", "reward")
+
+    def test_replay_capacity_covers_worker_wave_larger_than_update_target(self):
+        cfg = SimpleNamespace(
+            collector=SimpleNamespace(
+                groups_per_iter=2,
+                group_size=2,
+                candidate_group_size=None,
+                num_collectors=2,
+                envs_per_collector=4,
+            ),
+            env=SimpleNamespace(
+                max_outer_steps=5,
+                parallel_group_repeats=True,
+            ),
+            advantage=SimpleNamespace(
+                trajectory_return="sum",
+                keep_return_bounds=None,
+                candidate_selection="balanced",
+                candidate_selection_min_size=None,
+                candidate_selection_max_combinations=100000,
+            ),
+            loss=SimpleNamespace(mini_batch_size=2),
+            buffer=SimpleNamespace(
+                shared_init=False,
+                capacity_group_waves=2,
+                consume_after_n_samples=1,
+            ),
+        )
+
+        replay_buffer, _ = utils.make_replay_buffer(cfg, torch.device("cpu"))
+
+        # Eight envs advance four groups concurrently, so capacity follows the
+        # worker wave rather than the smaller two-group optimizer trigger.
+        assert replay_buffer._storage.max_size == 4 * 2 * 5 * 2
 
     def test_make_replay_buffer_scales_capacity_with_candidate_group_size(self):
         cfg = SimpleNamespace(
@@ -781,10 +1147,42 @@ class TestTokenizerAndTransforms:
             policy=SimpleNamespace(backend="openvla", mode="l1"),
             tokenizer=SimpleNamespace(vocab_size=16),
         )
-        assert (
-            utils.make_action_tokenizer(cfg, SimpleNamespace(action_tokenizer=None))
-            is None
+        assert utils.make_action_tokenizer(cfg) is None
+
+    def test_make_openvla_action_tokenizer_without_policy(self, monkeypatch):
+        cfg = SimpleNamespace(
+            policy=SimpleNamespace(
+                backend="openvla",
+                mode="tokens",
+                checkpoint="unused-checkpoint",
+                dataset_statistics="stats-repository",
+                unnorm_key="libero_spatial_no_noops",
+            ),
+            tokenizer=SimpleNamespace(vocab_size=256),
         )
+        norm_stats = {
+            "libero_spatial_no_noops": {
+                "action": {
+                    "q01": [-1.0, -2.0],
+                    "q99": [1.0, 2.0],
+                    "mask": [True, False],
+                }
+            }
+        }
+        sources = []
+
+        def load_statistics(source):
+            sources.append(source)
+            return norm_stats
+
+        monkeypatch.setattr(utils, "_load_openvla_dataset_statistics", load_statistics)
+
+        tokenizer = utils.make_action_tokenizer(cfg)
+
+        assert sources == ["stats-repository"]
+        assert isinstance(tokenizer, utils.VocabTailActionTokenizer)
+        assert tokenizer.num_bins == 256
+        assert tokenizer.norm_low.tolist() == [-1.0, -2.0]
 
     def test_chunk_transform_without_tokenizer_consumes_vla_chunk(self):
         cfg = SimpleNamespace(env=SimpleNamespace(max_outer_steps=1))

--- a/sota-implementations/vla_grpo/utils.py
+++ b/sota-implementations/vla_grpo/utils.py
@@ -32,14 +32,20 @@ from functools import partial
 
 import torch
 
-from tensordict import NonTensorData, TensorDict, TensorDictBase
+from tensordict import NonTensorData, NonTensorStack, TensorDict, TensorDictBase
+from tensordict.utils import NestedKey
 from torchrl._utils import logger as torchrl_logger, timeit
 from torchrl.collectors import Evaluator, MultiCollector
 from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
 from torchrl.data.vla import (
+    ACTION_CHUNK_KEY,
     ACTION_TOKENS_KEY,
     ActionTokenizerBase,
+    IMAGE_KEY,
+    INSTRUCTION_KEY,
+    STATE_KEY,
     UniformActionTokenizer,
+    VocabTailActionTokenizer,
 )
 from torchrl.envs import (
     ActionTokenizerTransform,
@@ -145,9 +151,37 @@ def _cfg_get(section, key: str, default=None):
     return getattr(section, key, default)
 
 
+def video_eval_episodes(cfg) -> int:
+    """Number of trajectories to run in the bounded video evaluator."""
+    value = _cfg_get(cfg.logger, "video_episodes", 1)
+    if value is None:
+        value = 1
+    value = float(value)
+    if 0.0 < value < 1.0:
+        return max(1, int(round(float(cfg.logger.eval_episodes) * value)))
+    return max(0, int(value))
+
+
 def candidate_group_size(cfg) -> int:
     """Number of rollout candidates collected for each GRPO group."""
     return int(cfg.collector.candidate_group_size or cfg.collector.group_size)
+
+
+def collector_group_workers(cfg) -> int:
+    """Number of independently advancing logical GRPO group workers."""
+    groups_per_iter = int(cfg.collector.groups_per_iter)
+    num_collectors = _cfg_get(cfg.collector, "num_collectors", None)
+    envs_per_collector = _cfg_get(cfg.collector, "envs_per_collector", None)
+    if num_collectors is None or envs_per_collector is None:
+        # Small factory tests and standalone replay users need not describe a
+        # collector topology. Falling back to the update target preserves the
+        # historical capacity calculation for those callers.
+        return groups_per_iter
+    total_envs = int(num_collectors) * int(envs_per_collector)
+    if not _cfg_get(cfg.env, "parallel_group_repeats", False):
+        return total_envs
+    group_size = int(cfg.collector.group_size)
+    return (total_envs + group_size - 1) // group_size
 
 
 def auto_device(device_spec) -> torch.device:
@@ -310,7 +344,7 @@ def make_policy(
     # "sequence" sums the chunk's log-probs into a single ratio per decision.
     log_probs_mode = "token" if cfg.loss.ratio_level == "token" else "sequence"
     if cfg.policy.backend == "tiny":
-        return TinyVLA(
+        policy = TinyVLA(
             action_dim=cfg.env.action_dim,
             chunk_size=cfg.env.chunk_size,
             action_head="tokens",
@@ -320,6 +354,27 @@ def make_policy(
             return_vla_action_container=False,
             device=device,
         )
+        # TinyVLA contains lazy layers. Materialize them before the policy is
+        # cloned into the inference process so the first weight sync copies
+        # real parameters instead of independently initialized placeholders.
+        init_td = TensorDict(
+            {
+                "observation": {
+                    "image": torch.zeros(
+                        1, *cfg.env.image_shape, dtype=torch.uint8, device=device
+                    ),
+                    "state": torch.zeros(
+                        1, cfg.env.state_dim, dtype=torch.float32, device=device
+                    ),
+                },
+                "language_instruction": NonTensorStack("initialize policy"),
+            },
+            batch_size=[1],
+            device=device,
+        )
+        with torch.no_grad():
+            policy(init_td)
+        return policy
     if cfg.policy.backend == "openvla":
         OpenVLAOFTWrapper = _openvla_wrapper_cls(cfg.policy.mode)
 
@@ -368,19 +423,80 @@ def make_policy(
     raise ValueError(f"Unknown policy backend {cfg.policy.backend!r}.")
 
 
-def make_action_tokenizer(cfg, policy: VLAWrapperBase) -> ActionTokenizerBase | None:
+def make_inference_policy(
+    cfg,
+    device: torch.device,
+    *,
+    policy_micro_batch_size: int | None = None,
+) -> VLAWrapperBase:
+    """Build the rollout policy in inference mode.
+
+    The learner returned by :func:`make_policy` must remain in training mode,
+    whereas the independently constructed inference-server copy must disable
+    dropout and other training-only state before serving rollout and
+    evaluation requests.
+    """
+    policy = make_policy(
+        cfg,
+        device,
+        policy_micro_batch_size=policy_micro_batch_size,
+    )
+    policy.eval()
+    return policy
+
+
+def _load_openvla_dataset_statistics(spec: str) -> dict:
+    """Load action statistics without instantiating an OpenVLA model."""
+    if not _has_openvla:
+        raise ImportError("The openvla backend requires the local openvla module.")
+    from openvla import _load_dataset_statistics
+
+    return _load_dataset_statistics(spec)
+
+
+def make_action_tokenizer(cfg) -> ActionTokenizerBase | None:
+    """Build the environment-side action codec independently of a policy."""
     if cfg.policy.backend == "openvla":
         if cfg.policy.mode == "l1":
             return None
-        # the codec lives in the checkpoint (vocab-tail mapping + norm_stats)
-        if policy.action_tokenizer is None:
-            raise RuntimeError(
-                "The OpenVLA policy did not expose an action tokenizer. Check "
-                "that the checkpoint carries dataset action statistics and "
-                "that policy.unnorm_key selects one of them."
-            )
-        return policy.action_tokenizer
+        # The token-to-action mapping only needs the normalization statistics;
+        # do not load a 7B learner model merely to construct the CPU env codec.
+        statistics_source = cfg.policy.dataset_statistics or cfg.policy.checkpoint
+        norm_stats = _load_openvla_dataset_statistics(statistics_source)
+        return VocabTailActionTokenizer.from_norm_stats(
+            norm_stats,
+            cfg.policy.unnorm_key,
+            num_bins=int(cfg.tokenizer.vocab_size),
+        )
     return UniformActionTokenizer(cfg.tokenizer.vocab_size, low=-1.0, high=1.0)
+
+
+def policy_io_keys(cfg) -> tuple[list[NestedKey], list[NestedKey]]:
+    """Return the VLA TensorDict contract without constructing the model."""
+    if cfg.policy.backend == "tiny":
+        return (
+            [IMAGE_KEY, STATE_KEY, INSTRUCTION_KEY],
+            [ACTION_TOKENS_KEY, LOG_PROBS_KEY],
+        )
+    if cfg.policy.backend != "openvla":
+        raise ValueError(f"Unknown policy backend {cfg.policy.backend!r}.")
+
+    in_keys: list[NestedKey] = [IMAGE_KEY]
+    if cfg.policy.mode == "l1" and cfg.policy.use_proprio:
+        in_keys.append(STATE_KEY)
+    in_keys.append(INSTRUCTION_KEY)
+    if cfg.policy.use_wrist_image:
+        in_keys.append(("observation", "wrist_image"))
+
+    if cfg.policy.mode == "tokens":
+        out_keys: list[NestedKey] = [ACTION_TOKENS_KEY, LOG_PROBS_KEY]
+    elif cfg.policy.mode == "l1":
+        out_keys = [ACTION_CHUNK_KEY]
+    else:
+        raise ValueError(
+            f"policy.mode must be 'tokens' or 'l1', got {cfg.policy.mode!r}."
+        )
+    return in_keys, out_keys
 
 
 def _chunk_transform(
@@ -623,26 +739,29 @@ def make_env(
             eval_mode=eval_mode,
             override=override,
         )
+        env_factory = partial(
+            _make_libero_worker,
+            cfg,
+            group_repeats=group_repeats,
+            eval_mode=eval_mode,
+            from_pixels=from_pixels,
+            worker_idx_offset=worker_idx_offset,
+            render_gpu_device_id=render_gpu_device_id,
+        )
         base = ParallelEnv(
             num_envs,
-            [
-                partial(
-                    _make_libero_worker,
-                    cfg,
-                    worker_idx,
-                    group_repeats=group_repeats,
-                    eval_mode=eval_mode,
-                    from_pixels=from_pixels,
-                    worker_idx_offset=worker_idx_offset,
-                    render_gpu_device_id=render_gpu_device_id,
-                )
-                for worker_idx in range(num_envs)
+            env_factory,
+            create_env_kwargs=[
+                {"worker_idx": worker_idx} for worker_idx in range(num_envs)
             ],
             mp_start_method="spawn",
             # MuJoCo runs on CPU; pin the env device so the collector/rollout
             # cast the GPU policy's action back to CPU before stepping (else a
             # cuda action reaches the CPU transforms -> mixed-device error)
             device="cpu",
+            metadata_from_workers=bool(
+                _cfg_get(cfg.env, "metadata_from_workers", False)
+            ),
         )
         if seed is not None:
             base.set_seed(seed)
@@ -669,39 +788,50 @@ def _make_collector_env(
     worker_idx_offset: int,
     render_gpu_device_id: int | None,
 ) -> ParallelEnv:
+    env_factory = partial(
+        _make_env_worker,
+        cfg,
+        tokenizer,
+        group_repeats=group_repeats,
+        seed=seed,
+        device=device if cfg.env.backend == "toy" else None,
+        worker_idx_offset=worker_idx_offset,
+        render_gpu_device_id=render_gpu_device_id,
+    )
     return ParallelEnv(
         num_envs,
-        [
-            partial(
-                _make_env_worker,
-                cfg,
-                tokenizer,
-                worker_idx,
-                group_repeats=group_repeats,
-                seed=seed,
-                device=device if cfg.env.backend == "toy" else None,
-                worker_idx_offset=worker_idx_offset,
-                render_gpu_device_id=render_gpu_device_id,
-            )
-            for worker_idx in range(num_envs)
+        env_factory,
+        create_env_kwargs=[
+            {"worker_idx": worker_idx} for worker_idx in range(num_envs)
         ],
         mp_start_method="spawn",
         device=device,
+        metadata_from_workers=bool(_cfg_get(cfg.env, "metadata_from_workers", False)),
     )
 
 
 def make_replay_buffer(
     cfg, device: torch.device
 ) -> tuple[TensorDictReplayBuffer, MCAdvantage]:
-    # The buffer holds one iteration's decisions; the write path computes the
-    # group-relative advantage (and drops degenerate groups) on whole
-    # trajectories, the read path samples decisions without replacement. The
-    # advantage transform is returned too so the training loop can flush its
-    # incomplete-group queues at iteration boundaries.
+    # Storage holds one update's accepted decisions; the transform may carry
+    # incomplete groups across updates. The write path computes group-relative
+    # advantage (and drops degenerate groups) on whole trajectories, while the
+    # read path samples accepted decisions without replacement. The advantage
+    # transform is returned too so the training loop can read and reset its
+    # per-update counters without clearing incomplete groups.
     capacity_group_waves = max(int(cfg.buffer.capacity_group_waves), 1)
     candidate_size = candidate_group_size(cfg)
+    groups_per_iter = int(cfg.collector.groups_per_iter)
+    if groups_per_iter < 1:
+        raise ValueError(
+            "collector.groups_per_iter must be positive, got " f"{groups_per_iter}."
+        )
+    # groups_per_iter is an update trigger, not a collector-wave shape. Size
+    # storage for either a full target batch or a full logical worker wave so
+    # small update targets remain safe under asynchronous overcollection.
+    capacity_groups = max(groups_per_iter, collector_group_workers(cfg))
     capacity = (
-        cfg.collector.groups_per_iter
+        capacity_groups
         * candidate_size
         * cfg.env.max_outer_steps
         * capacity_group_waves
@@ -719,13 +849,17 @@ def make_replay_buffer(
             device=device,
             shared_init=shared_init,
         ),
-        batch_size=cfg.loss.mini_batch_size,
+        # The update samples one complete policy batch, then forms
+        # trajectory-aware optimizer batches itself. ``mini_batch_size`` only
+        # limits the number of decisions sent through the VLA at once.
+        batch_size=None,
         consume_after_n_samples=cfg.buffer.consume_after_n_samples,
         shared=shared_init,
     )
     advantage = MCAdvantage(
         grpo_size=cfg.collector.group_size,
         prompt_key="group_id",
+        rewards_key=("next", "reward"),
         trajectory_return=cfg.advantage.trajectory_return,
         keep_return_bounds=keep_return_bounds,
         candidate_group_size=candidate_size,
@@ -754,7 +888,13 @@ def make_loss_module(cfg, policy: VLAWrapperBase) -> ClipPPOLoss:
         actor_network=policy,
         critic_network=None,
         clip_epsilon=clip_epsilon,
-        entropy_bonus=False,
+        entropy_bonus=True,
+        entropy_coeff=0.0,
+        # SimpleVLA averages decisions within a trajectory, then averages
+        # trajectories. Keep the token loss unreduced so the update can
+        # reproduce that weighting even when trajectories have different
+        # lengths.
+        reduction="none",
     )
     loss_module.set_keys(
         action=ACTION_TOKENS_KEY,
@@ -853,9 +993,9 @@ def _server_config_from_collector(cfg) -> InferenceServerConfig:
 
 def make_collector(
     cfg,
-    policy: VLAWrapperBase,
     device: torch.device,
     *,
+    policy_factory: Callable[[], VLAWrapperBase],
     tokenizer: ActionTokenizerBase | None,
     replay_buffer: TensorDictReplayBuffer,
     post_collect_hook: Callable[[TensorDictBase], None] | None = None,
@@ -864,8 +1004,10 @@ def make_collector(
 
     The stack is always a ``MultiCollector`` whose workers own batched
     ``ParallelEnv`` instances and call a shared process policy server through
-    ``PolicyClientModule``. The collector writes complete trajectories directly
-    into the replay buffer.
+    ``PolicyClientModule``. Only the inference-server child invokes
+    ``policy_factory``; the collector builder never receives or constructs the
+    learner policy. The collector writes complete trajectories directly into
+    the replay buffer.
     """
     num_collectors = int(cfg.collector.num_collectors)
     envs_per_collector = int(cfg.collector.envs_per_collector)
@@ -887,51 +1029,46 @@ def make_collector(
                 f"({envs_per_collector=} and {group_size=})."
             )
 
-    group_workers = (
-        total_envs // group_size if cfg.env.parallel_group_repeats else total_envs
-    )
     if cfg.env.backend == "libero":
         _validate_libero_env_count(
             cfg,
             total_envs,
             group_repeats=_training_group_repeats(cfg),
         )
-    groups_per_iter = int(cfg.collector.groups_per_iter)
-    if groups_per_iter < group_workers:
-        raise ValueError(
-            "collector.groups_per_iter must be at least the number of "
-            "shared policy-server group workers "
-            f"({groups_per_iter=} < {group_workers=})."
-        )
-    if groups_per_iter % group_workers:
-        warnings.warn(
-            "collector.groups_per_iter is not a multiple of the shared "
-            "policy-server group-worker count. Some same-policy partial "
-            "groups can be dropped at the update boundary."
-        )
-
     env_device = torch.device("cpu")
     ctx = mp.get_context("spawn")
+    torchrl_logger.info(
+        "Collector setup: creating shared transport for %d collectors.",
+        num_collectors,
+    )
     transport = MPTransport(ctx=ctx, use_manager=True)
     eval_client = transport.client()
     rollout_clients = [transport.client() for _ in range(num_collectors)]
-    policy_micro_batch_size = _cfg_get(cfg.collector, "policy_micro_batch_size", None)
+    torchrl_logger.info(
+        "Collector setup: starting inference-server child on %s; the child "
+        "will instantiate the rollout policy.",
+        device,
+    )
     server = ProcessInferenceServer(
-        policy_factory=partial(
-            make_policy,
-            cfg,
-            device,
-            policy_micro_batch_size=policy_micro_batch_size,
-        ),
+        policy_factory=policy_factory,
         transport=transport,
         server_config=_server_config_from_collector(cfg),
-        policy_device=device,
+        # OpenVLA wrappers own their input placement: raw uint8 images must stay
+        # on CPU through the reference preprocessing path, then the processed
+        # model inputs are moved to the model device.  Let the policy factory
+        # construct the model on ``device`` but do not have the generic
+        # inference server pre-move the whole request TensorDict to CUDA.
+        policy_device=None if cfg.policy.backend == "openvla" else device,
         output_device=env_device,
         mp_context=ctx,
     ).start()
+    torchrl_logger.info(
+        "Collector setup: inference server is ready at policy version %d.",
+        server.policy_version,
+    )
 
-    policy_in_keys = policy.in_keys
-    policy_out_keys = [*policy.out_keys, "policy_version"]
+    policy_in_keys, policy_out_keys = policy_io_keys(cfg)
+    policy_out_keys = [*policy_out_keys, "policy_version"]
     env_factories = [
         partial(
             _make_collector_env,
@@ -961,6 +1098,12 @@ def make_collector(
         in_keys=policy_in_keys,
         out_keys=policy_out_keys,
     )
+    torchrl_logger.info(
+        "Collector setup: constructing MultiCollector with %d subprocesses "
+        "and %d environment workers each.",
+        num_collectors,
+        envs_per_collector,
+    )
     collector = MultiCollector(
         env_factories,
         policy=None,
@@ -982,6 +1125,7 @@ def make_collector(
         num_sub_threads=int(cfg.collector.env_sub_threads),
         post_collect_hook=post_collect_hook,
     )
+    torchrl_logger.info("Collector setup: MultiCollector is ready.")
     return collector, server, eval_policy
 
 
@@ -990,6 +1134,7 @@ def _make_eval_env(
     tokenizer: ActionTokenizerBase | None,
     logger,
     device: torch.device,
+    num_envs: int | None = None,
 ) -> TransformedEnv:
     env = make_env(
         cfg,
@@ -998,6 +1143,7 @@ def _make_eval_env(
         device=device if cfg.env.backend == "toy" else None,
         eval_mode=True,
         from_pixels=logger is not None,
+        num_envs=num_envs,
     )
     if logger is not None:
         env.append_transform(
@@ -1040,9 +1186,13 @@ def make_evaluator(
     policy,
     logger,
     device: torch.device,
+    *,
+    record_video: bool = False,
+    num_trajectories: int | None = None,
+    num_envs: int | None = None,
 ) -> Evaluator:
     """Build the TorchRL evaluator used by the VLA GRPO recipe."""
-    record_video = logger is not None
+    record_video = bool(record_video) and logger is not None
     if (
         record_video
         and cfg.logger.eval_backend == "process"
@@ -1060,12 +1210,15 @@ def make_evaluator(
         tokenizer,
         video_logger,
         device,
+        num_envs,
     )
+    if num_trajectories is None:
+        num_trajectories = int(cfg.logger.eval_episodes)
     return Evaluator(
         env_factory,
         policy=None,
         policy_factory=partial(_policy_module_factory, policy),
-        num_trajectories=cfg.logger.eval_episodes,
+        num_trajectories=num_trajectories,
         max_steps=0,
         frames_per_batch=cfg.env.max_outer_steps,
         collector_kwargs={"traj_format": "cat"},
@@ -1078,6 +1231,34 @@ def make_evaluator(
         dump_video=record_video,
         busy_policy=cfg.logger.eval_busy_policy,
         backend=cfg.logger.eval_backend,
+    )
+
+
+def make_video_evaluator(
+    cfg,
+    tokenizer: ActionTokenizerBase | None,
+    policy,
+    logger,
+    device: torch.device,
+) -> Evaluator | None:
+    """Build the bounded visual evaluator, or ``None`` when video is disabled."""
+    if not bool(_cfg_get(cfg.logger, "record_video", True)) or logger is None:
+        return None
+    num_trajectories = video_eval_episodes(cfg)
+    if num_trajectories < 1:
+        return None
+    num_envs = _cfg_get(cfg.logger, "video_num_envs", 1)
+    if num_envs is not None:
+        num_envs = int(num_envs)
+    return make_evaluator(
+        cfg,
+        tokenizer,
+        policy,
+        logger,
+        device,
+        record_video=True,
+        num_trajectories=num_trajectories,
+        num_envs=num_envs,
     )
 
 
@@ -1101,26 +1282,55 @@ def _sync_replay_sampler_writes(replay_buffer: TensorDictReplayBuffer) -> None:
 
 def wait_for_replay(
     replay_buffer: TensorDictReplayBuffer,
+    advantage: MCAdvantage,
+    collector: MultiCollector,
     *,
+    min_replay_groups: int,
     min_replay_decisions: int,
     poll_interval_s: float,
     log_interval_s: float,
     iteration: int,
+    max_completed_trajectories: int | None = None,
 ) -> dict[str, float | int]:
-    """Wait until the replay buffer has enough sampleable decisions."""
+    """Wait for complete useful GRPO groups, plus an optional decision floor."""
     polls = 0
     next_log_s = 0.0
     with timeit("replay_wait") as wait_timer:
         _sync_replay_sampler_writes(replay_buffer)
-        while len(replay_buffer) < min_replay_decisions:
+        group_metrics = advantage_metrics(advantage, collector)
+        while True:
+            ready = _replay_ready(
+                sampleable_decisions=len(replay_buffer),
+                kept_groups=int(group_metrics["buffer/kept_groups"]),
+                min_replay_groups=min_replay_groups,
+                min_replay_decisions=min_replay_decisions,
+            )
+            trajectory_budget_reached = (
+                max_completed_trajectories is not None
+                and int(group_metrics["collector/completed_trajectories"])
+                >= max_completed_trajectories
+            )
+            if ready or trajectory_budget_reached:
+                break
             time.sleep(poll_interval_s)
             polls += 1
             _sync_replay_sampler_writes(replay_buffer)
+            group_metrics = advantage_metrics(advantage, collector)
             elapsed = wait_timer.elapsed()
             if elapsed >= next_log_s:
                 torchrl_logger.info(
-                    "waiting for replay iteration %d decisions %d/%d " "elapsed_s %.1f",
+                    "waiting for replay iteration %d kept_groups %d/%d "
+                    "complete_groups %d skipped_groups %d queued_trajectories %d "
+                    "completed_trajectories %d successes %d decisions %d/%d "
+                    "elapsed_s %.1f",
                     iteration,
+                    int(group_metrics["buffer/kept_groups"]),
+                    min_replay_groups,
+                    int(group_metrics["buffer/complete_groups"]),
+                    int(group_metrics["buffer/skipped_groups"]),
+                    int(group_metrics["buffer/queued_trajectories"]),
+                    int(group_metrics["collector/completed_trajectories"]),
+                    int(group_metrics["collector/successful_trajectories"]),
                     len(replay_buffer),
                     min_replay_decisions,
                     elapsed,
@@ -1131,18 +1341,182 @@ def wait_for_replay(
         "buffer/wait_polls": polls,
         "buffer/wait_s": elapsed,
         "buffer/decisions_before_update": len(replay_buffer),
+        "buffer/kept_groups_before_update": int(group_metrics["buffer/kept_groups"]),
+        "buffer/trajectory_budget_reached": int(trajectory_budget_reached),
+        "collector/completed_trajectories_before_update": int(
+            group_metrics["collector/completed_trajectories"]
+        ),
     }
 
 
-def replay_ready_target(cfg) -> int:
-    """Number of sampleable decisions required before an update starts."""
-    if cfg.collector.min_replay_decisions:
-        return int(cfg.collector.min_replay_decisions)
+def _replay_ready(
+    *,
+    sampleable_decisions: int,
+    kept_groups: int,
+    min_replay_groups: int,
+    min_replay_decisions: int,
+) -> bool:
+    """Return whether a complete, useful rollout batch is ready to train."""
     return (
-        int(cfg.collector.groups_per_iter)
-        * candidate_group_size(cfg)
-        * int(cfg.env.max_outer_steps)
+        kept_groups >= min_replay_groups
+        and sampleable_decisions > 0
+        and sampleable_decisions >= min_replay_decisions
     )
+
+
+def replay_ready_targets(cfg) -> tuple[int, int]:
+    """Useful-group and optional decision thresholds for an optimizer update."""
+    min_replay_decisions = _cfg_get(cfg.collector, "min_replay_decisions", None)
+    return (
+        int(cfg.collector.groups_per_iter),
+        0 if min_replay_decisions is None else int(min_replay_decisions),
+    )
+
+
+def _decision_loss(loss: torch.Tensor, batch_size: int) -> torch.Tensor:
+    """Average token-level PPO losses into one scalar per decision."""
+    if loss.numel() % batch_size:
+        raise RuntimeError(
+            "The unreduced PPO loss cannot be partitioned by decision: "
+            f"got shape {tuple(loss.shape)} for batch size {batch_size}."
+        )
+    return loss.reshape(batch_size, -1).mean(-1)
+
+
+def _decision_scalar_tensor(
+    value: torch.Tensor,
+    *,
+    num_decisions: int,
+    name: str,
+) -> torch.Tensor:
+    """Collapse a possibly broadcast metadata leaf to one value per decision."""
+    if value.shape[0] != num_decisions:
+        raise RuntimeError(
+            f"Expected one {name} row per decision, got shape "
+            f"{tuple(value.shape)} for {num_decisions} decisions."
+        )
+    rows = value.reshape(num_decisions, -1)
+    if not rows.shape[1]:
+        raise RuntimeError(f"{name} has an empty per-decision shape.")
+    scalar = rows[:, 0]
+    if rows.shape[1] > 1 and not torch.equal(
+        rows, scalar.unsqueeze(-1).expand_as(rows)
+    ):
+        raise RuntimeError(f"Each decision must carry exactly one {name} value.")
+    return scalar
+
+
+def _policy_version_span_metrics(
+    versions: torch.Tensor,
+    ids: torch.Tensor | None,
+    *,
+    prefix: str,
+) -> dict[str, float | int]:
+    """Measure behavior-policy mixing within trajectories or GRPO groups."""
+    if ids is None or not isinstance(ids, torch.Tensor):
+        return {}
+    ids = (
+        _decision_scalar_tensor(
+            ids,
+            num_decisions=versions.numel(),
+            name=f"{prefix} id",
+        )
+        .detach()
+        .cpu()
+    )
+    versions = versions.detach().cpu()
+    spans = torch.stack(
+        [
+            versions[ids == unit_id].max() - versions[ids == unit_id].min()
+            for unit_id in ids.unique()
+        ]
+    )
+    return {
+        f"train/mixed_policy_{prefix}_fraction": float((spans > 0).float().mean()),
+        f"train/{prefix}_policy_version_span_max": int(spans.max()),
+    }
+
+
+def policy_staleness_metrics(
+    data: TensorDictBase,
+    current_policy_version: int,
+) -> dict[str, float | int]:
+    """Summarize behavior-policy age without filtering replay data."""
+    version = data.get("policy_version", None)
+    if version is None:
+        raise KeyError(
+            "VLA-GRPO staleness accounting requires the inference server's "
+            "'policy_version' annotation."
+        )
+    if not isinstance(version, torch.Tensor):
+        raise TypeError(
+            "Expected tensor policy-version metadata, got " f"{type(version).__name__}."
+        )
+    versions = _decision_scalar_tensor(
+        version,
+        num_decisions=data.shape[0],
+        name="policy version",
+    ).to(dtype=torch.long)
+    current_policy_version = int(current_policy_version)
+    staleness = current_policy_version - versions
+    if bool((staleness < 0).any()):
+        raise RuntimeError(
+            "Replay contains a behavior-policy version newer than the trainer: "
+            f"trainer={current_policy_version}, newest={int(versions.max())}."
+        )
+    staleness_float = staleness.float()
+    metrics: dict[str, float | int] = {
+        "train/current_policy_version": current_policy_version,
+        "train/behavior_policy_version_min": int(versions.min()),
+        "train/behavior_policy_version_max": int(versions.max()),
+        "train/policy_staleness_min": int(staleness.min()),
+        "train/policy_staleness_mean": float(staleness_float.mean()),
+        "train/policy_staleness_p95": float(torch.quantile(staleness_float, 0.95)),
+        "train/policy_staleness_max": int(staleness.max()),
+        "train/stale_decision_fraction": float((staleness > 0).float().mean()),
+    }
+    metrics.update(
+        _policy_version_span_metrics(
+            versions,
+            data.get(("collector", "traj_ids"), None),
+            prefix="trajectory",
+        )
+    )
+    metrics.update(
+        _policy_version_span_metrics(
+            versions,
+            data.get("group_id", None),
+            prefix="group",
+        )
+    )
+    return metrics
+
+
+def _check_pre_update_policy_match(metrics: dict[str, float], cfg) -> None:
+    """Fail early when rollout and training policies disagree before PPO."""
+    min_ess = _cfg_get(cfg.train, "pre_update_min_ess", None)
+    max_clip_fraction = _cfg_get(cfg.train, "pre_update_max_clip_fraction", None)
+    if min_ess is not None and metrics["train/pre_update_ESS"] < float(min_ess):
+        raise RuntimeError(
+            "The rollout and training policies disagree before the first "
+            "optimizer step: pre-update ESS is "
+            f"{metrics['train/pre_update_ESS']:.6f}, below {float(min_ess):.6f}; "
+            f"clip_fraction={metrics['train/pre_update_clip_fraction']:.6f}, "
+            f"mean_ratio={metrics.get('train/pre_update_mean_ratio', float('nan')):.6f}, "
+            f"max_ratio={metrics.get('train/pre_update_max_ratio', float('nan')):.6f}."
+        )
+    if max_clip_fraction is not None and metrics[
+        "train/pre_update_clip_fraction"
+    ] > float(max_clip_fraction):
+        raise RuntimeError(
+            "The rollout and training policies disagree before the first "
+            "optimizer step: pre-update clip fraction is "
+            f"{metrics['train/pre_update_clip_fraction']:.6f}, above "
+            f"{float(max_clip_fraction):.6f}; "
+            f"ESS={metrics['train/pre_update_ESS']:.6f}, "
+            f"mean_ratio={metrics.get('train/pre_update_mean_ratio', float('nan')):.6f}, "
+            f"max_ratio={metrics.get('train/pre_update_max_ratio', float('nan')):.6f}."
+        )
 
 
 def update(
@@ -1155,79 +1529,186 @@ def update(
     *,
     logger=None,
     iteration: int,
+    current_policy_version: int | None = None,
 ) -> dict[str, float | int]:
-    """Run one PPO update over currently sampleable replay-buffer decisions."""
+    """Run a trajectory-weighted PPO update over one rollout-policy batch."""
     num_decisions = len(replay_buffer)
-    target_samples = max(
-        num_decisions * int(cfg.buffer.consume_after_n_samples),
-        num_decisions,
-    )
-    accumulate = max(int(cfg.loss.accumulate_batches), 1)
-    losses = []
-    clip_fractions = []
-    ess = []
+    if not num_decisions:
+        raise RuntimeError("Cannot update from an empty replay buffer.")
+    epochs = max(int(cfg.buffer.consume_after_n_samples), 1)
+    forward_batch_size = max(int(cfg.loss.mini_batch_size), 1)
+    trajectories_per_step = max(int(cfg.loss.trajectories_per_optimizer_step), 1)
+    loss_sum = torch.zeros((), device=device)
+    diagnostic_sums = {
+        "clip_fraction": torch.zeros((), device=device),
+        "ESS": torch.zeros((), device=device),
+        "kl_approx": torch.zeros((), device=device),
+        "mean_ratio": torch.zeros((), device=device),
+        "entropy": torch.zeros((), device=device),
+        "loss_entropy": torch.zeros((), device=device),
+    }
+    diagnostic_decisions = 0
     grad_norms = []
     optim_steps = 0
     trained_decisions = 0
+    trained_trajectories = 0
     micro_batches = 0
+    pre_update_metrics: dict[str, float] | None = None
+    staleness_metrics: dict[str, float | int] = {}
 
     def optimizer_step() -> None:
         nonlocal optim_steps
-        grad_norms.append(
-            torch.nn.utils.clip_grad_norm_(
-                loss_module.parameters(), cfg.optim.max_grad_norm
-            )
+        grad_norm = torch.nn.utils.clip_grad_norm_(
+            loss_module.parameters(), cfg.optim.max_grad_norm
         )
+        if not torch.isfinite(grad_norm):
+            raise FloatingPointError(
+                f"Non-finite gradient norm before optimizer step: {grad_norm}."
+            )
+        grad_norms.append(grad_norm.detach())
         optim.step()
         optim.zero_grad(set_to_none=True)
         scheduler.step()
         optim_steps += 1
 
+    optim.zero_grad(set_to_none=True)
     with timeit("train") as train_timer:
-        while trained_decisions < target_samples and len(replay_buffer):
-            batch = replay_buffer.sample()
-            batch = batch.to(device)
-            trained_decisions += batch.shape[0]
-            loss_vals = loss_module(batch)
-            loss = loss_vals["loss_objective"] / accumulate
-            loss.backward()
-            micro_batches += 1
-            losses.append(loss_vals["loss_objective"].detach())
-            clip_fractions.append(loss_vals["clip_fraction"].detach())
-            # Token-level ESS retains action feature dimensions. Reduce each
-            # minibatch before aggregation so partial batches do not make the
-            # diagnostic shapes heterogeneous.
-            ess.append(loss_vals["ESS"].detach().mean())
-            if micro_batches % accumulate == 0:
+        for _ in range(epochs):
+            data = replay_buffer.sample(batch_size=num_decisions)
+            if current_policy_version is not None and not staleness_metrics:
+                staleness_metrics = policy_staleness_metrics(
+                    data, current_policy_version
+                )
+            traj_ids = data.get(("collector", "traj_ids"), None)
+            if traj_ids is None:
+                raise KeyError(
+                    "Trajectory-aware VLA PPO requires "
+                    "('collector', 'traj_ids') in replay data."
+                )
+            traj_ids = traj_ids.reshape(-1).cpu()
+            if traj_ids.numel() != data.shape[0]:
+                raise RuntimeError(
+                    "Expected one trajectory id per replay decision, got "
+                    f"{traj_ids.numel()} ids for {data.shape[0]} decisions."
+                )
+            _, decision_to_traj = traj_ids.unique(sorted=False, return_inverse=True)
+            num_trajectories = int(decision_to_traj.max().item()) + 1
+            trajectory_lengths = torch.bincount(
+                decision_to_traj, minlength=num_trajectories
+            )
+            trajectory_order = torch.randperm(num_trajectories)
+
+            for traj_start in range(0, num_trajectories, trajectories_per_step):
+                step_trajectories = trajectory_order[
+                    traj_start : traj_start + trajectories_per_step
+                ]
+                step_trajectory_count = int(step_trajectories.numel())
+                decision_indices = (
+                    torch.isin(decision_to_traj, step_trajectories)
+                    .nonzero(as_tuple=False)
+                    .squeeze(-1)
+                )
+                step_diagnostic_sums = {
+                    key: torch.zeros((), device=device) for key in diagnostic_sums
+                }
+                step_max_ratio = torch.zeros((), device=device)
+                step_decisions = 0
+                step_loss = torch.zeros((), device=device)
+
+                for decision_start in range(
+                    0, decision_indices.numel(), forward_batch_size
+                ):
+                    indices = decision_indices[
+                        decision_start : decision_start + forward_batch_size
+                    ]
+                    batch_size = int(indices.numel())
+                    batch = data[indices].to(device)
+                    loss_vals = loss_module(batch)
+                    per_decision_loss = _decision_loss(
+                        loss_vals["loss_objective"], batch_size
+                    )
+                    batch_traj = decision_to_traj[indices]
+                    weights = (
+                        trajectory_lengths[batch_traj]
+                        .to(device=device, dtype=per_decision_loss.dtype)
+                        .reciprocal_()
+                    )
+                    weights.div_(step_trajectory_count)
+                    weighted_loss = (per_decision_loss * weights).sum()
+                    if not torch.isfinite(weighted_loss):
+                        raise FloatingPointError(
+                            "Non-finite trajectory-weighted PPO loss."
+                        )
+                    weighted_loss.backward()
+
+                    step_loss += weighted_loss.detach()
+                    trained_decisions += batch_size
+                    micro_batches += 1
+                    step_decisions += batch_size
+                    for key in step_diagnostic_sums:
+                        value = loss_vals[key].detach().mean()
+                        step_diagnostic_sums[key] += value * batch_size
+                        diagnostic_sums[key] += value * batch_size
+                    step_max_ratio = torch.maximum(
+                        step_max_ratio, loss_vals["max_ratio"].detach().max()
+                    )
+                    diagnostic_decisions += batch_size
+
+                if pre_update_metrics is None:
+                    pre_update_metrics = {
+                        "train/pre_update_clip_fraction": float(
+                            step_diagnostic_sums["clip_fraction"] / step_decisions
+                        ),
+                        "train/pre_update_ESS": float(
+                            step_diagnostic_sums["ESS"] / step_decisions
+                        ),
+                        "train/pre_update_kl_approx": float(
+                            step_diagnostic_sums["kl_approx"] / step_decisions
+                        ),
+                        "train/pre_update_mean_ratio": float(
+                            step_diagnostic_sums["mean_ratio"] / step_decisions
+                        ),
+                        "train/pre_update_max_ratio": float(step_max_ratio),
+                    }
+                    _check_pre_update_policy_match(pre_update_metrics, cfg)
+
+                loss_sum += step_loss * step_trajectory_count
+                trained_trajectories += step_trajectory_count
                 optimizer_step()
-        tail_micro_batches = micro_batches % accumulate
-        if tail_micro_batches:
-            # Each micro-batch loss was divided by the full `accumulate`, but
-            # the tail optimizer step accumulated fewer micro-batches. Rescale
-            # the accumulated gradients so the tail step averages over the
-            # micro-batches that actually contributed to it.
-            for param in loss_module.parameters():
-                if param.grad is not None:
-                    param.grad.mul_(accumulate / tail_micro_batches)
-            optimizer_step()
 
     train_time = max(train_timer.elapsed(), 1e-9)
     metrics: dict[str, float | int] = {
         "train/decisions": trained_decisions,
+        "train/trajectories": trained_trajectories,
         "train/micro_batches": micro_batches,
         "train/optim_steps": optim_steps,
+        "train/decisions_per_optim_step": trained_decisions / optim_steps,
+        "train/trajectories_per_optim_step": trained_trajectories / optim_steps,
         "throughput/train_decisions_per_s": trained_decisions / train_time,
         "throughput/optim_steps_per_s": optim_steps / train_time,
     }
-    if losses:
-        metrics.update(
-            {
-                "train/loss_objective": torch.stack(losses).mean().item(),
-                "train/clip_fraction": torch.stack(clip_fractions).mean().item(),
-                "train/ESS": torch.stack(ess).mean().item(),
-                "train/grad_norm": torch.stack(grad_norms).mean().item(),
-            }
-        )
+    metrics.update(
+        {
+            "train/loss_objective": float(loss_sum / trained_trajectories),
+            "train/clip_fraction": float(
+                diagnostic_sums["clip_fraction"] / diagnostic_decisions
+            ),
+            "train/ESS": float(diagnostic_sums["ESS"] / diagnostic_decisions),
+            "train/kl_approx": float(
+                diagnostic_sums["kl_approx"] / diagnostic_decisions
+            ),
+            "train/mean_ratio": float(
+                diagnostic_sums["mean_ratio"] / diagnostic_decisions
+            ),
+            "train/entropy": float(diagnostic_sums["entropy"] / diagnostic_decisions),
+            "train/loss_entropy": float(
+                diagnostic_sums["loss_entropy"] / diagnostic_decisions
+            ),
+            "train/grad_norm": float(torch.stack(grad_norms).mean()),
+        }
+    )
+    metrics.update(pre_update_metrics or {})
+    metrics.update(staleness_metrics)
     log_metrics(logger, metrics, iteration)
     return metrics
 
@@ -1243,21 +1724,25 @@ def _advantage_stats(
     return [advantage.get_stats()]
 
 
-def reset_advantage_state(
+def reset_advantage_stats(
     advantage: MCAdvantage, collector: MultiCollector | None = None
 ) -> None:
-    """Clear incomplete groups and reset counters at a policy boundary."""
-    advantage.clear_queues()
+    """Reset per-update counters without discarding incomplete groups."""
     advantage.reset_stats()
     if collector is not None and not advantage.is_shared:
-        collector.map_fn(f"{_WORKER_ADVANTAGE_PATH}.clear_queues")
         collector.map_fn(f"{_WORKER_ADVANTAGE_PATH}.reset_stats")
 
 
 def reset_collection_state(advantage: MCAdvantage, collector: MultiCollector) -> None:
-    """Drop partial trajectories before advancing the behavior policy."""
-    reset_advantage_state(advantage, collector)
-    collector.map_fn("reset")
+    """Advance metric accounting while preserving all collector work.
+
+    Completed trajectories waiting for the rest of their GRPO group remain in
+    ``MCAdvantage`` and environments continue any in-flight trajectory after
+    the inference server publishes new weights. Every decision is stamped with
+    its actual behavior-policy version, so the resulting lag can be measured
+    when the completed group is trained.
+    """
+    reset_advantage_stats(advantage, collector)
 
 
 def advantage_metrics(
@@ -1359,10 +1844,14 @@ def log_iteration_summary(
 
 
 def checkpoint_tensordict(
-    policy: torch.nn.Module, optim, scheduler, iteration: int
+    policy: torch.nn.Module,
+    optim,
+    scheduler,
+    iteration: int,
+    total_episodes: int | None = None,
 ) -> TensorDict:
     """TensorDict checkpoint payload for the VLA recipe."""
-    return TensorDict(
+    checkpoint = TensorDict(
         {
             "policy": policy_weights(policy),
             "iteration": torch.tensor(iteration, dtype=torch.long),
@@ -1372,19 +1861,41 @@ def checkpoint_tensordict(
         },
         batch_size=[],
     )
+    if total_episodes is not None:
+        checkpoint["total_episodes"] = torch.tensor(total_episodes, dtype=torch.long)
+    return checkpoint
 
 
-def save_checkpoint(path, policy: torch.nn.Module, optim, scheduler, iteration: int):
-    checkpoint_tensordict(policy, optim, scheduler, iteration).save(path)
+def save_checkpoint(
+    path,
+    policy: torch.nn.Module,
+    optim,
+    scheduler,
+    iteration: int,
+    total_episodes: int | None = None,
+):
+    checkpoint_tensordict(
+        policy,
+        optim,
+        scheduler,
+        iteration,
+        total_episodes=total_episodes,
+    ).save(path)
 
 
-def load_checkpoint(path, policy: torch.nn.Module, optim, scheduler, device) -> int:
+def load_checkpoint(
+    path, policy: torch.nn.Module, optim, scheduler, device
+) -> tuple[int, int | None]:
     checkpoint = TensorDict.load(path)
     apply_policy_weights(policy, checkpoint["policy"], device)
     optim.load_state_dict(checkpoint["optim"])
     scheduler.load_state_dict(checkpoint["scheduler"])
     torch.set_rng_state(checkpoint["torch_rng_state"])
-    return int(checkpoint["iteration"].item()) + 1
+    total_episodes = checkpoint.get("total_episodes", None)
+    return (
+        int(checkpoint["iteration"].item()) + 1,
+        None if total_episodes is None else int(total_episodes.item()),
+    )
 
 
 def log_metrics(logger, metrics: dict, step: int) -> None:

--- a/sota-implementations/vla_grpo/vla-grpo.py
+++ b/sota-implementations/vla_grpo/vla-grpo.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import os
 import warnings
+from functools import partial
 
 import hydra
 import torch
@@ -31,24 +32,28 @@ from utils import (
     make_action_tokenizer,
     make_collector,
     make_evaluator,
+    make_inference_policy,
     make_logger,
     make_loss_module,
     make_optimizer,
     make_policy,
     make_replay_buffer,
-    replay_ready_target,
+    make_video_evaluator,
+    replay_ready_targets,
     reset_collection_state,
     save_checkpoint,
     sync_policy_server,
     update,
+    video_eval_episodes,
     wait_for_replay,
 )
 
 warnings.filterwarnings("ignore", category=UserWarning, module="tensordict")
 
 
-@hydra.main(config_path="config", config_name="vla_grpo_toy", version_base="1.1")
+@hydra.main(config_path="config", config_name="vla_grpo_libero", version_base="1.1")
 def main(cfg):  # noqa: F821
+    torchrl_logger.info("Initializing VLA-GRPO with seed %d.", cfg.env.seed)
     torch.manual_seed(cfg.env.seed)
     train_device = auto_device(cfg.policy.device)
     rollout_device = (
@@ -64,18 +69,75 @@ def main(cfg):  # noqa: F821
     buffer_device = (
         torch.device(cfg.buffer.device) if cfg.buffer.device else train_device
     )
+    torchrl_logger.info(
+        "Resolved devices: learner=%s rollout=%s evaluation=%s replay=%s.",
+        train_device,
+        rollout_device,
+        eval_device,
+        buffer_device,
+    )
+    torchrl_logger.info(
+        "Initializing experiment logger: backend=%s mode=%s.",
+        cfg.logger.backend,
+        cfg.logger.mode,
+    )
     logger = make_logger(cfg)
-    policy = make_policy(cfg, train_device)
-    tokenizer = make_action_tokenizer(cfg, policy)
+    torchrl_logger.info("Experiment logger is ready.")
+    torchrl_logger.info("Building environment-side action tokenizer.")
+    tokenizer = make_action_tokenizer(cfg)
+    if cfg.policy.backend == "openvla":
+        torchrl_logger.info(
+            "Loading learner policy %s on %s.",
+            cfg.policy.checkpoint,
+            train_device,
+        )
+    else:
+        torchrl_logger.info(
+            "Building learner policy backend=%s on %s.",
+            cfg.policy.backend,
+            train_device,
+        )
+    learner_policy = make_policy(cfg, train_device)
+    torchrl_logger.info("Learner policy is ready; building replay and PPO state.")
     replay_buffer, advantage_transform = make_replay_buffer(cfg, buffer_device)
-    loss_module = make_loss_module(cfg, policy)
+    loss_module = make_loss_module(cfg, learner_policy)
     optim, scheduler = make_optimizer(cfg, loss_module)
+    rollout_policy_factory = partial(
+        make_inference_policy,
+        cfg,
+        rollout_device,
+        policy_micro_batch_size=cfg.collector.policy_micro_batch_size,
+    )
+    total_rollout_envs = int(cfg.collector.num_collectors) * int(
+        cfg.collector.envs_per_collector
+    )
+    torchrl_logger.info(
+        "Starting inference server and collectors: collectors=%d "
+        "envs_per_collector=%d total_envs=%d rollout_device=%s "
+        "policy_micro_batch_size=%s.",
+        cfg.collector.num_collectors,
+        cfg.collector.envs_per_collector,
+        total_rollout_envs,
+        rollout_device,
+        cfg.collector.policy_micro_batch_size,
+    )
     collector, policy_server, eval_policy = make_collector(
         cfg,
-        policy,
         rollout_device,
+        policy_factory=rollout_policy_factory,
         tokenizer=tokenizer,
         replay_buffer=replay_buffer,
+    )
+    torchrl_logger.info(
+        "Inference server and collectors are ready at policy version %d.",
+        policy_server.policy_version,
+    )
+    torchrl_logger.info(
+        "Building evaluator: episodes=%d envs=%d backend=%s device=%s.",
+        cfg.logger.eval_episodes,
+        cfg.env.eval_num_envs,
+        cfg.logger.eval_backend,
+        eval_device,
     )
     evaluator = make_evaluator(
         cfg,
@@ -84,37 +146,185 @@ def main(cfg):  # noqa: F821
         logger,
         eval_device,
     )
+    video_evaluator = make_video_evaluator(
+        cfg,
+        tokenizer,
+        eval_policy,
+        logger,
+        eval_device,
+    )
+    if video_evaluator is None:
+        torchrl_logger.info("Evaluator is ready; eval video recording is disabled.")
+    else:
+        torchrl_logger.info(
+            "Evaluator is ready; video evaluator will record %d episode(s) "
+            "with %s parallel env(s) per scheduled eval.",
+            video_eval_episodes(cfg),
+            cfg.logger.video_num_envs,
+        )
 
     start_iter = 0
+    resumed_episodes = None
     if cfg.checkpoint.resume:
-        start_iter = load_checkpoint(
-            cfg.checkpoint.resume, policy, optim, scheduler, train_device
+        torchrl_logger.info("Loading checkpoint from %s.", cfg.checkpoint.resume)
+        start_iter, resumed_episodes = load_checkpoint(
+            cfg.checkpoint.resume,
+            learner_policy,
+            optim,
+            scheduler,
+            train_device,
         )
         torchrl_logger.info(
             "Resumed from %s at iteration %d.", cfg.checkpoint.resume, start_iter
         )
 
-    target_replay_decisions = replay_ready_target(cfg)
+    target_replay_groups, target_replay_decisions = replay_ready_targets(cfg)
     episodes_per_iter = cfg.collector.groups_per_iter * candidate_group_size(cfg)
-    total_episodes = start_iter * episodes_per_iter
+    total_episodes = (
+        start_iter * episodes_per_iter if resumed_episodes is None else resumed_episodes
+    )
+    trajectory_budget = cfg.collector.get("total_trajectories", None)
+    if trajectory_budget is not None:
+        trajectory_budget = int(trajectory_budget)
     weight_sync_trainable_only = bool(cfg.train.weight_sync_trainable_only)
-    sync_policy_server(policy_server, policy, trainable_only=weight_sync_trainable_only)
+    torchrl_logger.info(
+        "Publishing initial learner weights to the inference server "
+        "(trainable_only=%s).",
+        weight_sync_trainable_only,
+    )
+    sync_policy_server(
+        policy_server,
+        learner_policy,
+        trainable_only=weight_sync_trainable_only,
+    )
+    torchrl_logger.info(
+        "Initial weights published; inference policy version is %d.",
+        policy_server.policy_version,
+    )
+    latest_eval_metrics = {}
+    last_eval_step = None
+    last_video_step = None
+
+    def record_eval_video(step: int) -> None:
+        nonlocal last_video_step
+        if video_evaluator is None or last_video_step == step:
+            return
+        torchrl_logger.info(
+            "Recording eval video for step %d over %d episode(s).",
+            step,
+            video_eval_episodes(cfg),
+        )
+        video_metrics = video_evaluator.evaluate(weights=None, step=step)
+        last_video_step = step
+        torchrl_logger.info(
+            "Eval video for step %d complete: success_rate=%.3f.",
+            step,
+            video_metrics["eval/success_rate"],
+        )
+
+    if start_iter == 0 and bool(cfg.logger.eval_before_train):
+        if cfg.logger.eval_async:
+            torchrl_logger.info(
+                "Submitting asynchronous frozen-policy baseline evaluation over "
+                "%d episodes.",
+                cfg.logger.eval_episodes,
+            )
+            evaluator.trigger_eval(weights=None, step=0)
+            record_eval_video(0)
+        else:
+            torchrl_logger.info(
+                "Starting frozen-policy baseline evaluation over %d episodes.",
+                cfg.logger.eval_episodes,
+            )
+            baseline_metrics = evaluator.evaluate(weights=None, step=0)
+            log_metrics(logger, baseline_metrics, 0)
+            latest_eval_metrics = baseline_metrics
+            last_eval_step = 0
+            torchrl_logger.info(
+                "Frozen-policy success rate: %.3f",
+                baseline_metrics["eval/success_rate"],
+            )
+            record_eval_video(0)
+    torchrl_logger.info("Starting asynchronous rollout collection.")
     collector.start()
+    torchrl_logger.info("Rollout collectors are running.")
 
     pbar = tqdm.tqdm(total=cfg.collector.total_iters, initial=start_iter)
+    completed_updates = start_iter
     try:
         for iteration in range(start_iter, cfg.collector.total_iters):
+            if trajectory_budget is not None and total_episodes >= trajectory_budget:
+                torchrl_logger.info(
+                    "Reached completed-trajectory budget: %d/%d.",
+                    total_episodes,
+                    trajectory_budget,
+                )
+                break
+            update_step = iteration + 1
+            torchrl_logger.info(
+                "Iteration %d/%d: collecting for at least %d useful groups "
+                "and %d decisions with policy version %d.",
+                update_step,
+                cfg.collector.total_iters,
+                target_replay_groups,
+                target_replay_decisions,
+                policy_server.policy_version,
+            )
             with timeit("collect"):
+                remaining_trajectories = (
+                    None
+                    if trajectory_budget is None
+                    else trajectory_budget - total_episodes
+                )
                 collect_metrics = wait_for_replay(
                     replay_buffer,
+                    advantage_transform,
+                    collector,
+                    min_replay_groups=target_replay_groups,
                     min_replay_decisions=target_replay_decisions,
                     poll_interval_s=cfg.collector.replay_wait_s,
                     log_interval_s=cfg.collector.replay_log_s,
-                    iteration=iteration,
+                    iteration=update_step,
+                    max_completed_trajectories=remaining_trajectories,
                 )
+            torchrl_logger.info(
+                "Iteration %d collection ready: kept_groups=%d decisions=%d "
+                "completed_trajectories=%d wait_s=%.1f.",
+                update_step,
+                collect_metrics["buffer/kept_groups_before_update"],
+                collect_metrics["buffer/decisions_before_update"],
+                collect_metrics["collector/completed_trajectories_before_update"],
+                collect_metrics["buffer/wait_s"],
+            )
+
+            if (
+                collect_metrics["buffer/trajectory_budget_reached"]
+                and collect_metrics["buffer/kept_groups_before_update"]
+                < target_replay_groups
+            ):
+                with collector.pause():
+                    group_metrics = advantage_metrics(advantage_transform, collector)
+                    reset_collection_state(advantage_transform, collector)
+                total_episodes += int(group_metrics["collector/completed_trajectories"])
+                torchrl_logger.info(
+                    "Reached completed-trajectory budget without another full "
+                    "useful policy batch: %d/%d.",
+                    total_episodes,
+                    trajectory_budget,
+                )
+                timeit.erase()
+                break
 
             with collector.pause():
                 num_decisions = len(replay_buffer)
+                behavior_policy_version = policy_server.policy_version
+                torchrl_logger.info(
+                    "Iteration %d: collectors paused; starting PPO over %d "
+                    "decisions from behavior policy version %d.",
+                    update_step,
+                    num_decisions,
+                    behavior_policy_version,
+                )
                 train_metrics = update(
                     replay_buffer,
                     loss_module,
@@ -123,24 +333,75 @@ def main(cfg):  # noqa: F821
                     cfg,
                     train_device,
                     logger=logger,
-                    iteration=iteration,
+                    iteration=update_step,
+                    current_policy_version=behavior_policy_version,
+                )
+                torchrl_logger.info(
+                    "Iteration %d PPO complete: loss=%.6f grad_norm=%.6f "
+                    "optimizer_steps=%d max_staleness=%s.",
+                    update_step,
+                    train_metrics["train/loss_objective"],
+                    train_metrics["train/grad_norm"],
+                    train_metrics["train/optim_steps"],
+                    train_metrics.get("train/policy_staleness_max", "unavailable"),
                 )
                 group_metrics = advantage_metrics(advantage_transform, collector)
                 reset_collection_state(advantage_transform, collector)
+                torchrl_logger.info(
+                    "Iteration %d: publishing updated learner weights.", update_step
+                )
                 sync_policy_server(
-                    policy_server, policy, trainable_only=weight_sync_trainable_only
+                    policy_server,
+                    learner_policy,
+                    trainable_only=weight_sync_trainable_only,
+                )
+                torchrl_logger.info(
+                    "Iteration %d: inference policy advanced to version %d; "
+                    "collectors will resume after the update boundary.",
+                    update_step,
+                    policy_server.policy_version,
                 )
 
             eval_metrics = {}
-            if iteration % cfg.logger.eval_iter == 0:
+            if update_step % cfg.logger.eval_iter == 0:
+                record_eval_video(update_step)
                 if cfg.logger.eval_async:
-                    evaluator.trigger_eval(weights=None, step=iteration)
+                    torchrl_logger.info(
+                        "Iteration %d: submitting asynchronous evaluation over "
+                        "%d episodes.",
+                        update_step,
+                        cfg.logger.eval_episodes,
+                    )
+                    evaluator.trigger_eval(weights=None, step=update_step)
                 else:
-                    eval_metrics = evaluator.evaluate(weights=None, step=iteration)
+                    torchrl_logger.info(
+                        "Iteration %d: starting synchronous evaluation over %d "
+                        "episodes.",
+                        update_step,
+                        cfg.logger.eval_episodes,
+                    )
+                    eval_metrics = evaluator.evaluate(weights=None, step=update_step)
+                    latest_eval_metrics = eval_metrics
+                    last_eval_step = update_step
+                    torchrl_logger.info(
+                        "Iteration %d evaluation complete: success_rate=%.3f.",
+                        update_step,
+                        eval_metrics["eval/success_rate"],
+                    )
             if cfg.logger.eval_async:
                 ready_eval = evaluator.poll(timeout=0)
                 if ready_eval is not None:
                     eval_metrics = ready_eval
+                    latest_eval_metrics = ready_eval
+                    last_eval_step = int(ready_eval["eval/step"])
+                    if last_eval_step != update_step:
+                        log_metrics(logger, ready_eval, last_eval_step)
+                    torchrl_logger.info(
+                        "Asynchronous evaluation for iteration %d complete: "
+                        "success_rate=%.3f.",
+                        last_eval_step,
+                        ready_eval["eval/success_rate"],
+                    )
 
             timings = timeit.todict(prefix="time")
             timeit.erase()
@@ -148,6 +409,7 @@ def main(cfg):  # noqa: F821
                 group_metrics["collector/completed_trajectories"]
             )
             total_episodes += completed_trajectories
+            completed_updates = update_step
             metrics, train_success = iteration_metrics(
                 cfg,
                 num_decisions=num_decisions,
@@ -159,9 +421,9 @@ def main(cfg):  # noqa: F821
                 timings=timings,
             )
             metrics["train/lr"] = scheduler.get_last_lr()[0]
-            log_metrics(logger, metrics, iteration)
+            log_metrics(logger, metrics, update_step)
             log_iteration_summary(
-                iteration,
+                update_step,
                 train_success=train_success,
                 num_decisions=num_decisions,
                 group_metrics=group_metrics,
@@ -176,47 +438,76 @@ def main(cfg):  # noqa: F821
                 cfg.checkpoint.save_iter
                 and (iteration + 1) % cfg.checkpoint.save_iter == 0
             ):
+                checkpoint_path = os.path.join(os.getcwd(), "checkpoint_latest")
+                torchrl_logger.info(
+                    "Iteration %d: saving checkpoint to %s.",
+                    update_step,
+                    checkpoint_path,
+                )
                 save_checkpoint(
-                    os.path.join(os.getcwd(), "checkpoint_latest"),
-                    policy,
+                    checkpoint_path,
+                    learner_policy,
                     optim,
                     scheduler,
                     iteration,
+                    total_episodes=total_episodes,
                 )
+                torchrl_logger.info("Iteration %d checkpoint saved.", update_step)
 
         if cfg.checkpoint.save_iter:
+            checkpoint_path = os.path.join(os.getcwd(), "checkpoint_latest")
+            torchrl_logger.info("Saving final checkpoint to %s.", checkpoint_path)
             save_checkpoint(
-                os.path.join(os.getcwd(), "checkpoint_latest"),
-                policy,
+                checkpoint_path,
+                learner_policy,
                 optim,
                 scheduler,
-                cfg.collector.total_iters - 1,
+                completed_updates - 1,
+                total_episodes=total_episodes,
             )
         if cfg.logger.eval_async and evaluator.pending:
+            torchrl_logger.info("Waiting for the pending asynchronous evaluation.")
             final_async = evaluator.wait(timeout=cfg.logger.eval_timeout_s)
             if final_async is not None:
-                log_metrics(logger, final_async, cfg.collector.total_iters)
-        final_eval = evaluator.evaluate(weights=None, step=cfg.collector.total_iters)
-        log_metrics(logger, final_eval, cfg.collector.total_iters)
+                last_eval_step = int(final_async["eval/step"])
+                latest_eval_metrics = final_async
+                log_metrics(logger, final_async, last_eval_step)
+        record_eval_video(completed_updates)
+        if last_eval_step == completed_updates:
+            final_eval = latest_eval_metrics
+        else:
+            torchrl_logger.info(
+                "Starting final evaluation at iteration %d over %d episodes.",
+                completed_updates,
+                cfg.logger.eval_episodes,
+            )
+            final_eval = evaluator.evaluate(weights=None, step=completed_updates)
+            log_metrics(logger, final_eval, completed_updates)
         torchrl_logger.info(
             "Final greedy success rate: %.3f", final_eval["eval/success_rate"]
         )
     finally:
+        torchrl_logger.info("Shutting down VLA-GRPO services.")
         pbar.close()
         try:
             evaluator.shutdown()
         finally:
             try:
-                collector.shutdown()
+                if video_evaluator is not None:
+                    video_evaluator.shutdown()
             finally:
                 try:
-                    policy_server.shutdown()
+                    collector.shutdown()
                 finally:
                     try:
-                        policy_server.transport.close()
+                        policy_server.shutdown()
                     finally:
-                        if logger is not None:
-                            logger.shutdown()
+                        try:
+                            policy_server.transport.close()
+                        finally:
+                            if logger is not None:
+                                logger.shutdown()
+        torchrl_logger.info("VLA-GRPO shutdown complete.")
 
 
 if __name__ == "__main__":

--- a/test/envs/test_parallel.py
+++ b/test/envs/test_parallel.py
@@ -132,6 +132,45 @@ class TestParallel:
                 4, make_env, create_env_kwargs=[{"seed": 0}, {"seed": 1}]
             )
 
+    def test_common_factory_only_constructs_one_metadata_env(self):
+        metadata_worker_indices = []
+
+        def make_env(worker_idx):
+            metadata_worker_indices.append(worker_idx)
+            return ContinuousActionVecMockEnv()
+
+        num_subcollectors = 5
+        envs_per_subcollector = 64
+        create_env_kwargs = [
+            {"worker_idx": worker_idx} for worker_idx in range(envs_per_subcollector)
+        ]
+
+        homogeneous = ParallelEnv(
+            envs_per_subcollector,
+            make_env,
+            create_env_kwargs=create_env_kwargs,
+        )
+        assert homogeneous._single_task
+        assert metadata_worker_indices == [0]
+        homogeneous_metadata_count = len(metadata_worker_indices)
+        homogeneous.close(raise_if_closed=False)
+
+        metadata_worker_indices.clear()
+        heterogeneous = ParallelEnv(
+            envs_per_subcollector,
+            [
+                partial(make_env, worker_idx=worker_idx)
+                for worker_idx in range(envs_per_subcollector)
+            ],
+        )
+        assert not heterogeneous._single_task
+        assert metadata_worker_indices == list(range(envs_per_subcollector))
+        heterogeneous_metadata_count = len(metadata_worker_indices)
+        heterogeneous.close(raise_if_closed=False)
+
+        assert num_subcollectors * heterogeneous_metadata_count == 320
+        assert num_subcollectors * homogeneous_metadata_count == 5
+
     @pytest.mark.gpu
     @pytest.mark.skipif(
         not torch.cuda.device_count(), reason="No cuda device detected."

--- a/test/envs/test_parallel.py
+++ b/test/envs/test_parallel.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import gc
 import os
+from functools import partial
 
 import numpy as np
 import pytest
@@ -34,6 +35,7 @@ from torchrl.envs import (
     TransformedEnv,
 )
 from torchrl.envs.batched_envs import _stackable
+from torchrl.envs.env_creator import get_env_metadata
 from torchrl.envs.libs.dm_control import _has_dmc, DMControlEnv
 from torchrl.envs.libs.gym import GymEnv
 from torchrl.envs.transforms import Compose, StepCounter
@@ -54,6 +56,12 @@ from torchrl.testing.mocking_classes import (
     MockBatchedLockedEnv,
     NestedCountingEnv,
 )
+
+
+def _make_parent_guarded_env(parent_pid):
+    if os.getpid() == parent_pid:
+        raise RuntimeError("env factory should only be called in a worker")
+    return ContinuousActionVecMockEnv()
 
 
 class TestParallel:
@@ -77,6 +85,26 @@ class TestParallel:
     @staticmethod
     def _batched_count(env):
         return torch.stack([count.detach().cpu().clone() for count in env.count], 0)
+
+    def test_get_env_metadata_closes_callable_env(self):
+        closed = []
+
+        class CloseCountingEnv(CountingEnv):
+            def close(self, *args, **kwargs):
+                closed.append(True)
+                return super().close(*args, **kwargs)
+
+        get_env_metadata(lambda: CloseCountingEnv())
+        assert closed == [True]
+
+        with pytest.raises(RuntimeError, match="validator failed"):
+            get_env_metadata(
+                lambda: CloseCountingEnv(),
+                env_validator=lambda env: (_ for _ in ()).throw(
+                    RuntimeError("validator failed")
+                ),
+            )
+        assert closed == [True, True]
 
     @staticmethod
     def _ones_action(env):
@@ -202,6 +230,51 @@ class TestParallel:
             assert rollout.shape[0] == 2
         finally:
             env.close(raise_if_closed=False)
+
+    def test_metadata_from_workers(self, maybe_fork_ParallelEnv):
+        parent_pid = os.getpid()
+        env = maybe_fork_ParallelEnv(
+            2,
+            partial(_make_parent_guarded_env, parent_pid),
+            metadata_from_workers=True,
+        )
+        try:
+            assert env._use_buffers is False
+            assert not env.is_closed
+            rollout = env.rollout(3)
+            assert rollout.shape[:2] == torch.Size([2, 3])
+        finally:
+            env.close(raise_if_closed=False)
+
+    def test_metadata_from_workers_lambda_does_not_use_env_creator(
+        self, maybe_fork_ParallelEnv
+    ):
+        parent_pid = os.getpid()
+        env = maybe_fork_ParallelEnv(
+            2,
+            lambda: _make_parent_guarded_env(parent_pid),
+            metadata_from_workers=True,
+        )
+        try:
+            assert all(
+                not isinstance(env_fn, EnvCreator) for env_fn in env.create_env_fn
+            )
+            rollout = env.rollout(3)
+            assert rollout.shape[:2] == torch.Size([2, 3])
+        finally:
+            env.close(raise_if_closed=False)
+
+    def test_metadata_from_workers_rejects_buffers(self, maybe_fork_ParallelEnv):
+        with pytest.raises(
+            RuntimeError,
+            match="metadata_from_workers=True is incompatible with use_buffers=True",
+        ):
+            maybe_fork_ParallelEnv(
+                2,
+                ContinuousActionVecMockEnv,
+                metadata_from_workers=True,
+                use_buffers=True,
+            )
 
     @pytest.mark.parametrize("parallel", [False, True])
     @pytest.mark.parametrize("use_buffers", [False, True])

--- a/test/transforms/test_action_transforms.py
+++ b/test/transforms/test_action_transforms.py
@@ -2044,6 +2044,41 @@ class TestMultiAction(TransformBase):
         assert rollout["next", "done"].squeeze(-1).tolist() == [False, True]
         assert rollout["next", "success"].squeeze(-1).tolist() == [False, True]
 
+    def test_stack_rewards_false_done_mid_chunk_keeps_terminal_reward(self):
+        # LIBERO emits reward=float(success) from the base step. With
+        # stack_rewards=False, an outer transition that terminates before the
+        # last action slot must still report that terminal reward.
+        class SuccessCountingEnv(CountingEnv):
+            def __init__(self):
+                super().__init__(max_steps=1)
+                self.observation_spec["success"] = Categorical(
+                    2,
+                    dtype=torch.bool,
+                    shape=(*self.batch_size, 1),
+                    device=self.device,
+                )
+
+            def _reset(self, tensordict, **kwargs):
+                out = super()._reset(tensordict, **kwargs)
+                out["success"] = out["done"].clone()
+                return out
+
+            def _step(self, tensordict):
+                out = super()._step(tensordict)
+                success = out["done"].clone()
+                out["success"] = success
+                out["reward"] = success.to(dtype=out["reward"].dtype)
+                return out
+
+        env = TransformedEnv(SuccessCountingEnv(), MultiAction(stack_rewards=False))
+        td = env.reset()
+        td["action"] = torch.ones(4, 1)
+        out = env.step(td)["next"]
+
+        assert out["success"].item()
+        assert out["done"].item()
+        torch.testing.assert_close(out["reward"], torch.ones(1))
+
 
 @pytest.mark.skipif(IS_WIN, reason="Test is flaky on Windows")
 class TestConditionalSkip(TransformBase):

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -264,6 +264,7 @@ class _PEnvMeta(_EnvPostInit):
         # multiprocessing with the spawn start method. Lambda functions cannot
         # be serialized with standard pickle, but EnvCreator uses cloudpickle.
         auto_wrap_envs = kwargs.pop("auto_wrap_envs", True)
+        metadata_from_workers = kwargs.get("metadata_from_workers", False)
 
         def _warn_lambda():
             if rl_warnings():
@@ -302,7 +303,7 @@ class _PEnvMeta(_EnvPostInit):
                 return result
             return create_env_fn
 
-        if auto_wrap_envs:
+        if auto_wrap_envs and not metadata_from_workers:
             if "create_env_fn" in kwargs:
                 kwargs["create_env_fn"] = _wrap_lambdas(kwargs["create_env_fn"])
             elif len(args) >= 2:
@@ -381,6 +382,12 @@ class BatchedEnvBase(EnvBase):
         daemon (bool, optional): whether the processes should be daemonized.
             This is only applicable to parallel environments such as :class:`~torchrl.envs.ParallelEnv`.
             Defaults to ``False``.
+        metadata_from_workers (bool, optional): if ``True``, :class:`~torchrl.envs.ParallelEnv`
+            starts its workers during construction and retrieves metadata from
+            the worker-created environments instead of constructing transient
+            environments in the parent process. This option implies
+            ``use_buffers=False`` when ``use_buffers`` is unset and is
+            incompatible with ``use_buffers=True``. Defaults to ``False``.
         auto_wrap_envs (bool, optional): if ``True`` (default), lambda functions passed as
             ``create_env_fn`` will be automatically wrapped in an :class:`~torchrl.envs.EnvCreator`
             to enable pickling for multiprocessing with the ``spawn`` start method.
@@ -511,6 +518,7 @@ class BatchedEnvBase(EnvBase):
         use_buffers: bool | None = None,
         consolidate: bool = True,
         daemon: bool = False,
+        metadata_from_workers: bool = False,
     ):
         super().__init__(device=device)
         self.serial_for_single = serial_for_single
@@ -524,6 +532,7 @@ class BatchedEnvBase(EnvBase):
         self._use_buffers = use_buffers
         self.consolidate = consolidate
         self.daemon = daemon
+        self._metadata_from_workers = metadata_from_workers
 
         self._single_task = callable(create_env_fn) or (len(set(create_env_fn)) == 1)
         if callable(create_env_fn):
@@ -575,13 +584,26 @@ class BatchedEnvBase(EnvBase):
         self.__dict__["_output_spec"] = None
         # self._prepare_dummy_env(create_env_fn, create_env_kwargs)
         self._properties_set = False
-        self._get_metadata(create_env_fn, create_env_kwargs)
+        self.has_lazy_inputs = False
         self._non_blocking = non_blocking
         if mp_start_method is not None and not isinstance(self, ParallelEnv):
             raise TypeError(
                 f"Cannot use mp_start_method={mp_start_method} with envs of type {type(self)}."
             )
         self._mp_start_method = mp_start_method
+        if self._metadata_from_workers:
+            if not isinstance(self, ParallelEnv):
+                raise TypeError(
+                    "metadata_from_workers=True is only supported by ParallelEnv."
+                )
+            if self._use_buffers is True:
+                raise RuntimeError(
+                    "metadata_from_workers=True is incompatible with use_buffers=True. "
+                    "Worker metadata must be collected before shared buffers can be "
+                    "allocated; use use_buffers=False or leave use_buffers unset."
+                )
+            self._use_buffers = False
+        self._get_metadata(create_env_fn, create_env_kwargs)
 
     is_spec_locked = EnvBase.is_spec_locked
 
@@ -903,13 +925,20 @@ class BatchedEnvBase(EnvBase):
     def _get_metadata(
         self, create_env_fn: list[Callable], create_env_kwargs: list[dict]
     ):
+        if self._metadata_from_workers:
+            worker_metadata = self._start_workers(gather_metadata=True)
+        else:
+            worker_metadata = None
         if self._single_task:
             # if EnvCreator, the metadata are already there
-            meta_data: EnvMetaData = get_env_metadata(
-                create_env_fn[0],
-                create_env_kwargs[0],
-                env_validator=self._validate_worker_env,
-            )
+            if worker_metadata is None:
+                meta_data: EnvMetaData = get_env_metadata(
+                    create_env_fn[0],
+                    create_env_kwargs[0],
+                    env_validator=self._validate_worker_env,
+                )
+            else:
+                meta_data = worker_metadata[0]
             self.meta_data = meta_data.expand(
                 *(self.num_workers, *meta_data.batch_size)
             )
@@ -931,13 +960,15 @@ class BatchedEnvBase(EnvBase):
             n_tasks = len(create_env_fn)
             self.meta_data: list[EnvMetaData] = []
             for i in range(n_tasks):
-                self.meta_data.append(
-                    get_env_metadata(
+                if worker_metadata is None:
+                    meta_data = get_env_metadata(
                         create_env_fn[i],
                         create_env_kwargs[i],
                         env_validator=self._validate_worker_env,
-                    ).clone()
-                )
+                    )
+                else:
+                    meta_data = worker_metadata[i]
+                self.meta_data.append(meta_data.clone())
             if self.share_individual_td is not True:
                 share_individual_td = not _stackable(
                     *[meta_data.tensordict for meta_data in self.meta_data]
@@ -1951,9 +1982,16 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
 
     """
 
-    def _start_workers(self) -> None:
+    def _start_workers(
+        self, *, gather_metadata: bool = False
+    ) -> list[EnvMetaData] | None:
         import torchrl
 
+        if gather_metadata and self._use_buffers:
+            raise RuntimeError(
+                "Worker metadata can only be gathered before startup when "
+                "use_buffers=False."
+            )
         self._timeout = 10.0
         self.BATCHED_PIPE_TIMEOUT = torchrl._utils.BATCHED_PIPE_TIMEOUT
 
@@ -2015,60 +2053,117 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                         "shm_done_flags": self._shm_done_flags,
                     }
                 )
-        with clear_mpi_env_vars():
-            for idx in range(_num_workers):
-                if self._verbose:
-                    torchrl_logger.info(f"initiating worker {idx}")
-                # No certainty which module multiprocessing_context is
-                parent_pipe, child_pipe = ctx.Pipe()
-                env_fun = self.create_env_fn[idx]
-                if not isinstance(env_fun, (EnvCreator, CloudpickleWrapper)):
-                    env_fun = CloudpickleWrapper(env_fun)
+        metadata = None
 
-                kwargs[idx].update(
-                    {
-                        "parent_pipe": parent_pipe,
-                        "child_pipe": child_pipe,
-                        "env_fun": env_fun,
-                        "env_fun_kwargs": self.create_env_kwargs[idx],
-                        "has_lazy_inputs": self.has_lazy_inputs,
-                        "num_threads": num_sub_threads,
-                        "non_blocking": self.non_blocking,
-                        "filter_warnings": self._filter_warnings_subprocess(),
-                    }
-                )
-                if self._use_buffers:
+        def _terminate_started_workers() -> None:
+            for proc in self._workers:
+                if proc.is_alive():
+                    proc.terminate()
+            for proc in self._workers:
+                proc.join()
+            for channel in self.parent_channels:
+                channel.close()
+            self.is_closed = True
+
+        try:
+            with clear_mpi_env_vars():
+                for idx in range(_num_workers):
+                    if self._verbose:
+                        torchrl_logger.info(f"initiating worker {idx}")
+                    # No certainty which module multiprocessing_context is
+                    parent_pipe, child_pipe = ctx.Pipe()
+                    env_fun = self.create_env_fn[idx]
+                    if not isinstance(env_fun, (EnvCreator, CloudpickleWrapper)):
+                        env_fun = CloudpickleWrapper(env_fun)
+
                     kwargs[idx].update(
                         {
-                            "shared_tensordict": self.shared_tensordicts[idx],
-                            "_selected_input_keys": self._selected_input_keys,
-                            "_selected_reset_keys": self._selected_reset_keys,
-                            "_selected_step_keys": self._selected_step_keys,
-                            "_non_tensor_keys": self._non_tensor_keys,
+                            "parent_pipe": parent_pipe,
+                            "child_pipe": child_pipe,
+                            "env_fun": env_fun,
+                            "env_fun_kwargs": self.create_env_kwargs[idx],
+                            "has_lazy_inputs": self.has_lazy_inputs,
+                            "num_threads": num_sub_threads,
+                            "non_blocking": self.non_blocking,
+                            "filter_warnings": self._filter_warnings_subprocess(),
                         }
                     )
-                else:
-                    kwargs[idx].update(
-                        {
-                            "consolidate": self.consolidate,
-                        }
-                    )
-                process = proc_fun(target=func, kwargs=kwargs[idx])
-                process.daemon = self.daemon
-                process.start()
-                child_pipe.close()
-                self.parent_channels.append(parent_pipe)
-                self._workers.append(process)
+                    if self._use_buffers:
+                        kwargs[idx].update(
+                            {
+                                "shared_tensordict": self.shared_tensordicts[idx],
+                                "_selected_input_keys": self._selected_input_keys,
+                                "_selected_reset_keys": self._selected_reset_keys,
+                                "_selected_step_keys": self._selected_step_keys,
+                                "_non_tensor_keys": self._non_tensor_keys,
+                            }
+                        )
+                    else:
+                        kwargs[idx].update(
+                            {
+                                "consolidate": self.consolidate,
+                            }
+                        )
+                    process = proc_fun(target=func, kwargs=kwargs[idx])
+                    process.daemon = self.daemon
+                    process.start()
+                    child_pipe.close()
+                    self.parent_channels.append(parent_pipe)
+                    self._workers.append(process)
 
-        for parent_pipe in self.parent_channels:
-            # use msg as sync point
-            parent_pipe.recv()
+            for parent_pipe in self.parent_channels:
+                # use msg as sync point
+                parent_pipe.recv()
 
-        # send shared tensordict to workers
-        for channel in self.parent_channels:
-            channel.send(("init", None))
-        self.is_closed = False
-        self.set_spec_lock_()
+            if gather_metadata:
+                for channel in self.parent_channels:
+                    channel.send(("get_metadata", None))
+                pipes_pending = {
+                    channel: idx for idx, channel in enumerate(self.parent_channels)
+                }
+                t0 = time.time()
+                while pipes_pending:
+                    remaining = self.BATCHED_PIPE_TIMEOUT - (time.time() - t0)
+                    if remaining <= 0:
+                        raise RuntimeError(
+                            "Failed to collect worker metadata within the "
+                            f"{self.BATCHED_PIPE_TIMEOUT} sec time limit. This "
+                            "threshold can be increased via the BATCHED_PIPE_TIMEOUT "
+                            "env variable."
+                        )
+                    ready = connection_wait(list(pipes_pending), timeout=remaining)
+                    if not ready:
+                        for worker_idx in pipes_pending.values():
+                            if not self._workers[worker_idx].is_alive():
+                                raise RuntimeError(
+                                    "Cannot collect metadata, worker "
+                                    f"{worker_idx} is dead."
+                                )
+                        continue
+                    for pipe in ready:
+                        pipes_pending.pop(pipe)
+                metadata = []
+                for idx, channel in enumerate(self.parent_channels):
+                    msg, result = channel.recv()
+                    if msg == "metadata_error":
+                        raise RuntimeError(
+                            f"Failed to collect metadata from worker {idx}: {result}"
+                        )
+                    if msg != "metadata":
+                        raise RuntimeError(
+                            f"Expected 'metadata' from worker {idx}, got {msg!r}."
+                        )
+                    metadata.append(result)
+
+            # send shared tensordict to workers
+            for channel in self.parent_channels:
+                channel.send(("init", None))
+            self.is_closed = False
+            self.set_spec_lock_()
+        except Exception:
+            _terminate_started_workers()
+            raise
+        return metadata
 
     def _filter_warnings_subprocess(self) -> bool:
         from torchrl import filter_warnings_subprocess
@@ -3212,6 +3307,16 @@ def _run_worker_pipe_shared_mem(
 
             initialized = True
 
+        elif cmd == "get_metadata":
+            try:
+                BatchedEnvBase._validate_worker_env(env)
+                metadata = EnvMetaData.metadata_from_env(env)
+            except Exception as err:
+                child_pipe.send(("metadata_error", repr(err)))
+            else:
+                child_pipe.send(("metadata", metadata))
+                del metadata
+
         elif cmd == "reset":
             if verbose:
                 torchrl_logger.info(f"resetting worker {pid}")
@@ -3509,6 +3614,16 @@ def _run_worker_pipe_direct(
             i = 0
 
             initialized = True
+
+        elif cmd == "get_metadata":
+            try:
+                BatchedEnvBase._validate_worker_env(env)
+                metadata = EnvMetaData.metadata_from_env(env)
+            except Exception as err:
+                child_pipe.send(("metadata_error", repr(err)))
+            else:
+                child_pipe.send(("metadata", metadata))
+                del metadata
 
         elif cmd == "reset":
             if verbose:

--- a/torchrl/envs/env_creator.py
+++ b/torchrl/envs/env_creator.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from collections.abc import Callable
+from contextlib import suppress
 from multiprocessing.sharedctypes import Synchronized
 from multiprocessing.synchronize import Lock, RLock
 
@@ -260,9 +261,13 @@ def get_env_metadata(
         if kwargs is None:
             kwargs = {}
         env = env_or_creator(**kwargs)
-        if env_validator is not None:
-            env_validator(env)
-        return EnvMetaData.metadata_from_env(env)
+        try:
+            if env_validator is not None:
+                env_validator(env)
+            return EnvMetaData.metadata_from_env(env)
+        finally:
+            with suppress(Exception):
+                env.close()
     elif isinstance(env_or_creator, EnvCreator):
         if not (
             kwargs == env_or_creator.create_env_kwargs

--- a/torchrl/envs/transforms/_action.py
+++ b/torchrl/envs/transforms/_action.py
@@ -834,10 +834,14 @@ class MultiAction(Transform):
                 a = a[global_idx]
             td = td.replace(a)
             td = parent.step(td)
+            # Keep the latest executed reward at the root. If a chunk ends
+            # early, the final outer step is skipped and EnvBase copies root
+            # leaves into ``next``; without this, stack_rewards=False would
+            # drop a terminal reward emitted before the final action slot.
+            reward_td = td["next"].select(*self.parent.reward_keys)
 
             # Save rewards and done states
             if self.stack_rewards:
-                reward_td = td["next"].select(*self.parent.reward_keys)
                 if global_idx is not None:
                     reward_td_expand = reward_td.new_zeros(
                         global_idx.shape + reward_td.shape[global_idx.ndim :]
@@ -855,8 +859,7 @@ class MultiAction(Transform):
                 obs.append(obs_td)
 
             td = parent.step_mdp(td)
-            if self.stack_rewards:
-                td.update(reward_td)
+            td.update(reward_td)
 
             any_done = parent.any_done(td)
             if any_done:

--- a/torchrl/objectives/llm/grpo.py
+++ b/torchrl/objectives/llm/grpo.py
@@ -1447,6 +1447,7 @@ class MCAdvantage(Transform):
         if self.trajectory_return is not None:
             reward = tensordict.get(self.rewards_key, None)
         if reward is not None:
+            reward = reward.to(torch.get_default_dtype())
             trajectory_return = float(reward.sum())
             self.trajectory_return_sum += trajectory_return
             self.trajectory_return_max = max(
@@ -1498,6 +1499,7 @@ class MCAdvantage(Transform):
             return tds
 
     def _trajectory_returns(self, rewards: list[torch.Tensor]) -> torch.Tensor:
+        rewards = [reward.to(torch.get_default_dtype()) for reward in rewards]
         if self.trajectory_return == "sum":
             return torch.stack([reward.sum() for reward in rewards])
         if self.trajectory_return == "max":


### PR DESCRIPTION
## Summary
- Fix VLA chunk reward propagation so early terminal success inside a `MultiAction(stack_rewards=False)` chunk is preserved as the outer transition reward.
- Keep GRPO advantages on `("next", "reward")` with summed trajectory returns and mixed-group filtering for useful updates.
- Add the LIBERO OpenVLA-OFT token recipe using the `Haozhan72/Openvla-oft-SFT-libero-spatial-trajall` checkpoint, candidate oversampling, process inference-server collection, bounded video eval, and SOTA recipe/smoke coverage.
- Reduce LIBERO startup overhead by using homogeneous `ParallelEnv` factories with per-worker kwargs, closing temporary metadata envs, and adding optional worker-originated metadata collection.

## Validation
- `pytest -q sota-implementations/vla_grpo/test_openvla.py` (`46 passed, 1 skipped`)
- `pytest -q test/transforms/test_action_transforms.py -k stack_rewards_false_done_mid_chunk_keeps_terminal_reward`
- `pytest -q test/envs/test_parallel.py -k 'get_env_metadata_closes_callable_env or metadata_from_workers'`
- `pytest -q .github/unittest/linux_sota/scripts/test_sota.py -k recipe`
- `python -m py_compile sota-implementations/vla_grpo/vla-grpo.py sota-implementations/vla_grpo/utils.py sota-implementations/vla_grpo/smoke.py`

## Current scale-run status
A full 8-GPU LIBERO-Spatial run is active with async 500-episode scalar eval plus bounded video eval. The PR is draft until the scale run produces collection/update curves and the final command/log evidence is attached.
