### PR TITLE
[Feature] rlrender live env kwargs and a bundled Node runtime for the MuJoCo WASM viewer

### DIFF
--- a/docs/source/reference/render.rst
+++ b/docs/source/reference/render.rst
@@ -27,8 +27,10 @@ thin: reusable display, playback, rollout, and acknowledgement helpers live in
 TorchRL rather than being copied into each notebook.
 
 The MuJoCo WASM viewer requires Node.js and either ``npm`` or ``pnpm``. The
-viewer installs the generated Vite project's pinned JavaScript dependencies
-when ``node_modules`` is absent, which requires network access. The generated
+optional ``mujoco_wasm`` extra (``pip install torchrl[mujoco_wasm]``) bundles a
+Node.js runtime through ``nodejs-wheel`` for machines without one. The viewer
+installs the generated Vite project's pinned JavaScript dependencies when
+``node_modules`` is absent, which requires network access. The generated
 ``node_modules`` directory is reused when present.
 
 Factories can be addressed as ``module.submodule:callable`` or as a local file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,8 @@ notebook = ["jupyterlab"]
 # recent torch), so the extra is empty on older interpreters
 vla = ["lerobot>=0.5.0; python_version >= '3.12'", "torchvision>=0.17"]
 rendering = ["moviepy", "pygame", "pyyaml", "torchcodec>=0.10.0"]
+# Node.js runtime for the MuJoCo WASM viewer on machines without a system Node.
+mujoco_wasm = ["nodejs-wheel"]
 tests = [
     "pytest",
     "pyyaml",

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -8,6 +8,7 @@ import argparse
 import hashlib
 import importlib.util
 import json
+import os
 import socket
 from pathlib import Path
 from types import SimpleNamespace
@@ -906,6 +907,42 @@ class TestMujocoWasm:
             )
         assert process.terminated is True
         assert display_module.objects == []
