### PR TITLE
[BugFix] Use real attention mask for single-string Tokenizer

### DIFF
--- a/test/transforms/test_key_transforms.py
+++ b/test/transforms/test_key_transforms.py
@@ -1579,3 +1579,69 @@ class TestTokenizer(TransformBase):
             return td
 
         env.check_env_specs()
+
+    @pytest.mark.parametrize(
+        "in_key,out_key",
+        [
+            ("observation", "tokens"),
+            (("nested", "text"), ("nested", "tokens")),
+        ],
+    )
+    def test_single_string_attention_mask_padding(self, in_key, out_key):
+        # Pad tokens on a single string must not be attended (issue #4223).
+        text = "hi"
+        max_length = 8
+        t = Tokenizer(
+            in_keys=[in_key],
+            out_keys=[out_key],
+            max_length=max_length,
+            return_attention_mask=True,
+        )
+        td_out = t(TensorDict({in_key: text}))
+        tokens = td_out.get(out_key)
+        mask_key = (
+            (*out_key[:-1], "attention_mask")
+            if isinstance(out_key, tuple)
+            else "attention_mask"
+        )
+        mask = td_out.get(mask_key)
+
+        assert tokens.ndim == 1
+        assert mask.ndim == 1
+        assert tokens.shape == mask.shape == (max_length,)
+
+        expected = t.tokenizer(
+            [text],
+            return_tensors="pt",
+            add_special_tokens=False,
+            padding="max_length",
+            max_length=max_length,
+            return_attention_mask=True,
+        )
+        torch.testing.assert_close(tokens, expected["input_ids"][0])
+        torch.testing.assert_close(mask, expected["attention_mask"][0])
+        assert (mask == 0).any()
+        assert (mask == 1).any()
+        pad_id = t.tokenizer.pad_token_id
+        assert (mask[tokens == pad_id] == 0).all()
+        assert (mask[tokens != pad_id] == 1).all()
+
+    def test_single_string_without_attention_mask(self):
+        text = "hi"
+        max_length = 8
+        t = Tokenizer(
+            in_keys=["observation"],
+            out_keys=["tokens"],
+            max_length=max_length,
+            return_attention_mask=False,
+        )
+        td_out = t(TensorDict({"observation": text}))
+        expected = t.tokenizer.encode(
+            text,
+            return_tensors="pt",
+            add_special_tokens=False,
+            padding="max_length",
+            max_length=max_length,
+        )[0]
+        torch.testing.assert_close(td_out["tokens"], expected)
+        assert "attention_mask" not in td_out.keys()

--- a/torchrl/envs/llm/transforms/tokenizer.py
+++ b/torchrl/envs/llm/transforms/tokenizer.py
@@ -174,10 +174,16 @@ class Tokenizer(UnaryTransform):
             kwargs["padding"] = "max_length"
             kwargs["max_length"] = self.max_length
         if isinstance(value, str):
-            out = self.tokenizer.encode(value, return_tensors="pt", **kwargs)[0]
-            # TODO: incorporate attention mask
             if self.return_attention_mask:
-                attention_mask = torch.ones_like(out, dtype=torch.int64)
+                # Use the same tokenizer call as the batch path so pad tokens
+                # are not attended. Squeeze the batch dim to keep the public
+                # 1D rank of encode()[0].
+                kwargs["return_attention_mask"] = True
+                out = self.tokenizer(value, return_tensors="pt", **kwargs)
+                attention_mask = out["attention_mask"][0]
+                out = out["input_ids"][0]
+            else:
+                out = self.tokenizer.encode(value, return_tensors="pt", **kwargs)[0]
         else:
             kwargs["padding"] = (
                 self.padding if self.max_length is None else "max_length"

--- a/torchrl/envs/transforms/_tensor.py
+++ b/torchrl/envs/transforms/_tensor.py
@@ -837,10 +837,16 @@ class Tokenizer(UnaryTransform):
             kwargs["padding"] = "max_length"
             kwargs["max_length"] = self.max_length
         if isinstance(value, str):
-            out = self.tokenizer.encode(value, return_tensors="pt", **kwargs)[0]
-            # TODO: incorporate attention mask
             if self.return_attention_mask:
-                attention_mask = torch.ones_like(out, dtype=torch.int64)
+                # Use the same tokenizer call as the batch path so pad tokens
+                # are not attended. Squeeze the batch dim to keep the public
+                # 1D rank of encode()[0].
+                kwargs["return_attention_mask"] = True
+                out = self.tokenizer(value, return_tensors="pt", **kwargs)
+                attention_mask = out["attention_mask"][0]
+                out = out["input_ids"][0]
+            else:
+                out = self.tokenizer.encode(value, return_tensors="pt", **kwargs)[0]
         else:
             kwargs["padding"] = (
                 self.padding if self.max_length is None else "max_length"


### PR DESCRIPTION
## Description

`Tokenizer.call_tokenizer_fn` treated a single `str` differently from a `list[str]`:

- A batch used `tokenizer(..., return_tensors="pt")` and the real `attention_mask`.
- A single string used `tokenizer.encode(...)` and then `torch.ones_like(out)`.

With `max_length` padding, pad tokens were marked as attended. The single-string path now uses the same tokenizer call as the batch path and squeezes the batch dimension so the public rank stays 1D (`encode()[0]`). If `return_attention_mask` is `False`, the encode-like path is unchanged.

The same helper exists on both `torchrl.envs.llm.transforms.Tokenizer` and `torchrl.envs.transforms.Tokenizer`; both copies are updated.

### Code example

With Transformers installed, a single padded string must carry zeros in its attention mask at padding positions.

```python
from tensordict import TensorDict
from torchrl.envs.transforms import Tokenizer

transform = Tokenizer(
    in_keys=["text"], out_keys=["tokens"],
    max_length=8, return_attention_mask=True,
)
out = transform(TensorDict(text="hi"))
tokens, mask = out["tokens"], out["attention_mask"]
assert tokens.shape == mask.shape == (8,)
is_padding = tokens == transform.tokenizer.pad_token_id
assert is_padding.any()
assert (mask[is_padding] == 0).all()  # Previously, the mask was all ones.
assert (mask[~is_padding] == 1).all()
```

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

close #4223

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.