### PR TITLE
[Algorithm] Reproduce the pinned JAX DreamerV3 Walker preset

### DIFF
--- a/.github/unittest/linux_sota/scripts/test_sota.py
+++ b/.github/unittest/linux_sota/scripts/test_sota.py
@@ -362,8 +362,7 @@ commands = {
   networks.num_classes=2 \
   networks.num_reward_bins=11 \
   networks.num_value_bins=11 \
-  networks.rnn_hidden_dim=8 \
-  networks.obs_embed_dim=8
+  networks.rnn_hidden_dim=8
 """,
 }
 

--- a/docs/source/reference/dreamer_v3.rst
+++ b/docs/source/reference/dreamer_v3.rst
@@ -256,8 +256,8 @@ each critic optimizer step:
 Replay critic loss
 ~~~~~~~~~~~~~~~~~~
 
-The reference implementation also fits the critic on the real replay sequences,
-not only on imagined trajectories.
+The author-maintained JAX implementation also fits the critic on the real
+replay sequences, not only on imagined trajectories.
 :meth:`~torchrl.objectives.DreamerV3ValueLoss.replay_value_loss` computes that
 term. Its return at each replay state uses the following replay reward and
 bootstraps from the first imagined lambda return of the next state, so the
@@ -292,8 +292,9 @@ the update schedule explicit. A typical update cycle is:
 6. Soft-update the slow critic.
 
 The runnable ``sota-implementations/dreamer_v3`` example uses a single optimizer
-over the world model, actor and critic parameters, reproducing the reference's
-adaptive gradient clipping, Adam and warmup chain.
+over the world model, actor and critic parameters, reproducing the current JAX
+implementation's adaptive gradient clipping, LaProp-style RMS scaling followed
+by momentum, and warmup chain.
 Those choices belong to the training recipe rather than the loss API, so users
 can substitute another optimizer or schedule without changing the objectives.
 

--- a/docs/source/reference/dreamer_v3.rst
+++ b/docs/source/reference/dreamer_v3.rst
@@ -291,9 +291,9 @@ the update schedule explicit. A typical update cycle is:
 5. Update the online critic on those same detached returns.
 6. Soft-update the slow critic.
 
-The runnable ``sota-implementations/dreamer_v3`` example uses separate Adam
-optimizers for the world model, actor, and critic. They share a learning rate,
-Adam coefficients, linear learning-rate warmup, and adaptive gradient clipping.
+The runnable ``sota-implementations/dreamer_v3`` example uses a single optimizer
+over the world model, actor and critic parameters, reproducing the reference's
+adaptive gradient clipping, Adam and warmup chain.
 Those choices belong to the training recipe rather than the loss API, so users
 can substitute another optimizer or schedule without changing the objectives.
 

--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -16,17 +16,34 @@ python sota-implementations/dreamer_v3/train.py \
   --config-name=config_dmc_walker
 ```
 
-The Walker preset matches the 640,867 trainable parameters of the reference
-implementation's `size1m` configuration, uses 16 environments, batches of 16
+The Walker preset tracks the author-maintained JAX implementation at commit
+`e3f02248693a79dc8b0ebd62c93683888ddaccfe`. It matches that implementation's
+640,867-parameter `size1m` configuration, uses 16 environments, batches of 16
 sequences of length 64, a replay ratio of 1024, and 1.1 million environment
 steps. BF16 training is enabled on CUDA. It logs stochastic training-episode
-returns against environment steps, matching the reference curve protocol
+returns against environment steps, matching the current JAX curve protocol
 without relying on wall-clock-dependent training iterations.
 
 The Walker task is seeded from `env.seed`, as every other TorchRL example is;
-pass `env.use_seed=false` for the reference's unseeded DMC resets. The step
-axis counts initial and reset-only driver records as the reference
+pass `env.use_seed=false` for the JAX implementation's unseeded DMC resets. The
+step axis counts initial and reset-only driver records as that
 implementation does.
+
+This is deliberately a reproduction of the pinned JAX `dmc_proprio` preset,
+not of the paper's proprioceptive protocol. The two protocols differ:
+
+| Setting | Pinned JAX `dmc_proprio` preset | DreamerV3 paper proprioceptive protocol |
+| --- | --- | --- |
+| Model size | `size1m` (640,867 parameters here) | 12M parameters |
+| Environment steps | 1.1M | 500K |
+| Action repeat | 1 | 2 |
+| Replay ratio | 1024 | 512 |
+| Optimizer | AGC, LaProp-style RMS scaling then momentum, 1,000-step warmup | Paper recipe |
+| Reported aggregation | Three-seed median and interquartile range in this benchmark | Five-seed mean and standard deviation |
+
+TorchRL's public DreamerV3 API documentation remains centered on the paper's
+algorithmic semantics. This named SOTA preset documents later choices in the
+evolving JAX codebase instead of silently treating them as paper requirements.
 
 Real collection and evaluation environments run on CPU; `optimization.device`
 selects where the models, losses and policy run and defaults to `null`, which

--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -16,10 +16,17 @@ python sota-implementations/dreamer_v3/train.py \
   --config-name=config_dmc_walker
 ```
 
-The Walker preset uses the 1M-parameter RSSM dimensions, batches of 16 sequences
-of length 64, a replay ratio of 1024, and 1.1 million environment steps. It logs
-evaluation return against environment steps to JSON so curves can be compared
+The Walker preset matches the 640,867 trainable parameters of the reference
+implementation's `size1m` configuration, uses 16 environments, batches of 16
+sequences of length 64, a replay ratio of 1024, and 1.1 million environment
+steps. BF16 training is enabled on CUDA. It logs stochastic training-episode
+returns against environment steps, matching the reference curve protocol
 without relying on wall-clock-dependent training iterations.
+
+The Walker task is seeded from `env.seed`, as every other TorchRL example is;
+pass `env.use_seed=false` for the reference's unseeded DMC resets. The step
+axis counts initial and reset-only driver records as the reference
+implementation does.
 
 Real collection and evaluation environments run on CPU; `optimization.device`
 selects where the models, losses and policy run and defaults to `null`, which
@@ -29,13 +36,31 @@ CPU execution.
 For a three-seed median and interquartile reproduction run:
 
 ```bash
-python sota-implementations/dreamer_v3/benchmark.py \
-  --seeds 0 1 2 \
-  --output-dir dmc_walker_runs
+python sota-implementations/dreamer_v3/benchmark.py --output-dir dmc_walker_runs
 ```
 
-The benchmark writes one metrics file per seed plus `summary.json` and checks a
-minimum final median return of 700. Use `--minimum-final-return` to override the
-acceptance threshold when evaluating a deliberately smaller ablation. Full
-learning-curve runs are intended for scheduled or manual validation; pull-request
-CI uses short smoke overrides.
+The benchmark writes one metrics file per seed plus `summary.json`, aggregates
+the stochastic training returns into median and interquartile curves over fixed
+windows, and fails when the final window median falls short. The seeds, the
+window and the threshold come from the `benchmark` block of
+`config_dmc_walker.yaml`, which ships three seeds, 50,000-step windows and a
+minimum final median return of 900; `benchmark.*` Hydra overrides change them,
+as in `benchmark.seeds=[0,1,2,3,4]`. `env.seed` and `logger.metrics_jsonl` are
+set per run and are rejected as overrides, since either would collapse the
+seeds onto one trajectory. Full learning-curve runs are intended for scheduled
+or manual validation; pull-request CI uses short smoke overrides.
+
+For a smaller ablation, shorten the run rather than the window:
+
+```bash
+python sota-implementations/dreamer_v3/benchmark.py --output-dir smoke \
+  collector.total_frames=100000 \
+  benchmark.minimum_final_median_return=0
+```
+
+Every worker runs to the same time limit, so episodes finish in bursts one
+episode apart: `(env.max_episode_steps + 1) * collector.num_envs`, or 16,016
+records for the preset. A window narrower than that holds no completed episode
+over most of the run, so the script refuses one before launching anything. The
+command above keeps the 50,000-step window and still fills two of them with
+about 48 episodes each.

--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -86,4 +86,6 @@ about 48 episodes each.
 since a short run never repays the build. `step` compiles the deterministic work
 and draws the same categories as an eager run; `scan` compiles the unrolled
 recurrence and the imagination prior, and is faster, but its draws fall inside
-the compiled region, so a seeded run diverges from an eager one.
+the compiled region, so a seeded run diverges from an eager one. The scan uses
+`optimization.rssm_scan_unroll=8` by default; lower values reduce compilation
+time and graph size, while `1` disables manual unrolling.

--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -64,3 +64,9 @@ records for the preset. A window narrower than that holds no completed episode
 over most of the run, so the script refuses one before launching anything. The
 command above keeps the 50,000-step window and still fills two of them with
 about 48 episodes each.
+
+`optimization.compile_rssm` compiles the RSSM recurrence and is off by default,
+since a short run never repays the build. `step` compiles the deterministic work
+and draws the same categories as an eager run; `scan` compiles the unrolled
+recurrence and the imagination prior, and is faster, but its draws fall inside
+the compiled region, so a seeded run diverges from an eager one.

--- a/sota-implementations/dreamer_v3/benchmark.py
+++ b/sota-implementations/dreamer_v3/benchmark.py
@@ -2,73 +2,218 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-"""Run and aggregate reproducible DreamerV3 DMC Walker learning curves."""
+"""Run and aggregate DreamerV3 DMC Walker learning curves."""
 from __future__ import annotations
 
 import argparse
 import json
+import math
 import subprocess
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
-import torch
+from omegaconf import DictConfig, OmegaConf
 
 from torchrl._utils import logger as torchrl_logger
 
+CONFIG_PATH = Path(__file__).with_name("config_dmc_walker.yaml")
+BASE_CONFIG_PATH = CONFIG_PATH.with_name("config.yaml")
+# Set for each run below. A caller override would break the seed loop.
+_RESERVED_OVERRIDES = ("env.seed", "logger.metrics_jsonl")
 
-def aggregate_runs(paths: list[Path]) -> dict:
-    """Aggregate aligned evaluation curves into median and interquartile bands."""
-    runs = [json.loads(path.read_text()) for path in paths]
-    steps = runs[0]["environment_steps"]
-    if any(run["environment_steps"] != steps for run in runs[1:]):
-        raise ValueError("All benchmark runs must use the same evaluation steps.")
-    returns = torch.tensor(
-        [run["evaluation_returns"] for run in runs], dtype=torch.float64
+
+def _quantile(values: Sequence[float], q: float) -> float:
+    """Return the linearly interpolated ``q`` quantile of ``values``."""
+    ordered = sorted(values)
+    position = q * (len(ordered) - 1)
+    lower, upper = math.floor(position), math.ceil(position)
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (position - lower)
+
+
+def _override_key(override: str) -> str:
+    """Return the config key a Hydra override addresses."""
+    return override.split("=", 1)[0].lstrip("+~").strip()
+
+
+def effective_config(overrides: Sequence[str] = ()) -> DictConfig:
+    """Compose the walker preset as Hydra will, with the caller's overrides."""
+    config = OmegaConf.merge(
+        OmegaConf.load(BASE_CONFIG_PATH), OmegaConf.load(CONFIG_PATH)
     )
+    dotlist = [override.lstrip("+") for override in overrides if "=" in override]
+    if dotlist:
+        config = OmegaConf.merge(config, OmegaConf.from_dotlist(dotlist))
+    return config
+
+
+def episode_cycle(config: DictConfig) -> int:
+    """Return the environment steps between episode-completion bursts.
+
+    Workers run to the same time limit, so episodes finish one episode apart.
+    """
+    num_envs = config.collector.num_envs
+    if config.collector.count_reset_records:
+        # The driver axis also counts the reset record of each episode.
+        return (config.env.max_episode_steps + 1) * num_envs
+    return config.env.max_episode_steps * num_envs
+
+
+def validate_window_size(window_size: int, overrides: Sequence[str] = ()) -> None:
+    """Refuse, before the runs start, a window too narrow for one episode."""
+    config = effective_config(overrides)
+    cycle = episode_cycle(config)
+    if window_size < cycle:
+        raise ValueError(
+            f"benchmark.window_size={window_size} is below the {cycle}-step "
+            f"episode cycle ({config.collector.num_envs} envs x "
+            f"{config.env.max_episode_steps}-step episodes), so most windows "
+            "would hold no completed episode. Shorten collector.total_frames "
+            "to run a smaller ablation, and leave the window alone."
+        )
+
+
+def benchmark_settings(overrides: Sequence[str] = ()) -> dict:
+    """Read the ``benchmark`` block of the walker preset, overrides applied."""
+    settings = effective_config(overrides).benchmark
+    return OmegaConf.to_container(settings, resolve=True)
+
+
+def reject_reserved_overrides(overrides: Sequence[str]) -> None:
+    """Refuse overrides of the keys this script sets per run.
+
+    Hydra takes the last of a duplicated key, so ``env.seed`` would train one
+    trajectory and report it under every seed's name.
+    """
+    for override in overrides:
+        key = _override_key(override)
+        if key in _RESERVED_OVERRIDES:
+            raise ValueError(
+                f"{key} is set per run by this script and cannot be overridden. "
+                "Use benchmark.seeds to choose the seeds and --output-dir to "
+                "choose where their metrics land."
+            )
+
+
+def _read_run(path: Path) -> dict:
+    """Fold one run's jsonl into the fields the aggregation needs."""
+    episode_steps: list[int] = []
+    episode_returns: list[float] = []
+    summary: dict | None = None
+    for line in path.read_text().splitlines():
+        if not line:
+            continue
+        record = json.loads(line)
+        if record["type"] == "train_episode":
+            episode_steps.append(record["environment_steps"])
+            episode_returns.append(record["score"])
+        elif record["type"] == "summary":
+            summary = record
+    if summary is None:
+        raise ValueError(
+            f"{path} has no summary record; the run did not finish, so its "
+            f"total step count is unknown."
+        )
+    return {
+        "seed": summary["seed"],
+        "total_environment_steps": summary["total_environment_steps"],
+        "training_episode_steps": episode_steps,
+        "training_episode_returns": episode_returns,
+    }
+
+
+def aggregate_runs(paths: Sequence[Path], window_size: int) -> dict:
+    """Aggregate stochastic training returns into fixed-step median/IQR bands.
+
+    Returns ``environment_steps`` with ``median_return``,
+    ``lower_quartile_return``, ``upper_quartile_return`` and
+    ``per_seed_window_median`` aligned to it, plus ``window_size`` and ``seeds``.
+    """
+    if window_size <= 0:
+        raise ValueError(f"window_size must be positive, got {window_size}.")
+    runs = [_read_run(path) for path in paths]
+    total_steps = min(run["total_environment_steps"] for run in runs)
+    steps = list(range(window_size, total_steps + 1, window_size))
+    if not steps:
+        raise ValueError(f"Runs must contain at least {window_size} environment steps.")
+    window_medians = []
+    for run in runs:
+        episode_steps = run["training_episode_steps"]
+        episode_returns = run["training_episode_returns"]
+        medians = []
+        for stop in steps:
+            start = stop - window_size
+            values = [
+                score
+                for step, score in zip(episode_steps, episode_returns)
+                if start < step <= stop
+            ]
+            if not values:
+                raise ValueError(
+                    f"Seed {run['seed']} has no completed training episode in "
+                    f"the ({start}, {stop}] window."
+                )
+            medians.append(_quantile(values, 0.5))
+        window_medians.append(medians)
+    across_seeds = list(zip(*window_medians))
     return {
         "environment_steps": steps,
-        "median_return": returns.median(0).values.tolist(),
-        "lower_quartile_return": torch.quantile(returns, 0.25, dim=0).tolist(),
-        "upper_quartile_return": torch.quantile(returns, 0.75, dim=0).tolist(),
+        "median_return": [_quantile(window, 0.5) for window in across_seeds],
+        "lower_quartile_return": [_quantile(window, 0.25) for window in across_seeds],
+        "upper_quartile_return": [_quantile(window, 0.75) for window in across_seeds],
+        "per_seed_window_median": window_medians,
+        "window_size": window_size,
         "seeds": [run["seed"] for run in runs],
     }
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--seeds", type=int, nargs="+", default=[0, 1, 2])
     parser.add_argument("--output-dir", type=Path, default=Path("dmc_walker_runs"))
-    parser.add_argument("--minimum-final-return", type=float, default=700.0)
-    parser.add_argument("overrides", nargs="*")
+    parser.add_argument(
+        "overrides",
+        nargs="*",
+        help=(
+            "Hydra overrides for the example. Those under benchmark.* also "
+            f"override the {CONFIG_PATH.name} block this script reads."
+        ),
+    )
     args = parser.parse_args()
+
+    reject_reserved_overrides(args.overrides)
+    settings = benchmark_settings(args.overrides)
+    seeds = settings["seeds"]
+    window_size = settings["window_size"]
+    minimum_final_return = settings["minimum_final_median_return"]
+    validate_window_size(window_size, args.overrides)
 
     args.output_dir = args.output_dir.resolve()
     args.output_dir.mkdir(parents=True, exist_ok=True)
     script = Path(__file__).with_name("train.py")
     metrics_paths = []
-    for seed in args.seeds:
-        metrics_path = args.output_dir / f"seed_{seed}.json"
+    for seed in seeds:
+        metrics_jsonl_path = args.output_dir / f"seed_{seed}.jsonl"
         command = [
             sys.executable,
             str(script),
             "--config-name=config_dmc_walker",
             f"env.seed={seed}",
-            f"logger.metrics_json={metrics_path}",
+            f"logger.metrics_jsonl={metrics_jsonl_path}",
             "logger.output_plot=null",
             *args.overrides,
         ]
         torchrl_logger.info("Running DMC Walker seed %d", seed)
         subprocess.run(command, check=True)
-        metrics_paths.append(metrics_path)
+        metrics_paths.append(metrics_jsonl_path)
 
-    summary = aggregate_runs(metrics_paths)
+    summary = aggregate_runs(metrics_paths, window_size=window_size)
     summary_path = args.output_dir / "summary.json"
     summary_path.write_text(json.dumps(summary, indent=2) + "\n")
     final_median = summary["median_return"][-1]
-    if final_median < args.minimum_final_return:
+    if final_median < minimum_final_return:
         raise RuntimeError(
             "Final median DMC Walker return "
-            f"{final_median:.1f} is below {args.minimum_final_return:.1f}."
+            f"{final_median:.1f} is below {minimum_final_return:.1f}."
         )
     torchrl_logger.info(
         "Saved DMC Walker median/IQR curve to %s (final median %.1f)",

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -3,17 +3,22 @@ env:
   name: Pendulum-v1
   task: null
   seed: 0
+  use_seed: true
   max_episode_steps: 200
 
 collector:
+  num_envs: 1
   frames_per_batch: 200
   total_frames: 5000
+  count_reset_records: false
   exploration: random  # one of: random, mode
 
 replay_buffer:
+  device: cpu  # null keeps replay on the training device
   buffer_size: 10000
   batch_size: 16
   seq_len: 16
+  online: true
   warmup_factor: 2  # collect (warmup_factor * batch_size * seq_len) frames before training
 
 networks:
@@ -27,7 +32,9 @@ networks:
   prior_layers: 2
   posterior_layers: 1
   norm_eps: 1.0e-4
-  obs_embed_dim: 32
+  # Sizes of the per-observation decoder heads, summing to the observation
+  # size. null builds a single head over the whole observation.
+  decoder_event_dims: null
   num_reward_bins: 255
   num_value_bins: 255
   hidden_dim: 64
@@ -40,7 +47,10 @@ networks:
   policy_max_std: 1.0
 
 optimization:
-  device:            # training device (models, losses, policy). null=auto
+  device: null       # training device (models, losses, policy). null=auto
+  deferred_policy_sync: false
+  separate_policy_rng: false
+  mixed_precision: false
   lr: 4.0e-5
   adam_eps: 1.0e-20
   adaptive_grad_clip: 0.3
@@ -54,6 +64,7 @@ optimization:
   return_normalization_min_scale: 1.0
   slow_critic_regularization: 1.0
   slow_critic_tau: 0.02
+  replay_value_loss_weight: 0.3
   free_bits: 1.0
   dynamic_loss_weight: 1.0
   representation_loss_weight: 0.1
@@ -61,10 +72,11 @@ optimization:
   lmbda: 0.95
 
 logger:
+  train_every: 200
   eval_every: 500
   eval_episodes: 3
   output_plot: dreamer_v3_pendulum.png
-  metrics_json: null
+  metrics_jsonl: null
 
 hydra:
   job:

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -51,6 +51,9 @@ optimization:
   deferred_policy_sync: false
   separate_policy_rng: false
   mixed_precision: false
+  # Compile the RSSM recurrence: null, "step" or "scan". "scan" is faster but
+  # changes the random stream; see the README.
+  compile_rssm: null
   lr: 4.0e-5
   adam_eps: 1.0e-20
   adaptive_grad_clip: 0.3

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -54,6 +54,8 @@ optimization:
   # Compile the RSSM recurrence: null, "step" or "scan". "scan" is faster but
   # changes the random stream; see the README.
   compile_rssm: null
+  # Number of RSSM steps traced per higher-order scan iteration.
+  rssm_scan_unroll: 8
   lr: 4.0e-5
   optimizer_eps: 1.0e-20
   adaptive_grad_clip: 0.3

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -55,7 +55,7 @@ optimization:
   # changes the random stream; see the README.
   compile_rssm: null
   lr: 4.0e-5
-  adam_eps: 1.0e-20
+  optimizer_eps: 1.0e-20
   adaptive_grad_clip: 0.3
   warmup_steps: 1000
   updates_per_batch: 8

--- a/sota-implementations/dreamer_v3/config_dmc_walker.yaml
+++ b/sota-implementations/dreamer_v3/config_dmc_walker.yaml
@@ -9,32 +9,51 @@ env:
   max_episode_steps: 1000
 
 collector:
-  frames_per_batch: 1000
+  num_envs: 16
+  frames_per_batch: 16
+  # Match the reference implementation's driver counter, which includes
+  # initial and reset-only records.
+  count_reset_records: true
   total_frames: 1100000
 
 replay_buffer:
+  # Keep sampled sequences and latent-context refreshes on the learner device.
+  device: null
   buffer_size: 5000000
   batch_size: 16
   seq_len: 64
-  warmup_factor: 1
+  online: true
+  # Warmup gates on 65-record windows, so 128 records per stream gives 1024.
+  warmup_factor: 2
 
 networks:
   rnn_hidden_dim: 512
   num_categoricals: 32
   num_classes: 4
-  obs_embed_dim: 64
+  # The walker observation keys in sorted order: height, orientations,
+  # velocity.
+  decoder_event_dims: [1, 14, 9]
   hidden_dim: 64
 
 optimization:
-  updates_per_batch: 1
+  deferred_policy_sync: true
+  separate_policy_rng: true
+  mixed_precision: true
   train_ratio: 1024
 
 logger:
+  # Approximately the reference's 120-second learner logging cadence.
+  train_every: 4096
+  # The reference curve uses the stochastic train_episode returns; the
+  # evaluator adds a deterministic return on a separate environment.
   eval_every: 10000
   eval_episodes: 5
   output_plot: dreamer_v3_dmc_walker.png
-  metrics_json: dreamer_v3_dmc_walker.json
+  metrics_jsonl: dreamer_v3_dmc_walker.jsonl
 
+# Read by benchmark.py: the seeds it runs, the window it aggregates over, and
+# the final-window median it requires. Hydra overrides of this block win.
 benchmark:
   seeds: [0, 1, 2]
-  minimum_final_median_return: 700.0
+  minimum_final_median_return: 900.0
+  window_size: 50000

--- a/sota-implementations/dreamer_v3/config_dmc_walker.yaml
+++ b/sota-implementations/dreamer_v3/config_dmc_walker.yaml
@@ -11,7 +11,7 @@ env:
 collector:
   num_envs: 16
   frames_per_batch: 16
-  # Match the reference implementation's driver counter, which includes
+  # Match the pinned JAX implementation's driver counter, which includes
   # initial and reset-only records.
   count_reset_records: true
   total_frames: 1100000
@@ -42,9 +42,9 @@ optimization:
   train_ratio: 1024
 
 logger:
-  # Approximately the reference's 120-second learner logging cadence.
+  # Approximately the JAX implementation's 120-second learner logging cadence.
   train_every: 4096
-  # The reference curve uses the stochastic train_episode returns; the
+  # The JAX curve uses the stochastic train_episode returns; the
   # evaluator adds a deterministic return on a separate environment.
   eval_every: 10000
   eval_episodes: 5

--- a/sota-implementations/dreamer_v3/dreamer_v3_agent.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_agent.py
@@ -510,6 +510,8 @@ def build_world_model(
     # Only the reset record of an episode has is_init set, thus a sampled
     # window can cross an episode boundary.
     rollout = RSSMRolloutV3(rssm_prior, rssm_posterior, reset_key="is_init")
+    if cfg.optimization.compile_rssm:
+        rollout.compile_rollout(cfg.optimization.compile_rssm)
 
     decoder_event_dims = tuple(cfg.networks.decoder_event_dims or (obs_dim,))
     if sum(decoder_event_dims) != obs_dim:
@@ -591,11 +593,15 @@ def build_imagination_model(
     prior_net: RSSMPriorV3,
     reward_net: DreamerV3MLP,
     reward_decoder: SymExpTwoHot,
+    compile_prior: bool = False,
 ) -> WorldModelWrapper:
-    """Build the imagination model from the trained world-model modules."""
+    """Build the imagination model from the trained world-model modules.
+
+    ``compile_prior`` compiles the prior here only, not in the shared rollout.
+    """
     transition_model = TensorDictSequential(
         TensorDictModule(
-            prior_net,
+            torch.compile(prior_net, dynamic=False) if compile_prior else prior_net,
             in_keys=["state", "belief", "action"],
             out_keys=["_", "state", "belief"],
         )

--- a/sota-implementations/dreamer_v3/dreamer_v3_agent.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_agent.py
@@ -65,7 +65,7 @@ class _DreamerV3Decoder(torch.nn.Module):
         cfg: DictConfig,
         input_dim: int,
         event_dims: tuple[int, ...],
-    ) -> None:
+    ):
         super().__init__()
         if not event_dims or any(size <= 0 for size in event_dims):
             raise ValueError(
@@ -89,7 +89,7 @@ class _DreamerV3Decoder(torch.nn.Module):
 
 
 class _DreamerV3Actor(torch.nn.Module):
-    def __init__(self, cfg: DictConfig, action_dim: int) -> None:
+    def __init__(self, cfg: DictConfig, action_dim: int):
         super().__init__()
         state_dim = latent_state_dim(cfg)
         self.backbone = DreamerV3MLP(
@@ -128,7 +128,7 @@ class _DreamerV3PolicyFilter(torch.nn.Module):
         self,
         prior_net: torch.nn.Module,
         posterior_net: torch.nn.Module,
-    ) -> None:
+    ):
         super().__init__()
         self.prior_net = prior_net
         self.posterior_net = posterior_net
@@ -167,7 +167,7 @@ class _DreamerV3PolicyCarry(torch.nn.Module):
 class _DreamerV3AutocastPolicy(TensorDictModuleBase):
     """Run the real-environment policy in BF16 on CUDA devices."""
 
-    def __init__(self, module: TensorDictModuleBase, enabled: bool) -> None:
+    def __init__(self, module: TensorDictModuleBase, enabled: bool):
         super().__init__()
         self.module = module
         self.enabled = enabled
@@ -195,7 +195,7 @@ class DreamerV3BehaviorPolicySync:
         self,
         learner_policy: torch.nn.Module,
         behavior_policy: torch.nn.Module,
-    ) -> None:
+    ):
         self._learner_policy = learner_policy
         self._behavior_policy = behavior_policy
         learner_parameters = tuple(learner_policy.named_parameters())
