### PR TITLE
[CI] Repair main test environment compatibility

### DIFF
--- a/.github/unittest/linux_libs/scripts_chess/setup_env.sh
+++ b/.github/unittest/linux_libs/scripts_chess/setup_env.sh
@@ -62,8 +62,6 @@ printf "* Installing dependencies (except PyTorch)\n"
 echo "  - python=${PYTHON_VERSION}" >> "${this_dir}/environment.yml"
 cat "${this_dir}/environment.yml"
 
-pip install pip --upgrade
-
 conda install anaconda::cmake -y
 conda install conda-forge::cairo -y
 

--- a/.github/unittest/linux_libs/scripts_gym/run_all.sh
+++ b/.github/unittest/linux_libs/scripts_gym/run_all.sh
@@ -16,7 +16,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update && apt-get install -y --no-install-recommends git wget gcc g++ curl software-properties-common
 apt-get install -y --no-install-recommends libglfw3 libgl1-mesa-glx libosmesa6 libosmesa6-dev libglew-dev libsdl2-dev libsdl2-2.0-0
 apt-get install -y --no-install-recommends libglvnd0 libgl1 libglx0 libegl1 libgles2 xvfb libegl-dev libx11-dev freeglut3-dev
-apt-get install -y --no-install-recommends librhash0 x11proto-dev cmake
+apt-get install -y --no-install-recommends librhash0 x11proto-dev cmake unar
 
 # Install Python 3.10 (Ubuntu 22.04 has Python 3.10 as default)
 apt-get install -y --no-install-recommends python3 python3-dev python3-venv python3-pip
@@ -142,14 +142,28 @@ uv pip install \
 
 # 11. Setup Atari ROMs
 printf "* Setting up Atari ROMs\n"
-if [ ! -d "Roms" ]; then
-    wget https://www.rarlab.com/rar/rarlinux-x64-5.7.1.tar.gz --no-check-certificate
-    tar -xzvf rarlinux-x64-5.7.1.tar.gz
+if ! find Roms -type f -iname '*pong*' -print -quit 2>/dev/null | grep -q .; then
     mkdir -p Roms
-    wget http://www.atarimania.com/roms/Roms.rar
-    ./rar/unrar e Roms.rar ./Roms -y
+    if ! wget --tries=5 --retry-connrefused --waitretry=5 \
+        -O Roms.rar http://www.atarimania.com/roms/Roms.rar; then
+        printf "Failed to download Atari ROM archive\n" >&2
+        exit 1
+    fi
+    if ! unar -f -o Roms Roms.rar; then
+        printf "Failed to extract Atari ROM archive\n" >&2
+        exit 1
+    fi
 fi
-python -m atari_py.import_roms Roms
+if ! python -m atari_py.import_roms Roms; then
+    printf "Failed to import Atari ROMs\n" >&2
+    exit 1
+fi
+python - <<'PY'
+import atari_py
+
+if "pong" not in {game.lower() for game in atari_py.list_games()}:
+    raise RuntimeError("Pong ROM was not imported")
+PY
 
 # 12. Set environment variables
 export MUJOCO_GL=egl

--- a/.github/unittest/linux_sota/scripts/environment.yml
+++ b/.github/unittest/linux_sota/scripts/environment.yml
@@ -21,7 +21,7 @@ dependencies:
     - pyyaml
     - scipy
     - psutil
-    - hydra-core<1.4
+    - hydra-core>=1.3,<1.4
     - imageio==2.26.0
     - dm_control
     - mujoco<3.3.6

--- a/.github/unittest/linux_sota/scripts/run_all.sh
+++ b/.github/unittest/linux_sota/scripts/run_all.sh
@@ -86,7 +86,7 @@ uv pip install \
   pyyaml \
   scipy \
   psutil \
-  "hydra-core<1.4" \
+  "hydra-core>=1.3,<1.4" \
   "imageio==2.26.0" \
   dm_control \
   "mujoco<3.3.6" \

--- a/.github/unittest/llm/scripts_sglang/install.sh
+++ b/.github/unittest/llm/scripts_sglang/install.sh
@@ -115,7 +115,7 @@ uv pip install --reinstall --index-url https://pypi.org/simple "torchvision===0.
 # Keep secondary dependencies inside the ranges required by the latest SGLang
 # dependency set so uv pip check catches real breakage instead of resolver drift.
 printf "* Constraining secondary dependencies for SGLang\n"
-uv pip install "pillow>=9.2,<12" "numpy>=1.25,<2.4" "fsspec[http]<=2026.2.0"
+uv pip install "cuda-bindings~=13.3.1" "pillow>=9.2,<12" "numpy>=1.25,<2.4" "fsspec[http]<=2026.2.0"
 
 # Install MCP dependencies for tool execution tests
 printf "* Installing MCP dependencies (uvx, Deno)\n"

--- a/.github/unittest/windows_optdepts/scripts/unittest.sh
+++ b/.github/unittest/windows_optdepts/scripts/unittest.sh
@@ -148,6 +148,8 @@ export CKPT_BACKEND=torch
 export MAX_IDLE_COUNT=60
 export BATCHED_PIPE_TIMEOUT=60
 export LAZY_LEGACY_OP=False
+# PyTorch's Windows nightly wheel is built without libuv support.
+export USE_LIBUV=0
 
 echo "=== Collecting environment info ==="
 python -m torch.utils.collect_env

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -29,7 +29,7 @@ onnxscript
 onnxruntime
 onnx
 psutil
-hydra-core>=1.1
+hydra-core>=1.3,<1.4
 omegaconf
 hydra-submitit-launcher
 transformers

--- a/examples/rlhf/config/train.yaml
+++ b/examples/rlhf/config/train.yaml
@@ -28,3 +28,7 @@ sys:
   device: cuda  # examples: cpu, cuda, cuda:0, cuda:1 etc., or try mps on macbooks
   dtype: bfloat16  # float32, bfloat16, or float16, the latter will auto implement a GradScaler
   compile: True  # use PyTorch 2.0 to compile the model to be faster
+
+hydra:
+  job:
+    chdir: true

--- a/examples/rlhf/config/train_reward.yaml
+++ b/examples/rlhf/config/train_reward.yaml
@@ -30,3 +30,7 @@ sys:
   device: cuda # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1' etc., or try 'mps' on macbooks
   dtype: bfloat16 # 'float32', 'bfloat16', or 'float16', the latter will auto implement a GradScaler
   compile: True # use PyTorch 2.0 to compile the model to be faster
+
+hydra:
+  job:
+    chdir: true

--- a/examples/rlhf/config/train_rlhf.yaml
+++ b/examples/rlhf/config/train_rlhf.yaml
@@ -39,3 +39,7 @@ sys:
   ref_device: cuda:1  # device of reference model
   dtype: bfloat16 # 'float32', 'bfloat16', or 'float16', the latter will auto implement a GradScaler
   compile: False # use PyTorch 2.0 to compile the model to be faster
+
+hydra:
+  job:
+    chdir: true

--- a/examples/rlhf/requirements.txt
+++ b/examples/rlhf/requirements.txt
@@ -1,5 +1,5 @@
 datasets
-hydra-core
+hydra-core>=1.3,<1.4
 matplotlib
 numpy
 PyYAML

--- a/examples/rlhf/train.py
+++ b/examples/rlhf/train.py
@@ -41,7 +41,7 @@ def create_loss_estimator(eval_iters, ctx):
     return estimate_loss
 
 
-@hydra.main(version_base="1.1", config_path="config", config_name="train")
+@hydra.main(version_base="1.3", config_path="config", config_name="train")
 def main(cfg):
     loss_logger = get_file_logger("loss_logger", "transformer_loss_logger.log")
 

--- a/examples/rlhf/train_reward.py
+++ b/examples/rlhf/train_reward.py
@@ -45,7 +45,7 @@ def create_loss_estimator(eval_iters, ctx):
     return estimate_loss
 
 
