### PR TITLE
[Doc] Refresh tutorial coverage for enduring APIs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -120,7 +120,9 @@ Intermediate
    tutorials/mujoco_cube_bowl_macros
    tutorials/collector_trajectory_assembly
    tutorials/evaluator
+   tutorials/rlrender
    tutorials/rb_tutorial
+   tutorials/checkpointing
    tutorials/memory_efficient_rl
    tutorials/export
    tutorials/vla
@@ -135,6 +137,7 @@ Advanced
    tutorials/multi_task
    tutorials/coding_ddpg
    tutorials/coding_dqn
+   tutorials/trl_interop
 
 References
 ==========

--- a/tutorials/sphinx-tutorials/coding_ddpg.py
+++ b/tutorials/sphinx-tutorials/coding_ddpg.py
@@ -866,6 +866,7 @@ collector = Collector(
     split_trajs=False,
     device=collector_device,
     exploration_type=ExplorationType.RANDOM,
+    auto_register_policy_transforms=True,
 )
 
 ###############################################################################

--- a/tutorials/sphinx-tutorials/coding_dqn.py
+++ b/tutorials/sphinx-tutorials/coding_dqn.py
@@ -304,6 +304,14 @@ def get_norm_stats():
 # values, pick up the one with the maximum value and write all those results
 # in the input :class:`tensordict.TensorDict`.
 #
+# The network's final dimension contains one value per discrete choice, while
+# the action spec describes the action written to the TensorDict. A categorical
+# spec therefore represents a scalar action, whereas a one-hot spec includes
+# the choice dimension in its shape. :class:`~torchrl.modules.QValueActor`
+# validates that contract through ``strict_shape=True``. Use
+# ``strict_shape="auto"`` when a compatible output should be reshaped, or
+# ``strict_shape=False`` only when another component owns the shape contract.
+#
 
 
 def make_model(dummy_env):
@@ -453,6 +461,7 @@ def get_collector(
         device=device,
         storing_device=device,
         split_trajs=False,
+        auto_register_policy_transforms=True,
         postproc=MultiStep(gamma=gamma, n_steps=5),
         **backend_kwargs,
     )

--- a/tutorials/sphinx-tutorials/coding_ppo.py
+++ b/tutorials/sphinx-tutorials/coding_ppo.py
@@ -527,6 +527,7 @@ collector = Collector(
     total_frames=total_frames,
     split_trajs=False,
     device=device,
+    auto_register_policy_transforms=True,
 )
 
 ######################################################################

--- a/tutorials/sphinx-tutorials/export.py
+++ b/tutorials/sphinx-tutorials/export.py
@@ -108,6 +108,7 @@ collector = Collector(
     frames_per_batch=frames_per_batch,
     total_frames=-1,
     init_random_frames=init_rand_steps,
+    auto_register_policy_transforms=True,
 )
 rb = ReplayBuffer(storage=LazyTensorStorage(100_000))
 

--- a/tutorials/sphinx-tutorials/export.py
+++ b/tutorials/sphinx-tutorials/export.py
@@ -108,7 +108,7 @@ collector = Collector(
     frames_per_batch=frames_per_batch,
     total_frames=-1,
     init_random_frames=init_rand_steps,
-    auto_register_policy_transforms=True,
+    auto_register_policy_transforms=False,
 )
 rb = ReplayBuffer(storage=LazyTensorStorage(100_000))
 

--- a/tutorials/sphinx-tutorials/getting-started-5.py
+++ b/tutorials/sphinx-tutorials/getting-started-5.py
@@ -79,6 +79,9 @@ policy_explore = Seq(policy, exploration_module)
 # Here comes the data part: we need a
 # :ref:`data collector <gs_storage_collector>` to easily get batches of data
 # and a :ref:`replay buffer <gs_storage_rb>` to store that data for training.
+# ``auto_register_policy_transforms=True`` asks the collector to attach any
+# environment transforms required by the policy, such as episode-start markers
+# and recurrent-state primers. The registration is spec-based and idempotent.
 #
 
 from torchrl.collectors import Collector
