### PR TITLE
[Feature] PPO-EWMA: trainer wiring and Hydra configs

### DIFF
--- a/sota-implementations/ppo_trainer/config/config.yaml
+++ b/sota-implementations/ppo_trainer/config/config.yaml
@@ -53,6 +53,12 @@ models:
     # Pendulum-v1 accepts torques in [-2, 2]; TanhNormal defaults to [-1, 1]
     low: -2.0
     high: 2.0
+    # floor on the policy std: without it the std collapses after ~300k
+    # frames and the log-prob ratios overflow to NaN
+    scale_lb: 0.1
+    # bound the location too: an unbounded loc saturates the tanh and the
+    # log-probability of actions at the bound overflows
+    tanh_loc: true
 
   value_model:
     in_keys: ["observation"]
@@ -88,11 +94,11 @@ training_env:
 loss:
   actor_network: ${models.policy_model}
   critic_network: ${models.value_model}
-  entropy_coeff: 0.01
+  entropy_coeff: 1.0e-4
 
 # Optimizer configuration
 optimizer:
-  lr: 0.001
+  lr: 3.0e-4
 
 # Collector configuration
 collector:
@@ -114,7 +120,7 @@ replay_buffer:
     shuffle: true
   writer:
     compilable: false
-  batch_size: 128
+  batch_size: 64
 
 logger:
   exp_name: ppo_pendulum_v1
@@ -129,14 +135,14 @@ trainer:
   total_frames: 1_000_000
   frame_skip: 1
   clip_grad_norm: true
-  clip_norm: 100.0
+  clip_norm: 1.0
   progress_bar: true
   seed: 42
   save_trainer_interval: 100
   log_interval: 100
   save_trainer_file: null
   optim_steps_per_batch: null
-  num_epochs: 2
+  num_epochs: 10
   async_collection: false
   # the multi-process collector syncs weights through weight-sync schemes;
   # map its "policy" destination to the trainer's actor

--- a/sota-implementations/ppo_trainer/config/config.yaml
+++ b/sota-implementations/ppo_trainer/config/config.yaml
@@ -50,6 +50,9 @@ models:
     param_keys: ["loc", "scale"]
     out_keys: ["action"]
     network: ${networks.policy_network}
+    # Pendulum-v1 accepts torques in [-2, 2]; TanhNormal defaults to [-1, 1]
+    low: -2.0
+    high: 2.0
 
   value_model:
     in_keys: ["observation"]

--- a/sota-implementations/ppo_trainer/config/config.yaml
+++ b/sota-implementations/ppo_trainer/config/config.yaml
@@ -135,6 +135,10 @@ trainer:
   optim_steps_per_batch: null
   num_epochs: 2
   async_collection: false
+  # the multi-process collector syncs weights through weight-sync schemes;
+  # map its "policy" destination to the trainer's actor
+  weight_update_map:
+    policy: loss_module.actor_network
 
 hydra:
   job:

--- a/sota-implementations/ppo_trainer/config/config.yaml
+++ b/sota-implementations/ppo_trainer/config/config.yaml
@@ -115,8 +115,6 @@ replay_buffer:
 
 logger:
   exp_name: ppo_pendulum_v1
-  offline: false
-  project: torchrl-sota-implementations
 
 # Trainer configuration
 trainer:

--- a/sota-implementations/ppo_trainer/config/config_ewma.yaml
+++ b/sota-implementations/ppo_trainer/config/config_ewma.yaml
@@ -18,8 +18,12 @@ loss:
   max_importance_ratio: 100.0
 
 target_net_updater:
-  # EWMA decay rate of the proximal policy (beta_prox in the paper)
-  eps: 0.889
+  # EWMA decay rate of the proximal policy (beta_prox in the paper). The paper
+  # sets 1 / (1 - eps) - 1, the center of mass of the average in optimizer
+  # steps, to about one epoch of minibatches; with 10 epochs of 16 minibatches
+  # a center of mass of two epochs (32 steps, eps 0.97) trained stably while
+  # one epoch (eps 0.941) collapsed.
+  eps: 0.97
   tau: null
 
 trainer:

--- a/sota-implementations/ppo_trainer/config/config_ewma.yaml
+++ b/sota-implementations/ppo_trainer/config/config_ewma.yaml
@@ -19,11 +19,11 @@ loss:
 
 target_net_updater:
   # EWMA decay rate of the proximal policy (beta_prox in the paper). The paper
-  # sets 1 / (1 - eps) - 1, the center of mass of the average in optimizer
-  # steps, to about one epoch of minibatches; with 10 epochs of 16 minibatches
-  # a center of mass of two epochs (32 steps, eps 0.97) trained stably while
-  # one epoch (eps 0.941) collapsed.
-  eps: 0.97
+  # keeps 1 / (1 - eps) - 1, the center of mass of the average in optimizer
+  # steps, of the order of the number of optimizer steps per collected batch
+  # (here 10 epochs x 16 minibatches = 160). On Pendulum, 0.99 (about 100
+  # steps) and 0.995 matched PPO, while 0.941 and 0.97 lagged behind.
+  eps: 0.99
   tau: null
 
 trainer:

--- a/sota-implementations/ppo_trainer/config/config_ewma.yaml
+++ b/sota-implementations/ppo_trainer/config/config_ewma.yaml
@@ -1,0 +1,26 @@
+# PPO-EWMA Trainer Configuration for Pendulum-v1
+#
+# Extends config.yaml: the proximal policy of the clipped objective is an
+# exponentially-weighted moving average of the policy (Hilton et al., 2021,
+# https://arxiv.org/abs/2110.00641), maintained by a SoftUpdate that the
+# trainer steps after every optimizer step. Run with:
+#   python train.py --config-name config_ewma
+
+defaults:
+  - config
+  - target_net_updater@target_net_updater: soft
+  - _self_
+
+loss:
+  # keep a detached copy of the actor as the proximal policy
+  delay_actor: true
+  # cap on the behavior ratio pi_theta / pi_behav, for numerical stability
+  max_importance_ratio: 100.0
+
+target_net_updater:
+  # EWMA decay rate of the proximal policy (beta_prox in the paper)
+  eps: 0.889
+  tau: null
+
+trainer:
+  target_net_updater: ${target_net_updater}

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -1271,6 +1271,28 @@ class TestModuleConfigs:
         assert cfg.exploration_type == "RANDOM"
         instantiate(cfg)
 
+    @pytest.mark.parametrize("bounds", [(-2.0, 2.0), ([-2.0], [2.0])])
+    def test_tanh_normal_model_config_bounds(self, bounds):
+        # low/high must reach the TanhNormal support; the default stays [-1, 1]
+        from hydra.utils import instantiate
+        from tensordict import TensorDict
+        from torchrl.trainers.algorithms.configs.modules import (
+            MLPConfig,
+            TanhNormalModelConfig,
+        )
+
+        low, high = bounds
+        network_cfg = MLPConfig(in_features=3, out_features=2, depth=1, num_cells=8)
+        td = TensorDict({"observation": torch.randn(4, 3)}, [4])
+        dist = instantiate(TanhNormalModelConfig(network=network_cfg)).get_dist(td)
+        assert dist.low == -1.0 and dist.high == 1.0
+        dist = instantiate(
+            TanhNormalModelConfig(network=network_cfg, low=low, high=high)
+        ).get_dist(td)
+        torch.testing.assert_close(dist.low, torch.as_tensor(low))
+        torch.testing.assert_close(dist.high, torch.as_tensor(high))
+        assert dist.sample((256,)).abs().max() <= 2.0
+
     @pytest.mark.skipif(not _has_hydra, reason="Hydra is not installed")
     def test_tensordict_sequential_config(self):
         """Test TensorDictSequentialConfig."""

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -2889,6 +2889,122 @@ trainer:
         self._run_hydra_test(tmpdir, yaml_config, test_code, "SUCCESS")
 
     @pytest.mark.skipif(not _has_gymnasium, reason="Gymnasium is not installed")
