### PR TITLE
[BugFix] Match DreamerV3 reference semantics

### DIFF
--- a/docs/source/reference/dreamer_v3.rst
+++ b/docs/source/reference/dreamer_v3.rst
@@ -7,6 +7,21 @@ experience, then trains an actor and a critic on trajectories generated inside
 that model. The real environment supplies data for the world model; most policy
 improvement happens in latent-space imagination.
 
+Paper and maintained implementation
+-----------------------------------
+
+This page treats the `DreamerV3 paper <https://arxiv.org/abs/2301.04104>`_ as
+the source of truth for the algorithm. The author-maintained
+`JAX implementation <https://github.com/danijar/dreamerv3>`_ continues to
+evolve and its named experiment presets can differ from the protocol reported
+in the paper. TorchRL documents those presets as separate reproduction targets
+rather than redefining the paper algorithm around the latest JAX configuration.
+
+Some constructor defaults predate full paper parity and remain for backward
+compatibility. The runnable DreamerV3 recipes pass the paper-compatible loss
+settings explicitly; changes to public defaults require the normal deprecation
+cycle.
+
 The high-level data flow is:
 
 .. code-block:: text
@@ -182,7 +197,8 @@ not only on imagined trajectories.
 :meth:`~torchrl.objectives.DreamerV3ValueLoss.replay_value_loss` computes that
 term. Its return at each replay state uses the following replay reward and
 bootstraps from the first imagined lambda return of the next state, so the
-critic sees on-policy data as well as imagined data. The method reads its
+critic is fitted on real replay states as well as imagined states. The method
+reads its
 ``reward``, ``done``, ``terminated`` and ``bootstrap`` entries through
 :attr:`~torchrl.objectives.DreamerV3ValueLoss.tensor_keys`, so
 :meth:`~torchrl.objectives.LossModule.set_keys` can redirect them:

--- a/docs/source/reference/dreamer_v3.rst
+++ b/docs/source/reference/dreamer_v3.rst
@@ -174,6 +174,28 @@ each critic optimizer step:
     # After loss.backward() and optimizer.step():
     slow_critic_updater.step()
 
+Replay critic loss
+~~~~~~~~~~~~~~~~~~
+
+The reference implementation also fits the critic on the real replay sequences,
+not only on imagined trajectories.
+:meth:`~torchrl.objectives.DreamerV3ValueLoss.replay_value_loss` computes that
+term. Its return at each replay state uses the following replay reward and
+bootstraps from the first imagined lambda return of the next state, so the
+critic sees on-policy data as well as imagined data. The method reads its
+``reward``, ``done``, ``terminated`` and ``bootstrap`` entries through
+:attr:`~torchrl.objectives.DreamerV3ValueLoss.tensor_keys`, so
+:meth:`~torchrl.objectives.LossModule.set_keys` can redirect them:
+
+.. code-block:: python
+
+    value_loss.set_keys(bootstrap="first_imagined_return")
+    replay_td = value_loss.replay_value_loss(replay_features)
+    loss = replay_td["loss_replay_value"]
+
+Because the input features stay attached, this term also trains the RSSM
+representation when the world-model loss returns live features.
+
 Optimization and training loop
 ------------------------------
 

