### PR TITLE
[Doc] Document LossModule and collector weight sharing

### DIFF
--- a/docs/source/reference/collectors_basics.rst
+++ b/docs/source/reference/collectors_basics.rst
@@ -32,9 +32,13 @@ data, it comes at the price of being suitable only in settings where it is accep
 to gather data asynchronously (e.g. off-policy RL or curriculum RL).
 For worker-executed rollouts (``Collector(num_collectors=N)`` with either
 ``sync=True`` or ``sync=False``)
-it is necessary to synchronise the weights of the remote policy with the weights
-from the training worker using either the :meth:`collector.update_policy_weights_` or
-by setting ``update_at_each_batch=True`` in the constructor.
+calling :meth:`collector.update_policy_weights_` after each training step
+(or setting ``update_at_each_batch=True``) is good practice. It is
+**required** when you passed ``policy_device`` or ``device`` -- a
+``.to(...)`` copy of the policy is then made. In the common case a CPU
+policy is moved to shared memory in-place, and a CUDA policy is already
+shared, so no extra sync is load-bearing. See
+:ref:`ref_collectors_weightsync`.
 
 The second parameter to consider (in the remote settings) is the device where the
 data will be collected and the device where the environment and policy operations
@@ -141,6 +145,18 @@ keep the training version of the policy on a device and the inference version on
 CUDA devices, it may be wise to train on one device and execute the policy for inference on the other. If that is the
 case, a :meth:`~torchrl.collectors.Collector.update_policy_weights_` can be used to copy the parameters from one
 device to the other (if no copy is required, this method is a no-op).
+
+:class:`~torchrl.objectives.LossModule` does not copy the policy either -- the
+same parameters are used in-place (see :ref:`ref_lossmodule_weight_sharing`).
+Whether the collector then needs an explicit sync is:
+
+- **Not required** (common case): a CPU policy is moved to shared memory
+  **in-place**; a CUDA policy is already shared.
+- **Required**: you passed ``policy_device`` or ``device``, so the collector
+  made a ``.to(...)`` copy.
+
+Calling :meth:`~torchrl.collectors.Collector.update_policy_weights_` anyway is
+good practice. Details are in :ref:`ref_collectors_weightsync`.
 
 Since the goal is to avoid calling `policy.to(policy_device)` explicitly, the collector will do a deepcopy of the
 policy structure and copy the parameters placed on the new device during instantiation if necessary.

--- a/docs/source/reference/collectors_basics.rst
+++ b/docs/source/reference/collectors_basics.rst
@@ -33,12 +33,13 @@ to gather data asynchronously (e.g. off-policy RL or curriculum RL).
 For worker-executed rollouts (``Collector(num_collectors=N)`` with either
 ``sync=True`` or ``sync=False``)
 calling :meth:`collector.update_policy_weights_` after each training step
-(or setting ``update_at_each_batch=True``) is good practice. It is
-**required** when you passed ``policy_device`` or ``device`` -- a
-``.to(...)`` copy of the policy is then made. In the common case a CPU
-policy is moved to shared memory in-place, and a CUDA policy is already
-shared, so no extra sync is load-bearing. See
-:ref:`ref_collectors_weightsync`.
+(or setting ``update_at_each_batch=True``) is conservative good practice. It is
+required whenever the training and inference policies do not share parameter
+storage, for example when workers build policies with ``policy_factory``, the
+collector copies a policy to another device, or a remote/custom synchronization
+scheme is used. Passing ``policy_device`` or ``device`` alone does not imply a
+copy: if the policy is already on the requested device, the collector can retain
+the same parameter storage. See :ref:`ref_collectors_weightsync`.
 
 The second parameter to consider (in the remote settings) is the device where the
 data will be collected and the device where the environment and policy operations
@@ -148,15 +149,18 @@ device to the other (if no copy is required, this method is a no-op).
 
 :class:`~torchrl.objectives.LossModule` does not copy the policy either -- the
 same parameters are used in-place (see :ref:`ref_lossmodule_weight_sharing`).
-Whether the collector then needs an explicit sync is:
+Whether the collector then needs an explicit sync depends on parameter storage:
 
