### PR TITLE
[CI] Run the full benchmark suite after merging labelled pull requests

### DIFF
--- a/.github/workflows/benchmarks_post_merge.yml
+++ b/.github/workflows/benchmarks_post_merge.yml
@@ -1,0 +1,31 @@
+name: Post-merge benchmarks
+# Opt-in: merging a pull request that carries the "benchmarks/trigger" label
+# runs the full benchmark suite on main right away and publishes it to the
+# trend, instead of waiting for the nightly sample. pull_request_target
+# provides a write-capable token for the dispatch; nothing is checked out.
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch the full benchmark suite
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      contains(github.event.pull_request.labels.*.name, 'benchmarks/trigger')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run benchmarks.yml on main
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          gh workflow run benchmarks.yml --repo "$GITHUB_REPOSITORY" --ref main \
+            -f suite=full -f skip-upload=false
+          echo "Dispatched the full benchmark suite on main for #${PR_NUMBER} (merge commit ${MERGE_SHA})." >> "$GITHUB_STEP_SUMMARY"

--- a/benchmarks/ASYNC_BENCHMARKS.md
+++ b/benchmarks/ASYNC_BENCHMARKS.md
@@ -94,6 +94,11 @@ Use **Run workflow**, choose the branch and `suite: async`. The CLI equivalent i
 A default manual run on main publishes; set `skip-upload` to keep artifacts only.
 To rerun the complete nightly workload, choose `suite: full`.
 
+Merging a pull request that carries the `benchmarks/trigger` label dispatches
+the full suite on main immediately (`benchmarks_post_merge.yml`), so the merge
+gets a trend point without waiting for the nightly sample. The short async
+suite still runs on every main merge touching `torchrl/` or `benchmarks/`.
+
 Locally, install `benchmarks/requirements.txt` and run from the repository:
 
 ```sh


### PR DESCRIPTION
## Summary

- New `benchmarks/trigger` label (created in the repository). Merging a pull request that carries it into `main` dispatches `benchmarks.yml` with `suite=full`, so the merge gets its own point on the published trend instead of waiting for the nightly sample.
- Implemented as a small dispatcher workflow, `.github/workflows/benchmarks_post_merge.yml`, on `pull_request_target` `closed` events, gated on `merged == true`, base branch `main`, and the label. It checks nothing out and only calls `gh workflow run` with the repository token (`actions: write`).
- Runbook note in `benchmarks/ASYNC_BENCHMARKS.md`.

## Context

Benchmarks do not run on every pull request: the PR comparison is opt-in via `benchmarks/upload`, the short async suite runs on main merges touching `torchrl/` or `benchmarks/`, and the full suite runs once nightly. This gives performance-relevant PRs a way to get a full-suite trend point right after merging.

## Validation

- YAML parses, actionlint clean, codespell clean.
- `workflow_dispatch` is one of the two events that a repository-token action is allowed to trigger, so the dispatch from the `pull_request_target` job creates a normal `Continuous Benchmark` run on `main` that publishes to `dev/bench`.

Generated with [Claude Code](https://claude.com/claude-code)
