### PR TITLE
[CI] Install torchcodec nightly wheels instead of building from source

### DIFF
--- a/.github/unittest/linux/scripts/run_all.sh
+++ b/.github/unittest/linux/scripts/run_all.sh
@@ -252,18 +252,9 @@ else
   uv_pip_install -e . --no-build-isolation --no-deps
 fi
 
-# install torchcodec (from source for nightly, from the PyTorch wheel index for stable)
+# install torchcodec from the PyTorch wheel index (nightly wheels for torch nightly)
 if [[ "$TORCH_VERSION" == "nightly" ]]; then
-  # torchcodec builds with scikit-build-core; --no-build-isolation requires the
-  # build backend to be present in the environment (pybind11/ninja/cmake already are).
-  uv_pip_install "scikit-build-core>=0.10"
-  torchcodec_dir=$(mktemp -d)
-  git clone --depth 1 https://github.com/pytorch/torchcodec.git "$torchcodec_dir"
-  python_base="$(python -c 'import sys; print(sys.base_prefix)')"
-  CMAKE_PREFIX_PATH="${python_base}${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}" \
-    I_CONFIRM_THIS_IS_NOT_A_LICENSE_VIOLATION=1 \
-    uv_pip_install --no-build-isolation "$torchcodec_dir"
-  rm -rf "$torchcodec_dir"
+  uv_pip_install --pre --index-url "https://download.pytorch.org/whl/nightly/${CU_VERSION}" torchcodec
 else
   uv_pip_install --index-url "https://download.pytorch.org/whl/${CU_VERSION}" torchcodec
 fi

--- a/.github/unittest/tutorials/scripts/run_all.sh
+++ b/.github/unittest/tutorials/scripts/run_all.sh
@@ -115,18 +115,18 @@ bash "${root_dir}/.github/unittest/helpers/assert_torch_version.sh" "$TORCH_VERS
 # ============================================================================================ #
 # ================================ TorchCodec ================================================ #
 
+# The editable torchrl install below runs with --no-build-isolation, which
+# requires the build backend to be present in the environment.
+uv pip install --no-progress setuptools ninja packaging "pybind11[global]"
+
 printf "* Installing torchcodec\n"
 if [[ "$RELEASE" == 0 ]]; then
-  # torchcodec builds with scikit-build-core; --no-build-isolation requires the
-  # build backend to be present in the environment.
-  uv pip install --no-progress setuptools ninja packaging "pybind11[global]" "scikit-build-core>=0.10"
-  torchcodec_dir="$(mktemp -d)"
-  git clone --depth 1 https://github.com/pytorch/torchcodec.git "$torchcodec_dir"
-  python_base="$(python -c 'import sys; print(sys.base_prefix)')"
-  CMAKE_PREFIX_PATH="${python_base}${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}" \
-    I_CONFIRM_THIS_IS_NOT_A_LICENSE_VIOLATION=1 \
-    uv pip install --no-progress --no-build-isolation "$torchcodec_dir"
-  rm -rf "$torchcodec_dir"
+  # Nightly wheels from the PyTorch index, matching the torch nightly above.
+  if [ "${CU_VERSION:-}" == cpu ] ; then
+    uv pip install --no-progress --pre torchcodec --index-url https://download.pytorch.org/whl/nightly/cpu
+  else
+    uv pip install --no-progress --pre torchcodec --index-url https://download.pytorch.org/whl/nightly/$CU_VERSION
+  fi
 else
   uv pip install --no-progress "torchcodec>=0.10.0"
 fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,16 +74,8 @@ jobs:
           python -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu -U --quiet --root-user-action=ignore
           python -m pip install cloudpickle packaging importlib_metadata numpy orjson "pyvers>=0.2.3,<0.3.0" --quiet --root-user-action=ignore
           python -m pip install git+https://github.com/pytorch/tensordict.git --no-deps --quiet --root-user-action=ignore
-          # torchcodec builds with scikit-build-core; --no-build-isolation requires
-          # the build backend to be present in the environment.
-          python -m pip install "scikit-build-core>=0.10" pybind11 ninja --quiet --root-user-action=ignore
-          torchcodec_dir=$(mktemp -d)
-          git clone --depth 1 https://github.com/pytorch/torchcodec.git "$torchcodec_dir"
-          python_base="$(python -c 'import sys; print(sys.base_prefix)')"
-          CMAKE_PREFIX_PATH="${python_base}${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}" \
-            I_CONFIRM_THIS_IS_NOT_A_LICENSE_VIOLATION=1 \
-            python -m pip install --no-build-isolation "$torchcodec_dir" --quiet --root-user-action=ignore
-          rm -rf "$torchcodec_dir"
+          # torchcodec nightly wheels, matching the torch nightly above.
+          python -m pip install --pre torchcodec --index-url https://download.pytorch.org/whl/nightly/cpu --quiet --root-user-action=ignore
         fi
         
         # 6. Install doc requirements BEFORE TorchRL to ensure gymnasium is available


### PR DESCRIPTION
## Description

All CI jobs are currently failing (see e.g. #4059) because the nightly CI paths build torchcodec from source, and that build now hard-fails: torchcodec's CMake requires libheif for HEIC decoding, which the CI images don't ship.

Per Nicolas (torchcodec maintainer), torchcodec publishes nightly wheels on the PyTorch index, so we can install those instead of cloning and building. This switches the three source-build sites (`linux/scripts/run_all.sh`, `tutorials/scripts/run_all.sh`, `docs.yml`) to `--pre torchcodec --index-url https://download.pytorch.org/whl/nightly/<cu>`. Stable/release paths are unchanged.

Nightly wheels exist for the variants CI uses: `cpu` (tests-cpu, docs) and `cu130` (GPU jobs). The olddeps (cu118) jobs don't install torchcodec.

## Tested

- Verified the wheels exist on the index for cpu/cu126/cu130 (`torchcodec-0.16.0.dev20260804`).
- Dry-run resolve of the new install command in a clean venv: pulls only torchcodec, no torch pin, so it won't disturb the torch/torchvision nightlies installed earlier in the scripts.
- `bash -n` on both scripts and YAML-parsed `docs.yml`.
- CI on this PR is the real test.