### PR TITLE
[Feature] [TQC] [2/3] Add truncated quantile critics

### DIFF
--- a/.github/unittest/linux_sota/scripts/test_sota.py
+++ b/.github/unittest/linux_sota/scripts/test_sota.py
@@ -153,6 +153,19 @@ commands = {
   env.name=Pendulum-v1 \
   logger.backend=
 """,
+    "tqc": """python sota-implementations/tqc/tqc.py \
+  collector.total_frames=48 \
+  collector.init_random_frames=10 \
+  collector.frames_per_batch=16 \
+  collector.env_per_collector=2 \
+  collector.device= \
+  optim.batch_size=10 \
+  optim.utd_ratio=1 \
+  replay_buffer.size=120 \
+  env.name=Pendulum-v1 \
+  network.device= \
+  logger.backend=
+""",
     "discrete_sac": """python sota-implementations/discrete_sac/discrete_sac.py \
   collector.total_frames=48 \
   collector.init_random_frames=10 \

--- a/benchmarks/test_objectives_benchmarks.py
+++ b/benchmarks/test_objectives_benchmarks.py
@@ -32,6 +32,7 @@ from torchrl.objectives import (
     ReinforceLoss,
     SACLoss,
     TD3Loss,
+    TQCLoss,
 )
 from torchrl.objectives.deprecated import REDQLoss_deprecated
 from torchrl.objectives.value import GAE
@@ -378,6 +379,111 @@ def test_sac_speed(
             losses = loss(td)
             sum(
                 [val for key, val in losses.items() if key.startswith("loss")]
+            ).backward()
+
+        benchmark.pedantic(
+            loss_and_bw,
+            args=(td,),
+            setup=loss.zero_grad,
+            iterations=1,
+            warmup_rounds=5,
+            rounds=50,
+        )
+    else:
+        benchmark(loss, td)
+
+
+@pytest.mark.parametrize("backward", [None, "backward"])
+@pytest.mark.parametrize("compile", [False, True, "reduce-overhead"])
+def test_tqc_speed(
+    benchmark,
+    backward,
+    compile,
+    n_obs=8,
+    n_act=4,
+    ncells=128,
+    batch=128,
+    n_hidden=64,
+    n_quantiles=25,
+):
+    if compile == "reduce-overhead" and backward is not None:
+        pytest.skip("reduce-overhead with backward causes segfaults in CI")
+    if compile:
+        torch._dynamo.reset_code_caches()
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    common = MLP(
+        num_cells=ncells,
+        in_features=n_obs,
+        depth=3,
+        out_features=n_hidden,
+        device=device,
+    )
+    actor_net = MLP(
+        num_cells=ncells,
+        in_features=n_hidden,
+        depth=2,
+        out_features=2 * n_act,
+        device=device,
+    )
+    critic_net = MLP(
+        in_features=n_hidden + n_act,
+        num_cells=ncells,
+        depth=2,
+        out_features=n_quantiles,
+        device=device,
+    )
+    batch = [batch]
+    td = TensorDict(
+        {
+            "obs": torch.randn(*batch, n_obs),
+            "action": torch.randn(*batch, n_act),
+            "next": {
+                "obs": torch.randn(*batch, n_obs),
+                "reward": torch.randn(*batch, 1),
+                "done": torch.zeros(*batch, 1, dtype=torch.bool),
+                "terminated": torch.zeros(*batch, 1, dtype=torch.bool),
+            },
+        },
+        batch,
+        device=device,
+    )
+    common = Mod(common, in_keys=["obs"], out_keys=["hidden"])
+    actor = ProbSeq(
+        common,
+        Mod(actor_net, in_keys=["hidden"], out_keys=["param"]),
+        Mod(NormalParamExtractor(), in_keys=["param"], out_keys=["loc", "scale"]),
+        ProbMod(
+            in_keys=["loc", "scale"],
+            out_keys=["action"],
+            distribution_class=TanhNormal,
+            distribution_kwargs={"safe_tanh": False},
+        ),
+    )
+    critic = Seq(
+        common,
+        Mod(
+            critic_net,
+            in_keys=["hidden", "action"],
+            out_keys=["state_action_value"],
+        ),
+    )
+    critic(actor(td.clone()))
+    loss = TQCLoss(
+        actor,
+        critic,
+        action_spec=Unbounded(shape=(n_act,)),
+        num_qvalue_nets=5,
+        top_quantiles_to_drop_per_net=2,
+    )
+    loss(td)
+    loss = _maybe_compile(loss, compile, td)
+
+    if backward:
+
+        def loss_and_bw(td):
+            losses = loss(td)
+            sum(
+                value for key, value in losses.items() if key.startswith("loss")
             ).backward()
 
         benchmark.pedantic(

--- a/docs/source/reference/objectives_actorcritic.rst
+++ b/docs/source/reference/objectives_actorcritic.rst
@@ -11,6 +11,7 @@ Loss modules for actor-critic algorithms.
 
     DDPGLoss
     SACLoss
+    TQCLoss
     DiscreteSACLoss
     TD3Loss
     REDQLoss

--- a/sota-check/run_tqc.sh
+++ b/sota-check/run_tqc.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#SBATCH --job-name=tqc
+#SBATCH --ntasks=32
+#SBATCH --cpus-per-task=1
+#SBATCH --gres=gpu:1
+#SBATCH --output=slurm_logs/tqc_%j.txt
+#SBATCH --error=slurm_errors/tqc_%j.txt
+
+current_commit=$(git rev-parse --short HEAD)
+project_name="torchrl-example-check-$current_commit"
+group_name="tqc"
+export PYTHONPATH=$(dirname $(dirname $PWD))
+python $PYTHONPATH/sota-implementations/tqc/tqc.py \
+  logger.backend=wandb \
+  logger.project_name="$project_name" \
+  logger.group_name="$group_name"
+
+# Capture the exit status of the Python command
+exit_status=$?
+# Write the exit status to a file
+if [ $exit_status -eq 0 ]; then
+  echo "${group_name}_${SLURM_JOB_ID}=success" >> report.log
+else
+  echo "${group_name}_${SLURM_JOB_ID}=error" >> report.log
+fi

--- a/sota-check/submitit-release-check.sh
+++ b/sota-check/submitit-release-check.sh
@@ -65,6 +65,7 @@ scripts=(
     run_ppo_mujoco.sh
     run_rnd_mujoco.sh
     run_sac.sh
+    run_tqc.sh
     run_td3.sh
     run_td3bc.sh
     run_dt.sh

--- a/sota-implementations/tqc/config.yaml
+++ b/sota-implementations/tqc/config.yaml
@@ -1,0 +1,59 @@
+env:
+  name: HalfCheetah-v4
+  task: ""
+  library: gymnasium
+  max_episode_steps: 1000
+  seed: 42
+
+collector:
+  total_frames: 1_000_000
+  init_random_frames: 25_000
+  frames_per_batch: 1000
+  device:
+  env_per_collector: 8
+
+replay_buffer:
+  size: 1_000_000
+  prb: False
+  scratch_dir:
+
+optim:
+  utd_ratio: 1.0
+  gamma: 0.99
+  lr: 3.0e-4
+  weight_decay: 0.0
+  batch_size: 256
+  target_update_polyak: 0.995
+  alpha_init: 1.0
+  adam_eps: 1.0e-8
+
+network:
+  actor_hidden_sizes: [256, 256]
+  critic_hidden_sizes: [512, 512, 512]
+  activation: relu
+  default_policy_scale: 1.0
+  scale_lb: 0.1
+  device:
+
+loss:
+  num_qvalue_nets: 5
+  num_quantiles: 25
+  top_quantiles_to_drop_per_net: 2
+
+logger:
+  backend: wandb
+  project_name: torchrl_example_tqc
+  group_name: null
+  exp_name: ${env.name}_TQC
+  mode: online
+  eval_iter: 25_000
+  video: False
+
+compile:
+  compile: False
+  compile_mode:
+  cudagraphs: False
+
+hydra:
+  job:
+    chdir: true

--- a/sota-implementations/tqc/tqc.py
+++ b/sota-implementations/tqc/tqc.py
@@ -1,0 +1,182 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import warnings
+
+import hydra
+import numpy as np
+import torch
+import tqdm
+from omegaconf import DictConfig
+from tensordict import TensorDict
+from tensordict.nn import CudaGraphModule
+
+from torchrl._utils import compile_with_warmup, get_available_device, timeit
+from torchrl.envs.utils import ExplorationType, set_exploration_type
+from torchrl.objectives import group_optimizers
+from torchrl.record.loggers import generate_exp_name, get_logger
+from utils import (
+    dump_video,
+    make_collector,
+    make_environment,
+    make_loss_module,
+    make_optimizers,
+    make_replay_buffer,
+    make_tqc_agent,
+)
+
+torch.set_float32_matmul_precision("high")
+
+
+@hydra.main(version_base="1.3", config_path="", config_name="config")
+def main(cfg: DictConfig):
+    device = (
+        torch.device(cfg.network.device)
+        if cfg.network.device
+        else get_available_device()
+    )
+    logger = None
+    if cfg.logger.backend:
+        experiment_name = generate_exp_name("TQC", cfg.logger.exp_name)
+        logger = get_logger(
+            logger_type=cfg.logger.backend,
+            logger_name="tqc_logging",
+            experiment_name=experiment_name,
+            wandb_kwargs={
+                "mode": cfg.logger.mode,
+                "config": dict(cfg),
+                "project": cfg.logger.project_name,
+                "group": cfg.logger.group_name,
+            },
+        )
+
+    torch.manual_seed(cfg.env.seed)
+    np.random.seed(cfg.env.seed)
+    train_env, eval_env = make_environment(cfg, logger=logger)
+    model, exploration_policy = make_tqc_agent(cfg, train_env, eval_env, device)
+    loss_module, target_updater = make_loss_module(cfg, model)
+
+    compile_mode = None
+    if cfg.compile.compile:
+        compile_mode = cfg.compile.compile_mode
+        if compile_mode in ("", None):
+            compile_mode = "default" if cfg.compile.cudagraphs else "reduce-overhead"
+    collector = make_collector(cfg, train_env, exploration_policy, compile_mode)
+    replay_buffer = make_replay_buffer(cfg, device)
+    actor_optimizer, critic_optimizer, alpha_optimizer = make_optimizers(
+        cfg, loss_module
+    )
+    optimizer = group_optimizers(actor_optimizer, critic_optimizer, alpha_optimizer)
+
+    def update(sampled_tensordict):
+        loss_tensordict = loss_module(sampled_tensordict)
+        if cfg.replay_buffer.prb:
+            loss_tensordict.set(
+                loss_module.tensor_keys.priority,
+                sampled_tensordict.get(loss_module.tensor_keys.priority),
+            )
+        total_loss = (
+            loss_tensordict.get("loss_actor")
+            + loss_tensordict.get("loss_qvalue")
+            + loss_tensordict.get("loss_alpha")
+        )
+        total_loss.backward()
+        optimizer.step()
+        optimizer.zero_grad(set_to_none=True)
+        target_updater.step()
+        return loss_tensordict.detach()
+
+    if cfg.compile.compile:
+        update = compile_with_warmup(update, mode=compile_mode, warmup=1)
+    if cfg.compile.cudagraphs:
+        warnings.warn(
+            "CudaGraphModule is experimental and may lead to silently wrong results.",
+            category=UserWarning,
+        )
+        update = CudaGraphModule(update, in_keys=[], out_keys=[], warmup=5)
+
+    collected_frames = 0
+    progress = tqdm.tqdm(total=cfg.collector.total_frames)
+    num_updates = int(cfg.collector.frames_per_batch * cfg.optim.utd_ratio)
+    total_iterations = len(collector)
+    collector_iterator = iter(collector)
+
+    while collected_frames < cfg.collector.total_frames:
+        timeit.printevery(num_prints=1000, total_count=total_iterations, erase=True)
+        with timeit("collect"):
+            data = next(collector_iterator)
+        collector.update_policy_weights_()
+        current_frames = data.numel()
+        progress.update(current_frames)
+        data = data.reshape(-1)
+        with timeit("rb - extend"):
+            replay_buffer.extend(data)
+        collected_frames += current_frames
+
+        if collected_frames >= cfg.collector.init_random_frames:
+            losses = TensorDict(batch_size=[num_updates])
+            with timeit("train"):
+                for update_index in range(num_updates):
+                    with timeit("rb - sample"):
+                        sampled_data = replay_buffer.sample()
+                    with timeit("update"):
+                        torch.compiler.cudagraph_mark_step_begin()
+                        loss_tensordict = update(sampled_data).clone()
+                    losses[update_index] = loss_tensordict.select(
+                        "loss_actor", "loss_qvalue", "loss_alpha"
+                    )
+                    if cfg.replay_buffer.prb:
+                        sampled_data.set(
+                            loss_module.tensor_keys.priority,
+                            loss_tensordict.get(loss_module.tensor_keys.priority),
+                        )
+                        replay_buffer.update_tensordict_priority(sampled_data)
+
+        episode_end = data.get(("next", "done")) | data.get(("next", "truncated"))
+        episode_rewards = data.get(("next", "episode_reward"))[episode_end]
+        metrics = {}
+        if episode_rewards.numel():
+            episode_lengths = data.get(("next", "step_count"))[episode_end]
+            metrics["train/reward"] = episode_rewards.float().mean()
+            metrics["train/episode_length"] = episode_lengths.float().mean()
+        if collected_frames >= cfg.collector.init_random_frames:
+            losses = losses.mean()
+            metrics["train/q_loss"] = losses.get("loss_qvalue")
+            metrics["train/actor_loss"] = losses.get("loss_actor")
+            metrics["train/alpha_loss"] = losses.get("loss_alpha")
+            metrics["train/alpha"] = loss_tensordict.get("alpha")
+            metrics["train/entropy"] = loss_tensordict.get("entropy")
+
+        if collected_frames % cfg.logger.eval_iter < cfg.collector.frames_per_batch:
+            with (
+                set_exploration_type(ExplorationType.DETERMINISTIC),
+                torch.no_grad(),
+                timeit("eval"),
+            ):
+                rollout = eval_env.rollout(
+                    cfg.env.max_episode_steps,
+                    model[0],
+                    auto_cast_to_device=True,
+                    break_when_any_done=True,
+                )
+                eval_env.apply(dump_video)
+                metrics["eval/reward"] = (
+                    rollout.get(("next", "reward")).sum(-2).mean().item()
+                )
+        if logger is not None:
+            metrics.update(timeit.todict(prefix="time"))
+            metrics["time/speed"] = progress.format_dict["rate"]
+            logger.log_metrics(metrics, collected_frames)
+
+    collector.shutdown()
+    if not eval_env.is_closed:
+        eval_env.close()
+    if not train_env.is_closed:
+        train_env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/sota-implementations/tqc/utils.py
+++ b/sota-implementations/tqc/utils.py
@@ -1,0 +1,237 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import functools
+
+import torch
+from tensordict.nn import InteractionType, TensorDictModule
+from tensordict.nn.distributions import NormalParamExtractor
+from torch import nn, optim
+
+from torchrl.collectors import Collector
+from torchrl.data import (
+    LazyMemmapStorage,
+    LazyTensorStorage,
+    TensorDictPrioritizedReplayBuffer,
+    TensorDictReplayBuffer,
+)
+from torchrl.envs import (
+    CatTensors,
+    Compose,
+    DMControlEnv,
+    DoubleToFloat,
+    EnvCreator,
+    ParallelEnv,
+    TransformedEnv,
+)
+from torchrl.envs.libs.gym import GymEnv, set_gym_backend
+from torchrl.envs.transforms import InitTracker, RewardSum, StepCounter
+from torchrl.envs.utils import ExplorationType, set_exploration_type
+from torchrl.modules import MLP, ProbabilisticActor, ValueOperator
+from torchrl.modules.distributions import TanhNormal
+from torchrl.objectives import SoftUpdate, TQCLoss
+from torchrl.record import VideoRecorder
+
+
+ACTIVATIONS = {
+    "leaky_relu": nn.LeakyReLU,
+    "relu": nn.ReLU,
+    "tanh": nn.Tanh,
+}
+
+
+def env_maker(cfg, device="cpu", from_pixels=False):
+    if cfg.env.library in ("gym", "gymnasium"):
+        with set_gym_backend(cfg.env.library):
+            return GymEnv(
+                cfg.env.name,
+                device=device,
+                from_pixels=from_pixels,
+                pixels_only=False,
+            )
+    if cfg.env.library == "dm_control":
+        env = DMControlEnv(
+            cfg.env.name,
+            cfg.env.task,
+            from_pixels=from_pixels,
+            pixels_only=False,
+        )
+        return TransformedEnv(
+            env, CatTensors(in_keys=env.observation_spec.keys(), out_key="observation")
+        )
+    raise NotImplementedError(f"Unknown environment library {cfg.env.library}.")
+
+
+def apply_env_transforms(env, max_episode_steps=1000):
+    return TransformedEnv(
+        env,
+        Compose(
+            InitTracker(),
+            StepCounter(max_episode_steps),
+            DoubleToFloat(),
+            RewardSum(),
+        ),
+    )
+
+
+def make_environment(cfg, logger=None):
+    env_factory = functools.partial(env_maker, cfg=cfg)
+    parallel_env = ParallelEnv(
+        cfg.collector.env_per_collector,
+        EnvCreator(env_factory),
+        serial_for_single=True,
+    )
+    parallel_env.set_seed(cfg.env.seed)
+    train_env = apply_env_transforms(parallel_env, cfg.env.max_episode_steps)
+
+    eval_factory = functools.partial(env_maker, cfg=cfg, from_pixels=cfg.logger.video)
+    eval_transforms = train_env.transform.clone()
+    if cfg.logger.video:
+        eval_transforms.insert(
+            0, VideoRecorder(logger, tag="rendering/test", in_keys=["pixels"])
+        )
+    eval_env = TransformedEnv(
+        ParallelEnv(
+            cfg.collector.env_per_collector,
+            EnvCreator(eval_factory),
+            serial_for_single=True,
+        ),
+        eval_transforms,
+    )
+    return train_env, eval_env
+
+
+def make_collector(cfg, train_env, exploration_policy, compile_mode):
+    device = cfg.collector.device
+    if device in ("", None):
+        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    collector = Collector(
+        train_env,
+        exploration_policy,
+        init_random_frames=cfg.collector.init_random_frames,
+        frames_per_batch=cfg.collector.frames_per_batch,
+        total_frames=cfg.collector.total_frames,
+        device=device,
+        compile_policy={"mode": compile_mode} if compile_mode else False,
+        cudagraph_policy={"warmup": 10} if cfg.compile.cudagraphs else False,
+    )
+    collector.set_seed(cfg.env.seed)
+    return collector
+
+
+def make_replay_buffer(cfg, device):
+    storage = (
+        LazyTensorStorage(cfg.replay_buffer.size, device=device)
+        if not cfg.replay_buffer.scratch_dir
+        else LazyMemmapStorage(
+            cfg.replay_buffer.size,
+            device="cpu",
+            scratch_dir=cfg.replay_buffer.scratch_dir,
+        )
+    )
+    replay_buffer_class = (
+        TensorDictPrioritizedReplayBuffer
+        if cfg.replay_buffer.prb
+        else TensorDictReplayBuffer
+    )
+    replay_buffer_kwargs = {}
+    if cfg.replay_buffer.prb:
+        replay_buffer_kwargs.update(alpha=0.7, beta=0.5)
+    replay_buffer = replay_buffer_class(
+        storage=storage,
+        batch_size=cfg.optim.batch_size,
+        prefetch=3,
+        **replay_buffer_kwargs,
+    )
+    if cfg.replay_buffer.scratch_dir:
+        replay_buffer.append_transform(lambda data: data.to(device))
+    return replay_buffer
+
+
+def make_tqc_agent(cfg, train_env, eval_env, device):
+    action_spec = train_env.action_spec_unbatched.to(device)
+    activation = ACTIVATIONS[cfg.network.activation]
+    actor_net = nn.Sequential(
+        MLP(
+            num_cells=cfg.network.actor_hidden_sizes,
+            out_features=2 * action_spec.shape[-1],
+            activation_class=activation,
+            device=device,
+        ),
+        NormalParamExtractor(
+            scale_mapping=f"biased_softplus_{cfg.network.default_policy_scale}",
+            scale_lb=cfg.network.scale_lb,
+        ),
+    )
+    actor = ProbabilisticActor(
+        spec=action_spec,
+        in_keys=["loc", "scale"],
+        module=TensorDictModule(
+            actor_net,
+            in_keys=["observation"],
+            out_keys=["loc", "scale"],
+        ),
+        distribution_class=TanhNormal,
+        distribution_kwargs={
+            "low": action_spec.space.low,
+            "high": action_spec.space.high,
+            "tanh_loc": False,
+        },
+        default_interaction_type=InteractionType.RANDOM,
+        return_log_prob=False,
+    )
+    critic = ValueOperator(
+        in_keys=["action", "observation"],
+        module=MLP(
+            num_cells=cfg.network.critic_hidden_sizes,
+            out_features=cfg.loss.num_quantiles,
+            activation_class=activation,
+            device=device,
+        ),
+    )
+    model = nn.ModuleList([actor, critic])
+    with torch.no_grad(), set_exploration_type(ExplorationType.RANDOM):
+        data = eval_env.fake_tensordict().to(device)
+        for network in model:
+            network(data)
+    return model, actor
+
+
+def make_loss_module(cfg, model):
+    loss_module = TQCLoss(
+        actor_network=model[0],
+        qvalue_network=model[1],
+        num_qvalue_nets=cfg.loss.num_qvalue_nets,
+        top_quantiles_to_drop_per_net=cfg.loss.top_quantiles_to_drop_per_net,
+        alpha_init=cfg.optim.alpha_init,
+    )
+    loss_module.make_value_estimator(gamma=cfg.optim.gamma)
+    target_updater = SoftUpdate(loss_module, eps=cfg.optim.target_update_polyak)
+    return loss_module, target_updater
+
+
+def make_optimizers(cfg, loss_module):
+    actor_parameters = loss_module.actor_network_params.flatten_keys().values()
+    critic_parameters = loss_module.qvalue_network_params.flatten_keys().values()
+    actor_optimizer = optim.Adam(
+        actor_parameters,
+        lr=cfg.optim.lr,
+        weight_decay=cfg.optim.weight_decay,
+        eps=cfg.optim.adam_eps,
+    )
+    critic_optimizer = optim.Adam(
+        critic_parameters,
+        lr=cfg.optim.lr,
+        weight_decay=cfg.optim.weight_decay,
+        eps=cfg.optim.adam_eps,
+    )
+    alpha_optimizer = optim.Adam([loss_module.log_alpha], lr=cfg.optim.lr)
+    return actor_optimizer, critic_optimizer, alpha_optimizer
+
+
+def dump_video(module):
+    if isinstance(module, VideoRecorder):
+        module.dump()

--- a/torchrl/objectives/__init__.py
+++ b/torchrl/objectives/__init__.py
@@ -39,6 +39,7 @@ from torchrl.objectives.rnd import RNDLoss
 from torchrl.objectives.sac import DiscreteSACLoss, SACLoss
 from torchrl.objectives.td3 import TD3Loss
 from torchrl.objectives.td3_bc import TD3BCLoss
+from torchrl.objectives.tqc import TQCLoss
 from torchrl.objectives.utils import (
     default_value_kwargs,
     distance_loss,
@@ -93,6 +94,7 @@ __all__ = [
     "TD3BCLoss",
     "TD3Loss",
     "TargetNetUpdater",
+    "TQCLoss",
     "ValueEstimators",
     "WorldModelLoss",
     "add_random_module",

--- a/torchrl/objectives/tqc.py
+++ b/torchrl/objectives/tqc.py
@@ -13,7 +13,7 @@ from torch import Tensor
 
 from torchrl.data.tensor_specs import TensorSpec
 from torchrl.envs.utils import ExplorationType, set_exploration_type
-from torchrl.objectives.sac import compute_log_prob, SACLoss
+from torchrl.objectives.sac import compute_rsample_log_prob, SACLoss
 from torchrl.objectives.utils import ValueEstimators
 
 
@@ -188,8 +188,7 @@ class TQCLoss(SACLoss):
             ),
         ):
             distribution = self.actor_network.get_dist(tensordict)
-            action = distribution.rsample()
-        log_prob = compute_log_prob(distribution, action, self.tensor_keys.log_prob)
+            action, log_prob = compute_rsample_log_prob(distribution)
 
         critic_input = tensordict.select(*self.qvalue_network.in_keys, strict=False)
         critic_input.set(self.tensor_keys.action, action)
@@ -235,12 +234,11 @@ class TQCLoss(SACLoss):
                     selection = ~terminated.squeeze(-1)
                     selected_tensordict = next_tensordict[selection]
             distribution = self.actor_network.get_dist(selected_tensordict)
-            action = distribution.rsample()
-            log_prob = (
-                compute_log_prob(distribution, action, self.tensor_keys.log_prob)
-                if selected_tensordict.batch_size.numel()
-                else None
-            )
+            if selected_tensordict.batch_size.numel():
+                action, log_prob = compute_rsample_log_prob(distribution)
+            else:
+                action = distribution.rsample()
+                log_prob = None
             selected_tensordict.set(self.tensor_keys.action, action)
             critic_output = self._vmap_qnetworkN0(
                 selected_tensordict, self.target_qvalue_network_params

--- a/torchrl/objectives/tqc.py
+++ b/torchrl/objectives/tqc.py
@@ -1,0 +1,347 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+from tensordict import TensorDictBase
+from tensordict.nn import ProbabilisticTensorDictSequential, TensorDictModule
+from torch import Tensor
+
+from torchrl.data.tensor_specs import TensorSpec
+from torchrl.envs.utils import ExplorationType, set_exploration_type
+from torchrl.objectives.sac import compute_log_prob, SACLoss
+from torchrl.objectives.utils import ValueEstimators
+
+
+class TQCLoss(SACLoss):
+    r"""Truncated Quantile Critics loss.
+
+    TQC critics predict return quantiles instead of one value. Bellman targets
+    pool every target critic's atoms, discard the highest from the shared pool,
+    and train each critic on what remains. The actor uses the full mixture.
+
+    See `Kuznetsov et al. (2020), Controlling Overestimation Bias with
+    Truncated Mixture of Continuous Distributional Quantile Critics
+    <https://arxiv.org/abs/2005.04269>`_.
+
+    Args:
+        actor_network (ProbabilisticTensorDictSequential): policy used to
+            sample actions and score their entropy.
+        qvalue_network (TensorDictModule or list of TensorDictModule):
+            critic whose last output dimension holds return atoms. One module
+            is copied across the ensemble; a list supplies each critic, as in
+            :class:`~torchrl.objectives.SACLoss`.
+
+    Keyword Args:
+        num_qvalue_nets (int, optional): ensemble size for one critic module.
+            Defaults to ``5``.
+        top_quantiles_to_drop_per_net (int, optional): upper atoms discarded per
+            critic from the pooled target. The total is this value times the
+            ensemble size. Defaults to ``2``.
+        alpha_init (float, optional): initial entropy temperature. Defaults to
+            ``1.0``.
+        min_alpha (float, optional): temperature floor. Defaults to ``None``.
+        max_alpha (float, optional): temperature ceiling. Defaults to ``None``.
+        action_spec (TensorSpec, optional): action domain for automatic target
+            entropy. Defaults to the actor's spec.
+        fixed_alpha (bool, optional): disable temperature learning. Defaults to
+            ``False``.
+        target_entropy (float or ``"auto"``, optional): entropy target.
+            Defaults to ``"auto"``.
+        delay_qvalue (bool, optional): maintain delayed target critics.
+            Defaults to ``True``.
+        separate_losses (bool, optional): exclude shared actor parameters from
+            critic training. Defaults to ``False``.
+        reduction (str, optional): ``"none"``, ``"mean"``, or
+            ``"sum"``. Defaults to ``"mean"``.
+        deactivate_vmap (bool, optional): loop over critics instead of using
+            ``vmap``. Defaults to ``False``.
+        skip_done_states (bool, optional): skip terminal next-state evaluation.
+            Defaults to ``False``.
+        use_prioritized_weights (bool or ``"auto"``, optional): use replay
+            weights when present. Defaults to ``"auto"``.
+        scalar_output_mode (str, optional): scalar handling when
+            ``reduction="none"``. See :class:`~torchrl.objectives.SACLoss`.
+
+    .. note::
+        Among TorchRL's built-in value estimators, TQC supports only
+        :class:`~torchrl.objectives.value.TD0Estimator`. Reward and termination
+        leaves are explicitly expanded to the target-atom shape so the value
+        estimator retains its strict shape checks.
+
+    Examples:
+        >>> import torch
+        >>> from torch import nn
+        >>> from tensordict import TensorDict
+        >>> from tensordict.nn import NormalParamExtractor, TensorDictModule
+        >>> from torchrl.data import Bounded
+        >>> from torchrl.modules import MLP, ProbabilisticActor, ValueOperator
+        >>> from torchrl.modules.distributions import TanhNormal
+        >>> from torchrl.objectives import SoftUpdate, TQCLoss
+        >>> n_obs, n_act, n_quantiles = 3, 2, 8
+        >>> action_spec = Bounded(-1, 1, (n_act,))
+        >>> actor_net = nn.Sequential(
+        ...     nn.Linear(n_obs, 2 * n_act), NormalParamExtractor()
+        ... )
+        >>> actor = ProbabilisticActor(
+        ...     TensorDictModule(
+        ...         actor_net,
+        ...         in_keys=["observation"],
+        ...         out_keys=["loc", "scale"],
+        ...     ),
+        ...     in_keys=["loc", "scale"],
+        ...     spec=action_spec,
+        ...     distribution_class=TanhNormal,
+        ... )
+        >>> critic = ValueOperator(
+        ...     MLP(
+        ...         in_features=n_obs + n_act,
+        ...         out_features=n_quantiles,
+        ...         num_cells=[],
+        ...     ),
+        ...     in_keys=["observation", "action"],
+        ... )
+        >>> loss = TQCLoss(actor, critic, num_qvalue_nets=2)
+        >>> loss.make_value_estimator(gamma=0.99)
+        >>> target_updater = SoftUpdate(loss, eps=0.995)
+        >>> batch = TensorDict(
+        ...     {
+        ...         "observation": torch.randn(4, n_obs),
+        ...         "action": action_spec.rand((4,)),
+        ...         "next": {
+        ...             "observation": torch.randn(4, n_obs),
+        ...             "reward": torch.randn(4, 1),
+        ...             "done": torch.zeros(4, 1, dtype=torch.bool),
+        ...             "terminated": torch.zeros(4, 1, dtype=torch.bool),
+        ...         },
+        ...     },
+        ...     batch_size=[4],
+        ... )
+        >>> output = loss(batch)
+        >>> output.get("loss_qvalue").shape
+        torch.Size([])
+    """
+
+    SUPPORTED_VALUE_ESTIMATORS = (ValueEstimators.TD0,)
+
+    def __init__(
+        self,
+        actor_network: ProbabilisticTensorDictSequential,
+        qvalue_network: TensorDictModule | list[TensorDictModule],
+        *,
+        num_qvalue_nets: int = 5,
+        top_quantiles_to_drop_per_net: int = 2,
+        alpha_init: float = 1.0,
+        min_alpha: float | None = None,
+        max_alpha: float | None = None,
+        action_spec: TensorSpec | None = None,
+        fixed_alpha: bool = False,
+        target_entropy: Literal["auto"] | float = "auto",
+        delay_qvalue: bool = True,
+        separate_losses: bool = False,
+        reduction: Literal["none", "mean", "sum"] | None = None,
+        deactivate_vmap: bool = False,
+        skip_done_states: bool = False,
+        use_prioritized_weights: Literal["auto"] | bool = "auto",
+        scalar_output_mode: Literal["exclude", "non_tensor"] | None = None,
+    ) -> None:
+        if num_qvalue_nets < 1:
+            raise ValueError("num_qvalue_nets must be greater than zero.")
+        if top_quantiles_to_drop_per_net < 0:
+            raise ValueError(
+                "top_quantiles_to_drop_per_net must be greater than or equal to zero."
+            )
+        self.top_quantiles_to_drop_per_net = top_quantiles_to_drop_per_net
+        super().__init__(
+            actor_network=actor_network,
+            qvalue_network=qvalue_network,
+            num_qvalue_nets=num_qvalue_nets,
+            loss_function="smooth_l1",
+            alpha_init=alpha_init,
+            min_alpha=min_alpha,
+            max_alpha=max_alpha,
+            action_spec=action_spec,
+            fixed_alpha=fixed_alpha,
+            target_entropy=target_entropy,
+            delay_actor=False,
+            delay_qvalue=delay_qvalue,
+            separate_losses=separate_losses,
+            reduction=reduction,
+            deactivate_vmap=deactivate_vmap,
+            skip_done_states=skip_done_states,
+            use_prioritized_weights=use_prioritized_weights,
+            scalar_output_mode=scalar_output_mode,
+        )
+
+    def actor_loss(
+        self, tensordict: TensorDictBase
+    ) -> tuple[Tensor, dict[str, Tensor]]:
+        weights = self._maybe_get_priority_weight(tensordict)
+        with (
+            set_exploration_type(ExplorationType.RANDOM),
+            self.actor_network_params.to_module(
+                self.actor_network, preserve_module_state=False
+            ),
+        ):
+            distribution = self.actor_network.get_dist(tensordict)
+            action = distribution.rsample()
+        log_prob = compute_log_prob(distribution, action, self.tensor_keys.log_prob)
+
+        critic_input = tensordict.select(*self.qvalue_network.in_keys, strict=False)
+        critic_input.set(self.tensor_keys.action, action)
+        critic_output = self._vmap_qnetworkN0(
+            critic_input, self._cached_detached_qvalue_params
+        )
+        quantiles = critic_output.get(self.tensor_keys.state_action_value)
+        expected_ndim = tensordict.ndim + 2
+        if quantiles.ndim != expected_ndim:
+            raise RuntimeError(
+                "The TQC critic must output one quantile dimension after the "
+                f"TensorDict batch dimensions, but got shape {quantiles.shape}."
+            )
+        # Policy gradients use the whole mixture; only Bellman targets are cut.
+        qvalue = quantiles.mean(dim=(0, -1))
+        if log_prob.shape != qvalue.shape:
+            raise RuntimeError(
+                f"Actor log-probability and critic value shapes differ: "
+                f"{log_prob.shape} and {qvalue.shape}."
+            )
+        loss_actor = self._alpha * log_prob - qvalue
+        loss_actor = self._reduce_loss(
+            loss_actor, tensordict=tensordict, weights=weights
+        )
+        return loss_actor, {"log_prob": log_prob.detach()}
+
+    def compute_target(self, tensordict: TensorDictBase) -> Tensor:
+        steps_key = self.value_estimator.tensor_keys.steps_to_next_obs
+        target_tensordict = tensordict.select("next", steps_key, strict=False).clone()
+        with (
+            torch.no_grad(),
+            set_exploration_type(ExplorationType.RANDOM),
+            self.actor_network_params.to_module(
+                self.actor_network, preserve_module_state=False
+            ),
+        ):
+            next_tensordict = target_tensordict.get("next")
+            selection = None
+            selected_tensordict = next_tensordict
+            if self.skip_done_states:
+                terminated = next_tensordict.get(self.tensor_keys.terminated)
+                if terminated.any():
+                    selection = ~terminated.squeeze(-1)
+                    selected_tensordict = next_tensordict[selection]
+            distribution = self.actor_network.get_dist(selected_tensordict)
+            action = distribution.rsample()
+            log_prob = (
+                compute_log_prob(distribution, action, self.tensor_keys.log_prob)
+                if selected_tensordict.batch_size.numel()
+                else None
+            )
+            selected_tensordict.set(self.tensor_keys.action, action)
+            critic_output = self._vmap_qnetworkN0(
+                selected_tensordict, self.target_qvalue_network_params
+            )
+            quantiles = critic_output.get(self.tensor_keys.state_action_value)
+            expected_ndim = selected_tensordict.ndim + 2
+            if quantiles.ndim != expected_ndim:
+                raise RuntimeError(
+                    "The TQC critic must output one quantile dimension after the "
+                    f"TensorDict batch dimensions, but got shape {quantiles.shape}."
+                )
+            if log_prob is None:
+                log_prob = quantiles.new_zeros(quantiles.shape[1:-1])
+            # Pool critics before trimming; trimming each critic is a different method.
+            quantiles = quantiles.movedim(0, -2).flatten(-2)
+            quantiles_to_drop = (
+                self.top_quantiles_to_drop_per_net * self.num_qvalue_nets
+            )
+            quantiles_to_keep = quantiles.shape[-1] - quantiles_to_drop
+            if quantiles_to_keep < 1:
+                raise ValueError(
+                    "top_quantiles_to_drop_per_net must be smaller than the "
+                    f"critic's number of quantiles ({quantiles.shape[-1] // self.num_qvalue_nets})."
+                )
+            quantiles = torch.sort(quantiles, dim=-1).values[..., :quantiles_to_keep]
+            if log_prob.shape != quantiles.shape[:-1]:
+                raise RuntimeError(
+                    f"Actor log-probability and target critic batch shapes differ: "
+                    f"{log_prob.shape} and {quantiles.shape[:-1]}."
+                )
+            next_value = quantiles - self._alpha * log_prob.unsqueeze(-1)
+            if selection is not None:
+                full_shape = (*tensordict.batch_size, next_value.shape[-1])
+                selection = selection.unsqueeze(-1).expand(full_shape)
+                next_value = next_value.new_zeros(full_shape).masked_scatter_(
+                    selection, next_value
+                )
+
+            # TD0 checks shapes strictly, so every retained atom gets its own entry.
+            for key in (
+                self.tensor_keys.reward,
+                self.tensor_keys.terminated,
+            ):
+                nested_key = ("next", *key) if isinstance(key, tuple) else ("next", key)
+                value = target_tensordict.get(nested_key)
+                while value.ndim < next_value.ndim:
+                    value = value.unsqueeze(-1)
+                target_tensordict.set(nested_key, value.expand_as(next_value))
+            steps = target_tensordict.get(steps_key, None)
+            if steps is not None:
+                while steps.ndim < next_value.ndim:
+                    steps = steps.unsqueeze(-1)
+                target_tensordict.set(steps_key, steps.expand_as(next_value))
+            return self.value_estimator.value_estimate(
+                target_tensordict, next_value=next_value
+            )
+
+    def qvalue_v2_loss(
+        self, tensordict: TensorDictBase
+    ) -> tuple[Tensor, dict[str, Tensor]]:
+        weights = self._maybe_get_priority_weight(tensordict)
+        target_quantiles = self.compute_target(tensordict)
+        critic_input = tensordict.select(*self.qvalue_network.in_keys, strict=False)
+        critic_output = self._vmap_qnetworkN0(critic_input, self.qvalue_network_params)
+        quantiles = critic_output.get(self.tensor_keys.state_action_value)
+        expected_ndim = tensordict.ndim + 2
+        if quantiles.ndim != expected_ndim:
+            raise RuntimeError(
+                "The TQC critic must output one quantile dimension after the "
+                f"TensorDict batch dimensions, but got shape {quantiles.shape}."
+            )
+        if target_quantiles.shape[:-1] != quantiles.shape[1:-1]:
+            raise RuntimeError(
+                f"Target and predicted critic batch shapes differ: "
+                f"{target_quantiles.shape[:-1]} and {quantiles.shape[1:-1]}."
+            )
+
+        # Regress every predicted quantile against every retained target atom.
+        pairwise_delta = target_quantiles.unsqueeze(0).unsqueeze(
+            -2
+        ) - quantiles.unsqueeze(-1)
+        absolute_delta = pairwise_delta.abs()
+        huber_loss = torch.where(
+            absolute_delta <= 1,
+            0.5 * pairwise_delta.square(),
+            absolute_delta - 0.5,
+        )
+        num_quantiles = quantiles.shape[-1]
+        quantile_fractions = (
+            torch.arange(num_quantiles, device=quantiles.device, dtype=quantiles.dtype)
+            + 0.5
+        ) / num_quantiles
+        quantile_fractions = quantile_fractions.view(
+            *([1] * (pairwise_delta.ndim - 2)), num_quantiles, 1
+        )
+        quantile_weights = (
+            quantile_fractions - (pairwise_delta.detach() < 0).to(quantiles.dtype)
+        ).abs()
+        loss_qvalue = (quantile_weights * huber_loss).mean(dim=(-1, -2)).sum(0)
+        loss_qvalue = self._reduce_loss(
+            loss_qvalue, tensordict=tensordict, weights=weights
+        )
+        td_error = absolute_delta.detach().mean(dim=(-1, -2)).max(0).values
+        return loss_qvalue, {"td_error": td_error}

--- a/torchrl/trainers/algorithms/configs/__init__.py
+++ b/torchrl/trainers/algorithms/configs/__init__.py
@@ -124,6 +124,7 @@ from torchrl.trainers.algorithms.configs.objectives import (
     SACLossConfig,
     SoftUpdateConfig,
     TD3LossConfig,
+    TQCLossConfig,
 )
 from torchrl.trainers.algorithms.configs.trainers import (
     A2CTrainerConfig,
@@ -409,6 +410,7 @@ __all__ = [
     "ReinforceLossConfig",
     "SACLossConfig",
     "TD3LossConfig",
+    "TQCLossConfig",
     # Value functions
     "GAEConfig",
     # Trainers
@@ -637,6 +639,7 @@ def _register_configs():
     cs.store(group="loss", name="reinforce", node=ReinforceLossConfig)
     cs.store(group="loss", name="sac", node=SACLossConfig)
     cs.store(group="loss", name="td3", node=TD3LossConfig)
+    cs.store(group="loss", name="tqc", node=TQCLossConfig)
 
     # =============================================================================
     # Value Function Configurations

--- a/torchrl/trainers/algorithms/configs/objectives.py
+++ b/torchrl/trainers/algorithms/configs/objectives.py
@@ -108,6 +108,31 @@ def _make_sac_loss(*args, **kwargs) -> SACLoss:
     return loss
 
 
+# Keep these fields in TQCLoss constructor order so Hydra exposes every option.
+@dataclass
+class TQCLossConfig(LossConfig):
+    """Hydra fields for :class:`~torchrl.objectives.TQCLoss`."""
+
+    actor_network: Any = None
+    qvalue_network: Any = None
+    num_qvalue_nets: int = 5
+    top_quantiles_to_drop_per_net: int = 2
+    alpha_init: float = 1.0
+    min_alpha: float | None = None
+    max_alpha: float | None = None
+    action_spec: Any = None
+    fixed_alpha: bool = False
+    target_entropy: str | float = "auto"
+    delay_qvalue: bool = True
+    separate_losses: bool = False
+    reduction: str | None = None
+    deactivate_vmap: bool = False
+    skip_done_states: bool = False
+    use_prioritized_weights: str | bool = "auto"
+    scalar_output_mode: str | None = None
+    _target_: str = "torchrl.objectives.TQCLoss"
+
+
 @dataclass
 class PPOLossConfig(LossConfig):
     """Hydra configuration for the PPO loss family.


### PR DESCRIPTION
## Summary

Add a reusable [`TQCLoss`](https://proceedings.mlr.press/v119/kuznetsov20a.html), a SAC-shaped HalfCheetah example, and an objective benchmark. The loss belongs in `torchrl.objectives`: pooled target truncation and quantile regression must follow TorchRL's functional-parameter, target-update, key-remapping, and value-estimation contracts.

<details><summary>Testing + notes</summary>
<p>

Environment: H100 80 GB, PyTorch 2.11.0+cu130.

- Numerical contracts: `7 passed`; public doctest: `1 passed`.
- Explicit critic lists pass with `SoftUpdate`, `[2, 3]` batches, and vectorized or looped evaluation.
- Eager, CUDA-graph, and compiled prioritized-memmap 50k-frame runs exit 0.
- Prioritized replay received varying finite `[256]` priorities for 3,000 CUDA-graph updates.
- Full objectives: `111 failed, 8021 passed, 2327 skipped`. Every failure is an existing CUDA tolerance in `test_values.py`; the representative failure reproduces unchanged on upstream `main`.
- All pre-commit hooks pass.

### Testing + Some Notes

**Good news: The TQC implementation works great. Bad news: there was a different bug from an old issue which affected TQC performance that I will fix in a follow-up.**

Three compiled 1M-frame seeds completed. Final-five evaluation means were 12,175 / 10,501 / 13,282. Seed 42 recovered from an entropy/critic explosion; seed 43 ended during one (`-588` final return). This matches the open `TanhNormal` instability in #2199, so this PR does not add a TQC-specific workaround.


<img width="1120" height="672" alt="tqc_learning_curve" src="https://github.com/user-attachments/assets/ed1aa97f-6318-4713-96a9-6b8ad8ec0924" />

<img width="1400" height="980" alt="tqc_training_diagnostics" src="https://github.com/user-attachments/assets/703bbcaf-9136-4c49-8796-3d1f55ca6a25" />

### Performance

`5 passed, 1 expected skip` in 33.41 s.

| loss path | median | IQR |
|---|---:|---:|
| eager forward | 7.298 ms | 0.137 ms |
| eager backward | 9.584 ms | 0.149 ms |
| compiled forward | 1.262 ms | 0.024 ms |
| compiled backward | 2.528 ms | 0.026 ms |
| reduce-overhead forward | 8.674 ms | 6.736 ms |

<img width="1120" height="672" alt="tqc_h100_benchmark" src="https://github.com/user-attachments/assets/71bf3903-b666-45d2-bb35-1d3eeeb24cff" />

</p>
</details> 

cc @vmoens 