### PR TITLE
[Performance] Compile the complete DreamerV3 learner step

### DIFF
--- a/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
+++ b/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
@@ -147,15 +147,52 @@ class _ReplayLearnerStep:
         self.replay_buffer.shutdown()
 
 
-def _measure(step, synchronize, *, warmup: int, iterations: int) -> list[float]:
+def _measure(step, synchronize, *, warmup: int, iterations: int):
     for _ in range(warmup):
         step()
     synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    host_latencies = []
     started = time.perf_counter()
     for _ in range(iterations):
+        before_update = time.perf_counter()
         step()
+        host_latencies.append((time.perf_counter() - before_update) * 1000)
     synchronize()
-    return [(time.perf_counter() - started) * 1000 / iterations]
+    return (time.perf_counter() - started) * 1000 / iterations, host_latencies
+
+
+def _profile_update(step, synchronize) -> dict:
+    with torch.profiler.profile(
+        activities=[
+            torch.profiler.ProfilerActivity.CPU,
+            torch.profiler.ProfilerActivity.CUDA,
+        ]
+    ) as profile:
+        step()
+        synchronize()
+
+    events = profile.events()
+    kernel_events = [
+        event
+        for event in events
+        if event.device_type == torch.autograd.DeviceType.CUDA
+        and not event.name.startswith(("Memcpy", "Memset"))
+    ]
+    launch_events = [
+        event
+        for event in events
+        if event.name.startswith("cudaLaunchKernel") or event.name == "cudaGraphLaunch"
+    ]
+    return {
+        "profile_kernel_count": len(kernel_events),
+        "profile_gpu_time_ms": sum(event.device_time_total for event in kernel_events)
+        / 1000,
+        "profile_cpu_launch_time_ms": sum(
+            event.self_cpu_time_total for event in launch_events
+        )
+        / 1000,
+    }
 
 
 def main() -> None:
@@ -173,8 +210,17 @@ def main() -> None:
     parser.add_argument(
         "--variants",
         nargs="+",
-        choices=("compiled_scan", "cuda_graph"),
-        default=("compiled_scan", "cuda_graph"),
+        choices=(
+            "eager",
+            "compiled_scan",
+            "cuda_graph",
+            "compiled_train_step",
+            "compiled_train_step_cuda_graph",
+        ),
+        default=(
+            "cuda_graph",
+            "compiled_train_step_cuda_graph",
+        ),
     )
     args = parser.parse_args()
     if not torch.cuda.is_available():
@@ -204,9 +250,18 @@ def main() -> None:
         cfg = _load_config(repo_root)
         cfg.replay_buffer.batch_size = args.batch
         cfg.replay_buffer.seq_len = args.steps
-        cfg.optimization.compile_rssm = "scan"
+        cfg.optimization.compile_rssm = (
+            "scan" if variant in ("compiled_scan", "cuda_graph") else None
+        )
         cfg.optimization.rssm_scan_unroll = args.unroll
