### PR TITLE
[BugFix] Fix DiffusionActor sampling and multidimensional training

### DIFF
--- a/test/modules/test_actor.py
+++ b/test/modules/test_actor.py
@@ -502,8 +502,9 @@ class TestDiffusionActor:
             assert p.grad is not None
 
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-    def test_dtype(self, dtype):
+    def test_reduced_precision_schedule(self, dtype):
         actor = DiffusionActor(action_dim=2, obs_dim=3, num_steps=3).to(dtype)
+        assert actor.module.alphas_cumprod.dtype is torch.float32
         td = TensorDict({"observation": torch.randn(4, 3, dtype=dtype)}, batch_size=[4])
         action = actor(td)["action"]
         assert action.dtype is dtype
@@ -520,6 +521,25 @@ class TestDiffusionActor:
                 TensorDict({"observation": observation.clone()}, batch_size=[4])
             )["action"]
         torch.testing.assert_close(action0, action1, rtol=0, atol=0)
+
+    @pytest.mark.parametrize(
+        ("dtype", "num_steps"),
+        [(torch.bfloat16, 258), (torch.float16, 2050)],
+    )
+    def test_timestep_dtype_resolution(self, dtype, num_steps):
+        actor = DiffusionActor(action_dim=2, obs_dim=3, num_steps=num_steps).to(dtype)
+        td = TensorDict({"observation": torch.randn(4, 3, dtype=dtype)}, [4])
+        with pytest.raises(ValueError, match="cannot be represented"):
+            actor(td)
+
+    def test_schedule_buffers_are_authoritative(self):
+        actor = DiffusionActor(action_dim=2, obs_dim=3, num_steps=3)
+        actor.module.alphas_cumprod.fill_(1)
+        clean_action = torch.randn(4, 2)
+        noisy_action, _ = actor.module.add_noise(
+            clean_action, torch.zeros(4, dtype=torch.long)
+        )
+        torch.testing.assert_close(noisy_action, clean_action)
 
 
 @pytest.mark.parametrize("device", get_default_devices())

--- a/test/modules/test_actor.py
+++ b/test/modules/test_actor.py
@@ -501,6 +501,26 @@ class TestDiffusionActor:
         for p in actor.parameters():
             assert p.grad is not None
 
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_dtype(self, dtype):
+        actor = DiffusionActor(action_dim=2, obs_dim=3, num_steps=3).to(dtype)
+        td = TensorDict({"observation": torch.randn(4, 3, dtype=dtype)}, batch_size=[4])
+        action = actor(td)["action"]
+        assert action.dtype is dtype
+        assert action.isfinite().all()
+
+    def test_deterministic(self):
+        actor = DiffusionActor(action_dim=2, obs_dim=3, num_steps=3)
+        observation = torch.randn(4, 3)
+        with set_exploration_type(ExplorationType.DETERMINISTIC):
+            action0 = actor(
+                TensorDict({"observation": observation.clone()}, batch_size=[4])
+            )["action"]
+            action1 = actor(
+                TensorDict({"observation": observation.clone()}, batch_size=[4])
+            )["action"]
+        torch.testing.assert_close(action0, action1, rtol=0, atol=0)
+
 
 @pytest.mark.parametrize("device", get_default_devices())
 def test_actorcritic(device):

--- a/test/objectives/test_diffusion_bc.py
+++ b/test/objectives/test_diffusion_bc.py
@@ -4,6 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import argparse
+
 import pytest
 import torch
 from tensordict import TensorDict
@@ -99,6 +101,23 @@ class TestDiffusionBCLoss:
         loss_td = loss_fn(td)
         assert "loss_diffusion_bc" in loss_td.keys()
 
+    def test_nested_keys(self):
+        actor = self._make_actor()
+        loss_fn = DiffusionBCLoss(actor)
+        loss_fn.set_keys(
+            action=("data", "demo_action"), observation=("data", "observation")
+        )
+        td = TensorDict(
+            {
+                "data": {
+                    "observation": torch.randn(8, 4),
+                    "demo_action": torch.randn(8, 2),
+                }
+            },
+            batch_size=[8],
+        )
+        assert loss_fn(td)["loss_diffusion_bc"].isfinite()
+
     def test_in_keys(self):
         actor = self._make_actor()
         loss_fn = DiffusionBCLoss(actor)
@@ -118,17 +137,24 @@ class TestDiffusionBCLoss:
         loss_td = loss_fn(td)
         assert loss_td["loss_diffusion_bc"].shape == torch.Size([])
 
