### PR TITLE
[Quality] Strengthen LLM policy loss tests

### DIFF
--- a/test/llm/test_llm_objectives.py
+++ b/test/llm/test_llm_objectives.py
@@ -854,9 +854,9 @@ class TestLosses:
             sample_log_prob=[0.0],
             advantage=[1.0],
         )
-        loss = CISPOLoss(
-            _FixedLogProbPolicy(), clip_epsilon=0.2, entropy_bonus=False
-        )(data)
+        loss = CISPOLoss(_FixedLogProbPolicy(), clip_epsilon=0.2, entropy_bonus=False)(
+            data
+        )
 
         torch.testing.assert_close(loss.loss_objective, torch.tensor(-0.8))
 

--- a/test/llm/test_llm_objectives.py
+++ b/test/llm/test_llm_objectives.py
@@ -15,7 +15,6 @@ import torch
 
 from tensordict import lazy_stack, MetaData, TensorDict
 from tensordict.nn import TensorDictModule
-from torchrl._utils import logger
 from torchrl.data import History, LazyStackStorage, ReplayBuffer
 from torchrl.data.llm.history import _CHAT_TEMPLATES
 from torchrl.envs.llm.transforms.kl import RetrieveLogProb
@@ -29,7 +28,6 @@ from torchrl.objectives.llm.distillation import (
 )
 from torchrl.objectives.llm.grpo import (
     CISPOLoss,
-    CISPOLossOutput,
     GRPOLoss,
     GRPOLossOutput,
     MCAdvantage,
@@ -662,6 +660,40 @@ def _mock_data_grpo(vocab_size: int, device: torch.device | str = "cpu") -> Tens
     return data
 
 
+class _FixedLogProbDistribution:
+    def __init__(self, log_prob, mask):
+        self.log_prob_value = log_prob
+        self.mask = mask
+
+    def log_prob(self, value):
+        return self.log_prob_value
+
+
+class _FixedLogProbPolicy(torch.nn.Module):
+    in_keys = ()
+
+    def get_dist(self, tensordict, **kwargs):
+        return _FixedLogProbDistribution(
+            tensordict["current_log_prob"], tensordict["mask"]
+        )
+
+
+def _policy_loss_data(current_log_prob, sample_log_prob, advantage):
+    current_log_prob = torch.tensor([current_log_prob], dtype=torch.float32)
+    sample_log_prob = torch.tensor([sample_log_prob], dtype=torch.float32)
+    advantage = torch.tensor([advantage], dtype=torch.float32).unsqueeze(-1)
+    return TensorDict(
+        {
+            "current_log_prob": current_log_prob,
+            "mask": torch.ones_like(current_log_prob, dtype=torch.bool),
+            ("tokens", "full"): torch.zeros_like(current_log_prob, dtype=torch.long),
+            ("log_probs", "full"): sample_log_prob,
+            "advantage": advantage,
+        },
+        batch_size=[1],
+    )
+
+
 class TestLosses:
     def test_grpo_token_mean_expands_token_mask(self):
         """Test token_mean aggregation with per-token values and masks."""
@@ -677,17 +709,10 @@ class TestLosses:
         expected = value[expected_mask].mean()
         torch.testing.assert_close(result, expected)
 
-    @pytest.mark.parametrize("dapo", [True, False], ids=["dapo", "symmetric"])
-    def test_grpo(self, mock_transformer_model, dapo):
+    def test_grpo(self, mock_transformer_model):
         """Test GRPO loss computation with mock models."""
         vocab_size = 1024
         device = torch.device("cpu")
-        if dapo:
-            eps_low = 0.20
-            eps_high = 0.28
-            eps = (eps_low, eps_high)
-        else:
-            eps = 0.20
         # Create mock model and wrap it
         model = mock_transformer_model(vocab_size=vocab_size, device=device)
         actor_network = TransformersWrapper(
@@ -698,7 +723,7 @@ class TestLosses:
         )
 
         # Create loss module
-        loss_fn = GRPOLoss(actor_network, clip_epsilon=eps)
+        loss_fn = GRPOLoss(actor_network, clip_epsilon=0.2)
 
         # Create fake data
         data = _mock_data_grpo(vocab_size=vocab_size, device=device)
@@ -743,73 +768,35 @@ class TestLosses:
             0 <= loss_vals.clip_fraction <= 1
         ), f"clip_fraction out of range: {loss_vals.clip_fraction}"
 
