### PR TITLE
[BugFix] Fix AsyncEnvPool queue-exchange shutdown deadlock

### DIFF
--- a/test/envs/test_special.py
+++ b/test/envs/test_special.py
@@ -76,6 +76,36 @@ class _DelayedCountingEnv(CountingEnv):
         return super()._step(tensordict)
 
 
+class _ManyKeysCountingEnv(CountingEnv):
+    """A CountingEnv with many observation keys.
+
+    A single pickled result of this env comfortably exceeds the OS pipe
+    capacity (16KB on macOS, 64KB on Linux) even though every tensor is
+    reduced to a small shared-memory handle: with 256 keys, one result pair
+    of ``step_and_maybe_reset`` pickles to roughly 90KB.
+    """
+
+    _NUM_EXTRA_KEYS = 256
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for index in range(self._NUM_EXTRA_KEYS):
+            self.observation_spec[f"obs{index}"] = Unbounded(
+                (*self.batch_size, 1), dtype=torch.float32
+            )
+
+    def _fill_extra_keys(self, tensordict):
+        for index in range(self._NUM_EXTRA_KEYS):
+            tensordict.set(f"obs{index}", torch.zeros(*self.batch_size, 1))
+        return tensordict
+
+    def _reset(self, tensordict, **kwargs):
+        return self._fill_extra_keys(super()._reset(tensordict, **kwargs))
+
+    def _step(self, tensordict):
+        return self._fill_extra_keys(super()._step(tensordict))
+
+
 def test_callable_metadata_env_closes_when_extraction_fails(monkeypatch):
     env = ContinuousActionVecMockEnv()
     closed = False
@@ -1010,6 +1040,41 @@ class TestAsyncEnvPool:
             assert result.shape[0] == 2
         finally:
             env._maybe_shutdown()
+
+    @set_capture_non_tensor_stack(False)
+    def test_queue_shutdown_with_unread_results(self):
+        """Shutdown must not deadlock when unread results are still buffered.
+
+        Each worker publishes one large result (~90KB pickled) that the
+        consumer never reads. Process teardown joins the queue feeder
+        threads, which block on the full pipe unless shutdown drains the
+        result queues while joining; a blocked worker in turn used to hang
+        ``AsyncEnvPool.shutdown()`` forever. Graceful exits (exitcode 0)
+        prove the workers did not need the terminate fallback either.
+        """
+        env = AsyncEnvPool(
+            [partial(_ManyKeysCountingEnv, max_steps=1000)] * 4,
+            backend="multiprocessing",
+            exchange="queue",
+        )
+        reset = env.reset()
+        reset.set("action", torch.ones(reset.shape + (1,)))
+        env.async_step_and_maybe_reset_send(reset)
+        # Each worker processes its step command and then the shutdown
+        # command in order, so the large results are buffered and unread
+        # when the workers exit.
+        shutdown_thread = threading.Thread(target=env.shutdown, daemon=True)
+        shutdown_thread.start()
+        shutdown_thread.join(timeout=120)
+        try:
+            assert not shutdown_thread.is_alive(), "shutdown deadlocked"
+            assert all(proc.exitcode == 0 for proc in env.threads)
+        finally:
+            # Do not leave live workers behind on failure: pytest joins all
+            # multiprocessing children at exit and would hang forever.
+            for proc in env.threads:
+                if proc.is_alive():
+                    proc.terminate()
 
     @pytest.mark.parametrize("backend", ["multiprocessing", "threading"])
     def test_deadline_batch_validation(self, make_envs, backend):

--- a/torchrl/envs/async_envs.py
+++ b/torchrl/envs/async_envs.py
@@ -964,6 +964,12 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
                     result_queue.get_nowait()
                 except queue.Empty:
                     break
+                except (EOFError, OSError):
+                    # The item has already been removed from the queue, but
+                    # rebuilding a discarded tensor can fail once its worker's
+                    # resource sharer has exited. Keep draining the remaining
+                    # items so other workers can finish flushing their queues.
+                    continue
 
     def shutdown(self):
         for env_id in range(self.num_envs):

--- a/torchrl/envs/async_envs.py
+++ b/torchrl/envs/async_envs.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import abc
 import multiprocessing
+import queue
 import threading
 from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import as_completed, FIRST_COMPLETED, ThreadPoolExecutor, wait
