### PR TITLE
[BugFix] honor collector masks in loss reductions

### DIFF
--- a/docs/source/reference/objectives_common.rst
+++ b/docs/source/reference/objectives_common.rst
@@ -12,6 +12,37 @@ Base classes and common utilities for all loss modules.
     LossModule
     add_random_module
 
+Masked reduction
+----------------
+
+Batches of padded sequences carry a per-position validity mask, and positions
+marked invalid must not contribute to the loss. Every loss reduces through
+:meth:`LossModule._reduce_loss`, which reads that mask from the input according
+to :attr:`LossModule.loss_mask_key`:
+
+- ``"auto"`` (the default) looks for each entry of
+  :data:`~torchrl.objectives.common.AUTO_LOSS_MASK_KEYS` and ANDs the ones it
+  finds, so a batch from :class:`~torchrl.data.SliceSampler` with
+  ``pad_output=True`` is handled without any configuration. On data carrying
+  none of those entries the reduction is unchanged.
+- a :class:`~tensordict.NestedKey` restricts masking to that single entry.
+- ``None`` disables masking.
+
+.. code-block:: python
+
+    loss = PPOLoss(actor, critic)
+    loss.loss_mask_key = ("my_masks", "valid")  # use this entry only
+    loss.loss_mask_key = None                   # reduce over every position
+
+Masked positions are selected out rather than multiplied by zero, so a
+non-finite value at a masked position affects neither the loss nor the
+gradients.
+
+.. autosummary::
+    :toctree: generated/
+
+    AUTO_LOSS_MASK_KEYS
+
 .. _ref_returns:
 
 Value Estimators

--- a/test/objectives/test_bc.py
+++ b/test/objectives/test_bc.py
@@ -286,6 +286,48 @@ class TestBCLoss:
         assert "is_pad" not in loss.in_keys
         torch.testing.assert_close(loss(td)["loss_bc"], unmasked)
 
+    def test_collector_mask(self):
+        # ("collector", "mask"), as written by SliceSampler(pad_output=True),
+        # is honored without any set_keys() call: padding rows (mask=False) do
+        # not contribute, so the loss matches the one over the real rows only.
+        n_obs, n_act = 3, 4
+        actor = TensorDictModule(
+            nn.Linear(n_obs, n_act), in_keys=["observation"], out_keys=["action"]
+        )
+        loss = BCLoss(actor, loss_function="l1")
+        obs = torch.randn(3, n_obs)
+        action = torch.randn(3, n_act)
+        action[2] = 1e6  # garbage target on the padding row
+        td = TensorDict(
+            {"observation": obs.clone(), "action": action.clone()}, batch_size=[3]
+        )
+        td["collector", "mask"] = torch.tensor([True, True, False])
+        real = TensorDict(
+            {"observation": obs[:2].clone(), "action": action[:2].clone()},
+            batch_size=[2],
+        )
+        torch.testing.assert_close(loss(td)["loss_bc"], loss(real)["loss_bc"])
+
+    def test_collector_mask_can_be_disabled(self):
+        n_obs, n_act = 3, 4
+        actor = TensorDictModule(
+            nn.Linear(n_obs, n_act), in_keys=["observation"], out_keys=["action"]
+        )
+        loss = BCLoss(actor, loss_function="l1")
+        action = torch.randn(3, n_act)
+        action[2] = 1e6  # padding row, far from anything the actor can predict
+        td = TensorDict(
+            {"observation": torch.randn(3, n_obs), "action": action}, batch_size=[3]
+        )
+        td["collector", "mask"] = torch.tensor([True, True, False])
+        masked = loss(td)["loss_bc"]
+        loss.loss_mask_key = None
+        unmasked = loss(td)["loss_bc"]
+        assert masked < unmasked
+        torch.testing.assert_close(
+            unmasked, loss(td.exclude(("collector", "mask")))["loss_bc"]
+        )
+
     def test_pad_mask_reduction_none(self):
         # with a mask, reduction="none" returns the flat 1D tensor of
         # unmasked loss elements (the _reduce convention)

--- a/test/objectives/test_loss_module.py
+++ b/test/objectives/test_loss_module.py
@@ -789,9 +789,7 @@ class TestLossMaskReduction:
         shifted = torch.tensor([True, False, True, False])
         td = self._td(x, collector_mask=collector, shifted_valid=shifted)
         # only position 0 is valid under both masks
-        torch.testing.assert_close(
-            self._make("sum")(td).get("loss_x"), torch.ones(())
-        )
+        torch.testing.assert_close(self._make("sum")(td).get("loss_x"), torch.ones(()))
 
     @pytest.mark.parametrize("bad", [float("nan"), float("inf"), -float("inf")])
     @pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
@@ -799,9 +797,9 @@ class TestLossMaskReduction:
         base = torch.ones(4, requires_grad=True)
         elementwise = base + torch.tensor([0.0, 0.0, bad, bad])
         valid = torch.tensor([True, True, False, False])
-        out = self._make(reduction)(
-            self._td(elementwise, collector_mask=valid)
-        ).get("loss_x")
+        out = self._make(reduction)(self._td(elementwise, collector_mask=valid)).get(
+            "loss_x"
+        )
         assert torch.isfinite(out).all(), f"{reduction} reduction returned {out}"
         out.sum().backward()
         assert torch.isfinite(base.grad).all()
@@ -856,10 +854,30 @@ class TestLossMaskReduction:
         caller = torch.tensor([True, True, False, False])
         collector = torch.tensor([True, False, True, False])
         loss = self._make("sum")
-        out = loss._reduce_loss(
-            x, self._td(x, collector_mask=collector), mask=caller
-        )
+        out = loss._reduce_loss(x, self._td(x, collector_mask=collector), mask=caller)
         torch.testing.assert_close(out, torch.ones(()))
