### PR TITLE
[Feature] Add DreamerV3MLPConfig

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -347,6 +347,7 @@ Model and Network Configurations
     ModelConfig
     NetworkConfig
     MLPConfig
+    DreamerV3MLPConfig
     ConvNetConfig
     TensorDictModuleConfig
     TanhNormalModelConfig

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -51,7 +51,7 @@ from torchrl.data.replay_buffers.writers import (
 )
 from torchrl.envs import AsyncEnvPool, ParallelEnv, SerialEnv
 from torchrl.envs.libs.vmas import VmasEnv
-from torchrl.modules import ConvNet, MLP, TanhModule, ValueOperator
+from torchrl.modules import ConvNet, DreamerV3MLP, MLP, TanhModule, ValueOperator
 from torchrl.modules.tensordict_module.exploration import AdditiveGaussianModule
 from torchrl.objectives.ppo import ClipPPOLoss, KLPENPPOLoss, PPOLoss
 from torchrl.record.loggers import (
@@ -1146,6 +1146,35 @@ class TestModuleConfigs:
         mlp(torch.randn(10, 10))
         # Note: instantiate() has issues with string class names for MLP
         # This is a known limitation - the MLP constructor expects actual classes
+
+    @pytest.mark.skipif(not _has_hydra, reason="Hydra is not installed")
+    def test_dreamer_v3_mlp_config(self):
+        """Test DreamerV3MLPConfig."""
+        from hydra.utils import instantiate
+        from torchrl.trainers.algorithms.configs.modules import DreamerV3MLPConfig
+
+        cfg = DreamerV3MLPConfig(
+            in_features=6,
+            out_features=4,
+            depth=2,
+            num_cells=8,
+            outscale=0.25,
+            norm_eps=1e-5,
+            device="cpu",
+        )
+        assert cfg._target_ == "torchrl.modules.DreamerV3MLP"
+        assert cfg.in_features == 6
+        assert cfg.out_features == 4
+        assert cfg.depth == 2
+        assert cfg.num_cells == 8
+        assert cfg.outscale == 0.25
+        assert cfg.norm_eps == 1e-5
+        assert cfg.device == "cpu"
+
+        module = instantiate(cfg)
+        assert isinstance(module, DreamerV3MLP)
+        output = module(torch.randn(3, 2), torch.randn(3, 4))
+        assert output.shape == (3, 4)
 
     @pytest.mark.skipif(not _has_hydra, reason="Hydra is not installed")
     def test_convnet_config(self):

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -68,13 +68,14 @@ try:
     from torchrl.trainers.algorithms import configs as algorithm_configs
     from torchrl.trainers.algorithms.configs.modules import (
         ActivationConfig,
+        DreamerV3MLPConfig,
         LayerConfig,
     )
 
     _configs_available = True
 except ImportError:
     _configs_available = False
-    ActivationConfig = LayerConfig = None
+    ActivationConfig = DreamerV3MLPConfig = LayerConfig = None
 
 
 _has_gym = (importlib.util.find_spec("gym") is not None) or (
@@ -1148,33 +1149,24 @@ class TestModuleConfigs:
         # This is a known limitation - the MLP constructor expects actual classes
 
     @pytest.mark.skipif(not _has_hydra, reason="Hydra is not installed")
-    def test_dreamer_v3_mlp_config(self):
+    @pytest.mark.parametrize(("out_features", "expected_features"), [(4, 4), (None, 8)])
+    def test_dreamer_v3_mlp_config(self, out_features, expected_features):
         """Test DreamerV3MLPConfig."""
         from hydra.utils import instantiate
-        from torchrl.trainers.algorithms.configs.modules import DreamerV3MLPConfig
 
         cfg = DreamerV3MLPConfig(
             in_features=6,
-            out_features=4,
+            out_features=out_features,
             depth=2,
             num_cells=8,
             outscale=0.25,
             norm_eps=1e-5,
             device="cpu",
         )
-        assert cfg._target_ == "torchrl.modules.DreamerV3MLP"
-        assert cfg.in_features == 6
-        assert cfg.out_features == 4
-        assert cfg.depth == 2
-        assert cfg.num_cells == 8
-        assert cfg.outscale == 0.25
-        assert cfg.norm_eps == 1e-5
-        assert cfg.device == "cpu"
-
         module = instantiate(cfg)
         assert isinstance(module, DreamerV3MLP)
         output = module(torch.randn(3, 2), torch.randn(3, 4))
-        assert output.shape == (3, 4)
+        assert output.shape == (3, expected_features)
 
     @pytest.mark.skipif(not _has_hydra, reason="Hydra is not installed")
     def test_convnet_config(self):

--- a/torchrl/modules/models/model_based.py
+++ b/torchrl/modules/models/model_based.py
@@ -1141,6 +1141,8 @@ class DreamerV3MLP(nn.Module):
         >>> module = DreamerV3MLP(6, 4, depth=2, num_cells=8)
         >>> module(torch.randn(3, 2), torch.randn(3, 4)).shape
         torch.Size([3, 4])
+
+    .. seealso:: :class:`~torchrl.trainers.algorithms.configs.modules.DreamerV3MLPConfig`
     """
 
     def __init__(

--- a/torchrl/trainers/algorithms/configs/__init__.py
+++ b/torchrl/trainers/algorithms/configs/__init__.py
@@ -98,6 +98,7 @@ from torchrl.trainers.algorithms.configs.logging import (
 from torchrl.trainers.algorithms.configs.modules import (
     AdditiveGaussianModuleConfig,
     ConvNetConfig,
+    DreamerV3MLPConfig,
     MLPConfig,
     ModelConfig,
     QMixerNetworkConfig,
@@ -299,6 +300,7 @@ __all__ = [
     "VmasEnvConfig",
     # Networks and Models
     "ConvNetConfig",
+    "DreamerV3MLPConfig",
     "MLPConfig",
     "ModelConfig",
     "TanhModuleConfig",
@@ -512,6 +514,7 @@ def _register_configs():
 
     # Network configs
     cs.store(group="network", name="mlp", node=MLPConfig)
+    cs.store(group="network", name="dreamer_v3_mlp", node=DreamerV3MLPConfig)
     cs.store(group="network", name="convnet", node=ConvNetConfig)
     cs.store(group="network", name="qmixer", node=QMixerNetworkConfig)
     cs.store(group="network", name="vdn_mixer", node=VDNMixerNetworkConfig)

--- a/torchrl/trainers/algorithms/configs/modules.py
+++ b/torchrl/trainers/algorithms/configs/modules.py
@@ -117,6 +117,9 @@ class DreamerV3MLPConfig(NetworkConfig):
     """A class to configure a DreamerV3 multilayer perceptron.
 
     Example:
+        >>> import torch
+        >>> from hydra.utils import instantiate
+        >>> from torchrl.trainers.algorithms.configs import DreamerV3MLPConfig
         >>> cfg = DreamerV3MLPConfig(
         ...     in_features=6, out_features=4, depth=2, num_cells=8
         ... )
@@ -124,21 +127,17 @@ class DreamerV3MLPConfig(NetworkConfig):
         >>> y = net(torch.randn(3, 2), torch.randn(3, 4))
         >>> assert y.shape == (3, 4)
 
-    .. seealso:: :class:`torchrl.modules.DreamerV3MLP`
+    .. seealso:: :class:`~torchrl.modules.DreamerV3MLP`
     """
 
     in_features: int = MISSING
-    out_features: int = MISSING
+    out_features: int | None = MISSING
     depth: int = 3
     num_cells: int = 1024
     outscale: float = 1.0
     norm_eps: float = 1e-4
     device: Any = None
     _target_: str = "torchrl.modules.DreamerV3MLP"
-
-    def __post_init__(self) -> None:
-        """Post-initialization hook for DreamerV3 MLP configurations."""
-        super().__post_init__()
 
 
 @dataclass

--- a/torchrl/trainers/algorithms/configs/modules.py
+++ b/torchrl/trainers/algorithms/configs/modules.py
@@ -113,6 +113,35 @@ class MLPConfig(NetworkConfig):
 
 
 @dataclass
+class DreamerV3MLPConfig(NetworkConfig):
+    """A class to configure a DreamerV3 multilayer perceptron.
+
+    Example:
+        >>> cfg = DreamerV3MLPConfig(
+        ...     in_features=6, out_features=4, depth=2, num_cells=8
+        ... )
+        >>> net = instantiate(cfg)
+        >>> y = net(torch.randn(3, 2), torch.randn(3, 4))
+        >>> assert y.shape == (3, 4)
+
+    .. seealso:: :class:`torchrl.modules.DreamerV3MLP`
+    """
+
+    in_features: int = MISSING
+    out_features: int = MISSING
+    depth: int = 3
+    num_cells: int = 1024
+    outscale: float = 1.0
+    norm_eps: float = 1e-4
+    device: Any = None
+    _target_: str = "torchrl.modules.DreamerV3MLP"
+
+    def __post_init__(self) -> None:
+        """Post-initialization hook for DreamerV3 MLP configurations."""
+        super().__post_init__()
+
+
+@dataclass
 class NormConfig(ConfigBase):
     """A class to configure a normalization layer.
 


### PR DESCRIPTION
## Description

This PR adds a config dataclass for DreamerV3's specialized MLP class.

## Motivation and Context

In preparation for integration of Dreamer v3 with the trainer infrastructure, this PR adds a dataclass to enable hydra-compatible configuration.

Closes #4186.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] New feature (non-breaking change which adds core functionality)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
