### PR TITLE
[Feature] Add DreamerV3 slow-critic regularization

### DIFF
--- a/benchmarks/test_objectives_benchmarks.py
+++ b/benchmarks/test_objectives_benchmarks.py
@@ -20,13 +20,14 @@ from tensordict.nn import (
 )
 from torch.nn import functional as F
 from torchrl.data.tensor_specs import Bounded, Unbounded
-from torchrl.modules import MLP, QValueActor, TanhNormal
+from torchrl.modules import MLP, QValueActor, SymExpTwoHot, TanhNormal
 from torchrl.objectives import (
     A2CLoss,
     ClipPPOLoss,
     CQLLoss,
     DDPGLoss,
     DQNLoss,
+    DreamerV3ValueLoss,
     IQLLoss,
     REDQLoss,
     ReinforceLoss,
@@ -34,6 +35,7 @@ from torchrl.objectives import (
     TD3Loss,
 )
 from torchrl.objectives.deprecated import REDQLoss_deprecated
+from torchrl.objectives.utils import SoftUpdate
 from torchrl.objectives.value import GAE
 from torchrl.objectives.value.functional import (
     generalized_advantage_estimate,
@@ -165,6 +167,51 @@ def _maybe_compile(fn, compile, td, fullgraph=FULLGRAPH, warmup=3):
             fn(td)
 
     return fn
+
+
+@pytest.mark.parametrize("compile", [False, True])
+def test_dreamer_v3_value_speed(
+    benchmark, compile, state_dim=32, belief_dim=32, bins=255, batch=128
+):
+    device = torch.device("cpu")
+    value_model = Seq(
+        Mod(
+            MLP(
+                in_features=state_dim + belief_dim,
+                out_features=bins,
+                depth=2,
+                num_cells=128,
+                device=device,
+            ),
+            in_keys=["state", "belief"],
+            out_keys=["state_value_logits"],
+        ),
+        Mod(
+            SymExpTwoHot(bins).to(device),
+            in_keys=["state_value_logits"],
+            out_keys=["state_value"],
+        ),
+    )
+    td = TensorDict(
+        {
+            "state": torch.randn(batch, state_dim, device=device),
+            "belief": torch.randn(batch, belief_dim, device=device),
+            "lambda_target": torch.randn(batch, 1, device=device),
+        },
+        [batch],
+    )
+    value_model(td.clone())
+    loss = DreamerV3ValueLoss(
+        value_model,
+        value_loss="two_hot",
+        discount_loss=False,
+        num_value_bins=bins,
+        slow_critic_regularization=1.0,
+    )
+    SoftUpdate(loss, tau=0.02)
+    loss(td)
+    loss = _maybe_compile(loss, compile, td, fullgraph=False, warmup=1)
+    benchmark(loss, td)
 
 
 @pytest.mark.parametrize("backward", [None, "backward"])

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -33,6 +33,8 @@ optimization:
   use_reinforce: true
   return_normalization_rate: 0.01
   return_normalization_min_scale: 1.0
+  slow_critic_regularization: 1.0
+  slow_critic_tau: 0.02
   free_bits: 1.0
   kl_alpha: 0.8
   gamma: 0.99

--- a/sota-implementations/dreamer_v3/dreamer_v3.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3.py
@@ -62,7 +62,7 @@ from torchrl.objectives import (
     DreamerV3ModelLoss,
     DreamerV3ValueLoss,
 )
-from torchrl.objectives.utils import ValueEstimators
+from torchrl.objectives.utils import SoftUpdate, ValueEstimators
 
 _has_matplotlib = importlib.util.find_spec("matplotlib") is not None
 
@@ -337,7 +337,9 @@ def main(cfg: DictConfig):
         value_loss="two_hot",
         num_value_bins=cfg.networks.num_value_bins,
         actor_loss=actor_loss,
+        slow_critic_regularization=cfg.optimization.slow_critic_regularization,
     )
+    value_target_updater = SoftUpdate(value_loss, tau=cfg.optimization.slow_critic_tau)
 
     opt_model = torch.optim.Adam(model_loss.parameters(), lr=cfg.optimization.lr)
     opt_actor = torch.optim.Adam(actor_model.parameters(), lr=cfg.optimization.lr)
@@ -471,6 +473,7 @@ def main(cfg: DictConfig):
                 value_loss.parameters(), cfg.optimization.grad_clip
             )
             opt_value.step()
+            value_target_updater.step()
 
             loss_hist["kl"].append(m_td["loss_model_kl"].detach())
             loss_hist["reco"].append(m_td["loss_model_reco"].detach())

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -52,7 +52,7 @@ from torchrl.objectives.dreamer_v3 import (
     two_hot_decode,
     two_hot_encode,
 )
-from torchrl.objectives.utils import ValueEstimators
+from torchrl.objectives.utils import SoftUpdate, ValueEstimators
 from torchrl.testing import get_default_devices
 from torchrl.testing.mocking_classes import ContinuousActionConvMockEnv
 
