### PR TITLE
[Feature] Expose the DreamerV3 optimizer as a core component

### DIFF
--- a/docs/source/reference/dreamer_v3.rst
+++ b/docs/source/reference/dreamer_v3.rst
@@ -291,8 +291,8 @@ the update schedule explicit. A typical update cycle is:
 5. Update the online critic on those same detached returns.
 6. Soft-update the slow critic.
 
-The runnable ``sota-implementations/dreamer_v3`` example uses a single optimizer
-over the world model, actor and critic parameters, reproducing the current JAX
+The public :class:`~torchrl.trainers.algorithms.DreamerV3Optimizer` jointly optimizes
+the world model, actor and critic parameters, reproducing the current JAX
 implementation's adaptive gradient clipping, LaProp-style RMS scaling followed
 by momentum, and warmup chain.
 Those choices belong to the training recipe rather than the loss API, so users

--- a/docs/source/reference/trainers.rst
+++ b/docs/source/reference/trainers.rst
@@ -52,3 +52,16 @@ Documentation Sections
    trainers_basics
    trainers_loggers
    trainers_hooks
+
+DreamerV3 optimization
+----------------------
+
+The algorithm-specific optimizer is available independently of a trainer or
+example script. See :doc:`dreamer_v3` for the loss and target-update composition.
+
+.. autosummary::
+   :toctree: generated/
+   :template: rl_template_noinherit.rst
+
+   ~torchrl.trainers.algorithms.DreamerV3Optimizer
+   ~torchrl.trainers.algorithms.configs.DreamerV3OptimizerConfig

--- a/sota-implementations/dreamer_v3/dreamer_v3_agent.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_agent.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import importlib.util
-from collections.abc import Callable, Iterable
 
 import torch
 from dreamer_v3_utils import latent_state_dim, POLICY_RNG_STREAM, stream_seed
@@ -267,118 +266,6 @@ class DreamerV3SeededPolicy(TensorDictModuleBase):
             torch.manual_seed(stream_seed(self.seed, self.counter, POLICY_RNG_STREAM))
             self.counter += 1
             return self.module(tensordict)
