### PR TITLE
[Feature] Route async collection into replay

### DIFF
--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -5652,6 +5652,33 @@ class TestCollectHooks:
         finally:
             collector.shutdown()
 
+    def test_post_collect_hook_runs_before_replay_write(self):
+        hook_calls = 0
+
+        def hook(result):
+            nonlocal hook_calls
+            hook_calls += 1
+            result.set("hook_marker", torch.ones(result.batch_size, dtype=torch.bool))
+
+        env = ContinuousActionVecMockEnv()
+        rb = ReplayBuffer(storage=LazyTensorStorage(64, device="cpu"))
+        collector = Collector(
+            env,
+            RandomPolicy(env.action_spec),
+            frames_per_batch=16,
+            total_frames=32,
+            replay_buffer=rb,
+            post_collect_hook=hook,
+        )
+        try:
+            outputs = list(collector)
+        finally:
+            collector.shutdown()
+
+        assert outputs == [None, None]
+        assert hook_calls == 2
+        assert rb[:]["hook_marker"].all()
+
     def test_hooks_none_by_default(self):
         collector = Collector(
             ContinuousActionVecMockEnv,

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -39,6 +39,12 @@ from torchrl._comm import (
     SharedBlock,
     TCPStoreRendezvous,
 )
+from torchrl.data import (
+    LazyTensorStorage,
+    ReplayBufferEnsemble,
+    TensorDictReplayBuffer,
+    TensorDictRoundRobinWriter,
+)
 from torchrl.modules.inference_server import (
     InferenceClient,
     InferenceDeviceConfig,
@@ -2635,6 +2641,195 @@ def _collector_owner_exit(status_queue, exit_event, reset_entered):
 
 class TestAsyncBatchedCollector:
     """Tests for :class:`AsyncBatchedCollector`."""
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            "cpu",
+            pytest.param(
+                "cuda",
+                marks=[
+                    pytest.mark.gpu,
+                    pytest.mark.skipif(
+                        not torch.cuda.is_available(), reason="requires CUDA"
+                    ),
+                ],
+            ),
+        ],
+    )
+    def test_policy_update_uses_inference_server(self, device):
+        class Policy(nn.Module):
+            in_keys = ["observation"]
+            out_keys = ["action"]
+
+            def __init__(self, value):
+                super().__init__()
+                self.value = nn.Parameter(torch.tensor(float(value)))
+
+            def forward(self, td):
+                return td.set("action", torch.ones_like(td["observation"]) * self.value)
+
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * 2,
+            policy=Policy(1),
+            frames_per_batch=4,
+            total_frames=-1,
+            server_config=InferenceServerConfig(
+                max_batch_size=2,
+                static_batch_size=2 if device == "cuda" else None,
+            ),
+            device_config=InferenceDeviceConfig(
+                policy_device=device, output_device="cpu"
+            ),
+            env_backend="threading",
+        )
+        iterator = iter(collector)
+        try:
+            next(iterator)
+            collector.update_policy_weights_(Policy(2))
+            for _ in range(3):
+                batch = next(iterator)
+                updated = batch["policy_version"] == 1
+                if updated.any():
+                    torch.testing.assert_close(
+                        batch["action"][updated],
+                        torch.full_like(batch["action"][updated], 2),
+                    )
+                    break
+            else:
+                pytest.fail("Updated policy version did not reach collection.")
+            assert collector.policy_version == 1
+        finally:
+            collector.shutdown()
+
+    @pytest.mark.parametrize(
+        ("env_backend", "env_exchange", "envs_per_worker", "process_slots"),
+        [
+            ("threading", "queue", 1, False),
+            ("multiprocessing", "queue", 1, False),
+            ("multiprocessing", "shm", 1, False),
+            ("multiprocessing", "queue", 2, False),
+            ("multiprocessing", "shm", 2, False),
+            ("multiprocessing", "queue", 1, True),
+        ],
+    )
+    def test_parent_replay_write_and_post_collect_hook(
+        self, env_backend, env_exchange, envs_per_worker, process_slots
+    ):
+        """Post-processing, hooks and routed writes run in the parent."""
+        parent_thread = threading.get_ident()
+        hook_calls = []
+
+        def postproc(td):
+            td.set(
+                "postproc_marker",
+                torch.ones(td.batch_size, dtype=torch.bool, device=td.device),
+            )
+            return td
+
+        def post_collect_hook(td):
+            assert td["postproc_marker"].all()
+            hook_calls.append(threading.get_ident())
+            td.set(
+                "hook_marker",
+                torch.ones(td.batch_size, dtype=torch.bool, device=td.device),
+            )
+
+        members = [
+            TensorDictReplayBuffer(
+                storage=LazyTensorStorage(64, device="cpu"),
+                writer=TensorDictRoundRobinWriter(track_generations=True),
+            )
+            for _ in range(2)
+        ]
+        replay_buffer = ReplayBufferEnsemble(*members, routing_key="env_index")
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * 2,
+            policy=None if process_slots else _make_counting_policy(),
+            policy_factory=_make_counting_policy if process_slots else None,
+            transport=_counting_process_transport(2) if process_slots else None,
+            server_config=InferenceServerConfig(
+                service_backend="process" if process_slots else "thread",
+                max_batch_size=2,
+            ),
+            frames_per_batch=10,
+            total_frames=21,
+            postproc=postproc,
+            post_collect_hook=post_collect_hook,
+            replay_buffer=replay_buffer,
+            env_exchange=env_exchange,
+            envs_per_worker=envs_per_worker,
+            env_backend=env_backend,
+        )
+        try:
+            outputs = list(collector)
+        finally:
+            collector.shutdown()
+
+        assert outputs and all(output is None for output in outputs)
+        assert hook_calls and set(hook_calls) == {parent_thread}
+        assert replay_buffer.stats()["write_count"] == 21
+        assert sum(len(member) for member in members) == 21
+        for env_id, member in enumerate(members):
+            # Fast streams may exhaust a short budget while another process starts.
+            if not len(member):
+                continue
+            stored = member[:]
+            assert stored.device == torch.device("cpu")
+            assert stored["postproc_marker"].all()
+            assert stored["hook_marker"].all()
+            assert (stored["env_index"] == env_id).all()
+
+    @pytest.mark.parametrize(
+        ("env_backend", "env_exchange", "envs_per_worker", "process_slots"),
+        [
+            ("threading", "queue", 1, False),
+            ("multiprocessing", "queue", 1, False),
+            ("multiprocessing", "shm", 1, False),
+            ("multiprocessing", "queue", 2, False),
+            ("multiprocessing", "shm", 2, False),
+            ("multiprocessing", "queue", 1, True),
+        ],
+    )
+    def test_replay_backpressure_does_not_block_shutdown(
+        self, env_backend, env_exchange, envs_per_worker, process_slots
+    ):
+        replay_buffer = TensorDictReplayBuffer(storage=LazyTensorStorage(64))
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * 2,
+            policy=None if process_slots else _make_counting_policy(),
+            policy_factory=_make_counting_policy if process_slots else None,
+            transport=_counting_process_transport(2) if process_slots else None,
+            server_config=InferenceServerConfig(
+                service_backend="process" if process_slots else "thread",
+                max_batch_size=2,
+            ),
+            frames_per_batch=2,
+            total_frames=-1,
+            replay_buffer=replay_buffer,
+            env_exchange=env_exchange,
+            envs_per_worker=envs_per_worker,
+            env_backend=env_backend,
+        )
+        iterator = iter(collector)
+        assert next(iterator) is None
+        deadline = time.monotonic() + 2.0
+        while not collector._result_queue.full() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert collector._result_queue.full()
+        workers = list(collector._workers)
+
+        try:
+            with collector.pause(timeout=10.0):
+                assert collector._result_queue.full()
+            assert next(iterator) is None
+            stored = replay_buffer[:].clone()
+            assert next(iterator) is None
+            assert_close(replay_buffer[: stored.numel()], stored)
+        finally:
+            collector.shutdown(timeout=2.0)
+
+        assert not any(worker.is_alive() for worker in workers)
 
     @pytest.mark.parametrize("total_frames", [60, 61])
     def test_basic_collection(self, total_frames):

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import contextlib
+import functools as ft
 import multiprocessing as mp
 import os
 import queue
