### PR TITLE
[Performance] Let AsyncEnvPool workers host multiple environments

### DIFF
--- a/benchmarks/test_envs_benchmark.py
+++ b/benchmarks/test_envs_benchmark.py
@@ -210,6 +210,9 @@ ASYNC_POOL_AFFINITY_STEP_LATENCY = 1e-3
 _AFFINITY_CPUS = (
     tuple(sorted(os.sched_getaffinity(0))) if hasattr(os, "sched_getaffinity") else ()
 )
+ASYNC_POOL_GROUPING_ENVS = 64
+ASYNC_POOL_GROUPING_TRANSITIONS = 512
+ASYNC_POOL_GROUPING_STEP_LATENCY = 0.05
 
 
 class DelayedCountingEnv(CountingEnv):
@@ -240,6 +243,7 @@ def _make_async_pool(
     reset_latency,
     max_steps,
     worker_affinity=None,
+    envs_per_worker=1,
 ):
     pool = AsyncEnvPool(
         [
@@ -254,6 +258,7 @@ def _make_async_pool(
         backend="multiprocessing",
         exchange=exchange,
         worker_affinity=worker_affinity,
+        envs_per_worker=envs_per_worker,
     )
     # Prime the steady state: after this, every round starts with a recv.
     tensordict = pool.reset()
@@ -465,6 +470,42 @@ def test_async_env_pool_step_latency_jitter(benchmark, pinned):
                         min(len(samples_ms) - 1, int(len(samples_ms) * 0.99))
                     ],
                 }
+            )
+        finally:
+            pool._maybe_shutdown()
+
+
+@pytest.mark.parametrize(
+    "envs_per_worker",
+    [1, 4],
+    ids=["64-processes", "16-processes-of-4"],
+)
+def test_async_env_pool_multi_env_workers(benchmark, envs_per_worker):
+    """Compare process layouts for many sleeping environments."""
+    with set_capture_non_tensor_stack(False):
+        pool = _make_async_pool(
+            ASYNC_POOL_GROUPING_ENVS,
+            "shm",
+            step_latency=ASYNC_POOL_GROUPING_STEP_LATENCY,
+            reset_latency=0.0,
+            max_steps=10_000_000,
+            envs_per_worker=envs_per_worker,
+        )
+        try:
+            benchmark.extra_info["num_envs"] = ASYNC_POOL_GROUPING_ENVS
+            benchmark.extra_info["num_processes"] = pool.num_workers
+            benchmark.extra_info["envs_per_worker"] = envs_per_worker
+            benchmark.extra_info["transitions"] = ASYNC_POOL_GROUPING_TRANSITIONS
+            benchmark.pedantic(
+                _async_pool_harvest,
+                args=(
+                    pool,
+                    ASYNC_POOL_GROUPING_TRANSITIONS,
+                    ASYNC_POOL_GROUPING_ENVS,
+                ),
+                rounds=5,
+                warmup_rounds=1,
+                iterations=1,
             )
         finally:
             pool._maybe_shutdown()

--- a/docs/source/reference/envs_vectorized.rst
+++ b/docs/source/reference/envs_vectorized.rst
@@ -356,16 +356,39 @@ per-environment receives own their tensor storage. Aggregate batches returned
 with ``stack="lazy"`` are views over the shared slots and remain valid only until
 actions are sent back to the corresponding environments.
 
+Multiprocessing pools can reduce process and command-pipe overhead by hosting
+several environments in each worker:
+
+.. code-block:: python
+
+    env = AsyncEnvPool(
+        [make_env] * 64,
+        backend="multiprocessing",
+        exchange="shm",
+        envs_per_worker=4,
+    )
+
+Each worker runs its environments concurrently in threads, so grouping is most
+useful for I/O-bound environments. CPU-bound Python environments can contend
+for the GIL and should generally keep ``envs_per_worker=1``. The process count
+is ``ceil(num_envs / envs_per_worker)``. Grouping also changes CPU-affinity
+granularity: a worker affinity mask applied before its environment threads are
+created is inherited by all of them, while tools that pin an already-running
+PID may need to target every thread explicitly. Container CPU sets and quotas
+apply to the grouped process and all of its threads; use one environment per
+worker when environments require independent CPU placement.
+
 .. _async_env_pool_cpu_affinity:
 
 CPU affinity (Linux)
 ~~~~~~~~~~~~~~~~~~~~
 
 The multiprocessing backend accepts ``worker_affinity`` to restrict each
-environment worker to selected CPUs. Pass one CPU mask per environment or a
-callable that returns a mask for an environment index. The mask is applied
-before the environment factory runs, so subprocesses created by the factory
-inherit the worker's affinity.
+worker process to selected CPUs. Pass one CPU mask per worker process or a
+callable that returns a mask for a worker index. With ``envs_per_worker=4`` and
+64 environments, provide 16 masks. The mask is applied before environment
+threads and factories start, so all environments in a worker and subprocesses
+created by their factories inherit the worker's affinity.
 
 This option is intended for deployments where Python workers, CPU-heavy
 simulators, and driver services share a constrained CPU set. Without explicit
@@ -426,9 +449,9 @@ Classes
 - :class:`~torchrl.envs.AsyncEnvPool`: A base class for asynchronous environment pools. It determines the backend
   implementation to use based on the provided arguments and manages the lifecycle of the environments.
 - :class:`~torchrl.envs.ProcessorAsyncEnvPool`: An implementation of :class:`~torchrl.envs.AsyncEnvPool` using
-  multiprocessing for parallel execution of environments. This class manages a pool of environments, each running in
-  its own process, and provides methods for asynchronous stepping and resetting of environments using inter-process
-  communication. It is automatically instantiated when `"multiprocessing"` is passed as a backend during the
+  multiprocessing for parallel execution of environments. This class manages a pool of environments across worker
+  processes and provides methods for asynchronous stepping and resetting using inter-process communication. It is
+  automatically instantiated when `"multiprocessing"` is passed as a backend during the
   :class:`~torchrl.envs.AsyncEnvPool` instantiation.
 - :class:`~torchrl.envs.ThreadingAsyncEnvPool`: An implementation of :class:`~torchrl.envs.AsyncEnvPool` using
   threading for parallel execution of environments. This class manages a pool of environments, each running in its own

--- a/test/envs/test_special.py
+++ b/test/envs/test_special.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import contextlib
+import multiprocessing
 import os
 import pickle
 import threading
@@ -84,6 +85,11 @@ class _DelayedCountingEnv(CountingEnv):
 
 def _round_robin_affinity(env_index, *, cpus):
     return (cpus[env_index % len(cpus)],)
+
+
+def _counting_env_with_affinity_report(env_index, reports):
+    reports.put((env_index, os.sched_getaffinity(0)))
+    return CountingEnv()
 
 
 class _ManyKeysCountingEnv(CountingEnv):
@@ -897,9 +903,12 @@ class TestAsyncEnvPool:
             partial(CountingEnv),
         ]
 
-    @pytest.mark.parametrize("backend", ["multiprocessing", "threading"])
-    def test_specs(self, backend, make_envs):
-        env = self.make_env(makers=make_envs, backend=backend)
+    @pytest.mark.parametrize(
+        ("backend", "envs_per_worker"),
+        [("multiprocessing", 1), ("multiprocessing", 3), ("threading", 1)],
+    )
+    def test_specs(self, backend, envs_per_worker, make_envs):
+        env = AsyncEnvPool(make_envs, backend=backend, envs_per_worker=envs_per_worker)
         assert env.batch_size == (4,)
         try:
             if backend == "multiprocessing":
@@ -921,24 +930,38 @@ class TestAsyncEnvPool:
         not hasattr(os, "sched_setaffinity"),
         reason="CPU affinity requires Linux",
     )
-    def test_worker_affinity_callable(self, make_envs):
+    @pytest.mark.parametrize("envs_per_worker", [1, 3])
+    def test_worker_affinity_callable(self, make_envs, envs_per_worker):
         cpus = tuple(np.int64(cpu) for cpu in sorted(os.sched_getaffinity(0)))
         affinity = partial(_round_robin_affinity, cpus=cpus)
+        reports = multiprocessing.Queue()
         env = AsyncEnvPool(
-            make_envs,
+            [
+                partial(_counting_env_with_affinity_report, env_index, reports)
+                for env_index in range(len(make_envs))
+            ],
             backend="multiprocessing",
             exchange="queue",
             worker_affinity=affinity,
+            envs_per_worker=envs_per_worker,
         )
         try:
             expected = [
-                {cpus[env_index % len(cpus)]} for env_index in range(env.num_envs)
+                {cpus[worker_index % len(cpus)]}
+                for worker_index in range(env.num_workers)
             ]
             assert [
                 os.sched_getaffinity(process.pid) for process in env.threads
             ] == expected
