### PR TITLE
[Example] Replace deprecated torch.cuda.amp.GradScaler with torch.amp in RLHF example

### DIFF
--- a/examples/rlhf/train.py
+++ b/examples/rlhf/train.py
@@ -93,7 +93,7 @@ def main(cfg):
     if train_cfg.decay_lr:
         scheduler = CosineAnnealingLR(optimizer, **train_cfg.scheduler)
 
-    scaler = torch.cuda.amp.GradScaler(enabled=(dtype == "float16"))
+    scaler = torch.amp.GradScaler("cuda", enabled=(dtype == "float16"))
     estimate_loss = create_loss_estimator(eval_iters, ctx)
 
     best_val_loss = float("inf")


### PR DESCRIPTION
Fixes #4138

### Summary

`torch.cuda.amp.GradScaler` has been deprecated since torch 2.3 and is scheduled for removal. This PR migrates the last remaining `torch.cuda.amp` reference in the repository — [examples/rlhf/train.py:96](https://github.com/pytorch/rl/blob/main/examples/rlhf/train.py#L96) — to the `torch.amp` API:

```python
scaler = torch.amp.GradScaler("cuda", enabled=(dtype == "float16"))
```

`torch.amp.GradScaler("cuda", ...)` is the official replacement, available since torch 2.3 and fully API-/state-dict-compatible. The example's autocasting already goes through the new API (`examples/rlhf/utils.py` returns `torch.amp.autocast(device_type="cuda", ...)` via `setup()`), and the library core (`torchrl/`) uses `torch.amp.*` throughout — this line was the only inconsistent spot.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Validation

Verified on torch 2.11.0 with `warnings.simplefilter("error", FutureWarning)`:

- `torch.amp.GradScaler("cuda", enabled=True)` constructs warning-free (autocast/AMP is disabled when CUDA is unavailable, by design).
- Control group: `torch.cuda.amp.GradScaler(enabled=True)` raises `FutureWarning` under the same filter — the fix is effective and the filter is sensitive.
- `py_compile` passes; the full repo has zero remaining `torch.cuda.amp` references (verified with grep).

### User impact

No behavior change; the `FutureWarning` emitted by every fp16 RLHF training run on torch 2.4+ is eliminated, as is the `AttributeError` risk once `torch.cuda.amp` is removed.

### Notes for reviewers

- `torch.amp.GradScaler("cuda")` and `torch.cuda.amp.GradScaler()` share the same methods and checkpoint/state-dict format, so no scaling behavior changes.
- The declared floor in `pyproject.toml` is `torch>=2.1.0`; `torch.amp.GradScaler` needs torch ≥ 2.3, but the library core already requires `torch.amp` in practice (e.g. `torchrl/modules/models/model_based.py`), so the effective minimum is unchanged.
- Same migration as [ultralytics/yolov5#13244](https://github.com/ultralytics/yolov5/pull/13244) and [huggingface/lerobot#3167](https://github.com/huggingface/lerobot/pull/3167).