### PR TITLE
[Performance] Cache and vectorize replay-boundary queries

### DIFF
--- a/benchmarks/test_replaybuffer_benchmark.py
+++ b/benchmarks/test_replaybuffer_benchmark.py
@@ -25,8 +25,10 @@ from torchrl.data.replay_buffers import (
     RandomSampler,
     RoundRobinWriter,
     SamplerWithoutReplacement,
+    Sequence,
     SliceSampler,
 )
+from torchrl.data.replay_buffers.utils import _boundary_distances_1d
 from torchrl.envs.transforms import ActionChunkTransform, CatFrames
 
 _TensorDictPrioritizedReplayBuffer = functools.partial(
@@ -75,6 +77,87 @@ def populate(rb, td):
 
 def sample(rb):
     rb.sample()
+
+
+def _replay_boundary_device():
+    device = os.getenv("TORCHRL_BENCHMARK_DEVICE")
+    if device == "GPU":
+        if not torch.cuda.is_available():
+            _skip_or_fail_unavailable("CUDA is not available")
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+def _make_boundary_storage(size, episode_length, device):
+    done = torch.zeros(size, 1, dtype=torch.bool, device=device)
+    done[episode_length - 1 :: episode_length] = True
+    done[-1] = True
+    rb = TensorDictReplayBuffer(
+        storage=LazyTensorStorage(size, device=device),
+    )
+    rb.extend(TensorDict({("next", "done"): done}, [size], device=device))
+    return rb
+
+
+@pytest.mark.parametrize("size", [10_000, 1_000_000])
+@pytest.mark.parametrize("episode_length", [32, 256])
+@pytest.mark.parametrize("cache_state", ["hot", "write_invalidated"])
+def test_sequence_boundary_query_benchmark(
+    benchmark, size, episode_length, cache_state
+):
+    device = _replay_boundary_device()
+    rb = _make_boundary_storage(size, episode_length, device)
+    anchor = torch.linspace(0, size - 1, 256, device=device).to(torch.long)
+    unit = Sequence(length=64, burn_in=40, bootstrap=5)
+    unit.expand(anchor, {}, rb.storage)
+
+    if cache_state == "write_invalidated":
+
+        def query():
+            rb.storage._bump_mutation_revision()
+            return unit.expand(anchor, {}, rb.storage)
+
+    else:
+
+        def query():
+            return unit.expand(anchor, {}, rb.storage)
+
+    benchmark(query)
+
+
+@pytest.mark.parametrize("size", [10_000, 1_000_000])
+@pytest.mark.parametrize("episode_length", [32, 256])
+@pytest.mark.parametrize("cache_values", [False, True])
+def test_slice_sampler_boundary_query_benchmark(
+    benchmark, size, episode_length, cache_values
+):
+    device = _replay_boundary_device()
+    rb = _make_boundary_storage(size, episode_length, device)
+    sampler = SliceSampler(
+        num_slices=256,
+        cache_values=cache_values,
+        end_key=("next", "done"),
+    )
+    benchmark(sampler._get_stop_and_length, rb.storage)
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_replay_boundary_kernel_benchmark(benchmark, compiled):
+    device = _replay_boundary_device()
+    size = 1_000_000
+    episode_length = 256
+    stop = torch.arange(
+        episode_length - 1, size, episode_length, device=device, dtype=torch.long
+    )
+    if stop[-1] != size - 1:
+        stop = torch.cat([stop, stop.new_tensor([size - 1])])
+    start = torch.remainder(torch.roll(stop, 1) + 1, size)
+    anchor = torch.linspace(0, size - 1, 256, device=device).to(torch.long)
+    query = _boundary_distances_1d
+    if compiled:
+        query = torch.compile(query, fullgraph=True)
+        query(anchor, start, stop, size)
+    benchmark(query, anchor, start, stop, size)
 
 
 def test_replay_buffer_direct_client_identity(benchmark):

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -106,6 +106,39 @@ def test_replay_buffer_read_write_all_in_order_with_end():
     assert updated["obs"].tolist() == [10, 11, 12, 3, 4, 5]
 
 
+def test_storage_mutation_revision_for_buffer_write_paths():
+    rb = TensorDictReplayBuffer(storage=LazyTensorStorage(8))
+    assert rb.storage._mutation_revision == 0
+
+    rb.extend(TensorDict({"obs": torch.arange(4)}, [4]))
+    revision = rb.storage._mutation_revision
+    assert revision == 1
+
+    rb[0] = TensorDict({"obs": torch.tensor(10)}, [])
+    assert rb.storage._mutation_revision == revision + 1
+    revision += 1
+
+    rb.set_at_("obs", torch.tensor([11]), torch.tensor([1]))
+    assert rb.storage._mutation_revision == revision + 1
+    revision += 1
+
+    rb.set_("obs", torch.arange(4) + 20)
+    assert rb.storage._mutation_revision == revision + 1
+    revision += 1
+
+    rb.update_(TensorDict({"obs": torch.arange(4) + 30}, [4]))
+    assert rb.storage._mutation_revision == revision + 1
+    revision += 1
+
+    state = rb.state_dict()
+    rb.load_state_dict(state)
+    assert rb.storage._mutation_revision == revision + 1
+    revision += 1
+
+    rb.empty()
+    assert rb.storage._mutation_revision == revision + 1
+
+
 def test_replay_buffer_read_write_all_in_order_matches_full_slice_ndim2():
     rb = TensorDictReplayBuffer(storage=LazyTensorStorage(6, ndim=2))
     rb_slice = TensorDictReplayBuffer(storage=LazyTensorStorage(6, ndim=2))

--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -48,7 +48,12 @@ from torchrl.data.replay_buffers.storages import (
     LazyTensorStorage,
     ListStorage,
 )
-from torchrl.data.replay_buffers.utils import _ReplayBoundaryIndex
+from torchrl.data.replay_buffers.utils import (
+    _boundary_distances_1d,
+    _boundary_distances_nd,
+    _make_boundary_search_nd,
+    _ReplayBoundaryIndex,
+)
 from torchrl.modules import GRUModule, set_recurrent_mode
 from torchrl.testing import get_default_devices
 
@@ -2745,6 +2750,93 @@ class TestFindStartStopTraj:
         assert start.squeeze(-1).tolist() == [8, 3, 5]
         assert stop.squeeze(-1).tolist() == [2, 4, 7]
         assert lengths.tolist() == [5, 2, 3]
+
+    def test_boundary_index_cache_and_storage_invalidation(self):
+        storage = LazyTensorStorage(10)
+        rb = TensorDictReplayBuffer(storage=storage, dim_extend=0)
+        done = torch.zeros(10, dtype=torch.bool)
+        done[[4, 9]] = True
+        rb.extend(TensorDict({"done": done}, [10]))
+
+        def make_boundary():
+            return _ReplayBoundaryIndex(
+                end=storage[:]["done"],
+                at_capacity=storage._is_full,
+                cursor=storage._last_cursor_index,
+                storage=storage,
+                source=("end", "done"),
+                cache_values=True,
+            )
+
+        first = make_boundary().boundaries()
+        second = make_boundary().boundaries()
+        assert first[0].data_ptr() == second[0].data_ptr()
+
+        updated = storage.get(4).clone()
+        updated["done"] = False
+        storage.set(4, updated, set_cursor=False)
+        third = make_boundary().boundaries()
+        assert third[0].data_ptr() != first[0].data_ptr()
+        assert third[1].squeeze(-1).tolist() == [9]
+
+    def test_slice_sampler_cache_uses_storage_revision(self):
+        storage = LazyTensorStorage(10)
+        sampler = SliceSampler(slice_len=2, end_key="done", cache_values=True)
+        rb = TensorDictReplayBuffer(storage=storage, sampler=sampler)
+        done = torch.zeros(10, dtype=torch.bool)
+        done[[4, 9]] = True
+        rb.extend(TensorDict({"done": done}, [10]))
+
+        first = sampler._get_stop_and_length(storage)
+        second = sampler._get_stop_and_length(storage)
+        assert first[0].data_ptr() == second[0].data_ptr()
+
+        updated = storage.get(4).clone()
+        updated["done"] = False
+        storage.set(4, updated, set_cursor=False)
+        third = sampler._get_stop_and_length(storage)
+        assert third[0].data_ptr() != first[0].data_ptr()
+        assert third[1].squeeze(-1).tolist() == [9]
+
+    def test_boundary_distance_kernel_fullgraph(self):
+        start = torch.tensor([8, 3, 5])
+        stop = torch.tensor([2, 4, 7])
+        anchor = torch.tensor([9, 3, 6])
+        compiled = torch.compile(
+            _boundary_distances_1d, backend="eager", fullgraph=True
+        )
+        eager = _boundary_distances_1d(anchor, start, stop, 10)
+        result = compiled(anchor, start, stop, 10)
+        torch.testing.assert_close(result, eager)
+
+    def test_multidimensional_boundary_index_and_fullgraph(self):
+        storage = LazyTensorStorage(10, ndim=2)
+        rb = TensorDictReplayBuffer(storage=storage, dim_extend=0)
+        done = torch.zeros(5, 2, 1, dtype=torch.bool)
+        done[1, 0] = done[2, 1] = True
+        done[4] = True
+        rb.extend(TensorDict({("next", "done"): done}, [5, 2]))
+        boundary = _ReplayBoundaryIndex(
+            end=done.squeeze(-1),
+            at_capacity=True,
+            cursor=storage._last_cursor_index,
+            storage=storage,
+            source=("end", ("next", "done")),
+            cache_values=True,
+        )
+        anchor = torch.tensor([[0, 0], [4, 0], [1, 1], [4, 1]])
+        distance_from_start, distance_to_stop = boundary.distances(anchor)
+        assert distance_from_start.tolist() == [0, 2, 1, 1]
+        assert distance_to_stop.tolist() == [1, 0, 1, 0]
+
+        start, stop, _ = boundary.boundaries()
+        search = _make_boundary_search_nd(start, stop, tuple(storage.shape))
+        compiled = torch.compile(
+            _boundary_distances_nd, backend="eager", fullgraph=True
+        )
+        eager = _boundary_distances_nd(anchor, start, stop, *search, 5)
+        result = compiled(anchor, start, stop, *search, 5)
+        torch.testing.assert_close(result, eager)
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")

--- a/test/rb/test_storages.py
+++ b/test/rb/test_storages.py
@@ -43,6 +43,7 @@ from torch.utils._pytree import tree_flatten, tree_map
 from torchrl.data import (
     CompressedListStorage,
     ReplayBuffer,
+    Sequence,
     TensorDictPrioritizedReplayBuffer,
     TensorDictReplayBuffer,
 )
@@ -882,6 +883,58 @@ class TestSharedStorageInit:
         assert len(rb) >= length + 2
         assert (rb[index] == data).all()
         queue.put("done")
+
+    def revision_worker(self, rb, queue):
+        rb.extend(TensorDict({"x": torch.arange(2)}, batch_size=(2,)))
+        queue.put(rb.storage._mutation_revision)
+
+    def boundary_worker(self, rb, queue):
+        rb[1] = TensorDict(
+            {"obs": torch.tensor(1), ("next", "done"): torch.tensor(True)},
+            [],
+        )
+        queue.put(rb.storage._mutation_revision)
+
+    def test_mutation_revision_shared_across_processes(self):
+        storage = LazyTensorStorage(max_size=8)
+        rb = TensorDictReplayBuffer(storage=storage).share(True)
+        rb.extend(TensorDict({"x": torch.arange(2)}, batch_size=(2,)))
+        assert storage._mutation_revision == 1
+
+        queue = mp.Queue()
+        process = mp.Process(target=self.revision_worker, args=(rb, queue))
+        process.start()
+        process.join()
+        assert process.exitcode == 0
+        assert queue.get(timeout=5) == 2
+        assert storage._mutation_revision == 2
+        assert storage._last_cursor_index == 3
+
+    def test_sequence_boundary_cache_invalidated_across_processes(self):
+        done = torch.zeros(8, dtype=torch.bool)
+        done[[3, 7]] = True
+        storage = LazyTensorStorage(max_size=8)
+        rb = TensorDictReplayBuffer(storage=storage).share(True)
+        rb.extend(
+            TensorDict(
+                {"obs": torch.arange(8), ("next", "done"): done},
+                batch_size=(8,),
+            )
+        )
+        unit = Sequence(length=4)
+        before, _ = unit.expand(torch.tensor([0]), {}, storage)
+        assert before.tolist() == [0, 1, 2, 3]
+
+        queue = mp.Queue()
+        process = mp.Process(target=self.boundary_worker, args=(rb, queue))
+        process.start()
+        process.join()
+        assert process.exitcode == 0
+        assert queue.get(timeout=5) == 2
+
+        after, info = unit.expand(torch.tensor([0]), {}, storage)
+        assert after.tolist() == [0, 1, 1, 1]
+        assert info["validity_mask"].tolist() == [True, True, False, False]
 
     @pytest.mark.parametrize(
         "storage_cls, use_tmpdir",

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -1492,6 +1492,7 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
         index = _to_numpy(index)
         with self._replay_lock:
             self._storage[:].set_at_(key, value, index)
+            self._storage._bump_mutation_revision()
         return self
 
     @_maybe_delay_init
@@ -1508,6 +1509,7 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
         """
         with self._replay_lock:
             self._storage[:].set_(key, value)
+            self._storage._bump_mutation_revision()
         return self
 
     @_maybe_delay_init
@@ -1531,6 +1533,7 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
                 clone=clone,
                 keys_to_update=keys_to_update,
             )
+            self._storage._bump_mutation_revision()
         return self
 
     @_maybe_delay_init
@@ -2058,7 +2061,7 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             predicate=predicate,
             trajectory_key=trajectory_key,
             at_capacity=bool(storage._is_full),
-            cursor=getattr(storage, "_last_cursor", None),
+            cursor=getattr(storage, "_last_cursor_index", None),
         )
 
     @_maybe_delay_init

--- a/torchrl/data/replay_buffers/sample_units.py
+++ b/torchrl/data/replay_buffers/sample_units.py
@@ -271,6 +271,9 @@ class Sequence(SampleUnit):
     @staticmethod
     def _newest_index(storage: Storage, written: int) -> int:
         """Physical index of the most recently written record."""
+        cursor = getattr(storage, "_last_cursor_index", None)
+        if cursor is not None:
+            return cursor % written
         cursor = getattr(storage, "_last_cursor", None)
         if isinstance(cursor, torch.Tensor):
             cursor = cursor.reshape(-1)
@@ -352,8 +355,11 @@ class Sequence(SampleUnit):
             boundary = _ReplayBoundaryIndex(
                 end=done,
                 at_capacity=storage._is_full,
-                cursor=getattr(storage, "_last_cursor", None),
+                cursor=getattr(storage, "_last_cursor_index", None),
                 device=device,
+                storage=storage,
+                source=("end", self.done_key),
+                cache_values=True,
             )
             dist_from_start, dist_to_stop = boundary.distances(anchor)
             max_len = boundary.length

--- a/torchrl/data/replay_buffers/samplers.py
+++ b/torchrl/data/replay_buffers/samplers.py
@@ -1751,24 +1751,9 @@ class SliceSampler(Sampler):
             if the last element of the trajectory tensor is identical to the first,
             the same trajectory spans across end and beginning.
         cache_values (bool, optional): to be used with static datasets.
-            Will cache the start and end signal of the trajectory. This can be safely used even
-            if the trajectory indices change during calls to :class:`~torchrl.data.ReplayBuffer.extend`
-            as this operation will erase the cache.
-
-            .. warning:: ``cache_values=True`` will not work if the sampler is used with a
-                storage that is extended by another buffer. For instance:
-
-                    >>> buffer0 = ReplayBuffer(storage=storage,
-                    ...     sampler=SliceSampler(num_slices=8, cache_values=True),
-                    ...     writer=ImmutableWriter())
-                    >>> buffer1 = ReplayBuffer(storage=storage,
-                    ...     sampler=other_sampler)
-                    >>> # Wrong! Does not erase the buffer from the sampler of buffer0
-                    >>> buffer1.extend(data)
-
-            .. warning:: ``cache_values=True`` will not work as expected if the buffer is
-                shared between processes and one process is responsible for writing
-                and one process for sampling, as erasing the cache can only be done locally.
+            Caches trajectory boundaries until the storage revision changes,
+            including writes from another buffer or process. Direct backing
+            tensor mutations cannot be detected.
 
         truncated_key (NestedKey, optional): If not ``None``, this argument
             indicates where a truncated signal should be written in the output
@@ -2095,7 +2080,7 @@ class SliceSampler(Sampler):
                 trajectory=trajectories,
                 at_capacity=True,
             )
-            self._cache["stop-and-length"] = vals
+            self._cache["static-stop-and-length"] = vals
 
         elif ends is not None:
             if traj_key is not None or end_key or end_keys:
@@ -2109,7 +2094,7 @@ class SliceSampler(Sampler):
                     "To be used, ends requires `cache_values` to be set to `True`."
                 )
             vals = self._find_start_stop_traj(end=ends, at_capacity=True)
-            self._cache["stop-and-length"] = vals
+            self._cache["static-stop-and-length"] = vals
 
         else:
             if traj_key is not None:
@@ -2178,7 +2163,14 @@ class SliceSampler(Sampler):
         )
 
     def _find_start_stop_traj(
-        self, *, trajectory=None, end=None, at_capacity: bool, cursor=None
+        self,
+        *,
+        trajectory=None,
+        end=None,
+        at_capacity: bool,
+        cursor=None,
+        storage=None,
+        source=None,
     ):
         # Thin wrapper around the shared module-level utilities (see
         # torchrl.data.find_start_stop_traj). Kept as a method, dispatching
@@ -2192,6 +2184,13 @@ class SliceSampler(Sampler):
             device=self._gpu_device,
             end_to_start_stop=lambda end, length: self._end_to_start_stop(
                 end=end, length=length
+            ),
+            storage=storage,
+            source=source,
+            cache_values=(
+                self.cache_values
+                and storage is not None
+                and type(self)._end_to_start_stop is SliceSampler._end_to_start_stop
             ),
         )
         return boundary.boundaries()
@@ -2308,8 +2307,8 @@ class SliceSampler(Sampler):
         self._fetch_traj = False
 
     def _get_stop_and_length(self, storage, fallback=True):
-        if self.cache_values and "stop-and-length" in self._cache:
-            return self._cache.get("stop-and-length")
+        if self.cache_values and "static-stop-and-length" in self._cache:
+            return self._cache.get("static-stop-and-length")
 
         if getattr(self, "_traj_key_auto", False):
             self._resolve_traj_key(storage)
@@ -2329,10 +2328,10 @@ class SliceSampler(Sampler):
                 vals = self._find_start_stop_traj(
                     trajectory=trajectory,
                     at_capacity=storage._is_full,
-                    cursor=getattr(storage, "_last_cursor", None),
+                    cursor=getattr(storage, "_last_cursor_index", None),
+                    storage=storage,
+                    source=("trajectory", self._used_traj_key),
                 )
-                if self.cache_values:
-                    self._cache["stop-and-length"] = vals
                 return vals
             except KeyError:
                 if fallback:
@@ -2361,10 +2360,15 @@ class SliceSampler(Sampler):
                 vals = self._find_start_stop_traj(
                     end=done[: len(storage)],
                     at_capacity=storage._is_full,
-                    cursor=getattr(storage, "_last_cursor", None),
+                    cursor=getattr(storage, "_last_cursor_index", None),
+                    storage=storage,
+                    source=(
+                        "end",
+                        tuple(self.end_keys)
+                        if self.end_keys is not None
+                        else self.end_key,
+                    ),
                 )
-                if self.cache_values:
-                    self._cache["stop-and-length"] = vals
                 return vals
             except KeyError:
                 if fallback:
@@ -3194,24 +3198,9 @@ class PrioritizedSliceSampler(SliceSampler, PrioritizedSampler):
             or when this signal is readily available. Must be used with ``cache_values=True``
             and cannot be used in conjunction with ``end_key`` or ``traj_key``.
         cache_values (bool, optional): to be used with static datasets.
-            Will cache the start and end signal of the trajectory. This can be safely used even
-            if the trajectory indices change during calls to :class:`~torchrl.data.ReplayBuffer.extend`
-            as this operation will erase the cache.
-
-            .. warning:: ``cache_values=True`` will not work if the sampler is used with a
-                storage that is extended by another buffer. For instance:
-
-                    >>> buffer0 = ReplayBuffer(storage=storage,
-                    ...     sampler=SliceSampler(num_slices=8, cache_values=True),
-                    ...     writer=ImmutableWriter())
-                    >>> buffer1 = ReplayBuffer(storage=storage,
-                    ...     sampler=other_sampler)
-                    >>> # Wrong! Does not erase the buffer from the sampler of buffer0
-                    >>> buffer1.extend(data)
-
-            .. warning:: ``cache_values=True`` will not work as expected if the buffer is
-                shared between processes and one process is responsible for writing
-                and one process for sampling, as erasing the cache can only be done locally.
+            Caches trajectory boundaries until the storage revision changes,
+            including writes from another buffer or process. Direct backing
+            tensor mutations cannot be detected.
 
         truncated_key (NestedKey, optional): If not ``None``, this argument
             indicates where a truncated signal should be written in the output

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -196,6 +196,65 @@ class Storage:
         self.checkpointer = checkpointer
         self._compilable = compilable
         self._attached_entities_list = []
+        self._mutation_revision_value = 0 if compilable else mp.Value("q", 0)
+        self._last_cursor_index_value = -1 if compilable else mp.Value("q", -1)
+
+    @property
+    def _mutation_revision(self) -> int:
+        """Monotonic storage-content revision shared with spawned processes."""
+        revision = getattr(self, "_mutation_revision_value", None)
+        if not self._compilable:
+            if revision is None:
+                revision = self._mutation_revision_value = mp.Value("q", 0)
+            return revision.value
+        if revision is None:
+            revision = self._mutation_revision_value = 0
+        return revision
+
+    def _bump_mutation_revision(self) -> None:
+        """Invalidates process-local metadata derived from storage contents."""
+        revision = getattr(self, "_mutation_revision_value", None)
+        if not self._compilable:
+            if revision is None:
+                revision = self._mutation_revision_value = mp.Value("q", 0)
+            with revision.get_lock():
+                revision.value += 1
+        else:
+            self._mutation_revision_value = self._mutation_revision + 1
+
+    @property
+    def _last_cursor_index(self) -> int | None:
+        """Last written time coordinate, shared with spawned processes."""
+        cursor = getattr(self, "_last_cursor_index_value", None)
+        if cursor is None:
+            return None
+        cursor = cursor if self._compilable else cursor.value
+        return None if cursor < 0 else cursor
+
+    def _set_last_cursor(self, cursor: Any) -> None:
+        self._last_cursor = cursor
+        if isinstance(cursor, torch.Tensor):
+            cursor = cursor.reshape(-1)
+            cursor = int(cursor[-1].item()) if cursor.numel() else -1
+        elif isinstance(cursor, range):
+            cursor = int(cursor[-1]) if len(cursor) else -1
+        elif isinstance(cursor, (tuple, list)):
+            time_cursor = cursor[0]
+            if isinstance(time_cursor, torch.Tensor):
+                time_cursor = time_cursor.reshape(-1)
+                cursor = int(time_cursor[-1].item()) if time_cursor.numel() else -1
+            else:
+                cursor = int(time_cursor)
+        elif cursor is None:
+            cursor = -1
+        else:
+            cursor = int(cursor)
+        shared_cursor = self._last_cursor_index_value
+        if self._compilable:
+            self._last_cursor_index_value = cursor
+        else:
+            with shared_cursor.get_lock():
+                shared_cursor.value = cursor
 
     @property
     def checkpointer(self):
@@ -252,6 +311,7 @@ class Storage:
 
     def loads(self, path):
         self.checkpointer.loads(self, path)
+        self._bump_mutation_revision()
 
     def attach(self, buffer: Any) -> None:
         """This function attaches a sampler to this storage.
@@ -351,7 +411,35 @@ class Storage:
     def __getstate__(self):
         state = copy(self.__dict__)
         state["_rng"] = None
+        if get_spawning_popen() is None:
+            revision = self._mutation_revision
+            last_cursor = self._last_cursor_index
+            state.pop("_mutation_revision_value", None)
+            state.pop("_last_cursor_index_value", None)
+            state["mutation_revision__context"] = revision
+            state["last_cursor_index__context"] = last_cursor
         return state
+
+    def __setstate__(self, state):
+        revision = state.pop("mutation_revision__context", None)
+        last_cursor = state.pop("last_cursor_index__context", None)
+        compilable = state.get("_compilable", False)
+        state.setdefault("_compilable", compilable)
+        if revision is not None:
+            if compilable:
+                state["_mutation_revision_value"] = revision
+            else:
+                state["_mutation_revision_value"] = mp.Value("q", revision)
+        if last_cursor is not None:
+            if compilable:
+                state["_last_cursor_index_value"] = last_cursor
+            else:
+                state["_last_cursor_index_value"] = mp.Value("q", last_cursor)
+        elif "_last_cursor_index_value" not in state:
+            state["_last_cursor_index_value"] = -1 if compilable else mp.Value("q", -1)
+        if "_mutation_revision_value" not in state:
+            state["_mutation_revision_value"] = 0 if compilable else mp.Value("q", 0)
+        self.__dict__.update(state)
 
     def __contains__(self, item):
         return self.contains(item)
@@ -421,6 +509,7 @@ class ListStorage(Storage):
             if isinstance(cursor, slice):
                 data = self._to_device(data)
                 self._set_slice(cursor, data)
+                self._bump_mutation_revision()
                 return
             if isinstance(
                 data,
@@ -458,6 +547,7 @@ class ListStorage(Storage):
                 )
             data = self._to_device(data)
             self._set_item(cursor, data)
+            self._bump_mutation_revision()
 
     def _set_item(self, cursor: int, data: Any) -> None:
         """Set a single item in the storage."""
@@ -526,9 +616,11 @@ class ListStorage(Storage):
                 raise TypeError(
                     f"Objects of type {type(elt)} are not supported by ListStorage.load_state_dict"
                 )
+        self._bump_mutation_revision()
 
     def _empty(self):
         self._storage = []
+        self._bump_mutation_revision()
 
     def __getstate__(self):
         if get_spawning_popen() is not None:
@@ -1011,7 +1103,7 @@ class TensorStorage(Storage):
                 state["_len_value"] = _len_value
             else:
                 state["_len_value"] = len
-        self.__dict__.update(state)
+        Storage.__setstate__(self, state)
 
     def state_dict(self) -> dict[str, Any]:
         _storage = self._storage
@@ -1063,6 +1155,7 @@ class TensorStorage(Storage):
             )
         self.initialized = state_dict["initialized"]
         self._len = state_dict["_len"]
+        self._bump_mutation_revision()
 
     @implement_for("torch", "2.3", compilable=True)
     def _set_tree_map(self, cursor, data, storage):
@@ -1099,7 +1192,7 @@ class TensorStorage(Storage):
         set_cursor: bool = True,
     ):
         if set_cursor:
