### PR TITLE
[BugFix] Do not inject transport kwarg outside a transport context

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -29,7 +29,11 @@ from torchrl import (
 )
 from torchrl._comm.backends import _get_service_backend, _get_transport_backend
 from torchrl._utils import _rng_decorator, as_remote, get_binary_env_var, implement_for
-from torchrl.data import ReplayBuffer
+from torchrl.data import (
+    PrioritizedReplayBuffer,
+    ReplayBuffer,
+    TensorDictPrioritizedReplayBuffer,
+)
 from torchrl.envs.libs.gym import gym_backend, GymWrapper, set_gym_backend
 
 from torchrl.objectives.utils import _pseudo_vmap
@@ -116,6 +120,37 @@ def test_context_selected_backend_errors_report_the_context():
             ValueError, match="enclosing torchrl.transport_backend context"
         ):
             ReplayBuffer()
+
+
+@pytest.mark.parametrize(
+    "buffer_cls", [PrioritizedReplayBuffer, TensorDictPrioritizedReplayBuffer]
+)
+def test_transport_default_is_not_injected_into_constructors(buffer_cls):
+    # Regression test: the service metaclass used to inject transport="auto"
+    # into every construction, breaking subclasses whose __init__ did not
+    # accept the keyword (e.g. PrioritizedReplayBuffer(alpha=..., beta=...)).
+    replay = buffer_cls(alpha=1.1, beta=1.1)
+    try:
+        assert replay.service_backend == "direct"
+    finally:
+        replay.shutdown()
+
+
+@pytest.mark.parametrize(
+    "buffer_cls", [PrioritizedReplayBuffer, TensorDictPrioritizedReplayBuffer]
+)
+def test_prioritized_buffers_accept_transport_kwargs(buffer_cls):
+    replay = buffer_cls(alpha=1.1, beta=1.1, transport="auto")
+    try:
+        assert replay.service_backend == "direct"
+    finally:
+        replay.shutdown()
+
+    with transport_backend("distributed"):
+        with pytest.raises(
+            ValueError, match="enclosing torchrl.transport_backend context"
+        ):
+            buffer_cls(alpha=1.1, beta=1.1)
 
 
 def _clear_gym_implement_for_state():

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -37,7 +37,6 @@ from torchrl._comm.backends import (
     _get_service_backend,
     _get_transport_backend,
     _resolve_service_backend,
-    _resolve_transport_backend,
 )
 
 try:
@@ -1620,11 +1619,17 @@ class _RayServiceMetaClass(type):
         options = dict(service_backend_options or {})
 
         transport_backend_from_context = False
-        if getattr(cls, "_accepts_transport_backend", False):
-            transport = kwargs.get("transport")
-            if transport is None:
-                transport_backend_from_context = _get_transport_backend() is not None
-                kwargs["transport"] = _resolve_transport_backend(None, default="auto")
+        if (
+            getattr(cls, "_accepts_transport_backend", False)
+            and kwargs.get("transport") is None
+        ):
+            # Only inject the scoped default: not every subclass accepts a
+            # ``transport`` keyword, and absent any context the constructor
+            # default is equivalent.
+            contextual_transport = _get_transport_backend()
+            if contextual_transport is not None:
+                transport_backend_from_context = True
+                kwargs["transport"] = contextual_transport
 
         def construct(factory):
             try:

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -1917,6 +1917,12 @@ class PrioritizedReplayBuffer(ReplayBuffer):
             particularly when using transforms with modules that require gradients.
             If not specified, defaults to ``True`` when ``transform_factory`` is provided,
             and ``False`` otherwise.
+        transport (str, optional): physical transport used by a remote replay
+            owner. ``"auto"`` selects the backend default. Defaults to
+            ``"auto"``.
+        transport_options (dict, optional): options for the selected transport.
+            For ``transport="distributed"``, ``backend`` selects ``"gloo"``
+            or ``"nccl"``. TensorDict layouts are bound lazily on first use.
 
     .. note::
         Generic prioritized replay buffers (ie. non-tensordict backed) require
@@ -1972,6 +1978,8 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         batch_size: int | None = None,
         dim_extend: int | None = None,
         delayed_init: bool = False,
+        transport: Literal["auto", "direct", "ray", "distributed"] = "auto",
+        transport_options: dict[str, Any] | None = None,
     ) -> None:
         if storage is None:
             storage = ListStorage(max_size=1_000)
@@ -2006,6 +2014,8 @@ class PrioritizedReplayBuffer(ReplayBuffer):
             batch_size=batch_size,
             dim_extend=dim_extend,
             delayed_init=delayed_init,
+            transport=transport,
+            transport_options=transport_options,
         )
 
     @property
@@ -2599,6 +2609,12 @@ class TensorDictPrioritizedReplayBuffer(TensorDictReplayBuffer):
             particularly when using transforms with modules that require gradients.
             If not specified, defaults to ``True`` when ``transform_factory`` is provided,
             and ``False`` otherwise.
+        transport (str, optional): physical transport used by a remote replay
+            owner. ``"auto"`` selects the backend default. Defaults to
+            ``"auto"``.
+        transport_options (dict, optional): options for the selected transport.
+            For ``transport="distributed"``, ``backend`` selects ``"gloo"``
+            or ``"nccl"``. TensorDict layouts are bound lazily on first use.
 
     Examples:
         >>> import torch
@@ -2677,6 +2693,8 @@ class TensorDictPrioritizedReplayBuffer(TensorDictReplayBuffer):
         generator: torch.Generator | None = None,
         shared: bool = False,
         compilable: bool = False,
+        transport: Literal["auto", "direct", "ray", "distributed"] = "auto",
+        transport_options: dict[str, Any] | None = None,
     ) -> None:
         storage = self._maybe_make_storage(storage, compilable=compilable)
         self._sync = sync
@@ -2713,6 +2731,8 @@ class TensorDictPrioritizedReplayBuffer(TensorDictReplayBuffer):
             generator=generator,
             shared=shared,
             compilable=compilable,
+            transport=transport,
+            transport_options=transport_options,
         )
 
     @property


### PR DESCRIPTION
## Summary
- stop the service metaclass from injecting `transport="auto"` into constructors when no `transport_backend` context is active
- add `transport`/`transport_options` kwargs to `PrioritizedReplayBuffer` and `TensorDictPrioritizedReplayBuffer` for parity with `ReplayBuffer`
- add regression tests next to the existing backend-context tests

## Root cause
Since #4022, `_RayServiceMetaClass.__call__` injected `kwargs["transport"] = "auto"` into every construction of a class carrying `_accepts_transport_backend`. Subclasses whose `__init__` has a closed keyword list (`PrioritizedReplayBuffer`, `TensorDictPrioritizedReplayBuffer`, several dataset buffers) crashed with `TypeError: __init__() got an unexpected keyword argument 'transport'` on plain construction. This failed `test/smoke_test.py::test_imports` and with it every wheel-test and tests-cpu job on all PRs.

The injection is only meaningful when a scoped `transport_backend` context provides a value; absent a context, the constructor default is equivalent, so the metaclass now leaves kwargs untouched. Contextual validation errors keep reporting the enclosing context, including for the prioritized buffers now that they accept the kwarg.

## Validation
- `uv run pytest test/smoke_test.py -q` (previously failing)
- `uv run pytest test/test_utils.py -q`
- `uv run pytest test/rb/test_prioritized.py -q`
- `./scripts/check-docstring-args` and pinned ufmt on the touched files

Generated with [Claude Code](https://claude.com/claude-code)