### PR TITLE
[BugFix] Bound AsyncEnvPool queue shared mappings

### DIFF
--- a/benchmarks/test_envs_benchmark.py
+++ b/benchmarks/test_envs_benchmark.py
@@ -186,6 +186,8 @@ def test_cat_frames_functional(benchmark, padding, N):
 # - test_async_env_pool_dispatch: free envs, so the round time is
 #   ASYNC_POOL_DISPATCH_TRANSITIONS x the consumer-side dispatch cost
 #   (recv -> action write -> send) per transition. The most sensitive tracker.
+# - test_async_env_pool_per_env_dispatch: the same free-env workload through
+#   the per-env receive path used by AsyncBatchedCollector.
 # - test_async_env_pool_fast_step_slow_reset: many envs with millisecond steps
 #   and long occasional resets (the game-engine regime). Sized so that the
 #   consumer is the bottleneck today: the round time falls toward the
@@ -256,6 +258,29 @@ def _async_pool_harvest(pool, num_transitions, max_get):
         harvested += num_ready
 
 
+def _make_async_pool_per_env(num_envs, exchange):
+    pool = AsyncEnvPool(
+        [partial(DelayedCountingEnv, max_steps=10_000_000)] * num_envs,
+        backend="multiprocessing",
+        exchange=exchange,
+    )
+    for env_index in range(num_envs):
+        pool.async_reset_send(env_index=env_index)
+    for env_index in range(num_envs):
+        tensordict = pool.async_reset_recv(env_index=env_index)
+        tensordict["action"] = torch.ones(1)
+        pool.async_step_and_maybe_reset_send(tensordict, env_index=env_index)
+    return pool
+
+
+def _async_pool_harvest_per_env(pool, num_transitions):
+    for index in range(num_transitions):
+        env_index = index % pool.num_envs
+        _, tensordict = pool.async_step_and_maybe_reset_recv(env_index=env_index)
+        tensordict["action"] = torch.ones(1)
+        pool.async_step_and_maybe_reset_send(tensordict, env_index=env_index)
+
+
 @pytest.mark.parametrize("exchange", ["queue", "shm"])
 def test_async_env_pool_dispatch(benchmark, exchange):
     """Consumer dispatch cost of AsyncEnvPool with free envs."""
@@ -277,6 +302,25 @@ def test_async_env_pool_dispatch(benchmark, exchange):
                     ASYNC_POOL_DISPATCH_TRANSITIONS,
                     ASYNC_POOL_DISPATCH_ENVS,
                 ),
