### PR TITLE
[BugFix] [Performance] fix dreamer v3 training semantics

### DIFF
--- a/sota-implementations/dreamer_v3/benchmark.py
+++ b/sota-implementations/dreamer_v3/benchmark.py
@@ -42,6 +42,7 @@ def main() -> None:
     parser.add_argument("overrides", nargs="*")
     args = parser.parse_args()
 
+    args.output_dir = args.output_dir.resolve()
     args.output_dir.mkdir(parents=True, exist_ok=True)
     script = Path(__file__).with_name("dreamer_v3.py")
     metrics_paths = []

--- a/sota-implementations/dreamer_v3/dreamer_v3.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3.py
@@ -66,6 +66,7 @@ from torchrl.objectives import (
     DreamerV3ActorLoss,
     DreamerV3ModelLoss,
     DreamerV3ValueLoss,
+    symexp,
     symlog,
 )
 from torchrl.objectives.utils import SoftUpdate, ValueEstimators
@@ -146,6 +147,13 @@ def build_world_model(*, cfg: DictConfig, obs_dim: int, action_dim: int):
     """
     state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
 
+    observation_encoder = DreamerV3MLP(
+        in_features=obs_dim,
+        out_features=cfg.networks.obs_embed_dim,
+        depth=cfg.networks.encoder_layers,
+        num_cells=cfg.networks.hidden_dim,
+        norm_eps=cfg.networks.norm_eps,
+    )
     encoder = TensorDictSequential(
         TensorDictModule(
             symlog,
@@ -153,13 +161,7 @@ def build_world_model(*, cfg: DictConfig, obs_dim: int, action_dim: int):
             out_keys=[("next", "symlog_observation")],
         ),
         TensorDictModule(
-            DreamerV3MLP(
-                in_features=obs_dim,
-                out_features=cfg.networks.obs_embed_dim,
-                depth=cfg.networks.encoder_layers,
-                num_cells=cfg.networks.hidden_dim,
-                norm_eps=cfg.networks.norm_eps,
-            ),
+            observation_encoder,
             in_keys=[("next", "symlog_observation")],
             out_keys=[("next", "encoded_latents")],
         ),
@@ -167,7 +169,7 @@ def build_world_model(*, cfg: DictConfig, obs_dim: int, action_dim: int):
 
     prior_net = RSSMPriorV3(
         action_shape=torch.Size([action_dim]),
-        hidden_dim=cfg.networks.rnn_hidden_dim,
+        hidden_dim=cfg.networks.hidden_dim,
         rnn_hidden_dim=cfg.networks.rnn_hidden_dim,
         num_categoricals=cfg.networks.num_categoricals,
         num_classes=cfg.networks.num_classes,
@@ -190,7 +192,7 @@ def build_world_model(*, cfg: DictConfig, obs_dim: int, action_dim: int):
     )
 
     posterior_net = RSSMPosteriorV3(
-        hidden_dim=cfg.networks.rnn_hidden_dim,
+        hidden_dim=cfg.networks.hidden_dim,
         num_categoricals=cfg.networks.num_categoricals,
         num_classes=cfg.networks.num_classes,
         rnn_hidden_dim=cfg.networks.rnn_hidden_dim,
@@ -208,16 +210,23 @@ def build_world_model(*, cfg: DictConfig, obs_dim: int, action_dim: int):
 
     rollout = RSSMRolloutV3(rssm_prior, rssm_posterior)
 
-    decoder = TensorDictModule(
-        DreamerV3MLP(
-            in_features=state_dim + cfg.networks.rnn_hidden_dim,
-            out_features=obs_dim,
-            depth=cfg.networks.decoder_layers,
-            num_cells=cfg.networks.hidden_dim,
-            norm_eps=cfg.networks.norm_eps,
+    decoder = TensorDictSequential(
+        TensorDictModule(
+            DreamerV3MLP(
+                in_features=state_dim + cfg.networks.rnn_hidden_dim,
+                out_features=obs_dim,
+                depth=cfg.networks.decoder_layers,
+                num_cells=cfg.networks.hidden_dim,
+                norm_eps=cfg.networks.norm_eps,
+            ),
+            in_keys=[("next", "state"), ("next", "belief")],
+            out_keys=[("next", "reco_symlog_observation")],
         ),
-        in_keys=[("next", "state"), ("next", "belief")],
-        out_keys=[("next", "reco_pixels")],
+        TensorDictModule(
+            symexp,
+            in_keys=[("next", "reco_symlog_observation")],
+            out_keys=[("next", "reco_pixels")],
+        ),
     )
 
     reward_net = DreamerV3MLP(
@@ -258,7 +267,15 @@ def build_world_model(*, cfg: DictConfig, obs_dim: int, action_dim: int):
     world_model = TensorDictSequential(
         encoder, rollout, decoder, reward_head, continuation_head
     )
-    return world_model, prior_net, reward_net, reward_decoder, continuation_net
+    return (
+        world_model,
+        observation_encoder,
+        prior_net,
+        posterior_net,
+        reward_net,
+        reward_decoder,
+        continuation_net,
+    )
 
 
 def build_imagination_model(*, prior_net, reward_net, reward_decoder):
@@ -330,6 +347,33 @@ def build_actor(*, cfg: DictConfig, action_dim: int):
             )
         )
     return actor_model
+
+
+def build_real_actor(*, observation_encoder, posterior_net, prior_net, actor_model):
+    """Build the observation-conditioned recurrent policy used in real envs."""
+    return TensorDictSequential(
+        TensorDictModule(
+            symlog,
+            in_keys=["observation"],
+            out_keys=["symlog_observation"],
+        ),
+        TensorDictModule(
+            observation_encoder,
+            in_keys=["symlog_observation"],
+            out_keys=["encoded_latents"],
+        ),
+        TensorDictModule(
+            posterior_net,
+            in_keys=["belief", "encoded_latents"],
+            out_keys=["_", "state"],
+        ),
+        actor_model,
+        TensorDictModule(
+            prior_net,
+            in_keys=["state", "belief", "action"],
+            out_keys=["_", "_", ("next", "belief")],
+        ),
+    )
 
 
 def build_value(*, cfg: DictConfig):
@@ -423,7 +467,9 @@ def main(cfg: DictConfig):
 
     (
         world_model,
+        observation_encoder,
         prior_net,
+        posterior_net,
         reward_net,
         reward_decoder,
         continuation_net,
@@ -438,6 +484,12 @@ def main(cfg: DictConfig):
         device
     )
     actor_model = build_actor(cfg=cfg, action_dim=action_dim).to(device)
+    real_actor = build_real_actor(
+        observation_encoder=observation_encoder,
+        posterior_net=posterior_net,
+        prior_net=prior_net,
+        actor_model=actor_model,
+    )
     value_model = build_value(cfg=cfg).to(device)
     mb_env = build_mb_env(
         cfg=cfg,
@@ -456,7 +508,7 @@ def main(cfg: DictConfig):
         unimix=cfg.networks.unimix,
         lambda_continue=1.0,
         continue_target_scale=1 - 1 / cfg.optimization.continuation_horizon,
-        global_average=True,  # state-based obs, not (C, H, W) pixels
+        global_average=False,
     ).to(device)
     model_loss.set_keys(pixels="observation")
     actor_loss = DreamerV3ActorLoss(
@@ -513,7 +565,7 @@ def main(cfg: DictConfig):
 
     collector = Collector(
         explore_env,
-        actor_model,
+        real_actor,
         frames_per_batch=cfg.collector.frames_per_batch,
         total_frames=cfg.collector.total_frames,
         policy_device=device,
@@ -521,7 +573,7 @@ def main(cfg: DictConfig):
         storing_device="cpu",
         exploration_type=ExplorationType.RANDOM
         if cfg.collector.exploration == "random"
-        else ExplorationType.MODE,
+        else ExplorationType.DETERMINISTIC,
     )
 
     rb = ReplayBuffer(
@@ -568,7 +620,15 @@ def main(cfg: DictConfig):
         )
 
     for data in collector:
-        rb.extend(data.reshape(-1))
+        replay_data = data.select(
+            "action",
+            "is_init",
+            ("next", "observation"),
+            ("next", "reward"),
+            ("next", "terminated"),
+            ("collector", "traj_ids"),
+        )
+        rb.extend(replay_data.reshape(-1))
         env_step += data.numel()
 
         if len(rb) < warmup:
@@ -634,7 +694,7 @@ def main(cfg: DictConfig):
             opt_actor.zero_grad(set_to_none=True)
             a_td["loss_actor"].backward()
             adaptive_grad_clip_(
-                actor_loss.parameters(), cfg.optimization.adaptive_grad_clip
+                actor_model.parameters(), cfg.optimization.adaptive_grad_clip
             )
             opt_actor.step()
             schedulers[1].step()
@@ -666,7 +726,7 @@ def main(cfg: DictConfig):
             latest_losses = batch_losses[-1].cpu()
             r = eval_episode_reward(
                 eval_env,
-                actor_model,
+                real_actor,
                 cfg.logger.eval_episodes,
                 cfg.env.max_episode_steps,
             )

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -865,9 +865,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             reward_head,
             reward_decoder,
             continuation_head,
-        ) = example["build_world_model"](
-            cfg=cfg, obs_dim=3, action_dim=self.action_dim
-        )
+        ) = example["build_world_model"](cfg=cfg, obs_dim=3, action_dim=self.action_dim)
         imagination_model = example["build_imagination_model"](
             prior_net=prior,
             reward_net=reward_head,
@@ -876,9 +874,9 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         continuation_model = example["build_continuation_model"](
             continuation_net=continuation_head
         ).to(device)
-        actor_model = example["build_actor"](
-            cfg=cfg, action_dim=self.action_dim
-        ).to(device)
+        actor_model = example["build_actor"](cfg=cfg, action_dim=self.action_dim).to(
+            device
+        )
         real_actor = example["build_real_actor"](
             observation_encoder=observation_encoder,
             posterior_net=posterior,
@@ -933,9 +931,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         real_input = TensorDict(
             {
                 "observation": observation,
-                "belief": torch.zeros(
-                    1, cfg.networks.rnn_hidden_dim, device=device
-                ),
+                "belief": torch.zeros(1, cfg.networks.rnn_hidden_dim, device=device),
             },
             [1],
         )
@@ -1241,8 +1237,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         torch.manual_seed(0)
         out_d = rollout(td_d)
         action_effect = (
-            out_c["next", "prior_logits"][:, 2]
-            - out_d["next", "prior_logits"][:, 2]
+            out_c["next", "prior_logits"][:, 2] - out_d["next", "prior_logits"][:, 2]
         ).abs()
         assert action_effect.max() > 1e-6
 

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -441,6 +441,35 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
                 assert not torch.isnan(p.grad).any(), f"NaN grad in {name}"
                 assert not torch.isinf(p.grad).any(), f"Inf grad in {name}"
 
+    def test_dreamer_v3_model_loss_sums_only_event_dims(self, device):
+        batch_size, event_size = (2, 3), 4
+        target = torch.ones(*batch_size, event_size, device=device)
+        logits = torch.zeros(
+            *batch_size, self.num_cats, self.num_classes, device=device
+        )
+        tensordict = TensorDict(
+            {
+                "next": {
+                    "pixels": target,
+                    "reco_pixels": torch.zeros_like(target),
+                    "prior_logits": logits,
+                    "posterior_logits": logits.clone(),
+                    "reward": torch.zeros(*batch_size, 1, device=device),
+                }
+            },
+            batch_size,
+        )
+        world_model = TensorDictModule(
+            torch.zeros_like,
+            in_keys=[("next", "true_reward")],
+            out_keys=[("next", "reward")],
+        )
+        loss_td, _ = DreamerV3ModelLoss(
+            world_model, reward_two_hot=False, free_bits=0.0, global_average=False
+        )(tensordict)
+        expected = event_size * symlog(torch.tensor(1.0, device=device)).square()
+        torch.testing.assert_close(loss_td["loss_model_reco"].squeeze(), expected)
+
     @pytest.mark.parametrize("free_bits", [0.0, 0.5])
     def test_dreamer_v3_kl_balanced_gradients(self, device, free_bits):
         """Both prior_logits and posterior_logits must receive gradients (KL balancing).
