### PR TITLE
[Feature] Add LoggerMonitor and Every for pull-based operational monitoring

### DIFF
--- a/docs/source/reference/trainers_loggers.rst
+++ b/docs/source/reference/trainers_loggers.rst
@@ -45,6 +45,40 @@ backpressure when several clients log concurrently.
     get_logger
     generate_exp_name
 
+Monitoring collectors and replay buffers
+----------------------------------------
+
+Any collector or replay buffer exposes a cheap
+:meth:`~torchrl.collectors.BaseCollector.stats` /
+:meth:`~torchrl.data.ReplayBuffer.stats` snapshot of operational counters
+(frames collected, buffer size, write count, worker liveness, ...). A
+:class:`~torchrl.record.loggers.monitoring.LoggerMonitor` periodically pulls
+those snapshots on a wall-clock or counter
+(:class:`~torchrl.record.loggers.monitoring.Every`) schedule, derives rates
+such as frames per second, and forwards namespaced metrics to any logger,
+without adding work to collection or sampling hot paths. This works with
+local, multiprocessing and Ray implementations alike.
+
+.. code-block:: python
+
+    from torchrl.record import WandbLogger
+    from torchrl.record.loggers.monitoring import Every, LoggerMonitor
+
+    logger = WandbLogger(exp_name="experiment", project="torchrl")
+
+    with LoggerMonitor(logger, poll_interval=1.0) as monitor:
+        monitor.watch(collector, name="collector", schedule=Every.counter("frames", 10_000))
+        monitor.watch(replay_buffer, name="replay_buffer", schedule=Every.seconds(5), step="write_count")
+        collector.start()
+        run_training()
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template_fun.rst
+
+    monitoring.LoggerMonitor
+    monitoring.Every
+
 Recording utils
 ---------------
 

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import functools
+import json
 
 import pytest
 import torch
@@ -1128,6 +1129,59 @@ def test_replay_buffer_prefetch_queue_length():
     assert (
         len(rb._prefetch_queue) == 2
     ), f"Expected prefetch queue to have 2 items, but got {len(rb._prefetch_queue)}."
+
+
+class TestBufferStats:
+    def test_stats_tracks_writes(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10), batch_size=2)
+        stats = rb.stats()
+        assert stats["size"] == 0
+        assert stats["write_count"] == 0
+        assert stats["capacity"] == 10
+        assert stats["utilization"] == 0.0
+        assert stats["prefetch_queue_size"] == 0
+        assert stats["initialized"]
+        rb.extend(torch.arange(15))
+        stats = rb.stats()
+        assert stats["size"] == 10
+        assert stats["write_count"] == 15
+        assert stats["utilization"] == 1.0
+
+    def test_stats_is_side_effect_free(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10), batch_size=2)
+        rb.extend(torch.arange(4))
+        before = rb.stats()
+        rb.stats()
+        rb.sample()
+        assert rb.stats() == before
+
+    def test_stats_does_not_initialize_buffer(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10), delayed_init=True)
+        stats = rb.stats()
+        assert stats["initialized"] is False
+        assert stats["size"] == 0
+        assert not rb.initialized
+        rb.extend(torch.arange(3))
+        stats = rb.stats()
+        assert stats["initialized"] is True
+        assert stats["size"] == 3
+
+    def test_stats_after_empty(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10))
+        rb.extend(torch.arange(6))
+        rb.empty(empty_write_count=False)
+        stats = rb.stats()
+        assert stats["size"] == 0
+        assert stats["write_count"] == 6
+        rb.empty()
+        stats = rb.stats()
+        assert stats["write_count"] == 0
+
+    def test_stats_is_serializable(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10))
+        rb.extend(torch.arange(4))
+        deserialized = json.loads(json.dumps(rb.stats()))
+        assert deserialized["size"] == 4
 
 
 if __name__ == "__main__":

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -36,7 +36,7 @@ from torchrl.data.replay_buffers.storages import (
     ListStorage,
     TensorStorage,
 )
-from torchrl.data.replay_buffers.writers import RoundRobinWriter
+from torchrl.data.replay_buffers.writers import ImmutableDatasetWriter, RoundRobinWriter
 from torchrl.envs.transforms.transforms import Transform
 from torchrl.objectives.llm import MCAdvantage
 
@@ -1160,6 +1160,8 @@ class TestBufferStats:
         stats = rb.stats()
         assert stats["initialized"] is False
         assert stats["size"] == 0
+        assert stats["capacity"] == 10
+        assert stats["utilization"] == 0.0
         assert not rb.initialized
         rb.extend(torch.arange(3))
         stats = rb.stats()
@@ -1182,6 +1184,16 @@ class TestBufferStats:
         rb.extend(torch.arange(4))
         deserialized = json.loads(json.dumps(rb.stats()))
         assert deserialized["size"] == 4
+
+    def test_stats_with_non_counting_writer(self):
+        # dataset buffers use ImmutableDatasetWriter, which has no _write_count
+        storage = LazyTensorStorage(10)
+        rb = ReplayBuffer(storage=storage, writer=ImmutableDatasetWriter())
+        storage.set(torch.arange(10), torch.zeros(10))
+        stats = rb.stats()
+        assert stats["size"] == 10
+        assert stats["write_count"] == 0
+        assert stats["capacity"] == 10
 
 
 if __name__ == "__main__":

--- a/test/rb/test_rb_distributed.py
+++ b/test/rb/test_rb_distributed.py
@@ -190,6 +190,29 @@ class TestRayRB:
         finally:
             rb.close()
 
+    def test_ray_rb_stats(self):
+        rb = RayReplayBuffer(
+            storage=partial(LazyTensorStorage, 100), ray_init_config={"num_cpus": 1}
+        )
+        try:
+            stats = rb.stats()
+            assert stats["size"] == 0
+            assert stats["write_count"] == 0
+            rb.extend(
+                TensorDict(
+                    {"x": torch.ones(10, 2), "y": torch.ones(10, 2)}, batch_size=10
+                )
+            )
+            stats = rb.stats()
+            assert stats["size"] == 10
+            assert stats["write_count"] == 10
+            assert stats["capacity"] == 100
+            assert stats["utilization"] == 0.1
+            client = rb.client()
+            assert client.stats()["write_count"] == 10
+        finally:
+            rb.close()
+
     def test_ray_rb_iter(self):
         rb = RayReplayBuffer(
             storage=partial(LazyTensorStorage, 100),

--- a/test/rb/test_writers.py
+++ b/test/rb/test_writers.py
@@ -13,6 +13,7 @@ from torch import multiprocessing as mp
 
 from torchrl.data import (
     PrioritizedReplayBuffer,
+    ReplayBuffer,
     TensorDictPrioritizedReplayBuffer,
     TensorDictReplayBuffer,
 )
@@ -28,6 +29,7 @@ from torchrl.data.replay_buffers.storages import (
     ListStorage,
 )
 from torchrl.data.replay_buffers.writers import (
+    RoundRobinWriter,
     TensorDictMaxValueWriter,
     TensorDictRoundRobinWriter,
 )
@@ -368,6 +370,37 @@ class TestMultiProc:
         # list storage cannot be shared
         with pytest.raises(RuntimeError, match="it has not been initialized yet"):
             self.exec_multiproc_rb(init=False)
+
+
+class TestWriterStateDict:
+    def test_roundrobin_state_dict_restores_write_count(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10))
+        rb.extend(torch.arange(15))
+        assert rb.write_count == 15
+        sd = rb.state_dict()
+        rb2 = ReplayBuffer(storage=LazyTensorStorage(10))
+        rb2.load_state_dict(sd)
+        assert rb2.write_count == 15
+        assert rb2._writer._cursor == rb._writer._cursor
+
+    def test_roundrobin_load_legacy_state_dict_without_write_count(self):
+        rb = ReplayBuffer(storage=LazyTensorStorage(10))
+        rb.extend(torch.arange(5))
+        sd = rb.state_dict()
+        del sd["_writer"]["_write_count"]
+        rb2 = ReplayBuffer(storage=LazyTensorStorage(10))
+        rb2.load_state_dict(sd)
+        assert rb2._writer._cursor == 5
+
+    def test_roundrobin_dumps_loads_write_count(self, tmp_path):
+        writer = RoundRobinWriter()
+        writer._cursor = 3
+        writer._write_count = 23
+        writer.dumps(tmp_path)
+        writer2 = RoundRobinWriter()
+        writer2.loads(tmp_path)
+        assert writer2._cursor == 3
+        assert writer2._write_count == 23
 
 
 if __name__ == "__main__":

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -5782,7 +5782,8 @@ class TestCollectorStats:
             assert stats["workers_alive"] == 2
             assert stats["frames"] >= 16
             assert stats["worker_frames"] >= 16
