### PR TITLE
[BugFix] Fix checkpointing of replay buffer prefetch state

### DIFF
--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -8,6 +8,7 @@ import argparse
 import contextlib
 import functools
 import json
+import pickle
 import threading
 
 import pytest
@@ -1169,6 +1170,141 @@ def test_replay_buffer_prefetch_queue_length():
     assert (
         len(rb._prefetch_queue) == 2
     ), f"Expected prefetch queue to have 2 items, but got {len(rb._prefetch_queue)}."
+
+
+def _make_prefetch_replay_buffer(
+    *, prefetch=2, batch_size=3, size=20, sampler=None, seed=0, storage=None
+):
+    generator = torch.Generator().manual_seed(seed)
+    replay_buffer = ReplayBuffer(
+        storage=ListStorage(size) if storage is None else storage,
+        sampler=sampler,
+        batch_size=batch_size,
+        prefetch=prefetch,
+        generator=generator,
+    )
+    replay_buffer.extend(torch.arange(size))
+    return replay_buffer
+
+
+def _settle_prefetch_queue(replay_buffer):
+    for future in replay_buffer._prefetch_queue:
+        future.result()
+
+
+def _assert_prefetch_samples_equal(expected, actual):
+    expected_data, expected_info = expected
+    actual_data, actual_info = actual
+    assert torch.equal(expected_data, actual_data)
+    assert torch.equal(expected_info["index"], actual_info["index"])
+
+
+def test_replay_buffer_prefetch_state_dict_roundtrip():
+    source = _make_prefetch_replay_buffer()
+    source.sample()
+    _settle_prefetch_queue(source)
+    state = source.state_dict()
+
+    restored = _make_prefetch_replay_buffer(seed=1)
+    restored.sample()
+    _settle_prefetch_queue(restored)
+    restored.load_state_dict(state)
+
+    for _ in range(4):
+        _assert_prefetch_samples_equal(
+            source.sample(return_info=True), restored.sample(return_info=True)
+        )
+
+
+def test_replay_buffer_prefetch_state_dict_legacy():
+    source = _make_prefetch_replay_buffer()
+    source.sample()
+    _settle_prefetch_queue(source)
+    state = source.state_dict()
+    state.pop("_prefetch_state")
+
+    restored = _make_prefetch_replay_buffer()
+    restored.sample()
+    restored.load_state_dict(state)
+
+    assert not restored._prefetch_queue
+
+
+def test_replay_buffer_prefetch_state_dict_capacity_mismatch():
+    source = _make_prefetch_replay_buffer(prefetch=2)
+    source.sample()
+    _settle_prefetch_queue(source)
+
+    restored = _make_prefetch_replay_buffer(prefetch=1)
+    with pytest.raises(RuntimeError, match="prefetch queue with capacity 2"):
+        restored.load_state_dict(source.state_dict())
+
+
+def test_replay_buffer_prefetch_state_dict_does_not_alias_queue():
+    source = _make_prefetch_replay_buffer()
+    source.sample()
+    _settle_prefetch_queue(source)
+    state = source.state_dict()
+
+    saved_data = state["_prefetch_state"]["queue"][0][0]
+    queued_data = source._prefetch_queue[0].result()[0]
+    saved_data.fill_(-1)
+
+    assert not torch.equal(saved_data, queued_data)
+
+
+def test_replay_buffer_prefetch_dumps_roundtrip(tmp_path):
+    source = _make_prefetch_replay_buffer(storage=LazyTensorStorage(20))
+    source.sample()
+    _settle_prefetch_queue(source)
+    source.dumps(tmp_path)
+
+    restored = _make_prefetch_replay_buffer(seed=1, storage=LazyTensorStorage(20))
+    restored.sample()
+    _settle_prefetch_queue(restored)
+    restored.loads(tmp_path)
+
+    for _ in range(4):
+        _assert_prefetch_samples_equal(
+            source.sample(return_info=True), restored.sample(return_info=True)
+        )
+
+
+def test_replay_buffer_prefetch_pickle_roundtrip():
+    source = _make_prefetch_replay_buffer()
+    source.sample()
+    _settle_prefetch_queue(source)
+
+    restored = pickle.loads(pickle.dumps(source))
+
+    for _ in range(4):
+        _assert_prefetch_samples_equal(
+            source.sample(return_info=True), restored.sample(return_info=True)
+        )
+
+
+def test_replay_buffer_prefetch_without_replacement_roundtrip():
+    source = _make_prefetch_replay_buffer(
+        size=10,
+        sampler=SamplerWithoutReplacement(drop_last=False),
+    )
+    first = source.sample()
+    _settle_prefetch_queue(source)
+    state = source.state_dict()
+
+    restored = _make_prefetch_replay_buffer(
+        size=10,
+        sampler=SamplerWithoutReplacement(drop_last=False),
+    )
+    restored.load_state_dict(state)
+    expected = list(source)
+    actual = list(restored)
+
+    assert len(expected) == len(actual)
+    for expected_batch, actual_batch in zip(expected, actual):
+        assert torch.equal(expected_batch, actual_batch)
+    samples = torch.cat([first, *expected])
+    assert torch.equal(samples.sort().values, torch.arange(10))
 
 
 class TestBufferStats:

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -1199,16 +1199,116 @@ def _assert_prefetch_samples_equal(expected, actual):
     assert torch.equal(expected_info["index"], actual_info["index"])
 
 
