### PR TITLE
[BugFix] Use legacy TCPStore on older torch

### DIFF
--- a/torchrl/_comm/distributed.py
+++ b/torchrl/_comm/distributed.py
@@ -35,6 +35,7 @@ import torch.distributed as dist
 from tensordict.base import _is_leaf_nontensor, TensorDictBase
 from tensordict.utils import NestedKey
 
+from torchrl import implement_for
 from torchrl._comm.mailbox import MailboxPeerClosedError, MailboxTransportError
 from torchrl._comm.request_reply import (
     Message,
@@ -74,12 +75,23 @@ _OP_TIMEOUT_S = 86_400.0
 # waits for a reply (mirrors torchrl._comm.mailbox._PEER_CHECK_INTERVAL).
 _HEALTH_CHECK_INTERVAL_S = 0.1
 
-# Some Windows torch wheels are built without libuv. Respect the documented
-# environment override elsewhere and default to the legacy TCPStore backend on
-# Windows so direct TCPStore construction remains usable there.
-_TCP_STORE_USE_LIBUV = (
-    sys.platform != "win32" and os.environ.get("USE_LIBUV", "1") != "0"
-)
+
+@implement_for("torch", "2.4")
+def _tcp_store_use_libuv() -> bool:
+    # Some Windows torch wheels are built without libuv. Respect the documented
+    # environment override elsewhere and default to the legacy TCPStore backend
+    # on Windows so direct TCPStore construction remains usable there.
+    return sys.platform != "win32" and os.environ.get("USE_LIBUV", "1") != "0"
+
+
+@implement_for("torch", None, "2.4")
+def _tcp_store_use_libuv() -> bool:  # noqa: F811
+    # Libuv became the default TCPStore backend in torch 2.4 and older wheels
+    # may be built without it.
+    return False
+
+
+_TCP_STORE_USE_LIBUV = _tcp_store_use_libuv()
 
 
 def _send_sentinel_async(


### PR DESCRIPTION
Torch 2.1 accepts the TCPStore use_libuv argument but its CUDA wheels can be built without the libuv implementation. Select the legacy backend for torch versions before 2.4, where libuv was not yet the default, while preserving the platform and USE_LIBUV handling for current torch.

The existing Ray replay-buffer gloo and NCCL integration tests cover this path in the oldest-dependency suite.

Validation:
- pinned ufmt check
- pinned flake8 check
- local targeted test collected successfully and skipped because Ray is unavailable

Observed in the repeated release-branch run: https://github.com/pytorch/rl/actions/runs/34016957959/job/101460635737