### PR TITLE
[BugFix] Restore the continuous benchmark feed

### DIFF
--- a/benchmarks/test_envs_benchmark.py
+++ b/benchmarks/test_envs_benchmark.py
@@ -245,9 +245,11 @@ def _make_async_pool(num_envs, exchange, step_latency, reset_latency, max_steps)
 def _async_pool_harvest(pool, num_transitions, max_get):
     harvested = 0
     while harvested < num_transitions:
-        _, td_next = pool.async_step_and_maybe_reset_recv(
-            min_get=1, max_get=max_get, timeout=1e-3
-        )
+        # timeout=None: block for the first result, then drain whatever else
+        # is ready without waiting. A finite timeout bounds the whole call
+        # (#4184) and raises TimeoutError whenever recv lands while all envs
+        # are mid-step, which is the normal state of this loop.
+        _, td_next = pool.async_step_and_maybe_reset_recv(min_get=1, max_get=max_get)
         num_ready = td_next.shape[0]
         td_next["action"] = torch.ones(num_ready, 1)
         pool.async_step_and_maybe_reset_send(td_next)

--- a/test/rb/test_storages.py
+++ b/test/rb/test_storages.py
@@ -387,6 +387,23 @@ class TestStorages:
         torch.testing.assert_close(storage[:75], data.repeat(3, 1))
 
     @pytest.mark.parametrize("storage_type", [LazyMemmapStorage, LazyTensorStorage])
+    def test_set_slice_cursor(self, storage_type):
+        """set() accepts a slice cursor and records the last written index.
+
+        Regression test: _set_last_cursor used to fall through to int(cursor)
+        for slices and raise TypeError, breaking any slice-indexed write.
+        """
+        storage = storage_type(20)
+        data = TensorDict(a=torch.arange(10).unsqueeze(-1), batch_size=[10])
+        storage.set(slice(0, 10), data)
+        assert len(storage) == 10
+        assert storage._last_cursor_index == 9
+        torch.testing.assert_close(storage[:10]["a"], data["a"])
+        # A slice with a step lands on the last actually-written index.
+        storage.set(slice(10, 20, 2), TensorDict(a=torch.zeros(5, 1), batch_size=[5]))
+        assert storage._last_cursor_index == 18
+
+    @pytest.mark.parametrize("storage_type", [LazyMemmapStorage, LazyTensorStorage])
     def test_extend_lazystack(self, storage_type):
         rb = ReplayBuffer(
             storage=storage_type(6),

--- a/torchrl/data/replay_buffers/storages/base.py
+++ b/torchrl/data/replay_buffers/storages/base.py
@@ -104,6 +104,12 @@ class Storage:
             cursor = cursor[-1] if cursor.numel() else -1
         elif isinstance(cursor, range):
             cursor = int(cursor[-1]) if len(cursor) else -1
+        elif isinstance(cursor, slice):
+            # Resolve against the addressable range: set() records the cursor
+            # before writing, so len(self) may still be 0 and only max_size
+            # bounds the slice reliably.
+            cursor_range = range(*cursor.indices(self.max_size))
+            cursor = int(cursor_range[-1]) if len(cursor_range) else -1
         elif isinstance(cursor, (tuple, list)):
             time_cursor = cursor[0]
             if isinstance(time_cursor, torch.Tensor):


### PR DESCRIPTION
## Description

The nightly benchmark job has been red since early August, and the gh-pages upload is skipped whenever any benchmark test fails, so the continuous benchmark dashboard has not received a data point since (its last update is ~Aug 10). Two independent fixes, one goal: make the benchmark job green so the trend feed flows again.

1. **`Storage.set()` with a slice cursor raised `TypeError`.** `_set_last_cursor` normalized `Tensor`/`range`/`tuple`/`list`/`None` cursors but let `slice` fall through to `int(cursor)`, even though `slice` is in `set()`'s own signature. Every `test_storage_write_benchmark` case failed on this (`storage.set(slice(0, n), data)`). Slices now resolve to the last written index via `cursor.indices(max_size)` (`max_size` rather than `len`, since `set()` records the cursor before the write). Regression test in `test/rb/test_storages.py` covers plain and stepped slices on `LazyTensorStorage` and `LazyMemmapStorage`.

2. **The AsyncEnvPool benchmark harvest loop broke under #4184's deadline semantics.** The loop used `recv(min_get=1, timeout=1e-3)`, written against the pre-#4184 behavior where the first get ignored the deadline. With the whole-call deadline it raises `TimeoutError` whenever `recv` is entered while all envs are mid-step -- the normal state of the loop (nightly 08-31: `test_async_env_pool_dispatch[queue]` fails with exactly this error). The loop now uses `timeout=None`: block for the first result, then drain whatever else is ready without waiting, which is the originally intended batching behavior and cannot time out.

Verified locally: the RB regression test passes, the previously-failing storage-write benchmarks pass, and all three `test_async_env_pool_*` series pass under the new recv semantics (`dispatch[queue]` included).

## Motivation and Context

Unblocks the benchmark trend feed that the AsyncEnvPool v2 sequence (#4061, #4182) relies on to demonstrate throughput improvements. Item 1 is also a user-facing bug fix: any direct slice-indexed storage write hit the same `TypeError`.

- [x] I have raised an issue to propose this change (#4061)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.