### PR TITLE
[Performance] Enable worker metadata for automatic parallel envs

### DIFF
--- a/docs/source/reference/envs_vectorized.rst
+++ b/docs/source/reference/envs_vectorized.rst
@@ -75,6 +75,11 @@ needed.
   should keep the default metadata path. At shutdown, workers started in this
   mode are closed one at a time to bound teardown resource spikes; the
   per-worker grace period is controlled by the ``shutdown_timeout`` argument.
+  Convenience constructors that create a :class:`ParallelEnv` from
+  ``num_workers`` (for example ``GymEnv("Pendulum-v1", num_workers=4)``)
+  enable worker-originated metadata automatically when the worker schemas are
+  compatible. Native vectorization arguments such as ``GymEnv(...,
+  num_envs=4)`` do not create a :class:`ParallelEnv` and are unaffected.
   Use one common factory with ``create_env_kwargs`` for
   worker-specific arguments:
 

--- a/test/libs/test_brax.py
+++ b/test/libs/test_brax.py
@@ -225,18 +225,16 @@ class TestBrax:
         for _ in range(5):
             env.clear_cache()
 
-    def test_num_workers_returns_lazy_parallel_env(self, envname, device):
-        """Ensure BraxEnv with num_workers > 1 returns a lazy ParallelEnv."""
+    def test_num_workers_returns_parallel_env(self, envname, device):
+        """Ensure BraxEnv workers report metadata directly."""
         env = BraxEnv(envname, num_workers=3, device=device)
         try:
             assert isinstance(env, ParallelEnv)
             assert env.num_workers == 3
-            # ParallelEnv should be lazy (not started yet)
-            assert env.is_closed
-            # configure_parallel should work before env starts
-            env.configure_parallel(use_buffers=False)
-            env.reset()
+            assert env._metadata_from_workers
+            assert env._use_buffers is False
             assert not env.is_closed
+            env.reset()
             assert env.batch_size == torch.Size([3])
         finally:
             env.close()

--- a/test/libs/test_dm_control.py
+++ b/test/libs/test_dm_control.py
@@ -116,23 +116,16 @@ class TestDMControl:
         assert final_seed0 == final_seed2
         assert_allclose_td(rollout0, rollout2)
 
-    def test_num_workers_returns_lazy_parallel_env(self):
-        """Ensure DMControlEnv with num_workers > 1 returns a lazy ParallelEnv."""
-        # When num_workers > 1, should return ParallelEnv directly (lazy)
+    def test_num_workers_returns_parallel_env(self):
+        """Ensure DMControlEnv workers report metadata directly."""
         env = DMControlEnv("cheetah", "run", num_workers=3)
         try:
             assert isinstance(env, ParallelEnv)
             assert env.num_workers == 3
-            # ParallelEnv should be lazy (not started yet)
-            assert env.is_closed
-
-            # configure_parallel should work before env starts
-            env.configure_parallel(use_buffers=False)
+            assert env._metadata_from_workers
             assert env._use_buffers is False
-
-            # After reset, env is started
-            env.reset()
             assert not env.is_closed
+            env.reset()
             assert env.batch_size == torch.Size([3])
         finally:
             env.close()

--- a/test/libs/test_genesis.py
+++ b/test/libs/test_genesis.py
@@ -9,6 +9,7 @@ import argparse
 import pytest
 import torch
 
+from torchrl.envs import ParallelEnv
 from torchrl.envs.libs.genesis import _has_genesis, GenesisEnv, GenesisWrapper
 from torchrl.envs.utils import check_env_specs
 
@@ -165,6 +166,17 @@ class TestGenesis:
             env.close()
         except Exception as e:
             pytest.skip(f"Genesis franka_reach not available: {e}")
+
+    def test_num_workers_uses_worker_metadata(self):
+        env = GenesisEnv("franka_reach", num_workers=2)
+        try:
+            assert isinstance(env, ParallelEnv)
+            assert env._metadata_from_workers
+            assert env._use_buffers is False
+            assert not env.is_closed
+            assert env.reset().batch_size == torch.Size([2])
+        finally:
+            env.close()
 
 
 if __name__ == "__main__":

