### PR TITLE
[Performance] Run inference from environment processes

### DIFF
--- a/benchmarks/bench_collectors.py
+++ b/benchmarks/bench_collectors.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import functools as ft
 import importlib.util
 import json
 import os
@@ -27,6 +28,7 @@ import time as time_module
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+import psutil
 import torch
 import torch.nn as nn
 from tensordict import TensorDict
@@ -47,6 +49,7 @@ from torchrl.modules import ConvNet, MLP
 from torchrl.modules.inference_server import (
     InferenceDeviceConfig,
     InferenceServerConfig,
+    ProcessSlotTransport,
 )
 
 OBS_SHAPE = (3, 84, 84)
@@ -68,6 +71,12 @@ class BenchmarkResult:
     env_step_latency_ms: float
     policy_delay_ms: float
     status: str
+    envs_per_worker: int = 1
+    warmup_batches: int = 0
+    p50_batch_ms: float = 0.0
+    p95_batch_ms: float = 0.0
+    host_rss_mib: float = 0.0
+    cuda_used_mib: float = 0.0
     frames: int = 0
     elapsed_s: float = 0.0
     frames_per_s: float = 0.0
@@ -228,6 +237,7 @@ class PolicyFactory:
     hidden_layers: int = 1
 
     def __call__(self) -> TensorDictModule:
+        torch.manual_seed(0)
         if not self.from_pixels:
             mlp = MLP(
                 activation_class=nn.ReLU,
@@ -258,6 +268,26 @@ class PolicyFactory:
             in_keys=["pixels"],
             out_keys=["action"],
         )
+
+
+def _make_process_slot_transport(
+    env_factory: EnvFactory, num_envs: int
+) -> ProcessSlotTransport:
+    env = env_factory()
+    try:
+        input_key = "pixels" if env_factory.from_pixels else "observation"
+        request_spec = env.fake_tensordict().select(input_key, strict=True)
+        response_spec = env.rand_action().set(
+            "policy_version",
+            torch.zeros(env.batch_size, dtype=torch.long),
+        )
+    finally:
+        env.close()
+    return ProcessSlotTransport(
+        request_spec=request_spec,
+        response_spec=response_spec,
+        num_slots=num_envs,
+    )
 
 
 def _parse_int_list(value: str) -> list[int]:
@@ -312,6 +342,7 @@ def bench(
     env_step_latency_ms: float,
     policy_delay_ms: float,
     warmup_batches: int,
+    envs_per_worker: int = 1,
 ) -> BenchmarkResult:
     collector = None
     total = 0
