### PR TITLE
[BugFix] Match DreamerV3 categorical and KL semantics

### DIFF
--- a/docs/source/reference/objectives_other.rst
+++ b/docs/source/reference/objectives_other.rst
@@ -47,3 +47,4 @@ DreamerV3 Utilities
     two_hot_encode
     two_hot_decode
     two_hot_cross_entropy
+    categorical_kl_terms

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -19,6 +19,7 @@ networks:
   rnn_hidden_dim: 32
   num_categoricals: 4
   num_classes: 4
+  unimix: 0.01
   obs_embed_dim: 32
   num_reward_bins: 255
   num_value_bins: 255
@@ -36,7 +37,8 @@ optimization:
   slow_critic_regularization: 1.0
   slow_critic_tau: 0.02
   free_bits: 1.0
-  kl_alpha: 0.8
+  dynamic_loss_weight: 1.0
+  representation_loss_weight: 0.1
   gamma: 0.99
   lmbda: 0.95
 

--- a/sota-implementations/dreamer_v3/dreamer_v3.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3.py
@@ -100,6 +100,7 @@ def build_world_model(*, cfg: DictConfig, obs_dim: int, action_dim: int):
         num_categoricals=cfg.networks.num_categoricals,
         num_classes=cfg.networks.num_classes,
         action_dim=action_dim,
+        unimix=cfg.networks.unimix,
     )
     rssm_prior = TensorDictModule(
         prior_net,
@@ -117,6 +118,7 @@ def build_world_model(*, cfg: DictConfig, obs_dim: int, action_dim: int):
         num_classes=cfg.networks.num_classes,
         rnn_hidden_dim=cfg.networks.rnn_hidden_dim,
         obs_embed_dim=cfg.networks.obs_embed_dim,
+        unimix=cfg.networks.unimix,
     )
     rssm_posterior = TensorDictModule(
         posterior_net,
@@ -314,7 +316,10 @@ def main(cfg: DictConfig):
         world_model,
         num_reward_bins=cfg.networks.num_reward_bins,
         free_bits=cfg.optimization.free_bits,
-        kl_alpha=cfg.optimization.kl_alpha,
+        kl_mode="separate",
+        lambda_dynamic=cfg.optimization.dynamic_loss_weight,
+        lambda_representation=cfg.optimization.representation_loss_weight,
+        unimix=cfg.networks.unimix,
         global_average=True,  # state-based obs, not (C, H, W) pixels
     )
     model_loss.set_keys(pixels="observation")
@@ -433,10 +438,9 @@ def main(cfg: DictConfig):
             )
 
             m_td, model_out = model_loss(sample)
+            model_kl = m_td["loss_model_dynamic"] + m_td["loss_model_representation"]
             total_m = (
-                m_td["loss_model_kl"]
-                + m_td["loss_model_reco"]
-                + m_td["loss_model_reward"]
+                model_kl + m_td["loss_model_reco"] + m_td["loss_model_reward"]
             ).squeeze()
             opt_model.zero_grad(set_to_none=True)
             total_m.backward()
@@ -475,7 +479,7 @@ def main(cfg: DictConfig):
             opt_value.step()
             value_target_updater.step()
 
