### PR TITLE
[BugFix] Expose replay buffer transport in Hydra config

### DIFF
--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -182,7 +182,6 @@ _CONFIG_PARITY_KNOWN_GAPS = frozenset(
         "RandomCropTensorDictConfig",
         "RemoveEmptySpecsConfig",
         "RenameTransformConfig",
-        "ReplayBufferConfig",
         "Reward2GoTransformConfig",
         "RewardSumConfig",
         "SMACv2EnvConfig",
@@ -613,6 +612,7 @@ class TestDataConfigs:
     @pytest.mark.skipif(not _has_hydra, reason="Hydra is not installed")
     def test_replay_buffer_config(self):
         """Test ReplayBufferConfig."""
+        from hydra.errors import InstantiationException
         from hydra.utils import instantiate
         from torchrl.trainers.algorithms.configs.data import (
             ListStorageConfig,
@@ -644,7 +644,24 @@ class TestDataConfigs:
         assert cfg_optional.writer is None
         assert cfg_optional.transform is None
         assert cfg_optional.batch_size is None
+        assert cfg_optional.transport == "auto"
+        assert cfg_optional.transport_options is None
         assert isinstance(instantiate(cfg_optional), ReplayBuffer)
+
+        # Test that transport fields are forwarded to ReplayBuffer.__init__.
+        cfg_transport = ReplayBufferConfig(transport="distributed")
+        with pytest.raises(
+            InstantiationException,
+            match="A direct ReplayBuffer only supports transport='auto' or 'direct'",
+        ):
+            instantiate(cfg_transport)
+
+        cfg_transport_options = ReplayBufferConfig(transport_options={"timeout": 1})
+        with pytest.raises(
+            InstantiationException,
+            match="transport_options are only valid for a remote ReplayBuffer",
+        ):
+            instantiate(cfg_transport_options)
 
     @pytest.mark.skipif(not _has_hydra, reason="Hydra is not installed")
     def test_tensordict_replay_buffer_config_optional_fields(self):

--- a/torchrl/trainers/algorithms/configs/data.py
+++ b/torchrl/trainers/algorithms/configs/data.py
@@ -15,10 +15,12 @@ from torchrl.trainers.algorithms.configs.common import ConfigBase
 
 if TYPE_CHECKING:
     _ReplayServiceBackend = Literal["direct", "ray"]
+    _ReplayTransport = Literal["auto", "direct", "ray", "distributed"]
 else:
-    # OmegaConf structured configs resolve this alias at runtime and do not
+    # OmegaConf structured configs resolve these aliases at runtime and do not
     # support Literal on all TorchRL-supported versions.
     _ReplayServiceBackend = str
+    _ReplayTransport = str
 
 
 @dataclass
@@ -440,3 +442,5 @@ class ReplayBufferConfig(ReplayBufferBaseConfig):
     delayed_init: bool | None = None
     service_backend: _ReplayServiceBackend = "direct"
     service_backend_options: dict[str, Any] = field(default_factory=dict)
+    transport: _ReplayTransport = "auto"
+    transport_options: dict[str, Any] | None = None


### PR DESCRIPTION
## Description

- Expose `transport` and `transport_options` on `ReplayBufferConfig` with the same defaults as `ReplayBuffer.__init__`.
- Preserve `Literal` typing for static analysis while using OmegaConf-compatible runtime aliases.
- Remove `ReplayBufferConfig` from the known config/class parity gaps.
- Extend the existing Hydra test to verify the defaults and prove that both fields reach the replay-buffer constructor.

## Motivation and Context

`ReplayBuffer.__init__` accepts transport selection and transport options, but its structured Hydra config omitted both fields. Hydra users therefore could not configure those constructor options through `ReplayBufferConfig`.

This addresses the replay-buffer portion of #4228.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q 'test/test_configs.py::TestConfigClassParity::test_wrapped_class_kwargs_have_config_fields[ReplayBufferConfig]' test/test_configs.py::TestDataConfigs::test_replay_buffer_config -rx` (2 passed)
- `pre-commit run --files torchrl/trainers/algorithms/configs/data.py test/test_configs.py` (all applicable hooks passed; `check-docstring-args` was skipped because its bare `python` command is unavailable in the Windows environment)
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.

AI assistance disclosure: AI-assisted development tools were used during investigation and implementation. The reported tests were run against the final diff.
