### PR TITLE
[Feature] Support multidimensional storage in Sequence sample units

### DIFF
--- a/benchmarks/test_replaybuffer_benchmark.py
+++ b/benchmarks/test_replaybuffer_benchmark.py
@@ -125,6 +125,28 @@ def test_sequence_boundary_query_benchmark(
     benchmark(query)
 
 
+@pytest.mark.parametrize("lanes", [8, 64])
+def test_sequence_multidimensional_boundary_query_benchmark(benchmark, lanes):
+    device = _replay_boundary_device()
+    time = 100_000
+    done = torch.zeros(time, lanes, 1, dtype=torch.bool, device=device)
+    done[255::256] = True
+    done[-1] = True
+    rb = TensorDictReplayBuffer(
+        storage=LazyTensorStorage(time * lanes, ndim=2, device=device),
+        dim_extend=0,
+    )
+    rb.extend(TensorDict({("next", "done"): done}, [time, lanes], device=device))
+    anchors = (
+        torch.linspace(0, time - 1, 256, device=device).to(torch.long),
+        torch.arange(256, device=device) % lanes,
+    )
+    unit = Sequence(length=64, burn_in=40, bootstrap=5)
+    unit.expand(anchors, {}, rb.storage)
+
+    benchmark(unit.expand, anchors, {}, rb.storage)
+
+
 @pytest.mark.parametrize("size", [10_000, 1_000_000])
 @pytest.mark.parametrize("episode_length", [32, 256])
 @pytest.mark.parametrize("cache_values", [False, True])

--- a/docs/source/reference/data_replaybuffers.rst
+++ b/docs/source/reference/data_replaybuffers.rst
@@ -62,6 +62,10 @@ anchor as a single transition;
 fixed-length sequence of records with explicit episode-boundary policies
 (``"pad"``, ``"stop"`` or ``"include_reset"``).
 
+For multidimensional storage, coordinate zero is time and the others are
+preserved lanes. ``index`` and ``anchor_index`` contain full coordinates, so
+priority reduction remains lane-specific.
+
 A sequence can include context outside its loss-bearing region. For example,
 in a recurrent Q-learning learner, a ``burn_in`` prefix reconstructs the
 model's hidden state, ``length`` records contribute to the loss, and a

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -1665,6 +1665,208 @@ class TestSequenceUnit:
         assert sample["obs"].shape[0] == 6
 
 
+class TestSequenceMultidimensional:
+    """Sequence expands time while preserving multidimensional lanes."""
+
+    def _make_rb(self, time=8, lanes=2, capacity=None, done=None, unit=None):
+        if capacity is None:
+            capacity = time * lanes
+        if done is None:
+            done = torch.zeros(time, lanes, 1, dtype=torch.bool)
+            done[-1] = True
+        rb = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(capacity, ndim=2),
+            dim_extend=0,
+            batch_size=2,
+            sample_unit=unit,
+        )
+        rb.extend(
+            TensorDict(
+                {
+                    "obs": torch.arange(time * lanes).reshape(time, lanes),
+                    ("stats", "episode_end"): done,
+                },
+                batch_size=[time, lanes],
+            )
+        )
+        return rb
+
+    def test_time_expansion_preserves_lanes_and_nested_done_key(self):
+        done = torch.zeros(8, 2, 1, dtype=torch.bool)
+        done[4, 0] = True
+        done[6, 1] = True
+        done[7] = True
+        rb = self._make_rb(done=done)
+        unit = Sequence(
+            length=2,
+            burn_in=1,
+            bootstrap=1,
+            dilation=2,
+            done_key=("stats", "episode_end"),
+        )
+        anchors = (torch.tensor([2, 2]), torch.tensor([0, 1]))
+
+        index, info = unit.expand(anchors, {}, rb.storage)
+
+        assert index[0].tolist() == [0, 2, 4, 4, 0, 2, 4, 6]
+        assert index[1].tolist() == [0, 0, 0, 0, 1, 1, 1, 1]
+        assert info["validity_mask"].tolist() == [
+            True,
+            True,
+            True,
+            False,
+            True,
+            True,
+            True,
+            True,
+        ]
+        assert info["learning_mask"].tolist() == [False, True, True, False] * 2
+        assert info["anchor_index"].tolist() == [[2, 0]] * 4 + [[2, 1]] * 4
+
+    def test_stop_shifts_time_but_retains_sampled_anchor(self):
+        done = torch.zeros(8, 2, 1, dtype=torch.bool)
+        done[4, 0] = True
+        done[7] = True
+        rb = self._make_rb(done=done)
+        unit = Sequence(
+            length=3,
+            episode_boundary="stop",
+            done_key=("stats", "episode_end"),
+        )
+
+        index, info = unit.expand(
+            (torch.tensor([4]), torch.tensor([0])), {}, rb.storage
+        )
+
+        assert index[0].tolist() == [2, 3, 4]
+        assert index[1].tolist() == [0, 0, 0]
+        assert info["validity_mask"].all()
+        assert info["anchor_index"].tolist() == [[4, 0]] * 3
+
+    def test_include_reset_respects_multidimensional_ring_write_seam(self):
+        rb = self._make_rb(time=8, capacity=12)
+        unit = Sequence(
+            length=3,
+            episode_boundary="include_reset",
+            done_key=("stats", "episode_end"),
+        )
+
+        wrapped, wrapped_info = unit.expand(
+            (torch.tensor([5]), torch.tensor([1])), {}, rb.storage
+        )
+        clamped, clamped_info = unit.expand(
+            (torch.tensor([1]), torch.tensor([1])), {}, rb.storage
+        )
+
+        assert wrapped[0].tolist() == [5, 0, 1]
+        assert wrapped[1].tolist() == [1, 1, 1]
+        assert wrapped_info["validity_mask"].all()
+        assert clamped[0].tolist() == [1, 1, 1]
+        assert clamped_info["validity_mask"].tolist() == [True, False, False]
+
+    def test_sampling_emits_full_coordinate_metadata(self):
+        unit = Sequence(
+            length=3,
+            done_key=("stats", "episode_end"),
+        )
+        rb = self._make_rb(time=5, unit=unit)
+
+        sample, info = rb.sample(return_info=True)
+
+        assert sample.batch_size == torch.Size([6])
+        assert sample["index"].shape == torch.Size([6, 2])
+        assert sample["anchor_index"].shape == torch.Size([6, 2])
+        assert isinstance(info["index"], tuple)
+        assert len(info["index"]) == 2
+        lane = sample["index"].reshape(2, 3, 2)[..., 1]
+        assert (lane == lane[:, :1]).all()
+
+    def test_priority_reduction_uses_full_anchor_coordinate(self):
+        rb = self._make_rb(time=5, unit=Sequence(length=2))
+        data = TensorDict(
+            {
+                "anchor_index": torch.tensor(
+                    [[2, 0], [2, 0], [2, 1], [2, 1], [2, 0], [2, 0]]
+                ),
+                "validity_mask": torch.tensor([True, False, True, True, True, True]),
+            },
+            batch_size=[6],
+        )
+        priority = torch.tensor([1.0, 99.0, 3.0, 4.0, 5.0, 6.0])
+
+        anchor, reduced = rb._anchor_reduced_priority(data, priority)
+
+        assert anchor.tolist() == [[2, 0], [2, 1]]
+        assert reduced.tolist() == [6.0, 4.0]
+
+    def test_priority_update_routes_to_multidimensional_anchors(self):
+        rb = TensorDictPrioritizedReplayBuffer(
+            alpha=1.0,
+            beta=1.0,
+            storage=LazyTensorStorage(10, ndim=2),
+            dim_extend=0,
+            sample_unit=Sequence(length=2),
+        )
+        rb.extend(
+            TensorDict(
+                {
+                    "obs": torch.arange(10).reshape(5, 2),
+                    ("next", "done"): torch.zeros(5, 2, 1, dtype=torch.bool),
+                },
+                batch_size=[5, 2],
+            )
+        )
+        coordinates = torch.cartesian_prod(torch.arange(5), torch.arange(2))
+        rb.update_priority(coordinates, torch.ones(10))
+        index, info = rb._sample_unit.expand(
+            (torch.tensor([2, 2, 2]), torch.tensor([0, 1, 0])), {}, rb.storage
+        )
+        data = rb.storage.get(index)
+        data.set("index", torch.stack(index, -1))
+        data.set("anchor_index", info["anchor_index"])
+        data.set(
+            "validity_mask",
+            torch.tensor([True, False, True, True, True, True]),
+        )
+        data.set("td_error", torch.tensor([1.0, 99.0, 3.0, 4.0, 5.0, 6.0]))
+        before = torch.tensor([float(rb.sampler._sum_tree[i]) for i in range(10)])
+
+        rb.update_tensordict_priority(data)
+
+        after = torch.tensor([float(rb.sampler._sum_tree[i]) for i in range(10)])
+        assert (before != after).nonzero().squeeze(-1).tolist() == [4, 5]
+        assert after[4].item() == pytest.approx(6.0)
+        assert after[5].item() == pytest.approx(4.0)
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    def test_cuda_storage_with_cpu_multidimensional_anchors(self):
+        done = torch.zeros(5, 2, 1, dtype=torch.bool, device="cuda")
+        done[-1] = True
+        rb = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(10, ndim=2, device="cuda"),
+            dim_extend=0,
+        )
+        rb.extend(
+            TensorDict(
+                {
+                    "obs": torch.arange(10, device="cuda").reshape(5, 2),
+                    ("next", "done"): done,
+                },
+                batch_size=[5, 2],
+                device="cuda",
+            )
+        )
+        anchors = (torch.tensor([1]), torch.tensor([1]))
+
+        index, info = Sequence(length=3).expand(anchors, {}, rb.storage)
+
+        assert all(component.device.type == "cpu" for component in index)
+        assert index[0].tolist() == [1, 2, 3]
+        assert index[1].tolist() == [1, 1, 1]
+        assert info["validity_mask"].device.type == "cpu"
+
+
 class TestSequenceBurnInBootstrap:
     """Executable spec for Sequence burn-in, bootstrap and dilation (#4039, piece 3).
 

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import collections
 import contextlib
 import json
+import math
 import multiprocessing
 import textwrap
 import threading
@@ -2865,15 +2866,35 @@ class TensorDictReplayBuffer(ReplayBuffer):
         the update well-defined when the same anchor appears in several
         windows. Returns ``None`` when no expansion metadata is present.
         """
