### PR TITLE
[Doc] Spell out the TorchRL contracts in the agent guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,13 @@
 House rules for LLM contributions to TorchRL. Sits on top of `CONTRIBUTING.md`;
 this file wins on conflicts. Read end-to-end before editing.
 
+The overarching rule: **stay within TorchRL's contracts.** When a task can be
+expressed with an existing component (a `TensorDictModule`, `env.rollout`, a
+transform, a collector, a replay buffer, a logger), use it. Do not write a
+bespoke loop, container or helper that re-implements what the library already
+does. A reviewer who has to read a hand-rolled stepping loop or a list of
+dataclasses of floats will send the PR back.
+
 ## 1. Imports
 
 - Module-top imports only. No function/method-level imports. Two exceptions:
@@ -15,7 +22,7 @@ this file wins on conflicts. Read end-to-end before editing.
 ## 2. Cross-version compatibility
 
 Use `torchrl.implement_for` (from `pyvers`) for version dispatch on torch / gym /
-gymnasium / etc. No hand-rolled `if torch.__version__ >= …` branches.
+gymnasium / etc. No hand-rolled `if torch.__version__ >= ...` branches.
 
 ## 3. Logging, printing, timing
 
@@ -23,17 +30,37 @@ gymnasium / etc. No hand-rolled `if torch.__version__ >= …` branches.
   (also `torchrl.torchrl_logger`).
 - Timing: `torchrl.timeit`, never `time.time()` blocks.
 
-## 4. TensorDict-first
+## 4. TensorDict-first, TorchRL contracts everywhere
 
 - New modules / transforms / losses / collectors / RB components accept and
   return `TensorDict` / `TensorDictBase`. No parallel dict-like containers.
 - New objectives expose tensordict keys via `_AcceptedKeys` + `set_keys()`,
   matching existing losses.
