### PR TITLE
[Quality] Test replay buffer data behavior

### DIFF
--- a/test/rb/test_prioritized.py
+++ b/test/rb/test_prioritized.py
@@ -341,8 +341,7 @@ def test_cuda_prioritized_replay_buffer_weight_matches_cpu_formula():
 
 @pytest.mark.parametrize("stack", [False, True])
 @pytest.mark.parametrize("datatype", ["tc", "tb"])
-@pytest.mark.parametrize("reduction", ["min", "max", "median", "mean"])
-def test_replay_buffer_trajectories(stack, reduction, datatype):
+def test_replay_buffer_trajectories(stack, datatype):
     traj_td = TensorDict(
         {"obs": torch.randn(3, 4, 5), "actions": torch.randn(3, 4, 2)},
         batch_size=[3, 4],
@@ -364,7 +363,7 @@ def test_replay_buffer_trajectories(stack, reduction, datatype):
             5,
             alpha=0.7,
             beta=0.9,
-            reduction=reduction,
+            reduction="max",
         ),
         batch_size=3,
     )

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -675,9 +675,7 @@ def test_rb_trajectories(stack, reduction):
         generator=torch.Generator().manual_seed(0),
     )
     rb.extend(traj_td)
-    update = traj_td.clone().set(
-        "index", torch.arange(3).view(3, 1).expand(3, 4)
-    )
+    update = traj_td.clone().set("index", torch.arange(3).view(3, 1).expand(3, 4))
     update.set("td_error", priorities)
     rb.update_tensordict_priority(update)
 
@@ -693,9 +691,9 @@ def test_rb_trajectories(stack, reduction):
     assert indices.unique().numel() == 3
     torch.testing.assert_close(
         sampled_td["priority_weight"],
-        expected_weights[indices].unsqueeze(-1).expand_as(
-            sampled_td["priority_weight"]
-        ),
+        expected_weights[indices]
+        .unsqueeze(-1)
+        .expand_as(sampled_td["priority_weight"]),
     )
 
 

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -655,6 +655,9 @@ def test_add_warning():
 @pytest.mark.parametrize("stack", [False, True])
 @pytest.mark.parametrize("reduction", ["min", "max", "mean", "median"])
 def test_rb_trajectories(stack, reduction):
+    priorities = torch.tensor(
+        [[1.0, 2.0, 4.0, 8.0], [2.0, 5.0, 6.0, 9.0], [3.0, 7.0, 10.0, 20.0]]
+    )
     traj_td = TensorDict(
         {"obs": torch.randn(3, 4, 5), "actions": torch.randn(3, 4, 2)},
         batch_size=[3, 4],
@@ -663,25 +666,37 @@ def test_rb_trajectories(stack, reduction):
         traj_td = torch.stack([td.to_tensordict() for td in traj_td], 0)
 
     rb = TensorDictPrioritizedReplayBuffer(
-        alpha=0.7,
-        beta=0.9,
+        alpha=1.0,
+        beta=1.0,
         priority_key="td_error",
         storage=ListStorage(5),
-        batch_size=3,
+        batch_size=24,
+        reduction=reduction,
+        generator=torch.Generator().manual_seed(0),
     )
     rb.extend(traj_td)
-    sampled_td = rb.sample()
-    sampled_td.set("td_error", torch.rand(3, 4))
-    rb.update_tensordict_priority(sampled_td)
-    sampled_td = rb.sample(include_info=True)
-    assert (sampled_td.get("priority_weight") > 0).all()
-    assert sampled_td.batch_size == torch.Size([3, 4])
-
-    # set back the trajectory length
-    sampled_td_filtered = sampled_td.to_tensordict().exclude(
-        "priority_weight", "index", "td_error"
+    update = traj_td.clone().set(
+        "index", torch.arange(3).view(3, 1).expand(3, 4)
     )
-    sampled_td_filtered.batch_size = [3, 4]
+    update.set("td_error", priorities)
+    rb.update_tensordict_priority(update)
+
+    reduced_priorities = {
+        "min": priorities.min(-1).values,
+        "max": priorities.max(-1).values,
+        "mean": priorities.mean(-1),
+        "median": priorities.median(-1).values,
+    }[reduction]
+    expected_weights = (reduced_priorities / reduced_priorities.min()).pow(-1)
+    sampled_td = rb.sample()
+    indices = sampled_td["index"][:, 0]
+    assert indices.unique().numel() == 3
+    torch.testing.assert_close(
+        sampled_td["priority_weight"],
+        expected_weights[indices].unsqueeze(-1).expand_as(
+            sampled_td["priority_weight"]
+        ),
+    )
 
 
 def test_shared_storage_prioritized_sampler():

--- a/test/test_offline_to_online.py
+++ b/test/test_offline_to_online.py
@@ -299,10 +299,20 @@ class TestPrefillReplayBuffer:
         result = prefill_replay_buffer(target, offline, n_samples=50)
         assert result is target
 
-    def test_prefill_respects_chunk_size(self):
+    def test_prefill_respects_chunk_size(self, monkeypatch):
         offline = _make_offline_buffer(n=1000)
         target = ReplayBuffer(storage=LazyTensorStorage(10_000))
+        chunk_sizes = []
+        extend = target.extend
+
+        def record_extend(data):
+            chunk_sizes.append(data.batch_size[0])
+            return extend(data)
+
+        monkeypatch.setattr(target, "extend", record_extend)
         prefill_replay_buffer(target, offline, n_samples=250, chunk_size=37)
+
+        assert chunk_sizes == [37, 37, 37, 37, 37, 37, 28]
         assert len(target) == 250
 
     def test_prefill_string_dataset_uses_chunk_size_as_dataset_batch_size(


### PR DESCRIPTION
## Summary

- verify prefill_replay_buffer uses the requested chunk sizes
- verify min, max, mean, and median trajectory-priority reductions with distinguishable priorities
- remove a redundant reduction parameterization that did not assert reduction behavior

## Motivation

Related to #4144. These tests now validate public chunking and prioritized replay behavior rather than only final shapes and lengths. This PR intentionally does not close the broader audit issue.

## Testing

- 13 focused replay and data tests passed
- git diff --check passed

cc @vmoens