-            both = collector.stats(workers="both")
+            assert stats["requested_frames_per_batch"] == 16
+            both = collector.stats(workers="both", timeout=30.0)
             assert "worker_0/frames" in both
             assert "worker_1/frames" in both
         finally:

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -9,6 +9,7 @@ import contextlib
 import functools
 import gc
 import inspect
+import json
 import os
 import subprocess
 import sys
@@ -5678,6 +5679,112 @@ class TestCollectorRemoteHelpers:
             ) == [0, 1]
             with pytest.raises(ValueError, match="Expected 2 argument entries"):
                 collector.map_fn("get_distant_attr", list_of_args=[("worker_idx",)])
+        finally:
+            collector.shutdown()
+
+
+class TestCollectorStats:
+    def test_single_collector_stats(self):
+        collector = Collector(
+            ContinuousActionVecMockEnv,
+            RandomPolicy(ContinuousActionVecMockEnv().action_spec),
+            frames_per_batch=16,
+            total_frames=32,
+        )
+        try:
+            stats = collector.stats()
+            assert stats["frames"] == 0
+            assert stats["batches"] == 0
+            assert stats["total_frames"] == 32
+            assert stats["requested_frames_per_batch"] == 16
+            assert not stats["completed"]
+            frames_seen = []
+            for _ in collector:
+                frames_seen.append(collector.stats()["frames"])
+            stats = collector.stats()
+            assert frames_seen == [16, 32]
+            assert stats["batches"] == 2
+            assert stats["completed"]
+        finally:
+            collector.shutdown()
+
+    def test_single_collector_stats_policy_version(self):
+        collector = Collector(
+            ContinuousActionVecMockEnv,
+            RandomPolicy(ContinuousActionVecMockEnv().action_spec),
+            frames_per_batch=16,
+            total_frames=32,
+            track_policy_version=True,
+        )
+        try:
+            assert isinstance(collector.stats().get("policy_version"), int)
+        finally:
+            collector.shutdown()
+
+    def test_stats_is_serializable(self):
+        collector = Collector(
+            ContinuousActionVecMockEnv,
+            RandomPolicy(ContinuousActionVecMockEnv().action_spec),
+            frames_per_batch=16,
+            total_frames=32,
+        )
+        try:
+            for _ in collector:
+                break
+            deserialized = json.loads(json.dumps(collector.stats()))
+            assert deserialized["frames"] == 16
+        finally:
+            collector.shutdown()
+
+    @pytest.mark.parametrize("collector_cls", [MultiSyncCollector, MultiAsyncCollector])
+    def test_multiprocess_collector_stats(self, collector_cls):
+        collector = collector_cls(
+            [ContinuousActionVecMockEnv, ContinuousActionVecMockEnv],
+            policy=RandomPolicy(ContinuousActionVecMockEnv().action_spec),
+            frames_per_batch=16,
+            total_frames=32,
+        )
+        try:
+            with pytest.raises(ValueError, match="workers must be one of"):
+                collector.stats(workers="bogus")
+            for _ in collector:
+                break
+            stats = collector.stats()
+            assert stats["workers"] == 2
+            assert stats["workers_alive"] == 2
+            assert stats["frames"] >= 16
+            both = collector.stats(workers="both")
+            assert "frames" in both
+            assert "worker_0/frames" in both
+            assert "worker_1/frames" in both
+            per_worker = collector.stats(workers="per_worker")
+            assert "frames" not in per_worker
+            assert "worker_0/frames" in per_worker
+        finally:
+            collector.shutdown()
+
+    @pytest.mark.skipif(not _has_ray, reason="requires ray.")
+    def test_ray_collector_stats(self):
+        collector = RayCollector(
+            [ContinuousActionVecMockEnv, ContinuousActionVecMockEnv],
+            policy=RandomPolicy(ContinuousActionVecMockEnv().action_spec),
+            frames_per_batch=16,
+            total_frames=32,
+            num_collectors=2,
+            ray_init_config={"num_cpus": 2, "include_dashboard": False},
+            remote_configs={"num_cpus": 1, "num_gpus": 0},
+        )
+        try:
+            for _ in collector:
+                break
+            stats = collector.stats()
+            assert stats["workers"] == 2
+            assert stats["workers_alive"] == 2
+            assert stats["frames"] >= 16
+            assert stats["worker_frames"] >= 16
+            both = collector.stats(workers="both")
+            assert "worker_0/frames" in both
+            assert "worker_1/frames" in both
         finally:
             collector.shutdown()
 

--- a/test/test_loggers.py
+++ b/test/test_loggers.py
@@ -20,10 +20,12 @@ from tensordict import MemoryMappedTensor
 
 from torchrl._comm import MailboxPeerClosedError
 from torchrl.checkpoint import Checkpoint
+from torchrl.data import LazyTensorStorage, ReplayBuffer
 from torchrl.envs import check_env_specs, GymEnv, ParallelEnv
 from torchrl.record.loggers.common import _has_torchcodec, Logger
 from torchrl.record.loggers.csv import CSVLogger
 from torchrl.record.loggers.mlflow import _has_mlflow, MLFlowLogger
+from torchrl.record.loggers.monitoring import Every, LoggerMonitor
 from torchrl.record.loggers.process import ProcessLogger
 from torchrl.record.loggers.ray import _RayLoggerClient, RayLogger
 from torchrl.record.loggers.tensorboard import _has_tb, TensorboardLogger
@@ -1300,6 +1302,200 @@ class TestRayLogger:
             logger = get_logger("csv", tmpdir, "test_get_logger", use_ray_service=True)
             assert isinstance(logger, RayLogger)
             logger.log_scalar("x", 1.0, step=0)