+
+    @pytest.mark.parametrize("mask_entry", ["collector_mask", "shifted_valid"])
+    def test_mask_with_trailing_singleton_dim(self, mask_entry):
+        # ("collector", "mask") is [B, T, 1] -- masks carry a trailing singleton
+        # to broadcast against [..., 1]-shaped rewards -- while a per-timestep
+        # loss is [B, T]. Expanding [B, T, 1] to [B, T] used to raise.
+        x = torch.ones(2, 3)
+        valid = torch.tensor([[True, True, False], [True, False, False]])
+        td = TensorDict({"elementwise": x}, [2])
+        key = (
+            ("collector", "mask") if mask_entry == "collector_mask" else "shifted_valid"
+        )
+        td.set(key, valid.unsqueeze(-1))
+        out = self._make("sum")(td).get("loss_x")
+        torch.testing.assert_close(out, torch.full((), 3.0))
+
+    def test_mask_with_extra_non_singleton_dim_raises(self):
+        x = torch.ones(2, 3)
+        td = TensorDict({"elementwise": x}, [2])
+        td.set(("collector", "mask"), torch.ones(2, 3, 4, dtype=torch.bool))
+        with pytest.raises(ValueError, match="more non-singleton dimensions"):
+            self._make("sum")(td)
 
     def test_mask_broadcasts_over_trailing_dims(self):
         x = torch.ones(3, 2)

--- a/test/objectives/test_loss_module.py
+++ b/test/objectives/test_loss_module.py
@@ -46,11 +46,7 @@ from torchrl.objectives import (
     SACLoss,
     TD3Loss,
 )
-from torchrl.objectives.common import (
-    add_random_module,
-    AUTO_LOSS_MASK_KEYS,
-    LossModule,
-)
+from torchrl.objectives.common import add_random_module, AUTO_LOSS_MASK_KEYS, LossModule
 from torchrl.objectives.utils import (
     _VALUE_ESTIMATOR_REGISTRY,
     _vmap_func,
@@ -888,7 +884,7 @@ class TestLossMaskReduction:
             self._make("sum")(td).get("loss_x"), torch.full((), 4.0)
         )
 
-    @pytest.mark.parametrize("bad", [0, 1.5, object()])
+    @pytest.mark.parametrize("bad", [0, 1.5, object(), (), ("mask", 0), ("mask", None)])
     def test_invalid_loss_mask_key_raises(self, bad):
         loss = _MaskedToyLoss()
         with pytest.raises(ValueError, match="loss_mask_key"):

--- a/test/objectives/test_loss_module.py
+++ b/test/objectives/test_loss_module.py
@@ -46,7 +46,11 @@ from torchrl.objectives import (
     SACLoss,
     TD3Loss,
 )
