### PR TITLE
[Feature] Complete DreamerV3 continuation training semantics

### DIFF
--- a/docs/source/reference/modules_models.rst
+++ b/docs/source/reference/modules_models.rst
@@ -32,6 +32,7 @@ Modules for model-based reinforcement learning, including world models and dynam
     RSSMRollout
     RSSMRolloutV3
     SymExpTwoHot
+    DreamerV3MLP
 
 PILCO
 -----

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -20,17 +20,33 @@ networks:
   num_categoricals: 4
   num_classes: 4
   unimix: 0.01
+  recurrent_model: block_gru
+  num_blocks: 8
+  dynamics_layers: 1
+  prior_layers: 2
+  posterior_layers: 1
+  norm_eps: 1.0e-4
   obs_embed_dim: 32
   num_reward_bins: 255
   num_value_bins: 255
   hidden_dim: 64
   depth: 2
+  encoder_layers: 3
+  decoder_layers: 3
+  reward_layers: 1
+  actor_layers: 3
+  value_layers: 3
+  policy_min_std: 0.1
+  policy_max_std: 1.0
 
 optimization:
-  lr: 3.0e-4
-  grad_clip: 100.0
+  lr: 4.0e-5
+  adam_eps: 1.0e-20
+  adaptive_grad_clip: 0.3
+  warmup_steps: 1000
   updates_per_batch: 8
-  imagination_horizon: 10
+  imagination_horizon: 15
+  continuation_horizon: 333
   use_reinforce: true
   return_normalization_rate: 0.01
   return_normalization_min_scale: 1.0
@@ -39,7 +55,7 @@ optimization:
   free_bits: 1.0
   dynamic_loss_weight: 1.0
   representation_loss_weight: 0.1
-  gamma: 0.99
+  gamma: 1.0
   lmbda: 0.95
 
 logger:

--- a/sota-implementations/dreamer_v3/dreamer_v3.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3.py
@@ -48,23 +48,56 @@ from torchrl.envs.libs.gym import GymEnv
 from torchrl.envs.model_based.dreamer import DreamerEnv
 from torchrl.envs.transforms import TensorDictPrimer
 from torchrl.envs.utils import ExplorationType, set_exploration_type
-from torchrl.modules import SymExpTwoHot, WorldModelWrapper
+from torchrl.modules import DreamerV3MLP, SymExpTwoHot, WorldModelWrapper
 from torchrl.modules.distributions.continuous import TanhNormal
-from torchrl.modules.models.model_based import DreamerActor
 from torchrl.modules.models.model_based_v3 import (
     RSSMPosteriorV3,
     RSSMPriorV3,
     RSSMRolloutV3,
 )
-from torchrl.modules.models.models import MLP
 from torchrl.objectives import (
     DreamerV3ActorLoss,
     DreamerV3ModelLoss,
     DreamerV3ValueLoss,
+    symlog,
 )
 from torchrl.objectives.utils import SoftUpdate, ValueEstimators
 
 _has_matplotlib = importlib.util.find_spec("matplotlib") is not None
+
+
+class _DreamerV3Actor(torch.nn.Module):
+    def __init__(self, cfg: DictConfig, action_dim: int):
+        super().__init__()
+        state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
+        self.backbone = DreamerV3MLP(
+            state_dim + cfg.networks.rnn_hidden_dim,
+            2 * action_dim,
+            depth=cfg.networks.actor_layers,
+            num_cells=cfg.networks.hidden_dim,
+            outscale=0.01,
+            norm_eps=cfg.networks.norm_eps,
+        )
+        self.action_dim = action_dim
+        self.min_std = cfg.networks.policy_min_std
+        self.max_std = cfg.networks.policy_max_std
+
+    def forward(self, state: torch.Tensor, belief: torch.Tensor):
+        mean, std = self.backbone(state, belief).split(self.action_dim, -1)
+        std = (self.max_std - self.min_std) * torch.sigmoid(std + 2) + self.min_std
+        return mean, std
+
+
+@torch.no_grad()
+def adaptive_grad_clip_(parameters, clip: float, minimum: float = 1e-3) -> None:
+    """Clip each parameter gradient relative to its parameter norm."""
+    for parameter in parameters:
+        if parameter.grad is None:
+            continue
+        grad_norm = parameter.grad.norm()
+        parameter_norm = parameter.detach().norm().clamp_min(minimum)
+        scale = (clip * parameter_norm / grad_norm.clamp_min(1e-12)).clamp_max(1)
+        parameter.grad.mul_(scale)
 
 
 def make_env(env_name: str, seed: int = 0):
