### PR TITLE
[Doc] Document issue assignment and trusted collaborators

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,9 @@ Complete your CLA here: <https://code.facebook.com/cla>
 We use GitHub issues to track public bugs. Please ensure your description is
 clear and has sufficient instructions to be able to reproduce the issue.
 
+To work on an open issue, comment `/assign` on the issue. This will assign the
+issue to you.
+
 Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
 disclosure of security bugs. In those cases, please go through the process
 outlined on that page and do not file a public issue.

--- a/README.md
+++ b/README.md
@@ -552,6 +552,19 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full
 contribution guide and the [call for contributions](https://github.com/pytorch/rl/issues/509)
 for open areas where help is especially useful.
 
+To work on an open issue, comment `/assign` on the issue. This will assign the
+issue to you.
+
+### Trusted collaborators
+
+TorchRL is maintained by [Vincent Moens (`vmoens`)](https://github.com/vmoens).
+The following trusted collaborators are also available for review guidance and
+contributor advice:
+
+- [`theap06`](https://github.com/theap06)
+- [`ParamThakkar123`](https://github.com/ParamThakkar123)
+- [`Xmaster6y`](https://github.com/Xmaster6y)
+
 For local development, install pre-commit hooks with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -562,8 +562,9 @@ The following trusted collaborators are also available for review guidance and
 contributor advice:
 
 - [`theap06`](https://github.com/theap06)
-- [`ParamThakkar123`](https://github.com/ParamThakkar123)
-- [`Xmaster6y`](https://github.com/Xmaster6y)
+
+If you would like to be added to this list, reach out to
+[Vincent Moens (`vmoens`)](https://github.com/vmoens).
 
 For local development, install pre-commit hooks with:
 


### PR DESCRIPTION
## Summary

- document that commenting `/assign` assigns an open issue to the commenter
- state that Vincent Moens maintains TorchRL
- name `theap06` as a trusted collaborator for review guidance and contributor advice
- invite contributors who want to join the trusted-collaborator list to contact `vmoens`

## Why

Contributors should be able to claim work and quickly identify an active person who can help with reviews or advice without implying merge permissions.

## Validation

- `uvx pre-commit run --files README.md CONTRIBUTING.md`