### PR TITLE
[Doc] Fix/ppo tutorial

### DIFF
--- a/tutorials/sphinx-tutorials/coding_ppo.py
+++ b/tutorials/sphinx-tutorials/coding_ppo.py
@@ -455,13 +455,24 @@ value_module = ValueOperator(
 )
 
 ######################################################################
-# let's try our policy and value modules. As we said earlier, the usage of
+# Let's try our policy and value modules. As we said earlier, the usage of
 # :class:`~tensordict.nn.TensorDictModule` makes it possible to directly read the output
 # of the environment to run these modules, as they know what information to read
-# and where to write it:
+# and where to write it.
 #
-print("Running policy:", policy_module(env.reset()))
-print("Running value:", value_module(env.reset()))
+# .. note::
+#     Running these modules with a dummy batch of data is not just for testing!
+#     Since we used ``nn.LazyLinear``, this step is required to initialize the
+#     network parameters. Without it, you will get an ``UninitializedParameter``
+#     error when the algorithm attempts to disable gradients or update the weights.
+#
+
+# Run a dummy forward pass to initialize the Lazy modules (strictly required!)
+out_policy = policy_module(env.reset())
+out_value = value_module(env.reset())
+
+print("Running policy:", out_policy)
+print("Running value:", out_value)
 
 ######################################################################
 # Data collector


### PR DESCRIPTION
## Description

This PR updates the `coding_ppo.py` tutorial to explicitly separate the dummy forward pass (required to initialize `LazyLinear` modules) from the print statements. Additionally, a Sphinx `.. note::` was added to clearly warn users that running the dummy batch is strictly required, preventing them from deleting this initialization logic when adapting the tutorial for their own scripts.

## Motivation and Context

Users copying the tutorial code frequently removed the `print()` statements for the dummy forward passes, unaware that they served as the mandatory initialization step for the underlying `LazyLinear` parameters. This led to an `UninitializedParameter` error later in the PPO execution loop when attempting to disable gradients on the uninitialized modules. By explicitly separating the logic and warning the user, this UX bug is resolved.

Closes #3134

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
