### PR TITLE
[Feature] Add ReplayBuffer.stats() for lightweight monitoring

### DIFF
--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import functools
+import json
 
 import pytest
 import torch
@@ -1128,6 +1129,59 @@ def test_replay_buffer_prefetch_queue_length():
     assert (
         len(rb._prefetch_queue) == 2
     ), f"Expected prefetch queue to have 2 items, but got {len(rb._prefetch_queue)}."
+
+
+class TestBufferStats:
+    def test_stats_tracks_writes(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10), batch_size=2)
+        stats = rb.stats()
+        assert stats["size"] == 0
+        assert stats["write_count"] == 0
+        assert stats["capacity"] == 10
+        assert stats["utilization"] == 0.0
+        assert stats["prefetch_queue_size"] == 0
+        assert stats["initialized"]
+        rb.extend(torch.arange(15))
+        stats = rb.stats()
+        assert stats["size"] == 10
+        assert stats["write_count"] == 15
+        assert stats["utilization"] == 1.0
+
+    def test_stats_is_side_effect_free(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10), batch_size=2)
+        rb.extend(torch.arange(4))
+        before = rb.stats()
+        rb.stats()
+        rb.sample()
+        assert rb.stats() == before
+
+    def test_stats_does_not_initialize_buffer(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10), delayed_init=True)
+        stats = rb.stats()
+        assert stats["initialized"] is False
+        assert stats["size"] == 0
+        assert not rb.initialized
+        rb.extend(torch.arange(3))
+        stats = rb.stats()
+        assert stats["initialized"] is True
+        assert stats["size"] == 3
+
+    def test_stats_after_empty(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10))
+        rb.extend(torch.arange(6))
+        rb.empty(empty_write_count=False)
+        stats = rb.stats()
+        assert stats["size"] == 0
+        assert stats["write_count"] == 6
+        rb.empty()
+        stats = rb.stats()
+        assert stats["write_count"] == 0
+
+    def test_stats_is_serializable(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10))
+        rb.extend(torch.arange(4))
+        deserialized = json.loads(json.dumps(rb.stats()))
+        assert deserialized["size"] == 4
 
 
 if __name__ == "__main__":

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -36,7 +36,7 @@ from torchrl.data.replay_buffers.storages import (
     ListStorage,
     TensorStorage,
 )
-from torchrl.data.replay_buffers.writers import RoundRobinWriter
+from torchrl.data.replay_buffers.writers import ImmutableDatasetWriter, RoundRobinWriter
 from torchrl.envs.transforms.transforms import Transform
 from torchrl.objectives.llm import MCAdvantage
 
@@ -1160,6 +1160,8 @@ class TestBufferStats:
         stats = rb.stats()
         assert stats["initialized"] is False
         assert stats["size"] == 0
+        assert stats["capacity"] == 10
+        assert stats["utilization"] == 0.0
         assert not rb.initialized
         rb.extend(torch.arange(3))
         stats = rb.stats()
@@ -1182,6 +1184,16 @@ class TestBufferStats:
         rb.extend(torch.arange(4))
         deserialized = json.loads(json.dumps(rb.stats()))
         assert deserialized["size"] == 4
+
+    def test_stats_with_non_counting_writer(self):
+        # dataset buffers use ImmutableDatasetWriter, which has no _write_count
+        storage = LazyTensorStorage(10)
+        rb = ReplayBuffer(storage=storage, writer=ImmutableDatasetWriter())
+        storage.set(torch.arange(10), torch.zeros(10))
+        stats = rb.stats()
+        assert stats["size"] == 10
+        assert stats["write_count"] == 0
+        assert stats["capacity"] == 10
 
 
 if __name__ == "__main__":

--- a/test/rb/test_rb_distributed.py
+++ b/test/rb/test_rb_distributed.py
@@ -190,6 +190,29 @@ class TestRayRB:
         finally:
             rb.close()
 