-        if (
-            not isinstance(self._sample_unit, SequenceSampleUnit)
-            or self._storage.ndim > 1
-        ):
+        if not isinstance(self._sample_unit, SequenceSampleUnit):
             return None
         anchor = data.get("anchor_index", None)
         if anchor is None:
             return None
         validity = data.get("validity_mask", None)
+        if self._storage.ndim > 1:
+            if anchor.ndim < 2 or anchor.shape[-1] != self._storage.ndim:
+                return None
+            anchor = anchor.reshape(-1, self._storage.ndim)
+            priority = priority.reshape(-1)
+            if anchor.shape[0] != priority.shape[0]:
+                return None
+            if validity is not None:
+                validity = validity.reshape(-1)
+                anchor = anchor[validity]
+                priority = priority[validity]
+            shape = tuple(self._storage.shape)
+            stride = anchor.new_tensor(
+                [math.prod(shape[dim + 1 :]) for dim in range(len(shape))]
+            )
+            flat_anchor = (anchor * stride).sum(-1)
+            unique, inverse = torch.unique(flat_anchor, return_inverse=True)
+            reduced = torch.zeros_like(unique, dtype=priority.dtype)
+            reduced.scatter_reduce_(
+                0, inverse, priority, reduce="amax", include_self=False
+            )
+            coordinate = (unique.unsqueeze(-1) // stride) % anchor.new_tensor(shape)
+            return coordinate, reduced
         while anchor.shape != priority.shape and anchor.ndim > priority.ndim:
             anchor = anchor[..., 0]
             if validity is not None:

--- a/torchrl/data/replay_buffers/sample_units.py
+++ b/torchrl/data/replay_buffers/sample_units.py
@@ -191,6 +191,10 @@ class Sequence(SampleUnit):
         dilation grid of the shifted anchor: the reported (pre-shift) anchor
         is then not necessarily one of the window's records.
 
+    For multidimensional storage, coordinate zero is time and the others are
+    preserved lanes. ``"index"`` and ``"anchor_index"`` carry full storage
+    coordinates.
+
     .. seealso:: :class:`~torchrl.trainers.algorithms.configs.data.SequenceConfig`
         for the Hydra configuration companion.
 
@@ -309,13 +313,21 @@ class Sequence(SampleUnit):
         info: dict[str, Any],
         storage: Storage,
     ) -> tuple[torch.Tensor | tuple, dict[str, Any]]:
-        if isinstance(index, tuple):
-            raise NotImplementedError(
-                "Multidimensional storage not yet supported by Sequence."
-            )
         self._check_storage(storage)
-
-        anchor = index.clone()
+        multidimensional = storage.ndim > 1
+        if isinstance(index, tuple):
+            anchor = torch.stack(index, -1)
+        else:
+            anchor = index.clone()
+        if multidimensional:
+            if anchor.ndim != 2 or anchor.shape[-1] != storage.ndim:
+                raise RuntimeError(
+                    "Sequence expected multidimensional anchors with shape "
+                    f"[batch, {storage.ndim}]."
+                )
+            anchor_time = anchor[:, 0]
+        else:
+            anchor_time = anchor
         B = anchor.shape[0]
         # All bookkeeping happens on the sampler's index device so that the
         # returned indices live on the same device as the ones Transition
@@ -340,7 +352,7 @@ class Sequence(SampleUnit):
         )
         expanded_info["step_in_sequence"] = steps.repeat(B)
         expanded_info["learning_mask"] = learning.repeat(B)
-        expanded_info["anchor_index"] = anchor.repeat_interleave(total)
+        expanded_info["anchor_index"] = anchor.repeat_interleave(total, dim=0)
 
         offset = ((steps - self.burn_in) * self.dilation).unsqueeze(0).expand(B, total)
 