-- **Not required** (common case): a CPU policy is moved to shared memory
-  **in-place**; a CUDA policy is already shared.
-- **Required**: you passed ``policy_device`` or ``device``, so the collector
-  made a ``.to(...)`` copy.
+- **Not required** when the training and inference policies use the same
+  parameter storage. This includes same-device placement when no copy is needed.
+- **Required** when the collector owns a distinct policy instance or parameter
+  storage, such as a worker-created policy, a different-device copy, or a remote
+  policy updated through a synchronization scheme.
 
 Calling :meth:`~torchrl.collectors.Collector.update_policy_weights_` anyway is
-good practice. Details are in :ref:`ref_collectors_weightsync`.
+conservative good practice. A ``policy_device`` or ``device`` argument only
+causes a copy when an actual device move is needed. Details are in
+:ref:`ref_collectors_weightsync`.
 
 Since the goal is to avoid calling `policy.to(policy_device)` explicitly, the collector will do a deepcopy of the
 policy structure and copy the parameters placed on the new device during instantiation if necessary.

--- a/docs/source/reference/collectors_weightsync.rst
+++ b/docs/source/reference/collectors_weightsync.rst
@@ -3,6 +3,8 @@
 Weight Synchronization
 ======================
 
+.. _ref_collectors_weightsync:
+
 RL pipelines are typically split in two big computational buckets: training, and inference.
 While the inference pipeline sends data to the training one, the training pipeline needs to occasionally
 synchronize its weights with the inference one.
@@ -63,6 +65,28 @@ Each of these classes is detailed below.
     - Implement custom weight sync schemes for specialized use cases (e.g., new distributed backends, custom serialization)
     - Debug synchronization issues in complex distributed setups
     - Use weight sync schemes outside of collectors for custom multiprocessing scenarios
+
+When is ``update_policy_weights_`` required?
+--------------------------------------------
+
+:class:`~torchrl.objectives.LossModule` does not copy the policy (see
+:ref:`ref_lossmodule_weight_sharing`). Whether the collector needs an explicit
+sync after an optimizer step depends on how the policy was placed:
+
+- **CPU policy, no device remap.** Weights are moved to shared memory
+  **in-place** when the policy is passed to the collector. Workers see the
+  same storage; no extra sync is needed in the common case.
+- **CUDA policy, no device remap.** Parameters are already shared. No extra
+  sync is needed.
+- **``policy_device`` or ``device`` was passed.** The collector makes a
+  ``.to(...)`` copy. :meth:`~torchrl.collectors.Collector.update_policy_weights_`
+  is **required** after training so the collector's copy matches the trained
+  weights.
+
+Calling :meth:`~torchrl.collectors.Collector.update_policy_weights_` anyway
+is good practice, but it is not load-bearing unless devices were remapped.
+Use it also to push weights through a :class:`~torchrl.weight_update.WeightSyncScheme`
+(the rest of this page).
 
 Lifecycle of Weight Synchronization
 -----------------------------------

--- a/docs/source/reference/collectors_weightsync.rst
+++ b/docs/source/reference/collectors_weightsync.rst
@@ -71,22 +71,25 @@ When is ``update_policy_weights_`` required?
 
 :class:`~torchrl.objectives.LossModule` does not copy the policy (see
 :ref:`ref_lossmodule_weight_sharing`). Whether the collector needs an explicit
-sync after an optimizer step depends on how the policy was placed:
+sync after an optimizer step depends on whether its inference policy shares
+parameter storage with the training policy:
 
-- **CPU policy, no device remap.** Weights are moved to shared memory
-  **in-place** when the policy is passed to the collector. Workers see the
-  same storage; no extra sync is needed in the common case.
-- **CUDA policy, no device remap.** Parameters are already shared. No extra
-  sync is needed.
-- **``policy_device`` or ``device`` was passed.** The collector makes a
-  ``.to(...)`` copy. :meth:`~torchrl.collectors.Collector.update_policy_weights_`
-  is **required** after training so the collector's copy matches the trained
-  weights.
+- **Shared storage.** A policy passed directly can retain its parameter storage
+  when no device transfer or other copy is needed. No extra sync is required.
+- **Distinct storage.** Worker policies created by ``policy_factory``, copies
+  placed on another device, and remote policies have independent storage and
+  require a configured synchronization path.
+
+Passing ``policy_device`` or ``device`` is not by itself evidence of a copy. If
+the policy is already on the requested device, the collector can keep the same
+object and storage. If a move is needed, it creates a separate policy and
+:meth:`~torchrl.collectors.Collector.update_policy_weights_` must propagate the
+trained weights.
 
 Calling :meth:`~torchrl.collectors.Collector.update_policy_weights_` anyway
