### PR TITLE
[Feature] Support background replay collection in AsyncBatchedCollector

### DIFF
--- a/benchmarks/bench_collectors.py
+++ b/benchmarks/bench_collectors.py
@@ -8,6 +8,8 @@ CUDA hosts, ``--mujoco-gl egl``.
 Examples:
     python benchmarks/bench_collectors.py --total-frames 2000
     python benchmarks/bench_collectors.py --num-envs 1,2,4,8 --policy-delay-ms 20
+    python benchmarks/bench_collectors.py --backends async-env-mp --replay-mode iterator
+    python benchmarks/bench_collectors.py --backends async-env-mp --replay-mode background
     python benchmarks/bench_collectors.py --num-envs 64 \
         --backends async-env-mp --env-exchange shm \
         --env-step-latency-ms 50 --policy-hidden-features 9216 \
@@ -35,7 +37,14 @@ from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 
 from torchrl.collectors import AsyncBatchedCollector, Collector
-from torchrl.data import Bounded, Categorical, Composite, Unbounded
+from torchrl.data import (
+    Bounded,
+    Categorical,
+    Composite,
+    LazyTensorStorage,
+    ReplayBuffer,
+    Unbounded,
+)
 from torchrl.envs import (
     EnvBase,
     GymEnv,
@@ -73,8 +82,8 @@ class BenchmarkResult:
     status: str
     envs_per_worker: int = 1
     warmup_batches: int = 0
-    p50_batch_ms: float = 0.0
-    p95_batch_ms: float = 0.0
+    p50_batch_ms: float | None = 0.0
+    p95_batch_ms: float | None = 0.0
     host_rss_mib: float = 0.0
     cuda_used_mib: float = 0.0
     frames: int = 0
@@ -343,6 +352,7 @@ def bench(
     policy_delay_ms: float,
     warmup_batches: int,
     envs_per_worker: int = 1,
+    replay_mode: str = "none",
 ) -> BenchmarkResult:
     collector = None
     total = 0
@@ -350,21 +360,42 @@ def bench(
     policy_stats: dict[str, float | int] = {}
     try:
         collector = factory()
+        if replay_mode != "none":
+            # Both modes store the same number of transitions in the same storage.
+            collector.total_frames = total_frames + warmup_batches * frames_per_batch
+            collector.replay_buffer = ReplayBuffer(
+                storage=LazyTensorStorage(collector.total_frames)
+            )
         iterator = iter(collector)
         for _ in range(warmup_batches):
             next(iterator)
         if hasattr(collector, "server_stats"):
             collector.server_stats(reset=True)
         latencies = []
+        initial_frames = collector._frames
         t0 = previous = time_module.perf_counter()
-        for batch in iterator:
-            now = time_module.perf_counter()
-            latencies.append((now - previous) * 1000)
-            previous = now
-            n = batch.numel()
-            total += n
-            if total >= total_frames:
-                break
+        if replay_mode == "background":
+            iterator.close()
+            collector.start()
+            collector._replay_thread.join(timeout=300)
+            if collector._replay_thread.is_alive():
+                raise TimeoutError("Background replay benchmark exceeded 300 seconds.")
+            total = collector.replay_buffer.write_count - initial_frames
+            if collector._replay_error is not None:
+                raise RuntimeError(
+                    "Background replay benchmark failed."
+                ) from collector._replay_error
+        else:
+            for batch in iterator:
+                now = time_module.perf_counter()
+                latencies.append((now - previous) * 1000)
+                previous = now
+                if batch is None:
+                    total = collector.replay_buffer.write_count - initial_frames
+                else:
+                    total += batch.numel()
+                if total >= total_frames:
+                    break
         elapsed = time_module.perf_counter() - t0
         if hasattr(collector, "server_stats"):
             policy_stats = collector.server_stats()
@@ -379,7 +410,12 @@ def bench(
         if torch.device(policy_device).type == "cuda":
             free, capacity = torch.cuda.mem_get_info(policy_device)
             cuda_used = capacity - free
-        percentiles = torch.tensor(latencies).quantile(torch.tensor([0.5, 0.95]))
+        # Background collection has no consumer-side batch latency to report.
+        percentiles = (
+            torch.tensor(latencies).quantile(torch.tensor([0.5, 0.95]))
+            if latencies
+            else None
+        )
         fps = total / elapsed if elapsed > 0 else 0.0
         return BenchmarkResult(
             collector=name,
@@ -396,8 +432,8 @@ def bench(
             status="ok",
             envs_per_worker=envs_per_worker,
             warmup_batches=warmup_batches,
-            p50_batch_ms=percentiles[0].item(),
-            p95_batch_ms=percentiles[1].item(),
+            p50_batch_ms=percentiles[0].item() if percentiles is not None else None,
+            p95_batch_ms=percentiles[1].item() if percentiles is not None else None,
             host_rss_mib=host_rss / 2**20,
             cuda_used_mib=cuda_used / 2**20,
             frames=total,
@@ -559,6 +595,12 @@ def main() -> None:
         choices=["queue", "shm", "auto"],
         help="AsyncEnvPool exchange used by multiprocessing env backends.",
     )
+    parser.add_argument(
+        "--replay-mode",
+        choices=["none", "iterator", "background"],
+        default="none",
+        help="Replay write mode for async-env-mp; iterator and background use identical storage.",
+    )
     parser.add_argument("--policy-device", default="auto")
     parser.add_argument("--output-device", default="cpu")
     parser.add_argument("--jsonl", default="bench_collectors_results.jsonl")
@@ -700,8 +742,9 @@ def main() -> None:
                     ) = _resolve_batching_rule(rule, num_envs)
                     results.append(
                         bench(
-                            name=f"AsyncBatched mp env ({args.env_exchange})",
-                            backend=f"{backend}-{args.env_exchange}",
+                            name=f"AsyncBatched mp env ({args.env_exchange}, replay={args.replay_mode})",
+                            backend=f"{backend}-{args.env_exchange}-replay-{args.replay_mode}",
+                            replay_mode=args.replay_mode,
                             batch_rule=label,
                             factory=lambda num_envs=num_envs, max_batch_size=max_batch_size, min_batch_size=min_batch_size, timeout=timeout: AsyncBatchedCollector(
                                 create_env_fn=[env_factory] * num_envs,

--- a/docs/source/reference/collectors_single.rst
+++ b/docs/source/reference/collectors_single.rst
@@ -138,6 +138,14 @@ The pause context finishes in-flight environment and policy requests, parks
 the coordinator threads, and leaves the inference server idle. Collection
 resumes automatically when the context exits.
 
+With ``replay_buffer=buffer``, calling ``collector.start()`` writes complete
+batches in a background thread until ``total_frames`` is reached. The ordinary
+iterator still writes synchronously and yields ``None``. Choose one mode per
+collector. Background mode runs post-processing and post-collect hooks on the
+writer thread; ``collector.pause()`` waits for writes as well as environment and
+policy work to finish. Call ``collector.async_shutdown()`` to join the writer,
+close workers, and propagate collection or replay errors.
+
 .. _async_batched_collector_cpu_affinity:
 
 On Linux, ``worker_affinity`` assigns CPU masks to the multiprocessing

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -41,6 +41,8 @@ from torchrl._comm import (
 )
 from torchrl.data import (
     LazyTensorStorage,
+    ListStorage,
+    ReplayBuffer,
     ReplayBufferEnsemble,
     TensorDictReplayBuffer,
     TensorDictRoundRobinWriter,
@@ -2713,8 +2715,9 @@ class TestAsyncBatchedCollector:
             ("multiprocessing", "queue", 1, True),
         ],
     )
+    @pytest.mark.parametrize("background", [False, True])
     def test_parent_replay_write_and_post_collect_hook(
-        self, env_backend, env_exchange, envs_per_worker, process_slots
+        self, env_backend, env_exchange, envs_per_worker, process_slots, background
     ):
         """Post-processing, hooks and routed writes run in the parent."""
         parent_thread = threading.get_ident()
@@ -2762,7 +2765,14 @@ class TestAsyncBatchedCollector:
             env_backend=env_backend,
         )
         try:
-            outputs = list(collector)
+            if background:
+                collector.start()
+                parent_thread = collector._replay_thread.ident
+                collector._replay_thread.join(timeout=20)
+                assert not collector._replay_thread.is_alive()
+                outputs = [None]
+            else:
+                outputs = list(collector)
         finally:
             collector.shutdown()
 
@@ -2830,6 +2840,115 @@ class TestAsyncBatchedCollector:
             collector.shutdown(timeout=2.0)
 
         assert not any(worker.is_alive() for worker in workers)
+
+    @pytest.mark.parametrize("exchange", ["queue", "shm"])
+    def test_background_replay_owns_transitions_and_stops_at_budget(self, exchange):
+        replay = ReplayBuffer(storage=ListStorage(128))
+        collector = AsyncBatchedCollector(
+            create_env_fn=[ft.partial(_counting_env_factory, max_steps=10_000)] * 3,
+            policy=_make_counting_policy(),
+            frames_per_batch=16,
+            total_frames=97,
+            replay_buffer=replay,
+            env_backend="multiprocessing",
+            env_exchange=exchange,
+        )
+        try:
+            collector.start()
+            with pytest.raises(RuntimeError, match="already collecting"):
+                collector.start()
+            with pytest.raises(RuntimeError, match="Background collection owns"):
+                next(iter(collector))
+            collector._replay_thread.join(timeout=20)
+            assert not collector._replay_thread.is_alive()
+            assert replay.write_count == 97
+            stored = replay[:].clone()
+            # Let workers reuse their exchange slots after the final replay write.
+            time.sleep(0.1)
+            assert replay.write_count == 97
+            assert_close(replay[:], stored)
+            torch.testing.assert_close(
+                stored["next", "observation"], stored["observation"] + 1
+            )
+            for env_id in stored["env_index"].unique():
+                obs = stored[stored["env_index"] == env_id]["observation"].flatten()
+                torch.testing.assert_close(obs, torch.arange(len(obs), dtype=obs.dtype))
+        finally:
+            collector.async_shutdown()
+
+    @pytest.mark.parametrize("fail", [False, True])
+    def test_background_replay_pause_and_error_shutdown(self, fail):
+        replay = ReplayBuffer(storage=LazyTensorStorage(128))
+        wrote = threading.Event()
+
+        def post_collect(td):
+            if fail:
+                raise ValueError("replay hook failed")
+            wrote.set()
+
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * 2,
+            policy=_make_counting_policy(),
+            frames_per_batch=4,
+            replay_buffer=replay,
+            post_collect_hook=post_collect,
+        )
+        collector.start()
+        writer = collector._replay_thread
+        workers = list(collector._workers)
+        try:
+            if fail:
+                writer.join(timeout=10)
+                with pytest.raises(
+                    RuntimeError, match="Background replay collection failed"
+                ) as error:
+                    collector.async_shutdown()
+                assert isinstance(error.value.__cause__, ValueError)
+            else:
+                assert wrote.wait(timeout=10)
+                with collector.pause(timeout=10):
+                    count = replay.write_count
+                    time.sleep(0.1)
+                    assert replay.write_count == count
+                collector.async_shutdown()
+            assert not writer.is_alive()
+            assert not any(worker.is_alive() for worker in workers)
+        finally:
+            collector.shutdown(raise_on_error=False)
+
+    def test_background_replay_shutdown_retains_blocked_writer(self):
+        entered, release = threading.Event(), threading.Event()
+
+        def blocking_hook(td):
+            entered.set()
+            if not release.wait(timeout=10):
+                raise TimeoutError("Replay hook was not released.")
+            raise ValueError("Replay hook failed during shutdown.")
+
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory],
+            policy=_make_counting_policy(),
+            frames_per_batch=1,
+            replay_buffer=ReplayBuffer(storage=ListStorage(16)),
+            post_collect_hook=blocking_hook,
+        )
+        try:
+            collector.start()
+            assert entered.wait(timeout=10)
+            writer = collector._replay_thread
+            with pytest.raises(TimeoutError, match="replay writer did not stop"):
+                collector.async_shutdown(timeout=0.1)
+            assert writer.is_alive()
+            release.set()
+            with pytest.raises(
+                RuntimeError, match="Background replay collection failed"
+            ) as error:
+                collector.async_shutdown()
+            assert isinstance(error.value.__cause__, ValueError)
+            assert not writer.is_alive()
+        finally:
+            release.set()
+            collector.shutdown(raise_on_error=False)
 
     @pytest.mark.parametrize("total_frames", [60, 61])
     def test_basic_collection(self, total_frames):

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -57,6 +57,10 @@ _ENV_BACKENDS = ("threading", "multiprocessing")
 _PauseRequest = tuple[threading.Barrier, threading.Event]
 
 
+class _CollectorStopped(RuntimeError):
+    """Internal signal interrupting a blocked rollout during shutdown."""
+
+
 def _make_transport(
     policy_backend: str, num_slots: int | None = None
 ) -> InferenceTransport:
@@ -848,6 +852,10 @@ class AsyncBatchedCollector(BaseCollector):
         self._pause_request: list[_PauseRequest | None] = [None]
         self._pause_lock = threading.Lock()
         self._transition_carry: deque[TensorDictBase] = deque()
+        self._iteration_lock = threading.Lock()
+        self._replay_lock = threading.Lock()
+        self._replay_thread: threading.Thread | None = None
+        self._replay_error: Exception | None = None
 
         # Per-env trajectory accumulators (for yield_completed_trajectories)
         self._yield_queues: list[deque] = [deque() for _ in range(self._num_envs)]
@@ -1087,6 +1095,7 @@ class AsyncBatchedCollector(BaseCollector):
 
         workers = tuple(self._workers)
         request = None
+        replay_locked = False
         try:
             if not workers:
                 yield None
@@ -1110,6 +1119,13 @@ class AsyncBatchedCollector(BaseCollector):
                             "Timed out while waiting for environment workers to pause."
                         )
                     self._shutdown_event.wait(0.01)
