### PR TITLE
[Algorithm] Add DMC Walker reproduction script for DreamerV3

### DIFF
--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -53,7 +53,20 @@ CPU execution.
 For a three-seed median and interquartile reproduction run:
 
 ```bash
-python sota-implementations/dreamer_v3/benchmark.py --output-dir dmc_walker_runs
+./sota-implementations/dreamer_v3/reproduce_dmc_walker.sh
+```
+
+For the fastest supported accelerator path, enable the compiled RSSM scan
+(unrolled eight steps at a time):
+
+```bash
+./sota-implementations/dreamer_v3/reproduce_dmc_walker.sh --fast
+```
+
+Compilation has an up-front cost, so the short validation remains eager:
+
+```bash
+./sota-implementations/dreamer_v3/reproduce_dmc_walker.sh --smoke
 ```
 
 The benchmark writes one metrics file per seed plus `summary.json`, aggregates
@@ -65,7 +78,12 @@ minimum final median return of 900; `benchmark.*` Hydra overrides change them,
 as in `benchmark.seeds=[0,1,2,3,4]`. `env.seed` and `logger.metrics_jsonl` are
 set per run and are rejected as overrides, since either would collapse the
 seeds onto one trajectory. Full learning-curve runs are intended for scheduled
-or manual validation; pull-request CI uses short smoke overrides.
+or manual validation; pull-request CI uses short smoke overrides. Set
+`OUTPUT_DIR` to change the output directory (the defaults are
+`dmc_walker_runs` and `dmc_walker_smoke`), and append any other Hydra overrides
+to the wrapper, for example `benchmark.seeds=[0]`. Each run logs the resolved
+training device, replay device, RSSM backend, scan unroll and mixed-precision
+state.
 
 For a smaller ablation, shorten the run rather than the window:
 

--- a/sota-implementations/dreamer_v3/reproduce_dmc_walker.sh
+++ b/sota-implementations/dreamer_v3/reproduce_dmc_walker.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Reproduce the DreamerV3 DMC Walker Walk result: the preset's benchmark
+# seeds and acceptance gate through benchmark.py. --smoke validates the
+# same pipeline with tiny settings in minutes; OUTPUT_DIR overrides the
+# output directory.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+output_dir="${OUTPUT_DIR:-dmc_walker_runs}"
+
+smoke=0
+for arg in "$@"; do
+  case "$arg" in
+    --smoke) smoke=1 ;;
+    *)
+      echo "usage: reproduce_dmc_walker.sh [--smoke]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$smoke" -eq 1 ]; then
+  python "$script_dir/benchmark.py" \
+    --output-dir "$output_dir" \
+    benchmark.window_size=200 \
+    benchmark.minimum_final_median_return=-100000 \
+    collector.num_envs=1 \
+    collector.count_reset_records=false \
+    collector.total_frames=400 \
+    collector.frames_per_batch=200 \
+    env.max_episode_steps=100 \
+    replay_buffer.batch_size=2 \
+    replay_buffer.seq_len=4 \
+    replay_buffer.warmup_factor=1 \
+    optimization.updates_per_batch=1 \
+    optimization.train_ratio=8 \
+    optimization.mixed_precision=false \
+    logger.eval_every=200 \
+    logger.eval_episodes=1 \
+    networks.hidden_dim=8 \
+    networks.encoder_layers=1 \
+    networks.decoder_layers=1 \
+    networks.reward_layers=1 \
+    networks.actor_layers=1 \
+    networks.value_layers=1 \
+    networks.num_categoricals=2 \
+    networks.num_classes=2 \
+    networks.num_reward_bins=11 \
+    networks.num_value_bins=11 \
+    networks.rnn_hidden_dim=8
+else
+  python "$script_dir/benchmark.py" --output-dir "$output_dir"
+fi

--- a/sota-implementations/dreamer_v3/reproduce_dmc_walker.sh
+++ b/sota-implementations/dreamer_v3/reproduce_dmc_walker.sh
@@ -1,53 +1,92 @@
 #!/usr/bin/env bash
 # Reproduce the DreamerV3 DMC Walker Walk result: the preset's benchmark