@@ -93,6 +96,7 @@ collector = Collector(
     frames_per_batch=frames_per_batch,
     total_frames=-1,
     init_random_frames=init_rand_steps,
+    auto_register_policy_transforms=True,
 )
 rb = ReplayBuffer(storage=LazyTensorStorage(100_000))
 

--- a/tutorials/sphinx-tutorials/memory_efficient_rl.py
+++ b/tutorials/sphinx-tutorials/memory_efficient_rl.py
@@ -607,6 +607,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
 #         policy_device="cuda",       # (fast collection)
 #         storing_device="cpu",       # but spill the batch to host RAM
 #         no_cuda_sync=False,         # keep explicit syncs unless transfers
+#         auto_register_policy_transforms=True,
 #     )                               # are already correctly ordered
 #
 # The rule of thumb: keep ``env_device`` / ``policy_device`` on the
@@ -714,6 +715,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
 #         frames_per_batch=1024,
 #         total_frames=1_000_000,
 #         compact_obs=True,                       # halve obs memory
+#         auto_register_policy_transforms=True,
 #     )
 #     rb = ReplayBuffer(
 #         storage=LazyMemmapStorage(1_000_000),   # spill to disk
@@ -746,6 +748,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
 #         policy=policy,
 #         frames_per_batch=1024,
 #         total_frames=1_000_000,
+#         auto_register_policy_transforms=True,
 #     )
 #     rb = ReplayBuffer(
 #         storage=LazyMemmapStorage(1_000_000),

--- a/tutorials/sphinx-tutorials/multiagent_competitive_ddpg.py
+++ b/tutorials/sphinx-tutorials/multiagent_competitive_ddpg.py
@@ -647,6 +647,7 @@ collector = Collector(
     device=device,
     frames_per_batch=frames_per_batch,
     total_frames=total_frames,
+    auto_register_policy_transforms=True,
 )
 
 ######################################################################

--- a/tutorials/sphinx-tutorials/multiagent_ppo.py
+++ b/tutorials/sphinx-tutorials/multiagent_ppo.py
@@ -550,6 +550,7 @@ collector = Collector(
     storing_device=device,
     frames_per_batch=frames_per_batch,
     total_frames=total_frames,
+    auto_register_policy_transforms=True,
 )
 
 ######################################################################

--- a/tutorials/sphinx-tutorials/rb_tutorial.py
+++ b/tutorials/sphinx-tutorials/rb_tutorial.py
@@ -42,7 +42,10 @@ Using Replay Buffers
 # - How to use :ref:`prioritized replay buffers <tuto_rb_prb>`;
 # - How to :ref:`transform data <tuto_rb_transform>` coming in and out from
 #   the buffer;
-# - How to store :ref:`trajectories <tuto_rb_traj>` in the buffer.
+# - How to store :ref:`trajectories <tuto_rb_traj>` in the buffer;
+# - How to sample structured sequences and query complete trajectories;
+# - Which replay-buffer tools support offline-to-online and asynchronous
+#   training workflows.
 #
 #
 # Basics: building a vanilla replay buffer
@@ -107,7 +110,7 @@ print("length after adding elements:", len(buffer))
 #   of efficiency;
 # - The :class:`~torchrl.data.replay_buffers.LazyTensorStorage` stores tensors data
 #   structures contiguously.
-#   It works naturally with :class:`~tensordidct.TensorDict`
+#   It works naturally with :class:`~tensordict.TensorDict`
 #   (or :class:`~torchrl.data.tensorclass`)
 #   objects. The storage is contiguous on a per-tensor basis, meaning that
 #   sampling will be more efficient than when using a list, but the
@@ -796,15 +799,12 @@ assert (data.exclude("collector") == s.squeeze(0).exclude("index", "collector"))
 # In many cases, it is desirable to access trajectories from the buffer rather
 # than simple transitions. TorchRL offers multiple ways of achieving this.
 #