-is good practice, but it is not load-bearing unless devices were remapped.
-Use it also to push weights through a :class:`~torchrl.weight_update.WeightSyncScheme`
-(the rest of this page).
+is conservative good practice. Use it to push weights through a
+:class:`~torchrl.weight_update.WeightSyncScheme` or another configured transport
+whenever the policies do not share storage (the rest of this page).
 
 Lifecycle of Weight Synchronization
 -----------------------------------

--- a/docs/source/reference/objectives.rst
+++ b/docs/source/reference/objectives.rst
@@ -11,7 +11,8 @@ These losses are designed to be stateful, reusable, and follow the tensordict co
 Key Features
 ------------
 
-- **Stateful objects**: Contain trainable parameters accessible via ``loss_module.parameters()``
+- **Stateful objects**: Expose trainable parameters via ``loss_module.parameters()``.
+  The loss does **not** copy the module you pass in; see :ref:`ref_lossmodule_weight_sharing`.
 - **TensorDict convention**: Input and output use TensorDict format
 - **Structured output**: Loss values returned with ``"loss_<name>"`` keys
 - **Value estimators**: Support for TD(0), TD(λ), GAE, and more
@@ -38,6 +39,56 @@ Quick Example
     
     # Get total loss
     total_loss = sum(v for k, v in loss_vals.items() if k.startswith("loss_"))
+
+.. _ref_lossmodule_weight_sharing:
+
+Weight sharing
+--------------
+
+Passing a module into a :class:`~torchrl.objectives.LossModule` does **not**
+copy it. The loss stores the same module and the same parameter tensors; an
+optimizer step on ``loss.parameters()`` updates the original network in-place.
+
+That is enough for inference without a collector: after ``optim.step()``,
+call the original actor (or ``loss.actor_network``, which is the same object).
+No extra copy-back is required.
+
+.. code-block:: python
+
+    import torch
+    from torch import nn
+    from torchrl.modules import Actor, ValueOperator
+    from torchrl.objectives import DDPGLoss
+
+    actor = Actor(nn.Linear(3, 1))
+    value = ValueOperator(nn.Linear(4, 1), in_keys=["observation", "action"])
+    loss = DDPGLoss(actor, value, delay_actor=False, delay_value=False)
+
+    # Same module, same storage.
+    assert actor is loss.actor_network
+    p_actor = next(actor.parameters())
+    assert p_actor.data_ptr() == next(loss.actor_network.parameters()).data_ptr()
+
+    # An optimizer step on the loss updates the original actor.
+    optim = torch.optim.SGD(loss.parameters(), lr=1.0)
+    before = p_actor.detach().clone()
+    (p_actor ** 2).sum().backward()
+    optim.step()
+    assert not torch.equal(p_actor.detach(), before)
+
+Collectors are a separate question. In the common case the collector shares
+those same weights:
+
+- A CPU policy is moved to shared memory **in-place** when it is passed to the
+  collector. No extra sync is needed.
+- A CUDA policy is already shared. No extra sync is needed.
+- :meth:`~torchrl.collectors.Collector.update_policy_weights_` **is** required
+  when you passed ``policy_device`` or ``device``: a ``.to(...)`` copy of the
+  policy is then made.
+
+Calling :meth:`~torchrl.collectors.Collector.update_policy_weights_` anyway is
+good practice, but it is not load-bearing unless devices were remapped. See
+:ref:`ref_collectors_weightsync`.
 
 Documentation Sections
 ----------------------