-# seeds and acceptance gate through benchmark.py. --smoke validates the
-# same pipeline with tiny settings in minutes; OUTPUT_DIR overrides the
-# output directory.
+# seeds and acceptance gate through benchmark.py. --fast enables the
+# compiled RSSM scan; --smoke validates the eager pipeline with tiny settings
+# in minutes. OUTPUT_DIR overrides the output directory, and KEY=VALUE
+# arguments are forwarded to Hydra.
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-output_dir="${OUTPUT_DIR:-dmc_walker_runs}"
+output_dir="${OUTPUT_DIR:-}"
+
+usage() {
+  echo "usage: reproduce_dmc_walker.sh [--fast | --smoke] [KEY=VALUE ...]"
+}
 
 smoke=0
+fast=0
+hydra_overrides=()
 for arg in "$@"; do
   case "$arg" in
     --smoke) smoke=1 ;;
+    --fast) fast=1 ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *=*) hydra_overrides+=("$arg") ;;
     *)
-      echo "usage: reproduce_dmc_walker.sh [--smoke]" >&2
+      usage >&2
       exit 2
       ;;
   esac
 done
 
-if [ "$smoke" -eq 1 ]; then
-  python "$script_dir/benchmark.py" \
-    --output-dir "$output_dir" \
-    benchmark.window_size=200 \
-    benchmark.minimum_final_median_return=-100000 \
-    collector.num_envs=1 \
-    collector.count_reset_records=false \
-    collector.total_frames=400 \
-    collector.frames_per_batch=200 \
-    env.max_episode_steps=100 \
-    replay_buffer.batch_size=2 \
-    replay_buffer.seq_len=4 \
-    replay_buffer.warmup_factor=1 \
-    optimization.updates_per_batch=1 \
-    optimization.train_ratio=8 \
-    optimization.mixed_precision=false \
-    logger.eval_every=200 \
-    logger.eval_episodes=1 \
-    networks.hidden_dim=8 \
-    networks.encoder_layers=1 \
-    networks.decoder_layers=1 \
-    networks.reward_layers=1 \
-    networks.actor_layers=1 \
-    networks.value_layers=1 \
-    networks.num_categoricals=2 \
-    networks.num_classes=2 \
-    networks.num_reward_bins=11 \
-    networks.num_value_bins=11 \
-    networks.rnn_hidden_dim=8
-else
-  python "$script_dir/benchmark.py" --output-dir "$output_dir"
+if [ "$smoke" -eq 1 ] && [ "$fast" -eq 1 ]; then
+  echo "--fast and --smoke are mutually exclusive." >&2
+  usage >&2
+  exit 2
 fi
+
+if [ -z "$output_dir" ]; then
+  if [ "$smoke" -eq 1 ]; then
+    output_dir="dmc_walker_smoke"
+  else
+    output_dir="dmc_walker_runs"
+  fi
+fi
+
+benchmark_command=(python "$script_dir/benchmark.py" --output-dir "$output_dir")
+
+if [ "$smoke" -eq 1 ]; then
+  benchmark_command+=(
+    benchmark.window_size=200
+    benchmark.minimum_final_median_return=-100000
+    collector.num_envs=1
+    collector.count_reset_records=false
+    collector.total_frames=400
+    collector.frames_per_batch=200
+    env.max_episode_steps=100
+    replay_buffer.batch_size=2
+    replay_buffer.buffer_size=400
+    replay_buffer.seq_len=4
+    replay_buffer.warmup_factor=1
+    optimization.compile_rssm=null
+    optimization.updates_per_batch=1
+    optimization.train_ratio=null
+    optimization.mixed_precision=false
+    logger.eval_every=200
+    logger.eval_episodes=1
+    networks.hidden_dim=8
+    networks.encoder_layers=1
+    networks.decoder_layers=1
+    networks.reward_layers=1
+    networks.actor_layers=1
+    networks.value_layers=1
+    networks.num_categoricals=2
+    networks.num_classes=2
+    networks.num_reward_bins=11
+    networks.num_value_bins=11
+    networks.rnn_hidden_dim=8
+  )
+elif [ "$fast" -eq 1 ]; then
+  benchmark_command+=(
+    optimization.compile_rssm=scan
+    optimization.rssm_scan_unroll=8
+  )
+fi
+
+if [ "${#hydra_overrides[@]}" -gt 0 ]; then
+  benchmark_command+=("${hydra_overrides[@]}")
+fi
+"${benchmark_command[@]}"

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -439,6 +439,20 @@ def main(cfg: DictConfig):
     replay_device = (
         torch.device(cfg.replay_buffer.device) if cfg.replay_buffer.device else device
     )