+                replay_locked = self._replay_lock.acquire(
+                    timeout=-1 if timeout is None else timeout
+                )
+                if not replay_locked:
+                    raise TimeoutError(
+                        "Timed out waiting for the replay writer to pause."
+                    )
                 yield None
                 return
 
@@ -1128,9 +1144,16 @@ class AsyncBatchedCollector(BaseCollector):
                     "coordinator threads to pause."
                 ) from None
 
+            replay_locked = self._replay_lock.acquire(
+                timeout=-1 if timeout is None else timeout
+            )
+            if not replay_locked:
+                raise TimeoutError("Timed out waiting for the replay writer to pause.")
             yield None
         finally:
             try:
+                if replay_locked:
+                    self._replay_lock.release()
                 if self._uses_process_env_workers and workers:
                     self._process_pause_event.clear()
                     # Wait for acknowledgement reset before a subsequent pause.
@@ -1271,6 +1294,10 @@ class AsyncBatchedCollector(BaseCollector):
         """
         rq = self._result_queue
         while True:
+            if self._shutdown_event.is_set():
+                raise _CollectorStopped(
+                    "The collector has stopped collecting transitions."
+                )
             if (
                 self._uses_process_env_workers
                 and self._worker_check_timer.elapsed() >= self._LIVENESS_POLL_S
@@ -1280,6 +1307,8 @@ class AsyncBatchedCollector(BaseCollector):
             try:
                 td = rq.get(timeout=self._LIVENESS_POLL_S)
             except queue.Empty:
+                if self._shutdown_event.is_set():
+                    continue
                 if not self._server.is_alive:
                     raise RuntimeError(
                         "The inference server died while the collector was "
@@ -1415,31 +1444,89 @@ class AsyncBatchedCollector(BaseCollector):
     # BaseCollector interface
     # ------------------------------------------------------------------
 
+    def start(self) -> None:
+        """Collect into replay in a background thread until ``total_frames``.
+
+        Requires ``replay_buffer``. Post-processing and the post-collect hook
+        run on the writer thread. Iteration and background collection are
+        mutually exclusive. Use :meth:`pause` to quiesce collection and writes,
+        and :meth:`async_shutdown` to join the writer and surface its errors.
+        """
+        if self.replay_buffer is None:
+            raise RuntimeError("Background collection requires a replay_buffer.")
+        if self._replay_thread is not None or self._iteration_lock.locked():
+            raise RuntimeError("The collector is already collecting.")
+        self._ensure_started()
+        self._replay_error = None
+        self._iteration_started = True
+        self._replay_thread = threading.Thread(
+            target=self._run_replay,
+            name="AsyncBatchedCollector-replay",
+            daemon=True,
+        )
+        self._replay_thread.start()
+
+    def _run_replay(self) -> None:
+        try:
+            for _ in self.iterator():
+                pass
+        except Exception as exc:
+            self._replay_error = exc
+            self._shutdown_event.set()
+
+    def __iter__(self) -> Iterator[TensorDictBase | None]:
+        if self._replay_thread is not None:
+            # Reject concurrent consumption before BaseCollector's iterator
+            # error handler shuts down the active background collector.
+            raise RuntimeError("Background collection owns the collector iterator.")
+        return super().__iter__()
+
     def iterator(self) -> Iterator[TensorDictBase | None]:
         """Iterate over collected batches."""
+        if self._replay_thread is not None and (
+            threading.current_thread() is not self._replay_thread
+        ):
+            raise RuntimeError("Background collection owns the collector iterator.")
         self._ensure_started()
-
-        total = self.total_frames
-        while total < 0 or self._frames < total:
-            self._iter += 1
-            td = self.rollout()
-            if not self.yield_completed_trajectories and total >= 0:
-                remaining = total - self._frames
-                if td.numel() > remaining:
-                    td = td.reshape(-1)[:remaining]
-            self._frames += td.numel()
-            if self._postproc is not None:
-                td = self._postproc(td)
-            if self.post_collect_hook is not None:
-                self.post_collect_hook(td)
-            if self.replay_buffer is not None:
-                td = _maybe_normalize_replay_buffer_tensordict_device(
-                    td, self.replay_buffer
-                )
-                self.replay_buffer.extend(td)
-                yield None
-            else:
+        if not self._iteration_lock.acquire(blocking=False):
+            raise RuntimeError("The collector is already collecting.")
+        try:
+            total = self.total_frames
+            while (
+                total < 0 or self._frames < total
+            ) and not self._shutdown_event.is_set():
+                self._iter += 1
+                td = self.rollout()
+                # The pause boundary includes post-processing and replay writes.
+                # Never hold this lock while waiting for a paused environment.
+                while not self._replay_lock.acquire(timeout=0.1):
+                    if self._shutdown_event.is_set():
+                        return
+                try:
+                    if self._shutdown_event.is_set():
+                        return
+                    if not self.yield_completed_trajectories and total >= 0:
+                        remaining = total - self._frames
+                        if td.numel() > remaining:
+                            td = td.reshape(-1)[:remaining]
+                    self._frames += td.numel()
+                    if self._postproc is not None:
+                        td = self._postproc(td)
+                    if self.post_collect_hook is not None:
+                        self.post_collect_hook(td)
+                    if self.replay_buffer is not None:
+                        td = _maybe_normalize_replay_buffer_tensordict_device(
+                            td, self.replay_buffer
+                        )
+                        self.replay_buffer.extend(td)
+                        td = None
+                finally:
+                    self._replay_lock.release()
                 yield td
+        except _CollectorStopped:
+            return
+        finally:
+            self._iteration_lock.release()
 
     def shutdown(
         self,
@@ -1458,6 +1545,11 @@ class AsyncBatchedCollector(BaseCollector):
         self._transition_carry.clear()
         _timeout = 5.0 if timeout is None else timeout
         shutdown_timer = timeit("AsyncBatchedCollector.shutdown").start()
+        replay_thread = self._replay_thread
+        if replay_thread is not None:
+            replay_thread.join(timeout=_timeout)
+            if not replay_thread.is_alive():
+                self._replay_thread = None
         if self._uses_process_env_workers:
             while any(worker.is_alive() for worker in self._workers):
                 if shutdown_timer.elapsed() >= _timeout:
@@ -1495,6 +1587,16 @@ class AsyncBatchedCollector(BaseCollector):
             self._worker_error_queue.close()
             self._worker_error_queue.join_thread()
             self._worker_error_queue = None
+
+        if raise_on_error:
+            if replay_thread is not None and replay_thread.is_alive():
+                raise TimeoutError(
+                    "The replay writer did not stop before shutdown timed out."
+                )
+            if self._replay_error is not None:
+                error = self._replay_error
+                self._replay_error = None
+                raise RuntimeError("Background replay collection failed.") from error
 
     def set_seed(self, seed: int, static_seed: bool = False) -> int:
         """Set the seed (no-op; envs are created inside the pool)."""


### PR DESCRIPTION
AsyncBatchedCollector can now collect directly into replay while the caller trains independently. `start()` runs the existing iterator on a dedicated writer thread; ordinary iteration retains synchronous replay writes and yields `None`.

The writer consumes owned transitions through the existing bounded collector queues. Queue and shared-memory exchange, grouped environments, process-slot workers, replay routing, post-processing, and post-collect hooks retain their existing collection behavior. Frame batches obey the exact remaining frame budget, including a partial final batch. Background hooks run on the writer thread.

`pause()` also waits for replay writes to finish. `async_shutdown()` interrupts blocked rollout reads, joins the writer, and reports background errors. A user hook or storage operation that outlives the shutdown timeout is reported and its thread remains tracked for a subsequent join. Foreground iteration and background collection cannot consume the same collector concurrently.

The benchmark adds `--replay-mode iterator` and `--replay-mode background` for `async-env-mp`. Both use identical replay storage, frame budgets, and warm-up counts; background mode does not report consumer-side batch latency.

Validation: the CPU AsyncBatchedCollector suite passed (74 passed, 3 Linux-only CPU-affinity cases skipped on macOS), using current TensorDict main. Coverage includes both replay modes across thread/process workers and grouped environments, exact frame counts, ListStorage ownership after exchange-slot reuse, pause, worker failure, blocked-hook shutdown, and background error propagation. Formatting, lint, and docstring-argument checks passed. Iterator and background benchmark smoke runs each stored exactly 32 measured frames after one 16-frame warm-up batch; this validates the benchmark workload, not a performance claim.

Rebased onto current origin/main. GPU and Linux-only validation remain with CI.
