### PR TITLE
[Deprecation] Make DreamerV3 defaults canonical

### DIFF
--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -308,6 +308,28 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
     # Utility tests
     # ------------------------------------------------------------------ #
 
+    def test_dreamer_v3_canonical_constructor_defaults(self, device):
+        model_loss = DreamerV3ModelLoss(
+            self._create_world_model(reward_two_hot=True).to(device),
+            num_reward_bins=self.num_reward_bins,
+        )
+        assert model_loss.kl_mode == "separate"
+        assert model_loss.unimix == 0.01
+
+        actor_loss = DreamerV3ActorLoss(
+            self._create_actor_model().to(device),
+            self._create_value_model().to(device),
+            self._create_mb_env().to(device),
+        )
+        assert actor_loss.use_reinforce
+
+        value_loss = DreamerV3ValueLoss(
+            self._create_value_model(out_features=self.num_reward_bins).to(device),
+            num_value_bins=self.num_reward_bins,
+        )
+        assert value_loss.value_loss == "two_hot"
+        assert value_loss.slow_critic_regularization == 1.0
+
     def test_dreamer_v3_symlog_invertibility(self, device):
         x = torch.tensor([-1000.0, -10.0, -1.0, 0.0, 1.0, 10.0, 1000.0], device=device)
         reconstructed = symexp(symlog(x))
@@ -410,6 +432,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             lambda_kl=lambda_kl,
             lambda_reco=lambda_reco,
             lambda_reward=lambda_reward,
+            kl_mode="balanced",
             reward_two_hot=reward_two_hot,
             num_reward_bins=self.num_reward_bins,
         )
@@ -423,6 +446,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         world_model = self._create_world_model(reward_two_hot=True).to(device)
         loss_module = DreamerV3ModelLoss(
             world_model,
+            kl_mode="balanced",
             num_reward_bins=self.num_reward_bins,
         )
         loss_td, _ = loss_module(tensordict)
@@ -706,8 +730,10 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
 
         value_loss = DreamerV3ValueLoss(
             value_model,
+            value_loss="symlog_mse",
             discount_loss=True,
             actor_loss=loss_module,
+            slow_critic_regularization=0.0,
         )
         value_loss(fake_data.detach())
 
@@ -769,7 +795,10 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             [batch, time_steps],
         )
         value_loss = DreamerV3ValueLoss(
-            self._create_value_model().to(device), reduction=reduction
+            self._create_value_model().to(device),
+            value_loss="symlog_mse",
+            slow_critic_regularization=0.0,
+            reduction=reduction,
         ).to(device)
         value_loss.set_keys(
             reward=("replay", "reward"),
@@ -794,6 +823,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             value_loss="symlog_mse",
             discount_loss=discount_loss,
             reduction=reduction,
+            slow_critic_regularization=0.0,
         )
         loss_td, _ = loss_module(tensordict)
         assert "loss_value" in loss_td.keys()
@@ -821,6 +851,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             value_loss="two_hot",
             discount_loss=discount_loss,
             num_value_bins=self.num_reward_bins,
+            slow_critic_regularization=0.0,
         )
         loss_td, _ = loss_module(tensordict)
         assert "loss_value" in loss_td.keys()
@@ -882,6 +913,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             legacy_value,
             value_loss="two_hot",
             num_value_bins=self.num_reward_bins,
+            slow_critic_regularization=0.0,
         )
         with pytest.warns(DeprecationWarning, match="removed in v0.16"):
             value_loss(self._create_value_data().to(device))
@@ -923,6 +955,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             value_model,
             value_loss="two_hot",
             num_value_bins=self.num_reward_bins,
