### PR TITLE
[BugFix] Fix TanhNormal sample scoring at tanh saturation

### DIFF
--- a/docs/source/reference/modules_distributions.rst
+++ b/docs/source/reference/modules_distributions.rst
@@ -18,3 +18,16 @@ Custom distribution classes for RL, extending PyTorch distributions.
     TanhDelta
     TanhNormal
     TruncatedNormal
+
+Sampling utilities
+==================
+
+.. currentmodule:: torchrl.modules.distributions.utils
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template_fun.rst
+
+    sample_and_log_prob
+    rsample_and_log_prob
+    composite_entropy

--- a/test/modules/test_actor.py
+++ b/test/modules/test_actor.py
@@ -30,7 +30,6 @@ from torchrl.modules import (
     MultiStepActorWrapper,
     ProbabilisticActor,
     SafeModule,
-    SafeProbabilisticModule,
     TanhDelta,
     TanhModule,
     TanhNormal,
@@ -46,33 +45,6 @@ from torchrl.modules.vla import LeRobotPolicyWrapper, TinyVLA, VLAWrapperBase
 
 from torchrl.testing import get_default_devices
 from torchrl.testing.mocking_classes import CountingEnv, NestedCountingEnv
-
-
-@pytest.mark.parametrize("device", get_default_devices())
-@pytest.mark.parametrize("num_samples", [None, 3])
-def test_probabilistic_module_tanhnormal_joint_log_prob(device, num_samples):
-    loc = torch.tensor([[20.0, -20.0]], device=device)
-    scale = torch.full_like(loc, 0.1)
-    module = SafeProbabilisticModule(
-        in_keys=["loc", "scale"],
-        out_keys=["action"],
-        distribution_class=TanhNormal,
-        default_interaction_type=InteractionType.RANDOM,
-        return_log_prob=True,
-        log_prob_key="sample_log_prob",
-        num_samples=num_samples,
-        generator=torch.Generator(device=device).manual_seed(0),
-    )
-
-    torch.manual_seed(0)
-    sample_shape = torch.Size() if num_samples is None else (num_samples,)
-    expected_action, expected_log_prob = TanhNormal(loc, scale).rsample_and_log_prob(
-        sample_shape
-    )
-    result = module(TensorDict({"loc": loc, "scale": scale}, batch_size=[1]))
-
-    torch.testing.assert_close(result["action"], expected_action)
-    torch.testing.assert_close(result["sample_log_prob"], expected_log_prob)
 
 
 @pytest.mark.parametrize(

--- a/test/modules/test_actor.py
+++ b/test/modules/test_actor.py
@@ -30,6 +30,7 @@ from torchrl.modules import (
     MultiStepActorWrapper,
     ProbabilisticActor,
     SafeModule,
+    SafeProbabilisticModule,
     TanhDelta,
     TanhModule,
     TanhNormal,
@@ -45,6 +46,40 @@ from torchrl.modules.vla import LeRobotPolicyWrapper, TinyVLA, VLAWrapperBase
 
 from torchrl.testing import get_default_devices
 from torchrl.testing.mocking_classes import CountingEnv, NestedCountingEnv
+
+
+@pytest.mark.parametrize("device", get_default_devices())
+@pytest.mark.parametrize("num_samples", [None, 3])
+def test_probabilistic_module_tanhnormal_joint_log_prob(
+    device, num_samples, monkeypatch
+):
+    loc = torch.tensor([[20.0, -20.0]], device=device)
+    scale = torch.full_like(loc, 0.1)
+    module = SafeProbabilisticModule(
+        in_keys=["loc", "scale"],
+        out_keys=["action"],
+        distribution_class=TanhNormal,
+        default_interaction_type=InteractionType.RANDOM,
+        return_log_prob=True,
+        log_prob_key="sample_log_prob",
+        num_samples=num_samples,
+        generator=torch.Generator(device=device).manual_seed(0),
+    )
+
+    sample_shape = torch.Size() if num_samples is None else (num_samples,)
+    torch.manual_seed(0)
+    expected_action, expected_log_prob = TanhNormal(loc, scale).rsample_and_log_prob(
+        sample_shape
+    )
+
+    def fail_log_prob(*args, **kwargs):
+        raise AssertionError("a freshly sampled TanhNormal was inverse-scored")
+
+    monkeypatch.setattr(TanhNormal, "log_prob", fail_log_prob)
+    result = module(TensorDict({"loc": loc, "scale": scale}, batch_size=[1]))
+
+    torch.testing.assert_close(result["action"], expected_action)
+    torch.testing.assert_close(result["sample_log_prob"], expected_log_prob)
 
 
 @pytest.mark.parametrize(

--- a/test/modules/test_actor.py
+++ b/test/modules/test_actor.py
@@ -30,6 +30,7 @@ from torchrl.modules import (
     MultiStepActorWrapper,
     ProbabilisticActor,
     SafeModule,
+    SafeProbabilisticModule,
     TanhDelta,
     TanhModule,
     TanhNormal,
@@ -45,6 +46,33 @@ from torchrl.modules.vla import LeRobotPolicyWrapper, TinyVLA, VLAWrapperBase
 
 from torchrl.testing import get_default_devices
 from torchrl.testing.mocking_classes import CountingEnv, NestedCountingEnv
+
+
+@pytest.mark.parametrize("device", get_default_devices())
+@pytest.mark.parametrize("num_samples", [None, 3])
+def test_probabilistic_module_tanhnormal_joint_log_prob(device, num_samples):
+    loc = torch.tensor([[20.0, -20.0]], device=device)
+    scale = torch.full_like(loc, 0.1)
+    module = SafeProbabilisticModule(
+        in_keys=["loc", "scale"],
+        out_keys=["action"],
+        distribution_class=TanhNormal,
+        default_interaction_type=InteractionType.RANDOM,
+        return_log_prob=True,
+        log_prob_key="sample_log_prob",
+        num_samples=num_samples,
+        generator=torch.Generator(device=device).manual_seed(0),
+    )
+
+    torch.manual_seed(0)
+    sample_shape = torch.Size() if num_samples is None else (num_samples,)
+    expected_action, expected_log_prob = TanhNormal(loc, scale).rsample_and_log_prob(
+        sample_shape
+    )
+    result = module(TensorDict({"loc": loc, "scale": scale}, batch_size=[1]))
+
+    torch.testing.assert_close(result["action"], expected_action)
+    torch.testing.assert_close(result["sample_log_prob"], expected_log_prob)
 
 
 @pytest.mark.parametrize(

--- a/test/objectives/test_cql.py
+++ b/test/objectives/test_cql.py
@@ -148,6 +148,22 @@ class TestCQL(LossModuleTestBase):
         )
         self.reset_parameters_recursive_test(loss_fn)
 
+    def test_cql_actor_uses_joint_sample_log_prob(self, monkeypatch):
+        torch.manual_seed(self.seed)
+        td = self._create_mock_data_cql()
+        loss_fn = CQLLoss(
+            actor_network=self._create_mock_actor(),
+            qvalue_network=self._create_mock_qvalue(),
+        )
+
+        def fail_log_prob(*args, **kwargs):
+            raise AssertionError("CQL inverse-scored a freshly sampled TanhNormal")
+
+        monkeypatch.setattr(TanhNormal, "log_prob", fail_log_prob)
+        actor_loss, metadata = loss_fn.actor_loss(td)
+        assert actor_loss.isfinite().all()
+        assert metadata[loss_fn.tensor_keys.log_prob].isfinite().all()
+
     @pytest.mark.parametrize("delay_actor", (True, False))
     @pytest.mark.parametrize("delay_qvalue", (True, True))
     @pytest.mark.parametrize("max_q_backup", [True, False])

--- a/test/objectives/test_sac.py
+++ b/test/objectives/test_sac.py
@@ -1281,6 +1281,28 @@ class TestSAC(LossModuleTestBase):
         )
         loss.load_state_dict(state)
 
+    def test_sac_uses_joint_sample_log_prob(self, version, monkeypatch):
+        torch.manual_seed(self.seed)
+        td = self._create_mock_data_sac()
+        actor = self._create_mock_actor()
+        qvalue = self._create_mock_qvalue()
+        value = self._create_mock_value() if version == 1 else None
+        loss = SACLoss(
+            actor_network=actor,
+            qvalue_network=qvalue,
+            value_network=value,
+        )
+
+        def fail_log_prob(*args, **kwargs):
+            raise AssertionError("SAC rescored a newly sampled action")
+
+        monkeypatch.setattr(TanhNormal, "log_prob", fail_log_prob)
+        with pytest.warns(
+            UserWarning, match="No target network updater"
+        ) if rl_warnings() else contextlib.nullcontext():
+            result = loss(td)
+        assert result.isfinite().all()
+
     @pytest.mark.parametrize("action_dim", [1, 2, 4, 8])
     def test_sac_target_entropy_auto(self, version, action_dim):
         """Regression test for issue #3291: target_entropy='auto' should be -dim(A)."""

--- a/test/objectives/test_sac.py
+++ b/test/objectives/test_sac.py
@@ -1281,28 +1281,6 @@ class TestSAC(LossModuleTestBase):
         )
         loss.load_state_dict(state)
 
-    def test_sac_uses_joint_sample_log_prob(self, version, monkeypatch):
-        torch.manual_seed(self.seed)
-        td = self._create_mock_data_sac()
-        actor = self._create_mock_actor()
-        qvalue = self._create_mock_qvalue()
-        value = self._create_mock_value() if version == 1 else None
-        loss = SACLoss(
-            actor_network=actor,
-            qvalue_network=qvalue,
-            value_network=value,
-        )
-
-        def fail_log_prob(*args, **kwargs):
-            raise AssertionError("SAC rescored a newly sampled action")
-
-        monkeypatch.setattr(TanhNormal, "log_prob", fail_log_prob)
-        with pytest.warns(
-            UserWarning, match="No target network updater"
-        ) if rl_warnings() else contextlib.nullcontext():
-            result = loss(td)
-        assert result.isfinite().all()
-
     @pytest.mark.parametrize("action_dim", [1, 2, 4, 8])
     def test_sac_target_entropy_auto(self, version, action_dim):
         """Regression test for issue #3291: target_entropy='auto' should be -dim(A)."""

--- a/test/objectives/test_sac.py
+++ b/test/objectives/test_sac.py
@@ -1281,6 +1281,28 @@ class TestSAC(LossModuleTestBase):
         )
         loss.load_state_dict(state)
 
+    def test_sac_uses_joint_sample_log_prob(self, version, monkeypatch):
+        torch.manual_seed(self.seed)
+        td = self._create_mock_data_sac()
+        actor = self._create_mock_actor()
+        qvalue = self._create_mock_qvalue()
+        value = self._create_mock_value() if version == 1 else None
+        loss = SACLoss(
+            actor_network=actor,
+            qvalue_network=qvalue,
+            value_network=value,
+        )
+
+        def fail_log_prob(*args, **kwargs):
+            raise AssertionError("SAC inverse-scored a freshly sampled TanhNormal")
+
+        monkeypatch.setattr(TanhNormal, "log_prob", fail_log_prob)
+        with pytest.warns(
+            UserWarning, match="No target network updater"
+        ) if rl_warnings() else contextlib.nullcontext():
+            result = loss(td)
+        assert result.isfinite().all()
+
     @pytest.mark.parametrize("action_dim", [1, 2, 4, 8])
     def test_sac_target_entropy_auto(self, version, action_dim):
         """Regression test for issue #3291: target_entropy='auto' should be -dim(A)."""

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -149,7 +149,7 @@ class TestTanhNormal:
     @pytest.mark.parametrize("safe_tanh", [False, True])
     @pytest.mark.parametrize("compiled", [False, True])
     @pytest.mark.parametrize("device", get_default_devices())
-    def test_tanhnormal_rsample_log_prob_consistency(
+    def test_tanhnormal_rsample_and_log_prob(
         self, dtype, low, high, safe_tanh, compiled, device
     ):
         if compiled and sys.version_info >= (3, 14):
@@ -178,26 +178,7 @@ class TestTanhNormal:
                 event_dims=1,
                 safe_tanh=safe_tanh,
             )
-            sample = dist.rsample()
-            log_prob = dist.log_prob(sample)
-            dist.log_prob(torch.zeros_like(sample))
-            rescored_log_prob = dist.log_prob(sample)
-            mutated_dist = TanhNormal(
-                loc=loc,
-                scale=scale,
-                low=low,
-                high=high,
-                event_dims=1,
-                safe_tanh=safe_tanh,
-            )
-            mutated_sample = mutated_dist.rsample()
-            mutated_sample.fill_((low + high) / 2)
-            return (
-                sample,
-                log_prob,
-                rescored_log_prob,
-                mutated_dist.log_prob(mutated_sample),
-            )
+            return dist.rsample_and_log_prob()
 
         if compiled:
             sample_and_log_prob = torch.compile(
@@ -205,9 +186,7 @@ class TestTanhNormal:
             )
 
         torch.manual_seed(0)
-        sample, log_prob, rescored_log_prob, mutated_log_prob = sample_and_log_prob(
-            loc, scale
-        )
+        sample, log_prob = sample_and_log_prob(loc, scale)
         sample_loc_grad, sample_scale_grad = torch.autograd.grad(
             sample.sum(), (loc, scale), retain_graph=True
         )
@@ -220,82 +199,28 @@ class TestTanhNormal:
             - tanh_log_det
             - affine_log_det
         ).sum(-1)
-        expected_mutated = TanhNormal(
-            loc=loc,
-            scale=scale,
-            low=low,
-            high=high,
-            event_dims=1,
-            safe_tanh=safe_tanh,
-        ).log_prob(torch.full_like(sample, (low + high) / 2))
-
         torch.testing.assert_close(log_prob, expected)
-        torch.testing.assert_close(rescored_log_prob, expected)
-        torch.testing.assert_close(mutated_log_prob, expected_mutated)
-        log_prob_grads = torch.autograd.grad(
-            log_prob.sum(), (loc, scale), retain_graph=True
-        )
-        rescored_log_prob_grads = torch.autograd.grad(
-            rescored_log_prob.sum(), (loc, scale), retain_graph=True
-        )
+        log_prob_grads = torch.autograd.grad(log_prob.sum(), (loc, scale))
         expected_grads = torch.autograd.grad(expected.sum(), (loc, scale))
-        for actual_grads in (log_prob_grads, rescored_log_prob_grads):
-            for actual_grad, expected_grad in zip(actual_grads, expected_grads):
-                torch.testing.assert_close(actual_grad, expected_grad)
+        for actual_grad, expected_grad in zip(log_prob_grads, expected_grads):
+            torch.testing.assert_close(actual_grad, expected_grad)
 
     @pytest.mark.parametrize("low, high", [(-1.0, 1.0), (-2.0, 3.0)])
-    def test_tanhnormal_cache_invalidation(self, low, high):
-        loc = torch.tensor([0.3])
+    def test_tanhnormal_log_prob_is_history_independent(self, low, high):
+        loc = torch.tensor([0.3], requires_grad=True)
         scale = torch.tensor([0.7])
         dist = TanhNormal(loc, scale, low=low, high=high, event_dims=0)
-        deterministic = dist.deterministic_sample
-        expected = deterministic.clone()
-        deterministic.zero_()
-        torch.testing.assert_close(dist.deterministic_sample, expected)
-
-        value = torch.tensor([0.2], requires_grad=True)
-        first_grad = torch.autograd.grad(dist.log_prob(value).sum(), value)[0]
-        second_grad = torch.autograd.grad(dist.log_prob(value).sum(), value)[0]
-        torch.testing.assert_close(first_grad, second_grad)
-
-        with torch.no_grad():
-            value.fill_(0.7)
-        expected = TanhNormal(loc, scale, low=low, high=high, event_dims=0).log_prob(
-            value
-        )
-        torch.testing.assert_close(dist.log_prob(value), expected)
-
-        sample = dist.sample()
-        sample.zero_()
-        expected = TanhNormal(loc, scale, low=low, high=high, event_dims=0).log_prob(
-            sample
-        )
-        torch.testing.assert_close(dist.log_prob(sample), expected)
-
-        old_loc = torch.full((2, 3), 7.5)
-        old_scale = torch.full((2, 3), 0.1)
-        dist = TanhNormal(
-            old_loc,
-            old_scale,
-            low=low,
-            high=high,
-            event_dims=1,
-            safe_tanh=False,
-        )
         torch.manual_seed(0)
-        sample = dist.rsample()
-        new_loc = torch.full((2, 3), 0.4)
-        new_scale = torch.full((2, 3), 0.8)
-        dist.update(new_loc, new_scale)
-        expected = TanhNormal(
-            new_loc,
-            new_scale,
-            low=low,
-            high=high,
-            event_dims=1,
-            safe_tanh=False,
-        ).log_prob(sample)
-        torch.testing.assert_close(dist.log_prob(sample), expected)
+        first = dist.rsample()
+        dist.rsample()
+        cloned = first.detach().clone().requires_grad_()
+        first_log_prob = dist.log_prob(first)
+        cloned_log_prob = dist.log_prob(cloned)
+
+        torch.testing.assert_close(first_log_prob, cloned_log_prob)
+        first_grad = torch.autograd.grad(first_log_prob.sum(), first)[0]
+        cloned_grad = torch.autograd.grad(cloned_log_prob.sum(), cloned)[0]
+        torch.testing.assert_close(first_grad, cloned_grad)
 
     def test_tanhnormal_mode(self):
         # Checks that the std of the mode computed by tanh normal is within a certain range

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import math
+import sys
 import warnings
 from functools import partial
 
@@ -32,7 +34,10 @@ from torchrl.modules.distributions import (
     MaskedOneHotCategorical,
     TanhDelta,
 )
-from torchrl.modules.distributions.continuous import SafeTanhTransform
+from torchrl.modules.distributions.continuous import (
+    SafeTanhTransform,
+    TORCH_VERSION_PRE_2_6,
+)
 from torchrl.modules.distributions.discrete import (
     _generate_ordinal_logits,
     LLMMaskedCategorical,
@@ -138,6 +143,69 @@ class TestTanhNormal:
             assert (a <= d.high).all()
             lp = d.log_prob(a)
             assert torch.isfinite(lp).all()
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+    @pytest.mark.parametrize("low, high", [(-1.0, 1.0), (-2.0, 3.0)])
+    @pytest.mark.parametrize("safe_tanh", [False, True])
+    @pytest.mark.parametrize("compiled", [False, True])
+    @pytest.mark.parametrize("device", get_default_devices())
+    def test_tanhnormal_rsample_log_prob_consistency(
+        self, dtype, low, high, safe_tanh, compiled, device
+    ):
+        if compiled and sys.version_info >= (3, 14):
+            pytest.skip("torch.compile requires Python < 3.14")
+        if compiled and safe_tanh and TORCH_VERSION_PRE_2_6:
+            pytest.skip("safe_tanh compilation requires torch 2.6+")
+
+        if safe_tanh:
+            magnitude = 20.0 if dtype is torch.float32 else 40.0
+        else:
+            magnitude = 7.5 if dtype is torch.float32 else 18.0
+        loc = torch.tensor(
+            [[magnitude, -magnitude], [-magnitude, magnitude]],
+            dtype=dtype,
+            device=device,
+            requires_grad=True,
+        )
+        scale = torch.full_like(loc, 0.1, requires_grad=True)
+
+        def sample_and_log_prob(loc, scale):
+            dist = TanhNormal(
+                loc=loc,
+                scale=scale,
+                low=low,
+                high=high,
+                event_dims=1,
+                safe_tanh=safe_tanh,
+            )
+            sample = dist.rsample()
+            return sample, dist.log_prob(sample)
+
+        if compiled:
+            sample_and_log_prob = torch.compile(
+                sample_and_log_prob, backend="eager", fullgraph=True
+            )
+
+        torch.manual_seed(0)
+        sample, log_prob = sample_and_log_prob(loc, scale)
+        sample_loc_grad, sample_scale_grad = torch.autograd.grad(
+            sample.sum(), (loc, scale), retain_graph=True
+        )
+        noise = (sample_scale_grad / sample_loc_grad).detach()
+        pre_tanh = loc + scale * noise
+        tanh_log_det = 2.0 * (math.log(2.0) - pre_tanh - F.softplus(-2.0 * pre_tanh))
+        affine_log_det = math.log((high - low) / 2.0)
+        expected = (
+            torch.distributions.Normal(loc, scale).log_prob(pre_tanh)
+            - tanh_log_det
+            - affine_log_det
+        ).sum(-1)
+
+        torch.testing.assert_close(log_prob, expected)
+        log_prob_grads = torch.autograd.grad(log_prob.sum(), (loc, scale))
+        expected_grads = torch.autograd.grad(expected.sum(), (loc, scale))
+        for log_prob_grad, expected_grad in zip(log_prob_grads, expected_grads):
+            torch.testing.assert_close(log_prob_grad, expected_grad)
 
     def test_tanhnormal_mode(self):
         # Checks that the std of the mode computed by tanh normal is within a certain range

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -179,7 +179,25 @@ class TestTanhNormal:
                 safe_tanh=safe_tanh,
             )
             sample = dist.rsample()
-            return sample, dist.log_prob(sample)
+            log_prob = dist.log_prob(sample)
+            dist.log_prob(torch.zeros_like(sample))
+            rescored_log_prob = dist.log_prob(sample)
+            mutated_dist = TanhNormal(
+                loc=loc,
+                scale=scale,
+                low=low,
+                high=high,
+                event_dims=1,
+                safe_tanh=safe_tanh,
+            )
+            mutated_sample = mutated_dist.rsample()
+            mutated_sample.fill_((low + high) / 2)
+            return (
+                sample,
+                log_prob,
+                rescored_log_prob,
+                mutated_dist.log_prob(mutated_sample),
+            )
 
         if compiled:
             sample_and_log_prob = torch.compile(
@@ -187,7 +205,9 @@ class TestTanhNormal:
             )
 
         torch.manual_seed(0)
-        sample, log_prob = sample_and_log_prob(loc, scale)
+        sample, log_prob, rescored_log_prob, mutated_log_prob = sample_and_log_prob(
+            loc, scale
+        )
         sample_loc_grad, sample_scale_grad = torch.autograd.grad(
             sample.sum(), (loc, scale), retain_graph=True
         )
@@ -200,12 +220,90 @@ class TestTanhNormal:
             - tanh_log_det
             - affine_log_det
         ).sum(-1)