+
+
+class _RecordingLogger(Logger):
+    def __init__(self):
+        self.calls = []
+        super().__init__(exp_name="recording", log_dir=tempfile.mkdtemp())
+
+    def _create_experiment(self):
+        return None
+
+    def log_scalar(self, name, value, step=None):
+        self.calls.append((name, value, step))
+
+    def log_video(self, name, video, step=None, **kwargs):
+        raise NotImplementedError
+
+    def log_hparams(self, cfg):
+        raise NotImplementedError
+
+    def __repr__(self):
+        return "RecordingLogger()"
+
+    def log_histogram(self, name, data, **kwargs):
+        raise NotImplementedError
+
+
+class _FakeStatsSource:
+    def __init__(self):
+        self.counters = {"frames": 0, "write_count": 0}
+        self.fail = False
+
+    def stats(self):
+        if self.fail:
+            raise RuntimeError("stats failure")
+        return {**self.counters, "note": "not-a-number"}
+
+
+class TestLoggerMonitor:
+    def test_every_validation(self):
+        assert Every.seconds(5.0).kind == "seconds"
+        counter = Every.counter("frames", 100)
+        assert counter.key == "frames"
+        with pytest.raises(ValueError, match="strictly positive"):
+            Every.seconds(0)
+        with pytest.raises(ValueError, match="counter key"):
+            Every(kind="counter", interval=10)
+        with pytest.raises(ValueError, match="kind"):
+            Every(kind="minutes", interval=10)
+
+    def test_manual_step_logs_namespaced_numeric_metrics(self):
+        logger = _RecordingLogger()
+        source = _FakeStatsSource()
+        monitor = LoggerMonitor(logger, background=False)
+        monitor.watch(source, name="src")
+        logged = monitor.step()
+        assert "src/frames" in logged["src"]
+        assert "src/note" not in logged["src"]
+        assert ("src/frames", 0.0, None) in logger.calls
+
+    def test_watch_rejects_targets_without_stats(self):
+        monitor = LoggerMonitor(_RecordingLogger(), background=False)
+        with pytest.raises(TypeError, match="stats"):
+            monitor.watch(object(), name="src")
+
+    def test_duplicate_and_default_names(self):
+        monitor = LoggerMonitor(_RecordingLogger(), background=False)
+        source = _FakeStatsSource()
+        monitor.watch(source, name="src")
+        with pytest.raises(ValueError, match="already registered"):
+            monitor.watch(source, name="src")
+        first = monitor.watch(source)
+        second = monitor.watch(source)
+        assert first == "_fakestatssource"
+        assert second == "_fakestatssource_1"
+        monitor.unwatch(second)
+        with pytest.raises(KeyError):
+            monitor.unwatch(second)
+
+    def test_counter_schedule_thresholds(self):
+        logger = _RecordingLogger()
+        source = _FakeStatsSource()
+        monitor = LoggerMonitor(logger, background=False)
+        monitor.watch(
+            source,
+            name="src",
+            schedule=Every.counter("frames", 100),
+            log_on_start=False,
+        )
+        assert monitor.step() == {}
+        source.counters["frames"] = 50
+        assert monitor.step() == {}
+        source.counters["frames"] = 120
+        logged = monitor.step()
+        assert logged["src"]["src/frames"] == 120.0
+        source.counters["frames"] = 180
+        assert monitor.step() == {}
+        source.counters["frames"] = 410
+        logged = monitor.step()
+        assert logged["src"]["src/frames"] == 410.0
+        assert len([c for c in logger.calls if c[0] == "src/frames"]) == 2
+
+    def test_counter_schedule_uses_counter_as_step(self):
+        logger = _RecordingLogger()
+        source = _FakeStatsSource()
+        monitor = LoggerMonitor(logger, background=False)
+        monitor.watch(source, name="src", schedule=Every.counter("frames", 100))
+        monitor.step()
+        source.counters["frames"] = 150
+        monitor.step()
+        steps = [c[2] for c in logger.calls if c[0] == "src/frames"]
+        assert steps == [0, 150]
+
+    def test_counter_reset_rebaselines_without_negative_rates(self):
+        logger = _RecordingLogger()
+        source = _FakeStatsSource()
+        monitor = LoggerMonitor(logger, background=False)
+        monitor.watch(
+            source,
+            name="src",
+            schedule=Every.counter("frames", 100),
+            log_on_start=False,
+        )
+        monitor.step()
+        source.counters["frames"] = 410
+        assert monitor.step() != {}
+        source.counters["frames"] = 10
+        assert monitor.step() == {}
+        source.counters["frames"] = 120
+        logged = monitor.step()
+        assert logged["src"]["src/frames"] == 120.0
+        rates = [
+            value for name, value, _ in logger.calls if name == "src/frames_per_second"
+        ]
+        assert all(rate >= 0 for rate in rates)
+
+    def test_rates_are_derived_from_counter_deltas(self):
+        logger = _RecordingLogger()
+        source = _FakeStatsSource()
+        monitor = LoggerMonitor(logger, background=False)
+        monitor.watch(source, name="src")
+        monitor.step()
+        source.counters["frames"] = 100
+        source.counters["write_count"] = 50
+        sleep(0.02)
+        logged = monitor.step()
+        assert logged["src"]["src/frames_per_second"] > 0
+        assert logged["src"]["src/writes_per_second"] > 0
+
+    def test_on_error_policies(self):
+        source = _FakeStatsSource()
+        source.fail = True
+        monitor = LoggerMonitor(_RecordingLogger(), background=False, on_error="raise")
+        monitor.watch(source, name="src")
+        with pytest.raises(RuntimeError, match="stats failure"):
+            monitor.step()
+        for policy in ("warn", "ignore"):
+            monitor = LoggerMonitor(
+                _RecordingLogger(), background=False, on_error=policy
+            )
+            monitor.watch(source, name="src")
+            assert monitor.step() == {}
+        with pytest.raises(ValueError, match="on_error"):
+            LoggerMonitor(_RecordingLogger(), on_error="explode")
+
+    def test_background_polling_and_final_snapshot(self):
+        logger = _RecordingLogger()
+        source = _FakeStatsSource()
+        with LoggerMonitor(logger, poll_interval=0.02) as monitor:
+            monitor.watch(source, name="src")
+            deadline = 100
+            while (
+                not any(name == "src/frames" for name, _, _ in logger.calls)
+                and deadline > 0
+            ):
+                sleep(0.02)
+                deadline -= 1
+        assert any(name == "src/frames" for name, _, _ in logger.calls)
+        count_after_exit = len(logger.calls)
+        sleep(0.1)
+        assert len(logger.calls) == count_after_exit
+
+    def test_monitor_with_replay_buffer_and_csv_logger(self, tmp_path):
+        logger = CSVLogger(exp_name="monitor", log_dir=str(tmp_path))
+        rb = ReplayBuffer(storage=LazyTensorStorage(100))
+        monitor = LoggerMonitor(logger, background=False)
+        monitor.watch(rb, name="replay_buffer", step="write_count")
+        rb.extend(torch.arange(10))
+        logged = monitor.step()
+        assert logged["replay_buffer"]["replay_buffer/size"] == 10.0
+        assert logged["replay_buffer"]["replay_buffer/write_count"] == 10.0
+        monitor.stop()
+        scalar_files = list(tmp_path.rglob("*.csv"))
+        assert scalar_files
+        logger.close()
 
 
 if __name__ == "__main__":

--- a/test/test_loggers.py
+++ b/test/test_loggers.py
@@ -1427,8 +1427,14 @@ class TestLoggerMonitor:
         monitor.step()
         source.counters["frames"] = 410
         assert monitor.step() != {}
+        watch = monitor._watches["src"]
+        time_of_last_log = watch.baseline_time
+        sleep(0.02)
         source.counters["frames"] = 10
         assert monitor.step() == {}
+        # the reset also re-baselines the clock, so the next rate only covers
+        # the post-reset window
+        assert watch.baseline_time > time_of_last_log
         source.counters["frames"] = 120
         logged = monitor.step()
         assert logged["src"]["src/frames"] == 120.0
@@ -1436,6 +1442,30 @@ class TestLoggerMonitor:
             value for name, value, _ in logger.calls if name == "src/frames_per_second"
         ]
         assert all(rate >= 0 for rate in rates)
+
+    def test_log_on_start_false_without_schedule_skips_first_poll(self):
+        logger = _RecordingLogger()
+        source = _FakeStatsSource()
+        monitor = LoggerMonitor(logger, background=False)
+        monitor.watch(source, name="src", log_on_start=False)
+        assert monitor.step() == {}
+        source.counters["frames"] = 100
+        sleep(0.02)
+        logged = monitor.step()
+        assert logged["src"]["src/frames"] == 100.0
+        # the baselining first poll lets the very first log carry a rate
+        assert logged["src"]["src/frames_per_second"] > 0
+
+    def test_stop_is_idempotent(self):
+        logger = _RecordingLogger()
+        source = _FakeStatsSource()
+        with LoggerMonitor(logger, poll_interval=60.0) as monitor:
+            monitor.watch(source, name="src")
+            monitor.stop()
+            calls_after_stop = len(logger.calls)
+            assert calls_after_stop > 0  # final snapshot was logged
+        # __exit__ does not log the final snapshots a second time
+        assert len(logger.calls) == calls_after_stop
 
     def test_rates_are_derived_from_counter_deltas(self):
         logger = _RecordingLogger()

--- a/torchrl/collectors/_base.py
+++ b/torchrl/collectors/_base.py
@@ -402,6 +402,69 @@ class BaseCollector(IterableDataset, metaclass=abc.ABCMeta):
         """
         self.post_collect_hook = hook
 
+    def stats(self) -> dict[str, int | float | bool]:
+        """Returns a cheap, serializable snapshot of the collector's progress.
+
+        The snapshot only contains scalar counters and gauges: it never
+        includes policy, environment or batch data, does not modify the
+        collector state and is safe to call while the collector is running.
+        Cumulative counters such as ``frames`` are meant to be converted into
+        rates by an external monitor such as
+        :class:`~torchrl.record.loggers.monitoring.LoggerMonitor`.
+
+        Entries are only present when the corresponding state exists on the
+        collector:
+
+        - ``"frames"``: total number of frames collected so far;
+        - ``"batches"``: number of batches delivered so far;
+        - ``"total_frames"``: requested total frames (absent for endless collectors);
+        - ``"completed"``: whether the frame budget has been reached;
+        - ``"requested_frames_per_batch"``: the per-batch frame budget;
+        - ``"policy_version"``: current policy version, when the collector
+          tracks it with an integer version.
+
+        Multi-worker collectors extend this signature with a ``workers``
+        argument controlling aggregate versus per-worker views.
+
+        Examples:
+            >>> from torchrl.collectors import Collector
+            >>> from torchrl.envs import GymEnv
+            >>> from torchrl.envs.utils import RandomPolicy
+            >>> env = GymEnv("Pendulum-v1")
+            >>> collector = Collector(
+            ...     env,
+            ...     RandomPolicy(env.action_spec),
+            ...     frames_per_batch=10,
+            ...     total_frames=20,
+            ... )
+            >>> for batch in collector:
+            ...     print(collector.stats()["frames"])
+            10
+            20
+        """
+        stats: dict[str, int | float | bool] = {}
+        frames = getattr(self, "_frames", None)
+        if frames is not None:
+            stats["frames"] = int(frames)
+        iters = getattr(self, "_iter", None)
+        if iters is not None:
+            stats["batches"] = int(iters) + 1
+        total_frames = getattr(self, "total_frames", None)
+        if isinstance(total_frames, int) and total_frames >= 0:
+            stats["total_frames"] = total_frames
+            if frames is not None:
+                stats["completed"] = bool(frames >= total_frames)
+        requested = getattr(self, "requested_frames_per_batch", None)
+        if isinstance(requested, int):
+            stats["requested_frames_per_batch"] = requested
+        try:
+            version = self.policy_version
+        except (AttributeError, RuntimeError):
+            version = None
+        if isinstance(version, int):
+            stats["policy_version"] = version
+        return stats
+
     def enable_profile(
         self,
         *,

--- a/torchrl/collectors/_multi_base.py
+++ b/torchrl/collectors/_multi_base.py
@@ -1851,6 +1851,43 @@ also that the state dict is synchronised across processes if needed."""
             results.append(result)
         return results
 
