### PR TITLE
[Performance] Use native replay collection in DreamerV3

### DIFF
--- a/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
+++ b/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
@@ -6,8 +6,8 @@
 
 The workload uses the maintained DMC Walker configuration and includes all
 model, actor, value, and replay-value losses, backward, the optimizer step,
-and the slow-value-target update. Replay sampling and environment collection
-are intentionally outside the learner timing.
+and the slow-value-target update. The optional replay workload uses the same
+native replay construction, prefetch, and conditional writeback as training.
 
 Example::
 
@@ -17,6 +17,7 @@ Example::
 from __future__ import annotations
 
 import argparse
+import functools as ft
 import json
 import runpy
 import statistics
@@ -71,6 +72,9 @@ def _make_data(
                 "terminated": torch.zeros(
                     batch, steps, 1, dtype=torch.bool, device=device
                 ),
+                "truncated": torch.zeros(
+                    batch, steps, 1, dtype=torch.bool, device=device
+                ),
             },
         },
         [batch, steps],
@@ -78,24 +82,80 @@ def _make_data(
     )
 
 
-def _measure(
-    learner_update,
-    data: TensorDict,
-    *,
-    device: torch.device,
-    warmup: int,
-    iterations: int,
-) -> list[float]:
+class _ReplayLearnerStep:
+    def __init__(
+        self,
+        example: dict,
+        cfg,
+        learner_update,
+        *,
+        device: torch.device,
+        replay_device: torch.device,
+        obs_dim: int,
+        action_dim: int,
+    ):
+        self.cfg = cfg
+        self.device = device
+        self.learner_update = learner_update
+        self.replay_context_update = example["replay_context_update"]
+        sequence_records = cfg.replay_buffer.seq_len + 1
+        num_streams = 4
+        records_per_stream = sequence_records * cfg.replay_buffer.batch_size
+        cfg.replay_buffer.buffer_size = records_per_stream * num_streams
+        cfg.replay_buffer.online = False
+        self.replay_buffer = example["_build_replay"](
+            cfg, num_streams, replay_device, device
+        )
+        replay_data = _make_data(
+            cfg,
+            replay_device,
+            batch=num_streams,
+            steps=records_per_stream,
+            obs_dim=obs_dim,
+            action_dim=action_dim,
+        )
+        replay_data["is_init"][:, 0] = True
+        self.replay_buffer.extend(replay_data)
+
+    def __call__(self) -> None:
+        sequence_records = self.cfg.replay_buffer.seq_len + 1
+        replay_sample = self.replay_buffer.sample().reshape(
+            self.cfg.replay_buffer.batch_size, sequence_records
+        )
+        sample_info = replay_sample.select("index", "index_generation")
+        sample = replay_sample.exclude("index", "index_generation")
+        sample = sample.to(self.device, non_blocking=True)[:, :-1]
+        if self.learner_update.replay_must_be_idle:
+            self.replay_buffer.synchronize()
+        _, state, belief = self.learner_update(sample)
+        if self.cfg.optimization.cudagraph_train_step:
+            state = state.clone()
+            belief = belief.clone()
+        index, generation, patch = self.replay_context_update(
+            sample_info, state, belief
+        )
+        self.replay_buffer.submit_update_if_present(
+            index=index, generation=generation, patch=patch
+        )
+
+    def synchronize(self) -> None:
+        self.replay_buffer.synchronize()
+        if self.device.type == "cuda":
+            torch.cuda.synchronize(self.device)
+
+    def close(self) -> None:
+        self.replay_buffer.shutdown()
+
+
+def _measure(step, synchronize, *, warmup: int, iterations: int) -> list[float]:
     for _ in range(warmup):
-        learner_update(data)
-    torch.cuda.synchronize(device)
-    samples = []
+        step()
+    synchronize()
+    started = time.perf_counter()
     for _ in range(iterations):
-        started = time.perf_counter()
-        learner_update(data)
-        torch.cuda.synchronize(device)
-        samples.append((time.perf_counter() - started) * 1000)
-    return samples
+        step()
+    synchronize()
+    return [(time.perf_counter() - started) * 1000 / iterations]
 
 
 def main() -> None:
@@ -105,6 +165,11 @@ def main() -> None:
     parser.add_argument("--unroll", type=int, default=8)
     parser.add_argument("--warmup", type=int, default=10)
     parser.add_argument("--iterations", type=int, default=50)
+    parser.add_argument(
+        "--replay-device",
+        choices=("cpu", "cuda"),
+        help="Include native replay sampling and writeback on this device.",
+    )
     parser.add_argument(
         "--variants",
         nargs="+",
@@ -163,18 +228,40 @@ def main() -> None:
                     example["LEARNER_RNG_STREAM"],
                 )
             )
