### PR TITLE
[CI] Stop failing benchmark publication on performance alerts

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -271,9 +271,13 @@ jobs:
           tool: ${{ env.BENCHMARK_SUITE == 'async' && 'customBiggerIsBetter' || 'pytest' }}
           output-file-path: results/CPU-benchmark-results/${{ env.BENCHMARK_SUITE == 'async' && 'trend.json' || 'output.json' }}
           benchmark-data-dir-path: ${{ env.BENCHMARK_SUITE == 'async' && 'dev/bench/async' || 'dev/bench' }}
-          fail-on-alert: true
+          # A performance alert must not fail publication: the red upload job
+          # hid a month-long publication outage. The job summary compares every
+          # series against its previous point instead.
+          fail-on-alert: false
           alert-threshold: '200%'
           comment-on-alert: false
+          summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gh-pages-branch: gh-pages
           auto-push: true
@@ -286,9 +290,13 @@ jobs:
           tool: ${{ env.BENCHMARK_SUITE == 'async' && 'customBiggerIsBetter' || 'pytest' }}
           output-file-path: results/GPU-benchmark-results/${{ env.BENCHMARK_SUITE == 'async' && 'trend.json' || 'output.json' }}
           benchmark-data-dir-path: ${{ env.BENCHMARK_SUITE == 'async' && 'dev/bench/async' || 'dev/bench' }}
-          fail-on-alert: true
+          # A performance alert must not fail publication: the red upload job
+          # hid a month-long publication outage. The job summary compares every
+          # series against its previous point instead.
+          fail-on-alert: false
           alert-threshold: '200%'
           comment-on-alert: false
+          summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gh-pages-branch: gh-pages
           auto-push: true

--- a/benchmarks/ASYNC_BENCHMARKS.md
+++ b/benchmarks/ASYNC_BENCHMARKS.md
@@ -121,4 +121,6 @@ Compiled TQC now has a bounded 15-minute setup budget without changing its timed
 workload. CPU and GPU publication is independent, only successful suites enter
 the trend, and partial output remains available as diagnostic artifacts.
 Failures still mark the workflow failed. Manual branch runs cannot contaminate
-main history.
+main history. A performance alert (a series more than twice as slow as its
+previous point) does not fail the upload job; the upload job summary compares
+every series with its previous point.


### PR DESCRIPTION
## Summary

- `fail-on-alert: false` on both gh-pages store steps (full nightly and async suites). A performance alert, meaning a series more than twice as slow as its previous point, no longer fails the upload job after the data has already been pushed.
- `summary-always: true` so the upload job summary compares every series with its previous point. Regressions stay visible without turning the job red.
- One sentence in `benchmarks/ASYNC_BENCHMARKS.md` documenting the alert behaviour.

## Why

The nightly orchestrator has concluded "failure" every day since at least 2026-08-09. On Aug 10 and Aug 11 both benchmark legs passed and the data was pushed, but `fail-on-alert` then failed the GPU store step on a single series that was 5.6x slower than its previous point. From Aug 12 the benchmark legs themselves failed (a storage-write benchmark `TypeError` on both devices until Sep 1, then compiled TQC timeouts on GPU until Sep 7), and because the status was already permanently red, the month-long gap in the published trend went unnoticed until #4287.

With ~240 noisy series per device and a 200% threshold, an alert-driven failure carries no signal. This keeps the alert threshold and the comparison but stops it from failing publication.

## Validation

- YAML parses, actionlint is clean apart from the pre-existing custom runner label, codespell is clean.
- `summary-always` is a supported input of `benchmark-action/github-action-benchmark@v1`; its handler writes the comparison table to the job summary independently of alert settings.

Generated with [Claude Code](https://claude.com/claude-code)
