### PR TITLE
[Feature] Add collector stats() snapshots (single, multiprocessing, Ray)

### DIFF
--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -5782,7 +5782,8 @@ class TestCollectorStats:
             assert stats["workers_alive"] == 2
             assert stats["frames"] >= 16
             assert stats["worker_frames"] >= 16
-            both = collector.stats(workers="both")
+            assert stats["requested_frames_per_batch"] == 16
+            both = collector.stats(workers="both", timeout=30.0)
             assert "worker_0/frames" in both
             assert "worker_1/frames" in both
         finally:

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -9,6 +9,7 @@ import contextlib
 import functools
 import gc
 import inspect
+import json
 import os
 import subprocess
 import sys
@@ -5678,6 +5679,112 @@ class TestCollectorRemoteHelpers:
             ) == [0, 1]
             with pytest.raises(ValueError, match="Expected 2 argument entries"):
                 collector.map_fn("get_distant_attr", list_of_args=[("worker_idx",)])
+        finally:
+            collector.shutdown()
+
+
+class TestCollectorStats:
+    def test_single_collector_stats(self):
+        collector = Collector(
+            ContinuousActionVecMockEnv,
+            RandomPolicy(ContinuousActionVecMockEnv().action_spec),
+            frames_per_batch=16,
+            total_frames=32,
+        )
+        try:
+            stats = collector.stats()
+            assert stats["frames"] == 0
+            assert stats["batches"] == 0
+            assert stats["total_frames"] == 32
+            assert stats["requested_frames_per_batch"] == 16
+            assert not stats["completed"]
+            frames_seen = []
+            for _ in collector:
+                frames_seen.append(collector.stats()["frames"])
+            stats = collector.stats()
+            assert frames_seen == [16, 32]
+            assert stats["batches"] == 2
+            assert stats["completed"]
+        finally:
+            collector.shutdown()
+
+    def test_single_collector_stats_policy_version(self):
+        collector = Collector(
+            ContinuousActionVecMockEnv,
+            RandomPolicy(ContinuousActionVecMockEnv().action_spec),
+            frames_per_batch=16,
+            total_frames=32,
+            track_policy_version=True,
+        )
+        try:
+            assert isinstance(collector.stats().get("policy_version"), int)
+        finally:
+            collector.shutdown()
+
+    def test_stats_is_serializable(self):
+        collector = Collector(
+            ContinuousActionVecMockEnv,
+            RandomPolicy(ContinuousActionVecMockEnv().action_spec),
+            frames_per_batch=16,
+            total_frames=32,
+        )
+        try:
+            for _ in collector:
+                break
+            deserialized = json.loads(json.dumps(collector.stats()))
+            assert deserialized["frames"] == 16
+        finally:
+            collector.shutdown()
+
+    @pytest.mark.parametrize("collector_cls", [MultiSyncCollector, MultiAsyncCollector])
+    def test_multiprocess_collector_stats(self, collector_cls):
+        collector = collector_cls(
+            [ContinuousActionVecMockEnv, ContinuousActionVecMockEnv],
+            policy=RandomPolicy(ContinuousActionVecMockEnv().action_spec),
+            frames_per_batch=16,
+            total_frames=32,
+        )
+        try:
+            with pytest.raises(ValueError, match="workers must be one of"):
+                collector.stats(workers="bogus")
+            for _ in collector:
+                break
+            stats = collector.stats()
+            assert stats["workers"] == 2
+            assert stats["workers_alive"] == 2
+            assert stats["frames"] >= 16
+            both = collector.stats(workers="both")
+            assert "frames" in both
+            assert "worker_0/frames" in both
+            assert "worker_1/frames" in both
+            per_worker = collector.stats(workers="per_worker")
+            assert "frames" not in per_worker
+            assert "worker_0/frames" in per_worker
+        finally:
+            collector.shutdown()
+
+    @pytest.mark.skipif(not _has_ray, reason="requires ray.")
+    def test_ray_collector_stats(self):
+        collector = RayCollector(
+            [ContinuousActionVecMockEnv, ContinuousActionVecMockEnv],
+            policy=RandomPolicy(ContinuousActionVecMockEnv().action_spec),
+            frames_per_batch=16,
+            total_frames=32,
+            num_collectors=2,
+            ray_init_config={"num_cpus": 2, "include_dashboard": False},
+            remote_configs={"num_cpus": 1, "num_gpus": 0},
+        )
+        try:
+            for _ in collector:
+                break
+            stats = collector.stats()
+            assert stats["workers"] == 2
+            assert stats["workers_alive"] == 2
+            assert stats["frames"] >= 16
+            assert stats["worker_frames"] >= 16
+            both = collector.stats(workers="both")
+            assert "worker_0/frames" in both
+            assert "worker_1/frames" in both
         finally:
             collector.shutdown()
 