+        expected_mutated = TanhNormal(
+            loc=loc,
+            scale=scale,
+            low=low,
+            high=high,
+            event_dims=1,
+            safe_tanh=safe_tanh,
+        ).log_prob(torch.full_like(sample, (low + high) / 2))
 
         torch.testing.assert_close(log_prob, expected)
-        log_prob_grads = torch.autograd.grad(log_prob.sum(), (loc, scale))
+        torch.testing.assert_close(rescored_log_prob, expected)
+        torch.testing.assert_close(mutated_log_prob, expected_mutated)
+        log_prob_grads = torch.autograd.grad(
+            log_prob.sum(), (loc, scale), retain_graph=True
+        )
+        rescored_log_prob_grads = torch.autograd.grad(
+            rescored_log_prob.sum(), (loc, scale), retain_graph=True
+        )
         expected_grads = torch.autograd.grad(expected.sum(), (loc, scale))
-        for log_prob_grad, expected_grad in zip(log_prob_grads, expected_grads):
-            torch.testing.assert_close(log_prob_grad, expected_grad)
+        for actual_grads in (log_prob_grads, rescored_log_prob_grads):
+            for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+                torch.testing.assert_close(actual_grad, expected_grad)
+
+    @pytest.mark.parametrize("low, high", [(-1.0, 1.0), (-2.0, 3.0)])
+    def test_tanhnormal_repeated_log_prob(self, low, high):
+        loc = torch.tensor([0.3])
+        scale = torch.tensor([0.7])
+        dist = TanhNormal(loc, scale, low=low, high=high, event_dims=0)
+        deterministic = dist.deterministic_sample
+        expected = deterministic.clone()
+        deterministic.zero_()
+        torch.testing.assert_close(dist.deterministic_sample, expected)
+
+        value = torch.tensor([0.2], requires_grad=True)
+        grads = []
+        for _ in range(2):
+            dist.log_prob(value).sum().backward()
+            grads.append(value.grad.clone())
+            value.grad = None
+        torch.testing.assert_close(grads[0], grads[1])
+
+        with torch.no_grad():
+            value.fill_(0.7)
+        expected = TanhNormal(loc, scale, low=low, high=high, event_dims=0).log_prob(
+            value
+        )
+        torch.testing.assert_close(dist.log_prob(value), expected)
+
+        torch.manual_seed(0)
+        sample = dist.sample()
+        dist.log_prob(sample)
+        sample.zero_()
+        expected = TanhNormal(loc, scale, low=low, high=high, event_dims=0).log_prob(
+            sample
+        )
+        torch.testing.assert_close(dist.log_prob(sample), expected)
+
+    @pytest.mark.parametrize("low, high", [(-1.0, 1.0), (-2.0, 3.0)])
+    @pytest.mark.parametrize("event_dims", [0, 1, 2])
+    def test_tanhnormal_update_clears_cache(self, low, high, event_dims):
+        old_loc = torch.full((2, 3), 7.5)
+        old_scale = torch.full((2, 3), 0.1)
+        dist = TanhNormal(
+            old_loc,
+            old_scale,
+            low=low,
+            high=high,
+            event_dims=event_dims,
+            safe_tanh=False,
+        )
+        torch.manual_seed(0)
+        sample = dist.rsample()
+        new_loc = torch.full((2, 3), 0.4)
+        new_scale = torch.full((2, 3), 0.8)
+        dist.update(new_loc, new_scale)
+        expected = TanhNormal(
+            new_loc,
+            new_scale,
+            low=low,
+            high=high,
+            event_dims=event_dims,
+            safe_tanh=False,
+        ).log_prob(sample)
+        torch.testing.assert_close(dist.log_prob(sample), expected)
 
     def test_tanhnormal_mode(self):
         # Checks that the std of the mode computed by tanh normal is within a certain range

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -15,8 +15,12 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from tensordict import TensorDictBase
-from tensordict.nn import NormalParamExtractor
+from tensordict import TensorDict, TensorDictBase
+from tensordict.nn import (
+    CompositeDistribution,
+    NormalParamExtractor,
+    set_composite_lp_aggregate,
+)
 from torch import autograd, nn
 from torch.utils._pytree import tree_map
 from torchrl.modules import (
@@ -41,6 +45,11 @@ from torchrl.modules.distributions.continuous import (
 from torchrl.modules.distributions.discrete import (
     _generate_ordinal_logits,
     LLMMaskedCategorical,
+)
+from torchrl.modules.distributions.utils import (
+    composite_entropy,
+    rsample_and_log_prob,
+    sample_and_log_prob,
 )
 
 from torchrl.testing import get_default_devices
@@ -157,10 +166,7 @@ class TestTanhNormal:
         if compiled and safe_tanh and TORCH_VERSION_PRE_2_6:
             pytest.skip("safe_tanh compilation requires torch 2.6+")
 
-        if safe_tanh:
-            magnitude = 20.0 if dtype is torch.float32 else 40.0
-        else:
-            magnitude = 7.5 if dtype is torch.float32 else 18.0
+        magnitude = 20.0 if dtype is torch.float32 else 40.0
         loc = torch.tensor(
             [[magnitude, -magnitude], [-magnitude, magnitude]],
             dtype=dtype,
@@ -186,12 +192,11 @@ class TestTanhNormal:
             )
 
         torch.manual_seed(0)
+        pre_tanh = torch.distributions.Normal(loc, scale).rsample()
+        torch.manual_seed(0)
         sample, log_prob = sample_and_log_prob(loc, scale)
-        sample_loc_grad, sample_scale_grad = torch.autograd.grad(
-            sample.sum(), (loc, scale), retain_graph=True
-        )
-        noise = (sample_scale_grad / sample_loc_grad).detach()
-        pre_tanh = loc + scale * noise
+        assert sample.isfinite().all()
+        assert (sample >= low).all() and (sample <= high).all()
         tanh_log_det = 2.0 * (math.log(2.0) - pre_tanh - F.softplus(-2.0 * pre_tanh))
         affine_log_det = math.log((high - low) / 2.0)
         expected = (
@@ -205,11 +210,84 @@ class TestTanhNormal:
         for actual_grad, expected_grad in zip(log_prob_grads, expected_grads):
             torch.testing.assert_close(actual_grad, expected_grad)
 
-    @pytest.mark.parametrize("low, high", [(-1.0, 1.0), (-2.0, 3.0)])
-    def test_tanhnormal_log_prob_is_history_independent(self, low, high):
+    @pytest.mark.parametrize(
+        "reparameterize, sample_shape", [(False, ()), (True, (3,))]
+    )
+    @pytest.mark.parametrize("device", get_default_devices())
+    def test_composite_sample_and_log_prob(
+        self, reparameterize, sample_shape, monkeypatch, device
+    ):
+        loc = torch.tensor([[20.0], [-20.0]], device=device, requires_grad=True)
+        scale = torch.full_like(loc, 0.1, requires_grad=True)
+        params = TensorDict(
+            {
+                "squashed": TensorDict({"loc": loc, "scale": scale}, batch_size=[2]),
+                "normal": TensorDict(
+                    {"loc": torch.zeros_like(loc), "scale": torch.ones_like(loc)},
+                    batch_size=[2],
+                ),
+            },
+            batch_size=[2],
+        )
+        dist = CompositeDistribution(
+            params,
+            distribution_map={
+                "squashed": TanhNormal,
+                "normal": torch.distributions.Normal,
+            },
+            name_map={
+                "squashed": ("agent", "action"),
+                "normal": ("agent", "aux"),
+            },
+            extra_kwargs={"squashed": {"event_dims": 1}},
+        )
+
+        def fail_log_prob(*args, **kwargs):
+            raise AssertionError("a freshly sampled TanhNormal was inverse-scored")
+
+        monkeypatch.setattr(TanhNormal, "log_prob", fail_log_prob)
+        helper = rsample_and_log_prob if reparameterize else sample_and_log_prob
+        torch.manual_seed(0)
+        with set_composite_lp_aggregate(False):
+            sample, component_log_prob = helper(dist, sample_shape)
+        torch.manual_seed(0)
+        with set_composite_lp_aggregate(True):
+            aggregate_sample, aggregate_log_prob = helper(dist, sample_shape)
+
+        expected_batch = torch.Size(sample_shape) + torch.Size([2])
+        assert sample.batch_size == expected_batch
+        assert sample["agent", "action"].requires_grad is reparameterize
+        torch.testing.assert_close(sample, aggregate_sample)
+        assert set(component_log_prob.keys(True, True)) == {
+            ("agent", "action_log_prob"),
+            ("agent", "aux_log_prob"),
+        }
+        expected_aggregate = sum(
+            component_log_prob.sum(dim="feature").values(True, True)
+        )
+        torch.testing.assert_close(aggregate_log_prob, expected_aggregate)
+
+        torch.manual_seed(0)
+        with set_composite_lp_aggregate(False):
+            component_entropy = composite_entropy(dist, 3)
+        torch.manual_seed(0)
+        with set_composite_lp_aggregate(True):
+            aggregate_entropy = composite_entropy(dist, 3)
+        assert set(component_entropy.keys(True, True)) == {
+            ("agent", "action_entropy"),
+            ("agent", "aux_entropy"),
+        }
+        expected_entropy = sum(component_entropy.sum(dim="feature").values(True, True))
+        torch.testing.assert_close(aggregate_entropy, expected_entropy)
+
+        aggregate_log_prob.sum().backward()
+        assert loc.grad is not None and loc.grad.isfinite().all()
+        assert scale.grad is not None and scale.grad.isfinite().all()
+
+    def test_tanhnormal_log_prob_is_history_independent(self):
         loc = torch.tensor([0.3], requires_grad=True)
         scale = torch.tensor([0.7])
-        dist = TanhNormal(loc, scale, low=low, high=high, event_dims=0)
+        dist = TanhNormal(loc, scale, event_dims=0)
         torch.manual_seed(0)
         first = dist.rsample()
         dist.rsample()

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -244,7 +244,7 @@ class TestTanhNormal:
                 torch.testing.assert_close(actual_grad, expected_grad)
 
     @pytest.mark.parametrize("low, high", [(-1.0, 1.0), (-2.0, 3.0)])
-    def test_tanhnormal_repeated_log_prob(self, low, high):
+    def test_tanhnormal_cache_invalidation(self, low, high):
         loc = torch.tensor([0.3])
         scale = torch.tensor([0.7])
         dist = TanhNormal(loc, scale, low=low, high=high, event_dims=0)
@@ -254,12 +254,9 @@ class TestTanhNormal:
         torch.testing.assert_close(dist.deterministic_sample, expected)
 
         value = torch.tensor([0.2], requires_grad=True)
-        grads = []
-        for _ in range(2):
-            dist.log_prob(value).sum().backward()
-            grads.append(value.grad.clone())
-            value.grad = None
-        torch.testing.assert_close(grads[0], grads[1])
+        first_grad = torch.autograd.grad(dist.log_prob(value).sum(), value)[0]
+        second_grad = torch.autograd.grad(dist.log_prob(value).sum(), value)[0]
+        torch.testing.assert_close(first_grad, second_grad)
 
         with torch.no_grad():
             value.fill_(0.7)
@@ -268,18 +265,13 @@ class TestTanhNormal:
         )
         torch.testing.assert_close(dist.log_prob(value), expected)
 
-        torch.manual_seed(0)
         sample = dist.sample()
-        dist.log_prob(sample)
         sample.zero_()
         expected = TanhNormal(loc, scale, low=low, high=high, event_dims=0).log_prob(
             sample
         )
         torch.testing.assert_close(dist.log_prob(sample), expected)
 
-    @pytest.mark.parametrize("low, high", [(-1.0, 1.0), (-2.0, 3.0)])
-    @pytest.mark.parametrize("event_dims", [0, 1, 2])
-    def test_tanhnormal_update_clears_cache(self, low, high, event_dims):
         old_loc = torch.full((2, 3), 7.5)
         old_scale = torch.full((2, 3), 0.1)
         dist = TanhNormal(
@@ -287,7 +279,7 @@ class TestTanhNormal:
             old_scale,
             low=low,
             high=high,
-            event_dims=event_dims,
+            event_dims=1,
             safe_tanh=False,
         )
         torch.manual_seed(0)
@@ -300,7 +292,7 @@ class TestTanhNormal:
             new_scale,
             low=low,
             high=high,
-            event_dims=event_dims,
+            event_dims=1,
             safe_tanh=False,
         ).log_prob(sample)
         torch.testing.assert_close(dist.log_prob(sample), expected)

--- a/torchrl/modules/distributions/continuous.py
+++ b/torchrl/modules/distributions/continuous.py
@@ -454,19 +454,22 @@ class TanhNormal(FasterTransformedDistribution):
         self.low = low
         self.high = high
 
+        # Preserve exact preimages when finite-precision tanh saturates.
         if safe_tanh:
             if is_compiling() and TORCH_VERSION_PRE_2_6:
                 _err_compile_safetanh()
-            t = SafeTanhTransform()
+            t = SafeTanhTransform(cache_size=1)
         else:
-            t = D.TanhTransform()
+            t = D.TanhTransform(cache_size=1)
         # t = D.TanhTransform()
         if is_compiling() or (self.non_trivial_max or self.non_trivial_min):
             t = _PatchedComposeTransform(
                 [
                     t,
                     _PatchedAffineTransform(
-                        loc=(high + low) / 2, scale=(high - low) / 2
+                        loc=(high + low) / 2,
+                        scale=(high - low) / 2,
+                        cache_size=1,
                     ),
                 ]
             )
@@ -557,7 +560,8 @@ class TanhNormal(FasterTransformedDistribution):
             tanh_loc=False,
         )
         for _ in range(200):
