### PR TITLE
[BugFix] Map sparse masked modes to original actions

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -881,6 +881,16 @@ class TestMaskedCategorical:
         sample_probs = torch.bincount(samples) / num_samples
         torch.testing.assert_close(sample_probs, ref_probs, rtol=1e-5, atol=1e-2)
 
+    def test_sparse_mode_uses_original_indices(self) -> None:
+        logits = torch.tensor([[0.0, 1.0, 10.0, 2.0], [0.0, 9.0, 1.0, 8.0]])
+        indices = torch.tensor([[0, 2], [1, 3]])
+        dist = MaskedCategorical(logits=logits, indices=indices)
+        expected = torch.tensor([2, 1])
+
+        torch.testing.assert_close(dist.mode, expected)
+        torch.testing.assert_close(dist.deterministic_sample, expected)
+        assert torch.isfinite(dist.log_prob(dist.mode)).all()
+
     @pytest.mark.parametrize("neg_inf", [-1e20, float("-inf")])
     @pytest.mark.parametrize("sparse", [False, True])
     @pytest.mark.parametrize("ndim", [2, 1, 3])
@@ -1136,6 +1146,16 @@ class TestMaskedOneHotCategorical:
         samples = dist.sample([num_samples]).argmax(-1)
         sample_probs = torch.bincount(samples) / num_samples
         torch.testing.assert_close(sample_probs, ref_probs, rtol=1e-5, atol=1e-2)
+
+    def test_sparse_mode_uses_original_indices(self) -> None:
+        logits = torch.tensor([[0.0, 1.0, 10.0, 2.0], [0.0, 9.0, 1.0, 8.0]])
+        indices = torch.tensor([[0, 2], [1, 3]])
+        dist = MaskedOneHotCategorical(logits=logits, indices=indices)
+        expected = F.one_hot(torch.tensor([2, 1]), num_classes=4)
+
+        torch.testing.assert_close(dist.mode, expected)
+        torch.testing.assert_close(dist.deterministic_sample, expected)
+        assert torch.isfinite(dist.log_prob(dist.mode)).all()
 
     @pytest.mark.parametrize("neg_inf", [-1e20, float("-inf")])
     def test_sample_sparse(self, neg_inf: float) -> None:

--- a/torchrl/modules/distributions/discrete.py
+++ b/torchrl/modules/distributions/discrete.py
@@ -433,6 +433,13 @@ class MaskedCategorical(D.Categorical):
     def deterministic_sample(self):
         return self.mode
 
+    @property
+    def mode(self) -> torch.Tensor:
+        mode = super().mode
+        if self._sparse_mask:
+            mode = self._mask.gather(-1, mode.unsqueeze(-1)).squeeze(-1)
+        return mode
+
 
 class MaskedOneHotCategorical(MaskedCategorical):
     """MaskedCategorical distribution.
@@ -541,6 +548,8 @@ class MaskedOneHotCategorical(MaskedCategorical):
 
     @property
     def mode(self) -> torch.Tensor:
+        if self._sparse_mask:
+            return F.one_hot(super().mode, self.num_samples)
         if hasattr(self, "logits"):
             return (self.logits == self.logits.max(-1, True)[0]).to(torch.long)
         else:


### PR DESCRIPTION
## Description

Sparse `MaskedCategorical` distributions gather logits into a compact list of valid actions, but their deterministic mode was returned as an offset into that compact list. This maps the mode back through the sparse indices, matching the action space used by `sample()`. `MaskedOneHotCategorical` now builds its sparse mode with the original action count as well.

The regression tests cover batched sparse indices for both categorical forms and verify `mode`, `deterministic_sample`, output shape, and finite `log_prob(mode)`.

## Motivation and Context

Fixes #4112.

Before this change, a four-action distribution restricted to actions `[0, 2]` could report action `1` as its mode even though that action was masked and had log-probability `-inf`. The one-hot variant returned a two-element vector instead of a four-element action.

- [x] I have raised an issue to propose this change

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the CONTRIBUTING guide
- [ ] My change requires a change to the documentation
- [x] I have updated the tests accordingly
- [ ] I have updated the documentation accordingly

## Validation

- `py -3.13 -m pytest test/test_distributions.py -q -k "TestMaskedCategorical or TestMaskedOneHotCategorical"`: 68 passed
- `py -3.13 -m pytest test/test_distributions.py -q -k "not test_tanhnormal_rsample_and_log_prob"`: 962 passed, 16 deselected
- Relevant pre-commit hooks on both changed files: passed (mixed-line-ending, ufmt, flake8, pydocstyle, pyupgrade, codespell, autoflake, docstring checks)
- `git diff --check`: passed

A full `test/test_distributions.py` run completed with 970 passed and 8 unrelated failures in `TestTanhNormal.test_tanhnormal_rsample_and_log_prob`; this Windows PyTorch build fails during TorchDynamo CUDA/Triton device discovery (`IndexError` in `get_device_properties`) before exercising this patch.

## Generative-tool disclosure

I used OpenAI Codex to assist with repository auditing, reproduction, duplicate searches, implementation, and test execution. I reviewed the complete diff and the affected sparse-mode mapping.