### PR TITLE
[Feature] CraftGround (Minecraft) environment wrapper

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,7 +11,10 @@
 
 "Environments/craftground":
   - changed-files:
-    - any-glob-to-any-file: ['torchrl/envs/libs/craftground.py', 'test/libs/test_craftground.py']
+    - any-glob-to-any-file:
+      - 'torchrl/envs/libs/craftground.py'
+      - 'test/libs/test_craftground.py'
+      - '.github/unittest/linux_libs/scripts_craftground/**'
 
 "Environments/mujoco_playground":
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,6 +9,10 @@
   - changed-files:
     - any-glob-to-any-file: ['torchrl/envs/libs/brax.py']
 
+"Environments/craftground":
+  - changed-files:
+    - any-glob-to-any-file: ['torchrl/envs/libs/craftground.py', 'test/libs/test_craftground.py']
+
 "Environments/mujoco_playground":
   - changed-files:
     - any-glob-to-any-file: ['torchrl/envs/libs/mujoco_playground.py']

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -131,6 +131,9 @@
 - name: Environments/brax
   description: "Triggers brax environment tests only"
   color: "0E8A16"
+- name: Environments/craftground
+  description: "Triggers craftground (Minecraft) environment tests only"
+  color: "0E8A16"
 
 - name: Environments/mujoco_playground
   description: "Triggers mujoco_playground environment tests only"

