### PR TITLE
[Performance] Add Triton backend to DreamerV3 RSSM

### DIFF
--- a/benchmarks/ad_hoc/bench_dreamer_v3_rssm.py
+++ b/benchmarks/ad_hoc/bench_dreamer_v3_rssm.py
@@ -1,0 +1,166 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Benchmark the DreamerV3 RSSM compiled scan with and without CUDA graphs.
+
+The default dimensions match the DMC Walker reproduction configuration. The
+benchmark measures a synchronized forward/backward update after compilation
+and graph-capture warmup; it intentionally excludes cold-start latency.
+
+Example::
+
+    python benchmarks/ad_hoc/bench_dreamer_v3_rssm.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import functools as ft
+import json
+import statistics
+import time
+from collections.abc import Callable
+
+import torch
+from tensordict import TensorDict
+from tensordict.nn import CudaGraphModule, TensorDictModule
+
+from torchrl.modules.models import RSSMPosteriorV3, RSSMPriorV3, RSSMRolloutV3
+
+
+def _make_rollout(device: torch.device) -> RSSMRolloutV3:
+    prior = RSSMPriorV3(
+        action_shape=torch.Size([6]),
+        hidden_dim=64,
+        rnn_hidden_dim=512,
+        num_categoricals=32,
+        num_classes=4,
+        action_dim=6,
+        recurrent_model="block_gru",
+        num_blocks=8,
+        num_layers=1,
+        prior_num_layers=2,
+        unimix=0.01,
+    )
+    posterior = RSSMPosteriorV3(
+        hidden_dim=64,
+        num_categoricals=32,
+        num_classes=4,
+        rnn_hidden_dim=512,
+        obs_embed_dim=64,
+        use_rms_norm=True,
+        num_layers=1,
+        unimix=0.01,
+    )
+    return RSSMRolloutV3(
+        TensorDictModule(
+            prior,
+            in_keys=["state", "belief", "action"],
+            out_keys=[
+                ("next", "prior_logits"),
+                ("next", "state"),
+                ("next", "belief"),
+            ],
+        ),
+        TensorDictModule(
+            posterior,
+            in_keys=[("next", "belief"), ("next", "encoded_latents")],
+            out_keys=[("next", "posterior_logits"), ("next", "state")],
+        ),
+        reset_key="is_init",
+    ).to(device)
+
+
+def _make_data(device: torch.device, batch: int, steps: int) -> TensorDict:
+    return TensorDict(
+        {
+            "state": torch.zeros(batch, steps, 128, device=device),
+            "belief": torch.zeros(batch, steps, 512, device=device),
+            "action": torch.randn(batch, steps, 6, device=device),
+            "is_init": torch.zeros(batch, steps, 1, dtype=torch.bool, device=device),
+            "next": {"encoded_latents": torch.randn(batch, steps, 64, device=device)},
+        },
+        [batch, steps],
+        device=device,
+    )
+
+
+def _measure(
+    step: Callable[[], object],
+    *,
+    device: torch.device,
+    warmup: int,
+    iterations: int,
+) -> list[float]:
+    for _ in range(warmup):
+        step()
+    torch.cuda.synchronize(device)
+    samples = []
+    for _ in range(iterations):
+        started = time.perf_counter()
+        step()
+        torch.cuda.synchronize(device)
+        samples.append((time.perf_counter() - started) * 1000)
+    return samples
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch", type=int, default=16)
+    parser.add_argument("--steps", type=int, default=64)
+    parser.add_argument("--unroll", type=int, default=8)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iterations", type=int, default=50)
+    args = parser.parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("This benchmark requires CUDA.")
+
+    torch.manual_seed(0)
+    torch.set_float32_matmul_precision("high")
+    device = torch.device("cuda:0")
+    rollout = _make_rollout(device)
+    rollout.compile_rollout("scan", unroll=args.unroll)
+    data = _make_data(device, args.batch, args.steps)
+
+    def train_step(value: TensorDict) -> torch.Tensor:
+        rollout.zero_grad(set_to_none=True)
+        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            output = rollout(value)
+            loss = (
+                output["next", "posterior_logits"].float().square().mean()
+                + output["next", "prior_logits"].float().square().mean()
+                + 1e-4 * output["next", "belief"].float().square().mean()
+            )
+        loss.backward()
+        return loss.detach()
+
+    variants: dict[str, Callable[[], object]] = {
+        "compiled_scan": ft.partial(train_step, data),
+    }
+    graphed_step = CudaGraphModule(train_step, warmup=args.warmup, device=device)
+    variants["cuda_graph"] = ft.partial(graphed_step, data)
+
+    for name, step in variants.items():
+        samples = _measure(
+            step,
+            device=device,
+            warmup=args.warmup,
+            iterations=args.iterations,
+        )
+        median_ms = statistics.median(samples)
+        result = {
+            "variant": name,
+            "batch": args.batch,
+            "steps": args.steps,
+            "unroll": args.unroll,
+            "median_ms": median_ms,
+            "transitions_per_second": args.batch * args.steps * 1000 / median_ms,
+            "min_ms": min(samples),
+            "max_ms": max(samples),
+        }
+        print(json.dumps(result, sort_keys=True), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/ad_hoc/bench_dreamer_v3_rssm.py
+++ b/benchmarks/ad_hoc/bench_dreamer_v3_rssm.py
@@ -2,11 +2,12 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-"""Benchmark the DreamerV3 RSSM compiled scan with and without CUDA graphs.
+"""Benchmark DreamerV3 RSSM recurrent and sequence backends after warmup.
 
 The default dimensions match the DMC Walker reproduction configuration. The
-benchmark measures a synchronized forward/backward update after compilation
-and graph-capture warmup; it intentionally excludes cold-start latency.
+benchmark measures synchronized forward/backward updates for compiled scan and
+CUDA-graph-captured loop/scan variants. Compilation and capture warmup are
+intentionally excluded.
 
 Example::
 
@@ -21,6 +22,7 @@ import json
 import statistics
 import time
 from collections.abc import Callable
+from typing import Literal
 
 import torch
 from tensordict import TensorDict
@@ -29,7 +31,10 @@ from tensordict.nn import CudaGraphModule, TensorDictModule
 from torchrl.modules.models import RSSMPosteriorV3, RSSMPriorV3, RSSMRolloutV3
 
 
-def _make_rollout(device: torch.device) -> RSSMRolloutV3:
+def _make_rollout(
+    device: torch.device,
+    recurrent_backend: Literal["reference", "triton"],
+) -> RSSMRolloutV3:
     prior = RSSMPriorV3(
         action_shape=torch.Size([6]),
         hidden_dim=64,
@@ -38,6 +43,7 @@ def _make_rollout(device: torch.device) -> RSSMRolloutV3:
         num_classes=4,
         action_dim=6,
         recurrent_model="block_gru",
+        recurrent_backend=recurrent_backend,
         num_blocks=8,
         num_layers=1,
         prior_num_layers=2,
@@ -86,6 +92,19 @@ def _make_data(device: torch.device, batch: int, steps: int) -> TensorDict:
     )
 
 
+def _train_step(rollout: RSSMRolloutV3, value: TensorDict) -> torch.Tensor:
+    rollout.zero_grad(set_to_none=True)
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        output = rollout(value)
+        loss = (
+            output["next", "posterior_logits"].float().square().mean()
+            + output["next", "prior_logits"].float().square().mean()
+            + 1e-4 * output["next", "belief"].float().square().mean()
+        )
+    loss.backward()
+    return loss.detach()
+
+
 def _measure(
     step: Callable[[], object],
     *,
@@ -110,6 +129,12 @@ def main() -> None:
     parser.add_argument("--batch", type=int, default=16)
     parser.add_argument("--steps", type=int, default=64)
     parser.add_argument("--unroll", type=int, default=8)
+    parser.add_argument(
+        "--recurrent-backends",
+        nargs="+",
+        choices=("reference", "triton"),
+        default=("reference", "triton"),
+    )
     parser.add_argument("--warmup", type=int, default=5)
     parser.add_argument("--iterations", type=int, default=50)
     args = parser.parse_args()
@@ -119,47 +144,45 @@ def main() -> None:
     torch.manual_seed(0)
     torch.set_float32_matmul_precision("high")
     device = torch.device("cuda:0")
-    rollout = _make_rollout(device)
-    rollout.compile_rollout("scan", unroll=args.unroll)
     data = _make_data(device, args.batch, args.steps)
+    for recurrent_backend in args.recurrent_backends:
+        for sequence_backend in ("loop", "scan"):
+            rollout = _make_rollout(device, recurrent_backend)
+            if sequence_backend == "scan":
+                rollout.compile_rollout("scan", unroll=args.unroll)
+            train_step = ft.partial(_train_step, rollout)
 
-    def train_step(value: TensorDict) -> torch.Tensor:
-        rollout.zero_grad(set_to_none=True)
-        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
-            output = rollout(value)
-            loss = (
-                output["next", "posterior_logits"].float().square().mean()
-                + output["next", "prior_logits"].float().square().mean()
-                + 1e-4 * output["next", "belief"].float().square().mean()
+            variants: dict[str, Callable[[], object]] = {}
+            if sequence_backend == "scan":
+                variants["compiled_scan"] = ft.partial(train_step, data)
+            graphed_step = CudaGraphModule(
+                train_step, warmup=args.warmup, device=device
             )
-        loss.backward()
-        return loss.detach()
+            variants[f"cuda_graph_{sequence_backend}"] = ft.partial(graphed_step, data)
 
-    variants: dict[str, Callable[[], object]] = {
-        "compiled_scan": ft.partial(train_step, data),
-    }
-    graphed_step = CudaGraphModule(train_step, warmup=args.warmup, device=device)
-    variants["cuda_graph"] = ft.partial(graphed_step, data)
-
-    for name, step in variants.items():
-        samples = _measure(
-            step,
-            device=device,
-            warmup=args.warmup,
-            iterations=args.iterations,
-        )
-        median_ms = statistics.median(samples)
-        result = {
-            "variant": name,
-            "batch": args.batch,
-            "steps": args.steps,
-            "unroll": args.unroll,
-            "median_ms": median_ms,
-            "transitions_per_second": args.batch * args.steps * 1000 / median_ms,
-            "min_ms": min(samples),
-            "max_ms": max(samples),
-        }
-        print(json.dumps(result, sort_keys=True), flush=True)
+            for name, step in variants.items():
+                samples = _measure(
+                    step,
+                    device=device,
+                    warmup=args.warmup,
+                    iterations=args.iterations,
+                )
+                median_ms = statistics.median(samples)
+                result = {
+                    "variant": name,
+                    "recurrent_backend": recurrent_backend,
+                    "batch": args.batch,
+                    "steps": args.steps,
+                    "unroll": args.unroll,
+                    "median_ms": median_ms,
+                    "transitions_per_second": args.batch
+                    * args.steps
+                    * 1000
+                    / median_ms,
+                    "min_ms": min(samples),
+                    "max_ms": max(samples),
+                }
+                print(json.dumps(result, sort_keys=True), flush=True)
 
 
 if __name__ == "__main__":

--- a/docs/source/reference/dreamer_v3.rst
+++ b/docs/source/reference/dreamer_v3.rst
@@ -110,6 +110,16 @@ latent state. The actor and prediction heads consume both ``state`` and
 blocks used by the example's encoder, decoder, actor, critic, and prediction
 heads.
 
+The block-GRU prior also accepts ``recurrent_backend="triton"``. This
+CUDA-only option routes each recurrent update through the fused Triton
+block-GRU kernel and requires Triton 3.3 or newer. It can be combined with
+``RSSMRolloutV3.compile_rollout("scan", unroll=8)`` and CUDA graphs. The
+Triton kernel only fuses the recurrent update: the prior and posterior heads,
+categorical sampling, and sequential RSSM dependency remain in the rollout.
+Whether it improves end-to-end speed therefore depends on the workload and
+capture mode; compare it with the default ``"reference"`` backend on the
+target hardware.
+
 For recurrent features outside an RSSM, :class:`~torchrl.modules.DreamerV3BlockGRUCell`
 exposes the same block-diagonal update as a single-step module, while
 :class:`~torchrl.modules.DreamerV3BlockGRU` executes batch-major sequences with
@@ -169,6 +179,13 @@ developer benchmark from a source checkout:
         --backends reference,scan,triton --batches 16 --seq-lens 64,512 \
         --hiddens 512 --input-size 512 --projection-size 512 --blocks 8 \
         --dtype bfloat16 --warmup 10 --iters 30
+
+For the complete prior/posterior RSSM update used by the maintained example,
+including compiled scan and CUDA-graph variants, run:
+
+.. code-block:: bash
+
+    python benchmarks/ad_hoc/bench_dreamer_v3_rssm.py
 
 Use the batch size, sequence length, widths, block count, dtype, and compile
 modes from the intended workload: backend performance is hardware- and

--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -57,7 +57,8 @@ For a three-seed median and interquartile reproduction run:
 ```
 
 For the fastest supported accelerator path, enable the compiled RSSM scan
-(unrolled eight steps at a time):
+(unrolled eight steps at a time) and CUDA-graph capture of the fixed-shape
+learner forward/backward:
 
 ```bash
 ./sota-implementations/dreamer_v3/reproduce_dmc_walker.sh --fast
@@ -82,8 +83,8 @@ or manual validation; pull-request CI uses short smoke overrides. Set
 `OUTPUT_DIR` to change the output directory (the defaults are
 `dmc_walker_runs` and `dmc_walker_smoke`), and append any other Hydra overrides
 to the wrapper, for example `benchmark.seeds=[0]`. Each run logs the resolved
-training device, replay device, RSSM backend, scan unroll and mixed-precision
-state.
+training device, replay device, RSSM backend, scan unroll, mixed-precision state
+and learner CUDA-graph setting.
 
 For a smaller ablation, shorten the run rather than the window:
 
@@ -107,3 +108,7 @@ recurrence and the imagination prior, and is faster, but its draws fall inside
 the compiled region, so a seeded run diverges from an eager one. The scan uses
 `optimization.rssm_scan_unroll=8` by default; lower values reduce compilation
 time and graph size, while `1` disables manual unrolling.
+`optimization.cudagraph_train_step=true` captures the learner forward and
+backward after five warmup calls. It requires CUDA and fixed input shapes;
+optimizer and target-network steps remain outside capture so their schedules
+continue to advance normally.

--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -64,6 +64,18 @@ learner forward/backward:
 ./sota-implementations/dreamer_v3/reproduce_dmc_walker.sh --fast
 ```
 
+The RSSM block GRU has an experimental NVIDIA-only Triton 3.3+ backend. It is
+an explicit ablation because its benefit depends on whether the learner is
+CUDA-graph captured; select it alongside any other Hydra overrides with:
+
+```bash
+./sota-implementations/dreamer_v3/reproduce_dmc_walker.sh --fast \
+  networks.recurrent_backend=triton
+```
+
+The default remains `reference`. Benchmark both choices on the target GPU
+after compile and capture warmup before selecting the Triton backend.
+
 Compilation has an up-front cost, so the short validation remains eager:
 
 ```bash

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -56,6 +56,8 @@ optimization:
   compile_rssm: null
   # Number of RSSM steps traced per higher-order scan iteration.
   rssm_scan_unroll: 8
+  # Capture the fixed-shape learner forward/backward on CUDA after warmup.
+  cudagraph_train_step: false
   lr: 4.0e-5
   optimizer_eps: 1.0e-20
   adaptive_grad_clip: 0.3

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -27,6 +27,8 @@ networks:
   num_classes: 4
   unimix: 0.01
   recurrent_model: block_gru
+  # Block-GRU execution backend: "reference" or CUDA-only "triton".
+  recurrent_backend: reference
   num_blocks: 8
   dynamics_layers: 1
   prior_layers: 2

--- a/sota-implementations/dreamer_v3/dreamer_v3_agent.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_agent.py
@@ -475,6 +475,7 @@ def build_world_model(
         action_dim=action_dim,
         unimix=cfg.networks.unimix,
         recurrent_model=cfg.networks.recurrent_model,
+        recurrent_backend=cfg.networks.recurrent_backend,
         num_blocks=cfg.networks.num_blocks,
         num_layers=cfg.networks.dynamics_layers,
         prior_num_layers=cfg.networks.prior_layers,

--- a/sota-implementations/dreamer_v3/reproduce_dmc_walker.sh
+++ b/sota-implementations/dreamer_v3/reproduce_dmc_walker.sh
@@ -83,6 +83,7 @@ elif [ "$fast" -eq 1 ]; then
   benchmark_command+=(
     optimization.compile_rssm=scan
     optimization.rssm_scan_unroll=8
+    optimization.cudagraph_train_step=true
   )
 fi
 

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -442,10 +442,12 @@ def main(cfg: DictConfig):
     use_bfloat16 = cfg.optimization.mixed_precision and device.type == "cuda"
     torchrl_logger.info(
         "DreamerV3 execution: device=%s, replay_device=%s, rssm_backend=%s, "
-        "rssm_scan_unroll=%s, mixed_precision=%s, cudagraph_train_step=%s",
+        "rssm_recurrent_backend=%s, rssm_scan_unroll=%s, mixed_precision=%s, "
+        "cudagraph_train_step=%s",
         device,
         replay_device,
         cfg.optimization.compile_rssm or "eager",
+        cfg.networks.recurrent_backend,
         (
             cfg.optimization.rssm_scan_unroll
             if cfg.optimization.compile_rssm == "scan"

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -60,7 +60,7 @@ from dreamer_v3_utils import (
 )
 from omegaconf import DictConfig
 from tensordict import TensorDict, TensorDictBase
-from tensordict.nn import TensorDictModuleBase
+from tensordict.nn import CudaGraphModule, TensorDictModuleBase
 
 from torchrl import timeit
 from torchrl._utils import get_available_device, logger as torchrl_logger
@@ -442,7 +442,7 @@ def main(cfg: DictConfig):
     use_bfloat16 = cfg.optimization.mixed_precision and device.type == "cuda"
     torchrl_logger.info(
         "DreamerV3 execution: device=%s, replay_device=%s, rssm_backend=%s, "
-        "rssm_scan_unroll=%s, mixed_precision=%s",
+        "rssm_scan_unroll=%s, mixed_precision=%s, cudagraph_train_step=%s",
         device,
         replay_device,
         cfg.optimization.compile_rssm or "eager",
@@ -452,6 +452,7 @@ def main(cfg: DictConfig):
             else "n/a"
         ),
         use_bfloat16,
+        cfg.optimization.cudagraph_train_step,
     )
     num_envs = cfg.collector.num_envs
     count_reset_records = cfg.collector.count_reset_records
@@ -579,8 +580,6 @@ def main(cfg: DictConfig):
 
         optimizer.zero_grad(set_to_none=True)
         total_loss.backward()
-        optimizer.step()
-        value_target_updater.step()
         metrics = torch.stack(
             (
                 model_kl.detach().reshape(()),
@@ -596,6 +595,13 @@ def main(cfg: DictConfig):
             model_out.get(("next", "state")).detach(),
             model_out.get(("next", "belief")).detach(),
         )
+
+    if cfg.optimization.cudagraph_train_step:
+        if device.type != "cuda":
+            raise RuntimeError(
+                "optimization.cudagraph_train_step requires a CUDA training device."
+            )
+        train_step = CudaGraphModule(train_step, warmup=5, device=device)
 
     if cfg.optimization.separate_policy_rng:
         # Keep the learner draws in a range apart from the policy stream.
@@ -663,6 +669,8 @@ def main(cfg: DictConfig):
                     refreshed_state,
                     refreshed_belief,
                 ) = train_step(sample)
+                optimizer.step()
+                value_target_updater.step()
                 batch_losses[update_index].copy_(update_losses)
                 loss_window_sum += update_losses
                 loss_window_updates += 1

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -520,6 +520,7 @@ def main(cfg: DictConfig):
         if cfg.optimization.train_ratio is not None
         else None
     )
+
     def train_step(
         sample: TensorDictBase,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:

--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -302,7 +302,7 @@ class TestDreamerV3Components:
         assert ratio.item() == pytest.approx(1.0, rel=0.05)
 
     @staticmethod
-    def _make_rollout(device):
+    def _make_rollout(device, recurrent_backend="reference"):
         prior = RSSMPriorV3(
             action_shape=(2,),
             hidden_dim=8,
@@ -311,6 +311,7 @@ class TestDreamerV3Components:
             num_classes=4,
             action_dim=2,
             recurrent_model="block_gru",
+            recurrent_backend=recurrent_backend,
             num_blocks=2,
             device=device,
         )
@@ -865,11 +866,74 @@ class TestDreamerV3Components:
         ).backward()
         assert all(parameter.grad is not None for parameter in rollout.parameters())
 
+    @pytest.mark.gpu
+    @pytest.mark.skipif(
+        not torch.cuda.is_available() or not _has_dreamer_v3_triton,
+        reason="DreamerV3 Triton backend requires CUDA and Triton 3.3+",
+    )
+    def test_rssm_rollout_triton_gradient_parity(self):
+        torch.manual_seed(0)
+        reference = self._make_rollout(torch.device("cuda"))
+        triton_rollout = self._make_rollout(
+            torch.device("cuda"), recurrent_backend="triton"
+        )
+        triton_rollout.load_state_dict(reference.state_dict())
+        reference_core = reference.rssm_prior.module.rnn
+        triton_core = triton_rollout.rssm_prior.module.rnn
+        state = torch.randn(2, 8, device="cuda")
+        belief = torch.randn(2, 8, device="cuda")
+        action = torch.randn(2, 2, device="cuda")
+        cotangent = torch.randn(2, 8, device="cuda")
+
+        def run(core):
+            core.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                output = core(state, belief, action)
+            (output.float() * cotangent).sum().backward()
+            return output, {
+                name: parameter.grad for name, parameter in core.named_parameters()
+            }
+
+        expected_output, expected_gradients = run(reference_core)
+        actual_output, actual_gradients = run(triton_core)
+        torch.testing.assert_close(actual_output, expected_output, atol=5e-2, rtol=5e-2)
+        assert actual_gradients.keys() == expected_gradients.keys()
+        for name in expected_gradients:
+            torch.testing.assert_close(
+                actual_gradients[name],
+                expected_gradients[name],
+                atol=5e-2,
+                rtol=5e-2,
+                msg=f"RSSM gradient mismatch for {name}",
+            )
+
+        triton_rollout.zero_grad(set_to_none=True)
+        triton_rollout.compile_rollout("scan", unroll=3)
+        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            output = triton_rollout(self._make_rollout_data(torch.device("cuda")))
+        sum(output[key].square().mean() for key in triton_rollout.out_keys).backward()
+        assert all(
+            parameter.grad is not None and parameter.grad.isfinite().all()
+            for parameter in triton_rollout.parameters()
+        )
+
 
 def test_public_block_gru_triton_errors():
     with mock.patch("torchrl.modules.models.model_based._has_dreamer_v3_triton", False):
         with pytest.raises(RuntimeError, match="requires Triton"):
             DreamerV3BlockGRU(6, 8, recurrent_backend="triton")
+        with pytest.raises(RuntimeError, match="requires Triton"):
+            RSSMPriorV3(
+                action_shape=(2,),
+                hidden_dim=8,
+                rnn_hidden_dim=8,
+                num_categoricals=4,
+                num_classes=4,
+                action_dim=2,
+                recurrent_model="block_gru",
+                recurrent_backend="triton",
+                num_blocks=2,
+            )
 
     class CustomActivation(torch.nn.Module):
         def forward(self, value):

--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -842,19 +842,21 @@ class TestDreamerV3Components:
             )
 
     @implement_for("torch", None, "2.6.0", compilable=True)
-    @pytest.mark.parametrize("scope", ["step"])
-    def test_rssm_rollout_compile(self, scope):
-        self._test_rssm_rollout_compile(scope)
+    @pytest.mark.parametrize(("scope", "unroll"), [("step", 1)])
+    def test_rssm_rollout_compile(self, scope, unroll):
+        self._test_rssm_rollout_compile(scope, unroll)
 
     @implement_for("torch", "2.6.0", compilable=True)
-    @pytest.mark.parametrize("scope", ["step", "scan"])
-    def test_rssm_rollout_compile(self, scope):  # noqa: F811
-        self._test_rssm_rollout_compile(scope)
+    @pytest.mark.parametrize(
+        ("scope", "unroll"), [("step", 1), ("scan", 1), ("scan", 3)]
+    )
+    def test_rssm_rollout_compile(self, scope, unroll):  # noqa: F811
+        self._test_rssm_rollout_compile(scope, unroll)
 
-    def _test_rssm_rollout_compile(self, scope):
+    def _test_rssm_rollout_compile(self, scope, unroll):
         rollout = self._make_rollout(torch.device("cpu"))
         data = self._make_rollout_data(torch.device("cpu"))
-        rollout.compile_rollout(scope, unroll=3 if scope == "scan" else 1)
+        rollout.compile_rollout(scope, unroll=unroll)
 
         output = rollout(data)
         (

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -33,7 +33,7 @@ from torchrl.data import Unbounded
 from torchrl.envs.model_based.dreamer import DreamerEnv
 from torchrl.envs.transforms import TensorDictPrimer, TransformedEnv
 from torchrl.modules import SafeSequential, SymExpTwoHot, WorldModelWrapper
-from torchrl.modules.distributions.continuous import TanhNormal
+from torchrl.modules.distributions.continuous import IndependentNormal, TanhNormal
 from torchrl.modules.models.model_based import (
     DreamerActor,
     RSSMPosteriorV3,
@@ -644,6 +644,50 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         )
         assert grad_total > 0, "All gradients are zero after actor backward"
 
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    def test_dreamer_v3_actor_loss_cuda_graph(self, device):
+        device = torch.device(device)
+        if device.type != "cuda":
+            pytest.skip("CUDA graph test only runs for the CUDA parametrization")
+
+        tensordict = self._create_actor_data().to(device).reshape(-1)
+        actor_model = self._create_actor_model().to(device)
+        # The DMC reproduction uses IndependentNormal, whose constructor does
+        # not materialize action bounds from the host during graph capture.
+        actor_model[-1].distribution_class = IndependentNormal
+        continuation_model = TensorDictModule(
+            nn.Sequential(nn.Linear(self.state_dim, 1), nn.Sigmoid()).to(device),
+            in_keys=["state"],
+            out_keys=["continuation"],
+        )
+        loss_module = DreamerV3ActorLoss(
+            actor_model,
+            self._create_value_model().to(device),
+            self._create_mb_env().to(device),
+            continuation_model=continuation_model,
+            imagination_horizon=3,
+        )
+        loss_module.make_value_estimator(ValueEstimators.TDLambda)
+        loss_module.to(device)
+
+        warmup_stream = torch.cuda.Stream(device)
+        warmup_stream.wait_stream(torch.cuda.current_stream(device))
+        with torch.cuda.stream(warmup_stream):
+            for _ in range(3):
+                loss_module(tensordict)
+        torch.cuda.current_stream(device).wait_stream(warmup_stream)
+        torch.cuda.synchronize(device)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            loss_td, fake_data = loss_module(tensordict)
+        graph.replay()
+        torch.cuda.synchronize(device)
+
+        assert torch.isfinite(loss_td["loss_actor"])
+        assert fake_data.shape == (tensordict.shape[0], 3)
+
     def test_dreamer_v3_continuation_lambda_and_weights(self, device):
         class _ConstantContinuation(nn.Module):
             def forward(self_, state, belief):
@@ -736,6 +780,35 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             horizon=2.0,
             lmbda=0.5,
         )
+        torch.testing.assert_close(
+            target, torch.tensor([[9.8125, 15.25, 23.0]], device=device)
+        )
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    def test_dreamer_v3_replay_value_target_cuda_graph(self, device):
+        device = torch.device(device)
+        if device.type != "cuda":
+            pytest.skip("CUDA graph test only runs for the CUDA parametrization")
+
+        reward = torch.tensor([[0.0, 1.0, 2.0, 3.0]], device=device)
+        bootstrap = torch.tensor([[10.0, 20.0, 30.0, 40.0]], device=device)
+        done = torch.zeros_like(reward, dtype=torch.bool)
+        terminated = torch.zeros_like(done)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            target = _replay_value_target(
+                reward,
+                done,
+                terminated,
+                bootstrap,
+                horizon=2.0,
+                lmbda=0.5,
+            )
+        graph.replay()
+        torch.cuda.synchronize(device)
+
         torch.testing.assert_close(
             target, torch.tensor([[9.8125, 15.25, 23.0]], device=device)
         )
@@ -1785,6 +1858,7 @@ def test_dreamer_v3_dmc_reproduction_modes(tmp_path):
         "dmc_walker_runs",
         "optimization.compile_rssm=scan",
         "optimization.rssm_scan_unroll=8",
+        "optimization.cudagraph_train_step=true",
         "benchmark.seeds=[0]",
     ]
 

--- a/torchrl/modules/models/_dreamer_v3_block_gru_triton.py
+++ b/torchrl/modules/models/_dreamer_v3_block_gru_triton.py
@@ -1028,13 +1028,15 @@ class _DreamerV3BlockGRUTritonFunction(torch.autograd.Function):
             update_bias,
             num_blocks,
             num_layers,
+            input_before_hidden,
             save_state,
-        ) = args[-6:]
-        tensors = args[:-6]
+        ) = args[-7:]
+        tensors = args[:-7]
         dynamic = [tensors[index : index + 3] for index in range(0, 3 * num_layers, 3)]
         gate_weight, gate_bias = tensors[3 * num_layers :]
