### PR TITLE
[Feature] Add CPU affinity controls to AsyncEnvPool

### DIFF
--- a/benchmarks/test_envs_benchmark.py
+++ b/benchmarks/test_envs_benchmark.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import argparse
+import os
+import statistics
 import time
 from functools import partial
 
@@ -200,6 +202,14 @@ ASYNC_POOL_REGIME_TRANSITIONS = 2048
 ASYNC_POOL_REGIME_STEP_LATENCY = 1e-3
 ASYNC_POOL_REGIME_RESET_LATENCY = 0.2
 ASYNC_POOL_REGIME_EPISODE_STEPS = 200
+ASYNC_POOL_AFFINITY_MIN_CPUS = 16
+ASYNC_POOL_AFFINITY_ENVS = 32
+ASYNC_POOL_AFFINITY_TRANSITIONS = 2048
+ASYNC_POOL_AFFINITY_STEP_LATENCY = 1e-3
+
+_AFFINITY_CPUS = (
+    tuple(sorted(os.sched_getaffinity(0))) if hasattr(os, "sched_getaffinity") else ()
+)
 
 
 class DelayedCountingEnv(CountingEnv):
@@ -223,7 +233,14 @@ class DelayedCountingEnv(CountingEnv):
         return super()._reset(tensordict, **kwargs)
 
 
