### PR TITLE
[Feature] Support fragmented trajectory slices

### DIFF
--- a/benchmarks/test_replaybuffer_benchmark.py
+++ b/benchmarks/test_replaybuffer_benchmark.py
@@ -164,35 +164,110 @@ def test_slice_sampler_boundary_query_benchmark(
     benchmark(sampler._get_stop_and_length, rb.storage)
 
 
+@pytest.mark.parametrize(
+    "cache_state",
+    [
+        pytest.param("hot", id="hot-cache"),
+        pytest.param("write_invalidated", id="write-invalidated"),
+        pytest.param("cold", id="cold-start"),
+    ],
+)
+@pytest.mark.parametrize(
+    "layout",
+    [
+        pytest.param("contiguous", id="contiguous"),
+        pytest.param("shuffled", id="fragmented-shuffled"),
+    ],
+)
 @pytest.mark.parametrize("size", [1_000, 100_000])
-def test_fragmented_slice_sampler_cached_sample(benchmark, size):
+def test_slice_sampler_sample(benchmark, size, layout, cache_state):
     device = _replay_boundary_device()
     num_trajectories = 8
-    storage_order = torch.arange(size, device=device)
-    rb = TensorDictReplayBuffer(
-        storage=LazyTensorStorage(size, device=device),
-        sampler=SliceSampler(
-            slice_len=8,
-            traj_key="trajectory",
-            step_key="step",
-            fragmented=True,
-        ),
-        batch_size=256,
-        generator=torch.Generator(device=device).manual_seed(0),
-    )
-    rb.extend(
-        TensorDict(
-            {
-                "trajectory": storage_order % num_trajectories,
-                "step": storage_order // num_trajectories,
-            },
-            [size],
+    trajectory_length = size // num_trajectories
+    logical_order = torch.arange(size, device=device)
+    trajectory = logical_order // trajectory_length
+    step = logical_order % trajectory_length
+    fragmented = layout == "shuffled"
+    if fragmented:
+        # Preserve the logical trajectories while changing only their physical layout.
+        permutation = torch.randperm(
+            size,
             device=device,
+            generator=torch.Generator(device=device).manual_seed(0),
         )
+        trajectory = trajectory[permutation]
+        step = step[permutation]
+    data = TensorDict(
+        {
+            "trajectory": trajectory,
+            "step": step,
+        },
+        [size],
+        device=device,
     )
-    rb.sample()
 
-    benchmark(rb.sample)
+    def make_replay_buffer():
+        rb = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(size, device=device),
+            sampler=SliceSampler(
+                slice_len=8,
+                traj_key="trajectory",
+                step_key="step",
+                cache_values=True,
+                fragmented=fragmented,
+            ),
+            batch_size=256,
+            generator=torch.Generator(device=device).manual_seed(0),
+        )
+        rb.extend(data)
+        return rb
+
+    rb = make_replay_buffer()
+    sample = rb.sample().reshape(-1, 8)
+    assert (sample["trajectory"] == sample["trajectory"][:, :1]).all()
+    assert (sample["step"].diff(dim=1) == 1).all()
+
+    def sample_replay_buffer(rb):
+        rb.sample()
+        if device.type == "cuda":
+            torch.cuda.synchronize(device)
+
+    if cache_state == "cold":
+
+        def cold_setup():
+            cold_rb = make_replay_buffer()
+            if device.type == "cuda":
+                torch.cuda.synchronize(device)
+            return (cold_rb,), {}
+
+        benchmark.pedantic(
+            sample_replay_buffer,
+            setup=cold_setup,
+            rounds=10,
+        )
+    elif cache_state == "write_invalidated":
+        next_write = 0
+
+        def write_setup():
+            nonlocal next_write
+            rb.add(data[next_write])
+            next_write = (next_write + 1) % size
+            if device.type == "cuda":
+                torch.cuda.synchronize(device)
+            return (rb,), {}
+
+        benchmark.pedantic(
+            sample_replay_buffer,
+            setup=write_setup,
+            rounds=25,
+        )
+    else:
+        benchmark.pedantic(
+            sample_replay_buffer,
+            args=(rb,),
+            rounds=200,
+            iterations=10,
+        )
 
 
 @pytest.mark.parametrize("compiled", [False, True])

--- a/benchmarks/test_replaybuffer_benchmark.py
+++ b/benchmarks/test_replaybuffer_benchmark.py
@@ -164,6 +164,37 @@ def test_slice_sampler_boundary_query_benchmark(
     benchmark(sampler._get_stop_and_length, rb.storage)
 
 
+@pytest.mark.parametrize("size", [1_000, 100_000])
+def test_fragmented_slice_sampler_cached_sample(benchmark, size):
+    device = _replay_boundary_device()
+    num_trajectories = 8
+    storage_order = torch.arange(size, device=device)
+    rb = TensorDictReplayBuffer(
+        storage=LazyTensorStorage(size, device=device),
+        sampler=SliceSampler(
+            slice_len=8,
+            traj_key="trajectory",
+            step_key="step",
+            fragmented=True,
+        ),
+        batch_size=256,
+        generator=torch.Generator(device=device).manual_seed(0),
+    )
+    rb.extend(
+        TensorDict(
+            {
+                "trajectory": storage_order % num_trajectories,
+                "step": storage_order // num_trajectories,
+            },
+            [size],
+            device=device,
+        )
+    )
+    rb.sample()
+
+    benchmark(rb.sample)
+
+
 @pytest.mark.parametrize("compiled", [False, True])
 def test_replay_boundary_kernel_benchmark(benchmark, compiled):
     device = _replay_boundary_device()

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -2610,6 +2610,15 @@ class TestUpdateIfPresent:
         assert result.stale_count == 0
         torch.testing.assert_close(rb[:]["obs"], patch["obs"])
 
+    def test_update_invalidates_derived_caches(self):
+        # Caches keyed on the storage revision (boundary caches, the
+        # fragmented trajectory index) must see conditional patches.
+        rb, _, index, generation = self._make_rb()
+        revision = rb._storage._mutation_revision
+        patch = {"obs": torch.full((10, 3), 42.0)}
+        rb.update_if_present(index=index, generation=generation, patch=patch)
+        assert rb._storage._mutation_revision > revision
+
     def test_stale_records_skipped_and_unmodified(self):
         rb, _, index, generation = self._make_rb()
         overwrite = TensorDict(

--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -566,6 +566,33 @@ class TestSamplers:
         sample = rb.sample().reshape(8, 2)
         assert torch.equal(sample["step"], torch.tensor([2, 3]).expand(8, 2))
 
+    def test_slice_sampler_fragmented_unbounded_lazy_stack_storage(self):
+        # List-backed storages default to an unbounded max_size; the index
+        # bookkeeping must not be sized by capacity.
+        rb = TensorDictReplayBuffer(
+            storage=LazyStackStorage(),
+            sampler=SliceSampler(
+                slice_len=2,
+                traj_key="trajectory",
+                step_key="step",
+                fragmented=True,
+            ),
+            batch_size=8,
+        )
+        rb.extend(
+            TensorDict(
+                {
+                    "trajectory": torch.arange(2).repeat(3),
+                    "step": torch.arange(3).repeat_interleave(2),
+                },
+                batch_size=[6],
+            )
+        )
+
+        sample = rb.sample().reshape(4, 2)
+        assert (sample["trajectory"] == sample["trajectory"][:, :1]).all()
+        assert (sample["step"][:, 1:] == sample["step"][:, :-1] + 1).all()
+
     @pytest.mark.parametrize("sampler", [SliceSampler, SliceSamplerWithoutReplacement])
     def test_slice_sampler_at_capacity(self, sampler):
         torch.manual_seed(0)

--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -593,6 +593,28 @@ class TestSamplers:
         assert (sample["trajectory"] == sample["trajectory"][:, :1]).all()
         assert (sample["step"][:, 1:] == sample["step"][:, :-1] + 1).all()
 
+    def test_slice_sampler_state_from_older_version(self):
+        # Samplers pickled before the fragmented attributes existed must keep
+        # working: their __dict__ lacks fragmented/step_key/_fragmented_index.
+        state = SliceSampler(slice_len=2, traj_key="trajectory").__getstate__()
+        for key in ("fragmented", "step_key", "_fragmented_index"):
+            state.pop(key)
+        legacy = SliceSampler.__new__(SliceSampler)
+        legacy.__dict__.update(state)
+
+        repr(legacy)
+        rb = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(4), sampler=legacy, batch_size=4
+        )
+        rb.extend(
+            TensorDict(
+                {"trajectory": torch.tensor([0, 0, 1, 1])},
+                batch_size=[4],
+            )
+        )
+        sample = rb.sample().reshape(2, 2)
+        assert (sample["trajectory"] == sample["trajectory"][:, :1]).all()
+
     @pytest.mark.parametrize("sampler", [SliceSampler, SliceSamplerWithoutReplacement])
     def test_slice_sampler_at_capacity(self, sampler):
         torch.manual_seed(0)

--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -615,6 +615,36 @@ class TestSamplers:
         sample = rb.sample().reshape(2, 2)
         assert (sample["trajectory"] == sample["trajectory"][:, :1]).all()
 
+    def test_slice_sampler_mark_update_cooperative(self):
+        # Classes mixing SliceSampler with a sampler that implements
+        # mark_update (e.g. PrioritizedSampler) must keep their write hook:
+        # SliceSampler.mark_update has to delegate to the next class in the
+        # MRO rather than swallow the call.
+        class _RecordingSampler(RandomSampler):
+            def __init__(self):
+                super().__init__()
+                self.marked = []
+
+            def mark_update(self, index, *, storage=None):
+                self.marked.append(index)
+
+        class _ComboSampler(SliceSampler, _RecordingSampler):
+            def __init__(self, **kwargs):
+                SliceSampler.__init__(self, **kwargs)
+                self.marked = []
+
+        sampler = _ComboSampler(slice_len=2, traj_key="trajectory")
+        rb = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(4), sampler=sampler, batch_size=4
+        )
+        rb.extend(
+            TensorDict(
+                {"trajectory": torch.tensor([0, 0, 1, 1])},
+                batch_size=[4],
+            )
+        )
+        assert len(sampler.marked) == 1
+
     @pytest.mark.parametrize("sampler", [SliceSampler, SliceSamplerWithoutReplacement])
     def test_slice_sampler_at_capacity(self, sampler):
         torch.manual_seed(0)

--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -645,6 +645,49 @@ class TestSamplers:
         )
         assert len(sampler.marked) == 1
 
+    def test_slice_sampler_fragmented_recovers_from_failed_update(self):
+        rb = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(4),
+            sampler=SliceSampler(
+                slice_len=2,
+                traj_key="trajectory",
+                step_key="step",
+                fragmented=True,
+            ),
+            batch_size=32,
+            generator=torch.Generator().manual_seed(0),
+        )
+        rb.extend(
+            TensorDict(
+                {
+                    "trajectory": torch.tensor([0, 0, 1, 1]),
+                    "step": torch.tensor([0, 1, 0, 1]),
+                },
+                batch_size=[4],
+            )
+        )
+        rb.sample()
+
+        # An in-place edit creating a duplicate (trajectory, step) pair,
+        # tracked via mark_update without a storage revision bump.
+        rb.storage._storage["trajectory"][3] = 0
+        rb.mark_update(torch.tensor([3]))
+        with pytest.raises(RuntimeError, match="duplicate"):
+            rb.sample()
+        # The failed update must not leave a partially applied index behind:
+        # while the duplicate persists, sampling keeps failing loudly instead
+        # of silently serving stale runs.
+        with pytest.raises(RuntimeError, match="duplicate"):
+            rb.sample()
+
+        # Restoring uniqueness lets sampling recover.
+        rb.storage._storage["trajectory"][3] = 1
+        rb.mark_update(torch.tensor([3]))
+        sample = rb.sample().reshape(16, 2)
+        assert (sample["trajectory"] == sample["trajectory"][:, :1]).all()
+        assert (sample["step"][:, 1:] == sample["step"][:, :-1] + 1).all()
+        assert (sample["trajectory"] == 1).any()
+
     @pytest.mark.parametrize("sampler", [SliceSampler, SliceSamplerWithoutReplacement])
     def test_slice_sampler_at_capacity(self, sampler):
         torch.manual_seed(0)