--- a/torchrl/collectors/_base.py
+++ b/torchrl/collectors/_base.py
@@ -402,6 +402,69 @@ class BaseCollector(IterableDataset, metaclass=abc.ABCMeta):
         """
         self.post_collect_hook = hook
 
+    def stats(self) -> dict[str, int | float | bool]:
+        """Returns a cheap, serializable snapshot of the collector's progress.
+
+        The snapshot only contains scalar counters and gauges: it never
+        includes policy, environment or batch data, does not modify the
+        collector state and is safe to call while the collector is running.
+        Cumulative counters such as ``frames`` are meant to be converted into
+        rates by an external monitor such as
+        :class:`~torchrl.record.loggers.monitoring.LoggerMonitor`.
+
+        Entries are only present when the corresponding state exists on the
+        collector:
+
+        - ``"frames"``: total number of frames collected so far;
+        - ``"batches"``: number of batches delivered so far;
+        - ``"total_frames"``: requested total frames (absent for endless collectors);
+        - ``"completed"``: whether the frame budget has been reached;
+        - ``"requested_frames_per_batch"``: the per-batch frame budget;
+        - ``"policy_version"``: current policy version, when the collector
+          tracks it with an integer version.
+
+        Multi-worker collectors extend this signature with a ``workers``
+        argument controlling aggregate versus per-worker views.
+
+        Examples:
+            >>> from torchrl.collectors import Collector
+            >>> from torchrl.envs import GymEnv
+            >>> from torchrl.envs.utils import RandomPolicy
+            >>> env = GymEnv("Pendulum-v1")
+            >>> collector = Collector(
+            ...     env,
+            ...     RandomPolicy(env.action_spec),
+            ...     frames_per_batch=10,
+            ...     total_frames=20,
+            ... )
+            >>> for batch in collector:
+            ...     print(collector.stats()["frames"])
+            10
+            20
+        """
+        stats: dict[str, int | float | bool] = {}
+        frames = getattr(self, "_frames", None)
+        if frames is not None:
+            stats["frames"] = int(frames)
+        iters = getattr(self, "_iter", None)
+        if iters is not None:
+            stats["batches"] = int(iters) + 1
+        total_frames = getattr(self, "total_frames", None)
+        if isinstance(total_frames, int) and total_frames >= 0:
+            stats["total_frames"] = total_frames
+            if frames is not None:
+                stats["completed"] = bool(frames >= total_frames)
+        requested = getattr(self, "requested_frames_per_batch", None)
+        if isinstance(requested, int):
+            stats["requested_frames_per_batch"] = requested
+        try:
+            version = self.policy_version
+        except (AttributeError, RuntimeError):
+            version = None
+        if isinstance(version, int):
+            stats["policy_version"] = version
+        return stats
+
     def enable_profile(
         self,
         *,

--- a/torchrl/collectors/_multi_base.py
+++ b/torchrl/collectors/_multi_base.py
@@ -1851,6 +1851,43 @@ also that the state dict is synchronised across processes if needed."""
             results.append(result)
         return results
 
