### PR TITLE
[Test] Track direct process-slot collection in continuous benchmarks

### DIFF
--- a/.github/scripts/summarize_async_benchmarks.py
+++ b/.github/scripts/summarize_async_benchmarks.py
@@ -70,7 +70,7 @@ def summarize(root: Path, summary: Path) -> None:
         [
             "",
             "RSS is a final process-tree snapshot, with shared pages counted per process. "
-            "CUDA peak covers measured rounds in the policy process. "
+            "CUDA peak covers measured rounds when inference runs in this process. "
             "Raw samples, server timing, machine information and dependency versions are in the run artifacts.",
             "",
         ]

--- a/benchmarks/ASYNC_BENCHMARKS.md
+++ b/benchmarks/ASYNC_BENCHMARKS.md
@@ -29,7 +29,7 @@ and `PolicyFactory` from `bench_collectors.py`.
 | Output batch / measured round | 256 / 1,024 transitions | same |
 | Warm-up / measured rounds | 2 / 5 | same |
 | Fresh process repetitions | 3 | same |
-| Torch threads / seed | 1 / 0 | same |
+| Torch threads / parent seed | 1 / 0 | same |
 | Async batching | min 1, max environment count, timeout 1 ms | same |
 
 Uniform episodes last 200 steps. The slow-reset workload has 16-step episodes
@@ -44,6 +44,12 @@ worker). The last two explicitly skip on revisions before their public APIs
 exist. They start new series when those features merge; absence is never
 reported as zero time or as a speedup. CUDA-only cases carry the `gpu` marker.
 Existing eager series continue unchanged through all merges.
+
+The `async-process-slots` and CUDA-only `async-process-slots-static` series
+exercise the direct worker-to-server transport when `ProcessSlotTransport`
+becomes public in #4272. They keep one environment per worker because that
+transport rejects grouped workers. The same workload and batching limits apply;
+these remain separate series alongside the grouped integrated curve.
 
 Follow **`async-shm-integrated`** for the cumulative performance curve. It starts
 with eager inference and one environment per worker, enables static inference
@@ -68,7 +74,10 @@ The Actions summary includes batch p95 latency, final process-tree RSS and CUDA
 peak allocation. Raw JSON includes every measured round, batch latency p50/p95,
 server batching/queue/forward statistics, machine information, and dependency
 versions. RSS includes shared pages once per process and is a final snapshot,
-not peak unique memory. CUDA peak covers measured rounds in the policy process.
+not peak unique memory. CUDA peak covers measured rounds when the policy runs in
+the benchmark process.
+Process-slot series omit that allocator metric because inference owns a separate
+CUDA process; they still report complete process-tree RSS and server timings.
 Artifacts are retained for 30 days and the dashboard keeps 250 points per series.
 
 The short suite uses the existing `linux.g5.4xlarge.nvidia.gpu` runner class, pinned

--- a/benchmarks/test_collectors_benchmark.py
+++ b/benchmarks/test_collectors_benchmark.py
@@ -40,7 +40,7 @@ from torchrl.envs import (
     TransformedEnv,
 )
 from torchrl.envs.libs.dm_control import DMControlEnv
-from torchrl.modules import MLP, RandomPolicy
+from torchrl.modules import inference_server, MLP, RandomPolicy
 from torchrl.modules.inference_server import (
     InferenceDeviceConfig,
     InferenceServerConfig,
@@ -69,7 +69,9 @@ class _ResetLatencyPixelEnv(PixelMockEnv):
         "async-shm",
         "async-shm-integrated",
         "async-shm-grouped",
+        "async-process-slots",
         pytest.param("async-shm-static", marks=pytest.mark.gpu),
+        pytest.param("async-process-slots-static", marks=pytest.mark.gpu),
     ],
 )
 def test_async_collection_pixels(benchmark, mode, regime):
@@ -81,8 +83,11 @@ def test_async_collection_pixels(benchmark, mode, regime):
     has_grouping = (
         "envs_per_worker" in inspect.signature(AsyncBatchedCollector).parameters
     )
+    use_process = mode.startswith("async-process-slots")
+    if use_process and not hasattr(inference_server, "ProcessSlotTransport"):
+        pytest.skip("Direct process slots are not available on this revision")
     integrated = mode == "async-shm-integrated"
