### PR TITLE
[BugFix] fix lazy target parameter initialization

### DIFF
--- a/test/objectives/test_dqn.py
+++ b/test/objectives/test_dqn.py
@@ -527,7 +527,8 @@ class TestDQN(LossModuleTestBase):
             p.data += torch.randn_like(p)
         assert all((p1 != p2).all() for p1, p2 in zip(parameters, actor.parameters()))
 
-    def test_distributional_dqn_lazy_target(self):
+    @pytest.mark.parametrize("actor_first", [False, True])
+    def test_distributional_dqn_lazy_target(self, actor_first):
         torch.manual_seed(self.seed)
         atoms = 3
         action_dim = 2
@@ -546,6 +547,9 @@ class TestDQN(LossModuleTestBase):
             atoms=atoms,
         )
 
+        if actor_first:
+            actor(td)
+            updater.step()
         assert torch.isfinite(loss_fn(td)["loss"])
 
         source_params = loss_fn.value_network_params

--- a/test/objectives/test_dqn.py
+++ b/test/objectives/test_dqn.py
@@ -527,6 +527,45 @@ class TestDQN(LossModuleTestBase):
             p.data += torch.randn_like(p)
         assert all((p1 != p2).all() for p1, p2 in zip(parameters, actor.parameters()))
 
+    def test_distributional_dqn_lazy_target(self):
+        torch.manual_seed(self.seed)
+        atoms = 3
+        action_dim = 2
+        actor = DistributionalQValueActor(
+            module=MLP(out_features=(atoms, action_dim), depth=2),
+            spec=OneHot(action_dim),
+            support=torch.arange(atoms),
+        )
+        loss_fn = DistributionalDQNLoss(actor, gamma=0.99, delay_value=True)
+        updater = SoftUpdate(loss_fn, eps=0.5)
+        td = self._create_mock_data_dqn(
+            action_spec_type="one_hot",
+            batch=5,
+            obs_dim=4,
+            action_dim=action_dim,
+            atoms=atoms,
+        )
+
+        assert torch.isfinite(loss_fn(td)["loss"])
+
+        source_params = loss_fn.value_network_params
+        target_params = loss_fn.target_value_network_params
+        for key, source in source_params.items(True, True):
+            target = target_params.get(key)
+            torch.testing.assert_close(target, source)
+            assert not target.is_set_to(source.data)
+
+        key, source = next(
+            (key, source)
+            for key, source in source_params.items(True, True)
+            if source.requires_grad
+        )
+        target = target_params.get(key)
+        expected = target + 0.5
+        source.data.add_(1)
+        updater.step()
+        torch.testing.assert_close(target, expected)
+
     @pytest.mark.parametrize("observation_key", ["observation", "observation2"])
     @pytest.mark.parametrize("reward_key", ["reward", "reward2"])
     @pytest.mark.parametrize("done_key", ["done", "done2"])

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -585,6 +585,11 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
                 ),
                 no_convert=True,
             )
+            target_params.uninitialized_keys = {
+                key
+                for key, value in params.items(True, True)
+                if torch.nn.parameter.is_lazy(value)
+            }
             setattr(self, name_params_target + "_params", target_params)
         self._has_update_associated[module_name] = not create_target_params
 
@@ -601,6 +606,15 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
     def __getattr__(self, item):
         if item.startswith("target_") and item.endswith("_params"):
             params = self._modules.get(item, None)
+            if params is not None:
+                pending_keys = getattr(params, "uninitialized_keys", None)
+                if pending_keys:
+                    source_params = getattr(self, item[7:])
+                    for key in pending_keys.copy():
+                        source = source_params.get(key)
+                        if not torch.nn.parameter.is_lazy(source):
+                            params.get(key).data = source.data.clone()
+                            pending_keys.remove(key)
             if params is None:
                 # no target param, take detached data
                 params = getattr(self, item[7:])

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -499,6 +499,8 @@ class TargetNetUpdater:
                 f"{self.__class__.__name__} must be "
                 f"initialized (`{self.__class__.__name__}.init_()`) before calling step()"
             )
+        for name in self._target_names:
+            getattr(self.loss_module, name)
         for key, param in self._sources.items():
             target = self._targets.get(f"target_{key}")
             if target.requires_grad:

--- a/torchrl/objectives/utils.py
+++ b/torchrl/objectives/utils.py
@@ -460,7 +460,7 @@ class TargetNetUpdater:
             self._distinct_and_params[key] = (
                 target.is_leaf
                 and source.requires_grad
-                and target.data_ptr() != source.data.data_ptr()
+                and not target.is_set_to(source.data)
             )
             found_distinct = found_distinct or self._distinct_and_params[key]
             target.data.copy_(source.data)


### PR DESCRIPTION
### TLDR

Closes https://github.com/pytorch/rl/issues/2523.

`convert_to_functional()` cloned `UninitializedParameter.data` into regular zero-length target tensors. The online network later materialized, but its delayed target remained 1-D and failed in `Linear`.

This PR records lazy target leaves and clones each from its source after materialization. `TargetNetUpdater` now uses `Tensor.is_set_to()` so distinct empty tensors are not mistaken for aliases.

<details><summary>Testing + visuals</summary>
<p>

### Testing:

Regression test constructs `DistributionalDQNLoss` and `SoftUpdate` before any model forward, then verifies:

- the first loss succeeds without dummy initialization;
- source and target parameters initially match without sharing storage;
- the subsequent soft update is correct.

- Loss: 0.734 to 0.044.
- Greedy accuracy: 35.7% to 97.2%.
- This is an execution and learning control, not benchmark evidence.

<img width="2160" height="720" alt="image" src="https://github.com/user-attachments/assets/10ce61bc-76b7-40af-bac9-e68ea22f6a54" />

Ran:

```bash
pytest test/objectives/test_dqn.py::TestDQN::test_distributional_dqn_lazy_target -q

pytest \
  test/objectives/test_dqn.py \
  test/objectives/test_loss_module.py \
  test/objectives/test_cql.py \
  test/objectives/test_ddpg.py \
  test/objectives/test_sac.py \
  test/objectives/test_iql.py \
  test/objectives/test_tqc.py \
  test/objectives/test_dreamer_v3.py \
  -q -k "not prioritized_weights"

pre-commit run --files \
  torchrl/objectives/common.py \
  torchrl/objectives/utils.py \
  test/objectives/test_dqn.py
 
```
 
 </p>
</details>

   ai disclosure: i used an agent to write desc