### PR TITLE
[Performance] Specialize GRU scan backward

### DIFF
--- a/docs/source/reference/modules_rnn.rst
+++ b/docs/source/reference/modules_rnn.rst
@@ -80,6 +80,52 @@ model shape and deployment target are known. ``"pad"`` is the safest baseline,
 ``"scan"`` is the compile-friendly baseline, and ``"triton"`` is the
 performance-oriented CUDA backend.
 
+Optimized GRU scan backward
+---------------------------
+
+For :class:`GRUModule`, selecting ``recurrent_backend="scan"`` also selects a
+specialized first-order backward pass when ``recurrent_recompute="none"``
+(the default). The input projection is evaluated over the flattened
+batch-time dimensions, the reverse scan carries only the hidden-state
+gradient, and input and parameter gradients are reduced outside the recurrent
+loop. This avoids carrying the ordinary autograd graph through every timestep
+while preserving the same module parameters and recurrent-state semantics.
+
+No separate optimization flag is required:
+
+.. code-block:: python
+
+    gru = GRUModule(
+        input_size=4,
+        hidden_size=64,
+        recurrent_backend="scan",
+        in_keys=["observation", "recurrent_state", "is_init"],
+        out_keys=["features", ("next", "recurrent_state")],
+    )
+
+The optimized backward supports ordinary first-order training, including
+autocast BF16 inputs with FP32 parameters. It intentionally does not support
+double backward or :mod:`torch.func` transforms such as ``jacrev``, ``vmap``,
+and ``grad``. Set ``recurrent_recompute="full"`` to use the checkpointed
+reference loop when lower saved-activation memory is more important than the
+specialized backward.
+
+Backend performance depends on the device, batch size, rollout horizon, and
+hidden width. From a TorchRL source checkout, use the
+`recurrent backward benchmark
+<https://github.com/pytorch/rl/blob/main/benchmarks/bench_rnn_backward.py>`_
+to compare the available implementations on the target hardware:
+
+.. code-block:: bash
+
+    python benchmarks/bench_rnn_backward.py --rnn gru \
+        --backends cudnn,scan,triton \
+        --batches 256,1024 --seq-lens 64,512 --hiddens 128,512 \
+        --warmup 10 --iters 30
+
+The benchmark reports synchronized forward, backward, and total times plus
+peak allocated CUDA memory for every requested shape.
+
 Triton precision controls
 -------------------------
 

--- a/test/modules/test_rnn.py
+++ b/test/modules/test_rnn.py
@@ -1561,6 +1561,79 @@ class TestLSTMModule:
             assert pad_name == scan_name
             torch.testing.assert_close(pad_grad, scan_grad, atol=5e-3, rtol=5e-3)
 
+    @pytest.mark.parametrize("num_layers", [1, 2])
+    @pytest.mark.parametrize("bias", [False, True])
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.7.0"),
+        reason="hoptorch requires torch >= 2.7.0",
+    )
+    @pytest.mark.skipif(not _has_hoptorch, reason="hoptorch is not installed")
+    def test_gru_scan_backward_routes_recurrent_state_gradients(self, num_layers, bias):
+        torch.manual_seed(0)
+        B, T, F, H = 3, 6, 4, 8
+        kwargs = {
+            "input_size": F,
+            "hidden_size": H,
+            "num_layers": num_layers,
+            "bias": bias,
+            "in_keys": ["obs", "hidden"],
+            "out_keys": ["feat", ("next", "hidden")],
+        }
+        pad_module = GRUModule(**kwargs)
+        scan_module = GRUModule(**kwargs, recurrent_backend="scan")
+        scan_module.load_state_dict(pad_module.state_dict())
+
+        obs_source = torch.randn(B, T, F)
+        hidden_source = torch.randn(B, T, num_layers, H)
+        is_init = torch.zeros(B, T, 1, dtype=torch.bool)
+        # Row 0 continues an existing trajectory, while the other rows start
+        # fresh trajectories. This exercises both initial-state and reset-state
+        # gradient routing.
+        is_init[1:, 0] = True
+        is_init[1, 3] = True
+        is_init[2, 2] = True
+        output_cotangent = torch.randn(B, T, H)
+        hidden_cotangent = torch.randn(B, T, num_layers, H)
+
+        def loss_and_grads(module):
+            obs = obs_source.detach().clone().requires_grad_()
+            hidden = hidden_source.detach().clone().requires_grad_()
+            data = TensorDict(
+                {
+                    "obs": obs,
+                    "hidden": hidden,
+                    "is_init": is_init.clone(),
+                },
+                [B, T],
+            )
+            with set_recurrent_mode(True):
+                out = module(data)
+            loss = (out["feat"] * output_cotangent).sum() + (
+                out["next", "hidden"] * hidden_cotangent
+            ).sum()
+            loss.backward()
+            return {
+                "feat": out["feat"].detach(),
+                "hidden": out["next", "hidden"].detach(),
+                "obs_grad": obs.grad,
+                "hidden_grad": hidden.grad,
+                "param_grads": {
+                    name: param.grad for name, param in module.named_parameters()
+                },
+            }
+
+        pad = loss_and_grads(pad_module)
+        scan = loss_and_grads(scan_module)
+        for key in ("feat", "hidden", "obs_grad", "hidden_grad"):
+            torch.testing.assert_close(pad[key], scan[key], atol=1e-5, rtol=1e-5)
+        for name in pad["param_grads"]:
+            torch.testing.assert_close(
+                pad["param_grads"][name],
+                scan["param_grads"][name],
+                atol=1e-5,
+                rtol=1e-5,
+            )
+
     @pytest.mark.gpu
     @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
     @pytest.mark.parametrize("backend", ["scan", "triton"])