-            self._last_cursor = cursor
+            self._set_last_cursor(cursor)
 
         if isinstance(data, list):
             # flip list
@@ -1160,6 +1253,7 @@ class TensorStorage(Storage):
                 raise
         else:
             self._set_tree_map(cursor, data, self._storage)
+        self._bump_mutation_revision()
 
     @implement_for("torch", None, "2.0", compilable=True)
     def set(  # noqa: F811
@@ -1170,7 +1264,7 @@ class TensorStorage(Storage):
         set_cursor: bool = True,
     ):
         if set_cursor:
-            self._last_cursor = cursor
+            self._set_last_cursor(cursor)
 
         if isinstance(data, list):
             # flip list
@@ -1244,6 +1338,7 @@ class TensorStorage(Storage):
                 # Provide informative error about key differences
                 self._raise_informative_lock_error(data, e)
             raise
+        self._bump_mutation_revision()
 
     def _wait_for_init(self):
         pass
@@ -1337,6 +1432,7 @@ class TensorStorage(Storage):
         # assuming that the data structure is the same, we don't need to to
         # anything if the cursor is reset to 0
         self._len = 0
+        self._bump_mutation_revision()
 
     def _init(self):
         raise NotImplementedError(
@@ -1854,6 +1950,7 @@ class LazyMemmapStorage(LazyTensorStorage):
             )
         self.initialized = state_dict["initialized"]
         self._len = state_dict["_len"]
