### PR TITLE
[Feature] PPO-EWMA: decouple the proximal policy from the behavior policy

### DIFF
--- a/.github/unittest/linux/scripts/run_all.sh
+++ b/.github/unittest/linux/scripts/run_all.sh
@@ -132,6 +132,7 @@ uv_pip_install \
   "huggingface-hub>=1.5.0,<2.0" \
   wandb \
   mlflow \
+  "sqlalchemy<2.1" \
   av \
   coverage \
   transformers \

--- a/docs/source/reference/objectives_policy.rst
+++ b/docs/source/reference/objectives_policy.rst
@@ -14,3 +14,36 @@ Loss modules for policy gradient algorithms.
     KLPENPPOLoss
     A2CLoss
     ReinforceLoss
+
+Decoupled proximal policy (PPO-EWMA)
+------------------------------------
+
+PPO uses the policy that collected the data (the ``sample_log_prob`` entry)
+for two distinct purposes: as the denominator of the importance-sampling
+ratio, and as the reference the trust region (clipping or KL penalty) pulls
+the updated policy towards. `Hilton et al. (2021)
+<https://arxiv.org/abs/2110.00641>`_ observe that only the first role requires
+the *behavior* policy; the second can use any recent *proximal* policy.
+
+Passing ``delay_actor=True`` to :class:`ClipPPOLoss` or :class:`KLPENPPOLoss`
+keeps a detached copy of the actor parameters under
+``target_actor_network_params`` and uses it as the proximal policy: the ratio
+being clipped (or the KL reference) becomes ``pi_theta / pi_prox`` and the
+surrogate is re-weighted by ``pi_prox / pi_behav`` so that the gradient
+estimate stays unbiased for the data at hand. Stepping a
+:class:`~torchrl.objectives.SoftUpdate` after every optimizer step turns the
+proximal policy into an exponentially-weighted moving average of the policy,
+which is PPO-EWMA; a :class:`~torchrl.objectives.HardUpdate` freezes it for a
+fixed number of steps instead. ``max_importance_ratio`` caps the behavior
+ratio for numerical stability with stale data. This decouples the strength of
+the trust region from how, and how recently, the data was collected.
+
+    >>> loss_module = ClipPPOLoss(actor, critic, delay_actor=True, max_importance_ratio=100.0)
+    >>> updater = SoftUpdate(loss_module, eps=0.889)  # eps is the EWMA decay rate beta_prox
+    >>> for batch in replay_buffer:
+    ...     losses = loss_module(batch)
+    ...     loss = losses["loss_objective"] + losses["loss_critic"] + losses["loss_entropy"]
+    ...     loss.backward()
+    ...     optimizer.step()
+    ...     optimizer.zero_grad()
+    ...     updater.step()

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -519,6 +519,7 @@ def main(cfg: DictConfig):
         if cfg.optimization.train_ratio is not None
         else None
     )
