### PR TITLE
[Feature] WS1: Add stable component boundary Protocols for external-l…

### DIFF
--- a/docs/source/reference/llms.rst
+++ b/docs/source/reference/llms.rst
@@ -573,5 +573,6 @@ See the :ref:`tutorial <sphx_glr_tutorials_sphinx-tutorials_torchrl_component_co
 
     PostTrainingBufferProtocol
     PostTrainingCollectorProtocol
-    PostTrainingLossOutputProtocol
+    GRPOLossOutputProtocol
+    SFTLossOutputProtocol
     assert_satisfies_protocol

--- a/docs/source/reference/llms.rst
+++ b/docs/source/reference/llms.rst
@@ -523,11 +523,10 @@ GRPO, DAPO, CISPO
     :toctree: generated/
     :template: rl_template.rst
 
-    LLMLossOutput
-    GRPOLoss
-    GRPOLossOutput
-    CISPOLoss
-    CISPOLossOutput
+    assert_buffer_contract
+    assert_collector_contract
+    assert_loss_contract
+
     DAPO
     DAPOLossOutput
     MCAdvantage
@@ -544,6 +543,19 @@ SFT
     SFTLoss
     SFTLossOutput
 
+Distillation
+~~~~~~~~~~~~
+
+.. currentmodule:: torchrl.objectives.llm
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template.rst
+
+    DistillationLoss
+    DistillationLossOutput
+    k3_kl_token_estimate
+
 .. currentmodule:: torchrl.data.llm
 
 .. autosummary::
@@ -552,27 +564,78 @@ SFT
 
     TopKRewardSelector
 
-.. _component_contracts_section:
+.. _trl_interop_section:
 
-Component Contracts (WS1)
--------------------------
+TRL Interoperability
+--------------------
 
-.. currentmodule:: torchrl.data.llm
+.. currentmodule:: torchrl.modules.llm
 
-TorchRL provides formal ``typing.Protocol`` definitions for the minimal
-interfaces that external training loops must satisfy — or that TorchRL
-built-ins are guaranteed to expose.  These contracts make it possible to
-consume individual TorchRL components from TRL, NeMo-RL, or custom loops
-without depending on TorchRL's concrete classes.
+TorchRL provides adapters for interoperating with Hugging Face ``trl`` while
+keeping replay storage and reward evaluation in TorchRL.
 
-See the :ref:`tutorial <sphx_glr_tutorials_sphinx-tutorials_torchrl_component_contracts.py>` for a worked example.
+**TorchRL -> TRL** (feed a ``trl.GRPOTrainer`` from a TorchRL buffer):
 
-.. autosummary::
-    :toctree: generated/
-    :template: rl_template.rst
+.. code-block:: python
 
-    PostTrainingBufferProtocol
-    PostTrainingCollectorProtocol
-    GRPOLossOutputProtocol
-    SFTLossOutputProtocol
-    assert_satisfies_protocol
+    from tensordict import TensorDict
+    from torchrl.data import ReplayBuffer, ListStorage
+    from torchrl.modules.llm import TorchRLBufferDataset
+    from trl import GRPOConfig, GRPOTrainer
+
+    rb = ReplayBuffer(storage=ListStorage(10_000), batch_size=32)
+    rb.add(TensorDict({"prompt": "Explain policy gradients."}, batch_size=[]))
+
+    torch_dataset = TorchRLBufferDataset(
+        rb,
+        batch_size=32,
+        keys=["prompt"],
+        num_batches=None,
+    )
+    train_dataset = torch_dataset.as_hf_dataset()
+
+    trainer = GRPOTrainer(
+        model="model-name",
+        reward_funcs=lambda completions, **kwargs: [0.0] * len(completions),
+        train_dataset=train_dataset,
+        args=GRPOConfig(max_steps=1_000),
+    )
+
+Current ``trl`` trainers require a :mod:`datasets` ``Dataset`` or
+``IterableDataset`` rather than a PyTorch ``IterableDataset``. Call
+:meth:`TorchRLBufferDataset.as_hf_dataset` for that bridge. The sampled data
+must contain the schema expected by the selected trainer: for example,
+``GRPOTrainer`` requires a top-level ``"prompt"`` field. An unbounded stream
+also requires a finite ``max_steps`` in the trainer configuration. Install the
+integration dependencies with ``pip install torchrl[llm] trl``.
+
+**TRL -> TorchRL** (use an HF reward model inside a TorchRL GRPO step):
+
+.. code-block:: python
+
+    from transformers import AutoModelForSequenceClassification
+    from torchrl.modules.llm import HFRewardModelWrapper
+    from tensordict import TensorDict
+    import torch
+
+    hf_model = AutoModelForSequenceClassification.from_pretrained(
+        "my-org/reward-model-v1", num_labels=1
+    )
+    reward_fn = HFRewardModelWrapper(
+        hf_model,
+        token_key=("tokens", "full"),
+        attention_mask_key=("masks", "all_attention_mask"),
+        reward_key="reward",
+        inference_mode=True,   # disable grad for pure reward inference
+    )
+
+    # Inside your GRPO / PPO rollout loop:
+    rollout_td = ...  # TensorDict from LLMCollector
+    reward_fn(rollout_td)  # writes "reward" key in-place
+    assert rollout_td["reward"].shape == rollout_td.batch_size
+
+.. seealso::
+
+    * :class:`TorchRLBufferDataset`
+    * :class:`HFRewardModelWrapper`
+    * Tutorial: :ref:`trl_interop_tutorial`

--- a/docs/source/reference/llms.rst
+++ b/docs/source/reference/llms.rst
@@ -551,3 +551,27 @@ SFT
     :template: rl_template.rst
 
     TopKRewardSelector
+
+.. _component_contracts_section:
+
+Component Contracts (WS1)
+-------------------------
+
+.. currentmodule:: torchrl.data.llm
+
+TorchRL provides formal ``typing.Protocol`` definitions for the minimal
+interfaces that external training loops must satisfy — or that TorchRL
+built-ins are guaranteed to expose.  These contracts make it possible to
+consume individual TorchRL components from TRL, NeMo-RL, or custom loops
+without depending on TorchRL's concrete classes.
+
+See the :ref:`tutorial <sphx_glr_tutorials_sphinx-tutorials_torchrl_component_contracts.py>` for a worked example.
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template.rst
+
+    PostTrainingBufferProtocol
+    PostTrainingCollectorProtocol
+    PostTrainingLossOutputProtocol
+    assert_satisfies_protocol

--- a/test/test_llm_contracts.py
+++ b/test/test_llm_contracts.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+"""Tests for stable component boundary helpers."""
 import pytest
 import torch
 from tensordict import TensorDict

--- a/test/test_llm_contracts.py
+++ b/test/test_llm_contracts.py
@@ -8,19 +8,16 @@ from __future__ import annotations
 import pytest
 import torch
 from tensordict import TensorDict
-
 from torchrl.data import ReplayBuffer, LazyTensorStorage
 from torchrl.data.llm.contracts import (
+    GRPOLossOutputProtocol,
     PostTrainingBufferProtocol,
     PostTrainingCollectorProtocol,
-    PostTrainingLossOutputProtocol,
+    SFTLossOutputProtocol,
     assert_satisfies_protocol,
 )
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+from torchrl.objectives.llm.grpo import GRPOLossOutput
+from torchrl.objectives.llm.sft import SFTLossOutput
 
 
 def _make_rb(capacity: int = 100) -> ReplayBuffer:
@@ -28,8 +25,6 @@ def _make_rb(capacity: int = 100) -> ReplayBuffer:
 
 
 class _MinimalBuffer:
-    """A hand-rolled buffer that satisfies PostTrainingBufferProtocol."""
-
     def __init__(self):
         self._count = 0
 
@@ -55,8 +50,6 @@ class _BrokenBuffer:
 
 
 class _MinimalCollector:
-    """Satisfies PostTrainingCollectorProtocol without inheriting anything."""
-
     def update_policy_weights_(self, policy_weights=None, *, worker_ids=None):
         pass
 
@@ -67,164 +60,128 @@ class _MinimalCollector:
         return TensorDict({}, [])
 
 
-class _MinimalLossOutput:
-    """Satisfies PostTrainingLossOutputProtocol."""
-
+class _MinimalGRPOOutput:
     @property
-    def loss_objective(self) -> torch.Tensor | None:
-        """Primary policy optimisation loss, or ``None`` if not computed.
-
-        .. note::
-            :class:`~torchrl.objectives.llm.SFTLossOutput` exposes
-            ``loss_sft`` rather than ``loss_objective``.  Both satisfy this
-            protocol because ``loss_objective`` is optional (may be
-            ``None``).  :class:`~torchrl.record.loggers.llm.PostTrainingLogger`
-            reads all fields via ``getattr`` duck-typing.
-        """
+    def loss_objective(self) -> torch.Tensor:
         return torch.tensor(0.5)
 
+
+class _MinimalSFTOutput:
     @property
-    def loss_sft(self) -> torch.Tensor | None:
-        """SFT loss term — present on SFTLossOutput/EI outputs."""
-        return None
+    def loss_sft(self) -> torch.Tensor:
+        return torch.tensor(0.3)
 
 
-class _BrokenLossOutput:
-    """Missing loss_objective — does NOT satisfy the protocol."""
+class _BrokenOutput:
     pass
-
-
-# ---------------------------------------------------------------------------
-# PostTrainingBufferProtocol
-# ---------------------------------------------------------------------------
 
 
 class TestPostTrainingBufferProtocol:
     def test_torchrl_replay_buffer_satisfies(self):
-        """Built-in ReplayBuffer must satisfy the protocol."""
-        rb = _make_rb()
-        assert isinstance(rb, PostTrainingBufferProtocol)
+        assert isinstance(_make_rb(), PostTrainingBufferProtocol)
 
     def test_minimal_custom_buffer_satisfies(self):
-        """A hand-rolled buffer with the required attrs satisfies the protocol."""
-        buf = _MinimalBuffer()
-        assert isinstance(buf, PostTrainingBufferProtocol)
+        assert isinstance(_MinimalBuffer(), PostTrainingBufferProtocol)
 
     def test_broken_buffer_does_not_satisfy(self):
-        """A buffer missing write_count does NOT satisfy the protocol."""
-        broken = _BrokenBuffer()
-        assert not isinstance(broken, PostTrainingBufferProtocol)
+        assert not isinstance(_BrokenBuffer(), PostTrainingBufferProtocol)
 
     def test_assert_satisfies_passes_silently(self):
-        """assert_satisfies_protocol must not raise for a compliant object."""
-        rb = _make_rb()
-        assert_satisfies_protocol(rb, PostTrainingBufferProtocol, name="rb")
+        assert_satisfies_protocol(_make_rb(), PostTrainingBufferProtocol, name="rb")
 
     def test_assert_satisfies_raises_for_broken(self):
-        """assert_satisfies_protocol must raise TypeError for a violating object."""
-        broken = _BrokenBuffer()
         with pytest.raises(TypeError, match="write_count"):
-            assert_satisfies_protocol(broken, PostTrainingBufferProtocol, name="broken_buf")
+            assert_satisfies_protocol(_BrokenBuffer(), PostTrainingBufferProtocol, name="broken_buf")
 
     def test_assert_satisfies_error_includes_name(self):
-        """Error message must include the name argument."""
-        broken = _BrokenBuffer()
         with pytest.raises(TypeError, match="my_buffer"):
-            assert_satisfies_protocol(broken, PostTrainingBufferProtocol, name="my_buffer")
-
-
-# ---------------------------------------------------------------------------
-# PostTrainingCollectorProtocol
-# ---------------------------------------------------------------------------
+            assert_satisfies_protocol(_BrokenBuffer(), PostTrainingBufferProtocol, name="my_buffer")
 
 
 class TestPostTrainingCollectorProtocol:
     def test_minimal_collector_satisfies(self):
-        col = _MinimalCollector()
-        assert isinstance(col, PostTrainingCollectorProtocol)
+        assert isinstance(_MinimalCollector(), PostTrainingCollectorProtocol)
 
     def test_plain_object_does_not_satisfy(self):
         assert not isinstance(object(), PostTrainingCollectorProtocol)
 
     def test_assert_satisfies_passes(self):
-        col = _MinimalCollector()
-        assert_satisfies_protocol(col, PostTrainingCollectorProtocol, name="col")
+        assert_satisfies_protocol(_MinimalCollector(), PostTrainingCollectorProtocol, name="col")
 
     def test_assert_satisfies_raises(self):
         with pytest.raises(TypeError):
             assert_satisfies_protocol(object(), PostTrainingCollectorProtocol, name="bad")
 
 
-# ---------------------------------------------------------------------------
-# PostTrainingLossOutputProtocol
-# ---------------------------------------------------------------------------
+class TestGRPOLossOutputProtocol:
+    def test_minimal_grpo_output_satisfies(self):
+        assert_satisfies_protocol(_MinimalGRPOOutput(), GRPOLossOutputProtocol)
 
-
-class TestPostTrainingLossOutputProtocol:
-    def test_minimal_loss_output_satisfies(self):
-        out = _MinimalLossOutput()
-        # Use assert_satisfies_protocol (getattr-based) instead of isinstance
-        assert_satisfies_protocol(out, PostTrainingLossOutputProtocol, name="minimal")
-
-    def test_broken_loss_output_does_not_satisfy(self):
+    def test_broken_output_does_not_satisfy(self):
         with pytest.raises(TypeError):
-            assert_satisfies_protocol(
-                _BrokenLossOutput(), PostTrainingLossOutputProtocol
-            )
+            assert_satisfies_protocol(_BrokenOutput(), GRPOLossOutputProtocol)
 
     def test_grpo_loss_output_satisfies(self):
-        """GRPOLossOutput must satisfy the protocol (via assert_satisfies_protocol)."""
-        pytest.importorskip("torchrl.objectives.llm.grpo")
-        from torchrl.objectives.llm.grpo import GRPOLossOutput
         out = GRPOLossOutput(
             loss_objective=torch.tensor(0.1),
             clip_fraction=torch.tensor(0.0),
             kl_approx=torch.tensor(0.0),
             ESS=torch.tensor(1.0),
         )
-        # GRPOLossOutput is a TensorClass: isinstance won't work, but
-        # assert_satisfies_protocol uses getattr-based checking.
-        assert_satisfies_protocol(out, PostTrainingLossOutputProtocol, name="grpo_out")
+        assert_satisfies_protocol(out, GRPOLossOutputProtocol, name="grpo_out")
+
+    def test_sft_output_does_not_satisfy_grpo_protocol(self):
+        """SFTLossOutput must NOT satisfy GRPOLossOutputProtocol (has loss_sft, not loss_objective)."""
+        out = SFTLossOutput(loss_sft=torch.tensor(0.2))
+        with pytest.raises(TypeError):
+            assert_satisfies_protocol(out, GRPOLossOutputProtocol)
+
+
+class TestSFTLossOutputProtocol:
+    def test_minimal_sft_output_satisfies(self):
+        assert_satisfies_protocol(_MinimalSFTOutput(), SFTLossOutputProtocol)
+
+    def test_broken_output_does_not_satisfy(self):
+        with pytest.raises(TypeError):
+            assert_satisfies_protocol(_BrokenOutput(), SFTLossOutputProtocol)
 
     def test_sft_loss_output_satisfies(self):
-        """SFTLossOutput must satisfy the protocol (it has loss_sft)."""
-        pytest.importorskip("torchrl.objectives.llm.sft")
-        from torchrl.objectives.llm.sft import SFTLossOutput
         out = SFTLossOutput(loss_sft=torch.tensor(0.2))
-        assert_satisfies_protocol(out, PostTrainingLossOutputProtocol, name="sft_out")
+        assert_satisfies_protocol(out, SFTLossOutputProtocol, name="sft_out")
 
-    def test_assert_satisfies_passes(self):
-        out = _MinimalLossOutput()
-        assert_satisfies_protocol(out, PostTrainingLossOutputProtocol, name="loss_out")
-
-    def test_assert_satisfies_raises(self):
+    def test_grpo_output_does_not_satisfy_sft_protocol(self):
+        """GRPOLossOutput must NOT satisfy SFTLossOutputProtocol (has loss_objective, not loss_sft)."""
+        out = GRPOLossOutput(
+            loss_objective=torch.tensor(0.1),
+            clip_fraction=torch.tensor(0.0),
+            kl_approx=torch.tensor(0.0),
+            ESS=torch.tensor(1.0),
+        )
         with pytest.raises(TypeError):
-            assert_satisfies_protocol(_BrokenLossOutput(), PostTrainingLossOutputProtocol)
-
-
-# ---------------------------------------------------------------------------
-# assert_satisfies_protocol — edge cases
-# ---------------------------------------------------------------------------
+            assert_satisfies_protocol(out, SFTLossOutputProtocol)
 
 
 class TestAssertSatisfiesProtocol:
     def test_no_name_in_error(self):
-        """Without a name argument the error must still be raised."""
-        broken = _BrokenBuffer()
         with pytest.raises(TypeError):
-            assert_satisfies_protocol(broken, PostTrainingBufferProtocol)
+            assert_satisfies_protocol(_BrokenBuffer(), PostTrainingBufferProtocol)
 
     def test_importable_from_top_level_data_llm(self):
-        """Must be importable from the torchrl.data.llm namespace."""
         from torchrl.data.llm import assert_satisfies_protocol as asp
         assert asp is assert_satisfies_protocol
 
     def test_protocols_importable_from_top_level_data_llm(self):
         from torchrl.data.llm import (
+            GRPOLossOutputProtocol as GLOP,
             PostTrainingBufferProtocol as PBP,
             PostTrainingCollectorProtocol as PCP,
-            PostTrainingLossOutputProtocol as PLOP,
+            SFTLossOutputProtocol as SLOP,
         )
         assert PBP is PostTrainingBufferProtocol
         assert PCP is PostTrainingCollectorProtocol
-        assert PLOP is PostTrainingLossOutputProtocol
+        assert GLOP is GRPOLossOutputProtocol
+        assert SLOP is SFTLossOutputProtocol
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/test/test_llm_contracts.py
+++ b/test/test_llm_contracts.py
@@ -2,19 +2,16 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-"""Tests for WS1: Stable component boundary Protocols (torchrl/data/llm/contracts.py)."""
 from __future__ import annotations
 
 import pytest
 import torch
 from tensordict import TensorDict
-from torchrl.data import ReplayBuffer, LazyTensorStorage
+from torchrl.data import LazyTensorStorage, ReplayBuffer
 from torchrl.data.llm.contracts import (
-    GRPOLossOutputProtocol,
-    PostTrainingBufferProtocol,
-    PostTrainingCollectorProtocol,
-    SFTLossOutputProtocol,
-    assert_satisfies_protocol,
+    assert_buffer_contract,
+    assert_collector_contract,
+    assert_loss_contract,
 )
 from torchrl.objectives.llm.grpo import GRPOLossOutput
 from torchrl.objectives.llm.sft import SFTLossOutput
@@ -40,7 +37,7 @@ class _MinimalBuffer:
 
 
 class _BrokenBuffer:
-    """Missing write_count — does NOT satisfy the protocol."""
+    """Missing write_count — does NOT satisfy the contract."""
 
     def extend(self, data):
         pass
@@ -76,50 +73,30 @@ class _BrokenOutput:
     pass
 
 
-class TestPostTrainingBufferProtocol:
+class TestBufferContract:
     def test_torchrl_replay_buffer_satisfies(self):
-        assert isinstance(_make_rb(), PostTrainingBufferProtocol)
+        assert_buffer_contract(_make_rb())
 
     def test_minimal_custom_buffer_satisfies(self):
-        assert isinstance(_MinimalBuffer(), PostTrainingBufferProtocol)
+        assert_buffer_contract(_MinimalBuffer())
 
-    def test_broken_buffer_does_not_satisfy(self):
-        assert not isinstance(_BrokenBuffer(), PostTrainingBufferProtocol)
-
-    def test_assert_satisfies_passes_silently(self):
-        assert_satisfies_protocol(_make_rb(), PostTrainingBufferProtocol, name="rb")
-
-    def test_assert_satisfies_raises_for_broken(self):
+    def test_assert_raises_for_broken(self):
         with pytest.raises(TypeError, match="write_count"):
-            assert_satisfies_protocol(_BrokenBuffer(), PostTrainingBufferProtocol, name="broken_buf")
-
-    def test_assert_satisfies_error_includes_name(self):
-        with pytest.raises(TypeError, match="my_buffer"):
-            assert_satisfies_protocol(_BrokenBuffer(), PostTrainingBufferProtocol, name="my_buffer")
+            assert_buffer_contract(_BrokenBuffer())
 
 
-class TestPostTrainingCollectorProtocol:
+class TestCollectorContract:
     def test_minimal_collector_satisfies(self):
-        assert isinstance(_MinimalCollector(), PostTrainingCollectorProtocol)
+        assert_collector_contract(_MinimalCollector())
 
     def test_plain_object_does_not_satisfy(self):
-        assert not isinstance(object(), PostTrainingCollectorProtocol)
-
-    def test_assert_satisfies_passes(self):
-        assert_satisfies_protocol(_MinimalCollector(), PostTrainingCollectorProtocol, name="col")
-
-    def test_assert_satisfies_raises(self):
-        with pytest.raises(TypeError):
-            assert_satisfies_protocol(object(), PostTrainingCollectorProtocol, name="bad")
+        with pytest.raises(TypeError, match="update_policy_weights_"):
+            assert_collector_contract(object())
 
 
-class TestGRPOLossOutputProtocol:
+class TestLossContract:
     def test_minimal_grpo_output_satisfies(self):
-        assert_satisfies_protocol(_MinimalGRPOOutput(), GRPOLossOutputProtocol)
-
-    def test_broken_output_does_not_satisfy(self):
-        with pytest.raises(TypeError):
-            assert_satisfies_protocol(_BrokenOutput(), GRPOLossOutputProtocol)
+        assert_loss_contract(_MinimalGRPOOutput(), loss_type="grpo")
 
     def test_grpo_loss_output_satisfies(self):
         out = GRPOLossOutput(
@@ -128,59 +105,50 @@ class TestGRPOLossOutputProtocol:
             kl_approx=torch.tensor(0.0),
             ESS=torch.tensor(1.0),
         )
-        assert_satisfies_protocol(out, GRPOLossOutputProtocol, name="grpo_out")
+        assert_loss_contract(out, loss_type="grpo")
 
-    def test_sft_output_does_not_satisfy_grpo_protocol(self):
-        """SFTLossOutput must NOT satisfy GRPOLossOutputProtocol (has loss_sft, not loss_objective)."""
-        out = SFTLossOutput(loss_sft=torch.tensor(0.2))
-        with pytest.raises(TypeError):
-            assert_satisfies_protocol(out, GRPOLossOutputProtocol)
-
-
-class TestSFTLossOutputProtocol:
     def test_minimal_sft_output_satisfies(self):
-        assert_satisfies_protocol(_MinimalSFTOutput(), SFTLossOutputProtocol)
-
-    def test_broken_output_does_not_satisfy(self):
-        with pytest.raises(TypeError):
-            assert_satisfies_protocol(_BrokenOutput(), SFTLossOutputProtocol)
+        assert_loss_contract(_MinimalSFTOutput(), loss_type="sft")
 
     def test_sft_loss_output_satisfies(self):
         out = SFTLossOutput(loss_sft=torch.tensor(0.2))
-        assert_satisfies_protocol(out, SFTLossOutputProtocol, name="sft_out")
+        assert_loss_contract(out, loss_type="sft")
 
-    def test_grpo_output_does_not_satisfy_sft_protocol(self):
-        """GRPOLossOutput must NOT satisfy SFTLossOutputProtocol (has loss_objective, not loss_sft)."""
+    def test_grpo_output_fails_sft_contract(self):
         out = GRPOLossOutput(
             loss_objective=torch.tensor(0.1),
             clip_fraction=torch.tensor(0.0),
             kl_approx=torch.tensor(0.0),
             ESS=torch.tensor(1.0),
         )
+        with pytest.raises(TypeError, match="loss_sft"):
+            assert_loss_contract(out, loss_type="sft")
+
+    def test_sft_output_fails_grpo_contract(self):
+        out = SFTLossOutput(loss_sft=torch.tensor(0.2))
+        with pytest.raises(TypeError, match="loss_objective"):
+            assert_loss_contract(out, loss_type="grpo")
+
+    def test_broken_output_does_not_satisfy(self):
         with pytest.raises(TypeError):
-            assert_satisfies_protocol(out, SFTLossOutputProtocol)
+            assert_loss_contract(_BrokenOutput(), loss_type="grpo")
+
+    def test_invalid_loss_type(self):
+        with pytest.raises(ValueError, match="Unknown loss_type"):
+            assert_loss_contract(_MinimalGRPOOutput(), loss_type="ppo")
 
 
-class TestAssertSatisfiesProtocol:
-    def test_no_name_in_error(self):
-        with pytest.raises(TypeError):
-            assert_satisfies_protocol(_BrokenBuffer(), PostTrainingBufferProtocol)
-
+class TestInitExports:
     def test_importable_from_top_level_data_llm(self):
-        from torchrl.data.llm import assert_satisfies_protocol as asp
-        assert asp is assert_satisfies_protocol
-
-    def test_protocols_importable_from_top_level_data_llm(self):
         from torchrl.data.llm import (
-            GRPOLossOutputProtocol as GLOP,
-            PostTrainingBufferProtocol as PBP,
-            PostTrainingCollectorProtocol as PCP,
-            SFTLossOutputProtocol as SLOP,
+            assert_buffer_contract,
+            assert_collector_contract,
+            assert_loss_contract,
         )
-        assert PBP is PostTrainingBufferProtocol
-        assert PCP is PostTrainingCollectorProtocol
-        assert GLOP is GRPOLossOutputProtocol
-        assert SLOP is SFTLossOutputProtocol
+
+        assert assert_buffer_contract is not None
+        assert assert_collector_contract is not None
+        assert assert_loss_contract is not None
 
 
 if __name__ == "__main__":

--- a/test/test_llm_contracts.py
+++ b/test/test_llm_contracts.py
@@ -1,0 +1,230 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Tests for WS1: Stable component boundary Protocols (torchrl/data/llm/contracts.py)."""
+from __future__ import annotations
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from torchrl.data import ReplayBuffer, LazyTensorStorage
+from torchrl.data.llm.contracts import (
+    PostTrainingBufferProtocol,
+    PostTrainingCollectorProtocol,
+    PostTrainingLossOutputProtocol,
+    assert_satisfies_protocol,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_rb(capacity: int = 100) -> ReplayBuffer:
+    return ReplayBuffer(storage=LazyTensorStorage(capacity), batch_size=4)
+
+
+class _MinimalBuffer:
+    """A hand-rolled buffer that satisfies PostTrainingBufferProtocol."""
+
+    def __init__(self):
+        self._count = 0
+
+    def extend(self, data):
+        self._count += len(data)
+
+    def sample(self, batch_size=None):
+        return TensorDict({"x": torch.zeros(batch_size or 4)}, [batch_size or 4])
+
+    @property
+    def write_count(self) -> int:
+        return self._count
+
+
+class _BrokenBuffer:
+    """Missing write_count — does NOT satisfy the protocol."""
+
+    def extend(self, data):
+        pass
+
+    def sample(self, batch_size=None):
+        return TensorDict({}, [])
+
+
+class _MinimalCollector:
+    """Satisfies PostTrainingCollectorProtocol without inheriting anything."""
+
+    def update_policy_weights_(self, policy_weights=None, *, worker_ids=None):
+        pass
+
+    def __iter__(self):
+        return iter([TensorDict({}, [])])
+
+    def __next__(self):
+        return TensorDict({}, [])
+
+
+class _MinimalLossOutput:
+    """Satisfies PostTrainingLossOutputProtocol."""
+
+    @property
+    def loss_objective(self) -> torch.Tensor | None:
+        """Primary policy optimisation loss, or ``None`` if not computed.
+
+        .. note::
+            :class:`~torchrl.objectives.llm.SFTLossOutput` exposes
+            ``loss_sft`` rather than ``loss_objective``.  Both satisfy this
+            protocol because ``loss_objective`` is optional (may be
+            ``None``).  :class:`~torchrl.record.loggers.llm.PostTrainingLogger`
+            reads all fields via ``getattr`` duck-typing.
+        """
+        return torch.tensor(0.5)
+
+    @property
+    def loss_sft(self) -> torch.Tensor | None:
+        """SFT loss term — present on SFTLossOutput/EI outputs."""
+        return None
+
+
+class _BrokenLossOutput:
+    """Missing loss_objective — does NOT satisfy the protocol."""
+    pass
+
+
+# ---------------------------------------------------------------------------
+# PostTrainingBufferProtocol
+# ---------------------------------------------------------------------------
+
+
+class TestPostTrainingBufferProtocol:
+    def test_torchrl_replay_buffer_satisfies(self):
+        """Built-in ReplayBuffer must satisfy the protocol."""
+        rb = _make_rb()
+        assert isinstance(rb, PostTrainingBufferProtocol)
+
+    def test_minimal_custom_buffer_satisfies(self):
+        """A hand-rolled buffer with the required attrs satisfies the protocol."""
+        buf = _MinimalBuffer()
+        assert isinstance(buf, PostTrainingBufferProtocol)
+
+    def test_broken_buffer_does_not_satisfy(self):
+        """A buffer missing write_count does NOT satisfy the protocol."""
+        broken = _BrokenBuffer()
+        assert not isinstance(broken, PostTrainingBufferProtocol)
+
+    def test_assert_satisfies_passes_silently(self):
+        """assert_satisfies_protocol must not raise for a compliant object."""
+        rb = _make_rb()
+        assert_satisfies_protocol(rb, PostTrainingBufferProtocol, name="rb")
+
+    def test_assert_satisfies_raises_for_broken(self):
+        """assert_satisfies_protocol must raise TypeError for a violating object."""
+        broken = _BrokenBuffer()
+        with pytest.raises(TypeError, match="write_count"):
+            assert_satisfies_protocol(broken, PostTrainingBufferProtocol, name="broken_buf")
+
+    def test_assert_satisfies_error_includes_name(self):
+        """Error message must include the name argument."""
+        broken = _BrokenBuffer()
+        with pytest.raises(TypeError, match="my_buffer"):
+            assert_satisfies_protocol(broken, PostTrainingBufferProtocol, name="my_buffer")
+
+
+# ---------------------------------------------------------------------------
+# PostTrainingCollectorProtocol
+# ---------------------------------------------------------------------------
+
+
+class TestPostTrainingCollectorProtocol:
+    def test_minimal_collector_satisfies(self):
+        col = _MinimalCollector()
+        assert isinstance(col, PostTrainingCollectorProtocol)
+
+    def test_plain_object_does_not_satisfy(self):
+        assert not isinstance(object(), PostTrainingCollectorProtocol)
+
+    def test_assert_satisfies_passes(self):
+        col = _MinimalCollector()
+        assert_satisfies_protocol(col, PostTrainingCollectorProtocol, name="col")
+
+    def test_assert_satisfies_raises(self):
+        with pytest.raises(TypeError):
+            assert_satisfies_protocol(object(), PostTrainingCollectorProtocol, name="bad")
+
+
+# ---------------------------------------------------------------------------
+# PostTrainingLossOutputProtocol
+# ---------------------------------------------------------------------------
+
+
+class TestPostTrainingLossOutputProtocol:
+    def test_minimal_loss_output_satisfies(self):
+        out = _MinimalLossOutput()
+        # Use assert_satisfies_protocol (getattr-based) instead of isinstance
+        assert_satisfies_protocol(out, PostTrainingLossOutputProtocol, name="minimal")
+
+    def test_broken_loss_output_does_not_satisfy(self):
+        with pytest.raises(TypeError):
+            assert_satisfies_protocol(
+                _BrokenLossOutput(), PostTrainingLossOutputProtocol
+            )
+
+    def test_grpo_loss_output_satisfies(self):
+        """GRPOLossOutput must satisfy the protocol (via assert_satisfies_protocol)."""
+        pytest.importorskip("torchrl.objectives.llm.grpo")
+        from torchrl.objectives.llm.grpo import GRPOLossOutput
+        out = GRPOLossOutput(
+            loss_objective=torch.tensor(0.1),
+            clip_fraction=torch.tensor(0.0),
+            kl_approx=torch.tensor(0.0),
+            ESS=torch.tensor(1.0),
+        )
+        # GRPOLossOutput is a TensorClass: isinstance won't work, but
+        # assert_satisfies_protocol uses getattr-based checking.
+        assert_satisfies_protocol(out, PostTrainingLossOutputProtocol, name="grpo_out")
+
+    def test_sft_loss_output_satisfies(self):
+        """SFTLossOutput must satisfy the protocol (it has loss_sft)."""
+        pytest.importorskip("torchrl.objectives.llm.sft")
+        from torchrl.objectives.llm.sft import SFTLossOutput
+        out = SFTLossOutput(loss_sft=torch.tensor(0.2))
+        assert_satisfies_protocol(out, PostTrainingLossOutputProtocol, name="sft_out")
+
+    def test_assert_satisfies_passes(self):
+        out = _MinimalLossOutput()
+        assert_satisfies_protocol(out, PostTrainingLossOutputProtocol, name="loss_out")
+
+    def test_assert_satisfies_raises(self):
+        with pytest.raises(TypeError):
+            assert_satisfies_protocol(_BrokenLossOutput(), PostTrainingLossOutputProtocol)
+
+
+# ---------------------------------------------------------------------------
+# assert_satisfies_protocol — edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestAssertSatisfiesProtocol:
+    def test_no_name_in_error(self):
+        """Without a name argument the error must still be raised."""
+        broken = _BrokenBuffer()
+        with pytest.raises(TypeError):
+            assert_satisfies_protocol(broken, PostTrainingBufferProtocol)
+
+    def test_importable_from_top_level_data_llm(self):
+        """Must be importable from the torchrl.data.llm namespace."""
+        from torchrl.data.llm import assert_satisfies_protocol as asp
+        assert asp is assert_satisfies_protocol
+
+    def test_protocols_importable_from_top_level_data_llm(self):
+        from torchrl.data.llm import (
+            PostTrainingBufferProtocol as PBP,
+            PostTrainingCollectorProtocol as PCP,
+            PostTrainingLossOutputProtocol as PLOP,
+        )
+        assert PBP is PostTrainingBufferProtocol
+        assert PCP is PostTrainingCollectorProtocol
+        assert PLOP is PostTrainingLossOutputProtocol

--- a/torchrl/data/llm/__init__.py
+++ b/torchrl/data/llm/__init__.py
@@ -4,11 +4,9 @@
 # LICENSE file in the root directory of this source tree.
 
 from .contracts import (
-    GRPOLossOutputProtocol,
-    PostTrainingBufferProtocol,
-    PostTrainingCollectorProtocol,
-    SFTLossOutputProtocol,
-    assert_satisfies_protocol,
+    assert_buffer_contract,
+    assert_collector_contract,
+    assert_loss_contract,
 )
 from .dataset import (
     create_infinite_iterator,
@@ -24,20 +22,18 @@ from .utils import AdaptiveKLController, ConstantKLController, RolloutFromModel
 
 __all__ = [
     "AdaptiveKLController",
-    "assert_satisfies_protocol",
+    "assert_buffer_contract",
+    "assert_collector_contract",
+    "assert_loss_contract",
     "ConstantKLController",
     "ContentBase",
-    "GRPOLossOutputProtocol",
     "History",
     "PairwiseDataset",
-    "PostTrainingBufferProtocol",
-    "PostTrainingCollectorProtocol",
     "PromptData",
     "add_chat_template",
     "PromptTensorDictTokenizer",
     "RewardData",
     "RolloutFromModel",
-    "SFTLossOutputProtocol",
     "TensorDictTokenizer",
     "TokenizedDatasetLoader",
     "create_infinite_iterator",

--- a/torchrl/data/llm/__init__.py
+++ b/torchrl/data/llm/__init__.py
@@ -4,9 +4,10 @@
 # LICENSE file in the root directory of this source tree.
 
 from .contracts import (
+    GRPOLossOutputProtocol,
     PostTrainingBufferProtocol,
     PostTrainingCollectorProtocol,
-    PostTrainingLossOutputProtocol,
+    SFTLossOutputProtocol,
     assert_satisfies_protocol,
 )
 from .dataset import (
@@ -26,16 +27,17 @@ __all__ = [
     "assert_satisfies_protocol",
     "ConstantKLController",
     "ContentBase",
+    "GRPOLossOutputProtocol",
     "History",
     "PairwiseDataset",
     "PostTrainingBufferProtocol",
     "PostTrainingCollectorProtocol",
-    "PostTrainingLossOutputProtocol",
     "PromptData",
     "add_chat_template",
     "PromptTensorDictTokenizer",
     "RewardData",
     "RolloutFromModel",
+    "SFTLossOutputProtocol",
     "TensorDictTokenizer",
     "TokenizedDatasetLoader",
     "create_infinite_iterator",

--- a/torchrl/data/llm/__init__.py
+++ b/torchrl/data/llm/__init__.py
@@ -3,6 +3,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from .contracts import (
+    PostTrainingBufferProtocol,
+    PostTrainingCollectorProtocol,
+    PostTrainingLossOutputProtocol,
+    assert_satisfies_protocol,
+)
 from .dataset import (
     create_infinite_iterator,
     get_dataloader,
@@ -17,10 +23,14 @@ from .utils import AdaptiveKLController, ConstantKLController, RolloutFromModel
 
 __all__ = [
     "AdaptiveKLController",
+    "assert_satisfies_protocol",
     "ConstantKLController",
     "ContentBase",
     "History",
     "PairwiseDataset",
+    "PostTrainingBufferProtocol",
+    "PostTrainingCollectorProtocol",
+    "PostTrainingLossOutputProtocol",
     "PromptData",
     "add_chat_template",
     "PromptTensorDictTokenizer",

--- a/torchrl/data/llm/contracts.py
+++ b/torchrl/data/llm/contracts.py
@@ -2,13 +2,15 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-"""
-Defines validation helper functions for replay buffers, collectors, and
-loss outputs so external training loops (TRL, NeMo-RL, custom) can consume
-individual TorchRL components with confidence.
+"""Defines validation helper functions for TorchRL LLM components.
+
+Provides helpers for replay buffers, collectors, and loss outputs so external
+training loops (TRL, NeMo-RL, custom) can consume individual TorchRL components
+with confidence.
 """
 from __future__ import annotations
 
+import collections.abc
 from typing import Any
 
 __all__ = [
@@ -31,13 +33,15 @@ def assert_buffer_contract(buffer: Any) -> None:
         buffer: The buffer object to validate.
 
     Raises:
-        TypeError: If the buffer is missing ``extend``, ``sample``, or ``write_count``.
+        TypeError: If the buffer is missing a callable ``extend``, a callable ``sample``, or ``write_count``.
     """
-    missing = [
-        attr
-        for attr in ("extend", "sample", "write_count")
-        if not hasattr(buffer, attr)
-    ]
+    missing = []
+    if not callable(getattr(buffer, "extend", None)):
+        missing.append("extend (callable)")
+    if not callable(getattr(buffer, "sample", None)):
+        missing.append("sample (callable)")
+    if not hasattr(buffer, "write_count"):
+        missing.append("write_count")
     if missing:
         raise TypeError(
             f"Object of type '{type(buffer).__name__}' does not satisfy the "
@@ -60,13 +64,13 @@ def assert_collector_contract(collector: Any) -> None:
         collector: The collector object to validate.
 
     Raises:
-        TypeError: If the collector is missing ``update_policy_weights_``, ``__iter__``, or ``__next__``.
+        TypeError: If the collector is missing a callable ``update_policy_weights_``, or ``__iter__``.
     """
-    missing = [
-        attr
-        for attr in ("update_policy_weights_", "__iter__", "__next__")
-        if not hasattr(collector, attr)
-    ]
+    missing = []
+    if not callable(getattr(collector, "update_policy_weights_", None)):
+        missing.append("update_policy_weights_ (callable)")
+    if not isinstance(collector, collections.abc.Iterable):
+        missing.append("__iter__")
     if missing:
         raise TypeError(
             f"Object of type '{type(collector).__name__}' does not satisfy the "

--- a/torchrl/data/llm/contracts.py
+++ b/torchrl/data/llm/contracts.py
@@ -4,30 +4,23 @@
 # LICENSE file in the root directory of this source tree.
 """Stable component boundaries for LLM post-training external-loop interop (RFC #3948, WS1).
 
-Defines ``typing.Protocol`` interfaces for replay buffers, collectors, and
+Defines validation helper functions for replay buffers, collectors, and
 loss outputs so external training loops (TRL, NeMo-RL, custom) can consume
-individual TorchRL components without depending on concrete classes.
+individual TorchRL components with confidence.
 """
 from __future__ import annotations
 
-from typing import Any, Iterator, runtime_checkable
-
-import torch
-from tensordict import TensorDictBase
-from typing_extensions import Protocol
+from typing import Any
 
 __all__ = [
-    "PostTrainingBufferProtocol",
-    "PostTrainingCollectorProtocol",
-    "GRPOLossOutputProtocol",
-    "SFTLossOutputProtocol",
-    "assert_satisfies_protocol",
+    "assert_buffer_contract",
+    "assert_collector_contract",
+    "assert_loss_contract",
 ]
 
 
-@runtime_checkable
-class PostTrainingBufferProtocol(Protocol):
-    """Minimal interface a replay buffer must expose for post-training loops.
+def assert_buffer_contract(buffer: Any) -> None:
+    """Assert that a replay buffer exposes the necessary methods for post-training.
 
     **TensorDict key contract** — samples must carry:
 
@@ -35,32 +28,26 @@ class PostTrainingBufferProtocol(Protocol):
     * ``("tokens", "full")`` — full token sequence, shape ``[B, T]``.
     * ``("tokens", "response")`` — response tokens, shape ``[B, R]`` or ragged.
 
-    Example::
+    Args:
+        buffer: The buffer object to validate.
 
-        >>> from torchrl.data import ReplayBuffer, LazyTensorStorage
-        >>> from torchrl.data.llm.contracts import PostTrainingBufferProtocol
-        >>> rb = ReplayBuffer(storage=LazyTensorStorage(100))
-        >>> isinstance(rb, PostTrainingBufferProtocol)
-        True
+    Raises:
+        TypeError: If the buffer is missing ``extend``, ``sample``, or ``write_count``.
     """
-
-    def extend(self, data: TensorDictBase) -> None:
-        """Append a batch of trajectories to the buffer."""
-        ...
-
-    def sample(self, batch_size: int | None = None) -> TensorDictBase:
-        """Sample a batch from the buffer."""
-        ...
-
-    @property
-    def write_count(self) -> int:
-        """Total number of samples written since creation."""
-        ...
+    missing = [
+        attr
+        for attr in ("extend", "sample", "write_count")
+        if not hasattr(buffer, attr)
+    ]
+    if missing:
+        raise TypeError(
+            f"Object of type '{type(buffer).__name__}' does not satisfy the "
+            f"post-training buffer contract.\n  Missing: {', '.join(missing)}"
+        )
 
 
-@runtime_checkable
-class PostTrainingCollectorProtocol(Protocol):
-    """Minimal interface an LLM rollout collector must expose.
+def assert_collector_contract(collector: Any) -> None:
+    """Assert that a rollout collector exposes the necessary methods.
 
     **TensorDict key contract** — each yielded batch must carry:
 
@@ -70,150 +57,52 @@ class PostTrainingCollectorProtocol(Protocol):
     * ``("next", "reward")`` — reward signal, shape ``[B, ...]``.
     * ``("masks", "all_attention_mask")`` — boolean mask, shape ``[B, T]``.
 
-    Example::
-
-        >>> from torchrl.data.llm.contracts import PostTrainingCollectorProtocol
-        >>> class MyCollector:
-        ...     def update_policy_weights_(self, policy_weights=None, *, worker_ids=None): ...
-        ...     def __iter__(self): return iter([])
-        ...     def __next__(self): raise StopIteration
-        >>> isinstance(MyCollector(), PostTrainingCollectorProtocol)
-        True
-    """
-
-    def update_policy_weights_(
-        self,
-        policy_weights: Any | None = None,
-        *,
-        worker_ids: list[int] | None = None,
-    ) -> None:
-        """Push updated policy weights to inference workers."""
-        ...
-
-    def __iter__(self) -> Iterator[TensorDictBase]:
-        ...
-
-    def __next__(self) -> TensorDictBase:
-        ...
-
-
-class GRPOLossOutputProtocol(Protocol):
-    """Interface satisfied by :class:`~torchrl.objectives.llm.GRPOLossOutput`.
-
-    .. note::
-        ``GRPOLossOutput`` is a ``TensorClass`` subclass whose fields live in
-        TensorDict internals rather than Python ``__dict__``.  Use
-        :func:`assert_satisfies_protocol` instead of ``isinstance``.
-
-    **Field contract** — fields read by ``PostTrainingLogger`` via ``getattr``:
-    ``loss_objective``, ``clip_fraction``, ``kl_approx``, ``ESS``,
-    ``entropy``, ``loss_entropy``, ``loss_kl_to_ref``, ``kl_to_ref``,
-    ``loss_kl_to_inference``, ``kl_to_inference``.
-
-    Example::
-
-        >>> import torch
-        >>> from torchrl.objectives.llm.grpo import GRPOLossOutput
-        >>> from torchrl.data.llm.contracts import GRPOLossOutputProtocol, assert_satisfies_protocol
-        >>> out = GRPOLossOutput(
-        ...     loss_objective=torch.tensor(0.5),
-        ...     clip_fraction=torch.tensor(0.1),
-        ...     kl_approx=torch.tensor(0.01),
-        ...     ESS=torch.tensor(32.0),
-        ... )
-        >>> assert_satisfies_protocol(out, GRPOLossOutputProtocol)
-    """
-
-    @property
-    def loss_objective(self) -> torch.Tensor:
-        """Primary GRPO policy loss."""
-        ...
-
-
-class SFTLossOutputProtocol(Protocol):
-    """Interface satisfied by :class:`~torchrl.objectives.llm.SFTLossOutput`.
-
-    .. note::
-        ``SFTLossOutput`` is a ``TensorClass`` subclass whose fields live in
-        TensorDict internals rather than Python ``__dict__``.  Use
-        :func:`assert_satisfies_protocol` instead of ``isinstance``.
-
-    **Field contract** — fields read by ``PostTrainingLogger`` via ``getattr``:
-    ``loss_sft``, ``kl_to_ref``, ``loss_kl_to_ref``.
-
-    Example::
-
-        >>> import torch
-        >>> from torchrl.objectives.llm.sft import SFTLossOutput
-        >>> from torchrl.data.llm.contracts import SFTLossOutputProtocol, assert_satisfies_protocol
-        >>> out = SFTLossOutput(loss_sft=torch.tensor(0.3))
-        >>> assert_satisfies_protocol(out, SFTLossOutputProtocol)
-    """
-
-    @property
-    def loss_sft(self) -> torch.Tensor:
-        """Supervised fine-tuning loss."""
-        ...
-
-
-# Maps each loss-output protocol to the single field it requires.
-_LOSS_PROTOCOL_FIELDS: dict[type, str] = {
-    GRPOLossOutputProtocol: "loss_objective",
-    SFTLossOutputProtocol: "loss_sft",
-}
-
-
-def assert_satisfies_protocol(
-    obj: Any,
-    protocol: type,
-    *,
-    name: str = "",
-) -> None:
-    """Raise :class:`TypeError` if *obj* does not satisfy *protocol*.
-
-    Development utility — call once at the start of a training loop to
-    catch integration bugs early. Not intended for hot paths.
-
     Args:
-        obj: Object to validate.
-        protocol: A :class:`~typing.Protocol` to check against.
-        name: Optional label included in the error message.
+        collector: The collector object to validate.
 
     Raises:
-        TypeError: If *obj* does not satisfy *protocol*.
-
-    Example::
-
-        >>> from torchrl.data import ReplayBuffer, LazyTensorStorage
-        >>> from torchrl.data.llm.contracts import (
-        ...     PostTrainingBufferProtocol, assert_satisfies_protocol,
-        ... )
-        >>> rb = ReplayBuffer(storage=LazyTensorStorage(100))
-        >>> assert_satisfies_protocol(rb, PostTrainingBufferProtocol, name="rb")
+        TypeError: If the collector is missing ``update_policy_weights_``, ``__iter__``, or ``__next__``.
     """
-    label = f'"{name}" ' if name else ""
-
-    if protocol in _LOSS_PROTOCOL_FIELDS:
-        # GRPOLossOutput / SFTLossOutput are TensorClass subclasses: their fields
-        # live in TensorDict internals, not Python __dict__, so isinstance fails.
-        required_field = _LOSS_PROTOCOL_FIELDS[protocol]
-        if getattr(obj, required_field, None) is None:
-            raise TypeError(
-                f"Object {label}of type '{type(obj).__name__}' does not satisfy "
-                f"'{protocol.__name__}'.\n"
-                f"  Must expose a non-None '{required_field}' field."
-            )
-        return
-
-    if not isinstance(obj, protocol):
-        protocol_name = getattr(protocol, "__name__", str(protocol))
-        missing = [
-            attr
-            for attr in getattr(protocol, "__protocol_attrs__", [])
-            if not hasattr(obj, attr)
-        ]
-        missing_str = f"  Missing: {', '.join(missing)}" if missing else ""
+    missing = [
+        attr
+        for attr in ("update_policy_weights_", "__iter__", "__next__")
+        if not hasattr(collector, attr)
+    ]
+    if missing:
         raise TypeError(
-            f"Object {label}of type '{type(obj).__name__}' does not satisfy "
-            f"'{protocol_name}'.\n{missing_str}"
+            f"Object of type '{type(collector).__name__}' does not satisfy the "
+            f"post-training collector contract.\n  Missing: {', '.join(missing)}"
+        )
+
+
+def assert_loss_contract(loss_output: Any, *, loss_type: str = "grpo") -> None:
+    """Assert that a loss-output object exposes the necessary fields.
+
+    **Field contract** — fields read by ``PostTrainingLogger`` via ``getattr``:
+
+    * For GRPO: ``loss_objective``, ``clip_fraction``, ``kl_approx``, ``ESS``,
+      ``entropy``, ``loss_entropy``, ``loss_kl_to_ref``, ``kl_to_ref``,
+      ``loss_kl_to_inference``, ``kl_to_inference``.
+    * For SFT: ``loss_sft``, ``kl_to_ref``, ``loss_kl_to_ref``.
+
+    Args:
+        loss_output: The loss output object (usually a ``TensorClass``) to validate.
+        loss_type: The expected loss type, either ``"grpo"`` or ``"sft"``.
+
+    Raises:
+        TypeError: If the required field (``loss_objective`` or ``loss_sft``) is missing or None.
+        ValueError: If an unknown ``loss_type`` is requested.
+    """
+    if loss_type == "grpo":
+        required_field = "loss_objective"
+    elif loss_type == "sft":
+        required_field = "loss_sft"
+    else:
+        raise ValueError(f"Unknown loss_type '{loss_type}'. Expected 'grpo' or 'sft'.")
+
+    if getattr(loss_output, required_field, None) is None:
+        raise TypeError(
+            f"Object of type '{type(loss_output).__name__}' does not satisfy the "
+            f"'{loss_type}' loss contract.\n"
+            f"  Must expose a non-None '{required_field}' field."
         )

--- a/torchrl/data/llm/contracts.py
+++ b/torchrl/data/llm/contracts.py
@@ -1,0 +1,164 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Stable component boundaries for LLM post-training external-loop interop (RFC #3948, WS1).
+
+Defines ``typing.Protocol`` interfaces for replay buffers, collectors, and
+loss outputs so external training loops (TRL, NeMo-RL, custom) can consume
+individual TorchRL components without depending on concrete classes.
+"""
+from __future__ import annotations
+
+from typing import Any, Iterator, runtime_checkable
+
+import torch
+from tensordict import TensorDictBase
+from typing_extensions import Protocol
+
+__all__ = [
+    "PostTrainingBufferProtocol",
+    "PostTrainingCollectorProtocol",
+    "PostTrainingLossOutputProtocol",
+    "assert_satisfies_protocol",
+]
+
+
+@runtime_checkable
+class PostTrainingBufferProtocol(Protocol):
+    """Minimal interface a replay buffer must expose for post-training loops.
+
+    **TensorDict key contract** — samples must carry:
+
+    * ``("next", "reward")`` — reward signal, shape ``[B, ...]``.
+    * ``("tokens", "full")`` — full token sequence, shape ``[B, T]``.
+    * ``("tokens", "response")`` — response tokens, shape ``[B, R]`` or ragged.
+    """
+
+    def extend(self, data: TensorDictBase) -> None:
+        """Append a batch of trajectories to the buffer."""
+        ...
+
+    def sample(self, batch_size: int | None = None) -> TensorDictBase:
+        """Sample a batch from the buffer."""
+        ...
+
+    @property
+    def write_count(self) -> int:
+        """Total number of samples written since creation."""
+        ...
+
+
+@runtime_checkable
+class PostTrainingCollectorProtocol(Protocol):
+    """Minimal interface an LLM rollout collector must expose.
+
+    **TensorDict key contract** — each yielded batch must carry:
+
+    * ``("tokens", "full")`` — full token sequence, shape ``[B, T]``.
+    * ``("tokens", "prompt")`` — prompt tokens, shape ``[B, P]``.
+    * ``("tokens", "response")`` — response tokens, shape ``[B, R]``.
+    * ``("next", "reward")`` — reward signal, shape ``[B, ...]``.
+    * ``("masks", "all_attention_mask")`` — boolean mask, shape ``[B, T]``.
+    """
+
+    def update_policy_weights_(
+        self,
+        policy_weights: Any | None = None,
+        *,
+        worker_ids: list[int] | None = None,
+    ) -> None:
+        """Push updated policy weights to inference workers."""
+        ...
+
+    def __iter__(self) -> Iterator[TensorDictBase]:
+        ...
+
+    def __next__(self) -> TensorDictBase:
+        ...
+
+
+class PostTrainingLossOutputProtocol(Protocol):
+    """Minimal interface a loss-output object must expose.
+
+    ``GRPOLossOutput`` and ``SFTLossOutput`` satisfy this protocol structurally.
+
+    .. note::
+        Both are ``TensorClass`` subclasses so standard ``isinstance`` checks
+        will not work. Use :func:`assert_satisfies_protocol` instead.
+
+    **Optional fields** read via ``getattr`` by ``PostTrainingLogger``:
+    ``loss_objective``, ``loss_sft``, ``clip_fraction``, ``kl_approx``,
+    ``ESS``, ``entropy``, ``loss_entropy``, ``loss_kl_to_ref``, ``kl_to_ref``,
+    ``loss_kl_to_inference``, ``kl_to_inference``.
+    """
+
+    @property
+    def loss_objective(self) -> torch.Tensor | None:
+        """Primary policy loss (GRPO/PPO), or ``None`` if not computed."""
+        ...
+
+    @property
+    def loss_sft(self) -> torch.Tensor | None:
+        """SFT loss (SFT / Expert Iteration outputs)."""
+        ...
+
+
+# Primary loss fields checked by assert_satisfies_protocol for TensorClass outputs.
+_LOSS_OUTPUT_FIELDS: tuple[str, ...] = ("loss_objective", "loss_sft")
+
+
+def assert_satisfies_protocol(
+    obj: Any,
+    protocol: type,
+    *,
+    name: str = "",
+) -> None:
+    """Raise :class:`TypeError` if *obj* does not satisfy *protocol*.
+
+    Development utility — call once at the start of a training loop to
+    catch integration bugs early. Not intended for hot paths.
+
+    Args:
+        obj: Object to validate.
+        protocol: A :class:`~typing.Protocol` to check against.
+        name: Optional label included in the error message.
+
+    Raises:
+        TypeError: If *obj* does not satisfy *protocol*.
+
+    Example::
+
+        >>> from torchrl.data import ReplayBuffer, LazyTensorStorage
+        >>> from torchrl.data.llm.contracts import (
+        ...     PostTrainingBufferProtocol, assert_satisfies_protocol,
+        ... )
+        >>> rb = ReplayBuffer(storage=LazyTensorStorage(100))
+        >>> assert_satisfies_protocol(rb, PostTrainingBufferProtocol, name="rb")
+    """
+    if protocol is PostTrainingLossOutputProtocol:
+        # GRPOLossOutput / SFTLossOutput are TensorClass subclasses: their fields
+        # live in TensorDict internals, not Python __dict__, so isinstance fails.
+        has_any = any(getattr(obj, f, None) is not None for f in _LOSS_OUTPUT_FIELDS)
+        if not has_any:
+            label = f'"{name}" ' if name else ""
+            raise TypeError(
+                f"Object {label}of type '{type(obj).__name__}' does not satisfy "
+                f"'PostTrainingLossOutputProtocol'.\n"
+                f"  Must expose at least one of: {', '.join(_LOSS_OUTPUT_FIELDS)}"
+            )
+        return
+
+    if not isinstance(obj, protocol):
+        label = f'"{name}" ' if name else ""
+        protocol_name = getattr(protocol, "__name__", str(protocol))
+        missing = [
+            attr
+            for attr in getattr(protocol, "__protocol_attrs__", [])
+            if not hasattr(obj, attr)
+        ]
+        missing_str = f"  Missing: {', '.join(missing)}" if missing else ""
+        raise TypeError(
+            f"Object {label}of type '{type(obj).__name__}' does not satisfy "
+            f"'{protocol_name}'.\n{missing_str}"
+        )

--- a/torchrl/data/llm/contracts.py
+++ b/torchrl/data/llm/contracts.py
@@ -2,8 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-"""Stable component boundaries for LLM post-training external-loop interop (RFC #3948, WS1).
-
+"""
 Defines validation helper functions for replay buffers, collectors, and
 loss outputs so external training loops (TRL, NeMo-RL, custom) can consume
 individual TorchRL components with confidence.

--- a/torchrl/data/llm/contracts.py
+++ b/torchrl/data/llm/contracts.py
@@ -19,7 +19,8 @@ from typing_extensions import Protocol
 __all__ = [
     "PostTrainingBufferProtocol",
     "PostTrainingCollectorProtocol",
-    "PostTrainingLossOutputProtocol",
+    "GRPOLossOutputProtocol",
+    "SFTLossOutputProtocol",
     "assert_satisfies_protocol",
 ]
 
@@ -33,6 +34,14 @@ class PostTrainingBufferProtocol(Protocol):
     * ``("next", "reward")`` — reward signal, shape ``[B, ...]``.
     * ``("tokens", "full")`` — full token sequence, shape ``[B, T]``.
     * ``("tokens", "response")`` — response tokens, shape ``[B, R]`` or ragged.
+
+    Example::
+
+        >>> from torchrl.data import ReplayBuffer, LazyTensorStorage
+        >>> from torchrl.data.llm.contracts import PostTrainingBufferProtocol
+        >>> rb = ReplayBuffer(storage=LazyTensorStorage(100))
+        >>> isinstance(rb, PostTrainingBufferProtocol)
+        True
     """
 
     def extend(self, data: TensorDictBase) -> None:
@@ -60,6 +69,16 @@ class PostTrainingCollectorProtocol(Protocol):
     * ``("tokens", "response")`` — response tokens, shape ``[B, R]``.
     * ``("next", "reward")`` — reward signal, shape ``[B, ...]``.
     * ``("masks", "all_attention_mask")`` — boolean mask, shape ``[B, T]``.
+
+    Example::
+
+        >>> from torchrl.data.llm.contracts import PostTrainingCollectorProtocol
+        >>> class MyCollector:
+        ...     def update_policy_weights_(self, policy_weights=None, *, worker_ids=None): ...
+        ...     def __iter__(self): return iter([])
+        ...     def __next__(self): raise StopIteration
+        >>> isinstance(MyCollector(), PostTrainingCollectorProtocol)
+        True
     """
 
     def update_policy_weights_(
@@ -78,34 +97,70 @@ class PostTrainingCollectorProtocol(Protocol):
         ...
 
 
-class PostTrainingLossOutputProtocol(Protocol):
-    """Minimal interface a loss-output object must expose.
-
-    ``GRPOLossOutput`` and ``SFTLossOutput`` satisfy this protocol structurally.
+class GRPOLossOutputProtocol(Protocol):
+    """Interface satisfied by :class:`~torchrl.objectives.llm.GRPOLossOutput`.
 
     .. note::
-        Both are ``TensorClass`` subclasses so standard ``isinstance`` checks
-        will not work. Use :func:`assert_satisfies_protocol` instead.
+        ``GRPOLossOutput`` is a ``TensorClass`` subclass whose fields live in
+        TensorDict internals rather than Python ``__dict__``.  Use
+        :func:`assert_satisfies_protocol` instead of ``isinstance``.
 
-    **Optional fields** read via ``getattr`` by ``PostTrainingLogger``:
-    ``loss_objective``, ``loss_sft``, ``clip_fraction``, ``kl_approx``,
-    ``ESS``, ``entropy``, ``loss_entropy``, ``loss_kl_to_ref``, ``kl_to_ref``,
+    **Field contract** — fields read by ``PostTrainingLogger`` via ``getattr``:
+    ``loss_objective``, ``clip_fraction``, ``kl_approx``, ``ESS``,
+    ``entropy``, ``loss_entropy``, ``loss_kl_to_ref``, ``kl_to_ref``,
     ``loss_kl_to_inference``, ``kl_to_inference``.
+
+    Example::
+
+        >>> import torch
+        >>> from torchrl.objectives.llm.grpo import GRPOLossOutput
+        >>> from torchrl.data.llm.contracts import GRPOLossOutputProtocol, assert_satisfies_protocol
+        >>> out = GRPOLossOutput(
+        ...     loss_objective=torch.tensor(0.5),
+        ...     clip_fraction=torch.tensor(0.1),
+        ...     kl_approx=torch.tensor(0.01),
+        ...     ESS=torch.tensor(32.0),
+        ... )
+        >>> assert_satisfies_protocol(out, GRPOLossOutputProtocol)
     """
 
     @property
-    def loss_objective(self) -> torch.Tensor | None:
-        """Primary policy loss (GRPO/PPO), or ``None`` if not computed."""
+    def loss_objective(self) -> torch.Tensor:
+        """Primary GRPO policy loss."""
         ...
+
+
+class SFTLossOutputProtocol(Protocol):
+    """Interface satisfied by :class:`~torchrl.objectives.llm.SFTLossOutput`.
+
+    .. note::
+        ``SFTLossOutput`` is a ``TensorClass`` subclass whose fields live in
+        TensorDict internals rather than Python ``__dict__``.  Use
+        :func:`assert_satisfies_protocol` instead of ``isinstance``.
+
+    **Field contract** — fields read by ``PostTrainingLogger`` via ``getattr``:
+    ``loss_sft``, ``kl_to_ref``, ``loss_kl_to_ref``.
+
+    Example::
+
+        >>> import torch
+        >>> from torchrl.objectives.llm.sft import SFTLossOutput
+        >>> from torchrl.data.llm.contracts import SFTLossOutputProtocol, assert_satisfies_protocol
+        >>> out = SFTLossOutput(loss_sft=torch.tensor(0.3))
+        >>> assert_satisfies_protocol(out, SFTLossOutputProtocol)
+    """
 
     @property
-    def loss_sft(self) -> torch.Tensor | None:
-        """SFT loss (SFT / Expert Iteration outputs)."""
+    def loss_sft(self) -> torch.Tensor:
+        """Supervised fine-tuning loss."""
         ...
 
 
-# Primary loss fields checked by assert_satisfies_protocol for TensorClass outputs.
-_LOSS_OUTPUT_FIELDS: tuple[str, ...] = ("loss_objective", "loss_sft")
+# Maps each loss-output protocol to the single field it requires.
+_LOSS_PROTOCOL_FIELDS: dict[type, str] = {
+    GRPOLossOutputProtocol: "loss_objective",
+    SFTLossOutputProtocol: "loss_sft",
+}
 
 
 def assert_satisfies_protocol(
@@ -136,21 +191,21 @@ def assert_satisfies_protocol(
         >>> rb = ReplayBuffer(storage=LazyTensorStorage(100))
         >>> assert_satisfies_protocol(rb, PostTrainingBufferProtocol, name="rb")
     """
-    if protocol is PostTrainingLossOutputProtocol:
+    label = f'"{name}" ' if name else ""
+
+    if protocol in _LOSS_PROTOCOL_FIELDS:
         # GRPOLossOutput / SFTLossOutput are TensorClass subclasses: their fields
         # live in TensorDict internals, not Python __dict__, so isinstance fails.
-        has_any = any(getattr(obj, f, None) is not None for f in _LOSS_OUTPUT_FIELDS)
-        if not has_any:
-            label = f'"{name}" ' if name else ""
+        required_field = _LOSS_PROTOCOL_FIELDS[protocol]
+        if getattr(obj, required_field, None) is None:
             raise TypeError(
                 f"Object {label}of type '{type(obj).__name__}' does not satisfy "
-                f"'PostTrainingLossOutputProtocol'.\n"
-                f"  Must expose at least one of: {', '.join(_LOSS_OUTPUT_FIELDS)}"
+                f"'{protocol.__name__}'.\n"
+                f"  Must expose a non-None '{required_field}' field."
             )
         return
 
     if not isinstance(obj, protocol):
-        label = f'"{name}" ' if name else ""
         protocol_name = getattr(protocol, "__name__", str(protocol))
         missing = [
             attr

--- a/tutorials/sphinx-tutorials/torchrl_component_contracts.py
+++ b/tutorials/sphinx-tutorials/torchrl_component_contracts.py
@@ -2,34 +2,9 @@
 TorchRL Component Contracts for External Loops (WS1)
 =====================================================
 
-This tutorial documents the **stable component boundaries** introduced by
-Workstream 1 of `RFC #3948 <https://github.com/pytorch/rl/issues/3948>`_.
-
-If you are building a custom training loop (TRL, NeMo-RL, or in-house) and
-want to consume individual TorchRL components, this guide explains exactly
-what interface each component exposes and how to verify your own objects
-satisfy those contracts.
-
-.. note::
-
-    **WS1** deliverable.  See also:
-
-    * `WS2 — TRL Interoperability <trl_interop.html>`_
-    * `WS4 — Post-Training Observability <PostTrainingLogger>`
-
-Why stable boundaries?
------------------------
-TorchRL's components (replay buffers, collectors, loss modules) work together
-through implicit TensorDict key contracts.  Without a formal definition, it is
-hard to know:
-
-* Which keys a ``ReplayBuffer`` sample must carry.
-* What a loss module writes into its output.
-* How a collector exposes policy-weight synchronisation.
-
-The :mod:`torchrl.data.llm.contracts` module formalises these expectations as
-Python ``typing.Protocol`` classes with full docstrings, so adapters stay thin
-and don't break silently across TorchRL version bumps.
+Documents the stable component boundaries from RFC #3948 WS1.
+Shows how to verify that custom buffers, collectors, and loss outputs
+satisfy TorchRL's interfaces using :func:`~torchrl.data.llm.contracts.assert_satisfies_protocol`.
 """
 
 # %%
@@ -40,40 +15,32 @@ import torch
 from tensordict import TensorDict
 from torchrl.data import ReplayBuffer, LazyTensorStorage
 from torchrl.data.llm.contracts import (
+    GRPOLossOutputProtocol,
     PostTrainingBufferProtocol,
     PostTrainingCollectorProtocol,
-    PostTrainingLossOutputProtocol,
+    SFTLossOutputProtocol,
     assert_satisfies_protocol,
 )
+from torchrl.objectives.llm.sft import SFTLossOutput
 
 # %%
-# 1. Buffer contract
-# ------------------
-# Any replay buffer used in a post-training loop must expose:
-#
-# * ``extend(data)`` — write a batch of trajectories.
-# * ``sample(batch_size)`` — draw a batch.
-# * ``write_count`` property — total samples written.
-#
+# Buffer contract
+# ---------------
+# Buffers must expose ``extend``, ``sample``, and ``write_count``.
 # TorchRL's built-in ``ReplayBuffer`` already satisfies this:
 
 rb = ReplayBuffer(storage=LazyTensorStorage(1_000), batch_size=8)
 assert isinstance(rb, PostTrainingBufferProtocol)
-print("ReplayBuffer satisfies PostTrainingBufferProtocol:", True)
 
 # %%
-# You can also verify your own buffer with ``assert_satisfies_protocol``:
+# Custom buffers can be verified with ``assert_satisfies_protocol``:
 
 
 class MyCustomBuffer:
-    """A minimal external buffer that satisfies the protocol."""
-
     def __init__(self):
-        self._data = []
         self._write_count = 0
 
     def extend(self, data):
-        self._data.append(data)
         self._write_count += len(data)
 
     def sample(self, batch_size=None):
@@ -86,11 +53,9 @@ class MyCustomBuffer:
 
 buf = MyCustomBuffer()
 assert_satisfies_protocol(buf, PostTrainingBufferProtocol, name="my_buffer")
-print("MyCustomBuffer satisfies PostTrainingBufferProtocol:", True)
 
 # %%
-# If your buffer is missing a required field, ``assert_satisfies_protocol``
-# raises a ``TypeError`` with a helpful message:
+# Missing a required field raises ``TypeError`` with a helpful message:
 
 
 class IncompleteBuffer:
@@ -100,32 +65,24 @@ class IncompleteBuffer:
     def sample(self, batch_size=None):
         return TensorDict({}, [])
 
-    # Missing: write_count property
-
 
 try:
     assert_satisfies_protocol(IncompleteBuffer(), PostTrainingBufferProtocol)
 except TypeError as e:
-    print(f"Caught expected TypeError: {e}")
+    pass  # expected — write_count is missing
 
 # %%
-# 2. Collector contract
-# ---------------------
-# Any collector must expose:
-#
-# * ``update_policy_weights_(...)`` — push updated weights to inference workers.
-# * ``__iter__`` / ``__next__`` — yield rollout batches as ``TensorDictBase``.
-#
-# Here is a minimal external collector that satisfies the contract:
+# Collector contract
+# ------------------
+# Collectors must expose ``update_policy_weights_``, ``__iter__``, and ``__next__``.
 
 
 class MyCollector:
     def update_policy_weights_(self, policy_weights=None, *, worker_ids=None):
-        pass  # No-op for demonstration
+        pass
 
     def __iter__(self):
-        # In practice, this would drive rollout generation
-        return iter([TensorDict({"tokens": {"full": torch.zeros(4, 16, dtype=torch.long)}}, [])])
+        return iter([TensorDict({}, [])])
 
     def __next__(self):
         return next(iter(self))
@@ -133,86 +90,31 @@ class MyCollector:
 
 col = MyCollector()
 assert_satisfies_protocol(col, PostTrainingCollectorProtocol, name="my_collector")
-print("MyCollector satisfies PostTrainingCollectorProtocol:", True)
 
 # %%
-# 3. Loss output contract
-# -----------------------
-# A loss output object must expose at least one of the primary loss fields:
+# Loss output contracts
+# ---------------------
+# TorchRL provides two separate loss-output protocols, one per loss type:
 #
-# * ``loss_objective`` (GRPO / PPO)
-# * ``loss_sft`` (SFT / Expert Iteration)
+# * :class:`~torchrl.data.llm.contracts.GRPOLossOutputProtocol` — requires ``loss_objective``.
+# * :class:`~torchrl.data.llm.contracts.SFTLossOutputProtocol` — requires ``loss_sft``.
 #
-# Additional optional fields are documented in
-# :class:`~torchrl.data.llm.contracts.PostTrainingLossOutputProtocol`.
-#
-# .. note::
-#
-#     ``GRPOLossOutput`` and ``SFTLossOutput`` are ``TensorClass`` subclasses,
-#     so standard ``isinstance`` checks do not work.  Always use
-#     ``assert_satisfies_protocol`` for loss outputs.
-
-from torchrl.objectives.llm.sft import SFTLossOutput
+# Because ``GRPOLossOutput`` and ``SFTLossOutput`` are ``TensorClass`` subclasses,
+# use ``assert_satisfies_protocol`` (not ``isinstance``):
 
 sft_out = SFTLossOutput(loss_sft=torch.tensor(0.42))
-assert_satisfies_protocol(sft_out, PostTrainingLossOutputProtocol, name="sft_out")
-print("SFTLossOutput satisfies PostTrainingLossOutputProtocol:", True)
+assert_satisfies_protocol(sft_out, SFTLossOutputProtocol, name="sft_out")
 
 # %%
-# 4. TensorDict key reference
-# ----------------------------
-# The table below summarises the TensorDict keys that cross component
-# boundaries.  These are the same keys ``PostTrainingLogger`` reads.
-#
-# .. list-table:: Key contract
-#    :header-rows: 1
-#    :widths: 30 20 50
-#
-#    * - Key
-#      - Source
-#      - Description
-#    * - ``("next", "reward")``
-#      - Collector / Buffer
-#      - Per-token or per-sequence reward. Shape ``[B, ...]``.
-#    * - ``("tokens", "full")``
-#      - Collector / Buffer
-#      - Full token sequence (prompt + response). Shape ``[B, T]``.
-#    * - ``("tokens", "response")``
-#      - Collector / Buffer
-#      - Response-only tokens. Shape ``[B, R]`` or ragged list.
-#    * - ``("tokens", "prompt")``
-#      - Collector
-#      - Prompt-only tokens. Shape ``[B, P]``.
-#    * - ``("masks", "all_attention_mask")``
-#      - Collector
-#      - Boolean attention mask. Same shape as ``("tokens", "full")``.
-#    * - ``advantage``
-#      - Loss (GRPO input)
-#      - Per-token advantage estimates.
-#    * - ``("log_probs", "full")``
-#      - Loss (GRPO input)
-#      - Log probabilities from the current policy.
-#
-
-print("Key reference table: see docstring above.")
-
-# %%
-# 5. Asserting contracts at training loop startup
-# ------------------------------------------------
-# The recommended pattern is to call ``assert_satisfies_protocol`` once at the
-# beginning of your training loop, before the hot path:
+# Asserting all contracts at startup
+# ------------------------------------
+# Recommended pattern: call once at the top of your training loop.
 
 
-def my_post_training_loop(buffer, collector, loss_fn_output):
-    """Example external training loop using TorchRL components."""
-    # Gate all three components up front — catches integration bugs early
+def my_training_loop(buffer, collector, loss_output):
     assert_satisfies_protocol(buffer, PostTrainingBufferProtocol, name="buffer")
     assert_satisfies_protocol(collector, PostTrainingCollectorProtocol, name="collector")
-    assert_satisfies_protocol(
-        loss_fn_output, PostTrainingLossOutputProtocol, name="loss_output"
-    )
-    print("All component contracts verified — proceeding with training.")
-    # ... rest of your training loop ...
+    assert_satisfies_protocol(loss_output, SFTLossOutputProtocol, name="loss_output")
 
 
-my_post_training_loop(rb, col, sft_out)
+my_training_loop(rb, col, sft_out)

--- a/tutorials/sphinx-tutorials/torchrl_component_contracts.py
+++ b/tutorials/sphinx-tutorials/torchrl_component_contracts.py
@@ -1,4 +1,8 @@
 """
