### PR TITLE
[BugFix] Detect empty distillation sequences in multidimensional batches

### DIFF
--- a/test/llm/test_llm_objectives.py
+++ b/test/llm/test_llm_objectives.py
@@ -14,6 +14,7 @@ import tensordict
 import torch
 
 from tensordict import lazy_stack, MetaData, TensorDict
+from tensordict.nn import TensorDictModule
 from torchrl._utils import logger
 from torchrl.data import History, LazyStackStorage, ReplayBuffer
 from torchrl.data.llm.history import _CHAT_TEMPLATES
@@ -1219,6 +1220,28 @@ class TestDistillation:
             DistillationLoss(actor_network=None, kl_direction="sideways")
         with pytest.raises(ValueError, match="reduction"):
             DistillationLoss(actor_network=None, reduction="average")
+
+    def test_distillation_empty_sequence_in_multidimensional_batch_raises(self):
+        mask = torch.ones(2, 2, 3, dtype=torch.bool)
+        mask[0, 1] = False
+        student_log_probs = torch.full((2, 2, 3), -1.0)
+        data = TensorDict(
+            {
+                ("history", "full"): student_log_probs,
+                ("masks", "all_attention_mask"): mask,
+                ("masks", "all_assistant_mask"): mask,
+                ("next", "teacher_log_probs", "full"): torch.full((2, 2, 3), -2.0),
+            },
+            batch_size=(2, 2),
+        )
+        student = TensorDictModule(
+            torch.nn.Identity(),
+            in_keys=[("history", "full")],
+            out_keys=[("log_probs", "full")],
+        )
+
+        with pytest.raises(ValueError, match="Some sequences"):
+            DistillationLoss(actor_network=student)(data)
 
     @pytest.mark.skipif(
         not _has_transformers, reason="transformers lib required to test distillation"

--- a/torchrl/objectives/llm/distillation.py
+++ b/torchrl/objectives/llm/distillation.py
@@ -428,7 +428,8 @@ class DistillationLoss(LossModule):
     def forward(self, tensordict: TensorDictBase) -> DistillationLossOutput:
         history: History = tensordict[self.tensor_keys.history]
         masks, attention_masks, assistant_masks = self._get_masks(tensordict, history)
-        if any(not mask.any() for mask in masks):
+        token_dim = tensordict.ndim - 1
+        if any((~mask.any(dim=token_dim)).any() for mask in masks):
             raise ValueError(
                 "Some sequences have no tokens selected for distillation. "
                 "Check the assistant/attention masks of the input."
@@ -482,9 +483,9 @@ class DistillationLoss(LossModule):
                 kl = k3_kl_token_estimate(lp, tlp)
             kl_tokens.append(kl)
 
-        summed_kl = torch.stack([kl.sum(tensordict.ndim - 1) for kl in kl_tokens])
+        summed_kl = torch.stack([kl.sum(token_dim) for kl in kl_tokens])
         if self.normalize_by_seq_length:
-            seq_lengths = torch.stack([mask.sum(tensordict.ndim - 1) for mask in masks])
+            seq_lengths = torch.stack([mask.sum(token_dim) for mask in masks])
             summed_kl = summed_kl / seq_lengths.clamp(min=1)
 
         loss = _distillation_loss(summed_kl, self.reduction)


### PR DESCRIPTION
## Description

Fixes `DistillationLoss`'s empty-sequence validation for multidimensional TensorDict batches. The previous `mask.any()` check collapsed both the token and remaining batch dimensions after the outer iteration, so an empty sequence was accepted whenever a sibling sequence selected at least one token.

The validation now reduces only the token dimension and checks every resulting per-sequence flag. The same token-dimension value is reused by the existing KL and sequence-length reductions. A transformers-free regression covers a `[2, 2]` batch where exactly one sequence is empty.

Closes #4081

## Motivation and Context

An accepted empty sequence silently received a zero loss because normalization clamps the zero token count. Grouped LLM batches such as `[prompts, generations]` could therefore hide malformed masks instead of raising the documented validation error.

- [x] I have raised an issue to propose this change: #4081

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Validation

- `python -m pytest test/llm/test_llm_objectives.py -q -k "distillation and not integration"`: 16 passed
- `python -m pytest test/llm/test_llm_objectives.py -q -m "not slow and not integration"`: 69 passed, 1 skipped, 2 deselected
- Repository pre-commit hooks on both changed files: all passed (ufmt, flake8, pydocstyle, pyupgrade, codespell, autoflake, docstring checks, and file checks)
- `git diff --check`: passed

## Checklist

- [x] I have read the CONTRIBUTING guide and CLAUDE.md.
- [x] I have updated the tests accordingly.
- [ ] My change requires a documentation update.
- [ ] I have updated the documentation accordingly.

## AI assistance disclosure

I used OpenAI Codex to help inspect the implementation, construct and run the pristine reproduction, search issues/pull requests/commits and the introducing PR for duplicates, implement the focused fix and regression, run validation, and draft this pull request. I reviewed the diff and reproduced the behavior before submission.
