### PR TITLE
[BugFix] [TQC] [1/3] Support list-valued critics in SoftUpdate

### DIFF
--- a/test/objectives/test_sac.py
+++ b/test/objectives/test_sac.py
@@ -373,6 +373,15 @@ class TestSAC(LossModuleTestBase):
             loss = loss_fn(td)
         assert "loss_qvalue" in loss.keys()
 
+        updater = SoftUpdate(loss_fn, eps=0.5)
+        targets_before = updater._targets.clone()
+        with torch.no_grad():
+            for source in updater._sources.values(True, True):
+                source.add_(1)
+        updater.step()
+        for key, target in updater._targets.items(True, True):
+            torch.testing.assert_close(target, targets_before.get(key) + 0.5)
+
     @pytest.mark.parametrize("delay_value", (True, False))
     @pytest.mark.parametrize("delay_actor", (True, False))
     @pytest.mark.parametrize("delay_qvalue", (True, False))

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -479,7 +479,8 @@ class TargetNetUpdater:
                 return (filter_target(key[0]), *key[1:])
             return key[7:]
 
-        self._sources = self._sources.select(
+        sources = self._sources.clone(False)
+        self._sources = sources.select(
             *[
                 filter_target(key)
                 for (key, val) in self._distinct_and_params.items()


### PR DESCRIPTION
## Summary

Closes https://github.com/pytorch/rl/issues/4076

Initialize target updaters from an unlocked shallow source container, allowing list-backed functional parameters to be structurally selected. Extend the existing SAC list-critic regression through a real `SoftUpdate.step()`.

<details>
<summary>Validation</summary>

Tested on an H100 80 GB host with PyTorch 2.11.0+cu130.

- Upstream reproduction fails in `SoftUpdate(...)` with `RuntimeError: Cannot modify locked TensorDict`.
- Patched reproduction moves both delayed critic leaves by exactly `0.5` after adding `1` to each source.
- Targeted updater/SAC tests: `12 passed, 196 deselected` in 1.98 s.
- Full SAC suite: `1679 passed, 494 skipped` in 27.16 s.
- All pre-commit hooks pass.

</details>

cc @vmoens 