### PR TITLE
[BugFix] Let PR authors request reviewers

### DIFF
--- a/.github/torchrlbot/README.md
+++ b/.github/torchrlbot/README.md
@@ -67,6 +67,8 @@ Rebase the PR branch onto a target branch (default: `main`).
 
 **Requirements:**
 - The commenter must have **write** (or higher) permission on the repository.
+- The PR branch must be in this repository. The workflow token is scoped to
+  `pytorch/rl` and cannot push rebased commits to a contributor's fork.
 
 #### `reviewer`
 
@@ -86,7 +88,8 @@ Reviewers can be space- or comma-separated, with or without a leading `@`.
 ```
 
 **Requirements:**
-- The commenter must have **write** (or higher) permission on the repository.
+- The commenter must be the **PR author** or have **write** (or higher)
+  permission on the repository.
 - Requested reviewers must be collaborators on the repository.
 - The PR author is skipped automatically (GitHub does not allow self-review).
 
@@ -100,9 +103,22 @@ Display the help message with all available commands.
 
 ## Permissions
 
-All commands require the commenter to have **write** access to the repository.
-This prevents external contributors from triggering merges or rebases. The bot
-checks permissions via the GitHub API before executing any action.
+The `merge` and `rebase` commands require the commenter to have **write** access
+to the repository. The `reviewer` command can also be run by the PR author, so
+external contributors can request a review on their own PR without being able to
+modify other contributors' PRs. The bot checks permissions via the GitHub API
+before executing any action.
+
+The workflow grants only the permissions used by its commands:
+
+- `contents: write` for same-repository rebases, branch deletion, and merges.
+- `pull-requests: write` for PR metadata, merges, and review requests.
+- `issues: write` for command acknowledgements and status comments.
+
+The token belongs to the GitHub Actions app and is scoped to `pytorch/rl`; it
+does not impersonate the commenter. Consequently, it cannot rebase fork branches,
+and `merge --force` can only bypass repository rules that explicitly allow the
+GitHub Actions app to bypass them.
 
 ## Architecture
 
@@ -122,8 +138,9 @@ The workflow:
 2. **Filter**: The job only runs if the comment is on a PR and contains `@torchrlbot`.
 3. **Parse**: `torchrlbot.py` reads the GitHub event payload, extracts the command
    line from the comment, and parses it with `argparse`.
-4. **Validate**: The bot checks that the commenter has write permission and that
-   the PR meets any required conditions (e.g., approval status for merge).
+4. **Validate**: The bot checks that the commenter is authorized for the command
+   and that the PR meets any required conditions (e.g., approval status for
+   merge).
 5. **Execute**: The appropriate handler runs (`ghstack land`, `gh pr merge`,
    `git rebase`, etc.) and posts status comments back on the PR.
 

--- a/.github/torchrlbot/test_torchrlbot.py
+++ b/.github/torchrlbot/test_torchrlbot.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).parents[2]
+_BOT_PATH = _REPO_ROOT / ".github" / "torchrlbot" / "torchrlbot.py"
+
+
+def _load_torchrlbot():
+    spec = importlib.util.spec_from_file_location("torchrlbot", _BOT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+torchrlbot = _load_torchrlbot()
+
+
+def _context(*, comment_author: str, pr_author: str = "contributor", **pr_info):
+    return torchrlbot.CommandContext(
+        repo="pytorch/rl",
+        pr_number=123,
+        comment_id=456,
+        comment_author=comment_author,
+        pr_info={"author": {"login": pr_author}, **pr_info},
+    )
+
+
+def test_pr_author_can_request_review(monkeypatch):
+    gh_calls = []
+    comments = []
+    ctx = _context(comment_author="Contributor", pr_author="contributor")
+
+    def unexpected_permission_check(*_args):
+        raise AssertionError("PR authors should not need repository write access")
+
+    monkeypatch.setattr(
+        torchrlbot, "check_write_permission", unexpected_permission_check
+    )
+    monkeypatch.setattr(
+        torchrlbot, "gh", lambda *args, **kwargs: gh_calls.append((args, kwargs))
+    )
+    monkeypatch.setattr(
+        torchrlbot,
+        "post_comment",
+        lambda *args: comments.append(args),
+    )
+
+    torchrlbot.cmd_reviewer(ctx, argparse.Namespace(reviewers=["maintainer"]))
+
+    assert gh_calls == [
+        (
+            (
+                "api",
+                "repos/pytorch/rl/pulls/123/requested_reviewers",
+                "--method",
+                "POST",
+                "--input",
+                "-",
+            ),
+            {"input": json.dumps({"reviewers": ["maintainer"]})},
+        )
+    ]
+    assert comments[-1][-1] == (
+        "Requested review from @maintainer (requested by @Contributor)."
+    )
+
+
+def test_write_collaborator_can_request_review(monkeypatch):
+    gh_calls = []
+    ctx = _context(comment_author="maintainer")
+
+    monkeypatch.setattr(torchrlbot, "check_write_permission", lambda *_args: True)
+    monkeypatch.setattr(
+        torchrlbot, "gh", lambda *args, **kwargs: gh_calls.append((args, kwargs))
+    )
+    monkeypatch.setattr(torchrlbot, "post_comment", lambda *_args: None)
+
+    torchrlbot.cmd_reviewer(ctx, argparse.Namespace(reviewers=["reviewer"]))
+
+    assert len(gh_calls) == 1
+
+
+def test_pr_author_is_not_requested_case_insensitively(monkeypatch):
+    gh_calls = []
+    comments = []
+    ctx = _context(comment_author="maintainer", pr_author="Contributor")
+
+    monkeypatch.setattr(torchrlbot, "check_write_permission", lambda *_args: True)
+    monkeypatch.setattr(
+        torchrlbot, "gh", lambda *args, **kwargs: gh_calls.append((args, kwargs))
+    )
+    monkeypatch.setattr(
+        torchrlbot,
+        "post_comment",
+        lambda *args: comments.append(args),
+    )
+
+    torchrlbot.cmd_reviewer(
+        ctx,
+        argparse.Namespace(reviewers=["contributor", "reviewer"]),
+    )
+
+    assert json.loads(gh_calls[0][1]["input"]) == {"reviewers": ["reviewer"]}
+    assert "skipped @Contributor" in comments[-1][-1]
+
+
+def test_unrelated_contributor_cannot_request_review(monkeypatch):
+    gh_calls = []
+    comments = []
+    ctx = _context(comment_author="unrelated-user")
+
+    monkeypatch.setattr(torchrlbot, "check_write_permission", lambda *_args: False)
+    monkeypatch.setattr(
+        torchrlbot, "gh", lambda *args, **kwargs: gh_calls.append((args, kwargs))
+    )
+    monkeypatch.setattr(
+        torchrlbot,
+        "post_comment",
+        lambda *args: comments.append(args),
+    )
+
+    torchrlbot.cmd_reviewer(ctx, argparse.Namespace(reviewers=["maintainer"]))
+
+    assert not gh_calls
+    assert "Only the PR author or collaborators with write access" in comments[-1][-1]
+
+
+def test_rebase_rejects_fork_before_running_git(monkeypatch):
+    comments = []
+    ctx = _context(
+        comment_author="maintainer",
+        headRefName="topic",
+        isCrossRepository=True,
+        headRepository={"nameWithOwner": "contributor/rl"},
+    )
+
+    monkeypatch.setattr(torchrlbot, "check_write_permission", lambda *_args: True)
+    monkeypatch.setattr(
+        torchrlbot,
+        "git",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("fork rebases must not invoke git")
+        ),
+    )
+    monkeypatch.setattr(
+        torchrlbot,
+        "post_comment",
+        lambda *args: comments.append(args),
+    )
+
+    torchrlbot.cmd_rebase(ctx, argparse.Namespace(branch="main"))
+
+    assert "cannot push to forks" in comments[-1][-1]
+    assert "contributor/rl:topic" in comments[-1][-1]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/.github/torchrlbot/torchrlbot.py
+++ b/.github/torchrlbot/torchrlbot.py
@@ -76,7 +76,8 @@ def get_pr_info(repo: str, pr_number: int) -> dict:
         "--repo",
         repo,
         "--json",
-        "headRefName,baseRefName,author,title,url,labels,mergeable,reviewDecision",
+        "headRefName,baseRefName,headRepository,isCrossRepository,author,title,"
+        "url,labels,mergeable,reviewDecision",
     )
     return json.loads(result.stdout)
 
@@ -234,6 +235,18 @@ def cmd_rebase(ctx: CommandContext, args: argparse.Namespace) -> None:
         )
         return
 
+    if pr.get("isCrossRepository"):
+        head_repo = (pr.get("headRepository") or {}).get("nameWithOwner", "the fork")
+        post_comment(
+            ctx.repo,
+            ctx.pr_number,
+            f"@{ctx.comment_author} TorchRLBot cannot rebase `{head_repo}:{head}` "
+            "because its GitHub Actions token is scoped to this repository and "
+            "cannot push to forks. Rebase the branch locally and force-push it "
+            "from an account with access to the fork.",
+        )
+        return
+
     post_comment(
         ctx.repo,
         ctx.pr_number,
@@ -282,22 +295,33 @@ def normalize_reviewers(tokens: list[str]) -> list[str]:
 
 def cmd_reviewer(ctx: CommandContext, args: argparse.Namespace) -> None:
     """Handle ``@torchrlbot reviewer``."""
+    pr_author = ctx.pr_info.get("author", {}).get("login")
+    is_pr_author = (
+        pr_author is not None and pr_author.casefold() == ctx.comment_author.casefold()
+    )
+
     # Permission gate
-    if not check_write_permission(ctx.repo, ctx.comment_author):
+    if not is_pr_author and not check_write_permission(ctx.repo, ctx.comment_author):
         post_comment(
             ctx.repo,
             ctx.pr_number,
             f"@{ctx.comment_author} you don't have write permission on this repository. "
-            "Only collaborators with write access can request reviewers.",
+            "Only the PR author or collaborators with write access can request "
+            "reviewers.",
         )
         return
 
     reviewers = normalize_reviewers(args.reviewers)
 
-    pr_author = ctx.pr_info.get("author", {}).get("login")
-    skipped_author = pr_author in reviewers
+    skipped_author = pr_author is not None and any(
+        reviewer.casefold() == pr_author.casefold() for reviewer in reviewers
+    )
     if skipped_author:
-        reviewers = [r for r in reviewers if r != pr_author]
+        reviewers = [
+            reviewer
+            for reviewer in reviewers
+            if reviewer.casefold() != pr_author.casefold()
+        ]
 
     if not reviewers:
         post_comment(
@@ -314,13 +338,13 @@ def cmd_reviewer(ctx: CommandContext, args: argparse.Namespace) -> None:
 
     try:
         gh(
-            "pr",
-            "edit",
-            str(ctx.pr_number),
-            "--repo",
-            ctx.repo,
-            "--add-reviewer",
-            ",".join(reviewers),
+            "api",
+            f"repos/{ctx.repo}/pulls/{ctx.pr_number}/requested_reviewers",
+            "--method",
+            "POST",
+            "--input",
+            "-",
+            input=json.dumps({"reviewers": reviewers}),
         )
         mentions = ", ".join(f"@{r}" for r in reviewers)
         note = (
@@ -385,6 +409,9 @@ Rebase the PR branch onto a target branch.
 |------|-------------|
 | `-b`, `--branch` | Target branch (default: `main`) |
 
+Only branches in this repository can be rebased; the workflow token cannot push
+to contributor forks.
+
 ### `reviewer`
 Request reviews from one or more repository collaborators.
 
@@ -394,6 +421,7 @@ Request reviews from one or more repository collaborators.
 
 Reviewers can be space- or comma-separated, with or without a leading `@`.
 The PR author is skipped automatically.
+The command can be run by the PR author or a collaborator with write access.
 
 ### `help`
 Show this help message.

--- a/.github/workflows/torchrlbot.yml
+++ b/.github/workflows/torchrlbot.yml
@@ -23,8 +23,11 @@ jobs:
       contains(github.event.comment.body, '@torchrlbot')
     runs-on: ubuntu-latest
     permissions:
+      # Rebase/push same-repository branches, delete branches, and merge PRs.
       contents: write
+      # Read PR metadata, request reviewers, and merge PRs.
       pull-requests: write
+      # React to commands and post status comments on PR conversations.
       issues: write
     steps:
       - name: Checkout repository
@@ -39,8 +42,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install ghstack
-        run: pip install ghstack
+      - name: Install dependencies
+        run: pip install ghstack pytest
+
+      - name: Test TorchRLBot
+        run: python -m pytest .github/torchrlbot/test_torchrlbot.py -q
 
       - name: Configure git
         run: |


### PR DESCRIPTION
## Summary

- allow external contributors to request reviews on PRs they authored while keeping unrelated users blocked
- call GitHub's dedicated review-request REST endpoint, which matches the workflow's existing `pull-requests: write` permission
- detect fork PRs before attempting a rebase and explain that the repository-scoped workflow token cannot push to the fork
- document the workflow permission mapping and add focused authorization tests that run before TorchRLBot executes

## Root cause

The reviewer command reused the write-access gate intended for branch-mutating commands. GitHub permits PR authors to request reviews, but TorchRLBot rejected them before reaching the review-request API.

## Permission audit

The workflow already grants the permissions needed for normal same-repository operations:

- `contents: write` for rebases, branch deletion, and merges
- `pull-requests: write` for PR metadata, merges, and review requests
- `issues: write` for reactions and status comments

The earlier rebase failure on #3459 was caused by a merge conflict rather than missing credentials. Fork rebases remain intentionally unsupported because `GITHUB_TOKEN` is scoped to `pytorch/rl`; the bot now reports that limitation before invoking Git. Force-merge bypass also depends on repository rules explicitly allowing the GitHub Actions app to bypass them.

## Validation

- `uv run --no-project --with pytest python -m pytest .github/torchrlbot/test_torchrlbot.py -q`
- `uv run --no-project --with pytest python .github/torchrlbot/test_torchrlbot.py -q`
- repository pre-commit hooks for all changed files
