### PR TITLE
[Feature] Add COMA multi-agent objective

### DIFF
--- a/.github/unittest/linux_sota/scripts/test_sota.py
+++ b/.github/unittest/linux_sota/scripts/test_sota.py
@@ -314,6 +314,13 @@ commands = {
   train.minibatch_size=100 \
   logger.backend=
 """,
+    "coma": """python sota-implementations/multiagent/coma.py \
+  collector.n_iters=2 \
+  collector.frames_per_batch=200 \
+  train.num_epochs=3 \
+  train.minibatch_size=100 \
+  logger.backend=
+""",
     "marl_sac": """python sota-implementations/multiagent/sac.py \
   collector.n_iters=2 \
   collector.frames_per_batch=200 \

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -132,6 +132,7 @@ Advanced
    :maxdepth: 1
 
    tutorials/multiagent_competitive_ddpg
+   tutorials/multiagent_coma
    tutorials/multi_task
    tutorials/coding_ddpg
    tutorials/coding_dqn

--- a/docs/source/reference/objectives_multiagent.rst
+++ b/docs/source/reference/objectives_multiagent.rst
@@ -56,3 +56,32 @@ update on the global value (Rashid et al. 2018).
     :template: rl_template_noinherit.rst
 
     QMixerLoss
+
+COMA
+----
+
+:class:`COMALoss` implements Counterfactual Multi-Agent Policy Gradients
+(Foerster et al. 2018) — a decentralised actor paired with a *centralised*
+critic that outputs one action value per possible action of the acting
+agent. The actor's advantage is a counterfactual baseline: the critic's own
+output is marginalised over the acting agent's action (holding every other
+agent's action fixed), crediting an agent only for the part of the outcome
+its own action choice affected.
+
+The critic is centralised through its inputs rather than through a mixing
+network: it is built with the acting agent's observation together with
+either the other agents' actions
+(:func:`~torchrl.objectives.multiagent.coma.add_action_without_self`) or a
+joint/global state
+(:func:`~torchrl.objectives.multiagent.coma.add_joint_observation`,
+:func:`~torchrl.objectives.multiagent.coma.add_masked_joint_action`). The
+critic itself is trained with an n-step TD target bootstrapped from a target
+network via :meth:`~torchrl.objectives.multiagent.COMALoss.compute_value_target`.
+
+See ``sota-implementations/multiagent/coma.py`` for a hydra-configured recipe.
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template_noinherit.rst
+
+    COMALoss

--- a/sota-check/run_multiagent_coma.sh
+++ b/sota-check/run_multiagent_coma.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#SBATCH --job-name=marl_coma
+#SBATCH --ntasks=32
+#SBATCH --cpus-per-task=1
+#SBATCH --gres=gpu:1
+#SBATCH --output=slurm_logs/marl_coma_%j.txt
+#SBATCH --error=slurm_errors/marl_coma_%j.txt
+
+current_commit=$(git rev-parse --short HEAD)
+project_name="torchrl-example-check-$current_commit"
+group_name="marl_coma"
+export PYTHONPATH=$(dirname $(dirname $PWD))
+python $PYTHONPATH/sota-implementations/multiagent/coma.py \
+  logger.backend=wandb \
+  logger.project_name="$project_name" \
+  logger.group_name="$group_name"
+
+# Capture the exit status of the Python command
+exit_status=$?
+# Write the exit status to a file
+if [ $exit_status -eq 0 ]; then
+  echo "${group_name}_${SLURM_JOB_ID}=success" >> report.log
+else
+  echo "${group_name}_${SLURM_JOB_ID}=error" >> report.log
+fi

--- a/sota-check/submitit-release-check.sh
+++ b/sota-check/submitit-release-check.sh
@@ -56,6 +56,7 @@ scripts=(
     run_iql_offline.sh
     run_iql_online.sh
     run_iql_discrete.sh
+    run_multiagent_coma.sh
     run_multiagent_iddpg.sh
     run_multiagent_ippo.sh
     run_multiagent_iql.sh

--- a/sota-implementations/multiagent/README.md
+++ b/sota-implementations/multiagent/README.md
@@ -42,6 +42,10 @@ For example:
 python mappo_ippo.py
 ```
 
+The available scripts are `mappo_ippo.py` (MAPPO / IPPO), `qmix_vdn.py` (QMix /
+VDN), `coma.py` (COMA), `maddpg_iddpg.py` (MADDPG / IDDPG), `iql.py` (IQL) and
+`sac.py` (multi-agent SAC).
+
 You can even change the config from the command line like:
 
 ```bash

--- a/sota-implementations/multiagent/coma.py
+++ b/sota-implementations/multiagent/coma.py
@@ -1,0 +1,285 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import time
+
+import hydra
+import torch
+from tensordict.nn import TensorDictModule
+from torch import nn
+from torchrl._utils import logger as torchrl_logger
+from torchrl.collectors import Collector
+from torchrl.data import TensorDictReplayBuffer
+from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
+from torchrl.data.replay_buffers.storages import LazyTensorStorage
+from torchrl.envs import RewardSum, TransformedEnv
+from torchrl.envs.libs.vmas import VmasEnv
+from torchrl.envs.utils import ExplorationType, set_exploration_type
+from torchrl.modules import OneHotCategorical, ProbabilisticActor
+from torchrl.modules.models.multiagent import MultiAgentMLP
+from torchrl.objectives import SoftUpdate
+from torchrl.objectives.multiagent.coma import COMALoss, add_action_without_self
+from utils.logging import init_logging, log_evaluation, log_training
+
+
+def rendering_callback(env, td):
+    env.frames.append(env.render(mode="rgb_array", agent_index_focus=None))
+
+
+@hydra.main(version_base="1.3", config_path="", config_name="coma")
+def train(cfg: DictConfig):  # noqa: F821
+    # Device
+    cfg.train.device = "cpu" if not torch.cuda.device_count() else "cuda:0"
+    cfg.env.device = cfg.train.device
+
+    # Seeding
+    torch.manual_seed(cfg.seed)
+
+    # Sampling
+    cfg.env.vmas_envs = cfg.collector.frames_per_batch // cfg.env.max_steps
+    cfg.collector.total_frames = cfg.collector.frames_per_batch * cfg.collector.n_iters
+    cfg.buffer.memory_size = cfg.collector.frames_per_batch
+
+    # Create env and env_test
+    env = VmasEnv(
+        scenario=cfg.env.scenario_name,
+        num_envs=cfg.env.vmas_envs,
+        continuous_actions=False,
+        # COMALoss (like its helper functions add_action_without_self /
+        # add_masked_joint_action) operates on one-hot actions, so the env
+        # must expose a OneHot action spec rather than VmasEnv's default
+        # Categorical (index-encoded) one.
+        categorical_actions=False,
+        max_steps=cfg.env.max_steps,
+        device=cfg.env.device,
+        seed=cfg.seed,
+        # Scenario kwargs
+        **cfg.env.scenario,
+    )
+    env = TransformedEnv(
+        env,
+        RewardSum(in_keys=[env.reward_key], out_keys=[("agents", "episode_reward")]),
+    )
+
+    env_test = VmasEnv(
+        scenario=cfg.env.scenario_name,
+        num_envs=cfg.eval.evaluation_episodes,
+        continuous_actions=False,
+        # COMALoss (like its helper functions add_action_without_self /
+        # add_masked_joint_action) operates on one-hot actions, so the env
+        # must expose a OneHot action spec rather than VmasEnv's default
+        # Categorical (index-encoded) one.
+        categorical_actions=False,
+        max_steps=cfg.env.max_steps,
+        device=cfg.env.device,
+        seed=cfg.seed,
+        # Scenario kwargs
+        **cfg.env.scenario,
+    )
+
+    n_actions = env.full_action_spec[env.action_key].space.n
+
+    # Policy: decentralised actor, one categorical distribution over
+    # `n_actions` per agent, conditioned only on that agent's own observation.
+    actor_net = MultiAgentMLP(
+        n_agent_inputs=env.observation_spec["agents", "observation"].shape[-1],
+        n_agent_outputs=n_actions,
+        n_agents=env.n_agents,
+        centralised=False,
+        share_params=cfg.model.shared_parameters,
+        device=cfg.train.device,
+        depth=2,
+        num_cells=256,
+        activation_class=nn.Tanh,
+    )
+    policy_module = TensorDictModule(
+        actor_net,
+        in_keys=[("agents", "observation")],
+        out_keys=[("agents", "logits")],
+    )
+    policy = ProbabilisticActor(
+        module=policy_module,
+        spec=env.full_action_spec_unbatched,
+        in_keys=[("agents", "logits")],
+        out_keys=[env.action_key],
+        distribution_class=OneHotCategorical,
+        return_log_prob=True,
+    )
+
+    # Critic: centralised through its inputs. Each agent's Q-value network
+    # conditions on its own observation and every other agent's action
+    # (`("agents", "action_without_self")`, written by
+    # `add_action_without_self`), and outputs one action value per possible
+    # action of the acting agent.
+    critic_net = MultiAgentMLP(
+        n_agent_inputs=env.observation_spec["agents", "observation"].shape[-1]
+        + (env.n_agents - 1) * n_actions,
+        n_agent_outputs=n_actions,
+        n_agents=env.n_agents,
+        centralised=False,
+        share_params=cfg.model.shared_parameters,
+        device=cfg.train.device,
+        depth=2,
+        num_cells=256,
+        activation_class=nn.Tanh,
+    )
+    qvalue_module = TensorDictModule(
+        critic_net,
+        in_keys=[("agents", "observation"), ("agents", "action_without_self")],
+        out_keys=[("agents", "action_value")],
+    )
+
+    collector = Collector(
+        env,
+        policy,
+        device=cfg.env.device,
+        storing_device=cfg.train.device,
+        frames_per_batch=cfg.collector.frames_per_batch,
+        total_frames=cfg.collector.total_frames,
+    )
+
+    replay_buffer = TensorDictReplayBuffer(
+        storage=LazyTensorStorage(cfg.buffer.memory_size, device=cfg.train.device),
+        sampler=SamplerWithoutReplacement(),
+        batch_size=cfg.train.minibatch_size,
+    )
+
+    # Loss
+    loss_module = COMALoss(
+        actor_network=policy,
+        qvalue_network=qvalue_module,
+        gamma=cfg.loss.gamma,
+        qvalue_loss_coef=cfg.loss.qvalue_loss_coef,
+        entropy_coef=cfg.loss.entropy_coef,
+        n_step=cfg.loss.n_step,
+        normalize_advantage=cfg.loss.normalize_advantage,
+    )
+    loss_module.set_keys(action=env.action_key)
+    target_net_updater = SoftUpdate(loss_module, eps=1 - cfg.loss.tau)
+
+    optim = torch.optim.Adam(loss_module.parameters(), cfg.train.lr)
+
+    # Logging
+    if cfg.logger.backend:
+        model_name = ("Het" if not cfg.model.shared_parameters else "") + "COMA"
+        logger = init_logging(cfg, model_name)
+
+    total_time = 0
+    total_frames = 0
+    sampling_start = time.time()
+    for i, tensordict_data in enumerate(collector):
+        torchrl_logger.info(f"\nIteration {i}")
+
+        sampling_time = time.time() - sampling_start
+
+        # VMAS reports a single team-shared done/terminated at the root; COMALoss
+        # expects a per-agent one, so we broadcast it onto the agent dimension.
+        tensordict_data.set(
+            ("next", "agents", "done"),
+            tensordict_data.get(("next", "done"))
+            .unsqueeze(-1)
+            .expand(tensordict_data.get_item_shape(("next", env.reward_key))),
+        )
+        tensordict_data.set(
+            ("next", "agents", "terminated"),
+            tensordict_data.get(("next", "terminated"))
+            .unsqueeze(-1)
+            .expand(tensordict_data.get_item_shape(("next", env.reward_key))),
+        )
+
+        # `compute_value_target` needs the rollout's time dimension intact
+        # (it bootstraps along it), so it must run before the batch is
+        # flattened into the replay buffer.
+        add_action_without_self(tensordict_data)
+        with torch.no_grad():
+            loss_module.compute_value_target(tensordict_data)
+
+        current_frames = tensordict_data.numel()
+        total_frames += current_frames
+        data_view = tensordict_data.reshape(-1)
+        replay_buffer.extend(data_view)
+
+        training_tds = []
+        training_start = time.time()
+        for _ in range(cfg.train.num_epochs):
+            for _ in range(cfg.collector.frames_per_batch // cfg.train.minibatch_size):
+                subdata = replay_buffer.sample()
+                loss_vals = loss_module(subdata)
+                training_tds.append(loss_vals.detach())
+
+                loss_value = (
+                    loss_vals["loss_actor"]
+                    + loss_vals["loss_qvalue"]
+                    + loss_vals["loss_entropy"]
+                )
+
+                loss_value.backward()
+
+                total_norm = torch.nn.utils.clip_grad_norm_(
+                    loss_module.parameters(), cfg.train.max_grad_norm
+                )
+                training_tds[-1].set("grad_norm", total_norm.mean())
+
+                optim.step()
+                optim.zero_grad()
+                target_net_updater.step()
+
+        collector.update_policy_weights_()
+
+        training_time = time.time() - training_start
+
+        iteration_time = sampling_time + training_time
+        total_time += iteration_time
+        training_tds = torch.stack(training_tds)
+
+        # More logs
+        if cfg.logger.backend:
+            log_training(
+                logger,
+                training_tds,
+                tensordict_data,
+                sampling_time,
+                training_time,
+                total_time,
+                i,
+                current_frames,
+                total_frames,
+                step=i,
+            )
+
+        if (
+            cfg.eval.evaluation_episodes > 0
+            and i % cfg.eval.evaluation_interval == 0
+            and cfg.logger.backend
+        ):
+            evaluation_start = time.time()
+            with torch.no_grad(), set_exploration_type(ExplorationType.DETERMINISTIC):
+                env_test.frames = []
+                rollouts = env_test.rollout(
+                    max_steps=cfg.env.max_steps,
+                    policy=policy,
+                    callback=rendering_callback,
+                    auto_cast_to_device=True,
+                    break_when_any_done=False,
+                    # We are running vectorized evaluation we do not want it to stop when just one env is done
+                )
+
+                evaluation_time = time.time() - evaluation_start
+
+                log_evaluation(logger, rollouts, env_test, evaluation_time, step=i)
+
+        if cfg.logger.backend == "wandb":
+            logger.experiment.log({}, commit=True)
+        sampling_start = time.time()
+    collector.shutdown()
+    if not env.is_closed:
+        env.close()
+    if not env_test.is_closed:
+        env_test.close()
+
+
+if __name__ == "__main__":
+    train()

--- a/sota-implementations/multiagent/coma.yaml
+++ b/sota-implementations/multiagent/coma.yaml
@@ -1,0 +1,48 @@
+seed: 0
+
+env:
+  max_steps: 100
+  scenario_name: "balance"
+  scenario:
+    n_agents: 3
+  device: ??? # These values will be populated dynamically
+  vmas_envs: ???
+
+model:
+  shared_parameters: True
+
+collector:
+  frames_per_batch: 60_000 # Frames sampled each sampling iteration
+  n_iters: 500 # Number of sampling/training iterations
+  total_frames: ???
+
+buffer:
+  memory_size: ???
+
+loss:
+  gamma: 0.9
+  qvalue_loss_coef: 0.5
+  entropy_coef: 0
+  n_step: 1
+  normalize_advantage: True
+  tau: 0.005 # For target net
+
+train:
+  num_epochs: 45  # optimization steps per batch of data collected
+  minibatch_size: 4096 # size of minibatches used in each epoch
+  lr: 5e-5
+  max_grad_norm: 40.0
+  device: ???
+
+eval:
+  evaluation_interval: 20
+  evaluation_episodes: 200
+
+logger:
+  backend: wandb # Delete to remove logging
+  project_name: null
+  group_name: null
+
+hydra:
+  job:
+    chdir: true

--- a/test/objectives/test_coma.py
+++ b/test/objectives/test_coma.py
@@ -232,3 +232,156 @@ def test_diagnostics_report_q_contrast_measures():
     torch.testing.assert_close(diag["target_contrast"], torch.tensor(1.0))
 
 
+def test_compute_value_target_bootstraps_along_time_only_rollout():
+    """A [T, n_agents, 1] rollout from an unbatched collector has no leading
+    batch dim: time must resolve to dim 0, not dim 1 (the agent dim), or the
+    bootstrap shift silently mixes agents together instead of time steps."""
+    loss = _make_loss(gamma=0.5)
+    actions = _one_hot([[0, 0], [1, 1], [2, 2]], n_actions=3)
+    tensordict = TensorDict(
+        {
+            ("agents", "observation"): torch.zeros(3, 2, 4),
+            ("agents", "action"): actions,
+            "next": {
+                "agents": {
+                    "reward": torch.zeros(3, 2, 1),
+                    "done": torch.tensor(
+                        [[[False], [False]], [[False], [False]], [[True], [True]]]
+                    ),
+                }
+            },
+        },
+        batch_size=[3],
+    )
+    add_action_without_self(tensordict)
+
+    loss.compute_value_target(tensordict)
+
+    expected = torch.tensor([[[1.0], [1.0]], [[2.0], [2.0]], [[0.0], [0.0]]])
+    torch.testing.assert_close(tensordict["value_target"], expected)
+
+
+def test_compute_value_target_marks_non_terminal_tail_as_invalid():
+    """A rollout window that simply ends (``done=False`` throughout, i.e. it
+    was truncated mid-episode rather than reaching a real terminal state) has
+    no known next transition beyond it. The zero-filled bootstrap there must
+    not be trusted as a real target, so the last ``n_step`` positions are
+    flagged invalid via ``shifted_valid`` instead of silently biasing the
+    return low."""
+    loss = _make_loss(gamma=0.5, n_step=1)
+    actions = _one_hot([[[0, 0], [1, 1], [2, 2]]], n_actions=3)
+    tensordict = TensorDict(
+        {
+            ("agents", "observation"): torch.zeros(1, 3, 2, 4),
+            ("agents", "action"): actions,
+            "next": {
+                "agents": {
+                    "reward": torch.zeros(1, 3, 2, 1),
+                    "done": torch.zeros(1, 3, 2, 1, dtype=torch.bool),
+                }
+            },
+        },
+        batch_size=[1, 3],
+    )
+    add_action_without_self(tensordict)
+
+    loss.compute_value_target(tensordict)
+
+    expected_valid = torch.tensor(
+        [[[[True], [True]], [[True], [True]], [[False], [False]]]]
+    )
+    torch.testing.assert_close(tensordict["shifted_valid"], expected_valid)
+
+
+def test_forward_excludes_shifted_invalid_positions_from_qvalue_loss():
+    """``compute_value_target``'s ``shifted_valid`` mask must be honored
+    automatically by ``forward`` (via ``LossModule._reduce_loss``): the
+    non-terminal tail's zero-filled target must not pull the qvalue loss even
+    though it is numerically way off."""
+    loss = _make_loss(gamma=0.5, qvalue_loss_coef=1.0, n_step=1)
+    actions = _one_hot([[0], [2]], n_actions=3)
+    tensordict = TensorDict(
+        {
+            ("agents", "observation"): torch.zeros(2, 1, 4),
+            ("agents", "action"): actions,
+            "next": {
+                "agents": {
+                    "reward": torch.zeros(2, 1, 1),
+                    "done": torch.zeros(2, 1, 1, dtype=torch.bool),
+                }
+            },
+        },
+        batch_size=[2],
+    )
+    add_action_without_self(tensordict)
+    loss.compute_value_target(tensordict)
+
+    loss_values = loss(tensordict)
+
+    # chosen_action_value = [1, 4]; value_target = [2, 0] (t1's target is the
+    # zero-filled, invalid one). Only t0's (1 - 2) ** 2 = 1 should count;
+    # t1's (4 - 0) ** 2 = 16 must be excluded by ``shifted_valid``.
+    torch.testing.assert_close(loss_values["loss_qvalue"], torch.tensor(1.0))
+
+
+def test_forward_excludes_positions_marked_by_collector_mask():
+    """``("collector", "mask")`` (written by a ``SliceSampler`` with
+    ``pad_output=True`` to flag padded steps) must be honored automatically as
+    well, independently of ``shifted_valid`` / ``compute_value_target``."""
+    loss = _make_loss(qvalue_loss_coef=1.0)
+    action = _one_hot([[0, 2]], n_actions=3)
+    tensordict = TensorDict(
+        {
+            ("agents", "observation"): torch.zeros(1, 2, 4),
+            ("agents", "action"): action,
+            "value_target": torch.tensor([[[2.0], [2.0]]]),
+            ("collector", "mask"): torch.tensor([[True, False]]),
+        },
+        batch_size=[1],
+    )
+    add_action_without_self(tensordict)
+
+    loss_values = loss(tensordict)
+
+    # chosen_action_value = [1, 4]; only the first (unmasked) position's
+    # (1 - 2) ** 2 = 1 counts. The second position's (4 - 2) ** 2 = 4 is
+    # excluded by the collector mask.
+    torch.testing.assert_close(loss_values["loss_qvalue"], torch.tensor(1.0))
+
+
+def test_compute_value_target_respects_flat_and_nested_reward_done_keys():
+    """Overriding ``reward``/``done`` via ``set_keys`` with a flat string (not
+    the default nested tuple) must not be shredded into a per-character tuple
+    such as ``("next", "r", "e", "w", "a", "r", "d")``."""
+    for reward_key, done_key in [
+        ("reward", "done"),
+        (("data", "reward"), ("data", "done")),
+    ]:
+        loss = _make_loss(gamma=0.5)
+        loss.set_keys(reward=reward_key, done=done_key)
+        actions = _one_hot([[[0, 0], [1, 1]]], n_actions=3)
+        tensordict = TensorDict(
+            {
+                ("agents", "observation"): torch.zeros(1, 2, 2, 4),
+                ("agents", "action"): actions,
+            },
+            batch_size=[1, 2],
+        )
+        tensordict.set(("next", reward_key), torch.zeros(1, 2, 2, 1))
+        tensordict.set(
+            ("next", done_key),
+            torch.tensor([[[[False], [False]], [[True], [True]]]]),
+        )
+        add_action_without_self(tensordict)
+
+        loss.compute_value_target(tensordict)
+
+        expected = torch.tensor([[[[1.0], [1.0]], [[0.0], [0.0]]]])
+        torch.testing.assert_close(tensordict["value_target"], expected)
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__, "-v"])
+

--- a/test/objectives/test_coma.py
+++ b/test/objectives/test_coma.py
@@ -204,6 +204,34 @@ def test_normalize_advantage_zero_centres_the_actor_signal():
     torch.testing.assert_close(norm_loss["loss_actor"], torch.tensor(0.0), atol=1e-5, rtol=0)
 
 
+def test_normalize_advantage_uses_effective_mask_with_population_std():
+    """Padded positions must not pollute the normalisation statistics, and a
+    single valid element must not produce NaN: Bessel's correction (the
+    default) divides by ``n - 1 == 0``, but the population estimator
+    (``correction=0``) used here does not."""
+    loss = _make_loss(normalize_advantage=True)
+    action = _one_hot([[0, 2]], n_actions=3)
+    tensordict = TensorDict(
+        {
+            ("agents", "observation"): torch.zeros(1, 2, 4),
+            ("agents", "action"): action,
+            "value_target": torch.zeros(1, 2, 1),
+            ("collector", "mask"): torch.tensor([[True, False]]),
+        },
+        batch_size=[1],
+    )
+    add_action_without_self(tensordict)
+
+    loss_values = loss(tensordict)
+
+    assert torch.isfinite(loss_values["loss_actor"])
+    # The only valid (unmasked) advantage is standardised against itself:
+    # its mean equals its own value, so it normalises to exactly 0.
+    torch.testing.assert_close(
+        loss_values["advantage"], torch.tensor(0.0), atol=1e-4, rtol=0
+    )
+
+
 def test_diagnostics_report_q_contrast_measures():
     """Flat-critic instrumentation: own-action spread, others-sensitivity,
     and empirical target contrast by chosen action."""
@@ -290,6 +318,44 @@ def test_compute_value_target_marks_non_terminal_tail_as_invalid():
     expected_valid = torch.tensor(
         [[[[True], [True]], [[True], [True]], [[False], [False]]]]
     )
+    torch.testing.assert_close(tensordict["shifted_valid"], expected_valid)
+
+
+def test_compute_value_target_invalidates_bootstrap_across_reset_boundary():
+    """``done=True`` with ``terminated=False`` (a truncation) still means row
+    ``t + 1`` is a *different*, unrelated episode -- an auto-reset collector
+    writes its first step right there. Shifting that row's chosen-action
+    value in as the bootstrap silently mixes two trajectories, and must not
+    happen regardless of ``terminated``; the truncated row itself is then
+    invalid (no real bootstrap is available for it)."""
+    loss = _make_loss(gamma=0.5, n_step=1)
+    actions = _one_hot([[0], [2]], n_actions=3)
+    tensordict = TensorDict(
+        {
+            ("agents", "observation"): torch.zeros(2, 1, 4),
+            ("agents", "action"): actions,
+            "next": {
+                "agents": {
+                    "reward": torch.tensor([[[0.5]], [[1.0]]]),
+                    "done": torch.tensor([[[True]], [[False]]]),
+                    "terminated": torch.zeros(2, 1, 1, dtype=torch.bool),
+                }
+            },
+        },
+        batch_size=[2],
+    )
+    add_action_without_self(tensordict)
+
+    loss.compute_value_target(tensordict)
+
+    # chosen_action_value = [1, 4] (actions 0 and 2 under FixedActionValue).
+    # Without the fix, the truncated row's target picks up the next
+    # (unrelated) episode's action value: 0.5 + 0.5 * 4 = 2.5 instead of 0.5.
+    expected = torch.tensor([[[0.5]], [[1.0]]])
+    torch.testing.assert_close(tensordict["value_target"], expected)
+    # Neither row is trustworthy: row 0 is a truncation (no real bootstrap
+    # available), row 1 is the non-terminated tail of the window.
+    expected_valid = torch.tensor([[[False]], [[False]]])
     torch.testing.assert_close(tensordict["shifted_valid"], expected_valid)
 
 

--- a/test/objectives/test_coma.py
+++ b/test/objectives/test_coma.py
@@ -28,7 +28,7 @@ def _one_hot(index, n_actions=3):
 
 
 def _make_loss(
-    gamma=0.5, qvalue_loss_coef=0.5, entropy_coef=0.0, n_step=1, normalize_advantage=False, clip_epsilon=None
+    gamma=0.5, qvalue_loss_coef=0.5, entropy_coef=0.0, n_step=1, normalize_advantage=False,
 ):
     obs_dim = 4
     n_actions = 3
@@ -60,7 +60,6 @@ def _make_loss(
         entropy_coef=entropy_coef,
         n_step=n_step,
         normalize_advantage=normalize_advantage,
-        clip_epsilon=clip_epsilon,
     )
 
 
@@ -233,34 +232,3 @@ def test_diagnostics_report_q_contrast_measures():
     torch.testing.assert_close(diag["target_contrast"], torch.tensor(1.0))
 
 
-def test_clipped_loss_uses_frozen_old_advantage_and_clips_ratio():
-    """PPO-COMA: A frozen on stored pi_old logits; ratio vs stored log-probs;
-    min(unclipped, clipped) freezes over-drifted samples, keeps corrections."""
-    loss = _make_loss(clip_epsilon=0.2)
-    action = _one_hot([[0, 2]], n_actions=3)
-    tensordict = TensorDict(
-        {
-            ("agents", "observation"): torch.zeros(1, 2, 4),
-            ("agents", "action"): action,
-            ("agents", "logits"): torch.zeros(1, 2, 3),  # stored pi_old: uniform
-            ("agents", "sample_log_prob"): torch.full((1, 2), 0.5).log(),
-            "value_target": torch.zeros(1, 2, 1),
-        },
-        batch_size=[1],
-    )
-    add_action_without_self(tensordict)
-
-    loss.compute_counterfactual_advantage(tensordict)
-    # baseline under uniform pi_old = mean([1,2,4]) = 7/3 -> A = [1-7/3, 4-7/3]
-    expected_advantage = torch.tensor([[[-4.0 / 3.0], [5.0 / 3.0]]])
-    torch.testing.assert_close(tensordict.get(("agents", "advantage_old")), expected_advantage)
-
-    out = loss(tensordict)
-
-    # current policy uniform (1/3) vs stored 0.5 -> ratio 2/3, outside [0.8, 1.2]
-    torch.testing.assert_close(out["ratio_mean"], torch.tensor(2.0 / 3.0))
-    torch.testing.assert_close(out["clip_fraction"], torch.tensor(1.0))
-    # agent1 (A<0, already drifted far in A's direction): clipped branch -> 0.8*(-4/3)
-    # agent2 (A>0, drifted the wrong way): unclipped branch stays -> (2/3)*(5/3)
-    expected_loss = -((0.8 * (-4.0 / 3.0) + (2.0 / 3.0) * (5.0 / 3.0)) / 2.0)
-    torch.testing.assert_close(out["loss_actor"], torch.tensor(expected_loss))

--- a/test/objectives/test_coma.py
+++ b/test/objectives/test_coma.py
@@ -1,0 +1,266 @@
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+from torch import nn
+from torchrl.modules import OneHotCategorical, ProbabilisticActor
+
+from torchrl.objectives.multiagent import COMALoss
+
+from torchrl.objectives.multiagent.coma import (
+    add_action_without_self,
+    add_joint_observation,
+    add_masked_joint_action,
+)
+
+
+class FixedActionValue(nn.Module):
+    def __init__(self, values: torch.Tensor):
+        super().__init__()
+        self.values = nn.Parameter(values.clone())
+
+    def forward(self, observation, action_without_self):
+        del action_without_self
+        return self.values.expand(*observation.shape[:-1], -1)
+
+
+def _one_hot(index, n_actions=3):
+    return torch.nn.functional.one_hot(torch.as_tensor(index), n_actions).to(torch.float)
+
+
+def _make_loss(
+    gamma=0.5, qvalue_loss_coef=0.5, entropy_coef=0.0, n_step=1, normalize_advantage=False, clip_epsilon=None
+):
+    obs_dim = 4
+    n_actions = 3
+    actor_net = nn.Linear(obs_dim, n_actions)
+    nn.init.zeros_(actor_net.weight)
+    nn.init.zeros_(actor_net.bias)
+    actor_module = TensorDictModule(
+        actor_net,
+        in_keys=[("agents", "observation")],
+        out_keys=[("agents", "logits")],
+    )
+    actor = ProbabilisticActor(
+        module=actor_module,
+        in_keys=[("agents", "logits")],
+        out_keys=[("agents", "action")],
+        distribution_class=OneHotCategorical,
+        return_log_prob=True,
+    )
+    qvalue_module = TensorDictModule(
+        FixedActionValue(torch.tensor([1.0, 2.0, 4.0])),
+        in_keys=[("agents", "observation"), ("agents", "action_without_self")],
+        out_keys=[("agents", "action_value")],
+    )
+    return COMALoss(
+        actor_network=actor,
+        qvalue_network=qvalue_module,
+        gamma=gamma,
+        qvalue_loss_coef=qvalue_loss_coef,
+        entropy_coef=entropy_coef,
+        n_step=n_step,
+        normalize_advantage=normalize_advantage,
+        clip_epsilon=clip_epsilon,
+    )
+
+
+def test_add_action_without_self_flattens_other_agents_actions():
+    action = _one_hot([[0, 1, 2]], n_actions=3)
+    tensordict = TensorDict({("agents", "action"): action}, batch_size=[1])
+
+    add_action_without_self(tensordict)
+
+    expected = torch.tensor(
+        [
+            [
+                [0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+                [1.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+                [1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            ]
+        ]
+    )
+    torch.testing.assert_close(tensordict.get(("agents", "action_without_self")), expected)
+
+
+def test_coma_loss_uses_counterfactual_baseline_and_qvalue_target():
+    loss = _make_loss(qvalue_loss_coef=0.25, entropy_coef=0.0)
+    action = _one_hot([[0, 2]], n_actions=3)
+    tensordict = TensorDict(
+        {
+            ("agents", "observation"): torch.zeros(1, 2, 4),
+            ("agents", "action"): action,
+            "value_target": torch.zeros(1, 2, 1),
+        },
+        batch_size=[1],
+    )
+    add_action_without_self(tensordict)
+
+    loss_values = loss(tensordict)
+
+    expected_advantage = torch.tensor([1.0, 4.0]).mean() - torch.tensor([1.0, 2.0, 4.0]).mean()
+    expected_qvalue_loss = ((torch.tensor([1.0, 4.0]) ** 2).mean()) * 0.25
+    torch.testing.assert_close(loss_values["advantage"], expected_advantage)
+    torch.testing.assert_close(loss_values["loss_qvalue"], expected_qvalue_loss)
+    assert set(loss.out_keys).issubset(set(loss_values.keys()))
+
+
+def test_compute_value_target_bootstraps_along_time_dimension():
+    loss = _make_loss(gamma=0.5)
+    actions = _one_hot([[[0, 0], [1, 1], [2, 2]]], n_actions=3)
+    tensordict = TensorDict(
+        {
+            ("agents", "observation"): torch.zeros(1, 3, 2, 4),
+            ("agents", "action"): actions,
+            "next": {
+                "agents": {
+                    "reward": torch.zeros(1, 3, 2, 1),
+                    "done": torch.tensor([[[[False], [False]], [[False], [False]], [[True], [True]]]]),
+                }
+            },
+        },
+        batch_size=[1, 3],
+    )
+    add_action_without_self(tensordict)
+
+    loss.compute_value_target(tensordict)
+
+    expected = torch.tensor([[[[1.0], [1.0]], [[2.0], [2.0]], [[0.0], [0.0]]]])
+    torch.testing.assert_close(tensordict["value_target"], expected)
+
+
+def test_compute_value_target_supports_nstep_returns():
+    """n_step=2 accumulates two rewards then bootstraps, stopping at done."""
+    loss = _make_loss(gamma=0.5, n_step=2)
+    actions = _one_hot([[[0, 0], [1, 1], [2, 2]]], n_actions=3)
+    tensordict = TensorDict(
+        {
+            ("agents", "observation"): torch.zeros(1, 3, 2, 4),
+            ("agents", "action"): actions,
+            "next": {
+                "agents": {
+                    "reward": torch.ones(1, 3, 2, 1),
+                    "done": torch.tensor([[[[False], [False]], [[False], [False]], [[True], [True]]]]),
+                }
+            },
+        },
+        batch_size=[1, 3],
+    )
+    add_action_without_self(tensordict)
+
+    loss.compute_value_target(tensordict)
+
+    # G2(t0) = r0 + g*r1 + g^2*Q(t2) = 1 + 0.5 + 0.25*4 = 2.5
+    # G2(t1) = r1 + g*r2 = 1.5 (done at t2 stops the bootstrap)
+    # G2(t2) = r2 = 1.0
+    expected = torch.tensor([[[[2.5], [2.5]], [[1.5], [1.5]], [[1.0], [1.0]]]])
+    torch.testing.assert_close(tensordict["value_target"], expected)
+
+
+def test_add_joint_observation_repeats_team_observation_per_agent():
+    observation = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]])
+    tensordict = TensorDict({("agents", "observation"): observation}, batch_size=[1])
+
+    add_joint_observation(tensordict)
+
+    expected = torch.tensor([[[1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0]]])
+    torch.testing.assert_close(tensordict.get(("agents", "joint_observation")), expected)
+
+
+def test_add_masked_joint_action_zeroes_own_action_block():
+    action = _one_hot([[0, 2]], n_actions=3)
+    tensordict = TensorDict({("agents", "action"): action}, batch_size=[1])
+
+    add_masked_joint_action(tensordict)
+
+    expected = torch.tensor(
+        [
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+                [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        ]
+    )
+    torch.testing.assert_close(tensordict.get(("agents", "masked_joint_action")), expected)
+
+
+def test_normalize_advantage_zero_centres_the_actor_signal():
+    """With a uniform policy, log-probs are constant, so the actor loss equals
+    -log(1/3) * mean(A); standardised advantages have zero mean, so the
+    normalized actor loss must vanish while the raw one does not."""
+    action = _one_hot([[0, 2]], n_actions=3)
+    data = {
+        ("agents", "observation"): torch.zeros(1, 2, 4),
+        ("agents", "action"): action,
+        "value_target": torch.zeros(1, 2, 1),
+    }
+    raw = TensorDict(dict(data), batch_size=[1])
+    add_action_without_self(raw)
+    norm = TensorDict(dict(data), batch_size=[1])
+    add_action_without_self(norm)
+
+    raw_loss = _make_loss(normalize_advantage=False)(raw)
+    norm_loss = _make_loss(normalize_advantage=True)(norm)
+
+    assert abs(raw_loss["loss_actor"].item()) > 1e-3
+    torch.testing.assert_close(norm_loss["loss_actor"], torch.tensor(0.0), atol=1e-5, rtol=0)
+
+
+def test_diagnostics_report_q_contrast_measures():
+    """Flat-critic instrumentation: own-action spread, others-sensitivity,
+    and empirical target contrast by chosen action."""
+    loss = _make_loss()
+    action = _one_hot([[0, 2]], n_actions=3)
+    tensordict = TensorDict(
+        {
+            ("agents", "observation"): torch.zeros(1, 2, 4),
+            ("agents", "action"): action,
+            ("agents", "logits"): torch.zeros(1, 2, 3),
+            "value_target": torch.tensor([[[0.5], [2.5]]]),
+        },
+        batch_size=[1],
+    )
+    add_action_without_self(tensordict)
+
+    diag = loss.diagnostics(tensordict)
+
+    # FixedActionValue outputs [1, 2, 4] for every input:
+    # population std of [1, 2, 4] = sqrt(14/9)
+    expected_spread = torch.tensor([1.0, 2.0, 4.0]).std(correction=0)
+    torch.testing.assert_close(diag["action_value_spread"], expected_spread.expand(1, 2))
+    # the fixed critic ignores other agents' actions entirely
+    torch.testing.assert_close(diag["others_sensitivity"], torch.zeros(1, 2))
+    # targets grouped by chosen action: {action0: 0.5, action2: 2.5} -> pop std 1.0
+    torch.testing.assert_close(diag["target_contrast"], torch.tensor(1.0))
+
+
+def test_clipped_loss_uses_frozen_old_advantage_and_clips_ratio():
+    """PPO-COMA: A frozen on stored pi_old logits; ratio vs stored log-probs;
+    min(unclipped, clipped) freezes over-drifted samples, keeps corrections."""
+    loss = _make_loss(clip_epsilon=0.2)
+    action = _one_hot([[0, 2]], n_actions=3)
+    tensordict = TensorDict(
+        {
+            ("agents", "observation"): torch.zeros(1, 2, 4),
+            ("agents", "action"): action,
+            ("agents", "logits"): torch.zeros(1, 2, 3),  # stored pi_old: uniform
+            ("agents", "sample_log_prob"): torch.full((1, 2), 0.5).log(),
+            "value_target": torch.zeros(1, 2, 1),
+        },
+        batch_size=[1],
+    )
+    add_action_without_self(tensordict)
+
+    loss.compute_counterfactual_advantage(tensordict)
+    # baseline under uniform pi_old = mean([1,2,4]) = 7/3 -> A = [1-7/3, 4-7/3]
+    expected_advantage = torch.tensor([[[-4.0 / 3.0], [5.0 / 3.0]]])
+    torch.testing.assert_close(tensordict.get(("agents", "advantage_old")), expected_advantage)
+
+    out = loss(tensordict)
+
+    # current policy uniform (1/3) vs stored 0.5 -> ratio 2/3, outside [0.8, 1.2]
+    torch.testing.assert_close(out["ratio_mean"], torch.tensor(2.0 / 3.0))
+    torch.testing.assert_close(out["clip_fraction"], torch.tensor(1.0))
+    # agent1 (A<0, already drifted far in A's direction): clipped branch -> 0.8*(-4/3)
+    # agent2 (A>0, drifted the wrong way): unclipped branch stays -> (2/3)*(5/3)
+    expected_loss = -((0.8 * (-4.0 / 3.0) + (2.0 / 3.0) * (5.0 / 3.0)) / 2.0)
+    torch.testing.assert_close(out["loss_actor"], torch.tensor(expected_loss))

--- a/torchrl/objectives/__init__.py
+++ b/torchrl/objectives/__init__.py
@@ -32,7 +32,7 @@ from torchrl.objectives.dreamer_v3 import (
 )
 from torchrl.objectives.gail import GAILLoss
 from torchrl.objectives.iql import DiscreteIQLLoss, IQLLoss
-from torchrl.objectives.multiagent import IPPOLoss, MAPPOLoss, QMixerLoss
+from torchrl.objectives.multiagent import COMALoss, IPPOLoss, MAPPOLoss, QMixerLoss
 from torchrl.objectives.pilco import ExponentialQuadraticCost
 from torchrl.objectives.ppo import ClipPPOLoss, KLPENPPOLoss, PPOLoss
 from torchrl.objectives.redq import REDQLoss
@@ -63,6 +63,7 @@ __all__ = [
     "CQLLoss",
     "DiffusionBCLoss",
     "ClipPPOLoss",
+    "COMALoss",
     "CrossQLoss",
     "DDPGLoss",
     "DQNLoss",

--- a/torchrl/objectives/multiagent/__init__.py
+++ b/torchrl/objectives/multiagent/__init__.py
@@ -5,5 +5,6 @@
 
 from .mappo import IPPOLoss, MAPPOLoss
 from .qmixer import QMixerLoss
+from .coma import COMALoss
 
-__all__ = ["IPPOLoss", "MAPPOLoss", "QMixerLoss"]
+__all__ = ["IPPOLoss", "MAPPOLoss", "QMixerLoss", "COMALoss"]

--- a/torchrl/objectives/multiagent/coma.py
+++ b/torchrl/objectives/multiagent/coma.py
@@ -24,8 +24,6 @@ class COMALoss(LossModule):
         action_value: NestedKey = ("agents", "action_value")
         chosen_action_value: NestedKey = ("agents", "chosen_action_value")
         logits: NestedKey = ("agents", "logits")
-        sample_log_prob: NestedKey = ("agents", "sample_log_prob")
-        advantage_old: NestedKey = ("agents", "advantage_old")
         reward: NestedKey = ("agents", "reward")
         done: NestedKey = ("agents", "done")
         terminated: NestedKey = ("agents", "terminated")
@@ -60,13 +58,10 @@ class COMALoss(LossModule):
         entropy_coef: float = 0.0,
         n_step: int = 1,
         normalize_advantage: bool = False,
-        clip_epsilon: float | None = None,
     ) -> None:
         super().__init__()
         if n_step < 1:
             raise ValueError(f"n_step must be >= 1, got {n_step}.")
-        if clip_epsilon is not None and not 0.0 < clip_epsilon < 1.0:
-            raise ValueError(f"clip_epsilon must be in (0, 1), got {clip_epsilon}.")
         self.convert_to_functional(actor_network, "actor_network")
         self.convert_to_functional(qvalue_network, "qvalue_network", create_target_params=True)
         self.gamma = gamma
@@ -74,7 +69,6 @@ class COMALoss(LossModule):
         self.entropy_coef = entropy_coef
         self.n_step = n_step
         self.normalize_advantage = normalize_advantage
-        self.clip_epsilon = clip_epsilon
 
     def forward(self, tensordict: TensorDictBase) -> TensorDict:
         td_copy = tensordict.clone(False)
@@ -84,37 +78,17 @@ class COMALoss(LossModule):
             self.qvalue_network(td_copy)
 
         chosen_action_value = self._chosen_action_value(td_copy)
-        if self.clip_epsilon is not None:
-            # PPO-COMA: the advantage was computed once per batch against the
-            # collection policy (pi_old) and frozen; see
-            # compute_counterfactual_advantage. Anchoring A and the ratio on
-            # the same pi_old is what makes the clipped surrogate coherent.
-            if self.tensor_keys.advantage_old not in tensordict.keys(True):
-                raise KeyError(
-                    "clip_epsilon is set: call compute_counterfactual_advantage on the batch before the update passes."
-                )
-            advantage = tensordict.get(self.tensor_keys.advantage_old).detach()
-        else:
-            advantage = self._counterfactual_advantage(td_copy, chosen_action_value).detach()
+
+        advantage = self._counterfactual_advantage(td_copy, chosen_action_value).detach()
+
         if self.normalize_advantage:
             # MAPPO-style per-batch standardisation: same counterfactual
             # advantage, rescaled so the actor step size is batch-invariant.
             advantage = (advantage - advantage.mean()) / advantage.std().clamp_min(1e-6)
 
         log_prob = dist.log_prob(td_copy.get(self.tensor_keys.action))
-        extra_outputs: dict[str, torch.Tensor] = {}
-        if self.clip_epsilon is not None:
-            old_log_prob = tensordict.get(self.tensor_keys.sample_log_prob).detach()
-            ratio = (log_prob - old_log_prob.reshape(log_prob.shape)).exp()
-            flat_advantage = advantage.squeeze(-1)
-            unclipped = ratio * flat_advantage
-            clipped = ratio.clamp(1.0 - self.clip_epsilon, 1.0 + self.clip_epsilon) * flat_advantage
-            loss_actor = -torch.min(unclipped, clipped).mean()
-            outside = (ratio < 1.0 - self.clip_epsilon) | (ratio > 1.0 + self.clip_epsilon)
-            extra_outputs["ratio_mean"] = ratio.detach().mean()
-            extra_outputs["clip_fraction"] = outside.float().mean()
-        else:
-            loss_actor = -(log_prob * advantage.squeeze(-1)).mean()
+
+        loss_actor = -(log_prob * advantage.squeeze(-1)).mean()
 
         target_value = td_copy.get(self.tensor_keys.value_target)
         loss_qvalue = F.mse_loss(chosen_action_value, target_value) * self.qvalue_loss_coef
@@ -131,7 +105,6 @@ class COMALoss(LossModule):
                 "pred_value": chosen_action_value.detach().mean(),
                 "target_value": target_value.detach().mean(),
                 "advantage": advantage.detach().mean(),
-                **extra_outputs,
             },
             batch_size=[],
         )
