### PR TITLE
[BugFix] Apply DreamerV3 return normalization in the reparameterization branch

### DIFF
--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -1412,6 +1412,61 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             torch.tensor(10.0, device=device),
         )
 
+    def test_dreamer_v3_reparam_return_normalization(self, device):
+        """The reparameterization branch must divide the objective by the
+        EMA return-percentile span, like the REINFORCE branch."""
+        actor_model = self._create_actor_model().to(device)
+        value_model = self._create_value_model().to(device)
+        loss_module = DreamerV3ActorLoss(
+            actor_model,
+            value_model,
+            self._create_mb_env().to(device),
+            imagination_horizon=3,
+            discount_loss=False,
+            entropy_bonus=0.0,
+            use_reinforce=False,
+        ).to(device)
+        loss_module.make_value_estimator(ValueEstimators.TDLambda)
+        loss_module.return_low.fill_(-2.0)
+        loss_module.return_high.fill_(8.0)
+        loss_module.eval()
+
+        loss_td, fake_data = loss_module(
+            self._create_actor_data().to(device).reshape(-1)
+        )
+        expected = -(fake_data["lambda_target"] / 10.0).mean()
+        torch.testing.assert_close(loss_td["loss_actor"], expected)
+        torch.testing.assert_close(
+            loss_td["return_scale"], torch.tensor(10.0, device=device)
+        )
+
+    def test_dreamer_v3_reparam_return_statistics_update(self, device):
+        """Training-mode forward in the reparameterization branch must update
+        the EMA return statistics."""
+        loss_module = DreamerV3ActorLoss(
+            self._create_actor_model().to(device),
+            self._create_value_model().to(device),
+            self._create_mb_env().to(device),
+            imagination_horizon=3,
+            entropy_bonus=0.0,
+            use_reinforce=False,
+            return_normalization_rate=0.01,
+        ).to(device)
+        loss_module.make_value_estimator(ValueEstimators.TDLambda)
+        loss_td, fake_data = loss_module(
+            self._create_actor_data().to(device).reshape(-1)
+        )
+        expected_low, expected_high = torch.quantile(
+            fake_data["lambda_target"].detach(),
+            torch.tensor([0.05, 0.95], device=device),
+        )
+        torch.testing.assert_close(loss_module.return_low, 0.01 * expected_low)
+        torch.testing.assert_close(loss_module.return_high, 0.01 * expected_high)
+        torch.testing.assert_close(
+            loss_td["return_scale"],
+            (loss_module.return_high - loss_module.return_low).clamp_min(1.0),
+        )
+
     def test_dreamer_v3_return_statistics_checkpoint(self, device):
         loss_module = DreamerV3ActorLoss(
             self._create_actor_model_with_log_prob().to(device),

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -514,6 +514,12 @@ class DreamerV3ActorLoss(LossModule):
     When the actor is a reparameterizable (continuous) policy the
     reparameterization gradient is used directly instead of REINFORCE.
 
+    With ``return_normalization=True`` (the default), both gradient
+    estimators divide the objective by an exponential moving average of the
+    5th-95th return-percentile span, ``max(min_scale, high - low)``,
+    following DreamerV3. This keeps the fixed entropy bonus ``eta``
+    comparable across reward scales.
+
     Reference: https://arxiv.org/abs/2301.04104
 
     Args:
@@ -533,14 +539,16 @@ class DreamerV3ActorLoss(LossModule):
             * stop-gradient advantage). If ``False``, uses the straight
             reparameterization gradient (suitable for continuous Gaussian
             actors). Default: ``False``.
-        return_normalization (bool, optional): Normalize detached REINFORCE
-            advantages by an EMA return-percentile span. Default: ``True``.
+        return_normalization (bool, optional): Normalize the actor objective
+            by an EMA return-percentile span: REINFORCE advantages and the
+            reparameterization lambda-returns are divided by the clamped span
+            between the low and high return quantiles. Default: ``True``.
         return_normalization_rate (float, optional): EMA update rate for the
             return statistics. Default: ``0.01``.
         return_normalization_quantiles (tuple of float, optional): Lower and
             upper return quantiles. Default: ``(0.05, 0.95)``.
-        return_normalization_min_scale (float, optional): Minimum divisor for
-            REINFORCE advantages. Default: ``1.0``.
+        return_normalization_min_scale (float, optional): Minimum value of the
+            return-span divisor. Default: ``1.0``.
 
     Examples:
         >>> import torch
@@ -790,10 +798,8 @@ class DreamerV3ActorLoss(LossModule):
             actor_loss = -(discount * log_prob * advantage).mean()
         else:
             # Reparameterization gradient
-            return_scale = torch.ones(
-                (), dtype=lambda_target.dtype, device=lambda_target.device
-            )
-            actor_loss = -(discount * lambda_target).mean()
+            return_scale = self._return_scale(lambda_target)
+            actor_loss = -(discount * lambda_target / return_scale).mean()
 
         if self.entropy_bonus > 0:
             if HAS_ENTROPY.get(type(policy_distribution), False):


### PR DESCRIPTION
## Description

`DreamerV3ActorLoss(return_normalization=True)` (the default) was silently inert in the default gradient mode: the reparameterization branch (`use_reinforce=False`, also the default) hardcoded `return_scale` to 1 and never called `_return_scale`, so the EMA percentile buffers (`return_low`/`return_high`) never updated and the actor objective ran unscaled against the fixed `entropy_bonus=3e-4`.

Since the percentile return normalization is precisely what makes a fixed entropy coefficient reward-scale invariant in DreamerV3 (https://arxiv.org/abs/2301.04104), the default configuration had a scale-dependent entropy/return balance, and the `return_normalization` knob advertised by the constructor did nothing.

The `sota-implementations/dreamer_v3` script is unaffected (it sets `use_reinforce: true`).

## Changes

- Divide the reparameterization objective by `_return_scale(lambda_target)`, matching the REINFORCE branch. The scale is computed from detached buffers, so gradient flow through `lambda_target` is unchanged.
- The `return_scale`, `return_low`, and `return_high` diagnostics reported by `forward` are now meaningful in reparameterization mode instead of constant 1/0/0.
- Docstring updates: `return_normalization` and `return_normalization_min_scale` no longer claim to be REINFORCE-only.

## Tests

- `test_dreamer_v3_reparam_return_normalization`: with preset EMA statistics in eval mode, the reparameterization loss equals `-(lambda_target / span).mean()` and `return_scale` reports the clamped span.
- `test_dreamer_v3_reparam_return_statistics_update`: a training-mode forward in reparameterization mode updates the EMA buffers with the lerped batch quantiles.
- Full `test/objectives/test_dreamer_v3.py`: 61 passed.

## Stack

This is the first PR of a three-PR stack (merge in order):

1. this PR (base: `main`)
2. `percentile-value-norm` - reusable `PercentileValueNorm`, DreamerV3 refactored onto it
3. `ppo-advantage-norm` - opt-in percentile advantage scaling for PPO/A2C

Generated with [Claude Code](https://claude.com/claude-code)