### PR TITLE
[Feature] Optional 2x2 task video at MicroDuck evaluations

### DIFF
--- a/examples/microduck/README.md
+++ b/examples/microduck/README.md
@@ -150,7 +150,8 @@ gait prior of `policy.from_prior=true` only walks along the forward command,
 so with it those tasks can do no better than stand. `smoke=true` runs a
 pipeline check. `evaluation.video.interval=4` logs, at every fourth
 evaluation, a 2x2 video of four tasks filmed in parallel (one native
-simulator per tile, each pinned to its task with `MicroDuckTaskSampler.fixed`);
+simulator per tile, each pinned to its task with `MicroDuckTaskSampler.fixed`,
+tiled by a `VideoRecorder` on the batched env);
 it is off by default because video storage on the logger side is not free,
 and W&B needs `moviepy` for it. Checkpoints are unified TorchRL
 checkpoints written with `save_render_checkpoint`, which `rlrender` and

--- a/examples/microduck/README.md
+++ b/examples/microduck/README.md
@@ -148,7 +148,11 @@ index; `env.task_id=2` pins one task at every reset (evaluation, rendering).
 Sidestep and jump tasks need the default end-to-end policy: the closed-form
 gait prior of `policy.from_prior=true` only walks along the forward command,
 so with it those tasks can do no better than stand. `smoke=true` runs a
-pipeline check. Checkpoints are unified TorchRL
+pipeline check. `evaluation.video.interval=4` logs, at every fourth
+evaluation, a 2x2 video of four tasks filmed in parallel (one native
+simulator per tile, each pinned to its task with `MicroDuckTaskSampler.fixed`);
+it is off by default because video storage on the logger side is not free,
+and W&B needs `moviepy` for it. Checkpoints are unified TorchRL
 checkpoints written with `save_render_checkpoint`, which `rlrender` and
 `policy.init_from` read directly.
 

--- a/examples/microduck/config.yaml
+++ b/examples/microduck/config.yaml
@@ -48,6 +48,12 @@ evaluation:
   steps: 500
   best_checkpoint_path: microduck_ppo_best.ckpt
   latest_checkpoint_path: null
+  video:                    # 2x2 grid of four tasks filmed in parallel, logged with the evaluation metrics
+    interval: null          # log at every N-th evaluation; null disables it (video storage is not free)
+    tasks: [1, 2, 3, 5]     # library indices of the four tiles, row-major
+    steps: 250              # frames at 50 Hz
+    width: 320
+    height: 240
 
 logger:
   backend: wandb            # wandb | csv | tensorboard | null

--- a/examples/microduck/ppo_mujoco.py
+++ b/examples/microduck/ppo_mujoco.py
@@ -1129,7 +1129,7 @@ def main(cfg: DictConfig) -> None:
                 "config": config,
             },
         )
-        video_recorder = None
+        video_callback = None
         if cfg.evaluation.video.interval is not None and logger is not None:
             # A 2x2 grid of four tasks filmed in parallel, logged at every
             # `video.interval`-th evaluation.
@@ -1144,7 +1144,7 @@ def main(cfg: DictConfig) -> None:
                 height=cfg.evaluation.video.height,
             )
 
-            def video_recorder(step: int) -> None:
+            def _video_callback(step: int) -> None:
                 record_task_grid(
                     video_env,
                     grid_recorder,
@@ -1152,6 +1152,8 @@ def main(cfg: DictConfig) -> None:
                     steps=cfg.evaluation.video.steps,
                     step=step,
                 )
