### PR TITLE
[BugFix] Fix tutorial frame accounting

### DIFF
--- a/tutorials/sphinx-tutorials/export.py
+++ b/tutorials/sphinx-tutorials/export.py
@@ -121,6 +121,11 @@ t0 = time.time()
 for data in collector:
     # Write data in replay buffer
     rb.extend(data)
+    num_frames = data.numel()
+    total_count += num_frames
+    total_episodes += data["next", "done"].sum().item()
+    # Update the exploration factor once per collected frame
+    exploration_module.step(num_frames)
     max_length = rb[:]["next", "step_count"].max()
     if len(rb) > init_rand_steps:
         # Optim loop (we do several optim steps
@@ -131,12 +136,8 @@ for data in collector:
             loss_vals["loss"].backward()
             optim.step()
             optim.zero_grad()
-            # Update exploration factor
-            exploration_module.step(data.numel())
             # Update target params
             updater.step()
-            total_count += data.numel()
-            total_episodes += data["next", "done"].sum()
     if max_length > 200:
         break
 

--- a/tutorials/sphinx-tutorials/getting-started-5.py
+++ b/tutorials/sphinx-tutorials/getting-started-5.py
@@ -144,6 +144,11 @@ t0 = time.time()
 for i, data in enumerate(collector):
     # Write data in replay buffer
     rb.extend(data)
+    num_frames = data.numel()
+    total_count += num_frames
+    total_episodes += data["next", "done"].sum().item()
+    # Update the exploration factor once per collected frame
+    exploration_module.step(num_frames)
     max_length = rb[:]["next", "step_count"].max()
     if len(rb) > init_rand_steps:
         # Optim loop (we do several optim steps
@@ -154,14 +159,10 @@ for i, data in enumerate(collector):
             loss_vals["loss"].backward()
             optim.step()
             optim.zero_grad()
-            # Update exploration factor
-            exploration_module.step(data.numel())
             # Update target params
             updater.step()
-            if i % 10:
-                torchrl_logger.info(f"Max num steps: {max_length}, rb length {len(rb)}")
-            total_count += data.numel()
-            total_episodes += data["next", "done"].sum()
+        if i % 10 == 0:
+            torchrl_logger.info(f"Max num steps: {max_length}, rb length {len(rb)}")
     if max_length > 200:
         break
 


### PR DESCRIPTION
## Summary

- account for collected frames and completed episodes once per collector iteration, including replay-buffer warm-up
- anneal epsilon once per collected frame while keeping target-network updates tied to optimizer steps
- fix the getting-started tutorial's logging condition and apply the accounting fix to the duplicated export tutorial loop

## Root cause

Collection-side bookkeeping and epsilon annealing were nested inside the replay optimization loop. Each collected batch was therefore counted and annealed `optim_steps` times, while warm-up batches were not counted at all. The logging condition also used a truthy modulo result, causing repeated logs on most iterations.

Fixes #4053

## Validation

- `python -m py_compile tutorials/sphinx-tutorials/getting-started-5.py tutorials/sphinx-tutorials/export.py`
- `ufmt check tutorials/sphinx-tutorials/getting-started-5.py tutorials/sphinx-tutorials/export.py`
- `python tutorials/sphinx-tutorials/getting-started-5.py` (completed end-to-end)
- `git diff --check`

Full pre-commit hook setup was unavailable locally because its pinned `libcst` build requires a Rust compiler.
