### PR TITLE
[BugFix] Implement shared MLP output bias

### DIFF
--- a/test/modules/test_mlp_conv.py
+++ b/test/modules/test_mlp_conv.py
@@ -12,7 +12,7 @@ import torch
 from torch import nn
 from torchrl.modules.models import BatchRenorm1d, Conv3dNet, ConvNet, MLP, NoisyLinear
 from torchrl.modules.models.recipes.impala import _ConvNetBlock
-from torchrl.modules.models.utils import SquashDims
+from torchrl.modules.models.utils import _reset_parameters_recursive, SquashDims
 
 from torchrl.testing import get_default_devices
 
@@ -35,8 +35,10 @@ class TestMLP:
     )
     @pytest.mark.parametrize("dropout", [0.0, 0.5])
     @pytest.mark.parametrize("bias_last_layer", [True, False])
-    @pytest.mark.parametrize("single_bias_last_layer", [True, False])
-    @pytest.mark.parametrize("layer_class", [nn.Linear, NoisyLinear])
+    @pytest.mark.parametrize(
+        "single_bias_last_layer,layer_class",
+        [(False, nn.Linear), (True, nn.Linear), (False, NoisyLinear)],
+    )
     @pytest.mark.parametrize("device", get_default_devices())
     def test_mlp(
         self,
@@ -100,6 +102,9 @@ class TestMLP:
         output = mlp(torch.zeros(4, 2))
         torch.testing.assert_close(output, torch.full((4, 2, 3), 2.0))
 
+        _reset_parameters_recursive(mlp)
+        torch.testing.assert_close(shared_bias[0], torch.zeros_like(shared_bias[0]))
+
         mlp_without_bias = MLP(
             in_features=2,
             out_features=3,
@@ -110,6 +115,16 @@ class TestMLP:
         assert all(
             parameter.numel() != 1 for parameter in mlp_without_bias.parameters()
         )
+
+    def test_single_bias_last_layer_rejects_noisy_linear(self):
+        with pytest.raises(ValueError, match="incompatible with NoisyLinear"):
+            MLP(
+                in_features=2,
+                out_features=3,
+                depth=0,
+                single_bias_last_layer=True,
+                layer_class=NoisyLinear,
+            )
 
     def test_kwargs(self):
         def make_activation(shift):

--- a/test/modules/test_mlp_conv.py
+++ b/test/modules/test_mlp_conv.py
@@ -68,7 +68,7 @@ class TestMLP:
             norm_kwargs=norm_kwargs,
             dropout=dropout,
             bias_last_layer=bias_last_layer,
-            single_bias_last_layer=False,
+            single_bias_last_layer=single_bias_last_layer,
             layer_class=layer_class,
             device=device,
         )
@@ -80,6 +80,34 @@ class TestMLP:
             [out_features] if isinstance(out_features, Number) else out_features
         )
         assert y.shape == torch.Size([batch, *out_features])
+
+    def test_single_bias_last_layer(self):
+        mlp = MLP(
+            in_features=2,
+            out_features=(2, 3),
+            depth=0,
+            single_bias_last_layer=True,
+        )
+        parameters = list(mlp.parameters())
+        shared_bias = [parameter for parameter in parameters if parameter.numel() == 1]
+        assert len(shared_bias) == 1
+
+        with torch.no_grad():
+            for parameter in parameters:
+                parameter.zero_()
+            shared_bias[0].fill_(2)
+
+        output = mlp(torch.zeros(4, 2))
+        torch.testing.assert_close(output, torch.full((4, 2, 3), 2.0))
+
+        mlp_without_bias = MLP(
+            in_features=2,
+            out_features=3,
+            depth=0,
+            bias_last_layer=False,
+            single_bias_last_layer=True,
+        )
+        assert all(parameter.numel() != 1 for parameter in mlp_without_bias.parameters())
 
     def test_kwargs(self):
         def make_activation(shift):

--- a/test/modules/test_mlp_conv.py
+++ b/test/modules/test_mlp_conv.py
@@ -107,7 +107,9 @@ class TestMLP:
             bias_last_layer=False,
             single_bias_last_layer=True,
         )
-        assert all(parameter.numel() != 1 for parameter in mlp_without_bias.parameters())
+        assert all(
+            parameter.numel() != 1 for parameter in mlp_without_bias.parameters()
+        )
 
     def test_kwargs(self):
         def make_activation(shift):