+    def stats(
+        self, workers: Literal["aggregate", "per_worker", "both"] = "aggregate"
+    ) -> dict[str, int | float | bool]:
+        """Returns a cheap, serializable snapshot of the collector's progress.
+
+        See :meth:`~torchrl.collectors.BaseCollector.stats` for the base
+        entries. On top of those, multiprocessing collectors report
+        ``"workers"`` (number of worker processes) and ``"workers_alive"``.
+
+        Args:
+            workers (str, optional): controls the worker view. With
+                ``"aggregate"`` (default), only coordinator-side counters are
+                reported and no worker communication happens, so the call is
+                safe from any thread. With ``"per_worker"`` or ``"both"``,
+                each worker is queried through the control pipes and its
+                snapshot is namespaced as ``"worker_<idx>/<metric>"``; since
+                this shares the control channel with other coordinator
+                commands, it should not race with concurrent control calls
+                such as weight updates issued from other threads.
+        """
+        if workers not in ("aggregate", "per_worker", "both"):
+            raise ValueError(
+                f"workers must be one of 'aggregate', 'per_worker' or 'both', got {workers!r}."
+            )
+        stats: dict[str, int | float | bool] = {}
+        if workers in ("aggregate", "both"):
+            stats.update(super().stats())
+        procs = getattr(self, "procs", None)
+        stats["workers"] = int(self.num_workers)
+        if procs:
+            stats["workers_alive"] = sum(int(proc.is_alive()) for proc in procs)
+        if workers in ("per_worker", "both"):
+            for idx, worker_stats in enumerate(self.map_fn("stats")):
+                for key, value in worker_stats.items():
+                    stats[f"worker_{idx}/{key}"] = value
+        return stats
+
     def __del__(self):
         try:
             self.shutdown()

