### PR TITLE
[BugFix] Stop caching self.device on SFTLoss and DistillationLoss

### DIFF
--- a/test/llm/test_llm_objectives.py
+++ b/test/llm/test_llm_objectives.py
@@ -1074,6 +1074,46 @@ class TestSFT:
         )
         loss(td)
 
+    def test_sft_does_not_cache_device(self):
+        policy = _FixedSFTPolicy(torch.tensor([[-2.0, -100.0], [-1.0, -3.0]]))
+        loss = SFTLoss(policy, tokenizer=object(), device="cpu")
+        assert "device" not in vars(loss)
+        loss.cpu()
+        assert "device" not in vars(loss)
+        out = loss(_sft_loss_data())
+        assert torch.isfinite(out.loss_sft)
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    @pytest.mark.skipif(
+        not _has_transformers, reason="transformers lib required to test SFT"
+    )
+    def test_sft_to_follows_module_device(self, data):
+        from transformers import AutoTokenizer, OPTConfig, OPTForCausalLM
+
+        tokenizer = AutoTokenizer.from_pretrained("facebook/opt-125m")
+        tokenizer.pad_token = tokenizer.eos_token
+        policy = TransformersWrapper(
+            OPTForCausalLM(OPTConfig()).eval(),
+            tokenizer=tokenizer,
+            generate=False,
+            chat_template_name="qwen",
+            input_mode="history",
+            pad_output=False,
+        )
+        loss = SFTLoss(
+            actor_network=policy,
+            tokenizer=tokenizer,
+            tokenizer_kwargs={"chat_template_name": "qwen"},
+            device="cpu",
+        )
+        assert "device" not in vars(loss)
+        loss.to(torch.device("cuda"))
+        assert "device" not in vars(loss)
+        loss_vals = loss(data)
+        assert loss_vals.loss_sft.device.type == "cuda"
+        assert torch.isfinite(loss_vals.loss_sft)
+
 
 class TestDistillation:
     @pytest.fixture(scope="class")
@@ -1356,6 +1396,55 @@ class TestDistillation:
         )
         with pytest.raises(KeyError, match="Teacher log-probs"):
             loss_fn(data.clone())
+
+    def test_distillation_does_not_cache_device(self):
+        mask = torch.ones(2, 3, dtype=torch.bool)
+        data = TensorDict(
+            {
+                ("history", "full"): torch.full((2, 3), -1.0),
+                ("masks", "all_attention_mask"): mask,
+                ("masks", "all_assistant_mask"): mask,
+                ("next", "teacher_log_probs", "full"): torch.full((2, 3), -2.0),
+            },
+            batch_size=(2,),
+        )
+        student = TensorDictModule(
+            torch.nn.Linear(3, 3, bias=False),
+            in_keys=[("history", "full")],
+            out_keys=[("log_probs", "full")],
+        )
+        loss_fn = DistillationLoss(actor_network=student, device="cpu")
+        assert "device" not in vars(loss_fn)
+        loss_fn.cpu()
+        assert "device" not in vars(loss_fn)
+        out = loss_fn(data)
+        assert torch.isfinite(out.loss_distill)
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    @pytest.mark.skipif(
+        not _has_transformers, reason="transformers lib required to test distillation"
+    )
+    def test_distillation_to_follows_module_device(self, data):
+        from transformers import OPTConfig, OPTForCausalLM
+
+        student, tokenizer = self._make_student()
+        teacher_model = OPTForCausalLM(OPTConfig()).eval()
+        td = data.clone()
+        self._write_teacher_log_probs(td, teacher_model, tokenizer)
+        loss_fn = DistillationLoss(
+            actor_network=student,
+            tokenizer=tokenizer,
+            tokenizer_kwargs={"chat_template_name": "qwen"},
+            device="cpu",
+        )
+        assert "device" not in vars(loss_fn)
+        loss_fn.to(torch.device("cuda"))
+        assert "device" not in vars(loss_fn)
+        td = td.to("cuda")
+        loss_vals = loss_fn(td)
+        assert loss_vals.loss_distill.device.type == "cuda"
+        assert torch.isfinite(loss_vals.loss_distill)
 
 
 @pytest.mark.slow

