### PR TITLE
[BugFix] fix single iql qvalue gradients

### DIFF
--- a/test/objectives/test_iql.py
+++ b/test/objectives/test_iql.py
@@ -527,9 +527,7 @@ class TestIQL(LossModuleTestBase):
         sd = loss_fn.state_dict()
         if num_qvalue == 1:
             for key, tensor in list(sd.items()):
-                if key.startswith(
-                    ("qvalue_network_params.", "target_qvalue_network_params.")
-                ):
+                if key.removeprefix("target_").startswith("qvalue_network_params."):
                     sd[key] = tensor.unsqueeze(0)
         loss_fn2 = IQLLoss(
             actor_network=actor,

--- a/test/objectives/test_iql.py
+++ b/test/objectives/test_iql.py
@@ -525,6 +525,12 @@ class TestIQL(LossModuleTestBase):
             loss_function="l2",
         )
         sd = loss_fn.state_dict()
+        if num_qvalue == 1:
+            for key, tensor in list(sd.items()):
+                if key.startswith(
+                    ("qvalue_network_params.", "target_qvalue_network_params.")
+                ):
+                    sd[key] = tensor.unsqueeze(0)
         loss_fn2 = IQLLoss(
             actor_network=actor,
             qvalue_network=qvalue,

--- a/test/objectives/test_iql.py
+++ b/test/objectives/test_iql.py
@@ -303,7 +303,7 @@ class TestIQL(LossModuleTestBase):
 
         loss_fn = IQLLoss(
             actor_network=actor,
-            qvalue_network=qvalue,
+            qvalue_network=[qvalue] if num_qvalue == 1 else qvalue,
             value_network=value,
             num_qvalue_nets=num_qvalue,
             temperature=temperature,
@@ -389,6 +389,11 @@ class TestIQL(LossModuleTestBase):
                         include_nested=True, leaves_only=True
                     )
                 )
+                if num_qvalue == 1:
+                    assert not any(
+                        (p.grad is None) or (p.grad == 0).all()
+                        for p in qvalue.parameters()
+                    )
             else:
                 raise NotImplementedError(k)
             loss_fn.zero_grad()
@@ -412,7 +417,7 @@ class TestIQL(LossModuleTestBase):
                     p.grad is None or p.grad.norm() == 0.0
                 ), f"target parameter {name} (shape: {p.shape}) has a non-null gradient"
 
-    @pytest.mark.parametrize("num_qvalue", [2])
+    @pytest.mark.parametrize("num_qvalue", [1, 2])
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("temperature", [0.1])
     @pytest.mark.parametrize("expectile", [0.1])
@@ -493,7 +498,7 @@ class TestIQL(LossModuleTestBase):
                 loss_no_vmap = loss_fn_no_vmap(td)
             assert_allclose_td(loss_vmap, loss_no_vmap)
 
-    @pytest.mark.parametrize("num_qvalue", [2])
+    @pytest.mark.parametrize("num_qvalue", [1, 2])
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("temperature", [0.0])
     @pytest.mark.parametrize("expectile", [0.1])
@@ -1297,6 +1302,11 @@ class TestDiscreteIQL(LossModuleTestBase):
                         include_nested=True, leaves_only=True
                     )
                 )
+                if num_qvalue == 1:
+                    assert not any(
+                        (p.grad is None) or (p.grad == 0).all()
+                        for p in qvalue.parameters()
+                    )
             else:
                 raise NotImplementedError(k)
             loss_fn.zero_grad()
@@ -1320,7 +1330,7 @@ class TestDiscreteIQL(LossModuleTestBase):
                     p.grad is None or p.grad.norm() == 0.0
                 ), f"target parameter {name} (shape: {p.shape}) has a non-null gradient"
 
