### PR TITLE
[Performance] mujoco playground skip 1d reshape

### DIFF
--- a/torchrl/envs/libs/mujoco_playground.py
+++ b/torchrl/envs/libs/mujoco_playground.py
@@ -911,7 +911,6 @@ class MujocoPlaygroundWrapper(_EnvWrapper):
         action = _tensor_to_ndarray(action_tensor)
 
         # vmap expects a flat leading batch dim, so collapse [d0, d1, ...] → [d0*d1*...].
-        # A one-dimensional batch already has the expected shape.
         if len(self.batch_size) != 1:
             state = _tree_flatten(state, self.batch_size)
             action = _tree_flatten(action, self.batch_size)

--- a/torchrl/envs/libs/mujoco_playground.py
+++ b/torchrl/envs/libs/mujoco_playground.py
@@ -872,7 +872,8 @@ class MujocoPlaygroundWrapper(_EnvWrapper):
         state = self._vmap_jit_env_reset(jax.numpy.stack(keys))
         # vmap output has leading dim = batch_size.numel() (flat).
         # _tree_reshape restores the original batch shape (e.g. [4, 8]).
-        state = _tree_reshape(state, self.batch_size)
+        if len(self.batch_size) != 1:
+            state = _tree_reshape(state, self.batch_size)
         # Store JAX state directly — avoids converting MJX/pytree state to
         # TensorDict and back, which breaks MJX's metadata pytree registration.
         self._current_state = state

--- a/torchrl/envs/libs/mujoco_playground.py
+++ b/torchrl/envs/libs/mujoco_playground.py
@@ -910,13 +910,16 @@ class MujocoPlaygroundWrapper(_EnvWrapper):
         action = _tensor_to_ndarray(action_tensor)
 
         # vmap expects a flat leading batch dim, so collapse [d0, d1, ...] → [d0*d1*...].
-        state = _tree_flatten(state, self.batch_size)
-        action = _tree_flatten(action, self.batch_size)
+        # A one-dimensional batch already has the expected shape.
+        if len(self.batch_size) != 1:
+            state = _tree_flatten(state, self.batch_size)
+            action = _tree_flatten(action, self.batch_size)
 
         next_state = self._vmap_jit_env_step(state, action)
 
         # Restore the original batch shape after vmap.
-        next_state = _tree_reshape(next_state, self.batch_size)
+        if len(self.batch_size) != 1:
+            next_state = _tree_reshape(next_state, self.batch_size)
         self._current_state = next_state
 
         done_shape = (*self.batch_size, 1)


### PR DESCRIPTION
### TLDR
very small pr. testing + visuals is just part of my investigation on torchrl perf:

> throughput of inference is still as best as it can be, especially with vectorized envs like mujoco (torch/warp/mjx)...

For a given 1-dim vec batch such as [4096], mujoco playground's vmap inputs and outputs hv the required flat lead dim. in this case, it is beneficial to skip the reshapes. scalar and multi-dim batches are not included.

this pr is just reducing the wrapper overhead for 1-dim mujoco vector batches.

transitions/s = aggregate per-env transitions [batch_size * vector_steps / elapsed_time]

<details><summary>Testing + visuals</summary>
<p>

### Testing:

Jax:

<img width="1440" height="810" alt="MuJoCo Playground JAX policy and environment throughput" src="https://github.com/user-attachments/assets/e51aca0e-9929-4cf1-a67e-ae564a6ed785" />

```arduino
CartpoleBalance, batch 4096, deterministic state-dependent 64x64 Tanh policy, 
100 warmup vector steps, and 500 measured vector steps per process:

20 proccesses, 5 abba rounds
```
- Median policy-plus-environment throughput: 592,124 to 723,537 transitions/s.
- Paired mean change: +22.08%; 95% bootstrap interval over the five within-round changes: +21.75% to +22.38%.

PPO control
```
same JAX backend
512 environments 
196,608 collected transitions
two PPO epochs
fixed seeds 0 and 1.
```
<img width="1260" height="810" alt="short PPO MuJoCo Playground collection throughput" src="https://github.com/user-attachments/assets/b4924594-afeb-4f4c-918e-2599f280c57a" />

Collection throughput changed +14.84% and +11.98% (+13.41% mean). Whole-script wall throughput changed +1.10% and +2.19%. 

Warp policy + environmnet

had to patch for this bc the warp config reshapes static state leaves when going through vec batch dim. but i use a fixed control of main + patch that skips only the invalid leaf reshapes. same shape reshapes not included.

<img width="1440" height="810" alt="throughput-abba" src="https://github.com/user-attachments/assets/2ed0ade0-77da-41bd-9b0a-76fd19bae077" />

Median throughput increased from 224,179 to 250,246 transitions/s. The paired mean change was +11.98%; the 95% bootstrap interval over the five within-round changes was +11.58% to +12.28%. 

For correctness: Twenty-step JAX scalar/1D/2D outputs, fixed-control/candidate 1D Warp outputs, and reset behavior matched bitwise; all 22 focused shape and mapping checks passed, and the Warp claim is 1D only.


</p>
</details> 

cc @vmoens @theap06 