-from torchrl.objectives.common import add_random_module, LossModule
+from torchrl.objectives.common import (
+    add_random_module,
+    AUTO_LOSS_MASK_KEYS,
+    LossModule,
+)
 from torchrl.objectives.utils import (
     _VALUE_ESTIMATOR_REGISTRY,
     _vmap_func,
@@ -702,6 +706,177 @@ class TestBase:
         assert loss_module.tensor_keys.some_key == "some_value"
         loss_module.set_keys(some_key="test")
         assert loss_module.tensor_keys.some_key == "test"
+
+
+class _MaskedToyLoss(LossModule):
+    """Minimal loss exposing ``_reduce_loss`` on a per-position input entry."""
+
+    def __init__(self, reduction: str = "mean"):
+        super().__init__()
+        self.reduction = reduction
+
+    def _forward_value_estimator_keys(self, **kwargs) -> None:
+        pass
+
+    def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
+        loss = self._reduce_loss(tensordict.get("elementwise"), tensordict)
+        return TensorDict({"loss_x": loss}, [])
+
+
+class TestLossMaskReduction:
+    """Executable spec for ``LossModule.loss_mask_key`` (#3866, #4057).
+
+    Contract pinned by this class:
+
+    - ``loss_mask_key="auto"`` (the default) reads the validity masks TorchRL
+      writes itself -- ``("collector", "mask")`` and ``"shifted_valid"``,
+      listed in ``AUTO_LOSS_MASK_KEYS`` -- and ANDs every one it finds, so a
+      position excluded by either does not contribute.
+    - With none of those entries present the reduction is unchanged, for every
+      ``reduction`` mode: adopting mask-aware reduction is a no-op on unmasked
+      data.
+    - A ``NestedKey`` restricts masking to that single entry (the auto keys are
+      then ignored); ``None`` disables masking entirely.
+    - Masked positions are *selected out*, not multiplied by zero, so a
+      non-finite value at a masked position poisons neither the loss nor the
+      gradients.
+    - A caller-supplied ``mask=`` keeps the legacy ``reduction="none"``
+      contract (output compacted to the unmasked elements), while a mask read
+      from the input preserves the loss shape.
+    """
+
+    @staticmethod
+    def _make(reduction="mean", mask_key="auto"):
+        loss = _MaskedToyLoss(reduction=reduction)
+        loss.loss_mask_key = mask_key
+        return loss
+
+    @staticmethod
+    def _td(elementwise, *, collector_mask=None, shifted_valid=None, **extra):
+        td = TensorDict({"elementwise": elementwise}, elementwise.shape[:1])
+        if collector_mask is not None:
+            td.set(("collector", "mask"), collector_mask)
+        if shifted_valid is not None:
+            td.set("shifted_valid", shifted_valid)
+        for key, value in extra.items():
+            td.set(key, value)
+        return td
+
+    def test_default_is_auto(self):
+        assert _MaskedToyLoss().loss_mask_key == "auto"
+        assert AUTO_LOSS_MASK_KEYS == (("collector", "mask"), "shifted_valid")
+
+    @pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+    def test_no_mask_entry_leaves_reduction_unchanged(self, reduction):
+        x = torch.randn(6)
+        out = self._make(reduction)(self._td(x)).get("loss_x")
+        expected = {"mean": x.mean(), "sum": x.sum(), "none": x}[reduction]
+        torch.testing.assert_close(out, expected)
+
+    @pytest.mark.parametrize("mask_entry", ["collector_mask", "shifted_valid"])
+    @pytest.mark.parametrize("reduction", ["mean", "sum"])
+    def test_auto_mask_excludes_masked_positions(self, mask_entry, reduction):
+        x = torch.arange(6, dtype=torch.float)
+        valid = torch.tensor([True, True, True, False, False, False])
+        td = self._td(x, **{mask_entry: valid})
+        out = self._make(reduction)(td).get("loss_x")
+        expected = x[valid].mean() if reduction == "mean" else x[valid].sum()
+        torch.testing.assert_close(out, expected)
+
+    def test_auto_masks_are_anded(self):
+        x = torch.ones(4)
+        collector = torch.tensor([True, True, False, False])
+        shifted = torch.tensor([True, False, True, False])
+        td = self._td(x, collector_mask=collector, shifted_valid=shifted)
+        # only position 0 is valid under both masks
+        torch.testing.assert_close(
+            self._make("sum")(td).get("loss_x"), torch.ones(())
+        )
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), -float("inf")])
+    @pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+    def test_non_finite_masked_positions_do_not_poison(self, bad, reduction):
+        base = torch.ones(4, requires_grad=True)
+        elementwise = base + torch.tensor([0.0, 0.0, bad, bad])
+        valid = torch.tensor([True, True, False, False])
+        out = self._make(reduction)(
+            self._td(elementwise, collector_mask=valid)
+        ).get("loss_x")
+        assert torch.isfinite(out).all(), f"{reduction} reduction returned {out}"
+        out.sum().backward()
+        assert torch.isfinite(base.grad).all()
+        # masked positions contribute no gradient at all
+        torch.testing.assert_close(base.grad[~valid], torch.zeros(2))
+
+    def test_explicit_key_ignores_the_auto_keys(self):
+        x = torch.arange(4, dtype=torch.float)
+        auto = torch.tensor([True, False, True, False])
+        mine = torch.tensor([True, True, False, False])
+        td = self._td(x, collector_mask=auto)
+        td.set(("my_masks", "valid"), mine)
+        out = self._make("sum", mask_key=("my_masks", "valid"))(td).get("loss_x")
+        torch.testing.assert_close(out, x[mine].sum())
+
+    def test_none_disables_masking(self):
+        x = torch.arange(4, dtype=torch.float)
+        valid = torch.tensor([True, False, True, False])
+        td = self._td(x, collector_mask=valid)
+        out = self._make("sum", mask_key=None)(td).get("loss_x")
+        torch.testing.assert_close(out, x.sum())
+
+    def test_tuple_key_reaches_an_entry_named_auto(self):
+        x = torch.arange(4, dtype=torch.float)
+        mine = torch.tensor([True, True, False, False])
+        td = self._td(x, auto=mine)
+        out = self._make("sum", mask_key=("auto",))(td).get("loss_x")
+        torch.testing.assert_close(out, x[mine].sum())
+
+    def test_missing_explicit_key_is_not_an_error(self):
+        x = torch.arange(4, dtype=torch.float)
+        out = self._make("sum", mask_key="absent")(self._td(x)).get("loss_x")
+        torch.testing.assert_close(out, x.sum())
+
+    def test_reduction_none_preserves_shape_and_zeroes_masked(self):
+        x = torch.arange(1, 5, dtype=torch.float)
+        valid = torch.tensor([True, False, True, False])
+        out = self._make("none")(self._td(x, collector_mask=valid)).get("loss_x")
+        assert out.shape == x.shape
+        torch.testing.assert_close(out, torch.where(valid, x, torch.zeros_like(x)))
+
+    def test_caller_mask_keeps_compaction_with_reduction_none(self):
+        # BCLoss relies on this: an explicitly passed mask drops the masked
+        # elements rather than zeroing them (see test_bc.py).
+        x = torch.arange(4, dtype=torch.float)
+        mask = torch.tensor([True, False, True, False])
+        out = _MaskedToyLoss("none")._reduce_loss(x, None, mask=mask)
+        torch.testing.assert_close(out, x[mask])
+
+    def test_caller_mask_and_auto_mask_combine(self):
+        x = torch.ones(4)
+        caller = torch.tensor([True, True, False, False])
+        collector = torch.tensor([True, False, True, False])
+        loss = self._make("sum")
+        out = loss._reduce_loss(
+            x, self._td(x, collector_mask=collector), mask=caller
+        )
+        torch.testing.assert_close(out, torch.ones(()))
+
+    def test_mask_broadcasts_over_trailing_dims(self):
+        x = torch.ones(3, 2)
+        valid = torch.tensor([True, True, False])
+        td = TensorDict({"elementwise": x}, [3])
+        td.set(("collector", "mask"), valid)
+        torch.testing.assert_close(
+            self._make("sum")(td).get("loss_x"), torch.full((), 4.0)
+        )
+
+    @pytest.mark.parametrize("bad", [0, 1.5, object()])
+    def test_invalid_loss_mask_key_raises(self, bad):
+        loss = _MaskedToyLoss()
+        with pytest.raises(ValueError, match="loss_mask_key"):
+            loss.loss_mask_key = bad
+        # the rejected assignment left the previous value in place
+        assert loss.loss_mask_key == "auto"
 
 
 class TestUtils:

--- a/torchrl/objectives/__init__.py
+++ b/torchrl/objectives/__init__.py
@@ -6,7 +6,11 @@
 from torchrl.objectives.a2c import A2CLoss
 from torchrl.objectives.act import ACTLoss
 from torchrl.objectives.bc import BCLoss
-from torchrl.objectives.common import add_random_module, LossModule
+from torchrl.objectives.common import (
+    add_random_module,
+    AUTO_LOSS_MASK_KEYS,
+    LossModule,
+)
 from torchrl.objectives.cql import CQLLoss, DiscreteCQLLoss
 from torchrl.objectives.crossq import CrossQLoss
 from torchrl.objectives.ddpg import DDPGLoss
