### PR TITLE
[CI] Fix Windows release tests

### DIFF
--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -8,6 +8,7 @@ import argparse
 import copy
 import functools as ft
 import importlib.util
+import sys
 from unittest import mock
 
 import pytest
@@ -43,6 +44,7 @@ from torchrl.testing import get_default_devices
 
 
 _has_hoptorch = importlib.util.find_spec("hoptorch") is not None
+_compile_backend = "eager" if sys.platform == "win32" else "inductor"
 
 
 @pytest.mark.parametrize("device", get_default_devices())
@@ -552,7 +554,7 @@ class TestDreamerV3Components:
             num_layers=2,
             recurrent_backend="scan",
         )
-        compiled = torch.compile(module, fullgraph=True)
+        compiled = torch.compile(module, backend=_compile_backend, fullgraph=True)
         value = torch.randn(2, 5, 6, requires_grad=True)
         hidden = torch.randn(2, 8, requires_grad=True)
         is_init = torch.tensor(
@@ -675,7 +677,7 @@ class TestDreamerV3Components:
         belief = torch.randn(3, 8)
         action = torch.randn(3, 2)
         uniform = torch.rand(3, 2)
-        compiled = torch.compile(prior, fullgraph=True)
+        compiled = torch.compile(prior, backend=_compile_backend, fullgraph=True)
 
         expected = prior(state, belief, action, _uniform=uniform)
         actual = compiled(state, belief, action, _uniform=uniform)
@@ -857,7 +859,7 @@ class TestDreamerV3Components:
     def _test_rssm_rollout_compile(self, scope, unroll):
         rollout = self._make_rollout(torch.device("cpu"))
         data = self._make_rollout_data(torch.device("cpu"))
-        rollout.compile_rollout(scope, unroll=unroll)
+        rollout.compile_rollout(scope, unroll=unroll, backend=_compile_backend)
 
         output = rollout(data)
         (

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -68,6 +68,7 @@ _has_gym = (
     importlib.util.find_spec("gymnasium") is not None
     or importlib.util.find_spec("gym") is not None
 )
+_compile_backend = "eager" if os.name == "nt" else "inductor"
 
 
 @pytest.mark.parametrize("device", get_default_devices())
@@ -396,7 +397,7 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         restored.load_state_dict(two_hot.state_dict())
         torch.testing.assert_close(restored(logits), expected)
 
-        compiled = torch.compile(restored, fullgraph=True)
+        compiled = torch.compile(restored, backend=_compile_backend, fullgraph=True)
         torch.testing.assert_close(compiled(logits), expected, rtol=1e-5, atol=1e-5)
 
     # ------------------------------------------------------------------ #
@@ -1707,7 +1708,9 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             loss_td["return_scale"], torch.tensor(10.0, device=device)
         )
 
-        compiled_scale = torch.compile(loss_module._return_scale, fullgraph=True)
+        compiled_scale = torch.compile(
+            loss_module._return_scale, backend=_compile_backend, fullgraph=True
+        )
         torch.testing.assert_close(
             compiled_scale(fake_data["lambda_target"]),
             torch.tensor(10.0, device=device),
@@ -1990,8 +1993,11 @@ def test_dreamer_v3_dmc_reproduction_modes(tmp_path):
         env=env,
         text=True,
     ).stdout.splitlines()
+    expected_benchmark = str(benchmark)
+    if os.name == "nt":
+        expected_benchmark = f"/{benchmark.drive[0].lower()}{benchmark.as_posix()[2:]}"
     assert fast == [
-        str(benchmark),
+        expected_benchmark,
         "--output-dir",
         "dmc_walker_runs",
         "optimization.compile_rssm=scan",

--- a/torchrl/_comm/distributed.py
+++ b/torchrl/_comm/distributed.py
@@ -20,9 +20,11 @@ receives and keeps each communicator single-threaded.
 """
 from __future__ import annotations
 
+import os
 import pickle
 import queue
 import socket
+import sys
 import threading
 import time
 from datetime import timedelta
@@ -71,6 +73,13 @@ _OP_TIMEOUT_S = 86_400.0
 # Poll period for peer-liveness / receiver-health checks while a client
 # waits for a reply (mirrors torchrl._comm.mailbox._PEER_CHECK_INTERVAL).
 _HEALTH_CHECK_INTERVAL_S = 0.1
+
+# Some Windows torch wheels are built without libuv. Respect the documented
+# environment override elsewhere and default to the legacy TCPStore backend on
+# Windows so direct TCPStore construction remains usable there.
+_TCP_STORE_USE_LIBUV = (
+    sys.platform != "win32" and os.environ.get("USE_LIBUV", "1") != "0"
+)
 
 
 def _send_sentinel_async(
@@ -317,7 +326,11 @@ class _DistributedClient:
             return
         host, port = self._store_info
         store = dist.TCPStore(
-            host, port, is_master=False, timeout=timedelta(seconds=self._timeout)
+            host,
+            port,
+            is_master=False,
+            timeout=timedelta(seconds=self._timeout),
+            use_libuv=_TCP_STORE_USE_LIBUV,
         )
         self._store = store
         # Reservation and process-group connection are separate. A domain
@@ -636,6 +649,7 @@ class TorchDistributedTransport(RequestReplyTransport):
                 is_master=True,
                 timeout=timedelta(seconds=timeout),
                 wait_for_workers=False,
+                use_libuv=_TCP_STORE_USE_LIBUV,
             )
             port = int(_store.port)
         elif port is None:
@@ -685,6 +699,7 @@ class TorchDistributedTransport(RequestReplyTransport):
                 port,
                 is_master=False,
                 timeout=timedelta(seconds=self._timeout),
+                use_libuv=_TCP_STORE_USE_LIBUV,
             )
         return self._store
 


### PR DESCRIPTION
The Windows release test job failed twice with the same nine failures.

This change:
- runs the Dreamer graph-capture assertions through the eager compiler backend on Windows runners that do not provide MSVC, while retaining Inductor elsewhere;
- compares the DMC reproduction script output using the path form emitted by Git Bash;
- makes direct TCPStore construction respect USE_LIBUV=0 and default to the legacy store backend on Windows wheels built without libuv.

Validation:
- all nine affected test cases pass locally;
- the distributed gloo transport integration passes with USE_LIBUV=0;
- pre-commit passes on all changed files.