### PR TITLE
[Performance] Batch AsyncBatchedCollector shared-memory coordination

### DIFF
--- a/benchmarks/bench_collectors.py
+++ b/benchmarks/bench_collectors.py
@@ -8,9 +8,14 @@ CUDA hosts, ``--mujoco-gl egl``.
 Examples:
     python benchmarks/bench_collectors.py --total-frames 2000
     python benchmarks/bench_collectors.py --num-envs 1,2,4,8 --policy-delay-ms 20
+    python benchmarks/bench_collectors.py --num-envs 64 \
+        --backends async-env-mp --env-exchange shm \
+        --env-step-latency-ms 50 --policy-hidden-features 9216 \
+        --policy-hidden-layers 2 --policy-device cuda:0
     MUJOCO_GL=egl python benchmarks/bench_collectors.py \
         --env gym-mujoco --from-pixels --mujoco-gl egl --policy-device cuda:0
 """
+
 from __future__ import annotations
 
 import argparse
@@ -219,6 +224,8 @@ class PolicyFactory:
     action_dim: int = ACTION_DIM
     delay_s: float = 0.0
     from_pixels: bool = True
+    hidden_features: int = 256
+    hidden_layers: int = 1
 
     def __call__(self) -> TensorDictModule:
         if not self.from_pixels:
@@ -244,7 +251,7 @@ class PolicyFactory:
             in_features=cnn_out.shape[-1],
             activation_class=nn.ReLU,
             out_features=self.action_dim,
-            num_cells=[256],
+            num_cells=[self.hidden_features] * self.hidden_layers,
         )
         return TensorDictModule(
             LatencyHead(nn.Sequential(cnn, mlp), delay_s=self.delay_s),
@@ -475,6 +482,24 @@ def main() -> None:
     parser.add_argument("--warmup-batches", type=int, default=1)
     parser.add_argument("--env-step-latency-ms", type=float, default=1.0)
     parser.add_argument("--policy-delay-ms", type=float, default=0.0)
+    parser.add_argument(
+        "--policy-hidden-features",
+        type=int,
+        default=256,
+        help="Width of each hidden policy layer.",
+    )
+    parser.add_argument(
+        "--policy-hidden-layers",
+        type=int,
+        default=1,
+        help="Number of hidden policy layers.",
+    )
+    parser.add_argument(
+        "--env-exchange",
+        default="queue",
+        choices=["queue", "shm", "auto"],
+        help="AsyncEnvPool exchange used by multiprocessing env backends.",
+    )
     parser.add_argument("--policy-device", default="auto")
     parser.add_argument("--output-device", default="cpu")
     parser.add_argument("--jsonl", default="bench_collectors_results.jsonl")
@@ -505,6 +530,8 @@ def main() -> None:
         action_dim=action_dim,
         delay_s=args.policy_delay_ms / 1000.0,
         from_pixels=env_factory.from_pixels,
+        hidden_features=args.policy_hidden_features,
+        hidden_layers=args.policy_hidden_layers,
     )
 
     results: list[BenchmarkResult] = []
@@ -614,8 +641,8 @@ def main() -> None:
                     ) = _resolve_batching_rule(rule, num_envs)
                     results.append(
                         bench(
-                            name="AsyncBatched mp env",
-                            backend=backend,
+                            name=f"AsyncBatched mp env ({args.env_exchange})",
+                            backend=f"{backend}-{args.env_exchange}",
                             batch_rule=label,
                             factory=lambda num_envs=num_envs, max_batch_size=max_batch_size, min_batch_size=min_batch_size, timeout=timeout: AsyncBatchedCollector(
                                 create_env_fn=[env_factory] * num_envs,
@@ -623,6 +650,7 @@ def main() -> None:
                                 frames_per_batch=args.frames_per_batch,
                                 total_frames=-1,
                                 env_backend="multiprocessing",
+                                env_exchange=args.env_exchange,
                                 server_config=InferenceServerConfig(
                                     service_backend="thread",
                                     max_batch_size=max_batch_size,
@@ -655,8 +683,10 @@ def main() -> None:
                     ) = _resolve_batching_rule(rule, num_envs)
                     results.append(
                         bench(
-                            name="AsyncBatched process server",
-                            backend=backend,
+                            name=(
+                                "AsyncBatched process server " f"({args.env_exchange})"
+                            ),
+                            backend=f"{backend}-{args.env_exchange}",
                             batch_rule=label,
                             factory=lambda num_envs=num_envs, max_batch_size=max_batch_size, min_batch_size=min_batch_size, timeout=timeout: AsyncBatchedCollector(
                                 create_env_fn=[env_factory] * num_envs,
@@ -664,6 +694,7 @@ def main() -> None:
                                 frames_per_batch=args.frames_per_batch,
                                 total_frames=-1,
                                 env_backend="multiprocessing",
+                                env_exchange=args.env_exchange,
                                 server_config=InferenceServerConfig(
                                     service_backend="process",
                                     max_batch_size=max_batch_size,

--- a/docs/source/reference/collectors_single.rst
+++ b/docs/source/reference/collectors_single.rst
@@ -128,6 +128,11 @@ and a **policy** -- all internal wiring is handled automatically:
   idle time.
 - Supports ``yield_completed_trajectories=True`` for episode-level yields.
 
+For many fixed-schema CPU environments, set ``env_backend="multiprocessing"``
+and ``env_exchange="shm"``. The collector then drains ready shared-memory slots
+in batches from one coordinator thread, while keeping faster environments
+independent of slower ones.
+
 Scaling ``Collector`` across local processes
 --------------------------------------------
 

--- a/docs/source/reference/collectors_single.rst
+++ b/docs/source/reference/collectors_single.rst
@@ -149,7 +149,8 @@ resumes automatically when the context exits.
 For many fixed-schema CPU environments, set ``env_backend="multiprocessing"``
 and ``env_exchange="shm"``. The collector then drains ready shared-memory slots
 in batches from one coordinator thread, while keeping faster environments
-independent of slower ones.
+independent of slower ones. This path is intended for environments whose step
+latency dominates its millisecond-scale coordinator polling interval.
 
 Scaling ``Collector`` across local processes
 --------------------------------------------

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -2226,6 +2226,42 @@ class TestAsyncBatchedCollector:
         assert total_collected == total_frames
         assert stats["requests"] > 0
 
+    def test_threaded_collection_batches_reset_and_step_observations(self):
+        policy_called = threading.Event()
+
+        class DelayedResetEnv(CountingEnv):
+            def _reset(self, tensordict, **kwargs):
+                assert policy_called.wait(5)
+                return super()._reset(tensordict, **kwargs)
+
+        class PolicyWithFeatures(_BatchCountingPolicy):
+            def forward(self, td):
+                policy_called.set()
+                return super().forward(td).set("features", td["observation"] * 2)
+
+        collector = AsyncBatchedCollector(
+            create_env_fn=[CountingEnv, DelayedResetEnv],
+            policy=PolicyWithFeatures(),
+            frames_per_batch=8,
+            total_frames=24,
+            max_batch_size=2,
+            min_batch_size=2,
+            server_timeout=0.1,
+            env_backend="threading",
+            device_config=InferenceDeviceConfig(policy_device="cpu"),
+        )
+        try:
+            batches = list(collector)
+            assert sum(batch.numel() for batch in batches) == 24
+            assert sum(batch["next", "done"].sum() for batch in batches) > 0
+            for batch in batches:
+                torch.testing.assert_close(batch["features"], batch["observation"] * 2)
+                torch.testing.assert_close(
+                    batch["next", "observation"], batch["observation"] + 1
+                )
+        finally:
+            collector.shutdown()
+
     def test_policy_factory(self):
         """policy_factory is called to create the policy."""
         num_envs = 2

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -18,7 +18,7 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
-from tensordict import lazy_stack, LazyStackedTensorDict, TensorDict
+from tensordict import lazy_stack, TensorDict
 from tensordict.base import TensorDictBase
 from tensordict.nn import TensorDictModule
 from tensordict.nn.probabilistic import (
@@ -53,10 +53,7 @@ from torchrl.modules.inference_server import (
 )
 from torchrl.modules.inference_server._config import _resolve_device_config
 from torchrl.modules.inference_server._monarch import MonarchTransport
-from torchrl.modules.inference_server._server import (
-    _default_collate,
-    _RayInferenceServerActor,
-)
+from torchrl.modules.inference_server._server import _RayInferenceServerActor
 
 _has_ray = importlib.util.find_spec("ray") is not None
 _has_monarch = importlib.util.find_spec("monarch") is not None
@@ -440,21 +437,6 @@ class TestInferenceServerCore:
 
         assert len(calls) >= 1
         assert sum(calls) == 4  # all 4 items processed
-
-    def test_default_collate_prefers_dense_batches(self):
-        """Homogeneous requests use one dense batch while mixed keys stay lazy."""
-        homogeneous = _default_collate(
-            [
-                TensorDict({"observation": torch.randn(4)}),
-                TensorDict({"observation": torch.randn(4)}),
-            ]
-        )
-        heterogeneous = _default_collate(
-            [TensorDict({"a": torch.randn(4)}), TensorDict({"b": torch.randn(4)})]
-        )
-
-        assert not isinstance(homogeneous, LazyStackedTensorDict)
-        assert isinstance(heterogeneous, LazyStackedTensorDict)
 
     def test_collate_error_resolves_futures_and_server_survives(self):
         """A collate failure must reject the affected futures, not kill the loop."""
@@ -2307,7 +2289,11 @@ class TestAsyncBatchedCollector:
         collector.shutdown()
         assert count >= 30
 
-    def test_shutdown_idempotent(self):
+    @pytest.mark.parametrize(
+        ("env_backend", "env_exchange"),
+        [("threading", "queue"), ("multiprocessing", "shm")],
+    )
+    def test_shutdown_idempotent(self, env_backend, env_exchange):
         """Calling shutdown twice should not raise."""
         policy = _make_counting_policy()
         collector = AsyncBatchedCollector(
@@ -2315,7 +2301,8 @@ class TestAsyncBatchedCollector:
             policy=policy,
             frames_per_batch=10,
             total_frames=10,
-            env_backend="threading",
+            env_backend=env_backend,
+            env_exchange=env_exchange,
         )
         # Consume one batch to start
         for _batch in collector:
@@ -2411,9 +2398,16 @@ class TestAsyncBatchedCollector:
         collector.shutdown()
         assert called["count"] >= 1
 
-    @pytest.mark.parametrize("env_backend", ["threading", "multiprocessing"])
-    def test_env_backend_smoke(self, env_backend):
-        """Thread and multiprocessing env backends collect data."""
+    @pytest.mark.parametrize(
+        ("env_backend", "env_exchange"),
+        [
+            ("threading", "queue"),
+            ("threading", "auto"),
+            ("multiprocessing", "queue"),
+        ],
+    )
+    def test_env_backend_smoke(self, env_backend, env_exchange):
+        """Supported environment backend and exchange pairs collect data."""
         collector = AsyncBatchedCollector(
             create_env_fn=[_counting_env_factory] * 2,
             policy=_make_counting_policy(),
@@ -2421,6 +2415,7 @@ class TestAsyncBatchedCollector:
             total_frames=20,
             max_batch_size=2,
             env_backend=env_backend,
+            env_exchange=env_exchange,
         )
         total = 0
         for batch in collector:
@@ -2428,14 +2423,16 @@ class TestAsyncBatchedCollector:
         collector.shutdown()
         assert total >= 20
 
-    def test_shared_memory_uses_batched_coordinator(self):
-        """Shared slots preserve outputs while one coordinator keeps all envs moving."""
+    def test_shared_memory_collection(self):
+        """Shared slots yield exact batches with correctly attributed transitions."""
         num_envs = 4
+        frames_per_batch = 10
+        total_frames = 60
         collector = AsyncBatchedCollector(
             create_env_fn=[_counting_env_factory] * num_envs,
             policy=_make_counting_policy(),
-            frames_per_batch=40,
-            total_frames=40,
+            frames_per_batch=frames_per_batch,
+            total_frames=total_frames,
             env_backend="multiprocessing",
             env_exchange="shm",
             server_config=InferenceServerConfig(
@@ -2444,17 +2441,24 @@ class TestAsyncBatchedCollector:
                 timeout=0.1,
             ),
         )
+        batches = []
+        env_ids = set()
         try:
-            batch = next(iter(collector))
-            env_ids = {int(env_id) for env_id in batch["env_index"]}
-            assert env_ids == set(range(num_envs))
-            assert "policy_version" in batch.keys()
             assert collector.env.resolved_exchange == "shm"
-            assert len(collector._workers) == 1
+            for batch in collector:
+                batches.append(batch.numel())
+                env_ids.update(int(env_id) for env_id in batch["env_index"])
+                assert "policy_version" in batch.keys()
+                torch.testing.assert_close(
+                    batch["next", "observation"],
+                    batch["observation"] + batch["action"],
+                )
         finally:
             collector.shutdown()
+        assert batches == [frames_per_batch] * (total_frames // frames_per_batch)
+        assert env_ids == set(range(num_envs))
 
-        with pytest.raises(ValueError, match="require env_backend"):
+        with pytest.raises(ValueError, match="requires env_backend"):
             AsyncBatchedCollector(
                 create_env_fn=[_counting_env_factory],
                 policy=_make_counting_policy(),
@@ -2761,7 +2765,11 @@ class TestThreadingTransportNoLostSignals:
 
 
 class TestWorkerCrashPropagation:
-    def test_worker_crash_propagates(self):
+    @pytest.mark.parametrize(
+        ("env_backend", "env_exchange"),
+        [("threading", "queue"), ("multiprocessing", "shm")],
+    )
+    def test_worker_crash_propagates(self, env_backend, env_exchange):
         """If the model always fails, the collector propagates the error."""
 
         def bad_model(td):
@@ -2772,6 +2780,8 @@ class TestWorkerCrashPropagation:
             policy=bad_model,
             frames_per_batch=10,
             total_frames=100,
+            env_backend=env_backend,
+            env_exchange=env_exchange,
         )
         with pytest.raises(RuntimeError, match="worker thread"):
             for _ in collector:

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import functools as ft
 import importlib.util
 import multiprocessing as mp
 import pickle
@@ -17,7 +18,7 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
-from tensordict import lazy_stack, TensorDict
+from tensordict import lazy_stack, LazyStackedTensorDict, TensorDict
 from tensordict.base import TensorDictBase
 from tensordict.nn import TensorDictModule
 from tensordict.nn.probabilistic import (
@@ -52,7 +53,10 @@ from torchrl.modules.inference_server import (
 )
 from torchrl.modules.inference_server._config import _resolve_device_config
 from torchrl.modules.inference_server._monarch import MonarchTransport
-from torchrl.modules.inference_server._server import _RayInferenceServerActor
+from torchrl.modules.inference_server._server import (
+    _default_collate,
+    _RayInferenceServerActor,
+)
 
 _has_ray = importlib.util.find_spec("ray") is not None
 _has_monarch = importlib.util.find_spec("monarch") is not None
@@ -436,6 +440,21 @@ class TestInferenceServerCore:
 
         assert len(calls) >= 1
         assert sum(calls) == 4  # all 4 items processed
+
+    def test_default_collate_prefers_dense_batches(self):
+        """Homogeneous requests use one dense batch while mixed keys stay lazy."""
+        homogeneous = _default_collate(
+            [
+                TensorDict({"observation": torch.randn(4)}),
+                TensorDict({"observation": torch.randn(4)}),
+            ]
+        )
+        heterogeneous = _default_collate(
+            [TensorDict({"a": torch.randn(4)}), TensorDict({"b": torch.randn(4)})]
+        )
+
+        assert not isinstance(homogeneous, LazyStackedTensorDict)
+        assert isinstance(heterogeneous, LazyStackedTensorDict)
 
     def test_collate_error_resolves_futures_and_server_survives(self):
         """A collate failure must reject the affected futures, not kill the loop."""
@@ -2260,20 +2279,25 @@ class TestAsyncBatchedCollector:
                 frames_per_batch=10,
             )
 
-    def test_yield_completed_trajectories(self):
+    @pytest.mark.parametrize(
+        ("env_backend", "env_exchange"),
+        [("threading", "queue"), ("multiprocessing", "shm")],
+    )
+    def test_yield_completed_trajectories(self, env_backend, env_exchange):
         """With yield_completed_trajectories, collector yields done trajectories."""
         num_envs = 3
         max_steps = 5
         policy = _make_counting_policy()
 
         collector = AsyncBatchedCollector(
-            create_env_fn=[lambda: CountingEnv(max_steps=max_steps)] * num_envs,
+            create_env_fn=[ft.partial(CountingEnv, max_steps=max_steps)] * num_envs,
             policy=policy,
             frames_per_batch=1,
             total_frames=30,
             yield_completed_trajectories=True,
             max_batch_size=num_envs,
-            env_backend="threading",
+            env_backend=env_backend,
+            env_exchange=env_exchange,
         )
         count = 0
         for batch in collector:
@@ -2367,6 +2391,41 @@ class TestAsyncBatchedCollector:
             total += batch.numel()
         collector.shutdown()
         assert total >= 20
+
+    def test_shared_memory_uses_batched_coordinator(self):
+        """Shared slots preserve outputs while one coordinator keeps all envs moving."""
+        num_envs = 4
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * num_envs,
+            policy=_make_counting_policy(),
+            frames_per_batch=40,
+            total_frames=40,
+            env_backend="multiprocessing",
+            env_exchange="shm",
+            server_config=InferenceServerConfig(
+                max_batch_size=num_envs,
+                min_batch_size=num_envs,
+                timeout=0.1,
+            ),
+        )
+        try:
+            batch = next(iter(collector))
+            env_ids = {int(env_id) for env_id in batch["env_index"]}
+            assert env_ids == set(range(num_envs))
+            assert "policy_version" in batch.keys()
+            assert collector.env.resolved_exchange == "shm"
+            assert len(collector._workers) == 1
+        finally:
+            collector.shutdown()
+
+        with pytest.raises(ValueError, match="require env_backend"):
+            AsyncBatchedCollector(
+                create_env_fn=[_counting_env_factory],
+                policy=_make_counting_policy(),
+                frames_per_batch=1,
+                env_backend="threading",
+                env_exchange="shm",
+            )
 
     def test_process_server_backend_smoke(self):
         """Dedicated process server works through AsyncBatchedCollector."""
@@ -2506,6 +2565,46 @@ class TestSlotTransport:
             for r in actor_results:
                 assert "action" in r.keys()
                 assert r["action"].shape == (2,)
+
+    def test_submit_multiple_slots_from_one_thread(self):
+        """Slot clients expose futures so one coordinator can fill a server batch."""
+        num_slots = 4
+        transport = SlotTransport(num_slots=num_slots)
+        clients = [transport.client() for _ in range(num_slots)]
+        policy = _make_policy()
+
+        with InferenceServer(
+            policy,
+            transport,
+            max_batch_size=num_slots,
+            min_batch_size=num_slots,
+            timeout=0.1,
+        ):
+            futures = [clients[0].submit(TensorDict({"observation": torch.randn(4)}))]
+            with pytest.raises(RuntimeError, match="inflight request"):
+                clients[0].submit(TensorDict({"observation": torch.randn(4)}))
+            futures.extend(
+                client.submit(TensorDict({"observation": torch.randn(4)}))
+                for client in clients[1:]
+            )
+            results = [future.result(timeout=10.0) for future in futures]
+
+        assert all("action" in result.keys() for result in results)
+
+    def test_drain_round_robin(self):
+        """Saturated drains rotate instead of repeatedly favoring low slot ids."""
+        transport = SlotTransport(num_slots=6)
+        for slot in range(6):
+            transport._slot_submit(slot, TensorDict({"observation": torch.zeros(1)}))
+        _, first, _ = transport.drain_with_timing(4)
+        assert first == [0, 1, 2, 3]
+
+        for slot in range(4):
+            transport._slot_submit(slot, TensorDict({"observation": torch.zeros(1)}))
+        _, second, _ = transport.drain_with_timing(4)
+        _, third, _ = transport.drain_with_timing(4)
+        assert second == [4, 5, 0, 1]
+        assert third == [2, 3]
 
     def test_too_many_clients_raises(self):
         """Creating more clients than slots raises RuntimeError."""

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -115,10 +115,97 @@ def _env_loop(
             result_queue.put(exc)
 
 
+def _env_ids(tensordict: TensorDictBase) -> list[int]:
+    """Read one environment index for each item in the leading batch dimension."""
+    values = tensordict.get(_ENV_IDX_KEY).tolist()
+    if not isinstance(values, list):
+        values = [values]
+    result = []
+    for value in values:
+        while isinstance(value, list):
+            value = value[0]
+        result.append(int(value))
+    return result
+
+
+def _env_batch_loop(
+    pool: AsyncEnvPool,
+    clients: list[PolicyClientModule],
+    result_queue: queue.Queue,
+    shutdown_event: threading.Event,
+    env_device: torch.device | None,
+    storing_device: torch.device | None,
+):
+    """Coordinate a shared-memory env pool from one thread in ready batches."""
+    exchange_keys = tuple(pool._slot_exchange._input_keys)
+    pending_actions = {}
+    policy_outputs = {}
+    stepping = 0
+    poll_interval = 0.001
+
+    try:
+        env_ids = list(range(pool.num_envs))
+        pool.async_reset_send(env_index=env_ids)
+        observations = pool.async_reset_recv(min_get=pool.num_envs)
+        for env_id, observation in zip(_env_ids(observations), observations.unbind(0)):
+            pending_actions[env_id] = clients[env_id].submit(observation)
+
+        while not shutdown_event.is_set():
+            ready_ids = [
+                env_id for env_id, future in pending_actions.items() if future.done()
+            ]
+            if ready_ids:
+                env_inputs = []
+                for env_id in ready_ids:
+                    action = pending_actions.pop(env_id).result()
+                    if env_device is not None:
+                        action = action.to(env_device)
+                    policy_outputs[env_id] = action
+                    env_inputs.append(action.select(*exchange_keys, strict=False))
+                pool.async_step_and_maybe_reset_send(
+                    lazy_stack(env_inputs), env_index=ready_ids
+                )
+                stepping += len(ready_ids)
+
+            if shutdown_event.is_set():
+                break
+            if not stepping:
+                shutdown_event.wait(poll_interval)
+                continue
+
+            try:
+                transitions, next_observations = pool.async_step_and_maybe_reset_recv(
+                    min_get=1,
+                    max_get=pool.num_envs,
+                    timeout=poll_interval if pending_actions else None,
+                )
+            except TimeoutError:
+                continue
+
+            completed_ids = _env_ids(next_observations)
+            stepping -= len(completed_ids)
+
+            # Submit the next observations before copying the transitions so
+            # policy inference overlaps the batched shared-memory copy.
+            for env_id, observation in zip(completed_ids, next_observations.unbind(0)):
+                pending_actions[env_id] = clients[env_id].submit(observation)
+
+            outputs = lazy_stack(
+                [policy_outputs.pop(env_id) for env_id in completed_ids]
+            )
+            transitions = transitions.clone().update(outputs)
+            if storing_device is not None:
+                transitions = transitions.to(storing_device)
+            result_queue.put(transitions)
+    except Exception as exc:
+        if not shutdown_event.is_set():
+            result_queue.put(exc)
+
+
 class AsyncBatchedCollector(BaseCollector):
     """Asynchronous collector with env slots and a policy server.
 
