### PR TITLE
[Feature] Add joint sample-and-score distribution adapter

### DIFF
--- a/benchmarks/test_objectives_benchmarks.py
+++ b/benchmarks/test_objectives_benchmarks.py
@@ -28,6 +28,10 @@ from torchrl.modules import (
     SymLogValueTransform,
     TanhNormal,
 )
+from torchrl.modules.distributions.utils import (
+    ensure_rsample_and_log_prob,
+    rsample_and_log_prob,
+)
 from torchrl.objectives import (
     A2CLoss,
     ClipPPOLoss,
@@ -67,6 +71,26 @@ FULLGRAPH = version.parse(".".join(TORCH_VERSION.split(".")[:3])) >= version.par
 #     torch.set_default_device(device)
 #     yield
 #     torch.set_default_device(cur_device)
+
+
+@pytest.mark.parametrize("interface", ["function", "method"])
+def test_joint_sample_log_prob_interface(benchmark, interface):
+    dist = torch.distributions.Independent(
+        torch.distributions.Normal(torch.zeros(256, 4), torch.ones(256, 4)),
+        1,
+    )
+    if interface == "method":
+        dist = ensure_rsample_and_log_prob(dist)
+
+        def joint_sample():
+            return dist.rsample_and_log_prob()
+
+    else:
+
+        def joint_sample():
+            return rsample_and_log_prob(dist)
+
+    benchmark.pedantic(joint_sample, iterations=10, rounds=100)
 
 
 class setup_value_fn:

--- a/docs/source/reference/modules_distributions.rst
+++ b/docs/source/reference/modules_distributions.rst
@@ -22,6 +22,19 @@ Custom distribution classes for RL, extending PyTorch distributions.
 Sampling utilities
 ==================
 
+TorchRL distributions returned by probabilistic modules expose joint
+sample-and-score methods. This lets consumers score the exact draw without
+depending on a particular distribution class::
+
+    action, log_prob = dist.rsample_and_log_prob()
+
+The :func:`ensure_rsample_and_log_prob` adapter preserves object identity for
+distributions that already implement this method and transparently wraps other
+PyTorch or third-party distributions. Adapted distributions preserve
+``isinstance`` behavior and can be passed directly to
+:func:`torch.distributions.kl_divergence`. The free functions remain available
+for raw distributions.
+
 .. currentmodule:: torchrl.modules.distributions.utils
 
 .. autosummary::
@@ -30,4 +43,5 @@ Sampling utilities
 
     sample_and_log_prob
     rsample_and_log_prob
+    ensure_rsample_and_log_prob
     composite_entropy

--- a/test/modules/test_actor.py
+++ b/test/modules/test_actor.py
@@ -31,6 +31,7 @@ from torchrl.modules import (
     ProbabilisticActor,
     SafeModule,
     SafeProbabilisticModule,
+    SafeProbabilisticTensorDictSequential,
     TanhDelta,
     TanhModule,
     TanhNormal,
@@ -78,6 +79,37 @@ def test_probabilistic_module_tanhnormal_joint_log_prob(
     monkeypatch.setattr(TanhNormal, "log_prob", fail_log_prob)
     result = module(TensorDict({"loc": loc, "scale": scale}, batch_size=[1]))
 
+    torch.testing.assert_close(result["action"], expected_action)
+    torch.testing.assert_close(result["sample_log_prob"], expected_log_prob)
+
+
+def test_probabilistic_module_adapts_standard_distribution():
+    loc = torch.tensor([[0.2, -0.4]], requires_grad=True)
+    scale = torch.tensor([[0.7, 1.1]], requires_grad=True)
+    module = SafeProbabilisticModule(
+        in_keys=["loc", "scale"],
+        out_keys=["action"],
+        distribution_class=torch.distributions.Normal,
+        default_interaction_type=InteractionType.RANDOM,
+        return_log_prob=True,
+        log_prob_key="sample_log_prob",
+    )
+    sequence = SafeProbabilisticTensorDictSequential(module)
+    data = TensorDict({"loc": loc, "scale": scale}, batch_size=[1])
+
+    direct_dist = module.get_dist(data)
+    sequence_dist = sequence.get_dist(data)
+    rebuilt_dist = sequence.build_dist_from_params(data)
+    for adapted_dist in (direct_dist, sequence_dist, rebuilt_dist):
+        assert isinstance(adapted_dist, torch.distributions.Normal)
+        assert callable(adapted_dist.rsample_and_log_prob)
+        assert callable(adapted_dist.sample_and_log_prob)
+
+    torch.manual_seed(0)
+    expected_action = torch.distributions.Normal(loc, scale).rsample()
+    expected_log_prob = torch.distributions.Normal(loc, scale).log_prob(expected_action)
+    torch.manual_seed(0)
+    result = module(data.clone())
     torch.testing.assert_close(result["action"], expected_action)
     torch.testing.assert_close(result["sample_log_prob"], expected_log_prob)
 

--- a/test/objectives/test_cql.py
+++ b/test/objectives/test_cql.py
@@ -34,10 +34,24 @@ from torchrl.testing import (  # noqa
 )
 
 
+def _make_independent_normal(loc, scale):
+    return torch.distributions.Independent(
+        torch.distributions.Normal(loc, scale),
+        1,
+    )
+
+
 class TestCQL(LossModuleTestBase):
     seed = 0
 
-    def _create_mock_actor(self, batch=2, obs_dim=3, action_dim=4, device="cpu"):
+    def _create_mock_actor(
+        self,
+        batch=2,
+        obs_dim=3,
+        action_dim=4,
+        device="cpu",
+        distribution_class=TanhNormal,
+    ):
         # Actor
         action_spec = Bounded(
             -torch.ones(action_dim), torch.ones(action_dim), (action_dim,)
@@ -50,7 +64,7 @@ class TestCQL(LossModuleTestBase):
             module=module,
             in_keys=["loc", "scale"],
             spec=action_spec,
-            distribution_class=TanhNormal,
+            distribution_class=distribution_class,
         )
         return actor.to(device)
 
@@ -148,18 +162,30 @@ class TestCQL(LossModuleTestBase):
         )
         self.reset_parameters_recursive_test(loss_fn)
 
-    def test_cql_actor_uses_joint_sample_log_prob(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "distribution_class", [TanhNormal, _make_independent_normal]
+    )
+    def test_cql_actor_uses_joint_sample_log_prob(
+        self, distribution_class, monkeypatch
+    ):
         torch.manual_seed(self.seed)
         td = self._create_mock_data_cql()
+        actor = self._create_mock_actor(distribution_class=distribution_class)
         loss_fn = CQLLoss(
-            actor_network=self._create_mock_actor(),
+            actor_network=actor,
             qvalue_network=self._create_mock_qvalue(),
         )
 
-        def fail_log_prob(*args, **kwargs):
-            raise AssertionError("CQL inverse-scored a freshly sampled TanhNormal")
+        if distribution_class is TanhNormal:
 
-        monkeypatch.setattr(TanhNormal, "log_prob", fail_log_prob)
+            def fail_log_prob(*args, **kwargs):
+                raise AssertionError("CQL inverse-scored a freshly sampled TanhNormal")
+
+            monkeypatch.setattr(TanhNormal, "log_prob", fail_log_prob)
+        else:
+            dist = actor.get_dist(td)
+            assert isinstance(dist, torch.distributions.Independent)
+
         actor_loss, metadata = loss_fn.actor_loss(td)
         assert actor_loss.isfinite().all()
         assert metadata[loss_fn.tensor_keys.log_prob].isfinite().all()

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import math
+import pickle
 import sys
 import warnings
 from functools import partial
@@ -48,6 +49,7 @@ from torchrl.modules.distributions.discrete import (
 )
 from torchrl.modules.distributions.utils import (
     composite_entropy,
+    ensure_rsample_and_log_prob,
     rsample_and_log_prob,
     sample_and_log_prob,
 )
@@ -55,6 +57,80 @@ from torchrl.modules.distributions.utils import (
 from torchrl.testing import get_default_devices
 
 _has_scipy = importlib.util.find_spec("scipy", None) is not None
+
+
+class TestJointSampleLogProbAdapter:
+    def test_native_distribution_preserves_identity(self):
+        dist = TanhNormal(torch.zeros(2), torch.ones(2))
+
+        assert ensure_rsample_and_log_prob(dist) is dist
+
+    @pytest.mark.parametrize("compiled", [False, True])
+    def test_reparameterized_fallback_preserves_sample_and_gradients(self, compiled):
+        if compiled and sys.version_info >= (3, 14):
+            pytest.skip("torch.compile requires Python < 3.14")
+
+        actual_loc = torch.tensor([0.2, -0.4], requires_grad=True)
+        actual_scale = torch.tensor([0.7, 1.1], requires_grad=True)
+        expected_loc = actual_loc.detach().clone().requires_grad_()
+        expected_scale = actual_scale.detach().clone().requires_grad_()
+
+        def joint_sample(loc, scale):
+            dist = ensure_rsample_and_log_prob(torch.distributions.Normal(loc, scale))
+            return dist.rsample_and_log_prob((3,))
+
+        if compiled:
+            joint_sample = torch.compile(joint_sample, backend="eager", fullgraph=True)
+
+        torch.manual_seed(0)
+        sample, log_prob = joint_sample(actual_loc, actual_scale)
+        torch.manual_seed(0)
+        expected_dist = torch.distributions.Normal(expected_loc, expected_scale)
+        expected_sample = expected_dist.rsample((3,))
+        expected_log_prob = expected_dist.log_prob(expected_sample)
+
+        torch.testing.assert_close(sample, expected_sample)
+        torch.testing.assert_close(log_prob, expected_log_prob)
+        grads = torch.autograd.grad(log_prob.sum(), (actual_loc, actual_scale))
+        expected_grads = torch.autograd.grad(
+            expected_log_prob.sum(), (expected_loc, expected_scale)
+        )
+        for grad, expected_grad in zip(grads, expected_grads):
+            torch.testing.assert_close(grad, expected_grad)
+
+    def test_proxy_preserves_distribution_api_and_serialization(self):
+        base_dist = torch.distributions.Normal(torch.zeros(2), torch.ones(2))
+        dist = ensure_rsample_and_log_prob(base_dist)
+
+        assert dist is ensure_rsample_and_log_prob(dist)
+        assert dist is not base_dist
+        assert isinstance(dist, torch.distributions.Normal)
+        assert dist.loc is base_dist.loc
+        torch.testing.assert_close(dist.mean, base_dist.mean)
+        assert dist.expand((3, 2)).batch_shape == torch.Size([3, 2])
+
+        restored = pickle.loads(pickle.dumps(dist))
+        assert isinstance(restored, torch.distributions.Normal)
+        torch.testing.assert_close(restored.loc, base_dist.loc)
+        for p, q in (
+            (dist, restored),
+            (dist, base_dist),
+            (base_dist, restored),
+        ):
+            torch.testing.assert_close(
+                torch.distributions.kl_divergence(p, q),
+                torch.zeros(2),
+            )
+
+    def test_non_reparameterized_distribution_rejects_joint_rsample(self):
+        dist = ensure_rsample_and_log_prob(
+            torch.distributions.Categorical(logits=torch.zeros(3))
+        )
+
+        sample, log_prob = dist.sample_and_log_prob((4,))
+        torch.testing.assert_close(log_prob, dist.log_prob(sample))
+        with pytest.raises(NotImplementedError):
+            dist.rsample_and_log_prob()
 
 
 @pytest.mark.skipif(torch.__version__ < "2.0", reason="torch 2.0 is required")
@@ -237,9 +313,10 @@ class TestTanhNormal:
     @pytest.mark.parametrize(
         "reparameterize, sample_shape", [(False, ()), (True, (3,))]
     )
+    @pytest.mark.parametrize("interface", ["function", "method"])
     @pytest.mark.parametrize("device", get_default_devices())
     def test_composite_sample_and_log_prob(
-        self, reparameterize, sample_shape, monkeypatch, device
+        self, reparameterize, sample_shape, interface, monkeypatch, device
     ):
         loc = torch.tensor([[20.0], [-20.0]], device=device, requires_grad=True)
         scale = torch.full_like(loc, 0.1, requires_grad=True)
@@ -265,18 +342,28 @@ class TestTanhNormal:
             },
             extra_kwargs={"squashed": {"event_dims": 1}},
         )
+        adapted_dist = ensure_rsample_and_log_prob(dist)
+        assert adapted_dist is not dist
+        assert isinstance(adapted_dist, CompositeDistribution)
 
         def fail_log_prob(*args, **kwargs):
             raise AssertionError("a freshly sampled TanhNormal was inverse-scored")
 
         monkeypatch.setattr(TanhNormal, "log_prob", fail_log_prob)
         helper = rsample_and_log_prob if reparameterize else sample_and_log_prob
+
+        def joint_sample(aggregate):
+            with set_composite_lp_aggregate(aggregate):
+                if interface == "function":
+                    return helper(dist, sample_shape)
+                if reparameterize:
+                    return adapted_dist.rsample_and_log_prob(sample_shape)
+                return adapted_dist.sample_and_log_prob(sample_shape)
+
         torch.manual_seed(0)
-        with set_composite_lp_aggregate(False):
-            sample, component_log_prob = helper(dist, sample_shape)
+        sample, component_log_prob = joint_sample(False)
         torch.manual_seed(0)
-        with set_composite_lp_aggregate(True):
-            aggregate_sample, aggregate_log_prob = helper(dist, sample_shape)
+        aggregate_sample, aggregate_log_prob = joint_sample(True)
 
         expected_batch = torch.Size(sample_shape) + torch.Size([2])
         assert sample.batch_size == expected_batch

--- a/torchrl/modules/__init__.py
+++ b/torchrl/modules/__init__.py
@@ -9,6 +9,7 @@ from . import functional
 from .distributions import (
     Delta,
     distributions_maps,
+    ensure_rsample_and_log_prob,
     IndependentNormal,
     LLMMaskedCategorical,
     MaskedCategorical,
@@ -157,6 +158,7 @@ __all__ = [
     "DecisionTransformer",
     "DecisionTransformerInferenceWrapper",
     "Delta",
+    "ensure_rsample_and_log_prob",
     "DistributionalDQNnet",
     "DistributionalQValueActor",
     "DistributionalQValueHook",

--- a/torchrl/modules/distributions/__init__.py
+++ b/torchrl/modules/distributions/__init__.py
@@ -23,6 +23,7 @@ from .discrete import (
     Ordinal,
     ReparamGradientStrategy,
 )
+from .utils import ensure_rsample_and_log_prob
 
 distributions_maps = {
     str(dist).lower(): dist
@@ -70,4 +71,5 @@ __all__ = [
     "LLMMaskedCategorical",
     "Ordinal",
     "ReparamGradientStrategy",
+    "ensure_rsample_and_log_prob",
 ]

--- a/torchrl/modules/distributions/utils.py
+++ b/torchrl/modules/distributions/utils.py
@@ -11,11 +11,198 @@ from tensordict import is_tensor_collection, TensorDict, TensorDictBase
 from tensordict.nn import composite_lp_aggregate, CompositeDistribution
 from torch import autograd, distributions as d
 from torch.distributions import Independent, Transform, TransformedDistribution
+from torch.distributions.kl import register_kl
 
 try:
     from torch.compiler import is_dynamo_compiling
 except ImportError:
     from torch._dynamo import is_compiling as is_dynamo_compiling
+
+
+class _JointSampleLogProbWrapper(d.Distribution):
+    """Transparent proxy adding joint sample-and-score methods."""
+
+    def __init__(self, distribution: d.Distribution) -> None:
+        self.distribution = distribution
+        super().__init__(
+            batch_shape=distribution.batch_shape,
+            event_shape=getattr(distribution, "event_shape", torch.Size()),
+            validate_args=False,
+        )
+
+    @property
+    def __class__(self):
+        # Preserve isinstance-based checks against the wrapped distribution.
+        distribution = object.__getattribute__(self, "__dict__").get("distribution")
+        if distribution is None:
+            return _JointSampleLogProbWrapper
+        return distribution.__class__
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "distribution":
+            raise AttributeError(name)
+        distribution = object.__getattribute__(self, "__dict__").get("distribution")
+        if distribution is None:
+            raise AttributeError(name)
+        return getattr(distribution, name)
+
+    def __repr__(self) -> str:
+        return repr(self.distribution)
+
+    def __reduce__(self):
+        return type(self), (self.distribution,)
+
+    def __iter__(self):
+        return iter(self.distribution)
+
+    def __len__(self) -> int:
+        return len(self.distribution)
+
+    def __getitem__(self, item):
+        return self.distribution[item]
+
+    @property
+    def arg_constraints(self):
+        return self.distribution.arg_constraints
+
+    @property
+    def support(self):
+        return self.distribution.support
+
+    @property
+    def has_rsample(self) -> bool:
+        return self.distribution.has_rsample
+
+    @property
+    def has_enumerate_support(self) -> bool:
+        return self.distribution.has_enumerate_support
+
+    @property
+    def mean(self):
+        return self.distribution.mean
+
+    @property
+    def mode(self):
+        return self.distribution.mode
+
+    @property
+    def variance(self):
+        return self.distribution.variance
+
+    @property
+    def stddev(self):
+        return self.distribution.stddev
+
+    def sample(self, sample_shape: torch.Size | tuple[int, ...] = ()) -> Any:
+        return self.distribution.sample(torch.Size(sample_shape))
+
+    def rsample(self, sample_shape: torch.Size | tuple[int, ...] = ()) -> Any:
+        return self.distribution.rsample(torch.Size(sample_shape))
+
+    def sample_n(self, n: int) -> Any:
+        return self.distribution.sample_n(n)
+
+    def log_prob(self, value: Any, *values: Any) -> torch.Tensor | TensorDictBase:
+        if values:
+            return self.distribution.log_prob(value, *values)
+        if isinstance(value, torch.Tensor) or is_tensor_collection(value):
+            return self.distribution.log_prob(value)
+        return self.distribution.log_prob(*value)
+
+    def entropy(self) -> torch.Tensor | TensorDictBase:
+        return self.distribution.entropy()
+
+    def enumerate_support(self, expand: bool = True) -> Any:
+        return self.distribution.enumerate_support(expand=expand)
+
+    def cdf(self, value: Any) -> torch.Tensor:
+        return self.distribution.cdf(value)
+
+    def icdf(self, value: Any) -> torch.Tensor:
+        return self.distribution.icdf(value)
+
+    def perplexity(self) -> torch.Tensor:
+        return self.distribution.perplexity()
+
+    def expand(
+        self,
+        batch_shape: torch.Size | tuple[int, ...],
+        _instance: d.Distribution | None = None,
+    ) -> d.Distribution:
+        distribution = self.distribution.expand(batch_shape)
+        if _instance is None:
+            return ensure_rsample_and_log_prob(distribution)
+        if not isinstance(_instance, _JointSampleLogProbWrapper):
+            raise TypeError("_instance must be a joint sample-and-score adapter.")
+        _JointSampleLogProbWrapper.__init__(_instance, distribution)
+        return _instance
+
+    def sample_and_log_prob(
+        self, sample_shape: torch.Size | tuple[int, ...] = ()
+    ) -> tuple[Any, torch.Tensor | TensorDictBase]:
+        return sample_and_log_prob(self.distribution, sample_shape)
+
+    def rsample_and_log_prob(
+        self, sample_shape: torch.Size | tuple[int, ...] = ()
+    ) -> tuple[Any, torch.Tensor | TensorDictBase]:
+        return rsample_and_log_prob(self.distribution, sample_shape)
+
+
+@register_kl(_JointSampleLogProbWrapper, _JointSampleLogProbWrapper)
+def _kl_joint_sample_log_prob_wrappers(
+    p: _JointSampleLogProbWrapper,
+    q: _JointSampleLogProbWrapper,
+) -> torch.Tensor:
+    """Delegate KL dispatch to the concrete wrapped distribution types."""
+    return d.kl_divergence(p.distribution, q.distribution)
+
+
+@register_kl(_JointSampleLogProbWrapper, d.Distribution)
+def _kl_joint_sample_log_prob_wrapper_left(
+    p: _JointSampleLogProbWrapper,
+    q: d.Distribution,
+) -> torch.Tensor:
+    """Delegate KL dispatch when only the left distribution is adapted."""
+    return d.kl_divergence(p.distribution, q)
+
+
+@register_kl(d.Distribution, _JointSampleLogProbWrapper)
+def _kl_joint_sample_log_prob_wrapper_right(
+    p: d.Distribution,
+    q: _JointSampleLogProbWrapper,
+) -> torch.Tensor:
+    """Delegate KL dispatch when only the right distribution is adapted."""
+    return d.kl_divergence(p, q.distribution)
+
+
+def ensure_rsample_and_log_prob(distribution: d.Distribution) -> d.Distribution:
+    """Return a distribution exposing joint sample-and-score methods.
+
+    Distributions with a native ``rsample_and_log_prob`` method are returned
+    unchanged. All others are wrapped in a transparent proxy whose joint
+    methods delegate to :func:`sample_and_log_prob` and
+    :func:`rsample_and_log_prob`.
+
+    Args:
+        distribution (Distribution): distribution to adapt.
+
+    Returns:
+        The original distribution when it already implements atomic
+        reparameterized sampling, or an adapted distribution otherwise.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.modules.distributions.utils import ensure_rsample_and_log_prob
+        >>> dist = ensure_rsample_and_log_prob(
+        ...     torch.distributions.Normal(torch.zeros(2), torch.ones(2))
+        ... )
+        >>> sample, log_prob = dist.rsample_and_log_prob()
+        >>> sample.shape == log_prob.shape
+        True
+    """
+    if callable(getattr(distribution, "rsample_and_log_prob", None)):
+        return distribution
+    return _JointSampleLogProbWrapper(distribution)
 
 
 def sample_and_log_prob(

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -25,6 +25,7 @@ from torch.distributions import Categorical
 from torchrl._utils import _replace_last
 from torchrl.data.tensor_specs import Composite, TensorSpec
 from torchrl.data.utils import _process_action_space_spec
+from torchrl.modules.distributions.utils import ensure_rsample_and_log_prob
 from torchrl.modules.tensordict_module.common import DistributionalDQNnet, SafeModule
 from torchrl.modules.tensordict_module.probabilistic import (
     SafeProbabilisticModule,
@@ -140,7 +141,7 @@ class Actor(SafeModule):
         td_out = self(tensordict)
         action = td_out.get(self.out_keys[0])
 
-        return Delta(action)
+        return ensure_rsample_and_log_prob(Delta(action))
 
 
 class ProbabilisticActor(SafeProbabilisticTensorDictSequential):

--- a/torchrl/modules/tensordict_module/probabilistic.py
+++ b/torchrl/modules/tensordict_module/probabilistic.py
@@ -28,7 +28,7 @@ from tensordict.utils import NestedKey
 
 from torchrl.data.tensor_specs import Composite, TensorSpec
 from torchrl.modules.distributions import Delta
-from torchrl.modules.distributions.utils import sample_and_log_prob
+from torchrl.modules.distributions.utils import ensure_rsample_and_log_prob
 from torchrl.modules.tensordict_module.common import _forward_hook_safe_action
 from torchrl.modules.tensordict_module.sequence import SafeSequential
 
@@ -283,6 +283,16 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule):
                 )
             self.register_forward_hook(_forward_hook_safe_action)
 
+    def get_dist(self, tensordict: TensorDictBase) -> torch.distributions.Distribution:
+        """Build a distribution with TorchRL's joint sample-and-score contract."""
+        return ensure_rsample_and_log_prob(super().get_dist(tensordict))
+
+    def build_dist_from_params(
+        self, tensordict: TensorDictBase
+    ) -> torch.distributions.Distribution:
+        """Build an adapted distribution from precomputed parameters."""
+        return self.get_dist(tensordict)
+
     @dispatch(auto_batch_size=False)
     @set_skip_existing_none()
     def forward(
@@ -321,9 +331,10 @@ class SafeProbabilisticModule(ProbabilisticTensorDictModule):
                 )
             aggregate_context = set_composite_lp_aggregate(False)
         with use_generator(generator), aggregate_context:
-            sample, log_prob = sample_and_log_prob(
-                dist, sample_shape, reparameterize=dist.has_rsample
-            )
+            if dist.has_rsample:
+                sample, log_prob = dist.rsample_and_log_prob(sample_shape)
+            else:
+                sample, log_prob = dist.sample_and_log_prob(sample_shape)
         if writeback is not None:
             writeback(generator)
         if self.num_samples is not None:
@@ -422,3 +433,20 @@ class SafeProbabilisticTensorDictSequential(
         super(ProbabilisticTensorDictSequential, self).__init__(
             *modules, partial_tolerant=partial_tolerant
         )
+
+    def get_dist(
+        self,
+        tensordict: TensorDictBase,
+        tensordict_out: TensorDictBase | None = None,
+        **kwargs,
+    ) -> torch.distributions.Distribution:
+        """Return the sequence distribution with joint sampling methods."""
+        return ensure_rsample_and_log_prob(
+            super().get_dist(tensordict, tensordict_out, **kwargs)
+        )
+
+    def build_dist_from_params(
+        self, tensordict: TensorDictBase
+    ) -> torch.distributions.Distribution:
+        """Build an adapted distribution from precomputed parameters."""
+        return ensure_rsample_and_log_prob(super().build_dist_from_params(tensordict))

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -26,7 +26,7 @@ from tensordict.utils import NestedKey
 from torch import distributions as d
 
 from torchrl.modules.distributions import HAS_ENTROPY
-from torchrl.modules.distributions.utils import rsample_and_log_prob
+from torchrl.modules.distributions.utils import ensure_rsample_and_log_prob
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
@@ -413,10 +413,11 @@ class A2CLoss(LossModule):
 
     @set_composite_lp_aggregate(False)
     def get_entropy_bonus(self, dist: d.Distribution) -> torch.Tensor:
-        if HAS_ENTROPY.get(type(dist), False):
+        dist = ensure_rsample_and_log_prob(dist)
+        if HAS_ENTROPY.get(dist.__class__, False):
             entropy = dist.entropy()
         else:
-            _, log_prob = rsample_and_log_prob(dist, (self.samples_mc_entropy,))
+            _, log_prob = dist.rsample_and_log_prob((self.samples_mc_entropy,))
             if is_tensor_collection(log_prob):
                 log_prob = log_prob.sum(dim="feature", reduce=True)
             entropy = -log_prob.mean(0)

--- a/torchrl/objectives/cql.py
+++ b/torchrl/objectives/cql.py
@@ -20,7 +20,7 @@ from torch import Tensor
 from torchrl.data.tensor_specs import Composite
 from torchrl.data.utils import _find_action_space
 from torchrl.envs.utils import ExplorationType, set_exploration_type
-from torchrl.modules.distributions.utils import rsample_and_log_prob
+from torchrl.modules.distributions.utils import ensure_rsample_and_log_prob
 from torchrl.modules.tensordict_module.actors import QValueActor
 from torchrl.modules.tensordict_module.common import ensure_tensordict_compatible
 from torchrl.objectives.common import LossModule
@@ -592,7 +592,8 @@ class CQLLoss(LossModule):
             dist = self.actor_network.get_dist(
                 tensordict,
             )
-            a_reparm, log_prob = rsample_and_log_prob(dist)
+            dist = ensure_rsample_and_log_prob(dist)
+            a_reparm, log_prob = dist.rsample_and_log_prob()
         bc_log_prob = dist.log_prob(tensordict.get(self.tensor_keys.action))
 
         bc_actor_loss = self._alpha * log_prob - bc_log_prob
@@ -616,7 +617,8 @@ class CQLLoss(LossModule):
             dist = self.actor_network.get_dist(
                 tensordict,
             )
-            a_reparm, log_prob = rsample_and_log_prob(dist)
+            dist = ensure_rsample_and_log_prob(dist)
+            a_reparm, log_prob = dist.rsample_and_log_prob()
 
         td_q = tensordict.select(*self.qvalue_network.in_keys, strict=False)
         if td_q is tensordict:
@@ -664,7 +666,8 @@ class CQLLoss(LossModule):
             self.actor_network, preserve_module_state=False
         ):
             dist = self.actor_network.get_dist(tensordict)
-            action, sample_log_prob = rsample_and_log_prob(dist)
+            dist = ensure_rsample_and_log_prob(dist)
+            action, sample_log_prob = dist.rsample_and_log_prob()
             tensordict.set(self.tensor_keys.action, action)
 
         return (
@@ -684,7 +687,8 @@ class CQLLoss(LossModule):
         with set_exploration_type(ExplorationType.RANDOM):
             next_tensordict = tensordict.get("next").clone(False)
             next_dist = self.actor_network.get_dist(next_tensordict)
-            next_action, next_sample_log_prob = rsample_and_log_prob(next_dist)
+            next_dist = ensure_rsample_and_log_prob(next_dist)
+            next_action, next_sample_log_prob = next_dist.rsample_and_log_prob()
             next_tensordict.set(self.tensor_keys.action, next_action)
         actor_data.to_module(
             self.actor_network, return_swap=False, preserve_module_state=False

--- a/torchrl/objectives/crossq.py
+++ b/torchrl/objectives/crossq.py
@@ -17,10 +17,7 @@ from torch import Tensor
 
 from torchrl.data.tensor_specs import Composite
 from torchrl.envs.utils import ExplorationType, set_exploration_type
-from torchrl.modules.distributions.utils import (
-    rsample_and_log_prob,
-    sample_and_log_prob,
-)
+from torchrl.modules.distributions.utils import ensure_rsample_and_log_prob
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
@@ -608,7 +605,8 @@ class CrossQLoss(LossModule):
             self.actor_network, preserve_module_state=False
         ):
             dist = self.actor_network.get_dist(tensordict)
-            a_reparm, log_prob = rsample_and_log_prob(dist)
+            dist = ensure_rsample_and_log_prob(dist)
+            a_reparm, log_prob = dist.rsample_and_log_prob()
 
         td_q = tensordict.select(*self.qvalue_network.in_keys, strict=False)
         self.qvalue_network.eval()
@@ -654,7 +652,8 @@ class CrossQLoss(LossModule):
             ):
                 next_tensordict = tensordict.get("next").clone(False)
                 next_dist = self.actor_network.get_dist(next_tensordict)
-                next_action, next_sample_log_prob = sample_and_log_prob(next_dist)
+                next_dist = ensure_rsample_and_log_prob(next_dist)
+                next_action, next_sample_log_prob = next_dist.sample_and_log_prob()
                 next_tensordict.set(self.tensor_keys.action, next_action)
 
         combined = torch.cat(

--- a/torchrl/objectives/decision_transformer.py
+++ b/torchrl/objectives/decision_transformer.py
@@ -14,7 +14,7 @@ from tensordict.nn import dispatch, ProbabilisticTensorDictSequential, TensorDic
 from tensordict.utils import NestedKey
 from torch import distributions as d
 
-from torchrl.modules.distributions.utils import rsample_and_log_prob
+from torchrl.modules.distributions.utils import ensure_rsample_and_log_prob
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import distance_loss
 
@@ -225,7 +225,8 @@ class OnlineDTLoss(LossModule):
         self._out_keys = values
 
     def get_entropy_bonus(self, dist: d.Distribution) -> torch.Tensor:
-        _, log_p = rsample_and_log_prob(dist, (self.samples_mc_entropy,))
+        dist = ensure_rsample_and_log_prob(dist)
+        _, log_p = dist.rsample_and_log_prob((self.samples_mc_entropy,))
         # log_p: (batch_size, context_len)
         return -log_p.mean(axis=0)
 

--- a/torchrl/objectives/llm/grpo.py
+++ b/torchrl/objectives/llm/grpo.py
@@ -37,7 +37,10 @@ from torch import distributions as d
 from torchrl._utils import logger as torchrl_logger, VERBOSE
 from torchrl.envs.transforms.ray_service import _maybe_clear_device, _maybe_to_device
 from torchrl.envs.transforms.transforms import Transform
-from torchrl.modules.distributions.utils import composite_entropy, sample_and_log_prob
+from torchrl.modules.distributions.utils import (
+    composite_entropy,
+    ensure_rsample_and_log_prob,
+)
 from torchrl.modules.llm import LLMWrapperBase
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import _sum_td_features, _validate_clip_epsilon
@@ -810,6 +813,7 @@ class GRPOLoss(LossModule):
     def _get_entropy(
         self, dist: d.Distribution, adv_shape: torch.Size
     ) -> torch.Tensor | TensorDict:
+        dist = ensure_rsample_and_log_prob(dist)
         try:
             entropy = (
                 composite_entropy(dist, self.samples_mc_entropy)
@@ -826,16 +830,15 @@ class GRPOLoss(LossModule):
         except NotImplementedError:
             if VERBOSE:
                 torchrl_logger.warning(
-                    f"Entropy not implemented for {type(dist)} or is not finite. Using Monte Carlo sampling."
+                    f"Entropy not implemented for {dist.__class__} or is not finite. Using Monte Carlo sampling."
                 )
             with set_composite_lp_aggregate(False) if isinstance(
                 dist, CompositeDistribution
             ) else contextlib.nullcontext():
-                _, log_prob = sample_and_log_prob(
-                    dist,
-                    (self.samples_mc_entropy,),
-                    reparameterize=getattr(dist, "has_rsample", False),
-                )
+                if dist.has_rsample:
+                    _, log_prob = dist.rsample_and_log_prob((self.samples_mc_entropy,))
+                else:
+                    _, log_prob = dist.sample_and_log_prob((self.samples_mc_entropy,))
                 if is_tensor_collection(log_prob):
                     if isinstance(self.tensor_keys.sample_log_prob, NestedKey):
                         log_prob = log_prob.get(self.tensor_keys.sample_log_prob)

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -29,7 +29,10 @@ from tensordict.utils import NestedKey
 from torch import distributions as d
 
 from torchrl._utils import _standardize, logger as torchrl_logger, VERBOSE
-from torchrl.modules.distributions.utils import composite_entropy, sample_and_log_prob
+from torchrl.modules.distributions.utils import (
+    composite_entropy,
+    ensure_rsample_and_log_prob,
+)
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
@@ -662,6 +665,7 @@ class PPOLoss(LossModule):
     def _get_entropy(
         self, dist: d.Distribution, adv_shape: torch.Size
     ) -> torch.Tensor | TensorDict:
+        dist = ensure_rsample_and_log_prob(dist)
         try:
             entropy = (
                 composite_entropy(dist, self.samples_mc_entropy)
@@ -678,18 +682,17 @@ class PPOLoss(LossModule):
         except NotImplementedError:
             if VERBOSE:
                 torchrl_logger.warning(
-                    f"Entropy not implemented for {type(dist)} or is not finite. Using Monte Carlo sampling."
+                    f"Entropy not implemented for {dist.__class__} or is not finite. Using Monte Carlo sampling."
                 )
             with (
                 set_composite_lp_aggregate(False)
                 if isinstance(dist, CompositeDistribution)
                 else contextlib.nullcontext()
             ):
-                _, log_prob = sample_and_log_prob(
-                    dist,
-                    (self.samples_mc_entropy,),
-                    reparameterize=getattr(dist, "has_rsample", False),
-                )
+                if dist.has_rsample:
+                    _, log_prob = dist.rsample_and_log_prob((self.samples_mc_entropy,))
+                else:
+                    _, log_prob = dist.sample_and_log_prob((self.samples_mc_entropy,))
                 if is_tensor_collection(log_prob):
                     if isinstance(self.tensor_keys.sample_log_prob, NestedKey):
                         log_prob = log_prob.get(self.tensor_keys.sample_log_prob)
@@ -1706,6 +1709,7 @@ class KLPENPPOLoss(PPOLoss):
                 "The parameters of the distribution were not found. "
                 f"Make sure they are provided to {type(self).__name__}."
             ) from err
+        previous_dist = ensure_rsample_and_log_prob(previous_dist)
         advantage = tensordict_copy.get(self.tensor_keys.advantage, None)
         if advantage is None:
             self.value_estimator(
@@ -1741,17 +1745,21 @@ class KLPENPPOLoss(PPOLoss):
             else contextlib.nullcontext()
         ):
             current_dist = self.actor_network.get_dist(tensordict_copy)
+        current_dist = ensure_rsample_and_log_prob(current_dist)
         is_composite = isinstance(current_dist, CompositeDistribution)
         try:
-            kl = torch.distributions.kl.kl_divergence(previous_dist, current_dist)
+            kl = torch.distributions.kl.kl_divergence(
+                previous_dist,
+                current_dist,
+            )
         except NotImplementedError:
             with (
                 set_composite_lp_aggregate(False)
                 if is_composite
                 else contextlib.nullcontext()
             ):
-                x, previous_log_prob = sample_and_log_prob(
-                    previous_dist, (self.samples_mc_kl,)
+                x, previous_log_prob = previous_dist.sample_and_log_prob(
+                    (self.samples_mc_kl,)
                 )
                 current_log_prob = current_dist.log_prob(x)
             if is_tensor_collection(previous_log_prob):

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -17,7 +17,7 @@ from torch import Tensor
 
 from torchrl.data.tensor_specs import Composite
 from torchrl.envs.utils import ExplorationType, set_exploration_type, step_mdp
-from torchrl.modules.distributions.utils import rsample_and_log_prob
+from torchrl.modules.distributions.utils import ensure_rsample_and_log_prob
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
@@ -526,7 +526,8 @@ class REDQLoss(LossModule):
             sample_key = self.tensor_keys.action
             sample_key_lp = self.tensor_keys.sample_log_prob
             tensordict_actor_dist = self.actor_network.build_dist_from_params(td_params)
-            sample, sample_log_prob = rsample_and_log_prob(tensordict_actor_dist)
+            tensordict_actor_dist = ensure_rsample_and_log_prob(tensordict_actor_dist)
+            sample, sample_log_prob = tensordict_actor_dist.rsample_and_log_prob()
             tensordict_actor.set(sample_key, sample)
             tensordict_actor.set(sample_key_lp, sample_log_prob)
 

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -26,7 +26,7 @@ from torch import Tensor
 from torchrl.data.tensor_specs import Composite, TensorSpec
 from torchrl.data.utils import _find_action_space
 from torchrl.envs.utils import ExplorationType, set_exploration_type
-from torchrl.modules.distributions.utils import rsample_and_log_prob
+from torchrl.modules.distributions.utils import ensure_rsample_and_log_prob
 from torchrl.modules.tensordict_module.actors import ActorCriticWrapper
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
@@ -53,7 +53,7 @@ def compute_rsample_log_prob(
 ) -> tuple[torch.Tensor | TensorDictBase, torch.Tensor]:
     """Draw and score an action, aggregating composite log-probabilities."""
     with set_composite_lp_aggregate(True):
-        return rsample_and_log_prob(action_dist)
+        return ensure_rsample_and_log_prob(action_dist).rsample_and_log_prob()
 
 
 class SACLoss(LossModule):

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -31,7 +31,7 @@ from torch import Tensor
 
 from torchrl._utils import logger, rl_warnings
 from torchrl.envs.utils import step_mdp
-from torchrl.modules.distributions.utils import sample_and_log_prob
+from torchrl.modules.distributions.utils import ensure_rsample_and_log_prob
 from torchrl.objectives.utils import (
     _maybe_get_or_select,
     _pseudo_vmap,
@@ -93,13 +93,15 @@ def _call_actor_net(
     log_prob_key: NestedKey,
 ):
     dist = actor_net.get_dist(data.select(*actor_net.in_keys, strict=False))
+    dist = ensure_rsample_and_log_prob(dist)
     current_interaction = interaction_type() or actor_net.default_interaction_type
     if current_interaction is InteractionType.RANDOM:
         sample_shape = actor_net.num_samples or torch.Size()
         with set_composite_lp_aggregate(True):
-            _, log_prob = sample_and_log_prob(
-                dist, sample_shape, reparameterize=dist.has_rsample
-            )
+            if dist.has_rsample:
+                _, log_prob = dist.rsample_and_log_prob(sample_shape)
+            else:
+                _, log_prob = dist.sample_and_log_prob(sample_shape)
         return log_prob
 
     s = actor_net._dist_sample(dist, interaction_type=current_interaction)


### PR DESCRIPTION
## Summary

- add `ensure_rsample_and_log_prob()` as an identity-preserving capability adapter
- expose `sample_and_log_prob()` and `rsample_and_log_prob()` on arbitrary PyTorch and third-party distributions through a lightweight proxy
- preserve concrete `isinstance` behavior and transparent `torch.distributions.kl_divergence` dispatch
- adapt distributions at TorchRL probabilistic-module and objective boundaries, allowing consumers to use the method contract without concrete-distribution branches or unwrapping
- document the method-oriented API and preserve the existing free-function fallback
- cover native identity, wrapped gradients, `torch.compile`, serialization, KL dispatch, composites, non-reparameterizable distributions, actor/objective integration, and sampling overhead

## Motivation

#4080 introduced atomic sample-and-score operations for `TanhNormal` and generic free-function fallbacks. Distribution-consuming modules are modular, however, and cannot assume which concrete distribution they will receive. This follow-up establishes a uniform internal method contract:

```python
action, log_prob = dist.rsample_and_log_prob()
```

Distributions that already provide the method retain object identity. Other distributions are adapted without modifying PyTorch classes or maintaining TorchRL copies of the `torch.distributions` namespace.

## Compatibility

The proxy delegates ordinary distribution behavior, including sampling, scoring, entropy, support, statistics, expansion, enumeration, mapping behavior for composite distributions, and distribution-specific attributes. Concrete `isinstance` checks remain transparent, including `CompositeDistribution` branches. PyTorch KL dispatch is registered for adapted/adapted and mixed adapted/raw pairs, so consumers do not need an unwrap API.

Structured `CompositeDistribution` samples continue to use the centralized component aggregation in the existing free functions. Distributions with `has_rsample=False` expose `sample_and_log_prob()` and continue to reject reparameterized sampling.

## Validation

- 2,023 passed across distribution, actor, CQL, A2C, PPO, and Reinforce suites
- direct non-skipped `KLPENPPOLoss` standard and composite executions passed
- adapter KL tests cover adapted/adapted, adapted/raw, and raw/adapted pairs
- GRPO dependency-free unit passed; transformer-backed cases require the optional `transformers` dependency unavailable locally
- sampling microbenchmark: adapted method 19.5 us mean; free function 20.0 us mean in the local run
- pinned `ufmt`, `flake8`, `pydocstyle`, and `git diff --check` passed