+    def test_ray_rb_stats(self):
+        rb = RayReplayBuffer(
+            storage=partial(LazyTensorStorage, 100), ray_init_config={"num_cpus": 1}
+        )
+        try:
+            stats = rb.stats()
+            assert stats["size"] == 0
+            assert stats["write_count"] == 0
+            rb.extend(
+                TensorDict(
+                    {"x": torch.ones(10, 2), "y": torch.ones(10, 2)}, batch_size=10
+                )
+            )
+            stats = rb.stats()
+            assert stats["size"] == 10
+            assert stats["write_count"] == 10
+            assert stats["capacity"] == 100
+            assert stats["utilization"] == 0.1
+            client = rb.client()
+            assert client.stats()["write_count"] == 10
+        finally:
+            rb.close()
+
     def test_ray_rb_iter(self):
         rb = RayReplayBuffer(
             storage=partial(LazyTensorStorage, 100),

--- a/torchrl/data/replay_buffers/ray_buffer.py
+++ b/torchrl/data/replay_buffers/ray_buffer.py
@@ -74,6 +74,9 @@ class _RayReplayBufferClient:
     def write_count(self):
         return ray.get(self._actor._getattr.remote("write_count"))
 
+    def stats(self):
+        return ray.get(self._actor.stats.remote())
+
     @property
     def dim_extend(self):
         return ray.get(self._actor._getattr.remote("dim_extend"))
@@ -179,6 +182,10 @@ class _LazyDistributedReplayClient:
             {"operation": torch.zeros((), dtype=torch.int64)}, batch_size=[]
         )
         return self._control_client(request, timeout=timeout)
+
+    def stats(self, *, timeout: float | None = None) -> dict[str, int | float | bool]:
+        snapshot = self._stats(timeout=timeout)
+        return {key: value.item() for key, value in snapshot.items()}
 
     def extend(self, data: TensorDictBase, *, timeout: float | None = None):
         if self._extend_client is None:
@@ -541,6 +548,13 @@ class RayReplayBuffer(ReplayBuffer):
     @property
     def write_count(self):
         return self._client.write_count
+
+    def stats(self) -> dict[str, int | float | bool]:
+        """Returns the buffer stats snapshot through a single actor round-trip.
+
+        See :meth:`~torchrl.data.ReplayBuffer.stats`.
+        """
+        return self._client.stats()
 
     @property
     def dim_extend(self):

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -939,18 +939,24 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
 
         Calling this method on an uninitialized buffer does not trigger its
         initialization; an empty snapshot with ``initialized=False`` is
-        returned instead.
+        returned instead (``capacity`` is still reported when the storage
+        already advertises it).
 
         Returns:
             A dictionary with the following entries:
 
             - ``"size"``: current number of elements in the buffer (mirrors ``len(buffer)``);
-            - ``"write_count"``: total number of items written through ``add`` and ``extend``;
+            - ``"write_count"``: total number of items written through ``add`` and
+              ``extend`` (``0`` for writers that do not track writes, such as
+              :class:`~torchrl.data.replay_buffers.writers.ImmutableDatasetWriter`);
             - ``"prefetch_queue_size"``: number of pending prefetched batches;
             - ``"initialized"``: whether the buffer components are initialized;
             - ``"capacity"``: maximum number of elements the storage can hold
               (only present when the storage advertises a ``max_size``);
             - ``"utilization"``: ``size / capacity`` (only present alongside ``capacity``).
+
+            Remote clients backed by the distributed transport report a subset
+            of these entries (``size`` and ``write_count``).
 
         Examples:
             >>> import torch
