### PR TITLE
[Feature] Add reusable value transforms

### DIFF
--- a/benchmarks/test_objectives_benchmarks.py
+++ b/benchmarks/test_objectives_benchmarks.py
@@ -20,7 +20,14 @@ from tensordict.nn import (
 )
 from torch.nn import functional as F
 from torchrl.data.tensor_specs import Bounded, Unbounded
-from torchrl.modules import MLP, QValueActor, SymExpTwoHot, TanhNormal
+from torchrl.modules import (
+    MLP,
+    QValueActor,
+    SignedHyperbolicValueTransform,
+    SymExpTwoHot,
+    SymLogValueTransform,
+    TanhNormal,
+)
 from torchrl.objectives import (
     A2CLoss,
     ClipPPOLoss,
@@ -167,6 +174,22 @@ def _maybe_compile(fn, compile, td, fullgraph=FULLGRAPH, warmup=3):
             fn(td)
 
     return fn
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [SymLogValueTransform(), SignedHyperbolicValueTransform()],
+    ids=["symlog", "signed-hyperbolic"],
+)
+@pytest.mark.parametrize("compile", [False, True])
+def test_value_transform_speed(benchmark, transform, compile, batch=2**20):
+    value = torch.randn(batch)
+
+    def round_trip(value):
+        return transform.inverse(transform(value))
+
+    round_trip = _maybe_compile(round_trip, compile, value)
+    benchmark(round_trip, value)
 
 
 @pytest.mark.parametrize("compile", [False, True])

--- a/docs/source/reference/modules_critics.rst
+++ b/docs/source/reference/modules_critics.rst
@@ -47,7 +47,7 @@ bootstrapping. They can be composed to build custom invertible mappings.
     SymLogValueTransform
     SignedHyperbolicValueTransform
     ComposeValueTransform
-    symlog
-    symexp
-    signed_hyperbolic
-    signed_parabolic
+    functional.symlog
+    functional.symexp
+    functional.signed_hyperbolic
+    functional.signed_parabolic

--- a/docs/source/reference/modules_critics.rst
+++ b/docs/source/reference/modules_critics.rst
@@ -30,3 +30,24 @@ Value networks estimate the value of states or state-action pairs.
     OnlineDTActor
     DTActor
     DecisionTransformer
+
+Value transforms
+----------------
+
+Value transforms compress large reward and return scales into a numerically
+convenient prediction space and provide the inverse mapping needed before
+bootstrapping. They can be composed to build custom invertible mappings.
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template_noinherit.rst
+
+    ValueTransform
+    IdentityValueTransform
+    SymLogValueTransform
+    SignedHyperbolicValueTransform
+    ComposeValueTransform
+    symlog
+    symexp
+    signed_hyperbolic
+    signed_parabolic

--- a/test/modules/test_value_transforms.py
+++ b/test/modules/test_value_transforms.py
@@ -7,14 +7,12 @@ from __future__ import annotations
 import pytest
 import torch
 
+import torchrl.modules as modules
 from torchrl.modules import (
     ComposeValueTransform,
+    functional as F,
     IdentityValueTransform,
-    signed_hyperbolic,
-    signed_parabolic,
     SignedHyperbolicValueTransform,
-    symexp,
-    symlog,
     SymLogValueTransform,
     ValueTransform,
 )
@@ -66,12 +64,16 @@ def test_value_transform_is_monotonic_and_compresses(transform):
 def test_value_transform_functional_api():
     value = torch.tensor([-100.0, -1.0, 0.0, 1.0, 100.0])
 
-    torch.testing.assert_close(SymLogValueTransform()(value), symlog(value))
-    torch.testing.assert_close(symexp(symlog(value)), value)
+    torch.testing.assert_close(SymLogValueTransform()(value), F.symlog(value))
+    torch.testing.assert_close(F.symexp(F.symlog(value)), value)
     torch.testing.assert_close(
-        SignedHyperbolicValueTransform()(value), signed_hyperbolic(value)
+        SignedHyperbolicValueTransform()(value), F.signed_hyperbolic(value)
     )
-    torch.testing.assert_close(signed_parabolic(signed_hyperbolic(value)), value)
+    torch.testing.assert_close(F.signed_parabolic(F.signed_hyperbolic(value)), value)
+    assert modules.symlog is F.symlog
+    assert modules.symexp is F.symexp
+    assert modules.signed_hyperbolic is F.signed_hyperbolic
+    assert modules.signed_parabolic is F.signed_parabolic
 
 
 def test_compose_value_transform_order():
@@ -106,7 +108,7 @@ def test_value_transform_errors():
     with pytest.raises(ValueError, match="epsilon must be positive"):
         SignedHyperbolicValueTransform(epsilon=0)
     with pytest.raises(ValueError, match="epsilon must be positive"):
-        signed_hyperbolic(torch.zeros(1), epsilon=-1)
+        F.signed_hyperbolic(torch.zeros(1), epsilon=-1)
     with pytest.raises(ValueError, match="at least one"):
         ComposeValueTransform()
     with pytest.raises(TypeError, match="ValueTransform"):

