### PR TITLE
[Versioning] Enact QValue shape validation for 0.14

### DIFF
--- a/sota-implementations/cql/utils.py
+++ b/sota-implementations/cql/utils.py
@@ -312,7 +312,7 @@ def make_cql_model(cfg, train_env, eval_env, device="cpu"):
 def make_discretecql_model(cfg, train_env, eval_env, device="cpu"):
     model_cfg = cfg.model
 
-    action_spec = train_env.action_spec
+    action_spec = train_env.action_spec_unbatched
 
     actor_net_kwargs = {
         "num_cells": model_cfg.hidden_sizes,

--- a/test/modules/test_qvalue_actor.py
+++ b/test/modules/test_qvalue_actor.py
@@ -528,30 +528,25 @@ class TestQValue:
         qvalue_actor(td)
         assert td["action"].shape == torch.Size([12, 1])
 
-    def test_qvalue_actor_strict_shape_true_raises(self):
-        """Test that strict_shape=True raises on shape mismatch."""
+    @pytest.mark.parametrize(
+        "strict_shape_kwargs",
+        [{}, {"strict_shape": True}, {"strict_shape": None}],
+        ids=["default", "true", "legacy-none"],
+    )
+    def test_qvalue_actor_strict_shape_raises(self, strict_shape_kwargs):
+        """Test that the default and strict modes raise on shape mismatch."""
         action_spec = Categorical(4, shape=torch.Size((1, 1)), dtype=torch.int64)
         module = TensorDictModule(
             module=nn.Linear(3, 1), in_keys=("observation",), out_keys=("action_value",)
         )
         qvalue_actor = QValueActor(
-            module=module, in_keys=["observation"], spec=action_spec, strict_shape=True
+            module=module,
+            in_keys=["observation"],
+            spec=action_spec,
+            **strict_shape_kwargs,
         )
         td = TensorDict({"observation": torch.randn(12, 3)})
         with pytest.raises(RuntimeError, match="does not match expected shape"):
-            qvalue_actor(td)
-
-    def test_qvalue_actor_strict_shape_none_warns(self):
-        """Test that strict_shape=None (default) issues FutureWarning."""
-        action_spec = Categorical(4, shape=torch.Size((1, 1)), dtype=torch.int64)
-        module = TensorDictModule(
-            module=nn.Linear(3, 1), in_keys=("observation",), out_keys=("action_value",)
-        )
-        qvalue_actor = QValueActor(
-            module=module, in_keys=["observation"], spec=action_spec
-        )
-        td = TensorDict({"observation": torch.randn(12, 3)})
-        with pytest.warns(FutureWarning, match="does not match expected shape"):
             qvalue_actor(td)
 
     def test_qvalue_actor_strict_shape_normal_no_warning(self):

--- a/test/modules/test_qvalue_actor.py
+++ b/test/modules/test_qvalue_actor.py
@@ -569,6 +569,37 @@ class TestQValue:
             assert len(future_warns) == 0
         assert td["action"].shape == torch.Size([5, 4])
 
+    def test_qvalue_module_strict_shape_nested_spec(self):
+        """Test that nested spec batch dimensions are not duplicated."""
+        spec = Composite(
+            agents=Composite(
+                action=Categorical(4, shape=(3,)),
+                shape=(3,),
+            )
+        )
+        module = QValueModule(
+            action_value_key=("agents", "action_value"),
+            out_keys=[
+                ("agents", "action"),
+                ("agents", "action_value"),
+                ("agents", "chosen_action_value"),
+            ],
+            spec=spec,
+        )
+        td = TensorDict(
+            {
+                "agents": TensorDict(
+                    {"action_value": torch.randn(2, 3, 4)},
+                    [2, 3],
+                )
+            },
+            [2],
+        )
+
+        module(td)
+
+        assert td["agents", "action"].shape == torch.Size([2, 3])
+
 
 @pytest.mark.parametrize("device", get_default_devices())
 def test_value_based_policy(device):

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -667,7 +667,12 @@ class QValueModule(TensorDictModuleBase):
             else None
         )
         if action_spec is not None and self.strict_shape is not False:
-            composite_batch_ndim = len(self.spec.shape)
+            action_key = unravel_key(action_key)
+            if isinstance(action_key, tuple):
+                action_spec_parent = self.spec[action_key[:-1]]
+            else:
+                action_spec_parent = self.spec
+            composite_batch_ndim = len(action_spec_parent.shape)
             per_sample_shape = action_spec.shape[composite_batch_ndim:]
             batch_shape = action_values.shape[:-1]
             target_shape = torch.Size(list(batch_shape) + list(per_sample_shape))

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Literal
 
 import torch
 from tensordict import TensorDictBase, unravel_key
