### PR TITLE
[BugFix] Avoid try/except for objective entropy and KL

### DIFF
--- a/docs/source/reference/modules_distributions.rst
+++ b/docs/source/reference/modules_distributions.rst
@@ -31,3 +31,5 @@ Sampling utilities
     sample_and_log_prob
     rsample_and_log_prob
     composite_entropy
+    has_analytic_entropy
+    has_analytic_kl

--- a/test/llm/test_llm_objectives.py
+++ b/test/llm/test_llm_objectives.py
@@ -50,6 +50,11 @@ prompts = [
 ]
 
 
+class _NormalWithNonfiniteEntropy(torch.distributions.Normal):
+    def entropy(self):
+        return torch.full_like(self.loc, float("nan"))
+
+
 @pytest.fixture(autouse=True, scope="module")
 def set_list_to_stack():
     with tensordict.set_list_to_stack(True):
@@ -695,6 +700,16 @@ def _policy_loss_data(current_log_prob, sample_log_prob, advantage):
 
 
 class TestLosses:
+    def test_grpo_entropy_mc_when_analytic_is_nonfinite(self):
+        loss_fn = GRPOLoss(actor_network=None)
+        loc = torch.zeros(3, 4)
+        dist = _NormalWithNonfiniteEntropy(loc, torch.ones_like(loc))
+
+        entropy = loss_fn._get_entropy(dist, adv_shape=loc.shape)
+
+        assert torch.isfinite(entropy).all()
+        assert entropy.shape == (3, 4, 1)
+
     def test_grpo_token_mean_expands_token_mask(self):
         """Test token_mean aggregation with per-token values and masks."""
         loss_fn = GRPOLoss(actor_network=None, aggregation="token_mean")

--- a/test/objectives/test_ppo.py
+++ b/test/objectives/test_ppo.py
@@ -36,7 +36,7 @@ from tensordict.nn import (
     TensorDictSequential as Seq,
     WrapModule,
 )
-from torch import autograd, nn
+from torch import autograd, distributions as d, nn
 
 from torchrl._utils import rl_warnings
 from torchrl.data import Bounded, Composite, Unbounded
@@ -65,6 +65,29 @@ from torchrl.testing import (  # noqa
     get_default_devices,
     PENDULUM_VERSIONED,
 )
+
+
+class _NormalWithoutEntropy(d.Normal):
+    """Normal that keeps the base ``Distribution.entropy`` stub."""
+
+    entropy = d.Distribution.entropy
+
+
+def _analytic_entropy_case(kind: str) -> tuple[d.Distribution, torch.Tensor]:
+    if kind == "normal":
+        loc = torch.zeros(3, 4)
+        scale = torch.ones(3, 4)
+        dist = d.Normal(loc, scale)
+        return dist, dist.entropy()
+    if kind == "independent":
+        loc = torch.zeros(3, 4)
+        scale = torch.ones(3, 4)
+        dist = d.Independent(d.Normal(loc, scale), 1)
+        return dist, dist.entropy()
+    if kind == "categorical":
+        dist = d.Categorical(logits=torch.zeros(3, 5))
+        return dist, dist.entropy()
+    raise ValueError(kind)
 
 
 @pytest.mark.skipif(not _has_transformers, reason="requires transformers lib")
@@ -1869,6 +1892,86 @@ def test_ppo_ess_preserves_feature_shape_for_singleton_batch():
         ess.append(output["ESS"])
 
     assert torch.stack(ess).shape == (2, chunk_size, action_dim)
