### PR TITLE
[BugFix] Compile the mujoco-torch physics step with fullgraph=True by default

### DIFF
--- a/test/libs/test_mujoco.py
+++ b/test/libs/test_mujoco.py
@@ -1026,10 +1026,26 @@ class TestMujoco:
 
     @pytest.mark.skipif(not _has_mujoco_torch, reason="mujoco-torch not installed")
     def test_torch_backend_compile_smoke(self):
-        """``compile_step=True`` must not raise on the default backend."""
+        """``compile_step=True`` compiles the batched step as a single graph.
+
+        The backend compiles with ``fullgraph=True`` by default, so a graph
+        break raises here instead of silently splitting the step into eager
+        fragments.  The graph counter guards against recompiles across steps,
+        which would otherwise degrade into an eager fallback once Dynamo's
+        recompile limit is hit.
+        """
+        import torch._dynamo
+        import torch._dynamo.utils
+
+        torch._dynamo.reset()
+        torch._dynamo.utils.counters.clear()
         env = HopperEnv(num_envs=2, seed=0, compile_step=True)
         td = env.rollout(3)
         assert torch.isfinite(td.get(("next", "reward"))).all()
+        unique_graphs = torch._dynamo.utils.counters["stats"].get("unique_graphs")
+        assert (
+            unique_graphs == 1
+        ), f"expected a single compiled graph, got {unique_graphs}"
 
     def test_unknown_backend_raises(self):
         with pytest.raises(ValueError, match="unknown backend"):

--- a/torchrl/envs/custom/mujoco/_backends.py
+++ b/torchrl/envs/custom/mujoco/_backends.py
@@ -320,8 +320,14 @@ class _TorchBackend(_PhysicsBackend):
         # keep the frame_skip loop in Python. Compiling the unrolled loop
         # blows up the graph (50x more nodes), which sends inductor's
         # fusion analysis into multi-hour territory on CUDA backends.
+        #
+        # ``fullgraph=True`` by default: a graph break inside ``vmap(step)``
+        # would otherwise be papered over by splitting the step into eager
+        # fragments (and, once the recompile limit is hit, by falling back
+        # to eager entirely), silently discarding the compiled path.
         if self._compile_step:
-            base_compiled = torch.compile(base, **self._compile_kwargs)
+            compile_kwargs = {"fullgraph": True, **self._compile_kwargs}
+            base_compiled = torch.compile(base, **compile_kwargs)
 
             def _multi_step(d, frame_skip: int):
                 for _ in range(frame_skip):

--- a/torchrl/envs/custom/mujoco/base.py
+++ b/torchrl/envs/custom/mujoco/base.py
@@ -211,6 +211,9 @@ class MujocoEnv(EnvBase, abc.ABC, metaclass=_MujocoMeta):
         compile_step: when ``backend="mujoco-torch"``, wrap the per-env
             physics step in :func:`torch.compile`. Ignored otherwise.
         compile_kwargs: forwarded to :func:`torch.compile` when applicable.
+            ``fullgraph=True`` is used unless overridden, so a graph break in
+            the physics step raises instead of silently falling back to eager
+            fragments.
         from_pixels: if ``True``, include a ``"pixels"`` observation rendered
             from MuJoCo at reset and after every step.
         pixels_only: if ``True``, return only the ``"pixels"`` observation.


### PR DESCRIPTION
## Summary

`_TorchBackend._build_step_fn` wrapped `torch.vmap(mujoco_torch.step)` in `torch.compile` without `fullgraph`. On torch nightly a graph break inside the batched step was papered over by splitting it into eager fragments, and once Dynamo's recompile limit was hit the whole step silently fell back to eager, so `compile_step=True` gave no speed-up and hid the underlying tracing bug (fixed on the mujoco-torch side in vmoens/mujoco-torch: scan cache keys and `cholesky_ex`).

## Changes

- `_TorchBackend._build_step_fn`: compile with `fullgraph=True` by default, still overridable through `compile_kwargs`.
- `MujocoEnv` docstring: document the default.
- `test_torch_backend_compile_smoke`: reset Dynamo, and assert the batched Hopper step compiles into exactly one graph across the rollout (a recompile would otherwise degrade into an eager fallback).

## Tested

- `pytest test/libs/test_mujoco.py -k test_torch_backend_compile_smoke` passes with torch `2.15.0.dev20260901`, tensordict main, mujoco-torch with the companion fix (47 s on CPU, single graph).
- `HopperEnv(num_envs=1|2, backend="mujoco-torch", compile_step=True).rollout(3)` completes with one graph.
- 8-env MicroDuck (`MicroDuckVelocityEnv`, `frame_skip=4`) with `compile_step=True`: two full 500-step episode batches after compile; warm throughput 180–193 transitions/s vs 44 eager on CPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