+    def test_ppo_ewma_trainer_parsing_with_file(self, tmpdir):
+        """PPO-EWMA: a soft target updater on a delay_actor loss reaches the trainer."""
+        os.makedirs(tmpdir / "save", exist_ok=True)
+
+        yaml_config = f"""
+defaults:
+  - env@training_env: gym
+  - model@models.policy_model: tanh_normal
+  - model@models.value_model: value
+  - network@networks.policy_network: mlp
+  - network@networks.value_network: mlp
+  - collector@data_collector: sync
+  - replay_buffer@replay_buffer: base
+  - storage@storage: tensor
+  - sampler@sampler: without_replacement
+  - writer@writer: round_robin
+  - trainer@trainer: ppo
+  - optimizer@optimizer: adam
+  - loss@loss: ppo
+  - target_net_updater@target_net_updater: soft
+  - logger@logger: csv
+  - _self_
+
+networks:
+  policy_network:
+    out_features: 2
+    in_features: 4
+
+  value_network:
+    out_features: 1
+    in_features: 4
+
+models:
+  policy_model:
+    return_log_prob: true
+    in_keys: ["observation"]
+    param_keys: ["loc", "scale"]
+    out_keys: ["action"]
+    network: ${{networks.policy_network}}
+
+  value_model:
+    in_keys: ["observation"]
+    out_keys: ["state_value"]
+    network: ${{networks.value_network}}
+
+training_env:
+  env_name: CartPole-v1
+
+storage:
+  max_size: 1000
+  device: cpu
+  ndim: 1
+
+replay_buffer:
+  storage: ${{storage}}
+  sampler: ${{sampler}}
+  writer: ${{writer}}
+
+loss:
+  actor_network: ${{models.policy_model}}
+  critic_network: ${{models.value_model}}
+  delay_actor: true
+  max_importance_ratio: 100.0
+
+target_net_updater:
+  eps: 0.889
+  tau: null
+
+data_collector:
+  create_env_fn: ${{training_env}}
+  policy: ${{models.policy_model}}
+  total_frames: 1000
+  frames_per_batch: 100
+
+optimizer:
+  lr: 0.001
+
+logger:
+  exp_name: test_exp
+
+trainer:
+  collector: ${{data_collector}}
+  optimizer: ${{optimizer}}
+  replay_buffer: ${{replay_buffer}}
+  loss_module: ${{loss}}
+  target_net_updater: ${{target_net_updater}}
+  logger: ${{logger}}
+  total_frames: 1000
+  frame_skip: 1
+  clip_grad_norm: true
+  clip_norm: 100.0
+  progress_bar: false
+  seed: 42
+  save_trainer_interval: 100
+  log_interval: 100
+  save_trainer_file: {tmpdir}/save/ckpt.pt
+  optim_steps_per_batch: 1
+"""
+
+        test_code = """
+    trainer = hydra.utils.instantiate(cfg.trainer)
+    assert isinstance(trainer, torchrl.trainers.algorithms.ppo.PPOTrainer)
+    assert trainer.loss_module.delay_actor
+    assert float(trainer.loss_module.max_importance_ratio) == 100.0
+    assert isinstance(trainer.target_net_updater, torchrl.objectives.SoftUpdate)
+    assert trainer.target_net_updater.eps == 0.889
+    # the updater is stepped after every optimizer step
+    assert any(
+        isinstance(getattr(op, "__wrapped__", op), torchrl.trainers.trainers.TargetNetUpdaterHook)
+        for op, _ in trainer._post_optim_ops
+    )
+"""
+
+        self._run_hydra_test(tmpdir, yaml_config, test_code, "SUCCESS")
+
+    @pytest.mark.skipif(not _has_gymnasium, reason="Gymnasium is not installed")
     def test_a2c_trainer_parsing_with_file(self, tmpdir):
         """Test A2C trainer parsing with file config."""
         os.makedirs(tmpdir / "save", exist_ok=True)

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -1292,6 +1292,11 @@ class TestModuleConfigs:
         torch.testing.assert_close(dist.low, torch.as_tensor(low))
         torch.testing.assert_close(dist.high, torch.as_tensor(high))
         assert dist.sample((256,)).abs().max() <= 2.0
