### PR TITLE
[BugFix] Honor TensorDict state when sampling Chess actions

### DIFF
--- a/test/envs/test_special.py
+++ b/test/envs/test_special.py
@@ -555,19 +555,10 @@ class TestChessEnv:
             # `mask_actions == False`, because `rand_action` can pick illegal
             # actions in that case.
             if mask_actions:
-                # TODO: Something is wrong in `ChessEnv.rand_action` which makes
-                # it fail to work properly for stateless mode. It doesn't know
-                # how to correctly reset the board state to what is given in the
-                # tensordict before picking an action. When this is fixed, we
-                # can get rid of the two `reset`s below
-                if not stateful:
-                    env.reset(td.clone())
                 td_act = td.clone()
                 for _ in range(10):
                     rand_action = env.rand_action(td_act)
                     assert (rand_action["action"] == all_actions["action"]).sum() == 1
-                if not stateful:
-                    env.reset()
 
             action_idx = torch.randint(0, all_actions.shape[0], ()).item()
             chosen_action = all_actions[action_idx]
@@ -575,6 +566,18 @@ class TestChessEnv:
 
             if td["done"]:
                 td = env.reset()
+
+    def test_rand_action_honors_input_state(self):
+        # Mid-game FEN whose only legal move is not legal at the start
+        # position. A stale ActionMask would sample from the start mask
+        # and fail the membership check.
+        fen = "5R1k/8/8/8/6R1/8/8/5K2 b - - 0 1"
+        env = ChessEnv(stateful=False, include_fen=True, mask_actions=True)
+        env.reset()
+        td = TensorDict({"fen": fen})
+        rand_action = env.rand_action(td.clone())
+        all_actions = env.all_actions(td.clone())
+        assert (rand_action["action"] == all_actions["action"]).sum() == 1
 
 
 @pytest.mark.parametrize("device", [None, *get_default_devices()])

--- a/test/envs/test_special.py
+++ b/test/envs/test_special.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import contextlib
+import pickle
 import threading
 from functools import partial
 
@@ -567,16 +568,45 @@ class TestChessEnv:
             if td["done"]:
                 td = env.reset()
 
-    def test_rand_action_honors_input_state(self):
-        # Mid-game FEN whose only legal move is not legal at the start
-        # position. A stale ActionMask would sample from the start mask
-        # and fail the membership check.
-        fen = "5R1k/8/8/8/6R1/8/8/5K2 b - - 0 1"
-        env = ChessEnv(stateful=False, include_fen=True, mask_actions=True)
+    @pytest.mark.parametrize(
+        "state_key,state",
+        [
+            ("fen", "5R1k/8/8/8/6R1/8/8/5K2 b - - 0 1"),
+            (
+                "pgn",
+                """[Event "?"]
+[Site "?"]
+[Date "????.??.??"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+1. Na3 c6 2. Nc4 c5 3. Nd6+ *""",
+            ),
+        ],
+    )
+    def test_rand_action_honors_input_state(self, state_key, state):
+        # Both positions have one legal move that is illegal at the start.
+        # Pickle round-tripping also exercises the sampler installed on the
+        # public TransformedEnv wrapper.
+        env = ChessEnv(
+            stateful=False,
+            include_fen=state_key == "fen",
+            include_pgn=state_key == "pgn",
+            mask_actions=True,
+        )
         env.reset()
-        td = TensorDict({"fen": fen})
+        env = pickle.loads(pickle.dumps(env))
+        td = TensorDict({state_key: state})
         rand_action = env.rand_action(td.clone())
         all_actions = env.all_actions(td.clone())
+        assert (rand_action["action"] == all_actions["action"]).sum() == 1
+
+        # A supplied mask must also override the stale start-position mask.
+        mask = torch.zeros_like(env.reset()["action_mask"])
+        mask[all_actions["action"]] = True
+        rand_action = env.rand_action(TensorDict({"action_mask": mask}))
         assert (rand_action["action"] == all_actions["action"]).sum() == 1
 
 

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -3387,12 +3387,33 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
 
         Args:
             tensordict (TensorDictBase, optional): tensordict where the resulting action should be written.
+                If given, the action spec is synchronized with the state
+                encoded in the tensordict before sampling (same contract as
+                :meth:`~.all_actions`): an ``"action_mask"`` entry updates the
+                spec in place; otherwise, if this env supports deterministic
+                resets, :meth:`~.reset` is called with ``set_state=True`` on a
+                clone so a raw FEN/PGN (or other state) is honored without
+                rewriting the caller's tensordict.
 
         Returns:
             a tensordict object with the "action" entry updated with a random
             sample from the action-spec.
 
         """
+        if tensordict is not None:
+            # Sample from this tensordict's state, not leftover env state
+            # (same contract as all_actions). Apply a provided action_mask
+            # directly; otherwise reset a clone when set_state is supported.
+            mask = tensordict.get("action_mask", None)
+            if mask is not None:
+                action_spec = self.input_spec["full_action_spec"]
+                if self.action_key in action_spec.keys(True, True):
+                    leaf = action_spec[self.action_key]
+                    update_mask = getattr(leaf, "update_mask", None)
+                    if update_mask is not None:
+                        update_mask(mask.to(leaf.device))
+            elif self._supports_set_state and self._input_td_has_state(tensordict):
+                self.reset(tensordict.clone(), set_state=True)
         shape = torch.Size([])
         if not self.batch_locked:
             if not self.batch_size and tensordict is not None:

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -3387,33 +3387,12 @@ class EnvBase(nn.Module, metaclass=_EnvPostInit):
 
         Args:
             tensordict (TensorDictBase, optional): tensordict where the resulting action should be written.
-                If given, the action spec is synchronized with the state
-                encoded in the tensordict before sampling (same contract as
-                :meth:`~.all_actions`): an ``"action_mask"`` entry updates the
-                spec in place; otherwise, if this env supports deterministic
-                resets, :meth:`~.reset` is called with ``set_state=True`` on a
-                clone so a raw FEN/PGN (or other state) is honored without
-                rewriting the caller's tensordict.
 
         Returns:
             a tensordict object with the "action" entry updated with a random
             sample from the action-spec.
 
         """