--- a/test/llm/test_llm_objectives.py
+++ b/test/llm/test_llm_objectives.py
@@ -1074,14 +1074,11 @@ class TestSFT:
         )
         loss(td)
 
-    def test_sft_does_not_cache_device(self):
+    def test_sft_constructor_device_does_not_move_actor(self):
         policy = _FixedSFTPolicy(torch.tensor([[-2.0, -100.0], [-1.0, -3.0]]))
-        loss = SFTLoss(policy, tokenizer=object(), device="cpu")
-        assert "device" not in vars(loss)
-        loss.cpu()
-        assert "device" not in vars(loss)
-        out = loss(_sft_loss_data())
-        assert torch.isfinite(out.loss_sft)
+        loss = SFTLoss(policy, tokenizer=object(), device="meta")
+        assert policy.log_probs.device.type == "cpu"
+        assert all(value.device.type == "cpu" for value in loss.state_dict().values())
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
@@ -1107,9 +1104,7 @@ class TestSFT:
             tokenizer_kwargs={"chat_template_name": "qwen"},
             device="cpu",
         )
-        assert "device" not in vars(loss)
         loss.to(torch.device("cuda"))
-        assert "device" not in vars(loss)
         loss_vals = loss(data)
         assert loss_vals.loss_sft.device.type == "cuda"
         assert torch.isfinite(loss_vals.loss_sft)
@@ -1397,28 +1392,17 @@ class TestDistillation:
         with pytest.raises(KeyError, match="Teacher log-probs"):
             loss_fn(data.clone())
 
-    def test_distillation_does_not_cache_device(self):
-        mask = torch.ones(2, 3, dtype=torch.bool)
-        data = TensorDict(
-            {
-                ("history", "full"): torch.full((2, 3), -1.0),
-                ("masks", "all_attention_mask"): mask,
-                ("masks", "all_assistant_mask"): mask,
-                ("next", "teacher_log_probs", "full"): torch.full((2, 3), -2.0),
-            },
-            batch_size=(2,),
-        )
+    def test_distillation_constructor_device_does_not_move_actor(self):
         student = TensorDictModule(
             torch.nn.Linear(3, 3, bias=False),
             in_keys=[("history", "full")],
             out_keys=[("log_probs", "full")],
         )
-        loss_fn = DistillationLoss(actor_network=student, device="cpu")
-        assert "device" not in vars(loss_fn)
-        loss_fn.cpu()
-        assert "device" not in vars(loss_fn)
-        out = loss_fn(data)
-        assert torch.isfinite(out.loss_distill)
+        loss_fn = DistillationLoss(actor_network=student, device="meta")
+        assert next(student.parameters()).device.type == "cpu"
+        assert all(
+            value.device.type == "cpu" for value in loss_fn.state_dict().values()
+        )
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
@@ -1438,9 +1422,7 @@ class TestDistillation:
             tokenizer_kwargs={"chat_template_name": "qwen"},
             device="cpu",
         )
-        assert "device" not in vars(loss_fn)
         loss_fn.to(torch.device("cuda"))
-        assert "device" not in vars(loss_fn)
         td = td.to("cuda")
         loss_vals = loss_fn(td)
         assert loss_vals.loss_distill.device.type == "cuda"

--- a/torchrl/objectives/llm/_utils.py
+++ b/torchrl/objectives/llm/_utils.py
@@ -1,0 +1,34 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import torch
+from tensordict import TensorDictBase
+from torch import nn
+
+
+def _runtime_device(
+    module: nn.Module,
+    tensordict: TensorDictBase,
+    *values: object,
+    fallback: torch.Tensor,
+) -> torch.device:
+    """Resolve the device relevant to the current loss invocation."""
+    if tensordict.device is not None:
+        return tensordict.device
+    for value in values:
+        if isinstance(value, torch.Tensor):
+            return value.device
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                if isinstance(item, torch.Tensor):
+                    return item.device
+    parameter = next(module.parameters(), None)
+    if parameter is not None:
+        return parameter.device
+    buffer = next(module.buffers(), None)
+    if buffer is not None:
+        return buffer.device
+    return fallback.device