--- a/test/libs/test_gym.py
+++ b/test/libs/test_gym.py
@@ -1748,7 +1748,7 @@ class TestGym:
         ), f"Expected False for Dict environment without pixels, got {result}"
 
     def test_num_workers_returns_parallel_env(self):
-        """Ensure explicit TorchRL `num_workers` returns a lazy ParallelEnv, while gym's
+        """Ensure explicit TorchRL `num_workers` returns a ParallelEnv, while gym's
         native `num_envs` remains a gym-native vectorization."""
 
         # TorchRL-managed parallelism: should return ParallelEnv
@@ -1760,7 +1760,12 @@ class TestGym:
             if nworkers is None:
                 nworkers = getattr(env, "num_envs", None)
             assert nworkers == 3
-            # start workers on first use
+            assert env._metadata_from_workers
+            assert env._use_buffers is False
+            assert not any(
+                isinstance(factory, EnvCreator) for factory in env.create_env_fn
+            )
+            assert not env.is_closed
             env.reset()
             assert env.batch_size == torch.Size([3])
         finally:
@@ -1773,19 +1778,15 @@ class TestGym:
         finally:
             env_gymvec.close()
 
-    def test_num_workers_kwargs_modifiable(self):
-        """Ensure the kwargs preserved by the GymEnv factory can be modified via
-        `configure_parallel` before workers start."""
+    def test_num_workers_parallel_env_is_started(self):
+        """Worker metadata starts the generated ParallelEnv during construction."""
 
         env = GymEnv("CartPole-v1", num_workers=3)
         try:
-            # should return a lazy ParallelEnv
             assert isinstance(env, ParallelEnv)
-
-            # configure_parallel should accept kwargs and be callable before start
-            env.configure_parallel(use_buffers=True, num_threads=1)
-
-            # starting the environment should work after configuring
+            assert not env.is_closed
+            with pytest.raises(RuntimeError, match="after the environment has started"):
+                env.configure_parallel(num_threads=1)
             td = env.reset()
             assert isinstance(td, TensorDict)
         finally:

--- a/test/libs/test_habitat.py
+++ b/test/libs/test_habitat.py
@@ -6,11 +6,32 @@ from __future__ import annotations
 
 import pytest
 import torch
-from tensordict import TensorDict
 
+import torchrl.envs as torchrl_envs
+from tensordict import TensorDict
 from torchrl.envs.batched_envs import ParallelEnv
 from torchrl.envs.libs.habitat import _has_habitat, HabitatEnv
 from torchrl.envs.utils import check_env_specs
+
+
+@pytest.mark.parametrize(
+    ("device", "expected"),
+    [([0, 0], True), ([0, 1], False)],
+)
+def test_num_workers_uses_worker_metadata_for_matching_devices(
+    monkeypatch, device, expected
+):
+    captured = {}
+
+    def fake_parallel_env(num_workers, create_env_fn, **kwargs):
+        captured["kwargs"] = kwargs
+        return captured
+
+    monkeypatch.setattr(torchrl_envs, "ParallelEnv", fake_parallel_env)
+
+    env = HabitatEnv("HabitatPick-v0", num_workers=2, device=device)
+
+    assert env["kwargs"]["metadata_from_workers"] is expected
 
 
 @pytest.mark.skipif(not _has_habitat, reason="habitat not installed")
@@ -29,22 +50,16 @@ class TestHabitat:
         if from_pixels:
             assert "pixels" in rollout.keys()
 
-    def test_num_workers_returns_lazy_parallel_env(self, envname):
-        """Ensure HabitatEnv with num_workers > 1 returns a lazy ParallelEnv."""
+    def test_num_workers_returns_parallel_env(self, envname):
+        """Ensure HabitatEnv workers report metadata directly."""
         env = HabitatEnv(envname, num_workers=3)
         try:
             assert isinstance(env, ParallelEnv)
             assert env.num_workers == 3
-            # ParallelEnv should be lazy (not started yet)
-            assert env.is_closed
-
-            # configure_parallel should work before env starts
-            env.configure_parallel(use_buffers=False)
+            assert env._metadata_from_workers
             assert env._use_buffers is False
-
-            # After reset, env is started
-            env.reset()
             assert not env.is_closed
+            env.reset()
             assert env.batch_size == torch.Size([3])
         finally:
             env.close()

--- a/test/libs/test_libero.py
+++ b/test/libs/test_libero.py
@@ -30,9 +30,10 @@ _FAST = {"camera_height": 64, "camera_width": 64, "settle_steps": 2}
 
 
 class _FakeParallelEnv:
-    def __init__(self, num_workers, create_env_fn):
+    def __init__(self, num_workers, create_env_fn, **kwargs):
         self.num_workers = num_workers
         self.create_env_fn = create_env_fn
+        self.kwargs = kwargs
 
 
 def test_parallel_env_dispatch(monkeypatch):
@@ -50,6 +51,7 @@ def test_parallel_env_dispatch(monkeypatch):
     )
 
     assert env.num_workers == 2
+    assert env.kwargs["metadata_from_workers"] is False
     first, second = env.create_env_fn
     assert first.keywords["num_workers"] == 1
     assert first.keywords["task_suite"] == "libero_spatial"
@@ -77,6 +79,22 @@ def test_parallel_env_num_envs_alias(monkeypatch):
     )
 
     assert env.num_workers == 2
+    assert env.kwargs["metadata_from_workers"] is True
+
+
+def test_parallel_env_safe_worker_variation_uses_worker_metadata(monkeypatch):
+    monkeypatch.setattr(libero_module, "ParallelEnv", _FakeParallelEnv)
+
+    env = LiberoEnv(
+        task_suite="libero_spatial",
+        task_id=0,
+        num_workers=2,
+        camera_height=[64, 64],
+        render_gpu_device_id=[0, 1],
+        group_id_offset=[0, 1000],
+    )
+
+    assert env.kwargs["metadata_from_workers"] is True
 
 
 def test_parallel_env_dispatch_validation():
@@ -274,6 +292,8 @@ class TestLibero:
         )
         try:
             assert env.num_workers == 2
+            assert env._metadata_from_workers
+            assert env._use_buffers is False
             assert env.batch_size == torch.Size([2])
             assert env.full_observation_spec["observation", "image"].shape == (
                 2,

--- a/test/libs/test_mjlab.py
+++ b/test/libs/test_mjlab.py
@@ -12,7 +12,7 @@ from typing import Any
 import pytest
 import torch
 
-from torchrl.envs import TransformedEnv
+from torchrl.envs import ParallelEnv, TransformedEnv
 from torchrl.envs.libs.mjlab import MJLabEnv, MJLabWrapper
 from torchrl.envs.transforms import InitTracker
 from torchrl.envs.utils import check_env_specs
@@ -125,6 +125,20 @@ def test_batch_size_and_pixels_validation_use_mjlab_task_cfg():
         MJLabEnv(_CARTPOLE_TASK, cfg=cfg, num_envs=3, batch_size=[2])
     with pytest.raises(ValueError, match="CameraSensor"):
         MJLabEnv(_CARTPOLE_TASK, cfg=cfg, num_envs=3, from_pixels=True)
+
+
+@pytest.mark.gpu
+@requires_mjlab_cuda
+def test_num_workers_uses_worker_metadata():
+    env = MJLabEnv(_CARTPOLE_TASK, num_workers=2, num_envs=1, device="cuda:0")
+    try:
+        assert isinstance(env, ParallelEnv)
+        assert env._metadata_from_workers
+        assert env._use_buffers is False
+        assert not env.is_closed
+        assert env.reset().batch_size == torch.Size([2, 1])
+    finally:
+        env.close()
 
 
 @pytest.mark.gpu

--- a/test/libs/test_mujoco.py
+++ b/test/libs/test_mujoco.py
@@ -902,10 +902,17 @@ class TestMujoco:
         are aliases; both produce a :class:`ParallelEnv` of N copies."""
         env_a = HopperEnv(backend="mujoco", num_envs=2, seed=0)
         env_b = HopperEnv(backend="mujoco", num_workers=2, seed=0)