@@ -602,8 +631,9 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
     def test_dreamer_v3_continuation_lambda_and_weights(self, device):
         class _ConstantContinuation(nn.Module):
             def forward(self_, state, belief):
-                return torch.full_like(state[..., :1], 0.5)
+                return state[..., :1] * 0 + 0.5
 
+        actor_model = self._create_actor_model_with_log_prob().to(device)
         continuation_model = TensorDictModule(
             _ConstantContinuation(),
             in_keys=["state", "belief"],
@@ -611,12 +641,15 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         ).to(device)
         value_model = self._create_value_model().to(device)
         loss_module = DreamerV3ActorLoss(
-            self._create_actor_model().to(device),
+            actor_model,
             value_model,
             self._create_mb_env().to(device),
             continuation_model=continuation_model,
             imagination_horizon=3,
             discount_loss=True,
+            entropy_bonus=0.0,
+            use_reinforce=True,
+            return_normalization=False,
         )
         loss_module.make_value_estimator(ValueEstimators.TDLambda, gamma=1.0, lmbda=0.5)
 
@@ -628,7 +661,9 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             torch.tensor([[[6.375], [11.5], [18.0]]], device=device),
         )
 
-        _, fake_data = loss_module(self._create_actor_data().to(device).reshape(-1))
+        loss_td, fake_data = loss_module(
+            self._create_actor_data().to(device).reshape(-1)
+        )
         expected_weight = torch.tensor([1.0, 0.5, 0.25], device=device)
         torch.testing.assert_close(
             fake_data["discount_weight"][0, :, 0], expected_weight
@@ -637,6 +672,23 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             fake_data["next", "continuation"],
             torch.full_like(fake_data["next", "continuation"], 0.5),
         )
