### PR TITLE
[BugFix] Route WandbLogger login through base URL

### DIFF
--- a/test/test_loggers.py
+++ b/test/test_loggers.py
@@ -10,14 +10,16 @@ import multiprocessing as mp
 import os
 import os.path
 import pathlib
+import sys
 import tempfile
 import threading
 from time import sleep
 
 import pytest
 import torch
-from tensordict import MemoryMappedTensor
 
+import torchrl.record.loggers.wandb as wandb_logger_module
+from tensordict import MemoryMappedTensor
 from torchrl._comm import MailboxPeerClosedError
 from torchrl.checkpoint import Checkpoint
 from torchrl.data import LazyTensorStorage, ReplayBuffer
@@ -364,6 +366,34 @@ def wandb_tmp_logger(tmp_path):
     logger.experiment.finish()
     wandb.finish()
     del logger
+
+
+def test_wandb_base_url_used_for_login_and_init(monkeypatch):
+    calls = []
+
+    class Settings:
+        def __init__(self, *, base_url):
+            self.base_url = base_url
+
+    def login(*, host, key=None):
+        del key
+        calls.append(("login", host))
+
+    def init(**kwargs):
+        calls.append(("init", kwargs["settings"].base_url))
+        return argparse.Namespace(config={})
+
+    monkeypatch.setitem(
+        sys.modules,
+        "wandb",
+        argparse.Namespace(Settings=Settings, init=init, login=login),
+    )
+    monkeypatch.setattr(wandb_logger_module, "_has_wandb", True)
+    base_url = "https://wandb.example.com"
+
+    WandbLogger(exp_name="test", base_url=base_url, log_env_packages=False)
+
+    assert calls == [("login", base_url), ("init", base_url)]
 
 
 @pytest.mark.skipif(not _has_wandb, reason="Wandb not installed")

--- a/torchrl/record/loggers/wandb.py
+++ b/torchrl/record/loggers/wandb.py
@@ -72,6 +72,10 @@ class WandbLogger(Logger):
         project (str, optional): The name of the project where you're sending
             the new run. If the project is not specified, the run is put in
             an ``"Uncategorized"`` project.
+        base_url (str, optional): The W&B server URL used for authentication and
+            data synchronization. Construct the logger before other code imports
+            or calls W&B, because the W&B client reads ``WANDB_BASE_URL`` when it
+            is initialized.
         log_env_packages (bool, optional): if ``True``, logs the Python runtime,
             installed package versions, and editable source locations under
             ``wandb.config["env"]``. Defaults to ``True``.
@@ -94,6 +98,7 @@ class WandbLogger(Logger):
         save_dir: str | None = None,
         id: str | None = None,
         project: str | None = None,
+        base_url: str | None = None,
         *,
         video_fps: int = 32,
         log_env_packages: bool = True,
@@ -113,6 +118,7 @@ class WandbLogger(Logger):
         self.save_dir = save_dir
         self.id = id
         self.project = project
+        self.base_url = base_url
         self.video_fps = video_fps
         self.log_env_packages = log_env_packages
         self._step_registry: dict[str, int] = {}
@@ -169,6 +175,17 @@ class WandbLogger(Logger):
 
         if self.offline:
             os.environ["WANDB_MODE"] = "dryrun"
+        if self.base_url is not None:
+            settings = self._wandb_kwargs.get("settings")
+            if settings is None:
+                settings = wandb.Settings(base_url=self.base_url)
+            elif isinstance(settings, Mapping):
+                settings = wandb.Settings(**{**settings, "base_url": self.base_url})
+            else:
+                settings.base_url = self.base_url
+            self._wandb_kwargs["settings"] = settings
+            if not self.offline:
+                wandb.login(host=self.base_url, key=getattr(settings, "api_key", None))
 
         return wandb.init(**self._wandb_kwargs)
 

--- a/torchrl/trainers/algorithms/configs/logging.py
+++ b/torchrl/trainers/algorithms/configs/logging.py
@@ -45,6 +45,7 @@ class WandbLoggerConfig(LoggerConfig):
     save_dir: str | None = None
     id: str | None = None
     project: str | None = None
+    base_url: str | None = None
     video_fps: int = 32
     log_env_packages: bool = True
     log_dir: str | None = None
@@ -64,6 +65,7 @@ def _make_wandb_logger(
     save_dir: str | None = None,
     id: str | None = None,
     project: str | None = None,
+    base_url: str | None = None,
     video_fps: int = 32,
     log_env_packages: bool = True,
     log_dir: str | None = None,
@@ -78,6 +80,7 @@ def _make_wandb_logger(
         save_dir=save_dir,
         id=id,
         project=project,
+        base_url=base_url,
         video_fps=video_fps,
         log_env_packages=log_env_packages,
         log_dir=log_dir,


### PR DESCRIPTION
## Summary

- add a dedicated base URL argument to WandbLogger
- use the same URL for W&B login and run settings
- expose the argument through WandbLoggerConfig

## Test plan

- focused base URL routing regression test
- existing non-video W&B logger tests
- W&B logger Hydra config and config/class parity tests
- offline W&B settings smoke test