+- **Policies are `TensorDictModule`s** (`TensorDictModule`,
+  `TensorDictModuleBase`, `ProbabilisticActor`, ...). Configuration goes into
+  the constructor and `in_keys` / `out_keys` are declared on the module. A
+  bare callable or a module-level function that computes an action is not a
+  policy, in the library or in an example.
+- **Rollouts are `env.rollout(policy=...)`** or a collector. No hand-written
+  `reset` / `step` loops. Whatever is needed along the way (logging, extra
+  observations, bookkeeping) is an env transform or an observation the env
+  exposes; metrics are computed afterwards from the returned tensordict.
+- **Aggregate with tensordict.** Stack per-episode or per-seed results into a
+  `TensorDict` and reduce with `.mean(dim)`, `.min(dim)`,
+  `.apply(fn, named=True)` and friends. Do not carry lists of dicts or
+  dataclasses of floats and reduce them with comprehensions.
+- **Env constructors are not kwarg soups.** Asset and simulator arguments
+  (paths, backend, device, batch size) stay on the constructor. Task
+  parameters (commands, reset distribution, reward weights, observation
+  options) go into one config dataclass, with classmethods on the env that
+  return presets (`MyEnv.some_task(...)`) so tasks have names. The built-in
+  reward must be switchable off so a transform can supply another one.
 
 ## 5. Type hints & annotations
 
 - Public signatures carry type hints. Hints must be accurate (not enforced by
-  mypy, but wrong hints are worse than none).
+  mypy, but wrong hints are worse than none), and must agree with the types
+  stated in the docstring.
 - **Prefer `NestedKey` over `str`** for tensordict keys, unless the value
   genuinely cannot be a `tensordict.NestedKey`.
 - **Use `Literal[...]`** for any fixed set of string values (e.g.
@@ -52,44 +79,46 @@ Strongly encouraged (not mandatory):
 ### 6a. Module device state
 
 - **Do not define or assign `self.device` on an `nn.Module`**, or cache an
-  equivalent single-device attribute. `module.to(...)`, `.cuda()`, and
-  `_apply(...)` move parameters and buffers, not arbitrary Python state, so a
-  cached device becomes stale. A module may also legitimately span several
-  devices under pipeline parallelism, tensor parallelism, FSDP, or manual
-  placement, in which case no single module device exists.
-- Derive placement from the specific input, parameter, or buffer involved in
-  an operation. Prefer device-preserving constructors such as `tensor.new_*`
-  or pass `device=tensor.device` explicitly. Do not infer a device for the
-  whole module from its first parameter.
+  equivalent single-device attribute. `module.to(...)`, `.cuda()` and
+  `_apply(...)` move parameters and buffers, not Python state, so a cached
+  device goes stale; and a module may span several devices (pipeline or
+  tensor parallelism, FSDP, manual placement), in which case no single module
+  device exists.
+- Derive placement from the specific input, parameter or buffer involved in an
+  operation (`tensor.new_*`, `device=tensor.device`). Do not infer a device
+  for the whole module from its first parameter.
 - Register persistent tensor state as a parameter or buffer so normal module
   transforms move it. A constructor may accept `device` to place initial
-  state, but must not retain that argument as module state.
-- Do not work around this rule by overriding `to()` or `_apply()` merely to
-  synchronize a device cache; that still encodes an invalid single-device
-  assumption and is brittle under sharding and composition.
+  state, but must not retain it as module state.
+- Do not work around this by overriding `to()` or `_apply()` to synchronize a
+  device cache; that still encodes an invalid single-device assumption.
 
 ## 7. Tests
 
 - Every new public class / function needs tests.
-- **Do not create new test files** when an existing one covers the area —
+- **Do not create new test files** when an existing one covers the area --
   extend it. Exception: a brand-new objective gets `test/test_<algo>.py`.
 - If your module accepts a `NestedKey` input, add a test exercising a nested
   key (not just a flat string).
-- Test files should end with an `if __name__ == "__main__":` block that invokes
+- Test files end with an `if __name__ == "__main__":` block that invokes
   `pytest.main(...)`, so the file can be executed directly.
 - New algorithms: also tested in the sota-implementations CI.
+- **Keep the volume proportionate.** One test per behavior, not one per
+  attribute; several hundred lines of tests for one class is a signal to
+  consolidate. Assert through the public API; tests that read or mutate
+  private attributes lock in the implementation instead of the behavior.
 
 ### 7a. Behavioral regression tests
 
 - **Test the bug fix, not its implementation.** A regression test must assert
   the behavior that was broken and fail if the bug is reintroduced.
 - **Use mocks and monkeypatching sparingly.** A test that only proves an
-  internal method was called is incomplete. For example, for a retry bug, make
-  the dependency fail once and then succeed, and assert that the operation
+  internal method was called is incomplete. For a retry bug, make the
+  dependency fail once and then succeed, and assert that the operation
   returns the expected result; do not only mock `_retry()` and assert that it
   was called.
 - Prefer small deterministic inputs and expected results derived independently
-  from the code under test. Shape, finiteness, key-presence, and no-exception
+  from the code under test. Shape, finiteness, key-presence and no-exception
   checks are not enough unless they are the behavior being fixed.
 - Parametrize only when cases exercise distinguishable behavior. Every
   parameter must reach the code under test and affect an assertion.
@@ -97,22 +126,16 @@ Strongly encouraged (not mandatory):
 ### 7b. The `gpu` marker (load-bearing!)
 
 The unified Linux CI (`.github/workflows/test-linux.yml`) collects tests with
-**two mutually-exclusive marker filters**:
-
-- `tests-cpu*` jobs run with `-m 'not gpu'`.
-- `tests-gpu*` and `tests-stable-gpu*` jobs run with `-m gpu`.
+**two mutually-exclusive marker filters**: `tests-cpu*` jobs run with
+`-m 'not gpu'`, `tests-gpu*` and `tests-stable-gpu*` jobs run with `-m gpu`.
 
 Any test gated by `@pytest.mark.skipif(not torch.cuda.is_available(), ...)`,
 `@pytest.mark.skipif(not torch.cuda.device_count(), ...)`, the project's
 `_has_triton` / `_has_cuda` flags, or any other CUDA-only requirement
-**must** also carry `@pytest.mark.gpu`. Otherwise:
-
-- On CPU runners the `skipif` skips it.
-- On GPU runners the `-m gpu` filter deselects it before collection.
-- Net result: the test never runs in CI and silently rots — the exact
-  failure mode that let the triton RNN recurrent-matmul bug ship.
-
-The convention is:
+**must** also carry `@pytest.mark.gpu`. Otherwise the CPU runners skip it,
+the GPU runners deselect it before collection, and the test never runs in CI
+and silently rots -- the exact failure mode that let the triton RNN
+recurrent-matmul bug ship.
 
 ```python
 @pytest.mark.gpu
@@ -121,39 +144,29 @@ def test_something_cuda_specific():
     ...
 ```
 
-Apply the marker at whatever scope is appropriate (function, class, or
-module via `pytestmark = pytest.mark.gpu`). Order doesn't matter; both
-decorators are required.
-
-**Exceptions**: dedicated GPU-runner workflows that pin a specific test
-file or `-k` filter (e.g. `unittests-torch_geometric`,
-`unittests-isaaclab`) do not use the `-m gpu` filter and therefore do not
-strictly need the marker. Adding it anyway is harmless and recommended
-for consistency.
-
-**Do not add `@pytest.mark.gpu`** to tests that meaningfully exercise both
-CPU and GPU paths via parametrization (e.g.
-`device = "cpu" if torch.cuda.device_count() == 0 else "cuda"`); those
-must continue to run on the CPU side.
+Apply the marker at whatever scope is appropriate (function, class, or module
+via `pytestmark = pytest.mark.gpu`); both decorators are required, in any
+order. Dedicated GPU-runner workflows that pin a test file or `-k` filter
+(e.g. `unittests-torch_geometric`, `unittests-isaaclab`) do not use the
+`-m gpu` filter, so the marker is optional but recommended there. **Do not
+add `@pytest.mark.gpu`** to tests that meaningfully exercise both CPU and GPU
+paths via parametrization (e.g. `device = "cpu" if torch.cuda.device_count()
+== 0 else "cuda"`); those must keep running on the CPU side.
 
 ### 7c. PR-gated CI suites: `ci/olddeps` and `ci/optdeps` labels
 
-Two expensive suites in `.github/workflows/test-linux.yml` do NOT run on
-pull requests by default. They run fully on every push to main and on the
-nightly orchestrator, so breakage still surfaces there -- but a PR that
-needs their signal must opt in via a label:
+Two expensive suites in `.github/workflows/test-linux.yml` do NOT run on pull
+requests by default; they run on every push to main and on the nightly
+orchestrator. A PR that needs their signal opts in via a label:
 
-- **`ci/olddeps`** runs `tests-olddeps` (oldest supported stable torch,
-  cu118, gym 0.13). Add this label whenever your change uses a torch API
-  that was added recently (anything you would only find in the current
-  stable/nightly torch, e.g. a new `torch.*` function, kwarg, or behavior
-  flag). If in doubt whether the oldest supported torch has it, add the
-  label. Without it, an incompatibility lands on main and only fails
-  post-merge.
-- **`ci/optdeps`** runs the full `tests-optdeps` suite (~2h). Add it when
-  your change touches optional-dependency integrations or their import
-  paths. PRs otherwise get `tests-optdeps-smoke`, which only builds the
-  optional-deps environment and checks imports.
+- **`ci/olddeps`** runs `tests-olddeps` (oldest supported stable torch, cu118,
+  gym 0.13). Add it whenever your change uses a torch API added recently (a
+  new `torch.*` function, kwarg or behavior flag). If in doubt whether the
+  oldest supported torch has it, add the label.
+- **`ci/optdeps`** runs the full `tests-optdeps` suite (~2h). Add it when your
+  change touches optional-dependency integrations or their import paths. PRs
+  otherwise get `tests-optdeps-smoke`, which only builds the environment and
+  checks imports.
 
 Adding a label does NOT retrigger CI: apply the label first, then push a
 commit or re-run the workflow so the gate sees it.
@@ -161,13 +174,23 @@ commit or re-run the workflow so the gate sees it.
 ## 8. Documentation
 
 - Every new public class / function referenced in `docs/source/reference/*.rst`.
-- Sphinx-style docstrings (`Args:`, `Returns:`, `Examples:`) with a runnable
-  `>>> …` example for every new public class.
+- Sphinx-style docstrings. Positional parameters go under `Args:`,
+  keyword-only ones under `Keyword Args:`. **Every entry states its type** in
+  parentheses (`(float or Sequence[float], optional)`), its default, and what
+  the value does. For a sequence or a mapping, say how it is consumed: sampled
+  at every reset or fixed, whether duplicates matter, whether a tensordict
+  entry can override it. A reader must not have to open the code to learn
+  whether a float or a tuple is expected.
+- **`Examples:` show real usage** a reader would copy: constructing the object,
+  then what makes it interesting -- batching and devices, switching backends
+  or compiling, setting a task, rendering, reading the outputs. A single
+  `env.rollout(10)` placeholder does not count. Mark lines that need assets or
+  hardware with `# doctest: +SKIP`; everything else must run.
 - Paper references: include the arXiv link + short citation in the class
   docstring.
-- No emojis anywhere — code, docstrings, comments, commits, PR bodies.
+- No emojis anywhere -- code, docstrings, comments, commits, PR bodies.
 
-## 9. Tutorials
+## 9. Tutorials and examples
 
 New "headline" features (algorithm family, collector, env wrapper) ship a
 tutorial under `tutorials/` (or extend an existing one). Sphinx-first:
@@ -175,6 +198,16 @@ tutorial under `tutorials/` (or extend an existing one). Sphinx-first:
 - `# prose comments` for explanation, **not** `print(...)`.
 - Include "What you will learn", "Conclusion", "Further reading" sections
   (names can be rephrased), mirroring existing tutos.
+
+Scripts under `examples/` and `sota-implementations/` are read as reference
+code and are held to rule 4 with extra force:
+
+- A few TorchRL components wired together, not a framework. Every function
+  and class must justify its existence; if a docstring cannot say in one
+  sentence why a reader wants it, remove it. Configuration lives on the policy
+  and env constructors, not in extra dataclasses.
+- **Do not commit notebooks (`.ipynb`), checkpoints, videos or datasets.**
+  Document the command that generates them (e.g. `rlrender ... --format ipynb`).
 
 ## 10. Benchmarks
 
@@ -210,12 +243,12 @@ in `0.(X+2)`.
 [Test] [Versioning]
 ```
 
-Pick the most specific. No squash requirement on commits — just make each
+Pick the most specific. No squash requirement on commits -- just make each
 commit read sensibly on its own.
 
 ## 14. Config / class parity
 
-Some classes (Trainers, losses, RB components, transforms, …) have a Hydra
+Some classes (Trainers, losses, RB components, transforms, ...) have a Hydra
 `*Config` dataclass companion under `torchrl/trainers/algorithms/configs/`.
 
 - **Parity.** Every kwarg of the wrapped class's `__init__` must appear as a


### PR DESCRIPTION
## Description

Folds the lessons from the MicroDuck reviews (#4204, #4205) into `CLAUDE.md` (which `AGENTS.md` links to), so every agent works within the library's contracts:

- an opening rule: stay within TorchRL's contracts instead of writing bespoke loops, containers or helpers;
- section 4: policies are `TensorDictModule`s configured in the constructor; rollouts go through `env.rollout` or a collector with transforms for anything in between; results are aggregated with tensordict reductions; env constructors keep task parameters in a config object with classmethod presets and let the built-in reward be switched off;
- section 7: keep test volume proportionate and assert through the public API;
- section 8: `Args` versus `Keyword Args`, a type on every entry with the semantics of sequence arguments, and `Examples` that show real usage (scaling, backends, tasks, rendering) rather than a placeholder rollout;
- section 9: examples are lean reference code; no notebooks, checkpoints, videos or datasets in git.

Sections 6a, 7b and 7c are tightened without changing their meaning; numbering is unchanged.

## Types of changes

- [x] Documentation (update in the documentation)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