--- a/torchrl/collectors/distributed/ray.py
+++ b/torchrl/collectors/distributed/ray.py
@@ -1063,14 +1063,20 @@ class RayCollector(BaseCollector):
         )
 
     def stats(
-        self, workers: Literal["aggregate", "per_worker", "both"] = "aggregate"
+        self,
+        workers: Literal["aggregate", "per_worker", "both"] = "aggregate",
+        *,
+        timeout: float | None = 10.0,
     ) -> dict[str, int | float | bool]:
         """Returns a cheap, serializable snapshot of the collector's progress.
 
         See :meth:`~torchrl.collectors.BaseCollector.stats` for the general
         contract. Worker snapshots are requested from all remote collectors
-        concurrently, one bounded RPC per worker; a worker whose request
-        fails is counted as dead and skipped.
+        concurrently, one RPC per worker bounded by ``timeout``; a worker
+        whose request fails or does not reply in time is counted as dead and
+        skipped. Note that, unlike multiprocessing collectors, every call
+        (including ``workers="aggregate"``) contacts each remote collector to
+        derive ``"workers_alive"`` and ``"worker_frames"``.
 
         Args:
             workers (str, optional): controls the worker view. With
@@ -1081,6 +1087,12 @@ class RayCollector(BaseCollector):
                 ``"worker_<idx>/<metric>"`` instead. ``"both"`` returns the
                 union. ``"workers"`` and ``"workers_alive"`` are always
                 present.
+
+        Keyword Args:
+            timeout (float, optional): how long to wait for the worker
+                snapshots, in seconds, so that a hung worker cannot block the
+                caller (for example a monitoring thread) indefinitely.
+                ``None`` waits forever. Defaults to ``10.0``.
 
         The coordinator-side ``"frames"`` counter tracks frames dispatched
         through the iterator. When remote collectors write directly into a
@@ -1095,21 +1107,27 @@ class RayCollector(BaseCollector):
         stats: dict[str, int | float | bool] = {}
         if workers in ("aggregate", "both"):
             stats["frames"] = int(self.collected_frames)
-            stats["frames_per_batch"] = int(self.frames_per_batch)
+            stats["requested_frames_per_batch"] = int(self.frames_per_batch)
             if isinstance(self.total_frames, int) and self.total_frames >= 0:
                 stats["total_frames"] = int(self.total_frames)
                 stats["completed"] = bool(self.collected_frames >= self.total_frames)
         remote_collectors = self.remote_collectors
         stats["workers"] = len(remote_collectors)
         futures = [collector.stats.remote() for collector in remote_collectors]
+        ready = set()
+        if futures:
+            ready_list, _ = ray.wait(futures, num_returns=len(futures), timeout=timeout)
+            ready = set(ready_list)
         per_worker = []
         alive = 0
         for future in futures:
-            try:
-                snapshot = ray.get(future)
-                alive += 1
-            except Exception:
-                snapshot = None
+            snapshot = None
+            if future in ready:
+                try:
+                    snapshot = ray.get(future)
+                    alive += 1
+                except Exception:
+                    snapshot = None
             per_worker.append(snapshot)
         stats["workers_alive"] = alive
         if workers in ("aggregate", "both"):

--- a/torchrl/collectors/distributed/ray.py
+++ b/torchrl/collectors/distributed/ray.py
@@ -10,7 +10,7 @@ import threading
 import warnings
 from collections import OrderedDict
 from collections.abc import Callable, Iterator, Sequence
-from typing import Any
+from typing import Any, Literal
 
 import torch
 import torch.nn as nn
@@ -1061,6 +1061,72 @@ class RayCollector(BaseCollector):
                 for collector in self.remote_collectors
             ]
         )
+
+    def stats(
+        self, workers: Literal["aggregate", "per_worker", "both"] = "aggregate"
+    ) -> dict[str, int | float | bool]:
+        """Returns a cheap, serializable snapshot of the collector's progress.
+
+        See :meth:`~torchrl.collectors.BaseCollector.stats` for the general
+        contract. Worker snapshots are requested from all remote collectors
+        concurrently, one bounded RPC per worker; a worker whose request
+        fails is counted as dead and skipped.
+
+        Args:
+            workers (str, optional): controls the worker view. With
+                ``"aggregate"`` (default), the snapshot contains the
+                coordinator counters plus ``"worker_frames"``, the sum of the
+                frame counters reported by the remote collectors. With
+                ``"per_worker"``, each remote snapshot is namespaced as
+                ``"worker_<idx>/<metric>"`` instead. ``"both"`` returns the
+                union. ``"workers"`` and ``"workers_alive"`` are always
+                present.
+
+        The coordinator-side ``"frames"`` counter tracks frames dispatched
+        through the iterator. When remote collectors write directly into a
+        replay buffer, the buffer's ``write_count`` is the authoritative
+        production counter and ``"worker_frames"`` is the closest
+        collector-side estimate.
+        """
+        if workers not in ("aggregate", "per_worker", "both"):
+            raise ValueError(
+                f"workers must be one of 'aggregate', 'per_worker' or 'both', got {workers!r}."
+            )
+        stats: dict[str, int | float | bool] = {}
+        if workers in ("aggregate", "both"):
+            stats["frames"] = int(self.collected_frames)
+            stats["frames_per_batch"] = int(self.frames_per_batch)
+            if isinstance(self.total_frames, int) and self.total_frames >= 0:
+                stats["total_frames"] = int(self.total_frames)
+                stats["completed"] = bool(self.collected_frames >= self.total_frames)
+        remote_collectors = self.remote_collectors
+        stats["workers"] = len(remote_collectors)
+        futures = [collector.stats.remote() for collector in remote_collectors]
+        per_worker = []
+        alive = 0
+        for future in futures:
+            try:
+                snapshot = ray.get(future)
+                alive += 1
+            except Exception:
+                snapshot = None
+            per_worker.append(snapshot)
+        stats["workers_alive"] = alive
+        if workers in ("aggregate", "both"):
+            worker_frames = [
+                snapshot["frames"]
+                for snapshot in per_worker
+                if snapshot is not None and "frames" in snapshot
+            ]
+            if worker_frames:
+                stats["worker_frames"] = int(sum(worker_frames))
+        if workers in ("per_worker", "both"):
+            for idx, snapshot in enumerate(per_worker):
+                if snapshot is None:
+                    continue
+                for key, value in snapshot.items():
+                    stats[f"worker_{idx}/{key}"] = value
+        return stats
 
     def _install_profile_hooks(self, config: ProfileConfig) -> None:
         """Install per-actor :class:`_ProfilerHook` on each selected remote actor.


### PR DESCRIPTION
## Description

Collector-side implementation step of the monitoring RFC: a cheap, side-effect-free `stats()` snapshot on `BaseCollector` and worker-aware overrides for multiprocessing and Ray collectors.