@@ -173,22 +146,7 @@ class COMALoss(LossModule):
         tensordict.set(self.tensor_keys.value_target, value_target.detach())
         return tensordict
 
-    def compute_counterfactual_advantage(self, tensordict: TensorDictBase) -> TensorDictBase:
-        """Write the frozen counterfactual advantage of the collection policy.
 
-        PPO-style anchoring: the baseline is computed from the *stored*
-        collection-time logits (pi_old) — the actor is deliberately not run
-        here — and the result is written once per batch under
-        ``advantage_old`` so that every reuse epoch optimises the same fixed
-        coefficient, coherent with the importance ratio's anchor.
-        """
-        td_copy = tensordict.clone(False)
-        with self.qvalue_network_params.to_module(self.qvalue_network):
-            self.qvalue_network(td_copy)
-        chosen_action_value = self._chosen_action_value(td_copy)
-        advantage = self._counterfactual_advantage(td_copy, chosen_action_value)
-        tensordict.set(self.tensor_keys.advantage_old, advantage.detach())
-        return tensordict
 
     def diagnostics(self, tensordict: TensorDictBase) -> dict[str, torch.Tensor]:
         """Return unreduced COMA quantities for trainer-side observability.

--- a/torchrl/objectives/multiagent/coma.py
+++ b/torchrl/objectives/multiagent/coma.py
@@ -245,7 +245,12 @@ class COMALoss(LossModule):
         if self.normalize_advantage:
             # MAPPO-style per-batch standardisation: same counterfactual
             # advantage, rescaled so the actor step size is batch-invariant.
-            advantage = (advantage - advantage.mean()) / advantage.std().clamp_min(1e-6)
+            # Restricted to the effective loss mask so padded/invalid
+            # transitions don't skew the statistics; population std
+            # (correction=0) avoids NaN when a single valid element remains,
+            # which Bessel's correction (the default) divides by zero.
+            adv_mean, adv_std = self._advantage_norm_stats(tensordict, advantage)
+            advantage = (advantage - adv_mean) / adv_std.clamp_min(1e-6)
 
         log_prob = dist.log_prob(td_copy.get(self.tensor_keys.action))
 
@@ -290,10 +295,10 @@ class COMALoss(LossModule):
     ) -> TensorDictBase:
         """Write the n-step Q-value target before flattening rollout data.
 
