### PR TITLE
[BE] Source mujoco-torch from main and torch nightly on every macOS Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,8 +80,9 @@ explicit = true
 
 [tool.uv.sources]
 tensordict = { git = "https://github.com/pytorch/tensordict" }
-torch = { index = "pytorch-nightly", marker = "sys_platform == 'darwin' and python_version != '3.12'" }
-torchvision = { index = "pytorch-nightly", marker = "sys_platform == 'darwin' and python_version != '3.12'" }
+mujoco-torch = { git = "https://github.com/vmoens/mujoco-torch" }
+torch = { index = "pytorch-nightly", marker = "sys_platform == 'darwin'" }
+torchvision = { index = "pytorch-nightly", marker = "sys_platform == 'darwin'" }
 
 [[tool.uv.dependency-metadata]]
 name = "lerobot"


### PR DESCRIPTION
## Description

Two `[tool.uv.sources]` changes so a synced environment follows the heads we develop against:

- `mujoco-torch` is sourced from `https://github.com/vmoens/mujoco-torch` (main), like `tensordict` already is. The PyPI release 0.2.0 mirrors MuJoCo enums at import time and fails against the locked mujoco 3.11 (`mjENBL_MULTICCD`), which broke every `backend="mujoco-torch"` env, including the default of `MujocoEnv`.
- The torch and torchvision nightly index now applies to every Python on macOS. The `python_version != '3.12'` exclusion is stale: `torch==2.15.0.dev20260903` resolves for CPython 3.12 on arm64.

`uv.lock` is not tracked in this repository; a `uv lock` after this change resolves mujoco-torch at 707ef67 and torch nightly for macOS 3.12.

## Types of changes

- [x] Build / environment

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