--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -688,6 +688,49 @@ class TestSamplers:
         assert (sample["step"][:, 1:] == sample["step"][:, :-1] + 1).all()
         assert (sample["trajectory"] == 1).any()
 
+    def test_slice_sampler_fragmented_deterministic_after_rebuild(self):
+        # For a given RNG state and identical buffer contents, samples must
+        # not depend on whether the index was maintained incrementally or
+        # rebuilt from scratch (e.g. after restoring a checkpoint).
+        generator = torch.Generator().manual_seed(0)
+        rb = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(4),
+            sampler=SliceSampler(
+                slice_len=1,
+                traj_key="trajectory",
+                step_key="step",
+                fragmented=True,
+            ),
+            batch_size=8,
+            generator=generator,
+        )
+        rb.extend(
+            TensorDict(
+                {
+                    "trajectory": torch.tensor([1, 1, 2, 2]),
+                    "step": torch.tensor([0, 1, 0, 1]),
+                },
+                batch_size=[4],
+            )
+        )
+        rb.sample()
+        # A wraparound write introduces a new trajectory through the
+        # incremental path.
+        rb.add(
+            TensorDict(
+                {"trajectory": torch.tensor(3), "step": torch.tensor(0)},
+                batch_size=[],
+            )
+        )
+
+        rng_state = generator.get_state()
+        incremental = rb.sample()
+        generator.set_state(rng_state)
+        rb.sampler.load_state_dict({})  # drops the index, forcing a rebuild
+        rebuilt = rb.sample()
+        assert torch.equal(incremental["index"], rebuilt["index"])
+        assert torch.equal(incremental["trajectory"], rebuilt["trajectory"])
+
     @pytest.mark.parametrize("sampler", [SliceSampler, SliceSamplerWithoutReplacement])
     def test_slice_sampler_at_capacity(self, sampler):
         torch.manual_seed(0)

--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -464,11 +464,7 @@ class TestSamplers:
 
     @pytest.mark.parametrize("device", get_default_devices())
     def test_slice_sampler_fragmented_interleaved_nested_keys(self, device):
-        records = [
-            (trajectory, step)
-            for step in range(6)
-            for trajectory in range(2)
-        ]
+        records = [(trajectory, step) for step in range(6) for trajectory in range(2)]
         trajectory = torch.tensor(
             [trajectory for trajectory, _ in records], device=device
         )
@@ -544,9 +540,7 @@ class TestSamplers:
 
         sample = rb.sample().reshape(16, 3)
         assert (sample["trajectory"] == sample["trajectory"][:, :1]).all()
-        assert torch.equal(
-            sample["step"], torch.tensor([1, 2, 3]).expand(16, 3)
-        )
+        assert torch.equal(sample["step"], torch.tensor([1, 2, 3]).expand(16, 3))
 
     def test_slice_sampler_fragmented_missing_step_splits_run(self):
         rb = TensorDictReplayBuffer(

--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -462,6 +462,116 @@ class TestSamplers:
 
         assert len(trajs_unique_id) == 4
 
+    @pytest.mark.parametrize("device", get_default_devices())
+    def test_slice_sampler_fragmented_interleaved_nested_keys(self, device):
+        records = [
+            (trajectory, step)
+            for step in range(6)
+            for trajectory in range(2)
+        ]
+        trajectory = torch.tensor(
+            [trajectory for trajectory, _ in records], device=device
+        )
+        step = torch.tensor([step for _, step in records], device=device)
+        data = TensorDict(
+            {
+                "metadata": TensorDict(
+                    {"trajectory": trajectory, "step": step},
+                    batch_size=[len(records)],
+                ),
+                "observation": trajectory * 100 + step,
+            },
+            batch_size=[len(records)],
+        )
+        rb = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(20, device=device),
+            sampler=SliceSampler(
+                slice_len=3,
+                traj_key=("metadata", "trajectory"),
+                step_key=("metadata", "step"),
+                fragmented=True,
+            ),
+            batch_size=96,
+            generator=torch.Generator(device=device).manual_seed(0),
+        )
+        rb.extend(data)
+
+        sample = rb.sample().reshape(32, 3)
+        sampled_trajectory = sample["metadata", "trajectory"]
+        sampled_step = sample["metadata", "step"]
+        storage_index = sample["index"].squeeze(-1)
+        assert (sampled_trajectory == sampled_trajectory[:, :1]).all()
+        assert (sampled_step[:, 1:] == sampled_step[:, :-1] + 1).all()
+        assert (storage_index[:, 1:] != storage_index[:, :-1] + 1).all()
+
+    def test_slice_sampler_fragmented_incremental_wraparound(self, monkeypatch):
+        trajectory = torch.arange(2).repeat(3)
+        step = torch.arange(3).repeat_interleave(2)
+        rb = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(6),
+            sampler=SliceSampler(
+                slice_len=3,
+                traj_key="trajectory",
+                step_key="step",
+                fragmented=True,
+            ),
+            batch_size=48,
+        )
+        rb.extend(
+            TensorDict(
+                {"trajectory": trajectory, "step": step},
+                batch_size=[6],
+            )
+        )
+        rb.sample()
+
+        def rebuild_is_forbidden(*args, **kwargs):
+            raise AssertionError("tracked writes must update the index incrementally")
+
+        monkeypatch.setattr(
+            rb.sampler._fragmented_index, "_full_rebuild", rebuild_is_forbidden
+        )
+        for trajectory_id in range(2):
+            rb.add(
+                TensorDict(
+                    {
+                        "trajectory": torch.tensor(trajectory_id),
+                        "step": torch.tensor(3),
+                    },
+                    batch_size=[],
+                )
+            )
+
+        sample = rb.sample().reshape(16, 3)
+        assert (sample["trajectory"] == sample["trajectory"][:, :1]).all()
+        assert torch.equal(
+            sample["step"], torch.tensor([1, 2, 3]).expand(16, 3)
+        )
+
+    def test_slice_sampler_fragmented_missing_step_splits_run(self):
+        rb = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(4),
+            sampler=SliceSampler(
+                slice_len=2,
+                traj_key="trajectory",
+                step_key="step",
+                fragmented=True,
+            ),
+            batch_size=16,
+        )
+        rb.extend(
+            TensorDict(
+                {
+                    "trajectory": torch.zeros(3, dtype=torch.long),
+                    "step": torch.tensor([0, 2, 3]),
+                },
+                batch_size=[3],
+            )
+        )
+
+        sample = rb.sample().reshape(8, 2)
+        assert torch.equal(sample["step"], torch.tensor([2, 3]).expand(8, 2))
+
     @pytest.mark.parametrize("sampler", [SliceSampler, SliceSamplerWithoutReplacement])
     def test_slice_sampler_at_capacity(self, sampler):
         torch.manual_seed(0)

--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -731,6 +731,27 @@ class TestSamplers:
         assert torch.equal(incremental["index"], rebuilt["index"])
         assert torch.equal(incremental["trajectory"], rebuilt["trajectory"])
 
+    def test_slice_sampler_fragmented_span_guard(self):
+        # A disabled span must be accepted in every equivalent spelling; an
+        # enabled one must be rejected.
+        for span in (False, 0, (0, 0), (False, False)):
+            SliceSampler(
+                slice_len=2,
+                traj_key="trajectory",
+                step_key="step",
+                fragmented=True,
+                span=span,
+            )
+        for span in (True, 1, (0, 1), (True, False)):
+            with pytest.raises(NotImplementedError, match="span"):
+                SliceSampler(
+                    slice_len=2,
+                    traj_key="trajectory",
+                    step_key="step",
+                    fragmented=True,
+                    span=span,
+                )
+
     @pytest.mark.parametrize("sampler", [SliceSampler, SliceSamplerWithoutReplacement])
     def test_slice_sampler_at_capacity(self, sampler):
         torch.manual_seed(0)

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -859,6 +859,8 @@ class TestDataConfigs:
             slice_len=None,  # Only set one of num_slices or slice_len
             end_key=("next", "done"),
             traj_key="episode",
+            step_key="step_count",
+            fragmented=False,
             cache_values=True,
             truncated_key=("next", "truncated"),
             strict_length=True,
@@ -871,6 +873,8 @@ class TestDataConfigs:
         assert cfg.slice_len is None
         assert cfg.end_key == ("next", "done")
         assert cfg.traj_key == "episode"
+        assert cfg.step_key == "step_count"
+        assert cfg.fragmented is False
         assert cfg.cache_values is True
         assert cfg.truncated_key == ("next", "truncated")
         assert cfg.strict_length is True