+    def stats(
+        self, workers: Literal["aggregate", "per_worker", "both"] = "aggregate"
+    ) -> dict[str, int | float | bool]:
+        """Returns a cheap, serializable snapshot of the collector's progress.
+
+        See :meth:`~torchrl.collectors.BaseCollector.stats` for the base
+        entries. On top of those, multiprocessing collectors report
+        ``"workers"`` (number of worker processes) and ``"workers_alive"``.
+
+        Args:
+            workers (str, optional): controls the worker view. With
+                ``"aggregate"`` (default), only coordinator-side counters are
+                reported and no worker communication happens, so the call is
+                safe from any thread. With ``"per_worker"`` or ``"both"``,
+                each worker is queried through the control pipes and its
+                snapshot is namespaced as ``"worker_<idx>/<metric>"``; since
+                this shares the control channel with other coordinator
+                commands, it should not race with concurrent control calls
+                such as weight updates issued from other threads.
+        """
+        if workers not in ("aggregate", "per_worker", "both"):
+            raise ValueError(
+                f"workers must be one of 'aggregate', 'per_worker' or 'both', got {workers!r}."
+            )
+        stats: dict[str, int | float | bool] = {}
+        if workers in ("aggregate", "both"):
+            stats.update(super().stats())
+        procs = getattr(self, "procs", None)
+        stats["workers"] = int(self.num_workers)
+        if procs:
+            stats["workers_alive"] = sum(int(proc.is_alive()) for proc in procs)
+        if workers in ("per_worker", "both"):
+            for idx, worker_stats in enumerate(self.map_fn("stats")):
+                for key, value in worker_stats.items():
+                    stats[f"worker_{idx}/{key}"] = value
+        return stats
+
     def __del__(self):
         try:
             self.shutdown()

--- a/torchrl/collectors/distributed/ray.py
+++ b/torchrl/collectors/distributed/ray.py
@@ -1063,14 +1063,20 @@ class RayCollector(BaseCollector):
         )
 
     def stats(
-        self, workers: Literal["aggregate", "per_worker", "both"] = "aggregate"
+        self,
+        workers: Literal["aggregate", "per_worker", "both"] = "aggregate",
+        *,
+        timeout: float | None = 10.0,
     ) -> dict[str, int | float | bool]:
         """Returns a cheap, serializable snapshot of the collector's progress.
 
         See :meth:`~torchrl.collectors.BaseCollector.stats` for the general
         contract. Worker snapshots are requested from all remote collectors
-        concurrently, one bounded RPC per worker; a worker whose request
-        fails is counted as dead and skipped.
+        concurrently, one RPC per worker bounded by ``timeout``; a worker
+        whose request fails or does not reply in time is counted as dead and
+        skipped. Note that, unlike multiprocessing collectors, every call
+        (including ``workers="aggregate"``) contacts each remote collector to
+        derive ``"workers_alive"`` and ``"worker_frames"``.
 
         Args:
             workers (str, optional): controls the worker view. With
@@ -1081,6 +1087,12 @@ class RayCollector(BaseCollector):
                 ``"worker_<idx>/<metric>"`` instead. ``"both"`` returns the
                 union. ``"workers"`` and ``"workers_alive"`` are always
                 present.
+
+        Keyword Args:
+            timeout (float, optional): how long to wait for the worker
+                snapshots, in seconds, so that a hung worker cannot block the
+                caller (for example a monitoring thread) indefinitely.
+                ``None`` waits forever. Defaults to ``10.0``.
 
         The coordinator-side ``"frames"`` counter tracks frames dispatched
         through the iterator. When remote collectors write directly into a
@@ -1095,21 +1107,27 @@ class RayCollector(BaseCollector):
         stats: dict[str, int | float | bool] = {}
         if workers in ("aggregate", "both"):
             stats["frames"] = int(self.collected_frames)
-            stats["frames_per_batch"] = int(self.frames_per_batch)
+            stats["requested_frames_per_batch"] = int(self.frames_per_batch)
             if isinstance(self.total_frames, int) and self.total_frames >= 0:
                 stats["total_frames"] = int(self.total_frames)
                 stats["completed"] = bool(self.collected_frames >= self.total_frames)
         remote_collectors = self.remote_collectors
         stats["workers"] = len(remote_collectors)
         futures = [collector.stats.remote() for collector in remote_collectors]
+        ready = set()
+        if futures:
+            ready_list, _ = ray.wait(futures, num_returns=len(futures), timeout=timeout)
+            ready = set(ready_list)
         per_worker = []
         alive = 0
         for future in futures:
-            try:
-                snapshot = ray.get(future)
-                alive += 1
-            except Exception:
-                snapshot = None
+            snapshot = None
+            if future in ready:
+                try:
+                    snapshot = ray.get(future)
+                    alive += 1
+                except Exception:
+                    snapshot = None
             per_worker.append(snapshot)
         stats["workers_alive"] = alive
         if workers in ("aggregate", "both"):

--- a/torchrl/collectors/distributed/ray.py
+++ b/torchrl/collectors/distributed/ray.py
@@ -10,7 +10,7 @@ import threading
 import warnings
 from collections import OrderedDict
 from collections.abc import Callable, Iterator, Sequence
-from typing import Any
+from typing import Any, Literal
 
 import torch
 import torch.nn as nn
@@ -1061,6 +1061,72 @@ class RayCollector(BaseCollector):
                 for collector in self.remote_collectors
             ]
         )
+
+    def stats(
+        self, workers: Literal["aggregate", "per_worker", "both"] = "aggregate"
+    ) -> dict[str, int | float | bool]:
+        """Returns a cheap, serializable snapshot of the collector's progress.
+
+        See :meth:`~torchrl.collectors.BaseCollector.stats` for the general
+        contract. Worker snapshots are requested from all remote collectors
+        concurrently, one bounded RPC per worker; a worker whose request
+        fails is counted as dead and skipped.
+
+        Args:
+            workers (str, optional): controls the worker view. With
+                ``"aggregate"`` (default), the snapshot contains the
+                coordinator counters plus ``"worker_frames"``, the sum of the
+                frame counters reported by the remote collectors. With
+                ``"per_worker"``, each remote snapshot is namespaced as
+                ``"worker_<idx>/<metric>"`` instead. ``"both"`` returns the
+                union. ``"workers"`` and ``"workers_alive"`` are always
+                present.
+
+        The coordinator-side ``"frames"`` counter tracks frames dispatched
+        through the iterator. When remote collectors write directly into a
+        replay buffer, the buffer's ``write_count`` is the authoritative
+        production counter and ``"worker_frames"`` is the closest
+        collector-side estimate.
+        """
+        if workers not in ("aggregate", "per_worker", "both"):
+            raise ValueError(
+                f"workers must be one of 'aggregate', 'per_worker' or 'both', got {workers!r}."
+            )
+        stats: dict[str, int | float | bool] = {}
+        if workers in ("aggregate", "both"):
+            stats["frames"] = int(self.collected_frames)
+            stats["frames_per_batch"] = int(self.frames_per_batch)
+            if isinstance(self.total_frames, int) and self.total_frames >= 0:
+                stats["total_frames"] = int(self.total_frames)
+                stats["completed"] = bool(self.collected_frames >= self.total_frames)
+        remote_collectors = self.remote_collectors
+        stats["workers"] = len(remote_collectors)
+        futures = [collector.stats.remote() for collector in remote_collectors]
+        per_worker = []
+        alive = 0
+        for future in futures:
+            try:
+                snapshot = ray.get(future)
+                alive += 1
+            except Exception:
+                snapshot = None
+            per_worker.append(snapshot)
+        stats["workers_alive"] = alive
+        if workers in ("aggregate", "both"):
+            worker_frames = [
+                snapshot["frames"]
+                for snapshot in per_worker
+                if snapshot is not None and "frames" in snapshot
+            ]
+            if worker_frames:
+                stats["worker_frames"] = int(sum(worker_frames))
+        if workers in ("per_worker", "both"):
+            for idx, snapshot in enumerate(per_worker):
+                if snapshot is None:
+                    continue
+                for key, value in snapshot.items():
+                    stats[f"worker_{idx}/{key}"] = value
+        return stats
 
     def _install_profile_hooks(self, config: ProfileConfig) -> None:
         """Install per-actor :class:`_ProfilerHook` on each selected remote actor.