-        samples = _measure(
-            learner_update,
-            data.clone(),
-            device=device,
-            warmup=args.warmup,
-            iterations=args.iterations,
-        )
+        replay_step = None
+        if args.replay_device is None:
+            step = ft.partial(learner_update, data.clone())
+            synchronize = ft.partial(torch.cuda.synchronize, device)
+            workload = "complete_learner_update"
+        else:
+            replay_step = _ReplayLearnerStep(
+                example,
+                cfg,
+                learner_update,
+                device=device,
+                replay_device=torch.device(args.replay_device),
+                obs_dim=obs_dim,
+                action_dim=action_dim,
+            )
+            step = replay_step
+            synchronize = replay_step.synchronize
+            workload = "complete_learner_update_with_replay"
+        try:
+            samples = _measure(
+                step,
+                synchronize,
+                warmup=args.warmup,
+                iterations=args.iterations,
+            )
+        finally:
+            if replay_step is not None:
+                replay_step.close()
         median_ms = statistics.median(samples)
         result = {
             "variant": variant,
-            "workload": "complete_learner_update",
+            "workload": workload,
             "device": torch.cuda.get_device_name(device),
+            "replay_device": args.replay_device,
             "torch_version": torch.__version__,
             "cuda_version": torch.version.cuda,
             "batch": args.batch,

--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -26,8 +26,10 @@ without relying on wall-clock-dependent training iterations.
 
 The Walker task is seeded from `env.seed`, as every other TorchRL example is;
 pass `env.use_seed=false` for the JAX implementation's unseeded DMC resets. The
-step axis counts initial and reset-only driver records as that
-implementation does.
+step axis counts initial and reset-only driver records as that implementation
+does. Those counts are reporting and update-scheduling semantics only: replay
+stores the canonical transitions emitted by the collector and does not insert
+synthetic reset records.
 
 This is deliberately a reproduction of the pinned JAX `dmc_proprio` preset,
 not of the paper's proprioceptive protocol. The two protocols differ:
@@ -49,6 +51,23 @@ Real collection and evaluation environments run on CPU; `optimization.device`
 selects where the models, losses and policy run and defaults to `null`, which
 auto-selects an available accelerator. Pass `optimization.device=cpu` to force
 CPU execution.
+
+Replay is assembled entirely from reusable TorchRL components. One
+`TensorDictReplayBuffer` is allocated per environment stream and the configured
+`replay_buffer.buffer_size` is split across them. A routed
+`ReplayBufferEnsemble` writes synchronous collector batches by their environment
+dimension and asynchronous batches by `env_index`. Sampling chooses ready
+streams according to their available windows. `replay_buffer.online=true` uses
+`StreamingSliceSampler` to consume newly completed, non-overlapping windows
+before uniform fallback; `false` uses regular uniform `SliceSampler` sampling.
+Both modes sample `seq_len + 1` transitions so the learner can train on the
+first `seq_len` and conditionally refresh the following records' latent state.
+
+Set `collector.backend=async` to use `AsyncBatchedCollector`; the default is the
+synchronous `Collector`. `collector.async_env_backend` selects `threading` or
+`multiprocessing` for asynchronous environments. In both cases collection
+post-processing, episode reporting, device normalization, and replay writes
+happen through the collector's standard replay integration.
 
 For a three-seed median and interquartile reproduction run:
 
@@ -75,6 +94,13 @@ The timing excludes replay sampling and environment collection. Use the
 benchmark arguments to change the batch size, sequence length, scan unroll,
 warmup, or number of measured updates. Compilation and graph capture happen
 during warmup and are excluded from the reported samples.
+
+Pass `--replay-device cpu` or `--replay-device cuda` to benchmark the complete
+learner with the same routed replay stack used by training. Replay uses its
+built-in one-batch prefetch and ordered conditional updates, allowing sampling
+and latent writeback to overlap learner work. CPU replay samples are pinned and
+the complete contiguous sequence is transferred non-blockingly before it is
+sliced on the learner device.
 
 On one NVIDIA GB200 with PyTorch 2.12.0, CUDA 13.0, BF16, batch size 16,
 sequence length 64, scan unroll 8, 10 warmup updates and 50 measured updates:

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -7,6 +7,8 @@ env:
   max_episode_steps: 200
 
 collector:
+  backend: sync  # one of: sync, async
+  async_env_backend: threading  # one of: threading, multiprocessing
   num_envs: 1
   frames_per_batch: 200
   total_frames: 5000

--- a/sota-implementations/dreamer_v3/dreamer_v3_agent.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_agent.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """The DreamerV3 networks, acting policy, optimizer and builders."""
+
 from __future__ import annotations
 
 import importlib.util
@@ -20,7 +21,6 @@ from tensordict.nn import (
     TensorDictSequential,
 )
 from tensordict.utils import NestedKey
-
 from torchrl.data import Unbounded
 from torchrl.envs import EnvBase, StepCounter, TransformedEnv
 from torchrl.envs.libs.gym import GymEnv
@@ -394,8 +394,9 @@ def build_world_model(
         out_keys=[("next", "posterior_logits"), ("next", "state")],
     )
 
-    # Only the reset record of an episode has is_init set, thus a sampled
-    # window can cross an episode boundary.
+    # Canonical collector transitions retain is_init. Slice sampling keeps a
+    # training window within one episode, while the rollout still handles a
+    # reset at its first transition.
     rollout = RSSMRolloutV3(rssm_prior, rssm_posterior, reset_key="is_init")
     if cfg.optimization.compile_rssm:
         rollout.compile_rollout(

--- a/sota-implementations/dreamer_v3/dreamer_v3_replay.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_replay.py
@@ -2,22 +2,14 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-"""Driver-step accounting and the continuous replay stream of the example."""
+"""Driver-step accounting and replay-context updates for DreamerV3."""
+
 from __future__ import annotations
 
-from typing import TypeAlias
+from collections.abc import Mapping
 
 import torch
-from tensordict import TensorDictBase
-
-from torchrl.data import LazyTensorStorage, ReplayBuffer, SliceSampler
-
-ReplayIndex: TypeAlias = torch.Tensor | tuple[torch.Tensor, ...]
-ReplaySampleInfo: TypeAlias = dict[str, ReplayIndex]
-_REPLAY_CONTEXT_VALID_KEY = ("collector", "context_valid")
-
-
-# --- Driver step accounting --------------------------------------------------
+from tensordict import NestedKey, TensorDictBase
 
 
 def driver_step_for_action(
@@ -73,412 +65,52 @@ class DreamerV3UpdateRatio:
         return repeats
 
 
-# --- Replay: record stream, writeback, sampling ------------------------------
-
-
-def _refresh_replay_context(
-    replay_buffer: ReplayBuffer,
-    sample_indices: ReplayIndex,
-    sample_generations: torch.Tensor,
+def replay_context_update(
+    sample: TensorDictBase,
     state: torch.Tensor,
     belief: torch.Tensor,
-) -> None:
-    if not isinstance(sample_indices, tuple):
-        sample_indices = (sample_indices,)
-    batch_size, sequence_length = state.shape[:2]
-    context_length = sequence_length + 1
-    destination_indices = tuple(
-        index.reshape(batch_size, context_length)[:, 1:].reshape(-1)
-        for index in sample_indices
+) -> tuple[TensorDictBase, torch.Tensor, Mapping[NestedKey, torch.Tensor]]:
+    """Build a deduplicated update for the context rows after a sampled step."""
+    if sample.ndim != 2:
+        raise RuntimeError(
+            "Expected a replay sample with shape [batch, time], got "
+            f"{tuple(sample.shape)}."
+        )
+    learner_shape = torch.Size((sample.shape[0], sample.shape[1] - 1))
+    if state.shape[:2] != learner_shape or belief.shape[:2] != learner_shape:
+        raise RuntimeError(
+            "Refreshed state and belief must match the learner sample batch and "
+            "time dimensions."
+        )
+
+    handles = sample.get("index")[:, 1:].reshape(-1)
+    generations = sample.get("index_generation")[:, 1:].reshape(-1)
+    buffer_ids = handles.get("buffer_ids")
+    local_indices = handles.get("index")
+    coordinates = torch.cat(
+        (buffer_ids.reshape(-1, 1), local_indices.reshape(buffer_ids.numel(), -1)),
+        -1,
     )
-    destination_generation = sample_generations.reshape(batch_size, context_length)[
-        :, 1:
-    ].reshape(-1)
-    # Slices overlap, and a CUDA index write leaves duplicate coordinates
-    # undefined. Keep the last value of each coordinate.
-    coordinates = torch.stack(destination_indices, -1)
-    linear_coordinate = coordinates[:, 0]
-    for coordinate, size in zip(
-        coordinates[:, 1:].unbind(-1), replay_buffer.storage.shape[1:]
-    ):
-        linear_coordinate = linear_coordinate * int(size) + coordinate
-    order = linear_coordinate.argsort(stable=True)
-    ordered_coordinate = linear_coordinate[order]
-    keep_ordered = torch.ones_like(ordered_coordinate, dtype=torch.bool)
-    keep_ordered[:-1] = ordered_coordinate[:-1] != ordered_coordinate[1:]
+
+    # Sampled slices may overlap. Keep the last value for each destination so
+    # indexed writes have deterministic semantics on every device.
+    order = torch.arange(coordinates.shape[0], device=coordinates.device)
+    for dimension in range(coordinates.shape[1] - 1, -1, -1):
+        order = order[coordinates[order, dimension].argsort(stable=True)]
+    ordered_coordinates = coordinates[order]
+    keep_ordered = torch.ones(
+        ordered_coordinates.shape[0], dtype=torch.bool, device=coordinates.device
+    )
+    keep_ordered[:-1] = (ordered_coordinates[:-1] != ordered_coordinates[1:]).any(-1)
     keep = order[keep_ordered]
-    destination_indices = tuple(index[keep] for index in destination_indices)
-    destination_index = (
-        torch.stack(destination_indices, -1)
-        if len(destination_indices) > 1
-        else destination_indices[0]
-    )
-    destination_generation = destination_generation[keep]
-    replay_buffer.update_if_present(
-        index=destination_index,
-        generation=destination_generation,
-        patch={
-            "state": state.detach()
-            .float()
-            .reshape(-1, state.shape[-1])[keep.to(state.device)],
-            "belief": belief.detach()
-            .float()
-            .reshape(-1, belief.shape[-1])[keep.to(belief.device)],
-            _REPLAY_CONTEXT_VALID_KEY: torch.ones(
-                (keep.numel(), 1), dtype=torch.bool, device=state.device
-            ),
+
+    state = state.detach().float().reshape(-1, state.shape[-1])
+    belief = belief.detach().float().reshape(-1, belief.shape[-1])
+    return (
+        handles[keep],
+        generations[keep],
+        {
+            "state": state[keep.to(state.device)],
+            "belief": belief[keep.to(belief.device)],
         },
     )
-
-
-class DreamerV3ReplayPipeline:
-    """Sample one batch ahead, and apply each latent refresh one update behind."""
-
-    def __init__(self):
-        self._prefetched: tuple[TensorDictBase, ReplaySampleInfo] | None = None
-        self._pending_context: tuple[
-            ReplaySampleInfo, torch.Tensor, torch.Tensor
-        ] | None = None
-
-    @property
-    def has_prefetched(self) -> bool:
-        return self._prefetched is not None
-
-    @property
-    def has_pending_context(self) -> bool:
-        return self._pending_context is not None
-
-    def prefetch(self, replay_buffer: ReplayBuffer) -> None:
-        if self._prefetched is None:
-            self._prefetched = replay_buffer.sample(return_info=True)
-
-    def take(
-        self, replay_buffer: ReplayBuffer
-    ) -> tuple[TensorDictBase, ReplaySampleInfo]:
-        """Return the prefetched batch, and sample the next one."""
-        self.prefetch(replay_buffer)
-        current = self._prefetched
-        self._prefetched = replay_buffer.sample(return_info=True)
-        return current
-
-    def apply_pending_context(self, replay_buffer: ReplayBuffer) -> None:
-        """Apply the previous refresh, after ``take`` samples the next batch."""
-        if self._pending_context is not None:
-            pending_info, pending_state, pending_belief = self._pending_context
-            _refresh_replay_context(
-                replay_buffer,
-                pending_info["index"],
-                pending_info["index_generation"],
-                pending_state,
-                pending_belief,
-            )
-            self._pending_context = None
-
-    def stage_context(
-        self,
-        sample_info: ReplaySampleInfo,
-        state: torch.Tensor,
-        belief: torch.Tensor,
-    ) -> None:
-        if self._pending_context is not None:
-            raise RuntimeError(
-                "The preceding replay context must be applied before staging "
-                "another learner output."
-            )
-        self._pending_context = (sample_info, state, belief)
-
-
-class DreamerV3ReplayRecordBuilder:
-    """Convert collector transitions into the replay stream."""
-
-    def __init__(self, num_streams: int):
-        self.num_streams = num_streams
-        self._started = False
-
-    def __call__(self, data: TensorDictBase) -> TensorDictBase:
-        if self.num_streams == 1:
-            data = data.reshape(1, -1)
-        elif data.ndim != 2 or data.shape[0] != self.num_streams:
-            raise RuntimeError(
-                "Expected collector data with shape [num_streams, time], got "
-                f"{tuple(data.shape)} for {self.num_streams} streams."
-            )
-
-        records = []
-        record_keys = (
-            "action",
-            "is_init",
-            "state",
-            "belief",
-            ("next", "observation"),
-            ("next", "reward"),
-            ("next", "done"),
-            ("next", "terminated"),
-        )
-        for time_index in range(data.shape[1]):
-            collector_step = data[:, time_index]
-            reset = collector_step.get("is_init").reshape(self.num_streams, -1).any(-1)
-            insert_reset = reset if self._started else torch.zeros_like(reset)
-            if insert_reset.any() and not insert_reset.all():
-                raise RuntimeError(
-                    "The 2D DreamerV3 replay stream requires synchronized episode "
-                    "resets across collector environments."
-                )
-
-            transition = collector_step.select(*record_keys, strict=True).clone()
-            # This record models the transition into next.observation, so it
-            # keeps its action; the separate reset record marks the reset.
-            transition.get("is_init").zero_()
-            transition.set(
-                _REPLAY_CONTEXT_VALID_KEY,
-                torch.ones_like(transition.get("is_init"), dtype=torch.bool),
-            )
-
-            if insert_reset.any():
-                reset_transition = transition.clone()
-                for key in (
-                    "action",
-                    "state",
-                    "belief",
-                    ("next", "reward"),
-                    ("next", "done"),
-                    ("next", "terminated"),
-                ):
-                    reset_transition.get(key).zero_()
-                reset_transition.get("is_init").fill_(True)
-                reset_transition.set(
-                    ("next", "observation"),
-                    collector_step.get("observation").clone(),
-                )
-                records.append(reset_transition)
-
-            records.append(transition)
-            self._started = True
-
-        return torch.stack(records, 1)
-
-
-class DreamerV3ShiftedRecordExtender:
-    """Keep a placeholder record for the posterior of the newest transition.
-
-    The next collector batch completes it in place, at the same slot.
-    """
-
-    def __init__(self, num_streams: int):
-        self.num_streams = num_streams
-        self._tail_index: torch.Tensor | None = None
-        self._tail_generation: torch.Tensor | None = None
-
-    @staticmethod
-    def _tail_placeholder(records: TensorDictBase) -> TensorDictBase:
-        tail = records[:, -1].clone()
-        tail.get("action").zero_()
-        tail.get("is_init").zero_()
-        tail.get("state").zero_()
-        tail.get("belief").zero_()
-        tail.get(("next", "reward")).zero_()
-        tail.get(("next", "done")).zero_()
-        tail.get(("next", "terminated")).zero_()
-        tail.get(_REPLAY_CONTEXT_VALID_KEY).zero_()
-        return tail.unsqueeze(1)
-
-    def _finalize_tail(
-        self, replay_buffer: ReplayBuffer, records: TensorDictBase
-    ) -> None:
-        tail_index = self._tail_index
-        tail_generation = self._tail_generation
-        if tail_index is None or tail_generation is None:
-            return
-
-        storage = replay_buffer.storage
-        stored = (
-            storage[tail_index]
-            if storage.ndim == 1
-            else storage[tuple(tail_index.unbind(-1))]
-        )
-        incoming = records[:, 0].clone().to(stored.device)
-        context_valid = stored.get(_REPLAY_CONTEXT_VALID_KEY)
-        incoming.set(
-            "state",
-            torch.where(context_valid, stored.get("state"), incoming.get("state")),
-        )
-        incoming.set(
-            "belief",
-            torch.where(context_valid, stored.get("belief"), incoming.get("belief")),
-        )
-        incoming.set(
-            _REPLAY_CONTEXT_VALID_KEY,
-            torch.ones_like(context_valid, dtype=torch.bool),
-        )
-        result = replay_buffer.update_if_present(
-            index=tail_index,
-            generation=tail_generation,
-            patch=incoming,
-        )
-        if result.updated_count != self.num_streams:
-            raise RuntimeError(
-                "The mutable DreamerV3 replay tail was recycled before it "
-                "could be finalized."
-            )
-
-    def extend(
-        self,
-        replay_buffer: ReplayBuffer,
-        replay_sampler: DreamerV3ReplaySampler,
-        records: TensorDictBase,
-    ) -> torch.Tensor:
-        if records.ndim != 2 or records.shape[0] != self.num_streams:
-            raise RuntimeError(
-                "Expected replay records with shape [num_streams, time], got "
-                f"{tuple(records.shape)} for {self.num_streams} streams."
-            )
-        self._finalize_tail(replay_buffer, records)
-        placeholder = self._tail_placeholder(records)
-        if self._tail_index is None:
-            appended = torch.cat([records, placeholder], 1)
-        else:
-            appended = torch.cat([records[:, 1:], placeholder], 1)
-        replay_indices = replay_buffer.extend(
-            appended if self.num_streams > 1 else appended.reshape(-1)
-        )
-        replay_sampler.observe_extend(replay_indices, replay_buffer.storage)
-
-        coordinates = torch.as_tensor(replay_indices, dtype=torch.long).reshape(
-            appended.shape[1], self.num_streams, replay_buffer.storage.ndim
-        )
-        tail_index = coordinates[-1]
-        if replay_buffer.storage.ndim == 1:
-            tail_index = tail_index[:, 0]
-        self._tail_index = tail_index.clone()
-        self._tail_generation = replay_buffer.writer.generations_of(
-            self._tail_index
-        ).clone()
-        return replay_indices
-
-
-class DreamerV3ReplaySampler(SliceSampler):
-    """Slice sampler that takes the oldest queued blocks before uniform ones."""
-
-    def __init__(self, *args, online: bool = True, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.online = online
-        self._stream_lengths: torch.Tensor | None = None
-        self._online_queue: list[torch.Tensor] = []
-
-    @property
-    def online_queue_size(self) -> int:
-        return len(self._online_queue)
-
-    def observe_extend(self, index: torch.Tensor, storage: LazyTensorStorage) -> None:
-        """Queue the start of each new, non-overlapping ``slice_len`` block."""
-        if not self.online:
-            return
-        index = torch.as_tensor(index, dtype=torch.long)
-        if storage.ndim == 1:
-            coordinates = index.reshape(-1, 1, 1)
-            num_streams = 1
-        else:
-            num_streams = storage.shape[1:].numel()
-            coordinates = index.reshape(-1, num_streams, storage.ndim)
-        if self._stream_lengths is None:
-            self._stream_lengths = torch.zeros(num_streams, dtype=torch.long)
-        elif self._stream_lengths.numel() != num_streams:
-            raise RuntimeError(
-                "The number of replay streams changed after initialization."
-            )
-
-        max_time = storage._max_size_along_dim0()
-        for coordinate_row in coordinates:
-            self._stream_lengths.add_(1)
-            enqueue = (self._stream_lengths > self.slice_len) & (
-                (self._stream_lengths - 1).remainder(self.slice_len) == 0
-            )
-            if enqueue.any():
-                starts = coordinate_row[enqueue].clone()
-                starts[:, 0].sub_(self.slice_len - 1).remainder_(max_time)
-                self._online_queue.extend(starts.unbind(0))
-
-    def _drop_stale_online(self, storage: LazyTensorStorage, seq_length: int) -> None:
-        """Drop queued starts whose ``seq_length`` window is no longer stored."""
-        if not self._online_queue or not storage._is_full:
-            return
-        stored_time = storage.shape[0]
-        oldest = (int(storage._last_cursor_index) + 1) % stored_time
-        live = stored_time - seq_length + 1
-        self._online_queue = [
-            start
-            for start in self._online_queue
-            if (int(start[0]) - oldest) % stored_time < live
-        ]
-
-    def sample(
-        self, storage: LazyTensorStorage, batch_size: int
-    ) -> tuple[tuple[torch.Tensor, ...], dict]:
-        seq_length, num_slices = self._adjusted_batch_size(batch_size)
-        self._drop_stale_online(storage, seq_length)
-        # Each sequence of a batch takes one online block if the queue has one.
-        num_online = min(num_slices, len(self._online_queue))
-        num_uniform = num_slices - num_online
-        if storage.ndim > 2:
-            raise RuntimeError("DreamerV3 continuous replay supports 1D or 2D storage.")
-        if num_uniform:
-            stored_time = storage.shape[0]
-            num_starts = stored_time - seq_length + 1
-            if num_starts < 1:
-                raise RuntimeError(
-                    f"Replay streams have length {stored_time}, but sampling "
-                    f"requires {seq_length} records."
-                )
-            num_streams = 1 if storage.ndim == 1 else storage.shape[1]
-            flat_start = torch.randint(
-                num_starts * num_streams,
-                (num_uniform,),
-                generator=self._rng,
-            )
-            relative_time = flat_start.div(num_streams, rounding_mode="floor")
-            stream = flat_start.remainder(num_streams)
-            oldest_time = (
-                (int(storage._last_cursor_index) + 1) % stored_time
-                if storage._is_full
-                else 0
-            )
-            start_time = (relative_time + oldest_time).remainder(stored_time)
-            if storage.ndim == 1:
-                uniform_starts = start_time.unsqueeze(-1)
-            else:
-                uniform_starts = torch.stack([start_time, stream], -1)
-            uniform_coordinates = self._tensor_slices_from_startend(
-                seq_length,
-                uniform_starts,
-                stored_time,
-            ).reshape(num_uniform, seq_length, storage.ndim)
-            index_device = uniform_starts.device
-        else:
-            uniform_coordinates = None
-            index_device = self._online_queue[0].device
-
-        if num_online:
-            online_starts = torch.stack(
-                [self._online_queue.pop(0) for _ in range(num_online)]
-            ).to(index_device)
-            online_coordinates = self._tensor_slices_from_startend(
-                seq_length,
-                online_starts,
-                storage.shape[0],
-            ).reshape(num_online, seq_length, storage.ndim)
-        else:
-            online_coordinates = None
-        coordinates = torch.cat(
-            [
-                candidate
-                for candidate in (online_coordinates, uniform_coordinates)
-                if candidate is not None
-            ],
-            0,
-        )
-        return coordinates.reshape(-1, storage.ndim).unbind(-1), {}
-
-    def _empty(self) -> None:
-        super()._empty()
-        self._stream_lengths = None
-        self._online_queue.clear()

--- a/sota-implementations/dreamer_v3/dreamer_v3_utils.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_utils.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Run logging, RNG streams and evaluation of the DreamerV3 example."""
+
 from __future__ import annotations
 
 import importlib.util
@@ -14,7 +15,6 @@ import torch
 from omegaconf import DictConfig
 from tensordict import TensorDictBase
 from tensordict.nn import TensorDictModuleBase
-
 from torchrl._utils import logger as torchrl_logger
 from torchrl.envs import EnvBase
 from torchrl.envs.utils import ExplorationType, set_exploration_type
@@ -62,6 +62,22 @@ def training_episode_returns(
 ) -> list[tuple[int, int, float]]:
     reward = data.get(("next", "reward")).squeeze(-1)
     done = data.get(("next", "done")).squeeze(-1)
+    env_index = data.get("env_index", default=None)
+    if env_index is not None:
+        completed = []
+        for position, (env, step_reward, step_done) in enumerate(
+            zip(
+                env_index.reshape(-1).cpu(),
+                reward.reshape(-1).cpu(),
+                done.reshape(-1).cpu(),
+            )
+        ):
+            env = int(env)
+            running_return[env].add_(step_reward)
+            if step_done:
+                completed.append((position, env, float(running_return[env])))
+                running_return[env] = 0
+        return completed
     if num_envs == 1:
         reward = reward.reshape(1, -1)
         done = done.reshape(1, -1)

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -15,15 +15,17 @@ Usage::
     python sota-implementations/dreamer_v3/train.py \\
         --config-name=config_dmc_walker
 """
+
 from __future__ import annotations
 
 import copy
+import functools as ft
+from collections.abc import Callable
 from pathlib import Path
 from typing import NamedTuple
 
 import hydra
 import torch
-
 from dreamer_v3_agent import (
     build_actor,
     build_continuation_model,
@@ -39,12 +41,9 @@ from dreamer_v3_agent import (
 )
 from dreamer_v3_replay import (
     collector_action_budget,
-    DreamerV3ReplayPipeline,
-    DreamerV3ReplayRecordBuilder,
-    DreamerV3ReplaySampler,
-    DreamerV3ShiftedRecordExtender,
     DreamerV3UpdateRatio,
     driver_step_for_action,
+    replay_context_update,
 )
 from dreamer_v3_utils import (
     append_jsonl,
@@ -62,10 +61,18 @@ from tensordict import TensorDict, TensorDictBase
 from tensordict.nn import CudaGraphModule, TensorDictModuleBase
 from torchrl import timeit
 from torchrl._utils import get_available_device, logger as torchrl_logger
-from torchrl.collectors import Collector
-from torchrl.data import LazyTensorStorage, ReplayBuffer, RoundRobinWriter
-from torchrl.envs import SerialEnv
+from torchrl.collectors import AsyncBatchedCollector, Collector
+from torchrl.data import (
+    LazyTensorStorage,
+    ReplayBufferEnsemble,
+    SliceSampler,
+    StreamingSliceSampler,
+    TensorDictReplayBuffer,
+    TensorDictRoundRobinWriter,
+)
+from torchrl.envs import SelectTransform, SerialEnv
 from torchrl.envs.utils import ExplorationType
+from torchrl.modules.inference_server import InferenceDeviceConfig
 from torchrl.objectives import (
     DreamerV3ActorLoss,
     DreamerV3ModelLoss,
@@ -105,6 +112,9 @@ class _LearnerUpdate:
         self.value_target_updater = learner.value_target_updater
         self.state_dim = latent_state_dim(cfg)
         self.use_bfloat16 = cfg.optimization.mixed_precision and device.type == "cuda"
+        self._cudagraph_warmup_remaining = (
+            cudagraph_warmup if cfg.optimization.cudagraph_train_step else 0
+        )
         train_step = self._forward_backward
         if cfg.optimization.cudagraph_train_step:
             if device.type != "cuda":
@@ -117,6 +127,11 @@ class _LearnerUpdate:
                 device=device,
             )
         self.train_step = train_step
+
+    @property
+    def replay_must_be_idle(self) -> bool:
+        """Whether replay work must finish before the next learner call."""
+        return self._cudagraph_warmup_remaining > 0
 
     def _forward_backward(
         self,
@@ -201,6 +216,8 @@ class _LearnerUpdate:
         sample: TensorDictBase,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         result = self.train_step(sample)
+        if self._cudagraph_warmup_remaining:
+            self._cudagraph_warmup_remaining -= 1
         self.optimizer.step()
         self.value_target_updater.step()
         return result
@@ -210,7 +227,12 @@ def _validated_action_budget(cfg: DictConfig) -> int:
     num_envs = cfg.collector.num_envs
     if num_envs <= 0:
         raise ValueError(f"collector.num_envs must be positive, got {num_envs}.")
-    if cfg.collector.frames_per_batch % num_envs:
+    if cfg.collector.backend not in ("sync", "async"):
+        raise ValueError(
+            "collector.backend must be 'sync' or 'async', got "
+            f"{cfg.collector.backend!r}."
+        )
+    if cfg.collector.backend == "sync" and cfg.collector.frames_per_batch % num_envs:
         raise ValueError(
             "collector.frames_per_batch must be divisible by collector.num_envs, "
             f"got {cfg.collector.frames_per_batch} and {num_envs}."
@@ -339,10 +361,18 @@ def _build_collection(
     state_dim: int,
     action_dim: int,
     collector_action_frames: int,
-) -> tuple[Collector, DreamerV3BehaviorPolicySync | None]:
+    replay_buffer: ReplayBufferEnsemble,
+    post_collect_hook: Callable[[TensorDictBase], None],
+) -> tuple[Collector | AsyncBatchedCollector, DreamerV3BehaviorPolicySync | None]:
     num_envs = cfg.collector.num_envs
+    collector_backend = cfg.collector.backend
+    if collector_backend not in ("sync", "async"):
+        raise ValueError(
+            "collector.backend must be 'sync' or 'async', got "
+            f"{collector_backend!r}."
+        )
     real_world_actor = learner.real_world_actor
-    if cfg.optimization.deferred_policy_sync:
+    if cfg.optimization.deferred_policy_sync and collector_backend == "sync":
         collector_actor = copy.deepcopy(real_world_actor)
         # The decoder cannot act, but the reference syncs both parameter trees.
         behavior_decoder = copy.deepcopy(learner.world_model[2])
@@ -353,6 +383,11 @@ def _build_collection(
         behavior_policy_sync = DreamerV3BehaviorPolicySync(
             learner_policy_tree, behavior_policy_tree
         )
+    elif collector_backend == "async":
+        # The inference server owns a separate actor that is refreshed through
+        # the collector's synchronized policy-update path after each train batch.
+        collector_actor = copy.deepcopy(real_world_actor)
+        behavior_policy_sync = None
     else:
         collector_actor = real_world_actor
         behavior_policy_sync = None
@@ -361,34 +396,67 @@ def _build_collection(
         if cfg.optimization.separate_policy_rng
         else collector_actor
     )
-
-    def make_explore_env(index: int):
-        seed = cfg.env.seed + 2 + index if cfg.env.use_seed else None
-        return make_primed_env(cfg, seed, state_dim, action_dim)
-
-    if num_envs == 1:
-        explore_env = make_explore_env(0)
-    else:
-        explore_env = SerialEnv(
-            num_envs,
-            [
-                (lambda index=index: make_explore_env(index))
-                for index in range(num_envs)
-            ],
+    create_env_fns = [
+        ft.partial(
+            make_primed_env,
+            cfg,
+            cfg.env.seed + 2 + index if cfg.env.use_seed else None,
+            state_dim,
+            action_dim,
         )
-
-    collector = Collector(
-        explore_env,
-        collector_policy,
-        frames_per_batch=cfg.collector.frames_per_batch,
-        total_frames=collector_action_frames,
-        policy_device=device,
-        env_device="cpu",
-        storing_device="cpu",
-        exploration_type=ExplorationType.RANDOM
-        if cfg.collector.exploration == "random"
-        else ExplorationType.MODE,
+        for index in range(num_envs)
+    ]
+    replay_postproc = SelectTransform(
+        "action",
+        "is_init",
+        "state",
+        "belief",
+        "env_index",
+        ("next", "observation"),
+        ("next", "reward"),
+        ("next", "done"),
+        ("next", "terminated"),
+        ("next", "truncated"),
+        keep_rewards=False,
+        keep_dones=False,
     )
+
+    collector_kwargs = {
+        "frames_per_batch": cfg.collector.frames_per_batch,
+        "total_frames": collector_action_frames,
+        "postproc": replay_postproc,
+        "post_collect_hook": post_collect_hook,
+        "replay_buffer": replay_buffer,
+    }
+    if collector_backend == "async":
+        collector = AsyncBatchedCollector(
+            create_env_fns,
+            policy=collector_policy,
+            max_batch_size=num_envs,
+            env_backend=cfg.collector.async_env_backend,
+            device_config=InferenceDeviceConfig(
+                policy_device=device,
+                output_device="cpu",
+                env_device="cpu",
+                storing_device="cpu",
+            ),
+            policy_version_key=None,
+            **collector_kwargs,
+        )
+    else:
+        collector = Collector(
+            SerialEnv(num_envs, create_env_fns),
+            collector_policy,
+            policy_device=device,
+            env_device="cpu",
+            storing_device="cpu",
+            exploration_type=(
+                ExplorationType.RANDOM
+                if cfg.collector.exploration == "random"
+                else ExplorationType.MODE
+            ),
+            **collector_kwargs,
+        )
     if cfg.optimization.separate_policy_rng:
         # The collector's construction-time policy call is not an action.
         collector_policy.reset_counter()
@@ -396,46 +464,45 @@ def _build_collection(
 
 
 def _build_replay(
-    cfg: DictConfig, num_envs: int, replay_device: torch.device
-) -> tuple[
-    ReplayBuffer,
-    DreamerV3ReplaySampler,
-    DreamerV3ReplayRecordBuilder,
-    DreamerV3ShiftedRecordExtender | None,
-    DreamerV3ReplayPipeline,
-]:
-    replay_sampler = DreamerV3ReplaySampler(
-        # The extra record receives the last refreshed posterior.
-        slice_len=cfg.replay_buffer.seq_len + 1,
-        online=cfg.replay_buffer.online,
-    )
-    rb = ReplayBuffer(
-        storage=LazyTensorStorage(
-            max_size=cfg.replay_buffer.buffer_size,
-            ndim=2 if num_envs > 1 else 1,
-            device=replay_device,
-        ),
-        dim_extend=1 if num_envs > 1 else 0,
-        writer=RoundRobinWriter(track_generations=True),
-        sampler=replay_sampler,
-        batch_size=cfg.replay_buffer.batch_size * (cfg.replay_buffer.seq_len + 1),
+    cfg: DictConfig,
+    num_envs: int,
+    replay_device: torch.device,
+    device: torch.device,
+) -> ReplayBufferEnsemble:
+    sequence_records = cfg.replay_buffer.seq_len + 1
+    base_capacity, remainder = divmod(cfg.replay_buffer.buffer_size, num_envs)
+    capacities = [base_capacity + (index < remainder) for index in range(num_envs)]
+    if min(capacities) < sequence_records:
+        raise ValueError(
+            f"replay_buffer.buffer_size={cfg.replay_buffer.buffer_size} split "
+            f"across {num_envs} streams cannot hold one {sequence_records}-record "
+            "sequence per stream."
+        )
+
+    sampler_type = StreamingSliceSampler if cfg.replay_buffer.online else SliceSampler
+    members = [
+        TensorDictReplayBuffer(
+            storage=LazyTensorStorage(capacity, device=replay_device),
+            sampler=sampler_type(
+                slice_len=sequence_records,
+                end_key=("next", "done"),
+            ),
+            writer=TensorDictRoundRobinWriter(track_generations=True),
+        )
+        for capacity in capacities
+    ]
+    return ReplayBufferEnsemble(
+        *members,
+        p="sampleable",
+        num_buffer_sampled=cfg.replay_buffer.batch_size,
+        routing_key="env_index" if cfg.collector.backend == "async" else None,
+        routing_dim=0 if cfg.collector.backend == "sync" else None,
+        batch_size=cfg.replay_buffer.batch_size * sequence_records,
         generator=torch.Generator().manual_seed(
             stream_seed(cfg.env.seed, 0, REPLAY_RNG_STREAM)
         ),
-    )
-    replay_record_builder = DreamerV3ReplayRecordBuilder(num_envs)
-    shifted_record_extender = (
-        DreamerV3ShiftedRecordExtender(num_envs)
-        if cfg.collector.count_reset_records
-        else None
-    )
-    replay_pipeline = DreamerV3ReplayPipeline()
-    return (
-        rb,
-        replay_sampler,
-        replay_record_builder,
-        shifted_record_extender,
-        replay_pipeline,
+        pin_memory=replay_device.type == "cpu" and device.type == "cuda",
+        prefetch=1,
     )
 
 
@@ -444,10 +511,21 @@ def _log_train_episodes(
     metrics_jsonl_path: Path | None,
     completed_episodes: list[tuple[int, int, float]],
     batch_start_action_step: int,
+    batch_start_record_step: int,
+    batch_reset_prefix: list[int],
 ) -> None:
     num_envs = cfg.collector.num_envs
     for time_index, env_index, score in completed_episodes:
-        if cfg.collector.count_reset_records:
+        if cfg.collector.backend == "async":
+            episode_step = batch_start_action_step + time_index + 1
+            if cfg.collector.count_reset_records:
+                episode_step = (
+                    batch_start_record_step
+                    + time_index
+                    + 1
+                    + batch_reset_prefix[time_index]
+                )
+        elif cfg.collector.count_reset_records:
             action_index = batch_start_action_step // num_envs + time_index + 1
             episode_step = driver_step_for_action(
                 action_index,
@@ -516,8 +594,9 @@ def _evaluate(
     latest_losses: torch.Tensor,
 ) -> torch.Tensor:
     # Evaluation samples RSSM latents, thus a fork keeps training unchanged.
-    with timeit("dreamer_v3/evaluation"), torch.random.fork_rng(
-        devices=[device] if device.type == "cuda" else []
+    with (
+        timeit("dreamer_v3/evaluation"),
+        torch.random.fork_rng(devices=[device] if device.type == "cuda" else []),
     ):
         r = eval_episode_reward(
             eval_env,
@@ -580,6 +659,7 @@ def main(cfg: DictConfig):
     real_env = make_env(cfg, cfg.env.seed)
     obs_dim = real_env.observation_spec["observation"].shape[0]
     action_dim = real_env.action_spec.shape[0]
+    real_env.close()
     state_dim = latent_state_dim(cfg)
     metrics_jsonl_path = (
         Path(cfg.logger.metrics_jsonl).resolve() if cfg.logger.metrics_jsonl else None
@@ -592,23 +672,54 @@ def main(cfg: DictConfig):
 
     learner = _build_learner(cfg, device, obs_dim, action_dim)
     learner_update = _LearnerUpdate(cfg, device, learner)
-
-    collector, behavior_policy_sync = _build_collection(
-        cfg, device, learner, state_dim, action_dim, collector_action_frames
-    )
-    (
-        rb,
-        replay_sampler,
-        replay_record_builder,
-        shifted_record_extender,
-        replay_pipeline,
-    ) = _build_replay(cfg, num_envs, replay_device)
-
+    rb = _build_replay(cfg, num_envs, replay_device, device)
     action_step = 0
-    # Each worker sends a reset record before its first control transition.
-    record_step = num_envs if count_reset_records else 0
+    reset_records = num_envs
+    record_step = reset_records if count_reset_records else 0
     update_step = 0
     running_training_return = torch.zeros(num_envs)
+    seen_stream = torch.zeros(num_envs, dtype=torch.bool)
+    completed_episodes: list[tuple[int, int, float]] = []
+    batch_reset_prefix: list[int] = []
+
+    def post_collect_hook(data: TensorDictBase) -> None:
+        nonlocal reset_records
+        completed_episodes.clear()
+        completed_episodes.extend(
+            training_episode_returns(data, running_training_return, num_envs)
+        )
+        if not count_reset_records:
+            return
+        is_init = data.get("is_init").reshape(-1).cpu()
+        env_index = data.get("env_index", default=None)
+        if env_index is None:
+            env_index = torch.arange(num_envs).reshape(num_envs, 1)
+            env_index = env_index.expand(data.batch_size).reshape(-1)
+        else:
+            env_index = env_index.reshape(-1).cpu()
+        batch_reset_prefix.clear()
+        batch_resets = 0
+        for stream, reset in zip(env_index, is_init):
+            if reset:
+                stream = int(stream)
+                if seen_stream[stream]:
+                    reset_records += 1
+                    batch_resets += 1
+                else:
+                    seen_stream[stream] = True
+            batch_reset_prefix.append(batch_resets)
+
+    collector, behavior_policy_sync = _build_collection(
+        cfg,
+        device,
+        learner,
+        state_dim,
+        action_dim,
+        collector_action_frames,
+        rb,
+        post_collect_hook,
+    )
+
     history_steps: list[int] = []
     history_eval: list[torch.Tensor] = []
     loss_history: list[torch.Tensor] = []
@@ -641,119 +752,138 @@ def main(cfg: DictConfig):
         # Keep the learner draws in a range apart from the policy stream.
         torch.manual_seed(stream_seed(cfg.env.seed, 0, LEARNER_RNG_STREAM))
 
-    for data in collector:
-        # The next action is already computed, thus it keeps the older policy.
-        if behavior_policy_sync is not None:
-            behavior_policy_sync.apply_after_action()
-        batch_start_action_step = action_step
-        completed_episodes = training_episode_returns(
-            data, running_training_return, num_envs
-        )
-        _log_train_episodes(
-            cfg, metrics_jsonl_path, completed_episodes, batch_start_action_step
-        )
-        replay_data = replay_record_builder(data)
-        with timeit("dreamer_v3/replay_extend"):
-            if shifted_record_extender is not None:
-                shifted_record_extender.extend(rb, replay_sampler, replay_data)
-            else:
-                replay_indices = rb.extend(
-                    replay_data if num_envs > 1 else replay_data.reshape(-1)
-                )
-                replay_sampler.observe_extend(replay_indices, rb.storage)
-        if (
-            not replay_pipeline.has_prefetched
-            and update_step == 0
-            and len(rb) >= num_envs * (cfg.replay_buffer.seq_len + 1)
-        ):
-            # Prefetch one batch ahead of the learner warmup gate below.
-            with timeit("dreamer_v3/replay_sample"):
-                replay_pipeline.prefetch(rb)
-        action_step += data.numel()
-        record_step += replay_data.numel() if count_reset_records else data.numel()
-
-        if len(rb) < warmup:
-            continue
-
-        batch_updates = (
-            update_ratio(record_step) if update_ratio is not None else updates_per_batch
-        )
-        if not batch_updates:
-            continue
-
-        if behavior_policy_sync is not None:
-            # Stage one time per batch; more updates keep the pending snapshot.
-            behavior_policy_sync.stage_before_training()
-
-        batch_losses = torch.empty((batch_updates, 6), device=device)
-        for update_index in range(batch_updates):
-            with timeit("dreamer_v3/replay_sample"):
-                replay_sample, sample_info = replay_pipeline.take(rb)
-                replay_sample = replay_sample.reshape(
-                    cfg.replay_buffer.batch_size,
-                    cfg.replay_buffer.seq_len + 1,
-                )
-                sample = replay_sample[:, :-1].to(device)
-            with timeit("dreamer_v3/replay_update"):
-                # Apply the older refresh, thus replay stays one sample ahead.
-                replay_pipeline.apply_pending_context(rb)
-            with timeit("dreamer_v3/train_update"):
-                (
-                    update_losses,
-                    refreshed_state,
-                    refreshed_belief,
-                ) = learner_update(sample)
-                batch_losses[update_index].copy_(update_losses)
-                loss_window_sum += update_losses
-                loss_window_updates += 1
-            with timeit("dreamer_v3/replay_update"):
-                replay_pipeline.stage_context(
-                    sample_info,
-                    refreshed_state,
-                    refreshed_belief,
-                )
-            update_step += 1
-
-        if record_loss_history:
-            loss_history.append(batch_losses.cpu())
-
-        train_log_due = bool(
-            metrics_jsonl_path is not None
-            and cfg.logger.train_every
-            and (
-                record_step >= next_train_log or action_step >= collector_action_frames
+    try:
+        for _ in collector:
+            # The collector writes canonical transitions directly into replay.
+            if behavior_policy_sync is not None:
+                behavior_policy_sync.apply_after_action()
+            batch_start_action_step = action_step
+            batch_start_record_step = record_step
+            action_step = int(collector.stats()["frames"])
+            record_step = (
+                action_step + reset_records if count_reset_records else action_step
             )
-        )
-        eval_due = bool(cfg.logger.eval_every and record_step >= next_eval)
-        latest_losses = batch_losses[-1].cpu() if eval_due else None
-        if train_log_due:
-            _log_train_window(
-                cfg=cfg,
-                metrics_jsonl_path=metrics_jsonl_path,
-                run_timer=run_timer,
-                record_step=record_step,
-                update_step=update_step,
-                loss_window_sum=loss_window_sum,
-                loss_window_updates=loss_window_updates,
+            _log_train_episodes(
+                cfg,
+                metrics_jsonl_path,
+                completed_episodes,
+                batch_start_action_step,
+                batch_start_record_step,
+                batch_reset_prefix,
             )
-            loss_window_sum.zero_()
-            loss_window_updates = 0
-            next_train_log = record_step + cfg.logger.train_every
 
-        if eval_due:
-            r = _evaluate(
-                cfg=cfg,
-                device=device,
-                eval_env=eval_env,
-                real_world_actor=learner.real_world_actor,
-                metrics_jsonl_path=metrics_jsonl_path,
-                run_timer=run_timer,
-                record_step=record_step,
-                latest_losses=latest_losses,
+            replay_stats = rb.stats()
+            if replay_stats["size"] < warmup or not rb.can_sample():
+                continue
+
+            batch_updates = (
+                update_ratio(record_step)
+                if update_ratio is not None
+                else updates_per_batch
             )
-            history_steps.append(record_step)
-            history_eval.append(r)
-            next_eval = record_step + cfg.logger.eval_every
+            if not batch_updates:
+                continue
+
+            if behavior_policy_sync is not None:
+                # Stage one time per batch; more updates keep the pending snapshot.
+                behavior_policy_sync.stage_before_training()
+
+            batch_losses = torch.empty((batch_updates, 6), device=device)
+            for update_index in range(batch_updates):
+                with timeit("dreamer_v3/replay_sample"):
+                    replay_sample = rb.sample().reshape(
+                        cfg.replay_buffer.batch_size,
+                        cfg.replay_buffer.seq_len + 1,
+                    )
+                    sample_info = replay_sample.select("index", "index_generation")
+                    sample = replay_sample.exclude("index", "index_generation")
+                    sample = sample.to(device, non_blocking=True)[:, :-1]
+                if learner_update.replay_must_be_idle:
+                    # CUDA graph capture rejects CUDA API calls from other threads.
+                    with timeit("dreamer_v3/replay_wait"):
+                        rb.synchronize()
+                with timeit("dreamer_v3/train_update"):
+                    (
+                        update_losses,
+                        refreshed_state,
+                        refreshed_belief,
+                    ) = learner_update(sample)
+                    batch_losses[update_index].copy_(update_losses)
+                    loss_window_sum += update_losses
+                    loss_window_updates += 1
+                if cfg.optimization.cudagraph_train_step:
+                    # CudaGraphModule reuses static output buffers across replays.
+                    refreshed_state = refreshed_state.clone()
+                    refreshed_belief = refreshed_belief.clone()
+                with timeit("dreamer_v3/replay_submit"):
+                    index, generation, patch = replay_context_update(
+                        sample_info, refreshed_state, refreshed_belief
+                    )
+                    rb.submit_update_if_present(
+                        index=index,
+                        generation=generation,
+                        patch=patch,
+                    )
+                update_step += 1
+
+            if isinstance(collector, AsyncBatchedCollector):
+                policy_weights = learner.real_world_actor
+                if cfg.optimization.separate_policy_rng:
+                    policy_weights = TensorDict(
+                        {"module": TensorDict.from_module(policy_weights)}, []
+                    )
+                collector.update_policy_weights_(policy_weights)
+
+            if record_loss_history:
+                loss_history.append(batch_losses.cpu())
+
+            train_log_due = bool(
+                metrics_jsonl_path is not None
+                and cfg.logger.train_every
+                and (
+                    record_step >= next_train_log
+                    or action_step >= collector_action_frames
+                )
+            )
+            eval_due = bool(cfg.logger.eval_every and record_step >= next_eval)
+            latest_losses = batch_losses[-1].cpu() if eval_due else None
+            if train_log_due:
+                _log_train_window(
+                    cfg=cfg,
+                    metrics_jsonl_path=metrics_jsonl_path,
+                    run_timer=run_timer,
+                    record_step=record_step,
+                    update_step=update_step,
+                    loss_window_sum=loss_window_sum,
+                    loss_window_updates=loss_window_updates,
+                )
+                loss_window_sum.zero_()
+                loss_window_updates = 0
+                next_train_log = record_step + cfg.logger.train_every
+
+            if eval_due:
+                r = _evaluate(
+                    cfg=cfg,
+                    device=device,
+                    eval_env=eval_env,
+                    real_world_actor=learner.real_world_actor,
+                    metrics_jsonl_path=metrics_jsonl_path,
+                    run_timer=run_timer,
+                    record_step=record_step,
+                    latest_losses=latest_losses,
+                )
+                history_steps.append(record_step)
+                history_eval.append(r)
+                next_eval = record_step + cfg.logger.eval_every
+
+    finally:
+        try:
+            collector.shutdown()
+        finally:
+            try:
+                eval_env.close()
+            finally:
+                rb.shutdown()
 
     if cfg.logger.output_plot:
         save_run_plot(cfg, history_steps, history_eval, loss_history)

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -6,6 +6,7 @@
 
 Reference: https://arxiv.org/abs/2301.04104
 """
+
 from __future__ import annotations
 
 import copy
@@ -29,8 +30,7 @@ from tensordict.nn import (
     TensorDictSequential,
 )
 from torch import nn
-
-from torchrl.data import Unbounded
+from torchrl.data import SliceSampler, StreamingSliceSampler, Unbounded
 from torchrl.envs.model_based.dreamer import DreamerEnv
 from torchrl.envs.transforms import TensorDictPrimer, TransformedEnv
 from torchrl.modules import SafeSequential, SymExpTwoHot, WorldModelWrapper
@@ -60,7 +60,7 @@ from torchrl.objectives.dreamer_v3 import (
     two_hot_encode,
 )
 from torchrl.objectives.utils import SoftUpdate, ValueEstimators
-from torchrl.testing import get_default_devices
+from torchrl.testing import get_default_devices, PENDULUM_VERSIONED
 from torchrl.testing.mocking_classes import ContinuousActionConvMockEnv
 from torchrl.trainers.algorithms import DreamerV3Optimizer
 
@@ -1287,6 +1287,36 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             if key.startswith(target_prefix)
         )
 
+        benchmark = runpy.run_path(
+            repo_root / "benchmarks/ad_hoc/bench_dreamer_v3_learner.py",
+            run_name="dreamer_v3_native_replay_cuda_graph_test",
+        )
+        cfg = make_config(True)
+        torch.manual_seed(0)
+        replay_learner = example["_build_learner"](cfg, device, 3, 1)
+        replay_update = example["_LearnerUpdate"](
+            cfg,
+            device,
+            replay_learner,
+            cudagraph_warmup=5,
+        )
+        replay_step = benchmark["_ReplayLearnerStep"](
+            example,
+            cfg,
+            replay_update,
+            device=device,
+            replay_device=torch.device("cpu"),
+            obs_dim=3,
+            action_dim=1,
+        )
+        try:
+            for _ in range(6):
+                replay_step()
+            replay_step.synchronize()
+            assert not replay_update.replay_must_be_idle
+        finally:
+            replay_step.close()
+
     @pytest.mark.skipif(not _has_omegaconf, reason="requires omegaconf")
     def test_dreamer_v3_dmc_benchmark_aggregation(self, device, tmp_path):
         from omegaconf import OmegaConf
@@ -1357,8 +1387,11 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         ):
             loss_module.value_model(online_td)
         target_td = tensordict.select(*value_model.in_keys, strict=False)
-        with torch.no_grad(), loss_module.target_value_model_params.to_module(
-            loss_module.value_model, preserve_module_state=False
+        with (
+            torch.no_grad(),
+            loss_module.target_value_model_params.to_module(
+                loss_module.value_model, preserve_module_state=False
+            ),
         ):
             loss_module.value_model(target_td)
         expected_slow_loss = two_hot_cross_entropy(
@@ -2003,6 +2036,194 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         assert prior_grad > 0, "Real prior received no gradient"
         assert posterior_grad > 0, "Real posterior received no gradient"
         assert B == 2 and T == 3
+
+
+@pytest.mark.skipif(
+    not (_has_hydra and _has_omegaconf and _has_gym),
+    reason="requires hydra, omegaconf, and gym",
+)
+@pytest.mark.parametrize("online", [False, True])
+@pytest.mark.parametrize("count_reset_records", [False, True])
+def test_dreamer_v3_native_stream_replay(monkeypatch, online, count_reset_records):
+    from omegaconf import OmegaConf
+
+    repo_root = Path(__file__).parents[2]
+    example_dir = repo_root / "sota-implementations/dreamer_v3"
+    monkeypatch.syspath_prepend(str(example_dir))
+    example = runpy.run_path(
+        example_dir / "train.py",
+        run_name=f"dreamer_v3_native_replay_{online}",
+    )
+    cfg = OmegaConf.load(example_dir / "config.yaml")
+    cfg.collector.num_envs = 2
+    cfg.collector.count_reset_records = count_reset_records
+    cfg.collector.total_frames = 16
+    cfg.collector.frames_per_batch = 4
+    cfg.env.max_episode_steps = 3
+    expected_action_budget = 12 if count_reset_records else 16
+    assert example["_validated_action_budget"](cfg) == expected_action_budget
+    cfg.replay_buffer.buffer_size = 15
+    cfg.replay_buffer.batch_size = 2
+    cfg.replay_buffer.seq_len = 2
+    cfg.replay_buffer.online = online
+    rb = example["_build_replay"](cfg, 2, torch.device("cpu"), torch.device("cpu"))
+    sampler_type = StreamingSliceSampler if online else SliceSampler
+    assert [rb[index].storage.max_size for index in range(2)] == [8, 7]
+    assert all(isinstance(rb[index].sampler, sampler_type) for index in range(2))
+
+    data = TensorDict(
+        {
+            "action": torch.arange(12).reshape(2, 6, 1).float(),
+            "is_init": torch.zeros(2, 6, 1, dtype=torch.bool),
+            "state": torch.zeros(2, 6, 4),
+            "belief": torch.zeros(2, 6, 5),
+            "next": {
+                "observation": torch.randn(2, 6, 3),
+                "reward": torch.randn(2, 6, 1),
+                "done": torch.zeros(2, 6, 1, dtype=torch.bool),
+                "terminated": torch.zeros(2, 6, 1, dtype=torch.bool),
+                "truncated": torch.zeros(2, 6, 1, dtype=torch.bool),
+            },
+        },
+        [2, 6],
+    )
+    data["is_init"][:, 0] = True
+    try:
+        rb.extend(data)
+        assert rb.stats()["write_count"] == 12
+        assert rb.can_sample()
+        sample = rb.sample().reshape(2, 3)
+        assert ("collector", "context_valid") not in sample.keys(True, True)
+        assert sample["is_init"].sum() <= 2
+        sample_info = sample.select("index", "index_generation")
+        index, generation, patch = example["replay_context_update"](
+            sample_info,
+            torch.ones(2, 2, 4),
+            torch.ones(2, 2, 5),
+        )
+        result = rb.submit_update_if_present(
+            index=index, generation=generation, patch=patch
+        ).result()
+        assert result.updated_count == index.numel()
+        assert any(rb[index][:]["state"].any() for index in range(2))
+        assert all(rb[index][:]["is_init"][0].all() for index in range(2))
+    finally:
+        rb.shutdown()
+
+
+@pytest.mark.skipif(not _has_omegaconf, reason="requires omegaconf")
+def test_dreamer_v3_replay_capacity_validation(monkeypatch):
+    from omegaconf import OmegaConf
+
+    repo_root = Path(__file__).parents[2]
+    example_dir = repo_root / "sota-implementations/dreamer_v3"
+    monkeypatch.syspath_prepend(str(example_dir))
+    example = runpy.run_path(
+        example_dir / "train.py", run_name="dreamer_v3_replay_capacity_test"
+    )
+    cfg = OmegaConf.load(example_dir / "config.yaml")
+    cfg.collector.num_envs = 2
+    cfg.replay_buffer.buffer_size = 7
+    cfg.replay_buffer.seq_len = 3
+    with pytest.raises(ValueError, match="cannot hold one 4-record sequence"):
+        example["_build_replay"](cfg, 2, torch.device("cpu"), torch.device("cpu"))
+
+
+@pytest.mark.skipif(
+    not (_has_hydra and _has_omegaconf and _has_gym),
+    reason="requires hydra, omegaconf, and gym",
+)
+def test_dreamer_v3_native_replay_benchmark_step_cpu(monkeypatch):
+    from omegaconf import OmegaConf
+
+    repo_root = Path(__file__).parents[2]
+    example_dir = repo_root / "sota-implementations/dreamer_v3"
+    monkeypatch.syspath_prepend(str(example_dir))
+    example = runpy.run_path(
+        example_dir / "train.py", run_name="dreamer_v3_replay_benchmark_cpu_test"
+    )
+    benchmark = runpy.run_path(
+        repo_root / "benchmarks/ad_hoc/bench_dreamer_v3_learner.py",
+        run_name="dreamer_v3_replay_benchmark_helpers_test",
+    )
+    cfg = OmegaConf.load(example_dir / "config.yaml")
+    cfg.replay_buffer.batch_size = 2
+    cfg.replay_buffer.seq_len = 3
+
+    class LearnerUpdate:
+        replay_must_be_idle = False
+
+        def __init__(self):
+            self.calls = 0
+
+        def __call__(self, sample):
+            self.calls += 1
+            assert sample.shape == (2, 3)
+            return (
+                torch.zeros(6),
+                sample["state"] + self.calls,
+                sample["belief"] + self.calls,
+            )
+
+    learner_update = LearnerUpdate()
+    step = benchmark["_ReplayLearnerStep"](
+        example,
+        cfg,
+        learner_update,
+        device=torch.device("cpu"),
+        replay_device=torch.device("cpu"),
+        obs_dim=3,
+        action_dim=1,
+    )
+    try:
+        step()
+        step()
+        step.synchronize()
+        assert learner_update.calls == 2
+        assert any(step.replay_buffer[index][:]["state"].any() for index in range(4))
+    finally:
+        step.close()
+
+
+@pytest.mark.skipif(
+    not (_has_hydra and _has_omegaconf and _has_gym),
+    reason="requires hydra, omegaconf, and gym",
+)
+@pytest.mark.parametrize(
+    ("collector_backend", "separate_policy_rng"),
+    [("sync", False), ("async", False), ("async", True)],
+)
+def test_dreamer_v3_native_replay_collection_smoke(
+    monkeypatch, collector_backend, separate_policy_rng
+):
+    from omegaconf import OmegaConf
+
+    repo_root = Path(__file__).parents[2]
+    example_dir = repo_root / "sota-implementations/dreamer_v3"
+    monkeypatch.syspath_prepend(str(example_dir))
+    example = runpy.run_path(
+        example_dir / "train.py",
+        run_name=f"dreamer_v3_native_replay_collection_{collector_backend}",
+    )
+    cfg = OmegaConf.load(example_dir / "config.yaml")
+    cfg.env.name = PENDULUM_VERSIONED()
+    cfg.optimization.separate_policy_rng = separate_policy_rng
+    cfg.optimization.device = "cpu"
+    cfg.optimization.updates_per_batch = 1
+    cfg.optimization.train_ratio = None
+    cfg.collector.backend = collector_backend
+    cfg.collector.num_envs = 2
+    cfg.collector.frames_per_batch = 8
+    cfg.collector.total_frames = 16
+    cfg.replay_buffer.buffer_size = 64
+    cfg.replay_buffer.batch_size = 2
+    cfg.replay_buffer.seq_len = 2
+    cfg.replay_buffer.warmup_factor = 1
+    cfg.logger.eval_every = 0
+    cfg.logger.train_every = 0
+    cfg.logger.output_plot = None
+    cfg.logger.metrics_jsonl = None
+    example["main"].__wrapped__(cfg)
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="requires bash")


### PR DESCRIPTION
DreamerV3 now uses native TorchRL replay throughout: one replay member per environment, synchronous routing by batch dimension and asynchronous routing by integer stream ID. Collectors insert canonical transitions in the parent; sampling returns T+1 records, training consumes T transitions and generation-checked context updates target the following rows. Reset records affect reporting and update scheduling without becoming artificial replay rows.

Depends on #4275 for parent-process collector replay insertion. The inference fixes and native ordered/streaming replay are merged into main. Whole-step compilation and eager warm-up before collection are adapted in #4268.

The previous script-owned replay worker, record builder, shifted writer and sampler are removed. Native replay owns ordered operations, future lifetime, errors, synchronization and shutdown. The full pinned batch is transferred before slicing, graph-backed outputs are cloned before asynchronous updates, and cleanup uses nested finally blocks.

Validation on the refreshed combined stack:
- Full CPU DreamerV3 objective suite: 82 passed, 3 GPU cases deselected.
- Native replay selection: 8 passed, including fresh/uniform sampling, reset accounting, capacity checks, CPU benchmark execution and real sync/async training smokes.
- Formatting, diff and complete outgoing code/metadata isolation audits pass.
- GPU captured learner, matched timing and integration validation are running in the dependent compile stack; performance readiness remains pending those results.

Final integration validation: 904 combined CPU inference/objective/replay tests passed. Eight real collection smoke cases pass on CPU and CUDA in the downstream generic SOTA integration. The seeded async policy update path and native replay schema are included. Six separate-process checkpoint/resume CUDA cases pass with the downstream checkpoint PR.

Oldest-dependency CI found a hard-coded Pendulum-v1 test assumption. Tests now use the existing version-aware Pendulum helper. All three native replay collection smoke cases pass against Gym 0.13; the downstream generic SOTA suite passes eight cases against the same backend. Production defaults are unchanged.

The base is #4275 (`codex/async-collector-replay`). The public optimizer extraction #4282 is merged, so a separate optimizer integration base is no longer needed. The example imports its optimizer from TorchRL core.

Validation after refreshing the stack onto main with #4297 merged (2026-09-08): the feature additions and removals are unchanged. The combined CPU DreamerV3, component, native-replay and config selection passed 394 tests, including separate-process checkpoint/resume. CUDA results and benchmark measurements above precede this restack; new CPU/GPU/dependency CI must validate the refreshed heads.