+    use_bfloat16 = cfg.optimization.mixed_precision and device.type == "cuda"
+    torchrl_logger.info(
+        "DreamerV3 execution: device=%s, replay_device=%s, rssm_backend=%s, "
+        "rssm_scan_unroll=%s, mixed_precision=%s",
+        device,
+        replay_device,
+        cfg.optimization.compile_rssm or "eager",
+        (
+            cfg.optimization.rssm_scan_unroll
+            if cfg.optimization.compile_rssm == "scan"
+            else "n/a"
+        ),
+        use_bfloat16,
+    )
     num_envs = cfg.collector.num_envs
     count_reset_records = cfg.collector.count_reset_records
     collector_action_frames = _validated_action_budget(cfg)
@@ -505,8 +519,6 @@ def main(cfg: DictConfig):
         if cfg.optimization.train_ratio is not None
         else None
     )
-    use_bfloat16 = cfg.optimization.mixed_precision and device.type == "cuda"
-
     def train_step(
         sample: TensorDictBase,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import runpy
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -1754,3 +1757,56 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         assert prior_grad > 0, "Real prior received no gradient"
         assert posterior_grad > 0, "Real posterior received no gradient"
         assert B == 2 and T == 3
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="requires bash")
+def test_dreamer_v3_dmc_reproduction_modes(tmp_path):
+    repo_root = Path(__file__).parents[2]
+    script = repo_root / "sota-implementations/dreamer_v3/reproduce_dmc_walker.sh"
+    benchmark = repo_root / "sota-implementations/dreamer_v3/benchmark.py"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python"
+    fake_python.write_text('#!/bin/sh\nprintf "%s\\n" "$@"\n')
+    fake_python.chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    fast = subprocess.run(
+        ["bash", str(script), "--fast", "benchmark.seeds=[0]"],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    ).stdout.splitlines()
+    assert fast == [
+        str(benchmark),
+        "--output-dir",
+        "dmc_walker_runs",
+        "optimization.compile_rssm=scan",
+        "optimization.rssm_scan_unroll=8",
+        "benchmark.seeds=[0]",
+    ]
+
+    smoke = subprocess.run(
+        ["bash", str(script), "--smoke"],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    ).stdout.splitlines()
+    assert smoke[:3] == [str(benchmark), "--output-dir", "dmc_walker_smoke"]
+    assert "replay_buffer.buffer_size=400" in smoke
+    assert "optimization.compile_rssm=null" in smoke
+    assert "optimization.updates_per_batch=1" in smoke
+    assert "optimization.train_ratio=null" in smoke
+
+    incompatible = subprocess.run(
+        ["bash", str(script), "--fast", "--smoke"],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+    assert incompatible.returncode == 2
+    assert "mutually exclusive" in incompatible.stderr


### PR DESCRIPTION
## Summary

- add `reproduce_dmc_walker.sh`, a single entry point that runs the walker preset's benchmark seeds and acceptance gate through `benchmark.py`
- `--smoke` validates the same pipeline (training, per-seed jsonl metrics, windowed aggregation, gate check) with tiny settings in minutes instead of the full 1.1M-step runs

## Results

Three seeds on a single MI300X reach final evaluation returns of 978.7 / 971.8 / 973.7 at 1.1M environment steps, final median 973.7, at or above the JAX reference plateau. The reference reports stochastic training-episode returns and ends at 490k steps. TorchRL crosses 700 roughly 100-150k steps after the reference median; final performance matches.

## Validation

- `reproduce_dmc_walker.sh --smoke` runs end to end on CPU (exit 0, summary.json written, gate evaluated)
- pre-commit passes on the added file
- the full reproduction was intentionally not rerun for this PR; the smoke validates the mechanics


<img width="1200" height="675" alt="image" src="https://github.com/user-attachments/assets/91d53ceb-4885-40d5-9bec-642794a48281" />

