### PR TITLE
[BugFix] Fix GradScaler import compat for torch < 2.3

### DIFF
--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -27,7 +27,10 @@ from tensordict._tensorcollection import TensorCollection
 from tensordict.nn import TensorDictModule
 from tensordict.utils import expand_right
 from torch import nn, optim
-from torch.amp import GradScaler
+try:
+    from torch.amp import GradScaler
+except ImportError:  # torch < 2.3
+    from torch.cuda.amp import GradScaler
 from torchrl._utils import (
     _CKPT_BACKEND,
     implement_for,

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -21,16 +21,13 @@ from textwrap import indent
 from typing import Any, Literal
 
 import numpy as np
-import torch.nn
+import torch
+from packaging import version
 from tensordict import NestedKey, NonTensorData, pad, TensorDict, TensorDictBase
 from tensordict._tensorcollection import TensorCollection
 from tensordict.nn import TensorDictModule
 from tensordict.utils import expand_right
 from torch import nn, optim
-try:
-    from torch.amp import GradScaler
-except ImportError:  # torch < 2.3
-    from torch.cuda.amp import GradScaler
 from torchrl._utils import (
     _CKPT_BACKEND,
     implement_for,
@@ -55,6 +52,13 @@ from torchrl.envs.utils import ExplorationType, set_exploration_type
 from torchrl.objectives.common import LossModule
 from torchrl.objectives.utils import TargetNetUpdater
 from torchrl.record.loggers import Logger
+
+_TORCH_GRAD_SCALER_HAS_DEVICE = version.parse(torch.__version__).release >= (2, 3)
+
+if _TORCH_GRAD_SCALER_HAS_DEVICE:
+    from torch.amp import GradScaler
+else:
+    from torch.cuda.amp import GradScaler
 
 try:
     from tqdm import tqdm
@@ -85,6 +89,17 @@ LOGGER_METHODS = {
 # Format strings for different data types in progress bar display
 TYPE_DESCR = {float: "4.4f", int: ""}
 REWARD_KEY = ("next", "reward")
+
+
+@implement_for("torch", "2.3")
+def _make_grad_scaler(device_type: str, enabled: bool) -> GradScaler:
+    return GradScaler(device_type, enabled=enabled)
+
+
+@implement_for("torch", None, "2.3")
+def _make_grad_scaler(device_type: str, enabled: bool) -> GradScaler:  # noqa: F811
+    return GradScaler(enabled=enabled)
+
 
 # On Windows, a memory-mapped checkpoint keeps the file locked for as long as
 # the loaded tensors are alive, so the checkpoint could neither be deleted nor
@@ -380,7 +395,7 @@ class MixedPrecisionOptimizationStepper(OptimizationStepper):
 
         # GradScaler is only useful for fp16; bf16 doesn't need it.
         self._use_scaler = mixed_precision and (autocast_dtype == torch.float16)
-        self.scaler = GradScaler(self.device_type, enabled=self._use_scaler)
+        self.scaler = _make_grad_scaler(self.device_type, self._use_scaler)
 
         # Internal micro-batch counter (reset after every optimizer step).
         self._micro_step: int = 0


### PR DESCRIPTION
## Description

Fixes the `olddeps` CI failure caused by an unconditional `from torch.amp import GradScaler`.

`torch.amp.GradScaler` was introduced in PyTorch 2.3. On older PyTorch environments, `GradScaler` lives at `torch.cuda.amp.GradScaler`. This caused a hard `ImportError` at collection time, crashing all 3 test files that import `torchrl.trainers`:
- `test/test_configs.py`
- `test/test_helpers.py`
- `test/test_trainer.py`

Replaces the bare import with a standard try/except compat shim.