### PR TITLE
[Feature] Add PercentileValueNorm and refactor DreamerV3 retnorm onto it

### DIFF
--- a/docs/source/reference/modules_critics.rst
+++ b/docs/source/reference/modules_critics.rst
@@ -13,6 +13,7 @@ Value networks estimate the value of states or state-action pairs.
     ValueNorm
     PopArtValueNorm
     RunningValueNorm
+    PercentileValueNorm
     DuelingCnnDQNet
     DistributionalDQNnet
     ConvNet

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -1600,6 +1600,32 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         torch.testing.assert_close(loss_module.return_low, expected_statistics[0])
         torch.testing.assert_close(loss_module.return_high, expected_statistics[1])
 
+    def test_dreamer_v3_legacy_retnorm_checkpoint_migrates(self, device):
+        """Checkpoints written before the retnorm refactor stored 0-dim
+        ``return_low`` / ``return_high`` buffers; loading them must fill the
+        ``retnorm`` statistics without strict-mode key errors."""
+        loss_module = DreamerV3ActorLoss(
+            self._create_actor_model_with_log_prob().to(device),
+            self._create_value_model().to(device),
+            self._create_mb_env().to(device),
+            imagination_horizon=3,
+            use_reinforce=True,
+        ).to(device)
+        legacy_checkpoint = {
+            key: value.detach().clone()
+            for key, value in loss_module.state_dict().items()
+            if key not in ("retnorm.low", "retnorm.high")
+        }
+        legacy_checkpoint["return_low"] = torch.tensor(-2.5, device=device)
+        legacy_checkpoint["return_high"] = torch.tensor(7.5, device=device)
+        loss_module.load_state_dict(legacy_checkpoint)
+        torch.testing.assert_close(
+            loss_module.retnorm.low, torch.tensor([-2.5], device=device)
+        )
+        torch.testing.assert_close(
+            loss_module.retnorm.high, torch.tensor([7.5], device=device)
+        )
+
     def test_dreamer_v3_value_loss_sync_gamma(self, device):
         """sync_gamma_with_actor_loss must pull gamma from the actor's value estimator."""
         mb_env = self._create_mb_env().to(device)