--- a/torchrl/data/replay_buffers/samplers/_trajectory.py
+++ b/torchrl/data/replay_buffers/samplers/_trajectory.py
@@ -1,0 +1,379 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+
+import torch
+from tensordict import TensorDictBase, is_tensor_collection
+from tensordict.utils import NestedKey
+
+from torchrl.data.replay_buffers.storages import Storage
+
+
+@dataclass
+class _FragmentedTrajectoryIndexUpdate:
+    full_rebuild: bool
+    affected: dict[int, set[int]]
+    removed_slots: set[int]
+
+
+class _FragmentedTrajectoryIndex:
+    """Indexes logical trajectory adjacency independently of storage order."""
+
+    def __init__(self, trajectory_key: NestedKey, step_key: NestedKey):
+        self.trajectory_key = trajectory_key
+        self.step_key = step_key
+        self._trajectory_positions: dict[int, dict[int, int]] | None = None
+        self._slot_records: list[tuple[int, int] | None] | None = None
+        self._previous: torch.Tensor | None = None
+        self._following: torch.Tensor | None = None
+        self._runs: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None
+        self._pending_indices: list[torch.Tensor] = []
+        self._pending_revisions: list[int] = []
+        self._pending_storage_id: int | None = None
+        self._cache_storage_id: int | None = None
+        self._cache_revision: int | None = None
+
+    @property
+    def trajectory_positions(self) -> dict[int, dict[int, int]]:
+        return self._trajectory_positions
+
+    @property
+    def previous(self) -> torch.Tensor:
+        return self._previous
+
+    @property
+    def following(self) -> torch.Tensor:
+        return self._following
+
+    @staticmethod
+    def _storage_device(storage: Storage) -> torch.device | None:
+        device = getattr(storage, "device", None)
+        if device is None or device == "auto":
+            return None
+        return torch.device(device)
+
+    def _validate_metadata(
+        self, data: TensorDictBase, index: torch.Tensor
+    ) -> tuple[list[int], list[int], list[int], torch.device]:
+        expected = index.numel()
+        trajectory = data.get(self.trajectory_key)
+        step = data.get(self.step_key)
+        for key, value in (
+            (self.trajectory_key, trajectory),
+            (self.step_key, step),
+        ):
+            if not isinstance(value, torch.Tensor):
+                raise TypeError(
+                    f"key={key!r} must contain a tensor, got {type(value).__name__}."
+                )
+            value = value.reshape(expected, -1)
+            if value.shape[1] != 1:
+                raise RuntimeError(
+                    f"Expected scalar values under key={key!r}, got shape "
+                    f"{tuple(value.shape)}."
+                )
+            if (
+                value.dtype == torch.bool
+                or torch.is_floating_point(value)
+                or torch.is_complex(value)
+            ):
+                raise TypeError(
+                    f"key={key!r} must contain integer values, got dtype={value.dtype}."
+                )
+        trajectory = trajectory.reshape(expected, -1)[:, 0]
+        step = step.reshape(expected, -1)[:, 0]
+        metadata = torch.stack(
+            (
+                index.to(device=step.device, dtype=torch.long),
+                trajectory.to(device=step.device, dtype=torch.long),
+                step.to(torch.long),
+            ),
+            dim=-1,
+        ).cpu()
+        slots, trajectories, steps = metadata.unbind(-1)
+        return slots.tolist(), trajectories.tolist(), steps.tolist(), step.device
+
+    def _read_records(
+        self, storage: Storage, index: torch.Tensor
+    ) -> tuple[list[int], list[int], list[int], torch.device]:
+        storage_device = self._storage_device(storage)
+        if storage_device is not None and index.device != storage_device:
+            index = index.to(storage_device)
+        lookup_index = index.clamp(0, len(storage) - 1)
+        data = storage.get(lookup_index)
+        if not is_tensor_collection(data):
+            raise TypeError(
+                "Fragmented trajectory indexing requires a single-dimensional "
+                "storage whose slices return a tensor collection, such as "
+                "LazyTensorStorage or LazyStackStorage."
+            )
+        return self._validate_metadata(data, index)
+
+    def clear(self) -> None:
+        self._trajectory_positions = None
+        self._slot_records = None
+        self._previous = None
+        self._following = None
+        self._runs = None
+        self._pending_indices.clear()
+        self._pending_revisions.clear()
+        self._pending_storage_id = None
+        self._cache_storage_id = None
+        self._cache_revision = None
+
+    def _full_rebuild(
+        self, storage: Storage, revision: int
+    ) -> _FragmentedTrajectoryIndexUpdate:
+        if storage.ndim > 1:
+            raise NotImplementedError(
+                "Fragmented trajectory indexing only supports single-dimensional "
+                f"storages, got storage.ndim={storage.ndim}."
+            )
+        storage_length = len(storage)
+        index = torch.arange(storage_length, dtype=torch.long)
+        slots, trajectories, steps, device = self._read_records(storage, index)
+        capacity = int(storage.max_size)
+        trajectory_positions: dict[int, dict[int, int]] = defaultdict(dict)
+        slot_records: list[tuple[int, int] | None] = [None] * capacity
+        for position, trajectory, step in zip(slots, trajectories, steps):
+            trajectory = int(trajectory)
+            step = int(step)
+            if step < 0:
+                raise ValueError(
+                    f"Step numbers must be non-negative, got {step} under "
+                    f"step_key={self.step_key!r}."
+                )
+            positions = trajectory_positions[trajectory]
+            if step in positions:
+                raise RuntimeError(
+                    "Found duplicate records for trajectory "
+                    f"{trajectory!r} at step {step}. Trajectory-step pairs must "
+                    "be unique in the live storage."
+                )
+            positions[step] = position
+            slot_records[position] = (trajectory, step)
+
+        previous = [-1] * capacity
+        following = [-1] * capacity
+        for positions in trajectory_positions.values():
+            for step, position in positions.items():
+                previous[position] = positions.get(step - 1, -1)
+                following[position] = positions.get(step + 1, -1)
+
+        self._slot_records = slot_records
+        self._trajectory_positions = dict(trajectory_positions)
+        self._previous = torch.tensor(previous, dtype=torch.long, device=device)
+        self._following = torch.tensor(following, dtype=torch.long, device=device)
+        self._runs = None
+        self._pending_indices.clear()
+        self._pending_revisions.clear()
+        self._pending_storage_id = None
+        self._cache_storage_id = id(storage)
+        self._cache_revision = revision
+        return _FragmentedTrajectoryIndexUpdate(
+            full_rebuild=True,
+            affected={},
+            removed_slots=set(),
+        )
+
+    def _consume_pending(self) -> torch.Tensor:
+        if len(self._pending_indices) == 1:
+            index = self._pending_indices[0]
+        elif all(
+            item.device == self._pending_indices[0].device
+            for item in self._pending_indices
+        ):
+            index = torch.cat(self._pending_indices)
+        else:
+            index = torch.cat([item.cpu() for item in self._pending_indices])
+        index = index.reshape(-1)
+        self._pending_indices.clear()
+        self._pending_revisions.clear()
+        self._pending_storage_id = None
+        return index
+
+    def _apply_pending(
+        self, storage: Storage, revision: int
+    ) -> _FragmentedTrajectoryIndexUpdate:
+        index = self._consume_pending()
+        storage_length = len(storage)
+        if not index.numel():
+            self._cache_revision = revision
+            return _FragmentedTrajectoryIndexUpdate(False, {}, set())
+        slots, trajectories, steps, _ = self._read_records(storage, index)
+        records = {
+            slot: (trajectory, step)
+            for slot, trajectory, step in zip(slots, trajectories, steps)
+            if 0 <= slot < storage_length
+        }
+        slots = list(records)
+        if not slots:
+            self._cache_revision = revision
+            return _FragmentedTrajectoryIndexUpdate(False, {}, set())
+        trajectories, steps = zip(*records.values())
+
+        affected: dict[int, set[int]] = defaultdict(set)
+        removed_slots = set(slots)
+        for slot in slots:
+            record = self._slot_records[slot]
+            if record is None:
+                continue
+            trajectory, step = record
+            positions = self._trajectory_positions[trajectory]
+            if positions.get(step) == slot:
+                del positions[step]
+            if not positions:
+                del self._trajectory_positions[trajectory]
+            affected[trajectory].add(step)
+            self._slot_records[slot] = None
+
+        new_records = []
+        seen = set()
+        for slot, trajectory, step in zip(slots, trajectories, steps):
+            trajectory = int(trajectory)
+            step = int(step)
+            if step < 0:
+                raise ValueError(
+                    f"Step numbers must be non-negative, got {step} under "
+                    f"step_key={self.step_key!r}."
+                )
+            record = (trajectory, step)
+            positions = self._trajectory_positions.get(trajectory)
+            if record in seen or (positions is not None and step in positions):
+                raise RuntimeError(
+                    "Found duplicate records for trajectory "
+                    f"{trajectory!r} at step {step}. Trajectory-step pairs must "
+                    "be unique in the live storage."
+                )
+            seen.add(record)
+            new_records.append((slot, trajectory, step))
+
+        for slot, trajectory, step in new_records:
+            self._trajectory_positions.setdefault(trajectory, {})[step] = slot
+            self._slot_records[slot] = (trajectory, step)
+            affected[trajectory].add(step)
+
+        previous_updates = {slot: -1 for slot in removed_slots}
+        following_updates = {slot: -1 for slot in removed_slots}
+        for trajectory, changed_steps in affected.items():
+            positions = self._trajectory_positions.get(trajectory, {})
+            link_steps = set()
+            for step in changed_steps:
+                link_steps.update(range(max(0, step - 1), step + 2))
+            for step in link_steps:
+                slot = positions.get(step)
+                if slot is None:
+                    continue
+                previous_updates[slot] = positions.get(step - 1, -1)
+                following_updates[slot] = positions.get(step + 1, -1)
+
+        packed_updates = [
+            *previous_updates.items(),
+            *following_updates.items(),
+        ]
+        updates = torch.tensor(
+            packed_updates, dtype=torch.long, device=self._previous.device
+        )
+        split = len(previous_updates)
+        self._previous[updates[:split, 0]] = updates[:split, 1]
+        self._following[updates[split:, 0]] = updates[split:, 1]
+        self._runs = None
+        self._cache_revision = revision
+        return _FragmentedTrajectoryIndexUpdate(
+            full_rebuild=False,
+            affected=dict(affected),
+            removed_slots=removed_slots,
+        )
+
+    def refresh(
+        self, storage: Storage
+    ) -> _FragmentedTrajectoryIndexUpdate | None:
+        revision = int(storage._mutation_revision)
+        if self._trajectory_positions is None or self._cache_storage_id != id(storage):
+            return self._full_rebuild(storage, revision)
+        if self._pending_indices and self._pending_storage_id == id(storage):
+            changed_revisions = {
+                pending_revision
+                for pending_revision in self._pending_revisions
+                if pending_revision > self._cache_revision
+            }
+            expected_revisions = set(range(self._cache_revision + 1, revision + 1))
+            if changed_revisions == expected_revisions:
+                return self._apply_pending(storage, revision)
+            return self._full_rebuild(storage, revision)
+        if self._cache_revision != revision:
+            return self._full_rebuild(storage, revision)
+        return None
+
+    def mark_update(
+        self, index: int | torch.Tensor, *, storage: Storage | None = None
+    ) -> None:
+        if storage is None:
+            self.clear()
+            return
+        storage_id = id(storage)
+        if self._pending_storage_id not in (None, storage_id):
+            self.clear()
+        self._pending_storage_id = storage_id
+        self._pending_indices.append(
+            torch.as_tensor(index, dtype=torch.long).detach().reshape(-1)
+        )
+        self._pending_revisions.append(int(storage._mutation_revision))
+
+    def runs(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Returns packed physical slots, run offsets, and logical run lengths."""
+        if self._trajectory_positions is None:
+            raise RuntimeError("The fragmented trajectory index has not been built.")
+        if self._runs is not None:
+            return self._runs
+
+        ordered_slots = []
+        run_offsets = []
+        run_lengths = []
+        for positions in self._trajectory_positions.values():
+            sorted_steps = sorted(positions)
+            run_start = 0
+            for run_end, step in enumerate(sorted_steps):
+                if (
+                    run_end < len(sorted_steps) - 1
+                    and sorted_steps[run_end + 1] == step + 1
+                ):
+                    continue
+                slots = [
+                    positions[run_step]
+                    for run_step in sorted_steps[run_start : run_end + 1]
+                ]
+                run_offsets.append(len(ordered_slots))
+                run_lengths.append(len(slots))
+                ordered_slots.extend(slots)
+                run_start = run_end + 1
+
+        device = self._previous.device
+        self._runs = (
+            torch.tensor(ordered_slots, dtype=torch.long, device=device),
+            torch.tensor(run_offsets, dtype=torch.long, device=device),
+            torch.tensor(run_lengths, dtype=torch.long, device=device),
+        )
+        return self._runs
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        for key in (
+            "_trajectory_positions",
+            "_slot_records",
+            "_previous",
+            "_following",
+            "_runs",
+        ):
+            state[key] = None
+        state["_pending_indices"] = []
+        state["_pending_revisions"] = []
+        state["_pending_storage_id"] = None
+        state["_cache_storage_id"] = None
+        state["_cache_revision"] = None
+        return state

--- a/torchrl/data/replay_buffers/samplers/_trajectory.py
+++ b/torchrl/data/replay_buffers/samplers/_trajectory.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 
 import torch
-from tensordict import TensorDictBase, is_tensor_collection
+from tensordict import is_tensor_collection, TensorDictBase
 from tensordict.utils import NestedKey
 
 from torchrl.data.replay_buffers.storages import Storage
@@ -290,9 +290,7 @@ class _FragmentedTrajectoryIndex:
             removed_slots=removed_slots,
         )
 
-    def refresh(
-        self, storage: Storage
-    ) -> _FragmentedTrajectoryIndexUpdate | None:
+    def refresh(self, storage: Storage) -> _FragmentedTrajectoryIndexUpdate | None:
         revision = int(storage._mutation_revision)
         if self._trajectory_positions is None or self._cache_storage_id != id(storage):
             return self._full_rebuild(storage, revision)

--- a/torchrl/data/replay_buffers/samplers/_trajectory.py
+++ b/torchrl/data/replay_buffers/samplers/_trajectory.py
@@ -20,7 +20,7 @@ class _FragmentedTrajectoryIndex:
         self.trajectory_key = trajectory_key
         self.step_key = step_key
         self._trajectory_positions: dict[int, dict[int, int]] | None = None
-        self._slot_records: list[tuple[int, int] | None] | None = None
+        self._slot_records: dict[int, tuple[int, int]] | None = None
         self._device: torch.device | None = None
         self._runs: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None
         self._pending_indices: list[torch.Tensor] = []
@@ -113,9 +113,10 @@ class _FragmentedTrajectoryIndex:
         storage_length = len(storage)
         index = torch.arange(storage_length, dtype=torch.long)
         slots, trajectories, steps, device = self._read_records(storage, index)
-        capacity = int(storage.max_size)
         trajectory_positions: dict[int, dict[int, int]] = defaultdict(dict)
-        slot_records: list[tuple[int, int] | None] = [None] * capacity
+        # Keyed by slot: list storages default to an unbounded max_size, so
+        # bookkeeping cannot be sized by capacity.
+        slot_records: dict[int, tuple[int, int]] = {}
         for position, trajectory, step in zip(slots, trajectories, steps):
             trajectory = int(trajectory)
             step = int(step)
@@ -179,7 +180,7 @@ class _FragmentedTrajectoryIndex:
         trajectories, steps = zip(*records.values())
 
         for slot in slots:
-            record = self._slot_records[slot]
+            record = self._slot_records.pop(slot, None)
             if record is None:
                 continue
             trajectory, step = record
@@ -188,7 +189,6 @@ class _FragmentedTrajectoryIndex:
                 del positions[step]
             if not positions:
                 del self._trajectory_positions[trajectory]
-            self._slot_records[slot] = None
 
         new_records = []
         seen = set()

--- a/torchrl/data/replay_buffers/samplers/_trajectory.py
+++ b/torchrl/data/replay_buffers/samplers/_trajectory.py
@@ -21,7 +21,10 @@ class _FragmentedTrajectoryIndex:
         self.trajectory_key = trajectory_key
         self.step_key = step_key
         self._trajectory_positions: dict[int, dict[int, int]] | None = None
-        self._slot_records: dict[int, tuple[int, int]] | None = None
+        # Per-slot record columns (CPU, long). A step of -1 marks a slot
+        # without a live record.
+        self._slot_traj: torch.Tensor | None = None
+        self._slot_step: torch.Tensor | None = None
         self._device: torch.device | None = None
         self._runs: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None
         self._pending_indices: list[torch.Tensor] = []
@@ -44,7 +47,7 @@ class _FragmentedTrajectoryIndex:
         trajectory: torch.Tensor | None,
         step: torch.Tensor | None,
         index: torch.Tensor,
-    ) -> tuple[list[int], list[int], list[int], torch.device]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.device]:
         expected = index.numel()
         for key, value in (
             (self.trajectory_key, trajectory),
@@ -79,11 +82,11 @@ class _FragmentedTrajectoryIndex:
             dim=-1,
         ).cpu()
         slots, trajectories, steps = metadata.unbind(-1)
-        return slots.tolist(), trajectories.tolist(), steps.tolist(), step.device
+        return slots, trajectories, steps, step.device
 
     def _read_records(
         self, storage: Storage, index: torch.Tensor
-    ) -> tuple[list[int], list[int], list[int], torch.device]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.device]:
         storage_device = self._storage_device(storage)
         if storage_device is not None and index.device != storage_device:
             index = index.to(storage_device)
@@ -118,7 +121,8 @@ class _FragmentedTrajectoryIndex:
 
     def clear(self) -> None:
         self._trajectory_positions = None
-        self._slot_records = None
+        self._slot_traj = None
+        self._slot_step = None
         self._device = None
         self._runs = None
         self._pending_indices.clear()
@@ -137,12 +141,9 @@ class _FragmentedTrajectoryIndex:
         index = torch.arange(storage_length, dtype=torch.long)
         slots, trajectories, steps, device = self._read_records(storage, index)
         trajectory_positions: dict[int, dict[int, int]] = defaultdict(dict)
-        # Keyed by slot: list storages default to an unbounded max_size, so
-        # bookkeeping cannot be sized by capacity.
-        slot_records: dict[int, tuple[int, int]] = {}
-        for position, trajectory, step in zip(slots, trajectories, steps):
-            trajectory = int(trajectory)
-            step = int(step)
+        for position, trajectory, step in zip(
+            slots.tolist(), trajectories.tolist(), steps.tolist()
+        ):
             if step < 0:
                 raise ValueError(
                     f"Step numbers must be non-negative, got {step} under "
@@ -156,9 +157,11 @@ class _FragmentedTrajectoryIndex:
                     "be unique in the live storage."
                 )
             positions[step] = position
-            slot_records[position] = (trajectory, step)
 
-        self._slot_records = slot_records
+        # The read index is arange(storage_length), so the metadata rows are
+        # already slot-aligned columns.
+        self._slot_traj = trajectories.clone()
+        self._slot_step = steps.clone()
         self._trajectory_positions = dict(trajectory_positions)
         self._device = device
         self._runs = None
@@ -193,7 +196,9 @@ class _FragmentedTrajectoryIndex:
         slots, trajectories, steps, _ = self._read_records(storage, index)
         records = {
             slot: (trajectory, step)
-            for slot, trajectory, step in zip(slots, trajectories, steps)
+            for slot, trajectory, step in zip(
+                slots.tolist(), trajectories.tolist(), steps.tolist()
+            )
             if 0 <= slot < storage_length
         }
         slots = list(records)
@@ -203,22 +208,32 @@ class _FragmentedTrajectoryIndex:
         trajectories, steps = zip(*records.values())
 
         try:
+            size = self._slot_step.numel()
+            max_slot = max(slots)
+            if max_slot >= size:
+                grow = max_slot + 1 - size
+                self._slot_traj = torch.cat(
+                    [self._slot_traj, self._slot_traj.new_zeros(grow)]
+                )
+                self._slot_step = torch.cat(
+                    [self._slot_step, self._slot_step.new_full((grow,), -1)]
+                )
+
             for slot in slots:
-                record = self._slot_records.pop(slot, None)
-                if record is None:
+                step = int(self._slot_step[slot])
+                if step < 0:
                     continue
-                trajectory, step = record
+                trajectory = int(self._slot_traj[slot])
                 positions = self._trajectory_positions[trajectory]
                 if positions.get(step) == slot:
                     del positions[step]
                 if not positions:
                     del self._trajectory_positions[trajectory]
+                self._slot_step[slot] = -1
 
             new_records = []
             seen = set()
             for slot, trajectory, step in zip(slots, trajectories, steps):
-                trajectory = int(trajectory)
-                step = int(step)
                 if step < 0:
                     raise ValueError(
                         f"Step numbers must be non-negative, got {step} under "
@@ -237,7 +252,8 @@ class _FragmentedTrajectoryIndex:
 
             for slot, trajectory, step in new_records:
                 self._trajectory_positions.setdefault(trajectory, {})[step] = slot
-                self._slot_records[slot] = (trajectory, step)
+                self._slot_traj[slot] = trajectory
+                self._slot_step[slot] = step
         except Exception:
             # The pending list is already consumed and the maps may be half
             # mutated; drop the index so the next refresh rebuilds instead of
@@ -298,32 +314,32 @@ class _FragmentedTrajectoryIndex:
         if self._runs is not None:
             return self._runs
 
-        ordered_slots = []
-        run_offsets = []
-        run_lengths = []
-        for positions in self._trajectory_positions.values():
-            sorted_steps = sorted(positions)
-            run_start = 0
-            for run_end, step in enumerate(sorted_steps):
-                if (
-                    run_end < len(sorted_steps) - 1
-                    and sorted_steps[run_end + 1] == step + 1
-                ):
-                    continue
-                slots = [
-                    positions[run_step]
-                    for run_step in sorted_steps[run_start : run_end + 1]
-                ]
-                run_offsets.append(len(ordered_slots))
-                run_lengths.append(len(slots))
-                ordered_slots.extend(slots)
-                run_start = run_end + 1
+        live = (self._slot_step >= 0).nonzero().squeeze(-1)
+        trajectory = self._slot_traj[live]
+        step = self._slot_step[live]
+        # Stable lexsort by (trajectory, step): the packing is then a pure
+        # function of the stored values, so samples drawn with a given RNG
+        # state do not depend on the write or rebuild history.
+        order = torch.argsort(step, stable=True)
+        order = order[torch.argsort(trajectory[order], stable=True)]
+        sorted_trajectory = trajectory[order]
+        sorted_step = step[order]
+        new_run = torch.ones_like(sorted_step, dtype=torch.bool)
+        if sorted_step.numel() > 1:
+            new_run[1:] = (sorted_trajectory[1:] != sorted_trajectory[:-1]) | (
+                sorted_step[1:] != sorted_step[:-1] + 1
+            )
+        run_offsets = new_run.nonzero().squeeze(-1)
+        boundaries = torch.cat(
+            [run_offsets, run_offsets.new_tensor([sorted_step.numel()])]
+        )
+        run_lengths = boundaries[1:] - boundaries[:-1]
 
         device = self._device
         self._runs = (
-            torch.tensor(ordered_slots, dtype=torch.long, device=device),
-            torch.tensor(run_offsets, dtype=torch.long, device=device),
-            torch.tensor(run_lengths, dtype=torch.long, device=device),
+            live[order].to(device),
+            run_offsets.to(device),
+            run_lengths.to(device),
         )
         return self._runs
 
@@ -331,7 +347,8 @@ class _FragmentedTrajectoryIndex:
         state = self.__dict__.copy()
         for key in (
             "_trajectory_positions",
-            "_slot_records",
+            "_slot_traj",
+            "_slot_step",
             "_device",
             "_runs",
         ):

--- a/torchrl/data/replay_buffers/samplers/_trajectory.py
+++ b/torchrl/data/replay_buffers/samplers/_trajectory.py
@@ -182,41 +182,48 @@ class _FragmentedTrajectoryIndex:
             return
         trajectories, steps = zip(*records.values())
 
-        for slot in slots:
-            record = self._slot_records.pop(slot, None)
-            if record is None:
-                continue
-            trajectory, step = record
-            positions = self._trajectory_positions[trajectory]
-            if positions.get(step) == slot:
-                del positions[step]
-            if not positions:
-                del self._trajectory_positions[trajectory]
+        try:
+            for slot in slots:
+                record = self._slot_records.pop(slot, None)
+                if record is None:
+                    continue
+                trajectory, step = record
+                positions = self._trajectory_positions[trajectory]
+                if positions.get(step) == slot:
+                    del positions[step]
+                if not positions:
+                    del self._trajectory_positions[trajectory]
 
-        new_records = []
-        seen = set()
-        for slot, trajectory, step in zip(slots, trajectories, steps):
-            trajectory = int(trajectory)
-            step = int(step)
-            if step < 0:
-                raise ValueError(
-                    f"Step numbers must be non-negative, got {step} under "
-                    f"step_key={self.step_key!r}."
-                )
-            record = (trajectory, step)
-            positions = self._trajectory_positions.get(trajectory)
-            if record in seen or (positions is not None and step in positions):
-                raise RuntimeError(
-                    "Found duplicate records for trajectory "
-                    f"{trajectory!r} at step {step}. Trajectory-step pairs must "
-                    "be unique in the live storage."
-                )
-            seen.add(record)
-            new_records.append((slot, trajectory, step))
+            new_records = []
+            seen = set()
+            for slot, trajectory, step in zip(slots, trajectories, steps):
+                trajectory = int(trajectory)
+                step = int(step)
+                if step < 0:
+                    raise ValueError(
+                        f"Step numbers must be non-negative, got {step} under "
+                        f"step_key={self.step_key!r}."
+                    )
+                record = (trajectory, step)
+                positions = self._trajectory_positions.get(trajectory)
+                if record in seen or (positions is not None and step in positions):
+                    raise RuntimeError(
+                        "Found duplicate records for trajectory "
+                        f"{trajectory!r} at step {step}. Trajectory-step pairs must "
+                        "be unique in the live storage."
+                    )
+                seen.add(record)
+                new_records.append((slot, trajectory, step))
 
-        for slot, trajectory, step in new_records:
-            self._trajectory_positions.setdefault(trajectory, {})[step] = slot
-            self._slot_records[slot] = (trajectory, step)
+            for slot, trajectory, step in new_records:
+                self._trajectory_positions.setdefault(trajectory, {})[step] = slot
+                self._slot_records[slot] = (trajectory, step)
+        except Exception:
+            # The pending list is already consumed and the maps may be half
+            # mutated; drop the index so the next refresh rebuilds instead of
+            # serving a partially applied update.
+            self.clear()
+            raise
 
         self._runs = None
         self._cache_revision = revision

--- a/torchrl/data/replay_buffers/samplers/_trajectory.py
+++ b/torchrl/data/replay_buffers/samplers/_trajectory.py
@@ -35,6 +35,18 @@ class _FragmentedTrajectoryIndex:
         self._cache_storage_ref: weakref.ref | None = None
         self._cache_revision: int | None = None
 
+    def _duplicate_error(self, trajectory: int, step: int) -> RuntimeError:
+        return RuntimeError(
+            f"Found duplicate records for trajectory {trajectory!r} at step "
+            f"{step} (traj_key={self.trajectory_key!r}, "
+            f"step_key={self.step_key!r}). Trajectory-step pairs must be "
+            "unique in the live storage. This commonly happens when "
+            "trajectory ids are reused, e.g. a recreated collector restarts "
+            "its traj_ids at 0 while episodes from a previous run are still "
+            "stored. Use a trajectory key whose ids stay unique across the "
+            "buffer lifetime, or empty the buffer before reusing ids."
+        )
+
     @staticmethod
     def _storage_device(storage: Storage) -> torch.device | None:
         device = getattr(storage, "device", None)
@@ -151,11 +163,7 @@ class _FragmentedTrajectoryIndex:
                 )
             positions = trajectory_positions[trajectory]
             if step in positions:
-                raise RuntimeError(
-                    "Found duplicate records for trajectory "
-                    f"{trajectory!r} at step {step}. Trajectory-step pairs must "
-                    "be unique in the live storage."
-                )
+                raise self._duplicate_error(trajectory, step)
             positions[step] = position
 
         # The read index is arange(storage_length), so the metadata rows are
@@ -242,11 +250,7 @@ class _FragmentedTrajectoryIndex:
                 record = (trajectory, step)
                 positions = self._trajectory_positions.get(trajectory)
                 if record in seen or (positions is not None and step in positions):
-                    raise RuntimeError(
-                        "Found duplicate records for trajectory "
-                        f"{trajectory!r} at step {step}. Trajectory-step pairs must "
-                        "be unique in the live storage."
-                    )
+                    raise self._duplicate_error(trajectory, step)
                 seen.add(record)
                 new_records.append((slot, trajectory, step))
 

--- a/torchrl/data/replay_buffers/samplers/_trajectory.py
+++ b/torchrl/data/replay_buffers/samplers/_trajectory.py
@@ -5,20 +5,12 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
 
 import torch
 from tensordict import is_tensor_collection, TensorDictBase
 from tensordict.utils import NestedKey
 
 from torchrl.data.replay_buffers.storages import Storage
-
-
-@dataclass
-class _FragmentedTrajectoryIndexUpdate:
-    full_rebuild: bool
-    affected: dict[int, set[int]]
-    removed_slots: set[int]
 
 
 class _FragmentedTrajectoryIndex:
@@ -29,26 +21,13 @@ class _FragmentedTrajectoryIndex:
         self.step_key = step_key
         self._trajectory_positions: dict[int, dict[int, int]] | None = None
         self._slot_records: list[tuple[int, int] | None] | None = None
-        self._previous: torch.Tensor | None = None
-        self._following: torch.Tensor | None = None
+        self._device: torch.device | None = None
         self._runs: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None
         self._pending_indices: list[torch.Tensor] = []
         self._pending_revisions: list[int] = []
         self._pending_storage_id: int | None = None
         self._cache_storage_id: int | None = None
         self._cache_revision: int | None = None
-
-    @property
-    def trajectory_positions(self) -> dict[int, dict[int, int]]:
-        return self._trajectory_positions
-
-    @property
-    def previous(self) -> torch.Tensor:
-        return self._previous
-
-    @property
-    def following(self) -> torch.Tensor:
-        return self._following
 
     @staticmethod
     def _storage_device(storage: Storage) -> torch.device | None:
@@ -117,8 +96,7 @@ class _FragmentedTrajectoryIndex:
     def clear(self) -> None:
         self._trajectory_positions = None
         self._slot_records = None
-        self._previous = None
-        self._following = None
+        self._device = None
         self._runs = None
         self._pending_indices.clear()
         self._pending_revisions.clear()
@@ -126,9 +104,7 @@ class _FragmentedTrajectoryIndex:
         self._cache_storage_id = None
         self._cache_revision = None
 
-    def _full_rebuild(
-        self, storage: Storage, revision: int
-    ) -> _FragmentedTrajectoryIndexUpdate:
+    def _full_rebuild(self, storage: Storage, revision: int) -> None:
         if storage.ndim > 1:
             raise NotImplementedError(
                 "Fragmented trajectory indexing only supports single-dimensional "
@@ -158,28 +134,15 @@ class _FragmentedTrajectoryIndex:
             positions[step] = position
             slot_records[position] = (trajectory, step)
 
-        previous = [-1] * capacity
-        following = [-1] * capacity
-        for positions in trajectory_positions.values():
-            for step, position in positions.items():
-                previous[position] = positions.get(step - 1, -1)
-                following[position] = positions.get(step + 1, -1)
-
         self._slot_records = slot_records
         self._trajectory_positions = dict(trajectory_positions)
-        self._previous = torch.tensor(previous, dtype=torch.long, device=device)
-        self._following = torch.tensor(following, dtype=torch.long, device=device)
+        self._device = device
         self._runs = None
         self._pending_indices.clear()
         self._pending_revisions.clear()
         self._pending_storage_id = None
         self._cache_storage_id = id(storage)
         self._cache_revision = revision
-        return _FragmentedTrajectoryIndexUpdate(
-            full_rebuild=True,
-            affected={},
-            removed_slots=set(),
-        )
 
     def _consume_pending(self) -> torch.Tensor:
         if len(self._pending_indices) == 1:
@@ -197,14 +160,12 @@ class _FragmentedTrajectoryIndex:
         self._pending_storage_id = None
         return index
 
-    def _apply_pending(
-        self, storage: Storage, revision: int
-    ) -> _FragmentedTrajectoryIndexUpdate:
+    def _apply_pending(self, storage: Storage, revision: int) -> None:
         index = self._consume_pending()
         storage_length = len(storage)
         if not index.numel():
             self._cache_revision = revision
-            return _FragmentedTrajectoryIndexUpdate(False, {}, set())
+            return
         slots, trajectories, steps, _ = self._read_records(storage, index)
         records = {
             slot: (trajectory, step)
@@ -214,11 +175,9 @@ class _FragmentedTrajectoryIndex:
         slots = list(records)
         if not slots:
             self._cache_revision = revision
-            return _FragmentedTrajectoryIndexUpdate(False, {}, set())
+            return
         trajectories, steps = zip(*records.values())
 
-        affected: dict[int, set[int]] = defaultdict(set)
-        removed_slots = set(slots)
         for slot in slots:
             record = self._slot_records[slot]
             if record is None:
@@ -229,7 +188,6 @@ class _FragmentedTrajectoryIndex:
                 del positions[step]
             if not positions:
                 del self._trajectory_positions[trajectory]
-            affected[trajectory].add(step)
             self._slot_records[slot] = None
 
         new_records = []
@@ -256,41 +214,11 @@ class _FragmentedTrajectoryIndex:
         for slot, trajectory, step in new_records:
             self._trajectory_positions.setdefault(trajectory, {})[step] = slot
             self._slot_records[slot] = (trajectory, step)
-            affected[trajectory].add(step)
 
-        previous_updates = {slot: -1 for slot in removed_slots}
-        following_updates = {slot: -1 for slot in removed_slots}
-        for trajectory, changed_steps in affected.items():
-            positions = self._trajectory_positions.get(trajectory, {})
-            link_steps = set()
-            for step in changed_steps:
-                link_steps.update(range(max(0, step - 1), step + 2))
-            for step in link_steps:
-                slot = positions.get(step)
-                if slot is None:
-                    continue
-                previous_updates[slot] = positions.get(step - 1, -1)
-                following_updates[slot] = positions.get(step + 1, -1)
-
-        packed_updates = [
-            *previous_updates.items(),
-            *following_updates.items(),
-        ]
-        updates = torch.tensor(
-            packed_updates, dtype=torch.long, device=self._previous.device
-        )
-        split = len(previous_updates)
-        self._previous[updates[:split, 0]] = updates[:split, 1]
-        self._following[updates[split:, 0]] = updates[split:, 1]
         self._runs = None
         self._cache_revision = revision
-        return _FragmentedTrajectoryIndexUpdate(
-            full_rebuild=False,
-            affected=dict(affected),
-            removed_slots=removed_slots,
-        )
 
-    def refresh(self, storage: Storage) -> _FragmentedTrajectoryIndexUpdate | None:
+    def refresh(self, storage: Storage) -> None:
         revision = int(storage._mutation_revision)
         if self._trajectory_positions is None or self._cache_storage_id != id(storage):
             return self._full_rebuild(storage, revision)
@@ -351,7 +279,7 @@ class _FragmentedTrajectoryIndex:
                 ordered_slots.extend(slots)
                 run_start = run_end + 1
 
-        device = self._previous.device
+        device = self._device
         self._runs = (
             torch.tensor(ordered_slots, dtype=torch.long, device=device),
             torch.tensor(run_offsets, dtype=torch.long, device=device),
@@ -364,8 +292,7 @@ class _FragmentedTrajectoryIndex:
         for key in (
             "_trajectory_positions",
             "_slot_records",
-            "_previous",
-            "_following",
+            "_device",
             "_runs",
         ):
             state[key] = None

--- a/torchrl/data/replay_buffers/samplers/_trajectory.py
+++ b/torchrl/data/replay_buffers/samplers/_trajectory.py
@@ -8,7 +8,7 @@ import weakref
 from collections import defaultdict
 
 import torch
-from tensordict import is_tensor_collection, TensorDictBase
+from tensordict import is_tensor_collection
 from tensordict.utils import NestedKey
 
 from torchrl.data.replay_buffers.storages import Storage
@@ -40,11 +40,12 @@ class _FragmentedTrajectoryIndex:
         return torch.device(device)
 
     def _validate_metadata(
-        self, data: TensorDictBase, index: torch.Tensor
+        self,
+        trajectory: torch.Tensor | None,
+        step: torch.Tensor | None,
+        index: torch.Tensor,
     ) -> tuple[list[int], list[int], list[int], torch.device]:
         expected = index.numel()
-        trajectory = data.get(self.trajectory_key)
-        step = data.get(self.step_key)
         for key, value in (
             (self.trajectory_key, trajectory),
             (self.step_key, step),
@@ -87,14 +88,33 @@ class _FragmentedTrajectoryIndex:
         if storage_device is not None and index.device != storage_device:
             index = index.to(storage_device)
         lookup_index = index.clamp(0, len(storage) - 1)
-        data = storage.get(lookup_index)
-        if not is_tensor_collection(data):
-            raise TypeError(
-                "Fragmented trajectory indexing requires a single-dimensional "
-                "storage whose slices return a tensor collection, such as "
-                "LazyTensorStorage or LazyStackStorage."
-            )
-        return self._validate_metadata(data, index)
+        # Prefer column reads: advanced-indexing the storage itself would
+        # materialize every stored key just to read two integer columns.
+        trajectory = step = None
+        try:
+            source = storage[:]
+        except Exception:
+            source = None
+        if is_tensor_collection(source):
+            try:
+                trajectory = source.get(self.trajectory_key, default=None)
+                step = source.get(self.step_key, default=None)
+            except Exception:
+                trajectory = step = None
+        if trajectory is not None and step is not None:
+            trajectory = trajectory[lookup_index.to(trajectory.device)]
+            step = step[lookup_index.to(step.device)]
+        else:
+            data = storage.get(lookup_index)
+            if not is_tensor_collection(data):
+                raise TypeError(
+                    "Fragmented trajectory indexing requires a single-dimensional "
+                    "storage whose slices return a tensor collection, such as "
+                    "LazyTensorStorage or LazyStackStorage."
+                )
+            trajectory = data.get(self.trajectory_key)
+            step = data.get(self.step_key)
+        return self._validate_metadata(trajectory, step, index)
 
     def clear(self) -> None:
         self._trajectory_positions = None

--- a/torchrl/data/replay_buffers/samplers/_trajectory.py
+++ b/torchrl/data/replay_buffers/samplers/_trajectory.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import weakref
 from collections import defaultdict
 
 import torch
@@ -25,8 +26,10 @@ class _FragmentedTrajectoryIndex:
         self._runs: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None
         self._pending_indices: list[torch.Tensor] = []
         self._pending_revisions: list[int] = []
-        self._pending_storage_id: int | None = None
-        self._cache_storage_id: int | None = None
+        # Weak references rather than id(): a recycled address of a dead
+        # storage must not be mistaken for the cached one.
+        self._pending_storage_ref: weakref.ref | None = None
+        self._cache_storage_ref: weakref.ref | None = None
         self._cache_revision: int | None = None
 
     @staticmethod
@@ -100,8 +103,8 @@ class _FragmentedTrajectoryIndex:
         self._runs = None
         self._pending_indices.clear()
         self._pending_revisions.clear()
-        self._pending_storage_id = None
-        self._cache_storage_id = None
+        self._pending_storage_ref = None
+        self._cache_storage_ref = None
         self._cache_revision = None
 
     def _full_rebuild(self, storage: Storage, revision: int) -> None:
@@ -141,8 +144,8 @@ class _FragmentedTrajectoryIndex:
         self._runs = None
         self._pending_indices.clear()
         self._pending_revisions.clear()
-        self._pending_storage_id = None
-        self._cache_storage_id = id(storage)
+        self._pending_storage_ref = None
+        self._cache_storage_ref = weakref.ref(storage)
         self._cache_revision = revision
 
     def _consume_pending(self) -> torch.Tensor:
@@ -158,7 +161,7 @@ class _FragmentedTrajectoryIndex:
         index = index.reshape(-1)
         self._pending_indices.clear()
         self._pending_revisions.clear()
-        self._pending_storage_id = None
+        self._pending_storage_ref = None
         return index
 
     def _apply_pending(self, storage: Storage, revision: int) -> None:
@@ -220,9 +223,17 @@ class _FragmentedTrajectoryIndex:
 
     def refresh(self, storage: Storage) -> None:
         revision = int(storage._mutation_revision)
-        if self._trajectory_positions is None or self._cache_storage_id != id(storage):
+        if (
+            self._trajectory_positions is None
+            or self._cache_storage_ref is None
+            or self._cache_storage_ref() is not storage
+        ):
             return self._full_rebuild(storage, revision)
-        if self._pending_indices and self._pending_storage_id == id(storage):
+        if (
+            self._pending_indices
+            and self._pending_storage_ref is not None
+            and self._pending_storage_ref() is storage
+        ):
             changed_revisions = {
                 pending_revision
                 for pending_revision in self._pending_revisions
@@ -242,10 +253,12 @@ class _FragmentedTrajectoryIndex:
         if storage is None:
             self.clear()
             return
-        storage_id = id(storage)
-        if self._pending_storage_id not in (None, storage_id):
+        if (
+            self._pending_storage_ref is not None
+            and self._pending_storage_ref() is not storage
+        ):
             self.clear()
-        self._pending_storage_id = storage_id
+        self._pending_storage_ref = weakref.ref(storage)
         self._pending_indices.append(
             torch.as_tensor(index, dtype=torch.long).detach().reshape(-1)
         )
@@ -298,7 +311,7 @@ class _FragmentedTrajectoryIndex:
             state[key] = None
         state["_pending_indices"] = []
         state["_pending_revisions"] = []
-        state["_pending_storage_id"] = None
-        state["_cache_storage_id"] = None
+        state["_pending_storage_ref"] = None
+        state["_cache_storage_ref"] = None
         state["_cache_revision"] = None
         return state

--- a/torchrl/data/replay_buffers/samplers/slice.py
+++ b/torchrl/data/replay_buffers/samplers/slice.py
@@ -82,6 +82,16 @@ class SliceSampler(Sampler):
             from a previous run are still stored) raises an error at sampling
             time. Defaults to ``False``. The ``span`` and ``compile`` options
             are not currently supported in fragmented mode.
+
+            .. warning:: The fragmented index tracks storage writes through
+                the storage's mutation revision. Buffers shared at process
+                spawn time keep that counter shared, so writes from other
+                processes are detected. A buffer transferred by plain
+                pickling (queues, cloudpickle, ``torch.save``) receives a
+                snapshot of the counter instead: writes made by another
+                process afterwards are not detected, even when the storage
+                data itself is shared (e.g. memory-mapped storages), and the
+                sampler keeps serving the transfer-time layout.
         ends (torch.Tensor, optional): a 1d boolean tensor containing the end of run signals.
             To be used whenever the ``end_key`` or ``traj_key`` is expensive to get,
             or when this signal is readily available. Must be used with ``cache_values=True``

--- a/torchrl/data/replay_buffers/samplers/slice.py
+++ b/torchrl/data/replay_buffers/samplers/slice.py
@@ -377,6 +377,8 @@ class SliceSampler(Sampler):
         span: bool | int | tuple[bool | int, bool | int] = False,
         use_gpu: torch.device | bool = False,
     ):
+        if isinstance(span, (bool, int)):
+            span = (span, span)
         if fragmented:
             if type(self).sample is not SliceSampler.sample:
                 raise NotImplementedError(
@@ -396,7 +398,7 @@ class SliceSampler(Sampler):
                     "The static trajectories argument is not supported with "
                     "fragmented=True; provide traj_key and step_key."
                 )
-            if span:
+            if any(span):
                 raise NotImplementedError("span is not supported with fragmented=True.")
             if compile:
                 raise NotImplementedError(
@@ -443,8 +445,6 @@ class SliceSampler(Sampler):
             )
         )
 
-        if isinstance(span, (bool, int)):
-            span = (span, span)
         self.span = span
 
         if trajectories is not None:

--- a/torchrl/data/replay_buffers/samplers/slice.py
+++ b/torchrl/data/replay_buffers/samplers/slice.py
@@ -351,6 +351,12 @@ class SliceSampler(Sampler):
     # We use this whenever we need to sample N times too many transitions to then select only a 1/N fraction of them
     _batch_size_multiplier: int | None = 1
 
+    # Class-level defaults keep samplers pickled by earlier torchrl versions
+    # (whose __dict__ lacks these attributes) working after an upgrade.
+    fragmented: bool = False
+    step_key: NestedKey | None = "step_count"
+    _fragmented_index: _FragmentedTrajectoryIndex | None = None
+
     def __init__(
         self,
         *,

--- a/torchrl/data/replay_buffers/samplers/slice.py
+++ b/torchrl/data/replay_buffers/samplers/slice.py
@@ -391,9 +391,7 @@ class SliceSampler(Sampler):
                     "fragmented=True; provide traj_key and step_key."
                 )
             if span:
-                raise NotImplementedError(
-                    "span is not supported with fragmented=True."
-                )
+                raise NotImplementedError("span is not supported with fragmented=True.")
             if compile:
                 raise NotImplementedError(
                     "compile is not supported with fragmented=True."
@@ -901,11 +899,13 @@ class SliceSampler(Sampler):
         selected_run_lengths = lengths[run_idx]
         available_starts = selected_run_lengths - sampled_lengths + 1
         relative_starts = (
-            torch.rand(
-                num_slices, device=lengths.device, generator=self._rng
+            (
+                torch.rand(num_slices, device=lengths.device, generator=self._rng)
+                * available_starts
             )
-            * available_starts
-        ).floor().to(run_offsets.dtype)
+            .floor()
+            .to(run_offsets.dtype)
+        )
         packed_starts = run_offsets[run_idx] + relative_starts
 
         if target_seq_length is not None:

--- a/torchrl/data/replay_buffers/samplers/slice.py
+++ b/torchrl/data/replay_buffers/samplers/slice.py
@@ -541,6 +541,9 @@ class SliceSampler(Sampler):
     ) -> None:
         if self.fragmented and self._fragmented_index is not None:
             self._fragmented_index.mark_update(index, storage=storage)
+        # Delegate cooperatively so classes mixing SliceSampler with e.g.
+        # PrioritizedSampler keep their write hook.
+        super().mark_update(index, storage=storage)
 
     def __repr__(self):
         return (

--- a/torchrl/data/replay_buffers/samplers/slice.py
+++ b/torchrl/data/replay_buffers/samplers/slice.py
@@ -76,9 +76,12 @@ class SliceSampler(Sampler):
             trajectory into separate sampleable runs. This mode currently supports
             single-dimensional TensorDict-backed storages and sampling with
             replacement. Trajectory ids and step numbers must be scalar integer
-            tensors, and every live trajectory-step pair must be unique. Defaults
-            to ``False``. The ``span`` and ``compile`` options are not currently
-            supported in fragmented mode.
+            tensors, and every live trajectory-step pair must be unique:
+            reusing trajectory ids (for instance a recreated collector
+            restarting ``("collector", "traj_ids")`` at zero while episodes
+            from a previous run are still stored) raises an error at sampling
+            time. Defaults to ``False``. The ``span`` and ``compile`` options
+            are not currently supported in fragmented mode.
         ends (torch.Tensor, optional): a 1d boolean tensor containing the end of run signals.
             To be used whenever the ``end_key`` or ``traj_key`` is expensive to get,
             or when this signal is readily available. Must be used with ``cache_values=True``

--- a/torchrl/data/replay_buffers/samplers/slice.py
+++ b/torchrl/data/replay_buffers/samplers/slice.py
@@ -11,6 +11,7 @@ from typing import Any
 import torch
 from tensordict import is_tensor_collection
 from tensordict.utils import NestedKey, unravel_key
+
 from torchrl._utils import _replace_last, logger
 from torchrl.data.replay_buffers.storages import Storage, TensorStorage
 from torchrl.data.replay_buffers.utils import (
@@ -19,6 +20,7 @@ from torchrl.data.replay_buffers.utils import (
     _ReplayBoundaryIndex,
 )
 
+from ._trajectory import _FragmentedTrajectoryIndex
 from .base import Sampler
 
 
@@ -65,6 +67,18 @@ class SliceSampler(Sampler):
             ``end_key``. Defaults to ``None`` (use ``end_key``).
         traj_key (NestedKey, optional): the key indicating the trajectories.
             Defaults to ``"episode"`` (commonly used across datasets in TorchRL).
+        step_key (NestedKey, optional): key containing a non-negative integer step
+            number for each item. Used only when ``fragmented=True`` and defaults
+            to ``"step_count"``.
+        fragmented (bool, optional): if ``True``, reconstructs logical trajectory
+            slices from ``traj_key`` and ``step_key`` even when consecutive steps
+            occupy non-adjacent storage positions. Missing logical steps split a
+            trajectory into separate sampleable runs. This mode currently supports
+            single-dimensional TensorDict-backed storages and sampling with
+            replacement. Trajectory ids and step numbers must be scalar integer
+            tensors, and every live trajectory-step pair must be unique. Defaults
+            to ``False``. The ``span`` and ``compile`` options are not currently
+            supported in fragmented mode.
         ends (torch.Tensor, optional): a 1d boolean tensor containing the end of run signals.
             To be used whenever the ``end_key`` or ``traj_key`` is expensive to get,
             or when this signal is readily available. Must be used with ``cache_values=True``
@@ -147,6 +161,9 @@ class SliceSampler(Sampler):
 
         To avoid this, either:
 
+        - set ``fragmented=True`` and provide both ``traj_key`` and ``step_key``
+          so that logical adjacency is reconstructed independently of storage
+          order,
         - set ``trajs_per_batch`` on the collector so that only **complete**
           trajectories (each ending with ``done=True``) are written to the
           buffer (use ``ndim=1`` on the storage — ``ndim >= 2`` is
@@ -342,6 +359,8 @@ class SliceSampler(Sampler):
         end_key: NestedKey | None = None,
         end_keys: Sequence[NestedKey] | None = None,
         traj_key: NestedKey | None = None,
+        step_key: NestedKey | None = "step_count",
+        fragmented: bool = False,
         ends: torch.Tensor | None = None,
         trajectories: torch.Tensor | None = None,
         cache_values: bool = False,
@@ -352,8 +371,38 @@ class SliceSampler(Sampler):
         span: bool | int | tuple[bool | int, bool | int] = False,
         use_gpu: torch.device | bool = False,
     ):
+        if fragmented:
+            if type(self).sample is not SliceSampler.sample:
+                raise NotImplementedError(
+                    "fragmented=True currently supports SliceSampler with "
+                    "replacement only."
+                )
+            if step_key is None:
+                raise ValueError("step_key must be provided when fragmented=True.")
+            if ends is not None:
+                raise ValueError(
+                    "fragmented=True requires trajectory and step identifiers; "
+                    "the static ends argument cannot reconstruct interleaved "
+                    "trajectories."
+                )
+            if trajectories is not None:
+                raise ValueError(
+                    "The static trajectories argument is not supported with "
+                    "fragmented=True; provide traj_key and step_key."
+                )
+            if span:
+                raise NotImplementedError(
+                    "span is not supported with fragmented=True."
+                )
+            if compile:
+                raise NotImplementedError(
+                    "compile is not supported with fragmented=True."
+                )
         self.num_slices = num_slices
         self.slice_len = slice_len
+        self.step_key = step_key
+        self.fragmented = fragmented
+        self._fragmented_index: _FragmentedTrajectoryIndex | None = None
         if end_keys is not None and end_key is not None:
             raise RuntimeError(
                 "`end_key` and `end_keys` are exclusive arguments: pass the "
@@ -470,14 +519,24 @@ class SliceSampler(Sampler):
         return state
 
     def extend(self, index: torch.Tensor) -> None:
+        if self.fragmented:
+            return
         super().extend(index)
         if self.cache_values:
             self._cache.clear()
 
     def add(self, index: torch.Tensor) -> None:
+        if self.fragmented:
+            return
         super().add(index)
         if self.cache_values:
             self._cache.clear()
+
+    def mark_update(
+        self, index: int | torch.Tensor, *, storage: Storage | None = None
+    ) -> None:
+        if self.fragmented and self._fragmented_index is not None:
+            self._fragmented_index.mark_update(index, storage=storage)
 
     def __repr__(self):
         return (
@@ -486,6 +545,8 @@ class SliceSampler(Sampler):
             f"end_key={self.end_key}, "
             f"end_keys={getattr(self, 'end_keys', None)}, "
             f"traj_key={self.traj_key}, "
+            f"step_key={self.step_key}, "
+            f"fragmented={self.fragmented}, "
             f"truncated_key={self.truncated_key}, "
             f"strict_length={self.strict_length}, "
             f"pad_output={getattr(self, 'pad_output', False)})"
@@ -757,6 +818,8 @@ class SliceSampler(Sampler):
     def sample(self, storage: Storage, batch_size: int) -> tuple[torch.Tensor, dict]:
         if self._batch_size_multiplier is not None:
             batch_size = batch_size * self._batch_size_multiplier
+        if self.fragmented:
+            return self._sample_fragmented(storage, batch_size)
         # pick up as many trajs as we need
         start_idx, stop_idx, lengths = self._get_stop_and_length(storage)
         # we have to make sure that the number of dims of the storage
@@ -777,6 +840,104 @@ class SliceSampler(Sampler):
             seq_length,
             num_slices,
             storage_length=storage_length,
+            storage=storage,
+        )
+
+    def _sample_fragmented(
+        self, storage: Storage, batch_size: int
+    ) -> tuple[tuple[torch.Tensor, ...], dict[str, Any]]:
+        if len(storage) == 0:
+            raise RuntimeError("Cannot sample from an empty storage.")
+        if getattr(self, "_traj_key_auto", False):
+            self._resolve_traj_key(storage)
+        if not self._fetch_traj or self.traj_key is None:
+            raise RuntimeError(
+                "fragmented=True requires a trajectory identifier under traj_key; "
+                "end-of-trajectory flags alone cannot reconstruct interleaved data."
+            )
+        indexer = self._fragmented_index
+        if (
+            indexer is None
+            or indexer.trajectory_key != self.traj_key
+            or indexer.step_key != self.step_key
+        ):
+            indexer = self._fragmented_index = _FragmentedTrajectoryIndex(
+                self.traj_key, self.step_key
+            )
+        indexer.refresh(storage)
+        ordered_slots, run_offsets, lengths = indexer.runs()
+        if not lengths.numel():
+            raise RuntimeError("No logical trajectory runs are available for sampling.")
+
+        seq_length, num_slices = self._adjusted_batch_size(batch_size)
+        if self.strict_length:
+            eligible = lengths >= seq_length
+            if not eligible.any():
+                raise RuntimeError(
+                    "Did not find a single fragmented trajectory run with "
+                    f"sufficient length (length range: {lengths.min()} - "
+                    f"{lengths.max()} / required={seq_length})."
+                )
+            run_offsets = run_offsets[eligible]
+            lengths = lengths[eligible]
+            run_idx = torch.randint(
+                lengths.shape[0],
+                (num_slices,),
+                device=lengths.device,
+                generator=self._rng,
+            )
+            sampled_lengths: int | torch.Tensor = seq_length
+            target_seq_length = None
+        else:
+            run_idx = torch.randint(
+                lengths.shape[0],
+                (num_slices,),
+                device=lengths.device,
+                generator=self._rng,
+            )
+            sampled_lengths = lengths[run_idx].clamp_max(seq_length)
+            target_seq_length = seq_length if self.pad_output else None
+
+        selected_run_lengths = lengths[run_idx]
+        available_starts = selected_run_lengths - sampled_lengths + 1
+        relative_starts = (
+            torch.rand(
+                num_slices, device=lengths.device, generator=self._rng
+            )
+            * available_starts
+        ).floor().to(run_offsets.dtype)
+        packed_starts = run_offsets[run_idx] + relative_starts
+
+        if target_seq_length is not None:
+            offsets = torch.arange(target_seq_length, device=lengths.device)
+            real_mask = offsets.unsqueeze(0) < sampled_lengths.unsqueeze(1)
+            offsets = torch.minimum(
+                offsets.unsqueeze(0), (sampled_lengths - 1).unsqueeze(1)
+            )
+            packed_indices = packed_starts.unsqueeze(1) + offsets
+            index = ordered_slots[packed_indices].reshape(-1, 1)
+            mask_flat = real_mask.reshape(-1)
+        elif isinstance(sampled_lengths, int):
+            offsets = torch.arange(sampled_lengths, device=lengths.device)
+            packed_indices = packed_starts.unsqueeze(1) + offsets
+            index = ordered_slots[packed_indices].reshape(-1, 1)
+            mask_flat = None
+        else:
+            packed_indices = torch.cat(
+                [
+                    torch.arange(length, device=lengths.device) + start
+                    for start, length in zip(packed_starts, sampled_lengths)
+                ]
+            )
+            index = ordered_slots[packed_indices].reshape(-1, 1)
+            mask_flat = None
+
+        return self._finalize_index(
+            index=index,
+            num_slices=num_slices,
+            seq_length=sampled_lengths,
+            target_seq_length=target_seq_length,
+            mask_flat=mask_flat,
             storage=storage,
         )
 
@@ -988,6 +1149,25 @@ class SliceSampler(Sampler):
             )
             mask_flat = None
 
+        return self._finalize_index(
+            index=index,
+            num_slices=num_slices,
+            seq_length=seq_length,
+            target_seq_length=target_seq_length,
+            mask_flat=mask_flat,
+            storage=storage,
+        )
+
+    def _finalize_index(
+        self,
+        *,
+        index: torch.Tensor,
+        num_slices: int,
+        seq_length: int | torch.Tensor,
+        target_seq_length: int | None,
+        mask_flat: torch.Tensor | None,
+        storage: Storage,
+    ) -> tuple[tuple[torch.Tensor, ...], dict[str, Any]]:
         if self.truncated_key is not None:
             truncated_key = self.truncated_key
             done_key = _replace_last(truncated_key, "done")
@@ -1109,7 +1289,8 @@ class SliceSampler(Sampler):
         self.__dict__["__used_end_key"] = value
 
     def _empty(self):
-        pass
+        if self._fragmented_index is not None:
+            self._fragmented_index.clear()
 
     def dumps(self, path):
         # no op - cache does not need to be saved
@@ -1123,4 +1304,5 @@ class SliceSampler(Sampler):
         return {}
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        ...
+        if self._fragmented_index is not None:
+            self._fragmented_index.clear()

--- a/torchrl/data/replay_buffers/storages/tensor.py
+++ b/torchrl/data/replay_buffers/storages/tensor.py
@@ -479,6 +479,9 @@ class TensorStorage(Storage):
         for key, value in patch.items():
             leaf = self._conditional_patch_leaf(key)
             leaf[coords] = value
+        # Caches derived from storage contents (boundary caches, the
+        # fragmented trajectory index) key their validity on the revision.
+        self._bump_mutation_revision()
 
     def __getstate__(self):
         state = super().__getstate__()

--- a/torchrl/trainers/algorithms/configs/data.py
+++ b/torchrl/trainers/algorithms/configs/data.py
@@ -173,6 +173,8 @@ class SliceSamplerConfig(SamplerConfig):
     end_key: Any = None
     end_keys: Any = None
     traj_key: Any = None
+    step_key: Any = "step_count"
+    fragmented: bool = False
     ends: Any = None
     trajectories: Any = None
     cache_values: bool = False


### PR DESCRIPTION
## Stack

This is the foundational PR for #4130. The geometric trajectory-window sampler is stacked on this branch and consumes the shared fragmented-trajectory index introduced here.

## Summary

- add an internal fragmented-trajectory index that maps logical `(trajectory, step)` adjacency independently of physical replay storage order
- add `SliceSampler(fragmented=True, step_key=...)` for fixed-length slices from interleaved or otherwise non-contiguous trajectories
- split missing logical steps into separate sampleable runs and refresh trajectory links incrementally after tracked writes
- preserve the existing flattened SliceSampler output, truncation, padding, and `is_init` metadata contracts
- add focused nested-key, wraparound, missing-step, and cached-sampling coverage
- continuously compare ordinary contiguous sampling with fragmented sampling across hot-cache, write-invalidated, and cold-start states

## Scope

Fragmented mode currently supports single-dimensional TensorDict-backed storages and SliceSampler with replacement. `span` and `compile` are left for follow-up work. End flags alone cannot reconstruct fragmented ordering; trajectory and step identifiers are required.

## Benchmark comparison

The benchmark constructs the same eight logical trajectories for both layouts. The baseline stores them contiguously and uses ordinary `SliceSampler`; the fragmented case applies a deterministic permutation to physical storage and uses `fragmented=True`. Both use the same tensor storage, metadata, batch size, slice length, and RNG seed. CUDA is synchronized at setup boundaries and after each timed sample.

Three cache states are measured:

- `hot-cache`: repeated sampling from an unchanged, already-indexed buffer
- `write-invalidated`: one tracked overwrite runs before every timed sample, outside the timed region
- `cold-start`: a newly populated replay buffer is prepared before every round and its first sample is timed

Representative local CPU medians:

| State | Contiguous, 1k | Fragmented, 1k | Contiguous, 100k | Fragmented, 100k |
| --- | ---: | ---: | ---: | ---: |
| hot cache | 87.6 us | 71.3 us | 94.8 us | 73.5 us |
| write invalidated | 141.3 us | 222.1 us | 304.0 us | 16.5 ms |
| cold start | 156.5 us | 452.4 us | 309.7 us | 41.6 ms |

The fragmented selector is faster once its packed trajectory index is hot, but rebuilding or repacking that index dominates when sampling immediately after writes. The benchmark uses fixed round counts for the slower states; all 12 local CPU cases complete in approximately 1.9 seconds.

## Validation

- `pytest test/rb/test_samplers.py -k fragmented -q` (3 passed)
- focused SliceSampler compatibility selection (21 passed)
- `pytest benchmarks/test_replaybuffer_benchmark.py::test_slice_sampler_sample --benchmark-only -q` (12 passed in approximately 1.9 seconds)
- exact repository ufmt check and `git diff --check`

The broader SliceSampler selection reached 87 passes locally; its prioritized cases cannot run because this environment lacks the native `SumSegmentTreeFp32` extension.