@@ -529,6 +530,11 @@ class QValueModule(TensorDictModuleBase):
             If this value is out of bounds, it is projected back onto the
             desired space using the :obj:`TensorSpec.project`
             method. Default is ``False``.
+        strict_shape (bool or "auto", optional): Controls action-shape validation
+            against ``spec``. ``True`` raises on a mismatch, ``"auto"`` attempts
+            to reshape the action, and ``False`` disables validation. ``None`` is
+            accepted for compatibility and behaves like ``True``. Defaults to
+            ``True``.
 
     Returns:
         if the input is a single tensor, a triplet containing the chosen action,
@@ -570,7 +576,7 @@ class QValueModule(TensorDictModuleBase):
         var_nums: int | None = None,
         spec: TensorSpec | None = None,
         safe: bool = False,
-        strict_shape: bool | str | None = None,
+        strict_shape: bool | Literal["auto"] | None = True,
     ):
         if isinstance(action_space, TensorSpec):
             raise TypeError("Using specs in action_space is deprecated")
@@ -667,7 +673,7 @@ class QValueModule(TensorDictModuleBase):
             target_shape = torch.Size(list(batch_shape) + list(per_sample_shape))
 
             if action.shape != target_shape:
-                if self.strict_shape is True:
+                if self.strict_shape is True or self.strict_shape is None:
                     raise RuntimeError(
                         f"Action shape {action.shape} does not match expected shape {target_shape} "
                         f"(per-sample spec shape: {per_sample_shape}). "
@@ -680,19 +686,6 @@ class QValueModule(TensorDictModuleBase):
                         raise RuntimeError(
                             f"Cannot reshape action from {action.shape} to {target_shape}."
                         )
-                elif self.strict_shape is None:
-                    import warnings
-
-                    warnings.warn(
-                        f"Action shape {action.shape} does not match expected shape {target_shape} "
-                        f"(per-sample spec shape: {per_sample_shape}). "
-                        f"In v0.14, this will raise an error. "
-                        f"Set strict_shape='auto' to automatically reshape, "
-                        f"strict_shape=True to raise immediately, "
-                        f"or strict_shape=False to silence this warning.",
-                        FutureWarning,
-                        stacklevel=2,
-                    )
 
         tensordict.update(
             dict(zip(self.out_keys, (action, action_values, chosen_action_value)))
@@ -1149,6 +1142,11 @@ class QValueActor(SafeSequential):
             the selected action value. Defaults to ``"chosen_action_value"``.
         action_mask_key (str or tuple of str, optional): The input key
             representing the action mask. Defaults to ``"None"`` (equivalent to no masking).
+        strict_shape (bool or "auto", optional): Controls action-shape validation
+            against ``spec``. ``True`` raises on a mismatch, ``"auto"`` attempts
+            to reshape the action, and ``False`` disables validation. ``None`` is
+            accepted for compatibility and behaves like ``True``. Defaults to
+            ``True``.
 
     .. note::
         ``out_keys`` cannot be passed. If the module is a :class:`tensordict.nn.TensorDictModule`
@@ -1209,7 +1207,7 @@ class QValueActor(SafeSequential):
         action_key: NestedKey | None = None,
         chosen_action_value_key: NestedKey | None = None,
         action_mask_key: NestedKey | None = None,
-        strict_shape: bool | str | None = None,
+        strict_shape: bool | Literal["auto"] | None = True,
     ):
         if isinstance(action_space, TensorSpec):
             raise RuntimeError(

--- a/torchrl/testing/mocking_classes.py
+++ b/torchrl/testing/mocking_classes.py
@@ -848,8 +848,10 @@ class DiscreteActionConvMockEnvNumpy(DiscreteActionConvMockEnv):
                 shape=batch_size,
             )
         if action_spec is None:
-            action_spec_cls = Categorical if categorical_action_encoding else OneHot
-            action_spec = action_spec_cls(7, shape=(*batch_size, 7))
+            if categorical_action_encoding:
+                action_spec = Categorical(7, shape=batch_size)
+            else:
+                action_spec = OneHot(7, shape=(*batch_size, 7))
         if state_spec is None:
             state_spec = Composite(
                 {


### PR DESCRIPTION
## Summary

- Enact the QValueModule and QValueActor action-shape validation behavior scheduled for TorchRL 0.14.
- Make strict validation the default while preserving strict_shape="auto" reshaping and strict_shape=False opt-out behavior.
- Treat the legacy explicit None value like the new strict default and document the contract.

## Testing

- test/modules/test_qvalue_actor.py: 73 passed.