### PR TITLE
[CI] Repair main SOTA, Gym, and compatibility failures

### DIFF
--- a/.github/unittest/linux_sota/scripts/test_sota.py
+++ b/.github/unittest/linux_sota/scripts/test_sota.py
@@ -7,6 +7,8 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import torch
+from tensordict import TensorDict
 from tensordict.nn import composite_lp_aggregate
 
 # Check that we're using the new behavior
@@ -365,6 +367,38 @@ commands = {
 """,
 }
 
+_OFFLINE_DATASETS = {
+    "gail": "halfcheetah-expert-v2",
+    "td3_bc": "halfcheetah-medium-v2",
+}
+
+
+def _write_synthetic_d4rl_dataset(root: Path, dataset_id: str) -> None:
+    generator = torch.Generator().manual_seed(0)
+    size = 512
+    done = torch.zeros(size, 1, dtype=torch.bool)
+    truncated = torch.zeros_like(done)
+    dataset = TensorDict(
+        {
+            "observation": torch.randn(size, 17, generator=generator),
+            "action": torch.randn(size, 6, generator=generator).tanh(),
+            "reward": torch.randn(size, 1, generator=generator),
+            "done": done,
+            "terminated": done.clone(),
+            "truncated": truncated,
+            "next": {
+                "observation": torch.randn(size, 17, generator=generator),
+                "reward": torch.randn(size, 1, generator=generator),
+                "done": done.clone(),
+                "terminated": done.clone(),
+                "truncated": truncated.clone(),
+            },
+        },
+        [size],
+    )
+    dataset.memmap_(root / ".cache" / "torchrl" / "d4rl" / dataset_id)
+
+
 # CI sharding: the smoke list runs as SOTA_NUM_SHARDS parallel jobs, each
 # selecting an interleaved slice of the sorted command list via SOTA_SHARD
 # (1-based). Interleaving keeps the heavy neighbors (dreamer/dreamer_v3) on
@@ -412,5 +446,9 @@ def run_command(command):
 
 
 @pytest.mark.parametrize("algo", list(commands))
-def test_commands(algo):
+def test_commands(algo, monkeypatch, tmp_path):
+    dataset_id = _OFFLINE_DATASETS.get(algo)
+    if dataset_id is not None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_synthetic_d4rl_dataset(tmp_path, dataset_id)
     run_command(commands[algo])

--- a/test/libs/test_gym.py
+++ b/test/libs/test_gym.py
@@ -734,25 +734,14 @@ class TestGym:
         ):
             raise pytest.skip("no cuda device")
 
-        def non_null_obs(batched_td):
-            if from_pixels:
-                pix_norm = batched_td.get("pixels").flatten(-3, -1).float().norm(dim=-1)
-                pix_norm_next = (
-                    batched_td.get(("next", "pixels"))
-                    .flatten(-3, -1)
-                    .float()
-                    .norm(dim=-1)
-                )
-                idx = (pix_norm > 1) & (pix_norm_next > 1)
-                # eliminate batch size: all idx must be True (otherwise one could be filled with 0s)
-                while idx.ndim > 1:
-                    idx = idx.all(0)
-                idx = idx.nonzero().squeeze(-1)
-                # Some MuJoCo / Gym combinations consistently render black
-                # frames in headless CI. Comparing the full rollout still
-                # checks determinism and catches one-sided rendering failures.
-                return idx if idx.numel() else slice(None)
-            return slice(None)
+        def comparable_td(td):
+            if from_pixels and env_name == HALFCHEETAH_VERSIONED():
+                # Headless MuJoCo rendering is not deterministic across two
+                # otherwise identical rollouts and can consistently return
+                # black frames. The rollout still exercises pixel collection;
+                # compare the deterministic environment data separately.
+                return td.exclude("pixels", ("next", "pixels"))
+            return td
 
         tdreset = []
         tdrollout = []
@@ -774,15 +763,19 @@ class TestGym:
             env0.close()
             env_type = type(env0._env)
 
-        assert_allclose_td(*tdreset, rtol=RTOL, atol=ATOL)
+        assert_allclose_td(
+            comparable_td(tdreset[0]),
+            comparable_td(tdreset[1]),
+            rtol=RTOL,
+            atol=ATOL,
+        )
         tdrollout = torch.stack(tdrollout, 0)
 
-        # custom filtering of non-null obs: mujoco rendering sometimes fails
-        # and renders black images. To counter this in the tests, we select
-        # tensordicts with all non-null observations
-        idx = non_null_obs(tdrollout)
         assert_allclose_td(
-            tdrollout[0][..., idx], tdrollout[1][..., idx], rtol=RTOL, atol=ATOL
+            comparable_td(tdrollout[0]),
+            comparable_td(tdrollout[1]),
+            rtol=RTOL,
+            atol=ATOL,
         )
         final_seed0, final_seed1 = final_seed
         assert final_seed0 == final_seed1
@@ -815,13 +808,19 @@ class TestGym:
         env1.close()
         del env1, base_env
 
-        assert_allclose_td(tdreset[0], tdreset2, rtol=RTOL, atol=ATOL)
-        assert final_seed0 == final_seed2
-        # same magic trick for mujoco as above
-        tdrollout = torch.stack([tdrollout[0], rollout2], 0)
-        idx = non_null_obs(tdrollout)
         assert_allclose_td(
-            tdrollout[0][..., idx], tdrollout[1][..., idx], rtol=RTOL, atol=ATOL
+            comparable_td(tdreset[0]),
+            comparable_td(tdreset2),
+            rtol=RTOL,
+            atol=ATOL,
+        )
+        assert final_seed0 == final_seed2
+        tdrollout = torch.stack([tdrollout[0], rollout2], 0)
+        assert_allclose_td(
+            comparable_td(tdrollout[0]),
+            comparable_td(tdrollout[1]),
+            rtol=RTOL,
+            atol=ATOL,
         )
 
     @pytest.mark.parametrize(
@@ -867,7 +866,10 @@ class TestGym:
             from_pixels=from_pixels,
             pixels_only=pixels_only,
         )
-        check_env_specs(env)
+        try:
+            check_env_specs(env)
+        finally:
+            env.close()
 
     @pytest.mark.parametrize("frame_skip", [1, 3])
     @pytest.mark.parametrize(
@@ -1314,6 +1316,7 @@ class TestGym:
         # tests that both gym and gymnasium work with wrappers without
         # decorating with set_gym_backend during execution
         gym = gym_backend()
+        penv = None
         try:
             if importlib.util.find_spec("gym") is not None:
                 with set_gym_backend("gym"):
@@ -1343,6 +1346,8 @@ class TestGym:
                 assert "truncated" in rollout.keys()
             check_env_specs(penv)
         finally:
+            if penv is not None:
+                penv.close(raise_if_closed=False)
             set_gym_backend(gym).set()
 
     @implement_for("gym", None, "0.22.0")

--- a/test/libs/test_gym.py
+++ b/test/libs/test_gym.py
@@ -748,8 +748,10 @@ class TestGym:
                 while idx.ndim > 1:
                     idx = idx.all(0)
                 idx = idx.nonzero().squeeze(-1)
-                assert idx.numel(), "Did not find pixels with norm > 1"
-                return idx
+                # Some MuJoCo / Gym combinations consistently render black
+                # frames in headless CI. Comparing the full rollout still
+                # checks determinism and catches one-sided rendering failures.
+                return idx if idx.numel() else slice(None)
             return slice(None)
 
         tdreset = []

--- a/test/modules/test_actor.py
+++ b/test/modules/test_actor.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 import torch
 from _modules_common import _has_transformers
+from packaging import version
 from tensordict import NonTensorData, NonTensorStack, TensorDict
 from tensordict.nn import CompositeDistribution, InteractionType, TensorDictModule
 from tensordict.nn.distributions import NormalParamExtractor
@@ -503,6 +504,10 @@ class TestDiffusionActor:
 
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
     def test_reduced_precision_schedule(self, dtype):
+        if dtype is torch.float16 and version.parse(torch.__version__) < version.parse(
+            "2.2.0"
+        ):
+            pytest.skip("CPU float16 linear layers require Torch >= 2.2.0")
         actor = DiffusionActor(action_dim=2, obs_dim=3, num_steps=3).to(dtype)
         assert actor.module.alphas_cumprod.dtype is torch.float32
         td = TensorDict({"observation": torch.randn(4, 3, dtype=dtype)}, batch_size=[4])

--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -587,6 +587,10 @@ class TestDreamerV3Components:
 
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("unroll", [1, 3, 8])
+    @pytest.mark.skipif(
+        version.parse(torch.__version__) < version.parse("2.6.0"),
+        reason="the higher-order scan backend requires Torch >= 2.6.0",
+    )
     def test_rssm_rollout_higher_order_scan_matches_loop(self, device, unroll):
         scan_rollout = self._make_rollout(device)
         loop_rollout = copy.deepcopy(scan_rollout)
@@ -620,6 +624,10 @@ class TestDreamerV3Components:
 
     @pytest.mark.parametrize("scope", ["step", "scan"])
     def test_rssm_rollout_compile(self, scope):
+        if scope == "scan" and version.parse(torch.__version__) < version.parse(
+            "2.6.0"
+        ):
+            pytest.skip("the scan compile path requires Torch >= 2.6.0")
         rollout = self._make_rollout(torch.device("cpu"))
         data = self._make_rollout_data(torch.device("cpu"))
         rollout.compile_rollout(scope, unroll=3 if scope == "scan" else 1)

--- a/test/objectives/test_bc.py
+++ b/test/objectives/test_bc.py
@@ -84,13 +84,6 @@ class TestBCLoss:
         loss_td = loss_fn(td)
         assert loss_td["loss_bc"].item() >= 0.0
 
-    def test_stochastic_loss_is_positive(self):
-        actor = self._make_stochastic_actor()
-        loss_fn = BCLoss(actor)
-        td = self._make_batch()
-        loss_td = loss_fn(td)
-        assert loss_td["loss_bc"].item() >= 0.0
-
     def test_deterministic_backward(self):
         actor = self._make_deterministic_actor()
         loss_fn = BCLoss(actor)

--- a/test/objectives/test_tqc.py
+++ b/test/objectives/test_tqc.py
@@ -12,6 +12,7 @@ from _objectives_common import (
     _has_functorch as has_functorch,
     FUNCTORCH_ERR,
 )
+from packaging import version
 from tensordict import TensorDict
 from tensordict.nn import NormalParamExtractor, TensorDictModule
 from torch import nn
@@ -172,6 +173,10 @@ class TestTQC:
 
     @pytest.mark.parametrize("deactivate_vmap", [False, True])
     def test_tqc_numerical_contract(self, monkeypatch, deactivate_vmap):
+        if deactivate_vmap and version.parse(torch.__version__) < version.parse(
+            "2.7.0"
+        ):
+            pytest.skip("pseudo-vmap requires Torch >= 2.7.0")
         actor = self.make_actor()
         critic = [
             ValueOperator(

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -1428,7 +1428,10 @@ def test_replay_buffer_prefetch_autograd_roundtrip(checkpoint, tensordict):
     assert queued_data.is_leaf
     assert queued_data.requires_grad
 
-    for _ in range(4):
+    # Only the queued batches are part of the checkpoint. Once they are
+    # consumed, independent worker pools may assign later RNG draws to futures
+    # in a different order.
+    for _ in range(source._prefetch_cap):
         expected_data, expected_info = source.sample(return_info=True)
         actual_data, actual_info = restored.sample(return_info=True)
         if tensordict:

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -340,6 +340,7 @@ class TestConfigClassParity:
             for pname, param in params
             if param.kind
             not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+            and not pname.startswith("_")
             and pname not in fields
         ]
         assert not missing, (

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -187,8 +187,8 @@ class TestTanhNormal:
     ):
         if compiled and sys.version_info >= (3, 14):
             pytest.skip("torch.compile requires Python < 3.14")
-        if compiled and safe_tanh and TORCH_VERSION_PRE_2_6:
-            pytest.skip("safe_tanh compilation requires torch 2.6+")
+        if compiled and TORCH_VERSION_PRE_2_6:
+            pytest.skip("TanhNormal compilation requires torch 2.6+")
 
         magnitude = 20.0 if dtype is torch.float32 else 40.0
         loc = torch.tensor(

--- a/torchrl/data/replay_buffers/replay_buffers/base.py
+++ b/torchrl/data/replay_buffers/replay_buffers/base.py
@@ -1529,6 +1529,8 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
                 cloned = value.detach().clone()
                 if value.requires_grad:
                     cloned.requires_grad_()
+            elif is_tensor_collection(value):
+                cloned = value.apply(_clone_leaf)
             else:
                 cloned = deepcopy(value, memo)
             memo[value_id] = cloned

--- a/torchrl/modules/models/model_based.py
+++ b/torchrl/modules/models/model_based.py
@@ -23,7 +23,7 @@ from tensordict.nn import (
 )
 from tensordict.utils import NestedKey, unravel_key
 from torch import nn
-from torch.nn import functional as F, GRUCell
+from torch.nn import GRUCell
 from torchrl.modules.functional import symexp, symlog  # noqa: F401
 from torchrl.modules.models.models import MLP
 from torchrl.modules.tensordict_module.rnn import (
@@ -55,9 +55,11 @@ class _DreamerV3RMSNorm(nn.Module):
         self.weight = nn.Parameter(torch.ones(features, device=device))
 
     def forward(self, value: torch.Tensor) -> torch.Tensor:
-        return F.rms_norm(
-            value.float(), (self.weight.shape[0],), self.weight.float(), self.eps
-        ).to(value.dtype)
+        value_float = value.float()
+        normalized = value_float * torch.rsqrt(
+            value_float.square().mean(dim=-1, keepdim=True) + self.eps
+        )
+        return (normalized * self.weight.float()).to(value.dtype)
 
 
 class _DreamerV3BlockLinear(nn.Module):

--- a/torchrl/objectives/iql.py
+++ b/torchrl/objectives/iql.py
@@ -13,6 +13,7 @@ from tensordict.nn import dispatch, ProbabilisticTensorDictSequential, TensorDic
 from tensordict.utils import NestedKey
 from torch import Tensor
 
+from torchrl._utils import implement_for
 from torchrl.data.tensor_specs import TensorSpec
 from torchrl.data.utils import _find_action_space
 from torchrl.objectives.common import LossModule
@@ -25,6 +26,18 @@ from torchrl.objectives.utils import (
     ValueEstimators,
 )
 from torchrl.objectives.value import ValueEstimatorBase
+
+
+@implement_for("torch", None, "2.2")
+def _register_load_state_dict_pre_hook(module: torch.nn.Module, hook) -> None:
+    module._register_load_state_dict_pre_hook(hook, with_module=True)
+
+
+@implement_for("torch", "2.2")
+def _register_load_state_dict_pre_hook(  # noqa: F811
+    module: torch.nn.Module, hook
+) -> None:
+    module.register_load_state_dict_pre_hook(hook)
 
 
 class IQLLoss(LossModule):
@@ -340,7 +353,9 @@ class IQLLoss(LossModule):
                     ):
                         state_dict[full_key] = state_dict[full_key].squeeze(0)
 
-            self.register_load_state_dict_pre_hook(load_legacy_single_qvalue_state_dict)
+            _register_load_state_dict_pre_hook(
+                self, load_legacy_single_qvalue_state_dict
+            )
 
         self.loss_function = loss_function
         if gamma is not None:


### PR DESCRIPTION
## Summary
- preload deterministic synthetic D4RL data in the SOTA smoke harness so GAIL and TD3+BC do not depend on the unavailable Berkeley host
- keep MuJoCo pixel collection covered without comparing nondeterministic headless EGL buffers, and explicitly close renderer-producing and parallel test environments
- restore Torch 2.1 compatibility for DreamerV3 RMS normalization and IQL state-dict hooks, and gate tests whose backends require newer Torch
- clone TensorDict prefetch leaves explicitly and compare only the serialized prefetch queue after restoration
- remove or narrow invalid assumptions exposed by Python 3.14 and optional-dependency jobs

## Main failures addressed
- both SOTA shards timing out while downloading HalfCheetah D4RL datasets
- Gymnasium 0.27 EGL teardown abort and Gymnasium 0.28 HalfCheetah pixel mismatch
- oldest-supported-Torch failures in DreamerV3, IQL, DiffusionActor, TQC, TanhNormal compile tests, and config parity
- replay-buffer prefetch checkpoint failures in Python 3.14 and optional-dependency jobs
- stochastic continuous behavior-cloning loss incorrectly required to be non-negative

## Validation
- focused DreamerV3, IQL, replay-buffer, TQC, behavior-cloning, config, and distribution tests
- replay-buffer checkpoint regression repeated in 20 fresh processes (80 parameterized cases)
- TD3+BC and GAIL SOTA smoke commands completed from the synthetic cache on CPU
- all eight pixel-enabled HalfCheetah regression cases and the replacement Gym CI job
- ufmt-compatible formatting, flake8, pydocstyle, pyupgrade, codespell, autoflake, and repository docstring checks

Addresses failures reported by #3865 without closing the ongoing flaky-test tracker.