### PR TITLE
[BugFix] Persist write_count in RoundRobinWriter checkpoints

### DIFF
--- a/test/rb/test_writers.py
+++ b/test/rb/test_writers.py
@@ -13,6 +13,7 @@ from torch import multiprocessing as mp
 
 from torchrl.data import (
     PrioritizedReplayBuffer,
+    ReplayBuffer,
     TensorDictPrioritizedReplayBuffer,
     TensorDictReplayBuffer,
 )
@@ -28,6 +29,7 @@ from torchrl.data.replay_buffers.storages import (
     ListStorage,
 )
 from torchrl.data.replay_buffers.writers import (
+    RoundRobinWriter,
     TensorDictMaxValueWriter,
     TensorDictRoundRobinWriter,
 )
@@ -368,6 +370,37 @@ class TestMultiProc:
         # list storage cannot be shared
         with pytest.raises(RuntimeError, match="it has not been initialized yet"):
             self.exec_multiproc_rb(init=False)
+
+
+class TestWriterStateDict:
+    def test_roundrobin_state_dict_restores_write_count(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10))
+        rb.extend(torch.arange(15))
+        assert rb.write_count == 15
+        sd = rb.state_dict()
+        rb2 = ReplayBuffer(storage=LazyTensorStorage(10))
+        rb2.load_state_dict(sd)
+        assert rb2.write_count == 15
+        assert rb2._writer._cursor == rb._writer._cursor
+
+    def test_roundrobin_load_legacy_state_dict_without_write_count(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10))
+        rb.extend(torch.arange(5))
+        sd = rb.state_dict()
+        del sd["_writer"]["_write_count"]
+        rb2 = ReplayBuffer(storage=LazyTensorStorage(10))
+        rb2.load_state_dict(sd)
+        assert rb2._writer._cursor == 5
+
+    def test_roundrobin_dumps_loads_write_count(self, tmp_path):
+        writer = RoundRobinWriter()
+        writer._cursor = 3
+        writer._write_count = 23
+        writer.dumps(tmp_path)
+        writer2 = RoundRobinWriter()
+        writer2.loads(tmp_path)
+        assert writer2._cursor == 3
+        assert writer2._write_count == 23
 
 
 if __name__ == "__main__":

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -164,13 +164,16 @@ class RoundRobinWriter(Writer):
         path = Path(path).absolute()
         path.mkdir(exist_ok=True)
         with open(path / "metadata.json", "w") as file:
-            json.dump({"cursor": self._cursor}, file)
+            json.dump({"cursor": self._cursor, "write_count": self._write_count}, file)
 
     def loads(self, path):
         path = Path(path).absolute()
         with open(path / "metadata.json") as file:
             metadata = json.load(file)
             self._cursor = metadata["cursor"]
+            write_count = metadata.get("write_count")
+            if write_count is not None:
+                self._write_count = write_count
 
     def add(self, data: Any) -> int | torch.Tensor:
         index = self._cursor
@@ -246,10 +249,13 @@ class RoundRobinWriter(Writer):
         )
 
     def state_dict(self) -> dict[str, Any]:
-        return {"_cursor": self._cursor}
+        return {"_cursor": self._cursor, "_write_count": self._write_count}
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         self._cursor = state_dict["_cursor"]
+        write_count = state_dict.get("_write_count")
+        if write_count is not None:
+            self._write_count = write_count
 
     def _empty(self, empty_write_count: bool = True) -> None:
         self._cursor = 0
@@ -692,6 +698,7 @@ class TensorDictMaxValueWriter(Writer):
             json.dump(
                 {
                     "cursor": self._cursor,
+                    "write_count": self._write_count,
                     "rank_key": self._rank_key,
                     "dtype": str(t.dtype),
                     "shape": list(t.shape),
@@ -704,6 +711,9 @@ class TensorDictMaxValueWriter(Writer):
         with open(path / "metadata.json") as file:
             metadata = json.load(file)
             self._cursor = metadata["cursor"]
+            write_count = metadata.get("write_count")
+            if write_count is not None:
+                self._write_count = write_count
             self._rank_key = metadata["rank_key"]
             shape = torch.Size(metadata["shape"])
             dtype = metadata["dtype"]


### PR DESCRIPTION
## Description

`RoundRobinWriter.state_dict()` and `dumps()` only persist the cursor, so `ReplayBuffer.write_count` silently resets to zero after a checkpoint restore, even though the docstring describes it as the total number of items ever written.

This PR persists `_write_count`:

- through `state_dict()` / `load_state_dict()`;
- through `dumps()` / `loads()` metadata (for both `RoundRobinWriter` and `TensorDictMaxValueWriter`).

Loading remains tolerant of checkpoints produced before this change: when the key is absent, the current counter is left untouched instead of raising.

## Motivation

`write_count` is the natural cumulative progress counter of a replay buffer and is increasingly used for scheduling and monitoring decisions. A counter that silently rewinds on resume makes any such logic misbehave and makes a counter decrease indistinguishable from an intentional `empty()`.
