### PR TITLE
[Feature] Add compile-safe pause to AsyncBatchedCollector

### DIFF
--- a/docs/source/reference/collectors_single.rst
+++ b/docs/source/reference/collectors_single.rst
@@ -120,6 +120,24 @@ and a **policy** -- all internal wiring is handled automatically:
 
     collector.shutdown()
 
+Compile modules and run their first warm-up calls before iterating the
+collector whenever possible. Compiler initialization can create process-wide
+worker resources, and overlapping a first compilation with the collector's
+coordinator and inference threads can stall either workload. If lazy
+compilation after collection has started is unavoidable, pause the collector
+around that call:
+
+.. code-block:: python
+
+    for data in collector:
+        with collector.pause():
+            compiled_learner(data)
+        break
+
+The pause context finishes in-flight environment and policy requests, parks
+the coordinator threads, and leaves the inference server idle. Collection
+resumes automatically when the context exits.
+
 **Key advantages over direct collection through** :class:`Collector`:
 
 - The inference server automatically **batches policy forward passes** from

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -2317,6 +2317,37 @@ class TestAsyncBatchedCollector:
         collector.shutdown()
         assert collected >= 50
 
+    def test_pause_for_torch_compile(self):
+        """Compilation can run while a started collector is quiescent."""
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * 4,
+            policy=_make_counting_policy(),
+            frames_per_batch=10,
+            total_frames=-1,
+            env_backend="threading",
+        )
+        iterator = iter(collector)
+        next(iterator)
+
+        def unrelated_module(value):
+            return value.sin().cos()
+
+        try:
+            with collector.pause():
+                paused_requests = collector.server_stats()["requests"]
+                compiled_module = torch.compile(unrelated_module, backend="eager")
+                value = torch.randn(8)
+                torch.testing.assert_close(
+                    compiled_module(value), unrelated_module(value)
+                )
+                time.sleep(0.05)
+                assert collector.server_stats()["requests"] == paused_requests
+
+            next(iterator)
+            assert collector.server_stats()["requests"] > paused_requests
+        finally:
+            collector.shutdown()
+
     def test_num_envs(self):
         """The collector knows the number of environments."""
         policy = _make_counting_policy()

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import contextlib
 import queue
 import threading
 import time
@@ -33,6 +34,7 @@ _ENV_IDX_KEY = "env_index"
 
 _POLICY_BACKENDS = ("threading", "multiprocessing", "ray", "monarch")
 _ENV_BACKENDS = ("threading", "multiprocessing")