+
+            video_callback = _video_callback
 
         train_ppo(
             env,
@@ -1161,7 +1163,7 @@ def main(cfg: DictConfig) -> None:
             max_episode_steps=cfg.env.max_episode_steps,
             evaluators=evaluators,
             evaluation_interval=cfg.evaluation.interval,
-            video_recorder=video_recorder,
+            video_recorder=video_callback,
             video_interval=cfg.evaluation.video.interval,
             best_checkpoint_path=cfg.evaluation.best_checkpoint_path,
             latest_checkpoint_path=cfg.evaluation.latest_checkpoint_path,

--- a/examples/microduck/ppo_mujoco.py
+++ b/examples/microduck/ppo_mujoco.py
@@ -86,6 +86,7 @@ from torchrl.modules import (
 )
 from torchrl.objectives import ClipPPOLoss, KLAdaptiveLR
 from torchrl.objectives.value import GAE
+from torchrl.record import VideoRecorder
 from torchrl.record.loggers import generate_exp_name, get_logger, Logger
 from torchrl.render import load_checkpoint, save_render_checkpoint
 
@@ -244,6 +245,7 @@ def make_video_env(
     cfg: DictConfig | Mapping[str, Any],
     task_ids: Sequence[int],
     *,
+    recorder: VideoRecorder,
     width: int,
     height: int,
 ) -> TransformedEnv:
@@ -252,8 +254,8 @@ def make_video_env(
     A batched native env with one simulator per entry of ``task_ids``, each
     pinned to its task at every reset by
     :meth:`~torchrl.envs.MicroDuckTaskSampler.fixed`, rendering ``pixels`` at
-    ``width`` x ``height``. Four tasks make the 2x2 grid of
-    :func:`tile_task_grid`.
+    ``width`` x ``height`` into ``recorder``, whose ``make_grid`` tiles the
+    batch (2x2 for four tasks, row-major) into one video.
     """
     env = make_env(
         OmegaConf.merge(
@@ -269,41 +271,22 @@ def make_video_env(
         from_pixels=True,
     )
     env.append_transform(MicroDuckTaskSampler.fixed(task_ids))
+    env.append_transform(recorder)
     return env
 
 
-def tile_task_grid(pixels: torch.Tensor) -> torch.Tensor:
-    """Tile the per-env frames of a rollout into one video, row-major.
-
-    ``pixels`` has shape ``(*batch, T, H, W, 3)`` with a batch of ``n`` envs;
-    the result has shape ``(T, 3, rows * H, cols * W)`` with ``cols`` the
-    ceiling of ``sqrt(n)`` (2x2 for four envs), in the ``uint8`` layout that
-    :meth:`~torchrl.record.loggers.Logger.log_video` expects.
-    """
-    frames = pixels.reshape(-1, *pixels.shape[-4:])
-    n, cols = frames.shape[0], math.ceil(math.sqrt(frames.shape[0]))
-    rows = math.ceil(n / cols)
-    if rows * cols != n:
-        frames = torch.cat(
-            (frames, frames.new_zeros(rows * cols - n, *frames.shape[1:]))
-        )
-    grid = torch.cat(
-        [
-            torch.cat(list(frames[r * cols : (r + 1) * cols]), dim=-2)
-            for r in range(rows)
-        ],
-        dim=-3,
-    )
-    return grid.permute(0, 3, 1, 2).contiguous()
-
-
 def record_task_grid(
-    env: TransformedEnv, actor: ProbabilisticActor, steps: int
-) -> torch.Tensor:
-    """Roll the deterministic actor out on the video env and return the tiled video."""
+    env: TransformedEnv,
+    recorder: VideoRecorder,
+    actor: ProbabilisticActor,
+    *,
+    steps: int,
+    step: int,
+) -> None:
+    """Roll the deterministic actor out on the video env and log the grid at ``step``."""
     with set_exploration_type(ExplorationType.DETERMINISTIC), torch.no_grad():
-        rollout = env.rollout(steps, actor, break_when_any_done=False)
-    return tile_task_grid(rollout["pixels"])
+        env.rollout(steps, actor, break_when_any_done=False)
+    recorder.dump(step=step)
 
 
 def task_labels(tasks: Sequence[MicroDuckTask]) -> list[str]:
@@ -794,8 +777,8 @@ def train_ppo(
 
     Every ``video_interval`` evaluations, ``video_recorder`` is called with
     the transition count, for a video logged alongside the metrics (see
-    :func:`record_task_grid`); it is off by default because video storage is
-    not free.
+    :func:`record_task_grid`); it is off by default because video storage on
+    the logger side is not free.
 
     Every ``evaluation_interval`` iterations the ``evaluators`` (one per
     task of the library, see :func:`make_evaluator`) run the actor's current
@@ -1150,19 +1133,24 @@ def main(cfg: DictConfig) -> None:
         if cfg.evaluation.video.interval is not None and logger is not None:
             # A 2x2 grid of four tasks filmed in parallel, logged at every
             # `video.interval`-th evaluation.
+            grid_recorder = VideoRecorder(
+                logger, tag="evaluation/task_grid", make_grid=True, fps=50
+            )
             video_env = make_video_env(
                 cfg.env,
                 list(cfg.evaluation.video.tasks),
+                recorder=grid_recorder,
                 width=cfg.evaluation.video.width,
                 height=cfg.evaluation.video.height,
             )
 
             def video_recorder(step: int) -> None:
-                logger.log_video(
-                    "evaluation/task_grid",
-                    record_task_grid(video_env, actor, cfg.evaluation.video.steps),
+                record_task_grid(
+                    video_env,
+                    grid_recorder,
+                    actor,
+                    steps=cfg.evaluation.video.steps,
                     step=step,
-                    fps=50,
                 )
 
         train_ppo(

--- a/examples/microduck/ppo_mujoco.py
+++ b/examples/microduck/ppo_mujoco.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 
 import math
 import sys
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import asdict, replace
 from functools import partial
@@ -75,6 +75,7 @@ from torchrl.envs import (
     MicroDuckTaskSampler,
     TransformedEnv,
 )
+from torchrl.envs.utils import ExplorationType, set_exploration_type
 from torchrl.modules import (
     get_primers_from_module,
     GRUModule,
@@ -126,6 +127,7 @@ def make_env(
     num_envs: int | None = None,
     parallel: bool | None = None,
     device: torch.device | str | None = None,
+    from_pixels: bool = False,
 ) -> TransformedEnv:
     """Build the batched env from the ``env`` section of ``config.yaml``.
 
@@ -140,6 +142,9 @@ def make_env(
     entries so a checkpoint renders with one env from a local asset path; other
     entries go through ``cfg``, e.g.
     ``--env-kwargs '{"cfg": {"backend": "mujoco", "task_id": 2}}'``.
+
+    ``from_pixels`` adds a rendered ``pixels`` observation at the config's
+    ``render_width`` and ``render_height`` (see :func:`make_video_env`).
 
     :class:`~torchrl.envs.InitTracker` marks episode starts. The primer that
     carries the GRU state between steps comes from the policy
@@ -201,6 +206,7 @@ def make_env(
         "camera_id": env_cfg["camera_id"],
         "render_width": env_cfg["render_width"],
         "render_height": env_cfg["render_height"],
+        "from_pixels": from_pixels,
     }
     if env_cfg["backend"] == "mujoco":
         kwargs["parallel"] = env_cfg["parallel"]
@@ -232,6 +238,72 @@ def make_tasks(entries: Sequence[Mapping[str, Any]]) -> list[MicroDuckTask]:
             )
         tasks.append(getattr(MicroDuckEnv, preset)(**kwargs))
     return tasks
+
+
+def make_video_env(
+    cfg: DictConfig | Mapping[str, Any],
+    task_ids: Sequence[int],
+    *,
+    width: int,
+    height: int,
+) -> TransformedEnv:
+    """Build the env that films one task per tile of the evaluation video.
+
+    A batched native env with one simulator per entry of ``task_ids``, each
+    pinned to its task at every reset by
+    :meth:`~torchrl.envs.MicroDuckTaskSampler.fixed`, rendering ``pixels`` at
+    ``width`` x ``height``. Four tasks make the 2x2 grid of
+    :func:`tile_task_grid`.
+    """
+    env = make_env(
+        OmegaConf.merge(
+            cfg,
+            {
+                "backend": "mujoco",
+                "task_id": None,
+                "render_width": width,
+                "render_height": height,
+            },
+        ),
+        num_envs=len(task_ids),
+        from_pixels=True,
+    )
+    env.append_transform(MicroDuckTaskSampler.fixed(task_ids))
+    return env
+
+
+def tile_task_grid(pixels: torch.Tensor) -> torch.Tensor:
+    """Tile the per-env frames of a rollout into one video, row-major.
+
+    ``pixels`` has shape ``(*batch, T, H, W, 3)`` with a batch of ``n`` envs;
+    the result has shape ``(T, 3, rows * H, cols * W)`` with ``cols`` the
+    ceiling of ``sqrt(n)`` (2x2 for four envs), in the ``uint8`` layout that
+    :meth:`~torchrl.record.loggers.Logger.log_video` expects.
+    """
+    frames = pixels.reshape(-1, *pixels.shape[-4:])
+    n, cols = frames.shape[0], math.ceil(math.sqrt(frames.shape[0]))
+    rows = math.ceil(n / cols)
+    if rows * cols != n:
+        frames = torch.cat(
+            (frames, frames.new_zeros(rows * cols - n, *frames.shape[1:]))
+        )
+    grid = torch.cat(
+        [
+            torch.cat(list(frames[r * cols : (r + 1) * cols]), dim=-2)
+            for r in range(rows)
+        ],
+        dim=-3,
+    )
+    return grid.permute(0, 3, 1, 2).contiguous()
+
+
+def record_task_grid(
+    env: TransformedEnv, actor: ProbabilisticActor, steps: int
+) -> torch.Tensor:
+    """Roll the deterministic actor out on the video env and return the tiled video."""
+    with set_exploration_type(ExplorationType.DETERMINISTIC), torch.no_grad():
+        rollout = env.rollout(steps, actor, break_when_any_done=False)
+    return tile_task_grid(rollout["pixels"])
 
 
 def task_labels(tasks: Sequence[MicroDuckTask]) -> list[str]:
@@ -697,6 +769,8 @@ def train_ppo(
     max_grad_norm: float = 1.0,
     per_task_advantage: bool = True,
     evaluators: Sequence[Evaluator] | None = None,
+    video_recorder: Callable[[int], None] | None = None,
+    video_interval: int | None = None,
     evaluation_interval: int | None = None,
     best_checkpoint_path: str | Path | None = None,
     latest_checkpoint_path: str | Path | None = None,
@@ -717,6 +791,11 @@ def train_ppo(
     loss over the whole minibatch, so the tasks whose rewards vary least
     (standing, a hop that has not happened yet) keep a learning signal next to
     the walking tasks.
+
+    Every ``video_interval`` evaluations, ``video_recorder`` is called with
+    the transition count, for a video logged alongside the metrics (see
+    :func:`record_task_grid`); it is off by default because video storage is
+    not free.
 
     Every ``evaluation_interval`` iterations the ``evaluators`` (one per
     task of the library, see :func:`make_evaluator`) run the actor's current
@@ -745,6 +824,8 @@ def train_ppo(
         raise ValueError("evaluation_interval must be positive when provided.")
     if evaluation_interval is not None and not evaluators:
         raise ValueError("evaluation_interval requires evaluators.")
+    if video_recorder is not None and (video_interval is None or video_interval < 1):
+        raise ValueError("video_recorder requires a positive video_interval.")
     checkpointing = (
         best_checkpoint_path is not None or latest_checkpoint_path is not None
     )
@@ -824,11 +905,17 @@ def train_ppo(
             config=config,
         )
 
+    evaluations = 0
+
     def evaluate(step: int) -> dict[str, float]:
-        nonlocal best_score, best_state
+        nonlocal best_score, best_state, evaluations
         results = [
             evaluator.evaluate(weights=actor, step=step) for evaluator in evaluators
         ]
+        if video_recorder is not None and evaluations % video_interval == 0:
+            with timeit("video"):
+                video_recorder(step)
+        evaluations += 1
         metrics = evaluation_metrics(results)
         score = evaluation_score(results)
         checkpoint(latest_checkpoint_path, step, metrics, score)
@@ -1018,6 +1105,7 @@ def main(cfg: DictConfig) -> None:
     }
     env = make_env(cfg.env)
     evaluators: list[Evaluator] = []
+    video_env = None
     logger = None
     try:
         actor, critic = make_models(env, device=env.device, **policy_kwargs)
@@ -1058,6 +1146,25 @@ def main(cfg: DictConfig) -> None:
                 "config": config,
             },
         )
+        video_recorder = None
+        if cfg.evaluation.video.interval is not None and logger is not None:
+            # A 2x2 grid of four tasks filmed in parallel, logged at every
+            # `video.interval`-th evaluation.
+            video_env = make_video_env(
+                cfg.env,
+                list(cfg.evaluation.video.tasks),
+                width=cfg.evaluation.video.width,
+                height=cfg.evaluation.video.height,
+            )
+
+            def video_recorder(step: int) -> None:
+                logger.log_video(
+                    "evaluation/task_grid",
+                    record_task_grid(video_env, actor, cfg.evaluation.video.steps),
+                    step=step,
+                    fps=50,
+                )
+
         train_ppo(
             env,
             actor,
@@ -1066,6 +1173,8 @@ def main(cfg: DictConfig) -> None:
             max_episode_steps=cfg.env.max_episode_steps,
             evaluators=evaluators,
             evaluation_interval=cfg.evaluation.interval,
+            video_recorder=video_recorder,
+            video_interval=cfg.evaluation.video.interval,
             best_checkpoint_path=cfg.evaluation.best_checkpoint_path,
             latest_checkpoint_path=cfg.evaluation.latest_checkpoint_path,
             policy_kwargs=policy_kwargs,
@@ -1077,6 +1186,8 @@ def main(cfg: DictConfig) -> None:
             logger.experiment.finish()
         for evaluator in evaluators:
             evaluator.shutdown()
+        if video_env is not None and not video_env.is_closed:
+            video_env.close()
         if not env.is_closed:
             env.close()
 

--- a/test/libs/test_mujoco.py
+++ b/test/libs/test_mujoco.py
@@ -1085,17 +1085,6 @@ class TestMujoco:
             "action_scale": 0.5,
             "tasks": [{"preset": "tracking_task", "speed": 0.03}],
         }
-        # The evaluation video tiles one env per cell, row-major, in the
-        # (T, C, H, W) layout loggers expect.
-        frames = (
-            torch.arange(4).view(4, 1, 1, 1, 1).expand(4, 2, 3, 5, 3).to(torch.uint8)
-        )
-        grid = ppo.tile_task_grid(frames)
-        assert grid.shape == (2, 3, 6, 10)
-        assert grid[0, 0, :3, :5].unique().tolist() == [0]
-        assert grid[0, 0, :3, 5:].unique().tolist() == [1]
-        assert grid[0, 0, 3:, :5].unique().tolist() == [2]
-        assert grid[0, 0, 3:, 5:].unique().tolist() == [3]
         assert ppo.task_labels(
             ppo.make_tasks(
                 [

--- a/test/libs/test_mujoco.py
+++ b/test/libs/test_mujoco.py
@@ -852,6 +852,31 @@ class TestMujoco:
         for weights in ([1.0, -1.0], [1.0, float("nan")], [1.0, float("inf")]):
             with pytest.raises(ValueError, match="finite.*non-negative"):
                 MicroDuckTaskSampler(weights)
+        # Fixed ids give every env its own task at every reset, including
+        # partial ones, which is how several tasks are filmed side by side.
+        env = TransformedEnv(
+            MicroDuckEnv(
+                scene,
+                backend="mujoco",
+                num_envs=2,
+                parallel=False,
+                tasks=library,
+                seed=0,
+            ),
+            MicroDuckTaskSampler.fixed([2, 0]),
+        )
+        rollout = env.rollout(3)
+        assert rollout["task_id"][..., 0].flatten(0, 1).tolist() == [[2] * 3, [0] * 3]
+        partial = env.reset(
+            TensorDict({"_reset": torch.tensor([[True], [False]])}, batch_size=(2, 1))
+        )
+        after = env.step(partial.set("action", env.action_spec.rand()))
+        assert after["next", "task_id"].flatten().tolist() == [2, 0]
+        with pytest.raises(ValueError, match="fixed task ids"):
+            TransformedEnv(env.base_env, MicroDuckTaskSampler.fixed([1])).reset()
+        env.close()
+        with pytest.raises(ValueError, match="exactly one"):
+            MicroDuckTaskSampler([1.0], task_ids=[0])
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
@@ -1060,6 +1085,17 @@ class TestMujoco:
             "action_scale": 0.5,
             "tasks": [{"preset": "tracking_task", "speed": 0.03}],
         }
+        # The evaluation video tiles one env per cell, row-major, in the
+        # (T, C, H, W) layout loggers expect.
+        frames = (
+            torch.arange(4).view(4, 1, 1, 1, 1).expand(4, 2, 3, 5, 3).to(torch.uint8)
+        )
+        grid = ppo.tile_task_grid(frames)
+        assert grid.shape == (2, 3, 6, 10)
+        assert grid[0, 0, :3, :5].unique().tolist() == [0]
+        assert grid[0, 0, :3, 5:].unique().tolist() == [1]
+        assert grid[0, 0, 3:, :5].unique().tolist() == [2]
+        assert grid[0, 0, 3:, 5:].unique().tolist() == [3]
         assert ppo.task_labels(
             ppo.make_tasks(
                 [

--- a/torchrl/envs/custom/mujoco/microduck.py
+++ b/torchrl/envs/custom/mujoco/microduck.py
@@ -1889,10 +1889,15 @@ class MicroDuckTaskSampler(Transform):
     the envs being reset; the env checks the indices against its library.
 
     Args:
-        weights (Sequence[float] or torch.Tensor): one non-negative sampling
-            weight per task of the env's library, in library order.
+        weights (Sequence[float] or torch.Tensor, optional): one non-negative
+            sampling weight per task of the env's library, in library order.
+            Exactly one of ``weights`` and ``task_ids`` must be given.
 
     Keyword Args:
+        task_ids (Sequence[int] or torch.Tensor, optional): one fixed task
+            index per env instead of a draw, so env ``i`` runs ``task_ids[i]``
+            at every reset; the count must match the number of envs. See
+            :meth:`fixed`.
         task_id_key (NestedKey, optional): key written in the reset
             TensorDict. Defaults to ``"task_id"``.
         seed (int, optional): seed of the sampler's generator. Inside a
@@ -1911,31 +1916,57 @@ class MicroDuckTaskSampler(Transform):
         ... )
         >>> env.rollout(50)["task_id"][:, 0, 0]  # one task per env  # doctest: +SKIP
         >>> sampler.probabilities.copy_(torch.tensor([0.0, 0.0, 1.0]))  # doctest: +SKIP
+
+        One fixed task per env, for instance to film four tasks side by side:
+
+        >>> MicroDuckTaskSampler.fixed([1, 2, 0, 2]).sample(torch.Size([4]))[:, 0]
+        tensor([1, 2, 0, 2])
     """
 
     def __init__(
         self,
-        weights: Sequence[float] | torch.Tensor,
+        weights: Sequence[float] | torch.Tensor | None = None,
         *,
+        task_ids: Sequence[int] | torch.Tensor | None = None,
         task_id_key: NestedKey = "task_id",
         seed: int | None = None,
     ):
         super().__init__(in_keys=[], out_keys=[], in_keys_inv=[], out_keys_inv=[])
-        weights = torch.as_tensor(weights, dtype=torch.float32).reshape(-1)
-        if (
-            weights.numel() == 0
-            or not torch.isfinite(weights).all()
-            or (weights < 0).any()
-            or weights.sum() <= 0
-        ):
-            raise ValueError(
-                "weights must be a finite, non-empty sequence of non-negative "
-                "values that do not all vanish."
-            )
+        if (weights is None) == (task_ids is None):
+            raise ValueError("Give exactly one of weights and task_ids.")
         self.task_id_key = task_id_key
-        self.register_buffer("probabilities", weights / weights.sum())
+        if weights is not None:
+            weights = torch.as_tensor(weights, dtype=torch.float32).reshape(-1)
+            if (
+                weights.numel() == 0
+                or not torch.isfinite(weights).all()
+                or (weights < 0).any()
+                or weights.sum() <= 0
+            ):
+                raise ValueError(
+                    "weights must be a finite, non-empty sequence of non-negative "
+                    "values that do not all vanish."
+                )
+            self.register_buffer("probabilities", weights / weights.sum())
+            self.task_ids = None
+        else:
+            task_ids = torch.as_tensor(task_ids, dtype=torch.long).reshape(-1)
+            if task_ids.numel() == 0 or (task_ids < 0).any():
+                raise ValueError("task_ids must be a non-empty sequence of indices.")
+            self.register_buffer("task_ids", task_ids)
+            self.probabilities = None
         self.rng: torch.Generator | None = None
         self._set_seed(seed)
+
+    @classmethod
+    def fixed(
+        cls,
+        task_ids: Sequence[int] | torch.Tensor,
+        *,
+        task_id_key: NestedKey = "task_id",
+    ) -> MicroDuckTaskSampler:
+        """One fixed task per env: env ``i`` runs ``task_ids[i]`` at every reset."""
+        return cls(task_ids=task_ids, task_id_key=task_id_key)
 
     def _set_seed(self, seed: int | None) -> None:
         if seed is None:
@@ -1945,8 +1976,19 @@ class MicroDuckTaskSampler(Transform):
         self.rng.manual_seed(int(seed))
 
     def sample(self, batch_size: torch.Size) -> torch.Tensor:
-        """Draw one task index per element of ``batch_size``, shape ``(*batch_size, 1)``."""
-        n = int(torch.Size(batch_size).numel())
+        """Return one task index per element of ``batch_size``, shape ``(*batch_size, 1)``.
+
+        Fixed ids are laid out over the batch in order; weighted samplers draw.
+        """
+        batch_size = torch.Size(batch_size)
+        n = int(batch_size.numel())
+        if self.task_ids is not None:
+            if self.task_ids.numel() != n:
+                raise ValueError(
+                    f"{self.task_ids.numel()} fixed task ids cannot cover a batch of "
+                    f"{n} envs (batch shape {tuple(batch_size)})."
+                )
+            return self.task_ids.reshape(*batch_size, 1)
         index = torch.multinomial(
             self.probabilities.cpu(), n, replacement=True, generator=self.rng
         )
@@ -1956,10 +1998,9 @@ class MicroDuckTaskSampler(Transform):
         batch_size = (
             self.parent.batch_size if self.parent is not None else torch.Size([])
         )
+        buffer = self.task_ids if self.probabilities is None else self.probabilities
         if tensordict is None:
-            tensordict = TensorDict(
-                batch_size=batch_size, device=self.probabilities.device
-            )
+            tensordict = TensorDict(batch_size=batch_size, device=buffer.device)
         tensordict.set(self.task_id_key, self.sample(batch_size).to(tensordict.device))
         return tensordict
 


### PR DESCRIPTION
Stacked on #4212 (`microduck/multitask`). Adds an optional 2x2 evaluation video to the MicroDuck PPO example: four tasks filmed in parallel, one native simulator per tile, logged with the evaluation metrics.

## Env: fixed per-env tasks

`MicroDuckTaskSampler` gains `task_ids=` (and the `fixed(task_ids)` constructor): instead of a weighted draw, env `i` runs `task_ids[i]` at every reset, full or partial. The count must match the number of envs. This is the "fixed assignment is written at reset" case of the library design; the env keeps drawing on its own when no sampler is attached.

## Example

- `make_video_env(cfg.env, task_ids, width=, height=)` builds a batched native env with one simulator per task id, rendering `pixels`, pinned with `MicroDuckTaskSampler.fixed`. `make_env` gained a `from_pixels` override for it.
- The grid is the recorder's own: a `VideoRecorder(logger, tag="evaluation/task_grid", make_grid=True, fps=50)` appended to the video env tiles the four workers' frames into a 2x2 (`ceil(sqrt(n))` columns, row-major) and `record_task_grid(env, recorder, actor, steps=, step=)` rolls the deterministic actor out and dumps the video at the training step. No tiling code in the example.
- `train_ppo(video_recorder=, video_interval=)` calls the recorder every `video_interval`-th evaluation. `main` wires it to `logger.log_video("evaluation/task_grid", ..., step=transitions, fps=50)` when `evaluation.video.interval` is set.
- Config: `evaluation.video: {interval: null, tasks: [1, 2, 3, 5], steps: 250, width: 320, height: 240}`. Off by default: video storage on the logger side is not free (a free W&B account has 5 GB), so `interval` is opt-in and counts evaluations, not iterations. W&B needs `moviepy`.

Checked on the pinned MJCF with a training checkpoint: four parallel workers, 50 steps at 320x240 give a `(50, 3, 480, 640)` uint8 grid in a few seconds, tiles in the requested task order.

## Tests

`test/libs/test_mujoco.py`: the fixed sampler pins one task per env at full and partial resets and rejects a wrong count or two modes at once. The grid layout is the recorder's, already covered by its own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