-    @pytest.mark.parametrize("batch_size", [[], [2, 3]])
-    def test_batch_shapes(self, batch_size):
+    @pytest.mark.parametrize(
+        ("batch_size", "data_shape"),
+        [
+            ([], []),
+            ([8], [8]),
+            ([2, 3], [2, 3]),
+            (None, [8]),
+            ([8], [8, 5]),
+        ],
+    )
+    def test_batch_layouts(self, batch_size, data_shape):
         actor = self._make_actor()
         loss_fn = DiffusionBCLoss(actor)
-        td = TensorDict(
-            {
-                "observation": torch.randn(*batch_size, 4),
-                "action": torch.randn(*batch_size, 2),
-            },
-            batch_size=batch_size,
-        )
+        data = {
+            "observation": torch.randn(*data_shape, 4),
+            "action": torch.randn(*data_shape, 2),
+        }
+        td = TensorDict(data) if batch_size is None else TensorDict(data, batch_size)
         loss = loss_fn(td)["loss_diffusion_bc"]
         loss.backward()
         assert loss.shape == torch.Size([])
@@ -162,3 +188,8 @@ class TestDiffusionBCLoss:
         assert (
             final_loss < initial_loss
         ), f"Loss did not decrease: {initial_loss:.4f} -> {final_loss:.4f}"
+
+
+if __name__ == "__main__":
+    args, unknown = argparse.ArgumentParser().parse_known_args()
+    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/objectives/test_diffusion_bc.py
+++ b/test/objectives/test_diffusion_bc.py
@@ -118,6 +118,22 @@ class TestDiffusionBCLoss:
         loss_td = loss_fn(td)
         assert loss_td["loss_diffusion_bc"].shape == torch.Size([])
 
+    @pytest.mark.parametrize("batch_size", [[], [2, 3]])
+    def test_batch_shapes(self, batch_size):
+        actor = self._make_actor()
+        loss_fn = DiffusionBCLoss(actor)
+        td = TensorDict(
+            {
+                "observation": torch.randn(*batch_size, 4),
+                "action": torch.randn(*batch_size, 2),
+            },
+            batch_size=batch_size,
+        )
+        loss = loss_fn(td)["loss_diffusion_bc"]
+        loss.backward()
+        assert loss.shape == torch.Size([])
+        assert all(parameter.grad is not None for parameter in actor.parameters())
+
     @pytest.mark.parametrize("action_dim,obs_dim", [(2, 4), (4, 8), (6, 12)])
     def test_various_dims(self, action_dim, obs_dim):
         actor = self._make_actor(action_dim=action_dim, obs_dim=obs_dim)

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -2742,6 +2742,16 @@ class _DDPMModule(nn.Module):
         self.register_buffer("alphas", alphas)
         self.register_buffer("alphas_cumprod", alphas_cumprod)
 
