### PR TITLE
[BugFix] Use compile-safe non-tensor construction in async environments

### DIFF
--- a/torchrl/envs/_async_exchange.py
+++ b/torchrl/envs/_async_exchange.py
@@ -278,7 +278,7 @@ class _SharedSlotExchange:
             self.result_slots[env_index]
             .select(*keys, strict=True)
             .clone()
-            .set("env_index", NonTensorData(env_index))
+            .set("env_index", NonTensorData(data=env_index))
         )
 
     def read_pair(
@@ -306,7 +306,7 @@ class _SharedSlotExchange:
 
     def read_pair_one(self, descriptor: tuple) -> tuple[TensorDictBase, TensorDictBase]:
         env_index, result_keys, next_keys, _ = descriptor
-        index_data = NonTensorData(env_index)
+        index_data = NonTensorData(data=env_index)
         result = (
             self.result_slots[env_index]
             .select(*result_keys, strict=True)

--- a/torchrl/envs/async_envs.py
+++ b/torchrl/envs/async_envs.py
@@ -1205,7 +1205,7 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
                 data = env.reset(data)
                 target = per_env_reset_queue if per_env else reset_queue
                 if shared_slots is None:
-                    data.set(cls._env_idx_key, NonTensorData(i))
+                    data.set(cls._env_idx_key, NonTensorData(data=i))
                     target.put(data)
                 else:
                     keys, ready_s = _SharedSlotExchange.publish(
@@ -1217,7 +1217,7 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
                     data = shared_slots[0].select(*data, strict=True)
                 data = env._reset(data)
                 if shared_slots is None:
-                    data.set(cls._env_idx_key, NonTensorData(i))
+                    data.set(cls._env_idx_key, NonTensorData(data=i))
                     reset_queue.put(data)
                 else:
                     keys, ready_s = _SharedSlotExchange.publish(
@@ -1230,8 +1230,8 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
                 data, data_ = env.step_and_maybe_reset(data)
                 target = per_env_step_reset_queue if per_env else step_reset_queue
                 if shared_slots is None:
-                    data.set(cls._env_idx_key, NonTensorData(i))
-                    data_.set(cls._env_idx_key, NonTensorData(i))
+                    data.set(cls._env_idx_key, NonTensorData(data=i))
+                    data_.set(cls._env_idx_key, NonTensorData(data=i))
                     target.put((data, data_))
                 else:
                     result_keys, next_keys, ready_s = _SharedSlotExchange.publish_pair(
@@ -1244,7 +1244,7 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
                 data = env.step(data)
                 target = per_env_step_queue if per_env else step_queue
                 if shared_slots is None:
-                    data.set(cls._env_idx_key, NonTensorData(i))
+                    data.set(cls._env_idx_key, NonTensorData(data=i))
                     target.put(data)
                 else:
                     keys, ready_s = _SharedSlotExchange.publish(
@@ -1256,7 +1256,7 @@ class ProcessorAsyncEnvPool(AsyncEnvPool):
                     data = shared_slots[0].select(*data, strict=True)
                 data = env._step(data)
                 if shared_slots is None:
-                    data.set(cls._env_idx_key, NonTensorData(i))
+                    data.set(cls._env_idx_key, NonTensorData(data=i))
                     step_queue.put(data)
                 else:
                     keys, ready_s = _SharedSlotExchange.publish(
@@ -1337,28 +1337,28 @@ class ThreadingAsyncEnvPool(AsyncEnvPool):
     @classmethod
     def _step_func(cls, env_td: tuple[EnvBase, TensorDictBase, int]):
         env, td, idx = env_td
-        return env.step(td).set(cls._env_idx_key, NonTensorData(idx))
+        return env.step(td).set(cls._env_idx_key, NonTensorData(data=idx))
 
     @classmethod
     def _private_step_func(cls, env_td: tuple[EnvBase, TensorDictBase, int]):
         env, td, idx = env_td
-        return env._step(td).set(cls._env_idx_key, NonTensorData(idx))
+        return env._step(td).set(cls._env_idx_key, NonTensorData(data=idx))
 
     @classmethod
     def _reset_func(cls, env_td: tuple[EnvBase, TensorDictBase]):
         env, td, idx = env_td
-        return env.reset(td).set(cls._env_idx_key, NonTensorData(idx))
+        return env.reset(td).set(cls._env_idx_key, NonTensorData(data=idx))
 
     @classmethod
     def _private_reset_func(cls, env_td: tuple[EnvBase, TensorDictBase]):
         env, td, idx = env_td
-        return env._reset(td).set(cls._env_idx_key, NonTensorData(idx))
+        return env._reset(td).set(cls._env_idx_key, NonTensorData(data=idx))
 
     @classmethod
     def _step_and_maybe_reset_func(cls, env_td: tuple[EnvBase, TensorDictBase]):
         env, td, idx = env_td
         td, td_ = env.step_and_maybe_reset(td)
-        idx = NonTensorData(idx)
+        idx = NonTensorData(data=idx)
         return td.set(cls._env_idx_key, idx), td_.set(cls._env_idx_key, idx)
 
     @staticmethod


### PR DESCRIPTION
Async environment exchanges now construct NonTensorData with data= explicitly. This keeps environment-index metadata valid while TensorDict's tensorclass compilation guards are active in another thread, without changing the metadata or transport behavior.

Validation: 14 existing asynchronous reset/step, shared-memory ownership, ordering, and queue-mapping tests passed. Pinned formatting, flake8, and diff checks pass. No new test duplicates the existing exchange coverage for this constructor-only compatibility change.
