### PR TITLE
[CI] Retry flaky-test artifact downloads

### DIFF
--- a/.github/scripts/analyze_flaky_tests.py
+++ b/.github/scripts/analyze_flaky_tests.py
@@ -131,7 +131,7 @@ def download_artifact(artifact_url: str, token: str) -> bytes | None:
         except requests.RequestException as error:
             if attempt == ARTIFACT_DOWNLOAD_ATTEMPTS - 1:
                 log(f"Warning: Failed to download artifact: {error}")
-                return None
+                raise
             delay = ARTIFACT_DOWNLOAD_BACKOFF_SECONDS * 2**attempt
             log(f"Warning: Artifact download failed; retrying in {delay}s: {error}")
             time.sleep(delay)

--- a/.github/scripts/analyze_flaky_tests.py
+++ b/.github/scripts/analyze_flaky_tests.py
@@ -53,6 +53,12 @@ MIN_EXECUTIONS = 3
 # Days to consider a test "newly flaky"
 NEW_FLAKY_DAYS = 7
 
+# Artifact downloads are redirected away from api.github.com and can fail
+# transiently on the runner even when the GitHub API itself is healthy.
+ARTIFACT_DOWNLOAD_ATTEMPTS = 3
+ARTIFACT_DOWNLOAD_BACKOFF_SECONDS = 2
+RETRYABLE_ARTIFACT_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
 
 # =============================================================================
 # GitHub API Helpers
@@ -117,15 +123,39 @@ def download_artifact(artifact_url: str, token: str) -> bytes | None:
         "X-GitHub-Api-Version": "2022-11-28",
     }
 
-    response = requests.get(
-        artifact_url, headers=headers, timeout=120, allow_redirects=True
-    )
+    for attempt in range(ARTIFACT_DOWNLOAD_ATTEMPTS):
+        try:
+            response = requests.get(
+                artifact_url, headers=headers, timeout=120, allow_redirects=True
+            )
+        except requests.RequestException as error:
+            if attempt == ARTIFACT_DOWNLOAD_ATTEMPTS - 1:
+                log(f"Warning: Failed to download artifact: {error}")
+                return None
+            delay = ARTIFACT_DOWNLOAD_BACKOFF_SECONDS * 2**attempt
+            log(f"Warning: Artifact download failed; retrying in {delay}s: {error}")
+            time.sleep(delay)
+            continue
 
-    if response.status_code != 200:
+        if response.status_code == 200:
+            return response.content
+
+        if (
+            response.status_code in RETRYABLE_ARTIFACT_STATUS_CODES
+            and attempt < ARTIFACT_DOWNLOAD_ATTEMPTS - 1
+        ):
+            delay = ARTIFACT_DOWNLOAD_BACKOFF_SECONDS * 2**attempt
+            log(
+                "Warning: Artifact download returned "
+                f"{response.status_code}; retrying in {delay}s"
+            )
+            time.sleep(delay)
+            continue
+
         log(f"Warning: Failed to download artifact ({response.status_code})")
         return None
 
-    return response.content
+    return None
 
 
 # =============================================================================

--- a/.github/scripts/analyze_flaky_tests.py
+++ b/.github/scripts/analyze_flaky_tests.py
@@ -24,6 +24,7 @@ import time
 import zipfile
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 
 import requests
@@ -115,6 +116,29 @@ def github_api_request(endpoint: str, token: str) -> dict | list | None:
     return response.json()
 
 
+def _retry_delay(response: requests.Response, fallback: float) -> float:
+    """Use the server cooldown for rate-limited responses when it is longer."""
+    if response.status_code != 429:
+        return fallback
+
+    retry_after = getattr(response, "headers", {}).get("Retry-After")
+    if not retry_after:
+        return fallback
+
+    try:
+        return max(fallback, float(retry_after))
+    except (TypeError, ValueError):
+        try:
+            retry_at = parsedate_to_datetime(retry_after)
+        except (TypeError, ValueError, IndexError, OverflowError):
+            log(f"Warning: Ignoring invalid Retry-After header: {retry_after!r}")
+            return fallback
+
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=timezone.utc)
+        return max(fallback, retry_at.timestamp() - time.time())
+
+
 def download_artifact(artifact_url: str, token: str) -> bytes | None:
     """Download an artifact zip file."""
     headers = {
@@ -145,9 +169,10 @@ def download_artifact(artifact_url: str, token: str) -> bytes | None:
             and attempt < ARTIFACT_DOWNLOAD_ATTEMPTS - 1
         ):
             delay = ARTIFACT_DOWNLOAD_BACKOFF_SECONDS * 2**attempt
+            delay = _retry_delay(response, delay)
             log(
                 "Warning: Artifact download returned "
-                f"{response.status_code}; retrying in {delay}s"
+                f"{response.status_code}; retrying in {delay:g}s"
             )
             time.sleep(delay)
             continue