-        batch, time, projected_size = projected_input.shape
+        batch, time, input_size = projected_input.shape
         hidden_size = initial_hidden.shape[-1]
+        projected_size = hidden_weight.shape[0]
         block_size = hidden_size // num_blocks
         compute_dtype = projected_input.dtype
         h_pad = max(
@@ -1059,8 +1061,12 @@ class _DreamerV3BlockGRUTritonFunction(torch.autograd.Function):
 
         first_weight = dynamic[0][0].to(compute_dtype)
         first_carry = first_weight[:, :block_size]
-        first_input = first_weight[:, block_size : block_size + projected_size]
-        first_hidden = first_weight[:, block_size + projected_size :]
+        if input_before_hidden:
+            first_input = first_weight[:, block_size : block_size + input_size]
+            first_hidden = first_weight[:, block_size + input_size :]
+        else:
+            first_hidden = first_weight[:, block_size : block_size + projected_size]
+            first_input = first_weight[:, block_size + projected_size :]
         first_recurrent = torch.cat((first_carry, first_hidden), 1)
         first_recurrent_p = F.pad(
             first_recurrent,
@@ -1213,6 +1219,7 @@ class _DreamerV3BlockGRUTritonFunction(torch.autograd.Function):
         ctx.activation_code = activation_code
         ctx.num_blocks = num_blocks
         ctx.num_layers = num_layers
+        ctx.input_before_hidden = input_before_hidden
         ctx.padding = (h_pad, p_pad, d_pad, g_pad, k_rec_pad)
         if save_state:
             ctx.save_for_backward(
@@ -1268,8 +1275,9 @@ class _DreamerV3BlockGRUTritonFunction(torch.autograd.Function):
             dynamic_norm_p,
             gate_weight_t_p,
         ) = saved[offset:]
-        batch, time, projected_size = projected_input.shape
+        batch, time, input_size = projected_input.shape
         hidden_size = initial_hidden.shape[-1]
+        projected_size = hidden_weight.shape[0]
         block_size = hidden_size // ctx.num_blocks
         h_pad, p_pad, d_pad, g_pad, k_rec_pad = ctx.padding
         if grad_outputs is None:
@@ -1341,7 +1349,7 @@ class _DreamerV3BlockGRUTritonFunction(torch.autograd.Function):
 
         # Input order: projected_input, initial_hidden, is_init, hidden_weight,
         # hidden_bias, hidden_norm_weight, 3 dynamic params per layer,
-        # gate_weight, gate_bias, then the 6 non-tensor arguments.
+        # gate_weight, gate_bias, then the 7 non-tensor arguments.
         needs_input_grad = ctx.needs_input_grad
         first_weight_index = 6
         gate_weight_index = first_weight_index + 3 * num_layers
@@ -1388,31 +1396,47 @@ class _DreamerV3BlockGRUTritonFunction(torch.autograd.Function):
                     hidden_normalized.float() * hidden_norm_weight.float(),
                     ctx.activation_code,
                 ).to(outputs.dtype)
-                grad_weight = torch.cat(
-                    (
-                        _block_weight_grad(
-                            previous,
-                            grad_pre,
-                            weight[:, :block_size],
-                        ),
-                        _block_weight_grad(
-                            projected_input,
-                            grad_pre,
-                            weight[
-                                :,
-                                block_size : block_size + projected_size,
-                            ],
-                            value_shared_across_blocks=True,
-                        ),
-                        _block_weight_grad(
-                            hidden_features,
-                            grad_pre,
-                            weight[:, block_size + projected_size :],
-                            value_shared_across_blocks=True,
-                        ),
-                    ),
-                    1,
+                grad_carry_weight = _block_weight_grad(
+                    previous,
+                    grad_pre,
+                    weight[:, :block_size],
                 )
+                if ctx.input_before_hidden:
+                    input_weight = weight[:, block_size : block_size + input_size]
+                    hidden_weight = weight[:, block_size + input_size :]
+                else:
+                    hidden_weight = weight[:, block_size : block_size + projected_size]
+                    input_weight = weight[:, block_size + projected_size :]
+                grad_input_weight = _block_weight_grad(
+                    projected_input,
+                    grad_pre,
+                    input_weight,
+                    value_shared_across_blocks=True,
+                )
+                grad_projected_hidden_weight = _block_weight_grad(
+                    hidden_features,
+                    grad_pre,
+                    hidden_weight,
+                    value_shared_across_blocks=True,
+                )
+                if ctx.input_before_hidden:
+                    grad_weight = torch.cat(
+                        (
+                            grad_carry_weight,
+                            grad_input_weight,
+                            grad_projected_hidden_weight,
+                        ),
+                        1,
+                    )
+                else:
+                    grad_weight = torch.cat(
+                        (
+                            grad_carry_weight,
+                            grad_projected_hidden_weight,
+                            grad_input_weight,
+                        ),
+                        1,
+                    )
             else:
                 layer_input = _activation(
                     dynamic_normalized[layer_index - 1].float()
@@ -1435,12 +1459,15 @@ class _DreamerV3BlockGRUTritonFunction(torch.autograd.Function):
             )
         if needs_input_grad[0]:
             first_weight = dynamic[0][0].to(outputs.dtype)
-            input_weight = first_weight[:, block_size : block_size + projected_size]
+            if ctx.input_before_hidden:
+                input_weight = first_weight[:, block_size : block_size + input_size]
+            else:
+                input_weight = first_weight[:, block_size + projected_size :]
             # The flat GEMM's reduction dimension sums over the blocks.
             grad_projected = (
                 (
                     grad_dynamic_pre[0].reshape(batch * time, hidden_size)
-                    @ input_weight.transpose(1, 2).reshape(hidden_size, projected_size)
+                    @ input_weight.transpose(1, 2).reshape(hidden_size, input_size)
                 )
                 .reshape_as(projected_input)
                 .to(projected_input.dtype)
@@ -1471,7 +1498,7 @@ class _DreamerV3BlockGRUTritonFunction(torch.autograd.Function):
             grad_gate_weight,
             grad_gate_bias,
         )
-        return (*tensor_grads, None, None, None, None, None, None)
+        return (*tensor_grads, None, None, None, None, None, None, None)
 
 
 def dreamer_v3_block_gru_triton(
@@ -1489,6 +1516,7 @@ def dreamer_v3_block_gru_triton(
     update_bias: float,
     num_blocks: int,
     num_layers: int,
+    input_before_hidden: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Run the CUDA-only fused DreamerV3 block-GRU recurrence."""
     if not _has_triton:
@@ -1544,5 +1572,6 @@ def dreamer_v3_block_gru_triton(
         update_bias,
         num_blocks,
         num_layers,
+        input_before_hidden,
         save_state,
     )

--- a/torchrl/modules/models/model_based.py
+++ b/torchrl/modules/models/model_based.py
@@ -2128,8 +2128,8 @@ class RSSMRolloutV3(TensorDictModuleBase):
                 masked_state.clone(),
                 masked_belief.clone(),
                 action_t,
-                prior_logits,
-                posterior_logits,
+                prior_logits.clone(),
+                posterior_logits.clone(),
                 state.clone(),
                 belief.clone(),
             )

--- a/torchrl/modules/models/model_based.py
+++ b/torchrl/modules/models/model_based.py
@@ -213,9 +213,19 @@ class _DreamerV3BlockGRU(nn.Module):
         num_blocks: int,
         num_layers: int,
         norm_eps: float,
+        recurrent_backend: Literal["reference", "triton"] = "reference",
         device=None,
     ):
         super().__init__()
+        if recurrent_backend not in ("reference", "triton"):
+            raise ValueError(
+                "recurrent_backend must be 'reference' or 'triton', got "
+                f"{recurrent_backend!r}."
+            )
+        if recurrent_backend == "triton" and not _has_dreamer_v3_triton:
+            raise RuntimeError(
+                "recurrent_backend='triton' requires Triton 3.3 or newer."
+            )
         if belief_dim % num_blocks:
             raise ValueError(
                 "rnn_hidden_dim must be divisible by num_blocks, got "
@@ -223,6 +233,7 @@ class _DreamerV3BlockGRU(nn.Module):
             )
         self.belief_dim = belief_dim
         self.num_blocks = num_blocks
+        self.recurrent_backend = recurrent_backend
         self.belief_projection = nn.Sequential(
             nn.Linear(belief_dim, hidden_dim, device=device),
             _DreamerV3RMSNorm(hidden_dim, norm_eps, device=device),
@@ -264,6 +275,8 @@ class _DreamerV3BlockGRU(nn.Module):
         action: torch.Tensor,
     ) -> torch.Tensor:
         action = action / action.detach().abs().clamp_min(1)
+        if self.recurrent_backend == "triton":
+            return self._triton(state, belief, action)
         features = torch.cat(
             [
                 self.belief_projection(belief),
@@ -280,6 +293,47 @@ class _DreamerV3BlockGRU(nn.Module):
             num_blocks=self.num_blocks,
             update_bias=-1.0,
         )
+
+    def _triton(
+        self,
+        state: torch.Tensor,
+        belief: torch.Tensor,
+        action: torch.Tensor,
+    ) -> torch.Tensor:
+        from torchrl.modules.models._dreamer_v3_block_gru_triton import (
+            dreamer_v3_block_gru_triton,
+        )
+
+        state_features = self.state_projection(state)
+        action_features = self.action_projection(action)
+        projected_input = torch.cat((state_features, action_features), -1)
+        batch_shape = belief.shape[:-1]
+        projected_input = projected_input.reshape(-1, 1, projected_input.shape[-1])
+        initial_hidden = belief.reshape(-1, self.belief_dim)
+        is_init = belief.new_zeros(initial_hidden.shape[0], 1, dtype=torch.bool)
+        dynamic_parameters = []
+        for index in range(0, len(self.hidden_layers), 3):
+            linear = self.hidden_layers[index]
+            norm = self.hidden_layers[index + 1]
+            dynamic_parameters.extend((linear.weight, linear.bias, norm.weight))
+        output, _ = dreamer_v3_block_gru_triton(
+            projected_input,
+            initial_hidden,
+            is_init,
+            self.belief_projection[0].weight,
+            self.belief_projection[0].bias,
+            self.belief_projection[1].weight,
+            dynamic_parameters,
+            self.gates.weight,
+            self.gates.bias,
+            self.hidden_layers[2],
+            self.hidden_layers[1].eps,
+            -1.0,
+            self.num_blocks,
+            len(self.hidden_layers) // 3,
+            input_before_hidden=False,
+        )
+        return output.reshape(*batch_shape, self.belief_dim)
 
 
 def _activation_with_derivative(
@@ -1425,6 +1479,10 @@ class RSSMPriorV3(nn.Module):
             ``"gru"`` preserves the historical TorchRL implementation while
             ``"block_gru"`` selects the grouped DreamerV3 core. Defaults to
             ``"gru"``.
+        recurrent_backend ("reference" or "triton", optional): Execution
+            backend for ``recurrent_model="block_gru"``. The explicit
+            ``"triton"`` backend requires an NVIDIA GPU and Triton 3.3 or
+            newer. Defaults to ``"reference"``.
         num_blocks (int, optional): Number of groups in the block GRU.
             Defaults to 8.
         num_layers (int, optional): Number of block-linear dynamics layers.
@@ -1468,6 +1526,7 @@ class RSSMPriorV3(nn.Module):
         *,
         action_shape: torch.Size | tuple[int, ...] | None = None,
         recurrent_model: Literal["gru", "block_gru"] = "gru",
+        recurrent_backend: Literal["reference", "triton"] = "reference",
         num_blocks: int = 8,
         num_layers: int = 1,
         prior_num_layers: int = 2,
@@ -1501,6 +1560,10 @@ class RSSMPriorV3(nn.Module):
             )
         if recurrent_model == "block_gru" and action_dim is None:
             raise ValueError("block_gru requires an explicit action_dim.")
+        if recurrent_model != "block_gru" and recurrent_backend != "reference":
+            raise ValueError(
+                "recurrent_backend only applies when recurrent_model='block_gru'."
+            )
         self.recurrent_model = recurrent_model
 
         if recurrent_model == "block_gru":
@@ -1512,6 +1575,7 @@ class RSSMPriorV3(nn.Module):
                 num_blocks=num_blocks,
                 num_layers=num_layers,
                 norm_eps=norm_eps,
+                recurrent_backend=recurrent_backend,
                 device=device,
             )
             prior_layers = []

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -757,6 +757,9 @@ class DreamerV3ActorLoss(LossModule):
                 policy=self.actor_model,
                 auto_reset=False,
                 tensordict=tensordict,
+                # Imagination is fixed-horizon; skip per-step CUDA-to-host
+                # synchronization for done checks.
+                break_when_any_done=False,
             )
             next_tensordict = step_mdp(fake_data, keep_other=True)
             with hold_out_net(self.value_model):
@@ -978,10 +981,11 @@ def _replay_value_target(
     terminated = terminated.squeeze(-1).unsqueeze(-1)
     bootstrap = bootstrap.squeeze(-1).unsqueeze(-1)
     # The vectorized path discovers and pads trajectory lengths dynamically,
-    # which cannot be captured by Dynamo in fullgraph mode.
+    # which cannot be captured by Dynamo or a CUDA graph.
     return_estimate = (
         td_lambda_return_estimate
         if _is_dynamo_compiling()
+        or (reward.is_cuda and torch.cuda.is_current_stream_capturing())
         else vec_td_lambda_return_estimate
     )
     return return_estimate(


### PR DESCRIPTION
Stacked on #4216; the first two commits in this diff belong to that PR.

## Summary

- expose the existing fused Triton block-GRU as an opt-in RSSM recurrent backend
- preserve the RSSM parameter layout and checkpoint compatibility by teaching the kernel wrapper about the RSSM feature order
- plumb the backend through the maintained DreamerV3 Hydra config and report it in the resolved execution settings
- add a warmed forward/backward benchmark covering compiled scan and CUDA-graph loop/scan variants
- document the measured limitation: the RSSM calls the kernel once per posterior-interleaved step, so Triton cannot retain the whole-sequence temporal fusion of the standalone block GRU

The default remains `reference`, including under `--fast`.

## GB200 benchmark

One NVIDIA GB200, BF16, batch 16, sequence length 64, scan unroll 8. Medians exclude five compile/capture warmup iterations.

| Recurrent backend | Sequence/capture path | Median update | Transitions/s |
|---|---|---:|---:|
| reference | CUDA-graph loop | 25.78 ms | 39,723 |
| reference | compiled scan | 204.12 ms | 5,017 |
| reference | CUDA-graph scan | 11.31 ms | 90,525 |
| Triton | CUDA-graph loop | 27.87 ms | 36,746 |
| Triton | compiled scan | 247.96 ms | 4,130 |
| Triton | CUDA-graph scan | 18.00 ms | 56,890 |

Full DMC Walker learner, after ten warmup updates, using compiled scan/unroll 8 and CUDA graph:

| Recurrent backend | Update | Transitions/s |
|---|---:|---:|
| reference | 17.91 ms | 57,162 |
| Triton | 24.77 ms | 41,344 |

The Triton learner is 38% slower per update (28% lower throughput) in this
configuration. These results are why this PR exposes Triton for compatibility
and experimentation but does not make it part of the recommended fast path.

## Test plan

- `26 passed, 214 deselected` for the DreamerV3 CPU component suite
- `1 passed, 239 deselected` on GB200 for BF16 recurrent-core forward/all-parameter-gradient parity and a full compiled-scan backward smoke test
- repository-pinned ufmt, flake8, pydocstyle, docstring/Sphinx checks, YAML validation, and codespell
