### PR TITLE
[BugFix] Keep replay storage bookkeeping compilable

### DIFF
--- a/test/rb/test_storages.py
+++ b/test/rb/test_storages.py
@@ -317,8 +317,8 @@ class TestStorages:
         sys.version_info >= (3, 14),
         reason="torch.compile is not supported on Python 3.14+",
     )
-    # This test checks if the `torch._dynamo.disable` wrapper around
-    # `TensorStorage._rand_given_ndim` is still necessary.
+    # This test checks that mutable storage bookkeeping does not cause
+    # excessive recompilation when writes and sampling are compiled together.
     def test__rand_given_ndim_recompile(self):
         torch._dynamo.reset_code_caches()
 
@@ -353,12 +353,38 @@ class TestStorages:
             torch._logging.set_logs()
 
         assert len(storage) == num_extend * data_size
+        assert storage._mutation_revision == num_extend
+        assert storage._last_cursor_index == num_extend * data_size - 1
         assert len(records) <= 8, (
             "Excessive recompilations detected. Expected 8 or fewer, but got "
-            f"{len(records)}. This suggests the `torch.compiler.disable` "
-            "decorators may not be working properly or new recompilation "
-            "sources have been introduced."
+            f"{len(records)}. Mutable storage state may be guarded or a compiled "
+            "graph may no longer be reusable."
         )
+
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.5.0"), reason="requires Torch >= 2.5.0"
+    )
+    @pytest.mark.skipif(_os_is_windows, reason="windows tests do not support compile")
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 14),
+        reason="torch.compile is not supported on Python 3.14+",
+    )
+    def test_compilable_storage_set_fullgraph(self):
+        storage = LazyTensorStorage(100, compilable=True)
+        data = torch.arange(25).unsqueeze(-1)
+        storage.set(torch.arange(25), data)
+
+        @torch.compile(fullgraph=True)
+        def write(cursor, value):
+            storage.set(cursor, value)
+
+        write(torch.arange(25, 50), data)
+        write(torch.arange(50, 75), data)
+
+        assert len(storage) == 75
+        assert storage._mutation_revision == 3
+        assert storage._last_cursor_index == 74
+        torch.testing.assert_close(storage[:75], data.repeat(3, 1))
 
     @pytest.mark.parametrize("storage_type", [LazyMemmapStorage, LazyTensorStorage])
     def test_extend_lazystack(self, storage_type):

--- a/torchrl/data/replay_buffers/storages.py
+++ b/torchrl/data/replay_buffers/storages.py
@@ -196,11 +196,15 @@ class Storage:
         self.checkpointer = checkpointer
         self._compilable = compilable
         self._attached_entities_list = []
-        self._mutation_revision_value = 0 if compilable else mp.Value("q", 0)
-        self._last_cursor_index_value = -1 if compilable else mp.Value("q", -1)
+        self._mutation_revision_value = (
+            torch.zeros((), dtype=torch.int64) if compilable else mp.Value("q", 0)
+        )
+        self._last_cursor_index_value = (
+            torch.full((), -1, dtype=torch.int64) if compilable else mp.Value("q", -1)
+        )
 
     @property
-    def _mutation_revision(self) -> int:
+    def _mutation_revision(self) -> int | torch.Tensor:
         """Monotonic storage-content revision shared with spawned processes."""
         revision = getattr(self, "_mutation_revision_value", None)
         if not self._compilable:
@@ -208,8 +212,10 @@ class Storage:
                 revision = self._mutation_revision_value = mp.Value("q", 0)
             return revision.value
         if revision is None:
-            revision = self._mutation_revision_value = 0
-        return revision
+            revision = self._mutation_revision_value = torch.zeros(
+                (), dtype=torch.int64
+            )
+        return revision if is_compiling() else int(revision.item())
 
     def _bump_mutation_revision(self) -> None:
         """Invalidates process-local metadata derived from storage contents."""
@@ -220,41 +226,55 @@ class Storage:
             with revision.get_lock():
                 revision.value += 1
         else:
-            self._mutation_revision_value = self._mutation_revision + 1
+            if revision is None:
+                revision = self._mutation_revision_value = torch.zeros(
+                    (), dtype=torch.int64
+                )
+            revision.add_(1)
 
     @property
-    def _last_cursor_index(self) -> int | None:
+    def _last_cursor_index(self) -> int | torch.Tensor | None:
         """Last written time coordinate, shared with spawned processes."""
         cursor = getattr(self, "_last_cursor_index_value", None)
         if cursor is None:
             return None
-        cursor = cursor if self._compilable else cursor.value
+        if self._compilable:
+            if is_compiling():
+                return cursor
+            cursor = int(cursor.item())
+        else:
+            cursor = cursor.value
         return None if cursor < 0 else cursor
 
     def _set_last_cursor(self, cursor: Any) -> None:
         self._last_cursor = cursor
         if isinstance(cursor, torch.Tensor):
             cursor = cursor.reshape(-1)