+        assert not fake_data["discount_weight"].requires_grad
+        actor_parameters = tuple(actor_model.parameters())
+        actual_gradients = torch.autograd.grad(
+            loss_td["loss_actor"], actor_parameters, retain_graph=True
+        )
+
+        actor_inputs = fake_data.select(*actor_model.in_keys, strict=False).detach()
+        distribution = actor_model.get_dist(actor_inputs)
+        log_prob = distribution.log_prob(fake_data["action"].detach())
+        log_prob = _match_trailing_dim(log_prob, fake_data["lambda_target"])
+        baseline_td = fake_data.select(*value_model.in_keys, strict=False)
+        value_model(baseline_td)
+        advantage = (fake_data["lambda_target"] - baseline_td["state_value"]).detach()
+        expected_loss = -(fake_data["discount_weight"] * log_prob * advantage).mean()
+        expected_gradients = torch.autograd.grad(expected_loss, actor_parameters)
+        for actual, expected in zip(actual_gradients, expected_gradients):
+            torch.testing.assert_close(actual, expected)
 
         value_loss = DreamerV3ValueLoss(
             value_model,
@@ -805,9 +857,17 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         )
         cfg = OmegaConf.load(repo_root / "sota-implementations/dreamer_v3/config.yaml")
         cfg.networks.num_reward_bins = self.num_reward_bins
