### PR TITLE
[BugFix] Bound process-slot collection and stop orphaned workers

### DIFF
--- a/benchmarks/ASYNC_BENCHMARKS.md
+++ b/benchmarks/ASYNC_BENCHMARKS.md
@@ -51,6 +51,14 @@ becomes public in #4272. They keep one environment per worker because that
 transport rejects grouped workers. The same workload and batching limits apply;
 these remain separate series alongside the grouped integrated curve.
 
+`test_async_collection_pixels_64_envs[mode]` adds a separate CUDA acceptance
+comparison for `async-shm` and `async-process-slots`: 64 environments, one per
+worker, with the same CNN plus two 1024-wide layers, one-millisecond environment
+steps, batches, warm-up and measured rounds described above. It runs in the
+same three fresh-process repetitions. Compare those two series with each other;
+they keep worker count fixed and do not replace the existing 32-environment
+trends. The policy is a pixel-collection proxy, not the complete DreamerV3 actor.
+
 Follow **`async-shm-integrated`** for the cumulative performance curve. It starts
 with eager inference and one environment per worker, enables static inference
 on GPU when that public option becomes available, and uses four environments

--- a/benchmarks/test_collectors_benchmark.py
+++ b/benchmarks/test_collectors_benchmark.py
@@ -76,6 +76,18 @@ class _ResetLatencyPixelEnv(PixelMockEnv):
 )
 def test_async_collection_pixels(benchmark, mode, regime):
     """Fixed end-to-end series; see ASYNC_BENCHMARKS.md before changing inputs."""
+    _benchmark_async_collection_pixels(benchmark, mode, regime)
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+@pytest.mark.parametrize("mode", ["async-shm", "async-process-slots"])
+def test_async_collection_pixels_64_envs(benchmark, mode):
+    """Compare transport paths with a matched 64-env CUDA pixel-policy workload."""
+    _benchmark_async_collection_pixels(benchmark, mode, "uniform", num_envs=64)
+
+
+def _benchmark_async_collection_pixels(benchmark, mode, regime, *, num_envs=None):
     device = "cuda:0" if torch.cuda.is_available() else "cpu"
     has_static = (
         "static_batch_size" in inspect.signature(InferenceServerConfig).parameters
@@ -102,7 +114,8 @@ def test_async_collection_pixels(benchmark, mode, regime):
         pytest.skip("Grouped environment workers are not available on this revision")
 
     # Keep these constants stable across merges. CPU and GPU are separate series.
-    num_envs = 32 if device != "cpu" else 8
+    if num_envs is None:
+        num_envs = 32 if device != "cpu" else 8
     frames_per_batch = 256
     batches_per_round = 4
     rounds = 5

--- a/docs/source/reference/collectors_single.rst
+++ b/docs/source/reference/collectors_single.rst
@@ -191,7 +191,14 @@ with ``env_backend="multiprocessing"`` and an
 :class:`~torchrl.modules.inference_server.InferenceServerConfig` whose
 ``service_backend`` is ``"process"``. Each environment process then performs
 its own reset/infer/step loop against a fixed shared-memory inference slot; the
-driver receives completed transitions only.
+driver receives completed transitions only. This mode bounds completed and
+in-flight transitions together to twice the environment count. Workers park
+before reserving capacity when the driver stops consuming, and ``pause()``
+still works with a full buffer. Environment workers are daemonic and both the
+workers and inference server exit if their owning process dies, including
+while environment or policy calls are blocked. Call ``shutdown()`` for normal
+cleanup; abrupt owner death cannot guarantee environment cleanup hooks run.
+Environment factories in this mode must not start multiprocessing children.
 
 Scaling ``Collector`` across local processes
 --------------------------------------------

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import contextlib
 import functools as ft
 import importlib.util
 import multiprocessing as mp
@@ -14,6 +15,7 @@ import queue
 import threading
 import time
 
+import psutil
 import pytest
 import torch
 import torch.distributed as dist
@@ -1483,7 +1485,7 @@ def _make_doubling_policy():
 def _shm_actor_fn(client, n_requests, result_queue):
     """Actor that submits known values and checks the doubled response."""
     for i in range(n_requests):
-        obs = torch.full((4,), float(i + 1))
+        obs = torch.full((4,), float(1000 * client.client_id + i + 1))
         result = client(TensorDict({"observation": obs}))
         assert torch.allclose(result["action"], obs * 2.0)
     result_queue.put(True)
@@ -1565,7 +1567,10 @@ class TestSharedMemoryTransport:
         assert torch.allclose(result_b["action"], torch.full((4,), 4.0))
         assert torch.allclose(result_a["action"], torch.full((4,), 2.0))
 
-    def test_exception_propagates_and_slot_is_released(self):
+    @pytest.mark.parametrize(
+        "transport_cls", [SharedMemoryTransport, ProcessSlotTransport]
+    )
+    def test_exception_propagates_and_slot_is_released(self, transport_cls):
         """Model errors reach the client and free the slot for reuse."""
 
         def flaky_model(td):
@@ -1574,7 +1579,7 @@ class TestSharedMemoryTransport:
             return td.set("action", td["observation"] * 2.0)
 
         request_spec, response_spec = _make_shm_specs(act_size=4, with_version=False)
-        transport = SharedMemoryTransport(request_spec, response_spec, num_slots=1)
+        transport = transport_cls(request_spec, response_spec, num_slots=1)
         client = transport.client()
         with InferenceServer(flaky_model, transport, max_batch_size=1):
             with pytest.raises(ValueError, match="shm model error"):
@@ -1649,10 +1654,13 @@ class TestSharedMemoryTransport:
         )
         t.join(timeout=5.0)
 
-    def test_result_timeout_keeps_slot(self):
+    @pytest.mark.parametrize(
+        "transport_cls", [SharedMemoryTransport, ProcessSlotTransport]
+    )
+    def test_result_timeout_keeps_slot(self, transport_cls):
         """A timed-out result() keeps the request in flight and retryable."""
         request_spec, response_spec = _make_shm_specs(with_version=False)