-        # Lazy ParallelEnvs -- don't start workers, just shape-check.
-        assert isinstance(env_a, ParallelEnv)
-        assert isinstance(env_b, ParallelEnv)
-        assert env_a.batch_size == env_b.batch_size
+        try:
+            assert isinstance(env_a, ParallelEnv)
+            assert isinstance(env_b, ParallelEnv)
+            assert env_a._metadata_from_workers
+            assert env_b._metadata_from_workers
+            assert env_a._use_buffers is False
+            assert env_b._use_buffers is False
+            assert env_a.batch_size == env_b.batch_size
+        finally:
+            env_a.close()
+            env_b.close()
 
     @pytest.mark.skipif(not _has_mujoco, reason="mujoco not installed")
     def test_mujoco_backend_rejects_both_envs_and_workers(self):
@@ -924,6 +931,8 @@ class TestMujoco:
     def test_mujoco_backend_parallel_rollout(self):
         env = HopperEnv(backend="mujoco", num_envs=2, seed=0)
         assert isinstance(env, ParallelEnv)
+        assert env._metadata_from_workers
+        assert env._use_buffers is False
         td = env.rollout(3)
         assert torch.isfinite(td.get(("next", "reward"))).all()
         env.close()

--- a/test/libs/test_mujoco_playground.py
+++ b/test/libs/test_mujoco_playground.py
@@ -186,18 +186,18 @@ class TestMujocoPlayground:
         tensordict = env.rollout(3)
         assert tensordict.shape == torch.Size([n, *batch_size, 3])
 
