### PR TITLE
[CI] Run VecNorm CUDA device tests in GPU jobs

### DIFF
--- a/test/transforms/test_normalization.py
+++ b/test/transforms/test_normalization.py
@@ -619,9 +619,12 @@ class TestVecNormV2:
         [
             pytest.param(
                 "cuda",
-                marks=pytest.mark.skipif(
-                    not torch.cuda.is_available(), reason="CUDA not available"
-                ),
+                marks=[
+                    pytest.mark.gpu,
+                    pytest.mark.skipif(
+                        not torch.cuda.is_available(), reason="CUDA not available"
+                    ),
+                ],
             ),
             pytest.param(
                 "mps",
@@ -680,9 +683,12 @@ class TestVecNormV2:
         [
             pytest.param(
                 "cuda",
-                marks=pytest.mark.skipif(
-                    not torch.cuda.is_available(), reason="CUDA not available"
-                ),
+                marks=[
+                    pytest.mark.gpu,
+                    pytest.mark.skipif(
+                        not torch.cuda.is_available(), reason="CUDA not available"
+                    ),
+                ],
             ),
             pytest.param(
                 "mps",


### PR DESCRIPTION
## Description

Mark the CUDA parameters of two VecNorm device tests with `pytest.mark.gpu` so the unified Linux GPU jobs collect and execute them. The MPS parameters remain outside the CUDA marker partition.

## Motivation and Context

The Linux test workflow runs CPU jobs with `-m "not gpu"` and GPU jobs with `-m gpu`. Before this change, CPU jobs collected these CUDA cases and skipped them, while GPU jobs deselected them. This left both CUDA regression paths unexecuted in normal Linux CI.

Closes #4156

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.

## Validation

- `python -m pytest --disable-plugin-autoload test/transforms/test_normalization.py -m gpu --collect-only -q`: 2 CUDA cases collected, 33 deselected
- `python -m pytest --disable-plugin-autoload test/transforms/test_normalization.py -m "not gpu" --collect-only -q`: 33 cases collected, 2 deselected
- `python -m ruff check --ignore E731 test/transforms/test_normalization.py`: passed
- `git diff --check`: passed