@@ -719,6 +719,114 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         value_model = self._create_value_model()
         with pytest.raises(ValueError, match="symlog_mse.*two_hot"):
             DreamerV3ValueLoss(value_model, value_loss="bad_loss_type")
+
+    def test_dreamer_v3_slow_critic_regularization_and_update(self, device):
+        value_model = self._create_value_model(out_features=self.num_reward_bins).to(
+            device
+        )
+        loss_module = DreamerV3ValueLoss(
+            value_model,
+            value_loss="two_hot",
+            discount_loss=False,
+            num_value_bins=self.num_reward_bins,
+            slow_critic_regularization=1.0,
+        ).to(device)
+        updater = SoftUpdate(loss_module, tau=0.02)
+        tensordict = self._create_value_data().to(device)
+
+        online_td = tensordict.select(*value_model.in_keys, strict=False)
+        with loss_module.value_model_params.to_module(
+            loss_module.value_model, preserve_module_state=False
+        ):
+            loss_module.value_model(online_td)
+        target_td = tensordict.select(*value_model.in_keys, strict=False)
+        with torch.no_grad(), loss_module.target_value_model_params.to_module(
+            loss_module.value_model, preserve_module_state=False
+        ):
+            loss_module.value_model(target_td)
+        expected_slow_loss = two_hot_cross_entropy(
+            online_td["state_value_logits"],
+            target_td["state_value"].squeeze(-1),
+            loss_module.value_bins,
+        ).mean()
+
+        loss_td, _ = loss_module(tensordict)
+        torch.testing.assert_close(loss_td["value_slow_loss"], expected_slow_loss)
+        loss_td["loss_value"].backward()
+        assert any(
+            parameter.grad is not None
+            for parameter in loss_module.value_model_params.values(True, True)
+            if parameter.requires_grad
+        )
+        assert all(
+            not parameter.requires_grad and parameter.grad is None
+            for parameter in loss_module.target_value_model_params.values(True, True)
+        )
+
+        source = next(
+            parameter
+            for parameter in loss_module.value_model_params.values(True, True)
+            if parameter.requires_grad
+        )
+        target = next(
+            parameter
+            for parameter in loss_module.target_value_model_params.values(True, True)
+            if parameter.shape == source.shape
+        )
+        target_before = target.clone()
+        with torch.no_grad():
+            source.add_(1.0)
+        updater.step()
+        torch.testing.assert_close(target, target_before.lerp(source.detach(), 0.02))
+
+    def test_dreamer_v3_slow_critic_checkpoint_and_online_bootstrap(self, device):
+        value_model = self._create_value_model(out_features=self.num_reward_bins).to(
+            device
+        )
+        actor_loss = DreamerV3ActorLoss(
+            self._create_actor_model().to(device),
+            value_model,
+            self._create_mb_env().to(device),
+        )
+        value_loss = DreamerV3ValueLoss(
+            value_model,
+            value_loss="two_hot",
+            num_value_bins=self.num_reward_bins,
+            actor_loss=actor_loss,
+            slow_critic_regularization=1.0,
+        ).to(device)
+        SoftUpdate(value_loss, tau=0.02)
+
+        actor_parameters = tuple(actor_loss.__dict__["value_model"].parameters())
+        online_parameters = tuple(value_loss.value_model_params.values(True, True))
+        target_parameters = tuple(
+            value_loss.target_value_model_params.values(True, True)
+        )
+        assert all(
+            any(parameter is online for online in online_parameters)
+            for parameter in actor_parameters
+        )
+        assert all(
+            all(parameter is not target for target in target_parameters)
+            for parameter in actor_parameters
+        )
+
+        checkpoint = {
+            key: value.detach().clone()
+            for key, value in value_loss.state_dict().items()
+        }
+        target_keys = [key for key in checkpoint if key.startswith("target_value")]
+        assert target_keys
+        expected_target = tuple(parameter.clone() for parameter in target_parameters)
+        with torch.no_grad():
+            for parameter in target_parameters:
+                parameter.add_(10.0)
+        value_loss.load_state_dict(checkpoint)
+        for actual, expected in zip(
+            value_loss.target_value_model_params.values(True, True),
+            expected_target,
+        ):
+            torch.testing.assert_close(actual, expected)
 
     # ------------------------------------------------------------------ #
     # RSSM component tests

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -21,7 +21,7 @@ import warnings
 from dataclasses import dataclass
 
 import torch
-from tensordict import TensorDict
+from tensordict import TensorDict, TensorDictParams
 from tensordict.nn import TensorDictModule
 from tensordict.utils import NestedKey, unravel_key
 
@@ -747,6 +747,10 @@ class DreamerV3ValueLoss(LossModule):
     call. The legacy ``gamma=`` kwarg + :meth:`sync_gamma_with_actor_loss`
     pattern is still supported.
 
+    Setting ``slow_critic_regularization`` to a positive value creates a
+    checkpointed target critic. Associate a :class:`~torchrl.objectives.SoftUpdate`
+    and step it after each critic optimizer step.
+
     Reference: https://arxiv.org/abs/2301.04104
 
     Args:
@@ -762,6 +766,9 @@ class DreamerV3ValueLoss(LossModule):
         actor_loss (DreamerV3ActorLoss, optional): If provided, ``gamma`` is
             read from this actor loss's value estimator on every forward call,
             avoiding any chance of a mismatch. Default: ``None``.
+        slow_critic_regularization (float, optional): Weight of the auxiliary
+            loss that trains the online critic toward decoded target-critic
+            predictions. Default: ``0.0``.
 
     Examples:
         >>> import torch
@@ -802,6 +809,8 @@ class DreamerV3ValueLoss(LossModule):
     default_keys = _AcceptedKeys
 
     value_model: TensorDictModule
+    value_model_params: TensorDictParams
+    target_value_model_params: TensorDictParams
 
     def __init__(
         self,
@@ -811,9 +820,17 @@ class DreamerV3ValueLoss(LossModule):
         gamma: float = 0.99,
         num_value_bins: int = _DEFAULT_NUM_BINS,
         actor_loss: DreamerV3ActorLoss | None = None,
+        slow_critic_regularization: float = 0.0,
     ):
         super().__init__()
-        self.value_model = value_model
+        if slow_critic_regularization < 0:
+            raise ValueError("slow_critic_regularization must be non-negative.")
+        self.slow_critic_regularization = slow_critic_regularization
+        self.convert_to_functional(
+            value_model,
+            "value_model",
+            create_target_params=bool(slow_critic_regularization),
+        )
         self.value_loss = value_loss
         self.gamma = gamma
         self.discount_loss = discount_loss
@@ -853,7 +870,10 @@ class DreamerV3ValueLoss(LossModule):
         lambda_target = fake_data.get("lambda_target")
 
         tensordict_select = fake_data.select(*self.value_model.in_keys, strict=False)
-        self.value_model(tensordict_select)
+        with self.value_model_params.to_module(
+            self.value_model, preserve_module_state=False
+        ):
+            self.value_model(tensordict_select)
         # lambda_target shape: [N, 1] (flat) or [B, T, 1] (batch x time)
         # Squeeze the trailing 1 for loss computation
         target_sq = lambda_target.squeeze(-1)  # [N] or [B, T]
@@ -890,8 +910,40 @@ class DreamerV3ValueLoss(LossModule):
             value_pred = tensordict_select.get(self.tensor_keys.value)
             loss = (symlog(value_pred.squeeze(-1)) - symlog(target_sq)).pow(2)
 
+        if self.slow_critic_regularization:
+            target_tensordict = fake_data.select(
+                *self.value_model.in_keys, strict=False
+            )
+            with torch.no_grad(), self.target_value_model_params.to_module(
+                self.value_model, preserve_module_state=False
+            ):
+                self.value_model(target_tensordict)
+            target_value = target_tensordict.get(self.tensor_keys.value)
+            if self.value_loss == "two_hot" and (
+                target_value.shape[-1] == self.value_bins.shape[0]
+            ):
+                target_value = two_hot_decode(target_value, self.value_bins).unsqueeze(
+                    -1
+                )
+            if self.value_loss == "two_hot":
+                slow_loss = two_hot_cross_entropy(
+                    value_pred, target_value.squeeze(-1), self.value_bins
+                )
+            else:
+                slow_loss = (
+                    symlog(value_pred.squeeze(-1)) - symlog(target_value.squeeze(-1))
+                ).pow(2)
+            loss = loss + self.slow_critic_regularization * slow_loss
+        else:
+            slow_loss = torch.zeros_like(loss)
+
         value_loss = (discount * loss).mean()
 
-        loss_tensordict = TensorDict({"loss_value": value_loss})
+        loss_tensordict = TensorDict(
+            {
+                "loss_value": value_loss,
+                "value_slow_loss": (discount * slow_loss).mean().detach(),
+            }
+        )
         self._clear_weakrefs(fake_data, loss_tensordict)
         return loss_tensordict, fake_data.data


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #4095
* #4075
* #4074
* #4073
* #4072
* __->__ #4068
* #4067
* #4066
* #4065

Summary:
- add functional online and checkpointed target critic parameters to DreamerV3ValueLoss
- regularize categorical online logits toward decoded target-critic predictions
- keep actor lambda-return bootstrapping attached to the online critic
- update the target with SoftUpdate(tau=0.02) after each maintained-example critic step
- add eager and torch.compile DreamerV3 objective benchmarks

Rationale:
A slowly moving critic supplies stable auxiliary targets without changing the online critic used for imagined lambda returns. Functional target parameters isolate gradients, participate in state-dict checkpoints, and integrate with TorchRL target updaters.

Test plan:
- uv run pytest -q test/objectives/test_dreamer_v3.py
- run the maintained DreamerV3 SOTA smoke with 11-bin CI overrides
- smoke the DreamerV3 value benchmark in CPU eager and torch.compile modes
- verify decoded target supervision, online gradients, absent target gradients, exact tau=0.02 movement, online actor ownership, and target state-dict restoration
- flake8 --config=setup.cfg on the changed Python files
- ufmt check on the changed Python files
- git diff --check