+            factory_masks = dict(reports.get(timeout=10) for _ in make_envs)
+            assert factory_masks == {
+                env_index: expected[env_index // envs_per_worker]
+                for env_index in range(len(make_envs))
+            }
         finally:
             env._maybe_shutdown()
+            reports.close()
+            reports.join_thread()
 
     @pytest.mark.skipif(
         not hasattr(os, "sched_setaffinity"),
@@ -960,7 +983,10 @@ class TestAsyncEnvPool:
         not hasattr(os, "sched_setaffinity"),
         reason="CPU affinity requires Linux",
     )
-    def test_worker_affinity_error_shuts_down_workers(self, make_envs, monkeypatch):
+    @pytest.mark.parametrize("envs_per_worker", [1, 3])
+    def test_worker_affinity_error_shuts_down_workers(
+        self, make_envs, monkeypatch, envs_per_worker
+    ):
         available_cpu = next(iter(os.sched_getaffinity(0)))
         unavailable_cpu = max(os.sched_getaffinity(0)) + 1
         processes = []
@@ -982,7 +1008,9 @@ class TestAsyncEnvPool:
                 make_envs,
                 backend="multiprocessing",
                 exchange="queue",
-                worker_affinity=[(available_cpu,)] * len(make_envs),
+                worker_affinity=[(available_cpu,)]
+                * ((len(make_envs) + envs_per_worker - 1) // envs_per_worker),
+                envs_per_worker=envs_per_worker,
             )
 
         assert processes
@@ -992,17 +1020,19 @@ class TestAsyncEnvPool:
         ("backend", "worker_affinity", "match"),
         [
             ("threading", [(0,)] * 4, "only supported"),
-            ("multiprocessing", [(0,)], "one CPU mask per environment"),
+            ("multiprocessing", [(0,)], "one CPU mask per worker process"),
         ],
     )
+    @pytest.mark.parametrize("envs_per_worker", [1, 3])
     def test_worker_affinity_validation(
-        self, make_envs, backend, worker_affinity, match
+        self, make_envs, backend, worker_affinity, match, envs_per_worker
     ):
         with pytest.raises(ValueError, match=match):
             AsyncEnvPool(
                 make_envs,
                 backend=backend,
                 worker_affinity=worker_affinity,
+                envs_per_worker=envs_per_worker,
             )
 
     @pytest.mark.parametrize("backend", ["multiprocessing", "threading"])
@@ -1070,6 +1100,57 @@ class TestAsyncEnvPool:
             assert "observation" in message
         finally:
             env._maybe_shutdown()
+
+    @pytest.mark.parametrize("exchange", ["queue", "shm"])
+    @set_capture_non_tensor_stack(False)
+    def test_multiprocessing_envs_per_worker(self, exchange):
+        makers = [partial(CountingEnv, start_val=index) for index in range(5)]
+        env = AsyncEnvPool(
+            makers,
+            backend="multiprocessing",
+            exchange=exchange,
+            envs_per_worker=2,
+        )
+        try:
+            assert env.num_workers == 3
+            assert len(env.threads) == 3
+
+            reset = env.reset()
+            torch.testing.assert_close(
+                reset["observation"].squeeze(-1),
+                torch.arange(5, dtype=torch.int32),
+            )
+            reset.set("action", torch.ones(reset.shape + (1,)))
+            step, next_step = env.step_and_maybe_reset(reset)
+            torch.testing.assert_close(
+                step["next", "observation"].squeeze(-1),
+                torch.arange(1, 6, dtype=torch.int32),
+            )
+            assert list(next_step[env._env_idx_key]) == list(range(5))
+
+            env.async_reset_send(env_index=4)
+            per_env_reset = env.async_reset_recv(env_index=4)
+            assert per_env_reset[env._env_idx_key] == 4
+        finally:
+            env._maybe_shutdown()
+
+    @pytest.mark.parametrize("envs_per_worker", [0, -1, 1.5, True])
+    def test_invalid_envs_per_worker(self, make_envs, envs_per_worker):
+        with pytest.raises(ValueError, match="positive integer"):
+            AsyncEnvPool(
+                make_envs,
+                backend="multiprocessing",
+                exchange="queue",
+                envs_per_worker=envs_per_worker,
+            )
+
+    def test_envs_per_worker_rejects_threading(self, make_envs):
+        with pytest.raises(ValueError, match="only supported"):
+            AsyncEnvPool(
+                make_envs,
+                backend="threading",
+                envs_per_worker=2,
+            )
 
     @set_capture_non_tensor_stack(False)
     def test_shared_memory_full_batch_preserves_env_order(self):
@@ -1245,6 +1326,29 @@ class TestAsyncEnvPool:
             for proc in env.threads:
                 if proc.is_alive():
                     proc.terminate()
+
+    @pytest.mark.parametrize("envs_per_worker", [1, 2])
+    def test_shutdown_after_worker_death_with_full_command_queue(self, envs_per_worker):
+        env = AsyncEnvPool(
+            [partial(CountingEnv)] * 2,
+            backend="multiprocessing",
+            exchange="queue",
+            envs_per_worker=envs_per_worker,
+        )
+        env.threads[0].terminate()
+        env.threads[0].join(timeout=5)
+        env.input_queue[0].put(("get_specs", [(0, None)]), timeout=1)
+        shutdown_thread = threading.Thread(target=env.shutdown, daemon=True)
+        try:
+            shutdown_thread.start()
+            shutdown_thread.join(timeout=5)
+            assert not shutdown_thread.is_alive(), "shutdown blocked on a dead worker"
+            assert all(not process.is_alive() for process in env.threads)
+        finally:
+            for process in env.threads:
+                if process.is_alive():
+                    process.terminate()
+                    process.join(timeout=5)
 
     @set_capture_non_tensor_stack(False)
     def test_queue_per_env_results_release_shared_mappings(self):

--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -429,6 +429,7 @@ class TestEnvConfigs:
             batched_env_type="async",
             backend="multiprocessing",
             exchange="shm",
