### PR TITLE
[BugFix] Handle discrete RSSM actions and report actor entropy

### DIFF
--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -658,6 +658,31 @@ class TestDreamerV3Components:
         assert belief.grad is not None
         assert all(parameter.grad is not None for parameter in prior.parameters())
 
+    @pytest.mark.parametrize("action_dtype", [torch.bool, torch.int64])
+    @pytest.mark.parametrize("recurrent_model", ["gru", "block_gru"])
+    def test_prior_nonfloating_actions(self, action_dtype, recurrent_model):
+        prior = RSSMPriorV3(
+            action_shape=(2,),
+            hidden_dim=8,
+            rnn_hidden_dim=8,
+            num_categoricals=2,
+            num_classes=4,
+            action_dim=2,
+            recurrent_model=recurrent_model,
+            num_blocks=2,
+        )
+        state = torch.randn(3, 8)
+        belief = torch.randn(3, 8)
+        action = torch.tensor([[0, 1], [1, 0], [0, 1]], dtype=action_dtype)
+        expected_logits, _, expected_belief = prior(state, belief, action.float())
+        logits, _, next_belief = prior(state, belief, action)
+        torch.testing.assert_close(logits, expected_logits)
+        torch.testing.assert_close(next_belief, expected_belief)
+        # Acting skips prior sampling and calls the deterministic update directly.
+        torch.testing.assert_close(
+            prior._update_belief(state, belief, action), expected_belief
+        )
+
     @pytest.mark.skipif(
         version.parse(torch.__version__) < version.parse("2.4.0"),
         reason="the native RMSNorm compile path requires Torch >= 2.4.0",

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -650,6 +650,34 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         )
         assert grad_total > 0, "All gradients are zero after actor backward"
 
+    @pytest.mark.parametrize("entropy_bonus", [0.0, 3e-4])
+    def test_dreamer_v3_actor_entropy(self, device, entropy_bonus):
+        actor_model = self._create_actor_model().to(device)
+        actor_model[-1].distribution_class = IndependentNormal
+        loss_module = DreamerV3ActorLoss(
+            actor_model,
+            self._create_value_model().to(device),
+            self._create_mb_env().to(device),
+            imagination_horizon=3,
+            entropy_bonus=entropy_bonus,
+        )
+        loss_td, fake_data = loss_module(
+            self._create_actor_data().to(device).reshape(-1)
+        )
+        if entropy_bonus:
+            distribution = actor_model.get_dist(
+                fake_data.select(*actor_model.in_keys).detach()
+            )
+            expected = (
+                fake_data["discount_weight"] * distribution.entropy().unsqueeze(-1)
+            ).mean()
+        else:
+            expected = loss_td["loss_actor"].new_zeros(())
+        torch.testing.assert_close(loss_td["actor_entropy"], expected)
+        assert not loss_td["actor_entropy"].requires_grad
+        loss_td["loss_actor"].backward()
+        assert any(p.grad is not None for p in actor_model.parameters())
+
     @pytest.mark.gpu
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
     def test_dreamer_v3_actor_loss_cuda_graph(self, device):

--- a/torchrl/modules/models/model_based.py
+++ b/torchrl/modules/models/model_based.py
@@ -1607,6 +1607,8 @@ class RSSMPriorV3(nn.Module):
 
         The acting path conditions on the observation, never on a prior sample.
         """
+        if not action.is_floating_point():
+            action = action.to(belief.dtype)
         if self.recurrent_model == "block_gru":
             belief = self.rnn(state, belief, action)
         else:

--- a/torchrl/objectives/dreamer_v3.py
+++ b/torchrl/objectives/dreamer_v3.py
@@ -564,7 +564,9 @@ class DreamerV3ActorLoss(LossModule):
         discount_loss (bool, optional): If ``True``, discount the actor loss
             with a cumulative gamma factor. Default: ``True``.
         entropy_bonus (float, optional): Weight for the entropy regularisation
-            term ``eta``. Default: ``3e-4``.
+            term ``eta``. The returned ``actor_entropy`` metric is detached and
+            discount-weighted, and is zero when this bonus is disabled.
+            Default: ``3e-4``.
         use_reinforce (bool, optional): If ``True``, uses REINFORCE (log-prob
             * stop-gradient advantage). If ``False``, uses the straight
             reparameterization gradient (suitable for continuous Gaussian
@@ -862,10 +864,13 @@ class DreamerV3ActorLoss(LossModule):
             entropy = _match_trailing_dim(entropy, discount)
             entropy = (discount * entropy).mean()
             actor_loss = actor_loss - self.entropy_bonus * entropy
+        else:
+            entropy = actor_loss.new_zeros(())
 
         loss_tensordict = TensorDict(
             {
                 "loss_actor": actor_loss,
+                "actor_entropy": entropy.detach(),
                 "return_low": self.return_low.detach().clone(),
                 "return_high": self.return_high.detach().clone(),
                 "return_scale": return_scale.detach().clone(),


### PR DESCRIPTION
DreamerV3 now accepts boolean and integer one-hot actions through both prior inference and the deterministic acting update. Non-floating actions are converted to the belief dtype before action normalization.

The actor loss also returns detached, discount-weighted `actor_entropy` for logging. It is zero when entropy regularization is disabled, preserving the existing training objective and defaults.

Validation: 24 existing and extended component/actor-loss cases pass. Coverage compares boolean/integer actions with floating actions for both recurrent models, checks the reported metric against analytic entropy with discount weights, and verifies actor gradients remain available. ufmt, flake8, and diff checks pass.