--- a/torchrl/objectives/llm/distillation.py
+++ b/torchrl/objectives/llm/distillation.py
@@ -176,8 +176,13 @@ class DistillationLoss(LossModule):
             with ``DistillationLoss(assistant_only=True)``; use
             ``RetrieveLogProb(assistant_only=False)`` when distilling on all
             attended tokens.
-        device (torch.device, optional): the device to use when tokenizing
-            the input and running the student. Defaults to ``None``.
+        device (torch.device | None, optional): device used to place the
+            student network at construction time. The value is not stored
+            on the module; after construction, move the loss with
+            :meth:`~torch.nn.Module.to`. Tokenization and student calls
+            derive their device from the actor parameters (or buffers), or
+            from a history/mask tensor if the actor has none. Defaults to
+            ``None``.
 
     .. note::
         The input tensordict is expected to contain the following keys by
@@ -342,7 +347,32 @@ class DistillationLoss(LossModule):
         self.normalize_by_seq_length = normalize_by_seq_length
         self.assistant_only = assistant_only
         self._set_in_keys()
-        self.device = device
+        if device is not None and actor_network is not None:
+            self.actor_network.to(device)
+
+    def _runtime_device(self, *values: object) -> torch.device | None:
+        """Device for tokenizer / student contexts, derived at call time.
+
+        Parameters and buffers move with ``.to()`` / ``.cpu()`` / ``.cuda()``;
+        a cached constructor device would not.
+        """
+        actor = self.actor_network
+        if actor is not None:
+            try:
+                return next(actor.parameters()).device
+            except (StopIteration, AttributeError):
+                try:
+                    return next(actor.buffers()).device
+                except (StopIteration, AttributeError):
+                    pass
+        for value in values:
+            if isinstance(value, torch.Tensor):
+                return value.device
+            if isinstance(value, (list, tuple)):
+                for tensor in value:
+                    if isinstance(tensor, torch.Tensor):
+                        return tensor.device
+        return None
 
     def _set_in_keys(self) -> None:
         """Sets the input keys for the loss module."""
@@ -355,6 +385,7 @@ class DistillationLoss(LossModule):
         """Returns the loss masks, the attention masks and, when recoverable, the assistant masks."""
         assistant_masks = tensordict.get(("masks", "all_assistant_mask"), as_list=True)
         attention_mask = tensordict.get(("masks", "all_attention_mask"), as_list=True)
+        device = self._runtime_device(assistant_masks, attention_mask)
         if (self.assistant_only and assistant_masks is None) or attention_mask is None:
             if self.tokenizer is None:
                 raise ValueError(
@@ -363,8 +394,8 @@ class DistillationLoss(LossModule):
                     "to the loss constructor or provide the masks in the input."
                 )
             with torch.device(
-                self.device
-            ) if self.device is not None else contextlib.nullcontext():
+                device
+            ) if device is not None else contextlib.nullcontext():
                 token_struct = history.apply_chat_template(
                     tokenizer=self.tokenizer, **self.tokenizer_kwargs
                 )
@@ -436,9 +467,10 @@ class DistillationLoss(LossModule):
             )
 
         input_loss = tensordict.select(self.tensor_keys.history)
+        device = self._runtime_device(masks, attention_masks)
         with torch.device(
-            self.device
-        ) if self.device is not None else contextlib.nullcontext():
+            device
+        ) if device is not None else contextlib.nullcontext():
             output_loss = self.actor_network(input_loss)
         log_probs = output_loss.get(self.tensor_keys.log_probs, as_list=True)
 

