### PR TITLE
[Test] Add off-policy data-parallel learning suite

### DIFF
--- a/sota-implementations/offpolicy-dp/README.md
+++ b/sota-implementations/offpolicy-dp/README.md
@@ -12,7 +12,7 @@ have shape `[N]`. Grouped sequence replay is not inferred from rollout shape;
 sequence-aware workloads must configure and validate it explicitly.
 
 Two asynchronous evaluators periodically load an exact learner-weight snapshot.
-The metric evaluator runs benchmark-correct deterministic episodes without
+The metric evaluator runs termination-aware deterministic episodes without
 rendering. A separate single-environment diagnostic rollout records
 `evaluation/video` to W&B; for locomotion tasks it continues until the configured
 video horizon after the agent becomes unhealthy, rather than producing a
@@ -26,6 +26,13 @@ The continuous environment is selected by `algorithm.environment_name`. The
 complex Humanoid task while retaining flat transition replay and the same
 Ray/Gloo/NCCL topology.
 
+Collection remains stochastic after replay prefill. SAC samples its policy,
+TD3 and DDPG apply persistent Gaussian action noise, and DQN retains nonzero
+epsilon-greedy exploration. Evaluation always uses the policy without the DDPG
+or TD3 exploration module. Replay samples log action mean, standard deviation,
+absolute maximum, and saturation fraction so a deterministic or saturated
+collector policy is visible during a run.
+
 The scale profile keeps Ray as the replay owner and uses the stack's distributed
 Gloo tensor transport for collector inserts and learner samples. This avoids
 serializing 25,000-transition GPU-collector batches through Ray pickle while
@@ -34,10 +41,24 @@ retaining the same replay service and ownership topology.
 The continuous scale profile uses four GPU collector actors. Each actor owns a
 compiled `mujoco-torch` Hopper environment with 25,000 parallel environments.
 Four additional GPU actors form the NCCL learner group, giving 100,000 total
-environments and four learner ranks on an eight-GPU node. The continuous runs
-collect 20 million frames, warm up with one million random frames, retain five
-million transitions, and use a global batch size of 4,096. Each approximately
-100,000-transition aggregate collection batch triggers 100 learner steps.
+environments and four learner ranks on an eight-GPU node.
+
+The learning-scale profiles collect 200 million transitions, or 2,000 policy
+decisions per environment. They do not use a separate random-action phase.
+Instead, the stochastic collection policy fills replay with ten million
+transitions (100 decisions per environment) before optimization starts. This
+separates learner startup from action selection and avoids distributed random
+warmup accounting against a shared replay write counter. Requiring a full
+1,000-step trajectory from every environment would delay learning until 100
+million transitions, so the prefill deliberately targets early terminations
+while persistent exploration continues throughout training.
+
+Scale replay retains the most recent 20 million transitions. A global batch of
+16,384 gives each learner rank 4,096 samples, and 25 optimizer steps per roughly
+100,000 collected frames preserve a sample update-to-data ratio of 4.096 while
+reducing small-batch synchronization overhead. Metric evaluation uses 64
+episodes of up to 1,000 steps every ten million frames; video is recorded every
+20 million frames.
 
 ## Installation
 
@@ -67,8 +88,8 @@ python sota-implementations/offpolicy-dp/train.py \
   algorithm=sac profile=smoke_continuous
 ```
 
-Run a 100,000-environment continuous validation by choosing `sac`, `ddpg`, or
-`td3`:
+Run a 100,000-environment, 200-million-transition continuous experiment by
+choosing `sac`, `ddpg`, or `td3`:
 
 ```bash
 python sota-implementations/offpolicy-dp/train.py \
@@ -86,7 +107,10 @@ python sota-implementations/offpolicy-dp/train.py \
 
 The Humanoid profiles use `frame_skip=1` so health termination is checked after
 every physics step. This prevents an unstable state in a 25,000-environment
-collector batch from advancing through a five-substep action before reset.
+collector batch from advancing through a five-substep action before reset. The
+scale run is lengthened to 2,000 decisions per environment to compensate for
+the finer control interval; it is not directly comparable to the standard
+five-substep Humanoid benchmark.
 
 Hydra overrides can reduce or expand any resource or training setting. Runtime
 summaries and Hydra output are written under `/root/artifacts/offpolicy-dp`.
@@ -111,7 +135,8 @@ metric becomes non-finite, the learner's published model version differs from
 its optimization count, or sampled replay data never observes an updated
 policy version. W&B additionally records collection and optimization
 throughput, replay activity, policy-version statistics, and terminal returns
-sampled from replay.
+sampled from replay. Continuous runs also record replay action dispersion and
+saturation to verify that the collection policy remains stochastic.
 
 Learner metrics are logged with slash-delimited namespaces. W&B therefore
 places losses under `loss`, predicted and target values under `value`, gradient

--- a/sota-implementations/offpolicy-dp/README.md
+++ b/sota-implementations/offpolicy-dp/README.md
@@ -1,0 +1,115 @@
+# Off-policy data-parallel validation
+
+This suite validates TorchRL's Ray-owned replay, asynchronous collection,
+multi-rank learner execution, and direct learner-to-collector weight publication
+for DQN, SAC, DDPG, and TD3.
+
+All four algorithms use transition replay. Each inner Ray collector installs a
+postprocessor through `collector_kwargs` that materializes and flattens `[B, T]`
+rollouts to `[B * T]` before direct insertion. The suite asserts that replay
+`write_count` equals the collector's transition count and that sampled batches
+have shape `[N]`. Grouped sequence replay is not inferred from rollout shape;
+sequence-aware workloads must configure and validate it explicitly.
+
+Two asynchronous evaluators periodically load an exact learner-weight snapshot.
+The metric evaluator runs benchmark-correct deterministic episodes without
+rendering. A separate single-environment diagnostic rollout records
+`evaluation/video` to W&B; for locomotion tasks it continues until the configured
+video horizon after the agent becomes unhealthy, rather than producing a
+one-frame video when an early policy falls immediately. Rendering is kept out
+of the 100,000 training environments. Both evaluators default to
+`mujoco-torch` on `cuda:7`, avoiding the CPU physics bottleneck and unavailable
+headless EGL/OpenGL support.
+
+The continuous environment is selected by `algorithm.environment_name`. The
+`humanoid_smoke` and `humanoid_scale` profiles run the substantially more
+complex Humanoid task while retaining flat transition replay and the same
+Ray/Gloo/NCCL topology.
+
+The scale profile keeps Ray as the replay owner and uses the stack's distributed
+Gloo tensor transport for collector inserts and learner samples. This avoids
+serializing 25,000-transition GPU-collector batches through Ray pickle while
+retaining the same replay service and ownership topology.
+
+The continuous scale profile uses four GPU collector actors. Each actor owns a
+compiled `mujoco-torch` Hopper environment with 25,000 parallel environments.
+Four additional GPU actors form the NCCL learner group, giving 100,000 total
+environments and four learner ranks on an eight-GPU node. The continuous runs
+collect 20 million frames, warm up with one million random frames, retain five
+million transitions, and use a global batch size of 4,096. Each approximately
+100,000-transition aggregate collection batch triggers 100 learner steps.
+
+## Installation
+
+Install the experiment-only dependencies into the active environment:
+
+```bash
+uv pip install --python /root/venv/bin/python \
+  -r sota-implementations/offpolicy-dp/requirements.txt
+```
+
+Configure W&B before launching. Credentials are intentionally not read by the
+scripts and must never be stored in this directory.
+
+## Individual runs
+
+Run the planned 100,000-frame DQN validation:
+
+```bash
+python sota-implementations/offpolicy-dp/train.py \
+  algorithm=dqn profile=dqn
+```
+
+Run a reduced SAC smoke test:
+
+```bash
+python sota-implementations/offpolicy-dp/train.py \
+  algorithm=sac profile=smoke_continuous
+```
+
+Run a 100,000-environment continuous validation by choosing `sac`, `ddpg`, or
+`td3`:
+
+```bash
+python sota-implementations/offpolicy-dp/train.py \
+  algorithm=sac profile=scale
+```
+
+Run rendered Humanoid DDPG validation:
+
+```bash
+python sota-implementations/offpolicy-dp/train.py \
+  algorithm=ddpg profile=humanoid_smoke
+python sota-implementations/offpolicy-dp/train.py \
+  algorithm=ddpg profile=humanoid_scale
+```
+
+Hydra overrides can reduce or expand any resource or training setting. Runtime
+summaries and Hydra output are written under `/root/artifacts/offpolicy-dp`.
+
+## Suite launcher
+
+The launcher uses a fresh Python process for every algorithm so Ray resources
+are released between runs. It records all failures instead of stopping at the
+first one.
+
+```bash
+python sota-implementations/offpolicy-dp/run_suite.py --mode smoke
+python sota-implementations/offpolicy-dp/run_suite.py --mode full
+```
+
+The `all` mode runs reduced smokes first and then the planned full runs.
+
+## Success checks
+
+Every run fails if optimization never starts, replay writes stop early, a
+metric becomes non-finite, the learner's published model version differs from
+its optimization count, or sampled replay data never observes an updated
+policy version. W&B additionally records collection and optimization
+throughput, replay activity, policy-version statistics, and terminal returns
+sampled from replay.
+
+Learner metrics are logged with slash-delimited namespaces. W&B therefore
+places losses under `loss`, predicted and target values under `value`, gradient
+and step metrics under `optimization`, and entropy/temperature under `policy`,
+rather than leaving these histories in the generic Charts section.

