### PR TITLE
[Refactor] Centralize replay trajectory-boundary queries

### DIFF
--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -48,6 +48,7 @@ from torchrl.data.replay_buffers.storages import (
     LazyTensorStorage,
     ListStorage,
 )
+from torchrl.data.replay_buffers.utils import _ReplayBoundaryIndex
 from torchrl.modules import GRUModule, set_recurrent_mode
 from torchrl.testing import get_default_devices
 
@@ -2730,6 +2731,20 @@ class TestFindStartStopTraj:
         result = sampler._find_start_stop_traj(at_capacity=at_capacity, **kwargs)
         for r, e in zip(result, expected):
             assert (r == e).all()
+
+    def test_boundary_index_anchor_distances(self):
+        end = torch.zeros(10, dtype=torch.bool)
+        end[2] = end[7] = True
+        boundary = _ReplayBoundaryIndex(end=end, at_capacity=True, cursor=4)
+        distance_from_start, distance_to_stop = boundary.distances(
+            torch.tensor([9, 3, 6])
+        )
+        assert distance_from_start.tolist() == [1, 0, 1]
+        assert distance_to_stop.tolist() == [3, 1, 1]
+        start, stop, lengths = boundary.boundaries()
+        assert start.squeeze(-1).tolist() == [8, 3, 5]
+        assert stop.squeeze(-1).tolist() == [2, 4, 7]
+        assert lengths.tolist() == [5, 2, 3]
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")

--- a/torchrl/data/replay_buffers/sample_units.py
+++ b/torchrl/data/replay_buffers/sample_units.py
@@ -12,7 +12,7 @@ from tensordict import is_tensor_collection
 from tensordict.utils import NestedKey
 
 from torchrl.data.replay_buffers.storages import TensorStorage
-from torchrl.data.replay_buffers.utils import _derive_end_flags, _end_to_start_stop
+from torchrl.data.replay_buffers.utils import _ReplayBoundaryIndex
 
 if TYPE_CHECKING:
     from torchrl.data.replay_buffers.storages import Storage
@@ -347,35 +347,16 @@ class Sequence(SampleUnit):
                 if self.done_key is not None
                 else torch.zeros(len(storage), dtype=torch.bool, device=device)
             )