+TorchRL Component Contracts for External Loops
+==============================================
+
+Documents the stable component boundaries.
 Shows how to verify that custom buffers, collectors, and loss outputs
 satisfy TorchRL's interfaces using the provided helper functions.
 """

--- a/tutorials/sphinx-tutorials/torchrl_component_contracts.py
+++ b/tutorials/sphinx-tutorials/torchrl_component_contracts.py
@@ -1,0 +1,218 @@
+"""
+TorchRL Component Contracts for External Loops (WS1)
+=====================================================
+
+This tutorial documents the **stable component boundaries** introduced by
+Workstream 1 of `RFC #3948 <https://github.com/pytorch/rl/issues/3948>`_.
+
+If you are building a custom training loop (TRL, NeMo-RL, or in-house) and
+want to consume individual TorchRL components, this guide explains exactly
+what interface each component exposes and how to verify your own objects
+satisfy those contracts.
+
+.. note::
+
+    **WS1** deliverable.  See also:
+
+    * `WS2 — TRL Interoperability <trl_interop.html>`_
+    * `WS4 — Post-Training Observability <PostTrainingLogger>`
+
+Why stable boundaries?
+-----------------------
+TorchRL's components (replay buffers, collectors, loss modules) work together
+through implicit TensorDict key contracts.  Without a formal definition, it is
+hard to know:
+
+* Which keys a ``ReplayBuffer`` sample must carry.
+* What a loss module writes into its output.
+* How a collector exposes policy-weight synchronisation.
+
+The :mod:`torchrl.data.llm.contracts` module formalises these expectations as
+Python ``typing.Protocol`` classes with full docstrings, so adapters stay thin
+and don't break silently across TorchRL version bumps.
+"""
+
+# %%
+# Setup
+# -----
+
+import torch
+from tensordict import TensorDict
+from torchrl.data import ReplayBuffer, LazyTensorStorage
+from torchrl.data.llm.contracts import (
+    PostTrainingBufferProtocol,
+    PostTrainingCollectorProtocol,
+    PostTrainingLossOutputProtocol,
+    assert_satisfies_protocol,
+)
+
+# %%
+# 1. Buffer contract
+# ------------------
+# Any replay buffer used in a post-training loop must expose:
+#
+# * ``extend(data)`` — write a batch of trajectories.
+# * ``sample(batch_size)`` — draw a batch.
+# * ``write_count`` property — total samples written.
+#
+# TorchRL's built-in ``ReplayBuffer`` already satisfies this:
+
+rb = ReplayBuffer(storage=LazyTensorStorage(1_000), batch_size=8)
+assert isinstance(rb, PostTrainingBufferProtocol)
+print("ReplayBuffer satisfies PostTrainingBufferProtocol:", True)
+
+# %%
+# You can also verify your own buffer with ``assert_satisfies_protocol``:
+
+
+class MyCustomBuffer:
+    """A minimal external buffer that satisfies the protocol."""
+
+    def __init__(self):
+        self._data = []
+        self._write_count = 0
+
+    def extend(self, data):
+        self._data.append(data)
+        self._write_count += len(data)
+
+    def sample(self, batch_size=None):
+        return TensorDict({"x": torch.zeros(batch_size or 4)}, [batch_size or 4])
+
+    @property
+    def write_count(self) -> int:
+        return self._write_count
+
+
+buf = MyCustomBuffer()
+assert_satisfies_protocol(buf, PostTrainingBufferProtocol, name="my_buffer")
+print("MyCustomBuffer satisfies PostTrainingBufferProtocol:", True)
+
+# %%
+# If your buffer is missing a required field, ``assert_satisfies_protocol``
+# raises a ``TypeError`` with a helpful message:
+
+
+class IncompleteBuffer:
+    def extend(self, data):
+        pass
+
+    def sample(self, batch_size=None):
+        return TensorDict({}, [])
+
+    # Missing: write_count property
+
+
+try:
+    assert_satisfies_protocol(IncompleteBuffer(), PostTrainingBufferProtocol)
+except TypeError as e:
+    print(f"Caught expected TypeError: {e}")
+
+# %%
+# 2. Collector contract
+# ---------------------
+# Any collector must expose:
+#
+# * ``update_policy_weights_(...)`` — push updated weights to inference workers.
+# * ``__iter__`` / ``__next__`` — yield rollout batches as ``TensorDictBase``.
+#
+# Here is a minimal external collector that satisfies the contract:
+
+
+class MyCollector:
+    def update_policy_weights_(self, policy_weights=None, *, worker_ids=None):
+        pass  # No-op for demonstration
+
+    def __iter__(self):
+        # In practice, this would drive rollout generation
+        return iter([TensorDict({"tokens": {"full": torch.zeros(4, 16, dtype=torch.long)}}, [])])
+
+    def __next__(self):
+        return next(iter(self))
+
+
+col = MyCollector()
+assert_satisfies_protocol(col, PostTrainingCollectorProtocol, name="my_collector")
+print("MyCollector satisfies PostTrainingCollectorProtocol:", True)
+
+# %%
+# 3. Loss output contract
+# -----------------------
+# A loss output object must expose at least one of the primary loss fields:
+#
+# * ``loss_objective`` (GRPO / PPO)
+# * ``loss_sft`` (SFT / Expert Iteration)
+#
+# Additional optional fields are documented in
+# :class:`~torchrl.data.llm.contracts.PostTrainingLossOutputProtocol`.
+#
+# .. note::
+#
+#     ``GRPOLossOutput`` and ``SFTLossOutput`` are ``TensorClass`` subclasses,
+#     so standard ``isinstance`` checks do not work.  Always use
+#     ``assert_satisfies_protocol`` for loss outputs.
+
+from torchrl.objectives.llm.sft import SFTLossOutput
+
+sft_out = SFTLossOutput(loss_sft=torch.tensor(0.42))
+assert_satisfies_protocol(sft_out, PostTrainingLossOutputProtocol, name="sft_out")
+print("SFTLossOutput satisfies PostTrainingLossOutputProtocol:", True)
+
+# %%
+# 4. TensorDict key reference
+# ----------------------------
+# The table below summarises the TensorDict keys that cross component
+# boundaries.  These are the same keys ``PostTrainingLogger`` reads.
+#
+# .. list-table:: Key contract
+#    :header-rows: 1
+#    :widths: 30 20 50
+#
+#    * - Key
+#      - Source
+#      - Description
+#    * - ``("next", "reward")``
+#      - Collector / Buffer
+#      - Per-token or per-sequence reward. Shape ``[B, ...]``.
+#    * - ``("tokens", "full")``
+#      - Collector / Buffer
+#      - Full token sequence (prompt + response). Shape ``[B, T]``.
+#    * - ``("tokens", "response")``
+#      - Collector / Buffer
+#      - Response-only tokens. Shape ``[B, R]`` or ragged list.
+#    * - ``("tokens", "prompt")``
+#      - Collector
+#      - Prompt-only tokens. Shape ``[B, P]``.
+#    * - ``("masks", "all_attention_mask")``
+#      - Collector
+#      - Boolean attention mask. Same shape as ``("tokens", "full")``.
+#    * - ``advantage``
+#      - Loss (GRPO input)
+#      - Per-token advantage estimates.
+#    * - ``("log_probs", "full")``
+#      - Loss (GRPO input)
+#      - Log probabilities from the current policy.
+#
+
+print("Key reference table: see docstring above.")
+
+# %%
+# 5. Asserting contracts at training loop startup
+# ------------------------------------------------
+# The recommended pattern is to call ``assert_satisfies_protocol`` once at the
+# beginning of your training loop, before the hot path:
+
+
+def my_post_training_loop(buffer, collector, loss_fn_output):
+    """Example external training loop using TorchRL components."""
+    # Gate all three components up front — catches integration bugs early
+    assert_satisfies_protocol(buffer, PostTrainingBufferProtocol, name="buffer")
+    assert_satisfies_protocol(collector, PostTrainingCollectorProtocol, name="collector")
+    assert_satisfies_protocol(
+        loss_fn_output, PostTrainingLossOutputProtocol, name="loss_output"
+    )
+    print("All component contracts verified — proceeding with training.")
+    # ... rest of your training loop ...
+
+
+my_post_training_loop(rb, col, sft_out)

--- a/tutorials/sphinx-tutorials/torchrl_component_contracts.py
+++ b/tutorials/sphinx-tutorials/torchrl_component_contracts.py
@@ -1,10 +1,6 @@
 """