--- a/torchrl/data/replay_buffers/ray_buffer.py
+++ b/torchrl/data/replay_buffers/ray_buffer.py
@@ -74,6 +74,9 @@ class _RayReplayBufferClient:
     def write_count(self):
         return ray.get(self._actor._getattr.remote("write_count"))
 
+    def stats(self):
+        return ray.get(self._actor.stats.remote())
+
     @property
     def dim_extend(self):
         return ray.get(self._actor._getattr.remote("dim_extend"))
@@ -179,6 +182,10 @@ class _LazyDistributedReplayClient:
             {"operation": torch.zeros((), dtype=torch.int64)}, batch_size=[]
         )
         return self._control_client(request, timeout=timeout)
+
+    def stats(self, *, timeout: float | None = None) -> dict[str, int | float | bool]:
+        snapshot = self._stats(timeout=timeout)
+        return {key: value.item() for key, value in snapshot.items()}
 
     def extend(self, data: TensorDictBase, *, timeout: float | None = None):
         if self._extend_client is None:
@@ -541,6 +548,13 @@ class RayReplayBuffer(ReplayBuffer):
     @property
     def write_count(self):
         return self._client.write_count
+
+    def stats(self) -> dict[str, int | float | bool]:
+        """Returns the buffer stats snapshot through a single actor round-trip.
+
+        See :meth:`~torchrl.data.ReplayBuffer.stats`.
+        """
+        return self._client.stats()
 
     @property
     def dim_extend(self):

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -939,18 +939,24 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
 
         Calling this method on an uninitialized buffer does not trigger its
         initialization; an empty snapshot with ``initialized=False`` is
-        returned instead.
+        returned instead (``capacity`` is still reported when the storage
+        already advertises it).
 
         Returns:
             A dictionary with the following entries:
 
             - ``"size"``: current number of elements in the buffer (mirrors ``len(buffer)``);
-            - ``"write_count"``: total number of items written through ``add`` and ``extend``;
+            - ``"write_count"``: total number of items written through ``add`` and
+              ``extend`` (``0`` for writers that do not track writes, such as
+              :class:`~torchrl.data.replay_buffers.writers.ImmutableDatasetWriter`);
             - ``"prefetch_queue_size"``: number of pending prefetched batches;
             - ``"initialized"``: whether the buffer components are initialized;
             - ``"capacity"``: maximum number of elements the storage can hold
               (only present when the storage advertises a ``max_size``);
             - ``"utilization"``: ``size / capacity`` (only present alongside ``capacity``).
+
+            Remote clients backed by the distributed transport report a subset
+            of these entries (``size`` and ``write_count``).
 
         Examples:
             >>> import torch
