### PR TITLE
[BugFix] Bump C++ extension standard to C++20 for torch nightly compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -185,8 +185,8 @@ def get_extensions():
 
     This function configures the C++ extension build process with appropriate
     compiler flags for different platforms:
-    - Windows (MSVC): Uses /O2, /std:c++17, /EHsc flags
-    - Unix-like (GCC/Clang): Uses -O3, -std=c++17, -fdiagnostics-color=always flags
+    - Windows (MSVC): Uses /O2, /std:c++20, /EHsc flags
+    - Unix-like (GCC/Clang): Uses -O3, -std=c++20, -fdiagnostics-color=always flags
 
     Returns:
         list: List of CppExtension objects to be built
@@ -235,7 +235,7 @@ def get_extensions():
         extra_compile_args = {
             "cxx": [
                 "-O3",
-                "-std=c++17",
+                "-std=c++20",
                 "-fdiagnostics-color=always",
             ]
         }
@@ -243,7 +243,7 @@ def get_extensions():
             extra_compile_args["cxx"].append("-DWITH_CUDA")
             extra_compile_args["nvcc"] = [
                 "-O3",
-                "-std=c++17",
+                "-std=c++20",
                 "-DWITH_CUDA",
             ]
         debug_mode = os.getenv("DEBUG", "0") == "1"
@@ -254,7 +254,7 @@ def get_extensions():
                     "-O0",
                     "-fno-inline",
                     "-g",
-                    "-std=c++17",
+                    "-std=c++20",
                     "-fdiagnostics-color=always",
                 ]
             }
@@ -263,7 +263,7 @@ def get_extensions():
                 extra_compile_args["nvcc"] = [
                     "-O0",
                     "-G",
-                    "-std=c++17",
+                    "-std=c++20",
                     "-DWITH_CUDA",
                 ]
             extra_link_args = ["-O0", "-g"]


### PR DESCRIPTION
## Description

The Push Binary Nightly wheel builds (`build-wheel-unix`, linux and macos, all Python versions) have been failing on main since at least 2026-08-02. Torch nightly headers now use C++20 features:

- `std::strong_ordering` in `c10/util/intrusive_ptr.h`
- `requires` clauses and `std::is_same_v` specialization checks in `ATen/core/TensorBase.h`
- `std::string_view::starts_with` in `c10/util/TypeIndex.h`

and `torch/csrc/api/include/torch/all.h` now hard-errors with "C++20 or later compatible compiler is required to use PyTorch." The Unix branch of `get_extensions()` in `setup.py` still compiled `torchrl/csrc` with `-std=c++17`, so ninja failed with `no type named 'strong_ordering' in namespace 'std'` etc. Example failing run: https://github.com/pytorch/rl/actions/runs/30830397705

## Fix

Bump the GCC/Clang `cxx` and `nvcc` flags (release and debug) from `-std=c++17` to `-std=c++20`. Windows already used `/std:c++20`.

## Verification

- Reproduced the CI failure locally on macOS: compiling `torchrl/csrc` against torch `2.14.0.dev20260804` with `-std=c++17` fails with the exact `strong_ordering` error; with `-std=c++20` the extension compiles and the resulting module imports and exposes its symbols (`SumSegmentTreeFp32`, `safeatanh`, ...).
- Oldest supported stable (torch 2.1, olddeps CI on Ubuntu 22.04 / GCC 11): GCC 11 fully supports `-std=c++20`, and torch 2.1 headers are C++17 code that compiles unchanged under C++20. The `ci/olddeps` label should be added before re-running CI to get that signal on this PR.
- The Push Binary Nightly workflow runs on `pull_request`, so the wheel jobs on this PR verify the fix directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)