### PR TITLE
[BugFix] Fix V-trace advantage bootstrap at truncated steps

### DIFF
--- a/test/objectives/test_values.py
+++ b/test/objectives/test_values.py
@@ -1858,24 +1858,16 @@ class TestValues:
         torch.testing.assert_close(r1, r2, rtol=1e-4, atol=1e-4)
 
     @pytest.mark.parametrize("device", get_default_devices())
-    @pytest.mark.parametrize("gamma", [0.99, 0.5])
-    @pytest.mark.parametrize("dtype", [torch.float, torch.double])
-    def test_vtrace_truncated_matches_split_trajectories(self, device, gamma, dtype):
-        # A truncated (done & ~terminated) step must bootstrap its advantage from
-        # its own next value, not from the v-trace target of the next trajectory.
-        torch.manual_seed(0)
-        T, t_trunc = 6, 3
-        done = torch.zeros(T, 1, device=device, dtype=torch.bool)
-        done[t_trunc - 1] = True
+    def test_vtrace_truncated_uses_next_value(self, device):
+        done = torch.tensor([[False], [True], [False], [False]], device=device)
         terminated = torch.zeros_like(done)
-        reward, state_value, next_state_value = torch.randn(
-            3, T, 1, device=device, dtype=dtype
-        )
-        log_pi = torch.rand(T, 1, device=device, dtype=dtype).log()
-        log_mu = torch.rand(T, 1, device=device, dtype=dtype).log()
+        reward = torch.zeros(4, 1, device=device)
+        state_value = torch.tensor([[1.0], [1.0], [100.0], [100.0]], device=device)
+        next_state_value = state_value.clone()
+        log_pi = log_mu = torch.zeros_like(state_value)
 
-        adv, vs = vtrace_advantage_estimate(
-            gamma,
+        advantage, _ = vtrace_advantage_estimate(
+            1.0,
             log_pi,
             log_mu,
             state_value,
@@ -1884,23 +1876,7 @@ class TestValues:
             done=done,
             terminated=terminated,
         )
-        adv_split, vs_split = zip(
-            *(
-                vtrace_advantage_estimate(
-                    gamma,
-                    log_pi[s],
-                    log_mu[s],
-                    state_value[s],
-                    next_state_value[s],
-                    reward[s],
-                    done=done[s],
-                    terminated=terminated[s],
-                )
-                for s in (slice(None, t_trunc), slice(t_trunc, None))
-            )
-        )
-        torch.testing.assert_close(vs, torch.cat(vs_split))
-        torch.testing.assert_close(adv, torch.cat(adv_split))
+        torch.testing.assert_close(advantage, torch.zeros_like(advantage))
 
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("gamma", [0.5, 0.99, 0.1])

--- a/test/objectives/test_values.py
+++ b/test/objectives/test_values.py
@@ -1858,6 +1858,51 @@ class TestValues:
         torch.testing.assert_close(r1, r2, rtol=1e-4, atol=1e-4)
 
     @pytest.mark.parametrize("device", get_default_devices())
+    @pytest.mark.parametrize("gamma", [0.99, 0.5])
+    @pytest.mark.parametrize("dtype", [torch.float, torch.double])
+    def test_vtrace_truncated_matches_split_trajectories(self, device, gamma, dtype):
+        # A truncated (done & ~terminated) step must bootstrap its advantage from
+        # its own next value, not from the v-trace target of the next trajectory.
+        torch.manual_seed(0)
+        T, t_trunc = 6, 3
+        done = torch.zeros(T, 1, device=device, dtype=torch.bool)
+        done[t_trunc - 1] = True
+        terminated = torch.zeros_like(done)
+        reward, state_value, next_state_value = torch.randn(
+            3, T, 1, device=device, dtype=dtype
+        )
+        log_pi = torch.rand(T, 1, device=device, dtype=dtype).log()
+        log_mu = torch.rand(T, 1, device=device, dtype=dtype).log()
+
+        adv, vs = vtrace_advantage_estimate(
+            gamma,
+            log_pi,
+            log_mu,
+            state_value,
+            next_state_value,
+            reward,
+            done=done,
+            terminated=terminated,
+        )
+        adv_split, vs_split = zip(
+            *(
+                vtrace_advantage_estimate(
+                    gamma,
+                    log_pi[s],
+                    log_mu[s],
+                    state_value[s],
+                    next_state_value[s],
+                    reward[s],
+                    done=done[s],
+                    terminated=terminated[s],
+                )
+                for s in (slice(None, t_trunc), slice(t_trunc, None))
+            )
+        )
+        torch.testing.assert_close(vs, torch.cat(vs_split))
+        torch.testing.assert_close(adv, torch.cat(adv_split))
+
+    @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("gamma", [0.5, 0.99, 0.1])
     @pytest.mark.parametrize("lmbda", [0.1, 0.5, 0.99])
     @pytest.mark.parametrize("N", [(3,), (7, 3)])

--- a/torchrl/objectives/value/functional.py
+++ b/torchrl/objectives/value/functional.py
@@ -1370,6 +1370,9 @@ def vtrace_advantage_estimate(
     vs_t_plus_1 = torch.cat(
         [vs[..., 1:, :], next_state_value[..., -1:, :]], dim=time_dim
     )
+    # at a trajectory boundary (done), the next entry along time belongs to
+    # another trajectory: bootstrap from the true next value instead
+    vs_t_plus_1 = torch.where(done, next_state_value, vs_t_plus_1)
     advantages = clipped_rho * (
         reward + terminated_discounts * vs_t_plus_1 - state_value
     )


### PR DESCRIPTION
## Description

`vtrace_advantage_estimate` computes the IMPALA advantage `rho_s (r_s + gamma v_{s+1} - V(x_s))` with `v_{s+1}` taken as the v-trace target shifted one step along time, using `next_state_value` only for the final step of the batch. When a batch holds several trajectories concatenated along time, the shifted entry at an intermediate `done` step is the v-trace target of the *first step of the next trajectory*. For a truncated step (`done & ~terminated`) the discount is `gamma`, so the next episode's value estimate leaks into the advantage. The `vs` recursion already cuts at `done`, so `value_target` was correct; only the advantage at in-batch truncations was wrong.

The fix uses `next_state_value` wherever `done` is set (`torch.where(done, next_state_value, vs_t_plus_1)`), which is what the function already does for the batch's last step and what GAE does at every truncation. Terminal steps are unaffected (their discount is already zero).

Minimal repro (two trajectories, V_A = 1, V_B = 100, r = 0, gamma = 1, on-policy): the advantage at the truncated step was `99.0` (= 0 + 100 - 1) instead of `0.0`.

Test: `test_vtrace_truncated_matches_split_trajectories` checks that the advantage and value target over a batch with an in-batch truncation equal the concatenation of the results computed on each trajectory separately. It fails on main (mismatch exactly at the truncated step) and passes with the fix; the existing `-k vtrace` selection in `test_values.py` still passes (224 → 228), the whole `test_values.py` file passes (2324 passed, 5 skipped), and `test_ppo.py -k vtrace` passes (98 passed).

## Motivation and Context

`VTrace` passes `("next", "done")` and `("next", "terminated")` separately, so any IMPALA / PPO-with-VTrace run whose rollouts contain time-limit truncations (gym `TimeLimit`, `StepCounter`, `max_frames_per_traj`) was training on advantages contaminated by the following episode's value at each truncation.

Fixes #4209

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vZKTbRaDh8FuXSbVpQomD