+_PauseRequest = tuple[threading.Barrier, threading.Event]
 
 
 def _make_transport(
@@ -71,6 +73,19 @@ def _make_transport(
     )
 
 
+def _wait_while_paused(pause_request: list[_PauseRequest | None]) -> None:
+    """Park one coordinator and report when it reaches the pause boundary."""
+    request = pause_request[0]
+    if request is None:
+        return
+    barrier, resume_event = request
+    try:
+        barrier.wait()
+    except threading.BrokenBarrierError:
+        return
+    resume_event.wait()
+
+
 def _env_loop(
     pool: AsyncEnvPool,
     env_id: int,
@@ -78,6 +93,7 @@ def _env_loop(
     client: Callable | None,
     result_queue: queue.Queue,
     shutdown_event: threading.Event,
+    pause_request: list[_PauseRequest | None],
     env_device: torch.device | None,
     storing_device: torch.device | None,
 ):
@@ -96,20 +112,21 @@ def _env_loop(
     try:
         pool.async_reset_send(env_index=env_id)
         obs = pool.async_reset_recv(env_index=env_id)
-        action_td = client(obs)
 
         while not shutdown_event.is_set():
+            _wait_while_paused(pause_request)
+            if shutdown_event.is_set():
+                break
+
+            action_td = client(obs)
             if env_device is not None:
                 action_td = action_td.to(env_device)
             pool.async_step_and_maybe_reset_send(action_td, env_index=env_id)
-            cur_td, next_obs = pool.async_step_and_maybe_reset_recv(env_index=env_id)
+            cur_td, obs = pool.async_step_and_maybe_reset_recv(env_index=env_id)
             cur_td.set(_ENV_IDX_KEY, env_id)
             if storing_device is not None:
                 cur_td = cur_td.to(storing_device)
             result_queue.put(cur_td)
-            if shutdown_event.is_set():
-                break
-            action_td = client(next_obs)
     except Exception as exc:
         if not shutdown_event.is_set():
             result_queue.put(exc)
@@ -411,6 +428,8 @@ class AsyncBatchedCollector(BaseCollector):
         self._env_pool: AsyncEnvPool | None = None
         self._workers: list[threading.Thread] = []
         self._clients: list[Callable] | None = None
+        self._pause_request: list[_PauseRequest | None] = [None]
+        self._pause_lock = threading.Lock()
 
         # Per-env trajectory accumulators (for yield_completed_trajectories)
         self._yield_queues: list[deque] = [deque() for _ in range(self._num_envs)]
@@ -469,6 +488,7 @@ class AsyncBatchedCollector(BaseCollector):
                     "client": self._clients[i],
                     "result_queue": self._result_queue,
                     "shutdown_event": self._shutdown_event,
+                    "pause_request": self._pause_request,
                     "env_device": self._env_device,
                     "storing_device": self._storing_device,
                 },
@@ -477,6 +497,70 @@ class AsyncBatchedCollector(BaseCollector):
             )
             self._workers.append(t)
             t.start()
+
+    @contextlib.contextmanager
+    def pause(self, timeout: float | None = 30.0) -> Iterator[None]:
+        """Pause environment coordination and policy inference.
+
+        In-flight policy and environment requests finish before the context is
+        entered. The coordinator threads then remain parked until the context
+        exits, leaving the inference server idle. This provides a quiescent
+        boundary for operations such as a lazy :func:`torch.compile` call.
+
+        Compile and warm up modules before starting collection whenever
+        possible. Use this context when compilation after collection has
+        started is unavoidable.
+
+        Args:
+            timeout (float or None): maximum seconds to wait for the
+                coordinator threads to pause. ``None`` waits indefinitely.
+                Defaults to ``30.0``.
+
+        Raises:
+            RuntimeError: if another pause is active or a coordinator exits.
+            TimeoutError: if the coordinator threads do not park within
+                ``timeout`` seconds.
+        """
+        if not self._pause_lock.acquire(blocking=False):
+            raise RuntimeError("AsyncBatchedCollector is already paused.")
+
+        workers = tuple(self._workers)
+        request = None
+        try:
+            if not workers:
+                yield None
+                return
+            if not all(worker.is_alive() for worker in workers):
+                raise RuntimeError(
+                    "AsyncBatchedCollector cannot pause because a coordinator "
+                    "thread has exited."
+                )
+
+            request = (threading.Barrier(len(workers) + 1), threading.Event())
+            self._pause_request[0] = request
+            try:
+                request[0].wait(timeout=timeout)
+            except threading.BrokenBarrierError:
+                if not all(worker.is_alive() for worker in workers):
+                    raise RuntimeError(
+                        "AsyncBatchedCollector cannot pause because a "
+                        "coordinator thread exited while pausing."
+                    ) from None
+                raise TimeoutError(
+                    "Timed out while waiting for AsyncBatchedCollector "
+                    "coordinator threads to pause."
+                ) from None
+
+            yield None
+        finally:
+            try:
+                if request is not None:
+                    if self._pause_request[0] is request:
+                        self._pause_request[0] = None
+                    request[0].abort()
+                    request[1].set()
+            finally:
+                self._pause_lock.release()
 
     @property
     def env(self) -> AsyncEnvPool:
@@ -661,6 +745,11 @@ class AsyncBatchedCollector(BaseCollector):
         """Shut down the collector, inference server, threads and env pool."""
         if self._shutdown_event is not None:
             self._shutdown_event.set()
+        request = self._pause_request[0]
+        self._pause_request[0] = None
+        if request is not None:
+            request[0].abort()
+            request[1].set()
         _timeout = timeout or 5.0
         for w in self._workers:
             w.join(timeout=_timeout)


### PR DESCRIPTION
## Description

- Add an `AsyncBatchedCollector.pause()` context manager that establishes a quiescent boundary with a per-pause coordinator barrier.
- Finish in-flight policy and environment work before entering the context, then resume every coordinator on normal or exceptional exit.
- Document compile-before-collect as the preferred pattern and `collector.pause()` as the fallback for unavoidable lazy compilation.
- Add a threading-backend regression that compiles an unrelated function while paused, verifies inference stays idle, and verifies collection resumes.

## Motivation and Context

Closes #4262.

An initial `torch.compile` can initialize compiler worker resources after the collector has already created many coordinator and inference threads. On affected runtimes this can stall compilation and collection together.

The investigation did not find a lock cycle in TorchRL: the inference server's model lock only guards its own policy forward and weight updates, so an unrelated learner compile cannot acquire it. On the current nightly, the compile-state check also remained false in a concurrent non-tracing thread. The observed wait is instead consistent with the main thread waiting for compiler-worker results while the active collector threads add process-level initialization and interpreter contention. This is runtime and backend dependent, so pre-compiling remains the strongest recommendation; the new pause context gives users a supported quiescent fallback.

- [x] I have raised an issue to propose this change (#4262)

## Types of changes

- [x] New feature (non-breaking change which adds core functionality)
- [x] Documentation (update in the documentation)

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly.
- [x] I have updated the documentation accordingly.

## Test plan

- `pytest test/test_inference_server.py -q` (115 passed, 18 skipped)
- ufmt, flake8, pydocstyle, docstring-argument, Sphinx-section, and diff checks