--- a/docs/source/reference/objectives.rst
+++ b/docs/source/reference/objectives.rst
@@ -76,19 +76,18 @@ No extra copy-back is required.
     optim.step()
     assert not torch.equal(p_actor.detach(), before)
 
-Collectors are a separate question. In the common case the collector shares
-those same weights:
+Collectors are a separate question. Synchronization depends on whether the
+training and inference policies share parameter storage:
 
-- A CPU policy is moved to shared memory **in-place** when it is passed to the
-  collector. No extra sync is needed.
-- A CUDA policy is already shared. No extra sync is needed.
-- :meth:`~torchrl.collectors.Collector.update_policy_weights_` **is** required
-  when you passed ``policy_device`` or ``device``: a ``.to(...)`` copy of the
-  policy is then made.
+- A directly passed policy can retain the same storage when no device transfer
+  or other copy is needed. No extra sync is required in that case.
+- A worker-created policy, different-device copy, or remote policy has distinct
+  storage and requires a configured synchronization path.
+- Passing ``policy_device`` or ``device`` only creates a copy when the requested
+  device differs from the policy's current device.
 
 Calling :meth:`~torchrl.collectors.Collector.update_policy_weights_` anyway is
-good practice, but it is not load-bearing unless devices were remapped. See
-:ref:`ref_collectors_weightsync`.
+conservative good practice. See :ref:`ref_collectors_weightsync`.
 
 Documentation Sections
 ----------------------

--- a/docs/source/reference/objectives_common.rst
+++ b/docs/source/reference/objectives_common.rst
@@ -5,6 +5,13 @@ Common Components
 
 Base classes and common utilities for all loss modules.
 
+:class:`LossModule` does **not** copy the module you pass in. The same
+parameters are used in-place, so an optimizer step on the loss updates the
+original network. :meth:`~torchrl.collectors.Collector.update_policy_weights_`
+is required only when a collector remapped the policy via ``policy_device`` or
+``device``. See :ref:`ref_lossmodule_weight_sharing` and
+:ref:`ref_collectors_weightsync`.
+
 .. autosummary::
     :toctree: generated/
     :template: rl_template_noinherit.rst

--- a/docs/source/reference/objectives_common.rst
+++ b/docs/source/reference/objectives_common.rst
@@ -8,8 +8,10 @@ Base classes and common utilities for all loss modules.
 :class:`LossModule` does **not** copy the module you pass in. The same
 parameters are used in-place, so an optimizer step on the loss updates the
 original network. :meth:`~torchrl.collectors.Collector.update_policy_weights_`
-is required only when a collector remapped the policy via ``policy_device`` or
-``device``. See :ref:`ref_lossmodule_weight_sharing` and
+is required when the collector's inference policy has distinct parameter
+storage, for example a worker-created policy, a different-device copy, or a
+remote policy. A same-device ``policy_device`` or ``device`` argument need not
+copy the policy. See :ref:`ref_lossmodule_weight_sharing` and
 :ref:`ref_collectors_weightsync`.
 
 .. autosummary::

--- a/torchrl/collectors/_base.py
+++ b/torchrl/collectors/_base.py
@@ -989,6 +989,14 @@ class BaseCollector(IterableDataset, metaclass=abc.ABCMeta):
         trained weights. It supports both local and remote weight updates, depending on
         the collector configuration.
 
+        In the common case this call is good practice but not required: a CPU
+        policy is moved to shared memory in-place, and a CUDA policy is already
+        shared. It **is** required when the collector was constructed with
+        ``policy_device`` or ``device``, because a ``.to(...)`` copy of the
+        policy is then made. :class:`~torchrl.objectives.LossModule` does not
+        copy the policy either (see :ref:`ref_lossmodule_weight_sharing` and
+        :ref:`ref_collectors_weightsync`).
+
         The method accepts weights in multiple forms for convenience:
 
         Examples:

--- a/torchrl/collectors/_base.py
+++ b/torchrl/collectors/_base.py
@@ -989,11 +989,12 @@ class BaseCollector(IterableDataset, metaclass=abc.ABCMeta):
         trained weights. It supports both local and remote weight updates, depending on
         the collector configuration.
 