+            slow_critic_regularization=0.0,
         )
         value_loss.set_keys(
             value=("predictions", "value"),
@@ -1350,6 +1383,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         world_model = self._create_world_model(reward_two_hot=True).to(device)
         loss_module = DreamerV3ModelLoss(
             world_model,
+            kl_mode="balanced",
             num_reward_bins=self.num_reward_bins,
         )
         loss_td, _ = loss_module(tensordict)
@@ -1705,6 +1739,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
 
         loss_module = DreamerV3ModelLoss(
             world_model,
+            kl_mode="balanced",
             num_reward_bins=self.num_reward_bins,
         )
         loss_td, _ = loss_module(tensordict)

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -227,15 +227,15 @@ class DreamerV3ModelLoss(LossModule):
             non-terminal continuation targets, for encoding the finite-horizon
             discount in the continuation model. Defaults to 1.0.
         kl_mode ("balanced" or "separate", optional): KL formulation.
-            ``"balanced"`` preserves the historical weighted aggregate;
-            ``"separate"`` emits the reference dynamics and representation
-            losses. Defaults to ``"balanced"``.
+            ``"balanced"`` selects the historical weighted aggregate;
+            ``"separate"`` emits the paper's dynamics and representation
+            losses. Defaults to ``"separate"``.
         lambda_dynamic (float, optional): Dynamics KL weight in separate mode.
             Defaults to 1.0.
         lambda_representation (float, optional): Representation KL weight in
             separate mode. Defaults to 0.1.
         unimix (float, optional): Uniform mixture used by the categorical KL
-            distributions. Defaults to 0.0 for compatibility.
+            distributions. Defaults to 0.01.
         kl_alpha (float, optional): KL balancing factor (alpha in the paper).
             Default: 0.8.
         free_bits (float, optional): Minimum KL per categorical in nats.
@@ -348,10 +348,10 @@ class DreamerV3ModelLoss(LossModule):
         lambda_reco: float = 1.0,
         lambda_reward: float = 1.0,
         lambda_continue: float = 0.0,
-        kl_mode: Literal["balanced", "separate"] = "balanced",
+        kl_mode: Literal["balanced", "separate"] = "separate",
         lambda_dynamic: float = 1.0,
         lambda_representation: float = 0.1,
-        unimix: float = 0.0,
+        unimix: float = 0.01,
         continue_target_scale: float = 1.0,
         kl_alpha: float = 0.8,
         free_bits: float = 1.0,
@@ -549,7 +549,7 @@ class DreamerV3ActorLoss(LossModule):
         use_reinforce (bool, optional): If ``True``, uses REINFORCE (log-prob
             * stop-gradient advantage). If ``False``, uses the straight
             reparameterization gradient (suitable for continuous Gaussian
-            actors). Default: ``False``.
+            actors). Default: ``True``.
         return_normalization (bool, optional): Normalize the actor objective
             by an EMA return-percentile span: REINFORCE advantages and the
             reparameterization lambda-returns are divided by the clamped span
@@ -691,7 +691,7 @@ class DreamerV3ActorLoss(LossModule):
         imagination_horizon: int = 15,
         discount_loss: bool = True,
         entropy_bonus: float = 3e-4,
-        use_reinforce: bool = False,
+        use_reinforce: bool = True,
         return_normalization: bool = True,
         return_normalization_rate: float = 0.01,
         return_normalization_quantiles: tuple[float, float] = (0.05, 0.95),
@@ -984,9 +984,9 @@ class DreamerV3ValueLoss(LossModule):
     Trains the value network to predict the lambda-target computed by
     :class:`DreamerV3ActorLoss`. Supports two loss modes:
 
-    - ``"symlog_mse"`` (default): ``(symlog(v_pred) - symlog(target))^2``
-    - ``"two_hot"``: Two-hot cross-entropy over a fixed bin grid (matches the
-      full DreamerV3 distribution-valued critic).
+    - ``"two_hot"`` (default): Two-hot cross-entropy over a fixed bin grid,
+      matching the DreamerV3 distribution-valued critic.
+    - ``"symlog_mse"``: ``(symlog(v_pred) - symlog(target))^2``.
 
     The discount factor used here must match the one the actor used to compute
     ``lambda_target``. The recommended way to keep them in lock-step is to
@@ -1004,7 +1004,7 @@ class DreamerV3ValueLoss(LossModule):
     Args:
         value_model (TensorDictModule): The value network.
         value_loss ("symlog_mse" or "two_hot", optional): Loss type.
-            Default: ``"symlog_mse"``.
+            Default: ``"two_hot"``.
         discount_loss (bool, optional): If ``True``, discounts the loss with
             a cumulative gamma factor. Default: ``True``.
         gamma (float, optional): Discount factor used when ``discount_loss=True``.
@@ -1016,20 +1016,28 @@ class DreamerV3ValueLoss(LossModule):
             avoiding any chance of a mismatch. Default: ``None``.
         slow_critic_regularization (float, optional): Weight of the auxiliary
             loss that trains the online critic toward decoded target-critic