-@hydra.main(version_base="1.1", config_path="config", config_name="train_reward")
+@hydra.main(version_base="1.3", config_path="config", config_name="train_reward")
 def main(cfg):
     loss_logger = get_file_logger("loss_logger", "reward_loss_logger.log")
 

--- a/examples/rlhf/train_rlhf.py
+++ b/examples/rlhf/train_rlhf.py
@@ -29,7 +29,7 @@ from utils import (
 )
 
 
-@hydra.main(version_base="1.1", config_path="config", config_name="train_rlhf")
+@hydra.main(version_base="1.3", config_path="config", config_name="train_rlhf")
 def main(cfg):
 
     # ============ Retrieve config ============ #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 dev = [
     "gym",
     "gymnasium",
-    "hydra-core>=1.1",
+    "hydra-core>=1.3,<1.4",
     "hydra-submitit-launcher",
     "imageio",
     "moviepy",
@@ -121,7 +121,7 @@ utils = [
     "tensorboard",
     "wandb",
     "tqdm",
-    "hydra-core>=1.1",
+    "hydra-core>=1.3,<1.4",
     "hydra-submitit-launcher",
     "pre-commit",
     "autoflake",

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@ from pathlib import Path
 import torch
 from setuptools import setup
 from torch.utils.cpp_extension import (
-    CUDA_HOME,
     BuildExtension,
     CppExtension,
+    CUDA_HOME,
     CUDAExtension,
 )
 

--- a/setup.py
+++ b/setup.py
@@ -3,20 +3,23 @@ from __future__ import annotations
 import contextlib
 import glob
 import importlib.util
+import inspect
 import json
 import logging
 import os
 import re
+import shlex
 import subprocess
 import sys
+import sysconfig
 from pathlib import Path
 
 import torch
 from setuptools import setup
 from torch.utils.cpp_extension import (
+    CUDA_HOME,
     BuildExtension,
     CppExtension,
-    CUDA_HOME,
     CUDAExtension,
 )
 
@@ -96,6 +99,47 @@ def _get_build_cuda_version() -> str | None:
     if not _should_build_cuda():
         return None
     return _get_nvcc_cuda_version() or getattr(torch.version, "cuda", None)
+
+
+def _get_cxx20_compatibility_flag() -> str | None:
+    """Return the provisional C++20 spelling for older Unix compilers."""
+    if sys.platform == "win32" or not _torch_extension_requires_cxx20():
+        return None
+
+    compiler = os.getenv("CXX") or sysconfig.get_config_var("CXX") or "c++"
+    compiler_command = shlex.split(compiler)
+    source = "int main() { return 0; }\n"
+
+    def accepts(flag: str) -> bool:
+        try:
+            result = subprocess.run(
+                [*compiler_command, flag, "-x", "c++", "-fsyntax-only", "-"],
+                input=source,
+                text=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+        except OSError:
+            return False
+        return result.returncode == 0
+
+    if accepts("-std=c++20"):
+        return None
+    if accepts("-std=c++2a"):
+        return "-std=c++2a"
+    return None
+
+
+def _torch_extension_requires_cxx20() -> bool:
+    """Detect the language standard selected by the installed BuildExtension."""
+    try:
+        source = inspect.getsource(BuildExtension.build_extensions)
+    except (OSError, TypeError):
+        source = ""
+    if re.search(r"cpp_flag\s*=.*['\"]c\+\+20['\"]", source):
+        return True
+    return "-std=c++20" in torch.__config__.show()
 
 
 def _check_and_clean_stale_builds():
@@ -230,9 +274,14 @@ def get_extensions():
             extra_link_args = ["/DEBUG"]
     else:
         # GCC/Clang flags for Unix-like systems
+        cxx20_compatibility_flag = _get_cxx20_compatibility_flag()
+        cxx_standard_args = (
+            [cxx20_compatibility_flag] if cxx20_compatibility_flag is not None else []
+        )
         extra_compile_args = {
             "cxx": [
                 "-O3",
+                *cxx_standard_args,
                 "-fdiagnostics-color=always",
             ]
         }
@@ -250,6 +299,7 @@ def get_extensions():
                     "-O0",
                     "-fno-inline",
                     "-g",
+                    *cxx_standard_args,
                     "-fdiagnostics-color=always",
                 ]
             }