--- a/.github/scripts/test_analyze_flaky_tests.py
+++ b/.github/scripts/test_analyze_flaky_tests.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import requests
+
+_SCRIPT_PATH = Path(__file__).with_name("analyze_flaky_tests.py")
+_SPEC = importlib.util.spec_from_file_location("analyze_flaky_tests", _SCRIPT_PATH)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+analyze = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(analyze)
+
+
+class _Response:
+    def __init__(self, status_code: int, content: bytes = b"") -> None:
+        self.status_code = status_code
+        self.content = content
+
+
+def test_download_artifact_retries_request_errors(monkeypatch):
+    responses = iter([_Response(200, b"artifact")])
+    sleeps: list[int] = []
+
+    def get(*args, **kwargs):
+        if not sleeps:
+            raise requests.ConnectionError("connection reset")
+        return next(responses)
+
+    monkeypatch.setattr(analyze.requests, "get", get)
+    monkeypatch.setattr(analyze.time, "sleep", sleeps.append)
+
+    assert (
+        analyze.download_artifact("https://example.test/artifact", "token")
+        == b"artifact"
+    )
+    assert sleeps == [2]
+
+
+def test_download_artifact_retries_transient_http_status(monkeypatch):
+    responses = iter([_Response(503), _Response(200, b"artifact")])
+    sleeps: list[int] = []
+
+    monkeypatch.setattr(
+        analyze.requests, "get", lambda *args, **kwargs: next(responses)
+    )
+    monkeypatch.setattr(analyze.time, "sleep", sleeps.append)
+
+    assert (
+        analyze.download_artifact("https://example.test/artifact", "token")
+        == b"artifact"
+    )
+    assert sleeps == [2]
+
+
+def test_download_artifact_does_not_retry_permanent_http_status(monkeypatch):
+    calls = 0
+
+    def get(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return _Response(404)
+
+    monkeypatch.setattr(analyze.requests, "get", get)
+    monkeypatch.setattr(analyze.time, "sleep", pytest.fail)
+
+    assert analyze.download_artifact("https://example.test/artifact", "token") is None
+    assert calls == 1

--- a/test/test_analyze_flaky_tests.py
+++ b/test/test_analyze_flaky_tests.py
@@ -37,6 +37,26 @@ def test_download_artifact_recovers_from_transient_failure(failure):
         )
 
 