@@ -82,15 +115,23 @@ def build_world_model(*, cfg: DictConfig, obs_dim: int, action_dim: int):
     """
     state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
 
-    encoder = TensorDictModule(
-        MLP(
-            in_features=obs_dim,
-            out_features=cfg.networks.obs_embed_dim,
-            depth=cfg.networks.depth,
-            num_cells=cfg.networks.hidden_dim,
+    encoder = TensorDictSequential(
+        TensorDictModule(
+            symlog,
+            in_keys=[("next", "observation")],
+            out_keys=[("next", "symlog_observation")],
         ),
-        in_keys=[("next", "observation")],
-        out_keys=[("next", "encoded_latents")],
+        TensorDictModule(
+            DreamerV3MLP(
+                in_features=obs_dim,
+                out_features=cfg.networks.obs_embed_dim,
+                depth=cfg.networks.encoder_layers,
+                num_cells=cfg.networks.hidden_dim,
+                norm_eps=cfg.networks.norm_eps,
+            ),
+            in_keys=[("next", "symlog_observation")],
+            out_keys=[("next", "encoded_latents")],
+        ),
     )
 
     prior_net = RSSMPriorV3(
@@ -101,6 +142,11 @@ def build_world_model(*, cfg: DictConfig, obs_dim: int, action_dim: int):
         num_classes=cfg.networks.num_classes,
         action_dim=action_dim,
         unimix=cfg.networks.unimix,
+        recurrent_model=cfg.networks.recurrent_model,
+        num_blocks=cfg.networks.num_blocks,
+        num_layers=cfg.networks.dynamics_layers,
+        prior_num_layers=cfg.networks.prior_layers,
+        norm_eps=cfg.networks.norm_eps,
     )
     rssm_prior = TensorDictModule(
         prior_net,
@@ -119,6 +165,9 @@ def build_world_model(*, cfg: DictConfig, obs_dim: int, action_dim: int):
         rnn_hidden_dim=cfg.networks.rnn_hidden_dim,
         obs_embed_dim=cfg.networks.obs_embed_dim,
         unimix=cfg.networks.unimix,
+        use_rms_norm=True,
+        num_layers=cfg.networks.posterior_layers,
+        norm_eps=cfg.networks.norm_eps,
     )
     rssm_posterior = TensorDictModule(
         posterior_net,
@@ -129,21 +178,24 @@ def build_world_model(*, cfg: DictConfig, obs_dim: int, action_dim: int):
     rollout = RSSMRolloutV3(rssm_prior, rssm_posterior)
 
     decoder = TensorDictModule(
-        MLP(
-            in_features=state_dim,
+        DreamerV3MLP(
+            in_features=state_dim + cfg.networks.rnn_hidden_dim,
             out_features=obs_dim,
-            depth=cfg.networks.depth,
+            depth=cfg.networks.decoder_layers,
             num_cells=cfg.networks.hidden_dim,
+            norm_eps=cfg.networks.norm_eps,
         ),
-        in_keys=[("next", "state")],
+        in_keys=[("next", "state"), ("next", "belief")],
         out_keys=[("next", "reco_pixels")],
     )
 
-    reward_net = MLP(
+    reward_net = DreamerV3MLP(
         in_features=state_dim + cfg.networks.rnn_hidden_dim,
         out_features=cfg.networks.num_reward_bins,
-        depth=cfg.networks.depth,
+        depth=cfg.networks.reward_layers,
         num_cells=cfg.networks.hidden_dim,
+        outscale=0.0,
+        norm_eps=cfg.networks.norm_eps,
     )
     reward_decoder = SymExpTwoHot(cfg.networks.num_reward_bins)
     reward_head = TensorDictSequential(
@@ -159,8 +211,23 @@ def build_world_model(*, cfg: DictConfig, obs_dim: int, action_dim: int):
         ),
     )
 
-    world_model = TensorDictSequential(encoder, rollout, decoder, reward_head)
-    return world_model, prior_net, reward_net, reward_decoder
+    continuation_net = DreamerV3MLP(
+        in_features=state_dim + cfg.networks.rnn_hidden_dim,
+        out_features=1,
+        depth=cfg.networks.reward_layers,
+        num_cells=cfg.networks.hidden_dim,
+        norm_eps=cfg.networks.norm_eps,
+    )
+    continuation_head = TensorDictModule(
+        continuation_net,
+        in_keys=[("next", "state"), ("next", "belief")],
+        out_keys=[("next", "continue_pred")],
+    )
+
+    world_model = TensorDictSequential(
+        encoder, rollout, decoder, reward_head, continuation_head
+    )
+    return world_model, prior_net, reward_net, reward_decoder, continuation_net
 
 
 def build_imagination_model(*, prior_net, reward_net, reward_decoder):
@@ -187,13 +254,25 @@ def build_imagination_model(*, prior_net, reward_net, reward_decoder):
     return WorldModelWrapper(transition_model, reward_model)
 
 
+def build_continuation_model(*, continuation_net):
+    """Build the imagination continuation predictor from the trained head."""
+    return TensorDictSequential(
+        TensorDictModule(
+            continuation_net,
+            in_keys=["state", "belief"],
+            out_keys=["continue_logits"],
+        ),
+        TensorDictModule(
+            torch.nn.Sigmoid(),
+            in_keys=["continue_logits"],
+            out_keys=["continuation"],
+        ),
+    )
+
+
 def build_actor(*, cfg: DictConfig, action_dim: int):
     state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
-    actor_mlp = DreamerActor(
-        out_features=action_dim,
-        depth=cfg.networks.depth,
-        num_cells=cfg.networks.hidden_dim,
-    )
+    actor_mlp = _DreamerV3Actor(cfg, action_dim)
     actor_model = ProbabilisticTensorDictSequential(
         TensorDictModule(
             actor_mlp,
@@ -226,11 +305,13 @@ def build_value(*, cfg: DictConfig):
     state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
     value_model = TensorDictSequential(
         TensorDictModule(
-            MLP(
+            DreamerV3MLP(
                 in_features=state_dim + cfg.networks.rnn_hidden_dim,
                 out_features=cfg.networks.num_value_bins,
-                depth=cfg.networks.depth,
+                depth=cfg.networks.value_layers,
                 num_cells=cfg.networks.hidden_dim,
+                outscale=0.0,
+                norm_eps=cfg.networks.norm_eps,
             ),
             in_keys=["state", "belief"],
             out_keys=["state_value_logits"],
@@ -296,14 +377,19 @@ def main(cfg: DictConfig):
     action_dim = real_env.action_spec.shape[0]
     state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
 
-    world_model, prior_net, reward_net, reward_decoder = build_world_model(
-        cfg=cfg, obs_dim=obs_dim, action_dim=action_dim
-    )
+    (
+        world_model,
+        prior_net,
+        reward_net,
+        reward_decoder,
+        continuation_net,
+    ) = build_world_model(cfg=cfg, obs_dim=obs_dim, action_dim=action_dim)
     imagination_model = build_imagination_model(
         prior_net=prior_net,
         reward_net=reward_net,
         reward_decoder=reward_decoder,
     )
+    continuation_model = build_continuation_model(continuation_net=continuation_net)
     actor_model = build_actor(cfg=cfg, action_dim=action_dim)
     value_model = build_value(cfg=cfg)
     mb_env = build_mb_env(
@@ -320,6 +406,8 @@ def main(cfg: DictConfig):
         lambda_dynamic=cfg.optimization.dynamic_loss_weight,
         lambda_representation=cfg.optimization.representation_loss_weight,
         unimix=cfg.networks.unimix,
+        lambda_continue=1.0,
+        continue_target_scale=1 - 1 / cfg.optimization.continuation_horizon,
         global_average=True,  # state-based obs, not (C, H, W) pixels
     )
     model_loss.set_keys(pixels="observation")
@@ -327,6 +415,7 @@ def main(cfg: DictConfig):
         actor_model,
         value_model,
         mb_env,
+        continuation_model=continuation_model,
         imagination_horizon=cfg.optimization.imagination_horizon,
         use_reinforce=cfg.optimization.use_reinforce,
         return_normalization_rate=cfg.optimization.return_normalization_rate,
@@ -346,9 +435,22 @@ def main(cfg: DictConfig):
     )
     value_target_updater = SoftUpdate(value_loss, tau=cfg.optimization.slow_critic_tau)
 
-    opt_model = torch.optim.Adam(model_loss.parameters(), lr=cfg.optimization.lr)
-    opt_actor = torch.optim.Adam(actor_model.parameters(), lr=cfg.optimization.lr)
-    opt_value = torch.optim.Adam(value_loss.parameters(), lr=cfg.optimization.lr)
+    optimizer_kwargs = {
+        "lr": cfg.optimization.lr,
+        "eps": cfg.optimization.adam_eps,
+        "betas": (0.9, 0.999),
+    }
+    opt_model = torch.optim.Adam(model_loss.parameters(), **optimizer_kwargs)
+    opt_actor = torch.optim.Adam(actor_model.parameters(), **optimizer_kwargs)
+    opt_value = torch.optim.Adam(value_loss.parameters(), **optimizer_kwargs)
+    schedulers = [
+        torch.optim.lr_scheduler.LinearLR(
+            optimizer,
+            start_factor=1 / cfg.optimization.warmup_steps,
+            total_iters=cfg.optimization.warmup_steps,
+        )
+        for optimizer in (opt_model, opt_actor, opt_value)
+    ]
 
     explore_env = TransformedEnv(
         make_env(cfg.env.name, cfg.env.seed + 2),
@@ -440,14 +542,18 @@ def main(cfg: DictConfig):
             m_td, model_out = model_loss(sample)
             model_kl = m_td["loss_model_dynamic"] + m_td["loss_model_representation"]
             total_m = (
-                model_kl + m_td["loss_model_reco"] + m_td["loss_model_reward"]
+                model_kl
+                + m_td["loss_model_reco"]
+                + m_td["loss_model_reward"]
+                + m_td["loss_model_continue"]
             ).squeeze()
             opt_model.zero_grad(set_to_none=True)
             total_m.backward()
-            torch.nn.utils.clip_grad_norm_(
-                model_loss.parameters(), cfg.optimization.grad_clip
+            adaptive_grad_clip_(
+                model_loss.parameters(), cfg.optimization.adaptive_grad_clip
             )
             opt_model.step()
+            schedulers[0].step()
 
             # Imagine from posterior states.
             post_state = (
@@ -465,18 +571,20 @@ def main(cfg: DictConfig):
             a_td, fake_data = actor_loss(actor_input)
             opt_actor.zero_grad(set_to_none=True)
             a_td["loss_actor"].backward()
-            torch.nn.utils.clip_grad_norm_(
-                actor_loss.parameters(), cfg.optimization.grad_clip
+            adaptive_grad_clip_(
+                actor_loss.parameters(), cfg.optimization.adaptive_grad_clip
             )
             opt_actor.step()
+            schedulers[1].step()
 
             v_td, _ = value_loss(fake_data.detach())
             opt_value.zero_grad(set_to_none=True)
             v_td["loss_value"].backward()
-            torch.nn.utils.clip_grad_norm_(
-                value_loss.parameters(), cfg.optimization.grad_clip
+            adaptive_grad_clip_(
+                value_loss.parameters(), cfg.optimization.adaptive_grad_clip
             )
             opt_value.step()
+            schedulers[2].step()
             value_target_updater.step()
 
             loss_hist["kl"].append(model_kl.detach())

--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -20,7 +20,11 @@ from torchrl.modules.models.model_based import (
     RSSMPrior,
     RSSMRollout,
 )
-from torchrl.modules.models.model_based_v3 import RSSMPosteriorV3, RSSMPriorV3
+from torchrl.modules.models.model_based_v3 import (
+    DreamerV3MLP,
+    RSSMPosteriorV3,
+    RSSMPriorV3,
+)
 
 from torchrl.testing import get_default_devices
 
@@ -261,6 +265,17 @@ class TestDreamerComponents:
 
 
 class TestDreamerV3Components:
+    def test_mlp_output_scale_and_multiple_inputs(self):
+        module = DreamerV3MLP(
+            6,
+            4,
+            depth=2,
+            num_cells=8,
+            outscale=0.0,
+        )
+        output = module(torch.randn(3, 2), torch.randn(3, 4))
+        torch.testing.assert_close(output, torch.zeros_like(output))
+
     @pytest.mark.parametrize("device", get_default_devices())
     def test_block_gru_reference_fixture(self, device):
         prior = RSSMPriorV3(

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -595,6 +595,52 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         )
         assert grad_total > 0, "All gradients are zero after actor backward"
 
+    def test_dreamer_v3_continuation_lambda_and_weights(self, device):
+        class _ConstantContinuation(nn.Module):
+            def forward(self_, state, belief):
+                return torch.full_like(state[..., :1], 0.5)
+
+        continuation_model = TensorDictModule(
+            _ConstantContinuation(),
+            in_keys=["state", "belief"],
+            out_keys=["continuation"],
+        ).to(device)
+        value_model = self._create_value_model().to(device)
+        loss_module = DreamerV3ActorLoss(
+            self._create_actor_model().to(device),
+            value_model,
+            self._create_mb_env().to(device),
+            continuation_model=continuation_model,
+            imagination_horizon=3,
+            discount_loss=True,
+        )
+        loss_module.make_value_estimator(ValueEstimators.TDLambda, gamma=1.0, lmbda=0.5)
+
+        reward = torch.tensor([[[1.0], [2.0], [3.0]]], device=device)
+        value = torch.tensor([[[10.0], [20.0], [30.0]]], device=device)
+        continuation = torch.full_like(reward, 0.5)
+        torch.testing.assert_close(
+            loss_module.lambda_target(reward, value, continuation),
+            torch.tensor([[[6.375], [11.5], [18.0]]], device=device),
+        )
+
+        _, fake_data = loss_module(self._create_actor_data().to(device).reshape(-1))
+        expected_weight = torch.tensor([1.0, 0.5, 0.25], device=device)
+        torch.testing.assert_close(
+            fake_data["discount_weight"][0, :, 0], expected_weight
+        )
+        torch.testing.assert_close(
+            fake_data["next", "continuation"],
+            torch.full_like(fake_data["next", "continuation"], 0.5),
+        )
+
+        value_loss = DreamerV3ValueLoss(
+            value_model,
+            discount_loss=True,
+            actor_loss=loss_module,
+        )
+        value_loss(fake_data.detach())
+
     # ------------------------------------------------------------------ #
     # Value loss tests
     # ------------------------------------------------------------------ #
@@ -749,15 +795,34 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         )
         cfg = OmegaConf.load(repo_root / "sota-implementations/dreamer_v3/config.yaml")
         cfg.networks.num_reward_bins = self.num_reward_bins
-        world_model, prior, reward_head, reward_decoder = example["build_world_model"](
-            cfg=cfg, obs_dim=3, action_dim=self.action_dim
-        )
+        (world_model, prior, reward_head, reward_decoder, continuation_head,) = example[
+            "build_world_model"
+        ](cfg=cfg, obs_dim=3, action_dim=self.action_dim)
         imagination_model = example["build_imagination_model"](
             prior_net=prior,
             reward_net=reward_head,
             reward_decoder=reward_decoder,
         ).to(device)
+        continuation_model = example["build_continuation_model"](
+            continuation_net=continuation_head
+        ).to(device)
         world_model = world_model.to(device)
+        observation = torch.tensor(
+            [[[0.0, 1.0, -3.0], [2.0, -1.0, 0.5]]], device=device
+        )
+        world_input = TensorDict(
+            {
+                "state": torch.zeros(1, 2, self.state_dim, device=device),
+                "belief": torch.zeros(1, 2, cfg.networks.rnn_hidden_dim, device=device),
+                "action": torch.zeros(1, 2, self.action_dim, device=device),
+                "next": {"observation": observation},
+            },
+            [1, 2],
+        )
+        world_model(world_input)
+        torch.testing.assert_close(
+            world_input["next", "symlog_observation"], symlog(observation)
+        )
         shared_parameters = tuple(prior.parameters()) + tuple(reward_head.parameters())
         world_parameters = tuple(world_model.parameters())
         imagination_parameters = tuple(imagination_model.parameters())
@@ -765,6 +830,13 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             any(parameter is candidate for candidate in world_parameters)
             and any(parameter is candidate for candidate in imagination_parameters)
             for parameter in shared_parameters
+        )
+        assert all(
+            any(parameter is candidate for candidate in world_parameters)
+            and any(
+                parameter is candidate for candidate in continuation_model.parameters()
+            )
+            for parameter in continuation_head.parameters()
         )
 
         reward_td = TensorDict(
@@ -777,6 +849,13 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         imagination_model.get_reward_operator()(reward_td)
         assert reward_td["reward_logits"].shape == (2, self.num_reward_bins)
         assert reward_td["reward"].shape == (2, 1)
+        continuation_model(reward_td)
+        assert reward_td["continuation"].shape == (2, 1)
+
+        parameter = nn.Parameter(torch.tensor([3.0, 4.0], device=device))
+        parameter.grad = torch.tensor([30.0, 40.0], device=device)
+        example["adaptive_grad_clip_"]([parameter], clip=0.3)
+        assert parameter.grad.norm().item() == pytest.approx(1.5)
 
     def test_dreamer_v3_value_invalid_loss_type(self, device):
         value_model = self._create_value_model()
@@ -988,6 +1067,26 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         assert prior_logits.shape == (B, T, self.num_cats, self.num_classes)
         assert post_logits.shape == (B, T, self.num_cats, self.num_classes)
 
+        reset = torch.zeros(B, T, 1, dtype=torch.bool, device=device)
+        reset[:, 2] = True
+        td_a = td.clone().set("is_init", reset)
+        td_b = td.clone().set("is_init", reset)
+        td_b["action"][:, :2] = torch.randn_like(td_b["action"][:, :2])
+        td_b["next", "encoded_latents"][:, :2] = torch.randn_like(
+            td_b["next", "encoded_latents"][:, :2]
+        )
+        torch.manual_seed(0)
+        out_a = rollout(td_a)
+        torch.manual_seed(0)
+        out_b = rollout(td_b)
+        for key in (
+            ("next", "prior_logits"),
+            ("next", "posterior_logits"),
+            ("next", "state"),
+            ("next", "belief"),
+        ):
+            torch.testing.assert_close(out_a[key][:, 2:], out_b[key][:, 2:])
+
     # ------------------------------------------------------------------ #
     # Coverage for previously untested branches
     # ------------------------------------------------------------------ #
@@ -1041,6 +1140,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         loss_module = DreamerV3ModelLoss(
             world_model,
             lambda_continue=1.0,
+            continue_target_scale=0.75,
             num_reward_bins=self.num_reward_bins,
         )
         # state/belief in the default data are zeros, so the continue_head
@@ -1050,8 +1150,13 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         base_td["belief"] = torch.randn_like(base_td["belief"])
         # seed a mix of done / not-done so the BCE target is non-degenerate
         base_td["next", "done"][0, 0] = True
-        loss_td, _ = loss_module(base_td)
+        loss_td, model_out = loss_module(base_td)
         assert "loss_model_continue" in loss_td.keys()
+        target = (~base_td["next", "terminated"]).float() * 0.75
+        expected = torch.nn.functional.binary_cross_entropy_with_logits(
+            model_out["next", "continue_pred"], target
+        )
+        torch.testing.assert_close(loss_td["loss_model_continue"].squeeze(), expected)
         loss_td["loss_model_continue"].backward()
         assert world_model.continue_head.weight.grad.abs().sum() > 0
         assert base_td.shape == (B, T)

--- a/torchrl/modules/__init__.py
+++ b/torchrl/modules/__init__.py
@@ -36,6 +36,7 @@ from .models import (
     DdpgMlpQNet,
     DecisionTransformer,
     DreamerActor,
+    DreamerV3MLP,
     DTActor,
     DuelingCnnDQNet,
     GPWorldModel,
@@ -54,9 +55,9 @@ from .models import (
     RSSMPosterior,
     RSSMPrior,
     RSSMRollout,
-    SymExpTwoHot,
     Squeeze2dLayer,
     SqueezeLayer,
+    SymExpTwoHot,
     VDNMixer,
 )
 from .tensordict_module import (
@@ -151,6 +152,7 @@ __all__ = [
     "DistributionalQValueHook",
     "DistributionalQValueModule",
     "DreamerActor",
+    "DreamerV3MLP",
     "DuelingCnnDQNet",
     "EGreedyModule",
     "GPWorldModel",

--- a/torchrl/modules/models/__init__.py
+++ b/torchrl/modules/models/__init__.py
@@ -28,7 +28,13 @@ from .model_based import (
     RSSMPrior,
     RSSMRollout,
 )
-from .model_based_v3 import RSSMPosteriorV3, RSSMPriorV3, RSSMRolloutV3, SymExpTwoHot
+from .model_based_v3 import (
+    DreamerV3MLP,
+    RSSMPosteriorV3,
+    RSSMPriorV3,
+    RSSMRolloutV3,
+    SymExpTwoHot,
+)
 from .models import (
     Conv2dNet,
     Conv3dNet,
@@ -70,6 +76,7 @@ __all__ = [
     "DecisionTransformer",
     "DistributionalDQNnet",
     "DreamerActor",
+    "DreamerV3MLP",
     "DTActor",
     "DuelingCnnDQNet",
     "DuelingMlpDQNet",

--- a/torchrl/modules/models/model_based_v3.py
+++ b/torchrl/modules/models/model_based_v3.py
@@ -12,6 +12,7 @@ from typing import Literal
 
 import torch
 from tensordict.nn import TensorDictModule, TensorDictModuleBase, TensorDictSequential
+from tensordict.utils import NestedKey, unravel_key
 from torch import nn
 from torch.nn import GRUCell
 
@@ -173,6 +174,62 @@ class _DreamerV3BlockGRU(nn.Module):
         candidate = (reset * candidate.flatten(-2)).tanh()
         update = (update.flatten(-2) - 1).sigmoid()
         return update * candidate + (1 - update) * belief
+
+
+class DreamerV3MLP(nn.Module):
+    """RMS-normalized multilayer perceptron used by DreamerV3 heads.
+
+    Args:
+        in_features (int): Input feature count.
+        out_features (int): Output feature count.
+        depth (int, optional): Number of hidden layers. Defaults to 3.
+        num_cells (int, optional): Hidden feature count. Defaults to 1024.
+        outscale (float, optional): Multiplicative initialization scale for the
+            output layer. Defaults to 1.0.
+        norm_eps (float, optional): RMS normalization epsilon. Defaults to
+            ``1e-4``.
+        device (torch.device, optional): Device on which to create parameters.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.modules import DreamerV3MLP
+        >>> module = DreamerV3MLP(6, 4, depth=2, num_cells=8)
+        >>> module(torch.randn(3, 2), torch.randn(3, 4)).shape
+        torch.Size([3, 4])
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        depth: int = 3,
+        num_cells: int = 1024,
+        outscale: float = 1.0,
+        norm_eps: float = 1e-4,
+        device=None,
+    ):
+        super().__init__()
+        layers = []
+        layer_in = in_features
+        for _ in range(depth):
+            layers.extend(
+                [
+                    nn.Linear(layer_in, num_cells, device=device),
+                    _DreamerV3RMSNorm(num_cells, norm_eps, device=device),
+                    nn.SiLU(),
+                ]
+            )
+            layer_in = num_cells
+        output = nn.Linear(layer_in, out_features, device=device)
+        layers.append(output)
+        self.model = nn.Sequential(*layers)
+        self.model.apply(_dreamer_v3_init)
+        with torch.no_grad():
+            output.weight.mul_(outscale)
+
+    def forward(self, *inputs: torch.Tensor) -> torch.Tensor:
+        value = inputs[0] if len(inputs) == 1 else torch.cat(inputs, -1)
+        return self.model(value)
 
 
 def symlog(x: torch.Tensor) -> torch.Tensor:
@@ -788,6 +845,9 @@ class RSSMRolloutV3(TensorDictModuleBase):
         rssm_prior (TensorDictModule): Prior module wrapping :class:`RSSMPriorV3`.
         rssm_posterior (TensorDictModule): Posterior module wrapping
             :class:`RSSMPosteriorV3`.
+        reset_key (NestedKey or None, optional): Boolean key marking the first
+            transition of an episode. State, belief, and action are zeroed at
+            those positions. Defaults to ``"is_init"``.
 
     Examples:
         >>> import torch
@@ -825,6 +885,7 @@ class RSSMRolloutV3(TensorDictModuleBase):
         self,
         rssm_prior: TensorDictModule,
         rssm_posterior: TensorDictModule,
+        reset_key: NestedKey | None = "is_init",
     ):
         super().__init__()
         _module = TensorDictSequential(rssm_prior, rssm_posterior)
@@ -832,6 +893,7 @@ class RSSMRolloutV3(TensorDictModuleBase):
         self.out_keys = _module.out_keys
         self.rssm_prior = rssm_prior
         self.rssm_posterior = rssm_posterior
+        self.reset_key = unravel_key(reset_key) if reset_key is not None else None
 
     def forward(self, tensordict):
         """Roll out the RSSM for one episode chunk.
@@ -855,6 +917,20 @@ class RSSMRolloutV3(TensorDictModuleBase):
         ) + list(self.out_keys)
 
         for t in range(time_steps):
+            reset = (
+                _tensordict.get(self.reset_key, None)
+                if self.reset_key is not None
+                else None
+            )
+            if reset is not None:
+                state = _tensordict.get("state")
+                belief = _tensordict.get("belief")
+                action = _tensordict.get("action")
+                while reset.ndim < state.ndim:
+                    reset = reset.unsqueeze(-1)
+                _tensordict.set("state", torch.where(reset, 0, state))
+                _tensordict.set("belief", torch.where(reset, 0, belief))
+                _tensordict.set("action", torch.where(reset, 0, action))
             self.rssm_prior(_tensordict)
             self.rssm_posterior(_tensordict)
 

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -23,7 +23,7 @@ from typing import Literal
 
 import torch
 from tensordict import TensorDict, TensorDictParams
-from tensordict.nn import TensorDictModule
+from tensordict.nn import TensorDictModule, TensorDictModuleBase
 from tensordict.utils import NestedKey, unravel_key
 
 from torchrl._utils import _maybe_record_function_decorator
@@ -212,6 +212,9 @@ class DreamerV3ModelLoss(LossModule):
         lambda_reward (float, optional): Reward prediction loss weight. Default: 1.0.
         lambda_continue (float, optional): Continue prediction loss weight.
             Default: 0.0 (disabled).
+        continue_target_scale (float, optional): Multiplier applied to
+            non-terminal continuation targets, for encoding the finite-horizon
+            discount in the continuation model. Defaults to 1.0.
         kl_mode ("balanced" or "separate", optional): KL formulation.
             ``"balanced"`` preserves the historical weighted aggregate;
             ``"separate"`` emits the reference dynamics and representation
@@ -306,6 +309,8 @@ class DreamerV3ModelLoss(LossModule):
                 Defaults to ``"continue_pred"``.
             done (NestedKey): Ground-truth done flag (optional).
                 Defaults to ``"done"``.
+            terminated (NestedKey): Ground-truth terminal flag (optional).
+                Defaults to ``"terminated"``.
         """
 
         reward: NestedKey = "reward"