-            lp = -self_copy.log_prob(m)
+            # Adam mutates m, so each inverse-cache key must be a new tensor.
+            lp = -self_copy.log_prob(m.clone())
             lp.mean().backward()
             mc = m.clone().detach()
             m.grad.clamp_max_(1)

--- a/torchrl/modules/distributions/continuous.py
+++ b/torchrl/modules/distributions/continuous.py
@@ -14,6 +14,7 @@ from packaging import version
 from torch import distributions as D, nn
 from torch.distributions import constraints
 from torch.distributions.transforms import _InverseTransform
+from torch.distributions.utils import _sum_rightmost
 
 from torchrl._utils import safe_is_current_stream_capturing
 from torchrl.modules.distributions.truncated_normal import (
@@ -454,14 +455,12 @@ class TanhNormal(FasterTransformedDistribution):
         self.low = low
         self.high = high
 
-        # Preserve exact preimages when finite-precision tanh saturates.
         if safe_tanh:
             if is_compiling() and TORCH_VERSION_PRE_2_6:
                 _err_compile_safetanh()
-            t = SafeTanhTransform(cache_size=1)
+            t = SafeTanhTransform()
         else:
-            t = D.TanhTransform(cache_size=1)
-        # t = D.TanhTransform()
+            t = D.TanhTransform()
         if is_compiling() or (self.non_trivial_max or self.non_trivial_min):
             t = _PatchedComposeTransform(
                 [
@@ -469,13 +468,66 @@ class TanhNormal(FasterTransformedDistribution):
                     _PatchedAffineTransform(
                         loc=(high + low) / 2,
                         scale=(high - low) / 2,
-                        cache_size=1,
                     ),
                 ]
             )
         self._t = t
+        # Preserve exact preimages when finite-precision tanh saturates.
+        self.cached_pair = None, None
+        self.cached_snapshot = None
+        self.cached_version = None
 
         self.update(loc, scale)
+
+    def transform_sample(self, preimage):
+        sample = preimage
+        for transform in self.transforms:
+            sample = transform(sample)
+        self.cached_pair = preimage, sample
+        self.cached_snapshot = sample.detach().clone()
+        self.cached_version = (
+            None if is_compiling() or torch.is_inference(sample) else sample._version
+        )
+        return sample
+
+    @torch.no_grad()
+    def sample(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
+        return self.transform_sample(self.base_dist.sample(sample_shape))
+
+    def rsample(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
+        return self.transform_sample(self.base_dist.rsample(sample_shape))
+
+    def log_prob(self, value: torch.Tensor) -> torch.Tensor:
+        cached_preimage, cached_sample = self.cached_pair
+        if value is not cached_sample:
+            return super().log_prob(value)
+        transform = self.transforms[0]
+        if is_compiling() or self.cached_version is None:
+            unchanged = torch.eq(value, self.cached_snapshot).all()
+            midpoint = torch.zeros_like(value) + (self.high + self.low) / 2
+            inverse_input = torch.where(unchanged, midpoint, value)
+            preimage = torch.where(
+                unchanged, cached_preimage, transform.inv(inverse_input)
+            )
+        elif value._version == self.cached_version:
+            preimage = cached_preimage
+        else:
+            return super().log_prob(value)
+
+        event_dim = len(self.event_shape)
+        event_dim += transform.domain.event_dim - transform.codomain.event_dim
+        log_prob = -_sum_rightmost(
+            transform.log_abs_det_jacobian(preimage, value),
+            event_dim - transform.domain.event_dim,
+        )
+        return log_prob + _sum_rightmost(
+            self.base_dist.log_prob(preimage),
+            event_dim - len(self.base_dist.event_shape),
+        )
 
     @property
     def min(self):
@@ -488,6 +540,9 @@ class TanhNormal(FasterTransformedDistribution):
         return self.high
 
     def update(self, loc: torch.Tensor, scale: torch.Tensor) -> None:
+        self.cached_pair = None, None
+        self.cached_snapshot = None
+        self.cached_version = None
         if self.tanh_loc:
             loc = (loc / self.upscale).tanh() * self.upscale
             # loc must be rescaled if tanh_loc
@@ -538,10 +593,7 @@ class TanhNormal(FasterTransformedDistribution):
 
     @property
     def deterministic_sample(self):
-        m = self.root_dist.mean
-        for t in self.transforms:
-            m = t(m)
-        return m
+        return self.transform_sample(self.root_dist.mean)
 
     @torch.enable_grad()
     def get_mode(self):
@@ -560,8 +612,7 @@ class TanhNormal(FasterTransformedDistribution):
             tanh_loc=False,
         )
         for _ in range(200):
-            # Adam mutates m, so each inverse-cache key must be a new tensor.
-            lp = -self_copy.log_prob(m.clone())
+            lp = -self_copy.log_prob(m)
             lp.mean().backward()
             mc = m.clone().detach()
             m.grad.clamp_max_(1)

--- a/torchrl/modules/distributions/continuous.py
+++ b/torchrl/modules/distributions/continuous.py
@@ -486,7 +486,11 @@ class TanhNormal(FasterTransformedDistribution):
         self.cached_pair = preimage, sample
         self.cached_snapshot = sample.detach().clone()
         self.cached_version = (
-            None if is_compiling() or torch.is_inference(sample) else sample._version
+            None
+            if is_compiling()
+            or safe_is_current_stream_capturing()
+            or torch.is_inference(sample)
+            else sample._version
         )
         return sample
 

--- a/torchrl/modules/distributions/continuous.py
+++ b/torchrl/modules/distributions/continuous.py
@@ -494,6 +494,14 @@ class TanhNormal(FasterTransformedDistribution):
             sample_shape + batch_shape, respectively.
 
         Use log_prob() for actions not drawn by this call.
+
+        Examples:
+            >>> loc = torch.tensor([20.0, -20.0])
+            >>> scale = torch.full_like(loc, 0.1)
+            >>> dist = TanhNormal(loc, scale, event_dims=1)
+            >>> action, log_prob = dist.rsample_and_log_prob()
+            >>> action.shape, log_prob.shape
+            (torch.Size([2]), torch.Size([]))
         """
         sample_shape = torch.Size(sample_shape)
         preimage = self.base_dist.rsample(sample_shape)
@@ -513,6 +521,14 @@ class TanhNormal(FasterTransformedDistribution):
 
         The action is detached. Its log probability keeps score-function gradients
         with respect to the distribution parameters.
+
+        Args:
+            sample_shape: Leading sample dimensions.
+
+        Returns:
+            The detached action and its differentiable log probability. Their
+            shapes are sample_shape + batch_shape + event_shape and
+            sample_shape + batch_shape, respectively.
         """
         sample_shape = torch.Size(sample_shape)
         preimage = self.base_dist.sample(sample_shape)

--- a/torchrl/modules/distributions/continuous.py
+++ b/torchrl/modules/distributions/continuous.py
@@ -484,16 +484,11 @@ class TanhNormal(FasterTransformedDistribution):
         transform = self.transforms[0]
         sample = transform(preimage)
 
-        event_dim = len(self.event_shape)
-        event_dim += transform.domain.event_dim - transform.codomain.event_dim
         log_prob = -_sum_rightmost(
             transform.log_abs_det_jacobian(preimage, sample),
-            event_dim - transform.domain.event_dim,
+            len(self.event_shape),
         )
-        log_prob = log_prob + _sum_rightmost(
-            self.base_dist.log_prob(preimage),
-            event_dim - len(self.base_dist.event_shape),
-        )
+        log_prob = log_prob + self.base_dist.log_prob(preimage)
         return sample, log_prob
 
     @property

--- a/torchrl/modules/distributions/continuous.py
+++ b/torchrl/modules/distributions/continuous.py
@@ -461,77 +461,40 @@ class TanhNormal(FasterTransformedDistribution):
             t = SafeTanhTransform()
         else:
             t = D.TanhTransform()
+        # t = D.TanhTransform()
         if is_compiling() or (self.non_trivial_max or self.non_trivial_min):
             t = _PatchedComposeTransform(
                 [
                     t,
                     _PatchedAffineTransform(
-                        loc=(high + low) / 2,
-                        scale=(high - low) / 2,
+                        loc=(high + low) / 2, scale=(high - low) / 2
                     ),
                 ]
             )
         self._t = t
-        # Preserve exact preimages when finite-precision tanh saturates.
-        self.cached_pair = None, None
-        self.cached_snapshot = None
-        self.cached_version = None
 
         self.update(loc, scale)
 
-    def transform_sample(self, preimage):
-        sample = preimage
-        for transform in self.transforms:
-            sample = transform(sample)
-        self.cached_pair = preimage, sample
-        self.cached_snapshot = sample.detach().clone()
-        self.cached_version = (
-            None
-            if is_compiling()
-            or safe_is_current_stream_capturing()
-            or torch.is_inference(sample)
-            else sample._version
-        )
-        return sample
-
-    @torch.no_grad()
-    def sample(self, sample_shape=None):
-        if sample_shape is None:
-            sample_shape = torch.Size()
-        return self.transform_sample(self.base_dist.sample(sample_shape))
-
-    def rsample(self, sample_shape=None):
-        if sample_shape is None:
-            sample_shape = torch.Size()
-        return self.transform_sample(self.base_dist.rsample(sample_shape))
-
-    def log_prob(self, value: torch.Tensor) -> torch.Tensor:
-        cached_preimage, cached_sample = self.cached_pair
-        if value is not cached_sample:
-            return super().log_prob(value)
+    def rsample_and_log_prob(
+        self, sample_shape: torch.Size | tuple[int, ...] = ()
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Draw a reparameterized sample and score it from the same preimage."""
+        sample_shape = torch.Size(sample_shape)
+        preimage = self.base_dist.rsample(sample_shape)
         transform = self.transforms[0]
-        if is_compiling() or self.cached_version is None:
-            unchanged = torch.eq(value, self.cached_snapshot).all()
-            midpoint = torch.zeros_like(value) + (self.high + self.low) / 2
-            inverse_input = torch.where(unchanged, midpoint, value)
-            preimage = torch.where(
-                unchanged, cached_preimage, transform.inv(inverse_input)
-            )
-        elif value._version == self.cached_version:
-            preimage = cached_preimage
-        else:
-            return super().log_prob(value)
+        sample = transform(preimage)
 
         event_dim = len(self.event_shape)
         event_dim += transform.domain.event_dim - transform.codomain.event_dim
         log_prob = -_sum_rightmost(
-            transform.log_abs_det_jacobian(preimage, value),
+            transform.log_abs_det_jacobian(preimage, sample),
             event_dim - transform.domain.event_dim,
         )
-        return log_prob + _sum_rightmost(
+        log_prob = log_prob + _sum_rightmost(
             self.base_dist.log_prob(preimage),
             event_dim - len(self.base_dist.event_shape),
         )
+        return sample, log_prob
 
     @property
     def min(self):
@@ -544,9 +507,6 @@ class TanhNormal(FasterTransformedDistribution):
         return self.high
 
     def update(self, loc: torch.Tensor, scale: torch.Tensor) -> None:
-        self.cached_pair = None, None
-        self.cached_snapshot = None
-        self.cached_version = None
         if self.tanh_loc:
             loc = (loc / self.upscale).tanh() * self.upscale
             # loc must be rescaled if tanh_loc
@@ -597,7 +557,10 @@ class TanhNormal(FasterTransformedDistribution):
 
     @property
     def deterministic_sample(self):
-        return self.transform_sample(self.root_dist.mean)
+        m = self.root_dist.mean
+        for t in self.transforms:
+            m = t(m)
+        return m
 
     @torch.enable_grad()
     def get_mode(self):

--- a/torchrl/modules/distributions/continuous.py
+++ b/torchrl/modules/distributions/continuous.py
@@ -478,17 +478,52 @@ class TanhNormal(FasterTransformedDistribution):
     def rsample_and_log_prob(
         self, sample_shape: torch.Size | tuple[int, ...] = ()
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Draw a reparameterized sample and score it from the same preimage."""
+        """Sample and score the same pre-tanh value with pathwise gradients.
+
+        Calling rsample() and log_prob() separately reconstructs the pre-tanh
+        value from the rounded action. Once tanh saturates, that inverse can return
+        a different Normal value and produce the wrong score and gradients. This
+        method scores the exact Normal value used to create the action.
+
+        Args:
+            sample_shape: Leading sample dimensions.
+
+        Returns:
+            The action and its log probability. Their shapes are
+            sample_shape + batch_shape + event_shape and
+            sample_shape + batch_shape, respectively.
+
+        Use log_prob() for actions not drawn by this call.
+        """
         sample_shape = torch.Size(sample_shape)
         preimage = self.base_dist.rsample(sample_shape)
         transform = self.transforms[0]
         sample = transform(preimage)
 
-        log_prob = -_sum_rightmost(
+        log_prob = self.base_dist.log_prob(preimage) - _sum_rightmost(
             transform.log_abs_det_jacobian(preimage, sample),
             len(self.event_shape),
         )
-        log_prob = log_prob + self.base_dist.log_prob(preimage)
+        return sample, log_prob
+
+    def sample_and_log_prob(
+        self, sample_shape: torch.Size | tuple[int, ...] = ()
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Sample and score the same pre-tanh value without pathwise gradients.
+
+        The action is detached. Its log probability keeps score-function gradients
+        with respect to the distribution parameters.
+        """
+        sample_shape = torch.Size(sample_shape)
+        preimage = self.base_dist.sample(sample_shape)
+        transform = self.transforms[0]
+        with torch.no_grad():
+            sample = transform(preimage)
+
+        log_prob = self.base_dist.log_prob(preimage) - _sum_rightmost(
+            transform.log_abs_det_jacobian(preimage, sample),
+            len(self.event_shape),
+        )
         return sample, log_prob
 
     @property

--- a/torchrl/modules/distributions/utils.py
+++ b/torchrl/modules/distributions/utils.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import torch
+from tensordict import is_tensor_collection, TensorDict
+from tensordict.nn import composite_lp_aggregate, CompositeDistribution
 from torch import autograd, distributions as d
 from torch.distributions import Independent, Transform, TransformedDistribution
 
@@ -12,6 +14,101 @@ try:
     from torch.compiler import is_dynamo_compiling
 except ImportError:
     from torch._dynamo import is_compiling as is_dynamo_compiling
+
+
+def sample_and_log_prob(
+    distribution: d.Distribution,
+    sample_shape: torch.Size | tuple[int, ...] = (),
+    *,
+    reparameterize: bool = False,
+):
+    """Sample once and score the same draw atomically when supported."""
+    sample_shape = torch.Size(sample_shape)
+    if isinstance(distribution, CompositeDistribution):
+        samples = {}
+        log_probs = {}
+        for name, component in distribution.dists.items():
+            sample, log_prob = sample_and_log_prob(
+                component,
+                sample_shape,
+                reparameterize=reparameterize,
+            )
+            samples[name] = sample
+            if isinstance(name, str):
+                log_prob_name = name + "_log_prob"
+            else:
+                log_prob_name = name[:-1] + (name[-1] + "_log_prob",)
+            log_probs[log_prob_name] = log_prob
+
+        batch_size = sample_shape + distribution.batch_shape
+        sample = TensorDict(samples, batch_size=batch_size)
+        if not composite_lp_aggregate():
+            return sample, TensorDict(log_probs, batch_size=batch_size)
+
+        log_prob = 0.0
+        for component_log_prob in log_probs.values():
+            if is_tensor_collection(component_log_prob):
+                component_log_prob = component_log_prob.sum(dim="feature", reduce=True)
+            elif component_log_prob.ndim > sample.ndim:
+                component_log_prob = component_log_prob.flatten(sample.ndim, -1).sum(-1)
+            log_prob = log_prob + component_log_prob
+        return sample, log_prob
+
+    method_name = "rsample_and_log_prob" if reparameterize else "sample_and_log_prob"
+    joint_sample = getattr(distribution, method_name, None)
+    if joint_sample is not None:
+        return joint_sample(sample_shape)
+    sample_fn = distribution.rsample if reparameterize else distribution.sample
+    sample = sample_fn(sample_shape)
+    if isinstance(sample, torch.Tensor) or is_tensor_collection(sample):
+        return sample, distribution.log_prob(sample)
+    return sample, distribution.log_prob(*sample)
+
+
+def rsample_and_log_prob(
+    distribution: d.Distribution,
+    sample_shape: torch.Size | tuple[int, ...] = (),
+):
+    """Reparameterize once and score the same draw atomically when supported."""
+    return sample_and_log_prob(
+        distribution,
+        sample_shape,
+        reparameterize=True,
+    )
+
+
+def composite_entropy(
+    distribution: CompositeDistribution,
+    samples_mc: int = 1,
+):
+    """Compute component entropy without inverse-scoring Monte Carlo samples."""
+    entropies = {}
+    for name, component in distribution.dists.items():
+        try:
+            entropy = component.entropy()
+        except NotImplementedError:
+            if not component.has_rsample:
+                raise
+            _, log_prob = rsample_and_log_prob(component, (samples_mc,))
+            entropy = -log_prob.mean(0)
+        if isinstance(name, str):
+            entropy_name = name + "_entropy"
+        else:
+            entropy_name = name[:-1] + (name[-1] + "_entropy",)
+        entropies[entropy_name] = entropy
+
+    if not composite_lp_aggregate():
+        return TensorDict(entropies, batch_size=distribution.batch_shape)
+
+    entropy = 0.0
+    batch_ndim = len(distribution.batch_shape)
+    for component_entropy in entropies.values():
+        if is_tensor_collection(component_entropy):
+            component_entropy = component_entropy.sum(dim="feature", reduce=True)
+        elif component_entropy.ndim > batch_ndim:
+            component_entropy = component_entropy.flatten(batch_ndim, -1).sum(-1)
+        entropy = entropy + component_entropy
+    return entropy
 
 
 def _cast_device(elt: torch.Tensor | float, device) -> torch.Tensor | float:

--- a/torchrl/modules/distributions/utils.py
+++ b/torchrl/modules/distributions/utils.py
@@ -4,8 +4,10 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+from typing import Any
+
 import torch
-from tensordict import is_tensor_collection, TensorDict
+from tensordict import is_tensor_collection, TensorDict, TensorDictBase
 from tensordict.nn import composite_lp_aggregate, CompositeDistribution
 from torch import autograd, distributions as d
 from torch.distributions import Independent, Transform, TransformedDistribution
@@ -21,8 +23,26 @@ def sample_and_log_prob(
     sample_shape: torch.Size | tuple[int, ...] = (),
     *,
     reparameterize: bool = False,
-):
-    """Sample once and score the same draw atomically when supported."""
+) -> tuple[Any, torch.Tensor | TensorDictBase]:
+    """Sample once and score the same draw atomically when supported.
+
+    If the distribution implements ``sample_and_log_prob`` or
+    ``rsample_and_log_prob``, the matching method is used so that the score is
+    computed from the same latent draw as the sample. Otherwise, this function
+    falls back to separate sampling and scoring. Composite distributions are
+    handled component by component and respect
+    :func:`~tensordict.nn.composite_lp_aggregate`.
+
+    Args:
+        distribution (Distribution): distribution to sample and score.
+        sample_shape (torch.Size or tuple of int, optional): leading sample
+            dimensions. Defaults to an empty shape.
+        reparameterize (bool, optional): if ``True``, use reparameterized
+            sampling. Defaults to ``False``.
+
+    Returns:
+        A tuple containing the sample and its log probability.
+    """
     sample_shape = torch.Size(sample_shape)
     if isinstance(distribution, CompositeDistribution):
         samples = {}
@@ -68,8 +88,17 @@ def sample_and_log_prob(
 def rsample_and_log_prob(
     distribution: d.Distribution,
     sample_shape: torch.Size | tuple[int, ...] = (),
-):
-    """Reparameterize once and score the same draw atomically when supported."""
+) -> tuple[Any, torch.Tensor | TensorDictBase]:
+    """Reparameterize once and score the same draw atomically when supported.
+
+    Args:
+        distribution (Distribution): distribution to sample and score.
+        sample_shape (torch.Size or tuple of int, optional): leading sample
+            dimensions. Defaults to an empty shape.
+
+    Returns:
+        A tuple containing the reparameterized sample and its log probability.
+    """
     return sample_and_log_prob(
         distribution,
         sample_shape,
@@ -80,8 +109,22 @@ def rsample_and_log_prob(
 def composite_entropy(
     distribution: CompositeDistribution,
     samples_mc: int = 1,
-):
-    """Compute component entropy without inverse-scoring Monte Carlo samples."""
+) -> torch.Tensor | TensorDictBase:
+    """Compute component entropy without inverse-scoring Monte Carlo samples.
+
+    Analytic component entropies are used when available. Components without
+    analytic entropy are estimated from atomic reparameterized samples.
+
+    Args:
+        distribution (CompositeDistribution): distribution whose component
+            entropies are computed.
+        samples_mc (int, optional): number of Monte Carlo samples used for
+            components without analytic entropy. Defaults to ``1``.
+
+    Returns:
+        The aggregated entropy, or a TensorDict of component entropies when
+        composite log-probability aggregation is disabled.
+    """
     entropies = {}
     for name, component in distribution.dists.items():
         try:

--- a/torchrl/modules/tensordict_module/probabilistic.py
+++ b/torchrl/modules/tensordict_module/probabilistic.py
@@ -6,15 +6,19 @@ from __future__ import annotations
 
 import inspect
 import warnings
+from contextlib import nullcontext
 
 import torch
 from tensordict import TensorDictBase, unravel_key_list
 from tensordict.nn import (
+    dispatch,
     InteractionType,
     ProbabilisticTensorDictModule,
     ProbabilisticTensorDictSequential,
     TensorDictModule,
 )
+from tensordict.nn.probabilistic import interaction_type
+from tensordict.nn.utils import _set_skip_existing_None as set_skip_existing_none
 from tensordict.utils import NestedKey
 
 from torchrl.data.tensor_specs import Composite, TensorSpec
@@ -28,6 +32,10 @@ from torchrl.modules.tensordict_module.sequence import SafeSequential
 _PTDM_HAS_GENERATOR = (
     "generator" in inspect.signature(ProbabilisticTensorDictModule.__init__).parameters
 )
+if _PTDM_HAS_GENERATOR:
+    from tensordict.nn.probabilistic import _use_generator as use_generator
+else:
+    use_generator = nullcontext
 
 
 class SafeProbabilisticModule(ProbabilisticTensorDictModule):
@@ -277,6 +285,54 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule):
                     "specs are not specified"
                 )
             self.register_forward_hook(_forward_hook_safe_action)
+
+    @dispatch(auto_batch_size=False)
+    @set_skip_existing_none()
+    def forward(
+        self,
+        tensordict: TensorDictBase,
+        tensordict_out: TensorDictBase | None = None,
+        _requires_sample: bool = True,
+    ) -> TensorDictBase:
+        if not self.return_log_prob or not _requires_sample:
+            return super().forward(
+                tensordict,
+                tensordict_out,
+                _requires_sample=_requires_sample,
+            )
+
+        dist = self.get_dist(tensordict)
+        current_interaction = interaction_type() or self.default_interaction_type
+        joint_sample = getattr(dist, "rsample_and_log_prob", None)
+        if (
+            current_interaction is not InteractionType.RANDOM
+            or joint_sample is None
+            or len(self.dist_sample_keys) != 1
+        ):
+            return super().forward(
+                tensordict,
+                tensordict_out,
+                _requires_sample=_requires_sample,
+            )
+
+        if tensordict_out is None:
+            tensordict_out = tensordict
+        if _PTDM_HAS_GENERATOR:
+            generator, writeback = self._resolve_generator(tensordict)
+        else:
+            generator = writeback = None
+        sample_shape = self.num_samples or torch.Size()
+        with use_generator(generator):
+            sample, log_prob = joint_sample(sample_shape)
+        if writeback is not None:
+            writeback(generator)
+        if self.num_samples is not None:
+            tensordict_out = tensordict_out.expand(
+                self.num_samples + tensordict_out.shape
+            )
+        tensordict_out.set(self.dist_sample_keys[0], sample)
+        tensordict_out.set(self.log_prob_key, log_prob)
+        return tensordict_out
 
     @property
     def spec(self) -> Composite:

--- a/torchrl/modules/tensordict_module/probabilistic.py
+++ b/torchrl/modules/tensordict_module/probabilistic.py
@@ -4,38 +4,33 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
-import inspect
 import warnings
 from contextlib import nullcontext
 
 import torch
-from tensordict import TensorDictBase, unravel_key_list
+from tensordict import is_tensor_collection, TensorDictBase, unravel_key_list
 from tensordict.nn import (
+    composite_lp_aggregate,
+    CompositeDistribution,
     dispatch,
     InteractionType,
     ProbabilisticTensorDictModule,
     ProbabilisticTensorDictSequential,
+    set_composite_lp_aggregate,
     TensorDictModule,
 )
-from tensordict.nn.probabilistic import interaction_type
+from tensordict.nn.probabilistic import (
+    _use_generator as use_generator,
+    interaction_type,
+)
 from tensordict.nn.utils import _set_skip_existing_None as set_skip_existing_none
 from tensordict.utils import NestedKey
 
 from torchrl.data.tensor_specs import Composite, TensorSpec
 from torchrl.modules.distributions import Delta
+from torchrl.modules.distributions.utils import sample_and_log_prob
 from torchrl.modules.tensordict_module.common import _forward_hook_safe_action
 from torchrl.modules.tensordict_module.sequence import SafeSequential
-
-# Older stable-release versions of ``tensordict`` predate the ``generator``
-# kwarg on ``ProbabilisticTensorDictModule.__init__``. We probe the signature
-# once at import time and forward the kwarg only when it is supported.
-_PTDM_HAS_GENERATOR = (
-    "generator" in inspect.signature(ProbabilisticTensorDictModule.__init__).parameters
-)
-if _PTDM_HAS_GENERATOR:
-    from tensordict.nn.probabilistic import _use_generator as use_generator
-else:
-    use_generator = nullcontext
 
 
 class SafeProbabilisticModule(ProbabilisticTensorDictModule):
@@ -141,6 +136,12 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule):
             If ``True``, the log-probability of the
             distribution sample will be written in the tensordict with the key
             `log_prob_key`. Default is ``False``.
+
+            Fresh random samples use a joint sample-and-score operation when
+            available, including each CompositeDistribution component. Existing
+            samples and deterministic interactions use regular log_prob. Other
+            distributions retain separate sampling and scoring.
+
         log_prob_keys (List[NestedKey], optional): keys where to write the log_prob if ``return_log_prob=True``.
             Defaults to `'<sample_key_name>_log_prob'`, where `<sample_key_name>` is each of the :attr:`out_keys`.
 
@@ -225,10 +226,6 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule):
         num_samples: int | torch.Size | None = None,
         generator: torch.Generator | int | NestedKey | None = None,
     ):
-        # ``generator`` was added to ``ProbabilisticTensorDictModule`` after
-        # the current stable-release tensordict; forward it only when the
-        # underlying class accepts it.
-        extra_kwargs = {"generator": generator} if _PTDM_HAS_GENERATOR else {}
         super().__init__(
             in_keys=in_keys,
             out_keys=out_keys,
@@ -241,7 +238,7 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule):
             log_prob_keys=log_prob_keys,
             log_prob_key=log_prob_key,
             num_samples=num_samples,
-            **extra_kwargs,
+            generator=generator,
         )
         if spec is not None:
             spec = spec.clone()
@@ -294,20 +291,11 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule):
         tensordict_out: TensorDictBase | None = None,
         _requires_sample: bool = True,
     ) -> TensorDictBase:
-        if not self.return_log_prob or not _requires_sample:
-            return super().forward(
-                tensordict,
-                tensordict_out,
-                _requires_sample=_requires_sample,
-            )
-
-        dist = self.get_dist(tensordict)
-        current_interaction = interaction_type() or self.default_interaction_type
-        joint_sample = getattr(dist, "rsample_and_log_prob", None)
         if (
-            current_interaction is not InteractionType.RANDOM
-            or joint_sample is None
-            or len(self.dist_sample_keys) != 1
+            not self.return_log_prob
+            or not _requires_sample
+            or (interaction_type() or self.default_interaction_type)
+            is not InteractionType.RANDOM
         ):
             return super().forward(
                 tensordict,
@@ -315,23 +303,58 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule):
                 _requires_sample=_requires_sample,
             )
 
+        dist = self.get_dist(tensordict)
         if tensordict_out is None:
             tensordict_out = tensordict
-        if _PTDM_HAS_GENERATOR:
-            generator, writeback = self._resolve_generator(tensordict)
-        else:
-            generator = writeback = None
+        generator, writeback = self._resolve_generator(tensordict)
         sample_shape = self.num_samples or torch.Size()
-        with use_generator(generator):
-            sample, log_prob = joint_sample(sample_shape)
+        aggregate = composite_lp_aggregate()
+        aggregate_context = nullcontext()
+        if isinstance(dist, CompositeDistribution):
+            if aggregate != self._composite_lp_aggreate_at_init:
+                raise RuntimeError(
+                    self._CHANGE_IN_C_LP_A.format(
+                        type(self).__name__,
+                        self._composite_lp_aggreate_at_init,
+                        aggregate,
+                    )
+                )
+            aggregate_context = set_composite_lp_aggregate(False)
+        with use_generator(generator), aggregate_context:
+            sample, log_prob = sample_and_log_prob(
+                dist, sample_shape, reparameterize=dist.has_rsample
+            )
         if writeback is not None:
             writeback(generator)
         if self.num_samples is not None:
             tensordict_out = tensordict_out.expand(
                 self.num_samples + tensordict_out.shape
             )
-        tensordict_out.set(self.dist_sample_keys[0], sample)
-        tensordict_out.set(self.log_prob_key, log_prob)
+
+        if isinstance(sample, TensorDictBase):
+            if is_tensor_collection(log_prob):
+                if aggregate:
+                    sample.update(log_prob)
+                    sample.set(
+                        self.log_prob_key,
+                        log_prob.sum(dim="feature", reduce=True),
+                    )
+                else:
+                    self._update_td_lp(log_prob)
+                    sample.update(log_prob)
+            else:
+                sample.set(self.log_prob_key, log_prob)
+            tensordict_out.update(sample)
+            return tensordict_out
+
+        if isinstance(sample, torch.Tensor):
+            sample = (sample,)
+        tensordict_out.update(dict(zip(self.dist_sample_keys, sample, strict=True)))
+        if is_tensor_collection(log_prob):
+            self._update_td_lp(log_prob)
+            tensordict_out.update(log_prob)
+        else:
+            tensordict_out.set(self.log_prob_key, log_prob)
         return tensordict_out
 
     @property

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -26,6 +26,7 @@ from tensordict.utils import NestedKey
 from torch import distributions as d
 
 from torchrl.modules.distributions import HAS_ENTROPY
+from torchrl.modules.distributions.utils import rsample_and_log_prob
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
@@ -415,10 +416,9 @@ class A2CLoss(LossModule):
         if HAS_ENTROPY.get(type(dist), False):
             entropy = dist.entropy()
         else:
-            x = dist.rsample((self.samples_mc_entropy,))
-            log_prob = dist.log_prob(x)
+            _, log_prob = rsample_and_log_prob(dist, (self.samples_mc_entropy,))
             if is_tensor_collection(log_prob):
-                log_prob = sum(log_prob.sum(dim="feature").values(True, True))
+                log_prob = log_prob.sum(dim="feature", reduce=True)
             entropy = -log_prob.mean(0)
         return entropy.unsqueeze(-1)
 

--- a/torchrl/objectives/cql.py
+++ b/torchrl/objectives/cql.py
@@ -20,6 +20,7 @@ from torch import Tensor
 from torchrl.data.tensor_specs import Composite
 from torchrl.data.utils import _find_action_space
 from torchrl.envs.utils import ExplorationType, set_exploration_type
+from torchrl.modules.distributions.utils import rsample_and_log_prob
 from torchrl.modules.tensordict_module.actors import QValueActor
 from torchrl.modules.tensordict_module.common import ensure_tensordict_compatible
 from torchrl.objectives.common import LossModule
@@ -591,8 +592,7 @@ class CQLLoss(LossModule):
             dist = self.actor_network.get_dist(
                 tensordict,
             )
-            a_reparm = dist.rsample()
-        log_prob = dist.log_prob(a_reparm)
+            a_reparm, log_prob = rsample_and_log_prob(dist)
         bc_log_prob = dist.log_prob(tensordict.get(self.tensor_keys.action))
 
         bc_actor_loss = self._alpha * log_prob - bc_log_prob
@@ -616,8 +616,7 @@ class CQLLoss(LossModule):
             dist = self.actor_network.get_dist(
                 tensordict,
             )
-            a_reparm = dist.rsample()
-        log_prob = dist.log_prob(a_reparm)
+            a_reparm, log_prob = rsample_and_log_prob(dist)
 
         td_q = tensordict.select(*self.qvalue_network.in_keys, strict=False)
         if td_q is tensordict:
@@ -665,9 +664,8 @@ class CQLLoss(LossModule):
             self.actor_network, preserve_module_state=False
         ):
             dist = self.actor_network.get_dist(tensordict)
-            action = dist.rsample()
+            action, sample_log_prob = rsample_and_log_prob(dist)
             tensordict.set(self.tensor_keys.action, action)
-            sample_log_prob = dist.log_prob(action)
 
         return (
             tensordict.select(
@@ -686,9 +684,8 @@ class CQLLoss(LossModule):
         with set_exploration_type(ExplorationType.RANDOM):
             next_tensordict = tensordict.get("next").clone(False)
             next_dist = self.actor_network.get_dist(next_tensordict)
-            next_action = next_dist.rsample()
+            next_action, next_sample_log_prob = rsample_and_log_prob(next_dist)
             next_tensordict.set(self.tensor_keys.action, next_action)
-            next_sample_log_prob = next_dist.log_prob(next_action)
         actor_data.to_module(
             self.actor_network, return_swap=False, preserve_module_state=False
         )

--- a/torchrl/objectives/crossq.py
+++ b/torchrl/objectives/crossq.py
@@ -17,6 +17,10 @@ from torch import Tensor
 
 from torchrl.data.tensor_specs import Composite
 from torchrl.envs.utils import ExplorationType, set_exploration_type
+from torchrl.modules.distributions.utils import (
+    rsample_and_log_prob,
+    sample_and_log_prob,
+)
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
@@ -604,8 +608,7 @@ class CrossQLoss(LossModule):
             self.actor_network, preserve_module_state=False
         ):
             dist = self.actor_network.get_dist(tensordict)
-            a_reparm = dist.rsample()
-        log_prob = dist.log_prob(a_reparm)
+            a_reparm, log_prob = rsample_and_log_prob(dist)
 
         td_q = tensordict.select(*self.qvalue_network.in_keys, strict=False)
         self.qvalue_network.eval()
@@ -651,9 +654,8 @@ class CrossQLoss(LossModule):
             ):
                 next_tensordict = tensordict.get("next").clone(False)
                 next_dist = self.actor_network.get_dist(next_tensordict)
-                next_action = next_dist.sample()
+                next_action, next_sample_log_prob = sample_and_log_prob(next_dist)
                 next_tensordict.set(self.tensor_keys.action, next_action)
-                next_sample_log_prob = next_dist.log_prob(next_action)
 
         combined = torch.cat(
             [

--- a/torchrl/objectives/decision_transformer.py
+++ b/torchrl/objectives/decision_transformer.py
@@ -14,6 +14,7 @@ from tensordict.nn import dispatch, ProbabilisticTensorDictSequential, TensorDic
 from tensordict.utils import NestedKey
 from torch import distributions as d
 
+from torchrl.modules.distributions.utils import rsample_and_log_prob
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import distance_loss
 
@@ -224,8 +225,7 @@ class OnlineDTLoss(LossModule):
         self._out_keys = values
 
     def get_entropy_bonus(self, dist: d.Distribution) -> torch.Tensor:
-        x = dist.rsample((self.samples_mc_entropy,))
-        log_p = dist.log_prob(x)
+        _, log_p = rsample_and_log_prob(dist, (self.samples_mc_entropy,))
         # log_p: (batch_size, context_len)
         return -log_p.mean(axis=0)
 

--- a/torchrl/objectives/llm/grpo.py
+++ b/torchrl/objectives/llm/grpo.py
@@ -37,6 +37,7 @@ from torch import distributions as d
 from torchrl._utils import logger as torchrl_logger, VERBOSE
 from torchrl.envs.transforms.ray_service import _maybe_clear_device, _maybe_to_device
 from torchrl.envs.transforms.transforms import Transform
+from torchrl.modules.distributions.utils import composite_entropy, sample_and_log_prob
 from torchrl.modules.llm import LLMWrapperBase
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import _sum_td_features, _validate_clip_epsilon
@@ -810,7 +811,11 @@ class GRPOLoss(LossModule):
         self, dist: d.Distribution, adv_shape: torch.Size
     ) -> torch.Tensor | TensorDict:
         try:
-            entropy = dist.entropy()
+            entropy = (
+                composite_entropy(dist, self.samples_mc_entropy)
+                if isinstance(dist, CompositeDistribution)
+                else dist.entropy()
+            )
             if not entropy.isfinite().all():
                 del entropy
                 if VERBOSE:
@@ -823,14 +828,14 @@ class GRPOLoss(LossModule):
                 torchrl_logger.warning(
                     f"Entropy not implemented for {type(dist)} or is not finite. Using Monte Carlo sampling."
                 )
-            if getattr(dist, "has_rsample", False):
-                x = dist.rsample((self.samples_mc_entropy,))
-            else:
-                x = dist.sample((self.samples_mc_entropy,))
             with set_composite_lp_aggregate(False) if isinstance(
                 dist, CompositeDistribution
             ) else contextlib.nullcontext():
-                log_prob = dist.log_prob(x)
+                _, log_prob = sample_and_log_prob(
+                    dist,
+                    (self.samples_mc_entropy,),
+                    reparameterize=getattr(dist, "has_rsample", False),
+                )
                 if is_tensor_collection(log_prob):
                     if isinstance(self.tensor_keys.sample_log_prob, NestedKey):
                         log_prob = log_prob.get(self.tensor_keys.sample_log_prob)

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -29,6 +29,7 @@ from tensordict.utils import NestedKey
 from torch import distributions as d
 
 from torchrl._utils import _standardize, logger as torchrl_logger, VERBOSE
+from torchrl.modules.distributions.utils import composite_entropy, sample_and_log_prob
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
@@ -662,7 +663,11 @@ class PPOLoss(LossModule):
         self, dist: d.Distribution, adv_shape: torch.Size
     ) -> torch.Tensor | TensorDict:
         try:
-            entropy = dist.entropy()
+            entropy = (
+                composite_entropy(dist, self.samples_mc_entropy)
+                if isinstance(dist, CompositeDistribution)
+                else dist.entropy()
+            )
             if not entropy.isfinite().all():
                 del entropy
                 if VERBOSE:
@@ -675,16 +680,16 @@ class PPOLoss(LossModule):
                 torchrl_logger.warning(
                     f"Entropy not implemented for {type(dist)} or is not finite. Using Monte Carlo sampling."
                 )
-            if getattr(dist, "has_rsample", False):
-                x = dist.rsample((self.samples_mc_entropy,))
-            else:
-                x = dist.sample((self.samples_mc_entropy,))
             with (
                 set_composite_lp_aggregate(False)
                 if isinstance(dist, CompositeDistribution)
                 else contextlib.nullcontext()
             ):
-                log_prob = dist.log_prob(x)
+                _, log_prob = sample_and_log_prob(
+                    dist,
+                    (self.samples_mc_entropy,),
+                    reparameterize=getattr(dist, "has_rsample", False),
+                )
                 if is_tensor_collection(log_prob):
                     if isinstance(self.tensor_keys.sample_log_prob, NestedKey):
                         log_prob = log_prob.get(self.tensor_keys.sample_log_prob)
@@ -1740,13 +1745,14 @@ class KLPENPPOLoss(PPOLoss):
         try:
             kl = torch.distributions.kl.kl_divergence(previous_dist, current_dist)
         except NotImplementedError:
-            x = previous_dist.sample((self.samples_mc_kl,))
             with (
                 set_composite_lp_aggregate(False)
                 if is_composite
                 else contextlib.nullcontext()
             ):
-                previous_log_prob = previous_dist.log_prob(x)
+                x, previous_log_prob = sample_and_log_prob(
+                    previous_dist, (self.samples_mc_kl,)
+                )
                 current_log_prob = current_dist.log_prob(x)
             if is_tensor_collection(previous_log_prob):
                 if previous_log_prob.batch_size != advantage.shape[:-1]:

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -17,6 +17,7 @@ from torch import Tensor
 
 from torchrl.data.tensor_specs import Composite
 from torchrl.envs.utils import ExplorationType, set_exploration_type, step_mdp
+from torchrl.modules.distributions.utils import rsample_and_log_prob
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
@@ -525,11 +526,9 @@ class REDQLoss(LossModule):
             sample_key = self.tensor_keys.action
             sample_key_lp = self.tensor_keys.sample_log_prob
             tensordict_actor_dist = self.actor_network.build_dist_from_params(td_params)
-            tensordict_actor.set(sample_key, tensordict_actor_dist.rsample())
-            tensordict_actor.set(
-                sample_key_lp,
-                tensordict_actor_dist.log_prob(tensordict_actor.get(sample_key)),
-            )
+            sample, sample_log_prob = rsample_and_log_prob(tensordict_actor_dist)
+            tensordict_actor.set(sample_key, sample)
+            tensordict_actor.set(sample_key_lp, sample_log_prob)
 
         # repeat tensordict_actor to match the qvalue size
         _actor_loss_td = (

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -57,6 +57,18 @@ def compute_log_prob(action_dist, action_or_tensordict, tensor_key) -> torch.Ten
     return lp
 
 
+def compute_rsample_log_prob(
+    action_dist, tensor_key
+) -> tuple[torch.Tensor | TensorDictBase, torch.Tensor]:
+    """Draw and score a reparameterized action in one operation when supported."""
+    if not isinstance(action_dist, CompositeDistribution):
+        joint_sample = getattr(action_dist, "rsample_and_log_prob", None)
+        if joint_sample is not None:
+            return joint_sample()
+    action = action_dist.rsample()
+    return action, compute_log_prob(action_dist, action, tensor_key)
+
+
 class SACLoss(LossModule):
     """TorchRL implementation of the SAC loss.
 
@@ -725,8 +737,9 @@ class SACLoss(LossModule):
             self.actor_network, preserve_module_state=False
         ):
             dist = self.actor_network.get_dist(tensordict)
-            a_reparm = dist.rsample()
-        log_prob = compute_log_prob(dist, a_reparm, self.tensor_keys.log_prob)
+            a_reparm, log_prob = compute_rsample_log_prob(
+                dist, self.tensor_keys.log_prob
+            )
 
         td_q = tensordict.select(*self.qvalue_network.in_keys, strict=False)
         td_q.set(self.tensor_keys.action, a_reparm)
@@ -853,9 +866,8 @@ class SACLoss(LossModule):
                     else:
                         next_tensordict_select = next_tensordict
                     next_dist = self.actor_network.get_dist(next_tensordict_select)
-                    next_action = next_dist.rsample()
-                    next_sample_log_prob = compute_log_prob(
-                        next_dist, next_action, self.tensor_keys.log_prob
+                    next_action, next_sample_log_prob = compute_rsample_log_prob(
+                        next_dist, self.tensor_keys.log_prob
                     )
                     if next_tensordict_select is not next_tensordict:
                         mask = ~done.squeeze(-1)
@@ -878,11 +890,10 @@ class SACLoss(LossModule):
                     next_tensordict.set(self.tensor_keys.action, next_action)
                 else:
                     next_dist = self.actor_network.get_dist(next_tensordict)
-                    next_action = next_dist.rsample()
-                    next_tensordict.set(self.tensor_keys.action, next_action)
-                    next_sample_log_prob = compute_log_prob(
-                        next_dist, next_action, self.tensor_keys.log_prob
+                    next_action, next_sample_log_prob = compute_rsample_log_prob(
+                        next_dist, self.tensor_keys.log_prob
                     )
+                    next_tensordict.set(self.tensor_keys.action, next_action)
 
             # get q-values
             next_tensordict_expand = self._vmap_qnetworkN0(
@@ -943,7 +954,7 @@ class SACLoss(LossModule):
             self.actor_network, preserve_module_state=False
         ):
             action_dist = self.actor_network.get_dist(td_copy)  # resample an action
-        action = action_dist.rsample()
+        action, log_p = compute_rsample_log_prob(action_dist, self.tensor_keys.log_prob)
 
         td_copy.set(self.tensor_keys.action, action, inplace=False)
 
@@ -955,8 +966,6 @@ class SACLoss(LossModule):
         min_qval = (
             td_copy.get(self.tensor_keys.state_action_value).squeeze(-1).min(0)[0]
         )
-
-        log_p = compute_log_prob(action_dist, action, self.tensor_keys.log_prob)
 
         if log_p.shape != min_qval.shape:
             raise RuntimeError(

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -15,7 +15,6 @@ import torch
 from tensordict import TensorDict, TensorDictBase, TensorDictParams
 from tensordict.nn import (
     composite_lp_aggregate,
-    CompositeDistribution,
     dispatch,
     ProbabilisticTensorDictSequential,
     set_composite_lp_aggregate,
@@ -27,6 +26,7 @@ from torch import Tensor
 from torchrl.data.tensor_specs import Composite, TensorSpec
 from torchrl.data.utils import _find_action_space
 from torchrl.envs.utils import ExplorationType, set_exploration_type
+from torchrl.modules.distributions.utils import rsample_and_log_prob
 from torchrl.modules.tensordict_module.actors import ActorCriticWrapper
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
@@ -48,25 +48,12 @@ def _delezify(func):
     return new_func
 
 
-def compute_log_prob(action_dist, action_or_tensordict, tensor_key) -> torch.Tensor:
-    """Compute the log probability of an action given a distribution."""
-    lp = action_dist.log_prob(action_or_tensordict)
-    if isinstance(action_dist, CompositeDistribution):
-        with set_composite_lp_aggregate(False):
-            return sum(lp.sum(dim="feature").values(True, True))
-    return lp
-
-
 def compute_rsample_log_prob(
-    action_dist, tensor_key
+    action_dist,
 ) -> tuple[torch.Tensor | TensorDictBase, torch.Tensor]:
-    """Draw and score a reparameterized action in one operation when supported."""
-    if not isinstance(action_dist, CompositeDistribution):
-        joint_sample = getattr(action_dist, "rsample_and_log_prob", None)
-        if joint_sample is not None:
-            return joint_sample()
-    action = action_dist.rsample()
-    return action, compute_log_prob(action_dist, action, tensor_key)
+    """Draw and score an action, aggregating composite log-probabilities."""
+    with set_composite_lp_aggregate(True):
+        return rsample_and_log_prob(action_dist)
 
 
 class SACLoss(LossModule):
@@ -737,9 +724,7 @@ class SACLoss(LossModule):
             self.actor_network, preserve_module_state=False
         ):
             dist = self.actor_network.get_dist(tensordict)
-            a_reparm, log_prob = compute_rsample_log_prob(
-                dist, self.tensor_keys.log_prob
-            )
+            a_reparm, log_prob = compute_rsample_log_prob(dist)
 
         td_q = tensordict.select(*self.qvalue_network.in_keys, strict=False)
         td_q.set(self.tensor_keys.action, a_reparm)
@@ -867,7 +852,7 @@ class SACLoss(LossModule):
                         next_tensordict_select = next_tensordict
                     next_dist = self.actor_network.get_dist(next_tensordict_select)
                     next_action, next_sample_log_prob = compute_rsample_log_prob(
-                        next_dist, self.tensor_keys.log_prob
+                        next_dist
                     )
                     if next_tensordict_select is not next_tensordict:
                         mask = ~done.squeeze(-1)
@@ -891,7 +876,7 @@ class SACLoss(LossModule):
                 else:
                     next_dist = self.actor_network.get_dist(next_tensordict)
                     next_action, next_sample_log_prob = compute_rsample_log_prob(
-                        next_dist, self.tensor_keys.log_prob
+                        next_dist
                     )
                     next_tensordict.set(self.tensor_keys.action, next_action)
 
@@ -954,7 +939,7 @@ class SACLoss(LossModule):
             self.actor_network, preserve_module_state=False
         ):
             action_dist = self.actor_network.get_dist(td_copy)  # resample an action
-        action, log_p = compute_rsample_log_prob(action_dist, self.tensor_keys.log_prob)
+        action, log_p = compute_rsample_log_prob(action_dist)
 
         td_copy.set(self.tensor_keys.action, action, inplace=False)
 

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -18,6 +18,7 @@ from tensordict import is_tensor_collection, TensorDictBase
 from tensordict.nn import (
     composite_lp_aggregate,
     dispatch,
+    InteractionType,
     ProbabilisticTensorDictModule,
     set_composite_lp_aggregate,
     set_skip_existing,
@@ -30,6 +31,7 @@ from torch import Tensor
 
 from torchrl._utils import logger, rl_warnings
 from torchrl.envs.utils import step_mdp
+from torchrl.modules.distributions.utils import sample_and_log_prob
 from torchrl.objectives.utils import (
     _maybe_get_or_select,
     _pseudo_vmap,
@@ -91,7 +93,16 @@ def _call_actor_net(
     log_prob_key: NestedKey,
 ):
     dist = actor_net.get_dist(data.select(*actor_net.in_keys, strict=False))
-    s = actor_net._dist_sample(dist, interaction_type=interaction_type())
+    current_interaction = interaction_type() or actor_net.default_interaction_type
+    if current_interaction is InteractionType.RANDOM:
+        sample_shape = actor_net.num_samples or torch.Size()
+        with set_composite_lp_aggregate(True):
+            _, log_prob = sample_and_log_prob(
+                dist, sample_shape, reparameterize=dist.has_rsample
+            )
+        return log_prob
+
+    s = actor_net._dist_sample(dist, interaction_type=current_interaction)
     with set_composite_lp_aggregate(True):
         return dist.log_prob(s)
 


### PR DESCRIPTION
## Description

Fix `TanhNormal.rsample() -> log_prob()` when finite-precision tanh saturation prevents `atanh(action)` from recovering the generating preimage, corrupting SAC scores and gradients.

`TanhNormal` now retains one forward-produced preimage and reuses it only for its unchanged sample. External or mutated values use the ordinary inverse path, and `update()` clears the cache. Compilation, inference, and CUDA capture validate the sample through a tensor snapshot. There are no clamps, flags, or training-specific defaults.

### Testing

- Direct final-head checks: `main` misses the score by `16,312` and the scale gradient by `165,992`; this PR is within `7.63e-6` and `9.54e-7` in eager, Dynamo eager, and Inductor.


<img width="1980" height="810" alt="tanhnormal_exact_preimage_h100" src="https://github.com/user-attachments/assets/e1286bc2-b2b8-4621-8e92-b1f637e31a49" />


- Matched MultiWalker SAC, 3 seeds × 2M frames: every `main` run develops score corruption and exploding losses; corrected runs keep score error at `0.0` and raw critic loss at or below `23.6`. E2E ran at `efb3a592b`; final head only adds the CUDA-capture dispatch validated below.

<img width="2520" height="1620" alt="multiwalker_main_vs_fix" src="https://github.com/user-attachments/assets/b9b86d87-cfc0-41f8-bbab-62fd5328a2cc" />


- Final head `be7a48dba`: focused H100 `18 passed`; distributions `974 passed`; pre-commit passes. Objectives at the behavior-identical E2E head: `7528 passed, 2324 skipped, 6 deselected`.
- Safe/unsafe tanh with ordinary/custom bounds passes inference and CUDA graph within `7.63e-6`; scale-gradient error is at most `4.55e-7`, with zero allocated-memory growth across 20,000 iterations.

The cached sample keeps its generating loc/scale gradient path. Cloned and external actions retain ordinary action gradients.

Closes #2199

cc @vmoens @theap06 