-
-
-# --- Optimizer ---
-
-
-class DreamerV3Optimizer(torch.optim.Optimizer):
-    """The DreamerV3 optimizer: AGC, RMS scaling, momentum and warmup.
-
-    AGC clips each gradient to the ``agc`` fraction of its parameter norm.
-    """
-
-    def __init__(
-        self,
-        parameters: Iterable[torch.nn.Parameter],
-        *,
-        lr: float = 4e-5,
-        agc: float = 0.3,
-        parameter_norm_min: float = 1e-3,
-        beta1: float = 0.9,
-        beta2: float = 0.999,
-        eps: float = 1e-20,
-        warmup_steps: int = 1000,
-    ):
-        super().__init__(
-            parameters,
-            {
-                "lr": lr,
-                "agc": agc,
-                "parameter_norm_min": parameter_norm_min,
-                "beta1": beta1,
-                "beta2": beta2,
-                "eps": eps,
-                "warmup_steps": warmup_steps,
-                "step": 0,
-            },
-        )
-
-    @torch.no_grad()
-    def step(self, closure: Callable[[], torch.Tensor] | None = None) -> None:
-        loss = None
-        if closure is not None:
-            with torch.enable_grad():
-                loss = closure()
-
-        for group in self.param_groups:
-            group["step"] += 1
-            step = group["step"]
-            warmup_steps = group["warmup_steps"]
-            schedule_step = step - 1
-            warmup = min(1.0, schedule_step / warmup_steps) if warmup_steps else 1.0
-            learning_rate = group["lr"] * warmup
-
-            # Group by device and dtype for the multi-tensor kernels.
-            buckets: dict[
-                tuple[torch.device, torch.dtype], list[torch.nn.Parameter]
-            ] = {}
-            for parameter in group["params"]:
-                if parameter.grad is not None:
-                    buckets.setdefault((parameter.device, parameter.dtype), []).append(
-                        parameter
-                    )
-
-            for parameters in buckets.values():
-                gradients = [parameter.grad.float() for parameter in parameters]
-                if group["agc"]:
-                    gradient_norms = list(torch._foreach_norm(gradients))
-                    parameter_norms = list(
-                        torch._foreach_norm(
-                            [parameter.detach().float() for parameter in parameters]
-                        )
-                    )
-                    torch._foreach_clamp_min_(
-                        parameter_norms, group["parameter_norm_min"]
-                    )
-                    maximum_norms = torch._foreach_mul(parameter_norms, group["agc"])
-                    gradient_denominators = torch._foreach_maximum(
-                        gradient_norms, maximum_norms
-                    )
-                    gradient_scales = torch._foreach_div(
-                        maximum_norms, gradient_denominators
-                    )
-                    gradients = list(torch._foreach_mul(gradients, gradient_scales))
-
-                rms = []
-                momentum = []
-                for parameter in parameters:
-                    state = self.state[parameter]
-                    if not state:
-                        state["rms"] = torch.zeros_like(parameter, dtype=torch.float32)
-                        state["momentum"] = torch.zeros_like(
-                            parameter, dtype=torch.float32
-                        )
-                    rms.append(state["rms"])
-                    momentum.append(state["momentum"])
-                beta1 = group["beta1"]
-                beta2 = group["beta2"]
-                torch._foreach_mul_(rms, beta2)
-                torch._foreach_addcmul_(rms, gradients, gradients, value=1 - beta2)
-                rms_hat = torch._foreach_div(rms, 1 - beta2**step)
-                rms_denominator = torch._foreach_sqrt(rms_hat)
-                torch._foreach_add_(rms_denominator, group["eps"])
-                normalized = torch._foreach_div(gradients, rms_denominator)
-                torch._foreach_mul_(momentum, beta1)
-                torch._foreach_add_(momentum, normalized, alpha=1 - beta1)
-                momentum_hat = torch._foreach_div(momentum, 1 - beta1**step)
-                if parameters[0].dtype != torch.float32:
-                    momentum_hat = [
-                        update.to(parameter.dtype)
-                        for update, parameter in zip(momentum_hat, parameters)
-                    ]
-                torch._foreach_add_(parameters, momentum_hat, alpha=-learning_rate)
-        return loss
 
 
 # --- Builders ---

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -33,7 +33,6 @@ from dreamer_v3_agent import (
     build_value,
     build_world_model,
     DreamerV3BehaviorPolicySync,
-    DreamerV3Optimizer,
     DreamerV3SeededPolicy,
     make_env,
     make_primed_env,
@@ -61,7 +60,6 @@ from dreamer_v3_utils import (
 from omegaconf import DictConfig
 from tensordict import TensorDict, TensorDictBase
 from tensordict.nn import CudaGraphModule, TensorDictModuleBase
-
 from torchrl import timeit
 from torchrl._utils import get_available_device, logger as torchrl_logger
 from torchrl.collectors import Collector
@@ -74,6 +72,7 @@ from torchrl.objectives import (
     DreamerV3ValueLoss,
 )
 from torchrl.objectives.utils import SoftUpdate, ValueEstimators
+from torchrl.trainers.algorithms import DreamerV3Optimizer
 
 
 class _Learner(NamedTuple):

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -8,6 +8,7 @@ Reference: https://arxiv.org/abs/2301.04104
 """
 from __future__ import annotations
 
+import copy
 import importlib.util
 import json
 import os
@@ -61,6 +62,7 @@ from torchrl.objectives.dreamer_v3 import (
 from torchrl.objectives.utils import SoftUpdate, ValueEstimators
 from torchrl.testing import get_default_devices
 from torchrl.testing.mocking_classes import ContinuousActionConvMockEnv
+from torchrl.trainers.algorithms import DreamerV3Optimizer
 
 _has_hydra = importlib.util.find_spec("hydra") is not None
 _has_omegaconf = importlib.util.find_spec("omegaconf") is not None
@@ -2030,3 +2032,39 @@ def test_dreamer_v3_dmc_reproduction_modes(tmp_path):
     )
     assert incompatible.returncode == 2
     assert "mutually exclusive" in incompatible.stderr
+
+
+@pytest.mark.parametrize("device", get_default_devices())
+def test_dreamer_v3_optimizer_updates_and_resume(device):
+    parameter = nn.Parameter(torch.tensor([3.0, 4.0], device=device))
+    optimizer = DreamerV3Optimizer(
+        [parameter], lr=0.05, agc=0.2, beta1=0.5, beta2=0.5, warmup_steps=2
+    )
+    parameter.grad = torch.tensor([6.0, 8.0], device=device)
+    optimizer.step()
+    # The first update builds moments but starts the warm-up at zero.
+    torch.testing.assert_close(parameter, parameter.new_tensor([3.0, 4.0]))
+    parameter.grad = torch.tensor([0.0, 10.0], device=device)
+    optimizer.step()
+    # Clipped gradients are (0.6, 0.8), then (0, 1). The second
+    # bias-corrected RMS for the second coordinate is sqrt(0.88).
+    expected = parameter.new_tensor(
+        [3.0 - 0.025 / 3, 4.0 - 0.025 * (1 + 2 / 0.88**0.5) / 3]
+    )
+    torch.testing.assert_close(parameter, expected)
+
+    restored_parameter = nn.Parameter(parameter.detach().clone())
+    restored = DreamerV3Optimizer([restored_parameter])
+    restored.load_state_dict(copy.deepcopy(optimizer.state_dict()))
+    for current, value in ((optimizer, parameter), (restored, restored_parameter)):
+        current.zero_grad(set_to_none=True)
+        with pytest.raises(RuntimeError, match="no parameter gradients"):
+            current.step()
+        value.grad = value.new_tensor([-2.0, 3.0])
+        current.step()
+    torch.testing.assert_close(restored_parameter, parameter)
+    assert not torch.equal(parameter, expected)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/torchrl/trainers/algorithms/__init__.py
+++ b/torchrl/trainers/algorithms/__init__.py
@@ -9,6 +9,7 @@ from .a2c import A2CTrainer
 from .cql import CQLTrainer
 from .ddpg import DDPGTrainer
 from .dqn import DQNTrainer
+from .dreamer_v3 import DreamerV3Optimizer
 from .grpo import GRPOTrainer
 from .iql import IQLTrainer
 from .offline_to_online import OfflineToOnlineTrainer
@@ -23,6 +24,7 @@ __all__ = [
     "CQLTrainer",
     "DDPGTrainer",
     "DQNTrainer",
+    "DreamerV3Optimizer",
     "GRPOTrainer",
     "IQLTrainer",
     "OfflineToOnlineTrainer",

--- a/torchrl/trainers/algorithms/configs/__init__.py
+++ b/torchrl/trainers/algorithms/configs/__init__.py
@@ -218,6 +218,7 @@ from torchrl.trainers.algorithms.configs.utils import (
     AdamConfig,
     AdamWConfig,
     ASGDConfig,
+    DreamerV3OptimizerConfig,
     LBFGSConfig,
     LionConfig,
     NAdamConfig,
@@ -260,6 +261,7 @@ __all__ = [
     "AdadeltaConfig",
     "AdagradConfig",
     "ASGDConfig",
+    "DreamerV3OptimizerConfig",
     "LBFGSConfig",
     "LionConfig",
     "NAdamConfig",
@@ -738,6 +740,7 @@ def _register_configs():
     # =============================================================================
 
     cs.store(group="optimizer", name="adam", node=AdamConfig)
+    cs.store(group="optimizer", name="dreamer_v3", node=DreamerV3OptimizerConfig)
     cs.store(group="optimizer", name="adamw", node=AdamWConfig)
     cs.store(group="optimizer", name="adamax", node=AdamaxConfig)
     cs.store(group="optimizer", name="adadelta", node=AdadeltaConfig)

--- a/torchrl/trainers/algorithms/configs/utils.py
+++ b/torchrl/trainers/algorithms/configs/utils.py
@@ -319,3 +319,37 @@ class LionConfig(ConfigBase):
 
     def __post_init__(self) -> None:
         """Post-initialization hook for Lion optimizer configurations."""
+
+
+@dataclass
+class DreamerV3OptimizerConfig(ConfigBase):
+    """Hydra configuration for :class:`~torchrl.trainers.algorithms.DreamerV3Optimizer`.
+
+    Instantiation returns a partial optimizer constructor; supply its parameters
+    after constructing the learner modules.
+
+    Examples:
+        >>> import torch
+        >>> from hydra.utils import instantiate
+        >>> from torchrl.trainers.algorithms.configs import DreamerV3OptimizerConfig
+        >>> make_optimizer = instantiate(DreamerV3OptimizerConfig(warmup_steps=0))
+        >>> parameter = torch.nn.Parameter(torch.ones(2))
+        >>> optimizer = make_optimizer([parameter])
+        >>> parameter.sum().backward()
+        >>> optimizer.step()
+        >>> bool((parameter < 1).all())
+        True
+    """
+
+    lr: float = 4e-5
+    agc: float = 0.3
+    parameter_norm_min: float = 1e-3
+    beta1: float = 0.9
+    beta2: float = 0.999
+    eps: float = 1e-20
+    warmup_steps: int = 1000
+    _target_: str = "torchrl.trainers.algorithms.DreamerV3Optimizer"
+    _partial_: bool = True
+
+    def __post_init__(self) -> None:
+        """Initialize the partial optimizer configuration."""

--- a/torchrl/trainers/algorithms/dreamer_v3.py
+++ b/torchrl/trainers/algorithms/dreamer_v3.py
@@ -1,0 +1,179 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+import torch
+
+
+class DreamerV3Optimizer(torch.optim.Optimizer):
+    """DreamerV3 adaptive gradient clipping, RMS scaling and momentum.
+
+    Clips each parameter's gradient by its parameter norm, normalizes it by a
+    bias-corrected moving RMS, and applies bias-corrected momentum. A linear
+    learning-rate warm-up starts at zero on the first step when enabled.
+    Moment estimates are accumulated in float32. Parameters with no gradient
+    are skipped; an update with no parameter gradients raises ``RuntimeError``.
+
+    Reference: Hafner et al., "Mastering Diverse Domains through World Models"
+    (2023), https://arxiv.org/abs/2301.04104.
+
+    See also :class:`~torchrl.trainers.algorithms.configs.DreamerV3OptimizerConfig`.
+
+    Args:
+        parameters (iterable of Tensor or dict): Parameters to optimize, or
+            parameter-group dictionaries. Group options override the defaults
+            below; each group maintains its own update counter.
+
+    Keyword Args:
+        lr (float, optional): Learning rate after warm-up. Default: ``4e-5``.
+        agc (float, optional): Maximum gradient norm as a fraction of the
+            clamped parameter norm. Zero disables clipping. Default: ``0.3``.
+        parameter_norm_min (float, optional): Lower bound on parameter norms
+            used for clipping. Default: ``1e-3``.
+        beta1 (float, optional): Decay of normalized-gradient momentum.
+            Default: ``0.9``.
+        beta2 (float, optional): Decay of the squared-gradient average.
+            Default: ``0.999``.
+        eps (float, optional): Added to the RMS denominator. Default: ``1e-20``.
+        warmup_steps (int, optional): Number of updates before the full learning
+            rate is reached. Zero disables warm-up. Default: ``1000``.
+
+    Examples:
+        >>> import torch
+        >>> from torchrl.trainers.algorithms import DreamerV3Optimizer
+        >>> parameter = torch.nn.Parameter(torch.tensor([1.0, -1.0]))
+        >>> optimizer = DreamerV3Optimizer([parameter], lr=0.01, warmup_steps=0)
+        >>> parameter.square().sum().backward()
+        >>> optimizer.step()
+        >>> bool((parameter.abs() < 1).all())
+        True
+        >>> optimizer.zero_grad(set_to_none=False)
+        >>> checkpoint = optimizer.state_dict()
+        >>> optimizer.load_state_dict(checkpoint)
+    """
+
+    def __init__(
+        self,
+        parameters: Iterable[torch.Tensor] | Iterable[dict[str, Any]],
+        *,
+        lr: float = 4e-5,
+        agc: float = 0.3,
+        parameter_norm_min: float = 1e-3,
+        beta1: float = 0.9,
+        beta2: float = 0.999,
+        eps: float = 1e-20,
+        warmup_steps: int = 1000,
+    ):
+        super().__init__(
+            parameters,
+            {
+                "lr": lr,
+                "agc": agc,
+                "parameter_norm_min": parameter_norm_min,
+                "beta1": beta1,
+                "beta2": beta2,
+                "eps": eps,
+                "warmup_steps": warmup_steps,
+                "step": 0,
+            },
+        )
+
+    @torch.no_grad()
+    def step(
+        self, closure: Callable[[], torch.Tensor] | None = None
+    ) -> torch.Tensor | None:
+        """Update parameters with gradients and return the optional closure loss.
+
+        Args:
+            closure (callable, optional): Re-evaluates the model, computes
+                gradients, and returns its loss. Default: ``None``.
+
+        Returns:
+            The closure's loss, or ``None`` when no closure is supplied.
+        """
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        if not any(
+            parameter.grad is not None
+            for group in self.param_groups
+            for parameter in group["params"]
+        ):
+            raise RuntimeError("DreamerV3 optimizer received no parameter gradients.")
+
+        for group in self.param_groups:
+            group["step"] += 1
+            step = group["step"]
+            warmup_steps = group["warmup_steps"]
+            schedule_step = step - 1
+            warmup = min(1.0, schedule_step / warmup_steps) if warmup_steps else 1.0
+            learning_rate = group["lr"] * warmup
+
+            # Group by device and dtype for the multi-tensor kernels.
+            buckets: dict[
+                tuple[torch.device, torch.dtype], list[torch.nn.Parameter]
+            ] = {}
+            for parameter in group["params"]:
+                if parameter.grad is not None:
+                    buckets.setdefault((parameter.device, parameter.dtype), []).append(
+                        parameter
+                    )
+
+            for parameters in buckets.values():
+                gradients = [parameter.grad.float() for parameter in parameters]
+                if group["agc"]:
+                    gradient_norms = list(torch._foreach_norm(gradients))
+                    parameter_norms = list(
+                        torch._foreach_norm(
+                            [parameter.detach().float() for parameter in parameters]
+                        )
+                    )
+                    torch._foreach_clamp_min_(
+                        parameter_norms, group["parameter_norm_min"]
+                    )
+                    maximum_norms = torch._foreach_mul(parameter_norms, group["agc"])
+                    gradient_denominators = torch._foreach_maximum(
+                        gradient_norms, maximum_norms
+                    )
+                    gradient_scales = torch._foreach_div(
+                        maximum_norms, gradient_denominators
+                    )
+                    gradients = list(torch._foreach_mul(gradients, gradient_scales))
+
+                rms = []
+                momentum = []
+                for parameter in parameters:
+                    state = self.state[parameter]
+                    if not state:
+                        state["rms"] = torch.zeros_like(parameter, dtype=torch.float32)
+                        state["momentum"] = torch.zeros_like(
+                            parameter, dtype=torch.float32
+                        )
+                    rms.append(state["rms"])
+                    momentum.append(state["momentum"])
+                beta1 = group["beta1"]
+                beta2 = group["beta2"]
+                torch._foreach_mul_(rms, beta2)
+                torch._foreach_addcmul_(rms, gradients, gradients, value=1 - beta2)
+                rms_hat = torch._foreach_div(rms, 1 - beta2**step)
+                rms_denominator = torch._foreach_sqrt(rms_hat)
+                torch._foreach_add_(rms_denominator, group["eps"])
+                normalized = torch._foreach_div(gradients, rms_denominator)
+                torch._foreach_mul_(momentum, beta1)
+                torch._foreach_add_(momentum, normalized, alpha=1 - beta1)
+                momentum_hat = torch._foreach_div(momentum, 1 - beta1**step)
+                if parameters[0].dtype != torch.float32:
+                    momentum_hat = [
+                        update.to(parameter.dtype)
+                        for update, parameter in zip(momentum_hat, parameters)
+                    ]
+                torch._foreach_add_(parameters, momentum_hat, alpha=-learning_rate)
+        return loss


### PR DESCRIPTION
A custom DreamerV3 learner currently has to import or copy its optimizer from the SOTA directory. Expose `DreamerV3Optimizer` from `torchrl.trainers.algorithms` and make the example import it. Preserve the existing AGC, RMS scaling, momentum, warm-up defaults and optimizer state format, with a clear error when no parameter has gradients.

Add public reference documentation, runnable examples and `DreamerV3OptimizerConfig`. This is an independent core-component extraction; no trainer abstraction or training defaults change.

Validation: numerical clipping/moment/warm-up and resumed-update regression passed on the current runtime and PyTorch 2.1.1; the existing SOTA shared-module test passed; config parity and all 19 new doctest examples passed. Repository-pinned formatting, Flake8, docstring, Sphinx underline and diff checks passed. The optimizer kernels are moved unchanged; existing learner benchmarks continue to exercise them through the public import.
