### PR TITLE
[BugFix] Fix Trainer optimizer checkpointing

### DIFF
--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -163,6 +163,7 @@ _mocking_optim = MockingOptim()
 def mocking_trainer(
     file=None,
     optimizer=_mocking_optim,
+    optimization_stepper=None,
     checkpoint=None,
     checkpoint_rotation=None,
     checkpoint_metadata=None,
@@ -180,6 +181,7 @@ def mocking_trainer(
         optim_steps_per_batch=None,
         loss_module=loss_module,
         optimizer=optimizer,
+        optimization_stepper=optimization_stepper,
         logger=logger,
         save_trainer_file=file,
         checkpoint=checkpoint,
@@ -1270,34 +1272,57 @@ class TestSubSampler:
 
 
 class TestTrainerCheckpointComponents:
-    def test_state_dict_roundtrips_optimizer_state(self):
+    def test_torch_checkpoint_roundtrips_optimizer_state(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CKPT_BACKEND", "torch")
+        checkpoint = tmp_path / "trainer.pt"
         model = nn.Linear(2, 1)
         optimizer = torch.optim.Adam(model.parameters(), lr=0.25)
-        trainer = mocking_trainer(optimizer=optimizer)
+        trainer = mocking_trainer(
+            file=checkpoint,
+            optimizer=optimizer,
+            optimization_stepper=DefaultOptimizationStepper(),
+        )
         model.weight.grad = torch.ones_like(model.weight)
         model.bias.grad = torch.ones_like(model.bias)
         optimizer.step()
-        state = trainer.state_dict()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            trainer.save_trainer(force_save=True)
 
         model2 = nn.Linear(2, 1)
         optimizer2 = torch.optim.Adam(model2.parameters(), lr=0.01)
-        trainer2 = mocking_trainer(optimizer=optimizer2)
+        trainer2 = mocking_trainer(
+            optimizer=optimizer2,
+            optimization_stepper=DefaultOptimizationStepper(),
+        )
+        trainer2.load_from_file(checkpoint)
+        torch.testing.assert_close(optimizer2.state_dict(), optimizer.state_dict())
+
+    def test_load_state_dict_accepts_checkpoint_without_optimizer(self):
+        trainer = mocking_trainer(
+            optimizer=torch.optim.Adam(nn.Linear(2, 1).parameters()),
+            optimization_stepper=DefaultOptimizationStepper(),
+        )
+        state = trainer.state_dict()
+        del state["optimizer"]
+
+        optimizer = torch.optim.Adam(nn.Linear(2, 1).parameters(), lr=0.01)
+        expected_state = deepcopy(optimizer.state_dict())
+        trainer2 = mocking_trainer(
+            optimizer=optimizer,
+            optimization_stepper=DefaultOptimizationStepper(),
+        )
         trainer2.load_state_dict(state)
-        state2 = optimizer2.state_dict()
-        state1 = optimizer.state_dict()
-        assert state2["param_groups"] == state1["param_groups"]
-        assert state2["state"].keys() == state1["state"].keys()
-        for key in state1["state"]:
-            for field in state1["state"][key]:
-                torch.testing.assert_close(
-                    state2["state"][key][field], state1["state"][key][field]
-                )
+
+        torch.testing.assert_close(optimizer.state_dict(), expected_state)
 
     def test_optimizer_hook_roundtrips_optimizer_state(self):
         model = nn.Linear(2, 1)
         optimizer = torch.optim.Adam(model.parameters(), lr=0.25)
         trainer = mocking_trainer(optimizer=None)
-        hook = OptimizerHook(optimizer)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            hook = OptimizerHook(optimizer)
         hook.register(trainer)
         model.weight.grad = torch.ones_like(model.weight)
         model.bias.grad = torch.ones_like(model.bias)
@@ -1307,18 +1332,12 @@ class TestTrainerCheckpointComponents:
         model2 = nn.Linear(2, 1)
         optimizer2 = torch.optim.Adam(model2.parameters(), lr=0.01)
         trainer2 = mocking_trainer(optimizer=None)
-        hook2 = OptimizerHook(optimizer2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            hook2 = OptimizerHook(optimizer2)
         hook2.register(trainer2)
         trainer2.load_state_dict(state)
-        state2 = optimizer2.state_dict()
-        state1 = optimizer.state_dict()
-        assert state2["param_groups"] == state1["param_groups"]
-        assert state2["state"].keys() == state1["state"].keys()
-        for key in state1["state"]:
-            for field in state1["state"][key]:
-                torch.testing.assert_close(
-                    state2["state"][key][field], state1["state"][key][field]
-                )
+        torch.testing.assert_close(optimizer2.state_dict(), optimizer.state_dict())
 
     def test_checkpoint_registers_optimizer(self):
         model = nn.Linear(2, 1)

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -1269,6 +1269,66 @@ class TestSubSampler:
         assert (td0 == td1).all()
 
 
+class TestTrainerCheckpointComponents:
+    def test_state_dict_roundtrips_optimizer_state(self):
+        model = nn.Linear(2, 1)
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.25)
+        trainer = mocking_trainer(optimizer=optimizer)
+        model.weight.grad = torch.ones_like(model.weight)
+        model.bias.grad = torch.ones_like(model.bias)
+        optimizer.step()
+        state = trainer.state_dict()
+
+        model2 = nn.Linear(2, 1)
+        optimizer2 = torch.optim.Adam(model2.parameters(), lr=0.01)
+        trainer2 = mocking_trainer(optimizer=optimizer2)
+        trainer2.load_state_dict(state)
+        state2 = optimizer2.state_dict()
+        state1 = optimizer.state_dict()
+        assert state2["param_groups"] == state1["param_groups"]
+        assert state2["state"].keys() == state1["state"].keys()
+        for key in state1["state"]:
+            for field in state1["state"][key]:
+                torch.testing.assert_close(
+                    state2["state"][key][field], state1["state"][key][field]
+                )
+
+    def test_optimizer_hook_roundtrips_optimizer_state(self):
+        model = nn.Linear(2, 1)
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.25)
+        trainer = mocking_trainer(optimizer=None)
+        hook = OptimizerHook(optimizer)
+        hook.register(trainer)
+        model.weight.grad = torch.ones_like(model.weight)
+        model.bias.grad = torch.ones_like(model.bias)
+        optimizer.step()
+        state = trainer.state_dict()
+
+        model2 = nn.Linear(2, 1)
+        optimizer2 = torch.optim.Adam(model2.parameters(), lr=0.01)
+        trainer2 = mocking_trainer(optimizer=None)
+        hook2 = OptimizerHook(optimizer2)
+        hook2.register(trainer2)
+        trainer2.load_state_dict(state)
+        state2 = optimizer2.state_dict()
+        state1 = optimizer.state_dict()
+        assert state2["param_groups"] == state1["param_groups"]
+        assert state2["state"].keys() == state1["state"].keys()
+        for key in state1["state"]:
+            for field in state1["state"][key]:
+                torch.testing.assert_close(
+                    state2["state"][key][field], state1["state"][key][field]
+                )
+
+    def test_checkpoint_registers_optimizer(self):
+        model = nn.Linear(2, 1)
+        trainer = mocking_trainer(
+            optimizer=torch.optim.Adam(model.parameters()),
+            checkpoint=Checkpoint(),
+        )
+        assert "optimizer" in trainer.checkpoint.components
+
+
 @pytest.mark.skipif(not _has_gym, reason="No gym library")
 @pytest.mark.skipif(not _has_tb, reason="No tensorboard library")
 @pytest.mark.skipif(

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -1051,8 +1051,9 @@ class Trainer:
         self.loss_module.load_state_dict(model_state_dict)
         self.collector.load_state_dict(collector_state_dict)
         optimizer = self._checkpoint_optimizer()
-        if optimizer is not None:
-            optimizer.load_state_dict(state_dict["optimizer"])
+        optimizer_state_dict = state_dict.get("optimizer")
+        if optimizer is not None and optimizer_state_dict:
+            optimizer.load_state_dict(optimizer_state_dict)
         for key, item in self._modules.items():
             if key == "optimizer":
                 continue
@@ -1122,7 +1123,9 @@ class Trainer:
             # Non-tensor values (scalars, bools, nested dicts) are wrapped in
             # NonTensorData automatically by _state_dict_to_td, so no pickle
             # dependency is needed.
-            for key in ("loss_module", "collector", "optimizer", *self._modules):
+            for key in dict.fromkeys(
+                ("loss_module", "collector", "optimizer", *self._modules)
+            ):
                 if key not in state:
                     continue
                 sd = state[key]
@@ -1267,7 +1270,9 @@ class Trainer:
         elif _CKPT_BACKEND == "memmap":
             path = pathlib.Path(file)
             state: dict = {}
-            for key in ("loss_module", "collector", "optimizer", *self._modules):
+            for key in dict.fromkeys(
+                ("loss_module", "collector", "optimizer", *self._modules)
+            ):
                 key_path = path / key
                 if key_path.exists():
                     state[key] = _td_to_state_dict(

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -891,6 +891,17 @@ class Trainer:
                 return policy
         return None
 
+    def _checkpoint_optimizer(self) -> Any | None:
+        """Return the optimizer owned by the Trainer or a legacy hook."""
+        optimizer = self.optimizer
+        if self._is_checkpointable(optimizer):
+            return optimizer
+        optimizer_hook = self._modules.get("optimizer")
+        hook_optimizer = getattr(optimizer_hook, "optimizer", optimizer_hook)
+        if self._is_checkpointable(hook_optimizer):
+            return hook_optimizer
+        return None
+
     def _sync_checkpoint_components(
         self, checkpoint: Checkpoint | None = None
     ) -> Checkpoint:
@@ -932,16 +943,7 @@ class Trainer:
         register("policy", self._checkpoint_policy())
         register("loss_module", self.loss_module)
 
-        optimizer = self.optimizer
-        if not self._is_checkpointable(optimizer):
-            optimizer_hook = self._modules.get("optimizer")
-            hook_optimizer = getattr(optimizer_hook, "optimizer", optimizer_hook)
-            optimizer = (
-                hook_optimizer
-                if self._is_checkpointable(hook_optimizer)
-                else optimizer_hook
-            )
-        register("optimizer", optimizer)
+        register("optimizer", self._checkpoint_optimizer())
 
         register("collector", self.collector)
         replay_buffer = getattr(self, "replay_buffer", None)
@@ -1014,22 +1016,32 @@ class Trainer:
 
     @property
     def app_state(self):
+        optimizer = self._checkpoint_optimizer()
         self._app_state = {
             "state": StateDict(**self._get_state()),
             "collector": self.collector,
             "loss_module": self.loss_module,
-            **{k: item for k, item in self._modules.items()},
+            **({"optimizer": optimizer} if optimizer is not None else {}),
+            **{k: item for k, item in self._modules.items() if k != "optimizer"},
         }
         return self._app_state
 
     def state_dict(self) -> dict:
         state = self._get_state()
-        state_dict = OrderedDict(
+        state_dict: OrderedDict[str, Any] = OrderedDict(
             collector=self.collector.state_dict(),
             loss_module=self.loss_module.state_dict(),
             state=state,
-            **{k: item.state_dict() for k, item in self._modules.items()},
         )
+        optimizer = self._checkpoint_optimizer()
+        if optimizer is not None:
+            state_dict["optimizer"] = optimizer.state_dict()
+        for key, item in self._modules.items():
+            # The standard optimizer component is emitted above, while a
+            # legacy OptimizerHook may also be registered under this name.
+            if key == "optimizer":
+                continue
+            state_dict[key] = item.state_dict()
         return state_dict
 
     def load_state_dict(self, state_dict: dict) -> None:
@@ -1038,7 +1050,12 @@ class Trainer:
 
         self.loss_module.load_state_dict(model_state_dict)
         self.collector.load_state_dict(collector_state_dict)
+        optimizer = self._checkpoint_optimizer()
+        if optimizer is not None:
+            optimizer.load_state_dict(state_dict["optimizer"])
         for key, item in self._modules.items():
+            if key == "optimizer":
+                continue
             item.load_state_dict(state_dict[key])
 
         self.collected_frames = state_dict["state"]["collected_frames"]
@@ -1105,7 +1122,9 @@ class Trainer:
             # Non-tensor values (scalars, bools, nested dicts) are wrapped in
             # NonTensorData automatically by _state_dict_to_td, so no pickle
             # dependency is needed.
-            for key in ("loss_module", "collector", *self._modules):
+            for key in ("loss_module", "collector", "optimizer", *self._modules):
+                if key not in state:
+                    continue
                 sd = state[key]
                 if sd:
                     _state_dict_to_td(sd).dumps(str(path / key))
@@ -1248,7 +1267,7 @@ class Trainer:
         elif _CKPT_BACKEND == "memmap":
             path = pathlib.Path(file)
             state: dict = {}
-            for key in ("loss_module", "collector", *self._modules):
+            for key in ("loss_module", "collector", "optimizer", *self._modules):
                 key_path = path / key
                 if key_path.exists():
                     state[key] = _td_to_state_dict(
@@ -2271,10 +2290,13 @@ class OptimizerHook(TrainerHookBase):
         return losses_td
 
     def state_dict(self) -> dict[str, Any]:
-        return {}
+        state_dict = getattr(self.optimizer, "state_dict", None)
+        return state_dict() if callable(state_dict) else {}
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        pass
+        load_state_dict = getattr(self.optimizer, "load_state_dict", None)
+        if state_dict and callable(load_state_dict):
+            load_state_dict(state_dict)
 
     def register(self, trainer, name="optimizer") -> None:
         trainer.register_op("optimizer", self)


### PR DESCRIPTION
## Description

Fix Trainer optimizer checkpointing across the supported Trainer checkpoint paths.

As described in #4188 , there are several cases in which the optimizer is silently not checkpointed. Namely:
- When an optimizer is passed directly to Trainer without a default stepper, the trainer may install an optimizer hook. In this case, the trainer does not checkpoint its optimizer (it checkpoints the hook instead), but the optimizer hook's state dict is empty.
- When using a default optimization stepper, the default stepper does not own the optimizer, and no hook is added to _modules. Therefore, the trainer's optimizer is not checkpointed.
- When an optimizer is provided through an explicitly registered hook, trainer.optimizer is None. But, the optimizer hook's state dict is empty.

This can pose a large problem when reloading the trainer checkpoint to resume training etc.

This PR ensures that in all paths (legacy optimizer hooks and optimization steppers) the optimizer state will be checkpointed.

## Motivation and Context

Closes #4188.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