+        self._bump_mutation_revision()
 
     def _init(
         self,
@@ -2252,6 +2349,7 @@ class CompressedListStorage(ListStorage):
         """Empty the storage."""
         self._storage = []
         self._metadata = []
+        self._bump_mutation_revision()
 
     def state_dict(self) -> dict[str, Any]:
         """Save the storage state."""
@@ -2269,6 +2367,7 @@ class CompressedListStorage(ListStorage):
             for elt in state_dict["_storage"]
         ]
         self._metadata = deepcopy(state_dict["_metadata"])
+        self._bump_mutation_revision()
 
     def to_bytestream(self, data_to_bytestream: torch.Tensor | np.array | Any) -> bytes:
         """Convert data to a byte stream."""
@@ -2618,7 +2717,7 @@ class StoreStorage(Storage):
         set_cursor: bool = True,
     ):
         if set_cursor:
-            self._last_cursor = cursor
+            self._set_last_cursor(cursor)
 
         if isinstance(data, list):
             data = _flip_list(data)
@@ -2643,6 +2742,7 @@ class StoreStorage(Storage):
             self._storage["_tensor"][cursor] = data
         else:
             self._storage[cursor] = data
+        self._bump_mutation_revision()
 
     def _get_new_len(self, data, cursor):
         if is_tensor_collection(data) or isinstance(data, torch.Tensor):