@@ -317,6 +322,7 @@ class DreamerV3ModelLoss(LossModule):
         reco_pixels: NestedKey = "reco_pixels"
         continue_pred: NestedKey = "continue_pred"
         done: NestedKey = "done"
+        terminated: NestedKey = "terminated"
 
     tensor_keys: _AcceptedKeys
     default_keys = _AcceptedKeys
@@ -333,6 +339,7 @@ class DreamerV3ModelLoss(LossModule):
         lambda_dynamic: float = 1.0,
         lambda_representation: float = 0.1,
         unimix: float = 0.0,
+        continue_target_scale: float = 1.0,
         kl_alpha: float = 0.8,
         free_bits: float = 1.0,
         reco_loss: str = "l2",
@@ -354,6 +361,9 @@ class DreamerV3ModelLoss(LossModule):
         self.lambda_dynamic = lambda_dynamic
         self.lambda_representation = lambda_representation
         self.unimix = unimix
+        if not 0 < continue_target_scale <= 1:
+            raise ValueError("continue_target_scale must be in (0, 1].")
+        self.continue_target_scale = continue_target_scale
         self.kl_alpha = kl_alpha
         self.free_bits = free_bits
         self.reco_loss = reco_loss
@@ -462,10 +472,11 @@ class DreamerV3ModelLoss(LossModule):
             continue_pred = tensordict.get(
                 ("next", self.tensor_keys.continue_pred), None
             )
