### PR TITLE
[BugFix] Assert History chat-template round-trip role and content

### DIFF
--- a/test/llm/test_data.py
+++ b/test/llm/test_data.py
@@ -843,7 +843,15 @@ The result is""",
         """Test round-trip conversion: History -> string -> History for various templates and tokenizers."""
         from transformers import AutoTokenizer
 
-        # Example chats
+        # Qwen chat templates (History's built-in template and the official
+        # tokenizer template) insert a default system message when the
+        # conversation does not start with one. The inverse parser then
+        # recovers that extra turn, so role/content cannot match the original.
+        if chat[0]["role"] != "system" and "qwen" in tokenizer_name.lower():
+            pytest.xfail(
+                "Qwen chat templates inject a default system message when the "
+                "conversation does not start with one"
+            )
 
         tokenizer = AutoTokenizer.from_pretrained(
             tokenizer_name, trust_remote_code=True
@@ -880,18 +888,19 @@ The result is""",
             chat_template_name=chat_template_name,
         )
 
-        # Normalize whitespace for comparison
+        # Normalize whitespace for comparison. Keep these asserts in the test
+        # body so a return inside the helper cannot make them dead again.
         def norm(x):
             if isinstance(x, list):
-                return [re.sub(r"\\s+", " ", str(xx).strip()) for xx in x]
-            return re.sub(r"\\s+", " ", str(x).strip())
-            # Compare roles and content
-            assert norm(parsed.role) == norm(
-                history.role
-            ), f"Roles do not match!\nOriginal: {history.role}\nParsed: {parsed.role}"
-            assert norm(parsed.content) == norm(
-                history.content
-            ), f"Content does not match!\nOriginal: {history.content}\nParsed: {parsed.content}"
+                return [re.sub(r"\s+", " ", str(xx).strip()) for xx in x]
+            return re.sub(r"\s+", " ", str(x).strip())
+
+        assert norm(parsed.role) == norm(
+            history.role
+        ), f"Roles do not match!\nOriginal: {history.role}\nParsed: {parsed.role}"
+        assert norm(parsed.content) == norm(
+            history.content
+        ), f"Content does not match!\nOriginal: {history.content}\nParsed: {parsed.content}"
 
         # All messages should be complete
         assert all(
@@ -964,8 +973,8 @@ The result is""",
         # Normalize whitespace for comparison
         def norm(x):
             if isinstance(x, list):
-                return [re.sub(r"\\s+", " ", str(xx).strip()) for xx in x]
-            return re.sub(r"\\s+", " ", str(x).strip())
+                return [re.sub(r"\s+", " ", str(xx).strip()) for xx in x]
+            return re.sub(r"\s+", " ", str(x).strip())
 
         # Check that we have the same number of messages as the original
         assert len(parsed.role) == len(


### PR DESCRIPTION
## Description

`TestHistory.test_history_round_trip` was supposed to check that `History -> apply_chat_template -> History.from_text` recovers the original roles and contents. The role/content asserts sat after `return` inside `norm()`, so they never ran, and `r"\\s+"` matched a literal backslash-s rather than whitespace. Only `assert all(parsed.is_complete)` executed.

This moves those asserts into the test body, uses `r"\s+"` for whitespace normalization, and applies the same regex fix in `test_history_round_trip_incomplete`. Qwen chats that do not start with a system message are xfailed: both History's qwen template and the official Qwen tokenizer template inject a default system turn, so that path cannot round-trip faithfully. The Qwen instruct / standard chat path still asserts role and content.

No `History` implementation change.

### Code example

Round-trip regression with a Qwen tokenizer (requires Transformers and the tokenizer files). The role/content assertions execute outside the normalization expression.

```python
import re
from transformers import AutoTokenizer
from torchrl.data.llm import History

tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct")
history = History.from_chats([
    {"role": "system", "content": "Be brief."},
    {"role": "user", "content": "Hello  there"},
    {"role": "assistant", "content": "Hi!"},
])
text = history.apply_chat_template(
    tokenizer=tokenizer, add_generation_prompt=False, return_dict=False,
)
parsed = History.from_text(text, tokenizer=tokenizer)
assert list(parsed.role) == list(history.role)
assert [re.sub(r"\s+", " ", str(x).strip()) for x in parsed.content] == [
    re.sub(r"\s+", " ", str(x).strip()) for x in history.content
]
assert all(parsed.is_complete)
```

## Motivation and Context

A broken inverse parser that returned any complete `History` would still pass CI. The comments next to the dead asserts already described the intended check.

close #4221

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.