### PR TITLE
[Feature] Wire value transforms into actor-critic losses

### DIFF
--- a/benchmarks/test_objectives_benchmarks.py
+++ b/benchmarks/test_objectives_benchmarks.py
@@ -7,7 +7,6 @@ import argparse
 import pytest
 import torch
 from packaging import version
-
 from tensordict import TensorDict
 from tensordict.nn import (
     composite_lp_aggregate,
@@ -59,6 +58,16 @@ TORCH_VERSION = torch.__version__
 FULLGRAPH = version.parse(".".join(TORCH_VERSION.split(".")[:3])) >= version.parse(
     "2.5.0"
 )  # Anything from 2.5, incl. nightlies, allows for fullgraph
+
+
+class _TransformedValueModule(torch.nn.Module):
+    def __init__(self, module, value_transform):
+        super().__init__()
+        self.module = module
+        self.value_transform = value_transform
+
+    def forward(self, *inputs):
+        return self.value_transform(self.module(*inputs))
 
 
 # @pytest.fixture(scope="module", autouse=True)
@@ -297,8 +306,17 @@ def test_dqn_speed(
 
 @pytest.mark.parametrize("backward", [None, "backward"])
 @pytest.mark.parametrize("compile", [False, True, "reduce-overhead"])
+@pytest.mark.parametrize("value_transform_cls", [None, SymLogValueTransform])
 def test_ddpg_speed(
-    benchmark, backward, compile, n_obs=8, n_act=4, ncells=128, batch=128, n_hidden=64
+    benchmark,
+    backward,
+    compile,
+    value_transform_cls,
+    n_obs=8,
+    n_act=4,
+    ncells=128,
+    batch=128,
+    n_hidden=64,
 ):
     if compile == "reduce-overhead" and backward is not None:
         pytest.skip("reduce-overhead with backward causes segfaults in CI")
@@ -326,6 +344,9 @@ def test_ddpg_speed(
         out_features=1,
         device=device,
     )
+    value_transform = value_transform_cls() if value_transform_cls is not None else None
+    if value_transform is not None:
+        value = _TransformedValueModule(value, value_transform)
     batch = [batch]
     td = TensorDict(
         {
@@ -347,7 +368,7 @@ def test_ddpg_speed(
     value = Mod(value, in_keys=["hidden", "action"], out_keys=["state_action_value"])
     value(actor(td))
 
-    loss = DDPGLoss(actor, value)
+    loss = DDPGLoss(actor, value, value_transform=value_transform)
 
     loss(td)
 
@@ -375,8 +396,17 @@ def test_ddpg_speed(
 
 @pytest.mark.parametrize("backward", [None, "backward"])
 @pytest.mark.parametrize("compile", [False, True, "reduce-overhead"])
+@pytest.mark.parametrize("value_transform_cls", [None, SymLogValueTransform])
 def test_sac_speed(
-    benchmark, backward, compile, n_obs=8, n_act=4, ncells=128, batch=128, n_hidden=64
+    benchmark,
+    backward,
+    compile,
+    value_transform_cls,
+    n_obs=8,
+    n_act=4,
+    ncells=128,
+    batch=128,
+    n_hidden=64,
 ):
     if compile == "reduce-overhead" and backward is not None:
         pytest.skip("reduce-overhead with backward causes segfaults in CI")
@@ -404,6 +434,9 @@ def test_sac_speed(
         out_features=1,
         device=device,
     )
+    value_transform = value_transform_cls() if value_transform_cls is not None else None
+    if value_transform is not None:
+        value = _TransformedValueModule(value, value_transform)
     batch = [batch]
     td = TensorDict(
         {
@@ -437,7 +470,12 @@ def test_sac_speed(
     value = Seq(common, value_head)
     value(actor(td.clone()))
 
-    loss = SACLoss(actor, value, action_spec=Unbounded(shape=(n_act,)))
+    loss = SACLoss(
+        actor,
+        value,
+        action_spec=Unbounded(shape=(n_act,)),
+        value_transform=value_transform,
+    )
 
     loss(td)
 
@@ -758,8 +796,17 @@ def test_redq_deprec_speed(
 
 @pytest.mark.parametrize("backward", [None, "backward"])
 @pytest.mark.parametrize("compile", [False, True, "reduce-overhead"])
+@pytest.mark.parametrize("value_transform_cls", [None, SymLogValueTransform])
 def test_td3_speed(
-    benchmark, backward, compile, n_obs=8, n_act=4, ncells=128, batch=128, n_hidden=64
+    benchmark,
+    backward,
+    compile,
+    value_transform_cls,
+    n_obs=8,
+    n_act=4,
+    ncells=128,
+    batch=128,
+    n_hidden=64,
 ):
     if compile == "reduce-overhead" and backward is not None:
         pytest.skip("reduce-overhead with backward causes segfaults in CI")
@@ -787,6 +834,9 @@ def test_td3_speed(
         out_features=1,
         device=device,
     )
+    value_transform = value_transform_cls() if value_transform_cls is not None else None
+    if value_transform is not None:
+        value = _TransformedValueModule(value, value_transform)
     batch = [batch]
     td = TensorDict(
         {
@@ -826,6 +876,7 @@ def test_td3_speed(
         actor,
         value,
         action_spec=Bounded(shape=(n_act,), low=-1, high=1),
+        value_transform=value_transform,
     )
 
     loss(td)
@@ -1053,10 +1104,12 @@ def test_a2c_speed(
 
 @pytest.mark.parametrize("backward", [None, "backward"])
 @pytest.mark.parametrize("compile", [False, True, "reduce-overhead"])
+@pytest.mark.parametrize("value_transform_cls", [None, SymLogValueTransform])
 def test_ppo_speed(
     benchmark,
     backward,
     compile,
+    value_transform_cls,
     n_obs=8,
     n_act=4,
     n_hidden=64,
@@ -1090,6 +1143,9 @@ def test_ppo_speed(
         out_features=1,
         device=device,
     )
+    value_transform = value_transform_cls() if value_transform_cls is not None else None
+    if value_transform is not None:
+        value_net = torch.nn.Sequential(value_net, value_transform)
     batch = [batch, T]
     if composite_lp_aggregate():
         raise RuntimeError(
@@ -1127,13 +1183,18 @@ def test_ppo_speed(
     actor(td.clone())
     critic(td.clone())
 
-    loss = ClipPPOLoss(actor_network=actor, critic_network=critic)
+    loss = ClipPPOLoss(
+        actor_network=actor,
+        critic_network=critic,
+        value_transform=value_transform,
+    )
     advantage = GAE(
         value_network=critic,
         gamma=0.99,
         lmbda=0.95,
         shifted=True,
         device=device,
+        value_transform=value_transform,
     )
     advantage(td)
     loss(td)

--- a/docs/source/reference/modules.rst
+++ b/docs/source/reference/modules.rst
@@ -53,6 +53,7 @@ Documentation Sections
    modules_actors
    modules_exploration
    modules_critics
+   value_transforms
    modules_rnn
    modules_mcts
    modules_models

--- a/docs/source/reference/value_transforms.rst
+++ b/docs/source/reference/value_transforms.rst
@@ -235,8 +235,12 @@ Target critics emit transformed predictions just like online critics. Target
 minima and SAC entropy subtraction happen after inversion. Replay priorities
 keep each objective's historical convention (squared for DDPG, TD3, and SAC
 v1; absolute for SAC v2), but measure the residual between the transformed
-prediction and transformed target. Values intended for monitoring are
-converted back to raw units so reward-scale dashboards remain interpretable.
+prediction and transformed target. Pass ``priority_function`` to these losses
+to override that convention with a callable accepting the prediction and target
+in transformed space and returning a per-element priority, for example
+``priority_function=lambda prediction, target: (prediction - target).abs()``.
+Values intended for monitoring are converted back to raw units so reward-scale
+dashboards remain interpretable.
 
 Hydra
 -----

--- a/docs/source/reference/value_transforms.rst
+++ b/docs/source/reference/value_transforms.rst
@@ -1,0 +1,285 @@
+.. _value_transforms:
+
+Value transforms in actor-critic objectives
+===========================================
+
+Value transforms compress large signed returns into a better-conditioned
+critic prediction space without changing the units used by the reinforcement
+learning algorithm. If ``h`` is the transform, the critic predicts
+``y = h(V)``. A one-step target is assembled as
+
+.. math::
+
+   z = r + \gamma (1 - d) h^{-1}(y_{next}),
+
+and critic regression compares ``y`` with ``h(z)``. The inverse is therefore
+applied *before* minima, entropy terms, Bellman arithmetic, return estimation,
+advantage estimation, and actor objectives. The completed target is transformed
+once, immediately before critic regression.
+
+Space contract
+--------------
+
+.. list-table:: TensorDict and diagnostic spaces
+   :header-rows: 1
+
+   * - Value
+     - Space
+   * - ``state_value`` and ``state_action_value``
+     - Transformed critic prediction space
+   * - ``reward``, ``advantage``, and ``value_target``
+     - Raw reward-return space
+   * - Explicit estimator ``next_value=``
+     - Raw value space
+   * - PPO ``clip_value``
+     - Raw value units
+   * - ``pred_value``, ``target_value``, and ``next_state_value`` diagnostics
+     - Raw value space
+   * - Replay ``td_error``
+     - Existing absolute or squared convention, using the transformed residual
+
+:class:`~torchrl.modules.ValueOperator` deliberately does not apply a value
+transform. Its wrapped module must emit transformed predictions. The loss owns
+the :class:`~torchrl.modules.ValueTransform` and passes the exact same object to
+lazy value estimators. A prebuilt estimator must also hold that same object;
+using an equivalent but distinct transform raises an error so the two sides
+cannot silently diverge.
+
+DDPG and TD3
+------------
+
+The following critic emits symlog predictions. Both DDPG and TD3 invert those
+predictions for the actor objective and target bootstrap, then transform the
+finished Bellman target for regression.
+
+.. code-block:: python
+
+    import torch
+    from tensordict import TensorDict
+    from torch import nn
+    from torchrl.data import Bounded
+    from torchrl.modules import Actor, SymLogValueTransform, ValueOperator
+    from torchrl.objectives import DDPGLoss, TD3Loss
+
+    obs_dim, action_dim = 3, 2
+    action_spec = Bounded(-torch.ones(action_dim), torch.ones(action_dim))
+
+    def make_actor():
+        return Actor(nn.Linear(obs_dim, action_dim), spec=action_spec)
+
+    class TransformedQ(nn.Module):
+        def __init__(self, transform):
+            super().__init__()
+            self.linear = nn.Linear(obs_dim + action_dim, 1)
+            self.transform = transform
+
+        def forward(self, observation, action):
+            raw_q = self.linear(torch.cat((observation, action), -1))
+            return self.transform(raw_q)
+
+    ddpg_transform = SymLogValueTransform()
+    ddpg_q = ValueOperator(
+        TransformedQ(ddpg_transform),
+        in_keys=["observation", "action"],
+    )
+    ddpg_loss = DDPGLoss(
+        make_actor(), ddpg_q, value_transform=ddpg_transform
+    )
+
+    td3_transform = SymLogValueTransform()
+    td3_q = ValueOperator(
+        TransformedQ(td3_transform),
+        in_keys=["observation", "action"],
+    )
+    td3_loss = TD3Loss(
+        make_actor(),
+        td3_q,
+        action_spec=action_spec,
+        value_transform=td3_transform,
+    )
+
+    replay_sample = TensorDict(
+        {
+            "observation": torch.randn(8, obs_dim),
+            "action": action_spec.rand((8,)),
+            "next": {
+                "observation": torch.randn(8, obs_dim),
+                "reward": torch.randn(8, 1) * 100.0,
+                "done": torch.zeros(8, 1, dtype=torch.bool),
+                "terminated": torch.zeros(8, 1, dtype=torch.bool),
+            },
+        },
+        [8],
+    )
+    ddpg_output = ddpg_loss(replay_sample.clone())
+    td3_output = td3_loss(replay_sample.clone())
+
+Continuous SAC v1 and v2
+------------------------
+
+For SAC, ``Q - alpha * log_prob`` is computed in raw units. SAC v1 requires
+both its Q and V networks to emit predictions in the same transform space; SAC
+v2 only needs the transformed Q critic.
+
+.. code-block:: python
+
+    from tensordict.nn import NormalParamExtractor, TensorDictModule
+    from torchrl.modules import ProbabilisticActor, TanhNormal
+    from torchrl.objectives import SACLoss
+
+    def make_stochastic_actor():
+        policy_module = TensorDictModule(
+            nn.Sequential(
+                nn.Linear(obs_dim, 2 * action_dim),
+                NormalParamExtractor(),
+            ),
+            in_keys=["observation"],
+            out_keys=["loc", "scale"],
+        )
+        return ProbabilisticActor(
+            policy_module,
+            in_keys=["loc", "scale"],
+            out_keys=["action"],
+            distribution_class=TanhNormal,
+            spec=action_spec,
+            return_log_prob=True,
+        )
+
+    sac_transform = SymLogValueTransform()
+    sac_q = ValueOperator(
+        TransformedQ(sac_transform),
+        in_keys=["observation", "action"],
+    )
+    sac_v = ValueOperator(
+        nn.Sequential(nn.Linear(obs_dim, 1), sac_transform),
+        in_keys=["observation"],
+    )
+    sac_v1_loss = SACLoss(
+        make_stochastic_actor(),
+        sac_q,
+        sac_v,
+        value_transform=sac_transform,
+    )
+
+    sac_v2_transform = SymLogValueTransform()
+    sac_v2_q = ValueOperator(
+        TransformedQ(sac_v2_transform),
+        in_keys=["observation", "action"],
+    )
+    sac_v2_loss = SACLoss(
+        make_stochastic_actor(),
+        sac_v2_q,
+        value_transform=sac_v2_transform,
+    )
+    sac_v1_output = sac_v1_loss(replay_sample.clone())
+    sac_v2_output = sac_v2_loss(replay_sample.clone())
+
+PPO, ClipPPO, and KLPENPPO
+--------------------------
+
+PPO rollout values remain transformed in ``state_value``. GAE inverts them to
+produce raw ``advantage`` and ``value_target`` entries. Pass the same transform
+object to GAE and the PPO loss. Value clipping is performed around the old and
+current *raw* predictions; only the clipped candidate is transformed for the
+critic loss.
+
+.. code-block:: python
+
+    from torchrl.objectives import ClipPPOLoss
+    from torchrl.objectives.value import GAE
+
+    ppo_transform = SymLogValueTransform()
+    critic = ValueOperator(
+        nn.Sequential(nn.Linear(obs_dim, 1), ppo_transform),
+        in_keys=["observation"],
+    )
+    gae = GAE(
+        gamma=0.99,
+        lmbda=0.95,
+        value_network=critic,
+        value_transform=ppo_transform,
+    )
+    ppo_actor = make_stochastic_actor()
+    ppo_loss = ClipPPOLoss(
+        ppo_actor,
+        critic,
+        clip_value=0.2,  # raw return units
+        value_transform=ppo_transform,
+    )
+
+    rollout = TensorDict(
+        {
+            "observation": torch.randn(2, 8, obs_dim),
+            "next": {
+                "observation": torch.randn(2, 8, obs_dim),
+                "reward": torch.randn(2, 8, 1) * 100.0,
+                "done": torch.zeros(2, 8, 1, dtype=torch.bool),
+                "terminated": torch.zeros(2, 8, 1, dtype=torch.bool),
+            },
+        },
+        [2, 8],
+        names=[None, "time"],
+    )
+    with torch.no_grad():
+        ppo_actor(rollout)
+    gae(rollout)
+    losses = ppo_loss(rollout)
+
+The same setup applies to :class:`~torchrl.objectives.PPOLoss` and
+:class:`~torchrl.objectives.KLPENPPOLoss`.
+
+Target networks, priorities, and logging
+----------------------------------------
+
+Target critics emit transformed predictions just like online critics. Target
+minima and SAC entropy subtraction happen after inversion. Replay priorities
+keep each objective's historical convention (squared for DDPG, TD3, and SAC
+v1; absolute for SAC v2), but measure the residual between the transformed
+prediction and transformed target. Values intended for monitoring are
+converted back to raw units so reward-scale dashboards remain interpretable.
+
+Hydra
+-----
+
+All supported loss and GAE configs accept nested ``_target_`` transforms. For
+example:
+
+.. code-block:: yaml
+
+    loss_module:
+      _target_: torchrl.trainers.algorithms.configs.objectives._make_ppo_loss
+      actor_network: ${actor}
+      critic_network: ${critic}
+      loss_type: clip
+      clip_value: 0.2
+      value_transform:
+        _target_: torchrl.modules.SymLogValueTransform
+
+    value:
+      _target_: torchrl.objectives.value.GAE
+      gamma: 0.99
+      lmbda: 0.95
+      value_network: ${critic}
+      value_transform: ${loss_module.value_transform}
+
+Unsupported combinations
+------------------------
+
+Value transforms are currently supported for DDPG, TD3, continuous SAC v1/v2,
+PPO, ClipPPO, KLPENPPO, TD(0), TD(1), TD(lambda), GAE, MultiAgentGAE, and
+V-trace. They are not scalar wrappers for distributional, categorical, or
+two-hot critics, and are not supported by Discrete SAC. Do not combine a value
+transform with MAPPO/IPPO :class:`~torchrl.modules.ValueNorm` or PopArt: those
+mechanisms each define a different prediction-space normalization, and TorchRL
+rejects configuring both at once.
+
+Passing ``None`` selects the existing identity path without adding tensor
+operations. A transformed path performs the inverse only when a prediction is
+consumed and applies one forward transform to each completed regression target.
+
+.. seealso::
+    :class:`~torchrl.modules.ValueTransform`,
+    :class:`~torchrl.modules.SymLogValueTransform`,
+    :class:`~torchrl.modules.SignedHyperbolicValueTransform`,
+    :class:`~torchrl.modules.ValueOperator`, and
+    :class:`~torchrl.objectives.value.ValueEstimatorBase`.

--- a/test/compile/test_compile_value.py
+++ b/test/compile/test_compile_value.py
@@ -3,16 +3,18 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Tests for torch.compile compatibility of value estimation functions."""
+
 from __future__ import annotations
 
 import sys
 
 import pytest
 import torch
+from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 from torch import nn
+from torchrl.modules.value_transforms import SymLogValueTransform
 from torchrl.objectives.value.advantages import TDLambdaEstimator
-
 from torchrl.objectives.value.functional import (
     generalized_advantage_estimate,
     td_lambda_return_estimate,
@@ -245,6 +247,36 @@ class TestTDLambdaEstimatorCompile:
 
         assert estimator.vectorized is True
         assert estimator._vectorized is True
+
+    def test_value_transform_compiles_fullgraph(self):
+        transform = SymLogValueTransform()
+        estimator = TDLambdaEstimator(
+            gamma=0.99,
+            lmbda=0.95,
+            value_network=None,
+            value_transform=transform,
+            vectorized=False,
+        )
+        raw_value = torch.linspace(-100.0, 100.0, 16).reshape(2, 8, 1)
+        raw_next_value = raw_value.flip(1)
+        tensordict = TensorDict(
+            {
+                "state_value": transform(raw_value),
+                "next": {
+                    "state_value": transform(raw_next_value),
+                    "reward": torch.randn(2, 8, 1),
+                    "done": torch.zeros(2, 8, 1, dtype=torch.bool),
+                    "terminated": torch.zeros(2, 8, 1, dtype=torch.bool),
+                },
+            },
+            [2, 8],
+        )
+
+        expected = estimator(tensordict.clone())
+        compiled = torch.compile(estimator, backend="eager", fullgraph=True)
+        result = compiled(tensordict.clone())
+        torch.testing.assert_close(result["advantage"], expected["advantage"])
+        torch.testing.assert_close(result["value_target"], expected["value_target"])
 
     def test_vectorized_property_returns_false_in_eager_mode_when_set_false(self):
         """Test that TDLambdaEstimator.vectorized returns False in eager mode when set to False."""

--- a/test/objectives/test_ddpg.py
+++ b/test/objectives/test_ddpg.py
@@ -50,6 +50,10 @@ from torchrl.testing import (  # noqa
 )
 
 
+def _absolute_priority(prediction, target):
+    return (prediction - target).abs()
+
+
 @pytest.mark.skipif(
     not _has_functorch, reason=f"functorch not installed: {FUNCTORCH_ERR}"
 )
@@ -284,7 +288,10 @@ class TestDDPG(LossModuleTestBase):
     @pytest.mark.parametrize(
         "transform_cls", [SymLogValueTransform, SignedHyperbolicValueTransform]
     )
-    def test_ddpg_value_transform_raw_objective_and_diagnostics(self, transform_cls):
+    @pytest.mark.parametrize("priority_function", [None, _absolute_priority])
+    def test_ddpg_value_transform_raw_objective_and_diagnostics(
+        self, transform_cls, priority_function
+    ):
         transform = transform_cls()
         torch.manual_seed(self.seed)
         raw_actor = self._create_mock_actor()
@@ -302,6 +309,7 @@ class TestDDPG(LossModuleTestBase):
             transformed_value,
             loss_function="l2",
             value_transform=transform,
+            priority_function=priority_function,
         )
         raw_out = raw_loss(td.clone())
         transformed_td = td.clone()
@@ -317,10 +325,14 @@ class TestDDPG(LossModuleTestBase):
             atol=1e-4,
             rtol=1e-4,
         )
+        transformed_residual = transform(transformed_out["pred_value"]) - transform(
+            transformed_out["target_value"]
+        )
         expected_priority = (
-            transform(transformed_out["pred_value"])
-            - transform(transformed_out["target_value"])
-        ).pow(2)
+            transformed_residual.pow(2)
+            if priority_function is None
+            else transformed_residual.abs()
+        )
         torch.testing.assert_close(transformed_td["td_error"], expected_priority)
         (transformed_out["loss_actor"] + transformed_out["loss_value"]).backward()
         assert all(
@@ -1116,7 +1128,10 @@ class TestTD3(LossModuleTestBase):
     @pytest.mark.parametrize(
         "transform_cls", [SymLogValueTransform, SignedHyperbolicValueTransform]
     )
-    def test_td3_value_transform_raw_objective_and_diagnostics(self, transform_cls):
+    @pytest.mark.parametrize("priority_function", [None, _absolute_priority])
+    def test_td3_value_transform_raw_objective_and_diagnostics(
+        self, transform_cls, priority_function
+    ):
         transform = transform_cls()
         torch.manual_seed(self.seed)
         raw_actor = self._create_mock_actor()
@@ -1144,6 +1159,7 @@ class TestTD3(LossModuleTestBase):
             policy_noise=0.0,
             loss_function="l2",
             value_transform=transform,
+            priority_function=priority_function,
         )
         raw_out = raw_loss(td.clone())
         transformed_td = td.clone()
@@ -1159,10 +1175,14 @@ class TestTD3(LossModuleTestBase):
             torch.testing.assert_close(
                 transformed_out[key], raw_out[key], atol=1e-4, rtol=1e-4, msg=key
             )
+        transformed_residual = transform(transformed_out["pred_value"]) - transform(
+            transformed_out["target_value"]
+        )
         expected_priority = (
-            transform(transformed_out["pred_value"])
-            - transform(transformed_out["target_value"])
-        ).pow(2)
+            transformed_residual.pow(2)
+            if priority_function is None
+            else transformed_residual.abs()
+        )
         torch.testing.assert_close(
             transformed_td["td_error"], expected_priority.max(0).values
         )

--- a/test/objectives/test_ddpg.py
+++ b/test/objectives/test_ddpg.py
@@ -18,7 +18,6 @@ from _objectives_common import (
     LossModuleTestBase,
 )
 from packaging import version as pkg_version
-
 from tensordict import assert_allclose_td, TensorDict
 from tensordict.nn import (
     NormalParamExtractor,
@@ -28,16 +27,20 @@ from tensordict.nn import (
     TensorDictSequential as Seq,
 )
 from torch import nn
-
 from torchrl._utils import rl_warnings
 from torchrl.data import Bounded, LazyTensorStorage, TensorDictPrioritizedReplayBuffer
 from torchrl.data.postprocs.postprocs import MultiStep
 from torchrl.modules.distributions.continuous import TanhNormal
 from torchrl.modules.models.models import MLP
 from torchrl.modules.tensordict_module.actors import Actor, ValueOperator
+from torchrl.modules.value_transforms import (
+    SignedHyperbolicValueTransform,
+    SymLogValueTransform,
+    ValueTransform,
+)
 from torchrl.objectives import DDPGLoss, TD3BCLoss, TD3Loss
 from torchrl.objectives.utils import SoftUpdate, ValueEstimators
-
+from torchrl.objectives.value import TD0Estimator
 from torchrl.testing import (  # noqa
     call_value_nets as _call_value_nets,
     dtype_fixture,
@@ -66,7 +69,14 @@ class TestDDPG(LossModuleTestBase):
         return actor.to(device)
 
     def _create_mock_value(
-        self, batch=2, obs_dim=3, action_dim=4, state_dim=8, device="cpu", out_keys=None
+        self,
+        batch=2,
+        obs_dim=3,
+        action_dim=4,
+        state_dim=8,
+        device="cpu",
+        out_keys=None,
+        value_transform=None,
     ):
         # Actor
         class ValueClass(nn.Module):
@@ -75,7 +85,10 @@ class TestDDPG(LossModuleTestBase):
                 self.linear = nn.Linear(obs_dim + action_dim + state_dim, 1)
 
             def forward(self, obs, state, act):
-                return self.linear(torch.cat([obs, state, act], -1))
+                value = self.linear(torch.cat([obs, state, act], -1))
+                if value_transform is not None:
+                    value = value_transform(value)
+                return value
 
         module = ValueClass()
         value = ValueOperator(
@@ -233,6 +246,104 @@ class TestDDPG(LossModuleTestBase):
         loss_fn = DDPGLoss(actor, value)
         self.reset_parameters_recursive_test(loss_fn)
 
+    def test_value_transform_state_dict_and_dtype(self):
+        class ScaleTransform(ValueTransform):
+            def __init__(self, scale):
+                super().__init__()
+                self.register_buffer("scale", torch.as_tensor(scale))
+
+            def forward(self, value):
+                return value * self.scale
+
+            def inverse(self, value):
+                return value / self.scale
+
+        transform = ScaleTransform(2.0)
+        loss = DDPGLoss(
+            self._create_mock_actor(),
+            self._create_mock_value(value_transform=transform),
+            value_transform=transform,
+        )
+        state_dict = loss.state_dict()
+        assert "value_transform.scale" in state_dict
+        assert loss.value_estimator.value_transform is transform
+
+        loss.to(dtype=torch.float64)
+        assert transform.scale.dtype is torch.float64
+
+        restored_transform = ScaleTransform(1.0)
+        restored = DDPGLoss(
+            self._create_mock_actor(),
+            self._create_mock_value(value_transform=restored_transform),
+            value_transform=restored_transform,
+        ).to(dtype=torch.float64)
+        assert restored.value_estimator.value_transform is restored_transform
+        restored.load_state_dict(loss.state_dict())
+        torch.testing.assert_close(restored_transform.scale, transform.scale)
+
+    @pytest.mark.parametrize(
+        "transform_cls", [SymLogValueTransform, SignedHyperbolicValueTransform]
+    )
+    def test_ddpg_value_transform_raw_objective_and_diagnostics(self, transform_cls):
+        transform = transform_cls()
+        torch.manual_seed(self.seed)
+        raw_actor = self._create_mock_actor()
+        raw_value = self._create_mock_value()
+        torch.manual_seed(self.seed)
+        transformed_actor = self._create_mock_actor()
+        transformed_value = self._create_mock_value(value_transform=transform)
+        td = self._create_mock_data_ddpg()
+        td[("next", "reward")][::2] = 100.0
+        td[("next", "reward")][1::2] = -100.0
+
+        raw_loss = DDPGLoss(raw_actor, raw_value, loss_function="l2")
+        transformed_loss = DDPGLoss(
+            transformed_actor,
+            transformed_value,
+            loss_function="l2",
+            value_transform=transform,
+        )
+        raw_out = raw_loss(td.clone())
+        transformed_td = td.clone()
+        transformed_out = transformed_loss(transformed_td)
+
+        torch.testing.assert_close(transformed_out["loss_actor"], raw_out["loss_actor"])
+        torch.testing.assert_close(
+            transformed_out["pred_value"], raw_out["pred_value"], atol=1e-4, rtol=1e-4
+        )
+        torch.testing.assert_close(
+            transformed_out["target_value"],
+            raw_out["target_value"],
+            atol=1e-4,
+            rtol=1e-4,
+        )
+        expected_priority = (
+            transform(transformed_out["pred_value"])
+            - transform(transformed_out["target_value"])
+        ).pow(2)
+        torch.testing.assert_close(transformed_td["td_error"], expected_priority)
+        (transformed_out["loss_actor"] + transformed_out["loss_value"]).backward()
+        assert all(
+            parameter.grad is None or torch.isfinite(parameter.grad).all()
+            for parameter in transformed_loss.parameters()
+        )
+
+        mismatched_estimator = TD0Estimator(
+            gamma=0.99,
+            value_network=None,
+            value_transform=transform_cls(),
+        )
+        with pytest.raises(ValueError, match="same value_transform instance"):
+            transformed_loss.make_value_estimator(mismatched_estimator)
+
+        matching_estimator = TD0Estimator(
+            gamma=0.99,
+            value_network=None,
+            value_transform=transform,
+        )
+        transformed_loss.make_value_estimator(matching_estimator)
+        assert transformed_loss.value_estimator is matching_estimator
+
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("delay_actor,delay_value", [(False, False), (True, True)])
     @pytest.mark.parametrize("td_est", list(ValueEstimators) + [None])
@@ -259,10 +370,13 @@ class TestDDPG(LossModuleTestBase):
         if td_est is not None:
             loss_fn.make_value_estimator(td_est)
 
-        with _check_td_steady(td), (
-            pytest.warns(UserWarning, match="No target network updater has been")
-            if (delay_actor or delay_value) and rl_warnings()
-            else contextlib.nullcontext()
+        with (
+            _check_td_steady(td),
+            (
+                pytest.warns(UserWarning, match="No target network updater has been")
+                if (delay_actor or delay_value) and rl_warnings()
+                else contextlib.nullcontext()
+            ),
         ):
             loss = loss_fn(td)
 
@@ -385,9 +499,11 @@ class TestDDPG(LossModuleTestBase):
             separate_losses=separate_losses,
         )
 
-        with pytest.warns(
-            UserWarning, match="No target network updater has been"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.warns(UserWarning, match="No target network updater has been")
+            if rl_warnings()
+            else contextlib.nullcontext()
+        ):
             loss = loss_fn(td)
 
         # remove warning
@@ -613,9 +729,14 @@ class TestDDPG(LossModuleTestBase):
         if td_est is not None:
             loss_fn.make_value_estimator(td_est)
 
-        with _check_td_steady(td), pytest.warns(
-            UserWarning, match="No target network updater has been"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            _check_td_steady(td),
+            (
+                pytest.warns(UserWarning, match="No target network updater has been")
+                if rl_warnings()
+                else contextlib.nullcontext()
+            ),
+        ):
             _ = loss_fn(td)
 
     def test_ddpg_notensordict(self):
@@ -637,9 +758,11 @@ class TestDDPG(LossModuleTestBase):
         }
         td = TensorDict(kwargs, td.batch_size).unflatten_keys("_")
 
-        with pytest.warns(
-            UserWarning, match="No target network updater has been"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.warns(UserWarning, match="No target network updater has been")
+            if rl_warnings()
+            else contextlib.nullcontext()
+        ):
             loss_val_td = loss(td)
             loss_val = loss(**kwargs)
             for i, key in enumerate(loss.out_keys):
@@ -824,6 +947,7 @@ class TestTD3(LossModuleTestBase):
         out_keys=None,
         action_key="action",
         observation_key="observation",
+        value_transform=None,
     ):
         # Actor
         class ValueClass(nn.Module):
@@ -832,7 +956,10 @@ class TestTD3(LossModuleTestBase):
                 self.linear = nn.Linear(obs_dim + action_dim, 1)
 
             def forward(self, obs, act):
-                return self.linear(torch.cat([obs, act], -1))
+                value = self.linear(torch.cat([obs, act], -1))
+                if value_transform is not None:
+                    value = value_transform(value)
+                return value
 
         module = ValueClass()
         value = ValueOperator(
@@ -985,6 +1112,65 @@ class TestTD3(LossModuleTestBase):
             bounds=(-1, 1),
         )
         self.reset_parameters_recursive_test(loss_fn)
+
+    @pytest.mark.parametrize(
+        "transform_cls", [SymLogValueTransform, SignedHyperbolicValueTransform]
+    )
+    def test_td3_value_transform_raw_objective_and_diagnostics(self, transform_cls):
+        transform = transform_cls()
+        torch.manual_seed(self.seed)
+        raw_actor = self._create_mock_actor()
+        raw_value = self._create_mock_value()
+        torch.manual_seed(self.seed)
+        transformed_actor = self._create_mock_actor()
+        transformed_value = self._create_mock_value(value_transform=transform)
+        td = self._create_mock_data_td3()
+        td[("next", "reward")][::2] = 100.0
+        td[("next", "reward")][1::2] = -100.0
+
+        torch.manual_seed(self.seed)
+        raw_loss = TD3Loss(
+            raw_actor,
+            raw_value,
+            bounds=(-1, 1),
+            policy_noise=0.0,
+            loss_function="l2",
+        )
+        torch.manual_seed(self.seed)
+        transformed_loss = TD3Loss(
+            transformed_actor,
+            transformed_value,
+            bounds=(-1, 1),
+            policy_noise=0.0,
+            loss_function="l2",
+            value_transform=transform,
+        )
+        raw_out = raw_loss(td.clone())
+        transformed_td = td.clone()
+        transformed_out = transformed_loss(transformed_td)
+
+        for key in (
+            "loss_actor",
+            "pred_value",
+            "target_value",
+            "next_state_value",
+            "state_action_value_actor",
+        ):
+            torch.testing.assert_close(
+                transformed_out[key], raw_out[key], atol=1e-4, rtol=1e-4, msg=key
+            )
+        expected_priority = (
+            transform(transformed_out["pred_value"])
+            - transform(transformed_out["target_value"])
+        ).pow(2)
+        torch.testing.assert_close(
+            transformed_td["td_error"], expected_priority.max(0).values
+        )
+        (transformed_out["loss_actor"] + transformed_out["loss_qvalue"]).backward()
+        assert all(
+            parameter.grad is None or torch.isfinite(parameter.grad).all()
+            for parameter in transformed_loss.parameters()
+        )
 
     @pytest.mark.skipif(not _has_functorch, reason="functorch not installed")
     @pytest.mark.parametrize("device", get_default_devices())
@@ -1269,9 +1455,11 @@ class TestTD3(LossModuleTestBase):
             loss_function="l2",
             separate_losses=separate_losses,
         )
-        with pytest.warns(
-            UserWarning, match="No target network updater has been"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.warns(UserWarning, match="No target network updater has been")
+            if rl_warnings()
+            else contextlib.nullcontext()
+        ):
             loss = loss_fn(td)
 
             assert all(
@@ -1547,9 +1735,11 @@ class TestTD3(LossModuleTestBase):
         }
         td = TensorDict(kwargs, td.batch_size).unflatten_keys("_")
 
-        with pytest.warns(
-            UserWarning, match="No target network updater has been"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.warns(UserWarning, match="No target network updater has been")
+            if rl_warnings()
+            else contextlib.nullcontext()
+        ):
             torch.manual_seed(0)
             loss_val_td = loss(td)
             torch.manual_seed(0)
@@ -2101,9 +2291,11 @@ class TestTD3BC(LossModuleTestBase):
             loss_function="l2",
             separate_losses=separate_losses,
         )
-        with pytest.warns(
-            UserWarning, match="No target network updater has been"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.warns(UserWarning, match="No target network updater has been")
+            if rl_warnings()
+            else contextlib.nullcontext()
+        ):
             loss = loss_fn(td)
 
             assert all(
@@ -2389,9 +2581,11 @@ class TestTD3BC(LossModuleTestBase):
         }
         td = TensorDict(kwargs, td.batch_size).unflatten_keys("_")
 
-        with pytest.warns(
-            UserWarning, match="No target network updater has been"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.warns(UserWarning, match="No target network updater has been")
+            if rl_warnings()
+            else contextlib.nullcontext()
+        ):
             torch.manual_seed(0)
             loss_val_td = loss(td)
             torch.manual_seed(0)

--- a/test/objectives/test_mappo.py
+++ b/test/objectives/test_mappo.py
@@ -9,13 +9,15 @@ MARL env (VMAS / PettingZoo). They follow the layout pattern from
 ``test/test_cost.py::TestQMixer`` — per-agent observations under
 ``("agents", "observation")`` and team-shared reward / done at the root.
 """
+
 from __future__ import annotations
+
+from copy import deepcopy
 
 import pytest
 import torch
 from tensordict import TensorDict
-from tensordict.nn import TensorDictModule
-
+from tensordict.nn import TensorDictModule, TensorDictSequential
 from torchrl.modules import (
     MultiAgentMLP,
     PopArtValueNorm,
@@ -24,10 +26,10 @@ from torchrl.modules import (
     ValueNorm,
 )
 from torchrl.modules.distributions import NormalParamExtractor, TanhNormal
+from torchrl.modules.value_transforms import SymLogValueTransform
 from torchrl.objectives import IPPOLoss, MAPPOLoss
 from torchrl.objectives.utils import ValueEstimators
 from torchrl.objectives.value import GAE, MultiAgentGAE
-
 
 # --------------------------------------------------------------------------
 # helpers
@@ -118,6 +120,41 @@ def _attach_action_and_logprob(td: TensorDict, actor: ProbabilisticActor, loss):
 
 
 class TestMultiAgentGAE:
+    def test_value_transform_returns_raw_per_agent_targets(self):
+        transform = SymLogValueTransform()
+        raw_critic = _make_critic()
+        transformed_critic = TensorDictSequential(
+            deepcopy(raw_critic),
+            TensorDictModule(
+                transform,
+                in_keys=[("agents", "state_value")],
+                out_keys=[("agents", "state_value")],
+            ),
+        )
+        raw_gae = MultiAgentGAE(gamma=0.99, lmbda=0.95, value_network=raw_critic)
+        transformed_gae = MultiAgentGAE(
+            gamma=0.99,
+            lmbda=0.95,
+            value_network=transformed_critic,
+            value_transform=transform,
+        )
+        raw_gae.set_keys(value=("agents", "state_value"))
+        transformed_gae.set_keys(value=("agents", "state_value"))
+        td = _make_data()
+        td[("next", "reward")].mul_(100.0)
+
+        expected = raw_gae(td.clone())
+        result = transformed_gae(td.clone())
+        torch.testing.assert_close(
+            result["advantage"], expected["advantage"], atol=1e-4, rtol=1e-4
+        )
+        torch.testing.assert_close(
+            result["value_target"],
+            expected["value_target"],
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
     def test_team_reward_broadcast(self):
         n_agents = 3
         critic = _make_critic(n_agents=n_agents)
@@ -238,6 +275,16 @@ class TestRunningValueNorm:
 
 
 class TestMAPPOLoss:
+    @pytest.mark.parametrize("loss_cls", [MAPPOLoss, IPPOLoss])
+    def test_value_transform_rejects_value_norm(self, loss_cls):
+        with pytest.raises(ValueError, match="Choose one critic scaling strategy"):
+            loss_cls(
+                _make_actor(),
+                _make_critic(centralized=loss_cls is MAPPOLoss),
+                value_norm=RunningValueNorm(shape=1),
+                value_transform=SymLogValueTransform(),
+            )
+
     def test_forward_shapes_and_backward(self):
         actor = _make_actor()
         critic = _make_critic(centralized=True)

--- a/test/objectives/test_ppo.py
+++ b/test/objectives/test_ppo.py
@@ -19,7 +19,7 @@ from _objectives_common import (
     LossModuleTestBase,
     MARLEnv,
 )
-
+from packaging import version as pack_version
 from tensordict import assert_allclose_td, TensorDict
 from tensordict.nn import (
     composite_lp_aggregate,
@@ -37,7 +37,6 @@ from tensordict.nn import (
     WrapModule,
 )
 from torch import autograd, nn
-
 from torchrl._utils import rl_warnings
 from torchrl.data import Bounded, Composite, Unbounded
 from torchrl.modules.distributions.continuous import TanhNormal
@@ -47,6 +46,7 @@ from torchrl.modules.tensordict_module.actors import (
     ProbabilisticActor,
     ValueOperator,
 )
+from torchrl.modules.value_transforms import SymLogValueTransform
 from torchrl.objectives import A2CLoss, ClipPPOLoss, KLPENPPOLoss, PPOLoss
 from torchrl.objectives.reinforce import ReinforceLoss
 from torchrl.objectives.utils import _sum_td_features, ValueEstimators
@@ -56,7 +56,6 @@ from torchrl.objectives.value.advantages import (
     TDLambdaEstimator,
     VTrace,
 )
-
 from torchrl.testing import (  # noqa
     call_value_nets as _call_value_nets,
     dtype_fixture,
@@ -134,8 +133,12 @@ class TestPPO(LossModuleTestBase):
         device="cpu",
         out_keys=None,
         observation_key="observation",
+        value_transform=None,
     ):
-        module = nn.Linear(obs_dim, 1)
+        if value_transform is None:
+            module = nn.Linear(obs_dim, 1)
+        else:
+            module = nn.Sequential(nn.Linear(obs_dim, 1), value_transform)
         value = ValueOperator(
             module=module,
             in_keys=[observation_key],
@@ -387,6 +390,63 @@ class TestPPO(LossModuleTestBase):
         value = self._create_mock_value()
         loss_fn = loss_class(actor, value)
         self.reset_parameters_recursive_test(loss_fn)
+
+    @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
+    def test_ppo_value_transform_clips_in_raw_space(self, loss_class):
+        transform = SymLogValueTransform()
+        torch.manual_seed(self.seed)
+        raw_actor = self._create_mock_actor()
+        raw_value = self._create_mock_value()
+        torch.manual_seed(self.seed)
+        transformed_actor = self._create_mock_actor()
+        transformed_value = self._create_mock_value(value_transform=transform)
+        td = self._create_mock_data_ppo(batch=6)
+
+        with torch.no_grad():
+            current_raw = raw_value(td.clone())["state_value"]
+        offset = torch.tensor([-20.0, 20.0, -20.0, 20.0, -20.0, 20.0]).unsqueeze(-1)
+        old_raw = current_raw + offset
+        target_raw = current_raw - 5.0 * offset
+        raw_td = td.clone().set("state_value", old_raw).set("value_target", target_raw)
+        transformed_td = (
+            td.clone()
+            .set("state_value", transform(old_raw))
+            .set("value_target", target_raw)
+        )
+
+        raw_loss = loss_class(
+            raw_actor,
+            raw_value,
+            clip_value=5.0,
+            loss_critic_type="l2",
+        )
+        transformed_loss = loss_class(
+            transformed_actor,
+            transformed_value,
+            clip_value=5.0,
+            loss_critic_type="l2",
+            value_transform=transform,
+        )
+        _, raw_clip_fraction, raw_explained_variance = raw_loss.loss_critic(raw_td)
+        (
+            transformed_critic_loss,
+            clip_fraction,
+            explained_variance,
+        ) = transformed_loss.loss_critic(transformed_td)
+
+        current_transformed = transform(current_raw)
+        target_transformed = transform(target_raw)
+        clipped_raw = old_raw + (current_raw - old_raw).clamp(-5.0, 5.0)
+        expected_loss = torch.maximum(
+            (target_transformed - current_transformed).pow(2),
+            (target_transformed - transform(clipped_raw)).pow(2),
+        )
+        torch.testing.assert_close(transformed_critic_loss, expected_loss)
+        torch.testing.assert_close(clip_fraction, raw_clip_fraction)
+        torch.testing.assert_close(explained_variance, raw_explained_variance)
+
+        transformed_loss.make_value_estimator(ValueEstimators.GAE)
+        assert transformed_loss.value_estimator.value_transform is transform
 
     @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
     @pytest.mark.parametrize("gradient_mode", (True, False))
@@ -964,9 +1024,11 @@ class TestPPO(LossModuleTestBase):
             "advantage": "advantage",
             "value_target": "value_target",
             "value": "state_value",
-            "sample_log_prob": "action_log_prob"
-            if not composite_action_dist
-            else ("action", "action1_log_prob"),
+            "sample_log_prob": (
+                "action_log_prob"
+                if not composite_action_dist
+                else ("action", "action1_log_prob")
+            ),
             "action": "action" if not composite_action_dist else ("action", "action1"),
             "reward": "reward",
             "done": "done",
@@ -2047,9 +2109,9 @@ class TestA2C(LossModuleTestBase):
         td = td.exclude(loss_fn.tensor_keys.value_target)
         if advantage is not None:
             advantage.set_keys(
-                sample_log_prob=actor.log_prob_keys
-                if composite_action_dist
-                else "action_log_prob"
+                sample_log_prob=(
+                    actor.log_prob_keys if composite_action_dist else "action_log_prob"
+                )
             )
             advantage(td)
         elif td_est is not None:

--- a/test/objectives/test_ppo.py
+++ b/test/objectives/test_ppo.py
@@ -19,7 +19,6 @@ from _objectives_common import (
     LossModuleTestBase,
     MARLEnv,
 )
-from packaging import version as pack_version
 from tensordict import assert_allclose_td, TensorDict
 from tensordict.nn import (
     composite_lp_aggregate,

--- a/test/objectives/test_sac.py
+++ b/test/objectives/test_sac.py
@@ -66,6 +66,10 @@ from torchrl.testing import (  # noqa
 )
 
 
+def _constant_priority(prediction, target):
+    return torch.full_like(prediction, 0.25)
+
+
 @pytest.mark.skipif(
     not _has_functorch, reason=f"functorch not installed: {FUNCTORCH_ERR}"
 )
@@ -434,6 +438,28 @@ class TestSAC(LossModuleTestBase):
         assert all(
             parameter.grad is None or torch.isfinite(parameter.grad).all()
             for parameter in transformed_loss.parameters()
+        )
+
+    def test_sac_priority_function(self, version):
+        transform = SymLogValueTransform()
+        actor = self._create_mock_actor()
+        qvalue = self._create_mock_qvalue(value_transform=transform)
+        value = (
+            self._create_mock_value(value_transform=transform) if version == 1 else None
+        )
+        loss = SACLoss(
+            actor,
+            qvalue,
+            value,
+            value_transform=transform,
+            priority_function=_constant_priority,
+        )
+        td = self._create_mock_data_sac()
+
+        loss(td)
+
+        torch.testing.assert_close(
+            td["td_error"], torch.full_like(td["td_error"], 0.25)
         )
 
     def test_sac_list_qvalue_networks(self, version):

--- a/test/objectives/test_sac.py
+++ b/test/objectives/test_sac.py
@@ -19,7 +19,6 @@ from _objectives_common import (
     FUNCTORCH_ERR,
     LossModuleTestBase,
 )
-
 from tensordict import assert_allclose_td, TensorDict, TensorDictBase
 from tensordict.nn import (
     CompositeDistribution,
@@ -32,7 +31,6 @@ from tensordict.nn import (
 )
 from tensordict.nn.distributions.composite import _add_suffix
 from torch import nn
-
 from torchrl._utils import rl_warnings
 from torchrl.data import (
     Bounded,
@@ -51,11 +49,14 @@ from torchrl.modules.tensordict_module.actors import (
     ProbabilisticActor,
     ValueOperator,
 )
+from torchrl.modules.value_transforms import (
+    SignedHyperbolicValueTransform,
+    SymLogValueTransform,
+)
 from torchrl.objectives import CrossQLoss, DiscreteSACLoss, SACLoss
 from torchrl.objectives.deprecated import DoubleREDQLoss_deprecated, REDQLoss_deprecated
 from torchrl.objectives.redq import REDQLoss
 from torchrl.objectives.utils import SoftUpdate, ValueEstimators
-
 from torchrl.testing import (  # noqa
     call_value_nets as _call_value_nets,
     dtype_fixture,
@@ -130,6 +131,7 @@ class TestSAC(LossModuleTestBase):
         observation_key="observation",
         action_key="action",
         out_keys=None,
+        value_transform=None,
     ):
         class ValueClass(nn.Module):
             def __init__(self):
@@ -139,7 +141,10 @@ class TestSAC(LossModuleTestBase):
             def forward(self, obs, act):
                 if isinstance(act, TensorDictBase):
                     act = act.get("action1")
-                return self.linear(torch.cat([obs, act], -1))
+                value = self.linear(torch.cat([obs, act], -1))
+                if value_transform is not None:
+                    value = value_transform(value)
+                return value
 
         module = ValueClass()
         qvalue = ValueOperator(
@@ -157,8 +162,12 @@ class TestSAC(LossModuleTestBase):
         device="cpu",
         observation_key="observation",
         out_keys=None,
+        value_transform=None,
     ):
-        module = nn.Linear(obs_dim, 1)
+        if value_transform is None:
+            module = nn.Linear(obs_dim, 1)
+        else:
+            module = nn.Sequential(nn.Linear(obs_dim, 1), value_transform)
         value = ValueOperator(
             module=module,
             in_keys=[observation_key],
@@ -351,6 +360,82 @@ class TestSAC(LossModuleTestBase):
         )
         self.reset_parameters_recursive_test(loss_fn)
 
+    @pytest.mark.parametrize(
+        "transform_cls", [SymLogValueTransform, SignedHyperbolicValueTransform]
+    )
+    def test_sac_value_transform_preserves_raw_entropy_units(
+        self, version, transform_cls
+    ):
+        transform = transform_cls()
+        torch.manual_seed(self.seed)
+        raw_actor = self._create_mock_actor()
+        raw_qvalue = self._create_mock_qvalue()
+        raw_value = self._create_mock_value() if version == 1 else None
+        torch.manual_seed(self.seed)
+        transformed_actor = self._create_mock_actor()
+        transformed_qvalue = self._create_mock_qvalue(value_transform=transform)
+        transformed_value = (
+            self._create_mock_value(value_transform=transform) if version == 1 else None
+        )
+        td = self._create_mock_data_sac()
+        td[("next", "reward")][::2] = 100.0
+        td[("next", "reward")][1::2] = -100.0
+
+        torch.manual_seed(self.seed)
+        raw_loss = SACLoss(
+            raw_actor,
+            raw_qvalue,
+            raw_value,
+            loss_function="l2",
+        )
+        torch.manual_seed(self.seed)
+        transformed_loss = SACLoss(
+            transformed_actor,
+            transformed_qvalue,
+            transformed_value,
+            loss_function="l2",
+            value_transform=transform,
+        )
+
+        torch.manual_seed(self.seed)
+        raw_actor_loss, raw_actor_metadata = raw_loss.actor_loss(td.clone())
+        torch.manual_seed(self.seed)
+        (
+            transformed_actor_loss,
+            transformed_actor_metadata,
+        ) = transformed_loss.actor_loss(td.clone())
+        torch.testing.assert_close(
+            transformed_actor_loss, raw_actor_loss, atol=1e-4, rtol=1e-4
+        )
+        torch.testing.assert_close(
+            transformed_actor_metadata["log_prob"], raw_actor_metadata["log_prob"]
+        )
+
+        if version == 1:
+            raw_target = raw_loss.value_estimator.value_estimate(
+                td, target_params=raw_loss._cached_target_params_actor_value
+            )
+            transformed_target = transformed_loss.value_estimator.value_estimate(
+                td,
+                target_params=transformed_loss._cached_target_params_actor_value,
+            )
+        else:
+            torch.manual_seed(self.seed)
+            raw_target = raw_loss._compute_target_v2(td)
+            torch.manual_seed(self.seed)
+            transformed_target = transformed_loss._compute_target_v2(td)
+        torch.testing.assert_close(transformed_target, raw_target, atol=1e-4, rtol=1e-4)
+
+        torch.manual_seed(self.seed)
+        transformed_out = transformed_loss(td.clone())
+        sum(
+            value for key, value in transformed_out.items() if key.startswith("loss_")
+        ).backward()
+        assert all(
+            parameter.grad is None or torch.isfinite(parameter.grad).all()
+            for parameter in transformed_loss.parameters()
+        )
+
     def test_sac_list_qvalue_networks(self, version):
         torch.manual_seed(self.seed)
         td = self._create_mock_data_sac()
@@ -367,9 +452,13 @@ class TestSAC(LossModuleTestBase):
             value_network=value,
             num_qvalue_nets=2,
         )
-        with pytest.warns(
-            UserWarning, match="No target network updater has been associated"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.warns(
+                UserWarning, match="No target network updater has been associated"
+            )
+            if rl_warnings()
+            else contextlib.nullcontext()
+        ):
             loss = loss_fn(td)
         assert "loss_qvalue" in loss.keys()
 
@@ -456,9 +545,14 @@ class TestSAC(LossModuleTestBase):
         if td_est is not None:
             loss_fn.make_value_estimator(td_est)
 
-        with _check_td_steady(td), pytest.warns(
-            UserWarning, match="No target network updater"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            _check_td_steady(td),
+            (
+                pytest.warns(UserWarning, match="No target network updater")
+                if rl_warnings()
+                else contextlib.nullcontext()
+            ),
+        ):
             loss = loss_fn(td)
 
         assert loss_fn.tensor_keys.priority in td.keys()
@@ -637,9 +731,14 @@ class TestSAC(LossModuleTestBase):
 
         tdc = td.clone()
         torch.manual_seed(0)
-        with _check_td_steady(td), pytest.warns(
-            UserWarning, match="No target network updater"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            _check_td_steady(td),
+            (
+                pytest.warns(UserWarning, match="No target network updater")
+                if rl_warnings()
+                else contextlib.nullcontext()
+            ),
+        ):
             loss_vmap = loss_fn_vmap(td)
         td = tdc
         torch.manual_seed(0)
@@ -665,13 +764,22 @@ class TestSAC(LossModuleTestBase):
             loss_fn_no_vmap.make_value_estimator(td_est)
 
         torch.manual_seed(0)
-        with pytest.raises(
-            NotImplementedError,
-            match="This implementation is not supported for torch<2.7",
-        ) if torch.__version__ < "2.7" else contextlib.nullcontext():
-            with _check_td_steady(td), pytest.warns(
-                UserWarning, match="No target network updater"
-            ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.raises(
+                NotImplementedError,
+                match="This implementation is not supported for torch<2.7",
+            )
+            if torch.__version__ < "2.7"
+            else contextlib.nullcontext()
+        ):
+            with (
+                _check_td_steady(td),
+                (
+                    pytest.warns(UserWarning, match="No target network updater")
+                    if rl_warnings()
+                    else contextlib.nullcontext()
+                ),
+            ):
                 loss_no_vmap = loss_fn_no_vmap(td)
             assert_allclose_td(loss_vmap, loss_no_vmap)
 
@@ -767,9 +875,11 @@ class TestSAC(LossModuleTestBase):
             num_qvalue_nets=1,
             separate_losses=separate_losses,
         )
-        with pytest.warns(
-            UserWarning, match="No target network updater has been"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.warns(UserWarning, match="No target network updater has been")
+            if rl_warnings()
+            else contextlib.nullcontext()
+        ):
             loss = loss_fn(td)
 
             assert loss_fn.tensor_keys.priority in td.keys()
@@ -909,10 +1019,14 @@ class TestSAC(LossModuleTestBase):
 
         torch.manual_seed(0)
         np.random.seed(0)
-        with pytest.warns(
-            UserWarning,
-            match="No target network updater has been associated with this loss module",
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.warns(
+                UserWarning,
+                match="No target network updater has been associated with this loss module",
+            )
+            if rl_warnings()
+            else contextlib.nullcontext()
+        ):
             with _check_td_steady(ms_td):
                 loss_ms = loss_fn(ms_td)
             assert loss_fn.tensor_keys.priority in ms_td.keys()
@@ -1145,9 +1259,11 @@ class TestSAC(LossModuleTestBase):
         # setting the seed for each loss so that drawing the random samples from value network
         # leads to same numbers for both runs
         torch.manual_seed(self.seed)
-        with pytest.warns(
-            UserWarning, match="No target network updater"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.warns(UserWarning, match="No target network updater")
+            if rl_warnings()
+            else contextlib.nullcontext()
+        ):
             loss_val = loss(**kwargs)
 
         torch.manual_seed(self.seed)
@@ -1306,9 +1422,11 @@ class TestSAC(LossModuleTestBase):
             raise AssertionError("SAC inverse-scored a freshly sampled TanhNormal")
 
         monkeypatch.setattr(TanhNormal, "log_prob", fail_log_prob)
-        with pytest.warns(
-            UserWarning, match="No target network updater"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.warns(UserWarning, match="No target network updater")
+            if rl_warnings()
+            else contextlib.nullcontext()
+        ):
             result = loss(td)
         assert result.isfinite().all()
 
@@ -1725,9 +1843,14 @@ class TestDiscreteSAC(LossModuleTestBase):
         if td_est is not None:
             loss_fn.make_value_estimator(td_est)
 
-        with _check_td_steady(td), pytest.warns(
-            UserWarning, match="No target network updater"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            _check_td_steady(td),
+            (
+                pytest.warns(UserWarning, match="No target network updater")
+                if rl_warnings()
+                else contextlib.nullcontext()
+            ),
+        ):
             loss = loss_fn(td)
 
         assert loss_fn.tensor_keys.priority in td.keys()
@@ -1849,9 +1972,14 @@ class TestDiscreteSAC(LossModuleTestBase):
             loss_fn_vmap.make_value_estimator(td_est)
 
         tdc = td.clone()
-        with _check_td_steady(td), pytest.warns(
-            UserWarning, match="No target network updater"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            _check_td_steady(td),
+            (
+                pytest.warns(UserWarning, match="No target network updater")
+                if rl_warnings()
+                else contextlib.nullcontext()
+            ),
+        ):
             torch.manual_seed(1)
             loss_vmap = loss_fn_vmap(td)
         td = tdc
@@ -1880,13 +2008,22 @@ class TestDiscreteSAC(LossModuleTestBase):
         if td_est is not None:
             loss_fn_no_vmap.make_value_estimator(td_est)
 
-        with pytest.raises(
-            NotImplementedError,
-            match="This implementation is not supported for torch<2.7",
-        ) if torch.__version__ < "2.7" else contextlib.nullcontext():
-            with _check_td_steady(td), pytest.warns(
-                UserWarning, match="No target network updater"
-            ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.raises(
+                NotImplementedError,
+                match="This implementation is not supported for torch<2.7",
+            )
+            if torch.__version__ < "2.7"
+            else contextlib.nullcontext()
+        ):
+            with (
+                _check_td_steady(td),
+                (
+                    pytest.warns(UserWarning, match="No target network updater")
+                    if rl_warnings()
+                    else contextlib.nullcontext()
+                ),
+            ):
                 torch.manual_seed(1)
                 loss_no_vmap = loss_fn_no_vmap(td)
             assert_allclose_td(loss_vmap, loss_no_vmap)
@@ -2003,9 +2140,14 @@ class TestDiscreteSAC(LossModuleTestBase):
 
         torch.manual_seed(0)
         np.random.seed(0)
-        with _check_td_steady(ms_td), pytest.warns(
-            UserWarning, match="No target network updater"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            _check_td_steady(ms_td),
+            (
+                pytest.warns(UserWarning, match="No target network updater")
+                if rl_warnings()
+                else contextlib.nullcontext()
+            ),
+        ):
             loss_ms = loss_fn(ms_td)
         assert loss_fn.tensor_keys.priority in ms_td.keys()
 
@@ -2186,9 +2328,11 @@ class TestDiscreteSAC(LossModuleTestBase):
         }
         td = TensorDict(kwargs, td.batch_size).unflatten_keys("_")
 
-        with pytest.warns(
-            UserWarning, match="No target network updater has been"
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.warns(UserWarning, match="No target network updater has been")
+            if rl_warnings()
+            else contextlib.nullcontext()
+        ):
             loss_val = loss(**kwargs)
             loss_val_td = loss(td)
 
@@ -2664,10 +2808,14 @@ class TestCrossQ(LossModuleTestBase):
         if td_est is not None:
             loss_fn_no_vmap.make_value_estimator(td_est)
 
-        with pytest.raises(
-            NotImplementedError,
-            match="This implementation is not supported for torch<2.7",
-        ) if torch.__version__ < "2.7" else contextlib.nullcontext():
+        with (
+            pytest.raises(
+                NotImplementedError,
+                match="This implementation is not supported for torch<2.7",
+            )
+            if torch.__version__ < "2.7"
+            else contextlib.nullcontext()
+        ):
             with _check_td_steady(td):
                 torch.manual_seed(1)
                 loss_no_vmap = loss_fn_no_vmap(td)
@@ -3515,10 +3663,14 @@ class TestREDQ(LossModuleTestBase):
             separate_losses=separate_losses,
         )
 
-        with pytest.warns(
-            UserWarning,
-            match="No target network updater has been associated with this loss module",
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.warns(
+                UserWarning,
+                match="No target network updater has been associated with this loss module",
+            )
+            if rl_warnings()
+            else contextlib.nullcontext()
+        ):
             loss = loss_fn(td)
 
             # check that losses are independent
@@ -3603,10 +3755,14 @@ class TestREDQ(LossModuleTestBase):
             separate_losses=separate_losses,
         )
 
-        with pytest.warns(
-            UserWarning,
-            match="No target network updater has been associated with this loss module",
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.warns(
+                UserWarning,
+                match="No target network updater has been associated with this loss module",
+            )
+            if rl_warnings()
+            else contextlib.nullcontext()
+        ):
             loss = loss_fn(td)
 
         SoftUpdate(loss_fn, eps=0.5)
@@ -4032,10 +4188,14 @@ class TestREDQ(LossModuleTestBase):
         td = TensorDict(kwargs, td.batch_size).unflatten_keys("_")
 
         torch.manual_seed(self.seed)
-        with pytest.warns(
-            UserWarning,
-            match="No target network updater has been associated with this loss module",
-        ) if rl_warnings() else contextlib.nullcontext():
+        with (
+            pytest.warns(
+                UserWarning,
+                match="No target network updater has been associated with this loss module",
+            )
+            if rl_warnings()
+            else contextlib.nullcontext()
+        ):
             loss_val = loss(**kwargs)
             torch.manual_seed(self.seed)
             loss_val_td = loss(td)

--- a/test/objectives/test_values.py
+++ b/test/objectives/test_values.py
@@ -21,13 +21,16 @@ from tensordict.nn import (
     TensorDictSequential as Seq,
 )
 from torch import nn
-
 from torchrl.envs import GymEnv, InitTracker, SerialEnv
 from torchrl.envs.libs.gym import _has_gym
 from torchrl.envs.transforms import TransformedEnv
 from torchrl.modules import GRUModule, LSTMModule, OneHotCategorical, set_recurrent_mode
 from torchrl.modules.models.models import MLP
 from torchrl.modules.tensordict_module.actors import ProbabilisticActor
+from torchrl.modules.value_transforms import (
+    SignedHyperbolicValueTransform,
+    SymLogValueTransform,
+)
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.value.advantages import (
     GAE,
@@ -47,7 +50,6 @@ from torchrl.objectives.value.functional import (
     vtrace_advantage_estimate,
 )
 from torchrl.objectives.value.utils import _custom_conv1d, _make_gammas_tensor
-
 from torchrl.testing import (  # noqa
     call_value_nets as _call_value_nets,
     dtype_fixture,
@@ -89,6 +91,164 @@ class TestValues:
         )
 
     @implement_for("torch", "2.7", compilable=True)
+    @pytest.mark.parametrize(
+        "estimator_cls,kwargs",
+        [
+            (TD0Estimator, {"gamma": 0.9}),
+            (TD1Estimator, {"gamma": 0.9}),
+            (TDLambdaEstimator, {"gamma": 0.9, "lmbda": 0.8}),
+            (GAE, {"gamma": 0.9, "lmbda": 0.8, "average_gae": False}),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "transform_cls", [SymLogValueTransform, SignedHyperbolicValueTransform]
+    )
+    def test_value_transform_keeps_predictions_and_returns_raw(
+        self, estimator_cls, kwargs, transform_cls
+    ):
+        transform = transform_cls()
+        raw_value = torch.linspace(-100.0, 100.0, 10).reshape(2, 5, 1)
+        raw_next_value = torch.linspace(80.0, -80.0, 10).reshape(2, 5, 1)
+        reward = torch.linspace(-50.0, 50.0, 10).reshape(2, 5, 1)
+        done = torch.zeros(2, 5, 1, dtype=torch.bool)
+        done[:, -1] = True
+        terminated = done.clone()
+        terminated[0, -1] = False
+        raw_td = TensorDict(
+            {
+                "critic": {"value": raw_value},
+                "next": {
+                    "critic": {"value": raw_next_value},
+                    "reward": reward,
+                    "done": done,
+                    "terminated": terminated,
+                },
+            },
+            batch_size=[2, 5],
+        )
+        transformed_td = raw_td.clone()
+        transformed_td.set(("critic", "value"), transform(raw_value))
+        transformed_td.set(("next", "critic", "value"), transform(raw_next_value))
+
+        raw_estimator = estimator_cls(value_network=None, **kwargs)
+        raw_estimator.set_keys(value=("critic", "value"))
+        transformed_estimator = estimator_cls(
+            value_network=None, value_transform=transform, **kwargs
+        )
+        transformed_estimator.set_keys(value=("critic", "value"))
+
+        expected = raw_estimator(raw_td.clone())
+        result = transformed_estimator(transformed_td)
+
+        torch.testing.assert_close(
+            result["advantage"], expected["advantage"], atol=1e-4, rtol=1e-4
+        )
+        torch.testing.assert_close(
+            result["value_target"],
+            expected["value_target"],
+            atol=1e-4,
+            rtol=1e-4,
+        )
+        torch.testing.assert_close(result[("critic", "value")], transform(raw_value))
+        torch.testing.assert_close(
+            result[("next", "critic", "value")], transform(raw_next_value)
+        )
+
+    def test_value_transform_validation(self):
+        with pytest.raises(TypeError, match="ValueTransform instance or None"):
+            TD0Estimator(gamma=0.9, value_network=None, value_transform=torch.exp)
+
+    def test_value_transform_non_tensordict_dispatch(self):
+        transform = SymLogValueTransform()
+        estimator = TD0Estimator(
+            gamma=0.9, value_network=None, value_transform=transform
+        )
+        raw_value = torch.tensor([[-100.0], [100.0]])
+        raw_next_value = torch.tensor([[50.0], [-50.0]])
+        reward = torch.tensor([[10.0], [-10.0]])
+        done = torch.zeros(2, 1, dtype=torch.bool)
+
+        advantage, value_target = estimator(
+            state_value=transform(raw_value),
+            next_state_value=transform(raw_next_value),
+            next_reward=reward,
+            next_done=done,
+            next_terminated=done,
+        )
+        expected_target = reward + 0.9 * raw_next_value
+        torch.testing.assert_close(value_target, expected_target)
+        torch.testing.assert_close(advantage, expected_target - raw_value)
+
+    def test_vtrace_value_transform_returns_raw_values(self):
+        transform = SymLogValueTransform()
+        torch.manual_seed(0)
+        raw_value_net = TensorDictModule(
+            nn.Linear(3, 1), in_keys=["obs"], out_keys=["state_value"]
+        )
+        raw_actor_net = TensorDictModule(
+            nn.Linear(3, 4), in_keys=["obs"], out_keys=["logits"]
+        )
+        raw_actor = ProbabilisticActor(
+            module=raw_actor_net,
+            in_keys=["logits"],
+            out_keys=["action"],
+            distribution_class=OneHotCategorical,
+            return_log_prob=True,
+        )
+        torch.manual_seed(0)
+        transformed_value_net = TensorDictModule(
+            nn.Sequential(nn.Linear(3, 1), transform),
+            in_keys=["obs"],
+            out_keys=["state_value"],
+        )
+        transformed_actor_net = TensorDictModule(
+            nn.Linear(3, 4), in_keys=["obs"], out_keys=["logits"]
+        )
+        transformed_actor = ProbabilisticActor(
+            module=transformed_actor_net,
+            in_keys=["logits"],
+            out_keys=["action"],
+            distribution_class=OneHotCategorical,
+            return_log_prob=True,
+        )
+        td = TensorDict(
+            {
+                "obs": torch.randn(2, 5, 3),
+                "next": {
+                    "obs": torch.randn(2, 5, 3),
+                    "reward": torch.linspace(-100.0, 100.0, 10).reshape(2, 5, 1),
+                    "done": torch.zeros(2, 5, 1, dtype=torch.bool),
+                    "terminated": torch.zeros(2, 5, 1, dtype=torch.bool),
+                },
+            },
+            [2, 5],
+        )
+        torch.manual_seed(0)
+        raw_actor(td)
+        raw_vtrace = VTrace(
+            gamma=0.9,
+            value_network=raw_value_net,
+            actor_network=raw_actor,
+        )
+        transformed_vtrace = VTrace(
+            gamma=0.9,
+            value_network=transformed_value_net,
+            actor_network=transformed_actor,
+            value_transform=transform,
+        )
+
+        expected = raw_vtrace(td.clone())
+        result = transformed_vtrace(td.clone())
+        torch.testing.assert_close(
+            result["advantage"], expected["advantage"], atol=1e-4, rtol=1e-4
+        )
+        torch.testing.assert_close(
+            result["value_target"],
+            expected["value_target"],
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
     @pytest.mark.parametrize(
         "estimator_cls,kwargs",
         [
@@ -567,10 +727,14 @@ class TestValues:
             vectorized=vectorized,
             deactivate_vmap=True,
         )
-        with pytest.raises(
-            NotImplementedError,
-            match="This implementation is not supported for torch<2.7",
-        ) if torch.__version__ < "2.7" else contextlib.nullcontext():
+        with (
+            pytest.raises(
+                NotImplementedError,
+                match="This implementation is not supported for torch<2.7",
+            )
+            if torch.__version__ < "2.7"
+            else contextlib.nullcontext()
+        ):
             with set_recurrent_mode(True):
                 r1 = gae(vals.copy())
             a1 = r1["advantage"]

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -1650,6 +1650,25 @@ class TestLossConfigs:
         assert cfg._target_ == "torchrl.objectives.value.GAE"
         assert cfg.value_chunk_dim == 1
 
+    def test_gae_config_nested_value_transform(self):
+        from hydra.utils import instantiate
+        from torchrl.modules import SymLogValueTransform
+        from torchrl.trainers.algorithms.configs.objectives import GAEConfig
+
+        gae = instantiate(
+            GAEConfig(
+                gamma=0.99,
+                lmbda=0.95,
+                value_network=None,
+                value_transform={"_target_": "torchrl.modules.SymLogValueTransform"},
+            ),
+            _target_whitelist_=[
+                "torchrl.objectives.value.GAE",
+                "torchrl.modules.SymLogValueTransform",
+            ],
+        )
+        assert isinstance(gae.value_transform, SymLogValueTransform)
+
     @pytest.mark.parametrize("loss_type", ["clip", "kl", "ppo"])
     @pytest.mark.skipif(not _has_gymnasium, reason="Gymnasium is not installed")
     def test_ppo_loss_config(self, loss_type):
@@ -1675,14 +1694,27 @@ class TestLossConfigs:
             actor_network=actor_network,
             critic_network=critic_network,
             loss_type=loss_type,
+            value_transform={"_target_": "torchrl.modules.SymLogValueTransform"},
         )
         assert (
             cfg._target_
             == "torchrl.trainers.algorithms.configs.objectives._make_ppo_loss"
         )
 
-        loss = instantiate(cfg)
+        loss = instantiate(
+            cfg,
+            _target_whitelist_=[
+                "torchrl.trainers.algorithms.configs.objectives._make_ppo_loss",
+                "torchrl.trainers.algorithms.configs.modules._make_tanh_normal_model",
+                "torchrl.trainers.algorithms.configs.modules._make_tensordict_module",
+                "torchrl.modules.MLP",
+                "torchrl.modules.SymLogValueTransform",
+                "torch.nn.Tanh",
+                "torch.nn.Linear",
+            ],
+        )
         assert isinstance(loss, PPOLoss)
+        assert loss.value_transform.__class__.__name__ == "SymLogValueTransform"
         if loss_type == "clip":
             assert isinstance(loss, ClipPPOLoss)
         elif loss_type == "kl":

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -1662,10 +1662,6 @@ class TestLossConfigs:
                 value_network=None,
                 value_transform={"_target_": "torchrl.modules.SymLogValueTransform"},
             ),
-            _target_whitelist_=[
-                "torchrl.objectives.value.GAE",
-                "torchrl.modules.SymLogValueTransform",
-            ],
         )
         assert isinstance(gae.value_transform, SymLogValueTransform)
 
@@ -1701,18 +1697,7 @@ class TestLossConfigs:
             == "torchrl.trainers.algorithms.configs.objectives._make_ppo_loss"
         )
 
-        loss = instantiate(
-            cfg,
-            _target_whitelist_=[
-                "torchrl.trainers.algorithms.configs.objectives._make_ppo_loss",
-                "torchrl.trainers.algorithms.configs.modules._make_tanh_normal_model",
-                "torchrl.trainers.algorithms.configs.modules._make_tensordict_module",
-                "torchrl.modules.MLP",
-                "torchrl.modules.SymLogValueTransform",
-                "torch.nn.Tanh",
-                "torch.nn.Linear",
-            ],
-        )
+        loss = instantiate(cfg)
         assert isinstance(loss, PPOLoss)
         assert loss.value_transform.__class__.__name__ == "SymLogValueTransform"
         if loss_type == "clip":

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -22,7 +22,6 @@ from tensordict.nn.probabilistic import interaction_type, InteractionType
 from tensordict.utils import expand_as_right, NestedKey
 from torch import nn
 from torch.distributions import Categorical
-
 from torchrl._utils import _replace_last
 from torchrl.data.tensor_specs import Composite, TensorSpec
 from torchrl.data.utils import _process_action_space_spec
@@ -433,6 +432,14 @@ class ValueOperator(TensorDictModule):
     ["state_action_value"], respectively and depending on whether the "action"
     key is part of the in_keys list).
 
+    ``ValueOperator`` does not transform its output. When a loss or value
+    estimator is configured with a
+    :class:`~torchrl.modules.ValueTransform`, the wrapped module must emit
+    values in that transform's prediction space. The ``"state_value"`` or
+    ``"state_action_value"`` entry remains in prediction space; the consumer
+    converts it back to raw reward-return units for Bellman, advantage, actor,
+    clipping, and diagnostic computations.
+
     Args:
         module (nn.Module): a :class:`torch.nn.Module` used to map the input to
             the output parameter space.
@@ -476,6 +483,14 @@ class ValueOperator(TensorDictModule):
             device=None,
             is_shared=False)
 
+
+    .. seealso::
+        :class:`~torchrl.modules.ValueTransform`,
+        :class:`~torchrl.objectives.value.ValueEstimatorBase`,
+        :class:`~torchrl.objectives.DDPGLoss`,
+        :class:`~torchrl.objectives.TD3Loss`,
+        :class:`~torchrl.objectives.SACLoss`, and
+        :class:`~torchrl.objectives.PPOLoss`.
 
     """
 

--- a/torchrl/modules/value_transforms.py
+++ b/torchrl/modules/value_transforms.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Invertible transforms for scalar value targets and predictions."""
+
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
@@ -42,7 +43,13 @@ class ValueTransform(nn.Module, metaclass=ABCMeta):
     .. seealso::
         :class:`IdentityValueTransform`, :class:`SymLogValueTransform`,
         :class:`SignedHyperbolicValueTransform`, and
-        :class:`ComposeValueTransform`.
+        :class:`ComposeValueTransform` for concrete transforms;
+        :class:`~torchrl.modules.ValueOperator` for the prediction-space
+        contract; and :class:`~torchrl.objectives.value.ValueEstimatorBase`,
+        :class:`~torchrl.objectives.DDPGLoss`,
+        :class:`~torchrl.objectives.TD3Loss`,
+        :class:`~torchrl.objectives.SACLoss`, and
+        :class:`~torchrl.objectives.PPOLoss` for consumers.
     """
 
     @abstractmethod

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import abc
 import functools
 import warnings
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Literal
@@ -802,6 +802,17 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
 
     def _set_value_transform(self, value_transform: ValueTransform | None) -> None:
         self.value_transform = _validate_value_transform(value_transform)
+
+    def _set_priority_function(
+        self,
+        priority_function: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None,
+    ) -> None:
+        if priority_function is not None and not callable(priority_function):
+            raise TypeError(
+                "priority_function must be callable or None, got "
+                f"{type(priority_function).__name__}."
+            )
+        self.priority_function = priority_function
 
     def _transform_value(self, value: torch.Tensor) -> torch.Tensor:
         return _transform_value(value, self.value_transform)

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -19,11 +19,18 @@ from tensordict.nn import TensorDictModule, TensorDictModuleBase, TensorDictPara
 from tensordict.utils import Buffer
 from torch import nn
 from torch.nn import Parameter
-
 from torchrl._utils import rl_warnings
 from torchrl.envs.utils import ExplorationType, set_exploration_type
 from torchrl.modules.tensordict_module.rnn import set_recurrent_mode
-from torchrl.objectives.utils import _reduce, default_value_kwargs, ValueEstimators
+from torchrl.modules.value_transforms import ValueTransform
+from torchrl.objectives.utils import (
+    _inverse_value_transform,
+    _reduce,
+    _transform_value,
+    _validate_value_transform,
+    default_value_kwargs,
+    ValueEstimators,
+)
 from torchrl.objectives.value import ValueEstimatorBase
 
 try:
@@ -762,6 +769,24 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
         if value_type is None:
             value_type = self.default_value_estimator
 
+        if hasattr(self, "value_transform"):
+            value_transform = self.value_transform
+            requested_transform = hyperparams.get("value_transform", value_transform)
+            if requested_transform is not value_transform:
+                raise ValueError(
+                    "The loss and its value estimator must use the same "
+                    "value_transform instance."
+                )
+            hyperparams["value_transform"] = value_transform
+
+            if isinstance(value_type, ValueEstimatorBase) and (
+                value_type.value_transform is not value_transform
+            ):
+                raise ValueError(
+                    "The loss and the provided value estimator must use the same "
+                    "value_transform instance."
+                )
+
         if isinstance(value_type, ValueEstimatorBase) or (
             isinstance(value_type, type) and issubclass(value_type, ValueEstimatorBase)
         ):
@@ -774,6 +799,15 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
             hp["gamma"] = self.gamma
         hp.update(hyperparams)
         return value_type, hp
+
+    def _set_value_transform(self, value_transform: ValueTransform | None) -> None:
+        self.value_transform = _validate_value_transform(value_transform)
+
+    def _transform_value(self, value: torch.Tensor) -> torch.Tensor:
+        return _transform_value(value, self.value_transform)
+
+    def _inverse_value_transform(self, value: torch.Tensor) -> torch.Tensor:
+        return _inverse_value_transform(value, self.value_transform)
 
     def register_coeff_buffer(
         self,
@@ -910,11 +944,28 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
             value_type = self.default_value_estimator
 
         if isinstance(value_type, ValueEstimatorBase):
+            if hasattr(self, "value_transform") and (
+                value_type.value_transform is not self.value_transform
+            ):
+                raise ValueError(
+                    "The loss and the provided value estimator must use the same "
+                    "value_transform instance."
+                )
             self._value_estimator = value_type
             self.value_type = type(value_type)
             return self
 
         if isinstance(value_type, type) and issubclass(value_type, ValueEstimatorBase):
+            if hasattr(self, "value_transform"):
+                requested_transform = hyperparams.get(
+                    "value_transform", self.value_transform
+                )
+                if requested_transform is not self.value_transform:
+                    raise ValueError(
+                        "The loss and its value estimator must use the same "
+                        "value_transform instance."
+                    )
+                hyperparams["value_transform"] = self.value_transform
             if "device" not in hyperparams:
                 device = self._default_device
                 if device is not None:

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass
 
@@ -36,6 +37,10 @@ class DDPGLoss(LossModule):
             remain in raw value space. Defaults to ``None``. See also
             :class:`~torchrl.modules.ValueOperator` and
             :class:`~torchrl.objectives.value.ValueEstimatorBase`.
+        priority_function (Callable[[Tensor, Tensor], Tensor], optional): a
+            callable that receives the critic prediction and Bellman target in
+            prediction space and returns their per-element replay priority.
+            Defaults to the squared residual used by DDPG.
         delay_actor (bool, optional): whether to separate the target actor networks from the actor networks used for
             data collection. Default is ``False``.
         delay_value (bool, optional): whether to separate the target value networks from the value networks used for
@@ -202,6 +207,8 @@ class DDPGLoss(LossModule):
         *,
         loss_function: str = "l2",
         value_transform: ValueTransform | None = None,
+        priority_function: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+        | None = None,
         delay_actor: bool = False,
         delay_value: bool = True,
         gamma: float | None = None,
@@ -214,6 +221,7 @@ class DDPGLoss(LossModule):
             reduction = "mean"
         super().__init__()
         self._set_value_transform(value_transform)
+        self._set_priority_function(priority_function)
         self.use_prioritized_weights = use_prioritized_weights
         self.delay_actor = delay_actor
         self.delay_value = delay_value
@@ -381,7 +389,12 @@ class DDPGLoss(LossModule):
             loss_function=self.loss_function,
         )
 
-        td_error = (pred_value_transformed - target_value_transformed).pow(2)
+        if self.priority_function is None:
+            td_error = (pred_value_transformed - target_value_transformed).pow(2)
+        else:
+            td_error = self.priority_function(
+                pred_value_transformed, target_value_transformed
+            )
         td_error = td_error.detach()
         if tensordict.device is not None:
             td_error = td_error.to(tensordict.device)

--- a/torchrl/objectives/ddpg.py
+++ b/torchrl/objectives/ddpg.py
@@ -12,8 +12,8 @@ import torch
 from tensordict import TensorDict, TensorDictBase, TensorDictParams
 from tensordict.nn import dispatch, TensorDictModule
 from tensordict.utils import NestedKey, unravel_key
-
 from torchrl.modules.tensordict_module.actors import ActorCriticWrapper
+from torchrl.modules.value_transforms import ValueTransform
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
@@ -31,6 +31,11 @@ class DDPGLoss(LossModule):
         actor_network (TensorDictModule): a policy operator.
         value_network (TensorDictModule): a Q value operator.
         loss_function (str): loss function for the value discrepancy. Can be one of "l1", "l2" or "smooth_l1".
+        value_transform (ValueTransform, optional): invertible transform used by
+            the critic prediction space. Bellman targets and actor objectives
+            remain in raw value space. Defaults to ``None``. See also
+            :class:`~torchrl.modules.ValueOperator` and
+            :class:`~torchrl.objectives.value.ValueEstimatorBase`.
         delay_actor (bool, optional): whether to separate the target actor networks from the actor networks used for
             data collection. Default is ``False``.
         delay_value (bool, optional): whether to separate the target value networks from the value networks used for
@@ -196,6 +201,7 @@ class DDPGLoss(LossModule):
         value_network: TensorDictModule,
         *,
         loss_function: str = "l2",
+        value_transform: ValueTransform | None = None,
         delay_actor: bool = False,
         delay_value: bool = True,
         gamma: float | None = None,
@@ -207,6 +213,7 @@ class DDPGLoss(LossModule):
         if reduction is None:
             reduction = "mean"
         super().__init__()
+        self._set_value_transform(value_transform)
         self.use_prioritized_weights = use_prioritized_weights
         self.delay_actor = delay_actor
         self.delay_value = delay_value
@@ -331,7 +338,8 @@ class DDPGLoss(LossModule):
             self.value_network, preserve_module_state=False
         ):
             td_copy = self.value_network(td_copy)
-        loss_actor = -td_copy.get(self.tensor_keys.state_action_value).squeeze(-1)
+        value = td_copy.get(self.tensor_keys.state_action_value).squeeze(-1)
+        loss_actor = -self._inverse_value_transform(value)
         metadata = {}
         loss_actor = self._reduce_loss(
             loss_actor, tensordict=tensordict, weights=weights
@@ -357,18 +365,23 @@ class DDPGLoss(LossModule):
             self.value_network, preserve_module_state=False
         ):
             self.value_network(td_copy)
-        pred_val = td_copy.get(self.tensor_keys.state_action_value).squeeze(-1)
+        pred_value_transformed = td_copy.get(
+            self.tensor_keys.state_action_value
+        ).squeeze(-1)
+        pred_value = self._inverse_value_transform(pred_value_transformed)
 
         target_value = self.value_estimator.value_estimate(
             tensordict, target_params=self._cached_target_params
         ).squeeze(-1)
+        target_value_transformed = self._transform_value(target_value)
 
-        # td_error = pred_val - target_value
         loss_value = distance_loss(
-            pred_val, target_value, loss_function=self.loss_function
+            pred_value_transformed,
+            target_value_transformed,
+            loss_function=self.loss_function,
         )
 
-        td_error = (pred_val - target_value).pow(2)
+        td_error = (pred_value_transformed - target_value_transformed).pow(2)
         td_error = td_error.detach()
         if tensordict.device is not None:
             td_error = td_error.to(tensordict.device)
@@ -380,10 +393,10 @@ class DDPGLoss(LossModule):
         with torch.no_grad():
             metadata = {
                 "td_error": td_error,
-                "pred_value": pred_val,
+                "pred_value": pred_value,
                 "target_value": target_value,
                 "target_value_max": target_value.max(),
-                "pred_value_max": pred_val.max(),
+                "pred_value_max": pred_value.max(),
             }
         loss_value = self._reduce_loss(
             loss_value, tensordict=tensordict, weights=weights

--- a/torchrl/objectives/multiagent/mappo.py
+++ b/torchrl/objectives/multiagent/mappo.py
@@ -13,13 +13,13 @@ References:
     - de Witt, C. S. et al. *Is Independent Learning All You Need in the
       StarCraft Multi-Agent Challenge?* 2020. https://arxiv.org/abs/2011.09533
 """
+
 from __future__ import annotations
 
 from typing import Any
 
 from tensordict.nn import TensorDictModule
 from tensordict.nn.probabilistic import ProbabilisticTensorDictSequential
-
 from torchrl.modules.value_norm import ValueNorm
 from torchrl.objectives.ppo import ClipPPOLoss
 from torchrl.objectives.utils import ValueEstimators
@@ -204,6 +204,11 @@ class MAPPOLoss(_MultiAgentPPOMixin, ClipPPOLoss):
             normalize_advantage_exclude_dims=normalize_advantage_exclude_dims,
             **kwargs,
         )
+        if value_norm is not None and self.value_transform is not None:
+            raise ValueError(
+                "value_transform and value_norm cannot be used together. "
+                "Choose one critic scaling strategy."
+            )
         # ``nn.Module.__setattr__`` registers the ``ValueNorm`` as a child
         # module automatically, so ``.to(device)`` / ``state_dict()`` / etc.
         # pick it up without us calling ``add_module`` a second time.

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -27,9 +27,9 @@ from tensordict.nn import (
 )
 from tensordict.utils import NestedKey
 from torch import distributions as d
-
 from torchrl._utils import _standardize, logger as torchrl_logger, VERBOSE
 from torchrl.modules.distributions.utils import composite_entropy, sample_and_log_prob
+from torchrl.modules.value_transforms import ValueTransform
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
@@ -168,6 +168,11 @@ class PPOLoss(LossModule):
             loss from the forward outputs.
         loss_critic_type (str, optional): loss function for the value discrepancy.
             Can be one of "l1", "l2" or "smooth_l1". Defaults to ``"smooth_l1"``.
+        value_transform (ValueTransform, optional): invertible transform used by
+            the critic prediction space. Returns, advantages, value clipping,
+            and diagnostics remain in raw value space. Defaults to ``None``.
+            See also :class:`~torchrl.modules.ValueOperator` and
+            :class:`~torchrl.objectives.value.ValueEstimatorBase`.
         normalize_advantage (bool, optional): if ``True``, the advantage will be normalized
             before being used. Defaults to ``False``.
         normalize_advantage_exclude_dims (Tuple[int], optional): dimensions to exclude from the advantage
@@ -471,6 +476,7 @@ class PPOLoss(LossModule):
         log_explained_variance: bool = True,
         critic_coeff: float | None = None,
         loss_critic_type: str = "smooth_l1",
+        value_transform: ValueTransform | None = None,
         normalize_advantage: bool = False,
         normalize_advantage_exclude_dims: tuple[int] = (),
         gamma: float | None = None,
@@ -517,6 +523,7 @@ class PPOLoss(LossModule):
         self._in_keys = None
         self._out_keys = None
         super().__init__()
+        self._set_value_transform(value_transform)
         if functional:
             self.convert_to_functional(actor_network, "actor_network")
         else:
@@ -859,13 +866,22 @@ class PPOLoss(LossModule):
                 f"Make sure that the 'value_key' passed to PPO is accurate."
             )
 
-        # Subclass hook: lets e.g. MAPPOLoss inject PopArt-style value
-        # normalisation uniformly across target_return / state_value /
-        # old_state_value so the MSE and the clip radius both live in
-        # normalised space.
-        target_return, state_value, old_state_value = self._critic_loss_inputs(
-            target_return, state_value, old_state_value
-        )
+        if self.value_transform is None:
+            # Subclass hook: lets e.g. MAPPOLoss inject PopArt-style value
+            # normalisation uniformly across target_return / state_value /
+            # old_state_value so the MSE and the clip radius both live in
+            # normalised space.
+            target_return, state_value, old_state_value = self._critic_loss_inputs(
+                target_return, state_value, old_state_value
+            )
+            target_return_raw = target_return
+            state_value_raw = state_value
+        else:
+            target_return_raw = target_return
+            state_value_raw = self._inverse_value_transform(state_value)
+            if old_state_value is not None:
+                old_state_value = self._inverse_value_transform(old_state_value)
+            target_return = self._transform_value(target_return_raw)
 
         loss_value = distance_loss(
             target_return,
@@ -877,18 +893,19 @@ class PPOLoss(LossModule):
         if self.clip_value:
             loss_value, clip_fraction = _clip_value_loss(
                 old_state_value,
-                state_value,
+                state_value_raw,
                 self.clip_value,
                 target_return,
                 loss_value,
                 self.loss_critic_type,
+                value_transform=self.value_transform,
             )
 
         explained_variance = None
         if self.log_explained_variance:
             with torch.no_grad():  # <‑‑ break grad‐flow
-                tgt = target_return.detach()
-                pred = state_value.detach()
+                tgt = target_return_raw.detach()
+                pred = state_value_raw.detach()
                 eps = torch.finfo(tgt.dtype).eps
 
                 resid = torch.var(tgt - pred, correction=0, dim=0)
@@ -991,9 +1008,11 @@ class PPOLoss(LossModule):
             if explained_variance is not None:
                 td_out.set("explained_variance", explained_variance)
         td_out = td_out.named_apply(
-            lambda name, value: self._reduce_loss(value, tensordict).squeeze(-1)
-            if name.startswith("loss_")
-            else value,
+            lambda name, value: (
+                self._reduce_loss(value, tensordict).squeeze(-1)
+                if name.startswith("loss_")
+                else value
+            ),
         )
         self._clear_weakrefs(
             tensordict,
@@ -1134,6 +1153,9 @@ class ClipPPOLoss(PPOLoss):
             loss from the forward outputs.
         loss_critic_type (str, optional): loss function for the value discrepancy.
             Can be one of "l1", "l2" or "smooth_l1". Defaults to ``"smooth_l1"``.
+        value_transform (ValueTransform, optional): invertible transform used by
+            the critic prediction space. Returns, advantages, value clipping,
+            and diagnostics remain in raw value space. Defaults to ``None``.
         normalize_advantage (bool, optional): if ``True``, the advantage will be normalized
             before being used. Defaults to ``False``.
         normalize_advantage_exclude_dims (Tuple[int], optional): dimensions to exclude from the advantage
@@ -1238,6 +1260,7 @@ class ClipPPOLoss(PPOLoss):
         entropy_coeff: float | Mapping[NestedKey, float] | None = None,
         critic_coeff: float | None = None,
         loss_critic_type: str = "smooth_l1",
+        value_transform: ValueTransform | None = None,
         normalize_advantage: bool = False,
         normalize_advantage_exclude_dims: tuple[int] = (),
         gamma: float | None = None,
@@ -1265,6 +1288,7 @@ class ClipPPOLoss(PPOLoss):
             entropy_coeff=entropy_coeff,
             critic_coeff=critic_coeff,
             loss_critic_type=loss_critic_type,
+            value_transform=value_transform,
             normalize_advantage=normalize_advantage,
             normalize_advantage_exclude_dims=normalize_advantage_exclude_dims,
             gamma=gamma,
@@ -1440,9 +1464,11 @@ class ClipPPOLoss(PPOLoss):
             td_out.set("max_ratio", ratio.max())
             td_out.set("mean_ratio", ratio.mean())
         td_out = td_out.named_apply(
-            lambda name, value: self._reduce_loss(value, tensordict).squeeze(-1)
-            if name.startswith("loss_")
-            else value,
+            lambda name, value: (
+                self._reduce_loss(value, tensordict).squeeze(-1)
+                if name.startswith("loss_")
+                else value
+            ),
         )
         self._clear_weakrefs(
             tensordict,
@@ -1495,6 +1521,9 @@ class KLPENPPOLoss(PPOLoss):
             loss. Defaults to ``1.0``.
         loss_critic_type (str, optional): loss function for the value discrepancy.
             Can be one of "l1", "l2" or "smooth_l1". Defaults to ``"smooth_l1"``.
+        value_transform (ValueTransform, optional): invertible transform used by
+            the critic prediction space. Returns, advantages, value clipping,
+            and diagnostics remain in raw value space. Defaults to ``None``.
         normalize_advantage (bool, optional): if ``True``, the advantage will be normalized
             before being used. Defaults to ``False``.
         normalize_advantage_exclude_dims (Tuple[int], optional): dimensions to exclude from the advantage
@@ -1598,6 +1627,7 @@ class KLPENPPOLoss(PPOLoss):
         entropy_coeff: float | Mapping[NestedKey, float] | None = None,
         critic_coeff: float | None = None,
         loss_critic_type: str = "smooth_l1",
+        value_transform: ValueTransform | None = None,
         normalize_advantage: bool = False,
         normalize_advantage_exclude_dims: tuple[int] = (),
         gamma: float | None = None,
@@ -1615,6 +1645,7 @@ class KLPENPPOLoss(PPOLoss):
             entropy_coeff=entropy_coeff,
             critic_coeff=critic_coeff,
             loss_critic_type=loss_critic_type,
+            value_transform=value_transform,
             normalize_advantage=normalize_advantage,
             normalize_advantage_exclude_dims=normalize_advantage_exclude_dims,
             gamma=gamma,
@@ -1801,9 +1832,11 @@ class KLPENPPOLoss(PPOLoss):
             if explained_variance is not None:
                 td_out.set("explained_variance", explained_variance)
         td_out = td_out.named_apply(
-            lambda name, value: self._reduce_loss(value, tensordict_copy).squeeze(-1)
-            if name.startswith("loss_")
-            else value,
+            lambda name, value: (
+                self._reduce_loss(value, tensordict_copy).squeeze(-1)
+                if name.startswith("loss_")
+                else value
+            ),
         )
         self._clear_weakrefs(
             tensordict,

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import math
 import warnings
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import wraps
 from numbers import Number
@@ -93,6 +94,11 @@ class SACLoss(LossModule):
             terms, and actor objectives remain in raw value space. Defaults to
             ``None``. See also :class:`~torchrl.modules.ValueOperator` and
             :class:`~torchrl.objectives.value.ValueEstimatorBase`.
+        priority_function (Callable[[Tensor, Tensor], Tensor], optional): a
+            callable that receives each Q-value prediction and its Bellman
+            target in prediction space and returns their per-element replay
+            priority. Defaults to the existing squared residual for SAC v1 and
+            absolute residual for SAC v2.
         loss_function (str, optional): loss function to be used with
             the value function loss. Default is `"smooth_l1"`.
         alpha_init (:obj:`float`, optional): initial entropy multiplier.
@@ -332,6 +338,7 @@ class SACLoss(LossModule):
         num_qvalue_nets: int = 2,
         loss_function: str = "smooth_l1",
         value_transform: ValueTransform | None = None,
+        priority_function: Callable[[Tensor, Tensor], Tensor] | None = None,
         alpha_init: float = 1.0,
         min_alpha: float | None = None,
         max_alpha: float | None = None,
@@ -356,6 +363,7 @@ class SACLoss(LossModule):
             reduction = "mean"
         super().__init__()
         self._set_value_transform(value_transform)
+        self._set_priority_function(priority_function)
         self.use_prioritized_weights = use_prioritized_weights
         self._set_deprecated_ctor_keys(priority_key=priority_key)
 
@@ -828,7 +836,11 @@ class SACLoss(LossModule):
         loss_value = self._reduce_loss(
             loss_value, tensordict=tensordict, weights=weights
         )
-        metadata = {"td_error": (pred_val - target_chunks).pow(2).flatten(0, 1)}
+        if self.priority_function is None:
+            td_error = (pred_val - target_chunks).pow(2)
+        else:
+            td_error = self.priority_function(pred_val, target_chunks)
+        metadata = {"td_error": td_error.flatten(0, 1)}
 
         return loss_value, metadata
 
@@ -925,10 +937,16 @@ class SACLoss(LossModule):
         pred_val = tensordict_expand.get(self.tensor_keys.state_action_value).squeeze(
             -1
         )
-        td_error = abs(pred_val - target_value_transformed)
+        target_value_transformed_expanded = target_value_transformed.expand_as(pred_val)
+        if self.priority_function is None:
+            td_error = abs(pred_val - target_value_transformed_expanded)
+        else:
+            td_error = self.priority_function(
+                pred_val, target_value_transformed_expanded
+            )
         loss_qval = distance_loss(
             pred_val,
-            target_value_transformed.expand_as(pred_val),
+            target_value_transformed_expanded,
             loss_function=self.loss_function,
         ).sum(0)
         loss_qval = self._reduce_loss(loss_qval, tensordict=tensordict, weights=weights)

--- a/torchrl/objectives/sac.py
+++ b/torchrl/objectives/sac.py
@@ -22,12 +22,12 @@ from tensordict.nn import (
 )
 from tensordict.utils import expand_right, NestedKey
 from torch import Tensor
-
 from torchrl.data.tensor_specs import Composite, TensorSpec
 from torchrl.data.utils import _find_action_space
 from torchrl.envs.utils import ExplorationType, set_exploration_type
 from torchrl.modules.distributions.utils import rsample_and_log_prob
 from torchrl.modules.tensordict_module.actors import ActorCriticWrapper
+from torchrl.modules.value_transforms import ValueTransform
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
@@ -88,6 +88,11 @@ class SACLoss(LossModule):
     Keyword Args:
         num_qvalue_nets (integer, optional): number of Q-Value networks used.
             Defaults to ``2``.
+        value_transform (ValueTransform, optional): invertible transform used by
+            the Q- and V-network prediction spaces. Bellman targets, entropy
+            terms, and actor objectives remain in raw value space. Defaults to
+            ``None``. See also :class:`~torchrl.modules.ValueOperator` and
+            :class:`~torchrl.objectives.value.ValueEstimatorBase`.
         loss_function (str, optional): loss function to be used with
             the value function loss. Default is `"smooth_l1"`.
         alpha_init (:obj:`float`, optional): initial entropy multiplier.
@@ -326,6 +331,7 @@ class SACLoss(LossModule):
         *,
         num_qvalue_nets: int = 2,
         loss_function: str = "smooth_l1",
+        value_transform: ValueTransform | None = None,
         alpha_init: float = 1.0,
         min_alpha: float | None = None,
         max_alpha: float | None = None,
@@ -349,6 +355,7 @@ class SACLoss(LossModule):
         if reduction is None:
             reduction = "mean"
         super().__init__()
+        self._set_value_transform(value_transform)
         self.use_prioritized_weights = use_prioritized_weights
         self._set_deprecated_ctor_keys(priority_key=priority_key)
 
@@ -718,10 +725,11 @@ class SACLoss(LossModule):
         self, tensordict: TensorDictBase
     ) -> tuple[Tensor, dict[str, Tensor]]:
         weights = self._maybe_get_priority_weight(tensordict)
-        with set_exploration_type(
-            ExplorationType.RANDOM
-        ), self.actor_network_params.to_module(
-            self.actor_network, preserve_module_state=False
+        with (
+            set_exploration_type(ExplorationType.RANDOM),
+            self.actor_network_params.to_module(
+                self.actor_network, preserve_module_state=False
+            ),
         ):
             dist = self.actor_network.get_dist(tensordict)
             a_reparm, log_prob = compute_rsample_log_prob(dist)
@@ -732,9 +740,10 @@ class SACLoss(LossModule):
             td_q,
             self._cached_detached_qvalue_params,  # should we clone?
         )
-        min_q_logprob = (
-            td_q.get(self.tensor_keys.state_action_value).min(0)[0].squeeze(-1)
+        q_value = self._inverse_value_transform(
+            td_q.get(self.tensor_keys.state_action_value)
         )
+        min_q_logprob = q_value.min(0)[0].squeeze(-1)
 
         if log_prob.shape != min_q_logprob.shape:
             raise RuntimeError(
@@ -790,6 +799,7 @@ class SACLoss(LossModule):
             target_value = self.value_estimator.value_estimate(
                 tensordict, target_params=target_params
             ).squeeze(-1)
+        target_value_transformed = self._transform_value(target_value)
 
         # Q-nets must be trained independently: as such, we split the data in 2
         # if required and train each q-net on one half of the data.
@@ -802,8 +812,8 @@ class SACLoss(LossModule):
         tensordict_chunks = tensordict.reshape(
             self.num_qvalue_nets, -1, *tensordict.shape[1:]
         )
-        target_chunks = target_value.reshape(
-            self.num_qvalue_nets, -1, *target_value.shape[1:]
+        target_chunks = target_value_transformed.reshape(
+            self.num_qvalue_nets, -1, *target_value_transformed.shape[1:]
         )
 
         # if vmap=True, it is assumed that the input tensordict must be cast to the param shape
@@ -837,10 +847,11 @@ class SACLoss(LossModule):
         tensordict = tensordict.clone(False)
         # get actions and log-probs
         with torch.no_grad():
-            with set_exploration_type(
-                ExplorationType.RANDOM
-            ), self.actor_network_params.to_module(
-                self.actor_network, preserve_module_state=False
+            with (
+                set_exploration_type(ExplorationType.RANDOM),
+                self.actor_network_params.to_module(
+                    self.actor_network, preserve_module_state=False
+                ),
             ):
                 next_tensordict = tensordict.get("next").copy()
                 if self.skip_done_states:
@@ -884,8 +895,8 @@ class SACLoss(LossModule):
             next_tensordict_expand = self._vmap_qnetworkN0(
                 next_tensordict, self.target_qvalue_network_params
             )
-            state_action_value = next_tensordict_expand.get(
-                self.tensor_keys.state_action_value
+            state_action_value = self._inverse_value_transform(
+                next_tensordict_expand.get(self.tensor_keys.state_action_value)
             )
             if (
                 state_action_value.shape[-len(next_sample_log_prob.shape) :]
@@ -894,10 +905,9 @@ class SACLoss(LossModule):
                 next_sample_log_prob = next_sample_log_prob.unsqueeze(-1)
             next_state_value = state_action_value - self._alpha * next_sample_log_prob
             next_state_value = next_state_value.min(0)[0]
-            tensordict.set(
-                ("next", self.value_estimator.tensor_keys.value), next_state_value
-            )
-            target_value = self.value_estimator.value_estimate(tensordict).squeeze(-1)
+            target_value = self.value_estimator.value_estimate(
+                tensordict, next_value=next_state_value
+            ).squeeze(-1)
             return target_value
 
     def qvalue_v2_loss(
@@ -906,6 +916,7 @@ class SACLoss(LossModule):
         weights = self._maybe_get_priority_weight(tensordict)
         # we pass the alpha value to the tensordict. Since it's a scalar, we must erase the batch-size first.
         target_value = self._compute_target_v2(tensordict)
+        target_value_transformed = self._transform_value(target_value)
 
         tensordict_expand = self._vmap_qnetworkN0(
             tensordict.select(*self.qvalue_network.in_keys, strict=False),
@@ -914,10 +925,10 @@ class SACLoss(LossModule):
         pred_val = tensordict_expand.get(self.tensor_keys.state_action_value).squeeze(
             -1
         )
-        td_error = abs(pred_val - target_value)
+        td_error = abs(pred_val - target_value_transformed)
         loss_qval = distance_loss(
             pred_val,
-            target_value.expand_as(pred_val),
+            target_value_transformed.expand_as(pred_val),
             loss_function=self.loss_function,
         ).sum(0)
         loss_qval = self._reduce_loss(loss_qval, tensordict=tensordict, weights=weights)
@@ -948,15 +959,17 @@ class SACLoss(LossModule):
             self.target_qvalue_network_params,
         )
 
-        min_qval = (
-            td_copy.get(self.tensor_keys.state_action_value).squeeze(-1).min(0)[0]
+        q_value = self._inverse_value_transform(
+            td_copy.get(self.tensor_keys.state_action_value)
         )
+        min_qval = q_value.squeeze(-1).min(0)[0]
 
         if log_p.shape != min_qval.shape:
             raise RuntimeError(
                 f"Losses shape mismatch: {min_qval.shape} and {log_p.shape}"
             )
         target_val = min_qval - self._alpha * log_p
+        target_val = self._transform_value(target_val)
 
         loss_value = distance_loss(
             pred_val, target_val, loss_function=self.loss_function

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -10,9 +10,9 @@ import torch
 from tensordict import TensorDict, TensorDictBase, TensorDictParams
 from tensordict.nn import dispatch, TensorDictModule
 from tensordict.utils import NestedKey
-
 from torchrl.data.tensor_specs import Bounded, Composite, TensorSpec
 from torchrl.envs.utils import step_mdp
+from torchrl.modules.value_transforms import ValueTransform
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _cache_values,
@@ -57,6 +57,11 @@ class TD3Loss(LossModule):
         loss_function (str, optional): loss function to be used for the Q-value.
             Can be one of  ``"smooth_l1"``, ``"l2"``,
             ``"l1"``, Default is ``"smooth_l1"``.
+        value_transform (ValueTransform, optional): invertible transform used by
+            the critic prediction space. Bellman targets and actor objectives
+            remain in raw value space. Defaults to ``None``. See also
+            :class:`~torchrl.modules.ValueOperator` and
+            :class:`~torchrl.objectives.value.ValueEstimatorBase`.
         delay_actor (bool, optional): whether to separate the target actor
             networks from the actor networks used for
             data collection. Default is ``True``.
@@ -232,6 +237,7 @@ class TD3Loss(LossModule):
         policy_noise: float = 0.2,
         noise_clip: float = 0.5,
         loss_function: str = "smooth_l1",
+        value_transform: ValueTransform | None = None,
         delay_actor: bool = True,
         delay_qvalue: bool = True,
         gamma: float | None = None,
@@ -244,6 +250,7 @@ class TD3Loss(LossModule):
         if reduction is None:
             reduction = "mean"
         super().__init__()
+        self._set_value_transform(value_transform)
         self.use_prioritized_weights = use_prioritized_weights
         self._in_keys = None
         self._set_deprecated_ctor_keys(priority=priority_key)
@@ -393,13 +400,16 @@ class TD3Loss(LossModule):
         ).expand(
             self.num_qvalue_nets, *tensordict_actor_grad.batch_size
         )  # for actor loss
-        state_action_value_actor = (
+        state_action_value_actor_transformed = (
             self._vmap_qvalue_network00(
                 actor_loss_td,
                 self._cached_detach_qvalue_network_params,
             )
             .get(self.tensor_keys.state_action_value)
             .squeeze(-1)
+        )
+        state_action_value_actor = self._inverse_value_transform(
+            state_action_value_actor_transformed
         )
         loss_actor = -(state_action_value_actor[0])
         metadata = {
@@ -448,7 +458,7 @@ class TD3Loss(LossModule):
             ).expand(
                 self.num_qvalue_nets, *next_td_actor.batch_size
             )  # for next value estimation
-            next_target_q1q2 = (
+            next_target_q1q2_transformed = (
                 self._vmap_qvalue_network00(
                     next_val_td,
                     self.target_qvalue_network_params,
@@ -456,21 +466,18 @@ class TD3Loss(LossModule):
                 .get(self.tensor_keys.state_action_value)
                 .squeeze(-1)
             )
+            next_target_q1q2 = self._inverse_value_transform(
+                next_target_q1q2_transformed
+            )
         # min over the next target qvalues
         next_target_qvalue = next_target_q1q2.min(0)[0]
-
-        # set next target qvalues
-        tensordict.set(
-            ("next", self.tensor_keys.state_action_value),
-            next_target_qvalue.unsqueeze(-1),
-        )
 
         qval_td = tensordict.select(*self.qvalue_network.in_keys, strict=False).expand(
             self.num_qvalue_nets,
             *tensordict.batch_size,
         )
         # preditcted current qvalues
-        current_qvalue = (
+        current_qvalue_transformed = (
             self._vmap_qvalue_network00(
                 qval_td,
                 self.qvalue_network_params,
@@ -478,14 +485,18 @@ class TD3Loss(LossModule):
             .get(self.tensor_keys.state_action_value)
             .squeeze(-1)
         )
+        current_qvalue = self._inverse_value_transform(current_qvalue_transformed)
 
         # compute target values for the qvalue loss (reward + gamma * next_target_qvalue * (1 - done))
-        target_value = self.value_estimator.value_estimate(tensordict).squeeze(-1)
+        target_value = self.value_estimator.value_estimate(
+            tensordict, next_value=next_target_qvalue.unsqueeze(-1)
+        ).squeeze(-1)
+        target_value_transformed = self._transform_value(target_value)
 
-        td_error = (current_qvalue - target_value).pow(2)
+        td_error = (current_qvalue_transformed - target_value_transformed).pow(2)
         loss_qval = distance_loss(
-            current_qvalue,
-            target_value.expand_as(current_qvalue),
+            current_qvalue_transformed,
+            target_value_transformed.expand_as(current_qvalue_transformed),
             loss_function=self.loss_function,
         ).sum(0)
         metadata = {

--- a/torchrl/objectives/td3.py
+++ b/torchrl/objectives/td3.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import torch
@@ -62,6 +63,10 @@ class TD3Loss(LossModule):
             remain in raw value space. Defaults to ``None``. See also
             :class:`~torchrl.modules.ValueOperator` and
             :class:`~torchrl.objectives.value.ValueEstimatorBase`.
+        priority_function (Callable[[Tensor, Tensor], Tensor], optional): a
+            callable that receives each critic prediction and the Bellman target
+            in prediction space and returns their per-element replay priority.
+            Defaults to the squared residual used by TD3.
         delay_actor (bool, optional): whether to separate the target actor
             networks from the actor networks used for
             data collection. Default is ``True``.
@@ -238,6 +243,8 @@ class TD3Loss(LossModule):
         noise_clip: float = 0.5,
         loss_function: str = "smooth_l1",
         value_transform: ValueTransform | None = None,
+        priority_function: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+        | None = None,
         delay_actor: bool = True,
         delay_qvalue: bool = True,
         gamma: float | None = None,
@@ -251,6 +258,7 @@ class TD3Loss(LossModule):
             reduction = "mean"
         super().__init__()
         self._set_value_transform(value_transform)
+        self._set_priority_function(priority_function)
         self.use_prioritized_weights = use_prioritized_weights
         self._in_keys = None
         self._set_deprecated_ctor_keys(priority=priority_key)
@@ -493,10 +501,20 @@ class TD3Loss(LossModule):
         ).squeeze(-1)
         target_value_transformed = self._transform_value(target_value)
 
-        td_error = (current_qvalue_transformed - target_value_transformed).pow(2)
+        target_value_transformed_expanded = target_value_transformed.expand_as(
+            current_qvalue_transformed
+        )
+        if self.priority_function is None:
+            td_error = (
+                current_qvalue_transformed - target_value_transformed_expanded
+            ).pow(2)
+        else:
+            td_error = self.priority_function(
+                current_qvalue_transformed, target_value_transformed_expanded
+            )
         loss_qval = distance_loss(
             current_qvalue_transformed,
-            target_value_transformed.expand_as(current_qvalue_transformed),
+            target_value_transformed_expanded,
             loss_function=self.loss_function,
         ).sum(0)
         metadata = {

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -30,6 +30,7 @@ except ImportError as err:
         raise err_ft from err
 from torchrl._utils import implement_for
 from torchrl.envs.utils import step_mdp
+from torchrl.modules.value_transforms import ValueTransform
 
 try:
     from torch.compiler import is_dynamo_compiling
@@ -41,6 +42,32 @@ _GAMMA_LMBDA_DEPREC_ERROR = (
     "is a deprecated feature. To customize your value function, "
     "run `loss_module.make_value_estimator(ValueEstimators.<value_fun>, gamma=val)`."
 )
+
+
+def _validate_value_transform(
+    value_transform: ValueTransform | None,
+) -> ValueTransform | None:
+    if value_transform is not None and not isinstance(value_transform, ValueTransform):
+        raise TypeError(
+            "value_transform must be a ValueTransform instance or None, got "
+            f"{type(value_transform).__name__}."
+        )
+    return value_transform
+
+
+def _transform_value(value: Tensor, value_transform: ValueTransform | None) -> Tensor:
+    if value_transform is None:
+        return value
+    return value_transform(value)
+
+
+def _inverse_value_transform(
+    value: Tensor, value_transform: ValueTransform | None
+) -> Tensor:
+    if value_transform is None:
+        return value
+    return value_transform.inverse(value)
+
 
 RANDOM_MODULE_LIST = (dropout._DropoutNd,)
 
@@ -939,6 +966,7 @@ def _clip_value_loss(
     target_return: torch.Tensor | TensorDict,
     loss_value: torch.Tensor | TensorDict,
     loss_critic_type: str,
+    value_transform: ValueTransform | None = None,
 ) -> tuple[torch.Tensor | TensorDict, torch.Tensor]:
     """Value clipping method for loss computation.
 
@@ -951,6 +979,7 @@ def _clip_value_loss(
     with torch.no_grad():
         clip_fraction = (pre_clipped != clipped).to(state_value.dtype).mean()
     state_value_clipped = old_state_value + clipped
+    state_value_clipped = _transform_value(state_value_clipped, value_transform)
     loss_value_clipped = distance_loss(
         target_return,
         state_value_clipped,
@@ -962,7 +991,7 @@ def _clip_value_loss(
 
 
 def _validate_clip_epsilon(
-    clip_epsilon: float | tuple[float, float]
+    clip_epsilon: float | tuple[float, float],
 ) -> tuple[float, float]:
     """Normalize and validate a PPO clip threshold.
 

--- a/torchrl/objectives/value/advantages.py
+++ b/torchrl/objectives/value/advantages.py
@@ -28,13 +28,16 @@ from tensordict.nn import (
 from tensordict.nn.probabilistic import interaction_type
 from tensordict.utils import NestedKey, unravel_key
 from torch import Tensor
-
 from torchrl._utils import logger, rl_warnings
 from torchrl.envs.utils import step_mdp
 from torchrl.modules.distributions.utils import sample_and_log_prob
+from torchrl.modules.value_transforms import ValueTransform
 from torchrl.objectives.utils import (
+    _inverse_value_transform,
     _maybe_get_or_select,
     _pseudo_vmap,
+    _transform_value,
+    _validate_value_transform,
     _vmap_func,
     hold_out_net,
     register_value_estimator,
@@ -118,6 +121,12 @@ class ValueEstimatorBase(TensorDictModuleBase):
     should be used instead.
 
     Keyword Args:
+        value_transform (ValueTransform, optional): invert value-network outputs
+            from prediction space before return and advantage arithmetic.
+            Stored value keys remain in prediction space; ``advantage`` and
+            ``value_target`` are written in raw reward-return units. Explicit
+            ``next_value=`` arguments are also interpreted as raw values.
+            Defaults to ``None``.
         value_chunk_size (int, optional): if set, splits value-network calls
             into chunks of this many elements along ``value_chunk_dim``.
             Defaults to ``None``.
@@ -133,6 +142,12 @@ class ValueEstimatorBase(TensorDictModuleBase):
             used when ``shifted=True``. ``1`` uses a ``T+1``
             budget, ``2`` can represent one internal reset plus the rollout
             boundary without dropping samples, and so on. Defaults to ``1``.
+
+    .. seealso::
+        :class:`~torchrl.modules.ValueTransform` for prediction-space
+        transforms, :class:`~torchrl.modules.ValueOperator` for the network
+        output contract, and :class:`~torchrl.objectives.PPOLoss` for an
+        on-policy consumer.
 
     """
 
@@ -291,6 +306,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
         advantage_key: NestedKey = None,
         value_target_key: NestedKey = None,
         value_key: NestedKey = None,
+        value_transform: ValueTransform | None = None,
         device: torch.device | None = None,
         deactivate_vmap: bool = False,
         value_chunk_size: int | None = None,
@@ -306,6 +322,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
         # init.
         self._device = device
         self._tensor_keys = None
+        self.value_transform = _validate_value_transform(value_transform)
         self.differentiable = differentiable
         self.deactivate_vmap = deactivate_vmap
         self.value_chunk_size = self._check_positive_int(
@@ -331,6 +348,7 @@ class ValueEstimatorBase(TensorDictModuleBase):
             raise RuntimeError(
                 "Setting 'advantage_key' via constructor is deprecated, use .set_keys(advantage_key='some_key') instead.",
             )
+
         if value_target_key is not None:
             raise RuntimeError(
                 "Setting 'value_target_key' via constructor is deprecated, use .set_keys(value_target_key='some_key') instead.",
@@ -339,6 +357,12 @@ class ValueEstimatorBase(TensorDictModuleBase):
             raise RuntimeError(
                 "Setting 'value_key' via constructor is deprecated, use .set_keys(value_key='some_key') instead.",
             )
+
+    def _transform_value(self, value: Tensor) -> Tensor:
+        return _transform_value(value, self.value_transform)
+
+    def _inverse_value_transform(self, value: Tensor) -> Tensor:
+        return _inverse_value_transform(value, self.value_transform)
 
     @staticmethod
     def _check_positive_int(value: int | None, name: str) -> int | None:
@@ -410,14 +434,21 @@ class ValueEstimatorBase(TensorDictModuleBase):
 
     @property
     def in_keys(self):
+        transition_keys = [
+            ("next", self.tensor_keys.reward),
+            ("next", self.tensor_keys.done),
+            ("next", self.tensor_keys.terminated),
+        ]
+        if self.value_network is None:
+            return [
+                self.tensor_keys.value,
+                ("next", self.tensor_keys.value),
+                *transition_keys,
+            ]
         try:
             in_keys = (
                 self.value_network.in_keys
-                + [
-                    ("next", self.tensor_keys.reward),
-                    ("next", self.tensor_keys.done),
-                    ("next", self.tensor_keys.terminated),
-                ]
+                + transition_keys
                 + [("next", in_key) for in_key in self.value_network.in_keys]
             )
         except AttributeError:
@@ -485,7 +516,8 @@ class ValueEstimatorBase(TensorDictModuleBase):
             target_params (TensorDictBase, optional): A nested TensorDict containing the
                 target params to be passed to the functional value network module.
             next_value (torch.Tensor, optional): the value of the next state
-                or state-action pair. Exclusive with ``target_params``.
+                or state-action pair in raw reward-return units, even when
+                ``value_transform`` is set. Exclusive with ``target_params``.
             **kwargs: the keyword arguments to be passed to the value network.
 
         Returns: a tensor corresponding to the state value.
@@ -504,10 +536,12 @@ class ValueEstimatorBase(TensorDictModuleBase):
     def _next_value(self, tensordict, target_params, kwargs):
         step_td = step_mdp(tensordict, keep_other=False)
         if self.value_network is not None:
-            with hold_out_net(
-                self.value_network
-            ) if target_params is None else target_params.to_module(
-                self.value_network, preserve_module_state=False
+            with (
+                hold_out_net(self.value_network)
+                if target_params is None
+                else target_params.to_module(
+                    self.value_network, preserve_module_state=False
+                )
             ):
                 self.value_network(step_td)
         next_value = step_td.get(self.tensor_keys.value)
@@ -1025,6 +1059,10 @@ class TD0Estimator(ValueEstimatorBase):
             of the advantage entry.  Defaults to ``"value_target"``.
         value_key (str or tuple of str, optional): [Deprecated] the value key to
             read from the input tensordict.  Defaults to ``"state_value"``.
+        value_transform (ValueTransform, optional): invert value predictions
+            before TD arithmetic. The stored value keys stay transformed and
+            the returned targets and advantages use raw units. Defaults to
+            ``None``.
         device (torch.device, optional): the device where the buffers will be instantiated.
             Defaults to ``torch.get_default_device()``.
         deactivate_vmap (bool, optional): whether to deactivate vmap calls and replace them with a plain for loop.
@@ -1058,6 +1096,7 @@ class TD0Estimator(ValueEstimatorBase):
         advantage_key: NestedKey = None,
         value_target_key: NestedKey = None,
         value_key: NestedKey = None,
+        value_transform: ValueTransform | None = None,
         skip_existing: bool | None = None,
         device: torch.device | None = None,
         deactivate_vmap: bool = False,
@@ -1074,6 +1113,7 @@ class TD0Estimator(ValueEstimatorBase):
             advantage_key=advantage_key,
             value_target_key=value_target_key,
             value_key=value_key,
+            value_transform=value_transform,
             skip_existing=skip_existing,
             device=device,
             deactivate_vmap=deactivate_vmap,
@@ -1170,9 +1210,11 @@ class TD0Estimator(ValueEstimatorBase):
                 params = params.detach()
                 if target_params is None:
                     target_params = params.clone(False)
-            with hold_out_net(self.value_network) if (
-                params is None and target_params is None
-            ) else nullcontext():
+            with (
+                hold_out_net(self.value_network)
+                if (params is None and target_params is None)
+                else nullcontext()
+            ):
                 # we may still need to pass gradient, but we don't want to assign grads to
                 # value net params
                 value, next_value, valid = self._call_value_nets(
@@ -1190,6 +1232,8 @@ class TD0Estimator(ValueEstimatorBase):
             value = tensordict.get(self.tensor_keys.value)
             next_value = tensordict.get(("next", self.tensor_keys.value))
 
+        value = self._inverse_value_transform(value)
+        next_value = self._inverse_value_transform(next_value)
         valid = tensordict.get("shifted_valid", default=None)
         data_for_value = self._prepare_shifted_tensordict(
             tensordict, valid, self._get_time_dim(None, tensordict)
@@ -1224,7 +1268,9 @@ class TD0Estimator(ValueEstimatorBase):
                 ("next", self.tensor_keys.reward), reward
             )  # we must update the rewards if they are used later in the code
         if next_value is None:
-            next_value = self._next_value(tensordict, target_params, kwargs=kwargs)
+            next_value = self._inverse_value_transform(
+                self._next_value(tensordict, target_params, kwargs=kwargs)
+            )
 
         done = tensordict.get(("next", self.tensor_keys.done))
         terminated = tensordict.get(("next", self.tensor_keys.terminated), default=done)
@@ -1268,6 +1314,10 @@ class TD1Estimator(ValueEstimatorBase):
             of the advantage entry.  Defaults to ``"value_target"``.
         value_key (str or tuple of str, optional): [Deprecated] the value key to
             read from the input tensordict.  Defaults to ``"state_value"``.
+        value_transform (ValueTransform, optional): invert value predictions
+            before TD arithmetic. The stored value keys stay transformed and
+            the returned targets and advantages use raw units. Defaults to
+            ``None``.
         shifted (bool, optional): controls how value and next-value
             are obtained from the value network. ``False`` (default) calls
             the value network twice (once on the root tensordict, once on
@@ -1345,6 +1395,7 @@ class TD1Estimator(ValueEstimatorBase):
         advantage_key: NestedKey = None,
         value_target_key: NestedKey = None,
         value_key: NestedKey = None,
+        value_transform: ValueTransform | None = None,
         shifted: bool = False,
         device: torch.device | None = None,
         time_dim: int | None = None,
@@ -1361,6 +1412,7 @@ class TD1Estimator(ValueEstimatorBase):
             advantage_key=advantage_key,
             value_target_key=value_target_key,
             value_key=value_key,
+            value_transform=value_transform,
             shifted=shifted,
             skip_existing=skip_existing,
             device=device,
@@ -1458,9 +1510,11 @@ class TD1Estimator(ValueEstimatorBase):
                 params = params.detach()
                 if target_params is None:
                     target_params = params.clone(False)
-            with hold_out_net(self.value_network) if (
-                params is None and target_params is None
-            ) else nullcontext():
+            with (
+                hold_out_net(self.value_network)
+                if (params is None and target_params is None)
+                else nullcontext()
+            ):
                 # we may still need to pass gradient, but we don't want to assign grads to
                 # value net params
                 value, next_value, valid = self._call_value_nets(
@@ -1478,6 +1532,8 @@ class TD1Estimator(ValueEstimatorBase):
             value = tensordict.get(self.tensor_keys.value)
             next_value = tensordict.get(("next", self.tensor_keys.value))
 
+        value = self._inverse_value_transform(value)
+        next_value = self._inverse_value_transform(next_value)
         valid = tensordict.get("shifted_valid", default=None)
         data_for_value = self._prepare_shifted_tensordict(
             tensordict, valid, self._get_time_dim(None, tensordict)
@@ -1513,7 +1569,9 @@ class TD1Estimator(ValueEstimatorBase):
                 ("next", self.tensor_keys.reward), reward
             )  # we must update the rewards if they are used later in the code
         if next_value is None:
-            next_value = self._next_value(tensordict, target_params, kwargs=kwargs)
+            next_value = self._inverse_value_transform(
+                self._next_value(tensordict, target_params, kwargs=kwargs)
+            )
 
         time_dim = self._get_time_dim(time_dim, tensordict)
         valid = tensordict.get("shifted_valid", default=None)
@@ -1567,6 +1625,10 @@ class TDLambdaEstimator(ValueEstimatorBase):
             of the advantage entry.  Defaults to ``"value_target"``.
         value_key (str or tuple of str, optional): [Deprecated] the value key to
             read from the input tensordict.  Defaults to ``"state_value"``.
+        value_transform (ValueTransform, optional): invert value predictions
+            before TD arithmetic. The stored value keys stay transformed and
+            the returned targets and advantages use raw units. Defaults to
+            ``None``.
         shifted (bool, optional): controls how value and next-value
             are obtained from the value network. ``False`` (default) calls
             the value network twice (once on the root tensordict, once on
@@ -1646,6 +1708,7 @@ class TDLambdaEstimator(ValueEstimatorBase):
         advantage_key: NestedKey = None,
         value_target_key: NestedKey = None,
         value_key: NestedKey = None,
+        value_transform: ValueTransform | None = None,
         shifted: bool = False,
         device: torch.device | None = None,
         time_dim: int | None = None,
@@ -1662,6 +1725,7 @@ class TDLambdaEstimator(ValueEstimatorBase):
             advantage_key=advantage_key,
             value_target_key=value_target_key,
             value_key=value_key,
+            value_transform=value_transform,
             skip_existing=skip_existing,
             shifted=shifted,
             device=device,
@@ -1772,9 +1836,11 @@ class TDLambdaEstimator(ValueEstimatorBase):
                 params = params.detach()
                 if target_params is None:
                     target_params = params.clone(False)
-            with hold_out_net(self.value_network) if (
-                params is None and target_params is None
-            ) else nullcontext():
+            with (
+                hold_out_net(self.value_network)
+                if (params is None and target_params is None)
+                else nullcontext()
+            ):
                 # we may still need to pass gradient, but we don't want to assign grads to
                 # value net params
                 value, next_value, valid = self._call_value_nets(
@@ -1791,6 +1857,8 @@ class TDLambdaEstimator(ValueEstimatorBase):
         else:
             value = tensordict.get(self.tensor_keys.value)
             next_value = tensordict.get(("next", self.tensor_keys.value))
+        value = self._inverse_value_transform(value)
+        next_value = self._inverse_value_transform(next_value)
         valid = tensordict.get("shifted_valid", default=None)
         data_for_value = self._prepare_shifted_tensordict(
             tensordict, valid, self._get_time_dim(None, tensordict)
@@ -1831,7 +1899,9 @@ class TDLambdaEstimator(ValueEstimatorBase):
             )  # we must update the rewards if they are used later in the code
 
         if next_value is None:
-            next_value = self._next_value(tensordict, target_params, kwargs=kwargs)
+            next_value = self._inverse_value_transform(
+                self._next_value(tensordict, target_params, kwargs=kwargs)
+            )
 
         time_dim = self._get_time_dim(time_dim, tensordict)
         valid = tensordict.get("shifted_valid", default=None)
@@ -1903,6 +1973,10 @@ class GAE(ValueEstimatorBase):
             of the advantage entry.  Defaults to ``"value_target"``.
         value_key (str or tuple of str, optional): [Deprecated] the value key to
             read from the input tensordict.  Defaults to ``"state_value"``.
+        value_transform (ValueTransform, optional): invert value predictions
+            before GAE arithmetic. The stored value keys stay transformed and
+            the returned targets and advantages use raw units. Defaults to
+            ``None``.
         shifted (bool, optional): controls how value and next-value
             are obtained from the value network. ``False`` (default) calls
             the value network twice (once on the root tensordict, once on
@@ -2009,6 +2083,7 @@ class GAE(ValueEstimatorBase):
         advantage_key: NestedKey = None,
         value_target_key: NestedKey = None,
         value_key: NestedKey = None,
+        value_transform: ValueTransform | None = None,
         shifted: bool = False,
         device: torch.device | None = None,
         time_dim: int | None = None,
@@ -2027,6 +2102,7 @@ class GAE(ValueEstimatorBase):
             advantage_key=advantage_key,
             value_target_key=value_target_key,
             value_key=value_key,
+            value_transform=value_transform,
             skip_existing=skip_existing,
             device=device,
             deactivate_vmap=deactivate_vmap,
@@ -2038,15 +2114,19 @@ class GAE(ValueEstimatorBase):
         )
         self.register_buffer(
             "gamma",
-            gamma.to(self._device)
-            if isinstance(gamma, Tensor)
-            else torch.tensor(gamma, device=self._device),
+            (
+                gamma.to(self._device)
+                if isinstance(gamma, Tensor)
+                else torch.tensor(gamma, device=self._device)
+            ),
         )
         self.register_buffer(
             "lmbda",
-            lmbda.to(self._device)
-            if isinstance(lmbda, Tensor)
-            else torch.tensor(lmbda, device=self._device),
+            (
+                lmbda.to(self._device)
+                if isinstance(lmbda, Tensor)
+                else torch.tensor(lmbda, device=self._device)
+            ),
         )
         self.average_gae = average_gae
         self.vectorized = vectorized
@@ -2165,9 +2245,11 @@ class GAE(ValueEstimatorBase):
                 params = params.detach()
                 if target_params is None:
                     target_params = params.clone(False)
-            with hold_out_net(self.value_network) if (
-                params is None and target_params is None
-            ) else nullcontext():
+            with (
+                hold_out_net(self.value_network)
+                if (params is None and target_params is None)
+                else nullcontext()
+            ):
                 # with torch.no_grad():
                 # we may still need to pass gradient, but we don't want to assign grads to
                 # value net params
@@ -2195,6 +2277,8 @@ class GAE(ValueEstimatorBase):
                     f"The tensor with key {('next', self.tensor_keys.value)} is missing, and no value network was provided."
                 )
 
+        value = self._inverse_value_transform(value)
+        next_value = self._inverse_value_transform(next_value)
         time_dim = self._get_time_dim(time_dim, tensordict)
         valid = tensordict.get("shifted_valid", default=None)
         data_for_value = self._prepare_shifted_tensordict(tensordict, valid, time_dim)
@@ -2329,9 +2413,11 @@ class GAE(ValueEstimatorBase):
                 params = params.detach()
                 if target_params is None:
                     target_params = params.clone(False)
-            with hold_out_net(self.value_network) if (
-                params is None and target_params is None
-            ) else nullcontext():
+            with (
+                hold_out_net(self.value_network)
+                if (params is None and target_params is None)
+                else nullcontext()
+            ):
                 # we may still need to pass gradient, but we don't want to assign grads to
                 # value net params
                 value, next_value, valid = self._call_value_nets(
@@ -2348,6 +2434,8 @@ class GAE(ValueEstimatorBase):
         else:
             value = tensordict.get(self.tensor_keys.value)
             next_value = tensordict.get(("next", self.tensor_keys.value))
+        value = self._inverse_value_transform(value)
+        next_value = self._inverse_value_transform(next_value)
         valid = tensordict.get("shifted_valid", default=None)
         data_for_value = self._prepare_shifted_tensordict(tensordict, valid, time_dim)
         reward = data_for_value.get(("next", self.tensor_keys.reward))
@@ -2400,12 +2488,21 @@ class MultiAgentGAE(GAE):
             the value tensor. Negative dimensions are taken modulo
             ``value.ndim``. Defaults to ``-2`` (penultimate), matching the
             convention used by :class:`~torchrl.modules.MultiAgentMLP`.
+        value_transform (ValueTransform, optional): forwarded to
+            :class:`GAE`; per-agent predictions stay in prediction space while
+            advantages and value targets use raw units. Defaults to ``None``.
 
     Other args/kwargs are forwarded to :class:`GAE`.
     """
 
-    def __init__(self, *, agent_dim: int = -2, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(
+        self,
+        *,
+        agent_dim: int = -2,
+        value_transform: ValueTransform | None = None,
+        **kwargs,
+    ):
+        super().__init__(value_transform=value_transform, **kwargs)
         self.agent_dim = agent_dim
 
     @staticmethod
@@ -2515,6 +2612,10 @@ class VTrace(ValueEstimatorBase):
             of the advantage entry.  Defaults to ``"value_target"``.
         value_key (str or tuple of str, optional): [Deprecated] the value key to
             read from the input tensordict.  Defaults to ``"state_value"``.
+        value_transform (ValueTransform, optional): invert value predictions
+            before V-trace arithmetic. The stored value keys stay transformed
+            and the returned targets and advantages use raw units. Defaults to
+            ``None``.
         shifted (bool, optional): controls how value and next-value
             are obtained from the value network. ``False`` (default) calls
             the value network twice (once on the root tensordict, once on
@@ -2628,6 +2729,7 @@ class VTrace(ValueEstimatorBase):
         advantage_key: NestedKey | None = None,
         value_target_key: NestedKey | None = None,
         value_key: NestedKey | None = None,
+        value_transform: ValueTransform | None = None,
         shifted: bool = False,
         device: torch.device | None = None,
         time_dim: int | None = None,
@@ -2644,6 +2746,7 @@ class VTrace(ValueEstimatorBase):
             advantage_key=advantage_key,
             value_target_key=value_target_key,
             value_key=value_key,
+            value_transform=value_transform,
             skip_existing=skip_existing,
             device=device,
             value_chunk_size=value_chunk_size,
@@ -2820,6 +2923,8 @@ class VTrace(ValueEstimatorBase):
             value = tensordict.get(self.tensor_keys.value)
             next_value = tensordict.get(("next", self.tensor_keys.value))
 
+        value = self._inverse_value_transform(value)
+        next_value = self._inverse_value_transform(next_value)
         lp = _maybe_get_or_select(tensordict, self.tensor_keys.sample_log_prob)
         if is_tensor_collection(lp):
             # Sum all values to match the batch size

--- a/torchrl/trainers/algorithms/configs/objectives.py
+++ b/torchrl/trainers/algorithms/configs/objectives.py
@@ -77,6 +77,7 @@ class SACLossConfig(LossConfig):
     use_prioritized_weights: str | bool = "auto"
     scalar_output_mode: str | None = None
     value_transform: Any = None
+    priority_function: Any = None
     _target_: str = "torchrl.trainers.algorithms.configs.objectives._make_sac_loss"
 
     def __post_init__(self) -> None:
@@ -88,14 +89,19 @@ def _make_sac_loss(*args, **kwargs) -> SACLoss:
     discrete_loss_type = kwargs.pop("discrete", False)
     gamma = kwargs.pop("gamma", None)
     value_transform = kwargs.pop("value_transform", None)
+    priority_function = kwargs.pop("priority_function", None)
 
-    if discrete_loss_type and value_transform is not None:
+    if discrete_loss_type and (
+        value_transform is not None or priority_function is not None
+    ):
         raise ValueError(
-            "value_transform is only supported by the continuous SACLoss; "
-            "DiscreteSACLoss uses a different value representation."
+            "value_transform and priority_function are only supported by the "
+            "continuous SACLoss; DiscreteSACLoss uses a different value "
+            "representation."
         )
     if not discrete_loss_type:
         kwargs["value_transform"] = value_transform
+        kwargs["priority_function"] = priority_function
 
     # Instantiate networks if they are config objects
     actor_network = kwargs.get("actor_network")
@@ -357,6 +363,7 @@ class TD3LossConfig(LossConfig):
     deactivate_vmap: bool = False
     use_prioritized_weights: str | bool = "auto"
     value_transform: Any = None
+    priority_function: Any = None
     _target_: str = "torchrl.trainers.algorithms.configs.objectives._make_td3_loss"
 
 
@@ -572,6 +579,7 @@ class DDPGLossConfig(LossConfig):
     reduction: str | None = None
     use_prioritized_weights: str | bool = "auto"
     value_transform: Any = None
+    priority_function: Any = None
     _target_: str = "torchrl.trainers.algorithms.configs.objectives._make_ddpg_loss"
 
     def __post_init__(self) -> None:

--- a/torchrl/trainers/algorithms/configs/objectives.py
+++ b/torchrl/trainers/algorithms/configs/objectives.py
@@ -76,6 +76,7 @@ class SACLossConfig(LossConfig):
     deactivate_vmap: bool = False
     use_prioritized_weights: str | bool = "auto"
     scalar_output_mode: str | None = None
+    value_transform: Any = None
     _target_: str = "torchrl.trainers.algorithms.configs.objectives._make_sac_loss"
 
     def __post_init__(self) -> None:
@@ -86,6 +87,15 @@ class SACLossConfig(LossConfig):
 def _make_sac_loss(*args, **kwargs) -> SACLoss:
     discrete_loss_type = kwargs.pop("discrete", False)
     gamma = kwargs.pop("gamma", None)
+    value_transform = kwargs.pop("value_transform", None)
+
+    if discrete_loss_type and value_transform is not None:
+        raise ValueError(
+            "value_transform is only supported by the continuous SACLoss; "
+            "DiscreteSACLoss uses a different value representation."
+        )
+    if not discrete_loss_type:
+        kwargs["value_transform"] = value_transform
 
     # Instantiate networks if they are config objects
     actor_network = kwargs.get("actor_network")
@@ -174,6 +184,7 @@ class PPOLossConfig(LossConfig):
     decrement: float = 0.5
     samples_mc_kl: int = 1
     device: Any = None
+    value_transform: Any = None
     _target_: str = "torchrl.trainers.algorithms.configs.objectives._make_ppo_loss"
 
     def __post_init__(self) -> None:
@@ -345,6 +356,7 @@ class TD3LossConfig(LossConfig):
     reduction: str | None = None
     deactivate_vmap: bool = False
     use_prioritized_weights: str | bool = "auto"
+    value_transform: Any = None
     _target_: str = "torchrl.trainers.algorithms.configs.objectives._make_td3_loss"
 
 
@@ -413,6 +425,7 @@ class GAEConfig(LossConfig):
     time_dim: int | None = None
     auto_reset_env: bool = False
     deactivate_vmap: bool = False
+    value_transform: Any = None
     value_chunk_size: int | None = None
     num_chunks: int | None = None
     num_chunk: int | None = None
@@ -558,6 +571,7 @@ class DDPGLossConfig(LossConfig):
     separate_losses: bool = False
     reduction: str | None = None
     use_prioritized_weights: str | bool = "auto"
+    value_transform: Any = None
     _target_: str = "torchrl.trainers.algorithms.configs.objectives._make_ddpg_loss"
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
## Summary

- add a shared `value_transform` contract to scalar value estimators and DDPG, TD3, continuous SAC v1/v2, PPO, ClipPPO, and KLPENPPO
- keep critic outputs in transformed prediction space while Bellman arithmetic, actor objectives, entropy terms, returns, advantages, PPO clipping, and diagnostics remain in raw units
- propagate the exact transform object to lazy/prebuilt estimators, add Hydra config support, and reject concurrent MAPPO/IPPO ValueNorm scaling
- document the end-to-end dataflow and add transformed eager/compiled objective benchmarks

## Key semantics

- `state_value` / `state_action_value`: transformed prediction space
- `advantage` / `value_target`, explicit estimator `next_value=`, PPO `clip_value`, and diagnostic values: raw reward-return space
- replay `td_error`: existing absolute/squared convention, computed from the transformed residual
- `value_transform=None`: existing identity path, with no added tensor operations
- unsupported: DiscreteSAC, distributional/two-hot critics, and concurrent ValueNorm/PopArt scaling

## Validation

- `pytest test/objectives/test_values.py test/objectives/test_ddpg.py test/objectives/test_sac.py test/objectives/test_ppo.py test/objectives/test_mappo.py test/compile/test_compile_value.py -k 'not prioritized_weights'`: 5,211 passed, 2,316 skipped
- targeted Hydra nested-instantiation and config parity checks: 9 passed
- transformed benchmark smoke tests: eager and compiled forward/backward passed for DDPG, TD3, SAC, and trajectory-shaped PPO/GAE
- guide examples executed end to end
- flake8, pydocstyle, docstring-argument, codespell, and Sphinx-section checks passed

The prioritized-replay tests excluded above require the optional segment-tree extension, which is unavailable in this local environment; transformed priority equations are covered directly in the DDPG/TD3/SAC regression tests.

## Local CPU benchmark snapshot

Representative eager forwards (mean):

| Objective | None | symlog | Delta |
| --- | ---: | ---: | ---: |
| DDPG | 1.247 ms | 1.309 ms | +5.0% |
| TD3 | 2.885 ms | 3.109 ms | +7.8% |
| SAC | 2.847 ms | 2.925 ms | +2.7% |
| PPO/GAE | 2.693 ms | 2.701 ms | +0.3% |

Profiler tensor-allocation volume increased by 0.8% (DDPG), 0.5% (TD3), 0.4% (SAC), and 0.5% (PPO/GAE). The transformed path does not add persistent TensorDict keys or retain duplicate raw/transformed predictions.
