### PR TITLE
[BugFix] preserve caller CUDA stream in Collector

### DIFF
--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -3298,8 +3298,10 @@ class TestCollectorDevices:
                 no_cuda_sync=no_cuda_sync,
             )
             assert collector.env.device == torch.device(env_device)
+            caller_stream = torch.cuda.current_stream()
             i = 0
             for d in collector:
+                assert torch.cuda.current_stream() == caller_stream
                 for _d in d.unbind(0):
                     u = _d["observation"].unique()
                     assert u.numel() == 1, i

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -1764,8 +1764,9 @@ class Collector(BaseCollector, metaclass=_CollectorMeta):
         Yields: TensorDictBase objects containing (chunks of) trajectories
 
         """
+        use_cuda_streams = self.return_same_td and not self.no_cuda_sync
         if (
-            not self.no_cuda_sync
+            use_cuda_streams
             and self.storing_device
             and self.storing_device.type == "cuda"
         ):
@@ -1773,7 +1774,7 @@ class Collector(BaseCollector, metaclass=_CollectorMeta):
             event = stream.record_event()
             streams = [stream]
             events = [event]
-        elif not self.no_cuda_sync and self.storing_device is None:
+        elif use_cuda_streams and self.storing_device is None:
             streams = []
             events = []
             # this way of checking cuda is robust to lazy stacks with mismatching shapes


### PR DESCRIPTION
### TLDR

Addresses #4142.

Collector.iterator() yielded while inside its private CUDA stream context, so default cloned batches ran caller PPO code on TorchRL's stream. This gates the private stream path to `return_same_td=True`. cloned batches stay on the caller stream.

<details><summary>Testing + visuals</summary>
<p>

### rtx 6000

```
parent ae9719f17b1517af5c2523a36c4616f003ee55cf
fixed  68f945c20fe26189d07d1717737c3b8ce5e66035
PyTorch 2.7.1+cu128, Warp 1.16.0
seed 0, 1 and 4 ParallelEnv workers
1,100 PPO updates / 70,400 frames per run
```

<img width="1800" height="720" alt="stream-context" src="https://github.com/user-attachments/assets/6a15c44e-a06f-480e-83e5-38b99ae6aa63" />


- Parent: 0/2,200 batches stayed on the caller stream.
- Fixed: 2,200/2,200 batches stayed on the caller stream.

<img width="1800" height="1260" alt="ppo-control" src="https://github.com/user-attachments/assets/ff7bfbc0-d646-459e-9c09-fa4a79a48267" />

- Loss and reward histories are exactly equal before and after the patch.
- All four runs completed with finite values.
- The substitute Warp workload did not reproduce the intermittent `libcuda.so.1` segfault on either revision. It does deterministically reproduce the TorchRL stream leak.

Ran regression which passed.

```bash
python -m pytest -q -p no:cacheprovider \
  test/test_collectors.py::TestCollectorDevices::test_no_synchronize
```

</p>
</details>

ai disclosure: i used an agent to write the description, though I modified it myself.