--- a/setup.py
+++ b/setup.py
@@ -184,9 +184,9 @@ def get_extensions():
     """Build C++ extensions with platform-specific compiler flags.
 
     This function configures the C++ extension build process with appropriate
-    compiler flags for different platforms:
-    - Windows (MSVC): Uses /O2, /std:c++20, /EHsc flags
-    - Unix-like (GCC/Clang): Uses -O3, -std=c++20, -fdiagnostics-color=always flags
+    compiler flags for different platforms. The C++ language standard is left
+    to PyTorch's BuildExtension, which selects the standard required by the
+    installed PyTorch release for both the host compiler and nvcc.
 
     Returns:
         list: List of CppExtension objects to be built
@@ -201,7 +201,6 @@ def get_extensions():
         extra_compile_args = {
             "cxx": [
                 "/O2",  # Optimization level 2 (equivalent to -O3)
-                "/std:c++20",  # C++20 standard
                 "/EHsc",  # Exception handling model
             ]
         }
@@ -218,7 +217,6 @@ def get_extensions():
                 "cxx": [
                     "/Od",  # No optimization (equivalent to -O0)
                     "/Zi",  # Generate debug info
-                    "/std:c++20",  # C++20 standard
                     "/EHsc",  # Exception handling model
                 ]
             }
@@ -235,7 +233,6 @@ def get_extensions():
         extra_compile_args = {
             "cxx": [
                 "-O3",
-                "-std=c++20",
                 "-fdiagnostics-color=always",
             ]
         }
@@ -243,7 +240,6 @@ def get_extensions():
             extra_compile_args["cxx"].append("-DWITH_CUDA")
             extra_compile_args["nvcc"] = [
                 "-O3",
-                "-std=c++20",
                 "-DWITH_CUDA",
             ]
         debug_mode = os.getenv("DEBUG", "0") == "1"
@@ -254,7 +250,6 @@ def get_extensions():
                     "-O0",
                     "-fno-inline",
                     "-g",
-                    "-std=c++20",
                     "-fdiagnostics-color=always",
                 ]
             }
@@ -263,7 +258,6 @@ def get_extensions():
                 extra_compile_args["nvcc"] = [
                     "-O0",
                     "-G",
-                    "-std=c++20",
                     "-DWITH_CUDA",
                 ]
             extra_link_args = ["-O0", "-g"]

--- a/sota-check/README.md
+++ b/sota-check/README.md
@@ -26,7 +26,7 @@ export MUJOCO_GL=egl
 conda create -n rl-sota-bench python=3.10 -y 
 conda install anaconda::libglu -y
 pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu121
-pip3 install "gymnasium[atari,mujoco]" vmas tqdm wandb pygame "moviepy<2.0.0" imageio submitit hydra-core transformers
+pip3 install "gymnasium[atari,mujoco]" vmas tqdm wandb pygame "moviepy<2.0.0" imageio submitit "hydra-core>=1.3,<1.4" transformers
 
 cd /path/to/tensordict
 python setup.py develop

--- a/sota-implementations/README.md
+++ b/sota-implementations/README.md
@@ -18,7 +18,7 @@ We provide examples to train the following algorithms:
 
 To run these examples, make sure you have installed hydra:
 ```
-pip install hydra-core
+pip install --upgrade "hydra-core>=1.3,<1.4"
 ```
 
 Scripts can be run from the directory of interest using:

--- a/sota-implementations/a2c/a2c_atari.py
+++ b/sota-implementations/a2c/a2c_atari.py
@@ -12,7 +12,7 @@ import torch
 torch.set_float32_matmul_precision("high")
 
 
-@hydra.main(config_path="", config_name="config_atari", version_base="1.1")
+@hydra.main(config_path="", config_name="config_atari", version_base="1.3")
 def main(cfg: DictConfig):  # noqa: F821
 
     from copy import deepcopy

--- a/sota-implementations/a2c/a2c_mujoco.py
+++ b/sota-implementations/a2c/a2c_mujoco.py
@@ -12,7 +12,7 @@ import torch
 torch.set_float32_matmul_precision("high")
 
 
-@hydra.main(config_path="", config_name="config_mujoco", version_base="1.1")
+@hydra.main(config_path="", config_name="config_mujoco", version_base="1.3")
 def main(cfg: DictConfig):  # noqa: F821
 
     from copy import deepcopy

--- a/sota-implementations/a2c/config_atari.yaml
+++ b/sota-implementations/a2c/config_atari.yaml
@@ -41,3 +41,7 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/a2c/config_mujoco.yaml
+++ b/sota-implementations/a2c/config_mujoco.yaml
@@ -37,3 +37,7 @@ compile:
   compile: False
   compile_mode: default
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/a2c_trainer/config/config.yaml
+++ b/sota-implementations/a2c_trainer/config/config.yaml
@@ -137,3 +137,7 @@ trainer:
   optim_steps_per_batch: null
   num_epochs: 1
   async_collection: false
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/a2c_trainer/train.py
+++ b/sota-implementations/a2c_trainer/train.py
@@ -7,7 +7,7 @@ import torchrl
 from torchrl.trainers.algorithms.configs import A2CTrainerConfig  # noqa: F401
 
 
-@hydra.main(config_path="config", config_name="config", version_base="1.1")
+@hydra.main(config_path="config", config_name="config", version_base="1.3")
 def main(cfg):
     def print_reward(td):
         torchrl.logger.info(f"reward: {td['next', 'reward'].mean(): 4.4f}")

--- a/sota-implementations/cql/cql_offline.py
+++ b/sota-implementations/cql/cql_offline.py
@@ -35,7 +35,7 @@ from utils import (
 torch.set_float32_matmul_precision("high")
 
 
-@hydra.main(config_path="", config_name="offline_config", version_base="1.1")
+@hydra.main(config_path="", config_name="offline_config", version_base="1.3")
 def main(cfg: DictConfig):  # noqa: F821
     # Create logger
     exp_name = generate_exp_name("CQL-offline", cfg.logger.exp_name)

--- a/sota-implementations/cql/cql_online.py
+++ b/sota-implementations/cql/cql_online.py
@@ -39,7 +39,7 @@ from utils import (
 torch.set_float32_matmul_precision("high")
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="online_config")
+@hydra.main(version_base="1.3", config_path="", config_name="online_config")
 def main(cfg: DictConfig):  # noqa: F821
     # Create logger
     exp_name = generate_exp_name("CQL-online", cfg.logger.exp_name)

--- a/sota-implementations/cql/discrete_cql_offline.py
+++ b/sota-implementations/cql/discrete_cql_offline.py
@@ -34,7 +34,7 @@ from utils import (
 torch.set_float32_matmul_precision("high")
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="discrete_offline_config")
+@hydra.main(version_base="1.3", config_path="", config_name="discrete_offline_config")
 def main(cfg):  # noqa: F821
     device = (
         torch.device(cfg.optim.device) if cfg.optim.device else get_available_device()

--- a/sota-implementations/cql/discrete_cql_online.py
+++ b/sota-implementations/cql/discrete_cql_online.py
@@ -36,7 +36,7 @@ from utils import (
 torch.set_float32_matmul_precision("high")
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="discrete_online_config")
+@hydra.main(version_base="1.3", config_path="", config_name="discrete_online_config")
 def main(cfg: DictConfig):  # noqa: F821
     device = (
         torch.device(cfg.optim.device) if cfg.optim.device else get_available_device()

--- a/sota-implementations/cql/discrete_offline_config.yaml
+++ b/sota-implementations/cql/discrete_offline_config.yaml
@@ -64,3 +64,7 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/cql/discrete_online_config.yaml
+++ b/sota-implementations/cql/discrete_online_config.yaml
@@ -62,3 +62,7 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/cql/offline_config.yaml
+++ b/sota-implementations/cql/offline_config.yaml
@@ -59,3 +59,7 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/cql/online_config.yaml
+++ b/sota-implementations/cql/online_config.yaml
@@ -71,3 +71,7 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/cql_trainer/config/config.yaml
+++ b/sota-implementations/cql_trainer/config/config.yaml
@@ -144,3 +144,7 @@ trainer:
   save_trainer_file: null
   optim_steps_per_batch: 64
   async_collection: false
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/cql_trainer/train.py
+++ b/sota-implementations/cql_trainer/train.py
@@ -6,7 +6,7 @@ import hydra
 from torchrl.trainers.algorithms.configs import *  # noqa: F401, F403
 
 
-@hydra.main(config_path="config", config_name="config", version_base="1.1")
+@hydra.main(config_path="config", config_name="config", version_base="1.3")
 def main(cfg):
     trainer = hydra.utils.instantiate(cfg.trainer)
     trainer.train()

--- a/sota-implementations/crossq/config.yaml
+++ b/sota-implementations/crossq/config.yaml
@@ -61,3 +61,7 @@ logger:
   exp_name: ${env.name}_CrossQ
   mode: online
   eval_iter: 25000
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/crossq/crossq.py
+++ b/sota-implementations/crossq/crossq.py
@@ -38,7 +38,7 @@ from utils import (
 torch.set_float32_matmul_precision("high")
 
 
-@hydra.main(version_base="1.1", config_path=".", config_name="config")
+@hydra.main(version_base="1.3", config_path=".", config_name="config")
 def main(cfg: DictConfig):  # noqa: F821
     device = (
         torch.device(cfg.network.device)

--- a/sota-implementations/ddpg/config.yaml
+++ b/sota-implementations/ddpg/config.yaml
@@ -55,3 +55,7 @@ logger:
   eval_iter: 25000
   video: False
   num_eval_envs: 1
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/ddpg/ddpg.py
+++ b/sota-implementations/ddpg/ddpg.py
@@ -37,7 +37,7 @@ from utils import (
 )
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="config")
+@hydra.main(version_base="1.3", config_path="", config_name="config")
 def main(cfg: DictConfig):  # noqa: F821
     device = (
         torch.device(cfg.optim.device) if cfg.optim.device else get_available_device()

--- a/sota-implementations/ddpg_trainer/config/config.yaml
+++ b/sota-implementations/ddpg_trainer/config/config.yaml
@@ -147,3 +147,7 @@ trainer:
   save_trainer_file: null
   optim_steps_per_batch: 64
   async_collection: false
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/ddpg_trainer/train.py
+++ b/sota-implementations/ddpg_trainer/train.py
@@ -6,7 +6,7 @@ import hydra
 from torchrl.trainers.algorithms.configs import *  # noqa: F401, F403
 
 
-@hydra.main(config_path="config", config_name="config", version_base="1.1")
+@hydra.main(config_path="config", config_name="config", version_base="1.3")
 def main(cfg):
     trainer = hydra.utils.instantiate(cfg.trainer)
     trainer.train()

--- a/sota-implementations/decision_transformer/dt.py
+++ b/sota-implementations/decision_transformer/dt.py
@@ -34,7 +34,7 @@ from utils import (
 )
 
 
-@hydra.main(config_path="", config_name="dt_config", version_base="1.1")
+@hydra.main(config_path="", config_name="dt_config", version_base="1.3")
 def main(cfg: DictConfig):  # noqa: F821
     set_gym_backend(cfg.env.backend).set()
 

--- a/sota-implementations/decision_transformer/dt_config.yaml
+++ b/sota-implementations/decision_transformer/dt_config.yaml
@@ -71,3 +71,7 @@ transformer:
   n_positions: 1024
   resid_pdrop: 0.1
   attn_pdrop: 0.1
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/decision_transformer/odt_config.yaml
+++ b/sota-implementations/decision_transformer/odt_config.yaml
@@ -72,3 +72,7 @@ transformer:
   n_positions: 1024
   resid_pdrop: 0.1
   attn_pdrop: 0.1
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/decision_transformer/online_dt.py
+++ b/sota-implementations/decision_transformer/online_dt.py
@@ -32,7 +32,7 @@ from utils import (
 )
 
 
-@hydra.main(config_path="", config_name="odt_config", version_base="1.1")
+@hydra.main(config_path="", config_name="odt_config", version_base="1.3")
 def main(cfg: DictConfig):  # noqa: F821
     set_gym_backend(cfg.env.backend).set()
 

--- a/sota-implementations/diffusion_bc/config.yaml
+++ b/sota-implementations/diffusion_bc/config.yaml
@@ -45,3 +45,7 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/diffusion_bc/diffusion_bc.py
+++ b/sota-implementations/diffusion_bc/diffusion_bc.py
@@ -38,7 +38,7 @@ from utils import (
 )
 
 
-@hydra.main(config_path="", config_name="config", version_base="1.1")
+@hydra.main(config_path="", config_name="config", version_base="1.3")
 def main(cfg: DictConfig):  # noqa: F821
     set_gym_backend(cfg.env.library).set()
 

--- a/sota-implementations/discrete_sac/config.yaml
+++ b/sota-implementations/discrete_sac/config.yaml
@@ -58,3 +58,7 @@ logger:
   mode: online
   eval_iter: 5000
   video: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/discrete_sac/discrete_sac.py
+++ b/sota-implementations/discrete_sac/discrete_sac.py
@@ -37,7 +37,7 @@ from utils import (
 )
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="config")
+@hydra.main(version_base="1.3", config_path="", config_name="config")
 def main(cfg: DictConfig):  # noqa: F821
     device = cfg.network.device
     if device in ("", None):

--- a/sota-implementations/dqn/config_atari.yaml
+++ b/sota-implementations/dqn/config_atari.yaml
@@ -45,3 +45,7 @@ compile:
   compile: False
   compile_mode: default
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/dqn/config_cartpole.yaml
+++ b/sota-implementations/dqn/config_cartpole.yaml
@@ -52,3 +52,7 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/dqn/dqn_atari.py
+++ b/sota-implementations/dqn/dqn_atari.py
@@ -30,7 +30,7 @@ from utils_atari import eval_model, make_dqn_model, make_env
 torch.set_float32_matmul_precision("high")
 
 
-@hydra.main(config_path="", config_name="config_atari", version_base="1.1")
+@hydra.main(config_path="", config_name="config_atari", version_base="1.3")
 def main(cfg: DictConfig):  # noqa: F821
 
     device = torch.device(cfg.device) if cfg.device else get_available_device()

--- a/sota-implementations/dqn/dqn_cartpole.py
+++ b/sota-implementations/dqn/dqn_cartpole.py
@@ -94,7 +94,7 @@ def _resume_checkpoint(
     )
 
 
-@hydra.main(config_path="", config_name="config_cartpole", version_base="1.1")
+@hydra.main(config_path="", config_name="config_cartpole", version_base="1.3")
 def main(cfg: DictConfig):
 
     device = torch.device(cfg.device) if cfg.device else get_available_device()

--- a/sota-implementations/dqn_trainer/config/config.yaml
+++ b/sota-implementations/dqn_trainer/config/config.yaml
@@ -122,3 +122,7 @@ trainer:
   eps_end: 0.05
   annealing_num_steps: 250_000
   async_collection: false
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/dqn_trainer/train.py
+++ b/sota-implementations/dqn_trainer/train.py
@@ -6,7 +6,7 @@ import hydra
 from torchrl.trainers.algorithms.configs import *  # noqa: F401, F403
 
 
-@hydra.main(config_path="config", config_name="config", version_base="1.1")
+@hydra.main(config_path="config", config_name="config", version_base="1.3")
 def main(cfg):
     trainer = hydra.utils.instantiate(cfg.trainer)
     trainer.train()

--- a/sota-implementations/dreamer/README.md
+++ b/sota-implementations/dreamer/README.md
@@ -24,7 +24,7 @@ uv pip install --pre torch torchvision --index-url https://download.pytorch.org/
 uv pip install tensordict torchrl
 
 # Install additional dependencies
-uv pip install mujoco dm_control wandb tqdm hydra-core
+uv pip install mujoco dm_control wandb tqdm "hydra-core>=1.3,<1.4"
 ```
 
 ### System Dependencies (for MuJoCo rendering)

--- a/sota-implementations/dreamer/config.yaml
+++ b/sota-implementations/dreamer/config.yaml
@@ -129,3 +129,7 @@ profiling:
     trace_file: collector_trace_{worker_idx}.json
     # Override init_random_frames when collector profiling is enabled (0 = skip random frames phase)
     init_random_frames_override: 0
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/dreamer/config_isaac.yaml
+++ b/sota-implementations/dreamer/config_isaac.yaml
@@ -84,3 +84,7 @@ logger:
   # Enable async eval with viewport rendering (requires >= 3 GPUs).
   video: True
   video_skip: 1
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/dreamer/dreamer.py
+++ b/sota-implementations/dreamer/dreamer.py
@@ -42,7 +42,7 @@ from torchrl.objectives.dreamer import (
 from torchrl.record.loggers import generate_exp_name, get_logger
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="config")
+@hydra.main(version_base="1.3", config_path="", config_name="config")
 def main(cfg: DictConfig):  # noqa: F821
     # cfg = correct_for_frame_skip(cfg)
 

--- a/sota-implementations/dreamer/dreamer_isaac.py
+++ b/sota-implementations/dreamer/dreamer_isaac.py
@@ -76,7 +76,7 @@ from torchrl.objectives.dreamer import (
 from torchrl.record.loggers import generate_exp_name, get_logger
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="config_isaac")
+@hydra.main(version_base="1.3", config_path="", config_name="config_isaac")
 def main(cfg: DictConfig):
     # ========================================================================
     # Device setup: sim on cuda:0, training on cuda:1 (or cuda:0 if single GPU)

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -39,3 +39,7 @@ logger:
   eval_every: 500
   eval_episodes: 3
   output_plot: dreamer_v3_pendulum.png
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/dreamer_v3/dreamer_v3.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3.py
@@ -269,7 +269,7 @@ def eval_episode_reward(env, actor, num_episodes: int) -> torch.Tensor:
     return torch.stack(totals).mean()
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="config")
+@hydra.main(version_base="1.3", config_path="", config_name="config")
 def main(cfg: DictConfig):
     torch.manual_seed(cfg.env.seed)
 

--- a/sota-implementations/expert-iteration/expert-iteration-async.py
+++ b/sota-implementations/expert-iteration/expert-iteration-async.py
@@ -380,7 +380,7 @@ def train(
     collector.shutdown()
 
 
-@hydra.main(version_base=None, config_path="config", config_name="ei_gsm8k")
+@hydra.main(version_base="1.3", config_path="config", config_name="ei_gsm8k")
 def main(cfg):
     # Force async mode
     if cfg.train.sync:

--- a/sota-implementations/expert-iteration/expert-iteration-sync.py
+++ b/sota-implementations/expert-iteration/expert-iteration-sync.py
@@ -379,7 +379,7 @@ def train(
     collector.shutdown()
 
 
-@hydra.main(version_base=None, config_path="config", config_name="ei_gsm8k")
+@hydra.main(version_base="1.3", config_path="config", config_name="ei_gsm8k")
 def main(cfg):
     # Force sync mode
     if not cfg.train.sync:

--- a/sota-implementations/gail/config.yaml
+++ b/sota-implementations/gail/config.yaml
@@ -49,3 +49,7 @@ compile:
 replay_buffer:
   dataset: halfcheetah-expert-v2
   batch_size: 256
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/gail/gail.py
+++ b/sota-implementations/gail/gail.py
@@ -34,7 +34,7 @@ from torchrl.record.loggers import generate_exp_name, get_logger
 torch.set_float32_matmul_precision("high")
 
 
-@hydra.main(config_path="", config_name="config")
+@hydra.main(config_path="", config_name="config", version_base="1.3")
 def main(cfg: DictConfig):  # noqa: F821
     set_gym_backend(cfg.env.backend).set()
 

--- a/sota-implementations/grpo/grpo-async.py
+++ b/sota-implementations/grpo/grpo-async.py
@@ -366,7 +366,7 @@ def train(
                 shutdown()
 
 
-@hydra.main(version_base=None, config_path="config", config_name="grpo_gsm8k")
+@hydra.main(version_base="1.3", config_path="config", config_name="grpo_gsm8k")
 def main(cfg):
     # Check for required GRPO dependencies
     check_grpo_dependencies(getattr(cfg.inference_model, "backend", "vllm"))

--- a/sota-implementations/grpo/grpo-sync.py
+++ b/sota-implementations/grpo/grpo-sync.py
@@ -326,7 +326,7 @@ def train(
             shutdown()
 
 
-@hydra.main(version_base=None, config_path="config", config_name="grpo_gsm8k")
+@hydra.main(version_base="1.3", config_path="config", config_name="grpo_gsm8k")
 def main(cfg):
     # Check for required GRPO dependencies
     check_grpo_dependencies()

--- a/sota-implementations/grpo/requirements_gsm8k.txt
+++ b/sota-implementations/grpo/requirements_gsm8k.txt
@@ -3,7 +3,7 @@ peft
 bitsandbytes
 datasets
 wandb
-hydra-core
+hydra-core>=1.3,<1.4
 ray
 tqdm
 tensordict

--- a/sota-implementations/grpo/requirements_ifeval.txt
+++ b/sota-implementations/grpo/requirements_ifeval.txt
@@ -5,7 +5,7 @@ peft
 bitsandbytes
 datasets
 wandb
-hydra-core
+hydra-core>=1.3,<1.4
 ray
 tqdm
 tensordict

--- a/sota-implementations/impala/config_multi_node_ray.yaml
+++ b/sota-implementations/impala/config_multi_node_ray.yaml
@@ -66,3 +66,7 @@ loss:
   critic_coeff: 0.5
   entropy_coeff: 0.01
   loss_critic_type: l2
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/impala/config_multi_node_submitit.yaml
+++ b/sota-implementations/impala/config_multi_node_submitit.yaml
@@ -47,3 +47,7 @@ loss:
   critic_coeff: 0.5
   entropy_coeff: 0.01
   loss_critic_type: l2
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/impala/config_single_node.yaml
+++ b/sota-implementations/impala/config_single_node.yaml
@@ -39,3 +39,7 @@ loss:
   critic_coeff: 0.5
   entropy_coeff: 0.01
   loss_critic_type: l2
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/impala/impala_multi_node_ray.py
+++ b/sota-implementations/impala/impala_multi_node_ray.py
@@ -13,7 +13,7 @@ import hydra
 from torchrl._utils import logger as torchrl_logger
 
 
-@hydra.main(config_path="", config_name="config_multi_node_ray", version_base="1.1")
+@hydra.main(config_path="", config_name="config_multi_node_ray", version_base="1.3")
 def main(cfg: DictConfig):  # noqa: F821
 
     import time

--- a/sota-implementations/impala/impala_multi_node_submitit.py
+++ b/sota-implementations/impala/impala_multi_node_submitit.py
@@ -14,7 +14,7 @@ from torchrl._utils import logger as torchrl_logger
 
 
 @hydra.main(
-    config_path="", config_name="config_multi_node_submitit", version_base="1.1"
+    config_path="", config_name="config_multi_node_submitit", version_base="1.3"
 )
 def main(cfg: DictConfig):  # noqa: F821
 

--- a/sota-implementations/impala/impala_single_node.py
+++ b/sota-implementations/impala/impala_single_node.py
@@ -13,7 +13,7 @@ import hydra
 from torchrl._utils import logger as torchrl_logger
 
 
-@hydra.main(config_path="", config_name="config_single_node", version_base="1.1")
+@hydra.main(config_path="", config_name="config_single_node", version_base="1.3")
 def main(cfg: DictConfig):  # noqa: F821
 
     import time

--- a/sota-implementations/iql/discrete_iql.py
+++ b/sota-implementations/iql/discrete_iql.py
@@ -40,7 +40,7 @@ from utils import (
 torch.set_float32_matmul_precision("high")
 
 
-@hydra.main(config_path="", config_name="discrete_iql")
+@hydra.main(config_path="", config_name="discrete_iql", version_base="1.3")
 def main(cfg: DictConfig):  # noqa: F821
     set_gym_backend(cfg.env.backend).set()
 

--- a/sota-implementations/iql/discrete_iql.yaml
+++ b/sota-implementations/iql/discrete_iql.yaml
@@ -64,3 +64,7 @@ compile:
   compile: False
   compile_mode: default
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/iql/iql_offline.py
+++ b/sota-implementations/iql/iql_offline.py
@@ -36,7 +36,7 @@ from utils import (
 torch.set_float32_matmul_precision("high")
 
 
-@hydra.main(config_path="", config_name="offline_config")
+@hydra.main(config_path="", config_name="offline_config", version_base="1.3")
 def main(cfg: DictConfig):  # noqa: F821
     set_gym_backend(cfg.env.backend).set()
 

--- a/sota-implementations/iql/iql_online.py
+++ b/sota-implementations/iql/iql_online.py
@@ -39,7 +39,7 @@ from utils import (
 torch.set_float32_matmul_precision("high")
 
 
-@hydra.main(config_path="", config_name="online_config")
+@hydra.main(config_path="", config_name="online_config", version_base="1.3")
 def main(cfg: DictConfig):  # noqa: F821
     set_gym_backend(cfg.env.backend).set()
 

--- a/sota-implementations/iql/offline_config.yaml
+++ b/sota-implementations/iql/offline_config.yaml
@@ -52,3 +52,7 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/iql/online_config.yaml
+++ b/sota-implementations/iql/online_config.yaml
@@ -66,3 +66,7 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/iql_trainer/config/config.yaml
+++ b/sota-implementations/iql_trainer/config/config.yaml
@@ -150,3 +150,7 @@ trainer:
   save_trainer_file: null
   optim_steps_per_batch: 64
   async_collection: false
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/iql_trainer/train.py
+++ b/sota-implementations/iql_trainer/train.py
@@ -6,7 +6,7 @@ import hydra
 from torchrl.trainers.algorithms.configs import *  # noqa: F401, F403
 
 
-@hydra.main(config_path="config", config_name="config", version_base="1.1")
+@hydra.main(config_path="config", config_name="config", version_base="1.3")
 def main(cfg):
     trainer = hydra.utils.instantiate(cfg.trainer)
     trainer.train()

--- a/sota-implementations/multiagent/README.md
+++ b/sota-implementations/multiagent/README.md
@@ -28,7 +28,7 @@ Install vmas and dependencies:
 ```bash
 pip install vmas
 pip install wandb "moviepy<2.0.0"
-pip install hydra-core
+pip install --upgrade "hydra-core>=1.3,<1.4"
 ```
 
 ### Run

--- a/sota-implementations/multiagent/iql.py
+++ b/sota-implementations/multiagent/iql.py
@@ -29,7 +29,7 @@ def rendering_callback(env, td):
     env.frames.append(env.render(mode="rgb_array", agent_index_focus=None))
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="iql")
+@hydra.main(version_base="1.3", config_path="", config_name="iql")
 def train(cfg: DictConfig):  # noqa: F821
     # Device
     cfg.train.device = "cpu" if not torch.cuda.device_count() else "cuda:0"

--- a/sota-implementations/multiagent/iql.yaml
+++ b/sota-implementations/multiagent/iql.yaml
@@ -38,3 +38,7 @@ logger:
   backend:  wandb # Delete to remove logging
   project_name: null
   group_name: null
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/multiagent/maddpg_iddpg.py
+++ b/sota-implementations/multiagent/maddpg_iddpg.py
@@ -34,7 +34,7 @@ def rendering_callback(env, td):
     env.frames.append(env.render(mode="rgb_array", agent_index_focus=None))
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="maddpg_iddpg")
+@hydra.main(version_base="1.3", config_path="", config_name="maddpg_iddpg")
 def train(cfg: DictConfig):  # noqa: F821
     # Device
     cfg.train.device = "cpu" if not torch.cuda.device_count() else "cuda:0"

--- a/sota-implementations/multiagent/maddpg_iddpg.yaml
+++ b/sota-implementations/multiagent/maddpg_iddpg.yaml
@@ -39,3 +39,7 @@ logger:
   backend:  wandb # Delete to remove logging
   project_name: null
   group_name: null
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/multiagent/mappo_ippo.py
+++ b/sota-implementations/multiagent/mappo_ippo.py
@@ -30,7 +30,7 @@ def rendering_callback(env, td):
     env.frames.append(env.render(mode="rgb_array", agent_index_focus=None))
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="mappo_ippo")
+@hydra.main(version_base="1.3", config_path="", config_name="mappo_ippo")
 def train(cfg: DictConfig):  # noqa: F821
     # Device
     cfg.train.device = "cpu" if not torch.cuda.device_count() else "cuda:0"

--- a/sota-implementations/multiagent/mappo_ippo.yaml
+++ b/sota-implementations/multiagent/mappo_ippo.yaml
@@ -41,3 +41,7 @@ logger:
   backend: wandb # Delete to remove logging
   project_name: null
   group_name: null
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/multiagent/qmix_vdn.py
+++ b/sota-implementations/multiagent/qmix_vdn.py
@@ -29,7 +29,7 @@ def rendering_callback(env, td):
     env.frames.append(env.render(mode="rgb_array", agent_index_focus=None))
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="qmix_vdn")
+@hydra.main(version_base="1.3", config_path="", config_name="qmix_vdn")
 def train(cfg: DictConfig):  # noqa: F821
     # Device
     cfg.train.device = "cpu" if not torch.cuda.device_count() else "cuda:0"

--- a/sota-implementations/multiagent/qmix_vdn.yaml
+++ b/sota-implementations/multiagent/qmix_vdn.yaml
@@ -39,3 +39,7 @@ logger:
   backend: wandb # Delete to remove logging
   project_name: null
   group_name: null
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/multiagent/sac.py
+++ b/sota-implementations/multiagent/sac.py
@@ -31,7 +31,7 @@ def rendering_callback(env, td):
     env.frames.append(env.render(mode="rgb_array", agent_index_focus=None))
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="sac")
+@hydra.main(version_base="1.3", config_path="", config_name="sac")
 def train(cfg: DictConfig):  # noqa: F821
     # Device
     cfg.train.device = "cpu" if not torch.cuda.device_count() else "cuda:0"

--- a/sota-implementations/multiagent/sac.yaml
+++ b/sota-implementations/multiagent/sac.yaml
@@ -41,3 +41,7 @@ logger:
   backend: wandb # Delete to remove logging
   project_name: null
   group_name: null
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/multiagent_trainer/config/maddpg.yaml
+++ b/sota-implementations/multiagent_trainer/config/maddpg.yaml
@@ -193,3 +193,7 @@ trainer:
   action_key: [agents, action]
   observation_key: [agents, observation]
   async_collection: false
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/multiagent_trainer/train.py
+++ b/sota-implementations/multiagent_trainer/train.py
@@ -9,7 +9,7 @@ import hydra
 from torchrl.trainers.algorithms.configs import *  # noqa: F401, F403
 
 
-@hydra.main(config_path="config", config_name="maddpg", version_base="1.1")
+@hydra.main(config_path="config", config_name="maddpg", version_base="1.3")
 def main(cfg):
     trainer = hydra.utils.instantiate(cfg.trainer)
     trainer.train()

--- a/sota-implementations/pilco/config.yaml
+++ b/sota-implementations/pilco/config.yaml
@@ -18,3 +18,7 @@ pilco:
   epochs: 3
   policy_training_steps: 100
   policy_n_basis: 10
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/pilco/pilco.py
+++ b/sota-implementations/pilco/pilco.py
@@ -170,7 +170,7 @@ def pilco_loop(
     return policy_module
 
 
-@hydra.main(config_path="", config_name="config", version_base="1.1")
+@hydra.main(config_path="", config_name="config", version_base="1.3")
 def main(cfg: DictConfig) -> None:
     device = torch.device(cfg.device) if cfg.device else get_available_device()
 

--- a/sota-implementations/ppo-async/config_mujoco.yaml
+++ b/sota-implementations/ppo-async/config_mujoco.yaml
@@ -54,3 +54,7 @@ loss:
   # worker: GAE computed on collector worker (stale critic, synced via SharedMemWeightSyncScheme)
   # learner: TD(0) advantage computed at training time with current critic
   # Only meaningful when collector.async_mode=start. Ignored when iterate.
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/ppo-async/ppo_async_mujoco.py
+++ b/sota-implementations/ppo-async/ppo_async_mujoco.py
@@ -55,7 +55,7 @@ from train import train_iterate, train_start
 from utils_mujoco import make_ppo_models
 
 
-@hydra.main(config_path="", config_name="config_mujoco", version_base="1.1")
+@hydra.main(config_path="", config_name="config_mujoco", version_base="1.3")
 def main(cfg: DictConfig):
 
     torch.set_float32_matmul_precision("high")

--- a/sota-implementations/ppo-async/requirements.txt
+++ b/sota-implementations/ppo-async/requirements.txt
@@ -1,4 +1,4 @@
-hydra-core
+hydra-core>=1.3,<1.4
 tqdm
 wandb
 mujoco-torch @ git+https://github.com/vmoens/mujoco-torch.git@main

--- a/sota-implementations/ppo/config_atari.yaml
+++ b/sota-implementations/ppo/config_atari.yaml
@@ -44,3 +44,7 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/ppo/config_mujoco.yaml
+++ b/sota-implementations/ppo/config_mujoco.yaml
@@ -50,3 +50,7 @@ compile:
 checkpoint:
   path: null
   interval: 0
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/ppo/ppo_atari.py
+++ b/sota-implementations/ppo/ppo_atari.py
@@ -15,7 +15,7 @@ import hydra
 from torchrl._utils import compile_with_warmup, get_available_device
 
 
-@hydra.main(config_path="", config_name="config_atari", version_base="1.1")
+@hydra.main(config_path="", config_name="config_atari", version_base="1.3")
 def main(cfg: DictConfig):  # noqa: F821
 
     import torch.optim

--- a/sota-implementations/ppo/ppo_mujoco.py
+++ b/sota-implementations/ppo/ppo_mujoco.py
@@ -106,7 +106,7 @@ def _make_eval_env_kwargs(cfg: DictConfig) -> dict[str, object]:
     return kwargs
 
 
-@hydra.main(config_path="", config_name="config_mujoco", version_base="1.1")
+@hydra.main(config_path="", config_name="config_mujoco", version_base="1.3")
 def main(cfg: DictConfig):
     device = (
         torch.device(cfg.optim.device) if cfg.optim.device else get_available_device()

--- a/sota-implementations/ppo_trainer/config/config.yaml
+++ b/sota-implementations/ppo_trainer/config/config.yaml
@@ -137,3 +137,7 @@ trainer:
   optim_steps_per_batch: null
   num_epochs: 2
   async_collection: false
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/ppo_trainer/train.py
+++ b/sota-implementations/ppo_trainer/train.py
@@ -7,7 +7,7 @@ import torchrl
 from torchrl.trainers.algorithms.configs import PPOTrainerConfig  # noqa: F401
 
 
-@hydra.main(config_path="config", config_name="config", version_base="1.1")
+@hydra.main(config_path="config", config_name="config", version_base="1.3")
 def main(cfg):
     def print_reward(td):
         torchrl.logger.info(f"reward: {td['next', 'reward'].mean(): 4.4f}")

--- a/sota-implementations/redq/config.yaml
+++ b/sota-implementations/redq/config.yaml
@@ -95,3 +95,7 @@ loss:
   gamma: 0.99
   hard_update: False
   value_network_update_interval: 200
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/redq/redq.py
+++ b/sota-implementations/redq/redq.py
@@ -41,7 +41,7 @@ DEFAULT_REWARD_SCALING = {
 }
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="config")
+@hydra.main(version_base="1.3", config_path="", config_name="config")
 def main(cfg: DictConfig):  # noqa: F821
 
     cfg = correct_for_frame_skip(cfg)

--- a/sota-implementations/reinforce_trainer/config/config.yaml
+++ b/sota-implementations/reinforce_trainer/config/config.yaml
@@ -136,3 +136,7 @@ trainer:
   optim_steps_per_batch: null
   num_epochs: 1
   async_collection: false
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/reinforce_trainer/train.py
+++ b/sota-implementations/reinforce_trainer/train.py
@@ -7,7 +7,7 @@ import torchrl
 from torchrl.trainers.algorithms.configs import ReinforceTrainerConfig  # noqa: F401
 
 
-@hydra.main(config_path="config", config_name="config", version_base="1.1")
+@hydra.main(config_path="config", config_name="config", version_base="1.3")
 def main(cfg):
     def print_reward(td):
         torchrl.logger.info(f"reward: {td['next', 'reward'].mean(): 4.4f}")

--- a/sota-implementations/rnd/config_mujoco.yaml
+++ b/sota-implementations/rnd/config_mujoco.yaml
@@ -47,3 +47,7 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/rnd/rnd_mujoco.py
+++ b/sota-implementations/rnd/rnd_mujoco.py
@@ -41,7 +41,7 @@ from torchrl.record.loggers import generate_exp_name, get_logger
 from utils_mujoco import eval_model, make_env, make_ppo_models, make_rnd_networks
 
 
-@hydra.main(config_path="", config_name="config_mujoco", version_base="1.1")
+@hydra.main(config_path="", config_name="config_mujoco", version_base="1.3")
 def main(cfg: DictConfig):
     torch.set_float32_matmul_precision("high")
 

--- a/sota-implementations/sac/config-async.yaml
+++ b/sota-implementations/sac/config-async.yaml
@@ -57,3 +57,7 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/sac/config.yaml
+++ b/sota-implementations/sac/config.yaml
@@ -56,3 +56,7 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/sac/sac-async.py
+++ b/sota-implementations/sac/sac-async.py
@@ -55,7 +55,7 @@ torch.set_float32_matmul_precision("high")
 tensordict.nn.functional_modules._exclude_td_from_pytree().set()
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="config-async")
+@hydra.main(version_base="1.3", config_path="", config_name="config-async")
 def main(cfg: DictConfig):  # noqa: F821
     device = (
         torch.device(cfg.network.device)

--- a/sota-implementations/sac/sac.py
+++ b/sota-implementations/sac/sac.py
@@ -39,7 +39,7 @@ from utils import (
 torch.set_float32_matmul_precision("high")
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="config")
+@hydra.main(version_base="1.3", config_path="", config_name="config")
 def main(cfg: DictConfig):  # noqa: F821
     device = (
         torch.device(cfg.network.device)

--- a/sota-implementations/sac_trainer/config/config.yaml
+++ b/sota-implementations/sac_trainer/config/config.yaml
@@ -154,3 +154,7 @@ trainer:
   save_trainer_file: null
   optim_steps_per_batch: 64  # Match SOTA utd_ratio
   async_collection: false
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/sac_trainer/train.py
+++ b/sota-implementations/sac_trainer/train.py
@@ -6,7 +6,7 @@ import hydra
 from torchrl.trainers.algorithms.configs import *  # noqa: F401, F403
 
 
-@hydra.main(config_path="config", config_name="config", version_base="1.1")
+@hydra.main(config_path="config", config_name="config", version_base="1.3")
 def main(cfg):
     trainer = hydra.utils.instantiate(cfg.trainer)
     trainer.train()

--- a/sota-implementations/td3/config.yaml
+++ b/sota-implementations/td3/config.yaml
@@ -57,3 +57,7 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/td3/td3.py
+++ b/sota-implementations/td3/td3.py
@@ -37,7 +37,7 @@ from utils import (
 torch.set_float32_matmul_precision("high")
 
 
-@hydra.main(version_base="1.1", config_path="", config_name="config")
+@hydra.main(version_base="1.3", config_path="", config_name="config")
 def main(cfg: DictConfig):  # noqa: F821
     device = (
         torch.device(cfg.network.device)

--- a/sota-implementations/td3_bc/config.yaml
+++ b/sota-implementations/td3_bc/config.yaml
@@ -48,3 +48,7 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/td3_bc/td3_bc.py
+++ b/sota-implementations/td3_bc/td3_bc.py
@@ -34,7 +34,7 @@ from utils import (
 )
 
 
-@hydra.main(config_path="", config_name="config")
+@hydra.main(config_path="", config_name="config", version_base="1.3")
 def main(cfg: DictConfig):  # noqa: F821
     set_gym_backend(cfg.env.library).set()
 

--- a/sota-implementations/td3_trainer/config/config.yaml
+++ b/sota-implementations/td3_trainer/config/config.yaml
@@ -162,3 +162,7 @@ trainer:
   save_trainer_file: null
   async_collection: false
   policy_update_delay: 2
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/td3_trainer/train.py
+++ b/sota-implementations/td3_trainer/train.py
@@ -6,7 +6,7 @@ import hydra
 from torchrl.trainers.algorithms.configs import *  # noqa: F401, F403
 
 
-@hydra.main(config_path="config", config_name="config", version_base="1.1")
+@hydra.main(config_path="config", config_name="config", version_base="1.3")
 def main(cfg):
     trainer = hydra.utils.instantiate(cfg.trainer)
     trainer.train()

--- a/sota-implementations/vla_grpo/config/vla_grpo_toy.yaml
+++ b/sota-implementations/vla_grpo/config/vla_grpo_toy.yaml
@@ -110,3 +110,7 @@ logger:
 checkpoint:
   save_iter: 25 # save every N iterations (0 disables)
   resume: null # path to a checkpoint_latest TensorDict directory to resume from
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/vla_grpo/vla-grpo.py
+++ b/sota-implementations/vla_grpo/vla-grpo.py
@@ -47,7 +47,7 @@ from utils import (
 warnings.filterwarnings("ignore", category=UserWarning, module="tensordict")
 
 
-@hydra.main(config_path="config", config_name="vla_grpo_toy", version_base="1.1")
+@hydra.main(config_path="config", config_name="vla_grpo_toy", version_base="1.3")
 def main(cfg):  # noqa: F821
     torch.manual_seed(cfg.env.seed)
     train_device = auto_device(cfg.policy.device)

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -2372,7 +2372,7 @@ class TestHydraParsing:
         # Register the configs manually for testing
         _register_configs()
         initialize_config_module(
-            "torchrl.trainers.algorithms.configs", version_base="1.1"
+            "torchrl.trainers.algorithms.configs", version_base="1.3"
         )
 
     def _run_hydra_test(
@@ -2387,7 +2387,7 @@ import hydra
 import torchrl
 from torchrl.trainers.algorithms.configs.common import Config
 
-@hydra.main(config_path="config", config_name="config", version_base="1.1")
+@hydra.main(config_path="config", config_name="config", version_base="1.3")
 def main(cfg):
 {test_script_content}
     print("{success_message}")

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -123,7 +123,7 @@ def test_dqn_maker(
     Config = dataclasses.make_dataclass(cls_name="Config", fields=config_fields)
     cs = ConfigStore.instance()
     cs.store(name="config", node=Config)
-    with initialize(version_base="1.1", config_path=None):
+    with initialize(version_base="1.3", config_path=None):
         cfg = compose(config_name="config", overrides=flags)
 
         env_maker = (
@@ -243,7 +243,7 @@ def test_transformed_env_constructor_with_state_dict(from_pixels):
     Config = dataclasses.make_dataclass(cls_name="Config", fields=config_fields)
     cs = ConfigStore.instance()
     cs.store(name="config", node=Config)
-    with initialize(version_base="1.1", config_path=None):
+    with initialize(version_base="1.3", config_path=None):
         cfg = compose(config_name="config", overrides=flags)
         env_maker = (
             ContinuousActionConvMockEnvNumpy

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -68,6 +68,12 @@ def _ray_lib():
     return _ray
 
 
+def _has_nccl_multi_rank_gpu() -> bool:
+    if not torch.cuda.is_available() or not dist.is_nccl_available():
+        return False
+    return tuple(torch.cuda.nccl.version()[:3]) >= (2, 30, 0)
+
+
 # =============================================================================
 # Helpers
 # =============================================================================
@@ -1641,7 +1647,10 @@ class TestRayTransport:
             server.shutdown()
 
     @pytest.mark.gpu
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+    @pytest.mark.skipif(
+        not _has_nccl_multi_rank_gpu(),
+        reason="requires NCCL >= 2.30 for multiple ranks on one GPU",
+    )
     def test_ray_owned_inference_with_nccl_transport(self, monkeypatch):
         # This test runs both NCCL ranks on the single GPU provided by the CI
         # worker. Production deployments should normally assign one GPU per rank.

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -90,14 +90,70 @@ def _expected_dist_version(base_version: str) -> str:
     return f"{base_version}+g{_git(['rev-parse', '--short', 'HEAD'])}"
 
 
-def test_build_extension_owns_cxx_standard():
+def test_build_extension_owns_cxx_standard_or_uses_alias():
     spec = importlib.util.spec_from_file_location("torchrl_setup", _ROOT / "setup.py")
     setup_module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(setup_module)
 
+    compatibility_flag = setup_module._get_cxx20_compatibility_flag()
     for extension in setup_module.get_extensions():
-        for flags in extension.extra_compile_args.values():
-            assert not any("std=" in flag or "std:" in flag for flag in flags)
+        for compiler, flags in extension.extra_compile_args.items():
+            standard_flags = [
+                flag for flag in flags if "std=" in flag or "std:" in flag
+            ]
+            expected = (
+                [compatibility_flag]
+                if compiler == "cxx" and compatibility_flag is not None
+                else []
+            )
+            assert standard_flags == expected
+
+
+def test_detect_torch_extension_cxx20(monkeypatch):
+    spec = importlib.util.spec_from_file_location("torchrl_setup", _ROOT / "setup.py")
+    setup_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(setup_module)
+
+    monkeypatch.setattr(
+        setup_module.inspect,
+        "getsource",
+        lambda _: "cpp_flag = cpp_flag_prefix + 'c++20'",
+    )
+
+    assert setup_module._torch_extension_requires_cxx20()
+
+
+def test_legacy_cxx20_spelling_fallback(monkeypatch):
+    spec = importlib.util.spec_from_file_location("torchrl_setup", _ROOT / "setup.py")
+    setup_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(setup_module)
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0 if "-std=c++2a" in command else 1)
+
+    monkeypatch.setattr(setup_module.subprocess, "run", run)
+    monkeypatch.setattr(setup_module.sys, "platform", "linux")
+    monkeypatch.setattr(setup_module, "_torch_extension_requires_cxx20", lambda: True)
+
+    assert setup_module._get_cxx20_compatibility_flag() == "-std=c++2a"
+    assert [command[-5] for command in calls] == ["-std=c++20", "-std=c++2a"]
+
+
+def test_no_cxx20_fallback_for_older_torch(monkeypatch):
+    spec = importlib.util.spec_from_file_location("torchrl_setup", _ROOT / "setup.py")
+    setup_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(setup_module)
+
+    monkeypatch.setattr(setup_module, "_torch_extension_requires_cxx20", lambda: False)
+
+    def run(*args, **kwargs):
+        raise AssertionError("The compiler should not be probed for a C++17 build")
+
+    monkeypatch.setattr(setup_module.subprocess, "run", run)
+
+    assert setup_module._get_cxx20_compatibility_flag() is None
 
 
 @pytest.mark.parametrize(

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -90,6 +90,16 @@ def _expected_dist_version(base_version: str) -> str:
     return f"{base_version}+g{_git(['rev-parse', '--short', 'HEAD'])}"
 
 
+def test_build_extension_owns_cxx_standard():
+    spec = importlib.util.spec_from_file_location("torchrl_setup", _ROOT / "setup.py")
+    setup_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(setup_module)
+
+    for extension in setup_module.get_extensions():
+        for flags in extension.extra_compile_args.values():
+            assert not any("std=" in flag or "std:" in flag for flag in flags)
+
+
 @pytest.mark.parametrize(
     "editable",
     [

--- a/torchrl/_comm/distributed.py
+++ b/torchrl/_comm/distributed.py
@@ -109,6 +109,13 @@ def _connect_key(prefix: str, client_idx: int) -> str:
     return f"{prefix}/connect/{client_idx}"
 
 
+def _store_flag_is_set(store: dist.Store, key: str) -> bool:
+    # Store.check() was not exposed to Python until torch 2.3. Adding zero is
+    # a nonblocking, cross-version value probe: an absent key is initialized
+    # to 0, while a set flag retains its nonzero value.
+    return bool(store.add(key, 0))
+
+
 def _sorted_leaf_keys(spec: TensorDictBase) -> list[NestedKey]:
     # _is_leaf_nontensor surfaces NonTensorData leaves (excluded by the
     # default leaf iterator) so validation rejects them instead of ignoring
@@ -741,7 +748,7 @@ class TorchDistributedTransport(RequestReplyTransport):
             connecting = [
                 client_idx
                 for client_idx in pending
-                if store.check([_connect_key(self._prefix, client_idx)])
+                if _store_flag_is_set(store, _connect_key(self._prefix, client_idx))
             ]
             for client_idx in connecting:
                 thread = threading.Thread(

--- a/torchrl/trainers/algorithms/configs/utils.py
+++ b/torchrl/trainers/algorithms/configs/utils.py
@@ -228,6 +228,7 @@ class LBFGSConfig(ConfigBase):
     tolerance_change: float = 1e-9
     history_size: int = 100
     line_search_fn: str | None = None
+    maximize: bool = False
     _target_: str = "torch.optim.LBFGS"
     _partial_: bool = True
 


### PR DESCRIPTION
## Summary

- let PyTorch's BuildExtension choose the C++ standard required by each installed torch release, restoring CUDA 11.8 and older compiler builds while keeping nightly C++20 support
- update Hydra test entry points to version base 1.3 and expose the new LBFGS `maximize` option
- repair SGLang's CUDA Python dependency pair, Gym Atari ROM extraction, and the Chess conda/pip setup
- disable libuv for the Windows nightly wheel, which is built without libuv support

This consolidates the current main CI repairs in one PR and supersedes #4056.
The full Hydra migration from that PR is included here with Achintya P credited
as a co-author.

## Root causes

The main failures came from several independent compatibility and CI-environment regressions:

- TorchRL hard-coded C++20 for both host and CUDA compilation, overriding the standards selected by stable/old PyTorch extension builders.
- Hydra 1.3.5 warns on `version_base="1.1"`; `test_configs.py` promotes warnings to errors.
- PyTorch nightly added `maximize` to `LBFGS.__init__`.
- SGLang resolved `cuda-python==13.3.1` with an incompatible prerelease `cuda-bindings`.
- the Gym job downloaded an external rarlab binary that returned HTTP 503.
- upgrading pip before later conda mutations left the Chess environment with mixed pip internals.
- Windows PyTorch nightly requests libuv by default despite being built without it.

## Validation

- targeted config parity and Hydra parsing tests against PyTorch `2.14.0.dev20260807`: 141 passed, 7 skipped, 62 expected xfails
- editable TorchRL extension build against the same PyTorch nightly
- shell syntax checks for all changed CI scripts
- Linux-targeted SGLang dry-run resolution selects matching `cuda-python==13.3.1` and `cuda-bindings==13.3.1`
- pre-commit hooks passed; autoflake was run separately because the system hook executable was unavailable
- prioritized ListStorage population benchmark: approximately 582 operations/second locally, so the earlier 35 operations/second alert was not reproduced

The `ci/olddeps` and `ci/optdeps` labels are required for the affected auxiliary suites.