+            envs_per_worker=2,
         )
         with warnings.catch_warnings():
             warnings.filterwarnings(
@@ -438,6 +439,7 @@ class TestEnvConfigs:
         try:
             assert isinstance(env, AsyncEnvPool)
             assert env.exchange == "shm"
+            assert env.num_workers == 1
         finally:
             env.close(raise_if_closed=False)
 
@@ -454,6 +456,7 @@ class TestEnvConfigs:
 
         config = OmegaConf.merge(config, {"worker_affinity": [[0, 1], [2, 3]]})
         assert config.worker_affinity == [[0, 1], [2, 3]]
+        assert config.envs_per_worker == 1
 
     @pytest.mark.parametrize(
         ("field", "value"),

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -2206,6 +2206,27 @@ from torchrl.collectors import AsyncBatchedCollector, Collector
 from torchrl.testing.mocking_classes import CountingEnv
 
 
+class _ControlledResetEnv(CountingEnv):
+    def __init__(self, *, reset_index=0, entered=None, release=None, fail=False):
+        super().__init__(max_steps=0)
+        self._reset_index = reset_index
+        self._reset_count = 0
+        self._entered = entered
+        self._release = release
+        self._fail = fail
+
+    def _reset(self, tensordict=None, **kwargs):
+        if self._reset_count == self._reset_index:
+            if self._entered is not None:
+                self._entered.set()
+            if self._fail:
+                raise ValueError("controlled reset failure")
+            if self._release is not None and not self._release.wait(timeout=10):
+                raise TimeoutError("reset was not released")
+        self._reset_count += 1
+        return super()._reset(tensordict, **kwargs)
+
+
 def _counting_env_factory(max_steps=5):
     """Factory that returns a CountingEnv."""
     return CountingEnv(max_steps=max_steps)
@@ -2609,17 +2630,22 @@ class TestAsyncBatchedCollector:
         assert collected >= 50
 
     @pytest.mark.parametrize(
-        ("env_backend", "env_exchange"),
-        [("threading", "queue"), ("multiprocessing", "shm")],
+        ("env_backend", "env_exchange", "envs_per_worker"),
+        [
+            ("threading", "queue", 1),
+            ("multiprocessing", "queue", 2),
+            ("multiprocessing", "shm", 2),
+        ],
     )
-    def test_pause_for_torch_compile(self, env_backend, env_exchange):
+    def test_pause_for_torch_compile(self, env_backend, env_exchange, envs_per_worker):
         """Compilation can run while a started collector is quiescent."""
         collector = AsyncBatchedCollector(
-            create_env_fn=[_counting_env_factory] * 4,
+            create_env_fn=[_counting_env_factory] * 5,
             policy=_make_counting_policy(),
             frames_per_batch=10,
             total_frames=-1,
             env_backend=env_backend,
+            envs_per_worker=envs_per_worker,
             env_exchange=env_exchange,
         )
         iterator = iter(collector)
@@ -2750,36 +2776,41 @@ class TestAsyncBatchedCollector:
                 env_exchange="shm",
             )
 
-    def test_worker_affinity_validation_is_eager(self):
-        with pytest.raises(ValueError, match="one CPU mask per environment"):
+    @pytest.mark.parametrize("envs_per_worker", [1, 2])
+    def test_worker_affinity_validation_is_eager(self, envs_per_worker):
+        with pytest.raises(ValueError, match="one CPU mask per worker process"):
             AsyncBatchedCollector(
-                create_env_fn=[_counting_env_factory] * 2,
+                create_env_fn=[_counting_env_factory] * 3,
                 policy=_make_counting_policy(),
                 frames_per_batch=10,
                 total_frames=10,
                 env_backend="multiprocessing",
                 worker_affinity=[(0,)],
+                envs_per_worker=envs_per_worker,
             )
 
     @pytest.mark.skipif(
         not hasattr(os, "sched_setaffinity"),
         reason="CPU affinity requires Linux",
     )
-    def test_cpu_affinity(self):
+    @pytest.mark.parametrize("envs_per_worker", [1, 2])
+    def test_cpu_affinity(self, envs_per_worker):
         """Worker processes and driver threads use their configured masks."""
         original_affinity = os.sched_getaffinity(0)
         cpus = sorted(original_affinity)
         driver_affinity = (cpus[0],)
         worker_affinity = (cpus[-1],)
         collector = AsyncBatchedCollector(
-            create_env_fn=[_counting_env_factory] * 2,
+            create_env_fn=[_counting_env_factory] * 3,
             policy=_make_counting_policy(),
             frames_per_batch=10,
             total_frames=10,
             max_batch_size=2,
             env_backend="multiprocessing",
-            worker_affinity=[worker_affinity] * 2,
+            worker_affinity=[worker_affinity]
+            * ((3 + envs_per_worker - 1) // envs_per_worker),
             driver_affinity=driver_affinity,
+            envs_per_worker=envs_per_worker,
         )
         try:
             collector._ensure_started()
@@ -2798,6 +2829,90 @@ class TestAsyncBatchedCollector:
                 == set(driver_affinity)
                 for input_queue in collector.env.input_queue
             )
+        finally:
+            collector.shutdown()
+
+    def test_multiprocessing_envs_per_worker(self):
+        """Grouped workers preserve every stream with a single receive owner."""
+        num_envs = 5
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * num_envs,
+            policy=_make_counting_policy(),
+            frames_per_batch=25,
+            total_frames=25,
+            max_batch_size=num_envs,
+            env_backend="multiprocessing",
+            envs_per_worker=2,
+        )
+        try:
+            batch = next(iter(collector))
+            env_ids = {int(env_id) for env_id in batch["env_index"]}
+            assert env_ids == set(range(num_envs))
+            assert len(collector.env.threads) == 3
+            assert len(collector._workers) == 1
+        finally:
+            collector.shutdown()
+
+    @pytest.mark.parametrize("env_exchange", ["queue", "shm"])
+    @pytest.mark.parametrize("reset_index", [0, 1])
+    def test_grouped_slow_reset_keeps_other_stream_running(
+        self, env_exchange, reset_index
+    ):
+        ctx = mp.get_context("spawn")
+        entered, release = ctx.Event(), ctx.Event()
+        collector = AsyncBatchedCollector(
+            create_env_fn=[
+                ft.partial(
+                    _ControlledResetEnv,
+                    reset_index=reset_index,
+                    entered=entered,
+                    release=release,
+                ),
+                _counting_env_factory,
+            ],
+            policy=_make_counting_policy(),
+            frames_per_batch=8,
+            total_frames=24,
+            env_backend="multiprocessing",
+            env_exchange=env_exchange,
+            envs_per_worker=2,
+        )
+        try:
+            collector._ensure_started()
+            assert entered.wait(timeout=5)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                try:
+                    batches = executor.submit(list, collector).result(timeout=5)
+                    assert sum(batch.numel() for batch in batches) == 24
+                    assert all(
+                        int(index) == 1
+                        for batch in batches
+                        for index in batch["env_index"]
+                    )
+                finally:
+                    release.set()
+        finally:
+            release.set()
+            collector.shutdown()
+
+    @pytest.mark.parametrize("env_exchange", ["queue", "shm"])
+    def test_grouped_environment_error_reaches_collector(self, env_exchange):
+        collector = AsyncBatchedCollector(
+            create_env_fn=[
+                ft.partial(_ControlledResetEnv, reset_index=1, fail=True),
+                _counting_env_factory,
+            ],
+            policy=_make_counting_policy(),
+            frames_per_batch=8,
+            env_backend="multiprocessing",
+            env_exchange=env_exchange,
+            envs_per_worker=2,
+        )
+        try:
+            with pytest.raises(RuntimeError) as error:
+                for _ in collector:
+                    pass
+            assert "controlled reset failure" in str(error.value.__cause__)
         finally:
             collector.shutdown()
 

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -180,17 +180,31 @@ def _env_batch_loop(
     try:
         env_ids = list(range(pool.num_envs))
         pool.async_reset_send(env_index=env_ids)
-        observations = pool.async_reset_recv(min_get=pool.num_envs)
-        for env_id, observation in zip(_env_ids(observations), observations.unbind(0)):
-            ready_observations[env_id] = observation
+        resetting = pool.num_envs
 
         while not shutdown_event.is_set():
+            if resetting:
+                try:
+                    observations = pool.async_reset_recv(
+                        min_get=1, max_get=resetting, timeout=poll_interval
+                    )
+                except TimeoutError:
+                    pass
+                else:
+                    reset_ids = _env_ids(observations)
+                    resetting -= len(reset_ids)
+                    ready_observations.update(zip(reset_ids, observations.unbind(0)))
             if pause_request[0] is None and ready_observations:
                 for env_id, observation in ready_observations.items():
                     pending_actions[env_id] = clients[env_id].submit(observation)
                 ready_observations.clear()
 
-            if pause_request[0] is not None and not pending_actions and not stepping:
+            if (
+                pause_request[0] is not None
+                and not resetting
+                and not pending_actions
+                and not stepping
+            ):
                 _wait_while_paused(pause_request)
                 continue
 
@@ -204,7 +218,11 @@ def _env_batch_loop(
                     if env_device is not None:
                         action = action.to(env_device)
                     policy_outputs[env_id] = action
-                    env_inputs.append(action.select(*exchange_keys, strict=False))
+                    env_inputs.append(
+                        action.select(*exchange_keys, strict=False)
+                        if exchange_keys
+                        else action
+                    )
                 pool.async_step_and_maybe_reset_send(
                     lazy_stack(env_inputs), env_index=ready_ids
                 )
@@ -220,7 +238,7 @@ def _env_batch_loop(
                 transitions, next_observations = pool.async_step_and_maybe_reset_recv(
                     min_get=1,
                     max_get=pool.num_envs,
-                    timeout=poll_interval if pending_actions else None,
+                    timeout=poll_interval,
                 )
             except TimeoutError:
                 continue
@@ -267,7 +285,7 @@ class AsyncBatchedCollector(BaseCollector):
     * An :class:`~torchrl.envs.AsyncEnvPool` runs *N* environments using
       whatever backend the user chooses (``"threading"``,
       ``"multiprocessing"``).
-    * With a shared-memory environment exchange, one coordinator thread drains
+    * With a shared-memory exchange or grouped workers, one coordinator drains
       whichever environments are ready and submits their observations without
       blocking. Other exchanges use one lightweight coordinator thread per
       environment.
@@ -345,6 +363,10 @@ class AsyncBatchedCollector(BaseCollector):
             :class:`~torchrl.envs.AsyncEnvPool`, one of ``"queue"``, ``"shm"``
             or ``"auto"``. The shared-memory exchange also enables batched
             coordination from one thread. Defaults to ``"queue"``.
+        envs_per_worker (int, optional): Number of environments hosted by each
+            multiprocessing worker. Grouped workers share one coordinator that
+            drains ready environments without waiting for a complete group.
+            Defaults to ``1``.
         policy_backend (str, optional): backend for the inference transport
             used to communicate with the
             :class:`~torchrl.modules.InferenceServer`.  One of
@@ -380,12 +402,12 @@ class AsyncBatchedCollector(BaseCollector):
             step-time jitter; most users should leave it unset. TorchRL knows
             which CPUs are available, but not the application's intended CPU
             partition or each environment's thread requirements, so it cannot
-            choose these masks automatically. Provide one mask per environment,
-            or a callable mapping each environment index to its mask. Defaults
+            choose these masks automatically. Provide one mask per worker process,
+            or a callable mapping each worker index to its mask. Defaults
             to ``None``. See :ref:`async_batched_collector_cpu_affinity` for a
             complete collector example.
         driver_affinity (Sequence[int], optional): Linux CPU affinity mask for
-            the inference-server and per-environment coordinator threads, plus
+            the inference-server and coordinator threads, plus
             parent-side multiprocessing queue feeder threads. Dedicated
             process-backed inference servers are not covered. The thread
             constructing the collector is restored to its original affinity
@@ -430,6 +452,7 @@ class AsyncBatchedCollector(BaseCollector):
         ] = "threading",
         env_backend: Literal["threading", "multiprocessing"] | None = None,
         env_exchange: Literal["queue", "shm", "auto"] = "queue",
+        envs_per_worker: int = 1,
         policy_backend: (
             Literal["threading", "multiprocessing", "ray", "monarch"] | None
         ) = None,
@@ -522,27 +545,43 @@ class AsyncBatchedCollector(BaseCollector):
                 "env_exchange='shm' requires env_backend='multiprocessing'."
             )
         self._env_exchange = env_exchange
+        if (
+            isinstance(envs_per_worker, bool)
+            or not isinstance(envs_per_worker, int)
+            or envs_per_worker < 1
+        ):
+            raise ValueError(
+                "envs_per_worker must be a positive integer, got "
+                f"{envs_per_worker!r}."
+            )
+        if envs_per_worker != 1 and effective_env_backend != "multiprocessing":
+            raise ValueError(
+                "envs_per_worker is only supported with "
+                "env_backend='multiprocessing'."
+            )
+        self._envs_per_worker = envs_per_worker
         if worker_affinity is None:
             self._worker_affinity = None
         else:
+            num_workers = (self._num_envs + envs_per_worker - 1) // envs_per_worker
             if callable(worker_affinity):
                 affinity_masks = [
-                    worker_affinity(env_index) for env_index in range(self._num_envs)
+                    worker_affinity(worker_index) for worker_index in range(num_workers)
                 ]
             else:
                 affinity_masks = list(worker_affinity)
-                if len(affinity_masks) != self._num_envs:
+                if len(affinity_masks) != num_workers:
                     raise ValueError(
                         "worker_affinity must provide one CPU mask per "
-                        f"environment, got {len(affinity_masks)} masks for "
-                        f"{self._num_envs} environments."
+                        f"worker process, got {len(affinity_masks)} masks for "
+                        f"{num_workers} worker processes."
                     )
             self._worker_affinity = [
                 _validate_cpu_affinity(
                     affinity,
-                    option_name=f"worker_affinity[{env_index}]",
+                    option_name=f"worker_affinity[{worker_index}]",
                 )
-                for env_index, affinity in enumerate(affinity_masks)
+                for worker_index, affinity in enumerate(affinity_masks)
             ]
         self._driver_affinity = (
             _validate_cpu_affinity(driver_affinity, option_name="driver_affinity")
@@ -655,6 +694,7 @@ class AsyncBatchedCollector(BaseCollector):
             self._env_pool = AsyncEnvPool(
                 self._create_env_fn,
                 backend=self._env_backend,
+                envs_per_worker=self._envs_per_worker,
                 # Explicit so the pool's default-change FutureWarning is not
                 # emitted from library code.
                 exchange=self._env_exchange,
@@ -687,7 +727,7 @@ class AsyncBatchedCollector(BaseCollector):
             self._shutdown_event = threading.Event()
 
             self._workers = []
-            if self._env_pool.resolved_exchange == "shm":
+            if self._env_pool.resolved_exchange == "shm" or self._envs_per_worker > 1:
                 self._uses_batched_coordinator = True
                 thread = threading.Thread(
                     target=_env_batch_loop,

--- a/torchrl/envs/_async_exchange.py
+++ b/torchrl/envs/_async_exchange.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import queue
 import threading
+from collections.abc import Callable
 from typing import Any
 
 import torch
@@ -21,6 +22,8 @@ def _receive_batch(
     min_get: int,
     max_get: int | None,
     timeout: float | None,
+    *,
+    check_worker_errors: Callable[[], None] | None = None,
 ) -> list[Any]:
     if min_get < 1:
         raise ValueError(f"min_get must be positive, got {min_get}.")
@@ -40,18 +43,32 @@ def _receive_batch(
 
     items: list[Any] = []
     while len(items) < min_get:
-        if deadline_timer is None:
+        if check_worker_errors is not None:
+            check_worker_errors()
+        if deadline_timer is None and check_worker_errors is None:
             items.append(result_queue.get())
             continue
-        remaining = timeout - deadline_timer.elapsed()
+        remaining = (
+            timeout - deadline_timer.elapsed() if deadline_timer is not None else 0.1
+        )
         try:
             if remaining <= 0:
                 # Deadline passed: drain what is already available without
                 # waiting before giving up.
                 items.append(result_queue.get_nowait())
             else:
-                items.append(result_queue.get(timeout=remaining))
+                items.append(
+                    result_queue.get(
+                        timeout=min(remaining, 0.1)
+                        if check_worker_errors is not None
+                        else remaining
+                    )
+                )
         except queue.Empty:
+            if check_worker_errors is not None:
+                check_worker_errors()
+                if deadline_timer is None or deadline_timer.elapsed() < timeout:
+                    continue
             # Requeue the partial harvest so no result is lost, then signal
             # the missed deadline. The pool's pending-result accounting is
             # only updated by the caller on success, so state stays
@@ -154,12 +171,13 @@ class _SharedSlotExchange:
                     )
 
     def worker_slots(
-        self, env_index: int
+        self, start: int, stop: int
     ) -> tuple[TensorDictBase, TensorDictBase, TensorDictBase, timeit]:
+        """Return one contiguous shared-memory slice for a worker process."""
         return (
-            self.input_slots[env_index],
-            self.result_slots[env_index],
-            self.next_slots[env_index],
+            self.input_buffer[start:stop],
+            self.result_buffer[start:stop],
+            self.next_buffer[start:stop],
             self._clock,
         )
 
@@ -223,13 +241,28 @@ class _SharedSlotExchange:
         timeout: float | None,
         *,
         track_action: bool,
+        check_worker_errors: Callable[[], None] | None = None,
     ) -> list[tuple]:
-        descriptors = _receive_batch(result_queue, min_get, max_get, timeout)
+        descriptors = _receive_batch(
+            result_queue,
+            min_get,
+            max_get,
+            timeout,
+            check_worker_errors=check_worker_errors,
+        )
         self._record_received(descriptors, max_get=max_get, track_action=track_action)
         return sorted(descriptors, key=lambda descriptor: descriptor[0])
 
-    def receive_one(self, result_queue, *, track_action: bool) -> tuple:
-        descriptor = result_queue.get()
+    def receive_one(
+        self,
+        result_queue,
+        *,
+        track_action: bool,
+        check_worker_errors: Callable[[], None] | None = None,
+    ) -> tuple:
+        descriptor = _receive_batch(
+            result_queue, 1, 1, None, check_worker_errors=check_worker_errors
+        )[0]
         self._record_received([descriptor], max_get=1, track_action=track_action)
         return descriptor
 

--- a/torchrl/envs/async_envs.py
+++ b/torchrl/envs/async_envs.py
@@ -9,6 +9,7 @@ import multiprocessing
 import os
 import queue
 import threading
+import traceback
 import warnings
 from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import as_completed, FIRST_COMPLETED, ThreadPoolExecutor, wait
@@ -141,11 +142,15 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
             it cannot infer which CPUs the application has reserved for other
             work or how many threads an environment and its subprocesses need.
             It therefore does not choose a partition automatically. Provide
-            one mask per environment, or a callable mapping an environment
-            index to its mask. The mask is applied before the environment is
-            constructed and is inherited by subprocesses it starts. Defaults
-            to ``None``. See :ref:`async_env_pool_cpu_affinity` for an example
-            and deployment guidance.
+            one mask per worker process, or a callable mapping a worker
+            index to its mask. The mask is applied before environment threads
+            and factories start and is inherited by subprocesses they start.
+            Defaults to ``None``. See :ref:`async_env_pool_cpu_affinity` for an
+            example and deployment guidance.
+        envs_per_worker (int, optional): Number of environments hosted by each
+            multiprocessing worker process. Environments within a worker are
+            executed concurrently in threads. This option is only supported by
+            the multiprocessing backend. Defaults to ``1``.
         create_env_kwargs (dict, optional):
             Keyword arguments to pass to the environment maker. Defaults to `{}`.
 
@@ -153,6 +158,8 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
         min_get (int): Minimum number of environments to process in a batch.
         env_makers (list): List of environment makers or environments.
         num_envs (int): Number of environments in the pool.
+        envs_per_worker (int): Number of environments hosted by each
+            multiprocessing worker.
         backend (str): Backend used for parallel execution.
         stack (str): Method used for stacking environment outputs.
 
@@ -277,6 +284,7 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
         worker_affinity: Sequence[Sequence[int]]
         | Callable[[int], Sequence[int]]
         | None = None,
+        envs_per_worker: int = 1,
         create_env_kwargs: dict | list[dict] | None = None,
     ) -> None:
         if not isinstance(env_makers, Sequence):
@@ -285,6 +293,20 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
         self.env_makers = env_makers
         self.num_envs = len(env_makers)
         self.backend = backend
+        if (
+            isinstance(envs_per_worker, bool)
+            or not isinstance(envs_per_worker, int)
+            or envs_per_worker < 1
+        ):
+            raise ValueError(
+                "envs_per_worker must be a positive integer, got "
+                f"{envs_per_worker!r}."
+            )
+        if backend != "multiprocessing" and envs_per_worker != 1:
+            raise ValueError(
+                "envs_per_worker is only supported with backend='multiprocessing'."
+            )
+        self.envs_per_worker = envs_per_worker
         self.worker_affinity = worker_affinity
         self._worker_affinity = None
         if worker_affinity is not None:
@@ -293,24 +315,25 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
                     "worker_affinity is only supported with "
                     "backend='multiprocessing'."
                 )
+            num_workers = (self.num_envs + envs_per_worker - 1) // envs_per_worker
             if callable(worker_affinity):
                 affinity_masks = [
-                    worker_affinity(env_index) for env_index in range(self.num_envs)
+                    worker_affinity(worker_index) for worker_index in range(num_workers)
                 ]
             else:
                 affinity_masks = list(worker_affinity)
-                if len(affinity_masks) != self.num_envs:
+                if len(affinity_masks) != num_workers:
                     raise ValueError(
                         "worker_affinity must provide one CPU mask per "
-                        f"environment, got {len(affinity_masks)} masks for "
-                        f"{self.num_envs} environments."
+                        f"worker process, got {len(affinity_masks)} masks for "
+                        f"{num_workers} worker processes."
                     )
             self._worker_affinity = [
                 _validate_cpu_affinity(
                     affinity,
-                    option_name=f"worker_affinity[{env_index}]",
+                    option_name=f"worker_affinity[{worker_index}]",
                 )
-                for env_index, affinity in enumerate(affinity_masks)
+                for worker_index, affinity in enumerate(affinity_masks)
             ]
         if exchange is None:
             if backend == "multiprocessing":
@@ -738,9 +761,9 @@ class AsyncEnvPool(EnvBase, metaclass=_AsyncEnvMeta):
 class ProcessorAsyncEnvPool(AsyncEnvPool):
     """An implementation of `AsyncEnvPool` using multiprocessing for parallel execution of environments.
 
-    This class manages a pool of environments, each running in its own process, and
-    provides methods for asynchronous stepping and resetting of environments using
-    inter-process communication.
+    This class manages a pool of environments across worker processes and provides
+    methods for asynchronous stepping and resetting using inter-process
+    communication. A worker can host multiple environments in dedicated threads.
 
     Supports per-env ``recv`` via ``env_index`` for thread-safe concurrent access
     from multiple collector threads.
@@ -751,8 +774,7 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
         If this is not possible, please raise an issue.
 
     Methods:
-        _setup(): Initializes the multiprocessing queues and processes for each
-            environment.
+        _setup(): Initializes multiprocessing queues and worker processes.
         async_step_send(tensordict): Sends a step command to the environments.
         async_step_recv(min_get): Receives the results of the step command.
         async_reset_send(tensordict): Sends a reset command to the environments.
@@ -761,6 +783,9 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
     """
 
     def _setup(self) -> None:
+        self._error_queue = Queue()
+        self._worker_error = None
+        self._worker_liveness_timer = timeit("async_env_worker_liveness").start()
         self.step_queue = Queue(maxsize=self.num_envs)
         self.reset_queue = Queue(maxsize=self.num_envs)
         self.step_reset_queue = Queue(maxsize=self.num_envs)
@@ -770,88 +795,189 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
         self._per_env_step_reset_queues = [
             Queue(maxsize=1) for _ in range(self.num_envs)
         ]
-        self.input_queue = [Queue(maxsize=1) for _ in range(self.num_envs)]
-        self.output_queue = [Queue(maxsize=1) for _ in range(self.num_envs)]
+        self._worker_env_indices = [
+            tuple(range(start, min(start + self.envs_per_worker, self.num_envs)))
+            for start in range(0, self.num_envs, self.envs_per_worker)
+        ]
+        self.num_workers = len(self._worker_env_indices)
+        self._env_to_worker = [
+            worker_index
+            for worker_index, env_indices in enumerate(self._worker_env_indices)
+            for _ in env_indices
+        ]
+        self.input_queue = [Queue(maxsize=1) for _ in range(self.num_workers)]
+        self.output_queue = [
+            Queue(maxsize=len(env_indices)) for env_indices in self._worker_env_indices
+        ]
         self._current_reset = 0
         self._current_step = 0
         self._current_step_reset = 0
         self._slot_exchange = None
 
-        num_threads = self.num_envs
         self.threads = []
-        for i in range(num_threads):
-            thread = multiprocessing.Process(
-                target=self._env_exec,
-                kwargs={
-                    "i": i,
-                    "env_or_factory": self.env_makers[i],
-                    "create_env_kwargs": self.create_env_kwargs[i],
-                    "input_queue": self.input_queue[i],
-                    "output_queue": self.output_queue[i],
-                    "step_reset_queue": self.step_reset_queue,
-                    "step_queue": self.step_queue,
-                    "reset_queue": self.reset_queue,
-                    "per_env_step_queue": self._per_env_step_queues[i],
-                    "per_env_reset_queue": self._per_env_reset_queues[i],
-                    "per_env_step_reset_queue": self._per_env_step_reset_queues[i],
-                    "cpu_affinity": None
+        try:
+            for worker_index, env_indices in enumerate(self._worker_env_indices):
+                if len(env_indices) == 1:
+                    env_index = env_indices[0]
+                    target = self._env_exec
+                    worker_kwargs = {
+                        "i": env_index,
+                        "env_or_factory": self.env_makers[env_index],
+                        "create_env_kwargs": self.create_env_kwargs[env_index],
+                        "input_queue": self.input_queue[worker_index],
+                        "output_queue": self.output_queue[worker_index],
+                        "step_reset_queue": self.step_reset_queue,
+                        "step_queue": self.step_queue,
+                        "reset_queue": self.reset_queue,
+                        "per_env_step_queue": self._per_env_step_queues[env_index],
+                        "per_env_reset_queue": self._per_env_reset_queues[env_index],
+                        "per_env_step_reset_queue": self._per_env_step_reset_queues[
+                            env_index
+                        ],
+                        "grouped_input": True,
+                    }
+                else:
+                    target = self._worker_exec
+                    worker_kwargs = {
+                        "env_indices": env_indices,
+                        "env_makers": [self.env_makers[i] for i in env_indices],
+                        "create_env_kwargs": [
+                            self.create_env_kwargs[i] for i in env_indices
+                        ],
+                        "input_queue": self.input_queue[worker_index],
+                        "output_queue": self.output_queue[worker_index],
+                        "step_reset_queue": self.step_reset_queue,
+                        "step_queue": self.step_queue,
+                        "reset_queue": self.reset_queue,
+                        "per_env_step_queues": [
+                            self._per_env_step_queues[i] for i in env_indices
+                        ],
+                        "per_env_reset_queues": [
+                            self._per_env_reset_queues[i] for i in env_indices
+                        ],
+                        "per_env_step_reset_queues": [
+                            self._per_env_step_reset_queues[i] for i in env_indices
+                        ],
+                    }
+                worker_kwargs["error_queue"] = self._error_queue
+                worker_kwargs["cpu_affinity"] = (
+                    None
                     if self._worker_affinity is None
-                    else self._worker_affinity[i],
-                },
-            )
-            self.threads.append(thread)
-            thread.start()
-        if self._worker_affinity is not None:
-            try:
-                for i in range(num_threads):
-                    status, payload = self.output_queue[i].get()
-                    if status != "affinity_ready":
-                        raise RuntimeError(
-                            f"AsyncEnvPool worker {i} failed to set its CPU "
-                            f"affinity: {payload}"
-                        )
-            except Exception:
-                for thread in self.threads:
-                    if thread.is_alive():
-                        thread.terminate()
-                for thread in self.threads:
-                    thread.join()
-                raise
-        # Get specs from each worker and cache them for _get_child_specs()
-        for i in range(num_threads):
-            self.input_queue[i].put(("get_specs", None))
-        self._child_specs = []
-        for i in range(num_threads):
-            self._child_specs.append(self.output_queue[i].get())
-        # Batch sizes are already available from the worker specs. Caching them
-        # here avoids a later round trip over the input queues used for steps,
-        # which may block behind in-flight env work.
-        self._env_batch_sizes = [torch.Size(spec.shape) for spec in self._child_specs]
-        specs = torch.stack(list(self._child_specs))
-        output_spec = specs["output_spec"]
-        input_spec = specs["input_spec"]
-        if self.exchange in ("shm", "auto"):
-            for i in range(num_threads):
-                self.input_queue[i].put(("get_fake_tensordict", None))
-            fake_tensordicts = [self.output_queue[i].get() for i in range(num_threads)]
-            try:
-                self._slot_exchange = _SharedSlotExchange(fake_tensordicts)
-            except (TypeError, ValueError, RuntimeError) as err:
-                if self.exchange == "shm":
-                    raise
-                torchrl_logger.info(
-                    "AsyncEnvPool(exchange='auto'): the env schema does not "
-                    f"support the shared-memory exchange, falling back to "
-                    f"the queue exchange. Reason: {err}"
+                    else self._worker_affinity[worker_index]
                 )
-            if self._slot_exchange is not None:
-                for i in range(num_threads):
-                    self.input_queue[i].put(
-                        ("init_shm", self._slot_exchange.worker_slots(i))
+                thread = multiprocessing.Process(
+                    target=target,
+                    kwargs=worker_kwargs,
+                )
+                self.threads.append(thread)
+                thread.start()
+            if self._worker_affinity is not None:
+                try:
+                    for i in range(self.num_workers):
+                        status, payload = _receive_batch(
+                            self.output_queue[i],
+                            1,
+                            1,
+                            None,
+                            check_worker_errors=self._check_worker_errors,
+                        )[0]
+                        if status != "affinity_ready":
+                            raise RuntimeError(
+                                f"AsyncEnvPool worker {i} failed to set its CPU "
+                                f"affinity: {payload}"
+                            )
+                except Exception:
+                    for thread in self.threads:
+                        if thread.is_alive():
+                            thread.terminate()
+                    for thread in self.threads:
+                        thread.join()
+                    raise
+            # Get specs from each worker and cache them for _get_child_specs()
+            for worker_index, env_indices in enumerate(self._worker_env_indices):
+                self.input_queue[worker_index].put(
+                    ("get_specs", [(env_index, None) for env_index in env_indices])
+                )
+            self._child_specs = [None] * self.num_envs
+            for worker_index, env_indices in enumerate(self._worker_env_indices):
+                for _ in env_indices:
+                    env_index, spec = _receive_batch(
+                        self.output_queue[worker_index],
+                        1,
+                        1,
+                        None,
+                        check_worker_errors=self._check_worker_errors,
+                    )[0]
+                    self._child_specs[env_index] = spec
+            # Batch sizes are already available from the worker specs. Caching them
+            # here avoids a later round trip over the input queues used for steps,
+            # which may block behind in-flight env work.
+            self._env_batch_sizes = [
+                torch.Size(spec.shape) for spec in self._child_specs
+            ]
+            specs = torch.stack(list(self._child_specs))
+            output_spec = specs["output_spec"]
+            input_spec = specs["input_spec"]
+            if self.exchange in ("shm", "auto"):
+                for worker_index, env_indices in enumerate(self._worker_env_indices):
+                    self.input_queue[worker_index].put(
+                        (
+                            "get_fake_tensordict",
+                            [(env_index, None) for env_index in env_indices],
+                        )
                     )
-                for i in range(num_threads):
-                    self.output_queue[i].get()
-        return output_spec, input_spec
+                fake_tensordicts = [None] * self.num_envs
+                for worker_index, env_indices in enumerate(self._worker_env_indices):
+                    for _ in env_indices:
+                        env_index, fake = _receive_batch(
+                            self.output_queue[worker_index],
+                            1,
+                            1,
+                            None,
+                            check_worker_errors=self._check_worker_errors,
+                        )[0]
+                        fake_tensordicts[env_index] = fake
+                try:
+                    self._slot_exchange = _SharedSlotExchange(fake_tensordicts)
+                except (TypeError, ValueError, RuntimeError) as err:
+                    if self.exchange == "shm":
+                        raise
+                    torchrl_logger.info(
+                        "AsyncEnvPool(exchange='auto'): the env schema does not "
+                        f"support the shared-memory exchange, falling back to "
+                        f"the queue exchange. Reason: {err}"
+                    )
+                if self._slot_exchange is not None:
+                    for worker_index, env_indices in enumerate(
+                        self._worker_env_indices
+                    ):
+                        self.input_queue[worker_index].put(
+                            (
+                                "init_shm",
+                                self._slot_exchange.worker_slots(
+                                    env_indices[0], env_indices[-1] + 1
+                                ),
+                            )
+                        )
+                    for worker_index, env_indices in enumerate(
+                        self._worker_env_indices
+                    ):
+                        for _ in env_indices:
+                            _receive_batch(
+                                self.output_queue[worker_index],
+                                1,
+                                1,
+                                None,
+                                check_worker_errors=self._check_worker_errors,
+                            )[0]
+            return output_spec, input_spec
+        except Exception:
+            for process in self.threads:
+                if process.is_alive():
+                    process.terminate()
+            for process in self.threads:
+                process.join()
+            raise
 
     def _get_child_specs(self) -> list:
         """Returns the cached specs from each child environment process."""
@@ -860,6 +986,25 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
     @property
     def env_batch_sizes(self) -> list[torch.Size]:
         return self._env_batch_sizes
+
+    def _send_worker_batches(
+        self,
+        msg: str,
+        env_idx: list[int],
+        local_tds: tuple[TensorDictBase, ...],
+        *,
+        per_env: bool,
+        record_action: bool,
+    ) -> None:
+        requests = [[] for _ in range(self.num_workers)]
+        for env_index, local_td in _zip_strict(env_idx, local_tds):
+            data = self._prepare_worker_data(
+                env_index, local_td, record_action=record_action
+            )
+            requests[self._env_to_worker[env_index]].append((env_index, data))
+        for worker_index, worker_requests in enumerate(requests):
+            if worker_requests:
+                self.input_queue[worker_index].put((msg, worker_requests, per_env))
 
     def _prepare_worker_data(
         self,
@@ -874,6 +1019,25 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
             env_index, tensordict, record_action=record_action
         )
 
+    def _check_worker_errors(self) -> None:
+        if self._worker_error is None:
+            try:
+                env_index, error = self._error_queue.get_nowait()
+            except queue.Empty:
+                if self._worker_liveness_timer.elapsed() >= 0.1:
+                    self._worker_liveness_timer.start()
+                    failed = [p for p in self.threads if p.exitcode is not None]
+                    if failed:
+                        self._worker_error = (
+                            "AsyncEnvPool worker process exited unexpectedly."
+                        )
+            else:
+                self._worker_error = (
+                    f"AsyncEnvPool environment {env_index} failed:\n{error}"
+                )
+        if self._worker_error is not None:
+            raise RuntimeError(self._worker_error)
+
     def _receive_items(
         self,
         result_queue,
@@ -884,13 +1048,20 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
         track_action: bool,
     ):
         if self._slot_exchange is None:
-            return _receive_batch(result_queue, min_get, max_get, timeout)
+            return _receive_batch(
+                result_queue,
+                min_get,
+                max_get,
+                timeout,
+                check_worker_errors=self._check_worker_errors,
+            )
         return self._slot_exchange.receive(
             result_queue,
             min_get,
             max_get,
             timeout,
             track_action=track_action,
+            check_worker_errors=self._check_worker_errors,
         )
 
     def _stack_queue_results(self, results) -> TensorDictBase:
@@ -916,10 +1087,13 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
                 )
             self._busy.update(env_idx)
 
-        local_tds = tensordict.unbind(0)
-        for _env_idx, local_td in _zip_strict(env_idx, local_tds):
-            data = self._prepare_worker_data(_env_idx, local_td, record_action=True)
-            self.input_queue[_env_idx].put(("step", data, _per_env))
+        self._send_worker_batches(
+            "step",
+            env_idx,
+            tensordict.unbind(0),
+            per_env=_per_env,
+            record_action=True,
+        )
         if not _per_env:
             self._current_step = self._current_step + len(env_idx)
 
@@ -933,9 +1107,17 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
     ) -> TensorDictBase:
         if env_index is not None:
             if self._slot_exchange is None:
-                return self._per_env_step_queues[env_index].get().clone()
+                return _receive_batch(
+                    self._per_env_step_queues[env_index],
+                    1,
+                    1,
+                    None,
+                    check_worker_errors=self._check_worker_errors,
+                )[0].clone()
             descriptor = self._slot_exchange.receive_one(
-                self._per_env_step_queues[env_index], track_action=True
+                self._per_env_step_queues[env_index],
+                track_action=True,
+                check_worker_errors=self._check_worker_errors,
             )
             return self._slot_exchange.read_one(descriptor)
         if min_get is None:
@@ -972,10 +1154,13 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
             )
         self._busy.update(env_idx)
 