@@ -246,7 +246,7 @@ class DreamerV3BehaviorPolicySync:
 class DreamerV3SeededPolicy(TensorDictModuleBase):
     """Give the policy its own random stream, with a new seed for each call."""
 
-    def __init__(self, module: TensorDictModuleBase, seed: int) -> None:
+    def __init__(self, module: TensorDictModuleBase, seed: int):
         super().__init__()
         self.module = module
         self.seed = seed
@@ -289,7 +289,7 @@ class DreamerV3Optimizer(torch.optim.Optimizer):
         beta2: float = 0.999,
         eps: float = 1e-20,
         warmup_steps: int = 1000,
-    ) -> None:
+    ):
         super().__init__(
             parameters,
             {

--- a/sota-implementations/dreamer_v3/dreamer_v3_agent.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_agent.py
@@ -511,7 +511,14 @@ def build_world_model(
     # window can cross an episode boundary.
     rollout = RSSMRolloutV3(rssm_prior, rssm_posterior, reset_key="is_init")
     if cfg.optimization.compile_rssm:
-        rollout.compile_rollout(cfg.optimization.compile_rssm)
+        rollout.compile_rollout(
+            cfg.optimization.compile_rssm,
+            unroll=(
+                cfg.optimization.rssm_scan_unroll
+                if cfg.optimization.compile_rssm == "scan"
+                else 1
+            ),
+        )
 
     decoder_event_dims = tuple(cfg.networks.decoder_event_dims or (obs_dim,))
     if sum(decoder_event_dims) != obs_dim:

--- a/sota-implementations/dreamer_v3/dreamer_v3_agent.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_agent.py
@@ -1,0 +1,759 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""The DreamerV3 networks, acting policy, optimizer and builders."""
+from __future__ import annotations
+
+import importlib.util
+from collections.abc import Callable, Iterable
+
+import torch
+from dreamer_v3_utils import latent_state_dim, POLICY_RNG_STREAM, stream_seed
+from omegaconf import DictConfig
+from tensordict import TensorDictBase
+from tensordict.nn import (
+    InteractionType,
+    ProbabilisticTensorDictModule,
+    ProbabilisticTensorDictSequential,
+    TensorDictModule,
+    TensorDictModuleBase,
+    TensorDictSequential,
+)
+from tensordict.utils import NestedKey
+
+from torchrl.data import Unbounded
+from torchrl.envs import EnvBase, StepCounter, TransformedEnv
+from torchrl.envs.libs.gym import GymEnv
+from torchrl.envs.model_based.dreamer import DreamerEnv
+from torchrl.envs.transforms import (
+    CatTensors,
+    ClipTransform,
+    DoubleToFloat,
+    InitTracker,
+    TensorDictPrimer,
+)
+from torchrl.modules import DreamerV3MLP, SymExpTwoHot, WorldModelWrapper
+from torchrl.modules.distributions.continuous import IndependentNormal
+from torchrl.modules.models.model_based_v3 import (
+    _dreamer_v3_init,
+    RSSMPosteriorV3,
+    RSSMPriorV3,
+    RSSMRolloutV3,
+)
+from torchrl.objectives import symexp, symlog
+
+_has_dm_control = importlib.util.find_spec("dm_control") is not None
+
+
+def _to_float(value: torch.Tensor) -> torch.Tensor:
+    return value.float()
+
+
+def _cast_float(key: NestedKey) -> TensorDictModule:
+    return TensorDictModule(_to_float, in_keys=[key], out_keys=[key])
+
+
+# --- Networks and the acting policy ---
+
+
+class _DreamerV3Decoder(torch.nn.Module):
+    """A shared trunk with one head for each observation event."""
+
+    def __init__(
+        self,
+        cfg: DictConfig,
+        input_dim: int,
+        event_dims: tuple[int, ...],
+    ) -> None:
+        super().__init__()
+        if not event_dims or any(size <= 0 for size in event_dims):
+            raise ValueError(
+                f"Decoder event dimensions must be positive: {event_dims}."
+            )
+        self.backbone = DreamerV3MLP(
+            input_dim,
+            None,
+            depth=cfg.networks.decoder_layers,
+            num_cells=cfg.networks.hidden_dim,
+            norm_eps=cfg.networks.norm_eps,
+        )
+        self.output_heads = torch.nn.ModuleList(
+            torch.nn.Linear(cfg.networks.hidden_dim, size) for size in event_dims
+        )
+        self.output_heads.apply(_dreamer_v3_init)
+
+    def forward(self, state: torch.Tensor, belief: torch.Tensor) -> torch.Tensor:
+        hidden = self.backbone(state, belief)
+        return torch.cat(tuple(head(hidden) for head in self.output_heads), -1)
+
+
+class _DreamerV3Actor(torch.nn.Module):
+    def __init__(self, cfg: DictConfig, action_dim: int) -> None:
+        super().__init__()
+        state_dim = latent_state_dim(cfg)
+        self.backbone = DreamerV3MLP(
+            state_dim + cfg.networks.rnn_hidden_dim,
+            None,
+            depth=cfg.networks.actor_layers,
+            num_cells=cfg.networks.hidden_dim,
+            norm_eps=cfg.networks.norm_eps,
+        )
+        self.mean_head = torch.nn.Linear(cfg.networks.hidden_dim, action_dim)
+        self.std_head = torch.nn.Linear(cfg.networks.hidden_dim, action_dim)
+        self.mean_head.apply(_dreamer_v3_init)
+        self.std_head.apply(_dreamer_v3_init)
+        with torch.no_grad():
+            self.mean_head.weight.mul_(0.01)
+            self.std_head.weight.mul_(0.01)
+        self.action_dim = action_dim
+        self.min_std = cfg.networks.policy_min_std
+        self.max_std = cfg.networks.policy_max_std
+
+    def forward(
+        self, state: torch.Tensor, belief: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # Belief before state, unlike the decoder. The order is deliberate.
+        hidden = self.backbone(belief, state)
+        mean = self.mean_head(hidden)
+        std = self.std_head(hidden)
+        mean = mean.tanh()
+        std = (self.max_std - self.min_std) * torch.sigmoid(std + 2) + self.min_std
+        # The Normal parameters stay FP32, also under BF16 autocast.
+        return mean.float(), std.float()
+
+
+class _DreamerV3PolicyFilter(torch.nn.Module):
+    def __init__(
+        self,
+        prior_net: torch.nn.Module,
+        posterior_net: torch.nn.Module,
+    ) -> None:
+        super().__init__()
+        self.prior_net = prior_net
+        self.posterior_net = posterior_net
+
+    def forward(
+        self,
+        state: torch.Tensor,
+        belief: torch.Tensor,
+        previous_action: torch.Tensor,
+        encoded_latents: torch.Tensor,
+        is_init: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        reset = is_init
+        while reset.ndim < state.ndim:
+            reset = reset.unsqueeze(-1)
+        state = torch.where(reset, 0, state)
+        belief = torch.where(reset, 0, belief)
+        previous_action = torch.where(reset, 0, previous_action)
+        # Advance the recurrence only. The posterior reads the observation.
+        belief = self.prior_net._update_belief(state, belief, previous_action)
+        _, state = self.posterior_net(belief, encoded_latents)
+        # The collector and the replay entries use FP32.
+        return state.float(), belief.float()
+
+
+class _DreamerV3PolicyCarry(torch.nn.Module):
+    def forward(
+        self,
+        state: torch.Tensor,
+        belief: torch.Tensor,
+        action: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return state.float(), belief.float(), action.float()
+
+
+class _DreamerV3AutocastPolicy(TensorDictModuleBase):
+    """Run the real-environment policy in BF16 on CUDA devices."""
+
+    def __init__(self, module: TensorDictModuleBase, enabled: bool) -> None:
+        super().__init__()
+        self.module = module
+        self.enabled = enabled
+        self.in_keys = module.in_keys
+        self.out_keys = module.out_keys
+
+    def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
+        state = tensordict.get("state")
+        with torch.autocast(
+            device_type=state.device.type,
+            dtype=torch.bfloat16,
+            enabled=self.enabled and state.device.type == "cuda",
+        ):
+            return self.module(tensordict)
+
+
+class DreamerV3BehaviorPolicySync:
+    """Give the behavior policy the learner parameters after the next action.
+
+    The snapshot comes from before the first update. Later updates do not
+    replace it.
+    """
+
+    def __init__(
+        self,
+        learner_policy: torch.nn.Module,
+        behavior_policy: torch.nn.Module,
+    ) -> None:
+        self._learner_policy = learner_policy
+        self._behavior_policy = behavior_policy
+        learner_parameters = tuple(learner_policy.named_parameters())
+        behavior_parameters = tuple(behavior_policy.named_parameters())
+        learner_names = tuple(name for name, _ in learner_parameters)
+        behavior_names = tuple(name for name, _ in behavior_parameters)
+        if learner_names != behavior_names:
+            raise RuntimeError(
+                "Learner and behavior policies must have identical parameter trees."
+            )
+        self._learner_parameters = tuple(
+            parameter for _, parameter in learner_parameters
+        )
+        self._behavior_parameters = tuple(
+            parameter for _, parameter in behavior_parameters
+        )
+        if any(
+            learner.shape != behavior.shape
+            for learner, behavior in zip(
+                self._learner_parameters, self._behavior_parameters
+            )
+        ):
+            raise RuntimeError(
+                "Learner and behavior policy parameter shapes must be identical."
+            )
+        self._pending: tuple[torch.Tensor, ...] | None = None
+
+    @property
+    def has_pending(self) -> bool:
+        return self._pending is not None
+
+    @torch.no_grad()
+    def stage_before_training(self) -> None:
+        if self._pending is None:
+            self._pending = tuple(
+                parameter.detach().clone() for parameter in self._learner_parameters
+            )
+
+    @torch.no_grad()
+    def apply_after_action(self) -> None:
+        if self._pending is None:
+            return
+        for target, source in zip(self._behavior_parameters, self._pending):
+            target.copy_(source)
+        self._pending = None
+
+
+class DreamerV3SeededPolicy(TensorDictModuleBase):
+    """Give the policy its own random stream, with a new seed for each call."""
+
+    def __init__(self, module: TensorDictModuleBase, seed: int) -> None:
+        super().__init__()
+        self.module = module
+        self.seed = seed
+        self.counter = 0
+        self.in_keys = module.in_keys
+        self.out_keys = module.out_keys
+
+    def reset_counter(self) -> None:
+        """Restart the counter, because a setup call can move it before step 0."""
+        self.counter = 0
+
+    def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
+        reference = tensordict.get("state", None)
+        if reference is None:
+            reference = tensordict.get(self.in_keys[0])
+        devices = [reference.device] if reference.device.type == "cuda" else []
+        with torch.random.fork_rng(devices=devices):
+            torch.manual_seed(stream_seed(self.seed, self.counter, POLICY_RNG_STREAM))
+            self.counter += 1
+            return self.module(tensordict)
+
+
+# --- Optimizer ---
+
+
+class DreamerV3Optimizer(torch.optim.Optimizer):
+    """The DreamerV3 optimizer: AGC, RMS scaling, momentum and warmup.
+
+    AGC clips each gradient to the ``agc`` fraction of its parameter norm.
+    """
+
+    def __init__(
+        self,
+        parameters: Iterable[torch.nn.Parameter],
+        *,
+        lr: float = 4e-5,
+        agc: float = 0.3,
+        parameter_norm_min: float = 1e-3,
+        beta1: float = 0.9,
+        beta2: float = 0.999,
+        eps: float = 1e-20,
+        warmup_steps: int = 1000,
+    ) -> None:
+        super().__init__(
+            parameters,
+            {
+                "lr": lr,
+                "agc": agc,
+                "parameter_norm_min": parameter_norm_min,
+                "beta1": beta1,
+                "beta2": beta2,
+                "eps": eps,
+                "warmup_steps": warmup_steps,
+                "step": 0,
+            },
+        )
+
+    @torch.no_grad()
+    def step(self, closure: Callable[[], torch.Tensor] | None = None) -> None:
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            group["step"] += 1
+            step = group["step"]
+            warmup_steps = group["warmup_steps"]
+            schedule_step = step - 1
+            warmup = min(1.0, schedule_step / warmup_steps) if warmup_steps else 1.0
+            learning_rate = group["lr"] * warmup
+
+            # Group by device and dtype for the multi-tensor kernels.
+            buckets: dict[
+                tuple[torch.device, torch.dtype], list[torch.nn.Parameter]
+            ] = {}
+            for parameter in group["params"]:
+                if parameter.grad is not None:
+                    buckets.setdefault((parameter.device, parameter.dtype), []).append(
+                        parameter
+                    )
+
+            for parameters in buckets.values():
+                gradients = [parameter.grad.float() for parameter in parameters]
+                if group["agc"]:
+                    gradient_norms = list(torch._foreach_norm(gradients))
+                    parameter_norms = list(
+                        torch._foreach_norm(
+                            [parameter.detach().float() for parameter in parameters]
+                        )
+                    )
+                    torch._foreach_clamp_min_(
+                        parameter_norms, group["parameter_norm_min"]
+                    )
+                    maximum_norms = torch._foreach_mul(parameter_norms, group["agc"])
+                    gradient_denominators = torch._foreach_maximum(
+                        gradient_norms, maximum_norms
+                    )
+                    gradient_scales = torch._foreach_div(
+                        maximum_norms, gradient_denominators
+                    )
+                    gradients = list(torch._foreach_mul(gradients, gradient_scales))
+
+                rms = []
+                momentum = []
+                for parameter in parameters:
+                    state = self.state[parameter]
+                    if not state:
+                        state["rms"] = torch.zeros_like(parameter, dtype=torch.float32)
+                        state["momentum"] = torch.zeros_like(
+                            parameter, dtype=torch.float32
+                        )
+                    rms.append(state["rms"])
+                    momentum.append(state["momentum"])
+                beta1 = group["beta1"]
+                beta2 = group["beta2"]
+                torch._foreach_mul_(rms, beta2)
+                torch._foreach_addcmul_(rms, gradients, gradients, value=1 - beta2)
+                rms_hat = torch._foreach_div(rms, 1 - beta2**step)
+                rms_denominator = torch._foreach_sqrt(rms_hat)
+                torch._foreach_add_(rms_denominator, group["eps"])
+                normalized = torch._foreach_div(gradients, rms_denominator)
+                torch._foreach_mul_(momentum, beta1)
+                torch._foreach_add_(momentum, normalized, alpha=1 - beta1)
+                momentum_hat = torch._foreach_div(momentum, 1 - beta1**step)
+                if parameters[0].dtype != torch.float32:
+                    momentum_hat = [
+                        update.to(parameter.dtype)
+                        for update, parameter in zip(momentum_hat, parameters)
+                    ]
+                torch._foreach_add_(parameters, momentum_hat, alpha=-learning_rate)
+        return loss
+
+
+# --- Builders ---
+
+
+def make_env(cfg: DictConfig, seed: int | None = 0) -> TransformedEnv:
+    if cfg.env.backend == "gym":
+        base_env = GymEnv(cfg.env.name, device="cpu")
+    elif cfg.env.backend == "dm_control":
+        if not _has_dm_control:
+            raise ImportError(
+                "The DMC DreamerV3 preset requires dm_control. Install the "
+                "optional dm_control dependencies before running it."
+            )
+        from torchrl.envs.libs.dm_control import DMControlEnv  # noqa: PLC0415
+
+        # Seed at construction: set_seed() also resets, which moves the stream.
+        base_env = DMControlEnv(
+            cfg.env.name,
+            cfg.env.task,
+            device="cpu",
+            _seed=seed if cfg.env.use_seed else None,
+        )
+    else:
+        raise ValueError(f"Unknown environment backend {cfg.env.backend!r}.")
+
+    env = TransformedEnv(base_env)
+    if cfg.env.backend == "dm_control":
+        env.append_transform(
+            CatTensors(
+                # The encoder reads the keys in sorted order.
+                in_keys=sorted(base_env.observation_spec.keys()),
+                out_key="observation",
+            )
+        )
+        # The env gets the clipped action. The buffer keeps the raw sample.
+        env.append_transform(ClipTransform(in_keys_inv=["action"], low=-1.0, high=1.0))
+    env.append_transform(DoubleToFloat())
+    env.append_transform(StepCounter(max_steps=cfg.env.max_episode_steps))
+    env.append_transform(InitTracker())
+    if cfg.env.backend != "dm_control" and cfg.env.use_seed:
+        env.set_seed(seed)
+    return env
+
+
+def make_primed_env(
+    cfg: DictConfig, seed: int | None, state_dim: int, action_dim: int
+) -> TransformedEnv:
+    """Build an environment primed with latent, belief and previous action."""
+    return TransformedEnv(
+        make_env(cfg, seed),
+        TensorDictPrimer(
+            random=False,
+            default_value=0,
+            state=Unbounded(state_dim),
+            belief=Unbounded(cfg.networks.rnn_hidden_dim),
+            previous_action=Unbounded(action_dim),
+        ),
+    )
+
+
+def build_world_model(
+    *, cfg: DictConfig, obs_dim: int, action_dim: int
+) -> tuple[TensorDictSequential, RSSMPriorV3, DreamerV3MLP, SymExpTwoHot, DreamerV3MLP]:
+    """Build the world model: encoder, RSSM rollout, decoder and two heads."""
+    state_dim = latent_state_dim(cfg)
+
+    encoder = TensorDictSequential(
+        TensorDictModule(
+            symlog,
+            in_keys=[("next", "observation")],
+            out_keys=[("next", "symlog_observation")],
+        ),
+        TensorDictModule(
+            DreamerV3MLP(
+                in_features=obs_dim,
+                # The output is the last hidden activation, with no projection.
+                out_features=None,
+                depth=cfg.networks.encoder_layers,
+                num_cells=cfg.networks.hidden_dim,
+                norm_eps=cfg.networks.norm_eps,
+            ),
+            in_keys=[("next", "symlog_observation")],
+            out_keys=[("next", "encoded_latents")],
+        ),
+    )
+
+    prior_net = RSSMPriorV3(
+        action_shape=torch.Size([action_dim]),
+        hidden_dim=cfg.networks.hidden_dim,
+        rnn_hidden_dim=cfg.networks.rnn_hidden_dim,
+        num_categoricals=cfg.networks.num_categoricals,
+        num_classes=cfg.networks.num_classes,
+        action_dim=action_dim,
+        unimix=cfg.networks.unimix,
+        recurrent_model=cfg.networks.recurrent_model,
+        num_blocks=cfg.networks.num_blocks,
+        num_layers=cfg.networks.dynamics_layers,
+        prior_num_layers=cfg.networks.prior_layers,
+        norm_eps=cfg.networks.norm_eps,
+    )
+    rssm_prior = TensorDictModule(
+        prior_net,
+        in_keys=["state", "belief", "action"],
+        out_keys=[
+            ("next", "prior_logits"),
+            ("next", "state"),
+            ("next", "belief"),
+        ],
+    )
+
+    posterior_net = RSSMPosteriorV3(
+        hidden_dim=cfg.networks.hidden_dim,
+        num_categoricals=cfg.networks.num_categoricals,
+        num_classes=cfg.networks.num_classes,
+        rnn_hidden_dim=cfg.networks.rnn_hidden_dim,
+        obs_embed_dim=cfg.networks.hidden_dim,
+        unimix=cfg.networks.unimix,
+        use_rms_norm=True,
+        num_layers=cfg.networks.posterior_layers,
+        norm_eps=cfg.networks.norm_eps,
+    )
+    rssm_posterior = TensorDictModule(
+        posterior_net,
+        in_keys=[("next", "belief"), ("next", "encoded_latents")],
+        out_keys=[("next", "posterior_logits"), ("next", "state")],
+    )
+
+    # Only the reset record of an episode has is_init set, thus a sampled
+    # window can cross an episode boundary.
+    rollout = RSSMRolloutV3(rssm_prior, rssm_posterior, reset_key="is_init")
+
+    decoder_event_dims = tuple(cfg.networks.decoder_event_dims or (obs_dim,))
+    if sum(decoder_event_dims) != obs_dim:
+        raise ValueError(
+            "Decoder event dimensions must sum to the flattened observation "
+            f"size, got {decoder_event_dims} for {obs_dim}."
+        )
+    # One head for each event: AGC clips each head separately, thus a merged
+    # head trains differently. The FP32 symexp keeps the loss symlog exact.
+    decoder = TensorDictSequential(
+        TensorDictModule(
+            _DreamerV3Decoder(
+                cfg,
+                state_dim + cfg.networks.rnn_hidden_dim,
+                decoder_event_dims,
+            ),
+            in_keys=[("next", "state"), ("next", "belief")],
+            out_keys=[("next", "reco_symlog_observation")],
+        ),
+        _cast_float(("next", "reco_symlog_observation")),
+        TensorDictModule(
+            symexp,
+            in_keys=[("next", "reco_symlog_observation")],
+            out_keys=[("next", "reco_pixels")],
+        ),
+    )
+
+    reward_net = DreamerV3MLP(
+        in_features=state_dim + cfg.networks.rnn_hidden_dim,
+        out_features=cfg.networks.num_reward_bins,
+        depth=cfg.networks.reward_layers,
+        num_cells=cfg.networks.hidden_dim,
+        outscale=0.0,
+        norm_eps=cfg.networks.norm_eps,
+    )
+    reward_decoder = SymExpTwoHot(cfg.networks.num_reward_bins)
+    reward_head = TensorDictSequential(
+        TensorDictModule(
+            reward_net,
+            in_keys=[("next", "belief"), ("next", "state")],
+            out_keys=[("next", "reward_logits")],
+        ),
+        TensorDictModule(
+            _to_float,
+            in_keys=[("next", "reward_logits")],
+            out_keys=[("next", "reward_logits")],
+        ),
+        TensorDictModule(
+            reward_decoder,
+            in_keys=[("next", "reward_logits")],
+            out_keys=[("next", "reward")],
+        ),
+    )
+
+    continuation_net = DreamerV3MLP(
+        in_features=state_dim + cfg.networks.rnn_hidden_dim,
+        out_features=1,
+        depth=cfg.networks.reward_layers,
+        num_cells=cfg.networks.hidden_dim,
+        norm_eps=cfg.networks.norm_eps,
+    )
+    continuation_head = TensorDictSequential(
+        TensorDictModule(
+            continuation_net,
+            in_keys=[("next", "belief"), ("next", "state")],
+            out_keys=[("next", "continue_pred")],
+        ),
+        _cast_float(("next", "continue_pred")),
+    )
+
+    world_model = TensorDictSequential(
+        encoder, rollout, decoder, reward_head, continuation_head
+    )
+    return world_model, prior_net, reward_net, reward_decoder, continuation_net
+
+
+def build_imagination_model(
+    *,
+    prior_net: RSSMPriorV3,
+    reward_net: DreamerV3MLP,
+    reward_decoder: SymExpTwoHot,
+) -> WorldModelWrapper:
+    """Build the imagination model from the trained world-model modules."""
+    transition_model = TensorDictSequential(
+        TensorDictModule(
+            prior_net,
+            in_keys=["state", "belief", "action"],
+            out_keys=["_", "state", "belief"],
+        )
+    )
+    reward_model = TensorDictSequential(
+        TensorDictModule(
+            reward_net,
+            in_keys=["belief", "state"],
+            out_keys=["reward_logits"],
+        ),
+        _cast_float("reward_logits"),
+        TensorDictModule(
+            reward_decoder,
+            in_keys=["reward_logits"],
+            out_keys=["reward"],
+        ),
+    )
+    return WorldModelWrapper(transition_model, reward_model)
+
+
+def build_continuation_model(*, continuation_net: DreamerV3MLP) -> TensorDictSequential:
+    return TensorDictSequential(
+        TensorDictModule(
+            continuation_net,
+            in_keys=["belief", "state"],
+            out_keys=["continue_logits"],
+        ),
+        _cast_float("continue_logits"),
+        TensorDictModule(
+            torch.nn.Sigmoid(),
+            in_keys=["continue_logits"],
+            out_keys=["continuation"],
+        ),
+    )
+
+
+def build_actor(
+    *, cfg: DictConfig, action_dim: int
+) -> ProbabilisticTensorDictSequential:
+    actor_mlp = _DreamerV3Actor(cfg, action_dim)
+    actor_model = ProbabilisticTensorDictSequential(
+        TensorDictModule(
+            actor_mlp,
+            in_keys=["state", "belief"],
+            out_keys=["loc", "scale"],
+        ),
+        ProbabilisticTensorDictModule(
+            in_keys=["loc", "scale"],
+            out_keys=["action"],
+            default_interaction_type=InteractionType.RANDOM,
+            distribution_class=IndependentNormal,
+            return_log_prob=True,
+            log_prob_key="action_log_prob",
+        ),
+    )
+    return actor_model
+
+
+def build_real_world_actor(
+    *,
+    world_model: TensorDictSequential,
+    actor_model: ProbabilisticTensorDictSequential,
+    mixed_precision: bool = False,
+) -> TensorDictModuleBase:
+    """Build the recurrent policy that acts in the real environment.
+
+    The policy shares the trained encoder, prior, posterior and actor.
+    """
+    encoder_net = world_model[0][1].module
+    rssm_rollout = world_model[1]
+    prior_net = rssm_rollout.rssm_prior.module
+    posterior_net = rssm_rollout.rssm_posterior.module
+    policy = TensorDictSequential(
+        TensorDictModule(
+            symlog,
+            in_keys=["observation"],
+            out_keys=["symlog_observation"],
+        ),
+        TensorDictModule(
+            encoder_net,
+            in_keys=["symlog_observation"],
+            out_keys=["encoded_latents"],
+        ),
+        TensorDictModule(
+            _DreamerV3PolicyFilter(prior_net, posterior_net),
+            in_keys=[
+                "state",
+                "belief",
+                "previous_action",
+                "encoded_latents",
+                "is_init",
+            ],
+            out_keys=["state", "belief"],
+        ),
+        actor_model,
+        TensorDictModule(
+            _DreamerV3PolicyCarry(),
+            in_keys=["state", "belief", "action"],
+            out_keys=[
+                ("next", "state"),
+                ("next", "belief"),
+                ("next", "previous_action"),
+            ],
+        ),
+    )
+    return _DreamerV3AutocastPolicy(policy, enabled=mixed_precision)
+
+
+def build_value(*, cfg: DictConfig) -> TensorDictSequential:
+    state_dim = latent_state_dim(cfg)
+    value_model = TensorDictSequential(
+        TensorDictModule(
+            DreamerV3MLP(
+                in_features=state_dim + cfg.networks.rnn_hidden_dim,
+                out_features=cfg.networks.num_value_bins,
+                depth=cfg.networks.value_layers,
+                num_cells=cfg.networks.hidden_dim,
+                outscale=0.0,
+                norm_eps=cfg.networks.norm_eps,
+            ),
+            in_keys=["belief", "state"],
+            out_keys=["state_value_logits"],
+        ),
+        _cast_float("state_value_logits"),
+        TensorDictModule(
+            SymExpTwoHot(cfg.networks.num_value_bins),
+            in_keys=["state_value_logits"],
+            out_keys=["state_value"],
+        ),
+    )
+    return value_model
+
+
+def build_mb_env(
+    *,
+    cfg: DictConfig,
+    real_env: EnvBase,
+    imagination_model: WorldModelWrapper,
+    device: torch.device,
+) -> DreamerEnv:
+    """Build the imagination environment from the trained world model."""
+    state_dim = latent_state_dim(cfg)
+    primer_env = TransformedEnv(
+        real_env,
+        TensorDictPrimer(
+            random=False,
+            default_value=0,
+            state=Unbounded(state_dim),
+            belief=Unbounded(cfg.networks.rnn_hidden_dim),
+        ),
+    )
+    mb_env = DreamerEnv(
+        world_model=imagination_model,
+        prior_shape=torch.Size([state_dim]),
+        belief_shape=torch.Size([cfg.networks.rnn_hidden_dim]),
+        device=device,
+    )
+    mb_env.set_specs_from_env(primer_env)
+    with torch.no_grad():
+        mb_env.rollout(3)
+    return mb_env

--- a/sota-implementations/dreamer_v3/dreamer_v3_replay.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_replay.py
@@ -1,0 +1,484 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Driver-step accounting and the continuous replay stream of the example."""
+from __future__ import annotations
+
+from typing import TypeAlias
+
+import torch
+from tensordict import TensorDictBase
+
+from torchrl.data import LazyTensorStorage, ReplayBuffer, SliceSampler
+
+ReplayIndex: TypeAlias = torch.Tensor | tuple[torch.Tensor, ...]
+ReplaySampleInfo: TypeAlias = dict[str, ReplayIndex]
+_REPLAY_CONTEXT_VALID_KEY = ("collector", "context_valid")
+
+
+# --- Driver step accounting --------------------------------------------------
+
+
+def driver_step_for_action(
+    action_index: int,
+    env_index: int,
+    num_envs: int,
+    max_episode_steps: int,
+) -> int:
+    """Return the driver step of a one-based action index, with reset records."""
+    reset_records = 1 + (action_index - 1) // max_episode_steps
+    vector_record = action_index + reset_records
+    return (vector_record - 1) * num_envs + env_index + 1
+
+
+def collector_action_budget(
+    record_budget: int,
+    num_envs: int,
+    max_episode_steps: int,
+) -> int:
+    """Return the actions in a driver-record budget that also holds resets."""
+    if record_budget % num_envs:
+        raise ValueError(
+            "A driver-record budget must be divisible by the number of "
+            f"environments, got {record_budget} and {num_envs}."
+        )
+    vector_records = record_budget // num_envs
+    reset_records = (vector_records + max_episode_steps) // (max_episode_steps + 1)
+    return (vector_records - reset_records) * num_envs
+
+
+class DreamerV3UpdateRatio:
+    """Schedule learner updates from a ratio of updates to driver records.
+
+    Each call truncates the count from the cumulative driver-record count and
+    keeps the remainder. The first call returns one update.
+
+    Args:
+        ratio (float): Learner updates for each driver record.
+    """
+
+    def __init__(self, ratio: float) -> None:
+        self.ratio = ratio
+        self._previous: float | None = None
+
+    def __call__(self, record_count: int) -> int:
+        if self.ratio <= 0:
+            return 0
+        if self._previous is None:
+            self._previous = float(record_count)
+            return 1
+        repeats = int((record_count - self._previous) * self.ratio)
+        self._previous += repeats / self.ratio
+        return repeats
+
+
+# --- Replay: record stream, writeback, sampling ------------------------------
+
+
+def _refresh_replay_context(
+    replay_buffer: ReplayBuffer,
+    sample_indices: ReplayIndex,
+    sample_generations: torch.Tensor,
+    state: torch.Tensor,
+    belief: torch.Tensor,
+) -> None:
+    if not isinstance(sample_indices, tuple):
+        sample_indices = (sample_indices,)
+    batch_size, sequence_length = state.shape[:2]
+    context_length = sequence_length + 1
+    destination_indices = tuple(
+        index.reshape(batch_size, context_length)[:, 1:].reshape(-1)
+        for index in sample_indices
+    )
+    destination_generation = sample_generations.reshape(batch_size, context_length)[
+        :, 1:
+    ].reshape(-1)
+    # Slices overlap, and a CUDA index write leaves duplicate coordinates
+    # undefined. Keep the last value of each coordinate.
+    coordinates = torch.stack(destination_indices, -1)
+    linear_coordinate = coordinates[:, 0]
+    for coordinate, size in zip(
+        coordinates[:, 1:].unbind(-1), replay_buffer.storage.shape[1:]
+    ):
+        linear_coordinate = linear_coordinate * int(size) + coordinate
+    order = linear_coordinate.argsort(stable=True)
+    ordered_coordinate = linear_coordinate[order]
+    keep_ordered = torch.ones_like(ordered_coordinate, dtype=torch.bool)
+    keep_ordered[:-1] = ordered_coordinate[:-1] != ordered_coordinate[1:]
+    keep = order[keep_ordered]
+    destination_indices = tuple(index[keep] for index in destination_indices)
+    destination_index = (
+        torch.stack(destination_indices, -1)
+        if len(destination_indices) > 1
+        else destination_indices[0]
+    )
+    destination_generation = destination_generation[keep]
+    replay_buffer.update_if_present(
+        index=destination_index,
+        generation=destination_generation,
+        patch={
+            "state": state.detach()
+            .float()
+            .reshape(-1, state.shape[-1])[keep.to(state.device)],
+            "belief": belief.detach()
+            .float()
+            .reshape(-1, belief.shape[-1])[keep.to(belief.device)],
+            _REPLAY_CONTEXT_VALID_KEY: torch.ones(
+                (keep.numel(), 1), dtype=torch.bool, device=state.device
+            ),
+        },
+    )
+
+
+class DreamerV3ReplayPipeline:
+    """Sample one batch ahead, and apply each latent refresh one update behind."""
+
+    def __init__(self) -> None:
+        self._prefetched: tuple[TensorDictBase, ReplaySampleInfo] | None = None
+        self._pending_context: tuple[
+            ReplaySampleInfo, torch.Tensor, torch.Tensor
+        ] | None = None
+
+    @property
+    def has_prefetched(self) -> bool:
+        return self._prefetched is not None
+
+    @property
+    def has_pending_context(self) -> bool:
+        return self._pending_context is not None
+
+    def prefetch(self, replay_buffer: ReplayBuffer) -> None:
+        if self._prefetched is None:
+            self._prefetched = replay_buffer.sample(return_info=True)
+
+    def take(
+        self, replay_buffer: ReplayBuffer
+    ) -> tuple[TensorDictBase, ReplaySampleInfo]:
+        """Return the prefetched batch, and sample the next one."""
+        self.prefetch(replay_buffer)
+        current = self._prefetched
+        self._prefetched = replay_buffer.sample(return_info=True)
+        return current
+
+    def apply_pending_context(self, replay_buffer: ReplayBuffer) -> None:
+        """Apply the previous refresh, after ``take`` samples the next batch."""
+        if self._pending_context is not None:
+            pending_info, pending_state, pending_belief = self._pending_context
+            _refresh_replay_context(
+                replay_buffer,
+                pending_info["index"],
+                pending_info["index_generation"],
+                pending_state,
+                pending_belief,
+            )
+            self._pending_context = None
+
+    def stage_context(
+        self,
+        sample_info: ReplaySampleInfo,
+        state: torch.Tensor,
+        belief: torch.Tensor,
+    ) -> None:
+        if self._pending_context is not None:
+            raise RuntimeError(
+                "The preceding replay context must be applied before staging "
+                "another learner output."
+            )
+        self._pending_context = (sample_info, state, belief)
+
+
+class DreamerV3ReplayRecordBuilder:
+    """Convert collector transitions into the replay stream."""
+
+    def __init__(self, num_streams: int) -> None:
+        self.num_streams = num_streams
+        self._started = False
+
+    def __call__(self, data: TensorDictBase) -> TensorDictBase:
+        if self.num_streams == 1:
+            data = data.reshape(1, -1)
+        elif data.ndim != 2 or data.shape[0] != self.num_streams:
+            raise RuntimeError(
+                "Expected collector data with shape [num_streams, time], got "
+                f"{tuple(data.shape)} for {self.num_streams} streams."
+            )
+
+        records = []
+        record_keys = (
+            "action",
+            "is_init",
+            "state",
+            "belief",
+            ("next", "observation"),
+            ("next", "reward"),
+            ("next", "done"),
+            ("next", "terminated"),
+        )
+        for time_index in range(data.shape[1]):
+            collector_step = data[:, time_index]
+            reset = collector_step.get("is_init").reshape(self.num_streams, -1).any(-1)
+            insert_reset = reset if self._started else torch.zeros_like(reset)
+            if insert_reset.any() and not insert_reset.all():
+                raise RuntimeError(
+                    "The 2D DreamerV3 replay stream requires synchronized episode "
+                    "resets across collector environments."
+                )
+
+            transition = collector_step.select(*record_keys, strict=True).clone()
+            # This record models the transition into next.observation, so it
+            # keeps its action; the separate reset record marks the reset.
+            transition.get("is_init").zero_()
+            transition.set(
+                _REPLAY_CONTEXT_VALID_KEY,
+                torch.ones_like(transition.get("is_init"), dtype=torch.bool),
+            )
+
+            if insert_reset.any():
+                reset_transition = transition.clone()
+                for key in (
+                    "action",
+                    "state",
+                    "belief",
+                    ("next", "reward"),
+                    ("next", "done"),
+                    ("next", "terminated"),
+                ):
+                    reset_transition.get(key).zero_()
+                reset_transition.get("is_init").fill_(True)
+                reset_transition.set(
+                    ("next", "observation"),
+                    collector_step.get("observation").clone(),
+                )
+                records.append(reset_transition)
+
+            records.append(transition)
+            self._started = True
+
+        return torch.stack(records, 1)
+
+
+class DreamerV3ShiftedRecordExtender:
+    """Keep a placeholder record for the posterior of the newest transition.
+
+    The next collector batch completes it in place, at the same slot.
+    """
+
+    def __init__(self, num_streams: int) -> None:
+        self.num_streams = num_streams
+        self._tail_index: torch.Tensor | None = None
+        self._tail_generation: torch.Tensor | None = None
+
+    @staticmethod
+    def _tail_placeholder(records: TensorDictBase) -> TensorDictBase:
+        tail = records[:, -1].clone()
+        tail.get("action").zero_()
+        tail.get("is_init").zero_()
+        tail.get("state").zero_()
+        tail.get("belief").zero_()
+        tail.get(("next", "reward")).zero_()
+        tail.get(("next", "done")).zero_()
+        tail.get(("next", "terminated")).zero_()
+        tail.get(_REPLAY_CONTEXT_VALID_KEY).zero_()
+        return tail.unsqueeze(1)
+
+    def _finalize_tail(
+        self, replay_buffer: ReplayBuffer, records: TensorDictBase
+    ) -> None:
+        tail_index = self._tail_index
+        tail_generation = self._tail_generation
+        if tail_index is None or tail_generation is None:
+            return
+
+        storage = replay_buffer.storage
+        stored = (
+            storage[tail_index]
+            if storage.ndim == 1
+            else storage[tuple(tail_index.unbind(-1))]
+        )
+        incoming = records[:, 0].clone().to(stored.device)
+        context_valid = stored.get(_REPLAY_CONTEXT_VALID_KEY)
+        incoming.set(
+            "state",
+            torch.where(context_valid, stored.get("state"), incoming.get("state")),
+        )
+        incoming.set(
+            "belief",
+            torch.where(context_valid, stored.get("belief"), incoming.get("belief")),
+        )
+        incoming.set(
+            _REPLAY_CONTEXT_VALID_KEY,
+            torch.ones_like(context_valid, dtype=torch.bool),
+        )
+        result = replay_buffer.update_if_present(
+            index=tail_index,
+            generation=tail_generation,
+            patch=incoming,
+        )
+        if result.updated_count != self.num_streams:
+            raise RuntimeError(
+                "The mutable DreamerV3 replay tail was recycled before it "
+                "could be finalized."
+            )
+
+    def extend(
+        self,
+        replay_buffer: ReplayBuffer,
+        replay_sampler: DreamerV3ReplaySampler,
+        records: TensorDictBase,
+    ) -> torch.Tensor:
+        if records.ndim != 2 or records.shape[0] != self.num_streams:
+            raise RuntimeError(
+                "Expected replay records with shape [num_streams, time], got "
+                f"{tuple(records.shape)} for {self.num_streams} streams."
+            )
+        self._finalize_tail(replay_buffer, records)
+        placeholder = self._tail_placeholder(records)
+        if self._tail_index is None:
+            appended = torch.cat([records, placeholder], 1)
+        else:
+            appended = torch.cat([records[:, 1:], placeholder], 1)
+        replay_indices = replay_buffer.extend(
+            appended if self.num_streams > 1 else appended.reshape(-1)
+        )
+        replay_sampler.observe_extend(replay_indices, replay_buffer.storage)
+
+        coordinates = torch.as_tensor(replay_indices, dtype=torch.long).reshape(
+            appended.shape[1], self.num_streams, replay_buffer.storage.ndim
+        )
+        tail_index = coordinates[-1]
+        if replay_buffer.storage.ndim == 1:
+            tail_index = tail_index[:, 0]
+        self._tail_index = tail_index.clone()
+        self._tail_generation = replay_buffer.writer.generations_of(
+            self._tail_index
+        ).clone()
+        return replay_indices
+
+
+class DreamerV3ReplaySampler(SliceSampler):
+    """Slice sampler that takes the oldest queued blocks before uniform ones."""
+
+    def __init__(self, *args, online: bool = True, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.online = online
+        self._stream_lengths: torch.Tensor | None = None
+        self._online_queue: list[torch.Tensor] = []
+
+    @property
+    def online_queue_size(self) -> int:
+        return len(self._online_queue)
+
+    def observe_extend(self, index: torch.Tensor, storage: LazyTensorStorage) -> None:
+        """Queue the start of each new, non-overlapping ``slice_len`` block."""
+        if not self.online:
+            return
+        index = torch.as_tensor(index, dtype=torch.long)
+        if storage.ndim == 1:
+            coordinates = index.reshape(-1, 1, 1)
+            num_streams = 1
+        else:
+            num_streams = storage.shape[1:].numel()
+            coordinates = index.reshape(-1, num_streams, storage.ndim)
+        if self._stream_lengths is None:
+            self._stream_lengths = torch.zeros(num_streams, dtype=torch.long)
+        elif self._stream_lengths.numel() != num_streams:
+            raise RuntimeError(
+                "The number of replay streams changed after initialization."
+            )
+
+        max_time = storage._max_size_along_dim0()
+        for coordinate_row in coordinates:
+            self._stream_lengths.add_(1)
+            enqueue = (self._stream_lengths > self.slice_len) & (
+                (self._stream_lengths - 1).remainder(self.slice_len) == 0
+            )
+            if enqueue.any():
+                starts = coordinate_row[enqueue].clone()
+                starts[:, 0].sub_(self.slice_len - 1).remainder_(max_time)
+                self._online_queue.extend(starts.unbind(0))
+
+    def _drop_stale_online(self, storage: LazyTensorStorage, seq_length: int) -> None:
+        """Drop queued starts whose ``seq_length`` window is no longer stored."""
+        if not self._online_queue or not storage._is_full:
+            return
+        stored_time = storage.shape[0]
+        oldest = (int(storage._last_cursor_index) + 1) % stored_time
+        live = stored_time - seq_length + 1
+        self._online_queue = [
+            start
+            for start in self._online_queue
+            if (int(start[0]) - oldest) % stored_time < live
+        ]
+
+    def sample(
+        self, storage: LazyTensorStorage, batch_size: int
+    ) -> tuple[tuple[torch.Tensor, ...], dict]:
+        seq_length, num_slices = self._adjusted_batch_size(batch_size)
+        self._drop_stale_online(storage, seq_length)
+        # Each sequence of a batch takes one online block if the queue has one.
+        num_online = min(num_slices, len(self._online_queue))
+        num_uniform = num_slices - num_online
+        if storage.ndim > 2:
+            raise RuntimeError("DreamerV3 continuous replay supports 1D or 2D storage.")
+        if num_uniform:
+            stored_time = storage.shape[0]
+            num_starts = stored_time - seq_length + 1
+            if num_starts < 1:
+                raise RuntimeError(
+                    f"Replay streams have length {stored_time}, but sampling "
+                    f"requires {seq_length} records."
+                )
+            num_streams = 1 if storage.ndim == 1 else storage.shape[1]
+            flat_start = torch.randint(
+                num_starts * num_streams,
+                (num_uniform,),
+                generator=self._rng,
+            )
+            relative_time = flat_start.div(num_streams, rounding_mode="floor")
+            stream = flat_start.remainder(num_streams)
+            oldest_time = (
+                (int(storage._last_cursor_index) + 1) % stored_time
+                if storage._is_full
+                else 0
+            )
+            start_time = (relative_time + oldest_time).remainder(stored_time)
+            if storage.ndim == 1:
+                uniform_starts = start_time.unsqueeze(-1)
+            else:
+                uniform_starts = torch.stack([start_time, stream], -1)
+            uniform_coordinates = self._tensor_slices_from_startend(
+                seq_length,
+                uniform_starts,
+                stored_time,
+            ).reshape(num_uniform, seq_length, storage.ndim)
+            index_device = uniform_starts.device
+        else:
+            uniform_coordinates = None
+            index_device = self._online_queue[0].device
+
+        if num_online:
+            online_starts = torch.stack(
+                [self._online_queue.pop(0) for _ in range(num_online)]
+            ).to(index_device)
+            online_coordinates = self._tensor_slices_from_startend(
+                seq_length,
+                online_starts,
+                storage.shape[0],
+            ).reshape(num_online, seq_length, storage.ndim)
+        else:
+            online_coordinates = None
+        coordinates = torch.cat(
+            [
+                candidate
+                for candidate in (online_coordinates, uniform_coordinates)
+                if candidate is not None
+            ],
+            0,
+        )
+        return coordinates.reshape(-1, storage.ndim).unbind(-1), {}
+
+    def _empty(self) -> None:
+        super()._empty()
+        self._stream_lengths = None
+        self._online_queue.clear()

--- a/sota-implementations/dreamer_v3/dreamer_v3_replay.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_replay.py
@@ -58,7 +58,7 @@ class DreamerV3UpdateRatio:
         ratio (float): Learner updates for each driver record.
     """
 
-    def __init__(self, ratio: float) -> None:
+    def __init__(self, ratio: float):
         self.ratio = ratio
         self._previous: float | None = None
 
@@ -134,7 +134,7 @@ def _refresh_replay_context(
 class DreamerV3ReplayPipeline:
     """Sample one batch ahead, and apply each latent refresh one update behind."""
 
-    def __init__(self) -> None:
+    def __init__(self):
         self._prefetched: tuple[TensorDictBase, ReplaySampleInfo] | None = None
         self._pending_context: tuple[
             ReplaySampleInfo, torch.Tensor, torch.Tensor
@@ -191,7 +191,7 @@ class DreamerV3ReplayPipeline:
 class DreamerV3ReplayRecordBuilder:
     """Convert collector transitions into the replay stream."""
 
-    def __init__(self, num_streams: int) -> None:
+    def __init__(self, num_streams: int):
         self.num_streams = num_streams
         self._started = False
 
@@ -264,7 +264,7 @@ class DreamerV3ShiftedRecordExtender:
     The next collector batch completes it in place, at the same slot.
     """
 
-    def __init__(self, num_streams: int) -> None:
+    def __init__(self, num_streams: int):
         self.num_streams = num_streams
         self._tail_index: torch.Tensor | None = None
         self._tail_generation: torch.Tensor | None = None
@@ -359,7 +359,7 @@ class DreamerV3ShiftedRecordExtender:
 class DreamerV3ReplaySampler(SliceSampler):
     """Slice sampler that takes the oldest queued blocks before uniform ones."""
 
-    def __init__(self, *args, online: bool = True, **kwargs) -> None:
+    def __init__(self, *args, online: bool = True, **kwargs):
         super().__init__(*args, **kwargs)
         self.online = online
         self._stream_lengths: torch.Tensor | None = None

--- a/sota-implementations/dreamer_v3/dreamer_v3_utils.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_utils.py
@@ -1,0 +1,146 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Run logging, RNG streams and evaluation of the DreamerV3 example."""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+from omegaconf import DictConfig
+from tensordict import TensorDictBase
+from tensordict.nn import TensorDictModuleBase
+
+from torchrl._utils import logger as torchrl_logger
+from torchrl.envs import EnvBase
+from torchrl.envs.utils import ExplorationType, set_exploration_type
+
+_has_matplotlib = importlib.util.find_spec("matplotlib") is not None
+
+
+# --- RNG streams -------------------------------------------------------------
+
+
+POLICY_RNG_STREAM = 0
+LEARNER_RNG_STREAM = 1
+REPLAY_RNG_STREAM = 2
+
+
+def stream_seed(seed: int, counter: int, stream: int) -> int:
+    """Make one deterministic Torch seed from a seed, a counter and a stream.
+
+    ``stream`` keeps its users independent: a change in the number of draws of
+    one stream does not change the sequences of the others.
+    """
+    rng = np.random.default_rng(seed=[seed, counter, stream])
+    words = rng.integers(0, np.iinfo(np.uint32).max, (2,), np.uint32)
+    return (int(words[0]) << 32) | int(words[1])
+
+
+# --- Run logging and episode bookkeeping -------------------------------------
+
+
+def append_jsonl(path: Path | None, record: dict[str, object]) -> None:
+    if path is None:
+        return
+    with path.open("a") as file:
+        file.write(json.dumps(record) + "\n")
+
+
+def latent_state_dim(cfg: DictConfig) -> int:
+    return cfg.networks.num_categoricals * cfg.networks.num_classes
+
+
+def training_episode_returns(
+    data: TensorDictBase,
+    running_return: torch.Tensor,
+    num_envs: int,
+) -> list[tuple[int, int, float]]:
+    reward = data.get(("next", "reward")).squeeze(-1)
+    done = data.get(("next", "done")).squeeze(-1)
+    if num_envs == 1:
+        reward = reward.reshape(1, -1)
+        done = done.reshape(1, -1)
+    completed = []
+    for time_index in range(reward.shape[-1]):
+        running_return.add_(reward[..., time_index].cpu())
+        finished = done[..., time_index].cpu()
+        completed.extend(
+            (time_index, int(env_index), float(running_return[env_index]))
+            for env_index in finished.nonzero().flatten()
+        )
+        running_return.masked_fill_(finished, 0)
+    return completed
+
+
+# --- Evaluation and plotting -------------------------------------------------
+
+
+@torch.no_grad()
+def eval_episode_reward(
+    env: EnvBase,
+    actor: TensorDictModuleBase,
+    num_episodes: int,
+    max_episode_steps: int,
+) -> torch.Tensor:
+    totals = []
+    with set_exploration_type(ExplorationType.DETERMINISTIC):
+        for _ in range(num_episodes):
+            td = env.rollout(
+                max_steps=max_episode_steps,
+                policy=actor,
+                break_when_any_done=True,
+                auto_cast_to_device=True,
+            )
+            totals.append(td.get(("next", "reward")).sum())
+    return torch.stack(totals).mean()
+
+
+def plot_enabled(cfg: DictConfig) -> bool:
+    """Return True if the run must record the per-update losses."""
+    return bool(cfg.logger.output_plot) and _has_matplotlib
+
+
+def save_run_plot(
+    cfg: DictConfig,
+    eval_steps: list[int],
+    eval_returns: list[torch.Tensor],
+    loss_history: list[torch.Tensor],
+) -> None:
+    if not _has_matplotlib:
+        torchrl_logger.warning(
+            "matplotlib is not installed; skipping plot %s", cfg.logger.output_plot
+        )
+        return
+    import matplotlib.pyplot as plt  # noqa: PLC0415
+
+    returns = (
+        (torch.stack(eval_returns) if eval_returns else torch.empty(0)).cpu().numpy()
+    )
+    losses = (torch.cat(loss_history) if loss_history else torch.empty(0, 6)).numpy()
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 4))
+    axes[0].plot(eval_steps, returns, marker="o")
+    axes[0].set_title(f"{cfg.env.name} eval reward (real env)")
+    axes[0].set_xlabel("env_step")
+    axes[0].set_ylabel("avg episode return")
+    axes[0].grid(True, alpha=0.3)
+
+    axes[1].plot(losses[:, 1], label="reco", alpha=0.8)
+    axes[1].plot(losses[:, 2], label="reward", alpha=0.8)
+    axes[1].plot(losses[:, 0], label="kl", alpha=0.8)
+    axes[1].set_title("World-model losses (update step)")
+    axes[1].set_xlabel("update step")
+    axes[1].legend()
+    axes[1].grid(True, alpha=0.3)
+
+    fig.suptitle(
+        f"DreamerV3 on {cfg.env.name} - {cfg.collector.total_frames} env steps"
+    )
+    fig.tight_layout()
+    fig.savefig(cfg.logger.output_plot, dpi=120)
+    torchrl_logger.info("Saved plot to %s", cfg.logger.output_plot)

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -2,10 +2,10 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-"""DreamerV3 training script that reproduces the reference implementation.
+"""DreamerV3 training script that reproduces a pinned JAX configuration.
 
 The script is proprioceptive, not pixel-based, and writes its metrics to a
-JSONL file on the same step axis as the reference.
+JSONL file on the same step axis as the author-maintained JAX implementation.
 
 Usage::
 
@@ -192,7 +192,7 @@ def _build_learner(
         trainable_parameters,
         lr=cfg.optimization.lr,
         agc=cfg.optimization.adaptive_grad_clip,
-        eps=cfg.optimization.adam_eps,
+        eps=cfg.optimization.optimizer_eps,
         warmup_steps=cfg.optimization.warmup_steps,
     )
 

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -128,6 +128,8 @@ def _build_learner(
         prior_net=prior_net,
         reward_net=reward_net,
         reward_decoder=reward_decoder,
+        # Compiling changes the categorical draws; "step" must match eager.
+        compile_prior=cfg.optimization.compile_rssm == "scan",
     ).to(device)
     continuation_model = build_continuation_model(continuation_net=continuation_net).to(
         device

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -2,474 +2,123 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-"""DreamerV3 on Pendulum-v1 — minimal end-to-end training script.
+"""DreamerV3 training script that reproduces the reference implementation.
 
-State-based (not pixel-based) to keep the script compact — the 3-D obs is
-treated as a flat feature vector with ``global_average=True`` in the model
-loss. The wiring is still real:
-
-- collector to replay buffer of sequences
-- world model = MLP encoder + RSSMPriorV3 + RSSMPosteriorV3 + MLP decoder + reward head
-- RSSM unrolled over each sequence via ``RSSMRolloutV3``
-- actor trained via REINFORCE in imagination (``DreamerV3ActorLoss``)
-- value trained on the same imagined rollout (``DreamerV3ValueLoss``)
-- periodic eval rollouts in the real env, episode reward logged
-
-Plots ``dreamer_v3_pendulum.png`` with two curves: (a) average eval reward,
-(b) world-model KL / reconstruction / reward losses.
+The script is proprioceptive, not pixel-based, and writes its metrics to a
+JSONL file on the same step axis as the reference.
 
 Usage::
 
     python sota-implementations/dreamer_v3/train.py \\
         collector.total_frames=5000 logger.eval_every=500
+
+    python sota-implementations/dreamer_v3/train.py \\
+        --config-name=config_dmc_walker
 """
 from __future__ import annotations
 
-import importlib.util
-import json
+import copy
 from pathlib import Path
+from typing import NamedTuple
 
 import hydra
 import torch
-from omegaconf import DictConfig
-from tensordict import TensorDict
-from tensordict.nn import (
-    InteractionType,
-    ProbabilisticTensorDictModule,
-    ProbabilisticTensorDictSequential,
-    TensorDictModule,
-    TensorDictSequential,
-)
 
+from dreamer_v3_agent import (
+    build_actor,
+    build_continuation_model,
+    build_imagination_model,
+    build_mb_env,
+    build_real_world_actor,
+    build_value,
+    build_world_model,
+    DreamerV3BehaviorPolicySync,
+    DreamerV3Optimizer,
+    DreamerV3SeededPolicy,
+    make_env,
+    make_primed_env,
+)
+from dreamer_v3_replay import (
+    collector_action_budget,
+    DreamerV3ReplayPipeline,
+    DreamerV3ReplayRecordBuilder,
+    DreamerV3ReplaySampler,
+    DreamerV3ShiftedRecordExtender,
+    DreamerV3UpdateRatio,
+    driver_step_for_action,
+)
+from dreamer_v3_utils import (
+    append_jsonl,
+    eval_episode_reward,
+    latent_state_dim,
+    LEARNER_RNG_STREAM,
+    plot_enabled,
+    REPLAY_RNG_STREAM,
+    save_run_plot,
+    stream_seed,
+    training_episode_returns,
+)
+from omegaconf import DictConfig
+from tensordict import TensorDict, TensorDictBase
+from tensordict.nn import TensorDictModuleBase
+
+from torchrl import timeit
 from torchrl._utils import get_available_device, logger as torchrl_logger
 from torchrl.collectors import Collector
-from torchrl.data import LazyTensorStorage, ReplayBuffer, Unbounded
-from torchrl.data.replay_buffers.samplers import SliceSampler
-from torchrl.envs import StepCounter, TransformedEnv
-from torchrl.envs.libs.gym import GymEnv
-from torchrl.envs.model_based.dreamer import DreamerEnv
-from torchrl.envs.transforms import (
-    CatTensors,
-    DoubleToFloat,
-    InitTracker,
-    TensorDictPrimer,
-)
-from torchrl.envs.utils import ExplorationType, set_exploration_type
-from torchrl.modules import DreamerV3MLP, SymExpTwoHot, WorldModelWrapper
-from torchrl.modules.distributions.continuous import TanhNormal
-from torchrl.modules.models.model_based import (
-    RSSMPosteriorV3,
-    RSSMPriorV3,
-    RSSMRolloutV3,
-)
+from torchrl.data import LazyTensorStorage, ReplayBuffer, RoundRobinWriter
+from torchrl.envs import SerialEnv
+from torchrl.envs.utils import ExplorationType
 from torchrl.objectives import (
     DreamerV3ActorLoss,
     DreamerV3ModelLoss,
     DreamerV3ValueLoss,
-    symexp,
-    symlog,
 )
 from torchrl.objectives.utils import SoftUpdate, ValueEstimators
 
-_has_matplotlib = importlib.util.find_spec("matplotlib") is not None
-_has_dm_control = importlib.util.find_spec("dm_control") is not None
+
+class _Learner(NamedTuple):
+    world_model: TensorDictModuleBase
+    model_loss: DreamerV3ModelLoss
+    actor_loss: DreamerV3ActorLoss
+    value_loss: DreamerV3ValueLoss
+    value_target_updater: SoftUpdate
+    optimizer: DreamerV3Optimizer
+    real_world_actor: TensorDictModuleBase
 
 
-class _DreamerV3Actor(torch.nn.Module):
-    def __init__(self, cfg: DictConfig, action_dim: int):
-        super().__init__()
-        state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
-        self.backbone = DreamerV3MLP(
-            state_dim + cfg.networks.rnn_hidden_dim,
-            2 * action_dim,
-            depth=cfg.networks.actor_layers,
-            num_cells=cfg.networks.hidden_dim,
-            outscale=0.01,
-            norm_eps=cfg.networks.norm_eps,
+def _validated_action_budget(cfg: DictConfig) -> int:
+    num_envs = cfg.collector.num_envs
+    if num_envs <= 0:
+        raise ValueError(f"collector.num_envs must be positive, got {num_envs}.")
+    if cfg.collector.frames_per_batch % num_envs:
+        raise ValueError(
+            "collector.frames_per_batch must be divisible by collector.num_envs, "
+            f"got {cfg.collector.frames_per_batch} and {num_envs}."
         )
-        self.action_dim = action_dim
-        self.min_std = cfg.networks.policy_min_std
-        self.max_std = cfg.networks.policy_max_std
-
-    def forward(self, state: torch.Tensor, belief: torch.Tensor):
-        mean, std = self.backbone(state, belief).split(self.action_dim, -1)
-        std = (self.max_std - self.min_std) * torch.sigmoid(std + 2) + self.min_std
-        return mean, std
-
-
-@torch.no_grad()
-def adaptive_grad_clip_(parameters, clip: float, minimum: float = 1e-3) -> None:
-    """Clip each parameter gradient relative to its parameter norm."""
-    for parameter in parameters:
-        if parameter.grad is None:
-            continue
-        grad_norm = parameter.grad.norm()
-        parameter_norm = parameter.detach().norm().clamp_min(minimum)
-        scale = (clip * parameter_norm / grad_norm.clamp_min(1e-12)).clamp_max(1)
-        parameter.grad.mul_(scale)
-
-
-def make_env(cfg: DictConfig, seed: int = 0) -> TransformedEnv:
-    if cfg.env.backend == "gym":
-        base_env = GymEnv(cfg.env.name, device="cpu")
-    elif cfg.env.backend == "dm_control":
-        if not _has_dm_control:
-            raise ImportError(
-                "The DMC DreamerV3 preset requires dm_control. Install the "
-                "optional dm_control dependencies before running it."
-            )
-        from torchrl.envs.libs.dm_control import DMControlEnv
-
-        base_env = DMControlEnv(cfg.env.name, cfg.env.task, device="cpu")
-    else:
-        raise ValueError(f"Unknown environment backend {cfg.env.backend!r}.")
-
-    env = TransformedEnv(base_env)
-    if cfg.env.backend == "dm_control":
-        env.append_transform(
-            CatTensors(
-                in_keys=list(base_env.observation_spec.keys()),
-                out_key="observation",
-            )
+    collector_action_frames = (
+        collector_action_budget(
+            cfg.collector.total_frames,
+            num_envs,
+            cfg.env.max_episode_steps,
         )
-    env.append_transform(DoubleToFloat())
-    env.append_transform(StepCounter(max_steps=cfg.env.max_episode_steps))
-    env.append_transform(InitTracker())
-    env.set_seed(seed)
-    return env
-
-
-def build_world_model(*, cfg: DictConfig, obs_dim: int, action_dim: int):
-    """MLP encoder + RSSMRolloutV3 + MLP decoder + reward head.
-
-    Returns a TensorDictSequential whose forward consumes a trajectory batch
-    and writes every key DreamerV3ModelLoss expects.
-    """
-    state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
-
-    observation_encoder = DreamerV3MLP(
-        in_features=obs_dim,
-        out_features=cfg.networks.obs_embed_dim,
-        depth=cfg.networks.encoder_layers,
-        num_cells=cfg.networks.hidden_dim,
-        norm_eps=cfg.networks.norm_eps,
+        if cfg.collector.count_reset_records
+        else cfg.collector.total_frames
     )
-    encoder = TensorDictSequential(
-        TensorDictModule(
-            symlog,
-            in_keys=[("next", "observation")],
-            out_keys=[("next", "symlog_observation")],
-        ),
-        TensorDictModule(
-            observation_encoder,
-            in_keys=[("next", "symlog_observation")],
-            out_keys=[("next", "encoded_latents")],
-        ),
-    )
-
-    prior_net = RSSMPriorV3(
-        action_shape=torch.Size([action_dim]),
-        hidden_dim=cfg.networks.hidden_dim,
-        rnn_hidden_dim=cfg.networks.rnn_hidden_dim,
-        num_categoricals=cfg.networks.num_categoricals,
-        num_classes=cfg.networks.num_classes,
-        action_dim=action_dim,
-        unimix=cfg.networks.unimix,
-        recurrent_model=cfg.networks.recurrent_model,
-        num_blocks=cfg.networks.num_blocks,
-        num_layers=cfg.networks.dynamics_layers,
-        prior_num_layers=cfg.networks.prior_layers,
-        norm_eps=cfg.networks.norm_eps,
-    )
-    rssm_prior = TensorDictModule(
-        prior_net,
-        in_keys=["state", "belief", "action"],
-        out_keys=[
-            ("next", "prior_logits"),
-            ("next", "state"),
-            ("next", "belief"),
-        ],
-    )
-
-    posterior_net = RSSMPosteriorV3(
-        hidden_dim=cfg.networks.hidden_dim,
-        num_categoricals=cfg.networks.num_categoricals,
-        num_classes=cfg.networks.num_classes,
-        rnn_hidden_dim=cfg.networks.rnn_hidden_dim,
-        obs_embed_dim=cfg.networks.obs_embed_dim,
-        unimix=cfg.networks.unimix,
-        use_rms_norm=True,
-        num_layers=cfg.networks.posterior_layers,
-        norm_eps=cfg.networks.norm_eps,
-    )
-    rssm_posterior = TensorDictModule(
-        posterior_net,
-        in_keys=[("next", "belief"), ("next", "encoded_latents")],
-        out_keys=[("next", "posterior_logits"), ("next", "state")],
-    )
-
-    rollout = RSSMRolloutV3(rssm_prior, rssm_posterior)
-
-    decoder = TensorDictSequential(
-        TensorDictModule(
-            DreamerV3MLP(
-                in_features=state_dim + cfg.networks.rnn_hidden_dim,
-                out_features=obs_dim,
-                depth=cfg.networks.decoder_layers,
-                num_cells=cfg.networks.hidden_dim,
-                norm_eps=cfg.networks.norm_eps,
-            ),
-            in_keys=[("next", "state"), ("next", "belief")],
-            out_keys=[("next", "reco_symlog_observation")],
-        ),
-        TensorDictModule(
-            symexp,
-            in_keys=[("next", "reco_symlog_observation")],
-            out_keys=[("next", "reco_pixels")],
-        ),
-    )
-
-    reward_net = DreamerV3MLP(
-        in_features=state_dim + cfg.networks.rnn_hidden_dim,
-        out_features=cfg.networks.num_reward_bins,
-        depth=cfg.networks.reward_layers,
-        num_cells=cfg.networks.hidden_dim,
-        outscale=0.0,
-        norm_eps=cfg.networks.norm_eps,
-    )
-    reward_decoder = SymExpTwoHot(cfg.networks.num_reward_bins)
-    reward_head = TensorDictSequential(
-        TensorDictModule(
-            reward_net,
-            in_keys=[("next", "state"), ("next", "belief")],
-            out_keys=[("next", "reward_logits")],
-        ),
-        TensorDictModule(
-            reward_decoder,
-            in_keys=[("next", "reward_logits")],
-            out_keys=[("next", "reward")],
-        ),
-    )
-
-    continuation_net = DreamerV3MLP(
-        in_features=state_dim + cfg.networks.rnn_hidden_dim,
-        out_features=1,
-        depth=cfg.networks.reward_layers,
-        num_cells=cfg.networks.hidden_dim,
-        norm_eps=cfg.networks.norm_eps,
-    )
-    continuation_head = TensorDictModule(
-        continuation_net,
-        in_keys=[("next", "state"), ("next", "belief")],
-        out_keys=[("next", "continue_pred")],
-    )
-
-    world_model = TensorDictSequential(
-        encoder, rollout, decoder, reward_head, continuation_head
-    )
-    return (
-        world_model,
-        observation_encoder,
-        prior_net,
-        posterior_net,
-        reward_net,
-        reward_decoder,
-        continuation_net,
-    )
-
-
-def build_imagination_model(*, prior_net, reward_net, reward_decoder):
-    """Build imagination operators backed by the trained world-model heads."""
-    transition_model = TensorDictSequential(
-        TensorDictModule(
-            prior_net,
-            in_keys=["state", "belief", "action"],
-            out_keys=["_", "state", "belief"],
+    if collector_action_frames % cfg.collector.frames_per_batch:
+        raise ValueError(
+            "The action budget derived from collector.total_frames must be "
+            "divisible by collector.frames_per_batch, got "
+            f"{collector_action_frames} and {cfg.collector.frames_per_batch}."
         )
-    )
-    reward_model = TensorDictSequential(
-        TensorDictModule(
-            reward_net,
-            in_keys=["state", "belief"],
-            out_keys=["reward_logits"],
-        ),
-        TensorDictModule(
-            reward_decoder,
-            in_keys=["reward_logits"],
-            out_keys=["reward"],
-        ),
-    )
-    return WorldModelWrapper(transition_model, reward_model)
+    return collector_action_frames
 
 
-def build_continuation_model(*, continuation_net):
-    """Build the imagination continuation predictor from the trained head."""
-    return TensorDictSequential(
-        TensorDictModule(
-            continuation_net,
-            in_keys=["state", "belief"],
-            out_keys=["continue_logits"],
-        ),
-        TensorDictModule(
-            torch.nn.Sigmoid(),
-            in_keys=["continue_logits"],
-            out_keys=["continuation"],
-        ),
-    )
-
-
-def build_actor(*, cfg: DictConfig, action_dim: int):
-    state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
-    actor_mlp = _DreamerV3Actor(cfg, action_dim)
-    actor_model = ProbabilisticTensorDictSequential(
-        TensorDictModule(
-            actor_mlp,
-            in_keys=["state", "belief"],
-            out_keys=["loc", "scale"],
-        ),
-        ProbabilisticTensorDictModule(
-            in_keys=["loc", "scale"],
-            out_keys=["action"],
-            default_interaction_type=InteractionType.RANDOM,
-            distribution_class=TanhNormal,
-            return_log_prob=True,
-            log_prob_key="action_log_prob",
-        ),
-    )
-    with torch.no_grad():
-        actor_model(
-            TensorDict(
-                {
-                    "state": torch.randn(1, 2, state_dim),
-                    "belief": torch.randn(1, 2, cfg.networks.rnn_hidden_dim),
-                },
-                [1],
-            )
-        )
-    return actor_model
-
-
-def build_real_actor(*, observation_encoder, posterior_net, prior_net, actor_model):
-    """Build the observation-conditioned recurrent policy used in real envs."""
-    return TensorDictSequential(
-        TensorDictModule(
-            symlog,
-            in_keys=["observation"],
-            out_keys=["symlog_observation"],
-        ),
-        TensorDictModule(
-            observation_encoder,
-            in_keys=["symlog_observation"],
-            out_keys=["encoded_latents"],
-        ),
-        TensorDictModule(
-            posterior_net,
-            in_keys=["belief", "encoded_latents"],
-            out_keys=["_", "state"],
-        ),
-        actor_model,
-        TensorDictModule(
-            prior_net,
-            in_keys=["state", "belief", "action"],
-            out_keys=["_", "_", ("next", "belief")],
-        ),
-    )
-
-
-def build_value(*, cfg: DictConfig):
-    state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
-    value_model = TensorDictSequential(
-        TensorDictModule(
-            DreamerV3MLP(
-                in_features=state_dim + cfg.networks.rnn_hidden_dim,
-                out_features=cfg.networks.num_value_bins,
-                depth=cfg.networks.value_layers,
-                num_cells=cfg.networks.hidden_dim,
-                outscale=0.0,
-                norm_eps=cfg.networks.norm_eps,
-            ),
-            in_keys=["state", "belief"],
-            out_keys=["state_value_logits"],
-        ),
-        TensorDictModule(
-            SymExpTwoHot(cfg.networks.num_value_bins),
-            in_keys=["state_value_logits"],
-            out_keys=["state_value"],
-        ),
-    )
-    with torch.no_grad():
-        value_model(
-            TensorDict(
-                {
-                    "state": torch.randn(1, 2, state_dim),
-                    "belief": torch.randn(1, 2, cfg.networks.rnn_hidden_dim),
-                },
-                [1],
-            )
-        )
-    return value_model
-
-
-def build_mb_env(*, cfg: DictConfig, real_env, imagination_model, device: torch.device):
-    """Imagination env backed by the trained prior and reward head."""
-    state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
-    primer_env = TransformedEnv(
-        real_env,
-        TensorDictPrimer(
-            random=False,
-            default_value=0,
-            state=Unbounded(state_dim),
-            belief=Unbounded(cfg.networks.rnn_hidden_dim),
-        ),
-    )
-    mb_env = DreamerEnv(
-        world_model=imagination_model,
-        prior_shape=torch.Size([state_dim]),
-        belief_shape=torch.Size([cfg.networks.rnn_hidden_dim]),
-        device=device,
-    )
-    mb_env.set_specs_from_env(primer_env)
-    with torch.no_grad():
-        mb_env.rollout(3)
-    return mb_env
-
-
-@torch.no_grad()
-def eval_episode_reward(
-    env, actor, num_episodes: int, max_episode_steps: int
-) -> torch.Tensor:
-    totals = []
-    with set_exploration_type(ExplorationType.DETERMINISTIC):
-        for _ in range(num_episodes):
-            td = env.rollout(
-                max_steps=max_episode_steps,
-                policy=actor,
-                break_when_any_done=True,
-                auto_cast_to_device=True,
-            )
-            totals.append(td.get(("next", "reward")).sum())
-    return torch.stack(totals).mean()
-
-
-@hydra.main(version_base="1.3", config_path="", config_name="config")
-def main(cfg: DictConfig):
-    torch.manual_seed(cfg.env.seed)
-
-    device = (
-        torch.device(cfg.optimization.device)
-        if cfg.optimization.device
-        else get_available_device()
-    )
-    real_env = make_env(cfg, cfg.env.seed)
-    obs_dim = real_env.observation_spec["observation"].shape[0]
-    action_dim = real_env.action_spec.shape[0]
-    state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
-
+def _build_learner(
+    cfg: DictConfig, device: torch.device, obs_dim: int, action_dim: int
+) -> _Learner:
     (
         world_model,
-        observation_encoder,
         prior_net,
-        posterior_net,
         reward_net,
         reward_decoder,
         continuation_net,
@@ -484,12 +133,6 @@ def main(cfg: DictConfig):
         device
     )
     actor_model = build_actor(cfg=cfg, action_dim=action_dim).to(device)
-    real_actor = build_real_actor(
-        observation_encoder=observation_encoder,
-        posterior_net=posterior_net,
-        prior_net=prior_net,
-        actor_model=actor_model,
-    )
     value_model = build_value(cfg=cfg).to(device)
     mb_env = build_mb_env(
         cfg=cfg,
@@ -508,7 +151,9 @@ def main(cfg: DictConfig):
         unimix=cfg.networks.unimix,
         lambda_continue=1.0,
         continue_target_scale=1 - 1 / cfg.optimization.continuation_horizon,
+        # The reference adds the event dimensions, then averages batch and time.
         global_average=False,
+        detach_output=False,
     ).to(device)
     model_loss.set_keys(pixels="observation")
     actor_loss = DreamerV3ActorLoss(
@@ -536,148 +181,350 @@ def main(cfg: DictConfig):
     ).to(device)
     value_target_updater = SoftUpdate(value_loss, tau=cfg.optimization.slow_critic_tau)
 
-    optimizer_kwargs = {
-        "lr": cfg.optimization.lr,
-        "eps": cfg.optimization.adam_eps,
-        "betas": (0.9, 0.999),
-    }
-    opt_model = torch.optim.Adam(model_loss.parameters(), **optimizer_kwargs)
-    opt_actor = torch.optim.Adam(actor_model.parameters(), **optimizer_kwargs)
-    opt_value = torch.optim.Adam(value_loss.parameters(), **optimizer_kwargs)
-    schedulers = [
-        torch.optim.lr_scheduler.LinearLR(
-            optimizer,
-            start_factor=1 / cfg.optimization.warmup_steps,
-            total_iters=cfg.optimization.warmup_steps,
-        )
-        for optimizer in (opt_model, opt_actor, opt_value)
-    ]
-
-    explore_env = TransformedEnv(
-        make_env(cfg, cfg.env.seed + 2),
-        TensorDictPrimer(
-            random=False,
-            default_value=0,
-            state=Unbounded(state_dim),
-            belief=Unbounded(cfg.networks.rnn_hidden_dim),
-        ),
+    trainable_parameters = (
+        list(world_model.parameters())
+        + list(actor_model.parameters())
+        + list(value_loss.parameters())
     )
+    optimizer = DreamerV3Optimizer(
+        trainable_parameters,
+        lr=cfg.optimization.lr,
+        agc=cfg.optimization.adaptive_grad_clip,
+        eps=cfg.optimization.adam_eps,
+        warmup_steps=cfg.optimization.warmup_steps,
+    )
+
+    real_world_actor = build_real_world_actor(
+        world_model=world_model,
+        actor_model=actor_model,
+        mixed_precision=cfg.optimization.mixed_precision,
+    )
+    return _Learner(
+        world_model=world_model,
+        model_loss=model_loss,
+        actor_loss=actor_loss,
+        value_loss=value_loss,
+        value_target_updater=value_target_updater,
+        optimizer=optimizer,
+        real_world_actor=real_world_actor,
+    )
+
+
+def _build_collection(
+    cfg: DictConfig,
+    device: torch.device,
+    learner: _Learner,
+    state_dim: int,
+    action_dim: int,
+    collector_action_frames: int,
+) -> tuple[Collector, DreamerV3BehaviorPolicySync | None]:
+    num_envs = cfg.collector.num_envs
+    real_world_actor = learner.real_world_actor
+    if cfg.optimization.deferred_policy_sync:
+        collector_actor = copy.deepcopy(real_world_actor)
+        # The decoder cannot act, but the reference syncs both parameter trees.
+        behavior_decoder = copy.deepcopy(learner.world_model[2])
+        learner_policy_tree = torch.nn.ModuleList(
+            [real_world_actor, learner.world_model[2]]
+        )
+        behavior_policy_tree = torch.nn.ModuleList([collector_actor, behavior_decoder])
+        behavior_policy_sync = DreamerV3BehaviorPolicySync(
+            learner_policy_tree, behavior_policy_tree
+        )
+    else:
+        collector_actor = real_world_actor
+        behavior_policy_sync = None
+    collector_policy = (
+        DreamerV3SeededPolicy(collector_actor, cfg.env.seed)
+        if cfg.optimization.separate_policy_rng
+        else collector_actor
+    )
+
+    def make_explore_env(index: int):
+        seed = cfg.env.seed + 2 + index if cfg.env.use_seed else None
+        return make_primed_env(cfg, seed, state_dim, action_dim)
+
+    if num_envs == 1:
+        explore_env = make_explore_env(0)
+    else:
+        explore_env = SerialEnv(
+            num_envs,
+            [
+                (lambda index=index: make_explore_env(index))
+                for index in range(num_envs)
+            ],
+        )
 
     collector = Collector(
         explore_env,
-        real_actor,
+        collector_policy,
         frames_per_batch=cfg.collector.frames_per_batch,
-        total_frames=cfg.collector.total_frames,
+        total_frames=collector_action_frames,
         policy_device=device,
         env_device="cpu",
         storing_device="cpu",
         exploration_type=ExplorationType.RANDOM
         if cfg.collector.exploration == "random"
-        else ExplorationType.DETERMINISTIC,
+        else ExplorationType.MODE,
     )
+    if cfg.optimization.separate_policy_rng:
+        # The collector's construction-time policy call is not an action.
+        collector_policy.reset_counter()
+    return collector, behavior_policy_sync
 
+
+def _build_replay(
+    cfg: DictConfig, num_envs: int, replay_device: torch.device
+) -> tuple[
+    ReplayBuffer,
+    DreamerV3ReplaySampler,
+    DreamerV3ReplayRecordBuilder,
+    DreamerV3ShiftedRecordExtender | None,
+    DreamerV3ReplayPipeline,
+]:
+    replay_sampler = DreamerV3ReplaySampler(
+        # The extra record receives the last refreshed posterior.
+        slice_len=cfg.replay_buffer.seq_len + 1,
+        online=cfg.replay_buffer.online,
+    )
     rb = ReplayBuffer(
-        storage=LazyTensorStorage(max_size=cfg.replay_buffer.buffer_size),
-        sampler=SliceSampler(
-            slice_len=cfg.replay_buffer.seq_len,
-            traj_key=("collector", "traj_ids"),
+        storage=LazyTensorStorage(
+            max_size=cfg.replay_buffer.buffer_size,
+            ndim=2 if num_envs > 1 else 1,
+            device=replay_device,
         ),
-        batch_size=cfg.replay_buffer.batch_size * cfg.replay_buffer.seq_len,
+        dim_extend=1 if num_envs > 1 else 0,
+        writer=RoundRobinWriter(track_generations=True),
+        sampler=replay_sampler,
+        batch_size=cfg.replay_buffer.batch_size * (cfg.replay_buffer.seq_len + 1),
+        generator=torch.Generator().manual_seed(
+            stream_seed(cfg.env.seed, 0, REPLAY_RNG_STREAM)
+        ),
+    )
+    replay_record_builder = DreamerV3ReplayRecordBuilder(num_envs)
+    shifted_record_extender = (
+        DreamerV3ShiftedRecordExtender(num_envs)
+        if cfg.collector.count_reset_records
+        else None
+    )
+    replay_pipeline = DreamerV3ReplayPipeline()
+    return (
+        rb,
+        replay_sampler,
+        replay_record_builder,
+        shifted_record_extender,
+        replay_pipeline,
     )
 
-    env_step = 0
+
+def _log_train_episodes(
+    cfg: DictConfig,
+    metrics_jsonl_path: Path | None,
+    completed_episodes: list[tuple[int, int, float]],
+    batch_start_action_step: int,
+) -> None:
+    num_envs = cfg.collector.num_envs
+    for time_index, env_index, score in completed_episodes:
+        if cfg.collector.count_reset_records:
+            action_index = batch_start_action_step // num_envs + time_index + 1
+            episode_step = driver_step_for_action(
+                action_index,
+                env_index,
+                num_envs,
+                cfg.env.max_episode_steps,
+            )
+        else:
+            episode_step = (
+                batch_start_action_step + time_index * num_envs + env_index + 1
+            )
+        append_jsonl(
+            metrics_jsonl_path,
+            {
+                "type": "train_episode",
+                "environment_steps": episode_step,
+                "score": score,
+            },
+        )
+
+
+def _log_train_window(
+    *,
+    cfg: DictConfig,
+    metrics_jsonl_path: Path | None,
+    run_timer,
+    record_step: int,
+    update_step: int,
+    loss_window_sum: torch.Tensor,
+    loss_window_updates: int,
+) -> None:
+    append_jsonl(
+        metrics_jsonl_path,
+        {
+            "type": "train",
+            "environment_steps": record_step,
+            "updates": update_step,
+            "updates_in_window": loss_window_updates,
+            **dict(
+                zip(
+                    (
+                        "loss_dynamic_representation",
+                        "loss_reconstruction",
+                        "loss_reward",
+                        "loss_actor",
+                        "loss_value",
+                        "loss_replay_value",
+                    ),
+                    (loss_window_sum / max(loss_window_updates, 1)).cpu().tolist(),
+                )
+            ),
+            "elapsed_seconds": run_timer.elapsed(),
+        },
+    )
+
+
+def _evaluate(
+    *,
+    cfg: DictConfig,
+    device: torch.device,
+    eval_env,
+    real_world_actor: TensorDictModuleBase,
+    metrics_jsonl_path: Path | None,
+    run_timer,
+    record_step: int,
+    latest_losses: torch.Tensor,
+) -> torch.Tensor:
+    # Evaluation samples RSSM latents, thus a fork keeps training unchanged.
+    with timeit("dreamer_v3/evaluation"), torch.random.fork_rng(
+        devices=[device] if device.type == "cuda" else []
+    ):
+        r = eval_episode_reward(
+            eval_env,
+            real_world_actor,
+            cfg.logger.eval_episodes,
+            cfg.env.max_episode_steps,
+        )
+    torchrl_logger.info(
+        "[env_step=%5d] eval_reward=%+.2f kl=%.3f reco=%.3f reward=%.3f actor=%.3f",
+        record_step,
+        r.item(),
+        latest_losses[0].item(),
+        latest_losses[1].item(),
+        latest_losses[2].item(),
+        latest_losses[3].item(),
+    )
+    append_jsonl(
+        metrics_jsonl_path,
+        {
+            "type": "evaluation",
+            "environment_steps": record_step,
+            "return": r.item(),
+            "episodes": cfg.logger.eval_episodes,
+            "elapsed_seconds": run_timer.elapsed(),
+        },
+    )
+    return r
+
+
+@hydra.main(version_base="1.3", config_path="", config_name="config")
+def main(cfg: DictConfig):
+    torch.manual_seed(cfg.env.seed)
+
+    device = (
+        torch.device(cfg.optimization.device)
+        if cfg.optimization.device
+        else get_available_device()
+    )
+    replay_device = (
+        torch.device(cfg.replay_buffer.device) if cfg.replay_buffer.device else device
+    )
+    num_envs = cfg.collector.num_envs
+    count_reset_records = cfg.collector.count_reset_records
+    collector_action_frames = _validated_action_budget(cfg)
+    real_env = make_env(cfg, cfg.env.seed)
+    obs_dim = real_env.observation_spec["observation"].shape[0]
+    action_dim = real_env.action_spec.shape[0]
+    state_dim = latent_state_dim(cfg)
+    metrics_jsonl_path = (
+        Path(cfg.logger.metrics_jsonl).resolve() if cfg.logger.metrics_jsonl else None
+    )
+    if metrics_jsonl_path is not None:
+        metrics_jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+        metrics_jsonl_path.write_text("")
+    timeit.reset()
+    run_timer = timeit("dreamer_v3/run").start()
+
+    learner = _build_learner(cfg, device, obs_dim, action_dim)
+    model_loss = learner.model_loss
+    actor_loss = learner.actor_loss
+    value_loss = learner.value_loss
+    optimizer = learner.optimizer
+    value_target_updater = learner.value_target_updater
+
+    collector, behavior_policy_sync = _build_collection(
+        cfg, device, learner, state_dim, action_dim, collector_action_frames
+    )
+    (
+        rb,
+        replay_sampler,
+        replay_record_builder,
+        shifted_record_extender,
+        replay_pipeline,
+    ) = _build_replay(cfg, num_envs, replay_device)
+
+    action_step = 0
+    # Each worker sends a reset record before its first control transition.
+    record_step = num_envs if count_reset_records else 0
+    update_step = 0
+    running_training_return = torch.zeros(num_envs)
     history_steps: list[int] = []
     history_eval: list[torch.Tensor] = []
     loss_history: list[torch.Tensor] = []
-    record_loss_history = bool(cfg.logger.output_plot and _has_matplotlib)
+    loss_window_sum = torch.zeros(6, device=device)
+    loss_window_updates = 0
+    record_loss_history = plot_enabled(cfg)
     next_eval = 0
+    next_train_log = 0
 
-    eval_env = TransformedEnv(
-        make_env(cfg, cfg.env.seed + 100),
-        TensorDictPrimer(
-            random=False,
-            default_value=0,
-            state=Unbounded(state_dim),
-            belief=Unbounded(cfg.networks.rnn_hidden_dim),
-        ),
-    )
+    eval_env = make_primed_env(cfg, cfg.env.seed + 100, state_dim, action_dim)
 
     warmup = (
         cfg.replay_buffer.warmup_factor
         * cfg.replay_buffer.batch_size
         * cfg.replay_buffer.seq_len
     )
+    warmup = max(warmup, num_envs * (cfg.replay_buffer.seq_len + 1))
 
     updates_per_batch = cfg.optimization.updates_per_batch
-    if cfg.optimization.train_ratio is not None:
-        updates_per_batch = max(
-            1,
-            round(
-                cfg.collector.frames_per_batch
-                * cfg.optimization.train_ratio
-                / (cfg.replay_buffer.batch_size * cfg.replay_buffer.seq_len)
-            ),
+    update_ratio = (
+        DreamerV3UpdateRatio(
+            cfg.optimization.train_ratio
+            / (cfg.replay_buffer.batch_size * cfg.replay_buffer.seq_len)
         )
+        if cfg.optimization.train_ratio is not None
+        else None
+    )
+    use_bfloat16 = cfg.optimization.mixed_precision and device.type == "cuda"
 
-    for data in collector:
-        replay_data = data.select(
-            "action",
-            "is_init",
-            ("next", "observation"),
-            ("next", "reward"),
-            ("next", "terminated"),
-            ("collector", "traj_ids"),
-        )
-        rb.extend(replay_data.reshape(-1))
-        env_step += data.numel()
-
-        if len(rb) < warmup:
-            continue
-
-        batch_losses = torch.empty(updates_per_batch, 4, device=device)
-        for update_index in range(updates_per_batch):
-            sample = (
-                rb.sample()
-                .reshape(cfg.replay_buffer.batch_size, cfg.replay_buffer.seq_len)
-                .to(device)
+    def train_step(
+        sample: TensorDictBase,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        with torch.autocast(
+            device_type=device.type,
+            dtype=torch.bfloat16,
+            enabled=use_bfloat16,
+        ):
+            model_loss_td, model_out = model_loss(sample)
+            model_kl = (
+                model_loss_td["loss_model_dynamic"]
+                + model_loss_td["loss_model_representation"]
             )
-
-            sample.set(
-                "state",
-                torch.zeros(
-                    cfg.replay_buffer.batch_size,
-                    cfg.replay_buffer.seq_len,
-                    state_dim,
-                    device=sample.device,
-                ),
-            )
-            sample.set(
-                "belief",
-                torch.zeros(
-                    cfg.replay_buffer.batch_size,
-                    cfg.replay_buffer.seq_len,
-                    cfg.networks.rnn_hidden_dim,
-                    device=sample.device,
-                ),
-            )
-
-            m_td, model_out = model_loss(sample)
-            model_kl = m_td["loss_model_dynamic"] + m_td["loss_model_representation"]
-            total_m = (
+            total_model_loss = (
                 model_kl
-                + m_td["loss_model_reco"]
-                + m_td["loss_model_reward"]
-                + m_td["loss_model_continue"]
+                + model_loss_td["loss_model_reco"]
+                + model_loss_td["loss_model_reward"]
+                + model_loss_td["loss_model_continue"]
             ).squeeze()
-            opt_model.zero_grad(set_to_none=True)
-            total_m.backward()
-            adaptive_grad_clip_(
-                model_loss.parameters(), cfg.optimization.adaptive_grad_clip
-            )
-            opt_model.step()
-            schedulers[0].step()
 
-            # Imagine from posterior states.
             post_state = (
                 model_out.get(("next", "state")).detach().reshape(-1, state_dim)
             )
@@ -690,114 +537,192 @@ def main(cfg: DictConfig):
                 {"state": post_state, "belief": post_belief},
                 [post_state.shape[0]],
             )
-            a_td, fake_data = actor_loss(actor_input)
-            opt_actor.zero_grad(set_to_none=True)
-            a_td["loss_actor"].backward()
-            adaptive_grad_clip_(
-                actor_model.parameters(), cfg.optimization.adaptive_grad_clip
-            )
-            opt_actor.step()
-            schedulers[1].step()
+            actor_loss_td, fake_data = actor_loss(actor_input)
+            value_loss_td, _ = value_loss(fake_data.detach())
 
-            v_td, _ = value_loss(fake_data.detach())
-            opt_value.zero_grad(set_to_none=True)
-            v_td["loss_value"].backward()
-            adaptive_grad_clip_(
-                value_loss.parameters(), cfg.optimization.adaptive_grad_clip
+            replay_features = TensorDict(
+                {
+                    "state": model_out.get(("next", "state")),
+                    "belief": model_out.get(("next", "belief")),
+                    "bootstrap": fake_data.get("lambda_target")[..., 0, 0].reshape(
+                        sample.batch_size
+                    ),
+                    "next": sample.get("next").select("reward", "done", "terminated"),
+                },
+                sample.batch_size,
             )
-            opt_value.step()
-            schedulers[2].step()
-            value_target_updater.step()
+            replay_loss = value_loss.replay_value_loss(
+                replay_features,
+                horizon=cfg.optimization.continuation_horizon,
+                lmbda=cfg.optimization.lmbda,
+            )["loss_replay_value"]
+            total_loss = (
+                total_model_loss
+                + actor_loss_td["loss_actor"]
+                + value_loss_td["loss_value"]
+                + cfg.optimization.replay_value_loss_weight * replay_loss
+            )
 
-            batch_losses[update_index] = torch.stack(
-                (
-                    model_kl.detach().reshape(()),
-                    m_td["loss_model_reco"].detach().reshape(()),
-                    m_td["loss_model_reward"].detach().reshape(()),
-                    a_td["loss_actor"].detach().reshape(()),
+        optimizer.zero_grad(set_to_none=True)
+        total_loss.backward()
+        optimizer.step()
+        value_target_updater.step()
+        metrics = torch.stack(
+            (
+                model_kl.detach().reshape(()),
+                model_loss_td["loss_model_reco"].detach().reshape(()),
+                model_loss_td["loss_model_reward"].detach().reshape(()),
+                actor_loss_td["loss_actor"].detach().reshape(()),
+                value_loss_td["loss_value"].detach().reshape(()),
+                replay_loss.detach().reshape(()),
+            )
+        )
+        return (
+            metrics,
+            model_out.get(("next", "state")).detach(),
+            model_out.get(("next", "belief")).detach(),
+        )
+
+    if cfg.optimization.separate_policy_rng:
+        # Keep the learner draws in a range apart from the policy stream.
+        torch.manual_seed(stream_seed(cfg.env.seed, 0, LEARNER_RNG_STREAM))
+
+    for data in collector:
+        # The next action is already computed, thus it keeps the older policy.
+        if behavior_policy_sync is not None:
+            behavior_policy_sync.apply_after_action()
+        batch_start_action_step = action_step
+        completed_episodes = training_episode_returns(
+            data, running_training_return, num_envs
+        )
+        _log_train_episodes(
+            cfg, metrics_jsonl_path, completed_episodes, batch_start_action_step
+        )
+        replay_data = replay_record_builder(data)
+        with timeit("dreamer_v3/replay_extend"):
+            if shifted_record_extender is not None:
+                shifted_record_extender.extend(rb, replay_sampler, replay_data)
+            else:
+                replay_indices = rb.extend(
+                    replay_data if num_envs > 1 else replay_data.reshape(-1)
                 )
-            )
+                replay_sampler.observe_extend(replay_indices, rb.storage)
+        if (
+            not replay_pipeline.has_prefetched
+            and update_step == 0
+            and len(rb) >= num_envs * (cfg.replay_buffer.seq_len + 1)
+        ):
+            # Prefetch one batch ahead of the learner warmup gate below.
+            with timeit("dreamer_v3/replay_sample"):
+                replay_pipeline.prefetch(rb)
+        action_step += data.numel()
+        record_step += replay_data.numel() if count_reset_records else data.numel()
+
+        if len(rb) < warmup:
+            continue
+
+        batch_updates = (
+            update_ratio(record_step) if update_ratio is not None else updates_per_batch
+        )
+        if not batch_updates:
+            continue
+
+        if behavior_policy_sync is not None:
+            # Stage one time per batch; more updates keep the pending snapshot.
+            behavior_policy_sync.stage_before_training()
+
+        batch_losses = torch.empty((batch_updates, 6), device=device)
+        for update_index in range(batch_updates):
+            with timeit("dreamer_v3/replay_sample"):
+                replay_sample, sample_info = replay_pipeline.take(rb)
+                replay_sample = replay_sample.reshape(
+                    cfg.replay_buffer.batch_size,
+                    cfg.replay_buffer.seq_len + 1,
+                )
+                sample = replay_sample[:, :-1].to(device)
+            with timeit("dreamer_v3/replay_update"):
+                # Apply the older refresh, thus replay stays one sample ahead.
+                replay_pipeline.apply_pending_context(rb)
+            with timeit("dreamer_v3/train_update"):
+                (
+                    update_losses,
+                    refreshed_state,
+                    refreshed_belief,
+                ) = train_step(sample)
+                batch_losses[update_index].copy_(update_losses)
+                loss_window_sum += update_losses
+                loss_window_updates += 1
+            with timeit("dreamer_v3/replay_update"):
+                replay_pipeline.stage_context(
+                    sample_info,
+                    refreshed_state,
+                    refreshed_belief,
+                )
+            update_step += 1
 
         if record_loss_history:
-            batch_losses = batch_losses.cpu()
-            loss_history.append(batch_losses)
+            loss_history.append(batch_losses.cpu())
 
-        if env_step >= next_eval:
-            latest_losses = batch_losses[-1].cpu()
-            r = eval_episode_reward(
-                eval_env,
-                real_actor,
-                cfg.logger.eval_episodes,
-                cfg.env.max_episode_steps,
+        train_log_due = bool(
+            metrics_jsonl_path is not None
+            and cfg.logger.train_every
+            and (
+                record_step >= next_train_log or action_step >= collector_action_frames
             )
-            history_steps.append(env_step)
+        )
+        eval_due = bool(cfg.logger.eval_every and record_step >= next_eval)
+        latest_losses = batch_losses[-1].cpu() if eval_due else None
+        if train_log_due:
+            _log_train_window(
+                cfg=cfg,
+                metrics_jsonl_path=metrics_jsonl_path,
+                run_timer=run_timer,
+                record_step=record_step,
+                update_step=update_step,
+                loss_window_sum=loss_window_sum,
+                loss_window_updates=loss_window_updates,
+            )
+            loss_window_sum.zero_()
+            loss_window_updates = 0
+            next_train_log = record_step + cfg.logger.train_every
+
+        if eval_due:
+            r = _evaluate(
+                cfg=cfg,
+                device=device,
+                eval_env=eval_env,
+                real_world_actor=learner.real_world_actor,
+                metrics_jsonl_path=metrics_jsonl_path,
+                run_timer=run_timer,
+                record_step=record_step,
+                latest_losses=latest_losses,
+            )
+            history_steps.append(record_step)
             history_eval.append(r)
-            torchrl_logger.info(
-                "[env_step=%5d] eval_reward=%+.2f kl=%.3f reco=%.3f reward=%.3f actor=%.3f",
-                env_step,
-                r.item(),
-                latest_losses[0].item(),
-                latest_losses[1].item(),
-                latest_losses[2].item(),
-                latest_losses[3].item(),
-            )
-            next_eval = env_step + cfg.logger.eval_every
+            next_eval = record_step + cfg.logger.eval_every
 
-    if cfg.logger.output_plot and _has_matplotlib:
-        import matplotlib.pyplot as plt  # noqa: PLC0415  (optional dep)
+    if cfg.logger.output_plot:
+        save_run_plot(cfg, history_steps, history_eval, loss_history)
 
-        eval_steps = history_steps
-        eval_rewards = torch.stack(history_eval).cpu().numpy() if history_eval else []
-        loss_curves = torch.cat(loss_history).numpy() if loss_history else None
-        kl_vals = loss_curves[:, 0] if loss_curves is not None else []
-        reco_vals = loss_curves[:, 1] if loss_curves is not None else []
-        reward_vals = loss_curves[:, 2] if loss_curves is not None else []
-
-        fig, axes = plt.subplots(1, 2, figsize=(12, 4))
-        axes[0].plot(eval_steps, eval_rewards, marker="o")
-        axes[0].set_title(f"{cfg.env.name} eval reward (real env)")
-        axes[0].set_xlabel("env_step")
-        axes[0].set_ylabel("avg episode return")
-        axes[0].grid(True, alpha=0.3)
-
-        axes[1].plot(reco_vals, label="reco", alpha=0.8)
-        axes[1].plot(reward_vals, label="reward", alpha=0.8)
-        axes[1].plot(kl_vals, label="kl", alpha=0.8)
-        axes[1].set_title("World-model losses (update step)")
-        axes[1].set_xlabel("update step")
-        axes[1].legend()
-        axes[1].grid(True, alpha=0.3)
-
-        fig.suptitle(
-            f"DreamerV3 on {cfg.env.name} - {cfg.collector.total_frames} env steps, "
-            f"{updates_per_batch} updates/batch"
-        )
-        fig.tight_layout()
-        fig.savefig(cfg.logger.output_plot, dpi=120)
-        torchrl_logger.info("Saved plot to %s", cfg.logger.output_plot)
-    elif cfg.logger.output_plot:
-        torchrl_logger.warning(
-            "matplotlib is not installed; skipping plot %s", cfg.logger.output_plot
-        )
-
-    if cfg.logger.metrics_json:
-        metrics_path = Path(cfg.logger.metrics_json)
-        metrics_path.parent.mkdir(parents=True, exist_ok=True)
-        metrics_path.write_text(
-            json.dumps(
-                {
-                    "backend": cfg.env.backend,
-                    "environment": cfg.env.name,
-                    "task": cfg.env.task,
-                    "seed": cfg.env.seed,
-                    "environment_steps": history_steps,
-                    "evaluation_returns": [value.item() for value in history_eval],
-                },
-                indent=2,
-            )
-            + "\n"
-        )
-        torchrl_logger.info("Saved evaluation metrics to %s", metrics_path)
+    append_jsonl(
+        metrics_jsonl_path,
+        {
+            "type": "summary",
+            "backend": cfg.env.backend,
+            "environment": cfg.env.name,
+            "task": cfg.env.task,
+            "seed": cfg.env.seed,
+            "environment_seeded": bool(cfg.env.use_seed),
+            "total_environment_steps": record_step,
+            "total_action_steps": action_step,
+            "updates": update_step,
+            "bfloat16": use_bfloat16,
+            "elapsed_seconds": run_timer.elapsed(),
+            "timings": timeit.todict(percall=False),
+        },
+    )
+    if metrics_jsonl_path is not None:
+        torchrl_logger.info("Saved run metrics to %s", metrics_jsonl_path)
 
 
 if __name__ == "__main__":

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -934,40 +934,35 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         not (_has_hydra and _has_omegaconf),
         reason="requires hydra and omegaconf",
     )
-    def test_dreamer_v3_sota_shares_imagination_parameters(self, device):
+    def test_dreamer_v3_sota_shares_imagination_parameters(self, device, monkeypatch):
         from omegaconf import OmegaConf
 
         repo_root = Path(__file__).parents[2]
+        example_dir = repo_root / "sota-implementations/dreamer_v3"
+        monkeypatch.syspath_prepend(str(example_dir))
         example = runpy.run_path(
             repo_root / "sota-implementations/dreamer_v3/train.py",
             run_name="dreamer_v3_test",
         )
         cfg = OmegaConf.load(repo_root / "sota-implementations/dreamer_v3/config.yaml")
         cfg.networks.num_reward_bins = self.num_reward_bins
-        (
-            world_model,
-            observation_encoder,
-            prior,
-            posterior,
-            reward_head,
-            reward_decoder,
-            continuation_head,
-        ) = example["build_world_model"](cfg=cfg, obs_dim=3, action_dim=self.action_dim)
+        (world_model, prior, reward_net, reward_decoder, continuation_net,) = example[
+            "build_world_model"
+        ](cfg=cfg, obs_dim=3, action_dim=self.action_dim)
+        posterior = world_model[1].rssm_posterior.module
         imagination_model = example["build_imagination_model"](
             prior_net=prior,
-            reward_net=reward_head,
+            reward_net=reward_net,
             reward_decoder=reward_decoder,
         ).to(device)
         continuation_model = example["build_continuation_model"](
-            continuation_net=continuation_head
+            continuation_net=continuation_net
         ).to(device)
         actor_model = example["build_actor"](cfg=cfg, action_dim=self.action_dim).to(
             device
         )
-        real_actor = example["build_real_actor"](
-            observation_encoder=observation_encoder,
-            posterior_net=posterior,
-            prior_net=prior,
+        real_actor = example["build_real_world_actor"](
+            world_model=world_model,
             actor_model=actor_model,
         ).to(device)
         world_model = world_model.to(device)
@@ -996,7 +991,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             symlog(world_input["next", "reco_pixels"]),
             world_input["next", "reco_symlog_observation"],
         )
-        shared_parameters = tuple(prior.parameters()) + tuple(reward_head.parameters())
+        shared_parameters = tuple(prior.parameters()) + tuple(reward_net.parameters())
         world_parameters = tuple(world_model.parameters())
         imagination_parameters = tuple(imagination_model.parameters())
         assert all(
@@ -1009,7 +1004,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             and any(
                 parameter is candidate for candidate in continuation_model.parameters()
             )
-            for parameter in continuation_head.parameters()
+            for parameter in continuation_net.parameters()
         )
 
         observation = torch.tensor(
@@ -1018,7 +1013,10 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         real_input = TensorDict(
             {
                 "observation": observation,
+                "state": torch.zeros(1, self.state_dim, device=device),
                 "belief": torch.zeros(1, cfg.networks.rnn_hidden_dim, device=device),
+                "previous_action": torch.zeros(1, self.action_dim, device=device),
+                "is_init": torch.zeros(1, 1, dtype=torch.bool, device=device),
             },
             [1],
         )
@@ -1042,11 +1040,6 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         continuation_model(reward_td)
         assert reward_td["continuation"].shape == (2, 1)
 
-        parameter = nn.Parameter(torch.tensor([3.0, 4.0], device=device))
-        parameter.grad = torch.tensor([30.0, 40.0], device=device)
-        example["adaptive_grad_clip_"]([parameter], clip=0.3)
-        assert parameter.grad.norm().item() == pytest.approx(1.5)
-
     @pytest.mark.skipif(not _has_omegaconf, reason="requires omegaconf")
     def test_dreamer_v3_dmc_benchmark_aggregation(self, device, tmp_path):
         from omegaconf import OmegaConf
@@ -1059,19 +1052,26 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         )
         paths = []
         for seed, returns in enumerate(([1.0, 4.0], [3.0, 6.0], [2.0, 5.0])):
-            path = tmp_path / f"seed_{seed}.json"
-            path.write_text(
-                json.dumps(
-                    {
-                        "seed": seed,
-                        "environment_steps": [100, 200],
-                        "evaluation_returns": returns,
-                    }
-                )
+            path = tmp_path / f"seed_{seed}.jsonl"
+            records = [
+                {
+                    "type": "train_episode",
+                    "environment_steps": step,
+                    "score": score,
+                }
+                for step, score in zip((100, 200), returns)
+            ]
+            records.append(
+                {
+                    "type": "summary",
+                    "seed": seed,
+                    "total_environment_steps": 200,
+                }
             )
+            path.write_text("\n".join(map(json.dumps, records)) + "\n")
             paths.append(path)
 
-        summary = benchmark["aggregate_runs"](paths)
+        summary = benchmark["aggregate_runs"](paths, window_size=100)
         assert summary["environment_steps"] == [100, 200]
         assert summary["median_return"] == [2.0, 5.0]
         assert summary["lower_quartile_return"] == [1.5, 4.5]

--- a/torchrl/modules/models/model_based.py
+++ b/torchrl/modules/models/model_based.py
@@ -1125,7 +1125,8 @@ class DreamerV3MLP(nn.Module):
 
     Args:
         in_features (int): Input feature count.
-        out_features (int): Output feature count.
+        out_features (int or None): Output feature count. If ``None``, the
+            module returns the last hidden activation.
         depth (int, optional): Number of hidden layers. Defaults to 3.
         num_cells (int, optional): Hidden feature count. Defaults to 1024.
         outscale (float, optional): Multiplicative initialization scale for the
@@ -1145,7 +1146,7 @@ class DreamerV3MLP(nn.Module):
     def __init__(
         self,
         in_features: int,
-        out_features: int,
+        out_features: int | None,
         depth: int = 3,
         num_cells: int = 1024,
         outscale: float = 1.0,
@@ -1164,12 +1165,15 @@ class DreamerV3MLP(nn.Module):
                 ]
             )
             layer_in = num_cells
-        output = nn.Linear(layer_in, out_features, device=device)
-        layers.append(output)
+        output = None
+        if out_features is not None:
+            output = nn.Linear(layer_in, out_features, device=device)
+            layers.append(output)
         self.model = nn.Sequential(*layers)
         self.model.apply(_dreamer_v3_init)
-        with torch.no_grad():
-            output.weight.mul_(outscale)
+        if output is not None:
+            with torch.no_grad():
+                output.weight.mul_(outscale)
 
     def forward(self, *inputs: torch.Tensor) -> torch.Tensor:
         value = inputs[0] if len(inputs) == 1 else torch.cat(inputs, -1)


### PR DESCRIPTION
## Stack

1. #4132 — RSSM performance
2. **#4133 — pinned JAX Walker reproduction (this PR)**
3. #4134 — canonical-defaults prototype

This branch is based directly on #4132 and contains six reproduction-specific commits after it. Merge #4132 first.

## Summary

This extracts the end-to-end Walker Walk reproduction from #4128 into a dedicated PR.

The new preset and benchmark:

- track the author-maintained JAX implementation at `e3f02248693a79dc8b0ebd62c93683888ddaccfe`;
- match the pinned `dmc_proprio` `size1m` model and its 640,867 trainable parameters;
- implement the pinned replay schedule, mutable replay context, behavior-policy synchronization, RNG streams, BF16 path, optimizer ordering, and JSONL metrics;
- use the lower PR's configurable higher-order scan with `optimization.rssm_scan_unroll=8` whenever `optimization.compile_rssm=scan`, while leaving compilation off for short runs;
- add the DMC Walker configuration, three-seed median/IQR benchmark driver, and a short SOTA CI smoke command;
- document exactly how the pinned JAX protocol differs from the paper protocol.

The important policy choice is explicit: TorchRL's public algorithm documentation stays centered on the DreamerV3 paper. This named preset records later choices in the evolving JAX implementation instead of silently treating them as requirements of the paper.

## Fixes made while extracting

- corrected the optimizer description from Adam to AGC plus LaProp-style RMS scaling followed by momentum and warmup;
- renamed the misleading `adam_eps` configuration key to `optimizer_eps`;
- distinguished "paper" from "pinned JAX implementation" throughout the README and comments;
- removed newly added explicit `__init__` return annotations to follow the repository convention;
- aligned the stacked tests with the corrected continuation weighting, reset-action masking, RMS normalization, and block-GRU fixture;
- updated the SOTA integration test for the extracted helper modules and current builder contracts;
- updated benchmark coverage to exercise the JSONL training-episode format and explicit aggregation window;
- removed `torch.promote_types` from the compiled categorical path so the old-dependency `torch.compile` check can trace it;
- restored support for `DreamerV3MLP(out_features=None)`, which the headless SOTA backbones require after #4128 was squashed.

## Test plan

The exact short DreamerV3 SOTA smoke command from `.github/unittest/linux_sota/scripts/test_sota.py` completes for 400 environment steps and two learner updates. The configuration/build integration test also passes with the new scan-unroll option. The long three-seed Walker benchmark is intentionally left for scheduled/manual validation while this PR remains a draft.

The rebased stack passes 71 DreamerV3 objective tests and 212 non-compile component tests. Formatter, flake8, pydocstyle, codespell, autoflake, and pyupgrade checks pass on the changed files. Compile-specific component tests remain enabled in CI.

The `ci/optdeps` label is intentional because this touches the optional dm_control integration. The compiled higher-order paths target recent PyTorch only.

