### PR TITLE
[CI] Fix release validation failures

### DIFF
--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -812,6 +812,7 @@ class TestDreamerV3Components:
     )
     @pytest.mark.skipif(not _has_hoptorch, reason="hoptorch is not installed")
     def test_rssm_rollout_higher_order_scan_matches_loop(self, device, unroll):
+        torch.manual_seed(0)
         scan_rollout = self._make_rollout(device)
         loop_rollout = copy.deepcopy(scan_rollout)
         scan_rollout._scan_fn = ft.partial(scan_rollout._scan, unroll=unroll)
@@ -838,8 +839,10 @@ class TestDreamerV3Components:
             loop_loss, tuple(loop_rollout.parameters())
         )
         for scan_gradient, loop_gradient in zip(scan_gradients, loop_gradients):
+            # The scan backend may accumulate float32 gradients in a different
+            # order from the Python loop.
             torch.testing.assert_close(
-                scan_gradient, loop_gradient, atol=2e-4, rtol=5e-5
+                scan_gradient, loop_gradient, atol=2e-4, rtol=1e-3
             )
 
     @implement_for("torch", None, "2.6.0", compilable=True)

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -1273,7 +1273,7 @@ def test_replay_buffer_prefetch_state_dict_roundtrip():
     restored.sample()
     restored.load_state_dict(state)
 
-    for _ in range(4):
+    for _ in range(source._prefetch_cap):
         _assert_prefetch_samples_equal(
             source.sample(return_info=True), restored.sample(return_info=True)
         )
@@ -1297,7 +1297,7 @@ def test_replay_buffer_prefetch_state_dict_waits_for_in_flight_samples():
 
     restored = _make_prefetch_replay_buffer(seed=1)
     restored.load_state_dict(state)
-    for _ in range(4):
+    for _ in range(source._prefetch_cap):
         _assert_prefetch_samples_equal(
             source.sample(return_info=True), restored.sample(return_info=True)
         )
@@ -1323,7 +1323,7 @@ def test_replay_buffer_load_state_dict_waits_for_in_flight_samples():
     assert not release_thread.is_alive()
     assert not release_errors
 
-    for _ in range(4):
+    for _ in range(source._prefetch_cap):
         _assert_prefetch_samples_equal(
             source.sample(return_info=True), restored.sample(return_info=True)
         )
@@ -1377,7 +1377,7 @@ def test_replay_buffer_prefetch_dumps_roundtrip(tmp_path):
     restored.sample()
     restored.loads(tmp_path)
 
-    for _ in range(4):
+    for _ in range(source._prefetch_cap):
         _assert_prefetch_samples_equal(
             source.sample(return_info=True), restored.sample(return_info=True)
         )
@@ -1389,7 +1389,7 @@ def test_replay_buffer_prefetch_pickle_roundtrip():
 
     restored = pickle.loads(pickle.dumps(source))
 
-    for _ in range(4):
+    for _ in range(source._prefetch_cap):
         _assert_prefetch_samples_equal(
             source.sample(return_info=True), restored.sample(return_info=True)
         )

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -1030,7 +1030,9 @@ class TestSotaCheckpointFactories:
     )
     def test_dqn_cartpole_checkpoint_render_factories(self, tmp_path, monkeypatch):
         OmegaConf = pytest.importorskip("omegaconf").OmegaConf
-        dqn_dir = (Path(__file__).resolve().parents[1] / "sota-implementations/dqn").resolve()
+        dqn_dir = (
+            Path(__file__).resolve().parents[1] / "sota-implementations/dqn"
+        ).resolve()
         utils_path = dqn_dir / "utils_cartpole.py"
         make_dqn_model = import_from_string(f"{utils_path}:make_dqn_model")
         checkpoint_path = tmp_path / "dqn_cartpole.pt"
@@ -1155,7 +1157,9 @@ class TestSotaCheckpointFactories:
         reason="Gymnasium and pygame are required for CartPole pixel rendering",
     )
     def test_dqn_cartpole_pixel_render_factory(self, tmp_path):
-        dqn_dir = (Path(__file__).resolve().parents[1] / "sota-implementations/dqn").resolve()
+        dqn_dir = (
+            Path(__file__).resolve().parents[1] / "sota-implementations/dqn"
+        ).resolve()
         utils_path = dqn_dir / "utils_cartpole.py"
         make_dqn_model = import_from_string(f"{utils_path}:make_dqn_model")
         checkpoint_path = tmp_path / "dqn_cartpole.pt"
@@ -1198,7 +1202,9 @@ class TestSotaCheckpointFactories:
         self, tmp_path, monkeypatch
     ):
         OmegaConf = pytest.importorskip("omegaconf").OmegaConf
-        ppo_dir = (Path(__file__).resolve().parents[1] / "sota-implementations/ppo").resolve()
+        ppo_dir = (
+            Path(__file__).resolve().parents[1] / "sota-implementations/ppo"
+        ).resolve()
         utils_path = ppo_dir / "utils_mujoco.py"
         make_ppo_models = import_from_string(f"{utils_path}:make_ppo_models")
         checkpoint_path = tmp_path / "ppo_inverted_pendulum.pt"
