### PR TITLE
[Performance] clone compiled policy outputs only

### DIFF
--- a/benchmarks/test_collectors_benchmark.py
+++ b/benchmarks/test_collectors_benchmark.py
@@ -479,9 +479,9 @@ def test_compiled_policy_large_observation(benchmark):
             iterations=1,
             rounds=10,
         )
-        benchmark.extra_info["cuda_peak_allocated_bytes"] = (
-            torch.cuda.max_memory_allocated(device)
-        )
+        benchmark.extra_info[
+            "cuda_peak_allocated_bytes"
+        ] = torch.cuda.max_memory_allocated(device)
     finally:
         try:
             collector.shutdown()

--- a/benchmarks/test_collectors_benchmark.py
+++ b/benchmarks/test_collectors_benchmark.py
@@ -10,6 +10,7 @@ import pytest
 import torch.cuda
 import tqdm
 from tensordict import TensorDict, TensorDictBase
+from tensordict.nn import TensorDictModule
 
 from torchrl.collectors import Collector, MultiAsyncCollector, MultiSyncCollector
 from torchrl.data import (
@@ -30,7 +31,8 @@ from torchrl.envs import (
     TransformedEnv,
 )
 from torchrl.envs.libs.dm_control import DMControlEnv
-from torchrl.modules import RandomPolicy
+from torchrl.modules import MLP, RandomPolicy
+from torchrl.testing.mocking_classes import MockBatchedLockedEnv
 
 
 class _PayloadEnv(EnvBase):
@@ -408,6 +410,83 @@ def test_parallel_env_compact_obs(benchmark, payload_size):
         )
     finally:
         collector.shutdown()
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_compiled_policy_large_observation(benchmark):
+    device = torch.device("cuda:0")
+    batch_size = torch.Size([4096])
+    observation_dim = 1024
+    payload_spec = Unbounded((*batch_size, observation_dim), device=device)
+    env = MockBatchedLockedEnv(device=device, batch_size=batch_size)
+    env.observation_spec = Composite(observation=payload_spec, shape=batch_size)
+    env.state_spec = env.observation_spec.clone()
+    env.reward_spec = payload_spec.clone()
+    with torch.random.fork_rng(devices=[device]):
+        torch.manual_seed(0)
+        policy = TensorDictModule(
+            MLP(
+                in_features=observation_dim,
+                out_features=1,
+                num_cells=[64, 64],
+                activation_class=torch.nn.Tanh,
+                activate_last_layer=True,
+                device=device,
+            ),
+            in_keys=["observation"],
+            out_keys=["action"],
+        )
+    frames_per_batch = batch_size.numel() * 8
+    collector = Collector(
+        env,
+        policy,
+        frames_per_batch=frames_per_batch,
+        total_frames=-1,
+        device=device,
+        max_frames_per_traj=-1,
+        compile_policy={"mode": "reduce-overhead", "warmup": 1},
+    )
+    previous_matmul_precision = torch.get_float32_matmul_precision()
+    batches_per_round = 10
+
+    def collect_batches():
+        for _ in range(batches_per_round):
+            next(collector_iterator)
+        torch.cuda.synchronize(device)
+
+    def reset_collector():
+        collector.reset()
+        torch.cuda.synchronize(device)
+
+    try:
+        torch.set_float32_matmul_precision("high")
+        collector_iterator = iter(collector)
+        for _ in range(20):
+            next(collector_iterator)
+        torch.cuda.synchronize(device)
+        torch.cuda.reset_peak_memory_stats(device)
+        benchmark.extra_info.update(
+            batches_per_round=batches_per_round,
+            frames_per_batch=frames_per_batch,
+            num_envs=batch_size.numel(),
+            observation_dim=observation_dim,
+            transitions_per_round=frames_per_batch * batches_per_round,
+        )
+        benchmark.pedantic(
+            collect_batches,
+            setup=reset_collector,
+            iterations=1,
+            rounds=10,
+        )
+        benchmark.extra_info["cuda_peak_allocated_bytes"] = (
+            torch.cuda.max_memory_allocated(device)
+        )
+    finally:
+        try:
+            collector.shutdown()
+        finally:
+            torch.set_float32_matmul_precision(previous_matmul_precision)
 
 
 @pytest.mark.skipif(not torch.cuda.device_count(), reason="no rendering without cuda")

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -2102,7 +2102,9 @@ class Collector(BaseCollector, metaclass=_CollectorMeta):
                     with _maybe_record_function("Collector.policy"):
                         policy_output = self._wrapped_policy(policy_input)
                     if self.compiled_policy:
-                        policy_output = policy_output.clone()
+                        policy_output = policy_output.select(
+                            *self._policy_output_keys, strict=False
+                        ).clone()
                     if self._carrier is not policy_output:
                         # ad-hoc update carrier
                         self._carrier.update(


### PR DESCRIPTION
### TLDR

This pr is also a very small change for perf but is a chance for me to document torchrl throughput metrics. 

> throughput of inference is still as best as it can be, especially with vectorized envs like mujoco (torch/warp/mjx)...

Connected to/similar to: https://github.com/pytorch/rl/pull/4115

<details><summary>Testing + visuals</summary>
<p>

### Testing:

Copy-overhead controls

```
MockBatchedLockedEnv
4096 CUDA environments
compiled 64x64 Tanh policy
20 processes, 5 ABBA rounds
```

Observation width 1

<img width="1440" height="810" alt="throughput-abba" src="https://github.com/user-attachments/assets/b4f5c09f-5333-4f13-b59f-c8ccfb4fa7f2" />

- Median throughput: 9.639M to 11.193M transitions/s.
- Paired mean change: +15.76%; 95% bootstrap interval: +14.05% to +17.40%.

Observation width 1024

<img width="1440" height="810" alt="throughput-abba" src="https://github.com/user-attachments/assets/de59c96f-b942-44c7-920e-82c9ea3d383f" />

- Median throughput: 7.780M to 8.687M transitions/s.
- Paired mean change: +11.26%; 95% bootstrap interval: +9.63% to +12.35%.

these lanes isolate Collector copy overhead. they are not real-physics results.

MuJoCo Playground control

```
CartpoleBalance
full JAX environment
compiled PPO actor
4096 environments
20 processes, 5 ABBA rounds
```

<img width="1440" height="810" alt="throughput-abba" src="https://github.com/user-attachments/assets/c5c3c57b-c7b8-4300-9122-31f629b9f1df" />


- Median throughput: 476,834 to 485,827 transitions/s.
- Paired mean change: +1.74%; 95% bootstrap interval: +0.74% to +2.67%.

this is below the 3% primary-effect floor, so it is a small positive control and not the headline result.

PPO control

```
same JAX backend
196,608 collected transitions per seed
fixed seeds 0 and 1
```

<img width="1260" height="810" alt="ppo-collection-throughput" src="https://github.com/user-attachments/assets/6940d812-cee4-4753-87a2-2ec714731531" />


Collection throughput changed +1.20% and +0.13%. Whole-script wall throughput changed +26.84% and -0.50%, so the wall results are not used as a performance claim. All 74 compared TensorBoard loss/reward values and checkpoint metrics matched exactly and were finite.

For correctness: the mock controls matched exactly; MuJoCo actions differed by at most `7.53e-7`, rewards by at most `1.13e-6`, and all 524,288 done flags matched; PyTorch peak memory did not increase, 6 GPU and 9 CPU/multiprocess Collector tests passed, and no prediction, transition, or reward is cached or reused.

</p>
</details>

cc @vmoens @theap06 