### PR TITLE
[BugFix] Propagate spec lock state through stacked composites

### DIFF
--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -838,6 +838,32 @@ class TestLock:
         spec["a", "b"] = spec["a", "b"].clone()
         spec["a"].set("b", spec["a", "b"].clone())
 
+    def test_stacked_composite_lock_propagates_to_children(self):
+        """Lock state must propagate through lazy stacks to the stacked children.
+
+        Regression test: the children hold the authoritative state and writes
+        through the stack go to them, so a child that was locked when stacked
+        (e.g. env specs shipped by AsyncEnvPool workers) made every write fail
+        even after ``unlock_(recurse=True)`` on the stack.
+        """
+        child_a = Composite(x=Unbounded((3,)))
+        child_b = Composite(x=Unbounded((4,)))
+        child_a.lock_(recurse=True)
+        child_b.lock_(recurse=True)
+        stacked = torch.stack([child_a, child_b], 0)
+
+        stacked.unlock_(recurse=True)
+        assert not child_a.locked
+        assert not child_b.locked
+        stacked["y"] = Unbounded((2, 5))
+        assert child_a["y"].shape == torch.Size((5,))
+
+        stacked.lock_(recurse=True)
+        assert child_a.locked
+        assert child_b.locked
+        with pytest.raises(RuntimeError, match="Cannot modify a locked Composite."):
+            stacked["z"] = Unbounded((2, 5))
+
     def test_edge_cases(self):
         level3 = Composite()
         level2 = Composite(level3=level3)

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -6473,6 +6473,52 @@ class StackedComposite(_LazyStackedMixin[Composite], Composite):
 
     """
 
+    # Composite._propagate_lock/_propagate_unlock recurse through values(),
+    # which for a lazy stack yields freshly assembled stacked entries. The
+    # authoritative state lives in the stacked children (self._specs), so the
+    # lock state must be propagated to them explicitly; otherwise a child
+    # that was locked when stacked stays locked after unlock_(recurse=True)
+    # and every write through StackedComposite.set fails.
+
+    def _propagate_lock(
+        self,
+        *,
+        recurse: bool,
+        lock_parents_weakrefs: list[weakref.ref] | None = None,
+        is_compiling: bool,
+    ) -> None:
+        super()._propagate_lock(
+            recurse=recurse,
+            lock_parents_weakrefs=lock_parents_weakrefs,
+            is_compiling=is_compiling,
+        )
+        if recurse:
+            if not is_compiling:
+                child_refs = (
+                    list(lock_parents_weakrefs)
+                    if lock_parents_weakrefs is not None
+                    else []
+                )
+                child_refs.append(weakref.ref(self))
+            else:
+                child_refs = lock_parents_weakrefs
+            for spec in self._specs:
+                if isinstance(spec, Composite):
+                    spec._propagate_lock(
+                        recurse=True,
+                        lock_parents_weakrefs=child_refs,
+                        is_compiling=is_compiling,
+                    )
+
+    def _propagate_unlock(self, recurse: bool) -> list[Composite]:
+        sub_specs = super()._propagate_unlock(recurse=recurse)
+        if recurse:
+            for spec in self._specs:
+                if isinstance(spec, Composite):
+                    sub_specs.extend(spec._propagate_unlock(recurse=recurse))
+                    sub_specs.append(spec)
+        return sub_specs
+
     def _reshape(
         self,
         *args,


### PR DESCRIPTION
## Description

`Composite._propagate_lock` / `_propagate_unlock` recurse through `values()`, which for a `StackedComposite` yields freshly assembled stacked entries. The authoritative state lives in the stacked children (`self._specs`), and every write through `StackedComposite.set` is forwarded to them -- so a child that was locked when stacked stayed locked forever: any write through the stack raised `RuntimeError: Cannot modify a locked Composite`, even immediately after `unlock_(recurse=True)` on the stack.

Concrete impact: `AsyncEnvPool(backend="multiprocessing")` could not be constructed for any env set whose specs stack lazily -- per-worker `NonTensor` entries (e.g. `CountingEnvWithString`), heterogeneous observation shapes across workers, etc. Workers ship their specs locked (envs lock specs at construction), `EnvBase.__init__` calls `unlock_(recurse=True)` on the stacked spec, and the first spec write crashed. Verified present on both current main and pre-0.14-prep main, so this is latent rather than a recent regression -- but it blocks the `exchange="auto"` fallback work (#4061), whose entire point is envs with exactly these schemas.

`StackedComposite` now overrides both propagation hooks to recurse into its children (with the same lock-parent weakref bookkeeping as the dense path).

Tests: a `TestLock` regression test asserting that lock/unlock through a lazy stack reaches already-locked children and that writes through the stack work after unlocking (and fail when locked). The full `TestLock` and all stacked/lazy spec selections pass locally; end-to-end pool construction over heterogeneous and NonTensor-spec envs verified manually and covered by the follow-up AsyncEnvPool PRs that depend on this fix.

## Motivation and Context

Unblocks PR 4 of the AsyncEnvPool v2 sequence (#4061): the `exchange="auto"` fallback targets env schemas that today cannot even construct a multiprocessing pool because of this bug.

- [x] I have raised an issue to propose this change (#4061)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.