-    The collector pairs per-env coordinator threads with an
+    The collector pairs environment coordinators with an
     :class:`~torchrl.envs.AsyncEnvPool` and an
     :class:`~torchrl.modules.InferenceServer`.
 
@@ -128,11 +215,10 @@ class AsyncBatchedCollector(BaseCollector):
     * An :class:`~torchrl.envs.AsyncEnvPool` runs *N* environments using
       whatever backend the user chooses (``"threading"``,
       ``"multiprocessing"``).
-    * *N* lightweight coordinator threads -- one per environment -- each own
-      a slot in the pool and an inference client.  A thread sends its env's
-      observation to the :class:`~torchrl.modules.InferenceServer`, blocks
-      until the batched action is returned, then sends the action back to
-      the pool for stepping.
+    * With a shared-memory environment exchange, one coordinator thread drains
+      whichever environments are ready and submits their observations without
+      blocking. Other exchanges use one lightweight coordinator thread per
+      environment.
     * The :class:`~torchrl.modules.InferenceServer` running in a background
       thread continuously drains observation submissions, batches them, runs
       a single forward pass, and fans actions back out.
@@ -202,6 +288,10 @@ class AsyncBatchedCollector(BaseCollector):
             of ``"threading"`` or ``"multiprocessing"``.  Falls back to
             ``backend`` when ``None``.  The coordinator threads are always
             Python threads regardless of this setting.  Defaults to ``None``.