--- a/torchrl/objectives/llm/distillation.py
+++ b/torchrl/objectives/llm/distillation.py
@@ -16,6 +16,7 @@ from tensordict.utils import _zip_strict
 from torchrl.data import History
 from torchrl.modules.llm.policies.transformers_wrapper import TransformersWrapper
 from torchrl.objectives.common import LossModule
+from torchrl.objectives.llm._utils import _runtime_device
 
 if TYPE_CHECKING:
     import transformers
@@ -176,13 +177,10 @@ class DistillationLoss(LossModule):
             with ``DistillationLoss(assistant_only=True)``; use
             ``RetrieveLogProb(assistant_only=False)`` when distilling on all
             attended tokens.
-        device (torch.device | None, optional): device used to place the
-            student network at construction time. The value is not stored
-            on the module; after construction, move the loss with
-            :meth:`~torch.nn.Module.to`. Tokenization and student calls
-            derive their device from the actor parameters (or buffers), or
-            from a history/mask tensor if the actor has none. Defaults to
-            ``None``.
+        device (torch.device | None, optional): fallback device used when neither
+            the input nor the student parameters and buffers provide one. This
+            does not move the student network; move the complete loss with
+            :meth:`~torch.nn.Module.to`. Defaults to ``None``.
 
     .. note::
         The input tensordict is expected to contain the following keys by
@@ -347,32 +345,9 @@ class DistillationLoss(LossModule):
         self.normalize_by_seq_length = normalize_by_seq_length
         self.assistant_only = assistant_only
         self._set_in_keys()
-        if device is not None and actor_network is not None:
-            self.actor_network.to(device)
-
-    def _runtime_device(self, *values: object) -> torch.device | None:
-        """Device for tokenizer / student contexts, derived at call time.
-
-        Parameters and buffers move with ``.to()`` / ``.cpu()`` / ``.cuda()``;
-        a cached constructor device would not.
-        """
-        actor = self.actor_network
-        if actor is not None:
-            try:
-                return next(actor.parameters()).device
-            except (StopIteration, AttributeError):
-                try:
-                    return next(actor.buffers()).device
-                except (StopIteration, AttributeError):
-                    pass
-        for value in values:
-            if isinstance(value, torch.Tensor):
-                return value.device
-            if isinstance(value, (list, tuple)):
-                for tensor in value:
-                    if isinstance(tensor, torch.Tensor):
-                        return tensor.device
-        return None
+        self.register_buffer(
+            "_device_fallback", torch.empty(0, device=device), persistent=False
+        )
 
     def _set_in_keys(self) -> None:
         """Sets the input keys for the loss module."""
@@ -385,7 +360,13 @@ class DistillationLoss(LossModule):
         """Returns the loss masks, the attention masks and, when recoverable, the assistant masks."""
         assistant_masks = tensordict.get(("masks", "all_assistant_mask"), as_list=True)
         attention_mask = tensordict.get(("masks", "all_attention_mask"), as_list=True)
-        device = self._runtime_device(assistant_masks, attention_mask)
+        device = _runtime_device(
+            self.actor_network,
+            tensordict,
+            assistant_masks,
+            attention_mask,
+            fallback=self._device_fallback,
+        )
         if (self.assistant_only and assistant_masks is None) or attention_mask is None:
             if self.tokenizer is None:
                 raise ValueError(
@@ -467,10 +448,14 @@ class DistillationLoss(LossModule):
             )
 
         input_loss = tensordict.select(self.tensor_keys.history)
-        device = self._runtime_device(masks, attention_masks)
-        with torch.device(
-            device
-        ) if device is not None else contextlib.nullcontext():
+        device = _runtime_device(
+            self.actor_network,
+            tensordict,
+            masks,
+            attention_masks,
+            fallback=self._device_fallback,
+        )
+        with torch.device(device) if device is not None else contextlib.nullcontext():
             output_loss = self.actor_network(input_loss)
         log_probs = output_loss.get(self.tensor_keys.log_probs, as_list=True)
 

