### PR TITLE
[CI] Restore old-dependency compatibility

### DIFF
--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -64,6 +64,7 @@ from torchrl.testing.mocking_classes import ContinuousActionConvMockEnv
 
 _has_hydra = importlib.util.find_spec("hydra") is not None
 _has_omegaconf = importlib.util.find_spec("omegaconf") is not None
+_has_hoptorch = importlib.util.find_spec("hoptorch") is not None
 _has_gym = (
     importlib.util.find_spec("gymnasium") is not None
     or importlib.util.find_spec("gym") is not None
@@ -1122,6 +1123,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    @pytest.mark.skipif(not _has_hoptorch, reason="requires hoptorch")
     @pytest.mark.skipif(
         not (_has_hydra and _has_omegaconf and _has_gym),
         reason="requires hydra, omegaconf, and gym",

--- a/torchrl/envs/custom/mujoco/microduck.py
+++ b/torchrl/envs/custom/mujoco/microduck.py
@@ -186,8 +186,9 @@ def _low_cost_collision_scene(scene_path: Path) -> Iterator[Path]:
     of convex-hull edges, which makes the two roughly 10,000-edge soles
     prohibitively expensive to compile or step in a batch. Visual meshes stay
     untouched; only geoms in the ``collision`` or ``self_collision_only``
-    classes are replaced, and MuJoCo performs the box fitting so its mesh
-    centering and principal-axis transforms remain part of the geom pose.
+    classes are replaced. The boxes are fitted after MuJoCo has applied its
+    mesh centering and principal-axis transforms so the proxy pose matches the
+    rendered mesh across MuJoCo versions.
 
     Self-contained MJCF files without an ``<include>`` are yielded unchanged so
     small fixtures and custom MicroDuck-compatible files keep working.
@@ -205,16 +206,15 @@ def _low_cost_collision_scene(scene_path: Path) -> Iterator[Path]:
 
     robot_tree = ET.parse(robot_path)
     robot_root = robot_tree.getroot()
-    proxy_count = 0
+    proxy_geoms = []
     for geom in robot_root.iter("geom"):
         if geom.get("class") not in {"collision", "self_collision_only"}:
             continue
         if geom.get("mesh") is None:
             continue
-        geom.set("type", "box")
-        proxy_count += 1
+        proxy_geoms.append(geom)
 
-    if not proxy_count:
+    if not proxy_geoms:
         yield scene_path
         return
 
@@ -222,7 +222,6 @@ def _low_cost_collision_scene(scene_path: Path) -> Iterator[Path]:
     if compiler is None:
         compiler = ET.Element("compiler")
         robot_root.insert(0, compiler)
-    compiler.set("fitaabb", "true")
     for attribute in ("meshdir", "texturedir"):
         directory = compiler.get(attribute)
         if directory is not None and not Path(directory).is_absolute():
@@ -231,8 +230,56 @@ def _low_cost_collision_scene(scene_path: Path) -> Iterator[Path]:
     with TemporaryDirectory(prefix="torchrl-microduck-") as directory:
         patched_robot = Path(directory) / robot_path.name
         patched_scene = Path(directory) / scene_path.name
+        generated_names = []
+        for index, geom in enumerate(proxy_geoms):
+            if geom.get("name") is None:
+                geom.set("name", f"torchrl_collision_proxy_{index}")
+                generated_names.append(geom)
+
+        # Compile the mesh geoms once to obtain MuJoCo's canonicalized mesh
+        # vertices and body-local pose. Explicitly writing the fitted boxes
+        # avoids the incorrect unrotated center produced by ``fitaabb`` in
+        # MuJoCo 3.3 and earlier.
         robot_tree.write(patched_robot, encoding="unicode")
         scene_tree.write(patched_scene, encoding="unicode")
+        mujoco = importlib.import_module("mujoco")
+        model = mujoco.MjModel.from_xml_path(str(patched_scene))
+        for geom in proxy_geoms:
+            geom_id = mujoco.mj_name2id(
+                model, mujoco.mjtObj.mjOBJ_GEOM, geom.get("name")
+            )
+            mesh_id = model.geom_dataid[geom_id]
+            start = model.mesh_vertadr[mesh_id]
+            stop = start + model.mesh_vertnum[mesh_id]
+            vertices = model.mesh_vert[start:stop]
+            center = (vertices.max(axis=0) + vertices.min(axis=0)) / 2
+            half_size = (vertices.max(axis=0) - vertices.min(axis=0)) / 2
+            rotated_center = model.geom_pos[geom_id].copy()
+            mujoco.mju_rotVecQuat(rotated_center, center, model.geom_quat[geom_id])
+
+            geom.set("type", "box")
+            geom.set(
+                "size", " ".join(format(float(value), ".17g") for value in half_size)
+            )
+            geom.set(
+                "pos",
+                " ".join(
+                    format(float(value), ".17g")
+                    for value in model.geom_pos[geom_id] + rotated_center
+                ),
+            )
+            for attribute in ("axisangle", "euler", "xyaxes", "zaxis"):
+                geom.attrib.pop(attribute, None)
+            geom.set(
+                "quat",
+                " ".join(
+                    format(float(value), ".17g") for value in model.geom_quat[geom_id]
+                ),
+            )
+            geom.attrib.pop("mesh", None)
+        for geom in generated_names:
+            geom.attrib.pop("name")
+        robot_tree.write(patched_robot, encoding="unicode")
         yield patched_scene
 
 

--- a/torchrl/envs/custom/mujoco/microduck.py
+++ b/torchrl/envs/custom/mujoco/microduck.py
@@ -58,7 +58,7 @@ from typing import Any, ClassVar
 
 import torch
 from tensordict import NestedKey, tensorclass, TensorDict, TensorDictBase
-from torchrl._utils import logger as torchrl_logger
+from torchrl._utils import implement_for, logger as torchrl_logger
 from torchrl.data.tensor_specs import Binary, Bounded, Categorical, Composite, Unbounded
 from torchrl.envs.custom.mujoco._backends import BackendName
 from torchrl.envs.custom.mujoco.base import _MujocoMeta, MujocoEnv
@@ -177,6 +177,80 @@ def _body_forward_vector(quaternion: torch.Tensor) -> torch.Tensor:
     )
 
 
+@implement_for("mujoco")
+def _write_collision_proxy_scene(
+    proxy_geoms: list[ET.Element],
+    compiler: ET.Element,
+    robot_tree: ET.ElementTree,
+    scene_tree: ET.ElementTree,
+    patched_robot: Path,
+    patched_scene: Path,
+) -> None:
+    """Write box proxies using MuJoCo's native mesh fitting."""
+    for geom in proxy_geoms:
+        geom.set("type", "box")
+    compiler.set("fitaabb", "true")
+    robot_tree.write(patched_robot, encoding="unicode")
+    scene_tree.write(patched_scene, encoding="unicode")
+
+
+@_write_collision_proxy_scene.register(to_version="3.3.7")
+def _(
+    proxy_geoms: list[ET.Element],
+    compiler: ET.Element,
+    robot_tree: ET.ElementTree,
+    scene_tree: ET.ElementTree,
+    patched_robot: Path,
+    patched_scene: Path,
+) -> None:
+    """Write explicit box proxies when ``fitaabb`` does not preserve their pose."""
+    generated_names = []
+    for index, geom in enumerate(proxy_geoms):
+        if geom.get("name") is None:
+            geom.set("name", f"torchrl_collision_proxy_{index}")
+            generated_names.append(geom)
+
+    # Compile the mesh geoms once to obtain MuJoCo's canonicalized mesh
+    # vertices and body-local pose. Before MuJoCo 3.3.7, ``fitaabb`` does not
+    # produce the same fitted pose as the current AABB containment semantics.
+    robot_tree.write(patched_robot, encoding="unicode")
+    scene_tree.write(patched_scene, encoding="unicode")
+    mujoco = importlib.import_module("mujoco")
+    model = mujoco.MjModel.from_xml_path(str(patched_scene))
+    for geom in proxy_geoms:
+        geom_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, geom.get("name"))
+        mesh_id = model.geom_dataid[geom_id]
+        start = model.mesh_vertadr[mesh_id]
+        stop = start + model.mesh_vertnum[mesh_id]
+        vertices = model.mesh_vert[start:stop]
+        center = (vertices.max(axis=0) + vertices.min(axis=0)) / 2
+        half_size = (vertices.max(axis=0) - vertices.min(axis=0)) / 2
+        rotated_center = model.geom_pos[geom_id].copy()
+        mujoco.mju_rotVecQuat(rotated_center, center, model.geom_quat[geom_id])
+
+        geom.set("type", "box")
+        geom.set("size", " ".join(format(float(value), ".17g") for value in half_size))
+        geom.set(
+            "pos",
+            " ".join(
+                format(float(value), ".17g")
+                for value in model.geom_pos[geom_id] + rotated_center
+            ),
+        )
+        for attribute in ("axisangle", "euler", "xyaxes", "zaxis"):
+            geom.attrib.pop(attribute, None)
+        geom.set(
+            "quat",
+            " ".join(
+                format(float(value), ".17g") for value in model.geom_quat[geom_id]
+            ),
+        )
+        geom.attrib.pop("mesh", None)
+    for geom in generated_names:
+        geom.attrib.pop("name")
+    robot_tree.write(patched_robot, encoding="unicode")
+
+
 @contextmanager
 def _low_cost_collision_scene(scene_path: Path) -> Iterator[Path]:
     """Replace detailed collision meshes with tight box proxies at load time.
@@ -230,56 +304,14 @@ def _low_cost_collision_scene(scene_path: Path) -> Iterator[Path]:
     with TemporaryDirectory(prefix="torchrl-microduck-") as directory:
         patched_robot = Path(directory) / robot_path.name
         patched_scene = Path(directory) / scene_path.name
-        generated_names = []
-        for index, geom in enumerate(proxy_geoms):
-            if geom.get("name") is None:
-                geom.set("name", f"torchrl_collision_proxy_{index}")
-                generated_names.append(geom)
-
-        # Compile the mesh geoms once to obtain MuJoCo's canonicalized mesh
-        # vertices and body-local pose. Explicitly writing the fitted boxes
-        # avoids the incorrect unrotated center produced by ``fitaabb`` in
-        # MuJoCo 3.3 and earlier.
-        robot_tree.write(patched_robot, encoding="unicode")
-        scene_tree.write(patched_scene, encoding="unicode")
-        mujoco = importlib.import_module("mujoco")
-        model = mujoco.MjModel.from_xml_path(str(patched_scene))
-        for geom in proxy_geoms:
-            geom_id = mujoco.mj_name2id(
-                model, mujoco.mjtObj.mjOBJ_GEOM, geom.get("name")
-            )
-            mesh_id = model.geom_dataid[geom_id]
-            start = model.mesh_vertadr[mesh_id]
-            stop = start + model.mesh_vertnum[mesh_id]
-            vertices = model.mesh_vert[start:stop]
-            center = (vertices.max(axis=0) + vertices.min(axis=0)) / 2
-            half_size = (vertices.max(axis=0) - vertices.min(axis=0)) / 2
-            rotated_center = model.geom_pos[geom_id].copy()
-            mujoco.mju_rotVecQuat(rotated_center, center, model.geom_quat[geom_id])
-
-            geom.set("type", "box")
-            geom.set(
-                "size", " ".join(format(float(value), ".17g") for value in half_size)
-            )
-            geom.set(
-                "pos",
-                " ".join(
-                    format(float(value), ".17g")
-                    for value in model.geom_pos[geom_id] + rotated_center
-                ),
-            )
-            for attribute in ("axisangle", "euler", "xyaxes", "zaxis"):
-                geom.attrib.pop(attribute, None)
-            geom.set(
-                "quat",
-                " ".join(
-                    format(float(value), ".17g") for value in model.geom_quat[geom_id]
-                ),
-            )
-            geom.attrib.pop("mesh", None)
-        for geom in generated_names:
-            geom.attrib.pop("name")
-        robot_tree.write(patched_robot, encoding="unicode")
+        _write_collision_proxy_scene(
+            proxy_geoms,
+            compiler,
+            robot_tree,
+            scene_tree,
+            patched_robot,
+            patched_scene,
+        )
         yield patched_scene
 
 

--- a/torchrl/modules/distributions/utils.py
+++ b/torchrl/modules/distributions/utils.py
@@ -24,14 +24,33 @@ from torch.distributions.kl import _KL_REGISTRY
 from torchrl._utils import logger as torchrl_logger, VERBOSE
 
 try:
-    from torch.compiler import is_dynamo_compiling
+    from torch.compiler import assume_constant_result, is_dynamo_compiling
 except ImportError:
-    from torch._dynamo import is_compiling as is_dynamo_compiling
+    from torch._dynamo import (
+        assume_constant_result,
+        is_compiling as is_dynamo_compiling,
+    )
 
 _ANALYTIC_ENTROPY_CACHE: dict[type, bool] = {}
 _ANALYTIC_KL_CACHE: dict[tuple[type, type], bool] = {}
 _MC_ENTROPY_WARNED: set[type] = set()
 _MC_KL_WARNED: set[tuple[type, type]] = set()
+
+
+@assume_constant_result
+def _class_has_analytic_entropy(cls: type) -> bool:
+    cached = _ANALYTIC_ENTROPY_CACHE.get(cls)
+    if cached is not None:
+        return cached
+    entropy_fn = getattr(cls, "entropy", None)
+    result = entropy_fn is not None and entropy_fn is not d.Distribution.entropy
+    _ANALYTIC_ENTROPY_CACHE[cls] = result
+    return result
+
+
+@assume_constant_result
+def _class_has_callable(cls: type, name: str) -> bool:
+    return callable(getattr(cls, name, None))
 
 
 def sample_and_log_prob(
@@ -90,10 +109,11 @@ def sample_and_log_prob(
             log_prob = log_prob + component_log_prob
         return sample, log_prob
 
-    method_name = "rsample_and_log_prob" if reparameterize else "sample_and_log_prob"
-    joint_sample = getattr(distribution, method_name, None)
-    if joint_sample is not None:
-        return joint_sample(sample_shape)
+    if reparameterize:
+        if _class_has_callable(distribution.__class__, "rsample_and_log_prob"):
+            return distribution.rsample_and_log_prob(sample_shape)
+    elif _class_has_callable(distribution.__class__, "sample_and_log_prob"):
+        return distribution.sample_and_log_prob(sample_shape)
     sample_fn = distribution.rsample if reparameterize else distribution.sample
     sample = sample_fn(sample_shape)
     if isinstance(sample, torch.Tensor) or is_tensor_collection(sample):
@@ -152,14 +172,9 @@ def has_analytic_entropy(dist: d.Distribution) -> bool:
         return False
     if isinstance(dist, Independent):
         return has_analytic_entropy(dist.base_dist)
-    cls = type(dist)
-    cached = _ANALYTIC_ENTROPY_CACHE.get(cls)
-    if cached is not None:
-        return cached
-    entropy_fn = getattr(cls, "entropy", None)
-    result = entropy_fn is not None and entropy_fn is not d.Distribution.entropy
-    _ANALYTIC_ENTROPY_CACHE[cls] = result
-    return result
+    # Passing the class keeps this reflection independent of the generated
+    # distribution object and lets older Dynamo treat the result as constant.
+    return _class_has_analytic_entropy(dist.__class__)
 
 
 def has_analytic_kl(p: d.Distribution, q: d.Distribution) -> bool:

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -26,7 +26,7 @@ from tensordict import TensorDict, TensorDictBase, TensorDictParams
 from tensordict.nn import TensorDictModule, TensorDictModuleBase
 from tensordict.utils import NestedKey, unravel_key
 
-from torchrl._utils import _maybe_record_function_decorator
+from torchrl._utils import _maybe_record_function_decorator, implement_for
 from torchrl.envs.model_based.dreamer import DreamerEnv
 from torchrl.envs.utils import ExplorationType, set_exploration_type, step_mdp
 from torchrl.modules.distributions.utils import (
@@ -60,6 +60,19 @@ from torchrl.objectives.value.functional import (
 symexp = _symexp
 two_hot_decode = _two_hot_decode
 two_hot_encode = _two_hot_encode
+
+
+@implement_for("torch", None, "2.2")
+def _register_load_state_dict_pre_hook(module: torch.nn.Module, hook) -> None:
+    module._register_load_state_dict_pre_hook(hook, with_module=True)
+
+
+@implement_for("torch", "2.2")
+def _register_load_state_dict_pre_hook(  # noqa: F811
+    module: torch.nn.Module, hook
+) -> None:
+    module.register_load_state_dict_pre_hook(hook)
+
 
 # ---------------------------------------------------------------------------
 # KL balancing for categorical distributions (DreamerV3 §3)
@@ -721,7 +734,7 @@ class DreamerV3ActorLoss(LossModule):
             min_scale=return_normalization_min_scale,
             device=self._default_device,
         )
-        self.register_load_state_dict_pre_hook(self._migrate_legacy_retnorm_state)
+        _register_load_state_dict_pre_hook(self, self._migrate_legacy_retnorm_state)
         if gamma is not None:
             raise TypeError(_GAMMA_LMBDA_DEPREC_ERROR)
         if lmbda is not None:

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -775,8 +775,9 @@ class PPOLoss(LossModule):
                     entropy = torch.where(entropy.isfinite(), entropy, sampled_entropy)
                 else:
                     entropy = sampled_entropy
-        if is_composite and entropy.batch_size != adv_shape:
-            entropy.batch_size = adv_shape
+        if is_composite:
+            if is_tensor_collection(entropy) and entropy.batch_size != adv_shape:
+                entropy.batch_size = adv_shape
         return entropy.unsqueeze(-1)
 
     def _get_cur_log_prob(

--- a/torchrl/objectives/ppo.py
+++ b/torchrl/objectives/ppo.py
@@ -768,14 +768,14 @@ class PPOLoss(LossModule):
                 _, log_prob = sample_and_log_prob(
                     dist,
                     (self.samples_mc_entropy,),
-                    reparameterize=getattr(dist, "has_rsample", False),
+                    reparameterize=dist.has_rsample,
                 )
                 sampled_entropy = -log_prob.mean(0)
                 if analytic_entropy and compiling:
                     entropy = torch.where(entropy.isfinite(), entropy, sampled_entropy)
                 else:
                     entropy = sampled_entropy
-        if is_tensor_collection(entropy) and entropy.batch_size != adv_shape:
+        if is_composite and entropy.batch_size != adv_shape:
             entropy.batch_size = adv_shape
         return entropy.unsqueeze(-1)
 

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -1283,6 +1283,9 @@ class Trainer:
         elif _CKPT_BACKEND == "torch":
             for key, value in _torch_load_defaults().items():
                 kwargs.setdefault(key, value)
+            if isinstance(file, pathlib.Path):
+                # Older torch versions require a string path when mmap is set.
+                file = str(file)
             loaded_dict: OrderedDict = torch.load(file, **kwargs)
             self.load_state_dict(loaded_dict)
         elif _CKPT_BACKEND == "memmap":


### PR DESCRIPTION
The release branch old-dependency job consistently fails against supported older dependencies.

This restores compatibility by:
- using the pre-2.2 load-state hook registration API for DreamerV3;
- keeping distribution capability checks compatible with older Dynamo while preserving compiled PPO entropy fallback;
- passing string paths to older torch mmap checkpoint loading;
- skipping the hoptorch-only CUDA graph test when olddeps intentionally installs TorchRL without dependencies;
- using native MicroDuck collision-proxy fitting with MuJoCo 3.3.7 and later, with explicit fitting only where earlier MuJoCo behavior produces a different proxy pose.

Validation:
- targeted tests pass on current dependencies;
- DreamerV3, PPO compilation, and trainer checkpoint tests pass with torch 2.1.1;
- the MicroDuck proxy test passes with MuJoCo 3.2.7, 3.3.5, 3.3.7, and the current environment;
- test/test_distributions.py passes (985 tests);
- formatter, flake8, pydocstyle, autoflake, compile, and diff checks pass after the MicroDuck dispatch cleanup.