### PR TITLE
[BugFix] Drop flaky B2/K16 tile from DreamerV3 block-GRU Triton

### DIFF
--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -9,6 +9,7 @@ import copy
 import functools as ft
 import importlib.util
 import sys
+from contextlib import contextmanager
 from unittest import mock
 
 import pytest
@@ -45,6 +46,29 @@ from torchrl.testing import get_default_devices
 
 _has_hoptorch = importlib.util.find_spec("hoptorch") is not None
 _compile_backend = "eager" if sys.platform == "win32" else "inductor"
+
+
+@contextmanager
+def _ieee_float32_matmul():
+    """Force IEEE fp32 matmul so the PyTorch reference matches Triton.
+
+    ``DreamerV3BlockGRU``'s reference path uses ``F.linear`` (TF32 on Ampere+).
+    The Triton kernels request ``input_precision="ieee"``. Comparing the two
+    at atol=3e-4 is borderline when cuBLAS may pick a TF32 algorithm
+    (#3865 ``[SiLU-4-1-2-3-dtype4-48]``).
+    """
+    previous_precision = torch.get_float32_matmul_precision()
+    previous_allow_tf32 = torch.backends.cuda.matmul.allow_tf32
+    previous_cudnn_tf32 = torch.backends.cudnn.allow_tf32
+    torch.set_float32_matmul_precision("highest")
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
+    try:
+        yield
+    finally:
+        torch.set_float32_matmul_precision(previous_precision)
+        torch.backends.cuda.matmul.allow_tf32 = previous_allow_tf32
+        torch.backends.cudnn.allow_tf32 = previous_cudnn_tf32
 
 
 @pytest.mark.parametrize("device", get_default_devices())
@@ -983,19 +1007,22 @@ def test_public_block_gru_triton_gradient_parity(
             {name: parameter.grad for name, parameter in module.named_parameters()},
         )
 
-    expected = run(reference)
-    tolerance = (
-        {"atol": 4e-2, "rtol": 6e-2}
-        if dtype is torch.bfloat16
-        else {"atol": 3e-4, "rtol": 3e-4}
-    )
-    for _ in range(3):
-        actual = run(triton_module)
-        for expected_value, actual_value in zip(expected[:4], actual[:4]):
-            torch.testing.assert_close(actual_value, expected_value, **tolerance)
-        assert actual[4].keys() == expected[4].keys()
-        for name in expected[4]:
-            torch.testing.assert_close(actual[4][name], expected[4][name], **tolerance)
+    with _ieee_float32_matmul():
+        expected = run(reference)
+        tolerance = (
+            {"atol": 4e-2, "rtol": 6e-2}
+            if dtype is torch.bfloat16
+            else {"atol": 3e-4, "rtol": 3e-4}
+        )
+        for _ in range(3):
+            actual = run(triton_module)
+            for expected_value, actual_value in zip(expected[:4], actual[:4]):
+                torch.testing.assert_close(actual_value, expected_value, **tolerance)
+            assert actual[4].keys() == expected[4].keys()
+            for name in expected[4]:
+                torch.testing.assert_close(
+                    actual[4][name], expected[4][name], **tolerance
+                )
 
 
 @pytest.mark.gpu

--- a/torchrl/modules/models/_dreamer_v3_block_gru_triton.py
+++ b/torchrl/modules/models/_dreamer_v3_block_gru_triton.py
@@ -200,13 +200,16 @@ if _has_triton:
         triton.Config({"BLOCK_B": 8, "BLOCK_K": 32}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_B": 8, "BLOCK_K": 64}, num_warps=8, num_stages=1),
     ]
-    # The B2/K16 backward kernel can intermittently produce incorrect gradients.
-    # The same configuration is safe for the forward kernel.
-    _BACKWARD_CONFIGS = [
+    # The B2/K16 tile can intermittently produce incorrect values. It was first
+    # seen on the backward kernel; the B=2 float32 gradient-parity case
+    # (hidden=32, 4 blocks, proj=48) still selected it on the forward path
+    # (#3865). Keep it out of both autotune sets.
+    _SAFE_CONFIGS = [
         config
         for config in _CONFIGS
         if (config.kwargs["BLOCK_B"], config.kwargs["BLOCK_K"]) != (2, 16)
     ]
+    _BACKWARD_CONFIGS = _SAFE_CONFIGS
 
     def _prune_configs(configs, named_args, **kwargs):
         h_pad = kwargs.get("H_PAD") or named_args["H_PAD"]
@@ -241,7 +244,7 @@ if _has_triton:
         return (value > 0.0).to(tl.float32)
 
     @triton.autotune(
-        configs=_CONFIGS,
+        configs=_SAFE_CONFIGS,
         key=[
             "T",
             "H",


### PR DESCRIPTION
## Description

The flaky-test tracker (#3865) reports

`test_public_block_gru_triton_gradient_parity[SiLU-4-1-2-3-dtype4-48]`

at about 11% (8/72). That shape is batch=2, float32, 4 blocks, projection 48. After padding, only `BLOCK_K=16` tiles survive, so forward autotune chose between `(1, 16)` and `(2, 16)`.

The kernel already documented that the B2/K16 tile can intermittently produce incorrect **backward** values and removed it from the backward autotune set. The same tile was still in the forward set. This PR removes it from both.

The parity test also pins IEEE fp32 matmul (`torch.set_float32_matmul_precision("highest")` and `allow_tf32=False`). The PyTorch reference uses `F.linear` (TF32 on Ampere+); the Triton kernels request `input_precision="ieee"`. Comparing those at atol=3e-4 is borderline when cuBLAS picks a TF32 algorithm.

This does not close #3865. That issue is the daily tracker (33 tests). This is only the block-GRU case.

### Code example

CUDA/Triton reproduction command for the reported batch=2, float32, four-block case. The test compares outputs, hidden states, input gradients, and parameter gradients under IEEE fp32 settings.

```bash
python -m pytest test/modules/test_dreamer_components.py -m gpu \
  -k 'test_public_block_gru_triton_gradient_parity and SiLU-4-1-2-3-dtype4-48' -v
```

## Motivation and Context

#3865 (block-GRU Triton gradient-parity case only)

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.

Local machine has no CUDA, so the GPU test was not run here. CI GPU jobs need to cover it.