### PR TITLE
[Performance] Benchmark AsyncEnvPool dispatch and throughput

### DIFF
--- a/benchmarks/test_envs_benchmark.py
+++ b/benchmarks/test_envs_benchmark.py
@@ -3,15 +3,25 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import argparse
+import time
+from functools import partial
 
 import pytest
 import torch
 
-from tensordict import TensorDict
-from torchrl.envs import ParallelEnv, SerialEnv, step_mdp, StepCounter, TransformedEnv
+from tensordict import set_capture_non_tensor_stack, TensorDict
+from torchrl.envs import (
+    AsyncEnvPool,
+    ParallelEnv,
+    SerialEnv,
+    step_mdp,
+    StepCounter,
+    TransformedEnv,
+)
 from torchrl.envs.libs.dm_control import DMControlEnv
 from torchrl.envs.libs.libero import _has_libero, LiberoEnv
 from torchrl.envs.transforms.functional import cat_frames
+from torchrl.testing.mocking_classes import CountingEnv
 
 
 def make_simple_env():
@@ -164,6 +174,152 @@ def test_cat_frames_functional(benchmark, padding, N):
         padding=padding,
         time_dim=-2,
     )
+
+
+# AsyncEnvPool throughput benchmarks (north-star series for #4061).
+#
+# These series track the async data plane on the continuous benchmark
+# dashboard and are expected to fall as the exchange internals are optimized.
+# Series names are load-bearing for trend continuity - do not rename them, and
+# do not change the workload constants below; add new series instead.
+#
+# - test_async_env_pool_dispatch: free envs, so the round time is
+#   ASYNC_POOL_DISPATCH_TRANSITIONS x the consumer-side dispatch cost
+#   (recv -> action write -> send) per transition. The most sensitive tracker.
+# - test_async_env_pool_fast_step_slow_reset: many envs with millisecond steps
+#   and long occasional resets (the game-engine regime). Sized so that the
+#   consumer is the bottleneck today: the round time falls toward the
+#   env-supply ceiling as dispatch gets cheaper.
+
+ASYNC_POOL_DISPATCH_ENVS = 8
+ASYNC_POOL_DISPATCH_TRANSITIONS = 1024
+ASYNC_POOL_REGIME_ENVS = 32
+ASYNC_POOL_REGIME_TRANSITIONS = 2048
+ASYNC_POOL_REGIME_STEP_LATENCY = 1e-3
+ASYNC_POOL_REGIME_RESET_LATENCY = 0.2
+ASYNC_POOL_REGIME_EPISODE_STEPS = 200
+
+
+class DelayedCountingEnv(CountingEnv):
+    """A CountingEnv with configurable synchronous step and reset latencies."""
+
+    def __init__(
+        self, *, step_latency: float = 0.0, reset_latency: float = 0.0, **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.step_latency = step_latency
+        self.reset_latency = reset_latency
+
+    def _step(self, tensordict):
+        if self.step_latency:
+            time.sleep(self.step_latency)
+        return super()._step(tensordict)
+
+    def _reset(self, tensordict, **kwargs):
+        if self.reset_latency:
+            time.sleep(self.reset_latency)
+        return super()._reset(tensordict, **kwargs)
+
+
+def _make_async_pool(num_envs, exchange, step_latency, reset_latency, max_steps):
+    pool = AsyncEnvPool(
+        [
+            partial(
+                DelayedCountingEnv,
+                max_steps=max_steps,
+                step_latency=step_latency,
+                reset_latency=reset_latency,
+            )
+        ]
+        * num_envs,
+        backend="multiprocessing",
+        exchange=exchange,
+    )
+    # Prime the steady state: after this, every round starts with a recv.
+    tensordict = pool.reset()
+    tensordict["action"] = torch.ones(num_envs, 1)
+    pool.async_step_and_maybe_reset_send(tensordict)
+    return pool
+
+
+def _async_pool_harvest(pool, num_transitions, max_get):
+    harvested = 0
+    while harvested < num_transitions:
+        _, td_next = pool.async_step_and_maybe_reset_recv(
+            min_get=1, max_get=max_get, timeout=1e-3
+        )
+        num_ready = td_next.shape[0]
+        td_next["action"] = torch.ones(num_ready, 1)
+        pool.async_step_and_maybe_reset_send(td_next)
+        harvested += num_ready
+
+
+@pytest.mark.parametrize("exchange", ["queue", "shm"])
+def test_async_env_pool_dispatch(benchmark, exchange):
+    """Consumer dispatch cost of AsyncEnvPool with free envs."""
+    with set_capture_non_tensor_stack(False):
+        pool = _make_async_pool(
+            ASYNC_POOL_DISPATCH_ENVS,
+            exchange,
+            step_latency=0.0,
+            reset_latency=0.0,
+            max_steps=10_000_000,
+        )
+        try:
+            benchmark.extra_info["num_envs"] = ASYNC_POOL_DISPATCH_ENVS
+            benchmark.extra_info["transitions"] = ASYNC_POOL_DISPATCH_TRANSITIONS
+            benchmark.pedantic(
+                _async_pool_harvest,
+                args=(
+                    pool,
+                    ASYNC_POOL_DISPATCH_TRANSITIONS,
+                    ASYNC_POOL_DISPATCH_ENVS,
+                ),
+                rounds=5,
+                warmup_rounds=1,
+                iterations=1,
+            )
+        finally:
+            pool._maybe_shutdown()
+
+
+# Note: the queue exchange is deliberately not parametrized here. At 32
+# workers the queue path hangs during setup/reset with the spawn start method
+# (macOS-confirmed; tracked for a fix in the AsyncEnvPool v2 sequence). The
+# queue baseline is covered by test_async_env_pool_dispatch at 8 workers.
+@pytest.mark.parametrize("exchange", ["shm"])
+def test_async_env_pool_fast_step_slow_reset(benchmark, exchange):
+    """AsyncEnvPool throughput with millisecond steps and long resets.
+
+    32 envs with 1 ms steps and a 200 ms reset every 200 steps supply roughly
+    16k transitions/s; resets are absorbed worker-side by
+    ``step_and_maybe_reset``. The round time is dispatch-bound until the
+    consumer path gets cheaper than the env supply.
+    """
+    with set_capture_non_tensor_stack(False):
+        pool = _make_async_pool(
+            ASYNC_POOL_REGIME_ENVS,
+            exchange,
+            step_latency=ASYNC_POOL_REGIME_STEP_LATENCY,
+            reset_latency=ASYNC_POOL_REGIME_RESET_LATENCY,
+            max_steps=ASYNC_POOL_REGIME_EPISODE_STEPS,
+        )
+        try:
+            benchmark.extra_info["num_envs"] = ASYNC_POOL_REGIME_ENVS
+            benchmark.extra_info["transitions"] = ASYNC_POOL_REGIME_TRANSITIONS
+            benchmark.pedantic(
+                _async_pool_harvest,
+                args=(
+                    pool,
+                    ASYNC_POOL_REGIME_TRANSITIONS,
+                    ASYNC_POOL_REGIME_ENVS,
+                ),
+                rounds=5,
+                warmup_rounds=1,
+                iterations=1,
+            )
+        finally:
+            pool._maybe_shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Adds AsyncEnvPool benchmark series to `benchmarks/test_envs_benchmark.py` so the async data plane is tracked on the continuous benchmark dashboard:

- `test_async_env_pool_dispatch[queue|shm]`: 8 zero-latency envs, harvesting 1024 transitions per round. The round time is 1024 x the consumer-side dispatch cost (`recv` -> action write -> `send`), making this the most sensitive tracker of exchange overhead.
- `test_async_env_pool_fast_step_slow_reset[shm]`: 32 envs with 1 ms steps and a 200 ms reset every 200 steps (the game-engine regime: fast steps, long resets, resets absorbed worker-side by `step_and_maybe_reset`). Sized so that the consumer path is a real bottleneck today; the round time falls toward the env-supply ceiling (~16k transitions/s) as dispatch gets cheaper.

Both series drive the pool through `async_step_and_maybe_reset_send/recv` with `min_get=1, max_get=num_envs, timeout=1e-3` -- the harvest loop of the SEED-style regime described in #4061. Series names and workload constants are documented in-file as load-bearing for trend continuity: subsequent optimization PRs must move the line, not the goalposts (new modes get new series).

Reference numbers from a local run (M-series macOS, spawn start method; CI runners use fork):

| series | mean/round | derived |
| --- | --- | --- |
| dispatch[queue] | 262 ms | ~256 us/transition consumer cost |
| dispatch[shm] | 99 ms | ~97 us/transition consumer cost |
| fast_step_slow_reset[shm] | 380 ms | ~5.4k transitions/s |

For context, a bare shared-tensor slot exchange (readiness flags + per-worker semaphores + one vectorized gather/scatter) floors at ~6 us/transition on the same machine; that gap is the headroom these series exist to track.

### Bug found while validating

`exchange="queue"` hangs at 32 workers under the spawn start method (macOS-confirmed): all workers come up, then the consumer blocks forever in `async_reset_recv`/`_setup` while workers exit silently. `exchange="shm"` at 32 workers and `exchange="queue"` at 8 workers are fine. Repro:

```python
from functools import partial
from torchrl.envs import AsyncEnvPool
from torchrl.testing.mocking_classes import CountingEnv

pool = AsyncEnvPool(
    [partial(CountingEnv, max_steps=200)] * 32,
    backend="multiprocessing",
    exchange="queue",
)
pool.reset()  # hangs on macOS (spawn)
```

The regime benchmark is therefore shm-only for now (the queue baseline remains covered by the 8-worker dispatch series); the hang is tracked for a fix in the v2 sequence, which replaces the queue hot path anyway. Since spawn is mandatory for CUDA users, this likely affects Linux users too and deserves its own investigation.

## Motivation and Context

First PR of the AsyncEnvPool v2 sequence (#4061). Every planned optimization -- descriptor-free readiness signaling, vectorized gather/scatter in `recv`/`send`, worker-owned autoreset, fixed-shape inference integration (#4110) -- should register as a drop in these series. Merging the benchmark first also makes the `benchmarks/upload` PR comparison usable for those PRs, since the PR benchmark workflow pins benchmark definitions from the base SHA: a benchmark added in the same PR as an optimization cannot be compared against its baseline.

- [x] I have raised an issue to propose this change (#4061)

## Types of changes

- [x] New feature (non-breaking change which adds core functionality)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
