### PR TITLE
[Feature] Preserve local MuJoCo model paths

### DIFF
--- a/docs/source/reference/envs_api.rst
+++ b/docs/source/reference/envs_api.rst
@@ -323,7 +323,11 @@ A family of MuJoCo-backed envs sharing one base class
 native-torch engine, ``"mjx"`` -- JAX-vectorized, or ``"mujoco"`` --
 official C-bindings). For envs with a standalone XML asset, the XML can be a
 local path or an ``http(s)`` URL, so users can point at remote models without
-vendoring them. Subclasses describe the *task* by overriding
+vendoring them. Pass ``patch_xml=False`` for directory-based local models that
+use relative ``<include>`` entries, meshes, textures, or other assets; the
+model path is then preserved across all three backends so MuJoCo resolves
+resources relative to its directory. Subclasses describe the *task* by
+overriding
 :meth:`~torchrl.envs.MujocoEnv._compute_reward` and
 :meth:`~torchrl.envs.MujocoEnv._compute_done`.
 

--- a/test/libs/test_mujoco.py
+++ b/test/libs/test_mujoco.py
@@ -1708,21 +1708,33 @@ class TestMujoco:
         )
         env.close()
 
-    def test_xml_path_kwarg_overrides_class_attr(self, tmp_path):
-        """Custom ``xml_path=`` overrides the class-level :attr:`XML_PATH`."""
-        backend = _AVAILABLE_BACKENDS[0]
-        # A trivial single-hinge model -- pure-XML, no external mesh deps.
-        xml = (
-            "<mujoco><worldbody>"
-            "<body name='b' pos='0 0 1'>"
-            "<joint name='j' type='hinge'/>"
-            "<geom size='0.1' mass='1'/>"
+    @pytest.mark.parametrize("backend", _AVAILABLE_BACKENDS)
+    def test_xml_path_preserves_relative_assets(self, tmp_path, backend):
+        assets = tmp_path / "assets"
+        assets.mkdir()
+        (assets / "tetrahedron.obj").write_text(
+            "v 0 0 0\n"
+            "v 0.1 0 0\n"
+            "v 0 0.1 0\n"
+            "v 0 0 0.1\n"
+            "f 1 3 2\n"
+            "f 1 2 4\n"
+            "f 1 4 3\n"
+            "f 2 3 4\n"
+        )
+        (tmp_path / "robot.xml").write_text(
+            "<mujoco><compiler meshdir='assets'/>"
+            "<asset><mesh name='tetrahedron' file='tetrahedron.obj'/></asset>"
+            "<worldbody><body name='body' pos='0 0 1'>"
+            "<joint name='joint' type='hinge'/>"
+            "<geom type='sphere' size='0.1' mass='1'/>"
+            "<geom type='mesh' mesh='tetrahedron' contype='0' conaffinity='0'/>"
             "</body></worldbody>"
-            "<actuator><motor name='a' joint='j' gear='1' ctrlrange='-1 1'/></actuator>"
+            "<actuator><motor joint='joint' ctrlrange='-1 1'/></actuator>"
             "</mujoco>"
         )
-        path = tmp_path / "tiny.xml"
-        path.write_text(xml)
+        path = tmp_path / "scene.xml"
+        path.write_text("<mujoco><include file='robot.xml'/></mujoco>")
 
         class TinyEnv(MujocoEnv):
             FRAME_SKIP = 2
@@ -1735,10 +1747,18 @@ class TestMujoco:
                     self.num_envs, 1, dtype=torch.bool, device=self.device
                 )
 
-        env = TinyEnv(xml_path=str(path), backend=backend, num_envs=1, seed=0)
+        num_envs = 1 if backend == "mujoco" else 2
+        env = TinyEnv(
+            xml_path=path,
+            patch_xml=False,
+            backend=backend,
+            num_envs=num_envs,
+            seed=0,
+        )
         check_env_specs(env)
         td = env.rollout(3)