+
     def train_step(
         sample: TensorDictBase,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:

--- a/test/objectives/test_ppo.py
+++ b/test/objectives/test_ppo.py
@@ -20,7 +20,7 @@ from _objectives_common import (
     MARLEnv,
 )
 
-from tensordict import assert_allclose_td, TensorDict
+from tensordict import assert_allclose_td, is_tensor_collection, TensorDict
 from tensordict.nn import (
     composite_lp_aggregate,
     CompositeDistribution,
@@ -48,7 +48,14 @@ from torchrl.modules.tensordict_module.actors import (
     ValueOperator,
 )
 from torchrl.modules.value_norm import PercentileValueNorm
-from torchrl.objectives import A2CLoss, ClipPPOLoss, KLAdaptiveLR, KLPENPPOLoss, PPOLoss
+from torchrl.objectives import (
+    A2CLoss,
+    ClipPPOLoss,
+    KLAdaptiveLR,
+    KLPENPPOLoss,
+    PPOLoss,
+    SoftUpdate,
+)
 from torchrl.objectives.reinforce import ReinforceLoss
 from torchrl.objectives.utils import _sum_td_features, ValueEstimators
 from torchrl.objectives.value.advantages import (
@@ -1377,6 +1384,213 @@ class TestPPO(LossModuleTestBase):
             ClipPPOLoss(actor, value, clip_epsilon=(1.0, 0.2))
         with pytest.raises(ValueError, match="clip_value=True"):
             ClipPPOLoss(actor, value, clip_epsilon=(0.2, 0.28), clip_value=True)
+
+    @pytest.mark.parametrize("composite_action_dist", [False, True])
+    def test_ppo_decoupled_proximal_policy(self, composite_action_dist):
+        # delay_actor=True: the clipping acts on r = pi_theta / pi_prox, with
+        # pi_prox running on the target params, and the surrogate is
+        # re-weighted by pi_prox / pi_behav (decoupled clipped objective of
+        # Hilton et al. 2021, https://arxiv.org/abs/2110.00641)
+        torch.manual_seed(self.seed)
+        batch = 16
+        td = self._create_mock_data_ppo(
+            batch=batch, composite_action_dist=composite_action_dist
+        )
+        actor = self._create_mock_actor(composite_action_dist=composite_action_dist)
+        value = self._create_mock_value()
+        advantage = torch.randn(batch, 1)
+        td["advantage"] = advantage
+        td["value_target"] = torch.randn(batch, 1)
+        if composite_action_dist:
+            action = td.select(("action", "action1"))
+            lp_key = ("action", "action1_log_prob")
+        else:
+            action = td["action"]
+            lp_key = "action_log_prob"
+
+        def make_loss(**kwargs):
+            loss = ClipPPOLoss(
+                actor, value, clip_epsilon=0.2, entropy_bonus=False, **kwargs
+            )
+            if composite_action_dist:
+                loss.set_keys(action=("action", "action1"), sample_log_prob=[lp_key])
+            return loss
+
+        def log_prob_with(params):
+            with torch.no_grad(), params.to_module(actor, preserve_module_state=False):
+                lp = actor.get_dist(td.clone()).log_prob(action)
+            return _sum_td_features(lp) if is_tensor_collection(lp) else lp
+
+        def decoupled_objective(lp_cur, lp_prox, lp_behav):
+            ratio = (lp_cur - lp_prox).exp().unsqueeze(-1)
+            weight = (lp_prox - lp_behav).exp().unsqueeze(-1)
+            gain = torch.minimum(ratio * advantage, ratio.clamp(0.8, 1.2) * advantage)
+            return -(weight * gain).mean()
+
+        loss_fn = make_loss(delay_actor=True)
+        # only the actor gets a proximal copy
+        assert "target_actor_network_params" in dict(loss_fn.named_children())
+        assert "target_critic_network_params" not in dict(loss_fn.named_children())
+        updater = SoftUpdate(loss_fn, eps=0.5)
+        # move the policy away from the proximal snapshot taken at construction
+        with torch.no_grad():
+            for p in actor.parameters():
+                p.add_(0.5 * torch.randn_like(p))
+        lp_cur = log_prob_with(loss_fn.actor_network_params)
+        lp_prox = log_prob_with(loss_fn.target_actor_network_params)
+        assert not torch.allclose(lp_cur, lp_prox)
+
+        # proximal == behavior policy: the decoupled loss is the standard one
+        td[lp_key] = lp_prox
+        out = loss_fn(td.clone())
+        out_std = make_loss()(td.clone())
+        for key in (
+            "loss_objective",
+            "clip_fraction",
+            "ESS",
+            "kl_approx",
+            "max_ratio",
+            "mean_ratio",
+        ):
+            torch.testing.assert_close(out[key], out_std[key], msg=key)
+
+        # proximal != behavior policy: hand-computed decoupled objective
+        lp_behav = lp_prox - 0.3 * torch.randn(batch)
+        td[lp_key] = lp_behav
+        out = loss_fn(td.clone())
+        torch.testing.assert_close(
+            out["loss_objective"], decoupled_objective(lp_cur, lp_prox, lp_behav)
+        )
+        ratio = (lp_cur - lp_prox).exp()
+        torch.testing.assert_close(
+            out["clip_fraction"], ((ratio < 0.8) | (ratio > 1.2)).float().mean()
+        )
+        torch.testing.assert_close(out["kl_approx"], (lp_prox - lp_cur).mean())
+        # the ratio statistics describe the weights the data is multiplied by
+        torch.testing.assert_close(out["mean_ratio"], (lp_cur - lp_behav).exp().mean())
+
+        # stepping the updater moves the proximal policy and the loss follows
+        updater.step()
+        lp_prox_new = log_prob_with(loss_fn.target_actor_network_params)
+        assert not torch.allclose(lp_prox_new, lp_prox)
+        torch.testing.assert_close(
+            loss_fn(td.clone())["loss_objective"],
+            decoupled_objective(lp_cur, lp_prox_new, lp_behav),
+        )
+
+    def test_ppo_max_importance_ratio(self):
+        # the behavior ratio pi_theta / pi_behav is capped at max_importance_ratio
+        # by lifting the detached behavior log-prob: a capped sample keeps a
+        # policy gradient (scaled by the cap) rather than the zero gradient a
+        # clamp on the ratio would give
+        torch.manual_seed(self.seed)
+        batch = 4
+        td = self._create_mock_data_ppo(batch=batch)
+        actor = self._create_mock_actor()
+        value = self._create_mock_value()
+        td["value_target"] = torch.randn(batch, 1)
+        with torch.no_grad():
+            lp_orig = actor.get_dist(td.clone()).log_prob(td["action"])
+        td["action_log_prob"] = lp_orig - torch.tensor(10.0).log()  # ratio = 10
+        with pytest.raises(ValueError, match="max_importance_ratio"):
+            ClipPPOLoss(actor, value, max_importance_ratio=0.0)
+        loss_capped = ClipPPOLoss(
+            actor, value, entropy_bonus=False, max_importance_ratio=4.0
+        )
+        loss_plain = ClipPPOLoss(actor, value, entropy_bonus=False)
+        tol = {"rtol": 1e-4, "atol": 1e-4}
+
+        # negative advantage: the unclipped branch is selected
+        td["advantage"] = -torch.ones(batch, 1)
+        torch.testing.assert_close(
+            loss_plain(td.clone())["loss_objective"], torch.tensor(10.0), **tol
+        )
+        out = loss_capped(td.clone())
+        torch.testing.assert_close(out["loss_objective"], torch.tensor(4.0), **tol)
+        torch.testing.assert_close(out["max_ratio"], torch.tensor(4.0), **tol)
+        out["loss_objective"].backward()
+        assert any(
+            p.grad is not None and p.grad.abs().sum() > 0 for p in actor.parameters()
+        )
+        # positive advantage: the clipped branch is selected, 1.2 * 4 / 10
+        td["advantage"] = torch.ones(batch, 1)
+        torch.testing.assert_close(
+            loss_plain(td.clone())["loss_objective"], torch.tensor(-1.2), **tol
+        )
+        torch.testing.assert_close(
+            loss_capped(td.clone())["loss_objective"], torch.tensor(-0.48), **tol
+        )
+
+        # with a decoupled proximal policy the cap acts on the total ratio
+        # pi_theta / pi_behav = r * (pi_prox / pi_behav)
+        loss_dec = ClipPPOLoss(
+            actor,
+            value,
+            entropy_bonus=False,
+            delay_actor=True,
+            max_importance_ratio=4.0,
+        )
+        SoftUpdate(loss_dec, eps=0.9)
+        with torch.no_grad():
+            for p in actor.parameters():
+                p.add_(0.5 * torch.randn_like(p))
+            lp_cur = actor.get_dist(td.clone()).log_prob(td["action"])
+        advantage = torch.randn(batch, 1)
+        td["advantage"] = advantage
+        ratio = (lp_cur - lp_orig).exp().unsqueeze(-1)
+        weight = torch.minimum(torch.tensor(10.0), 4.0 / ratio)
+        gain = torch.minimum(
+            ratio * weight * advantage, ratio.clamp(0.8, 1.2) * weight * advantage
+        )
+        torch.testing.assert_close(
+            loss_dec(td.clone())["loss_objective"], -gain.mean(), **tol
+        )
+
+    def test_ppo_kl_pen_decoupled_proximal_policy(self):
+        # delay_actor=True: the KL penalty is measured against the proximal
+        # policy held in the target params rather than against the behavior
+        # distribution parameters stored in the data, while the surrogate keeps
+        # the behavior ratio pi_theta / pi_behav
+        torch.manual_seed(self.seed)
+        batch = 16
+        td = self._create_mock_data_ppo(batch=batch)
+        actor = self._create_mock_actor()
+        value = self._create_mock_value()
+        advantage = torch.randn(batch, 1)
+        td["advantage"] = advantage
+        td["value_target"] = torch.randn(batch, 1)
+        loss_fn = KLPENPPOLoss(
+            actor, value, entropy_bonus=False, beta=1.0, delay_actor=True
+        )
+        SoftUpdate(loss_fn, eps=0.9)
+        with torch.no_grad():
+            for p in actor.parameters():
+                p.add_(0.5 * torch.randn_like(p))
+            dist_cur = actor.get_dist(td.clone())
+            lp_cur = dist_cur.log_prob(td["action"])
+            with loss_fn.target_actor_network_params.to_module(
+                actor, preserve_module_state=False
+            ):
+                dist_prox = actor.get_dist(td.clone())
+            lp_prox = dist_prox.log_prob(td["action"])
+            kl = torch.distributions.kl.kl_divergence(dist_prox, dist_cur)
+        lp_behav = lp_prox - 0.3 * torch.randn(batch)
+        td["action_log_prob"] = lp_behav
+        # the behavior distribution parameters stored in the data are far off
+        # and must not enter the penalty
+        td["loc"] = td["loc"] + 100.0
+        out = loss_fn(td.clone())
+        torch.testing.assert_close(out["kl"], kl.unsqueeze(-1))
+        ratio_behav = (lp_cur - lp_behav).exp().unsqueeze(-1)
+        torch.testing.assert_close(
+            out["loss_objective"], -(ratio_behav * advantage - kl.unsqueeze(-1)).mean()
+        )
+
+    def test_ppo_delay_actor_requires_functional(self):
+        actor = self._create_mock_actor()
+        value = self._create_mock_value()
+        with pytest.raises(ValueError, match="functional=True"):
+            ClipPPOLoss(actor, value, delay_actor=True, functional=False)
 
     @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
     def test_ppo_flat_advantage_raises(self, loss_class):

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -1692,6 +1692,41 @@ class TestLossConfigs:
         elif loss_type == "kl":
             assert isinstance(loss, KLPENPPOLoss)
 
+    @pytest.mark.parametrize("loss_type", ["clip", "kl"])
+    @pytest.mark.skipif(not _has_gymnasium, reason="Gymnasium is not installed")
+    def test_ppo_loss_config_delay_actor(self, loss_type):
+        # the PPO-EWMA fields reach the loss: a proximal copy of the actor is
+        # created and the behavior-ratio cap is registered
+        from hydra.utils import instantiate
+        from torchrl.trainers.algorithms.configs.modules import (
+            MLPConfig,
+            TanhNormalModelConfig,
+            TensorDictModuleConfig,
+        )
+        from torchrl.trainers.algorithms.configs.objectives import PPOLossConfig
+
+        cfg = PPOLossConfig(
+            actor_network=TanhNormalModelConfig(
+                network=MLPConfig(
+                    in_features=10, out_features=10, depth=2, num_cells=32
+                ),
+                in_keys=["observation"],
+                out_keys=["action"],
+            ),
+            critic_network=TensorDictModuleConfig(
+                module=MLPConfig(in_features=10, out_features=1, depth=2, num_cells=32),
+                in_keys=["observation"],
+                out_keys=["state_value"],
+            ),
+            loss_type=loss_type,
+            delay_actor=True,
+            max_importance_ratio=100.0,
+        )
+        loss = instantiate(cfg)
+        assert loss.delay_actor
+        assert "target_actor_network_params" in dict(loss.named_children())
+        assert loss.max_importance_ratio == 100.0
+
     @pytest.mark.skipif(not _has_gymnasium, reason="Gymnasium is not installed")
     def test_dqn_loss_config(self):
         from torchrl.trainers.algorithms.configs.objectives import DQNLossConfig

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -217,6 +217,22 @@ class PPOLoss(LossModule):
             The purpose of clipping is to limit the impact of extreme value predictions, helping stabilize training
             and preventing large updates. However, it will have no impact if the value estimate was done by the current
             version of the value estimator. Defaults to ``None``.
+        delay_actor (bool, optional): if ``True``, a detached copy of the actor parameters is kept under
+            ``target_actor_network_params`` and used as the *proximal policy* of the objective, decoupled from
+            the *behavior policy* that collected the data (whose log-probabilities are read from the
+            ``sample_log_prob`` entry). The surrogate stays weighted by the behavior ratio ``pi_theta / pi_behav``
+            (so the gradient estimate remains unbiased for the data at hand) while the proximal policy is used
+            by the trust-region term of the subclasses (clipping in :class:`~torchrl.objectives.ClipPPOLoss`,
+            KL penalty in :class:`~torchrl.objectives.KLPENPPOLoss`) and by the ``kl_approx`` diagnostic.
+            Updating the target parameters with :class:`~torchrl.objectives.SoftUpdate` after every optimizer
+            step makes the proximal policy an exponentially-weighted moving average of the policy, i.e. PPO-EWMA
+            ("Batch size-invariance for policy optimization", Hilton et al., 2021,
+            https://arxiv.org/abs/2110.00641). Requires ``functional=True``. Defaults to ``False``.
+        max_importance_ratio (:obj:`float`, optional): if provided, the behavior ratio ``pi_theta / pi_behav`` is
+            capped at this value. Stale data, or a proximal policy that drifted away from the behavior policy,
+            can otherwise produce arbitrarily large ratios. The cap lifts the (gradient-free) behavior
+            log-probability rather than clamping the ratio, so capped samples keep a rescaled policy gradient,
+            as in the reference PPO-EWMA implementation (which uses ``100.0``). Defaults to ``None`` (no cap).
         device (torch.device, optional): device of the buffers. Defaults to ``None``.
 
             .. note:: Parameters and buffers from the policy / critic will not be cast to that device to ensure that
@@ -469,7 +485,9 @@ class PPOLoss(LossModule):
     default_keys = _AcceptedKeys
     tensor_keys: _AcceptedKeys
     default_value_estimator = ValueEstimators.GAE
-    _schedulable_buffers = frozenset({"entropy_coeff", "critic_coeff", "clip_value"})
+    _schedulable_buffers = frozenset(
+        {"entropy_coeff", "critic_coeff", "clip_value", "max_importance_ratio"}
+    )
 
     actor_network: ProbabilisticTensorDictModule
     critic_network: TensorDictModule
@@ -502,6 +520,8 @@ class PPOLoss(LossModule):
         critic: ProbabilisticTensorDictSequential = None,
         reduction: str | None = None,
         clip_value: float | None = None,
+        delay_actor: bool = False,
+        max_importance_ratio: float | None = None,
         device: torch.device | None = None,
         **kwargs,
     ):
@@ -537,11 +557,20 @@ class PPOLoss(LossModule):
         self._out_keys = None
         super().__init__()
         if functional:
-            self.convert_to_functional(actor_network, "actor_network")
+            self.convert_to_functional(
+                actor_network, "actor_network", create_target_params=delay_actor
+            )
+        elif delay_actor:
+            raise ValueError(
+                "delay_actor=True requires functional=True: the proximal policy is "
+                "held in target_actor_network_params, which only exists for "
+                "functionalized modules."
+            )
         else:
             self.actor_network = actor_network
             self.actor_network_params = None
             self.target_actor_network_params = None
+        self.delay_actor = delay_actor
 
         if separate_losses:
             # we want to make sure there are no duplicates in the params: the
@@ -614,6 +643,13 @@ class PPOLoss(LossModule):
         )
 
         self.register_coeff_buffer("clip_value", clip_value, device=device)
+        if max_importance_ratio is not None and max_importance_ratio <= 0:
+            raise ValueError(
+                f"max_importance_ratio must be > 0, got {max_importance_ratio}."
+            )
+        self.register_coeff_buffer(
+            "max_importance_ratio", max_importance_ratio, device=device
+        )
         try:
             log_prob_keys = self.actor_network.log_prob_keys
             action_keys = self.actor_network.dist_sample_keys
@@ -727,17 +763,21 @@ class PPOLoss(LossModule):
                 entropy.batch_size = adv_shape
         return entropy.unsqueeze(-1)
 
-    def _get_cur_log_prob(self, tensordict):
+    def _get_cur_log_prob(
+        self, tensordict: TensorDictBase, params: TensorDictParams | None = None
+    ):
+        # ``params`` selects the parameter set the actor runs with (the current
+        # parameters by default; the target parameters for the proximal policy).
         if isinstance(
             self.actor_network,
             (ProbabilisticTensorDictSequential, ProbabilisticTensorDictModule),
         ) or hasattr(self.actor_network, "get_dist"):
             # assert tensordict['log_probs'].requires_grad
             # assert tensordict['logits'].requires_grad
+            if params is None:
+                params = self.actor_network_params
             with (
-                self.actor_network_params.to_module(
-                    self.actor_network, preserve_module_state=False
-                )
+                params.to_module(self.actor_network, preserve_module_state=False)
                 if self.functional
                 else contextlib.nullcontext()
             ):
@@ -778,7 +818,16 @@ class PPOLoss(LossModule):
 
     def _log_weight(
         self, tensordict: TensorDictBase, adv_shape: torch.Size
-    ) -> tuple[torch.Tensor, d.Distribution, torch.Tensor]:
+    ) -> tuple[torch.Tensor, d.Distribution, torch.Tensor, torch.Tensor | None]:
+        # Returns
+        #   log_weight: log(pi_theta / pi_prox), the ratio the trust region acts on;
+        #   dist: the current policy distribution;
+        #   kl_approx: log(pi_prox / pi_theta), a diagnostic;
+        #   log_is_weight: log(pi_prox / pi_behav), the gradient-free correction
+        #       that turns log_weight into the behavior ratio
+        #       log(pi_theta / pi_behav) the surrogate must be weighted by.
+        #       ``None`` when the proximal policy is the behavior policy and no
+        #       ratio cap is set, in which case log_weight already is that ratio.
         prev_log_prob = _maybe_get_or_select(
             tensordict,
             self.tensor_keys.sample_log_prob,
@@ -794,6 +843,13 @@ class PPOLoss(LossModule):
             )
 
         log_prob, dist, is_composite = self._get_cur_log_prob(tensordict)
+        if self.delay_actor:
+            with torch.no_grad():
+                prox_log_prob, _, _ = self._get_cur_log_prob(
+                    tensordict, params=self.target_actor_network_params
+                )
+        else:
+            prox_log_prob = prev_log_prob
 
         if is_composite:
             with set_composite_lp_aggregate(False):
@@ -809,18 +865,42 @@ class PPOLoss(LossModule):
                     if is_tensor_collection(log_prob):
                         log_prob = _sum_td_features(log_prob)
                         log_prob.view_as(prev_log_prob)
-                if log_prob.batch_size != adv_shape:
+                    if is_tensor_collection(prox_log_prob):
+                        prox_log_prob = _sum_td_features(prox_log_prob)
+                if is_tensor_collection(log_prob) and log_prob.batch_size != adv_shape:
                     log_prob.batch_size = adv_shape
-        log_weight = (log_prob - prev_log_prob).unsqueeze(-1)
+                if (
+                    is_tensor_collection(prox_log_prob)
+                    and prox_log_prob.batch_size != adv_shape
+                ):
+                    prox_log_prob.batch_size = adv_shape
+        log_weight = (log_prob - prox_log_prob).unsqueeze(-1)
         if is_tensor_collection(log_weight):
             log_weight = _sum_td_features(log_weight)
             log_weight = log_weight.view(adv_shape).unsqueeze(-1)
 
-        kl_approx = (prev_log_prob - log_prob).unsqueeze(-1)
+        kl_approx = (prox_log_prob - log_prob).unsqueeze(-1)
         if is_tensor_collection(kl_approx):
             kl_approx = _sum_td_features(kl_approx)
 
-        return log_weight, dist, kl_approx
+        log_is_weight = None
+        if self.delay_actor:
+            log_is_weight = (prox_log_prob - prev_log_prob).unsqueeze(-1)
+            if is_tensor_collection(log_is_weight):
+                log_is_weight = _sum_td_features(log_is_weight)
+                log_is_weight = log_is_weight.view(adv_shape).unsqueeze(-1)
+        if self.max_importance_ratio is not None:
+            if log_is_weight is None:
+                log_is_weight = torch.zeros_like(log_weight)
+            # Cap pi_theta / pi_behav at max_importance_ratio by lifting the
+            # (gradient-free) behavior log-prob, as the reference PPO-EWMA
+            # implementation does: a capped sample keeps a rescaled policy
+            # gradient instead of the zero gradient a clamp on the ratio gives.
+            log_is_weight = torch.minimum(
+                log_is_weight, self.max_importance_ratio.log() - log_weight.detach()
+            )
+
+        return log_weight, dist, kl_approx, log_is_weight
 
     def _critic_loss_inputs(
         self,
@@ -1025,11 +1105,14 @@ class PPOLoss(LossModule):
             advantage, tensordict, update_norm=update_norm
         )
 
-        log_weight, dist, kl_approx = self._log_weight(
+        log_weight, dist, kl_approx, log_is_weight = self._log_weight(
             tensordict, adv_shape=advantage.shape[:-1]
         )
         advantage = _broadcast_advantage_to_log_weight(advantage, log_weight)
         _check_advantage_broadcast(advantage, log_weight)
+        if log_is_weight is not None:
+            # the surrogate is weighted by the behavior ratio pi_theta / pi_behav
+            log_weight = log_weight + log_is_weight
         neg_loss = log_weight.exp() * advantage
         td_out = TensorDict({"loss_objective": -neg_loss})
         td_out.set("kl_approx", kl_approx.detach().mean())  # for logging
@@ -1247,6 +1330,21 @@ class ClipPPOLoss(PPOLoss):
             ``clip_epsilon`` parameter will be used as the clipping threshold (this is only compatible with a
             scalar ``clip_epsilon``; with an asymmetric ``(low, high)`` tuple, pass an explicit float threshold
             instead). If not provided or ``False``, no clipping will be performed. Defaults to ``False``.
+        delay_actor (bool, optional): if ``True``, a detached copy of the actor parameters is kept under
+            ``target_actor_network_params`` and used as the *proximal policy*: the clipping acts on
+            ``pi_theta / pi_prox`` while the surrogate is re-weighted by ``pi_prox / pi_behav``, where
+            ``pi_behav`` is the *behavior policy* that collected the data (``sample_log_prob`` entry), so the
+            gradient estimate remains unbiased for the data at hand. This decouples the strength of the trust
+            region from how (and how recently) the data was collected. Updating the target parameters with
+            :class:`~torchrl.objectives.SoftUpdate` after every optimizer step makes the proximal policy an
+            exponentially-weighted moving average of the policy, i.e. PPO-EWMA ("Batch size-invariance for
+            policy optimization", Hilton et al., 2021, https://arxiv.org/abs/2110.00641); see the note below.
+            Requires ``functional=True``. Defaults to ``False``.
+        max_importance_ratio (:obj:`float`, optional): if provided, the behavior ratio ``pi_theta / pi_behav`` is
+            capped at this value. Stale data, or a proximal policy that drifted away from the behavior policy,
+            can otherwise produce arbitrarily large ratios. The cap lifts the (gradient-free) behavior
+            log-probability rather than clamping the ratio, so capped samples keep a rescaled policy gradient,
+            as in the reference PPO-EWMA implementation (which uses ``100.0``). Defaults to ``None`` (no cap).
         device (torch.device, optional): device of the buffers. Defaults to ``None``.
 
             .. note:: Parameters and buffers from the policy / critic will not be cast to that device to ensure that
@@ -1293,6 +1391,31 @@ class ClipPPOLoss(PPOLoss):
 
       This will work regardless of whether separate_losses is activated or not.
 
+    .. note::
+      **Decoupled proximal policy (PPO-EWMA).** With ``delay_actor=True`` the loss follows the decoupled
+      clipped objective of Hilton et al. (2021),
+
+          loss = -(pi_prox / pi_behav) * min(r * advantage, clip(r, 1 - eps, 1 + eps) * advantage),
+          r = pi_theta / pi_prox,
+
+      where ``pi_prox`` runs on ``target_actor_network_params``. Any :class:`~torchrl.objectives.TargetNetUpdater`
+      controls how old the proximal policy is: a :class:`~torchrl.objectives.SoftUpdate` stepped after every
+      optimizer step gives the EWMA of the paper (``eps`` being the decay rate ``beta_prox``), a
+      :class:`~torchrl.objectives.HardUpdate` refreshes it every ``value_network_update_interval`` steps.
+      ``clip_fraction`` and ``kl_approx`` then describe ``r``, the ratio the trust region acts on, whereas
+      ``ESS``, ``max_ratio`` and ``mean_ratio`` describe the behavior ratio ``pi_theta / pi_behav`` the data
+      is actually weighted by.
+
+        >>> loss_module = ClipPPOLoss(actor, critic, delay_actor=True, max_importance_ratio=100.0)
+        >>> updater = SoftUpdate(loss_module, eps=0.889)
+        >>> for batch in replay_buffer:
+        ...     losses = loss_module(batch)
+        ...     loss = losses["loss_objective"] + losses["loss_critic"] + losses["loss_entropy"]
+        ...     loss.backward()
+        ...     optimizer.step()
+        ...     optimizer.zero_grad()
+        ...     updater.step()
+
     """
 
     _schedulable_buffers = frozenset(
@@ -1324,6 +1447,8 @@ class ClipPPOLoss(PPOLoss):
         separate_losses: bool = False,
         reduction: str | None = None,
         clip_value: bool | float | None = None,
+        delay_actor: bool = False,
+        max_importance_ratio: float | None = None,
         device: torch.device | None = None,
         **kwargs,
     ):
@@ -1352,6 +1477,8 @@ class ClipPPOLoss(PPOLoss):
             separate_losses=separate_losses,
             reduction=reduction,
             clip_value=clip_value,
+            delay_actor=delay_actor,
+            max_importance_ratio=max_importance_ratio,
             device=device,
             **kwargs,
         )
@@ -1461,24 +1588,33 @@ class ClipPPOLoss(PPOLoss):
             advantage, tensordict, update_norm=update_norm
         )
 
-        log_weight, dist, kl_approx = self._log_weight(
+        log_weight, dist, kl_approx, log_is_weight = self._log_weight(
             tensordict, adv_shape=advantage.shape[:-1]
         )
         advantage = _broadcast_advantage_to_log_weight(advantage, log_weight)
         _check_advantage_broadcast(advantage, log_weight)
+        # log_weight is the ratio the clipping acts on (pi_theta / pi_prox); the
+        # surrogate itself is weighted by the behavior ratio
+        # pi_theta / pi_behav = exp(log_weight + log_is_weight). Both coincide
+        # when the proximal policy is the behavior policy (log_is_weight=None).
+        log_behav_weight = (
+            log_weight if log_is_weight is None else log_weight + log_is_weight
+        )
         # ESS for logging
         with torch.no_grad():
             # In theory, ESS should be computed on particles sampled from the same source. Here we sample according
             # to different, unrelated trajectories, which is not standard. Still, it can give an idea of the weights'
             # dispersion.
-            lw = log_weight.squeeze(-1)
+            lw = log_behav_weight.squeeze(-1)
             ess = (2 * lw.logsumexp(0) - (2 * lw).logsumexp(0)).exp()
             batch = log_weight.shape[0]
 
-        gain1 = log_weight.exp() * advantage
+        gain1 = log_behav_weight.exp() * advantage
 
         log_weight_clip = log_weight.clamp(*self._clip_bounds)
         clip_fraction = (log_weight_clip != log_weight).to(log_weight.dtype).mean()
+        if log_is_weight is not None:
+            log_weight_clip = log_weight_clip + log_is_weight
         ratio = log_weight_clip.exp()
         gain2 = ratio * advantage
 
@@ -1510,7 +1646,7 @@ class ClipPPOLoss(PPOLoss):
 
         td_out.set("ESS", ess / batch)
         with torch.no_grad():
-            ratio = log_weight.exp()
+            ratio = log_behav_weight.exp()
             td_out.set("max_ratio", ratio.max())
             td_out.set("mean_ratio", ratio.mean())
         td_out = td_out.named_apply(
@@ -1616,6 +1752,22 @@ class KLPENPPOLoss(PPOLoss):
             The purpose of clipping is to limit the impact of extreme value predictions, helping stabilize training
             and preventing large updates. However, it will have no impact if the value estimate was done by the current
             version of the value estimator. Defaults to ``None``.
+        delay_actor (bool, optional): if ``True``, a detached copy of the actor parameters is kept under
+            ``target_actor_network_params`` and used as the *proximal policy* of the objective, decoupled from
+            the *behavior policy* that collected the data (whose log-probabilities are read from the
+            ``sample_log_prob`` entry). The surrogate stays weighted by the behavior ratio ``pi_theta / pi_behav``
+            (so the gradient estimate remains unbiased for the data at hand) while the proximal policy is used
+            by the trust-region term of the subclasses (clipping in :class:`~torchrl.objectives.ClipPPOLoss`,
+            KL penalty in :class:`~torchrl.objectives.KLPENPPOLoss`) and by the ``kl_approx`` diagnostic.
+            Updating the target parameters with :class:`~torchrl.objectives.SoftUpdate` after every optimizer
+            step makes the proximal policy an exponentially-weighted moving average of the policy, i.e. PPO-EWMA
+            ("Batch size-invariance for policy optimization", Hilton et al., 2021,
+            https://arxiv.org/abs/2110.00641). Requires ``functional=True``. Defaults to ``False``.
+        max_importance_ratio (:obj:`float`, optional): if provided, the behavior ratio ``pi_theta / pi_behav`` is
+            capped at this value. Stale data, or a proximal policy that drifted away from the behavior policy,
+            can otherwise produce arbitrarily large ratios. The cap lifts the (gradient-free) behavior
+            log-probability rather than clamping the ratio, so capped samples keep a rescaled policy gradient,
+            as in the reference PPO-EWMA implementation (which uses ``100.0``). Defaults to ``None`` (no cap).
         device (torch.device, optional): device of the buffers. Defaults to ``None``.
 
             .. note:: Parameters and buffers from the policy / critic will not be cast to that device to ensure that
@@ -1695,6 +1847,8 @@ class KLPENPPOLoss(PPOLoss):
         separate_losses: bool = False,
         reduction: str | None = None,
         clip_value: float | None = None,
+        delay_actor: bool = False,
+        max_importance_ratio: float | None = None,
         device: torch.device | None = None,
         **kwargs,
     ):
@@ -1713,6 +1867,8 @@ class KLPENPPOLoss(PPOLoss):
             separate_losses=separate_losses,
             reduction=reduction,
             clip_value=clip_value,
+            delay_actor=delay_actor,
+            max_importance_ratio=max_importance_ratio,
             device=device,
             **kwargs,
         )
@@ -1791,13 +1947,22 @@ class KLPENPPOLoss(PPOLoss):
     @dispatch
     def forward(self, tensordict: TensorDictBase) -> TensorDict:
         tensordict_copy = tensordict.copy()
-        try:
-            previous_dist = self.actor_network.build_dist_from_params(tensordict)
-        except KeyError as err:
-            raise KeyError(
-                "The parameters of the distribution were not found. "
-                f"Make sure they are provided to {type(self).__name__}."
-            ) from err
+        if self.delay_actor:
+            # the KL penalty pulls the policy towards the proximal policy held
+            # in the target parameters, not towards the behavior policy whose
+            # distribution parameters are stored in the data
+            with torch.no_grad(), self.target_actor_network_params.to_module(
+                self.actor_network, preserve_module_state=False
+            ):
+                previous_dist = self.actor_network.get_dist(tensordict_copy)
+        else:
+            try:
+                previous_dist = self.actor_network.build_dist_from_params(tensordict)
+            except KeyError as err:
+                raise KeyError(
+                    "The parameters of the distribution were not found. "
+                    f"Make sure they are provided to {type(self).__name__}."
+                ) from err
         advantage = tensordict_copy.get(self.tensor_keys.advantage, None)
         update_norm = advantage is None
         if advantage is None:
@@ -1811,11 +1976,14 @@ class KLPENPPOLoss(PPOLoss):
             advantage, tensordict_copy, update_norm=update_norm
         )
 
-        log_weight, dist, kl_approx = self._log_weight(
+        log_weight, dist, kl_approx, log_is_weight = self._log_weight(
             tensordict_copy, adv_shape=advantage.shape[:-1]
         )
         advantage = _broadcast_advantage_to_log_weight(advantage, log_weight)
         _check_advantage_broadcast(advantage, log_weight)
+        if log_is_weight is not None:
+            # the surrogate is weighted by the behavior ratio pi_theta / pi_behav
+            log_weight = log_weight + log_is_weight
         neg_loss = log_weight.exp() * advantage
 
         with (

--- a/torchrl/trainers/algorithms/configs/objectives.py
+++ b/torchrl/trainers/algorithms/configs/objectives.py
@@ -166,6 +166,8 @@ class PPOLossConfig(LossConfig):
     critic: Any = None
     reduction: str | None = None
     clip_value: float | None = None
+    delay_actor: bool = False
+    max_importance_ratio: float | None = None
     # float for symmetric clipping or a (low, high) pair for DAPO-style
     # asymmetric clipping (ClipPPOLoss only)
     clip_epsilon: Any = 0.2


### PR DESCRIPTION
## Description

Implements the decoupled PPO objectives of [Batch size-invariance for policy optimization](https://arxiv.org/abs/2110.00641) (Hilton, Cobbe, Schulman, 2021; reference code: [openai/ppo-ewma](https://github.com/openai/ppo-ewma)).

PPO uses the policy that collected the data for two distinct purposes: as the denominator of the importance-sampling ratio, and as the reference the trust region (clipping or KL penalty) pulls the updated policy towards. Only the first role requires the *behavior* policy; the second can use any recent *proximal* policy. Decoupling them orthogonalizes inference (data collection) from training: the strength of the trust region no longer depends on how, or how recently, the data was collected.

### What changes

- `PPOLoss` / `ClipPPOLoss` / `KLPENPPOLoss` gain `delay_actor: bool = False`. When set, a detached copy of the actor parameters is created under `target_actor_network_params` (the standard TorchRL target-network machinery, `create_target_params=True`) and used as the proximal policy:
  - `ClipPPOLoss`: `loss = -(pi_prox / pi_behav) * min(r * A, clip(r, 1 - eps, 1 + eps) * A)` with `r = pi_theta / pi_prox`, i.e. the decoupled clipped objective (Section 2 of the paper).
  - `KLPENPPOLoss`: the surrogate keeps the behavior ratio `pi_theta / pi_behav` while the KL penalty is measured against the proximal policy.
  - Any `TargetNetUpdater` controls the age of the proximal policy. A `SoftUpdate(loss, eps=beta_prox)` stepped after every optimizer step gives the EWMA of the paper (PPO-EWMA); a `HardUpdate` freezes it for a fixed number of steps.
- New `max_importance_ratio: float | None = None` caps the behavior ratio `pi_theta / pi_behav`. As in the reference implementation the cap lifts the detached behavior log-prob rather than clamping the ratio, so capped samples keep a rescaled policy gradient instead of a zero one. Available for all three losses (useful on its own with stale/async data).
- Diagnostics: with a decoupled proximal policy, `clip_fraction` and `kl_approx` describe `r` (the ratio the trust region acts on) while `ESS`, `max_ratio` and `mean_ratio` describe the behavior ratio the data is actually weighted by. With the defaults everything is bit-identical to before.
- `_log_weight` now returns a fourth element, the (gradient-free) log importance correction, `None` in the default configuration.
- Docs: kwarg docstrings for the three losses, a PPO-EWMA note with a usage snippet on `ClipPPOLoss`, and a "Decoupled proximal policy (PPO-EWMA)" section in `objectives_policy.rst`.

### Usage

```python
loss_module = ClipPPOLoss(actor, critic, delay_actor=True, max_importance_ratio=100.0)
updater = SoftUpdate(loss_module, eps=0.889)  # eps is the EWMA decay rate beta_prox
for batch in replay_buffer:
    losses = loss_module(batch)
    (losses["loss_objective"] + losses["loss_critic"] + losses["loss_entropy"]).backward()
    optimizer.step()
    optimizer.zero_grad()
    updater.step()
```

`MAPPOLoss` / `IPPOLoss` inherit the feature through `ClipPPOLoss`.

### Tests

New tests in `test/objectives/test_ppo.py`:

- `test_ppo_decoupled_proximal_policy` (flat and composite action distributions): the decoupled loss reduces to the standard `ClipPPOLoss` when the proximal policy equals the behavior policy; matches the hand-computed decoupled objective, clip fraction, `kl_approx` and ratio statistics when it does not; and follows the proximal policy after a `SoftUpdate.step()`.
- `test_ppo_max_importance_ratio`: exact values of both `min()` branches with and without the cap, the capped sample keeps a non-zero policy gradient, and the cap acts on the total ratio with a decoupled proximal policy.
- `test_ppo_kl_pen_decoupled_proximal_policy`: the KL is measured against the target-parameter policy (the behavior distribution parameters stored in the data are ignored) while the surrogate keeps the behavior ratio.
- `test_ppo_delay_actor_requires_functional`.

The full `test/objectives/test_ppo.py` and `test/objectives/test_mappo.py` pass locally.

### Follow-up

A stacked PR adds the Hydra config fields (`PPOLossConfig.delay_actor` / `max_importance_ratio`, `PPOTrainerConfig.target_net_updater`) and the `OnPolicyTrainer` wiring so PPO-EWMA can be run from the trainer.

### Update: CI hygiene commits

Two small commits ride along so the stack gets a green CI: the `ufmt` reformat of `sota-implementations/dreamer_v3/train.py` (the Lint workflow is red on `main` for this file) and a `sqlalchemy<2.1` pin in `.github/unittest/linux/scripts/run_all.sh` (uv resolved the pre-release `2.1.0b3`, which breaks the MLflow logger fixtures in the `mp` partition). The remaining red jobs, `unittests-gym` (Atari ROM download 403) and a triton tolerance flake in `test_dreamer_components.py`, are environmental.

Generated with [Claude Code](https://claude.com/claude-code)

