### PR TITLE
[Performance] Lock TransformedEnv specs by default

### DIFF
--- a/test/transforms/test_compose_and_env.py
+++ b/test/transforms/test_compose_and_env.py
@@ -204,12 +204,42 @@ class TestTransformedEnv:
         assert "other_count" in env.observation_spec.keys()
         assert env.is_spec_locked
 
-    def test_spec_lock_opt_out(self) -> None:
-        env = TransformedEnv(ContinuousActionVecMockEnv(), StepCounter())
-        env.set_spec_lock_(False)
+    @pytest.mark.parametrize("set_after_init", [False, True])
+    def test_spec_lock_opt_out(self, set_after_init: bool) -> None:
+        env = TransformedEnv(
+            ContinuousActionVecMockEnv(), StepCounter(), spec_locked=set_after_init
+        )
+        if set_after_init:
+            env.set_spec_lock_(False)
         assert not env.is_spec_locked
         assert not env.observation_spec.is_locked
         assert env._step_mdp is not env._step_mdp
+
+    def test_spec_lock_without_spec_cache(self) -> None:
+        class DynamicKeyTransform(Transform):
+            enabled = False
+
+            def transform_observation_spec(
+                self, observation_spec: TensorSpec
+            ) -> TensorSpec:
+                if self.enabled:
+                    observation_spec["dynamic"] = Unbounded(shape=(1,))
+                return observation_spec
+
+        transform = DynamicKeyTransform()
+        env = TransformedEnv(
+            ContinuousActionVecMockEnv(), transform, cache_specs=False
+        )
+
+        assert env.is_spec_locked
+        assert env.observation_spec.is_locked
+        assert env.input_spec.is_locked
+        assert "dynamic" not in env.observation_keys
+
+        transform.enabled = True
+
+        assert "dynamic" in env.observation_keys
+        assert env.observation_spec.is_locked
 
     def test_spec_lock_with_lazy_transform(self) -> None:
         env = TransformedEnv(

--- a/test/transforms/test_compose_and_env.py
+++ b/test/transforms/test_compose_and_env.py
@@ -227,9 +227,7 @@ class TestTransformedEnv:
                 return observation_spec
 
         transform = DynamicKeyTransform()
-        env = TransformedEnv(
-            ContinuousActionVecMockEnv(), transform, cache_specs=False
-        )
+        env = TransformedEnv(ContinuousActionVecMockEnv(), transform, cache_specs=False)
 
         assert env.is_spec_locked
         assert env.observation_spec.is_locked

--- a/test/transforms/test_compose_and_env.py
+++ b/test/transforms/test_compose_and_env.py
@@ -174,6 +174,65 @@ class TestTransformedEnv:
         def _set_seed(self, seed: int) -> None:
             pass
 
+    def test_spec_lock_deferred_until_specs_materialize(self) -> None:
+        env = TransformedEnv(ContinuousActionVecMockEnv(), StepCounter())
+        assert env.is_spec_locked
+        assert env.__dict__["_output_spec"] is None
+        assert env.__dict__["_input_spec"] is None
+
+        _ = env.observation_spec, env.action_spec
+
+        assert env.__dict__["_output_spec"].is_locked
+        assert env.__dict__["_input_spec"].is_locked
+        with pytest.raises(RuntimeError, match="Cannot modify a locked Composite"):
+            env.observation_spec["extra"] = Unbounded(shape=(3,))
+
+    def test_spec_lock_caches_derived_values(self) -> None:
+        env = TransformedEnv(ContinuousActionVecMockEnv(), StepCounter())
+        env.rollout(3)
+        assert env._step_mdp is env._step_mdp
+        assert env.reward_keys is env.reward_keys
+
+    def test_spec_lock_survives_append_transform(self) -> None:
+        env = TransformedEnv(ContinuousActionVecMockEnv(), StepCounter())
+        env.rollout(3)
+        step_mdp = env._step_mdp
+
+        env.append_transform(StepCounter(step_count_key="other_count"))
+
+        assert env._step_mdp is not step_mdp
+        assert "other_count" in env.observation_spec.keys()
+        assert env.is_spec_locked
+
+    def test_spec_lock_opt_out(self) -> None:
+        env = TransformedEnv(ContinuousActionVecMockEnv(), StepCounter())
+        env.set_spec_lock_(False)
+        assert not env.is_spec_locked
+        assert not env.observation_spec.is_locked
+        assert env._step_mdp is not env._step_mdp
+
+    def test_spec_lock_with_lazy_transform(self) -> None:
+        env = TransformedEnv(
+            ContinuousActionVecMockEnv(), ObservationNorm(in_keys=["observation"])
+        )
+        assert env.is_spec_locked
+
+        env.transform.init_stats(num_iter=11, reduce_dim=0, cat_dim=0)
+
+        assert not torch.equal(
+            env.observation_spec["observation"].space.low,
+            env.base_env.observation_spec["observation"].space.low,
+        )
+        assert env.__dict__["_output_spec"].is_locked
+        env.rollout(3)
+
+    def test_spec_lock_applies_to_rebuilt_parent(self) -> None:
+        env = TransformedEnv(
+            ContinuousActionVecMockEnv(), Compose(StepCounter(), RewardScaling(0, 1))
+        )
+        _ = env.output_spec
+        assert env.transform[-1].parent.is_spec_locked
+
     def test_no_modif_specs(self) -> None:
         base_env = self.DummyCompositeEnv()
         specs = base_env.specs.clone()

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -93,7 +93,7 @@ def _cache_value(func):
 
     @wraps(func)
     def wrapper(self, *args, **kwargs):
-        if not self.is_spec_locked:
+        if not self.is_spec_locked or not self.__dict__.get("cache_specs", True):
             return func(self, *args, **kwargs)
         result = self.__dict__.setdefault("_cache", {}).get(func_name, NO_DEFAULT)
         if result is NO_DEFAULT:

--- a/torchrl/envs/transforms/_base.py
+++ b/torchrl/envs/transforms/_base.py
@@ -933,7 +933,11 @@ class _TEnvPostInit(_EnvPostInit):
         compile_kwargs = _pop_compile_kwargs(kwargs)
         instance: EnvBase = super(_EnvPostInit, self).__call__(*args, **kwargs)
         # we skip the materialization of the specs, because this can't be done with lazy
-        # transforms such as ObservationNorm.
+        # transforms such as ObservationNorm. The lock is only intent at this point:
+        # set_spec_lock_ records the flag, and _make_output_spec / _make_input_spec
+        # apply the real lock once the specs exist.
+        # TODO: honour a `spec_locked` kwarg, as _EnvPostInit does.
+        instance.set_spec_lock_(True)
         return _maybe_compile_env(instance, compile_kwargs)
 
 

--- a/torchrl/envs/transforms/_base.py
+++ b/torchrl/envs/transforms/_base.py
@@ -930,14 +930,14 @@ class Transform(nn.Module):
 
 class _TEnvPostInit(_EnvPostInit):
     def __call__(self, *args, **kwargs):
+        spec_locked = kwargs.pop("spec_locked", True)
         compile_kwargs = _pop_compile_kwargs(kwargs)
         instance: EnvBase = super(_EnvPostInit, self).__call__(*args, **kwargs)
         # we skip the materialization of the specs, because this can't be done with lazy
         # transforms such as ObservationNorm. The lock is only intent at this point:
         # set_spec_lock_ records the flag, and _make_output_spec / _make_input_spec
         # apply the real lock once the specs exist.
-        # TODO: honour a `spec_locked` kwarg, as _EnvPostInit does.
-        instance.set_spec_lock_(True)
+        instance.set_spec_lock_(spec_locked)
         return _maybe_compile_env(instance, compile_kwargs)
 
 
@@ -1255,6 +1255,8 @@ but got an object of type {type(transform)}."""
             if output_spec is not None:
                 return output_spec
         output_spec = self._make_output_spec()
+        if self.is_spec_locked:
+            output_spec.lock_(recurse=True)
         return output_spec
 
     @_maybe_unlock
@@ -1276,6 +1278,8 @@ but got an object of type {type(transform)}."""
             if input_spec is not None:
                 return input_spec
         input_spec = self._make_input_spec()
+        if self.is_spec_locked:
+            input_spec.lock_(recurse=True)
         return input_spec
 
     @_maybe_unlock

--- a/torchrl/envs/transforms/_clip.py
+++ b/torchrl/envs/transforms/_clip.py
@@ -139,8 +139,8 @@ class ClipTransform(Transform):
     def transform_reward_spec(self, reward_spec: TensorSpec) -> TensorSpec:
         for key in self.in_keys:
             if key in self.parent.reward_keys:
-                spec = self.parent.output_spec["full_reward_spec"][key]
-                self.parent.output_spec["full_reward_spec"][key] = Bounded(
+                spec = reward_spec[key]
+                reward_spec[key] = Bounded(
                     shape=spec.shape,
                     device=spec.device,
                     dtype=spec.dtype,
@@ -151,7 +151,7 @@ class ClipTransform(Transform):
                     if self.low is not None
                     else self.low_min,
                 )
-        return self.parent.output_spec["full_reward_spec"]
+        return reward_spec
 
     def _reset(
         self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase

--- a/torchrl/envs/transforms/_env.py
+++ b/torchrl/envs/transforms/_env.py
@@ -1071,7 +1071,7 @@ class StepCounter(Transform):
 
     def transform_output_spec(self, output_spec: Composite) -> Composite:
         if self.max_steps:
-            full_done_spec = self.parent.output_spec["full_done_spec"]
+            full_done_spec = output_spec["full_done_spec"]
             for truncated_key in self.truncated_keys:
                 truncated_key = unravel_key(truncated_key)
                 # find a matching done key (there might be more than one)
@@ -1117,7 +1117,6 @@ class StepCounter(Transform):
                     full_done_spec[done_key] = Categorical(
                         2, dtype=torch.bool, device=output_spec.device, shape=shape
                     )
-            output_spec["full_done_spec"] = full_done_spec
         return super().transform_output_spec(output_spec)
 
     def transform_input_spec(self, input_spec: Composite) -> Composite:
@@ -1479,14 +1478,13 @@ class RandomTruncationTransform(Transform):
         return self._reset(tensordict, tensordict_reset)
 
     def transform_output_spec(self, output_spec: Composite) -> Composite:
-        full_done_spec = self.parent.output_spec["full_done_spec"]
+        full_done_spec = output_spec["full_done_spec"]
         # Ensure truncated and done keys exist in the spec
         if "truncated" not in full_done_spec.keys():
             done_shape = full_done_spec["done"].shape
             full_done_spec["truncated"] = Categorical(
                 2, dtype=torch.bool, device=output_spec.device, shape=done_shape
             )
-        output_spec["full_done_spec"] = full_done_spec
         return super().transform_output_spec(output_spec)
 
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:

--- a/torchrl/envs/transforms/_reward.py
+++ b/torchrl/envs/transforms/_reward.py
@@ -860,15 +860,15 @@ class SignTransform(Transform):
     def transform_reward_spec(self, reward_spec: TensorSpec) -> TensorSpec:
         for key in self.in_keys:
             if key in self.parent.reward_keys:
-                spec = self.parent.output_spec["full_reward_spec"][key]
-                self.parent.output_spec["full_reward_spec"][key] = Bounded(
+                spec = reward_spec[key]
+                reward_spec[key] = Bounded(
                     shape=spec.shape,
                     device=spec.device,
                     dtype=spec.dtype,
                     high=1.0,
                     low=-1.0,
                 )
-        return self.parent.output_spec["full_reward_spec"]
+        return reward_spec
 
     def _reset(
         self, tensordict: TensorDictBase, tensordict_reset: TensorDictBase


### PR DESCRIPTION
## Summary

- Prevent transform spec hooks from mutating specs owned by their parent environment.
- Lock `TransformedEnv` specs by default while keeping spec materialization lazy.
- Cache derived spec values such as reward keys and `_step_mdp` when specs are stable.
- Preserve explicit opt-outs through `spec_locked=False` and dynamic-spec behavior through `cache_specs=False`.

## Why this is needed

Environment specs are executable contracts, not just metadata. TorchRL uses them to discover observation, reward, and done keys; allocate rollout tensordicts; validate environment outputs; and configure operations such as `step_mdp`. If a transform changes the wrong spec, the visible failure can occur much later than the mutation and look unrelated to the transform.

A transform spec hook receives a cloned input spec and must describe only the effect of that transform. Several hooks instead read from and wrote to `self.parent.output_spec`. Because `TransformedEnv` specs were unlocked by default, these invalid writes did not fail at the mutation site: they silently changed the contract of the upstream environment.

This could produce user-visible correctness bugs in composed environments:

- `StepCounter` and truncation transforms could add or rewrite done and truncated entries on the parent spec. The parent could then advertise keys that it does not actually emit, leading to rollout allocation or environment-spec validation mismatches.
- Clipping and reward-sign transforms could replace reward bounds on the parent spec. Code inspecting the upstream environment could then see post-transform bounds even though the parent still emits untransformed rewards.
- Reusing a corrupted parent spec in another spec computation could make results depend on which transformed spec was accessed first.
- Leaving transformed specs unlocked disabled the existing derived-value cache, so helpers such as reward-key discovery and `_step_mdp` were rebuilt repeatedly on hot paths.

Locking specs makes accidental mutation fail immediately and enables safe caching. Updating the affected hooks to mutate only their provided clone removes the underlying parent-corruption bug.

## Implementation

- Record the requested lock state at construction and apply it when input and output specs materialize.
- Update the affected clipping, reward-sign, step-counter, and truncation hooks to modify and return their input specs.
- Keep transient specs locked when `cache_specs=False`, while bypassing derived-value caching so transforms with changing specs continue to recompute keys correctly.
- Invalidate spec and derived-value caches when transforms are appended.
- Honor both constructor-level and post-construction spec-lock opt-outs.

## User-facing behavior

The default behavior now matches other environments: materialized specs are locked. Users with intentionally dynamic transform specs can continue to use `cache_specs=False`, and users who need mutable specs can opt out with `spec_locked=False` or `set_spec_lock_(False)`.

## Testing

Added regression coverage for:

- deferred locking with lazy spec materialization;
- caching of derived spec values;
- cache invalidation after appending a transform;
- constructor-level and post-construction lock opt-outs;
- lazy `ObservationNorm` initialization;
- rebuilt transform parents;
- dynamic transform specs with `cache_specs=False`;
- parent spec immutability.

Local validation of the affected suites:

- `test/transforms/test_compose_and_env.py`
- `test/envs/test_env_base.py`
- 235 passed, 20 skipped.