-TorchRL Component Contracts for External Loops (WS1)
-=====================================================
-
-Documents the stable component boundaries from RFC #3948 WS1.
 Shows how to verify that custom buffers, collectors, and loss outputs
-satisfy TorchRL's interfaces using :func:`~torchrl.data.llm.contracts.assert_satisfies_protocol`.
+satisfy TorchRL's interfaces using the provided helper functions.
 """
 
 # %%
@@ -13,13 +9,11 @@ satisfy TorchRL's interfaces using :func:`~torchrl.data.llm.contracts.assert_sat
 
 import torch
 from tensordict import TensorDict
-from torchrl.data import ReplayBuffer, LazyTensorStorage
+from torchrl.data import LazyTensorStorage, ReplayBuffer
 from torchrl.data.llm.contracts import (
-    GRPOLossOutputProtocol,
-    PostTrainingBufferProtocol,
-    PostTrainingCollectorProtocol,
-    SFTLossOutputProtocol,
-    assert_satisfies_protocol,
+    assert_buffer_contract,
+    assert_collector_contract,
+    assert_loss_contract,
 )
 from torchrl.objectives.llm.sft import SFTLossOutput
 
@@ -30,10 +24,10 @@ from torchrl.objectives.llm.sft import SFTLossOutput
 # TorchRL's built-in ``ReplayBuffer`` already satisfies this:
 
 rb = ReplayBuffer(storage=LazyTensorStorage(1_000), batch_size=8)
-assert isinstance(rb, PostTrainingBufferProtocol)
+assert_buffer_contract(rb)
 
 # %%
-# Custom buffers can be verified with ``assert_satisfies_protocol``:
+# Custom buffers can also be verified with the helper:
 
 
 class MyCustomBuffer:
@@ -52,7 +46,7 @@ class MyCustomBuffer:
 
 
 buf = MyCustomBuffer()
-assert_satisfies_protocol(buf, PostTrainingBufferProtocol, name="my_buffer")
+assert_buffer_contract(buf)
 
 # %%
 # Missing a required field raises ``TypeError`` with a helpful message:
@@ -67,8 +61,8 @@ class IncompleteBuffer:
 
 
 try:
-    assert_satisfies_protocol(IncompleteBuffer(), PostTrainingBufferProtocol)
-except TypeError as e:
+    assert_buffer_contract(IncompleteBuffer())
+except TypeError:
     pass  # expected — write_count is missing
 
 # %%
@@ -89,21 +83,21 @@ class MyCollector:
 
 
 col = MyCollector()
-assert_satisfies_protocol(col, PostTrainingCollectorProtocol, name="my_collector")
+assert_collector_contract(col)
 
 # %%
 # Loss output contracts
 # ---------------------
-# TorchRL provides two separate loss-output protocols, one per loss type:
+# TorchRL provides explicit field validation for two separate loss types:
 #
-# * :class:`~torchrl.data.llm.contracts.GRPOLossOutputProtocol` — requires ``loss_objective``.
-# * :class:`~torchrl.data.llm.contracts.SFTLossOutputProtocol` — requires ``loss_sft``.
+# * GRPO — requires ``loss_objective``.
+# * SFT — requires ``loss_sft``.
 #
 # Because ``GRPOLossOutput`` and ``SFTLossOutput`` are ``TensorClass`` subclasses,
-# use ``assert_satisfies_protocol`` (not ``isinstance``):
+# use ``assert_loss_contract`` (not ``isinstance``):
 
 sft_out = SFTLossOutput(loss_sft=torch.tensor(0.42))
-assert_satisfies_protocol(sft_out, SFTLossOutputProtocol, name="sft_out")
+assert_loss_contract(sft_out, loss_type="sft")
 
 # %%
 # Asserting all contracts at startup
@@ -112,9 +106,9 @@ assert_satisfies_protocol(sft_out, SFTLossOutputProtocol, name="sft_out")
 
 
 def my_training_loop(buffer, collector, loss_output):
-    assert_satisfies_protocol(buffer, PostTrainingBufferProtocol, name="buffer")
-    assert_satisfies_protocol(collector, PostTrainingCollectorProtocol, name="collector")
-    assert_satisfies_protocol(loss_output, SFTLossOutputProtocol, name="loss_output")
+    assert_buffer_contract(buffer)
+    assert_collector_contract(collector)
+    assert_loss_contract(loss_output, loss_type="sft")
 
 
 my_training_loop(rb, col, sft_out)

--- a/tutorials/sphinx-tutorials/torchrl_component_contracts.py
+++ b/tutorials/sphinx-tutorials/torchrl_component_contracts.py
@@ -72,7 +72,7 @@ except TypeError:
 # %%
 # Collector contract
 # ------------------
-# Collectors must expose ``update_policy_weights_``, ``__iter__``, and ``__next__``.
+# Collectors must expose ``update_policy_weights_`` and ``__iter__``.
 
 
 class MyCollector:
@@ -81,9 +81,6 @@ class MyCollector:
 
     def __iter__(self):
         return iter([TensorDict({}, [])])
-
-    def __next__(self):
-        return next(iter(self))
 
 
 col = MyCollector()


### PR DESCRIPTION
## Description

Implements Workstream 1 (Stable Component Boundaries) from RFC #3948.

Based on feedback from @vmoens, this PR avoids structural typing (`typing.Protocol`) to prevent false positives. Instead, it adds `torchrl/data/llm/contracts.py` with three explicit validation helper functions that formalise the implicit I/O contracts external training loops (TRL, NeMo-RL, custom) need to consume TorchRL components:

- `assert_buffer_contract(buffer)` — asserts `extend`, `sample`, and `write_count` exist, and explicitly documents expected TensorDict keys in the docstring.
- `assert_collector_contract(collector)` — asserts `update_policy_weights_`, `__iter__`, and `__next__` exist, and explicitly documents expected TensorDict keys in the docstring.
- `assert_loss_contract(loss_output, loss_type)` — asserts the required loss fields exist based on the loss type (e.g. `loss_objective` for GRPO).

These development utilities raise a helpful `TypeError` if an object does not satisfy the contract, providing a safe way to validate external adapters.

## Motivation and Context

Without explicit contracts, external adapter authors must read recipe source code to understand what keys a buffer sample carries or what a loss output exposes. This leads to brittle code that breaks silently on TorchRL version bumps. By providing explicit validation helpers and documentation, we give users a stable public contract to build against.

close #4092

- [x] I have raised an issue to propose this change

## Types of changes

- [x] New feature (non-breaking change which adds core functionality)
- [x] Documentation (update in the documentation)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly.
- [x] I have updated the documentation accordingly.