-        if tensordict is not None:
-            # Sample from this tensordict's state, not leftover env state
-            # (same contract as all_actions). Apply a provided action_mask
-            # directly; otherwise reset a clone when set_state is supported.
-            mask = tensordict.get("action_mask", None)
-            if mask is not None:
-                action_spec = self.input_spec["full_action_spec"]
-                if self.action_key in action_spec.keys(True, True):
-                    leaf = action_spec[self.action_key]
-                    update_mask = getattr(leaf, "update_mask", None)
-                    if update_mask is not None:
-                        update_mask(mask.to(leaf.device))
-            elif self._supports_set_state and self._input_td_has_state(tensordict):
-                self.reset(tensordict.clone(), set_state=True)
         shape = torch.Size([])
         if not self.batch_locked:
             if not self.batch_size and tensordict is not None:

--- a/torchrl/envs/custom/chess.py
+++ b/torchrl/envs/custom/chess.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import functools as ft
 import importlib.util
 import io
 import pathlib
@@ -23,6 +24,22 @@ from torchrl.envs.common import _EnvPostInit
 from torchrl.envs.utils import _classproperty
 
 _has_torchvision = importlib.util.find_spec("torchvision") is not None
+
+
+def _chess_rand_action(
+    env: EnvBase, tensordict: TensorDictBase | None = None
+) -> TensorDictBase:
+    chess_env = getattr(env, "base_env", env)
+    if tensordict is not None and not chess_env.stateful and chess_env.mask_actions:
+        mask = tensordict.get("action_mask", None)
+        state_key = "fen" if chess_env.include_fen else "pgn"
+        if mask is None and tensordict.get(state_key, None) is not None:
+            mask = chess_env._legal_moves_to_index(
+                tensordict=tensordict, return_mask=True
+            )[1]
+        if mask is not None:
+            env.action_spec.update_mask(mask.to(env.action_spec.device))
+    return EnvBase.rand_action(env, tensordict)
 
 
 class _ChessMeta(_EnvPostInit):
@@ -62,6 +79,9 @@ class _ChessMeta(_EnvPostInit):
             from torchrl.envs import ActionMask
 
             instance = instance.append_transform(ActionMask())
+            # The public ChessEnv is now a TransformedEnv. Keep its specialized
+            # sampler on that wrapper so ActionMask's transformed spec is used.
+            instance.rand_action = ft.partial(_chess_rand_action, instance)
         return instance
 
 
@@ -370,6 +390,10 @@ class ChessEnv(EnvBase, metaclass=_ChessMeta):
                 "legal ones, call 'env.full_action_spec.enumerate()'."
             )
         return super().all_actions(tensordict)
+
+    def rand_action(self, tensordict: TensorDictBase | None = None) -> TensorDictBase:
+        """Sample a legal action from the state carried by ``tensordict``."""
+        return _chess_rand_action(self, tensordict)
 
     def _reset(self, tensordict=None, **kwargs):
         # ``set_state`` is resolved by ``EnvBase.reset``: when truthy, honor the


### PR DESCRIPTION
## Description

Make `ChessEnv.rand_action(tensordict)` honor the Chess state carried by its
input without changing generic `EnvBase` sampling semantics.

For stateless masked Chess environments, the sampler refreshes the active
action mask from either:

- an explicit `action_mask` in the input TensorDict, or
- the configured raw FEN/PGN state.

Public masked `ChessEnv` construction returns a `TransformedEnv` with
`ActionMask`, so the Chess-specific sampler is also retained on that wrapper
and samples from its transformed action spec. Generic environments, including
those with multiple action leaves, continue to use the unchanged
`EnvBase.rand_action` behavior.

The tests cover raw FEN, raw PGN, a supplied mask, the existing `all_actions`
path, and a standard-library pickle round trip.

### Code example

With python-chess installed, sampling uses the FEN supplied in the TensorDict even if the environment was last reset to the starting position.

```python
from tensordict import TensorDict
from torchrl.envs import ChessEnv

env = ChessEnv(stateful=False, include_fen=True, include_pgn=False, mask_actions=True)
env.reset()  # Leaves a starting-position mask on the wrapper.
state = TensorDict({"fen": "5R1k/8/8/8/6R1/8/8/5K2 b - - 0 1"})
legal = env.all_actions(state.clone())["action"]
sampled = env.rand_action(state.clone())["action"]
assert legal.numel() == 1
assert (sampled == legal).any()  # Sample the supplied position's sole legal move.
env.close()
```

## Motivation and Context

Closes #4225.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