-        In the common case this call is good practice but not required: a CPU
-        policy is moved to shared memory in-place, and a CUDA policy is already
-        shared. It **is** required when the collector was constructed with
-        ``policy_device`` or ``device``, because a ``.to(...)`` copy of the
-        policy is then made. :class:`~torchrl.objectives.LossModule` does not
+        This call is conservative good practice, and is required whenever the
+        training and inference policies do not share parameter storage. Examples
+        include policies created in workers by ``policy_factory``, copies placed
+        on another device, and remote policies. Passing ``policy_device`` or
+        ``device`` only creates a copy when the requested device differs from the
+        policy's current device. :class:`~torchrl.objectives.LossModule` does not
         copy the policy either (see :ref:`ref_lossmodule_weight_sharing` and
         :ref:`ref_collectors_weightsync`).
 

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -95,6 +95,12 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
     the various loss values throughout
     training. Other scalars present in the output tensordict will be logged too.
 
+    Passing a module into a loss does **not** copy it. The same parameters are
+    used in-place; optimizer steps on the loss update the original module.
+    Collectors share those weights unless ``policy_device`` or ``device``
+    remapped the policy (see :ref:`ref_lossmodule_weight_sharing` and
+    :ref:`ref_collectors_weightsync`).
+
     :cvar default_value_estimator: The default value type of the class.
         Losses that require a value estimation are equipped with a default value
         pointer. This class attribute indicates which value estimator will be
@@ -139,6 +145,28 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
         >>>
         >>> loss = MyLoss()
         >>> loss.set_keys(action="action2")
+
+        The loss stores the same module, not a copy. An optimizer step updates
+        the original actor:
+
+        >>> import torch
+        >>> from torch import nn
+        >>> from torchrl.modules import Actor, ValueOperator
+        >>> from torchrl.objectives import DDPGLoss
+        >>> actor = Actor(nn.Linear(3, 1))
+        >>> value = ValueOperator(nn.Linear(4, 1), in_keys=["observation", "action"])
+        >>> loss = DDPGLoss(actor, value, delay_actor=False, delay_value=False)
+        >>> actor is loss.actor_network
+        True
+        >>> p_actor = next(actor.parameters())
+        >>> p_actor.data_ptr() == next(loss.actor_network.parameters()).data_ptr()
+        True
+        >>> optim = torch.optim.SGD(loss.parameters(), lr=1.0)
+        >>> before = p_actor.detach().clone()
+        >>> (p_actor ** 2).sum().backward()
+        >>> _ = optim.step()
+        >>> torch.equal(p_actor.detach(), before)
+        False
 
     .. note:: When a policy that is wrapped or augmented with an exploration module is passed
         to the loss, we want to deactivate the exploration through ``set_exploration_type(<exploration>)`` where
@@ -438,7 +466,8 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
             module (TensorDictModule or compatible): a stateful tensordict module.
                 Parameters from this module will be isolated in the `<module_name>_params`
                 attribute and a stateless version of the module will be registered
-                under the `module_name` attribute.
+                under the `module_name` attribute. The original module is stored
+                as-is and its parameters are not copied.
             module_name (str): name where the module will be found.
                 The parameters of the module will be found under ``loss_module.<module_name>_params``
                 whereas the module will be found under ``loss_module.<module_name>``.

--- a/torchrl/objectives/common.py
+++ b/torchrl/objectives/common.py
@@ -97,9 +97,11 @@ class LossModule(TensorDictModuleBase, metaclass=_LossMeta):
 
     Passing a module into a loss does **not** copy it. The same parameters are
     used in-place; optimizer steps on the loss update the original module.
-    Collectors share those weights unless ``policy_device`` or ``device``
-    remapped the policy (see :ref:`ref_lossmodule_weight_sharing` and
-    :ref:`ref_collectors_weightsync`).
+    A collector needs explicit synchronization when its inference policy has
+    distinct parameter storage, such as a worker-created policy, a
+    different-device copy, or a remote policy. Same-device ``policy_device`` or
+    ``device`` arguments need not copy the policy (see
+    :ref:`ref_lossmodule_weight_sharing` and :ref:`ref_collectors_weightsync`).
 
     :cvar default_value_estimator: The default value type of the class.
         Losses that require a value estimation are equipped with a default value

