### PR TITLE
[BugFix] Fix cudagraph_policy instability and add action std test

### DIFF
--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -287,7 +287,7 @@ class ParametricPolicy(Actor):
         )
 
 
-class RandomPolicy(torch.nn.Module):
+class MockRandomPolicy(torch.nn.Module):
     def __init__(self, action_dim):
         super().__init__()
         self.action_dim = action_dim
@@ -296,7 +296,6 @@ class RandomPolicy(torch.nn.Module):
         return torch.randn(
             *observation.shape[:-1], self.action_dim, device=observation.device
         )
-
 
 
 class DeterministicZeroPolicyNet(nn.Module):
@@ -2345,8 +2344,18 @@ if __name__ == "__main__":
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
-    @pytest.mark.skipif(IS_WINDOWS, reason="torch.compile not fully supported on windows")
+    @pytest.mark.skipif(
+        IS_WINDOWS, reason="torch.compile not fully supported on windows"
+    )
     def test_cudagraph_policy_stochastic_diversity(self):
+        try:
+            from torch.compiler import cudagraph_mark_step_begin
+
+            _ = cudagraph_mark_step_begin
+        except ImportError:
+            pytest.skip(
+                "cudagraph_mark_step_begin not available in this PyTorch version."
+            )
 
         def create_env():
             return ContinuousActionVecMockEnv(device="cuda:0")