@@ -962,16 +968,24 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             5 5 10
         """
         if not self.initialized:
-            return {
+            stats = {
                 "size": 0,
                 "write_count": 0,
                 "prefetch_queue_size": 0,
                 "initialized": False,
             }
+            storage = getattr(self, "_storage", None) or getattr(
+                self, "_init_storage", None
+            )
+            capacity = getattr(storage, "max_size", None)
+            if isinstance(capacity, int):
+                stats["capacity"] = capacity
+                stats["utilization"] = 0.0
+            return stats
         with self._replay_lock:
             size = len(self)
             capacity = getattr(self._storage, "max_size", None)
-            write_count = self._writer._write_count
+            write_count = getattr(self._writer, "_write_count", 0)
             prefetch_queue_size = len(self._prefetch_queue)
         stats = {
             "size": int(size),

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -927,6 +927,63 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
         """The total number of items written so far in the buffer through add and extend."""
         return self._writer._write_count
 
+    def stats(self) -> dict[str, int | float | bool]:
+        """Returns a cheap, serializable snapshot of the buffer's operational state.
+
+        The snapshot only contains scalar counters and gauges. It never
+        includes the storage content, does not modify the buffer state and is
+        safe to call concurrently with writes and samples. Cumulative
+        counters such as ``write_count`` are meant to be converted into rates
+        by an external monitor such as
+        :class:`~torchrl.record.loggers.monitoring.LoggerMonitor`.
+
+        Calling this method on an uninitialized buffer does not trigger its
+        initialization; an empty snapshot with ``initialized=False`` is
+        returned instead.
+
+        Returns:
+            A dictionary with the following entries:
+
+            - ``"size"``: current number of elements in the buffer (mirrors ``len(buffer)``);
+            - ``"write_count"``: total number of items written through ``add`` and ``extend``;
+            - ``"prefetch_queue_size"``: number of pending prefetched batches;
+            - ``"initialized"``: whether the buffer components are initialized;
+            - ``"capacity"``: maximum number of elements the storage can hold
+              (only present when the storage advertises a ``max_size``);
+            - ``"utilization"``: ``size / capacity`` (only present alongside ``capacity``).
+
+        Examples:
+            >>> import torch
+            >>> from torchrl.data import LazyTensorStorage, ReplayBuffer
+            >>> rb = ReplayBuffer(storage=LazyTensorStorage(10))
+            >>> rb.extend(torch.arange(5))
+            >>> snapshot = rb.stats()
+            >>> print(snapshot["size"], snapshot["write_count"], snapshot["capacity"])
+            5 5 10
+        """
+        if not self.initialized:
+            return {
+                "size": 0,
+                "write_count": 0,
+                "prefetch_queue_size": 0,
+                "initialized": False,
+            }
+        with self._replay_lock:
+            size = len(self)
+            capacity = getattr(self._storage, "max_size", None)
+            write_count = self._writer._write_count
+            prefetch_queue_size = len(self._prefetch_queue)
+        stats = {
+            "size": int(size),
+            "write_count": int(write_count),
+            "prefetch_queue_size": int(prefetch_queue_size),
+            "initialized": True,
+        }
+        if capacity is not None:
+            stats["capacity"] = int(capacity)
+            stats["utilization"] = float(size) / capacity if capacity else 0.0
+        return stats
+
     def __repr__(self) -> str:
         from torchrl.envs.transforms import Compose
 

--- a/torchrl/data/replay_buffers/writers.py
+++ b/torchrl/data/replay_buffers/writers.py
@@ -164,13 +164,16 @@ class RoundRobinWriter(Writer):
         path = Path(path).absolute()
         path.mkdir(exist_ok=True)
         with open(path / "metadata.json", "w") as file:
-            json.dump({"cursor": self._cursor}, file)
+            json.dump({"cursor": self._cursor, "write_count": self._write_count}, file)
 
     def loads(self, path):
         path = Path(path).absolute()
         with open(path / "metadata.json") as file:
             metadata = json.load(file)
             self._cursor = metadata["cursor"]
+            write_count = metadata.get("write_count")
+            if write_count is not None:
+                self._write_count = write_count
 
     def add(self, data: Any) -> int | torch.Tensor:
         index = self._cursor
@@ -246,10 +249,13 @@ class RoundRobinWriter(Writer):
         )
 
     def state_dict(self) -> dict[str, Any]:
-        return {"_cursor": self._cursor}
+        return {"_cursor": self._cursor, "_write_count": self._write_count}
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         self._cursor = state_dict["_cursor"]
+        write_count = state_dict.get("_write_count")
+        if write_count is not None:
+            self._write_count = write_count
 
     def _empty(self, empty_write_count: bool = True) -> None:
         self._cursor = 0
@@ -692,6 +698,7 @@ class TensorDictMaxValueWriter(Writer):
             json.dump(
                 {
                     "cursor": self._cursor,
+                    "write_count": self._write_count,
                     "rank_key": self._rank_key,
                     "dtype": str(t.dtype),
                     "shape": list(t.shape),
@@ -704,6 +711,9 @@ class TensorDictMaxValueWriter(Writer):
         with open(path / "metadata.json") as file:
             metadata = json.load(file)
             self._cursor = metadata["cursor"]
+            write_count = metadata.get("write_count")
+            if write_count is not None:
+                self._write_count = write_count
             self._rank_key = metadata["rank_key"]
             shape = torch.Size(metadata["shape"])
             dtype = metadata["dtype"]

--- a/torchrl/record/__init__.py
+++ b/torchrl/record/__init__.py
@@ -5,6 +5,8 @@
 
 from .loggers import (
     CSVLogger,
+    Every,
+    LoggerMonitor,
     MLFlowLogger,
     ProcessLogger,
     RayLogger,
@@ -15,6 +17,8 @@ from .recorder import PixelRenderTransform, TensorDictRecorder, VideoRecorder
 
 __all__ = [
     "CSVLogger",
+    "Every",
+    "LoggerMonitor",
     "MLFlowLogger",
     "ProcessLogger",
     "RayLogger",

--- a/torchrl/record/loggers/__init__.py
+++ b/torchrl/record/loggers/__init__.py
@@ -7,6 +7,7 @@ from .common import Logger
 
 from .csv import CSVLogger
 from .mlflow import MLFlowLogger
+from .monitoring import Every, LoggerMonitor
 from .process import ProcessLogger
 from .ray import RayLogger
 from .tensorboard import TensorboardLogger
@@ -16,6 +17,8 @@ from .wandb import WandbLogger
 
 __all__ = [
     "Logger",
+    "LoggerMonitor",
+    "Every",
     "ProcessLogger",
     "RayLogger",
     "CSVLogger",

--- a/torchrl/record/loggers/monitoring.py
+++ b/torchrl/record/loggers/monitoring.py
@@ -1,0 +1,468 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import math
+import threading
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from torchrl._utils import logger as torchrl_logger
+from torchrl.record.loggers.common import Logger
+
+__all__ = ["Every", "LoggerMonitor"]
+
+
+_DEFAULT_RATE_NAMES = {
+    "frames": "frames_per_second",
+    "batches": "batches_per_second",
+    "write_count": "writes_per_second",
+    "worker_frames": "worker_frames_per_second",
+    "sample_calls": "samples_per_second",
+    "samples_returned": "samples_returned_per_second",
+}
+
+
+@dataclass(frozen=True)
+class Every:
+    """A logging schedule for :class:`~torchrl.record.loggers.monitoring.LoggerMonitor`.
+
+    Schedules are built through the two factory methods rather than the
+    constructor:
+
+    - :meth:`Every.seconds` triggers on wall-clock time;
+    - :meth:`Every.counter` triggers whenever a cumulative counter reported
+      by the watched object's ``stats()`` snapshot crosses a multiple of
+      ``interval``.
+
+    Counter schedules are observed, not executed at the exact operation: if
+    a counter jumps across several thresholds between two polls, the latest
+    snapshot is logged once. A counter decrease (after a reset or a state
+    restoration) re-baselines the schedule instead of producing spurious
+    logs.
+
+    Examples:
+        >>> from torchrl.record.loggers.monitoring import Every
+        >>> Every.seconds(5.0)
+        Every(kind='seconds', interval=5.0, key=None)
+        >>> Every.counter("frames", 10_000)
+        Every(kind='counter', interval=10000, key='frames')
+    """
+
+    kind: Literal["seconds", "counter"]
+    interval: float
+    key: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind not in ("seconds", "counter"):
+            raise ValueError(f"kind must be 'seconds' or 'counter', got {self.kind!r}.")
+        if not self.interval or self.interval <= 0:
+            raise ValueError(
+                f"interval must be strictly positive, got {self.interval}."
+            )
+        if self.kind == "counter" and not self.key:
+            raise ValueError("counter schedules require a non-empty counter key.")
+
+    @classmethod
+    def seconds(cls, interval: float) -> Every:
+        """Returns a wall-clock schedule triggering every ``interval`` seconds."""
+        return cls(kind="seconds", interval=float(interval))
+
+    @classmethod
+    def counter(cls, key: str, interval: int) -> Every:
+        """Returns a schedule triggering when the stats entry ``key`` crosses a multiple of ``interval``."""
+        return cls(kind="counter", interval=interval, key=key)
+
+
+class _Watch:
+    """Internal bookkeeping for one monitored target."""
+
+    def __init__(
+        self,
+        *,
+        target: Any,
+        name: str,
+        schedule: Every | None,
+        step_key: str | None,
+        stats_fn: Callable[..., Mapping[str, Any]],
+        stats_kwargs: dict[str, Any],
+        rate_keys: tuple[str, ...] | None,
+        log_on_start: bool,
+        log_on_close: bool,
+    ) -> None:
+        self.target = target
+        self.name = name
+        self.schedule = schedule
+        self.step_key = step_key
+        self.stats_fn = stats_fn
+        self.stats_kwargs = stats_kwargs
+        self.rate_keys = rate_keys
+        self.log_on_start = log_on_start
+        self.log_on_close = log_on_close
+        self.baseline_counters: dict[str, float] = {}
+        self.baseline_time: float | None = None
+        self.next_threshold: float | None = None
+        self.last_counter_value: float | None = None
+        self.last_log_time: float | None = None
+        self.has_logged = False
+        self.error_warned = False
+
+
+class LoggerMonitor:
+    """A pull-based monitor logging operational statistics of collectors and replay buffers.
+
+    The monitor periodically requests a cheap ``stats()`` snapshot from each
+    watched object, decides whether the snapshot is due for logging according
+    to the per-target schedule, derives rates from cumulative counter deltas,
+    namespaces the metrics as ``"<name>/<metric>"`` and forwards them to a
+    single :class:`~torchrl.record.loggers.common.Logger`.
+
+    Because snapshots are pulled from the monitor's own thread (or from
+    explicit :meth:`step` calls), no logging work is ever executed on the
+    collection, write or sampling hot paths of the watched objects, and a
+    slow logging backend can only delay the next poll, never build an
+    unbounded backlog. The monitor works with any object exposing a
+    ``stats()`` method returning a flat mapping of scalars: in particular
+    local, multiprocessing and Ray collectors and replay buffers share the
+    same interface.
+
+    The monitor never takes ownership of the logger or of the watched
+    objects: stopping the monitor leaves both running, and shutting down the
+    logger remains the caller's responsibility.
+
+    Args:
+        logger (Logger): the output sink. Any TorchRL logger works, including
+            loggers running as a service (``service_backend="ray"``).
+
+    Keyword Args:
+        poll_interval (float, optional): how often the background thread
+            polls the watched objects, in seconds. Counter schedules are
+            evaluated at each poll, so this bounds their resolution.
+            Defaults to ``1.0``.
+        background (bool, optional): if ``True`` (default), entering the
+            monitor context (or calling :meth:`start`) spawns a daemon
+            thread that polls every ``poll_interval`` seconds. If ``False``,
+            nothing runs in the background and the user drives the monitor
+            through explicit :meth:`step` calls, which keeps tests and
+            deterministic loops reproducible.
+        on_error (str, optional): behavior when polling or logging a target
+            fails: ``"warn"`` (default) logs a warning once per failure
+            streak through the torchrl logger, ``"ignore"`` silently skips,
+            and ``"raise"`` propagates the exception (in background mode
+            this terminates the monitor thread).
+
+    Examples:
+        >>> import tempfile
+        >>> import torch
+        >>> from torchrl.data import LazyTensorStorage, ReplayBuffer
+        >>> from torchrl.record import CSVLogger
+        >>> from torchrl.record.loggers.monitoring import Every, LoggerMonitor
+        >>> logger = CSVLogger(exp_name="monitor_demo", log_dir=tempfile.mkdtemp())
+        >>> rb = ReplayBuffer(storage=LazyTensorStorage(100))
+        >>> monitor = LoggerMonitor(logger, background=False)
+        >>> handle = monitor.watch(rb, name="replay_buffer", step="write_count")
+        >>> rb.extend(torch.arange(10))
+        >>> logged = monitor.step()
+        >>> print(logged["replay_buffer"]["replay_buffer/size"])
+        10.0
+
+    The typical background usage mirrors the RFC acceptance example:
+
+        >>> with LoggerMonitor(logger) as monitor:  # doctest: +SKIP
+        ...     monitor.watch(collector, name="collector", schedule=Every.counter("frames", 10_000))
+        ...     monitor.watch(replay_buffer, name="replay_buffer", schedule=Every.seconds(5), step="write_count")
+        ...     collector.start()
+        ...     run_training()
+    """
+
+    def __init__(
+        self,
+        logger: Logger,
+        *,
+        poll_interval: float = 1.0,
+        background: bool = True,
+        on_error: Literal["warn", "raise", "ignore"] = "warn",
+    ) -> None:
+        if on_error not in ("warn", "raise", "ignore"):
+            raise ValueError(
+                f"on_error must be one of 'warn', 'raise' or 'ignore', got {on_error!r}."
+            )
+        if poll_interval <= 0:
+            raise ValueError(f"poll_interval must be positive, got {poll_interval}.")
+        self._logger = logger
+        self._poll_interval = float(poll_interval)
+        self._background = background
+        self._on_error = on_error
+        self._watches: dict[str, _Watch] = {}
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def watch(
+        self,
+        target: Any,
+        *,
+        name: str | None = None,
+        schedule: Every | None = None,
+        step: str | None = None,
+        stats_fn: Callable[..., Mapping[str, Any]] | None = None,
+        stats_kwargs: dict[str, Any] | None = None,
+        rate_keys: tuple[str, ...] | None = None,
+        log_on_start: bool = True,
+        log_on_close: bool = True,
+    ) -> str:
+        """Registers an object to monitor and returns its watch name.
+
+        Args:
+            target: any object exposing a ``stats()`` method returning a flat
+                mapping of scalars, such as collectors and replay buffers.
+
+        Keyword Args:
+            name (str, optional): namespace prefix for this target's metrics.
+                Must be unique within the monitor. Defaults to the lowercase
+                class name, uniquified with a numeric suffix if needed.
+            schedule (Every, optional): when to log. ``None`` (default) logs
+                at every poll.
+            step (str, optional): name of a snapshot entry to use as the
+                logical logging step (for example ``"write_count"``). For
+                counter schedules this defaults to the schedule's counter
+                key; otherwise the logger's own step handling applies.
+            stats_fn (callable, optional): replaces ``target.stats`` as the
+                snapshot provider. Runs in the monitor's process and thread.
+            stats_kwargs (dict, optional): keyword arguments forwarded to the
+                snapshot provider, for example ``{"workers": "both"}`` for
+                distributed collectors.
+            rate_keys (tuple of str, optional): snapshot entries to derive
+                per-second rates from, based on their delta since the last
+                logged snapshot. Defaults to the entries of the snapshot that
+                are known cumulative counters (``frames``, ``batches``,
+                ``write_count``, ...). A counter decrease re-baselines the
+                rate instead of reporting a negative value.
+            log_on_start (bool, optional): whether the first poll of this
+                target logs unconditionally. Defaults to ``True``.
+            log_on_close (bool, optional): whether :meth:`stop` logs a final
+                snapshot of this target. Defaults to ``True``.
+
+        Returns:
+            The watch name, usable with :meth:`unwatch`.
+        """
+        if stats_fn is None:
+            stats_attr = getattr(target, "stats", None)
+            if not callable(stats_attr):
+                raise TypeError(
+                    f"Cannot watch object of type {type(target).__name__}: it does not "
+                    "expose a callable stats() method and no stats_fn was provided."
+                )
+            stats_fn = stats_attr
+        with self._lock:
+            if name is None:
+                base = type(target).__name__.lower()
+                name = base
+                suffix = 0
+                while name in self._watches:
+                    suffix += 1
+                    name = f"{base}_{suffix}"
+            elif name in self._watches:
+                raise ValueError(f"A watch named {name!r} is already registered.")
+            if step is None and schedule is not None and schedule.kind == "counter":
+                step = schedule.key
+            self._watches[name] = _Watch(
+                target=target,
+                name=name,
+                schedule=schedule,
+                step_key=step,
+                stats_fn=stats_fn,
+                stats_kwargs=dict(stats_kwargs or {}),
+                rate_keys=tuple(rate_keys) if rate_keys is not None else None,
+                log_on_start=log_on_start,
+                log_on_close=log_on_close,
+            )
+        return name
+
+    def unwatch(self, name: str) -> None:
+        """Stops monitoring the named target without touching the target itself."""
+        with self._lock:
+            if name not in self._watches:
+                raise KeyError(f"No watch named {name!r}.")
+            del self._watches[name]
+
+    def step(self) -> dict[str, dict[str, float]]:
+        """Polls every watched target once and logs the snapshots that are due.
+
+        This is the manual-mode entry point; the background thread calls it
+        on a timer. Returns a mapping from watch name to the logged payload,
+        containing only the targets that were actually logged during this
+        step.
+        """
+        logged: dict[str, dict[str, float]] = {}
+        with self._lock:
+            watches = list(self._watches.values())
+        for watch in watches:
+            payload = self._poll(watch)
+            if payload is not None:
+                logged[watch.name] = payload
+        return logged
+
+    def start(self) -> LoggerMonitor:
+        """Starts the background polling thread (no-op when ``background=False``)."""
+        if self._background and self._thread is None:
+            self._stop_event.clear()
+            self._thread = threading.Thread(
+                target=self._run, name="LoggerMonitor", daemon=True
+            )
+            self._thread.start()
+        return self
+
+    def stop(self, *, log_final: bool | None = None) -> None:
+        """Stops polling and logs a final snapshot of each target.
+
+        The watched objects and the logger are left untouched: shutting them
+        down remains the caller's responsibility.
+
+        Keyword Args:
+            log_final (bool, optional): overrides the per-watch
+                ``log_on_close`` setting when provided.
+        """
+        self._stop_event.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=max(5.0, 2 * self._poll_interval))
+            self._thread = None
+        with self._lock:
+            watches = list(self._watches.values())
+        for watch in watches:
+            should_log = watch.log_on_close if log_final is None else log_final
+            if should_log:
+                self._poll(watch, force=True)
+
+    def __enter__(self) -> LoggerMonitor:
+        return self.start()
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.stop()
+
+    def _run(self) -> None:
+        while not self._stop_event.wait(self._poll_interval):
+            self.step()
+
+    def _poll(self, watch: _Watch, force: bool = False) -> dict[str, float] | None:
+        try:
+            return self._poll_impl(watch, force=force)
+        except Exception as err:
+            if self._on_error == "raise":
+                raise
+            if self._on_error == "warn" and not watch.error_warned:
+                watch.error_warned = True
+                torchrl_logger.warning(
+                    f"LoggerMonitor failed to poll or log watch {watch.name!r}: {err!r}. "
+                    "Further errors for this watch will be silent until it recovers."
+                )
+            return None
+
+    def _poll_impl(self, watch: _Watch, force: bool = False) -> dict[str, float] | None:
+        raw = watch.stats_fn(**watch.stats_kwargs)
+        snapshot = {
+            key: float(value)
+            for key, value in raw.items()
+            if isinstance(value, (int, float)) and math.isfinite(value)
+        }
+        now = time.monotonic()
+        first_poll = watch.baseline_time is None
+        due = force or self._is_due(watch, snapshot, now, first_poll=first_poll)
+        payload = None
+        if due:
+            rates = self._compute_rates(watch, snapshot, now)
+            payload = {
+                f"{watch.name}/{key}": value
+                for key, value in {**snapshot, **rates}.items()
+            }
+            step_value = None
+            if watch.step_key is not None and watch.step_key in snapshot:
+                step_value = int(snapshot[watch.step_key])
+            self._logger.log_metrics(payload, step=step_value)
+            watch.baseline_counters = dict(snapshot)
+            watch.baseline_time = now
+            watch.last_log_time = now
+            watch.has_logged = True
+        elif first_poll:
+            watch.baseline_counters = dict(snapshot)
+            watch.baseline_time = now
+        watch.error_warned = False
+        return payload
+
+    def _is_due(
+        self, watch: _Watch, snapshot: dict[str, float], now: float, *, first_poll: bool
+    ) -> bool:
+        schedule = watch.schedule
+        if first_poll and not watch.has_logged:
+            if watch.log_on_start:
+                self._prime_schedule(watch, snapshot)
+                return True
+        if schedule is None:
+            return True
+        if schedule.kind == "seconds":
+            reference = watch.last_log_time
+            if reference is None:
+                reference = watch.baseline_time
+            if reference is None:
+                return False
+            return now - reference >= schedule.interval
+        counter = snapshot.get(schedule.key)
+        if counter is None:
+            return False
+        if watch.next_threshold is None:
+            self._prime_schedule(watch, snapshot)
+            return False
+        if watch.last_counter_value is not None and counter < watch.last_counter_value:
+            watch.baseline_counters = dict(snapshot)
+            watch.next_threshold = (
+                counter // schedule.interval + 1
+            ) * schedule.interval
+            watch.last_counter_value = counter
+            return False
+        watch.last_counter_value = counter
+        if counter >= watch.next_threshold:
+            watch.next_threshold = (
+                counter // schedule.interval + 1
+            ) * schedule.interval
+            return True
+        return False
+
+    def _prime_schedule(self, watch: _Watch, snapshot: dict[str, float]) -> None:
+        schedule = watch.schedule
+        if schedule is not None and schedule.kind == "counter":
+            counter = snapshot.get(schedule.key)
+            if counter is not None:
+                watch.next_threshold = (
+                    counter // schedule.interval + 1
+                ) * schedule.interval
+                watch.last_counter_value = counter
+
+    def _compute_rates(
+        self, watch: _Watch, snapshot: dict[str, float], now: float
+    ) -> dict[str, float]:
+        if watch.baseline_time is None:
+            return {}
+        elapsed = now - watch.baseline_time
+        if elapsed <= 0:
+            return {}
+        if watch.rate_keys is not None:
+            keys = watch.rate_keys
+        else:
+            keys = tuple(key for key in snapshot if key in _DEFAULT_RATE_NAMES)
+        rates = {}
+        for key in keys:
+            current = snapshot.get(key)
+            previous = watch.baseline_counters.get(key)
+            if current is None or previous is None:
+                continue
+            delta = current - previous
+            if delta < 0:
+                continue
+            rate_name = _DEFAULT_RATE_NAMES.get(key, f"{key}_per_second")
+            rates[rate_name] = delta / elapsed
+        return rates

--- a/torchrl/record/loggers/monitoring.py
+++ b/torchrl/record/loggers/monitoring.py
@@ -46,11 +46,24 @@ class Every:
     logs.
 
     Examples:
-        >>> from torchrl.record.loggers.monitoring import Every
-        >>> Every.seconds(5.0)
-        Every(kind='seconds', interval=5.0, key=None)
-        >>> Every.counter("frames", 10_000)
-        Every(kind='counter', interval=10000, key='frames')
+        >>> import tempfile
+        >>> import torch
+        >>> from torchrl.data import LazyTensorStorage, ReplayBuffer
+        >>> from torchrl.record import CSVLogger
+        >>> from torchrl.record.loggers.monitoring import Every, LoggerMonitor
+        >>> logger = CSVLogger(exp_name="every_demo", log_dir=tempfile.mkdtemp())
+        >>> rb = ReplayBuffer(storage=LazyTensorStorage(100))
+        >>> monitor = LoggerMonitor(logger, background=False)
+        >>> name = monitor.watch(
+        ...     rb, name="rb", schedule=Every.counter("write_count", 50), log_on_start=False
+        ... )
+        >>> logged = monitor.step()  # primes the schedule, nothing logged yet
+        >>> print(logged)
+        {}
+        >>> _ = rb.extend(torch.arange(60))
+        >>> logged = monitor.step()  # write_count crossed the 50 threshold
+        >>> print(logged["rb"]["rb/write_count"])
+        60.0
     """
 
     kind: Literal["seconds", "counter"]
