### PR TITLE
[BugFix] Preserve Delta multidimensional event shapes

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -52,6 +52,19 @@ class TestDelta:
         assert d.log_prob(d.mode).shape == x.shape[:-1]
         assert (d.log_prob(d.mode) == float("inf")).all()
 
+    def test_delta_multidimensional_event_shape(self, device):
+        param = torch.zeros(2, 3, 4, device=device)
+        dist = Delta(param, batch_shape=(2,), event_shape=(3, 4))
+
+        assert dist.log_prob(dist.param).shape == (2,)
+
+        expanded = dist.expand((5, 2))
+
+        assert expanded.param.shape == (5, 2, 3, 4)
+        assert expanded.batch_shape == (5, 2)
+        assert expanded.event_shape == (3, 4)
+        assert expanded.log_prob(expanded.param).shape == (5, 2)
+
     @pytest.mark.parametrize("div_up", [1, 2])
     @pytest.mark.parametrize("div_down", [1, 2])
     def test_tanhdelta_logprob(self, device, div_up, div_down):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -57,6 +57,12 @@ class TestDelta:
         dist = Delta(param, batch_shape=(2,), event_shape=(3, 4))
 
         assert dist.log_prob(dist.param).shape == (2,)
+        mismatched = dist.param.clone()
+        mismatched[1, 0, 0] = 1
+        torch.testing.assert_close(
+            dist.log_prob(mismatched),
+            torch.tensor([float("inf"), -float("inf")], device=device),
+        )
 
         expanded = dist.expand((5, 2))
 
@@ -64,6 +70,11 @@ class TestDelta:
         assert expanded.batch_shape == (5, 2)
         assert expanded.event_shape == (3, 4)
         assert expanded.log_prob(expanded.param).shape == (5, 2)
+        expanded_mismatched = expanded.param.clone()
+        expanded_mismatched[3, 1, 0, 0] = 1
+        expected = torch.full((5, 2), float("inf"), device=device)
+        expected[3, 1] = -float("inf")
+        torch.testing.assert_close(expanded.log_prob(expanded_mismatched), expected)
 
     @pytest.mark.parametrize("div_up", [1, 2])
     @pytest.mark.parametrize("div_down", [1, 2])

--- a/torchrl/modules/distributions/continuous.py
+++ b/torchrl/modules/distributions/continuous.py
@@ -638,6 +638,8 @@ class Delta(D.Distribution):
                 self.param.expand((*batch_shape, *self.event_shape)),
                 atol=self.atol,
                 rtol=self.rtol,
+                batch_shape=batch_shape,
+                event_shape=self.event_shape,
             )
         return self
 
@@ -647,8 +649,8 @@ class Delta(D.Distribution):
     def _is_equal(self, value: torch.Tensor) -> torch.Tensor:
         param = self.param.expand_as(value)
         is_equal = abs(value - param) < self.atol + self.rtol * abs(param)
-        for i in range(-1, -len(self.event_shape) - 1, -1):
-            is_equal = is_equal.all(i)
+        for _ in self.event_shape:
+            is_equal = is_equal.all(-1)
         return is_equal
 
     def log_prob(self, value: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Description

Preserve `Delta` distributions' multidimensional event semantics in both expansion and log-probability evaluation.

`Delta.expand()` now forwards the requested batch shape and existing event shape to the returned distribution instead of falling back to one-dimensional event inference. `_is_equal()` now reduces the current final dimension once per event axis, so `log_prob()` retains every batch dimension when the event has more than one axis.

An existing distribution test module now covers a `(2,)` batch with a `(3, 4)` event before and after expansion to `(5, 2)`. It also perturbs one element in a single batch item and verifies that the negative log-probability remains localized to that item before and after expansion.

## Motivation and Context

Without this change, `Delta(param, batch_shape=(2,), event_shape=(3, 4))` returns a `log_prob` with shape `(3,)`. Expanding it to batch shape `(5, 2)` also silently changes its metadata to batch shape `(5, 2, 3)` and event shape `(4,)`. The parameter and sample shapes remain plausible, which makes the semantic corruption easy to miss.

Closes #4090

- [x] I have raised an issue to propose this change: #4090

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Validation

- The focused regression was run against the pristine implementation and failed with the incorrect expanded batch shape.
- `python -m pytest test/test_distributions.py::TestDelta -q`: 11 passed
- Repository pre-commit hooks on both changed files: all passed
- `git diff --check`: passed

All local tests were run on CPU in a single process.

## Checklist

- [x] I have read the CONTRIBUTING guide and `CLAUDE.md`.
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly.
- [ ] I have updated the documentation accordingly.

## AI assistance disclosure

I used OpenAI Codex to help inspect the implementation, construct and run the pristine reproduction, search existing issues and pull requests for duplicates, implement the focused fix and regression, run validation, and draft this pull request. I reviewed the diff and reproduced the behavior before submission.