@@ -2355,7 +2364,7 @@ if __name__ == "__main__":
         n_actions = env.action_spec.shape[-1]
 
         policy = TensorDictModule(
-            RandomPolicy(n_actions), in_keys=["observation"], out_keys=["action"]
+            MockRandomPolicy(n_actions), in_keys=["observation"], out_keys=["action"]
         )
 
         collector = Collector(
@@ -2380,7 +2389,9 @@ if __name__ == "__main__":
         assert actions is not None, "Collector yielded no data"
         # If RNG is frozen by cudagraph, standard deviation will be exactly 0 across steps
         std = actions.std(dim=0).mean().item()
-        assert std > 0.1, f"Actions have abnormally low variance (std={std}). cudagraph RNG state might be frozen."
+        assert (
+            std > 0.1
+        ), f"Actions have abnormally low variance (std={std}). cudagraph RNG state might be frozen."
 
     @pytest.mark.parametrize("use_async", [False, True])
     @pytest.mark.parametrize(

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -287,6 +287,18 @@ class ParametricPolicy(Actor):
         )
 
 
+class RandomPolicy(torch.nn.Module):
+    def __init__(self, action_dim):
+        super().__init__()
+        self.action_dim = action_dim
+
+    def forward(self, observation):
+        return torch.randn(
+            *observation.shape[:-1], self.action_dim, device=observation.device
+        )
+
+
+
 class DeterministicZeroPolicyNet(nn.Module):
     """A simple policy that always outputs action 0 (for discrete action spaces)."""
 
@@ -2330,6 +2342,45 @@ if __name__ == "__main__":
 
         assert_allclose_td(data1, data20)
         assert_allclose_td(data10, data20)
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
+    @pytest.mark.skipif(IS_WINDOWS, reason="torch.compile not fully supported on windows")
+    def test_cudagraph_policy_stochastic_diversity(self):
+
+        def create_env():
+            return ContinuousActionVecMockEnv(device="cuda:0")
+
+        env = create_env()
+        n_actions = env.action_spec.shape[-1]
+
+        policy = TensorDictModule(
+            RandomPolicy(n_actions), in_keys=["observation"], out_keys=["action"]
+        )
+
+        collector = Collector(
+            create_env_fn=create_env,
+            policy=policy,
+            total_frames=20,
+            frames_per_batch=20,
+            device="cuda:0",
+            storing_device="cuda:0",
+            cudagraph_policy=True,
+            compile_policy={"mode": "default", "fullgraph": False},
+        )
+
+        actions = None
+        try:
+            for data in collector:
+                actions = data["action"]
+                break
+        finally:
+            collector.shutdown()
+
+        assert actions is not None, "Collector yielded no data"
+        # If RNG is frozen by cudagraph, standard deviation will be exactly 0 across steps
+        std = actions.std(dim=0).mean().item()
+        assert std > 0.1, f"Actions have abnormally low variance (std={std}). cudagraph RNG state might be frozen."
 
     @pytest.mark.parametrize("use_async", [False, True])
     @pytest.mark.parametrize(

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -1488,7 +1488,7 @@ class Collector(BaseCollector, metaclass=_CollectorMeta):
                     policy_input = self._carrier.copy()
                     if self.policy_device:
                         policy_input = policy_input.to(self.policy_device)
-                    if self.compiled_policy:
+                    if self.compiled_policy or self.cudagraphed_policy:
                         cudagraph_mark_step_begin()
                     policy_output = self._wrapped_policy(policy_input)
                 policy_output_keys = set(policy_output.keys(True, True))
@@ -1548,7 +1548,7 @@ class Collector(BaseCollector, metaclass=_CollectorMeta):
                 policy_input_clone = (
                     policy_input.clone()
                 )  # to test if values have changed in-place
-                if self.compiled_policy:
+                if self.compiled_policy or self.cudagraphed_policy:
                     cudagraph_mark_step_begin()
                 policy_output = self._wrapped_policy(policy_input)
 
@@ -2097,11 +2097,11 @@ class Collector(BaseCollector, metaclass=_CollectorMeta):
                     else:
                         policy_input = self._carrier
                     # we still do the assignment for security
-                    if self.compiled_policy:
+                    if self.compiled_policy or self.cudagraphed_policy:
                         cudagraph_mark_step_begin()
                     with _maybe_record_function("Collector.policy"):
                         policy_output = self._wrapped_policy(policy_input)
-                    if self.compiled_policy:
+                    if self.compiled_policy or self.cudagraphed_policy:
                         policy_output = policy_output.select(
                             *self._policy_output_keys, strict=False
                         ).clone()

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -1488,8 +1488,13 @@ class Collector(BaseCollector, metaclass=_CollectorMeta):
                     policy_input = self._carrier.copy()
                     if self.policy_device:
                         policy_input = policy_input.to(self.policy_device)
-                    if self.compiled_policy or self.cudagraphed_policy:
+                    if self.compiled_policy:
                         cudagraph_mark_step_begin()
+                    elif self.cudagraphed_policy:
+                        try:
+                            cudagraph_mark_step_begin()
+                        except NotImplementedError:
+                            pass
                     policy_output = self._wrapped_policy(policy_input)
                 policy_output_keys = set(policy_output.keys(True, True))
                 missing_out_keys = [
@@ -1548,8 +1553,13 @@ class Collector(BaseCollector, metaclass=_CollectorMeta):
                 policy_input_clone = (
                     policy_input.clone()
                 )  # to test if values have changed in-place
-                if self.compiled_policy or self.cudagraphed_policy:
+                if self.compiled_policy:
                     cudagraph_mark_step_begin()
+                elif self.cudagraphed_policy:
+                    try:
+                        cudagraph_mark_step_begin()
+                    except NotImplementedError:
+                        pass
                 policy_output = self._wrapped_policy(policy_input)
 
                 # check that we don't have exclusive keys, because they don't appear in keys
@@ -2097,8 +2107,13 @@ class Collector(BaseCollector, metaclass=_CollectorMeta):
                     else:
                         policy_input = self._carrier
                     # we still do the assignment for security
-                    if self.compiled_policy or self.cudagraphed_policy:
+                    if self.compiled_policy:
                         cudagraph_mark_step_begin()
+                    elif self.cudagraphed_policy:
+                        try:
+                            cudagraph_mark_step_begin()
+                        except NotImplementedError:
+                            pass
                     with _maybe_record_function("Collector.policy"):
                         policy_output = self._wrapped_policy(policy_input)
                     if self.compiled_policy or self.cudagraphed_policy:


### PR DESCRIPTION
## Description

This PR fixes a bug where the standard deviation of actions from a `cudagraph_policy` collapses to zero during training when using a stochastic policy compiled with `torch.compile`. 

When a compiled module is captured into a `CudaGraphModule` by the `SyncDataCollector`, Inductor's internal Philox RNG state (seed and offset) gets frozen as static buffers. Consequently, the random samples drawn (e.g. from `Beta` or `Normal` distributions) are identical on every step replay.

Fix injects `torch.compiler.cudagraph_mark_step_begin()` immediately before the compiled policy is called during rollout. This signals PyTorch to emit an offset-increment kernel, ensuring fresh random numbers are generated on every execution of the CUDA graph. Additionally, a defensive `.clone()` is added to the policy outputs to prevent aliasing with the static CUDA graph buffers inside the TensorDict.

## Motivation and Context

Fixes the learning instability and action standard deviation collapse observed when `cudagraph_policy=True` is used with a compiled stochastic policy.

close #3002

- [x] I have raised a bug report to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes a bug)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
