### PR TITLE
[Feature] Normalize DreamerV3 REINFORCE return scale

### DIFF
--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -31,6 +31,8 @@ optimization:
   updates_per_batch: 8
   imagination_horizon: 10
   use_reinforce: true
+  return_normalization_rate: 0.01
+  return_normalization_min_scale: 1.0
   free_bits: 1.0
   kl_alpha: 0.8
   gamma: 0.99

--- a/sota-implementations/dreamer_v3/dreamer_v3.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3.py
@@ -324,6 +324,8 @@ def main(cfg: DictConfig):
         mb_env,
         imagination_horizon=cfg.optimization.imagination_horizon,
         use_reinforce=cfg.optimization.use_reinforce,
+        return_normalization_rate=cfg.optimization.return_normalization_rate,
+        return_normalization_min_scale=cfg.optimization.return_normalization_min_scale,
     )
     actor_loss.make_value_estimator(
         ValueEstimators.TDLambda,

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -44,6 +44,7 @@ from torchrl.objectives import (
 )
 from torchrl.objectives.dreamer_v3 import (
     _default_bins,
+    _match_trailing_dim,
     categorical_kl_balanced,
     symexp,
     symlog,
@@ -942,6 +943,90 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             if p.grad is not None
         )
         assert actor_grad > 0, "REINFORCE path produced no actor gradients"
+
+    def test_dreamer_v3_reinforce_return_normalization(self, device):
+        actor_model = self._create_actor_model_with_log_prob().to(device)
+        value_model = self._create_value_model().to(device)
+        loss_module = DreamerV3ActorLoss(
+            actor_model,
+            value_model,
+            self._create_mb_env().to(device),
+            imagination_horizon=3,
+            discount_loss=False,
+            entropy_bonus=0.0,
+            use_reinforce=True,
+        ).to(device)
+        loss_module.make_value_estimator(ValueEstimators.TDLambda)
+        loss_module.return_low.fill_(-2.0)
+        loss_module.return_high.fill_(8.0)
+        loss_module.eval()
+
+        loss_td, fake_data = loss_module(
+            self._create_actor_data().to(device).reshape(-1)
+        )
+        baseline_td = fake_data.select(*value_model.in_keys, strict=False)
+        value_model(baseline_td)
+        advantage = (fake_data["lambda_target"] - baseline_td["state_value"]).detach()
+        log_prob = _match_trailing_dim(
+            fake_data["action_log_prob"], fake_data["lambda_target"]
+        )
+        expected = -(log_prob * advantage / 10.0).sum((-2, -1)).mean()
+        torch.testing.assert_close(loss_td["loss_actor"], expected)
+        torch.testing.assert_close(
+            loss_td["return_scale"], torch.tensor(10.0, device=device)
+        )
+
+        compiled_scale = torch.compile(loss_module._return_scale, fullgraph=True)
+        torch.testing.assert_close(
+            compiled_scale(fake_data["lambda_target"]),
+            torch.tensor(10.0, device=device),
+        )
+
+    def test_dreamer_v3_return_statistics_checkpoint(self, device):
+        loss_module = DreamerV3ActorLoss(
+            self._create_actor_model_with_log_prob().to(device),
+            self._create_value_model().to(device),
+            self._create_mb_env().to(device),
+            imagination_horizon=3,
+            entropy_bonus=0.0,
+            use_reinforce=True,
+            return_normalization_rate=0.01,
+        ).to(device)
+        loss_module.make_value_estimator(ValueEstimators.TDLambda)
+        loss_td, fake_data = loss_module(
+            self._create_actor_data().to(device).reshape(-1)
+        )
+        expected_low, expected_high = torch.quantile(
+            fake_data["lambda_target"].detach(),
+            torch.tensor([0.05, 0.95], device=device),
+        )
+        torch.testing.assert_close(loss_module.return_low, 0.01 * expected_low)
+        torch.testing.assert_close(loss_module.return_high, 0.01 * expected_high)
+        torch.testing.assert_close(loss_td["return_low"], loss_module.return_low)
+        torch.testing.assert_close(loss_td["return_high"], loss_module.return_high)
+        torch.testing.assert_close(
+            loss_td["return_scale"],
+            (loss_module.return_high - loss_module.return_low).clamp_min(1.0),
+        )
+
+        checkpoint = {
+            key: value.detach().clone()
+            for key, value in loss_module.state_dict().items()
+        }
+        expected_statistics = (
+            loss_module.return_low.clone(),
+            loss_module.return_high.clone(),
+        )
+        loss_module.return_low.zero_()
+        loss_module.return_high.zero_()
+        loss_module.load_state_dict(checkpoint)
+        torch.testing.assert_close(loss_module.return_low, expected_statistics[0])
+        torch.testing.assert_close(loss_module.return_high, expected_statistics[1])
+
+        loss_module.eval()
+        loss_module(self._create_actor_data().to(device).reshape(-1))
+        torch.testing.assert_close(loss_module.return_low, expected_statistics[0])
+        torch.testing.assert_close(loss_module.return_high, expected_statistics[1])
 
     def test_dreamer_v3_value_loss_sync_gamma(self, device):
         """sync_gamma_with_actor_loss must pull gamma from the actor's value estimator."""

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -420,6 +420,14 @@ class DreamerV3ActorLoss(LossModule):
             * stop-gradient advantage). If ``False``, uses the straight
             reparameterization gradient (suitable for continuous Gaussian
             actors). Default: ``False``.