-    def test_num_workers_returns_lazy_parallel_env(self, envname, device):
-        """num_workers > 1 returns a lazy ParallelEnv."""
+    def test_num_workers_returns_parallel_env(self, envname, device):
+        """num_workers > 1 uses worker-originated metadata."""
         env = MujocoPlaygroundEnv(
             envname, num_workers=3, device=device, config_overrides=_JAX_CONFIG
         )
         try:
             assert isinstance(env, ParallelEnv)
             assert env.num_workers == 3
-            assert env.is_closed
-            env.configure_parallel(use_buffers=False)
-            env.reset()
+            assert env._metadata_from_workers
+            assert env._use_buffers is False
             assert not env.is_closed
+            env.reset()
         finally:
             env.close()
 

--- a/torchrl/envs/custom/mujoco/base.py
+++ b/torchrl/envs/custom/mujoco/base.py
@@ -159,7 +159,10 @@ class _MujocoMeta(_EnvPostInit):
                     # Re-enters this metaclass with N=1 -> falls through.
                     return cls(*_args, **_kwargs)
 
-                return wrap_cls(n, _factory)
+                parallel_kwargs = (
+                    {"metadata_from_workers": True} if wrap_cls is ParallelEnv else {}
+                )
+                return wrap_cls(n, _factory, **parallel_kwargs)
             # Single env: pass through.
             return super().__call__(*args, **kwargs)
 

--- a/torchrl/envs/libs/brax.py
+++ b/torchrl/envs/libs/brax.py
@@ -40,7 +40,7 @@ def _get_envs():
 
 
 class _BraxMeta(_EnvPostInit):
-    """Metaclass for BraxEnv that returns a lazy ParallelEnv when num_workers > 1."""
+    """Metaclass for BraxEnv that returns a ParallelEnv when num_workers > 1."""
 
     def __call__(cls, *args, num_workers: int | None = None, **kwargs):
         # Extract num_workers from explicit kwarg or kwargs dict
@@ -61,8 +61,7 @@ class _BraxMeta(_EnvPostInit):
             def make_env(_env_name=env_name, _kwargs=env_kwargs):
                 return cls(_env_name, num_workers=1, **_kwargs)
 
-            # Return lazy ParallelEnv (workers not started yet)
-            return ParallelEnv(num_workers, make_env)
+            return ParallelEnv(num_workers, make_env, metadata_from_workers=True)
 
         return super().__call__(*args, **kwargs)
 
@@ -551,9 +550,10 @@ class BraxEnv(BraxWrapper, metaclass=_BraxMeta):
         allow_done_after_reset (bool, optional): if ``True``, it is tolerated
             for envs to be ``done`` just after :meth:`reset` is called.
             Defaults to ``False``.
-        num_workers (int, optional): if greater than 1, a lazy :class:`~torchrl.envs.ParallelEnv`
+        num_workers (int, optional): if greater than 1, a :class:`~torchrl.envs.ParallelEnv`
             will be returned instead, with each worker instantiating its own
