### PR TITLE
[BugFix] Stabilize cross-format checkpoint recovery

### DIFF
--- a/test/test_checkpoint.py
+++ b/test/test_checkpoint.py
@@ -9,6 +9,8 @@ import json
 import os
 import random
 import zipfile
+from datetime import datetime, timezone
+from unittest.mock import Mock
 
 import numpy as np
 import pytest
@@ -665,6 +667,13 @@ def test_checkpoint_rotation_recovers_interrupted_cross_format_replacement(
     monkeypatch.setattr(rotation, "_remove_atomically", remove_atomically)
 
     new_path = rotation._checkpoint_path(4, new_format)
+    os.utime(old_path, ns=(1_000_000_000, 1_000_000_000))
+    os.utime(new_path, ns=(2_000_000_000, 2_000_000_000))
+    monkeypatch.setattr(
+        rotation,
+        "_read_created_at",
+        Mock(return_value=datetime(2026, 1, 1, tzinfo=timezone.utc)),
+    )
     assert rotation.checkpoints() == (new_path,)
     assert rotation.latest() == new_path
     value = {}

--- a/torchrl/checkpoint/_checkpoint.py
+++ b/torchrl/checkpoint/_checkpoint.py
@@ -1343,6 +1343,7 @@ class _RotatedCheckpoint:
     step: int
     metric: float | None
     created_at: datetime
+    modified_at_ns: int
 
 
 class CheckpointRotation:
@@ -1508,6 +1509,7 @@ class CheckpointRotation:
                 continue
             try:
                 manifest = Checkpoint.manifest(path)
+                modified_at_ns = path.stat().st_mtime_ns
             except (CheckpointError, OSError, TypeError, ValueError):
                 continue
             records.append(
@@ -1516,10 +1518,16 @@ class CheckpointRotation:
                     step=int(step_text),
                     metric=self._read_metric(manifest),
                     created_at=self._read_created_at(manifest, path),
+                    modified_at_ns=modified_at_ns,
                 )
             )
         records.sort(
-            key=lambda record: (record.step, record.created_at, record.path.name)
+            key=lambda record: (
+                record.step,
+                record.created_at,
+                record.modified_at_ns,
+                record.path.name,
+            )
         )
         return records
 


### PR DESCRIPTION
Fixes cross-format checkpoint recovery when two manifests have identical creation timestamps, as observed on Windows. Rotation now uses filesystem modification nanoseconds before filename ordering, so interrupted replacements keep the newly written checkpoint regardless of container format.

The existing interrupted-replacement test now forces equal creation times and distinct write order.

Validation:
- test/test_checkpoint.py: 60 passed, 1 skipped
- pinned ufmt check
- pinned flake8 check

Observed in: https://github.com/pytorch/rl/actions/runs/34016957895/job/101452018472