### PR TITLE
[Feature] Isaac Lab 3.x compatibility for wrapper

### DIFF
--- a/test/libs/test_isaac.py
+++ b/test/libs/test_isaac.py
@@ -392,6 +392,55 @@ def test_isaaclab_all_false_reset_to_state_is_no_op():
     assert (out["policy"] == td["policy"]).all()
 
 
+def test_isaaclab_v3_compat_regressions(monkeypatch):
+    tensor = torch.ones(3, 4)
+    assert isaac_lab_lib._isaac_data_to_torch(tensor) is tensor
+    assert (
+        isaac_lab_lib._isaac_data_to_torch(types.SimpleNamespace(torch=tensor))
+        is tensor
+    )
+
+    env = IsaacLabWrapper.__new__(IsaacLabWrapper)
+    env.from_tiled_camera = False
+    env._rename_policy_to_observation = False
+    reward = torch.ones(4)
+    terminated = torch.zeros(4, dtype=torch.bool)
+    truncated = torch.zeros(4, dtype=torch.bool)
+    _, reward_out, terminated_out, truncated_out, done_out, _ = env._output_transform(
+        ({"policy": torch.ones(4, 2)}, reward, terminated, truncated, {})
+    )
+    reward.add_(1.0)
+    terminated.fill_(True)
+    truncated.fill_(True)
+    assert reward_out.shape == (4, 1)
+    assert (reward_out == 1.0).all()
+    assert not terminated_out.any()
+    assert not truncated_out.any()
+    assert not done_out.any()
+
+    class DirectRLEnvWarp:
+        pass
+
+    fake_mod = types.ModuleType("isaaclab_experimental.envs.direct_rl_env_warp")
+    fake_mod.DirectRLEnvWarp = DirectRLEnvWarp
+    monkeypatch.setitem(
+        sys.modules, "isaaclab_experimental", types.ModuleType("isaaclab_experimental")
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "isaaclab_experimental.envs",
+        types.ModuleType("isaaclab_experimental.envs"),
+    )
+    monkeypatch.setitem(
+        sys.modules, "isaaclab_experimental.envs.direct_rl_env_warp", fake_mod
+    )
+    monkeypatch.setattr(isaac_lab_lib, "_has_isaaclab_experimental", True)
+    assert IsaacLabWrapper._direct_reset_uses_mask(DirectRLEnvWarp())
+    assert not IsaacLabWrapper._direct_reset_uses_mask(object())
+    monkeypatch.setattr(isaac_lab_lib, "_has_isaaclab_experimental", False)
+    assert not IsaacLabWrapper._direct_reset_uses_mask(DirectRLEnvWarp())
+
+
 @pytest.mark.skipif(not _has_isaac, reason="IsaacGym not found")
 @pytest.mark.parametrize(
     "task",

--- a/torchrl/envs/libs/isaac_lab.py
+++ b/torchrl/envs/libs/isaac_lab.py
@@ -28,6 +28,22 @@ from torchrl.envs.libs.gym import GymWrapper
 _has_isaaclab = importlib.util.find_spec("isaaclab") is not None
 _has_isaaclab_newton = importlib.util.find_spec("isaaclab_newton") is not None
 _has_isaaclab_ov = importlib.util.find_spec("isaaclab_ov") is not None
+_has_isaaclab_experimental = (
+    importlib.util.find_spec("isaaclab_experimental") is not None
+)
+
+
+def _isaac_data_to_torch(value: Any) -> torch.Tensor:
+    """Converts an Isaac Lab data buffer (2.x torch.Tensor, 3.x warp ProxyArray or warp array) to a torch.Tensor."""
+    if isinstance(value, torch.Tensor):
+        return value
+    torch_view = getattr(value, "torch", None)
+    if isinstance(torch_view, torch.Tensor):
+        return torch_view
+    try:
+        return torch.from_dlpack(value)
+    except Exception:
+        return torch.as_tensor(value)
 
 
 class IsaacLabWrapper(GymWrapper):
@@ -128,6 +144,13 @@ class IsaacLabWrapper(GymWrapper):
 
         >>> env = gym.make("Isaac-Ant-v0", cfg=AntEnvCfg())
         >>> env = IsaacLabWrapper(env)
+
+    .. note:: With Isaac Lab 3.x, the ``AppLauncher`` boilerplate above is
+        replaced by the ``isaaclab_tasks.utils`` helpers
+        (``add_launcher_args``, ``launch_simulation``,
+        ``resolve_task_config``), and the physics backend is selected through
+        a Hydra-style preset override such as ``physics=newton_mjwarp`` or
+        ``physics=ovphysx``. The wrapper itself supports both versions.
 
     """
 
@@ -295,7 +318,9 @@ class IsaacLabWrapper(GymWrapper):
                     channels = camera.data.output[self.tiled_camera_data_type].shape[-1]
             dtype = self.pixels_dtype
             if dtype is None:
-                dtype = camera.data.output[self.tiled_camera_data_type].dtype
+                dtype = _isaac_data_to_torch(
+                    camera.data.output[self.tiled_camera_data_type]
+                ).dtype
             shape = (*self.batch_size, cfg.height, cfg.width, channels)
             if dtype == torch.uint8:
                 pixels_spec = Bounded(
@@ -324,7 +349,7 @@ class IsaacLabWrapper(GymWrapper):
 
     def _read_tiled_camera_pixels(self) -> torch.Tensor:
         pixels = self._get_tiled_camera().data.output[self.tiled_camera_data_type]
-        pixels = torch.as_tensor(pixels, device=self.device)
+        pixels = _isaac_data_to_torch(pixels).to(self.device)
         if self.pixels_channels is not None:
             pixels = pixels[..., : self.pixels_channels]
         if self.pixels_dtype is not None and pixels.dtype != self.pixels_dtype:
@@ -366,7 +391,7 @@ class IsaacLabWrapper(GymWrapper):
         observations, reward, terminated, truncated, info = step_outputs_tuple
         observations = self._add_tiled_camera_pixels(observations)
         done = terminated | truncated
-        reward = reward.unsqueeze(-1)  # to get to (num_envs, 1)
+        reward = reward.clone().unsqueeze(-1)  # to get to (num_envs, 1)
         return (
             observations,
             reward,
@@ -557,7 +582,16 @@ class IsaacLabWrapper(GymWrapper):
             # that DirectRLEnv / DirectMARLEnv reset() would normally do.
             if seed is not None:
                 unwrapped.seed(seed)
-            unwrapped._reset_idx(env_ids)
+            if self._direct_reset_uses_mask(unwrapped):
+                mask = torch.zeros(
+                    self.batch_size.numel(),
+                    dtype=torch.bool,
+                    device=unwrapped.device,
+                )
+                mask[env_ids] = True
+                unwrapped._reset_idx(mask)
+            else:
+                unwrapped._reset_idx(env_ids)
             unwrapped.scene.write_data_to_sim()
             unwrapped.sim.forward()
             return unwrapped._get_observations(), unwrapped.extras
@@ -567,6 +601,15 @@ class IsaacLabWrapper(GymWrapper):
             f"{type(unwrapped).__name__}. Supported bases are ManagerBasedEnv "
             "(and subclasses), DirectRLEnv and DirectMARLEnv."
         )
+
+    @staticmethod
+    def _direct_reset_uses_mask(env: Any) -> bool:
+        """Whether ``env._reset_idx`` expects a boolean mask (Isaac Lab 3.x ``DirectRLEnvWarp``) rather than indices."""
+        if not _has_isaaclab_experimental:
+            return False
+        from isaaclab_experimental.envs.direct_rl_env_warp import DirectRLEnvWarp
+
+        return isinstance(env, DirectRLEnvWarp)
 
     def _build_reset_tensordict(self, obs: Any, info: dict | None) -> TensorDictBase:
         """Rebuild a torchrl-style reset tensordict from Isaac's (obs, info)."""


### PR DESCRIPTION
## Description

Isaac Lab 3.0 (beta2) introduces a factory-based multi-backend architecture. Testing `IsaacLabWrapper` against it end-to-end (kit-less install, `ovphysx` backend, A10) showed the wrapper's step/reset machinery works unmodified in all supported configurations, with two concrete defects fixed here:

1. **Reward buffer aliasing.** Isaac Lab 3.x mutates the manager-based reward buffer in place between steps (verified by holding references across 20 steps; `terminated`/`truncated` are no longer mutated, but reward now is). The wrapper cloned terminated/truncated but passed reward through as a view of the mutated buffer. It now clones the reward as well.
2. **v3 `ProxyArray` in the tiled-camera path.** `.data.*` buffers are warp-backed `ProxyArray` objects in 3.x (with a `torch` view accessor), so `torch.as_tensor` on `camera.data.output[...]` no longer yields a usable tensor, and dtype probing returned warp dtypes. A new `_isaac_data_to_torch` helper accepts v2 `torch.Tensor` buffers, v3 proxies, and plain warp arrays (via DLPack).

Also adds a docstring note for the 3.x launch API (`launch_simulation`/Hydra presets replacing `AppLauncher`).

Results with a basic warp run 
'''
env=IsaacLabWrapper(env=<OrderEnforcing<CartpoleWarpEnv<Isaac-Cartpole-Direct-Warp-v0>>>, batch_size=torch.Size([8]))
batch_size: torch.Size([8]) device: cuda:0
rollout shape: torch.Size([8, 50])
reward sum: 94.55167388916016
done fraction: 0.03999999910593033
episode_reward: tensor([ 2.7660,  3.7561, 15.9770,  1.4488,  4.8248, 11.1499,  3.3809,  0.6895])
'''