+    def _schedule(
+        self, reference: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        dtype = reference.dtype
+        if dtype in (torch.float16, torch.bfloat16):
+            dtype = torch.float32
+        betas = self.betas.to(device=reference.device, dtype=dtype)
+        alphas = 1.0 - betas
+        return betas, alphas, torch.cumprod(alphas, dim=0)
+
     def add_noise(
         self, clean_action: torch.Tensor, t: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -2761,14 +2771,16 @@ class _DDPMModule(nn.Module):
             Tuple of ``(noisy_action, noise)`` both of shape
             ``(..., action_dim)``.
         """
-        alpha_bar_t = self.alphas_cumprod.to(clean_action.device)[t]  # (...)
+        _, _, alphas_cumprod = self._schedule(clean_action)
+        alpha_bar_t = alphas_cumprod[t]  # (...)
         # Broadcast scalar/batch alpha_bar_t to match action dimensions
         while alpha_bar_t.dim() < clean_action.dim():
             alpha_bar_t = alpha_bar_t.unsqueeze(-1)
         noise = torch.randn_like(clean_action)
         noisy_action = (
-            alpha_bar_t.sqrt() * clean_action + (1.0 - alpha_bar_t).sqrt() * noise
-        )
+            alpha_bar_t.sqrt() * clean_action.to(alpha_bar_t.dtype)
+            + (1.0 - alpha_bar_t).sqrt() * noise.to(alpha_bar_t.dtype)
+        ).to(clean_action.dtype)
         return noisy_action, noise
 
     def forward(self, observation: torch.Tensor) -> torch.Tensor:
@@ -2786,20 +2798,20 @@ class _DDPMModule(nn.Module):
         """
         batch_shape = observation.shape[:-1]
         device = observation.device
+        dtype = observation.dtype
         deterministic = interaction_type() == InteractionType.DETERMINISTIC
 
-        # Move schedule buffers to the observation device
-        betas = self.betas.to(device)
-        alphas = self.alphas.to(device)
-        alphas_cumprod = self.alphas_cumprod.to(device)
+        betas, alphas, alphas_cumprod = self._schedule(observation)
+        schedule_dtype = betas.dtype
 
         # Start from pure Gaussian noise
-        x = torch.randn(*batch_shape, self.action_dim, device=device)
+        if deterministic:
+            x = torch.zeros(*batch_shape, self.action_dim, device=device, dtype=dtype)
+        else:
+            x = torch.randn(*batch_shape, self.action_dim, device=device, dtype=dtype)
 
         for t in reversed(range(self.num_steps)):
-            t_tensor = torch.full(
-                (*batch_shape, 1), t, dtype=torch.float32, device=device
-            )
+            t_tensor = torch.full((*batch_shape, 1), t, dtype=dtype, device=device)
             model_input = torch.cat([x, observation, t_tensor], dim=-1)
             predicted_noise = self.score_network(model_input)
 
@@ -2808,6 +2820,8 @@ class _DDPMModule(nn.Module):
             alpha_bar_t = alphas_cumprod[t]
 
             # DDPM reverse step
+            x = x.to(schedule_dtype)
+            predicted_noise = predicted_noise.to(schedule_dtype)
             x = (1.0 / alpha_t.sqrt()) * (
                 x - (beta_t / (1.0 - alpha_bar_t).sqrt()) * predicted_noise
             )
@@ -2820,6 +2834,7 @@ class _DDPMModule(nn.Module):
                     beta_t.sqrt() * noise,
                     torch.zeros_like(x),
                 )
+            x = x.to(dtype)
 
         return x
 

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -2742,15 +2742,40 @@ class _DDPMModule(nn.Module):
         self.register_buffer("alphas", alphas)
         self.register_buffer("alphas_cumprod", alphas_cumprod)
 
+    def _apply(self, fn, recurse=True):
+        schedule = {
+            "betas": self.betas,
+            "alphas": self.alphas,
+            "alphas_cumprod": self.alphas_cumprod,
+        }
+        super()._apply(fn, recurse=recurse)
+        for name, value in schedule.items():
+            target = getattr(self, name)
+            setattr(self, name, value.to(device=target.device))
+        return self
+
     def _schedule(
         self, reference: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         dtype = reference.dtype
         if dtype in (torch.float16, torch.bfloat16):
             dtype = torch.float32
-        betas = self.betas.to(device=reference.device, dtype=dtype)
-        alphas = 1.0 - betas
-        return betas, alphas, torch.cumprod(alphas, dim=0)
+        return (
+            self.betas.to(device=reference.device, dtype=dtype),
+            self.alphas.to(device=reference.device, dtype=dtype),
+            self.alphas_cumprod.to(device=reference.device, dtype=dtype),
+        )
+
+    def _validate_timestep_dtype(self, dtype: torch.dtype) -> None:
+        max_steps = {
+            torch.bfloat16: 257,
+            torch.float16: 2049,
+        }.get(dtype)
+        if max_steps is not None and self.num_steps > max_steps:
+            raise ValueError(
+                f"num_steps={self.num_steps} cannot be represented without duplicate "
+                f"timesteps in {dtype}. Use at most {max_steps} steps or a float32 model."
+            )
 
     def add_noise(
         self, clean_action: torch.Tensor, t: torch.Tensor
@@ -2771,6 +2796,7 @@ class _DDPMModule(nn.Module):
             Tuple of ``(noisy_action, noise)`` both of shape
             ``(..., action_dim)``.
         """
+        self._validate_timestep_dtype(clean_action.dtype)
         _, _, alphas_cumprod = self._schedule(clean_action)
         alpha_bar_t = alphas_cumprod[t]  # (...)
         # Broadcast scalar/batch alpha_bar_t to match action dimensions
@@ -2787,8 +2813,9 @@ class _DDPMModule(nn.Module):
         """Run the full DDPM reverse chain conditioned on *observation*.
 
         Respects :func:`~tensordict.nn.probabilistic.interaction_type`:
-        when the interaction type is ``DETERMINISTIC``, the stochastic noise
-        injection step is skipped, producing a deterministic (mean) trajectory.
+        when the interaction type is ``DETERMINISTIC``, the chain starts from
+        an all-zero latent and skips stochastic noise injection. This produces
+        repeatable output but does not sample from the Gaussian DDPM prior.
 
         Args:
             observation: ``(..., obs_dim)`` tensor.
@@ -2800,11 +2827,11 @@ class _DDPMModule(nn.Module):
         device = observation.device
         dtype = observation.dtype
         deterministic = interaction_type() == InteractionType.DETERMINISTIC
+        self._validate_timestep_dtype(dtype)
 
         betas, alphas, alphas_cumprod = self._schedule(observation)
         schedule_dtype = betas.dtype
 
-        # Start from pure Gaussian noise
         if deterministic:
             x = torch.zeros(*batch_shape, self.action_dim, device=device, dtype=dtype)
         else:
@@ -2850,8 +2877,9 @@ class DiffusionActor(SafeModule):
     ``out_keys=["action"]``.
 
     Respects :func:`~tensordict.nn.probabilistic.interaction_type`: setting
-    the interaction type to ``DETERMINISTIC`` disables stochastic noise
-    injection during the reverse chain, yielding a deterministic output.
+    the interaction type to ``DETERMINISTIC`` starts from an all-zero latent
+    and disables stochastic noise injection during the reverse chain. The
+    result is repeatable but is not a sample from the Gaussian DDPM prior.
 
     Args:
         action_dim (int): Dimensionality of the action space.
@@ -2864,7 +2892,10 @@ class DiffusionActor(SafeModule):
             last dimension.  If ``None``, a two-hidden-layer MLP of width 256
             with a :class:`~torch.nn.LazyLinear` first layer is constructed
             automatically (``obs_dim`` need not be specified in this case).
-        num_steps (int): Number of DDPM denoising steps.  Defaults to 100.
+        num_steps (int): Number of DDPM denoising steps. Reduced-precision
+            models require at most 257 steps for bfloat16 and 2049 steps for
+            float16 so every raw integer timestep remains distinct. Defaults
+            to 100.
         beta_start (float): Starting beta for the linear schedule.
             Defaults to 1e-4.
         beta_end (float): Ending beta for the linear schedule.

--- a/torchrl/objectives/diffusion_bc.py
+++ b/torchrl/objectives/diffusion_bc.py
@@ -140,7 +140,7 @@ class DiffusionBCLoss(LossModule):
         clean_action = tensordict[self.tensor_keys.action]
         observation = tensordict[self.tensor_keys.observation]
 
-        batch_shape = tensordict.batch_size
+        batch_shape = clean_action.shape[:-1]
         device = clean_action.device
 
         with self.actor_network_params.to_module(

--- a/torchrl/objectives/diffusion_bc.py
+++ b/torchrl/objectives/diffusion_bc.py
@@ -140,7 +140,7 @@ class DiffusionBCLoss(LossModule):
         clean_action = tensordict[self.tensor_keys.action]
         observation = tensordict[self.tensor_keys.observation]
 
-        batch_size = clean_action.shape[0]
+        batch_shape = tensordict.batch_size
         device = clean_action.device
 
         with self.actor_network_params.to_module(
@@ -150,13 +150,13 @@ class DiffusionBCLoss(LossModule):
             ddpm = self.actor_network.module
 
             # Sample a random timestep per batch element
-            t = torch.randint(0, ddpm.num_steps, (batch_size,), device=device)
+            t = torch.randint(0, ddpm.num_steps, tuple(batch_shape), device=device)
 
             # Forward diffusion: corrupt the clean action
             noisy_action, noise = ddpm.add_noise(clean_action, t)
 
             # Build the score network input: (noisy_action || observation || t)
-            t_float = t.float().unsqueeze(-1)  # (B, 1)
+            t_float = t.to(dtype=noisy_action.dtype).unsqueeze(-1)
             model_input = torch.cat([noisy_action, observation, t_float], dim=-1)
 
             # Predict the noise


### PR DESCRIPTION
## Summary: 
Fixes multidimensional batch handling in `DiffusionBCLoss` and corrects `DiffusionActor` behavior for reduced-precision and deterministic inference.

Also keeps diffusion schedule calculations in float32 for numerical stability.