-        Targets follow the recursion ``G_k(t) = r(t) + gamma * (1 -
-        terminated(t)) * G_{k-1}(t+1)`` with ``G_0`` the target-network
-        chosen-action Q-values, applied ``n_step`` times along the rollout's
-        time dimension. The time dimension is resolved via
+        Targets follow the recursion ``G_k(t) = r(t) + gamma * (1 - done(t))
+        * G_{k-1}(t+1)`` with ``G_0`` the target-network chosen-action
+        Q-values, applied ``n_step`` times along the rollout's time
+        dimension. The time dimension is resolved via
         :func:`~torchrl.objectives.multiagent.coma._resolve_time_dim` (the
         dimension named ``"time"`` if any, otherwise the last batch
         dimension), so a ``[T]`` rollout from an unbatched collector, a ``[B,
@@ -301,19 +306,23 @@ class COMALoss(LossModule):
         shift the correct axis. ``n_step=1`` is the TD(0) target;
         ``n_step=10`` matches EPyMARL's ``q_nstep: 10`` within episodes.
 
-        Bootstrapping is gated on ``terminated`` rather than ``done``: a
-        ``done`` flag raised by truncation (time-limit, or the sampled window
-        simply ending mid-episode) must not zero the return, since the
-        trajectory continues past the sampled window. But that also means the
-        true bootstrap value at those positions -- the target Q at the real
-        next transition -- can fall outside the rollout handed to this
-        method. Rather than fabricate one from a zero-filled shift, this
-        writes a ``"shifted_valid"`` mask (picked up automatically by
+        The shift itself is gated on ``done``, not ``terminated``: whenever a
+        rollout ends -- whether by real termination or by truncation --
+        row ``t + 1`` in the same window is a fresh, unrelated episode (an
+        auto-reset collector writes its first step right after), so reusing
+        its chosen-action Q-value as the bootstrap for row ``t`` would silently
+        mix the two trajectories. ``terminated`` only decides *why* the
+        bootstrap is missing there: for a true terminal state it is
+        legitimately zero (an absorbing state has no future value), so the
+        row is valid as-is; for a truncation (``done`` but not ``terminated``)
+        the real bootstrap -- the target Q at the actual next transition --
+        is simply not available in this window, and rather than fabricate one,
+        this writes a ``"shifted_valid"`` mask (picked up automatically by
         :meth:`~torchrl.objectives.common.LossModule._reduce_loss`, see
         :data:`~torchrl.objectives.common.AUTO_LOSS_MASK_KEYS`) that excludes
-        the tail transitions -- up to ``n_step`` of them at every
-        non-terminated rollout end -- whose target would otherwise be
-        silently biased low.
+        it -- along with the tail transitions at a non-terminated rollout end,
+        up to ``n_step`` of them -- from the loss instead of silently biasing
+        the target.
         """
         if params is None:
             params = self.target_qvalue_network_params
@@ -329,19 +338,22 @@ class COMALoss(LossModule):
         time_dim = _resolve_time_dim(tensordict)
 
         reward = tensordict.get(("next", self.tensor_keys.reward))
-        done = tensordict.get(("next", self.tensor_keys.done)).to(chosen_action_value.dtype)
+        done = tensordict.get(("next", self.tensor_keys.done)).to(torch.bool)
         terminated = tensordict.get(
             ("next", self.tensor_keys.terminated), default=done
-        ).to(chosen_action_value.dtype)
-        not_terminated = 1.0 - terminated
+        ).to(torch.bool)
+        not_done = (~done).to(chosen_action_value.dtype)
 
         value_target = chosen_action_value
-        valid = torch.ones_like(terminated, dtype=torch.bool)
+        valid = torch.ones_like(done, dtype=torch.bool)
         for _ in range(self.n_step):
             next_value = _shift_time(value_target, time_dim, fill_value=0.0)
             next_valid = _shift_time(valid, time_dim, fill_value=False)
-            value_target = reward + self.gamma * not_terminated * next_value
-            valid = terminated.to(torch.bool) | next_valid
+            value_target = reward + self.gamma * not_done * next_value
+            # terminated: always valid, the zeroed bootstrap above is correct.
+            # truncated: never valid, no real bootstrap is available.
+            # otherwise: valid iff the shifted-in value itself was.
+            valid = terminated | (~done & next_valid)
 
         tensordict.set(self.tensor_keys.value_target, value_target.detach())
         tensordict.set("shifted_valid", valid)
@@ -414,6 +426,26 @@ class COMALoss(LossModule):
         action_value = tensordict.get(self.tensor_keys.action_value)
         counterfactual_baseline = (action_prob * action_value).sum(dim=-1, keepdim=True)
         return chosen_action_value - counterfactual_baseline
+
+    def _advantage_norm_stats(
+        self, tensordict: TensorDictBase, advantage: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Mean/std of ``advantage``, restricted to the effective loss mask.
+
+        Padded or otherwise invalid positions (``("collector", "mask")``,
+        ``"shifted_valid")``) must not skew the normalisation statistics.
+        ``correction=0`` (population std) avoids ``NaN`` when a single valid
+        element remains, which the default Bessel's correction divides by
+        zero.
+        """
+        mask = None
+        for mask_key in self._loss_mask_keys():
+            tensordict_mask = tensordict.get(mask_key, default=None)
+            if tensordict_mask is not None:
+                tensordict_mask = self._expand_loss_mask(tensordict_mask, advantage)
+                mask = tensordict_mask if mask is None else mask & tensordict_mask
+        valid_advantage = advantage[mask] if mask is not None else advantage
+        return valid_advantage.mean(), valid_advantage.std(correction=0)
 
 
 def add_action_without_self(tensordict: TensorDictBase) -> TensorDictBase:

--- a/torchrl/objectives/multiagent/coma.py
+++ b/torchrl/objectives/multiagent/coma.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+from tensordict import TensorDict, TensorDictBase, TensorDictParams
+from tensordict.nn import TensorDictModule
+from tensordict.utils import NestedKey
+from torchrl.objectives.common import LossModule
+
+
+class COMALoss(LossModule):
+    """Counterfactual multi-agent policy-gradient loss.
+
+    The actor is decentralised. The Q-value network is centralised through its
+    inputs and must emit one action value per agent action under
+    ``("agents", "action_value")``.
+    """
+
+    @dataclass
+    class _AcceptedKeys:
+        action: NestedKey = ("agents", "action")
+        action_value: NestedKey = ("agents", "action_value")
+        chosen_action_value: NestedKey = ("agents", "chosen_action_value")
+        logits: NestedKey = ("agents", "logits")
+        sample_log_prob: NestedKey = ("agents", "sample_log_prob")
+        advantage_old: NestedKey = ("agents", "advantage_old")
+        reward: NestedKey = ("agents", "reward")
+        done: NestedKey = ("agents", "done")
+        terminated: NestedKey = ("agents", "terminated")
+        value_target: NestedKey = "value_target"
+
+    tensor_keys: _AcceptedKeys
+    default_keys = _AcceptedKeys
+    out_keys = [
+        "loss_actor",
+        "loss_qvalue",
+        "loss_entropy",
+        "entropy",
+        "pred_value",
+        "target_value",
+        "advantage",
+    ]
+
+    actor_network: TensorDictModule
+    actor_network_params: TensorDictParams
+    target_actor_network_params: TensorDictParams
+    qvalue_network: TensorDictModule
+    qvalue_network_params: TensorDictParams
+    target_qvalue_network_params: TensorDictParams
+
+    def __init__(
+        self,
+        actor_network: TensorDictModule,
+        qvalue_network: TensorDictModule,
+        *,
+        gamma: float = 0.99,
+        qvalue_loss_coef: float = 0.5,
+        entropy_coef: float = 0.0,
+        n_step: int = 1,
+        normalize_advantage: bool = False,
+        clip_epsilon: float | None = None,
+    ) -> None:
+        super().__init__()
+        if n_step < 1:
+            raise ValueError(f"n_step must be >= 1, got {n_step}.")
+        if clip_epsilon is not None and not 0.0 < clip_epsilon < 1.0:
+            raise ValueError(f"clip_epsilon must be in (0, 1), got {clip_epsilon}.")
+        self.convert_to_functional(actor_network, "actor_network")
+        self.convert_to_functional(qvalue_network, "qvalue_network", create_target_params=True)
+        self.gamma = gamma
+        self.qvalue_loss_coef = qvalue_loss_coef
+        self.entropy_coef = entropy_coef
+        self.n_step = n_step
+        self.normalize_advantage = normalize_advantage
+        self.clip_epsilon = clip_epsilon
+
+    def forward(self, tensordict: TensorDictBase) -> TensorDict:
+        td_copy = tensordict.clone(False)
+
+        dist = self.actor_network.get_dist(td_copy)
+        with self.qvalue_network_params.to_module(self.qvalue_network):
+            self.qvalue_network(td_copy)
+
+        chosen_action_value = self._chosen_action_value(td_copy)
+        if self.clip_epsilon is not None:
+            # PPO-COMA: the advantage was computed once per batch against the
+            # collection policy (pi_old) and frozen; see
+            # compute_counterfactual_advantage. Anchoring A and the ratio on
+            # the same pi_old is what makes the clipped surrogate coherent.
+            if self.tensor_keys.advantage_old not in tensordict.keys(True):
+                raise KeyError(
+                    "clip_epsilon is set: call compute_counterfactual_advantage on the batch before the update passes."
+                )
+            advantage = tensordict.get(self.tensor_keys.advantage_old).detach()
+        else:
+            advantage = self._counterfactual_advantage(td_copy, chosen_action_value).detach()
+        if self.normalize_advantage:
+            # MAPPO-style per-batch standardisation: same counterfactual
+            # advantage, rescaled so the actor step size is batch-invariant.
+            advantage = (advantage - advantage.mean()) / advantage.std().clamp_min(1e-6)
+
+        log_prob = dist.log_prob(td_copy.get(self.tensor_keys.action))
+        extra_outputs: dict[str, torch.Tensor] = {}
+        if self.clip_epsilon is not None:
+            old_log_prob = tensordict.get(self.tensor_keys.sample_log_prob).detach()
+            ratio = (log_prob - old_log_prob.reshape(log_prob.shape)).exp()
+            flat_advantage = advantage.squeeze(-1)
+            unclipped = ratio * flat_advantage
+            clipped = ratio.clamp(1.0 - self.clip_epsilon, 1.0 + self.clip_epsilon) * flat_advantage
+            loss_actor = -torch.min(unclipped, clipped).mean()
+            outside = (ratio < 1.0 - self.clip_epsilon) | (ratio > 1.0 + self.clip_epsilon)
+            extra_outputs["ratio_mean"] = ratio.detach().mean()
+            extra_outputs["clip_fraction"] = outside.float().mean()
+        else:
+            loss_actor = -(log_prob * advantage.squeeze(-1)).mean()
+
+        target_value = td_copy.get(self.tensor_keys.value_target)
+        loss_qvalue = F.mse_loss(chosen_action_value, target_value) * self.qvalue_loss_coef
+
+        entropy = dist.entropy().mean()
+        loss_entropy = -self.entropy_coef * entropy
+
+        return TensorDict(
+            {
+                "loss_actor": loss_actor,
+                "loss_qvalue": loss_qvalue,
+                "loss_entropy": loss_entropy,
+                "entropy": entropy.detach(),
+                "pred_value": chosen_action_value.detach().mean(),
+                "target_value": target_value.detach().mean(),
+                "advantage": advantage.detach().mean(),
+                **extra_outputs,
+            },
+            batch_size=[],
+        )
+
+    def compute_value_target(
+        self,
+        tensordict: TensorDictBase,
+        params: TensorDictParams | None = None,
+    ) -> TensorDictBase:
+        """Write the n-step Q-value target before flattening rollout data.
+
+        The collector batch is expected to keep time in dimension 1. Targets
+        follow the recursion G_k(t) = r(t) + gamma * (1 - done(t)) * G_{k-1}(t+1)
+        with G_0 = target-network chosen-action Q-values, applied ``n_step``
+        times. ``n_step=1`` is the TD(0) target; ``n_step=10`` matches
+        EPyMARL's ``q_nstep: 10`` within episodes. Values past the end of the
+        batch are treated as zero, so the last ``n_step`` transitions of a
+        batch are biased low unless they end an episode.
+        """
+        if params is None:
+            params = self.target_qvalue_network_params
+
+        td_copy = tensordict.clone(False)
+        with params.to_module(self.qvalue_network):
+            self.qvalue_network(td_copy)
+
+        chosen_action_value = self._chosen_action_value(td_copy)
+        if chosen_action_value.ndim < 2:
+            raise ValueError("COMALoss.compute_value_target expects an environment/time rollout batch.")
+
+        reward = tensordict.get(("next",) + tuple(self.tensor_keys.reward))
+        done = tensordict.get(("next",) + tuple(self.tensor_keys.done)).to(chosen_action_value.dtype)
+
+        value_target = chosen_action_value
+        for _ in range(self.n_step):
+            next_value = torch.zeros_like(value_target)
+            next_value[:, :-1] = value_target[:, 1:]
+            value_target = reward + self.gamma * (1.0 - done) * next_value
+        tensordict.set(self.tensor_keys.value_target, value_target.detach())
+        return tensordict
+
+    def compute_counterfactual_advantage(self, tensordict: TensorDictBase) -> TensorDictBase:
+        """Write the frozen counterfactual advantage of the collection policy.
+
+        PPO-style anchoring: the baseline is computed from the *stored*
+        collection-time logits (pi_old) — the actor is deliberately not run
+        here — and the result is written once per batch under
+        ``advantage_old`` so that every reuse epoch optimises the same fixed
+        coefficient, coherent with the importance ratio's anchor.
+        """
+        td_copy = tensordict.clone(False)
+        with self.qvalue_network_params.to_module(self.qvalue_network):
+            self.qvalue_network(td_copy)
+        chosen_action_value = self._chosen_action_value(td_copy)
+        advantage = self._counterfactual_advantage(td_copy, chosen_action_value)
+        tensordict.set(self.tensor_keys.advantage_old, advantage.detach())
+        return tensordict
+
+    def diagnostics(self, tensordict: TensorDictBase) -> dict[str, torch.Tensor]:
+        """Return unreduced COMA quantities for trainer-side observability.
+
+        This deliberately leaves aggregation to a reusable trainer hook: callers
+        can log global summaries, per-agent values, or custom histograms without
+        changing the loss used for optimization.
+        """
+        td_copy = tensordict.clone(False)
+        with self.qvalue_network_params.to_module(self.qvalue_network):
+            self.qvalue_network(td_copy)
+        chosen_action_value = self._chosen_action_value(td_copy)
+        advantage = self._counterfactual_advantage(td_copy, chosen_action_value)
+        target_value = td_copy.get(self.tensor_keys.value_target)
+
+        # Q-contrast measures (flat-critic hypothesis): how differentiated are
+        # the Q outputs across own actions, how sensitive are they to the other
+        # agents' actions, and how contrasted are the empirical targets by
+        # chosen action (the reference the critic should match).
+        action_value = td_copy.get(self.tensor_keys.action_value)
+        action_value_spread = action_value.std(dim=-1, correction=0)
+
+        permuted = tensordict.clone(False)
+        for key in (("agents", "masked_joint_action"), ("agents", "action_without_self")):
+            if key in permuted.keys(True):
+                values = permuted.get(key)
+                index = torch.randperm(values.shape[0], device=values.device)
+                permuted.set(key, values[index])
+        with self.qvalue_network_params.to_module(self.qvalue_network):
+            self.qvalue_network(permuted)
+        others_sensitivity = (permuted.get(self.tensor_keys.action_value) - action_value).abs().mean(dim=-1)
+
+        flat_action = tensordict.get(self.tensor_keys.action).to(torch.float).reshape(-1, action_value.shape[-1])
+        flat_target = target_value.reshape(-1, 1)
+        counts = flat_action.sum(dim=0)
+        means = (flat_action * flat_target).sum(dim=0) / counts.clamp_min(1.0)
+        taken = counts > 0
+        if int(taken.sum()) > 1:
+            target_contrast = means[taken].std(correction=0)
+        else:
+            target_contrast = torch.zeros((), device=action_value.device)
+
+        return {
+            "advantage": advantage.detach(),
+            "td_error": (target_value - chosen_action_value).detach(),
+            "chosen_action_value": chosen_action_value.detach(),
+            "target_value": target_value.detach(),
+            "action_value_spread": action_value_spread.detach(),
+            "others_sensitivity": others_sensitivity.detach(),
+            "target_contrast": target_contrast.detach(),
+        }
+
+    def _chosen_action_value(self, tensordict: TensorDictBase) -> torch.Tensor:
+        action = tensordict.get(self.tensor_keys.action).to(torch.float)
+        action_value = tensordict.get(self.tensor_keys.action_value)
+        chosen_action_value = (action * action_value).sum(dim=-1, keepdim=True)
+        tensordict.set(self.tensor_keys.chosen_action_value, chosen_action_value)
+        return chosen_action_value
+
+    def _counterfactual_advantage(
+        self,
+        tensordict: TensorDictBase,
+        chosen_action_value: torch.Tensor,
+    ) -> torch.Tensor:
+        action_prob = tensordict.get(self.tensor_keys.logits).softmax(dim=-1)
+        action_value = tensordict.get(self.tensor_keys.action_value)
+        counterfactual_baseline = (action_prob * action_value).sum(dim=-1, keepdim=True)
+        return chosen_action_value - counterfactual_baseline
+
+
+def add_action_without_self(tensordict: TensorDictBase) -> TensorDictBase:
+    """Write each agent's other-agent actions under ``action_without_self``."""
+    if ("agents", "action") not in tensordict.keys(True):
+        return tensordict
+
+    actions = tensordict.get(("agents", "action"))
+    n_agents = actions.shape[-2]
+    if n_agents == 1:
+        tensordict.set(("agents", "action_without_self"), actions.new_empty(*actions.shape[:-2], 1, 0))
+        return tensordict
+
+    other_actions = torch.stack(
+        [torch.cat([actions[..., :i, :], actions[..., i + 1 :, :]], dim=-2) for i in range(n_agents)],
+        dim=-3,
+    )
+    tensordict.set(("agents", "action_without_self"), other_actions.reshape(*actions.shape[:-2], n_agents, -1))
+    return tensordict
+
+
+def add_joint_observation(tensordict: TensorDictBase) -> TensorDictBase:
+    """Write the concatenated team observation under ``joint_observation``.
+
+    Every agent row receives the same concatenation of all agents'
+    observations. This mirrors EPyMARL's Gym wrapper, where the global state
+    fed to the COMA critic is the concatenation of individual observations.
+    """
+    observation = tensordict.get(("agents", "observation"))
+    n_agents = observation.shape[-2]
+    joint = observation.reshape(*observation.shape[:-2], 1, -1).expand(
+        *observation.shape[:-2], n_agents, n_agents * observation.shape[-1]
+    )
+    tensordict.set(("agents", "joint_observation"), joint.clone())
+    return tensordict
+
+
+def add_masked_joint_action(tensordict: TensorDictBase) -> TensorDictBase:
+    """Write the joint one-hot action with each agent's own slot zeroed.
+
+    This mirrors EPyMARL's ``COMACritic._build_inputs``: agent ``i`` sees the
+    full joint action vector of size ``n_agents * n_actions`` with the block
+    corresponding to its own action masked to zero, so its Q-values are not
+    conditioned on the action being marginalised by the counterfactual
+    baseline.
+    """
+    actions = tensordict.get(("agents", "action")).to(torch.float)
+    n_agents, n_actions = actions.shape[-2], actions.shape[-1]
+    joint = actions.reshape(*actions.shape[:-2], 1, -1).expand(*actions.shape[:-2], n_agents, n_agents * n_actions)
+    own_block = torch.eye(n_agents, device=actions.device, dtype=actions.dtype).repeat_interleave(n_actions, dim=1)
+    tensordict.set(("agents", "masked_joint_action"), joint * (1.0 - own_block))
+    return tensordict

--- a/torchrl/objectives/multiagent/coma.py
+++ b/torchrl/objectives/multiagent/coma.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -10,12 +15,164 @@ from tensordict.utils import NestedKey
 from torchrl.objectives.common import LossModule
 
 
-class COMALoss(LossModule):
-    """Counterfactual multi-agent policy-gradient loss.
+def _resolve_time_dim(tensordict: TensorDictBase) -> int:
+    """Locate the rollout time dimension of ``tensordict``.
 
-    The actor is decentralised. The Q-value network is centralised through its
-    inputs and must emit one action value per agent action under
-    ``("agents", "action_value")``.
+    Mirrors :meth:`~torchrl.objectives.value.ValueEstimatorBase._get_time_dim`:
+    the dimension named ``"time"`` if the tensordict carries dimension names,
+    otherwise the last batch dimension. A ``[T]`` rollout from an unbatched
+    collector therefore resolves to dimension 0 and a ``[B, T]`` batch to
+    dimension 1, rather than assuming time is always dimension 1.
+    """
+    if tensordict._has_names():
+        for i, name in enumerate(tensordict.names):
+            if name == "time":
+                return i
+    return tensordict.ndim - 1
+
+
+def _shift_time(
+    tensor: torch.Tensor, time_dim: int, fill_value: float | bool = 0
+) -> torch.Tensor:
+    """Advance ``tensor`` by one step along ``time_dim``, backfilling the freed slot with ``fill_value``."""
+    length = tensor.shape[time_dim]
+    shifted = torch.full_like(tensor, fill_value)
+    if length > 1:
+        shifted.narrow(time_dim, 0, length - 1).copy_(
+            tensor.narrow(time_dim, 1, length - 1)
+        )
+    return shifted
+
+
+class COMALoss(LossModule):
+    """Counterfactual multi-agent policy-gradient loss (COMA).
+
+    Reference: Foerster, J. et al. *Counterfactual Multi-Agent Policy
+    Gradients.* AAAI 2018. https://arxiv.org/abs/1705.08926
+
+    COMA trains a *decentralised* actor (each agent's policy conditions only
+    on its own local observation) together with a *centralised* critic. The
+    critic is centralised through its inputs -- it typically conditions on
+    the joint observation/action of the team (see :func:`add_joint_observation`,
+    :func:`add_masked_joint_action` and :func:`add_action_without_self`) --
+    and must emit one action value per possible action of the acting agent,
+    under ``("agents", "action_value")``.
+
+    The actor's learning signal is a counterfactual advantage: for agent
+    ``i``, the critic's own output is marginalised over agent ``i``'s action
+    (holding every other agent's action fixed) to obtain a baseline. The
+    advantage, ``chosen_action_value - baseline``, credits agent ``i`` only
+    for the part of the outcome its own action choice affected, addressing
+    the multi-agent credit-assignment problem without factorising the joint
+    reward.
+
+    The critic is trained with an n-step TD target bootstrapped from a target
+    network; see :meth:`compute_value_target`.
+
+    Args:
+        actor_network (ProbabilisticTensorDictSequential): the decentralised
+            policy. Conditions on ``("agents", "observation")`` and outputs a
+            distribution over ``("agents", "action")`` -- build with e.g.
+            :class:`~torchrl.modules.ProbabilisticActor` wrapping a
+            :class:`~torchrl.modules.MultiAgentMLP` with
+            ``centralized=False``.
+        qvalue_network (TensorDictModule): the centralised critic. Must
+            output one action value per possible action of the acting agent
+            under ``("agents", "action_value")``.
+
+    Keyword Args:
+        gamma (float, optional): discount factor. Defaults to ``0.99``.
+        qvalue_loss_coef (float, optional): weight of the critic's MSE loss
+            relative to the actor loss. Defaults to ``0.5``.
+        entropy_coef (float, optional): weight of the entropy bonus.
+            Defaults to ``0.0`` (no bonus).
+        n_step (int, optional): number of Bellman backups applied by
+            :meth:`compute_value_target`. ``1`` is the TD(0) target; higher
+            values match EPyMARL's ``q_nstep``. Defaults to ``1``.
+        normalize_advantage (bool, optional): if ``True``, standardises the
+            counterfactual advantage (zero mean, unit variance) across the
+            batch before scaling the actor loss, MAPPO-style. Defaults to
+            ``False``.
+        reduction (str, optional): the reduction to apply to the elementwise
+            actor / critic / entropy losses. Can be one of ``"mean"``,
+            ``"sum"`` or ``"none"``. Padded or otherwise invalid positions
+            (``("collector", "mask")``, or the ``"shifted_valid"`` mask
+            written by :meth:`compute_value_target`) are excluded from the
+            reduction automatically. Defaults to ``"mean"``.
+
+    Examples:
+        >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from tensordict.nn import TensorDictModule
+        >>> from torch import nn
+        >>> from torchrl.modules import OneHotCategorical, ProbabilisticActor
+        >>> from torchrl.objectives.multiagent import COMALoss
+        >>> from torchrl.objectives.multiagent.coma import add_action_without_self
+        >>> n_agents, obs_dim, n_actions = 3, 4, 5
+        >>> actor_net = TensorDictModule(
+        ...     nn.Linear(obs_dim, n_actions),
+        ...     in_keys=[("agents", "observation")],
+        ...     out_keys=[("agents", "logits")],
+        ... )
+        >>> actor = ProbabilisticActor(
+        ...     module=actor_net,
+        ...     in_keys=[("agents", "logits")],
+        ...     out_keys=[("agents", "action")],
+        ...     distribution_class=OneHotCategorical,
+        ...     return_log_prob=True,
+        ... )
+        >>> class Critic(nn.Module):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.net = nn.Linear(obs_dim + (n_agents - 1) * n_actions, n_actions)
+        ...     def forward(self, observation, action_without_self):
+        ...         return self.net(torch.cat([observation, action_without_self], dim=-1))
+        >>> qvalue_net = TensorDictModule(
+        ...     Critic(),
+        ...     in_keys=[("agents", "observation"), ("agents", "action_without_self")],
+        ...     out_keys=[("agents", "action_value")],
+        ... )
+        >>> loss = COMALoss(actor, qvalue_net)
+        >>> batch, time = 2, 4
+        >>> tensordict = TensorDict(
+        ...     {
+        ...         "agents": TensorDict(
+        ...             {"observation": torch.zeros(batch, time, n_agents, obs_dim)},
+        ...             [batch, time, n_agents],
+        ...         ),
+        ...         "next": TensorDict(
+        ...             {
+        ...                 "agents": TensorDict(
+        ...                     {
+        ...                         "reward": torch.zeros(batch, time, n_agents, 1),
+        ...                         "done": torch.zeros(batch, time, n_agents, 1, dtype=torch.bool),
+        ...                         "terminated": torch.zeros(batch, time, n_agents, 1, dtype=torch.bool),
+        ...                     },
+        ...                     [batch, time, n_agents],
+        ...                 ),
+        ...             },
+        ...             [batch, time],
+        ...         ),
+        ...     },
+        ...     [batch, time],
+        ... )
+        >>> with torch.no_grad():
+        ...     _ = actor(tensordict)
+        >>> _ = add_action_without_self(tensordict)
+        >>> _ = loss.compute_value_target(tensordict)
+        >>> loss(tensordict)
+        TensorDict(
+            fields={
+                advantage: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False),
+                entropy: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False),
+                loss_actor: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False),
+                loss_entropy: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False),
+                loss_qvalue: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False),
+                pred_value: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False),
+                target_value: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False)},
+            batch_size=torch.Size([]),
+            device=None,
+            is_shared=False)
     """
 
     @dataclass
@@ -58,10 +215,13 @@ class COMALoss(LossModule):
         entropy_coef: float = 0.0,
         n_step: int = 1,
         normalize_advantage: bool = False,
+        reduction: str | None = None,
     ) -> None:
         super().__init__()
         if n_step < 1:
             raise ValueError(f"n_step must be >= 1, got {n_step}.")
+        if reduction is None:
+            reduction = "mean"
         self.convert_to_functional(actor_network, "actor_network")
         self.convert_to_functional(qvalue_network, "qvalue_network", create_target_params=True)
         self.gamma = gamma
@@ -69,6 +229,7 @@ class COMALoss(LossModule):
         self.entropy_coef = entropy_coef
         self.n_step = n_step
         self.normalize_advantage = normalize_advantage
+        self.reduction = reduction
 
     def forward(self, tensordict: TensorDictBase) -> TensorDict:
         td_copy = tensordict.clone(False)
@@ -88,23 +249,36 @@ class COMALoss(LossModule):
 
         log_prob = dist.log_prob(td_copy.get(self.tensor_keys.action))
 
-        loss_actor = -(log_prob * advantage.squeeze(-1)).mean()
+        actor_loss = -log_prob * advantage.squeeze(-1)
+        loss_actor = self._reduce_loss(actor_loss, tensordict=tensordict)
 
         target_value = td_copy.get(self.tensor_keys.value_target)
-        loss_qvalue = F.mse_loss(chosen_action_value, target_value) * self.qvalue_loss_coef
+        qvalue_loss = (
+            F.mse_loss(chosen_action_value, target_value, reduction="none")
+            * self.qvalue_loss_coef
+        )
+        loss_qvalue = self._reduce_loss(qvalue_loss, tensordict=tensordict)
 
-        entropy = dist.entropy().mean()
-        loss_entropy = -self.entropy_coef * entropy
+        entropy = dist.entropy()
+        loss_entropy = self._reduce_loss(
+            -self.entropy_coef * entropy, tensordict=tensordict
+        )
 
         return TensorDict(
             {
                 "loss_actor": loss_actor,
                 "loss_qvalue": loss_qvalue,
                 "loss_entropy": loss_entropy,
-                "entropy": entropy.detach(),
-                "pred_value": chosen_action_value.detach().mean(),
-                "target_value": target_value.detach().mean(),
-                "advantage": advantage.detach().mean(),
+                "entropy": self._reduce_loss(entropy.detach(), tensordict=tensordict),
+                "pred_value": self._reduce_loss(
+                    chosen_action_value.detach().squeeze(-1), tensordict=tensordict
+                ),
+                "target_value": self._reduce_loss(
+                    target_value.detach().squeeze(-1), tensordict=tensordict
+                ),
+                "advantage": self._reduce_loss(
+                    advantage.detach().squeeze(-1), tensordict=tensordict
+                ),
             },
             batch_size=[],
         )
@@ -116,13 +290,30 @@ class COMALoss(LossModule):
     ) -> TensorDictBase:
         """Write the n-step Q-value target before flattening rollout data.
 
