### PR TITLE
[Quality] Test asymmetric ClipPPO behavior

### DIFF
--- a/test/objectives/test_ppo.py
+++ b/test/objectives/test_ppo.py
@@ -1322,6 +1322,10 @@ class TestPPO(LossModuleTestBase):
         value = self._create_mock_value()
         advantage = GAE(gamma=0.9, lmbda=0.9, value_network=value)
         advantage(td)
+        with torch.no_grad():
+            current_log_prob = actor.get_dist(td).log_prob(td["action"])
+        td["action_log_prob"] = current_log_prob - torch.tensor(1.25).log()
+        td["advantage"] = torch.ones_like(td["advantage"])
 
         loss_sym = ClipPPOLoss(actor, value, clip_epsilon=0.2)
         loss_asym = ClipPPOLoss(actor, value, clip_epsilon=(0.2, 0.28))
@@ -1343,8 +1347,11 @@ class TestPPO(LossModuleTestBase):
         torch.manual_seed(self.seed)
         out_eq = loss_eq(td.clone())
         torch.testing.assert_close(out_sym["loss_objective"], out_eq["loss_objective"])
-        # the asymmetric loss runs end-to-end
-        loss_asym(td.clone())
+        out_asym = loss_asym(td.clone())
+        torch.testing.assert_close(out_sym["loss_objective"], torch.tensor(-1.2))
+        torch.testing.assert_close(out_asym["loss_objective"], torch.tensor(-1.25))
+        torch.testing.assert_close(out_sym["clip_fraction"], torch.tensor(1.0))
+        torch.testing.assert_close(out_asym["clip_fraction"], torch.tensor(0.0))
 
         # both buffer flavors accept scheduled scalar assignment
         loss_sym.clip_epsilon = 0.1


### PR DESCRIPTION
## Summary

- force a policy ratio above the symmetric upper bound
- verify exact objectives and clip fractions for symmetric and asymmetric bounds

## Motivation

Related to #4144. The existing test exercised the asymmetric API without asserting its objective. This PR intentionally does not close the broader audit issue.

## Testing

- 2 focused asymmetric ClipPPO tests passed
- git diff --check passed

cc @vmoens