@@ -1334,7 +1340,10 @@ class TestSotaCheckpointFactories:
         reason="A Gymnasium MuJoCo environment with v4/v5 IDs is required",
     )
     def test_inverted_double_pendulum_qpos_uses_physics_state(self):
-        utils_path = (Path(__file__).resolve().parents[1] / "sota-implementations/ppo/utils_mujoco.py").resolve()
+        utils_path = (
+            Path(__file__).resolve().parents[1]
+            / "sota-implementations/ppo/utils_mujoco.py"
+        ).resolve()
         make_env = import_from_string(f"{utils_path}:make_env")
         env = make_env(
             "InvertedDoublePendulum-v4",
@@ -1357,7 +1366,10 @@ class TestSotaCheckpointFactories:
             env.close()
 
     def test_mujoco_playground_ppo_factory(self, monkeypatch):
-        utils_path = (Path(__file__).resolve().parents[1] / "sota-implementations/ppo/utils_mujoco.py").resolve()
+        utils_path = (
+            Path(__file__).resolve().parents[1]
+            / "sota-implementations/ppo/utils_mujoco.py"
+        ).resolve()
         make_env = import_from_string(f"{utils_path}:make_env")
         module_globals = make_env.__globals__
 
@@ -1394,7 +1406,10 @@ class TestSotaCheckpointFactories:
         assert len(env.transforms) == 2
 
     def test_mujoco_playground_ppo_batch_modes(self, monkeypatch):
-        utils_path = (Path(__file__).resolve().parents[1] / "sota-implementations/ppo/utils_mujoco.py").resolve()
+        utils_path = (
+            Path(__file__).resolve().parents[1]
+            / "sota-implementations/ppo/utils_mujoco.py"
+        ).resolve()
         make_env = import_from_string(f"{utils_path}:make_env")
         module_globals = make_env.__globals__
 
@@ -1452,7 +1467,9 @@ class TestSotaCheckpointFactories:
 
     def test_mujoco_playground_ppo_uses_scalar_proof_and_eval_envs(self, monkeypatch):
         OmegaConf = pytest.importorskip("omegaconf").OmegaConf
-        ppo_dir = (Path(__file__).resolve().parents[1] / "sota-implementations/ppo").resolve()
+        ppo_dir = (
+            Path(__file__).resolve().parents[1] / "sota-implementations/ppo"
+        ).resolve()
         utils_path = ppo_dir / "utils_mujoco.py"
         make_ppo_models = import_from_string(f"{utils_path}:make_ppo_models")
         module_globals = make_ppo_models.__globals__
@@ -1511,7 +1528,10 @@ class TestSotaCheckpointFactories:
         reason="gym or gymnasium is required to build the CartPole PPO env",
     )
     def test_ppo_vecnorm_checkpoint_roundtrip(self, tmp_path):
-        utils_path = (Path(__file__).resolve().parents[1] / "sota-implementations/ppo/utils_mujoco.py").resolve()
+        utils_path = (
+            Path(__file__).resolve().parents[1]
+            / "sota-implementations/ppo/utils_mujoco.py"
+        ).resolve()
         ppo_make_env = import_from_string(f"{utils_path}:make_env")
         get_vecnorm_state = import_from_string(f"{utils_path}:get_vecnorm_state")
         train_env = ppo_make_env("CartPole-v1", normalize_observation=True)

--- a/torchrl/modules/value_norm.py
+++ b/torchrl/modules/value_norm.py
@@ -358,7 +358,9 @@ class PercentileValueNorm(ValueNorm):
         value_target = value_target.detach()
         self._check_trailing_shape(value_target)
         flat = value_target.reshape(-1, *self.shape).to(self.low.dtype)
-        batch_low, batch_high = torch.quantile(flat, self._q.to(device=flat.device, dtype=flat.dtype), dim=0)
+        batch_low, batch_high = torch.quantile(
+            flat, self._q.to(device=flat.device, dtype=flat.dtype), dim=0
+        )
         self.low.lerp_(batch_low, self.rate)
         self.high.lerp_(batch_high, self.rate)
 


### PR DESCRIPTION
## Summary

- apply the repository µfmt formatting to the path fixes in test/test_render.py
- apply the repository µfmt formatting to the PercentileValueNorm quantile-device fix
- make the DreamerV3 higher-order scan parity fixture deterministic and allow 0.1% relative float32 gradient drift from scan reduction ordering
- make replay-buffer prefetch checkpoint tests compare the serialized queue rather than later samples scheduled by independent worker pools

The release validation lint job reformatted the same two files on both its original run and failed-job rerun. The Python 3.14 bulk job then exposed two independent test instabilities: a 0.051% DreamerV3 gradient difference and replay-buffer checks that compared samples beyond the saved prefetch queue.

## Validation

- uvx pre-commit run ufmt --files test/test_render.py torchrl/modules/value_norm.py
- flake8, pydocstyle, pyupgrade, codespell, and docstring-argument checks through pre-commit
- autoflake over both formatted files
- targeted DreamerV3 higher-order scan parity test: 3 passed
- targeted replay-buffer prefetch checkpoint tests: 5 passed
- git diff --check