--- a/test/objectives/test_mappo.py
+++ b/test/objectives/test_mappo.py
@@ -18,6 +18,7 @@ from tensordict.nn import TensorDictModule
 
 from torchrl.modules import (
     MultiAgentMLP,
+    PercentileValueNorm,
     PopArtValueNorm,
     ProbabilisticActor,
     RunningValueNorm,
@@ -169,6 +170,22 @@ class TestValueNormBase:
         with pytest.raises(TypeError):
             ValueNorm(shape=1)  # type: ignore[abstract]
 
+    @pytest.mark.parametrize(
+        "cls", [PopArtValueNorm, RunningValueNorm, PercentileValueNorm]
+    )
+    def test_scale_is_normalize_slope(self, cls):
+        """scale() must be the multiplicative factor applied by normalize():
+        normalize(a) - normalize(b) == (a - b) / scale()."""
+        torch.manual_seed(0)
+        vn = cls(shape=1)
+        for _ in range(5):
+            vn.update(torch.randn(256, 1) * 3.0 + 1.0)
+        a = torch.randn(16, 1)
+        b = torch.randn(16, 1)
+        torch.testing.assert_close(
+            (vn.normalize(a) - vn.normalize(b)) * vn.scale(), a - b
+        )
+
 
 class TestPopArtValueNorm:
     def test_running_stats_converge(self):
@@ -230,6 +247,74 @@ class TestRunningValueNorm:
         vn.update(b)
         # Combined mean of 1000 ones + 1000 fives = 3.0 exactly.
         assert abs(vn.mean.item() - 3.0) < 1e-4
+
+
+class TestPercentileValueNorm:
+    def test_ema_tracks_batch_quantiles(self):
+        vn = PercentileValueNorm(shape=1, rate=0.5)
+        # linspace(0, 100, 101) has exact 5th / 95th percentiles at 5 and 95.
+        x = torch.linspace(0.0, 100.0, steps=101).unsqueeze(-1)
+        vn.update(x)
+        torch.testing.assert_close(vn.low, torch.tensor([2.5]))
+        torch.testing.assert_close(vn.high, torch.tensor([47.5]))
+        vn.update(x)
+        torch.testing.assert_close(vn.low, torch.tensor([3.75]))
+        torch.testing.assert_close(vn.high, torch.tensor([71.25]))
+
+    def test_min_scale_clamps_degenerate_span(self):
+        """Constant targets give a zero span; normalize must not blow up."""
+        vn = PercentileValueNorm(shape=1, rate=1.0)
+        vn.update(torch.full((100, 1), 0.5))
+        torch.testing.assert_close(vn.scale(), torch.tensor([1.0]))
+        torch.testing.assert_close(
+            vn.normalize(torch.tensor([0.25])), torch.tensor([0.25])
+        )
+
+    def test_scale_only_by_default(self):
+        """center=False (default) must rescale without shifting."""
+        vn = PercentileValueNorm(shape=1, rate=1.0)
+        vn.update(torch.linspace(0.0, 200.0, steps=201).unsqueeze(-1))
+        # low=10, high=190 -> span 180
+        torch.testing.assert_close(
+            vn.normalize(torch.tensor([90.0])), torch.tensor([0.5])
+        )
+        torch.testing.assert_close(
+            vn.normalize(torch.tensor([0.0])), torch.tensor([0.0])
+        )
+        y = torch.randn(32, 1)
+        torch.testing.assert_close(vn.denormalize(vn.normalize(y)), y)
+
+    def test_center_maps_percentile_range_to_unit_interval(self):
+        vn = PercentileValueNorm(shape=1, rate=1.0, center=True)
+        vn.update(torch.linspace(0.0, 200.0, steps=201).unsqueeze(-1))
+        torch.testing.assert_close(
+            vn.normalize(torch.tensor([10.0])), torch.tensor([0.0])
+        )
+        torch.testing.assert_close(
+            vn.normalize(torch.tensor([190.0])), torch.tensor([1.0])
+        )
+        y = torch.randn(32, 1)
+        torch.testing.assert_close(vn.denormalize(vn.normalize(y)), y)
+
+    def test_per_element_shape(self):
+        """Quantiles are tracked per trailing element (e.g. per agent)."""
+        vn = PercentileValueNorm(shape=(2, 1), rate=1.0)
+        a = torch.linspace(0.0, 100.0, steps=101)
+        b = torch.linspace(0.0, 200.0, steps=101)
+        x = torch.stack([a, b], dim=-1).unsqueeze(-1)  # (101, 2, 1)
+        vn.update(x)
+        torch.testing.assert_close(vn.scale(), torch.tensor([[90.0], [180.0]]))
+
+    def test_bad_args_raise(self):
+        with pytest.raises(ValueError, match="quantiles"):
+            PercentileValueNorm(quantiles=(0.9, 0.1))
+        with pytest.raises(ValueError, match="rate"):
+            PercentileValueNorm(rate=1.5)
+        with pytest.raises(ValueError, match="min_scale"):
+            PercentileValueNorm(min_scale=0.0)
+        vn = PercentileValueNorm(shape=1)
+        with pytest.raises(ValueError, match="trailing shape"):
+            vn.update(torch.randn(4, 8))
 
 
 # --------------------------------------------------------------------------

--- a/test/objectives/test_mappo.py
+++ b/test/objectives/test_mappo.py
@@ -170,6 +170,28 @@ class TestValueNormBase:
         with pytest.raises(TypeError):
             ValueNorm(shape=1)  # type: ignore[abstract]
 
+    def test_legacy_subclass_without_scale_still_instantiates(self):
+        """Subclasses written before scale() existed must keep working (with a
+        deprecation warning) until scale() becomes abstract in v0.16."""
+
+        class LegacyNorm(ValueNorm):
+            def update(self, value_target):
+                pass
+
+            def normalize(self, value_target):
+                return value_target
+
+            def denormalize(self, normalised_value):
+                return normalised_value
+
+        with pytest.warns(DeprecationWarning, match="abstract in v0.16"):
+            vn = LegacyNorm(shape=1)
+        x = torch.randn(4, 1)
+        vn.update(x)
+        torch.testing.assert_close(vn.denormalize(vn.normalize(x)), x)
+        with pytest.raises(NotImplementedError, match="scale"):
+            vn.scale()
+
     @pytest.mark.parametrize(
         "cls", [PopArtValueNorm, RunningValueNorm, PercentileValueNorm]
     )

--- a/torchrl/modules/__init__.py
+++ b/torchrl/modules/__init__.py
@@ -114,7 +114,12 @@ from .tensordict_module.exploration import (
     set_exploration_modules_spec_from_env,
 )
 from .utils import get_env_transforms_from_module, get_primers_from_module
-from .value_norm import PopArtValueNorm, RunningValueNorm, ValueNorm
+from .value_norm import (
+    PercentileValueNorm,
+    PopArtValueNorm,
+    RunningValueNorm,
+    ValueNorm,
+)
 from .value_transforms import (
     ComposeValueTransform,
     IdentityValueTransform,
@@ -207,6 +212,7 @@ __all__ = [
     "Ordinal",
     "OrnsteinUhlenbeckProcessModule",
     "OrnsteinUhlenbeckProcessWrapper",
+    "PercentileValueNorm",
     "PopArtValueNorm",
     "ProbabilisticActor",
     "PUCTScore",

--- a/torchrl/modules/value_norm.py
+++ b/torchrl/modules/value_norm.py
@@ -14,6 +14,11 @@ implementations:
 - :class:`RunningValueNorm` — exact Welford running mean / variance with no
   decay. Cheaper and more stable when value targets are stationary; tends to
   be the better default for shorter / non-curriculum runs.
+- :class:`PercentileValueNorm` — exponential-moving-average of a low / high
+  quantile pair, rescaling by the clamped span between them (the DreamerV3
+  "return normalisation", Hafner et al. 2023,
+  https://arxiv.org/abs/2301.04104). Scale-only by default, which suits
+  advantage scaling.
 
 Plug any subclass into :class:`~torchrl.objectives.multiagent.MAPPOLoss` (or
 your own actor-critic loss) via ``value_norm=...``.
@@ -73,6 +78,15 @@ class ValueNorm(nn.Module, metaclass=ABCMeta):
     @abstractmethod
     def denormalize(self, normalised_value: torch.Tensor) -> torch.Tensor:
         """Inverse of :meth:`normalize` — recover real-scale values."""
+
+    @abstractmethod
+    def scale(self) -> torch.Tensor:
+        """Multiplicative scale currently applied by :meth:`normalize`.
+
+        Exposed separately so consumers can rescale quantities that must not
+        be re-centred, e.g. advantages (already centred by the value
+        baseline), for which only the division by the scale applies.
+        """
 
     # ------------------------------------------------------- shared helpers
 
@@ -161,6 +175,10 @@ class PopArtValueNorm(ValueNorm):
         mean, var = self._running_stats()
         return normalised_value * var.sqrt() + mean
 
+    def scale(self) -> torch.Tensor:
+        _, var = self._running_stats()
+        return var.sqrt()
+
 
 class RunningValueNorm(ValueNorm):
     """Exact running mean / variance (Welford's online algorithm).
@@ -238,3 +256,104 @@ class RunningValueNorm(ValueNorm):
 
     def denormalize(self, normalised_value: torch.Tensor) -> torch.Tensor:
         return normalised_value * self._var().sqrt() + self.mean
+
+    def scale(self) -> torch.Tensor:
+        return self._var().sqrt()
+
+
+class PercentileValueNorm(ValueNorm):
+    """DreamerV3-style EMA percentile-range value normaliser.
+
+    Tracks exponential moving averages of a low and a high quantile of the
+    value targets and rescales by the span between them, clamped from below:
+    ``scale = max(min_scale, high - low)``. Following DreamerV3 (Hafner et
+    al., *Mastering Diverse Domains through World Models*, 2023,
+    https://arxiv.org/abs/2301.04104), the clamp scales large values down
+    without amplifying small or noisy ones, which keeps fixed coefficients
+    such as an entropy bonus comparable across reward scales.
+
+    By default (``center=False``) :meth:`normalize` only divides by the
+    span — the DreamerV3 recipe for advantages, which are already centred by
+    the value baseline. With ``center=True`` the low-percentile EMA is also
+    subtracted, mapping the tracked percentile range onto ``[0, 1]``.
+
+    Keyword Args:
+        shape: per-element shape of the value tensor (everything except the
+            leading batch / time / agent dims that get reduced). Defaults to
+            ``1``.
+        quantiles: lower and upper quantiles tracked by the EMA. Defaults to
+            ``(0.05, 0.95)``.
+        rate: EMA update rate towards the batch quantiles; higher = faster
+            adaptation. Defaults to ``0.01``.
+        min_scale: lower bound of the normalisation scale. Defaults to
+            ``1.0``.
+        center: if ``True``, subtract the low-percentile EMA in
+            :meth:`normalize`. Defaults to ``False``.
+        epsilon: kept for interface parity with the other normalisers;
+            unused because ``min_scale`` already bounds the divisor.
+        device: device for the running-stats buffers.
+
+    Example:
+        >>> vn = PercentileValueNorm(shape=1, rate=1.0)
+        >>> returns = torch.linspace(0.0, 100.0, steps=101).unsqueeze(-1)
+        >>> vn.update(returns)
+        >>> vn.scale()
+        tensor([90.])
+        >>> vn.normalize(torch.tensor([45.0]))
+        tensor([0.5000])
+    """
+
+    def __init__(
+        self,
+        *,
+        shape: int | tuple[int, ...] = 1,
+        quantiles: tuple[float, float] = (0.05, 0.95),
+        rate: float = 0.01,
+        min_scale: float = 1.0,
+        center: bool = False,
+        epsilon: float = 1e-5,
+        device: torch.device | None = None,
+    ) -> None:
+        super().__init__(shape=shape, epsilon=epsilon, device=device)
+        low, high = quantiles
+        if not 0 <= low < high <= 1:
+            raise ValueError(
+                f"quantiles must satisfy 0 <= low < high <= 1, got {quantiles}."
+            )
+        if not 0 <= rate <= 1:
+            raise ValueError(f"rate must be in [0, 1], got {rate}.")
+        if min_scale <= 0:
+            raise ValueError(f"min_scale must be positive, got {min_scale}.")
+        self.quantiles = (float(low), float(high))
+        self.rate = rate
+        self.min_scale = min_scale
+        self.center = center
+        self.register_buffer("low", torch.zeros(self.shape, device=device))
+        self.register_buffer("high", torch.zeros(self.shape, device=device))
+        self.register_buffer(
+            "_q",
+            torch.tensor([float(low), float(high)], device=device),
+            persistent=False,
+        )
+
+    @torch.no_grad()
+    def update(self, value_target: torch.Tensor) -> None:
+        value_target = value_target.detach()
+        self._check_trailing_shape(value_target)
+        flat = value_target.reshape(-1, *self.shape).to(self.low.dtype)
+        batch_low, batch_high = torch.quantile(flat, self._q.to(flat.dtype), dim=0)
+        self.low.lerp_(batch_low, self.rate)
+        self.high.lerp_(batch_high, self.rate)
+
+    def normalize(self, value_target: torch.Tensor) -> torch.Tensor:
+        if self.center:
+            return (value_target - self.low) / self.scale()
+        return value_target / self.scale()
+
+    def denormalize(self, normalised_value: torch.Tensor) -> torch.Tensor:
+        if self.center:
+            return normalised_value * self.scale() + self.low
+        return normalised_value * self.scale()
+
+    def scale(self) -> torch.Tensor:
+        return (self.high - self.low).clamp_min(self.min_scale)

--- a/torchrl/modules/value_norm.py
+++ b/torchrl/modules/value_norm.py
@@ -26,6 +26,7 @@ your own actor-critic loss) via ``value_norm=...``.
 from __future__ import annotations
 
 import math
+import warnings
 from abc import ABCMeta, abstractmethod
 
 import torch
@@ -43,10 +44,10 @@ class ValueNorm(nn.Module, metaclass=ABCMeta):
     - **denormalize** the critic's output back to the real reward scale when
       forming bootstrapped value estimates inside GAE / TD.
 
-    Subclasses must implement :meth:`update`, :meth:`normalize`, and
-    :meth:`denormalize`. The convention is that all three operate on tensors
-    whose trailing dims match :attr:`shape` (the per-element value shape,
-    usually ``(1,)``).
+    Subclasses must implement :meth:`update`, :meth:`normalize`,
+    :meth:`denormalize`, and :meth:`scale`. The convention is that they all
+    operate on tensors whose trailing dims match :attr:`shape` (the
+    per-element value shape, usually ``(1,)``).
     """
 
     shape: tuple[int, ...]
@@ -64,6 +65,14 @@ class ValueNorm(nn.Module, metaclass=ABCMeta):
         self.shape = tuple(shape)
         self.epsilon = epsilon
         self._device = device
+        if type(self).scale is ValueNorm.scale:
+            warnings.warn(
+                f"{type(self).__name__} does not implement scale(). "
+                "ValueNorm.scale() will become abstract in v0.16; implement it "
+                "in your subclass to keep it instantiable.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     # ------------------------------------------------------------------ API
 
@@ -79,14 +88,22 @@ class ValueNorm(nn.Module, metaclass=ABCMeta):
     def denormalize(self, normalised_value: torch.Tensor) -> torch.Tensor:
         """Inverse of :meth:`normalize` — recover real-scale values."""
 
-    @abstractmethod
     def scale(self) -> torch.Tensor:
         """Multiplicative scale currently applied by :meth:`normalize`.
 
         Exposed separately so consumers can rescale quantities that must not
         be re-centred, e.g. advantages (already centred by the value
         baseline), for which only the division by the scale applies.
+
+        Deliberately not abstract until v0.16 so that subclasses written
+        before it existed keep instantiating (with a ``DeprecationWarning``);
+        this default raises ``NotImplementedError`` when called.
         """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement scale(). Implement it "
+            "to use this normaliser where a multiplicative scale is required "
+            "(e.g. advantage scaling)."
+        )
 
     # ------------------------------------------------------- shared helpers
 

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -40,6 +40,7 @@ from torchrl.modules.models.model_based import (  # noqa: F401
     two_hot_decode as _two_hot_decode,
     two_hot_encode as _two_hot_encode,
 )
+from torchrl.modules.value_norm import PercentileValueNorm
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
     _GAMMA_LMBDA_DEPREC_ERROR,
@@ -529,7 +530,10 @@ class DreamerV3ActorLoss(LossModule):
     estimators divide the objective by an exponential moving average of the
     5th-95th return-percentile span, ``max(min_scale, high - low)``,
     following DreamerV3. This keeps the fixed entropy bonus ``eta``
-    comparable across reward scales.
+    comparable across reward scales. The statistics live in a
+    :class:`~torchrl.modules.PercentileValueNorm` submodule
+    (``self.retnorm``); ``return_low`` / ``return_high`` are exposed as
+    read-through views for logging.
 
     Reference: https://arxiv.org/abs/2301.04104
 
@@ -709,21 +713,11 @@ class DreamerV3ActorLoss(LossModule):
         self.entropy_bonus = entropy_bonus
         self.use_reinforce = use_reinforce
         self.return_normalization = return_normalization
-        if not 0 <= return_normalization_rate <= 1:
-            raise ValueError("return_normalization_rate must be in [0, 1].")
-        lower_quantile, upper_quantile = return_normalization_quantiles
-        if not 0 <= lower_quantile < upper_quantile <= 1:
-            raise ValueError(
-                "return_normalization_quantiles must satisfy "
-                "0 <= lower < upper <= 1."
-            )
-        if return_normalization_min_scale <= 0:
-            raise ValueError("return_normalization_min_scale must be positive.")
-        self.return_normalization_rate = return_normalization_rate
-        self.return_normalization_quantiles = return_normalization_quantiles
-        self.return_normalization_min_scale = return_normalization_min_scale
-        self.register_buffer("return_low", torch.tensor(0.0))
-        self.register_buffer("return_high", torch.tensor(0.0))
+        self.retnorm = PercentileValueNorm(
+            quantiles=return_normalization_quantiles,
+            rate=return_normalization_rate,
+            min_scale=return_normalization_min_scale,
+        )
         if gamma is not None:
             raise TypeError(_GAMMA_LMBDA_DEPREC_ERROR)
         if lmbda is not None:
@@ -856,20 +850,30 @@ class DreamerV3ActorLoss(LossModule):
         if not self.return_normalization:
             return torch.ones((), dtype=returns.dtype, device=returns.device)
         if self.training:
-            quantiles = torch.tensor(
-                self.return_normalization_quantiles,
-                dtype=self.return_low.dtype,
-                device=self.return_low.device,
-            )
-            current_low, current_high = torch.quantile(
-                returns.detach().to(self.return_low), quantiles
-            )
-            with torch.no_grad():
-                self.return_low.lerp_(current_low, self.return_normalization_rate)
-                self.return_high.lerp_(current_high, self.return_normalization_rate)
-        return (self.return_high - self.return_low).clamp_min(
-            self.return_normalization_min_scale
-        )
+            self.retnorm.update(returns)
+        return self.retnorm.scale().squeeze(-1)
+
+    @property
+    def return_normalization_rate(self) -> float:
+        return self.retnorm.rate
+
+    @property
+    def return_normalization_quantiles(self) -> tuple[float, float]:
+        return self.retnorm.quantiles
+
+    @property
+    def return_normalization_min_scale(self) -> float:
+        return self.retnorm.min_scale
+
+    @property
+    def return_low(self) -> torch.Tensor:
+        """EMA of the low return quantile (0-dim view of ``retnorm.low``)."""
+        return self.retnorm.low.squeeze(-1)
+
+    @property
+    def return_high(self) -> torch.Tensor:
+        """EMA of the high return quantile (0-dim view of ``retnorm.high``)."""
+        return self.retnorm.high.squeeze(-1)
 
     def lambda_target(
         self,

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -718,10 +718,25 @@ class DreamerV3ActorLoss(LossModule):
             rate=return_normalization_rate,
             min_scale=return_normalization_min_scale,
         )
+        self.register_load_state_dict_pre_hook(self._migrate_legacy_retnorm_state)
         if gamma is not None:
             raise TypeError(_GAMMA_LMBDA_DEPREC_ERROR)
         if lmbda is not None:
             raise TypeError(_GAMMA_LMBDA_DEPREC_ERROR)
+
+    def _migrate_legacy_retnorm_state(self, module, state_dict, prefix, *args) -> None:
+        # Checkpoints written before the retnorm refactor stored the return
+        # quantiles as flat 0-dim buffers on the loss itself.
+        for legacy, current in (
+            ("return_low", "retnorm.low"),
+            ("return_high", "retnorm.high"),
+        ):
+            legacy_key = prefix + legacy
+            current_key = prefix + current
+            if legacy_key in state_dict and current_key not in state_dict:
+                state_dict[current_key] = state_dict.pop(legacy_key).reshape(
+                    self.retnorm.low.shape
+                )
 
     def _forward_value_estimator_keys(self, **kwargs) -> None:
         if self._value_estimator is not None:


### PR DESCRIPTION
## Description

Second PR of the return-normalization stack (based on #4125; merge that first, then rebase this onto `main`).

DreamerV3's 5th-95th percentile return scaling was private to `DreamerV3ActorLoss`. This PR promotes it to a reusable primitive in the existing `ValueNorm` family, next to `PopArtValueNorm` and `RunningValueNorm`:

- **`PercentileValueNorm`**: EMA of a low/high quantile pair (`quantiles=(0.05, 0.95)`, `rate=0.01` by default), with the normalisation scale clamped from below (`scale = max(min_scale, high - low)`), following DreamerV3 (https://arxiv.org/abs/2301.04104). By default it is scale-only (`center=False`), which is the DreamerV3 recipe for advantages (already centred by the value baseline); `center=True` additionally subtracts the low-percentile EMA, mapping the tracked range onto `[0, 1]`. Quantiles are tracked per trailing element (`shape`), so per-agent statistics work the same way as in the other normalisers.
- **`ValueNorm.scale()`**: new interface method (implemented by all three normalisers) returning the multiplicative scale applied by `normalize`. Consumers that rescale advantages need the scale without the centering; DreamerV3 uses it here, and the follow-up PPO/A2C PR uses it as well.
- **`DreamerV3ActorLoss` refactor**: the loss now holds a `PercentileValueNorm` submodule (`self.retnorm`) instead of private `return_low`/`return_high` buffers and a hand-rolled quantile EMA. `return_low`, `return_high`, `return_normalization_rate`, `return_normalization_quantiles`, and `return_normalization_min_scale` remain accessible as read-through properties, so the constructor signature, produced losses, diagnostics, and logging are unchanged. Since MAPPO/IPPO already accept any `ValueNorm` via `value_norm=`, they can now use percentile normalisation for the critic with no further changes.

Note on checkpoints: state-dict keys move from `return_low`/`return_high` to `retnorm.low`/`retnorm.high` (shape `(1,)` instead of 0-dim). DreamerV3 has not shipped in a release, so no deprecation cycle applies; flagging it for anyone with in-flight training runs on main.

## Tests

- `TestPercentileValueNorm` in `test/objectives/test_mappo.py` (where the ValueNorm family is tested): EMA tracking of exact batch quantiles, min-scale clamping on degenerate spans, scale-only vs center semantics with denormalize round-trips, per-element (per-agent) shapes, and argument validation.
- `TestValueNormBase.test_scale_is_normalize_slope`: interface contract `normalize(a) - normalize(b) == (a - b) / scale()` for all three normalisers.
- Existing DreamerV3 retnorm tests (including the torch.compile check on `_return_scale` and the state-dict round-trip) pass unchanged: `test/objectives/test_mappo.py` + `test/objectives/test_dreamer_v3.py`: 95 passed.

## Stack

1. #4125 (base: `main`)
2. this PR (base: `dreamerv3-retnorm-reparam`)
3. `ppo-advantage-norm` - opt-in percentile advantage scaling for PPO/A2C

Related: #4100 wires the stateless invertible `ValueTransform` family (symlog et al.) into losses in prediction space; this stack is the complementary stateful normaliser in raw return space. No file overlap.

Generated with [Claude Code](https://claude.com/claude-code)