-            done = tensordict.get(("next", self.tensor_keys.done), None)
-            if continue_pred is not None and done is not None:
-                # continue = 1 - done; BCE with logits
-                continue_target = (~done).float()
+            terminated = tensordict.get(("next", self.tensor_keys.terminated), None)
+            if terminated is None:
+                terminated = tensordict.get(("next", self.tensor_keys.done), None)
+            if continue_pred is not None and terminated is not None:
+                continue_target = (~terminated).float() * self.continue_target_scale
                 continue_loss = torch.nn.functional.binary_cross_entropy_with_logits(
                     continue_pred.squeeze(-1), continue_target.squeeze(-1)
                 ).unsqueeze(-1)
@@ -502,6 +513,9 @@ class DreamerV3ActorLoss(LossModule):
         actor_model (TensorDictModule): The actor / policy network.
         value_model (TensorDictModule): The value network.
         model_based_env (DreamerEnv): The imagination environment.
+        continuation_model (TensorDictModuleBase, optional): Shared trained
+            model that writes continuation probabilities for imagined states.
+            Defaults to ``None``.
         imagination_horizon (int, optional): Rollout length inside imagination.
             Default: 15.
         discount_loss (bool, optional): If ``True``, discount the actor loss
@@ -616,6 +630,10 @@ class DreamerV3ActorLoss(LossModule):
                 Defaults to ``"action_log_prob"``.
             done (NestedKey): Done flag. Defaults to ``"done"``.
             terminated (NestedKey): Terminated flag. Defaults to ``"terminated"``.
