### PR TITLE
[CI] Fix DreamerV3 smoke path on Windows

### DIFF
--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -2015,7 +2015,7 @@ def test_dreamer_v3_dmc_reproduction_modes(tmp_path):
         env=env,
         text=True,
     ).stdout.splitlines()
-    assert smoke[:3] == [str(benchmark), "--output-dir", "dmc_walker_smoke"]
+    assert smoke[:3] == [expected_benchmark, "--output-dir", "dmc_walker_smoke"]
     assert "replay_buffer.buffer_size=400" in smoke
     assert "optimization.compile_rssm=null" in smoke
     assert "optimization.updates_per_batch=1" in smoke


### PR DESCRIPTION
The Windows unit-test workflow runs the DreamerV3 reproduction script through Git Bash, which converts the benchmark path to POSIX form. The fast-mode assertion accounted for this conversion, but the smoke-mode assertion still compared against the native Windows path.

Reuse the same platform-adjusted expected path for both invocations.

Validation:
- `python -m pytest test/objectives/test_dreamer_v3.py::test_dreamer_v3_dmc_reproduction_modes -q`
- pinned ufmt check
- flake8