@@ -165,7 +178,7 @@ class LoggerMonitor:
         >>> rb = ReplayBuffer(storage=LazyTensorStorage(100))
         >>> monitor = LoggerMonitor(logger, background=False)
         >>> handle = monitor.watch(rb, name="replay_buffer", step="write_count")
-        >>> rb.extend(torch.arange(10))
+        >>> _ = rb.extend(torch.arange(10))
         >>> logged = monitor.step()
         >>> print(logged["replay_buffer"]["replay_buffer/size"])
         10.0
@@ -201,6 +214,7 @@ class LoggerMonitor:
         self._lock = threading.Lock()
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
+        self._stopped = False
 
     def watch(
         self,
@@ -235,7 +249,13 @@ class LoggerMonitor:
                 snapshot provider. Runs in the monitor's process and thread.
             stats_kwargs (dict, optional): keyword arguments forwarded to the
                 snapshot provider, for example ``{"workers": "both"}`` for
-                distributed collectors.
+                distributed collectors. For multiprocessing collectors,
+                per-worker snapshots travel over the collector control pipes
+                and must not race with control calls (such as weight updates)
+                issued from other threads; see
+                :meth:`~torchrl.collectors.MultiSyncCollector.stats` for the
+                thread-safety contract before enabling per-worker views on a
+                background monitor.
             rate_keys (tuple of str, optional): snapshot entries to derive
                 per-second rates from, based on their delta since the last
                 logged snapshot. Defaults to the entries of the snapshot that
@@ -243,7 +263,9 @@ class LoggerMonitor:
                 ``write_count``, ...). A counter decrease re-baselines the
                 rate instead of reporting a negative value.
             log_on_start (bool, optional): whether the first poll of this