--- a/torchrl/objectives/llm/sft.py
+++ b/torchrl/objectives/llm/sft.py
@@ -17,6 +17,7 @@ from tensordict.utils import _zip_strict
 from torchrl.data import History
 from torchrl.modules.llm.policies.transformers_wrapper import TransformersWrapper
 from torchrl.objectives.common import LossModule
+from torchrl.objectives.llm._utils import _runtime_device
 
 if TYPE_CHECKING:
     import transformers
@@ -121,12 +122,10 @@ class SFTLoss(LossModule):
                 \text{loss} = -\log\sigma(\beta \cdot (\text{log_probs} - \text{ref_log_probs}))
 
             Defaults to `0.1`.
-        device (torch.device | None, optional): device used to place the actor
-            network at construction time. The value is not stored on the module;
-            after construction, move the loss with :meth:`~torch.nn.Module.to`.
-            Tokenization and actor calls derive their device from the actor
-            parameters (or buffers), or from a history/mask tensor if the actor
-            has none. Defaults to `None`.
+        device (torch.device | None, optional): fallback device used when neither
+            the input nor the actor parameters and buffers provide one. This does
+            not move the actor network; move the complete loss with
+            :meth:`~torch.nn.Module.to`. Defaults to `None`.
 
     .. note::
         The input tensordict is expected to contain the following keys by default:
@@ -300,32 +299,9 @@ class SFTLoss(LossModule):
             self.kl_to_ref_coeff = 0.0
         self.beta = beta
         self._set_in_keys()
-        if device is not None and actor_network is not None:
-            self.actor_network.to(device)
-
-    def _runtime_device(self, *values: object) -> torch.device | None:
-        """Device for tokenizer / actor contexts, derived at call time.
-
-        Parameters and buffers move with ``.to()`` / ``.cpu()`` / ``.cuda()``;
-        a cached constructor device would not.
-        """
-        actor = self.actor_network
-        if actor is not None:
-            try:
-                return next(actor.parameters()).device
-            except (StopIteration, AttributeError):
-                try:
-                    return next(actor.buffers()).device
-                except (StopIteration, AttributeError):
-                    pass
-        for value in values:
-            if isinstance(value, torch.Tensor):
-                return value.device
-            if isinstance(value, (list, tuple)):
-                for tensor in value:
-                    if isinstance(tensor, torch.Tensor):
-                        return tensor.device
-        return None
+        self.register_buffer(
+            "_device_fallback", torch.empty(0, device=device), persistent=False
+        )
 
     def _set_in_keys(self) -> None:
         """Sets the input keys for the loss module."""
@@ -372,7 +348,13 @@ class SFTLoss(LossModule):
         token_struct = None
         assistant_masks = tensordict.get(("masks", "all_assistant_mask"), as_list=True)
         attention_mask = tensordict.get(("masks", "all_attention_mask"), as_list=True)