-        (world_model, prior, reward_head, reward_decoder, continuation_head,) = example[
-            "build_world_model"
-        ](cfg=cfg, obs_dim=3, action_dim=self.action_dim)
+        (
+            world_model,
+            observation_encoder,
+            prior,
+            posterior,
+            reward_head,
+            reward_decoder,
+            continuation_head,
+        ) = example["build_world_model"](
+            cfg=cfg, obs_dim=3, action_dim=self.action_dim
+        )
         imagination_model = example["build_imagination_model"](
             prior_net=prior,
             reward_net=reward_head,
@@ -816,7 +876,21 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         continuation_model = example["build_continuation_model"](
             continuation_net=continuation_head
         ).to(device)
+        actor_model = example["build_actor"](
+            cfg=cfg, action_dim=self.action_dim
+        ).to(device)
+        real_actor = example["build_real_actor"](
+            observation_encoder=observation_encoder,
+            posterior_net=posterior,
+            prior_net=prior,
+            actor_model=actor_model,
+        ).to(device)
         world_model = world_model.to(device)
+        assert (
+            prior.rnn_to_prior_projector[0].out_features
+            == posterior.obs_rnn_to_post_projector[0].out_features
+            == cfg.networks.hidden_dim
+        )
         observation = torch.tensor(
             [[[0.0, 1.0, -3.0], [2.0, -1.0, 0.5]]], device=device
         )
@@ -829,9 +903,13 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             },
             [1, 2],
         )
