### PR TITLE
[Trainer] Implement GRPOTrainer and SOTA execution pipelines

### DIFF
--- a/.github/unittest/linux_sota/scripts/test_sota.py
+++ b/.github/unittest/linux_sota/scripts/test_sota.py
@@ -25,18 +25,6 @@ commands = {
   logger.eval_episodes=4 \
   checkpoint.save_iter=2
 """,
-    "grpo_sync": """python sota-implementations/grpo/grpo-sync.py \
-  train.epochs=1 \
-  train.total_dialog_turns=4 \
-  train.mixed_precision=False \
-  logger.backend=
-""",
-    "grpo_async": """python sota-implementations/grpo/grpo-async.py \
-  train.epochs=1 \
-  train.total_dialog_turns=4 \
-  train.mixed_precision=False \
-  logger.backend=
-""",
     "diffusion_bc": """python sota-implementations/diffusion_bc/diffusion_bc.py \
   optim.gradient_steps=55 \
   replay_buffer.dataset= \

--- a/.github/unittest/linux_sota/scripts/test_sota.py
+++ b/.github/unittest/linux_sota/scripts/test_sota.py
@@ -25,6 +25,18 @@ commands = {
   logger.eval_episodes=4 \
   checkpoint.save_iter=2
 """,
+    "grpo_sync": """python sota-implementations/grpo/grpo-sync.py \
+  train.epochs=1 \
+  train.total_dialog_turns=4 \
+  train.mixed_precision=False \
+  logger.backend=
+""",
+    "grpo_async": """python sota-implementations/grpo/grpo-async.py \
+  train.epochs=1 \
+  train.total_dialog_turns=4 \
+  train.mixed_precision=False \
+  logger.backend=
+""",
     "diffusion_bc": """python sota-implementations/diffusion_bc/diffusion_bc.py \
   optim.gradient_steps=55 \
   replay_buffer.dataset= \

--- a/docs/source/reference/trainers_basics.rst
+++ b/docs/source/reference/trainers_basics.rst
@@ -35,6 +35,7 @@ Algorithm-specific trainers
     IQLTrainer
     CQLTrainer
     TD3Trainer
+    GRPOTrainer
 
 Builders
 --------

--- a/docs/source/reference/trainers_basics.rst
+++ b/docs/source/reference/trainers_basics.rst
@@ -14,6 +14,7 @@ Trainer and hooks
 
     Trainer
     TrainerHookBase
+    MixedPrecisionOptimizationStepper
 
 Algorithm-specific trainers
 ---------------------------

--- a/sota-check/run_grpo_async.sh
+++ b/sota-check/run_grpo_async.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#SBATCH --job-name=grpo_async
+#SBATCH --ntasks=8
+#SBATCH --cpus-per-task=1
+#SBATCH --gres=gpu:1
+#SBATCH --output=slurm_logs/grpo_async_%j.txt
+#SBATCH --error=slurm_errors/grpo_async_%j.txt
+
+current_commit=$(git rev-parse --short HEAD)
+project_name="torchrl-example-check-$current_commit"
+group_name="grpo_async"
+export PYTHONPATH=$(dirname $(dirname $PWD))
+python $PYTHONPATH/sota-implementations/grpo/grpo-async.py \
+  logger.backend=wandb \
+  logger.project_name="$project_name" \
+  logger.group_name="$group_name"
+
+# Capture the exit status of the Python command
+exit_status=$?
+# Write the exit status to a file
+if [ $exit_status -eq 0 ]; then
+  echo "${group_name}_${SLURM_JOB_ID}=success" >> report.log
+else
+  echo "${group_name}_${SLURM_JOB_ID}=error" >> report.log
+fi

--- a/sota-check/run_grpo_sync.sh
+++ b/sota-check/run_grpo_sync.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#SBATCH --job-name=grpo_sync
+#SBATCH --ntasks=8
+#SBATCH --cpus-per-task=1
+#SBATCH --gres=gpu:1
+#SBATCH --output=slurm_logs/grpo_sync_%j.txt
+#SBATCH --error=slurm_errors/grpo_sync_%j.txt
+
+current_commit=$(git rev-parse --short HEAD)
+project_name="torchrl-example-check-$current_commit"
+group_name="grpo_sync"
+export PYTHONPATH=$(dirname $(dirname $PWD))
+python $PYTHONPATH/sota-implementations/grpo/grpo-sync.py \
+  logger.backend=wandb \
+  logger.project_name="$project_name" \
+  logger.group_name="$group_name"
+
+# Capture the exit status of the Python command
+exit_status=$?
+# Write the exit status to a file
+if [ $exit_status -eq 0 ]; then
+  echo "${group_name}_${SLURM_JOB_ID}=success" >> report.log
+else
+  echo "${group_name}_${SLURM_JOB_ID}=error" >> report.log
+fi

--- a/sota-implementations/grpo/grpo-async.py
+++ b/sota-implementations/grpo/grpo-async.py
@@ -152,12 +152,8 @@ def train(
         for collector in collectors:
             sender.register_collector(collector)
 
-    # Wait until the replay buffer has at least one write before starting training
-    import time
-
-    while not replay_buffer.write_count:
-        torchrl_logger.info("Waiting for replay buffer...")
-        time.sleep(1)
+    # The trainer waits for the replay buffer to receive its first write
+    # before starting optimization, so no manual wait is needed here.
 
     # Make optimizer
     optimizer = torch.optim.Adam(
@@ -186,28 +182,30 @@ def train(
         config=OmegaConf.to_container(cfg, resolve=True),
     )
 
-    # In async mode the collector runs in the background and writes to the
-    # replay buffer directly.  GRPOTrainer with async_collection=True skips
+    # In async mode the collectors run in the background and write to the
+    # replay buffer directly. GRPOTrainer with async_collection=True skips
     # the pre_epoch buffer-extend hook and only samples from it.
     # We pass the first collector as the reference collector for the trainer's
-    # progress tracking; the others have already been started above.
+    # progress tracking; the others have already been started above
+    # (start() is a no-op on an already-running collector).
     torchrl_logger.info("Building GRPOTrainer...")
     autocast_dtype = getattr(torch, cfg.train_model.torch_dtype)
-    total_steps = (
-        -(cfg.train.total_dialog_turns // -cfg.train.optim_batch_size)
-        * cfg.train.epochs
-    )
     trainer = GRPOTrainer(
         collector=collectors[0],
         total_frames=cfg.train.total_dialog_turns,
         frame_skip=1,
-        optim_steps_per_batch=total_steps,
+        # One optimizer step (gradient_accumulation_steps micro-batches) per
+        # trainer iteration, so that weight updates every
+        # `weight_update_frequency` optimizer steps interleave with collection
+        # as in the reference loop.
+        optim_steps_per_batch=cfg.train.gradient_accumulation_steps,
         loss_module=loss_fn,
         optimizer=optimizer,
         weight_sync_sender=sender,
         weight_update_frequency=cfg.train.weight_update_frequency,
         empty_replay_buffer_on_weight_update=False,  # async mode: never flush
         replay_buffer=replay_buffer,
+        device=train_device,
         mixed_precision=cfg.train.mixed_precision,
         autocast_dtype=autocast_dtype,
         gradient_accumulation_steps=cfg.train.gradient_accumulation_steps,

--- a/sota-implementations/grpo/grpo-async.py
+++ b/sota-implementations/grpo/grpo-async.py
@@ -6,9 +6,7 @@
 from __future__ import annotations
 
 import contextlib
-import gc
 import os
-import time
 from functools import partial
 from pathlib import Path
 
@@ -16,7 +14,6 @@ import hydra
 from omegaconf import OmegaConf
 
 from torchrl import merge_ray_runtime_env, torchrl_logger
-from torchrl.data.llm.history import History
 from torchrl.record.loggers.wandb import WandbLogger
 from torchrl.weight_update.llm import get_model_metadata
 
@@ -35,7 +32,6 @@ from grpo_utils import (
     compute_device_allocation,
     get_inference_model,
     get_train_model,
-    log_training_metrics,
     make_env,
     make_weight_sync_scheme,
 )
@@ -47,18 +43,11 @@ except ImportError:
     raise ImportError(
         "TensorDict is required. Please install it with `pip install tensordict`."
     )
-from torch.amp.autocast_mode import autocast
-from torch.amp.grad_scaler import GradScaler
-from torchrl._utils import timeit
 from torchrl.collectors.llm import RayLLMCollector
 from torchrl.data import LazyStackStorage, ReplayBuffer
 from torchrl.data.replay_buffers.ray_buffer import RayReplayBuffer
 from torchrl.objectives.llm.grpo import GRPOLoss, MCAdvantage
-
-
-def _tensor_is_finite(tensor) -> bool:
-    tensor = torch.as_tensor(tensor).detach()
-    return bool(torch.isfinite(tensor).all().item())
+from torchrl.trainers.algorithms.grpo import GRPOTrainer
 
 
 def _finish_wandb_logger(wandb_logger: WandbLogger | None, exit_code: int) -> None:
@@ -92,20 +81,21 @@ def train(
     inference_policy,
     devices: list[int] | None = None,
 ):
-    """Main training loop for GRPO async.
+    """Main training entry point for GRPO async.
 
-    This function implements asynchronous training where data collection and optimization
-    happen concurrently. The total number of steps is determined by the number of epochs,
-    samples per epoch, and batches collected.
+    Data collection and optimization happen concurrently (async mode).
+    The training loop is fully managed by :class:`~torchrl.trainers.GRPOTrainer`
+    with ``async_collection=True``.
 
     Args:
-        replay_buffer: The replay buffer to store experiences
-        cfg: The configuration object containing training parameters
-        collectors: The collectors objects.
+        replay_buffer: The replay buffer to store experiences.
+        cfg: The configuration object containing training parameters.
+        collectors: The list of async collector objects.
+        inference_policy: The inference-side LLM wrapper.
         devices: The devices to use for the training model.
     """
     # Setup training model and tokenizer
-    policy_training, train_tokenizer = get_train_model(cfg, devices=devices)
+    policy_training, _train_tokenizer = get_train_model(cfg, devices=devices)
     train_device = torch.device(f"cuda:{devices[0]}" if devices else "cuda:0")
 
     # Setup loss function
@@ -133,12 +123,7 @@ def train(
     )
 
     # Set up weight sync scheme for collectors
-    # Note: We need to get the sender after the collectors are created
-    # For now, we'll update the collectors to use the scheme
     torchrl_logger.info("Setting up weight synchronization scheme...")
-
-    # We'll need to manually set up the sender since collectors were already created
-    # without the scheme. In production, collectors should be created with weight_sync_schemes parameter.
     sender = weight_sync_scheme.create_sender()
     # Register the HuggingFace model directly (not the TransformersWrapper)
     # so state_dict() keys match vLLM's expected format (e.g., model.layers.0.*)
@@ -153,11 +138,9 @@ def train(
         sender.init_all_workers_group(metadata, vllm_engine=inference_engine)
 
     # First weight update
-    with timeit("update_policy_weights"):
-        sender.update_weights()
+    torchrl_logger.info("Performing first weight update...")
+    sender.update_weights()
     torchrl_logger.info("Completed first update_policy_weights. Starting collectors...")
-    timeit.print(prefix="First update_policy_weights_ time")
-    timeit.reset()
 
     for i, collector in enumerate(collectors):
         torchrl_logger.info(f"Starting collector {i}...")
@@ -168,6 +151,9 @@ def train(
     if hasattr(sender, "register_collector"):
         for collector in collectors:
             sender.register_collector(collector)
+
+    # Wait until the replay buffer has at least one write before starting training
+    import time
 
     while not replay_buffer.write_count:
         torchrl_logger.info("Waiting for replay buffer...")
@@ -181,7 +167,6 @@ def train(
         eps=getattr(cfg.optimizer, "eps", 1e-8),
         fused=False,
     )
-    scaler = GradScaler(enabled=cfg.train.mixed_precision)
 
     # Make checkpoint dir
     checkpoint_dir = Path(cfg.logging.checkpoint_dir)
@@ -193,7 +178,6 @@ def train(
         experiment_name = [experiment_name]
     else:
         experiment_name = []
-
     experiment_name.append(cfg.env.dataset)
     experiment_name.append(cfg.model.name)
     wandb_logger = WandbLogger(
@@ -202,159 +186,46 @@ def train(
         config=OmegaConf.to_container(cfg, resolve=True),
     )
 
-    # Training loop
+    # In async mode the collector runs in the background and writes to the
+    # replay buffer directly.  GRPOTrainer with async_collection=True skips
+    # the pre_epoch buffer-extend hook and only samples from it.
+    # We pass the first collector as the reference collector for the trainer's
+    # progress tracking; the others have already been started above.
+    torchrl_logger.info("Building GRPOTrainer...")
+    autocast_dtype = getattr(torch, cfg.train_model.torch_dtype)
     total_steps = (
         -(cfg.train.total_dialog_turns // -cfg.train.optim_batch_size)
         * cfg.train.epochs
     )
-    torchrl_logger.info(f"Total steps: {total_steps}")
+    trainer = GRPOTrainer(
+        collector=collectors[0],
+        total_frames=cfg.train.total_dialog_turns,
+        frame_skip=1,
+        optim_steps_per_batch=total_steps,
+        loss_module=loss_fn,
+        optimizer=optimizer,
+        weight_sync_sender=sender,
+        weight_update_frequency=cfg.train.weight_update_frequency,
+        empty_replay_buffer_on_weight_update=False,  # async mode: never flush
+        replay_buffer=replay_buffer,
+        mixed_precision=cfg.train.mixed_precision,
+        autocast_dtype=autocast_dtype,
+        gradient_accumulation_steps=cfg.train.gradient_accumulation_steps,
+        clip_norm=cfg.optimizer.clip_grad_norm,
+        logger=wandb_logger,
+        log_interval=cfg.train.logging_frequency,
+        num_epochs=1,  # async: one pass per collection step
+        async_collection=True,
+        log_rewards=True,
+        log_kl=cfg.train.use_kl_to_ref,
+    )
 
-    pbar = tqdm.tqdm(total=total_steps)
-    grad_norm = 0.0  # Initialize grad_norm
-    data_read_count = 0
-    optim_steps = 0  # Track optimizer steps for weight update scheduling
-    skipped_nonfinite_updates = 0
-    start_time = time.time()
+    torchrl_logger.info("Starting training loop.")
     exit_code = 1
     try:
-        for step in range(total_steps):
-            if not any(collector.is_running() for collector in collectors):
-                raise RuntimeError(
-                    f"Collectors stopped before training completed at step {step}/{total_steps}."
-                )
-            pbar.update(1)
-            pbar.set_description(f"Step {step}, writes: {replay_buffer.write_count}")
-
-            with timeit("sampling"):
-                # Sample the correct batch size for gradient accumulation
-                # The replay buffer is configured with batch_size = optim_batch_size // gradient_accumulation_steps
-                # So we should sample that amount per step, not the full optim_batch_size
-                batch_size_per_step = (
-                    cfg.train.optim_batch_size // cfg.train.gradient_accumulation_steps
-                )
-                batch = replay_buffer.sample(batch_size_per_step).to(train_device)
-                history: History = batch.view(-1)[0]["history", "full"]
-                history_str: list[str] | str = history.apply_chat_template(
-                    tokenizer=train_tokenizer
-                )
-                while not isinstance(history_str, str):
-                    history_str = "\n".join(history_str)
-
-                data_read_count += batch.numel()
-
-            with timeit("forward_pass"):
-                # Use the model's dtype for autocast to avoid bf16→fp16 downcast
-                # (fp16 range ±65504 can overflow with bf16 activations ±3.4e38)
-                autocast_dtype = getattr(torch, cfg.train_model.torch_dtype)
-                with autocast(
-                    "cuda",
-                    enabled=cfg.train.mixed_precision,
-                    dtype=autocast_dtype,
-                ):
-                    loss = loss_fn(batch)
-                    loss_val = (
-                        loss.mean(reduce=True) / cfg.train.gradient_accumulation_steps
-                    )
-                    if not _tensor_is_finite(loss_val):
-                        torchrl_logger.warning(
-                            f"Skipping GRPO training step {step} because loss is "
-                            f"non-finite: {loss_val.detach()}."
-                        )
-                        optimizer.zero_grad(set_to_none=True)
-                        continue
-
-            with timeit("backward_pass"):
-                if (
-                    cfg.train.mixed_precision
-                    and cfg.train_model.torch_dtype == "float16"
-                ):
-                    scaler = GradScaler(enabled=True)
-                    scaler.scale(loss_val).backward()
-                else:
-                    loss_val.backward()
-
-            if (step + 1) % cfg.train.gradient_accumulation_steps == 0:
-                with timeit("optim_step"):
-                    if (
-                        cfg.train.mixed_precision
-                        and cfg.train_model.torch_dtype == "float16"
-                    ):
-                        scaler.unscale_(optimizer)
-
-                    grad_norm = torch.nn.utils.clip_grad_norm_(
-                        policy_training.parameters(),
-                        cfg.optimizer.clip_grad_norm,
-                    )
-                    did_optim_step = _tensor_is_finite(grad_norm)
-                    if not did_optim_step:
-                        skipped_nonfinite_updates += 1
-                        torchrl_logger.warning(
-                            f"Skipping optimizer step at GRPO training step {step} "
-                            f"because gradient norm is non-finite: {grad_norm}. "
-                            f"Skipped non-finite updates: "
-                            f"{skipped_nonfinite_updates}."
-                        )
-                        optimizer.zero_grad(set_to_none=True)
-                        grad_norm = torch.zeros((), device=train_device)
-                    elif (
-                        cfg.train.mixed_precision
-                        and cfg.train_model.torch_dtype == "float16"
-                    ):
-                        scaler.step(optimizer)
-                        scaler.update()
-                    else:
-                        optimizer.step()
-
-                    if did_optim_step:
-                        optimizer.zero_grad(set_to_none=True)
-
-                if did_optim_step:
-                    optim_steps += 1
-
-                # Weight sync is tied to optimizer steps, not gradient steps.
-                # This ensures the training model diverges from the inference model
-                # between syncs, which is essential for meaningful importance sampling
-                # in GRPO (otherwise ESS stays at 1.0 and GRPO degenerates to REINFORCE).
-                if (
-                    did_optim_step
-                    and optim_steps % cfg.train.weight_update_frequency == 0
-                ):
-                    with timeit("update_policy_weights"):
-                        torchrl_logger.info(
-                            f"Updating policy weights (optim step {optim_steps})..."
-                        )
-                        sender.update_weights()
-                        gc.collect()
-
-                    timeit.print(prefix="timeit")
-                    wandb_logger.log_metrics(
-                        {f"timeit/{key}": val for key, val in timeit.todict().items()}
-                    )
-                    timeit.reset()
-
-            if (step % cfg.train.logging_frequency) == 0:
-                log_training_metrics(
-                    wandb_logger=wandb_logger,
-                    replay_buffer=replay_buffer,
-                    batch=batch,
-                    loss=loss,
-                    grad_norm=grad_norm,
-                    global_step=step,
-                    data_read_count=data_read_count,
-                    collector=collectors[0],
-                    start_time=start_time,
-                    gradient_accumulation_steps=cfg.train.gradient_accumulation_steps,
-                    history_str=history_str,
-                    use_kl_to_ref=cfg.train.use_kl_to_ref,
-                )
-
-            del loss_val
-            # TODO: do we need this? Does it interfere with other processes?
-            # torch.cuda.empty_cache()
-            gc.collect()
+        trainer.train()
         exit_code = 0
     finally:
-        pbar.close()
         with contextlib.suppress(Exception):
             _finish_wandb_logger(wandb_logger, exit_code)
         for collector in collectors:
@@ -374,7 +245,8 @@ def main(cfg):
     # Force async mode
     if cfg.train.sync:
         raise ValueError(
-            "grpo-async.py must run in async mode (`python grpo-async.py mode=async`). Please use grpo-sync.py for sync mode (`python grpo-sync.py mode=sync`)."
+            "grpo-async.py must run in async mode (`python grpo-async.py mode=async`). "
+            "Please use grpo-sync.py for sync mode (`python grpo-sync.py mode=sync`)."
         )
 
     # Compute device allocation

--- a/sota-implementations/grpo/grpo-async.py
+++ b/sota-implementations/grpo/grpo-async.py
@@ -216,6 +216,7 @@ def train(
         async_collection=True,
         log_rewards=True,
         log_kl=cfg.train.use_kl_to_ref,
+        log_timings=True,
     )
 
     torchrl_logger.info("Starting training loop.")

--- a/sota-implementations/grpo/grpo-sync.py
+++ b/sota-implementations/grpo/grpo-sync.py
@@ -193,6 +193,7 @@ def train(
         async_collection=False,
         log_rewards=True,
         log_kl=cfg.train.use_kl_to_ref,
+        log_timings=True,
     )
 
     # Run training

--- a/sota-implementations/grpo/grpo-sync.py
+++ b/sota-implementations/grpo/grpo-sync.py
@@ -173,13 +173,16 @@ def train(
         collector=collector,
         total_frames=cfg.train.total_dialog_turns,
         frame_skip=1,
-        optim_steps_per_batch=cfg.train.epochs,
+        # None: iterate over the whole replay buffer once per epoch, matching
+        # the reference GRPO loop (`for batch in replay_buffer`).
+        optim_steps_per_batch=None,
         loss_module=loss_fn,
         optimizer=optimizer,
         weight_sync_sender=sender,
         weight_update_frequency=1,  # sync mode: push weights every collected batch
         empty_replay_buffer_on_weight_update=cfg.train.empty_replay_buffer,
         replay_buffer=replay_buffer,
+        device=train_device,
         mixed_precision=cfg.train.mixed_precision,
         autocast_dtype=autocast_dtype,
         gradient_accumulation_steps=cfg.train.gradient_accumulation_steps,

--- a/sota-implementations/grpo/grpo-sync.py
+++ b/sota-implementations/grpo/grpo-sync.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import contextlib
-import gc
 import os
 from functools import partial
 from pathlib import Path
@@ -14,7 +13,6 @@ from pathlib import Path
 import hydra
 
 from torchrl import merge_ray_runtime_env, torchrl_logger
-from torchrl.data.llm.history import History
 from torchrl.record.loggers.wandb import WandbLogger
 from torchrl.weight_update.llm import get_model_metadata
 
@@ -24,10 +22,8 @@ except ImportError:
     raise ImportError(
         "Ray is required for sync training. Please install ray with `pip install ray`."
     )
-import time
 
 import torch
-import tqdm
 
 from grpo_utils import (
     add_kl_transforms_to_replay_buffer,
@@ -35,7 +31,6 @@ from grpo_utils import (
     compute_device_allocation,
     get_inference_model,
     get_train_model,
-    log_training_metrics,
     make_env,
     make_weight_sync_scheme,
 )
@@ -47,13 +42,11 @@ except ImportError:
     raise ImportError(
         "TensorDict is required. Please install it with `pip install tensordict`."
     )
-from torch.amp.autocast_mode import autocast
-from torch.amp.grad_scaler import GradScaler
-from torchrl._utils import timeit
 from torchrl.collectors.llm import RayLLMCollector
 from torchrl.data import LazyStackStorage, ReplayBuffer, SamplerWithoutReplacement
 from torchrl.data.replay_buffers.ray_buffer import RayReplayBuffer
 from torchrl.objectives.llm.grpo import GRPOLoss, MCAdvantage
+from torchrl.trainers.algorithms.grpo import GRPOTrainer
 
 
 def _finish_wandb_logger(wandb_logger: WandbLogger | None, exit_code: int) -> None:
@@ -87,20 +80,21 @@ def train(
     inference_policy,
     devices: list[int] | None = None,
 ):
-    """Main training loop for GRPO sync.
+    """Main training entry point for GRPO sync.
 
-    This function implements synchronous training where data collection and optimization
-    happen in separate, consecutive steps. The total number of steps is determined by the number of epochs,
-    samples per epoch, and batches collected.
+    Data collection and optimization happen in separate, consecutive steps.
+    The training loop is fully managed by :class:`~torchrl.trainers.GRPOTrainer`.
 
     Args:
-        replay_buffer: The replay buffer to store experiences. The sampler will typically be a `SamplerWithoutReplacement`.
-        cfg: The configuration object containing training parameters
+        replay_buffer: The replay buffer to store experiences. The sampler will
+            typically be a :class:`~torchrl.data.SamplerWithoutReplacement`.
+        cfg: The configuration object containing training parameters.
         collector: The collector object.
+        inference_policy: The inference-side LLM wrapper.
         devices: The devices to use for the training model.
     """
     # Setup training model and tokenizer
-    policy_training, train_tokenizer = get_train_model(cfg, devices=devices)
+    policy_training, _train_tokenizer = get_train_model(cfg, devices=devices)
     train_device = torch.device(f"cuda:{devices[0]}" if devices else "cuda:0")
 
     # Setup loss function
@@ -142,10 +136,8 @@ def train(
     sender.register_collector(collector)
 
     # First weight update
-    with timeit("update_policy_weights"):
-        sender.update_weights()
-    timeit.print(prefix="First update_policy_weights_ time")
-    timeit.reset()
+    torchrl_logger.info("Performing first weight update...")
+    sender.update_weights()
 
     # Make optimizer
     torchrl_logger.info("Starting optimizer.")
@@ -156,7 +148,6 @@ def train(
         eps=getattr(cfg.optimizer, "eps", 1e-8),
         fused=False,
     )
-    scaler = GradScaler(enabled=cfg.train.mixed_precision)
 
     # Make checkpoint dir
     checkpoint_dir = Path(cfg.logging.checkpoint_dir)
@@ -169,161 +160,53 @@ def train(
         experiment_name = [experiment_name]
     else:
         experiment_name = []
-
     experiment_name.append(cfg.env.dataset)
     experiment_name.append(cfg.model.name)
     wandb_logger = WandbLogger(
         project="grpo-sync", exp_name="-".join(["grpo-sync"] + experiment_name)
     )
 
-    # Training loop
+    # Build the GRPOTrainer — replaces the manual training loop
+    torchrl_logger.info("Building GRPOTrainer...")
+    autocast_dtype = getattr(torch, cfg.train_model.torch_dtype)
+    trainer = GRPOTrainer(
+        collector=collector,
+        total_frames=cfg.train.total_dialog_turns,
+        frame_skip=1,
+        optim_steps_per_batch=cfg.train.epochs,
+        loss_module=loss_fn,
+        optimizer=optimizer,
+        weight_sync_sender=sender,
+        weight_update_frequency=1,  # sync mode: push weights every collected batch
+        empty_replay_buffer_on_weight_update=cfg.train.empty_replay_buffer,
+        replay_buffer=replay_buffer,
+        mixed_precision=cfg.train.mixed_precision,
+        autocast_dtype=autocast_dtype,
+        gradient_accumulation_steps=cfg.train.gradient_accumulation_steps,
+        clip_norm=cfg.optimizer.clip_grad_norm,
+        logger=wandb_logger,
+        log_interval=cfg.train.logging_frequency,
+        num_epochs=cfg.train.epochs,
+        async_collection=False,
+        log_rewards=True,
+        log_kl=cfg.train.use_kl_to_ref,
+    )
+
+    # Run training
     torchrl_logger.info("Starting training loop.")
-    pbar = tqdm.tqdm(collector)
-    grad_norm = 0.0  # Initialize grad_norm
-    data_read_count = 0
-
-    global_step = 0
-    start_time = time.time()
-    for data in pbar:
-        # Wait for the replay buffer to be filled - when reasoning, we collect trajectories
-        #  so the buffer may not be filled straight away
-        if not len(replay_buffer):
-            torchrl_logger.info("Waiting for replay buffer to be filled")
-            continue
-        else:
-            torchrl_logger.info(f"Replay buffer filled: {len(replay_buffer)}")
-
-        pbar.update(1)
-
-        # data is None as the collector directly writes to the replay buffer
-        if data is not None:
-            raise ValueError("Data is not None")
-
-        for _ in range(cfg.train.epochs):
-            # Iterate over the replay buffer
-            for batch in replay_buffer:
-                batch = batch.to(train_device)
-                global_step += 1
-                pbar.set_description(
-                    f"Gradient step {global_step}, writes: {replay_buffer.write_count}, batch size: {batch.shape}"
-                )
-                history: History = batch.view(-1)[0]["next", "history"].prompt
-                history_str: list[str] | str = history.apply_chat_template(
-                    tokenizer=train_tokenizer
-                )
-                while not isinstance(history_str, str):
-                    history_str = "\n".join(history_str)
-
-                data_read_count += batch.numel()
-
-                with timeit("forward_pass"):
-                    # Use the model's dtype for autocast to avoid bf16→fp16 downcast
-                    autocast_dtype = getattr(torch, cfg.train_model.torch_dtype)
-                    with autocast(
-                        "cuda",
-                        enabled=cfg.train.mixed_precision,
-                        dtype=autocast_dtype,
-                    ):
-                        loss = loss_fn(batch)
-                        loss_val = (
-                            loss.mean(reduce=True)
-                            / cfg.train.gradient_accumulation_steps
-                        )
-
-                with timeit("backward_pass"):
-                    if (
-                        cfg.train.mixed_precision
-                        and cfg.train_model.torch_dtype == "float16"
-                    ):
-                        scaler = GradScaler(enabled=True)
-                        scaler.scale(loss_val).backward()
-                    else:
-                        loss_val.backward()
-
-                if ((global_step + 1) % cfg.train.gradient_accumulation_steps) == 0:
-                    with timeit("optim_step"):
-                        if (
-                            cfg.train.mixed_precision
-                            and cfg.train_model.torch_dtype == "float16"
-                        ):
-                            scaler.unscale_(optimizer)
-
-                        grad_norm = torch.nn.utils.clip_grad_norm_(
-                            policy_training.parameters(),
-                            cfg.optimizer.clip_grad_norm,
-                        )
-
-                        if (
-                            cfg.train.mixed_precision
-                            and cfg.train_model.torch_dtype == "float16"
-                        ):
-                            scaler.step(optimizer)
-                            scaler.update()
-                        else:
-                            optimizer.step()
-                        optimizer.zero_grad(set_to_none=True)
-
-                del loss_val
-                # TODO: do we need this? Does it interfere with other processes?
-                # torch.cuda.empty_cache()
-                gc.collect()
-
-                if (global_step % cfg.train.logging_frequency) == 0:
-                    log_training_metrics(
-                        wandb_logger=wandb_logger,
-                        replay_buffer=replay_buffer,
-                        batch=batch,
-                        loss=loss,
-                        grad_norm=grad_norm,
-                        global_step=global_step,
-                        data_read_count=data_read_count,
-                        collector=collector,
-                        start_time=start_time,
-                        gradient_accumulation_steps=cfg.train.gradient_accumulation_steps,
-                        history_str=history_str,
-                        use_kl_to_ref=cfg.train.use_kl_to_ref,
-                    )
-
-                # Checkpointing disabled to prevent disk space issues
-                # if (global_step + 1) % cfg.train.checkpoint_frequency == 0:
-                #     with timeit("save_checkpoint"):
-                #         torchrl_logger.info(
-                #             f"Saving checkpoint {(global_step+1) // cfg.train.checkpoint_frequency}..."
-                #         )
-                #         checkpoint = {
-                #             "step": global_step,
-                #             "model_state_dict": policy_training.model.state_dict(),
-                #             "optimizer_state_dict": optimizer.state_dict(),
-                #             "scaler_state_dict": scaler.state_dict(),
-                #             "config": dict(cfg),
-                #         }
-                #         torch.save(checkpoint, checkpoint_dir / f"checkpoint_{global_step:04d}.pt")
-
-        with timeit("update_policy_weights"):
-            torchrl_logger.info("Updating policy weights...")
-            sender.update_weights()
-            # TODO: do we need this? Does it interfere with other processes?
-            # torch.cuda.empty_cache()
-            gc.collect()
-
-        timeit.print(prefix="timeit")
-        wandb_logger.log_metrics(
-            {f"timeit/{key}": val for key, val in timeit.todict().items()}
-        )
-        timeit.reset()
-
-        if cfg.train.empty_replay_buffer:
-            replay_buffer.empty(empty_write_count=False)
-
-    pbar.close()
-    with contextlib.suppress(Exception):
-        _finish_wandb_logger(wandb_logger, 0)
-    with contextlib.suppress(Exception):
-        collector.shutdown()
-    shutdown = getattr(sender, "shutdown", None)
-    if shutdown is not None:
+    exit_code = 1
+    try:
+        trainer.train()
+        exit_code = 0
+    finally:
         with contextlib.suppress(Exception):
-            shutdown()
+            _finish_wandb_logger(wandb_logger, exit_code)
+        with contextlib.suppress(Exception):
+            collector.shutdown()
+        shutdown = getattr(sender, "shutdown", None)
+        if shutdown is not None:
+            with contextlib.suppress(Exception):
+                shutdown()
 
 
 @hydra.main(version_base="1.3", config_path="config", config_name="grpo_gsm8k")
@@ -334,7 +217,8 @@ def main(cfg):
     # Force sync mode
     if not cfg.train.sync:
         raise ValueError(
-            "grpo-sync.py must run in sync mode (`python grpo-sync.py mode=sync`). Please use grpo-async.py for async mode (`python grpo-async.py mode=async`)."
+            "grpo-sync.py must run in sync mode (`python grpo-sync.py mode=sync`). "
+            "Please use grpo-async.py for async mode (`python grpo-async.py mode=async`)."
         )
     if cfg.train.weight_update_frequency is not None:
         raise ValueError("weight_update_frequency must be left empty in sync mode.")

--- a/sota-implementations/grpo/grpo_utils.py
+++ b/sota-implementations/grpo/grpo_utils.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import functools
 
-import time
 import warnings
 from typing import Any, Literal
 
@@ -14,7 +13,7 @@ import torch
 from omegaconf import DictConfig
 from torch import device as torch_device, dtype as torch_dtype
 
-from torchrl._utils import logger as torchrl_logger, timeit
+from torchrl._utils import logger as torchrl_logger
 from torchrl.envs.llm import AddThinkingPrompt, GSM8KEnv, KLRewardTransform, RetrieveKL
 from torchrl.envs.llm.datasets.countdown import CountdownEnv
 from torchrl.envs.llm.datasets.ifeval import IFEvalEnv
@@ -912,110 +911,3 @@ def add_kl_transforms_to_replay_buffer(replay_buffer, cfg: DictConfig):
         )
 
     replay_buffer.append_transform(kl_transform, invert=True)
-
-
-@timeit("Logging metrics")
-def log_training_metrics(
-    wandb_logger,
-    replay_buffer,
-    batch,
-    loss,
-    grad_norm,
-    global_step,
-    data_read_count,
-    collector,
-    start_time,
-    gradient_accumulation_steps,
-    history_str=None,
-    use_kl_to_ref=True,
-):
-    """Log training metrics to wandb.
-
-    Args:
-        wandb_logger: The wandb logger instance
-        replay_buffer: The replay buffer containing collected data
-        batch: The current training batch
-        loss: The computed loss object
-        grad_norm: The gradient norm value
-        global_step: Current global training step
-        data_read_count: Total data read count
-        collector: The collector instance
-        start_time: Training start time
-        gradient_accumulation_steps: Number of gradient accumulation steps
-        history_str: Optional history string for logging
-    """
-    with torch.no_grad():
-        rb_content = replay_buffer[:]
-        step_count = rb_content.get(("next", "step_count")).view(-1).float().mean()
-        batch_policy_version = batch["next", "policy_version"].view(-1).min()
-        batch_policy_age = collector.policy_version - batch_policy_version
-
-        # Buffer-level staleness stats
-        buffer_policy_versions = (
-            rb_content.get(("next", "policy_version")).view(-1).float()
-        )
-        current_version = collector.policy_version
-        buffer_staleness = current_version - buffer_policy_versions
-        buffer_staleness_mean = float(buffer_staleness.mean())
-        buffer_staleness_max = float(buffer_staleness.max())
-
-        elapsed = time.time() - start_time
-        optim_steps = global_step // gradient_accumulation_steps
-
-        metrics = {
-            # --- training/ : loss components and optimizer state ---
-            "training/loss_objective": float(loss.loss_objective),
-            "training/clip_fraction": float(loss.clip_fraction),
-            "training/ESS": float(loss.ESS),
-            "training/entropy_loss": float(loss.loss_entropy.mean()),
-            "training/kl_approx_to_inference": float(loss.kl_approx),
-            "training/kl_to_inference": float(loss.kl_to_inference.mean()),
-            "training/loss_kl_to_inference": float(loss.loss_kl_to_inference.mean()),
-            "training/grad_norm": float(grad_norm)
-            if global_step % gradient_accumulation_steps == 0
-            else 0.0,
-            "training/gradient_steps": global_step,
-            "training/optim_steps": optim_steps,
-            # --- inference/ : collection and policy version state ---
-            "inference/policy_version": collector.policy_version,
-            "inference/batch_policy_version": batch_policy_version,
-            "inference/batch_policy_age": batch_policy_age,
-            "inference/staleness_mean": buffer_staleness_mean,
-            "inference/staleness_max": buffer_staleness_max,
-            # --- buffer/ : replay buffer statistics ---
-            "buffer/write_count": int(replay_buffer.write_count),
-            "buffer/reward_mean": float(
-                torch.cat(rb_content.get(("next", "reward"), as_list=True)).mean()
-            ),
-            "buffer/seq_length_mean": float(
-                torch.tensor(
-                    [
-                        t.numel()
-                        for t in rb_content.get(("tokens", "response"), as_list=True)
-                    ],
-                    dtype=torch.float,
-                ).mean()
-            ),
-            "buffer/step_count_mean": float(step_count),
-            "buffer/data_read_count": data_read_count,
-            # --- throughput/ : training speed metrics ---
-            "throughput/gradient_steps_per_second": float(global_step / elapsed),
-            "throughput/optim_steps_per_second": float(optim_steps / elapsed),
-            "throughput/gradient_steps_per_write": float(
-                global_step / replay_buffer.write_count
-            ),
-            "throughput/optim_steps_per_write": float(
-                optim_steps / replay_buffer.write_count
-            ),
-        }
-        if use_kl_to_ref:
-            metrics["training/kl_to_ref"] = float(loss.kl_to_ref.mean())
-            metrics["training/loss_kl_to_ref"] = float(loss.loss_kl_to_ref.mean())
-            metrics["buffer/kl_penalty_to_ref_mean"] = float(
-                torch.cat(rb_content.get(("next", "kl_penalty"), as_list=True)).mean()
-            )
-
-        wandb_logger.log_metrics(metrics, step=global_step)
-
-        if history_str is not None:
-            wandb_logger.log_str("history", history_str, step=global_step)

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -28,6 +28,7 @@ from torchrl.data import (
     LazyMemmapStorage,
     LazyTensorStorage,
     ListStorage,
+    SamplerWithoutReplacement,
     TensorDictPrioritizedReplayBuffer,
     TensorDictReplayBuffer,
 )
@@ -2216,6 +2217,25 @@ def _make_grpo_batch(reward_offset=0.0):
     )
 
 
+class _BufferWritingCollector:
+    """Mimics an LLM collector created with a replay_buffer: it writes each
+    collected batch to the buffer directly and yields None."""
+
+    def __init__(self, batches, replay_buffer):
+        self._batches = batches
+        self.replay_buffer = replay_buffer
+        self.init_random_frames = 0
+        self.shutdown_calls = 0
+
+    def __iter__(self):
+        for batch in self._batches:
+            self.replay_buffer.extend(batch)
+            yield None
+
+    def shutdown(self):
+        self.shutdown_calls += 1
+
+
 class TestGRPOTrainer:
     def test_train_updates_policy_syncs_weights_and_logs_metrics(self):
         model = nn.Linear(1, 1, bias=False)
@@ -2257,6 +2277,47 @@ class TestGRPOTrainer:
         ]
         assert logger.records["kl_to_ref"][-1] == (8, pytest.approx(0.25))
         assert logger.records["kl_to_inference"][-1] == (8, pytest.approx(0.5))
+
+    def test_buffer_writing_collector_trains_from_replay_buffer(self):
+        # LLM collectors created with a replay_buffer write to it directly and
+        # yield None; the trainer must sample from the buffer and track frames
+        # via its write count.
+        model = nn.Linear(1, 1, bias=False)
+        nn.init.zeros_(model.weight)
+        initial_weight = model.weight.detach().clone()
+        replay_buffer = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(100),
+            sampler=SamplerWithoutReplacement(),
+            batch_size=2,
+        )
+        collector = _BufferWritingCollector(
+            [_make_grpo_batch(reward_offset=float(i)) for i in range(4)],
+            replay_buffer,
+        )
+        logger = _RecordingLogger()
+
+        with pytest.warns(UserWarning, match="experimental"):
+            trainer = GRPOTrainer(
+                collector=collector,
+                total_frames=8,
+                frame_skip=1,
+                optim_steps_per_batch=None,
+                loss_module=_GRPORegressionLoss(model),
+                optimizer=torch.optim.SGD(model.parameters(), lr=0.05),
+                replay_buffer=replay_buffer,
+                logger=logger,
+                log_interval=0,
+                progress_bar=False,
+            )
+
+        trainer.train()
+
+        assert not torch.equal(model.weight, initial_weight)
+        assert collector.shutdown_calls == 1
+        assert trainer.collected_frames == 8
+        # Rewards are logged from the optimization sub-batches, at the
+        # write-count steps of each collection iteration.
+        assert [step for step, _ in logger.records["reward_mean"]] == [2, 4, 6, 8]
 
     def test_gradient_accumulation_matches_a_full_batch_update(self):
         accumulated_model = nn.Linear(1, 1, bias=False)

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -2400,6 +2400,62 @@ class TestGRPOTrainer:
             full_batch_model.weight,
         )
 
+    def test_nonfinite_loss_skips_the_accumulation_window(self):
+        model = nn.Linear(1, 1, bias=False)
+        nn.init.zeros_(model.weight)
+        initial_weight = model.weight.detach().clone()
+        stepper = MixedPrecisionOptimizationStepper(
+            torch.optim.SGD(model.parameters(), lr=0.1),
+            gradient_accumulation_steps=2,
+        )
+        trainer = Trainer(
+            collector=MockingCollector(),
+            total_frames=2,
+            frame_skip=1,
+            optim_steps_per_batch=1,
+            loss_module=_GRPORegressionLoss(model),
+            optimization_stepper=stepper,
+            progress_bar=False,
+        )
+        batch = _make_grpo_batch()
+
+        stepper.step(trainer, batch)
+        bad_batch = batch.clone()
+        bad_batch["target"] = bad_batch["target"] * float("inf")
+        stepper.step(trainer, bad_batch)
+
+        # The non-finite micro-batch drops the accumulated gradients and
+        # restarts the accumulation window: no optimizer step has happened.
+        assert stepper.optimizer_step_count == 0
+        assert stepper._skipped_nonfinite_steps == 1
+        assert torch.equal(model.weight, initial_weight)
+        assert all(p.grad is None for p in model.parameters())
+
+    def test_nonfinite_grad_norm_skips_the_optimizer_step(self):
+        model = nn.Linear(1, 1, bias=False)
+        nn.init.zeros_(model.weight)
+        initial_weight = model.weight.detach().clone()
+        model.weight.register_hook(lambda grad: grad * float("inf"))
+        stepper = MixedPrecisionOptimizationStepper(
+            torch.optim.SGD(model.parameters(), lr=0.1),
+        )
+        trainer = Trainer(
+            collector=MockingCollector(),
+            total_frames=1,
+            frame_skip=1,
+            optim_steps_per_batch=1,
+            loss_module=_GRPORegressionLoss(model),
+            optimization_stepper=stepper,
+            progress_bar=False,
+        )
+
+        metrics = stepper.step(trainer, _make_grpo_batch())
+
+        assert stepper.optimizer_step_count == 0
+        assert stepper._skipped_nonfinite_steps == 1
+        assert torch.equal(model.weight, initial_weight)
+        assert metrics["grad_norm"] == 0.0
+
     @pytest.mark.parametrize("gradient_accumulation_steps", [0, -1])
     def test_rejects_invalid_gradient_accumulation(self, gradient_accumulation_steps):
         model = nn.Linear(1, 1)

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -41,7 +41,7 @@ from torchrl.trainers.algorithms.a2c import A2CTrainer
 from torchrl.trainers.algorithms.cql import CQLTrainer
 from torchrl.trainers.algorithms.ddpg import DDPGTrainer
 from torchrl.trainers.algorithms.dqn import DQNTrainer
-from torchrl.trainers.algorithms.grpo import GRPOOptimizationStepper, GRPOTrainer
+from torchrl.trainers.algorithms.grpo import GRPOTrainer
 from torchrl.trainers.algorithms.iql import IQLTrainer
 from torchrl.trainers.algorithms.offline_to_online import OfflineToOnlineTrainer
 from torchrl.trainers.algorithms.ppo import PPOTrainer
@@ -60,6 +60,7 @@ from torchrl.trainers.trainers import (
     LogScalar,
     LRSchedulerHook,
     mask_batch,
+    MixedPrecisionOptimizationStepper,
     OptimizationStepper,
     OptimizerHook,
     ReplayBufferTrainer,
@@ -2283,7 +2284,7 @@ class TestGRPOTrainer:
         # post_optim stage every `update_weights_interval` optimizer steps,
         # discounting gradient-accumulation micro-steps.
         model = nn.Linear(1, 1, bias=False)
-        stepper = GRPOOptimizationStepper(
+        stepper = MixedPrecisionOptimizationStepper(
             torch.optim.SGD(model.parameters(), lr=0.05),
             gradient_accumulation_steps=2,
         )
@@ -2359,7 +2360,7 @@ class TestGRPOTrainer:
         nn.init.zeros_(accumulated_model.weight)
         full_batch_model.load_state_dict(accumulated_model.state_dict())
 
-        accumulated_stepper = GRPOOptimizationStepper(
+        accumulated_stepper = MixedPrecisionOptimizationStepper(
             torch.optim.SGD(accumulated_model.parameters(), lr=0.1),
             gradient_accumulation_steps=2,
         )
@@ -2372,7 +2373,7 @@ class TestGRPOTrainer:
             optimization_stepper=accumulated_stepper,
             progress_bar=False,
         )
-        full_batch_stepper = GRPOOptimizationStepper(
+        full_batch_stepper = MixedPrecisionOptimizationStepper(
             torch.optim.SGD(full_batch_model.parameters(), lr=0.1)
         )
         full_batch_trainer = Trainer(
@@ -2405,14 +2406,14 @@ class TestGRPOTrainer:
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
 
         with pytest.raises(ValueError, match="must be >= 1"):
-            GRPOOptimizationStepper(
+            MixedPrecisionOptimizationStepper(
                 optimizer,
                 gradient_accumulation_steps=gradient_accumulation_steps,
             )
 
     def test_rejects_loss_outputs_without_an_optimization_objective(self):
         model = nn.Linear(1, 1)
-        stepper = GRPOOptimizationStepper(torch.optim.SGD(model.parameters(), lr=0.1))
+        stepper = MixedPrecisionOptimizationStepper(torch.optim.SGD(model.parameters(), lr=0.1))
         trainer = Trainer(
             collector=MockingCollector(),
             total_frames=1,

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -2166,6 +2166,548 @@ class TestEarlyStopping:
         assert collector.shutdown_calls == 1
 
 
-if __name__ == "__main__":
+
+
+# --- GRPO Trainer Tests ---
+from unittest.mock import MagicMock, patch
+from torch import nn, optim
+from tensordict import TensorDict
+
+from torchrl.trainers.algorithms.grpo import (
+    GRPOOptimizationStepper,
+    GRPOTrainer,
+    WeightSyncHook,
+)
+def _make_optimizer(model: nn.Module | None = None) -> optim.Optimizer:
+    if model is None:
+        model = nn.Linear(4, 4)
+    return optim.Adam(model.parameters(), lr=1e-3)
+
+
+def _make_loss_td(value: float = 1.0) -> TensorDict:
+    """Return a minimal TensorDict that mimics GRPOLoss output."""
+    return TensorDict(
+        {"loss_policy": torch.tensor(value, requires_grad=False)},
+        batch_size=[],
+    )
+
+
+def _make_grpo_trainer(**kwargs) -> GRPOTrainer:
+    """Build a GRPOTrainer with sensible defaults for testing (no LLM deps)."""
+    model = nn.Linear(4, 4)
+    optimizer = _make_optimizer(model)
+    collector = MagicMock()
+    collector.frames_per_batch = 4
+    loss_fn = MagicMock()
+
+    defaults = {
+        "collector": collector,
+        "total_frames": 100,
+        "frame_skip": 1,
+        "optim_steps_per_batch": 2,
+        "loss_module": loss_fn,
+        "optimizer": optimizer,
+        "weight_sync_sender": None,
+        "log_rewards": False,
+        "log_kl": False,
+    }
+    defaults.update(kwargs)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return GRPOTrainer(**defaults)
+
+
+# ===========================================================================
+# GRPOOptimizationStepper
+# ===========================================================================
+
+
+class TestGRPOOptimizationStepper:
+    def test_default_construction(self):
+        opt = _make_optimizer()
+        stepper = GRPOOptimizationStepper(opt)
+        assert stepper.gradient_accumulation_steps == 1
+        assert stepper.mixed_precision is False
+        assert stepper._use_scaler is False
+        assert stepper._micro_step == 0
+
+    def test_fp16_enables_scaler(self):
+        opt = _make_optimizer()
+        stepper = GRPOOptimizationStepper(
+            opt, mixed_precision=True, autocast_dtype=torch.float16
+        )
+        assert stepper._use_scaler is True
+
+    def test_bf16_no_scaler(self):
+        opt = _make_optimizer()
+        stepper = GRPOOptimizationStepper(
+            opt, mixed_precision=True, autocast_dtype=torch.bfloat16
+        )
+        assert stepper._use_scaler is False
+
+    def test_invalid_accumulation_steps(self):
+        opt = _make_optimizer()
+        with pytest.raises(
+            ValueError, match="gradient_accumulation_steps must be >= 1"
+        ):
+            GRPOOptimizationStepper(opt, gradient_accumulation_steps=0)
+
+    def test_state_dict_round_trip(self):
+        model = nn.Linear(4, 4)
+        opt = _make_optimizer(model)
+        stepper = GRPOOptimizationStepper(opt, gradient_accumulation_steps=2)
+        stepper._micro_step = 1
+
+        sd = stepper.state_dict()
+        assert "optimizer" in sd
+        assert sd["micro_step"] == 1
+
+        model2 = nn.Linear(4, 4)
+        opt2 = _make_optimizer(model2)
+        stepper2 = GRPOOptimizationStepper(opt2, gradient_accumulation_steps=2)
+        stepper2.load_state_dict(sd)
+        assert stepper2._micro_step == 1
+
+    def test_micro_step_increments_each_call(self):
+        model = nn.Linear(4, 4)
+        opt = _make_optimizer(model)
+        stepper = GRPOOptimizationStepper(opt, gradient_accumulation_steps=3)
+
+        # Patch compute_loss on a fake trainer
+        trainer = MagicMock()
+        trainer.compute_loss.return_value = TensorDict(
+            {"loss_policy": torch.tensor(0.5, requires_grad=True)},
+            batch_size=[],
+        )
+        trainer.clip_grad_norm = True
+        trainer.clip_norm = 1.0
+
+        batch = TensorDict({}, batch_size=[])
+        stepper.step(trainer, batch)
+        assert stepper._micro_step == 1
+
+        stepper.step(trainer, batch)
+        assert stepper._micro_step == 2
+
+    def test_optimizer_step_executes_at_accumulation_boundary(self):
+        model = nn.Linear(4, 4)
+        opt = _make_optimizer(model)
+        stepper = GRPOOptimizationStepper(opt, gradient_accumulation_steps=2)
+
+        trainer = MagicMock()
+
+        def make_loss_td(_batch):
+            return TensorDict(
+                {"loss_policy": torch.tensor(0.5, requires_grad=True)},
+                batch_size=[],
+            )
+
+        trainer.compute_loss.side_effect = make_loss_td
+        batch = TensorDict({}, batch_size=[])
+
+        # Step 1: gradients accumulate, optimizer NOT stepped
+        with patch.object(opt, "step") as mock_step:
+            stepper.step(trainer, batch)
+            mock_step.assert_not_called()
+
+        # Step 2: accumulation boundary → optimizer should step
+        with patch.object(opt, "step") as mock_step:
+            stepper.step(trainer, batch)
+            mock_step.assert_called_once()
+
+    def test_end_to_end_optimization_reduces_loss(self):
+        """Verifies the stepper actually trains a simple model."""
+        model = nn.Linear(2, 1, bias=False)
+        nn.init.constant_(model.weight, 1.0)
+        opt = optim.SGD(model.parameters(), lr=0.5)
+        stepper = GRPOOptimizationStepper(opt, gradient_accumulation_steps=1)
+
+        x = torch.tensor([[1.0, 1.0]])
+        target = torch.tensor([[0.0]])
+
+        class SimpleLoss(nn.Module):
+            def forward(self, batch):
+                pred = model(x)
+                loss = nn.functional.mse_loss(pred, target)
+                return TensorDict({"loss_policy": loss}, batch_size=[])
+
+        trainer = MagicMock()
+        trainer.compute_loss.side_effect = lambda b: SimpleLoss()(b)
+        batch = TensorDict({}, batch_size=[])
+
+        initial_weight = model.weight.data.clone()
+        stepper.step(trainer, batch)
+        # Weight should have changed
+        assert not torch.equal(model.weight.data, initial_weight)
+
+
+# ===========================================================================
+# WeightSyncHook
+# ===========================================================================
+
+
+class TestWeightSyncHook:
+    def test_construction(self):
+        sender = MagicMock()
+        hook = WeightSyncHook(
+            sender, weight_update_frequency=5, empty_replay_buffer=True
+        )
+        assert hook.weight_update_frequency == 5
+        assert hook.empty_replay_buffer is True
+
+    def test_update_weights_called_at_correct_frequency(self):
+        sender = MagicMock()
+        hook = WeightSyncHook(sender, weight_update_frequency=3)
+        trainer = MagicMock()
+
+        # Only triggers when optim_count % frequency == 0
+        batch = TensorDict({}, batch_size=[])
+        for optim_count in range(1, 10):
+            trainer._optim_count = optim_count
+            hook._trainer = trainer
+            hook(batch)
+
+        # Steps 3, 6, 9 → 3 calls
+        assert sender.update_weights.call_count == 3
+
+    def test_replay_buffer_emptied_when_flag_set(self):
+        sender = MagicMock()
+        hook = WeightSyncHook(
+            sender, weight_update_frequency=1, empty_replay_buffer=True
+        )
+        trainer = MagicMock()
+        trainer._optim_count = 1
+        trainer.replay_buffer = MagicMock()
+        hook._trainer = trainer
+        hook(TensorDict({}, batch_size=[]))
+        trainer.replay_buffer.empty.assert_called_once_with(empty_write_count=False)
+
+    def test_replay_buffer_not_emptied_when_flag_false(self):
+        sender = MagicMock()
+        hook = WeightSyncHook(
+            sender, weight_update_frequency=1, empty_replay_buffer=False
+        )
+        trainer = MagicMock()
+        trainer._optim_count = 1
+        trainer.replay_buffer = MagicMock()
+        hook._trainer = trainer
+        hook(TensorDict({}, batch_size=[]))
+        trainer.replay_buffer.empty.assert_not_called()
+
+    def test_no_update_when_replay_buffer_is_none(self):
+        """Should not crash when replay_buffer is None."""
+        sender = MagicMock()
+        hook = WeightSyncHook(
+            sender, weight_update_frequency=1, empty_replay_buffer=True
+        )
+        trainer = MagicMock()
+        trainer._optim_count = 1
+        trainer.replay_buffer = None
+        hook._trainer = trainer
+        hook(TensorDict({}, batch_size=[]))  # Should not raise
+        sender.update_weights.assert_called_once()
+
+
+# ===========================================================================
+# GRPOTrainer construction
+# ===========================================================================
+
+
+class TestGRPOTrainerConstruction:
+    def test_basic_construction_no_sender(self):
+        trainer = _make_grpo_trainer()
+        assert trainer is not None
+
+    def test_raises_without_optimizer_and_stepper(self):
+        collector = MagicMock()
+        loss_fn = MagicMock()
+        with pytest.raises(ValueError, match="requires either an `optimizer`"):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                GRPOTrainer(
+                    collector=collector,
+                    total_frames=100,
+                    frame_skip=1,
+                    optim_steps_per_batch=2,
+                    loss_module=loss_fn,
+                    optimizer=None,
+                    optimization_stepper=None,
+                    log_rewards=False,
+                    log_kl=False,
+                )
+
+    def test_custom_stepper_accepted(self):
+        model = nn.Linear(4, 4)
+        opt = _make_optimizer(model)
+        stepper = GRPOOptimizationStepper(opt, gradient_accumulation_steps=4)
+        collector = MagicMock()
+        loss_fn = MagicMock()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            trainer = GRPOTrainer(
+                collector=collector,
+                total_frames=100,
+                frame_skip=1,
+                optim_steps_per_batch=2,
+                loss_module=loss_fn,
+                optimizer=None,  # No optimizer needed — stepper owns it
+                optimization_stepper=stepper,
+                log_rewards=False,
+                log_kl=False,
+            )
+        assert trainer is not None
+
+    def test_mixed_precision_propagated_to_stepper(self):
+        model = nn.Linear(4, 4)
+        opt = _make_optimizer(model)
+        collector = MagicMock()
+        loss_fn = MagicMock()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            trainer = GRPOTrainer(
+                collector=collector,
+                total_frames=100,
+                frame_skip=1,
+                optim_steps_per_batch=2,
+                loss_module=loss_fn,
+                optimizer=opt,
+                mixed_precision=True,
+                autocast_dtype=torch.bfloat16,
+                log_rewards=False,
+                log_kl=False,
+            )
+        # The internal stepper should have the flag
+        stepper = trainer._modules.get("optimization_stepper")
+        assert stepper is not None
+        assert stepper.mixed_precision is True
+        assert stepper.autocast_dtype == torch.bfloat16
+
+    def test_gradient_accumulation_propagated(self):
+        model = nn.Linear(4, 4)
+        opt = _make_optimizer(model)
+        collector = MagicMock()
+        loss_fn = MagicMock()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            trainer = GRPOTrainer(
+                collector=collector,
+                total_frames=100,
+                frame_skip=1,
+                optim_steps_per_batch=2,
+                loss_module=loss_fn,
+                optimizer=opt,
+                gradient_accumulation_steps=8,
+                log_rewards=False,
+                log_kl=False,
+            )
+        stepper = trainer._modules.get("optimization_stepper")
+        assert stepper.gradient_accumulation_steps == 8
+
+    def test_weight_sync_hook_registered_when_sender_provided(self):
+        """When sender is passed, a WeightSyncHook must appear in post_steps."""
+        sender = MagicMock()
+        trainer = _make_grpo_trainer(weight_sync_sender=sender)
+        # Hooks are wrapped by a timing closure; check cell contents for the hook name
+        has_sync_hook = any(
+            any(
+                getattr(cell, "cell_contents", None) == "WeightSyncHook"
+                for cell in (fn.__closure__ or [])
+            )
+            for fn, _ in trainer._post_steps_ops
+        )
+        assert has_sync_hook
+
+    def test_no_weight_sync_hook_when_no_sender(self):
+        trainer = _make_grpo_trainer(weight_sync_sender=None)
+        # No WeightSyncHook should appear in the timing closure names
+        has_sync_hook = any(
+            any(
+                getattr(cell, "cell_contents", None) == "WeightSyncHook"
+                for cell in (fn.__closure__ or [])
+            )
+            for stage_ops in [
+                trainer._post_steps_ops,
+                trainer._pre_epoch_ops,
+                trainer._post_optim_ops,
+                trainer._pre_optim_ops,
+            ]
+            for fn, _ in stage_ops
+        )
+        assert not has_sync_hook
+
+    def test_async_collection_flag_stored(self):
+        trainer = _make_grpo_trainer(async_collection=True)
+        assert trainer.async_collection is True
+
+    def test_emits_experimental_warning(self):
+        # Do NOT suppress warnings here — we want to capture the UserWarning
+        model = torch.nn.Linear(4, 4)
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+        collector = MagicMock()
+        loss_fn = MagicMock()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            GRPOTrainer(
+                collector=collector,
+                total_frames=100,
+                frame_skip=1,
+                optim_steps_per_batch=2,
+                loss_module=loss_fn,
+                optimizer=optimizer,
+                log_rewards=False,
+                log_kl=False,
+            )
+        user_warnings = [x for x in w if issubclass(x.category, UserWarning)]
+        assert any("experimental" in str(x.message).lower() for x in user_warnings)
+
+    def test_replay_buffer_hooks_registered(self):
+        """ReplayBufferTrainer hooks should appear when a replay buffer is provided."""
+        from torchrl.data import LazyTensorStorage, ReplayBuffer
+
+        rb = ReplayBuffer(storage=LazyTensorStorage(100), batch_size=4)
+        trainer = _make_grpo_trainer(replay_buffer=rb)
+        # process_optim_batch hooks are stored in _process_optim_batch_ops
+        assert len(trainer._process_optim_batch_ops) > 0
+
+    def test_no_replay_buffer_no_crash(self):
+        """Passing no replay buffer is valid (e.g., remote RB setup)."""
+        trainer = _make_grpo_trainer(replay_buffer=None)
+        assert trainer is not None
+
+    def test_weight_update_frequency_respected(self):
+        """WeightSyncHook.weight_update_frequency should match what was passed."""
+        sender = MagicMock()
+        trainer = _make_grpo_trainer(
+            weight_sync_sender=sender,
+            weight_update_frequency=7,
+        )
+        # The WeightSyncHook is stashed inside the timing-closure cell contents.
+        # The hook object itself is a cell_contents that is a WeightSyncHook instance.
+        sync_hooks = []
+        for fn, _ in trainer._post_steps_ops:
+            for cell in fn.__closure__ or []:
+                try:
+                    obj = cell.cell_contents
+                    if isinstance(obj, WeightSyncHook):
+                        sync_hooks.append(obj)
+                except ValueError:
+                    pass
+        assert len(sync_hooks) == 1
+        assert sync_hooks[0].weight_update_frequency == 7
+
+
+# ===========================================================================
+# Public API / import checks
+# ===========================================================================
+
+
+class TestPublicAPI:
+    def test_grpotrainer_in_algorithms_init(self):
+        from torchrl.trainers import algorithms
+
+        assert hasattr(algorithms, "GRPOTrainer")
+
+    def test_grpotrainer_in_trainers_init(self):
+        import torchrl.trainers as T
+
+        assert hasattr(T, "GRPOTrainer")
+        assert hasattr(T, "GRPOOptimizationStepper")
+        assert hasattr(T, "WeightSyncHook")
+
+    def test_grpotrainer_importable_directly(self):
+        from torchrl.trainers.algorithms.grpo import GRPOTrainer as GT
+
+        assert GT is GRPOTrainer
+
+
+# ===========================================================================
+# Edge cases
+# ===========================================================================
+
+
+class TestEdgeCases:
+    def test_clip_norm_none_does_not_clip(self):
+        """With clip_norm=None the stepper should still run without error."""
+        model = nn.Linear(4, 4)
+        opt = _make_optimizer(model)
+        stepper = GRPOOptimizationStepper(opt, clip_norm=None)
+
+        trainer = MagicMock()
+        trainer.compute_loss.return_value = TensorDict(
+            {"loss_policy": torch.tensor(1.0, requires_grad=True)},
+            batch_size=[],
+        )
+        batch = TensorDict({}, batch_size=[])
+        result = stepper.step(trainer, batch)
+        assert "loss_policy" in result.keys()
+
+    def test_no_loss_keys_raises(self):
+        """If the loss module returns no 'loss_*' keys, a RuntimeError is raised."""
+        model = nn.Linear(4, 4)
+        opt = _make_optimizer(model)
+        stepper = GRPOOptimizationStepper(opt)
+
+        trainer = MagicMock()
+        trainer.compute_loss.return_value = TensorDict(
+            {"some_other_key": torch.tensor(1.0)},
+            batch_size=[],
+        )
+        batch = TensorDict({}, batch_size=[])
+        with pytest.raises(RuntimeError, match="no 'loss_\\*' keys"):
+            stepper.step(trainer, batch)
+
+    def test_state_dict_has_no_scaler_for_bf16(self):
+        """bf16 stepper state_dict must not include a 'scaler' key."""
+        opt = _make_optimizer()
+        stepper = GRPOOptimizationStepper(
+            opt, mixed_precision=True, autocast_dtype=torch.bfloat16
+        )
+        sd = stepper.state_dict()
+        assert "scaler" not in sd
+
+    def test_state_dict_has_scaler_for_fp16(self):
+        """fp16 stepper state_dict must include a 'scaler' key."""
+        opt = _make_optimizer()
+        stepper = GRPOOptimizationStepper(
+            opt, mixed_precision=True, autocast_dtype=torch.float16
+        )
+        sd = stepper.state_dict()
+        assert "scaler" in sd
+
+    def test_load_state_dict_restores_micro_step(self):
+        opt = _make_optimizer()
+        stepper = GRPOOptimizationStepper(opt, gradient_accumulation_steps=4)
+        stepper._micro_step = 3
+        sd = stepper.state_dict()
+
+        opt2 = _make_optimizer()
+        stepper2 = GRPOOptimizationStepper(opt2, gradient_accumulation_steps=4)
+        stepper2.load_state_dict(sd)
+        assert stepper2._micro_step == 3
+
+    def test_weight_sync_hook_no_update_when_count_not_multiple(self):
+        sender = MagicMock()
+        hook = WeightSyncHook(sender, weight_update_frequency=5)
+        trainer = MagicMock()
+        trainer._optim_count = 3  # Not a multiple of 5
+        trainer.replay_buffer = None
+        hook._trainer = trainer
+        hook(TensorDict({}, batch_size=[]))
+        sender.update_weights.assert_not_called()
+
+    def test_weight_sync_hook_zero_optim_count_executes(self):
+        """optim_count=0: 0 % N == 0, so it should execute."""
+        sender = MagicMock()
+        hook = WeightSyncHook(sender, weight_update_frequency=5)
+        trainer = MagicMock()
+        trainer._optim_count = 0
+        trainer.replay_buffer = None
+        hook._trainer = trainer
+        hook(TensorDict({}, batch_size=[]))
+        sender.update_weights.assert_called_once()
+
+
+
+if __name__ == '__main__':
     args, unknown = argparse.ArgumentParser().parse_known_args()
-    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)
+    pytest.main([__file__, '--capture', 'no', '--exitfirst'] + unknown)

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -2257,7 +2257,6 @@ class TestGRPOTrainer:
                 loss_module=_GRPORegressionLoss(model),
                 optimizer=torch.optim.SGD(model.parameters(), lr=0.05),
                 weight_sync_sender=sender,
-                weight_update_frequency=2,
                 gradient_accumulation_steps=2,
                 logger=logger,
                 log_interval=0,
@@ -2267,7 +2266,8 @@ class TestGRPOTrainer:
         trainer.train()
 
         assert not torch.equal(model.weight, initial_weight)
-        assert sender.update_calls == 1
+        # Sync mode pushes weights once per collected batch.
+        assert sender.update_calls == 4
         assert collector.shutdown_calls == 1
         assert logger.records["reward_mean"] == [
             (2, 2.0),
@@ -2277,6 +2277,40 @@ class TestGRPOTrainer:
         ]
         assert logger.records["kl_to_ref"][-1] == (8, pytest.approx(0.25))
         assert logger.records["kl_to_inference"][-1] == (8, pytest.approx(0.5))
+
+    def test_update_weights_optim_step_cadence(self):
+        # UpdateWeights with interval_unit="optim_steps" fires at the
+        # post_optim stage every `update_weights_interval` optimizer steps,
+        # discounting gradient-accumulation micro-steps.
+        model = nn.Linear(1, 1, bias=False)
+        stepper = GRPOOptimizationStepper(
+            torch.optim.SGD(model.parameters(), lr=0.05),
+            gradient_accumulation_steps=2,
+        )
+        collector = MockingIterableCollector([_make_grpo_batch() for _ in range(4)])
+        collector.init_random_frames = 0
+        sender = _CountingWeightSender()
+        trainer = Trainer(
+            collector=collector,
+            total_frames=8,
+            frame_skip=1,
+            optim_steps_per_batch=1,
+            loss_module=_GRPORegressionLoss(model),
+            optimization_stepper=stepper,
+            progress_bar=False,
+        )
+        UpdateWeights(
+            update_weights_interval=2,
+            trainer=trainer,
+            sender=sender,
+            interval_unit="optim_steps",
+        ).register(trainer)
+
+        trainer.train()
+
+        # 4 micro-steps with accumulation 2 -> 2 optimizer steps -> 1 push.
+        assert stepper.optimizer_step_count == 2
+        assert sender.update_calls == 1
 
     def test_buffer_writing_collector_trains_from_replay_buffer(self):
         # LLM collectors created with a replay_buffer write to it directly and

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -40,6 +40,7 @@ from torchrl.trainers.algorithms.a2c import A2CTrainer
 from torchrl.trainers.algorithms.cql import CQLTrainer
 from torchrl.trainers.algorithms.ddpg import DDPGTrainer
 from torchrl.trainers.algorithms.dqn import DQNTrainer
+from torchrl.trainers.algorithms.grpo import GRPOOptimizationStepper, GRPOTrainer
 from torchrl.trainers.algorithms.iql import IQLTrainer
 from torchrl.trainers.algorithms.offline_to_online import OfflineToOnlineTrainer
 from torchrl.trainers.algorithms.ppo import PPOTrainer
@@ -2166,548 +2167,171 @@ class TestEarlyStopping:
         assert collector.shutdown_calls == 1
 
 
+class _GRPORegressionLoss(nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, batch):
+        prediction = self.model(batch["input"])
+        loss = nn.functional.mse_loss(prediction, batch["target"])
+        return TensorDict(
+            {
+                "loss_objective": loss,
+                "kl_to_ref": loss.new_tensor(0.25),
+                "kl_to_inference": loss.new_tensor(0.5),
+            },
+            [],
+        )
 
 
-# --- GRPO Trainer Tests ---
-from unittest.mock import MagicMock, patch
-from torch import nn, optim
-from tensordict import TensorDict
+class _RecordingLogger:
+    def __init__(self):
+        self.records = {}
 
-from torchrl.trainers.algorithms.grpo import (
-    GRPOOptimizationStepper,
-    GRPOTrainer,
-    WeightSyncHook,
-)
-def _make_optimizer(model: nn.Module | None = None) -> optim.Optimizer:
-    if model is None:
-        model = nn.Linear(4, 4)
-    return optim.Adam(model.parameters(), lr=1e-3)
+    def log_scalar(self, name, value, step):
+        if isinstance(value, torch.Tensor):
+            value = value.item()
+        self.records.setdefault(name, []).append((step, value))
 
 
-def _make_loss_td(value: float = 1.0) -> TensorDict:
-    """Return a minimal TensorDict that mimics GRPOLoss output."""
+class _CountingWeightSender:
+    def __init__(self):
+        self.update_calls = 0
+
+    def update_weights(self):
+        self.update_calls += 1
+
+
+def _make_grpo_batch(reward_offset=0.0):
     return TensorDict(
-        {"loss_policy": torch.tensor(value, requires_grad=False)},
-        batch_size=[],
+        {
+            "input": torch.tensor([[1.0], [2.0]]),
+            "target": torch.tensor([[2.0], [4.0]]),
+            ("next", "reward"): torch.tensor(
+                [1.0 + reward_offset, 3.0 + reward_offset]
+            ),
+        },
+        [2],
     )
 
 
-def _make_grpo_trainer(**kwargs) -> GRPOTrainer:
-    """Build a GRPOTrainer with sensible defaults for testing (no LLM deps)."""
-    model = nn.Linear(4, 4)
-    optimizer = _make_optimizer(model)
-    collector = MagicMock()
-    collector.frames_per_batch = 4
-    loss_fn = MagicMock()
-
-    defaults = {
-        "collector": collector,
-        "total_frames": 100,
-        "frame_skip": 1,
-        "optim_steps_per_batch": 2,
-        "loss_module": loss_fn,
-        "optimizer": optimizer,
-        "weight_sync_sender": None,
-        "log_rewards": False,
-        "log_kl": False,
-    }
-    defaults.update(kwargs)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        return GRPOTrainer(**defaults)
-
-
-# ===========================================================================
-# GRPOOptimizationStepper
-# ===========================================================================
-
-
-class TestGRPOOptimizationStepper:
-    def test_default_construction(self):
-        opt = _make_optimizer()
-        stepper = GRPOOptimizationStepper(opt)
-        assert stepper.gradient_accumulation_steps == 1
-        assert stepper.mixed_precision is False
-        assert stepper._use_scaler is False
-        assert stepper._micro_step == 0
-
-    def test_fp16_enables_scaler(self):
-        opt = _make_optimizer()
-        stepper = GRPOOptimizationStepper(
-            opt, mixed_precision=True, autocast_dtype=torch.float16
+class TestGRPOTrainer:
+    def test_train_updates_policy_syncs_weights_and_logs_metrics(self):
+        model = nn.Linear(1, 1, bias=False)
+        nn.init.zeros_(model.weight)
+        initial_weight = model.weight.detach().clone()
+        collector = MockingIterableCollector(
+            [_make_grpo_batch(reward_offset=float(i)) for i in range(4)]
         )
-        assert stepper._use_scaler is True
+        collector.init_random_frames = 0
+        logger = _RecordingLogger()
+        sender = _CountingWeightSender()
 
-    def test_bf16_no_scaler(self):
-        opt = _make_optimizer()
-        stepper = GRPOOptimizationStepper(
-            opt, mixed_precision=True, autocast_dtype=torch.bfloat16
-        )
-        assert stepper._use_scaler is False
-
-    def test_invalid_accumulation_steps(self):
-        opt = _make_optimizer()
-        with pytest.raises(
-            ValueError, match="gradient_accumulation_steps must be >= 1"
-        ):
-            GRPOOptimizationStepper(opt, gradient_accumulation_steps=0)
-
-    def test_state_dict_round_trip(self):
-        model = nn.Linear(4, 4)
-        opt = _make_optimizer(model)
-        stepper = GRPOOptimizationStepper(opt, gradient_accumulation_steps=2)
-        stepper._micro_step = 1
-
-        sd = stepper.state_dict()
-        assert "optimizer" in sd
-        assert sd["micro_step"] == 1
-
-        model2 = nn.Linear(4, 4)
-        opt2 = _make_optimizer(model2)
-        stepper2 = GRPOOptimizationStepper(opt2, gradient_accumulation_steps=2)
-        stepper2.load_state_dict(sd)
-        assert stepper2._micro_step == 1
-
-    def test_micro_step_increments_each_call(self):
-        model = nn.Linear(4, 4)
-        opt = _make_optimizer(model)
-        stepper = GRPOOptimizationStepper(opt, gradient_accumulation_steps=3)
-
-        # Patch compute_loss on a fake trainer
-        trainer = MagicMock()
-        trainer.compute_loss.return_value = TensorDict(
-            {"loss_policy": torch.tensor(0.5, requires_grad=True)},
-            batch_size=[],
-        )
-        trainer.clip_grad_norm = True
-        trainer.clip_norm = 1.0
-
-        batch = TensorDict({}, batch_size=[])
-        stepper.step(trainer, batch)
-        assert stepper._micro_step == 1
-
-        stepper.step(trainer, batch)
-        assert stepper._micro_step == 2
-
-    def test_optimizer_step_executes_at_accumulation_boundary(self):
-        model = nn.Linear(4, 4)
-        opt = _make_optimizer(model)
-        stepper = GRPOOptimizationStepper(opt, gradient_accumulation_steps=2)
-
-        trainer = MagicMock()
-
-        def make_loss_td(_batch):
-            return TensorDict(
-                {"loss_policy": torch.tensor(0.5, requires_grad=True)},
-                batch_size=[],
-            )
-
-        trainer.compute_loss.side_effect = make_loss_td
-        batch = TensorDict({}, batch_size=[])
-
-        # Step 1: gradients accumulate, optimizer NOT stepped
-        with patch.object(opt, "step") as mock_step:
-            stepper.step(trainer, batch)
-            mock_step.assert_not_called()
-
-        # Step 2: accumulation boundary → optimizer should step
-        with patch.object(opt, "step") as mock_step:
-            stepper.step(trainer, batch)
-            mock_step.assert_called_once()
-
-    def test_end_to_end_optimization_reduces_loss(self):
-        """Verifies the stepper actually trains a simple model."""
-        model = nn.Linear(2, 1, bias=False)
-        nn.init.constant_(model.weight, 1.0)
-        opt = optim.SGD(model.parameters(), lr=0.5)
-        stepper = GRPOOptimizationStepper(opt, gradient_accumulation_steps=1)
-
-        x = torch.tensor([[1.0, 1.0]])
-        target = torch.tensor([[0.0]])
-
-        class SimpleLoss(nn.Module):
-            def forward(self, batch):
-                pred = model(x)
-                loss = nn.functional.mse_loss(pred, target)
-                return TensorDict({"loss_policy": loss}, batch_size=[])
-
-        trainer = MagicMock()
-        trainer.compute_loss.side_effect = lambda b: SimpleLoss()(b)
-        batch = TensorDict({}, batch_size=[])
-
-        initial_weight = model.weight.data.clone()
-        stepper.step(trainer, batch)
-        # Weight should have changed
-        assert not torch.equal(model.weight.data, initial_weight)
-
-
-# ===========================================================================
-# WeightSyncHook
-# ===========================================================================
-
-
-class TestWeightSyncHook:
-    def test_construction(self):
-        sender = MagicMock()
-        hook = WeightSyncHook(
-            sender, weight_update_frequency=5, empty_replay_buffer=True
-        )
-        assert hook.weight_update_frequency == 5
-        assert hook.empty_replay_buffer is True
-
-    def test_update_weights_called_at_correct_frequency(self):
-        sender = MagicMock()
-        hook = WeightSyncHook(sender, weight_update_frequency=3)
-        trainer = MagicMock()
-
-        # Only triggers when optim_count % frequency == 0
-        batch = TensorDict({}, batch_size=[])
-        for optim_count in range(1, 10):
-            trainer._optim_count = optim_count
-            hook._trainer = trainer
-            hook(batch)
-
-        # Steps 3, 6, 9 → 3 calls
-        assert sender.update_weights.call_count == 3
-
-    def test_replay_buffer_emptied_when_flag_set(self):
-        sender = MagicMock()
-        hook = WeightSyncHook(
-            sender, weight_update_frequency=1, empty_replay_buffer=True
-        )
-        trainer = MagicMock()
-        trainer._optim_count = 1
-        trainer.replay_buffer = MagicMock()
-        hook._trainer = trainer
-        hook(TensorDict({}, batch_size=[]))
-        trainer.replay_buffer.empty.assert_called_once_with(empty_write_count=False)
-
-    def test_replay_buffer_not_emptied_when_flag_false(self):
-        sender = MagicMock()
-        hook = WeightSyncHook(
-            sender, weight_update_frequency=1, empty_replay_buffer=False
-        )
-        trainer = MagicMock()
-        trainer._optim_count = 1
-        trainer.replay_buffer = MagicMock()
-        hook._trainer = trainer
-        hook(TensorDict({}, batch_size=[]))
-        trainer.replay_buffer.empty.assert_not_called()
-
-    def test_no_update_when_replay_buffer_is_none(self):
-        """Should not crash when replay_buffer is None."""
-        sender = MagicMock()
-        hook = WeightSyncHook(
-            sender, weight_update_frequency=1, empty_replay_buffer=True
-        )
-        trainer = MagicMock()
-        trainer._optim_count = 1
-        trainer.replay_buffer = None
-        hook._trainer = trainer
-        hook(TensorDict({}, batch_size=[]))  # Should not raise
-        sender.update_weights.assert_called_once()
-
-
-# ===========================================================================
-# GRPOTrainer construction
-# ===========================================================================
-
-
-class TestGRPOTrainerConstruction:
-    def test_basic_construction_no_sender(self):
-        trainer = _make_grpo_trainer()
-        assert trainer is not None
-
-    def test_raises_without_optimizer_and_stepper(self):
-        collector = MagicMock()
-        loss_fn = MagicMock()
-        with pytest.raises(ValueError, match="requires either an `optimizer`"):
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                GRPOTrainer(
-                    collector=collector,
-                    total_frames=100,
-                    frame_skip=1,
-                    optim_steps_per_batch=2,
-                    loss_module=loss_fn,
-                    optimizer=None,
-                    optimization_stepper=None,
-                    log_rewards=False,
-                    log_kl=False,
-                )
-
-    def test_custom_stepper_accepted(self):
-        model = nn.Linear(4, 4)
-        opt = _make_optimizer(model)
-        stepper = GRPOOptimizationStepper(opt, gradient_accumulation_steps=4)
-        collector = MagicMock()
-        loss_fn = MagicMock()
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
+        with pytest.warns(UserWarning, match="experimental"):
             trainer = GRPOTrainer(
                 collector=collector,
-                total_frames=100,
+                total_frames=8,
                 frame_skip=1,
-                optim_steps_per_batch=2,
-                loss_module=loss_fn,
-                optimizer=None,  # No optimizer needed — stepper owns it
-                optimization_stepper=stepper,
-                log_rewards=False,
-                log_kl=False,
+                optim_steps_per_batch=1,
+                loss_module=_GRPORegressionLoss(model),
+                optimizer=torch.optim.SGD(model.parameters(), lr=0.05),
+                weight_sync_sender=sender,
+                weight_update_frequency=2,
+                gradient_accumulation_steps=2,
+                logger=logger,
+                log_interval=0,
+                progress_bar=False,
             )
-        assert trainer is not None
 
-    def test_mixed_precision_propagated_to_stepper(self):
-        model = nn.Linear(4, 4)
-        opt = _make_optimizer(model)
-        collector = MagicMock()
-        loss_fn = MagicMock()
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            trainer = GRPOTrainer(
-                collector=collector,
-                total_frames=100,
-                frame_skip=1,
-                optim_steps_per_batch=2,
-                loss_module=loss_fn,
-                optimizer=opt,
-                mixed_precision=True,
-                autocast_dtype=torch.bfloat16,
-                log_rewards=False,
-                log_kl=False,
-            )
-        # The internal stepper should have the flag
-        stepper = trainer._modules.get("optimization_stepper")
-        assert stepper is not None
-        assert stepper.mixed_precision is True
-        assert stepper.autocast_dtype == torch.bfloat16
+        trainer.train()
 
-    def test_gradient_accumulation_propagated(self):
-        model = nn.Linear(4, 4)
-        opt = _make_optimizer(model)
-        collector = MagicMock()
-        loss_fn = MagicMock()
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            trainer = GRPOTrainer(
-                collector=collector,
-                total_frames=100,
-                frame_skip=1,
-                optim_steps_per_batch=2,
-                loss_module=loss_fn,
-                optimizer=opt,
-                gradient_accumulation_steps=8,
-                log_rewards=False,
-                log_kl=False,
-            )
-        stepper = trainer._modules.get("optimization_stepper")
-        assert stepper.gradient_accumulation_steps == 8
+        assert not torch.equal(model.weight, initial_weight)
+        assert sender.update_calls == 1
+        assert collector.shutdown_calls == 1
+        assert logger.records["reward_mean"] == [
+            (2, 2.0),
+            (4, 3.0),
+            (6, 4.0),
+            (8, 5.0),
+        ]
+        assert logger.records["kl_to_ref"][-1] == (8, pytest.approx(0.25))
+        assert logger.records["kl_to_inference"][-1] == (8, pytest.approx(0.5))
 
-    def test_weight_sync_hook_registered_when_sender_provided(self):
-        """When sender is passed, a WeightSyncHook must appear in post_steps."""
-        sender = MagicMock()
-        trainer = _make_grpo_trainer(weight_sync_sender=sender)
-        # Hooks are wrapped by a timing closure; check cell contents for the hook name
-        has_sync_hook = any(
-            any(
-                getattr(cell, "cell_contents", None) == "WeightSyncHook"
-                for cell in (fn.__closure__ or [])
-            )
-            for fn, _ in trainer._post_steps_ops
+    def test_gradient_accumulation_matches_a_full_batch_update(self):
+        accumulated_model = nn.Linear(1, 1, bias=False)
+        full_batch_model = nn.Linear(1, 1, bias=False)
+        nn.init.zeros_(accumulated_model.weight)
+        full_batch_model.load_state_dict(accumulated_model.state_dict())
+
+        accumulated_stepper = GRPOOptimizationStepper(
+            torch.optim.SGD(accumulated_model.parameters(), lr=0.1),
+            gradient_accumulation_steps=2,
         )
-        assert has_sync_hook
+        accumulated_trainer = Trainer(
+            collector=MockingCollector(),
+            total_frames=2,
+            frame_skip=1,
+            optim_steps_per_batch=1,
+            loss_module=_GRPORegressionLoss(accumulated_model),
+            optimization_stepper=accumulated_stepper,
+            progress_bar=False,
+        )
+        full_batch_stepper = GRPOOptimizationStepper(
+            torch.optim.SGD(full_batch_model.parameters(), lr=0.1)
+        )
+        full_batch_trainer = Trainer(
+            collector=MockingCollector(),
+            total_frames=2,
+            frame_skip=1,
+            optim_steps_per_batch=1,
+            loss_module=_GRPORegressionLoss(full_batch_model),
+            optimization_stepper=full_batch_stepper,
+            progress_bar=False,
+        )
+        batch = _make_grpo_batch()
+        micro_batches = batch.unbind(0)
+        initial_weight = accumulated_model.weight.detach().clone()
 
-    def test_no_weight_sync_hook_when_no_sender(self):
-        trainer = _make_grpo_trainer(weight_sync_sender=None)
-        # No WeightSyncHook should appear in the timing closure names
-        has_sync_hook = any(
-            any(
-                getattr(cell, "cell_contents", None) == "WeightSyncHook"
-                for cell in (fn.__closure__ or [])
+        accumulated_stepper.step(accumulated_trainer, micro_batches[0])
+        assert torch.equal(accumulated_model.weight, initial_weight)
+
+        accumulated_stepper.step(accumulated_trainer, micro_batches[1])
+        full_batch_stepper.step(full_batch_trainer, batch)
+
+        torch.testing.assert_close(
+            accumulated_model.weight,
+            full_batch_model.weight,
+        )
+
+    @pytest.mark.parametrize("gradient_accumulation_steps", [0, -1])
+    def test_rejects_invalid_gradient_accumulation(self, gradient_accumulation_steps):
+        model = nn.Linear(1, 1)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+
+        with pytest.raises(ValueError, match="must be >= 1"):
+            GRPOOptimizationStepper(
+                optimizer,
+                gradient_accumulation_steps=gradient_accumulation_steps,
             )
-            for stage_ops in [
-                trainer._post_steps_ops,
-                trainer._pre_epoch_ops,
-                trainer._post_optim_ops,
-                trainer._pre_optim_ops,
-            ]
-            for fn, _ in stage_ops
+
+    def test_rejects_loss_outputs_without_an_optimization_objective(self):
+        model = nn.Linear(1, 1)
+        stepper = GRPOOptimizationStepper(torch.optim.SGD(model.parameters(), lr=0.1))
+        trainer = Trainer(
+            collector=MockingCollector(),
+            total_frames=1,
+            frame_skip=1,
+            optim_steps_per_batch=1,
+            loss_module=nn.Identity(),
+            optimization_stepper=stepper,
+            progress_bar=False,
         )
-        assert not has_sync_hook
 
-    def test_async_collection_flag_stored(self):
-        trainer = _make_grpo_trainer(async_collection=True)
-        assert trainer.async_collection is True
-
-    def test_emits_experimental_warning(self):
-        # Do NOT suppress warnings here — we want to capture the UserWarning
-        model = torch.nn.Linear(4, 4)
-        optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
-        collector = MagicMock()
-        loss_fn = MagicMock()
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            GRPOTrainer(
-                collector=collector,
-                total_frames=100,
-                frame_skip=1,
-                optim_steps_per_batch=2,
-                loss_module=loss_fn,
-                optimizer=optimizer,
-                log_rewards=False,
-                log_kl=False,
-            )
-        user_warnings = [x for x in w if issubclass(x.category, UserWarning)]
-        assert any("experimental" in str(x.message).lower() for x in user_warnings)
-
-    def test_replay_buffer_hooks_registered(self):
-        """ReplayBufferTrainer hooks should appear when a replay buffer is provided."""
-        from torchrl.data import LazyTensorStorage, ReplayBuffer
-
-        rb = ReplayBuffer(storage=LazyTensorStorage(100), batch_size=4)
-        trainer = _make_grpo_trainer(replay_buffer=rb)
-        # process_optim_batch hooks are stored in _process_optim_batch_ops
-        assert len(trainer._process_optim_batch_ops) > 0
-
-    def test_no_replay_buffer_no_crash(self):
-        """Passing no replay buffer is valid (e.g., remote RB setup)."""
-        trainer = _make_grpo_trainer(replay_buffer=None)
-        assert trainer is not None
-
-    def test_weight_update_frequency_respected(self):
-        """WeightSyncHook.weight_update_frequency should match what was passed."""
-        sender = MagicMock()
-        trainer = _make_grpo_trainer(
-            weight_sync_sender=sender,
-            weight_update_frequency=7,
-        )
-        # The WeightSyncHook is stashed inside the timing-closure cell contents.
-        # The hook object itself is a cell_contents that is a WeightSyncHook instance.
-        sync_hooks = []
-        for fn, _ in trainer._post_steps_ops:
-            for cell in fn.__closure__ or []:
-                try:
-                    obj = cell.cell_contents
-                    if isinstance(obj, WeightSyncHook):
-                        sync_hooks.append(obj)
-                except ValueError:
-                    pass
-        assert len(sync_hooks) == 1
-        assert sync_hooks[0].weight_update_frequency == 7
-
-
-# ===========================================================================
-# Public API / import checks
-# ===========================================================================
-
-
-class TestPublicAPI:
-    def test_grpotrainer_in_algorithms_init(self):
-        from torchrl.trainers import algorithms
-
-        assert hasattr(algorithms, "GRPOTrainer")
-
-    def test_grpotrainer_in_trainers_init(self):
-        import torchrl.trainers as T
-
-        assert hasattr(T, "GRPOTrainer")
-        assert hasattr(T, "GRPOOptimizationStepper")
-        assert hasattr(T, "WeightSyncHook")
-
-    def test_grpotrainer_importable_directly(self):
-        from torchrl.trainers.algorithms.grpo import GRPOTrainer as GT
-
-        assert GT is GRPOTrainer
-
-
-# ===========================================================================
-# Edge cases
-# ===========================================================================
-
-
-class TestEdgeCases:
-    def test_clip_norm_none_does_not_clip(self):
-        """With clip_norm=None the stepper should still run without error."""
-        model = nn.Linear(4, 4)
-        opt = _make_optimizer(model)
-        stepper = GRPOOptimizationStepper(opt, clip_norm=None)
-
-        trainer = MagicMock()
-        trainer.compute_loss.return_value = TensorDict(
-            {"loss_policy": torch.tensor(1.0, requires_grad=True)},
-            batch_size=[],
-        )
-        batch = TensorDict({}, batch_size=[])
-        result = stepper.step(trainer, batch)
-        assert "loss_policy" in result.keys()
-
-    def test_no_loss_keys_raises(self):
-        """If the loss module returns no 'loss_*' keys, a RuntimeError is raised."""
-        model = nn.Linear(4, 4)
-        opt = _make_optimizer(model)
-        stepper = GRPOOptimizationStepper(opt)
-
-        trainer = MagicMock()
-        trainer.compute_loss.return_value = TensorDict(
-            {"some_other_key": torch.tensor(1.0)},
-            batch_size=[],
-        )
-        batch = TensorDict({}, batch_size=[])
         with pytest.raises(RuntimeError, match="no 'loss_\\*' keys"):
-            stepper.step(trainer, batch)
-
-    def test_state_dict_has_no_scaler_for_bf16(self):
-        """bf16 stepper state_dict must not include a 'scaler' key."""
-        opt = _make_optimizer()
-        stepper = GRPOOptimizationStepper(
-            opt, mixed_precision=True, autocast_dtype=torch.bfloat16
-        )
-        sd = stepper.state_dict()
-        assert "scaler" not in sd
-
-    def test_state_dict_has_scaler_for_fp16(self):
-        """fp16 stepper state_dict must include a 'scaler' key."""
-        opt = _make_optimizer()
-        stepper = GRPOOptimizationStepper(
-            opt, mixed_precision=True, autocast_dtype=torch.float16
-        )
-        sd = stepper.state_dict()
-        assert "scaler" in sd
-
-    def test_load_state_dict_restores_micro_step(self):
-        opt = _make_optimizer()
-        stepper = GRPOOptimizationStepper(opt, gradient_accumulation_steps=4)
-        stepper._micro_step = 3
-        sd = stepper.state_dict()
-
-        opt2 = _make_optimizer()
-        stepper2 = GRPOOptimizationStepper(opt2, gradient_accumulation_steps=4)
-        stepper2.load_state_dict(sd)
-        assert stepper2._micro_step == 3
-
-    def test_weight_sync_hook_no_update_when_count_not_multiple(self):
-        sender = MagicMock()
-        hook = WeightSyncHook(sender, weight_update_frequency=5)
-        trainer = MagicMock()
-        trainer._optim_count = 3  # Not a multiple of 5
-        trainer.replay_buffer = None
-        hook._trainer = trainer
-        hook(TensorDict({}, batch_size=[]))
-        sender.update_weights.assert_not_called()
-
-    def test_weight_sync_hook_zero_optim_count_executes(self):
-        """optim_count=0: 0 % N == 0, so it should execute."""
-        sender = MagicMock()
-        hook = WeightSyncHook(sender, weight_update_frequency=5)
-        trainer = MagicMock()
-        trainer._optim_count = 0
-        trainer.replay_buffer = None
-        hook._trainer = trainer
-        hook(TensorDict({}, batch_size=[]))
-        sender.update_weights.assert_called_once()
+            stepper.step(trainer, _make_grpo_batch())
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
-    pytest.main([__file__, '--capture', 'no', '--exitfirst'] + unknown)
+    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -2469,7 +2469,9 @@ class TestGRPOTrainer:
 
     def test_rejects_loss_outputs_without_an_optimization_objective(self):
         model = nn.Linear(1, 1)
-        stepper = MixedPrecisionOptimizationStepper(torch.optim.SGD(model.parameters(), lr=0.1))
+        stepper = MixedPrecisionOptimizationStepper(
+            torch.optim.SGD(model.parameters(), lr=0.1)
+        )
         trainer = Trainer(
             collector=MockingCollector(),
             total_frames=1,

--- a/torchrl/collectors/llm/ray_collector.py
+++ b/torchrl/collectors/llm/ray_collector.py
@@ -125,6 +125,10 @@ class RayLLMCollector(LLMCollector):
             remote_config.setdefault("num_gpus", num_gpus)
         remote_cls = LLMCollector.as_remote(remote_config).remote
         self.sync_iter = sync_iter
+        # Keep a local handle on the replay buffer so that buffer-facing
+        # helpers inherited from Collector (e.g. ``getattr_rb``) work on this
+        # wrapper: the remote collector holds its own reference.
+        self.replay_buffer = replay_buffer
         self._collector = remote_cls(
             env=env,
             policy=policy,
@@ -173,6 +177,16 @@ class RayLLMCollector(LLMCollector):
                     yield result
             except StopIteration:
                 break
+
+    @property
+    def init_random_frames(self) -> int:
+        """Number of random warmup frames (always 0 for LLM collectors).
+
+        The remote :class:`~torchrl.collectors.llm.LLMCollector` is created
+        without ``init_random_frames``, so the local wrapper reports 0. This
+        attribute is read by :class:`~torchrl.trainers.Trainer`.
+        """
+        return 0
 
     def start(self):
         """Starts the collector in a background thread."""

--- a/torchrl/trainers/__init__.py
+++ b/torchrl/trainers/__init__.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .algorithms.grpo import GRPOTrainer
 from .trainers import (
     BatchSubSampler,
     ClearCudaCache,
@@ -35,7 +34,6 @@ __all__ = [
     "CountFramesLog",
     "DefaultOptimizationStepper",
     "EarlyStopping",
-    "GRPOTrainer",
     "LogScalar",
     "LogTiming",
     "LogValidationReward",

--- a/torchrl/trainers/__init__.py
+++ b/torchrl/trainers/__init__.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from .algorithms.grpo import GRPOOptimizationStepper, GRPOTrainer, WeightSyncHook
 from .trainers import (
     BatchSubSampler,
     ClearCudaCache,
@@ -33,6 +34,8 @@ __all__ = [
     "CountFramesLog",
     "DefaultOptimizationStepper",
     "EarlyStopping",
+    "GRPOOptimizationStepper",
+    "GRPOTrainer",
     "LogScalar",
     "LogTiming",
     "LogValidationReward",
@@ -49,4 +52,5 @@ __all__ = [
     "TargetNetUpdaterHook",
     "UTDRHook",
     "ValueEstimatorHook",
+    "WeightSyncHook",
 ]

--- a/torchrl/trainers/__init__.py
+++ b/torchrl/trainers/__init__.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .algorithms.grpo import GRPOOptimizationStepper, GRPOTrainer
+from .algorithms.grpo import GRPOTrainer
 from .trainers import (
     BatchSubSampler,
     ClearCudaCache,
@@ -15,6 +15,7 @@ from .trainers import (
     LogValidationReward,
     LRSchedulerHook,
     mask_batch,
+    MixedPrecisionOptimizationStepper,
     OptimizationStepper,
     OptimizerHook,
     ReplayBufferTrainer,
@@ -34,13 +35,13 @@ __all__ = [
     "CountFramesLog",
     "DefaultOptimizationStepper",
     "EarlyStopping",
-    "GRPOOptimizationStepper",
     "GRPOTrainer",
     "LogScalar",
     "LogTiming",
     "LogValidationReward",
     "LRSchedulerHook",
     "mask_batch",
+    "MixedPrecisionOptimizationStepper",
     "OptimizationStepper",
     "OptimizerHook",
     "ReplayBufferTrainer",

--- a/torchrl/trainers/__init__.py
+++ b/torchrl/trainers/__init__.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .algorithms.grpo import GRPOOptimizationStepper, GRPOTrainer, WeightSyncHook
+from .algorithms.grpo import GRPOOptimizationStepper, GRPOTrainer
 from .trainers import (
     BatchSubSampler,
     ClearCudaCache,
@@ -52,5 +52,4 @@ __all__ = [
     "TargetNetUpdaterHook",
     "UTDRHook",
     "ValueEstimatorHook",
-    "WeightSyncHook",
 ]

--- a/torchrl/trainers/algorithms/__init__.py
+++ b/torchrl/trainers/algorithms/__init__.py
@@ -9,7 +9,7 @@ from .a2c import A2CTrainer
 from .cql import CQLTrainer
 from .ddpg import DDPGTrainer
 from .dqn import DQNTrainer
-from .grpo import GRPOOptimizationStepper, GRPOTrainer
+from .grpo import GRPOTrainer
 from .iql import IQLTrainer
 from .offline_to_online import OfflineToOnlineTrainer
 from .on_policy import OnPolicyTrainer
@@ -23,7 +23,6 @@ __all__ = [
     "CQLTrainer",
     "DDPGTrainer",
     "DQNTrainer",
-    "GRPOOptimizationStepper",
     "GRPOTrainer",
     "IQLTrainer",
     "OfflineToOnlineTrainer",

--- a/torchrl/trainers/algorithms/__init__.py
+++ b/torchrl/trainers/algorithms/__init__.py
@@ -9,6 +9,7 @@ from .a2c import A2CTrainer
 from .cql import CQLTrainer
 from .ddpg import DDPGTrainer
 from .dqn import DQNTrainer
+from .grpo import GRPOOptimizationStepper, GRPOTrainer, WeightSyncHook
 from .iql import IQLTrainer
 from .offline_to_online import OfflineToOnlineTrainer
 from .on_policy import OnPolicyTrainer
@@ -22,6 +23,8 @@ __all__ = [
     "CQLTrainer",
     "DDPGTrainer",
     "DQNTrainer",
+    "GRPOOptimizationStepper",
+    "GRPOTrainer",
     "IQLTrainer",
     "OfflineToOnlineTrainer",
     "OnPolicyTrainer",
@@ -29,4 +32,5 @@ __all__ = [
     "ReinforceTrainer",
     "SACTrainer",
     "TD3Trainer",
+    "WeightSyncHook",
 ]

--- a/torchrl/trainers/algorithms/__init__.py
+++ b/torchrl/trainers/algorithms/__init__.py
@@ -9,7 +9,7 @@ from .a2c import A2CTrainer
 from .cql import CQLTrainer
 from .ddpg import DDPGTrainer
 from .dqn import DQNTrainer
-from .grpo import GRPOOptimizationStepper, GRPOTrainer, WeightSyncHook
+from .grpo import GRPOOptimizationStepper, GRPOTrainer
 from .iql import IQLTrainer
 from .offline_to_online import OfflineToOnlineTrainer
 from .on_policy import OnPolicyTrainer
@@ -32,5 +32,4 @@ __all__ = [
     "ReinforceTrainer",
     "SACTrainer",
     "TD3Trainer",
-    "WeightSyncHook",
 ]

--- a/torchrl/trainers/algorithms/configs/__init__.py
+++ b/torchrl/trainers/algorithms/configs/__init__.py
@@ -131,6 +131,7 @@ from torchrl.trainers.algorithms.configs.trainers import (
     CQLTrainerConfig,
     DDPGTrainerConfig,
     DQNTrainerConfig,
+    GRPOTrainerConfig,
     IQLTrainerConfig,
     OfflineToOnlineTrainerConfig,
     OnPolicyTrainerConfig,
@@ -426,6 +427,7 @@ __all__ = [
     "SACTrainerConfig",
     "TD3TrainerConfig",
     "TrainerConfig",
+    "GRPOTrainerConfig",
     # Hooks
     "HookConfig",
     "BatchSubSamplerConfig",
@@ -713,6 +715,7 @@ def _register_configs():
     cs.store(group="trainer", name="reinforce", node=ReinforceTrainerConfig)
     cs.store(group="trainer", name="sac", node=SACTrainerConfig)
     cs.store(group="trainer", name="td3", node=TD3TrainerConfig)
+    cs.store(group="trainer", name="grpo", node=GRPOTrainerConfig)
 
     # =============================================================================
     # Hook Configurations

--- a/torchrl/trainers/algorithms/configs/trainers.py
+++ b/torchrl/trainers/algorithms/configs/trainers.py
@@ -1650,24 +1650,40 @@ class GRPOTrainerConfig(TrainerConfig):
     collector: Any
     total_frames: int
     loss_module: Any
+    optim_steps_per_batch: int = 1
     optimizer: Any | None = None
     optimization_stepper: Any | None = None
+    # LLM-specific
     weight_sync_sender: Any | None = None
     weight_update_frequency: int = 1
     empty_replay_buffer_on_weight_update: bool = False
+    # Replay buffer
+    replay_buffer: Any | None = None
+    batch_size: int | None = None
+    # Mixed precision / gradient accumulation
     mixed_precision: bool = False
-    autocast_dtype: Any | None = None
+    autocast_dtype: Any = None
     gradient_accumulation_steps: int = 1
-    clip_norm: float | None = None
+    # Standard trainer args
     logger: Any | None = None
+    clip_grad_norm: bool = True
+    clip_norm: float | None = 1.0
+    progress_bar: bool = True
+    seed: int | None = None
+    save_trainer_interval: int = 10000
     log_interval: int = 10000
+    save_trainer_file: Any | None = None
+    checkpoint: Any | None = None
+    checkpoint_rotation: Any | None = None
+    checkpoint_metadata: Any | None = None
     num_epochs: int = 1
     async_collection: bool = False
+    log_timings: bool = False
+    auto_log_optim_steps: bool = True
+    # Logging toggles
     log_rewards: bool = True
-    log_kl: bool = False
+    log_kl: bool = True
     frame_skip: int = 1
-    optim_steps_per_batch: int = 1
-    replay_buffer: Any | None = None
     _target_: str = "torchrl.trainers.algorithms.configs.trainers._make_grpo_trainer"
 
     def __post_init__(self) -> None:

--- a/torchrl/trainers/algorithms/configs/trainers.py
+++ b/torchrl/trainers/algorithms/configs/trainers.py
@@ -1638,3 +1638,65 @@ def _make_td3_trainer(*args, **kwargs) -> TD3Trainer:
     )
     _register_trainer_hooks(trainer, hooks)
     return trainer
+
+
+@dataclass
+class GRPOTrainerConfig(TrainerConfig):
+    """Hydra configuration for :class:`~torchrl.trainers.algorithms.GRPOTrainer`.
+
+    Every kwarg accepted by ``GRPOTrainer.__init__`` is exposed as a field here.
+    """
+
+    collector: Any
+    total_frames: int
+    loss_module: Any
+    optimizer: Any | None = None
+    optimization_stepper: Any | None = None
+    weight_sync_sender: Any | None = None
+    weight_update_frequency: int = 1
+    empty_replay_buffer_on_weight_update: bool = False
+    mixed_precision: bool = False
+    autocast_dtype: Any | None = None
+    gradient_accumulation_steps: int = 1
+    clip_norm: float | None = None
+    logger: Any | None = None
+    log_interval: int = 10000
+    num_epochs: int = 1
+    async_collection: bool = False
+    log_rewards: bool = True
+    log_kl: bool = False
+    frame_skip: int = 1
+    optim_steps_per_batch: int = 1
+    replay_buffer: Any | None = None
+    _target_: str = "torchrl.trainers.algorithms.configs.trainers._make_grpo_trainer"
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+
+
+def _make_grpo_trainer(**kwargs):
+    from torchrl.trainers.algorithms.grpo import GRPOTrainer
+    from torchrl.trainers.trainers import Logger
+
+    collector = kwargs.pop("collector")
+    total_frames = kwargs.pop("total_frames")
+    if total_frames is None:
+        total_frames = collector.total_frames
+    loss_module = kwargs.pop("loss_module")
+
+    if (
+        "logger" in kwargs
+        and kwargs["logger"] is not None
+        and not isinstance(kwargs["logger"], Logger)
+    ):
+        raise TypeError(
+            f"logger must be a Logger or None, got {type(kwargs['logger'])}"
+        )
+
+    trainer = GRPOTrainer(
+        collector=collector,
+        total_frames=total_frames,
+        loss_module=loss_module,
+        **kwargs,
+    )
+    return trainer

--- a/torchrl/trainers/algorithms/configs/trainers.py
+++ b/torchrl/trainers/algorithms/configs/trainers.py
@@ -1651,7 +1651,7 @@ class GRPOTrainerConfig(TrainerConfig):
     collector: Any
     total_frames: int
     loss_module: Any
-    optim_steps_per_batch: int = 1
+    optim_steps_per_batch: int | None = None
     optimizer: Any | None = None
     optimization_stepper: Any | None = None
     # LLM-specific
@@ -1661,6 +1661,7 @@ class GRPOTrainerConfig(TrainerConfig):
     # Replay buffer
     replay_buffer: Any | None = None
     batch_size: int | None = None
+    device: Any = None
     # Mixed precision / gradient accumulation
     mixed_precision: bool = False
     autocast_dtype: Any = None

--- a/torchrl/trainers/algorithms/configs/trainers.py
+++ b/torchrl/trainers/algorithms/configs/trainers.py
@@ -1645,7 +1645,9 @@ def _make_td3_trainer(*args, **kwargs) -> TD3Trainer:
 class GRPOTrainerConfig(TrainerConfig):
     """Hydra configuration for :class:`~torchrl.trainers.algorithms.GRPOTrainer`.
 
-    Every kwarg accepted by ``GRPOTrainer.__init__`` is exposed as a field here.
+    Every kwarg accepted by ``GRPOTrainer.__init__`` is exposed as a field
+    here. ``autocast_dtype`` is a dtype name (e.g. ``"bfloat16"``); ``None``
+    keeps the trainer default (``torch.bfloat16``).
     """
 
     collector: Any
@@ -1664,11 +1666,10 @@ class GRPOTrainerConfig(TrainerConfig):
     device: Any = None
     # Mixed precision / gradient accumulation
     mixed_precision: bool = False
-    autocast_dtype: Any = None
+    autocast_dtype: str | None = None
     gradient_accumulation_steps: int = 1
     # Standard trainer args
     logger: Any | None = None
-    clip_grad_norm: bool = True
     clip_norm: float | None = 1.0
     progress_bar: bool = True
     seed: int | None = None
@@ -1686,6 +1687,7 @@ class GRPOTrainerConfig(TrainerConfig):
     log_rewards: bool = True
     log_kl: bool = True
     frame_skip: int = 1
+    hooks: list[Any] | None = None
     _target_: str = "torchrl.trainers.algorithms.configs.trainers._make_grpo_trainer"
 
     def __post_init__(self) -> None:
@@ -1700,20 +1702,43 @@ def _make_grpo_trainer(**kwargs) -> GRPOTrainer:
     if total_frames is None:
         total_frames = collector.total_frames
     loss_module = kwargs.pop("loss_module")
+    optimizer = kwargs.pop("optimizer", None)
+    replay_buffer = kwargs.pop("replay_buffer", None)
+    async_collection = kwargs.pop("async_collection", False)
+    autocast_dtype = kwargs.pop("autocast_dtype", None)
+    logger = kwargs.pop("logger", None)
+    hooks = kwargs.pop("hooks", None)
 
-    if (
-        "logger" in kwargs
-        and kwargs["logger"] is not None
-        and not isinstance(kwargs["logger"], Logger)
-    ):
-        raise TypeError(
-            f"logger must be a Logger or None, got {type(kwargs['logger'])}"
-        )
+    # Instantiate partial configs, mirroring the other trainer factories
+    if not isinstance(collector, BaseCollector):
+        if not async_collection:
+            collector = collector()
+        else:
+            collector = collector(replay_buffer=replay_buffer)
+    if not isinstance(loss_module, torch.nn.Module):
+        loss_module = loss_module()
+    if optimizer is not None and not isinstance(optimizer, torch.optim.Optimizer):
+        optimizer = optimizer(params=loss_module.parameters())
+
+    if logger is not None and not isinstance(logger, Logger):
+        raise TypeError(f"logger must be a Logger or None, got {type(logger)}")
+
+    if autocast_dtype is not None:
+        if not hasattr(torch, autocast_dtype) or not isinstance(
+            getattr(torch, autocast_dtype), torch.dtype
+        ):
+            raise ValueError(f"Unknown dtype name: {autocast_dtype!r}")
+        kwargs["autocast_dtype"] = getattr(torch, autocast_dtype)
 
     trainer = GRPOTrainer(
         collector=collector,
         total_frames=total_frames,
         loss_module=loss_module,
+        optimizer=optimizer,
+        replay_buffer=replay_buffer,
+        async_collection=async_collection,
+        logger=logger,
         **kwargs,
     )
+    _register_trainer_hooks(trainer, hooks)
     return trainer

--- a/torchrl/trainers/algorithms/configs/trainers.py
+++ b/torchrl/trainers/algorithms/configs/trainers.py
@@ -21,6 +21,7 @@ from torchrl.trainers.algorithms.configs.common import _normalize_hydra_key, Con
 from torchrl.trainers.algorithms.cql import CQLTrainer
 from torchrl.trainers.algorithms.ddpg import DDPGTrainer
 from torchrl.trainers.algorithms.dqn import DQNTrainer
+from torchrl.trainers.algorithms.grpo import GRPOTrainer
 from torchrl.trainers.algorithms.iql import IQLTrainer
 from torchrl.trainers.algorithms.offline_to_online import OfflineToOnlineTrainer
 from torchrl.trainers.algorithms.ppo import PPOTrainer
@@ -1690,8 +1691,7 @@ class GRPOTrainerConfig(TrainerConfig):
         super().__post_init__()
 
 
-def _make_grpo_trainer(**kwargs):
-    from torchrl.trainers.algorithms.grpo import GRPOTrainer
+def _make_grpo_trainer(**kwargs) -> GRPOTrainer:
     from torchrl.trainers.trainers import Logger
 
     collector = kwargs.pop("collector")

--- a/torchrl/trainers/algorithms/grpo.py
+++ b/torchrl/trainers/algorithms/grpo.py
@@ -103,6 +103,13 @@ class GRPOOptimizationStepper(OptimizationStepper):
     # ------------------------------------------------------------------
 
     def state_dict(self) -> dict[str, Any]:
+        if self._micro_step % self.gradient_accumulation_steps != 0:
+            raise RuntimeError(
+                f"Cannot save stepper state mid-accumulation. (micro_step={self._micro_step}, "
+                f"accumulation_steps={self.gradient_accumulation_steps}). "
+                "Adjust your save_interval to align with the gradient accumulation window."
+            )
+
         sd: dict[str, Any] = {
             "optimizer": self.optimizer.state_dict(),
             "micro_step": self._micro_step,
@@ -174,12 +181,15 @@ class GRPOOptimizationStepper(OptimizationStepper):
                 grad_norm = float(nn.utils.clip_grad_norm_(params, self.clip_norm))
 
             if self._use_scaler:
+                scale_before = self.scaler.get_scale()
                 self.scaler.step(self.optimizer)
                 self.scaler.update()
+                # If scale dropped, an overflow occurred and optimizer.step() was skipped.
+                if self.scaler.get_scale() >= scale_before:
+                    self._optimizer_step_count += 1
             else:
                 self.optimizer.step()
-
-            self._optimizer_step_count += 1
+                self._optimizer_step_count += 1
             self.optimizer.zero_grad(set_to_none=True)
             losses_td["grad_norm"] = torch.tensor(grad_norm)
 

--- a/torchrl/trainers/algorithms/grpo.py
+++ b/torchrl/trainers/algorithms/grpo.py
@@ -5,9 +5,11 @@
 
 """GRPO (Group Relative Policy Optimization) Trainer for LLM alignment.
 
-This module provides a :class:`GRPOTrainer` and :class:`GRPOOptimizationStepper`
-that integrate the GRPO / LLM alignment training loop into the standard
-TorchRL :class:`~torchrl.trainers.Trainer` framework.
+This module provides a :class:`GRPOTrainer` that integrates the GRPO / LLM
+alignment training loop into the standard TorchRL
+:class:`~torchrl.trainers.Trainer` framework, building on
+:class:`~torchrl.trainers.MixedPrecisionOptimizationStepper` for the
+optimization step.
 
 The key differences from a standard RL trainer are:
 
@@ -24,7 +26,6 @@ The key differences from a standard RL trainer are:
 
 from __future__ import annotations
 
-import gc
 import pathlib
 import warnings
 from collections.abc import Callable, Mapping
@@ -32,8 +33,7 @@ from typing import Any
 
 import torch
 from tensordict import TensorDictBase
-from torch import nn, optim
-from torch.amp import GradScaler
+from torch import optim
 from torchrl.checkpoint import Checkpoint, CheckpointRotation
 from torchrl.collectors import BaseCollector
 from torchrl.data.replay_buffers.replay_buffers import ReplayBuffer
@@ -42,174 +42,12 @@ from torchrl.objectives.common import LossModule
 from torchrl.record.loggers import Logger
 from torchrl.trainers.trainers import (
     LogScalar,
+    MixedPrecisionOptimizationStepper,
     OptimizationStepper,
     ReplayBufferTrainer,
     Trainer,
     UpdateWeights,
 )
-
-
-class GRPOOptimizationStepper(OptimizationStepper):
-    """Mixed-precision optimization step for GRPO / LLM alignment training.
-
-    This stepper wraps each forward/backward pass in ``torch.amp.autocast``
-    and optionally scales gradients with ``torch.amp.GradScaler`` (for fp16).
-    It also implements *gradient accumulation*: gradients are accumulated for
-    ``gradient_accumulation_steps`` micro-batches before the optimizer is
-    stepped and zeroed.
-
-    Args:
-        optimizer (optim.Optimizer): The optimizer to use.
-        mixed_precision (bool, optional): Whether to enable mixed-precision
-            training. Default: ``False``.
-        autocast_dtype (torch.dtype, optional): The dtype to use inside
-            ``autocast``. Default: ``torch.bfloat16``.
-        gradient_accumulation_steps (int, optional): Number of micro-batches
-            over which gradients are accumulated before a step. Default: ``1``.
-        clip_norm (float, optional): Maximum gradient norm for clipping.
-            Default: ``1.0``.
-
-    .. note::
-        ``GradScaler`` is only enabled when ``mixed_precision=True`` *and*
-        ``autocast_dtype=torch.float16``.  With bfloat16 (the recommended
-        dtype for modern GPUs) the scaler is a no-op and is not created.
-    """
-
-    def __init__(
-        self,
-        optimizer: optim.Optimizer,
-        *,
-        mixed_precision: bool = False,
-        autocast_dtype: torch.dtype = torch.bfloat16,
-        gradient_accumulation_steps: int = 1,
-        clip_norm: float | None = 1.0,
-    ) -> None:
-        if gradient_accumulation_steps < 1:
-            raise ValueError("gradient_accumulation_steps must be >= 1")
-        self.optimizer = optimizer
-        self.mixed_precision = mixed_precision
-        self.autocast_dtype = autocast_dtype
-        self.gradient_accumulation_steps = gradient_accumulation_steps
-        self.clip_norm = clip_norm
-
-        # GradScaler is only useful for fp16; bf16 doesn't need it.
-        self._use_scaler = mixed_precision and (autocast_dtype == torch.float16)
-        self.scaler = GradScaler("cuda", enabled=self._use_scaler)
-
-        # Internal micro-batch counter (reset after every optimizer step).
-        self._micro_step: int = 0
-        self._optimizer_step_count: int = 0
-
-    @property
-    def optimizer_step_count(self) -> int:
-        """Number of completed optimizer steps.
-
-        Discounts gradient-accumulation micro-steps and steps skipped by the
-        GradScaler on overflow. Read by hooks that act on an optimizer-step
-        cadence (e.g. :class:`~torchrl.trainers.UpdateWeights` with
-        ``interval_unit="optim_steps"``).
-        """
-        return self._optimizer_step_count
-
-    # ------------------------------------------------------------------
-    # Checkpointing (optimizer + scaler state)
-    # ------------------------------------------------------------------
-
-    def state_dict(self) -> dict[str, Any]:
-        if self._micro_step % self.gradient_accumulation_steps != 0:
-            raise RuntimeError(
-                f"Cannot save stepper state mid-accumulation. (micro_step={self._micro_step}, "
-                f"accumulation_steps={self.gradient_accumulation_steps}). "
-                "Adjust your save_interval to align with the gradient accumulation window."
-            )
-
-        sd: dict[str, Any] = {
-            "optimizer": self.optimizer.state_dict(),
-            "micro_step": self._micro_step,
-            "optimizer_step_count": self._optimizer_step_count,
-        }
-        if self._use_scaler:
-            sd["scaler"] = self.scaler.state_dict()
-        return sd
-
-    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        self.optimizer.load_state_dict(state_dict["optimizer"])
-        self._micro_step = state_dict.get("micro_step", 0)
-        self._optimizer_step_count = state_dict.get("optimizer_step_count", 0)
-        if self._use_scaler and "scaler" in state_dict:
-            self.scaler.load_state_dict(state_dict["scaler"])
-
-    # ------------------------------------------------------------------
-    # Core step
-    # ------------------------------------------------------------------
-
-    def step(self, trainer: Trainer, sub_batch: TensorDictBase) -> TensorDictBase:
-        """Perform one GRPO forward pass and scaled backward pass.
-
-        The optimizer is only stepped and zeroed every
-        ``gradient_accumulation_steps`` calls.
-
-        Args:
-            trainer (Trainer): The owning :class:`~torchrl.trainers.Trainer`.
-            sub_batch (TensorDictBase): Mini-batch used for this step.
-
-        Returns:
-            A :class:`~tensordict.TensorDict` with scalar metrics (losses,
-            grad_norm) suitable for logging.
-        """
-        # ---- forward pass (optionally under autocast) ----
-        with torch.amp.autocast(
-            "cuda",
-            enabled=self.mixed_precision,
-            dtype=self.autocast_dtype,
-        ):
-            losses_td = trainer.compute_loss(sub_batch)
-            # Sum all loss_* keys and normalise by accumulation steps.
-            loss_items = [v for k, v in losses_td.items() if k.startswith("loss")]
-            if not loss_items:
-                raise RuntimeError(
-                    "GRPOLoss returned no 'loss_*' keys. "
-                    "Make sure your loss module prefixes scalar outputs with 'loss'."
-                )
-            loss = sum(loss_items) / self.gradient_accumulation_steps
-
-        # ---- backward pass ----
-        if self._use_scaler:
-            self.scaler.scale(loss).backward()
-        else:
-            loss.backward()
-
-        self._micro_step += 1
-
-        # ---- optimizer step every `gradient_accumulation_steps` micro-batches ----
-        if self._micro_step % self.gradient_accumulation_steps == 0:
-            if self._use_scaler:
-                self.scaler.unscale_(self.optimizer)
-
-            grad_norm = 0.0
-            if self.clip_norm is not None:
-                params = [
-                    p for group in self.optimizer.param_groups for p in group["params"]
-                ]
-                grad_norm = float(nn.utils.clip_grad_norm_(params, self.clip_norm))
-
-            if self._use_scaler:
-                scale_before = self.scaler.get_scale()
-                self.scaler.step(self.optimizer)
-                self.scaler.update()
-                # If scale dropped, an overflow occurred and optimizer.step() was skipped.
-                if self.scaler.get_scale() >= scale_before:
-                    self._optimizer_step_count += 1
-            else:
-                self.optimizer.step()
-                self._optimizer_step_count += 1
-            self.optimizer.zero_grad(set_to_none=True)
-            losses_td["grad_norm"] = torch.tensor(grad_norm)
-
-            # Free memory after the step.
-            gc.collect()
-
-        return losses_td.detach()
 
 
 class GRPOTrainer(Trainer):
@@ -266,8 +104,9 @@ class GRPOTrainer(Trainer):
         loss_module (LossModule): The GRPO loss module.
         optimizer (optim.Optimizer, optional): Optimizer. Required when
             ``optimization_stepper`` is not provided.
-        optimization_stepper (GRPOOptimizationStepper, optional): Custom
-            stepper. If omitted, a :class:`GRPOOptimizationStepper` is
+        optimization_stepper (OptimizationStepper, optional): Custom
+            stepper. If omitted, a
+            :class:`~torchrl.trainers.MixedPrecisionOptimizationStepper` is
             constructed automatically from ``optimizer`` and the
             mixed-precision arguments below.
         weight_sync_sender (optional): Object with an ``update_weights()``
@@ -350,7 +189,7 @@ class GRPOTrainer(Trainer):
         optim_steps_per_batch: int | None = None,
         loss_module: LossModule | Callable[[TensorDictBase], TensorDictBase],
         optimizer: optim.Optimizer | None = None,
-        optimization_stepper: GRPOOptimizationStepper | None = None,
+        optimization_stepper: OptimizationStepper | None = None,
         # LLM-specific
         weight_sync_sender: Any | None = None,
         weight_update_frequency: int = 1,
@@ -398,7 +237,7 @@ class GRPOTrainer(Trainer):
                     "GRPOTrainer requires either an `optimizer` or a custom "
                     "`optimization_stepper`."
                 )
-            optimization_stepper = GRPOOptimizationStepper(
+            optimization_stepper = MixedPrecisionOptimizationStepper(
                 optimizer=optimizer,
                 mixed_precision=mixed_precision,
                 autocast_dtype=autocast_dtype,

--- a/torchrl/trainers/algorithms/grpo.py
+++ b/torchrl/trainers/algorithms/grpo.py
@@ -30,11 +30,9 @@ from collections.abc import Callable, Mapping
 from typing import Any
 
 import torch
-
 from tensordict import TensorDictBase
 from torch import nn, optim
 from torch.amp import GradScaler
-
 from torchrl.checkpoint import Checkpoint, CheckpointRotation
 from torchrl.collectors import BaseCollector
 from torchrl.data.replay_buffers.replay_buffers import ReplayBuffer
@@ -98,6 +96,7 @@ class GRPOOptimizationStepper(OptimizationStepper):
 
         # Internal micro-batch counter (reset after every optimizer step).
         self._micro_step: int = 0
+        self._optimizer_step_count: int = 0
 
     # ------------------------------------------------------------------
     # Checkpointing (optimizer + scaler state)
@@ -107,6 +106,7 @@ class GRPOOptimizationStepper(OptimizationStepper):
         sd: dict[str, Any] = {
             "optimizer": self.optimizer.state_dict(),
             "micro_step": self._micro_step,
+            "optimizer_step_count": self._optimizer_step_count,
         }
         if self._use_scaler:
             sd["scaler"] = self.scaler.state_dict()
@@ -115,6 +115,7 @@ class GRPOOptimizationStepper(OptimizationStepper):
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         self.optimizer.load_state_dict(state_dict["optimizer"])
         self._micro_step = state_dict.get("micro_step", 0)
+        self._optimizer_step_count = state_dict.get("optimizer_step_count", 0)
         if self._use_scaler and "scaler" in state_dict:
             self.scaler.load_state_dict(state_dict["scaler"])
 
@@ -178,6 +179,7 @@ class GRPOOptimizationStepper(OptimizationStepper):
             else:
                 self.optimizer.step()
 
+            self._optimizer_step_count += 1
             self.optimizer.zero_grad(set_to_none=True)
             losses_td["grad_norm"] = torch.tensor(grad_norm)
 
@@ -209,17 +211,38 @@ class WeightSyncHook(TrainerHookBase):
         sender: Any,
         weight_update_frequency: int = 1,
         empty_replay_buffer: bool = False,
-    ) -> None:
+    ):
+        if weight_update_frequency < 1:
+            raise ValueError("weight_update_frequency must be >= 1")
         self.sender = sender
         self.weight_update_frequency = weight_update_frequency
         self.empty_replay_buffer = empty_replay_buffer
+        self._last_update = 0
 
-    def __call__(self, batch: TensorDictBase) -> None:
+    def __call__(self) -> None:
         trainer = self._trainer
-        if (trainer._optim_count % self.weight_update_frequency) == 0:
-            self.sender.update_weights()
-            if self.empty_replay_buffer and trainer.replay_buffer is not None:
-                trainer.replay_buffer.empty(empty_write_count=False)
+        optim_count = getattr(
+            trainer.optimization_stepper,
+            "_optimizer_step_count",
+            trainer._optim_count,
+        )
+        if optim_count - self._last_update < self.weight_update_frequency:
+            return
+        self.sender.update_weights()
+        self._last_update = optim_count
+        if self.empty_replay_buffer and trainer.replay_buffer is not None:
+            trainer.replay_buffer.empty(empty_write_count=False)
+
+    def state_dict(self) -> dict[str, Any]:
+        return {"last_update": self._last_update}
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        self._last_update = state_dict.get("last_update", 0)
+
+    def register(self, trainer: Trainer, name: str = "weight_sync") -> None:
+        self._trainer = trainer
+        trainer.register_module(name, self)
+        trainer.register_op("post_steps", self)
 
 
 class GRPOTrainer(Trainer):
@@ -459,7 +482,7 @@ class GRPOTrainer(Trainer):
                 weight_update_frequency=weight_update_frequency,
                 empty_replay_buffer=empty_replay_buffer_on_weight_update,
             )
-            self.register_op("post_steps", ws_hook)
+            ws_hook.register(self)
 
         # --- Logging hooks ---
         if log_rewards:
@@ -486,12 +509,18 @@ class GRPOTrainer(Trainer):
 
     def _setup_kl_logging(self) -> None:
         """Register hooks to log KL divergence keys emitted by GRPOLoss."""
+        self.register_op("post_optim_complete_log", self._log_kl_metrics)
+
+    def _log_kl_metrics(
+        self, optim_steps: int, average_losses: TensorDictBase | None
+    ) -> dict[str, float]:
+        """Read KL metrics from the averaged optimization output."""
+        del optim_steps
+        if average_losses is None:
+            return {}
+        metrics = {}
         for kl_key in ("kl_to_ref", "kl_to_inference"):
-            hook = LogScalar(
-                key=kl_key,
-                logname=kl_key,
-                log_pbar=False,
-                include_std=False,
-                reduction="mean",
-            )
-            self.register_op("post_optim_complete_log", hook)
+            value = average_losses.get(kl_key, None)
+            if value is not None:
+                metrics[kl_key] = value.float().mean().item()
+        return metrics

--- a/torchrl/trainers/algorithms/grpo.py
+++ b/torchrl/trainers/algorithms/grpo.py
@@ -1,0 +1,497 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""GRPO (Group Relative Policy Optimization) Trainer for LLM alignment.
+
+This module provides a :class:`GRPOTrainer` and :class:`GRPOOptimizationStepper`
+that integrate the GRPO / LLM alignment training loop into the standard
+TorchRL :class:`~torchrl.trainers.Trainer` framework.
+
+The key differences from a standard RL trainer are:
+
+- Mixed-precision training via ``torch.amp.autocast`` and ``torch.amp.GradScaler``.
+- Gradient accumulation across multiple micro-batches.
+- A *weight-sync sender* hook that pushes updated weights back to the
+  inference engine (vLLM / SGLang) after a configurable number of optimizer
+  steps.
+- LLM-specific logging (KL divergence, ESS, per-token loss, etc.).
+- Native support for the ``RayReplayBuffer`` and ``RayLLMCollector``
+  used in the SOTA GRPO scripts.
+"""
+
+from __future__ import annotations
+
+import gc
+import pathlib
+import warnings
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import torch
+
+from tensordict import TensorDictBase
+from torch import nn, optim
+from torch.amp import GradScaler
+
+from torchrl.checkpoint import Checkpoint, CheckpointRotation
+from torchrl.collectors import BaseCollector
+from torchrl.data.replay_buffers.replay_buffers import ReplayBuffer
+from torchrl.objectives.common import LossModule
+from torchrl.record.loggers import Logger
+from torchrl.trainers.trainers import (
+    LogScalar,
+    OptimizationStepper,
+    ReplayBufferTrainer,
+    Trainer,
+    TrainerHookBase,
+)
+
+
+class GRPOOptimizationStepper(OptimizationStepper):
+    """Mixed-precision optimization step for GRPO / LLM alignment training.
+
+    This stepper wraps each forward/backward pass in ``torch.amp.autocast``
+    and optionally scales gradients with ``torch.amp.GradScaler`` (for fp16).
+    It also implements *gradient accumulation*: gradients are accumulated for
+    ``gradient_accumulation_steps`` micro-batches before the optimizer is
+    stepped and zeroed.
+
+    Args:
+        optimizer (optim.Optimizer): The optimizer to use.
+        mixed_precision (bool, optional): Whether to enable mixed-precision
+            training. Default: ``False``.
+        autocast_dtype (torch.dtype, optional): The dtype to use inside
+            ``autocast``. Default: ``torch.bfloat16``.
+        gradient_accumulation_steps (int, optional): Number of micro-batches
+            over which gradients are accumulated before a step. Default: ``1``.
+        clip_norm (float, optional): Maximum gradient norm for clipping.
+            Default: ``1.0``.
+
+    .. note::
+        ``GradScaler`` is only enabled when ``mixed_precision=True`` *and*
+        ``autocast_dtype=torch.float16``.  With bfloat16 (the recommended
+        dtype for modern GPUs) the scaler is a no-op and is not created.
+    """
+
+    def __init__(
+        self,
+        optimizer: optim.Optimizer,
+        *,
+        mixed_precision: bool = False,
+        autocast_dtype: torch.dtype = torch.bfloat16,
+        gradient_accumulation_steps: int = 1,
+        clip_norm: float | None = 1.0,
+    ) -> None:
+        if gradient_accumulation_steps < 1:
+            raise ValueError("gradient_accumulation_steps must be >= 1")
+        self.optimizer = optimizer
+        self.mixed_precision = mixed_precision
+        self.autocast_dtype = autocast_dtype
+        self.gradient_accumulation_steps = gradient_accumulation_steps
+        self.clip_norm = clip_norm
+
+        # GradScaler is only useful for fp16; bf16 doesn't need it.
+        self._use_scaler = mixed_precision and (autocast_dtype == torch.float16)
+        self.scaler = GradScaler("cuda", enabled=self._use_scaler)
+
+        # Internal micro-batch counter (reset after every optimizer step).
+        self._micro_step: int = 0
+
+    # ------------------------------------------------------------------
+    # Checkpointing (optimizer + scaler state)
+    # ------------------------------------------------------------------
+
+    def state_dict(self) -> dict[str, Any]:
+        sd: dict[str, Any] = {
+            "optimizer": self.optimizer.state_dict(),
+            "micro_step": self._micro_step,
+        }
+        if self._use_scaler:
+            sd["scaler"] = self.scaler.state_dict()
+        return sd
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        self.optimizer.load_state_dict(state_dict["optimizer"])
+        self._micro_step = state_dict.get("micro_step", 0)
+        if self._use_scaler and "scaler" in state_dict:
+            self.scaler.load_state_dict(state_dict["scaler"])
+
+    # ------------------------------------------------------------------
+    # Core step
+    # ------------------------------------------------------------------
+
+    def step(self, trainer: Trainer, sub_batch: TensorDictBase) -> TensorDictBase:
+        """Perform one GRPO forward pass and scaled backward pass.
+
+        The optimizer is only stepped and zeroed every
+        ``gradient_accumulation_steps`` calls.
+
+        Args:
+            trainer (Trainer): The owning :class:`~torchrl.trainers.Trainer`.
+            sub_batch (TensorDictBase): Mini-batch used for this step.
+
+        Returns:
+            A :class:`~tensordict.TensorDict` with scalar metrics (losses,
+            grad_norm) suitable for logging.
+        """
+        # ---- forward pass (optionally under autocast) ----
+        with torch.amp.autocast(
+            "cuda",
+            enabled=self.mixed_precision,
+            dtype=self.autocast_dtype,
+        ):
+            losses_td = trainer.compute_loss(sub_batch)
+            # Sum all loss_* keys and normalise by accumulation steps.
+            loss_items = [v for k, v in losses_td.items() if k.startswith("loss")]
+            if not loss_items:
+                raise RuntimeError(
+                    "GRPOLoss returned no 'loss_*' keys. "
+                    "Make sure your loss module prefixes scalar outputs with 'loss'."
+                )
+            loss = sum(loss_items) / self.gradient_accumulation_steps
+
+        # ---- backward pass ----
+        if self._use_scaler:
+            self.scaler.scale(loss).backward()
+        else:
+            loss.backward()
+
+        self._micro_step += 1
+
+        # ---- optimizer step every `gradient_accumulation_steps` micro-batches ----
+        if self._micro_step % self.gradient_accumulation_steps == 0:
+            if self._use_scaler:
+                self.scaler.unscale_(self.optimizer)
+
+            grad_norm = 0.0
+            if self.clip_norm is not None:
+                params = [
+                    p for group in self.optimizer.param_groups for p in group["params"]
+                ]
+                grad_norm = float(nn.utils.clip_grad_norm_(params, self.clip_norm))
+
+            if self._use_scaler:
+                self.scaler.step(self.optimizer)
+                self.scaler.update()
+            else:
+                self.optimizer.step()
+
+            self.optimizer.zero_grad(set_to_none=True)
+            losses_td["grad_norm"] = torch.tensor(grad_norm)
+
+            # Free memory after the step.
+            gc.collect()
+
+        return losses_td.detach()
+
+
+class WeightSyncHook(TrainerHookBase):
+    """Post-optimization hook that pushes updated weights to the inference engine.
+
+    This hook calls ``sender.update_weights()`` every
+    ``weight_update_frequency`` optimizer steps, then optionally empties the
+    replay buffer (for on-policy / synchronous GRPO).
+
+    Args:
+        sender: A weight-sync sender object that has an ``update_weights()``
+            method (e.g. the sender returned by
+            ``WeightSyncScheme.create_sender()``).
+        weight_update_frequency (int, optional): How many optimizer steps
+            between weight pushes.  Default: ``1`` (push after every step).
+        empty_replay_buffer (bool, optional): Whether to empty the replay
+            buffer after pushing weights (sync GRPO).  Default: ``False``.
+    """
+
+    def __init__(
+        self,
+        sender: Any,
+        weight_update_frequency: int = 1,
+        empty_replay_buffer: bool = False,
+    ) -> None:
+        self.sender = sender
+        self.weight_update_frequency = weight_update_frequency
+        self.empty_replay_buffer = empty_replay_buffer
+
+    def __call__(self, batch: TensorDictBase) -> None:
+        trainer = self._trainer
+        if (trainer._optim_count % self.weight_update_frequency) == 0:
+            self.sender.update_weights()
+            if self.empty_replay_buffer and trainer.replay_buffer is not None:
+                trainer.replay_buffer.empty(empty_write_count=False)
+
+
+class GRPOTrainer(Trainer):
+    """A trainer for LLM alignment using GRPO (or compatible) objectives.
+
+    .. warning::
+        This is an experimental/prototype feature. The API may change in future
+        versions. Please report any issues or feedback to help improve this
+        implementation.
+
+    This trainer integrates the full GRPO training loop —
+    mixed-precision, gradient accumulation, inference-weight synchronization,
+    and LLM-specific logging — into the standard
+    :class:`~torchrl.trainers.Trainer` hook system.
+
+    It is designed to work with:
+
+    - :class:`~torchrl.objectives.llm.GRPOLoss` (or any ``LossModule`` whose
+      outputs start with ``"loss_"``)
+    - :class:`~torchrl.collectors.llm.RayLLMCollector`
+    - :class:`~torchrl.data.replay_buffers.RayReplayBuffer` (or any
+      :class:`~torchrl.data.ReplayBuffer`)
+
+    The weight-sync sender is intentionally decoupled from the trainer so that
+    neither ``vllm`` nor ``sglang`` need to be imported by the core library.
+
+    Examples:
+        >>> from torchrl.trainers.algorithms.grpo import GRPOTrainer
+        >>> import torch
+        >>> from unittest.mock import MagicMock
+        >>> collector = MagicMock()
+        >>> loss_module = MagicMock()
+        >>> optimizer = torch.optim.Adam(torch.nn.Linear(2, 2).parameters())
+        >>> trainer = GRPOTrainer(
+        ...     collector=collector,
+        ...     total_frames=100,
+        ...     frame_skip=1,
+        ...     optim_steps_per_batch=2,
+        ...     loss_module=loss_module,
+        ...     optimizer=optimizer,
+        ...     log_rewards=False,
+        ...     log_kl=False,
+        ... )
+        >>> # trainer.train()
+
+    Args:
+        collector (BaseCollector): The data collector (typically a
+            :class:`~torchrl.collectors.llm.RayLLMCollector`).
+        total_frames (int): Total number of frames / dialog turns.
+        frame_skip (int): Frame skip value (set to 1 for LLM tasks).
+        optim_steps_per_batch (int): Number of micro-batches drawn from the
+            replay buffer per collected batch.
+        loss_module (LossModule): The GRPO loss module.
+        optimizer (optim.Optimizer, optional): Optimizer. Required when
+            ``optimization_stepper`` is not provided.
+        optimization_stepper (GRPOOptimizationStepper, optional): Custom
+            stepper. If omitted, a :class:`GRPOOptimizationStepper` is
+            constructed automatically from ``optimizer`` and the
+            mixed-precision arguments below.
+        weight_sync_sender (optional): Object with an ``update_weights()``
+            method used to push training weights to the inference engine.
+            Pass ``None`` to disable weight synchronization (useful for
+            offline testing).
+        weight_update_frequency (int, optional): Optimizer steps between
+            weight pushes to the inference engine. Default: ``1``.
+        empty_replay_buffer_on_weight_update (bool, optional): If ``True``,
+            the replay buffer is emptied after each weight push (sync GRPO).
+            Default: ``False``.
+        replay_buffer (ReplayBuffer, optional): The replay buffer used for
+            sampling.
+        batch_size (int, optional): Override the replay buffer's batch size.
+        mixed_precision (bool, optional): Enable autocast + GradScaler.
+            Default: ``False``.
+        autocast_dtype (torch.dtype, optional): dtype for ``autocast``.
+            Default: ``torch.bfloat16``.
+        gradient_accumulation_steps (int, optional): Gradient accumulation.
+            Default: ``1``.
+        logger (Logger, optional): Logger (e.g. ``WandbLogger``).
+        clip_grad_norm (bool, optional): Unused — clipping is handled by the
+            stepper. Kept for API compatibility.
+        clip_norm (float, optional): Gradient clip norm. Default: ``1.0``.
+        progress_bar (bool, optional): Show a ``tqdm`` progress bar.
+        seed (int, optional): Random seed.
+        save_trainer_interval (int, optional): Frame interval between saves.
+        log_interval (int, optional): Frame interval between logs.
+        save_trainer_file (str | Path, optional): Path for legacy saves.
+        checkpoint (Checkpoint, optional): Unified checkpoint object.
+        checkpoint_rotation (CheckpointRotation, optional): Rotation policy.
+        checkpoint_metadata (Callable, optional): Extra metadata callback.
+        num_epochs (int, optional): Epochs per collected batch. Default: ``1``.
+        async_collection (bool, optional): Whether data is collected
+            asynchronously (``grpo-async`` mode). Default: ``False``.
+        log_timings (bool, optional): Log timing of each hook. Default: ``False``.
+        auto_log_optim_steps (bool, optional): Log ``optim_steps`` after each
+            optimization loop. Default: ``True``.
+        log_rewards (bool, optional): Log reward / return statistics.
+            Default: ``True``.
+        log_kl (bool, optional): Log KL-divergence keys from the loss output.
+            Default: ``True``.
+
+    Examples:
+        >>> from torchrl.trainers.algorithms.grpo import GRPOTrainer
+        >>> # Assuming you have a collector, loss_fn, optimizer, replay_buffer,
+        >>> # and weight_sync_sender already constructed (see SOTA scripts):
+        >>> trainer = GRPOTrainer(
+        ...     collector=collector,
+        ...     total_frames=cfg.train.total_dialog_turns,
+        ...     frame_skip=1,
+        ...     optim_steps_per_batch=cfg.train.epochs,
+        ...     loss_module=loss_fn,
+        ...     optimizer=optimizer,
+        ...     weight_sync_sender=sender,
+        ...     weight_update_frequency=1,
+        ...     empty_replay_buffer_on_weight_update=cfg.train.empty_replay_buffer,
+        ...     replay_buffer=replay_buffer,
+        ...     mixed_precision=cfg.train.mixed_precision,
+        ...     gradient_accumulation_steps=cfg.train.gradient_accumulation_steps,
+        ...     clip_norm=cfg.optimizer.clip_grad_norm,
+        ...     logger=wandb_logger,
+        ... )
+        >>> trainer.train()
+    """
+
+    def __init__(
+        self,
+        *,
+        collector: BaseCollector,
+        total_frames: int,
+        frame_skip: int = 1,
+        optim_steps_per_batch: int,
+        loss_module: LossModule | Callable[[TensorDictBase], TensorDictBase],
+        optimizer: optim.Optimizer | None = None,
+        optimization_stepper: GRPOOptimizationStepper | None = None,
+        # LLM-specific
+        weight_sync_sender: Any | None = None,
+        weight_update_frequency: int = 1,
+        empty_replay_buffer_on_weight_update: bool = False,
+        # Replay buffer
+        replay_buffer: ReplayBuffer | None = None,
+        batch_size: int | None = None,
+        # Mixed precision / gradient accumulation
+        mixed_precision: bool = False,
+        autocast_dtype: torch.dtype = torch.bfloat16,
+        gradient_accumulation_steps: int = 1,
+        # Standard trainer args
+        logger: Logger | None = None,
+        clip_grad_norm: bool = True,
+        clip_norm: float | None = 1.0,
+        progress_bar: bool = True,
+        seed: int | None = None,
+        save_trainer_interval: int = 10000,
+        log_interval: int = 10000,
+        save_trainer_file: str | pathlib.Path | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_rotation: CheckpointRotation | None = None,
+        checkpoint_metadata: Callable[[Trainer], Mapping[str, Any]] | None = None,
+        num_epochs: int = 1,
+        async_collection: bool = False,
+        log_timings: bool = False,
+        auto_log_optim_steps: bool = True,
+        # Logging toggles
+        log_rewards: bool = True,
+        log_kl: bool = True,
+    ) -> None:
+        warnings.warn(
+            "GRPOTrainer is an experimental/prototype feature. The API may "
+            "change in future versions. Please report any issues or feedback "
+            "to help improve this implementation.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+        # --- Build a stepper if one wasn't provided ---
+        if optimization_stepper is None:
+            if optimizer is None:
+                raise ValueError(
+                    "GRPOTrainer requires either an `optimizer` or a custom "
+                    "`optimization_stepper`."
+                )
+            optimization_stepper = GRPOOptimizationStepper(
+                optimizer=optimizer,
+                mixed_precision=mixed_precision,
+                autocast_dtype=autocast_dtype,
+                gradient_accumulation_steps=gradient_accumulation_steps,
+                clip_norm=clip_norm,
+            )
+
+        super().__init__(
+            collector=collector,
+            total_frames=total_frames,
+            frame_skip=frame_skip,
+            optim_steps_per_batch=optim_steps_per_batch,
+            loss_module=loss_module,
+            optimizer=optimizer,
+            optimization_stepper=optimization_stepper,
+            replay_buffer=replay_buffer,
+            batch_size=batch_size,
+            logger=logger,
+            clip_grad_norm=clip_grad_norm,
+            clip_norm=clip_norm,
+            progress_bar=progress_bar,
+            seed=seed,
+            save_trainer_interval=save_trainer_interval,
+            log_interval=log_interval,
+            save_trainer_file=save_trainer_file,
+            checkpoint=checkpoint,
+            checkpoint_rotation=checkpoint_rotation,
+            checkpoint_metadata=checkpoint_metadata,
+            num_epochs=num_epochs,
+            async_collection=async_collection,
+            log_timings=log_timings,
+            auto_log_optim_steps=auto_log_optim_steps,
+        )
+
+        self.replay_buffer = replay_buffer
+        self.async_collection = async_collection
+
+        # --- Wire replay buffer hooks ---
+        if replay_buffer is not None:
+            rb_trainer = ReplayBufferTrainer(
+                replay_buffer,
+                batch_size=None,
+                flatten_tensordicts=False,
+                memmap=False,
+                device=getattr(replay_buffer.storage, "device", "cpu"),
+                iterate=True,
+            )
+            if not async_collection:
+                # In sync mode: push collected data into the buffer before each epoch.
+                self.register_op("pre_epoch", rb_trainer.extend)
+            self.register_op("process_optim_batch", rb_trainer.sample)
+
+        # --- Wire weight-sync sender hook ---
+        if weight_sync_sender is not None:
+            ws_hook = WeightSyncHook(
+                sender=weight_sync_sender,
+                weight_update_frequency=weight_update_frequency,
+                empty_replay_buffer=empty_replay_buffer_on_weight_update,
+            )
+            self.register_op("post_steps", ws_hook)
+
+        # --- Logging hooks ---
+        if log_rewards:
+            self._setup_reward_logging()
+        if log_kl:
+            self._setup_kl_logging()
+
+    # ------------------------------------------------------------------
+    # Logging helpers
+    # ------------------------------------------------------------------
+
+    def _setup_reward_logging(self) -> None:
+        """Register hooks to log GRPO reward / return statistics."""
+        for reduction in ("mean", "max"):
+            hook = LogScalar(
+                key=("next", "reward"),
+                logname=f"reward_{reduction}",
+                log_pbar=(reduction == "mean"),
+                include_std=(reduction == "mean"),
+                reduction=reduction,
+            )
+            stage = "post_optim_log" if self.async_collection else "pre_steps_log"
+            self.register_op(stage, hook)
+
+    def _setup_kl_logging(self) -> None:
+        """Register hooks to log KL divergence keys emitted by GRPOLoss."""
+        for kl_key in ("kl_to_ref", "kl_to_inference"):
+            hook = LogScalar(
+                key=kl_key,
+                logname=kl_key,
+                log_pbar=False,
+                include_std=False,
+                reduction="mean",
+            )
+            self.register_op("post_optim_complete_log", hook)

--- a/torchrl/trainers/algorithms/grpo.py
+++ b/torchrl/trainers/algorithms/grpo.py
@@ -53,6 +53,9 @@ from torchrl.trainers.trainers import (
 class GRPOTrainer(Trainer):
     """A trainer for LLM alignment using GRPO (or compatible) objectives.
 
+    See also :class:`~torchrl.trainers.algorithms.configs.GRPOTrainerConfig`
+    for the Hydra configuration counterpart.
+
     .. warning::
         This is an experimental/prototype feature. The API may change in future
         versions. Please report any issues or feedback to help improve this
@@ -61,7 +64,10 @@ class GRPOTrainer(Trainer):
     This trainer integrates the full GRPO training loop —
     mixed-precision, gradient accumulation, inference-weight synchronization,
     and LLM-specific logging — into the standard
-    :class:`~torchrl.trainers.Trainer` hook system.
+    :class:`~torchrl.trainers.Trainer` hook system. Scalar diagnostics emitted
+    by the loss (e.g. ``ESS``, ``clip_fraction``, ``kl_approx`` for
+    :class:`~torchrl.objectives.llm.GRPOLoss`) are logged automatically after
+    each optimization loop.
 
     It is designed to work with:
 
@@ -73,25 +79,6 @@ class GRPOTrainer(Trainer):
 
     The weight-sync sender is intentionally decoupled from the trainer so that
     neither ``vllm`` nor ``sglang`` need to be imported by the core library.
-
-    Examples:
-        >>> from torchrl.trainers.algorithms.grpo import GRPOTrainer
-        >>> import torch
-        >>> from unittest.mock import MagicMock
-        >>> collector = MagicMock()
-        >>> loss_module = MagicMock()
-        >>> optimizer = torch.optim.Adam(torch.nn.Linear(2, 2).parameters())
-        >>> trainer = GRPOTrainer(
-        ...     collector=collector,
-        ...     total_frames=100,
-        ...     frame_skip=1,
-        ...     optim_steps_per_batch=2,
-        ...     loss_module=loss_module,
-        ...     optimizer=optimizer,
-        ...     log_rewards=False,
-        ...     log_kl=False,
-        ... )
-        >>> # trainer.train()
 
     Args:
         collector (BaseCollector): The data collector (typically a
@@ -135,9 +122,8 @@ class GRPOTrainer(Trainer):
         gradient_accumulation_steps (int, optional): Gradient accumulation.
             Default: ``1``.
         logger (Logger, optional): Logger (e.g. ``WandbLogger``).
-        clip_grad_norm (bool, optional): Unused — clipping is handled by the
-            stepper. Kept for API compatibility.
-        clip_norm (float, optional): Gradient clip norm. Default: ``1.0``.
+        clip_norm (float, optional): Gradient clip norm, applied by the
+            stepper. Default: ``1.0``.
         progress_bar (bool, optional): Show a ``tqdm`` progress bar.
         seed (int, optional): Random seed.
         save_trainer_interval (int, optional): Frame interval between saves.
@@ -204,7 +190,6 @@ class GRPOTrainer(Trainer):
         gradient_accumulation_steps: int = 1,
         # Standard trainer args
         logger: Logger | None = None,
-        clip_grad_norm: bool = True,
         clip_norm: float | None = 1.0,
         progress_bar: bool = True,
         seed: int | None = None,
@@ -256,8 +241,6 @@ class GRPOTrainer(Trainer):
             replay_buffer=replay_buffer,
             batch_size=batch_size,
             logger=logger,
-            clip_grad_norm=clip_grad_norm,
-            clip_norm=clip_norm,
             progress_bar=progress_bar,
             seed=seed,
             save_trainer_interval=save_trainer_interval,

--- a/torchrl/trainers/algorithms/grpo.py
+++ b/torchrl/trainers/algorithms/grpo.py
@@ -36,6 +36,7 @@ from torch.amp import GradScaler
 from torchrl.checkpoint import Checkpoint, CheckpointRotation
 from torchrl.collectors import BaseCollector
 from torchrl.data.replay_buffers.replay_buffers import ReplayBuffer
+from torchrl.data.utils import DEVICE_TYPING
 from torchrl.objectives.common import LossModule
 from torchrl.record.loggers import Logger
 from torchrl.trainers.trainers import (
@@ -303,8 +304,9 @@ class GRPOTrainer(Trainer):
             :class:`~torchrl.collectors.llm.RayLLMCollector`).
         total_frames (int): Total number of frames / dialog turns.
         frame_skip (int): Frame skip value (set to 1 for LLM tasks).
-        optim_steps_per_batch (int): Number of micro-batches drawn from the
-            replay buffer per collected batch.
+        optim_steps_per_batch (int, optional): Number of micro-batches drawn
+            from the replay buffer per collected batch and epoch. ``None``
+            (default) iterates over the whole replay buffer once per epoch.
         loss_module (LossModule): The GRPO loss module.
         optimizer (optim.Optimizer, optional): Optimizer. Required when
             ``optimization_stepper`` is not provided.
@@ -324,6 +326,9 @@ class GRPOTrainer(Trainer):
         replay_buffer (ReplayBuffer, optional): The replay buffer used for
             sampling.
         batch_size (int, optional): Override the replay buffer's batch size.
+        device (torch.device, optional): Device on which sampled batches are
+            placed before the loss forward pass (typically the training
+            device). ``None`` leaves samples on their storage device.
         mixed_precision (bool, optional): Enable autocast + GradScaler.
             Default: ``False``.
         autocast_dtype (torch.dtype, optional): dtype for ``autocast``.
@@ -382,7 +387,7 @@ class GRPOTrainer(Trainer):
         collector: BaseCollector,
         total_frames: int,
         frame_skip: int = 1,
-        optim_steps_per_batch: int,
+        optim_steps_per_batch: int | None = None,
         loss_module: LossModule | Callable[[TensorDictBase], TensorDictBase],
         optimizer: optim.Optimizer | None = None,
         optimization_stepper: GRPOOptimizationStepper | None = None,
@@ -393,6 +398,7 @@ class GRPOTrainer(Trainer):
         # Replay buffer
         replay_buffer: ReplayBuffer | None = None,
         batch_size: int | None = None,
+        device: DEVICE_TYPING | None = None,
         # Mixed precision / gradient accumulation
         mixed_precision: bool = False,
         autocast_dtype: torch.dtype = torch.bfloat16,
@@ -471,16 +477,22 @@ class GRPOTrainer(Trainer):
         self.async_collection = async_collection
 
         # --- Wire replay buffer hooks ---
+        # LLM collectors created with a replay_buffer write to it directly and
+        # yield None; in that case the trainer must not extend the buffer again.
+        collector_extends_buffer = getattr(collector, "replay_buffer", None) is not None
         if replay_buffer is not None:
             rb_trainer = ReplayBufferTrainer(
                 replay_buffer,
                 batch_size=None,
                 flatten_tensordicts=False,
                 memmap=False,
-                device=getattr(replay_buffer.storage, "device", "cpu"),
-                iterate=True,
+                device=device,
+                # Sync mode iterates over the buffer once per epoch (matching
+                # the reference GRPO loop); async mode draws random samples of
+                # the buffer's own batch size.
+                iterate=not async_collection,
             )
-            if not async_collection:
+            if not async_collection and not collector_extends_buffer:
                 # In sync mode: push collected data into the buffer before each epoch.
                 self.register_op("pre_epoch", rb_trainer.extend)
             self.register_op("process_optim_batch", rb_trainer.sample)
@@ -514,7 +526,15 @@ class GRPOTrainer(Trainer):
                 include_std=(reduction == "mean"),
                 reduction=reduction,
             )
-            stage = "post_optim_log" if self.async_collection else "pre_steps_log"
+            # The collected batch is only available at pre_steps_log when the
+            # collector yields real batches. With async collection or a
+            # buffer-writing collector the batch is None there, so rewards are
+            # logged from the optimization sub-batches instead.
+            stage = (
+                "post_optim_log"
+                if (self.async_collection or self.replay_buffer is not None)
+                else "pre_steps_log"
+            )
             self.register_op(stage, hook)
 
     def _setup_kl_logging(self) -> None:

--- a/torchrl/trainers/algorithms/grpo.py
+++ b/torchrl/trainers/algorithms/grpo.py
@@ -13,9 +13,10 @@ The key differences from a standard RL trainer are:
 
 - Mixed-precision training via ``torch.amp.autocast`` and ``torch.amp.GradScaler``.
 - Gradient accumulation across multiple micro-batches.
-- A *weight-sync sender* hook that pushes updated weights back to the
-  inference engine (vLLM / SGLang) after a configurable number of optimizer
-  steps.
+- A *weight-sync sender* (wired through
+  :class:`~torchrl.trainers.UpdateWeights`) that pushes updated weights back
+  to the inference engine (vLLM / SGLang) after a configurable number of
+  optimizer steps.
 - LLM-specific logging (KL divergence, ESS, per-token loss, etc.).
 - Native support for the ``RayReplayBuffer`` and ``RayLLMCollector``
   used in the SOTA GRPO scripts.
@@ -44,7 +45,7 @@ from torchrl.trainers.trainers import (
     OptimizationStepper,
     ReplayBufferTrainer,
     Trainer,
-    TrainerHookBase,
+    UpdateWeights,
 )
 
 
@@ -98,6 +99,17 @@ class GRPOOptimizationStepper(OptimizationStepper):
         # Internal micro-batch counter (reset after every optimizer step).
         self._micro_step: int = 0
         self._optimizer_step_count: int = 0
+
+    @property
+    def optimizer_step_count(self) -> int:
+        """Number of completed optimizer steps.
+
+        Discounts gradient-accumulation micro-steps and steps skipped by the
+        GradScaler on overflow. Read by hooks that act on an optimizer-step
+        cadence (e.g. :class:`~torchrl.trainers.UpdateWeights` with
+        ``interval_unit="optim_steps"``).
+        """
+        return self._optimizer_step_count
 
     # ------------------------------------------------------------------
     # Checkpointing (optimizer + scaler state)
@@ -200,62 +212,6 @@ class GRPOOptimizationStepper(OptimizationStepper):
         return losses_td.detach()
 
 
-class WeightSyncHook(TrainerHookBase):
-    """Post-optimization hook that pushes updated weights to the inference engine.
-
-    This hook calls ``sender.update_weights()`` every
-    ``weight_update_frequency`` optimizer steps, then optionally empties the
-    replay buffer (for on-policy / synchronous GRPO).
-
-    Args:
-        sender: A weight-sync sender object that has an ``update_weights()``
-            method (e.g. the sender returned by
-            ``WeightSyncScheme.create_sender()``).
-        weight_update_frequency (int, optional): How many optimizer steps
-            between weight pushes.  Default: ``1`` (push after every step).
-        empty_replay_buffer (bool, optional): Whether to empty the replay
-            buffer after pushing weights (sync GRPO).  Default: ``False``.
-    """
-
-    def __init__(
-        self,
-        sender: Any,
-        weight_update_frequency: int = 1,
-        empty_replay_buffer: bool = False,
-    ):
-        if weight_update_frequency < 1:
-            raise ValueError("weight_update_frequency must be >= 1")
-        self.sender = sender
-        self.weight_update_frequency = weight_update_frequency
-        self.empty_replay_buffer = empty_replay_buffer
-        self._last_update = 0
-
-    def __call__(self) -> None:
-        trainer = self._trainer
-        optim_count = getattr(
-            trainer.optimization_stepper,
-            "_optimizer_step_count",
-            trainer._optim_count,
-        )
-        if optim_count - self._last_update < self.weight_update_frequency:
-            return
-        self.sender.update_weights()
-        self._last_update = optim_count
-        if self.empty_replay_buffer and trainer.replay_buffer is not None:
-            trainer.replay_buffer.empty(empty_write_count=False)
-
-    def state_dict(self) -> dict[str, Any]:
-        return {"last_update": self._last_update}
-
-    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        self._last_update = state_dict.get("last_update", 0)
-
-    def register(self, trainer: Trainer, name: str = "weight_sync") -> None:
-        self._trainer = trainer
-        trainer.register_module(name, self)
-        trainer.register_op("post_steps", self)
-
-
 class GRPOTrainer(Trainer):
     """A trainer for LLM alignment using GRPO (or compatible) objectives.
 
@@ -319,7 +275,11 @@ class GRPOTrainer(Trainer):
             Pass ``None`` to disable weight synchronization (useful for
             offline testing).
         weight_update_frequency (int, optional): Optimizer steps between
-            weight pushes to the inference engine. Default: ``1``.
+            weight pushes to the inference engine when ``async_collection=True``
+            (registered at the ``post_optim`` stage through
+            :class:`~torchrl.trainers.UpdateWeights`). In sync mode weights
+            are pushed once per collected batch and this value is unused.
+            Default: ``1``.
         empty_replay_buffer_on_weight_update (bool, optional): If ``True``,
             the replay buffer is emptied after each weight push (sync GRPO).
             Default: ``False``.
@@ -499,18 +459,38 @@ class GRPOTrainer(Trainer):
 
         # --- Wire weight-sync sender hook ---
         if weight_sync_sender is not None:
-            ws_hook = WeightSyncHook(
-                sender=weight_sync_sender,
-                weight_update_frequency=weight_update_frequency,
-                empty_replay_buffer=empty_replay_buffer_on_weight_update,
-            )
-            ws_hook.register(self)
+            if async_collection:
+                # Push weights every `weight_update_frequency` optimizer steps,
+                # in the middle of the optimization loop if needed. This keeps
+                # the inference engine close to the training policy, which is
+                # essential for meaningful importance sampling in GRPO.
+                update_weights = UpdateWeights(
+                    update_weights_interval=weight_update_frequency,
+                    trainer=self,
+                    sender=weight_sync_sender,
+                    interval_unit="optim_steps",
+                )
+            else:
+                # Sync mode: push weights once per collected batch, after the
+                # optimization epochs have consumed it.
+                update_weights = UpdateWeights(
+                    trainer=self,
+                    sender=weight_sync_sender,
+                )
+            update_weights.register(self)
+        if empty_replay_buffer_on_weight_update and replay_buffer is not None:
+            # Sync GRPO: flush the on-policy buffer once its batch has been
+            # consumed and the inference weights have been refreshed.
+            self.register_op("post_steps", self._empty_replay_buffer)
 
         # --- Logging hooks ---
         if log_rewards:
             self._setup_reward_logging()
         if log_kl:
             self._setup_kl_logging()
+
+    def _empty_replay_buffer(self) -> None:
+        self.replay_buffer.empty(empty_write_count=False)
 
     # ------------------------------------------------------------------
     # Logging helpers

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -1417,7 +1417,7 @@ class Trainer:
         self._setup_hook()
 
         for batch in iterator:
-            if not self.async_collection:
+            if not self.async_collection and batch is not None:
                 batch = self._process_batch_hook(batch)
                 current_frames = (
                     batch.get(("collector", "mask"), torch.tensor(batch.numel()))
@@ -1427,10 +1427,16 @@ class Trainer:
                 )
                 self.collected_frames += current_frames
             else:
-                # In async mode, batch is None and we track frames via write_count
+                # Batch is None: either async collection, or a synchronous
+                # collector that writes directly to the replay buffer (e.g.
+                # LLM collectors created with a replay_buffer). Frames are
+                # tracked via the buffer write count in both cases.
                 batch = None
                 cf = self.collected_frames
-                self.collected_frames = self.collector.getattr_rb("write_count")
+                if self.replay_buffer is not None:
+                    self.collected_frames = self._replay_write_count()
+                else:
+                    self.collected_frames = self.collector.getattr_rb("write_count")
                 current_frames = self.collected_frames - cf
 
             # LOGGING POINT 1: Pre-optimization logging (e.g., rewards, frame counts)

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -384,14 +384,16 @@ class MixedPrecisionOptimizationStepper(OptimizationStepper):
         # Internal micro-batch counter (reset after every optimizer step).
         self._micro_step: int = 0
         self._optimizer_step_count: int = 0
+        self._skipped_nonfinite_steps: int = 0
 
     @property
     def optimizer_step_count(self) -> int:
         """Number of completed optimizer steps.
 
         Discounts gradient-accumulation micro-steps and steps skipped by the
-        GradScaler on overflow. Read by hooks that act on an optimizer-step
-        cadence (e.g. :class:`~torchrl.trainers.UpdateWeights` with
+        GradScaler on overflow or by the non-finite guards. Read by hooks that
+        act on an optimizer-step cadence (e.g.
+        :class:`~torchrl.trainers.UpdateWeights` with
         ``interval_unit="optim_steps"``).
         """
         return self._optimizer_step_count
@@ -412,6 +414,7 @@ class MixedPrecisionOptimizationStepper(OptimizationStepper):
             "optimizer": self.optimizer.state_dict(),
             "micro_step": self._micro_step,
             "optimizer_step_count": self._optimizer_step_count,
+            "skipped_nonfinite_steps": self._skipped_nonfinite_steps,
         }
         if self._use_scaler:
             sd["scaler"] = self.scaler.state_dict()
@@ -421,6 +424,7 @@ class MixedPrecisionOptimizationStepper(OptimizationStepper):
         self.optimizer.load_state_dict(state_dict["optimizer"])
         self._micro_step = state_dict.get("micro_step", 0)
         self._optimizer_step_count = state_dict.get("optimizer_step_count", 0)
+        self._skipped_nonfinite_steps = state_dict.get("skipped_nonfinite_steps", 0)
         if self._use_scaler and "scaler" in state_dict:
             self.scaler.load_state_dict(state_dict["scaler"])
 
@@ -458,6 +462,20 @@ class MixedPrecisionOptimizationStepper(OptimizationStepper):
                 )
             loss = sum(loss_items) / self.gradient_accumulation_steps
 
+        # ---- non-finite loss guard ----
+        # A single non-finite loss would poison the gradients accumulated so
+        # far, so the whole accumulation window is dropped and restarted.
+        if not torch.isfinite(loss.detach()).all():
+            self._skipped_nonfinite_steps += 1
+            torchrl_logger.warning(
+                f"Skipping optimization step because the loss is non-finite: "
+                f"{loss.detach()}. Skipped non-finite steps: "
+                f"{self._skipped_nonfinite_steps}."
+            )
+            self.optimizer.zero_grad(set_to_none=True)
+            self._micro_step = 0
+            return self._reduce_metrics(losses_td)
+
         # ---- backward pass ----
         if self._use_scaler:
             self.scaler.scale(loss).backward()
@@ -467,6 +485,7 @@ class MixedPrecisionOptimizationStepper(OptimizationStepper):
         self._micro_step += 1
 
         # ---- optimizer step every `gradient_accumulation_steps` micro-batches ----
+        grad_norm = None
         if self._micro_step % self.gradient_accumulation_steps == 0:
             if self._use_scaler:
                 self.scaler.unscale_(self.optimizer)
@@ -485,13 +504,38 @@ class MixedPrecisionOptimizationStepper(OptimizationStepper):
                 # If scale dropped, an overflow occurred and optimizer.step() was skipped.
                 if self.scaler.get_scale() >= scale_before:
                     self._optimizer_step_count += 1
+            elif self.clip_norm is not None and not math.isfinite(grad_norm):
+                # Without a GradScaler (e.g. bf16 or full precision) nothing
+                # skips overflowing updates, so guard the step explicitly.
+                self._skipped_nonfinite_steps += 1
+                torchrl_logger.warning(
+                    f"Skipping optimizer step because the gradient norm is "
+                    f"non-finite: {grad_norm}. Skipped non-finite steps: "
+                    f"{self._skipped_nonfinite_steps}."
+                )
+                grad_norm = 0.0
             else:
                 self.optimizer.step()
                 self._optimizer_step_count += 1
             self.optimizer.zero_grad(set_to_none=True)
-            losses_td["grad_norm"] = torch.tensor(grad_norm)
 
-        return losses_td.detach()
+        metrics = self._reduce_metrics(losses_td)
+        if grad_norm is not None:
+            metrics["grad_norm"] = torch.tensor(grad_norm)
+        return metrics
+
+    @staticmethod
+    def _reduce_metrics(losses_td: TensorDictBase) -> TensorDictBase:
+        """Detach the loss output and reduce non-scalar entries to their mean.
+
+        Steppers must return scalar metrics suitable for logging; loss modules
+        such as :class:`~torchrl.objectives.llm.GRPOLoss` also emit per-token
+        diagnostics (KL divergences) that are reduced here.
+        """
+        metrics = {}
+        for key, value in losses_td.detach().items():
+            metrics[key] = value.float().mean() if value.numel() > 1 else value
+        return TensorDict(metrics, [])
 
 
 class Trainer:

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -27,6 +27,7 @@ from tensordict._tensorcollection import TensorCollection
 from tensordict.nn import TensorDictModule
 from tensordict.utils import expand_right
 from torch import nn, optim
+from torch.amp import GradScaler
 from torchrl._utils import (
     _CKPT_BACKEND,
     implement_for,
@@ -315,6 +316,182 @@ class DefaultOptimizationStepper(OptimizationStepper):
         trainer.optimizer.zero_grad()
 
         return losses_td
+
+
+class MixedPrecisionOptimizationStepper(OptimizationStepper):
+    """Optimization step with mixed precision and gradient accumulation.
+
+    This stepper wraps each forward/backward pass in ``torch.amp.autocast``
+    and optionally scales gradients with ``torch.amp.GradScaler`` (for fp16).
+    It also implements *gradient accumulation*: gradients are accumulated for
+    ``gradient_accumulation_steps`` micro-batches before the optimizer is
+    stepped and zeroed.
+
+    It can be used with any :class:`~torchrl.trainers.Trainer`; LLM trainers
+    such as :class:`~torchrl.trainers.algorithms.GRPOTrainer` construct it by
+    default.
+
+    Args:
+        optimizer (optim.Optimizer): The optimizer to use.
+
+    Keyword Args:
+        mixed_precision (bool, optional): Whether to enable mixed-precision
+            training. Default: ``False``.
+        autocast_dtype (torch.dtype, optional): The dtype to use inside
+            ``autocast``. Default: ``torch.bfloat16``.
+        gradient_accumulation_steps (int, optional): Number of micro-batches
+            over which gradients are accumulated before a step. Default: ``1``.
+        clip_norm (float, optional): Maximum gradient norm for clipping.
+            Default: ``1.0``.
+        device_type (str, optional): Device type passed to ``autocast`` and
+            ``GradScaler`` (e.g. ``"cuda"`` or ``"cpu"``). Defaults to the
+            device type of the optimizer's first parameter.
+
+    .. note::
+        ``GradScaler`` is only enabled when ``mixed_precision=True`` *and*
+        ``autocast_dtype=torch.float16``.  With bfloat16 (the recommended
+        dtype for modern GPUs) the scaler is a no-op and is not created.
+    """
+
+    def __init__(
+        self,
+        optimizer: optim.Optimizer,
+        *,
+        mixed_precision: bool = False,
+        autocast_dtype: torch.dtype = torch.bfloat16,
+        gradient_accumulation_steps: int = 1,
+        clip_norm: float | None = 1.0,
+        device_type: str | None = None,
+    ) -> None:
+        if gradient_accumulation_steps < 1:
+            raise ValueError("gradient_accumulation_steps must be >= 1")
+        self.optimizer = optimizer
+        self.mixed_precision = mixed_precision
+        self.autocast_dtype = autocast_dtype
+        self.gradient_accumulation_steps = gradient_accumulation_steps
+        self.clip_norm = clip_norm
+        if device_type is None:
+            params = [
+                p for group in optimizer.param_groups for p in group["params"]
+            ]
+            device_type = params[0].device.type if params else "cpu"
+        self.device_type = device_type
+
+        # GradScaler is only useful for fp16; bf16 doesn't need it.
+        self._use_scaler = mixed_precision and (autocast_dtype == torch.float16)
+        self.scaler = GradScaler(self.device_type, enabled=self._use_scaler)
+
+        # Internal micro-batch counter (reset after every optimizer step).
+        self._micro_step: int = 0
+        self._optimizer_step_count: int = 0
+
+    @property
+    def optimizer_step_count(self) -> int:
+        """Number of completed optimizer steps.
+
+        Discounts gradient-accumulation micro-steps and steps skipped by the
+        GradScaler on overflow. Read by hooks that act on an optimizer-step
+        cadence (e.g. :class:`~torchrl.trainers.UpdateWeights` with
+        ``interval_unit="optim_steps"``).
+        """
+        return self._optimizer_step_count
+
+    # ------------------------------------------------------------------
+    # Checkpointing (optimizer + scaler state)
+    # ------------------------------------------------------------------
+
+    def state_dict(self) -> dict[str, Any]:
+        if self._micro_step % self.gradient_accumulation_steps != 0:
+            raise RuntimeError(
+                f"Cannot save stepper state mid-accumulation. (micro_step={self._micro_step}, "
+                f"accumulation_steps={self.gradient_accumulation_steps}). "
+                "Adjust your save_interval to align with the gradient accumulation window."
+            )
+
+        sd: dict[str, Any] = {
+            "optimizer": self.optimizer.state_dict(),
+            "micro_step": self._micro_step,
+            "optimizer_step_count": self._optimizer_step_count,
+        }
+        if self._use_scaler:
+            sd["scaler"] = self.scaler.state_dict()
+        return sd
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        self.optimizer.load_state_dict(state_dict["optimizer"])
+        self._micro_step = state_dict.get("micro_step", 0)
+        self._optimizer_step_count = state_dict.get("optimizer_step_count", 0)
+        if self._use_scaler and "scaler" in state_dict:
+            self.scaler.load_state_dict(state_dict["scaler"])
+
+    # ------------------------------------------------------------------
+    # Core step
+    # ------------------------------------------------------------------
+
+    def step(self, trainer: Trainer, sub_batch: TensorDictBase) -> TensorDictBase:
+        """Perform one forward pass and scaled backward pass.
+
+        The optimizer is only stepped and zeroed every
+        ``gradient_accumulation_steps`` calls.
+
+        Args:
+            trainer (Trainer): The owning :class:`~torchrl.trainers.Trainer`.
+            sub_batch (TensorDictBase): Mini-batch used for this step.
+
+        Returns:
+            A :class:`~tensordict.TensorDict` with scalar metrics (losses,
+            grad_norm) suitable for logging.
+        """
+        # ---- forward pass (optionally under autocast) ----
+        with torch.amp.autocast(
+            self.device_type,
+            enabled=self.mixed_precision,
+            dtype=self.autocast_dtype,
+        ):
+            losses_td = trainer.compute_loss(sub_batch)
+            # Sum all loss_* keys and normalise by accumulation steps.
+            loss_items = [v for k, v in losses_td.items() if k.startswith("loss")]
+            if not loss_items:
+                raise RuntimeError(
+                    "The loss module returned no 'loss_*' keys. "
+                    "Make sure your loss module prefixes scalar outputs with 'loss'."
+                )
+            loss = sum(loss_items) / self.gradient_accumulation_steps
+
+        # ---- backward pass ----
+        if self._use_scaler:
+            self.scaler.scale(loss).backward()
+        else:
+            loss.backward()
+
+        self._micro_step += 1
+
+        # ---- optimizer step every `gradient_accumulation_steps` micro-batches ----
+        if self._micro_step % self.gradient_accumulation_steps == 0:
+            if self._use_scaler:
+                self.scaler.unscale_(self.optimizer)
+
+            grad_norm = 0.0
+            if self.clip_norm is not None:
+                params = [
+                    p for group in self.optimizer.param_groups for p in group["params"]
+                ]
+                grad_norm = float(nn.utils.clip_grad_norm_(params, self.clip_norm))
+
+            if self._use_scaler:
+                scale_before = self.scaler.get_scale()
+                self.scaler.step(self.optimizer)
+                self.scaler.update()
+                # If scale dropped, an overflow occurred and optimizer.step() was skipped.
+                if self.scaler.get_scale() >= scale_before:
+                    self._optimizer_step_count += 1
+            else:
+                self.optimizer.step()
+                self._optimizer_step_count += 1
+            self.optimizer.zero_grad(set_to_none=True)
+            losses_td["grad_norm"] = torch.tensor(grad_norm)
+
+        return losses_td.detach()
 
 
 class Trainer:

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -371,9 +371,7 @@ class MixedPrecisionOptimizationStepper(OptimizationStepper):
         self.gradient_accumulation_steps = gradient_accumulation_steps
         self.clip_norm = clip_norm
         if device_type is None:
-            params = [
-                p for group in optimizer.param_groups for p in group["params"]
-            ]
+            params = [p for group in optimizer.param_groups for p in group["params"]]
             device_type = params[0].device.type if params else "cpu"
         self.device_type = device_type
 

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -2702,10 +2702,10 @@ class UpdateWeights(TrainerHookBase):
     intervals. If the devices match, this will result in a no-op.
 
     Args:
-        collector (BaseCollector): A data collector where the policy weights
-            must be synced.
-        update_weights_interval (int): Interval (in terms of number of batches
-            collected) where the sync must take place.
+        collector (BaseCollector, optional): A data collector where the policy
+            weights must be synced. Not required when a ``sender`` is given.
+        update_weights_interval (int, optional): Interval where the sync must
+            take place, counted in units of ``interval_unit``. Default: ``1``.
         policy_weights_getter (Callable, optional): A callable that returns the policy
             weights to sync. Used for backward compatibility. If both this and
             weight_update_map are provided, weight_update_map takes precedence.
@@ -2713,7 +2713,22 @@ class UpdateWeights(TrainerHookBase):
             (keys in collector's weight_sync_schemes) to source paths on the trainer.
             Example: ``{"policy": "loss_module.actor_network", "replay_buffer.transforms[0]": "loss_module.critic_network"}``.
         trainer (Trainer, optional): The trainer instance, required when using
-            weight_update_map to resolve source paths.
+            weight_update_map to resolve source paths, or when
+            ``interval_unit="optim_steps"`` (to read the optimizer step count).
+
+    Keyword Args:
+        sender (optional): A weight-sync sender object exposing an
+            ``update_weights()`` method (e.g. the sender returned by a
+            :class:`~torchrl.weight_update.weight_sync_schemes.WeightSyncScheme`'s
+            ``create_sender()``). When provided, weights are pushed through the
+            sender instead of ``collector.update_policy_weights_()``. This is
+            used by LLM trainers whose inference engine (vLLM, SGLang) is fed
+            by a standalone sender.
+        interval_unit (str, optional): Unit of ``update_weights_interval``:
+            ``"batches"`` (default) counts collected batches and registers the
+            hook at the ``post_steps`` stage; ``"optim_steps"`` counts
+            optimizer steps and registers the hook at the ``post_optim`` stage,
+            enabling weight pushes in the middle of an optimization loop.
 
     Examples:
         >>> # Legacy usage with policy_weights_getter
@@ -2734,15 +2749,27 @@ class UpdateWeights(TrainerHookBase):
         ... )
         >>> trainer.register_op("post_steps", update_weights)
 
+        >>> # Sender-based usage with optimizer-step cadence (LLM trainers)
+        >>> update_weights = UpdateWeights(
+        ...     update_weights_interval=10,
+        ...     trainer=trainer,
+        ...     sender=sender,
+        ...     interval_unit="optim_steps",
+        ... )
+        >>> update_weights.register(trainer)
+
     """
 
     def __init__(
         self,
-        collector: BaseCollector,
-        update_weights_interval: int,
+        collector: BaseCollector | None = None,
+        update_weights_interval: int = 1,
         policy_weights_getter: Callable[[Any], Any] | None = None,
         weight_update_map: dict[str, str] | None = None,
         trainer: Trainer | None = None,
+        *,
+        sender: Any | None = None,
+        interval_unit: Literal["batches", "optim_steps"] = "batches",
     ):
         self.collector = collector
         self.update_weights_interval = update_weights_interval
@@ -2750,28 +2777,72 @@ class UpdateWeights(TrainerHookBase):
         self.policy_weights_getter = policy_weights_getter
         self.weight_update_map = weight_update_map
         self.trainer = trainer
+        self.sender = sender
+        self.interval_unit = interval_unit
+        self._last_update_count = 0
 
         # Validate inputs
+        if update_weights_interval < 1:
+            raise ValueError("update_weights_interval must be >= 1")
+        if interval_unit not in ("batches", "optim_steps"):
+            raise ValueError(
+                f"interval_unit must be 'batches' or 'optim_steps', got {interval_unit!r}"
+            )
+        if sender is None and collector is None:
+            raise ValueError("either a collector or a sender must be provided")
+        if sender is not None and (
+            policy_weights_getter is not None or weight_update_map is not None
+        ):
+            raise ValueError(
+                "sender is mutually exclusive with policy_weights_getter and "
+                "weight_update_map"
+            )
         if weight_update_map is not None and trainer is None:
             raise ValueError("trainer must be provided when using weight_update_map")
+        if interval_unit == "optim_steps" and trainer is None:
+            raise ValueError(
+                "trainer must be provided when interval_unit='optim_steps'"
+            )
+
+    def _optimizer_step_count(self) -> int:
+        """Read the optimizer step count from the trainer.
+
+        Prefers the stepper's ``optimizer_step_count`` (which discounts
+        gradient-accumulation micro-steps and skipped steps) and falls back to
+        the trainer's raw optimization-loop counter.
+        """
+        stepper = getattr(self.trainer, "optimization_stepper", None)
+        count = getattr(stepper, "optimizer_step_count", None)
+        if count is None:
+            count = self.trainer._optim_count
+        return count
 
     def __call__(self):
-        self.counter += 1
-        if self.counter % self.update_weights_interval == 0:
-            # New approach: use weight_update_map if provided
-            if self.weight_update_map is not None:
-                self._update_with_map()
-            # Legacy approach: use policy_weights_getter
+        if self.interval_unit == "optim_steps":
+            count = self._optimizer_step_count()
+            if count - self._last_update_count < self.update_weights_interval:
+                return
+            self._last_update_count = count
+        else:
+            self.counter += 1
+            if self.counter % self.update_weights_interval != 0:
+                return
+        if self.sender is not None:
+            self.sender.update_weights()
+        # New approach: use weight_update_map if provided
+        elif self.weight_update_map is not None:
+            self._update_with_map()
+        # Legacy approach: use policy_weights_getter
+        else:
+            weights = (
+                self.policy_weights_getter()
+                if self.policy_weights_getter is not None
+                else None
+            )
+            if weights is not None:
+                self.collector.update_policy_weights_(weights)
             else:
-                weights = (
-                    self.policy_weights_getter()
-                    if self.policy_weights_getter is not None
-                    else None
-                )
-                if weights is not None:
-                    self.collector.update_policy_weights_(weights)
-                else:
-                    self.collector.update_policy_weights_()
+                self.collector.update_policy_weights_()
 
     def _update_with_map(self):
         """Update weights using the weight_update_map."""
@@ -2802,17 +2873,24 @@ class UpdateWeights(TrainerHookBase):
         self.collector.update_policy_weights_(weights_dict=weights_dict)
 
     def register(self, trainer: Trainer, name: str = "update_weights"):
+        if self.trainer is None:
+            self.trainer = trainer
         trainer.register_module(name, self)
+        stage = "post_optim" if self.interval_unit == "optim_steps" else "post_steps"
         trainer.register_op(
-            "post_steps",
+            stage,
             self,
         )
 
     def state_dict(self) -> dict:
-        return {"counter": self.counter}
+        return {
+            "counter": self.counter,
+            "last_update_count": self._last_update_count,
+        }
 
     def load_state_dict(self, state_dict) -> None:
         self.counter = state_dict.get("counter", 0)
+        self._last_update_count = state_dict.get("last_update_count", 0)
 
 
 class CountFramesLog(TrainerHookBase):


### PR DESCRIPTION
## Description

This PR introduces `GRPOTrainer` into the core `torchrl/trainers/algorithms` suite, bringing native support for RLHF (Reinforcement Learning from Human Feedback) architectures into TorchRL. 

Key architectural implementations include:
- **`GRPOTrainer`**: Integrated natively with the standard `Trainer` class to reuse existing data collection and hook logic.
- **`GRPOOptimizationStepper`**: Decouples `autocast`, gradient accumulation, and gradient clipping logic from the main loop.
- **`WeightSyncHook`**: Provides robust, asynchronous weight synchronization tailored for distributed LLM inference engines (e.g., vLLM, sglang), ensuring models stay in sync at precise macro-steps.
- **Hydra Config Parity**: Introduced `GRPOTrainerConfig` mapped 1:1 with the initializer to ensure non-breaking support for Hydra configuration pipelines.
- **SOTA Refactor & CI**: Refactored `sota-implementations/grpo/` (both sync and async) to utilize this new abstracted API, and added them to the GitHub Actions smoke test matrix via `sota-check`.
- **Testing**: Added 23 comprehensive unit tests validating accumulation boundaries, sync triggers, and extreme edge cases.

## Motivation and Context

As TorchRL continues to expand its utility for Large Language Model tuning (RLHF/PPO/GRPO), the lack of a standardized, abstracted `GRPOTrainer` meant that implementations required massive, monolithic custom training loops (as previously seen in `sota-implementations/grpo`). 

This PR solves this by providing a unified, modular, and heavily tested Trainer API specific to GRPO. It massively simplifies the code required by end-users to train LLMs via GRPO while enabling seamless integration with external high-throughput inference engines like vLLM.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] New feature (non-breaking change which adds core functionality)
- [x] Documentation (update in the documentation)
- [x] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