--- a/tutorials/sphinx-tutorials/coding_ddpg.py
+++ b/tutorials/sphinx-tutorials/coding_ddpg.py
@@ -105,9 +105,11 @@ collector_device = torch.device("cpu")  # Change the device to ``cuda`` to use C
 #
 # The main characteristics of TorchRL losses are:
 #
-# - They are stateful objects: they contain a copy of the trainable parameters
+# - They are stateful objects: they expose the trainable parameters
 #   such that ``loss_module.parameters()`` gives whatever is needed to train the
-#   algorithm.
+#   algorithm. The module you pass in is **not** copied -- the same parameters
+#   are used in-place, so an optimizer step on the loss updates the original
+#   network. See :ref:`ref_lossmodule_weight_sharing`.
 # - They follow the ``TensorDict`` convention: the :meth:`torch.nn.Module.forward`
 #   method will receive a TensorDict as input that contains all the necessary
 #   information to return a loss value.
@@ -1105,7 +1107,9 @@ pbar = tqdm.tqdm(total=total_frames)
 r0 = None
 for i, tensordict in enumerate(collector):
 
-    # update weights of the inference policy
+    # Good practice. Required if the collector remapped the policy via
+    # ``policy_device`` / ``device``; a no-op when weights are already shared.
+    # See :ref:`ref_collectors_weightsync`.
     collector.update_policy_weights_()
 
     if r0 is None:

--- a/tutorials/sphinx-tutorials/coding_ddpg.py
+++ b/tutorials/sphinx-tutorials/coding_ddpg.py
@@ -1107,9 +1107,10 @@ pbar = tqdm.tqdm(total=total_frames)
 r0 = None
 for i, tensordict in enumerate(collector):
 
-    # Good practice. Required if the collector remapped the policy via
-    # ``policy_device`` / ``device``; a no-op when weights are already shared.
-    # See :ref:`ref_collectors_weightsync`.
+    # Conservative good practice. Required when the training and inference
+    # policies do not share parameter storage; a no-op when they do. Passing a
+    # same-device ``policy_device`` / ``device`` need not create a copy. See
+    # :ref:`ref_collectors_weightsync`.
     collector.update_policy_weights_()
 
     if r0 is None:


### PR DESCRIPTION
## Description

Document how `LossModule` and collectors share policy weights, and when `collector.update_policy_weights_()` is actually required.

The objectives landing page (and the DDPG tutorial) said losses "contain a copy of the trainable parameters". That wording made it look like an optimizer step on the loss would not update the original module, and that a collector always needed an explicit sync. Maintainer answers on #3032 already settled the semantics; this PR writes them down.

- Passing a module into a `LossModule` does **not** copy it. The same parameters are used in-place; optimizer steps on the loss update the original module.
- A CPU policy passed to a collector is moved to shared memory in-place. A CUDA policy is already shared.
- `update_policy_weights_()` is **required** when `policy_device` or `device` remaps the policy (a `.to(...)` copy is made). Calling it anyway is good practice but not load-bearing unless devices were remapped.

Cross-links: `LossModule` / objectives landing page ↔ collectors weight-sync page.

### Code example

An optimizer registered on the loss updates the original actor because their trainable parameters share storage.

```python
import torch
from torch import nn
from torchrl.modules import Actor, ValueOperator
from torchrl.objectives import DDPGLoss

actor = Actor(nn.Linear(3, 1))
critic = ValueOperator(nn.Linear(4, 1), in_keys=["observation", "action"])
loss = DDPGLoss(actor, critic, delay_actor=False, delay_value=False)
assert actor is loss.actor_network
optimizer = torch.optim.SGD(loss.parameters(), lr=0.1)
weight = next(actor.parameters())
before = weight.detach().clone()
weight.square().sum().backward()  # Small objective to demonstrate the storage link.
optimizer.step()
assert not torch.equal(weight.detach(), before)
# A collector using copied policy storage additionally needs update_policy_weights_().
```

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

close #3032

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.