### PR TITLE
[Performance] Accelerate DreamerV3 training with CUDA graphs

### DIFF
--- a/.github/unittest/helpers/coverage_run_parallel.py
+++ b/.github/unittest/helpers/coverage_run_parallel.py
@@ -28,6 +28,11 @@ def write_config(config_path: Path, argv: list[str]) -> None:
     """
     assert not config_path.exists(), "Temporary coverage config exists already"
     cmdline = shlex.join(argv[1:])
+    thread_concurrency = (
+        "    thread\n"
+        if os.environ.get("TORCHRL_COV_TRACE_THREADS", "1") != "0"
+        else ""
+    )
     with open(str(config_path), "w", encoding="utf-8") as fh:
         fh.write(
             f"""# .coveragerc to control coverage.py
@@ -35,8 +40,7 @@ def write_config(config_path: Path, argv: list[str]) -> None:
 parallel=True
 concurrency=
     multiprocessing
-    thread
-command_line={cmdline}
+{thread_concurrency}command_line={cmdline}
 """
         )
 

--- a/.github/unittest/linux/scripts/run_all.sh
+++ b/.github/unittest/linux/scripts/run_all.sh
@@ -500,7 +500,10 @@ run_non_distributed_tests() {
       ;;
     collectors)
       echo "Running shard collectors: ${collector_tests} (serial)"
-      python .github/unittest/helpers/coverage_run_parallel.py -m pytest ${collector_tests} \
+      # Coverage's thread hook can crash multiprocessing.Queue feeder threads
+      # on Python 3.10. Process coverage remains enabled for this shard.
+      TORCHRL_COV_TRACE_THREADS=0 \
+        python .github/unittest/helpers/coverage_run_parallel.py -m pytest ${collector_tests} \
         "${GPU_MARKER_FILTER[@]}" \
         ${json_report_args} \
         ${common_args} ${serial_timeout}

--- a/.github/unittest/linux_libs/scripts_gym/run_all.sh
+++ b/.github/unittest/linux_libs/scripts_gym/run_all.sh
@@ -145,6 +145,7 @@ printf "* Setting up Atari ROMs\n"
 if ! find Roms -type f -iname '*pong*' -print -quit 2>/dev/null | grep -q .; then
     mkdir -p Roms
     if ! wget --tries=5 --retry-connrefused --waitretry=5 \
+        --user-agent='Mozilla/5.0' \
         -O Roms.rar https://www.atarimania.com/roms/Roms.rar; then
         printf "Failed to download Atari ROM archive\n" >&2
         exit 1

--- a/.github/unittest/linux_libs/scripts_gym/run_all.sh
+++ b/.github/unittest/linux_libs/scripts_gym/run_all.sh
@@ -145,7 +145,7 @@ printf "* Setting up Atari ROMs\n"
 if ! find Roms -type f -iname '*pong*' -print -quit 2>/dev/null | grep -q .; then
     mkdir -p Roms
     if ! wget --tries=5 --retry-connrefused --waitretry=5 \
-        -O Roms.rar http://www.atarimania.com/roms/Roms.rar; then
+        -O Roms.rar https://www.atarimania.com/roms/Roms.rar; then
         printf "Failed to download Atari ROM archive\n" >&2
         exit 1
     fi

--- a/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
+++ b/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
@@ -1,0 +1,195 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Benchmark complete DreamerV3 learner updates after warmup.
+
+The workload uses the maintained DMC Walker configuration and includes all
+model, actor, value, and replay-value losses, backward, the optimizer step,
+and the slow-value-target update. Replay sampling and environment collection
+are intentionally outside the learner timing.
+
+Example::
+
+    python benchmarks/ad_hoc/bench_dreamer_v3_learner.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import runpy
+import statistics
+import sys
+import time
+from pathlib import Path
+
+import torch
+from omegaconf import OmegaConf
+from tensordict import TensorDict
+
+
+def _load_example(repo_root: Path) -> dict:
+    example_dir = repo_root / "sota-implementations/dreamer_v3"
+    sys.path.insert(0, str(example_dir))
+    return runpy.run_path(
+        example_dir / "train.py",
+        run_name="dreamer_v3_learner_benchmark",
+    )
+
+
+def _load_config(repo_root: Path):
+    example_dir = repo_root / "sota-implementations/dreamer_v3"
+    base = OmegaConf.load(example_dir / "config.yaml")
+    walker = OmegaConf.load(example_dir / "config_dmc_walker.yaml")
+    del walker.defaults
+    return OmegaConf.merge(base, walker)
+
+
+def _make_data(
+    cfg,
+    device: torch.device,
+    *,
+    batch: int,
+    steps: int,
+    obs_dim: int,
+    action_dim: int,
+) -> TensorDict:
+    state_dim = cfg.networks.num_categoricals * cfg.networks.num_classes
+    return TensorDict(
+        {
+            "state": torch.zeros(batch, steps, state_dim, device=device),
+            "belief": torch.zeros(
+                batch, steps, cfg.networks.rnn_hidden_dim, device=device
+            ),
+            "action": torch.randn(batch, steps, action_dim, device=device),
+            "is_init": torch.zeros(batch, steps, 1, dtype=torch.bool, device=device),
+            "next": {
+                "observation": torch.randn(batch, steps, obs_dim, device=device),
+                "reward": torch.randn(batch, steps, 1, device=device),
+                "done": torch.zeros(batch, steps, 1, dtype=torch.bool, device=device),
+                "terminated": torch.zeros(
+                    batch, steps, 1, dtype=torch.bool, device=device
+                ),
+            },
+        },
+        [batch, steps],
+        device=device,
+    )
+
+
+def _measure(
+    learner_update,
+    data: TensorDict,
+    *,
+    device: torch.device,
+    warmup: int,
+    iterations: int,
+) -> list[float]:
+    for _ in range(warmup):
+        learner_update(data)
+    torch.cuda.synchronize(device)
+    samples = []
+    for _ in range(iterations):
+        started = time.perf_counter()
+        learner_update(data)
+        torch.cuda.synchronize(device)
+        samples.append((time.perf_counter() - started) * 1000)
+    return samples
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch", type=int, default=16)
+    parser.add_argument("--steps", type=int, default=64)
+    parser.add_argument("--unroll", type=int, default=8)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=50)
+    parser.add_argument(
+        "--variants",
+        nargs="+",
+        choices=("compiled_scan", "cuda_graph"),
+        default=("compiled_scan", "cuda_graph"),
+    )
+    args = parser.parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("This benchmark requires CUDA.")
+
+    repo_root = Path(__file__).parents[2]
+    example = _load_example(repo_root)
+    template_cfg = _load_config(repo_root)
+    device = torch.device("cuda:0")
+    torch.set_float32_matmul_precision("high")
+
+    real_env = example["make_env"](template_cfg, template_cfg.env.seed)
+    obs_dim = real_env.observation_spec["observation"].shape[0]
+    action_dim = real_env.action_spec.shape[0]
+    real_env.close()
+    torch.manual_seed(1)
+    data = _make_data(
+        template_cfg,
+        device,
+        batch=args.batch,
+        steps=args.steps,
+        obs_dim=obs_dim,
+        action_dim=action_dim,
+    )
+
+    for variant in args.variants:
+        cfg = _load_config(repo_root)
+        cfg.replay_buffer.batch_size = args.batch
+        cfg.replay_buffer.seq_len = args.steps
+        cfg.optimization.compile_rssm = "scan"
+        cfg.optimization.rssm_scan_unroll = args.unroll
+        cfg.optimization.cudagraph_train_step = variant == "cuda_graph"
+        torch.manual_seed(0)
+        learner = example["_build_learner"](
+            cfg,
+            device,
+            obs_dim,
+            action_dim,
+        )
+        learner_update = example["_LearnerUpdate"](
+            cfg,
+            device,
+            learner,
+            cudagraph_warmup=args.warmup,
+        )
+        if cfg.optimization.separate_policy_rng:
+            torch.manual_seed(
+                example["stream_seed"](
+                    cfg.env.seed,
+                    0,
+                    example["LEARNER_RNG_STREAM"],
+                )
+            )
+        samples = _measure(
+            learner_update,
+            data.clone(),
+            device=device,
+            warmup=args.warmup,
+            iterations=args.iterations,
+        )
+        median_ms = statistics.median(samples)
+        result = {
+            "variant": variant,
+            "workload": "complete_learner_update",
+            "device": torch.cuda.get_device_name(device),
+            "torch_version": torch.__version__,
+            "cuda_version": torch.version.cuda,
+            "batch": args.batch,
+            "steps": args.steps,
+            "unroll": args.unroll,
+            "warmup": args.warmup,
+            "iterations": args.iterations,
+            "mixed_precision": cfg.optimization.mixed_precision,
+            "median_ms": median_ms,
+            "transitions_per_second": args.batch * args.steps * 1000 / median_ms,
+            "min_ms": min(samples),
+            "max_ms": max(samples),
+        }
+        print(json.dumps(result, sort_keys=True), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/ad_hoc/bench_dreamer_v3_rssm.py
+++ b/benchmarks/ad_hoc/bench_dreamer_v3_rssm.py
@@ -1,0 +1,166 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Benchmark the DreamerV3 RSSM compiled scan with and without CUDA graphs.
+
+The default dimensions match the DMC Walker reproduction configuration. The
+benchmark measures a synchronized forward/backward update after compilation
+and graph-capture warmup; it intentionally excludes cold-start latency.
+
+Example::
+
+    python benchmarks/ad_hoc/bench_dreamer_v3_rssm.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import functools as ft
+import json
+import statistics
+import time
+from collections.abc import Callable
+
+import torch
+from tensordict import TensorDict
+from tensordict.nn import CudaGraphModule, TensorDictModule
+
+from torchrl.modules.models import RSSMPosteriorV3, RSSMPriorV3, RSSMRolloutV3
+
+
+def _make_rollout(device: torch.device) -> RSSMRolloutV3:
+    prior = RSSMPriorV3(
+        action_shape=torch.Size([6]),
+        hidden_dim=64,
+        rnn_hidden_dim=512,
+        num_categoricals=32,
+        num_classes=4,
+        action_dim=6,
+        recurrent_model="block_gru",
+        num_blocks=8,
+        num_layers=1,
+        prior_num_layers=2,
+        unimix=0.01,
+    )
+    posterior = RSSMPosteriorV3(
+        hidden_dim=64,
+        num_categoricals=32,
+        num_classes=4,
+        rnn_hidden_dim=512,
+        obs_embed_dim=64,
+        use_rms_norm=True,
+        num_layers=1,
+        unimix=0.01,
+    )
+    return RSSMRolloutV3(
+        TensorDictModule(
+            prior,
+            in_keys=["state", "belief", "action"],
+            out_keys=[
+                ("next", "prior_logits"),
+                ("next", "state"),
+                ("next", "belief"),
+            ],
+        ),
+        TensorDictModule(
+            posterior,
+            in_keys=[("next", "belief"), ("next", "encoded_latents")],
+            out_keys=[("next", "posterior_logits"), ("next", "state")],
+        ),
+        reset_key="is_init",
+    ).to(device)
+
+
+def _make_data(device: torch.device, batch: int, steps: int) -> TensorDict:
+    return TensorDict(
+        {
+            "state": torch.zeros(batch, steps, 128, device=device),
+            "belief": torch.zeros(batch, steps, 512, device=device),
+            "action": torch.randn(batch, steps, 6, device=device),
+            "is_init": torch.zeros(batch, steps, 1, dtype=torch.bool, device=device),
+            "next": {"encoded_latents": torch.randn(batch, steps, 64, device=device)},
+        },
+        [batch, steps],
+        device=device,
+    )
+
+
+def _measure(
+    step: Callable[[], object],
+    *,
+    device: torch.device,
+    warmup: int,
+    iterations: int,
+) -> list[float]:
+    for _ in range(warmup):
+        step()
+    torch.cuda.synchronize(device)
+    samples = []
+    for _ in range(iterations):
+        started = time.perf_counter()
+        step()
+        torch.cuda.synchronize(device)
+        samples.append((time.perf_counter() - started) * 1000)
+    return samples
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch", type=int, default=16)
+    parser.add_argument("--steps", type=int, default=64)
+    parser.add_argument("--unroll", type=int, default=8)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iterations", type=int, default=50)
+    args = parser.parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("This benchmark requires CUDA.")
+
+    torch.manual_seed(0)
+    torch.set_float32_matmul_precision("high")
+    device = torch.device("cuda:0")
+    rollout = _make_rollout(device)
+    rollout.compile_rollout("scan", unroll=args.unroll)
+    data = _make_data(device, args.batch, args.steps)
+
+    def train_step(value: TensorDict) -> torch.Tensor:
+        rollout.zero_grad(set_to_none=True)
+        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            output = rollout(value)
+            loss = (
+                output["next", "posterior_logits"].float().square().mean()
+                + output["next", "prior_logits"].float().square().mean()
+                + 1e-4 * output["next", "belief"].float().square().mean()
+            )
+        loss.backward()
+        return loss.detach()
+
+    variants: dict[str, Callable[[], object]] = {
+        "compiled_scan": ft.partial(train_step, data),
+    }
+    graphed_step = CudaGraphModule(train_step, warmup=args.warmup, device=device)
+    variants["cuda_graph"] = ft.partial(graphed_step, data)
+
+    for name, step in variants.items():
+        samples = _measure(
+            step,
+            device=device,
+            warmup=args.warmup,
+            iterations=args.iterations,
+        )
+        median_ms = statistics.median(samples)
+        result = {
+            "variant": name,
+            "batch": args.batch,
+            "steps": args.steps,
+            "unroll": args.unroll,
+            "median_ms": median_ms,
+            "transitions_per_second": args.batch * args.steps * 1000 / median_ms,
+            "min_ms": min(samples),
+            "max_ms": max(samples),
+        }
+        print(json.dumps(result, sort_keys=True), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -64,6 +64,26 @@ learner forward/backward:
 ./sota-implementations/dreamer_v3/reproduce_dmc_walker.sh --fast
 ```
 
+To measure the same fixed-shape learner update after compile and capture
+warmup—including every loss, backward, optimizer, and slow-target update—run:
+
+```bash
+python benchmarks/ad_hoc/bench_dreamer_v3_learner.py
+```
+
+The timing excludes replay sampling and environment collection. Use the
+benchmark arguments to change the batch size, sequence length, scan unroll,
+warmup, or number of measured updates. Compilation and graph capture happen
+during warmup and are excluded from the reported samples.
+
+On one NVIDIA GB200 with PyTorch 2.12.0, CUDA 13.0, BF16, batch size 16,
+sequence length 64, scan unroll 8, 10 warmup updates and 50 measured updates:
+
+| Learner backend | Median update | Transitions/s | Speedup |
+| --- | ---: | ---: | ---: |
+| Compiled scan | 358.51 ms | 2,856 | 1.00x |
+| Compiled scan + CUDA graph | 17.83 ms | 57,415 | 20.10x |
+
 Compilation has an up-front cost, so the short validation remains eager:
 
 ```bash

--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -57,7 +57,8 @@ For a three-seed median and interquartile reproduction run:
 ```
 
 For the fastest supported accelerator path, enable the compiled RSSM scan
-(unrolled eight steps at a time):
+(unrolled eight steps at a time) and CUDA-graph capture of the fixed-shape
+learner forward/backward:
 
 ```bash
 ./sota-implementations/dreamer_v3/reproduce_dmc_walker.sh --fast
@@ -82,8 +83,8 @@ or manual validation; pull-request CI uses short smoke overrides. Set
 `OUTPUT_DIR` to change the output directory (the defaults are
 `dmc_walker_runs` and `dmc_walker_smoke`), and append any other Hydra overrides
 to the wrapper, for example `benchmark.seeds=[0]`. Each run logs the resolved
-training device, replay device, RSSM backend, scan unroll and mixed-precision
-state.
+training device, replay device, RSSM backend, scan unroll, mixed-precision state
+and learner CUDA-graph setting.
 
 For a smaller ablation, shorten the run rather than the window:
 
@@ -107,3 +108,7 @@ recurrence and the imagination prior, and is faster, but its draws fall inside
 the compiled region, so a seeded run diverges from an eager one. The scan uses
 `optimization.rssm_scan_unroll=8` by default; lower values reduce compilation
 time and graph size, while `1` disables manual unrolling.
+`optimization.cudagraph_train_step=true` captures the learner forward and
+backward after five warmup calls. It requires CUDA and fixed input shapes;
+optimizer and target-network steps remain outside capture so their schedules
+continue to advance normally.

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -56,6 +56,8 @@ optimization:
   compile_rssm: null
   # Number of RSSM steps traced per higher-order scan iteration.
   rssm_scan_unroll: 8
+  # Capture the fixed-shape learner forward/backward on CUDA after warmup.
+  cudagraph_train_step: false
   lr: 4.0e-5
   optimizer_eps: 1.0e-20
   adaptive_grad_clip: 0.3

--- a/sota-implementations/dreamer_v3/reproduce_dmc_walker.sh
+++ b/sota-implementations/dreamer_v3/reproduce_dmc_walker.sh
@@ -83,6 +83,7 @@ elif [ "$fast" -eq 1 ]; then
   benchmark_command+=(
     optimization.compile_rssm=scan
     optimization.rssm_scan_unroll=8
+    optimization.cudagraph_train_step=true
   )
 fi
 

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -86,6 +86,127 @@ class _Learner(NamedTuple):
     real_world_actor: TensorDictModuleBase
 
 
+class _LearnerUpdate:
+    """Run one complete DreamerV3 learner update."""
+
+    def __init__(
+        self,
+        cfg: DictConfig,
+        device: torch.device,
+        learner: _Learner,
+        *,
+        cudagraph_warmup: int = 5,
+    ):
+        self.cfg = cfg
+        self.device = device
+        self.model_loss = learner.model_loss
+        self.actor_loss = learner.actor_loss
+        self.value_loss = learner.value_loss
+        self.optimizer = learner.optimizer
+        self.value_target_updater = learner.value_target_updater
+        self.state_dim = latent_state_dim(cfg)
+        self.use_bfloat16 = cfg.optimization.mixed_precision and device.type == "cuda"
+        train_step = self._forward_backward
+        if cfg.optimization.cudagraph_train_step:
+            if device.type != "cuda":
+                raise RuntimeError(
+                    "optimization.cudagraph_train_step requires a CUDA training device."
+                )
+            train_step = CudaGraphModule(
+                train_step,
+                warmup=cudagraph_warmup,
+                device=device,
+            )
+        self.train_step = train_step
+
+    def _forward_backward(
+        self,
+        sample: TensorDictBase,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        cfg = self.cfg
+        with torch.autocast(
+            device_type=self.device.type,
+            dtype=torch.bfloat16,
+            enabled=self.use_bfloat16,
+        ):
+            model_loss_td, model_out = self.model_loss(sample)
+            model_kl = (
+                model_loss_td["loss_model_dynamic"]
+                + model_loss_td["loss_model_representation"]
+            )
+            total_model_loss = (
+                model_kl
+                + model_loss_td["loss_model_reco"]
+                + model_loss_td["loss_model_reward"]
+                + model_loss_td["loss_model_continue"]
+            ).squeeze()
+
+            post_state = (
+                model_out.get(("next", "state")).detach().reshape(-1, self.state_dim)
+            )
+            post_belief = (
+                model_out.get(("next", "belief"))
+                .detach()
+                .reshape(-1, cfg.networks.rnn_hidden_dim)
+            )
+            actor_input = TensorDict(
+                {"state": post_state, "belief": post_belief},
+                [post_state.shape[0]],
+            )
+            actor_loss_td, fake_data = self.actor_loss(actor_input)
+            value_loss_td, _ = self.value_loss(fake_data.detach())
+
+            replay_features = TensorDict(
+                {
+                    "state": model_out.get(("next", "state")),
+                    "belief": model_out.get(("next", "belief")),
+                    "bootstrap": fake_data.get("lambda_target")[..., 0, 0].reshape(
+                        sample.batch_size
+                    ),
+                    "next": sample.get("next").select("reward", "done", "terminated"),
+                },
+                sample.batch_size,
+            )
+            replay_loss = self.value_loss.replay_value_loss(
+                replay_features,
+                horizon=cfg.optimization.continuation_horizon,
+                lmbda=cfg.optimization.lmbda,
+            )["loss_replay_value"]
+            total_loss = (
+                total_model_loss
+                + actor_loss_td["loss_actor"]
+                + value_loss_td["loss_value"]
+                + cfg.optimization.replay_value_loss_weight * replay_loss
+            )
+
+        self.optimizer.zero_grad(set_to_none=True)
+        total_loss.backward()
+        metrics = torch.stack(
+            (
+                model_kl.detach().reshape(()),
+                model_loss_td["loss_model_reco"].detach().reshape(()),
+                model_loss_td["loss_model_reward"].detach().reshape(()),
+                actor_loss_td["loss_actor"].detach().reshape(()),
+                value_loss_td["loss_value"].detach().reshape(()),
+                replay_loss.detach().reshape(()),
+            )
+        )
+        return (
+            metrics,
+            model_out.get(("next", "state")).detach(),
+            model_out.get(("next", "belief")).detach(),
+        )
+
+    def __call__(
+        self,
+        sample: TensorDictBase,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        result = self.train_step(sample)
+        self.optimizer.step()
+        self.value_target_updater.step()
+        return result
+
+
 def _validated_action_budget(cfg: DictConfig) -> int:
     num_envs = cfg.collector.num_envs
     if num_envs <= 0:
@@ -471,11 +592,7 @@ def main(cfg: DictConfig):
     run_timer = timeit("dreamer_v3/run").start()
 
     learner = _build_learner(cfg, device, obs_dim, action_dim)
-    model_loss = learner.model_loss
-    actor_loss = learner.actor_loss
-    value_loss = learner.value_loss
-    optimizer = learner.optimizer
-    value_target_updater = learner.value_target_updater
+    learner_update = _LearnerUpdate(cfg, device, learner)
 
     collector, behavior_policy_sync = _build_collection(
         cfg, device, learner, state_dim, action_dim, collector_action_frames
@@ -520,89 +637,6 @@ def main(cfg: DictConfig):
         if cfg.optimization.train_ratio is not None
         else None
     )
-
-    def train_step(
-        sample: TensorDictBase,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        with torch.autocast(
-            device_type=device.type,
-            dtype=torch.bfloat16,
-            enabled=use_bfloat16,
-        ):
-            model_loss_td, model_out = model_loss(sample)
-            model_kl = (
-                model_loss_td["loss_model_dynamic"]
-                + model_loss_td["loss_model_representation"]
-            )
-            total_model_loss = (
-                model_kl
-                + model_loss_td["loss_model_reco"]
-                + model_loss_td["loss_model_reward"]
-                + model_loss_td["loss_model_continue"]
-            ).squeeze()
-
-            post_state = (
-                model_out.get(("next", "state")).detach().reshape(-1, state_dim)
-            )
-            post_belief = (
-                model_out.get(("next", "belief"))
-                .detach()
-                .reshape(-1, cfg.networks.rnn_hidden_dim)
-            )
-            actor_input = TensorDict(
-                {"state": post_state, "belief": post_belief},
-                [post_state.shape[0]],
-            )
-            actor_loss_td, fake_data = actor_loss(actor_input)
-            value_loss_td, _ = value_loss(fake_data.detach())
-
-            replay_features = TensorDict(
-                {
-                    "state": model_out.get(("next", "state")),
-                    "belief": model_out.get(("next", "belief")),
-                    "bootstrap": fake_data.get("lambda_target")[..., 0, 0].reshape(
-                        sample.batch_size
-                    ),
-                    "next": sample.get("next").select("reward", "done", "terminated"),
-                },
-                sample.batch_size,
-            )
-            replay_loss = value_loss.replay_value_loss(
-                replay_features,
-                horizon=cfg.optimization.continuation_horizon,
-                lmbda=cfg.optimization.lmbda,
-            )["loss_replay_value"]
-            total_loss = (
-                total_model_loss
-                + actor_loss_td["loss_actor"]
-                + value_loss_td["loss_value"]
-                + cfg.optimization.replay_value_loss_weight * replay_loss
-            )
-
-        optimizer.zero_grad(set_to_none=True)
-        total_loss.backward()
-        metrics = torch.stack(
-            (
-                model_kl.detach().reshape(()),
-                model_loss_td["loss_model_reco"].detach().reshape(()),
-                model_loss_td["loss_model_reward"].detach().reshape(()),
-                actor_loss_td["loss_actor"].detach().reshape(()),
-                value_loss_td["loss_value"].detach().reshape(()),
-                replay_loss.detach().reshape(()),
-            )
-        )
-        return (
-            metrics,
-            model_out.get(("next", "state")).detach(),
-            model_out.get(("next", "belief")).detach(),
-        )
-
-    if cfg.optimization.cudagraph_train_step:
-        if device.type != "cuda":
-            raise RuntimeError(
-                "optimization.cudagraph_train_step requires a CUDA training device."
-            )
-        train_step = CudaGraphModule(train_step, warmup=5, device=device)
 
     if cfg.optimization.separate_policy_rng:
         # Keep the learner draws in a range apart from the policy stream.
@@ -669,9 +703,7 @@ def main(cfg: DictConfig):
                     update_losses,
                     refreshed_state,
                     refreshed_belief,
-                ) = train_step(sample)
-                optimizer.step()
-                value_target_updater.step()
+                ) = learner_update(sample)
                 batch_losses[update_index].copy_(update_losses)
                 loss_window_sum += update_losses
                 loss_window_updates += 1

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -60,7 +60,7 @@ from dreamer_v3_utils import (
 )
 from omegaconf import DictConfig
 from tensordict import TensorDict, TensorDictBase
-from tensordict.nn import TensorDictModuleBase
+from tensordict.nn import CudaGraphModule, TensorDictModuleBase
 
 from torchrl import timeit
 from torchrl._utils import get_available_device, logger as torchrl_logger
@@ -442,7 +442,7 @@ def main(cfg: DictConfig):
     use_bfloat16 = cfg.optimization.mixed_precision and device.type == "cuda"
     torchrl_logger.info(
         "DreamerV3 execution: device=%s, replay_device=%s, rssm_backend=%s, "
-        "rssm_scan_unroll=%s, mixed_precision=%s",
+        "rssm_scan_unroll=%s, mixed_precision=%s, cudagraph_train_step=%s",
         device,
         replay_device,
         cfg.optimization.compile_rssm or "eager",
@@ -452,6 +452,7 @@ def main(cfg: DictConfig):
             else "n/a"
         ),
         use_bfloat16,
+        cfg.optimization.cudagraph_train_step,
     )
     num_envs = cfg.collector.num_envs
     count_reset_records = cfg.collector.count_reset_records
@@ -580,8 +581,6 @@ def main(cfg: DictConfig):
 
         optimizer.zero_grad(set_to_none=True)
         total_loss.backward()
-        optimizer.step()
-        value_target_updater.step()
         metrics = torch.stack(
             (
                 model_kl.detach().reshape(()),
@@ -597,6 +596,13 @@ def main(cfg: DictConfig):
             model_out.get(("next", "state")).detach(),
             model_out.get(("next", "belief")).detach(),
         )
+
+    if cfg.optimization.cudagraph_train_step:
+        if device.type != "cuda":
+            raise RuntimeError(
+                "optimization.cudagraph_train_step requires a CUDA training device."
+            )
+        train_step = CudaGraphModule(train_step, warmup=5, device=device)
 
     if cfg.optimization.separate_policy_rng:
         # Keep the learner draws in a range apart from the policy stream.
@@ -664,6 +670,8 @@ def main(cfg: DictConfig):
                     refreshed_state,
                     refreshed_belief,
                 ) = train_step(sample)
+                optimizer.step()
+                value_target_updater.step()
                 batch_losses[update_index].copy_(update_losses)
                 loss_window_sum += update_losses
                 loss_window_updates += 1

--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -981,7 +981,7 @@ def test_public_block_gru_triton_gradient_parity(
     tolerance = (
         {"atol": 4e-2, "rtol": 6e-2}
         if dtype is torch.bfloat16
-        else {"atol": 3e-4, "rtol": 3e-4}
+        else {"atol": 2e-3, "rtol": 3e-4}
     )
     for expected_value, actual_value in zip(expected[:4], actual[:4]):
         torch.testing.assert_close(actual_value, expected_value, **tolerance)

--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -842,19 +842,21 @@ class TestDreamerV3Components:
             )
 
     @implement_for("torch", None, "2.6.0", compilable=True)
-    @pytest.mark.parametrize("scope", ["step"])
-    def test_rssm_rollout_compile(self, scope):
-        self._test_rssm_rollout_compile(scope)
+    @pytest.mark.parametrize(("scope", "unroll"), [("step", 1)])
+    def test_rssm_rollout_compile(self, scope, unroll):
+        self._test_rssm_rollout_compile(scope, unroll)
 
     @implement_for("torch", "2.6.0", compilable=True)
-    @pytest.mark.parametrize("scope", ["step", "scan"])
-    def test_rssm_rollout_compile(self, scope):  # noqa: F811
-        self._test_rssm_rollout_compile(scope)
+    @pytest.mark.parametrize(
+        ("scope", "unroll"), [("step", 1), ("scan", 1), ("scan", 3)]
+    )
+    def test_rssm_rollout_compile(self, scope, unroll):  # noqa: F811
+        self._test_rssm_rollout_compile(scope, unroll)
 
-    def _test_rssm_rollout_compile(self, scope):
+    def _test_rssm_rollout_compile(self, scope, unroll):
         rollout = self._make_rollout(torch.device("cpu"))
         data = self._make_rollout_data(torch.device("cpu"))
-        rollout.compile_rollout(scope, unroll=3 if scope == "scan" else 1)
+        rollout.compile_rollout(scope, unroll=unroll)
 
         output = rollout(data)
         (

--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -961,6 +961,7 @@ def test_public_block_gru_triton_gradient_parity(
     hidden_cotangent = torch.randn(batch, 32, device="cuda", dtype=dtype) / (batch * 32)
 
     def run(module):
+        module.zero_grad(set_to_none=True)
         value = value_source.detach().clone().requires_grad_()
         hidden = hidden_source.detach().clone().requires_grad_()
         output, final_hidden = module(value, hidden, is_init)
@@ -977,17 +978,18 @@ def test_public_block_gru_triton_gradient_parity(
         )
 
     expected = run(reference)
-    actual = run(triton_module)
     tolerance = (
         {"atol": 4e-2, "rtol": 6e-2}
         if dtype is torch.bfloat16
-        else {"atol": 3e-3, "rtol": 3e-4}
+        else {"atol": 3e-4, "rtol": 3e-4}
     )
-    for expected_value, actual_value in zip(expected[:4], actual[:4]):
-        torch.testing.assert_close(actual_value, expected_value, **tolerance)
-    assert actual[4].keys() == expected[4].keys()
-    for name in expected[4]:
-        torch.testing.assert_close(actual[4][name], expected[4][name], **tolerance)
+    for _ in range(3):
+        actual = run(triton_module)
+        for expected_value, actual_value in zip(expected[:4], actual[:4]):
+            torch.testing.assert_close(actual_value, expected_value, **tolerance)
+        assert actual[4].keys() == expected[4].keys()
+        for name in expected[4]:
+            torch.testing.assert_close(actual[4][name], expected[4][name], **tolerance)
 
 
 @pytest.mark.gpu

--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -981,7 +981,7 @@ def test_public_block_gru_triton_gradient_parity(
     tolerance = (
         {"atol": 4e-2, "rtol": 6e-2}
         if dtype is torch.bfloat16
-        else {"atol": 2e-3, "rtol": 3e-4}
+        else {"atol": 3e-3, "rtol": 3e-4}
     )
     for expected_value, actual_value in zip(expected[:4], actual[:4]):
         torch.testing.assert_close(actual_value, expected_value, **tolerance)

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -33,7 +33,7 @@ from torchrl.data import Unbounded
 from torchrl.envs.model_based.dreamer import DreamerEnv
 from torchrl.envs.transforms import TensorDictPrimer, TransformedEnv
 from torchrl.modules import SafeSequential, SymExpTwoHot, WorldModelWrapper
-from torchrl.modules.distributions.continuous import TanhNormal
+from torchrl.modules.distributions.continuous import IndependentNormal, TanhNormal
 from torchrl.modules.models.model_based import (
     DreamerActor,
     RSSMPosteriorV3,
@@ -644,6 +644,50 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         )
         assert grad_total > 0, "All gradients are zero after actor backward"
 
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    def test_dreamer_v3_actor_loss_cuda_graph(self, device):
+        device = torch.device(device)
+        if device.type != "cuda":
+            pytest.skip("CUDA graph test only runs for the CUDA parametrization")
+
+        tensordict = self._create_actor_data().to(device).reshape(-1)
+        actor_model = self._create_actor_model().to(device)
+        # The DMC reproduction uses IndependentNormal, whose constructor does
+        # not materialize action bounds from the host during graph capture.
+        actor_model[-1].distribution_class = IndependentNormal
+        continuation_model = TensorDictModule(
+            nn.Sequential(nn.Linear(self.state_dim, 1), nn.Sigmoid()).to(device),
+            in_keys=["state"],
+            out_keys=["continuation"],
+        )
+        loss_module = DreamerV3ActorLoss(
+            actor_model,
+            self._create_value_model().to(device),
+            self._create_mb_env().to(device),
+            continuation_model=continuation_model,
+            imagination_horizon=3,
+        )
+        loss_module.make_value_estimator(ValueEstimators.TDLambda)
+        loss_module.to(device)
+
+        warmup_stream = torch.cuda.Stream(device)
+        warmup_stream.wait_stream(torch.cuda.current_stream(device))
+        with torch.cuda.stream(warmup_stream):
+            for _ in range(3):
+                loss_module(tensordict)
+        torch.cuda.current_stream(device).wait_stream(warmup_stream)
+        torch.cuda.synchronize(device)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            loss_td, fake_data = loss_module(tensordict)
+        graph.replay()
+        torch.cuda.synchronize(device)
+
+        assert torch.isfinite(loss_td["loss_actor"])
+        assert fake_data.shape == (tensordict.shape[0], 3)
+
     def test_dreamer_v3_continuation_lambda_and_weights(self, device):
         class _ConstantContinuation(nn.Module):
             def forward(self_, state, belief):
@@ -736,6 +780,35 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             horizon=2.0,
             lmbda=0.5,
         )
+        torch.testing.assert_close(
+            target, torch.tensor([[9.8125, 15.25, 23.0]], device=device)
+        )
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    def test_dreamer_v3_replay_value_target_cuda_graph(self, device):
+        device = torch.device(device)
+        if device.type != "cuda":
+            pytest.skip("CUDA graph test only runs for the CUDA parametrization")
+
+        reward = torch.tensor([[0.0, 1.0, 2.0, 3.0]], device=device)
+        bootstrap = torch.tensor([[10.0, 20.0, 30.0, 40.0]], device=device)
+        done = torch.zeros_like(reward, dtype=torch.bool)
+        terminated = torch.zeros_like(done)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            target = _replay_value_target(
+                reward,
+                done,
+                terminated,
+                bootstrap,
+                horizon=2.0,
+                lmbda=0.5,
+            )
+        graph.replay()
+        torch.cuda.synchronize(device)
+
         torch.testing.assert_close(
             target, torch.tensor([[9.8125, 15.25, 23.0]], device=device)
         )
@@ -1785,6 +1858,7 @@ def test_dreamer_v3_dmc_reproduction_modes(tmp_path):
         "dmc_walker_runs",
         "optimization.compile_rssm=scan",
         "optimization.rssm_scan_unroll=8",
+        "optimization.cudagraph_train_step=true",
         "benchmark.seeds=[0]",
     ]
 

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -64,6 +64,10 @@ from torchrl.testing.mocking_classes import ContinuousActionConvMockEnv
 
 _has_hydra = importlib.util.find_spec("hydra") is not None
 _has_omegaconf = importlib.util.find_spec("omegaconf") is not None
+_has_gym = (
+    importlib.util.find_spec("gymnasium") is not None
+    or importlib.util.find_spec("gym") is not None
+)
 
 
 @pytest.mark.parametrize("device", get_default_devices())
@@ -1115,6 +1119,140 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         assert reward_td["reward"].shape == (2, 1)
         continuation_model(reward_td)
         assert reward_td["continuation"].shape == (2, 1)
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    @pytest.mark.skipif(
+        not (_has_hydra and _has_omegaconf and _has_gym),
+        reason="requires hydra, omegaconf, and gym",
+    )
+    def test_dreamer_v3_full_learner_cuda_graph_matches_eager(
+        self, device, monkeypatch
+    ):
+        from omegaconf import OmegaConf
+
+        device = torch.device(device)
+        if device.type != "cuda":
+            pytest.skip("CUDA graph test only runs for the CUDA parametrization")
+
+        repo_root = Path(__file__).parents[2]
+        example_dir = repo_root / "sota-implementations/dreamer_v3"
+        monkeypatch.syspath_prepend(str(example_dir))
+        example = runpy.run_path(
+            example_dir / "train.py",
+            run_name="dreamer_v3_learner_cuda_graph_test",
+        )
+
+        def make_config(cudagraph: bool):
+            cfg = OmegaConf.load(example_dir / "config.yaml")
+            cfg.networks.rnn_hidden_dim = 8
+            cfg.networks.num_categoricals = 2
+            cfg.networks.num_classes = 2
+            cfg.networks.num_blocks = 2
+            cfg.networks.hidden_dim = 8
+            cfg.networks.num_reward_bins = 16
+            cfg.networks.num_value_bins = 16
+            cfg.networks.encoder_layers = 1
+            cfg.networks.decoder_layers = 1
+            cfg.networks.reward_layers = 1
+            cfg.networks.actor_layers = 1
+            cfg.networks.value_layers = 1
+            cfg.replay_buffer.batch_size = 2
+            cfg.replay_buffer.seq_len = 3
+            cfg.optimization.imagination_horizon = 3
+            cfg.optimization.continuation_horizon = 3
+            cfg.optimization.warmup_steps = 0
+            cfg.optimization.mixed_precision = True
+            cfg.optimization.compile_rssm = "scan"
+            cfg.optimization.rssm_scan_unroll = 1
+            cfg.optimization.cudagraph_train_step = cudagraph
+            return cfg
+
+        state_dim = 4
+        torch.manual_seed(1)
+        data = TensorDict(
+            {
+                "state": torch.zeros(2, 3, state_dim, device=device),
+                "belief": torch.zeros(2, 3, 8, device=device),
+                "action": torch.randn(2, 3, 1, device=device),
+                "is_init": torch.zeros(2, 3, 1, dtype=torch.bool, device=device),
+                "next": {
+                    "observation": torch.randn(2, 3, 3, device=device),
+                    "reward": torch.randn(2, 3, 1, device=device),
+                    "done": torch.zeros(2, 3, 1, dtype=torch.bool, device=device),
+                    "terminated": torch.zeros(2, 3, 1, dtype=torch.bool, device=device),
+                },
+            },
+            [2, 3],
+            device=device,
+        )
+
+        updates = []
+        modules = []
+        learners = []
+        for cudagraph in (False, True):
+            cfg = make_config(cudagraph)
+            torch.manual_seed(0)
+            learner = example["_build_learner"](cfg, device, 3, 1)
+            learners.append(learner)
+            modules.append(
+                nn.ModuleList(
+                    [learner.model_loss, learner.actor_loss, learner.value_loss]
+                )
+            )
+            updates.append(
+                example["_LearnerUpdate"](
+                    cfg,
+                    device,
+                    learner,
+                    cudagraph_warmup=5,
+                )
+            )
+
+        initial_state = {
+            key: value.detach().clone()
+            for key, value in modules[0].state_dict().items()
+        }
+        torch.testing.assert_close(modules[1].state_dict(), initial_state)
+
+        # Compile both paths and finish graph capture without applying updates.
+        for update, sample in zip(updates, (data.clone(), data.clone())):
+            for _ in range(5):
+                update.train_step(sample)
+        for module in modules:
+            module.load_state_dict(initial_state)
+
+        eager_data = data.clone()
+        graph_data = data.clone()
+        for seed in (10, 11):
+            torch.manual_seed(seed)
+            expected = updates[0](eager_data)
+            torch.manual_seed(seed)
+            actual = updates[1](graph_data)
+            torch.testing.assert_close(actual, expected, atol=2e-3, rtol=2e-3)
+
+        torch.testing.assert_close(
+            modules[1].state_dict(),
+            modules[0].state_dict(),
+            atol=2e-4,
+            rtol=2e-3,
+        )
+        torch.testing.assert_close(
+            learners[1].optimizer.state_dict(),
+            learners[0].optimizer.state_dict(),
+            atol=2e-3,
+            rtol=2e-3,
+        )
+        assert learners[0].optimizer.state
+        assert learners[1].optimizer.state
+        assert learners[0].optimizer.param_groups[0]["step"] == 2
+        assert learners[1].optimizer.param_groups[0]["step"] == 2
+        target_prefix = "2.target_value_model_params"
+        assert any(
+            not torch.equal(value, initial_state[key])
+            for key, value in modules[0].state_dict().items()
+            if key.startswith(target_prefix)
+        )
 
     @pytest.mark.skipif(not _has_omegaconf, reason="requires omegaconf")
     def test_dreamer_v3_dmc_benchmark_aggregation(self, device, tmp_path):

--- a/torchrl/modules/models/_dreamer_v3_block_gru_triton.py
+++ b/torchrl/modules/models/_dreamer_v3_block_gru_triton.py
@@ -200,6 +200,13 @@ if _has_triton:
         triton.Config({"BLOCK_B": 8, "BLOCK_K": 32}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_B": 8, "BLOCK_K": 64}, num_warps=8, num_stages=1),
     ]
+    # The B2/K16 backward kernel can intermittently produce incorrect gradients.
+    # The same configuration is safe for the forward kernel.
+    _BACKWARD_CONFIGS = [
+        config
+        for config in _CONFIGS
+        if (config.kwargs["BLOCK_B"], config.kwargs["BLOCK_K"]) != (2, 16)
+    ]
 
     def _prune_configs(configs, named_args, **kwargs):
         h_pad = kwargs.get("H_PAD") or named_args["H_PAD"]
@@ -602,7 +609,7 @@ if _has_triton:
         )
 
     @triton.autotune(
-        configs=_CONFIGS,
+        configs=_BACKWARD_CONFIGS,
         key=[
             "T",
             "H",

--- a/torchrl/modules/models/model_based.py
+++ b/torchrl/modules/models/model_based.py
@@ -2128,8 +2128,8 @@ class RSSMRolloutV3(TensorDictModuleBase):
                 masked_state.clone(),
                 masked_belief.clone(),
                 action_t,
-                prior_logits,
-                posterior_logits,
+                prior_logits.clone(),
+                posterior_logits.clone(),
                 state.clone(),
                 belief.clone(),
             )

--- a/torchrl/modules/models/model_based.py
+++ b/torchrl/modules/models/model_based.py
@@ -1983,6 +1983,11 @@ class RSSMRolloutV3(TensorDictModuleBase):
         while reset.ndim < action.ndim:
             reset = reset.unsqueeze(-1)
 
+        if self._scan_fn is not None:
+            # ``compile_rollout`` can run before the module is moved to its
+            # execution device. hoptorch validates scan backward per device
+            # type, and the validation must happen outside the compiled call.
+            _maybe_warm_scan_backward(action.device)
         scan = self._scan_fn or self._loop
         (
             input_states,

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -757,6 +757,9 @@ class DreamerV3ActorLoss(LossModule):
                 policy=self.actor_model,
                 auto_reset=False,
                 tensordict=tensordict,
+                # Imagination is fixed-horizon; skip per-step CUDA-to-host
+                # synchronization for done checks.
+                break_when_any_done=False,
             )
             next_tensordict = step_mdp(fake_data, keep_other=True)
             with hold_out_net(self.value_model):
@@ -978,10 +981,11 @@ def _replay_value_target(
     terminated = terminated.squeeze(-1).unsqueeze(-1)
     bootstrap = bootstrap.squeeze(-1).unsqueeze(-1)
     # The vectorized path discovers and pads trajectory lengths dynamically,
-    # which cannot be captured by Dynamo in fullgraph mode.
+    # which cannot be captured by Dynamo or a CUDA graph.
     return_estimate = (
         td_lambda_return_estimate
         if _is_dynamo_compiling()
+        or (reward.is_cuda and torch.cuda.is_current_stream_capturing())
         else vec_td_lambda_return_estimate
     )
     return return_estimate(


### PR DESCRIPTION
## Summary

- add an opt-in CUDA-graph learner path to the DreamerV3 DMC reproduction
- make fixed-horizon imagination and replay lambda returns CUDA-graph compatible
- cover compiled RSSM scan unroll 1 and CUDA graph capture with regression tests
- add reproducible steady-state RSSM and complete-learner benchmarks that exclude compilation and capture warmup
- compare two complete uncaptured and CUDA-graph learner updates across losses, parameters, optimizer state, and slow targets

The `--fast` reproduction mode now selects the compiled RSSM scan with unroll 8 and captures the fixed-shape learner forward/backward after five warmup calls. Optimizer and target-network updates remain outside capture so their Python-side schedules continue to advance.

## Why

Profiling the compiled scan path on one NVIDIA GB200 showed about 7,500 CUDA launches per learner update, despite only about 14.7 ms of self CUDA kernel time. The dominant gap was CPU dispatch and scheduling overhead rather than arithmetic throughput.

A same-hardware, steady-state full-learner comparison at batch 16 x sequence 64, BF16 compute and FP32 parameters gave:

| implementation | median ms/update | transitions/s | relative to JAX |
| --- | ---: | ---: | ---: |
| upstream DreamerV3 JAX | 22.04 | 46,468 | 1.00x |
| TorchRL compiled scan | 358.51 | 2,856 | 16.3x slower |
| TorchRL compiled scan + CUDA graph | 17.83 | 57,415 | 1.24x faster |

The checked-in complete-learner benchmark reproduces the TorchRL rows with 10 warmup updates and 50 measured updates. It includes model, actor, value, and replay-value losses, imagination, backward, the optimizer step, and the slow-target update. It excludes compile/capture latency, replay sampling, and environment collection.

The JAX baseline is pinned to `danijar/dreamerv3@e3f02248693a79dc8b0ebd62c93683888ddaccfe`. A JAX compatibility shim only adapts the older positional `jax.jit` call convention to JAX 0.11 for GB200 support.

Triton is therefore not required for parity in this configuration. It remains a possible follow-up for residual kernel-time improvements.

## Test plan

- `test/modules/test_dreamer_components.py -k rssm_rollout_compile`: 3 passed
- `test/objectives/test_dreamer_v3.py -m "not gpu"`: 74 passed
- existing GB200 GPU capture regressions: 2 passed
- GB200 complete-learner equivalence regression: 1 passed
- DreamerV3 SOTA smoke command: passed
- `benchmarks/ad_hoc/bench_dreamer_v3_learner.py` on GB200:
  - compiled scan: 358.51 ms/update
  - compiled scan + CUDA graph: 17.83 ms/update
- `benchmarks/ad_hoc/bench_dreamer_v3_rssm.py` on GB200:
  - compiled scan: 218.04 ms/update
  - CUDA graph: 10.40 ms/update
