### PR TITLE
[Deprecation] Add exchange="auto" and announce v0.15 async pool defaults

### DIFF
--- a/test/envs/test_special.py
+++ b/test/envs/test_special.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import contextlib
 import threading
+import warnings
 from functools import partial
 
 import numpy as np
@@ -46,6 +47,7 @@ from torchrl.testing.mocking_classes import (
     ContinuousActionVecMockEnv,
     CountingBatchedEnv,
     CountingEnv,
+    CountingEnvWithString,
     DiscreteActionConvMockEnv,
     DiscreteActionConvMockEnvNumpy,
     DiscreteActionVecMockEnv,
@@ -1075,6 +1077,67 @@ class TestAsyncEnvPool:
             for proc in env.threads:
                 if proc.is_alive():
                     proc.terminate()
+
+    @set_capture_non_tensor_stack(False)
+    def test_exchange_auto_resolves_to_shm(self, make_envs):
+        env = AsyncEnvPool(make_envs, backend="multiprocessing", exchange="auto")
+        try:
+            assert env.resolved_exchange == "shm"
+            assert env._slot_exchange is not None
+            reset = env.reset()
+            reset.set("action", torch.ones(reset.shape + (1,)))
+            step, next_step = env.step_and_maybe_reset(reset)
+            assert step.shape == env.shape
+            assert next_step.shape == env.shape
+        finally:
+            env._maybe_shutdown()
+
+    @set_capture_non_tensor_stack(False)
+    def test_exchange_auto_falls_back_to_queue(self):
+        # CountingEnvWithString has a non-tensor leaf, which the shared-memory
+        # exchange rejects; "auto" must fall back to the queue exchange and
+        # still produce a working pool.
+        env = AsyncEnvPool(
+            [partial(CountingEnvWithString) for _ in range(2)],
+            backend="multiprocessing",
+            exchange="auto",
+        )
+        try:
+            assert env.resolved_exchange == "queue"
+            assert env._slot_exchange is None
+            reset = env.reset()
+            reset.set("action", torch.ones(reset.shape + (1,)))
+            step, next_step = env.step_and_maybe_reset(reset)
+            assert step.shape == env.shape
+        finally:
+            env._maybe_shutdown()
+
+    def test_exchange_auto_threading(self, make_envs):
+        env = AsyncEnvPool(make_envs, backend="threading", exchange="auto")
+        try:
+            assert env.resolved_exchange == "queue"
+        finally:
+            env._maybe_shutdown()
+
+    def test_exchange_default_future_warning(self, make_envs):
+        with pytest.warns(FutureWarning, match="default exchange"):
+            env = AsyncEnvPool(make_envs, backend="multiprocessing")
+        env._maybe_shutdown()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            env = AsyncEnvPool(make_envs, backend="multiprocessing", exchange="queue")
+        env._maybe_shutdown()
+        assert not any("default exchange" in str(w.message) for w in caught)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            env = AsyncEnvPool(make_envs, backend="threading")
+        env._maybe_shutdown()
+        assert not any("default exchange" in str(w.message) for w in caught)
+
+    def test_env_index_type_future_warning(self, make_envs):
+        with pytest.warns(FutureWarning, match="env_index"):
+            env = AsyncEnvPool(make_envs, backend="threading")
+        env._maybe_shutdown()
 
     @pytest.mark.parametrize("backend", ["multiprocessing", "threading"])
     def test_deadline_batch_validation(self, make_envs, backend):

--- a/test/envs/test_special.py
+++ b/test/envs/test_special.py
@@ -1134,11 +1134,6 @@ class TestAsyncEnvPool:
         env._maybe_shutdown()
         assert not any("default exchange" in str(w.message) for w in caught)
 
-    def test_env_index_type_future_warning(self, make_envs):
-        with pytest.warns(FutureWarning, match="env_index"):
-            env = AsyncEnvPool(make_envs, backend="threading")
-        env._maybe_shutdown()
-
     @pytest.mark.parametrize("backend", ["multiprocessing", "threading"])
     def test_deadline_batch_validation(self, make_envs, backend):
         env = AsyncEnvPool(make_envs, backend=backend)

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -432,6 +432,10 @@ class AsyncBatchedCollector(BaseCollector):
         self._env_pool = AsyncEnvPool(
             self._create_env_fn,
             backend=self._env_backend,
+            # Pinned to the current default so the pool's default-change
+            # FutureWarning is not emitted from library code; switching the
+            # collector to the shm exchange is a deliberate follow-up.
+            exchange="queue",
             **kwargs,
         )
 

--- a/torchrl/envs/_async_exchange.py
+++ b/torchrl/envs/_async_exchange.py
@@ -123,6 +123,16 @@ class _SharedSlotExchange:
                     "Shared slot exchange requires identical TensorDict keys across "
                     f"workers; worker {index} differs from worker 0."
                 )
