### PR TITLE
[Feature] Add ordered replay operations

### DIFF
--- a/docs/source/reference/data_replaybuffers.rst
+++ b/docs/source/reference/data_replaybuffers.rst
@@ -138,6 +138,35 @@ writer does not track generations.
     )
     print(f"updated {result.updated_count}, skipped {result.stale_count} stale records")
 
+Ordered asynchronous updates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When sampling is prefetched, the conditional write can be submitted with
+:meth:`~torchrl.data.ReplayBuffer.submit_update_if_present`. The replay buffer
+orders the write after the samples already in its prefetch queue and orders
+newly prefetched samples after the write. Prefetch workers otherwise remain
+parallel, so callers do not need a separate replay thread or queue to overlap
+sampling and writeback with learner work.
+
+.. code-block:: python
+
+    future = buffer.submit_update_if_present(
+        index=sample["index"],
+        generation=sample["index_generation"],
+        patch={"recurrent_state": refreshed},
+    )
+    # Continue learner work. Inspect the result only when it is needed.
+    result = future.result()
+
+The submitted tensors are retained by reference and must remain immutable
+until the future completes. Clone outputs stored in reusable memory, including
+static CUDA-graph output buffers, before submitting them. Call
+:meth:`~torchrl.data.ReplayBuffer.synchronize` at an explicit execution
+boundary to wait for both updates and prefetched samples without consuming the
+prefetched results. Checkpointing does this automatically, and
+:meth:`~torchrl.data.ReplayBuffer.shutdown` additionally closes both executor
+pools and propagates background errors.
+
 Version-compared updates
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -1304,14 +1304,17 @@ def _make_replay_buffer_with_blocked_prefetch(seed=0):
     return replay_buffer, collate
 
 
-def test_replay_buffer_orders_submitted_updates_with_prefetch():
+@pytest.mark.parametrize(
+    ("key", "overwrite"), [("obs", False), (("latent", "state"), True)]
+)
+def test_replay_buffer_orders_submitted_updates_with_prefetch(key, overwrite):
     replay_buffer = _OrderedUpdateReplayBuffer(
         storage=LazyTensorStorage(8),
         writer=TensorDictRoundRobinWriter(track_generations=True),
         batch_size=8,
         prefetch=2,
     )
-    index = replay_buffer.extend(TensorDict({"obs": torch.zeros(8)}, batch_size=[8]))
+    index = replay_buffer.extend(TensorDict({key: torch.zeros(8)}, batch_size=[8]))
     generation = replay_buffer.writer.generations_of(index)
     replay_buffer.sample()
     assert replay_buffer.prefetch_started.wait(timeout=5)
@@ -1319,7 +1322,7 @@ def test_replay_buffer_orders_submitted_updates_with_prefetch():
     future = replay_buffer.submit_update_if_present(
         index=index,
         generation=generation,
-        patch={"obs": torch.ones(8)},
+        patch={key: torch.ones(8)},
     )
     assert not replay_buffer.update_started.wait(timeout=0.05)
     replay_buffer.release_prefetch.set()
@@ -1333,11 +1336,13 @@ def test_replay_buffer_orders_submitted_updates_with_prefetch():
     sample_thread.start()
     assert not replay_buffer.sample_after_update_started.wait(timeout=0.05)
 
+    if overwrite:
+        replay_buffer.extend(TensorDict({key: torch.full((8,), 3.0)}, batch_size=[8]))
     replay_buffer.release_update.set()
     sample_thread.join(timeout=5)
     assert not sample_thread.is_alive()
