### PR TITLE
[BugFix] Fix hardcoded test_render paths for cross-repository CI

### DIFF
--- a/test/test_render.py
+++ b/test/test_render.py
@@ -1030,7 +1030,7 @@ class TestSotaCheckpointFactories:
     )
     def test_dqn_cartpole_checkpoint_render_factories(self, tmp_path, monkeypatch):
         OmegaConf = pytest.importorskip("omegaconf").OmegaConf
-        dqn_dir = Path("sota-implementations/dqn").resolve()
+        dqn_dir = (Path(__file__).resolve().parents[1] / "sota-implementations/dqn").resolve()
         utils_path = dqn_dir / "utils_cartpole.py"
         make_dqn_model = import_from_string(f"{utils_path}:make_dqn_model")
         checkpoint_path = tmp_path / "dqn_cartpole.pt"
@@ -1155,7 +1155,7 @@ class TestSotaCheckpointFactories:
         reason="Gymnasium and pygame are required for CartPole pixel rendering",
     )
     def test_dqn_cartpole_pixel_render_factory(self, tmp_path):
-        dqn_dir = Path("sota-implementations/dqn").resolve()
+        dqn_dir = (Path(__file__).resolve().parents[1] / "sota-implementations/dqn").resolve()
         utils_path = dqn_dir / "utils_cartpole.py"
         make_dqn_model = import_from_string(f"{utils_path}:make_dqn_model")
         checkpoint_path = tmp_path / "dqn_cartpole.pt"
@@ -1198,7 +1198,7 @@ class TestSotaCheckpointFactories:
         self, tmp_path, monkeypatch
     ):
         OmegaConf = pytest.importorskip("omegaconf").OmegaConf
-        ppo_dir = Path("sota-implementations/ppo").resolve()
+        ppo_dir = (Path(__file__).resolve().parents[1] / "sota-implementations/ppo").resolve()
         utils_path = ppo_dir / "utils_mujoco.py"
         make_ppo_models = import_from_string(f"{utils_path}:make_ppo_models")
         checkpoint_path = tmp_path / "ppo_inverted_pendulum.pt"
@@ -1334,7 +1334,7 @@ class TestSotaCheckpointFactories:
         reason="A Gymnasium MuJoCo environment with v4/v5 IDs is required",
     )
     def test_inverted_double_pendulum_qpos_uses_physics_state(self):
-        utils_path = Path("sota-implementations/ppo/utils_mujoco.py").resolve()
+        utils_path = (Path(__file__).resolve().parents[1] / "sota-implementations/ppo/utils_mujoco.py").resolve()
         make_env = import_from_string(f"{utils_path}:make_env")
         env = make_env(
             "InvertedDoublePendulum-v4",
@@ -1357,7 +1357,7 @@ class TestSotaCheckpointFactories:
             env.close()
 
     def test_mujoco_playground_ppo_factory(self, monkeypatch):
-        utils_path = Path("sota-implementations/ppo/utils_mujoco.py").resolve()
+        utils_path = (Path(__file__).resolve().parents[1] / "sota-implementations/ppo/utils_mujoco.py").resolve()
         make_env = import_from_string(f"{utils_path}:make_env")
         module_globals = make_env.__globals__
 
@@ -1394,7 +1394,7 @@ class TestSotaCheckpointFactories:
         assert len(env.transforms) == 2
 
     def test_mujoco_playground_ppo_batch_modes(self, monkeypatch):
-        utils_path = Path("sota-implementations/ppo/utils_mujoco.py").resolve()
+        utils_path = (Path(__file__).resolve().parents[1] / "sota-implementations/ppo/utils_mujoco.py").resolve()
         make_env = import_from_string(f"{utils_path}:make_env")
         module_globals = make_env.__globals__
 
@@ -1452,7 +1452,7 @@ class TestSotaCheckpointFactories:
 
     def test_mujoco_playground_ppo_uses_scalar_proof_and_eval_envs(self, monkeypatch):
         OmegaConf = pytest.importorskip("omegaconf").OmegaConf
-        ppo_dir = Path("sota-implementations/ppo").resolve()
+        ppo_dir = (Path(__file__).resolve().parents[1] / "sota-implementations/ppo").resolve()
         utils_path = ppo_dir / "utils_mujoco.py"
         make_ppo_models = import_from_string(f"{utils_path}:make_ppo_models")
         module_globals = make_ppo_models.__globals__
@@ -1511,7 +1511,7 @@ class TestSotaCheckpointFactories:
         reason="gym or gymnasium is required to build the CartPole PPO env",
     )
     def test_ppo_vecnorm_checkpoint_roundtrip(self, tmp_path):
-        utils_path = Path("sota-implementations/ppo/utils_mujoco.py").resolve()
+        utils_path = (Path(__file__).resolve().parents[1] / "sota-implementations/ppo/utils_mujoco.py").resolve()
         ppo_make_env = import_from_string(f"{utils_path}:make_env")
         get_vecnorm_state = import_from_string(f"{utils_path}:get_vecnorm_state")
         train_env = ppo_make_env("CartPole-v1", normalize_observation=True)


### PR DESCRIPTION
## Description

Fixes the `ImportError: Could not import file '/pytorch/tensordict/sota-implementations/ppo/utils_mujoco.py'` occurring during cross-repository CI jobs.

Previously, `test_render.py` relied on paths resolved relative to the current working directory:
`utils_path = Path("sota-implementations/ppo/utils_mujoco.py").resolve()`

This breaks when `test_render.py` is run from a runner where the current working directory is not the root of the `torchrl` repository (e.g., during the cross-repo `test-gpu` CI job in the `tensordict` repo).

This PR updates all 8 hardcoded paths in `test_render.py` to correctly resolve relative to the test file's location using the standard TorchRL convention:
`(Path(__file__).resolve().parents[1] / "sota-implementations/...")`

This makes the path resolution absolutely foolproof regardless of the PyTest execution context.

## Motivation and Context

This change is required to stabilize cross-dependency testing on `main` prior to the 0.14 release. 

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