-# The preferred way is currently to store trajectories along the first
-# dimension of the buffer and use a :class:`~torchrl.data.replay_buffers.SliceSampler` to
-# sample these batches of data. This class only needs a couple of information
-# about your data structure to do its job (not that as of now it is only
-# compatible with tensordict-structured data): the number of slices or their
-# length and some information about where the separation between the
-# episodes can be found (e.g. :ref:`recall that <gs_storage_collector>` with a
-# :ref:`DataCollector <ref_collectors>`, the trajectory id is stored in
-# ``("collector", "traj_ids")``). In this simple example, we construct a data
+# A common approach is to store trajectories along the first dimension of the
+# buffer and use a :class:`~torchrl.data.replay_buffers.SliceSampler` to sample
+# them. The sampler reads the desired number or length of slices and the
+# markers that identify episode boundaries. For example, a
+# :ref:`DataCollector <ref_collectors>` stores trajectory identifiers under
+# ``("collector", "traj_ids")``. In this example, we construct data
 # with 4 consecutive short trajectories and sample 4 slices out of it, each of
 # length 2 (since the batch size is 8, and 8 items // 4 slices = 2 time steps).
 # We mark the steps as well.
@@ -840,6 +840,82 @@ print("steps are successive", sample["steps"])
 gc.collect()
 
 ######################################################################
+# Sequence sampling and trajectory queries
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# A sampler chooses anchor records. A
+# :class:`~torchrl.data.replay_buffers.SampleUnit` controls what each anchor
+# expands into. :class:`~torchrl.data.replay_buffers.Sequence` can include a
+# burn-in prefix for recurrent state, a learning region, and bootstrap context
+# for a target estimator. It also returns masks that distinguish real records
+# from padding and identify the learning region.
+#
+# Trajectory queries operate on the same boundary markers. The
+# :data:`~torchrl.data.traj` expression below selects complete trajectories by
+# length and accumulated reward without coupling the query to the storage
+# layout.
+
+from torchrl.data import Sequence, traj
+
+trajectory_ids = torch.tensor([0, 0, 0, 1, 1, 1, 1, 1])
+done = torch.zeros(8, 1, dtype=torch.bool)
+done[2] = done[7] = True
+trajectory_data = TensorDict(
+    {
+        "observation": torch.arange(8, dtype=torch.float32).unsqueeze(-1),
+        ("collector", "traj_ids"): trajectory_ids,
+        ("next", "reward"): torch.tensor(
+            [1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0]
+        ).unsqueeze(-1),
+        ("next", "done"): done,
+    },
+    batch_size=[8],
+)
+
+sequence_rb = TensorDictReplayBuffer(
+    storage=LazyTensorStorage(8),
+    batch_size=2,
+    sample_unit=Sequence(
+        length=2,
+        burn_in=1,
+        bootstrap=1,
+        episode_boundary="pad",
+    ),
+)
+sequence_rb.extend(trajectory_data)
+sequence_sample, sequence_info = sequence_rb.sample(return_info=True)
+
+# Two anchors expand to four records each: one burn-in record, two learning
+# records, and one bootstrap record. A loss should only use entries selected
+# by both masks.
+assert sequence_sample.batch_size == torch.Size([8])
+loss_mask = sequence_info["learning_mask"] & sequence_info["validity_mask"]
+assert loss_mask.shape == torch.Size([8])
+
+selected = sequence_rb.query((traj.length >= 5) & (traj.reward.sum() > 5))
+assert len(selected) == 1
+assert selected[0].length == 5
+
+######################################################################
+# Offline-to-online and asynchronous workflows
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# :class:`~torchrl.data.OfflineToOnlineReplayBuffer` presents offline and
+# online data through one sampling interface, while
+# :func:`~torchrl.data.prefill_replay_buffer` copies an initial dataset into a
+# destination buffer. :class:`~torchrl.trainers.algorithms.OfflineToOnlineTrainer`
+# coordinates collection, sampling, optimization, and the transition between
+# the two data sources.
+#
+# Long-running or asynchronous systems can inspect
+# :meth:`~torchrl.data.ReplayBuffer.stats`, retire records with
+# ``consume_after_n_samples``, and enable generation tracking on a
+# :class:`~torchrl.data.RoundRobinWriter` before applying delayed updates with
+# :meth:`~torchrl.data.ReplayBuffer.update_if_present`. These controls keep
+# monitoring, data lifetime, and stale-write protection independent from the
+# storage and sampling strategy.
+
+######################################################################
 # Storing trajectories from a collector
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
@@ -867,7 +943,13 @@ gc.collect()
 #         ),
 #         batch_size=256,
 #     )