--- a/test/modules/test_value_transforms.py
+++ b/test/modules/test_value_transforms.py
@@ -1,0 +1,130 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import pytest
+import torch
+
+from torchrl.modules import (
+    ComposeValueTransform,
+    IdentityValueTransform,
+    signed_hyperbolic,
+    signed_parabolic,
+    SignedHyperbolicValueTransform,
+    symexp,
+    symlog,
+    SymLogValueTransform,
+    ValueTransform,
+)
+
+
+@pytest.mark.parametrize(
+    ("transform", "atol", "rtol"),
+    [
+        (IdentityValueTransform(), 0.0, 0.0),
+        (SymLogValueTransform(), 1e-10, 1e-10),
+        (SignedHyperbolicValueTransform(), 1e-9, 1e-9),
+        (
+            ComposeValueTransform(
+                SignedHyperbolicValueTransform(), SymLogValueTransform()
+            ),
+            1e-8,
+            1e-8,
+        ),
+    ],
+)
+def test_value_transform_round_trip(transform, atol, rtol):
+    value = torch.tensor(
+        [-1e6, -100.0, -1.0, -1e-6, 0.0, 1e-6, 1.0, 100.0, 1e6],
+        dtype=torch.float64,
+    )
+
+    transformed = transform(value)
+    reconstructed = transform.inverse(transformed)
+
+    torch.testing.assert_close(reconstructed, value, atol=atol, rtol=rtol)
+    assert transformed.shape == value.shape
+    assert transformed.dtype == value.dtype
+    assert transformed.device == value.device
+
+
+@pytest.mark.parametrize(
+    "transform", [SymLogValueTransform(), SignedHyperbolicValueTransform()]
+)
+def test_value_transform_is_monotonic_and_compresses(transform):
+    value = torch.linspace(-1e4, 1e4, 1001, dtype=torch.float64)
+    transformed = transform(value)
+
+    assert torch.all(transformed.diff() > 0)
+    assert transformed[0].abs() < value[0].abs()
+    assert transformed[-1].abs() < value[-1].abs()
+    torch.testing.assert_close(transformed, -transform(-value))
+
+
+def test_value_transform_functional_api():
+    value = torch.tensor([-100.0, -1.0, 0.0, 1.0, 100.0])
+
+    torch.testing.assert_close(SymLogValueTransform()(value), symlog(value))
+    torch.testing.assert_close(symexp(symlog(value)), value)
+    torch.testing.assert_close(
+        SignedHyperbolicValueTransform()(value), signed_hyperbolic(value)
+    )
+    torch.testing.assert_close(signed_parabolic(signed_hyperbolic(value)), value)
+
+
+def test_compose_value_transform_order():
+    first = SignedHyperbolicValueTransform(epsilon=1e-2)
+    second = SymLogValueTransform()
+    transform = ComposeValueTransform(first, second)
+    value = torch.tensor([-10.0, 0.0, 10.0])
+
+    torch.testing.assert_close(transform(value), second(first(value)))
+    torch.testing.assert_close(
+        transform.inverse(transform(value)),
+        first.inverse(second.inverse(transform(value))),
+    )
+
+
+def test_value_transform_gradients():
+    value = torch.tensor([-100.0, -1.0, -0.1, 0.0, 0.1, 1.0, 100.0], requires_grad=True)
+    transform = ComposeValueTransform(
+        SignedHyperbolicValueTransform(), SymLogValueTransform()
+    )
+
+    transform(value).sum().backward()
+
+    assert value.grad is not None
+    assert torch.isfinite(value.grad).all()
+    assert (value.grad > 0).all()
+
+
+def test_value_transform_errors():
+    with pytest.raises(TypeError):
+        ValueTransform()
+    with pytest.raises(ValueError, match="epsilon must be positive"):
+        SignedHyperbolicValueTransform(epsilon=0)
+    with pytest.raises(ValueError, match="epsilon must be positive"):
+        signed_hyperbolic(torch.zeros(1), epsilon=-1)
+    with pytest.raises(ValueError, match="at least one"):
+        ComposeValueTransform()
+    with pytest.raises(TypeError, match="ValueTransform"):
+        ComposeValueTransform(torch.nn.Identity())
+
+
+def test_value_transform_compile():
+    transform = ComposeValueTransform(
+        SignedHyperbolicValueTransform(), SymLogValueTransform()
+    )
+    value = torch.tensor([-100.0, 0.0, 100.0])
+
+    compiled = torch.compile(transform, backend="eager", fullgraph=True)
+    compiled_inverse = torch.compile(transform.inverse, backend="eager", fullgraph=True)
+
+    torch.testing.assert_close(compiled(value), transform(value))
+    torch.testing.assert_close(compiled_inverse(compiled(value)), value)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/torchrl/modules/__init__.py
+++ b/torchrl/modules/__init__.py
@@ -111,6 +111,17 @@ from .tensordict_module.exploration import (
 )
 from .utils import get_env_transforms_from_module, get_primers_from_module
 from .value_norm import PopArtValueNorm, RunningValueNorm, ValueNorm