@@ -2666,6 +2766,7 @@ class StoreStorage(Storage):
 
     def _empty(self):
         self._len = 0
+        self._bump_mutation_revision()
 
     def state_dict(self) -> dict[str, Any]:
         return {
@@ -2693,6 +2794,7 @@ class StoreStorage(Storage):
                 db=state_dict["_db"],
                 td_id=td_id,
             )
+        self._bump_mutation_revision()
 
     def contains(self, item):
         if isinstance(item, int):

--- a/torchrl/data/replay_buffers/utils.py
+++ b/torchrl/data/replay_buffers/utils.py
@@ -10,7 +10,9 @@ import itertools
 import math
 import operator
 import os
+import threading
 import typing
+import weakref
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Union
@@ -45,6 +47,96 @@ if hasattr(typing, "get_args"):
 else:
     # python 3.7
     INT_CLASSES = (int, np.integer)
+
+
+_REPLAY_BOUNDARY_CACHE: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+_REPLAY_BOUNDARY_CACHE_LOCK = threading.RLock()
+
+
+def _freeze_boundary_cache_key(value: Any) -> Any:
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_boundary_cache_key(item) for item in value)
+    if isinstance(value, torch.device):
+        return str(value)
+    if isinstance(value, torch.Tensor):
+        value = value.reshape(-1)
+        return tuple(value.detach().cpu().tolist())
+    if isinstance(value, range):
+        return (value.start, value.stop, value.step)
+    return value
+
+
+def _boundary_cursor_cache_key(cursor: Any) -> int | None:
+    if isinstance(cursor, torch.Tensor):
+        cursor = cursor.reshape(-1)
+        return int(cursor[-1].item()) if cursor.numel() else None
+    if isinstance(cursor, range):
+        return int(cursor[-1]) if len(cursor) else None
+    if cursor is None:
+        return None
+    return int(cursor)
+
+
+def _boundary_distances_1d(
+    anchor: torch.Tensor,
+    start: torch.Tensor,
+    stop: torch.Tensor,
+    length: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pure searchsorted boundary query used by sequence sample units."""
+    trajectory_index = torch.searchsorted(stop, anchor).remainder(stop.shape[0])
+    anchor_start = start[trajectory_index]
+    anchor_stop = stop[trajectory_index]
+    distance_from_start = torch.remainder(anchor - anchor_start, length)
+    distance_to_stop = torch.remainder(anchor_stop - anchor, length)
+    return distance_from_start.to(torch.long), distance_to_stop.to(torch.long)
+
+
+def _boundary_distances_nd(
+    anchor: torch.Tensor,
+    start: torch.Tensor,
+    stop: torch.Tensor,
+    stop_key: torch.Tensor,
+    boundary_index: torch.Tensor,
+    lane_stride: torch.Tensor,
+    length: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pure lane-aware searchsorted query for multidimensional storage."""
+    lane = (anchor[:, 1:] * lane_stride).sum(-1)
+    anchor_key = lane * (2 * length) + anchor[:, 0]
+    search_index = torch.searchsorted(stop_key, anchor_key)
+    trajectory_index = boundary_index[search_index]
+    anchor_start = start[trajectory_index, 0]
+    anchor_stop = stop[trajectory_index, 0]
+    distance_from_start = torch.remainder(anchor[:, 0] - anchor_start, length)
+    distance_to_stop = torch.remainder(anchor_stop - anchor[:, 0], length)
+    return distance_from_start.to(torch.long), distance_to_stop.to(torch.long)
+
+
+def _make_boundary_search_nd(
+    start: torch.Tensor,
+    stop: torch.Tensor,
+    storage_shape: tuple[int, ...],
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    lane_shape = storage_shape[1:]
+    lane_stride = torch.tensor(
+        [math.prod(lane_shape[index + 1 :]) for index in range(len(lane_shape))],
+        dtype=torch.long,
+        device=stop.device,
+    )
+    lane = (stop[:, 1:] * lane_stride).sum(-1)
+    regular_key = lane * (2 * storage_shape[0]) + stop[:, 0]
+    order = torch.argsort(regular_key)
+    regular_key = regular_key[order]
+    ordered_lane = lane[order]
+    first = torch.ones_like(ordered_lane, dtype=torch.bool)
+    first[1:] = ordered_lane[1:] != ordered_lane[:-1]
+    first_index = torch.arange(order.shape[0], device=order.device)[first]
+    sentinel_key = regular_key[first_index] + storage_shape[0]
+    stop_key = torch.cat([regular_key, sentinel_key])
+    boundary_index = torch.cat([order, order[first_index]])
+    sort_order = torch.argsort(stop_key)
+    return stop_key[sort_order], boundary_index[sort_order], lane_stride
 
 
 def _to_numpy(data: Tensor) -> np.ndarray:
@@ -228,7 +320,42 @@ class _ReplayBoundaryIndex:
             ]
             | None
         ) = None,