-        world_model(world_input)
+        world_input = world_model(world_input)
         torch.testing.assert_close(
             world_input["next", "symlog_observation"], symlog(observation)
+        )
+        torch.testing.assert_close(
+            symlog(world_input["next", "reco_pixels"]),
+            world_input["next", "reco_symlog_observation"],
         )
         shared_parameters = tuple(prior.parameters()) + tuple(reward_head.parameters())
         world_parameters = tuple(world_model.parameters())
@@ -848,6 +926,25 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             )
             for parameter in continuation_head.parameters()
         )
+
+        observation = torch.tensor(
+            [[0.25, -0.75, 1.5]], device=device, requires_grad=True
+        )
+        real_input = TensorDict(
+            {
+                "observation": observation,
+                "belief": torch.zeros(
+                    1, cfg.networks.rnn_hidden_dim, device=device
+                ),
+            },
+            [1],
+        )
+        real_actor(real_input)
+        observation_gradient = torch.autograd.grad(
+            real_input["loc"].sum(), observation
+        )[0]
+        assert observation_gradient.abs().sum() > 0
+        assert ("next", "belief") in real_input.keys(include_nested=True)
 
         reward_td = TensorDict(
             {
@@ -1135,6 +1232,20 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         ):
             torch.testing.assert_close(out_a[key][:, 2:], out_b[key][:, 2:])
 
+        td_c = td_a.clone()
+        td_d = td_a.clone()
+        td_c["action"][:, 2].zero_()
+        td_d["action"][:, 2].fill_(1.0)
+        torch.manual_seed(0)
+        out_c = rollout(td_c)
+        torch.manual_seed(0)
+        out_d = rollout(td_d)
+        action_effect = (
+            out_c["next", "prior_logits"][:, 2]
+            - out_d["next", "prior_logits"][:, 2]
+        ).abs()
+        assert action_effect.max() > 1e-6
+
     # ------------------------------------------------------------------ #
     # Coverage for previously untested branches
     # ------------------------------------------------------------------ #
@@ -1294,7 +1405,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         log_prob = _match_trailing_dim(
             fake_data["action_log_prob"], fake_data["lambda_target"]
         )
-        expected = -(log_prob * advantage / 10.0).sum((-2, -1)).mean()
+        expected = -(log_prob * advantage / 10.0).mean()
         torch.testing.assert_close(loss_td["loss_actor"], expected)
         torch.testing.assert_close(
             loss_td["return_scale"], torch.tensor(10.0, device=device)

--- a/torchrl/modules/models/model_based_v3.py
+++ b/torchrl/modules/models/model_based_v3.py
@@ -820,8 +820,8 @@ class RSSMRolloutV3(TensorDictModuleBase):
         rssm_posterior (TensorDictModule): Posterior module wrapping
             :class:`RSSMPosteriorV3`.
         reset_key (NestedKey or None, optional): Boolean key marking the first
-            transition of an episode. State, belief, and action are zeroed at
-            those positions. Defaults to ``"is_init"``.
+            transition of an episode. State and belief are zeroed at those
+            positions. Defaults to ``"is_init"``.
 
     Examples:
         >>> import torch
@@ -899,12 +899,10 @@ class RSSMRolloutV3(TensorDictModuleBase):
             if reset is not None:
                 state = _tensordict.get("state")
                 belief = _tensordict.get("belief")
-                action = _tensordict.get("action")
                 while reset.ndim < state.ndim:
                     reset = reset.unsqueeze(-1)
                 _tensordict.set("state", torch.where(reset, 0, state))
                 _tensordict.set("belief", torch.where(reset, 0, belief))
-                _tensordict.set("action", torch.where(reset, 0, action))
             self.rssm_prior(_tensordict)
             self.rssm_posterior(_tensordict)
 

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -29,6 +29,8 @@ from tensordict.utils import NestedKey, unravel_key
 from torchrl._utils import _maybe_record_function_decorator
 from torchrl.envs.model_based.dreamer import DreamerEnv
 from torchrl.envs.utils import ExplorationType, set_exploration_type, step_mdp
+from torchrl.modules.distributions import HAS_ENTROPY
+from torchrl.modules.distributions.utils import rsample_and_log_prob
 from torchrl.modules.functional import symexp as _symexp, symlog as symlog
 from torchrl.modules.models.model_based_v3 import (  # noqa: F401
     _default_bins,
@@ -421,7 +423,7 @@ class DreamerV3ModelLoss(LossModule):
         else:
             reco_loss = (symlog(pixels) - symlog(reco_pixels)).abs()
         if not self.global_average:
-            reco_loss = reco_loss.sum((-3, -2, -1))
+            reco_loss = reco_loss.reshape(*tensordict.batch_size, -1).sum(-1)
         reco_loss = reco_loss.mean().unsqueeze(-1)
 
         # ---- Reward loss ----
@@ -631,6 +633,7 @@ class DreamerV3ActorLoss(LossModule):
             belief (NestedKey): Deterministic GRU hidden state. Defaults to ``"belief"``.
             reward (NestedKey): Imagined reward. Defaults to ``"reward"``.
             value (NestedKey): State value. Defaults to ``"state_value"``.
+            action (NestedKey): Imagined action. Defaults to ``"action"``.
             action_log_prob (NestedKey): Log-prob of the taken action.
                 Defaults to ``"action_log_prob"``.
             done (NestedKey): Done flag. Defaults to ``"done"``.
@@ -645,6 +648,7 @@ class DreamerV3ActorLoss(LossModule):
         belief: NestedKey = "belief"
         reward: NestedKey = "reward"
         value: NestedKey = "state_value"
+        action: NestedKey = "action"
         action_log_prob: NestedKey = "action_log_prob"
         done: NestedKey = "done"
         terminated: NestedKey = "terminated"
@@ -760,11 +764,21 @@ class DreamerV3ActorLoss(LossModule):
             ).cumprod(dim=-2)
         else:
             discount = torch.ones_like(lambda_target)
-        fake_data.set(self.tensor_keys.discount_weight, discount.detach())
+        discount = discount.detach()
+        fake_data.set(self.tensor_keys.discount_weight, discount)
+
+        if self.use_reinforce or self.entropy_bonus > 0:
+            actor_inputs = fake_data.select(
+                *self.actor_model.in_keys, strict=False
+            ).detach()
+            policy_distribution = self.actor_model.get_dist(actor_inputs)
 
         if self.use_reinforce:
-            # REINFORCE: log pi(a|z) * sg(A_t)
-            log_prob = fake_data.get(self.tensor_keys.action_log_prob)
+            # REINFORCE: score a stopped action from a stopped imagined state.
+            # The rollout action is reparameterized, so its cached log-probability
+            # has a pathwise component and is not a score-function estimator.
+            action = fake_data.get(self.tensor_keys.action).detach()
+            log_prob = policy_distribution.log_prob(action)
             log_prob = _match_trailing_dim(log_prob, lambda_target)
             with hold_out_net(self.value_model):
                 baseline_td = fake_data.select(*self.value_model.in_keys, strict=False)
@@ -773,19 +787,22 @@ class DreamerV3ActorLoss(LossModule):
             advantage = (lambda_target - baseline).detach()
             return_scale = self._return_scale(lambda_target)
             advantage = advantage / return_scale
-            actor_loss = -(discount * log_prob * advantage).sum((-2, -1)).mean()
+            actor_loss = -(discount * log_prob * advantage).mean()
         else:
             # Reparameterization gradient
             return_scale = torch.ones(
                 (), dtype=lambda_target.dtype, device=lambda_target.device
             )
-            actor_loss = -(discount * lambda_target).sum((-2, -1)).mean()
+            actor_loss = -(discount * lambda_target).mean()
 
-        # Entropy bonus (if actor provides log_prob)
-        log_prob_for_entropy = fake_data.get(self.tensor_keys.action_log_prob, None)
-        if log_prob_for_entropy is not None and self.entropy_bonus > 0:
-            log_prob_for_entropy = _match_trailing_dim(log_prob_for_entropy, discount)
-            entropy = -(discount * log_prob_for_entropy).sum((-2, -1)).mean()
+        if self.entropy_bonus > 0:
+            if HAS_ENTROPY.get(type(policy_distribution), False):
+                entropy = policy_distribution.entropy()
+            else:
+                _, entropy_log_prob = rsample_and_log_prob(policy_distribution)
+                entropy = -entropy_log_prob
+            entropy = _match_trailing_dim(entropy, discount)
+            entropy = (discount * entropy).mean()
             actor_loss = actor_loss - self.entropy_bonus * entropy
 
         loss_tensordict = TensorDict(


### PR DESCRIPTION
### TLDR

working on this part:
> that the new algos that we have provided all have nice looking learning curves (especially dreamer 3 on some non trivial task)

This pr fixes DreamerV3's real-policy, reset, reconstruction, and actor-loss paths. The real policy now uses each observation and shares the trained world model.

Connected to/based on: https://github.com/pytorch/rl/pull/4118. It does not duplicate that pr's device, CPU-replay, or history changes.

<details><summary>Testing + visuals</summary>
<p>

### DMC Walker Stand

```
NVIDIA H100 PCIe
646,819 unique optimizer-owned parameters
24D observation, 6D continuous action
seed 0, 3,000 real steps and 3,000 updates
B=8, T=16, imagination horizon 15
3 evaluation episodes per point
```

<img width="2430" height="972" alt="image" src="https://github.com/user-attachments/assets/4180f43f-7ea1-4fbc-a7c9-ab7e76e323a2" />


- Reconstruction loss: 22.420 to 2.958 (-86.8%).
- Reward loss: 5.387 to 0.576 (-89.3%).
- Raw return first-four median: 105.19; last-four median: 128.70 (+22.3%); final: 212.15.

these are raw, unsmoothed points from a complete exit-0 fixed-worktree run. the curve log predates the semantic commit and has no embedded SHA, and one 3k-step seed is not benchmark evidence.

### Functional controls

```
baseline 6e18e35b
fixed semantics 8fdf0b5e
same seed and paired observations
```

<img width="2304" height="936" alt="image" src="https://github.com/user-attachments/assets/1a2a04b1-4cfa-434a-a7bb-de4fa90f0946" />

- Observation gradient norm: 0 to 0.003504; paired-observation action delta: 0 to 0.004378.
- Shared world-model parameter tensors: 0 to 48; next belief: absent to present.
- The baseline deterministic caller exits 1 on `TanhNormal.mode`; the fixed caller exits 0.
- The exact CI lint command passes locally; 268 Dreamer consumer tests pass.

### Reproduction

```bash
/usr/bin/time -v python sota-implementations/dreamer_v3/dreamer_v3.py \
  --config-name=config_dmc_walker env.task=stand \
  optimization.device=cuda optimization.use_reinforce=false \
  collector.total_frames=3000 collector.frames_per_batch=250 \
  replay_buffer.buffer_size=3000 replay_buffer.batch_size=8 \
  replay_buffer.seq_len=16 replay_buffer.warmup_factor=1 \
  optimization.train_ratio=null optimization.updates_per_batch=250 \
  logger.eval_every=250 logger.eval_episodes=3 \
  logger.metrics_json=/tmp/walker_stand.json \
  2>&1 | tee /tmp/walker_stand.log
```

```python
import re
from pathlib import Path

import matplotlib.pyplot as plt

pattern = re.compile(
    r"\[env_step=\s*(\d+)\]\s+eval_reward=([+-]?\d+(?:\.\d+)?)\s+"
    r"kl=\S+\s+reco=(\d+(?:\.\d+)?)\s+reward=(\d+(?:\.\d+)?)"
)
points = [tuple(map(float, match.groups())) for match in pattern.finditer(Path("/tmp/walker_stand.log").read_text())]
steps, returns, reconstruction, reward = zip(*points)
plt.style.use("dark_background")
figure, axes = plt.subplots(1, 2)
axes[0].plot(steps, returns, marker="o")
axes[1].plot(steps, reconstruction, marker="o", label="reconstruction")
axes[1].plot(steps, reward, marker="o", label="reward")
axes[1].set_yscale("log")
figure.savefig("dreamer_v3_h100_learning_dark.png")
```

```bash
pre-commit run --all-files
pytest test/modules/test_dreamer_components.py test/objectives/test_dreamer_v3.py -q
```

```python
real_actor(real_input)
gradient = torch.autograd.grad(real_input["loc"].sum(), observation)[0]
assert gradient.abs().sum() > 0
assert ("next", "belief") in real_input.keys(include_nested=True)
```

</p>
</details>

ai disclosure: in this pr i used an agent for helping me format and write the pr description and help with env testing

cc @vmoens @theap06