### PR TITLE
[BugFix] Seed batched native MuJoCo workers distinctly

### DIFF
--- a/test/libs/test_mujoco.py
+++ b/test/libs/test_mujoco.py
@@ -129,6 +129,20 @@ class TestMujoco:
         assert torch.equal(state["qpos"], qpos)
         env.close()
 
+    @pytest.mark.skipif(not _has_mujoco, reason="MuJoCo is not installed")
+    @pytest.mark.parametrize("parallel", [False, True])
+    def test_native_batched_workers_draw_distinct_reset_noise(self, parallel):
+        # Workers built from one seed used to replay the same reset noise.
+        env = HopperEnv(num_envs=2, seed=0, backend="mujoco", parallel=parallel)
+        twin = HopperEnv(num_envs=2, seed=0, backend="mujoco", parallel=parallel)
+        try:
+            observation = env.reset()["observation"]
+            assert not torch.equal(observation[0], observation[1])
+            torch.testing.assert_close(observation, twin.reset()["observation"])
+        finally:
+            env.close()
+            twin.close()
+
     @pytest.mark.skipif(not _has_mujoco_torch, reason="mujoco-torch not installed")
     def test_torch_backend_rollout_partial_reset(self):
         env = HopperEnv(

--- a/torchrl/envs/custom/mujoco/base.py
+++ b/torchrl/envs/custom/mujoco/base.py
@@ -22,6 +22,7 @@ from typing import Any, ClassVar, Literal
 import numpy as np
 import torch
 from tensordict import TensorDict, TensorDictBase
+from torchrl._utils import seed_generator
 from torchrl.data.tensor_specs import Binary, Bounded, Composite, Unbounded
 from torchrl.envs.common import _EnvPostInit, EnvBase
 from torchrl.envs.custom.mujoco._backends import (
@@ -155,14 +156,23 @@ class _MujocoMeta(_EnvPostInit):
                 inner_kwargs = dict(kwargs)
                 inner_kwargs["num_envs"] = 1
 
-                def _factory(_args=args, _kwargs=inner_kwargs):
+                def _factory(_args=args, _kwargs=inner_kwargs, **worker_kwargs):
                     # Re-enters this metaclass with N=1 -> falls through.
-                    return cls(*_args, **_kwargs)
+                    return cls(*_args, **{**_kwargs, **worker_kwargs})
 
+                # Chain one seed per worker, as EnvBase.set_seed does across a
+                # batch, so workers draw distinct reset noise from one seed.
+                seed = kwargs.get("seed")
+                worker_kwargs = []
+                for _ in range(n):
+                    worker_kwargs.append({} if seed is None else {"seed": seed})
+                    seed = None if seed is None else seed_generator(seed)
                 parallel_kwargs = (
                     {"metadata_from_workers": True} if wrap_cls is ParallelEnv else {}
                 )
-                return wrap_cls(n, _factory, **parallel_kwargs)
+                return wrap_cls(
+                    n, _factory, create_env_kwargs=worker_kwargs, **parallel_kwargs
+                )
             # Single env: pass through.
             return super().__call__(*args, **kwargs)
 


### PR DESCRIPTION
## Description

`MujocoEnv(num_envs=N, seed=s, backend="mujoco")` builds one worker per env through `_MujocoMeta` from the same kwargs, so every `SerialEnv` / `ParallelEnv` worker was seeded with `s` and replayed the same reset noise (and, for `MicroDuckEnv`, the same velocity command at every reset). Each worker now receives its own seed through `create_env_kwargs`, derived from the requested seed with `torchrl._utils.seed_generator` (the same chain `EnvBase.set_seed` walks across a batch), so the batch stays reproducible for a given seed and a later `set_seed` produces the same assignment. `seed=None` was unaffected.

Found while writing the `MicroDuckTask` docstring example in #4204: four envs built with `seed=0` all drew the same command.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).

## Validation

`test_native_batched_workers_draw_distinct_reset_noise` (serial and parallel) asserts that two workers built from one seed reset to different observations and that two envs built from the same seed reset identically; it fails on `main` and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