+            # Leaves-only iteration silently skips non-tensor entries, so walk
+            # every key explicitly: a NonTensorData leaf must reject the
+            # exchange rather than end up in a shared slot.
+            for key in tensordict.keys(True):
+                value = tensordict.get(key)
+                if isinstance(value, (NonTensorData, NonTensorStack)):
+                    raise TypeError(
+                        "Shared slot exchange only supports tensor leaves, "
+                        f"got {type(value).__name__} at key {key!r}."
+                    )
             for key, value in tensordict.items(True, True):
                 if not isinstance(value, torch.Tensor):
                     raise TypeError(

--- a/torchrl/envs/async_envs.py
+++ b/torchrl/envs/async_envs.py
@@ -244,11 +244,6 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
                 "exchange='shm' is only supported with backend='multiprocessing'."
             )
         self.exchange = exchange
-        warnings.warn(
-            "The 'env_index' entries returned by AsyncEnvPool will change "
-            "from NonTensorData/NonTensorStack to torch.Tensor in v0.15.",
-            FutureWarning,
-        )
         if create_env_kwargs is None:
             create_env_kwargs = {}
         if isinstance(create_env_kwargs, Mapping):

--- a/torchrl/envs/async_envs.py
+++ b/torchrl/envs/async_envs.py
@@ -8,6 +8,7 @@ import abc
 import multiprocessing
 import queue
 import threading
+import warnings
 from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import as_completed, FIRST_COMPLETED, ThreadPoolExecutor, wait
 from multiprocessing import Queue
@@ -74,10 +75,19 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
             The backend to use for parallel execution. Defaults to `"threading"`.
         stack (Literal["dense", "maybe_dense", "lazy"], optional):
             The method to use for stacking environment outputs. Defaults to `"dense"`.
-        exchange (Literal["queue", "shm"], optional): Data exchange used by the
-            multiprocessing backend. ``"shm"`` stores fixed-shape tensor data in
-            shared slots and sends only readiness descriptors through queues.
-            Defaults to ``"queue"``.
+        exchange (Literal["queue", "shm", "auto"], optional): Data exchange
+            used by the multiprocessing backend. ``"shm"`` stores fixed-shape
+            tensor data in shared slots and sends only readiness descriptors
+            through queues; it requires identical, fixed-shape, CPU, tensor-only
+            schemas across workers. ``"auto"`` selects ``"shm"`` when the env
+            schema supports it and falls back to ``"queue"`` otherwise (the
+            resolution is reported by :attr:`resolved_exchange` and logged on
+            fallback). Defaults to ``"queue"``.
+
+            .. warning::
+                The default will change from ``"queue"`` to ``"auto"`` in
+                v0.15 for the multiprocessing backend. A ``FutureWarning`` is
+                emitted when the default is relied upon.
         create_env_kwargs (dict, optional):
             Keyword arguments to pass to the environment maker. Defaults to `{}`.
 