-            :class:`~torchrl.envs.BraxEnv` instance. Defaults to ``None``.
+            :class:`~torchrl.envs.BraxEnv` instance and reporting metadata directly
+            to the parent. Defaults to ``None``.
 
     .. note::
         There are two orthogonal ways to scale environment throughput:

--- a/torchrl/envs/libs/dm_control.py
+++ b/torchrl/envs/libs/dm_control.py
@@ -117,16 +117,12 @@ def _robust_to_tensor(array: float | np.ndarray) -> torch.Tensor:
 
 
 class _DMControlMeta(_EnvPostInit):
-    """Metaclass for DMControlEnv that returns a lazy ParallelEnv when num_workers > 1.
+    """Metaclass for DMControlEnv that returns a ParallelEnv when num_workers > 1.
 
     When ``DMControlEnv(..., num_workers=4)`` is called, this metaclass intercepts the
     call and returns a :class:`~torchrl.envs.ParallelEnv` instead. The returned
-    ParallelEnv is lazy — workers are not started until the environment is actually used
-    (e.g., via :meth:`torchrl.envs.batched_envs.BatchedEnvBase.reset` / :meth:`torchrl.envs.batched_envs.BatchedEnvBase.step`
-    or when accessing specs).
-
-    Users can call :meth:`torchrl.envs.batched_envs.BatchedEnvBase.configure_parallel`
-    to set ParallelEnv parameters before the environment starts.
+    Workers start during construction and provide their metadata directly, avoiding a
+    temporary ``DMControlEnv`` construction in the parent process.
     """
 
     def __call__(cls, *args, num_workers: int | None = None, **kwargs):
@@ -154,8 +150,7 @@ class _DMControlMeta(_EnvPostInit):
             def make_env(_env_name=env_name, _task_name=task_name, _kwargs=env_kwargs):
                 return cls(_env_name, _task_name, num_workers=1, **_kwargs)
 
-            # Return lazy ParallelEnv (workers not started yet)
-            return ParallelEnv(num_workers, make_env)
+            return ParallelEnv(num_workers, make_env, metadata_from_workers=True)
 
         return super().__call__(*args, **kwargs)
 
@@ -398,11 +393,10 @@ class DMControlEnv(DMControlWrapper, metaclass=_DMControlMeta):
         env_name (str): name of the environment.
         task_name (str): name of the task.
         num_workers (int, optional): number of parallel environments. Defaults to 1.
-            When ``num_workers > 1``, a lazy :class:`~torchrl.envs.ParallelEnv` is
-            returned instead of a single environment. The parallel environment
-            is not started until it is actually used (e.g., via reset/step or
-            accessing specs). Use :meth:`~torchrl.envs.BatchedEnvBase.configure_parallel`
-            to set parallel execution parameters before the environment starts.
+            When ``num_workers > 1``, a :class:`~torchrl.envs.ParallelEnv` is
+            returned instead of a single environment. Its workers provide their
+            metadata directly, avoiding a temporary environment construction in
+            the parent process.
 
     Keyword Args:
         from_pixels (bool, optional): if ``True``, an attempt to return the pixel
@@ -458,11 +452,8 @@ class DMControlEnv(DMControlWrapper, metaclass=_DMControlMeta):
             is_shared=False)
         >>> print(env.available_envs)
         [('acrobot', ['swingup', 'swingup_sparse']), ...]
-        >>> # For running multiple envs in parallel (returns a lazy ParallelEnv)
+        >>> # Run multiple envs in parallel without parent-side construction
         >>> env = DMControlEnv("cheetah", "run", num_workers=4)
-        >>> # Configure parallel parameters before the env starts
-        >>> env.configure_parallel(use_buffers=True, num_threads=2)
-        >>> # Environment starts when first used
         >>> env.reset()
     """
 

--- a/torchrl/envs/libs/genesis.py
+++ b/torchrl/envs/libs/genesis.py
@@ -455,7 +455,7 @@ class GenesisWrapper(EnvBase):
 
 
 class _GenesisEnvMeta(_EnvPostInit):
-    """Return a lazy ParallelEnv when ``num_workers > 1``."""
+    """Return a ParallelEnv when ``num_workers > 1``."""
 
     def __call__(cls, *args, num_workers: int | None = None, **kwargs):
         if num_workers is None:
@@ -477,7 +477,7 @@ class _GenesisEnvMeta(_EnvPostInit):
             def make_env(_env_name=env_name, _task_name=task_name, _kwargs=env_kwargs):
                 return cls(_env_name, _task_name, num_workers=1, **_kwargs)
 
-            return ParallelEnv(num_workers, make_env)
+            return ParallelEnv(num_workers, make_env, metadata_from_workers=True)
 
         return super().__call__(*args, **kwargs)
 
@@ -489,9 +489,9 @@ class GenesisEnv(GenesisWrapper, metaclass=_GenesisEnvMeta):
         env_name (str): registered environment name. Currently one of
             ``'franka_reach'`` or ``'franka_grab'``.
         task_name (str, optional): task name; unused by the built-in configs.
-        num_workers (int, optional): when ``> 1``, returns a lazy
+        num_workers (int, optional): when ``> 1``, returns a
             :class:`~torchrl.envs.ParallelEnv` wrapping per-worker Genesis envs.
-            Defaults to ``1``.
+            Workers report metadata directly to the parent. Defaults to ``1``.
         max_steps (int, optional): truncation horizon. Defaults to ``1000``.
         frame_skip (int, optional): physics steps per env step. Defaults to ``1``.
         from_pixels (bool, optional): if ``True``, a default camera is added

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -878,13 +878,13 @@ class _GymAsyncMeta(_EnvPostInit):
         )
 
         if cls.__name__ == "GymEnv" and num_workers > 1:
-            from torchrl.envs import EnvCreator, ParallelEnv
+            from torchrl.envs import ParallelEnv
 
             env_name = args[0] if args else kwargs.get("env_name")
             env_kwargs = kwargs.copy()
             env_kwargs.pop("env_name", None)
             make_env = partial(cls, env_name, **env_kwargs)
-            return ParallelEnv(num_workers, EnvCreator(make_env))
+            return ParallelEnv(num_workers, make_env, metadata_from_workers=True)
 
         instance: GymWrapper = super().__call__(*args, **kwargs)
 
@@ -1820,11 +1820,10 @@ class GymEnv(GymWrapper):
             will be used by default.
         num_workers (int, optional): number of top-level worker subprocesses used to create/run
             multiple :class:`GymEnv` instances in parallel (handled by the metaclass
-            :class:`_GymAsyncMeta`). When ``num_workers > 1``, a lazy
+            :class:`_GymAsyncMeta`). When ``num_workers > 1``, a
             :class:`~torchrl.envs.ParallelEnv` is returned whose factory preserves the original
-            `GymEnv` kwargs. You can modify the ParallelEnv construction/configuration before
-            it starts by calling :meth:`~torchrl.envs.batched_envs.BatchedEnvBase.configure_parallel`
-            on the returned object (for example: ``env.configure_parallel(use_buffers=True, num_threads=2)``).
+            `GymEnv` kwargs. Its workers provide their metadata directly, avoiding a temporary
+            `GymEnv` construction in the parent process.
             When both ``num_workers`` and ``num_envs`` are greater than 1, the total number of
             environments executed in parallel is ``num_workers * num_envs``. Defaults to ``1``.
         disable_env_checker (bool, optional): for gym > 0.24 only. If ``True`` (default

--- a/torchrl/envs/libs/habitat.py
+++ b/torchrl/envs/libs/habitat.py
@@ -40,7 +40,7 @@ def _get_available_envs():
 
 
 class _HabitatMeta(_GymAsyncMeta):
-    """Metaclass for HabitatEnv that returns a lazy ParallelEnv when num_workers > 1."""
+    """Metaclass for HabitatEnv that returns a ParallelEnv when num_workers > 1."""
 
     def __call__(cls, *args, num_workers: int | None = None, **kwargs):
         # Extract num_workers from explicit kwarg or kwargs dict
@@ -77,7 +77,12 @@ class _HabitatMeta(_GymAsyncMeta):
                 functools.partial(cls, env_name, num_workers=1, device=d, **env_kwargs)
                 for d in devices
             ]
-            return ParallelEnv(num_workers, make_envs)
+            metadata_from_workers = len({str(device) for device in devices}) == 1
+            return ParallelEnv(
+                num_workers,
+                make_envs,
+                metadata_from_workers=metadata_from_workers,
+            )
 
         return super().__call__(*args, **kwargs)
 