@@ -322,15 +353,33 @@ def bench(
         iterator = iter(collector)
         for _ in range(warmup_batches):
             next(iterator)
-        t0 = time_module.perf_counter()
+        if hasattr(collector, "server_stats"):
+            collector.server_stats(reset=True)
+        latencies = []
+        t0 = previous = time_module.perf_counter()
         for batch in iterator:
+            now = time_module.perf_counter()
+            latencies.append((now - previous) * 1000)
+            previous = now
             n = batch.numel()
             total += n
             if total >= total_frames:
                 break
-        if collector is not None and hasattr(collector, "server_stats"):
+        elapsed = time_module.perf_counter() - t0
+        if hasattr(collector, "server_stats"):
             policy_stats = collector.server_stats()
-        elapsed = time_module.perf_counter() - t0 if t0 is not None else 0.0
+        process = psutil.Process()
+        host_rss = process.memory_info().rss
+        for child in process.children(recursive=True):
+            try:
+                host_rss += child.memory_info().rss
+            except psutil.NoSuchProcess:
+                pass
+        cuda_used = 0
+        if torch.device(policy_device).type == "cuda":
+            free, capacity = torch.cuda.mem_get_info(policy_device)
+            cuda_used = capacity - free
+        percentiles = torch.tensor(latencies).quantile(torch.tensor([0.5, 0.95]))
         fps = total / elapsed if elapsed > 0 else 0.0
         return BenchmarkResult(
             collector=name,
@@ -345,6 +394,12 @@ def bench(
             env_step_latency_ms=env_step_latency_ms,
             policy_delay_ms=policy_delay_ms,
             status="ok",
+            envs_per_worker=envs_per_worker,
+            warmup_batches=warmup_batches,
+            p50_batch_ms=percentiles[0].item(),
+            p95_batch_ms=percentiles[1].item(),
+            host_rss_mib=host_rss / 2**20,
+            cuda_used_mib=cuda_used / 2**20,
             frames=total,
             elapsed_s=elapsed,
             frames_per_s=fps,
@@ -464,10 +519,14 @@ def main() -> None:
         help="Set MUJOCO_GL/PYOPENGL_PLATFORM, e.g. egl",
     )
     parser.add_argument("--num-envs", default="1,2,4")
+    parser.add_argument("--envs-per-worker", type=int, default=1)
     parser.add_argument(
         "--backends",
-        default="parallel,async-thread,async-env-mp,async-process",
-        help="Comma-separated: parallel, async-thread, async-env-mp, async-process",
+        default=("parallel,async-thread,async-env-mp,async-process,async-process-slot"),
+        help=(
+            "Comma-separated: parallel, async-thread, async-env-mp, "
+            "async-process, async-process-slot"
+        ),
     )
     parser.add_argument(
         "--batching-rules",
@@ -651,6 +710,7 @@ def main() -> None:
                                 total_frames=-1,
                                 env_backend="multiprocessing",
                                 env_exchange=args.env_exchange,
+                                envs_per_worker=args.envs_per_worker,
                                 server_config=InferenceServerConfig(
                                     service_backend="thread",
                                     max_batch_size=max_batch_size,
@@ -671,6 +731,7 @@ def main() -> None:
                             env_step_latency_ms=args.env_step_latency_ms,
                             policy_delay_ms=args.policy_delay_ms,
                             warmup_batches=args.warmup_batches,
+                            envs_per_worker=args.envs_per_worker,
                         )
                     )
             elif backend == "async-process":
@@ -695,6 +756,51 @@ def main() -> None:
                                 total_frames=-1,
                                 env_backend="multiprocessing",
                                 env_exchange=args.env_exchange,
+                                server_config=InferenceServerConfig(
+                                    service_backend="process",
+                                    max_batch_size=max_batch_size,
+                                    min_batch_size=min_batch_size,
+                                    timeout=timeout,
+                                ),
+                                device_config=InferenceDeviceConfig(
+                                    policy_device=policy_device,
+                                    output_device=output_device,
+                                ),
+                            ),
+                            env_name=args.env,
+                            num_envs=num_envs,
+                            frames_per_batch=args.frames_per_batch,
+                            total_frames=args.total_frames,
+                            policy_device=policy_device,
+                            output_device=output_device,
+                            env_step_latency_ms=args.env_step_latency_ms,
+                            policy_delay_ms=args.policy_delay_ms,
+                            warmup_batches=args.warmup_batches,
+                        )
+                    )
+            elif backend == "async-process-slot":
+                for rule in batching_rules:
+                    (
+                        max_batch_size,
+                        min_batch_size,
+                        timeout,
+                        label,
+                    ) = _resolve_batching_rule(rule, num_envs)
+                    results.append(
+                        bench(
+                            name="AsyncBatched direct process slots",
+                            backend=backend,
+                            batch_rule=label,
+                            factory=ft.partial(
+                                AsyncBatchedCollector,
+                                create_env_fn=[env_factory] * num_envs,
+                                policy_factory=policy_factory,
+                                transport=_make_process_slot_transport(
+                                    env_factory, num_envs
+                                ),
+                                frames_per_batch=args.frames_per_batch,
+                                total_frames=-1,
+                                env_backend="multiprocessing",
                                 server_config=InferenceServerConfig(
                                     service_backend="process",
                                     max_batch_size=max_batch_size,

--- a/docs/source/reference/collectors_single.rst
+++ b/docs/source/reference/collectors_single.rst
@@ -185,6 +185,14 @@ in batches from one coordinator thread, while keeping faster environments
 independent of slower ones. This path is intended for environments whose step
 latency dominates its millisecond-scale coordinator polling interval.
 
+When both environment stepping and inference should leave the driver process,
+pass a :class:`~torchrl.modules.inference_server.ProcessSlotTransport` together
+with ``env_backend="multiprocessing"`` and an
+:class:`~torchrl.modules.inference_server.InferenceServerConfig` whose
+``service_backend`` is ``"process"``. Each environment process then performs
+its own reset/infer/step loop against a fixed shared-memory inference slot; the
+driver receives completed transitions only.
+
 Scaling ``Collector`` across local processes
 --------------------------------------------
 

--- a/docs/source/reference/modules_inference_server.rst
+++ b/docs/source/reference/modules_inference_server.rst
@@ -47,6 +47,7 @@ lifecycle.
     SlotTransport
     MPTransport
     SharedMemoryTransport
+    ProcessSlotTransport
     RayTransport
     MonarchTransport
 
@@ -185,6 +186,51 @@ all device transfers (batches are moved to ``policy_device`` before the
 forward pass, results copied back into the CPU response slots).
 ``num_slots`` bounds the number of concurrently in-flight requests and
 provides natural backpressure.
+
+Direct process-slot transport
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For one synchronous acting loop per environment worker,
+:class:`ProcessSlotTransport` assigns one fixed request/response slot to each
+worker. Workers notify the dedicated inference process through a shared
+semaphore, and the server sweeps ready slots in round-robin order. Observation
+and action tensors therefore never cross the driver process:
+
+.. code-block:: python
+
+    import torch
+    from tensordict import TensorDict
+    from torchrl.collectors import AsyncBatchedCollector
+    from torchrl.modules.inference_server import (
+        InferenceServerConfig,
+        ProcessSlotTransport,
+    )
+
+    num_envs = 64
+    transport = ProcessSlotTransport(
+        request_spec=TensorDict({"pixels": torch.zeros(3, 84, 84, dtype=torch.uint8)}),
+        response_spec=TensorDict(
+            {
+                "action": torch.zeros(6),
+                "policy_version": torch.zeros((), dtype=torch.long),
+            }
+        ),
+        num_slots=num_envs,
+    )
+    collector = AsyncBatchedCollector(
+        create_env_fn=[make_env] * num_envs,
+        policy_factory=make_policy,
+        transport=transport,
+        env_backend="multiprocessing",
+        server_config=InferenceServerConfig(
+            service_backend="process", max_batch_size=num_envs
+        ),
+        frames_per_batch=1024,
+    )
+
+The driver continues to receive completed transitions from the workers. The
+transport requires fixed-shape CPU tensor request and response specs; policy
+execution and device transfers remain owned by the inference process.
 
 Structured Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/reference/services_workflow.rst
+++ b/docs/source/reference/services_workflow.rst
@@ -254,7 +254,7 @@ different transport.
      - ``process``
      - --
      - Gloo or NCCL [1]_
-     - ``process`` or ``shared_memory``
+     - ``process``, ``shared_memory``, or ``process_slot``
    * - :class:`~torchrl.modules.inference_server.InferenceServer`
      - ``ray``
      - ``ray``
@@ -300,6 +300,12 @@ universal ordering.
      - CPU
      - Preallocated slots avoid pickling tensor contents. This is generally a
        better process-local choice for large, stable CPU TensorDict payloads.
+   * - ``process_slot``
+     - Fixed keys, shapes, dtypes, and batch sizes; one slot per client
+     - Tensor leaves only
+     - CPU
+     - Fixed per-worker slots and process-shared signals keep observations and
+       actions off the driver path. Each client has one in-flight request.
    * - ``ray``
      - Dynamic
      - Ray-serializable values, including strings and non-tensor data

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -18,7 +18,6 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-
 from tensordict import lazy_stack, TensorDict
 from tensordict.base import TensorDictBase
 from tensordict.nn import TensorDictModule
@@ -27,6 +26,7 @@ from tensordict.nn.probabilistic import (
     InteractionType,
     set_interaction_type,
 )
+from tensordict.utils import assert_close
 from torchrl import service_backend, transport_backend
 from torchrl._comm import (
     CommandChannel,
@@ -37,7 +37,6 @@ from torchrl._comm import (
     SharedBlock,
     TCPStoreRendezvous,
 )
-
 from torchrl.modules.inference_server import (
     InferenceClient,
     InferenceDeviceConfig,
@@ -47,6 +46,7 @@ from torchrl.modules.inference_server import (
     MPTransport,
     PolicyClientModule,
     ProcessInferenceServer,
+    ProcessSlotTransport,
     RayTransport,
     SharedMemoryTransport,
     SlotTransport,
@@ -335,7 +335,12 @@ class TestInferenceServerCore:
 
     @pytest.mark.parametrize(
         ("service_backend", "transport"),
-        [("thread", "ray"), ("process", "ray"), ("ray", "shared_memory")],
+        [
+            ("thread", "ray"),
+            ("thread", "process_slot"),
+            ("process", "ray"),
+            ("ray", "shared_memory"),
+        ],
     )
     def test_invalid_backend_transport_rejected_before_start(
         self, service_backend, transport
@@ -1736,6 +1741,83 @@ class TestSharedMemoryTransport:
             assert result_queue.get(timeout=1.0) is True
 
 
+class TestProcessSlotTransport:
+    def test_round_robin_nested_slots(self):
+        """A capped sweep rotates fairly and preserves nested-key payloads."""
+        request_spec = TensorDict({"agent": {"observation": torch.zeros(4)}})
+        response_spec = TensorDict({"agent": {"action": torch.zeros(4)}})
+        transport = ProcessSlotTransport(request_spec, response_spec, num_slots=4)
+        clients = [transport.client() for _ in range(4)]
+        futures = [
+            client.submit(
+                TensorDict({"agent": {"observation": torch.full((4,), float(slot))}})
+            )
+            for slot, client in enumerate(clients)
+        ]
+
+        transport.wait_for_work(timeout=1.0)
+        items, callbacks = transport.drain(2)
+        assert callbacks == [0, 1]
+        for item, callback in zip(items, callbacks):
+            transport.resolve(
+                callback,
+                TensorDict({"agent": {"action": 2 * item["agent", "observation"]}}),
+            )
+        for slot in callbacks:
+            assert torch.equal(
+                futures[slot].result(timeout=1.0)["agent", "action"],
+                torch.full((4,), float(2 * slot)),
+            )
+
+        futures[0] = clients[0].submit(
+            TensorDict({"agent": {"observation": torch.full((4,), 4.0)}})
+        )
+        futures[1] = clients[1].submit(
+            TensorDict({"agent": {"observation": torch.full((4,), 5.0)}})
+        )
+        transport.wait_for_work(timeout=1.0)
+        items, callbacks = transport.drain(4)
+        assert callbacks == [2, 3, 0, 1]
+        for item, callback in zip(items, callbacks):
+            transport.resolve(
+                callback,
+                TensorDict({"agent": {"action": 2 * item["agent", "observation"]}}),
+            )
+        assert all(future.result(timeout=1.0) is not None for future in futures)
+
+    def test_canonical_process_server_and_spawned_clients(self):
+        """Spawned workers exchange only slot signals with the server process."""
+        ctx = mp.get_context("spawn")
+        request_spec, response_spec = _make_shm_specs(act_size=4, with_version=False)
+        server = InferenceServer(
+            policy_factory=_make_doubling_policy,
+            service_backend="process",
+            service_backend_options={"mp_context": ctx},
+            transport="process_slot",
+            transport_options={"ctx": ctx},
+            request_spec=request_spec,
+            response_spec=response_spec,
+            num_clients=2,
+            max_batch_size=2,
+        )
+        clients = server.clients(2)
+        result_queue = ctx.Queue()
+        processes = []
+        with server:
+            for client in clients:
+                process = ctx.Process(
+                    target=_shm_actor_fn,
+                    args=(client, 3, result_queue),
+                )
+                process.start()
+                processes.append(process)
+            for process in processes:
+                process.join(timeout=30.0)
+                assert process.exitcode == 0
+            assert server.stats()["requests"] == 6
+        assert all(result_queue.get(timeout=1.0) is True for _ in processes)
+
+
 # =============================================================================
 # Tests: RayTransport (Commit 4)
 # =============================================================================
@@ -2463,6 +2545,19 @@ class TestProcessInferenceServer:
         assert not health["process_alive"]
 
 
+def _counting_process_transport(num_slots):
+    return ProcessSlotTransport(
+        TensorDict({"observation": torch.zeros(1, dtype=torch.int32)}),
+        TensorDict(
+            {
+                "action": torch.zeros(1, dtype=torch.int32),
+                "policy_version": torch.zeros((), dtype=torch.long),
+            }
+        ),
+        num_slots=num_slots,
+    )
+
+
 class TestAsyncBatchedCollector:
     """Tests for :class:`AsyncBatchedCollector`."""
 
@@ -2793,8 +2888,10 @@ class TestAsyncBatchedCollector:
         not hasattr(os, "sched_setaffinity"),
         reason="CPU affinity requires Linux",
     )
-    @pytest.mark.parametrize("envs_per_worker", [1, 2])
-    def test_cpu_affinity(self, envs_per_worker):
+    @pytest.mark.parametrize(
+        ("envs_per_worker", "process_slots"), [(1, False), (2, False), (1, True)]
+    )
+    def test_cpu_affinity(self, envs_per_worker, process_slots):
         """Worker processes and driver threads use their configured masks."""
         original_affinity = os.sched_getaffinity(0)
         cpus = sorted(original_affinity)
@@ -2802,10 +2899,15 @@ class TestAsyncBatchedCollector:
         worker_affinity = (cpus[-1],)
         collector = AsyncBatchedCollector(
             create_env_fn=[_counting_env_factory] * 3,
-            policy=_make_counting_policy(),
+            policy=None if process_slots else _make_counting_policy(),
+            policy_factory=_make_counting_policy if process_slots else None,
+            transport=_counting_process_transport(3) if process_slots else None,
+            server_config=InferenceServerConfig(
+                service_backend="process" if process_slots else "thread",
+                max_batch_size=2,
+            ),
             frames_per_batch=10,
             total_frames=10,
-            max_batch_size=2,
             env_backend="multiprocessing",
             worker_affinity=[worker_affinity]
             * ((3 + envs_per_worker - 1) // envs_per_worker),
@@ -2815,9 +2917,20 @@ class TestAsyncBatchedCollector:
         try:
             collector._ensure_started()
             assert os.sched_getaffinity(0) == original_affinity
+            if process_slots:
+                # Spawn returns before the worker applies its affinity. A pause
+                # acknowledges that every worker has completed its startup.
+                with collector.pause():
+                    assert all(
+                        os.sched_getaffinity(process.pid) == set(worker_affinity)
+                        for process in collector._workers
+                    )
+                assert next(iter(collector)).numel() == 10
+                return
+            processes = collector.env.threads
             assert all(
                 os.sched_getaffinity(process.pid) == set(worker_affinity)
-                for process in collector.env.threads
+                for process in processes
             )
             driver_threads = [collector._server._worker, *collector._workers]
             assert all(
@@ -2937,13 +3050,15 @@ class TestAsyncBatchedCollector:
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
-    def test_process_server_static_batch(self):
+    @pytest.mark.parametrize("process_slots", [False, True])
+    def test_process_server_static_batch(self, process_slots):
         collector = AsyncBatchedCollector(
             create_env_fn=[_counting_env_factory] * 2,
             policy_factory=_make_counting_policy,
             frames_per_batch=10,
             total_frames=20,
-            env_backend="threading",
+            transport=_counting_process_transport(2) if process_slots else None,
+            env_backend="multiprocessing" if process_slots else "threading",
             server_config=InferenceServerConfig(
                 service_backend="process",
                 max_batch_size=2,
@@ -2961,6 +3076,91 @@ class TestAsyncBatchedCollector:
             total += batch.numel()
         collector.shutdown()
         assert total >= 20
+
+    @pytest.mark.parametrize("total_frames", [24, 25])
+    def test_process_slot_workers_bypass_driver_coordination(self, total_frames):
+        """Environment processes infer and step without driver coordinators."""
+        num_envs = 2
+        transport = _counting_process_transport(num_envs)
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * num_envs,
+            policy_factory=_make_counting_policy,
+            transport=transport,
+            frames_per_batch=12,
+            total_frames=total_frames,
+            env_backend="multiprocessing",
+            server_config=InferenceServerConfig(
+                service_backend="process", max_batch_size=num_envs
+            ),
+        )
+        workers = []
+        try:
+            iterator = iter(collector)
+            batch = next(iterator)
+            saved = batch.clone()
+            for _ in range(2):
+                with collector.pause(timeout=5):
+                    requests = collector.server_stats()["requests"]
+                    time.sleep(0.05)
+                    assert collector.server_stats()["requests"] == requests
+            assert batch.numel() + sum(td.numel() for td in iterator) == total_frames
+            assert_close(batch, saved)
+            workers = list(collector._workers)
+            assert collector._env_pool is None
+            assert all(worker.pid is not None for worker in workers)
+            assert batch["action"].eq(1).all()
+            assert "policy_version" in batch.keys()
+            assert collector.server_stats()["requests"] >= batch.numel()
+        finally:
+            collector.shutdown()
+        assert not any(worker.is_alive() for worker in workers)
+
+    @pytest.mark.parametrize("failure", ["reset", "worker_death"])
+    def test_process_slot_worker_failure_with_active_stream(self, failure):
+        entered = mp.get_context("spawn").Event()
+        transport = _counting_process_transport(2)
+        collector = AsyncBatchedCollector(
+            create_env_fn=[
+                ft.partial(
+                    _ControlledResetEnv, reset_index=1, entered=entered, fail=True
+                )
+                if failure == "reset"
+                else _counting_env_factory,
+                _counting_env_factory,
+            ],
+            policy_factory=_make_counting_policy,
+            transport=transport,
+            frames_per_batch=8,
+            env_backend="multiprocessing",
+            server_config=InferenceServerConfig(
+                service_backend="process", max_batch_size=2
+            ),
+        )
+        iterator = iter(collector)
+
+        def collect_until_error():
+            for _ in iterator:
+                pass
+
+        try:
+            if failure == "worker_death":
+                next(iterator)
+                collector._workers[0].terminate()
+                collector._workers[0].join(timeout=5)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(collect_until_error)
+                try:
+                    if failure == "reset":
+                        # Time error propagation after reset, independently of spawn.
+                        assert entered.wait(timeout=30)
+                    with pytest.raises(RuntimeError, match="worker") as error:
+                        future.result(timeout=8)
+                    if failure == "reset":
+                        assert "controlled reset failure" in str(error.value.__cause__)
+                finally:
+                    collector.shutdown()
+        finally:
+            collector.shutdown()
 
     def test_policy_version_key_none_disables_annotations(self):
         collector = AsyncBatchedCollector(

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -5,12 +5,13 @@
 from __future__ import annotations
 
 import contextlib
+import multiprocessing as mp
 import os
 import queue
 import threading
 import time
 from collections import deque, OrderedDict
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import Literal
 
 import torch
@@ -21,11 +22,15 @@ from tensordict import (
     NestedKey,
     TensorDictBase,
 )
-
 from torchrl._comm import MailboxTransportError
-from torchrl._utils import _maybe_record_function_decorator, logger as torchrl_logger
+from torchrl._utils import (
+    _maybe_record_function_decorator,
+    logger as torchrl_logger,
+    timeit,
+)
 from torchrl.collectors._base import BaseCollector
-from torchrl.envs import AsyncEnvPool, EnvBase
+from torchrl.data.utils import CloudpickleWrapper
+from torchrl.envs import AsyncEnvPool, EnvBase, EnvCreator
 from torchrl.envs.async_envs import _validate_cpu_affinity
 from torchrl.modules.inference_server import (
     InferenceDeviceConfig,
@@ -33,6 +38,7 @@ from torchrl.modules.inference_server import (
     InferenceServerConfig,
     PolicyClientModule,
     ProcessInferenceServer,
+    ProcessSlotTransport,
     ThreadingTransport,
 )
 from torchrl.modules.inference_server._config import _resolve_device_config
@@ -141,6 +147,65 @@ def _env_loop(
     except Exception as exc:
         if not shutdown_event.is_set():
             result_queue.put(exc)
+
+
+def _process_env_loop(
+    env_factory: Callable[[], EnvBase],
+    create_env_kwargs: dict,
+    env_id: int,
+    client: PolicyClientModule,
+    result_queue,
+    shutdown_event,
+    pause_event,
+    paused_event,
+    error_queue,
+    worker_affinity: Sequence[int] | None,
+    env_device: torch.device | None,
+    storing_device: torch.device | None,
+):
+    """Run environment stepping and remote inference in one worker process."""
+    env = None
+    try:
+        if worker_affinity is not None:
+            os.sched_setaffinity(0, worker_affinity)
+        torch.set_num_threads(1)
+        env = env_factory(**create_env_kwargs)
+        observation = env.reset()
+        while not shutdown_event.is_set():
+            if pause_event.is_set():
+                paused_event.set()
+                while pause_event.is_set() and not shutdown_event.is_set():
+                    shutdown_event.wait(0.01)
+                paused_event.clear()
+                continue
+            policy_output = client(observation)
+            action_td = observation.update(policy_output)
+            if env_device is not None:
+                action_td = action_td.to(env_device)
+            transition, observation = env.step_and_maybe_reset(action_td)
+            transition.set(_ENV_IDX_KEY, env_id)
+            # multiprocessing.Queue serializes on a feeder thread after put()
+            # returns. Own the transition storage before the environment or
+            # inference response slot can be reused.
+            transition = transition.clone()
+            if storing_device is not None:
+                transition = transition.to(storing_device)
+            if all(
+                value.device.type == "cpu"
+                for value in transition.values(True, True)
+                if isinstance(value, torch.Tensor)
+            ):
+                # Transfer one shared storage instead of negotiating a file
+                # descriptor for every tensor leaf of every transition.
+                transition = transition.consolidate()
+            result_queue.put(transition)
+    except Exception as exc:
+        if not shutdown_event.is_set():
+            error_queue.put(RuntimeError(f"Environment {env_id} failed: {exc!r}"))
+            shutdown_event.wait()
+    finally:
+        if env is not None:
+            env.close()
 
 
 def _env_ids(tensordict: TensorDictBase) -> list[int]:
@@ -289,6 +354,9 @@ class AsyncBatchedCollector(BaseCollector):
       whichever environments are ready and submits their observations without
       blocking. Other exchanges use one lightweight coordinator thread per
       environment.
+    * With a :class:`~torchrl.modules.inference_server.ProcessSlotTransport`,
+      each multiprocessing environment worker talks directly to the dedicated
+      inference process; the driver receives completed transitions only.
     * The :class:`~torchrl.modules.InferenceServer` running in a background
       thread continuously drains observation submissions, batches them, runs
       a single forward pass, and fans actions back out.
@@ -327,9 +395,12 @@ class AsyncBatchedCollector(BaseCollector):
         server_timeout (float, optional): seconds the server waits for work
             before dispatching a partial batch.  Defaults to ``0.01``.
         transport (InferenceTransport, optional): a pre-built transport
-            object.  When provided, it takes precedence over
-            ``policy_backend``.  When ``None`` (default) a transport is
-            created automatically from the resolved ``policy_backend``.
+            object. When provided, it takes precedence over ``policy_backend``.
+            A :class:`~torchrl.modules.inference_server.ProcessSlotTransport`
+            together with multiprocessing environment and server backends runs
+            the complete acting loop in environment worker processes. When
+            ``None`` (default), a transport is created from the resolved
+            ``policy_backend``.
         device (torch.device or str, optional): device for policy inference
             (shorthand for ``InferenceDeviceConfig(policy_device=...)``).
             Defaults to ``None``.
@@ -604,6 +675,38 @@ class AsyncBatchedCollector(BaseCollector):
                 effective_policy_backend, num_slots=self._num_envs
             )
         self._transport = transport
+        self._uses_process_env_workers = isinstance(transport, ProcessSlotTransport)
+        if self._uses_process_env_workers:
+            if envs_per_worker != 1:
+                raise ValueError("ProcessSlotTransport requires envs_per_worker=1.")
+            if (
+                server_backend != "process"
+                or effective_env_backend != "multiprocessing"
+            ):
+                raise ValueError(
+                    "ProcessSlotTransport requires both a process inference server "
+                    "and env_backend='multiprocessing'."
+                )
+            if env_exchange != "queue":
+                raise ValueError(
+                    "env_exchange does not apply when ProcessSlotTransport owns "
+                    "the environment-worker exchange; leave it as 'queue'."
+                )
+            if transport._num_slots < self._num_envs:
+                raise ValueError(
+                    f"ProcessSlotTransport needs at least one slot per environment "
+                    f"({self._num_envs}), but has {transport._num_slots}."
+                )
+            for name, target_device in (
+                ("env_device", self._env_device),
+                ("storing_device", self._storing_device),
+            ):
+                if target_device is not None and target_device.type != "cpu":
+                    raise ValueError(
+                        f"ProcessSlotTransport requires a CPU {name}; got "
+                        f"{target_device}. Keep CUDA policy execution in the "
+                        "inference server process."
+                    )
 
         # ---- build inference server -------------------------------------------
         if server_backend == "process":
@@ -623,6 +726,7 @@ class AsyncBatchedCollector(BaseCollector):
                 stats_window_size=_server_defaults.stats_window_size,
                 policy_version=policy_version,
                 policy_version_key=policy_version_key,
+                mp_context=(transport._ctx if self._uses_process_env_workers else None),
             )
         else:
             self._server = InferenceServer(
@@ -658,10 +762,11 @@ class AsyncBatchedCollector(BaseCollector):
         self._iter = -1
 
         # ---- runtime state (created lazily) -----------------------------------
-        self._shutdown_event: threading.Event | None = None
-        self._result_queue: queue.Queue | None = None
+        self._shutdown_event: object | None = None
+        self._result_queue: object | None = None
+        self._worker_error_queue = None
         self._env_pool: AsyncEnvPool | None = None
-        self._workers: list[threading.Thread] = []
+        self._workers: list[threading.Thread | mp.Process] = []
         self._clients: list[Callable] | None = None
         self._uses_batched_coordinator = False
         self._pause_request: list[_PauseRequest | None] = [None]
@@ -686,6 +791,90 @@ class AsyncBatchedCollector(BaseCollector):
             if self._driver_affinity is not None:
                 original_affinity = os.sched_getaffinity(0)
                 os.sched_setaffinity(0, self._driver_affinity)
+
+            if self._uses_process_env_workers:
+                if self._clients is None:
+                    self._clients = [
+                        PolicyClientModule(
+                            self._transport.client(),
+                            max_inflight=self._max_inflight_per_env,
+                        )
+                        for _ in range(self._num_envs)
+                    ]
+                if self._server.static_batch_size is not None:
+                    self._server.prepare_cudagraph(self._transport._request_slots[0])
+                if not self._server.is_alive:
+                    self._server.start()
+
+                create_env_kwargs = self._create_env_kwargs
+                if create_env_kwargs is None:
+                    create_env_kwargs = [{} for _ in range(self._num_envs)]
+                elif isinstance(create_env_kwargs, Mapping):
+                    create_env_kwargs = [
+                        dict(create_env_kwargs) for _ in range(self._num_envs)
+                    ]
+                elif len(create_env_kwargs) != self._num_envs:
+                    raise ValueError(
+                        "create_env_kwargs must be a dict or a list of dicts with "
+                        f"length {self._num_envs}."
+                    )
+
+                ctx = self._transport._ctx
+                self._result_queue = ctx.Queue()
+                self._worker_error_queue = ctx.Queue()
+                self._worker_check_timer = timeit(
+                    "AsyncBatchedCollector.worker_liveness", sync=False
+                )
+                self._worker_check_timer.start()
+                self._shutdown_event = ctx.Event()
+                self._process_pause_event = ctx.Event()
+                self._process_paused_events = [
+                    ctx.Event() for _ in range(self._num_envs)
+                ]
+                self._workers = []
+                self._uses_batched_coordinator = False
+                try:
+                    for env_id, (env_factory, env_kwargs, client) in enumerate(
+                        zip(self._create_env_fn, create_env_kwargs, self._clients)
+                    ):
+                        if not isinstance(
+                            env_factory, (EnvCreator, CloudpickleWrapper)
+                        ):
+                            env_factory = CloudpickleWrapper(env_factory)
+                        process = ctx.Process(
+                            target=_process_env_loop,
+                            kwargs={
+                                "env_factory": env_factory,
+                                "create_env_kwargs": env_kwargs,
+                                "env_id": env_id,
+                                "client": client,
+                                "result_queue": self._result_queue,
+                                "shutdown_event": self._shutdown_event,
+                                "pause_event": self._process_pause_event,
+                                "paused_event": self._process_paused_events[env_id],
+                                "error_queue": self._worker_error_queue,
+                                "worker_affinity": (
+                                    self._worker_affinity[env_id]
+                                    if self._worker_affinity is not None
+                                    else None
+                                ),
+                                "env_device": self._env_device,
+                                "storing_device": self._storing_device,
+                            },
+                            name=f"AsyncBatchedCollector-env-{env_id}",
+                        )
+                        process.start()
+                        self._workers.append(process)
+                except BaseException:
+                    self._shutdown_event.set()
+                    for process in self._workers:
+                        if process.is_alive():
+                            process.terminate()
+                        process.join(timeout=1.0)
+                    self._workers = []
+                    self._server.shutdown(timeout=1.0)
+                    raise
+                return
 
             # Build the pool under the driver mask so feeder threads inherit it.
             kwargs = {}
@@ -812,6 +1001,22 @@ class AsyncBatchedCollector(BaseCollector):
                     "thread has exited."
                 )
 
+            if self._uses_process_env_workers:
+                self._process_pause_event.set()
+                pause_timer = timeit("AsyncBatchedCollector.process_pause", sync=False)
+                pause_timer.start()
+                while not all(event.is_set() for event in self._process_paused_events):
+                    self._check_process_workers()
+                    if not self._server.is_alive:
+                        raise RuntimeError("The inference server exited while pausing.")
+                    if timeout is not None and pause_timer.elapsed() >= timeout:
+                        raise TimeoutError(
+                            "Timed out while waiting for environment workers to pause."
+                        )
+                    self._shutdown_event.wait(0.01)
+                yield None
+                return
+
             request = (threading.Barrier(len(workers) + 1), threading.Event())
             self._pause_request[0] = request
             try:
@@ -830,6 +1035,14 @@ class AsyncBatchedCollector(BaseCollector):
             yield None
         finally:
             try:
+                if self._uses_process_env_workers and workers:
+                    self._process_pause_event.clear()
+                    # Wait for acknowledgement reset before a subsequent pause.
+                    while any(event.is_set() for event in self._process_paused_events):
+                        if self._shutdown_event.wait(0.01) or not all(
+                            worker.is_alive() for worker in workers
+                        ):
+                            break
                 if request is not None:
                     if self._pause_request[0] is request:
                         self._pause_request[0] = None
@@ -842,6 +1055,11 @@ class AsyncBatchedCollector(BaseCollector):
     def env(self) -> AsyncEnvPool:
         """The underlying :class:`AsyncEnvPool`."""
         self._ensure_started()
+        if self._env_pool is None:
+            raise RuntimeError(
+                "ProcessSlotTransport runs environments directly in worker "
+                "processes and does not create an AsyncEnvPool."
+            )
         return self._env_pool
 
     @property
@@ -874,9 +1092,9 @@ class AsyncBatchedCollector(BaseCollector):
     _SERVER_DEATH_GRACE_S = 2.0
 
     def _check_worker_result(self, item):
-        """Re-raise exceptions propagated from coordinator threads.
+        """Re-raise exceptions propagated from collector workers.
 
-        Worker threads may observe a dying server before the liveness
+        Workers may observe a dying server before the liveness
         watchdog does: their transport read errors out first, and process
         teardown is asynchronous, so a killed server can still report alive
         for a moment. Mailbox transport failures identify a dead peer by
@@ -902,11 +1120,22 @@ class AsyncBatchedCollector(BaseCollector):
                 if time.monotonic() >= deadline:
                     break
                 time.sleep(0.1)
+            worker_kind = "process" if self._uses_process_env_workers else "thread"
             raise RuntimeError(
-                "A collector worker thread raised an exception."
+                f"A collector worker {worker_kind} raised an exception."
             ) from item
 
     _LIVENESS_POLL_S = 1.0
+
+    def _check_process_workers(self) -> None:
+        try:
+            error = self._worker_error_queue.get_nowait()
+        except queue.Empty:
+            pass
+        else:
+            raise RuntimeError("An environment worker failed.") from error
+        if any(not worker.is_alive() for worker in self._workers):
+            raise RuntimeError("An environment worker process exited while collecting.")
 
     def _next_result(self) -> TensorDictBase:
         """Block for the next transition, watching server and worker liveness.
@@ -918,6 +1147,12 @@ class AsyncBatchedCollector(BaseCollector):
         """
         rq = self._result_queue
         while True:
+            if (
+                self._uses_process_env_workers
+                and self._worker_check_timer.elapsed() >= self._LIVENESS_POLL_S
+            ):
+                self._worker_check_timer.start()
+                self._check_process_workers()
             try:
                 td = rq.get(timeout=self._LIVENESS_POLL_S)
             except queue.Empty:
@@ -929,10 +1164,30 @@ class AsyncBatchedCollector(BaseCollector):
                     ) from None
                 if self._workers and not any(w.is_alive() for w in self._workers):
                     raise RuntimeError(
-                        "All collector worker threads exited while the "
+                        "All collector workers exited while the "
                         "collector was waiting for transitions."
                     ) from None
+                if self._uses_process_env_workers:
+                    exited = [
+                        worker for worker in self._workers if not worker.is_alive()
+                    ]
+                    if exited:
+                        details = ", ".join(
+                            f"{worker.name} (exitcode={worker.exitcode})"
+                            for worker in exited
+                        )
+                        raise RuntimeError(
+                            "Environment worker process exited while the "
+                            f"collector was running: {details}."
+                        ) from None
                 continue
+            except (EOFError, OSError) as exc:
+                if not self._uses_process_env_workers:
+                    raise
+                self._check_process_workers()
+                raise RuntimeError(
+                    "An environment worker result could not be received."
+                ) from exc
             self._check_worker_result(td)
             return td
 
@@ -970,6 +1225,13 @@ class AsyncBatchedCollector(BaseCollector):
                     td = rq.get_nowait()
                 except queue.Empty:
                     break
+                except (EOFError, OSError) as exc:
+                    if not self._uses_process_env_workers:
+                        raise
+                    self._check_process_workers()
+                    raise RuntimeError(
+                        "An environment worker result could not be received."
+                    ) from exc
                 self._check_worker_result(td)
                 if self._uses_batched_coordinator:
                     for transition in td.unbind(0):
@@ -1049,7 +1311,7 @@ class AsyncBatchedCollector(BaseCollector):
         raise_on_error: bool = True,
     ) -> None:
         """Shut down the collector, inference server, threads and env pool."""
-        if self._shutdown_event is not None:
+        if self._shutdown_event is not None and self._workers:
             self._shutdown_event.set()
         request = self._pause_request[0]
         self._pause_request[0] = None
@@ -1057,14 +1319,45 @@ class AsyncBatchedCollector(BaseCollector):
             request[0].abort()
             request[1].set()
         self._transition_carry.clear()
-        _timeout = timeout or 5.0
-        for w in self._workers:
-            w.join(timeout=_timeout)
+        _timeout = 5.0 if timeout is None else timeout
+        shutdown_timer = timeit("AsyncBatchedCollector.shutdown").start()
+        if self._uses_process_env_workers:
+            while any(worker.is_alive() for worker in self._workers):
+                if shutdown_timer.elapsed() >= _timeout:
+                    break
+                if self._result_queue is not None:
+                    while True:
+                        try:
+                            self._result_queue.get_nowait()
+                        except queue.Empty:
+                            break
+                        except (EOFError, OSError):
+                            # The item is already removed from the queue, but
+                            # rebuilding a discarded tensor can fail once its
+                            # worker's resource sharer has exited.
+                            continue
+                for worker in self._workers:
+                    worker.join(timeout=0.05)
+            for worker in self._workers:
+                if worker.is_alive():
+                    worker.terminate()
+                worker.join(timeout=1.0)
+        else:
+            for worker in self._workers:
+                worker.join(timeout=_timeout)
         self._workers = []
-        self._server.shutdown(timeout=_timeout)
+        self._server.shutdown(timeout=max(0.0, _timeout - shutdown_timer.elapsed()))
         if close_env and self._env_pool is not None:
             self._env_pool.close(raise_if_closed=raise_on_error)
             self._env_pool = None
+        if self._uses_process_env_workers and self._result_queue is not None:
+            self._result_queue.close()
+            self._result_queue.join_thread()
+            self._result_queue = None
+        if self._worker_error_queue is not None:
+            self._worker_error_queue.close()
+            self._worker_error_queue.join_thread()
+            self._worker_error_queue = None
 
     def set_seed(self, seed: int, static_seed: bool = False) -> int:
         """Set the seed (no-op; envs are created inside the pool)."""

--- a/torchrl/modules/inference_server/__init__.py
+++ b/torchrl/modules/inference_server/__init__.py
@@ -10,6 +10,7 @@ from torchrl.modules.inference_server._config import (
 )
 from torchrl.modules.inference_server._monarch import MonarchTransport
 from torchrl.modules.inference_server._mp import MPTransport
+from torchrl.modules.inference_server._process_slot import ProcessSlotTransport
 from torchrl.modules.inference_server._ray import RayTransport
 from torchrl.modules.inference_server._server import (
     InferenceClient,
@@ -27,10 +28,11 @@ __all__ = [
     "InferenceServer",
     "InferenceServerConfig",
     "InferenceTransport",
-    "MonarchTransport",
     "MPTransport",
+    "MonarchTransport",
     "PolicyClientModule",
     "ProcessInferenceServer",
+    "ProcessSlotTransport",
     "RayTransport",
     "SharedMemoryTransport",
     "SlotTransport",

--- a/torchrl/modules/inference_server/_factory.py
+++ b/torchrl/modules/inference_server/_factory.py
@@ -11,6 +11,7 @@ from tensordict.base import TensorDictBase
 from torchrl.modules.inference_server._distributed import _DistributedInferenceTransport
 from torchrl.modules.inference_server._monarch import MonarchTransport
 from torchrl.modules.inference_server._mp import MPTransport
+from torchrl.modules.inference_server._process_slot import ProcessSlotTransport
 from torchrl.modules.inference_server._ray import RayTransport
 from torchrl.modules.inference_server._shared_memory import SharedMemoryTransport
 from torchrl.modules.inference_server._slot import SlotTransport
@@ -36,7 +37,13 @@ def _validate_inference_transport_selection(
     kind = "auto" if transport is None else transport
     allowed = {
         "thread": {"auto", "thread", "queue", "direct"},
-        "process": {"auto", "process", "shared_memory", "distributed"},
+        "process": {
+            "auto",
+            "process",
+            "process_slot",
+            "shared_memory",
+            "distributed",
+        },
         "ray": {"auto", "ray", "distributed"},
     }[service_backend]
     if kind not in allowed:
@@ -46,10 +53,10 @@ def _validate_inference_transport_selection(
         )
     if request_spec is None and response_spec is not None:
         raise ValueError("response_spec requires request_spec.")
-    if kind == "shared_memory" and request_spec is None:
-        raise ValueError(
-            "transport='shared_memory' requires request_spec and response_spec."
-        )
+    if kind in ("shared_memory", "process_slot") and (
+        request_spec is None or response_spec is None
+    ):
+        raise ValueError(f"transport={kind!r} requires request_spec and response_spec.")
     if kind == "distributed" and service_backend == "process" and request_spec is None:
         raise ValueError(
             "Process-owned distributed inference requires request_spec and response_spec."
@@ -130,6 +137,17 @@ def _make_inference_transport(
             )
         options.setdefault("num_slots", num_clients or 1)
         return SharedMemoryTransport(request_spec, response_spec, **options)
+    if kind == "process_slot":
+        if service_backend != "process":
+            raise ValueError(
+                "transport='process_slot' requires service_backend='process'."
+            )
+        if request_spec is None or response_spec is None:
+            raise ValueError(
+                "transport='process_slot' requires request_spec and response_spec."
+            )
+        options.setdefault("num_slots", num_clients or 1)
+        return ProcessSlotTransport(request_spec, response_spec, **options)
     if kind == "direct":
         if service_backend != "thread":
             raise ValueError("transport='direct' requires service_backend='thread'.")
@@ -148,7 +166,8 @@ def _make_inference_transport(
         return _DistributedInferenceTransport(request_spec, response_spec, **options)
     raise ValueError(
         f"Unknown inference transport {transport!r}. Expected one of 'auto', "
-        "'thread', 'process', 'ray', 'shared_memory', 'direct', or 'distributed'."
+        "'thread', 'process', 'ray', 'shared_memory', 'process_slot', 'direct', "
+        "or 'distributed'."
     )
 
 
@@ -156,6 +175,8 @@ def _inference_transport_kind(transport: InferenceTransport) -> str:
     """Return the compact selector for a resolved inference transport."""
     if isinstance(transport, SharedMemoryTransport):
         return "shared_memory"
+    if isinstance(transport, ProcessSlotTransport):
+        return "process_slot"
     if isinstance(transport, SlotTransport):
         return "direct"
     if isinstance(transport, RayTransport):

--- a/torchrl/modules/inference_server/_process_slot.py
+++ b/torchrl/modules/inference_server/_process_slot.py
@@ -1,0 +1,400 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import multiprocessing as mp
+import queue
+import time
+
+import torch
+from tensordict.base import _is_leaf_nontensor, TensorDictBase
+from tensordict.utils import NestedKey
+
+from torchrl._comm import MailboxPeerClosedError, MailboxTransportError
+from torchrl.modules.inference_server._client import (
+    _NO_INTERACTION_TYPE_CODE,
+    _REMOTE_INTERACTION_TYPE_KEY,
+)
+from torchrl.modules.inference_server._transport import InferenceTransport
+
+_MISSING = object()
+_PEER_CHECK_INTERVAL = 0.1
+
+
+class _ProcessSlotFuture:
+    """Future for one request in a fixed process-shared slot."""
+
+    def __init__(self, client: _ProcessSlotClient):
+        self._client = client
+        self._outcome = _MISSING
+
+    def done(self) -> bool:
+        """Return whether the response is ready or the server has exited."""
+        if self._outcome is not _MISSING:
+            return True
+        if self._client._response_event.is_set():
+            return True
+        peer_alive = self._client._peer_alive
+        return peer_alive is not None and not peer_alive.is_set()
+
+    def result(self, timeout: float | None = None) -> TensorDictBase:
+        """Return the response, retaining the slot when a timeout elapses."""
+        if self._outcome is _MISSING:
+            self._outcome = self._client._receive(timeout)
+        if isinstance(self._outcome, BaseException):
+            raise self._outcome
+        return self._outcome
+
+
+class _ProcessSlotClient:
+    """Process-side client bound to one :class:`ProcessSlotTransport` slot."""
+
+    def __init__(
+        self,
+        *,
+        slot_id: int,
+        request_slots: TensorDictBase,
+        response_slots: TensorDictBase,
+        request_keys: list[NestedKey],
+        request_ready,
+        submitted_at,
+        response_status,
+        response_event,
+        exception_queue,
+        work_semaphore,
+        peer_alive,
+        copy_result: bool,
+    ):
+        self._slot_id = slot_id
+        self._request_slots = request_slots
+        self._response_slots = response_slots
+        self._request_keys = request_keys
+        self._request_ready = request_ready
+        self._submitted_at = submitted_at
+        self._response_status = response_status
+        self._response_event = response_event
+        self._exception_queue = exception_queue
+        self._work_semaphore = work_semaphore
+        self._peer_alive = peer_alive
+        self._copy_result = copy_result
+        self._in_flight = False
+
+    @property
+    def client_id(self) -> int:
+        """The fixed slot identifier assigned to this client."""
+        return self._slot_id
+
+    def submit(self, td: TensorDictBase) -> _ProcessSlotFuture:
+        """Write a request into this client's slot and signal the server."""
+        if self._in_flight:
+            raise RuntimeError(
+                "ProcessSlotTransport clients support one in-flight request. "
+                "Wait for the current future before submitting another."
+            )
+        if self._peer_alive is not None and not self._peer_alive.is_set():
+            raise MailboxPeerClosedError(
+                "Inference server process closed before request submission."
+            )
+        request = td.select(*self._request_keys, strict=True)
+        for key, value in request.items(include_nested=True, leaves_only=True):
+            device = getattr(value, "device", None)
+            if device is None or device.type != "cpu":
+                raise ValueError(
+                    "ProcessSlotTransport only accepts CPU tensors; got "
+                    f"device {device} for key {key!r}. Keep environment workers "
+                    "CPU-side and let the server move batches to the policy device."
+                )
+
+        slot = self._slot_id
+        self._request_slots[slot].update_(request)
+        interaction_code = td.get(_REMOTE_INTERACTION_TYPE_KEY, default=None)
+        interaction_slot = self._request_slots[slot].get(_REMOTE_INTERACTION_TYPE_KEY)
+        if interaction_code is None:
+            interaction_slot.fill_(_NO_INTERACTION_TYPE_CODE)
+        else:
+            interaction_slot.copy_(interaction_code)
+        self._response_event.clear()
+        self._response_status[slot] = 0
+        self._submitted_at[slot] = time.monotonic()
+        self._request_ready[slot] = 1
+        self._in_flight = True
+        self._work_semaphore.release()
+        return _ProcessSlotFuture(self)
+
+    def __call__(
+        self, td: TensorDictBase, timeout: float | None = None
+    ) -> TensorDictBase:
+        """Submit a request and block for its response."""
+        return self.submit(td).result(timeout=timeout)
+
+    def _receive(self, timeout: float | None) -> TensorDictBase | BaseException:
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while not self._response_event.is_set():
+            remaining = None if deadline is None else deadline - time.monotonic()
+            if remaining is not None and remaining <= 0:
+                raise queue.Empty(
+                    f"Timeout waiting for process slot {self._slot_id}."
+                ) from None
+            wait_timeout = (
+                _PEER_CHECK_INTERVAL
+                if remaining is None
+                else min(remaining, _PEER_CHECK_INTERVAL)
+            )
+            self._response_event.wait(timeout=wait_timeout)
+            if self._response_event.is_set():
+                break
+            if self._peer_alive is not None:
+                try:
+                    peer_is_alive = self._peer_alive.is_set()
+                except Exception as err:
+                    raise MailboxTransportError(
+                        "Failed to query the inference server's liveness."
+                    ) from err
+                if not peer_is_alive:
+                    self._in_flight = False
+                    raise MailboxPeerClosedError(
+                        "Inference server process closed before replying to "
+                        f"slot {self._slot_id}."
+                    ) from None
+
+        slot = self._slot_id
+        try:
+            if self._response_status[slot]:
+                return self._exception_queue.get()
+            result = self._response_slots[slot]
+            return result.clone() if self._copy_result else result
+        finally:
+            self._response_event.clear()
+            self._in_flight = False
+
+
+class ProcessSlotTransport(InferenceTransport):
+    """Fixed-slot shared-memory transport for environment worker processes.
+
+    Each client owns one CPU shared-memory request/response slot. A worker
+    copies an observation into its slot and releases a process-shared
+    semaphore; the inference server sweeps ready slots in round-robin order,
+    batches their tensor views, writes actions back, and wakes the matching
+    workers. Only synchronization signals cross process boundaries on the
+    inference hot path.
+
+    This transport allows environment workers and a
+    :class:`~torchrl.modules.inference_server.ProcessInferenceServer` to
+    communicate without routing observations or actions through the driver.
+    Each client permits one in-flight request, which naturally applies
+    per-environment backpressure.
+
+    Args:
+        request_spec (TensorDictBase): representative request whose keys,
+            shapes, dtypes and batch size define each request slot. Leaves
+            must be CPU tensors.
+        response_spec (TensorDictBase): representative response, including
+            server-added keys such as ``"policy_version"``. Leaves must be
+            CPU tensors.
+
+    Keyword Args:
+        num_slots (int): number of fixed slots and maximum number of clients.
+        ctx (multiprocessing context, optional): context used for process
+            synchronization primitives. Defaults to ``"spawn"``.
+        copy_result (bool, optional): whether clients clone responses before
+            returning them. Defaults to ``True``. If ``False``, a response is
+            a borrowed view valid only until that client submits again.
+
+    .. note::
+        Create at most one client per environment worker. Unlike queue-based
+        transports, clients do not need registration with the already-running
+        server because every slot and signal is allocated at construction.
+
+    Example:
+        >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from tensordict.nn import TensorDictModule
+        >>> from torchrl.modules.inference_server import (
+        ...     InferenceServer,
+        ...     ProcessSlotTransport,
+        ... )
+        >>> transport = ProcessSlotTransport(
+        ...     TensorDict({"observation": torch.zeros(4)}),
+        ...     TensorDict(
+        ...         {
+        ...             "action": torch.zeros(2),
+        ...             "policy_version": torch.zeros((), dtype=torch.long),
+        ...         }
+        ...     ),
+        ...     num_slots=4,
+        ... )
+        >>> client = transport.client()
+        >>> policy = TensorDictModule(
+        ...     torch.nn.Linear(4, 2), in_keys=["observation"], out_keys=["action"]
+        ... )
+        >>> with InferenceServer(policy, transport, max_batch_size=4):
+        ...     result = client(TensorDict({"observation": torch.randn(4)}))
+        >>> result["action"].shape
+        torch.Size([2])
+    """
+
+    _clients_require_registration = False
+
+    def __init__(
+        self,
+        request_spec: TensorDictBase,
+        response_spec: TensorDictBase,
+        *,
+        num_slots: int,
+        ctx: mp.context.BaseContext | None = None,
+        copy_result: bool = True,
+    ):
+        if isinstance(num_slots, bool) or not isinstance(num_slots, int):
+            raise TypeError("num_slots must be an integer.")
+        if num_slots < 1:
+            raise ValueError(f"num_slots must be positive, got {num_slots}.")
+        self._num_slots = num_slots
+        self._ctx = ctx if ctx is not None else mp.get_context("spawn")
+        self._copy_result = bool(copy_result)
+        self._next_client_slot = 0
+        self._next_slot = 0
+        self._acquired_signals = 0
+
+        request_keys = list(request_spec.keys(include_nested=True, leaves_only=True))
+        self._request_keys = [
+            key for key in request_keys if key != _REMOTE_INTERACTION_TYPE_KEY
+        ]
+        request_slot_spec = request_spec.clone(recurse=False)
+        if _REMOTE_INTERACTION_TYPE_KEY not in request_keys:
+            request_slot_spec.set(
+                _REMOTE_INTERACTION_TYPE_KEY,
+                torch.full(
+                    request_spec.batch_size,
+                    _NO_INTERACTION_TYPE_CODE,
+                    dtype=torch.int8,
+                ),
+            )
+        self._request_slots = self._make_slots(request_slot_spec, "request_spec")
+        self._response_slots = self._make_slots(response_spec, "response_spec")
+        self._response_keys = list(
+            response_spec.keys(include_nested=True, leaves_only=True)
+        )
+
+        self._request_ready = self._ctx.Array("b", num_slots, lock=False)
+        self._submitted_at = self._ctx.Array("d", num_slots, lock=False)
+        self._response_status = self._ctx.Array("b", num_slots, lock=False)
+        self._response_events = [self._ctx.Event() for _ in range(num_slots)]
+        self._exception_queues = [self._ctx.SimpleQueue() for _ in range(num_slots)]
+        self._work_semaphore = self._ctx.Semaphore(0)
+        self._peer_alive = self._ctx.Event()
+        self._peer_alive.set()
+
+    def _make_slots(self, spec: TensorDictBase, argname: str) -> TensorDictBase:
+        leaves = list(
+            spec.items(
+                include_nested=True, leaves_only=True, is_leaf=_is_leaf_nontensor
+            )
+        )
+        if not leaves:
+            raise ValueError(f"{argname} must contain at least one tensor leaf.")
+        for key, value in leaves:
+            if not isinstance(value, torch.Tensor):
+                raise TypeError(
+                    "ProcessSlotTransport specs only support tensor leaves; "
+                    f"{argname} has a {type(value).__name__} at key {key!r}."
+                )
+            if value.device.type != "cpu":
+                raise ValueError(
+                    "ProcessSlotTransport slots live in CPU shared memory; "
+                    f"{argname} has a {value.device} tensor at key {key!r}."
+                )
+        return (
+            spec.unsqueeze(0)
+            .expand(self._num_slots, *spec.batch_size)
+            .clone()
+            .share_memory_()
+        )
+
+    def _set_peer_alive(self, alive_event) -> None:
+        self._peer_alive = alive_event
+
+    def client(self) -> _ProcessSlotClient:
+        """Create a client bound to the next unused slot."""
+        slot_id = self._next_client_slot
+        self._next_client_slot += 1
+        if slot_id >= self._num_slots:
+            raise RuntimeError(
+                f"ProcessSlotTransport has {self._num_slots} slots but client() "
+                f"was called {slot_id + 1} times."
+            )
+        return _ProcessSlotClient(
+            slot_id=slot_id,
+            request_slots=self._request_slots,
+            response_slots=self._response_slots,
+            request_keys=self._request_keys,
+            request_ready=self._request_ready,
+            submitted_at=self._submitted_at,
+            response_status=self._response_status,
+            response_event=self._response_events[slot_id],
+            exception_queue=self._exception_queues[slot_id],
+            work_semaphore=self._work_semaphore,
+            peer_alive=self._peer_alive,
+            copy_result=self._copy_result,
+        )
+
+    def submit(self, td: TensorDictBase):
+        """Reject unbound submissions; callers must first obtain a client."""
+        raise NotImplementedError(
+            "ProcessSlotTransport does not support submit(). Call client() "
+            "to obtain a fixed-slot client."
+        )
+
+    def wait_for_work(self, timeout: float) -> None:
+        """Wait until an environment worker marks a request slot ready."""
+        if self._work_semaphore.acquire(timeout=timeout):
+            self._acquired_signals += 1
+
+    def drain(self, max_items: int) -> tuple[list[TensorDictBase], list[int]]:
+        """Sweep ready slots in round-robin order."""
+        items, callbacks, _submitted_at = self.drain_with_timing(max_items)
+        return items, callbacks
+
+    def drain_with_timing(
+        self, max_items: int
+    ) -> tuple[list[TensorDictBase], list[int], list[float | None]]:
+        """Sweep ready slots and return request submission timestamps."""
+        items = []
+        callbacks = []
+        submitted_at = []
+        start_slot = self._next_slot
+        for offset in range(self._num_slots):
+            slot = (start_slot + offset) % self._num_slots
+            if not self._request_ready[slot]:
+                continue
+            self._request_ready[slot] = 0
+            items.append(self._request_slots[slot].copy())
+            callbacks.append(slot)
+            submitted_at.append(self._submitted_at[slot])
+            self._submitted_at[slot] = 0.0
+            self._next_slot = (slot + 1) % self._num_slots
+            if len(items) >= max_items:
+                break
+
+        signals_to_consume = len(items)
+        acquired = min(signals_to_consume, self._acquired_signals)
+        self._acquired_signals -= acquired
+        signals_to_consume -= acquired
+        for _ in range(signals_to_consume):
+            self._work_semaphore.acquire(block=False)
+        return items, callbacks, submitted_at
+
+    def resolve(self, callback: int, result: TensorDictBase) -> None:
+        """Copy a response into its slot and wake the owning worker."""
+        self._response_slots[callback].update_(
+            result.select(*self._response_keys, strict=True)
+        )
+        self._response_status[callback] = 0
+        self._response_events[callback].set()
+
+    def resolve_exception(self, callback: int, exc: BaseException) -> None:
+        """Send a model exception to the owning worker and wake it."""
+        self._exception_queues[callback].put(exc)
+        self._response_status[callback] = 1
+        self._response_events[callback].set()

--- a/torchrl/modules/inference_server/_server.py
+++ b/torchrl/modules/inference_server/_server.py
@@ -309,10 +309,10 @@ class InferenceServer(metaclass=_InferenceServerMeta):
             or ``"nccl"``. Explicit selectors never fall back to another
             transport.
         request_spec (TensorDictBase, optional): static request layout for
-            shared-memory or process-owned distributed transports, and the
-            representative unbatched request used for CUDA-graph capture when
-            ``static_batch_size`` is set. Ray-owned distributed transports
-            infer and bind this layout on first use.
+            ``"shared_memory"``, ``"process_slot"``, or process-owned
+            distributed transports, and the representative unbatched request
+            used for CUDA-graph capture when ``static_batch_size`` is set.
+            Ray-owned distributed transports infer and bind this layout on first use.
         response_spec (TensorDictBase, optional): static response layout paired
             with ``request_spec``.
         num_clients (int, optional): expected concurrent client count for
@@ -400,6 +400,7 @@ class InferenceServer(metaclass=_InferenceServerMeta):
             "process",
             "ray",
             "shared_memory",
+            "process_slot",
             "direct",
             "distributed",
         ] = "auto",
@@ -1356,7 +1357,11 @@ class ProcessInferenceServer:
             transport._set_peer_alive(peer_alive)
         self._peer_alive = peer_alive
         self._process_monitor: threading.Thread | None = None
-        self._service_client = transport.client()
+        self._service_client = (
+            transport.client()
+            if getattr(transport, "_clients_require_registration", True)
+            else None
+        )
         self._shutdown_event = self._ctx.Event()
         self._ready_queue = self._ctx.Queue()
         control_request_queue = self._ctx.Queue()
@@ -1483,19 +1488,22 @@ class ProcessInferenceServer:
 
     def shutdown(self, timeout: float | None = 5.0) -> None:
         """Signal the child process to stop and wait for it to exit."""
-        if self.is_alive:
-            try:
-                self._request_control("shutdown", timeout=timeout or 5.0)
-            except Exception:
-                pass
-        self._shutdown_event.set()
         process = self._process
         if process is None:
             return
+        if self.is_alive:
+            try:
+                self._request_control(
+                    "shutdown", timeout=5.0 if timeout is None else timeout
+                )
+            except Exception:
+                pass
+        if process.is_alive():
+            self._shutdown_event.set()
         process.join(timeout=timeout)
         if process.is_alive():
             process.terminate()
-            process.join(timeout=timeout)
+            process.join(timeout=max(1.0, timeout) if timeout is not None else None)
         monitor = self._process_monitor
         if monitor is not None:
             monitor.join(timeout=timeout)
@@ -1520,6 +1528,8 @@ class ProcessInferenceServer:
 
     def client(self) -> Any:
         """Return a restricted inference client from the owned transport."""
+        if self._service_client is None:
+            self._service_client = self.transport.client()
         return self._service_client
 
     def clients(self, num_clients: int) -> list[Any]:
@@ -1528,7 +1538,7 @@ class ProcessInferenceServer:
             raise TypeError("num_clients must be an integer.")
         if num_clients < 1:
             raise ValueError("num_clients must be at least 1.")
-        # MPTransport routes replies per client, so reserve a fresh endpoint.
+        # Transports may route replies per client, so reserve fresh endpoints.
         return [self.transport.client() for _ in range(num_clients)]
 
     def stats(


### PR DESCRIPTION
`ProcessSlotTransport` gives each spawned environment a fixed shared-memory inference slot. Workers run reset, inference and stepping directly against the process-owned server; the parent receives owned completed transitions. This PR depends on #4271 and supports static CUDA-graph inference from #4269.

Workers inherit configured CPU affinity before constructing environments. Pause waits for in-flight work, worker exceptions and exits reach the iterator even while other streams are active, and repeated shutdown remains bounded. Direct process slots explicitly reject grouped workers; grouping remains available through AsyncEnvPool.

Validation found and fixed an unreadable-result error after worker death. The Linux affinity test now waits for startup acknowledgement before inspecting worker masks. Completed CPU transitions are consolidated into one owned storage before transfer: profiling showed per-leaf file-descriptor negotiation consumed about 90% of parent collection time.

Validation:
- Full CPU inference suite before final transport consolidation: 144 passed, 15 skipped.
- Linux/GPU selection: 28 initially passed; both failures were fixed and the five affinity/error cases passed on rerun. Static capture, including direct process slots, passed.
- After consolidation, Linux process ownership, repeated pause, worker exceptions and worker death: 4 passed.
- Formatting, lint, docstring arguments, Sphinx underline and diff checks pass. Dependency suites are enabled before push.

Matched fake-pixel benchmark: NVIDIA GB200, PyTorch 2.15.0.dev20260906+cu130, TensorDict 0.14 main (faee822), 16 environments, 5 ms environment latency, two 1024-unit policy layers, 256 frames/batch, two warm-up batches and 2,048 measured frames. Three runs per case; all use identical seeds, dependencies and hardware. Startup, server-stat RPCs and memory inspection are excluded from measured collection time. Host RSS sums parent and children at the end; CUDA memory is device-wide used memory on the dedicated GPU, not peak tensor allocation.

| Mode | Frames/s range | Median batch latency ms | p95 batch latency ms | Host RSS MiB | CUDA used MiB |
|---|---:|---:|---:|---:|---:|
| Shared-memory coordinator, one env/worker | 1073.9–1092.9 | 234.30–238.46 | 239.33–246.90 | 14350.5–14865.9 | 892.3 |
| Shared-memory coordinator, four envs/worker | 963.5–1085.0 | 236.04–244.59 | 241.80–319.33 | 5397.6–6452.3 | 892.3 |
| Direct process slots, original per-leaf transfer | 363.8–376.0 | 682.69–699.56 | 697.72–723.99 | 16903.1–18857.1 | 1780.1–1782.1 |
| Direct process slots, consolidated transfer | 1636.9–1960.7 | 122.17–132.40 | 174.89–259.79 | 14753.6–15274.6 | 1584.1 |

The consolidation change removes the reproducible direct-process regression in this workload. Grouping reduces process memory, but these short runs do not establish a throughput gain. Parent replay backpressure, pause and shutdown validation passed in the integration stack; these figures describe this collector workload only.

Final bounded integration stack, three further repetitions with the same workload, dependencies and warm-up:

| Mode | Frames/s | p50 batch ms | p95 batch ms | Host RSS MiB | CUDA used MiB |
|---|---:|---:|---:|---:|---:|
| Shared-memory coordinator, one env/worker | 1009.81–1061.53 | 240.45–242.73 | 245.13–291.56 | 15312.44–15375.44 | 892.31–892.31 |
| Shared-memory coordinator, four envs/worker | 1072.05–1077.66 | 237.55–238.14 | 243.39–244.98 | 5458.88–5968.50 | 892.31–892.31 |
| Direct slots, consolidated transfer | 1940.39–2024.66 | 115.61–122.17 | 180.96–184.33 | 14763.44–15781.44 | 1584.12–1584.12 |

The final integration CPU run passed 904 inference/objective/replay tests. The selected Linux/GPU collector tests passed all 19 cases. The reset-error regression now measures propagation after the worker acknowledges entering reset, rather than including process startup in its failure deadline.


## Continuous pixel-collection comparison

The [isolated #4269/#4271/#4272 stack](https://github.com/pytorch/rl/actions/runs/34163040035) includes the CUDA input-padding follow-up and the process-slot continuous series from #4289. Three GPU repetitions passed with identical dependency/system-package lists and GPU model/driver to the earlier continuous controls: NVIDIA A10G, 32 CPU environments, 1 ms steps, CNN plus two 1024-wide layers, 256-frame output batches, two warm-up rounds and five measured 1,024-frame rounds. One slow-reset stream stalls for 200 ms every 16 steps. This differs from the GB200/16-environment/5 ms workload above.

| Mode | Uniform frames/s [run range] | Slow-reset frames/s [run range] | Uniform batch p95 ms | Uniform summed RSS MiB |
| --- | ---: | ---: | ---: | ---: |
| Grouped coordinator, eager | 849.8 [847.2, 864.2] | 854.8 [835.9, 870.7] | 342.7 | 7338.6 |
| Grouped coordinator, graph | 764.4 [751.7, 778.0] | 759.8 [739.7, 774.4] | 443.0 | 7282.9 |
| Direct slots, eager | 684.5 [681.3, 688.2] | 681.1 [677.2, 688.8] | 524.8 | 26015.8 |
| Direct slots, graph | 660.2 [660.0, 662.3] | 660.8 [658.7, 662.6] | 545.3 | 26208.6 |

These compare supported configurations with the same total environment count: grouped coordination uses four environments per worker; direct slots require one. They do not isolate worker count from transport. Direct server forward medians improve from 1.62 ms eager to 0.87 ms graph, while total collection slows. Profile the remaining transport/collection costs before claiming a gain for this workload. The earlier GB200 win does not generalize to this A10G workload. RSS counts shared pages per process; the benchmark omits the child server's CUDA allocator peak rather than reporting the parent's unrelated value.