-        cfg.optimization.cudagraph_train_step = variant == "cuda_graph"
+        cfg.optimization.compile_train_step = variant in (
+            "compiled_train_step",
+            "compiled_train_step_cuda_graph",
+        )
+        cfg.optimization.cudagraph_train_step = variant in (
+            "cuda_graph",
+            "compiled_train_step_cuda_graph",
+        )
         torch.manual_seed(0)
         learner = example["_build_learner"](
             cfg,
@@ -247,16 +302,17 @@ def main() -> None:
             synchronize = replay_step.synchronize
             workload = "complete_learner_update_with_replay"
         try:
-            samples = _measure(
+            mean_ms, host_latencies = _measure(
                 step,
                 synchronize,
                 warmup=args.warmup,
                 iterations=args.iterations,
             )
+            peak_memory = torch.cuda.max_memory_allocated(device) / 2**20
+            profile_metrics = _profile_update(step, synchronize)
         finally:
             if replay_step is not None:
                 replay_step.close()
-        median_ms = statistics.median(samples)
         result = {
             "variant": variant,
             "workload": workload,
@@ -270,10 +326,16 @@ def main() -> None:
             "warmup": args.warmup,
             "iterations": args.iterations,
             "mixed_precision": cfg.optimization.mixed_precision,
-            "median_ms": median_ms,
-            "transitions_per_second": args.batch * args.steps * 1000 / median_ms,
-            "min_ms": min(samples),
-            "max_ms": max(samples),
+            "warmup_updates": args.warmup,
+            "measured_updates": args.iterations,
+            "mean_update_ms": mean_ms,
+            "transitions_per_second": args.batch * args.steps * 1000 / mean_ms,
+            "p50_host_update_ms": statistics.median(host_latencies),
+            "p95_host_update_ms": statistics.quantiles(
+                host_latencies, n=20, method="inclusive"
+            )[18],
+            "peak_cuda_allocated_mib": peak_memory,
+            **profile_metrics,
         }
         print(json.dumps(result, sort_keys=True), flush=True)
 

--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -154,7 +154,31 @@ recurrence and the imagination prior, and is faster, but its draws fall inside
 the compiled region, so a seeded run diverges from an eager one. The scan uses
 `optimization.rssm_scan_unroll=8` by default; lower values reduce compilation
 time and graph size, while `1` disables manual unrolling.
+`optimization.compile_train_step=true` compiles the complete learner forward
+and backward with TorchInductor, including the model, actor, value, and replay
+value losses. It subsumes `optimization.compile_rssm`, which is ignored to avoid
+nested compilation of shared RSSM modules. The compile mode defaults to
+`optimization.compile_train_step_mode=default`; autotuning modes are opt-in.
+Compilation and CUDA-graph warmup use a fixed-shape synthetic batch before the
+collector is constructed, so async collection is not live while Dynamo runs.
+When combined with `optimization.cudagraph_train_step=true`, the
+Inductor-compiled function is warmed up before CUDA graph capture.
 `optimization.cudagraph_train_step=true` captures the learner forward and
 backward after five warmup calls. It requires CUDA and fixed input shapes;
 optimizer and target-network steps remain outside capture so their schedules
 continue to advance normally.
+
+Train-update timing remains asynchronous by default. Set
+`optimization.sync_timers=true` when completed GPU timing is needed; this
+synchronizes around each measured update and intentionally disables CPU/GPU
+overlap.
+
+To compare the existing CUDA-graph path with whole-step compilation, run:
+
+```bash
+python benchmarks/ad_hoc/bench_dreamer_v3_learner.py \
+  --variants cuda_graph compiled_train_step_cuda_graph
+```
+
+Each variant reports the median synchronized update time plus a one-update
+profiler sample with kernel count, summed GPU kernel time, and CPU launch time.

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -58,8 +58,14 @@ optimization:
   compile_rssm: null
   # Number of RSSM steps traced per higher-order scan iteration.
   rssm_scan_unroll: 8
+  # Compile the complete learner forward/backward with TorchInductor.
+  compile_train_step: false
+  # torch.compile mode for the complete learner step.
+  compile_train_step_mode: default
   # Capture the fixed-shape learner forward/backward on CUDA after warmup.
   cudagraph_train_step: false
+  # Synchronize CUDA around train-update timing. This disables CPU/GPU overlap.
+  sync_timers: false
   lr: 4.0e-5
   optimizer_eps: 1.0e-20
   adaptive_grad_clip: 0.3

--- a/sota-implementations/dreamer_v3/dreamer_v3_agent.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_agent.py
@@ -328,7 +328,11 @@ def make_primed_env(
 
 
 def build_world_model(
-    *, cfg: DictConfig, obs_dim: int, action_dim: int
+    *,
+    cfg: DictConfig,
+    obs_dim: int,
+    action_dim: int,
+    compile_rollout: bool = True,
 ) -> tuple[TensorDictSequential, RSSMPriorV3, DreamerV3MLP, SymExpTwoHot, DreamerV3MLP]:
     """Build the world model: encoder, RSSM rollout, decoder and two heads."""
     state_dim = latent_state_dim(cfg)
@@ -398,7 +402,7 @@ def build_world_model(
     # training window within one episode, while the rollout still handles a
     # reset at its first transition.
     rollout = RSSMRolloutV3(rssm_prior, rssm_posterior, reset_key="is_init")
-    if cfg.optimization.compile_rssm:
+    if compile_rollout and cfg.optimization.compile_rssm:
         rollout.compile_rollout(
             cfg.optimization.compile_rssm,
             unroll=(

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -104,6 +104,16 @@ class _LearnerUpdate:
         cudagraph_warmup: int = 5,
     ):
         self.cfg = cfg
+        self._sample_keys = [
+            "action",
+            "is_init",
+            "state",
+            "belief",
+            ("next", "observation"),
+            ("next", "reward"),
+            ("next", "done"),
+            ("next", "terminated"),
+        ]
         self.device = device
         self.model_loss = learner.model_loss
         self.actor_loss = learner.actor_loss
@@ -112,10 +122,24 @@ class _LearnerUpdate:
         self.value_target_updater = learner.value_target_updater
         self.state_dim = latent_state_dim(cfg)
         self.use_bfloat16 = cfg.optimization.mixed_precision and device.type == "cuda"
+        self._warmup_steps = (
+            cudagraph_warmup
+            if cfg.optimization.cudagraph_train_step
+            else int(
+                bool(
+                    cfg.optimization.compile_train_step or cfg.optimization.compile_rssm
+                )
+            )
+        )
         self._cudagraph_warmup_remaining = (
             cudagraph_warmup if cfg.optimization.cudagraph_train_step else 0
         )
         train_step = self._forward_backward
+        if cfg.optimization.compile_train_step:
+            train_step = torch.compile(
+                train_step,
+                mode=cfg.optimization.compile_train_step_mode,
+            )
         if cfg.optimization.cudagraph_train_step:
             if device.type != "cuda":
                 raise RuntimeError(
@@ -193,7 +217,7 @@ class _LearnerUpdate:
                 + cfg.optimization.replay_value_loss_weight * replay_loss
             )
 
-        self.optimizer.zero_grad(set_to_none=True)
+        self.optimizer.zero_grad(set_to_none=False)
         total_loss.backward()
         metrics = torch.stack(
             (
@@ -215,12 +239,69 @@ class _LearnerUpdate:
         self,
         sample: TensorDictBase,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        sample = sample.select(*self._sample_keys)
+        # Replay sampling may squeeze boolean feature axes. Match capture inputs.
+        for key in ("is_init", ("next", "done"), ("next", "terminated")):
+            sample.set(key, sample.get(key).reshape(*sample.batch_size, 1))
         result = self.train_step(sample)
         if self._cudagraph_warmup_remaining:
             self._cudagraph_warmup_remaining -= 1
         self.optimizer.step()
         self.value_target_updater.step()
         return result
+
+
+def _fake_learner_sample(
+    cfg: DictConfig,
+    device: torch.device,
+    obs_dim: int,
+    action_dim: int,
+) -> TensorDict:
+    batch_size = (cfg.replay_buffer.batch_size, cfg.replay_buffer.seq_len)
+    return TensorDict(
+        {
+            "state": torch.zeros(*batch_size, latent_state_dim(cfg)),
+            "belief": torch.zeros(*batch_size, cfg.networks.rnn_hidden_dim),
+            "action": torch.zeros(*batch_size, action_dim),
+            "is_init": torch.zeros(*batch_size, 1, dtype=torch.bool),
+            "next": {
+                "observation": torch.zeros(*batch_size, obs_dim),
+                "reward": torch.zeros(*batch_size, 1),
+                "done": torch.zeros(*batch_size, 1, dtype=torch.bool),
+                "terminated": torch.zeros(*batch_size, 1, dtype=torch.bool),
+            },
+        },
+        batch_size,
+        device=device,
+    )
+
+
+def _warm_up_learner(
+    cfg: DictConfig,
+    device: torch.device,
+    learner_update: _LearnerUpdate,
+    obs_dim: int,
+    action_dim: int,
+) -> None:
+    if not learner_update._warmup_steps:
+        return
+
+    cpu_rng_state = torch.get_rng_state()
+    cuda_rng_state = torch.cuda.get_rng_state(device) if device.type == "cuda" else None
+    return_low = learner_update.actor_loss.retnorm.low.detach().clone()
+    return_high = learner_update.actor_loss.retnorm.high.detach().clone()
+    sample = _fake_learner_sample(cfg, device, obs_dim, action_dim)
+    try:
+        for _ in range(learner_update._warmup_steps):
+            learner_update.train_step(sample.select(*learner_update._sample_keys))
+        learner_update._cudagraph_warmup_remaining = 0
+        learner_update.optimizer.zero_grad(set_to_none=False)
+    finally:
+        learner_update.actor_loss.retnorm.low.copy_(return_low)
+        learner_update.actor_loss.retnorm.high.copy_(return_high)
+        torch.set_rng_state(cpu_rng_state)
+        if cuda_rng_state is not None:
+            torch.cuda.set_rng_state(cuda_rng_state, device)
 
 
 def _validated_action_budget(cfg: DictConfig) -> int:
@@ -264,14 +345,22 @@ def _build_learner(
         reward_net,
         reward_decoder,
         continuation_net,
-    ) = build_world_model(cfg=cfg, obs_dim=obs_dim, action_dim=action_dim)
+    ) = build_world_model(
+        cfg=cfg,
+        obs_dim=obs_dim,
+        action_dim=action_dim,
+        compile_rollout=not cfg.optimization.compile_train_step,
+    )
     world_model = world_model.to(device)
     imagination_model = build_imagination_model(
         prior_net=prior_net,
         reward_net=reward_net,
         reward_decoder=reward_decoder,
-        # Compiling changes the categorical draws; "step" must match eager.
-        compile_prior=cfg.optimization.compile_rssm == "scan",
+        # The whole-step compile owns shared modules and subsumes RSSM compile.
+        compile_prior=(
+            cfg.optimization.compile_rssm == "scan"
+            and not cfg.optimization.compile_train_step
+        ),
     ).to(device)
     continuation_model = build_continuation_model(continuation_net=continuation_net).to(
         device
@@ -641,7 +730,8 @@ def main(cfg: DictConfig):
     use_bfloat16 = cfg.optimization.mixed_precision and device.type == "cuda"
     torchrl_logger.info(
         "DreamerV3 execution: device=%s, replay_device=%s, rssm_backend=%s, "
-        "rssm_scan_unroll=%s, mixed_precision=%s, cudagraph_train_step=%s",
+        "rssm_scan_unroll=%s, mixed_precision=%s, compile_train_step=%s, "
+        "cudagraph_train_step=%s",
         device,
         replay_device,
         cfg.optimization.compile_rssm or "eager",
@@ -651,6 +741,7 @@ def main(cfg: DictConfig):
             else "n/a"
         ),
         use_bfloat16,
+        cfg.optimization.compile_train_step,
         cfg.optimization.cudagraph_train_step,
     )
     num_envs = cfg.collector.num_envs
@@ -672,6 +763,7 @@ def main(cfg: DictConfig):
 
     learner = _build_learner(cfg, device, obs_dim, action_dim)
     learner_update = _LearnerUpdate(cfg, device, learner)
+    _warm_up_learner(cfg, device, learner_update, obs_dim, action_dim)
     rb = _build_replay(cfg, num_envs, replay_device, device)
     action_step = 0
     reset_records = num_envs
@@ -802,7 +894,9 @@ def main(cfg: DictConfig):
                     # CUDA graph capture rejects CUDA API calls from other threads.
                     with timeit("dreamer_v3/replay_wait"):
                         rb.synchronize()
-                with timeit("dreamer_v3/train_update"):
+                with timeit(
+                    "dreamer_v3/train_update", sync=cfg.optimization.sync_timers
+                ):
                     (
                         update_losses,
                         refreshed_state,

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -10,6 +10,7 @@ Reference: https://arxiv.org/abs/2301.04104
 from __future__ import annotations
 
 import copy
+import functools as ft
 import importlib.util
 import json
 import os
@@ -84,6 +85,42 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
     rnn_hidden_dim = 8
     action_dim = 3
     num_reward_bins = 16  # small for tests; paper uses 255
+
+    def _small_sota_config(
+        self,
+        example_dir: Path,
+        *,
+        compile_train_step: bool,
+        cudagraph_train_step: bool,
+        mixed_precision: bool = False,
+    ):
+        from omegaconf import OmegaConf
+
+        cfg = OmegaConf.load(example_dir / "config.yaml")
+        cfg.env.name = PENDULUM_VERSIONED()
+        cfg.networks.rnn_hidden_dim = 8
+        cfg.networks.num_categoricals = 2
+        cfg.networks.num_classes = 2
+        cfg.networks.num_blocks = 2
+        cfg.networks.hidden_dim = 8
+        cfg.networks.num_reward_bins = 16
+        cfg.networks.num_value_bins = 16
+        cfg.networks.encoder_layers = 1
+        cfg.networks.decoder_layers = 1
+        cfg.networks.reward_layers = 1
+        cfg.networks.actor_layers = 1
+        cfg.networks.value_layers = 1
+        cfg.replay_buffer.batch_size = 2
+        cfg.replay_buffer.seq_len = 3
+        cfg.optimization.imagination_horizon = 3
+        cfg.optimization.continuation_horizon = 3
+        cfg.optimization.warmup_steps = 0
+        cfg.optimization.mixed_precision = mixed_precision
+        cfg.optimization.compile_rssm = "scan"
+        cfg.optimization.rssm_scan_unroll = 1
+        cfg.optimization.compile_train_step = compile_train_step
+        cfg.optimization.cudagraph_train_step = cudagraph_train_step
+        return cfg
 
     def _create_world_model_data(self):
         B, T = 2, 3
@@ -452,6 +489,19 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             if p.grad is not None:
                 assert not torch.isnan(p.grad).any(), f"NaN grad in {name}"
                 assert not torch.isinf(p.grad).any(), f"Inf grad in {name}"
+
+    def test_dreamer_v3_model_loss_compile_preserves_input(self, device):
+        tensordict = self._create_world_model_data().to(device)
+        reward = tensordict["next", "reward"].clone()
+        loss_module = DreamerV3ModelLoss(
+            self._create_world_model(reward_two_hot=True).to(device),
+            num_reward_bins=self.num_reward_bins,
+        )
+        compiled_loss = torch.compile(loss_module, backend="eager")
+
+        for _ in range(2):
+            compiled_loss(tensordict)
+            torch.testing.assert_close(tensordict["next", "reward"], reward)
 
     def test_dreamer_v3_model_loss_sums_only_event_dims(self, device):
         batch_size, event_size = (2, 3), 4
@@ -1159,11 +1209,10 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         not (_has_hydra and _has_omegaconf and _has_gym),
         reason="requires hydra, omegaconf, and gym",
     )
-    def test_dreamer_v3_full_learner_cuda_graph_matches_eager(
-        self, device, monkeypatch
+    @pytest.mark.parametrize("compile_train_step", [False, True])
+    def test_dreamer_v3_full_learner_cuda_graph_matches_uncaptured(
+        self, device, monkeypatch, compile_train_step
     ):
-        from omegaconf import OmegaConf
-
         device = torch.device(device)
         if device.type != "cuda":
             pytest.skip("CUDA graph test only runs for the CUDA parametrization")
@@ -1175,31 +1224,6 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             example_dir / "train.py",
             run_name="dreamer_v3_learner_cuda_graph_test",
         )
-
-        def make_config(cudagraph: bool):
-            cfg = OmegaConf.load(example_dir / "config.yaml")
-            cfg.networks.rnn_hidden_dim = 8
-            cfg.networks.num_categoricals = 2
-            cfg.networks.num_classes = 2
-            cfg.networks.num_blocks = 2
-            cfg.networks.hidden_dim = 8
-            cfg.networks.num_reward_bins = 16
-            cfg.networks.num_value_bins = 16
-            cfg.networks.encoder_layers = 1
-            cfg.networks.decoder_layers = 1
-            cfg.networks.reward_layers = 1
-            cfg.networks.actor_layers = 1
-            cfg.networks.value_layers = 1
-            cfg.replay_buffer.batch_size = 2
-            cfg.replay_buffer.seq_len = 3
-            cfg.optimization.imagination_horizon = 3
-            cfg.optimization.continuation_horizon = 3
-            cfg.optimization.warmup_steps = 0
-            cfg.optimization.mixed_precision = True
-            cfg.optimization.compile_rssm = "scan"
-            cfg.optimization.rssm_scan_unroll = 1
-            cfg.optimization.cudagraph_train_step = cudagraph
-            return cfg
 
         state_dim = 4
         torch.manual_seed(1)
@@ -1224,7 +1248,12 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         modules = []
         learners = []
         for cudagraph in (False, True):
-            cfg = make_config(cudagraph)
+            cfg = self._small_sota_config(
+                example_dir,
+                compile_train_step=compile_train_step,
+                cudagraph_train_step=cudagraph,
+                mixed_precision=True,
+            )
             torch.manual_seed(0)
             learner = example["_build_learner"](cfg, device, 3, 1)
             learners.append(learner)
@@ -1249,12 +1278,14 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         torch.testing.assert_close(modules[1].state_dict(), initial_state)
 
         # Compile both paths and finish graph capture without applying updates.
-        for update, sample in zip(updates, (data.clone(), data.clone())):
-            for _ in range(5):
-                update.train_step(sample)
+        for update in updates:
+            example["_warm_up_learner"](update.cfg, device, update, 3, 1)
         for module in modules:
             module.load_state_dict(initial_state)
 
+        # Actual replay batches have squeezed boolean feature axes.
+        for key in ("is_init", ("next", "done"), ("next", "terminated")):
+            data.set(key, data.get(key).squeeze(-1))
         eager_data = data.clone()
         graph_data = data.clone()
         for seed in (10, 11):
@@ -1276,6 +1307,11 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             atol=2e-3,
             rtol=2e-3,
         )
+        for module in modules:
+            assert any(
+                not torch.equal(parameter, initial_state[name])
+                for name, parameter in module.named_parameters()
+            )
         assert learners[0].optimizer.state
         assert learners[1].optimizer.state
         assert learners[0].optimizer.param_groups[0]["step"] == 2
@@ -1291,7 +1327,12 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             repo_root / "benchmarks/ad_hoc/bench_dreamer_v3_learner.py",
             run_name="dreamer_v3_native_replay_cuda_graph_test",
         )
-        cfg = make_config(True)
+        cfg = self._small_sota_config(
+            example_dir,
+            compile_train_step=compile_train_step,
+            cudagraph_train_step=True,
+            mixed_precision=True,
+        )
         torch.manual_seed(0)
         replay_learner = example["_build_learner"](cfg, device, 3, 1)
         replay_update = example["_LearnerUpdate"](
@@ -1316,6 +1357,54 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
             assert not replay_update.replay_must_be_idle
         finally:
             replay_step.close()
+
+    @pytest.mark.skipif(
+        not (_has_hydra and _has_omegaconf and _has_gym),
+        reason="requires hydra, omegaconf, and gym",
+    )
+    def test_dreamer_v3_full_learner_compile_avoids_nested_rssm(
+        self, device, monkeypatch
+    ):
+        device = torch.device(device)
+        if device.type != "cpu":
+            pytest.skip("CPU compile regression")
+
+        repo_root = Path(__file__).parents[2]
+        example_dir = repo_root / "sota-implementations/dreamer_v3"
+        monkeypatch.syspath_prepend(str(example_dir))
+        example = runpy.run_path(
+            example_dir / "train.py",
+            run_name="dreamer_v3_learner_compile_test",
+        )
+        cfg = self._small_sota_config(
+            example_dir,
+            compile_train_step=True,
+            cudagraph_train_step=False,
+        )
+        monkeypatch.setattr(
+            torch, "compile", ft.partial(torch.compile, backend="eager")
+        )
+
+        learner = example["_build_learner"](cfg, device, 3, 1)
+        update = example["_LearnerUpdate"](cfg, device, learner)
+        sample = example["_fake_learner_sample"](cfg, device, 3, 1)
+        reward = sample.get(("next", "reward")).clone()
+        for key in ("is_init", ("next", "done"), ("next", "terminated")):
+            sample.set(key, sample.get(key).squeeze(-1))
+        example["_warm_up_learner"](cfg, device, update, 3, 1)
+        parameters = list(learner.optimizer.param_groups[0]["params"])
+        before = [parameter.detach().clone() for parameter in parameters]
+        metrics, _, _ = update(sample)
+
+        assert any(
+            not torch.equal(parameter, previous)
+            for parameter, previous in zip(parameters, before)
+        )
+        assert torch.isfinite(metrics).all()
+        learner.optimizer.zero_grad(set_to_none=True)
+        with pytest.raises(RuntimeError, match="no parameter gradients"):
+            learner.optimizer.step()
+        torch.testing.assert_close(sample.get(("next", "reward")), reward)
 
     @pytest.mark.skipif(not _has_omegaconf, reason="requires omegaconf")
     def test_dreamer_v3_dmc_benchmark_aggregation(self, device, tmp_path):

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -411,7 +411,9 @@ class DreamerV3ModelLoss(LossModule):
 
     @_maybe_record_function_decorator("dreamer_v3/world_model_loss")
     def forward(self, tensordict: TensorDict) -> tuple[TensorDict, TensorDict]:
-        tensordict = tensordict.copy()
+        # Rebuild nested containers without copying tensor storage. Under
+        # compilation, a shallow copy can retain the input's nested containers.
+        tensordict = tensordict.select(*tensordict.keys(True, True))
         tensordict.rename_key_(
             ("next", self.tensor_keys.reward),
             ("next", self.tensor_keys.true_reward),


### PR DESCRIPTION
Whole-step compilation now wraps the native DreamerV3 learner forward/backward, including model, actor, value and replay-value losses. It owns shared RSSM modules and disables nested compilation. Compile and graph warm-up finish before collection starts; the existing training defaults remain unchanged.

Depends on #4265. Closes #4267.

The learner selects the same input schema for synthetic warm-up and replay batches. Model loss reconstructs nested containers before renaming reward keys, preventing compiled calls from mutating the caller's replay sample. Gradient buffers remain allocated after capture, and an optimizer step with no parameter gradients raises a clear error. Optimizer schedules and target updates remain outside capture.

Validation:
- Eight focused CPU learner/native-replay tests passed, including a real compiled update and input-key preservation.
- Both CUDA graph regressions passed on NVIDIA GB200: capture with and without whole-step compilation, production warm-up, subsequent parameter and target updates, and native replay updates.
- Repository-pinned formatting and Flake8 pass; complete outgoing diff and commit metadata audited.
- Three matched LOW-priority GPU repetitions completed, followed by three longer matched repetitions to investigate timing variation. Full results and limitations are below. The final combined CPU inference/objective/replay suite passed 904 tests; downstream real SOTA and separate-process resume tests also pass on CUDA.

Whole-step compilation is opt-in. The maintained fast preset continues to use its established compiled-scan plus CUDA-graph configuration.

Matched benchmark: NVIDIA GB200, Python 3.12, PyTorch 2.15.0.dev20260906+cu130, TensorDict public main faee822, BF16, batch 2, sequence length 8, unroll 2, CPU native replay, one CPU thread. Each comparison uses identical hardware, dependencies, seed and warm-up. Timing includes sampling, transfer, learner losses/backward, optimizer/target updates and ordered replay writeback, with final synchronization. Host percentiles exclude that final synchronization. Profiler figures come from one additional completed update.

Three repetitions, 10 warm-up and 30 measured updates; ranges across runs:

| Variant | Mean update ms | Transitions/s | p50 host ms | p95 host ms | Peak CUDA MiB | Kernels/update | Profile GPU ms |
|---|---:|---:|---:|---:|---:|---:|---:|
| eager | 134.80–141.49 | 113.08–118.69 | 134.89–141.79 | 136.74–143.85 | 62.83–62.83 | 5428.00–5428.00 | 16.15–16.28 |
| compiled_scan | 134.45–219.49 | 72.90–119.01 | 134.27–218.08 | 138.05–231.43 | 62.21–62.21 | 3849.00–3849.00 | 13.38–16.48 |
| cuda_graph | 10.75–12.33 | 1297.41–1487.94 | 11.19–12.28 | 12.40–15.77 | 22.88–22.88 | 3893.00–3893.00 | 8.09–8.18 |
| compiled_train_step | 43.55–65.53 | 244.16–367.35 | 43.79–65.35 | 44.34–69.03 | 47.44–47.48 | 1598.00–1598.00 | 9.90–13.64 |
| compiled_train_step_cuda_graph | 12.47–15.68 | 1020.23–1283.33 | 12.17–16.07 | 14.44–19.26 | 22.86–22.86 | 1607.00–1607.00 | 7.20–7.93 |

Follow-up: three repetitions with 30 warm-up and 100 measured updates, keeping all other settings identical:

| Variant | Mean update ms | Transitions/s | p50 host ms | p95 host ms | Peak CUDA MiB | Kernels/update | Profile GPU ms |
|---|---:|---:|---:|---:|---:|---:|---:|
| compiled_scan | 110.00–146.80 | 108.99–145.45 | 109.99–146.55 | 112.76–152.48 | 62.21–62.21 | 3857.00–3857.00 | 13.26–14.83 |
| cuda_graph | 10.87–11.45 | 1396.77–1472.19 | 11.41–11.82 | 12.46–17.25 | 22.88–22.88 | 3901.00–3901.00 | 7.06–8.24 |
| compiled_train_step_cuda_graph | 11.28–12.42 | 1288.41–1418.57 | 11.63–12.75 | 13.17–14.55 | 22.86–22.90 | 1615.00–1615.00 | 6.08–7.19 |

Whole-step compilation improves this uncaptured workload over eager execution, but the captured whole-step variant is 3.8–8.4% slower than compiled scan plus CUDA graphs in the paired longer runs. It uses 1,615 kernels versus 3,901 and less profiled GPU time; the end-to-end difference therefore lies outside the reduced GPU kernel time, with host/replay overhead and run variation still relevant. Longer warm-up removes the largest short-run outlier but does not establish a captured throughput gain. This is an opt-in implementation for review, not a replacement for the existing fast preset. No training default changes.

Reproduce with `OMP_NUM_THREADS=1 TORCHINDUCTOR_COMPILE_THREADS=8 python benchmarks/ad_hoc/bench_dreamer_v3_learner.py --batch 2 --steps 8 --unroll 2 --warmup 10 --iterations 30 --replay-device cpu --variants eager compiled_scan cuda_graph compiled_train_step compiled_train_step_cuda_graph`; use `--warmup 30 --iterations 100 --variants compiled_scan cuda_graph compiled_train_step_cuda_graph` for the follow-up.

Oldest-dependency CI found a hard-coded Pendulum-v1 test assumption. Tests now use the existing version-aware Pendulum helper. All three native replay collection smoke cases pass against Gym 0.13; the downstream generic SOTA suite passes eight cases against the same backend. Production defaults are unchanged.

Validation after refreshing the stack onto main with #4297 merged (2026-09-08): the feature additions and removals are unchanged. The combined CPU DreamerV3, component, native-replay and config selection passed 394 tests, including separate-process checkpoint/resume. CUDA results and benchmark measurements above precede this restack; new CPU/GPU/dependency CI must validate the refreshed heads.