--- a/.github/unittest/linux_libs/scripts_craftground/install.sh
+++ b/.github/unittest/linux_libs/scripts_craftground/install.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+unset PYTORCH_VERSION
+# For unittest, nightly PyTorch is used as the following section,
+# so no need to set PYTORCH_VERSION.
+# In fact, keeping PYTORCH_VERSION forces us to hardcode PyTorch version in config.
+
+set -e
+
+# Ensure uv is in PATH
+export PATH="$HOME/.local/bin:$PATH"
+
+# Activate the virtual environment
+source ./env/bin/activate
+
+if [ "${CU_VERSION:-}" == cpu ] ; then
+    version="cpu"
+else
+    if [[ ${#CU_VERSION} -eq 4 ]]; then
+        CUDA_VERSION="${CU_VERSION:2:1}.${CU_VERSION:3:1}"
+    elif [[ ${#CU_VERSION} -eq 5 ]]; then
+        CUDA_VERSION="${CU_VERSION:2:2}.${CU_VERSION:4:1}"
+    fi
+    echo "Using CUDA $CUDA_VERSION as determined by CU_VERSION ($CU_VERSION)"
+    version="$(python -c "print('.'.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
+fi
+
+# submodules
+git submodule sync && git submodule update --init --recursive
+
+printf "Installing PyTorch with cu128"
+if [[ "$TORCH_VERSION" == "nightly" ]]; then
+  if [ "${CU_VERSION:-}" == cpu ] ; then
+      uv pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu -U
+  else
+      uv pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128 -U
+  fi
+elif [[ "$TORCH_VERSION" == "stable" ]]; then
+    if [ "${CU_VERSION:-}" == cpu ] ; then
+      uv pip install torch --index-url https://download.pytorch.org/whl/cpu -U
+  else
+      uv pip install torch --index-url https://download.pytorch.org/whl/cu128 -U
+  fi
+else
+  printf "Failed to install pytorch"
+  exit 1
+fi
+
+# Ensure tensordict and torchrl dependencies are installed
+# (since we use --no-deps for tensordict and torchrl)
+uv pip install numpy "pyvers>=0.2.3" packaging cloudpickle
+
+# Install build dependencies for torchrl (needed with --no-build-isolation)
+uv pip install setuptools wheel setuptools_scm ninja "pybind11[global]"
+
+# install tensordict
+if [[ "$RELEASE" == 0 ]]; then
+  uv pip install --no-deps git+https://github.com/pytorch/tensordict.git
+else
+  uv pip install --no-deps tensordict
+fi
+
+# smoke test
+python -c "import functorch;import tensordict"
+
+printf "* Installing torchrl\n"
+python -m pip install -e . --no-build-isolation --no-deps
+
+# smoke test
+python -c "import torchrl"
+
+# Install craftground without deps so the nightly torch installed above is
+# kept (craftground declares a dependency on stable torch). Its other
+# dependencies come from requirements.txt / the runtime package below.
+printf "* Installing craftground\n"
+uv pip install --no-deps craftground craftground-runtime-mc121
+
+# smoke test
+python -c "import craftground"
+
+# Pre-build the CraftGround Gradle project so the expensive part (Gradle
+# bootstrap, Minecraft client + assets download from Mojang's servers, mod
+# compilation) happens outside the test run. The downloaded game files stay
+# on this runner and are never uploaded or redistributed; users of this
+# recipe are expected to own a Minecraft: Java Edition license
+# (see knowledge_base/MINECRAFT.md).
+env_path="$(python -c "from craftground.environment.runtime_packages import resolve_runtime_env_path; print(resolve_runtime_env_path('1.21'))")"
+echo "CraftGround runtime Gradle project: ${env_path}"
+pushd "${env_path}"
+chmod +x gradlew || true
+./gradlew --no-daemon classes downloadAssets \
+  || ./gradlew --no-daemon classes \
+  || echo "WARNING: Gradle pre-build failed; the first env reset will retry the build"
+popd

--- a/.github/unittest/linux_libs/scripts_craftground/post_process.sh
+++ b/.github/unittest/linux_libs/scripts_craftground/post_process.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Activate the virtual environment
+source ./env/bin/activate

--- a/.github/unittest/linux_libs/scripts_craftground/requirements.txt
+++ b/.github/unittest/linux_libs/scripts_craftground/requirements.txt
@@ -1,0 +1,21 @@
+# Core dependencies for tensordict/torchrl (installed with --no-deps)
+numpy
+pyvers>=0.2.3
+packaging
+cloudpickle
+
+# Test dependencies
+pytest
+pytest-xdist
+pytest-instafail
+pytest-error-for-skips
+coverage
+
+# CraftGround dependencies, except torch (torch is installed in install.sh
+# and craftground itself is installed there with --no-deps to avoid pinning
+# a stable torch in the cached environment)
+gymnasium
+Pillow
+protobuf>=5.0.0
+typing_extensions
+psutil

--- a/.github/unittest/linux_libs/scripts_craftground/requirements.txt
+++ b/.github/unittest/linux_libs/scripts_craftground/requirements.txt
@@ -11,6 +11,12 @@ pytest-instafail
 pytest-error-for-skips
 coverage
 
+# CraftGround's Gradle-driven native build needs a recent CMake; the apt
+# cmake on ubuntu22.04 (3.22) is too old, so take the pip one (installed in
+# the venv, which is active when the tests run).
+cmake
+ninja
+
 # CraftGround dependencies, except torch (torch is installed in install.sh
 # and craftground itself is installed there with --no-deps to avoid pinning
 # a stable torch in the cached environment)

--- a/.github/unittest/linux_libs/scripts_craftground/run_test.sh
+++ b/.github/unittest/linux_libs/scripts_craftground/run_test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Activate the virtual environment
+source ./env/bin/activate
+
+apt-get update && apt-get install -y git wget cmake
+
+export PYTORCH_TEST_WITH_SLOW='1'
+export LAZY_LEGACY_OP=False
+python -m torch.utils.collect_env
+# Avoid error: "fatal: unsafe repository"
+git config --global --add safe.directory '*'
+
+root_dir="$(git rev-parse --show-toplevel)"
+env_dir="${root_dir}/env"
+lib_dir="${env_dir}/lib"
+
+deactivate 2>/dev/null || true && source ./env/bin/activate
+
+# this workflow only tests the libs
+python -c "import craftground"
+java -version
+
+# The Minecraft client needs an X display; use a virtual framebuffer with
+# Mesa software rendering.
+Xvfb :99 -screen 0 1024x768x24 &
+export DISPLAY=:99
+
+python .github/unittest/helpers/coverage_run_parallel.py -m pytest test/libs/test_craftground.py --instafail -v --durations 200 --capture no -k TestCraftGround --error-for-skips --runslow
+
+coverage combine -q
+coverage xml -i

--- a/.github/unittest/linux_libs/scripts_craftground/setup_env.sh
+++ b/.github/unittest/linux_libs/scripts_craftground/setup_env.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# This script is for setting up environment in which unit test is ran.
+# To speed up the CI time, the resulting environment is cached.
+#
+# Do not install PyTorch and torchvision here, otherwise they also get cached.
+
+set -e
+set -v
+
+apt-get update && apt-get upgrade -y && apt-get install -y git cmake
+# Avoid error: "fatal: unsafe repository"
+git config --global --add safe.directory '*'
+# CraftGround launches a real Minecraft client through Gradle: it needs a JDK
+# (OpenJDK 21 for Minecraft 1.21), a virtual display (Xvfb) and an OpenGL
+# stack (Mesa software rendering is sufficient for the tests).
+apt-get install -y wget \
+    gcc \
+    g++ \
+    unzip \
+    curl \
+    patchelf \
+    openjdk-21-jdk \
+    xvfb \
+    libgl1-mesa-dev \
+    libegl1-mesa-dev \
+    libglu1-mesa-dev \
+    libglfw3-dev \
+    libglew-dev \
+    xorg-dev \
+    libglvnd0 \
+    libgl1 \
+    libglx0 \
+    libegl1 \
+    libgles2 \
+    libglib2.0-0
+
+# Upgrade specific package
+apt-get upgrade -y libstdc++6
+
+this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+root_dir="$(git rev-parse --show-toplevel)"
+env_dir="${root_dir}/env"
+
+cd "${root_dir}"
+
+# Install uv if not already installed
+if ! command -v uv &> /dev/null; then
+    printf "* Installing uv\n"
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# Create virtual environment using uv
+printf "python: ${PYTHON_VERSION}\n"
+if [ ! -d "${env_dir}" ]; then
+    printf "* Creating a test environment with uv\n"
+    uv venv "${env_dir}" --python "${PYTHON_VERSION}"
+fi
+
+# Activate the virtual environment
+source "${env_dir}/bin/activate"
+
+# Upgrade pip
+uv pip install --upgrade pip
+
+# Install dependencies from requirements.txt
+printf "* Installing dependencies (except PyTorch)\n"
+if [ -f "${this_dir}/requirements.txt" ]; then
+    uv pip install -r "${this_dir}/requirements.txt"
+fi

--- a/.github/unittest/linux_libs/scripts_craftground/setup_env.sh
+++ b/.github/unittest/linux_libs/scripts_craftground/setup_env.sh
@@ -33,7 +33,8 @@ apt-get install -y wget \
     libglx0 \
     libegl1 \
     libgles2 \
-    libglib2.0-0
+    libglib2.0-0 \
+    python3-dev
 
 # Upgrade specific package
 apt-get upgrade -y libstdc++6
@@ -51,7 +52,11 @@ if ! command -v uv &> /dev/null; then
     export PATH="$HOME/.local/bin:$PATH"
 fi
 
-# Create virtual environment using uv
+# Create virtual environment using uv. Force a uv-managed interpreter: the
+# apt packages above (JDK/X11 stack) pull in a headerless system python3.10,
+# which uv would otherwise pick up, breaking source builds of
+# tensordict/torchrl (cmake cannot find Python3_INCLUDE_DIRS).
+export UV_PYTHON_PREFERENCE=only-managed
 printf "python: ${PYTHON_VERSION}\n"
 if [ ! -d "${env_dir}" ]; then
     printf "* Creating a test environment with uv\n"

--- a/.github/workflows/test-linux-libs.yml
+++ b/.github/workflows/test-linux-libs.yml
@@ -93,6 +93,47 @@ jobs:
 
         bash .github/unittest/linux_libs/scripts_brax/run_all.sh
 
+  unittests-craftground:
+    strategy:
+      matrix:
+        python_version: ["3.10"]
+        cuda_arch_version: ["12.8"]
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Environments') || contains(github.event.pull_request.labels.*.name, 'Environments/craftground') }}
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      repository: pytorch/rl
+      runner: "linux.g5.4xlarge.nvidia.gpu"
+      gpu-arch-type: cuda
+      gpu-arch-version: "12.8"
+      docker-image: "nvidia/cuda:12.4.0-devel-ubuntu22.04"
+      timeout: 120
+      script: |
+        if [[ "${{ github.ref }}" =~ release/* ]]; then
+          export RELEASE=1
+          export TORCH_VERSION=stable
+        else
+          export RELEASE=0
+          export TORCH_VERSION=nightly
+        fi
+
+        set -euo pipefail
+        export PYTHON_VERSION="3.10"
+        export CU_VERSION="12.8"
+        export TAR_OPTIONS="--no-same-owner"
+        export UPLOAD_CHANNEL="nightly"
+        export TF_CPP_MIN_LOG_LEVEL=0
+        export BATCHED_PIPE_TIMEOUT=60
+        export TD_GET_DEFAULTS_TO_NONE=1
+
+        nvidia-smi
+
+        bash .github/unittest/linux_libs/scripts_craftground/setup_env.sh
+        bash .github/unittest/linux_libs/scripts_craftground/install.sh
+        PYTHON=./env/bin/python bash .github/unittest/helpers/assert_torch_version.sh "$TORCH_VERSION"
+        PYTHON=./env/bin/python bash .github/unittest/helpers/assert_torch_tensordict_versions.sh "$TORCH_VERSION"
+        bash .github/unittest/linux_libs/scripts_craftground/run_test.sh
+        bash .github/unittest/linux_libs/scripts_craftground/post_process.sh
+
   unittests-mujoco-playground:
     strategy:
       matrix:

--- a/docs/source/reference/envs_libraries.rst
+++ b/docs/source/reference/envs_libraries.rst
@@ -82,6 +82,8 @@ Available wrappers
 
     BraxEnv
     BraxWrapper
+    CraftGroundEnv
+    CraftGroundWrapper
     DMControlEnv
     DMControlWrapper
     GenesisEnv
@@ -126,6 +128,19 @@ Available wrappers
     gym_backend
     set_gym_backend
     register_gym_spec_conversion
+
+.. note:: **Minecraft licensing** (:class:`~torchrl.envs.CraftGroundEnv`,
+    :class:`~torchrl.envs.CraftGroundWrapper`): TorchRL does not ship or
+    redistribute Minecraft. The CraftGround backend downloads the Minecraft
+    client from Mojang's servers onto the user's machine at first launch and
+    runs it in offline mode. Users are expected to own a valid Minecraft:
+    Java Edition license, and usage is subject to the
+    `Minecraft EULA <https://www.minecraft.net/eula>`_, including its
+    restrictions on commercial exploitation. The downloaded game files must
+    never be redistributed (e.g. inside public Docker images). See the
+    `knowledge_base/MINECRAFT.md
+    <https://github.com/pytorch/rl/blob/main/knowledge_base/MINECRAFT.md>`_
+    entry for installation and licensing details.
 
 Auto-resetting Environments
 ---------------------------

--- a/knowledge_base/MINECRAFT.md
+++ b/knowledge_base/MINECRAFT.md
@@ -31,9 +31,11 @@ onto your machine and launches the game in offline mode.
   Mojang itself through the build tooling. Recipes (Dockerfiles, scripts) that
   download the game at build/run time on the user's machine are fine; baked
   images are not.
-- **Library licenses.** CraftGround is licensed under LGPL-3.0. TorchRL uses
-  it as a regular, optional Python dependency (no CraftGround code is vendored
-  into TorchRL), which leaves TorchRL's MIT license unaffected.
+- **Library licensing.** CraftGround is a separate, optional dependency; no
+  CraftGround code is vendored or redistributed by TorchRL. At the time of
+  writing, CraftGround's repository ships a GPL-3.0 license file while its
+  package metadata reports MIT. Consult CraftGround's upstream licensing
+  information before distributing software that depends on it.
 
 ## Installation
 

--- a/knowledge_base/MINECRAFT.md
+++ b/knowledge_base/MINECRAFT.md
@@ -1,0 +1,121 @@
+# Minecraft (CraftGround) Guide
+
+This guide covers running Minecraft-based RL environments in TorchRL through
+[CraftGround](https://github.com/yhs0602/CraftGround): what you must know about
+Minecraft's license before you start, how to install the toolchain, and how to
+run headless.
+
+## Minecraft ownership and licensing (read this first)
+
+TorchRL does not ship, bundle, or redistribute Minecraft, and neither does
+CraftGround. CraftGround ships a [Fabric](https://fabricmc.net/) mod together
+with a Gradle project; on the first environment start, that Gradle project
+downloads the Minecraft client and its assets directly from Mojang's servers
+onto your machine and launches the game in offline mode.
+
+- **Own the game.** Users are expected to own a valid Minecraft: Java Edition
+  license (a one-time purchase from [minecraft.net](https://www.minecraft.net),
+  roughly USD 30). The environment runs the game in offline mode so that no
+  account login is required during headless training; offline mode bypasses
+  authentication, not the requirement to own the game.
+- **EULA.** Use of Minecraft is governed by the
+  [Minecraft End User License Agreement](https://www.minecraft.net/eula) and
+  Mojang's usage guidelines, including their restriction on commercial
+  exploitation of the game. Academic and research use of Minecraft-based RL
+  environments has a long public history (Project Malmo, MineRL, MineDojo,
+  CraftGround); users and their organizations remain responsible for reviewing
+  the EULA for their own use case, in particular for any commercial use.
+- **Never redistribute game files.** Do not publish Docker images, CI caches,
+  or any other artifacts that contain the downloaded Minecraft client or its
+  assets. Every machine, including CI runners, must fetch Minecraft from
+  Mojang itself through the build tooling. Recipes (Dockerfiles, scripts) that
+  download the game at build/run time on the user's machine are fine; baked
+  images are not.
+- **Library licenses.** CraftGround is licensed under LGPL-3.0. TorchRL uses
+  it as a regular, optional Python dependency (no CraftGround code is vendored
+  into TorchRL), which leaves TorchRL's MIT license unaffected.
+
+## Installation
+
+CraftGround needs Python packages, a JDK, and a recent CMake:
+
+```bash
+conda create -n craftground python=3.11 -y
+conda activate craftground
+conda install -c conda-forge openjdk=21 cmake -y
+pip install craftground
+```
+
+Notes:
+
+- OpenJDK 21 is required (Minecraft 1.21 targets Java 21). Any distribution
+  works (`conda-forge`, `apt install openjdk-21-jdk`, ...); make sure
+  `JAVA_HOME` points at it if you have several JDKs installed.
+- `pip install craftground` pulls `craftground-runtime-mc121`, which contains
+  the Fabric mod's Gradle project. The first `env.reset()` runs
+  `./gradlew runClient` in that project: Gradle downloads Minecraft from
+  Mojang, compiles the mod, and boots the game. Expect several minutes and a
+  few GB of downloads on the very first run; later runs reuse the caches
+  (`~/.gradle` and the runtime package directory).
+- If you change `JAVA_HOME` or the native toolchain after a failed first run,
+  clear the stale CMake cache with
+  `python -c "import craftground; craftground.clear_native_build_cache()"`.
+
+## Usage with TorchRL
+
+```python
+from craftground.initial_environment_config import (
+    InitialEnvironmentConfig,
+    WorldType,
+)
+from torchrl.envs import CraftGroundEnv, StepCounter, TransformedEnv
+
+env = CraftGroundEnv(
+    initial_env_config=InitialEnvironmentConfig(
+        image_width=114,
+        image_height=64,
+        world_type=WorldType.SUPERFLAT,
+    ),
+    port=8023,
+)
+env = TransformedEnv(env, StepCounter(max_steps=100))
+td = env.rollout(10)
+```
+
+The base environment is a sandbox: it emits a zero reward and never
+terminates. Compose rewards and termination conditions with TorchRL
+transforms, and interact with the world by sending Minecraft commands through
+`env.add_command("...")` (executed on the next step).
+
+## Headless operation
+
+The Minecraft client needs an X display and OpenGL 3.2+. On a headless Linux
+machine the simplest setup is a virtual framebuffer with Mesa software
+rendering:
+
+```bash
+apt-get install -y xvfb libgl1-mesa-dev libegl1-mesa-dev libglew-dev \
+    libglu1-mesa-dev libglfw3-dev xorg-dev
+Xvfb :99 -screen 0 1024x768x24 &
+export DISPLAY=:99
+```
+
+Software rendering is sufficient for functional tests and small-frame
+training. For GPU-accelerated rendering on headless NVIDIA machines, use
+[VirtualGL](https://virtualgl.org/) and pass `use_vglrun=True` to the
+environment constructor; see the
+[CraftGround headless guide](https://yhs0602.github.io/CraftGround/installation/headless)
+for the full VirtualGL/X server configuration.
+
+## Troubleshooting
+
+- **`gradlew` not found / permission denied**: the runtime package directory
+  may have been installed without execute bits; the wrapper fixes permissions
+  automatically, but a custom `env_path` must contain an executable `gradlew`.
+- **First reset hangs**: check the Gradle build by constructing the
+  environment with `verbose_gradle=True` (through
+  `CraftGroundEnv(craftground_kwargs={"verbose_gradle": True}, ...)`); most
+  first-run failures are missing JDK, missing X display, or blocked network
+  access to Mojang's download servers.
+- **Orphan Java processes** after a crash: CraftGround removes orphans on the
+  next start; `pkill -f runClient` cleans up manually.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,10 @@ offline-data = [
     "pillow",
 ]
 marl = ["vmas>=1.2.10", "pettingzoo>=1.24.1", "dm-meltingpot; python_version>='3.11'"]
+# Requires OpenJDK 21 at runtime and a Minecraft: Java Edition license
+# (Minecraft is downloaded from Mojang at first launch, never redistributed);
+# see knowledge_base/MINECRAFT.md
+craftground = ["craftground"]
 open_spiel = ["open_spiel>=1.5"]
 brax = ["jax>=0.7.0; python_version>='3.11'", "brax; python_version>='3.11'"]
 mujoco_playground = ["jax>=0.7.0; python_version>='3.11'", "playground; python_version>='3.11'"]

--- a/test/libs/test_craftground.py
+++ b/test/libs/test_craftground.py
@@ -1,0 +1,103 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""CraftGround (Minecraft) wrapper tests.
+
+These tests boot a real Minecraft client through CraftGround's Gradle
+project, which requires OpenJDK 21, an X display (e.g. Xvfb on headless
+machines) and network access to Mojang's servers on the first run. They run
+in the dedicated ``unittests-craftground`` CI job; see
+``knowledge_base/MINECRAFT.md`` for the setup and the Minecraft ownership
+and licensing requirements.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+from torchrl.envs import StepCounter, TransformedEnv
+from torchrl.envs.libs.craftground import (
+    _has_craftground,
+    CraftGroundEnv,
+    CraftGroundWrapper,
+)
+from torchrl.envs.utils import check_env_specs
+
+
+def _tiny_config():
+    """A small, fast-to-render superflat world configuration."""
+    from craftground.initial_environment_config import (
+        InitialEnvironmentConfig,
+        WorldType,
+    )
+
+    return InitialEnvironmentConfig(
+        image_width=114,
+        image_height=64,
+        world_type=WorldType.SUPERFLAT,
+        render_distance=2,
+        simulation_distance=5,
+        hud_hidden=True,
+    )
+
+
+@pytest.mark.skipif(not _has_craftground, reason="craftground not installed")
+class TestCraftGround:
+    @pytest.fixture(scope="class")
+    def env_v1(self):
+        # Booting Minecraft is expensive: share one environment (with fast
+        # resets) across the tests that use the default v1 action space.
+        env = CraftGroundEnv(initial_env_config=_tiny_config())
+        yield env
+        env.close(raise_if_closed=False)
+
+    def test_env_specs(self, env_v1):
+        check_env_specs(env_v1)
+
+    def test_rollout_pixels(self, env_v1):
+        td = env_v1.rollout(3)
+        pixels = td["next", "pixels"]
+        assert pixels.dtype == torch.uint8
+        assert pixels.shape == torch.Size([3, 64, 114, 3])
+        # the base env is a sandbox: no reward, no termination
+        assert (td["next", "reward"] == 0).all()
+        assert not td["next", "done"].any()
+
+    def test_transform_composition(self, env_v1):
+        # rewards/termination are composed on top of the sandbox with
+        # transforms: a StepCounter must truncate the rollout
+        env = TransformedEnv(env_v1, StepCounter(max_steps=2))
+        td = env.rollout(5)
+        assert td.shape == torch.Size([2])
+        assert td["next", "truncated"][-1]
+
+    def test_wrapper_specs(self):
+        import craftground
+
+        base = craftground.make(initial_env_config=_tiny_config())
+        env = CraftGroundWrapper(base)
+        try:
+            check_env_specs(env)
+        finally:
+            env.close(raise_if_closed=False)
+
+    def test_v2_action_space(self):
+        import craftground
+
+        env = CraftGroundEnv(
+            initial_env_config=_tiny_config(),
+            action_space_version=craftground.ActionSpaceVersion.V2_MINERL_HUMAN,
+        )
+        try:
+            action_keys = set(env.full_action_spec.keys(True, True))
+            # dotted upstream keys ("hotbar.1") are exposed with underscores
+            assert "hotbar_1" in action_keys
+            assert "camera" in action_keys
+            td = env.rollout(2)
+            assert td["next", "pixels"].dtype == torch.uint8
+        finally:
+            env.close(raise_if_closed=False)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/torchrl/envs/__init__.py
+++ b/torchrl/envs/__init__.py
@@ -38,6 +38,8 @@ from .gym_like import default_info_dict_reader, GymLikeEnv
 from .libs import (
     BraxEnv,
     BraxWrapper,
+    CraftGroundEnv,
+    CraftGroundWrapper,
     DMControlEnv,
     DMControlWrapper,
     GenesisEnv,
@@ -214,6 +216,8 @@ __all__ = [
     "ChessEnv",
     "ClipTransform",
     "Compose",
+    "CraftGroundEnv",
+    "CraftGroundWrapper",
     "ConditionalSkip",
     "Crop",
     "DMControlEnv",

--- a/torchrl/envs/libs/__init__.py
+++ b/torchrl/envs/libs/__init__.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from .brax import BraxEnv, BraxWrapper
+from .craftground import CraftGroundEnv, CraftGroundWrapper
 from .dm_control import DMControlEnv, DMControlWrapper
 from .envpool import MultiThreadedEnv, MultiThreadedEnvWrapper
 from .genesis import GenesisEnv, GenesisWrapper
@@ -42,6 +43,8 @@ from .vmas import VmasEnv, VmasWrapper
 __all__ = [
     "BraxEnv",
     "BraxWrapper",
+    "CraftGroundEnv",
+    "CraftGroundWrapper",
     "DMControlEnv",
     "DMControlWrapper",
     "GenesisEnv",

--- a/torchrl/envs/libs/craftground.py
+++ b/torchrl/envs/libs/craftground.py
@@ -14,9 +14,11 @@
     Minecraft End User License Agreement (https://www.minecraft.net/eula),
     including its restrictions on commercial exploitation. Never redistribute
     the downloaded game files (for instance inside public Docker images or CI
-    caches). CraftGround itself is LGPL-3.0 and is used by TorchRL as a
-    regular, optional Python dependency. See ``knowledge_base/MINECRAFT.md``
-    for details.
+    caches). CraftGround is a separate, optional Python dependency that TorchRL
+    does not vendor or redistribute. Its upstream repository currently ships a
+    GPL-3.0 license file while its package metadata reports MIT; consult the
+    upstream licensing information before distribution. See
+    ``knowledge_base/MINECRAFT.md`` for details.
 """
 from __future__ import annotations
 
@@ -89,9 +91,11 @@ class CraftGroundWrapper(GymWrapper):
         Minecraft EULA (https://www.minecraft.net/eula), including its
         restrictions on commercial exploitation. Never redistribute the
         downloaded game files (e.g. in public Docker images or CI caches).
-        CraftGround itself is licensed under LGPL-3.0 and is used as a regular
-        optional dependency. See ``knowledge_base/MINECRAFT.md`` in the TorchRL
-        repository for details.
+        CraftGround is a separate, optional dependency that TorchRL does not
+        vendor or redistribute. Its upstream repository currently ships a
+        GPL-3.0 license file while its package metadata reports MIT; consult the
+        upstream licensing information before distribution. See
+        ``knowledge_base/MINECRAFT.md`` in the TorchRL repository for details.
 
     .. note:: The environment is spawned lazily: constructing the wrapper only
         binds an IPC channel. The Minecraft client (a Java subprocess built and
@@ -326,9 +330,11 @@ class CraftGroundEnv(CraftGroundWrapper):
         Minecraft EULA (https://www.minecraft.net/eula), including its
         restrictions on commercial exploitation. Never redistribute the
         downloaded game files (e.g. in public Docker images or CI caches).
-        CraftGround itself is licensed under LGPL-3.0 and is used as a regular
-        optional dependency. See ``knowledge_base/MINECRAFT.md`` in the TorchRL
-        repository for details.
+        CraftGround is a separate, optional dependency that TorchRL does not
+        vendor or redistribute. Its upstream repository currently ships a
+        GPL-3.0 license file while its package metadata reports MIT; consult the
+        upstream licensing information before distribution. See
+        ``knowledge_base/MINECRAFT.md`` in the TorchRL repository for details.
 
     Keyword Args:
         initial_env_config (craftground.InitialEnvironmentConfig, optional):

--- a/torchrl/envs/libs/craftground.py
+++ b/torchrl/envs/libs/craftground.py
@@ -1,0 +1,406 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""CraftGround (Minecraft) environment wrappers.
+
+.. note:: **Minecraft ownership and licensing.** TorchRL does not ship, bundle
+    or redistribute Minecraft. On first use, CraftGround's Gradle project
+    downloads the Minecraft client and its assets from Mojang's servers onto
+    the local machine and runs the game in offline mode. Offline mode removes
+    the need for an account login during headless training; it does not remove
+    the requirement to own the game: users are expected to own a valid
+    Minecraft: Java Edition license, and any use of Minecraft is subject to the
+    Minecraft End User License Agreement (https://www.minecraft.net/eula),
+    including its restrictions on commercial exploitation. Never redistribute
+    the downloaded game files (for instance inside public Docker images or CI
+    caches). CraftGround itself is LGPL-3.0 and is used by TorchRL as a
+    regular, optional Python dependency. See ``knowledge_base/MINECRAFT.md``
+    for details.
+"""
+from __future__ import annotations
+
+import importlib.util
+from typing import Literal, TYPE_CHECKING
+
+import numpy as np
+import torch
+from torchrl.data.tensor_specs import Bounded, Categorical, Composite, Unbounded
+from torchrl.envs.libs.gym import (
+    _gym_to_torchrl_spec_transform,
+    GymWrapper,
+    set_gym_backend,
+)
+from torchrl.envs.utils import _classproperty
+
+if TYPE_CHECKING:
+    from craftground.environment.environment import CraftGroundEnvironment
+    from craftground.initial_environment_config import InitialEnvironmentConfig
+
+_has_craftground = importlib.util.find_spec("craftground") is not None
+
+# Boolean entries of CraftGround's v2 (MineRL-human-like) action space. The
+# upstream gymnasium Dict space uses dotted keys ("hotbar.1") which cannot be
+# used as TensorDict keys; we expose underscored variants and translate back in
+# read_action.
+_V2_BOOL_KEYS = (
+    "attack",
+    "back",
+    "forward",
+    "jump",
+    "left",
+    "right",
+    "sneak",
+    "sprint",
+    "use",
+    "drop",
+    "inventory",
+) + tuple(f"hotbar_{i}" for i in range(1, 10))
+
+
+class CraftGroundWrapper(GymWrapper):
+    """CraftGround (Minecraft) environment wrapper.
+
+    GitHub: https://github.com/yhs0602/CraftGround
+
+    Documentation: https://yhs0602.github.io/CraftGround/
+
+    Paper: Yun et al., "CraftGround: A Flexible Reinforcement Learning
+    Environment Based on the Latest Minecraft" (2025).
+
+    CraftGround runs a lightweight, headless-capable Minecraft client
+    instrumented through a Fabric mod, and exposes it as a gymnasium
+    environment. Observations are ego-centric RGB frames; actions follow
+    either the MineDojo-style multi-discrete layout (v1) or a
+    MineRL-human-like dictionary layout (v2).
+
+    The wrapped environment is a *sandbox*: the underlying ``step`` always
+    returns a zero reward and never terminates. Rewards and termination
+    conditions are meant to be composed on top with TorchRL transforms
+    (see the example below), or by sending Minecraft commands through
+    ``env.add_command(...)`` and reading the resulting state.
+
+    .. note:: **Minecraft ownership and licensing.** TorchRL does not
+        distribute Minecraft. On the first :meth:`reset`, CraftGround's Gradle
+        project downloads the Minecraft client from Mojang's servers onto the
+        local machine and runs it in offline mode. Users are expected to own a
+        valid Minecraft: Java Edition license; offline mode bypasses
+        authentication, not ownership. Usage of Minecraft is governed by the
+        Minecraft EULA (https://www.minecraft.net/eula), including its
+        restrictions on commercial exploitation. Never redistribute the
+        downloaded game files (e.g. in public Docker images or CI caches).
+        CraftGround itself is licensed under LGPL-3.0 and is used as a regular
+        optional dependency. See ``knowledge_base/MINECRAFT.md`` in the TorchRL
+        repository for details.
+
+    .. note:: The environment is spawned lazily: constructing the wrapper only
+        binds an IPC channel. The Minecraft client (a Java subprocess built and
+        launched through Gradle) starts on the first :meth:`reset`, which can
+        take several minutes on the very first run while Gradle downloads
+        Minecraft and compiles the mod. Requires a JDK (OpenJDK 21) and, on
+        headless machines, a virtual display (e.g. ``Xvfb``); see
+        ``knowledge_base/MINECRAFT.md``.
+
+    .. note:: Only the ``RAW`` (default) and ``PNG`` screen encoding modes are
+        supported. ``RAW`` frames have shape ``(H, W, 3)``, ``PNG`` frames
+        ``(3, W, H)``, both ``torch.uint8``. With a binocular configuration
+        (``eye_distance > 0``) a second ``pixels_2`` entry is added.
+
+    Args:
+        env (craftground.environment.environment.CraftGroundEnvironment): the
+            CraftGround environment instance to wrap.
+
+    Keyword Args:
+        categorical_action_encoding (bool, optional): if ``True``, categorical
+            specs will be converted to the TorchRL equivalent
+            (:class:`torchrl.data.Categorical`), otherwise a one-hot encoding
+            will be used (:class:`torchrl.data.OneHot`). Defaults to ``False``.
+            Only used with the v1 (MineDojo-style) action space.
+        device (torch.device, optional): if provided, the device on which the
+            data is to be cast. Defaults to ``torch.device("cpu")``.
+        batch_size (torch.Size, optional): only ``torch.Size([])`` is
+            supported, as CraftGround environments are not vectorized.
+        allow_done_after_reset (bool, optional): if ``True``, it is tolerated
+            for envs to be ``done`` just after :meth:`reset` is called.
+            Defaults to ``False``.
+
+    Attributes:
+        available_envs: an empty list; CraftGround environments are described
+            by a ``craftground.InitialEnvironmentConfig`` rather than selected
+            from a registry of task ids.
+
+    Examples:
+        >>> import craftground  # doctest: +SKIP
+        >>> from torchrl.envs import TransformedEnv, StepCounter
+        >>> from torchrl.envs.libs.craftground import CraftGroundWrapper
+        >>> base = craftground.make(port=8023)  # doctest: +SKIP
+        >>> env = CraftGroundWrapper(base)  # doctest: +SKIP
+        >>> # the sandbox emits no reward: compose one with a transform,
+        >>> # e.g. a step-count budget via StepCounter
+        >>> env = TransformedEnv(env, StepCounter(max_steps=100))  # doctest: +SKIP
+        >>> td = env.rollout(3)  # doctest: +SKIP
+        >>> assert td["next", "pixels"].dtype is torch.uint8  # doctest: +SKIP
+
+    """
+
+    git_url = "https://github.com/yhs0602/CraftGround"
+    libname = "craftground"
+
+    _lib = None
+
+    @_classproperty
+    def lib(cls):
+        if cls._lib is not None:
+            return cls._lib
+        try:
+            import craftground
+        except ImportError as err:
+            raise ImportError(
+                "craftground not found. Install it with `pip install craftground` "
+                "(requires OpenJDK 21 at runtime; see "
+                "https://yhs0602.github.io/CraftGround/ and "
+                "knowledge_base/MINECRAFT.md for setup and licensing notes)."
+            ) from err
+        cls._lib = craftground
+        return craftground
+
+    @_classproperty
+    def available_envs(cls):
+        # CraftGround has no registry of named tasks: environments are
+        # parameterized by an InitialEnvironmentConfig instead.
+        return []
+
+    def _check_kwargs(self, kwargs: dict):
+        super()._check_kwargs(kwargs)
+        env = kwargs["env"]
+        if not hasattr(env, "initial_env"):
+            raise TypeError(
+                "env must be a craftground CraftGroundEnvironment instance "
+                "(missing the `initial_env` attribute). Use CraftGroundEnv to "
+                "build one from a configuration."
+            )
+
+    def _build_env(
+        self,
+        env,
+        from_pixels: bool = False,
+        pixels_only: bool = False,
+    ):
+        if from_pixels:
+            raise ValueError(
+                "CraftGround environments are natively pixel-based: observations "
+                "already contain a `pixels` entry, and `from_pixels` is not "
+                "supported."
+            )
+        return super()._build_env(env, from_pixels=from_pixels, pixels_only=pixels_only)
+
+    @staticmethod
+    def _uses_v2_actions(env) -> bool:
+        version = getattr(env, "action_space_version", None)
+        return getattr(version, "name", None) == "V2_MINERL_HUMAN"
+
+    def _make_specs(self, env, batch_size=None) -> None:
+        config = env.initial_env
+        height = config.imageSizeY
+        width = config.imageSizeX
+        mode = getattr(
+            config.screen_encoding_mode, "name", str(config.screen_encoding_mode)
+        )
+        if mode == "RAW":
+            pixels_shape = (height, width, 3)
+        elif mode == "PNG":
+            pixels_shape = (3, width, height)
+        else:
+            raise NotImplementedError(
+                f"screen_encoding_mode {mode!r} is not supported by "
+                "CraftGroundWrapper. Use ScreenEncodingMode.RAW (default) or "
+                "ScreenEncodingMode.PNG."
+            )
+        pixels_spec = Bounded(
+            low=0,
+            high=255,
+            shape=pixels_shape,
+            dtype=torch.uint8,
+            device=self.device,
+        )
+        observation_spec = Composite(pixels=pixels_spec, shape=self.batch_size)
+        self._binocular = config.eye_distance > 0
+        if self._binocular:
+            observation_spec["pixels_2"] = pixels_spec.clone()
+
+        self._v2_actions = self._uses_v2_actions(env)
+        if self._v2_actions:
+            action_spec = self._make_v2_action_spec()
+        else:
+            action_spec = _gym_to_torchrl_spec_transform(
+                env.action_space,
+                device=self.device,
+                categorical_action_encoding=self._categorical_action_encoding,
+            )
+
+        self.done_spec = self._make_done_spec()
+        self.action_spec = action_spec
+        self.reward_spec = Unbounded(shape=(1,), device=self.device)
+        self.observation_spec = observation_spec
+
+    _make_specs = set_gym_backend("gymnasium")(_make_specs)
+
+    def _make_v2_action_spec(self) -> Composite:
+        spec = {
+            key: Categorical(2, shape=(), dtype=torch.bool, device=self.device)
+            for key in _V2_BOOL_KEYS
+        }
+        spec["camera"] = Bounded(
+            low=-180.0,
+            high=180.0,
+            shape=(2,),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        return Composite(spec, shape=self.batch_size)
+
+    def read_action(self, action):
+        if self._v2_actions:
+            # Translate the composite action back to CraftGround's dict format
+            # (dotted hotbar keys, python bools, float32 camera).
+            out = {}
+            for key, value in action.items():
+                if key == "camera":
+                    if isinstance(value, torch.Tensor):
+                        value = value.detach().cpu()
+                    out["camera"] = np.asarray(value, dtype=np.float32)
+                else:
+                    out[key.replace("hotbar_", "hotbar.")] = bool(value)
+            return out
+        return super().read_action(action)
+
+    def _process_obs(self, observations):
+        out = {"pixels": self._to_image(observations["pov"])}
+        if self._binocular:
+            out["pixels_2"] = self._to_image(observations["pov_2"])
+        return out
+
+    @staticmethod
+    def _to_image(image):
+        if isinstance(image, torch.Tensor):
+            return image
+        # CraftGround returns flipped, read-only numpy views; make them
+        # contiguous and writable before tensor conversion.
+        return np.ascontiguousarray(image)
+
+    def _output_transform(self, step_outputs_tuple):
+        # CraftGround's step returns (obs, reward, terminated, truncated, info)
+        # where info is the observation dict itself and reward/terminated are
+        # sandbox placeholders. The raw protobuf entry of the observation dict
+        # is dropped here.
+        observations, reward, terminated, truncated, _ = step_outputs_tuple
+        observations = self._process_obs(observations)
+        terminated = bool(terminated)
+        truncated = bool(truncated)
+        return (
+            observations,
+            reward,
+            terminated,
+            truncated,
+            terminated | truncated,
+            None,
+        )
+
+    def _reset_output_transform(self, reset_outputs_tuple):
+        observations, _ = reset_outputs_tuple
+        return self._process_obs(observations), None
+
+
+class CraftGroundEnv(CraftGroundWrapper):
+    """CraftGround (Minecraft) environment built from a configuration.
+
+    See :class:`CraftGroundWrapper` for behavior details and licensing notes.
+    The constructor builds the environment through ``craftground.make(...)``.
+
+    .. note:: **Minecraft ownership and licensing.** TorchRL does not
+        distribute Minecraft. On the first :meth:`reset`, CraftGround's Gradle
+        project downloads the Minecraft client from Mojang's servers onto the
+        local machine and runs it in offline mode. Users are expected to own a
+        valid Minecraft: Java Edition license; offline mode bypasses
+        authentication, not ownership. Usage of Minecraft is governed by the
+        Minecraft EULA (https://www.minecraft.net/eula), including its
+        restrictions on commercial exploitation. Never redistribute the
+        downloaded game files (e.g. in public Docker images or CI caches).
+        CraftGround itself is licensed under LGPL-3.0 and is used as a regular
+        optional dependency. See ``knowledge_base/MINECRAFT.md`` in the TorchRL
+        repository for details.
+
+    Keyword Args:
+        initial_env_config (craftground.InitialEnvironmentConfig, optional):
+            the world/observation configuration (image size, game mode, world
+            type, seed, initial commands, ...). Defaults to a fresh
+            ``InitialEnvironmentConfig()``.
+        mc_version (str, optional): the Minecraft version to run. Only
+            ``"1.21"`` is currently functional upstream. Defaults to
+            ``"1.21"``.
+        port (int, optional): the IPC port used to communicate with the
+            Minecraft process. A free port is picked automatically if the
+            given one is busy. Defaults to ``8000``.
+        action_space_version (craftground.ActionSpaceVersion, optional): the
+            action layout, either ``V1_MINEDOJO`` (multi-discrete) or
+            ``V2_MINERL_HUMAN`` (dict of booleans plus a continuous camera).
+            Defaults to ``V1_MINEDOJO``.
+        env_path (str, optional): path to a custom CraftGround Gradle project.
+            Defaults to the project shipped with the installed
+            ``craftground-runtime-mc121`` package.
+        use_shared_memory (bool, optional): if ``True``, uses the shared-memory
+            IPC backend instead of TCP sockets. Defaults to ``False``.
+        verbose (bool, optional): enables CraftGround's verbose logging.
+            Defaults to ``False``.
+        craftground_kwargs (dict, optional): additional keyword arguments
+            forwarded verbatim to ``craftground.make``.
+        **kwargs: additional keyword arguments passed to
+            :class:`CraftGroundWrapper` (e.g. ``device``).
+
+    Examples:
+        >>> from craftground.initial_environment_config import (  # doctest: +SKIP
+        ...     InitialEnvironmentConfig, WorldType)
+        >>> from torchrl.envs.libs.craftground import CraftGroundEnv
+        >>> env = CraftGroundEnv(  # doctest: +SKIP
+        ...     initial_env_config=InitialEnvironmentConfig(
+        ...         image_width=114, image_height=64,
+        ...         world_type=WorldType.SUPERFLAT,
+        ...     ),
+        ...     port=8023,
+        ... )
+        >>> td = env.reset()  # doctest: +SKIP
+        >>> td["pixels"].shape  # doctest: +SKIP
+        torch.Size([64, 114, 3])
+
+    """
+
+    def __init__(
+        self,
+        *,
+        initial_env_config: InitialEnvironmentConfig | None = None,
+        mc_version: Literal["1.21", "26.2"] = "1.21",
+        port: int = 8000,
+        action_space_version=None,
+        env_path: str | None = None,
+        use_shared_memory: bool = False,
+        verbose: bool = False,
+        craftground_kwargs: dict | None = None,
+        **kwargs,
+    ):
+        craftground = self.lib
+        if action_space_version is None:
+            action_space_version = craftground.ActionSpaceVersion.V1_MINEDOJO
+        craftground_kwargs = (
+            dict(craftground_kwargs) if craftground_kwargs is not None else {}
+        )
+        env: CraftGroundEnvironment = craftground.make(
+            initial_env_config=initial_env_config,
+            mc_version=mc_version,
+            port=port,
+            action_space_version=action_space_version,
+            env_path=env_path,
+            use_shared_memory=use_shared_memory,
+            verbose=verbose,
+            **craftground_kwargs,
+        )
+        super().__init__(env=env, **kwargs)

--- a/torchrl/envs/libs/craftground.py
+++ b/torchrl/envs/libs/craftground.py
@@ -384,7 +384,7 @@ class CraftGroundEnv(CraftGroundWrapper):
         self,
         *,
         initial_env_config: InitialEnvironmentConfig | None = None,
-        mc_version: Literal["1.21", "26.2"] = "1.21",
+        mc_version: Literal["1.21"] = "1.21",
         port: int = 8000,
         action_space_version=None,
         env_path: str | None = None,


### PR DESCRIPTION
## Description

Adds a TorchRL integration for [CraftGround](https://github.com/yhs0602/CraftGround), a lightweight, headless-capable Minecraft RL environment available through `pip install craftground`:

- `CraftGroundWrapper` (wraps a `CraftGroundEnvironment`) and `CraftGroundEnv` (builds one from an `InitialEnvironmentConfig`), exported from `torchrl.envs`.
- Explicit spec construction: `pixels` uint8 frames (`(H, W, 3)` for RAW, `(3, W, H)` for PNG encoding, optional binocular `pixels_2`). The upstream declared observation space does not match the returned observations (and contains `gym.spaces.Sequence`), so specs are built from the env configuration instead, and the raw protobuf entry of each observation is dropped.
- Both action layouts supported: v1 MineDojo-style `MultiDiscrete` through the standard gym spec converter, and v2 MineRL-human-like dict exposed as a composite spec (dotted upstream keys such as `hotbar.1` are exposed as `hotbar_1` since TensorDict keys cannot contain dots) with translation back to the upstream format in `read_action`.
- The base env is a sandbox (zero reward, never terminates): rewards and termination are composed with TorchRL transforms, which is documented with examples.
- Minecraft 1.21 is the supported runtime version.

## Licensing

The requirements are documented in the module and class docstrings, in `envs_libraries.rst`, and in a new `knowledge_base/MINECRAFT.md` page:

- TorchRL and CraftGround do not ship or redistribute Minecraft. Gradle downloads the client from Mojang's servers onto the user's machine at first reset and runs it in offline mode.
- Users are expected to own a valid Minecraft: Java Edition license; offline mode bypasses authentication, not ownership. Usage is subject to the Minecraft EULA, including its restriction on commercial exploitation.
- The downloaded game files must never be redistributed, including in public Docker images or CI caches.
- CraftGround is a separate optional dependency that TorchRL does not vendor or redistribute. Its upstream repository currently ships a GPL-3.0 license file while its package metadata reports MIT; the documentation records that discrepancy without making a compatibility claim.

## Dedicated CI runtime

- New `unittests-craftground` job in `test-linux-libs.yml`, gated on the `Environments` / `Environments/craftground` labels like the other lib jobs.
- `.github/unittest/linux_libs/scripts_craftground/`: OpenJDK 21 + Xvfb + Mesa software GL; CraftGround installed with `--no-deps` so the nightly torch is preserved; the Gradle project is pre-built in `install.sh` so the Minecraft download and mod compilation happen outside the test run; pytest runs with `--error-for-skips`.
- `labeler.yml`/`labels.yml` entries for `Environments/craftground`, including CI-script changes, and a `craftground` optional-dependency extra in `pyproject.toml`.

## Tested

`test/libs/test_craftground.py` boots a real Minecraft client in the dedicated job: `check_env_specs` on both construction paths, uint8 pixel rollout with sandbox invariants (zero reward, no termination), transform-composed truncation via `StepCounter`, and the v2 action-space translation. The dedicated `unittests-craftground` job passed end to end on the functional implementation.

Verified locally against CraftGround 2.7.4 (construction does not boot the game): full wrapper construction, spec building, observation processing of the flipped read-only frames, and action translation for both layouts (v2 output accepted by CraftGround's own `action_v2_dict_to_message`). Linters (flake8, ufmt, pydocstyle, pyupgrade, codespell, docstring-args checker) pass. The tests also collect and skip cleanly when CraftGround is absent.