@@ -96,6 +100,7 @@ __all__ = [
     "ValueEstimators",
     "WorldModelLoss",
     "add_random_module",
+    "AUTO_LOSS_MASK_KEYS",
     "categorical_kl_balanced",
     "default_value_kwargs",
     "distance_loss",

--- a/torchrl/objectives/__init__.py
+++ b/torchrl/objectives/__init__.py
@@ -6,11 +6,7 @@
 from torchrl.objectives.a2c import A2CLoss
 from torchrl.objectives.act import ACTLoss
 from torchrl.objectives.bc import BCLoss
-from torchrl.objectives.common import (
-    add_random_module,
-    AUTO_LOSS_MASK_KEYS,
-    LossModule,
-)
+from torchrl.objectives.common import add_random_module, AUTO_LOSS_MASK_KEYS, LossModule
 from torchrl.objectives.cql import CQLLoss, DiscreteCQLLoss
 from torchrl.objectives.crossq import CrossQLoss
 from torchrl.objectives.ddpg import DDPGLoss

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -558,9 +558,8 @@ class A2CLoss(LossModule):
             td_out.set("loss_critic", loss_critic)
             if value_clip_fraction is not None:
                 td_out.set("value_clip_fraction", value_clip_fraction)
-        loss_mask = tensordict.get("shifted_valid", default=None)
         td_out = td_out.named_apply(
-            lambda name, value: self._reduce_loss(value, mask=loss_mask).squeeze(-1)
+            lambda name, value: self._reduce_loss(value, tensordict).squeeze(-1)
             if name.startswith("loss_")
             else value,
         )

--- a/torchrl/objectives/bc.py
+++ b/torchrl/objectives/bc.py
@@ -325,8 +325,6 @@ class BCLoss(LossModule):
                         "distribution-based (NLL) or cross-entropy loss."
                     )
         loss = self._reduce_loss(loss, tensordict=tensordict, mask=mask)
-        if mask is not None and self.reduction == "mean":
-            loss = loss.masked_fill(~mask.any(), torch.nan)
 
         td_out = TensorDict({"loss_bc": loss})
         self._clear_weakrefs(

--- a/torchrl/objectives/bc.py
+++ b/torchrl/objectives/bc.py
@@ -17,7 +17,6 @@ from tensordict.nn import dispatch, TensorDictModule
 from tensordict.utils import NestedKey
 
 from torchrl.objectives.common import LossModule
-from torchrl.objectives.utils import _reduce
 
 
 class BCLoss(LossModule):
@@ -325,10 +324,9 @@ class BCLoss(LossModule):
                         "elementwise loss (e.g. loss_function='l1'), not a "
                         "distribution-based (NLL) or cross-entropy loss."
                     )
-                while mask.ndim < loss.ndim:
-                    mask = mask.unsqueeze(-1)
-                mask = mask.expand_as(loss)
-        loss = _reduce(loss, reduction=self.reduction, mask=mask)
+        loss = self._reduce_loss(loss, tensordict=tensordict, mask=mask)
+        if mask is not None and self.reduction == "mean":
+            loss = loss.masked_fill(~mask.any(), torch.nan)
 
         td_out = TensorDict({"loss_bc": loss})
         self._clear_weakrefs(

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -329,6 +329,20 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
 
     @staticmethod
     def _expand_loss_mask(mask: torch.Tensor, loss: torch.Tensor) -> torch.Tensor:
+        # Validity masks conventionally carry a trailing singleton dimension, to
+        # broadcast against the [..., 1]-shaped rewards they accompany --
+        # ``("collector", "mask")`` is [B, T, 1] where a per-timestep loss is
+        # [B, T]. Drop those before broadcasting the other way.
+        while mask.ndim > loss.ndim and mask.shape[-1] == 1:
+            mask = mask.squeeze(-1)
+        if mask.ndim > loss.ndim:
+            raise ValueError(
+                f"A mask of shape {tuple(mask.shape)} cannot be applied to a "
+                f"loss of shape {tuple(loss.shape)}: the mask has more "
+                "non-singleton dimensions than the loss. Per-element masking "
+                "requires an elementwise loss, not one whose event dimensions "
+                "have already been reduced (e.g. a log-prob)."
+            )
         if mask.ndim < loss.ndim:
             mask = mask.reshape(mask.shape + (1,) * (loss.ndim - mask.ndim))
         return mask.expand_as(loss)

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -264,8 +264,6 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
 
     @staticmethod
     def _expand_loss_mask(mask: torch.Tensor, loss: torch.Tensor) -> torch.Tensor:
-        while mask.ndim > loss.ndim and mask.shape[-1] == 1:
-            mask = mask.squeeze(-1)
         if mask.ndim < loss.ndim:
             mask = mask.reshape(mask.shape + (1,) * (loss.ndim - mask.ndim))
         return mask.expand_as(loss)
@@ -288,8 +286,6 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
             for mask_key in (("collector", "mask"), "shifted_valid"):
                 tensordict_mask = tensordict.get(mask_key, default=None)
                 if tensordict_mask is not None:
-                    if mask_key == "shifted_valid":
-                        preserve_shape = False
                     tensordict_mask = self._expand_loss_mask(tensordict_mask, loss)
                     mask = tensordict_mask if mask is None else mask & tensordict_mask
         if mask is not None:

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -278,20 +278,17 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
         mask: torch.Tensor | None = None,
         reduction: str | None = None,
         weights: torch.Tensor | None = None,
-        preserve_shape: bool | None = None,
     ) -> torch.Tensor:
         if reduction is None:
             reduction = self.reduction
-        infer_preserve_shape = preserve_shape is None
-        if infer_preserve_shape:
-            preserve_shape = mask is None
+        preserve_shape = mask is None
         if mask is not None:
             mask = self._expand_loss_mask(mask, loss)
         if tensordict is not None:
             for mask_key in (("collector", "mask"), "shifted_valid"):
                 tensordict_mask = tensordict.get(mask_key, default=None)
                 if tensordict_mask is not None:
-                    if mask_key == "shifted_valid" and infer_preserve_shape:
+                    if mask_key == "shifted_valid":
                         preserve_shape = False
                     tensordict_mask = self._expand_loss_mask(tensordict_mask, loss)
                     mask = tensordict_mask if mask is None else mask & tensordict_mask

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -14,13 +14,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 import torch
-from tensordict import (
-    is_tensor_collection,
-    NestedKey,
-    TensorDict,
-    TensorDictBase,
-    unravel_key,
-)
+from tensordict import is_tensor_collection, NestedKey, TensorDict, TensorDictBase
 from tensordict.nn import TensorDictModule, TensorDictModuleBase, TensorDictParams
 from tensordict.utils import Buffer
 from torch import nn
@@ -310,12 +304,8 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
         error = ValueError(
             f"loss_mask_key must be 'auto', None or a NestedKey, got {value!r}."
         )
-        if not isinstance(value, (str, tuple)):
+        if not isinstance(value, NestedKey):
             raise error
-        try:
-            unravel_key(value)
-        except Exception as err:
-            raise error from err
         self._loss_mask_key = value
 
     def _loss_mask_keys(self) -> tuple[NestedKey, ...]:

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -302,11 +302,6 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
                 if weights is not None:
                     loss = loss * weights
                 return torch.where(mask, loss, torch.zeros_like(loss))
-            if weights is not None and reduction == "mean":
-                masked_weights = weights * mask.to(weights.dtype)
-                denominator = masked_weights.sum()
-                denominator = denominator.masked_fill(denominator == 0, 1)
-                return (loss * masked_weights).sum() / denominator
             if weights is None and reduction == "mean":
                 return (loss * mask.to(loss.dtype)).sum() / mask.sum().clamp_min(1)
             if weights is None and reduction == "sum":

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -264,6 +264,8 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
 
     @staticmethod
     def _expand_loss_mask(mask: torch.Tensor, loss: torch.Tensor) -> torch.Tensor:
+        while mask.ndim > loss.ndim and mask.shape[-1] == 1:
+            mask = mask.squeeze(-1)
         if mask.ndim < loss.ndim:
             mask = mask.reshape(mask.shape + (1,) * (loss.ndim - mask.ndim))
         return mask.expand_as(loss)
@@ -276,15 +278,35 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
         mask: torch.Tensor | None = None,
         reduction: str | None = None,
         weights: torch.Tensor | None = None,
+        preserve_shape: bool | None = None,
     ) -> torch.Tensor:
         if reduction is None:
             reduction = self.reduction
-        if mask is None and tensordict is not None:
-            mask = tensordict.get("shifted_valid", default=None)
+        infer_preserve_shape = preserve_shape is None
+        if infer_preserve_shape:
+            preserve_shape = mask is None
         if mask is not None:
             mask = self._expand_loss_mask(mask, loss)
+        if tensordict is not None:
+            for mask_key in (("collector", "mask"), "shifted_valid"):
+                tensordict_mask = tensordict.get(mask_key, default=None)
+                if tensordict_mask is not None:
+                    if mask_key == "shifted_valid" and infer_preserve_shape:
+                        preserve_shape = False
+                    tensordict_mask = self._expand_loss_mask(tensordict_mask, loss)
+                    mask = tensordict_mask if mask is None else mask & tensordict_mask
+        if mask is not None:
             if weights is not None and weights.shape != loss.shape:
                 weights = self._expand_loss_mask(weights, loss)
+            if reduction == "none" and preserve_shape:
+                if weights is not None:
+                    loss = loss * weights
+                return torch.where(mask, loss, torch.zeros_like(loss))
+            if weights is not None and reduction == "mean":
+                masked_weights = weights * mask.to(weights.dtype)
+                denominator = masked_weights.sum()
+                denominator = denominator.masked_fill(denominator == 0, 1)
+                return (loss * masked_weights).sum() / denominator
             if weights is None and reduction == "mean":
                 return (loss * mask.to(loss.dtype)).sum() / mask.sum().clamp_min(1)
             if weights is None and reduction == "sum":

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -11,9 +11,16 @@ import warnings
 from collections.abc import Iterator
 from copy import deepcopy
 from dataclasses import dataclass
+from typing import Literal
 
 import torch
-from tensordict import is_tensor_collection, TensorDict, TensorDictBase
+from tensordict import (
+    is_tensor_collection,
+    NestedKey,
+    TensorDict,
+    TensorDictBase,
+    unravel_key,
+)
 from tensordict.nn import TensorDictModule, TensorDictModuleBase, TensorDictParams
 from tensordict.utils import Buffer
 from torch import nn
@@ -29,6 +36,15 @@ try:
     from torch.compiler import is_compiling
 except ImportError:
     from torch._dynamo import is_compiling
+
+
+#: Input entries that :attr:`LossModule.loss_mask_key` ``= "auto"`` looks for,
+#: in order, ANDing every one it finds. Both are written by TorchRL itself:
+#: ``("collector", "mask")`` by :class:`~torchrl.data.SliceSampler` with
+#: ``pad_output=True`` (``False`` marks duplicated padding steps), and
+#: ``"shifted_valid"`` by the value estimators (``False`` marks positions whose
+#: bootstrapped target crosses an episode boundary).
+AUTO_LOSS_MASK_KEYS: tuple[NestedKey, ...] = (("collector", "mask"), "shifted_valid")
 
 
 def _updater_check_forward_prehook(module, *args, **kwargs):
@@ -107,6 +123,17 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
     buffers that are commonly scheduled during training. The assignment performs
     an in-place update, preserving the buffer's device and dtype.
 
+    Padded or otherwise invalid positions are excluded from the reduction
+    through :attr:`loss_mask_key`. It defaults to ``"auto"``, which discovers
+    the validity masks TorchRL itself writes (``("collector", "mask")`` from
+    :class:`~torchrl.data.SliceSampler` with ``pad_output=True``, and
+    ``"shifted_valid"`` from the value estimators); set it to a
+    :class:`~tensordict.NestedKey` to name a single mask entry, or to ``None``
+    to reduce over every position:
+
+        >>> loss.loss_mask_key = ("my_masks", "valid")  # use this entry only
+        >>> loss.loss_mask_key = None                   # no masking at all
+
     Examples:
         >>> class MyLoss(LossModule):
         >>>     @dataclass