-        assert td.shape == torch.Size([1, 3])
+        assert td.shape == torch.Size([num_envs, 3])
+        assert torch.isfinite(td.get(("next", "observation"))).all()
 
 
 if __name__ == "__main__":

--- a/torchrl/envs/custom/mujoco/_backends.py
+++ b/torchrl/envs/custom/mujoco/_backends.py
@@ -35,6 +35,15 @@ _has_mjx = _has_mujoco and importlib.util.find_spec("mujoco.mjx") is not None
 
 
 BackendName = Literal["mujoco-torch", "mjx", "mujoco"]
+ModelSource = str | Path
+
+
+def _load_mujoco_model(source: ModelSource):
+    import mujoco
+
+    if isinstance(source, Path):
+        return mujoco.MjModel.from_xml_path(str(source))
+    return mujoco.MjModel.from_xml_string(source)
 
 
 def _get_tensorclass_leaf(obj: Any, key: str | tuple[str, ...]) -> Any:
@@ -121,17 +130,17 @@ class _PhysicsBackend(abc.ABC):
     actuator_ctrllimited: torch.Tensor
 
     def __init__(
-        self, xml_string: str, *, num_envs: int, device: torch.device | None
+        self, source: ModelSource, *, num_envs: int, device: torch.device | None
     ) -> None:
         self.num_envs = num_envs
         self.device = (
             torch.device(device) if device is not None else torch.device("cpu")
         )
-        self._init_model(xml_string)
+        self._init_model(source)
 
     @abc.abstractmethod
-    def _init_model(self, xml_string: str) -> None:
-        """Parse XML and prepare the batched data state.
+    def _init_model(self, source: ModelSource) -> None:
+        """Load the model source and prepare the batched data state.
 
         Populates ``nq, nv, nu, timestep, qpos0, qvel0, actuator_lo,
         actuator_hi`` from the parsed model.
@@ -232,7 +241,7 @@ class _TorchBackend(_PhysicsBackend):
 
     def __init__(
         self,
-        xml_string: str,
+        source: ModelSource,
         *,
         num_envs: int,
         device: torch.device | None,
@@ -246,13 +255,13 @@ class _TorchBackend(_PhysicsBackend):
             )
         self._compile_step = compile_step
         self._compile_kwargs = compile_kwargs or {}
-        super().__init__(xml_string, num_envs=num_envs, device=device)
+        super().__init__(source, num_envs=num_envs, device=device)
 
-    def _init_model(self, xml_string: str) -> None:
+    def _init_model(self, source: ModelSource) -> None:
         import mujoco
         import mujoco_torch
 
-        m_mj = mujoco.MjModel.from_xml_string(xml_string)
+        m_mj = _load_mujoco_model(source)
         d_mj = mujoco.MjData(m_mj)
         mujoco.mj_forward(m_mj, d_mj)
         self._m_mj = m_mj
@@ -468,7 +477,7 @@ class _MujocoBackend(_PhysicsBackend):
 
     def __init__(
         self,
-        xml_string: str,
+        source: ModelSource,
         *,
         num_envs: int,
         device: torch.device | None,
@@ -485,12 +494,12 @@ class _MujocoBackend(_PhysicsBackend):
                 "(MujocoEnv does this automatically when num_workers>1 "
                 "or num_envs>1 is passed)."
             )
-        super().__init__(xml_string, num_envs=num_envs, device=device)
+        super().__init__(source, num_envs=num_envs, device=device)
 
-    def _init_model(self, xml_string: str) -> None:
+    def _init_model(self, source: ModelSource) -> None:
         import mujoco
 
-        m_mj = mujoco.MjModel.from_xml_string(xml_string)
+        m_mj = _load_mujoco_model(source)
         d_mj = mujoco.MjData(m_mj)
         mujoco.mj_forward(m_mj, d_mj)
 