-        transport = SharedMemoryTransport(request_spec, response_spec, num_slots=1)
+        transport = transport_cls(request_spec, response_spec, num_slots=1)
         client = transport.client()
         fut = client.submit(TensorDict({"observation": torch.ones(4)}))
         with pytest.raises(queue.Empty):
@@ -1663,11 +1671,15 @@ class TestSharedMemoryTransport:
         transport.resolve(callbacks[0], TensorDict({"action": torch.ones(2)}))
         assert torch.allclose(fut.result(timeout=5.0)["action"], torch.ones(2))
 
-    def test_copy_result_false_returns_borrowed_view(self):
+    @pytest.mark.parametrize(
+        "transport_cls", [SharedMemoryTransport, ProcessSlotTransport]
+    )
+    @pytest.mark.parametrize("copy_result", [False, True])
+    def test_copy_result_false_returns_borrowed_view(self, transport_cls, copy_result):
         """copy_result=False returns a view into the shared response slot."""
         request_spec, response_spec = _make_shm_specs(with_version=False)
-        transport = SharedMemoryTransport(
-            request_spec, response_spec, num_slots=1, copy_result=False
+        transport = transport_cls(
+            request_spec, response_spec, num_slots=1, copy_result=copy_result
         )
         client = transport.client()
         fut = client.submit(TensorDict({"observation": torch.ones(4)}))
@@ -1675,22 +1687,27 @@ class TestSharedMemoryTransport:
         items, callbacks = transport.drain(1)
         transport.resolve(callbacks[0], TensorDict({"action": torch.ones(2)}))
         result = fut.result(timeout=5.0)
-        assert (
-            result["action"].data_ptr()
-            == transport._response_slots["action"][0].data_ptr()
-        )
+        next_future = client.submit(TensorDict({"observation": torch.zeros(4)}))
+        transport.wait_for_work(timeout=5.0)
+        _, callbacks = transport.drain(1)
+        transport.resolve(callbacks[0], TensorDict({"action": torch.zeros(2)}))
+        assert next_future.result(timeout=5.0)["action"].eq(0).all()
+        assert result["action"].eq(1 if copy_result else 0).all()
 
-    def test_spec_validation(self):
+    @pytest.mark.parametrize(
+        "transport_cls", [SharedMemoryTransport, ProcessSlotTransport]
+    )
+    def test_spec_validation(self, transport_cls):
         """Bad specs are rejected at construction time."""
         response_spec = TensorDict({"action": torch.zeros(2)})
         with pytest.raises(TypeError, match="tensor leaves"):
-            SharedMemoryTransport(
+            transport_cls(
                 TensorDict({"instruction": "hello"}), response_spec, num_slots=1
             )
         with pytest.raises(ValueError, match="at least one tensor leaf"):
-            SharedMemoryTransport(TensorDict({}), response_spec, num_slots=1)
+            transport_cls(TensorDict({}), response_spec, num_slots=1)
         with pytest.raises(ValueError, match="num_slots"):
-            SharedMemoryTransport(
+            transport_cls(
                 TensorDict({"observation": torch.zeros(4)}),
                 response_spec,
                 num_slots=0,
@@ -1698,15 +1715,18 @@ class TestSharedMemoryTransport:
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
-    def test_cuda_input_raises(self):
+    @pytest.mark.parametrize(
+        "transport_cls", [SharedMemoryTransport, ProcessSlotTransport]
+    )
+    def test_cuda_input_raises(self, transport_cls):
         """CUDA tensors are rejected: slots are CPU shared memory only."""
         request_spec, response_spec = _make_shm_specs()
-        transport = SharedMemoryTransport(request_spec, response_spec, num_slots=1)
+        transport = transport_cls(request_spec, response_spec, num_slots=1)
         client = transport.client()
         with pytest.raises(ValueError, match="CPU tensors"):
             client.submit(TensorDict({"observation": torch.randn(4, device="cuda")}))
         with pytest.raises(ValueError, match="CPU shared memory"):
-            SharedMemoryTransport(
+            transport_cls(
                 TensorDict({"observation": torch.zeros(4, device="cuda")}),
                 response_spec,
                 num_slots=1,
@@ -1742,12 +1762,15 @@ class TestSharedMemoryTransport:
 
 
 class TestProcessSlotTransport:
-    def test_round_robin_nested_slots(self):
+    @pytest.mark.parametrize("wait_for_work", [False, True])
+    def test_round_robin_nested_slots(self, wait_for_work):
         """A capped sweep rotates fairly and preserves nested-key payloads."""
         request_spec = TensorDict({"agent": {"observation": torch.zeros(4)}})
         response_spec = TensorDict({"agent": {"action": torch.zeros(4)}})
         transport = ProcessSlotTransport(request_spec, response_spec, num_slots=4)
         clients = [transport.client() for _ in range(4)]
+        with pytest.raises(RuntimeError, match="4 slots"):
+            transport.client()
         futures = [
             client.submit(
                 TensorDict({"agent": {"observation": torch.full((4,), float(slot))}})
@@ -1755,7 +1778,12 @@ class TestProcessSlotTransport:
             for slot, client in enumerate(clients)
         ]
 
-        transport.wait_for_work(timeout=1.0)
+        with pytest.raises(RuntimeError, match="one in-flight"):
+            clients[0].submit(
+                TensorDict({"agent": {"observation": torch.full((4,), -1.0)}})
+            )
+        if wait_for_work:
+            transport.wait_for_work(timeout=1.0)
         items, callbacks = transport.drain(2)
         assert callbacks == [0, 1]
         for item, callback in zip(items, callbacks):
@@ -1775,7 +1803,8 @@ class TestProcessSlotTransport:
         futures[1] = clients[1].submit(
             TensorDict({"agent": {"observation": torch.full((4,), 5.0)}})
         )
-        transport.wait_for_work(timeout=1.0)
+        if wait_for_work:
+            transport.wait_for_work(timeout=1.0)
         items, callbacks = transport.drain(4)
         assert callbacks == [2, 3, 0, 1]
         for item, callback in zip(items, callbacks):
@@ -2463,7 +2492,8 @@ class TestProcessInferenceServer:
             server.start()
         assert not server.is_alive
 
-    def test_killed_server_unblocks_waiting_clients(self):
+    @pytest.mark.parametrize("process_slots", [False, True])
+    def test_killed_server_unblocks_waiting_clients(self, process_slots):
         """A killed server process makes blocked clients raise promptly.
 
         Clients created before the server object exist must also observe the
@@ -2471,7 +2501,9 @@ class TestProcessInferenceServer:
         untimed wait would block forever on a reply that never comes.
         """
         ctx = mp.get_context("spawn")
-        transport = MPTransport(ctx=ctx)
+        transport = (
+            _counting_process_transport(1) if process_slots else MPTransport(ctx=ctx)
+        )
         client = transport.client()
         server = ProcessInferenceServer(
             policy_factory=_make_counting_policy,
@@ -2483,7 +2515,7 @@ class TestProcessInferenceServer:
             result = client(TensorDict({"observation": torch.ones(1)}))
             assert "action" in result.keys()
             server._process.kill()
-            with pytest.raises(MailboxPeerClosedError, match="peer closed"):
+            with pytest.raises(MailboxPeerClosedError, match="closed"):
                 client(TensorDict({"observation": torch.ones(1)}))
         finally:
             server.shutdown(timeout=1.0)
@@ -2556,6 +2588,49 @@ def _counting_process_transport(num_slots):
         ),
         num_slots=num_slots,
     )
+
+
+class _StepCountEnv(CountingEnv):
+    def __init__(self, steps):
+        super().__init__()
+        self.steps = steps
+
+    def _step(self, td):
+        result = super()._step(td)
+        with self.steps.get_lock():
+            self.steps.value += 1
+        return result
+
+
+def _collector_owner_exit(status_queue, exit_event, reset_entered):
+    # Keep the collector alive through interpreter teardown, without shutdown().
+    global _owner_exit_collector
+    _owner_exit_collector = AsyncBatchedCollector(
+        create_env_fn=[
+            _ControlledResetEnv if reset_entered is not None else _counting_env_factory
+        ]
+        * 2,
+        create_env_kwargs=(
+            {"entered": reset_entered, "release": mp.get_context("spawn").Event()}
+            if reset_entered is not None
+            else None
+        ),
+        policy_factory=_make_counting_policy,
+        transport=_counting_process_transport(2),
+        frames_per_batch=4,
+        env_backend="multiprocessing",
+        server_config=InferenceServerConfig(service_backend="process"),
+    )
+    if reset_entered is None:
+        next(iter(_owner_exit_collector))
+    else:
+        _owner_exit_collector._ensure_started()
+        assert reset_entered.wait(timeout=30)
+    status_queue.put(
+        [worker.pid for worker in _owner_exit_collector._workers]
+        + [_owner_exit_collector._server._process.pid]
+    )
+    exit_event.wait()
 
 
 class TestAsyncBatchedCollector:
@@ -3082,8 +3157,10 @@ class TestAsyncBatchedCollector:
         """Environment processes infer and step without driver coordinators."""
         num_envs = 2
         transport = _counting_process_transport(num_envs)
+        steps = mp.get_context("spawn").Value("i", 0)
         collector = AsyncBatchedCollector(
-            create_env_fn=[_counting_env_factory] * num_envs,
+            create_env_fn=[_StepCountEnv] * num_envs,
+            create_env_kwargs={"steps": steps},
             policy_factory=_make_counting_policy,
             transport=transport,
             frames_per_batch=12,
@@ -3098,9 +3175,15 @@ class TestAsyncBatchedCollector:
             iterator = iter(collector)
             batch = next(iterator)
             saved = batch.clone()
+            deadline = time.monotonic() + 5
+            capacity = 2 * num_envs
+            while steps.value < batch.numel() + capacity:
+                assert time.monotonic() < deadline, "workers did not fill the buffer"
+                time.sleep(0.01)
             for _ in range(2):
                 with collector.pause(timeout=5):
                     requests = collector.server_stats()["requests"]
+                    assert steps.value == batch.numel() + capacity
                     time.sleep(0.05)
                     assert collector.server_stats()["requests"] == requests
             assert batch.numel() + sum(td.numel() for td in iterator) == total_frames
@@ -3147,6 +3230,10 @@ class TestAsyncBatchedCollector:
                 next(iterator)
                 collector._workers[0].terminate()
                 collector._workers[0].join(timeout=5)
+                original_workers = tuple(collector._workers)
+                with pytest.raises(RuntimeError, match="worker"):
+                    next(collector.iterator())
+                assert tuple(collector._workers) == original_workers
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
                 future = executor.submit(collect_until_error)
                 try:
@@ -3161,6 +3248,98 @@ class TestAsyncBatchedCollector:
                     collector.shutdown()
         finally:
             collector.shutdown()
+
+    @pytest.mark.parametrize("exit_mode", ["normal", "kill", "kill-during-reset"])
+    def test_process_workers_exit_with_owner(self, exit_mode):
+        ctx = mp.get_context("spawn")
+        status_queue = ctx.Queue()
+        exit_event = ctx.Event()
+        reset_entered = ctx.Event() if exit_mode == "kill-during-reset" else None
+        owner = ctx.Process(
+            target=_collector_owner_exit,
+            args=(
+                status_queue,
+                exit_event,
+                reset_entered,
+            ),
+        )
+        children = []
+        owner.start()
+        try:
+            children = [psutil.Process(pid) for pid in status_queue.get(timeout=60)]
+            if exit_mode != "normal":
+                owner.kill()
+            else:
+                exit_event.set()
+            owner.join(timeout=10)
+            assert not owner.is_alive(), "interpreter exit waited for collector workers"
+            deadline = time.monotonic() + 5
+            while True:
+                alive = []
+                for child in children:
+                    with contextlib.suppress(psutil.NoSuchProcess):
+                        if (
+                            child.is_running()
+                            and child.status() != psutil.STATUS_ZOMBIE
+                        ):
+                            alive.append(child)
+                if not alive:
+                    break
+                assert (
+                    time.monotonic() < deadline
+                ), "collector processes outlived their owner"
+                time.sleep(0.05)
+        finally:
+            if owner.is_alive():
+                owner.kill()
+            owner.join(timeout=5)
+            for child in children:
+                with contextlib.suppress(psutil.NoSuchProcess):
+                    if child.is_running():
+                        child.kill()
+            status_queue.close()
+            status_queue.join_thread()
+
+    @pytest.mark.parametrize("kwargs", [[{}], [None, {}], 2])
+    def test_create_env_kwargs_rejected_before_start(self, kwargs):
+        with pytest.raises(ValueError, match="create_env_kwargs"):
+            AsyncBatchedCollector(
+                create_env_fn=[_counting_env_factory] * 2,
+                policy_factory=_make_counting_policy,
+                transport=_counting_process_transport(2),
+                create_env_kwargs=kwargs,
+                frames_per_batch=4,
+                env_backend="multiprocessing",
+                server_config=InferenceServerConfig(service_backend="process"),
+            )
+
+    @pytest.mark.parametrize(
+        "override, message",
+        [
+            ({"envs_per_worker": 2}, "envs_per_worker=1"),
+            ({"env_exchange": "shm"}, "env_exchange does not apply"),
+            ({"env_backend": "threading"}, "env_backend='multiprocessing'"),
+            (
+                {"device_config": InferenceDeviceConfig(storing_device="cuda")},
+                "CPU storing_device",
+            ),
+            (
+                {"device_config": InferenceDeviceConfig(env_device="cuda")},
+                "CPU env_device",
+            ),
+        ],
+    )
+    def test_process_slots_reject_unsupported_collection(self, override, message):
+        options = {"env_backend": "multiprocessing", **override}
+        with pytest.raises(ValueError, match=message):
+            AsyncBatchedCollector(
+                create_env_fn=[_counting_env_factory] * 2,
+                policy_factory=_make_counting_policy,
+                transport=_counting_process_transport(2),
+                frames_per_batch=4,
+                server_config=InferenceServerConfig(service_backend="process"),
+                **options,
+            )
 
     def test_policy_version_key_none_disables_annotations(self):
         collector = AsyncBatchedCollector(

--- a/torchrl/_comm/mailbox.py
+++ b/torchrl/_comm/mailbox.py
@@ -4,6 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import multiprocessing as mp
+import os
 import queue
 import threading
 import time
@@ -13,6 +15,16 @@ from typing import Any
 
 _MISSING = object()
 _PEER_CHECK_INTERVAL = 0.1
+
+
+def _exit_on_parent_exit() -> None:
+    """Watch the owner from a child daemon thread, including during blocked work."""
+    parent = mp.parent_process()
+    if parent is not None:
+        _wait_for_connection([parent.sentinel])
+        # No owner remains to consume results or release blocked IPC. Normal
+        # interpreter teardown can itself wait forever for queue feeder threads.
+        os._exit(0)
 
 
 class MailboxTransportError(RuntimeError):

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -23,6 +23,7 @@ from tensordict import (
     TensorDictBase,
 )
 from torchrl._comm import MailboxTransportError
+from torchrl._comm.mailbox import _exit_on_parent_exit
 from torchrl._utils import (
     _maybe_record_function_decorator,
     logger as torchrl_logger,
@@ -155,6 +156,7 @@ def _process_env_loop(
     env_id: int,
     client: PolicyClientModule,
     result_queue,
+    result_capacity,
     shutdown_event,
     pause_event,
     paused_event,
@@ -168,6 +170,7 @@ def _process_env_loop(
     try:
         if worker_affinity is not None:
             os.sched_setaffinity(0, worker_affinity)
+        threading.Thread(target=_exit_on_parent_exit, daemon=True).start()
         torch.set_num_threads(1)
         env = env_factory(**create_env_kwargs)
         observation = env.reset()
@@ -177,6 +180,13 @@ def _process_env_loop(
                 while pause_event.is_set() and not shutdown_event.is_set():
                     shutdown_event.wait(0.01)
                 paused_event.clear()
+                continue
+            # Reserve capacity before inference/stepping. A full result queue
+            # must still let the worker observe pause and shutdown requests.
+            if not result_capacity.acquire(timeout=0.01):
+                continue
+            if pause_event.is_set() or shutdown_event.is_set():
+                result_capacity.release()
                 continue
             policy_output = client(observation)
             action_td = observation.update(policy_output)
@@ -198,7 +208,7 @@ def _process_env_loop(
                 # Transfer one shared storage instead of negotiating a file
                 # descriptor for every tensor leaf of every transition.
                 transition = transition.consolidate()
-            result_queue.put(transition)
+            result_queue.put(transition, block=False)
     except Exception as exc:
         if not shutdown_event.is_set():
             error_queue.put(RuntimeError(f"Environment {env_id} failed: {exc!r}"))
@@ -357,6 +367,8 @@ class AsyncBatchedCollector(BaseCollector):
     * With a :class:`~torchrl.modules.inference_server.ProcessSlotTransport`,
       each multiprocessing environment worker talks directly to the dedicated
       inference process; the driver receives completed transitions only.
+      Completed and in-flight transitions are bounded to twice the environment
+      count. Workers and the inference server exit when their owner dies.
     * The :class:`~torchrl.modules.InferenceServer` running in a background
       thread continuously drains observation submissions, batches them, runs
       a single forward pass, and fans actions back out.
@@ -588,6 +600,16 @@ class AsyncBatchedCollector(BaseCollector):
             raise TypeError("create_env_fn must be a list of env factories.")
         self._create_env_fn = list(create_env_fn)
         self._num_envs = len(create_env_fn)
+        if create_env_kwargs is not None and not isinstance(create_env_kwargs, Mapping):
+            if (
+                not isinstance(create_env_kwargs, Sequence)
+                or len(create_env_kwargs) != self._num_envs
+                or not all(isinstance(kwargs, Mapping) for kwargs in create_env_kwargs)
+            ):
+                raise ValueError(
+                    "create_env_kwargs must be a dict or a list of dicts with "
+                    f"length {self._num_envs}."
+                )
         self._create_env_kwargs = create_env_kwargs
 
         # ---- resolve backends -------------------------------------------------
@@ -783,8 +805,15 @@ class AsyncBatchedCollector(BaseCollector):
 
     def _ensure_started(self) -> None:
         """Create the env pool, start the server and coordinator threads."""
-        if self._workers and all(w.is_alive() for w in self._workers):
-            return
+        if self._workers:
+            if self._uses_process_env_workers:
+                self._check_process_workers()
+                if self._shutdown_event.is_set():
+                    raise RuntimeError(
+                        "Environment workers have stopped; create a new collector."
+                    )
+            if all(w.is_alive() for w in self._workers):
+                return
 
         original_affinity = None
         try:
@@ -813,14 +842,13 @@ class AsyncBatchedCollector(BaseCollector):
                     create_env_kwargs = [
                         dict(create_env_kwargs) for _ in range(self._num_envs)
                     ]
-                elif len(create_env_kwargs) != self._num_envs:
-                    raise ValueError(
-                        "create_env_kwargs must be a dict or a list of dicts with "
-                        f"length {self._num_envs}."
-                    )
 
                 ctx = self._transport._ctx
-                self._result_queue = ctx.Queue()
+                # Count completed and in-flight transitions together. Queue
+                # capacity alone cannot prevent workers from blocking in put().
+                capacity = 2 * self._num_envs
+                self._result_queue = ctx.Queue(maxsize=capacity)
+                self._result_capacity = ctx.BoundedSemaphore(capacity)
                 self._worker_error_queue = ctx.Queue()
                 self._worker_check_timer = timeit(
                     "AsyncBatchedCollector.worker_liveness", sync=False
@@ -849,6 +877,7 @@ class AsyncBatchedCollector(BaseCollector):
                                 "env_id": env_id,
                                 "client": client,
                                 "result_queue": self._result_queue,
+                                "result_capacity": self._result_capacity,
                                 "shutdown_event": self._shutdown_event,
                                 "pause_event": self._process_pause_event,
                                 "paused_event": self._process_paused_events[env_id],
@@ -862,6 +891,7 @@ class AsyncBatchedCollector(BaseCollector):
                                 "storing_device": self._storing_device,
                             },
                             name=f"AsyncBatchedCollector-env-{env_id}",
+                            daemon=True,
                         )
                         process.start()
                         self._workers.append(process)
@@ -968,9 +998,11 @@ class AsyncBatchedCollector(BaseCollector):
         """Pause environment coordination and policy inference.
 
         In-flight policy and environment requests finish before the context is
-        entered. The coordinator threads then remain parked until the context
-        exits, leaving the inference server idle. This provides a quiescent
-        boundary for operations such as a lazy :func:`torch.compile` call.
+        entered. The coordinator threads or environment processes then remain
+        parked until the context exits, leaving the inference server idle.
+        Completed transitions can remain buffered for the next iteration.
+        This provides a quiescent boundary for operations such as a lazy
+        :func:`torch.compile` call.
 
         Compile and warm up modules before starting collection whenever
         possible. Use this context when compilation after collection has
@@ -1189,6 +1221,8 @@ class AsyncBatchedCollector(BaseCollector):
                     "An environment worker result could not be received."
                 ) from exc
             self._check_worker_result(td)
+            if self._uses_process_env_workers:
+                self._result_capacity.release()
             return td
 
     @_maybe_record_function_decorator("AsyncBatchedCollector._rollout_frames")
@@ -1233,6 +1267,8 @@ class AsyncBatchedCollector(BaseCollector):
                         "An environment worker result could not be received."
                     ) from exc
                 self._check_worker_result(td)
+                if self._uses_process_env_workers:
+                    self._result_capacity.release()
                 if self._uses_batched_coordinator:
                     for transition in td.unbind(0):
                         if collected < frames_to_collect:

--- a/torchrl/modules/inference_server/_process_slot.py
+++ b/torchrl/modules/inference_server/_process_slot.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 import multiprocessing as mp
 import queue
 import time
+from ctypes import Array, c_byte, c_double
+from multiprocessing.queues import SimpleQueue
+from multiprocessing.synchronize import Event, Lock, Semaphore
 
 import torch
 from tensordict.base import _is_leaf_nontensor, TensorDictBase
@@ -16,6 +19,10 @@ from torchrl._comm import MailboxPeerClosedError, MailboxTransportError
 from torchrl.modules.inference_server._client import (
     _NO_INTERACTION_TYPE_CODE,
     _REMOTE_INTERACTION_TYPE_KEY,
+)
+from torchrl.modules.inference_server._slot_utils import (
+    _make_slot_bank,
+    _take_ready_slots,
 )
 from torchrl.modules.inference_server._transport import InferenceTransport
 
@@ -58,13 +65,14 @@ class _ProcessSlotClient:
         request_slots: TensorDictBase,
         response_slots: TensorDictBase,
         request_keys: list[NestedKey],
-        request_ready,
-        submitted_at,
-        response_status,
-        response_event,
-        exception_queue,
-        work_semaphore,
-        peer_alive,
+        request_ready: Array[c_byte],
+        request_lock: Lock,
+        submitted_at: Array[c_double],
+        response_status: Array[c_byte],
+        response_event: Event,
+        exception_queue: SimpleQueue,
+        work_semaphore: Semaphore,
+        peer_alive: Event | None,
         copy_result: bool,
     ):
         self._slot_id = slot_id
@@ -72,6 +80,7 @@ class _ProcessSlotClient:
         self._response_slots = response_slots
         self._request_keys = request_keys
         self._request_ready = request_ready
+        self._request_lock = request_lock
         self._submitted_at = submitted_at
         self._response_status = response_status
         self._response_event = response_event
@@ -118,9 +127,12 @@ class _ProcessSlotClient:
         self._response_event.clear()
         self._response_status[slot] = 0
         self._submitted_at[slot] = time.monotonic()
-        self._request_ready[slot] = 1
         self._in_flight = True
-        self._work_semaphore.release()
+        # The server takes this lock even after a timed-out semaphore wait.
+        # Releasing it publishes all preceding payload writes to that reader.
+        with self._request_lock:
+            self._request_ready[slot] = 1
+            self._work_semaphore.release()
         return _ProcessSlotFuture(self)
 
     def __call__(
@@ -257,7 +269,13 @@ class ProcessSlotTransport(InferenceTransport):
         self._next_slot = 0
         self._acquired_signals = 0
 
-        request_keys = list(request_spec.keys(include_nested=True, leaves_only=True))
+        request_keys = list(
+            request_spec.keys(
+                include_nested=True, leaves_only=True, is_leaf=_is_leaf_nontensor
+            )
+        )
+        if not request_keys:
+            raise ValueError("request_spec must contain at least one tensor leaf.")
         self._request_keys = [
             key for key in request_keys if key != _REMOTE_INTERACTION_TYPE_KEY
         ]
@@ -271,13 +289,18 @@ class ProcessSlotTransport(InferenceTransport):
                     dtype=torch.int8,
                 ),
             )
-        self._request_slots = self._make_slots(request_slot_spec, "request_spec")
-        self._response_slots = self._make_slots(response_spec, "response_spec")
+        self._request_slots = _make_slot_bank(
+            request_slot_spec, self._num_slots, type(self).__name__, "request_spec"
+        )
+        self._response_slots = _make_slot_bank(
+            response_spec, self._num_slots, type(self).__name__, "response_spec"
+        )
         self._response_keys = list(
             response_spec.keys(include_nested=True, leaves_only=True)
         )
 
         self._request_ready = self._ctx.Array("b", num_slots, lock=False)
+        self._request_lock = self._ctx.Lock()
         self._submitted_at = self._ctx.Array("d", num_slots, lock=False)
         self._response_status = self._ctx.Array("b", num_slots, lock=False)
         self._response_events = [self._ctx.Event() for _ in range(num_slots)]
@@ -286,50 +309,25 @@ class ProcessSlotTransport(InferenceTransport):
         self._peer_alive = self._ctx.Event()
         self._peer_alive.set()
 
-    def _make_slots(self, spec: TensorDictBase, argname: str) -> TensorDictBase:
-        leaves = list(
-            spec.items(
-                include_nested=True, leaves_only=True, is_leaf=_is_leaf_nontensor
-            )
-        )
-        if not leaves:
-            raise ValueError(f"{argname} must contain at least one tensor leaf.")
-        for key, value in leaves:
-            if not isinstance(value, torch.Tensor):
-                raise TypeError(
-                    "ProcessSlotTransport specs only support tensor leaves; "
-                    f"{argname} has a {type(value).__name__} at key {key!r}."
-                )
-            if value.device.type != "cpu":
-                raise ValueError(
-                    "ProcessSlotTransport slots live in CPU shared memory; "
-                    f"{argname} has a {value.device} tensor at key {key!r}."
-                )
-        return (
-            spec.unsqueeze(0)
-            .expand(self._num_slots, *spec.batch_size)
-            .clone()
-            .share_memory_()
-        )
-
     def _set_peer_alive(self, alive_event) -> None:
         self._peer_alive = alive_event
 
     def client(self) -> _ProcessSlotClient:
         """Create a client bound to the next unused slot."""
         slot_id = self._next_client_slot
-        self._next_client_slot += 1
         if slot_id >= self._num_slots:
             raise RuntimeError(
                 f"ProcessSlotTransport has {self._num_slots} slots but client() "
                 f"was called {slot_id + 1} times."
             )
+        self._next_client_slot += 1
         return _ProcessSlotClient(
             slot_id=slot_id,
             request_slots=self._request_slots,
             response_slots=self._response_slots,
             request_keys=self._request_keys,
             request_ready=self._request_ready,
+            request_lock=self._request_lock,
             submitted_at=self._submitted_at,
             response_status=self._response_status,
             response_event=self._response_events[slot_id],
@@ -363,20 +361,22 @@ class ProcessSlotTransport(InferenceTransport):
         items = []
         callbacks = []
         submitted_at = []
-        start_slot = self._next_slot
-        for offset in range(self._num_slots):
-            slot = (start_slot + offset) % self._num_slots
-            if not self._request_ready[slot]:
-                continue
-            self._request_ready[slot] = 0
+        # The semaphore is a doorbell, not the payload's memory barrier: a
+        # timed drain can run without acquiring a signal. Synchronize with each
+        # publisher before looking at flags, including on weakly ordered CPUs.
+        with self._request_lock:
+            callbacks = _take_ready_slots(
+                self._request_ready, self._next_slot, max_items
+            )
+            if callbacks:
+                self._next_slot = (callbacks[-1] + 1) % self._num_slots
+        for slot in callbacks:
             items.append(self._request_slots[slot].copy())
-            callbacks.append(slot)
             submitted_at.append(self._submitted_at[slot])
             self._submitted_at[slot] = 0.0
-            self._next_slot = (slot + 1) % self._num_slots
-            if len(items) >= max_items:
-                break
 
+        # Consume doorbells for drained requests, including a signal already
+        # consumed by wait_for_work(). Extra wakeups are harmless.
         signals_to_consume = len(items)
         acquired = min(signals_to_consume, self._acquired_signals)
         self._acquired_signals -= acquired

--- a/torchrl/modules/inference_server/_server.py
+++ b/torchrl/modules/inference_server/_server.py
@@ -40,6 +40,7 @@ from torchrl._comm.backends import (
     _resolve_service_backend,
     _resolve_transport_backend,
 )
+from torchrl._comm.mailbox import _exit_on_parent_exit
 from torchrl._comm.ray_runtime import _RayRuntimeLease, _set_ray_client_liveness
 from torchrl.modules.inference_server._client import (
     _INTERACTION_TYPE_TO_CODE,
@@ -1107,6 +1108,7 @@ def _process_server_entry(
     policy_version_value=None,
 ) -> None:
     """Run an :class:`InferenceServer` loop inside a child process."""
+    threading.Thread(target=_exit_on_parent_exit, daemon=True).start()
     try:
         model = policy_factory()
         server = InferenceServer(
@@ -1358,9 +1360,7 @@ class ProcessInferenceServer:
         self._peer_alive = peer_alive
         self._process_monitor: threading.Thread | None = None
         self._service_client = (
-            transport.client()
-            if getattr(transport, "_clients_require_registration", True)
-            else None
+            transport.client() if transport._clients_require_registration else None
         )
         self._shutdown_event = self._ctx.Event()
         self._ready_queue = self._ctx.Queue()

--- a/torchrl/modules/inference_server/_shared_memory.py
+++ b/torchrl/modules/inference_server/_shared_memory.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 import multiprocessing as mp
 import queue
 
-import torch
-from tensordict.base import _is_leaf_nontensor, TensorDictBase
+from tensordict.base import TensorDictBase
 from tensordict.utils import NestedKey
 
 from torchrl._comm import MailboxClient, MailboxFuture
 from torchrl.modules.inference_server._queue_transport import QueueBasedTransport
+from torchrl.modules.inference_server._slot_utils import _make_slot_bank
 
 _MISSING = object()
 
@@ -240,8 +240,12 @@ class SharedMemoryTransport(QueueBasedTransport):
         self._ctx = ctx if ctx is not None else mp.get_context("spawn")
         self._copy_result = bool(copy_result)
 
-        self._request_slots = self._make_slots(request_spec, "request_spec")
-        self._response_slots = self._make_slots(response_spec, "response_spec")
+        self._request_slots = _make_slot_bank(
+            request_spec, self._num_slots, type(self).__name__, "request_spec"
+        )
+        self._response_slots = _make_slot_bank(
+            response_spec, self._num_slots, type(self).__name__, "response_spec"
+        )
         self._request_keys = list(
             request_spec.keys(include_nested=True, leaves_only=True)
         )
@@ -261,35 +265,6 @@ class SharedMemoryTransport(QueueBasedTransport):
         peer_alive = self._ctx.Event()
         peer_alive.set()
         self._set_peer_alive(peer_alive)
-
-    def _make_slots(self, spec: TensorDictBase, argname: str) -> TensorDictBase:
-        # _is_leaf_nontensor surfaces NonTensorData leaves (excluded by the
-        # default leaf iterator) so they are rejected instead of ignored.
-        leaves = list(
-            spec.items(
-                include_nested=True, leaves_only=True, is_leaf=_is_leaf_nontensor
-            )
-        )
-        if not leaves:
-            raise ValueError(f"{argname} must contain at least one tensor leaf.")
-        for key, value in leaves:
-            if not isinstance(value, torch.Tensor):
-                raise TypeError(
-                    f"SharedMemoryTransport specs only support tensor leaves; "
-                    f"{argname} has a {type(value).__name__} at key {key!r}. "
-                    "Encode small metadata as tensors or use MPTransport."
-                )
-            if value.device.type != "cpu":
-                raise ValueError(
-                    f"SharedMemoryTransport slots live in CPU shared memory; "
-                    f"{argname} has a {value.device} tensor at key {key!r}."
-                )
-        return (
-            spec.unsqueeze(0)
-            .expand(self._num_slots, *spec.batch_size)
-            .clone()
-            .share_memory_()
-        )
 
     def _make_response_queue(self) -> mp.Queue:
         return self._ctx.Queue()

--- a/torchrl/modules/inference_server/_slot.py
+++ b/torchrl/modules/inference_server/_slot.py
@@ -11,6 +11,7 @@ from collections.abc import Callable
 
 from tensordict.base import TensorDictBase
 
+from torchrl.modules.inference_server._slot_utils import _take_ready_slots
 from torchrl.modules.inference_server._transport import InferenceTransport
 
 
@@ -240,28 +241,21 @@ class SlotTransport(InferenceTransport):
                     break
 
         items: list[TensorDictBase] = []
-        slot_ids: list[int] = []
         submitted_at: list[float | None] = []
-        start = self._sweep_start
-        for offset in range(self._num_slots):
-            i = (start + offset) % self._num_slots
-            if self._obs_ready[i]:
-                self._obs_ready[i] = False
-                submitted_at.append(self._submitted_at[i])
-                self._submitted_at[i] = None
-                if self._obs_buffer is not None:
-                    # Flush first-time observations that arrived before the
-                    # buffer existed into the buffer.
-                    if self._obs[i] is not None:
-                        self._obs_buffer[i].update_(self._obs[i])
-                        self._obs[i] = None
-                    items.append(self._obs_buffer[i])
-                else:
-                    items.append(self._obs[i])
+        slot_ids = _take_ready_slots(self._obs_ready, self._sweep_start, max_items)
+        for i in slot_ids:
+            submitted_at.append(self._submitted_at[i])
+            self._submitted_at[i] = None
+            if self._obs_buffer is not None:
+                # Flush first-time observations that arrived before the
+                # buffer existed into the buffer.
+                if self._obs[i] is not None:
+                    self._obs_buffer[i].update_(self._obs[i])
                     self._obs[i] = None
-                slot_ids.append(i)
-                if len(slot_ids) >= max_items:
-                    break
+                items.append(self._obs_buffer[i])
+            else:
+                items.append(self._obs[i])
+                self._obs[i] = None
         if slot_ids:
             self._sweep_start = (slot_ids[-1] + 1) % self._num_slots
         return items, slot_ids, submitted_at

--- a/torchrl/modules/inference_server/_slot_utils.py
+++ b/torchrl/modules/inference_server/_slot_utils.py
@@ -1,0 +1,54 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+from collections.abc import MutableSequence
+from ctypes import Array, c_byte
+
+import torch
+from tensordict.base import _is_leaf_nontensor, TensorDictBase
+
+
+def _make_slot_bank(
+    spec: TensorDictBase, num_slots: int, transport_name: str, argname: str
+) -> TensorDictBase:
+    """Validate a CPU tensor spec and allocate a shared request or response bank."""
+    # _is_leaf_nontensor surfaces NonTensorData leaves (excluded by the
+    # default leaf iterator) so they are rejected instead of ignored.
+    leaves = list(
+        spec.items(include_nested=True, leaves_only=True, is_leaf=_is_leaf_nontensor)
+    )
+    if not leaves:
+        raise ValueError(f"{argname} must contain at least one tensor leaf.")
+    for key, value in leaves:
+        if not isinstance(value, torch.Tensor):
+            raise TypeError(
+                f"{transport_name} specs only support tensor leaves; "
+                f"{argname} has a {type(value).__name__} at key {key!r}. "
+                "Encode small metadata as tensors or use MPTransport."
+            )
+        if value.device.type != "cpu":
+            raise ValueError(
+                f"{transport_name} slots live in CPU shared memory; "
+                f"{argname} has a {value.device} tensor at key {key!r}."
+            )
+    return spec.unsqueeze(0).expand(num_slots, *spec.batch_size).clone().share_memory_()
+
+
+def _take_ready_slots(
+    ready: MutableSequence[bool] | Array[c_byte], start: int, max_items: int
+) -> list[int]:
+    """Claim ready slots in circular order; the caller supplies synchronization."""
+    slots = []
+    if max_items <= 0:
+        return slots
+    for offset in range(len(ready)):
+        slot = (start + offset) % len(ready)
+        if ready[slot]:
+            ready[slot] = False
+            slots.append(slot)
+            if len(slots) >= max_items:
+                break
+    return slots

--- a/torchrl/modules/inference_server/_transport.py
+++ b/torchrl/modules/inference_server/_transport.py
@@ -21,6 +21,9 @@ class InferenceTransport(abc.ABC):
     and :meth:`resolve`.
     """
 
+    # Fixed-slot transports allocate every client channel before server startup.
+    _clients_require_registration: bool = True
+
     @abc.abstractmethod
     def submit(self, td: TensorDictBase) -> Future[TensorDictBase]:
         """Submit a single inference request.


### PR DESCRIPTION
Process-slot collection could keep its environment and inference processes running after the driver died, and its unbounded result queue allowed an idle learner to accumulate transitions indefinitely. Request draining also read shared readiness flags without a guaranteed publication barrier after a timed-out semaphore wait. This follows up on the review of #4272.

The collector now reserves capacity before inference and stepping, bounding completed and in-flight transitions together to twice the environment count. Workers can pause with a full buffer, preserve owned transition values and exact emitted frame budgets, and stop when their owner exits. The inference process also watches its owner, including while policy or environment work is blocked. Normal cleanup still uses `shutdown()`; abrupt owner death cannot run environment cleanup hooks reliably. Environment factories in this mode run in daemonic workers and cannot create multiprocessing children.

Request publication and draining synchronize through a process-shared lock. Shared-memory slot allocation and round-robin claiming use common internal helpers. The patch also validates environment kwargs before startup, rejects iterator re-entry after worker death, declares the transport registration contract, and adds the missing process-slot error, timeout, ownership, attribution, overflow, device/spec and unsupported-mode coverage.

Validation:
- CPU inference coverage, including slow multiprocessing cases: 168 passed in the full run. The added blocked-reset owner-exit case exposed a spawn-event lifetime error in its test fixture; the fixture was corrected and all three owner-exit cases passed on rerun.
- Both transport docstring examples pass: 20 examples total.
- Benchmark reporting tests: 10 passed.
- Pinned formatting, Flake8, docstring style/argument checks, Sphinx section checks and diff checks pass.
- CUDA regressions and Linux affinity coverage require CI. Every added CUDA-only case carries `gpu`.

The existing CPU pixel benchmark completed for both transports on the same Apple M5 Max, Python 3.14.6, PyTorch 2.14 and dependency environment. Each measurement used eight environments, two warm-up rounds and five measured rounds. These are single-run smoke measurements, not repeated-run performance evidence:

| Mode | Merged implementation frames/s | Follow-up frames/s |
| --- | ---: | ---: |
| Shared-memory coordinator | 1566.6 | 1804.9 |
| Direct process slots | 220.0 | 203.7 |

The patch adds a separate continuous 64-environment CUDA comparison using the existing CNN plus two 1024-wide layers and identical worker counts, batching and warm-up. Existing 32-environment series remain unchanged. The workflow repeats in three fresh processes and records throughput, latency, memory and server timing. The policy is a pixel-collection proxy, not a full DreamerV3 actor. The [continuous comparison run](https://github.com/pytorch/rl/actions/runs/34196379424) targets this PR head with three repetitions. This PR remains draft pending GPU measurements and regression assessment; it claims no speedup.

The per-slot exception-pipe consolidation request remains open. Replacing those pipes with a shared queue requires a demultiplexing design that preserves exception attribution and out-of-order consumption across independent client processes. Worker-written replay rings remain deferred; parent-process replay insertion remains the integration direction. Land this follow-up before reconciling #4275 with the bounded collection path.