@@ -130,6 +157,7 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
     """
 
     _schedulable_buffers: frozenset = frozenset()
+    _loss_mask_key: NestedKey | Literal["auto"] | None = "auto"
 
     @dataclass
     class _AcceptedKeys:
@@ -262,6 +290,43 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
                     f"Setting '{key}' via the constructor is deprecated, use .set_keys(<key>='some_key') instead.",
                 )
 
+    @property
+    def loss_mask_key(self) -> NestedKey | Literal["auto"] | None:
+        """Which input entry marks the positions that contribute to the loss.
+
+        ``"auto"`` (the default) discovers the validity masks TorchRL writes
+        itself -- see :data:`AUTO_LOSS_MASK_KEYS`. A
+        :class:`~tensordict.NestedKey` restricts masking to that single entry;
+        ``None`` disables it. To use an entry literally named ``"auto"``, pass
+        the one-element tuple ``("auto",)``.
+        """
+        return self._loss_mask_key
+
+    @loss_mask_key.setter
+    def loss_mask_key(self, value: NestedKey | Literal["auto"] | None) -> None:
+        if value is None or (isinstance(value, str) and value == "auto"):
+            self._loss_mask_key = value
+            return
+        error = ValueError(
+            f"loss_mask_key must be 'auto', None or a NestedKey, got {value!r}."
+        )
+        if not isinstance(value, (str, tuple)):
+            raise error
+        try:
+            unravel_key(value)
+        except Exception as err:
+            raise error from err
+        self._loss_mask_key = value
+
+    def _loss_mask_keys(self) -> tuple[NestedKey, ...]:
+        """The input entries :meth:`_reduce_loss` will look for, in order."""
+        key = self._loss_mask_key
+        if key is None:
+            return ()
+        if key == "auto":
+            return AUTO_LOSS_MASK_KEYS
+        return (key,)
+
     @staticmethod
     def _expand_loss_mask(mask: torch.Tensor, loss: torch.Tensor) -> torch.Tensor:
         if mask.ndim < loss.ndim:
@@ -279,26 +344,32 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
     ) -> torch.Tensor:
         if reduction is None:
             reduction = self.reduction
-        preserve_shape = mask is None
+        # A caller-supplied mask keeps the legacy ``reduction="none"`` contract
+        # (masked positions are dropped, the output is compacted); masks read
+        # from the input instead preserve the loss shape, so that per-position
+        # outputs stay aligned with the input batch.
+        caller_mask = mask is not None
         if mask is not None:
             mask = self._expand_loss_mask(mask, loss)
         if tensordict is not None:
-            for mask_key in (("collector", "mask"), "shifted_valid"):
+            for mask_key in self._loss_mask_keys():
                 tensordict_mask = tensordict.get(mask_key, default=None)
                 if tensordict_mask is not None:
                     tensordict_mask = self._expand_loss_mask(tensordict_mask, loss)
                     mask = tensordict_mask if mask is None else mask & tensordict_mask
         if mask is not None:
+            # Select rather than multiply: masked positions may hold non-finite
+            # values, and ``nan * 0`` is ``nan`` in both the forward and the
+            # backward pass.
+            loss = torch.where(mask, loss, torch.zeros_like(loss))
             if weights is not None and weights.shape != loss.shape:
                 weights = self._expand_loss_mask(weights, loss)
-            if reduction == "none" and preserve_shape:
-                if weights is not None:
-                    loss = loss * weights
-                return torch.where(mask, loss, torch.zeros_like(loss))
+            if reduction == "none" and not caller_mask:
+                return loss if weights is None else loss * weights
             if weights is None and reduction == "mean":
-                return (loss * mask.to(loss.dtype)).sum() / mask.sum().clamp_min(1)
+                return loss.sum() / mask.sum().clamp_min(1)
             if weights is None and reduction == "sum":
-                return (loss * mask.to(loss.dtype)).sum()
+                return loss.sum()
         return _reduce(loss, reduction=reduction, mask=mask, weights=weights)
 
     def set_keys(self, **kwargs) -> None:

--- a/torchrl/objectives/decision_transformer.py
+++ b/torchrl/objectives/decision_transformer.py
@@ -255,24 +255,26 @@ class OnlineDTLoss(LossModule):
             "loss_alpha": loss_alpha,
         }
 
-        # Handle batch_size and scalar values (alpha, entropy) based on reduction mode
+        # Handle batch_size and scalar values based on reduction mode
         if self.reduction == "none":
             batch_size = tensordict.batch_size
             td_out = TensorDict(out, batch_size=batch_size)
-            if self.scalar_output_mode == "non_tensor":
-                td_out.set_non_tensor("alpha", self.alpha.detach())
-                td_out.set_non_tensor("entropy", entropy.detach().mean())
         else:
             out["entropy"] = entropy.detach().mean()
             out["alpha"] = self.alpha.detach()
             td_out = TensorDict(out, [])
-            td_out = td_out.named_apply(
-                lambda name, value: self._reduce_loss(
-                    value, tensordict=tensordict
-                ).squeeze(-1)
-                if name.startswith("loss_")
-                else value,
-            )
+        td_out = td_out.named_apply(
+            lambda name, value: self._reduce_loss(
+                value,
+                tensordict,
+                preserve_shape=self.reduction == "none",
+            ).squeeze(-1)
+            if name.startswith("loss_")
+            else value,
+        )
+        if self.reduction == "none" and self.scalar_output_mode == "non_tensor":
+            td_out.set_non_tensor("alpha", self.alpha.detach())
+            td_out.set_non_tensor("entropy", entropy.detach().mean())
         self._clear_weakrefs(
             tensordict,
             td_out,

--- a/torchrl/objectives/decision_transformer.py
+++ b/torchrl/objectives/decision_transformer.py
@@ -268,7 +268,7 @@ class OnlineDTLoss(LossModule):
                 value,
                 tensordict,
                 preserve_shape=self.reduction == "none",
-            ).squeeze(-1)
+            )
             if name.startswith("loss_")
             else value,
         )

--- a/torchrl/objectives/decision_transformer.py
+++ b/torchrl/objectives/decision_transformer.py
@@ -255,26 +255,24 @@ class OnlineDTLoss(LossModule):
             "loss_alpha": loss_alpha,
         }
 
-        # Handle batch_size and scalar values based on reduction mode
+        # Handle batch_size and scalar values (alpha, entropy) based on reduction mode
         if self.reduction == "none":
             batch_size = tensordict.batch_size
             td_out = TensorDict(out, batch_size=batch_size)
+            if self.scalar_output_mode == "non_tensor":
+                td_out.set_non_tensor("alpha", self.alpha.detach())
+                td_out.set_non_tensor("entropy", entropy.detach().mean())
         else:
             out["entropy"] = entropy.detach().mean()
             out["alpha"] = self.alpha.detach()
             td_out = TensorDict(out, [])
-        td_out = td_out.named_apply(
-            lambda name, value: self._reduce_loss(
-                value,
-                tensordict,
-                preserve_shape=self.reduction == "none",
+            td_out = td_out.named_apply(
+                lambda name, value: self._reduce_loss(
+                    value, tensordict=tensordict
+                ).squeeze(-1)
+                if name.startswith("loss_")
+                else value,
             )
-            if name.startswith("loss_")
-            else value,
-        )
-        if self.reduction == "none" and self.scalar_output_mode == "non_tensor":
-            td_out.set_non_tensor("alpha", self.alpha.detach())
-            td_out.set_non_tensor("entropy", entropy.detach().mean())
         self._clear_weakrefs(
             tensordict,
             td_out,

--- a/torchrl/objectives/deprecated.py
+++ b/torchrl/objectives/deprecated.py
@@ -335,6 +335,10 @@ class REDQLoss_deprecated(LossModule):
             raise RuntimeError(
                 f"QVal and actor loss have different shape: {loss_qval.shape} and {loss_actor.shape}"
             )
+        loss_tensordict = tensordict.unsqueeze(0)
+        loss_actor = self._reduce_loss(loss_actor, loss_tensordict)
+        loss_qval = self._reduce_loss(loss_qval, loss_tensordict)
+        loss_alpha = self._reduce_loss(loss_alpha, tensordict)
         td_out = TensorDict(
             {
                 "loss_actor": loss_actor,
@@ -344,12 +348,6 @@ class REDQLoss_deprecated(LossModule):
                 "entropy": -sample_log_prob.detach().mean(),
             },
             [],
-        )
-        td_out = td_out.named_apply(
-            lambda name, value: self._reduce_loss(value, tensordict=tensordict)
-            if name.startswith("loss_")
-            else value,
-            batch_size=[],
         )
         self._clear_weakrefs(
             tensordict,

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -985,9 +985,8 @@ class PPOLoss(LossModule):
                 td_out.set("value_clip_fraction", value_clip_fraction)
             if explained_variance is not None:
                 td_out.set("explained_variance", explained_variance)
-        loss_mask = tensordict.get("shifted_valid", default=None)
         td_out = td_out.named_apply(
-            lambda name, value: self._reduce_loss(value, mask=loss_mask).squeeze(-1)
+            lambda name, value: self._reduce_loss(value, tensordict).squeeze(-1)
             if name.startswith("loss_")
             else value,
         )
@@ -1435,9 +1434,8 @@ class ClipPPOLoss(PPOLoss):
             ratio = log_weight.exp()
             td_out.set("max_ratio", ratio.max())
             td_out.set("mean_ratio", ratio.mean())
-        loss_mask = tensordict.get("shifted_valid", default=None)
         td_out = td_out.named_apply(
-            lambda name, value: self._reduce_loss(value, mask=loss_mask).squeeze(-1)
+            lambda name, value: self._reduce_loss(value, tensordict).squeeze(-1)
             if name.startswith("loss_")
             else value,
         )
@@ -1796,9 +1794,8 @@ class KLPENPPOLoss(PPOLoss):
                 td_out.set("value_clip_fraction", value_clip_fraction)
             if explained_variance is not None:
                 td_out.set("explained_variance", explained_variance)
-        loss_mask = tensordict_copy.get("shifted_valid", default=None)
         td_out = td_out.named_apply(
-            lambda name, value: self._reduce_loss(value, mask=loss_mask).squeeze(-1)
+            lambda name, value: self._reduce_loss(value, tensordict_copy).squeeze(-1)
             if name.startswith("loss_")
             else value,
         )

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -637,11 +637,9 @@ class REDQLoss(LossModule):
         if self.reduction != "none":
             loss_tensordict = tensordict.unsqueeze(0)
             td_out = td_out.named_apply(
-                lambda name, value: (
-                    self._reduce_loss(value, tensordict=loss_tensordict)
-                    if name.startswith("loss_")
-                    else value
-                ),
+                lambda name, value: self._reduce_loss(value, loss_tensordict)
+                if name.startswith("loss_")
+                else value,
             )
         if self.reduction == "none" and self.scalar_output_mode == "non_tensor":
             # Move scalars to non-tensor after creation

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -634,14 +634,15 @@ class REDQLoss(LossModule):
                 "target_value": target_value.detach(),
             }
         td_out = TensorDict(out, [])
-        loss_tensordict = tensordict.unsqueeze(0)
-        td_out = td_out.named_apply(
-            lambda name, value: (
-                self._reduce_loss(value, tensordict=loss_tensordict)
-                if name.startswith("loss_")
-                else value
-            ),
-        )
+        if self.reduction != "none":
+            loss_tensordict = tensordict.unsqueeze(0)
+            td_out = td_out.named_apply(
+                lambda name, value: (
+                    self._reduce_loss(value, tensordict=loss_tensordict)
+                    if name.startswith("loss_")
+                    else value
+                ),
+            )
         if self.reduction == "none" and self.scalar_output_mode == "non_tensor":
             # Move scalars to non-tensor after creation
             td_out.set_non_tensor("alpha", td_out.pop("alpha"))

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -621,7 +621,6 @@ class REDQLoss(LossModule):
                 "next.state_value": next_state_value.detach(),
                 "target_value": target_value.detach(),
             }
-            td_out = TensorDict(out, [])
         else:
             out = {
                 "loss_actor": loss_actor,
@@ -634,20 +633,19 @@ class REDQLoss(LossModule):
                 "next.state_value": next_state_value.detach(),
                 "target_value": target_value.detach(),
             }
-            td_out = TensorDict(out, [])
-            if self.reduction != "none":
-                loss_mask = tensordict.get("shifted_valid", default=None)
-                if loss_mask is not None:
-                    loss_mask = loss_mask.unsqueeze(0)
-                td_out = td_out.named_apply(
-                    lambda name, value: self._reduce_loss(value, mask=loss_mask)
-                    if name.startswith("loss_")
-                    else value,
-                )
-            elif self.scalar_output_mode == "non_tensor":
-                # Move scalars to non-tensor after creation
-                td_out.set_non_tensor("alpha", td_out.pop("alpha"))
-                td_out.set_non_tensor("entropy", td_out.pop("entropy"))
+        td_out = TensorDict(out, [])
+        loss_tensordict = tensordict.unsqueeze(0)
+        td_out = td_out.named_apply(
+            lambda name, value: (
+                self._reduce_loss(value, tensordict=loss_tensordict)
+                if name.startswith("loss_")
+                else value
+            ),
+        )
+        if self.reduction == "none" and self.scalar_output_mode == "non_tensor":
+            # Move scalars to non-tensor after creation
+            td_out.set_non_tensor("alpha", td_out.pop("alpha"))
+            td_out.set_non_tensor("entropy", td_out.pop("entropy"))
         self._clear_weakrefs(
             tensordict,
             td_out,

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -634,13 +634,12 @@ class REDQLoss(LossModule):
                 "target_value": target_value.detach(),
             }
         td_out = TensorDict(out, [])
-        if self.reduction != "none":
-            loss_tensordict = tensordict.unsqueeze(0)
-            td_out = td_out.named_apply(
-                lambda name, value: self._reduce_loss(value, loss_tensordict)
-                if name.startswith("loss_")
-                else value,
-            )
+        loss_tensordict = tensordict.unsqueeze(0)
+        td_out = td_out.named_apply(
+            lambda name, value: self._reduce_loss(value, loss_tensordict)
+            if name.startswith("loss_")
+            else value,
+        )
         if self.reduction == "none" and self.scalar_output_mode == "non_tensor":
             # Move scalars to non-tensor after creation
             td_out.set_non_tensor("alpha", td_out.pop("alpha"))

--- a/torchrl/objectives/reinforce.py
+++ b/torchrl/objectives/reinforce.py
@@ -393,9 +393,8 @@ class ReinforceLoss(LossModule):
         td_out.set("loss_value", loss_value)
         if value_clip_fraction is not None:
             td_out.set("value_clip_fraction", value_clip_fraction)
-        loss_mask = tensordict.get("shifted_valid", default=None)
         td_out = td_out.named_apply(
-            lambda name, value: self._reduce_loss(value, mask=loss_mask).squeeze(-1)
+            lambda name, value: self._reduce_loss(value, tensordict).squeeze(-1)
             if name.startswith("loss_")
             else value,
         )

--- a/torchrl/objectives/rnd.py
+++ b/torchrl/objectives/rnd.py
@@ -14,7 +14,6 @@ from tensordict.utils import NestedKey
 
 from torchrl.envs.transforms.rnd import RunningMeanStd
 from torchrl.objectives.common import LossModule
-from torchrl.objectives.utils import _reduce
 
 
 class RNDLoss(LossModule):
@@ -129,6 +128,7 @@ class RNDLoss(LossModule):
 
         per_sample_loss = (pred_feat - target_feat).pow(2).mean(dim=-1)
 
+        mask = None
         if self.update_fraction < 1.0:
             mask = (
                 torch.rand(per_sample_loss.shape, device=per_sample_loss.device)
@@ -137,11 +137,8 @@ class RNDLoss(LossModule):
             per_sample_loss = torch.where(
                 mask, per_sample_loss, torch.zeros_like(per_sample_loss)
             )
-            if self.reduction == "mean":
-                loss = per_sample_loss.sum() / mask.sum().clamp_min(1)
-            else:
-                loss = _reduce(per_sample_loss, self.reduction)
-        else:
-            loss = _reduce(per_sample_loss, self.reduction)
+            if self.reduction == "none":
+                mask = None
+        loss = self._reduce_loss(per_sample_loss, tensordict=tensordict, mask=mask)
 
         return TensorDict({"loss_predictor": loss}, batch_size=[])


### PR DESCRIPTION
#3888 refactored objectives to route through _reduce_loss but the collector mask change from #3850 never merged, leaving a gap. The relevant code changed as well. This made it so padded timesteps from collector, mask were still included and could change the final loss and grads. 

BC & RND use it directly. A2C, ppo and reinforce pass input via TensorDict and REDQ/OnlineDT deal with shape-specific cases their own way. 

closes #3866.

Ran tests; 9314 passed.

cc @vmoens 

## Tested

`test/objectives`: **7525 passed, 2330 skipped**, matching the pre-PR baseline
(7522 passed with the same skips, plus the 3 new regression tests).

Worth flagging: before the fix in `4cc1e15`, this branch **failed 72 existing
tests** — every `TestTD3::test_td3_batcher` and `TestTD3BC::test_td3bc_batcher`
parametrization. Their fixtures supply `("collector", "mask")` with the standard
trailing-singleton shape `[B, T, 1]` against a `[B, T]` loss, and
`_expand_loss_mask` only handled masks with *fewer* dimensions than the loss, so
`expand_as` raised. `shifted_valid` never hit this because the value estimators
emit it already squeezed. That crash is the reason a mask-discovery change needs
the objectives suite run against a baseline, not just new unit tests.