+        env_exchange (str, optional): data exchange of a multiprocessing
+            :class:`~torchrl.envs.AsyncEnvPool`, one of ``"queue"``, ``"shm"``
+            or ``"auto"``. The shared-memory exchange also enables batched
+            coordination from one thread. Defaults to ``"queue"``.
         policy_backend (str, optional): backend for the inference transport
             used to communicate with the
             :class:`~torchrl.modules.InferenceServer`.  One of
@@ -268,8 +358,10 @@ class AsyncBatchedCollector(BaseCollector):
             "threading", "multiprocessing", "ray", "monarch"
         ] = "threading",
         env_backend: Literal["threading", "multiprocessing"] | None = None,
-        policy_backend: Literal["threading", "multiprocessing", "ray", "monarch"]
-        | None = None,
+        env_exchange: Literal["queue", "shm", "auto"] = "queue",
+        policy_backend: (
+            Literal["threading", "multiprocessing", "ray", "monarch"] | None
+        ) = None,
         reset_at_each_iter: bool = False,
         postproc: Callable[[TensorDictBase], TensorDictBase] | None = None,
         yield_completed_trajectories: bool = False,
@@ -340,6 +432,17 @@ class AsyncBatchedCollector(BaseCollector):
                 f"Expected one of {_ENV_BACKENDS}."
             )
         self._env_backend = effective_env_backend