@@ -645,7 +654,7 @@ class _MJXBackend(_PhysicsBackend):
 
     def __init__(
         self,
-        xml_string: str,
+        source: ModelSource,
         *,
         num_envs: int,
         device: torch.device | None,
@@ -655,14 +664,13 @@ class _MJXBackend(_PhysicsBackend):
                 "backend='mjx' requires `mujoco>=3.0` (with mjx) and `jax`. "
                 "Install with `pip install mujoco-mjx jax`."
             )
-        super().__init__(xml_string, num_envs=num_envs, device=device)
+        super().__init__(source, num_envs=num_envs, device=device)
 
-    def _init_model(self, xml_string: str) -> None:
+    def _init_model(self, source: ModelSource) -> None:
         import jax
-        import mujoco
         from mujoco import mjx
 
-        m_mj = mujoco.MjModel.from_xml_string(xml_string)
+        m_mj = _load_mujoco_model(source)
         mx = mjx.put_model(m_mj)
         dx0_single = mjx.make_data(mx)
         dx0_single = mjx.forward(mx, dx0_single)
@@ -860,7 +868,7 @@ class _MJXBackend(_PhysicsBackend):
 
 def make_backend(
     name: BackendName,
-    xml_string: str,
+    source: ModelSource,
     *,
     num_envs: int,
     device: torch.device | None,
@@ -876,16 +884,16 @@ def make_backend(
     """
     if name == "mujoco-torch":
         return _TorchBackend(
-            xml_string,
+            source,
             num_envs=num_envs,
             device=device,
             compile_step=compile_step,
             compile_kwargs=compile_kwargs,
         )
     if name == "mjx":
-        return _MJXBackend(xml_string, num_envs=num_envs, device=device)
+        return _MJXBackend(source, num_envs=num_envs, device=device)
     if name == "mujoco":
-        return _MujocoBackend(xml_string, num_envs=num_envs, device=device)
+        return _MujocoBackend(source, num_envs=num_envs, device=device)
     raise ValueError(
         f"unknown backend {name!r}; expected one of 'mujoco-torch', 'mjx', 'mujoco'"
     )

--- a/torchrl/envs/custom/mujoco/assets/NOTICE
+++ b/torchrl/envs/custom/mujoco/assets/NOTICE
@@ -24,4 +24,6 @@ To avoid vendoring assets you'd rather not redistribute, most
 :class:`~torchrl.envs.custom.mujoco.MujocoEnv` subclasses accept an
 ``xml_path=`` constructor kwarg that may be a local path *or* an
 ``http(s)://`` URL. Override :attr:`MujocoEnv.XML_PATH` /
-:attr:`MujocoEnv.XML_URL` on a custom subclass to point elsewhere.
+:attr:`MujocoEnv.XML_URL` on a custom subclass to point elsewhere. For local
+models with relative includes or assets, pass ``patch_xml=False`` so the model
+directory remains available to MuJoCo's resource loader.

--- a/torchrl/envs/custom/mujoco/base.py
+++ b/torchrl/envs/custom/mujoco/base.py
@@ -187,6 +187,11 @@ class MujocoEnv(EnvBase, abc.ABC, metaclass=_MujocoMeta):
 
     Args:
         xml_path: optional override for the XML asset (path or URL).
+        patch_xml: if ``True`` (default), load the XML as text and apply
+            :meth:`_patch_xml`. If ``False``, pass a local ``xml_path`` to
+            MuJoCo unchanged so relative includes, meshes, textures, and other
+            assets resolve from the model directory. Remote URLs are still
+            loaded as text and therefore must be self-contained.
         backend: ``"mujoco-torch"`` (default), ``"mjx"``, or ``"mujoco"``.
         num_envs: batch size; the env's ``batch_size`` is ``(num_envs,)``.
         device: torch device for observations / rewards / actions.
@@ -255,6 +260,7 @@ class MujocoEnv(EnvBase, abc.ABC, metaclass=_MujocoMeta):
         self,
         *,
         xml_path: str | Path | None = None,
+        patch_xml: bool = True,
         backend: Literal["mujoco-torch", "mjx", "mujoco"] = "mujoco-torch",
         num_envs: int = 1,
         device: torch.device | None = None,
@@ -296,10 +302,10 @@ class MujocoEnv(EnvBase, abc.ABC, metaclass=_MujocoMeta):
         self._render_counter = 0
         self.camera_id = int(camera_id)
 
-        xml_string = self._load_xml(xml_path)
+        source = self._load_xml(xml_path, patch_xml=patch_xml)
         self._backend: _PhysicsBackend = make_backend(
             backend,
-            xml_string,
+            source,
             num_envs=num_envs,
             device=self.device,
             compile_step=compile_step,
@@ -317,7 +323,27 @@ class MujocoEnv(EnvBase, abc.ABC, metaclass=_MujocoMeta):
     # XML resolution + patching
     # ------------------------------------------------------------------
 
-    def _load_xml(self, xml_path: str | Path | None) -> str:
+    def _resolve_xml_candidate(
+        self,
+        candidate: str | Path,
+        *,
+        patch_xml: bool,
+    ) -> str | Path:
+        value = str(candidate)
+        if not patch_xml and not value.startswith(("http://", "https://")):
+            path = Path(candidate).expanduser()
+            if not path.is_file():
+                raise FileNotFoundError(path)
+            return path.resolve()
+        xml = resolve_xml_string(candidate)
+        return self._patch_xml(xml) if patch_xml else xml
+
+    def _load_xml(
+        self,
+        xml_path: str | Path | None,
+        *,
+        patch_xml: bool = True,
+    ) -> str | Path:
         # An explicit ``xml_path=...`` is treated as a hard request: if
         # it can't be resolved, surface the error rather than silently
         # falling back to the class-level defaults. Subclass-level
@@ -325,7 +351,7 @@ class MujocoEnv(EnvBase, abc.ABC, metaclass=_MujocoMeta):
         # the last failure preserved as ``__cause__``.
         if xml_path is not None:
             try:
-                return self._patch_xml(resolve_xml_string(xml_path))
+                return self._resolve_xml_candidate(xml_path, patch_xml=patch_xml)
             except OSError as e:
                 raise FileNotFoundError(
                     f"{type(self).__name__}: explicit xml_path={xml_path!r} "
@@ -348,8 +374,7 @@ class MujocoEnv(EnvBase, abc.ABC, metaclass=_MujocoMeta):
         last_exc: Exception | None = None
         for cand in candidates:
             try:
-                xml_string = resolve_xml_string(cand)
-                return self._patch_xml(xml_string)
+                return self._resolve_xml_candidate(cand, patch_xml=patch_xml)
             except OSError as e:
                 last_exc = e
         raise FileNotFoundError(

--- a/torchrl/envs/custom/mujoco/cube_bowl.py
+++ b/torchrl/envs/custom/mujoco/cube_bowl.py
@@ -200,7 +200,13 @@ class CubeBowlEnv(MujocoEnv):
     # XML loading and construction-time scene randomization.
     # ------------------------------------------------------------------
 
-    def _load_xml(self, xml_path: str | Path | None) -> str:
+    def _load_xml(
+        self,
+        xml_path: str | Path | None,
+        *,
+        patch_xml: bool = True,
+    ) -> str:
+        del patch_xml
         if xml_path is not None:
             raise ValueError(
                 "CubeBowlEnv composes a MuJoCo Menagerie UR5e scene; pass "


### PR DESCRIPTION
## Summary

- add a `patch_xml=False` mode that preserves a local model path instead of flattening it into an XML string
- let MuJoCo resolve relative includes, meshes, textures, and other resources from the model directory
- use the same path-aware model loader for the native MuJoCo, MJX, and MuJoCo-Torch backends

## Test plan

- pinned `ufmt` check on the changed Python files
- full native `TestMujoco` class: 39 passed, 14 skipped, 10 expected xfails
- relative include and mesh regression on CPU with `mujoco`, `mjx`, and `mujoco-torch`

No CUDA validation was performed.