-            loss_hist["kl"].append(m_td["loss_model_kl"].detach())
+            loss_hist["kl"].append(model_kl.detach())
             loss_hist["reco"].append(m_td["loss_model_reco"].detach())
             loss_hist["reward"].append(m_td["loss_model_reward"].detach())
             loss_hist["actor"].append(a_td["loss_actor"].detach())

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -46,6 +46,7 @@ from torchrl.objectives.dreamer_v3 import (
     _default_bins,
     _match_trailing_dim,
     categorical_kl_balanced,
+    categorical_kl_terms,
     symexp,
     symlog,
     two_hot_cross_entropy,
@@ -480,6 +481,68 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         kl.backward()
         assert prior_logits.grad.abs().max().item() == pytest.approx(0.0, abs=1e-6)
         assert posterior_logits.grad.abs().max().item() == pytest.approx(0.0, abs=1e-6)
+
+    def test_dreamer_v3_reference_kl_fixture_and_gradients(self, device):
+        posterior_logits = torch.tensor(
+            [[[2.0, -1.0, 0.5], [-0.5, 1.5, 0.0]]],
+            device=device,
+            requires_grad=True,
+        )
+        prior_logits = torch.tensor(
+            [[[0.0, 1.0, -1.0], [1.0, -0.5, 0.5]]],
+            device=device,
+            requires_grad=True,
+        )
+
+        dynamics, representation = categorical_kl_terms(
+            posterior_logits,
+            prior_logits,
+            free_nats=0.0,
+            unimix=0.01,
+        )
+        assert dynamics.item() == pytest.approx(1.9163513, abs=1e-6)
+        assert representation.item() == pytest.approx(1.9163513, abs=1e-6)
+
+        dynamics.backward(retain_graph=True)
+        assert posterior_logits.grad is None
+        assert prior_logits.grad is not None and prior_logits.grad.norm() > 0
+        prior_logits.grad = None
+        representation.backward()
+        assert posterior_logits.grad is not None and posterior_logits.grad.norm() > 0
+        assert prior_logits.grad is None
+
+    def test_dreamer_v3_reference_kl_aggregates_before_free_nats(self, device):
+        logits = torch.randn(3, 4, 8, device=device, requires_grad=True)
+        dynamics, representation = categorical_kl_terms(
+            logits,
+            logits,
+            free_nats=1.0,
+            unimix=0.01,
+        )
+        assert dynamics.item() == pytest.approx(1.0)
+        assert representation.item() == pytest.approx(1.0)
+
+    def test_dreamer_v3_model_loss_reference_kl_keys(self, device):
+        tensordict = self._create_world_model_data().to(device)
+        world_model = self._create_world_model(reward_two_hot=True).to(device)
+        loss_module = DreamerV3ModelLoss(
+            world_model,
+            kl_mode="separate",
+            lambda_dynamic=1.0,
+            lambda_representation=0.1,
+            unimix=0.01,
+            free_bits=0.0,
+            num_reward_bins=self.num_reward_bins,
+        )
+        loss_td, _ = loss_module(tensordict)
+        assert "loss_model_kl" not in loss_td.keys()
+        assert "loss_model_dynamic" in loss_td.keys()
+        assert "loss_model_representation" in loss_td.keys()
+        dynamic = loss_td["loss_model_dynamic"]
+        representation = loss_td["loss_model_representation"]
+        assert dynamic.shape == torch.Size([1])
+        assert representation.shape == torch.Size([1])
+        (dynamic + representation).backward()
 
     def test_dreamer_v3_model_tensor_keys(self, device):
         world_model = self._create_world_model()

--- a/torchrl/modules/models/model_based_v3.py
+++ b/torchrl/modules/models/model_based_v3.py
@@ -241,6 +241,16 @@ def _default_bins(
     return torch.cat((half, -half.flip(0)))
 
 
+def _unimix_probs(logits: torch.Tensor, unimix: float) -> torch.Tensor:
+    """Return categorical probabilities mixed with a uniform distribution."""
+    if not 0 <= unimix < 1:
+        raise ValueError(f"unimix must be in [0, 1), got {unimix}.")
+    probs = torch.softmax(logits, dim=-1)
+    if unimix:
+        probs = (1 - unimix) * probs + unimix / logits.shape[-1]
+    return probs
+
+
 def two_hot_encode(x: torch.Tensor, bins: torch.Tensor) -> torch.Tensor:
     """Encode raw scalar values on a sorted two-hot support.
 
@@ -452,6 +462,8 @@ class RSSMPriorV3(nn.Module):
             block-GRU mode. Defaults to 2.
         norm_eps (float, optional): RMS normalization epsilon. Defaults to
             ``1e-4``.
+        unimix (float, optional): Fraction of uniform probability mixed into
+            categorical samples. Defaults to ``0.0`` for compatibility.
         device (torch.device, optional): Device. Defaults to None.
 
     Examples:
@@ -489,6 +501,7 @@ class RSSMPriorV3(nn.Module):
         num_layers: int = 1,
         prior_num_layers: int = 2,
         norm_eps: float = 1e-4,
+        unimix: float = 0.0,
     ):
         super().__init__()
         if action_spec is not None and action_shape is not None:
@@ -505,6 +518,9 @@ class RSSMPriorV3(nn.Module):
         self.num_categoricals = num_categoricals
         self.num_classes = num_classes
         self.rnn_hidden_dim = rnn_hidden_dim
+        if not 0 <= unimix < 1:
+            raise ValueError(f"unimix must be in [0, 1), got {unimix}.")
+        self.unimix = unimix
         state_dim = num_categoricals * num_classes
 
         if recurrent_model not in ("gru", "block_gru"):
@@ -604,7 +620,7 @@ class RSSMPriorV3(nn.Module):
             *prior_logits_flat.shape[:-1], self.num_categoricals, self.num_classes
         )
 
-        state = _straight_through_categorical(prior_logits)
+        state = _straight_through_categorical(prior_logits, self.unimix)
         state = state.view(*state.shape[:-2], self.num_categoricals * self.num_classes)
 
         return prior_logits, state, belief
@@ -640,6 +656,8 @@ class RSSMPosteriorV3(nn.Module):
             ``use_rms_norm=True``. Defaults to 1.
         norm_eps (float, optional): RMS normalization epsilon. Defaults to
             ``1e-4``.
+        unimix (float, optional): Fraction of uniform probability mixed into
+            categorical samples. Defaults to ``0.0`` for compatibility.
         device (torch.device, optional): Device. Defaults to None.
 
     Examples:
@@ -671,10 +689,14 @@ class RSSMPosteriorV3(nn.Module):
         use_rms_norm: bool = False,
         num_layers: int = 1,
         norm_eps: float = 1e-4,
+        unimix: float = 0.0,
     ):
         super().__init__()
         self.num_categoricals = num_categoricals
         self.num_classes = num_classes
+        if not 0 <= unimix < 1:
+            raise ValueError(f"unimix must be in [0, 1), got {unimix}.")
+        self.unimix = unimix
 
         if use_rms_norm and (rnn_hidden_dim is None or obs_embed_dim is None):
             raise ValueError(
@@ -745,7 +767,7 @@ class RSSMPosteriorV3(nn.Module):
         posterior_logits = post_logits_flat.view(
             *post_logits_flat.shape[:-1], self.num_categoricals, self.num_classes
         )
-        state = _straight_through_categorical(posterior_logits)
+        state = _straight_through_categorical(posterior_logits, self.unimix)
         state = state.view(*state.shape[:-2], self.num_categoricals * self.num_classes)
         return posterior_logits, state
 
@@ -847,7 +869,9 @@ class RSSMRolloutV3(TensorDictModuleBase):
         return torch.stack(tensordict_out, tensordict.ndim - 1)
 
 
-def _straight_through_categorical(logits: torch.Tensor) -> torch.Tensor:
+def _straight_through_categorical(
+    logits: torch.Tensor, unimix: float = 0.0
+) -> torch.Tensor:
     """Sample from categorical with straight-through gradient estimator.
 
     Forward: hard one-hot sample.
@@ -859,8 +883,8 @@ def _straight_through_categorical(logits: torch.Tensor) -> torch.Tensor:
     Returns:
         one_hot tensor with same shape, gradients through softmax.
     """
-    probs = torch.softmax(logits, dim=-1)
-    indices = torch.distributions.Categorical(logits=logits).sample()
+    probs = _unimix_probs(logits, unimix)
+    indices = torch.distributions.Categorical(probs=probs).sample()
     one_hot = torch.zeros_like(probs)
     one_hot.scatter_(-1, indices.unsqueeze(-1), 1.0)
     # Straight-through: forward = one_hot, backward gradient = grad(probs).

--- a/torchrl/objectives/__init__.py
+++ b/torchrl/objectives/__init__.py
@@ -20,6 +20,7 @@ from torchrl.objectives.dreamer import (
 )
 from torchrl.objectives.dreamer_v3 import (
     categorical_kl_balanced,
+    categorical_kl_terms,
     DreamerV3ActorLoss,
     DreamerV3ModelLoss,
     DreamerV3ValueLoss,
@@ -98,6 +99,7 @@ __all__ = [
     "WorldModelLoss",
     "add_random_module",
     "categorical_kl_balanced",
+    "categorical_kl_terms",
     "default_value_kwargs",
     "distance_loss",
     "group_optimizers",

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass
+from typing import Literal
 
 import torch
 from tensordict import TensorDict, TensorDictParams
@@ -31,6 +32,7 @@ from torchrl.envs.utils import ExplorationType, set_exploration_type, step_mdp
 from torchrl.modules.models.model_based_v3 import (
     _default_bins,
     _DEFAULT_NUM_BINS,
+    _unimix_probs,
     symexp as _symexp,
     symlog as symlog,
     two_hot_cross_entropy as two_hot_cross_entropy,
@@ -53,6 +55,54 @@ two_hot_encode = _two_hot_encode
 # ---------------------------------------------------------------------------
 # KL balancing for categorical distributions (DreamerV3 §3)
 # ---------------------------------------------------------------------------
+
+
+def categorical_kl_terms(
+    posterior_logits: torch.Tensor,
+    prior_logits: torch.Tensor,
+    free_nats: float = 1.0,
+    unimix: float = 0.01,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return DreamerV3 dynamics and representation KL losses.
+
+    The dynamics term stops gradients through the posterior and the
+    representation term stops gradients through the prior. KL divergence is
+    summed over the stochastic categoricals before applying the free-nat
+    threshold, matching the aggregated one-hot distribution used by the
+    reference DreamerV3 implementation.
+
+    Args:
+        posterior_logits (torch.Tensor): Posterior logits with shape
+            ``[..., num_categoricals, num_classes]``.
+        prior_logits (torch.Tensor): Prior logits with the same shape.
+        free_nats (float, optional): Minimum aggregated KL in nats. Defaults to
+            ``1.0``.
+        unimix (float, optional): Fraction of uniform probability mixed into
+            each categorical. Defaults to ``0.01``.
+
+    Returns:
+        A pair containing the scalar dynamics and representation KL losses.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.objectives import categorical_kl_terms
+        >>> posterior = torch.randn(2, 4, 8, requires_grad=True)
+        >>> prior = torch.randn(2, 4, 8, requires_grad=True)
+        >>> dynamics, representation = categorical_kl_terms(posterior, prior)
+        >>> dynamics.shape, representation.shape
+        (torch.Size([]), torch.Size([]))
+    """
+    posterior = _unimix_probs(posterior_logits, unimix)
+    prior = _unimix_probs(prior_logits, unimix)
+    posterior_log = posterior.log()
+    prior_log = prior.log()
+
+    dynamics = (posterior.detach() * (posterior_log.detach() - prior_log)).sum((-1, -2))
+    representation = (posterior * (posterior_log - prior_log.detach())).sum((-1, -2))
+    if free_nats:
+        dynamics = dynamics.clamp_min(free_nats)
+        representation = representation.clamp_min(free_nats)
+    return dynamics.mean(), representation.mean()
 
 
 def categorical_kl_balanced(
@@ -162,6 +212,16 @@ class DreamerV3ModelLoss(LossModule):
         lambda_reward (float, optional): Reward prediction loss weight. Default: 1.0.
         lambda_continue (float, optional): Continue prediction loss weight.
             Default: 0.0 (disabled).
+        kl_mode ("balanced" or "separate", optional): KL formulation.
+            ``"balanced"`` preserves the historical weighted aggregate;
+            ``"separate"`` emits the reference dynamics and representation
+            losses. Defaults to ``"balanced"``.
+        lambda_dynamic (float, optional): Dynamics KL weight in separate mode.
+            Defaults to 1.0.
+        lambda_representation (float, optional): Representation KL weight in
+            separate mode. Defaults to 0.1.
+        unimix (float, optional): Uniform mixture used by the categorical KL
+            distributions. Defaults to 0.0 for compatibility.
         kl_alpha (float, optional): KL balancing factor (alpha in the paper).
             Default: 0.8.
         free_bits (float, optional): Minimum KL per categorical in nats.
@@ -269,6 +329,10 @@ class DreamerV3ModelLoss(LossModule):
         lambda_reco: float = 1.0,
         lambda_reward: float = 1.0,
         lambda_continue: float = 0.0,
+        kl_mode: Literal["balanced", "separate"] = "balanced",
+        lambda_dynamic: float = 1.0,
+        lambda_representation: float = 0.1,
+        unimix: float = 0.0,
         kl_alpha: float = 0.8,
         free_bits: float = 1.0,
         reco_loss: str = "l2",
@@ -282,6 +346,14 @@ class DreamerV3ModelLoss(LossModule):
         self.lambda_reco = lambda_reco
         self.lambda_reward = lambda_reward
         self.lambda_continue = lambda_continue
+        if kl_mode not in ("balanced", "separate"):
+            raise ValueError(
+                "kl_mode must be 'balanced' or 'separate', got " f"{kl_mode!r}."
+            )
+        self.kl_mode = kl_mode
+        self.lambda_dynamic = lambda_dynamic
+        self.lambda_representation = lambda_representation
+        self.unimix = unimix
         self.kl_alpha = kl_alpha
         self.free_bits = free_bits
         self.reco_loss = reco_loss
@@ -309,12 +381,22 @@ class DreamerV3ModelLoss(LossModule):
         # ---- KL loss ----
         prior_logits = tensordict.get(("next", self.tensor_keys.prior_logits))
         posterior_logits = tensordict.get(("next", self.tensor_keys.posterior_logits))
-        kl_loss = categorical_kl_balanced(
-            posterior_logits,
-            prior_logits,
-            alpha=self.kl_alpha,
-            free_bits=self.free_bits,
-        ).unsqueeze(-1)
+        if self.kl_mode == "separate":
+            dynamic_loss, representation_loss = categorical_kl_terms(
+                posterior_logits,
+                prior_logits,
+                free_nats=self.free_bits,
+                unimix=self.unimix,
+            )
+            dynamic_loss = dynamic_loss.unsqueeze(-1)
+            representation_loss = representation_loss.unsqueeze(-1)
+        else:
+            kl_loss = categorical_kl_balanced(
+                posterior_logits,
+                prior_logits,
+                alpha=self.kl_alpha,
+                free_bits=self.free_bits,
+            ).unsqueeze(-1)
 
         # ---- Reconstruction loss ----
         pixels = tensordict.get(("next", self.tensor_keys.pixels)).contiguous()
@@ -360,10 +442,20 @@ class DreamerV3ModelLoss(LossModule):
         reward_loss = reward_loss.mean().unsqueeze(-1)
 
         td_out = TensorDict(
-            loss_model_kl=self.lambda_kl * kl_loss,
             loss_model_reco=self.lambda_reco * reco_loss,
             loss_model_reward=self.lambda_reward * reward_loss,
         )
+        if self.kl_mode == "separate":
+            td_out.set(
+                "loss_model_dynamic",
+                self.lambda_kl * self.lambda_dynamic * dynamic_loss,
+            )
+            td_out.set(
+                "loss_model_representation",
+                self.lambda_kl * self.lambda_representation * representation_loss,
+            )
+        else:
+            td_out.set("loss_model_kl", self.lambda_kl * kl_loss)
 
         # ---- Optional continue loss ----
         if self.lambda_continue > 0:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #4095
* #4075
* #4074
* __->__ #4073
* #4072
* #4068
* #4067
* #4066
* #4065

Summary:
- add configurable categorical unimix to the DreamerV3 prior and posterior
- add separate dynamics and representation KL terms with aggregated free nats
- configure the maintained example for 1% unimix and 1.0/0.1 KL weighting

Rationale:
The reference objective mixes categorical probabilities with a uniform
component, sums KL across stochastic variables before applying free nats, and
optimizes stopped-gradient dynamics and representation terms separately. The
previous balanced aggregate used different gradient weights and free-bit
semantics, which prevented numerical and training-curve parity.

Test plan:
- pytest test/objectives/test_dreamer_v3.py -q
- pytest test/modules/test_dreamer_components.py -k DreamerV3Components -q
- pytest --doctest-modules torchrl/objectives/dreamer_v3.py -q
- run the maintained DreamerV3 SOTA smoke with the worktree virtual environment
- verify frozen 1% unimix KL values, stopped-gradient routing, aggregated free
  nats, separate loss keys, and end-to-end optimization