### PR TITLE
[BugFix] Preserve TruncatedNormal sample dtype

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -542,6 +542,30 @@ class TestIndependentNormal:
 
 
 class TestTruncatedNormal:
+    @pytest.mark.parametrize("device", get_default_devices())
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.float64])
+    @pytest.mark.parametrize("tensor_bounds", [False, True])
+    def test_truncnormal_rsample_dtype(self, device, dtype, tensor_bounds):
+        torch.manual_seed(0)
+        loc = torch.zeros(3, device=device, dtype=dtype, requires_grad=True)
+        scale = torch.ones(3, device=device, dtype=dtype, requires_grad=True)
+        if tensor_bounds:
+            low = torch.full_like(loc, -1)
+            high = torch.full_like(loc, 1)
+        else:
+            low = -1.0
+            high = 1.0
+
+        dist = TruncatedNormal(loc, scale, low=low, high=high)
+        sample = dist.rsample((4,))
+
+        assert sample.dtype == dtype
+        assert sample.isfinite().all()
+        sample.sum().backward()
+        for grad in (loc.grad, scale.grad):
+            assert grad is not None and grad.dtype == dtype
+            assert grad.isfinite().all()
+
     @pytest.mark.parametrize(
         "min", [-torch.ones(3), -1, 3 * torch.tensor([-1.0, -2.0, -0.5]), -0.1]
     )

--- a/torchrl/modules/distributions/continuous.py
+++ b/torchrl/modules/distributions/continuous.py
@@ -244,11 +244,11 @@ class TruncatedNormal(D.Independent):
 
         if not isinstance(high, torch.Tensor):
             high = torch.as_tensor(high, device=self.device, dtype=loc.dtype)
-        else:
+        elif high.device != self.device:
             high = high.to(self.device)
         if not isinstance(low, torch.Tensor):
             low = torch.as_tensor(low, device=self.device, dtype=loc.dtype)
-        else:
+        elif low.device != self.device:
             low = low.to(self.device)
         self.low = low
         self.high = high

--- a/torchrl/modules/distributions/continuous.py
+++ b/torchrl/modules/distributions/continuous.py
@@ -242,8 +242,14 @@ class TruncatedNormal(D.Independent):
         self.device = loc.device
         self.upscale = torch.as_tensor(upscale, device=self.device)
 
-        high = torch.as_tensor(high, device=self.device)
-        low = torch.as_tensor(low, device=self.device)
+        if not isinstance(high, torch.Tensor):
+            high = torch.as_tensor(high, device=self.device, dtype=loc.dtype)
+        else:
+            high = high.to(self.device)
+        if not isinstance(low, torch.Tensor):
+            low = torch.as_tensor(low, device=self.device, dtype=loc.dtype)
+        else:
+            low = low.to(self.device)
         self.low = low
         self.high = high
         self.update(loc, scale)

--- a/torchrl/modules/distributions/truncated_normal.py
+++ b/torchrl/modules/distributions/truncated_normal.py
@@ -130,9 +130,7 @@ class TruncatedStandardNormal(Distribution):
         if sample_shape is None:
             sample_shape = torch.Size([])
         shape = self._extended_shape(sample_shape)
-        p = torch.empty(shape, device=self.a.device).uniform_(
-            self._dtype_min_gt_0, self._dtype_max_lt_1
-        )
+        p = self.a.new_empty(shape).uniform_(self._dtype_min_gt_0, self._dtype_max_lt_1)
         return self.icdf(p)
 
 


### PR DESCRIPTION
## Description

Preserve the promoted dtype of samples returned by `TruncatedNormal.rsample()`.

The upcast had two independent sources:

- scalar `low` and `high` bounds were materialized in the global default dtype instead of `loc.dtype`;
- the inverse-CDF sampler created its uniform probabilities with `torch.empty`, also using the global default dtype.

This change gives scalar bounds the location dtype and creates probability samples from the normalized bound tensor. Explicit tensor bounds retain their own dtype, so normal PyTorch promotion semantics are preserved. The regression test covers scalar and tensor bounds across `float16`, `float32`, and `float64`, and checks finite samples plus finite same-dtype gradients.

## Motivation and Context

Closes #4136.

Mixed-precision policies can use `TruncatedNormal` to generate bounded actions. Returning `float32` from `float16` parameters silently changes the action dtype and diverges from `torch.distributions.Normal`. The fix is applied at the two dtype-introducing constructors rather than casting the final sample, so explicitly wider parameters or tensor bounds still promote naturally.

- [x] I have raised an issue to propose this change

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly.
- [ ] I have updated the documentation accordingly.

## Validation

- The new six-case regression failed on pristine `main` for both `float16` paths before the fix.
- `py -3.13 -m pytest test/test_distributions.py -q` — 984 passed; one local warning that the optional TorchRL C++ extension is unavailable.
- All changed-file pre-commit hooks passed. The Windows-incompatible `python` invocation for `check-docstring-args` was also run directly with `py -3.13` and passed.
- `py -3.13 -m py_compile` passed for all three changed files.
- Manual mixed-dtype checks verified that wider `scale` or explicit tensor bounds still promote the output, while all-`float16` inputs remain `float16`.
- `git diff --check` passed.

## Notes

A `torch.compile` smoke test was attempted but is not counted as passing: the local Windows host has no MSVC `cl`, and full-graph eager compilation reaches an existing `Tensor.tolist()` graph break in `TruncatedStandardNormal.__init__` before sampling.