@@ -205,7 +215,7 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
         *,
         backend: Literal["threading", "multiprocessing", "asyncio"] = "threading",
         stack: Literal["dense", "maybe_dense", "lazy"] = "dense",
-        exchange: Literal["queue", "shm"] = "queue",
+        exchange: Literal["queue", "shm", "auto"] | None = None,
         create_env_kwargs: dict | list[dict] | None = None,
     ) -> None:
         if not isinstance(env_makers, Sequence):
@@ -214,13 +224,31 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
         self.env_makers = env_makers
         self.num_envs = len(env_makers)
         self.backend = backend
-        if exchange not in ("queue", "shm"):
-            raise ValueError(f"exchange must be 'queue' or 'shm', got {exchange!r}.")
-        if backend != "multiprocessing" and exchange != "queue":
+        if exchange is None:
+            if backend == "multiprocessing":
+                warnings.warn(
+                    "The default exchange of AsyncEnvPool with the "
+                    "multiprocessing backend will change from 'queue' to "
+                    "'auto' in v0.15. Pass exchange='queue' to keep the "
+                    "current behavior, or exchange='auto' to adopt the "
+                    "future default now.",
+                    FutureWarning,
+                )
+            exchange = "queue"
+        if exchange not in ("queue", "shm", "auto"):
+            raise ValueError(
+                f"exchange must be 'queue', 'shm' or 'auto', got {exchange!r}."
+            )
+        if backend != "multiprocessing" and exchange == "shm":
             raise ValueError(
                 "exchange='shm' is only supported with backend='multiprocessing'."
             )
         self.exchange = exchange
+        warnings.warn(
+            "The 'env_index' entries returned by AsyncEnvPool will change "
+            "from NonTensorData/NonTensorStack to torch.Tensor in v0.15.",
+            FutureWarning,
+        )
         if create_env_kwargs is None:
             create_env_kwargs = {}
         if isinstance(create_env_kwargs, Mapping):
@@ -568,6 +596,16 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
         """
         raise NotImplementedError
 
+    @property
+    def resolved_exchange(self) -> Literal["queue", "shm"]:
+        """The data exchange actually in use, after resolving ``exchange="auto"``.
+
+        ``"shm"`` when the shared-memory slot exchange is active, ``"queue"``
+        otherwise (including the threading backend, which has no shared-memory
+        exchange).
+        """
+        return "shm" if getattr(self, "_slot_exchange", None) is not None else "queue"
+
     def stats(self, *, reset: bool = False) -> dict[str, float | int]:
         """Return shared-memory exchange statistics.
 
@@ -675,17 +713,27 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
         output_spec = specs["output_spec"]
         input_spec = specs["input_spec"]
         self._slot_exchange = None
-        if self.exchange == "shm":
+        if self.exchange in ("shm", "auto"):
             for i in range(num_threads):
                 self.input_queue[i].put(("get_fake_tensordict", None))
             fake_tensordicts = [self.output_queue[i].get() for i in range(num_threads)]