-        The collector batch is expected to keep time in dimension 1. Targets
-        follow the recursion G_k(t) = r(t) + gamma * (1 - done(t)) * G_{k-1}(t+1)
-        with G_0 = target-network chosen-action Q-values, applied ``n_step``
-        times. ``n_step=1`` is the TD(0) target; ``n_step=10`` matches
-        EPyMARL's ``q_nstep: 10`` within episodes. Values past the end of the
-        batch are treated as zero, so the last ``n_step`` transitions of a
-        batch are biased low unless they end an episode.
+        Targets follow the recursion ``G_k(t) = r(t) + gamma * (1 -
+        terminated(t)) * G_{k-1}(t+1)`` with ``G_0`` the target-network
+        chosen-action Q-values, applied ``n_step`` times along the rollout's
+        time dimension. The time dimension is resolved via
+        :func:`~torchrl.objectives.multiagent.coma._resolve_time_dim` (the
+        dimension named ``"time"`` if any, otherwise the last batch
+        dimension), so a ``[T]`` rollout from an unbatched collector, a ``[B,
+        T]`` batch, and inputs with additional leading batch dimensions all
+        shift the correct axis. ``n_step=1`` is the TD(0) target;
+        ``n_step=10`` matches EPyMARL's ``q_nstep: 10`` within episodes.
+
+        Bootstrapping is gated on ``terminated`` rather than ``done``: a
+        ``done`` flag raised by truncation (time-limit, or the sampled window
+        simply ending mid-episode) must not zero the return, since the
+        trajectory continues past the sampled window. But that also means the
+        true bootstrap value at those positions -- the target Q at the real
+        next transition -- can fall outside the rollout handed to this
+        method. Rather than fabricate one from a zero-filled shift, this
+        writes a ``"shifted_valid"`` mask (picked up automatically by
+        :meth:`~torchrl.objectives.common.LossModule._reduce_loss`, see
+        :data:`~torchrl.objectives.common.AUTO_LOSS_MASK_KEYS`) that excludes
+        the tail transitions -- up to ``n_step`` of them at every
+        non-terminated rollout end -- whose target would otherwise be
+        silently biased low.
         """
         if params is None:
             params = self.target_qvalue_network_params
@@ -135,18 +326,26 @@ class COMALoss(LossModule):
         if chosen_action_value.ndim < 2:
             raise ValueError("COMALoss.compute_value_target expects an environment/time rollout batch.")
 
-        reward = tensordict.get(("next",) + tuple(self.tensor_keys.reward))
-        done = tensordict.get(("next",) + tuple(self.tensor_keys.done)).to(chosen_action_value.dtype)
+        time_dim = _resolve_time_dim(tensordict)
+
+        reward = tensordict.get(("next", self.tensor_keys.reward))
+        done = tensordict.get(("next", self.tensor_keys.done)).to(chosen_action_value.dtype)
+        terminated = tensordict.get(
+            ("next", self.tensor_keys.terminated), default=done
+        ).to(chosen_action_value.dtype)
+        not_terminated = 1.0 - terminated
 
         value_target = chosen_action_value
+        valid = torch.ones_like(terminated, dtype=torch.bool)
         for _ in range(self.n_step):
-            next_value = torch.zeros_like(value_target)
-            next_value[:, :-1] = value_target[:, 1:]
-            value_target = reward + self.gamma * (1.0 - done) * next_value
+            next_value = _shift_time(value_target, time_dim, fill_value=0.0)
+            next_valid = _shift_time(valid, time_dim, fill_value=False)
+            value_target = reward + self.gamma * not_terminated * next_value
+            valid = terminated.to(torch.bool) | next_valid
+
         tensordict.set(self.tensor_keys.value_target, value_target.detach())
+        tensordict.set("shifted_valid", valid)
         return tensordict
-
-
 
     def diagnostics(self, tensordict: TensorDictBase) -> dict[str, torch.Tensor]:
         """Return unreduced COMA quantities for trainer-side observability.

