### PR TITLE
[BugFix] Strengthen behavioral regression tests

### DIFF
--- a/test/objectives/test_controllers.py
+++ b/test/objectives/test_controllers.py
@@ -94,7 +94,7 @@ class TestRBFController:
         assert squashed_cov.shape == (10, 3, 3)
         assert cross_cov.shape == (10, 3, 3)
 
-    def test_deterministic_with_zero_variance(self):
+    def test_zero_input_covariance_collapses_action_covariance(self):
         controller = RBFController(
             input_dim=4, output_dim=1, max_action=1.0, n_basis=5
         ).double()
@@ -102,10 +102,12 @@ class TestRBFController:
         mean = torch.randn(2, 4, dtype=torch.float64)
         zero_cov = torch.zeros(2, 4, 4, dtype=torch.float64)
 
-        action_mean1, _, _ = controller(mean, zero_cov)
-        action_mean2, _, _ = controller(mean, zero_cov)
+        action_mean, action_cov, _ = controller(mean, zero_cov)
 
-        torch.testing.assert_close(action_mean1, action_mean2)
+        assert torch.isfinite(action_mean).all()
+        torch.testing.assert_close(
+            action_cov, torch.zeros_like(action_cov), atol=2e-6, rtol=0
+        )
 
     def test_gradients_flow(self):
         controller = RBFController(

--- a/test/test_rlhf.py
+++ b/test/test_rlhf.py
@@ -16,12 +16,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from tensordict import (
-    is_tensor_collection,
-    MemoryMappedTensor,
-    TensorDict,
-    TensorDictBase,
-)
+from tensordict import MemoryMappedTensor, TensorDict, TensorDictBase
 from tensordict.nn import TensorDictModule
 from torchrl._utils import print_directory_tree
 from torchrl.data.llm import TensorDictTokenizer
@@ -217,7 +212,6 @@ def test_dataset_to_tensordict(tmpdir, suffix):
 )
 @pytest.mark.parametrize("device", get_default_devices())
 @pytest.mark.parametrize("split", ["train"])
-@pytest.mark.parametrize("infinite", [True, False])
 def test_get_dataloader(
     tmpdir1,
     tensorclass_type,
@@ -226,7 +220,6 @@ def test_get_dataloader(
     device,
     dataset,
     split,
-    infinite,
     minidata_dir_tldr,
     minidata_dir_comparison,
 ):
@@ -236,29 +229,48 @@ def test_get_dataloader(
         dataset = minidata_dir_comparison
     else:
         raise NotImplementedError
-    dl = get_dataloader(
+    finite_dataloader = get_dataloader(
         batch_size,
         block_size,
         tensorclass_type,
         device,
         dataset_name=dataset,
-        infinite=infinite,
+        infinite=False,
         prefetch=0,
         split=split,
         root_dir=tmpdir1,
         from_disk=True,
     )
-    for data in dl:  # noqa: B007
-        break
-    assert data.shape[0] == batch_size
-    for value in data.values():
-        if value.ndim > 1:
-            assert value.shape[1] == block_size
-    assert data.device == device
-    if infinite:
-        assert not is_tensor_collection(dl)
-    else:
-        assert not is_tensor_collection(dl)
+    num_batches = len(finite_dataloader) // batch_size
+    assert num_batches > 0
+
+    finite_iterator = iter(finite_dataloader)
+    for _ in range(num_batches):
+        finite_batch = next(finite_iterator)
+    with pytest.raises(StopIteration):
+        next(finite_iterator)
+
+    infinite_iterator = get_dataloader(
+        batch_size,
+        block_size,
+        tensorclass_type,
+        device,
+        dataset_name=dataset,
+        infinite=True,
+        prefetch=0,
+        split=split,
+        root_dir=tmpdir1,
+        from_disk=True,
+    )
+    for _ in range(num_batches + 1):
+        infinite_batch = next(infinite_iterator)
+
+    for data in (finite_batch, infinite_batch):
+        assert data.shape[0] == batch_size
+        for value in data.values():
+            if value.ndim > 1:
+                assert value.shape[1] == block_size
+        assert data.device == device
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Description

Strengthen the behavioral regression tests identified in #4144:

- verify finite RLHF dataloaders exhaust and infinite dataloaders continue beyond one full pass
- verify zero input covariance produces near-zero action covariance in `RBFController`

## Motivation and Context

The previous tests only consumed one dataloader batch and repeated a deterministic mean assertion, so they did not exercise the intended finite/infinite behavior or covariance propagation.

Closes #4144

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.