+def test_download_artifact_honors_retry_after_header():
+    rate_limited = SimpleNamespace(
+        status_code=429,
+        headers={"Retry-After": "120"},
+        content=b"",
+    )
+    success = SimpleNamespace(status_code=200, content=b"artifact")
+    sleeps: list[float] = []
+    with (
+        patch.object(analyze.requests, "get", side_effect=[rate_limited, success]),
+        patch.object(analyze.time, "sleep", side_effect=sleeps.append),
+    ):
+        assert (
+            analyze.download_artifact("https://example.test/artifact", "token")
+            == b"artifact"
+        )
+
+    assert sleeps == [120]
+
+
 def test_download_artifact_preserves_persistent_failure():
     with (
         patch.object(

--- a/test/test_analyze_flaky_tests.py
+++ b/test/test_analyze_flaky_tests.py
@@ -6,7 +6,9 @@ from pathlib import Path
 import pytest
 import requests
 
-_SCRIPT_PATH = Path(__file__).with_name("analyze_flaky_tests.py")
+_SCRIPT_PATH = (
+    Path(__file__).parents[1] / ".github" / "scripts" / "analyze_flaky_tests.py"
+)
 _SPEC = importlib.util.spec_from_file_location("analyze_flaky_tests", _SCRIPT_PATH)
 assert _SPEC is not None
 assert _SPEC.loader is not None
@@ -15,19 +17,23 @@ _SPEC.loader.exec_module(analyze)
 
 
 class _Response:
-    def __init__(self, status_code: int, content: bytes = b"") -> None:
+    def __init__(self, status_code: int, content: bytes = b""):
         self.status_code = status_code
         self.content = content
 
 
-def test_download_artifact_retries_request_errors(monkeypatch):
-    responses = iter([_Response(200, b"artifact")])
+@pytest.mark.parametrize(
+    "failure", [requests.ConnectionError("connection reset"), _Response(503)]
+)
+def test_download_artifact_retries_transient_failures(monkeypatch, failure):
+    responses = iter([failure, _Response(200, b"artifact")])
     sleeps: list[int] = []
 
     def get(*args, **kwargs):
-        if not sleeps:
-            raise requests.ConnectionError("connection reset")
-        return next(responses)
+        response = next(responses)
+        if isinstance(response, requests.RequestException):
+            raise response
+        return response
 
     monkeypatch.setattr(analyze.requests, "get", get)
     monkeypatch.setattr(analyze.time, "sleep", sleeps.append)
@@ -39,20 +45,22 @@ def test_download_artifact_retries_request_errors(monkeypatch):
     assert sleeps == [2]
 
 
-def test_download_artifact_retries_transient_http_status(monkeypatch):
-    responses = iter([_Response(503), _Response(200, b"artifact")])
+def test_download_artifact_reraises_exhausted_request_errors(monkeypatch):
+    errors = iter(
+        requests.ConnectionError("persistent failure")
+        for _ in range(analyze.ARTIFACT_DOWNLOAD_ATTEMPTS)
+    )
     sleeps: list[int] = []
 
-    monkeypatch.setattr(
-        analyze.requests, "get", lambda *args, **kwargs: next(responses)
-    )
+    def get(*args, **kwargs):
+        raise next(errors)
+
+    monkeypatch.setattr(analyze.requests, "get", get)
     monkeypatch.setattr(analyze.time, "sleep", sleeps.append)
 
-    assert (
+    with pytest.raises(requests.ConnectionError, match="persistent failure"):
         analyze.download_artifact("https://example.test/artifact", "token")
-        == b"artifact"
-    )
-    assert sleeps == [2]
+    assert sleeps == [2, 4]
 
 
 def test_download_artifact_does_not_retry_permanent_http_status(monkeypatch):
@@ -68,3 +76,7 @@ def test_download_artifact_does_not_retry_permanent_http_status(monkeypatch):
 
     assert analyze.download_artifact("https://example.test/artifact", "token") is None
     assert calls == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/test/test_analyze_flaky_tests.py
+++ b/test/test_analyze_flaky_tests.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import requests
@@ -16,66 +18,36 @@ analyze = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(analyze)
 
 
-class _Response:
-    def __init__(self, status_code: int, content: bytes = b""):
-        self.status_code = status_code
-        self.content = content
-
-
 @pytest.mark.parametrize(
-    "failure", [requests.ConnectionError("connection reset"), _Response(503)]
+    "failure",
+    [
+        requests.ConnectionError("connection reset"),
+        SimpleNamespace(status_code=503, content=b""),
+    ],
 )
-def test_download_artifact_retries_transient_failures(monkeypatch, failure):
-    responses = iter([failure, _Response(200, b"artifact")])
-    sleeps: list[int] = []
+def test_download_artifact_recovers_from_transient_failure(failure):
+    success = SimpleNamespace(status_code=200, content=b"artifact")
+    with (
+        patch.object(analyze.requests, "get", side_effect=[failure, success]),
+        patch.object(analyze.time, "sleep"),
+    ):
+        assert (
+            analyze.download_artifact("https://example.test/artifact", "token")
+            == b"artifact"
+        )
 
-    def get(*args, **kwargs):
-        response = next(responses)
-        if isinstance(response, requests.RequestException):
-            raise response
-        return response
 
-    monkeypatch.setattr(analyze.requests, "get", get)
-    monkeypatch.setattr(analyze.time, "sleep", sleeps.append)
-
-    assert (
+def test_download_artifact_preserves_persistent_failure():
+    with (
+        patch.object(
+            analyze.requests,
+            "get",
+            side_effect=requests.ConnectionError("persistent failure"),
+        ),
+        patch.object(analyze.time, "sleep"),
+        pytest.raises(requests.ConnectionError, match="persistent failure"),
+    ):
         analyze.download_artifact("https://example.test/artifact", "token")
-        == b"artifact"
-    )
-    assert sleeps == [2]
-
-
-def test_download_artifact_reraises_exhausted_request_errors(monkeypatch):
-    errors = iter(
-        requests.ConnectionError("persistent failure")
-        for _ in range(analyze.ARTIFACT_DOWNLOAD_ATTEMPTS)
-    )
-    sleeps: list[int] = []
-
-    def get(*args, **kwargs):
-        raise next(errors)
-
-    monkeypatch.setattr(analyze.requests, "get", get)
-    monkeypatch.setattr(analyze.time, "sleep", sleeps.append)
-
-    with pytest.raises(requests.ConnectionError, match="persistent failure"):
-        analyze.download_artifact("https://example.test/artifact", "token")
-    assert sleeps == [2, 4]
-
-
-def test_download_artifact_does_not_retry_permanent_http_status(monkeypatch):
-    calls = 0
-
-    def get(*args, **kwargs):
-        nonlocal calls
-        calls += 1
-        return _Response(404)
-
-    monkeypatch.setattr(analyze.requests, "get", get)
-    monkeypatch.setattr(analyze.time, "sleep", pytest.fail)
-
-    assert analyze.download_artifact("https://example.test/artifact", "token") is None
-    assert calls == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fixes #4054. The flaky-test tracker currently fails the whole analysis job when a GitHub Actions artifact download encounters a transient connection reset, TLS error, or retryable 5xx/429 response.

Artifact downloads now retry request exceptions and transient HTTP statuses with bounded exponential backoff, while permanent HTTP errors still fail fast.

## Motivation and Context

The failed tracker runs in #4054 show `ConnectionResetError` and `SSLCertVerificationError` while downloading artifact archives from GitHub. The API requests succeed, but the redirected artifact request is not retried.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the CONTRIBUTION guide.
- [x] I have updated the tests accordingly.

## Validation

- `python -m pytest -q .github/scripts/test_analyze_flaky_tests.py`
- `python -m ruff check --ignore EXE001,PERF102 .github/scripts/analyze_flaky_tests.py .github/scripts/test_analyze_flaky_tests.py`
- Existing TorchRL CPU/GPU regression tests for the tracked flaky-test entries pass locally.

## Disclosure

AI assistance was used for repository exploration and drafting. I reviewed the implementation and ran the validation commands above.