### PR TITLE
[Quality] Add numerical loss regression tests

### DIFF
--- a/test/objectives/test_act.py
+++ b/test/objectives/test_act.py
@@ -4,10 +4,13 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import math
+
 import pytest
 import torch
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
+from torch import nn
 
 from torchrl.data.vla import ACTION_CHUNK_KEY
 from torchrl.envs.transforms import ActionChunkTransform
@@ -21,6 +24,15 @@ from torchrl.objectives import ACTLoss
 OBS_DIM = 14
 ACTION_DIM = 7
 CHUNK_SIZE = 10  # small for fast tests
+
+
+class _FixedACTActor(nn.Module):
+    def forward(self, observation, action_chunk):
+        return (
+            observation[..., :4].unflatten(-1, (2, 2)),
+            observation[..., 4:6],
+            observation[..., 6:8],
+        )
 
 
 def _make_actor(
@@ -223,23 +235,46 @@ class TestACTLoss:
             if p.grad is not None:
                 assert p.grad.abs().sum() > 0
 
-    @pytest.mark.parametrize("kl_weight", [0.0, 1.0, 10.0, 100.0])
-    def test_kl_weight_decomposition(self, kl_weight):
-        """loss_act == loss_reconstruction + kl_weight * loss_kl."""
-        actor = _make_actor()
-        loss_fn = ACTLoss(actor, kl_weight=kl_weight)
-        td = _make_batch()
+    @pytest.mark.parametrize("kl_weight", [0.0, 3.0])
+    @pytest.mark.parametrize("reduction", ["none", "mean", "sum"])
+    def test_loss_formula_and_reduction(self, reduction, kl_weight):
+        actor = TensorDictModule(
+            _FixedACTActor(),
+            in_keys=["observation", "action_chunk"],
+            out_keys=["action_pred", "mu", "log_var"],
+        )
+        loss_fn = ACTLoss(actor, kl_weight=kl_weight, reduction=reduction)
+        td = TensorDict(
+            {
+                "observation": torch.tensor(
+                    [
+                        [0.0, 2.0, -1.0, 4.0, 0.0, 1.0, 0.0, math.log(4.0)],
+                        [2.0, 0.0, 3.0, -2.0, 2.0, 0.0, 0.0, 0.0],
+                    ]
+                ),
+                ACTION_CHUNK_KEY: torch.tensor(
+                    [[[1.0, 0.0], [1.0, 2.0]], [[0.0, 1.0], [1.0, -1.0]]]
+                ),
+            },
+            batch_size=[2],
+        )
         loss_td = loss_fn(td)
-        expected = loss_td["loss_reconstruction"] + kl_weight * loss_td["loss_kl"]
-        torch.testing.assert_close(loss_td["loss_act"], expected)
 
-    def test_zero_kl_weight(self):
-        """With kl_weight=0, loss_act equals loss_reconstruction exactly."""
-        actor = _make_actor()
-        loss_fn = ACTLoss(actor, kl_weight=0.0)
-        td = _make_batch()
-        loss_td = loss_fn(td)
-        torch.testing.assert_close(loss_td["loss_act"], loss_td["loss_reconstruction"])
+        expected_reconstruction = torch.tensor([1.75, 1.5])
+        expected_kl = torch.tensor([2.0 - math.log(4.0) / 2, 2.0])
+        if reduction == "mean":
+            expected_reconstruction = expected_reconstruction.mean()
+            expected_kl = expected_kl.mean()
+        elif reduction == "sum":
+            expected_reconstruction = expected_reconstruction.sum()
+            expected_kl = expected_kl.sum()
+        expected_loss = expected_reconstruction + kl_weight * expected_kl
+
+        torch.testing.assert_close(
+            loss_td["loss_reconstruction"], expected_reconstruction
+        )
+        torch.testing.assert_close(loss_td["loss_kl"], expected_kl)
+        torch.testing.assert_close(loss_td["loss_act"], expected_loss)
 
     def test_reconstruction_and_kl_detached(self):
         """loss_reconstruction and loss_kl must not retain grad."""
@@ -249,15 +284,6 @@ class TestACTLoss:
         loss_td = loss_fn(td)
         assert not loss_td["loss_reconstruction"].requires_grad
         assert not loss_td["loss_kl"].requires_grad
-
-    @pytest.mark.parametrize("reduction", ["mean", "sum"])
-    def test_reduction(self, reduction):
-        actor = _make_actor()
-        loss_fn = ACTLoss(actor, reduction=reduction)
-        td = _make_batch()
-        loss_td = loss_fn(td)
-        assert loss_td["loss_act"].shape == torch.Size([])
-        assert loss_td["loss_act"].isfinite()
 
     def test_in_keys(self):
         actor = _make_actor()

--- a/test/objectives/test_bc.py
+++ b/test/objectives/test_bc.py
@@ -129,26 +129,25 @@ class TestBCLoss:
             if p.grad is not None:
                 assert p.grad.abs().sum() > 0
 
-    @pytest.mark.parametrize("reduction", ["none", "mean", "sum"])
-    def test_reduction_modes(self, reduction):
-        actor = self._make_deterministic_actor()
-        loss_fn = BCLoss(actor, reduction=reduction)
-        td = self._make_batch(batch_size=4)
-        loss_td = loss_fn(td)
-        assert "loss_bc" in loss_td.keys()
-        if reduction == "none":
-            # For deterministic actor, loss should be scalar per sample then reduced
-            pass  # The exact shape depends on implementation
-        else:
-            assert loss_td["loss_bc"].shape == torch.Size([])
-
-    @pytest.mark.parametrize("loss_function", ["l1", "l2", "smooth_l1"])
-    def test_loss_functions_deterministic(self, loss_function):
-        actor = self._make_deterministic_actor()
+    @pytest.mark.parametrize(
+        ("loss_function", "expected"),
+        [("l1", 1.75), ("l2", 5.25), ("smooth_l1", 1.375)],
+    )
+    def test_loss_functions_deterministic(self, loss_function, expected):
+        module = nn.Linear(2, 2, bias=False)
+        with torch.no_grad():
+            module.weight.copy_(torch.eye(2))
+        actor = TensorDictModule(module, in_keys=["observation"], out_keys=["action"])
         loss_fn = BCLoss(actor, loss_function=loss_function)
-        td = self._make_batch()
-        loss_td = loss_fn(td)
-        assert loss_td["loss_bc"].isfinite()
+        td = TensorDict(
+            {
+                "observation": torch.tensor([[0.0, 0.0], [1.0, -2.0]]),
+                "action": torch.tensor([[2.0, 0.0], [0.0, 2.0]]),
+            },
+            batch_size=[2],
+        )
+        loss = loss_fn(td)["loss_bc"]
+        torch.testing.assert_close(loss, loss.new_tensor(expected))
 
     def test_custom_keys(self):
         actor = self._make_deterministic_actor()

--- a/test/objectives/test_diffusion_bc.py
+++ b/test/objectives/test_diffusion_bc.py
@@ -9,9 +9,27 @@ import argparse
 import pytest
 import torch
 from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+from torch import nn
 
 from torchrl.modules import DiffusionActor
 from torchrl.objectives import DiffusionBCLoss
+
+
+class _FixedDDPM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.num_steps = 1
+        self.score_network = nn.Linear(5, 2)
+        with torch.no_grad():
+            self.score_network.weight.zero_()
+            self.score_network.bias.copy_(torch.tensor([1.0, -1.0]))
+
+    def forward(self, observation):
+        return observation[..., :2]
+
+    def add_noise(self, clean_action, t):
+        return torch.zeros_like(clean_action), clean_action
 
 
 class TestDiffusionBCLoss:
@@ -69,23 +87,28 @@ class TestDiffusionBCLoss:
             if p.grad is not None:
                 assert p.grad.abs().sum() > 0
 
-    def test_reduction_none(self):
-        """reduction='none' should not aggregate — loss is still scalar (MSE averages internally)."""
-        actor = self._make_actor()
-        loss_fn = DiffusionBCLoss(actor, reduction="none")
-        td = self._make_batch()
-        loss_td = loss_fn(td)
-        # With reduction='none' the raw element-wise tensor is returned from mse_loss
-        assert "loss_diffusion_bc" in loss_td.keys()
-
-    def test_reduction_sum(self):
-        actor = self._make_actor()
-        loss_fn_mean = DiffusionBCLoss(actor, reduction="mean")
-        loss_fn_sum = DiffusionBCLoss(actor, reduction="sum")
-        td = self._make_batch(batch_size=4)
-        # Both should produce a finite scalar
-        assert loss_fn_mean(td)["loss_diffusion_bc"].isfinite()
-        assert loss_fn_sum(td)["loss_diffusion_bc"].isfinite()
+    @pytest.mark.parametrize(
+        ("reduction", "expected"),
+        [
+            ("none", [[1.0, 4.0], [1.0, 25.0]]),
+            ("mean", 7.75),
+            ("sum", 31.0),
+        ],
+    )
+    def test_reduction(self, reduction, expected):
+        actor = TensorDictModule(
+            _FixedDDPM(), in_keys=["observation"], out_keys=["action"]
+        )
+        loss_fn = DiffusionBCLoss(actor, reduction=reduction)
+        td = TensorDict(
+            {
+                "observation": torch.zeros(2, 2),
+                "action": torch.tensor([[0.0, 1.0], [2.0, 4.0]]),
+            },
+            batch_size=[2],
+        )
+        loss = loss_fn(td)["loss_diffusion_bc"]
+        torch.testing.assert_close(loss, loss.new_tensor(expected))
 
     def test_custom_keys(self):
         actor = self._make_actor()


### PR DESCRIPTION
## Summary

- verify BCLoss L1, L2, and smooth-L1 values independently
- verify DiffusionBCLoss elementwise and reduced values
- verify ACTLoss reconstruction, Gaussian KL, weighting, and reductions with fixed actor outputs

## Motivation

Related to #4144. The previous tests could pass with incorrect formulas or reductions. This PR intentionally does not close the broader audit issue.

## Testing

- 102 focused objective tests passed
- targeted mutation checks rejected incorrect behavior
- git diff --check passed

cc @vmoens