+        assert dist.tanh_loc is False
+        dist = instantiate(
+            TanhNormalModelConfig(network=network_cfg, tanh_loc=True)
+        ).get_dist(td)
+        assert dist.tanh_loc is True
 
     @pytest.mark.skipif(not _has_hydra, reason="Hydra is not installed")
     def test_tensordict_sequential_config(self):

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -23,6 +23,12 @@ from torch import nn
 _has_tb = importlib.util.find_spec("tensorboard") is not None
 
 from tensordict import TensorDict
+from tensordict.nn import (
+    NormalParamExtractor,
+    ProbabilisticTensorDictModule,
+    ProbabilisticTensorDictSequential,
+    TensorDictModule,
+)
 from torchrl.checkpoint import Checkpoint, CheckpointRotation
 from torchrl.data import (
     LazyMemmapStorage,
@@ -33,7 +39,8 @@ from torchrl.data import (
     TensorDictReplayBuffer,
 )
 from torchrl.envs.libs.gym import _has_gym
-from torchrl.objectives import LossModule
+from torchrl.modules import TanhNormal
+from torchrl.objectives import ClipPPOLoss, HardUpdate, LossModule, SoftUpdate
 from torchrl.testing import PONG_VERSIONED
 from torchrl.trainers import LogValidationReward, Trainer
 from torchrl.trainers._execution import _Learner
@@ -1987,6 +1994,96 @@ class TestLRSchedulerHook:
         # no new optimization step: the scheduler must not advance
         hook()
         assert optimizer.param_groups[0]["lr"] == 0.5
+
+
+class TestOnPolicyTargetNetUpdater:
+    # OnPolicyTrainer(target_net_updater=...) must step the updater after every
+    # optimizer step: this is what keeps the proximal policy of a
+    # ClipPPOLoss(delay_actor=True) an EWMA of the policy (PPO-EWMA)
+
+    @staticmethod
+    def _make_trainer(updater_cls, **updater_kwargs):
+        torch.manual_seed(0)
+        actor = ProbabilisticTensorDictSequential(
+            TensorDictModule(
+                nn.Sequential(nn.Linear(3, 8), NormalParamExtractor()),
+                in_keys=["observation"],
+                out_keys=["loc", "scale"],
+            ),
+            ProbabilisticTensorDictModule(
+                in_keys=["loc", "scale"],
+                out_keys=["action"],
+                distribution_class=TanhNormal,
+                return_log_prob=True,
+            ),
+        )
+        critic = TensorDictModule(
+            nn.Linear(3, 1), in_keys=["observation"], out_keys=["state_value"]
+        )
+        loss_module = ClipPPOLoss(actor, critic, delay_actor=True, entropy_bonus=False)
+        updater = updater_cls(loss_module, **updater_kwargs)
+        with warnings.catch_warnings():
+            # the on-policy trainers warn that they are experimental
+            warnings.simplefilter("ignore", UserWarning)
+            trainer = PPOTrainer(
+                collector=MockingCollector(),
+                total_frames=None,
+                frame_skip=1,
+                optim_steps_per_batch=3,
+                loss_module=loss_module,
+                optimizer=torch.optim.SGD(loss_module.parameters(), lr=0.1),
+                target_net_updater=updater,
+                num_epochs=1,
+                add_gae=False,
+                progress_bar=False,
+                enable_logging=False,
+            )
+        trainer._pbar_str = OrderedDict()
+        batch = TensorDict(
+            {
+                "observation": torch.randn(8, 3),
+                "action": torch.rand(8, 4) * 1.8 - 0.9,
+                loss_module.tensor_keys.sample_log_prob: torch.randn(8),
+                "advantage": torch.randn(8, 1),
+                "value_target": torch.randn(8, 1),
+            },
+            [8],
+        )
+        return trainer, loss_module, updater, batch
+
+    def test_updater_steps_once_per_optim_step(self):
+        trainer, loss_module, updater, batch = self._make_trainer(
+            HardUpdate, value_network_update_interval=100
+        )
+        before = {
+            key: value.clone()
+            for key, value in loss_module.target_actor_network_params.items(True, True)
+        }
+        trainer.optim_steps(batch)
+        assert trainer._optim_count == 3
+        # one updater step per optimizer step, none of which reached the
+        # hard-update interval: the proximal policy is still the snapshot
+        assert updater.counter == 3
+        after = loss_module.target_actor_network_params
+        for key, value in before.items():
+            torch.testing.assert_close(after.get(key), value)
+
+    def test_soft_update_moves_proximal_policy(self):
+        trainer, loss_module, updater, batch = self._make_trainer(SoftUpdate, eps=0.5)
+        before = {
+            key: value.clone()
+            for key, value in loss_module.target_actor_network_params.items(True, True)
+        }
+        trainer.optim_steps(batch)
+        after = loss_module.target_actor_network_params
+        current = loss_module.actor_network_params
+        # the proximal policy followed the policy without copying it
+        assert any(
+            not torch.allclose(after.get(key), value) for key, value in before.items()
+        )
+        assert any(
+            not torch.allclose(after.get(key), current.get(key)) for key in before
+        )
 
 
 class TestValueEstimatorHook:

--- a/torchrl/trainers/algorithms/configs/modules.py
+++ b/torchrl/trainers/algorithms/configs/modules.py
@@ -318,6 +318,10 @@ class TanhNormalModelConfig(ModelConfig):
             :class:`~torchrl.modules.TanhNormal` (a scalar or a per-dimension
             sequence). Defaults to ``None``, i.e. the distribution default of ``-1``.
         high: upper bound of the action support. Defaults to ``None``, i.e. ``1``.
+        tanh_loc: if ``True``, the location is squashed to ``[-upscale, upscale]``
+            before the tanh transform, which keeps the log-probability of actions
+            at the bounds finite (see :class:`~torchrl.modules.TanhNormal`).
+            Defaults to ``False``.
 
     .. seealso:: :class:`torchrl.modules.TanhNormal`
     """
@@ -330,6 +334,7 @@ class TanhNormalModelConfig(ModelConfig):
     scale_lb: float = 1e-4
     low: Any = None
     high: Any = None
+    tanh_loc: bool = False
 
     param_keys: Any = None
 
@@ -534,6 +539,8 @@ def _make_tanh_normal_model(*args, **kwargs):
         if not isinstance(value, (int, float)):
             value = torch.as_tensor(list(value), dtype=torch.get_default_dtype())
         distribution_kwargs[bound] = value
+    if kwargs.pop("tanh_loc", False):
+        distribution_kwargs["tanh_loc"] = True
     if distribution_kwargs:
         kwargs["distribution_kwargs"] = distribution_kwargs
 

--- a/torchrl/trainers/algorithms/configs/modules.py
+++ b/torchrl/trainers/algorithms/configs/modules.py
@@ -313,6 +313,12 @@ class TanhNormalModelConfig(ModelConfig):
         >>> y = net(torch.randn(1, 10))
         >>> assert y.shape == (1, 5)
 
+    Args:
+        low: lower bound of the action support handed to
+            :class:`~torchrl.modules.TanhNormal` (a scalar or a per-dimension
+            sequence). Defaults to ``None``, i.e. the distribution default of ``-1``.
+        high: upper bound of the action support. Defaults to ``None``, i.e. ``1``.
+
     .. seealso:: :class:`torchrl.modules.TanhNormal`
     """
 
@@ -322,6 +328,8 @@ class TanhNormalModelConfig(ModelConfig):
     extract_normal_params: bool = True
     scale_mapping: str = "biased_softplus_1.0"
     scale_lb: float = 1e-4
+    low: Any = None
+    high: Any = None
 
     param_keys: Any = None
 
@@ -517,6 +525,17 @@ def _make_tanh_normal_model(*args, **kwargs):
     eval_mode = kwargs.pop("eval_mode", False)
     exploration_type = kwargs.pop("exploration_type", "RANDOM")
     shared = kwargs.pop("shared", False)
+    distribution_kwargs = dict(kwargs.pop("distribution_kwargs", None) or {})
+    for bound in ("low", "high"):
+        value = kwargs.pop(bound, None)
+        if value is None:
+            continue
+        # omegaconf hands sequences over as ListConfig
+        if not isinstance(value, (int, float)):
+            value = torch.as_tensor(list(value), dtype=torch.get_default_dtype())
+        distribution_kwargs[bound] = value
+    if distribution_kwargs:
+        kwargs["distribution_kwargs"] = distribution_kwargs
 
     # Now instantiate the network
     if hasattr(network, "_target_"):

--- a/torchrl/trainers/algorithms/configs/trainers.py
+++ b/torchrl/trainers/algorithms/configs/trainers.py
@@ -481,7 +481,9 @@ class OnPolicyTrainerConfig(TrainerConfig):
     gae: Any = None
     lr_scheduler: Any = None
     target_net_updater: Any = None
-    weight_update_map: dict[str, str] | None = None
+    # ``Any`` rather than ``dict[str, str] | None``: OmegaConf cannot merge a
+    # mapping into a typed optional-dict field whose default is ``None``
+    weight_update_map: Any = None
     log_timings: bool = False
     auto_log_optim_steps: bool = True
     batch_size: int | None = None

--- a/torchrl/trainers/algorithms/configs/trainers.py
+++ b/torchrl/trainers/algorithms/configs/trainers.py
@@ -427,6 +427,10 @@ class OnPolicyTrainerConfig(TrainerConfig):
         lr_scheduler: Learning-rate scheduler (or a partial configuration taking
             the optimizer as input), stepped once per collected batch via
             :class:`~torchrl.trainers.LRSchedulerHook`.
+        target_net_updater: Target-parameter updater (or a partial configuration
+            taking the loss module as input, e.g. ``SoftUpdateConfig``), stepped
+            after every optimizer step. Pair it with ``PPOLossConfig(delay_actor=True)``
+            for PPO-EWMA.
         weight_update_map: Mapping from collector destination paths to trainer source paths.
             Required if collector has weight_sync_schemes configured.
             Example: ``{"policy": "loss_module.actor_network", "replay_buffer.transforms[0]": "loss_module.critic_network"}``.
@@ -476,6 +480,7 @@ class OnPolicyTrainerConfig(TrainerConfig):
     add_gae: bool = True
     gae: Any = None
     lr_scheduler: Any = None
+    target_net_updater: Any = None
     weight_update_map: dict[str, str] | None = None
     log_timings: bool = False
     auto_log_optim_steps: bool = True
@@ -572,6 +577,7 @@ def _make_onpolicy_trainer(trainer_cls, *args, **kwargs):
     gae = kwargs.pop("gae", None)
     kwargs.pop("create_env_fn", None)
     lr_scheduler = kwargs.pop("lr_scheduler", None)
+    target_net_updater = kwargs.pop("target_net_updater", None)
     weight_update_map = kwargs.pop("weight_update_map", None)
     log_timings = kwargs.pop("log_timings", False)
     auto_log_optim_steps = kwargs.pop("auto_log_optim_steps", True)
@@ -636,6 +642,11 @@ def _make_onpolicy_trainer(trainer_cls, *args, **kwargs):
     ):
         # then it's a partial config taking the optimizer as input
         lr_scheduler = lr_scheduler(optimizer)
