### PR TITLE
[BugFix] Add hoptorch skipif to RSSM scan rollout test

### DIFF
--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -810,6 +810,7 @@ class TestDreamerV3Components:
         version.parse(torch.__version__) < version.parse("2.6.0"),
         reason="the higher-order scan backend requires Torch >= 2.6.0",
     )
+    @pytest.mark.skipif(not _has_hoptorch, reason="hoptorch is not installed")
     def test_rssm_rollout_higher_order_scan_matches_loop(self, device, unroll):
         scan_rollout = self._make_rollout(device)
         loop_rollout = copy.deepcopy(scan_rollout)


### PR DESCRIPTION
## Description

Adds the `@pytest.mark.skipif(not _has_hoptorch, reason="hoptorch is not installed")` guard to `test_rssm_rollout_higher_order_scan_matches_loop`.

This test was the only scan-backend test in `test_dreamer_components.py` missing this decorator. All 8 other scan tests in the same file use the two-decorator pattern (torch version check + hoptorch availability check). Without the hoptorch guard, CI runners where hoptorch is not installed crash with `NotImplementedError` instead of gracefully skipping.

## Motivation and Context
Fixes the 3 failing tests on `main`