### PR TITLE
[BugFix] Cache AsyncEnvPool batch sizes during setup

### DIFF
--- a/test/envs/test_special.py
+++ b/test/envs/test_special.py
@@ -872,6 +872,9 @@ class TestAsyncEnvPool:
         env = self.make_env(makers=make_envs, backend=backend)
         assert env.batch_size == (4,)
         try:
+            if backend == "multiprocessing":
+                assert env._env_batch_sizes == [torch.Size([])] * 4
+            assert env.env_batch_sizes == [torch.Size([])] * 4
             r = env.reset()
             assert r.shape == env.shape
             s = env.rand_step(r)

--- a/test/envs/test_special.py
+++ b/test/envs/test_special.py
@@ -9,6 +9,7 @@ import pickle
 import threading
 import warnings
 from functools import partial
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -873,8 +874,12 @@ class TestAsyncEnvPool:
         assert env.batch_size == (4,)
         try:
             if backend == "multiprocessing":
-                assert env._env_batch_sizes == [torch.Size([])] * 4
-            assert env.env_batch_sizes == [torch.Size([])] * 4
+                with patch.object(
+                    type(env.input_queue[0]), "put", side_effect=AssertionError
+                ):
+                    assert env.env_batch_sizes == [torch.Size([])] * 4
+            else:
+                assert env.env_batch_sizes == [torch.Size([])] * 4
             r = env.reset()
             assert r.shape == env.shape
             s = env.rand_step(r)

--- a/torchrl/envs/async_envs.py
+++ b/torchrl/envs/async_envs.py
@@ -705,7 +705,8 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
         for i in range(num_threads):
             self._child_specs.append(self.output_queue[i].get())
         # Batch sizes are already available from the worker specs. Caching them
-        # here avoids a later queue round trip that may block behind env work.
+        # here avoids a later round trip over the input queues used for steps,
+        # which may block behind in-flight env work.
         self._env_batch_sizes = [torch.Size(spec.shape) for spec in self._child_specs]
         specs = torch.stack(list(self._child_specs))
         output_spec = specs["output_spec"]
@@ -740,13 +741,7 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
 
     @property
     def env_batch_sizes(self) -> list[torch.Size]:
-        batch_sizes = getattr(self, "_env_batch_sizes", [])
-        if not batch_sizes:
-            for _env_idx in range(self.num_envs):
-                self.input_queue[_env_idx].put(("batch_size", None))
-                batch_sizes.append(self.output_queue[_env_idx].get())
-            self._env_batch_sizes = batch_sizes
-        return batch_sizes
+        return self._env_batch_sizes
 
     def _prepare_worker_data(
         self,
@@ -1078,8 +1073,6 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
             elif msg == "init_shm":
                 shared_slots = data
                 output_queue.put(True)
-            elif msg == "batch_size":
-                output_queue.put(env.batch_size)
             elif msg == "reset":
                 if shared_slots is not None:
                     data = shared_slots[0].select(*data, strict=True)

--- a/torchrl/envs/async_envs.py
+++ b/torchrl/envs/async_envs.py
@@ -704,6 +704,9 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
         self._child_specs = []
         for i in range(num_threads):
             self._child_specs.append(self.output_queue[i].get())
+        # Batch sizes are already available from the worker specs. Caching them
+        # here avoids a later queue round trip that may block behind env work.
+        self._env_batch_sizes = [torch.Size(spec.shape) for spec in self._child_specs]
         specs = torch.stack(list(self._child_specs))
         output_spec = specs["output_spec"]
         input_spec = specs["input_spec"]


### PR DESCRIPTION
## Summary

- derive and cache each worker environment batch size from specs already collected during multiprocessing pool setup
- remove the obsolete lazy worker queue lookup and its unused worker command
- verify that reading the public `env_batch_sizes` property performs no worker queue writes

## Test plan

- `python -m pytest test/envs/test_special.py::TestAsyncEnvPool -q` (27 passed)
- `black --check torchrl/envs/async_envs.py test/envs/test_special.py`
- `usort check torchrl/envs/async_envs.py test/envs/test_special.py`
- `flake8 torchrl/envs/async_envs.py test/envs/test_special.py`