+
+
+class TestObjectiveEntropy:
+    """Closed-form vs Monte Carlo entropy without try/except (issue #2403)."""
+
+    def _ppo_loss(self):
+        return TestPPO()._make_entropy_loss(entropy_coeff=0.01)
+
+    def _a2c_loss(self):
+        helper = TestA2C()
+        return A2CLoss(helper._create_mock_actor(), helper._create_mock_value())
+
+    def test_ppo_entropy_mc_without_analytic(self):
+        loss = self._ppo_loss()
+        loc = torch.zeros(3, 4)
+        scale = torch.ones(3, 4)
+        dist = _NormalWithoutEntropy(loc, scale)
+        entropy = loss._get_entropy(dist, adv_shape=loc.shape)
+        assert torch.isfinite(entropy).all()
+        assert entropy.shape == loc.shape + (1,)
+
+    @pytest.mark.parametrize("kind", ["normal", "independent", "categorical"])
+    def test_ppo_entropy_matches_analytic(self, kind):
+        loss = self._ppo_loss()
+        dist, expected = _analytic_entropy_case(kind)
+        entropy = loss._get_entropy(dist, adv_shape=expected.shape)
+        torch.testing.assert_close(entropy, expected.unsqueeze(-1))
+
+    def test_ppo_entropy_composite_matches_analytic(self):
+        loss = self._ppo_loss()
+        loc = torch.zeros(3, 2)
+        scale = torch.ones(3, 2)
+        params = TensorDict(
+            {"action": TensorDict({"loc": loc, "scale": scale}, [3])},
+            [3],
+        )
+        dist = CompositeDistribution(
+            params,
+            distribution_map={"action": d.Normal},
+            name_map={"action": "action"},
+        )
+        expected = d.Normal(loc, scale).entropy().sum(-1).unsqueeze(-1)
+        with set_composite_lp_aggregate(True):
+            entropy = loss._get_entropy(dist, adv_shape=torch.Size([3]))
+        torch.testing.assert_close(entropy, expected)
+
+    def test_a2c_entropy_mc_without_analytic(self):
+        loss = self._a2c_loss()
+        loc = torch.zeros(3, 4)
+        scale = torch.ones(3, 4)
+        dist = _NormalWithoutEntropy(loc, scale)
+        entropy = loss.get_entropy_bonus(dist)
+        assert torch.isfinite(entropy).all()
+        assert entropy.shape == loc.shape + (1,)
+
+    @pytest.mark.parametrize("kind", ["normal", "independent", "categorical"])
+    def test_a2c_entropy_matches_analytic(self, kind):
+        loss = self._a2c_loss()
+        dist, expected = _analytic_entropy_case(kind)
+        entropy = loss.get_entropy_bonus(dist)
+        torch.testing.assert_close(entropy, expected.unsqueeze(-1))
+
+    def test_a2c_entropy_composite_is_finite(self):
+        # CompositeDistribution.entropy() is not a closed-form tensor; A2C
+        # must take the MC path and still return a finite entropy tensor.
+        loss = self._a2c_loss()
+        loc = torch.zeros(3, 2)
+        scale = torch.ones(3, 2)
+        params = TensorDict(
+            {"action": TensorDict({"loc": loc, "scale": scale}, [3])},
+            [3],
+        )
+        dist = CompositeDistribution(
+            params,
+            distribution_map={"action": TanhNormal},
+            name_map={"action": "action"},
+        )
+        entropy = loss.get_entropy_bonus(dist)
+        assert torch.isfinite(entropy).all()
+        assert not isinstance(entropy, TensorDict)
 
 
 class TestA2C(LossModuleTestBase):

--- a/test/objectives/test_ppo.py
+++ b/test/objectives/test_ppo.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import contextlib
 import functools
 import itertools
+import sys
 from dataclasses import asdict
 
 import pytest
@@ -71,6 +72,13 @@ class _NormalWithoutEntropy(d.Normal):
     """Normal that keeps the base ``Distribution.entropy`` stub."""
 
     entropy = d.Distribution.entropy
+
+
+class _NormalWithNonfiniteEntropy(d.Normal):
+    """Normal with an unusable analytic entropy implementation."""
+
+    def entropy(self):
+        return torch.full_like(self.loc, float("nan"))
 
 
 def _analytic_entropy_case(kind: str) -> tuple[d.Distribution, torch.Tensor]:
@@ -1913,6 +1921,22 @@ class TestObjectiveEntropy:
         assert torch.isfinite(entropy).all()
         assert entropy.shape == loc.shape + (1,)
 
+    @pytest.mark.parametrize("compiled", [False, True])
+    def test_ppo_entropy_mc_when_analytic_is_nonfinite(self, compiled):
+        if compiled and sys.version_info >= (3, 14):
+            pytest.skip("torch.compile requires Python < 3.14")
+        loss = self._ppo_loss()
+
+        def get_entropy(loc, scale):
+            dist = _NormalWithNonfiniteEntropy(loc, scale)
+            return loss._get_entropy(dist, adv_shape=loc.shape)
+
+        if compiled:
+            get_entropy = torch.compile(get_entropy, backend="eager", fullgraph=True)
+        entropy = get_entropy(torch.zeros(3, 4), torch.ones(3, 4))
+        assert torch.isfinite(entropy).all()
+        assert entropy.shape == (3, 4, 1)
+
     @pytest.mark.parametrize("kind", ["normal", "independent", "categorical"])
     def test_ppo_entropy_matches_analytic(self, kind):
         loss = self._ppo_loss()
@@ -1920,7 +1944,10 @@ class TestObjectiveEntropy:
         entropy = loss._get_entropy(dist, adv_shape=expected.shape)
         torch.testing.assert_close(entropy, expected.unsqueeze(-1))
 
-    def test_ppo_entropy_composite_matches_analytic(self):
+    @pytest.mark.parametrize(
+        "distribution_class", [d.Normal, _NormalWithNonfiniteEntropy]
+    )
+    def test_ppo_entropy_composite_matches_analytic(self, distribution_class):
         loss = self._ppo_loss()
         loc = torch.zeros(3, 2)
         scale = torch.ones(3, 2)
@@ -1930,13 +1957,16 @@ class TestObjectiveEntropy:
         )
         dist = CompositeDistribution(
             params,
-            distribution_map={"action": d.Normal},
+            distribution_map={"action": distribution_class},
             name_map={"action": "action"},
         )
         expected = d.Normal(loc, scale).entropy().sum(-1).unsqueeze(-1)
         with set_composite_lp_aggregate(True):
             entropy = loss._get_entropy(dist, adv_shape=torch.Size([3]))
