### PR TITLE
[BugFix] Keep Dreamer return stats on the model device

### DIFF
--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -719,6 +719,7 @@ class DreamerV3ActorLoss(LossModule):
             quantiles=return_normalization_quantiles,
             rate=return_normalization_rate,
             min_scale=return_normalization_min_scale,
+            device=self._default_device,
         )
         self.register_load_state_dict_pre_hook(self._migrate_legacy_retnorm_state)
         if gamma is not None:


### PR DESCRIPTION
DreamerV3ActorLoss creates its percentile return normalizer after receiving the actor, value model, and model-based environment. The normalizer was created on the default CPU even when those modules were already on CUDA, causing every actor-loss path that updates return statistics to fail with a device mismatch.

Construct the normalizer on the loss module default device inferred from its registered parameters.

Validation:
- the 18 affected actor-loss and categorical-value cases pass locally;
- a meta-device construction check confirms the return-normalization buffers follow the model device;
- pre-commit passes on the changed file.

The existing parametrized actor-loss tests already cover the behavior on CUDA-enabled CI, so no duplicate test was added.