-    assert future.result(timeout=5).updated_count == 8
-    assert (replay_buffer.sample_after_update["obs"] == 1).all()
+    assert future.result(timeout=5).updated_count == (0 if overwrite else 8)
+    assert (replay_buffer.sample_after_update[key] == (3 if overwrite else 1)).all()
     assert max(
         replay_buffer.events.index("sample-2-end"),
         replay_buffer.events.index("sample-3-end"),
@@ -1417,6 +1422,10 @@ def test_replay_buffer_shutdown_propagates_update_errors_and_is_idempotent():
     assert future.done()
     assert not replay_buffer.is_alive
     replay_buffer.shutdown()
+    with pytest.raises(RuntimeError, match="cannot accept updates"):
+        replay_buffer.submit_update_if_present(
+            index=index, generation=generation, patch={"obs": torch.ones(4)}
+        )
     with pytest.raises(RuntimeError, match="cannot be sampled"):
         replay_buffer.sample(1)
 

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -1248,6 +1248,47 @@ class _BlockingPrefetchCollate:
         return torch.stack(data)
 
 
+class _OrderedUpdateReplayBuffer(TensorDictReplayBuffer):
+    def __init__(self, **kwargs):
+        self.events = []
+        self.prefetch_started = threading.Event()
+        self.release_prefetch = threading.Event()
+        self.update_started = threading.Event()
+        self.release_update = threading.Event()
+        self.sample_after_update_started = threading.Event()
+        self.sample_after_update = None
+        self._sample_calls = 0
+        self._sample_calls_lock = threading.Lock()
+        super().__init__(**kwargs)
+
+    def _sample(self, batch_size):
+        with self._sample_calls_lock:
+            self._sample_calls += 1
+            call = self._sample_calls
+        self.events.append(f"sample-{call}-start")
+        if call in (2, 3):
+            if call == 3:
+                self.prefetch_started.set()
+            if not self.release_prefetch.wait(timeout=5):
+                raise RuntimeError("Timed out waiting to release prefetched samples.")
+        elif call >= 4:
+            self.sample_after_update_started.set()
+        result = super()._sample(batch_size)
+        if call >= 4:
+            self.sample_after_update = result[0]
+        self.events.append(f"sample-{call}-end")
+        return result
+
+    def update_if_present(self, **kwargs):
+        self.events.append("update-start")
+        self.update_started.set()
+        if not self.release_update.wait(timeout=5):
+            raise RuntimeError("Timed out waiting to release the update.")
+        result = super().update_if_present(**kwargs)
+        self.events.append("update-end")
+        return result
+
+
 def _make_replay_buffer_with_blocked_prefetch(seed=0):
     collate = _BlockingPrefetchCollate()
     replay_buffer = ReplayBuffer(
@@ -1261,6 +1302,123 @@ def _make_replay_buffer_with_blocked_prefetch(seed=0):
     replay_buffer.sample()
     assert collate.prefetch_started.wait(timeout=5)
     return replay_buffer, collate
+
+
+def test_replay_buffer_orders_submitted_updates_with_prefetch():
+    replay_buffer = _OrderedUpdateReplayBuffer(
+        storage=LazyTensorStorage(8),
+        writer=TensorDictRoundRobinWriter(track_generations=True),
+        batch_size=8,
+        prefetch=2,
+    )
+    index = replay_buffer.extend(TensorDict({"obs": torch.zeros(8)}, batch_size=[8]))
+    generation = replay_buffer.writer.generations_of(index)
+    replay_buffer.sample()
+    assert replay_buffer.prefetch_started.wait(timeout=5)
+
+    future = replay_buffer.submit_update_if_present(
+        index=index,
+        generation=generation,
+        patch={"obs": torch.ones(8)},
+    )
+    assert not replay_buffer.update_started.wait(timeout=0.05)
+    replay_buffer.release_prefetch.set()
+    assert replay_buffer.update_started.wait(timeout=5)
+
+    # Consume the two samples that preceded the update. Their replacements
+    # have been submitted but must wait for the update barrier.
+    replay_buffer.sample()
+    replay_buffer.sample()
+    sample_thread = threading.Thread(target=replay_buffer.sample)
+    sample_thread.start()
+    assert not replay_buffer.sample_after_update_started.wait(timeout=0.05)
+
+    replay_buffer.release_update.set()
+    sample_thread.join(timeout=5)
+    assert not sample_thread.is_alive()
+    assert future.result(timeout=5).updated_count == 8
+    assert (replay_buffer.sample_after_update["obs"] == 1).all()
+    assert max(
+        replay_buffer.events.index("sample-2-end"),
+        replay_buffer.events.index("sample-3-end"),
+    ) < replay_buffer.events.index("update-start")
+    assert replay_buffer.events.index("update-end") < replay_buffer.events.index(
+        "sample-4-start"
+    )
+    replay_buffer.shutdown()
+
+
+def test_replay_buffer_synchronize_keeps_prefetched_results_and_checkpoints_updates():
+    replay_buffer = TensorDictReplayBuffer(
+        storage=LazyTensorStorage(8),
+        writer=TensorDictRoundRobinWriter(track_generations=True),
+        batch_size=4,
+        prefetch=2,
+        generator=torch.Generator().manual_seed(0),
+    )
+    index = replay_buffer.extend(TensorDict({"obs": torch.zeros(8)}, batch_size=[8]))
+    generation = replay_buffer.writer.generations_of(index)
+    replay_buffer.sample()
+    queued = len(replay_buffer._prefetch_queue)
+    prefetched = []
+    for queued_future in replay_buffer._prefetch_queue:
+        queued_data, queued_info = queued_future.result()
+        prefetched.append((queued_data.clone(), queued_info["index"].clone()))
+    future = replay_buffer.submit_update_if_present(
+        index=index,
+        generation=generation,
+        patch={"obs": torch.ones(8)},
+    )
+
+    replay_buffer.synchronize()
+    assert future.result().updated_count == 8
+    assert len(replay_buffer._prefetch_queue) == queued
+    for expected_data, expected_index in prefetched:
+        actual_data, actual_info = replay_buffer.sample(return_info=True)
+        assert_allclose_td(actual_data.select("obs"), expected_data.select("obs"))
+        assert torch.equal(actual_info["index"], expected_index)
+
+    second = replay_buffer.submit_update_if_present(
+        index=index,
+        generation=generation,
+        patch={"obs": torch.full((8,), 2.0)},
+    )
+    state = replay_buffer.state_dict()
+    assert second.done()
+
+    restored = TensorDictReplayBuffer(
+        storage=LazyTensorStorage(8),
+        writer=TensorDictRoundRobinWriter(track_generations=True),
+        batch_size=4,
+        prefetch=2,
+    )
+    restored.load_state_dict(state)
+    assert (restored[:]["obs"] == 2).all()
+    assert len(restored._prefetch_queue) == queued
+    replay_buffer.shutdown()
+    restored.shutdown()
+
+
+def test_replay_buffer_shutdown_propagates_update_errors_and_is_idempotent():
+    replay_buffer = TensorDictReplayBuffer(
+        storage=LazyTensorStorage(4),
+        writer=TensorDictRoundRobinWriter(track_generations=True),
+    )
+    index = replay_buffer.extend(TensorDict({"obs": torch.zeros(4)}, batch_size=[4]))
+    generation = replay_buffer.writer.generations_of(index)
+    future = replay_buffer.submit_update_if_present(
+        index=index,
+        generation=generation,
+        patch={"missing": torch.ones(4)},
+    )
+
+    with pytest.raises(KeyError, match="missing"):
+        replay_buffer.shutdown()
+    assert future.done()
+    assert not replay_buffer.is_alive
+    replay_buffer.shutdown()
+    with pytest.raises(RuntimeError, match="cannot be sampled"):
+        replay_buffer.sample(1)
 
 
 def _release_prefetch_when_futures_lock_is_held(

--- a/torchrl/data/replay_buffers/ray_buffer.py
+++ b/torchrl/data/replay_buffers/ray_buffer.py
@@ -592,6 +592,10 @@ class RayReplayBuffer(ReplayBuffer):
         """
         return self._client.stats()
 
+    def synchronize(self) -> None:
+        """Wait for pending work owned by the replay-buffer actor."""
+        return ray.get(self._rb.synchronize.remote())
+
     def update_if_present(
         self,
         *,

--- a/torchrl/data/replay_buffers/replay_buffers/base.py
+++ b/torchrl/data/replay_buffers/replay_buffers/base.py
@@ -1145,8 +1145,6 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             raise NotImplementedError(
                 "submit_update_if_present is only supported by direct replay buffers."
             )
-        if self._service_shutdown:
-            raise RuntimeError("A shut down replay buffer cannot accept updates.")
         operation = ft.partial(
             self.update_if_present,
             index=index,
@@ -1157,6 +1155,8 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             require_newer=require_newer,
         )
         with self._futures_lock:
+            if self._service_shutdown:
+                raise RuntimeError("A shut down replay buffer cannot accept updates.")
             while (
                 self._pending_update_futures and self._pending_update_futures[0].done()
             ):

--- a/torchrl/data/replay_buffers/replay_buffers/base.py
+++ b/torchrl/data/replay_buffers/replay_buffers/base.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import collections
 import contextlib
+import functools as ft
 import json
 import multiprocessing
 import pickle
@@ -25,7 +26,6 @@ try:
 except ImportError:
     from torch._dynamo import is_compiling
 
-from functools import wraps
 from typing import Literal, TYPE_CHECKING, TypeVar
 
 from tensordict import (
@@ -99,13 +99,19 @@ def _storage_index(index: Any, storage: Storage) -> Any:
 
 
 def _maybe_delay_init(func):
-    @wraps(func)
+    @ft.wraps(func)
     def wrapper(self, *args, **kwargs):
         if self._delayed_init and not self.initialized:
             self._init()
         return func(self, *args, **kwargs)
 
     return wrapper
+
+
+def _run_after_futures(futures: tuple[Future, ...], operation: Callable[[], T]) -> T:
+    for future in futures:
+        future.result()
+    return operation()
 
 
 class ConditionalUpdateResult(TensorClass["nocast"]):
@@ -459,6 +465,9 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
         self._prefetch = bool(prefetch)
         self._prefetch_cap = prefetch or 0
         self._prefetch_queue = collections.deque()
+        self._pending_update_futures = collections.deque()
+        self._sample_dependency = None
+        self._update_executor = None
         self._batch_size = batch_size
         self._warned_batch_size_conflict = False
 
@@ -672,9 +681,46 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             del self._distributed_service
 
     def shutdown(self, timeout: float | None = None) -> None:
-        """Mark this direct replay-buffer owner as shut down."""
+        """Wait for pending replay work and close this direct replay buffer.
+
+        Pending prefetched samples and asynchronous conditional updates are
+        allowed to finish before their executors are closed. Any background
+        exception is re-raised after both executors have been shut down.
+        Repeated calls are safe.
+        """
         del timeout
-        self._service_shutdown = True
+        with self._futures_lock:
+            if self._service_shutdown:
+                return
+            self._service_shutdown = True
+
+        error = None
+        try:
+            self.synchronize()
+        except BaseException as err:
+            error = err
+        finally:
+            with self._futures_lock:
+                prefetch_executor = getattr(self, "_prefetch_executor", None)
+                update_executor = self._update_executor
+                self._prefetch_executor = None
+                self._update_executor = None
+            if prefetch_executor is not None:
+                prefetch_executor.shutdown(wait=True)
+            if update_executor is not None:
+                update_executor.shutdown(wait=True)
+        if error is not None:
+            raise error
+
+    def synchronize(self) -> None:
+        """Wait for pending samples and asynchronous updates.
+
+        Prefetched results remain queued and are returned by subsequent calls
+        to :meth:`sample` in the same order. Background exceptions are
+        propagated to the caller.
+        """
+        with self._futures_lock:
+            self._synchronize_futures_locked()
 
     def _initialize_prioritized_sampler(self) -> None:
         """Initialize priority trees for existing data when using PrioritizedSampler.
@@ -1038,6 +1084,97 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             stats["capacity"] = int(capacity)
             stats["utilization"] = float(size) / capacity if capacity else 0.0
         return stats
+
+    @_maybe_delay_init
+    def submit_update_if_present(
+        self,
+        *,
+        index: torch.Tensor,
+        generation: torch.Tensor,
+        patch: Mapping[NestedKey, torch.Tensor] | TensorDictBase,
+        version_key: NestedKey | None = None,
+        version: int | torch.Tensor | None = None,
+        require_newer: bool = False,
+    ) -> Future[ConditionalUpdateResult]:
+        """Submits an ordered conditional update on a background thread.
+
+        The update runs after all samples that were already prefetched when
+        this method was called. Samples prefetched after this call wait for
+        the update, while unrelated prefetch work remains parallel. Multiple
+        submitted updates execute in submission order.
+
+        Inputs are retained by reference until the returned future completes.
+        Callers must not mutate ``index``, ``generation``, ``patch`` or
+        ``version`` in that interval. In particular, values backed by static
+        CUDA-graph output buffers must be cloned before submission.
+
+        Keyword arguments have the same meaning as in
+        :meth:`update_if_present`.
+
+        Returns:
+            A :class:`concurrent.futures.Future` whose result is the
+            :class:`ConditionalUpdateResult` returned by
+            :meth:`update_if_present`.
+
+        Examples:
+            >>> import torch
+            >>> from tensordict import TensorDict
+            >>> from torchrl.data import (
+            ...     LazyTensorStorage,
+            ...     TensorDictReplayBuffer,
+            ...     TensorDictRoundRobinWriter,
+            ... )
+            >>> rb = TensorDictReplayBuffer(
+            ...     storage=LazyTensorStorage(4),
+            ...     writer=TensorDictRoundRobinWriter(track_generations=True),
+            ... )
+            >>> index = rb.extend(
+            ...     TensorDict({"value": torch.zeros(4)}, batch_size=[4])
+            ... )
+            >>> generation = rb.writer.generations_of(index)
+            >>> future = rb.submit_update_if_present(
+            ...     index=index,
+            ...     generation=generation,
+            ...     patch={"value": torch.ones(4)},
+            ... )
+            >>> future.result().updated_count
+            4
+            >>> rb.shutdown()
+        """
+        if self.service_backend != "direct":
+            raise NotImplementedError(
+                "submit_update_if_present is only supported by direct replay buffers."
+            )
+        if self._service_shutdown:
+            raise RuntimeError("A shut down replay buffer cannot accept updates.")
+        operation = ft.partial(
+            self.update_if_present,
+            index=index,
+            generation=generation,
+            patch=patch,
+            version_key=version_key,
+            version=version,
+            require_newer=require_newer,
+        )
+        with self._futures_lock:
+            while (
+                self._pending_update_futures and self._pending_update_futures[0].done()
+            ):
+                completed = self._pending_update_futures.popleft()
+                completed.result()
+            if not self._pending_update_futures:
+                self._sample_dependency = None
+            if self._update_executor is None:
+                self._update_executor = ThreadPoolExecutor(max_workers=1)
+            dependencies = tuple(self._prefetch_queue)
+            if self._sample_dependency is not None:
+                dependencies = (*dependencies, self._sample_dependency)
+            future = self._update_executor.submit(
+                _run_after_futures, dependencies, operation
+            )
+            self._pending_update_futures.append(future)
+            self._sample_dependency = future
+        return future
 
     def update_if_present(
         self,
@@ -1539,11 +1676,30 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
 
         return tree_map(_clone_leaf, result)
 
+    def _synchronize_futures_locked(self) -> None:
+        futures = tuple(
+            dict.fromkeys((*self._prefetch_queue, *self._pending_update_futures))
+        )
+        if futures:
+            wait(futures)
+        error = None
+        for future in futures:
+            try:
+                future.result()
+            except BaseException as err:
+                if error is None:
+                    error = err
+        self._pending_update_futures.clear()
+        self._sample_dependency = None
+        if error is not None:
+            raise error
+
     @contextlib.contextmanager
     def _capture_prefetch_state(
         self, *, clone_queue: bool = True
     ) -> Iterator[dict[str, Any]]:
         with self._futures_lock:
+            self._synchronize_futures_locked()
             results = (
                 tuple(future.result() for future in self._prefetch_queue)
                 if self._prefetch
@@ -1658,6 +1814,7 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         prefetch_state = state_dict.get("_prefetch_state")
         self._validate_prefetch_state(prefetch_state)
+        self.synchronize()
         with self._futures_lock:
             self._clear_prefetch_queue_locked()
             with self._replay_lock:
@@ -1760,6 +1917,7 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
         path = Path(path).absolute()
         prefetch_state = self._load_prefetch_state(path)
         self._validate_prefetch_state(prefetch_state)
+        self.synchronize()
         with self._futures_lock:
             self._clear_prefetch_queue_locked()
             with self._replay_lock:
@@ -2045,6 +2203,8 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             A batch of data selected in the replay buffer.
             A tuple containing this batch and info if return_info flag is set to True.
         """
+        if self._service_shutdown:
+            raise RuntimeError("A shut down replay buffer cannot be sampled.")
         if (
             batch_size is not None
             and self._batch_size is not None
@@ -2069,19 +2229,33 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
                 "for a proper usage of the batch-size arguments."
             )
         if not self._prefetch:
+            with self._futures_lock:
+                dependency = self._sample_dependency
+            if dependency is not None:
+                dependency.result()
             result = self._sample(batch_size)
         else:
             with self._futures_lock:
                 if len(self._prefetch_queue):
                     result = self._prefetch_queue.popleft().result()
                 else:
+                    if self._sample_dependency is not None:
+                        self._sample_dependency.result()
                     result = self._sample(batch_size)
                 while (
                     len(self._prefetch_queue)
                     < min(self._sampler._remaining_batches, self._prefetch_cap)
                     and not self._sampler.ran_out
                 ):
-                    fut = self._prefetch_executor.submit(self._sample, batch_size)
+                    operation = ft.partial(self._sample, batch_size)
+                    if self._sample_dependency is None:
+                        fut = self._prefetch_executor.submit(operation)
+                    else:
+                        fut = self._prefetch_executor.submit(
+                            _run_after_futures,
+                            (self._sample_dependency,),
+                            operation,
+                        )
                     self._prefetch_queue.append(fut)
 
         if return_info:
@@ -2316,10 +2490,12 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
                 state["_futures_lock_placeholder"] = None
             _prefetch_queue = state.pop("_prefetch_queue", None)
             _prefetch_executor = state.pop("_prefetch_executor", None)
+            state.pop("_update_executor", None)
             if _prefetch_queue is not None:
                 state["_prefetch_queue_placeholder"] = None
             if _prefetch_executor is not None:
                 state["_prefetch_executor_placeholder"] = None
+            state["_update_executor_placeholder"] = None
             state["_prefetch_state"] = prefetch_state
             return state
 
@@ -2349,6 +2525,12 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             state["_prefetch_executor"] = ThreadPoolExecutor(
                 max_workers=state["_prefetch_cap"]
             )
+        if "_update_executor_placeholder" in state:
+            state.pop("_update_executor_placeholder")
+            state["_update_executor"] = None
+        state.setdefault("_pending_update_futures", collections.deque())
+        state.setdefault("_sample_dependency", None)
+        state.setdefault("_update_executor", None)
         self.__dict__.update(state)
         if rngstate is not None:
             self.set_rng(rng)


### PR DESCRIPTION
Adds `ReplayBuffer.submit_update_if_present()` for ordered background conditional updates and `synchronize()` for a quiescent replay boundary. Updates wait for earlier prefetch work; later sampling waits for preceding updates. Generation checks prevent latent patches from modifying overwritten rows. Submitted inputs remain owned by the caller and must stay unchanged until the future completes.

Checkpoint serialization drains pending operations while preserving prefetched samples, their order, sampler state and RNG state. Shutdown drains both executors, propagates background failures, and rejects new work. Admission is checked under the executor lock so shutdown cannot race with a new update submission.

Validation: 17 focused CPU cases pass, covering ordered sampling/updates, overwrite rejection with nested patch keys, pending-work checkpoints, state_dict/disk/pickle replay restoration, retained prefetched results, and shutdown errors. Formatting, lint, documentation and diff checks pass.

First replay dependency for #4274, then #4275 and #4265.
