### PR TITLE
[BugFix] Harden the Triton RNN backend

### DIFF
--- a/test/modules/_modules_common.py
+++ b/test/modules/_modules_common.py
@@ -10,6 +10,8 @@ import sys
 import torch
 from packaging import version
 
+from torchrl._utils import _triton_version_at_least
+
 _has_transformers = importlib.util.find_spec("transformers") is not None
 _has_vllm = importlib.util.find_spec("vllm") is not None
 
@@ -17,20 +19,11 @@ TORCH_VERSION = version.parse(version.parse(torch.__version__).base_version)
 IS_WINDOWS = sys.platform == "win32"
 
 
-def _has_triton_backend() -> bool:
-    """Mirror of the triton-availability check inside the RNN backend.
-
-    Triton must be installed, CUDA must be available, and the Triton build
-    must expose the ``triton.language.extra.libdevice`` submodule
-    (Triton >= 2.2). Older Triton installations are routed to scan/pad
-    backends, so the triton-specific tests are skipped there.
-    """
-    if importlib.util.find_spec("triton") is None or not torch.cuda.is_available():
-        return False
-    return importlib.util.find_spec("triton.language.extra.libdevice") is not None
-
-
-_has_triton = _has_triton_backend()
+# Mirror of the triton-availability check inside the RNN backend: Triton
+# >= 2.2 must be installed and CUDA must be available. Older Triton
+# installations are routed to scan/pad backends, so the triton-specific
+# tests are skipped there.
+_has_triton = _triton_version_at_least("2.2") and torch.cuda.is_available()
 _triton_skip_reason = "requires triton (>= 2.2) and CUDA"
 
 _has_functorch = (

--- a/torchrl/_utils.py
+++ b/torchrl/_utils.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import collections
 import contextvars
 import functools
+import importlib.metadata
 import inspect
 import logging
 import math
@@ -25,6 +26,7 @@ from typing import Any, cast, TypeVar
 
 import numpy as np
 import torch
+from packaging import version as _packaging_version
 
 from pyvers import implement_for  # noqa: F401
 from tensordict import unravel_key
@@ -121,6 +123,20 @@ def _mp_sharing_strategy_for_spawn() -> str | None:
 @implement_for("torch", "2.8")
 def _mp_sharing_strategy_for_spawn() -> str | None:  # noqa: F811
     return None
+
+
+def _triton_version_at_least(minimum: str) -> bool:
+    """Return whether the installed triton distribution is at least ``minimum``.
+
+    The version is read from package metadata rather than by importing triton:
+    importing triton is expensive and can fail at probe time on older or
+    partial installs, and ``find_spec`` cannot report a version.
+    """
+    try:
+        triton_version = importlib.metadata.version("triton")
+    except importlib.metadata.PackageNotFoundError:
+        return False
+    return _packaging_version.parse(triton_version) >= _packaging_version.parse(minimum)
 
 
 def strtobool(val: Any) -> bool:

--- a/torchrl/modules/tensordict_module/_rnn_triton.py
+++ b/torchrl/modules/tensordict_module/_rnn_triton.py
@@ -36,13 +36,13 @@ Limitations of this prototype:
 """
 from __future__ import annotations
 
-import importlib.metadata
 import os
 
 import torch
 import torch.nn.functional as F
-from packaging import version
+from torch.autograd.function import once_differentiable
 
+from torchrl._utils import _triton_version_at_least
 from torchrl.modules.tensordict_module._rnn_precision import (
     _maybe_enable_tf32,
     _resolve_precision,
@@ -50,26 +50,13 @@ from torchrl.modules.tensordict_module._rnn_precision import (
     RecurrentMatmulPrecisionUserMode,
 )
 
+# The kernels rely on Triton's libdevice ``tanh`` and on a backward path that
+# uses ``tl.atomic_add`` with a 2-D mask, which older Triton compilers reject.
+# Older installations fall back transparently to the ``scan`` / ``pad``
+# backends.
+_TRITON_MIN_VERSION = "2.2"
 
-def _check_triton_available() -> bool:
-    """True if the installed Triton exposes everything this module needs.
-
-    The backend's kernels rely on Triton's libdevice ``tanh`` and on a backward
-    path that uses ``tl.atomic_add`` with a 2-D mask, which older Triton
-    compilers reject. The version is read from package metadata rather than
-    probing libdevice via ``find_spec`` because older Triton builds lack the
-    ``triton.language.extra`` parent and that probe would raise
-    ``ModuleNotFoundError`` at torchrl import time. Older
-    installations fall back transparently to the ``scan`` / ``pad`` backends.
-    """
-    try:
-        triton_version = importlib.metadata.version("triton")
-    except importlib.metadata.PackageNotFoundError:
-        return False
-    return version.parse(triton_version) >= version.parse("2.2")
-
-
-_has_triton = _check_triton_available()
+_has_triton = _triton_version_at_least(_TRITON_MIN_VERSION)
 
 if _has_triton:
     import triton
@@ -1250,35 +1237,38 @@ if _has_triton:
 
             h_prev = hidden_p[:, 0].contiguous()
             h_next = torch.empty_like(h_prev)
-            for t in range(T):
-                _gru_fwd_step_tiled_h_kernel[grid](
-                    gates_x,
-                    hidden_p,
-                    h_prev,
-                    w_r_t,
-                    w_z_t,
-                    w_n_t,
-                    b_hh_p,
-                    is_init,
-                    out,
-                    save_r,
-                    save_z,
-                    save_n,
-                    save_gh_n,
-                    h_next,
-                    B,
-                    T,
-                    H=H_pad,
-                    t=t,
-                    BLOCK_B=_FWD_TILED_BLOCK_B,
-                    BLOCK_H=_FWD_TILED_BLOCK_H,
-                    BLOCK_K=_FWD_TILED_BLOCK_K,
-                    INPUT_PRECISION=input_precision,
-                    SAVE_GATES=save_gates,
-                    num_warps=_FWD_TILED_NUM_WARPS,
-                    num_stages=1,
-                )
-                h_prev, h_next = h_next, h_prev
+            # Triton launches on the current CUDA context; pin it to the input
+            # tensors' device so non-default devices are safe.
+            with torch.cuda.device(gates_x.device):
+                for t in range(T):
+                    _gru_fwd_step_tiled_h_kernel[grid](
+                        gates_x,
+                        hidden_p,
+                        h_prev,
+                        w_r_t,
+                        w_z_t,
+                        w_n_t,
+                        b_hh_p,
+                        is_init,
+                        out,
+                        save_r,
+                        save_z,
+                        save_n,
+                        save_gh_n,
+                        h_next,
+                        B,
+                        T,
+                        H=H_pad,
+                        t=t,
+                        BLOCK_B=_FWD_TILED_BLOCK_B,
+                        BLOCK_H=_FWD_TILED_BLOCK_H,
+                        BLOCK_K=_FWD_TILED_BLOCK_K,
+                        INPUT_PRECISION=input_precision,
+                        SAVE_GATES=save_gates,
+                        num_warps=_FWD_TILED_NUM_WARPS,
+                        num_stages=1,
+                    )
+                    h_prev, h_next = h_next, h_prev
             return h_prev
 
         h_final = torch.empty(B, H_pad, dtype=out.dtype, device=out.device)
@@ -1286,26 +1276,27 @@ if _has_triton:
         def grid(meta):
             return (triton.cdiv(B, meta["BLOCK_B"]),)
 
-        _gru_fwd_kernel[grid](
-            gates_x,
-            hidden_p,
-            w_r_t,
-            w_z_t,
-            w_n_t,
-            b_hh_p,
-            is_init,
-            out,
-            save_r,
-            save_z,
-            save_n,
-            save_gh_n,
-            h_final,
-            B,
-            T,
-            H=H_pad,
-            SAVE_GATES=save_gates,
-            INPUT_PRECISION=input_precision,
-        )
+        with torch.cuda.device(gates_x.device):
+            _gru_fwd_kernel[grid](
+                gates_x,
+                hidden_p,
+                w_r_t,
+                w_z_t,
+                w_n_t,
+                b_hh_p,
+                is_init,
+                out,
+                save_r,
+                save_z,
+                save_n,
+                save_gh_n,
+                h_final,
+                B,
+                T,
+                H=H_pad,
+                SAVE_GATES=save_gates,
+                INPUT_PRECISION=input_precision,
+            )
         return h_final
 
     def _lstm_fwd_launch(
@@ -1348,42 +1339,44 @@ if _has_triton:
             c_prev = cell_p[:, 0].contiguous()
             h_next = torch.empty_like(h_prev)
             c_next = torch.empty_like(c_prev)
-            for t in range(T):
-                _lstm_fwd_step_tiled_h_kernel[grid](
-                    gates_x,
-                    hidden_p,
-                    cell_p,
-                    h_prev,
-                    c_prev,
-                    w_i_t,
-                    w_f_t,
-                    w_g_t,
-                    w_o_t,
-                    b_hh_p,
-                    is_init,
-                    out,
-                    c_out,
-                    save_i,
-                    save_f,
-                    save_g,
-                    save_o,
-                    save_tanhc,
-                    h_next,
-                    c_next,
-                    B,
-                    T,
-                    H=H_pad,
-                    t=t,
-                    BLOCK_B=_FWD_TILED_BLOCK_B,
-                    BLOCK_H=_FWD_TILED_BLOCK_H,
-                    BLOCK_K=_FWD_TILED_BLOCK_K,
-                    INPUT_PRECISION=input_precision,
-                    SAVE_GATES=save_gates,
-                    num_warps=_FWD_TILED_NUM_WARPS,
-                    num_stages=1,
-                )
-                h_prev, h_next = h_next, h_prev
-                c_prev, c_next = c_next, c_prev
+            # See _gru_fwd_launch for why the launch pins the CUDA context.
+            with torch.cuda.device(gates_x.device):
+                for t in range(T):
+                    _lstm_fwd_step_tiled_h_kernel[grid](
+                        gates_x,
+                        hidden_p,
+                        cell_p,
+                        h_prev,
+                        c_prev,
+                        w_i_t,
+                        w_f_t,
+                        w_g_t,
+                        w_o_t,
+                        b_hh_p,
+                        is_init,
+                        out,
+                        c_out,
+                        save_i,
+                        save_f,
+                        save_g,
+                        save_o,
+                        save_tanhc,
+                        h_next,
+                        c_next,
+                        B,
+                        T,
+                        H=H_pad,
+                        t=t,
+                        BLOCK_B=_FWD_TILED_BLOCK_B,
+                        BLOCK_H=_FWD_TILED_BLOCK_H,
+                        BLOCK_K=_FWD_TILED_BLOCK_K,
+                        INPUT_PRECISION=input_precision,
+                        SAVE_GATES=save_gates,
+                        num_warps=_FWD_TILED_NUM_WARPS,
+                        num_stages=1,
+                    )
+                    h_prev, h_next = h_next, h_prev
+                    c_prev, c_next = c_next, c_prev
             return h_prev, c_prev
 
         h_final = torch.empty(B, H_pad, dtype=out.dtype, device=out.device)
@@ -1392,31 +1385,32 @@ if _has_triton:
         def grid(meta):
             return (triton.cdiv(B, meta["BLOCK_B"]),)
 
-        _lstm_fwd_kernel[grid](
-            gates_x,
-            hidden_p,
-            cell_p,
-            w_i_t,
-            w_f_t,
-            w_g_t,
-            w_o_t,
-            b_hh_p,
-            is_init,
-            out,
-            c_out,
-            save_i,
-            save_f,
-            save_g,
-            save_o,
-            save_tanhc,
-            h_final,
-            c_final,
-            B,
-            T,
-            H=H_pad,
-            SAVE_GATES=save_gates,
-            INPUT_PRECISION=input_precision,
-        )
+        with torch.cuda.device(gates_x.device):
+            _lstm_fwd_kernel[grid](
+                gates_x,
+                hidden_p,
+                cell_p,
+                w_i_t,
+                w_f_t,
+                w_g_t,
+                w_o_t,
+                b_hh_p,
+                is_init,
+                out,
+                c_out,
+                save_i,
+                save_f,
+                save_g,
+                save_o,
+                save_tanhc,
+                h_final,
+                c_final,
+                B,
+                T,
+                H=H_pad,
+                SAVE_GATES=save_gates,
+                INPUT_PRECISION=input_precision,
+            )
         return h_final, c_final
 
 
@@ -1633,6 +1627,7 @@ class _GRUFn(torch.autograd.Function):
         return _unpad_last(out, H, H_pad), _unpad_last(h_final, H, H_pad)
 
     @staticmethod
+    @once_differentiable
     def backward(ctx, dout, dh_final):
         B, T, I_in, H, H_pad = ctx.shapes
         input_precision = ctx.input_precision
@@ -1713,27 +1708,29 @@ class _GRUFn(torch.autograd.Function):
         def grid(meta):
             return (triton.cdiv(B, meta["BLOCK_B"]),)
 
-        _gru_bwd_kernel[grid](
-            hidden_p,
-            w_r,
-            w_z,
-            w_n,
-            is_init,
-            out,
-            save_r,
-            save_z,
-            save_n,
-            save_gh_n,
-            dout_p,
-            dh_final_p,
-            dgates_x,
-            dgates_h,
-            dhidden_p,
-            B,
-            T,
-            H=H_pad,
-            INPUT_PRECISION=input_precision,
-        )
+        # See _gru_fwd_launch for why the launch pins the CUDA context.
+        with torch.cuda.device(hidden_p.device):
+            _gru_bwd_kernel[grid](
+                hidden_p,
+                w_r,
+                w_z,
+                w_n,
+                is_init,
+                out,
+                save_r,
+                save_z,
+                save_n,
+                save_gh_n,
+                dout_p,
+                dh_final_p,
+                dgates_x,
+                dgates_h,
+                dhidden_p,
+                B,
+                T,
+                H=H_pad,
+                INPUT_PRECISION=input_precision,
+            )
 
         # h_prev[b, t] for the dW_hh computation.
         h_prev_all = torch.empty_like(out)
@@ -1919,6 +1916,7 @@ class _LSTMFn(torch.autograd.Function):
         )
 
     @staticmethod
+    @once_differentiable
     def backward(ctx, dout, dc_out, dh_final, dc_final):
         B, T, I_in, H, H_pad = ctx.shapes
         input_precision = ctx.input_precision
@@ -2020,34 +2018,36 @@ class _LSTMFn(torch.autograd.Function):
         def grid(meta):
             return (triton.cdiv(B, meta["BLOCK_B"]),)
 
-        _lstm_bwd_kernel[grid](
-            hidden_p,
-            cell_p,
-            w_i,
-            w_f,
-            w_g,
-            w_o,
-            is_init,
-            out,
-            c_out,
-            save_i,
-            save_f,
-            save_g,
-            save_o,
-            save_tanhc,
-            dout_p,
-            dc_out_p,
-            dh_final_p,
-            dc_final_p,
-            dgates_x,
-            dgates_h,
-            dhidden_p,
-            dcell_p,
-            B,
-            T,
-            H=H_pad,
-            INPUT_PRECISION=input_precision,
-        )
+        # See _gru_fwd_launch for why the launch pins the CUDA context.
+        with torch.cuda.device(hidden_p.device):
+            _lstm_bwd_kernel[grid](
+                hidden_p,
+                cell_p,
+                w_i,
+                w_f,
+                w_g,
+                w_o,
+                is_init,
+                out,
+                c_out,
+                save_i,
+                save_f,
+                save_g,
+                save_o,
+                save_tanhc,
+                dout_p,
+                dc_out_p,
+                dh_final_p,
+                dc_final_p,
+                dgates_x,
+                dgates_h,
+                dhidden_p,
+                dcell_p,
+                B,
+                T,
+                H=H_pad,
+                INPUT_PRECISION=input_precision,
+            )
 
         h_prev_all = torch.empty_like(out)
         h_prev_all[:, 0] = hidden_p[:, 0]

--- a/torchrl/modules/tensordict_module/rnn.py
+++ b/torchrl/modules/tensordict_module/rnn.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import contextvars
-import importlib.metadata
 import importlib.util
 import typing
 from collections.abc import Iterable
@@ -14,7 +13,6 @@ from typing import Any
 import torch
 import torch.nn.functional as F
 import torch.utils.checkpoint as _torch_checkpoint
-from packaging import version
 
 from tensordict import TensorDict, TensorDictBase, unravel_key_list
 from tensordict.base import NO_DEFAULT
@@ -26,6 +24,7 @@ from torch.nn.modules.rnn import RNNCellBase
 from torchrl._utils import (
     _ContextManager,
     _DecoratorContextManager,
+    _triton_version_at_least,
     implement_for,
     is_compiling,
 )
@@ -77,24 +76,11 @@ def _maybe_warm_scan_backward(device: torch.device | str | int | None) -> None:
         ensure_scan_backward(device)
 
 
-def _check_triton_available() -> bool:
-    """True if Triton is installed and exposes the API the kernels need.
-
-    Mirrors the probe in :mod:`torchrl.modules.tensordict_module._rnn_triton`.
-    The backend requires ``triton.language.extra.libdevice`` which is only
-    available from Triton 2.2 onwards. Older Triton builds fall back to the
-    scan / pad backends. The version is read from package metadata to avoid
-    eagerly importing Triton (or its missing ``triton.language.extra`` parent)
-    at torchrl import time.
-    """
-    try:
-        triton_version = importlib.metadata.version("triton")
-    except importlib.metadata.PackageNotFoundError:
-        return False
-    return version.parse(triton_version) >= version.parse("2.2")
-
-
-_has_triton = _check_triton_available()
+# Mirrors the probe in :mod:`torchrl.modules.tensordict_module._rnn_triton`.
+# The backend requires ``triton.language.extra.libdevice`` which is only
+# available from Triton 2.2 onwards. Older Triton builds fall back to the
+# scan / pad backends.
+_has_triton = _triton_version_at_least("2.2")
 
 
 def _canonical_stride(shape: typing.Sequence[int]) -> tuple[int, ...]:


### PR DESCRIPTION
## Description

Ports the hardening fixes that landed on the DreamerV3 Triton backend in #4160 (76cb9ba98) to the pre-existing Triton GRU/LSTM backend, which shares the same latent issues:

- **CUDA context pinning**: every Triton kernel launch (`_gru_fwd_kernel`, `_lstm_fwd_kernel`, the tiled per-step forward kernels, and both backward kernels) is now wrapped in `with torch.cuda.device(...)`. Triton launches on the current CUDA context, so tensors living on a non-current device caused illegal memory accesses.
- **Double backward now raises**: `_GRUFn.backward` / `_LSTMFn.backward` consume kernel-written gate buffers and no-grad-saved intermediates, so `create_graph=True` silently produced partial/wrong second-order gradients. They are now marked `@once_differentiable`, turning that into a clear error.
- **Shared triton probe**: the duplicated triton-availability probes in `_rnn_triton.py`, `rnn.py`, and `test/modules/_modules_common.py` are migrated to `torchrl._utils._triton_version_at_least` (same helper #4160 adds; the hunk is identical so the branches merge cleanly). Each caller keeps its minimum version (2.2).

The `_DreamerV3BlockGRUScanFunction` counterpart mentioned in the #4160 review lives on the unmerged block-GRU stack (#4158-#4174), not on main, so its `once_differentiable` fix has to be applied there and is not part of this PR.

## Testing

- `test/modules/test_rnn.py`: 218 passed, 48 skipped (triton+CUDA-gated) locally on CPU.
- `test/modules/test_dreamer_components.py`: 218 passed.
- GPU parity tests for the triton backend run in CI (`tests-gpu`).

Generated with [Claude Code](https://claude.com/claude-code)