-        device = self._runtime_device(assistant_masks, attention_mask)
+        device = _runtime_device(
+            self.actor_network,
+            tensordict,
+            assistant_masks,
+            attention_mask,
+            fallback=self._device_fallback,
+        )
         if assistant_masks is None:
             # Apply tokenizer to history and gather mask
             with torch.device(
@@ -401,9 +383,7 @@ class SFTLoss(LossModule):
 
         input_loss = tensordict.select(self.tensor_keys.history)
 
-        with torch.device(
-            device
-        ) if device is not None else contextlib.nullcontext():
+        with torch.device(device) if device is not None else contextlib.nullcontext():
             output_loss = self.actor_network(input_loss)
 
         # get log-probs

--- a/torchrl/objectives/llm/sft.py
+++ b/torchrl/objectives/llm/sft.py
@@ -121,7 +121,12 @@ class SFTLoss(LossModule):
                 \text{loss} = -\log\sigma(\beta \cdot (\text{log_probs} - \text{ref_log_probs}))
 
             Defaults to `0.1`.
-        device (torch.device | None, optional): the device to use for the loss, when tokenizing the input. Defaults to `None`.
+        device (torch.device | None, optional): device used to place the actor
+            network at construction time. The value is not stored on the module;
+            after construction, move the loss with :meth:`~torch.nn.Module.to`.
+            Tokenization and actor calls derive their device from the actor
+            parameters (or buffers), or from a history/mask tensor if the actor
+            has none. Defaults to `None`.
 
     .. note::
         The input tensordict is expected to contain the following keys by default:
@@ -295,7 +300,32 @@ class SFTLoss(LossModule):
             self.kl_to_ref_coeff = 0.0
         self.beta = beta
         self._set_in_keys()
-        self.device = device
+        if device is not None and actor_network is not None:
+            self.actor_network.to(device)
+
+    def _runtime_device(self, *values: object) -> torch.device | None:
+        """Device for tokenizer / actor contexts, derived at call time.
+
+        Parameters and buffers move with ``.to()`` / ``.cpu()`` / ``.cuda()``;
+        a cached constructor device would not.
+        """
+        actor = self.actor_network
+        if actor is not None:
+            try:
+                return next(actor.parameters()).device
+            except (StopIteration, AttributeError):
+                try:
+                    return next(actor.buffers()).device
+                except (StopIteration, AttributeError):
+                    pass
+        for value in values:
+            if isinstance(value, torch.Tensor):
+                return value.device
+            if isinstance(value, (list, tuple)):
+                for tensor in value:
+                    if isinstance(tensor, torch.Tensor):
+                        return tensor.device
+        return None
 
     def _set_in_keys(self) -> None:
         """Sets the input keys for the loss module."""
@@ -342,11 +372,12 @@ class SFTLoss(LossModule):
         token_struct = None
         assistant_masks = tensordict.get(("masks", "all_assistant_mask"), as_list=True)
         attention_mask = tensordict.get(("masks", "all_attention_mask"), as_list=True)
+        device = self._runtime_device(assistant_masks, attention_mask)
         if assistant_masks is None:
             # Apply tokenizer to history and gather mask
             with torch.device(
-                self.device
-            ) if self.device is not None else contextlib.nullcontext():
+                device
+            ) if device is not None else contextlib.nullcontext():
                 token_struct = history.apply_chat_template(
                     tokenizer=self.tokenizer, **self.tokenizer_kwargs
                 )
@@ -371,8 +402,8 @@ class SFTLoss(LossModule):
         input_loss = tensordict.select(self.tensor_keys.history)
 
         with torch.device(
-            self.device
-        ) if self.device is not None else contextlib.nullcontext():
+            device
+        ) if device is not None else contextlib.nullcontext():
             output_loss = self.actor_network(input_loss)
 
         # get log-probs


### PR DESCRIPTION
## Description

`SFTLoss` and `DistillationLoss` assigned `self.device` on the `LossModule` / `nn.Module`. `.to()` / `.cpu()` / `.cuda()` move parameters and buffers but not that Python attribute, so tokenizer masks and actor inputs could be created on a stale device.

The constructor still accepts `device=` and uses it to place the actor at init, then discards it. At runtime, tokenization and actor calls derive the device from `actor_network` parameters (or buffers), falling back to a history/mask tensor.

### Code example

Given a scoring `TransformersWrapper` actor, its tokenizer, and a compatible History batch `data`, move the loss after construction. On CUDA, the output must follow the moved module.

```python
import torch
from torchrl.objectives.llm import SFTLoss

# actor was built with generate=False and input_mode="history".
loss = SFTLoss(
    actor_network=actor, tokenizer=tokenizer,
    tokenizer_kwargs={"chat_template_name": "qwen"}, device="cpu",
)
loss.to("cuda")  # Moves registered parameters/buffers, including the actor.
result = loss(data.to("cuda"))
assert result["loss_sft"].device.type == "cuda"
assert torch.isfinite(result["loss_sft"])
result["loss_sft"].backward()
# The constructor's device="cpu" must not recast runtime masks back to CPU.
```

## Motivation and Context

A cached `self.device` violates TorchRL's module-device contract (Agents.md 6a) and breaks after `loss.to("cuda")` / `loss.cpu()`.

close #4224

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.