-                target logs unconditionally. Defaults to ``True``.
+                target logs unconditionally. When ``False``, the first poll
+                only records baselines, so the first logged snapshot can
+                carry rates. Defaults to ``True``.
             log_on_close (bool, optional): whether :meth:`stop` logs a final
                 snapshot of this target. Defaults to ``True``.
 
@@ -309,6 +331,7 @@ class LoggerMonitor:
 
     def start(self) -> LoggerMonitor:
         """Starts the background polling thread (no-op when ``background=False``)."""
+        self._stopped = False
         if self._background and self._thread is None:
             self._stop_event.clear()
             self._thread = threading.Thread(
@@ -321,7 +344,10 @@ class LoggerMonitor:
         """Stops polling and logs a final snapshot of each target.
 
         The watched objects and the logger are left untouched: shutting them
-        down remains the caller's responsibility.
+        down remains the caller's responsibility. Calling :meth:`stop` again
+        without an intervening :meth:`start` is a no-op, so exiting the
+        context manager after an explicit stop does not log the final
+        snapshots twice.
 
         Keyword Args:
             log_final (bool, optional): overrides the per-watch
@@ -329,9 +355,21 @@ class LoggerMonitor:
         """
         self._stop_event.set()
         thread = self._thread
+        polling_thread_stuck = False
         if thread is not None:
             thread.join(timeout=max(5.0, 2 * self._poll_interval))
+            polling_thread_stuck = thread.is_alive()
             self._thread = None
+        if self._stopped:
+            return
+        self._stopped = True
+        if polling_thread_stuck:
+            torchrl_logger.warning(
+                "LoggerMonitor could not join its polling thread within the stop "
+                "timeout (a stats() call is probably hanging); skipping the final "
+                "snapshots to avoid polling concurrently with the stuck thread."
+            )
+            return
         with self._lock:
             watches = list(self._watches.values())
         for watch in watches:
@@ -402,6 +440,9 @@ class LoggerMonitor:
             if watch.log_on_start:
                 self._prime_schedule(watch, snapshot)
                 return True
+            if schedule is None:
+                # log_on_start=False: the first poll only records baselines.
+                return False
         if schedule is None:
             return True
         if schedule.kind == "seconds":
@@ -418,7 +459,11 @@ class LoggerMonitor:
             self._prime_schedule(watch, snapshot)
             return False
         if watch.last_counter_value is not None and counter < watch.last_counter_value:
+            # the counter was reset (empty(), state restore, ...): re-baseline
+            # both the counters and the clock so the next rate only covers the
+            # post-reset window.
             watch.baseline_counters = dict(snapshot)
+            watch.baseline_time = now
             watch.next_threshold = (
                 counter // schedule.interval + 1
             ) * schedule.interval


### PR DESCRIPTION
## Description

Core deliverable of the collector/replay-buffer monitoring RFC: `torchrl.record.loggers.monitoring` with `LoggerMonitor` and `Every`, letting one TorchRL logger observe any number of collectors and replay buffers (local, multiprocessing or Ray) without putting logging work on collection or sampling hot paths.

```python
logger = WandbLogger(exp_name="experiment", project="torchrl")

with LoggerMonitor(logger, poll_interval=1.0) as monitor:
    monitor.watch(collector, name="collector", schedule=Every.counter("frames", 10_000))
    monitor.watch(replay_buffer, name="replay_buffer", schedule=Every.seconds(5), step="write_count")
    collector.start()
    run_training()
```

Design (source / monitor / sink separation from the RFC):

- **Pull-based**: snapshots are requested from the monitor's own daemon thread, or through explicit `monitor.step()` calls (`background=False`) for deterministic tests. Watched objects never call the logger; a slow backend can only delay the next poll, never build an unbounded backlog.
- **Schedules**: `Every.seconds(x)` (wall clock) and `Every.counter(key, n)` (logical counters). Counter thresholds are observed at poll time; a jump across several thresholds logs the latest snapshot once; a counter decrease (reset, `empty()`, state restore) re-baselines instead of producing spurious logs or negative rates.
- **Rates**: derived by the monitor from cumulative counter deltas between logged snapshots (`frames_per_second`, `writes_per_second`, ...), so sources need no timers or rolling windows.
- **Namespacing and steps**: metrics log as `<name>/<metric>`; the per-watch `step` key (defaulting to the counter key for counter schedules) gives each namespace an independent logical step, matching the per-prefix step handling in `WandbLogger`.
- **Lifecycle**: the monitor owns neither the logger nor the targets. `stop()` logs final snapshots (`log_on_close`) and joins the thread; logger shutdown stays explicit. `on_error="warn"|"raise"|"ignore"` controls failure behavior.
- **Custom providers**: `watch(..., stats_fn=..., stats_kwargs=..., rate_keys=...)` for driver-side custom gauges and per-worker views.

## Notes

Stacked on #4030, #4031 and #4032 (their commits are included here; only the last commit is new). I will rebase once those land. Docs added to `trainers_loggers.rst`. Follow-ups per the RFC's phasing: compile-safe sample counters and richer sampler stats, source-side custom providers for remote objects, and composable event observers for batch-derived metrics.