--- a/sota-implementations/dreamer_v3/dreamer_v3.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3.py
@@ -57,7 +57,7 @@ from torchrl.envs.transforms import (
 from torchrl.envs.utils import ExplorationType, set_exploration_type
 from torchrl.modules import DreamerV3MLP, SymExpTwoHot, WorldModelWrapper
 from torchrl.modules.distributions.continuous import TanhNormal
-from torchrl.modules.models.model_based_v3 import (
+from torchrl.modules.models.dreamer_v3 import (
     RSSMPosteriorV3,
     RSSMPriorV3,
     RSSMRolloutV3,

--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -10,6 +10,7 @@ import pytest
 import torch
 from packaging import version
 from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
 from torchrl.data.tensor_specs import Bounded
 from torchrl.modules import SafeModule
 from torchrl.modules.models.model_based import (
@@ -21,9 +22,12 @@ from torchrl.modules.models.model_based import (
     RSSMRollout,
 )
 from torchrl.modules.models.model_based_v3 import (
+    _DreamerV3BlockLinear,
+    _DreamerV3RMSNorm,
     DreamerV3MLP,
     RSSMPosteriorV3,
     RSSMPriorV3,
+    RSSMRolloutV3,
 )
 
 from torchrl.testing import get_default_devices
@@ -265,6 +269,17 @@ class TestDreamerComponents:
 
 
 class TestDreamerV3Components:
+    def test_reference_normalization_and_block_fan_in(self):
+        norm = _DreamerV3RMSNorm(8)
+        assert set(dict(norm.named_parameters())) == {"weight"}
+
+        torch.manual_seed(0)
+        one_block = _DreamerV3BlockLinear(1024, 1024, num_blocks=1)
+        torch.manual_seed(1)
+        eight_blocks = _DreamerV3BlockLinear(1024, 1024, num_blocks=8)
+        ratio = eight_blocks.weight.std() / one_block.weight.std()
+        assert ratio.item() == pytest.approx(1.0, rel=0.05)
+
     def test_mlp_output_scale_and_multiple_inputs(self):
         module = DreamerV3MLP(
             6,
@@ -310,13 +325,18 @@ class TestDreamerV3Components:
 
         torch.testing.assert_close(
             logits,
-            torch.tensor([[[-0.2459, -0.0750], [0.0959, 0.2668]]], device=device),
+            torch.tensor(
+                [[[-0.2538432, -0.0850009], [0.0838414, 0.2526837]]],
+                device=device,
+            ),
             atol=5e-5,
             rtol=5e-5,
         )
         torch.testing.assert_close(
             next_belief,
-            torch.tensor([[0.0593, -0.1581, 0.2277, -0.2400]], device=device),
+            torch.tensor(
+                [[0.0575409, -0.1607322, 0.2253285, -0.2480658]], device=device
+            ),
             atol=5e-5,
             rtol=5e-5,
         )
@@ -394,6 +414,75 @@ class TestDreamerV3Components:
         logits, state = posterior(belief, embedding)
         assert logits.shape == (3, 2, 4)
         assert state.shape == (3, 8)
+
+    @pytest.mark.parametrize("device", get_default_devices())
+    @pytest.mark.parametrize("action_key", ["action", ("agent", "action")])
+    def test_rssm_rollout_masks_action_on_reset(self, device, action_key):
+        num_categoricals = num_classes = 2
+        state_dim = num_categoricals * num_classes
+        belief_dim = 4
+        action_dim = 2
+        embedding_dim = 3
+        prior = RSSMPriorV3(
+            action_shape=(action_dim,),
+            hidden_dim=belief_dim,
+            rnn_hidden_dim=belief_dim,
+            num_categoricals=num_categoricals,
+            num_classes=num_classes,
+            action_dim=action_dim,
+            recurrent_model="block_gru",
+            num_blocks=2,
+            device=device,
+        )
+        posterior = RSSMPosteriorV3(
+            hidden_dim=belief_dim,
+            num_categoricals=num_categoricals,
+            num_classes=num_classes,
+            rnn_hidden_dim=belief_dim,
+            obs_embed_dim=embedding_dim,
+            device=device,
+        )
+        rollout = RSSMRolloutV3(
+            TensorDictModule(
+                prior,
+                in_keys=["state", "belief", action_key],
+                out_keys=[
+                    ("next", "prior_logits"),
+                    ("next", "state"),
+                    ("next", "belief"),
+                ],
+            ),
+            TensorDictModule(
+                posterior,
+                in_keys=[("next", "belief"), ("next", "encoded_latents")],
+                out_keys=[("next", "posterior_logits"), ("next", "state")],
+            ),
+        )
+
+        def run(action):
+            tensordict = TensorDict(
+                {
+                    "state": torch.zeros(1, 2, state_dim, device=device),
+                    "belief": torch.zeros(1, 2, belief_dim, device=device),
+                    "is_init": torch.ones(1, 2, 1, dtype=torch.bool, device=device),
+                    "next": {
+                        "encoded_latents": torch.zeros(
+                            1, 2, embedding_dim, device=device
+                        )
+                    },
+                },
+                [1, 2],
+            )
+            tensordict.set(action_key, action)
+            torch.manual_seed(0)
+            return rollout(tensordict)
+
+        zero_action = torch.zeros(1, 2, action_dim, device=device)
+        nonzero_action = torch.ones_like(zero_action)
+        torch.testing.assert_close(
+            run(zero_action)["next", "belief"],
+            run(nonzero_action)["next", "belief"],
+        )
 
 
 if __name__ == "__main__":

--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -13,6 +13,14 @@ from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 from torchrl.data.tensor_specs import Bounded
 from torchrl.modules import SafeModule
+from torchrl.modules.models.dreamer_v3 import (
+    _DreamerV3BlockLinear,
+    _DreamerV3RMSNorm,
+    DreamerV3MLP,
+    RSSMPosteriorV3,
+    RSSMPriorV3,
+    RSSMRolloutV3,
+)
 from torchrl.modules.models.model_based import (
     DreamerActor,
     ObsDecoder,
@@ -20,14 +28,6 @@ from torchrl.modules.models.model_based import (
     RSSMPosterior,
     RSSMPrior,
     RSSMRollout,
-)
-from torchrl.modules.models.model_based_v3 import (
-    _DreamerV3BlockLinear,
-    _DreamerV3RMSNorm,
-    DreamerV3MLP,
-    RSSMPosteriorV3,
-    RSSMPriorV3,
-    RSSMRolloutV3,
 )
 
 from torchrl.testing import get_default_devices

--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -272,6 +272,15 @@ class TestDreamerV3Components:
     def test_reference_normalization_and_block_fan_in(self):
         norm = _DreamerV3RMSNorm(8)
         assert set(dict(norm.named_parameters())) == {"weight"}
+        with torch.no_grad():
+            norm.weight.copy_(torch.linspace(0.5, 1.5, 8))
+        value = torch.randn(3, 8, dtype=torch.bfloat16)
+        expected = (
+            value.float()
+            * torch.rsqrt(value.float().square().mean(-1, keepdim=True) + norm.eps)
+            * norm.weight
+        )
+        torch.testing.assert_close(norm(value), expected.to(value.dtype))
 
         torch.manual_seed(0)
         one_block = _DreamerV3BlockLinear(1024, 1024, num_blocks=1)

--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -383,6 +383,10 @@ class TestDreamerV3Components:
         assert belief.grad is not None
         assert all(parameter.grad is not None for parameter in prior.parameters())
 
+    @pytest.mark.skipif(
+        version.parse(torch.__version__) < version.parse("2.4.0"),
+        reason="the native RMSNorm compile path requires Torch >= 2.4.0",
+    )
     def test_block_gru_torch_compile(self):
         prior = RSSMPriorV3(
             action_shape=(2,),

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -715,13 +715,17 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
     # Value loss tests
     # ------------------------------------------------------------------ #
 
-    def test_dreamer_v3_replay_value_target(self, device):
+    @pytest.mark.parametrize("compiled", [False, True])
+    def test_dreamer_v3_replay_value_target(self, device, compiled):
         reward = torch.tensor([[0.0, 1.0, 2.0, 3.0]], device=device)
         bootstrap = torch.tensor([[10.0, 20.0, 30.0, 40.0]], device=device)
         done = torch.zeros_like(reward, dtype=torch.bool)
         terminated = torch.zeros_like(done)
 
-        target = _replay_value_target(
+        target_fn = _replay_value_target
+        if compiled:
+            target_fn = torch.compile(target_fn, backend="eager", fullgraph=True)
+        target = target_fn(
             reward,
             done,
             terminated,

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -46,6 +46,7 @@ from torchrl.objectives import (
 from torchrl.objectives.dreamer_v3 import (
     _default_bins,
     _match_trailing_dim,
+    _replay_value_target,
     categorical_kl_balanced,
     categorical_kl_terms,
     symexp,
@@ -591,6 +592,18 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         }
         self.tensordict_keys_test(loss_fn, default_keys=default_keys)
 
+    @pytest.mark.parametrize("detach_output", [True, False])
+    def test_dreamer_v3_model_loss_detach_output(self, device, detach_output):
+        world_model = self._create_world_model().to(device)
+        loss_module = DreamerV3ModelLoss(
+            world_model,
+            num_reward_bins=self.num_reward_bins,
+            detach_output=detach_output,
+        )
+        _, features = loss_module(self._create_world_model_data().to(device))
+        posterior = features["next", "posterior_logits"]
+        assert posterior.requires_grad is not detach_output
+
     # ------------------------------------------------------------------ #
     # Actor loss tests
     # ------------------------------------------------------------------ #
@@ -664,7 +677,8 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         loss_td, fake_data = loss_module(
             self._create_actor_data().to(device).reshape(-1)
         )
-        expected_weight = torch.tensor([1.0, 0.5, 0.25], device=device)
+        # The initial state is weighted by its own continuation probability.
+        expected_weight = torch.tensor([0.5, 0.25, 0.125], device=device)
         torch.testing.assert_close(
             fake_data["discount_weight"][0, :, 0], expected_weight
         )
@@ -700,6 +714,68 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
     # ------------------------------------------------------------------ #
     # Value loss tests
     # ------------------------------------------------------------------ #
+
+    def test_dreamer_v3_replay_value_target(self, device):
+        reward = torch.tensor([[0.0, 1.0, 2.0, 3.0]], device=device)
+        bootstrap = torch.tensor([[10.0, 20.0, 30.0, 40.0]], device=device)
+        done = torch.zeros_like(reward, dtype=torch.bool)
+        terminated = torch.zeros_like(done)
+
+        target = _replay_value_target(
+            reward,
+            done,
+            terminated,
+            bootstrap,
+            horizon=2.0,
+            lmbda=0.5,
+        )
+        torch.testing.assert_close(
+            target, torch.tensor([[9.8125, 15.25, 23.0]], device=device)
+        )
+
+    def test_dreamer_v3_replay_value_loss_nested_keys(self, device):
+        batch, time_steps = 2, 4
+        state = torch.randn(
+            batch,
+            time_steps,
+            self.state_dim,
+            device=device,
+            requires_grad=True,
+        )
+        replay = TensorDict(
+            {
+                "state": state,
+                "belief": torch.randn(
+                    batch, time_steps, self.rnn_hidden_dim, device=device
+                ),
+                "first_return": torch.randn(batch, time_steps, device=device),
+                "next": {
+                    "replay": {
+                        "reward": torch.randn(batch, time_steps, device=device),
+                        "done": torch.zeros(
+                            batch, time_steps, dtype=torch.bool, device=device
+                        ),
+                        "terminated": torch.zeros(
+                            batch, time_steps, dtype=torch.bool, device=device
+                        ),
+                    }
+                },
+            },
+            [batch, time_steps],
+        )
+        value_loss = DreamerV3ValueLoss(self._create_value_model().to(device)).to(
+            device
+        )
+        value_loss.set_keys(
+            reward=("replay", "reward"),
+            done=("replay", "done"),
+            terminated=("replay", "terminated"),
+            bootstrap="first_return",
+        )
+
+        loss = value_loss.replay_value_loss(replay)["loss_replay_value"]
+        loss.backward()
+        assert state.grad is not None and state.grad.abs().sum() > 0
 
     @pytest.mark.parametrize("discount_loss", [True, False])
     def test_dreamer_v3_value_loss_symlog_mse(self, device, discount_loss):
@@ -1236,10 +1312,10 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         out_c = rollout(td_c)
         torch.manual_seed(0)
         out_d = rollout(td_d)
-        action_effect = (
-            out_c["next", "prior_logits"][:, 2] - out_d["next", "prior_logits"][:, 2]
-        ).abs()
-        assert action_effect.max() > 1e-6
+        torch.testing.assert_close(
+            out_c["next", "prior_logits"][:, 2],
+            out_d["next", "prior_logits"][:, 2],
+        )
 
     # ------------------------------------------------------------------ #
     # Coverage for previously untested branches

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -733,7 +733,8 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             target, torch.tensor([[9.8125, 15.25, 23.0]], device=device)
         )
 
-    def test_dreamer_v3_replay_value_loss_nested_keys(self, device):
+    @pytest.mark.parametrize("reduction", ["none", "mean", "sum"])
+    def test_dreamer_v3_replay_value_loss_nested_keys(self, device, reduction):
         batch, time_steps = 2, 4
         state = torch.randn(
             batch,
@@ -763,9 +764,9 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             },
             [batch, time_steps],
         )
-        value_loss = DreamerV3ValueLoss(self._create_value_model().to(device)).to(
-            device
-        )
+        value_loss = DreamerV3ValueLoss(
+            self._create_value_model().to(device), reduction=reduction
+        ).to(device)
         value_loss.set_keys(
             reward=("replay", "reward"),
             done=("replay", "done"),
@@ -774,21 +775,27 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         )
 
         loss = value_loss.replay_value_loss(replay)["loss_replay_value"]
-        loss.backward()
+        expected_shape = (batch, time_steps - 1) if reduction == "none" else ()
+        assert loss.shape == expected_shape
+        loss.sum().backward()
         assert state.grad is not None and state.grad.abs().sum() > 0
 
     @pytest.mark.parametrize("discount_loss", [True, False])
-    def test_dreamer_v3_value_loss_symlog_mse(self, device, discount_loss):
+    @pytest.mark.parametrize("reduction", ["none", "mean", "sum"])
+    def test_dreamer_v3_value_loss_symlog_mse(self, device, discount_loss, reduction):
         tensordict = self._create_value_data().to(device)
         value_model = self._create_value_model(out_features=1).to(device)
         loss_module = DreamerV3ValueLoss(
             value_model,
             value_loss="symlog_mse",
             discount_loss=discount_loss,
+            reduction=reduction,
         )
         loss_td, _ = loss_module(tensordict)
         assert "loss_value" in loss_td.keys()
-        loss_td["loss_value"].backward()
+        expected_shape = tensordict.batch_size if reduction == "none" else ()
+        assert loss_td["loss_value"].shape == expected_shape
+        loss_td["loss_value"].sum().backward()
         grad_total = sum(
             p.grad.pow(2).sum().item()
             for p in loss_module.parameters()

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -31,12 +31,12 @@ from torchrl.envs.model_based.dreamer import DreamerEnv
 from torchrl.envs.transforms import TensorDictPrimer, TransformedEnv
 from torchrl.modules import SafeSequential, SymExpTwoHot, WorldModelWrapper
 from torchrl.modules.distributions.continuous import TanhNormal
-from torchrl.modules.models.model_based import DreamerActor
-from torchrl.modules.models.model_based_v3 import (
+from torchrl.modules.models.dreamer_v3 import (
     RSSMPosteriorV3,
     RSSMPriorV3,
     RSSMRolloutV3,
 )
+from torchrl.modules.models.model_based import DreamerActor
 from torchrl.modules.models.models import MLP
 from torchrl.objectives import (
     DreamerV3ActorLoss,

--- a/torchrl/modules/models/__init__.py
+++ b/torchrl/modules/models/__init__.py
@@ -4,13 +4,23 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import sys
+
 from torchrl.modules.tensordict_module.common import DistributionalDQNnet
 
+from . import dreamer_v3
 from .act import ACTModel
 from .batchrenorm import BatchRenorm1d
 from .cross_group_critic import CrossCriticGroupSpec, CrossGroupCritic
 
 from .decision_transformer import DecisionTransformer
+from .dreamer_v3 import (
+    DreamerV3MLP,
+    RSSMPosteriorV3,
+    RSSMPriorV3,
+    RSSMRolloutV3,
+    SymExpTwoHot,
+)
 from .exploration import (
     ConsistentDropout,
     ConsistentDropoutModule,
@@ -27,13 +37,6 @@ from .model_based import (
     RSSMPosterior,
     RSSMPrior,
     RSSMRollout,
-)
-from .model_based_v3 import (
-    DreamerV3MLP,
-    RSSMPosteriorV3,
-    RSSMPriorV3,
-    RSSMRolloutV3,
-    SymExpTwoHot,
 )
 from .models import (
     Conv2dNet,
@@ -58,6 +61,11 @@ from .multiagent import (
 )
 from .rbf_controller import RBFController
 from .utils import Squeeze2dLayer, SqueezeLayer
+
+
+# Preserve the module path shipped in TorchRL 0.13 without keeping a duplicate
+# compatibility file. New code should import from ``dreamer_v3``.
+sys.modules[f"{__name__}.model_based_v3"] = dreamer_v3
 
 __all__ = [
     "ACTModel",

--- a/torchrl/modules/models/dreamer_v3.py
+++ b/torchrl/modules/models/dreamer_v3.py
@@ -33,19 +33,6 @@ def _dreamer_v3_init(module: nn.Module) -> None:
             nn.init.zeros_(module.bias)
 
 
-@implement_for("torch", None, "2.4", compilable=True)
-def _has_native_rms_norm() -> bool:
-    return False
-
-
-@implement_for("torch", "2.4", compilable=True)
-def _has_native_rms_norm() -> bool:  # noqa: F811
-    return True
-
-
-_HAS_NATIVE_RMS_NORM = _has_native_rms_norm()
-
-
 class _DreamerV3RMSNorm(nn.Module):
     """RMS normalization with a learned scale and no shift."""
 
@@ -54,15 +41,18 @@ class _DreamerV3RMSNorm(nn.Module):
         self.eps = eps
         self.weight = nn.Parameter(torch.ones(features, device=device))
 
+    @implement_for("torch", None, "2.4", compilable=True)
     def forward(self, value: torch.Tensor) -> torch.Tensor:
-        if _HAS_NATIVE_RMS_NORM:
-            return F.rms_norm(
-                value.float(), (self.weight.shape[0],), self.weight.float(), self.eps
-            ).to(value.dtype)
         dtype = value.dtype
         value = value.float()
         value = value * torch.rsqrt(value.square().mean(-1, keepdim=True) + self.eps)
         return (value * self.weight.float()).to(dtype)
+
+    @implement_for("torch", "2.4", compilable=True)
+    def forward(self, value: torch.Tensor) -> torch.Tensor:  # noqa: F811
+        return F.rms_norm(
+            value.float(), (self.weight.shape[0],), self.weight.float(), self.eps
+        ).to(value.dtype)
 
 
 class _DreamerV3BlockLinear(nn.Module):

--- a/torchrl/modules/models/dreamer_v3.py
+++ b/torchrl/modules/models/dreamer_v3.py
@@ -33,6 +33,19 @@ def _dreamer_v3_init(module: nn.Module) -> None:
             nn.init.zeros_(module.bias)
 
 
+@implement_for("torch", None, "2.4", compilable=True)
+def _has_native_rms_norm() -> bool:
+    return False
+
+
+@implement_for("torch", "2.4", compilable=True)
+def _has_native_rms_norm() -> bool:  # noqa: F811
+    return True
+
+
+_HAS_NATIVE_RMS_NORM = _has_native_rms_norm()
+
+
 class _DreamerV3RMSNorm(nn.Module):
     """RMS normalization with a learned scale and no shift."""
 
@@ -41,18 +54,15 @@ class _DreamerV3RMSNorm(nn.Module):
         self.eps = eps
         self.weight = nn.Parameter(torch.ones(features, device=device))
 
-    @implement_for("torch", None, "2.4", compilable=True)
     def forward(self, value: torch.Tensor) -> torch.Tensor:
+        if _HAS_NATIVE_RMS_NORM:
+            return F.rms_norm(
+                value.float(), (self.weight.shape[0],), self.weight.float(), self.eps
+            ).to(value.dtype)
         dtype = value.dtype
         value = value.float()
         value = value * torch.rsqrt(value.square().mean(-1, keepdim=True) + self.eps)
         return (value * self.weight.float()).to(dtype)
-
-    @implement_for("torch", "2.4", compilable=True)
-    def forward(self, value: torch.Tensor) -> torch.Tensor:  # noqa: F811
-        return F.rms_norm(
-            value.float(), (self.weight.shape[0],), self.weight.float(), self.eps
-        ).to(value.dtype)
 
 
 class _DreamerV3BlockLinear(nn.Module):

--- a/torchrl/modules/models/dreamer_v3.py
+++ b/torchrl/modules/models/dreamer_v3.py
@@ -501,7 +501,7 @@ class RSSMPriorV3(nn.Module):
 
     Examples:
         >>> import torch
-        >>> from torchrl.modules.models.model_based_v3 import RSSMPriorV3
+        >>> from torchrl.modules.models.dreamer_v3 import RSSMPriorV3
         >>> prior = RSSMPriorV3(
         ...     action_shape=torch.Size([2]),
         ...     hidden_dim=16,
@@ -698,7 +698,7 @@ class RSSMPosteriorV3(nn.Module):
 
     Examples:
         >>> import torch
-        >>> from torchrl.modules.models.model_based_v3 import RSSMPosteriorV3
+        >>> from torchrl.modules.models.dreamer_v3 import RSSMPosteriorV3
         >>> posterior = RSSMPosteriorV3(
         ...     hidden_dim=16,
         ...     num_categoricals=4,
@@ -838,7 +838,7 @@ class RSSMRolloutV3(TensorDictModuleBase):
         >>> import torch
         >>> from tensordict import TensorDict
         >>> from tensordict.nn import TensorDictModule
-        >>> from torchrl.modules.models.model_based_v3 import (
+        >>> from torchrl.modules.models.dreamer_v3 import (
         ...     RSSMPosteriorV3, RSSMPriorV3, RSSMRolloutV3,
         ... )
         >>> prior = TensorDictModule(

--- a/torchrl/modules/models/model_based_v3.py
+++ b/torchrl/modules/models/model_based_v3.py
@@ -14,8 +14,9 @@ import torch
 from tensordict.nn import TensorDictModule, TensorDictModuleBase, TensorDictSequential
 from tensordict.utils import NestedKey, unravel_key
 from torch import nn
-from torch.nn import GRUCell
+from torch.nn import functional as F, GRUCell
 
+from torchrl._utils import implement_for
 from torchrl.modules.functional import symexp, symlog  # noqa: F401
 
 
@@ -40,11 +41,18 @@ class _DreamerV3RMSNorm(nn.Module):
         self.eps = eps
         self.weight = nn.Parameter(torch.ones(features, device=device))
 
+    @implement_for("torch", None, "2.4", compilable=True)
     def forward(self, value: torch.Tensor) -> torch.Tensor:
         dtype = value.dtype
         value = value.float()
         value = value * torch.rsqrt(value.square().mean(-1, keepdim=True) + self.eps)
         return (value * self.weight.float()).to(dtype)
+
+    @implement_for("torch", "2.4", compilable=True)
+    def forward(self, value: torch.Tensor) -> torch.Tensor:  # noqa: F811
+        return F.rms_norm(
+            value.float(), (self.weight.shape[0],), self.weight.float(), self.eps
+        ).to(value.dtype)
 
 
 class _DreamerV3BlockLinear(nn.Module):

--- a/torchrl/modules/models/model_based_v3.py
+++ b/torchrl/modules/models/model_based_v3.py
@@ -15,12 +15,31 @@ from tensordict.nn import TensorDictModule, TensorDictModuleBase, TensorDictSequ
 from tensordict.utils import NestedKey, unravel_key
 from torch import nn
 from torch.nn import GRUCell
+from torchrl._utils import implement_for
 
 from torchrl.modules.functional import symexp, symlog  # noqa: F401
 
 
 _DEFAULT_NUM_BINS = 255
 _DEFAULT_BIN_RANGE = 20.0
+
+
+@implement_for("torch", None, "2.4", compilable=True)
+def _dreamer_v3_compute_dtype(value: torch.Tensor) -> torch.dtype:
+    """Return the autocast dtype for ``value``, or its own dtype."""
+    if value.device.type == "cuda" and torch.is_autocast_enabled():
+        return torch.get_autocast_gpu_dtype()
+    if value.device.type == "cpu" and torch.is_autocast_cpu_enabled():
+        return torch.get_autocast_cpu_dtype()
+    return value.dtype
+
+
+@implement_for("torch", "2.4", compilable=True)
+def _dreamer_v3_compute_dtype(value: torch.Tensor) -> torch.dtype:  # noqa: F811
+    device_type = value.device.type
+    if torch.is_autocast_enabled(device_type):
+        return torch.get_autocast_dtype(device_type)
+    return value.dtype
 
 
 def _dreamer_v3_init(module: nn.Module) -> None:
@@ -33,19 +52,18 @@ def _dreamer_v3_init(module: nn.Module) -> None:
 
 
 class _DreamerV3RMSNorm(nn.Module):
-    """RMS normalization with learned scale and shift."""
+    """RMS normalization with a learned scale and no shift."""
 
     def __init__(self, features: int, eps: float = 1e-4, device=None):
         super().__init__()
         self.eps = eps
         self.weight = nn.Parameter(torch.ones(features, device=device))
-        self.bias = nn.Parameter(torch.zeros(features, device=device))
 
     def forward(self, value: torch.Tensor) -> torch.Tensor:
         dtype = value.dtype
         value = value.float()
         value = value * torch.rsqrt(value.square().mean(-1, keepdim=True) + self.eps)
-        return (value * self.weight.float() + self.bias.float()).to(dtype)
+        return (value * self.weight.float()).to(dtype)
 
 
 class _DreamerV3BlockLinear(nn.Module):
@@ -74,7 +92,8 @@ class _DreamerV3BlockLinear(nn.Module):
             torch.empty(num_blocks, block_in, block_out, device=device)
         )
         self.bias = nn.Parameter(torch.zeros(out_features, device=device))
-        std = 1.1368 / block_in**0.5
+        # Fan-in spans the whole kernel: divide by in_features, not block_in.
+        std = 1.1368 / in_features**0.5
         nn.init.trunc_normal_(self.weight, std=std, a=-2 * std, b=2 * std)
 
     def forward(self, value: torch.Tensor) -> torch.Tensor:
@@ -82,7 +101,8 @@ class _DreamerV3BlockLinear(nn.Module):
             *value.shape[:-1], self.num_blocks, self.in_features // self.num_blocks
         )
         value = torch.einsum("...bi,bio->...bo", value, self.weight)
-        return value.flatten(-2) + self.bias
+        # An FP32 bias would promote a BF16 recurrence back to FP32.
+        return value.flatten(-2) + self.bias.to(value.dtype)
 
 
 class _DreamerV3BlockGRU(nn.Module):
@@ -148,6 +168,11 @@ class _DreamerV3BlockGRU(nn.Module):
         belief: torch.Tensor,
         action: torch.Tensor,
     ) -> torch.Tensor:
+        # Autocast covers only matmuls: without these casts the residual is FP32.
+        compute_dtype = _dreamer_v3_compute_dtype(belief)
+        state = state.to(compute_dtype)
+        belief = belief.to(compute_dtype)
+        action = action.to(compute_dtype)
         action = action / action.detach().abs().clamp_min(1)
         features = torch.cat(
             [
@@ -183,7 +208,8 @@ class DreamerV3MLP(nn.Module):
 
     Args:
         in_features (int): Input feature count.
-        out_features (int): Output feature count.
+        out_features (int or None): Output feature count. If ``None``, the
+            module returns the last hidden activation.
         depth (int, optional): Number of hidden layers. Defaults to 3.
         num_cells (int, optional): Hidden feature count. Defaults to 1024.
         outscale (float, optional): Multiplicative initialization scale for the
@@ -203,7 +229,7 @@ class DreamerV3MLP(nn.Module):
     def __init__(
         self,
         in_features: int,
-        out_features: int,
+        out_features: int | None,
         depth: int = 3,
         num_cells: int = 1024,
         outscale: float = 1.0,
@@ -222,12 +248,15 @@ class DreamerV3MLP(nn.Module):
                 ]
             )
             layer_in = num_cells
-        output = nn.Linear(layer_in, out_features, device=device)
-        layers.append(output)
+        output = None
+        if out_features is not None:
+            output = nn.Linear(layer_in, out_features, device=device)
+            layers.append(output)
         self.model = nn.Sequential(*layers)
         self.model.apply(_dreamer_v3_init)
-        with torch.no_grad():
-            output.weight.mul_(outscale)
+        if output is not None:
+            with torch.no_grad():
+                output.weight.mul_(outscale)
 
     def forward(self, *inputs: torch.Tensor) -> torch.Tensor:
         value = inputs[0] if len(inputs) == 1 else torch.cat(inputs, -1)
@@ -264,9 +293,11 @@ def _default_bins(
 
 
 def _unimix_probs(logits: torch.Tensor, unimix: float) -> torch.Tensor:
-    """Return categorical probabilities mixed with a uniform distribution."""
+    """Mix categorical probabilities with a uniform distribution."""
     if not 0 <= unimix < 1:
         raise ValueError(f"unimix must be in [0, 1), got {unimix}.")
+    # Softmax needs FP32: autocast would otherwise drop the precision.
+    logits = logits.to(torch.promote_types(logits.dtype, torch.float32))
     probs = torch.softmax(logits, dim=-1)
     if unimix:
         probs = (1 - unimix) * probs + unimix / logits.shape[-1]
@@ -624,6 +655,27 @@ class RSSMPriorV3(nn.Module):
             belief (torch.Tensor): Updated GRU hidden state, shape
                 ``[..., rnn_hidden_dim]``.
         """
+        belief = self._update_belief(state, belief, action)
+        prior_logits_flat = self.rnn_to_prior_projector(belief)
+        prior_logits = prior_logits_flat.view(
+            *prior_logits_flat.shape[:-1], self.num_categoricals, self.num_classes
+        )
+
+        state = _straight_through_categorical(prior_logits, self.unimix)
+        state = state.view(*state.shape[:-2], self.num_categoricals * self.num_classes)
+
+        return prior_logits, state, belief
+
+    def _update_belief(
+        self,
+        state: torch.Tensor,
+        belief: torch.Tensor,
+        action: torch.Tensor,
+    ) -> torch.Tensor:
+        """Advance the deterministic state and skip the prior head.
+
+        The acting path conditions on the observation, never on a prior sample.
+        """
         if self.recurrent_model == "block_gru":
             belief = self.rnn(state, belief, action)
         else:
@@ -639,16 +691,7 @@ class RSSMPriorV3(nn.Module):
                     belief.float() if belief is not None else None,
                 )
             belief = belief.to(dtype)
-
-        prior_logits_flat = self.rnn_to_prior_projector(belief)
-        prior_logits = prior_logits_flat.view(
-            *prior_logits_flat.shape[:-1], self.num_categoricals, self.num_classes
-        )
-
-        state = _straight_through_categorical(prior_logits, self.unimix)
-        state = state.view(*state.shape[:-2], self.num_categoricals * self.num_classes)
-
-        return prior_logits, state, belief
+        return belief
 
 
 class RSSMPosteriorV3(nn.Module):
@@ -820,8 +863,11 @@ class RSSMRolloutV3(TensorDictModuleBase):
         rssm_posterior (TensorDictModule): Posterior module wrapping
             :class:`RSSMPosteriorV3`.
         reset_key (NestedKey or None, optional): Boolean key marking the first
-            transition of an episode. State and belief are zeroed at those
-            positions. Defaults to ``"is_init"``.
+            transition of an episode. The rollout zeroes the state, belief and
+            action there. Defaults to ``"is_init"``.
+        action_key (NestedKey or None, optional): Action key, zeroed on a reset
+            step. Defaults to ``None``: the module then takes the
+            ``rssm_prior`` input key that is not ``"state"`` or ``"belief"``.
 
     Examples:
         >>> import torch
@@ -860,6 +906,7 @@ class RSSMRolloutV3(TensorDictModuleBase):
         rssm_prior: TensorDictModule,
         rssm_posterior: TensorDictModule,
         reset_key: NestedKey | None = "is_init",
+        action_key: NestedKey | None = None,
     ):
         super().__init__()
         _module = TensorDictSequential(rssm_prior, rssm_posterior)
@@ -868,6 +915,21 @@ class RSSMRolloutV3(TensorDictModuleBase):
         self.rssm_prior = rssm_prior
         self.rssm_posterior = rssm_posterior
         self.reset_key = unravel_key(reset_key) if reset_key is not None else None
+        if action_key is not None:
+            self.action_key = unravel_key(action_key)
+        else:
+            candidates = [
+                key
+                for key in map(unravel_key, rssm_prior.in_keys)
+                if key not in ("state", "belief")
+            ]
+            if len(candidates) > 1:
+                raise ValueError(
+                    "Could not infer the action key from the prior in_keys "
+                    f"{list(rssm_prior.in_keys)}: {candidates} are all "
+                    "candidates. Pass action_key explicitly."
+                )
+            self.action_key = candidates[0] if candidates else None
 
     def forward(self, tensordict):
         """Roll out the RSSM for one episode chunk.
@@ -903,6 +965,21 @@ class RSSMRolloutV3(TensorDictModuleBase):
                     reset = reset.unsqueeze(-1)
                 _tensordict.set("state", torch.where(reset, 0, state))
                 _tensordict.set("belief", torch.where(reset, 0, belief))
+                # A reset step must not use the previous action either.
+                action = (
+                    _tensordict.get(self.action_key, None)
+                    if self.action_key is not None
+                    else None
+                )
+                if action is not None:
+                    action_reset = reset
+                    while action_reset.ndim > action.ndim:
+                        action_reset = action_reset.squeeze(-1)
+                    while action_reset.ndim < action.ndim:
+                        action_reset = action_reset.unsqueeze(-1)
+                    _tensordict.set(
+                        self.action_key, torch.where(action_reset, 0, action)
+                    )
             self.rssm_prior(_tensordict)
             self.rssm_posterior(_tensordict)
 
@@ -929,11 +1006,10 @@ def _straight_through_categorical(
         logits: ``[..., num_categoricals, num_classes]``
 
     Returns:
-        one_hot tensor with same shape, gradients through softmax.
+        A one-hot tensor like ``logits``, with the gradient of the FP32 softmax.
     """
     probs = _unimix_probs(logits, unimix)
     indices = torch.distributions.Categorical(probs=probs).sample()
     one_hot = torch.zeros_like(probs)
     one_hot.scatter_(-1, indices.unsqueeze(-1), 1.0)
-    # Straight-through: forward = one_hot, backward gradient = grad(probs).
-    return probs + (one_hot - probs).detach()
+    return (probs + (one_hot - probs).detach()).to(logits.dtype)

--- a/torchrl/modules/models/model_based_v3.py
+++ b/torchrl/modules/models/model_based_v3.py
@@ -15,31 +15,12 @@ from tensordict.nn import TensorDictModule, TensorDictModuleBase, TensorDictSequ
 from tensordict.utils import NestedKey, unravel_key
 from torch import nn
 from torch.nn import GRUCell
-from torchrl._utils import implement_for
 
 from torchrl.modules.functional import symexp, symlog  # noqa: F401
 
 
 _DEFAULT_NUM_BINS = 255
 _DEFAULT_BIN_RANGE = 20.0
-
-
-@implement_for("torch", None, "2.4", compilable=True)
-def _dreamer_v3_compute_dtype(value: torch.Tensor) -> torch.dtype:
-    """Return the autocast dtype for ``value``, or its own dtype."""
-    if value.device.type == "cuda" and torch.is_autocast_enabled():
-        return torch.get_autocast_gpu_dtype()
-    if value.device.type == "cpu" and torch.is_autocast_cpu_enabled():
-        return torch.get_autocast_cpu_dtype()
-    return value.dtype
-
-
-@implement_for("torch", "2.4", compilable=True)
-def _dreamer_v3_compute_dtype(value: torch.Tensor) -> torch.dtype:  # noqa: F811
-    device_type = value.device.type
-    if torch.is_autocast_enabled(device_type):
-        return torch.get_autocast_dtype(device_type)
-    return value.dtype
 
 
 def _dreamer_v3_init(module: nn.Module) -> None:
@@ -101,8 +82,7 @@ class _DreamerV3BlockLinear(nn.Module):
             *value.shape[:-1], self.num_blocks, self.in_features // self.num_blocks
         )
         value = torch.einsum("...bi,bio->...bo", value, self.weight)
-        # An FP32 bias would promote a BF16 recurrence back to FP32.
-        return value.flatten(-2) + self.bias.to(value.dtype)
+        return value.flatten(-2) + self.bias
 
 
 class _DreamerV3BlockGRU(nn.Module):
@@ -168,11 +148,6 @@ class _DreamerV3BlockGRU(nn.Module):
         belief: torch.Tensor,
         action: torch.Tensor,
     ) -> torch.Tensor:
-        # Autocast covers only matmuls: without these casts the residual is FP32.
-        compute_dtype = _dreamer_v3_compute_dtype(belief)
-        state = state.to(compute_dtype)
-        belief = belief.to(compute_dtype)
-        action = action.to(compute_dtype)
         action = action / action.detach().abs().clamp_min(1)
         features = torch.cat(
             [
@@ -208,8 +183,7 @@ class DreamerV3MLP(nn.Module):
 
     Args:
         in_features (int): Input feature count.
-        out_features (int or None): Output feature count. If ``None``, the
-            module returns the last hidden activation.
+        out_features (int): Output feature count.
         depth (int, optional): Number of hidden layers. Defaults to 3.
         num_cells (int, optional): Hidden feature count. Defaults to 1024.
         outscale (float, optional): Multiplicative initialization scale for the
@@ -229,7 +203,7 @@ class DreamerV3MLP(nn.Module):
     def __init__(
         self,
         in_features: int,
-        out_features: int | None,
+        out_features: int,
         depth: int = 3,
         num_cells: int = 1024,
         outscale: float = 1.0,
@@ -248,15 +222,12 @@ class DreamerV3MLP(nn.Module):
                 ]
             )
             layer_in = num_cells
-        output = None
-        if out_features is not None:
-            output = nn.Linear(layer_in, out_features, device=device)
-            layers.append(output)
+        output = nn.Linear(layer_in, out_features, device=device)
+        layers.append(output)
         self.model = nn.Sequential(*layers)
         self.model.apply(_dreamer_v3_init)
-        if output is not None:
-            with torch.no_grad():
-                output.weight.mul_(outscale)
+        with torch.no_grad():
+            output.weight.mul_(outscale)
 
     def forward(self, *inputs: torch.Tensor) -> torch.Tensor:
         value = inputs[0] if len(inputs) == 1 else torch.cat(inputs, -1)
@@ -293,11 +264,9 @@ def _default_bins(
 
 
 def _unimix_probs(logits: torch.Tensor, unimix: float) -> torch.Tensor:
-    """Mix categorical probabilities with a uniform distribution."""
+    """Return categorical probabilities mixed with a uniform distribution."""
     if not 0 <= unimix < 1:
         raise ValueError(f"unimix must be in [0, 1), got {unimix}.")
-    # Softmax needs FP32: autocast would otherwise drop the precision.
-    logits = logits.to(torch.promote_types(logits.dtype, torch.float32))
     probs = torch.softmax(logits, dim=-1)
     if unimix:
         probs = (1 - unimix) * probs + unimix / logits.shape[-1]
@@ -655,27 +624,6 @@ class RSSMPriorV3(nn.Module):
             belief (torch.Tensor): Updated GRU hidden state, shape
                 ``[..., rnn_hidden_dim]``.
         """
-        belief = self._update_belief(state, belief, action)
-        prior_logits_flat = self.rnn_to_prior_projector(belief)
-        prior_logits = prior_logits_flat.view(
-            *prior_logits_flat.shape[:-1], self.num_categoricals, self.num_classes
-        )
-
-        state = _straight_through_categorical(prior_logits, self.unimix)
-        state = state.view(*state.shape[:-2], self.num_categoricals * self.num_classes)
-
-        return prior_logits, state, belief
-
-    def _update_belief(
-        self,
-        state: torch.Tensor,
-        belief: torch.Tensor,
-        action: torch.Tensor,
-    ) -> torch.Tensor:
-        """Advance the deterministic state and skip the prior head.
-
-        The acting path conditions on the observation, never on a prior sample.
-        """
         if self.recurrent_model == "block_gru":
             belief = self.rnn(state, belief, action)
         else:
@@ -691,7 +639,16 @@ class RSSMPriorV3(nn.Module):
                     belief.float() if belief is not None else None,
                 )
             belief = belief.to(dtype)
-        return belief
+
+        prior_logits_flat = self.rnn_to_prior_projector(belief)
+        prior_logits = prior_logits_flat.view(
+            *prior_logits_flat.shape[:-1], self.num_categoricals, self.num_classes
+        )
+
+        state = _straight_through_categorical(prior_logits, self.unimix)
+        state = state.view(*state.shape[:-2], self.num_categoricals * self.num_classes)
+
+        return prior_logits, state, belief
 
 
 class RSSMPosteriorV3(nn.Module):
@@ -1006,10 +963,11 @@ def _straight_through_categorical(
         logits: ``[..., num_categoricals, num_classes]``
 
     Returns:
-        A one-hot tensor like ``logits``, with the gradient of the FP32 softmax.
+        one_hot tensor with same shape, gradients through softmax.
     """
     probs = _unimix_probs(logits, unimix)
     indices = torch.distributions.Categorical(probs=probs).sample()
     one_hot = torch.zeros_like(probs)
     one_hot.scatter_(-1, indices.unsqueeze(-1), 1.0)
-    return (probs + (one_hot - probs).detach()).to(logits.dtype)
+    # Straight-through: forward = one_hot, backward gradient = grad(probs).
+    return probs + (one_hot - probs).detach()

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -111,7 +111,6 @@ def categorical_kl_balanced(
     prior_logits: torch.Tensor,
     alpha: float = 0.8,
     free_bits: float = 1.0,
-    unimix: float = 0.01,
 ) -> torch.Tensor:
     """KL divergence with balancing between posterior and prior.
 
@@ -134,8 +133,6 @@ def categorical_kl_balanced(
         prior_logits: Shape ``[..., num_categoricals, num_classes]``.
         alpha (float): Balancing weight (0.8 in the paper). Default: 0.8.
         free_bits (float): Minimum per-categorical KL in nats. Default: 1.0.
-        unimix (float): Uniform mixture before the KL. Default: 0.01.
-
     Returns:
         Scalar KL loss.
 
@@ -147,8 +144,8 @@ def categorical_kl_balanced(
         >>> kl = categorical_kl_balanced(posterior, prior, alpha=0.8, free_bits=0.1)
         >>> kl.backward()
     """
-    posterior = _unimix_probs(posterior_logits, unimix)
-    prior = _unimix_probs(prior_logits, unimix)
+    posterior = torch.softmax(posterior_logits, dim=-1)
+    prior = torch.softmax(prior_logits, dim=-1)
 
     eps = 1e-8
     posterior = posterior.clamp(min=eps)
@@ -231,7 +228,8 @@ class DreamerV3ModelLoss(LossModule):
             Defaults to 1.0.
         lambda_representation (float, optional): Representation KL weight in
             separate mode. Defaults to 0.1.
-        unimix (float, optional): Uniform mixture for the KL. Default: 0.01.
+        unimix (float, optional): Uniform mixture used by the categorical KL
+            distributions. Defaults to 0.0 for compatibility.
         kl_alpha (float, optional): KL balancing factor (alpha in the paper).
             Default: 0.8.
         free_bits (float, optional): Minimum KL per categorical in nats.
@@ -347,7 +345,7 @@ class DreamerV3ModelLoss(LossModule):
         kl_mode: Literal["balanced", "separate"] = "balanced",
         lambda_dynamic: float = 1.0,
         lambda_representation: float = 0.1,
-        unimix: float = 0.01,
+        unimix: float = 0.0,
         continue_target_scale: float = 1.0,
         kl_alpha: float = 0.8,
         free_bits: float = 1.0,
@@ -417,7 +415,6 @@ class DreamerV3ModelLoss(LossModule):
                 prior_logits,
                 alpha=self.kl_alpha,
                 free_bits=self.free_bits,
-                unimix=self.unimix,
             ).unsqueeze(-1)
 
         # ---- Reconstruction loss ----
@@ -711,11 +708,6 @@ class DreamerV3ActorLoss(LossModule):
         self.return_normalization_rate = return_normalization_rate
         self.return_normalization_quantiles = return_normalization_quantiles
         self.return_normalization_min_scale = return_normalization_min_scale
-        self.register_buffer(
-            "_return_normalization_quantiles",
-            torch.tensor(return_normalization_quantiles),
-            persistent=False,
-        )
         self.register_buffer("return_low", torch.tensor(0.0))
         self.register_buffer("return_high", torch.tensor(0.0))
         if gamma is not None:
@@ -837,6 +829,11 @@ class DreamerV3ActorLoss(LossModule):
                 "return_low": self.return_low.detach().clone(),
                 "return_high": self.return_high.detach().clone(),
                 "return_scale": return_scale.detach().clone(),
+                "continuation_mean": (
+                    continuation.mean().detach()
+                    if continuation is not None
+                    else torch.ones((), device=actor_loss.device)
+                ),
             },
             [],
         )
@@ -847,9 +844,13 @@ class DreamerV3ActorLoss(LossModule):
         if not self.return_normalization:
             return torch.ones((), dtype=returns.dtype, device=returns.device)
         if self.training:
+            quantiles = torch.tensor(
+                self.return_normalization_quantiles,
+                dtype=self.return_low.dtype,
+                device=self.return_low.device,
+            )
             current_low, current_high = torch.quantile(
-                returns.detach().to(self.return_low),
-                self._return_normalization_quantiles,
+                returns.detach().to(self.return_low), quantiles
             )
             with torch.no_grad():
                 self.return_low.lerp_(current_low, self.return_normalization_rate)
@@ -1281,16 +1282,15 @@ class DreamerV3ValueLoss(LossModule):
                     symlog(value_pred.squeeze(-1)) - symlog(target_value.squeeze(-1))
                 ).pow(2)
             loss = loss + self.slow_critic_regularization * slow_loss
-            slow_metric = (discount * slow_loss).mean().detach()
         else:
-            slow_metric = torch.zeros((), device=loss.device, dtype=loss.dtype)
+            slow_loss = torch.zeros_like(loss)
 
         value_loss = (discount * loss).mean()
 
         loss_tensordict = TensorDict(
             {
                 "loss_value": value_loss,
-                "value_slow_loss": slow_metric,
+                "value_slow_loss": (discount * slow_loss).mean().detach(),
             }
         )
         self._clear_weakrefs(fake_data, loss_tensordict)

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -32,7 +32,7 @@ from torchrl.envs.utils import ExplorationType, set_exploration_type, step_mdp
 from torchrl.modules.distributions import HAS_ENTROPY
 from torchrl.modules.distributions.utils import rsample_and_log_prob
 from torchrl.modules.functional import symexp as _symexp, symlog as symlog
-from torchrl.modules.models.model_based_v3 import (  # noqa: F401
+from torchrl.modules.models.dreamer_v3 import (  # noqa: F401
     _default_bins,
     _DEFAULT_NUM_BINS,
     _unimix_probs,
@@ -565,7 +565,7 @@ class DreamerV3ActorLoss(LossModule):
         >>> from torchrl.modules import MLP, SafeSequential, WorldModelWrapper
         >>> from torchrl.modules.distributions.continuous import TanhNormal
         >>> from torchrl.modules.models.model_based import DreamerActor
-        >>> from torchrl.modules.models.model_based_v3 import RSSMPriorV3
+        >>> from torchrl.modules.models.dreamer_v3 import RSSMPriorV3
         >>> from torchrl.objectives import DreamerV3ActorLoss
         >>> from torchrl.objectives.utils import ValueEstimators
         >>> from torchrl.testing.mocking_classes import ContinuousActionConvMockEnv

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -48,7 +48,11 @@ from torchrl.objectives.utils import (
     ValueEstimators,
 )
 from torchrl.objectives.value import ValueEstimatorBase
-from torchrl.objectives.value.functional import td_lambda_return_estimate
+from torchrl.objectives.value.functional import (
+    is_dynamo_compiling as _is_dynamo_compiling,
+    td_lambda_return_estimate,
+    vec_td_lambda_return_estimate,
+)
 
 symexp = _symexp
 two_hot_decode = _two_hot_decode
@@ -947,8 +951,15 @@ def _replay_value_target(
     done = done.squeeze(-1).unsqueeze(-1)
     terminated = terminated.squeeze(-1).unsqueeze(-1)
     bootstrap = bootstrap.squeeze(-1).unsqueeze(-1)
+    # The vectorized path discovers and pads trajectory lengths dynamically,
+    # which cannot be captured by Dynamo in fullgraph mode.
+    return_estimate = (
+        td_lambda_return_estimate
+        if _is_dynamo_compiling()
+        else vec_td_lambda_return_estimate
+    )
     return (
-        td_lambda_return_estimate(
+        return_estimate(
             gamma=1 - 1 / horizon,
             lmbda=lmbda,
             next_state_value=bootstrap[..., 1:, :],

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -1003,6 +1003,8 @@ class DreamerV3ValueLoss(LossModule):
         slow_critic_regularization (float, optional): Weight of the auxiliary
             loss that trains the online critic toward decoded target-critic
             predictions. Default: ``0.0``.
+        reduction ("none", "mean" or "sum", optional): Reduction applied to
+            the loss. Defaults to ``"mean"``.
 
     Examples:
         >>> import torch
@@ -1070,11 +1072,15 @@ class DreamerV3ValueLoss(LossModule):
         num_value_bins: int = _DEFAULT_NUM_BINS,
         actor_loss: DreamerV3ActorLoss | None = None,
         slow_critic_regularization: float = 0.0,
+        reduction: Literal["none", "mean", "sum"] | None = None,
     ):
         super().__init__()
+        if reduction is None:
+            reduction = "mean"
         if slow_critic_regularization < 0:
             raise ValueError("slow_critic_regularization must be non-negative.")
         self.slow_critic_regularization = slow_critic_regularization
+        self.reduction = reduction
         self.convert_to_functional(
             value_model,
             "value_model",
@@ -1202,7 +1208,7 @@ class DreamerV3ValueLoss(LossModule):
             )
 
         return TensorDict(
-            {"loss_replay_value": (weight.to(loss.dtype) * loss).mean()}, []
+            loss_replay_value=self._reduce_loss(weight.to(loss.dtype) * loss)
         )
 
     def _step_value_loss(
@@ -1287,13 +1293,11 @@ class DreamerV3ValueLoss(LossModule):
         else:
             slow_loss = torch.zeros_like(loss)
 
-        value_loss = (discount * loss).mean()
+        value_loss = self._reduce_loss(discount * loss)
 
         loss_tensordict = TensorDict(
-            {
-                "loss_value": value_loss,
-                "value_slow_loss": (discount * slow_loss).mean().detach(),
-            }
+            loss_value=value_loss,
+            value_slow_loss=self._reduce_loss(discount * slow_loss).detach(),
         )
         self._clear_weakrefs(fake_data, loss_tensordict)
         return loss_tensordict, fake_data.data

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -934,6 +934,7 @@ class DreamerV3ActorLoss(LossModule):
 # ---------------------------------------------------------------------------
 
 
+@torch.no_grad()
 def _replay_value_target(
     reward: torch.Tensor,
     done: torch.Tensor,
@@ -958,18 +959,14 @@ def _replay_value_target(
         if _is_dynamo_compiling()
         else vec_td_lambda_return_estimate
     )
-    return (
-        return_estimate(
-            gamma=1 - 1 / horizon,
-            lmbda=lmbda,
-            next_state_value=bootstrap[..., 1:, :],
-            reward=reward[..., 1:, :],
-            done=done[..., 1:, :],
-            terminated=terminated[..., 1:, :],
-        )
-        .squeeze(-1)
-        .detach()
-    )
+    return return_estimate(
+        gamma=1 - 1 / horizon,
+        lmbda=lmbda,
+        next_state_value=bootstrap[..., 1:, :],
+        reward=reward[..., 1:, :],
+        done=done[..., 1:, :],
+        terminated=terminated[..., 1:, :],
+    ).squeeze(-1)
 
 
 class DreamerV3ValueLoss(LossModule):

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 import torch
-from tensordict import TensorDict, TensorDictParams
+from tensordict import TensorDict, TensorDictBase, TensorDictParams
 from tensordict.nn import TensorDictModule, TensorDictModuleBase
 from tensordict.utils import NestedKey, unravel_key
 
@@ -111,6 +111,7 @@ def categorical_kl_balanced(
     prior_logits: torch.Tensor,
     alpha: float = 0.8,
     free_bits: float = 1.0,
+    unimix: float = 0.01,
 ) -> torch.Tensor:
     """KL divergence with balancing between posterior and prior.
 
@@ -119,9 +120,12 @@ def categorical_kl_balanced(
              + (1 - alpha) * KL(posterior || sg(prior))
 
     The first term trains only the *prior*; the second trains only the
-    *posterior*. Free bits are applied **per categorical** (clamped before
-    averaging across categoricals and batch), matching Hafner et al. 2023
-    eq. 5: ``L_KL = max(free_bits, KL_per_categorical)``.
+    *posterior*. ``free_bits`` lower-limits each categorical KL, then the
+    function averages over the categoricals and the batch.
+
+    .. note::
+        The reference clamps the KL *sum* over the categoricals, not each
+        one. Use :func:`categorical_kl_terms` for that behavior.
 
     Reference: https://arxiv.org/abs/2301.04104
 
@@ -130,6 +134,7 @@ def categorical_kl_balanced(
         prior_logits: Shape ``[..., num_categoricals, num_classes]``.
         alpha (float): Balancing weight (0.8 in the paper). Default: 0.8.
         free_bits (float): Minimum per-categorical KL in nats. Default: 1.0.
+        unimix (float): Uniform mixture before the KL. Default: 0.01.
 
     Returns:
         Scalar KL loss.
@@ -142,8 +147,8 @@ def categorical_kl_balanced(
         >>> kl = categorical_kl_balanced(posterior, prior, alpha=0.8, free_bits=0.1)
         >>> kl.backward()
     """
-    posterior = torch.softmax(posterior_logits, dim=-1)
-    prior = torch.softmax(prior_logits, dim=-1)
+    posterior = _unimix_probs(posterior_logits, unimix)
+    prior = _unimix_probs(prior_logits, unimix)
 
     eps = 1e-8
     posterior = posterior.clamp(min=eps)
@@ -155,7 +160,6 @@ def categorical_kl_balanced(
     prior_sg = prior.detach()
     kl_term2 = (posterior * (posterior.log() - prior_sg.log())).sum(-1)
 
-    # Free bits per categorical (clamp before reducing). Hafner et al. 2023, eq. 5.
     kl_term1 = kl_term1.clamp_min(free_bits).mean()
     kl_term2 = kl_term2.clamp_min(free_bits).mean()
 
@@ -197,8 +201,8 @@ class DreamerV3ModelLoss(LossModule):
 
     1. **KL loss** — balanced KL between prior and posterior categorical
        distributions (see :func:`categorical_kl_balanced`).
-    2. **Reconstruction loss** — symlog MSE between predicted and true
-       observations.
+    2. **Reconstruction loss** — squared (``"l2"``) or absolute (``"l1"``)
+       error between the decoded and the true observations, in symlog space.
     3. **Reward loss** — two-hot cross-entropy or symlog MSE for the predicted
        reward.
 
@@ -227,14 +231,12 @@ class DreamerV3ModelLoss(LossModule):
             Defaults to 1.0.
         lambda_representation (float, optional): Representation KL weight in
             separate mode. Defaults to 0.1.
-        unimix (float, optional): Uniform mixture used by the categorical KL
-            distributions. Defaults to 0.0 for compatibility.
+        unimix (float, optional): Uniform mixture for the KL. Default: 0.01.
         kl_alpha (float, optional): KL balancing factor (alpha in the paper).
             Default: 0.8.
         free_bits (float, optional): Minimum KL per categorical in nats.
             Default: 1.0.
-        reco_loss (str, optional): Reconstruction loss type (``"l2"`` or
-            ``"l1"``). Default: ``"l2"``.
+        reco_loss ("l1" or "l2", optional): Loss type. Default: ``"l2"``.
         reward_two_hot (bool, optional): If ``True``, the reward head is
             expected to output **logits over** ``num_reward_bins`` and the loss
             is two-hot cross-entropy. If ``False``, the reward head outputs a
@@ -244,6 +246,9 @@ class DreamerV3ModelLoss(LossModule):
         global_average (bool, optional): If ``True``, averages losses over all
             dimensions. Otherwise sums over non-batch/time dims first. Default:
             ``False``.
+        detach_output (bool, optional): If ``True``, the returned world model
+            output is detached. Set it to ``False`` when a replay value loss
+            must train the representation. Default: ``True``.
 
     Examples:
         >>> import torch
@@ -342,14 +347,15 @@ class DreamerV3ModelLoss(LossModule):
         kl_mode: Literal["balanced", "separate"] = "balanced",
         lambda_dynamic: float = 1.0,
         lambda_representation: float = 0.1,
-        unimix: float = 0.0,
+        unimix: float = 0.01,
         continue_target_scale: float = 1.0,
         kl_alpha: float = 0.8,
         free_bits: float = 1.0,
-        reco_loss: str = "l2",
+        reco_loss: Literal["l1", "l2"] = "l2",
         reward_two_hot: bool = True,
         num_reward_bins: int = _DEFAULT_NUM_BINS,
         global_average: bool = False,
+        detach_output: bool = True,
     ):
         super().__init__()
         self.world_model = world_model
@@ -374,6 +380,7 @@ class DreamerV3ModelLoss(LossModule):
         self.reward_two_hot = reward_two_hot
         self.num_reward_bins = num_reward_bins
         self.global_average = global_average
+        self.detach_output = detach_output
         self.register_buffer(
             "reward_bins",
             _default_bins(num_reward_bins),
@@ -410,6 +417,7 @@ class DreamerV3ModelLoss(LossModule):
                 prior_logits,
                 alpha=self.kl_alpha,
                 free_bits=self.free_bits,
+                unimix=self.unimix,
             ).unsqueeze(-1)
 
         # ---- Reconstruction loss ----
@@ -487,7 +495,7 @@ class DreamerV3ModelLoss(LossModule):
                 td_out.set("loss_model_continue", self.lambda_continue * continue_loss)
 
         self._clear_weakrefs(tensordict, td_out)
-        return td_out, tensordict.data
+        return td_out, tensordict.data if self.detach_output else tensordict
 
 
 # ---------------------------------------------------------------------------
@@ -703,6 +711,11 @@ class DreamerV3ActorLoss(LossModule):
         self.return_normalization_rate = return_normalization_rate
         self.return_normalization_quantiles = return_normalization_quantiles
         self.return_normalization_min_scale = return_normalization_min_scale
+        self.register_buffer(
+            "_return_normalization_quantiles",
+            torch.tensor(return_normalization_quantiles),
+            persistent=False,
+        )
         self.register_buffer("return_low", torch.tensor(0.0))
         self.register_buffer("return_high", torch.tensor(0.0))
         if gamma is not None:
@@ -733,37 +746,50 @@ class DreamerV3ActorLoss(LossModule):
             next_tensordict = step_mdp(fake_data, keep_other=True)
             with hold_out_net(self.value_model):
                 next_tensordict = self.value_model(next_tensordict)
+        next_value = next_tensordict.get(self.tensor_keys.value)
 
         reward = fake_data.get(("next", self.tensor_keys.reward))
-        next_value = next_tensordict.get(self.tensor_keys.value)
         continuation = None
+        root_continuation = None
         continuation_model = self.__dict__.get("continuation_model")
         if continuation_model is not None:
+            # step_mdp shifts by one: only index 0 needs a new forward pass.
+            first_td = fake_data[..., :1].select(
+                *continuation_model.in_keys, strict=False
+            )
             continuation_td = next_tensordict.select(
                 *continuation_model.in_keys, strict=False
             )
             with hold_out_net(continuation_model):
+                continuation_model(first_td)
                 continuation_model(continuation_td)
             continuation = continuation_td.get(self.tensor_keys.continuation)
+            root_continuation = torch.cat(
+                [
+                    first_td.get(self.tensor_keys.continuation),
+                    continuation[..., :-1, :],
+                ],
+                dim=-2,
+            )
+            fake_data.set(self.tensor_keys.continuation, root_continuation)
             fake_data.set(("next", self.tensor_keys.continuation), continuation)
         lambda_target = self.lambda_target(reward, next_value, continuation)
         fake_data.set("lambda_target", lambda_target)
 
-        if self.discount_loss:
+        if not self.discount_loss:
+            discount = torch.ones_like(lambda_target)
+        else:
             gamma = self.value_estimator.gamma.to(tensordict.device)
-            if continuation is None:
-                step_discount = gamma.expand(lambda_target.shape)
-            else:
-                step_discount = gamma * continuation
+            # w_t uses the root continuations (0..H-1), the returns use 1..H.
+            continuations = (
+                root_continuation
+                if continuation is not None
+                else torch.ones_like(lambda_target)
+            )
             discount = torch.cat(
-                [
-                    torch.ones_like(step_discount[..., :1, :]),
-                    step_discount[..., :-1, :],
-                ],
+                [continuations[..., :1, :], gamma * continuations[..., 1:, :]],
                 dim=-2,
             ).cumprod(dim=-2)
-        else:
-            discount = torch.ones_like(lambda_target)
         discount = discount.detach()
         fake_data.set(self.tensor_keys.discount_weight, discount)
 
@@ -811,11 +837,6 @@ class DreamerV3ActorLoss(LossModule):
                 "return_low": self.return_low.detach().clone(),
                 "return_high": self.return_high.detach().clone(),
                 "return_scale": return_scale.detach().clone(),
-                "continuation_mean": (
-                    continuation.mean().detach()
-                    if continuation is not None
-                    else torch.ones((), device=actor_loss.device)
-                ),
             },
             [],
         )
@@ -826,13 +847,9 @@ class DreamerV3ActorLoss(LossModule):
         if not self.return_normalization:
             return torch.ones((), dtype=returns.dtype, device=returns.device)
         if self.training:
-            quantiles = torch.tensor(
-                self.return_normalization_quantiles,
-                dtype=self.return_low.dtype,
-                device=self.return_low.device,
-            )
             current_low, current_high = torch.quantile(
-                returns.detach().to(self.return_low), quantiles
+                returns.detach().to(self.return_low),
+                self._return_normalization_quantiles,
             )
             with torch.no_grad():
                 self.return_low.lerp_(current_low, self.return_normalization_rate)
@@ -910,6 +927,37 @@ class DreamerV3ActorLoss(LossModule):
 # ---------------------------------------------------------------------------
 
 
+def _replay_value_target(
+    reward: torch.Tensor,
+    done: torch.Tensor,
+    terminated: torch.Tensor,
+    bootstrap: torch.Tensor,
+    horizon: float,
+    lmbda: float,
+) -> torch.Tensor:
+    """Compute the lambda returns along a replay sequence.
+
+    The output has one step less than the input: element ``k`` is the return
+    for replay state ``k``, from the rewards and bootstraps at ``k + 1`` on.
+    """
+    reward = reward.squeeze(-1)
+    done = done.squeeze(-1)
+    terminated = terminated.squeeze(-1)
+    discount = 1 - 1 / horizon
+    live = (~terminated[..., 1:]).to(reward.dtype) * discount
+    continuation = (~done[..., 1:]).to(reward.dtype) * lmbda
+    intermediate = reward[..., 1:] + (1 - continuation) * live * bootstrap[..., 1:]
+    next_return = bootstrap[..., -1]
+    returns = []
+    for time_index in reversed(range(intermediate.shape[-1])):
+        next_return = (
+            intermediate[..., time_index]
+            + live[..., time_index] * continuation[..., time_index] * next_return
+        )
+        returns.append(next_return)
+    return torch.stack(returns[::-1], -1).detach()
+
+
 class DreamerV3ValueLoss(LossModule):
     """DreamerV3 Value Loss.
 
@@ -938,7 +986,7 @@ class DreamerV3ValueLoss(LossModule):
 
     Args:
         value_model (TensorDictModule): The value network.
-        value_loss (str, optional): Loss type — ``"symlog_mse"`` or ``"two_hot"``.
+        value_loss ("symlog_mse" or "two_hot", optional): Loss type.
             Default: ``"symlog_mse"``.
         discount_loss (bool, optional): If ``True``, discounts the loss with
             a cumulative gamma factor. Default: ``True``.
@@ -985,11 +1033,23 @@ class DreamerV3ValueLoss(LossModule):
                 ``"state_value_logits"``.
             discount_weight (NestedKey): Optional cumulative imagination
                 weight. Defaults to ``"discount_weight"``.
+            reward (NestedKey): Replay reward, read under ``"next"``.
+                Defaults to ``"reward"``.
+            done (NestedKey): Replay episode end, read under ``"next"``.
+                Defaults to ``"done"``.
+            terminated (NestedKey): Replay terminal, read under ``"next"``.
+                Defaults to ``"terminated"``.
+            bootstrap (NestedKey): First imagined lambda return of each replay
+                state, read at the root. Defaults to ``"bootstrap"``.
         """
 
         value: NestedKey = "state_value"
         value_logits: NestedKey = "state_value_logits"
         discount_weight: NestedKey = "discount_weight"
+        reward: NestedKey = "reward"
+        done: NestedKey = "done"
+        terminated: NestedKey = "terminated"
+        bootstrap: NestedKey = "bootstrap"
 
     tensor_keys: _AcceptedKeys
     default_keys = _AcceptedKeys
@@ -1001,7 +1061,7 @@ class DreamerV3ValueLoss(LossModule):
     def __init__(
         self,
         value_model: TensorDictModule,
-        value_loss: str = "symlog_mse",
+        value_loss: Literal["symlog_mse", "two_hot"] = "symlog_mse",
         discount_loss: bool = True,
         gamma: float = 0.99,
         num_value_bins: int = _DEFAULT_NUM_BINS,
@@ -1051,6 +1111,104 @@ class DreamerV3ValueLoss(LossModule):
             estimator_gamma = estimator_gamma.item()
         self.gamma = float(estimator_gamma)
 
+    def replay_value_loss(
+        self,
+        tensordict: TensorDictBase,
+        *,
+        horizon: float = 333.0,
+        lmbda: float = 0.95,
+    ) -> TensorDictBase:
+        """Compute the DreamerV3 critic loss on a replay sequence.
+
+        The return of each replay state uses the reward of the next step and
+        bootstraps from ``bootstrap``, the first imagined return of that
+        state. The gradient stays on the input features, so the loss can
+        train the RSSM representation when the model loss does not detach.
+
+        Args:
+            tensordict (TensorDictBase): Posterior replay features, batch size
+                ``[B, T]``, with the ``value_model`` input keys and the
+                ``reward``, ``done``, ``terminated`` and ``bootstrap`` entries
+                that :attr:`tensor_keys` names.
+            horizon (float, optional): Discount horizon; the step discount is
+                ``1 - 1 / horizon``. Defaults to ``333.0``.
+            lmbda (float, optional): Lambda-return coefficient. Default: 0.95.
+
+        Returns:
+            A tensordict with the scalar, unweighted ``loss_replay_value``.
+
+        Examples:
+            >>> import torch
+            >>> from tensordict import TensorDict
+            >>> from tensordict.nn import TensorDictModule
+            >>> from torchrl.modules import MLP
+            >>> from torchrl.objectives import DreamerV3ValueLoss
+            >>> value_model = TensorDictModule(
+            ...     MLP(out_features=1, depth=1, num_cells=8),
+            ...     in_keys=["state"],
+            ...     out_keys=["state_value"],
+            ... )
+            >>> loss = DreamerV3ValueLoss(value_model)
+            >>> replay = TensorDict({
+            ...     "state": torch.randn(2, 5, 4),
+            ...     "bootstrap": torch.randn(2, 5),
+            ...     "next": {
+            ...         "reward": torch.randn(2, 5, 1),
+            ...         "done": torch.zeros(2, 5, 1, dtype=torch.bool),
+            ...         "terminated": torch.zeros(2, 5, 1, dtype=torch.bool),
+            ...     },
+            ... }, [2, 5])
+            >>> loss_td = loss.replay_value_loss(replay)
+            >>> loss_td["loss_replay_value"].shape
+            torch.Size([])
+        """
+        reward = tensordict.get(("next", self.tensor_keys.reward))
+        done = tensordict.get(("next", self.tensor_keys.done))
+        terminated = tensordict.get(("next", self.tensor_keys.terminated))
+        bootstrap = tensordict.get(self.tensor_keys.bootstrap)
+        target = _replay_value_target(
+            reward, done, terminated, bootstrap, horizon, lmbda
+        )
+        done = done.squeeze(-1)
+        # Drop the last step (no next state) and the steps that end an episode.
+        weight = ~done[..., :-1]
+
+        value_tensordict = tensordict.select(*self.value_model.in_keys, strict=False)
+        with self.value_model_params.to_module(
+            self.value_model, preserve_module_state=False
+        ):
+            self.value_model(value_tensordict)
+        prediction = (
+            value_tensordict.get(self.tensor_keys.value_logits)[..., :-1, :]
+            if self.value_loss == "two_hot"
+            else value_tensordict.get(self.tensor_keys.value)[..., :-1, 0]
+        )
+        loss = self._step_value_loss(prediction, target)
+
+        if self.slow_critic_regularization:
+            target_tensordict = tensordict.select(
+                *self.value_model.in_keys, strict=False
+            )
+            with torch.no_grad(), self.target_value_model_params.to_module(
+                self.value_model, preserve_module_state=False
+            ):
+                self.value_model(target_tensordict)
+            slow_target = target_tensordict.get(self.tensor_keys.value)[..., :-1, 0]
+            loss = loss + self.slow_critic_regularization * self._step_value_loss(
+                prediction, slow_target
+            )
+
+        return TensorDict(
+            {"loss_replay_value": (weight.to(loss.dtype) * loss).mean()}, []
+        )
+
+    def _step_value_loss(
+        self, prediction: torch.Tensor, target: torch.Tensor
+    ) -> torch.Tensor:
+        if self.value_loss == "two_hot":
+            return two_hot_cross_entropy(prediction, target, self.value_bins)
+        return (symlog(prediction) - symlog(target)).square()
+
     @_maybe_record_function_decorator("dreamer_v3/value_loss")
     def forward(self, fake_data) -> tuple[TensorDict, TensorDict]:
         lambda_target = fake_data.get("lambda_target")
@@ -1065,10 +1223,10 @@ class DreamerV3ValueLoss(LossModule):
         target_sq = lambda_target.squeeze(-1)  # [N] or [B, T]
 
         provided_discount = fake_data.get(self.tensor_keys.discount_weight, None)
-        gamma = self._resolved_gamma()
         if provided_discount is not None:
             discount = provided_discount.squeeze(-1)
         elif self.discount_loss and target_sq.ndim >= 2:
+            gamma = self._resolved_gamma()
             discount = gamma * torch.ones_like(target_sq)
             discount[..., 0] = 1
             discount = discount.cumprod(dim=-1)
@@ -1123,15 +1281,16 @@ class DreamerV3ValueLoss(LossModule):
                     symlog(value_pred.squeeze(-1)) - symlog(target_value.squeeze(-1))
                 ).pow(2)
             loss = loss + self.slow_critic_regularization * slow_loss
+            slow_metric = (discount * slow_loss).mean().detach()
         else:
-            slow_loss = torch.zeros_like(loss)
+            slow_metric = torch.zeros((), device=loss.device, dtype=loss.dtype)
 
         value_loss = (discount * loss).mean()
 
         loss_tensordict = TensorDict(
             {
                 "loss_value": value_loss,
-                "value_slow_loss": (discount * slow_loss).mean().detach(),
+                "value_slow_loss": slow_metric,
             }
         )
         self._clear_weakrefs(fake_data, loss_tensordict)

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -133,6 +133,7 @@ def categorical_kl_balanced(
         prior_logits: Shape ``[..., num_categoricals, num_classes]``.
         alpha (float): Balancing weight (0.8 in the paper). Default: 0.8.
         free_bits (float): Minimum per-categorical KL in nats. Default: 1.0.
+
     Returns:
         Scalar KL loss.
 

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -48,6 +48,7 @@ from torchrl.objectives.utils import (
     ValueEstimators,
 )
 from torchrl.objectives.value import ValueEstimatorBase
+from torchrl.objectives.value.functional import td_lambda_return_estimate
 
 symexp = _symexp
 two_hot_decode = _two_hot_decode
@@ -942,22 +943,22 @@ def _replay_value_target(
     The output has one step less than the input: element ``k`` is the return
     for replay state ``k``, from the rewards and bootstraps at ``k + 1`` on.
     """
-    reward = reward.squeeze(-1)
-    done = done.squeeze(-1)
-    terminated = terminated.squeeze(-1)
-    discount = 1 - 1 / horizon
-    live = (~terminated[..., 1:]).to(reward.dtype) * discount
-    continuation = (~done[..., 1:]).to(reward.dtype) * lmbda
-    intermediate = reward[..., 1:] + (1 - continuation) * live * bootstrap[..., 1:]
-    next_return = bootstrap[..., -1]
-    returns = []
-    for time_index in reversed(range(intermediate.shape[-1])):
-        next_return = (
-            intermediate[..., time_index]
-            + live[..., time_index] * continuation[..., time_index] * next_return
+    reward = reward.squeeze(-1).unsqueeze(-1)
+    done = done.squeeze(-1).unsqueeze(-1)
+    terminated = terminated.squeeze(-1).unsqueeze(-1)
+    bootstrap = bootstrap.squeeze(-1).unsqueeze(-1)
+    return (
+        td_lambda_return_estimate(
+            gamma=1 - 1 / horizon,
+            lmbda=lmbda,
+            next_state_value=bootstrap[..., 1:, :],
+            reward=reward[..., 1:, :],
+            done=done[..., 1:, :],
+            terminated=terminated[..., 1:, :],
         )
-        returns.append(next_return)
-    return torch.stack(returns[::-1], -1).detach()
+        .squeeze(-1)
+        .detach()
+    )
 
 
 class DreamerV3ValueLoss(LossModule):


### PR DESCRIPTION
## Summary

This PR is now the focused DreamerV3 correctness patch. The end-to-end reproduction, performance work, default changes, and broad test rewrite have been extracted so the semantic fixes can be reviewed on their own.

Retained fixes:

- reset the previous action together with RSSM state and belief at episode boundaries, including nested action keys;
- use the DreamerV3 RMS normalization without an additive offset;
- initialize block-linear recurrent kernels from the full input fan-in rather than independently per block;
- expose the separate dynamics/representation KL formulation and categorical unimix without changing compatibility defaults in this PR;
- include the root continuation in imagination discount weights;
- train the critic on real replay sequences with a closed-form replay target and configurable detached outputs;
- document the paper as the normative algorithmic reference while identifying later author-maintained JAX choices separately.

The original correctness commits remain authored by @unography. The final small refactor removes unrelated changes, corrects the replay-data wording, and replaces the oversized test rewrite with focused regression tests.

## Extracted follow-ups

- #4132 isolates RSSM fast paths, compilation, mixed precision, and benchmarks.
- #4133 isolates the pinned JAX Walker Walk reproduction and explicitly compares its protocol with the paper.
- #4134 is a draft community discussion that prototypes canonical public defaults before implementing TorchRL's required deprecation schedule.

## Scope reduction

The original mixed change was 18 files and roughly 7,864 changed lines. This PR is now 5 files and 476 changed lines.

## Test plan

```text
PYTHONPATH=. python -m pytest -q \
  test/modules/test_dreamer_components.py \
  test/objectives/test_dreamer_v3.py
275 passed
```

Formatting checks and `git diff --check` also pass.