-    use_static = mode == "async-shm-static" or (
+    use_static = mode in ("async-shm-static", "async-process-slots-static") or (
         integrated and device != "cpu" and has_static
     )
     group_size = (
@@ -103,7 +108,7 @@ def test_async_collection_pixels(benchmark, mode, regime):
     rounds = 5
     warmup_rounds = 2
     gc.collect()
-    if device != "cpu":
+    if device != "cpu" and not use_process:
         torch.cuda.empty_cache()
     torch.manual_seed(0)
     old_threads = torch.get_num_threads()
@@ -138,13 +143,32 @@ def test_async_collection_pixels(benchmark, mode, regime):
         else:
             config = {"static_batch_size": num_envs} if use_static else {}
             grouped = {"envs_per_worker": group_size} if group_size > 1 else {}
+            process_options = {}
+            if use_process:
+                probe = factories[0]()
+                try:
+                    request_spec = probe.fake_tensordict().select("pixels", strict=True)
+                    response_spec = probe.rand_action().set(
+                        "policy_version",
+                        torch.zeros(probe.batch_size, dtype=torch.long),
+                    )
+                finally:
+                    probe.close()
+                process_options["transport"] = inference_server.ProcessSlotTransport(
+                    request_spec=request_spec,
+                    response_spec=response_spec,
+                    num_slots=num_envs,
+                )
+                config["service_backend"] = "process"
             collector = AsyncBatchedCollector(
                 factories,
                 policy_factory=policy_factory,
                 frames_per_batch=frames_per_batch,
                 total_frames=-1,
                 env_backend="multiprocessing",
-                env_exchange="queue" if mode == "async-queue" else "shm",
+                env_exchange=(
+                    "queue" if mode == "async-queue" or use_process else "shm"
+                ),
                 server_config=InferenceServerConfig(
                     max_batch_size=num_envs, min_batch_size=1, timeout=0.001, **config
                 ),
@@ -152,6 +176,7 @@ def test_async_collection_pixels(benchmark, mode, regime):
                     policy_device=device, output_device="cpu", storing_device="cpu"
                 ),
                 **grouped,
+                **process_options,
             )
         iterator = iter(collector)
         latencies = []
@@ -169,7 +194,7 @@ def test_async_collection_pixels(benchmark, mode, regime):
         for _ in range(warmup_rounds):
             collect_round()
         latencies.clear()
-        if device != "cpu":
+        if device != "cpu" and not use_process:
             torch.cuda.synchronize()
             torch.cuda.reset_peak_memory_stats()
         if isinstance(collector, AsyncBatchedCollector):
@@ -178,7 +203,10 @@ def test_async_collection_pixels(benchmark, mode, regime):
         latency_ms = torch.tensor(latencies[: rounds * batches_per_round]) * 1000
         process = psutil.Process()
         benchmark.extra_info.update(
-            execution=f"{'graph' if use_static else 'eager'}; {group_size} envs/worker",
+            execution=(
+                f"{'graph' if use_static else 'eager'}; {group_size} envs/worker"
+                + ("; process acting" if use_process else "")
+            ),
             num_envs=num_envs,
             frames_per_batch=frames_per_batch,
             transitions=frames_per_batch * batches_per_round,
@@ -191,7 +219,7 @@ def test_async_collection_pixels(benchmark, mode, regime):
                 for child in [process, *process.children(recursive=True)]
             ),
         )
-        if device != "cpu":
+        if device != "cpu" and not use_process:
             benchmark.extra_info[
                 "cuda_peak_allocated_bytes"
             ] = torch.cuda.max_memory_allocated()


### PR DESCRIPTION
Extend the continuous pixel-collection benchmark with eager and static-graph process-slot series for #4272. They use the same environments, policy shape, batching limits, warm-up and frame budget as the existing modes, and skip explicitly until `ProcessSlotTransport` is public. Direct workers retain one environment per process because that transport rejects grouping; the grouped integrated series remains unchanged.

Report process-tree RSS and server timing. Omit the parent CUDA allocator metric for process inference, whose allocator lives in the server, and document that limitation. This extends the benchmark merged in #4287 without changing its existing measured workloads.

Validation: baseline CPU selection 13 passed/10 expected skips; isolated #4269/#4271/#4272 CPU selection 4 passed/2 CUDA skips; reporting tests 10 passed. Formatting, Flake8 and diff checks pass. [Three-repeat combined GPU validation](https://github.com/pytorch/rl/actions/runs/34163040035) completed successfully: 13 GPU inference tests passed (one optional-dependency skip), followed by all eight benchmark cases in each repeat; summaries and artifact uploads passed. The isolated validation branch alone contains its focused GPU workflow selection. Broader PR checks are still running; none has failed.

Review independently of #4269; include this benchmark extension before merging #4272 so its new path appears in continuous history immediately.