+    if target_net_updater is not None and not isinstance(
+        target_net_updater, TargetNetUpdater
+    ):
+        # then it's a partial config taking the loss module as input
+        target_net_updater = target_net_updater(loss_module)
 
     # Quick instance checks
     if not isinstance(collector, BaseCollector):
@@ -660,6 +671,7 @@ def _make_onpolicy_trainer(trainer_cls, *args, **kwargs):
         loss_module=loss_module,
         optimizer=optimizer,
         lr_scheduler=lr_scheduler,
+        target_net_updater=target_net_updater,
         logger=logger,
         clip_grad_norm=clip_grad_norm,
         clip_norm=clip_norm,

--- a/torchrl/trainers/algorithms/on_policy.py
+++ b/torchrl/trainers/algorithms/on_policy.py
@@ -23,12 +23,14 @@ from torchrl.collectors import BaseCollector
 from torchrl.data.replay_buffers.replay_buffers import ReplayBuffer
 from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
 from torchrl.objectives.common import LossModule
+from torchrl.objectives.utils import TargetNetUpdater
 from torchrl.objectives.value.advantages import GAE
 from torchrl.record.loggers import Logger
 from torchrl.trainers.trainers import (
     LogScalar,
     LRSchedulerHook,
     ReplayBufferTrainer,
+    TargetNetUpdaterHook,
     Trainer,
     UpdateWeights,
     ValueEstimatorHook,
@@ -61,6 +63,12 @@ class OnPolicyTrainer(Trainer):
         optimizer (optim.Optimizer, optional): The optimizer for training.
         lr_scheduler (optim.lr_scheduler.LRScheduler, optional): Learning-rate scheduler,
             stepped once per collected batch via :class:`~torchrl.trainers.LRSchedulerHook`.
+        target_net_updater (TargetNetUpdater, optional): Target-parameter updater, stepped
+            after every optimizer step via :class:`~torchrl.trainers.TargetNetUpdaterHook`.
+            Pair it with a loss built with ``delay_actor=True`` (see
+            :class:`~torchrl.objectives.ClipPPOLoss`) to maintain the proximal policy of
+            PPO-EWMA: a :class:`~torchrl.objectives.SoftUpdate` turns it into an
+            exponentially-weighted moving average of the policy. Default: ``None``.
         logger (Logger, optional): Logger for tracking training metrics.
         clip_grad_norm (bool, optional): Whether to clip gradient norms. Default: True.
         clip_norm (float, optional): Maximum gradient norm value.
@@ -118,6 +126,7 @@ class OnPolicyTrainer(Trainer):
         loss_module: LossModule | Callable[[TensorDictBase], TensorDictBase],
         optimizer: optim.Optimizer | None = None,
         lr_scheduler: optim.lr_scheduler.LRScheduler | None = None,
+        target_net_updater: TargetNetUpdater | None = None,
         logger: Logger | None = None,
         clip_grad_norm: bool = True,
         clip_norm: float | None = None,
@@ -167,6 +176,7 @@ class OnPolicyTrainer(Trainer):
             optim_steps_per_batch=optim_steps_per_batch,
             loss_module=loss_module,
             optimizer=optimizer,
+            target_net_updater=target_net_updater,
             logger=logger,
             clip_grad_norm=clip_grad_norm,
             clip_norm=clip_norm,
@@ -216,6 +226,12 @@ class OnPolicyTrainer(Trainer):
 
         if lr_scheduler is not None:
             LRSchedulerHook(lr_scheduler).register(self)
+
+        if target_net_updater is not None:
+            # stepped after every optimizer step, as the PPO-EWMA proximal
+            # policy requires (a post_steps registration would only step it
+            # once per collected batch)
+            self.register_op("post_optim", TargetNetUpdaterHook(target_net_updater))
 
         if hasattr(self.loss_module, "set_keys"):
             self.loss_module.set_keys(


### PR DESCRIPTION
## Description

Stacked on #4213 (base branch `ppo-ewma`): merge that one first, then retarget this PR to `main`.

Wires the decoupled proximal policy / PPO-EWMA feature of #4213 into the trainer and the Hydra configs so it can be run from `PPOTrainer`.

### What changes

- `OnPolicyTrainer` (and thus `PPOTrainer`, `A2CTrainer`, `ReinforceTrainer`) accepts `target_net_updater: TargetNetUpdater | None`. It is handed to the base `Trainer` (so it is checkpointed like the other trainers' updaters) and registered as a `TargetNetUpdaterHook` at the `post_optim` stage, i.e. stepped after every optimizer step, which is what the PPO-EWMA proximal policy requires (`post_steps` would only step it once per collected batch).
- `PPOLossConfig` gains `delay_actor: bool = False` and `max_importance_ratio: float | None = None`, forwarded to all three loss flavors (matching the loss signatures).
- `OnPolicyTrainerConfig` gains `target_net_updater: Any = None`; `_make_onpolicy_trainer` instantiates a partial config (e.g. `SoftUpdateConfig`) with the loss module, as the off-policy trainer factories do.
- `sota-implementations/ppo_trainer/config/config_ewma.yaml`: composed example (`defaults: - config`) enabling PPO-EWMA on the Pendulum PPO trainer recipe: `loss.delay_actor=true`, `loss.max_importance_ratio=100.0`, `target_net_updater@target_net_updater: soft` with `eps: 0.889` (the paper's default `beta_prox`). Run with `python train.py --config-name config_ewma`.
- The `ppo_trainer` base `config.yaml` carried two wandb-only keys (`offline`, `project`) in its csv logger section, which made it fail to compose under Hydra's struct mode (`Key 'offline' not in 'CSVLoggerConfig'`). They are dropped so the base config, and therefore the example above, composes. `a2c_trainer` and `reinforce_trainer` have the same pre-existing issue and are left for a separate fix.

### Tests

- `test/test_trainer.py::TestOnPolicyTargetNetUpdater`: a real `PPOTrainer` with a `ClipPPOLoss(delay_actor=True)` steps a `HardUpdate` exactly once per optimizer step (counter equals the number of optimizer steps, proximal policy untouched below the interval), and a `SoftUpdate` moves the proximal policy without copying the policy.
- `test/test_configs.py::test_ppo_loss_config_delay_actor` (clip and kl): the new fields reach the instantiated loss.
- `test/test_configs.py::test_ppo_ewma_trainer_parsing_with_file`: a yaml with `target_net_updater@target_net_updater: soft` and `loss.delay_actor: true` produces a `PPOTrainer` holding the `SoftUpdate` and a `post_optim` `TargetNetUpdaterHook`.
- `config_ewma.yaml` composes and its loss and updater instantiate locally.

### Update: the example config now runs end to end

`OnPolicyTrainer` requires `weight_update_map` when the collector ships weight-sync schemes, which the `multi_async` collector of `config.yaml` now does by default, so `train.py` could not start (`ValueError: Collector has weight_sync_schemes configured, but weight_update_map was not provided`). `config.yaml` now maps the collector's `policy` destination to `loss_module.actor_network`, and `OnPolicyTrainerConfig.weight_update_map` is typed `Any` because OmegaConf cannot merge a mapping into a `dict[str, str] | None` field defaulting to `None`, neither from yaml nor from the CLI. `python train.py --config-name config_ewma` runs end to end.

Local sanity check on a MacBook (Pendulum-v1, 1M frames, seed 42, mean per-step reward over the last 100k frames; a random policy scores about -6): `config.yaml` (PPO) reaches -4.62 with the mean log-ratio blowing up to 130 and a clip fraction of 0.40 late in training; `config_ewma.yaml` with the paper's default `eps=0.889` reaches -5.03 with stable diagnostics; with `eps=0.941`, i.e. the paper's rule `1/(1-eps) - 1 = optimizer steps per collected batch` (16 here), PPO-EWMA reaches -3.62 with a clip fraction of 0.25 and a mean log-ratio of 1.0. Single seed, so indicative only. Note that the example's `tanh_normal` model config exposes no action bounds, so actions are limited to [-1, 1] while Pendulum accepts [-2, 2], which makes the task harder than the standard benchmark for every variant.

### Update: tuned, runnable example

Three further commits make the Pendulum example learn properly: `TanhNormalModelConfig` gained `low`/`high` (the example policy was capped at torque +-1 while Pendulum accepts +-2) and `tanh_loc`; the example now uses a std floor of 0.1 and `tanh_loc` (without them the std collapses, the tanh saturates and the log-probabilities of actions at the bound overflow to NaN after 300k to 550k frames), lr 3e-4, 10 epochs, minibatches of 64, gradient clip 1 and entropy coefficient 1e-4; `config_ewma.yaml` sets `eps=0.99`.

Local results (1M frames, single seed, mean per-step reward over the last 100k frames; random is about -6, solved is about -1): PPO -1.64 (first reaches -1 at 447k frames), PPO-EWMA `eps=0.99` -1.32 (reaches -3 per step at 319k frames vs 342k for PPO), `eps=0.995` -2.41, `eps=0.97` -3.22, `eps=0.941` -4.15. Decays whose center of mass is of the order of the optimizer steps per collected batch work best; short decays lag. W&B project `vmoens/torchrl-ppo-ewma`, runs `e_ppo`, `f_ewma_e99`, `f_ewma_e995`, `e_ewma_e97`.

Generated with [Claude Code](https://claude.com/claude-code)