+        storage: Any | None = None,
+        source: Any | None = None,
+        cache_values: bool = False,
     ) -> None:
+        self.device = device
+        self._end_to_start_stop_fn = end_to_start_stop
+        self._boundaries = None
+        self._search = None
+        self._cache_storage = None
+        self._cache_key = None
+        shape = getattr(storage, "shape", None) if storage is not None else None
+        self.storage_shape = tuple(shape) if shape is not None else None
+        if cache_values and storage is not None and source is not None:
+            revision = storage._mutation_revision
+            cache_key = (
+                _freeze_boundary_cache_key(source),
+                tuple(shape) if shape is not None else None,
+                len(storage),
+                bool(storage._is_full),
+                _boundary_cursor_cache_key(
+                    getattr(storage, "_last_cursor_index", None)
+                ),
+                str(device) if device is not None else None,
+            )
+            with _REPLAY_BOUNDARY_CACHE_LOCK:
+                storage_cache = _REPLAY_BOUNDARY_CACHE.get(storage)
+                if storage_cache is None or storage_cache[0] != revision:
+                    storage_cache = (revision, {})
+                    _REPLAY_BOUNDARY_CACHE[storage] = storage_cache
+                cached = storage_cache[1].get(cache_key)
+            self._cache_storage = storage
+            self._cache_key = cache_key
+            if cached is not None:
+                self.end = None
+                self.length, self._boundaries, self._search = cached
+                return
         end, length = _derive_end_flags(
             trajectory=trajectory,
             end=end,
@@ -237,9 +364,6 @@ class _ReplayBoundaryIndex:
         )
         self.end = end
         self.length = length