--- a/sota-implementations/offpolicy-dp/README.md
+++ b/sota-implementations/offpolicy-dp/README.md
@@ -84,6 +84,10 @@ python sota-implementations/offpolicy-dp/train.py \
   algorithm=ddpg profile=humanoid_scale
 ```
 
+The Humanoid profiles use `frame_skip=1` so health termination is checked after
+every physics step. This prevents an unstable state in a 25,000-environment
+collector batch from advancing through a five-substep action before reset.
+
 Hydra overrides can reduce or expand any resource or training setting. Runtime
 summaries and Hydra output are written under `/root/artifacts/offpolicy-dp`.
 

--- a/sota-implementations/offpolicy-dp/config/algorithm/ddpg.yaml
+++ b/sota-implementations/offpolicy-dp/config/algorithm/ddpg.yaml
@@ -1,0 +1,7 @@
+name: ddpg
+environment_kind: mujoco
+environment_name: hopper
+learning_rate: 0.0003
+gamma: 0.99
+hidden_sizes: [256, 256]
+target_update_polyak: 0.995

--- a/sota-implementations/offpolicy-dp/config/algorithm/ddpg.yaml
+++ b/sota-implementations/offpolicy-dp/config/algorithm/ddpg.yaml
@@ -5,3 +5,6 @@ learning_rate: 0.0003
 gamma: 0.99
 hidden_sizes: [256, 256]
 target_update_polyak: 0.995
+# Keep collection stochastic throughout training. Evaluation uses the actor
+# without this module and remains deterministic.
+exploration_std: 0.2

--- a/sota-implementations/offpolicy-dp/config/algorithm/dqn.yaml
+++ b/sota-implementations/offpolicy-dp/config/algorithm/dqn.yaml
@@ -1,0 +1,10 @@
+name: dqn
+environment_kind: gym
+environment_name: CartPole-v1
+learning_rate: 0.0003
+gamma: 0.99
+hidden_sizes: [256, 256]
+target_update_interval: 100
+eps_init: 1.0
+eps_end: 0.05
+annealing_num_steps: 100_000

--- a/sota-implementations/offpolicy-dp/config/algorithm/sac.yaml
+++ b/sota-implementations/offpolicy-dp/config/algorithm/sac.yaml
@@ -1,0 +1,8 @@
+name: sac
+environment_kind: mujoco
+environment_name: hopper
+learning_rate: 0.0003
+gamma: 0.99
+hidden_sizes: [256, 256]
+alpha_init: 1.0
+target_update_polyak: 0.995

--- a/sota-implementations/offpolicy-dp/config/algorithm/td3.yaml
+++ b/sota-implementations/offpolicy-dp/config/algorithm/td3.yaml
@@ -1,0 +1,11 @@
+name: td3
+environment_kind: mujoco
+environment_name: hopper
+learning_rate: 0.0003
+gamma: 0.99
+hidden_sizes: [256, 256]
+target_update_polyak: 0.995
+policy_noise: 0.2
+noise_clip: 0.5
+exploration_std: 0.1
+policy_update_delay: 2

--- a/sota-implementations/offpolicy-dp/config/config.yaml
+++ b/sota-implementations/offpolicy-dp/config/config.yaml
@@ -1,0 +1,58 @@
+defaults:
+  - _self_
+  - algorithm: sac
+  - profile: scale
+
+seed: 42
+
+logging:
+  project: torchrl-dp-offpolicy-validation
+  group: dp-stack-main
+  mode: online
+  interval_frames: 100_000
+  sample_size: 8192
+  log_env_packages: true
+
+evaluation:
+  enabled: true
+  # Rendering stays in a single environment on one already-allocated device.
+  backend: mujoco-torch
+  device: cuda:7
+  compile_step: false
+  interval_frames: 2_000_000
+  num_envs: 16
+  num_trajectories: 16
+  max_steps: 100
+  shutdown_timeout: 600.0
+  video: true
+  # Keep scalar evaluation benchmark-correct. Video uses a single diagnostic
+  # rollout that continues after Hopper becomes unhealthy so it shows motion.
+  video_interval_frames: 2_000_000
+  video_num_envs: 1
+  video_num_trajectories: 1
+  video_max_steps: 100
+  render_width: 128
+  render_height: 128
+  video_skip: 2
+  video_fps: 15
+  video_max_frames: 50
+
+artifacts_dir: /root/artifacts/offpolicy-dp
+
+replay:
+  # These feed-forward off-policy algorithms store individual transitions.
+  # A sequence-aware workload must opt into and validate grouped storage itself.
+  storage_mode: transitions
+  transport_backend: gloo
+  transport_timeout: 1200.0
+
+ray:
+  include_dashboard: false
+  log_to_driver: true
+  ignore_reinit_error: true
+
+hydra:
+  job:
+    chdir: false
+  run:
+    dir: /root/artifacts/offpolicy-dp/hydra/${algorithm.name}-${now:%Y%m%d-%H%M%S}

--- a/sota-implementations/offpolicy-dp/config/config.yaml
+++ b/sota-implementations/offpolicy-dp/config/config.yaml
@@ -5,6 +5,11 @@ defaults:
 
 seed: 42
 
+environment:
+  # Use the task default unless a stability profile requests finer-grained
+  # termination checks between physics substeps.
+  frame_skip: null
+
 logging:
   project: torchrl-dp-offpolicy-validation
   group: dp-stack-main
@@ -19,6 +24,7 @@ evaluation:
   backend: mujoco-torch
   device: cuda:7
   compile_step: false
+  frame_skip: null
   interval_frames: 2_000_000
   num_envs: 16
   num_trajectories: 16

--- a/sota-implementations/offpolicy-dp/config/profile/dqn.yaml
+++ b/sota-implementations/offpolicy-dp/config/profile/dqn.yaml
@@ -1,0 +1,41 @@
+# @package _global_
+
+environment:
+  backend: gym
+  total_num_envs: 2
+  num_collectors: 2
+  compile_step: false
+  compile_mode: null
+  max_episode_steps: 500
+
+collection:
+  total_frames: 100_000
+  init_random_frames: 10_000
+  frames_per_env: 1_024
+
+replay:
+  capacity: 100_000
+  batch_size: 512
+  num_cpus: 1
+  transport: auto
+
+learner:
+  world_size: 2
+  num_cpus_per_rank: 1
+  num_gpus_per_rank: 1
+  backend: nccl
+  optim_steps_per_batch: 1
+  poll_interval: 0.05
+  setup_timeout: 300.0
+  command_timeout: 600.0
+
+logging:
+  interval_frames: 10_000
+
+evaluation:
+  device: cpu
+  num_envs: 1
+  num_trajectories: 1
+  interval_frames: 25_000
+  max_steps: 500
+  video_max_frames: 250

--- a/sota-implementations/offpolicy-dp/config/profile/dqn.yaml
+++ b/sota-implementations/offpolicy-dp/config/profile/dqn.yaml
@@ -10,7 +10,10 @@ environment:
 
 collection:
   total_frames: 100_000
-  init_random_frames: 10_000
+  # Epsilon starts at one, so replay prefill is already random without a
+  # separate collector-level random-action phase.
+  init_random_frames: 0
+  learning_starts: 10_000
   frames_per_env: 1_024
 
 replay:

--- a/sota-implementations/offpolicy-dp/config/profile/humanoid_scale.yaml
+++ b/sota-implementations/offpolicy-dp/config/profile/humanoid_scale.yaml
@@ -1,0 +1,48 @@
+# @package _global_
+
+algorithm:
+  environment_name: humanoid
+
+environment:
+  backend: mujoco-torch
+  total_num_envs: 100_000
+  num_collectors: 4
+  compile_step: true
+  compile_mode: default
+  max_episode_steps: 1_000
+
+collection:
+  total_frames: 20_000_000
+  init_random_frames: 1_000_000
+  frames_per_env: 1
+
+replay:
+  capacity: 5_000_000
+  batch_size: 4_096
+  num_cpus: 2
+  transport: distributed
+
+learner:
+  world_size: 4
+  num_cpus_per_rank: 1
+  num_gpus_per_rank: 1
+  backend: nccl
+  optim_steps_per_batch: 100
+  poll_interval: 0.05
+  setup_timeout: 600.0
+  command_timeout: 1_200.0
+
+logging:
+  interval_frames: 100_000
+  sample_size: 1_024
+
+evaluation:
+  interval_frames: 2_000_000
+  num_envs: 16
+  num_trajectories: 16
+  max_steps: 250
+  video_interval_frames: 2_000_000
+  video_num_envs: 1
+  video_num_trajectories: 1
+  video_max_steps: 250
+  video_max_frames: 125

--- a/sota-implementations/offpolicy-dp/config/profile/humanoid_scale.yaml
+++ b/sota-implementations/offpolicy-dp/config/profile/humanoid_scale.yaml
@@ -15,13 +15,18 @@ environment:
   max_episode_steps: 1_000
 
 collection:
-  total_frames: 20_000_000
-  init_random_frames: 1_000_000
+  # At 100K environments this provides 2K decisions per environment instead
+  # of the 200-decision transport validation run.
+  total_frames: 200_000_000
+  init_random_frames: 0
+  # Collect 100 noisy-policy decisions per environment before learning. A full
+  # 1K-step prefill would cost 100M transitions before the first update.
+  learning_starts: 10_000_000
   frames_per_env: 1
 
 replay:
-  capacity: 5_000_000
-  batch_size: 4_096
+  capacity: 20_000_000
+  batch_size: 16_384
   num_cpus: 2
   transport: distributed
 
@@ -30,23 +35,24 @@ learner:
   num_cpus_per_rank: 1
   num_gpus_per_rank: 1
   backend: nccl
-  optim_steps_per_batch: 100
+  # 25 * 16384 / 100000 = 4.096 sampled transitions per collected transition.
+  optim_steps_per_batch: 25
   poll_interval: 0.05
   setup_timeout: 600.0
   command_timeout: 1_200.0
 
 logging:
-  interval_frames: 100_000
-  sample_size: 1_024
+  interval_frames: 1_000_000
+  sample_size: 4_096
 
 evaluation:
   frame_skip: 1
-  interval_frames: 2_000_000
-  num_envs: 16
-  num_trajectories: 16
-  max_steps: 250
-  video_interval_frames: 2_000_000
+  interval_frames: 10_000_000
+  num_envs: 64
+  num_trajectories: 64
+  max_steps: 1_000
+  video_interval_frames: 20_000_000
   video_num_envs: 1
   video_num_trajectories: 1
-  video_max_steps: 250
-  video_max_frames: 125
+  video_max_steps: 1_000
+  video_max_frames: 500

--- a/sota-implementations/offpolicy-dp/config/profile/humanoid_scale.yaml
+++ b/sota-implementations/offpolicy-dp/config/profile/humanoid_scale.yaml
@@ -9,6 +9,9 @@ environment:
   num_collectors: 4
   compile_step: true
   compile_mode: default
+  # Check health and reset after every physics step. With 25K environments per
+  # collector, a five-substep action eventually exposes unstable solver state.
+  frame_skip: 1
   max_episode_steps: 1_000
 
 collection:
@@ -37,6 +40,7 @@ logging:
   sample_size: 1_024
 
 evaluation:
+  frame_skip: 1
   interval_frames: 2_000_000
   num_envs: 16
   num_trajectories: 16

--- a/sota-implementations/offpolicy-dp/config/profile/humanoid_smoke.yaml
+++ b/sota-implementations/offpolicy-dp/config/profile/humanoid_smoke.yaml
@@ -1,0 +1,49 @@
+# @package _global_
+
+algorithm:
+  environment_name: humanoid
+
+environment:
+  backend: mujoco-torch
+  total_num_envs: 8_192
+  num_collectors: 2
+  compile_step: true
+  compile_mode: default
+  max_episode_steps: 1_000
+
+collection:
+  total_frames: 262_144
+  init_random_frames: 65_536
+  frames_per_env: 1
+
+replay:
+  capacity: 524_288
+  batch_size: 1_024
+  num_cpus: 1
+  transport: distributed
+
+learner:
+  world_size: 2
+  num_cpus_per_rank: 1
+  num_gpus_per_rank: 1
+  backend: nccl
+  optim_steps_per_batch: 10
+  poll_interval: 0.05
+  setup_timeout: 600.0
+  command_timeout: 1_200.0
+
+logging:
+  interval_frames: 32_768
+  # Distributed replay binds the per-rank schema to 1024 / 2.
+  sample_size: 512
+
+evaluation:
+  interval_frames: 65_536
+  num_envs: 8
+  num_trajectories: 8
+  max_steps: 250
+  video_interval_frames: 65_536
+  video_num_envs: 1
+  video_num_trajectories: 1
+  video_max_steps: 250
+  video_max_frames: 125

--- a/sota-implementations/offpolicy-dp/config/profile/humanoid_smoke.yaml
+++ b/sota-implementations/offpolicy-dp/config/profile/humanoid_smoke.yaml
@@ -9,6 +9,9 @@ environment:
   num_collectors: 2
   compile_step: true
   compile_mode: default
+  # Check health and reset after every physics step. With large batches, a
+  # five-substep action can let one unstable state reach the solver first.
+  frame_skip: 1
   max_episode_steps: 1_000
 
 collection:
@@ -38,6 +41,7 @@ logging:
   sample_size: 512
 
 evaluation:
+  frame_skip: 1
   interval_frames: 65_536
   num_envs: 8
   num_trajectories: 8

--- a/sota-implementations/offpolicy-dp/config/profile/humanoid_smoke.yaml
+++ b/sota-implementations/offpolicy-dp/config/profile/humanoid_smoke.yaml
@@ -16,7 +16,8 @@ environment:
 
 collection:
   total_frames: 262_144
-  init_random_frames: 65_536
+  init_random_frames: 0
+  learning_starts: 65_536
   frames_per_env: 1
 
 replay:

--- a/sota-implementations/offpolicy-dp/config/profile/scale.yaml
+++ b/sota-implementations/offpolicy-dp/config/profile/scale.yaml
@@ -9,13 +9,23 @@ environment:
   max_episode_steps: 1000
 
 collection:
-  total_frames: 20_000_000
-  init_random_frames: 1_000_000
+  # Two thousand decisions per environment gives the stream enough temporal
+  # depth for learning while preserving 100K-way collection.
+  total_frames: 200_000_000
+  # SAC is stochastic, TD3/DDPG add action noise, and DQN is epsilon-greedy.
+  # Avoid a separate random-only phase whose accounting is ambiguous with a
+  # shared direct replay service.
+  init_random_frames: 0
+  # Prefill with 100 stochastic-policy decisions per environment before the
+  # first learner step. This is replay fill, not random-action warmup.
+  learning_starts: 10_000_000
   frames_per_env: 1
 
 replay:
-  capacity: 5_000_000
-  batch_size: 4096
+  capacity: 20_000_000
+  # A 4K batch per learner rank uses the H200s more efficiently. Twenty-five
+  # steps per 100K collected frames preserves the previous 4.096 sample UTD.
+  batch_size: 16_384
   num_cpus: 2
   transport: distributed
 
@@ -24,11 +34,21 @@ learner:
   num_cpus_per_rank: 1
   num_gpus_per_rank: 1
   backend: nccl
-  optim_steps_per_batch: 100
+  optim_steps_per_batch: 25
   poll_interval: 0.05
   setup_timeout: 600.0
   command_timeout: 1200.0
 
 logging:
-  # Distributed replay binds a fixed per-rank sample schema: 4096 / 4.
-  sample_size: 1024
+  interval_frames: 1_000_000
+  # Distributed replay binds a fixed per-rank sample schema: 16384 / 4.
+  sample_size: 4_096
+
+evaluation:
+  interval_frames: 10_000_000
+  num_envs: 64
+  num_trajectories: 64
+  max_steps: 1_000
+  video_interval_frames: 20_000_000
+  video_max_steps: 500
+  video_max_frames: 250

--- a/sota-implementations/offpolicy-dp/config/profile/scale.yaml
+++ b/sota-implementations/offpolicy-dp/config/profile/scale.yaml
@@ -1,0 +1,34 @@
+# @package _global_
+
+environment:
+  backend: mujoco-torch
+  total_num_envs: 100_000
+  num_collectors: 4
+  compile_step: true
+  compile_mode: default
+  max_episode_steps: 1000
+
+collection:
+  total_frames: 20_000_000
+  init_random_frames: 1_000_000
+  frames_per_env: 1
+
+replay:
+  capacity: 5_000_000
+  batch_size: 4096
+  num_cpus: 2
+  transport: distributed
+
+learner:
+  world_size: 4
+  num_cpus_per_rank: 1
+  num_gpus_per_rank: 1
+  backend: nccl
+  optim_steps_per_batch: 100
+  poll_interval: 0.05
+  setup_timeout: 600.0
+  command_timeout: 1200.0
+
+logging:
+  # Distributed replay binds a fixed per-rank sample schema: 4096 / 4.
+  sample_size: 1024

--- a/sota-implementations/offpolicy-dp/config/profile/smoke_continuous.yaml
+++ b/sota-implementations/offpolicy-dp/config/profile/smoke_continuous.yaml
@@ -10,7 +10,8 @@ environment:
 
 collection:
   total_frames: 32_768
-  init_random_frames: 4_096
+  init_random_frames: 0
+  learning_starts: 4_096
   frames_per_env: 2
 
 replay:

--- a/sota-implementations/offpolicy-dp/config/profile/smoke_continuous.yaml
+++ b/sota-implementations/offpolicy-dp/config/profile/smoke_continuous.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+
+environment:
+  backend: mujoco-torch
+  total_num_envs: 2048
+  num_collectors: 2
+  compile_step: true
+  compile_mode: default
+  max_episode_steps: 1000
+
+collection:
+  total_frames: 32_768
+  init_random_frames: 4_096
+  frames_per_env: 2
+
+replay:
+  capacity: 65_536
+  batch_size: 512
+  num_cpus: 1
+  transport: auto
+
+learner:
+  world_size: 2
+  num_cpus_per_rank: 1
+  num_gpus_per_rank: 1
+  backend: nccl
+  optim_steps_per_batch: 1
+  poll_interval: 0.05
+  setup_timeout: 300.0
+  command_timeout: 600.0
+
+logging:
+  interval_frames: 4_096
+
+evaluation:
+  interval_frames: 16_384
+  video_max_frames: 50

--- a/sota-implementations/offpolicy-dp/config/profile/smoke_dqn.yaml
+++ b/sota-implementations/offpolicy-dp/config/profile/smoke_dqn.yaml
@@ -10,7 +10,8 @@ environment:
 
 collection:
   total_frames: 4_096
-  init_random_frames: 512
+  init_random_frames: 0
+  learning_starts: 512
   frames_per_env: 256
 
 replay:

--- a/sota-implementations/offpolicy-dp/config/profile/smoke_dqn.yaml
+++ b/sota-implementations/offpolicy-dp/config/profile/smoke_dqn.yaml
@@ -1,0 +1,41 @@
+# @package _global_
+
+environment:
+  backend: gym
+  total_num_envs: 2
+  num_collectors: 2
+  compile_step: false
+  compile_mode: null
+  max_episode_steps: 500
+
+collection:
+  total_frames: 4_096
+  init_random_frames: 512
+  frames_per_env: 256
+
+replay:
+  capacity: 8_192
+  batch_size: 256
+  num_cpus: 1
+  transport: auto
+
+learner:
+  world_size: 2
+  num_cpus_per_rank: 1
+  num_gpus_per_rank: 1
+  backend: nccl
+  optim_steps_per_batch: 1
+  poll_interval: 0.05
+  setup_timeout: 300.0
+  command_timeout: 600.0
+
+logging:
+  interval_frames: 512
+
+evaluation:
+  device: cpu
+  num_envs: 1
+  num_trajectories: 1
+  interval_frames: 2_048
+  max_steps: 500
+  video_max_frames: 250

--- a/sota-implementations/offpolicy-dp/requirements.txt
+++ b/sota-implementations/offpolicy-dp/requirements.txt
@@ -1,0 +1,7 @@
+hydra-core>=1.3
+gymnasium>=1.0
+moviepy>=2.0
+mujoco-torch @ git+https://github.com/vmoens/mujoco-torch.git@main
+pygame>=2.6
+ray>=2.40
+wandb>=0.19

--- a/sota-implementations/offpolicy-dp/run_suite.py
+++ b/sota-implementations/offpolicy-dp/run_suite.py
@@ -1,0 +1,119 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Launch the off-policy DP validations sequentially in isolated processes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from torchrl._utils import logger as torchrl_logger
+
+
+@dataclass(frozen=True)
+class SuiteRun:
+    algorithm: str
+    profile: str
+
+
+SMOKE_RUNS = (
+    SuiteRun("dqn", "smoke_dqn"),
+    SuiteRun("sac", "smoke_continuous"),
+    SuiteRun("ddpg", "smoke_continuous"),
+    SuiteRun("td3", "smoke_continuous"),
+)
+
+FULL_RUNS = (
+    SuiteRun("dqn", "dqn"),
+    SuiteRun("sac", "scale"),
+    SuiteRun("ddpg", "scale"),
+    SuiteRun("td3", "scale"),
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        choices=("smoke", "full", "all"),
+        default="all",
+        help="Run reduced smokes, planned full runs, or both in that order.",
+    )
+    parser.add_argument(
+        "--algorithm",
+        action="append",
+        choices=("dqn", "sac", "ddpg", "td3"),
+        help="Limit the suite to one or more algorithms.",
+    )
+    parser.add_argument(
+        "--group",
+        default="dp-stack-main",
+        help="W&B group applied to every child run.",
+    )
+    parser.add_argument(
+        "--artifacts-dir",
+        default="/root/artifacts/offpolicy-dp",
+        help="Remote directory for suite and child summaries.",
+    )
+    return parser.parse_args()
+
+
+def _selected_runs(args: argparse.Namespace) -> list[SuiteRun]:
+    runs: list[SuiteRun] = []
+    if args.mode in ("smoke", "all"):
+        runs.extend(SMOKE_RUNS)
+    if args.mode in ("full", "all"):
+        runs.extend(FULL_RUNS)
+    if args.algorithm:
+        selected = set(args.algorithm)
+        runs = [run for run in runs if run.algorithm in selected]
+    return runs
+
+
+def main() -> int:
+    args = _parse_args()
+    script = Path(__file__).with_name("train.py")
+    results = []
+    for run in _selected_runs(args):
+        command = [
+            sys.executable,
+            str(script),
+            f"algorithm={run.algorithm}",
+            f"profile={run.profile}",
+            f"logging.group={args.group}",
+            f"artifacts_dir={args.artifacts_dir}",
+        ]
+        torchrl_logger.info(f"Starting {run.algorithm} with profile={run.profile}.")
+        completed = subprocess.run(command, check=False)
+        results.append(
+            {
+                **asdict(run),
+                "returncode": completed.returncode,
+                "status": "completed" if completed.returncode == 0 else "failed",
+            }
+        )
+    artifact_dir = Path(args.artifacts_dir)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    summary_path = artifact_dir / f"suite-{args.mode}-{timestamp}.json"
+    summary_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n")
+    torchrl_logger.info(f"Suite summary written to {summary_path}.")
+    failures = [result for result in results if result["returncode"]]
+    if failures:
+        torchrl_logger.error(
+            "Suite failures: "
+            + ", ".join(f"{item['algorithm']}[{item['profile']}]" for item in failures)
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sota-implementations/offpolicy-dp/train.py
+++ b/sota-implementations/offpolicy-dp/train.py
@@ -458,6 +458,15 @@ def _make_ddpg(cfg: DictConfig, proof_env: TransformedEnv) -> AlgorithmObjects:
     qvalue = _make_qvalue(observation_dim, action_dim, hidden_sizes)
     _materialize(actor, proof_env)
     _materialize(qvalue, proof_env)
+    exploration_module = AdditiveGaussianModule(
+        spec=action_spec,
+        sigma_init=1.0,
+        sigma_end=1.0,
+        mean=0.0,
+        std=float(cfg.algorithm.exploration_std),
+        safe=False,
+    )
+    policy = TensorDictSequential(actor, exploration_module)
     loss_module = DDPGLoss(
         actor_network=actor,
         value_network=qvalue,
@@ -473,12 +482,13 @@ def _make_ddpg(cfg: DictConfig, proof_env: TransformedEnv) -> AlgorithmObjects:
         loss_module, eps=float(cfg.algorithm.target_update_polyak)
     )
     return AlgorithmObjects(
-        policy=actor,
+        policy=policy,
         evaluation_policy=actor,
         loss_module=loss_module,
         optimizer=optimizer,
         target_updater=target_updater,
         trainer_cls=DDPGTrainer,
+        trainer_kwargs={"exploration_module": exploration_module},
     )
 
 
@@ -803,7 +813,7 @@ def _make_collector(
         "num_cpus": 1,
         "num_gpus": 1 if use_gpu else 0,
     }
-    return RayCollector(
+    collector = RayCollector(
         create_env_fn=_make_env_factories(cfg),
         policy=policy,
         replay_buffer=replay,
@@ -826,6 +836,13 @@ def _make_collector(
         ray_init_config=_ray_init_config(cfg),
         sync=False,
     )
+    # Random-only collection and replay prefill are separate concerns. The
+    # inner collectors receive init_random_frames above, while the controller
+    # uses this threshold to delay learning until stochastic-policy data has
+    # filled replay. This also avoids per-collector random-frame thresholds
+    # being compared against the shared replay write count.
+    collector.init_random_frames = int(cfg.collection.learning_starts)
+    return collector
 
 
 def _git_commit() -> str:
@@ -959,6 +976,15 @@ class RuntimeValidationHook:
             metrics["policy_version/sample_min"] = float(policy_version.min())
             metrics["policy_version/sample_max"] = float(policy_version.max())
             metrics["policy_version/sample_mean"] = float(policy_version.float().mean())
+        action = sample.get("action", None)
+        if action is not None and action.is_floating_point():
+            action = action.float()
+            metrics["exploration/action_mean"] = float(action.mean())
+            metrics["exploration/action_std"] = float(action.std())
+            metrics["exploration/action_abs_max"] = float(action.abs().max())
+            metrics["exploration/action_saturation_fraction"] = float(
+                (action.abs() >= 0.99).float().mean()
+            )
         done = sample.get(("next", "done"), None)
         episode_return = sample.get(("next", "episode_reward"), None)
         if done is not None and episode_return is not None:

--- a/sota-implementations/offpolicy-dp/train.py
+++ b/sota-implementations/offpolicy-dp/train.py
@@ -1,0 +1,1322 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Run an off-policy Trainer with Ray collection, replay, and DDP learners."""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import json
+import math
+import os
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import hydra
+import ray
+import torch
+import wandb
+from omegaconf import DictConfig, OmegaConf
+from tensordict import TensorDictBase
+from tensordict.nn import InteractionType, TensorDictModule, TensorDictSequential
+from tensordict.nn.distributions import NormalParamExtractor
+from torch import nn, optim
+
+from torchrl._utils import logger as torchrl_logger
+from torchrl.collectors import Collector, Evaluator
+from torchrl.collectors.distributed import RayCollector
+from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
+from torchrl.envs import (
+    Compose,
+    GymEnv,
+    HopperEnv,
+    HumanoidEnv,
+    InitTracker,
+    RewardSum,
+    TransformedEnv,
+)
+from torchrl.envs.utils import ExplorationType, set_exploration_type
+from torchrl.modules import (
+    AdditiveGaussianModule,
+    EGreedyModule,
+    MLP,
+    ProbabilisticActor,
+    QValueActor,
+    TanhModule,
+    ValueOperator,
+)
+from torchrl.modules.distributions import TanhNormal
+from torchrl.objectives import (
+    DDPGLoss,
+    DQNLoss,
+    HardUpdate,
+    SACLoss,
+    SoftUpdate,
+    TD3Loss,
+)
+from torchrl.objectives.common import LossModule
+from torchrl.objectives.utils import TargetNetUpdater
+from torchrl.record import VideoRecorder
+from torchrl.record.loggers import get_logger, Logger
+from torchrl.trainers import Trainer
+from torchrl.trainers.algorithms import DDPGTrainer, DQNTrainer, SACTrainer, TD3Trainer
+from torchrl.trainers.algorithms.td3 import TD3OptimizationStepper
+from torchrl.trainers.trainers import OptimizationStepper
+
+
+@dataclass
+class AlgorithmObjects:
+    """Objects whose connected parameter graph is copied to learner ranks."""
+
+    policy: nn.Module
+    evaluation_policy: nn.Module
+    loss_module: LossModule
+    optimizer: optim.Optimizer | None
+    target_updater: TargetNetUpdater
+    trainer_cls: type[Trainer]
+    optimization_stepper: OptimizationStepper | None = None
+    trainer_kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+class _ContinueVideoAfterTermination:
+    """Keep a diagnostic rollout alive after the task termination condition."""
+
+    def _compute_done(
+        self,
+        state: TensorDictBase,
+        next_state: TensorDictBase,
+    ) -> torch.Tensor:
+        return torch.zeros_like(super()._compute_done(state, next_state))
+
+
+class _HopperVideoEnv(_ContinueVideoAfterTermination, HopperEnv):
+    """Hopper environment used only for diagnostic video recording."""
+
+
+class _HumanoidVideoEnv(_ContinueVideoAfterTermination, HumanoidEnv):
+    """Humanoid environment used only for diagnostic video recording."""
+
+
+_CONTINUOUS_ENV_CLASSES = {
+    "hopper": HopperEnv,
+    "humanoid": HumanoidEnv,
+}
+_CONTINUOUS_VIDEO_ENV_CLASSES = {
+    "hopper": _HopperVideoEnv,
+    "humanoid": _HumanoidVideoEnv,
+}
+_EVALUATION_ENV_LOCK = threading.Lock()
+
+
+def _continuous_env_class(
+    environment_name: str, *, record_video: bool = False
+) -> type[HopperEnv] | type[HumanoidEnv]:
+    classes = _CONTINUOUS_VIDEO_ENV_CLASSES if record_video else _CONTINUOUS_ENV_CLASSES
+    try:
+        return classes[environment_name]
+    except KeyError as err:
+        raise ValueError(
+            f"Unsupported continuous environment {environment_name!r}; "
+            f"expected one of {sorted(classes)}."
+        ) from err
+
+
+def _wandb_metric_name(name: str) -> str:
+    """Place scalar histories in stable W&B workspace sections."""
+    if "/" in name:
+        return name
+    if "." in name:
+        return name.replace(".", "/")
+    exact_names = {
+        "alpha": "policy/alpha",
+        "entropy": "policy/entropy",
+        "grad_norm": "optimization/grad_norm",
+        "optim_steps": "optimization/steps",
+        "td_error": "value/td_error",
+    }
+    mapped = exact_names.get(name)
+    if mapped is not None:
+        return mapped
+    prefixes = (
+        ("loss_", "loss/"),
+        ("target_value_", "value/target_"),
+        ("pred_value_", "value/predicted_"),
+        ("value_", "value/"),
+        ("action_value_", "value/action_"),
+    )
+    for source, destination in prefixes:
+        if name.startswith(source):
+            return destination + name.removeprefix(source)
+    if name == "loss":
+        return "loss/total"
+    return f"training/{name}"
+
+
+class NamespacedLogger:
+    """Serialize logger calls and group unscoped learner metrics in W&B."""
+
+    def __init__(self, logger: Logger) -> None:
+        self._logger = logger
+        self._lock = threading.RLock()
+
+    @property
+    def experiment(self) -> Any:
+        return self._logger.experiment
+
+    def client(self) -> NamespacedLogger:
+        return self
+
+    def log_metrics(
+        self,
+        metrics: dict[str, Any] | TensorDictBase,
+        step: int | None = None,
+        *,
+        keys_sep: str = "/",
+    ) -> dict[str, Any]:
+        if isinstance(metrics, TensorDictBase):
+            metrics = metrics.flatten_keys(keys_sep).to_dict()
+        grouped = {_wandb_metric_name(key): value for key, value in metrics.items()}
+        with self._lock:
+            return self._logger.log_metrics(grouped, step=step, keys_sep=keys_sep)
+
+    def log_scalar(
+        self, name: str, value: float, step: int | None = None, **kwargs: Any
+    ) -> None:
+        with self._lock:
+            self._logger.log_scalar(
+                _wandb_metric_name(name), value, step=step, **kwargs
+            )
+
+    def log_video(
+        self, name: str, video: torch.Tensor, step: int | None = None, **kwargs: Any
+    ) -> None:
+        with self._lock:
+            self._logger.log_video(_wandb_metric_name(name), video, step=step, **kwargs)
+
+    def log_histogram(self, name: str, data: Any, **kwargs: Any) -> None:
+        with self._lock:
+            self._logger.log_histogram(_wandb_metric_name(name), data, **kwargs)
+
+    def log_hparams(self, cfg: DictConfig | dict[str, Any]) -> None:
+        with self._lock:
+            self._logger.log_hparams(cfg)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._logger, name)
+
+
+def flatten_replay_postproc(data: TensorDictBase) -> TensorDictBase:
+    """Materialize a flat transition batch for direct Ray replay insertion."""
+    num_transitions = data.numel()
+    data = data.exclude(
+        "action_value",
+        "chosen_action_value",
+        "loc",
+        "param",
+        "scale",
+    ).reshape(-1)
+    # Collector rollouts reuse preallocated storage. Materialization keeps Ray from
+    # serializing the complete backing allocation through a flattened tensor view.
+    data = data.clone()
+    if data.ndim != 1 or data.numel() != num_transitions:
+        raise RuntimeError(
+            "Off-policy replay postprocessing must flatten [B, T] rollouts to "
+            f"[B * T]; got batch_size={data.batch_size}."
+        )
+    return data
+
+
+def make_continuous_env(
+    *,
+    environment_name: str,
+    backend: str,
+    num_envs: int,
+    device: str,
+    compile_step: bool,
+    compile_mode: str | None,
+    max_episode_steps: int,
+    seed: int,
+) -> TransformedEnv:
+    """Create one natively batched MuJoCo environment inside a Ray actor."""
+    compile_kwargs = None if compile_mode is None else {"mode": compile_mode}
+    env_cls = _continuous_env_class(environment_name)
+    env = env_cls(
+        backend=backend,
+        num_envs=num_envs,
+        device=torch.device(device),
+        seed=seed,
+        max_episode_steps=max_episode_steps,
+        compile_step=compile_step,
+        compile_kwargs=compile_kwargs,
+        dtype=torch.float32,
+    )
+    return TransformedEnv(env, Compose(InitTracker(), RewardSum()))
+
+
+def make_cartpole_env(*, env_name: str, seed: int) -> TransformedEnv:
+    """Create one CPU CartPole environment inside a Ray actor."""
+    env = TransformedEnv(
+        GymEnv(env_name, device="cpu"),
+        Compose(InitTracker(), RewardSum()),
+    )
+    env.set_seed(seed)
+    return env
+
+
+def _materialize(module: nn.Module, proof_env: TransformedEnv) -> None:
+    with torch.no_grad(), set_exploration_type(ExplorationType.RANDOM):
+        module(proof_env.fake_tensordict())
+
+
+def _make_dqn(cfg: DictConfig, proof_env: TransformedEnv) -> AlgorithmObjects:
+    action_spec = proof_env.action_spec_unbatched
+    observation_dim = proof_env.observation_spec["observation"].shape[-1]
+    action_dim = action_spec.shape[-1]
+    qvalue_module = TensorDictModule(
+        MLP(
+            in_features=observation_dim,
+            out_features=action_dim,
+            num_cells=list(cfg.algorithm.hidden_sizes),
+            activation_class=nn.ReLU,
+        ),
+        in_keys=["observation"],
+        out_keys=["action_value"],
+    )
+    value_network = QValueActor(
+        qvalue_module,
+        in_keys=["observation"],
+        spec=action_spec,
+    )
+    _materialize(value_network, proof_env)
+    greedy_module = EGreedyModule(
+        spec=action_spec,
+        eps_init=float(cfg.algorithm.eps_init),
+        eps_end=float(cfg.algorithm.eps_end),
+        annealing_num_steps=int(cfg.algorithm.annealing_num_steps),
+    )
+    policy = TensorDictSequential(value_network, greedy_module)
+    loss_module = DQNLoss(
+        value_network,
+        action_space=action_spec,
+        delay_value=True,
+        loss_function="smooth_l1",
+    )
+    loss_module.make_value_estimator(gamma=float(cfg.algorithm.gamma))
+    optimizer = optim.Adam(
+        loss_module.parameters(), lr=float(cfg.algorithm.learning_rate)
+    )
+    target_updater = HardUpdate(
+        loss_module,
+        value_network_update_interval=int(cfg.algorithm.target_update_interval),
+    )
+    return AlgorithmObjects(
+        policy=policy,
+        evaluation_policy=value_network,
+        loss_module=loss_module,
+        optimizer=optimizer,
+        target_updater=target_updater,
+        trainer_cls=DQNTrainer,
+        trainer_kwargs={"greedy_module": greedy_module},
+    )
+
+
+def _continuous_specs(proof_env: TransformedEnv) -> tuple[int, int, Any]:
+    observation_dim = proof_env.observation_spec["observation"].shape[-1]
+    action_spec = proof_env.action_spec_unbatched
+    action_dim = action_spec.shape[-1]
+    return observation_dim, action_dim, action_spec
+
+
+def _make_stochastic_actor(
+    observation_dim: int,
+    action_dim: int,
+    action_spec: Any,
+    hidden_sizes: list[int],
+) -> ProbabilisticActor:
+    actor_net = nn.Sequential(
+        MLP(
+            in_features=observation_dim,
+            out_features=2 * action_dim,
+            num_cells=hidden_sizes,
+            activation_class=nn.ReLU,
+        ),
+        NormalParamExtractor(scale_mapping="biased_softplus_1.0", scale_lb=1e-4),
+    )
+    actor_module = TensorDictModule(
+        actor_net,
+        in_keys=["observation"],
+        out_keys=["loc", "scale"],
+    )
+    return ProbabilisticActor(
+        module=actor_module,
+        spec=action_spec,
+        in_keys=["loc", "scale"],
+        distribution_class=TanhNormal,
+        distribution_kwargs={
+            "low": action_spec.space.low,
+            "high": action_spec.space.high,
+            "tanh_loc": False,
+        },
+        default_interaction_type=InteractionType.RANDOM,
+        return_log_prob=False,
+    )
+
+
+def _make_deterministic_actor(
+    observation_dim: int,
+    action_dim: int,
+    action_spec: Any,
+    hidden_sizes: list[int],
+) -> TensorDictSequential:
+    return TensorDictSequential(
+        TensorDictModule(
+            MLP(
+                in_features=observation_dim,
+                out_features=action_dim,
+                num_cells=hidden_sizes,
+                activation_class=nn.ReLU,
+            ),
+            in_keys=["observation"],
+            out_keys=["param"],
+        ),
+        TanhModule(
+            in_keys=["param"],
+            out_keys=["action"],
+            spec=action_spec,
+        ),
+    )
+
+
+def _make_qvalue(
+    observation_dim: int,
+    action_dim: int,
+    hidden_sizes: list[int],
+) -> ValueOperator:
+    return ValueOperator(
+        module=MLP(
+            in_features=observation_dim + action_dim,
+            out_features=1,
+            num_cells=hidden_sizes,
+            activation_class=nn.ReLU,
+        ),
+        in_keys=["action", "observation"],
+    )
+
+
+def _make_sac(cfg: DictConfig, proof_env: TransformedEnv) -> AlgorithmObjects:
+    observation_dim, action_dim, action_spec = _continuous_specs(proof_env)
+    hidden_sizes = list(cfg.algorithm.hidden_sizes)
+    actor = _make_stochastic_actor(
+        observation_dim, action_dim, action_spec, hidden_sizes
+    )
+    qvalue = _make_qvalue(observation_dim, action_dim, hidden_sizes)
+    _materialize(actor, proof_env)
+    _materialize(qvalue, proof_env)
+    loss_module = SACLoss(
+        actor_network=actor,
+        qvalue_network=qvalue,
+        num_qvalue_nets=2,
+        loss_function="smooth_l1",
+        delay_actor=False,
+        delay_qvalue=True,
+        alpha_init=float(cfg.algorithm.alpha_init),
+        action_spec=action_spec,
+    )
+    loss_module.make_value_estimator(gamma=float(cfg.algorithm.gamma))
+    optimizer = optim.Adam(
+        loss_module.parameters(), lr=float(cfg.algorithm.learning_rate)
+    )
+    target_updater = SoftUpdate(
+        loss_module, eps=float(cfg.algorithm.target_update_polyak)
+    )
+    return AlgorithmObjects(
+        policy=actor,
+        evaluation_policy=actor,
+        loss_module=loss_module,
+        optimizer=optimizer,
+        target_updater=target_updater,
+        trainer_cls=SACTrainer,
+    )
+
+
+def _make_ddpg(cfg: DictConfig, proof_env: TransformedEnv) -> AlgorithmObjects:
+    observation_dim, action_dim, action_spec = _continuous_specs(proof_env)
+    hidden_sizes = list(cfg.algorithm.hidden_sizes)
+    actor = _make_deterministic_actor(
+        observation_dim, action_dim, action_spec, hidden_sizes
+    )
+    qvalue = _make_qvalue(observation_dim, action_dim, hidden_sizes)
+    _materialize(actor, proof_env)
+    _materialize(qvalue, proof_env)
+    loss_module = DDPGLoss(
+        actor_network=actor,
+        value_network=qvalue,
+        loss_function="smooth_l1",
+        delay_actor=True,
+        delay_value=True,
+    )
+    loss_module.make_value_estimator(gamma=float(cfg.algorithm.gamma))
+    optimizer = optim.Adam(
+        loss_module.parameters(), lr=float(cfg.algorithm.learning_rate)
+    )
+    target_updater = SoftUpdate(
+        loss_module, eps=float(cfg.algorithm.target_update_polyak)
+    )
+    return AlgorithmObjects(
+        policy=actor,
+        evaluation_policy=actor,
+        loss_module=loss_module,
+        optimizer=optimizer,
+        target_updater=target_updater,
+        trainer_cls=DDPGTrainer,
+    )
+
+
+def _make_td3(cfg: DictConfig, proof_env: TransformedEnv) -> AlgorithmObjects:
+    observation_dim, action_dim, action_spec = _continuous_specs(proof_env)
+    hidden_sizes = list(cfg.algorithm.hidden_sizes)
+    actor = _make_deterministic_actor(
+        observation_dim, action_dim, action_spec, hidden_sizes
+    )
+    qvalue = _make_qvalue(observation_dim, action_dim, hidden_sizes)
+    _materialize(actor, proof_env)
+    _materialize(qvalue, proof_env)
+    exploration_module = AdditiveGaussianModule(
+        spec=action_spec,
+        sigma_init=1.0,
+        sigma_end=1.0,
+        mean=0.0,
+        std=float(cfg.algorithm.exploration_std),
+        safe=False,
+    )
+    policy = TensorDictSequential(actor, exploration_module)
+    loss_module = TD3Loss(
+        actor_network=actor,
+        qvalue_network=qvalue,
+        num_qvalue_nets=2,
+        loss_function="smooth_l1",
+        delay_actor=True,
+        delay_qvalue=True,
+        action_spec=action_spec,
+        policy_noise=float(cfg.algorithm.policy_noise),
+        noise_clip=float(cfg.algorithm.noise_clip),
+    )
+    loss_module.make_value_estimator(gamma=float(cfg.algorithm.gamma))
+    actor_params = list(loss_module.actor_network_params.flatten_keys().values())
+    critic_params = list(loss_module.qvalue_network_params.flatten_keys().values())
+    optimizer_actor = optim.Adam(actor_params, lr=float(cfg.algorithm.learning_rate))
+    optimizer_critic = optim.Adam(critic_params, lr=float(cfg.algorithm.learning_rate))
+    optimization_stepper = TD3OptimizationStepper(
+        optimizer_actor=optimizer_actor,
+        optimizer_critic=optimizer_critic,
+        policy_update_delay=int(cfg.algorithm.policy_update_delay),
+    )
+    target_updater = SoftUpdate(
+        loss_module, eps=float(cfg.algorithm.target_update_polyak)
+    )
+    return AlgorithmObjects(
+        policy=policy,
+        evaluation_policy=actor,
+        loss_module=loss_module,
+        optimizer=None,
+        target_updater=target_updater,
+        trainer_cls=TD3Trainer,
+        optimization_stepper=optimization_stepper,
+        trainer_kwargs={"exploration_module": exploration_module},
+    )
+
+
+def _make_algorithm(cfg: DictConfig, proof_env: TransformedEnv) -> AlgorithmObjects:
+    builders = {
+        "dqn": _make_dqn,
+        "sac": _make_sac,
+        "ddpg": _make_ddpg,
+        "td3": _make_td3,
+    }
+    try:
+        builder = builders[str(cfg.algorithm.name)]
+    except KeyError as err:
+        raise ValueError(f"Unsupported algorithm {cfg.algorithm.name!r}.") from err
+    return builder(cfg, proof_env)
+
+
+def _make_env_factories(cfg: DictConfig) -> list[partial]:
+    num_collectors = int(cfg.environment.num_collectors)
+    total_num_envs = int(cfg.environment.total_num_envs)
+    if total_num_envs % num_collectors:
+        raise ValueError("total_num_envs must be divisible by num_collectors.")
+    envs_per_collector = total_num_envs // num_collectors
+    if cfg.algorithm.environment_kind == "gym":
+        if envs_per_collector != 1:
+            raise ValueError("The Gym DQN profile requires one env per Ray collector.")
+        return [
+            partial(
+                make_cartpole_env,
+                env_name=str(cfg.algorithm.environment_name),
+                seed=int(cfg.seed) + worker,
+            )
+            for worker in range(num_collectors)
+        ]
+    return [
+        partial(
+            make_continuous_env,
+            environment_name=str(cfg.algorithm.environment_name),
+            backend=str(cfg.environment.backend),
+            num_envs=envs_per_collector,
+            device="cuda",
+            compile_step=bool(cfg.environment.compile_step),
+            compile_mode=cfg.environment.compile_mode,
+            max_episode_steps=int(cfg.environment.max_episode_steps),
+            seed=int(cfg.seed) + worker,
+        )
+        for worker in range(num_collectors)
+    ]
+
+
+def _make_proof_env(cfg: DictConfig) -> TransformedEnv:
+    if cfg.algorithm.environment_kind == "gym":
+        return make_cartpole_env(
+            env_name=str(cfg.algorithm.environment_name), seed=int(cfg.seed)
+        )
+    return make_continuous_env(
+        environment_name=str(cfg.algorithm.environment_name),
+        backend=str(cfg.environment.backend),
+        num_envs=1,
+        device="cpu",
+        compile_step=False,
+        compile_mode=None,
+        max_episode_steps=int(cfg.environment.max_episode_steps),
+        seed=int(cfg.seed),
+    )
+
+
+def _make_evaluation_env_unlocked(
+    cfg: DictConfig,
+    logger: NamespacedLogger,
+    *,
+    record_video: bool = False,
+) -> TransformedEnv:
+    """Create a metric or video evaluation environment."""
+    transforms = [InitTracker(), RewardSum()]
+    if record_video:
+        transforms.append(
+            VideoRecorder(
+                logger,
+                tag="evaluation/video",
+                in_keys=["pixels"],
+                skip=int(cfg.evaluation.video_skip),
+                fps=int(cfg.evaluation.video_fps),
+                max_frames=int(cfg.evaluation.video_max_frames),
+                make_grid=True,
+            )
+        )
+    if cfg.algorithm.environment_kind == "gym":
+        env = GymEnv(
+            str(cfg.algorithm.environment_name),
+            device="cpu",
+            from_pixels=record_video,
+            pixels_only=False,
+        )
+    else:
+        env_cls = _continuous_env_class(
+            str(cfg.algorithm.environment_name), record_video=record_video
+        )
+        num_envs = (
+            int(cfg.evaluation.video_num_envs)
+            if record_video
+            else int(cfg.evaluation.num_envs)
+        )
+        max_steps = (
+            int(cfg.evaluation.video_max_steps)
+            if record_video
+            else int(cfg.evaluation.max_steps)
+        )
+        env = env_cls(
+            backend=str(cfg.evaluation.backend),
+            num_envs=num_envs,
+            device=torch.device(str(cfg.evaluation.device)),
+            seed=int(cfg.seed) + 10_000,
+            max_episode_steps=max_steps,
+            compile_step=bool(cfg.evaluation.compile_step),
+            dtype=torch.float32,
+            from_pixels=record_video,
+            pixels_only=False,
+            render_width=int(cfg.evaluation.render_width),
+            render_height=int(cfg.evaluation.render_height),
+            render_every=int(cfg.evaluation.video_skip),
+        )
+    eval_env = TransformedEnv(env, Compose(*transforms))
+    eval_env.set_seed(int(cfg.seed) + 10_000)
+    return eval_env
+
+
+def _make_evaluation_env(
+    cfg: DictConfig,
+    logger: NamespacedLogger,
+    *,
+    record_video: bool = False,
+) -> TransformedEnv:
+    """Create one metric or video environment at a time."""
+    # mujoco-torch environment construction invokes lazy wrappers that cannot
+    # be initialised concurrently by the metric and video evaluator threads.
+    with _EVALUATION_ENV_LOCK:
+        return _make_evaluation_env_unlocked(cfg, logger, record_video=record_video)
+
+
+def _make_evaluation_policy(
+    env: TransformedEnv,
+    *,
+    policy: nn.Module,
+    device: str,
+) -> nn.Module:
+    """Build the evaluation policy lazily beside its run environment."""
+    del env
+    return copy.deepcopy(policy).to(device)
+
+
+def _initialize_evaluator(evaluator: Evaluator) -> None:
+    """Materialize a thread evaluator before asynchronous training starts."""
+    # Environment construction alone is insufficient: Collector construction
+    # resets the environment and also touches lazy environment specifications.
+    evaluator._backend._ensure_collector()
+
+
+def _ray_init_config(cfg: DictConfig) -> dict[str, Any]:
+    return OmegaConf.to_container(cfg.ray, resolve=True)  # type: ignore[return-value]
+
+
+def _make_replay_transport_specs(
+    cfg: DictConfig,
+    policy: nn.Module,
+    proof_env: TransformedEnv,
+) -> tuple[TensorDictBase | None, TensorDictBase | None]:
+    if str(cfg.replay.transport) != "distributed":
+        return None, None
+    num_collectors = int(cfg.environment.num_collectors)
+    envs_per_collector = int(cfg.environment.total_num_envs) // num_collectors
+    frames_per_batch = envs_per_collector * int(cfg.collection.frames_per_env)
+    fake_collector = Collector(
+        proof_env,
+        policy,
+        frames_per_batch=frames_per_batch,
+        total_frames=frames_per_batch,
+        init_random_frames=0,
+        device="cpu",
+        storing_device="cpu",
+        env_device="cpu",
+        policy_device="cpu",
+        exploration_type=ExplorationType.RANDOM,
+        postproc=flatten_replay_postproc,
+        track_policy_version=True,
+        return_same_td=True,
+    )
+    try:
+        extend_spec = fake_collector.fake_tensordict()
+    finally:
+        fake_collector.shutdown(close_env=False)
+
+    world_size = int(cfg.learner.world_size)
+    global_batch_size = int(cfg.replay.batch_size)
+    if global_batch_size % world_size:
+        raise ValueError("replay.batch_size must be divisible by learner.world_size.")
+    local_batch_size = global_batch_size // world_size
+    sample_spec = extend_spec[:local_batch_size].clone()
+    sample_spec.set("index", torch.zeros(local_batch_size, dtype=torch.int64))
+    # Consolidating the schemas makes their one-time Ray bootstrap a single
+    # compact storage rather than one torch.save payload per TensorDict leaf.
+    return extend_spec.consolidate(), sample_spec.consolidate()
+
+
+def _make_replay(
+    cfg: DictConfig,
+    extend_spec: TensorDictBase | None = None,
+    sample_spec: TensorDictBase | None = None,
+) -> TensorDictReplayBuffer:
+    if str(cfg.replay.storage_mode) != "transitions":
+        raise ValueError(
+            "DQN, SAC, DDPG, and TD3 require replay.storage_mode=transitions. "
+            "Grouped sequence replay must be configured by a workload that "
+            "explicitly supports sequence samples."
+        )
+    transport = str(cfg.replay.transport)
+    transport_options = None
+    if transport == "distributed":
+        transport_options = {
+            "backend": str(cfg.replay.transport_backend),
+            "timeout": float(cfg.replay.transport_timeout),
+            "extend_spec": extend_spec,
+            "sample_spec": sample_spec,
+        }
+    return TensorDictReplayBuffer(
+        storage=partial(
+            LazyTensorStorage,
+            int(cfg.replay.capacity),
+            device="cpu",
+        ),
+        batch_size=int(cfg.replay.batch_size),
+        service_backend="ray",
+        service_backend_options={
+            "ray_init_config": _ray_init_config(cfg),
+            "remote_config": {"num_cpus": int(cfg.replay.num_cpus)},
+        },
+        transport=transport,
+        transport_options=transport_options,
+    )
+
+
+def _make_collector(
+    cfg: DictConfig,
+    policy: nn.Module,
+    replay: TensorDictReplayBuffer,
+) -> RayCollector:
+    num_collectors = int(cfg.environment.num_collectors)
+    envs_per_collector = int(cfg.environment.total_num_envs) // num_collectors
+    frames_per_batch = envs_per_collector * int(cfg.collection.frames_per_env)
+    use_gpu = cfg.algorithm.environment_kind == "mujoco"
+    device = "cuda" if use_gpu else "cpu"
+    remote_configs = {
+        "num_cpus": 1,
+        "num_gpus": 1 if use_gpu else 0,
+    }
+    return RayCollector(
+        create_env_fn=_make_env_factories(cfg),
+        policy=policy,
+        replay_buffer=replay,
+        collector_class="single",
+        collector_kwargs={
+            # Direct replay is owned by the inner collectors. The outer
+            # RayCollector postprocessor never sees these batches.
+            "postproc": flatten_replay_postproc,
+            "track_policy_version": True,
+        },
+        frames_per_batch=frames_per_batch,
+        total_frames=int(cfg.collection.total_frames),
+        init_random_frames=int(cfg.collection.init_random_frames),
+        device=device,
+        storing_device="cpu",
+        env_device=device,
+        policy_device=device,
+        exploration_type=ExplorationType.RANDOM,
+        remote_configs=remote_configs,
+        ray_init_config=_ray_init_config(cfg),
+        sync=False,
+    )
+
+
+def _git_commit() -> str:
+    configured = os.environ.get("TORCHRL_GIT_COMMIT")
+    if configured:
+        return configured
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode == 0:
+        return completed.stdout.strip()
+    return "unknown"
+
+
+def _make_logger(cfg: DictConfig, run_name: str, commit: str) -> Logger:
+    config = OmegaConf.to_container(cfg, resolve=True)
+    assert isinstance(config, dict)
+    config["git_commit"] = commit
+    logger = get_logger(
+        "wandb",
+        logger_name=str(cfg.artifacts_dir),
+        experiment_name=run_name,
+        wandb_kwargs={
+            "project": str(cfg.logging.project),
+            "group": str(cfg.logging.group),
+            "mode": str(cfg.logging.mode),
+            "config": config,
+            "log_env_packages": bool(cfg.logging.log_env_packages),
+            "tags": [
+                "offpolicy-dp",
+                str(cfg.algorithm.name),
+                f"learners-{cfg.learner.world_size}",
+                f"collectors-{cfg.environment.num_collectors}",
+            ],
+        },
+    )
+    if logger is None:
+        raise RuntimeError("W&B logger construction unexpectedly returned None.")
+    return logger
+
+
+def _replay_write_count(replay: TensorDictReplayBuffer) -> int:
+    value = replay.write_count
+    if callable(value):
+        value = value()
+    return int(value)
+
+
+def _as_float(value: Any) -> float | None:
+    if isinstance(value, torch.Tensor):
+        if value.numel() != 1:
+            return None
+        return float(value.detach().cpu())
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _validate_transition_sample(
+    sample: TensorDictBase, expected_num_transitions: int
+) -> None:
+    if sample.ndim != 1 or sample.numel() != expected_num_transitions:
+        raise RuntimeError(
+            "Standard off-policy replay must return a flat [N] transition "
+            f"batch, got batch_size={sample.batch_size} for N="
+            f"{expected_num_transitions}."
+        )
+
+
+def _diagnostic_replay_sample_size(cfg: DictConfig) -> int:
+    sample_size = int(cfg.logging.sample_size)
+    if str(cfg.replay.transport) != "distributed":
+        return sample_size
+
+    world_size = int(cfg.learner.world_size)
+    global_batch_size = int(cfg.replay.batch_size)
+    if global_batch_size % world_size:
+        raise ValueError("replay.batch_size must be divisible by learner.world_size.")
+    transport_sample_size = global_batch_size // world_size
+    if sample_size != transport_sample_size:
+        raise ValueError(
+            "logging.sample_size must match the distributed replay transport's "
+            "fixed per-rank sample schema: expected replay.batch_size / "
+            f"learner.world_size = {transport_sample_size}, got {sample_size}."
+        )
+    return sample_size
+
+
+class RuntimeValidationHook:
+    """Log controller-side throughput and fail promptly on non-finite metrics."""
+
+    def __init__(
+        self,
+        trainer: Trainer,
+        replay: TensorDictReplayBuffer,
+        *,
+        interval_frames: int,
+        sample_size: int,
+    ) -> None:
+        self.trainer = trainer
+        self.replay = replay
+        self.interval_frames = interval_frames
+        self.sample_size = sample_size
+        self.last_frames = int(trainer.collected_frames)
+        self.last_optim_steps = int(trainer._optim_count)
+        self.last_time = time.monotonic()
+        self.last_sample_frames = 0
+        self.checked_counts: dict[str, int] = {}
+
+    def _check_finite(self) -> None:
+        for key, values in self.trainer._log_dict.items():
+            start = self.checked_counts.get(key, 0)
+            for value in values[start:]:
+                scalar = _as_float(value)
+                if scalar is not None and not math.isfinite(scalar):
+                    raise RuntimeError(f"Non-finite training metric {key}={scalar}.")
+            self.checked_counts[key] = len(values)
+
+    def _sample_metrics(self) -> dict[str, float]:
+        size = len(self.replay)
+        if size < self.sample_size:
+            return {}
+        sample = self.replay.sample(self.sample_size)
+        _validate_transition_sample(sample, self.sample_size)
+        metrics: dict[str, float] = {"replay/sample_batch_ndim": sample.ndim}
+        policy_version = sample.get("policy_version", None)
+        if policy_version is not None:
+            metrics["policy_version/sample_min"] = float(policy_version.min())
+            metrics["policy_version/sample_max"] = float(policy_version.max())
+            metrics["policy_version/sample_mean"] = float(policy_version.float().mean())
+        done = sample.get(("next", "done"), None)
+        episode_return = sample.get(("next", "episode_reward"), None)
+        if done is not None and episode_return is not None:
+            done = done.squeeze(-1).bool()
+            if done.any():
+                terminal_return = episode_return.squeeze(-1)[done]
+                metrics["returns/replay_terminal_mean"] = float(
+                    terminal_return.float().mean()
+                )
+                metrics["returns/replay_terminal_count"] = float(done.sum())
+        return metrics
+
+    def __call__(self) -> None:
+        self._check_finite()
+        frames = int(self.trainer.collected_frames)
+        if frames <= self.last_frames:
+            return
+        now = time.monotonic()
+        elapsed = max(now - self.last_time, 1e-9)
+        optim_steps = int(self.trainer._optim_count)
+        metrics: dict[str, float] = {
+            "throughput/collection_fps": (frames - self.last_frames) / elapsed,
+            "throughput/optimization_sps": (optim_steps - self.last_optim_steps)
+            / elapsed,
+            "replay/size": float(len(self.replay)),
+            "replay/write_count": float(_replay_write_count(self.replay)),
+            "distributed/published_model_version": float(
+                self.trainer._published_model_version
+            ),
+            "distributed/learner_world_size": float(
+                self.trainer._execution_backend.world_size
+            ),
+        }
+        if frames - self.last_sample_frames >= self.interval_frames:
+            metrics.update(self._sample_metrics())
+            self.last_sample_frames = frames
+        self.trainer._log(**metrics)
+        self.last_frames = frames
+        self.last_optim_steps = optim_steps
+        self.last_time = now
+
+
+class EvaluationHook:
+    """Evaluate current learner weights and record the rendered rollout."""
+
+    def __init__(
+        self,
+        trainer: Trainer,
+        evaluator: Evaluator,
+        logger: NamespacedLogger,
+        *,
+        interval_frames: int,
+        shutdown_timeout: float,
+        log_results: bool = True,
+    ) -> None:
+        self.trainer = trainer
+        self.evaluator = evaluator
+        self.logger = logger
+        self.interval_frames = interval_frames
+        self.shutdown_timeout = shutdown_timeout
+        self.log_results = log_results
+        self.next_frames = interval_frames
+        self.pending_policy_version: int | None = None
+
+    def _log_result(self, result: dict[str, Any]) -> None:
+        result = dict(result)
+        step = int(result.pop("evaluation/step"))
+        if self.log_results:
+            if self.pending_policy_version is not None:
+                result["evaluation/policy_version"] = self.pending_policy_version
+            self.logger.log_metrics(result, step=step)
+        self.pending_policy_version = None
+
+    def _poll(self) -> None:
+        result = self.evaluator.poll()
+        if result is not None:
+            self._log_result(result)
+
+    def __call__(self) -> None:
+        self._poll()
+        frames = int(self.trainer.collected_frames)
+        if frames < self.next_frames or self.evaluator.pending:
+            return
+        policy_version = int(self.trainer._published_model_version)
+        weights = self.trainer._execution_backend.get_weights(
+            expected_version=policy_version
+        )
+        if self.evaluator.trigger_eval(weights, step=frames):
+            self.pending_policy_version = policy_version
+            self.next_frames = frames + self.interval_frames
+
+    def shutdown(self) -> None:
+        self._poll()
+        if self.evaluator.pending:
+            result = self.evaluator.wait(timeout=self.shutdown_timeout)
+            if result is None:
+                raise TimeoutError(
+                    "The final evaluator rollout did not finish before shutdown."
+                )
+            self._log_result(result)
+        self.evaluator.shutdown(timeout=self.shutdown_timeout)
+
+
+def _make_trainer(
+    cfg: DictConfig,
+    objects: AlgorithmObjects,
+    collector: RayCollector,
+    replay: TensorDictReplayBuffer,
+    logger: NamespacedLogger,
+) -> Trainer:
+    learner_options = {
+        "world_size": int(cfg.learner.world_size),
+        "resources_per_rank": {
+            "num_cpus": int(cfg.learner.num_cpus_per_rank),
+            "num_gpus": int(cfg.learner.num_gpus_per_rank),
+        },
+        "backend": str(cfg.learner.backend),
+        "setup_timeout": float(cfg.learner.setup_timeout),
+        "command_timeout": float(cfg.learner.command_timeout),
+        "ray_init_config": _ray_init_config(cfg),
+    }
+    kwargs: dict[str, Any] = {
+        "collector": collector,
+        "total_frames": int(cfg.collection.total_frames),
+        "frame_skip": 1,
+        "optim_steps_per_batch": int(cfg.learner.optim_steps_per_batch),
+        "loss_module": objects.loss_module,
+        "optimizer": objects.optimizer,
+        "replay_buffer": replay,
+        "batch_size": int(cfg.replay.batch_size),
+        "target_net_updater": objects.target_updater,
+        "learner_backend": "ray",
+        "learner_backend_options": learner_options,
+        "learner_poll_interval": float(cfg.learner.poll_interval),
+        "logger": logger,
+        "enable_logging": False,
+        "async_collection": True,
+        "progress_bar": True,
+        "seed": int(cfg.seed),
+        "log_interval": int(cfg.logging.interval_frames),
+        "save_trainer_file": None,
+    }
+    if objects.optimization_stepper is not None:
+        kwargs["optimization_stepper"] = objects.optimization_stepper
+    kwargs.update(objects.trainer_kwargs)
+    return objects.trainer_cls(**kwargs)
+
+
+def _all_metrics_finite(trainer: Trainer) -> bool:
+    for values in trainer._log_dict.values():
+        for value in values:
+            scalar = _as_float(value)
+            if scalar is not None and not math.isfinite(scalar):
+                return False
+    return True
+
+
+def _validate_final_state(
+    cfg: DictConfig,
+    trainer: Trainer,
+    replay: TensorDictReplayBuffer,
+) -> dict[str, Any]:
+    optim_steps = int(trainer._optim_count)
+    published_version = int(trainer._published_model_version)
+    write_count = _replay_write_count(replay)
+    collected_frames = int(trainer.collected_frames)
+    if optim_steps <= 0:
+        raise RuntimeError("The learner completed without an optimization step.")
+    if published_version != optim_steps:
+        raise RuntimeError(
+            "Published policy version does not match optimization count: "
+            f"published={published_version}, optim_steps={optim_steps}."
+        )
+    if collected_frames < int(cfg.collection.total_frames):
+        raise RuntimeError(
+            f"Collector reported {collected_frames} transitions, expected at "
+            f"least {cfg.collection.total_frames}."
+        )
+    if write_count != collected_frames:
+        raise RuntimeError(
+            "Direct replay transition accounting diverged from collection: "
+            f"write_count={write_count}, collected_frames={collected_frames}."
+        )
+    if not _all_metrics_finite(trainer):
+        raise RuntimeError("At least one recorded training metric is non-finite.")
+    sample_size = _diagnostic_replay_sample_size(cfg)
+    if len(replay) < sample_size:
+        raise RuntimeError(
+            "Replay does not contain enough transitions for the final diagnostic "
+            f"sample: size={len(replay)}, sample_size={sample_size}."
+        )
+    sample = replay.sample(sample_size)
+    _validate_transition_sample(sample, sample_size)
+    policy_version = sample.get("policy_version", None)
+    if policy_version is None:
+        raise RuntimeError("Replay samples do not contain policy_version.")
+    max_policy_version = int(policy_version.max())
+    if max_policy_version <= 0:
+        raise RuntimeError("Replay contains no data from an updated policy.")
+    return {
+        "algorithm": str(cfg.algorithm.name),
+        "status": "completed",
+        "collected_frames": collected_frames,
+        "replay_write_count": write_count,
+        "replay_size": len(replay),
+        "replay_sample_batch_size": list(sample.batch_size),
+        "replay_sample_batch_ndim": sample.ndim,
+        "replay_sample_numel": sample.numel(),
+        "optimization_steps": optim_steps,
+        "published_model_version": published_version,
+        "max_sampled_policy_version": max_policy_version,
+        "num_collectors": int(cfg.environment.num_collectors),
+        "total_num_envs": int(cfg.environment.total_num_envs),
+        "learner_world_size": int(cfg.learner.world_size),
+    }
+
+
+def _write_summary(cfg: DictConfig, run_name: str, summary: dict[str, Any]) -> Path:
+    artifact_dir = Path(str(cfg.artifacts_dir))
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    path = artifact_dir / f"{run_name}.json"
+    path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    return path
+
+
+@hydra.main(config_path="config", config_name="config", version_base="1.3")
+def main(cfg: DictConfig) -> None:
+    """Construct and run one configured distributed off-policy experiment."""
+    torch.manual_seed(int(cfg.seed))
+    commit = _git_commit()
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    run_name = (
+        f"{cfg.algorithm.name}-{cfg.algorithm.environment_name}-"
+        f"{cfg.environment.total_num_envs}env-"
+        f"{cfg.environment.num_collectors}c-{cfg.learner.world_size}l-{timestamp}"
+    )
+    logger = NamespacedLogger(_make_logger(cfg, run_name, commit))
+    experiment = logger.experiment
+    replay: TensorDictReplayBuffer | None = None
+    collector: RayCollector | None = None
+    evaluators: list[Evaluator] = []
+    exit_code = 1
+    try:
+        diagnostic_sample_size = _diagnostic_replay_sample_size(cfg)
+        proof_env = _make_proof_env(cfg)
+        try:
+            objects = _make_algorithm(cfg, proof_env)
+            extend_spec, sample_spec = _make_replay_transport_specs(
+                cfg, objects.policy, proof_env
+            )
+        finally:
+            proof_env.close()
+        replay = _make_replay(cfg, extend_spec, sample_spec)
+        collector = _make_collector(cfg, objects.policy, replay)
+        trainer = _make_trainer(cfg, objects, collector, replay, logger)
+        validation_hook = RuntimeValidationHook(
+            trainer,
+            replay,
+            interval_frames=int(cfg.logging.interval_frames),
+            sample_size=diagnostic_sample_size,
+        )
+        trainer.register_op("post_steps", validation_hook)
+        if bool(cfg.evaluation.enabled):
+            eval_device = str(cfg.evaluation.device)
+            eval_num_envs = (
+                1
+                if cfg.algorithm.environment_kind == "gym"
+                else int(cfg.evaluation.num_envs)
+            )
+            evaluator = Evaluator(
+                partial(_make_evaluation_env, cfg, logger, record_video=False),
+                policy_factory=partial(
+                    _make_evaluation_policy,
+                    policy=objects.evaluation_policy,
+                    device=eval_device,
+                ),
+                num_trajectories=int(cfg.evaluation.num_trajectories),
+                max_steps=int(cfg.evaluation.max_steps),
+                frames_per_batch=int(cfg.evaluation.max_steps) * eval_num_envs,
+                collector_kwargs={"traj_format": "padded"},
+                log_prefix="evaluation",
+                device=eval_device,
+                exploration_type=ExplorationType.DETERMINISTIC,
+                dump_video=False,
+                busy_policy="skip",
+            )
+            _initialize_evaluator(evaluator)
+            evaluators.append(evaluator)
+            evaluation_hook = EvaluationHook(
+                trainer,
+                evaluator,
+                logger,
+                interval_frames=int(cfg.evaluation.interval_frames),
+                shutdown_timeout=float(cfg.evaluation.shutdown_timeout),
+            )
+            trainer.register_op("post_steps", evaluation_hook)
+            trainer.register_op("shutdown", evaluation_hook.shutdown)
+            if bool(cfg.evaluation.video):
+                video_num_envs = (
+                    1
+                    if cfg.algorithm.environment_kind == "gym"
+                    else int(cfg.evaluation.video_num_envs)
+                )
+                video_evaluator = Evaluator(
+                    partial(_make_evaluation_env, cfg, logger, record_video=True),
+                    policy_factory=partial(
+                        _make_evaluation_policy,
+                        policy=objects.evaluation_policy,
+                        device=eval_device,
+                    ),
+                    num_trajectories=int(cfg.evaluation.video_num_trajectories),
+                    max_steps=int(cfg.evaluation.video_max_steps),
+                    frames_per_batch=(
+                        int(cfg.evaluation.video_max_steps) * video_num_envs
+                    ),
+                    collector_kwargs={"traj_format": "padded"},
+                    log_prefix="evaluation",
+                    device=eval_device,
+                    exploration_type=ExplorationType.DETERMINISTIC,
+                    dump_video=True,
+                    busy_policy="skip",
+                )
+                _initialize_evaluator(video_evaluator)
+                evaluators.append(video_evaluator)
+                video_hook = EvaluationHook(
+                    trainer,
+                    video_evaluator,
+                    logger,
+                    interval_frames=int(cfg.evaluation.video_interval_frames),
+                    shutdown_timeout=float(cfg.evaluation.shutdown_timeout),
+                    log_results=False,
+                )
+                trainer.register_op("post_steps", video_hook)
+                trainer.register_op("shutdown", video_hook.shutdown)
+        trainer.train()
+        summary = _validate_final_state(cfg, trainer, replay)
+        summary.update(
+            {
+                "git_commit": commit,
+                "run_name": run_name,
+                "wandb_url": getattr(experiment, "url", None),
+            }
+        )
+        path = _write_summary(cfg, run_name, summary)
+        experiment.summary.update(summary)
+        torchrl_logger.info(f"Validation summary written to {path}.")
+        exit_code = 0
+    except BaseException as err:
+        failure = {
+            "algorithm": str(cfg.algorithm.name),
+            "status": "failed",
+            "error_type": type(err).__name__,
+            "error": str(err),
+            "git_commit": commit,
+            "run_name": run_name,
+            "wandb_url": getattr(experiment, "url", None),
+        }
+        _write_summary(cfg, run_name, failure)
+        experiment.summary.update(failure)
+        raise
+    finally:
+        if collector is not None:
+            with contextlib.suppress(Exception):
+                collector.shutdown()
+        for evaluator in evaluators:
+            with contextlib.suppress(Exception):
+                evaluator.shutdown()
+        if replay is not None:
+            with contextlib.suppress(Exception):
+                replay.shutdown()
+        experiment.finish(exit_code=exit_code)
+        wandb.finish(exit_code=exit_code)
+        if ray.is_initialized():
+            ray.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/sota-implementations/offpolicy-dp/train.py
+++ b/sota-implementations/offpolicy-dp/train.py
@@ -242,6 +242,7 @@ def make_continuous_env(
     device: str,
     compile_step: bool,
     compile_mode: str | None,
+    frame_skip: int | None,
     max_episode_steps: int,
     seed: int,
 ) -> TransformedEnv:
@@ -253,6 +254,7 @@ def make_continuous_env(
         num_envs=num_envs,
         device=torch.device(device),
         seed=seed,
+        frame_skip=frame_skip,
         max_episode_steps=max_episode_steps,
         compile_step=compile_step,
         compile_kwargs=compile_kwargs,
@@ -574,6 +576,11 @@ def _make_env_factories(cfg: DictConfig) -> list[partial]:
             device="cuda",
             compile_step=bool(cfg.environment.compile_step),
             compile_mode=cfg.environment.compile_mode,
+            frame_skip=(
+                None
+                if cfg.environment.frame_skip is None
+                else int(cfg.environment.frame_skip)
+            ),
             max_episode_steps=int(cfg.environment.max_episode_steps),
             seed=int(cfg.seed) + worker,
         )
@@ -593,6 +600,11 @@ def _make_proof_env(cfg: DictConfig) -> TransformedEnv:
         device="cpu",
         compile_step=False,
         compile_mode=None,
+        frame_skip=(
+            None
+            if cfg.environment.frame_skip is None
+            else int(cfg.environment.frame_skip)
+        ),
         max_episode_steps=int(cfg.environment.max_episode_steps),
         seed=int(cfg.seed),
     )
@@ -644,6 +656,11 @@ def _make_evaluation_env_unlocked(
             num_envs=num_envs,
             device=torch.device(str(cfg.evaluation.device)),
             seed=int(cfg.seed) + 10_000,
+            frame_skip=(
+                None
+                if cfg.evaluation.frame_skip is None
+                else int(cfg.evaluation.frame_skip)
+            ),
             max_episode_steps=max_steps,
             compile_step=bool(cfg.evaluation.compile_step),
             dtype=torch.float32,

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -1986,6 +1986,7 @@ class TestTrainerConfigs:
         assert cfg.total_frames == 200
         assert cfg.optim_steps_per_batch == 4
         assert cfg.async_collection is False
+        assert cfg.exploration_module is None
 
     @pytest.mark.skipif(not _has_gymnasium, reason="Gymnasium is not installed")
     def test_iql_trainer_config(self):

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -1660,6 +1660,30 @@ class TestPostOptimCompleteLog:
         assert parameter.default is None
 
 
+class TestDDPGTrainer:
+    def test_exploration_module_execution_weight_publication(self):
+        trainer = object.__new__(DDPGTrainer)
+        trainer.exploration_module = nn.Linear(3, 2)
+
+        model_weights_key, auxiliary_weights = trainer._execution_weight_publication()
+
+        assert model_weights_key == ("module", "0")
+        assert torch.equal(
+            auxiliary_weights["module", "1", "weight"],
+            trainer.exploration_module.weight,
+        )
+        assert torch.equal(
+            auxiliary_weights["module", "1", "bias"],
+            trainer.exploration_module.bias,
+        )
+
+    def test_no_exploration_module_uses_default_weight_publication(self):
+        trainer = object.__new__(DDPGTrainer)
+        trainer.exploration_module = None
+
+        assert trainer._execution_weight_publication() == (None, None)
+
+
 class TestDefaultOptimizationStepper:
     def test_loss_components_partial(self):
         torch.manual_seed(0)

--- a/torchrl/trainers/algorithms/configs/trainers.py
+++ b/torchrl/trainers/algorithms/configs/trainers.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, TYPE_CHECKING
 
 import torch
-from tensordict.nn import TensorDictModuleBase
+from tensordict.nn import TensorDictModuleBase, TensorDictSequential
 
 from torchrl.collectors import BaseCollector
 from torchrl.data import Categorical, Composite, OneHot
@@ -943,6 +943,7 @@ class DDPGTrainerConfig(TrainerConfig):
     create_env_fn: Any = None
     actor_network: Any = None
     critic_network: Any = None
+    exploration_module: Any = None
     target_net_updater: Any = None
     async_collection: bool = False
     log_timings: bool = False
@@ -993,6 +994,7 @@ def _make_ddpg_trainer(*args, **kwargs) -> DDPGTrainer:
     seed = kwargs.pop("seed")
     actor_network = kwargs.pop("actor_network")
     critic_network = kwargs.pop("critic_network")
+    exploration_module = kwargs.pop("exploration_module", None)
     kwargs.pop("create_env_fn", None)
     target_net_updater = kwargs.pop("target_net_updater")
     async_collection = kwargs.pop("async_collection", False)
@@ -1016,11 +1018,27 @@ def _make_ddpg_trainer(*args, **kwargs) -> DDPGTrainer:
         actor_network = actor_network()
     if critic_network is not None and not isinstance(critic_network, torch.nn.Module):
         critic_network = critic_network()
+    if exploration_module is not None and not isinstance(
+        exploration_module, torch.nn.Module
+    ):
+        exploration_module = exploration_module()
+    if exploration_module is not None and actor_network is None:
+        raise ValueError(
+            "DDPGTrainerConfig requires actor_network when exploration_module is set."
+        )
+    exploration_policy = (
+        TensorDictSequential(actor_network, exploration_module)
+        if exploration_module is not None
+        else actor_network
+    )
     if not isinstance(collector, BaseCollector):
+        collector_kwargs = (
+            {"policy": exploration_policy} if exploration_policy is not None else {}
+        )
         if not async_collection:
-            collector = collector()
+            collector = collector(**collector_kwargs)
         elif replay_buffer is not None:
-            collector = collector(replay_buffer=replay_buffer)
+            collector = collector(replay_buffer=replay_buffer, **collector_kwargs)
 
     if not isinstance(loss_module, LossModule):
         loss_module = loss_module(
@@ -1079,6 +1097,7 @@ def _make_ddpg_trainer(*args, **kwargs) -> DDPGTrainer:
         episode_reward_key=episode_reward_key,
         action_key=action_key,
         observation_key=observation_key,
+        exploration_module=exploration_module,
     )
     _register_trainer_hooks(trainer, hooks)
     return trainer

--- a/torchrl/trainers/algorithms/ddpg.py
+++ b/torchrl/trainers/algorithms/ddpg.py
@@ -14,8 +14,9 @@ from functools import partial
 from typing import Any, Literal
 
 from tensordict import TensorDict, TensorDictBase
+from tensordict.nn import TensorDictSequential
 from tensordict.utils import NestedKey
-from torch import optim
+from torch import nn, optim
 
 from torchrl.checkpoint import Checkpoint
 from torchrl.collectors import BaseCollector
@@ -76,6 +77,9 @@ class DDPGTrainer(Trainer):
         log_observations (bool, optional): Whether to log observation statistics. Defaults to False.
         target_net_updater (TargetNetUpdater): Target network updater (typically
             :class:`~torchrl.objectives.utils.SoftUpdate`).
+        exploration_module (nn.Module, optional): Exploration module appended to
+            the deterministic actor for collection. The actor without this module
+            is used for the DDPG loss. Defaults to ``None``.
         async_collection (bool, optional): Whether to use async data collection. Defaults to False.
         log_timings (bool, optional): Whether to log timing information for hooks. Defaults to False.
         done_key (NestedKey, optional): Done key used by losses and logging. Defaults to "done".
@@ -128,6 +132,7 @@ class DDPGTrainer(Trainer):
         episode_reward_key: NestedKey = "reward_sum",
         action_key: NestedKey = "action",
         observation_key: NestedKey = "observation",
+        exploration_module: nn.Module | None = None,
     ) -> None:
         warnings.warn(
             "DDPGTrainer is an experimental/prototype feature. The API may change in future versions. "
@@ -189,10 +194,15 @@ class DDPGTrainer(Trainer):
         if learner_backend == "local":
             self.register_op("post_optim", TargetNetUpdaterHook(target_net_updater))
 
+        self.exploration_module = exploration_module
+
         if learner_backend == "local":
-            policy_weights_getter = partial(
-                TensorDict.from_module, self.loss_module.actor_network
-            )
+            weights_source = self.loss_module.actor_network
+            if exploration_module is not None:
+                weights_source = TensorDictSequential(
+                    weights_source, exploration_module
+                )
+            policy_weights_getter = partial(TensorDict.from_module, weights_source)
             update_weights = UpdateWeights(
                 self.collector, 1, policy_weights_getter=policy_weights_getter
             )
@@ -218,6 +228,11 @@ class DDPGTrainer(Trainer):
 
         if self.enable_logging:
             self._setup_ddpg_logging()
+
+    def _execution_weight_publication(
+        self,
+    ) -> tuple[NestedKey | None, TensorDictBase | None]:
+        return self._compose_execution_weight_publication(self.exploration_module)
 
     def _setup_ddpg_logging(self):
         """Set up logging hooks for DDPG-specific metrics."""


### PR DESCRIPTION
## What

Adds `sota-implementations/offpolicy-dp/`, a Hydra-configured distributed suite for DQN, SAC, DDPG, and TD3 using the merged data-parallel Trainer and flexible transport APIs.

The suite includes:

- Ray collectors writing directly to Ray-owned replay through Gloo tensor transport
- NCCL learner groups and direct policy-weight publication
- inner-collector rollout flattening from `[B, T]` to `[B * T]` before replay insertion
- transition-count, replay-shape, policy-version, optimizer-version, and finite-metric assertions
- W&B metric namespaces, asynchronous evaluation, and rendered Humanoid video
- persistent stochastic collection for every algorithm
- replay action dispersion and saturation metrics
- smoke profiles plus 100K-environment learning-scale profiles

DDPG now accepts an optional `exploration_module` in `DDPGTrainer` and `DDPGTrainerConfig`. Local and Ray execution publish weights with the same `actor + exploration` structure used by the collector, while the loss and evaluator continue to use the deterministic actor. The SOTA DDPG configuration applies fixed Gaussian action noise with standard deviation 0.2.

## Experiment design

Random-only collection is disabled in these profiles. SAC is stochastic, TD3 and DDPG use persistent Gaussian action noise, and DQN begins with epsilon equal to one. Learner startup is separated from action selection: scale runs collect ten million stochastic-policy transitions before the first optimization step instead of requesting a distributed random-action warmup against the shared replay counter.

The scale defaults are a starting point for the next allocation:

- 100,000 environments across four GPU collectors
- four NCCL learner ranks
- 200 million collected transitions, or 2,000 decisions per environment
- 10 million stochastic-policy replay-prefill transitions
- 20 million-transition replay capacity
- 16,384 global batch size, or 4,096 samples per learner rank
- 25 optimizer steps per approximately 100,000 collected transitions, preserving a 4.096 sample update-to-data ratio
- 64 deterministic evaluation episodes of up to 1,000 steps every ten million transitions

A full 1,000-step prefill trajectory from every environment would require 100 million transitions before learning begins. The shorter stochastic prefill targets early terminations while exploration continues throughout the run. Humanoid retains `frame_skip=1` for batched solver stability and therefore is not directly comparable to the standard five-substep benchmark.

## Why

The distributed components need an end-to-end workload that exercises collection, replay transport, multi-rank learning, policy synchronization, numerical health, and shutdown together. DDPG collection must remain stochastic after replay prefill; publishing only its deterministic actor can optimize losses without improving behavior. Separating replay fill from random-only action selection also avoids per-collector warmup thresholds being compared with a shared replay write count.

## Validation

- `python3 -m py_compile torchrl/trainers/algorithms/ddpg.py torchrl/trainers/algorithms/configs/trainers.py sota-implementations/offpolicy-dp/train.py sota-implementations/offpolicy-dp/run_suite.py test/test_trainer.py test/test_configs.py`
- `pre-commit run --files <changed files>`
- `python -m pytest test/test_trainer.py test/test_configs.py -k 'TestDDPGTrainer or test_ddpg_trainer_config' -q` — 3 passed
- Hydra composition checks for every smoke and scale profile
- Exploration-mode check: Gaussian collection action standard deviation 0.201; deterministic action standard deviation 0.000

The earlier runs below validate transport, replay accounting, flat sampled batches, policy publication, numerical finiteness, and shutdown. They predate the learning-scale redesign and should not be interpreted as successful learning curves. The redesigned 200-million-transition profiles have not been run because the original allocation has ended.

- [DQN, CartPole, 100K frames](https://wandb.ai/vmoens/torchrl-dp-offpolicy-validation/runs/5wvv6tu6)
- [SAC, Hopper, 100K environments, 20M frames](https://wandb.ai/vmoens/torchrl-dp-offpolicy-validation/runs/1wpjte0u)
- [DDPG, Hopper, 100K environments, 20M frames](https://wandb.ai/vmoens/torchrl-dp-offpolicy-validation/runs/d7i35n8i)
- [TD3, Hopper, 100K environments, 20M frames](https://wandb.ai/vmoens/torchrl-dp-offpolicy-validation/runs/zb8yq3rc)
- [DDPG, Humanoid, 100K environments, 20M frames](https://wandb.ai/vmoens/torchrl-dp-offpolicy-validation/runs/5gqt6zge)

Related stacks: #4005 and #3958.