-    @pytest.mark.parametrize("num_qvalue", [2])
+    @pytest.mark.parametrize("num_qvalue", [1, 2])
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("temperature", [0.0])
     @pytest.mark.parametrize("expectile", [0.1])

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -334,9 +334,7 @@ class IQLLoss(LossModule):
                 for key, current in module.state_dict().items():
                     full_key = prefix + key
                     if (
-                        key.startswith(
-                            ("qvalue_network_params.", "target_qvalue_network_params.")
-                        )
+                        key.removeprefix("target_").startswith("qvalue_network_params.")
                         and full_key in state_dict
                         and state_dict[full_key].shape == (1, *current.shape)
                     ):

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -326,6 +326,23 @@ class IQLLoss(LossModule):
             create_target_params=True,
             compare_against=qvalue_policy_params,
         )
+        if num_qvalue_nets == 1:
+
+            def load_legacy_single_qvalue_state_dict(
+                module, state_dict, prefix, *load_args
+            ):
+                for key, current in module.state_dict().items():
+                    full_key = prefix + key
+                    if (
+                        key.startswith(
+                            ("qvalue_network_params.", "target_qvalue_network_params.")
+                        )
+                        and full_key in state_dict
+                        and state_dict[full_key].shape == (1, *current.shape)
+                    ):
+                        state_dict[full_key] = state_dict[full_key].squeeze(0)
+
+            self.register_load_state_dict_pre_hook(load_legacy_single_qvalue_state_dict)
 
         self.loss_function = loss_function
         if gamma is not None:

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -313,10 +313,16 @@ class IQLLoss(LossModule):
             )
         else:
             qvalue_policy_params = None
+        if (
+            num_qvalue_nets == 1
+            and isinstance(qvalue_network, (list, tuple))
+            and len(qvalue_network) == 1
+        ):
+            qvalue_network = qvalue_network[0]
         self.convert_to_functional(
             qvalue_network,
             "qvalue_network",
-            num_qvalue_nets,
+            None if num_qvalue_nets == 1 else num_qvalue_nets,
             create_target_params=True,
             compare_against=qvalue_policy_params,
         )
@@ -344,12 +350,20 @@ class IQLLoss(LossModule):
         self.scalar_output_mode = scalar_output_mode
 
     def _make_vmap(self):
-        self._vmap_qvalue_networkN0 = _vmap_func(
+        vectorized_qvalue_network = _vmap_func(
             self.qvalue_network,
             (None, 0),
             randomness=self.vmap_randomness,
             pseudo_vmap=self.deactivate_vmap,
         )
+        if self.qvalue_network_params.ndim == 0:
+
+            def call_single_qvalue_network(tensordict, params):
+                return vectorized_qvalue_network(tensordict, params.unsqueeze(0))
+
+            self._vmap_qvalue_networkN0 = call_single_qvalue_network
+        else:
+            self._vmap_qvalue_networkN0 = vectorized_qvalue_network
 
     @property
     def device(self) -> torch.device:


### PR DESCRIPTION
### TLDR

Closes #3127.

Problem: num_qvalue_nets=1 still expanded and cloned the passed Q network, so gradients landed on a separate parameter set.

Solution: keep the passed parameters for one Q network and add the size-one ensemble axis only during Q evaluation.

<details><summary>Testing + visuals</summary>
<p>

CartPole-v1 test

5,000 environment steps
num_qvalue_nets=1
Adam over the passed actor, Q, and value modules
5 evaluation episodes per point
raw, unsmoothed points

<img width="3240" height="990" alt="image" src="https://github.com/user-attachments/assets/a21867fc-b546-46b3-b472-342bbd3b1b30" />


- Base: the loss-owned Q received gradients, but the passed Q gradient and weight change stayed exactly zero.
- Fixed: the passed and loss-owned Q gradients match; the passed Q weight distance reached 10.972.

other checks:

```bash
pytest test/objectives/test_iql.py -q
pre-commit run --files torchrl/objectives/iql.py test/objectives/test_iql.py
```

- 898 IQL tests pass.
- Direct-module, one-item-list, normal-vmap, pseudo-vmap, state-dict, target-update, and fullgraph-compile paths pass.
- `num_qvalue_nets > 1` remains on the existing ensemble path.

</p>
</details>

cc @vmoens