-        local_tds = tensordict.unbind(0)
-        for _env_idx, local_td in _zip_strict(env_idx, local_tds):
-            data = self._prepare_worker_data(_env_idx, local_td, record_action=True)
-            self.input_queue[_env_idx].put(("_step", data))
+        self._send_worker_batches(
+            "_step",
+            env_idx,
+            tensordict.unbind(0),
+            per_env=False,
+            record_action=True,
+        )
         self._current_step = self._current_step + len(env_idx)
 
     _async_private_step_recv = async_step_recv
@@ -992,12 +1177,15 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
                     f"Some envs are still processing a step: envs that are busy: {self._busy}, queried: {env_idx}."
                 )
             self._busy.update(env_idx)
-        local_tds = tensordict.unbind(0)
-        for _env_idx, local_td in _zip_strict(env_idx, local_tds):
-            if not _per_env:
-                self._current_step_reset = self._current_step_reset + 1
-            data = self._prepare_worker_data(_env_idx, local_td, record_action=True)
-            self.input_queue[_env_idx].put(("step_and_maybe_reset", data, _per_env))
+        if not _per_env:
+            self._current_step_reset = self._current_step_reset + len(env_idx)
+        self._send_worker_batches(
+            "step_and_maybe_reset",
+            env_idx,
+            tensordict.unbind(0),
+            per_env=_per_env,
+            record_action=True,
+        )
 
     def async_step_and_maybe_reset_recv(
         self,
@@ -1009,10 +1197,18 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
     ) -> tuple[TensorDictBase, TensorDictBase]:
         if env_index is not None:
             if self._slot_exchange is None:
-                result, next_result = self._per_env_step_reset_queues[env_index].get()
+                result, next_result = _receive_batch(
+                    self._per_env_step_reset_queues[env_index],
+                    1,
+                    1,
+                    None,
+                    check_worker_errors=self._check_worker_errors,
+                )[0]
                 return result.clone(), next_result.clone()
             descriptor = self._slot_exchange.receive_one(
-                self._per_env_step_reset_queues[env_index], track_action=True
+                self._per_env_step_reset_queues[env_index],
+                track_action=True,
+                check_worker_errors=self._check_worker_errors,
             )
             return self._slot_exchange.read_pair_one(descriptor)
         if min_get is None:
@@ -1053,12 +1249,15 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
                     f"Some envs are still processing a step: envs that are busy: {self._busy}, queried: {env_idx}."
                 )
             self._busy.update(env_idx)
-        local_tds = tensordict.unbind(0)
-        for _env_idx, local_td in _zip_strict(env_idx, local_tds):
-            if not _per_env:
-                self._current_reset = self._current_reset + 1
-            data = self._prepare_worker_data(_env_idx, local_td, record_action=False)
-            self.input_queue[_env_idx].put(("reset", data, _per_env))
+        if not _per_env:
+            self._current_reset = self._current_reset + len(env_idx)
+        self._send_worker_batches(
+            "reset",
+            env_idx,
+            tensordict.unbind(0),
+            per_env=_per_env,
+            record_action=False,
+        )
 
     def async_reset_recv(
         self,
@@ -1070,9 +1269,17 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
     ) -> TensorDictBase:
         if env_index is not None:
             if self._slot_exchange is None:
-                return self._per_env_reset_queues[env_index].get().clone()
+                return _receive_batch(
+                    self._per_env_reset_queues[env_index],
+                    1,
+                    1,
+                    None,
+                    check_worker_errors=self._check_worker_errors,
+                )[0].clone()
             descriptor = self._slot_exchange.receive_one(
-                self._per_env_reset_queues[env_index], track_action=False
+                self._per_env_reset_queues[env_index],
+                track_action=False,
+                check_worker_errors=self._check_worker_errors,
             )
             return self._slot_exchange.read_one(descriptor)
         if min_get is None:
@@ -1110,11 +1317,14 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
                 f"Some envs are still processing a step: envs that are busy: {self._busy}, queried: {env_idx}."
             )
         self._busy.update(env_idx)
-        local_tds = tensordict.unbind(0)
-        for _env_idx, local_td in _zip_strict(env_idx, local_tds):
-            self._current_reset = self._current_reset + 1
-            data = self._prepare_worker_data(_env_idx, local_td, record_action=False)
-            self.input_queue[_env_idx].put(("_reset", data))
+        self._current_reset = self._current_reset + len(env_idx)
+        self._send_worker_batches(
+            "_reset",
+            env_idx,
+            tensordict.unbind(0),
+            per_env=False,
+            record_action=False,
+        )
 
     _async_private_reset_recv = async_reset_recv
 