@@ -23,7 +24,7 @@ from tensordict import (
 from tensordict.tensorclass import NonTensorData, NonTensorStack
 from tensordict.utils import _zip_strict, expand_as_right
 
-from torchrl._utils import timeit
+from torchrl._utils import logger as torchrl_logger, timeit
 from torchrl.data.tensor_specs import NonTensor
 from torchrl.envs._async_exchange import _receive_batch, _SharedSlotExchange
 from torchrl.envs.common import _EnvPostInit, EnvBase
@@ -947,12 +948,48 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
 
     _async_private_reset_recv = async_reset_recv
 
+    _SHUTDOWN_TIMEOUT = 60.0
+
+    def _drain_result_queues(self) -> None:
+        for result_queue in (
+            self.step_queue,
+            self.reset_queue,
+            self.step_reset_queue,
+            *self._per_env_step_queues,
+            *self._per_env_reset_queues,
+            *self._per_env_step_reset_queues,
+        ):
+            while True:
+                try:
+                    result_queue.get_nowait()
+                except queue.Empty:
+                    break
+
     def shutdown(self):
         for env_id in range(self.num_envs):
             self.input_queue[env_id].put(("shutdown", None))
 
+        # A worker whose unread results still sit in a result queue cannot
+        # exit: its process teardown joins the queue's feeder thread, which
+        # blocks writing into the full pipe that nothing reads any more.
+        # Draining the result queues while joining unblocks those feeders so
+        # the workers exit through the normal teardown path.
+        deadline = timeit("async_env_shutdown_deadline").start()
         for thread in self.threads:
-            thread.join()
+            while thread.is_alive() and deadline.elapsed() < self._SHUTDOWN_TIMEOUT:
+                self._drain_result_queues()
+                thread.join(timeout=0.1)
+        stragglers = [thread for thread in self.threads if thread.is_alive()]
+        if stragglers:
+            torchrl_logger.warning(
+                f"AsyncEnvPool.shutdown: terminating {len(stragglers)} worker "
+                f"process(es) that did not exit within "
+                f"{self._SHUTDOWN_TIMEOUT}s."
+            )
+            for thread in stragglers:
+                thread.terminate()
+            for thread in stragglers:
+                thread.join()
 
     @classmethod
     def _env_exec(


### PR DESCRIPTION
## Description

Fixes the `AsyncEnvPool` shutdown deadlock first reported in #4182: with `exchange="queue"`, `shutdown()` hangs forever once enough unread results are buffered (reproduced at 32 workers on macOS; Linux's 64KB pipes are exposed the same way, just with a higher threshold).

Root cause (confirmed with a faulthandler dump: the parent blocks in `thread.join()` inside `shutdown()` while setup, reset and harvesting all completed fine): unread results are still sitting in the result queues when workers receive the shutdown command. Python process teardown joins each `mp.Queue`'s feeder thread, and a feeder blocks forever writing into a full pipe that nothing will ever drain again -- so the worker never exits, and the parent's `join()` never returns. This is the documented "joining processes that use queues" pitfall of `multiprocessing`.

The fix, in two layers:

- **Drain while joining (the actual fix):** `shutdown()` now drains the result queues while joining the workers. Draining unblocks any feeder stuck on a full pipe, so the workers flush and exit through their normal teardown path. (Worker-side `cancel_join_thread()` was tried first and rejected: skipping the feeder join lets interpreter finalization race a live daemon feeder thread, which reliably hangs worker exit on macOS -- it trades one deadlock for another.)
- **Safety net:** workers that still have not exited after 60s are terminated with a warning log instead of hanging forever, so no future regression can turn shutdown into an infinite hang again.

The regression test gives each of 4 workers one large unread result (a 64KB string observation, pickled by value so tensor-sharing reductions cannot shrink it below pipe capacity) and asserts that `shutdown()` returns *and* that every worker exited with code 0 -- proving the graceful path, not the terminate fallback, resolved it. Verified to fail before the fix and pass with it.

## Motivation and Context

PR 3 of the AsyncEnvPool v2 sequence (#4061, benchmarks in #4182). Any consumer loop that stops harvesting while steps are in flight -- the normal way an async collection loop ends -- could previously deadlock the process at `close()`. This also unblocks re-adding the queue-exchange variant of the `fast_step_slow_reset` benchmark series that #4182 shipped shm-only.

- [x] I have raised an issue to propose this change (#4061)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