--- a/tutorials/sphinx-tutorials/multiagent_coma.py
+++ b/tutorials/sphinx-tutorials/multiagent_coma.py
@@ -1,0 +1,504 @@
+"""
+Multi-Agent Reinforcement Learning (COMA) with TorchRL Tutorial
+================================================================
+**Author**: `The TorchRL team <https://github.com/pytorch/rl>`_
+
+.. seealso::
+   This tutorial builds on :doc:`/tutorials/multiagent_ppo`. It is
+   suggested but not mandatory to get familiar with that one first, since we
+   will skip over the multi-agent environment basics already covered there.
+
+This tutorial demonstrates how to use PyTorch and :py:mod:`torchrl` to train
+`COMA <https://arxiv.org/abs/1705.08926>`_ (Counterfactual Multi-Agent
+Policy Gradients), a MARL algorithm that tackles the **multi-agent credit
+assignment problem**: when the team only receives a single shared reward,
+how should each agent know whether its own action helped or hurt?
+
+COMA answers this with a *counterfactual baseline*: a centralised critic
+outputs one Q-value per possible action of the acting agent, and each
+agent's advantage is obtained by comparing the Q-value of the action it
+actually took against the *expected* Q-value it would have gotten had it
+acted according to its current policy instead, while every other agent's
+action is held fixed. This isolates the part of the outcome that agent's
+own choice is responsible for.
+
+In this tutorial, we will use the *Balance* environment from
+`VMAS <https://github.com/proroklab/VectorizedMultiAgentSimulator>`__, with
+its **discrete** action space (COMA, like the original paper, is designed
+for discrete actions).
+
+Key learnings:
+
+- How to build a decentralised actor paired with a centralised, per-action
+  critic for a discrete-action MARL problem;
+- How the counterfactual baseline is computed, and why it addresses credit
+  assignment;
+- How :meth:`~torchrl.objectives.multiagent.COMALoss.compute_value_target`
+  bootstraps an n-step Q-value target along the rollout's time dimension,
+  and how it flags rollout-boundary transitions that have no reliable
+  bootstrap so they are excluded from the loss automatically;
+- How to tie all of this into a full COMA training loop.
+
+"""
+
+######################################################################
+# If you are running this in Google Colab, make sure you install the following dependencies:
+#
+# .. code-block:: bash
+#
+#    !pip3 install torchrl
+#    !pip3 install vmas
+#    !pip3 install tqdm
+#
+# Like PPO, COMA is trained *on-policy*: at every iteration we collect a
+# batch of rollouts with the current policies, then immediately consume
+# them for a few epochs of gradient updates before collecting again.
+#
+# What is specific to COMA is the *critic*. Rather than estimating a state
+# value :math:`V(s)`, the critic estimates, for the acting agent :math:`i`,
+# one Q-value per possible action:
+# :math:`Q(s, u^{-i}, u^i)` for every :math:`u^i` in the action space, where
+# :math:`u^{-i}` are the actions of every other agent. The critic is
+# *centralised* in the sense that it conditions on information beyond agent
+# :math:`i`'s own observation (typically the other agents' actions or a
+# global state), but it is trained once per agent, not once per team, and
+# it outputs a value *per action* rather than a single scalar.
+#
+# Given this critic, the counterfactual advantage for agent :math:`i` is:
+#
+# .. math::
+#
+#    A^i(s, u) = Q(s, u^{-i}, u^i) - \sum_{u'^i} \pi^i(u'^i \mid s) \, Q(s, u^{-i}, u'^i)
+#
+# The first term is the Q-value of the action agent :math:`i` actually
+# took. The second term marginalises the critic's own output over agent
+# :math:`i`'s action under its current policy, holding every other agent's
+# action fixed -- this is the counterfactual baseline. Because it is
+# computed from the *same* critic call, no extra network evaluation is
+# needed, and because it is specific to agent :math:`i`, it isolates
+# exactly the part of the team's Q-value that agent :math:`i`'s own choice
+# affected.
+#
+# This tutorial is structured as follows:
+#
+# 1. We define a set of hyperparameters.
+#
+# 2. We create a vectorized, discrete-action multi-agent environment using
+#    TorchRL's wrapper for the VMAS simulator, and a helper transform that
+#    prepares the critic's other-agents-actions input.
+#
+# 3. We design the decentralised actor and the centralised, per-action
+#    critic.
+#
+# 4. We create the sampling collector and the replay buffer.
+#
+# 5. We run our training loop and analyse the results.
+#
+# Let's import our dependencies
+#
+
+# Torch
+import torch
+
+# Tensordict modules
+from tensordict.nn import set_composite_lp_aggregate, TensorDictModule
+from torch import multiprocessing
+
+# Data collection
+from torchrl.collectors import Collector
+from torchrl.data.replay_buffers import ReplayBuffer
+from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
+from torchrl.data.replay_buffers.storages import LazyTensorStorage
+
+# Env
+from torchrl.envs import RewardSum, TransformedEnv
+from torchrl.envs.libs.vmas import VmasEnv
+from torchrl.envs.utils import check_env_specs
+
+# Multi-agent network
+from torchrl.modules import MultiAgentMLP, OneHotCategorical, ProbabilisticActor
+
+# Loss
+from torchrl.objectives import SoftUpdate
+from torchrl.objectives.multiagent.coma import add_action_without_self, COMALoss
+
+# Utils
+torch.manual_seed(0)
+from matplotlib import pyplot as plt
+from tqdm import tqdm
+
+######################################################################
+# Define Hyperparameters
+# ----------------------
+#
+# We set the hyperparameters for our tutorial. Depending on the resources
+# available, one may choose to execute the policy and the simulator on GPU
+# or on another device. You can tune some of these values to adjust the
+# computational requirements.
+#
+
+# Devices
+is_fork = multiprocessing.get_start_method() == "fork"
+device = (
+    torch.device(0)
+    if torch.cuda.is_available() and not is_fork
+    else torch.device("cpu")
+)
+vmas_device = device  # The device where the simulator is run (VMAS can run on GPU)
+
+# Sampling
+frames_per_batch = 6_000  # Number of team frames collected per training iteration
+n_iters = 10  # Number of sampling and training iterations
+total_frames = frames_per_batch * n_iters
+
+# Training
+num_epochs = 30  # Number of optimization steps per training iteration
+minibatch_size = 400  # Size of the mini-batches in each optimization step
+lr = 5e-4  # Learning rate
+max_grad_norm = 1.0  # Maximum norm for the gradients
+
+# COMA
+gamma = 0.9  # discount factor
+n_step = 1  # number of Bellman backups applied by compute_value_target (TD(0) if 1)
+qvalue_loss_coef = 0.5  # weight of the critic's MSE loss relative to the actor loss
+entropy_eps = 1e-3  # coefficient of the entropy term in the COMA loss
+tau = 0.005  # soft-update rate for the target critic
+
+# disable log-prob aggregation
+set_composite_lp_aggregate(False).set()
+
+######################################################################
+# Environment
+# -----------
+#
+# We use the *Balance* VMAS scenario with its **discrete** action space
+# (``continuous_actions=False``): each agent picks one out of a small set of
+# discrete moves at every step. COMA -- like the original paper, which
+# targets StarCraft Multi-Agent Challenge -- assumes a discrete action
+# space, since the critic must enumerate every possible action of the
+# acting agent.
+#
+
+max_steps = 100  # Episode steps before done
+num_vmas_envs = frames_per_batch // max_steps
+scenario_name = "balance"
+n_agents = 3
+
+env = VmasEnv(
+    scenario=scenario_name,
+    num_envs=num_vmas_envs,
+    continuous_actions=False,
+    # COMALoss and its helpers (add_action_without_self, ...) operate on
+    # one-hot actions, so we need a OneHot action spec rather than VmasEnv's
+    # default Categorical (index-encoded) one.
+    categorical_actions=False,
+    max_steps=max_steps,
+    device=vmas_device,
+    n_agents=n_agents,
+)
+env = TransformedEnv(
+    env,
+    RewardSum(in_keys=[env.reward_key], out_keys=[("agents", "episode_reward")]),
+)
+check_env_specs(env)
+
+n_actions = env.full_action_spec[env.action_key].space.n
+print("number of discrete actions per agent:", n_actions)
+
+######################################################################
+# ``add_action_without_self``
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# COMA's critic is centralised through its *inputs*: alongside its own
+# observation, each agent's critic call also sees the *other* agents'
+# actions. :func:`~torchrl.objectives.multiagent.coma.add_action_without_self`
+# is a small tensordict transform that, given a joint one-hot action tensor
+# of shape ``(*B, n_agents, n_actions)``, writes for every agent the
+# flattened actions of every *other* agent under ``("agents",
+# "action_without_self")``, of shape
+# ``(*B, n_agents, (n_agents - 1) * n_actions)``.
+#
+# Let's see it in action on a random rollout:
+#
+rollout = env.rollout(3)
+add_action_without_self(rollout)
+print(
+    "action shape:",
+    rollout["agents", "action"].shape,
+    "-> action_without_self shape:",
+    rollout["agents", "action_without_self"].shape,
+)
+
+######################################################################
+# Policy
+# ------
+#
+# The actor is **decentralised**: each agent's policy outputs a categorical
+# distribution over its ``n_actions`` discrete moves, conditioned only on
+# its own observation.
+#
+
+share_parameters_policy = True
+
+actor_net = MultiAgentMLP(
+    n_agent_inputs=env.observation_spec["agents", "observation"].shape[-1],
+    n_agent_outputs=n_actions,
+    n_agents=env.n_agents,
+    centralised=False,  # decentralised: each agent acts from its own observation
+    share_params=share_parameters_policy,
+    device=device,
+    depth=2,
+    num_cells=256,
+    activation_class=torch.nn.Tanh,
+)
+policy_module = TensorDictModule(
+    actor_net,
+    in_keys=[("agents", "observation")],
+    out_keys=[("agents", "logits")],
+)
+policy = ProbabilisticActor(
+    module=policy_module,
+    spec=env.full_action_spec_unbatched,
+    in_keys=[("agents", "logits")],
+    out_keys=[env.action_key],
+    distribution_class=OneHotCategorical,
+    return_log_prob=True,
+)
+
+######################################################################
+# Critic network
+# --------------
+#
+# The critic conditions on the acting agent's own observation *and* the
+# other agents' actions (via ``action_without_self``), and outputs one
+# Q-value per possible action of the acting agent. Note that, unlike
+# MAPPO's critic, this is not "centralised" through a shared network across
+# agents -- :class:`~torchrl.modules.MultiAgentMLP` with ``centralised=False``
+# and ``share_params=True`` still gives every agent the same *weights*, but
+# each agent's Q-values are computed from its own observation plus the
+# other agents' actions, not from the concatenation of everyone's
+# observation.
+#
+
+share_parameters_critic = True
+
+critic_net = MultiAgentMLP(
+    n_agent_inputs=env.observation_spec["agents", "observation"].shape[-1]
+    + (env.n_agents - 1) * n_actions,
+    n_agent_outputs=n_actions,  # one Q-value per action of the acting agent
+    n_agents=env.n_agents,
+    centralised=False,
+    share_params=share_parameters_critic,
+    device=device,
+    depth=2,
+    num_cells=256,
+    activation_class=torch.nn.Tanh,
+)
+qvalue_module = TensorDictModule(
+    critic_net,
+    in_keys=[("agents", "observation"), ("agents", "action_without_self")],
+    out_keys=[("agents", "action_value")],
+)
+
+######################################################################
+# Let's try our policy and critic on the rollout we collected above (after
+# adding the ``action_without_self`` key, which the critic needs):
+#
+print("Running policy:", policy(env.reset()))
+print("Running qvalue:", qvalue_module(rollout))
+
+######################################################################
+# Data collector and replay buffer
+# ---------------------------------
+#
+# These are the same building blocks used across TorchRL's on-policy
+# algorithms; see :doc:`/tutorials/multiagent_ppo` for a more detailed
+# walkthrough.
+#
+collector = Collector(
+    env,
+    policy,
+    device=vmas_device,
+    storing_device=device,
+    frames_per_batch=frames_per_batch,
+    total_frames=total_frames,
+)
+
+replay_buffer = ReplayBuffer(
+    storage=LazyTensorStorage(frames_per_batch, device=device),
+    sampler=SamplerWithoutReplacement(),
+    batch_size=minibatch_size,
+)
+
+######################################################################
+# Loss function
+# -------------
+#
+# :class:`~torchrl.objectives.multiagent.COMALoss` needs both networks:
+# the actor to compute the log-probability and the counterfactual baseline,
+# and the critic to compute the chosen-action Q-value.
+#
+# A target critic is created automatically (COMA bootstraps its Q-value
+# target from a target network, just like DQN), so we also need a target
+# updater.
+#
+loss_module = COMALoss(
+    actor_network=policy,
+    qvalue_network=qvalue_module,
+    gamma=gamma,
+    qvalue_loss_coef=qvalue_loss_coef,
+    entropy_coef=entropy_eps,
+    n_step=n_step,
+)
+loss_module.set_keys(action=env.action_key)
+target_net_updater = SoftUpdate(loss_module, eps=1 - tau)
+
+optim = torch.optim.Adam(loss_module.parameters(), lr)
+
+######################################################################
+# Training loop
+# -------------
+#
+# The critical difference with a GAE-based loop (as in the PPO tutorial) is
+# :meth:`~torchrl.objectives.multiagent.COMALoss.compute_value_target`: it
+# must be called on the *freshly collected* rollout, before it is flattened
+# into the replay buffer, because it bootstraps the Q-value target along
+# the rollout's time dimension (``G_k(t) = r(t) + \gamma (1 - terminated(t))
+# \, G_{k-1}(t+1)``, applied ``n_step`` times). It also writes a
+# ``"shifted_valid"`` mask: transitions at the very end of a rollout window
+# that has not actually terminated have no real "next" data to bootstrap
+# from, so rather than silently biasing their target towards zero, they are
+# flagged invalid and automatically excluded from the loss (through
+# :meth:`~torchrl.objectives.common.LossModule._reduce_loss`).
+#
+# The steps are:
+#
+# * Collect data
+#     * Add ``action_without_self`` and compute the Q-value target
+#         * Loop over epochs
+#             * Loop over minibatches to compute loss values
+#                 * Back propagate
+#                 * Optimise
+#                 * Soft-update the target critic
+#             * Repeat
+#         * Repeat
+#     * Repeat
+# * Repeat
+#
+
+pbar = tqdm(total=n_iters, desc="episode_reward_mean = 0")
+
+episode_reward_mean_list = []
+for tensordict_data in collector:
+    # VMAS reports a single team-shared done/terminated at the root; COMALoss
+    # expects a per-agent one, so we broadcast it onto the agent dimension.
+    tensordict_data.set(
+        ("next", "agents", "done"),
+        tensordict_data.get(("next", "done"))
+        .unsqueeze(-1)
+        .expand(tensordict_data.get_item_shape(("next", env.reward_key))),
+    )
+    tensordict_data.set(
+        ("next", "agents", "terminated"),
+        tensordict_data.get(("next", "terminated"))
+        .unsqueeze(-1)
+        .expand(tensordict_data.get_item_shape(("next", env.reward_key))),
+    )
+
+    add_action_without_self(tensordict_data)
+    with torch.no_grad():
+        loss_module.compute_value_target(tensordict_data)
+
+    data_view = tensordict_data.reshape(-1)  # Flatten the batch size to shuffle data
+    replay_buffer.extend(data_view)
+
+    for _ in range(num_epochs):
+        for _ in range(frames_per_batch // minibatch_size):
+            subdata = replay_buffer.sample()
+            loss_vals = loss_module(subdata)
+
+            loss_value = (
+                loss_vals["loss_actor"]
+                + loss_vals["loss_qvalue"]
+                + loss_vals["loss_entropy"]
+            )
+
+            loss_value.backward()
+
+            torch.nn.utils.clip_grad_norm_(
+                loss_module.parameters(), max_grad_norm
+            )  # Optional
+
+            optim.step()
+            optim.zero_grad()
+            target_net_updater.step()
+
+    collector.update_policy_weights_()
+
+    # Logging
+    done = tensordict_data.get(("next", "agents", "done"))
+    episode_reward_mean = (
+        tensordict_data.get(("next", "agents", "episode_reward"))[done].mean().item()
+    )
+    episode_reward_mean_list.append(episode_reward_mean)
+    pbar.set_description(f"episode_reward_mean = {episode_reward_mean}", refresh=False)
+    pbar.update()
+
+######################################################################
+# Results
+# -------
+#
+# Let's plot the mean reward obtained per episode.
+#
+# To make training last longer, increase the ``n_iters`` hyperparameter.
+#
+plt.plot(episode_reward_mean_list)
+plt.xlabel("Training iterations")
+plt.ylabel("Reward")
+plt.title("Episode reward mean")
+plt.show()
+
+######################################################################
+# Render
+# ------
+#
+# If you are running this in a machine with GUI, you can render the trained policy by running:
+#
+# .. code-block:: python
+#
+#    with torch.no_grad():
+#       env.rollout(
+#           max_steps=max_steps,
+#           policy=policy,
+#           callback=lambda env, _: env.render(),
+#           auto_cast_to_device=True,
+#           break_when_any_done=False,
+#       )
+#
+
+######################################################################
+# Conclusion and next steps
+# --------------------------
+#
+# In this tutorial, we have seen:
+#
+# - How to build a decentralised actor and a centralised, per-action critic
+#   for a discrete-action MARL problem, using
+#   :func:`~torchrl.objectives.multiagent.coma.add_action_without_self` to
+#   feed the critic the other agents' actions;
+# - How the counterfactual baseline addresses multi-agent credit assignment
+#   without needing to factorise the joint reward;
+# - How :meth:`~torchrl.objectives.multiagent.COMALoss.compute_value_target`
+#   bootstraps along the rollout's time dimension and masks out rollout
+#   boundaries with no reliable bootstrap value;
+# - How to tie all of this into a full COMA training loop.
+#
+# You can check out all the TorchRL multi-agent implementations
+# (including COMA, MAPPO/IPPO, QMIX/VDN, MADDPG/IDDPG, and more) as
+# code-only Hydra scripts under ``sota-implementations/multiagent`` in the
+# GitHub repository.
+#
+# If you want to compare COMA against a state-value critic instead of a
+# per-action one, check out :doc:`/tutorials/multiagent_ppo` (MAPPO/IPPO)
+# and :class:`~torchrl.objectives.multiagent.QMixerLoss` (QMix/VDN).
+#

--- a/tutorials/sphinx-tutorials/multiagent_ppo.py
+++ b/tutorials/sphinx-tutorials/multiagent_ppo.py
@@ -787,8 +787,10 @@ plt.show()
 # These are code-only scripts of many popular MARL algorithms such as the ones seen in this tutorial,
 # QMIX, MADDPG, IQL, and many more!
 #
-# You can also check out our other multi-agent tutorial on how to train competitive
-# MADDPG/IDDPG in PettingZoo/VMAS with multiple agent groups: :doc:`/tutorials/multiagent_competitive_ddpg`.
+# You can also check out our other multi-agent tutorials: how to train competitive
+# MADDPG/IDDPG in PettingZoo/VMAS with multiple agent groups
+# (:doc:`/tutorials/multiagent_competitive_ddpg`), and how to address multi-agent
+# credit assignment with a counterfactual critic in COMA (:doc:`/tutorials/multiagent_coma`).
 #
 # If you are interested in creating or wrapping your own multi-agent environments in TorchRL,
 # you can check out the dedicated


### PR DESCRIPTION
## What

Adds a dedicated `COMALoss` objective for multi-agent reinforcement learning. The loss implements the COMA counterfactual baseline with a decentralised actor and a centralised Q-value network, including n-step Q-value targets and optional advantage normalisation.

## Contents

* `torchrl/objectives/multiagent/coma.py`: `COMALoss` implementation and helpers to construct the joint observation, joint action without the current agent, and masked joint action inputs used by the centralised critic.
* `torchrl/objectives/multiagent/__init__.py` and `torchrl/objectives/__init__.py`: expose `COMALoss`.
* `test/objectives/test_coma.py`: tests for the counterfactual baseline, Q-value targets, n-step returns, input construction helpers, advantage normalisation, and diagnostics.

## Tests

Ran:

`python -m pytest test/objectives/test_coma.py`

8 passed.