+from .value_transforms import (
+    ComposeValueTransform,
+    IdentityValueTransform,
+    signed_hyperbolic,
+    signed_parabolic,
+    SignedHyperbolicValueTransform,
+    symexp,
+    symlog,
+    SymLogValueTransform,
+    ValueTransform,
+)
 from .planners import CEMPlanner, MPCPlannerBase, MPPIPlanner  # usort:skip
 from .mcts import (  # usort:skip
     EXP3Score,
@@ -135,6 +146,7 @@ __all__ = [
     "EXP3Score",
     "ConsistentDropout",
     "ConsistentDropoutModule",
+    "ComposeValueTransform",
     "Conv3dNet",
     "ConvNet",
     "CrossCriticGroupSpec",
@@ -163,6 +175,7 @@ __all__ = [
     "GRUModule",
     "LLMMaskedCategorical",
     "IndependentNormal",
+    "IdentityValueTransform",
     "LMHeadActorValueOperator",
     "LSTM",
     "LSTMCell",
@@ -213,7 +226,9 @@ __all__ = [
     "SafeSequential",
     "Squeeze2dLayer",
     "SqueezeLayer",
+    "SignedHyperbolicValueTransform",
     "SymExpTwoHot",
+    "SymLogValueTransform",
     "TanhDelta",
     "TanhModule",
     "TanhNormal",
@@ -225,6 +240,7 @@ __all__ = [
     "VLAWrapperBase",
     "ValueNorm",
     "ValueOperator",
+    "ValueTransform",
     "VmapModule",
     "WorldModel",
     "WorldModelWrapper",
@@ -234,8 +250,12 @@ __all__ = [
     "get_recurrent_matmul_precision",
     "recurrent_mode",
     "reset_noise",
+    "signed_hyperbolic",
+    "signed_parabolic",
     "set_exploration_modules_spec_from_env",
     "set_recurrent_matmul_precision",
     "set_recurrent_mode",
+    "symexp",
+    "symlog",
     "RandomPolicy",
 ]

--- a/torchrl/modules/__init__.py
+++ b/torchrl/modules/__init__.py
@@ -5,6 +5,7 @@
 
 from torchrl.modules.tensordict_module.common import DistributionalDQNnet
 
+from . import functional
 from .distributions import (
     Delta,
     distributions_maps,
@@ -22,6 +23,7 @@ from .distributions import (
     TanhNormal,
     TruncatedNormal,
 )
+from .functional import signed_hyperbolic, signed_parabolic, symexp, symlog
 from .models import (
     BatchRenorm1d,
     ConsistentDropout,
@@ -114,11 +116,7 @@ from .value_norm import PopArtValueNorm, RunningValueNorm, ValueNorm
 from .value_transforms import (
     ComposeValueTransform,
     IdentityValueTransform,
-    signed_hyperbolic,
-    signed_parabolic,
     SignedHyperbolicValueTransform,
-    symexp,
-    symlog,
     SymLogValueTransform,
     ValueTransform,
 )
@@ -245,6 +243,7 @@ __all__ = [
     "WorldModel",
     "WorldModelWrapper",
     "distributions_maps",
+    "functional",
     "get_env_transforms_from_module",
     "get_primers_from_module",
     "get_recurrent_matmul_precision",

--- a/torchrl/modules/functional.py
+++ b/torchrl/modules/functional.py
@@ -1,0 +1,146 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Functional operations for TorchRL modules."""
+from __future__ import annotations
+
+import torch
+
+
+def symlog(value: torch.Tensor) -> torch.Tensor:
+    """Apply the element-wise symmetric logarithm transform.
+
+    The transform is defined as
+    ``sign(value) * log(1 + abs(value))`` and compresses both positive and
+    negative values while remaining approximately linear around zero.
+
+    Args:
+        value (torch.Tensor): Input tensor.
+
+    Returns:
+        A tensor with the same shape, dtype, and device as ``value``.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.modules import functional as F
+        >>> value = torch.tensor([-100.0, 0.0, 100.0])
+        >>> F.symlog(value)
+        tensor([-4.6151,  0.0000,  4.6151])
+
+    .. seealso::
+        :func:`symexp` for the inverse operation and
+        :class:`~torchrl.modules.SymLogValueTransform` for the module form.
+    """
+    transformed = value.sign() * value.abs().log1p()
+    # ``sign`` has a zero derivative at the origin even though symlog has a
+    # derivative of one there. Keep the mathematically correct local gradient.
+    return torch.where(value == 0, value, transformed)
+
+
+def symexp(value: torch.Tensor) -> torch.Tensor:
+    """Apply the inverse symmetric exponential transform element-wise.
+
+    Args:
+        value (torch.Tensor): Input tensor in symmetric-log space.
+
+    Returns:
+        A tensor with the same shape, dtype, and device as ``value``.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.modules import functional as F
+        >>> value = torch.tensor([-100.0, 0.0, 100.0])
+        >>> transformed = F.symlog(value)
+        >>> transformed
+        tensor([-4.6151,  0.0000,  4.6151])
+        >>> F.symexp(transformed)
+        tensor([-100.0000,    0.0000,  100.0000])
+
+    .. seealso::
+        :func:`symlog` for the forward operation and
+        :class:`~torchrl.modules.SymLogValueTransform` for the module form.
+    """
+    transformed = value.sign() * value.abs().expm1()
+    return torch.where(value == 0, value, transformed)
+
+
+def signed_hyperbolic(value: torch.Tensor, epsilon: float = 1e-3) -> torch.Tensor:
+    """Apply the signed hyperbolic value transform.
+
+    This is the scale-compressing transform introduced by Pohlen et al. and
+    used by algorithms in the MuZero and Muesli families:
+
+    ``sign(value) * (sqrt(abs(value) + 1) - 1) + epsilon * value``.
+
+    Args:
+        value (torch.Tensor): Input tensor.
+        epsilon (float, optional): Positive linear correction that keeps the
+            inverse Lipschitz continuous. Defaults to ``1e-3``.
+
+    Returns:
+        A tensor with the same shape, dtype, and device as ``value``.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.modules import functional as F
+        >>> value = torch.tensor([-100.0, 0.0, 100.0])
+        >>> F.signed_hyperbolic(value)
+        tensor([-9.1499,  0.0000,  9.1499])
+
+    .. seealso::
+        :func:`signed_parabolic` for the inverse operation and
+        :class:`~torchrl.modules.SignedHyperbolicValueTransform` for the module
+        form.
+
+    .. note::
+        See `Observe and Look Further: Achieving Consistent Performance on
+        Atari <https://arxiv.org/abs/1805.11593>`_ (Pohlen et al., 2018).
+    """
+    if epsilon <= 0:
+        raise ValueError(f"epsilon must be positive, got {epsilon}.")
+    transformed = value.sign() * (torch.sqrt(value.abs() + 1) - 1) + epsilon * value
+    origin = value * (0.5 + epsilon)
+    return torch.where(value == 0, origin, transformed)
+
+
+def signed_parabolic(value: torch.Tensor, epsilon: float = 1e-3) -> torch.Tensor:
+    """Apply the inverse of :func:`signed_hyperbolic` element-wise.
+
+    Args:
+        value (torch.Tensor): Input tensor in signed-hyperbolic space.
+        epsilon (float, optional): Positive linear correction used by the
+            corresponding :func:`signed_hyperbolic` call. Defaults to
+            ``1e-3``.
+
+    Returns:
+        A tensor with the same shape, dtype, and device as ``value``.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.modules import functional as F
+        >>> value = torch.tensor([-100.0, 0.0, 100.0])
+        >>> transformed = F.signed_hyperbolic(value)
+        >>> transformed
+        tensor([-9.1499,  0.0000,  9.1499])
+        >>> F.signed_parabolic(transformed)
+        tensor([-100.0000,    0.0000,  100.0000])
+
+    .. seealso::
+        :func:`signed_hyperbolic` for the forward operation and
+        :class:`~torchrl.modules.SignedHyperbolicValueTransform` for the module
+        form.
+    """
+    if epsilon <= 0:
+        raise ValueError(f"epsilon must be positive, got {epsilon}.")
+    magnitude = value.abs()
+    discriminant = torch.sqrt(1 + 4 * epsilon * (magnitude + 1 + epsilon))
+    # This rationalized form of (discriminant - 1) / (2 * epsilon)
+    # avoids cancellation when epsilon is small.
+    root = 2 * (magnitude + 1 + epsilon) / (discriminant + 1)
+    transformed = value.sign() * (root.square() - 1)
+    origin = value / (0.5 + epsilon)
+    return torch.where(value == 0, origin, transformed)
+
+
+__all__ = ["signed_hyperbolic", "signed_parabolic", "symexp", "symlog"]

--- a/torchrl/modules/models/model_based_v3.py
+++ b/torchrl/modules/models/model_based_v3.py
@@ -16,6 +16,8 @@ from tensordict.utils import NestedKey, unravel_key
 from torch import nn
 from torch.nn import GRUCell
 
+from torchrl.modules.value_transforms import symexp, symlog  # noqa: F401
+
 
 _DEFAULT_NUM_BINS = 255
 _DEFAULT_BIN_RANGE = 20.0
@@ -230,43 +232,6 @@ class DreamerV3MLP(nn.Module):
     def forward(self, *inputs: torch.Tensor) -> torch.Tensor:
         value = inputs[0] if len(inputs) == 1 else torch.cat(inputs, -1)
         return self.model(value)
-
-
-def symlog(x: torch.Tensor) -> torch.Tensor:
-    """Apply the element-wise symmetric logarithm transform.
-
-    Args:
-        x (torch.Tensor): Input tensor.
-
-    Returns:
-        A tensor with the same shape, dtype, and device as ``x``.
-
-    Examples:
-        >>> import torch
-        >>> from torchrl.objectives import symlog
-        >>> symlog(torch.tensor([-100.0, 0.0, 100.0]))
-        tensor([-4.6151,  0.0000,  4.6151])
-    """
-    return x.sign() * (x.abs() + 1).log()
-
-
-def symexp(x: torch.Tensor) -> torch.Tensor:
-    """Apply the inverse of :func:`symlog` element-wise.
-
-    Args:
-        x (torch.Tensor): Input tensor.
-
-    Returns:
-        A tensor with the same shape, dtype, and device as ``x``.
-
-    Examples:
-        >>> import torch
-        >>> from torchrl.objectives import symexp, symlog
-        >>> x = torch.tensor([-1000.0, 0.0, 1000.0])
-        >>> torch.allclose(symexp(symlog(x)), x, atol=1e-4)
-        True
-    """
-    return x.sign() * x.abs().expm1()
 
 
 def _default_bins(

--- a/torchrl/modules/models/model_based_v3.py
+++ b/torchrl/modules/models/model_based_v3.py
@@ -16,7 +16,7 @@ from tensordict.utils import NestedKey, unravel_key
 from torch import nn
 from torch.nn import GRUCell
 
-from torchrl.modules.value_transforms import symexp, symlog  # noqa: F401
+from torchrl.modules.functional import symexp, symlog  # noqa: F401
 
 
 _DEFAULT_NUM_BINS = 255

--- a/torchrl/modules/value_transforms.py
+++ b/torchrl/modules/value_transforms.py
@@ -10,116 +10,7 @@ from abc import ABCMeta, abstractmethod
 import torch
 from torch import nn
 
-
-def symlog(value: torch.Tensor) -> torch.Tensor:
-    """Apply the element-wise symmetric logarithm transform.
-
-    The transform is defined as
-    ``sign(value) * log(1 + abs(value))`` and compresses both positive and
-    negative values while remaining approximately linear around zero.
-
-    Args:
-        value (torch.Tensor): Input tensor.
-
-    Returns:
-        A tensor with the same shape, dtype, and device as ``value``.
-
-    Examples:
-        >>> import torch
-        >>> from torchrl.modules import symlog
-        >>> symlog(torch.tensor([-100.0, 0.0, 100.0]))
-        tensor([-4.6151,  0.0000,  4.6151])
-    """
-    transformed = value.sign() * value.abs().log1p()
-    # ``sign`` has a zero derivative at the origin even though symlog has a
-    # derivative of one there. Keep the mathematically correct local gradient.
-    return torch.where(value == 0, value, transformed)
-
-
-def symexp(value: torch.Tensor) -> torch.Tensor:
-    """Apply the inverse symmetric exponential transform element-wise.
-
-    Args:
-        value (torch.Tensor): Input tensor in symmetric-log space.
-
-    Returns:
-        A tensor with the same shape, dtype, and device as ``value``.
-
-    Examples:
-        >>> import torch
-        >>> from torchrl.modules import symexp, symlog
-        >>> value = torch.tensor([-1000.0, 0.0, 1000.0])
-        >>> torch.allclose(symexp(symlog(value)), value, atol=1e-4)
-        True
-    """
-    transformed = value.sign() * value.abs().expm1()
-    return torch.where(value == 0, value, transformed)
-
-
-def signed_hyperbolic(value: torch.Tensor, epsilon: float = 1e-3) -> torch.Tensor:
-    """Apply the signed hyperbolic value transform.
-
-    This is the scale-compressing transform introduced by Pohlen et al. and
-    used by algorithms in the MuZero and Muesli families:
-
-    ``sign(value) * (sqrt(abs(value) + 1) - 1) + epsilon * value``.
-
-    Args:
-        value (torch.Tensor): Input tensor.
-        epsilon (float, optional): Positive linear correction that keeps the
-            inverse Lipschitz continuous. Defaults to ``1e-3``.
-
-    Returns:
-        A tensor with the same shape, dtype, and device as ``value``.
-
-    Examples:
-        >>> import torch
-        >>> from torchrl.modules import signed_hyperbolic
-        >>> signed_hyperbolic(torch.tensor([-100.0, 0.0, 100.0]))
-        tensor([-9.1499,  0.0000,  9.1499])
-
-    .. note::
-        See `Observe and Look Further: Achieving Consistent Performance on
-        Atari <https://arxiv.org/abs/1805.11593>`_ (Pohlen et al., 2018).
-    """
-    if epsilon <= 0:
-        raise ValueError(f"epsilon must be positive, got {epsilon}.")
-    transformed = value.sign() * (torch.sqrt(value.abs() + 1) - 1) + epsilon * value
-    origin = value * (0.5 + epsilon)
-    return torch.where(value == 0, origin, transformed)
-
-
-def signed_parabolic(value: torch.Tensor, epsilon: float = 1e-3) -> torch.Tensor:
-    """Apply the inverse of :func:`signed_hyperbolic` element-wise.
-
-    Args:
-        value (torch.Tensor): Input tensor in signed-hyperbolic space.
-        epsilon (float, optional): Positive linear correction used by the
-            corresponding :func:`signed_hyperbolic` call. Defaults to
-            ``1e-3``.
-
-    Returns:
-        A tensor with the same shape, dtype, and device as ``value``.
-
-    Examples:
-        >>> import torch
-        >>> from torchrl.modules import signed_hyperbolic, signed_parabolic
-        >>> value = torch.tensor([-1000.0, 0.0, 1000.0])
-        >>> torch.allclose(
-        ...     signed_parabolic(signed_hyperbolic(value)), value, atol=1e-3
-        ... )
-        True
-    """
-    if epsilon <= 0:
-        raise ValueError(f"epsilon must be positive, got {epsilon}.")
-    magnitude = value.abs()
-    discriminant = torch.sqrt(1 + 4 * epsilon * (magnitude + 1 + epsilon))
-    # This rationalized form of (discriminant - 1) / (2 * epsilon)
-    # avoids cancellation when epsilon is small.
-    root = 2 * (magnitude + 1 + epsilon) / (discriminant + 1)
-    transformed = value.sign() * (root.square() - 1)
-    origin = value / (0.5 + epsilon)
-    return torch.where(value == 0, origin, transformed)
+from . import functional as F
 
 
 class ValueTransform(nn.Module, metaclass=ABCMeta):
@@ -131,6 +22,27 @@ class ValueTransform(nn.Module, metaclass=ABCMeta):
 
     Subclasses implement :meth:`forward` and :meth:`inverse` as element-wise
     tensor operations.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.modules import ValueTransform
+        >>> class ScaleValueTransform(ValueTransform):
+        ...     def forward(self, value):
+        ...         return value * 2
+        ...     def inverse(self, value):
+        ...         return value / 2
+        >>> transform = ScaleValueTransform()
+        >>> value = torch.tensor([-2.0, 0.0, 2.0])
+        >>> transformed = transform(value)
+        >>> transformed
+        tensor([-4.,  0.,  4.])
+        >>> transform.inverse(transformed)
+        tensor([-2.,  0.,  2.])
+
+    .. seealso::
+        :class:`IdentityValueTransform`, :class:`SymLogValueTransform`,
+        :class:`SignedHyperbolicValueTransform`, and
+        :class:`ComposeValueTransform`.
     """
 
     @abstractmethod
@@ -150,8 +62,15 @@ class IdentityValueTransform(ValueTransform):
         >>> from torchrl.modules import IdentityValueTransform
         >>> transform = IdentityValueTransform()
         >>> value = torch.tensor([-1.0, 0.0, 1.0])
-        >>> torch.equal(transform(value), transform.inverse(value))
-        True
+        >>> transformed = transform(value)
+        >>> transformed
+        tensor([-1.,  0.,  1.])
+        >>> transform.inverse(transformed)
+        tensor([-1.,  0.,  1.])
+
+    .. seealso::
+        :class:`ValueTransform` for the interface and
+        :class:`ComposeValueTransform` for composing transforms.
     """
 
     def forward(self, value: torch.Tensor) -> torch.Tensor:
@@ -166,8 +85,9 @@ class IdentityValueTransform(ValueTransform):
 class SymLogValueTransform(ValueTransform):
     """Symmetric-log value transform used by DreamerV3.
 
-    This transform applies :func:`symlog` in the forward direction and
-    :func:`symexp` in the inverse direction.
+    This transform applies :func:`torchrl.modules.functional.symlog` in the
+    forward direction and :func:`torchrl.modules.functional.symexp` in the
+    inverse direction.
 
     Examples:
         >>> import torch
@@ -177,8 +97,14 @@ class SymLogValueTransform(ValueTransform):
         >>> transformed = transform(value)
         >>> transformed
         tensor([-4.6151,  0.0000,  4.6151])
-        >>> torch.allclose(transform.inverse(transformed), value)
-        True
+        >>> transform.inverse(transformed)
+        tensor([-100.0000,    0.0000,  100.0000])
+
+    .. seealso::
+        :func:`torchrl.modules.functional.symlog` and
+        :func:`torchrl.modules.functional.symexp` for the functional form,
+        and :class:`SignedHyperbolicValueTransform` for an alternative
+        nonlinear transform.
 
     .. note::
         See `Mastering Diverse Domains through World Models
@@ -186,12 +112,12 @@ class SymLogValueTransform(ValueTransform):
     """
 
     def forward(self, value: torch.Tensor) -> torch.Tensor:
-        """Apply :func:`symlog` to ``value``."""
-        return symlog(value)
+        """Apply :func:`torchrl.modules.functional.symlog` to ``value``."""
+        return F.symlog(value)
 
     def inverse(self, value: torch.Tensor) -> torch.Tensor:
-        """Apply :func:`symexp` to ``value``."""
-        return symexp(value)
+        """Apply :func:`torchrl.modules.functional.symexp` to ``value``."""
+        return F.symexp(value)
 
 
 class SignedHyperbolicValueTransform(ValueTransform):
@@ -209,8 +135,14 @@ class SignedHyperbolicValueTransform(ValueTransform):
         >>> transformed = transform(value)
         >>> transformed
         tensor([-9.1499,  0.0000,  9.1499])
-        >>> torch.allclose(transform.inverse(transformed), value, atol=1e-4)
-        True
+        >>> transform.inverse(transformed)
+        tensor([-100.0000,    0.0000,  100.0000])
+
+    .. seealso::
+        :func:`torchrl.modules.functional.signed_hyperbolic` and
+        :func:`torchrl.modules.functional.signed_parabolic` for the functional
+        form, and :class:`SymLogValueTransform` for an alternative nonlinear
+        transform.
 
     .. note::
         See `Observe and Look Further: Achieving Consistent Performance on
@@ -224,12 +156,12 @@ class SignedHyperbolicValueTransform(ValueTransform):
         self.epsilon = epsilon
 
     def forward(self, value: torch.Tensor) -> torch.Tensor:
-        """Apply :func:`signed_hyperbolic` to ``value``."""
-        return signed_hyperbolic(value, self.epsilon)
+        """Apply the signed-hyperbolic transform to ``value``."""
+        return F.signed_hyperbolic(value, self.epsilon)
 
     def inverse(self, value: torch.Tensor) -> torch.Tensor:
-        """Apply :func:`signed_parabolic` to ``value``."""
-        return signed_parabolic(value, self.epsilon)
+        """Apply the signed-parabolic inverse to ``value``."""
+        return F.signed_parabolic(value, self.epsilon)
 
 
 class ComposeValueTransform(ValueTransform):
@@ -255,8 +187,13 @@ class ComposeValueTransform(ValueTransform):
         >>> transformed = transform(value)
         >>> transformed
         tensor([-2.3175,  0.0000,  2.3175])
-        >>> torch.allclose(transform.inverse(transformed), value, atol=1e-4)
-        True
+        >>> transform.inverse(transformed)
+        tensor([-100.0000,    0.0000,  100.0000])
+
+    .. seealso::
+        :class:`ValueTransform` for the component interface,
+        :class:`SymLogValueTransform`, and
+        :class:`SignedHyperbolicValueTransform`.
     """
 
     def __init__(self, *transforms: ValueTransform) -> None:

--- a/torchrl/modules/value_transforms.py
+++ b/torchrl/modules/value_transforms.py
@@ -174,7 +174,10 @@ class SymLogValueTransform(ValueTransform):
         >>> from torchrl.modules import SymLogValueTransform
         >>> transform = SymLogValueTransform()
         >>> value = torch.tensor([-100.0, 0.0, 100.0])
-        >>> torch.allclose(transform.inverse(transform(value)), value)
+        >>> transformed = transform(value)
+        >>> transformed
+        tensor([-4.6151,  0.0000,  4.6151])
+        >>> torch.allclose(transform.inverse(transformed), value)
         True
 
     .. note::
@@ -203,7 +206,10 @@ class SignedHyperbolicValueTransform(ValueTransform):
         >>> from torchrl.modules import SignedHyperbolicValueTransform
         >>> transform = SignedHyperbolicValueTransform(epsilon=1e-3)
         >>> value = torch.tensor([-100.0, 0.0, 100.0])
-        >>> torch.allclose(transform.inverse(transform(value)), value, atol=1e-4)
+        >>> transformed = transform(value)
+        >>> transformed
+        tensor([-9.1499,  0.0000,  9.1499])
+        >>> torch.allclose(transform.inverse(transformed), value, atol=1e-4)
         True
 
     .. note::
@@ -246,7 +252,10 @@ class ComposeValueTransform(ValueTransform):
         ...     SignedHyperbolicValueTransform(), SymLogValueTransform()
         ... )
         >>> value = torch.tensor([-100.0, 0.0, 100.0])
-        >>> torch.allclose(transform.inverse(transform(value)), value, atol=1e-4)
+        >>> transformed = transform(value)
+        >>> transformed
+        tensor([-2.3175,  0.0000,  2.3175])
+        >>> torch.allclose(transform.inverse(transformed), value, atol=1e-4)
         True
     """
 

--- a/torchrl/modules/value_transforms.py
+++ b/torchrl/modules/value_transforms.py
@@ -1,0 +1,271 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Invertible transforms for scalar value targets and predictions."""
+from __future__ import annotations
+
+from abc import ABCMeta, abstractmethod
+
+import torch
+from torch import nn
+
+
+def symlog(value: torch.Tensor) -> torch.Tensor:
+    """Apply the element-wise symmetric logarithm transform.
+
+    The transform is defined as
+    ``sign(value) * log(1 + abs(value))`` and compresses both positive and
+    negative values while remaining approximately linear around zero.
+
+    Args:
+        value (torch.Tensor): Input tensor.
+
+    Returns:
+        A tensor with the same shape, dtype, and device as ``value``.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.modules import symlog
+        >>> symlog(torch.tensor([-100.0, 0.0, 100.0]))
+        tensor([-4.6151,  0.0000,  4.6151])
+    """
+    transformed = value.sign() * value.abs().log1p()
+    # ``sign`` has a zero derivative at the origin even though symlog has a
+    # derivative of one there. Keep the mathematically correct local gradient.
+    return torch.where(value == 0, value, transformed)
+
+
+def symexp(value: torch.Tensor) -> torch.Tensor:
+    """Apply the inverse symmetric exponential transform element-wise.
+
+    Args:
+        value (torch.Tensor): Input tensor in symmetric-log space.
+
+    Returns:
+        A tensor with the same shape, dtype, and device as ``value``.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.modules import symexp, symlog
+        >>> value = torch.tensor([-1000.0, 0.0, 1000.0])
+        >>> torch.allclose(symexp(symlog(value)), value, atol=1e-4)
+        True
+    """
+    transformed = value.sign() * value.abs().expm1()
+    return torch.where(value == 0, value, transformed)
+
+
+def signed_hyperbolic(value: torch.Tensor, epsilon: float = 1e-3) -> torch.Tensor:
+    """Apply the signed hyperbolic value transform.
+
+    This is the scale-compressing transform introduced by Pohlen et al. and
+    used by algorithms in the MuZero and Muesli families:
+
+    ``sign(value) * (sqrt(abs(value) + 1) - 1) + epsilon * value``.
+
+    Args:
+        value (torch.Tensor): Input tensor.
+        epsilon (float, optional): Positive linear correction that keeps the
+            inverse Lipschitz continuous. Defaults to ``1e-3``.
+
+    Returns:
+        A tensor with the same shape, dtype, and device as ``value``.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.modules import signed_hyperbolic
+        >>> signed_hyperbolic(torch.tensor([-100.0, 0.0, 100.0]))
+        tensor([-9.1499,  0.0000,  9.1499])
+
+    .. note::
+        See `Observe and Look Further: Achieving Consistent Performance on
+        Atari <https://arxiv.org/abs/1805.11593>`_ (Pohlen et al., 2018).
+    """
+    if epsilon <= 0:
+        raise ValueError(f"epsilon must be positive, got {epsilon}.")
+    transformed = value.sign() * (torch.sqrt(value.abs() + 1) - 1) + epsilon * value
+    origin = value * (0.5 + epsilon)
+    return torch.where(value == 0, origin, transformed)
+
+
+def signed_parabolic(value: torch.Tensor, epsilon: float = 1e-3) -> torch.Tensor:
+    """Apply the inverse of :func:`signed_hyperbolic` element-wise.
+
+    Args:
+        value (torch.Tensor): Input tensor in signed-hyperbolic space.
+        epsilon (float, optional): Positive linear correction used by the
+            corresponding :func:`signed_hyperbolic` call. Defaults to
+            ``1e-3``.
+
+    Returns:
+        A tensor with the same shape, dtype, and device as ``value``.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.modules import signed_hyperbolic, signed_parabolic
+        >>> value = torch.tensor([-1000.0, 0.0, 1000.0])
+        >>> torch.allclose(
+        ...     signed_parabolic(signed_hyperbolic(value)), value, atol=1e-3
+        ... )
+        True
+    """
+    if epsilon <= 0:
+        raise ValueError(f"epsilon must be positive, got {epsilon}.")
+    magnitude = value.abs()
+    discriminant = torch.sqrt(1 + 4 * epsilon * (magnitude + 1 + epsilon))
+    # This rationalized form of (discriminant - 1) / (2 * epsilon)
+    # avoids cancellation when epsilon is small.
+    root = 2 * (magnitude + 1 + epsilon) / (discriminant + 1)
+    transformed = value.sign() * (root.square() - 1)
+    origin = value / (0.5 + epsilon)
+    return torch.where(value == 0, origin, transformed)
+
+
+class ValueTransform(nn.Module, metaclass=ABCMeta):
+    """Abstract base class for invertible scalar value transforms.
+
+    A value transform maps raw rewards or returns to a numerically convenient
+    prediction space. :meth:`inverse` maps predictions back to the raw value
+    space before they are used for bootstrapping.
+
+    Subclasses implement :meth:`forward` and :meth:`inverse` as element-wise
+    tensor operations.
+    """
+
+    @abstractmethod
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        """Map a raw value tensor to the transformed prediction space."""
+
+    @abstractmethod
+    def inverse(self, value: torch.Tensor) -> torch.Tensor:
+        """Map a transformed value tensor back to raw value space."""
+
+
+class IdentityValueTransform(ValueTransform):
+    """Leave scalar values unchanged.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.modules import IdentityValueTransform
+        >>> transform = IdentityValueTransform()
+        >>> value = torch.tensor([-1.0, 0.0, 1.0])
+        >>> torch.equal(transform(value), transform.inverse(value))
+        True
+    """
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        """Return ``value`` unchanged."""
+        return value
+
+    def inverse(self, value: torch.Tensor) -> torch.Tensor:
+        """Return ``value`` unchanged."""
+        return value
+
+
+class SymLogValueTransform(ValueTransform):
+    """Symmetric-log value transform used by DreamerV3.
+
+    This transform applies :func:`symlog` in the forward direction and
+    :func:`symexp` in the inverse direction.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.modules import SymLogValueTransform
+        >>> transform = SymLogValueTransform()
+        >>> value = torch.tensor([-100.0, 0.0, 100.0])
+        >>> torch.allclose(transform.inverse(transform(value)), value)
+        True
+
+    .. note::
+        See `Mastering Diverse Domains through World Models
+        <https://arxiv.org/abs/2301.04104>`_ (Hafner et al., 2023).
+    """
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        """Apply :func:`symlog` to ``value``."""
+        return symlog(value)
+
+    def inverse(self, value: torch.Tensor) -> torch.Tensor:
+        """Apply :func:`symexp` to ``value``."""
+        return symexp(value)
+
+
+class SignedHyperbolicValueTransform(ValueTransform):
+    """Signed-hyperbolic transform for large-magnitude value targets.
+
+    Args:
+        epsilon (float, optional): Positive linear correction that keeps the
+            inverse Lipschitz continuous. Defaults to ``1e-3``.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.modules import SignedHyperbolicValueTransform
+        >>> transform = SignedHyperbolicValueTransform(epsilon=1e-3)
+        >>> value = torch.tensor([-100.0, 0.0, 100.0])
+        >>> torch.allclose(transform.inverse(transform(value)), value, atol=1e-4)
+        True
+
+    .. note::
+        See `Observe and Look Further: Achieving Consistent Performance on
+        Atari <https://arxiv.org/abs/1805.11593>`_ (Pohlen et al., 2018).
+    """
+
+    def __init__(self, epsilon: float = 1e-3) -> None:
+        super().__init__()
+        if epsilon <= 0:
+            raise ValueError(f"epsilon must be positive, got {epsilon}.")
+        self.epsilon = epsilon
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        """Apply :func:`signed_hyperbolic` to ``value``."""
+        return signed_hyperbolic(value, self.epsilon)
+
+    def inverse(self, value: torch.Tensor) -> torch.Tensor:
+        """Apply :func:`signed_parabolic` to ``value``."""
+        return signed_parabolic(value, self.epsilon)
+
+
+class ComposeValueTransform(ValueTransform):
+    """Compose value transforms while preserving the inverse mapping.
+
+    Forward transforms are applied in the order provided. Inverse transforms
+    are applied in reverse order.
+
+    Args:
+        *transforms (ValueTransform): Transforms to compose.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.modules import (
+        ...     ComposeValueTransform,
+        ...     SignedHyperbolicValueTransform,
+        ...     SymLogValueTransform,
+        ... )
+        >>> transform = ComposeValueTransform(
+        ...     SignedHyperbolicValueTransform(), SymLogValueTransform()
+        ... )
+        >>> value = torch.tensor([-100.0, 0.0, 100.0])
+        >>> torch.allclose(transform.inverse(transform(value)), value, atol=1e-4)
+        True
+    """
+
+    def __init__(self, *transforms: ValueTransform) -> None:
+        super().__init__()
+        if not transforms:
+            raise ValueError("ComposeValueTransform requires at least one transform.")
+        if not all(isinstance(transform, ValueTransform) for transform in transforms):
+            raise TypeError("All transforms must be ValueTransform instances.")
+        self.transforms = nn.ModuleList(transforms)
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        """Apply the component transforms in order."""
+        for transform in self.transforms:
+            value = transform(value)
+        return value
+
+    def inverse(self, value: torch.Tensor) -> torch.Tensor:
+        """Apply the component inverse transforms in reverse order."""
+        for transform in reversed(self.transforms):
+            value = transform.inverse(value)
+        return value

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -33,12 +33,11 @@ from torchrl.modules.models.model_based_v3 import (  # noqa: F401
     _default_bins,
     _DEFAULT_NUM_BINS,
     _unimix_probs,
-    symexp as _symexp,
-    symlog as symlog,
     two_hot_cross_entropy as two_hot_cross_entropy,
     two_hot_decode as _two_hot_decode,
     two_hot_encode as _two_hot_encode,
 )
+from torchrl.modules.value_transforms import symexp as _symexp, symlog as symlog
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _GAMMA_LMBDA_DEPREC_ERROR,

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -29,6 +29,7 @@ from tensordict.utils import NestedKey, unravel_key
 from torchrl._utils import _maybe_record_function_decorator
 from torchrl.envs.model_based.dreamer import DreamerEnv
 from torchrl.envs.utils import ExplorationType, set_exploration_type, step_mdp
+from torchrl.modules.functional import symexp as _symexp, symlog as symlog
 from torchrl.modules.models.model_based_v3 import (  # noqa: F401
     _default_bins,
     _DEFAULT_NUM_BINS,
@@ -37,7 +38,6 @@ from torchrl.modules.models.model_based_v3 import (  # noqa: F401
     two_hot_decode as _two_hot_decode,
     two_hot_encode as _two_hot_encode,
 )
-from torchrl.modules.value_transforms import symexp as _symexp, symlog as symlog
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _GAMMA_LMBDA_DEPREC_ERROR,


### PR DESCRIPTION
## Summary

- add a public `ValueTransform` module interface with identity, symmetric-log, signed-hyperbolic, and composable implementations
- add the stateless operations to `torchrl.modules.functional`, mirroring the `torch.nn.functional` pattern, while retaining convenient top-level aliases
- centralize DreamerV3's existing symlog helpers on the shared implementation while preserving existing objective imports
- document the actual transformed and reconstructed values in every example, with cross-links between functional and module forms
- cover numerical round trips, gradients at zero, validation, composition, `torch.compile`, and eager/compiled benchmarks

## Why

Value-learning algorithms often need an invertible compression of large reward and return scales. TorchRL already carried DreamerV3-specific symlog helpers, but they were not available as reusable modules, and the signed-hyperbolic transform used by Muesli/MuZero-style methods was missing.

This provides a small algorithm-independent API that can be used by future losses and value estimators without duplicating transform mathematics.

## User impact

Users can call stateless transforms through `torchrl.modules.functional`, select and compose value-space mappings as ordinary `nn.Module` instances, and apply the inverse before bootstrapping. Existing top-level and DreamerV3 imports continue to work.

## Validation

- `python -m pytest test/modules/test_value_transforms.py test/objectives/test_dreamer_v3.py --doctest-modules torchrl/modules/functional.py torchrl/modules/value_transforms.py -q` — 78 passed
- `python -m pytest benchmarks/test_objectives_benchmarks.py -k value_transform_speed --benchmark-only -q` — 4 passed
- targeted `ufmt`, `flake8`, `pydocstyle`, `codespell`, `autoflake`, Sphinx-section, and docstring-argument checks passed

The aggregate pre-commit bootstrap could not build its pinned `libcst==1.0.1` under Python 3.12 because no Rust compiler is installed; the applicable hooks were run directly from their existing environments.