-            cursor = int(cursor[-1].item()) if cursor.numel() else -1
+            cursor = cursor[-1] if cursor.numel() else -1
         elif isinstance(cursor, range):
             cursor = int(cursor[-1]) if len(cursor) else -1
         elif isinstance(cursor, (tuple, list)):
             time_cursor = cursor[0]
             if isinstance(time_cursor, torch.Tensor):
                 time_cursor = time_cursor.reshape(-1)
-                cursor = int(time_cursor[-1].item()) if time_cursor.numel() else -1
+                cursor = time_cursor[-1] if time_cursor.numel() else -1
             else:
                 cursor = int(time_cursor)
         elif cursor is None:
             cursor = -1
         else:
             cursor = int(cursor)
-        shared_cursor = self._last_cursor_index_value
         if self._compilable:
-            self._last_cursor_index_value = cursor
-        else:
-            with shared_cursor.get_lock():
-                shared_cursor.value = cursor
+            if isinstance(cursor, torch.Tensor):
+                self._last_cursor_index_value = cursor
+            else:
+                self._last_cursor_index_value.fill_(cursor)
+            return
+        if isinstance(cursor, torch.Tensor):
+            cursor = int(cursor.item())
+        shared_cursor = self._last_cursor_index_value
+        with shared_cursor.get_lock():
+            shared_cursor.value = cursor
 
     @property
     def checkpointer(self):
@@ -427,18 +447,28 @@ class Storage:
         state.setdefault("_compilable", compilable)
         if revision is not None:
             if compilable:
-                state["_mutation_revision_value"] = revision
+                state["_mutation_revision_value"] = torch.tensor(
+                    revision, dtype=torch.int64
+                )
             else:
                 state["_mutation_revision_value"] = mp.Value("q", revision)
         if last_cursor is not None:
             if compilable:
-                state["_last_cursor_index_value"] = last_cursor
+                state["_last_cursor_index_value"] = torch.tensor(
+                    last_cursor, dtype=torch.int64
+                )
             else:
                 state["_last_cursor_index_value"] = mp.Value("q", last_cursor)
         elif "_last_cursor_index_value" not in state:
-            state["_last_cursor_index_value"] = -1 if compilable else mp.Value("q", -1)
+            state["_last_cursor_index_value"] = (
+                torch.full((), -1, dtype=torch.int64)
+                if compilable
+                else mp.Value("q", -1)
+            )
         if "_mutation_revision_value" not in state:
-            state["_mutation_revision_value"] = 0 if compilable else mp.Value("q", 0)
+            state["_mutation_revision_value"] = (
+                torch.zeros((), dtype=torch.int64) if compilable else mp.Value("q", 0)
+            )
         self.__dict__.update(state)
 
     def __contains__(self, item):


### PR DESCRIPTION
## Summary

- represent compilable storage revision and cursor bookkeeping as scalar tensors
- update the revision in place and carry tensor cursors through the compiled graph
- preserve Python integer access for eager cache logic and multiprocessing values for non-compilable storage
- cover repeated writes with `fullgraph=True` and verify revision/cursor semantics in the recompilation test

## First bad commit

The regression starts at `416941983` (`[Performance] Cache and vectorize replay-boundary queries`, #4084), merged on August 11.

Using the same Torch 2.11 environment:

- parent `cbc435e09`: `test__rand_given_ndim_recompile` passes
- `416941983`: the test fails with 12 recompilation records

That commit introduced two mutable Python scalars on the compiled storage write path:

1. `_mutation_revision_value` was incremented as a Python integer on every write, so Dynamo guarded each observed value and recompiled the resumed `TensorStorage.set()` frame.
2. `_set_last_cursor()` converted a tensor cursor with `.item()`, forcing a graph break.

The fix keeps both values as zero-dimensional tensors when `compilable=True`. Revision updates use `add_`, cursor updates stay tensor operations, and eager readers still receive Python integers. No compile-disable decorator is added.

This failure was observed in the CPU bulk job for #4073 and is unrelated to that PR's changes: https://github.com/pytorch/rl/actions/runs/31532919040/job/93917137645?pr=4073

## Validation

- first-bad-commit check: parent passes; `416941983` fails with 12 records
- recompilation test after fix: passes with one recorded recompilation locally; revision and cursor values remain correct
- repeated initialized writes compile with `fullgraph=True`
- focused compile tests pass on Torch 2.11 and Torch 2.13
- `pytest test/rb/test_storages.py -q`: 90 passed, 42 skipped
- storage suite plus cache invalidation tests: 92 passed, 42 skipped
- replay-buffer compile matrix: 12 passed with zero post-warmup recompilations
- compilable storage pickle/fullgraph round trip passes