### PR TITLE
[BugFix]: Preserve renamed done keys in batched environments

### DIFF
--- a/test/transforms/test_key_transforms.py
+++ b/test/transforms/test_key_transforms.py
@@ -18,6 +18,7 @@ from _transforms_common import _has_transformers, TransformBase
 from tensordict import NonTensorData, NonTensorStack, TensorDict, TensorDictBase
 from torch import nn
 
+from torchrl.collectors import Collector
 from torchrl.data import (
     Categorical,
     Composite,
@@ -633,6 +634,28 @@ class TestRenameTransform(TransformBase):
                 env.close()
             except RuntimeError:
                 pass
+
+    def test_parallel_renamed_done(self, create_copy, maybe_fork_ParallelEnv):
+        def make_env():
+            return TransformedEnv(
+                ContinuousActionVecMockEnv().add_truncated_keys(),
+                RenameTransform(
+                    ["terminated"],
+                    [("stuff", "terminated")],
+                    create_copy=create_copy,
+                ),
+            )
+
+        env = maybe_fork_ParallelEnv(2, make_env)
+        expected_done_keys = {"done", "truncated", ("stuff", "terminated")}
+        if create_copy:
+            expected_done_keys.add("terminated")
+        assert set(env.done_keys) == expected_done_keys
+        collector = Collector(env, frames_per_batch=4, total_frames=4)
+        try:
+            next(iter(collector))
+        finally:
+            collector.shutdown()
 
     def test_trans_serial_env_check(self, create_copy):
         def make_env():

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -507,6 +507,8 @@ class BatchedEnvBase(EnvBase):
     """
 
     _verbose: bool = VERBOSE
+    # Worker metadata contains the final key layout, including transforms.
+    auto_complete_done_specs = False
     _excluded_wrapped_keys = [
         "is_closed",
         "parent_channels",

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -612,6 +612,8 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
     # the transition ``FutureWarning`` and the ``NotImplementedError`` raised by
     # :meth:`reset` when ``set_state=True`` on an env that does not support it.
     _supports_set_state: bool = False
+    # Metadata-backed wrappers can preserve an already post-processed done spec.
+    auto_complete_done_specs: bool = True
     # Whether this env implements ``frame_skip`` natively in its own ``_step``
     # (e.g. :class:`~torchrl.envs.GymLikeEnv` loops over ``wrapper_frame_skip``).
     # When ``False`` (the default) and a ``frame_skip > 1`` is requested, the
@@ -1899,6 +1901,8 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
         empty, nothing is changed.
 
         """
+        if not self.auto_complete_done_specs:
+            return
         try:
             full_done_spec = self.output_spec["full_done_spec"]
         except KeyError:

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -1398,7 +1398,7 @@ def _aggregate_end_of_traj(
     batch_size = data.batch_size
     n = len(batch_size)
     if done_keys is not None and reset_keys is None:
-        reset_keys = {_replace_last(key, "done") for key in done_keys}
+        reset_keys = done_keys
     if reset_keys is not None:
         reset = False
         has_missing = None


### PR DESCRIPTION
Parallelenv was fabricating keys and re-completing transformed worker specs. 
Batched envs will now ppreserve the worker metadata. collector tracking will read the done keys directly.

Closes https://github.com/pytorch/rl/issues/2445

tested & passed regressions

cc @vmoens @theap06 