+            continuation (NestedKey): Predicted continuation probability.
+                Defaults to ``"continuation"``.
+            discount_weight (NestedKey): Cumulative imagination weight.
+                Defaults to ``"discount_weight"``.
         """
 
         state: NestedKey = "state"
@@ -625,6 +643,8 @@ class DreamerV3ActorLoss(LossModule):
         action_log_prob: NestedKey = "action_log_prob"
         done: NestedKey = "done"
         terminated: NestedKey = "terminated"
+        continuation: NestedKey = "continuation"
+        discount_weight: NestedKey = "discount_weight"
 
     tensor_keys: _AcceptedKeys
     default_keys = _AcceptedKeys
@@ -639,6 +659,7 @@ class DreamerV3ActorLoss(LossModule):
         value_model: TensorDictModule,
         model_based_env: DreamerEnv,
         *,
+        continuation_model: TensorDictModuleBase | None = None,
         imagination_horizon: int = 15,
         discount_loss: bool = True,
         entropy_bonus: float = 3e-4,
@@ -654,6 +675,7 @@ class DreamerV3ActorLoss(LossModule):
         self.actor_model = actor_model
         self.__dict__["value_model"] = value_model
         self.model_based_env = model_based_env
+        self.__dict__["continuation_model"] = continuation_model
         self.imagination_horizon = imagination_horizon
         self.discount_loss = discount_loss
         self.entropy_bonus = entropy_bonus
@@ -705,16 +727,35 @@ class DreamerV3ActorLoss(LossModule):
 
         reward = fake_data.get(("next", self.tensor_keys.reward))
         next_value = next_tensordict.get(self.tensor_keys.value)
-        lambda_target = self.lambda_target(reward, next_value)
+        continuation = None
+        continuation_model = self.__dict__.get("continuation_model")
+        if continuation_model is not None:
+            continuation_td = next_tensordict.select(
+                *continuation_model.in_keys, strict=False
+            )
+            with hold_out_net(continuation_model):
+                continuation_model(continuation_td)
+            continuation = continuation_td.get(self.tensor_keys.continuation)
+            fake_data.set(("next", self.tensor_keys.continuation), continuation)
+        lambda_target = self.lambda_target(reward, next_value, continuation)
         fake_data.set("lambda_target", lambda_target)
 
         if self.discount_loss:
             gamma = self.value_estimator.gamma.to(tensordict.device)
-            discount = gamma.expand(lambda_target.shape).clone()
-            discount[..., 0, :] = 1
-            discount = discount.cumprod(dim=-2)
+            if continuation is None:
+                step_discount = gamma.expand(lambda_target.shape)
+            else:
+                step_discount = gamma * continuation
+            discount = torch.cat(
+                [
+                    torch.ones_like(step_discount[..., :1, :]),
+                    step_discount[..., :-1, :],
+                ],
+                dim=-2,
+            ).cumprod(dim=-2)
         else:
             discount = torch.ones_like(lambda_target)
+        fake_data.set(self.tensor_keys.discount_weight, discount.detach())
 
         if self.use_reinforce:
             # REINFORCE: log pi(a|z) * sg(A_t)
@@ -748,6 +789,11 @@ class DreamerV3ActorLoss(LossModule):
                 "return_low": self.return_low.detach().clone(),
                 "return_high": self.return_high.detach().clone(),
                 "return_scale": return_scale.detach().clone(),
+                "continuation_mean": (
+                    continuation.mean().detach()
+                    if continuation is not None
+                    else torch.ones((), device=actor_loss.device)
+                ),
             },
             [],
         )
@@ -773,7 +819,27 @@ class DreamerV3ActorLoss(LossModule):
             self.return_normalization_min_scale
         )
 
-    def lambda_target(self, reward: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
+    def lambda_target(
+        self,
+        reward: torch.Tensor,
+        value: torch.Tensor,
+        continuation: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if continuation is not None:
+            gamma = self.value_estimator.gamma.to(reward)
+            lmbda = self.value_estimator.lmbda.to(reward)
+            next_return = value[..., -1, :]
+            returns = []
+            for reward_t, value_t, continuation_t in zip(
+                reversed(reward.unbind(-2)),
+                reversed(value.unbind(-2)),
+                reversed(continuation.unbind(-2)),
+            ):
+                next_return = reward_t + gamma * continuation_t * (
+                    (1 - lmbda) * value_t + lmbda * next_return
+                )
+                returns.append(next_return)
+            return torch.stack(returns[::-1], dim=-2)
         done = torch.zeros(reward.shape, dtype=torch.bool, device=reward.device)
         terminated = torch.zeros(reward.shape, dtype=torch.bool, device=reward.device)
         input_tensordict = TensorDict(
@@ -892,10 +958,13 @@ class DreamerV3ValueLoss(LossModule):
                 ``"state_value"``.
             value_logits (NestedKey): Categorical value logits key. Defaults to
                 ``"state_value_logits"``.
+            discount_weight (NestedKey): Optional cumulative imagination
+                weight. Defaults to ``"discount_weight"``.
         """
 
         value: NestedKey = "state_value"
         value_logits: NestedKey = "state_value_logits"
