### PR TITLE
[CI] Label benchmark trend points with the benchmarked commit

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -279,6 +279,9 @@ jobs:
           comment-on-alert: false
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Label the point with the benchmarked commit. Without this, dispatched
+          # and scheduled runs record whatever main's head is at upload time.
+          ref: ${{ github.sha }}
           gh-pages-branch: gh-pages
           auto-push: true
           max-items-in-chart: 250
@@ -298,6 +301,9 @@ jobs:
           comment-on-alert: false
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Label the point with the benchmarked commit. Without this, dispatched
+          # and scheduled runs record whatever main's head is at upload time.
+          ref: ${{ github.sha }}
           gh-pages-branch: gh-pages
           auto-push: true
           max-items-in-chart: 250


### PR DESCRIPTION
## Summary

Pass `ref: ${{ github.sha }}` to `benchmark-action/github-action-benchmark` in both gh-pages store steps so each trend point references the commit that was actually checked out and benchmarked.

## Why

The action only reads the commit from the event payload on `push` events. For `workflow_dispatch` (manual and `benchmarks/trigger` runs) and the nightly `workflow_call`, it resolves `github.ref`, which is main's head at upload time. The first full-suite point published after #4287 measured `b3af4830` but was recorded under `5ef3c124`, the head of main an hour later, and the point dispatched for #4289 will be mislabelled the same way. With the label-triggered post-merge runs from #4293, the commit link on each point is the whole purpose, so it should be exact.

## Validation

- YAML parses, actionlint clean apart from the pre-existing custom runner label, codespell clean.
- `ref` is a documented optional input ("Ref to use when finding commit"); the action's `getCommit` falls back to it whenever the payload carries no `head_commit`.

Generated with [Claude Code](https://claude.com/claude-code)