-#     collector = Collector(env, policy, frames_per_batch=200, total_frames=-1)
+#     collector = Collector(
+#         env,
+#         policy,
+#         frames_per_batch=200,
+#         total_frames=-1,
+#         auto_register_policy_transforms=True,
+#     )
 #     for data in collector:
 #         rb.extend(data)
 #         batch = rb.sample()  # contiguous sub-sequences
@@ -911,7 +993,9 @@ gc.collect()
 #
 # - Create a Replay Buffer, customize its storage, sampler and transforms;
 # - Choose the best storage type for your problem (list, memory or disk-based);
-# - Minimize the memory footprint of your buffer.
+# - Minimize the memory footprint of your buffer;
+# - Sample learning sequences and filter complete trajectories;
+# - Choose lifecycle controls for offline-to-online or asynchronous training.
 #
 # Next steps
 # ----------
@@ -923,4 +1007,7 @@ gc.collect()
 #   :class:`~torchrl.data.replay_buffers.PrioritizedSliceSampler` and
 #   :class:`~torchrl.data.replay_buffers.SliceSamplerWithoutReplacement`, or other writers
 #   such as :class:`~torchrl.data.replay_buffers.TensorDictMaxValueWriter`.
+# - See :ref:`the replay-buffer reference <ref_buffers>` for sequence sampling,
+#   trajectory queries, consuming samples, statistics, and generation-aware
+#   updates.
 # - Check how to checkpoint ReplayBuffers in :ref:`the doc <checkpoint-rb>`.

--- a/tutorials/sphinx-tutorials/torchrl_demo.py
+++ b/tutorials/sphinx-tutorials/torchrl_demo.py
@@ -323,6 +323,7 @@ collector = Collector(
     policy=actor,
     frames_per_batch=200,  # Collect 200 frames per iteration
     total_frames=1000,  # Stop after 1000 total frames
+    auto_register_policy_transforms=True,
 )
 
 for batch in collector:
@@ -453,6 +454,7 @@ collector = Collector(
     policy=policy,
     frames_per_batch=100,
     total_frames=2000,
+    auto_register_policy_transforms=True,
 )
 
 # 4. Create a replay buffer

--- a/tutorials/sphinx-tutorials/trl_interop.py
+++ b/tutorials/sphinx-tutorials/trl_interop.py
@@ -7,8 +7,7 @@ TRL Interoperability: Using TorchRL Buffers and HF Reward Models Together
 **Author**: TorchRL contributors
 
 This tutorial demonstrates how to bridge TorchRL and Hugging Face ``trl``
-using the two adapter classes introduced in Workstream 2 of the post-training
-RFC (:ref:`trl_interop_section`):
+using the adapter classes documented in :ref:`trl_interop_section`:
 
 * :class:`~torchrl.modules.llm.TorchRLBufferDataset`: expose replay samples as
   PyTorch or Hugging Face iterable datasets.


### PR DESCRIPTION
## Summary

- expose checkpointing, rendering, and TRL interoperability tutorials in the main gallery
- cover sequence sampling, trajectory queries, and replay lifecycle workflows
- document discrete-action shape contracts and opt collectors into policy transform registration
- keep the prose focused on stable concepts without release-era language

## Validation

- changed-file pre-commit hooks
- compile all tutorial sources
- execute checkpointing.py, rlrender.py, and trl_interop.py
- smoke-test sequence sampling, trajectory querying, and collector transform registration

The complete replay tutorial reaches its pre-existing prioritized sampler section locally, where the optional compiled segment-tree extension is unavailable; the edited replay section executes independently.