+                rounds=5,
+                warmup_rounds=1,
+                iterations=1,
+            )
+        finally:
+            pool._maybe_shutdown()
+
+
+@pytest.mark.parametrize("exchange", ["queue", "shm"])
+def test_async_env_pool_per_env_dispatch(benchmark, exchange):
+    """Per-env dispatch cost on the path used by AsyncBatchedCollector."""
+    with set_capture_non_tensor_stack(False):
+        pool = _make_async_pool_per_env(ASYNC_POOL_DISPATCH_ENVS, exchange)
+        try:
+            benchmark.extra_info["num_envs"] = ASYNC_POOL_DISPATCH_ENVS
+            benchmark.extra_info["transitions"] = ASYNC_POOL_DISPATCH_TRANSITIONS
+            benchmark.pedantic(
+                _async_pool_harvest_per_env,
+                args=(pool, ASYNC_POOL_DISPATCH_TRANSITIONS),
                 rounds=5,
                 warmup_rounds=1,
                 iterations=1,

--- a/test/envs/test_special.py
+++ b/test/envs/test_special.py
@@ -109,6 +109,29 @@ class _ManyKeysCountingEnv(CountingEnv):
         return self._fill_extra_keys(super()._step(tensordict))
 
 
+class _PixelCountingEnv(CountingEnv):
+    """A counting env with the pixel payload from the mmap regression."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.observation_spec["pixels"] = Unbounded(
+            (*self.batch_size, 3, 64, 64), dtype=torch.uint8
+        )
+
+    def _fill_pixels(self, tensordict):
+        tensordict.set(
+            "pixels",
+            torch.zeros(*self.batch_size, 3, 64, 64, dtype=torch.uint8),
+        )
+        return tensordict
+
+    def _reset(self, tensordict, **kwargs):
+        return self._fill_pixels(super()._reset(tensordict, **kwargs))
+
+    def _step(self, tensordict):
+        return self._fill_pixels(super()._step(tensordict))
+
+
 def test_callable_metadata_env_closes_when_extraction_fails(monkeypatch):
     env = ContinuousActionVecMockEnv()
     closed = False
@@ -1110,6 +1133,42 @@ class TestAsyncEnvPool:
             for proc in env.threads:
                 if proc.is_alive():
                     proc.terminate()
+
+    @set_capture_non_tensor_stack(False)
+    def test_queue_per_env_results_release_shared_mappings(self):
+        """Retained pixel transitions must not retain queue transport mappings."""
+        env = AsyncEnvPool(
+            [partial(_PixelCountingEnv, max_steps=1000)],
+            backend="multiprocessing",
+            exchange="queue",
+            stack="lazy",
+        )
+        retained = []
+        try:
+            env.async_reset_send(env_index=0)
+            next_tensordict = env.async_reset_recv(env_index=0)
+            for _ in range(128):
+                next_tensordict.set("action", torch.ones(1))
+                env.async_step_and_maybe_reset_send(next_tensordict, env_index=0)
+                transition, next_tensordict = env.async_step_and_maybe_reset_recv(
+                    env_index=0
+                )
+                retained.append(transition)
+
+            batch = env.reset()
+            assert len(retained) == 128
+            assert not any(
+                value.is_shared()
+                for tensordict in (
+                    *retained,
+                    next_tensordict,
+                    *batch.unbind(0),
+                )
+                for _, value in tensordict.items(True, True)
+                if isinstance(value, torch.Tensor)
+            )
+        finally:
+            env._maybe_shutdown()
 
     @set_capture_non_tensor_stack(False)
     def test_exchange_auto_resolves_to_shm(self, make_envs):

--- a/torchrl/envs/async_envs.py
+++ b/torchrl/envs/async_envs.py
@@ -76,13 +76,16 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
         stack (Literal["dense", "maybe_dense", "lazy"], optional):
             The method to use for stacking environment outputs. Defaults to `"dense"`.
         exchange (Literal["queue", "shm", "auto"], optional): Data exchange
-            used by the multiprocessing backend. ``"shm"`` stores fixed-shape
-            tensor data in shared slots and sends only readiness descriptors
-            through queues; it requires identical, fixed-shape, CPU, tensor-only
-            schemas across workers. ``"auto"`` selects ``"shm"`` when the env
-            schema supports it and falls back to ``"queue"`` otherwise (the
-            resolution is reported by :attr:`resolved_exchange` and logged on
-            fallback). Defaults to ``"queue"``.
+            used by the multiprocessing backend. ``"queue"`` supports dynamic
+            data and copies received tensors out of multiprocessing shared
+            memory so retaining results does not retain one mapping per tensor.
+            ``"shm"`` stores fixed-shape tensor data in shared slots and sends
+            only readiness descriptors through queues; it requires identical,
+            fixed-shape, CPU, tensor-only schemas across workers. ``"auto"``
+            selects ``"shm"`` when the env schema supports it and falls back to
+            ``"queue"`` otherwise (the resolution is reported by
+            :attr:`resolved_exchange` and logged on fallback). Defaults to
+            ``"queue"``.
 
             .. warning::
                 The default will change from ``"queue"`` to ``"auto"`` in
@@ -777,6 +780,16 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
             track_action=track_action,
         )
 
+    def _stack_queue_results(self, results) -> TensorDictBase:
+        result = self._stack_func(results)
+        if isinstance(result, LazyStackedTensorDict):
+            # A lazy stack retains the individual TensorDicts reconstructed by
+            # multiprocessing.Queue, and therefore one shared-memory mapping
+            # per tensor. Clone its constituents into process-private storage;
+            # dense stacks already own their newly allocated tensor storage.
+            result = result.clone()
+        return result
+
     def async_step_send(
         self, tensordict: TensorDictBase, env_index: int | list[int] | None = None
     ) -> None:
@@ -807,7 +820,7 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
     ) -> TensorDictBase:
         if env_index is not None:
             if self._slot_exchange is None:
-                return self._per_env_step_queues[env_index].get()
+                return self._per_env_step_queues[env_index].get().clone()
             descriptor = self._slot_exchange.receive_one(
                 self._per_env_step_queues[env_index], track_action=True
             )
@@ -833,7 +846,7 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
             return result
         r, idx = self._sort_results(r)
         self._busy.difference_update(idx)
-        return self._stack_func(r)
+        return self._stack_queue_results(r)
 
     def _async_private_step_send(
         self, tensordict: TensorDictBase, env_index: int | list[int] | None = None
@@ -883,7 +896,8 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
     ) -> tuple[TensorDictBase, TensorDictBase]:
         if env_index is not None:
             if self._slot_exchange is None:
-                return self._per_env_step_reset_queues[env_index].get()
+                result, next_result = self._per_env_step_reset_queues[env_index].get()
+                return result.clone(), next_result.clone()
             descriptor = self._slot_exchange.receive_one(
                 self._per_env_step_reset_queues[env_index], track_action=True
             )
@@ -910,7 +924,7 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
         r, r_ = zip(*r)
         r, r_, idx = self._sort_results(r, r_)
         self._busy.difference_update(idx)
-        return self._stack_func(r), self._stack_func(r_)
+        return self._stack_queue_results(r), self._stack_queue_results(r_)
 
     def async_reset_send(
         self,
@@ -943,7 +957,7 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
     ) -> TensorDictBase:
         if env_index is not None:
             if self._slot_exchange is None:
-                return self._per_env_reset_queues[env_index].get()
+                return self._per_env_reset_queues[env_index].get().clone()
             descriptor = self._slot_exchange.receive_one(
                 self._per_env_reset_queues[env_index], track_action=False
             )
@@ -969,7 +983,7 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
             return result
         r, idx = self._sort_results(r)
         self._busy.difference_update(idx)
-        return self._stack_func(r)
+        return self._stack_queue_results(r)
 
     def _async_private_reset_send(
         self,


### PR DESCRIPTION
## Summary

- copy per-environment queue results out of multiprocessing shared memory before returning them
- copy lazy-stacked queue results while avoiding an extra copy for dense stacks that already own their storage
- add a retained pixel-transition regression and a per-environment dispatch benchmark for queue and shared-slot exchange

## Motivation

Multiprocessing queues reconstruct tensor storages as shared-memory mappings. The per-environment receive path used by AsyncBatchedCollector returned those tensors directly, so retaining a large lazy batch retained one mapping per tensor per transition and could exhaust the process mapping limit. Queue exchange now preserves result ownership without retaining transport mappings; the explicit shared-slot exchange keeps its existing zero-copy behavior.

## Testing

- `python -m pytest test/envs/test_special.py::TestAsyncEnvPool -q` (28 passed)
- `python -m pytest test/test_inference_server.py::TestAsyncBatchedCollector -q` (16 passed)
- queue and shared-slot variants of `test_async_env_pool_per_env_dispatch` (passed)
- Black, flake8, pydocstyle, pyupgrade, codespell, autoflake, and repository structural checks on the changed files (passed)