--- a/torchrl/modules/models/models.py
+++ b/torchrl/modules/models/models.py
@@ -26,6 +26,15 @@ from torchrl.modules.models.utils import (
 from torchrl.modules.tensordict_module.common import DistributionalDQNnet  # noqa
 
 
+class _SharedBias(nn.Module):
+    def __init__(self, device: DEVICE_TYPING | None = None, dtype=None):
+        super().__init__()
+        self.bias = nn.Parameter(torch.zeros(1, device=device, dtype=dtype))
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        return input + self.bias
+
+
 class MLP(nn.Sequential):
     """A multi-layer perceptron.
 
@@ -70,9 +79,8 @@ class MLP(nn.Sequential):
             dropout);
         bias_last_layer (bool): if ``True``, the last Linear layer will have a bias parameter.
             default: True;
-        single_bias_last_layer (bool): if ``True``, the last dimension of the bias of the last layer will be a singleton
-            dimension.
-            default: True;
+        single_bias_last_layer (bool): if ``True``, the bias of the last layer is
+            shared across its output features. Defaults to ``False``.
         layer_class (Type[nn.Module] or callable, optional): class to be used
             for the linear layers;
         layer_kwargs (dict or list of dicts, optional): kwargs for the linear
@@ -209,9 +217,6 @@ class MLP(nn.Sequential):
         self.layer_kwargs = layer_kwargs
 
         self.activate_last_layer = activate_last_layer
-        if single_bias_last_layer:
-            raise NotImplementedError
-
         if not (isinstance(num_cells, Sequence) or depth is not None):
             raise RuntimeError(
                 "If num_cells is provided as an integer, \
@@ -252,16 +257,15 @@ class MLP(nn.Sequential):
             _bias = layer_kwargs.pop(
                 "bias", self.bias_last_layer if i == self.depth else True
             )
+            single_bias = i == self.depth and self.single_bias_last_layer and _bias
             if _in is not None:
-                layers.append(
-                    create_on_device(
-                        self.layer_class,
-                        device,
-                        _in,
-                        _out,
-                        bias=_bias,
-                        **layer_kwargs,
-                    )
+                layer = create_on_device(
+                    self.layer_class,
+                    device,
+                    _in,
+                    _out,
+                    bias=_bias and not single_bias,
+                    **layer_kwargs,
                 )
             else:
                 try:
@@ -271,9 +275,20 @@ class MLP(nn.Sequential):
                         f"The lazy version of {self.layer_class.__name__} is not implemented yet. "
                         "Consider providing the input feature dimensions explicitly when creating an MLP module"
                     )
+                layer = create_on_device(
+                    lazy_version,
+                    device,
+                    _out,
+                    bias=_bias and not single_bias,
+                    **layer_kwargs,
+                )
+            layers.append(layer)
+            if single_bias:
+                parameter = next(layer.parameters(), None)
                 layers.append(
-                    create_on_device(
-                        lazy_version, device, _out, bias=_bias, **layer_kwargs
+                    _SharedBias(
+                        device=parameter.device if parameter is not None else device,
+                        dtype=parameter.dtype if parameter is not None else None,
                     )
                 )
 

--- a/torchrl/modules/models/models.py
+++ b/torchrl/modules/models/models.py
@@ -15,6 +15,7 @@ from torch import nn
 from torchrl._utils import prod
 from torchrl.data.utils import DEVICE_TYPING
 from torchrl.modules.models.decision_transformer import DecisionTransformer
+from torchrl.modules.models.exploration import NoisyLinear
 from torchrl.modules.models.utils import (
     _find_depth,
     create_on_device,
@@ -30,6 +31,9 @@ class _SharedBias(nn.Module):
     def __init__(self, device: DEVICE_TYPING | None = None, dtype=None):
         super().__init__()
         self.bias = nn.Parameter(torch.zeros(1, device=device, dtype=dtype))
+
+    def reset_parameters(self) -> None:
+        nn.init.zeros_(self.bias)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         return input + self.bias
@@ -80,7 +84,8 @@ class MLP(nn.Sequential):
         bias_last_layer (bool): if ``True``, the last Linear layer will have a bias parameter.
             default: True;
         single_bias_last_layer (bool): if ``True``, the bias of the last layer is
-            shared across its output features. Defaults to ``False``.
+            shared across its output features. This option is incompatible with
+            :class:`~torchrl.modules.NoisyLinear`. Defaults to ``False``.
         layer_class (Type[nn.Module] or callable, optional): class to be used
             for the linear layers;
         layer_kwargs (dict or list of dicts, optional): kwargs for the linear
@@ -281,6 +286,14 @@ class MLP(nn.Sequential):
                     _out,
                     bias=_bias and not single_bias,
                     **layer_kwargs,
+                )
+            if (
+                i == self.depth
+                and self.single_bias_last_layer
+                and isinstance(layer, NoisyLinear)
+            ):
+                raise ValueError(
+                    "single_bias_last_layer=True is incompatible with NoisyLinear."
                 )
             layers.append(layer)
             if single_bias:


### PR DESCRIPTION
## Summary

- implement the documented single_bias_last_layer option as one scalar bias shared across output features\n- honor bias_last_layer, lazy layers, device and dtype, and shaped outputs\n- reject single shared bias with NoisyLinear because its per-output stochastic bias has incompatible semantics\n- reset the shared scalar through the standard recursive reset path\n- activate the existing parameterized coverage and add focused shared-bias assertions\n\n## Motivation\n\nRelated to #4144. The maintainer confirmed that the public option raising NotImplementedError was a bug and should follow its documented behavior. This PR intentionally does not close the broader audit issue.\n\n## Testing\n\n- all 1,299 focused TestMLP cases passed\n- git diff --check passed\n\ncc @vmoens