-            self._slot_exchange = _SharedSlotExchange(fake_tensordicts)
-            for i in range(num_threads):
-                self.input_queue[i].put(
-                    ("init_shm", self._slot_exchange.worker_slots(i))
+            try:
+                self._slot_exchange = _SharedSlotExchange(fake_tensordicts)
+            except (TypeError, ValueError, RuntimeError) as err:
+                if self.exchange == "shm":
+                    raise
+                torchrl_logger.info(
+                    "AsyncEnvPool(exchange='auto'): the env schema does not "
+                    f"support the shared-memory exchange, falling back to "
+                    f"the queue exchange. Reason: {err}"
                 )
-            for i in range(num_threads):
-                self.output_queue[i].get()
+            if self._slot_exchange is not None:
+                for i in range(num_threads):
+                    self.input_queue[i].put(
+                        ("init_shm", self._slot_exchange.worker_slots(i))
+                    )
+                for i in range(num_threads):
+                    self.output_queue[i].get()
         return output_spec, input_spec
 
     def _get_child_specs(self) -> list:

--- a/torchrl/trainers/algorithms/configs/envs.py
+++ b/torchrl/trainers/algorithms/configs/envs.py
@@ -64,7 +64,7 @@ def make_batched_env(
     device: str | None = None,
     backend: Literal["threading", "multiprocessing", "asyncio"] = "threading",
     stack: Literal["dense", "maybe_dense", "lazy"] = "dense",
-    exchange: Literal["queue", "shm"] = "queue",
+    exchange: Literal["queue", "shm", "auto"] = "queue",
     **kwargs: Any,
 ) -> EnvBase:
     """Create a batched environment.
@@ -104,8 +104,10 @@ def make_batched_env(
         raise ValueError(
             "stack must be 'dense', 'maybe_dense', or 'lazy', " f"got {stack!r}."
         )
-    if exchange not in ("queue", "shm"):
-        raise ValueError(f"exchange must be 'queue' or 'shm', got {exchange!r}.")
+    if exchange not in ("queue", "shm", "auto"):
+        raise ValueError(
+            f"exchange must be 'queue', 'shm' or 'auto', got {exchange!r}."
+        )
 
     # If create_env_fn is a config object, create a lambda that instantiates it each time
     if isinstance(create_env_fn, EnvBase):


### PR DESCRIPTION
## Description

Deprecation step (1 of 2) for the AsyncEnvPool exchange default, following the two-release policy: warn in 0.14, flip in 0.15.

Rebased onto `main` after #4197 and #4198 merged. The stacked-composite lock fix remains required because the env schemas that `exchange="auto"` falls back for cannot otherwise construct a multiprocessing pool.

- Adds `exchange="auto"`: resolves to the shared-memory exchange when the backend is multiprocessing and the env schema supports it (identical, fixed-shape, CPU, tensor-only), and falls back to the queue exchange otherwise, logging the reason once. An explicit `exchange="shm"` still fails loudly when the schema does not validate. On the threading backend, `"auto"` resolves to `"queue"`.
- Adds the read-only `AsyncEnvPool.resolved_exchange` property reporting the exchange actually in use.
- Emits a `FutureWarning` when a multiprocessing pool is constructed without an explicit `exchange`: the default changes from `"queue"` to `"auto"` in v0.15. Passing `exchange=` explicitly silences it; Hydra users are unaffected because the config layer always passes the value through (its own default stays `"queue"` until 0.15).
- `torchrl.collectors._async_batched` now pins `exchange="queue"` explicitly so library-internal construction does not emit the user-facing warning.
- Config parity: `make_batched_env` and its validation accept `"auto"`.
- Fixes a validation gap in `_SharedSlotExchange._validate` that the fallback test exposed: leaves-only tensordict iteration silently skips `NonTensorData` entries, so an env with a non-tensor observation slipped past the tensor-leaves check, the exchange got built around it, and the `init_shm` handshake deadlocked—for explicit `exchange="shm"` too. Non-tensor leaves are now detected explicitly and reject the exchange with a clear `TypeError` (which is exactly what `"auto"` needs to fall back on).

The shm exchange is 5x cheaper on the consumer hot path than the queue exchange (measured in #4182: ~97 vs ~256 us of consumer dispatch cost per transition), so `"auto"` as the eventual default gives stock multiprocessing users the fast path out of the box without breaking envs with dynamic or non-tensor schemas.

## Motivation and Context

PR 4 of the AsyncEnvPool v2 sequence (#4061; benchmarks in #4182). Getting good out-of-the-box speed requires the fast path to become the default, and the two-release policy requires the warning to ship in 0.14 for the default to flip in 0.15.

- [x] I have raised an issue to propose this change (#4061)

## Types of changes

- [x] New feature (non-breaking change which adds core functionality)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