@@ -1745,11 +1818,12 @@ class TestLSTMModule:
                 with set_recurrent_mode(True):
                     return scan_module(td)
 
-            with torch.no_grad():
-                out = call(data.clone())
+            out = call(data.clone())
+            out["feat"].square().mean().backward()
         finally:
             torch._dynamo.config.capture_scalar_outputs = prev
         assert "feat" in out.keys(True, True)
+        assert all(param.grad is not None for param in scan_module.parameters())
 
     @pytest.mark.parametrize("rnn_type", ["gru", "lstm"])
     @pytest.mark.skipif(

--- a/test/modules/test_rnn.py
+++ b/test/modules/test_rnn.py
@@ -1634,6 +1634,72 @@ class TestLSTMModule:
                 rtol=1e-5,
             )
 
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.7.0"),
+        reason="hoptorch requires torch >= 2.7.0",
+    )
+    @pytest.mark.skipif(not _has_hoptorch, reason="hoptorch is not installed")
+    def test_gru_scan_backward_autocast_bfloat16(self):
+        torch.manual_seed(0)
+        module = GRUModule(
+            input_size=4,
+            hidden_size=8,
+            in_keys=["obs", "hidden"],
+            out_keys=["feat", ("next", "hidden")],
+            recurrent_backend="scan",
+        )
+        obs = torch.randn(2, 5, 4, dtype=torch.bfloat16, requires_grad=True)
+        data = TensorDict(
+            {
+                "obs": obs,
+                "hidden": torch.zeros(2, 5, 1, 8, dtype=torch.bfloat16),
+                "is_init": torch.zeros(2, 5, 1, dtype=torch.bool),
+            },
+            [2, 5],
+        )
+        with set_recurrent_mode(True), torch.autocast("cpu", torch.bfloat16):
+            out = module(data)
+        out["feat"].float().sum().backward()
+        assert obs.grad is not None
+        assert torch.isfinite(obs.grad).all()
+        for parameter in module.parameters():
+            assert parameter.grad is not None
+            assert torch.isfinite(parameter.grad).all()
+
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.7.0"),
+        reason="hoptorch requires torch >= 2.7.0",
+    )
+    @pytest.mark.skipif(not _has_hoptorch, reason="hoptorch is not installed")
+    def test_gru_scan_double_backward_raises(self):
+        torch.manual_seed(0)
+        module = GRUModule(
+            input_size=4,
+            hidden_size=8,
+            in_keys=["obs", "hidden"],
+            out_keys=["feat", ("next", "hidden")],
+            recurrent_backend="scan",
+        )
+        obs = torch.randn(2, 5, 4, requires_grad=True)
+        data = TensorDict(
+            {
+                "obs": obs,
+                "hidden": torch.zeros(2, 5, 1, 8),
+                "is_init": torch.zeros(2, 5, 1, dtype=torch.bool),
+            },
+            [2, 5],
+        )
+        with set_recurrent_mode(True):
+            out = module(data)
+        cotangent = torch.randn_like(out["feat"]).requires_grad_()
+        (grad,) = torch.autograd.grad(
+            out["feat"], obs, grad_outputs=cotangent, create_graph=True
+        )
+        with pytest.raises(
+            RuntimeError, match="differentiate twice|does not require grad"
+        ):
+            grad.sum().backward()
+
     @pytest.mark.gpu
     @pytest.mark.skipif(not _has_triton, reason=_triton_skip_reason)
     @pytest.mark.parametrize("backend", ["scan", "triton"])

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -153,6 +153,158 @@ def _gru_cell_from_gate_params(
     return newgate + inputgate * (hx - newgate)
 
 
+class _GRUScanFunction(torch.autograd.Function):
+    """GRU sequence with a hidden-gradient-only reverse scan.
+
+    The input projection and all shared-parameter gradient reductions run over
+    the flattened batch-time dimensions. Only the recurrent hidden-state
+    derivative remains inside the reverse scan.
+    """
+
+    @staticmethod
+    def forward(ctx, x, initial, reset_hidden, is_init, w_ih, w_hh, b_ih, b_hh):
+        time, batch, _ = x.shape
+        hidden_size = initial.shape[-1]
+        gate_chunks = (hidden_size, hidden_size, hidden_size)
+        gates_x = F.linear(x.flatten(0, 1), w_ih, b_ih).view(
+            time, batch, 3 * hidden_size
+        )
+
+        def step(carry, inputs):
+            gates_x_t, reset_hidden_t, init_t = inputs
+            h_previous = torch.where(init_t.unsqueeze(-1), reset_hidden_t, carry)
+            gates_h = F.linear(h_previous, w_hh, b_hh)
+            i_r, i_z, i_n = gates_x_t.split(gate_chunks, -1)
+            h_r, h_z, h_n = gates_h.split(gate_chunks, -1)
+            resetgate = (i_r + h_r).sigmoid()
+            updategate = (i_z + h_z).sigmoid()
+            newgate = (i_n + resetgate * h_n).tanh()
+            hidden = newgate + updategate * (h_previous - newgate)
+            return hidden, (
+                hidden.clone(),
+                resetgate,
+                updategate,
+                newgate,
+                h_n,
+            )
+
+        _, (hidden, resetgate, updategate, newgate, h_n) = _scan(
+            step, initial, (gates_x, reset_hidden, is_init), dim=0
+        )
+        ctx.hidden_size = hidden_size
+        ctx.save_for_backward(
+            x,
+            initial,
+            reset_hidden,
+            is_init,
+            w_ih,
+            w_hh,
+            hidden,
+            resetgate,
+            updategate,
+            newgate,
+            h_n,
+        )
+        return hidden
+
+    @staticmethod
+    def backward(ctx, grad_hidden):
+        (
+            x,
+            initial,
+            reset_hidden,
+            is_init,
+            w_ih,
+            w_hh,
+            hidden,
+            resetgate,
+            updategate,
+            newgate,
+            h_n,
+        ) = ctx.saved_tensors
+        hidden_size = ctx.hidden_size
+        time, batch, input_size = x.shape
+
+        previous_hidden = torch.cat((initial.unsqueeze(0), hidden[:-1]), 0)
+        previous_hidden = torch.where(
+            is_init.unsqueeze(-1), reset_hidden, previous_hidden
+        )
+
+        def reverse_step(d_hidden_next, inputs):
+            (
+                d_hidden_t,
+                previous_hidden_t,
+                resetgate_t,
+                updategate_t,
+                newgate_t,
+                h_n_t,
+                init_t,
+            ) = inputs
+            d_hidden = d_hidden_t + d_hidden_next
+            d_newgate = d_hidden * (1 - updategate_t)
+            d_updategate = d_hidden * (previous_hidden_t - newgate_t)
+            d_previous_direct = d_hidden * updategate_t
+
+            d_newgate_pre = d_newgate * (1 - newgate_t.square())
+            d_h_n = d_newgate_pre * resetgate_t
+            d_updategate_pre = d_updategate * updategate_t * (1 - updategate_t)
+            d_resetgate_pre = d_newgate_pre * h_n_t * resetgate_t * (1 - resetgate_t)
+            d_gates_x = torch.cat(
+                (d_resetgate_pre, d_updategate_pre, d_newgate_pre), -1
+            )
+            d_gates_h = torch.cat((d_resetgate_pre, d_updategate_pre, d_h_n), -1)
+            d_previous = d_previous_direct + F.linear(d_gates_h, w_hh.t())
+            d_hidden_next = torch.where(
+                init_t.unsqueeze(-1), torch.zeros_like(d_previous), d_previous
+            )
+            return d_hidden_next, (d_gates_x, d_gates_h, d_previous)
+
+        reversed_inputs = tuple(
+            value.flip(0)
+            for value in (
+                grad_hidden,
+                previous_hidden,
+                resetgate,
+                updategate,
+                newgate,
+                h_n,
+                is_init,
+            )
+        )
+        d_initial, (d_gates_x, d_gates_h, d_previous) = _scan(
+            reverse_step,
+            torch.zeros_like(initial),
+            reversed_inputs,
+            dim=0,
+        )
+        d_gates_x = d_gates_x.flip(0)
+        d_gates_h = d_gates_h.flip(0)
+        d_previous = d_previous.flip(0)
+
+        d_gates_x_flat = d_gates_x.reshape(time * batch, 3 * hidden_size)
+        d_gates_h_flat = d_gates_h.reshape(time * batch, 3 * hidden_size)
+        x_flat = x.reshape(time * batch, input_size)
+        previous_hidden_flat = previous_hidden.reshape(time * batch, hidden_size)
+        d_x = F.linear(d_gates_x_flat, w_ih.t()).view_as(x)
+        d_w_ih = d_gates_x_flat.t() @ x_flat
+        d_w_hh = d_gates_h_flat.t() @ previous_hidden_flat
+        d_b_ih = d_gates_x_flat.sum(0)
+        d_b_hh = d_gates_h_flat.sum(0)
+        d_reset_hidden = torch.where(
+            is_init.unsqueeze(-1), d_previous, torch.zeros_like(d_previous)
+        )
+        return (
+            d_x,
+            d_initial,
+            d_reset_hidden,
+            None,
+            d_w_ih,
+            d_w_hh,
+            d_b_ih,
+            d_b_hh,
+        )
+
+
 @implement_for("torch", None, "2.6.0", compilable=True)
 def _scan(*args: Any, **kwargs: Any) -> Any:
     raise NotImplementedError(
@@ -2858,73 +3010,58 @@ class GRUModule(ModuleBase):
             )
 
         recompute = self.recurrent_recompute == "full"
-        # Split the packed GRU gate parameters outside the scan body. This keeps
-        # the scan step from producing intermediate tensors whose width is the
-        # composite symbolic expression ``3 * hidden_size`` and avoids the
-        # chunk/split-on-activations path in scan's compiled backward. Each gate
-        # clone is an independent allocation, preserving the existing scan
-        # input-aliasing workaround for cuDNN-flattened RNN parameters while
-        # keeping gradients connected to the packed parameters.
         hidden_size = self.gru.hidden_size
-        weight_ihs, weight_hhs, bias_ihs, bias_hhs = [], [], [], []
-        for layer in range(self.gru.num_layers):
-            weights = self.gru._all_weights[layer]
-            weight_ihs.append(
-                _split_gru_gate_param(getattr(self.gru, weights[0]), hidden_size)
-            )
-            weight_hhs.append(
-                _split_gru_gate_param(getattr(self.gru, weights[1]), hidden_size)
-            )
-            bias_ihs.append(
-                _split_gru_gate_param(
-                    getattr(self.gru, weights[2]) if self.gru.bias else None,
-                    hidden_size,
-                )
-            )
-            bias_hhs.append(
-                _split_gru_gate_param(
-                    getattr(self.gru, weights[3]) if self.gru.bias else None,
-                    hidden_size,
-                )
-            )
-
         input = _canonical_contiguous(input.transpose(0, 1))
         is_init = _canonical_contiguous(is_init.transpose(0, 1))
         reset_hidden = _canonical_contiguous(hidden_in.permute(1, 2, 0, 3))
         num_layers = self.gru.num_layers
 
-        def step(carry, inputs):
-            h_layers = carry
-            x_t, init_t, reset_hidden_t = inputs
-            init_t = init_t.unsqueeze(0).unsqueeze(-1)
-            h_layers = torch.where(init_t, reset_hidden_t, h_layers)
-            h_unbound = h_layers.unbind(0)
-            new_h = []
-            for layer in range(num_layers):
-                h_new = _gru_cell_from_gate_params(
-                    x_t,
-                    h_unbound[layer],
-                    weight_ihs[layer],
-                    bias_ihs[layer],
-                    weight_hhs[layer],
-                    bias_hhs[layer],
-                )
-                new_h.append(h_new)
-                x_t = h_new
-            # torch.stack allocates a fresh tensor, so the carry needs no
-            # extra clone. The per-step output is derived from the carry
-            # via transpose+flatten (view-style at the HOP tracer level
-            # even though it copies at runtime) — clone it and x_t to
-            # break the carry/output aliasing scan would otherwise flag.
-            new_h = torch.stack(new_h, 0)
-            hidden_out = new_h.transpose(0, 1).flatten(1).clone()
-            return new_h, (x_t.clone(), hidden_out)
-
-        def step_unpacked(h_layers, x_t, init_t, reset_hidden_t):
-            new_h, (out_t, hidden_out) = step(h_layers, (x_t, init_t, reset_hidden_t))
-            return new_h, out_t, hidden_out
-
         if recompute:
+            # Split the packed parameters outside the checkpointed loop. Each
+            # gate clone remains connected to the packed parameter while
+            # breaking cuDNN's shared flat-storage aliases.
+            weight_ihs, weight_hhs, bias_ihs, bias_hhs = [], [], [], []
+            for layer in range(num_layers):
+                weights = self.gru._all_weights[layer]
+                weight_ihs.append(
+                    _split_gru_gate_param(getattr(self.gru, weights[0]), hidden_size)
+                )
+                weight_hhs.append(
+                    _split_gru_gate_param(getattr(self.gru, weights[1]), hidden_size)
+                )
+                bias_ihs.append(
+                    _split_gru_gate_param(
+                        getattr(self.gru, weights[2]) if self.gru.bias else None,
+                        hidden_size,
+                    )
+                )
+                bias_hhs.append(
+                    _split_gru_gate_param(
+                        getattr(self.gru, weights[3]) if self.gru.bias else None,
+                        hidden_size,
+                    )
+                )
+
+            def step_unpacked(h_layers, x_t, init_t, reset_hidden_t):
+                init_t = init_t.unsqueeze(0).unsqueeze(-1)
+                h_layers = torch.where(init_t, reset_hidden_t, h_layers)
+                h_unbound = h_layers.unbind(0)
+                new_h = []
+                for layer in range(num_layers):
+                    h_new = _gru_cell_from_gate_params(
+                        x_t,
+                        h_unbound[layer],
+                        weight_ihs[layer],
+                        bias_ihs[layer],
+                        weight_hhs[layer],
+                        bias_hhs[layer],
+                    )
+                    new_h.append(h_new)
+                    x_t = h_new
+                new_h = torch.stack(new_h, 0)
+                hidden_out = new_h.transpose(0, 1).flatten(1)
+                return new_h, x_t, hidden_out
+
             h_carry = initial_hidden
             outputs_list: list[torch.Tensor] = []
             hidden_list: list[torch.Tensor] = []
@@ -2943,9 +3080,35 @@ class GRUModule(ModuleBase):
             outputs = torch.stack(outputs_list, 0)
             hidden_steps = torch.stack(hidden_list, 0)
         else:
-            _, (outputs, hidden_steps) = _scan(
-                step, initial_hidden, (input, is_init, reset_hidden), dim=0
-            )
+            layer_input = input
+            hidden_layers = []
+            for layer in range(num_layers):
+                weights = self.gru._all_weights[layer]
+                # cuDNN may flatten every layer into shared storage. Independent
+                # clones keep scan's input aliasing rules satisfied while
+                # preserving gradients to the original packed parameters.
+                w_ih = getattr(self.gru, weights[0]).clone()
+                w_hh = getattr(self.gru, weights[1]).clone()
+                if self.gru.bias:
+                    b_ih = getattr(self.gru, weights[2]).clone()
+                    b_hh = getattr(self.gru, weights[3]).clone()
+                else:
+                    b_ih = layer_input.new_zeros(3 * hidden_size)
+                    b_hh = layer_input.new_zeros(3 * hidden_size)
+                layer_hidden = _GRUScanFunction.apply(
+                    layer_input,
+                    initial_hidden[layer],
+                    reset_hidden[:, layer],
+                    is_init,
+                    w_ih,
+                    w_hh,
+                    b_ih,
+                    b_hh,
+                )
+                hidden_layers.append(layer_hidden)
+                layer_input = layer_hidden
+            outputs = layer_input
+            hidden_steps = torch.stack(hidden_layers, -2).flatten(-2)
         outputs = outputs.transpose(0, 1)
         hidden_steps = hidden_steps.unflatten(
             -1, (self.gru.num_layers, self.gru.hidden_size)

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -21,6 +21,7 @@ from tensordict.base import NO_DEFAULT
 from tensordict.nn import dispatch, TensorDictModuleBase as ModuleBase
 from tensordict.utils import expand_as_right, NestedKey, set_lazy_legacy
 from torch import nn, Tensor
+from torch.autograd.function import once_differentiable
 from torch.nn.modules.rnn import RNNCellBase
 
 from torchrl._utils import (
@@ -159,6 +160,12 @@ class _GRUScanFunction(torch.autograd.Function):
     The input projection and all shared-parameter gradient reductions run over
     the flattened batch-time dimensions. Only the recurrent hidden-state
     derivative remains inside the reverse scan.
+
+    ``torch.func`` transforms (``jacrev``, ``vmap``, ``grad``) are not
+    supported: this Function uses the ctx-style ``forward``, which PyTorch
+    rejects with its standard ``setup_context`` error before the recurrence
+    runs. The backward is marked ``once_differentiable`` because it consumes
+    gate states saved without autograd history.
     """
 
     @staticmethod
@@ -208,6 +215,7 @@ class _GRUScanFunction(torch.autograd.Function):
         return hidden
 
     @staticmethod
+    @once_differentiable
     def backward(ctx, grad_hidden):
         (
             x,
@@ -224,6 +232,11 @@ class _GRUScanFunction(torch.autograd.Function):
         ) = ctx.saved_tensors
         hidden_size = ctx.hidden_size
         time, batch, input_size = x.shape
+
+        # The forward may have run under autocast with fp32 parameters, so the
+        # weights are cast to the gradient dtype before the backward linears.
+        gate_dtype = torch.promote_types(grad_hidden.dtype, resetgate.dtype)
+        w_hh_t = w_hh.t().to(gate_dtype)
 
         previous_hidden = torch.cat((initial.unsqueeze(0), hidden[:-1]), 0)
         previous_hidden = torch.where(
@@ -253,7 +266,7 @@ class _GRUScanFunction(torch.autograd.Function):
                 (d_resetgate_pre, d_updategate_pre, d_newgate_pre), -1
             )
             d_gates_h = torch.cat((d_resetgate_pre, d_updategate_pre, d_h_n), -1)
-            d_previous = d_previous_direct + F.linear(d_gates_h, w_hh.t())
+            d_previous = d_previous_direct + F.linear(d_gates_h, w_hh_t)
             d_hidden_next = torch.where(
                 init_t.unsqueeze(-1), torch.zeros_like(d_previous), d_previous
             )
@@ -285,7 +298,7 @@ class _GRUScanFunction(torch.autograd.Function):
         d_gates_h_flat = d_gates_h.reshape(time * batch, 3 * hidden_size)
         x_flat = x.reshape(time * batch, input_size)
         previous_hidden_flat = previous_hidden.reshape(time * batch, hidden_size)
-        d_x = F.linear(d_gates_x_flat, w_ih.t()).view_as(x)
+        d_x = F.linear(d_gates_x_flat, w_ih.t().to(d_gates_x_flat.dtype)).view_as(x)
         d_w_ih = d_gates_x_flat.t() @ x_flat
         d_w_hh = d_gates_h_flat.t() @ previous_hidden_flat
         d_b_ih = d_gates_x_flat.sum(0)


### PR DESCRIPTION
## Summary
- Hoist the GRU input projection out of the recurrent scan.
- Use a GRU-specific reverse scan that carries only the hidden-state gradient.
- Reduce input, parameter, and bias gradients over flattened batch-time dimensions outside the scan.
- Preserve the existing recompute path and public API.
- Document the one-kwarg backend selection, first-order limitations, and the hardware benchmark workflow.

## Testing
- Full RNN test module: 222 passed, 48 CUDA/Triton-only tests skipped.
- Added pad/scan output and gradient parity coverage for one and two layers, with and without bias, including initial and reset recurrent-state gradients.
- Extended the compiled scan regression to exercise backward and parameter gradients.
- Added BF16 autocast backward coverage and explicit double-backward rejection coverage.
- RST section-underline and whitespace validation passed for the recurrent-module documentation.

## Benchmark
Local CPU eager forward and backward, B=64, T=32, input=32, hidden=128, one layer:
- Before: 100.7 ms median
- After: 10.2 ms median

CUDA performance remains covered by `benchmarks/bench_rnn_backward.py`; the recurrent-module documentation now includes a runnable command for comparing cuDNN, scan, and Triton on the target hardware.