### PR TITLE
[BugFix] Close Procgen native environments

### DIFF
--- a/test/libs/test_misc.py
+++ b/test/libs/test_misc.py
@@ -498,11 +498,13 @@ class TestProcgen:
 
     def test_procgen_num_envs_batch_size(self):
         env = ProcgenEnv("coinrun", num_envs=3)
+        native_env = env._env.env
         try:
             td = env.reset()
             assert td["observation"].shape[0] == 3
         finally:
             env.close()
+        assert native_env.closed
 
     def test_procgen_seeding_is_deterministic(self):
         # Procgen must be seeded at construction time via the seed parameter

--- a/torchrl/envs/libs/procgen.py
+++ b/torchrl/envs/libs/procgen.py
@@ -192,6 +192,15 @@ class ProcgenWrapper(_EnvWrapper):
         except Exception:
             warnings.warn("ProcgenWrapper: seeding failed (best-effort).")
 
+    def close(self, *, raise_if_closed: bool = True) -> None:
+        # procgen.ProcgenEnv returns a gym3 ToBaselinesVecEnv whose close method
+        # is a no-op. Close the nested CEnv explicitly so its worker threads and
+        # native resources are released.
+        nested_env = getattr(self._env, "env", None)
+        if nested_env is not None:
+            nested_env.close()
+        super().close(raise_if_closed=raise_if_closed)
+
     def _reset(self, tensordict=None, **kwargs) -> TensorDict:
         obs = self._env.reset()
         if isinstance(obs, (tuple, list)):


### PR DESCRIPTION
## Summary

- close the nested gym3 CEnv used by Procgen instead of stopping at the no-op Baselines compatibility wrapper
- release native Procgen worker threads and resources between environments
- assert the native environment is closed in the Procgen integration tests

## Validation

- `python -m compileall -q torchrl/envs/libs/procgen.py test/libs/test_misc.py`
- `autoflake --check-diff torchrl/envs/libs/procgen.py test/libs/test_misc.py`
- `git diff --check`
- the Procgen integration test is skipped locally because Procgen is unavailable on macOS; the dedicated Linux Procgen job provides the integration signal

Fixes the repeated two-hour hang in https://github.com/pytorch/rl/actions/runs/33986456375/job/101384435559.