+
+    def test_vite_finds_node_bundled_with_package_manager(self, monkeypatch, tmp_path):
+        dependencies = tmp_path / "dependencies"
+        manager = dependencies / "bin" / "fallback" / "pnpm"
+        node = (
+            dependencies / "node" / "bin" / ("node.exe" if os.name == "nt" else "node")
+        )
+        manager.parent.mkdir(parents=True)
+        node.parent.mkdir(parents=True)
+        manager.write_text("#!/bin/sh\n")
+        node.write_text("#!/bin/sh\n")
+        manager.chmod(0o755)
+        node.chmod(0o755)
+
+        def which(command, path=None):
+            if command == "node":
+                return None
+            if command == "pnpm":
+                return str(manager)
+            raise AssertionError(f"Unexpected executable lookup: {command}")
+
+        calls = []
+        monkeypatch.setattr(mujoco_wasm_module.shutil, "which", which)
+        monkeypatch.setattr(
+            mujoco_wasm_module.subprocess,
+            "Popen",
+            lambda command, cwd, env: calls.append((command, cwd, env))
+            or FakeProcess(),
+        )
+
+        mujoco_wasm_module._start_vite("pnpm", tmp_path, "127.0.0.1", 5178)
+
+        command, cwd, env = calls[0]
+        assert command[:3] == ["pnpm", "exec", "vite"]
+        assert cwd == tmp_path
+        assert env["PATH"].split(os.pathsep)[0] == str(node.parent)
 
     def test_play_mujoco_wasm_trajectory_autoplay_writes_public_asset(
         self, monkeypatch, tmp_path

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -19,7 +19,6 @@ import torchrl.render as render_module
 import torchrl.render.artifacts as artifacts_module
 import torchrl.render.mujoco_wasm as mujoco_wasm_module
 from tensordict import TensorDict
-
 from torchrl.checkpoint import Checkpoint
 from torchrl.data import Composite, Unbounded
 from torchrl.envs import EnvBase, ObservationNorm, set_gym_backend, StepCounter, VecNorm
@@ -699,7 +698,7 @@ class TestRenderNotebook:
         notebook = json.loads(result.artifact_path.read_text(encoding="utf-8"))
         source = "\n".join("".join(cell["source"]) for cell in notebook["cells"])
         assert "collect_rollouts_in_notebook" in source
-        assert "live_result = collect_rollouts_in_notebook()" in source
+        assert "env_kwargs=live_env_kwargs" in source
         assert not (tmp_path / "live_report" / "rollouts").exists()
         metadata = json.loads((tmp_path / "live_report" / "metadata.json").read_text())
         assert metadata["num_trajs"] == 0
@@ -722,6 +721,7 @@ class TestRenderNotebook:
 
         def fake_make_env(config, *, checkpoint=None):
             calls["env_checkpoint"] = checkpoint
+            calls["env_kwargs"] = dict(config.env_kwargs)
             return fake_env
 
         def fake_make_policy(
@@ -749,9 +749,15 @@ class TestRenderNotebook:
             if "collect_rollouts_in_notebook" in "".join(cell["source"])
             and cell["cell_type"] == "code"
         )
-        exec("".join(live_cell["source"]), {"cfg": config})
+        namespace = {"cfg": config}
+        exec("".join(live_cell["source"]), namespace)
+        namespace["collect_rollouts_in_notebook"](
+            env_kwargs={"commanded_x_velocity": -0.3}
+        )
+        assert config.env_kwargs == {}
         assert calls == {
             "env_checkpoint": checkpoint,
+            "env_kwargs": {"commanded_x_velocity": -0.3},
             "policy_checkpoint": checkpoint,
             "checkpoint_digest": "digest",
             "closed": True,

--- a/torchrl/render/mujoco_wasm.py
+++ b/torchrl/render/mujoco_wasm.py
@@ -9,6 +9,7 @@ import importlib
 import importlib.util
 import json
 import math
+import os
 import shutil
 import socket
 import subprocess
@@ -21,7 +22,6 @@ from typing import Any
 
 import torch
 from tensordict import NestedKey, TensorDictBase
-
 from torchrl.render.config import parse_nested_key
 
 _has_ipython = importlib.util.find_spec("IPython") is not None
@@ -470,7 +470,35 @@ def _start_vite(
             str(port),
             "--strictPort",
         ]
-    return subprocess.Popen(command, cwd=viewer_dir)
+    return subprocess.Popen(
+        command,
+        cwd=viewer_dir,
+        env=_package_manager_runtime_env(manager),
+    )
+
+
+def _package_manager_runtime_env(manager: str) -> dict[str, str] | None:
+    """Expose a Node runtime bundled next to a standalone package manager."""
+    if shutil.which("node") is not None:
+        return None
+    manager_path = shutil.which(manager)
+    if manager_path is None:
+        return None
+    manager_path = Path(manager_path).resolve()
+    for parent in list(manager_path.parents)[:4]:
+        for executable in ("node", "node.exe"):
+            for candidate in (
+                parent / executable,
+                parent / "bin" / executable,
+                parent / "node" / "bin" / executable,
+            ):
+                if candidate.is_file() and os.access(candidate, os.X_OK):
+                    env = os.environ.copy()
+                    env["PATH"] = os.pathsep.join(
+                        (str(candidate.parent), env.get("PATH", ""))
+                    )
+                    return env
+    return None
 
 
 def _wait_for_viewer_server(

--- a/torchrl/render/mujoco_wasm.py
+++ b/torchrl/render/mujoco_wasm.py
@@ -435,8 +435,10 @@ def _find_package_manager() -> str:
         if shutil.which(candidate) is not None:
             return candidate
     raise RuntimeError(
-        "MuJoCo WASM viewer startup requires pnpm or npm on PATH. "
-        "Call write_mujoco_wasm_viewer() and serve the viewer manually if needed."
+        "MuJoCo WASM viewer startup requires Node.js and pnpm or npm on PATH. "
+        "Install Node.js, or install the `mujoco_wasm` extra "
+        "(`pip install torchrl[mujoco_wasm]`, or `uv run --extra mujoco_wasm`) "
+        "to get a bundled runtime."
     )
 
 

--- a/torchrl/render/notebook.py
+++ b/torchrl/render/notebook.py
@@ -203,9 +203,11 @@ def _live_rollout_cells() -> list[dict[str, Any]]:
             "Run this cell to generate trajectories from the checkpoint. "
             "It constructs the configured environment and policy inside the kernel, "
             "collects rollouts, and replaces the `rollouts` variable used by the "
-            "playback cells below."
+            "playback cells below. Edit `live_env_kwargs` before collecting to "
+            "change environment inputs without regenerating the notebook."
         ),
         _code_cell(
+            "from dataclasses import replace\n\n"
             "from torchrl.render import (\n"
             "    checkpoint_hash,\n"
             "    collect_render_rollouts,\n"
@@ -213,8 +215,12 @@ def _live_rollout_cells() -> list[dict[str, Any]]:
             "    load_render_policy,\n"
             "    make_render_env,\n"
             ")\n\n"
-            "def collect_rollouts_in_notebook(config=None):\n"
+            "def collect_rollouts_in_notebook(config=None, *, env_kwargs=None):\n"
             "    config = cfg if config is None else config\n"
+            "    if env_kwargs is not None:\n"
+            "        config = replace(\n"
+            "            config, env_kwargs={**config.env_kwargs, **env_kwargs}\n"
+            "        )\n"
             "    checkpoint = load_checkpoint(\n"
             "        config.ckpt, map_location=config.policy_device or config.device\n"
             "    )\n"
@@ -228,8 +234,17 @@ def _live_rollout_cells() -> list[dict[str, Any]]:
             "    finally:\n"
             "        close = getattr(env, 'close', None)\n"
             "        if callable(close):\n"
-            "            close()\n\n"
-            "live_result = collect_rollouts_in_notebook()\n"
+            "            close()"
+        ),
+        _code_cell(
+            "# Edit these values before collecting another rollout.\n"
+            "live_env_kwargs = dict(cfg.env_kwargs)\n"
+            "live_env_kwargs"
+        ),
+        _code_cell(
+            "live_result = collect_rollouts_in_notebook(\n"
+            "    env_kwargs=live_env_kwargs\n"
+            ")\n"
             "rollouts = live_result.trajectories\n"
             "live_result.metadata"
         ),


### PR DESCRIPTION
## Description

Three small, independent improvements to `torchrl.render`, split out of #4191:

- Generated rlrender notebooks expose a `live_env_kwargs` cell that is merged into the render config before the in-kernel rollout, so environment inputs (for example a velocity command) can change without regenerating the notebook.
- When `node` is not on `PATH` but `pnpm`/`npm` is, the MuJoCo WASM viewer looks for a Node runtime installed next to the package manager and exposes it to the Vite process.
- A new opt-in `mujoco_wasm` extra ships a Node runtime through `nodejs-wheel`. It is deliberately not added to the shared `rendering` extra so video-export users do not download Node.

## Motivation and Context

Part of the MicroDuck stack: #4183 -> this PR -> MicroDuckEnv -> MicroDuck examples. Supersedes the render changes in #4191.

## Types of changes

- [x] New feature (non-breaking change which adds core functionality)
- [x] Documentation (update in the documentation)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.

## Validation

- `pytest test/test_render.py -k "TestMujocoWasm or TestRenderNotebook"` passes locally.
- Pinned `ufmt`, `flake8`, `pydocstyle`, `codespell` and the docstring-args script pass on the changed files.

Generated with [Claude Code](https://claude.com/claude-code)