### PR TITLE
[Doc] Clarify TensorDictPrimer is required for RNN collection

### DIFF
--- a/docs/source/reference/modules_rnn.rst
+++ b/docs/source/reference/modules_rnn.rst
@@ -204,6 +204,8 @@ See also
 
 * :ref:`data-layout` for the contiguous trajectory layout and replay-buffer
   handoff.
+* :ref:`Recurrent state lifecycle <ref_recurrent_state_lifecycle>` for
+  the primer / ``auto_register_policy_transforms`` collection path.
 * :class:`LSTMModule` and :class:`GRUModule` for constructor arguments and
   examples.
 * :class:`set_recurrent_mode` for switching between single-step and recurrent

--- a/docs/source/reference/recurrent_state_lifecycle.rst
+++ b/docs/source/reference/recurrent_state_lifecycle.rst
@@ -365,6 +365,9 @@ See also
   a runnable tutorial that walks through this lifecycle end to end:
   collection, :class:`~torchrl.data.replay_buffers.SliceSampler` replay, and
   a full-sequence ``set_recurrent_mode(True)`` forward.
+- :ref:`Recurrent DQN <RNN_tuto>` — builds the primer explicitly with
+  :meth:`~torchrl.modules.LSTMModule.make_tensordict_primer` (the
+  collector-side alternative is ``auto_register_policy_transforms=True``).
 - ``examples/replay-buffers/recurrent_slice_sampler_pipeline.py`` — a
   minimal, runnable script version (GRU policy, the collector writing
   directly into the buffer, ``SliceSampler`` auto-detecting the trajectory

--- a/tutorials/sphinx-tutorials/dqn_with_rnn.py
+++ b/tutorials/sphinx-tutorials/dqn_with_rnn.py
@@ -142,22 +142,26 @@ device = (
 #   calls to :meth:`~torchrl.envs.EnvBase.reset` by adding a ``"is_init"``
 #   boolean mask in the TensorDict that will track which steps require a reset
 #   of the RNN hidden states.
-# - The :class:`~torchrl.envs.transforms.TensorDictPrimer` transform is a bit more
-#   technical. It is not required to use RNN policies. However, it
-#   instructs the environment (and subsequently the collector) that some extra
-#   keys are to be expected. Once added, a call to `env.reset()` will populate
-#   the entries indicated in the primer with zeroed tensors. Knowing that
-#   these tensors are expected by the policy, the collector will pass them on
-#   during collection. Eventually, we'll be storing our hidden states in the
-#   replay buffer, which will help us bootstrap the computation of the
-#   RNN operations in the loss module (which would otherwise be initiated
-#   with 0s). In summary: not including this transform will not impact hugely
-#   the training of our policy, but it will make the recurrent keys disappear
-#   from the collected data and the replay buffer, which will in turn lead to
-#   a slightly less optimal training.
-#   Fortunately, the :class:`~torchrl.modules.LSTMModule` we propose is
-#   equipped with a helper method to build just that transform for us, so
-#   we can wait until we build it!
+# - The :class:`~torchrl.envs.transforms.TensorDictPrimer` transform is
+#   required on this tutorial's collector path if you want hidden states
+#   to travel through ``env.reset`` → collector → policy → replay.
+#   It instructs the environment (and subsequently the collector) that
+#   some extra keys are to be expected. Once added, a call to
+#   ``env.reset()`` will populate the entries indicated in the primer
+#   with zeroed tensors. Knowing that these tensors are expected by the
+#   policy, the collector will pass them on during collection, and we
+#   will store them in the replay buffer so the loss can bootstrap the
+#   RNN from a real carry instead of zeros. Omitting the primer does
+#   not crash: the collector drops the recurrent keys, the policy
+#   zeros its hidden state at every step, and recurrency silently
+#   dies. Training still runs, but it is worse.
+#   ``auto_register_policy_transforms=True`` on the collector is the
+#   equivalent automatic path: it can attach
+#   :class:`~torchrl.envs.transforms.InitTracker` and the primer for you
+#   (see :ref:`ref_recurrent_state_lifecycle`). This tutorial builds
+#   the primer explicitly via
+#   :meth:`~torchrl.modules.LSTMModule.make_tensordict_primer`, so we
+#   wait until the LSTM is constructed before appending it.
 #
 
 env = TransformedEnv(
@@ -259,10 +263,16 @@ print("out_keys", lstm.out_keys)
 # move the recurrent state to the root TensorDict, making it available to the
 # RNN during the following call (see figure in the intro).
 #
-# As mentioned earlier, we have one more optional transform to add to our
-# environment to make sure that the recurrent states are passed to the buffer.
-# The :meth:`~torchrl.modules.LSTMModule.make_tensordict_primer` method does
-# exactly that:
+# As mentioned earlier, we still need a
+# :class:`~torchrl.envs.transforms.TensorDictPrimer` so that hidden
+# states travel through ``env.reset`` → collector → policy → replay.
+# Without it the collector does not feed recurrent state to the
+# policy; the LSTM zeros or drops that state and recurrency silently
+# dies. ``auto_register_policy_transforms=True`` on the collector
+# is the equivalent automatic path (see
+# :ref:`ref_recurrent_state_lifecycle`). This tutorial builds the
+# primer explicitly via
+# :meth:`~torchrl.modules.LSTMModule.make_tensordict_primer`:
 #
 env.append_transform(lstm.make_tensordict_primer())
 
@@ -493,13 +503,17 @@ if traj_lens:
 # - Indicate to the LSTM module that a reset is needed via an :class:`~torchrl.envs.transforms.InitTracker`
 #   transform
 # - Incorporate this module in a policy and in a loss module
-# - Make sure that the collector is made aware of the recurrent state entries
-#   such that they can be stored in the replay buffer along with the rest of
-#   the data
+# - Append a :class:`~torchrl.envs.transforms.TensorDictPrimer` (or enable
+#   ``auto_register_policy_transforms=True`` on the collector) so hidden
+#   states travel through collection and into the replay buffer. Omitting
+#   it does not crash; recurrency just dies silently
 #
 # Further Reading
 # ---------------
 #
+# - :ref:`Recurrent state lifecycle <ref_recurrent_state_lifecycle>` —
+#   how hidden states move through ``env.reset``, collection, replay,
+#   and the loss.
 # - The TorchRL documentation can be found `here <https://pytorch.org/rl/>`_.
 
 


### PR DESCRIPTION
## Description

The recurrent DQN tutorial described :class:`~torchrl.envs.transforms.TensorDictPrimer` as optional / not required. That is incorrect for the collector path used in the tutorial: without a primer (or equivalent auto-registration), the collector does not feed hidden state to the policy. The LSTM zeros or drops recurrent state, recurrency silently dies, and training still runs but is worse.

This PR rewrites those tutorial comments so they match the actual contract:

- On this tutorial's collector path, a primer is required if hidden states should travel through ``env.reset`` → collector → policy → replay.
- Omitting it does not crash; it zeros/drops recurrent state.
- ``auto_register_policy_transforms=True`` is the collector-side alternative. This tutorial still builds the primer explicitly via ``lstm.make_tensordict_primer()``.

One-line cross-links were added from ``recurrent_state_lifecycle.rst`` and ``modules_rnn.rst``. Training logic is unchanged.

### Code example

Attach the LSTM primer before creating the collector so hidden state survives between policy calls. This Pendulum example requires Gymnasium.

```python
from tensordict.nn import TensorDictSequential
from torchrl.collectors import Collector
from torchrl.envs import Compose, GymEnv, InitTracker, TransformedEnv
from torchrl.modules import LSTMModule

lstm = LSTMModule(input_size=3, hidden_size=1, in_key="observation", out_key="action")
env = TransformedEnv(
    GymEnv("Pendulum-v1"), Compose(InitTracker(), lstm.make_tensordict_primer()),
)
collector = Collector(
    env, TensorDictSequential(lstm), frames_per_batch=8, total_frames=8,
)
batch = next(iter(collector))
assert "recurrent_state_h" in batch.keys()
assert ("next", "recurrent_state_h") in batch.keys(True, True)
collector.shutdown()
# Alternatively, let Collector register policy transforms with
# auto_register_policy_transforms=True; keep InitTracker on the environment.
```

## Motivation and Context

Without this clarification, readers following the tutorial can drop the primer, get no error, and train a non-recurrent policy.

close #2362

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.