@@ -1142,15 +1352,25 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
                     continue
 
     def shutdown(self):
-        for env_id in range(self.num_envs):
-            self.input_queue[env_id].put(("shutdown", None))
+        deadline = timeit("async_env_shutdown_deadline").start()
+        pending = set(range(self.num_workers))
+        while pending and deadline.elapsed() < self._SHUTDOWN_TIMEOUT:
+            self._drain_result_queues()
+            for worker_index in tuple(pending):
+                if not self.threads[worker_index].is_alive():
+                    pending.remove(worker_index)
+                    continue
+                try:
+                    self.input_queue[worker_index].put(("shutdown", None), timeout=0.01)
+                except queue.Full:
+                    continue
+                pending.remove(worker_index)
 
         # A worker whose unread results still sit in a result queue cannot
         # exit: its process teardown joins the queue's feeder thread, which
         # blocks writing into the full pipe that nothing reads any more.
         # Draining the result queues while joining unblocks those feeders so
         # the workers exit through the normal teardown path.
-        deadline = timeit("async_env_shutdown_deadline").start()
         for thread in self.threads:
             while thread.is_alive() and deadline.elapsed() < self._SHUTDOWN_TIMEOUT:
                 self._drain_result_queues()
@@ -1168,6 +1388,98 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
                 thread.join()
 
     @classmethod
+    def _worker_exec(
+        cls,
+        env_indices,
+        env_makers,
+        create_env_kwargs,
+        input_queue,
+        output_queue,
+        step_queue,
+        step_reset_queue,
+        reset_queue,
+        per_env_step_queues=None,
+        per_env_reset_queues=None,
+        per_env_step_reset_queues=None,
+        cpu_affinity=None,
+        error_queue=None,
+    ):
+        if cpu_affinity is not None:
+            try:
+                os.sched_setaffinity(0, cpu_affinity)
+            except Exception as err:
+                output_queue.put(("affinity_error", repr(err)))
+                return
+            output_queue.put(("affinity_ready", None))
+        local_input_queues = {env_index: queue.Queue(1) for env_index in env_indices}
+        env_threads = []
+        for (
+            env_index,
+            env_maker,
+            kwargs,
+            per_env_step_queue,
+            per_env_reset_queue,
+            per_env_step_reset_queue,
+        ) in zip(
+            env_indices,
+            env_makers,
+            create_env_kwargs,
+            per_env_step_queues,
+            per_env_reset_queues,
+            per_env_step_reset_queues,
+        ):
+            env_thread = threading.Thread(
+                target=cls._env_exec,
+                daemon=True,
+                kwargs={
+                    "i": env_index,
+                    "error_queue": error_queue,
+                    "env_or_factory": env_maker,
+                    "create_env_kwargs": kwargs,
+                    "input_queue": local_input_queues[env_index],
+                    "output_queue": output_queue,
+                    "step_queue": step_queue,
+                    "step_reset_queue": step_reset_queue,
+                    "reset_queue": reset_queue,
+                    "per_env_step_queue": per_env_step_queue,
+                    "per_env_reset_queue": per_env_reset_queue,
+                    "per_env_step_reset_queue": per_env_step_reset_queue,
+                },
+            )
+            env_threads.append(env_thread)
+            env_thread.start()
+
+        while True:
+            msg_data = input_queue.get()
+            if len(msg_data) == 3:
+                msg, requests, per_env = msg_data
+            else:
+                msg, requests = msg_data
+                per_env = False
+            if msg == "shutdown":
+                for env_thread, local_queue in zip(
+                    env_threads, local_input_queues.values()
+                ):
+                    if env_thread.is_alive():
+                        local_queue.put(("shutdown", None))
+                for env_thread in env_threads:
+                    env_thread.join()
+                break
+            if msg == "init_shm":
+                input_slots, result_slots, next_slots, clock = requests
+                requests = [
+                    (env_index, (input_slot, result_slot, next_slot, clock))
+                    for env_index, input_slot, result_slot, next_slot in zip(
+                        env_indices,
+                        input_slots.unbind(0),
+                        result_slots.unbind(0),
+                        next_slots.unbind(0),
+                    )
+                ]
+            for env_index, data in requests:
+                local_input_queues[env_index].put((msg, data, per_env))
+
+    @classmethod
     def _env_exec(
         cls,
         i,
@@ -1182,103 +1494,129 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
         per_env_reset_queue=None,
         per_env_step_reset_queue=None,
         cpu_affinity=None,
+        error_queue=None,
+        grouped_input=False,
     ):
-        if cpu_affinity is not None:
-            try:
-                os.sched_setaffinity(0, cpu_affinity)
-            except Exception as err:
-                output_queue.put(("affinity_error", repr(err)))
-                return
-            output_queue.put(("affinity_ready", None))
-        if not isinstance(env_or_factory, EnvBase):
-            env = env_or_factory(**create_env_kwargs)
-        else:
-            env = env_or_factory
-        shared_slots = None
+        try:
+            if cpu_affinity is not None:
+                try:
+                    os.sched_setaffinity(0, cpu_affinity)
+                except Exception as err:
+                    output_queue.put(("affinity_error", repr(err)))
+                    return
+                output_queue.put(("affinity_ready", None))
+            if not isinstance(env_or_factory, EnvBase):
+                env = env_or_factory(**create_env_kwargs)
+            else:
+                env = env_or_factory
+            shared_slots = None
 
-        while True:
-            msg_data = input_queue.get()
-            if len(msg_data) == 3:
-                msg, data, per_env = msg_data
-            else:
-                msg, data = msg_data
-                per_env = False
-            if msg == "get_specs":
-                output_queue.put(env.specs)
-            elif msg == "get_fake_tensordict":
-                output_queue.put(env.fake_tensordict())
-            elif msg == "init_shm":
-                shared_slots = data
-                output_queue.put(True)
-            elif msg == "reset":
-                if shared_slots is not None:
-                    data = shared_slots[0].select(*data, strict=True)
-                data = env.reset(data)
-                target = per_env_reset_queue if per_env else reset_queue
-                if shared_slots is None:
-                    data.set(cls._env_idx_key, NonTensorData(data=i))
-                    target.put(data)
+            while True:
+                msg_data = input_queue.get()
+                if len(msg_data) == 3:
+                    msg, data, per_env = msg_data
                 else:
-                    keys, ready_s = _SharedSlotExchange.publish(
-                        shared_slots[1], data, shared_slots[3]
-                    )
-                    target.put((i, keys, ready_s))
-            elif msg == "_reset":
-                if shared_slots is not None:
-                    data = shared_slots[0].select(*data, strict=True)
-                data = env._reset(data)
-                if shared_slots is None:
-                    data.set(cls._env_idx_key, NonTensorData(data=i))
-                    reset_queue.put(data)
+                    msg, data = msg_data
+                    per_env = False
+                if grouped_input and msg != "shutdown":
+                    if msg == "init_shm":
+                        input_slots, result_slots, next_slots, clock = data
+                        data = (
+                            input_slots[0],
+                            result_slots[0],
+                            next_slots[0],
+                            clock,
+                        )
+                    else:
+                        _, data = data[0]
+                if msg == "get_specs":
+                    output_queue.put((i, env.specs))
+                elif msg == "get_fake_tensordict":
+                    output_queue.put((i, env.fake_tensordict()))
+                elif msg == "init_shm":
+                    shared_slots = data
+                    output_queue.put(True)
+                elif msg == "reset":
+                    if shared_slots is not None:
+                        data = shared_slots[0].select(*data, strict=True)
+                    data = env.reset(data)
+                    target = per_env_reset_queue if per_env else reset_queue
+                    if shared_slots is None:
+                        data.set(cls._env_idx_key, NonTensorData(data=i))
+                        target.put(data)
+                    else:
+                        keys, ready_s = _SharedSlotExchange.publish(
+                            shared_slots[1], data, shared_slots[3]
+                        )
+                        target.put((i, keys, ready_s))
+                elif msg == "_reset":
+                    if shared_slots is not None:
+                        data = shared_slots[0].select(*data, strict=True)
+                    data = env._reset(data)
+                    if shared_slots is None:
+                        data.set(cls._env_idx_key, NonTensorData(data=i))
+                        reset_queue.put(data)
+                    else:
+                        keys, ready_s = _SharedSlotExchange.publish(
+                            shared_slots[1], data, shared_slots[3]
+                        )
+                        reset_queue.put((i, keys, ready_s))
+                elif msg == "step_and_maybe_reset":
+                    if shared_slots is not None:
+                        data = shared_slots[0].select(*data, strict=True)
+                    data, data_ = env.step_and_maybe_reset(data)
+                    target = per_env_step_reset_queue if per_env else step_reset_queue
+                    if shared_slots is None:
+                        data.set(cls._env_idx_key, NonTensorData(data=i))
+                        data_.set(cls._env_idx_key, NonTensorData(data=i))
+                        target.put((data, data_))
+                    else:
+                        (
+                            result_keys,
+                            next_keys,
+                            ready_s,
+                        ) = _SharedSlotExchange.publish_pair(
+                            shared_slots[1],
+                            shared_slots[2],
+                            data,
+                            data_,
+                            shared_slots[3],
+                        )
+                        target.put((i, result_keys, next_keys, ready_s))
+                elif msg == "step":
+                    if shared_slots is not None:
+                        data = shared_slots[0].select(*data, strict=True)
+                    data = env.step(data)
+                    target = per_env_step_queue if per_env else step_queue
+                    if shared_slots is None:
+                        data.set(cls._env_idx_key, NonTensorData(data=i))
+                        target.put(data)
+                    else:
+                        keys, ready_s = _SharedSlotExchange.publish(
+                            shared_slots[1], data, shared_slots[3]
+                        )
+                        target.put((i, keys, ready_s))
+                elif msg == "_step":
+                    if shared_slots is not None:
+                        data = shared_slots[0].select(*data, strict=True)
+                    data = env._step(data)
+                    if shared_slots is None:
+                        data.set(cls._env_idx_key, NonTensorData(data=i))
+                        step_queue.put(data)
+                    else:
+                        keys, ready_s = _SharedSlotExchange.publish(
+                            shared_slots[1], data, shared_slots[3]
+                        )
+                        step_queue.put((i, keys, ready_s))
+                elif msg == "shutdown":
+                    env.close()
+                    break
                 else:
-                    keys, ready_s = _SharedSlotExchange.publish(
-                        shared_slots[1], data, shared_slots[3]
-                    )
-                    reset_queue.put((i, keys, ready_s))
-            elif msg == "step_and_maybe_reset":
-                if shared_slots is not None:
-                    data = shared_slots[0].select(*data, strict=True)
-                data, data_ = env.step_and_maybe_reset(data)
-                target = per_env_step_reset_queue if per_env else step_reset_queue
-                if shared_slots is None:
-                    data.set(cls._env_idx_key, NonTensorData(data=i))
-                    data_.set(cls._env_idx_key, NonTensorData(data=i))
-                    target.put((data, data_))
-                else:
-                    result_keys, next_keys, ready_s = _SharedSlotExchange.publish_pair(
-                        shared_slots[1], shared_slots[2], data, data_, shared_slots[3]
-                    )
-                    target.put((i, result_keys, next_keys, ready_s))
-            elif msg == "step":
-                if shared_slots is not None:
-                    data = shared_slots[0].select(*data, strict=True)
-                data = env.step(data)
-                target = per_env_step_queue if per_env else step_queue
-                if shared_slots is None:
-                    data.set(cls._env_idx_key, NonTensorData(data=i))
-                    target.put(data)
-                else:
-                    keys, ready_s = _SharedSlotExchange.publish(
-                        shared_slots[1], data, shared_slots[3]
-                    )
-                    target.put((i, keys, ready_s))
-            elif msg == "_step":
-                if shared_slots is not None:
-                    data = shared_slots[0].select(*data, strict=True)
-                data = env._step(data)
-                if shared_slots is None:
-                    data.set(cls._env_idx_key, NonTensorData(data=i))
-                    step_queue.put(data)
-                else:
-                    keys, ready_s = _SharedSlotExchange.publish(
-                        shared_slots[1], data, shared_slots[3]
-                    )
-                    step_queue.put((i, keys, ready_s))
-            elif msg == "shutdown":
-                env.close()
-                break
-            else:
-                raise RuntimeError(f"Unknown msg {msg} for worker {i}")
+                    raise RuntimeError(f"Unknown msg {msg} for worker {i}")
+        except Exception:
+            if error_queue is None:
+                raise
+            error_queue.put((i, traceback.format_exc()))
 
 
 class ThreadingAsyncEnvPool(AsyncEnvPool):

--- a/torchrl/trainers/algorithms/configs/envs.py
+++ b/torchrl/trainers/algorithms/configs/envs.py
@@ -39,6 +39,7 @@ class BatchedEnvConfig(EnvConfig):
     stack: str = "dense"
     exchange: str = "queue"
     worker_affinity: list[list[int]] | None = None
+    envs_per_worker: int = 1
     _target_: str = "torchrl.trainers.algorithms.configs.envs.make_batched_env"
 
     def __post_init__(self) -> None:
@@ -70,6 +71,7 @@ def make_batched_env(
     worker_affinity: Sequence[Sequence[int]]
     | Callable[[int], Sequence[int]]
     | None = None,
+    envs_per_worker: int = 1,
     **kwargs: Any,
 ) -> EnvBase:
     """Create a batched environment.
@@ -84,6 +86,8 @@ def make_batched_env(
         exchange: Async multiprocessing exchange mode.
         worker_affinity: Optional Linux CPU affinity masks for async
             multiprocessing workers.
+        envs_per_worker: Environments hosted by each async multiprocessing
+            worker process.
         **kwargs: Additional keyword arguments.
 
     Returns:
@@ -142,6 +146,7 @@ def make_batched_env(
         kwargs["exchange"] = exchange
         if worker_affinity is not None:
             kwargs["worker_affinity"] = worker_affinity
+        kwargs["envs_per_worker"] = envs_per_worker
         return AsyncEnvPool([env_fn] * num_workers, **kwargs)
     else:
         raise ValueError(f"Unknown batched_env_type: {batched_env_type}")


### PR DESCRIPTION
`envs_per_worker` lets multiprocessing `AsyncEnvPool` host several environments concurrently in each process, reducing process overhead while preserving global environment indices and per-environment receives. CPU affinity applies before environment threads and factories start; the Hydra configuration exposes the same default.

Targets main; #4269 is merged. Shared-memory and grouped queue exchanges use one collector coordinator to own aggregate receives. It consumes ready resets and steps independently, so a slow initial or later reset cannot stall unrelated streams. Worker exceptions propagate to callers, and shutdown remains bounded when a dead worker leaves a full command queue.

Validation:
- Combined AsyncEnvPool and AsyncBatchedCollector suites: 76 passed, 7 Linux affinity cases skipped on macOS.
- Configuration coverage: 2 passed.
- Behavioral regressions cover slow initial/later resets with both exchanges, grouped worker exceptions, exact frame budgets, pause, and shutdown with a dead worker and full command queue.
- ufmt, flake8, and diff checks pass.
- Linux affinity passed in the combined collector/pool selection. Matched GPU collector runs are recorded in #4272.

The existing benchmark covers grouped workers. Three matched fake-pixel runs with 16 environments on GB200 measured 1073.9–1092.9 frames/s and 14.0–14.5 GiB summed host RSS with one environment per process, versus 963.5–1085.0 frames/s and 5.3–6.3 GiB with four per process. Grouping reduces process memory; these short runs do not establish a throughput gain. Full hardware, workload, timing and memory definitions are in #4272.