-        torch.testing.assert_close(entropy, expected)
+        if distribution_class is d.Normal:
+            torch.testing.assert_close(entropy, expected)
+        else:
+            assert torch.isfinite(entropy).all()
 
     def test_a2c_entropy_mc_without_analytic(self):
         loss = self._a2c_loss()

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -46,6 +46,7 @@ from torchrl.modules.distributions.discrete import (
 )
 from torchrl.modules.distributions.utils import (
     composite_entropy,
+    has_analytic_kl,
     rsample_and_log_prob,
     sample_and_log_prob,
 )
@@ -53,6 +54,24 @@ from torchrl.modules.distributions.utils import (
 from torchrl.testing import get_default_devices
 
 _has_scipy = importlib.util.find_spec("scipy", None) is not None
+
+
+def test_has_analytic_kl_observes_late_registration():
+    class FirstDistribution(torch.distributions.Distribution):
+        pass
+
+    class SecondDistribution(torch.distributions.Distribution):
+        pass
+
+    first = FirstDistribution()
+    second = SecondDistribution()
+    assert not has_analytic_kl(first, second)
+
+    @torch.distributions.register_kl(FirstDistribution, SecondDistribution)
+    def _registered_kl(first, second):
+        return torch.zeros(first.batch_shape)
+
+    assert has_analytic_kl(first, second)
 
 
 @pytest.mark.skipif(torch.__version__ < "2.0", reason="torch 2.0 is required")

--- a/torchrl/modules/distributions/__init__.py
+++ b/torchrl/modules/distributions/__init__.py
@@ -23,6 +23,7 @@ from .discrete import (
     Ordinal,
     ReparamGradientStrategy,
 )
+from .utils import has_analytic_entropy, has_analytic_kl
 
 distributions_maps = {
     str(dist).lower(): dist
@@ -70,4 +71,6 @@ __all__ = [
     "LLMMaskedCategorical",
     "Ordinal",
     "ReparamGradientStrategy",
+    "has_analytic_entropy",
+    "has_analytic_kl",
 ]

--- a/torchrl/modules/distributions/utils.py
+++ b/torchrl/modules/distributions/utils.py
@@ -193,7 +193,9 @@ def has_analytic_kl(p: d.Distribution, q: d.Distribution) -> bool:
         if p.reinterpreted_batch_ndims != q.reinterpreted_batch_ndims:
             return False
         return has_analytic_kl(p.base_dist, q.base_dist)
-    if isinstance(p, TransformedDistribution) and isinstance(q, TransformedDistribution):
+    if isinstance(p, TransformedDistribution) and isinstance(
+        q, TransformedDistribution
+    ):
         if p.transforms != q.transforms or p.event_shape != q.event_shape:
             return False
         return has_analytic_kl(p.base_dist, q.base_dist)
@@ -286,9 +288,7 @@ def composite_entropy(
                 _, log_prob = rsample_and_log_prob(component, (samples_mc,))
             sampled_entropy = -log_prob.mean(0)
             if analytic_entropy and compiling:
-                entropy = torch.where(
-                    entropy.isfinite(), entropy, sampled_entropy
-                )
+                entropy = torch.where(entropy.isfinite(), entropy, sampled_entropy)
             else:
                 entropy = sampled_entropy
         if isinstance(name, str):

--- a/torchrl/modules/distributions/utils.py
+++ b/torchrl/modules/distributions/utils.py
@@ -199,8 +199,8 @@ def has_analytic_kl(p: d.Distribution, q: d.Distribution) -> bool:
         return has_analytic_kl(p.base_dist, q.base_dist)
     key = (type(p), type(q))
     cached = _ANALYTIC_KL_CACHE.get(key)
-    if cached is not None:
-        return cached
+    if cached:
+        return True
     result = False
     type_p, type_q = key
     for super_p, super_q in _KL_REGISTRY:
@@ -211,7 +211,8 @@ def has_analytic_kl(p: d.Distribution, q: d.Distribution) -> bool:
         if issubclass(type_p, super_p) and issubclass(type_q, super_q):
             result = True
             break
-    _ANALYTIC_KL_CACHE[key] = result
+    if result:
+        _ANALYTIC_KL_CACHE[key] = True
     return result
 
 

--- a/torchrl/modules/distributions/utils.py
+++ b/torchrl/modules/distributions/utils.py
@@ -2,6 +2,14 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+"""Sampling, entropy and KL helpers for TorchRL distributions.
+
+``has_analytic_entropy`` and ``has_analytic_kl`` detect closed-form
+``entropy`` / ``kl_divergence`` implementations from the distribution
+class (or the torch KL registry) so objectives can avoid ``try/except``
+on the hot path.
+"""
+
 from __future__ import annotations
 
 from typing import Any
@@ -11,11 +19,19 @@ from tensordict import is_tensor_collection, TensorDict, TensorDictBase
 from tensordict.nn import composite_lp_aggregate, CompositeDistribution
 from torch import autograd, distributions as d
 from torch.distributions import Independent, Transform, TransformedDistribution
+from torch.distributions.kl import _KL_REGISTRY
+
+from torchrl._utils import logger as torchrl_logger, VERBOSE
 
 try:
     from torch.compiler import is_dynamo_compiling
 except ImportError:
     from torch._dynamo import is_compiling as is_dynamo_compiling
+
+_ANALYTIC_ENTROPY_CACHE: dict[type, bool] = {}
+_ANALYTIC_KL_CACHE: dict[tuple[type, type], bool] = {}
+_MC_ENTROPY_WARNED: set[type] = set()
+_MC_KL_WARNED: set[tuple[type, type]] = set()
 
 
 def sample_and_log_prob(
@@ -106,6 +122,123 @@ def rsample_and_log_prob(
     )
 
 
+def has_analytic_entropy(dist: d.Distribution) -> bool:
+    """Return whether ``dist`` implements a closed-form ``entropy()``.
+
+    The check is class-level: ``type(dist).entropy is not
+    torch.distributions.Distribution.entropy``. ``Independent`` is resolved
+    through its base distribution because ``Independent.entropy`` always
+    exists and only works when the base distribution implements entropy.
+    ``CompositeDistribution`` is treated as not having a closed-form
+    entropy: its ``entropy()`` may return a TensorDict and still relies on
+    ``try/except`` internally. Use :func:`composite_entropy` for composites.
+
+    Args:
+        dist (torch.distributions.Distribution): distribution to inspect.
+
+    Returns:
+        bool: ``True`` if a closed-form entropy method is available.
+
+    Examples:
+        >>> import torch
+        >>> from torch import distributions as d
+        >>> from torchrl.modules.distributions.utils import has_analytic_entropy
+        >>> has_analytic_entropy(d.Normal(torch.zeros(2), torch.ones(2)))
+        True
+        >>> has_analytic_entropy(d.Independent(d.Normal(torch.zeros(2), torch.ones(2)), 1))
+        True
+    """
+    if isinstance(dist, CompositeDistribution):
+        return False
+    if isinstance(dist, Independent):
+        return has_analytic_entropy(dist.base_dist)
+    cls = type(dist)
+    cached = _ANALYTIC_ENTROPY_CACHE.get(cls)
+    if cached is not None:
+        return cached
+    entropy_fn = getattr(cls, "entropy", None)
+    result = entropy_fn is not None and entropy_fn is not d.Distribution.entropy
+    _ANALYTIC_ENTROPY_CACHE[cls] = result
+    return result
+
+
+def has_analytic_kl(p: d.Distribution, q: d.Distribution) -> bool:
+    """Return whether ``kl_divergence(p, q)`` has a registered closed form.
+
+    ``Independent`` and ``TransformedDistribution`` pairs are resolved
+    through their bases, matching the registered torch KL implementations
+    without calling them (those wrappers raise ``NotImplementedError`` when
+    the inner pair is missing). Other pairs are looked up in
+    ``torch.distributions.kl._KL_REGISTRY``.
+
+    Args:
+        p (torch.distributions.Distribution): left argument of
+            ``kl_divergence(p, q)``.
+        q (torch.distributions.Distribution): right argument of
+            ``kl_divergence(p, q)``.
+
+    Returns:
+        bool: ``True`` if a closed-form KL is registered for this pair.
+
+    Examples:
+        >>> import torch
+        >>> from torch import distributions as d
+        >>> from torchrl.modules.distributions.utils import has_analytic_kl
+        >>> loc = torch.zeros(2)
+        >>> scale = torch.ones(2)
+        >>> has_analytic_kl(d.Normal(loc, scale), d.Normal(loc, scale))
+        True
+    """
+    if isinstance(p, Independent) and isinstance(q, Independent):
+        if p.reinterpreted_batch_ndims != q.reinterpreted_batch_ndims:
+            return False
+        return has_analytic_kl(p.base_dist, q.base_dist)
+    if isinstance(p, TransformedDistribution) and isinstance(q, TransformedDistribution):
+        if p.transforms != q.transforms or p.event_shape != q.event_shape:
+            return False
+        return has_analytic_kl(p.base_dist, q.base_dist)
+    key = (type(p), type(q))
+    cached = _ANALYTIC_KL_CACHE.get(key)
+    if cached is not None:
+        return cached
+    result = False
+    type_p, type_q = key
+    for super_p, super_q in _KL_REGISTRY:
+        if super_p is Independent or super_q is Independent:
+            continue
+        if super_p is TransformedDistribution or super_q is TransformedDistribution:
+            continue
+        if issubclass(type_p, super_p) and issubclass(type_q, super_q):
+            result = True
+            break
+    _ANALYTIC_KL_CACHE[key] = result
+    return result
+
+
+def _warn_mc_entropy(dist: d.Distribution) -> None:
+    if not VERBOSE:
+        return
+    cls = type(dist)
+    if cls in _MC_ENTROPY_WARNED:
+        return
+    _MC_ENTROPY_WARNED.add(cls)
+    torchrl_logger.warning(
+        f"Entropy not implemented for {cls}. Using Monte Carlo sampling."
+    )
+
+
+def _warn_mc_kl(p: d.Distribution, q: d.Distribution) -> None:
+    if not VERBOSE:
+        return
+    key = (type(p), type(q))
+    if key in _MC_KL_WARNED:
+        return
+    _MC_KL_WARNED.add(key)
+    torchrl_logger.warning(
+        f"KL divergence not implemented for {key}. Using Monte Carlo sampling."
+    )
+
+
 def composite_entropy(
     distribution: CompositeDistribution,
     samples_mc: int = 1,
@@ -127,11 +260,15 @@ def composite_entropy(
     """
     entropies = {}
     for name, component in distribution.dists.items():
-        try:
+        if has_analytic_entropy(component):
             entropy = component.entropy()
-        except NotImplementedError:
+        else:
             if not component.has_rsample:
-                raise
+                raise NotImplementedError(
+                    f"Entropy is not implemented for {type(component)} and "
+                    "the component does not support reparameterized sampling."
+                )
+            _warn_mc_entropy(component)
             _, log_prob = rsample_and_log_prob(component, (samples_mc,))
             entropy = -log_prob.mean(0)
         if isinstance(name, str):

--- a/torchrl/modules/distributions/utils.py
+++ b/torchrl/modules/distributions/utils.py
@@ -260,17 +260,36 @@ def composite_entropy(
     """
     entropies = {}
     for name, component in distribution.dists.items():
-        if has_analytic_entropy(component):
+        analytic_entropy = has_analytic_entropy(component)
+        if analytic_entropy:
             entropy = component.entropy()
-        else:
-            if not component.has_rsample:
+        compiling = is_dynamo_compiling()
+        needs_mc = not analytic_entropy or compiling
+        if analytic_entropy and not compiling and not entropy.isfinite().all():
+            needs_mc = True
+        if needs_mc:
+            if not analytic_entropy and not component.has_rsample:
                 raise NotImplementedError(
                     f"Entropy is not implemented for {type(component)} and "
                     "the component does not support reparameterized sampling."
                 )
-            _warn_mc_entropy(component)
-            _, log_prob = rsample_and_log_prob(component, (samples_mc,))
-            entropy = -log_prob.mean(0)
+            if not compiling:
+                _warn_mc_entropy(component)
+            if analytic_entropy:
+                _, log_prob = sample_and_log_prob(
+                    component,
+                    (samples_mc,),
+                    reparameterize=component.has_rsample,
+                )
+            else:
+                _, log_prob = rsample_and_log_prob(component, (samples_mc,))
+            sampled_entropy = -log_prob.mean(0)
+            if analytic_entropy and compiling:
+                entropy = torch.where(
+                    entropy.isfinite(), entropy, sampled_entropy
+                )
+            else:
+                entropy = sampled_entropy
         if isinstance(name, str):
             entropy_name = name + "_entropy"
         else:

--- a/torchrl/objectives/a2c.py
+++ b/torchrl/objectives/a2c.py
@@ -25,8 +25,11 @@ from tensordict.nn import (
 from tensordict.utils import NestedKey
 from torch import distributions as d
 
-from torchrl.modules.distributions import HAS_ENTROPY
-from torchrl.modules.distributions.utils import rsample_and_log_prob
+from torchrl.modules.distributions.utils import (
+    _warn_mc_entropy,
+    has_analytic_entropy,
+    rsample_and_log_prob,
+)
 from torchrl.modules.value_norm import ValueNorm
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
@@ -432,9 +435,10 @@ class A2CLoss(LossModule):
 
     @set_composite_lp_aggregate(False)
     def get_entropy_bonus(self, dist: d.Distribution) -> torch.Tensor:
-        if HAS_ENTROPY.get(type(dist), False):
+        if has_analytic_entropy(dist):
             entropy = dist.entropy()
         else:
+            _warn_mc_entropy(dist)
             _, log_prob = rsample_and_log_prob(dist, (self.samples_mc_entropy,))
             if is_tensor_collection(log_prob):
                 log_prob = log_prob.sum(dim="feature", reduce=True)

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -29,8 +29,10 @@ from tensordict.utils import NestedKey, unravel_key
 from torchrl._utils import _maybe_record_function_decorator
 from torchrl.envs.model_based.dreamer import DreamerEnv
 from torchrl.envs.utils import ExplorationType, set_exploration_type, step_mdp
-from torchrl.modules.distributions import HAS_ENTROPY
-from torchrl.modules.distributions.utils import rsample_and_log_prob
+from torchrl.modules.distributions.utils import (
+    has_analytic_entropy,
+    rsample_and_log_prob,
+)
 from torchrl.modules.functional import symexp as _symexp, symlog as symlog
 from torchrl.modules.models.model_based import (  # noqa: F401
     _default_bins,
@@ -835,7 +837,7 @@ class DreamerV3ActorLoss(LossModule):
             actor_loss = -(discount * lambda_target / return_scale).mean()
 
         if self.entropy_bonus > 0:
-            if HAS_ENTROPY.get(type(policy_distribution), False):
+            if has_analytic_entropy(policy_distribution):
                 entropy = policy_distribution.entropy()
             else:
                 _, entropy_log_prob = rsample_and_log_prob(policy_distribution)

--- a/torchrl/objectives/llm/grpo.py
+++ b/torchrl/objectives/llm/grpo.py
@@ -856,9 +856,7 @@ class GRPOLoss(LossModule):
                 )
                 sampled_entropy = -log_prob.mean(0)
                 if analytic_entropy and compiling:
-                    entropy = torch.where(
-                        entropy.isfinite(), entropy, sampled_entropy
-                    )
+                    entropy = torch.where(entropy.isfinite(), entropy, sampled_entropy)
                 else:
                     entropy = sampled_entropy
         if is_tensor_collection(entropy) and entropy.batch_size != adv_shape:

--- a/torchrl/objectives/llm/grpo.py
+++ b/torchrl/objectives/llm/grpo.py
@@ -34,10 +34,15 @@ from tensordict.nn import (
 )
 from tensordict.utils import expand_as_right
 from torch import distributions as d
-from torchrl._utils import logger as torchrl_logger, VERBOSE
+from torchrl._utils import logger as torchrl_logger
 from torchrl.envs.transforms.ray_service import _maybe_clear_device, _maybe_to_device
 from torchrl.envs.transforms.transforms import Transform
-from torchrl.modules.distributions.utils import composite_entropy, sample_and_log_prob
+from torchrl.modules.distributions.utils import (
+    _warn_mc_entropy,
+    composite_entropy,
+    has_analytic_entropy,
+    sample_and_log_prob,
+)
 from torchrl.modules.llm import LLMWrapperBase
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import _sum_td_features, _validate_clip_epsilon
@@ -810,27 +815,18 @@ class GRPOLoss(LossModule):
     def _get_entropy(
         self, dist: d.Distribution, adv_shape: torch.Size
     ) -> torch.Tensor | TensorDict:
-        try:
-            entropy = (
-                composite_entropy(dist, self.samples_mc_entropy)
-                if isinstance(dist, CompositeDistribution)
-                else dist.entropy()
-            )
-            if not entropy.isfinite().all():
-                del entropy
-                if VERBOSE:
-                    torchrl_logger.info(
-                        "Entropy is not finite. Using Monte Carlo sampling."
-                    )
-                raise NotImplementedError
-        except NotImplementedError:
-            if VERBOSE:
-                torchrl_logger.warning(
-                    f"Entropy not implemented for {type(dist)} or is not finite. Using Monte Carlo sampling."
-                )
-            with set_composite_lp_aggregate(False) if isinstance(
-                dist, CompositeDistribution
-            ) else contextlib.nullcontext():
+        is_composite = isinstance(dist, CompositeDistribution)
+        if is_composite:
+            entropy = composite_entropy(dist, self.samples_mc_entropy)
+        elif has_analytic_entropy(dist):
+            entropy = dist.entropy()
+        else:
+            _warn_mc_entropy(dist)
+            with (
+                set_composite_lp_aggregate(False)
+                if is_composite
+                else contextlib.nullcontext()
+            ):
                 _, log_prob = sample_and_log_prob(
                     dist,
                     (self.samples_mc_entropy,),

--- a/torchrl/objectives/llm/grpo.py
+++ b/torchrl/objectives/llm/grpo.py
@@ -41,6 +41,7 @@ from torchrl.modules.distributions.utils import (
     _warn_mc_entropy,
     composite_entropy,
     has_analytic_entropy,
+    is_dynamo_compiling,
     sample_and_log_prob,
 )
 from torchrl.modules.llm import LLMWrapperBase
@@ -818,26 +819,29 @@ class GRPOLoss(LossModule):
         is_composite = isinstance(dist, CompositeDistribution)
         if is_composite:
             entropy = composite_entropy(dist, self.samples_mc_entropy)
-        elif has_analytic_entropy(dist):
-            entropy = dist.entropy()
         else:
-            _warn_mc_entropy(dist)
-            with (
-                set_composite_lp_aggregate(False)
-                if is_composite
-                else contextlib.nullcontext()
-            ):
+            analytic_entropy = has_analytic_entropy(dist)
+            if analytic_entropy:
+                entropy = dist.entropy()
+            compiling = is_dynamo_compiling()
+            needs_mc = not analytic_entropy or compiling
+            if analytic_entropy and not compiling and not entropy.isfinite().all():
+                needs_mc = True
+            if needs_mc:
+                if not compiling:
+                    _warn_mc_entropy(dist)
                 _, log_prob = sample_and_log_prob(
                     dist,
                     (self.samples_mc_entropy,),
                     reparameterize=getattr(dist, "has_rsample", False),
                 )
-                if is_tensor_collection(log_prob):
-                    if isinstance(self.tensor_keys.sample_log_prob, NestedKey):
-                        log_prob = log_prob.get(self.tensor_keys.sample_log_prob)
-                    else:
-                        log_prob = log_prob.select(*self.tensor_keys.sample_log_prob)
-            entropy = -log_prob.mean(0)
+                sampled_entropy = -log_prob.mean(0)
+                if analytic_entropy and compiling:
+                    entropy = torch.where(
+                        entropy.isfinite(), entropy, sampled_entropy
+                    )
+                else:
+                    entropy = sampled_entropy
         if is_tensor_collection(entropy) and entropy.batch_size != adv_shape:
             entropy.batch_size = adv_shape
         return entropy.unsqueeze(-1)

--- a/torchrl/objectives/llm/grpo.py
+++ b/torchrl/objectives/llm/grpo.py
@@ -818,7 +818,26 @@ class GRPOLoss(LossModule):
     ) -> torch.Tensor | TensorDict:
         is_composite = isinstance(dist, CompositeDistribution)
         if is_composite:
-            entropy = composite_entropy(dist, self.samples_mc_entropy)
+            can_compute_component_entropy = all(
+                has_analytic_entropy(component) or component.has_rsample
+                for component in dist.dists.values()
+            )
+            if can_compute_component_entropy:
+                entropy = composite_entropy(dist, self.samples_mc_entropy)
+            else:
+                if not is_dynamo_compiling():
+                    _warn_mc_entropy(dist)
+                with set_composite_lp_aggregate(False):
+                    _, log_prob = sample_and_log_prob(
+                        dist,
+                        (self.samples_mc_entropy,),
+                        reparameterize=getattr(dist, "has_rsample", False),
+                    )
+                    if isinstance(self.tensor_keys.sample_log_prob, NestedKey):
+                        log_prob = log_prob.get(self.tensor_keys.sample_log_prob)
+                    else:
+                        log_prob = log_prob.select(*self.tensor_keys.sample_log_prob)
+                entropy = -log_prob.mean(0)
         else:
             analytic_entropy = has_analytic_entropy(dist)
             if analytic_entropy:

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -35,6 +35,7 @@ from torchrl.modules.distributions.utils import (
     composite_entropy,
     has_analytic_entropy,
     has_analytic_kl,
+    is_dynamo_compiling,
     sample_and_log_prob,
 )
 from torchrl.modules.value_norm import ValueNorm
@@ -698,29 +699,29 @@ class PPOLoss(LossModule):
         is_composite = isinstance(dist, CompositeDistribution)
         if is_composite:
             entropy = composite_entropy(dist, self.samples_mc_entropy)
-        elif has_analytic_entropy(dist):
-            entropy = dist.entropy()
         else:
-            _warn_mc_entropy(dist)
-            with (
-                set_composite_lp_aggregate(False)
-                if is_composite
-                else contextlib.nullcontext()
-            ):
+            analytic_entropy = has_analytic_entropy(dist)
+            if analytic_entropy:
+                entropy = dist.entropy()
+            compiling = is_dynamo_compiling()
+            needs_mc = not analytic_entropy or compiling
+            if analytic_entropy and not compiling and not entropy.isfinite().all():
+                needs_mc = True
+            if needs_mc:
+                if not compiling:
+                    _warn_mc_entropy(dist)
                 _, log_prob = sample_and_log_prob(
                     dist,
                     (self.samples_mc_entropy,),
                     reparameterize=getattr(dist, "has_rsample", False),
                 )
-                if is_tensor_collection(log_prob):
-                    if isinstance(self.tensor_keys.sample_log_prob, NestedKey):
-                        log_prob = log_prob.get(self.tensor_keys.sample_log_prob)
-                    else:
-                        log_prob = log_prob.select(*self.tensor_keys.sample_log_prob)
-
-            entropy = -log_prob.mean(0)
-            if is_tensor_collection(entropy) and entropy.batch_size != adv_shape:
-                entropy.batch_size = adv_shape
+                sampled_entropy = -log_prob.mean(0)
+                if analytic_entropy and compiling:
+                    entropy = torch.where(
+                        entropy.isfinite(), entropy, sampled_entropy
+                    )
+                else:
+                    entropy = sampled_entropy
         return entropy.unsqueeze(-1)
 
     def _get_cur_log_prob(self, tensordict):

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -736,9 +736,7 @@ class PPOLoss(LossModule):
                 )
                 sampled_entropy = -log_prob.mean(0)
                 if analytic_entropy and compiling:
-                    entropy = torch.where(
-                        entropy.isfinite(), entropy, sampled_entropy
-                    )
+                    entropy = torch.where(entropy.isfinite(), entropy, sampled_entropy)
                 else:
                     entropy = sampled_entropy
         if is_tensor_collection(entropy) and entropy.batch_size != adv_shape:

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -28,8 +28,15 @@ from tensordict.nn import (
 from tensordict.utils import NestedKey
 from torch import distributions as d
 
-from torchrl._utils import _standardize, logger as torchrl_logger, VERBOSE
-from torchrl.modules.distributions.utils import composite_entropy, sample_and_log_prob
+from torchrl._utils import _standardize
+from torchrl.modules.distributions.utils import (
+    _warn_mc_entropy,
+    _warn_mc_kl,
+    composite_entropy,
+    has_analytic_entropy,
+    has_analytic_kl,
+    sample_and_log_prob,
+)
 from torchrl.modules.value_norm import ValueNorm
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import (
@@ -688,27 +695,16 @@ class PPOLoss(LossModule):
     def _get_entropy(
         self, dist: d.Distribution, adv_shape: torch.Size
     ) -> torch.Tensor | TensorDict:
-        try:
-            entropy = (
-                composite_entropy(dist, self.samples_mc_entropy)
-                if isinstance(dist, CompositeDistribution)
-                else dist.entropy()
-            )
-            if not entropy.isfinite().all():
-                del entropy
-                if VERBOSE:
-                    torchrl_logger.info(
-                        "Entropy is not finite. Using Monte Carlo sampling."
-                    )
-                raise NotImplementedError
-        except NotImplementedError:
-            if VERBOSE:
-                torchrl_logger.warning(
-                    f"Entropy not implemented for {type(dist)} or is not finite. Using Monte Carlo sampling."
-                )
+        is_composite = isinstance(dist, CompositeDistribution)
+        if is_composite:
+            entropy = composite_entropy(dist, self.samples_mc_entropy)
+        elif has_analytic_entropy(dist):
+            entropy = dist.entropy()
+        else:
+            _warn_mc_entropy(dist)
             with (
                 set_composite_lp_aggregate(False)
-                if isinstance(dist, CompositeDistribution)
+                if is_composite
                 else contextlib.nullcontext()
             ):
                 _, log_prob = sample_and_log_prob(
@@ -1827,9 +1823,10 @@ class KLPENPPOLoss(PPOLoss):
         ):
             current_dist = self.actor_network.get_dist(tensordict_copy)
         is_composite = isinstance(current_dist, CompositeDistribution)
-        try:
+        if has_analytic_kl(previous_dist, current_dist):
             kl = torch.distributions.kl.kl_divergence(previous_dist, current_dist)
-        except NotImplementedError:
+        else:
+            _warn_mc_kl(previous_dist, current_dist)
             with (
                 set_composite_lp_aggregate(False)
                 if is_composite

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -698,7 +698,26 @@ class PPOLoss(LossModule):
     ) -> torch.Tensor | TensorDict:
         is_composite = isinstance(dist, CompositeDistribution)
         if is_composite:
-            entropy = composite_entropy(dist, self.samples_mc_entropy)
+            can_compute_component_entropy = all(
+                has_analytic_entropy(component) or component.has_rsample
+                for component in dist.dists.values()
+            )
+            if can_compute_component_entropy:
+                entropy = composite_entropy(dist, self.samples_mc_entropy)
+            else:
+                if not is_dynamo_compiling():
+                    _warn_mc_entropy(dist)
+                with set_composite_lp_aggregate(False):
+                    _, log_prob = sample_and_log_prob(
+                        dist,
+                        (self.samples_mc_entropy,),
+                        reparameterize=getattr(dist, "has_rsample", False),
+                    )
+                    if isinstance(self.tensor_keys.sample_log_prob, NestedKey):
+                        log_prob = log_prob.get(self.tensor_keys.sample_log_prob)
+                    else:
+                        log_prob = log_prob.select(*self.tensor_keys.sample_log_prob)
+                entropy = -log_prob.mean(0)
         else:
             analytic_entropy = has_analytic_entropy(dist)
             if analytic_entropy:
@@ -722,6 +741,8 @@ class PPOLoss(LossModule):
                     )
                 else:
                     entropy = sampled_entropy
+        if is_tensor_collection(entropy) and entropy.batch_size != adv_shape:
+            entropy.batch_size = adv_shape
         return entropy.unsqueeze(-1)
 
     def _get_cur_log_prob(self, tensordict):


### PR DESCRIPTION
## Description

Remove `try/except` control flow around entropy and KL on the objective hot path so `torch.compile` gets a clear, exception-free graph.

Closed-form entropy is detected ahead of time with `has_analytic_entropy` (`type(dist).entropy is not torch.distributions.Distribution.entropy`, with `Independent` resolved through its base). Closed-form KL is detected with `has_analytic_kl` (registry lookup, with `Independent` / `TransformedDistribution` pairs resolved through their bases). If the analytic path is missing, the existing Monte Carlo fallback is used directly and logged once when `VERBOSE` is set.

Non-finite analytic values are no longer converted into `NotImplementedError` to jump to MC. Composite distributions keep using `composite_entropy` (now also exception-free). The same entropy rewrite is applied to A2C, DreamerV3, and GRPO.

### Code example

Select the analytic or Monte Carlo entropy path before evaluating it, without catching NotImplementedError on the hot path.

```python
import torch
from torch.distributions import Normal, kl_divergence
from torchrl.modules import TanhNormal
from torchrl.modules.distributions import has_analytic_entropy, has_analytic_kl

normal = Normal(torch.zeros(3), torch.ones(3))
squashed = TanhNormal(torch.zeros(3), torch.ones(3))
assert has_analytic_entropy(normal)
assert not has_analytic_entropy(squashed)
for dist in (normal, squashed):
    if has_analytic_entropy(dist):
        entropy = dist.entropy()
    else:
        samples = dist.rsample((128,))
        entropy = -dist.log_prob(samples).mean(0)
    assert torch.isfinite(entropy).all()
assert has_analytic_kl(normal, normal)
torch.testing.assert_close(kl_divergence(normal, normal), torch.zeros(3))
```

## Motivation and Context

`try/except NotImplementedError` around `dist.entropy()` / `kl_divergence` is hostile to `torch.compile`: when the except path is live the error is unclear, and raising on non-finite values is data-dependent control flow.

close #2403

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.