### PR TITLE
[Quality] Exercise tensor lambda test cases

### DIFF
--- a/test/objectives/test_values.py
+++ b/test/objectives/test_values.py
@@ -1574,10 +1574,16 @@ class TestValues:
 
         if lmbda_tensor == "tensor":
             lmbda_vec = torch.full_like(reward, lmbda)
-        elif gamma_tensor == "tensor_single_element":
+        elif lmbda_tensor == "tensor_single_element":
             lmbda_vec = torch.as_tensor([lmbda], device=device)
         else:
             lmbda_vec = lmbda
+        if lmbda_tensor == "tensor":
+            assert lmbda_vec.shape == reward.shape
+        elif lmbda_tensor == "tensor_single_element":
+            assert lmbda_vec.shape == (1,)
+        else:
+            assert isinstance(lmbda_vec, float)
 
         r1 = vec_generalized_advantage_estimate(
             gamma_vec,
@@ -1925,10 +1931,14 @@ class TestValues:
         else:
             gamma_vec = gamma
 
-        if gamma_tensor == "tensor_single_element":
+        if lmbda_tensor == "tensor_single_element":
             lmbda_vec = torch.as_tensor([lmbda], device=device)
         else:
             lmbda_vec = lmbda
+        if lmbda_tensor == "tensor_single_element":
+            assert lmbda_vec.shape == (1,)
+        else:
+            assert isinstance(lmbda_vec, float)
 
         v1 = vec_td_lambda_advantage_estimate(
             gamma,

--- a/test/objectives/test_values.py
+++ b/test/objectives/test_values.py
@@ -1545,7 +1545,8 @@ class TestValues:
         "gamma_tensor", ["scalar", "tensor", "tensor_single_element"]
     )
     @pytest.mark.parametrize(
-        "lmbda_tensor", ["scalar", "tensor", "tensor_single_element"]
+        "lmbda_tensor",
+        ["scalar", "tensor", "tensor_zero_dim", "tensor_single_element"],
     )
     def test_gae_param_as_tensor(
         self, device, N, dtype, has_done, gamma_tensor, lmbda_tensor
@@ -1574,16 +1575,12 @@ class TestValues:
 
         if lmbda_tensor == "tensor":
             lmbda_vec = torch.full_like(reward, lmbda)
+        elif lmbda_tensor == "tensor_zero_dim":
+            lmbda_vec = torch.as_tensor(lmbda, device=device)
         elif lmbda_tensor == "tensor_single_element":
             lmbda_vec = torch.as_tensor([lmbda], device=device)
         else:
             lmbda_vec = lmbda
-        if lmbda_tensor == "tensor":
-            assert lmbda_vec.shape == reward.shape
-        elif lmbda_tensor == "tensor_single_element":
-            assert lmbda_vec.shape == (1,)
-        else:
-            assert isinstance(lmbda_vec, float)
 
         r1 = vec_generalized_advantage_estimate(
             gamma_vec,
@@ -1905,7 +1902,9 @@ class TestValues:
     @pytest.mark.parametrize(
         "gamma_tensor", ["scalar", "tensor", "tensor_single_element"]
     )
-    @pytest.mark.parametrize("lmbda_tensor", ["scalar", "tensor_single_element"])
+    @pytest.mark.parametrize(
+        "lmbda_tensor", ["scalar", "tensor_zero_dim", "tensor_single_element"]
+    )
     def test_tdlambda_tensor_gamma_single_element(
         self, device, gamma, lmbda, N, T, F, has_done, gamma_tensor, lmbda_tensor
     ):
@@ -1931,14 +1930,12 @@ class TestValues:
         else:
             gamma_vec = gamma
 
-        if lmbda_tensor == "tensor_single_element":
+        if lmbda_tensor == "tensor_zero_dim":
+            lmbda_vec = torch.as_tensor(lmbda, device=device)
+        elif lmbda_tensor == "tensor_single_element":
             lmbda_vec = torch.as_tensor([lmbda], device=device)
         else:
             lmbda_vec = lmbda
-        if lmbda_tensor == "tensor_single_element":
-            assert lmbda_vec.shape == (1,)
-        else:
-            assert isinstance(lmbda_vec, float)
 
         v1 = vec_td_lambda_advantage_estimate(
             gamma,


### PR DESCRIPTION
## Summary

- correct the GAE and TD-lambda parameterization condition to use lmbda_tensor\n- exercise scalar, zero-dimensional, and one-dimensional lambda representations through the value computations\n\n## Motivation\n\nRelated to #4144. The typo left the tensor-lambda cases selecting a different representation than their test IDs claimed. This PR intentionally does not close the broader audit issue.\n\n## Testing\n\n- 720 focused value-objective tests passed\n- git diff --check passed\n\ncc @vmoens