@@ -348,7 +360,7 @@ class Sequence(SampleUnit):
             done = (
                 storage.get(self.done_key)
                 if self.done_key is not None
-                else torch.zeros(len(storage), dtype=torch.bool, device=device)
+                else torch.zeros(storage.shape, dtype=torch.bool, device=device)
             )
             while done.ndim > storage.ndim and done.shape[-1] == 1:
                 done = done.squeeze(-1)
@@ -364,7 +376,7 @@ class Sequence(SampleUnit):
             dist_from_start, dist_to_stop = boundary.distances(anchor)
             max_len = boundary.length
 
-            anchor_eff = anchor
+            anchor_eff = anchor_time
             if self.episode_boundary == "stop":
                 shortfall = (
                     self.dilation * (self.length + self.bootstrap - 1) - dist_to_stop
@@ -372,7 +384,7 @@ class Sequence(SampleUnit):
                 shift = torch.clamp(
                     shortfall, min=torch.zeros_like(shortfall), max=dist_from_start
                 )
-                anchor_eff = anchor - shift
+                anchor_eff = anchor_time - shift
                 dist_to_stop = dist_to_stop + shift
                 dist_from_start = dist_from_start - shift
 
@@ -389,20 +401,25 @@ class Sequence(SampleUnit):
             # write seam (between the newest and the oldest record of the
             # ring buffer) nor read slots that were never written -- in
             # either direction, since burn-in walks backward from the anchor.
-            written = len(storage)
+            written = storage.shape[0]
             newest = self._newest_index(storage, written)
             oldest = (newest + 1) % written if storage._is_full else 0
             newest = torch.as_tensor(newest, device=device, dtype=torch.long)
             oldest = torch.as_tensor(oldest, device=device, dtype=torch.long)
-            dist_forward = torch.remainder(newest - anchor, written)
-            dist_backward = torch.remainder(anchor - oldest, written)
+            dist_forward = torch.remainder(newest - anchor_time, written)
+            dist_backward = torch.remainder(anchor_time - oldest, written)
             validity = (offset <= dist_forward.unsqueeze(1)) & (
                 offset >= -dist_backward.unsqueeze(1)
             )
             clamped_offset = torch.minimum(offset, dist_forward.unsqueeze(1))
             clamped_offset = torch.maximum(clamped_offset, -dist_backward.unsqueeze(1))
-            indices = torch.remainder(anchor.unsqueeze(1) + clamped_offset, written)
+            indices = torch.remainder(
+                anchor_time.unsqueeze(1) + clamped_offset, written
+            )
 
         expanded_info["validity_mask"] = validity.flatten()
-
+        if multidimensional:
+            lane = anchor[:, 1:].unsqueeze(1).expand(B, total, storage.ndim - 1)
+            coordinates = torch.cat([indices.unsqueeze(-1), lane], -1).flatten(0, 1)
+            return tuple(coordinates.unbind(-1)), expanded_info
         return indices.flatten(), expanded_info


### PR DESCRIPTION
Depends on #4084. GitHub shows the cumulative diff until that PR lands.

## Summary

- expand time while preserving lane coordinates for `storage.ndim > 1`
- return full-coordinate indices and reduce priorities per anchor coordinate
- cover masks, nested keys, ring wraparound, and CUDA placement

GB10, `[100000, 64]` storage: 0.195 ms cached; 1.004 ms invalidated.

## Tests

Replay core, samplers, storages, CUDA, and full-graph boundary kernels.
