### PR TITLE
[BugFix] multiprocessing start method ValueError on Windows in tutorials

### DIFF
--- a/tutorials/sphinx-tutorials/coding_ddpg.py
+++ b/tutorials/sphinx-tutorials/coding_ddpg.py
@@ -73,7 +73,10 @@ warnings.filterwarnings("ignore")
 from torch import multiprocessing
 
 if multiprocessing.get_start_method(allow_none=True) is None:
-    multiprocessing.set_start_method("fork")
+    try:
+        multiprocessing.set_start_method("fork")
+    except ValueError:
+        pass
 
 # sphinx_gallery_end_ignore
 

--- a/tutorials/sphinx-tutorials/coding_dqn.py
+++ b/tutorials/sphinx-tutorials/coding_dqn.py
@@ -97,7 +97,10 @@ warnings.filterwarnings("ignore")
 from torch import multiprocessing
 
 if multiprocessing.get_start_method(allow_none=True) is None:
-    multiprocessing.set_start_method("fork")
+    try:
+        multiprocessing.set_start_method("fork")
+    except ValueError:
+        pass
 mp_context = multiprocessing.get_start_method()
 
 # sphinx_gallery_end_ignore

--- a/tutorials/sphinx-tutorials/coding_ppo.py
+++ b/tutorials/sphinx-tutorials/coding_ppo.py
@@ -115,7 +115,10 @@ warnings.filterwarnings("ignore")
 # This allows the tutorial to run as a script without if __name__ == "__main__"
 
 if _multiprocessing.get_start_method(allow_none=True) is None:
-    _multiprocessing.set_start_method("fork")
+    try:
+        _multiprocessing.set_start_method("fork")
+    except ValueError:
+        pass
 
 # sphinx_gallery_end_ignore
 

--- a/tutorials/sphinx-tutorials/dqn_with_rnn.py
+++ b/tutorials/sphinx-tutorials/dqn_with_rnn.py
@@ -79,7 +79,10 @@ warnings.filterwarnings("ignore")
 from torch import multiprocessing
 
 if multiprocessing.get_start_method(allow_none=True) is None:
-    multiprocessing.set_start_method("fork")
+    try:
+        multiprocessing.set_start_method("fork")
+    except ValueError:
+        pass
 
 # sphinx_gallery_end_ignore
 

--- a/tutorials/sphinx-tutorials/multi_task.py
+++ b/tutorials/sphinx-tutorials/multi_task.py
@@ -18,7 +18,10 @@ warnings.filterwarnings("ignore")
 from torch import multiprocessing
 
 if multiprocessing.get_start_method(allow_none=True) is None:
-    multiprocessing.set_start_method("fork")
+    try:
+        multiprocessing.set_start_method("fork")
+    except ValueError:
+        pass
 mp_context = multiprocessing.get_start_method()
 
 # sphinx_gallery_end_ignore

--- a/tutorials/sphinx-tutorials/pendulum.py
+++ b/tutorials/sphinx-tutorials/pendulum.py
@@ -86,7 +86,10 @@ warnings.filterwarnings("ignore")
 from torch import multiprocessing
 
 if multiprocessing.get_start_method(allow_none=True) is None:
-    multiprocessing.set_start_method("fork")
+    try:
+        multiprocessing.set_start_method("fork")
+    except ValueError:
+        pass
 # sphinx_gallery_end_ignore
 
 from collections import defaultdict

--- a/tutorials/sphinx-tutorials/pretrained_models.py
+++ b/tutorials/sphinx-tutorials/pretrained_models.py
@@ -24,7 +24,10 @@ warnings.filterwarnings("ignore")
 from torch import multiprocessing
 
 if multiprocessing.get_start_method(allow_none=True) is None:
-    multiprocessing.set_start_method("fork")
+    try:
+        multiprocessing.set_start_method("fork")
+    except ValueError:
+        pass
 
 # sphinx_gallery_end_ignore
 

--- a/tutorials/sphinx-tutorials/recurrent_sequence_training.py
+++ b/tutorials/sphinx-tutorials/recurrent_sequence_training.py
@@ -92,7 +92,10 @@ warnings.filterwarnings("ignore")
 from torch import multiprocessing
 
 if multiprocessing.get_start_method(allow_none=True) is None:
-    multiprocessing.set_start_method("fork")
+    try:
+        multiprocessing.set_start_method("fork")
+    except ValueError:
+        pass
 # sphinx_gallery_end_ignore
 
 import torch

--- a/tutorials/sphinx-tutorials/torchrl_demo.py
+++ b/tutorials/sphinx-tutorials/torchrl_demo.py
@@ -30,7 +30,10 @@ warnings.filterwarnings("ignore")
 from torch import multiprocessing
 
 if multiprocessing.get_start_method(allow_none=True) is None:
-    multiprocessing.set_start_method("fork")
+    try:
+        multiprocessing.set_start_method("fork")
+    except ValueError:
+        pass
 # sphinx_gallery_end_ignore
 
 ###############################################################################

--- a/tutorials/sphinx-tutorials/torchrl_envs.py
+++ b/tutorials/sphinx-tutorials/torchrl_envs.py
@@ -47,7 +47,10 @@ warnings.filterwarnings("ignore")
 from torch import multiprocessing
 
 if multiprocessing.get_start_method(allow_none=True) is None:
-    multiprocessing.set_start_method("fork")
+    try:
+        multiprocessing.set_start_method("fork")
+    except ValueError:
+        pass
 mp_context = multiprocessing.get_start_method()
 
 # sphinx_gallery_end_ignore


### PR DESCRIPTION
## Description

This PR fixes a bug where running any of the Sphinx-Gallery tutorials on Windows causes an immediate `ValueError: cannot find context for 'fork'`.

The issue was caused by explicitly hardcoding `multiprocessing.set_start_method("fork")` at the module level across 10 different tutorial files, which is unsupported on Windows (which defaults to `"spawn"`). 

This PR wraps these calls in a `try...except ValueError` block. This ensures that the `"fork"` method is still used on UNIX systems where it's needed to bypass the `__main__` guard for Sphinx-Gallery, while safely gracefully failing back to the OS default on Windows so the tutorials can actually run.

## Motivation and Context

This change is required because the TorchRL tutorial gallery was entirely broken on Windows for users trying to run the scripts locally. 

Fixes #<INSERT_ISSUE_NUMBER>

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