-    def test_kl_mask_threshold(self, mock_transformer_model):
-        """Test that kl_mask_threshold properly filters out high-KL tokens."""
-        torch.manual_seed(42)
-        vocab_size = 1024
-        device = (
-            torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
+    def test_grpo_asymmetric_clipping(self):
+        data = _policy_loss_data(
+            current_log_prob=[torch.log(torch.tensor(1.25))],
+            sample_log_prob=[0.0],
+            advantage=[1.0],
         )
+        loss = GRPOLoss(
+            _FixedLogProbPolicy(),
+            clip_epsilon=(0.20, 0.28),
+            entropy_bonus=False,
+        )(data)
 
-        # Create mock model and wrap it
-        model = mock_transformer_model(vocab_size=vocab_size, device=device)
-        actor_network = TransformersWrapper(
-            model,
-            generate=False,
-            pad_output=True,
-            input_mode="history",
+        torch.testing.assert_close(loss.loss_objective, torch.tensor(-1.25))
+        torch.testing.assert_close(loss.clip_fraction, torch.tensor(0.0))
+
+    def test_kl_mask_threshold(self):
+        data = _policy_loss_data(
+            current_log_prob=[0.0, 1.0],
+            sample_log_prob=[0.0, 0.0],
+            advantage=[2.0, 10.0],
         )
+        loss = GRPOLoss(
+            _FixedLogProbPolicy(),
+            clip_epsilon=(0.9, 2.0),
+            kl_mask_threshold=0.125,
+            entropy_bonus=False,
+        )(data)
 
-        # Create fake data
-        data = _mock_data_grpo(vocab_size=vocab_size, device=device)
-
-        # First, test that the data works without any threshold
-        loss_fn_baseline = GRPOLoss(
-            actor_network, clip_epsilon=0.2, kl_mask_threshold=None
-        )
-
-        data_baseline = data.clone()
-        loss_baseline = loss_fn_baseline(data_baseline)
-        logger.info(f"Baseline loss (no threshold): {loss_baseline.loss_objective}")
-        logger.info(f"Baseline ESS: {loss_baseline.ESS}")
-
-        # Check baseline is valid
-        if not torch.isfinite(loss_baseline.loss_objective):
-            raise ValueError(
-                f"Baseline loss is not finite: {loss_baseline.loss_objective}, skipping test"
-            )
-
-        # Now test with kl_mask_threshold enabled
-        # Use a very high threshold that should not mask any tokens
-        kl_threshold = 100.0  # Extremely high threshold to ensure no masking
-        loss_fn_with_threshold = GRPOLoss(
-            actor_network, clip_epsilon=0.2, kl_mask_threshold=kl_threshold
-        )
-
-        data_with_threshold = data.clone()
-        loss_with_threshold = loss_fn_with_threshold(data_with_threshold)
-
-        # Should produce valid output
-        assert isinstance(loss_with_threshold, GRPOLossOutput)
-
-        # Check that the loss is finite (with such a high threshold, it should be)
-        assert torch.isfinite(
-            loss_with_threshold.loss_objective
-        ), f"loss_with_threshold is not finite: {loss_with_threshold.loss_objective}"
-        assert torch.isfinite(
-            loss_with_threshold.ESS
-        ), f"ESS with threshold is not finite: {loss_with_threshold.ESS}"
-
-        logger.info(
-            f"Loss with high threshold (100.0): {loss_with_threshold.loss_objective}"
-        )
-        logger.info(f"ESS with high threshold: {loss_with_threshold.ESS}")
-
-        # The losses should be identical or very similar since we're not masking anything
-        # (the difference comes only from numerical precision)
-        assert torch.isclose(
-            loss_baseline.loss_objective, loss_with_threshold.loss_objective, rtol=1e-3
-        ), f"Losses differ too much with high threshold: {loss_baseline.loss_objective} vs {loss_with_threshold.loss_objective}"
+        torch.testing.assert_close(loss.loss_objective, torch.tensor(-2.0))
 
     def test_failure_missing_entries(self, mock_transformer_model):
         """Test that GRPO fails when required keys are missing but works without optional keys."""
@@ -861,67 +848,17 @@ class TestLosses:
         with pytest.raises(KeyError, match="Couldn't find the ref log-prob"):
             loss_fn_with_kl(data_missing_ref_for_kl)
 
-    def test_cispo(self, mock_transformer_model):
-        """Test CISPO loss computation with mock models."""
-        vocab_size = 1024
-        device = torch.device("cpu")
-        eps = 0.20
-
-        # Create mock model and wrap it
-        model = mock_transformer_model(vocab_size=vocab_size, device=device)
-        actor_network = TransformersWrapper(
-            model,
-            generate=False,
-            pad_output=True,
-            input_mode="history",
+    def test_cispo_clips_importance_weight(self):
+        data = _policy_loss_data(
+            current_log_prob=[torch.log(torch.tensor(0.5))],
+            sample_log_prob=[0.0],
+            advantage=[1.0],
         )
+        loss = CISPOLoss(
+            _FixedLogProbPolicy(), clip_epsilon=0.2, entropy_bonus=False
+        )(data)
 
-        # Create loss module
-
-        loss_fn = CISPOLoss(actor_network, clip_epsilon=eps)
-
-        # Create fake data
-        data = _mock_data_grpo(vocab_size=vocab_size, device=device)
-
-        # Compute loss
-        loss_vals = loss_fn(data)
-
-        # Assertions: Check output type and structure
-
-        assert isinstance(
-            loss_vals, CISPOLossOutput
-        ), f"Expected CISPOLossOutput, got {type(loss_vals)}"
-
-        # Check that all expected keys are present (same as GRPO)
-        assert hasattr(loss_vals, "loss_objective"), "Missing loss_objective"
-        assert hasattr(loss_vals, "clip_fraction"), "Missing clip_fraction"
-        assert hasattr(loss_vals, "kl_approx"), "Missing kl_approx"
-        assert hasattr(loss_vals, "ESS"), "Missing ESS"
-        assert hasattr(loss_vals, "entropy"), "Missing entropy"
-        assert hasattr(loss_vals, "loss_entropy"), "Missing loss_entropy"
-
-        # Check tensor shapes (all losses should be scalars after reduction)
-        assert (
-            loss_vals.loss_objective.shape == ()
-        ), f"loss_objective should be scalar, got {loss_vals.loss_objective.shape}"
-        assert (
-            loss_vals.clip_fraction.shape == ()
-        ), f"clip_fraction should be scalar, got {loss_vals.clip_fraction.shape}"
-        assert (
-            loss_vals.kl_approx.shape == ()
-        ), f"kl_approx should be scalar, got {loss_vals.kl_approx.shape}"
-        assert (
-            loss_vals.ESS.shape == ()
-        ), f"ESS should be scalar, got {loss_vals.ESS.shape}"
-
-        # Check that losses are finite
-        assert torch.isfinite(loss_vals.loss_objective), "loss_objective is not finite"
-        assert torch.isfinite(loss_vals.ESS), "ESS is not finite"
-
-        # Check that clip_fraction is in valid range [0, 1]
-        assert (
-            0 <= loss_vals.clip_fraction <= 1
-        ), f"clip_fraction out of range: {loss_vals.clip_fraction}"
+        torch.testing.assert_close(loss.loss_objective, torch.tensor(-0.8))
 
 
 class TestSFT:


### PR DESCRIPTION
## Summary

- distinguish asymmetric GRPO clipping from symmetric clipping with exact ratios
- exercise KL masking with tokens on both sides of the threshold
- verify the CISPO clipped-importance objective numerically

## Motivation

Related to #4144. The prior shape and finiteness checks did not distinguish these public behaviors. This PR intentionally does not close the broader audit issue.

## Testing

- 69 focused tests passed, with 3 optional-dependency skips
- targeted mutation checks rejected incorrect behavior
- git diff --check passed

cc @vmoens