### PR TITLE
[BugFix] Decode DreamerV3 rewards and values end to end

### DIFF
--- a/.github/unittest/linux_sota/scripts/test_sota.py
+++ b/.github/unittest/linux_sota/scripts/test_sota.py
@@ -342,6 +342,7 @@ commands = {
   networks.num_categoricals=2 \
   networks.num_classes=2 \
   networks.num_reward_bins=11 \
+  networks.num_value_bins=11 \
   networks.rnn_hidden_dim=8 \
   networks.obs_embed_dim=8
 """,

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -20,7 +20,8 @@ networks:
   num_categoricals: 4
   num_classes: 4
   obs_embed_dim: 32
-  num_reward_bins: 41
+  num_reward_bins: 255
+  num_value_bins: 255
   hidden_dim: 64
   depth: 2
 

--- a/sota-implementations/dreamer_v3/dreamer_v3.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3.py
@@ -48,7 +48,7 @@ from torchrl.envs.libs.gym import GymEnv
 from torchrl.envs.model_based.dreamer import DreamerEnv
 from torchrl.envs.transforms import TensorDictPrimer
 from torchrl.envs.utils import ExplorationType, set_exploration_type
-from torchrl.modules import SafeSequential, WorldModelWrapper
+from torchrl.modules import SymExpTwoHot, WorldModelWrapper
 from torchrl.modules.distributions.continuous import TanhNormal
 from torchrl.modules.models.model_based import DreamerActor
 from torchrl.modules.models.model_based_v3 import (
@@ -137,18 +137,52 @@ def build_world_model(*, cfg: DictConfig, obs_dim: int, action_dim: int):
         out_keys=[("next", "reco_pixels")],
     )
 
-    reward_head = TensorDictModule(
-        MLP(
-            in_features=state_dim + cfg.networks.rnn_hidden_dim,
-            out_features=cfg.networks.num_reward_bins,
-            depth=cfg.networks.depth,
-            num_cells=cfg.networks.hidden_dim,
+    reward_net = MLP(
+        in_features=state_dim + cfg.networks.rnn_hidden_dim,
+        out_features=cfg.networks.num_reward_bins,
+        depth=cfg.networks.depth,
+        num_cells=cfg.networks.hidden_dim,
+    )
+    reward_decoder = SymExpTwoHot(cfg.networks.num_reward_bins)
+    reward_head = TensorDictSequential(
+        TensorDictModule(
+            reward_net,
+            in_keys=[("next", "state"), ("next", "belief")],
+            out_keys=[("next", "reward_logits")],
         ),
-        in_keys=[("next", "state"), ("next", "belief")],
-        out_keys=[("next", "reward")],
+        TensorDictModule(
+            reward_decoder,
+            in_keys=[("next", "reward_logits")],
+            out_keys=[("next", "reward")],
+        ),
     )
 
-    return TensorDictSequential(encoder, rollout, decoder, reward_head)
+    world_model = TensorDictSequential(encoder, rollout, decoder, reward_head)
+    return world_model, prior_net, reward_net, reward_decoder
+
+
+def build_imagination_model(*, prior_net, reward_net, reward_decoder):
+    """Build imagination operators backed by the trained world-model heads."""
+    transition_model = TensorDictSequential(
+        TensorDictModule(
+            prior_net,
+            in_keys=["state", "belief", "action"],
+            out_keys=["_", "state", "belief"],
+        )
+    )
+    reward_model = TensorDictSequential(
+        TensorDictModule(
+            reward_net,
+            in_keys=["state", "belief"],
+            out_keys=["reward_logits"],
+        ),
+        TensorDictModule(
+            reward_decoder,
+            in_keys=["reward_logits"],
+            out_keys=["reward"],
+        ),
+    )
+    return WorldModelWrapper(transition_model, reward_model)
 
 
 def build_actor(*, cfg: DictConfig, action_dim: int):
@@ -188,15 +222,22 @@ def build_actor(*, cfg: DictConfig, action_dim: int):
 
 def build_value(*, cfg: DictConfig):
     state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
-    value_model = TensorDictModule(
-        MLP(
-            in_features=state_dim + cfg.networks.rnn_hidden_dim,
-            out_features=1,
-            depth=cfg.networks.depth,
-            num_cells=cfg.networks.hidden_dim,
+    value_model = TensorDictSequential(
+        TensorDictModule(
+            MLP(
+                in_features=state_dim + cfg.networks.rnn_hidden_dim,
+                out_features=cfg.networks.num_value_bins,
+                depth=cfg.networks.depth,
+                num_cells=cfg.networks.hidden_dim,
+            ),
+            in_keys=["state", "belief"],
+            out_keys=["state_value_logits"],
         ),
-        in_keys=["state", "belief"],
-        out_keys=["state_value"],
+        TensorDictModule(
+            SymExpTwoHot(cfg.networks.num_value_bins),
+            in_keys=["state_value_logits"],
+            out_keys=["state_value"],
+        ),
     )
     with torch.no_grad():
         value_model(
@@ -211,8 +252,8 @@ def build_value(*, cfg: DictConfig):
     return value_model
 
 
-def build_mb_env(*, cfg: DictConfig, real_env, action_dim: int):
-    """Imagination env: DreamerEnv wrapping an independent V3 prior + reward head."""
+def build_mb_env(*, cfg: DictConfig, real_env, imagination_model):
+    """Imagination env backed by the trained prior and reward head."""
     state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
     primer_env = TransformedEnv(
         real_env,
@@ -223,33 +264,8 @@ def build_mb_env(*, cfg: DictConfig, real_env, action_dim: int):
             belief=Unbounded(cfg.networks.rnn_hidden_dim),
         ),
     )
-    rssm_prior = RSSMPriorV3(
-        action_spec=real_env.action_spec,
-        hidden_dim=cfg.networks.rnn_hidden_dim,
-        rnn_hidden_dim=cfg.networks.rnn_hidden_dim,
-        num_categoricals=cfg.networks.num_categoricals,
-        num_classes=cfg.networks.num_classes,
-        action_dim=action_dim,
-    )
-    transition_model = SafeSequential(
-        TensorDictModule(
-            rssm_prior,
-            in_keys=["state", "belief", "action"],
-            out_keys=["_", "state", "belief"],
-        )
-    )
-    reward_model = TensorDictModule(
-        MLP(
-            in_features=state_dim + cfg.networks.rnn_hidden_dim,
-            out_features=1,
-            depth=cfg.networks.depth,
-            num_cells=cfg.networks.hidden_dim,
-        ),
-        in_keys=["state", "belief"],
-        out_keys=["reward"],
-    )
     mb_env = DreamerEnv(
-        world_model=WorldModelWrapper(transition_model, reward_model),
+        world_model=imagination_model,
         prior_shape=torch.Size([state_dim]),
         belief_shape=torch.Size([cfg.networks.rnn_hidden_dim]),
     )
@@ -269,7 +285,7 @@ def eval_episode_reward(env, actor, num_episodes: int) -> torch.Tensor:
     return torch.stack(totals).mean()
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="config")
+@hydra.main(config_path="", config_name="config")
 def main(cfg: DictConfig):
     torch.manual_seed(cfg.env.seed)
 
@@ -278,13 +294,20 @@ def main(cfg: DictConfig):
     action_dim = real_env.action_spec.shape[0]
     state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
 
-    world_model = build_world_model(cfg=cfg, obs_dim=obs_dim, action_dim=action_dim)
+    world_model, prior_net, reward_net, reward_decoder = build_world_model(
+        cfg=cfg, obs_dim=obs_dim, action_dim=action_dim
+    )
+    imagination_model = build_imagination_model(
+        prior_net=prior_net,
+        reward_net=reward_net,
+        reward_decoder=reward_decoder,
+    )
     actor_model = build_actor(cfg=cfg, action_dim=action_dim)
     value_model = build_value(cfg=cfg)
     mb_env = build_mb_env(
         cfg=cfg,
         real_env=make_env(cfg.env.name, cfg.env.seed + 1),
-        action_dim=action_dim,
+        imagination_model=imagination_model,
     )
 
     model_loss = DreamerV3ModelLoss(
@@ -308,11 +331,14 @@ def main(cfg: DictConfig):
         lmbda=cfg.optimization.lmbda,
     )
     value_loss = DreamerV3ValueLoss(
-        value_model, value_loss="symlog_mse", actor_loss=actor_loss
+        value_model,
+        value_loss="two_hot",
+        num_value_bins=cfg.networks.num_value_bins,
+        actor_loss=actor_loss,
     )
 
     opt_model = torch.optim.Adam(model_loss.parameters(), lr=cfg.optimization.lr)
-    opt_actor = torch.optim.Adam(actor_loss.parameters(), lr=cfg.optimization.lr)
+    opt_actor = torch.optim.Adam(actor_model.parameters(), lr=cfg.optimization.lr)
     opt_value = torch.optim.Adam(value_loss.parameters(), lr=cfg.optimization.lr)
 
     explore_env = TransformedEnv(

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -8,15 +8,20 @@ Reference: https://arxiv.org/abs/2301.04104
 """
 from __future__ import annotations
 
+import runpy
+from pathlib import Path
+
 import pytest
 import torch
 from _objectives_common import LossModuleTestBase
+from omegaconf import OmegaConf
 from tensordict import TensorDict
 from tensordict.nn import (
     InteractionType,
     ProbabilisticTensorDictModule,
     ProbabilisticTensorDictSequential,
     TensorDictModule,
+    TensorDictSequential,
 )
 from torch import nn
 
@@ -127,6 +132,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
                 # reward head
                 out_r = num_reward_bins if reward_two_hot else 1
                 self_.reward_net = nn.LazyLinear(out_r)
+                self_.reward_decoder = SymExpTwoHot(num_reward_bins)
                 self_.num_cats = num_cats
                 self_.num_classes = num_classes
                 self_.reward_two_hot = reward_two_hot
@@ -162,6 +168,9 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
                 tensordict.set(("next", "prior_logits"), prior_logits)
                 tensordict.set(("next", "posterior_logits"), posterior_logits)
                 tensordict.set(("next", "reco_pixels"), reco_pixels)
+                if self_.reward_two_hot:
+                    tensordict.set(("next", "reward_logits"), reward_pred)
+                    reward_pred = self_.reward_decoder(reward_pred)
                 tensordict.set(("next", "reward"), reward_pred)
                 return tensordict
 
@@ -252,11 +261,22 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         return actor_model
 
     def _create_value_model(self, out_features=1):
-        value_model = TensorDictModule(
+        value_head = TensorDictModule(
             MLP(out_features=out_features, depth=1, num_cells=8),
             in_keys=["state", "belief"],
-            out_keys=["state_value"],
+            out_keys=["state_value" if out_features == 1 else "state_value_logits"],
         )
+        if out_features == 1:
+            value_model = value_head
+        else:
+            value_model = TensorDictSequential(
+                value_head,
+                TensorDictModule(
+                    SymExpTwoHot(out_features),
+                    in_keys=["state_value_logits"],
+                    out_keys=["state_value"],
+                ),
+            )
         with torch.no_grad():
             td = TensorDict(
                 {
@@ -465,6 +485,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         loss_fn = DreamerV3ModelLoss(world_model, num_reward_bins=self.num_reward_bins)
         default_keys = {
             "reward": "reward",
+            "reward_logits": "reward_logits",
             "true_reward": "true_reward",
             "prior_logits": "prior_logits",
             "posterior_logits": "posterior_logits",
@@ -557,6 +578,141 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             if p.grad is not None
         )
         assert grad_total > 0, "All gradients are zero after value (two_hot) backward"
+
+    def test_dreamer_v3_categorical_value_exposes_decoded_value(self, device):
+        value_model = self._create_value_model(out_features=self.num_reward_bins).to(
+            device
+        )
+        tensordict = self._create_value_data().to(device)
+        value_model(tensordict)
+        assert tensordict["state_value_logits"].shape[-1] == self.num_reward_bins
+        assert tensordict["state_value"].shape[-1] == 1
+
+        actor_loss = DreamerV3ActorLoss(
+            self._create_actor_model().to(device),
+            value_model,
+            self._create_mb_env().to(device),
+            imagination_horizon=3,
+        )
+        actor_loss.make_value_estimator(ValueEstimators.TDLambda)
+        loss_td, fake_data = actor_loss(
+            self._create_actor_data().to(device).reshape(-1)
+        )
+        assert loss_td["loss_actor"].ndim == 0
+        assert fake_data["lambda_target"].shape[-1] == 1
+
+    def test_dreamer_v3_legacy_logits_keys_warn(self, device):
+        class LegacyWorldModel(nn.Module):
+            def __init__(self_, world_model):
+                super().__init__()
+                self_.world_model = world_model
+
+            def forward(self_, tensordict):
+                tensordict = self_.world_model(tensordict)
+                logits = tensordict.pop(("next", "reward_logits"))
+                tensordict.set(("next", "reward"), logits)
+                return tensordict
+
+        world_model = LegacyWorldModel(self._create_world_model()).to(device)
+        model_loss = DreamerV3ModelLoss(
+            world_model, num_reward_bins=self.num_reward_bins
+        )
+        with pytest.warns(DeprecationWarning, match="removed in v0.16"):
+            model_loss(self._create_world_model_data().to(device))
+
+        legacy_value = TensorDictModule(
+            MLP(out_features=self.num_reward_bins, depth=1, num_cells=8),
+            in_keys=["state", "belief"],
+            out_keys=["state_value"],
+        ).to(device)
+        value_loss = DreamerV3ValueLoss(
+            legacy_value,
+            value_loss="two_hot",
+            num_value_bins=self.num_reward_bins,
+        )
+        with pytest.warns(DeprecationWarning, match="removed in v0.16"):
+            value_loss(self._create_value_data().to(device))
+
+    def test_dreamer_v3_nested_logits_keys(self, device):
+        class NestedWorldModel(nn.Module):
+            def __init__(self_, world_model):
+                super().__init__()
+                self_.world_model = world_model
+
+            def forward(self_, tensordict):
+                tensordict = self_.world_model(tensordict)
+                tensordict.rename_key_(
+                    ("next", "reward_logits"),
+                    ("next", "predictions", "reward_logits"),
+                )
+                return tensordict
+
+        model_loss = DreamerV3ModelLoss(
+            NestedWorldModel(self._create_world_model()).to(device),
+            num_reward_bins=self.num_reward_bins,
+        )
+        model_loss.set_keys(reward_logits=("predictions", "reward_logits"))
+        model_loss(self._create_world_model_data().to(device))
+
+        value_model = TensorDictSequential(
+            TensorDictModule(
+                MLP(out_features=self.num_reward_bins, depth=1, num_cells=8),
+                in_keys=["state", "belief"],
+                out_keys=[("predictions", "value_logits")],
+            ),
+            TensorDictModule(
+                SymExpTwoHot(self.num_reward_bins),
+                in_keys=[("predictions", "value_logits")],
+                out_keys=[("predictions", "value")],
+            ),
+        ).to(device)
+        value_loss = DreamerV3ValueLoss(
+            value_model,
+            value_loss="two_hot",
+            num_value_bins=self.num_reward_bins,
+        )
+        value_loss.set_keys(
+            value=("predictions", "value"),
+            value_logits=("predictions", "value_logits"),
+        )
+        value_loss(self._create_value_data().to(device))
+
+    def test_dreamer_v3_sota_shares_imagination_parameters(self, device):
+        repo_root = Path(__file__).parents[2]
+        example = runpy.run_path(
+            repo_root / "sota-implementations/dreamer_v3/dreamer_v3.py",
+            run_name="dreamer_v3_test",
+        )
+        cfg = OmegaConf.load(repo_root / "sota-implementations/dreamer_v3/config.yaml")
+        cfg.networks.num_reward_bins = self.num_reward_bins
+        world_model, prior, reward_head, reward_decoder = example["build_world_model"](
+            cfg=cfg, obs_dim=3, action_dim=self.action_dim
+        )
+        imagination_model = example["build_imagination_model"](
+            prior_net=prior,
+            reward_net=reward_head,
+            reward_decoder=reward_decoder,
+        ).to(device)
+        world_model = world_model.to(device)
+        shared_parameters = tuple(prior.parameters()) + tuple(reward_head.parameters())
+        world_parameters = tuple(world_model.parameters())
+        imagination_parameters = tuple(imagination_model.parameters())
+        assert all(
+            any(parameter is candidate for candidate in world_parameters)
+            and any(parameter is candidate for candidate in imagination_parameters)
+            for parameter in shared_parameters
+        )
+
+        reward_td = TensorDict(
+            {
+                "state": torch.randn(2, self.state_dim, device=device),
+                "belief": torch.randn(2, cfg.networks.rnn_hidden_dim, device=device),
+            },
+            [2],
+        )
+        imagination_model.get_reward_operator()(reward_td)
+        assert reward_td["reward_logits"].shape == (2, self.num_reward_bins)
+        assert reward_td["reward"].shape == (2, 1)
 
     def test_dreamer_v3_value_invalid_loss_type(self, device):
         value_model = self._create_value_model()
@@ -839,6 +995,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
                     nn.Unflatten(-1, (3, 64, 64)),
                 )
                 self_.reward_head = nn.LazyLinear(self.num_reward_bins)
+                self_.reward_decoder = SymExpTwoHot(self.num_reward_bins)
                 self_.prior = prior_net
                 self_.posterior = posterior_net
                 self_.num_cats = self.num_cats
@@ -879,7 +1036,8 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
                 td.set(("next", "prior_logits"), prior_logits)
                 td.set(("next", "posterior_logits"), post_logits)
                 td.set(("next", "reco_pixels"), reco_pixels)
-                td.set(("next", "reward"), reward_pred)
+                td.set(("next", "reward_logits"), reward_pred)
+                td.set(("next", "reward"), self_.reward_decoder(reward_pred))
                 return td
 
         world_model = _EndToEndWorldModel().to(device)

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -17,12 +17,13 @@ use in custom models.
 """
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 
 import torch
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
-from tensordict.utils import NestedKey
+from tensordict.utils import NestedKey, unravel_key
 
 from torchrl._utils import _maybe_record_function_decorator
 from torchrl.envs.model_based.dreamer import DreamerEnv
@@ -30,11 +31,11 @@ from torchrl.envs.utils import ExplorationType, set_exploration_type, step_mdp
 from torchrl.modules.models.model_based_v3 import (
     _default_bins,
     _DEFAULT_NUM_BINS,
-    symexp as symexp,
+    symexp as _symexp,
     symlog as symlog,
     two_hot_cross_entropy as two_hot_cross_entropy,
-    two_hot_decode as two_hot_decode,
-    two_hot_encode as two_hot_encode,
+    two_hot_decode as _two_hot_decode,
+    two_hot_encode as _two_hot_encode,
 )
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
@@ -44,6 +45,10 @@ from torchrl.objectives.utils import (
     ValueEstimators,
 )
 from torchrl.objectives.value import ValueEstimatorBase
+
+symexp = _symexp
+two_hot_decode = _two_hot_decode
+two_hot_encode = _two_hot_encode
 
 # ---------------------------------------------------------------------------
 # KL balancing for categorical distributions (DreamerV3 §3)
@@ -177,23 +182,26 @@ class DreamerV3ModelLoss(LossModule):
         >>> import torch
         >>> from tensordict import TensorDict
         >>> from torch import nn
+        >>> from torchrl.modules import SymExpTwoHot
         >>> from torchrl.objectives import DreamerV3ModelLoss
         >>> class StubWorldModel(nn.Module):
         ...     def __init__(self):
         ...         super().__init__()
         ...         self.head = nn.LazyLinear(4 * 4)
         ...         self.reward_head = nn.LazyLinear(16)
+        ...         self.reward_decoder = SymExpTwoHot(16)
         ...         self.decoder = nn.LazyLinear(3 * 8 * 8)
         ...     def forward(self, td):
         ...         B, T = td.shape
         ...         x = torch.cat([td["state"], td["belief"]], dim=-1)
         ...         logits = self.head(x).view(B, T, 4, 4)
         ...         reco = self.decoder(x).view(B, T, 3, 8, 8)
-        ...         reward = self.reward_head(x)
+        ...         reward_logits = self.reward_head(x)
         ...         td.set(("next", "prior_logits"), logits)
         ...         td.set(("next", "posterior_logits"), logits)
         ...         td.set(("next", "reco_pixels"), reco)
-        ...         td.set(("next", "reward"), reward)
+        ...         td.set(("next", "reward_logits"), reward_logits)
+        ...         td.set(("next", "reward"), self.reward_decoder(reward_logits))
         ...         return td
         >>> wm = StubWorldModel()
         >>> td = TensorDict({
@@ -220,7 +228,10 @@ class DreamerV3ModelLoss(LossModule):
         """Configurable tensordict keys.
 
         Attributes:
-            reward (NestedKey): Predicted reward. Defaults to ``"reward"``.
+            reward (NestedKey): Decoded predicted reward. Defaults to
+                ``"reward"``.
+            reward_logits (NestedKey): Categorical reward logits. Defaults to
+                ``"reward_logits"``.
             true_reward (NestedKey): Ground-truth reward (stored temporarily).
                 Defaults to ``"true_reward"``.
             prior_logits (NestedKey): Prior categorical logits from the prior
@@ -238,6 +249,7 @@ class DreamerV3ModelLoss(LossModule):
         """
 
         reward: NestedKey = "reward"
+        reward_logits: NestedKey = "reward_logits"
         true_reward: NestedKey = "true_reward"
         prior_logits: NestedKey = "prior_logits"
         posterior_logits: NestedKey = "posterior_logits"
@@ -320,9 +332,19 @@ class DreamerV3ModelLoss(LossModule):
 
         # ---- Reward loss ----
         true_reward = tensordict.get(("next", self.tensor_keys.true_reward))
-        pred_reward = tensordict.get(("next", self.tensor_keys.reward))
-
         if self.reward_two_hot:
+            reward_logits_key = unravel_key(("next", self.tensor_keys.reward_logits))
+            pred_reward = tensordict.get(reward_logits_key, None)
+            if pred_reward is None:
+                legacy_key = unravel_key(("next", self.tensor_keys.reward))
+                pred_reward = tensordict.get(legacy_key)
+                warnings.warn(
+                    "Storing DreamerV3 categorical reward logits under the decoded "
+                    f"reward key {legacy_key!r} is deprecated and will be removed in "
+                    "v0.16. Write logits to the configured reward_logits key instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             if pred_reward.shape[-1] != self.num_reward_bins:
                 raise ValueError(
                     f"reward_two_hot=True expects the reward head to output "
@@ -333,6 +355,7 @@ class DreamerV3ModelLoss(LossModule):
                 pred_reward, true_reward, self.reward_bins
             )
         else:
+            pred_reward = tensordict.get(("next", self.tensor_keys.reward))
             reward_loss = (symlog(true_reward) - symlog(pred_reward)).pow(2).squeeze(-1)
         reward_loss = reward_loss.mean().unsqueeze(-1)
 
@@ -706,10 +729,14 @@ class DreamerV3ValueLoss(LossModule):
         """Configurable tensordict keys.
 
         Attributes:
-            value (NestedKey): Predicted value key. Defaults to ``"state_value"``.
+            value (NestedKey): Decoded predicted value key. Defaults to
+                ``"state_value"``.
+            value_logits (NestedKey): Categorical value logits key. Defaults to
+                ``"state_value_logits"``.
         """
 
         value: NestedKey = "state_value"
+        value_logits: NestedKey = "state_value_logits"
 
     tensor_keys: _AcceptedKeys
     default_keys = _AcceptedKeys
@@ -767,8 +794,6 @@ class DreamerV3ValueLoss(LossModule):
 
         tensordict_select = fake_data.select(*self.value_model.in_keys, strict=False)
         self.value_model(tensordict_select)
-        value_pred = tensordict_select.get(self.tensor_keys.value)
-
         # lambda_target shape: [N, 1] (flat) or [B, T, 1] (batch x time)
         # Squeeze the trailing 1 for loss computation
         target_sq = lambda_target.squeeze(-1)  # [N] or [B, T]
@@ -782,6 +807,17 @@ class DreamerV3ValueLoss(LossModule):
             discount = torch.ones_like(target_sq)
 
         if self.value_loss == "two_hot":
+            value_pred = tensordict_select.get(self.tensor_keys.value_logits, None)
+            if value_pred is None:
+                value_pred = tensordict_select.get(self.tensor_keys.value)
+                warnings.warn(
+                    "Storing DreamerV3 categorical value logits under the decoded "
+                    f"value key {unravel_key(self.tensor_keys.value)!r} is deprecated "
+                    "and will be removed in v0.16. Write logits to the configured "
+                    "value_logits key instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             if value_pred.shape[-1] != self.value_bins.shape[0]:
                 raise ValueError(
                     f"value_loss='two_hot' expects the value head to output "
@@ -791,6 +827,7 @@ class DreamerV3ValueLoss(LossModule):
             loss = two_hot_cross_entropy(value_pred, target_sq, self.value_bins)
         else:
             # symlog MSE
+            value_pred = tensordict_select.get(self.tensor_keys.value)
             loss = (symlog(value_pred.squeeze(-1)) - symlog(target_sq)).pow(2)
 
         value_loss = (discount * loss).mean()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #4095
* #4075
* #4074
* #4073
* #4072
* #4068
* #4067
* __->__ #4066
* #4065

Summary:
- add configurable reward_logits and value_logits NestedKeys while reserving reward and value keys for decoded scalars
- preserve legacy logits-under-scalar-key inputs with v0.16 deprecation warnings
- expose categorical critic logits and decoded values to lambda returns
- share the trained prior and categorical reward head with imagination
- configure the maintained DreamerV3 example for 255-bin reward and value cross entropy

Rationale:
Training consumes categorical logits, whereas environment rewards, critic baselines, and TD-lambda returns require decoded scalars. Separating these representations prevents logits from leaking into return computation, and sharing the trained heads ensures imagination reflects the optimized world model.

Test plan:
- uv run pytest -q test/objectives/test_dreamer_v3.py
- run the maintained DreamerV3 SOTA smoke with 11-bin CI overrides
- flake8 --config=setup.cfg on the changed Python files
- ufmt check on the changed Python files
- git diff --check