-            end, max_len = _derive_end_flags(
+            while done.ndim > storage.ndim and done.shape[-1] == 1:
+                done = done.squeeze(-1)
+            boundary = _ReplayBoundaryIndex(
                 end=done,
                 at_capacity=storage._is_full,
                 cursor=getattr(storage, "_last_cursor", None),
+                device=device,
             )
-            # _end_to_start_stop returns its indices on the device of ``end``
-            # (the storage device): move the flags first so start/stop live
-            # on the anchor device.
-            end = end.to(device)
-            start, stop, _ = _end_to_start_stop(end=end, length=max_len, device=device)
-            start = start[:, 0]
-            stop = stop[:, 0]
-
-            start_exp = start.unsqueeze(0)
-            stop_exp = stop.unsqueeze(0)
-            a_exp = anchor.unsqueeze(1)
-
-            cond1 = (start_exp <= stop_exp) & (start_exp <= a_exp) & (a_exp <= stop_exp)
-            cond2 = (start_exp > stop_exp) & (
-                (a_exp >= start_exp) | (a_exp <= stop_exp)
-            )
-            mask = cond1 | cond2
-
-            traj_idx = mask.float().argmax(dim=1)
-            a_start = start[traj_idx]
-            a_stop = stop[traj_idx]
-
-            dist_to_stop = ((a_stop - anchor) % max_len).to(torch.long)
-            dist_from_start = ((anchor - a_start) % max_len).to(torch.long)
+            dist_from_start, dist_to_stop = boundary.distances(anchor)
+            max_len = boundary.length
 
             anchor_eff = anchor
             if self.episode_boundary == "stop":

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -26,9 +26,9 @@ from torchrl._utils import _replace_last, logger, rl_warnings
 from torchrl.data.replay_buffers.storages import Storage, StorageEnsemble, TensorStorage
 from torchrl.data.replay_buffers.utils import (
     _auto_device,
-    _derive_end_flags,
     _end_to_start_stop,
     _is_int,
+    _ReplayBoundaryIndex,
     unravel_index,
 )
 
@@ -2184,10 +2184,17 @@ class SliceSampler(Sampler):
         # torchrl.data.find_start_stop_traj). Kept as a method, dispatching
         # through self._end_to_start_stop, so that subclasses overriding
         # either hook keep working and the sampler's GPU device is applied.
-        end, length = _derive_end_flags(
-            trajectory=trajectory, end=end, at_capacity=at_capacity, cursor=cursor
+        boundary = _ReplayBoundaryIndex(
+            trajectory=trajectory,
+            end=end,
+            at_capacity=at_capacity,
+            cursor=cursor,
+            device=self._gpu_device,
+            end_to_start_stop=lambda end, length: self._end_to_start_stop(
+                end=end, length=length
+            ),
         )
-        return self._end_to_start_stop(end=end, length=length)
+        return boundary.boundaries()
 
     def _end_to_start_stop(self, end, length):
         return _end_to_start_stop(end=end, length=length, device=self._gpu_device)

--- a/torchrl/data/replay_buffers/utils.py
+++ b/torchrl/data/replay_buffers/utils.py
@@ -211,6 +211,79 @@ def find_start_stop_traj(
     return _end_to_start_stop(end=end, length=length, device=device)
 
 
+class _ReplayBoundaryIndex:
+    """Shared trajectory boundaries for replay components."""
+
+    def __init__(
+        self,
+        *,
+        trajectory: torch.Tensor | None = None,
+        end: torch.Tensor | None = None,
+        at_capacity: bool,
+        cursor: int | torch.Tensor | range | None = None,
+        device: torch.device | None = None,
+        end_to_start_stop: (
+            Callable[
+                [torch.Tensor, int], tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+            ]
+            | None
+        ) = None,
+    ) -> None:
+        end, length = _derive_end_flags(
+            trajectory=trajectory,
+            end=end,
+            at_capacity=at_capacity,
+            cursor=cursor,
+        )
+        self.end = end
+        self.length = length
+        self.device = device
+        self._end_to_start_stop_fn = end_to_start_stop
+        self._boundaries = None
+
+    def boundaries(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Returns canonical inclusive starts, stops, and trajectory lengths."""
+        boundaries = self._boundaries
+        if boundaries is None:
+            if self._end_to_start_stop_fn is None:
+                boundaries = _end_to_start_stop(
+                    end=self.end, length=self.length, device=self.device
+                )
+            else:
+                boundaries = self._end_to_start_stop_fn(self.end, self.length)
+            self._boundaries = boundaries
+        return boundaries
+
+    def distances(self, anchor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Returns distances from starts and to stops for each anchor."""
+        start, stop, _ = self.boundaries()
+        if start.shape[-1] != 1:
+            raise NotImplementedError(
+                "Anchor boundary queries currently require one-dimensional storage."
+            )
+        start = start[:, 0].to(anchor.device)
+        stop = stop[:, 0].to(anchor.device)
+        start_exp = start.unsqueeze(0)
+        stop_exp = stop.unsqueeze(0)
+        anchor_exp = anchor.unsqueeze(1)
+        in_linear_trajectory = (
+            (start_exp <= stop_exp)
+            & (start_exp <= anchor_exp)
+            & (anchor_exp <= stop_exp)
+        )
+        in_wrapped_trajectory = (start_exp > stop_exp) & (
+            (anchor_exp >= start_exp) | (anchor_exp <= stop_exp)
+        )
+        trajectory_index = (
+            (in_linear_trajectory | in_wrapped_trajectory).to(torch.int64).argmax(dim=1)
+        )
+        anchor_start = start[trajectory_index]
+        anchor_stop = stop[trajectory_index]
+        distance_from_start = torch.remainder(anchor - anchor_start, self.length)
+        distance_to_stop = torch.remainder(anchor_stop - anchor, self.length)
+        return distance_from_start.to(torch.long), distance_to_stop.to(torch.long)
+
+
 def _derive_end_flags(
     *,
     trajectory: torch.Tensor | None = None,


### PR DESCRIPTION
## Summary

Unifies trajectory-boundary recovery for `Sequence` and `SliceSampler` behind `_ReplayBoundaryIndex`. This is a refactor with no intended behavior change.

Stack: #4084, then #4085.

## Tests

Focused boundary and sampler tests; pre-commit checks.