-            predictions. Default: ``0.0``.
+            predictions. Default: ``1.0``.
         reduction ("none", "mean" or "sum", optional): Reduction applied to
             the loss. Defaults to ``"mean"``.
 
     Examples:
         >>> import torch
         >>> from tensordict import TensorDict
-        >>> from tensordict.nn import TensorDictModule
-        >>> from torchrl.modules import MLP
+        >>> from tensordict.nn import TensorDictModule, TensorDictSequential
+        >>> from torchrl.modules import MLP, SymExpTwoHot
         >>> from torchrl.objectives import DreamerV3ValueLoss
         >>> value_model = TensorDictModule(
-        ...     MLP(out_features=1, depth=1, num_cells=8),
+        ...     MLP(out_features=255, depth=1, num_cells=8),
         ...     in_keys=["state"],
-        ...     out_keys=["state_value"],
+        ...     out_keys=["state_value_logits"],
+        ... )
+        >>> value_model = TensorDictSequential(
+        ...     value_model,
+        ...     TensorDictModule(
+        ...         SymExpTwoHot(255),
+        ...         in_keys=["state_value_logits"],
+        ...         out_keys=["state_value"],
+        ...     ),
         ... )
         >>> td = TensorDict({
         ...     "state": torch.randn(8, 4),
@@ -1080,12 +1088,12 @@ class DreamerV3ValueLoss(LossModule):
     def __init__(
         self,
         value_model: TensorDictModule,
-        value_loss: Literal["symlog_mse", "two_hot"] = "symlog_mse",
+        value_loss: Literal["symlog_mse", "two_hot"] = "two_hot",
         discount_loss: bool = True,
         gamma: float = 0.99,
         num_value_bins: int = _DEFAULT_NUM_BINS,
         actor_loss: DreamerV3ActorLoss | None = None,
-        slow_critic_regularization: float = 0.0,
+        slow_critic_regularization: float = 1.0,
         reduction: Literal["none", "mean", "sum"] | None = None,
     ):
         super().__init__()


### PR DESCRIPTION
## Stack

1. #4132 — RSSM performance
2. #4133 — pinned JAX Walker reproduction
3. **#4134 — canonical-defaults prototype (this PR)**

This branch is based directly on #4133 and adds one defaults-focused commit. Merge #4132 and #4133 first.

## Summary

This draft makes the public DreamerV3 loss constructors select the canonical paper/JAX recipe without extra keyword arguments:

- separate dynamics and representation KL losses;
- 1% categorical uniform mixture;
- REINFORCE actor gradients;
- two-hot critic loss;
- slow-critic regularization with weight 1.

Historical behavior remains available explicitly through `kl_mode="balanced"`, `unimix=0`, `use_reinforce=False`, `value_loss="symlog_mse"`, and `slow_critic_regularization=0`.

This discussion came out of the review and extraction of #4128.

## Paper versus JAX

My proposed rule is:

1. Document the paper as the normative algorithmic contract.
2. Document later JAX choices in named, pinned presets such as #4133.
3. Use paper-canonical public defaults when the paper is unambiguous; do not silently inherit every subsequent JAX experiment as an API requirement.

For these five settings, the paper and the current JAX recipe point in the same direction. The JAX-specific environment size, step count, replay ratio, optimizer schedule, RNG, and logging choices stay in the named SOTA preset rather than becoming loss API defaults.

## Community feedback requested

This is deliberately a draft prototype, not merge-ready deprecation code. Changing these defaults directly would violate TorchRL's compatibility policy. Before replacing this implementation with staged warnings and versioned default changes, I would like feedback on:

- Is the five-setting default bundle the right canonical contract?
- Should any setting remain compatibility-first even after a deprecation cycle?
- Is explicit legacy configuration sufficient, or is a named compatibility preset/factory warranted?
- Should all five defaults migrate together, or should model, actor, and critic defaults move separately?

Once the direction is agreed, the direct switches in this draft should be converted to the repository's two-minor-release warning/default-change schedule with explicit target versions.

## Test plan

```text
PYTHONPATH=. python -m pytest -q test/objectives/test_dreamer_v3.py
71 passed
```