+        if env_exchange not in ("queue", "shm", "auto"):
+            raise ValueError(
+                f"env_exchange={env_exchange!r} is not supported. Expected one of "
+                "('queue', 'shm', 'auto')."
+            )
+        if env_exchange != "queue" and effective_env_backend != "multiprocessing":
+            raise ValueError(
+                "env_exchange='shm' and 'auto' require "
+                "env_backend='multiprocessing'."
+            )
+        self._env_exchange = env_exchange
         self._server_backend = server_backend
         if server_backend == "process":
             if policy_backend not in (None, "multiprocessing"):
@@ -411,6 +514,7 @@ class AsyncBatchedCollector(BaseCollector):
         self._env_pool: AsyncEnvPool | None = None
         self._workers: list[threading.Thread] = []
         self._clients: list[Callable] | None = None
+        self._uses_batched_coordinator = False
 
         # Per-env trajectory accumulators (for yield_completed_trajectories)
         self._yield_queues: list[deque] = [deque() for _ in range(self._num_envs)]
@@ -421,7 +525,7 @@ class AsyncBatchedCollector(BaseCollector):
     # ------------------------------------------------------------------
 
     def _ensure_started(self) -> None:
-        """Create the env pool, start the server and per-env threads."""
+        """Create the env pool, start the server and coordinator threads."""
         if self._workers and all(w.is_alive() for w in self._workers):
             return
 
