### PR TITLE
[Test] Seed DDPG prioritized replay weight coverage

### DIFF
--- a/test/objectives/test_ddpg.py
+++ b/test/objectives/test_ddpg.py
@@ -696,6 +696,8 @@ class TestDDPG(LossModuleTestBase):
     )
     def test_ddpg_prioritized_weights(self):
         """Test DDPG with prioritized replay buffer weighted loss reduction."""
+        torch.manual_seed(self.seed)
+        np.random.seed(self.seed)
         n_obs = 4
         n_act = 2
         batch_size = 32


### PR DESCRIPTION
The prioritized-weight DDPG test depended on the RNG state left by earlier tests. A legitimate near-zero TD error can make the sampled importance weights too small for its absolute spread assertion, and the second sample can also contain only untouched rows. This caused the Python 3.14 CPU bulk job to fail while replay behaved correctly.

Seed both Torch (networks and input data) and NumPy (CPU replay sampling) with the class's existing seed. The test keeps its current workload and assertions.

Validation: the original test failed for seeds 150, 435 and 440 in 500 local trials. The fixed test passes from each of those prior RNG states and seed 0 on Python 3.14 / PyTorch 2.14; its pytest invocation, formatting, Flake8 and diff checks pass. [Observed CI failure](https://github.com/pytorch/rl/actions/runs/34159704459/job/101858965607).

The [Python 3.14 CPU bulk CI job](https://github.com/pytorch/rl/actions/runs/34161064535/job/101862848600) passed: 24,344 tests, 3,125 skips and 61 expected failures.