+class _BlockingPrefetchCollate:
+    def __init__(self):
+        self._calls = 0
+        self._lock = threading.Lock()
+        self.prefetch_started = threading.Event()
+        self.release_prefetch = threading.Event()
+
+    def __call__(self, data):
+        with self._lock:
+            self._calls += 1
+            call = self._calls
+        if call > 1:
+            self.prefetch_started.set()
+            if not self.release_prefetch.wait(timeout=5):
+                raise RuntimeError("Timed out waiting to release prefetched samples.")
+        return torch.stack(data)
+
+
+def _make_replay_buffer_with_blocked_prefetch(seed=0):
+    collate = _BlockingPrefetchCollate()
+    replay_buffer = ReplayBuffer(
+        storage=ListStorage(20),
+        collate_fn=collate,
+        batch_size=3,
+        prefetch=2,
+        generator=torch.Generator().manual_seed(seed),
+    )
+    replay_buffer.extend(torch.arange(20))
+    replay_buffer.sample()
+    assert collate.prefetch_started.wait(timeout=5)
+    return replay_buffer, collate
+
+
+def _release_prefetch_when_futures_lock_is_held(
+    replay_buffer, collate, operation_started, errors
+):
+    try:
+        if not operation_started.wait(timeout=5):
+            raise RuntimeError("Timed out waiting for the checkpoint operation.")
+        poll_delay = threading.Event()
+        for _ in range(1000):
+            if not replay_buffer._futures_lock.acquire(blocking=False):
+                return
+            replay_buffer._futures_lock.release()
+            poll_delay.wait(timeout=0.001)
+        raise RuntimeError("The checkpoint operation did not acquire the futures lock.")
+    except Exception as error:
+        errors.append(error)
+    finally:
+        collate.release_prefetch.set()
+
+
 def test_replay_buffer_prefetch_state_dict_roundtrip():
     source = _make_prefetch_replay_buffer()
     source.sample()
-    _settle_prefetch_queue(source)
     state = source.state_dict()
 
     restored = _make_prefetch_replay_buffer(seed=1)
     restored.sample()
-    _settle_prefetch_queue(restored)
     restored.load_state_dict(state)