@@ -432,10 +536,9 @@ class AsyncBatchedCollector(BaseCollector):
         self._env_pool = AsyncEnvPool(
             self._create_env_fn,
             backend=self._env_backend,
-            # Pinned to the current default so the pool's default-change
-            # FutureWarning is not emitted from library code; switching the
-            # collector to the shm exchange is a deliberate follow-up.
-            exchange="queue",
+            # Explicit so the pool's default-change FutureWarning is not
+            # emitted from library code.
+            exchange=self._env_exchange,
             **kwargs,
         )
 
@@ -454,11 +557,32 @@ class AsyncBatchedCollector(BaseCollector):
         if not self._server.is_alive:
             self._server.start()
 
-        # Start per-env coordinator threads
+        # Start coordinator threads. Shared slots can be drained safely in
+        # ready batches, avoiding one Python thread and one clone per env.
         self._result_queue = queue.Queue()
         self._shutdown_event = threading.Event()
 
         self._workers = []
+        if self._env_pool.resolved_exchange == "shm":
+            self._uses_batched_coordinator = True
+            thread = threading.Thread(
+                target=_env_batch_loop,
+                kwargs={
+                    "pool": self._env_pool,
+                    "clients": self._clients,
+                    "result_queue": self._result_queue,
+                    "shutdown_event": self._shutdown_event,
+                    "env_device": self._env_device,
+                    "storing_device": self._storing_device,
+                },
+                daemon=True,
+                name="AsyncBatchedCollector-env-batch",
+            )
+            self._workers.append(thread)
+            thread.start()
+            return
+
+        self._uses_batched_coordinator = False
         for i in range(self._num_envs):
             t = threading.Thread(
                 target=_env_loop,
@@ -586,7 +710,10 @@ class AsyncBatchedCollector(BaseCollector):
         while collected < self.frames_per_batch:
             # Block for at least one transition
             td = self._next_result()
-            transitions.append(td)
+            if self._uses_batched_coordinator:
+                transitions.extend(td.unbind(0))
+            else:
+                transitions.append(td)
             collected += td.numel()
             # Batch-drain any additional items already in the queue
             while collected < self.frames_per_batch:
@@ -595,7 +722,10 @@ class AsyncBatchedCollector(BaseCollector):
                 except queue.Empty:
                     break
                 self._check_worker_result(td)
-                transitions.append(td)
+                if self._uses_batched_coordinator:
+                    transitions.extend(td.unbind(0))
+                else:
+                    transitions.append(td)
                 collected += td.numel()
             if self.verbose:
                 torchrl_logger.debug(
@@ -609,25 +739,33 @@ class AsyncBatchedCollector(BaseCollector):
         """Drain transitions until a complete trajectory is available."""
         while not self._trajectory_queue:
             td = self._next_result()
-            env_id = 0
-            eid = td.get(_ENV_IDX_KEY, default=None)
-            if eid is not None:
-                # Unwrap NonTensorData / NonTensorStack / list wrappers
-                if hasattr(eid, "data"):
-                    eid = eid.data
-                while isinstance(eid, (list,)) and len(eid) == 1:
-                    eid = eid[0]
-                env_id = int(eid)
-
-            self._yield_queues[env_id].append(td)
-            if td["next", "done"].any():
-                self._trajectory_queue.append(
-                    lazy_stack(list(self._yield_queues[env_id]), -1)
-                )
-                self._yield_queues[env_id].clear()
+            if self._uses_batched_coordinator:
+                for transition in td.unbind(0):
+                    self._record_trajectory_transition(transition)
+            else:
+                self._record_trajectory_transition(td)
 
         result = self._trajectory_queue.popleft()
         return result.reshape(-1)
+
+    def _record_trajectory_transition(self, td: TensorDictBase) -> None:
+        """Record one environment transition for trajectory yielding."""
+        env_id = 0
+        eid = td.get(_ENV_IDX_KEY, default=None)
+        if eid is not None:
+            # Unwrap NonTensorData / NonTensorStack / list wrappers
+            if hasattr(eid, "data"):
+                eid = eid.data
+            while isinstance(eid, list) and len(eid) == 1:
+                eid = eid[0]
+            env_id = int(eid)
+
+        self._yield_queues[env_id].append(td)
+        if td["next", "done"].any():
+            self._trajectory_queue.append(
+                lazy_stack(list(self._yield_queues[env_id]), -1)
+            )
+            self._yield_queues[env_id].clear()
 
     @property
     def rollout(self) -> Callable[[], TensorDictBase]:

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -13,7 +13,13 @@ from collections.abc import Callable, Iterator, Sequence
 from typing import Literal
 
 import torch
-from tensordict import lazy_stack, NestedKey, TensorDictBase
+from tensordict import (
+    lazy_stack,
+    LazyStackedTensorDict,
+    maybe_dense_stack,
+    NestedKey,
+    TensorDictBase,
+)
 
 from torchrl._comm import MailboxTransportError
 from torchrl._utils import _maybe_record_function_decorator, logger as torchrl_logger
@@ -134,12 +140,16 @@ def _env_loop(
 
 def _env_ids(tensordict: TensorDictBase) -> list[int]:
     """Read one environment index for each item in the leading batch dimension."""
-    values = tensordict.get(_ENV_IDX_KEY).tolist()
+    values = tensordict.get(_ENV_IDX_KEY)
+    if hasattr(values, "data") and not isinstance(values, torch.Tensor):
+        values = values.data
+    if hasattr(values, "tolist"):
+        values = values.tolist()
     if not isinstance(values, list):
         values = [values]
     result = []
     for value in values:
-        while isinstance(value, list):
+        while isinstance(value, list) and len(value) == 1:
             value = value[0]
         result.append(int(value))
     return result
@@ -155,7 +165,7 @@ def _env_batch_loop(
     storing_device: torch.device | None,
 ):
     """Coordinate a shared-memory env pool from one thread in ready batches."""
-    exchange_keys = tuple(pool._slot_exchange._input_keys)
+    exchange_keys = pool.exchange_keys
     ready_observations = {}
     pending_actions = {}
     policy_outputs = {}
@@ -225,7 +235,12 @@ def _env_batch_loop(
             outputs = lazy_stack(
                 [policy_outputs.pop(env_id) for env_id in completed_ids]
             )
-            transitions = transitions.clone().update(outputs)
+            # Dense pool stacking already copied the transition tensors out of
+            # shared memory before the slots can be reused. A lazy stack still
+            # aliases the slots and must be cloned before actions are sent back.
+            if isinstance(transitions, LazyStackedTensorDict):
+                transitions = transitions.clone()
+            transitions.update(outputs.exclude(*transitions.keys(True, True)))
             if storing_device is not None:
                 transitions = transitions.to(storing_device)
             result_queue.put(transitions)
@@ -469,10 +484,9 @@ class AsyncBatchedCollector(BaseCollector):
                 f"env_exchange={env_exchange!r} is not supported. Expected one of "
                 "('queue', 'shm', 'auto')."
             )
-        if env_exchange != "queue" and effective_env_backend != "multiprocessing":
+        if env_exchange == "shm" and effective_env_backend != "multiprocessing":
             raise ValueError(
-                "env_exchange='shm' and 'auto' require "
-                "env_backend='multiprocessing'."
+                "env_exchange='shm' requires env_backend='multiprocessing'."
             )
         self._env_exchange = env_exchange
         self._server_backend = server_backend
@@ -500,6 +514,7 @@ class AsyncBatchedCollector(BaseCollector):
                 max_batch_size=max_batch_size,
                 min_batch_size=min_batch_size,
                 timeout=server_timeout,
+                collate_fn=maybe_dense_stack,
                 policy_device=policy_device,
                 output_device=output_device,
                 weight_sync=weight_sync,
@@ -516,6 +531,7 @@ class AsyncBatchedCollector(BaseCollector):
                 max_batch_size=max_batch_size,
                 min_batch_size=min_batch_size,
                 timeout=server_timeout,
+                collate_fn=maybe_dense_stack,
                 policy_device=policy_device,
                 output_device=output_device,
                 weight_sync=weight_sync,
@@ -549,6 +565,7 @@ class AsyncBatchedCollector(BaseCollector):
         self._uses_batched_coordinator = False
         self._pause_request: list[_PauseRequest | None] = [None]
         self._pause_lock = threading.Lock()
+        self._transition_carry: deque[TensorDictBase] = deque()
 
         # Per-env trajectory accumulators (for yield_completed_trajectories)
         self._yield_queues: list[deque] = [deque() for _ in range(self._num_envs)]
@@ -807,14 +824,24 @@ class AsyncBatchedCollector(BaseCollector):
         collected = 0
         transitions: list[TensorDictBase] = []
 
+        while self._transition_carry and collected < self.frames_per_batch:
+            transition = self._transition_carry.popleft()
+            transitions.append(transition)
+            collected += transition.numel()
+
         while collected < self.frames_per_batch:
             # Block for at least one transition
             td = self._next_result()
             if self._uses_batched_coordinator:
-                transitions.extend(td.unbind(0))
+                for transition in td.unbind(0):
+                    if collected < self.frames_per_batch:
+                        transitions.append(transition)
+                        collected += transition.numel()
+                    else:
+                        self._transition_carry.append(transition)
             else:
                 transitions.append(td)
-            collected += td.numel()
+                collected += td.numel()
             # Batch-drain any additional items already in the queue
             while collected < self.frames_per_batch:
                 try:
@@ -823,10 +850,15 @@ class AsyncBatchedCollector(BaseCollector):
                     break
                 self._check_worker_result(td)
                 if self._uses_batched_coordinator:
-                    transitions.extend(td.unbind(0))
+                    for transition in td.unbind(0):
+                        if collected < self.frames_per_batch:
+                            transitions.append(transition)
+                            collected += transition.numel()
+                        else:
+                            self._transition_carry.append(transition)
                 else:
                     transitions.append(td)
-                collected += td.numel()
+                    collected += td.numel()
             if self.verbose:
                 torchrl_logger.debug(
                     f"AsyncBatchedCollector: {collected}/{self.frames_per_batch} frames"
@@ -851,14 +883,8 @@ class AsyncBatchedCollector(BaseCollector):
     def _record_trajectory_transition(self, td: TensorDictBase) -> None:
         """Record one environment transition for trajectory yielding."""
         env_id = 0
-        eid = td.get(_ENV_IDX_KEY, default=None)
-        if eid is not None:
-            # Unwrap NonTensorData / NonTensorStack / list wrappers
-            if hasattr(eid, "data"):
-                eid = eid.data
-            while isinstance(eid, list) and len(eid) == 1:
-                eid = eid[0]
-            env_id = int(eid)
+        if td.get(_ENV_IDX_KEY, default=None) is not None:
+            env_id = _env_ids(td)[0]
 
         self._yield_queues[env_id].append(td)
         if td["next", "done"].any():
@@ -904,6 +930,7 @@ class AsyncBatchedCollector(BaseCollector):
         if request is not None:
             request[0].abort()
             request[1].set()
+        self._transition_carry.clear()
         _timeout = timeout or 5.0
         for w in self._workers:
             w.join(timeout=_timeout)

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -126,7 +126,10 @@ def _env_loop(
             if shutdown_event.is_set():
                 break
 
-            action_td = client(obs)
+            # Initial resets may have no device metadata while later policy
+            # results do. Keep requests collatable when streams start or reset
+            # at different times; tensor placement is unchanged.
+            action_td = client(obs.clone(recurse=False).clear_device_())
             if env_device is not None:
                 action_td = action_td.to(env_device)
             pool.async_step_and_maybe_reset_send(action_td, env_index=env_id)

--- a/torchrl/envs/async_envs.py
+++ b/torchrl/envs/async_envs.py
@@ -23,7 +23,7 @@ from tensordict import (
     TensorDictBase,
 )
 from tensordict.tensorclass import NonTensorData, NonTensorStack
-from tensordict.utils import _zip_strict, expand_as_right
+from tensordict.utils import _zip_strict, expand_as_right, NestedKey
 
 from torchrl._utils import logger as torchrl_logger, timeit
 from torchrl.data.tensor_specs import NonTensor
@@ -603,6 +603,17 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
         exchange).
         """
         return "shm" if getattr(self, "_slot_exchange", None) is not None else "queue"
+
+    @property
+    def exchange_keys(self) -> tuple[NestedKey, ...]:
+        """The tensor keys accepted by the active shared-memory exchange.
+
+        Returns an empty tuple when the resolved exchange is ``"queue"``.
+        """
+        exchange = getattr(self, "_slot_exchange", None)
+        if exchange is None:
+            return ()
+        return tuple(exchange._input_keys)
 
     def stats(self, *, reset: bool = False) -> dict[str, float | int]:
         """Return shared-memory exchange statistics.

--- a/torchrl/modules/inference_server/_server.py
+++ b/torchrl/modules/inference_server/_server.py
@@ -20,7 +20,7 @@ from statistics import mean
 from typing import Any, Literal
 
 import torch
-from tensordict import lazy_stack, TensorDict
+from tensordict import maybe_dense_stack, TensorDict
 from tensordict.base import TensorDictBase
 from tensordict.nn.probabilistic import InteractionType, set_interaction_type
 from tensordict.utils import NestedKey
@@ -248,7 +248,7 @@ def _normalize_tensordict_device_metadata(data: TensorDictBase) -> TensorDictBas
 
 
 def _default_collate(items: list[TensorDictBase]) -> TensorDictBase:
-    return lazy_stack(
+    return maybe_dense_stack(
         [
             _normalize_tensordict_device_metadata(item)
             if isinstance(item, TensorDictBase)
@@ -305,7 +305,7 @@ class InferenceServer(metaclass=_InferenceServerMeta):
         timeout (float, optional): seconds to wait for new work before
             dispatching a partial batch. Default: ``0.01``.
         collate_fn (Callable, optional): function used to stack a list of
-            TensorDicts into a batch. Default: :func:`~tensordict.lazy_stack`.
+            TensorDicts into a batch. Default: :func:`~tensordict.maybe_dense_stack`.
         device (torch.device or str, optional): device to move batches to
             before calling the model. This is kept as an alias for
             ``policy_device`` for backward compatibility. ``None`` means no

--- a/torchrl/modules/inference_server/_server.py
+++ b/torchrl/modules/inference_server/_server.py
@@ -20,7 +20,7 @@ from statistics import mean
 from typing import Any, Literal
 
 import torch
-from tensordict import maybe_dense_stack, TensorDict
+from tensordict import lazy_stack, TensorDict
 from tensordict.base import TensorDictBase
 from tensordict.nn.probabilistic import InteractionType, set_interaction_type
 from tensordict.utils import NestedKey
@@ -248,7 +248,7 @@ def _normalize_tensordict_device_metadata(data: TensorDictBase) -> TensorDictBas
 
 
 def _default_collate(items: list[TensorDictBase]) -> TensorDictBase:
-    return maybe_dense_stack(
+    return lazy_stack(
         [
             _normalize_tensordict_device_metadata(item)
             if isinstance(item, TensorDictBase)
@@ -305,7 +305,7 @@ class InferenceServer(metaclass=_InferenceServerMeta):
         timeout (float, optional): seconds to wait for new work before
             dispatching a partial batch. Default: ``0.01``.
         collate_fn (Callable, optional): function used to stack a list of
-            TensorDicts into a batch. Default: :func:`~tensordict.maybe_dense_stack`.
+            TensorDicts into a batch. Default: :func:`~tensordict.lazy_stack`.
         device (torch.device or str, optional): device to move batches to
             before calling the model. This is kept as an alias for
             ``policy_device`` for backward compatibility. ``None`` means no

--- a/torchrl/modules/inference_server/_slot.py
+++ b/torchrl/modules/inference_server/_slot.py
@@ -118,7 +118,7 @@ class SlotTransport(InferenceTransport):
             submit.  Subsequent submits copy into the buffer in-place
             (``update_``).  Defaults to ``False`` because the extra copy
             into the buffer is not currently compensated by the batching
-            path (``lazy_stack`` still calls ``torch.stack``).
+            path, which still materializes a separate policy-input batch.
 
     .. note::
         This transport is only suitable for in-process threading scenarios

--- a/torchrl/modules/inference_server/_slot.py
+++ b/torchrl/modules/inference_server/_slot.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import itertools
 import threading
 import time
+from collections.abc import Callable
 
 from tensordict.base import TensorDictBase
 
@@ -28,11 +29,67 @@ class _SlotClient:
     def __init__(self, transport: SlotTransport, slot_id: int):
         self._transport = transport
         self._slot_id = slot_id
+        self._inflight: _SlotFuture | None = None
 
     def __call__(self, td: TensorDictBase) -> TensorDictBase:
         """Submit an observation and block until the action is ready."""
-        self._transport._slot_submit(self._slot_id, td)
-        return self._transport._slot_recv(self._slot_id)
+        return self.submit(td).result()
+
+    def submit(self, td: TensorDictBase) -> _SlotFuture:
+        """Submit an observation without blocking for the action."""
+        if self._inflight is not None:
+            raise RuntimeError(
+                f"Inference slot {self._slot_id} already has an inflight request."
+            )
+        future = _SlotFuture(self._transport, self._slot_id, self._release)
+        self._inflight = future
+        try:
+            self._transport._slot_submit(self._slot_id, td)
+        except BaseException:
+            self._release()
+            raise
+        return future
+
+    def _release(self) -> None:
+        self._inflight = None
+
+
+class _SlotFuture:
+    """Minimal future backed by a slot's reusable action event."""
+
+    def __init__(
+        self,
+        transport: SlotTransport,
+        slot_id: int,
+        release: Callable[[], None],
+    ):
+        self._transport = transport
+        self._slot_id = slot_id
+        self._release = release
+        self._completed = False
+        self._result: TensorDictBase | None = None
+        self._exception: BaseException | None = None
+
+    def done(self) -> bool:
+        return self._completed or self._transport._action_events[self._slot_id].is_set()
+
+    def result(self, timeout: float | None = None) -> TensorDictBase:
+        if not self._completed:
+            try:
+                self._result = self._transport._slot_recv(
+                    self._slot_id, timeout=timeout
+                )
+            except TimeoutError:
+                raise
+            except BaseException as exc:
+                self._exception = exc
+            self._completed = True
+            self._release()
+        if self._exception is not None:
+            raise self._exception
+        if self._result is None:
+            raise RuntimeError(f"Inference slot {self._slot_id} returned no result.")
+        return self._result
 
 
 class SlotTransport(InferenceTransport):
@@ -99,6 +156,10 @@ class SlotTransport(InferenceTransport):
         # Pre-allocated observation buffer (lazily initialised)
         self._obs_buffer: TensorDictBase | None = None
 
+        # Begin the next sweep after the last slot served so a saturated
+        # transport cannot repeatedly favor low-numbered slots.
+        self._sweep_start = 0
+
     # -- actor (env-thread) API -----------------------------------------------
 
     def _slot_submit(self, slot_id: int, td: TensorDictBase) -> None:
@@ -116,9 +177,10 @@ class SlotTransport(InferenceTransport):
         with self._work_cond:
             self._work_cond.notify()
 
-    def _slot_recv(self, slot_id: int) -> TensorDictBase:
+    def _slot_recv(self, slot_id: int, timeout: float | None = None) -> TensorDictBase:
         """Block until the server writes an action into the slot."""
-        self._action_events[slot_id].wait()
+        if not self._action_events[slot_id].wait(timeout=timeout):
+            raise TimeoutError(f"Timed out waiting for inference slot {slot_id}.")
         self._action_events[slot_id].clear()
         result = self._actions[slot_id]
         self._actions[slot_id] = None
@@ -180,7 +242,9 @@ class SlotTransport(InferenceTransport):
         items: list[TensorDictBase] = []
         slot_ids: list[int] = []
         submitted_at: list[float | None] = []
-        for i in range(self._num_slots):
+        start = self._sweep_start
+        for offset in range(self._num_slots):
+            i = (start + offset) % self._num_slots
             if self._obs_ready[i]:
                 self._obs_ready[i] = False
                 submitted_at.append(self._submitted_at[i])
@@ -198,6 +262,8 @@ class SlotTransport(InferenceTransport):
                 slot_ids.append(i)
                 if len(slot_ids) >= max_items:
                     break
+        if slot_ids:
+            self._sweep_start = (slot_ids[-1] + 1) % self._num_slots
         return items, slot_ids, submitted_at
 
     def resolve(self, callback: int, result: TensorDictBase) -> None:


### PR DESCRIPTION
AsyncBatchedCollector now coordinates shared-memory environments from one thread, batches ready requests, and drains inference slots fairly. The collector exposes the environment exchange, preserves transition ownership, and returns an exact final frame batch even when total_frames is not divisible by frames_per_batch. Completed-trajectory mode retains its complete-trajectory behavior.

Integration with current main preserves worker/driver CPU affinity, including feeder-thread inheritance, and compile-safe pause. The existing collector benchmark includes shared-memory selection and a reproducible large-policy preset.

Validation: 32 focused collector and slot-transport tests passed; one Linux affinity test was skipped on macOS. The new non-divisible-budget cases reproduced overshoot before the fix and pass afterward. Pinned formatting, flake8, and diff checks pass. GPU comparisons and Linux affinity validation are pending.

Mixed reset/post-step inference regression: the threaded collector clears TensorDict device metadata before batching requests, while preserving tensor placement. A deterministic delayed-reset test reproduces the previous heterogeneous-stack device failure and verifies continued collection and policy features. The collector class passes 26 CPU cases (one Linux-specific skip).