@@ -20,6 +21,7 @@ from tensordict import (
     LazyStackedTensorDict,
     maybe_dense_stack,
     NestedKey,
+    TensorDict,
     TensorDictBase,
 )
 from torchrl._comm import MailboxTransportError
@@ -30,6 +32,8 @@ from torchrl._utils import (
     timeit,
 )
 from torchrl.collectors._base import BaseCollector
+from torchrl.collectors.utils import _maybe_normalize_replay_buffer_tensordict_device
+from torchrl.data.replay_buffers import ReplayBuffer
 from torchrl.data.utils import CloudpickleWrapper
 from torchrl.envs import AsyncEnvPool, EnvBase, EnvCreator
 from torchrl.envs.async_envs import _validate_cpu_affinity
@@ -44,6 +48,7 @@ from torchrl.modules.inference_server import (
 )
 from torchrl.modules.inference_server._config import _resolve_device_config
 from torchrl.modules.inference_server._transport import InferenceTransport
+from torchrl.weight_update.weight_sync_schemes import WeightStrategy
 
 _ENV_IDX_KEY = "env_index"
 
@@ -101,6 +106,21 @@ def _wait_while_paused(pause_request: list[_PauseRequest | None]) -> None:
     resume_event.wait()
 
 
+def _put_result(result_queue, item, shutdown_event, *, pause=None) -> bool:
+    """Retain a completed result through backpressure and pause."""
+    while not shutdown_event.is_set():
+        if pause is not None:
+            pause()
+        if shutdown_event.is_set():
+            break
+        try:
+            result_queue.put(item, timeout=0.1)
+            return True
+        except queue.Full:
+            continue
+    return False
+
+
 def _env_loop(
     pool: AsyncEnvPool,
     env_id: int,
@@ -144,10 +164,16 @@ def _env_loop(
             cur_td.set(_ENV_IDX_KEY, env_id)
             if storing_device is not None:
                 cur_td = cur_td.to(storing_device)
-            result_queue.put(cur_td)
+            if not _put_result(
+                result_queue,
+                cur_td,
+                shutdown_event,
+                pause=ft.partial(_wait_while_paused, pause_request),
+            ):
+                break
     except Exception as exc:
         if not shutdown_event.is_set():
-            result_queue.put(exc)
+            _put_result(result_queue, exc, shutdown_event)
 
 
 def _process_env_loop(
@@ -248,6 +274,7 @@ def _env_batch_loop(
     exchange_keys = pool.exchange_keys
     ready_observations = {}
     pending_actions = {}
+    pending_results = deque()
     policy_outputs = {}
     stepping = 0
     poll_interval = 0.001
@@ -258,6 +285,15 @@ def _env_batch_loop(
         resetting = pool.num_envs
 
         while not shutdown_event.is_set():
+            while pending_results:
+                try:
+                    result_queue.put_nowait(pending_results[0])
+                except queue.Full:
+                    break
+                pending_results.popleft()
+            if pending_results and pause_request[0] is None:
+                shutdown_event.wait(poll_interval)
+                continue
             if resetting:
                 try:
                     observations = pool.async_reset_recv(
@@ -339,12 +375,18 @@ def _env_batch_loop(
             if isinstance(transitions, LazyStackedTensorDict):
                 transitions = transitions.clone()
             transitions.update(outputs.exclude(*transitions.keys(True, True)))
+            transitions.set(
+                _ENV_IDX_KEY,
+                torch.tensor(completed_ids, device=transitions.device, dtype=torch.long)
+                .reshape(-1, *([1] * (transitions.ndim - 1)))
+                .expand(transitions.batch_size),
+            )
             if storing_device is not None:
                 transitions = transitions.to(storing_device)
-            result_queue.put(transitions)
+            pending_results.append(transitions)
     except Exception as exc:
         if not shutdown_event.is_set():
-            result_queue.put(exc)
+            _put_result(result_queue, exc, shutdown_event)
 
 
 class AsyncBatchedCollector(BaseCollector):
@@ -460,6 +502,14 @@ class AsyncBatchedCollector(BaseCollector):
             start of every collection batch.  Defaults to ``False``.
         postproc (Callable, optional): post-processing transform applied to
             each collected batch before yielding.  Defaults to ``None``.
+        replay_buffer (ReplayBuffer, optional): replay buffer to extend in the
+            collector's parent thread after post-processing. When provided,
+            iteration yields ``None`` instead of full rollout batches.
+            Defaults to ``None``.
+        post_collect_hook (Callable, optional): callback invoked with each
+            post-processed batch before it is normalized and written to replay
+            (or yielded when no replay buffer is configured). Defaults to
+            ``None``.
         yield_completed_trajectories (bool, optional): if ``True``, the
             collector yields individual completed trajectories as they finish
             rather than fixed-size batches.  ``frames_per_batch`` acts as the
@@ -541,6 +591,8 @@ class AsyncBatchedCollector(BaseCollector):
         ) = None,
         reset_at_each_iter: bool = False,
         postproc: Callable[[TensorDictBase], TensorDictBase] | None = None,
+        replay_buffer: ReplayBuffer | None = None,
+        post_collect_hook: Callable[[TensorDictBase], None] | None = None,
         yield_completed_trajectories: bool = False,
         weight_sync=None,
         weight_sync_model_id: str = "policy",
@@ -555,6 +607,7 @@ class AsyncBatchedCollector(BaseCollector):
         policy_version: int = 0,
         policy_version_key: NestedKey | None = "policy_version",
     ):
+        super().__init__(post_collect_hook=post_collect_hook)
         if policy is not None and policy_factory is not None:
             raise TypeError("policy and policy_factory are mutually exclusive.")
         if policy is None and policy_factory is None:
@@ -778,6 +831,7 @@ class AsyncBatchedCollector(BaseCollector):
         self.reset_at_each_iter = reset_at_each_iter
         self.yield_completed_trajectories = yield_completed_trajectories
         self._postproc = postproc
+        self.replay_buffer = replay_buffer
         self.verbose = verbose
 
         self._frames = 0
@@ -942,7 +996,17 @@ class AsyncBatchedCollector(BaseCollector):
 
             # Start coordinator threads. Shared slots can be drained safely in
             # ready batches, avoiding one Python thread and one clone per env.
-            self._result_queue = queue.Queue()
+            self._uses_batched_coordinator = (
+                self._env_pool.resolved_exchange == "shm" or self._envs_per_worker > 1
+            )
+            # A ready packet contains at most one transition per environment.
+            # Bound the queue by roughly one rollout, plus in-flight completions.
+            queue_size = self.frames_per_batch
+            if self._uses_batched_coordinator:
+                queue_size = max(
+                    1, queue_size // self._env_pool.fake_tensordict().numel()
+                )
+            self._result_queue = queue.Queue(maxsize=queue_size)
             self._shutdown_event = threading.Event()
 
             self._workers = []
@@ -1116,6 +1180,34 @@ class AsyncBatchedCollector(BaseCollector):
     def policy_version(self) -> int:
         """The live behavior-policy version of the inference server."""
         return self._server.policy_version
+
+    def _maybe_fallback_update(
+        self,
+        policy_or_weights=None,
+        *,
+        model_id: str | None = None,
+    ) -> None:
+        if model_id not in (None, "policy"):
+            raise KeyError(f"Unknown AsyncBatchedCollector model_id {model_id!r}.")
+        if isinstance(policy_or_weights, torch.nn.Module):
+            weights = TensorDict.from_module(policy_or_weights)
+        elif isinstance(policy_or_weights, TensorDictBase):
+            weights = policy_or_weights
+        elif isinstance(policy_or_weights, dict):
+            weights = TensorDict.from_dict(policy_or_weights, batch_size=[])
+        else:
+            raise TypeError(
+                "AsyncBatchedCollector policy updates require an nn.Module, "
+                "TensorDict, or state dictionary."
+            )
+        weights = weights.detach().clone()
+        update_model_weights = getattr(self._server, "update_model_weights", None)
+        if update_model_weights is not None:
+            update_model_weights(weights)
+        else:
+            self._server.update_model(
+                ft.partial(WeightStrategy().apply_weights, weights=weights)
+            )
 
     # ------------------------------------------------------------------
     # Rollout: drain the result queue
@@ -1323,7 +1415,7 @@ class AsyncBatchedCollector(BaseCollector):
     # BaseCollector interface
     # ------------------------------------------------------------------
 
-    def iterator(self) -> Iterator[TensorDictBase]:
+    def iterator(self) -> Iterator[TensorDictBase | None]:
         """Iterate over collected batches."""
         self._ensure_started()
 
@@ -1338,7 +1430,16 @@ class AsyncBatchedCollector(BaseCollector):
             self._frames += td.numel()
             if self._postproc is not None:
                 td = self._postproc(td)
-            yield td
+            if self.post_collect_hook is not None:
+                self.post_collect_hook(td)
+            if self.replay_buffer is not None:
+                td = _maybe_normalize_replay_buffer_tensordict_device(
+                    td, self.replay_buffer
+                )
+                self.replay_buffer.extend(td)
+                yield None
+            else:
+                yield td
 
     def shutdown(
         self,

--- a/torchrl/collectors/_single.py
+++ b/torchrl/collectors/_single.py
@@ -1841,6 +1841,8 @@ class Collector(BaseCollector, metaclass=_CollectorMeta):
                         self.post_collect_hook(tensordict_out)
                     yield tensordict_out
                 elif self.replay_buffer is not None and not self._ignore_rb:
+                    if self.post_collect_hook is not None:
+                        self.post_collect_hook(tensordict_out)
                     tensordict_out = _maybe_normalize_replay_buffer_tensordict_device(
                         tensordict_out, self.replay_buffer
                     )

--- a/torchrl/collectors/utils.py
+++ b/torchrl/collectors/utils.py
@@ -613,6 +613,20 @@ def _maybe_normalize_replay_buffer_tensordict_device(
     if storage_device is None:
         storage_data = getattr(storage, "_storage", None)
         storage_device = getattr(storage_data, "device", None)
+    if storage_device is None:
+        member_storages = getattr(storage, "_storages", None)
+        if member_storages:
+            member_devices = []
+            for member in member_storages:
+                member_device = getattr(member, "device", None) or getattr(
+                    getattr(member, "_storage", None), "device", None
+                )
+                if member_device is None or member_device == "auto":
+                    member_devices = []
+                    break
+                member_devices.append(torch.device(member_device))
+            if member_devices and len(set(member_devices)) == 1:
+                storage_device = member_devices[0]
     if storage_device is None or storage_device == "auto":
         return data
     storage_device = torch.device(storage_device)


### PR DESCRIPTION
`AsyncBatchedCollector` supports parent-process replay insertion and a post-collection hook. Each batch is trimmed to the remaining frame budget, post-processed, passed to the hook, normalized to the replay device and inserted before yielding `None`. Integer stream IDs route grouped and shared-memory batches consistently into native replay ensembles.

Targets main directly. The collector/inference prerequisites (#4269, #4271, #4272 and #4297) and native replay prerequisites (#4273 and #4274) are merged. The temporary collector/replay integration base is no longer needed. Review this PR before #4265 and #4268.

Thread-coordinator result queues are bounded by the batch budget. Completed transitions remain owned during backpressure and pause; grouped coordinators drain in-flight inference before acknowledging pause. Direct process workers retain main's capacity reservation before inference and nonblocking publication, bounding completed and in-flight transitions to twice the environment count. Shutdown can interrupt a full queue. Policy updates use the server's in-place storage contract, including captured inference.

Validation of the reconciled stack on 2026-09-08:
- Full CPU inference run with slow tests: 181 passed, 11 skipped, one failure from the obsolete queue-size assertion. That assertion was removed; all 14 focused replay/hook/policy-update cases then passed, including the failed case. These cover exact frame budgets, parent insertion, retained records, full-buffer pause/resume and shutdown across threading, multiprocessing queue/shared memory, grouped workers and direct process slots.
- Combined downstream DreamerV3/component/native-replay/config selection: 394 passed, including sync/async collection, ordered updates with overwrite generations and separate-process checkpoint/resume with and without replay, graceful termination and continued logging.
- Pinned formatting, Flake8, docstring and diff checks passed. Complete outgoing code and metadata were audited for project isolation.

CUDA and dependency CI must validate the refreshed heads. Earlier GPU and benchmark results remain recorded in the collector and learner PRs; this restack adds no new GPU measurements or performance claim. Existing CI opt-in labels are retained.