-        self.device = device
-        self._end_to_start_stop_fn = end_to_start_stop
-        self._boundaries = None
 
     def boundaries(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Returns canonical inclusive starts, stops, and trajectory lengths."""
@@ -251,37 +375,63 @@ class _ReplayBoundaryIndex:
                 )
             else:
                 boundaries = self._end_to_start_stop_fn(self.end, self.length)
+            if self.device is not None and self._end_to_start_stop_fn is None:
+                boundaries = tuple(value.to(self.device) for value in boundaries)
             self._boundaries = boundaries
+            if self._cache_storage is not None:
+                with _REPLAY_BOUNDARY_CACHE_LOCK:
+                    revision, storage_cache = _REPLAY_BOUNDARY_CACHE[
+                        self._cache_storage
+                    ]
+                    if revision == self._cache_storage._mutation_revision:
+                        storage_cache[self._cache_key] = (
+                            self.length,
+                            boundaries,
+                            self._search,
+                        )
         return boundaries
+
+    def _update_cached_search(self) -> None:
+        if self._cache_storage is None:
+            return
+        with _REPLAY_BOUNDARY_CACHE_LOCK:
+            revision, storage_cache = _REPLAY_BOUNDARY_CACHE[self._cache_storage]
+            if revision == self._cache_storage._mutation_revision:
+                storage_cache[self._cache_key] = (
+                    self.length,
+                    self._boundaries,
+                    self._search,
+                )
 
     def distances(self, anchor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         """Returns distances from starts and to stops for each anchor."""
         start, stop, _ = self.boundaries()
-        if start.shape[-1] != 1:
-            raise NotImplementedError(
-                "Anchor boundary queries currently require one-dimensional storage."
+        start = start.to(anchor.device)
+        stop = stop.to(anchor.device)
+        if start.shape[-1] == 1:
+            return _boundary_distances_1d(anchor, start[:, 0], stop[:, 0], self.length)
+        if anchor.ndim != 2 or anchor.shape[-1] != start.shape[-1]:
+            raise RuntimeError(
+                "Multidimensional anchors must have shape [batch, storage.ndim]."
             )
-        start = start[:, 0].to(anchor.device)
-        stop = stop[:, 0].to(anchor.device)
-        start_exp = start.unsqueeze(0)
-        stop_exp = stop.unsqueeze(0)
-        anchor_exp = anchor.unsqueeze(1)
-        in_linear_trajectory = (
-            (start_exp <= stop_exp)
-            & (start_exp <= anchor_exp)
-            & (anchor_exp <= stop_exp)
+        if self.storage_shape is None:
+            raise RuntimeError(
+                "Multidimensional boundary queries require the storage shape."
+            )
+        search = self._search
+        if search is None:
+            search = _make_boundary_search_nd(start, stop, self.storage_shape)
+            self._search = search
+            self._update_cached_search()
+        else:
+            search = tuple(value.to(anchor.device) for value in search)
+        return _boundary_distances_nd(
+            anchor,
+            start,
+            stop,
+            *search,
+            self.length,
         )
-        in_wrapped_trajectory = (start_exp > stop_exp) & (
-            (anchor_exp >= start_exp) | (anchor_exp <= stop_exp)
-        )
-        trajectory_index = (
-            (in_linear_trajectory | in_wrapped_trajectory).to(torch.int64).argmax(dim=1)
-        )
-        anchor_start = start[trajectory_index]
-        anchor_stop = stop[trajectory_index]
-        distance_from_start = torch.remainder(anchor - anchor_start, self.length)
-        distance_to_stop = torch.remainder(anchor_stop - anchor, self.length)
-        return distance_from_start.to(torch.long), distance_to_stop.to(torch.long)
 
 
 def _derive_end_flags(


### PR DESCRIPTION
Depends on #4083. GitHub shows the cumulative diff until that PR lands.

## Summary

- cache boundaries by storage revision, including cross-process writes
- replace dense scans with compile-friendly `searchsorted` queries
- add focused replay-boundary benchmarks

GB10, 1M records: 0.536 ms to 0.161 ms (3.3x); invalidated query 0.478 ms.

## Tests

Replay core, samplers, storages, multiprocessing invalidation, and compiled kernels.