+
+    for _ in range(4):
+        _assert_prefetch_samples_equal(
+            source.sample(return_info=True), restored.sample(return_info=True)
+        )
+
+
+def test_replay_buffer_prefetch_state_dict_waits_for_in_flight_samples():
+    source, collate = _make_replay_buffer_with_blocked_prefetch()
+    operation_started = threading.Event()
+    release_errors = []
+    release_thread = threading.Thread(
+        target=_release_prefetch_when_futures_lock_is_held,
+        args=(source, collate, operation_started, release_errors),
+        daemon=True,
+    )
+    release_thread.start()
+    operation_started.set()
+    state = source.state_dict()
+    release_thread.join(timeout=5)
+    assert not release_thread.is_alive()
+    assert not release_errors
+
+    restored = _make_prefetch_replay_buffer(seed=1)
+    restored.load_state_dict(state)
+    for _ in range(4):
+        _assert_prefetch_samples_equal(
+            source.sample(return_info=True), restored.sample(return_info=True)
+        )
+
+
+def test_replay_buffer_load_state_dict_waits_for_in_flight_samples():
+    source = _make_prefetch_replay_buffer()
+    source.sample()
+    state = source.state_dict()
+
+    restored, collate = _make_replay_buffer_with_blocked_prefetch(seed=1)
+    operation_started = threading.Event()
+    release_errors = []
+    release_thread = threading.Thread(
+        target=_release_prefetch_when_futures_lock_is_held,
+        args=(restored, collate, operation_started, release_errors),
+        daemon=True,
+    )
+    release_thread.start()
+    operation_started.set()
+    restored.load_state_dict(state)
+    release_thread.join(timeout=5)
+    assert not release_thread.is_alive()
+    assert not release_errors
 
     for _ in range(4):
         _assert_prefetch_samples_equal(
@@ -1233,11 +1333,13 @@ def test_replay_buffer_prefetch_state_dict_legacy():
 def test_replay_buffer_prefetch_state_dict_capacity_mismatch():
     source = _make_prefetch_replay_buffer(prefetch=2)
     source.sample()
-    _settle_prefetch_queue(source)
 
     restored = _make_prefetch_replay_buffer(prefetch=1)
+    restored.sample()
+    queue_before_load = tuple(restored._prefetch_queue)
     with pytest.raises(RuntimeError, match="prefetch queue with capacity 2"):
         restored.load_state_dict(source.state_dict())
+    assert tuple(restored._prefetch_queue) == queue_before_load
 
 
 def test_replay_buffer_prefetch_state_dict_does_not_alias_queue():
@@ -1256,12 +1358,10 @@ def test_replay_buffer_prefetch_state_dict_does_not_alias_queue():
 def test_replay_buffer_prefetch_dumps_roundtrip(tmp_path):
     source = _make_prefetch_replay_buffer(storage=LazyTensorStorage(20))
     source.sample()
-    _settle_prefetch_queue(source)
     source.dumps(tmp_path)
 
     restored = _make_prefetch_replay_buffer(seed=1, storage=LazyTensorStorage(20))
     restored.sample()
-    _settle_prefetch_queue(restored)
     restored.loads(tmp_path)
 
     for _ in range(4):
@@ -1273,7 +1373,6 @@ def test_replay_buffer_prefetch_dumps_roundtrip(tmp_path):
 def test_replay_buffer_prefetch_pickle_roundtrip():
     source = _make_prefetch_replay_buffer()
     source.sample()
-    _settle_prefetch_queue(source)
 
     restored = pickle.loads(pickle.dumps(source))
 
@@ -1281,6 +1380,49 @@ def test_replay_buffer_prefetch_pickle_roundtrip():
         _assert_prefetch_samples_equal(
             source.sample(return_info=True), restored.sample(return_info=True)
         )
+
+
+@pytest.mark.parametrize("checkpoint", ["state_dict", "pickle"])
+@pytest.mark.parametrize("tensordict", [False, True])
+def test_replay_buffer_prefetch_autograd_roundtrip(checkpoint, tensordict):
+    replay_buffer_cls = TensorDictReplayBuffer if tensordict else ReplayBuffer
+
+    def make_replay_buffer(seed):
+        replay_buffer = replay_buffer_cls(
+            storage=ListStorage(20),
+            batch_size=3,
+            prefetch=2,
+            generator=torch.Generator().manual_seed(seed),
+        )
+        values = torch.arange(20.0, requires_grad=True) * 2
+        if tensordict:
+            values = TensorDict({"value": values}, [20])
+        replay_buffer.extend(values)
+        return replay_buffer
+
+    source = make_replay_buffer(seed=0)
+    source.sample()
+
+    if checkpoint == "state_dict":
+        restored = make_replay_buffer(seed=1)
+        restored.load_state_dict(source.state_dict())
+    else:
+        restored = pickle.loads(pickle.dumps(source))
+
+    queued_data = restored._prefetch_queue[0].result()[0]
+    if tensordict:
+        queued_data = queued_data["value"]
+    assert queued_data.is_leaf
+    assert queued_data.requires_grad
+
+    for _ in range(4):
+        expected_data, expected_info = source.sample(return_info=True)
+        actual_data, actual_info = restored.sample(return_info=True)
+        if tensordict:
+            assert_allclose_td(expected_data, actual_data)
+        else:
+            assert torch.equal(expected_data, actual_data)
+        assert torch.equal(expected_info["index"], actual_info["index"])
 
 
 def test_replay_buffer_prefetch_without_replacement_roundtrip():

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -9,11 +9,13 @@ import contextlib
 import json
 import math
 import multiprocessing
+import pickle
 import textwrap
 import threading
 import warnings
-from collections.abc import Callable, Mapping, Sequence
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from concurrent.futures import Future, ThreadPoolExecutor, wait
+from copy import deepcopy
 from multiprocessing.context import get_spawning_popen
 from pathlib import Path
 from typing import Any
@@ -1537,34 +1539,115 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             self._storage._bump_mutation_revision()
         return self
 
+    def _clone_prefetch_result(self, result):
+        return deepcopy(result)
+
+    @contextlib.contextmanager
+    def _capture_prefetch_state(self) -> Iterator[dict[str, Any]]:
+        with self._futures_lock:
+            if not self._prefetch:
+                yield {"version": 1, "capacity": 0, "queue": ()}
+                return
+            queue = tuple(
+                self._clone_prefetch_result(future.result())
+                for future in self._prefetch_queue
+            )
+            yield {
+                "version": 1,
+                "capacity": self._prefetch_cap,
+                "queue": queue,
+            }
+
+    def _clear_prefetch_queue_locked(self) -> None:
+        futures = tuple(self._prefetch_queue)
+        for future in futures:
+            future.cancel()
+        if futures:
+            wait(futures)
+        self._prefetch_queue.clear()
+
+    def _restore_prefetch_queue_locked(
+        self, prefetch_state: dict[str, Any] | None
+    ) -> None:
+        if prefetch_state is None:
+            return
+        if not isinstance(prefetch_state, dict):
+            raise TypeError("The prefetch state must be a dictionary.")
+        if prefetch_state.get("version") != 1:
+            raise RuntimeError(
+                f"Unsupported prefetch state version: {prefetch_state.get('version')}."
+            )
+        capacity = prefetch_state.get("capacity")
+        if isinstance(capacity, bool) or not isinstance(capacity, int) or capacity < 0:
+            raise ValueError(
+                "The saved prefetch capacity must be a non-negative integer."
+            )
+        if capacity != self._prefetch_cap:
+            raise RuntimeError(
+                f"Cannot restore a prefetch queue with capacity {capacity} into a "
+                f"replay buffer with capacity {self._prefetch_cap}."
+            )
+        queue = prefetch_state.get("queue")
+        if not isinstance(queue, (list, tuple)):
+            raise TypeError("The saved prefetch queue must be a list or tuple.")
+        if len(queue) > capacity:
+            raise ValueError(
+                f"The saved prefetch queue contains {len(queue)} entries but its "
+                f"capacity is {capacity}."
+            )
+        if queue and not self._prefetch:
+            raise RuntimeError(
+                "Cannot restore a non-empty prefetch queue when prefetching is disabled."
+            )
+        for result in queue:
+            future = Future()
+            future.set_result(self._clone_prefetch_result(result))
+            self._prefetch_queue.append(future)
+
+    def _dump_prefetch_state(self, path: Path, prefetch_state: dict[str, Any]) -> None:
+        with open(path / "prefetch.pkl", "wb") as file:
+            pickle.dump(prefetch_state, file)
+
+    def _load_prefetch_state(self, path: Path) -> dict[str, Any] | None:
+        prefetch_path = path / "prefetch.pkl"
+        if not prefetch_path.exists():
+            return None
+        with open(prefetch_path, "rb") as file:
+            return pickle.load(file)
+
     @_maybe_delay_init
     def state_dict(self) -> dict[str, Any]:
-        return {
-            "_storage": self._storage.state_dict(),
-            "_sampler": self._sampler.state_dict(),
-            "_writer": self._writer.state_dict(),
-            "_transforms": self._transform.state_dict(),
-            "_batch_size": self._batch_size,
-            "_consume_after_n_samples": self._consume_after_n_samples,
-            "_rng": (self._rng.get_state().clone(), str(self._rng.device))
-            if self._rng is not None
-            else None,
-        }
+        with self._capture_prefetch_state() as prefetch_state:
+            return {
+                "_storage": self._storage.state_dict(),
+                "_sampler": self._sampler.state_dict(),
+                "_writer": self._writer.state_dict(),
+                "_transforms": self._transform.state_dict(),
+                "_batch_size": self._batch_size,
+                "_consume_after_n_samples": self._consume_after_n_samples,
+                "_rng": (self._rng.get_state().clone(), str(self._rng.device))
+                if self._rng is not None
+                else None,
+                "_prefetch_state": prefetch_state,
+            }
 
     @_maybe_delay_init
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        self._storage.load_state_dict(state_dict["_storage"])
-        self._sampler.load_state_dict(state_dict["_sampler"])
-        self._writer.load_state_dict(state_dict["_writer"])
-        self._transform.load_state_dict(state_dict["_transforms"])
-        self._batch_size = state_dict["_batch_size"]
-        self._consume_after_n_samples = state_dict.get("_consume_after_n_samples")
-        rng = state_dict.get("_rng")
-        if rng is not None:
-            state, device = rng
-            rng = torch.Generator(device=device)
-            rng.set_state(state)
-            self.set_rng(generator=rng)
+        with self._futures_lock:
+            self._clear_prefetch_queue_locked()
+            self._storage.load_state_dict(state_dict["_storage"])
+            self._sampler.load_state_dict(state_dict["_sampler"])
+            self._writer.load_state_dict(state_dict["_writer"])
+            self._transform.load_state_dict(state_dict["_transforms"])
+            self._batch_size = state_dict["_batch_size"]
+            self._consume_after_n_samples = state_dict.get("_consume_after_n_samples")
+            rng = state_dict.get("_rng")
+            if rng is not None:
+                state, device = rng
+                rng = torch.Generator(device=device)
+                rng.set_state(state)
+                self.set_rng(generator=rng)
+            self._restore_prefetch_queue_locked(state_dict.get("_prefetch_state"))
 
     @_maybe_delay_init
     def dumps(self, path):
@@ -1606,28 +1689,30 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
         """
         path = Path(path).absolute()
         path.mkdir(exist_ok=True)
-        self._storage.dumps(path / "storage")
-        self._sampler.dumps(path / "sampler")
-        self._writer.dumps(path / "writer")
-        if self._rng is not None:
-            rng_state = TensorDict(
-                rng_state=self._rng.get_state().clone(),
-                device=self._rng.device,
-            )
-            rng_state.memmap(path / "rng_state")
+        with self._capture_prefetch_state() as prefetch_state:
+            self._storage.dumps(path / "storage")
+            self._sampler.dumps(path / "sampler")
+            self._writer.dumps(path / "writer")
+            if self._rng is not None:
+                rng_state = TensorDict(
+                    rng_state=self._rng.get_state().clone(),
+                    device=self._rng.device,
+                )
+                rng_state.memmap(path / "rng_state")
 
-        # fall back on state_dict for transforms
-        transform_sd = self._transform.state_dict()
-        if transform_sd:
-            torch.save(transform_sd, path / "transform.t")
-        with open(path / "buffer_metadata.json", "w") as file:
-            json.dump(
-                {
-                    "batch_size": self._batch_size,
-                    "consume_after_n_samples": self._consume_after_n_samples,
-                },
-                file,
-            )
+            # fall back on state_dict for transforms
+            transform_sd = self._transform.state_dict()
+            if transform_sd:
+                torch.save(transform_sd, path / "transform.t")
+            with open(path / "buffer_metadata.json", "w") as file:
+                json.dump(
+                    {
+                        "batch_size": self._batch_size,
+                        "consume_after_n_samples": self._consume_after_n_samples,
+                    },
+                    file,
+                )
+            self._dump_prefetch_state(path, prefetch_state)
 
     @_maybe_delay_init
     def loads(self, path):
@@ -1642,21 +1727,24 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
 
         """
         path = Path(path).absolute()
-        self._storage.loads(path / "storage")
-        self._sampler.loads(path / "sampler")
-        self._writer.loads(path / "writer")
-        if (path / "rng_state").exists():
-            rng_state = TensorDict.load_memmap(path / "rng_state")
-            rng = torch.Generator(device=rng_state.device)
-            rng.set_state(rng_state["rng_state"])
-            self.set_rng(rng)
-        # fall back on state_dict for transforms
-        if (path / "transform.t").exists():
-            self._transform.load_state_dict(torch.load(path / "transform.t"))
-        with open(path / "buffer_metadata.json") as file:
-            metadata = json.load(file)
-        self._batch_size = metadata["batch_size"]
-        self._consume_after_n_samples = metadata.get("consume_after_n_samples")
+        with self._futures_lock:
+            self._clear_prefetch_queue_locked()
+            self._storage.loads(path / "storage")
+            self._sampler.loads(path / "sampler")
+            self._writer.loads(path / "writer")
+            if (path / "rng_state").exists():
+                rng_state = TensorDict.load_memmap(path / "rng_state")
+                rng = torch.Generator(device=rng_state.device)
+                rng.set_state(rng_state["rng_state"])
+                self.set_rng(rng)
+            # fall back on state_dict for transforms
+            if (path / "transform.t").exists():
+                self._transform.load_state_dict(torch.load(path / "transform.t"))
+            with open(path / "buffer_metadata.json") as file:
+                metadata = json.load(file)
+            self._batch_size = metadata["batch_size"]
+            self._consume_after_n_samples = metadata.get("consume_after_n_samples")
+            self._restore_prefetch_queue_locked(self._load_prefetch_state(path))
 
     @_maybe_delay_init
     def save(self, *args, **kwargs):
@@ -2173,29 +2261,31 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
 
     @_maybe_delay_init
     def __getstate__(self) -> dict[str, Any]:
-        state = self.__dict__.copy()
-        if getattr(self, "_rng", None) is not None:
-            rng_state = TensorDict(
-                rng_state=self._rng.get_state().clone(),
-                device=self._rng.device,
-            )
-            state["_rng"] = rng_state
-        _replay_lock = state.pop("_replay_lock", None)
-        _futures_lock = state.pop("_futures_lock", None)
-        if _replay_lock is not None:
-            state["_replay_lock_placeholder"] = None
-        if _futures_lock is not None:
-            state["_futures_lock_placeholder"] = None
-        # Remove non-picklable prefetch objects - they will be recreated on unpickle
-        _prefetch_queue = state.pop("_prefetch_queue", None)
-        _prefetch_executor = state.pop("_prefetch_executor", None)
-        if _prefetch_queue is not None:
-            state["_prefetch_queue_placeholder"] = None
-        if _prefetch_executor is not None:
-            state["_prefetch_executor_placeholder"] = None
-        return state
+        with self._capture_prefetch_state() as prefetch_state:
+            state = self.__dict__.copy()
+            if getattr(self, "_rng", None) is not None:
+                rng_state = TensorDict(
+                    rng_state=self._rng.get_state().clone(),
+                    device=self._rng.device,
+                )
+                state["_rng"] = rng_state
+            _replay_lock = state.pop("_replay_lock", None)
+            _futures_lock = state.pop("_futures_lock", None)
+            if _replay_lock is not None:
+                state["_replay_lock_placeholder"] = None
+            if _futures_lock is not None:
+                state["_futures_lock_placeholder"] = None
+            _prefetch_queue = state.pop("_prefetch_queue", None)
+            _prefetch_executor = state.pop("_prefetch_executor", None)
+            if _prefetch_queue is not None:
+                state["_prefetch_queue_placeholder"] = None
+            if _prefetch_executor is not None:
+                state["_prefetch_executor_placeholder"] = None
+            state["_prefetch_state"] = prefetch_state
+            return state
 
     def __setstate__(self, state: dict[str, Any]):
+        prefetch_state = state.pop("_prefetch_state", None)
         rngstate = None
         if "_rng" in state:
             rngstate = state["_rng"]
@@ -2223,6 +2313,8 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
         self.__dict__.update(state)
         if rngstate is not None:
             self.set_rng(rng)
+        with self._futures_lock:
+            self._restore_prefetch_queue_locked(prefetch_state)
 
     @property
     @_maybe_delay_init

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -1539,24 +1539,54 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             self._storage._bump_mutation_revision()
         return self
 
-    def _clone_prefetch_result(self, result):
-        return deepcopy(result)
+    def _clone_prefetch_result(
+        self, result: tuple[Any, dict[str, Any]]
+    ) -> tuple[Any, dict[str, Any]]:
+        memo = {}
+
+        def _clone_leaf(value: Any) -> Any:
+            value_id = id(value)
+            if value_id in memo:
+                return memo[value_id]
+            if isinstance(value, Tensor):
+                # PyTorch deliberately rejects deepcopy for non-leaf tensors. A
+                # checkpoint only needs their value and requires-grad property,
+                # not the live autograd graph that produced the sample.
+                cloned = value.detach().clone()
+                if value.requires_grad:
+                    cloned.requires_grad_()
+            else:
+                cloned = deepcopy(value, memo)
+            memo[value_id] = cloned
+            return cloned
+
+        return tree_map(_clone_leaf, result)
 
     @contextlib.contextmanager
-    def _capture_prefetch_state(self) -> Iterator[dict[str, Any]]:
+    def _capture_prefetch_state(
+        self, *, clone_queue: bool = True
+    ) -> Iterator[dict[str, Any]]:
         with self._futures_lock:
-            if not self._prefetch:
-                yield {"version": 1, "capacity": 0, "queue": ()}
-                return
-            queue = tuple(
-                self._clone_prefetch_result(future.result())
-                for future in self._prefetch_queue
+            results = (
+                tuple(future.result() for future in self._prefetch_queue)
+                if self._prefetch
+                else ()
             )
-            yield {
-                "version": 1,
-                "capacity": self._prefetch_cap,
-                "queue": queue,
-            }
+            # Futures acquire the replay lock while sampling, so only take it
+            # after every queued future has settled. Holding both locks while
+            # the caller captures the remaining components keeps the queue,
+            # storage, sampler, writer and RNG at one logical point in time.
+            with self._replay_lock:
+                queue = (
+                    tuple(self._clone_prefetch_result(result) for result in results)
+                    if clone_queue
+                    else results
+                )
+                yield {
+                    "version": 1,
+                    "capacity": int(self._prefetch_cap),
+                    "queue": queue,
+                }
 
     def _clear_prefetch_queue_locked(self) -> None:
         futures = tuple(self._prefetch_queue)
@@ -1566,9 +1596,7 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             wait(futures)
         self._prefetch_queue.clear()
 
-    def _restore_prefetch_queue_locked(
-        self, prefetch_state: dict[str, Any] | None
-    ) -> None:
+    def _validate_prefetch_state(self, prefetch_state: dict[str, Any] | None) -> None:
         if prefetch_state is None:
             return
         if not isinstance(prefetch_state, dict):
@@ -1578,11 +1606,16 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
                 f"Unsupported prefetch state version: {prefetch_state.get('version')}."
             )
         capacity = prefetch_state.get("capacity")
-        if isinstance(capacity, bool) or not isinstance(capacity, int) or capacity < 0:
+        if (
+            isinstance(capacity, bool)
+            or not isinstance(capacity, INT_CLASSES)
+            or capacity < 0
+        ):
             raise ValueError(
                 "The saved prefetch capacity must be a non-negative integer."
             )
-        if capacity != self._prefetch_cap:
+        capacity = int(capacity)
+        if capacity != int(self._prefetch_cap):
             raise RuntimeError(
                 f"Cannot restore a prefetch queue with capacity {capacity} into a "
                 f"replay buffer with capacity {self._prefetch_cap}."
@@ -1599,9 +1632,22 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             raise RuntimeError(
                 "Cannot restore a non-empty prefetch queue when prefetching is disabled."
             )
+
+    def _restore_prefetch_queue_locked(
+        self,
+        prefetch_state: dict[str, Any] | None,
+        *,
+        clone_queue: bool = True,
+    ) -> None:
+        self._validate_prefetch_state(prefetch_state)
+        if prefetch_state is None:
+            return
+        queue = prefetch_state["queue"]
         for result in queue:
             future = Future()
-            future.set_result(self._clone_prefetch_result(result))
+            if clone_queue:
+                result = self._clone_prefetch_result(result)
+            future.set_result(result)
             self._prefetch_queue.append(future)
 
     def _dump_prefetch_state(self, path: Path, prefetch_state: dict[str, Any]) -> None:
@@ -1633,21 +1679,26 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
 
     @_maybe_delay_init
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        prefetch_state = state_dict.get("_prefetch_state")
+        self._validate_prefetch_state(prefetch_state)
         with self._futures_lock:
             self._clear_prefetch_queue_locked()
-            self._storage.load_state_dict(state_dict["_storage"])
-            self._sampler.load_state_dict(state_dict["_sampler"])
-            self._writer.load_state_dict(state_dict["_writer"])
-            self._transform.load_state_dict(state_dict["_transforms"])
-            self._batch_size = state_dict["_batch_size"]
-            self._consume_after_n_samples = state_dict.get("_consume_after_n_samples")
-            rng = state_dict.get("_rng")
-            if rng is not None:
-                state, device = rng
-                rng = torch.Generator(device=device)
-                rng.set_state(state)
-                self.set_rng(generator=rng)
-            self._restore_prefetch_queue_locked(state_dict.get("_prefetch_state"))
+            with self._replay_lock:
+                self._storage.load_state_dict(state_dict["_storage"])
+                self._sampler.load_state_dict(state_dict["_sampler"])
+                self._writer.load_state_dict(state_dict["_writer"])
+                self._transform.load_state_dict(state_dict["_transforms"])
+                self._batch_size = state_dict["_batch_size"]
+                self._consume_after_n_samples = state_dict.get(
+                    "_consume_after_n_samples"
+                )
+                rng = state_dict.get("_rng")
+                if rng is not None:
+                    state, device = rng
+                    rng = torch.Generator(device=device)
+                    rng.set_state(state)
+                    self.set_rng(generator=rng)
+                self._restore_prefetch_queue_locked(prefetch_state)
 
     @_maybe_delay_init
     def dumps(self, path):
@@ -1689,7 +1740,10 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
         """
         path = Path(path).absolute()
         path.mkdir(exist_ok=True)
-        with self._capture_prefetch_state() as prefetch_state:
+        # The queue cannot be consumed while this context is active, so the
+        # pickle stream can read it directly without allocating another full
+        # queue-sized copy first.
+        with self._capture_prefetch_state(clone_queue=False) as prefetch_state:
             self._storage.dumps(path / "storage")
             self._sampler.dumps(path / "sampler")
             self._writer.dumps(path / "writer")
@@ -1727,24 +1781,29 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
 
         """
         path = Path(path).absolute()
+        prefetch_state = self._load_prefetch_state(path)
+        self._validate_prefetch_state(prefetch_state)
         with self._futures_lock:
             self._clear_prefetch_queue_locked()
-            self._storage.loads(path / "storage")
-            self._sampler.loads(path / "sampler")
-            self._writer.loads(path / "writer")
-            if (path / "rng_state").exists():
-                rng_state = TensorDict.load_memmap(path / "rng_state")
-                rng = torch.Generator(device=rng_state.device)
-                rng.set_state(rng_state["rng_state"])
-                self.set_rng(rng)
-            # fall back on state_dict for transforms
-            if (path / "transform.t").exists():
-                self._transform.load_state_dict(torch.load(path / "transform.t"))
-            with open(path / "buffer_metadata.json") as file:
-                metadata = json.load(file)
-            self._batch_size = metadata["batch_size"]
-            self._consume_after_n_samples = metadata.get("consume_after_n_samples")
-            self._restore_prefetch_queue_locked(self._load_prefetch_state(path))
+            with self._replay_lock:
+                self._storage.loads(path / "storage")
+                self._sampler.loads(path / "sampler")
+                self._writer.loads(path / "writer")
+                if (path / "rng_state").exists():
+                    rng_state = TensorDict.load_memmap(path / "rng_state")
+                    rng = torch.Generator(device=rng_state.device)
+                    rng.set_state(rng_state["rng_state"])
+                    self.set_rng(rng)
+                # fall back on state_dict for transforms
+                if (path / "transform.t").exists():
+                    self._transform.load_state_dict(torch.load(path / "transform.t"))
+                with open(path / "buffer_metadata.json") as file:
+                    metadata = json.load(file)
+                self._batch_size = metadata["batch_size"]
+                self._consume_after_n_samples = metadata.get("consume_after_n_samples")
+                # This method owns the freshly unpickled queue, so moving its
+                # results into completed futures avoids a redundant deep copy.
+                self._restore_prefetch_queue_locked(prefetch_state, clone_queue=False)
 
     @_maybe_delay_init
     def save(self, *args, **kwargs):
@@ -2314,7 +2373,9 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
         if rngstate is not None:
             self.set_rng(rng)
         with self._futures_lock:
-            self._restore_prefetch_queue_locked(prefetch_state)
+            # __setstate__ owns prefetch_state after popping it from the pickle
+            # payload, so queue entries can be transferred without cloning.
+            self._restore_prefetch_queue_locked(prefetch_state, clone_queue=False)
 
     @property
     @_maybe_delay_init


### PR DESCRIPTION
## Summary

Persist the replay buffer prefetch queue across `state_dict` / `load_state_dict`, `dumps` / `loads`, and Python pickle round-trips.

A restored buffer now returns the batches that had already been prefetched at checkpoint time before producing new samples. This keeps sample order, sampler state, and RNG state aligned, including for `SamplerWithoutReplacement`.

## Root cause

Prefetch workers advance the sampler and RNG when they produce a batch, before that batch is consumed by `ReplayBuffer.sample()`. Previous checkpoints serialized the already-advanced sampler and RNG but discarded the completed or in-flight queue entries. Restoring such a checkpoint therefore skipped the prefetched batches and resumed from a later sampling state.

## Implementation

- Wait for queued futures while holding the futures lock so queue consumption cannot race checkpoint capture.
- Acquire the replay lock only after futures settle, preserving the existing `futures -> replay` lock order and avoiding deadlock with workers sampling under the replay lock.
- Capture storage, sampler, writer, transform, RNG, and the ordered prefetch queue at one checkpoint boundary.
- Store a versioned prefetch payload containing the configured capacity and completed queue results.
- Recreate saved queue entries as completed `Future` objects so the existing sampling path can consume them without starting replacement worker pools or special-casing restored batches.
- Cancel and settle a target buffer's current futures before loading checkpoint state.
- Validate prefetch version, capacity, and queue shape before mutating a live target buffer. Invalid or capacity-mismatched state therefore leaves its current queue intact.
- Preserve backward compatibility with state dictionaries and checkpoint directories that predate the prefetch payload; loading them clears any target queue and resumes without restored entries.

## Autograd and ownership

Queued samples can contain non-leaf tensors, either because list-backed samples are stacked or because a transform produced autograd-connected values. `copy.deepcopy` rejects these tensors.

The queue clone now walks the sample PyTree, detaches and clones tensor leaves, restores their `requires_grad` property, and deep-copies non-tensor leaves. Checkpoints preserve sample values and tensor metadata without retaining a live autograd graph.

Ownership is handled per checkpoint API:

- `state_dict()` and `__getstate__()` clone queued results so returned state cannot alias the live queue.
- `dumps()` serializes the queue directly while checkpoint locks are held, avoiding a redundant full queue-sized pre-copy.
- `loads()` and `__setstate__()` transfer ownership of freshly deserialized queue entries into completed futures instead of cloning them again.
- `load_state_dict()` still clones queue entries because the caller retains ownership of the supplied state dictionary.

The unavoidable checkpoint-size increase is bounded by the configured prefetch capacity: at most `prefetch` completed, post-transform batches are stored. No additional executor is created for state-dict or disk restoration, and the restored queue remains bounded by that capacity.

## Validation

Added or extended coverage for:

- state-dict, disk, and pickle round-trips;
- in-flight checkpoint capture and loading over active worker futures;
- plain tensor and TensorDict samples containing non-leaf autograd tensors;
- queue ownership / non-aliasing;
- legacy checkpoints without prefetch state;
- capacity mismatch without partial queue mutation;
- exact continuation for sampling without replacement.

Local results:

- 14 focused prefetch/checkpoint tests passed with warnings treated as errors.
- Both deterministic in-flight concurrency tests passed 20 consecutive repetitions (40 runs).
- 385 replay-buffer tests passed on the rebased branch, with one CUDA-only skip; prioritized/priority tests requiring the unavailable local C++ segment-tree extension were excluded.
- A concurrent-write stress probe completed 4,010 consistent checkpoint snapshots.
- Repeated pickle/unpickle/use/discard probes returned prefetch worker threads to their baseline after in-flight work settled and garbage collection ran.
- Python 3.10 syntax parsing, `ufmt`, `flake8`, `pydocstyle`, `codespell`, and `git diff --check` passed for the changed files.

## Current status

Rebased onto `main` at `7923c6da0`. Conflict resolution preserves the current replay-buffer sample-unit and storage mutation-revision changes alongside prefetch checkpointing. The force-push to the contributor branch triggered fresh CI.