@@ -962,16 +968,24 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             5 5 10
         """
         if not self.initialized:
-            return {
+            stats = {
                 "size": 0,
                 "write_count": 0,
                 "prefetch_queue_size": 0,
                 "initialized": False,
             }
+            storage = getattr(self, "_storage", None) or getattr(
+                self, "_init_storage", None
+            )
+            capacity = getattr(storage, "max_size", None)
+            if isinstance(capacity, int):
+                stats["capacity"] = capacity
+                stats["utilization"] = 0.0
+            return stats
         with self._replay_lock:
             size = len(self)
             capacity = getattr(self._storage, "max_size", None)
-            write_count = self._writer._write_count
+            write_count = getattr(self._writer, "_write_count", 0)
             prefetch_queue_size = len(self._prefetch_queue)
         stats = {
             "size": int(size),

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -927,6 +927,63 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
         """The total number of items written so far in the buffer through add and extend."""
         return self._writer._write_count
 
+    def stats(self) -> dict[str, int | float | bool]:
+        """Returns a cheap, serializable snapshot of the buffer's operational state.
+
+        The snapshot only contains scalar counters and gauges. It never
+        includes the storage content, does not modify the buffer state and is
+        safe to call concurrently with writes and samples. Cumulative
+        counters such as ``write_count`` are meant to be converted into rates
+        by an external monitor such as
+        :class:`~torchrl.record.loggers.monitoring.LoggerMonitor`.
+
+        Calling this method on an uninitialized buffer does not trigger its
+        initialization; an empty snapshot with ``initialized=False`` is
+        returned instead.
+
+        Returns:
+            A dictionary with the following entries:
+
+            - ``"size"``: current number of elements in the buffer (mirrors ``len(buffer)``);
+            - ``"write_count"``: total number of items written through ``add`` and ``extend``;
+            - ``"prefetch_queue_size"``: number of pending prefetched batches;
+            - ``"initialized"``: whether the buffer components are initialized;
+            - ``"capacity"``: maximum number of elements the storage can hold
+              (only present when the storage advertises a ``max_size``);
+            - ``"utilization"``: ``size / capacity`` (only present alongside ``capacity``).
+
+        Examples:
+            >>> import torch
+            >>> from torchrl.data import LazyTensorStorage, ReplayBuffer
+            >>> rb = ReplayBuffer(storage=LazyTensorStorage(10))
+            >>> rb.extend(torch.arange(5))
+            >>> snapshot = rb.stats()
+            >>> print(snapshot["size"], snapshot["write_count"], snapshot["capacity"])
+            5 5 10
+        """
+        if not self.initialized:
+            return {
+                "size": 0,
+                "write_count": 0,
+                "prefetch_queue_size": 0,
+                "initialized": False,
+            }
+        with self._replay_lock:
+            size = len(self)
+            capacity = getattr(self._storage, "max_size", None)
+            write_count = self._writer._write_count
+            prefetch_queue_size = len(self._prefetch_queue)
+        stats = {
+            "size": int(size),
+            "write_count": int(write_count),
+            "prefetch_queue_size": int(prefetch_queue_size),
+            "initialized": True,
+        }
+        if capacity is not None:
+            stats["capacity"] = int(capacity)
+            stats["utilization"] = float(size) / capacity if capacity else 0.0
+        return stats
+
     def __repr__(self) -> str:
         from torchrl.envs.transforms import Compose
 


### PR DESCRIPTION
## Description

First implementation step of the collector/replay-buffer monitoring RFC: a cheap, side-effect-free, serializable `stats()` snapshot on `ReplayBuffer`.

```python
>>> rb.stats()
{'size': 5, 'write_count': 5, 'prefetch_queue_size': 0, 'initialized': True, 'capacity': 10, 'utilization': 0.5}
```

Contract:

- scalar counters and gauges only, never storage content or `state_dict()`-style state;
- side-effect free and safe to call concurrently with writes and samples (snapshot taken under `_replay_lock`);
- calling it on a delayed-init buffer does not trigger initialization (returns an empty snapshot with `initialized=False`);
- JSON-serializable, directly consumable by `Logger.log_metrics()`;
- cumulative counters (`write_count`) are meant to be turned into rates by an external monitor.

Remote implementations:

- `RayReplayBuffer.stats()` performs a single actor round-trip for the whole snapshot instead of one RPC per attribute (the existing per-property pattern);
- the distributed transport client maps its control-channel stats to the same dictionary contract.