+        return_normalization (bool, optional): Normalize detached REINFORCE
+            advantages by an EMA return-percentile span. Default: ``True``.
+        return_normalization_rate (float, optional): EMA update rate for the
+            return statistics. Default: ``0.01``.
+        return_normalization_quantiles (tuple of float, optional): Lower and
+            upper return quantiles. Default: ``(0.05, 0.95)``.
+        return_normalization_min_scale (float, optional): Minimum divisor for
+            REINFORCE advantages. Default: ``1.0``.
 
     Examples:
         >>> import torch
@@ -543,6 +551,10 @@ class DreamerV3ActorLoss(LossModule):
         discount_loss: bool = True,
         entropy_bonus: float = 3e-4,
         use_reinforce: bool = False,
+        return_normalization: bool = True,
+        return_normalization_rate: float = 0.01,
+        return_normalization_quantiles: tuple[float, float] = (0.05, 0.95),
+        return_normalization_min_scale: float = 1.0,
         gamma: float | None = None,
         lmbda: float | None = None,
     ):
@@ -554,6 +566,22 @@ class DreamerV3ActorLoss(LossModule):
         self.discount_loss = discount_loss
         self.entropy_bonus = entropy_bonus
         self.use_reinforce = use_reinforce
+        self.return_normalization = return_normalization
+        if not 0 <= return_normalization_rate <= 1:
+            raise ValueError("return_normalization_rate must be in [0, 1].")
+        lower_quantile, upper_quantile = return_normalization_quantiles
+        if not 0 <= lower_quantile < upper_quantile <= 1:
+            raise ValueError(
+                "return_normalization_quantiles must satisfy "
+                "0 <= lower < upper <= 1."
+            )
+        if return_normalization_min_scale <= 0:
+            raise ValueError("return_normalization_min_scale must be positive.")
+        self.return_normalization_rate = return_normalization_rate
+        self.return_normalization_quantiles = return_normalization_quantiles
+        self.return_normalization_min_scale = return_normalization_min_scale
+        self.register_buffer("return_low", torch.tensor(0.0))
+        self.register_buffer("return_high", torch.tensor(0.0))
         if gamma is not None:
             raise TypeError(_GAMMA_LMBDA_DEPREC_ERROR)
         if lmbda is not None:
@@ -605,9 +633,14 @@ class DreamerV3ActorLoss(LossModule):
                 self.value_model(baseline_td)
             baseline = baseline_td.get(self.tensor_keys.value)
             advantage = (lambda_target - baseline).detach()
+            return_scale = self._return_scale(lambda_target)
+            advantage = advantage / return_scale
             actor_loss = -(discount * log_prob * advantage).sum((-2, -1)).mean()
         else:
             # Reparameterization gradient
+            return_scale = torch.ones(
+                (), dtype=lambda_target.dtype, device=lambda_target.device
+            )
             actor_loss = -(discount * lambda_target).sum((-2, -1)).mean()
 
         # Entropy bonus (if actor provides log_prob)
@@ -617,9 +650,36 @@ class DreamerV3ActorLoss(LossModule):
             entropy = -(discount * log_prob_for_entropy).sum((-2, -1)).mean()
             actor_loss = actor_loss - self.entropy_bonus * entropy
 
-        loss_tensordict = TensorDict({"loss_actor": actor_loss}, [])
+        loss_tensordict = TensorDict(
+            {
+                "loss_actor": actor_loss,
+                "return_low": self.return_low.detach().clone(),
+                "return_high": self.return_high.detach().clone(),
+                "return_scale": return_scale.detach().clone(),
+            },
+            [],
+        )
         self._clear_weakrefs(tensordict, loss_tensordict)
         return loss_tensordict, fake_data.data
+
+    def _return_scale(self, returns: torch.Tensor) -> torch.Tensor:
+        if not self.return_normalization:
+            return torch.ones((), dtype=returns.dtype, device=returns.device)
+        if self.training:
+            quantiles = torch.tensor(
+                self.return_normalization_quantiles,
+                dtype=self.return_low.dtype,
+                device=self.return_low.device,
+            )
+            current_low, current_high = torch.quantile(
+                returns.detach().to(self.return_low), quantiles
+            )
+            with torch.no_grad():
+                self.return_low.lerp_(current_low, self.return_normalization_rate)
+                self.return_high.lerp_(current_high, self.return_normalization_rate)
+        return (self.return_high - self.return_low).clamp_min(
+            self.return_normalization_min_scale
+        )
 
     def lambda_target(self, reward: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
         done = torch.zeros(reward.shape, dtype=torch.bool, device=reward.device)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #4095
* #4075
* #4074
* #4073
* #4072
* #4068
* __->__ #4067
* #4066
* #4065

Summary:
- checkpoint EMA fifth- and ninety-fifth-percentile return statistics in the actor loss
- update them at rate 0.01 without debiasing and clamp the span to at least 1.0
- divide detached REINFORCE advantages by the uncentered span
- expose low, high, and scale diagnostics plus normalization configuration
- enable the maintained example with the paper defaults

Rationale:
DreamerV3 normalizes the scale of REINFORCE advantages so reward magnitude does not directly determine actor-gradient magnitude. Persisting the EMA state keeps resumed training numerically continuous while evaluation remains read-only.

Test plan:
- uv run pytest -q test/objectives/test_dreamer_v3.py
- run the maintained DreamerV3 SOTA smoke with 11-bin CI overrides
- verify the normalized REINFORCE equation, EMA updates, eval stability, torch.compile, gradients, and state-dict round trip
- flake8 --config=setup.cfg on the changed Python files
- ufmt check on the changed Python files
- git diff --check