--- a/torchrl/envs/libs/libero.py
+++ b/torchrl/envs/libs/libero.py
@@ -112,8 +112,37 @@ def _normalize_libero_num_workers(
     return num_workers
 
 
+def _libero_worker_metadata_compatible(worker_kwargs: list[dict[str, Any]]) -> bool:
+    non_schema_keys = {
+        "group_id_mode",
+        "group_id_offset",
+        "group_repeats",
+        "init_state_id",
+        "init_state_mode",
+        "init_states",
+        "instruction",
+        "max_episode_steps",
+        "render_gpu_device_id",
+        "seed",
+        "settle_steps",
+    }
+
+    def schema_kwargs(kwargs):
+        return tuple(
+            (key, repr(value))
+            for key, value in sorted(kwargs.items())
+            if key not in non_schema_keys
+        )
+
+    reference = schema_kwargs(worker_kwargs[0])
+    return all(
+        schema_kwargs(worker_kwargs_i) == reference
+        for worker_kwargs_i in worker_kwargs[1:]
+    )
+
+
 class _LiberoEnvMeta(_EnvPostInit):
-    """Metaclass that returns a lazy ``ParallelEnv`` for ``LiberoEnv`` workers."""
+    """Metaclass that returns a ``ParallelEnv`` for ``LiberoEnv`` workers."""
 
     def __call__(
         cls,
@@ -165,7 +194,11 @@ class _LiberoEnvMeta(_EnvPostInit):
             partial(cls, num_workers=1, **worker_kwarg)
             for worker_kwarg in worker_kwargs
         ]
-        return ParallelEnv(num_workers, make_envs)
+        return ParallelEnv(
+            num_workers,
+            make_envs,
+            metadata_from_workers=_libero_worker_metadata_compatible(worker_kwargs),
+        )
 
 
 class LiberoWrapper(_EnvWrapper):
@@ -598,7 +631,10 @@ class LiberoEnv(LiberoWrapper, metaclass=_LiberoEnvMeta):
     Keyword Args:
         num_workers (int, optional): if greater than ``1``, return a
             :class:`~torchrl.envs.ParallelEnv` with ``num_workers`` LIBERO
-            workers. Defaults to ``1``.
+            workers. Each worker provides its metadata directly, so no temporary
+            LIBERO environment is constructed in the parent process, unless
+            worker-specific arguments produce different observation schemas.
+            Defaults to ``1``.
         num_envs (int, optional): alias for ``num_workers``.
         camera_height (int or list of int, optional): rendered image height.
             When ``num_workers > 1``, a list dispatches one value per worker

--- a/torchrl/envs/libs/mjlab.py
+++ b/torchrl/envs/libs/mjlab.py
@@ -621,7 +621,7 @@ class MJLabWrapper(_EnvWrapper):
 
 
 class _MJLabEnvMeta(_EnvPostInit):
-    """Return a lazy ParallelEnv when ``num_workers > 1``."""
+    """Return a ParallelEnv when ``num_workers > 1``."""
 
     def __call__(cls, *args, num_workers: int | None = None, **kwargs):
         if num_workers is None:
@@ -630,7 +630,7 @@ class _MJLabEnvMeta(_EnvPostInit):
             kwargs.pop("num_workers", None)
         num_workers = int(num_workers) if num_workers is not None else 1
         if cls.__name__ == "MJLabEnv" and num_workers > 1:
-            from torchrl.envs import EnvCreator, ParallelEnv
+            from torchrl.envs import ParallelEnv
 
             task_id = args[0] if len(args) >= 1 else kwargs.get("task_id")
             env_kwargs = {
@@ -640,7 +640,7 @@ class _MJLabEnvMeta(_EnvPostInit):
             def make_env(_task_id=task_id, _kwargs=env_kwargs):
                 return cls(_task_id, num_workers=1, **_kwargs)
 
-            return ParallelEnv(num_workers, EnvCreator(make_env))
+            return ParallelEnv(num_workers, make_env, metadata_from_workers=True)
         return super().__call__(*args, **kwargs)
 
 
@@ -670,8 +670,9 @@ class MJLabEnv(MJLabWrapper, metaclass=_MJLabEnvMeta):
         pixels_only: See :class:`MJLabWrapper`.
         pixels_key: See :class:`MJLabWrapper`.
         pixels_sensor: See :class:`MJLabWrapper`.
-        num_workers: If greater than one, return a lazy
+        num_workers: If greater than one, return a
             :class:`~torchrl.envs.ParallelEnv` with one mjlab env per worker.
+            Workers report metadata directly to the parent.
 
     See also :class:`~torchrl.trainers.algorithms.configs.MJLabEnvConfig`.
 

--- a/torchrl/envs/libs/mujoco_playground.py
+++ b/torchrl/envs/libs/mujoco_playground.py
@@ -371,7 +371,7 @@ def _get_envs() -> list[str]:
 
 
 class _MujocoPlaygroundMeta(_EnvPostInit):
-    """Metaclass for MujocoPlaygroundEnv that returns a lazy ParallelEnv when num_workers > 1."""
+    """Metaclass returning a ParallelEnv when num_workers > 1."""
 
     def __call__(cls, *args, num_workers: int | None = None, **kwargs):
         # Accept num_workers either as the explicit kwarg or via the kwargs
@@ -389,7 +389,7 @@ class _MujocoPlaygroundMeta(_EnvPostInit):
             def make_env(_env_name=env_name, _kwargs=env_kwargs):
                 return cls(_env_name, num_workers=1, **_kwargs)
 
-            return ParallelEnv(num_workers, make_env)
+            return ParallelEnv(num_workers, make_env, metadata_from_workers=True)
 
         return super().__call__(*args, **kwargs)
 
@@ -989,9 +989,10 @@ class MujocoPlaygroundEnv(MujocoPlaygroundWrapper, metaclass=_MujocoPlaygroundMe
         allow_done_after_reset (bool, optional): if ``True``, it is tolerated
             for envs to be ``done`` just after :meth:`reset` is called.
             Defaults to ``False``.
-        num_workers (int, optional): if greater than 1, a lazy :class:`~torchrl.envs.ParallelEnv`
+        num_workers (int, optional): if greater than 1, a :class:`~torchrl.envs.ParallelEnv`
             will be returned instead, with each worker instantiating its own
-            :class:`~torchrl.envs.MujocoPlaygroundEnv` instance. Defaults to ``None``.
+            :class:`~torchrl.envs.MujocoPlaygroundEnv` instance and reporting
+            metadata directly to the parent. Defaults to ``None``.
 
     .. note::
         There are two orthogonal ways to scale environment throughput:


### PR DESCRIPTION
## Summary

- automatically enable worker-originated metadata when environment convenience constructors create a `ParallelEnv` from `num_workers`
- cover Gym, DMControl, Brax, Habitat, LIBERO, Genesis, MJLab, MuJoCo Playground, and process-based custom MuJoCo environments
- retain parent-side metadata for known heterogeneous LIBERO schemas and Habitat device assignments
- document the automatic behavior and extend the existing integration tests

## Motivation

`metadata_from_workers=True` was introduced in #4028 to avoid constructing temporary environments in the parent process. Convenience constructors such as `GymEnv(..., num_workers=N)` synthesized a `ParallelEnv` without enabling that mode, so they still paid the parent-side construction cost unless users built the `ParallelEnv` manually.

This follow-up makes the optimized path automatic when the generated workers have compatible tensor schemas. Gym's native `num_envs` vectorization remains unchanged.

## User impact

Automatically generated process-based environments now start their workers during construction and use pipe-based communication (`use_buffers=False`), as required by worker-originated metadata. Expensive simulator environments are no longer instantiated solely for metadata in the parent process.

## Validation

- `pytest -q test/envs/test_parallel.py -k metadata_from_workers`
- focused `num_workers` tests across Gym, LIBERO, Habitat, Genesis, MJLab, custom MuJoCo, Brax, DMControl, and MuJoCo Playground
- pre-commit hooks for all changed files (`ufmt` run directly from the cached Python 3.11 hook environment)

Local result: 16 passed. Seven optional-dependency cases were collected and skipped because those dependencies or CUDA were unavailable locally; the `ci/optdeps` label requests their full CI coverage.