+        discount_weight: NestedKey = "discount_weight"
 
     tensor_keys: _AcceptedKeys
     default_keys = _AcceptedKeys
@@ -970,8 +1039,11 @@ class DreamerV3ValueLoss(LossModule):
         # Squeeze the trailing 1 for loss computation
         target_sq = lambda_target.squeeze(-1)  # [N] or [B, T]
 
+        provided_discount = fake_data.get(self.tensor_keys.discount_weight, None)
         gamma = self._resolved_gamma()
-        if self.discount_loss and target_sq.ndim >= 2:
+        if provided_discount is not None:
+            discount = provided_discount.squeeze(-1)
+        elif self.discount_loss and target_sq.ndim >= 2:
             discount = gamma * torch.ones_like(target_sq)
             discount[..., 0] = 1
             discount = discount.cumprod(dim=-1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #4095
* #4075
* __->__ #4074
* #4073
* #4072
* #4068
* #4067
* #4066
* #4065

Summary:
- share a trained continuation head with imagination and use it in lambda returns
- propagate cumulative continuation weights to actor and value objectives
- add episode-reset masking, symlog vector encoding, and RMS-normalized DreamerV3 heads
- align the maintained optimizer, warmup, initialization, and horizon settings

Rationale:
A continuation predictor is only useful when its probabilities govern imagined
returns and objective weighting. Previously the optional auxiliary loss did not
affect imagination, recurrent carries were not explicitly reset at episode
boundaries, and the maintained setup used materially different preprocessing and
optimization settings. These gaps prevented meaningful reference-curve comparison.

Test plan:
- pytest test/objectives/test_dreamer_v3.py -q
- pytest test/modules/test_dreamer_components.py -k DreamerV3Components -q
- pytest --doctest-modules torchrl/modules/models/model_based_v3.py torchrl/objectives/dreamer_v3.py -q
- run the maintained DreamerV3 SOTA smoke with 400 environment steps
- verify continuation lambda fixtures, cumulative weights, shared parameters,
  terminal target scaling, recurrent resets, symlog inputs, AGC, and zero-scale heads