-def _make_async_pool(num_envs, exchange, step_latency, reset_latency, max_steps):
+def _make_async_pool(
+    num_envs,
+    exchange,
+    step_latency,
+    reset_latency,
+    max_steps,
+    worker_affinity=None,
+):
     pool = AsyncEnvPool(
         [
             partial(
@@ -236,6 +253,7 @@ def _make_async_pool(num_envs, exchange, step_latency, reset_latency, max_steps)
         * num_envs,
         backend="multiprocessing",
         exchange=exchange,
+        worker_affinity=worker_affinity,
     )
     # Prime the steady state: after this, every round starts with a recv.
     tensordict = pool.reset()
@@ -279,6 +297,38 @@ def _async_pool_harvest_per_env(pool, num_transitions):
         _, tensordict = pool.async_step_and_maybe_reset_recv(env_index=env_index)
         tensordict["action"] = torch.ones(1)
         pool.async_step_and_maybe_reset_send(tensordict, env_index=env_index)
+
+
+def _async_pool_step_latencies(pool, num_transitions):
+    # Drain every in-flight warm-up step, then send a fresh synchronized round
+    # so each observed latency has a precise dispatch timestamp.
+    _, td_next = pool.async_step_and_maybe_reset_recv(min_get=pool.num_envs)
+    td_next["action"] = torch.ones(pool.num_envs, 1)
+    sent_at = time.perf_counter()
+    pool.async_step_and_maybe_reset_send(td_next)
+    send_times = [sent_at] * pool.num_envs
+
+    latencies = []
+    while len(latencies) < num_transitions:
+        _, td_next = pool.async_step_and_maybe_reset_recv(
+            min_get=1, max_get=pool.num_envs
+        )
+        observed_at = time.perf_counter()
+        env_indices = td_next["env_index"]
+        if isinstance(env_indices, torch.Tensor):
+            env_indices = env_indices.reshape(-1).tolist()
+        else:
+            env_indices = [int(env_index) for env_index in env_indices]
+        latencies.extend(
+            observed_at - send_times[env_index] for env_index in env_indices
+        )
+
+        td_next["action"] = torch.ones(td_next.shape[0], 1)
+        sent_at = time.perf_counter()
+        pool.async_step_and_maybe_reset_send(td_next)
+        for env_index in env_indices:
+            send_times[env_index] = sent_at
+    return latencies[:num_transitions]
 
 
 @pytest.mark.parametrize("exchange", ["queue", "shm"])
@@ -363,6 +413,56 @@ def test_async_env_pool_fast_step_slow_reset(benchmark, exchange):
                 rounds=5,
                 warmup_rounds=1,
                 iterations=1,
+            )
+        finally:
+            pool._maybe_shutdown()
+
+
+@pytest.mark.skipif(
+    len(_AFFINITY_CPUS) < ASYNC_POOL_AFFINITY_MIN_CPUS,
+    reason="CPU-affinity jitter benchmark requires a many-core Linux host",
+)
+@pytest.mark.parametrize("pinned", [False, True], ids=["default", "pinned"])
+def test_async_env_pool_step_latency_jitter(benchmark, pinned):
+    """Track pool wall time and last-round latency with worker-only affinity.
+
+    ``pytest-benchmark`` measures each complete 2048-transition round. The
+    latency summary in ``extra_info`` describes only the samples returned by
+    the last of five measured rounds; the driver remains unpinned in both
+    variants.
+    """
+    num_envs = min(ASYNC_POOL_AFFINITY_ENVS, len(_AFFINITY_CPUS))
+    worker_affinity = [(cpu,) for cpu in _AFFINITY_CPUS[:num_envs]] if pinned else None
+    with set_capture_non_tensor_stack(False):
+        pool = _make_async_pool(
+            num_envs,
+            exchange="shm",
+            step_latency=ASYNC_POOL_AFFINITY_STEP_LATENCY,
+            reset_latency=0.0,
+            max_steps=10_000_000,
+            worker_affinity=worker_affinity,
+        )
+        try:
+            samples = benchmark.pedantic(
+                _async_pool_step_latencies,
+                args=(pool, ASYNC_POOL_AFFINITY_TRANSITIONS),
+                rounds=5,
+                warmup_rounds=1,
+                iterations=1,
+            )
+            samples_ms = sorted(sample * 1e3 for sample in samples)
+            benchmark.extra_info.update(
+                {
+                    "affinity": "pinned" if pinned else "default",
+                    "num_envs": num_envs,
+                    "transitions": ASYNC_POOL_AFFINITY_TRANSITIONS,
+                    "step_latency_mean_ms": statistics.fmean(samples_ms),
+                    "step_latency_stddev_ms": statistics.pstdev(samples_ms),
+                    "step_latency_p50_ms": samples_ms[len(samples_ms) // 2],
+                    "step_latency_p99_ms": samples_ms[
+                        min(len(samples_ms) - 1, int(len(samples_ms) * 0.99))
+                    ],
+                }
             )
         finally:
             pool._maybe_shutdown()

--- a/docs/source/reference/collectors_single.rst
+++ b/docs/source/reference/collectors_single.rst
@@ -138,6 +138,39 @@ The pause context finishes in-flight environment and policy requests, parks
 the coordinator threads, and leaves the inference server idle. Collection
 resumes automatically when the context exits.
 
+.. _async_batched_collector_cpu_affinity:
+
+On Linux, ``worker_affinity`` assigns CPU masks to the multiprocessing
+environment workers, while ``driver_affinity`` assigns one mask to the
+inference-server and coordinator threads, as well as the pool's parent-side
+queue feeder threads. Dedicated process-backed inference servers use a spawned
+process and are not covered by ``driver_affinity``. For example, with two
+driver CPUs followed by four two-CPU worker windows:
+
+.. code-block:: python
+
+    import os
+
+    available_cpus = sorted(os.sched_getaffinity(0))
+    driver_cpus = available_cpus[:2]
+    worker_cpus = available_cpus[2:10]
+    worker_masks = [
+        tuple(worker_cpus[start : start + 2])
+        for start in range(0, len(worker_cpus), 2)
+    ]
+    collector = AsyncBatchedCollector(
+        create_env_fn=[make_env] * len(worker_masks),
+        policy=policy,
+        frames_per_batch=200,
+        env_backend="multiprocessing",
+        driver_affinity=driver_cpus,
+        worker_affinity=worker_masks,
+    )
+
+Build both masks from the CPUs visible through ``os.sched_getaffinity(0)``.
+See :ref:`async_env_pool_cpu_affinity` for container cpuset, CFS quota, and
+Kubernetes CPU Manager considerations.
+
 **Key advantages over direct collection through** :class:`Collector`:
 
 - The inference server automatically **batches policy forward passes** from

--- a/docs/source/reference/envs_vectorized.rst
+++ b/docs/source/reference/envs_vectorized.rst
@@ -356,6 +356,65 @@ per-environment receives own their tensor storage. Aggregate batches returned
 with ``stack="lazy"`` are views over the shared slots and remain valid only until
 actions are sent back to the corresponding environments.
 
+.. _async_env_pool_cpu_affinity:
+
+CPU affinity (Linux)
+~~~~~~~~~~~~~~~~~~~~
+
+The multiprocessing backend accepts ``worker_affinity`` to restrict each
+environment worker to selected CPUs. Pass one CPU mask per environment or a
+callable that returns a mask for an environment index. The mask is applied
+before the environment factory runs, so subprocesses created by the factory
+inherit the worker's affinity.
+
+This option is intended for deployments where Python workers, CPU-heavy
+simulators, and driver services share a constrained CPU set. Without explicit
+placement, the scheduler may run them on the same CPUs, increasing contention
+and environment step-time jitter. Most applications should leave the option
+unset and use the operating system's scheduler.
+
+TorchRL can discover the CPUs available to the current process, but that set
+does not reveal which CPUs the application reserves for its driver or other
+services, nor how many threads each environment and its subprocesses require.
+An automatic partition would therefore impose an arbitrary workload policy and
+can reduce throughput. Affinity is explicit for that reason.
+
+.. code-block:: python
+
+    import os
+
+    available_cpus = sorted(os.sched_getaffinity(0))
+    worker_cpus = available_cpus[:8]
+    worker_masks = [
+        tuple(worker_cpus[start : start + 2])
+        for start in range(0, len(worker_cpus), 2)
+    ]
+    env = AsyncEnvPool(
+        [make_env] * len(worker_masks),
+        backend="multiprocessing",
+        exchange="queue",
+        worker_affinity=worker_masks,
+    )
+
+Every subprocess created by an environment factory inherits that worker's
+mask. A one-CPU mask therefore confines both the Python worker and all of its
+environment subprocesses to that single CPU; use a wider window when the
+environment launches CPU-parallel work.
+
+Affinity masks do not replace container resource configuration:
+
+- A process can only run on CPUs granted by its container or cgroup cpuset.
+  TorchRL validates each mask against ``os.sched_getaffinity(0)`` before
+  workers start; build masks from those currently available indices.
+- A CFS CPU quota limits CPU time, not CPU placement. Affinity neither bypasses
+  that quota nor reserves the selected CPUs, and pinning to fewer CPUs than the
+  quota can reduce usable parallelism.
+- In Kubernetes, exclusive container CPUs require the kubelet CPU Manager's
+  ``static`` policy, a ``Guaranteed`` pod, and integer CPU requests (with the
+  matching limits required for ``Guaranteed`` QoS). The resulting cpuset bounds
+  the masks accepted here; the application must still divide those assigned
+  CPUs between its workers and driver threads.
+
 .. note:: This class and its subclasses should work when nested in with :class:`~torchrl.envs.transforms.TransformedEnv` and
     batched environments, but users won't currently be able to use the async features of the base environment when
     it's nested in these classes. One should prefer nested transformed envs within an `AsyncEnvPool` instead.

--- a/test/envs/test_special.py
+++ b/test/envs/test_special.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import contextlib
+import os
 import pickle
 import threading
 import warnings
@@ -30,6 +31,7 @@ from torchrl.envs import (
     ConditionalSkip,
     EnvBase,
     ParallelEnv,
+    ProcessorAsyncEnvPool,
     SerialEnv,
 )
 from torchrl.envs.batched_envs import (
@@ -78,6 +80,10 @@ class _DelayedCountingEnv(CountingEnv):
     def _step(self, tensordict):
         threading.Event().wait(self.delay)
         return super()._step(tensordict)
+
+
+def _round_robin_affinity(env_index, *, cpus):
+    return (cpus[env_index % len(cpus)],)
 
 
 class _ManyKeysCountingEnv(CountingEnv):
@@ -910,6 +916,94 @@ class TestAsyncEnvPool:
             env.check_env_specs(break_when_any_done="both")
         finally:
             env._maybe_shutdown()
+
+    @pytest.mark.skipif(
+        not hasattr(os, "sched_setaffinity"),
+        reason="CPU affinity requires Linux",
+    )
+    def test_worker_affinity_callable(self, make_envs):
+        cpus = tuple(np.int64(cpu) for cpu in sorted(os.sched_getaffinity(0)))
+        affinity = partial(_round_robin_affinity, cpus=cpus)
+        env = AsyncEnvPool(
+            make_envs,
+            backend="multiprocessing",
+            exchange="queue",
+            worker_affinity=affinity,
+        )
+        try:
+            expected = [
+                {cpus[env_index % len(cpus)]} for env_index in range(env.num_envs)
+            ]
+            assert [
+                os.sched_getaffinity(process.pid) for process in env.threads
+            ] == expected
+        finally:
+            env._maybe_shutdown()
+
+    @pytest.mark.skipif(
+        not hasattr(os, "sched_setaffinity"),
+        reason="CPU affinity requires Linux",
+    )
+    def test_worker_affinity_rejects_unavailable_cpu(self, make_envs):
+        unavailable_cpu = max(os.sched_getaffinity(0)) + 1
+        with pytest.raises(
+            ValueError,
+            match=rf"worker_affinity\[0\].*unavailable.*{unavailable_cpu}",
+        ):
+            AsyncEnvPool(
+                make_envs,
+                backend="multiprocessing",
+                worker_affinity=[(unavailable_cpu,)] * len(make_envs),
+            )
+
+    @pytest.mark.skipif(
+        not hasattr(os, "sched_setaffinity"),
+        reason="CPU affinity requires Linux",
+    )
+    def test_worker_affinity_error_shuts_down_workers(self, make_envs, monkeypatch):
+        available_cpu = next(iter(os.sched_getaffinity(0)))
+        unavailable_cpu = max(os.sched_getaffinity(0)) + 1
+        processes = []
+        setup = ProcessorAsyncEnvPool._setup
+
+        def setup_with_invalid_affinity(env):
+            env._worker_affinity = [(unavailable_cpu,)] * env.num_envs
+            try:
+                setup(env)
+            finally:
+                processes.extend(env.threads)
+
+        monkeypatch.setattr(
+            ProcessorAsyncEnvPool, "_setup", setup_with_invalid_affinity
+        )
+
+        with pytest.raises(RuntimeError, match="failed to set its CPU affinity"):
+            AsyncEnvPool(
+                make_envs,
+                backend="multiprocessing",
+                exchange="queue",
+                worker_affinity=[(available_cpu,)] * len(make_envs),
+            )
+
+        assert processes
+        assert all(process.exitcode is not None for process in processes)
+
+    @pytest.mark.parametrize(
+        ("backend", "worker_affinity", "match"),
+        [
+            ("threading", [(0,)] * 4, "only supported"),
+            ("multiprocessing", [(0,)], "one CPU mask per environment"),
+        ],
+    )
+    def test_worker_affinity_validation(
+        self, make_envs, backend, worker_affinity, match
+    ):
+        with pytest.raises(ValueError, match=match):
+            AsyncEnvPool(
+                make_envs,
+                backend=backend,
+                worker_affinity=worker_affinity,
+            )
 
     @pytest.mark.parametrize("backend", ["multiprocessing", "threading"])
     @pytest.mark.parametrize("min_get", [None, 1, 2])

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -448,6 +448,10 @@ class TestEnvConfigs:
         assert config.backend == "threading"
         assert config.stack == "dense"
         assert config.exchange == "queue"
+        assert config.worker_affinity is None
+
+        config = OmegaConf.merge(config, {"worker_affinity": [[0, 1], [2, 3]]})
+        assert config.worker_affinity == [[0, 1], [2, 3]]
 
     @pytest.mark.parametrize(
         ("field", "value"),

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import concurrent.futures
 import importlib.util
 import multiprocessing as mp
+import os
 import pickle
 import queue
 import threading
@@ -2398,6 +2399,57 @@ class TestAsyncBatchedCollector:
             total += batch.numel()
         collector.shutdown()
         assert total >= 20
+
+    def test_worker_affinity_validation_is_eager(self):
+        with pytest.raises(ValueError, match="one CPU mask per environment"):
+            AsyncBatchedCollector(
+                create_env_fn=[_counting_env_factory] * 2,
+                policy=_make_counting_policy(),
+                frames_per_batch=10,
+                total_frames=10,
+                env_backend="multiprocessing",
+                worker_affinity=[(0,)],
+            )
+
+    @pytest.mark.skipif(
+        not hasattr(os, "sched_setaffinity"),
+        reason="CPU affinity requires Linux",
+    )
+    def test_cpu_affinity(self):
+        """Worker processes and driver threads use their configured masks."""
+        original_affinity = os.sched_getaffinity(0)
+        cpus = sorted(original_affinity)
+        driver_affinity = (cpus[0],)
+        worker_affinity = (cpus[-1],)
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * 2,
+            policy=_make_counting_policy(),
+            frames_per_batch=10,
+            total_frames=10,
+            max_batch_size=2,
+            env_backend="multiprocessing",
+            worker_affinity=[worker_affinity] * 2,
+            driver_affinity=driver_affinity,
+        )
+        try:
+            collector._ensure_started()
+            assert os.sched_getaffinity(0) == original_affinity
+            assert all(
+                os.sched_getaffinity(process.pid) == set(worker_affinity)
+                for process in collector.env.threads
+            )
+            driver_threads = [collector._server._worker, *collector._workers]
+            assert all(
+                os.sched_getaffinity(thread.native_id) == set(driver_affinity)
+                for thread in driver_threads
+            )
+            assert all(
+                os.sched_getaffinity(input_queue._thread.native_id)
+                == set(driver_affinity)
+                for input_queue in collector.env.input_queue
+            )
+        finally:
+            collector.shutdown()
 
     def test_process_server_backend_smoke(self):
         """Dedicated process server works through AsyncBatchedCollector."""

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import contextlib
+import os
 import queue
 import threading
 import time
@@ -19,6 +20,7 @@ from torchrl._comm import MailboxTransportError
 from torchrl._utils import _maybe_record_function_decorator, logger as torchrl_logger
 from torchrl.collectors._base import BaseCollector
 from torchrl.envs import AsyncEnvPool, EnvBase
+from torchrl.envs.async_envs import _validate_cpu_affinity
 from torchrl.modules.inference_server import (
     InferenceDeviceConfig,
     InferenceServer,
@@ -247,6 +249,24 @@ class AsyncBatchedCollector(BaseCollector):
         create_env_kwargs (dict or list[dict], optional): keyword arguments
             forwarded to each environment factory.  A single dict is broadcast
             to all factories.
+        worker_affinity (Sequence[Sequence[int]] or Callable[[int], Sequence[int]], optional):
+            Optional Linux CPU placement forwarded to the multiprocessing
+            :class:`~torchrl.envs.AsyncEnvPool`. Use it when worker scheduling
+            on CPUs reserved for simulators or driver work causes contention or
+            step-time jitter; most users should leave it unset. TorchRL knows
+            which CPUs are available, but not the application's intended CPU
+            partition or each environment's thread requirements, so it cannot
+            choose these masks automatically. Provide one mask per environment,
+            or a callable mapping each environment index to its mask. Defaults
+            to ``None``. See :ref:`async_batched_collector_cpu_affinity` for a
+            complete collector example.
+        driver_affinity (Sequence[int], optional): Linux CPU affinity mask for
+            the inference-server and per-environment coordinator threads, plus
+            parent-side multiprocessing queue feeder threads. Dedicated
+            process-backed inference servers are not covered. The thread
+            constructing the collector is restored to its original affinity
+            after startup. Defaults to ``None``. See
+            :ref:`async_batched_collector_cpu_affinity` for an example.
 
     Examples:
         >>> from torchrl.collectors import AsyncBatchedCollector
@@ -294,6 +314,10 @@ class AsyncBatchedCollector(BaseCollector):
         weight_sync_model_id: str = "policy",
         verbose: bool = False,
         create_env_kwargs: dict | list[dict] | None = None,
+        worker_affinity: Sequence[Sequence[int]]
+        | Callable[[int], Sequence[int]]
+        | None = None,
+        driver_affinity: Sequence[int] | None = None,
         server_config: InferenceServerConfig | None = None,
         device_config: InferenceDeviceConfig | None = None,
         policy_version: int = 0,
@@ -356,7 +380,39 @@ class AsyncBatchedCollector(BaseCollector):
                 f"env_backend={effective_env_backend!r} is not supported. "
                 f"Expected one of {_ENV_BACKENDS}."
             )
+        if worker_affinity is not None and effective_env_backend != "multiprocessing":
+            raise ValueError(
+                "worker_affinity is only supported with "
+                "env_backend='multiprocessing'."
+            )
         self._env_backend = effective_env_backend
+        if worker_affinity is None:
+            self._worker_affinity = None
+        else:
+            if callable(worker_affinity):
+                affinity_masks = [
+                    worker_affinity(env_index) for env_index in range(self._num_envs)
+                ]
+            else:
+                affinity_masks = list(worker_affinity)
+                if len(affinity_masks) != self._num_envs:
+                    raise ValueError(
+                        "worker_affinity must provide one CPU mask per "
+                        f"environment, got {len(affinity_masks)} masks for "
+                        f"{self._num_envs} environments."
+                    )
+            self._worker_affinity = [
+                _validate_cpu_affinity(
+                    affinity,
+                    option_name=f"worker_affinity[{env_index}]",
+                )
+                for env_index, affinity in enumerate(affinity_masks)
+            ]
+        self._driver_affinity = (
+            _validate_cpu_affinity(driver_affinity, option_name="driver_affinity")
+            if driver_affinity is not None
+            else None
+        )
         self._server_backend = server_backend
         if server_backend == "process":
             if policy_backend not in (None, "multiprocessing"):
@@ -444,59 +500,74 @@ class AsyncBatchedCollector(BaseCollector):
         if self._workers and all(w.is_alive() for w in self._workers):
             return
 
-        # Build env pool
-        kwargs = {}
-        if self._create_env_kwargs is not None:
-            kwargs["create_env_kwargs"] = self._create_env_kwargs
-        self._env_pool = AsyncEnvPool(
-            self._create_env_fn,
-            backend=self._env_backend,
-            # Pinned to the current default so the pool's default-change
-            # FutureWarning is not emitted from library code; switching the
-            # collector to the shm exchange is a deliberate follow-up.
-            exchange="queue",
-            **kwargs,
-        )
+        original_affinity = None
+        try:
+            if self._driver_affinity is not None:
+                original_affinity = os.sched_getaffinity(0)
+                os.sched_setaffinity(0, self._driver_affinity)
 
-        # Create clients before a process server starts so response queues are
-        # inherited by the child process.
-        if self._clients is None:
-            self._clients = [
-                PolicyClientModule(
-                    self._transport.client(),
-                    max_inflight=self._max_inflight_per_env,
-                )
-                for _ in range(self._num_envs)
-            ]
-
-        # Start inference server
-        if not self._server.is_alive:
-            self._server.start()
-
-        # Start per-env coordinator threads
-        self._result_queue = queue.Queue()
-        self._shutdown_event = threading.Event()
-
-        self._workers = []
-        for i in range(self._num_envs):
-            t = threading.Thread(
-                target=_env_loop,
-                kwargs={
-                    "pool": self._env_pool,
-                    "env_id": i,
-                    "transport": self._transport,
-                    "client": self._clients[i],
-                    "result_queue": self._result_queue,
-                    "shutdown_event": self._shutdown_event,
-                    "pause_request": self._pause_request,
-                    "env_device": self._env_device,
-                    "storing_device": self._storing_device,
-                },
-                daemon=True,
-                name=f"AsyncBatchedCollector-env-{i}",
+            # Build the pool while the driver mask is active so its parent-side
+            # multiprocessing queue feeder threads inherit that mask. Worker
+            # processes apply their own masks before constructing their envs.
+            kwargs = {}
+            if self._create_env_kwargs is not None:
+                kwargs["create_env_kwargs"] = self._create_env_kwargs
+            self._env_pool = AsyncEnvPool(
+                self._create_env_fn,
+                backend=self._env_backend,
+                # Pinned to the current default so the pool's default-change
+                # FutureWarning is not emitted from library code; switching the
+                # collector to the shm exchange is a deliberate follow-up.
+                exchange="queue",
+                worker_affinity=self._worker_affinity,
+                **kwargs,
             )
-            self._workers.append(t)
-            t.start()
+
+            # Create clients before a process server starts so response queues
+            # are inherited by the child process.
+            if self._clients is None:
+                self._clients = [
+                    PolicyClientModule(
+                        self._transport.client(),
+                        max_inflight=self._max_inflight_per_env,
+                    )
+                    for _ in range(self._num_envs)
+                ]
+
+            # Threads inherit the affinity of the thread that creates them.
+            if not self._server.is_alive:
+                self._server.start()
+
+            # Start per-env coordinator threads
+            self._result_queue = queue.Queue()
+            self._shutdown_event = threading.Event()
+
+            self._workers = []
+            for i in range(self._num_envs):
+                t = threading.Thread(
+                    target=_env_loop,
+                    kwargs={
+                        "pool": self._env_pool,
+                        "env_id": i,
+                        "transport": self._transport,
+                        "client": self._clients[i],
+                        "result_queue": self._result_queue,
+                        "shutdown_event": self._shutdown_event,
+                        "pause_request": self._pause_request,
+                        "env_device": self._env_device,
+                        "storing_device": self._storing_device,
+                    },
+                    daemon=True,
+                    name=f"AsyncBatchedCollector-env-{i}",
+                )
+                self._workers.append(t)
+                t.start()
+        except Exception:
+            self.shutdown(raise_on_error=False)
+            raise
+        finally:
+            if original_affinity is not None:
+                os.sched_setaffinity(0, original_affinity)
 
     @contextlib.contextmanager
     def pause(self, timeout: float | None = 30.0) -> Iterator[None]:

--- a/torchrl/envs/async_envs.py
+++ b/torchrl/envs/async_envs.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 
 import abc
 import multiprocessing
+import os
 import queue
 import threading
 import warnings
 from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import as_completed, FIRST_COMPLETED, ThreadPoolExecutor, wait
 from multiprocessing import Queue
+from numbers import Integral
 from typing import Literal
 
 import torch
@@ -29,6 +31,43 @@ from torchrl._utils import logger as torchrl_logger, timeit
 from torchrl.data.tensor_specs import NonTensor
 from torchrl.envs._async_exchange import _receive_batch, _SharedSlotExchange
 from torchrl.envs.common import _EnvPostInit, EnvBase
+
+
+class _ValidatedCPUAffinity(tuple):
+    pass
+
+
+def _validate_cpu_affinity(
+    cpu_affinity: Sequence[int], *, option_name: str
+) -> tuple[int, ...]:
+    if isinstance(cpu_affinity, _ValidatedCPUAffinity):
+        return cpu_affinity
+    if not hasattr(os, "sched_setaffinity") or not hasattr(os, "sched_getaffinity"):
+        raise NotImplementedError(
+            f"{option_name} requires os.sched_getaffinity and "
+            "os.sched_setaffinity, which are only available on Linux."
+        )
+    try:
+        cpu_affinity = tuple(cpu_affinity)
+    except TypeError as err:
+        raise TypeError(f"{option_name} must be a sequence of CPU indices.") from err
+    if not cpu_affinity:
+        raise ValueError(f"{option_name} must contain at least one CPU index.")
+    if any(
+        isinstance(cpu, bool) or not isinstance(cpu, Integral) for cpu in cpu_affinity
+    ):
+        raise TypeError(f"{option_name} must contain only integer CPU indices.")
+    if any(cpu < 0 for cpu in cpu_affinity):
+        raise ValueError(f"{option_name} CPU indices must be non-negative.")
+    cpu_affinity = _ValidatedCPUAffinity(int(cpu) for cpu in cpu_affinity)
+    available_cpus = os.sched_getaffinity(0)
+    unavailable_cpus = sorted(set(cpu_affinity).difference(available_cpus))
+    if unavailable_cpus:
+        raise ValueError(
+            f"{option_name} contains CPUs unavailable to this process: "
+            f"{unavailable_cpus}."
+        )
+    return cpu_affinity
 
 
 class _AsyncEnvMeta(_EnvPostInit):
@@ -91,6 +130,22 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
                 The default will change from ``"queue"`` to ``"auto"`` in
                 v0.15 for the multiprocessing backend. A ``FutureWarning`` is
                 emitted when the default is relied upon.
+        worker_affinity (Sequence[Sequence[int]] or Callable[[int], Sequence[int]], optional):
+            Optional Linux CPU placement for multiprocessing workers. This is
+            useful when environment workers share a constrained CPU set with
+            CPU-heavy simulators or other services: without affinity, the
+            scheduler may place them on the same CPUs and increase environment
+            step-time jitter. Most users should leave this as ``None``.
+
+            TorchRL can discover which CPUs the current process may use, but
+            it cannot infer which CPUs the application has reserved for other
+            work or how many threads an environment and its subprocesses need.
+            It therefore does not choose a partition automatically. Provide
+            one mask per environment, or a callable mapping an environment
+            index to its mask. The mask is applied before the environment is
+            constructed and is inherited by subprocesses it starts. Defaults
+            to ``None``. See :ref:`async_env_pool_cpu_affinity` for an example
+            and deployment guidance.
         create_env_kwargs (dict, optional):
             Keyword arguments to pass to the environment maker. Defaults to `{}`.
 
@@ -219,6 +274,9 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
         backend: Literal["threading", "multiprocessing", "asyncio"] = "threading",
         stack: Literal["dense", "maybe_dense", "lazy"] = "dense",
         exchange: Literal["queue", "shm", "auto"] | None = None,
+        worker_affinity: Sequence[Sequence[int]]
+        | Callable[[int], Sequence[int]]
+        | None = None,
         create_env_kwargs: dict | list[dict] | None = None,
     ) -> None:
         if not isinstance(env_makers, Sequence):
@@ -227,6 +285,33 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
         self.env_makers = env_makers
         self.num_envs = len(env_makers)
         self.backend = backend
+        self.worker_affinity = worker_affinity
+        self._worker_affinity = None
+        if worker_affinity is not None:
+            if backend != "multiprocessing":
+                raise ValueError(
+                    "worker_affinity is only supported with "
+                    "backend='multiprocessing'."
+                )
+            if callable(worker_affinity):
+                affinity_masks = [
+                    worker_affinity(env_index) for env_index in range(self.num_envs)
+                ]
+            else:
+                affinity_masks = list(worker_affinity)
+                if len(affinity_masks) != self.num_envs:
+                    raise ValueError(
+                        "worker_affinity must provide one CPU mask per "
+                        f"environment, got {len(affinity_masks)} masks for "
+                        f"{self.num_envs} environments."
+                    )
+            self._worker_affinity = [
+                _validate_cpu_affinity(
+                    affinity,
+                    option_name=f"worker_affinity[{env_index}]",
+                )
+                for env_index, affinity in enumerate(affinity_masks)
+            ]
         if exchange is None:
             if backend == "multiprocessing":
                 warnings.warn(
@@ -679,6 +764,7 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
         self._current_reset = 0
         self._current_step = 0
         self._current_step_reset = 0
+        self._slot_exchange = None
 
         num_threads = self.num_envs
         self.threads = []
@@ -697,10 +783,29 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
                     "per_env_step_queue": self._per_env_step_queues[i],
                     "per_env_reset_queue": self._per_env_reset_queues[i],
                     "per_env_step_reset_queue": self._per_env_step_reset_queues[i],
+                    "cpu_affinity": None
+                    if self._worker_affinity is None
+                    else self._worker_affinity[i],
                 },
             )
             self.threads.append(thread)
             thread.start()
+        if self._worker_affinity is not None:
+            try:
+                for i in range(num_threads):
+                    status, payload = self.output_queue[i].get()
+                    if status != "affinity_ready":
+                        raise RuntimeError(
+                            f"AsyncEnvPool worker {i} failed to set its CPU "
+                            f"affinity: {payload}"
+                        )
+            except Exception:
+                for thread in self.threads:
+                    if thread.is_alive():
+                        thread.terminate()
+                for thread in self.threads:
+                    thread.join()
+                raise
         # Get specs from each worker and cache them for _get_child_specs()
         for i in range(num_threads):
             self.input_queue[i].put(("get_specs", None))
@@ -714,7 +819,6 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
         specs = torch.stack(list(self._child_specs))
         output_spec = specs["output_spec"]
         input_spec = specs["input_spec"]
-        self._slot_exchange = None
         if self.exchange in ("shm", "auto"):
             for i in range(num_threads):
                 self.input_queue[i].put(("get_fake_tensordict", None))
@@ -1066,7 +1170,15 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
         per_env_step_queue=None,
         per_env_reset_queue=None,
         per_env_step_reset_queue=None,
+        cpu_affinity=None,
     ):
+        if cpu_affinity is not None:
+            try:
+                os.sched_setaffinity(0, cpu_affinity)
+            except Exception as err:
+                output_queue.put(("affinity_error", repr(err)))
+                return
+            output_queue.put(("affinity_ready", None))
         if not isinstance(env_or_factory, EnvBase):
             env = env_or_factory(**create_env_kwargs)
         else:

--- a/torchrl/trainers/algorithms/configs/envs.py
+++ b/torchrl/trainers/algorithms/configs/envs.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -37,6 +38,7 @@ class BatchedEnvConfig(EnvConfig):
     backend: str = "threading"
     stack: str = "dense"
     exchange: str = "queue"
+    worker_affinity: list[list[int]] | None = None
     _target_: str = "torchrl.trainers.algorithms.configs.envs.make_batched_env"
 
     def __post_init__(self) -> None:
@@ -65,6 +67,9 @@ def make_batched_env(
     backend: Literal["threading", "multiprocessing", "asyncio"] = "threading",
     stack: Literal["dense", "maybe_dense", "lazy"] = "dense",
     exchange: Literal["queue", "shm", "auto"] = "queue",
+    worker_affinity: Sequence[Sequence[int]]
+    | Callable[[int], Sequence[int]]
+    | None = None,
     **kwargs: Any,
 ) -> EnvBase:
     """Create a batched environment.
@@ -77,6 +82,8 @@ def make_batched_env(
         backend: Async execution backend.
         stack: Async result stacking mode.
         exchange: Async multiprocessing exchange mode.
+        worker_affinity: Optional Linux CPU affinity masks for async
+            multiprocessing workers.
         **kwargs: Additional keyword arguments.
 
     Returns:
@@ -133,6 +140,8 @@ def make_batched_env(
         kwargs["backend"] = backend
         kwargs["stack"] = stack
         kwargs["exchange"] = exchange
+        if worker_affinity is not None:
+            kwargs["worker_affinity"] = worker_affinity
         return AsyncEnvPool([env_fn] * num_workers, **kwargs)
     else:
         raise ValueError(f"Unknown batched_env_type: {batched_env_type}")


### PR DESCRIPTION
## Summary

- add per-worker Linux CPU affinity masks to multiprocessing AsyncEnvPool and apply them before environment construction
- add a driver affinity mask for AsyncBatchedCollector coordinator and inference-server execution
- document cpuset, CFS quota, and Kubernetes CPU Manager interactions, and add a many-core step-latency jitter benchmark

## Tests

- 56 passed, 3 skipped across TestAsyncEnvPool, TestAsyncBatchedCollector, and TestEnvConfigs on macOS
- Linux-only worker and driver affinity assertions collected and skipped locally for CI
- pre-commit hooks pass on all changed files
- new latency sampler smoke test passes